### PR TITLE
ci: enforce DCO sign-off on pull requests

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,54 @@
+name: DCO
+
+# Enforces the Developer Certificate of Origin on every pull request: each
+# commit must carry a `Signed-off-by:` trailer (see CONTRIBUTING.md). We verify
+# in plain git instead of a third-party action so there's no external dependency
+# to pin or license — matching the secret-scan workflow's approach.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: Signed-off-by
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0 # full history so we can enumerate every PR commit
+
+      - name: Check sign-off on all PR commits
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          missing=0
+          for sha in $(git rev-list "$BASE_SHA".."$HEAD_SHA"); do
+            # Merge commits are exempt — they carry no contributed authorship.
+            if [ "$(git rev-list --parents -n1 "$sha" | wc -w)" -gt 2 ]; then
+              continue
+            fi
+            author="$(git show -s --format='%an <%ae>' "$sha")"
+            if ! git show -s --format='%(trailers:key=Signed-off-by,valueonly)' "$sha" \
+                | grep -qxF "$author"; then
+              if [ "$missing" -eq 0 ]; then
+                echo "Commits missing a matching 'Signed-off-by: $author' trailer:"
+                echo
+              fi
+              echo "  $sha $(git show -s --format='%s' "$sha")"
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo
+            echo "Each commit must be signed off by its author per the DCO."
+            echo "Amend with: git commit --amend -s   (or: git rebase --signoff $BASE_SHA)"
+            echo "See CONTRIBUTING.md#developer-certificate-of-origin-dco"
+            exit 1
+          fi
+
+          echo "All PR commits are signed off."

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # full history so we can enumerate every PR commit
+          persist-credentials: false # read-only checkout; don't leave the token in git config
 
       - name: Check sign-off on all PR commits
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Pre-commit hooks. https://pre-commit.com
-# Install once:  pipx install pre-commit && pre-commit install
+# Install once:  pipx install pre-commit && pre-commit install --hook-type pre-commit --hook-type commit-msg
 # Run on demand: pre-commit run --all-files
 default_stages: [pre-commit]
 repos:
@@ -28,6 +28,16 @@ repos:
   - repo: meta
     hooks:
       - id: check-hooks-apply
+
+  # DCO sign-off enforcement, mirroring .github/workflows/dco.yml. Runs at the
+  # commit-msg stage because the `Signed-off-by:` trailer is part of the message.
+  - repo: local
+    hooks:
+      - id: dco-signoff
+        name: DCO sign-off (git commit -s)
+        entry: scripts/check_dco_signoff.sh
+        language: script
+        stages: [commit-msg]
 
   # Project checks — build / compile / lint / format (nx affected for speed).
   # Tests run in their own workflow (.github/workflows/test.yml).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,7 +16,7 @@ bunx nx run @traycer/protocol:build   # a single package
 
 ## Pre-commit hooks
 
-Install the hygiene hooks once with `pipx install pre-commit && pre-commit install`; they then run on every commit (`pre-commit run --all-files` to run manually). Lint and format are enforced in CI.
+Install the hygiene hooks once with `pipx install pre-commit && pre-commit install --hook-type pre-commit --hook-type commit-msg`; they then run on every commit (`pre-commit run --all-files` to run manually). The `commit-msg` hook type is required for DCO sign-off enforcement. Lint and format are enforced in CI.
 
 ## Workspace layout
 

--- a/scripts/check_dco_signoff.sh
+++ b/scripts/check_dco_signoff.sh
@@ -12,9 +12,11 @@ if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
   exit 0
 fi
 
-# The committer is the author of a fresh commit; match the DCO trailer to them.
-name="$(git config user.name)"
-email="$(git config user.email)"
+# Match the DCO trailer to the commit's actual author. Git exports GIT_AUTHOR_*
+# into the commit-msg hook environment, so these reflect a `--author` override;
+# fall back to git config when they're unset.
+name="${GIT_AUTHOR_NAME:-$(git config user.name)}"
+email="${GIT_AUTHOR_EMAIL:-$(git config user.email)}"
 expected="Signed-off-by: ${name} <${email}>"
 
 if grep -qixF "$expected" "$msg_file"; then

--- a/scripts/check_dco_signoff.sh
+++ b/scripts/check_dco_signoff.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# commit-msg hook: enforce the Developer Certificate of Origin locally, the same
+# rule as .github/workflows/dco.yml. pre-commit passes the path to the commit
+# message file as $1. The commit author's `Signed-off-by:` trailer must be
+# present — add it with `git commit -s`.
+set -euo pipefail
+
+msg_file="$1"
+
+# Merge commits carry no contributed authorship — skip them.
+if [ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+  exit 0
+fi
+
+# The committer is the author of a fresh commit; match the DCO trailer to them.
+name="$(git config user.name)"
+email="$(git config user.email)"
+expected="Signed-off-by: ${name} <${email}>"
+
+if grep -qixF "$expected" "$msg_file"; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+Commit is missing its DCO sign-off trailer:
+
+  $expected
+
+Re-run with sign-off:  git commit -s
+(amending the last commit:  git commit --amend -s)
+See CONTRIBUTING.md#developer-certificate-of-origin-dco
+EOF
+exit 1


### PR DESCRIPTION
## Summary

We document the DCO in `CONTRIBUTING.md` and the PR template, but nothing enforces it — an outside PR with unsigned commits passes all checks today. This wires up enforcement in two places:

- **`.github/workflows/dco.yml`** — on every `pull_request`, walks each commit between base and head and fails if any commit lacks a `Signed-off-by:` trailer matching its author. Pure git (no third-party action to license/pin, matching `secret-scan.yml`); merge commits exempt; prints the exact `git commit --amend -s` fix on failure.
- **`scripts/check_dco_signoff.sh` + `.pre-commit-config.yaml`** — a local `commit-msg`-stage hook mirroring the same rule, so contributors catch a missing sign-off before pushing. Runs at `commit-msg` (not `pre-commit`) because the trailer lives in the commit message.

## Follow-ups (not in this PR)

- Mark **DCO / Signed-off-by** as a required status check in branch protection for `main` so it actually blocks merges.
- Contributors must re-run `pre-commit install --hook-type pre-commit --hook-type commit-msg` (now in the config header) to activate the local hook.

## Checklist

- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] `shellcheck` clean; workflow YAML validated; hook behavior tested (fails without sign-off, passes with)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Developer Certificate of Origin (DCO) checks that validate commit `Signed-off-by` sign-offs for pull requests.
  * Enabled local DCO sign-off enforcement during commits via a commit message hook.
* **Documentation**
  * Updated development setup instructions to reflect installing both pre-commit and commit-message hooks so DCO checks run locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->