### PR TITLE
Adjust terminal workspace launch picker UX

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test:
     name: test (${{ matrix.project }})
-    runs-on: if(${{ matrix.project == 'traycer-clients-gui-app' }}, ubuntu-latest-8-cores, ubuntu-latest)
+    runs-on: ${{ matrix.project == 'traycer-clients-gui-app' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     strategy:
       # Run every project even if one fails, so a single red project doesn't
       # mask the others.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   test:
     name: test (${{ matrix.project }})
-    runs-on: ubuntu-latest
+    runs-on: if(${{ matrix.project == 'traycer-clients-gui-app' }}, ubuntu-latest-8-cores, ubuntu-latest)
     strategy:
       # Run every project even if one fails, so a single red project doesn't
       # mask the others.

--- a/.traycer/environment.json
+++ b/.traycer/environment.json
@@ -1,0 +1,15 @@
+{
+  "setup": {
+    "default": "make build\npre-commit install\npre-commit install-hooks\npre-commit install --hook-type pre-commit --hook-type commit-msg",
+    "macos": null,
+    "windows": null,
+    "linux": null
+  },
+  "teardown": {
+    "default": "",
+    "macos": null,
+    "windows": null,
+    "linux": null
+  },
+  "updatedAt": 1782327514294
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker-no-double.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker-no-double.test.tsx
@@ -1,17 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { paneTabRefs } from "@/stores/epics/canvas/actions";
 import { collectPanes } from "@/stores/epics/canvas/tile-tree";
 import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
 
-// A double-click on a folder row fires the row's `onSelect` twice before the
-// popover's `setIsOpen(false)` (a state update) can unmount the list. Each call
-// mints a fresh `term-${uuidv4()}` id, so without a guard two terminals open.
-// The folder list is mocked to a button that fires onSelect twice in one click
-// handler - the exact synchronous double-fire - so the latch is what collapses
-// it to a single terminal.
+// A double-click can fire two handlers before React flushes the state update
+// that closes the popover. Row selection must not launch anything; the launch
+// latch is what collapses a double-fired Launch action to a single terminal.
 
 const ROW: WorktreeBindingSelectorRow = {
   hostId: "host-1",
@@ -66,6 +64,32 @@ vi.mock("@/components/worktree/worktree-folder-list-body", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    variant: _variant,
+    size: _size,
+    asChild: _asChild,
+    className: _className,
+    children,
+    onClick,
+    ...props
+  }: ComponentProps<"button"> & {
+    readonly variant?: string | undefined;
+    readonly size?: string | undefined;
+    readonly asChild?: boolean | undefined;
+  }) => (
+    <button
+      {...props}
+      onClick={(event) => {
+        onClick?.(event);
+        if (children === "Launch") onClick?.(event);
+      }}
+    >
+      {children}
+    </button>
+  ),
+}));
+
 import { NewTerminalPicker } from "../new-terminal-picker";
 
 function resetCanvas(): void {
@@ -78,18 +102,24 @@ function tabTiles(tabId: string): ReadonlyArray<EpicCanvasTileRef> {
   return collectPanes(canvas.root).flatMap((pane) => paneTabRefs(canvas, pane));
 }
 
-describe("<NewTerminalPicker /> double-pick guard", () => {
+describe("<NewTerminalPicker /> double-launch guard", () => {
   beforeEach(() => {
     cleanup();
     resetCanvas();
   });
 
-  it("opens a single terminal when a folder row is picked twice in one burst", () => {
+  it("opens a single terminal when Launch fires twice after row selection", () => {
     const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic");
     render(<NewTerminalPicker epicId="epic-1" tabId={tabId} />);
     fireEvent.click(screen.getByTestId("epic-terminals-panel-add"));
 
     fireEvent.click(screen.getByTestId("double-pick-row"));
+    expect(tabTiles(tabId).filter((t) => t.type === "terminal")).toHaveLength(
+      0,
+    );
+    const launchButton = screen.getByRole("button", { name: "Launch" });
+    expect(launchButton.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(launchButton);
 
     const terminals = tabTiles(tabId).filter((t) => t.type === "terminal");
     expect(terminals).toHaveLength(1);

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker.test.tsx
@@ -127,7 +127,9 @@ describe("<NewTerminalPicker />", () => {
     expect(primaryOption.className).toContain("cursor-pointer");
     expect(screen.getByRole("option", { name: /feature-x/i })).toBeDefined();
     expect(screen.getByText("/work/traycer-wt/feature-x")).toBeDefined();
-    // Create-new flow has no persistent selection to check-mark.
+    expect(
+      screen.getByRole("button", { name: "Launch" }).hasAttribute("disabled"),
+    ).toBe(true);
     expect(
       screen
         .getAllByRole("option")
@@ -135,10 +137,30 @@ describe("<NewTerminalPicker />", () => {
     ).toBe(true);
   });
 
-  it("creates a terminal bound to the row's host and cwd on a single click", () => {
+  it("selects a workspace without creating a terminal on a single click", () => {
     const tabId = openPicker();
 
     fireEvent.click(screen.getByRole("option", { name: /feature-x/i }));
+
+    const tiles = tabTiles(tabId);
+    expect(tiles.filter((tile) => tile.type === "terminal")).toHaveLength(0);
+    expect(screen.queryByTestId("new-terminal-picker-popover")).not.toBeNull();
+    const worktreeOption = screen.getByRole("option", { name: /feature-x/i });
+    const primaryOption = screen.getByRole("option", {
+      name: /traycer.*main/i,
+    });
+    expect(worktreeOption.dataset.checked).toBe("true");
+    expect(primaryOption.dataset.checked).toBeUndefined();
+    expect(
+      screen.getByRole("button", { name: "Launch" }).hasAttribute("disabled"),
+    ).toBe(false);
+  });
+
+  it("launches a terminal bound to the selected row's host and cwd", () => {
+    const tabId = openPicker();
+
+    fireEvent.click(screen.getByRole("option", { name: /feature-x/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Launch" }));
 
     const tiles = tabTiles(tabId);
     const terminals = tiles.filter((tile) => tile.type === "terminal");

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
@@ -1,9 +1,9 @@
 /**
  * Picker popover behind the Terminals panel "+" action. Top section picks
  * the host (machine); below it the shared worktree folder list shows
- * everything already bound to the epic. Selecting a folder immediately
- * opens a raw terminal tab bound to that row's host, with the row's
- * `runningDir` persisted as the PTY working directory.
+ * everything already bound to the epic. Selecting a folder stages it; the
+ * footer launch action opens a raw terminal tab bound to that row's host, with
+ * the row's `runningDir` persisted as the PTY working directory.
  *
  * The folder query and epic-artifact subscription live in
  * `NewTerminalFolders`, mounted inside the popover content so a closed
@@ -32,35 +32,41 @@ interface NewTerminalPickerProps {
 
 export function NewTerminalPicker(props: NewTerminalPickerProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [selectedRow, setSelectedRow] =
+    useState<WorktreeBindingSelectorRow | null>(null);
   const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
 
-  // A double-click on a folder row fires `onSelect` twice before
-  // `setIsOpen(false)` (a state update) can unmount the list, so each click
-  // would mint a fresh `term-${uuidv4()}` id and open a second terminal. This
-  // synchronous latch collapses one open→pick session to a single terminal;
-  // it is reset when the popover (re)opens.
-  const hasPickedRef = useRef(false);
+  // A double-click on the launch action fires twice before `setIsOpen(false)`
+  // can unmount the popover, so each click would mint a fresh terminal id. This
+  // synchronous latch collapses one open->launch session to a single terminal.
+  const hasLaunchedRef = useRef(false);
   const handleOpenChange = useCallback((open: boolean) => {
-    if (open) hasPickedRef.current = false;
+    if (open) {
+      hasLaunchedRef.current = false;
+      setSelectedRow(null);
+    }
     setIsOpen(open);
   }, []);
 
-  const handleSelectRow = useCallback(
-    (row: WorktreeBindingSelectorRow) => {
-      if (hasPickedRef.current) return;
-      hasPickedRef.current = true;
-      openTileInTab(props.tabId, {
-        id: `term-${uuidv4()}`,
-        instanceId: uuidv4(),
-        type: "terminal",
-        name: DEFAULT_TERMINAL_TITLE,
-        hostId: row.hostId,
-        cwd: row.runningDir,
-      });
-      setIsOpen(false);
-    },
-    [openTileInTab, props.tabId],
-  );
+  const handleLaunch = useCallback(() => {
+    if (hasLaunchedRef.current || selectedRow === null) return;
+    hasLaunchedRef.current = true;
+    openTileInTab(props.tabId, {
+      id: `term-${uuidv4()}`,
+      instanceId: uuidv4(),
+      type: "terminal",
+      name: DEFAULT_TERMINAL_TITLE,
+      hostId: selectedRow.hostId,
+      cwd: selectedRow.runningDir,
+    });
+    setIsOpen(false);
+  }, [openTileInTab, props.tabId, selectedRow]);
+
+  const handleSelectRow = useCallback((row: WorktreeBindingSelectorRow) => {
+    setSelectedRow(row);
+  }, []);
+
+  const launchDisabled = selectedRow === null;
 
   return (
     <Popover open={isOpen} onOpenChange={handleOpenChange}>
@@ -82,7 +88,21 @@ export function NewTerminalPicker(props: NewTerminalPickerProps) {
         data-testid="new-terminal-picker-popover"
       >
         <WorktreePickerHostSection />
-        <NewTerminalFolders epicId={props.epicId} onSelect={handleSelectRow} />
+        <NewTerminalFolders
+          epicId={props.epicId}
+          selectedRow={selectedRow}
+          onSelect={handleSelectRow}
+        />
+        <div className="flex justify-end border-t border-border/60 bg-muted/20 px-2.5 py-2.5">
+          <Button
+            type="button"
+            size="sm"
+            disabled={launchDisabled}
+            onClick={handleLaunch}
+          >
+            Launch
+          </Button>
+        </div>
       </PopoverContent>
     </Popover>
   );
@@ -94,6 +114,7 @@ export function NewTerminalPicker(props: NewTerminalPickerProps) {
  */
 function NewTerminalFolders(props: {
   readonly epicId: string;
+  readonly selectedRow: WorktreeBindingSelectorRow | null;
   readonly onSelect: (row: WorktreeBindingSelectorRow) => void;
 }) {
   const bindingsQuery = useWorktreeListBindingsForEpic({
@@ -110,7 +131,7 @@ function NewTerminalFolders(props: {
       isPending={bindingsQuery.isPending}
       isError={bindingsQuery.isError}
       rows={rows}
-      selectedRow={null}
+      selectedRow={props.selectedRow}
       secondaryLabel={(row) => row.runningDir}
       onSelect={props.onSelect}
     />


### PR DESCRIPTION
## Summary
- stage terminal workspace selection instead of launching immediately on row click
- add a right-aligned Launch action in the picker footer
- update terminal picker tests for selection and launch behavior

## Verification
- bun run test src/components/epic-canvas/sidebar/__tests__/new-terminal-picker.test.tsx
- bun run compile
- bunx eslint src/components/epic-canvas/sidebar/new-terminal-picker.tsx src/components/epic-canvas/sidebar/__tests__/new-terminal-picker.test.tsx --max-warnings 0
- git diff --check
- bun x -y react-doctor@latest . --verbose --diff main --offline --no-score
- pre-commit workspace checks during git commit