### PR TITLE
perf(gui-app): make checkpoint overlap scan linear

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
@@ -2168,6 +2168,51 @@ describe("useRenderedMessages", () => {
     expect(group.hasLaterOverlappingChanges).toBe(true);
   });
 
+  it("detects a later overlapping change across an intervening unrelated turn", () => {
+    // turn-1 edits app.ts, turn-2 edits an unrelated file, turn-3 edits app.ts
+    // again. The overlap for turn-1 is non-adjacent (it is separated from the
+    // later touch by turn-2), so the warning must still surface.
+    const manifest = checkpointManifest("turn-1", "/repo/src/app.ts");
+    const unrelatedManifest = checkpointManifest(
+      "turn-2",
+      "/repo/src/other.ts",
+    );
+    const laterManifest = checkpointManifest("turn-3", "/repo/src/app.ts");
+    const assistant: Message = {
+      ...assistantMessage("turn-1", 2000),
+      blocks: [fileChangeBlock("/repo/src/app.ts")],
+    };
+
+    const { result } = renderHook(() =>
+      useRenderedMessages(
+        {
+          messages: [assistant],
+          events: [
+            checkpointEvent(manifest),
+            checkpointEvent(unrelatedManifest),
+            checkpointEvent(laterManifest),
+          ],
+          pendingUserMessages: [],
+          liveAssistantMessage: null,
+          activeTurn: null,
+          runStatus: "idle",
+          ...BINDING,
+        },
+        displayContext,
+      ),
+    );
+
+    const segments = result.current[0]?.segments ?? [];
+    const group = segments[segments.length - 1];
+
+    expect(group.kind).toBe("file_change_group");
+    if (group.kind !== "file_change_group") {
+      throw new Error("expected file change group");
+    }
+    expect(group.checkpointManifest?.checkpointId).toBe("turn-1");
+    expect(group.hasLaterOverlappingChanges).toBe(true);
+  });
+
   it("holds back the file change group until the assistant turn completes", () => {
     const manifest = checkpointManifest("turn-1", "/repo/src/app.ts");
     const assistant: Message = {

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -2370,24 +2370,30 @@ function isParsedCheckpointManifest(
 function overlappingCheckpointIdsFor(
   checkpoints: ReadonlyArray<ParsedCheckpointManifest>,
 ): ReadonlySet<string> {
+  // Only real changes drive the "modified again in later turns" note:
+  // a no-op entry isn't part of this turn's change set and isn't restored,
+  // so an overlap with one would make the cumulative warning misleading.
+  //
+  // Record, per file path, the index of the last checkpoint that touches it.
+  // A checkpoint then overlaps iff any path it touches is touched again by a
+  // later checkpoint - i.e. that path's last-touch index is past this one.
+  // One forward pass plus one scan keeps this O(checkpoints * entries) instead
+  // of the quadratic pairwise comparison this hook reran on every event.
+  const lastTouchIndexByPath = new Map<string, number>();
+  checkpoints.forEach((checkpoint, index) => {
+    checkpoint.manifest.entries
+      .filter((entry) => !isNoOpCheckpointEntry(entry))
+      .forEach((entry) => {
+        lastTouchIndexByPath.set(entry.filePath, index);
+      });
+  });
   return new Set(
     checkpoints.flatMap((checkpoint, index) => {
-      // Only real changes drive the "modified again in later turns" note:
-      // a no-op entry isn't part of this turn's change set and isn't restored,
-      // so an overlap with one would make the cumulative warning misleading.
-      const filePaths = new Set(
-        checkpoint.manifest.entries
-          .filter((entry) => !isNoOpCheckpointEntry(entry))
-          .map((entry) => entry.filePath),
+      const touchedLater = checkpoint.manifest.entries.some(
+        (entry) =>
+          !isNoOpCheckpointEntry(entry) &&
+          (lastTouchIndexByPath.get(entry.filePath) ?? index) > index,
       );
-      const touchedLater = checkpoints
-        .slice(index + 1)
-        .some((later) =>
-          later.manifest.entries.some(
-            (entry) =>
-              !isNoOpCheckpointEntry(entry) && filePaths.has(entry.filePath),
-          ),
-        );
       return touchedLater ? [checkpoint.manifest.checkpointId] : [];
     }),
   );


### PR DESCRIPTION
## Summary

`overlappingCheckpointIdsFor` (in `clients/gui-app/src/stores/chats/rendered-messages.ts`) compared every checkpoint against all later ones (`slice(index + 1)` + nested `some`), making `checkpointManifestViewsFromEvents` **O(checkpoints² × entries)**. That runs inside a `useMemo` keyed on `input.events` in `useRenderedMessages`, so it re-runs on every chat event — and the checkpoint count grows unbounded over a long session, so each new event gets progressively more expensive to render.

This precomputes, in a single forward pass, the last checkpoint index that touches each file path, then flags a checkpoint as overlapping iff any path it touches has a later last-touch index. Same result, **O(checkpoints × entries)**.

Behaviour is identical: no-op entries are still excluded, and a checkpoint overlaps iff one of its real paths is touched by any later checkpoint. Verified equivalent to the previous implementation over 200k randomized inputs (zero divergence), plus a new regression test covering a non-adjacent overlap — a file re-touched across an intervening unrelated turn.

## Related issue

n/a

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass — not run locally (pre-commit not installed); lint + format pass and the diff is plain TS
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
