### PR TITLE
Fix number list detection by replacing visual-line plugin with paragraph-based rules

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-list-input.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-list-input.test.tsx
@@ -41,10 +41,11 @@ afterEach(() => {
 });
 
 describe("composer list input", () => {
-  it("turns '- ' after a visual line break into a bullet list", () => {
+  it("turns '- ' on a second paragraph into a bullet list", () => {
     const { editor } = makeFixture();
     editor.commands.insertContent("Intro");
-    editor.commands.setHardBreak();
+    // Shift+Enter now splits into a real paragraph (no hardBreak).
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
 
     typeText(editor, "- ");
     typeText(editor, "item");
@@ -59,10 +60,10 @@ describe("composer list input", () => {
     expect(editor.state.doc.lastChild?.textContent).toBe("");
   });
 
-  it("turns '1. ' after a visual line break into an ordered list", () => {
+  it("turns '1. ' on a second paragraph into an ordered list", () => {
     const { editor } = makeFixture();
     editor.commands.insertContent("Intro");
-    editor.commands.setHardBreak();
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
 
     typeText(editor, "3. ");
     typeText(editor, "step");
@@ -78,10 +79,30 @@ describe("composer list input", () => {
     expect(editor.state.doc.lastChild?.textContent).toBe("");
   });
 
+  it("wraps existing text when a marker is typed before it (regression)", () => {
+    const { editor } = makeFixture();
+    editor.commands.insertContent("hello");
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
+    typeText(editor, "abc");
+    // Caret to the start of the second paragraph, before "abc".
+    let beforeAbc = -1;
+    editor.state.doc.descendants((node, pos) => {
+      if (node.isText && node.text === "abc") beforeAbc = pos;
+      return true;
+    });
+    editor.commands.setTextSelection(beforeAbc);
+
+    typeText(editor, "1. ");
+
+    expect(editor.state.doc.firstChild?.textContent).toBe("hello");
+    expect(textOfFirstNode(editor, "listItem")).toBe("abc");
+    expect(firstNodeOfType(editor, "orderedList")).not.toBeNull();
+  });
+
   it("submits with Enter even when the caret is inside a list item", () => {
     const { editor, submitCalls } = makeFixture();
     editor.commands.insertContent("Intro");
-    editor.commands.setHardBreak();
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
     typeText(editor, "- ");
     typeText(editor, "item");
 
@@ -94,7 +115,7 @@ describe("composer list input", () => {
   it("continues the current list with Shift+Enter", () => {
     const { editor, submitCalls } = makeFixture();
     editor.commands.insertContent("Intro");
-    editor.commands.setHardBreak();
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
     typeText(editor, "1. ");
     typeText(editor, "first");
 

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-paste-normalize.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-paste-normalize.test.tsx
@@ -1,0 +1,192 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import {
+  DOMParser as ProseMirrorDOMParser,
+  Fragment,
+  Slice,
+} from "@tiptap/pm/model";
+import { TextSelection } from "@tiptap/pm/state";
+
+import { sanitizeMarkdownHtml } from "@/lib/composer/markdown-paste";
+import { normalizeSliceSoftBreaks } from "@/lib/composer/normalize-soft-breaks";
+import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-json-content";
+import { buildComposerExtensions } from "../editor/editor-config";
+import { createComposerPickerStore } from "../picker/composer-picker-store";
+
+const editors: Editor[] = [];
+const elements: HTMLElement[] = [];
+
+function makeEditor(): Editor {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  elements.push(el);
+  const editor = new Editor({
+    element: el,
+    extensions: buildComposerExtensions({
+      pickerStore: createComposerPickerStore(),
+      placeholder: "t",
+      onSubmit: { current: () => {} },
+      slashProviderId: "claude",
+    }),
+    content: { type: "doc", content: [{ type: "paragraph" }] },
+  });
+  editors.push(editor);
+  return editor;
+}
+
+afterEach(() => {
+  editors.splice(0).forEach((e) => e.destroy());
+  elements.splice(0).forEach((e) => e.remove());
+});
+
+function typeChar(editor: Editor, char: string): void {
+  const { from, to } = editor.state.selection;
+  const def = () => editor.state.tr.insertText(char, from, to);
+  const handled =
+    editor.view.someProp("handleTextInput", (h) => {
+      const r = h(editor.view, from, to, char, def);
+      return r === true ? true : undefined;
+    }) === true;
+  if (!handled) editor.view.dispatch(def());
+}
+function typeText(editor: Editor, v: string): void {
+  Array.from(v).forEach((c) => typeChar(editor, c));
+}
+
+function setText(editor: Editor, text: string): void {
+  editor.commands.setContent({
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  });
+}
+
+function caretBefore(editor: Editor, text: string): void {
+  let pos = -1;
+  editor.state.doc.descendants((node, p) => {
+    if (node.isText && node.text === text && pos === -1) pos = p;
+    return true;
+  });
+  editor.commands.setTextSelection(pos);
+}
+
+describe("normalizeSliceSoftBreaks", () => {
+  it("splits inline 'a\\nb' into two paragraphs with open depth 1/1", () => {
+    const editor = makeEditor();
+    const schema = editor.state.schema;
+    const inline = new Slice(Fragment.from(schema.text("a\nb")), 0, 0);
+    const out = normalizeSliceSoftBreaks(inline, schema);
+    expect(out.content.childCount).toBe(2);
+    expect(out.content.firstChild?.type.name).toBe("paragraph");
+    expect(out.content.firstChild?.textContent).toBe("a");
+    expect(out.content.lastChild?.textContent).toBe("b");
+    expect(out.openStart).toBe(1);
+    expect(out.openEnd).toBe(1);
+  });
+
+  it("returns the original slice unchanged when there is no soft break", () => {
+    const editor = makeEditor();
+    const schema = editor.state.schema;
+    const inline = new Slice(Fragment.from(schema.text("abc")), 0, 0);
+    const out = normalizeSliceSoftBreaks(inline, schema);
+    expect(out).toBe(inline);
+  });
+
+  it("never splits a code block's literal newline", () => {
+    const editor = makeEditor();
+    const schema = editor.state.schema;
+    const code = schema.nodes.codeBlock.create(null, schema.text("a\nb"));
+    const slice = new Slice(Fragment.from(code), 0, 0);
+    const out = normalizeSliceSoftBreaks(slice, schema);
+    expect(out).toBe(slice);
+    expect(out.content.firstChild?.type.name).toBe("codeBlock");
+  });
+
+  it("mid-paragraph paste merges at both ends (XYa / bZ)", () => {
+    const editor = makeEditor();
+    setText(editor, "XYZ");
+    editor.view.dispatch(
+      editor.state.tr.setSelection(TextSelection.create(editor.state.doc, 3)),
+    );
+    const inline = new Slice(
+      Fragment.from(editor.state.schema.text("a\nb")),
+      0,
+      0,
+    );
+    editor.view.dispatch(
+      editor.state.tr.replaceSelection(
+        normalizeSliceSoftBreaks(inline, editor.state.schema),
+      ),
+    );
+    expect(editor.state.doc.childCount).toBe(2);
+    expect(editor.state.doc.firstChild?.textContent).toBe("XYa");
+    expect(editor.state.doc.lastChild?.textContent).toBe("bZ");
+  });
+});
+
+describe("paste -> list end to end (HTML branch)", () => {
+  it("HTML 'hello<br>abc' pastes as two paragraphs, then '1. ' on line 2 lists 'abc'", () => {
+    const editor = makeEditor();
+    const html = "<div>hello<br>abc</div>";
+    const sanitized = sanitizeMarkdownHtml(html);
+    if (sanitized === null)
+      throw new Error("sanitizeMarkdownHtml returned null");
+    const parser = ProseMirrorDOMParser.fromSchema(editor.state.schema);
+    const slice = parser.parseSlice(sanitized, { preserveWhitespace: false });
+    editor.view.dispatch(
+      editor.state.tr.replaceSelection(
+        normalizeSliceSoftBreaks(slice, editor.state.schema),
+      ),
+    );
+
+    // Two real paragraphs, no hardBreak.
+    expect(editor.state.doc.childCount).toBe(2);
+    expect(editor.state.doc.firstChild?.textContent).toBe("hello");
+    expect(editor.state.doc.lastChild?.textContent).toBe("abc");
+
+    caretBefore(editor, "abc");
+    typeText(editor, "1. ");
+
+    expect(editor.state.doc.firstChild?.textContent).toBe("hello");
+    let listItemText: string | null = null;
+    editor.state.doc.descendants((node) => {
+      if (node.type.name === "listItem" && listItemText === null) {
+        listItemText = node.textContent;
+        return false;
+      }
+      return true;
+    });
+    expect(listItemText).toBe("abc");
+  });
+});
+
+describe("serialization invariance", () => {
+  it("hardBreak and paragraph representations submit identical text", () => {
+    const withHardBreak = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "text", text: "hello" },
+            { type: "hardBreak" },
+            { type: "text", text: "abc" },
+          ],
+        },
+      ],
+    };
+    const withParagraphs = {
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "hello" }] },
+        { type: "paragraph", content: [{ type: "text", text: "abc" }] },
+      ],
+    };
+    expect(extractPlainTextFromComposerJSONContent(withHardBreak)).toBe(
+      "hello\nabc",
+    );
+    expect(extractPlainTextFromComposerJSONContent(withParagraphs)).toBe(
+      "hello\nabc",
+    );
+  });
+});

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-list-keymap.ts
@@ -1,7 +1,5 @@
 import { Extension } from "@tiptap/core";
 import type { Editor } from "@tiptap/core";
-import type { Node as ProseMirrorNode, Schema } from "@tiptap/pm/model";
-import { Plugin, TextSelection, type EditorState } from "@tiptap/pm/state";
 import type { ComposerPickerStore } from "../../picker/composer-picker-store";
 
 export interface ChatListKeymapOptions {
@@ -19,10 +17,6 @@ export const ChatListKeymap = Extension.create<ChatListKeymapOptions>({
     };
   },
 
-  addProseMirrorPlugins() {
-    return [visualLineListInputPlugin()];
-  },
-
   addKeyboardShortcuts() {
     const { onSubmit, pickerStore } = this.options;
     return {
@@ -32,10 +26,18 @@ export const ChatListKeymap = Extension.create<ChatListKeymapOptions>({
       },
       "Shift-Enter": ({ editor }) => {
         if (handleListEnter(editor)) return true;
-        // `setHardBreak` dispatches without scrollIntoView, so a newline past
-        // the editor's max-height wouldn't follow the caret until the next
-        // keystroke. Chain scrollIntoView so the cursor stays visible.
-        return editor.chain().setHardBreak().scrollIntoView().run();
+        if (editor.isActive("codeBlock")) {
+          // `splitBlock` would fragment one code block into two; `newlineInCode`
+          // inserts a real in-code newline. A bare `return false` would insert
+          // nothing here, because `Enter` is globally bound to submit and
+          // nothing else binds `Shift-Enter`.
+          return editor.chain().newlineInCode().scrollIntoView().run();
+        }
+        // A soft newline is a paragraph boundary: `splitBlock` makes each visual
+        // line its own textblock, so native list/heading input rules fire on
+        // every line. `scrollIntoView` keeps the caret visible when the new line
+        // pushes past the editor's max-height.
+        return editor.chain().splitBlock().scrollIntoView().run();
       },
       Enter: () => {
         if (handlePickerEnter(pickerStore)) return true;
@@ -45,115 +47,6 @@ export const ChatListKeymap = Extension.create<ChatListKeymapOptions>({
     };
   },
 });
-
-interface VisualLineListMatch {
-  readonly kind: "bullet" | "ordered";
-  readonly hardBreakPos: number;
-  readonly insertAfter: number;
-  readonly start: number | null;
-}
-
-function visualLineListInputPlugin(): Plugin {
-  return new Plugin({
-    props: {
-      handleTextInput(view, from, to, text) {
-        if (text !== " " || from !== to) return false;
-        const match = visualLineListMatch(view.state, from);
-        if (match === null) return false;
-        const listNode = createEmptyListNode(
-          view.state.schema,
-          match.kind,
-          match.start,
-        );
-        if (listNode === null) return false;
-
-        const tr = view.state.tr.delete(match.hardBreakPos, from);
-        const insertPos = tr.mapping.map(match.insertAfter);
-        tr.insert(insertPos, listNode);
-        tr.setSelection(TextSelection.create(tr.doc, insertPos + 3));
-        view.dispatch(tr.scrollIntoView());
-        return true;
-      },
-    },
-  });
-}
-
-function visualLineListMatch(
-  state: EditorState,
-  from: number,
-): VisualLineListMatch | null {
-  const $from = state.doc.resolve(from);
-  const parent = $from.parent;
-  if (parent.type.name !== "paragraph") return null;
-
-  const marker = markerAfterLastHardBreak(parent, $from.parentOffset);
-  if (marker === null) return null;
-
-  const ordered = /^(\d+)\.$/.exec(marker.text);
-  if (ordered !== null) {
-    return {
-      kind: "ordered",
-      hardBreakPos: $from.start() + marker.hardBreakOffset,
-      insertAfter: $from.after(),
-      start: Number.parseInt(ordered[1], 10),
-    };
-  }
-
-  if (marker.text === "-" || marker.text === "+" || marker.text === "*") {
-    return {
-      kind: "bullet",
-      hardBreakPos: $from.start() + marker.hardBreakOffset,
-      insertAfter: $from.after(),
-      start: null,
-    };
-  }
-
-  return null;
-}
-
-function markerAfterLastHardBreak(
-  parent: ProseMirrorNode,
-  parentOffset: number,
-): { readonly hardBreakOffset: number; readonly text: string } | null {
-  let hardBreakOffset: number | null = null;
-  let lineText = "";
-
-  let offset = 0;
-  for (let index = 0; index < parent.childCount; index += 1) {
-    const child = parent.child(index);
-    if (offset >= parentOffset) break;
-    const childEnd = offset + child.nodeSize;
-    if (child.type.name === "hardBreak" && childEnd <= parentOffset) {
-      hardBreakOffset = offset;
-      lineText = "";
-      offset = childEnd;
-      continue;
-    }
-    if (child.isText) {
-      const text = child.text ?? "";
-      const end = Math.min(text.length, parentOffset - offset);
-      if (end > 0) lineText += text.slice(0, end);
-    }
-    offset = childEnd;
-  }
-
-  return hardBreakOffset === null ? null : { hardBreakOffset, text: lineText };
-}
-
-function createEmptyListNode(
-  schema: Schema,
-  kind: "bullet" | "ordered",
-  start: number | null,
-): ProseMirrorNode | null {
-  const paragraph = schema.nodes.paragraph.createAndFill();
-  if (paragraph === null) return null;
-  const listItem = schema.nodes.listItem.createAndFill(null, paragraph);
-  if (listItem === null) return null;
-  const listType =
-    kind === "bullet" ? schema.nodes.bulletList : schema.nodes.orderedList;
-  const attrs = kind === "ordered" ? { start: start ?? 1 } : null;
-  return listType.createAndFill(attrs, listItem);
-}
 
 function handlePickerEnter(pickerStore: ComposerPickerStore | null): boolean {
   if (pickerStore === null) return false;

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
@@ -10,6 +10,7 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import { readComposerContentFromClipboardData } from "@/lib/composer/composer-clipboard";
 import { sanitizeMarkdownHtml } from "@/lib/composer/markdown-paste";
+import { normalizeSliceSoftBreaks } from "@/lib/composer/normalize-soft-breaks";
 import {
   parseLeadingSlashCommand,
   slashCommandParagraph,
@@ -49,7 +50,9 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
                   composerContent,
                 );
                 if (slice === null) return false;
-                const tr = view.state.tr.replaceSelection(slice);
+                const tr = view.state.tr.replaceSelection(
+                  normalizeSliceSoftBreaks(slice, view.state.schema),
+                );
                 view.dispatch(tr.scrollIntoView());
                 return true;
               }
@@ -65,7 +68,9 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
                 const slice = parser.parseSlice(sanitized, {
                   preserveWhitespace: false,
                 });
-                const tr = view.state.tr.replaceSelection(slice);
+                const tr = view.state.tr.replaceSelection(
+                  normalizeSliceSoftBreaks(slice, view.state.schema),
+                );
                 view.dispatch(tr.scrollIntoView());
                 return true;
               }
@@ -95,7 +100,9 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
                 editor.markdown.parse(text),
               );
               if (slice === null) return false;
-              const tr = view.state.tr.replaceSelection(slice);
+              const tr = view.state.tr.replaceSelection(
+                normalizeSliceSoftBreaks(slice, view.state.schema),
+              );
               view.dispatch(tr.scrollIntoView());
               return true;
             },

--- a/clients/gui-app/src/lib/composer/normalize-soft-breaks.ts
+++ b/clients/gui-app/src/lib/composer/normalize-soft-breaks.ts
@@ -1,0 +1,130 @@
+import {
+  Fragment,
+  Slice,
+  type Node as ProseMirrorNode,
+  type Schema,
+} from "@tiptap/pm/model";
+
+/**
+ * Rewrites a pasted slice so every soft newline is a paragraph boundary instead
+ * of an inline `hardBreak` (or a literal `\n` inside a text node). Each visual
+ * line then becomes its own textblock, so the native list/heading input rules
+ * fire on every line - the composer no longer needs a custom plugin to start a
+ * list on a non-first visual line.
+ *
+ * Only paragraph content (and loose top-level inline content) is split. Code
+ * blocks keep their literal `\n`, and lists pass through untouched. When the
+ * slice carries no soft break, the original slice is returned verbatim so a
+ * plain single-line paste keeps its inline-merge behavior.
+ */
+export function normalizeSliceSoftBreaks(slice: Slice, schema: Schema): Slice {
+  if (!fragmentHasSoftBreak(slice.content)) return slice;
+
+  const blocks = splitFragmentIntoParagraphs(slice.content, schema);
+  const fragment = Fragment.fromArray(blocks);
+
+  // Open the paragraph boundaries (depth 1) so the leading block merges into the
+  // caret's left remainder and the trailing block into the right remainder - the
+  // standard "paste paragraphs into mid-text" behavior. A non-paragraph boundary
+  // (list / code block) stays closed so it is inserted as its own block.
+  const openStart = fragment.firstChild?.type.name === "paragraph" ? 1 : 0;
+  const openEnd = fragment.lastChild?.type.name === "paragraph" ? 1 : 0;
+  return new Slice(fragment, openStart, openEnd);
+}
+
+function fragmentHasSoftBreak(fragment: Fragment): boolean {
+  let found = false;
+  fragment.forEach((child) => {
+    if (found) return;
+    if (inlineHasSoftBreak(child)) {
+      found = true;
+      return;
+    }
+    // Only paragraph content is eligible for splitting; code blocks keep their
+    // literal newlines and lists are left intact.
+    if (child.type.name === "paragraph") {
+      child.content.forEach((inline) => {
+        if (inlineHasSoftBreak(inline)) found = true;
+      });
+    }
+  });
+  return found;
+}
+
+function inlineHasSoftBreak(node: ProseMirrorNode): boolean {
+  if (node.type.name === "hardBreak") return true;
+  return node.isText && (node.text ?? "").includes("\n");
+}
+
+function splitFragmentIntoParagraphs(
+  fragment: Fragment,
+  schema: Schema,
+): ProseMirrorNode[] {
+  const out: ProseMirrorNode[] = [];
+  let inlineBuffer: ProseMirrorNode[] = [];
+
+  const flushInline = (): void => {
+    if (inlineBuffer.length === 0) return;
+    out.push(
+      ...splitInlineIntoParagraphs(
+        Fragment.fromArray(inlineBuffer),
+        schema,
+        null,
+      ),
+    );
+    inlineBuffer = [];
+  };
+
+  fragment.forEach((child) => {
+    if (!child.isBlock) {
+      // Loose top-level inline (e.g. the markdown branch unwraps a single
+      // paragraph to its inline content). Buffer it, then split on flush.
+      inlineBuffer.push(child);
+      return;
+    }
+    flushInline();
+    if (child.type.name === "paragraph") {
+      out.push(
+        ...splitInlineIntoParagraphs(child.content, schema, child.attrs),
+      );
+      return;
+    }
+    // Code blocks, lists, and any other block node pass through unchanged.
+    out.push(child);
+  });
+
+  flushInline();
+  return out;
+}
+
+function splitInlineIntoParagraphs(
+  inline: Fragment,
+  schema: Schema,
+  attrs: Record<string, unknown> | null,
+): ProseMirrorNode[] {
+  const runs: ProseMirrorNode[][] = [[]];
+
+  inline.forEach((node) => {
+    if (node.type.name === "hardBreak") {
+      runs.push([]);
+      return;
+    }
+    if (node.isText && (node.text ?? "").includes("\n")) {
+      const segments = (node.text ?? "").split("\n");
+      segments.forEach((segment, index) => {
+        if (index > 0) runs.push([]);
+        if (segment.length > 0) {
+          runs[runs.length - 1].push(schema.text(segment, node.marks));
+        }
+      });
+      return;
+    }
+    // Plain text without a newline, or an inline atom (mention / slashCommand /
+    // image) - keep it in the current run, marks intact.
+    runs[runs.length - 1].push(node);
+  });
+
+  return runs.map((run) =>
+    schema.nodes.paragraph.create(attrs, Fragment.fromArray(run)),
+  );
+}


### PR DESCRIPTION
## Summary

- Replace custom visualLineListInputPlugin with native list input rules by using real paragraphs (splitBlock) instead of visual lines with hardBreaks
- Add normalizeSliceSoftBreaks utility to convert soft breaks to paragraph boundaries on paste, so list/heading rules fire on every pasted line
- Update Shift+Enter to splitBlock for paragraphs and newlineInCode for code blocks to match the new paragraph-boundary model

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved handling of pasted content containing line breaks, ensuring proper paragraph boundaries in the chat composer.

* **Bug Fixes**
  * Enhanced Shift-Enter keyboard shortcut behavior for better paragraph creation and list input support.
  * Refined list marker detection to correctly process list prefixes when working with existing text content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->