### PR TITLE
fix(gui-app): surface the host's model-load error message

### DIFF
--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
@@ -67,7 +67,17 @@ export function ModelRowsState(props: ModelRowsStateProps): ReactNode | null {
   }
 
   if (activeProvider !== null && activeProvider.modelsError !== null) {
-    return <PickerStateRow label="Couldn't load models" icon={undefined} />;
+    // Surface the host's specific reason - the cursor adapter classifies a
+    // rejected key ("Cursor rejected the API key…") or an un-shipped SDK
+    // ("Cursor isn't available in this host build…") into clear copy - instead
+    // of a generic catch-all. Fall back when the message is empty.
+    const reason = activeProvider.modelsError.message.trim();
+    return (
+      <PickerStateRow
+        label={reason.length > 0 ? reason : "Couldn't load models"}
+        icon={undefined}
+      />
+    );
   }
 
   if (rowsCount === 0) {


### PR DESCRIPTION
## What

The model picker rendered a hardcoded **"Couldn't load models"** whenever a provider's model fetch failed, discarding the `HostRpcError.message` the host already provides. This renders `modelsError.message` (with a fallback when empty) so the host's classified reason reaches the user — e.g. _"Cursor rejected the API key. Verify it in Settings → Providers."_ or _"Cursor isn't available in this Traycer host build."_

## Context

This is the renderer half of the Cursor "Couldn't load models" fix. The substantive host-side fix — which ships `@cursor/sdk` with the host so model listing works at all, and classifies the failures this PR surfaces — is in traycerai/traycer-internal#4087.

Fixes #55
