### PR TITLE
Use npm trusted publishing for CLI

### DIFF
--- a/.github/workflows/publish-cli-package-managers.yml
+++ b/.github/workflows/publish-cli-package-managers.yml
@@ -15,8 +15,8 @@ name: publish-cli-package-managers
 #
 # Homebrew is published via a PULL REQUEST against the tap's protected main
 # branch; merging that PR is the human gate before the formula goes live. npm
-# publishes directly (no review gate) - gate it with the `release` environment's
-# required reviewers and a scoped, expiring NPM_TOKEN.
+# publishes directly through npm Trusted Publishing (GitHub OIDC) - gate it with
+# the `release` environment's required reviewers instead of a long-lived token.
 
 on:
   release:
@@ -152,16 +152,11 @@ jobs:
     steps:
       - name: Determine publish mode
         id: gate
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             echo "mode=dry-run" >> "$GITHUB_OUTPUT"
-          elif [ -z "$NPM_TOKEN" ]; then
-            echo "::error::NPM_TOKEN is unset; cannot publish to npm. Set the secret or run with dry_run=true."
-            exit 1
           else
             echo "mode=publish" >> "$GITHUB_OUTPUT"
           fi
@@ -179,7 +174,6 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24.15.0"
-          registry-url: "https://registry.npmjs.org"
       - name: Install workspace dependencies
         run: bun install --frozen-lockfile
       - name: Stamp CLI production deploy target
@@ -198,12 +192,10 @@ jobs:
       - name: Skip existing npm version
         if: steps.gate.outputs.mode == 'publish'
         id: existing
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          if npm view "@traycerai/cli@${VERSION}" version >/dev/null 2>&1; then
+          if npm view "@traycerai/cli@${VERSION}" version --registry "https://registry.npmjs.org" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "@traycerai/cli@${VERSION} already exists; skipping publish."
           else
@@ -211,12 +203,10 @@ jobs:
           fi
       - name: Publish npm package (with provenance)
         if: steps.gate.outputs.mode == 'publish' && steps.existing.outputs.exists != 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish clients/traycer-cli/dist-npm --provenance --access public --tag "$DIST_TAG"
+        run: npm publish clients/traycer-cli/dist-npm --provenance --access public --tag "$DIST_TAG" --registry "https://registry.npmjs.org"
       - name: npm dry run
         if: steps.gate.outputs.mode == 'dry-run'
-        run: npm publish clients/traycer-cli/dist-npm --access public --tag "$DIST_TAG" --dry-run
+        run: npm publish clients/traycer-cli/dist-npm --access public --tag "$DIST_TAG" --registry "https://registry.npmjs.org" --dry-run
 
   publish-homebrew-formula:
     name: Open Homebrew formula PR

