### PR TITLE
fix(desktop): keep the staging slot off the production host and CLI

### DIFF
--- a/clients/desktop/src/electron-main/cli/__tests__/resolve-cli-invocation-staging.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/resolve-cli-invocation-staging.test.ts
@@ -1,0 +1,182 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Internal-only `staging` deploy slot. Like dev, staging is a NON-production
+// build, but unlike dev it is NOT `isDevBuild`. CLI discovery must still skip
+// the PATH lookup for it: a developer's machine routinely has a released/prod
+// `traycer` on PATH (Homebrew, `~/.traycer/cli/bin` symlinked into the prod
+// `Traycer.app`), and adopting it would drive the staging app's `host
+// ensure`/`host start` through a PRODUCTION CLI - onto the prod host slot
+// (`ai.traycer.host`) and prod cloud, leaving the staging splash stuck on
+// "Starting local Traycer Host...". PATH trust is production-only; every other
+// slot uses its bundled/slot CLI. These tests pin that contract.
+
+let work: string;
+let homeDir: string;
+let resourcesDir: string;
+
+function bundledCliBinaryName(): string {
+  return process.platform === "win32" ? "traycer.exe" : "traycer";
+}
+
+function writeExecutable(path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, "#!/bin/sh\nexit 0\n");
+  if (process.platform !== "win32") chmodSync(path, 0o755);
+}
+
+function stageBundledArchCli(): string {
+  const p = join(
+    resourcesDir,
+    "cli",
+    `${process.platform}-${process.arch}`,
+    bundledCliBinaryName(),
+  );
+  writeExecutable(p);
+  return p;
+}
+
+function writeManifestAt(manifestPath: string, binaryPath: string): void {
+  mkdirSync(dirname(manifestPath), { recursive: true });
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      version: "0.0.0",
+      installedAt: new Date().toISOString(),
+      binaryPath,
+      source: "desktop",
+      pendingUpgrade: null,
+    }),
+    "utf8",
+  );
+}
+
+vi.mock("electron-log", () => ({
+  default: {
+    transports: {
+      file: { level: "info" },
+      console: { level: "info" },
+    },
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    getAppPath: (): string => "/tmp/desktop-app",
+  },
+}));
+
+// Pin the staging slot: non-dev (so discovery reaches the PATH section) but
+// non-production (so the PATH section must be skipped). The env-scoped CLI home
+// resolves to `~/.traycer/cli/staging`.
+vi.mock("../../../config", async (importActual) => {
+  const actual = await importActual<typeof import("../../../config")>();
+  return {
+    ...actual,
+    isDevBuild: false,
+    config: { ...actual.config, environment: "staging" },
+  };
+});
+
+const ORIGINAL_PATH = process.env.PATH;
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+
+beforeEach(() => {
+  work = mkdtempSync(join(tmpdir(), "traycer-cli-discovery-staging-"));
+  homeDir = join(work, "home");
+  resourcesDir = join(work, "resources");
+  mkdirSync(homeDir, { recursive: true });
+  mkdirSync(resourcesDir, { recursive: true });
+  process.env.HOME = homeDir;
+  if (process.platform === "win32") {
+    process.env.USERPROFILE = homeDir;
+  }
+  Object.defineProperty(process, "resourcesPath", {
+    value: resourcesDir,
+    configurable: true,
+  });
+  vi.resetModules();
+});
+
+afterEach(() => {
+  rmSync(work, { recursive: true, force: true });
+  vi.resetModules();
+  if (ORIGINAL_PATH === undefined) {
+    delete process.env.PATH;
+  } else {
+    process.env.PATH = ORIGINAL_PATH;
+  }
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+  if (ORIGINAL_USERPROFILE === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  }
+});
+
+describe("resolveTraycerCliInvocation (staging slot) - env-scoped resolution", () => {
+  it("skips a `traycer` on PATH and uses the bundled Staging.app CLI (a prod CLI on PATH must not hijack the staging slot)", async () => {
+    // Simulate the user's released/prod CLI on PATH (Homebrew / the
+    // `~/.traycer/cli/bin` symlink into the production Traycer.app).
+    const fakePathBin = join(work, "fake-prod-cli-bin", bundledCliBinaryName());
+    writeExecutable(fakePathBin);
+    process.env.PATH = dirname(fakePathBin);
+
+    // The Staging.app bundles its own arch-scoped CLI under resources/cli/.
+    const bundled = stageBundledArchCli();
+
+    const { resolveTraycerCliInvocation } = await import("../traycer-cli");
+    const inv = await resolveTraycerCliInvocation();
+    expect(inv.command).toBe(bundled);
+    expect(inv.command).not.toBe(fakePathBin);
+  });
+
+  it("reads the staging-slot manifest, never the prod slot's", async () => {
+    // A leftover prod install wrote `~/.traycer/cli/manifest.json`; the staging
+    // slot must read `~/.traycer/cli/staging/manifest.json` instead.
+    const prodBin = join(
+      homeDir,
+      ".traycer",
+      "cli",
+      "bin",
+      bundledCliBinaryName(),
+    );
+    writeExecutable(prodBin);
+    writeManifestAt(join(homeDir, ".traycer", "cli", "manifest.json"), prodBin);
+
+    const stagingBin = join(
+      homeDir,
+      ".traycer",
+      "cli",
+      "staging",
+      "bin",
+      bundledCliBinaryName(),
+    );
+    writeExecutable(stagingBin);
+    writeManifestAt(
+      join(homeDir, ".traycer", "cli", "staging", "manifest.json"),
+      stagingBin,
+    );
+
+    const { resolveTraycerCliInvocation } = await import("../traycer-cli");
+    const inv = await resolveTraycerCliInvocation();
+    expect(inv.command).toBe(stagingBin);
+  });
+});

