### PR TITLE
feat(gui-app): history-row right-click menu + fix open-in-new-window

### DIFF
--- a/clients/gui-app/src/components/epic-tabs/__tests__/epic-tab-host.test.tsx
+++ b/clients/gui-app/src/components/epic-tabs/__tests__/epic-tab-host.test.tsx
@@ -422,12 +422,12 @@ describe("EpicTabHost keep-alive", () => {
 
     await waitFor(() => {
       expect(
-        useEpicCanvasStore.getState().firstTabIdForEpic("epic-a"),
+        useEpicCanvasStore.getState().resolveTabIdForEpic("epic-a"),
       ).not.toBeNull();
     });
     const firstCreatedTabId = useEpicCanvasStore
       .getState()
-      .firstTabIdForEpic("epic-a");
+      .resolveTabIdForEpic("epic-a");
     if (firstCreatedTabId === null) {
       throw new Error("expected first created tab");
     }
@@ -445,12 +445,12 @@ describe("EpicTabHost keep-alive", () => {
 
     await waitFor(() => {
       expect(
-        useEpicCanvasStore.getState().firstTabIdForEpic("epic-b"),
+        useEpicCanvasStore.getState().resolveTabIdForEpic("epic-b"),
       ).not.toBeNull();
     });
     const secondCreatedTabId = useEpicCanvasStore
       .getState()
-      .firstTabIdForEpic("epic-b");
+      .resolveTabIdForEpic("epic-b");
     if (secondCreatedTabId === null) {
       throw new Error("expected second created tab");
     }
@@ -468,12 +468,12 @@ describe("EpicTabHost keep-alive", () => {
 
     await waitFor(() => {
       expect(
-        useEpicCanvasStore.getState().firstTabIdForEpic("epic-a"),
+        useEpicCanvasStore.getState().resolveTabIdForEpic("epic-a"),
       ).not.toBeNull();
     });
     const firstCreatedTabId = useEpicCanvasStore
       .getState()
-      .firstTabIdForEpic("epic-a");
+      .resolveTabIdForEpic("epic-a");
     if (firstCreatedTabId === null) {
       throw new Error("expected first created tab");
     }
@@ -481,7 +481,7 @@ describe("EpicTabHost keep-alive", () => {
     act(() => {
       useEpicCanvasStore.getState().closeTab(firstCreatedTabId);
     });
-    expect(useEpicCanvasStore.getState().firstTabIdForEpic("epic-a")).toBe(
+    expect(useEpicCanvasStore.getState().resolveTabIdForEpic("epic-a")).toBe(
       firstCreatedTabId,
     );
     expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]);
@@ -491,12 +491,12 @@ describe("EpicTabHost keep-alive", () => {
 
     await waitFor(() => {
       expect(
-        useEpicCanvasStore.getState().firstTabIdForEpic("epic-a"),
+        useEpicCanvasStore.getState().resolveTabIdForEpic("epic-a"),
       ).not.toBeNull();
     });
     const secondCreatedTabId = useEpicCanvasStore
       .getState()
-      .firstTabIdForEpic("epic-a");
+      .resolveTabIdForEpic("epic-a");
     expect(secondCreatedTabId).toBe(firstCreatedTabId);
     expect(useEpicCanvasStore.getState().openTabOrder).toEqual([
       firstCreatedTabId,

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -276,7 +276,7 @@ describe("<EpicsListPanel />", () => {
     await waitFor(() => {
       const tabId = useEpicCanvasStore
         .getState()
-        .firstTabIdForEpic("epic-from-history");
+        .resolveTabIdForEpic("epic-from-history");
       expect(tabId).not.toBeNull();
       expect(router.state.location.pathname).toBe(
         `/epics/epic-from-history/${tabId}`,
@@ -320,6 +320,28 @@ describe("<EpicsListPanel />", () => {
       await screen.findByTestId("epics-list-row-open-new-window"),
     ).toBeDefined();
     expect(screen.queryByTestId("epics-list-row-open-background")).toBeNull();
+  });
+
+  it("mounts no context menu for a phase row in browser mode (no windows bridge)", async () => {
+    // Browser build: no windows bridge, so Open in New Window is unavailable and
+    // the phase row already suppresses Open in Background. With no action left,
+    // the row must not wrap itself in a context menu - right-click must never
+    // pop an empty menu.
+    testState.items = [
+      historyItem({
+        id: "history-phase-web",
+        epicId: "phase-web",
+        taskType: "phase",
+        title: "Phase in browser",
+      }),
+    ];
+    renderPanel("embedded", "/");
+
+    fireEvent.contextMenu(await screen.findByTestId("epics-list-row-card"));
+
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(screen.queryByTestId("epics-list-row-open-background")).toBeNull();
+    expect(screen.queryByTestId("epics-list-row-open-new-window")).toBeNull();
   });
 
   it("shows the running activity status on history rows", async () => {

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -26,6 +26,65 @@ import type { HistoryFacets } from "@/hooks/home/use-history-query";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useHistorySearchStore } from "@/stores/home/history-search-store";
 import { DEFAULT_HISTORY_SEARCH } from "@/lib/history-search";
+import { WindowsBridgeContext } from "@/providers/windows-bridge-context";
+import { setDesktopEpicOwnershipBridge } from "@/lib/windows/desktop-epic-ownership";
+import type { DesktopWindowsBridge } from "@/lib/windows/types";
+
+/**
+ * Light up the desktop "Open in New Window" path: both the renderer context
+ * bridge (gates the menu item via `useWindowsBridge`) and the module-level
+ * ownership bridge (gates `useEpicOpenInNewWindowFlow.isAvailable`) must be set.
+ */
+function enableDesktopBridge(): void {
+  const bridge = stubWindowsBridge();
+  testState.bridge = bridge;
+  setDesktopEpicOwnershipBridge(bridge);
+}
+
+function stubWindowsBridge(): DesktopWindowsBridge {
+  const disposable = { dispose: vi.fn() };
+  return {
+    windowId: "window-test",
+    list: vi.fn(() => Promise.resolve([])),
+    onChange: vi.fn(() => disposable),
+    requestNew: vi.fn(() => Promise.resolve()),
+    requestFocus: vi.fn(() => Promise.resolve()),
+    requestClose: vi.fn(() => Promise.resolve()),
+    requestOpenEpicInNewWindow: vi.fn(() =>
+      Promise.resolve({ result: "focused", windowId: "window-test" } as const),
+    ),
+    ownership: {
+      snapshot: vi.fn(() => Promise.resolve([])),
+      claim: vi.fn(() => Promise.resolve({ ok: true } as const)),
+      release: vi.fn(() => Promise.resolve()),
+      onChange: vi.fn(() => disposable),
+    },
+    perWindowState: {
+      get: vi.fn(() =>
+        Promise.resolve({
+          epicTabs: [],
+          activeTabId: null,
+          canvasByTabId: {},
+          landingDrafts: [],
+          activeLandingDraftId: null,
+        }),
+      ),
+      update: vi.fn(() => Promise.resolve()),
+      onChange: vi.fn(() => disposable),
+    },
+    authSession: {
+      get: vi.fn(() =>
+        Promise.resolve({
+          status: "signed-out",
+          token: null,
+          profile: null,
+        } as const),
+      ),
+      set: vi.fn(() => Promise.resolve()),
+      onChange: vi.fn(() => disposable),
+    },
+  };
+}
 
 interface RenameEpicTitleVariables {
   readonly epicDelta: {
@@ -54,6 +113,7 @@ const testState = vi.hoisted(() => ({
     ownershipScopes: [] as HistoryFacets["ownershipScopes"],
   },
   isFetching: false,
+  bridge: null as DesktopWindowsBridge | null,
   mutate:
     vi.fn<
       (
@@ -161,10 +221,18 @@ function renderPanel(variant: EpicsListPanelVariant, initialEntry: string) {
 }
 
 function RootOutlet(): ReactNode {
-  return (
+  const content = (
     <TooltipProvider>
       <Outlet />
     </TooltipProvider>
+  );
+  if (testState.bridge === null) return content;
+  return (
+    <WindowsBridgeContext.Provider
+      value={{ bridge: testState.bridge, hasHydrated: true }}
+    >
+      {content}
+    </WindowsBridgeContext.Provider>
   );
 }
 
@@ -180,6 +248,8 @@ describe("<EpicsListPanel />", () => {
       ownershipScopes: [],
     };
     testState.isFetching = false;
+    testState.bridge = null;
+    setDesktopEpicOwnershipBridge(null);
     testState.mutate.mockReset();
     testState.renameMutate.mockReset();
     testState.refetch.mockReset();
@@ -191,6 +261,7 @@ describe("<EpicsListPanel />", () => {
 
   afterEach(() => {
     cleanup();
+    setDesktopEpicOwnershipBridge(null);
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useHistorySearchStore.setState({ search: DEFAULT_HISTORY_SEARCH });
   });
@@ -212,6 +283,43 @@ describe("<EpicsListPanel />", () => {
       );
     });
     expect(screen.queryByTestId("old-epic-route")).toBeNull();
+  });
+
+  it("offers both context-menu actions for an epic row", async () => {
+    enableDesktopBridge();
+    renderPanel("embedded", "/");
+
+    fireEvent.contextMenu(await screen.findByTestId("epics-list-row-card"));
+
+    expect(
+      await screen.findByTestId("epics-list-row-open-background"),
+    ).toBeDefined();
+    expect(
+      screen.queryByTestId("epics-list-row-open-new-window"),
+    ).not.toBeNull();
+  });
+
+  it("hides Open in Background for phase rows, keeping Open in New Window", async () => {
+    // A phase only opens through its migration route (migrationSource=phase),
+    // which a plain background canvas tab can't carry - so background-open is
+    // suppressed while the route-based New Window action stays available.
+    enableDesktopBridge();
+    testState.items = [
+      historyItem({
+        id: "history-phase-1",
+        epicId: "phase-1",
+        taskType: "phase",
+        title: "Phase from history",
+      }),
+    ];
+    renderPanel("embedded", "/");
+
+    fireEvent.contextMenu(await screen.findByTestId("epics-list-row-card"));
+
+    expect(
+      await screen.findByTestId("epics-list-row-open-new-window"),
+    ).toBeDefined();
+    expect(screen.queryByTestId("epics-list-row-open-background")).toBeNull();
   });
 
   it("shows the running activity status on history rows", async () => {

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -9,7 +9,9 @@ import {
 } from "react";
 import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
 import {
+  ArrowDownToLine,
   Check,
+  ExternalLink,
   Layers,
   ListChecks,
   Pencil,
@@ -19,6 +21,18 @@ import {
   X,
 } from "lucide-react";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { openEpicInBackground } from "@/lib/commands/actions/open-epic-in-background";
+import {
+  useHistoryOpenInNewWindowFlow,
+  type HistoryNewWindowFlow,
+} from "@/components/epics/use-history-open-in-new-window";
+import { UnsyncedEpicMoveDialog } from "@/components/layout/dialogs/unsynced-epic-move-dialog";
 import { Button } from "@/components/ui/button";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
@@ -208,6 +222,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
   // PanelChromeBar / PanelSearchInput / EpicsSortMenu bail unless their own
   // data actually changes.
   const { search, update: updateSearch, clear: clearSearch } = historySearch;
+  const openInNewWindowFlow = useHistoryOpenInNewWindowFlow();
 
   const {
     data,
@@ -392,6 +407,8 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
             isFetchingNextPage={isFetchingNextPage}
             onLoadMore={fetchNextPage}
             onSelectEpic={onSelectEpic}
+            onOpenInNewWindow={openInNewWindowFlow.requestOpen}
+            openInNewWindowAvailable={openInNewWindowFlow.isAvailable}
           />
         </div>
       </section>
@@ -407,6 +424,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
         isPending={deleteMutation.isPending}
         onConfirm={handleConfirmDelete}
       />
+      <UnsyncedEpicMoveDialog flow={openInNewWindowFlow.epicFlow} />
     </TooltipProvider>
   );
 }
@@ -672,6 +690,8 @@ interface EpicsListBodyProps {
   readonly isFetchingNextPage: boolean;
   readonly onLoadMore: () => void;
   readonly onSelectEpic: ((epicId: string) => void) | null;
+  readonly onOpenInNewWindow: HistoryNewWindowFlow["requestOpen"];
+  readonly openInNewWindowAvailable: boolean;
 }
 
 function EpicsListBody(props: EpicsListBodyProps): ReactNode {
@@ -690,6 +710,8 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     isFetchingNextPage,
     onLoadMore,
     onSelectEpic,
+    onOpenInNewWindow,
+    openInNewWindowAvailable,
   } = props;
 
   if (error !== null) {
@@ -724,6 +746,8 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
               onToggleSelection={onToggleSelection}
               onRequestDelete={onRequestDelete}
               onSelectEpic={onSelectEpic}
+              onOpenInNewWindow={onOpenInNewWindow}
+              openInNewWindowAvailable={openInNewWindowAvailable}
             />
           ))}
         </ul>
@@ -787,6 +811,8 @@ interface EpicsListRowProps {
   readonly onToggleSelection: (id: string) => void;
   readonly onRequestDelete: (ids: ReadonlyArray<string>) => void;
   readonly onSelectEpic: ((epicId: string) => void) | null;
+  readonly onOpenInNewWindow: HistoryNewWindowFlow["requestOpen"];
+  readonly openInNewWindowAvailable: boolean;
 }
 
 const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
@@ -797,6 +823,8 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     onToggleSelection,
     onRequestDelete,
     onSelectEpic,
+    onOpenInNewWindow,
+    openInNewWindowAvailable,
   } = props;
   const isPhase = item.taskType === "phase";
   const displayTitle = historyItemDisplayTitle(item);
@@ -814,6 +842,12 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
   const linkTabId = useEpicCanvasStore(
     (s) => s.firstTabIdForEpic(item.epicId) ?? item.epicId,
   );
+  const openInBackground = useCallback(() => {
+    openEpicInBackground(item.epicId, item.title);
+  }, [item.epicId, item.title]);
+  const openInNewWindow = useCallback(() => {
+    onOpenInNewWindow(item);
+  }, [onOpenInNewWindow, item]);
   const commitEpicTitle = useCallback(
     (nextTitle: string) => {
       if (isPhase) return;
@@ -977,45 +1011,75 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
       <div className="flex w-5 shrink-0 items-center justify-center">
         {selectionControl}
       </div>
-      <div
-        data-testid="epics-list-row-card"
-        data-selection-disabled={selectionDisabled ? "true" : undefined}
-        className={historyRowCardClassName({
-          selectionDisabled,
-          selectedForDelete: historySelectedForDelete({
-            selectionMode,
-            isSelected,
-            canDeleteItem,
-          }),
-        })}
-      >
-        {rowInteractionLayer}
-        <div className="pointer-events-none relative z-10 flex items-center justify-between gap-3 p-3 pr-12 text-ui-sm">
-          <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
-            <HistoryRowLeadingIcon item={item} />
-            {isRenaming ? (
-              <input
-                {...renameInputProps}
-                type="text"
-                aria-label={`Rename ${displayTitle}`}
-                data-testid="epics-list-row-title-input"
-                className="pointer-events-auto w-full min-w-0 flex-1 rounded border border-input bg-background/90 px-1.5 py-0.5 font-medium text-foreground outline-none focus:border-ring/70 focus-visible:ring-0"
-              />
-            ) : (
-              <span className="flex min-w-0 items-center gap-1.5 overflow-hidden">
-                <span className="truncate font-medium text-foreground">
-                  {displayTitle}
-                </span>
-                {titleEditControl}
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div
+            data-testid="epics-list-row-card"
+            data-selection-disabled={selectionDisabled ? "true" : undefined}
+            className={historyRowCardClassName({
+              selectionDisabled,
+              selectedForDelete: historySelectedForDelete({
+                selectionMode,
+                isSelected,
+                canDeleteItem,
+              }),
+            })}
+          >
+            {rowInteractionLayer}
+            <div className="pointer-events-none relative z-10 flex items-center justify-between gap-3 p-3 pr-12 text-ui-sm">
+              <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+                <HistoryRowLeadingIcon item={item} />
+                {isRenaming ? (
+                  <input
+                    {...renameInputProps}
+                    type="text"
+                    aria-label={`Rename ${displayTitle}`}
+                    data-testid="epics-list-row-title-input"
+                    className="pointer-events-auto w-full min-w-0 flex-1 rounded border border-input bg-background/90 px-1.5 py-0.5 font-medium text-foreground outline-none focus:border-ring/70 focus-visible:ring-0"
+                  />
+                ) : (
+                  <span className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+                    <span className="truncate font-medium text-foreground">
+                      {displayTitle}
+                    </span>
+                    {titleEditControl}
+                  </span>
+                )}
               </span>
-            )}
-          </span>
-          <span className="shrink-0 text-ui-xs text-muted-foreground">
-            updated {item.updatedLabel}
-          </span>
-        </div>
-        {deleteControl}
-      </div>
+              <span className="shrink-0 text-ui-xs text-muted-foreground">
+                updated {item.updatedLabel}
+              </span>
+            </div>
+            {deleteControl}
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent
+          onCloseAutoFocus={(event) => event.preventDefault()}
+        >
+          {/* Phases have no background-open: a phase only opens through its
+              migration route (migrationSource=phase), which a plain canvas tab
+              can't carry, so it would activate into the wrong (non-migration)
+              surface. New Window stays available - it goes through the route. */}
+          {isPhase ? null : (
+            <ContextMenuItem
+              onSelect={openInBackground}
+              data-testid="epics-list-row-open-background"
+            >
+              <ArrowDownToLine />
+              Open in Background
+            </ContextMenuItem>
+          )}
+          {openInNewWindowAvailable ? (
+            <ContextMenuItem
+              onSelect={openInNewWindow}
+              data-testid="epics-list-row-open-new-window"
+            >
+              <ExternalLink />
+              Open in New Window
+            </ContextMenuItem>
+          ) : null}
+        </ContextMenuContent>
+      </ContextMenu>
     </li>
   );
 });

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -840,7 +840,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const linkTabId = useEpicCanvasStore(
-    (s) => s.firstTabIdForEpic(item.epicId) ?? item.epicId,
+    (s) => s.resolveTabIdForEpic(item.epicId) ?? item.epicId,
   );
   const openInBackground = useCallback(() => {
     openEpicInBackground(item.epicId, item.title);
@@ -1003,6 +1003,69 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
       onBlockUnavailableDelete={blockUnavailableDeleteAction}
     />
   );
+  const rowCard = (
+    <div
+      data-testid="epics-list-row-card"
+      data-selection-disabled={selectionDisabled ? "true" : undefined}
+      className={historyRowCardClassName({
+        selectionDisabled,
+        selectedForDelete: historySelectedForDelete({
+          selectionMode,
+          isSelected,
+          canDeleteItem,
+        }),
+      })}
+    >
+      {rowInteractionLayer}
+      <div className="pointer-events-none relative z-10 flex items-center justify-between gap-3 p-3 pr-12 text-ui-sm">
+        <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+          <HistoryRowLeadingIcon item={item} />
+          {isRenaming ? (
+            <input
+              {...renameInputProps}
+              type="text"
+              aria-label={`Rename ${displayTitle}`}
+              data-testid="epics-list-row-title-input"
+              className="pointer-events-auto w-full min-w-0 flex-1 rounded border border-input bg-background/90 px-1.5 py-0.5 font-medium text-foreground outline-none focus:border-ring/70 focus-visible:ring-0"
+            />
+          ) : (
+            <span className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+              <span className="truncate font-medium text-foreground">
+                {displayTitle}
+              </span>
+              {titleEditControl}
+            </span>
+          )}
+        </span>
+        <span className="shrink-0 text-ui-xs text-muted-foreground">
+          updated {item.updatedLabel}
+        </span>
+      </div>
+      {deleteControl}
+    </div>
+  );
+  // Phases have no background-open: a phase only opens through its migration
+  // route (migrationSource=phase), which a plain canvas tab can't carry, so it
+  // would activate into the wrong (non-migration) surface. New Window stays
+  // available - it goes through the route.
+  const backgroundMenuItem = isPhase ? null : (
+    <ContextMenuItem
+      onSelect={openInBackground}
+      data-testid="epics-list-row-open-background"
+    >
+      <ArrowDownToLine />
+      Open in Background
+    </ContextMenuItem>
+  );
+  const newWindowMenuItem = openInNewWindowAvailable ? (
+    <ContextMenuItem
+      onSelect={openInNewWindow}
+      data-testid="epics-list-row-open-new-window"
+    >
+      <ExternalLink />
+      Open in New Window
+    </ContextMenuItem>
+  ) : null;
   return (
     <li
       data-testid="epics-list-row"
@@ -1011,75 +1074,22 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
       <div className="flex w-5 shrink-0 items-center justify-center">
         {selectionControl}
       </div>
-      <ContextMenu>
-        <ContextMenuTrigger asChild>
-          <div
-            data-testid="epics-list-row-card"
-            data-selection-disabled={selectionDisabled ? "true" : undefined}
-            className={historyRowCardClassName({
-              selectionDisabled,
-              selectedForDelete: historySelectedForDelete({
-                selectionMode,
-                isSelected,
-                canDeleteItem,
-              }),
-            })}
+      {/* Skip the context menu entirely when no action qualifies (e.g. a phase
+          row in the browser build with no windows bridge) so right-click never
+          opens an empty popover. */}
+      {backgroundMenuItem === null && newWindowMenuItem === null ? (
+        rowCard
+      ) : (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>{rowCard}</ContextMenuTrigger>
+          <ContextMenuContent
+            onCloseAutoFocus={(event) => event.preventDefault()}
           >
-            {rowInteractionLayer}
-            <div className="pointer-events-none relative z-10 flex items-center justify-between gap-3 p-3 pr-12 text-ui-sm">
-              <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
-                <HistoryRowLeadingIcon item={item} />
-                {isRenaming ? (
-                  <input
-                    {...renameInputProps}
-                    type="text"
-                    aria-label={`Rename ${displayTitle}`}
-                    data-testid="epics-list-row-title-input"
-                    className="pointer-events-auto w-full min-w-0 flex-1 rounded border border-input bg-background/90 px-1.5 py-0.5 font-medium text-foreground outline-none focus:border-ring/70 focus-visible:ring-0"
-                  />
-                ) : (
-                  <span className="flex min-w-0 items-center gap-1.5 overflow-hidden">
-                    <span className="truncate font-medium text-foreground">
-                      {displayTitle}
-                    </span>
-                    {titleEditControl}
-                  </span>
-                )}
-              </span>
-              <span className="shrink-0 text-ui-xs text-muted-foreground">
-                updated {item.updatedLabel}
-              </span>
-            </div>
-            {deleteControl}
-          </div>
-        </ContextMenuTrigger>
-        <ContextMenuContent
-          onCloseAutoFocus={(event) => event.preventDefault()}
-        >
-          {/* Phases have no background-open: a phase only opens through its
-              migration route (migrationSource=phase), which a plain canvas tab
-              can't carry, so it would activate into the wrong (non-migration)
-              surface. New Window stays available - it goes through the route. */}
-          {isPhase ? null : (
-            <ContextMenuItem
-              onSelect={openInBackground}
-              data-testid="epics-list-row-open-background"
-            >
-              <ArrowDownToLine />
-              Open in Background
-            </ContextMenuItem>
-          )}
-          {openInNewWindowAvailable ? (
-            <ContextMenuItem
-              onSelect={openInNewWindow}
-              data-testid="epics-list-row-open-new-window"
-            >
-              <ExternalLink />
-              Open in New Window
-            </ContextMenuItem>
-          ) : null}
-        </ContextMenuContent>
-      </ContextMenu>
+            {backgroundMenuItem}
+            {newWindowMenuItem}
+          </ContextMenuContent>
+        </ContextMenu>
+      )}
     </li>
   );
 });

--- a/clients/gui-app/src/components/epics/use-history-open-in-new-window.ts
+++ b/clients/gui-app/src/components/epics/use-history-open-in-new-window.ts
@@ -1,0 +1,69 @@
+import { useCallback } from "react";
+import {
+  useEpicOpenInNewWindowFlow,
+  type EpicNewWindowFlow,
+} from "@/components/layout/hooks/use-epic-open-in-new-window";
+import { useWindowsBridge } from "@/providers/windows-bridge-context";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { openEpicInNewWindow } from "@/lib/commands/actions/open-epic-in-new-window";
+import type { HistoryItem } from "@/components/home/data/home-page.data";
+
+export interface HistoryNewWindowFlow {
+  readonly isAvailable: boolean;
+  readonly requestOpen: (item: HistoryItem) => void;
+  readonly epicFlow: EpicNewWindowFlow;
+}
+
+/**
+ * History-row "Open in New Window" dispatcher.
+ *
+ * An epic already open in this window is popped out through the shared
+ * `useEpicOpenInNewWindowFlow` move flow - which transfers ownership and, when
+ * the epic has unsynced edits, raises the confirm dialog - instead of silently
+ * focusing the current window (the old bug). Every other case (epic open only
+ * in another window, or open nowhere, and all phase rows) is delegated to
+ * `openEpicInNewWindow`. Phases route there too because the move flow can't
+ * carry `migrationSource=phase`, and a phase is never a movable epic tab.
+ *
+ * The dialog is owned by the panel that calls this hook: render
+ * `<UnsyncedEpicMoveDialog flow={epicFlow} />` once alongside the list.
+ */
+export function useHistoryOpenInNewWindowFlow(): HistoryNewWindowFlow {
+  const bridge = useWindowsBridge();
+  const epicFlow = useEpicOpenInNewWindowFlow();
+  // Depend on the memoized action, not the whole `epicFlow` object (a fresh
+  // literal each render), so `requestOpen` stays stable and the memoized rows
+  // it is handed to don't re-render on every panel render.
+  const requestEpicMove = epicFlow.requestOpenInNewWindow;
+
+  const requestOpen = useCallback(
+    (item: HistoryItem) => {
+      if (bridge === null) return;
+      if (item.taskType !== "phase") {
+        const localTabId = useEpicCanvasStore
+          .getState()
+          .firstTabIdForEpic(item.epicId);
+        if (localTabId !== null) {
+          requestEpicMove({
+            epicId: item.epicId,
+            tabId: localTabId,
+            title: item.title,
+          });
+          return;
+        }
+      }
+      void openEpicInNewWindow(bridge, {
+        epicId: item.epicId,
+        tabId: item.epicId,
+        isPhase: item.taskType === "phase",
+      });
+    },
+    [bridge, requestEpicMove],
+  );
+
+  return {
+    isAvailable: bridge !== null && epicFlow.isAvailable,
+    requestOpen,
+    epicFlow,
+  };
+}

--- a/clients/gui-app/src/components/epics/use-history-open-in-new-window.ts
+++ b/clients/gui-app/src/components/epics/use-history-open-in-new-window.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import {
   useEpicOpenInNewWindowFlow,
   type EpicNewWindowFlow,
@@ -42,7 +42,7 @@ export function useHistoryOpenInNewWindowFlow(): HistoryNewWindowFlow {
       if (item.taskType !== "phase") {
         const localTabId = useEpicCanvasStore
           .getState()
-          .firstTabIdForEpic(item.epicId);
+          .resolveTabIdForEpic(item.epicId);
         if (localTabId !== null) {
           requestEpicMove({
             epicId: item.epicId,
@@ -61,9 +61,15 @@ export function useHistoryOpenInNewWindowFlow(): HistoryNewWindowFlow {
     [bridge, requestEpicMove],
   );
 
-  return {
-    isAvailable: bridge !== null && epicFlow.isAvailable,
-    requestOpen,
-    epicFlow,
-  };
+  // Keep a stable identity (see `useEpicOpenInNewWindowFlow`): `epicFlow` is
+  // already memoized upstream, so this object only changes when availability,
+  // `requestOpen`, or the underlying flow actually changes.
+  return useMemo(
+    () => ({
+      isAvailable: bridge !== null && epicFlow.isAvailable,
+      requestOpen,
+      epicFlow,
+    }),
+    [bridge, epicFlow, requestOpen],
+  );
 }

--- a/clients/gui-app/src/components/layout/hooks/use-epic-open-in-new-window.tsx
+++ b/clients/gui-app/src/components/layout/hooks/use-epic-open-in-new-window.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   LANDING_ROUTE,
@@ -167,12 +167,26 @@ export function useEpicOpenInNewWindowFlow(): EpicNewWindowFlow {
     };
   }, [executeMove, queuedMove]);
 
-  return {
-    isAvailable,
-    pendingMove,
-    requestOpenInNewWindow,
-    waitForSync,
-    cancelMove,
-    discardAndMove,
-  };
+  // Memoize so the returned flow keeps a stable identity across renders where
+  // nothing it carries changed. Consumers thread it into effect deps (e.g.
+  // `UnsyncedEpicMoveDialog`'s registry subscription); a fresh object each
+  // render would churn those subscriptions on every unrelated re-render.
+  return useMemo(
+    () => ({
+      isAvailable,
+      pendingMove,
+      requestOpenInNewWindow,
+      waitForSync,
+      cancelMove,
+      discardAndMove,
+    }),
+    [
+      isAvailable,
+      pendingMove,
+      requestOpenInNewWindow,
+      waitForSync,
+      cancelMove,
+      discardAndMove,
+    ],
+  );
 }

--- a/clients/gui-app/src/lib/commands/actions/__tests__/open-epic-in-new-window.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/open-epic-in-new-window.test.ts
@@ -115,7 +115,9 @@ describe("openEpicInNewWindow", () => {
     // would self-focus instead of opening a new window.
     const { bridge, calls } = makeBridge({
       windowId: "window-a",
-      owned: [{ tabId: "tab-self", epicId: "phase-self", windowId: "window-a" }],
+      owned: [
+        { tabId: "tab-self", epicId: "phase-self", windowId: "window-a" },
+      ],
     });
 
     await openEpicInNewWindow(bridge, {

--- a/clients/gui-app/src/lib/commands/actions/__tests__/open-epic-in-new-window.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/open-epic-in-new-window.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { openEpicInNewWindow } from "@/lib/commands/actions/open-epic-in-new-window";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { epicCanvasKey } from "@/lib/persist";
+import type {
+  DesktopOwnershipEntry,
+  DesktopWindowsBridge,
+} from "@/lib/windows/types";
+
+vi.mock("@/lib/analytics", () => ({
+  Analytics: { getInstance: () => ({ track: () => undefined }) },
+  AnalyticsEvent: { TaskOpened: "task_opened" },
+}));
+
+interface BridgeCalls {
+  readonly newRoutes: string[];
+  readonly focusedWindows: string[];
+}
+
+function makeBridge(options: {
+  readonly windowId: string;
+  readonly owned: ReadonlyArray<DesktopOwnershipEntry>;
+}): { bridge: DesktopWindowsBridge; calls: BridgeCalls } {
+  const calls: BridgeCalls = { newRoutes: [], focusedWindows: [] };
+  const bridge: DesktopWindowsBridge = {
+    windowId: options.windowId,
+    list: () => Promise.resolve([]),
+    onChange: () => ({ dispose: () => undefined }),
+    requestNew: (initialRoute) => {
+      calls.newRoutes.push(initialRoute ?? "");
+      return Promise.resolve();
+    },
+    requestFocus: (windowId) => {
+      calls.focusedWindows.push(windowId);
+      return Promise.resolve();
+    },
+    requestClose: () => Promise.resolve(),
+    requestOpenEpicInNewWindow: () =>
+      Promise.resolve({ result: "moved" as const, windowId: "window-x" }),
+    ownership: {
+      snapshot: () => Promise.resolve([...options.owned]),
+      claim: () => Promise.resolve({ ok: true as const }),
+      release: () => Promise.resolve(),
+      onChange: () => ({ dispose: () => undefined }),
+    },
+    perWindowState: {
+      get: () =>
+        Promise.resolve({
+          epicTabs: [],
+          activeTabId: null,
+          canvasByTabId: {},
+          landingDrafts: [],
+          activeLandingDraftId: null,
+        }),
+      update: () => Promise.resolve(),
+      onChange: () => ({ dispose: () => undefined }),
+    },
+    authSession: {
+      get: () =>
+        Promise.resolve({
+          status: "signed-out" as const,
+          token: null,
+          profile: null,
+        }),
+      set: () => Promise.resolve(),
+      onChange: () => ({ dispose: () => undefined }),
+    },
+  };
+  return { bridge, calls };
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  useEpicCanvasStore.persist.setOptions({ name: epicCanvasKey(null) });
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+});
+
+describe("openEpicInNewWindow", () => {
+  // The "epic already open in THIS window" case is handled upstream by the move
+  // flow (see use-history-open-in-new-window), so this helper only covers an
+  // epic open elsewhere or open nowhere.
+  it("focuses the owning window when the epic is open (mounted) in another window", async () => {
+    const { bridge, calls } = makeBridge({
+      windowId: "window-a",
+      owned: [{ tabId: "tab-1", epicId: "epic-far", windowId: "window-b" }],
+    });
+
+    await openEpicInNewWindow(bridge, {
+      epicId: "epic-far",
+      tabId: "epic-far",
+      isPhase: false,
+    });
+
+    expect(calls.focusedWindows).toEqual(["window-b"]);
+    expect(calls.newRoutes).toEqual([]);
+  });
+
+  it("opens a new window at the epic route when the epic is open nowhere", async () => {
+    const { bridge, calls } = makeBridge({ windowId: "window-a", owned: [] });
+
+    await openEpicInNewWindow(bridge, {
+      epicId: "epic-new",
+      tabId: "epic-new",
+      isPhase: false,
+    });
+
+    expect(calls.focusedWindows).toEqual([]);
+    expect(calls.newRoutes).toEqual(["/epics/epic-new/epic-new"]);
+  });
+
+  it("carries migrationSource=phase in the new-window route for phase rows", async () => {
+    const { bridge, calls } = makeBridge({ windowId: "window-a", owned: [] });
+
+    await openEpicInNewWindow(bridge, {
+      epicId: "phase-1",
+      tabId: "phase-1",
+      isPhase: true,
+    });
+
+    expect(calls.newRoutes).toEqual([
+      "/epics/phase-1/phase-1?migrationSource=phase",
+    ]);
+  });
+});

--- a/clients/gui-app/src/lib/commands/actions/__tests__/open-epic-in-new-window.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/open-epic-in-new-window.test.ts
@@ -108,6 +108,28 @@ describe("openEpicInNewWindow", () => {
     expect(calls.newRoutes).toEqual(["/epics/epic-new/epic-new"]);
   });
 
+  it("ignores the current window's own ownership entry and opens a new window", async () => {
+    // A phase that resolved in-place is mounted in THIS window and so holds an
+    // ownership entry keyed by its epicId. Phase rows always route here (never
+    // through the move flow), so the scan must exclude the current window or it
+    // would self-focus instead of opening a new window.
+    const { bridge, calls } = makeBridge({
+      windowId: "window-a",
+      owned: [{ tabId: "tab-self", epicId: "phase-self", windowId: "window-a" }],
+    });
+
+    await openEpicInNewWindow(bridge, {
+      epicId: "phase-self",
+      tabId: "phase-self",
+      isPhase: true,
+    });
+
+    expect(calls.focusedWindows).toEqual([]);
+    expect(calls.newRoutes).toEqual([
+      "/epics/phase-self/phase-self?migrationSource=phase",
+    ]);
+  });
+
   it("carries migrationSource=phase in the new-window route for phase rows", async () => {
     const { bridge, calls } = makeBridge({ windowId: "window-a", owned: [] });
 

--- a/clients/gui-app/src/lib/commands/actions/open-epic-in-background.ts
+++ b/clients/gui-app/src/lib/commands/actions/open-epic-in-background.ts
@@ -1,0 +1,19 @@
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+
+/**
+ * Opens an epic in a background header tab without leaving the current
+ * surface - the active tab and route are untouched, so the History overlay
+ * stays open and the `/epics` / home lists keep their place. Reuses an
+ * existing tab for the epic when one is already open.
+ *
+ * Centralised here (mirroring `openEpicFromList`) so the history row's
+ * right-click action and any future entry point stay in lockstep.
+ */
+export function openEpicInBackground(
+  epicId: string,
+  title: string | undefined,
+): void {
+  Analytics.getInstance().track(AnalyticsEvent.TaskOpened, null);
+  useEpicCanvasStore.getState().openEpicTabInBackground(epicId, title);
+}

--- a/clients/gui-app/src/lib/commands/actions/open-epic-in-new-window.ts
+++ b/clients/gui-app/src/lib/commands/actions/open-epic-in-new-window.ts
@@ -24,7 +24,11 @@ export interface OpenEpicInNewWindowInput {
  * confirm dialog). This helper only covers the remaining cases:
  *
  *  1. `ownership.snapshot()` catches the epic when it's the live/mounted tab in
- *     another window; we focus that window.
+ *     ANOTHER window; we focus that window. The current window is excluded from
+ *     the scan: phases resolve in-place under `epicId === phaseId` and so the
+ *     current window can hold an ownership entry for `input.epicId` (phase rows
+ *     always route here, never through the move flow). Matching it would refocus
+ *     this window instead of opening a new one - the silent self-focus bug.
  *  2. Otherwise open a fresh window at the epic route. Resolving here (rather
  *     than letting the new window's claim-on-mount bounce back to `/epics`)
  *     keeps the focus path flash-free.
@@ -40,7 +44,10 @@ export async function openEpicInNewWindow(
 ): Promise<void> {
   Analytics.getInstance().track(AnalyticsEvent.TaskOpened, null);
   const owned = await bridge.ownership.snapshot();
-  const existing = owned.find((entry) => entry.epicId === input.epicId);
+  const existing = owned.find(
+    (entry) =>
+      entry.epicId === input.epicId && entry.windowId !== bridge.windowId,
+  );
   if (existing !== undefined) {
     await bridge.requestFocus(existing.windowId);
     return;

--- a/clients/gui-app/src/lib/commands/actions/open-epic-in-new-window.ts
+++ b/clients/gui-app/src/lib/commands/actions/open-epic-in-new-window.ts
@@ -1,0 +1,54 @@
+import type { DesktopWindowsBridge } from "@/lib/windows/types";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+
+export interface OpenEpicInNewWindowInput {
+  readonly epicId: string;
+  /**
+   * Tab id segment for the new window's epic route. The epic is not open in
+   * this window (the open-here case is handled upstream by the move flow), so
+   * this is the `epicId` fallback; the destination window self-heals it into a
+   * real tab id on mount.
+   */
+  readonly tabId: string;
+  /** Phase rows carry `migrationSource=phase` so the migration view opens. */
+  readonly isPhase: boolean;
+}
+
+/**
+ * Opens a history epic/phase that is NOT open in the current window in a
+ * separate desktop window.
+ *
+ * The "already open in this window" case is handled by the caller through
+ * `useHistoryOpenInNewWindowFlow` -> `useEpicOpenInNewWindowFlow`, which pops
+ * the live tab out via the ownership-aware move flow (with its unsynced-edits
+ * confirm dialog). This helper only covers the remaining cases:
+ *
+ *  1. `ownership.snapshot()` catches the epic when it's the live/mounted tab in
+ *     another window; we focus that window.
+ *  2. Otherwise open a fresh window at the epic route. Resolving here (rather
+ *     than letting the new window's claim-on-mount bounce back to `/epics`)
+ *     keeps the focus path flash-free.
+ *
+ * Known gap: an epic open in ANOTHER window only as an unmounted/background tab
+ * holds no ownership entry, so step 1 misses it. Closing that fully needs the
+ * desktop main process to resolve the epic across every window's per-window
+ * snapshot; the renderer cannot see other windows' tab lists.
+ */
+export async function openEpicInNewWindow(
+  bridge: DesktopWindowsBridge,
+  input: OpenEpicInNewWindowInput,
+): Promise<void> {
+  Analytics.getInstance().track(AnalyticsEvent.TaskOpened, null);
+  const owned = await bridge.ownership.snapshot();
+  const existing = owned.find((entry) => entry.epicId === input.epicId);
+  if (existing !== undefined) {
+    await bridge.requestFocus(existing.windowId);
+    return;
+  }
+  await bridge.requestNew(buildEpicRoute(input));
+}
+
+function buildEpicRoute(input: OpenEpicInNewWindowInput): string {
+  const base = `/epics/${encodeURIComponent(input.epicId)}/${encodeURIComponent(input.tabId)}`;
+  return input.isPhase ? `${base}?migrationSource=phase` : base;
+}

--- a/clients/gui-app/src/routes/epics.$epicId.$tabId.tsx
+++ b/clients/gui-app/src/routes/epics.$epicId.$tabId.tsx
@@ -18,7 +18,7 @@ export const Route = createFileRoute("/epics/$epicId/$tabId")({
     const state = useEpicCanvasStore.getState();
     const tab = state.tabsById[params.tabId];
     if (tab?.epicId === params.epicId) return;
-    const fallback = state.firstTabIdForEpic(params.epicId);
+    const fallback = state.resolveTabIdForEpic(params.epicId);
     if (fallback === null) return;
     redirect({
       to: "/epics/$epicId/$tabId",

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -224,7 +224,7 @@ describe("epic canvas store header tabs", () => {
     const state = useEpicCanvasStore.getState();
     expect(state.tabsById["tab-hidden"]?.epicId).toBe("epic-hidden");
     expect(state.openTabOrder).toEqual([]);
-    expect(state.firstTabIdForEpic("epic-hidden")).toBe("tab-hidden");
+    expect(state.resolveTabIdForEpic("epic-hidden")).toBe("tab-hidden");
   });
 
   it("keeps legacy persisted tabs regardless of a now-removed lastSeenAt", async () => {

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -294,6 +294,40 @@ describe("epic canvas store header tabs", () => {
     expect(persisted.state).not.toHaveProperty("pendingChatTitles");
   });
 
+  it("opens an epic in a background tab without changing the active tab", () => {
+    const store = useEpicCanvasStore.getState();
+    const activeTabId = store.openEpicTab("epic-active", "Active");
+    expect(useEpicCanvasStore.getState().activeTabId).toBe(activeTabId);
+
+    const backgroundTabId = store.openEpicTabInBackground(
+      "epic-background",
+      "Background",
+    );
+
+    const state = useEpicCanvasStore.getState();
+    expect(state.activeTabId).toBe(activeTabId);
+    expect(state.openTabOrder).toContain(backgroundTabId);
+    expect(state.tabsById[backgroundTabId]?.epicId).toBe("epic-background");
+  });
+
+  it("reuses the existing tab when opening an already-open epic in background", () => {
+    const store = useEpicCanvasStore.getState();
+    const existingTabId = store.openEpicTab("epic-reuse", "Reuse");
+    const otherTabId = store.openEpicTab("epic-other", "Other");
+    expect(useEpicCanvasStore.getState().activeTabId).toBe(otherTabId);
+
+    const resolved = store.openEpicTabInBackground("epic-reuse", "Reuse");
+
+    const state = useEpicCanvasStore.getState();
+    expect(resolved).toBe(existingTabId);
+    expect(state.activeTabId).toBe(otherTabId);
+    expect(
+      state.openTabOrder.filter(
+        (id) => state.tabsById[id]?.epicId === "epic-reuse",
+      ),
+    ).toEqual([existingTabId]);
+  });
+
   it("hides a closed tab while preserving its canvas for reopen", () => {
     const store = useEpicCanvasStore.getState();
     const tabId = store.openEpicTab("epic-restore", "Restore Me");

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -148,6 +148,14 @@ export interface EpicCanvasStore {
 
   openEpicTab: (epicId: string, name: string | undefined) => string;
   /**
+   * Open an epic tab in the header strip WITHOUT activating it - the active
+   * tab and current route are left untouched. Reuses an existing tab for the
+   * epic when one is already open (returns its id, makes no change). Used by
+   * the history "Open in Background" action so a row can be opened behind the
+   * current surface (e.g. without dismissing the History overlay).
+   */
+  openEpicTabInBackground: (epicId: string, name: string | undefined) => string;
+  /**
    * Close the tab as a user-visible header action: remove it from
    * `openTabOrder`, update active/recent pointers, and keep `tabsById[tabId]`
    * available for reopen. Use `discardTabState` when the tab record must be
@@ -427,6 +435,37 @@ export function resolveTabIdForEpic(
   return firstTabIdForEpicInState(state, epicId);
 }
 
+function createEpicViewTab(
+  epicId: string,
+  name: string | undefined,
+): EpicViewTab {
+  return { tabId: uuidv4(), epicId, name: name ?? UNTITLED_EPIC_TITLE };
+}
+
+/**
+ * Shared `set()` payload for appending a freshly-created epic tab to the strip:
+ * registers the tab + an empty canvas, pushes it onto `openTabOrder`, points
+ * the epic's most-recent pointer at it, and seeds an empty artifact tree if the
+ * epic has none. Activation is layered on by the caller (`openEpicTab` makes it
+ * active; `openEpicTabInBackground` leaves `activeTabId` untouched).
+ */
+function appendedEpicTabState(state: EpicCanvasStore, tab: EpicViewTab) {
+  const { tabId, epicId } = tab;
+  return {
+    tabsById: { ...state.tabsById, [tabId]: tab },
+    canvasByTabId: { ...state.canvasByTabId, [tabId]: createEmptyCanvas() },
+    openTabOrder: [...state.openTabOrder, tabId],
+    mostRecentTabIdByEpicId: {
+      ...state.mostRecentTabIdByEpicId,
+      [epicId]: tabId,
+    },
+    artifactTreeByEpicId:
+      epicId in state.artifactTreeByEpicId
+        ? state.artifactTreeByEpicId
+        : { ...state.artifactTreeByEpicId, [epicId]: [] },
+  };
+}
+
 function epicTabNames(
   tabsById: Readonly<Record<string, EpicViewTab | undefined>>,
   epicId: string,
@@ -619,30 +658,33 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       pendingChatTitles: {},
 
       openEpicTab: (epicId, name) => {
-        const tabId = uuidv4();
-        const tab: EpicViewTab = {
-          tabId,
-          epicId,
-          name: name ?? UNTITLED_EPIC_TITLE,
-        };
+        const tab = createEpicViewTab(epicId, name);
         set((state) => ({
-          tabsById: { ...state.tabsById, [tabId]: tab },
-          canvasByTabId: {
-            ...state.canvasByTabId,
-            [tabId]: createEmptyCanvas(),
-          },
-          openTabOrder: [...state.openTabOrder, tabId],
-          activeTabId: tabId,
-          mostRecentTabIdByEpicId: {
-            ...state.mostRecentTabIdByEpicId,
-            [epicId]: tabId,
-          },
-          artifactTreeByEpicId:
-            epicId in state.artifactTreeByEpicId
-              ? state.artifactTreeByEpicId
-              : { ...state.artifactTreeByEpicId, [epicId]: [] },
+          ...appendedEpicTabState(state, tab),
+          activeTabId: tab.tabId,
         }));
-        return tabId;
+        return tab.tabId;
+      },
+
+      openEpicTabInBackground: (epicId, name) => {
+        const existing = resolveTabIdForEpic(get(), epicId);
+        if (existing !== null) {
+          // Reveal a preserved-but-hidden tab in the strip without activating
+          // it; an already-visible tab is left exactly where it is.
+          if (!get().openTabOrder.includes(existing)) {
+            set((current) =>
+              current.openTabOrder.includes(existing)
+                ? current
+                : { openTabOrder: [...current.openTabOrder, existing] },
+            );
+          }
+          return existing;
+        }
+        const tab = createEpicViewTab(epicId, name);
+        // activeTabId is intentionally left untouched - the tab opens behind
+        // the current surface and never steals focus.
+        set((current) => appendedEpicTabState(current, tab));
+        return tab.tabId;
       },
 
       closeTab: (tabId) => {

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -212,7 +212,7 @@ export interface EpicCanvasStore {
    * Return the best existing tab id for an epic using the same active/recent
    * preference as reopen, without creating a new tab.
    */
-  firstTabIdForEpic: (epicId: string) => string | null;
+  resolveTabIdForEpic: (epicId: string) => string | null;
 
   /**
    * Open a tile in `tabId`'s canvas as a permanent tab (dedup-aware: focuses
@@ -670,14 +670,14 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         const existing = resolveTabIdForEpic(get(), epicId);
         if (existing !== null) {
           // Reveal a preserved-but-hidden tab in the strip without activating
-          // it; an already-visible tab is left exactly where it is.
-          if (!get().openTabOrder.includes(existing)) {
-            set((current) =>
-              current.openTabOrder.includes(existing)
-                ? current
-                : { openTabOrder: [...current.openTabOrder, existing] },
-            );
-          }
+          // it; an already-visible tab is left exactly where it is. The
+          // functional updater is the single guard - it no-ops (returns the
+          // same state, which Zustand bails on) when the tab is already shown.
+          set((current) =>
+            current.openTabOrder.includes(existing)
+              ? current
+              : { openTabOrder: [...current.openTabOrder, existing] },
+          );
           return existing;
         }
         const tab = createEpicViewTab(epicId, name);
@@ -1004,7 +1004,7 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         return state.openEpicTab(epicId, name ?? UNTITLED_EPIC_TITLE);
       },
 
-      firstTabIdForEpic: (epicId) => resolveTabIdForEpic(get(), epicId),
+      resolveTabIdForEpic: (epicId) => resolveTabIdForEpic(get(), epicId),
 
       openTileInTab: (tabId, node) => {
         set((state) =>


### PR DESCRIPTION
## Summary

Replaces the default OS/Electron right-click "Copy Link" on history rows (which copied the in-app href) with a custom Radix context menu, and fixes "Open in New Window" for an epic already open in the current window.

Applies to all three surfaces that share the history row: the History overlay, the `/epics` tab, and the home-embedded recent list.

## Changes

**Custom right-click menu**
- **Open in Background** — opens the epic tab behind the current surface without switching or closing it (new `openEpicTabInBackground` canvas action; no-op if already open). Hidden for **phase** rows, whose migration route (`migrationSource=phase`) a plain canvas tab can't carry.
- **Open in New Window** — routes through `useEpicOpenInNewWindowFlow`, so an epic already open **in this window** is popped out via the ownership-aware move flow, including its **unsynced-edits confirm dialog** — instead of silently focusing the current window (the bug). Epics open only elsewhere / nowhere, and all phases, delegate to `openEpicInNewWindow` (focus the owning window, else spawn a new one; phases keep `migrationSource=phase`). Hidden in web mode.

**Bug fixed**
Previously, right-clicking a history row whose epic was already open in the current window's tab strip and choosing "Open in New Window" did nothing — the action called `requestFocus(bridge.windowId)` on the already-focused window. It now pops the tab out to a new window.

**Cleanups / centralization**
- Removed the dead focus-self branch + `isEpicOpenInThisWindow` from `openEpicInNewWindow` (the open-here case is now handled by the flow).
- Extracted `createEpicViewTab` + `appendedEpicTabState` so `openEpicTab` and `openEpicTabInBackground` share one tab-append payload (~45 lines of duplication removed).

## Verification
- `bun run --filter @traycer-clients/gui-app compile` — clean
- ESLint + `react-doctor` on changed files — clean
- Tests: canvas store + panel + new-window action (46) and `components/layout` + `stores/tabs` regression net (116) — all pass. New tests cover menu gating (epic vs phase), move-flow routing (open-here / elsewhere / nowhere / phase), and the background action.