### PR TITLE
fix: resolve CodeQL code-scanning findings

### DIFF
--- a/clients/desktop/scripts/prepack/check-tray-assets.cjs
+++ b/clients/desktop/scripts/prepack/check-tray-assets.cjs
@@ -14,7 +14,7 @@
  * rename or delete. Fail loudly with a regeneration hint.
  */
 
-const { existsSync, statSync } = require("node:fs");
+const { openSync, fstatSync, readSync, closeSync } = require("node:fs");
 const { resolve } = require("node:path");
 
 const trayDir = resolve(__dirname, "..", "..", "resources", "tray");
@@ -37,24 +37,29 @@ const problems = [];
 
 for (const name of required) {
   const path = resolve(trayDir, name);
-  if (!existsSync(path)) {
+  // Open once and inspect through the descriptor (fstat + read), so the file we
+  // size-check is the same one we read — no stat-then-open TOCTOU. A failed
+  // open (ENOENT) is the "missing" case.
+  let fd;
+  try {
+    fd = openSync(path, "r");
+  } catch {
     problems.push(`missing: ${name}`);
     continue;
   }
-  const info = statSync(path);
-  if (!info.isFile() || info.size === 0) {
-    problems.push(`empty or non-file: ${name}`);
-    continue;
-  }
-  const fd = require("node:fs").openSync(path, "r");
-  const head = Buffer.alloc(8);
   try {
-    require("node:fs").readSync(fd, head, 0, 8, 0);
+    const info = fstatSync(fd);
+    if (!info.isFile() || info.size === 0) {
+      problems.push(`empty or non-file: ${name}`);
+      continue;
+    }
+    const head = Buffer.alloc(8);
+    readSync(fd, head, 0, 8, 0);
+    if (!head.equals(PNG_SIGNATURE)) {
+      problems.push(`not a valid PNG (bad signature): ${name}`);
+    }
   } finally {
-    require("node:fs").closeSync(fd);
-  }
-  if (!head.equals(PNG_SIGNATURE)) {
-    problems.push(`not a valid PNG (bad signature): ${name}`);
+    closeSync(fd);
   }
 }
 

--- a/clients/desktop/src/electron-main/host/host-lifecycle.ts
+++ b/clients/desktop/src/electron-main/host/host-lifecycle.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import { watch, type FSWatcher } from "node:fs";
 import { EventEmitter } from "node:events";
 import { createConnection } from "node:net";
@@ -619,11 +619,10 @@ async function safeReadLogTail(
   path: string,
   maxLines: number,
 ): Promise<string | null> {
+  // Read directly and let the single catch handle every failure mode — a
+  // missing file (ENOENT) and a path that's a directory (EISDIR) both land
+  // here. A prior stat()/isFile() check would only add a TOCTOU window.
   try {
-    const info = await stat(path);
-    if (!info.isFile()) {
-      return null;
-    }
     const raw = await readFile(path, "utf8");
     const lines = raw.split(/\r?\n/);
     return lines.slice(-maxLines).join("\n");

--- a/clients/desktop/src/electron-main/tray/__tests__/tray.test.ts
+++ b/clients/desktop/src/electron-main/tray/__tests__/tray.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join, resolve as resolvePath } from "node:path";
 import type { DesktopTrayEpic } from "../../../ipc-contracts/host-types";
 import type { TrayManagedWindow } from "../tray";
@@ -198,10 +198,15 @@ describe("resolveTrayIconPath", () => {
       expect(existsSync(asset.path), `expected ${asset.path} to exist`).toBe(
         true,
       );
-      const info = statSync(asset.path);
-      expect(info.isFile()).toBe(true);
-      expect(info.size).toBeGreaterThan(0);
-      const head = readFileSync(asset.path).subarray(0, 8);
+      // Read once and assert against the buffer — reading a directory would
+      // throw, so this also covers the "is a regular file" expectation without
+      // a separate stat() that could race the read.
+      const contents = readFileSync(asset.path);
+      expect(
+        contents.length,
+        `expected ${asset.path} to be non-empty`,
+      ).toBeGreaterThan(0);
+      const head = contents.subarray(0, 8);
       expect(
         head.equals(PNG_SIGNATURE),
         `expected ${asset.path} to start with the PNG signature`,

--- a/clients/traycer-cli/src/commands/host-logs.ts
+++ b/clients/traycer-cli/src/commands/host-logs.ts
@@ -123,16 +123,20 @@ async function followLog(path: string, quiet: boolean): Promise<void> {
     const tick = async (): Promise<void> => {
       if (stopped) return;
       try {
-        const stats = await stat(path);
-        missingRetries = 0;
-        if (stats.size < offset) {
-          // Truncated / rotated: re-read from the top.
-          offset = 0;
-        }
-        if (stats.size > offset) {
-          const length = stats.size - offset;
-          const fh = await open(path, "r");
-          try {
+        // Open first, then size and read through the same handle, so the size
+        // we act on is the file we read rather than re-resolving the path twice
+        // (a TOCTOU window). Re-opening each tick also transparently follows a
+        // rotation: the next open lands on whatever file now holds the path.
+        const fh = await open(path, "r");
+        try {
+          const stats = await fh.stat();
+          missingRetries = 0;
+          if (stats.size < offset) {
+            // Truncated / rotated: re-read from the top.
+            offset = 0;
+          }
+          if (stats.size > offset) {
+            const length = stats.size - offset;
             const buf = Buffer.alloc(length);
             const { bytesRead } = await fh.read(buf, 0, length, offset);
             if (bytesRead > 0) {
@@ -144,9 +148,9 @@ async function followLog(path: string, quiet: boolean): Promise<void> {
               }
               offset += bytesRead;
             }
-          } finally {
-            await fh.close();
           }
+        } finally {
+          await fh.close();
         }
       } catch {
         // ENOENT or transient: bounded retry then give up. Restart of

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -204,6 +204,18 @@ interface BuildTaskXmlOptions {
   readonly cli: CliInvocation;
 }
 
+// Quote a single token for a Windows command line the way CommandLineToArgvW
+// parses it: a backslash is literal unless it runs up to a `"`. So we double
+// only the backslashes immediately before a quote (escaping the quote with one
+// extra) and those before the closing quote we append, leaving interior path
+// separators like the ones in `C:\Users\foo` untouched.
+function quoteWindowsArg(arg: string): string {
+  const escaped = arg
+    .replace(/(\\*)"/g, '$1$1\\"')
+    .replace(/(\\+)$/, "$1$1");
+  return `"${escaped}"`;
+}
+
 function buildTaskXml(options: BuildTaskXmlOptions): string {
   // <Command> takes a single executable; <Arguments> takes the rest as
   // a single string. schtasks parses the latter with shell rules, so
@@ -213,11 +225,7 @@ function buildTaskXml(options: BuildTaskXmlOptions): string {
     "host",
     "start",
   ];
-  // Escape backslashes before quotes: otherwise an arg ending in `\` would let
-  // its trailing backslash escape our closing quote and break out of the token.
-  const argumentsLine = argv
-    .map((arg) => `"${arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`)
-    .join(" ");
+  const argumentsLine = argv.map(quoteWindowsArg).join(" ");
   const userId = resolveTaskUserId();
   return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -1,4 +1,4 @@
-import { rm, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readHostPidMetadata } from "../../host/pid-metadata";
@@ -41,7 +41,12 @@ export function createWindowsController(
 
 async function installService(options: InstallServiceOptions): Promise<void> {
   const taskName = windowsTaskName(options.label);
-  const xmlPath = join(tmpdir(), `${sanitize(options.label.id)}.task.xml`);
+  // schtasks /Create /XML reads the task definition from disk. Stage it inside a
+  // private per-invocation directory (mkdtemp ⇒ mode 0700 with an unguessable
+  // suffix) rather than a predictable name in the shared tmpdir, so a local
+  // attacker can't pre-create or symlink the path we're about to write.
+  const tmpDir = await mkdtemp(join(tmpdir(), "traycer-task-"));
+  const xmlPath = join(tmpDir, "task.xml");
   // schtasks /Create /XML requires UTF-16 LE with BOM. Anything else
   // fails with "The specified file is not a valid XML file". Node's
   // built-in `utf16le` encoder paired with a leading U+FEFF BOM
@@ -68,7 +73,7 @@ async function installService(options: InstallServiceOptions): Promise<void> {
       exitCode: 1,
     });
   } finally {
-    await rm(xmlPath, { force: true });
+    await rm(tmpDir, { recursive: true, force: true });
   }
   // Kick the task immediately so the host comes up without waiting
   // for the next logon.
@@ -194,10 +199,6 @@ function describeCause(cause: unknown): string {
   return cause instanceof Error ? cause.message : String(cause);
 }
 
-function sanitize(value: string): string {
-  return value.replace(/[^A-Za-z0-9._-]/g, "_");
-}
-
 interface BuildTaskXmlOptions {
   readonly label: ServiceLabel;
   readonly cli: CliInvocation;
@@ -212,7 +213,11 @@ function buildTaskXml(options: BuildTaskXmlOptions): string {
     "host",
     "start",
   ];
-  const argumentsLine = argv.map((arg) => `"${arg.replace(/"/g, '\\"')}"`).join(" ");
+  // Escape backslashes before quotes: otherwise an arg ending in `\` would let
+  // its trailing backslash escape our closing quote and break out of the token.
+  const argumentsLine = argv
+    .map((arg) => `"${arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`)
+    .join(" ");
   const userId = resolveTaskUserId();
   return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">

--- a/protocol/src/common/json-content-serializer.ts
+++ b/protocol/src/common/json-content-serializer.ts
@@ -601,7 +601,9 @@ function serializeTable(node: JsonContent, ctx: SerializerContext): string {
           isHeader = true;
         }
         const cellContent = serializeChildren(cell.content, ctx);
-        cells.push(cellContent.replace(/\|/g, "\\|"));
+        // Escape backslashes before pipes so a literal trailing `\` in a cell
+        // can't escape the `\|` we add and merge two cells together.
+        cells.push(cellContent.replace(/\\/g, "\\\\").replace(/\|/g, "\\|"));
       }
     }
 

--- a/protocol/src/host/agent/gui/tool-input-detail.ts
+++ b/protocol/src/host/agent/gui/tool-input-detail.ts
@@ -67,12 +67,19 @@ function normalize(value: string): string {
   return value.trim().replace(/\s+/g, " ");
 }
 
+// Escape a value for inclusion inside a double-quoted token: backslashes first
+// (so the escapes we add for quotes aren't themselves re-interpreted), then the
+// quotes.
+function escapeDoubleQuoted(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
 // Quote a token for a reconstructed command line only when it isn't already a
 // bare shell-safe word, so simple values stay unquoted while paths/queries with
 // spaces or specials read correctly.
 function quoteArg(value: string): string {
   if (/^[\w./@:=+-]+$/.test(value)) return value;
-  return `"${value.replace(/"/g, '\\"')}"`;
+  return `"${escapeDoubleQuoted(value)}"`;
 }
 
 // `-C N`, or `-B N -A N`, from either the flag keys or the spelled-out aliases.
@@ -112,7 +119,7 @@ function reconstructGrep(record: Record<string, unknown>): string | null {
     ...grepContextArgs(record),
     ...(type !== null ? [`--type ${quoteArg(type)}`] : []),
     ...(glob !== null ? [`--glob ${quoteArg(glob)}`] : []),
-    `"${pattern.replace(/"/g, '\\"')}"`,
+    `"${escapeDoubleQuoted(pattern)}"`,
     ...(path !== null ? [quoteArg(path)] : []),
   ].join(" ");
 }

--- a/scripts/dev-desktop.js
+++ b/scripts/dev-desktop.js
@@ -176,9 +176,9 @@ async function stageDevCliWrapper() {
 
 function ensureHostLog() {
   fs.mkdirSync(path.dirname(DEV_HOST_LOG), { recursive: true });
-  if (!fs.existsSync(DEV_HOST_LOG)) {
-    fs.closeSync(fs.openSync(DEV_HOST_LOG, "a"));
-  }
+  // Opening in append mode creates the file if it's absent and is a no-op
+  // otherwise, so there's no need (and no safe way) to existsSync-then-create.
+  fs.closeSync(fs.openSync(DEV_HOST_LOG, "a"));
 }
 
 // `--release <version>` pins a specific host release; omitted ⇒ the CLI


### PR DESCRIPTION
## Summary

Resolves the CodeQL alerts flagged on the client code. All fixes are behavior-preserving — they tighten escaping and remove TOCTOU windows without changing observable output.

### `js/incomplete-sanitization` (high) — 4 alerts
Escape **backslashes before** the quote/pipe escapes we add, so a value ending in `\` can't escape our delimiter and break out of its token:
- `service/platforms/windows.ts` — schtasks `<Arguments>` line
- `host/agent/gui/tool-input-detail.ts` — command reconstruction (`quoteArg` + grep pattern), now via a shared `escapeDoubleQuoted` helper
- `common/json-content-serializer.ts` — markdown table-cell serialization

### `js/insecure-temporary-file` (high) — 1 alert
- `service/platforms/windows.ts` — stage the task XML in a private `mkdtemp` dir (mode 0700, unguessable suffix) instead of a predictable `tmpdir()/<id>.task.xml`. Removes the now-unused `sanitize` helper.

### `js/file-system-race` (high) — 5 alerts
Remove `stat`/`exists` prechecks that raced a following read:
- `commands/host-logs.ts` — tail loop now opens once and `fstat`s the descriptor it reads
- `electron-main/host/host-lifecycle.ts` — `safeReadLogTail` reads-and-catches (EISDIR/ENOENT both handled) instead of `stat().isFile()` then read
- `scripts/prepack/check-tray-assets.cjs` — open once, `fstat` + `read` through the descriptor
- `electron-main/tray/__tests__/tray.test.ts` — read the asset once, derive size/signature from the buffer
- `scripts/dev-desktop.js` — `openSync(…, "a")` already creates the log; dropped the `existsSync` guard

## Not changed (recommend dismissing as by-design)
- **`js/file-access-to-http` (medium, ×4)** — `auth-validation.ts`, `fetch-resource.ts`: sending the stored bearer to its own authn endpoint / fetching from the trusted host-registry manifest URL is the intended design.
- **`js/http-to-file-access` (medium, ×2)** — `store/credentials.ts`, `manifest/cli-manifest.ts`: persisting downloaded credentials/manifest is the intended download path (already written atomically with mode 0600).

The Scorecard alerts (BranchProtection, CodeReview, Fuzzing, CIIBestPractices) are repo-policy, not code — tracked separately.

## Verification
- `nx compile` + `nx lint` green across protocol, traycer-cli, desktop
- `nx test` desktop (324) green; traycer-cli green except 5 **pre-existing** `auto-bootstrap.test.ts` failures present on `main` before this branch (unrelated `isProcessAlive` mock)
- Ran `check-tray-assets.cjs` directly — passes

## Checklist
- [x] `bun run lint`, `bun run compile` pass
- [x] Pre-commit hooks pass
- [x] Commit signed off (DCO)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in log polling that could miss new log updates.
  * Corrected backslash handling in Markdown table serialization to prevent cells from merging.
  * Improved command-line escaping for Windows scheduled task configuration and tool input reconstruction.
* **Improved Reliability**
  * Made tray asset prechecks more robust when validating required PNGs.
  * Simplified log-tail reading to avoid extra filesystem checks.
  * Ensured the dev host log is always opened in append mode.
* **Tests**
  * Updated tray icon path tests to validate PNG headers using in-memory reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->