### PR TITLE
fix(gui-app): markdown copy fidelity + new-chat modal input height & Escape

### DIFF
--- a/clients/gui-app/__tests__/editor-core/build-artifact-extensions.test.ts
+++ b/clients/gui-app/__tests__/editor-core/build-artifact-extensions.test.ts
@@ -130,6 +130,40 @@ describe("buildArtifactExtensions", () => {
     editor.destroy();
   });
 
+  it("serializes a copied selection to markdown via clipboardTextSerializer", () => {
+    const editor = createArtifactEditor();
+    const md = [
+      "# Title",
+      "",
+      "- one",
+      "- two",
+      "",
+      "1. first",
+      "2. second",
+      "",
+    ].join("\n");
+    editor.commands.setContent(md, {
+      contentType: "markdown",
+      parseOptions: { preserveWhitespace: false },
+    });
+
+    // A select-all copy goes through ProseMirror's clipboard pipeline, which
+    // reads the `clipboardTextSerializer` contributed by `MarkdownClipboard`.
+    const { doc } = editor.state;
+    const { text } = editor.view.serializeForClipboard(
+      doc.slice(0, doc.content.size),
+    );
+
+    // Markers survive (default textContent serialization would drop them) and
+    // list items are not blank-line separated.
+    expect(text).toContain("# Title");
+    expect(text).toContain("- one\n- two");
+    expect(text).toContain("1. first");
+    expect(text).toContain("2. second");
+    expect(text).not.toContain("- one\n\n- two");
+    editor.destroy();
+  });
+
   it("pairs the artifact-room doc fragment with artifactRoom awareness - Collaboration binds to the artifact-room doc and CollaborationCaret binds to the same artifactRoom awareness", () => {
     // Per ticket 4a598302-…/Fix: GUI artifact-room-doc awareness and reconnect-safe
     // body edits - when the body fragment lives in a artifact-room doc, the

--- a/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
+++ b/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
@@ -20,6 +20,8 @@ import { cn } from "@/lib/utils";
 import { registerComposerFocus } from "@/lib/composer/composer-focus-registry";
 
 import { buildComposerExtensions } from "./editor/editor-config";
+import { mentionSuggestionPluginKey } from "./editor/extensions/mention-extension";
+import { slashSuggestionPluginKey } from "./editor/extensions/slash-command-extension";
 import { insertImageAttachmentsCommand } from "@/hooks/composer/use-composer-paste";
 import type { ImageAttachmentAttrs } from "./editor/extensions/image-attachment-extension";
 import type { ComposerPickerStore } from "./picker/composer-picker-store";
@@ -45,6 +47,14 @@ export interface ComposerPromptEditorHandle {
    * sequential segments append cleanly.
    */
   readonly insertDictatedText: (text: string) => void;
+  /**
+   * Fully exit whichever `@`/`/` suggestion picker is currently open (clearing
+   * the plugin's active range/decoration and closing the picker menu), and
+   * report whether one was open. Lets a surrounding surface (e.g. a dialog)
+   * treat Escape as "close the picker" without the editor's own keydown - see
+   * the New Conversation modal, where Radix would otherwise swallow the Escape.
+   */
+  readonly dismissActiveSuggestion: () => boolean;
 }
 
 export interface ComposerPromptEditorProps {
@@ -281,6 +291,22 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     [editor],
   );
 
+  const dismissActiveSuggestion = useCallback((): boolean => {
+    if (editor === null) return false;
+    // The store's `open` flips with the suggestion plugin's active state (the
+    // render's onStart/onExit drive it), so this gates on a picker actually
+    // showing. Dispatch the suggestion-exit meta to both plugin keys; the
+    // active one transitions to "stopped" - clearing its range/decoration and
+    // firing onExit, which closes the menu - and the inactive one ignores it.
+    if (!pickerStore.getState().open) return false;
+    editor.view.dispatch(
+      editor.state.tr
+        .setMeta(mentionSuggestionPluginKey, { exit: true })
+        .setMeta(slashSuggestionPluginKey, { exit: true }),
+    );
+    return true;
+  }, [editor, pickerStore]);
+
   useImperativeHandle(
     ref,
     () => ({
@@ -293,9 +319,11 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
       insertImageAttachments,
       removeImageAttachmentById,
       insertDictatedText,
+      dismissActiveSuggestion,
     }),
     [
       clear,
+      dismissActiveSuggestion,
       focus,
       focusAtEnd,
       getJSON,

--- a/clients/gui-app/src/components/chat/composer/editor/editor-config.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/editor-config.ts
@@ -16,6 +16,7 @@ import { AttachmentGroupNode } from "./extensions/attachment-group-extension";
 import { ImageAttachmentNode } from "./extensions/image-attachment-extension";
 import { ChatListKeymap } from "./extensions/chat-list-keymap";
 import { createChatPasteHandler } from "./extensions/chat-paste-handler";
+import { ChatCopySerializer } from "./extensions/chat-copy-serializer";
 
 export interface BuildComposerExtensionsArgs {
   readonly pickerStore: ComposerPickerStore;
@@ -57,5 +58,8 @@ export function buildComposerExtensions(
       pickerStore: args.pickerStore,
     }),
     createChatPasteHandler({ pickerStore: args.pickerStore }),
+    // Cmd+C / Cmd+X -> structured plain text (list markers, mentions, slash
+    // commands) instead of ProseMirror's default blank-line-joined textContent.
+    ChatCopySerializer,
   ];
 }

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-copy-serializer.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-copy-serializer.ts
@@ -1,0 +1,29 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+import { composerClipboardTextSerializer } from "@/lib/composer/composer-clipboard";
+
+/**
+ * Makes Cmd+C / Cmd+X from the composer write structured plain text (list
+ * markers, mentions, slash commands) to the clipboard instead of ProseMirror's
+ * default `textContent` - which drops `-` / `1.` markers and double-spaces every
+ * block.
+ *
+ * Contributed as a ProseMirror plugin prop (read by `view.someProp`) rather than
+ * via the React `editorProps` so the behavior travels with the extension bundle
+ * and is exercised by `serializeForClipboard` in tests.
+ */
+export const ChatCopySerializer = Extension.create({
+  name: "chatCopySerializer",
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("chatCopySerializer"),
+        props: {
+          clipboardTextSerializer: (slice) =>
+            composerClipboardTextSerializer(slice),
+        },
+      }),
+    ];
+  },
+});

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/mention-extension.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/mention-extension.ts
@@ -1,5 +1,6 @@
 import { mergeAttributes, type Editor } from "@tiptap/core";
 import Mention from "@tiptap/extension-mention";