--- a/clients/traycer-cli/README.md
+++ b/clients/traycer-cli/README.md
@@ -1,0 +1,131 @@
+# @traycerai/cli
+
+The npm distribution of the Traycer command line tool.
+
+Traycer Desktop already includes the CLI and runs it behind the scenes, so most people do not need to install this package directly. Install `@traycerai/cli` when you want to manage the local Traycer Host from a terminal, script Traycer workflows, or use the agent/workspace automation surface outside the desktop app.
+
+The npm package is a fully bundled JavaScript build with no runtime npm dependencies. It runs on Node.js 20.18.0 or newer.
+
+## Installation
+
+```sh
+npm install -g @traycerai/cli
+```
+
+You can also run it without a global install:
+
+```sh
+npx @traycerai/cli --help
+```
+
+For the full desktop app, install Traycer from [traycer.ai/download](https://traycer.ai/download).
+
+## Quick Start
+
+```sh
+traycer login
+traycer host ensure
+traycer host status
+```
+
+`traycer login` starts the browser-based sign-in flow. `traycer host ensure` installs the host version supported by this CLI, registers it with the operating system service manager when needed, and starts it. `traycer host status` confirms the local host process and endpoint.
+
+## What It Does
+
+- **Host lifecycle:** download, verify, install, start, stop, update, and supervise the local Traycer Host.
+- **Authentication:** sign in with OAuth PKCE and share credentials with Traycer Desktop.
+- **Diagnostics:** inspect host status, logs, service registration, and setup problems.
+- **Configuration:** manage shell selection and environment overrides used by host and agent sessions.
+- **Workspaces:** list Traycer workspaces and create isolated Git worktrees.
+- **Agent automation:** list, create, message, and inspect agents from Traycer-managed sessions.
+
+## Common Commands
+
+| Command                        | Purpose                                                                |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `traycer login`                | Sign in to Traycer.                                                    |
+| `traycer logout`               | Remove locally stored credentials.                                     |
+| `traycer whoami`               | Show the signed-in user.                                               |
+| `traycer host ensure`          | Install, register, and start the local Traycer Host if needed.         |
+| `traycer host status`          | Show host process, endpoint, and activity status.                      |
+| `traycer host doctor`          | Diagnose host installation and runtime issues.                         |
+| `traycer host logs --tail 200` | Print recent host logs.                                                |
+| `traycer host update`          | Update the installed host to the latest compatible release.            |
+| `traycer host available`       | List host versions available for this environment.                     |
+| `traycer cli upgrade`          | Upgrade the installed CLI binary when supported by the install source. |
+| `traycer config shell get`     | Show the shell used for host bootstrap and terminal tabs.              |
+| `traycer config env list`      | Show environment overrides used by Traycer.                            |
+
+Use `--help` on any command group for the full local reference:
+
+```sh
+traycer --help
+traycer host --help
+traycer agent --help
+```
+
+## Scripting
+
+```sh
+traycer host status --json
+```
+
+Most commands support `--json`, which emits structured NDJSON events suitable for automation. The CLI also supports `--quiet` and `--no-progress` for logs, and honors non-interactive environments such as CI.
+
+## Agent and Workspace Commands
+
+Traycer-launched agent sessions receive environment variables such as `TRAYCER_AGENT_ID` and `TRAYCER_EPIC_ID`. In that context, the CLI can inspect the current epic, communicate with other agents, and create worktrees:
+
+```sh
+traycer agent list
+traycer agent inbox
+traycer agent send --to <agent-id> --message "Can you review this change?"
+traycer workspace list
+traycer worktree create --workspace /path/to/repo --branch my-feature
+```
+
+These commands are mainly intended for Traycer-managed automation, but they are regular CLI commands and can be scripted when the host is running and the required IDs are supplied.
+
+## Host Security
+
+The npm package ships the CLI bundle only. The Traycer Host is a separate signed binary distributed through GitHub Releases. Before installation, host archives are verified by checksum and minisign signature against the trust root embedded in the CLI.
+
+On supported platforms, the CLI supervises the host through the operating system service manager, including launchd on macOS and systemd user services on Linux.
+
+## Authentication and Local Files
+
+Sign-in uses OAuth with PKCE on a local loopback callback. Credentials and CLI state are stored under your Traycer home directory, including shared auth state used by Traycer Desktop.
+
+Provider API keys are not configured through this CLI. Configure providers in Traycer Desktop under Settings > Providers.
+
+## Troubleshooting
+
+Start with:
+
+```sh
+traycer host doctor
+traycer host logs --tail 200
+```
+
+If the host is missing or stopped, run:
+
+```sh
+traycer host ensure
+```
+
+If the service is registered but not responding, restart it:
+
+```sh
+traycer host restart
+```
+
+## Links
+
+- Documentation: [docs.traycer.ai](https://docs.traycer.ai)
+- Desktop app: [traycer.ai/download](https://traycer.ai/download)
+- Source code: [github.com/traycerai/traycer](https://github.com/traycerai/traycer)
+- CLI 1.0.0 release notes: [github.com/traycerai/traycer/releases/tag/cli-v1.0.0](https://github.com/traycerai/traycer/releases/tag/cli-v1.0.0)
+
+## License
+
+Apache-2.0. See the repository [LICENSE](https://github.com/traycerai/traycer/blob/main/LICENSE).


### PR DESCRIPTION
## Summary
- switch the CLI npm publish workflow from `NPM_TOKEN` auth to npm Trusted Publishing via GitHub OIDC
- add a package README for `@traycerai/cli` so npm publishes useful package documentation
- keep npm provenance publishing enabled and verify the README is included in the generated package

## Verification
- `bun run --cwd clients/traycer-cli build`
- `npm pack clients/traycer-cli/dist-npm --dry-run --json`
- `bunx prettier --check .github/workflows/publish-cli-package-managers.yml clients/traycer-cli/README.md`
- `git diff --check`
- pre-commit hooks during `git commit -s`
