### PR TITLE
fix(gui-app): label report-issue dialog fields for screen readers

### DIFF
--- a/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/report-issue-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/report-issue-dialog.test.tsx
@@ -1,0 +1,47 @@
+import "../../../../../../__tests__/test-browser-apis";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { ReportIssueDialog } from "../report-issue-dialog";
+
+function renderDialog(): void {
+  const runnerHost = new MockRunnerHost({
+    signInUrl: "https://example.invalid/signin",
+    authnBaseUrl: "https://example.invalid",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+  const queryClient = new QueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RunnerHostProvider runnerHost={runnerHost}>
+        <ReportIssueDialog open onOpenChange={() => {}} support={null} />
+      </RunnerHostProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ReportIssueDialog", () => {
+  it("gives every field's control a programmatic label", () => {
+    renderDialog();
+
+    // queryByLabelText resolves only when the visible <Label> is associated
+    // with the control (htmlFor -> id), which is the accessibility contract
+    // this form must keep - screen readers announce the name and clicking the
+    // label focuses the input.
+    for (const fieldLabel of [
+      "Title",
+      "What happened?",
+      "Steps to reproduce",
+      "Expected behavior",
+      "Actual behavior",
+    ]) {
+      expect(screen.queryByLabelText(fieldLabel)).not.toBeNull();
+    }
+  });
+});

--- a/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, type ReactNode } from "react";
+import {
+  cloneElement,
+  useEffect,
+  useId,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { Bug } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -234,11 +241,17 @@ function Field({
 }: {
   label: string;
   required?: boolean;
-  children: ReactNode;
+  children: ReactElement<{ id?: string }>;
 }): ReactNode {
+  // Associate the visible label with its control so screen readers announce a
+  // name and clicking the label focuses the input. The control is passed as a
+  // single element child, so thread a generated id onto it and the label's
+  // htmlFor rather than asking every call site to wire its own.
+  const id = useId();
   return (
     <div className="grid gap-1.5">
       <Label
+        htmlFor={id}
         className={cn(
           "text-ui-sm",
           required && "after:ml-0.5 after:text-destructive after:content-['*']",
@@ -246,7 +259,7 @@ function Field({
       >
         {label}
       </Label>
-      {children}
+      {cloneElement(children, { id })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The `Field` wrapper in the desktop Report-an-Issue dialog (`clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx`) rendered a Radix `<Label>` with no `htmlFor` and the control as a sibling child, not nested. Radix `Label` associates only via `htmlFor`→`id` or by wrapping the control, so none of the five inputs (Title, What happened?, Steps to reproduce, Expected behavior, Actual behavior) had a programmatic label — only a placeholder.

Result: screen readers announce no name for any field (WCAG 1.3.1 / 4.1.2), and clicking a visible label doesn't focus its input. This form is opened from the command palette, the app menu, and update-error toasts.

`Field` now owns the association: it generates an id with `useId()`, sets it on the label's `htmlFor`, and threads it onto its single control child. Fixes all five fields with no call-site changes.

Added a test that renders the dialog and asserts each field is reachable by its accessible name (`queryByLabelText`); it fails before the change and passes after.

## Related issue

n/a

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass — not run locally (pre-commit not installed); lint + format pass and the diff is plain TS
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
