### PR TITLE
Wire onboarding footer links

### DIFF
--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
@@ -8,9 +8,12 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { LazyMotion, domAnimation } from "motion/react";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { traycerInfo } from "@traycer-clients/shared/platform/traycer-info";
 import { useOnboardingStore } from "@/stores/onboarding/onboarding-store";
 import { ONBOARDING_ACTS } from "@/components/onboarding/onboarding-acts";
 import type { OnboardingAgentGuideState } from "@/components/onboarding/onboarding-diorama";
+import { RunnerHostContext } from "@/providers/runner-host-context";
 
 type GuideQueryState = {
   readonly data:
@@ -130,6 +133,18 @@ function renderPage(args: { readonly replay: boolean }) {
   );
 }
 
+function createRunnerHost() {
+  return new MockRunnerHost({
+    signInUrl: "https://auth.traycer.test/sign-in",
+    authnBaseUrl: "https://auth.traycer.test",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+}
+
 async function advanceToStage(stage: number): Promise<void> {
   const current = Number(
     screen.getByTestId("onboarding-diorama-stub").getAttribute("data-stage"),
@@ -210,6 +225,35 @@ describe("OnboardingPage", () => {
     renderPage({ replay: false });
 
     expect(screen.getByText("v0.0.0")).not.toBeNull();
+  });
+
+  it("wires onboarding footer links to the website destinations", () => {
+    const host = createRunnerHost();
+    render(
+      <RunnerHostContext.Provider value={host}>
+        <LazyMotion features={domAnimation}>
+          <OnboardingPage replay={false} />
+        </LazyMotion>
+      </RunnerHostContext.Provider>,
+    );
+
+    const expectedLinks = [
+      ["Features", traycerInfo.mainWebsiteFeatures],
+      ["Enterprise", traycerInfo.mainWebsiteEnterprise],
+      ["Support", traycerInfo.mainWebsiteContactUs],
+    ] as const;
+
+    expectedLinks.forEach(([label, url]) => {
+      const link = screen.getByRole<HTMLAnchorElement>("link", {
+        name: label,
+      });
+      expect(link.href).toBe(url);
+      fireEvent.click(link);
+    });
+
+    expect(host.openedExternalLinks).toEqual(
+      expectedLinks.map(([, url]) => url),
+    );
   });
 
   it("advances through all five acts while keeping the Figma continue label", async () => {

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
@@ -256,6 +256,43 @@ describe("OnboardingPage", () => {
     );
   });
 
+  it("falls back to browser navigation when the runner host cannot open a footer link", async () => {
+    const host = createRunnerHost();
+    const openExternalLinkMock = vi
+      .spyOn(host, "openExternalLink")
+      .mockRejectedValue(new Error("host unavailable"));
+    const windowOpenMock = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => null);
+
+    render(
+      <RunnerHostContext.Provider value={host}>
+        <LazyMotion features={domAnimation}>
+          <OnboardingPage replay={false} />
+        </LazyMotion>
+      </RunnerHostContext.Provider>,
+    );
+
+    fireEvent.click(
+      screen.getByRole<HTMLAnchorElement>("link", {
+        name: "Support",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(windowOpenMock).toHaveBeenCalledWith(
+        traycerInfo.mainWebsiteContactUs,
+        "_blank",
+        "noopener,noreferrer",
+      );
+    });
+    expect(openExternalLinkMock).toHaveBeenCalledWith(
+      traycerInfo.mainWebsiteContactUs,
+    );
+
+    windowOpenMock.mockRestore();
+  });
+
   it("advances through all five acts while keeping the Figma continue label", async () => {
     renderPage({ replay: false });
 

--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -743,16 +743,22 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
 function OnboardingFooterLinks() {
   const runnerHost = use(RunnerHostContext);
 
+  const openInBrowser = useCallback((url: string) => {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, []);
+
   const openFooterLink = useCallback(
     (event: MouseEvent<HTMLAnchorElement>, url: string) => {
       event.preventDefault();
       if (runnerHost !== null) {
-        void runnerHost.openExternalLink(url);
+        void runnerHost.openExternalLink(url).catch(() => {
+          openInBrowser(url);
+        });
         return;
       }
-      window.open(url, "_blank", "noopener,noreferrer");
+      openInBrowser(url);
     },
-    [runnerHost],
+    [openInBrowser, runnerHost],
   );
 
   return (

--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -1,5 +1,7 @@
 import {
+  type MouseEvent,
   type ReactNode,
+  use,
   useCallback,
   useEffect,
   useEffectEvent,
@@ -9,6 +11,7 @@ import {
 } from "react";
 import { useNavigate, useRouter } from "@tanstack/react-router";
 import { AnimatePresence, m } from "motion/react";
+import { traycerInfo } from "@traycer-clients/shared/platform/traycer-info";
 import packageJson from "../../../package.json";
 import geistPixelSquareUrl from "@/assets/fonts/GeistPixel-Square.woff2?url";
 import onboardingBackdropUrl from "@/assets/brand/gradient-bg.jpg?url";
@@ -25,6 +28,7 @@ import {
 import { OnboardingThemePicker } from "@/components/onboarding/onboarding-theme-picker";
 import { useAgentSelectionGuideGlobalOnboardingDraftQuery } from "@/hooks/agent/use-agent-selection-guide-global-onboarding-draft-query";
 import { useAgentSelectionGuideSetGlobalMutation } from "@/hooks/agent/use-agent-selection-guide-set-global-mutation";
+import { RunnerHostContext } from "@/providers/runner-host-context";
 import {
   selectIsLastStep,
   selectStep,
@@ -33,6 +37,11 @@ import {
 import { cn } from "@/lib/utils";
 
 const ACT_EASE = [0.32, 0.72, 0, 1] as const;
+const ONBOARDING_FOOTER_LINKS = [
+  { label: "Features", url: traycerInfo.mainWebsiteFeatures },
+  { label: "Enterprise", url: traycerInfo.mainWebsiteEnterprise },
+  { label: "Support", url: traycerInfo.mainWebsiteContactUs },
+] as const;
 const ONBOARDING_STYLE = `
 @font-face {
   font-family: "Geist Pixel Square";
@@ -724,22 +733,45 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
 
         <footer className="flex items-center justify-between gap-4 px-10 font-heading text-[0.75rem] leading-none text-white/75 [@media(min-height:920px)]:text-[0.8125rem] max-sm:px-5">
           <span>{resolveAppVersionLabel()}</span>
-          <nav aria-label="Traycer footer links" className="hidden sm:block">
-            <ul className="flex items-center gap-8">
-              {["Features", "Enterprise", "Support"].map((label) => (
-                <li key={label}>
-                  <button
-                    type="button"
-                    className="transition-colors hover:text-white/80"
-                  >
-                    {label}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </nav>
+          <OnboardingFooterLinks />
         </footer>
       </div>
     </main>
+  );
+}
+
+function OnboardingFooterLinks() {
+  const runnerHost = use(RunnerHostContext);
+
+  const openFooterLink = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, url: string) => {
+      event.preventDefault();
+      if (runnerHost !== null) {
+        void runnerHost.openExternalLink(url);
+        return;
+      }
+      window.open(url, "_blank", "noopener,noreferrer");
+    },
+    [runnerHost],
+  );
+
+  return (
+    <nav aria-label="Traycer footer links" className="hidden sm:block">
+      <ul className="flex items-center gap-8">
+        {ONBOARDING_FOOTER_LINKS.map((link) => (
+          <li key={link.label}>
+            <a
+              href={link.url}
+              target="_blank"
+              rel="noreferrer"
+              onClick={(event) => openFooterLink(event, link.url)}
+              className="transition-colors hover:text-white/80"
+            >
+              {link.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
 }

--- a/clients/shared/platform/traycer-info.ts
+++ b/clients/shared/platform/traycer-info.ts
@@ -1,0 +1,5 @@
+export const traycerInfo = {
+  mainWebsiteFeatures: "https://traycer.ai/#features",
+  mainWebsiteEnterprise: "https://traycer.ai/enterprise",
+  mainWebsiteContactUs: "https://traycer.ai/contact-us",
+} as const;


### PR DESCRIPTION
## Summary
- Wire the onboarding footer links to the current Traycer website destinations
- Route footer clicks through the runner host with browser fallback
- Keep onboarding link destinations in a client-shared source used by app code and tests

## Validation
- bun run --cwd clients/gui-app test src/components/onboarding/__tests__/onboarding-page.test.tsx
- bun run --filter @traycer-clients/gui-app compile
- bun run --filter @traycer-clients/desktop compile
- bun run --filter @traycer-clients/shared lint
- npx -y react-doctor@latest . --verbose --scope changed --base public/main --offline --no-score
- local pre-commit hook passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the onboarding footer to show externally configured links for Features, Enterprise, and Support/Contact.
* **Bug Fixes**
  * Improved external link behavior by routing through the app’s link handler when available, with a safe fallback to open links in a new tab with `noopener,noreferrer` if routing fails.
* **Tests**
  * Added assertions to verify footer link destinations and click behavior, including fallback handling when external link routing is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->