### PR TITLE
Add package-manager publishers (npm + Homebrew)

### DIFF
--- a/.github/workflows/publish-cli-package-managers.yml
+++ b/.github/workflows/publish-cli-package-managers.yml
@@ -1,0 +1,316 @@
+name: publish-cli-package-managers
+
+# External CLI package-manager publisher (runs in the PUBLIC OSS repo): npm +
+# Homebrew formula.
+#
+# Auto-triggers when a stable cli-v<version> GitHub Release is published here
+# (release: released fires only for full releases, never prereleases, so RC tags
+# are excluded automatically). Also dispatchable by tag for manual re-runs.
+#
+# This lives in the OSS repo (not the private build repo) for one reason: npm
+# provenance (--provenance) is only accepted when the publishing workflow runs
+# in a PUBLIC source repository. Building + publishing here lets the package
+# carry a verifiable SLSA provenance attestation. The CLI source is checked out
+# at the exact commit recorded in the release's release-provenance.json.
+#
+# Homebrew is published via a PULL REQUEST against the tap's protected main
+# branch; merging that PR is the human gate before the formula goes live. npm
+# publishes directly (no review gate) - gate it with the `release` environment's
+# required reviewers and a scoped, expiring NPM_TOKEN.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "CLI release tag to publish (e.g. cli-v1.6.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "Validate only: npm publish --dry-run and skip the Homebrew PR push."
+        required: false
+        type: boolean
+        default: false
+      supported_host_version:
+        description: "Override the host version the npm CLI pins. Empty = read it from the release's provenance."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve release coordinates
+    # Skip non-CLI release events (host-v*/desktop-v* also fire `released`).
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'cli-v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.compute.outputs.version }}
+      dist_tag: ${{ steps.compute.outputs.dist_tag }}
+      oss_ref: ${{ steps.provenance.outputs.oss_ref }}
+      supported_host_version: ${{ steps.provenance.outputs.supported_host_version }}
+    env:
+      RELEASE_REPO: ${{ github.repository }}
+    steps:
+      - name: Parse tag into version + npm dist-tag
+        id: compute
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$RELEASE_TAG"
+          fi
+          if [[ "$tag" != cli-v* ]]; then
+            echo "::error::Tag '$tag' must be a CLI release tag of the form cli-v<semver> (e.g. cli-v1.6.0)."
+            exit 1
+          fi
+          version="${tag#cli-v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version '$version' parsed from tag '$tag'. Expected semver (e.g. 1.5.0)."
+            exit 1
+          fi
+          dist_tag="latest"
+          if [[ "$version" == *-* ]]; then
+            prerelease="${version#*-}"
+            dist_tag="${prerelease%%.*}"
+            if ! [[ "$dist_tag" =~ ^[0-9A-Za-z][0-9A-Za-z._-]*$ ]]; then
+              echo "::error::Invalid npm dist-tag derived from prerelease '$version': '$dist_tag'."
+              exit 1
+            fi
+          fi
+          {
+            echo "tag=$tag"
+            echo "version=$version"
+            echo "dist_tag=$dist_tag"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved tag=$tag version=$version dist_tag=$dist_tag"
+      - name: Verify release + read provenance
+        id: provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.compute.outputs.tag }}
+          SUPPORTED_HOST_OVERRIDE: ${{ inputs.supported_host_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! gh release view "$TAG" --repo "$RELEASE_REPO" >/dev/null 2>&1; then
+            echo "::error::Release '$TAG' does not exist on ${RELEASE_REPO}."
+            exit 1
+          fi
+          tmp="$(mktemp -d)"
+          if ! gh release download "$TAG" --repo "$RELEASE_REPO" --pattern release-provenance.json --dir "$tmp" >/dev/null 2>&1; then
+            echo "::error::release-provenance.json is missing from '$TAG'; cannot resolve the OSS source commit to build npm from."
+            exit 1
+          fi
+          oss_ref="$(jq -r '.ossRef // empty' "$tmp/release-provenance.json")"
+          if [ -z "$oss_ref" ]; then
+            echo "::error::release-provenance.json for '$TAG' has no ossRef; cannot build npm from a known source commit."
+            exit 1
+          fi
+          supported_host_version="$SUPPORTED_HOST_OVERRIDE"
+          if [ -z "$supported_host_version" ]; then
+            supported_host_version="$(jq -r '.supportedHostVersion // empty' "$tmp/release-provenance.json")"
+          fi
+          if [ -z "$supported_host_version" ]; then
+            echo "::error::No supported host version available: release-provenance.json for '$TAG' predates the supportedHostVersion field. Re-run with the supported_host_version input set."
+            exit 1
+          fi
+          echo "oss_ref=$oss_ref" >> "$GITHUB_OUTPUT"
+          echo "supported_host_version=$supported_host_version" >> "$GITHUB_OUTPUT"
+          echo "OSS source ref: $oss_ref ; supported host version: $supported_host_version"
+
+  publish-npm:
+    name: Publish @traycerai/cli to npm
+    needs: resolve
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      VERSION: ${{ needs.resolve.outputs.version }}
+      DIST_TAG: ${{ needs.resolve.outputs.dist_tag }}
+      RELEASE_REPO: ${{ github.repository }}
+    steps:
+      - name: Determine publish mode
+        id: gate
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "mode=dry-run" >> "$GITHUB_OUTPUT"
+          elif [ -z "$NPM_TOKEN" ]; then
+            echo "::error::NPM_TOKEN is unset; cannot publish to npm. Set the secret or run with dry_run=true."
+            exit 1
+          else
+            echo "mode=publish" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Check out CLI source at the built commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.resolve.outputs.oss_ref }}
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.12"
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24.15.0"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install workspace dependencies
+        run: bun install --frozen-lockfile
+      - name: Stamp CLI production deploy target
+        env:
+          TRAYCER_SUPPORTED_HOST_VERSION: ${{ needs.resolve.outputs.supported_host_version }}
+          TRAYCER_RELEASE_REPO: ${{ env.RELEASE_REPO }}
+        run: bun clients/traycer-cli/scripts/set-deploy-target.cjs --target=production
+      - name: Build npm package
+        env:
+          TRAYCER_CLI_SENTRY_DSN: ${{ secrets.TRAYCER_CLI_SENTRY_DSN }}
+          TRAYCER_CLI_VERSION: ${{ needs.resolve.outputs.version }}
+        run: bun run --cwd clients/traycer-cli build
+      - name: Restore CLI deploy target to local
+        if: always()
+        run: bun clients/traycer-cli/scripts/set-deploy-target.cjs --restore
+      - name: Skip existing npm version
+        if: steps.gate.outputs.mode == 'publish'
+        id: existing
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if npm view "@traycerai/cli@${VERSION}" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "@traycerai/cli@${VERSION} already exists; skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish npm package (with provenance)
+        if: steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish clients/traycer-cli/dist-npm --provenance --access public --tag "$DIST_TAG"
+      - name: npm dry run
+        if: steps.gate.outputs.mode == 'dry-run'
+        run: npm publish clients/traycer-cli/dist-npm --access public --tag "$DIST_TAG" --dry-run
+
+  publish-homebrew-formula:
+    name: Open Homebrew formula PR
+    needs: resolve
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    concurrency:
+      group: homebrew-tap-publish
+      cancel-in-progress: false
+    env:
+      VERSION: ${{ needs.resolve.outputs.version }}
+      RELEASE_REPO: ${{ github.repository }}
+    steps:
+      - name: Check tap repo secrets
+        if: ${{ inputs.dry_run != true }}
+        env:
+          HOMEBREW_TAP_REPO: ${{ secrets.TRAYCER_HOMEBREW_TAP_REPO }}
+          TAP_PUSH_TOKEN: ${{ secrets.TRAYCER_TAP_PUSH_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$HOMEBREW_TAP_REPO" || -z "$TAP_PUSH_TOKEN" ]]; then
+            echo "::error::TRAYCER_HOMEBREW_TAP_REPO and TRAYCER_TAP_PUSH_TOKEN must be set to open the Homebrew formula PR (or run with dry_run=true)."
+            exit 1
+          fi
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24.15.0"
+      - name: Download CLI descriptors for the formula
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p descriptors
+          # The formula needs both macOS descriptors (required) and the Linux
+          # descriptors (optional - Linuxbrew). Download whichever exist.
+          for platform_key in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            if gh release view "cli-v${VERSION}" --repo "$RELEASE_REPO" --json assets \
+              --jq ".assets[] | select(.name == \"cli-descriptor-${platform_key}.json\") | .url" | grep -q .; then
+              gh release download "cli-v${VERSION}" --repo "$RELEASE_REPO" \
+                --pattern "cli-descriptor-${platform_key}.json" \
+                --dir descriptors --clobber
+            fi
+          done
+          for required in darwin-arm64 darwin-x64; do
+            if [ ! -f "descriptors/cli-descriptor-${required}.json" ]; then
+              echo "::error::Required macOS descriptor cli-descriptor-${required}.json is missing from cli-v${VERSION}."
+              exit 1
+            fi
+          done
+          ls -la descriptors/
+      - name: Render Homebrew formula
+        shell: bash
+        run: |
+          set -euo pipefail
+          DESCRIPTOR_ARGS=()
+          for f in descriptors/cli-descriptor-*.json; do
+            [ -f "$f" ] || continue
+            DESCRIPTOR_ARGS+=(--descriptor "$f")
+          done
+          node scripts/native-packaging/publish-cli-package-managers.cjs \
+            --version "$VERSION" \
+            --staging staging \
+            --release-repo "$RELEASE_REPO" \
+            --managers homebrew \
+            "${DESCRIPTOR_ARGS[@]}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: homebrew-formula
+          path: staging/homebrew/Formula/traycer.rb
+      - name: Open Homebrew formula PR
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ secrets.TRAYCER_TAP_PUSH_TOKEN }}
+          TAP_REPO: ${{ secrets.TRAYCER_HOMEBREW_TAP_REPO }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" tap
+          cd tap
+          git config user.name "traycer-release-bot"
+          git config user.email "release@traycer.ai"
+          branch="traycer-formula-${VERSION}"
+          git checkout -B "$branch"
+          mkdir -p Formula
+          cp ../staging/homebrew/Formula/traycer.rb Formula/traycer.rb
+          git add Formula/traycer.rb
+          if git diff --cached --quiet; then
+            echo "::notice::Formula already up to date for ${VERSION}; nothing to PR."
+            exit 0
+          fi
+          git commit -m "traycer ${VERSION}"
+          git push --force origin "$branch"
+          existing="$(gh pr list --repo "$TAP_REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "::notice::PR #${existing} already open for ${branch}; updated its branch."
+          else
+            gh pr create --repo "$TAP_REPO" --base main --head "$branch" \
+              --title "traycer ${VERSION}" \
+              --body "Automated Homebrew formula update for Traycer CLI ${VERSION}. Generated by publish-cli-package-managers.yml. Review and merge to publish."
+          fi

--- a/.github/workflows/publish-cli-package-managers.yml
+++ b/.github/workflows/publish-cli-package-managers.yml
@@ -118,6 +118,13 @@ jobs:
             echo "::error::release-provenance.json for '$TAG' has no ossRef; cannot build npm from a known source commit."
             exit 1
           fi
+          # Pin to an immutable full commit SHA. Refuse a movable ref (branch/
+          # tag) or any injected value so the publish only ever builds from the
+          # exact source commit the release was cut from.
+          if ! [[ "$oss_ref" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::ossRef '$oss_ref' is not a full 40-char commit SHA; refusing to build from a movable or untrusted ref."
+            exit 1
+          fi
           supported_host_version="$SUPPORTED_HOST_OVERRIDE"
           if [ -z "$supported_host_version" ]; then
             supported_host_version="$(jq -r '.supportedHostVersion // empty' "$tmp/release-provenance.json")"
@@ -166,6 +173,9 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.12"
+          # Always fetch the pinned Bun fresh in this publish path rather than
+          # restoring a cached executable.
+          no-cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.15.0"

--- a/.github/workflows/publish-desktop-cask.yml
+++ b/.github/workflows/publish-desktop-cask.yml
@@ -1,0 +1,161 @@
+name: publish-desktop-cask
+
+# Homebrew desktop-cask publisher (runs in the PUBLIC OSS repo).
+#
+# Auto-triggers when a stable desktop-v<version> GitHub Release is published
+# here (release: released never fires for prereleases, so RC tags are excluded).
+# Also dispatchable by tag for manual re-runs.
+#
+# The cask is published via a PULL REQUEST against the tap's protected main
+# branch; merging that PR is the human gate before the cask goes live.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Desktop release tag to publish (e.g. desktop-v1.6.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "Render the cask only; skip the tap PR push."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  render-and-pr:
+    name: Render + PR traycer-desktop cask
+    # Skip non-desktop release events (cli-v*/host-v* also fire `released`).
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'desktop-v') }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+    concurrency:
+      group: homebrew-tap-publish
+      cancel-in-progress: false
+    env:
+      RELEASE_REPO: ${{ github.repository }}
+    steps:
+      - name: Parse tag into version
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag="$RELEASE_TAG"
+          fi
+          if [[ "$tag" != desktop-v* ]]; then
+            echo "::error::Tag '$tag' must be a desktop release tag of the form desktop-v<semver> (e.g. desktop-v1.6.0)."
+            exit 1
+          fi
+          version="${tag#desktop-v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version '$version' parsed from tag '$tag'. Expected semver (e.g. 1.5.0)."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Check tap repo secrets
+        if: ${{ inputs.dry_run != true }}
+        env:
+          HOMEBREW_TAP_REPO: ${{ secrets.TRAYCER_HOMEBREW_TAP_REPO }}
+          TAP_PUSH_TOKEN: ${{ secrets.TRAYCER_TAP_PUSH_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "$HOMEBREW_TAP_REPO" || -z "$TAP_PUSH_TOKEN" ]]; then
+            echo "::error::TRAYCER_HOMEBREW_TAP_REPO and TRAYCER_TAP_PUSH_TOKEN must be set to open the cask PR (or run with dry_run=true)."
+            exit 1
+          fi
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24.15.0"
+      - name: Download macOS DMGs from desktop release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! gh release view "desktop-v${VERSION}" --repo "$RELEASE_REPO" >/dev/null 2>&1; then
+            echo "::error::Release 'desktop-v${VERSION}' does not exist on ${RELEASE_REPO}."
+            exit 1
+          fi
+          mkdir -p dmg
+          for asset in \
+            "traycer-desktop-macos-arm64.dmg" \
+            "traycer-desktop-macos-x64.dmg"; do
+            gh release download "desktop-v${VERSION}" \
+              --repo "$RELEASE_REPO" \
+              --pattern "$asset" \
+              --dir dmg \
+              --clobber
+            test -f "dmg/$asset"
+          done
+      - name: Render cask
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_url="https://github.com/${RELEASE_REPO}/releases/download/desktop-v${VERSION}"
+          arm_sha="$(shasum -a 256 dmg/traycer-desktop-macos-arm64.dmg | awk '{print $1}')"
+          x64_sha="$(shasum -a 256 dmg/traycer-desktop-macos-x64.dmg | awk '{print $1}')"
+          node scripts/native-packaging/publish-cli-package-managers.cjs \
+            --desktop-cask \
+            --version "$VERSION" \
+            --staging staging \
+            --mac-arm-url "${base_url}/traycer-desktop-macos-arm64.dmg" \
+            --mac-arm-sha256 "$arm_sha" \
+            --mac-x64-url "${base_url}/traycer-desktop-macos-x64.dmg" \
+            --mac-x64-sha256 "$x64_sha"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-cask
+          path: staging/homebrew/Casks/traycer-desktop.rb
+      - name: Open desktop cask PR
+        if: ${{ inputs.dry_run != true }}
+        env:
+          GH_TOKEN: ${{ secrets.TRAYCER_TAP_PUSH_TOKEN }}
+          TAP_REPO: ${{ secrets.TRAYCER_HOMEBREW_TAP_REPO }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" tap
+          cd tap
+          git config user.name "traycer-release-bot"
+          git config user.email "release@traycer.ai"
+          branch="traycer-desktop-${VERSION}"
+          git checkout -B "$branch"
+          mkdir -p Casks
+          cp ../staging/homebrew/Casks/traycer-desktop.rb Casks/traycer-desktop.rb
+          git add Casks/traycer-desktop.rb
+          if git diff --cached --quiet; then
+            echo "::notice::Cask already up to date for ${VERSION}; nothing to PR."
+            exit 0
+          fi
+          git commit -m "traycer-desktop ${VERSION}"
+          git push --force origin "$branch"
+          existing="$(gh pr list --repo "$TAP_REPO" --head "$branch" --state open --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "::notice::PR #${existing} already open for ${branch}; updated its branch."
+          else
+            gh pr create --repo "$TAP_REPO" --base main --head "$branch" \
+              --title "traycer-desktop ${VERSION}" \
+              --body "Automated Homebrew cask update for Traycer Desktop ${VERSION}. Generated by publish-desktop-cask.yml. Review and merge to publish."
+          fi

--- a/scripts/native-packaging/publish-cli-package-managers.cjs
+++ b/scripts/native-packaging/publish-cli-package-managers.cjs
@@ -236,13 +236,16 @@ class Traycer < Formula
   def install
     bin.install Dir["traycer*"].first => "traycer"
     # Mark this install as homebrew-owned so 'traycer cli upgrade' guides
-    # the user to 'brew upgrade traycer' instead of self-replacing.
-    system bin/"traycer", "cli", "mark-source", "--source", "homebrew",
-           "--binary-path", bin/"traycer", "--installed-version", version
-  rescue
-    # 'mark-source' is best-effort: it writes the CLI install manifest if
-    # the user's home is writable. Brew install must not fail because of it.
-    nil
+    # the user to 'brew upgrade traycer' instead of self-replacing. Only the
+    # mark-source call is best-effort (it writes the CLI install manifest if
+    # the user's home is writable) - a failed bin.install above must still
+    # fail the formula rather than be swallowed.
+    begin
+      system bin/"traycer", "cli", "mark-source", "--source", "homebrew",
+             "--binary-path", bin/"traycer", "--installed-version", version
+    rescue
+      nil
+    end
   end
 
   test do

--- a/scripts/native-packaging/publish-cli-package-managers.cjs
+++ b/scripts/native-packaging/publish-cli-package-managers.cjs
@@ -1,0 +1,753 @@
+"use strict";
+
+// Generate package-manager manifest updates for a published CLI release.
+//
+// This script is invoked from the cross-platform `update-cli-package-
+// managers` workflow after all per-platform CLI release workflows have
+// finished publishing the signed binaries to the cli-v* GitHub Release
+// on RELEASE_REPO. It does not push to upstream taps/repos directly -
+// instead it:
+//
+//   1. Reads the per-platform descriptors emitted by sign-cli-binary.cjs.
+//   2. Renders ready-to-commit manifests for Homebrew, winget, scoop,
+//      a debian/rpm template metadata file, a Desktop Homebrew cask, and a generated install
+//      manifest hint (so package-manager install hooks can call
+//      `traycer cli mark-source` with the correct source identifier).
+//   3. Writes the rendered manifests under a staging directory the
+//      workflow then commits/pushes to the external taps using a
+//      configured PAT secret.
+//
+// External repository assumptions (configured via secrets in workflows):
+//   - Homebrew tap:   traycerai/homebrew-traycer   (Formula/traycer.rb, Casks/traycer-desktop.rb)
+//   - winget:        microsoft/winget-pkgs forks   (manifests/t/Traycer/CLI)
+//   - scoop:         traycerai/scoop-traycer        (bucket/traycer-cli.json)
+//   - deb/rpm:       traycerai/traycer-apt-rpm     (versions.json)
+//
+// Required secrets (used by the calling workflow, not this script):
+//   TRAYCER_TAP_PUSH_TOKEN   PAT with `repo` scope on the tap repos.
+//
+// Output: writes files under --staging <dir>, prints a JSON summary
+// (paths + manifest snippets) on stdout.
+
+const fs = require("node:fs");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+// Canonical public-facing repo URL used for auto-generated release-notes
+// links in Homebrew/winget/Scoop/deb-rpm manifests. The build-time repo
+// (`traycerai/traycer-development`) is private; auto-generated download
+// pages must point at the public mirror. Override per-invocation via
+// `--release-notes-url <url>` when cutting a release out of a fork.
+const DEFAULT_RELEASE_NOTES_REPO = "traycerai/traycer";
+
+function parseArgs(argv) {
+  const out = { descriptors: [] };
+  const valueFor = (token, index) => {
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`Missing value for ${token}`);
+    }
+    return value;
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--descriptor") {
+      out.descriptors.push(valueFor(token, i));
+      i += 1;
+    } else if (token === "--version") {
+      out.version = valueFor(token, i);
+      i += 1;
+    } else if (token === "--staging") {
+      out.staging = valueFor(token, i);
+      i += 1;
+    } else if (token === "--release-notes-url") {
+      out.releaseNotesUrl = valueFor(token, i);
+      i += 1;
+    } else if (token === "--release-repo") {
+      out.releaseRepo = valueFor(token, i);
+      i += 1;
+    } else if (token === "--homepage") {
+      out.homepage = valueFor(token, i);
+      i += 1;
+    } else if (token === "--license") {
+      out.license = valueFor(token, i);
+      i += 1;
+    } else if (token === "--managers") {
+      out.managers = valueFor(token, i);
+      i += 1;
+    } else if (token === "--desktop-cask") {
+      out.desktopCask = true;
+    } else if (token === "--mac-arm-url") {
+      out.macArmUrl = valueFor(token, i);
+      i += 1;
+    } else if (token === "--mac-arm-sha256") {
+      out.macArmSha256 = valueFor(token, i);
+      i += 1;
+    } else if (token === "--mac-x64-url") {
+      out.macX64Url = valueFor(token, i);
+      i += 1;
+    } else if (token === "--mac-x64-sha256") {
+      out.macX64Sha256 = valueFor(token, i);
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function requiredArg(args, name) {
+  if (typeof args[name] !== "string" || args[name].length === 0) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return args[name];
+}
+
+function readDescriptor(file) {
+  const raw = fs.readFileSync(file, "utf8");
+  const obj = JSON.parse(raw);
+  if (typeof obj.platformKey !== "string" || obj.descriptor === undefined) {
+    throw new Error(`Descriptor ${file} missing platformKey/descriptor`);
+  }
+  return obj;
+}
+
+function descriptorsByPlatform(descriptors) {
+  const out = {};
+  for (const d of descriptors) {
+    out[d.platformKey] = d.descriptor;
+  }
+  return out;
+}
+
+function requirePlatform(byPlatform, key) {
+  const d = byPlatform[key];
+  if (d === undefined) {
+    throw new Error(
+      `Missing descriptor for platform '${key}'; cannot render package-manager manifest`,
+    );
+  }
+  // A descriptor with `available: false` is legitimate per the fixture
+  // schema but has empty url/sha256/signatureUrl fields. Rendering one
+  // into a Homebrew/winget/Scoop/deb-rpm manifest would commit `url ""`
+  // / `sha256 ""` to the public tap. Fail loudly here so the publisher
+  // never produces a broken tap commit; release engineers must either
+  // republish the platform asset or drop the platform from the matrix.
+  if (d.available !== true) {
+    const reason =
+      typeof d.unavailableReason === "string" && d.unavailableReason.length > 0
+        ? d.unavailableReason
+        : "(no unavailableReason recorded)";
+    throw new Error(
+      `Descriptor for platform '${key}' is marked available=false (${reason}); cannot render package-manager manifest with an empty URL/sha256`,
+    );
+  }
+  return d;
+}
+
+function maybePlatform(byPlatform, key) {
+  const d = byPlatform[key];
+  if (d === undefined) return null;
+  // Treat available=false the same as a missing descriptor for optional
+  // platforms - the renderer's conditional `linuxBlock` / arm64 winget /
+  // arm64 scoop branches must omit the platform entirely rather than
+  // emit empty fields. The strict counterpart is requirePlatform.
+  if (d.available !== true) return null;
+  return d;
+}
+
+const DEFAULT_MANAGERS = ["homebrew", "winget", "scoop", "deb-rpm"];
+
+function selectedManagers(rawManagers) {
+  if (typeof rawManagers !== "string" || rawManagers.trim().length === 0) {
+    return new Set(DEFAULT_MANAGERS);
+  }
+  const selected = rawManagers
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (selected.length === 0) {
+    throw new Error("--managers must name at least one manager when supplied");
+  }
+  for (const manager of selected) {
+    if (!DEFAULT_MANAGERS.includes(manager)) {
+      throw new Error(
+        `Unknown package manager '${manager}'. Expected one of: ${DEFAULT_MANAGERS.join(", ")}`,
+      );
+    }
+  }
+  return new Set(selected);
+}
+
+// Homebrew formula - single ruby file that downloads the SEA binary
+// directly. Two-arch macOS support via on_macos/on_arm/on_intel; Linux
+// support is included so `brew install` works on Linuxbrew too.
+function renderHomebrewFormula({
+  version,
+  byPlatform,
+  homepage,
+  license,
+  releaseNotesUrl,
+}) {
+  const darwinArm = requirePlatform(byPlatform, "darwin-arm64");
+  const darwinX64 = requirePlatform(byPlatform, "darwin-x64");
+  const linuxArm = maybePlatform(byPlatform, "linux-arm64");
+  const linuxX64 = maybePlatform(byPlatform, "linux-x64");
+  const linuxBlock =
+    linuxArm !== null || linuxX64 !== null
+      ? `
+  on_linux do
+${
+  linuxArm !== null
+    ? `    on_arm do
+      url "${linuxArm.url}"
+      sha256 "${linuxArm.sha256}"
+    end
+`
+    : ""
+}${
+          linuxX64 !== null
+            ? `    on_intel do
+      url "${linuxX64.url}"
+      sha256 "${linuxX64.sha256}"
+    end
+`
+            : ""
+        }  end`
+      : "";
+  return `# Auto-generated by scripts/native-packaging/publish-cli-package-managers.cjs
+# Source: ${releaseNotesUrl}
+# Do not hand-edit - the next CLI release will overwrite this file.
+class Traycer < Formula
+  desc "Traycer CLI - host supervisor, auth, and config surface"
+  homepage "${homepage}"
+  version "${version}"
+  license "${license}"
+
+  on_macos do
+    on_arm do
+      url "${darwinArm.url}"
+      sha256 "${darwinArm.sha256}"
+    end
+    on_intel do
+      url "${darwinX64.url}"
+      sha256 "${darwinX64.sha256}"
+    end
+  end${linuxBlock}
+
+  def install
+    bin.install Dir["traycer*"].first => "traycer"
+    # Mark this install as homebrew-owned so 'traycer cli upgrade' guides
+    # the user to 'brew upgrade traycer' instead of self-replacing.
+    system bin/"traycer", "cli", "mark-source", "--source", "homebrew",
+           "--binary-path", bin/"traycer", "--installed-version", version
+  rescue
+    # 'mark-source' is best-effort: it writes the CLI install manifest if
+    # the user's home is writable. Brew install must not fail because of it.
+    nil
+  end
+
+  test do
+    # 'traycer --version' prints only a semver-shaped version string
+    # (no 'traycer' prefix). We pin two checks:
+    #   1. The reported value matches the released formula version
+    #      exactly. This catches release artifacts that were built
+    #      without TRAYCER_CLI_VERSION (which would otherwise report
+    #      the source-tree placeholder "0.0.0-local" or a stale
+    #      "0.0.0"); a generic /^\\d+\\.\\d+\\.\\d+/ shape match would
+    #      let those slip through.
+    #   2. As defence in depth, reject the literal placeholders so a
+    #      future formula refactor that loosens (1) still cannot ship a
+    #      placeholder build.
+    reported = shell_output("#{bin}/traycer --version").strip
+    assert_equal version.to_s, reported
+    refute_match(/\\A0\\.0\\.0(?:-local)?\\z/, reported)
+  end
+end
+`;
+}
+
+function renderHomebrewCask({ version, homepage, macArm, macX64 }) {
+  return `# Auto-generated by scripts/native-packaging/publish-cli-package-managers.cjs
+# Do not hand-edit - the next Desktop release will overwrite this file.
+cask "traycer-desktop" do
+  arch arm: "arm64", intel: "x64"
+
+  version "${version}"
+
+  on_arm do
+    sha256 "${macArm.sha256}"
+    url "${macArm.url}"
+  end
+
+  on_intel do
+    sha256 "${macX64.sha256}"
+    url "${macX64.url}"
+  end
+
+  name "Traycer"
+  desc "Traycer desktop app"
+  homepage "${homepage}"
+
+  auto_updates true
+  depends_on macos: ">= :monterey"
+
+  app "Traycer.app"
+end
+`;
+}
+
+// winget manifest - three YAML files per package version (version,
+// installer, locale). The installer file pins the platform-specific
+// sha256 + URL so winget's downloader verifies the bytes before
+// running the SEA executable as a portable.
+function renderWingetManifests({
+  version,
+  byPlatform,
+  homepage,
+  license,
+  releaseNotesUrl,
+}) {
+  const winX64 = requirePlatform(byPlatform, "win32-x64");
+  const winArm = maybePlatform(byPlatform, "win32-arm64");
+  const installers = [
+    {
+      Architecture: "x64",
+      InstallerType: "portable",
+      InstallerUrl: winX64.url,
+      InstallerSha256: winX64.sha256.toUpperCase(),
+    },
+  ];
+  if (winArm !== null) {
+    installers.push({
+      Architecture: "arm64",
+      InstallerType: "portable",
+      InstallerUrl: winArm.url,
+      InstallerSha256: winArm.sha256.toUpperCase(),
+    });
+  }
+
+  const versionYaml = `PackageIdentifier: Traycer.CLI
+PackageVersion: ${version}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0
+`;
+  const installerYaml = `PackageIdentifier: Traycer.CLI
+PackageVersion: ${version}
+MinimumOSVersion: 10.0.0.0
+InstallModes:
+  - silent
+Commands:
+  - traycer
+ReleaseDate: ${new Date().toISOString().slice(0, 10)}
+Installers:
+${installers
+  .map(
+    (i) =>
+      `  - Architecture: ${i.Architecture}
+    InstallerType: ${i.InstallerType}
+    InstallerUrl: ${i.InstallerUrl}
+    InstallerSha256: ${i.InstallerSha256}`,
+  )
+  .join("\n")}
+ManifestType: installer
+ManifestVersion: 1.6.0
+`;
+  const localeYaml = `PackageIdentifier: Traycer.CLI
+PackageVersion: ${version}
+PackageLocale: en-US
+Publisher: Traycer
+PublisherUrl: ${homepage}
+PackageName: Traycer CLI
+PackageUrl: ${homepage}
+License: ${license}
+ShortDescription: Traycer CLI - host supervisor, auth, and config surface
+ReleaseNotesUrl: ${releaseNotesUrl}
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0
+`;
+  return {
+    "Traycer.CLI.yaml": versionYaml,
+    "Traycer.CLI.installer.yaml": installerYaml,
+    "Traycer.CLI.locale.en-US.yaml": localeYaml,
+  };
+}
+
+// Scoop manifest - single JSON describing per-arch SEA binaries.
+//
+// Per-architecture `bin` uses the `[[source, alias]]` form so the
+// downloaded asset (`traycer-cli-windows-x64.exe` /
+// `traycer-cli-windows-arm64.exe`)
+// is exposed on PATH as `traycer.exe` (and as the alias `traycer`).
+// Without the alias mapping `scoop install` would shim the long
+// asset name and `traycer ...` would not resolve from the user's
+// shell.
+function renderScoopManifest({
+  version,
+  byPlatform,
+  homepage,
+  license,
+  releaseNotesUrl,
+  releaseRepo,
+}) {
+  const winX64 = requirePlatform(byPlatform, "win32-x64");
+  const winArm = maybePlatform(byPlatform, "win32-arm64");
+  const x64AssetName = basenameFromUrl(winX64.url);
+  const architecture = {
+    "64bit": {
+      url: winX64.url,
+      hash: winX64.sha256,
+      bin: [[x64AssetName, "traycer"]],
+    },
+  };
+  if (winArm !== null) {
+    const armAssetName = basenameFromUrl(winArm.url);
+    architecture.arm64 = {
+      url: winArm.url,
+      hash: winArm.sha256,
+      bin: [[armAssetName, "traycer"]],
+    };
+  }
+  const manifest = {
+    version,
+    description: "Traycer CLI - host supervisor, auth, and config surface",
+    homepage,
+    license,
+    architecture,
+    notes: `Release notes: ${releaseNotesUrl}`,
+    post_install: [
+      // Locate the alias shim Scoop created from the [[source, alias]]
+      // mapping above. Falls back to the raw asset if a future Scoop
+      // version stops generating the alias.
+      "$traycerExe = Join-Path $dir 'traycer.exe'",
+      "if (-not (Test-Path $traycerExe)) {",
+      "  $candidate = Get-ChildItem -Path $dir -Filter 'traycer-cli-windows-*.exe' | Select-Object -First 1",
+      "  if ($candidate) { $traycerExe = $candidate.FullName }",
+      "}",
+      // Scoop install runs `post_install` synchronously and blocks the
+      // user's shell prompt until every entry returns. `& $traycer ...`
+      // therefore stretches install time by however long `mark-source`
+      // takes. Start the helper detached (`-Wait:$false`) and hide its
+      // window so the source-attribution write is best-effort and never
+      // visible to the user - errors are still silenced with `2>$null`.
+      "Start-Process -FilePath $traycerExe -ArgumentList @('cli','mark-source','--source','scoop','--binary-path',$traycerExe,'--installed-version',$version) -NoNewWindow -Wait:$false 2>$null",
+    ],
+    // checkver reads `latest` from the rolling `cli-manifest` GitHub
+    // Release asset on RELEASE_REPO (the same versions.json the CLI
+    // self-update consumes); autoupdate templates the per-arch asset
+    // URLs on the cli-v<version> Release.
+    checkver: {
+      url: `https://github.com/${releaseRepo}/releases/download/cli-manifest/versions.json`,
+      jsonpath: "$.latest",
+    },
+    autoupdate: {
+      architecture: {
+        "64bit": {
+          url: `https://github.com/${releaseRepo}/releases/download/cli-v$version/traycer-cli-windows-x64.exe`,
+        },
+        arm64: {
+          url: `https://github.com/${releaseRepo}/releases/download/cli-v$version/traycer-cli-windows-arm64.exe`,
+        },
+      },
+    },
+  };
+  return manifest;
+}
+
+function basenameFromUrl(urlString) {
+  try {
+    const parsed = new URL(urlString);
+    const segments = parsed.pathname.split("/");
+    const last = segments[segments.length - 1];
+    if (typeof last === "string" && last.length > 0) return last;
+  } catch {
+    // fall through
+  }
+  // Defensive default - keeps `bin` valid even if URL parsing fails.
+  return "traycer.exe";
+}
+
+// Per-package postRemove script. Only removes the marker for the
+// package being uninstalled (`apt` for .deb, `rpm` for .rpm) so the
+// other package manager's marker - if a user has both installed - is
+// left intact. Only `rmdir /var/lib/traycer` if the directory is now
+// empty (other markers might still be present).
+function renderPostRemoveScript(pkgKind) {
+  if (pkgKind !== "deb" && pkgKind !== "rpm") {
+    throw new Error(`renderPostRemoveScript: invalid pkgKind '${pkgKind}'`);
+  }
+  const markerSuffix = pkgKind === "deb" ? "apt" : "rpm";
+  return [
+    "#!/bin/sh",
+    `rm -f /var/lib/traycer/source.${markerSuffix}`,
+    '[ -z "$(ls -A /var/lib/traycer 2>/dev/null)" ] && rmdir /var/lib/traycer 2>/dev/null || true',
+    "exit 0",
+  ].join("\n");
+}
+
+// Debian/RPM metadata - package-manager-agnostic JSON consumed by our
+// apt/rpm repo build pipeline. The pipeline downloads the binary,
+// builds a .deb / .rpm with post-install hooks that call
+// `traycer cli mark-source --source apt|rpm` and removes only the
+// installed binary on uninstall (post-remove does NOT touch ~/.traycer
+// or the host install directory).
+function renderDebRpmMetadata({
+  version,
+  byPlatform,
+  homepage,
+  license,
+  releaseNotesUrl,
+}) {
+  const linuxArm = maybePlatform(byPlatform, "linux-arm64");
+  const linuxX64 = requirePlatform(byPlatform, "linux-x64");
+  const architectures = {
+    amd64: {
+      url: linuxX64.url,
+      sha256: linuxX64.sha256,
+      signatureUrl: linuxX64.signatureUrl,
+    },
+  };
+  if (linuxArm !== null) {
+    architectures.arm64 = {
+      url: linuxArm.url,
+      sha256: linuxArm.sha256,
+      signatureUrl: linuxArm.signatureUrl,
+    };
+  }
+  return {
+    name: "traycer-cli",
+    version,
+    description: "Traycer CLI - host supervisor, auth, and config surface",
+    homepage,
+    license,
+    releaseNotesUrl,
+    architectures,
+    postInstall: {
+      // Write a system-wide install-source marker that any subsequent
+      // `traycer cli upgrade` invocation reads (see
+      // traycer-clients/traycer-cli/src/manifest/cli-manifest.ts ::
+      // readSystemSourceMarker). The marker is preferred over the
+      // legacy `cli mark-source` invocation because it works for
+      // unattended installs where SUDO_USER is unset and for
+      // multi-user systems where no single $HOME is "the user".
+      script: [
+        "#!/bin/sh",
+        "set -e",
+        "SRC=${PKG_SOURCE:-apt}",
+        "install -d -m 0755 /var/lib/traycer",
+        'printf \'{"source":"%s","binaryPath":"/usr/bin/traycer","version":"' +
+          version +
+          '"}\\n\' "$SRC" > /var/lib/traycer/source.${SRC}',
+        "chmod 0644 /var/lib/traycer/source.${SRC}",
+        "exit 0",
+      ].join("\n"),
+    },
+    // Pre-remove must NEVER touch ~/.traycer/, the host install dir,
+    // or the OS service registration. Package-manager uninstall removes
+    // ONLY the CLI binary (handled implicitly by dpkg/rpm). The script
+    // is a no-op placeholder so the build pipeline can include the hook
+    // file without conditional logic.
+    preRemove: {
+      script: ["#!/bin/sh", "exit 0"].join("\n"),
+    },
+    postRemove: {
+      // Clean up only the system-wide install-source marker for the
+      // package being uninstalled (deb or rpm) so a subsequent
+      // re-install through the same package manager cleanly re-records
+      // it, and a coexisting install through the *other* manager keeps
+      // its marker untouched. Never touches ~/.traycer/, host install
+      // dir, or service registration. The build pipeline reads the
+      // per-kind variant matching the artifact it's emitting.
+      deb: { script: renderPostRemoveScript("deb") },
+      rpm: { script: renderPostRemoveScript("rpm") },
+    },
+  };
+}
+
+function sha256OfString(s) {
+  return crypto.createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+function writeFile(target, content) {
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const version = requiredArg(args, "version");
+  const staging = requiredArg(args, "staging");
+  // RELEASE_REPO coordinate (the OSS distribution surface). Drives both
+  // the auto-generated release-notes links and the GitHub-Releases-hosted
+  // scoop checkver/autoupdate URLs. Override per-invocation via
+  // `--release-repo`; defaults to the public mirror.
+  const releaseRepo = args.releaseRepo || DEFAULT_RELEASE_NOTES_REPO;
+  const releaseNotesUrl =
+    args.releaseNotesUrl ||
+    `https://github.com/${releaseRepo}/releases/tag/cli-v${version}`;
+  const homepage = args.homepage || "https://traycer.ai";
+  const license = args.license || "Apache-2.0";
+  if (args.desktopCask === true) {
+    const macArm = {
+      url: requiredArg(args, "macArmUrl"),
+      sha256: requiredArg(args, "macArmSha256"),
+    };
+    const macX64 = {
+      url: requiredArg(args, "macX64Url"),
+      sha256: requiredArg(args, "macX64Sha256"),
+    };
+    const cask = renderHomebrewCask({ version, homepage, macArm, macX64 });
+    const caskPath = path.join(
+      staging,
+      "homebrew",
+      "Casks",
+      "traycer-desktop.rb",
+    );
+    writeFile(caskPath, cask);
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          version,
+          written: [
+            {
+              manager: "homebrew-cask",
+              path: caskPath,
+              sha256: sha256OfString(cask),
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return;
+  }
+  const managers = selectedManagers(args.managers);
+  const descriptors = (args.descriptors || []).map(readDescriptor);
+  if (descriptors.length === 0) {
+    throw new Error("At least one --descriptor must be supplied");
+  }
+  const byPlatform = descriptorsByPlatform(descriptors);
+  fs.mkdirSync(staging, { recursive: true });
+
+  const summary = { version, written: [] };
+
+  // ----- Homebrew -----
+  if (managers.has("homebrew")) {
+    const formula = renderHomebrewFormula({
+      version,
+      byPlatform,
+      homepage,
+      license,
+      releaseNotesUrl,
+    });
+    const formulaPath = path.join(staging, "homebrew", "Formula", "traycer.rb");
+    writeFile(formulaPath, formula);
+    summary.written.push({
+      manager: "homebrew",
+      path: formulaPath,
+      sha256: sha256OfString(formula),
+    });
+  }
+
+  // ----- winget -----
+  if (managers.has("winget")) {
+    const wingetFiles = renderWingetManifests({
+      version,
+      byPlatform,
+      homepage,
+      license,
+      releaseNotesUrl,
+    });
+    const wingetDir = path.join(
+      staging,
+      "winget",
+      "manifests",
+      "t",
+      "Traycer",
+      "CLI",
+      version,
+    );
+    for (const [name, content] of Object.entries(wingetFiles)) {
+      const p = path.join(wingetDir, name);
+      writeFile(p, content);
+      summary.written.push({
+        manager: "winget",
+        path: p,
+        sha256: sha256OfString(content),
+      });
+    }
+  }
+
+  // ----- scoop -----
+  if (managers.has("scoop")) {
+    const scoop = renderScoopManifest({
+      version,
+      byPlatform,
+      homepage,
+      license,
+      releaseNotesUrl,
+      releaseRepo,
+    });
+    const scoopPath = path.join(staging, "scoop", "bucket", "traycer-cli.json");
+    const scoopContent = `${JSON.stringify(scoop, null, 2)}\n`;
+    writeFile(scoopPath, scoopContent);
+    summary.written.push({
+      manager: "scoop",
+      path: scoopPath,
+      sha256: sha256OfString(scoopContent),
+    });
+  }
+
+  // ----- deb + rpm metadata -----
+  if (managers.has("deb-rpm")) {
+    const debRpm = renderDebRpmMetadata({
+      version,
+      byPlatform,
+      homepage,
+      license,
+      releaseNotesUrl,
+    });
+    const debRpmPath = path.join(
+      staging,
+      "deb-rpm",
+      "versions",
+      `${version}.json`,
+    );
+    const debRpmContent = `${JSON.stringify(debRpm, null, 2)}\n`;
+    writeFile(debRpmPath, debRpmContent);
+    summary.written.push({
+      manager: "deb-rpm",
+      path: debRpmPath,
+      sha256: sha256OfString(debRpmContent),
+    });
+  }
+
+  // ----- CLI versions.json (used by scoop's checkver + Desktop probe) -----
+  const cliVersions = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    latest: version,
+    version,
+    platforms: byPlatform,
+    releaseNotesUrl,
+  };
+  const cliVersionsPath = path.join(staging, "cli", "versions.json");
+  const cliVersionsContent = `${JSON.stringify(cliVersions, null, 2)}\n`;
+  writeFile(cliVersionsPath, cliVersionsContent);
+  summary.written.push({
+    manager: "cli-versions",
+    path: cliVersionsPath,
+    sha256: sha256OfString(cliVersionsContent),
+  });
+
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(
+    `[publish-cli-package-managers] ${err && err.message ? err.message : err}\n`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
Adds two workflows that publish the CLI to external package managers, plus the render script they need.

## What
- **`publish-cli-package-managers.yml`** — publishes `@traycerai/cli` to npm **with provenance** and opens a Homebrew **formula** PR against the tap.
- **`publish-desktop-cask.yml`** — opens a Homebrew **cask** PR against the tap.
- **`scripts/native-packaging/publish-cli-package-managers.cjs`** — render script (formula/cask/versions), previously only in the build repo.

## Triggers
- `on: release: [released]` — fires only for stable releases (`released` never fires for prereleases, so RC tags are excluded). Each workflow guards on its tag prefix (`cli-v*` / `desktop-v*`).
- `workflow_dispatch` with a `tag` input for manual re-runs.

## Why here (public repo)
npm `--provenance` is only accepted when the publishing workflow runs in a **public** source repo. Publishing from the private build repo fails with `E422 (Unsupported ... visibility: "private")`. Building here lets the package carry a verifiable SLSA provenance attestation. The CLI source is checked out at the exact commit recorded in the release's `release-provenance.json` (`ossRef`).

## Setup required before first run
- `release` environment with required reviewers (gates the npm publish).
- Secrets: `NPM_TOKEN`, `TRAYCER_HOMEBREW_TAP_REPO`, `TRAYCER_TAP_PUSH_TOKEN`, `TRAYCER_CLI_SENTRY_DSN`.
- The tap PAT needs Pull-requests: write (Homebrew is published via PR, merged by a human).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated publishing for CLI releases to package managers, including npm and Homebrew.
  * Added Homebrew cask publishing for the desktop app with release asset verification and PR updates.
  * Expanded release automation to generate package metadata for multiple distribution channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->