### PR TITLE
fix(gui-app): settle in-flight attachment reads on epic dispose

### DIFF
--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/store.test.ts
@@ -2281,4 +2281,37 @@ describe("createOpenEpicStore", () => {
       opened.dispose();
     });
   });
+
+  it("settles an in-flight attachment read when disposed without an abort", async () => {
+    const { factory } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    // Park a waiter on a hash that has not synced in yet, then dispose the
+    // session without firing the caller's abort signal - the path the
+    // registry's MRU prune takes. The promise must still resolve (null) and
+    // the waiter's observer must unbind, rather than dangling on the
+    // destroyed doc forever.
+    const controller = new AbortController();
+    let settled = false;
+    const pending = opened.store
+      .getState()
+      .readAttachmentBytes("missing-hash", controller.signal)
+      .then((bytes) => {
+        settled = true;
+        return bytes;
+      });
+
+    opened.dispose();
+
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(settled).toBe(true);
+    expect(await pending).toBeNull();
+  });
 });

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -547,6 +547,7 @@ export function createOpenEpicStore(
   type AttachmentReadWaiter = {
     readonly hash: string;
     readonly onChange: () => void;
+    readonly settle: (bytes: Uint8Array | null) => void;
     observedMap: Y.Map<unknown> | null;
   };
   const attachmentReadWaiters = new Set<AttachmentReadWaiter>();
@@ -1874,6 +1875,13 @@ export function createOpenEpicStore(
           dispose: () => {
             if (disposed) return;
             disposed = true;
+            // Settle any in-flight attachment reads (resolve null) so their
+            // observers unbind from the live doc and their promises don't
+            // dangle forever - the caller's abort signal isn't guaranteed to
+            // fire when a session is disposed by the registry's MRU prune.
+            // Must run before destroyReplica so the unobserve targets a live
+            // doc.
+            [...attachmentReadWaiters].forEach((waiter) => waiter.settle(null));
             unsubscribeAuthUserId?.();
             unsubscribeAuthUserId = null;
             projector.detach();
@@ -1904,17 +1912,17 @@ export function createOpenEpicStore(
                 observedMap: null,
                 onChange: () => {
                   const bytes = waiter.observedMap?.get(hash);
-                  if (bytes instanceof Uint8Array) settle(bytes);
+                  if (bytes instanceof Uint8Array) waiter.settle(bytes);
+                },
+                settle: (bytes: Uint8Array | null): void => {
+                  if (!attachmentReadWaiters.has(waiter)) return;
+                  attachmentReadWaiters.delete(waiter);
+                  waiter.observedMap?.unobserve(waiter.onChange);
+                  signal.removeEventListener("abort", onAbort);
+                  resolve(bytes);
                 },
               };
-              const settle = (bytes: Uint8Array | null): void => {
-                if (!attachmentReadWaiters.has(waiter)) return;
-                attachmentReadWaiters.delete(waiter);
-                waiter.observedMap?.unobserve(waiter.onChange);
-                signal.removeEventListener("abort", onAbort);
-                resolve(bytes);
-              };
-              const onAbort = (): void => settle(null);
+              const onAbort = (): void => waiter.settle(null);
               signal.addEventListener("abort", onAbort);
               attachmentReadWaiters.add(waiter);
               bindAttachmentWaiter(waiter);


### PR DESCRIPTION
## Summary

`readAttachmentBytes` (in `clients/gui-app/src/stores/epics/open-epic/store.ts`) parks a waiter that `observe`s the live Y.Doc `attachments` map and resolves once the bytes sync in. A waiter is torn down only by its own resolve or by the caller's abort signal.

`dispose()` tore down the projector, stream client, and replica (`destroyReplica(doc, awareness)`) but never drained `attachmentReadWaiters`. So when a read is still in flight at dispose time — e.g. a session disposed by the registry's MRU prune while an image is still streaming in (the method has no fixed give-up), where the caller's `AbortSignal` isn't guaranteed to fire — the waiter is left:

- with a `.observe(onChange)` still registered on the now-`destroy()`ed doc's `attachments` map, and
- a promise that never resolves (orphaned for the page lifetime).

This drains the waiter set in `dispose()` before the replica is destroyed: each pending read is settled to `null` and its observer unbound from the live map. `settle` is hoisted onto the waiter so `dispose` and the abort path share one teardown. The abort and resolve paths are unchanged.

Verified with a new test (added next to the other dispose tests): park a waiter on an unsynced hash, dispose without firing the abort signal, and assert the promise resolves to `null`. It fails before the fix (promise never settles) and passes after.

## Related issue

n/a

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass — not run locally (pre-commit not installed); lint + format pass and the diff is plain TS
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