+import { PluginKey } from "@tiptap/pm/state";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 
 import {
@@ -19,6 +20,17 @@ import { dataAttributeMap, MENTION_ATTRIBUTE_NAMES } from "./attribute-helpers";
 export interface MentionExtensionDeps {
   readonly pickerStore: ComposerPickerStore;
 }
+
+/**
+ * Stable key for the `@` mention suggestion plugin. Exported (and pinned via the
+ * suggestion config below, overriding extension-mention's auto-generated key) so
+ * code outside the editor can imperatively exit an open suggestion by
+ * dispatching `setMeta(mentionSuggestionPluginKey, { exit: true })` - see the
+ * editor's `dismissActiveSuggestion` handle.
+ */
+export const mentionSuggestionPluginKey = new PluginKey(
+  "composer-mention-suggestion",
+);
 
 export function createMentionExtension(deps: MentionExtensionDeps) {
   const ChatMention = Mention.extend({
@@ -60,6 +72,7 @@ export function createMentionExtension(deps: MentionExtensionDeps) {
     deleteTriggerWithBackspace: true,
     HTMLAttributes: { "data-composer-mention": "" },
     suggestion: {
+      pluginKey: mentionSuggestionPluginKey,
       char: "@",
       allowSpaces: false,
       allowedPrefixes: null,

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/slash-command-extension.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/slash-command-extension.ts
@@ -59,6 +59,16 @@ export const ChatSlashCommandNode = TiptapNode.create({
 
 const slashLeadingGuardKey = new PluginKey("composer-slash-leading-guard");
 
+/**
+ * Stable key for the `/` command suggestion plugin. Exported (and pinned via the
+ * Suggestion config below) so code outside the editor can imperatively exit an
+ * open suggestion by dispatching `setMeta(slashSuggestionPluginKey, { exit: true })`
+ * - see the editor's `dismissActiveSuggestion` handle.
+ */
+export const slashSuggestionPluginKey = new PluginKey(
+  "composer-slash-suggestion",
+);
+
 function slashLeadingGuardPlugin(): Plugin {
   return new Plugin({
     key: slashLeadingGuardKey,
@@ -115,6 +125,7 @@ export function createSlashSuggestionExtension(
       return [
         Suggestion({
           editor: this.editor,
+          pluginKey: slashSuggestionPluginKey,
           char: "/",
           allowSpaces: false,
           startOfLine: true,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 import { v4 as uuidv4 } from "uuid";
@@ -95,16 +102,6 @@ import {
   worktreeStagingKeyString,
 } from "@/stores/worktree/worktree-intent-staging-store";
 import { useWorktreeIntentMemoryStore } from "@/stores/worktree/worktree-intent-memory-store";
-
-/**
- * Compact, bounded editor sizing for the dialog. The base composer editor grows
- * unbounded (see `COMPOSER_EDITOR_CLASSNAME`); the modal caps it so a long
- * prompt scrolls inside the dialog rather than stretching it.
- */
-const NEW_CONVERSATION_EDITOR_CLASSNAME = cn(
-  COMPOSER_EDITOR_CLASSNAME,
-  "max-h-[4.5rem]",
-);
 
 /**
  * Isolated subscriber for the live draft content. The editor rewrites content
@@ -248,12 +245,27 @@ function NewConversationModalDialog(props: {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
+  // The composer's @/slash picker (see `ComposerMenu`) is a plain portalled
+  // floating menu, not a Radix dismissable layer, so Radix can't coordinate
+  // Escape with it. Radix's escape listener runs first (document, capture) and
+  // dismisses the dialog; preventing that needs `preventDefault`, but that also
+  // suppresses ProseMirror's keydown (it ignores defaultPrevented events), so
+  // the picker's own Escape-close never fires. The body publishes an imperative
+  // dismiss here: while a picker is open we close it ourselves and preventDefault
+  // (first Escape closes only the picker); once it's closed the call returns
+  // false and Escape falls through to dismiss the dialog (second Escape).
+  const dismissPickerRef = useRef<(() => boolean) | null>(null);
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent
         className="w-[min(92vw,48rem)] max-w-[min(92vw,48rem)] gap-3 p-4 sm:max-w-[min(92vw,48rem)]"
         data-testid="epic-sidebar-new-conversation-modal"
         showCloseButton={false}
+        onEscapeKeyDown={(event) => {
+          if (dismissPickerRef.current?.() === true) {
+            event.preventDefault();
+          }
+        }}
       >
         <DialogClose asChild>
           <Button
@@ -275,6 +287,7 @@ function NewConversationModalDialog(props: {
               epicId={props.epicId}
               tabId={props.tabId}
               placement={props.placement}
+              dismissPickerRef={dismissPickerRef}
               onSubmitted={() => props.onOpenChange(false)}
             />
           </SurfaceActivityProvider>
@@ -288,15 +301,27 @@ function NewConversationModalBody(props: {
   readonly epicId: string;
   readonly tabId: string;
   readonly placement: ConversationTilePlacement;
+  readonly dismissPickerRef: RefObject<(() => boolean) | null>;
   readonly onSubmitted: () => void;
 }) {
-  const { epicId, tabId, placement, onSubmitted } = props;
+  const { epicId, tabId, placement, dismissPickerRef, onSubmitted } = props;
   const permissionRole = useEpicPermissionRole();
   const connectionStatus = useEpicConnectionStatus();
   const isDisconnected = connectionStatus === "closed";
   const canMutate = isEditableRole(permissionRole) && !isDisconnected;
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null);
   const [pickerStore] = useState(() => createComposerPickerStore());
+  // Bridge the editor's imperative picker dismiss up to the dialog's Escape
+  // handler (see `NewConversationModalDialog`). Returns true when a picker was
+  // open and got closed, so the dialog keeps itself open for that Escape.
+  // Cleared on unmount so a stale closure can never block dismissing the dialog.
+  useEffect(() => {
+    dismissPickerRef.current = () =>
+      editorRef.current?.dismissActiveSuggestion() ?? false;
+    return () => {
+      dismissPickerRef.current = null;
+    };
+  }, [dismissPickerRef]);
   const latestWorkspaceSeed = useLatestConversationWorkspaceSeed(epicId);
   const seed = useNewConversationModalSeed(epicId, latestWorkspaceSeed);
   // Subscribe to the NON-content draft fields only. `content` is rewritten on
@@ -647,7 +672,7 @@ function NewConversationModalBody(props: {
       toolbarStore={toolbarStore}
       composerMode={draftComposerMode}
       chatEditorIsActive={chatComposerActive}
-      editorClassName={NEW_CONVERSATION_EDITOR_CLASSNAME}
+      editorClassName={COMPOSER_EDITOR_CLASSNAME}
       initialContent={initialContent}
       initialSelection={null}
       canSubmit={canSubmit}

--- a/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
@@ -499,6 +499,7 @@ function editorHandleForPrompt(prompt: string): ComposerPromptEditorHandle {
     insertImageAttachments: () => undefined,
     removeImageAttachmentById: () => undefined,
     insertDictatedText: () => undefined,
+    dismissActiveSuggestion: () => false,
   };
 }
 

--- a/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
@@ -680,6 +680,7 @@ function editorHandleForPrompt(prompt: string): ComposerPromptEditorHandle {
     insertImageAttachments: () => undefined,
     removeImageAttachmentById: () => undefined,
     insertDictatedText: () => undefined,
+    dismissActiveSuggestion: () => false,
   };
 }
 

--- a/clients/gui-app/src/components/home/composer/composer-editor-classnames.ts
+++ b/clients/gui-app/src/components/home/composer/composer-editor-classnames.ts
@@ -2,9 +2,11 @@ import { cn } from "@/lib/utils";
 
 /**
  * Base editor sizing shared by every composer surface. It intentionally has NO
- * max-height so the landing composer keeps growing with content; surfaces that
- * need a compact, bounded editor (e.g. the New Conversation modal) compose this
- * with their own `max-h-*` and pass it via `editorClassName`.
+ * max-height of its own, so the editor element's baked-in
+ * `max-h-[min(50vh,15rem)]` (see `composer-prompt-editor.tsx`) governs the grow
+ * ceiling: the editor grows with content up to that bound, then scrolls
+ * internally. Surfaces that need a tighter, compact editor can compose this with
+ * their own `max-h-*` and pass it via `editorClassName`.
  *
  * Kept in its own leaf module (not `composer-body.tsx`) so the component file
  * exports only components - a non-component export there would defeat Fast

--- a/clients/gui-app/src/editor-core/extensions/build-artifact-extensions.ts
+++ b/clients/gui-app/src/editor-core/extensions/build-artifact-extensions.ts
@@ -23,6 +23,7 @@ import { FencePromotionExtension } from "../nodes/shared/fence-promotion-extensi
 import { ThreadAnchor } from "./thread-anchor";
 import { CommentDecorationsExtension } from "./comment-decorations-extension";
 import { CommentShortcutExtension } from "./comment-shortcut-extension";
+import { MarkdownClipboard } from "./markdown-clipboard-extension";
 
 /**
  * `@tiptap/extension-collaboration-caret` only reads `provider.awareness` off
@@ -90,6 +91,11 @@ export function buildArtifactExtensions(
       codeBlock: false,
     }),
     Markdown,
+    // Cmd+C / Cmd+X -> Markdown (via the `Markdown` manager above) instead of
+    // ProseMirror's default textContent, which drops `#` / `-` / `1.` / fences
+    // and double-spaces every block. Registered right after `Markdown` so the
+    // manager its serializer reads is already in storage.
+    MarkdownClipboard,
     Collaboration.configure({ document: doc, fragment }),
     CollaborationCaret.configure({
       provider,

--- a/clients/gui-app/src/editor-core/extensions/markdown-clipboard-extension.ts
+++ b/clients/gui-app/src/editor-core/extensions/markdown-clipboard-extension.ts
@@ -1,0 +1,39 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+import { sliceToDocJson } from "@/lib/editor/prosemirror-json";
+
+/**
+ * Makes Cmd+C / Cmd+X from an artifact editor copy Markdown instead of
+ * ProseMirror's default `textContent` - which drops `#`, `-`, `1.`, fences and
+ * double-spaces every block.
+ *
+ * The copied slice is wrapped into a doc and run through the same
+ * `@tiptap/markdown` manager that backs `editor.getMarkdown()`, so headings,
+ * lists, task lists, tables and mermaid / wireframe fences all serialize through
+ * their registered renderers. Contributed as a ProseMirror plugin prop (read by
+ * `view.someProp`) so the behavior travels with the extension bundle.
+ *
+ * Must be registered alongside the `Markdown` extension, whose storage owns the
+ * manager.
+ */
+export const MarkdownClipboard = Extension.create({
+  name: "markdownClipboard",
+  addProseMirrorPlugins() {
+    const { editor } = this;
+    return [
+      new Plugin({
+        key: new PluginKey("markdownClipboard"),
+        props: {
+          clipboardTextSerializer: (slice) => {
+            const doc = sliceToDocJson(slice);
+            if (doc === null) {
+              return slice.content.textBetween(0, slice.content.size, "\n");
+            }
+            return editor.storage.markdown.manager.serialize(doc);
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/clients/gui-app/src/lib/composer/__tests__/composer-clipboard.test.ts
+++ b/clients/gui-app/src/lib/composer/__tests__/composer-clipboard.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from "vitest";
+import { getSchema } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import {
   buildComposerClipboardHtml,
   composerClipboardPlainText,
+  composerClipboardTextSerializer,
   parseComposerClipboardHtml,
 } from "@/lib/composer/composer-clipboard";
+
+function docNode(doc: JsonContent) {
+  return getSchema([StarterKit]).nodeFromJSON(doc);
+}
 
 const STRUCTURED_CONTENT: JsonContent = {
   type: "doc",
@@ -98,3 +105,50 @@ describe("composer clipboard helpers", () => {
     expect(html).toContain("- bullet one<br>- bullet two");
   });
 });
+
+describe("composerClipboardTextSerializer", () => {
+  it("keeps bullet and ordered markers when serializing a copied slice", () => {
+    // A select-all copy: the whole document.
+    const node = docNode({
+      type: "doc",
+      content: [
+        { type: "bulletList", content: [listItem("alpha"), listItem("beta")] },
+        {
+          type: "orderedList",
+          content: [listItem("first"), listItem("second")],
+        },
+      ],
+    });
+    const slice = node.slice(0, node.content.size);
+
+    // Default ProseMirror serialization would yield "alpha\n\nbeta\n\nfirst…"
+    // with the markers stripped; the structured serializer keeps them.
+    expect(composerClipboardTextSerializer(slice)).toBe(
+      ["- alpha", "- beta", "", "1. first", "2. second"].join("\n"),
+    );
+  });
+
+  it("does not inject blank lines into an inline (within-paragraph) selection", () => {
+    const node = docNode({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "hello world" }] },
+      ],
+    });
+    // Positions 2..11 land inside the single text node -> "ello worl".
+    const slice = node.slice(2, 11);
+    expect(composerClipboardTextSerializer(slice)).toBe("ello worl");
+  });
+
+  it("returns an empty string for an empty slice", () => {
+    const node = docNode({ type: "doc", content: [{ type: "paragraph" }] });
+    expect(composerClipboardTextSerializer(node.slice(0, 0))).toBe("");
+  });
+});
+
+function listItem(text: string): JsonContent {
+  return {
+    type: "listItem",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}

--- a/clients/gui-app/src/lib/composer/composer-clipboard.ts
+++ b/clients/gui-app/src/lib/composer/composer-clipboard.ts
@@ -1,3 +1,4 @@
+import type { Slice } from "@tiptap/pm/model";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import {
@@ -5,6 +6,11 @@ import {
   numberValue,
   slashCommandPlainTextFromAttrs,
 } from "@/lib/composer/tiptap-json-content";
+import {
+  isJsonContent,
+  isRecord,
+  sliceToDocJson,
+} from "@/lib/editor/prosemirror-json";
 
 const CLIPBOARD_SCHEMA = "traycer.composer-content";
 const CLIPBOARD_VERSION = 1;
@@ -57,6 +63,19 @@ export function composerClipboardPlainText(content: JsonContent): string {
   return normalizeClipboardText(
     composerClipboardPlainTextFromNode(content, { listDepth: 0 }),
   );
+}
+
+/**
+ * `clipboardTextSerializer` for the chat composer editor. ProseMirror's default
+ * serializer emits node `textContent` joined by blank lines, which drops list
+ * markers and double-spaces every block. Routing the copied slice through the
+ * composer's structured plain-text serializer instead keeps `-` / `1.` markers,
+ * mentions, and slash commands intact on Cmd+C / Cmd+X.
+ */
+export function composerClipboardTextSerializer(slice: Slice): string {
+  const doc = sliceToDocJson(slice);
+  if (doc === null) return "";
+  return composerClipboardPlainText(doc);
 }
 
 export function buildComposerClipboardHtml(
@@ -257,41 +276,4 @@ function escapeHtmlText(value: string): string {
 
 function escapeHtmlAttr(value: string): string {
   return escapeHtmlText(value).replace(/"/g, "&quot;").replace(/'/g, "&#39;");
-}
-
-function isJsonContent(value: unknown, depth: number): value is JsonContent {
-  if (depth > 100) return false;
-  if (!isRecord(value)) return false;
-  if (!isStringOrUndefined(value.type)) return false;
-  if (!isStringOrUndefined(value.text)) return false;
-  if (!isAttrsOrUndefined(value.attrs)) return false;
-  if (!isMarksOrUndefined(value.marks)) return false;
-  const content = value.content;
-  if (content === undefined) return true;
-  return (
-    Array.isArray(content) &&
-    content.every((child) => isJsonContent(child, depth + 1))
-  );
-}
-
-function isStringOrUndefined(value: unknown): boolean {
-  return value === undefined || typeof value === "string";
-}
-
-function isAttrsOrUndefined(value: unknown): boolean {
-  return value === undefined || isRecord(value);
-}
-
-function isMarksOrUndefined(value: unknown): boolean {
-  if (value === undefined) return true;
-  if (!Array.isArray(value)) return false;
-  return value.every((mark) => {
-    if (!isRecord(mark)) return false;
-    if (typeof mark.type !== "string") return false;
-    return isAttrsOrUndefined(mark.attrs);
-  });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/clients/gui-app/src/lib/editor/prosemirror-json.ts
+++ b/clients/gui-app/src/lib/editor/prosemirror-json.ts
@@ -1,0 +1,66 @@
+import type { Slice } from "@tiptap/pm/model";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+
+/**
+ * Wrap a copied ProseMirror slice into a `doc`-shaped JSON tree so a block-aware
+ * serializer (markdown / structured plain text) can walk it the same way it
+ * walks a whole document.
+ *
+ * A slice whose top level is inline (e.g. a fragment of bare text with no
+ * enclosing block) is wrapped in a paragraph first, so the serializer emits one
+ * block instead of treating each text run as its own block - the latter injects
+ * a blank line between runs.
+ *
+ * Returns `null` for an empty slice. `Fragment.toJSON()` is typed `any` by
+ * ProseMirror; it is funnelled through `unknown` and the `isJsonContent` guard
+ * so no `any` escapes into the typed surface.
+ */
+export function sliceToDocJson(slice: Slice): JsonContent | null {
+  const firstChild = slice.content.firstChild;
+  if (firstChild === null) return null;
+  const content: unknown = slice.content.toJSON();
+  const doc: unknown = firstChild.isInline
+    ? { type: "doc", content: [{ type: "paragraph", content }] }
+    : { type: "doc", content };
+  return isJsonContent(doc, 0) ? doc : null;
+}
+
+export function isJsonContent(
+  value: unknown,
+  depth: number,
+): value is JsonContent {
+  if (depth > 100) return false;
+  if (!isRecord(value)) return false;
+  if (!isStringOrUndefined(value.type)) return false;
+  if (!isStringOrUndefined(value.text)) return false;
+  if (!isAttrsOrUndefined(value.attrs)) return false;
+  if (!isMarksOrUndefined(value.marks)) return false;
+  const content = value.content;
+  if (content === undefined) return true;
+  return (
+    Array.isArray(content) &&
+    content.every((child) => isJsonContent(child, depth + 1))
+  );
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringOrUndefined(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isAttrsOrUndefined(value: unknown): boolean {
+  return value === undefined || isRecord(value);
+}
+
+function isMarksOrUndefined(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!Array.isArray(value)) return false;
+  return value.every((mark) => {
+    if (!isRecord(mark)) return false;
+    if (typeof mark.type !== "string") return false;
+    return isAttrsOrUndefined(mark.attrs);
+  });
+}


### PR DESCRIPTION
## Summary

Two independent GUI fixes (one commit each).

### 1. Preserve markdown formatting when copying from editors
Neither the chat composer nor the collaborative artifact editor registered a `clipboardTextSerializer`, so ProseMirror fell back to `textBetween(…, "\n\n")` on copy/select-all — **stripping list markers and headings and double-spacing every block**.

Each editor now contributes a `clipboardTextSerializer` via a ProseMirror plugin (so the behavior ships with the extension bundle and is exercised by `serializeForClipboard`):
- **Composer** reuses the existing `composerClipboardPlainText` (mentions, slash commands, attachments, nested list markers).
- **Collab artifact editor** serializes through the markdown manager (headings, lists, tables, task lists, mermaid/wireframe fences).

A shared `sliceToDocJson` helper (+ JSON type guard) wraps a copied slice into a `doc` tree without leaking ProseMirror's `any`-typed `toJSON()`.

### 2. New-chat modal: input height + Escape handling
The new-conversation modal (sidebar **+**, in-pane PaneOpener, ⌘K) capped its composer at `max-h-[4.5rem]`, so long prompts hit an internal scrollbar after ~2 lines. It now reuses `COMPOSER_EDITOR_CLASSNAME` and grows like the landing/epic composer — comfortable default → `min(50vh,15rem)` → internal scroll.

It also fixes Escape handling for the `@`/`/` picker: the picker renders as a non-Radix portal, so a single Escape both closed the picker **and** cascaded to dismiss the Dialog. Now: explicit suggestion plugin keys + an imperative `dismissActiveSuggestion()` on the editor handle, and the Dialog's `onEscapeKeyDown` consumes Escape only when a picker is open. First Escape closes just the picker; second closes the modal. Landing/epic composers are unaffected (not hosted in a Radix dialog).

## Test plan
- `nx affected` lint / format / compile / build — green (via pre-commit).
- Composer + editor-core unit tests pass, including new tests that assert list/heading markers survive a select-all copy in both editors, and the mention/slash flow still detects suggestions after pinning plugin keys.
- Manual: select-all + Cmd+C from composer and a collab artifact → markers/headings preserved; new-chat modal input grows then scrolls; Escape closes picker then modal.