### PR TITLE
fix(gui-app): exclude resize handles from canvas focus navigation

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/__tests__/resize-handle.test.tsx
@@ -419,4 +419,17 @@ describe("<SplitResizeHandle />", () => {
     expect(handle.getAttribute("aria-valuemax")).toBe("100");
     expect(handle.tabIndex).toBe(0);
   });
+
+  it("tags its group id on data-resize-group-id, never data-group-id", () => {
+    const onCommitSizes =
+      vi.fn<(groupId: string, sizes: ReadonlyArray<number>) => void>();
+    const { handle } = renderHandle([0.5, 0.5], onCommitSizes);
+
+    // The handle carries the split GROUP id, but NOT under `data-group-id` -
+    // that attribute marks tab-group panes and is collected by the canvas
+    // focus-navigation `readTileRects`. A handle on `data-group-id` would win
+    // the spatial neighbour search and break cross-split focus navigation.
+    expect(handle.getAttribute("data-resize-group-id")).toBe(GROUP_ID);
+    expect(handle.hasAttribute("data-group-id")).toBe(false);
+  });
 });

--- a/clients/gui-app/src/components/epic-canvas/canvas/resize-handle.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/resize-handle.tsx
@@ -161,7 +161,13 @@ export function SplitResizeHandle(props: SplitResizeHandleProps) {
       aria-valuemax={100}
       aria-label="Resize pane"
       data-testid="split-resize-handle"
-      data-group-id={groupId}
+      // NOT `data-group-id`: that attribute marks tab-group panes, and the
+      // canvas focus-navigation `readTileRects` collects every `[data-group-id]`
+      // as a focus target. A handle sits exactly on the seam between two panes,
+      // so it would win the spatial neighbour search - but its id is a split
+      // GROUP id, not a pane id, so the focus update would silently no-op.
+      // Keep handles on their own attribute so focus nav never sees them.
+      data-resize-group-id={groupId}
       data-handle-index={index}
       className={cn(
         "relative z-10 shrink-0 bg-border ring-offset-background focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden",

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -685,7 +685,7 @@ function GroupedPanelBody(props: {
 /**
  * Synthetic group id for the section run's resize handles; the commit
  * callback maps fractions straight back to panel weights, so the id is only
- * surfaced on the handle's `data-group-id` for tests.
+ * surfaced on the handle's `data-resize-group-id` for tests.
  */
 const SECTION_RUN_GROUP_ID = "epic-left-panel-sections";
 /** Old `minSize="2rem"` floor, now enforced by the custom handle. */

--- a/clients/gui-app/src/lib/keybindings/__tests__/tile-geometry.test.ts
+++ b/clients/gui-app/src/lib/keybindings/__tests__/tile-geometry.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { findNeighbor, type TileRect } from "@/lib/keybindings/tile-geometry";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  findNeighbor,
+  readTileRects,
+  type TileRect,
+} from "@/lib/keybindings/tile-geometry";
 
 function rect(id: string, box: [number, number, number, number]): TileRect {
   const [x, y, width, height] = box;
@@ -68,5 +72,64 @@ describe("findNeighbor", () => {
     expect(findNeighbor(topR, tiles, "left")).toBe("topL");
     expect(findNeighbor(topL, tiles, "down")).toBe("bottom");
     expect(findNeighbor(topR, tiles, "down")).toBe("bottom");
+  });
+});
+
+// Regression: a split resize handle sits on the seam between two panes, so it
+// scores better than the true neighbour pane in `findNeighbor` (primaryGap 0
+// vs ~handle-width). It must therefore NOT be a focus target. The handle is
+// kept off `data-group-id` (it uses `data-resize-group-id`), so `readTileRects`
+// excludes it and downstream navigation lands on the neighbour pane - never on
+// the handle's split-group id, which no pane matches (a silent no-op).
+describe("readTileRects excludes split resize handles", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  function appendBox(
+    parent: HTMLElement,
+    attr: "data-group-id" | "data-resize-group-id",
+    id: string,
+    box: [number, number, number, number],
+  ): HTMLElement {
+    const [x, y, width, height] = box;
+    const el = document.createElement("div");
+    el.setAttribute(attr, id);
+    parent.append(el);
+    vi.spyOn(el, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(x, y, width, height),
+    );
+    return el;
+  }
+
+  it("collects panes only, so cross-split focus lands on the neighbour pane", () => {
+    // Real horizontal-split geometry (split-container.tsx, flex-row):
+    //   [ pane-A (grow) ][ handle w-px ][ pane-B (grow) ]
+    // The 1px handle sits exactly on the seam at x=499.5.
+    const container = document.createElement("div");
+    document.body.append(container);
+    appendBox(container, "data-group-id", "pane-A", [0, 0, 499.5, 600]);
+    appendBox(
+      container,
+      "data-resize-group-id",
+      "group-root",
+      [499.5, 0, 1, 600],
+    );
+    appendBox(container, "data-group-id", "pane-B", [500.5, 0, 499.5, 600]);
+
+    const rects = readTileRects(container);
+
+    // The handle's split-group id must be absent entirely.
+    expect([...rects.map((r) => r.id)].sort()).toEqual(["pane-A", "pane-B"]);
+    expect(rects.some((r) => r.id === "group-root")).toBe(false);
+
+    const paneA = rects.find((r) => r.id === "pane-A");
+    const paneB = rects.find((r) => r.id === "pane-B");
+    if (paneA === undefined || paneB === undefined) {
+      throw new Error("expected both pane rects to be collected");
+    }
+    expect(findNeighbor(paneA, rects, "right")).toBe("pane-B");
+    expect(findNeighbor(paneB, rects, "left")).toBe("pane-A");
   });
 });

--- a/clients/gui-app/src/lib/keybindings/tile-geometry.ts
+++ b/clients/gui-app/src/lib/keybindings/tile-geometry.ts
@@ -121,9 +121,17 @@ export function findNeighbor(
 }
 
 /**
- * Read the current tab-group layout from the DOM. Groups are rendered
+ * Read the current tab-group layout from the DOM. Panes are rendered
  * with `data-group-id` by `tab-group-view.tsx`; we query globally
  * within `root`.
+ *
+ * Invariant: every `data-group-id` value is a leaf PANE id. The pane wrapper
+ * plus its pane-scoped children (`tab-strip.tsx`, `pane-opener.tsx`) all reuse
+ * the owning pane's id, so duplicate ids here are harmless. Split resize
+ * handles must NOT use `data-group-id` - their id is a split-GROUP id that no
+ * pane matches, so a handle on the seam would win the `findNeighbor` search and
+ * make `setActivePane` silently no-op. Handles therefore carry
+ * `data-resize-group-id` instead (see `resize-handle.tsx`) and are excluded.
  */
 export function readTileRects(root: ParentNode): Array<TileRect> {
   const nodes = root.querySelectorAll<HTMLElement>("[data-group-id]");


### PR DESCRIPTION
## Problem

`Cmd+Alt+Arrow` group focus navigation (`group.focus.{up,down,left,right}`) never moved pane focus across groups/splits — in any direction.

## Root cause

Canvas focus navigation reads pane rectangles from the DOM via `readTileRects()` (`lib/keybindings/tile-geometry.ts`), which collects **every** `[data-group-id]` element. The split **resize handle** (`canvas/resize-handle.tsx`) also rendered `data-group-id`, but its value is the split **group** id, not a leaf pane id.

Because the 1px handle sits exactly on the seam between two panes, `findNeighbor()` scored it best (`primaryGap ≈ 0`, full orthogonal overlap) and returned the handle's group id. `setActivePane()` (`stores/epics/canvas/actions.ts`) then rejected it via `findPaneById(...) === null` and returned state unchanged — a silent no-op. A handle exists between every adjacent pair (including nested groups), so cross-split navigation was universally broken.

## Fix

Give resize handles their own `data-resize-group-id` attribute so `readTileRects` collects panes only. The handle still passes `groupId` to `onCommitSizes` for the resize commit; only the DOM marker name changed, and nothing reads the handle by `data-group-id`.

- `resize-handle.tsx`: `data-group-id` → `data-resize-group-id` (canvas + sidebar section-run handles share this component)
- `tile-geometry.ts`: documented the invariant on `readTileRects` (every `data-group-id` is a leaf pane id; handles are excluded)
- `epic-sidebar.tsx`: updated doc-comment reference
- `resize-handle.test.tsx`: assert the handle exposes `data-resize-group-id` and never `data-group-id`
- `tile-geometry.test.ts`: regression test — a handle on the seam is excluded by `readTileRects`, so `findNeighbor` lands on the neighbour pane

## Testing

- `bun run --cwd clients/gui-app compile` — clean
- `bun run --cwd clients/gui-app test` — 3148 passed, 1 skipped
- `pre-commit run --files <changed>` — all hooks pass (incl. nx-affected build / compile / lint / format)
