### PR TITLE
Support bundled Windows host zip archives

### DIFF
--- a/clients/traycer-cli/src/installer/__tests__/bundled-host.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/bundled-host.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const osMock = vi.hoisted(() => ({
+  platform: vi.fn(),
+  arch: vi.fn(),
+}));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, platform: osMock.platform, arch: osMock.arch };
+});
+
+import { resolveBundledHostArchive } from "../bundled-host";
+
+let scratchRoot: string;
+let originalExecPath: string;
+
+beforeEach(() => {
+  scratchRoot = mkdtempSync(join(tmpdir(), "traycer-bundled-host-"));
+  originalExecPath = process.execPath;
+  Object.defineProperty(process, "execPath", {
+    value: join(scratchRoot, "traycer.exe"),
+    configurable: true,
+  });
+  osMock.platform.mockReset();
+  osMock.arch.mockReset();
+});
+
+afterEach(() => {
+  Object.defineProperty(process, "execPath", {
+    value: originalExecPath,
+    configurable: true,
+  });
+  rmSync(scratchRoot, { recursive: true, force: true });
+  vi.clearAllMocks();
+});
+
+describe("resolveBundledHostArchive", () => {
+  it("resolves bundled Windows host zips next to the CLI binary", async () => {
+    osMock.platform.mockReturnValue("win32");
+    osMock.arch.mockReturnValue("x64");
+    const archive = join(scratchRoot, "host-runtime-win32-x64.zip");
+    writeFileSync(archive, "");
+
+    await expect(resolveBundledHostArchive()).resolves.toBe(archive);
+  });
+
+  it("resolves Windows arm64 to the x64 host archive", async () => {
+    osMock.platform.mockReturnValue("win32");
+    osMock.arch.mockReturnValue("arm64");
+    const archive = join(scratchRoot, "host-runtime-win32-x64.zip");
+    writeFileSync(archive, "");
+
+    await expect(resolveBundledHostArchive()).resolves.toBe(archive);
+  });
+
+  it("keeps tarball lookup for non-Windows platforms", async () => {
+    osMock.platform.mockReturnValue("darwin");
+    osMock.arch.mockReturnValue("arm64");
+    const archive = join(scratchRoot, "host-runtime-darwin-arm64.tar.gz");
+    writeFileSync(archive, "");
+
+    await expect(resolveBundledHostArchive()).resolves.toBe(archive);
+  });
+});

--- a/clients/traycer-cli/src/installer/bundled-host.ts
+++ b/clients/traycer-cli/src/installer/bundled-host.ts
@@ -17,12 +17,15 @@ import { dirname, join } from "node:path";
 // staged CLI binary. In those cases callers fall back to the registry
 // (or an explicit `--from`).
 //
-// The filename mirrors the build output in
-// scripts/desktop-install-cloud.js (`hostArchivePath`):
-// `host-runtime-<process.platform>-<process.arch>.tar.gz`.
+// The filenames mirror host release packaging: macOS/Linux use tarballs,
+// while Windows uses a zip. Windows arm64 resolves to the x64 host runtime
+// because there is no native Windows arm64 host.
 export async function resolveBundledHostArchive(): Promise<string | null> {
-  const fileName = `host-runtime-${osPlatform()}-${osArch()}.tar.gz`;
-  const candidate = join(dirname(process.execPath), fileName);
+  const platform = osPlatform();
+  const arch = platform === "win32" && osArch() === "arm64" ? "x64" : osArch();
+  const baseName = `host-runtime-${platform}-${arch}`;
+  const extension = platform === "win32" ? ".zip" : ".tar.gz";
+  const candidate = join(dirname(process.execPath), `${baseName}${extension}`);
   try {
     await access(candidate, constants.R_OK);
     return candidate;


### PR DESCRIPTION
## Summary
- resolve bundled Windows host archives using the release-format `.zip` name
- map Windows ARM lookup to the supported x64 host archive
- add focused resolver coverage for Windows zip and non-Windows tarball lookup

## Verification
- bun run --cwd traycer/clients/traycer-cli test src/installer/__tests__/bundled-host.test.ts
- bun run --cwd traycer/clients/traycer-cli compile