### PR TITLE
fix(rate-limit): carry the selected account on the rate-limit-usage q…

### DIFF
--- a/clients/gui-app/src/hooks/host/use-host-rate-limit-usage-query.ts
+++ b/clients/gui-app/src/hooks/host/use-host-rate-limit-usage-query.ts
@@ -1,8 +1,6 @@
-import type { RateLimitUsageRequest } from "@traycer/protocol/host";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
-
-const RATE_LIMIT_USAGE_REQUEST: RateLimitUsageRequest = {};
+import { useAccountContextStore } from "@/stores/auth/account-context-store";
 
 /**
  * Live artifact rate-limit usage for the default host. Default-host scoped, like
@@ -13,10 +11,11 @@ const RATE_LIMIT_USAGE_REQUEST: RateLimitUsageRequest = {};
  */
 export function useHostRateLimitUsageQuery() {
   const client = useHostClient();
+  const accountContext = useAccountContextStore((s) => s.accountContext);
   return useHostQuery<HostRpcRegistry, "host.getRateLimitUsage">({
     client,
     method: "host.getRateLimitUsage",
-    params: RATE_LIMIT_USAGE_REQUEST,
+    params: { accountContext },
     options: {
       retry: false,
     },

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -1,6 +1,14 @@
 import { z } from "zod";
+import {
+  DEFAULT_ACCOUNT_CONTEXT,
+  accountContextSchema,
+} from "@traycer/protocol/common/schemas";
 
-export const rateLimitUsageRequestSchema = z.object({}).strict();
+export const rateLimitUsageRequestSchema = z
+  .object({
+    accountContext: accountContextSchema.default(DEFAULT_ACCOUNT_CONTEXT),
+  })
+  .strict();
 export type RateLimitUsageRequest = z.infer<typeof rateLimitUsageRequestSchema>;
 
 // Mirrors the aperture rate-limit shape defined in an internal shared package


### PR DESCRIPTION
…uery

The host rate-limit-usage query addressed the caller's personal bucket, but a team-billed turn drains aperture under the team's tier - so RateLimitView showed the wrong/zero usage for team accounts. Thread the active accountContext through the request schema (defaulted for back-compat) and the gui query, so the host can forward it to the server's read.

## Summary

<!-- What does this change, and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