--- a/clients/desktop/src/electron-main/cli/cli-discovery.ts
+++ b/clients/desktop/src/electron-main/cli/cli-discovery.ts
@@ -521,16 +521,25 @@ export async function discoverCli(): Promise<CliDiscoveryResult> {
     }
     return { kind: "none" };
   }
-  const pathCli = await findCliOnPath();
-  if (pathCli !== null) {
-    const source = await inferNpmPathSource(pathCli);
-    const version = source === "npm" ? await probeCliVersion(pathCli) : null;
-    return {
-      kind: "path",
-      binaryPath: pathCli,
-      version,
-      ...(source !== undefined ? { source } : {}),
-    };
+  // PATH trust is production-only. A `traycer` on PATH carries its OWN baked
+  // deploy slot (`config.environment`), so adopting a PATH binary for a
+  // non-production build lets a released/prod CLI on the user's PATH (Homebrew,
+  // `~/.traycer/cli/bin`) hijack a staging install onto the PRODUCTION host slot
+  // (prod cloud, `~/.traycer/host/install`, `ai.traycer.host`). Non-production
+  // non-dev slots (e.g. internal `staging`) use their bundled/slot CLI - the
+  // same reason the dev slot skips PATH above.
+  if (config.environment === "production") {
+    const pathCli = await findCliOnPath();
+    if (pathCli !== null) {
+      const source = await inferNpmPathSource(pathCli);
+      const version = source === "npm" ? await probeCliVersion(pathCli) : null;
+      return {
+        kind: "path",
+        binaryPath: pathCli,
+        version,
+        ...(source !== undefined ? { source } : {}),
+      };
+    }
   }
   const bundled = await resolveBundledCliPath();
   if (bundled !== null) {

--- a/clients/desktop/src/electron-main/host/__tests__/host-paths.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-paths.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { getHostFsLayout } from "../host-paths";
+import { getHostFsLayout, labelForEnvironment } from "../host-paths";
 
 /**
  * Pin the cross-workspace contract: the desktop runner MUST look for the
@@ -73,5 +73,34 @@ describe("getHostFsLayout", () => {
     expect(layout.installRecordFile).toBe(
       join(homedir(), ".traycer", "host", "dev", "install", "install.json"),
     );
+  });
+});
+
+/**
+ * The service label namespaces the host's LaunchAgent / SMAppService
+ * registration per slot. It MUST agree with the in-bundle plist the installer
+ * ships (`scripts/desktop-install-cloud.js` `hostAgentLabel`) and the CLI's
+ * `serviceLabelFor`: production keeps the bare `ai.traycer.host`; every other
+ * slot nests under its own name. A dev-only fallback that mapped internal
+ * `staging` builds onto `ai.traycer.host.dev` broke staging host bring-up.
+ */
+describe("labelForEnvironment", () => {
+  it("keeps the bare ai.traycer.host id for production", () => {
+    const label = labelForEnvironment("production");
+    expect(label.id).toBe("ai.traycer.host");
+    expect(label.appSupportDirName).toBe("Traycer");
+  });
+
+  it("nests the dev slot under ai.traycer.host.dev", () => {
+    const label = labelForEnvironment("dev");
+    expect(label.id).toBe("ai.traycer.host.dev");
+    expect(label.appSupportDirName).toBe("Traycer-Dev");
+  });
+
+  it("gives the internal staging slot its OWN ai.traycer.host.staging id (never the dev slot's)", () => {
+    const label = labelForEnvironment("staging");
+    expect(label.id).toBe("ai.traycer.host.staging");
+    expect(label.displayName).toBe("Traycer Host (Staging)");
+    expect(label.appSupportDirName).toBe("Traycer-Staging");
   });
 });

--- a/clients/desktop/src/electron-main/host/host-paths.ts
+++ b/clients/desktop/src/electron-main/host/host-paths.ts
@@ -32,10 +32,27 @@ export const DEV_LABEL: ServiceLabel = {
   appSupportDirName: "Traycer-Dev",
 };
 
-// The label for an environment/slot. Mirrors the CLI's `serviceLabelFor`.
+// The label for an environment/slot. Mirrors the CLI's `serviceLabelFor`:
+// production keeps the bare `ai.traycer.host`; every other slot nests under its
+// own name (`ai.traycer.host.<environment>`) so a staging/dev install owns an
+// isolated LaunchAgent + app-support dir and never collides with prod. A
+// hardcoded dev-only fallback silently mapped internal `staging` builds onto the
+// dev slot (`ai.traycer.host.dev`), mismatching the `ai.traycer.host.staging`
+// plist the installer ships - derive from `environment` so new slots can't drift.
 export function labelForEnvironment(environment: Environment): ServiceLabel {
   if (environment === "production") return PRODUCTION_LABEL;
-  return DEV_LABEL;
+  if (environment === "dev") return DEV_LABEL;
+  const titled = capitalizeEnvironment(environment);
+  return {
+    id: `ai.traycer.host.${environment}`,
+    displayName: `Traycer Host (${titled})`,
+    appSupportDirName: `Traycer-${titled}`,
+  };
+}
+
+function capitalizeEnvironment(environment: Environment): string {
+  if (environment.length === 0) return environment;
+  return environment.charAt(0).toUpperCase() + environment.slice(1);
 }
 
 /**


### PR DESCRIPTION
## What

A staging (internal, non-production) desktop build was collapsing onto the **production** host slot, leaving the app stuck on "Starting local Traycer Host…" while attached to the prod host (`ai.traycer.host`, prod cloud).

Two independent causes, both from the dev-vs-production binary assumption in the client:

### 1. CLI discovery adopted a PATH `traycer` for non-dev builds
`discoverCli()` only skipped the PATH lookup for `isDevBuild`. A staging build is non-dev, so it fell through to `findCliOnPath()` and picked up whatever `traycer` was on PATH — on a dev machine that's the released/prod CLI (Homebrew, the `~/.traycer/cli/bin` symlink into the prod `Traycer.app`). The desktop then ran `host ensure`/`host start` through a **production** CLI, driving everything onto `~/.traycer/host/install`, `ai.traycer.host`, and the prod cloud.

**Fix:** PATH trust is production-only. Non-production slots (dev and staging) use their bundled/slot CLI.

### 2. `labelForEnvironment` mapped staging onto the dev slot
The dev-only fallback returned `DEV_LABEL` (`ai.traycer.host.dev`) for staging, mismatching the `ai.traycer.host.staging` plist the installer ships. It now derives `ai.traycer.host.<environment>` for every non-prod/non-dev slot, mirroring the CLI's `serviceLabelFor`.

## Tests
- `resolve-cli-invocation-staging.test.ts` (new): staging skips a PATH `traycer` and uses the bundled CLI; staging-slot manifest scoping.
- `host-paths.test.ts`: per-slot `labelForEnvironment` (prod / dev / staging).

## Validation
- `bun run --cwd clients/desktop compile` — clean
- desktop vitest — 337/337 pass
- `eslint . --max-warnings 0` — clean
