### PR TITLE
Add Grok (xAI) harness support to protocol and GUI

### DIFF
--- a/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
+++ b/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
@@ -10,11 +10,14 @@ import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { useTabProvidersList } from "@/hooks/providers/use-tab-providers-list-query";
 
 // The harness id set is a superset of the provider-CLI id set (it also carries
-// `traycer`, which has no provider-CLI login). Only CLI harnesses gate.
+// `traycer`, which has no provider-CLI login). Only CLI harnesses gate. Grok is
+// GUI-only (not in the TUI map) but DOES gate — its `grok login` subscription /
+// XAI_API_KEY auth surfaces as a provider, mirroring the host's
+// `harnessIdToProviderId`.
 function providerIdForHarness(harnessId: GuiHarnessId): ProviderId | null {
-  return harnessId === "traycer"
-    ? null
-    : TUI_HARNESS_ID_TO_PROVIDER_ID[harnessId];
+  if (harnessId === "traycer") return null;
+  if (harnessId === "grok") return "grok";
+  return TUI_HARNESS_ID_TO_PROVIDER_ID[harnessId];
 }
 
 export interface ProviderReauthGate {

--- a/clients/gui-app/src/components/home/data/harness-icon-map.ts
+++ b/clients/gui-app/src/components/home/data/harness-icon-map.ts
@@ -2,6 +2,7 @@ import {
   ClaudeAIIcon,
   CodexIcon,
   CursorIcon,
+  GrokIcon,
   OpenCodeIcon,
   TraycerIcon,
   type HarnessIcon,
@@ -19,4 +20,5 @@ export const PROVIDER_ICON_CONFIG: Record<ProviderId, HarnessIconConfig> = {
   opencode: { Icon: OpenCodeIcon, className: "text-foreground" },
   traycer: { Icon: TraycerIcon, className: "text-foreground" },
   cursor: { Icon: CursorIcon, className: "text-foreground" },
+  grok: { Icon: GrokIcon, className: "text-foreground" },
 };

--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -3,6 +3,7 @@ import CodexMono from "@lobehub/icons/es/Codex/components/Mono";
 import ClaudeColor from "@lobehub/icons/es/Claude/components/Color";
 import OpenCodeMono from "@lobehub/icons/es/OpenCode/components/Mono";
 import CursorMono from "@lobehub/icons/es/Cursor/components/Mono";
+import GrokMono from "@lobehub/icons/es/Grok/components/Mono";
 
 export type HarnessIcon = (props: SVGProps<SVGSVGElement>) => ReactElement;
 
@@ -17,6 +18,7 @@ export const CodexIcon: HarnessIcon = (props) => <CodexMono {...props} />;
 export const ClaudeAIIcon: HarnessIcon = (props) => <ClaudeColor {...props} />;
 export const OpenCodeIcon: HarnessIcon = (props) => <OpenCodeMono {...props} />;
 export const CursorIcon: HarnessIcon = (props) => <CursorMono {...props} />;
+export const GrokIcon: HarnessIcon = (props) => <GrokMono {...props} />;
 
 // Traycer does not have a lobehub entry — hand-rolled from the brand mark.
 export const TraycerIcon: HarnessIcon = (props) => (

--- a/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
@@ -19,6 +19,7 @@ const TOUR_PROVIDERS: ReadonlyArray<{
   { id: "codex", harnessId: "codex" },
   { id: "opencode", harnessId: "opencode" },
   { id: "cursor", harnessId: "cursor" },
+  { id: "grok", harnessId: "grok" },
 ];
 
 type InstallState = "detected" | "missing" | "pending";

--- a/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
@@ -343,6 +343,12 @@ const PROVIDERS: ReadonlyArray<{
     status: "API key set",
     capabilities: ["gui"],
   },
+  {
+    harnessId: "grok",
+    label: "Grok",
+    status: "SuperGrok / X",
+    capabilities: ["gui"],
+  },
 ];
 
 const PALETTE_ROWS = [

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -99,6 +99,7 @@ const PROVIDER_DESCRIPTIONS: Record<ProviderId, string> = {
   cursor:
     "Cursor agent - SDK-driven chats authenticated with your Cursor API key.",
   traycer: "Traycer's managed harness uses the selected OpenCode CLI binary.",
+  grok: "Grok agent - xAI's coding CLI via your SuperGrok / X subscription.",
 };
 
 const TERMINAL_AGENT_ARGS_PLACEHOLDER: Record<
@@ -120,6 +121,7 @@ function terminalAgentArgsPlaceholder(providerId: ProviderId): string {
       return TERMINAL_AGENT_ARGS_PLACEHOLDER.opencode;
     case "cursor":
     case "traycer":
+    case "grok":
       return "CLI arguments (optional)";
   }
 }
@@ -130,6 +132,7 @@ const HARNESS_ICON_ID: Record<ProviderId, HarnessIconId> = {
   opencode: "opencode",
   cursor: "cursor",
   traycer: "traycer",
+  grok: "grok",
 };
 
 // Grid keeps the columns aligned across header + rows; `minmax(0,1fr)` on
@@ -726,6 +729,8 @@ function envNamePlaceholder(providerId: ProviderId): string {
       return "ANTHROPIC_API_KEY";
     case "cursor":
       return "CURSOR_API_KEY";
+    case "grok":
+      return "XAI_API_KEY";
   }
 }
 

--- a/clients/gui-app/src/lib/chat/sender-display.ts
+++ b/clients/gui-app/src/lib/chat/sender-display.ts
@@ -133,9 +133,20 @@ function normalizeReasoningEffort(
 }
 
 function agentProviderLabel(provider: GuiHarnessId): string {
-  if (provider === "claude") return "Claude Code";
-  if (provider === "opencode") return "OpenCode";
-  if (provider === "traycer") return "Traycer";
-  if (provider === "cursor") return "Cursor";
-  return "Codex";
+  // Exhaustive switch over GuiHarnessId: a new harness id makes this fail to
+  // compile (no return on the new path) instead of silently mislabeling.
+  switch (provider) {
+    case "claude":
+      return "Claude Code";
+    case "codex":
+      return "Codex";
+    case "opencode":
+      return "OpenCode";
+    case "traycer":
+      return "Traycer";
+    case "cursor":
+      return "Cursor";
+    case "grok":
+      return "Grok";
+  }
 }

--- a/protocol/src/common/_internal/schemas.ts
+++ b/protocol/src/common/_internal/schemas.ts
@@ -48,4 +48,11 @@ export const epicArtifactKindSchema = z.enum([
   "review",
 ]);
 
-export const harnessIdSchema = z.enum(["claude", "codex", "opencode", "traycer", "cursor"]);
+export const harnessIdSchema = z.enum([
+  "claude",
+  "codex",
+  "opencode",
+  "traycer",
+  "cursor",
+  "grok",
+]);

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -1,4 +1,8 @@
-import { defineRpcContract } from "@traycer/protocol/framework/index";
+import {
+  defineDowngradePath,
+  defineRpcContract,
+  defineUpgradePath,
+} from "@traycer/protocol/framework/index";
 import {
   createAgentRequestSchema,
   createAgentResponseSchema,
@@ -18,6 +22,7 @@ import {
   listHarnessModelsResponseSchema,
   listAgentsRequestSchema,
   listAgentsResponseSchema,
+  listAgentsResponseSchemaV10,
   sendAgentMessageRequestSchema,
   sendAgentMessageResponseSchema,
   stopAgentRequestSchema,
@@ -90,7 +95,44 @@ export const agentListV10 = defineRpcContract({
   method: "agent.list",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: listAgentsRequestSchema,
+  responseSchema: listAgentsResponseSchemaV10,
+});
+
+export const agentListV20 = defineRpcContract({
+  method: "agent.list",
+  schemaVersion: { major: 2, minor: 0 } as const,
+  requestSchema: listAgentsRequestSchema,
   responseSchema: listAgentsResponseSchema,
+});
+
+export const agentListUpgradeV1ToV2 = defineUpgradePath<
+  typeof agentListV10,
+  typeof agentListV20
+>({
+  from: { major: 1, minor: 0 },
+  to: { major: 2, minor: 0 },
+  // A grok-less v1.0 response is a valid v2.0 response (grok is purely
+  // additive), and the request shape is identical — both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentListDowngradeV2ToV1 = defineDowngradePath<
+  typeof agentListV20,
+  typeof agentListV10
+>({
+  from: { major: 2, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop grok agents so a v1.0 client's strict (grok-less) decode never sees
+  // one. The re-parse yields the precise v1.0 type without an assertion.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listAgentsResponseSchemaV10.parse({
+      ...response,
+      agents: response.agents.filter((agent) => agent.harnessId !== "grok"),
+    }),
+  }),
 });
 
 export const agentSendMessageV10 = defineRpcContract({

--- a/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import { agentListDowngradeV2ToV1 } from "@traycer/protocol/host/agent/contracts";
+import {
+  listAgentsResponseSchema,
+  listAgentsResponseSchemaV10,
+} from "@traycer/protocol/host/agent/shared";
+import { agentGuiListHarnessesDowngradeV2ToV1 } from "@traycer/protocol/host/agent/gui/contracts";
+import {
+  guiHarnessOptionSchema,
+  listGuiHarnessesResponseSchema,
+  listGuiHarnessesResponseSchemaV10,
+} from "@traycer/protocol/host/agent/gui/unary-schemas";
+import {
+  providersListResponseSchema,
+  providersListResponseSchemaV10,
+} from "@traycer/protocol/host/provider-schemas";
+// Importing from the registry runs `defineVersionedRpcRegistry` (full structural
+// + schema-compatibility validation) at module load, so this import alone
+// asserts the new v2.0 lines and their upgrade/downgrade bridges are well-formed.
+import { providersListDowngradeV2ToV1 } from "@traycer/protocol/host/registry";
+
+function harnessOption(id: string) {
+  return guiHarnessOptionSchema.parse({
+    id,
+    label: id,
+    available: true,
+    error: null,
+    modes: ["gui"],
+    requiresApiKey: false,
+  });
+}
+
+function agentSummary(id: string, harnessId: string | null) {
+  return {
+    id,
+    parentId: null,
+    hostId: "host-1",
+    isLocal: true,
+    surface: "gui",
+    harnessId,
+    isSelf: false,
+    title: id,
+    capabilities: { readTranscript: true, sendMessage: true },
+    active: false,
+    folderPaths: [],
+    isWorktree: false,
+  };
+}
+
+function providerState(providerId: string) {
+  return {
+    providerId,
+    enabled: true,
+    disabledBy: null,
+    selected: { kind: "bundled" },
+    candidates: [],
+    auth: { status: "unknown", badgeText: null, label: null, detail: null },
+    authPending: false,
+    checkedAt: null,
+    apiKey: { supported: false, configured: false, source: null },
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
+  };
+}
+
+describe("grok non-breaking v2→v1 downgrade bridges", () => {
+  it("drops grok from agent.gui.listHarnesses for v1.0 callers", () => {
+    const v2Response = listGuiHarnessesResponseSchema.parse({
+      harnesses: [harnessOption("claude"), harnessOption("grok"), harnessOption("cursor")],
+    });
+
+    const result = agentGuiListHarnessesDowngradeV2ToV1.downgradeResponse(v2Response);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.harnesses.map((harness) => harness.id)).toEqual(["claude", "cursor"]);
+    // The downgraded value must satisfy the frozen grok-less v1.0 schema — i.e.
+    // a real v1.0 client's strict decode would accept it.
+    expect(() => listGuiHarnessesResponseSchemaV10.parse(result.value)).not.toThrow();
+  });
+
+  it("drops grok from providers.list for v1.0 callers", () => {
+    const v2Response = providersListResponseSchema.parse({
+      providers: [providerState("cursor"), providerState("grok")],
+    });
+
+    const result = providersListDowngradeV2ToV1.downgradeResponse(v2Response);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.providers.map((provider) => provider.providerId)).toEqual(["cursor"]);
+    expect(() => providersListResponseSchemaV10.parse(result.value)).not.toThrow();
+  });
+
+  it("drops grok agents from agent.list for v1.0 callers", () => {
+    const v2Response = listAgentsResponseSchema.parse({
+      caller: { agentId: "self", canSendMessages: true },
+      scope: "all",
+      agents: [
+        agentSummary("a-claude", "claude"),
+        agentSummary("a-grok", "grok"),
+        agentSummary("a-null", null),
+      ],
+    });
+
+    const result = agentListDowngradeV2ToV1.downgradeResponse(v2Response);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.agents.map((agent) => agent.id)).toEqual(["a-claude", "a-null"]);
+    // A real v1.0 client's strict (grok-less) decode must accept the result.
+    expect(() => listAgentsResponseSchemaV10.parse(result.value)).not.toThrow();
+  });
+});

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -667,6 +667,14 @@ export const traycerUserMessageAnchorResolvedSchema = z.object({
   opencodeUserMessageId: z.string(),
 });
 
+export const grokUserMessageAnchorResolvedSchema = z.object({
+  harnessId: z.literal("grok"),
+  sessionId: z.string(),
+  // The ACP session id the `grok agent stdio` process assigned for this turn.
+  // Null until `session/new` resolves; used to resume the same ACP session.
+  grokSessionId: z.string().nullable(),
+});
+
 export const userMessageAnchorResolvedEventSchema = z.object({
   ...baseRuntimeEventFields,
   type: z.literal("user_message.anchor_resolved"),
@@ -677,6 +685,7 @@ export const userMessageAnchorResolvedEventSchema = z.object({
     openCodeUserMessageAnchorResolvedSchema,
     cursorUserMessageAnchorResolvedSchema,
     traycerUserMessageAnchorResolvedSchema,
+    grokUserMessageAnchorResolvedSchema,
   ]),
 });
 export type UserMessageAnchorResolvedEvent = z.infer<

--- a/protocol/src/host/agent/gui/contracts.ts
+++ b/protocol/src/host/agent/gui/contracts.ts
@@ -1,4 +1,8 @@
-import { defineRpcContract } from "@traycer/protocol/framework/index";
+import {
+  defineDowngradePath,
+  defineRpcContract,
+  defineUpgradePath,
+} from "@traycer/protocol/framework/index";
 import {
   getGuiAgentPlanRequestSchema,
   getGuiAgentPlanResponseSchema,
@@ -8,16 +12,56 @@ import {
   listGuiAgentModelsResponseSchema,
   listGuiHarnessesRequestSchema,
   listGuiHarnessesResponseSchema,
+  listGuiHarnessesResponseSchemaV10,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
 import { chatSubscribeV10 } from "@traycer/protocol/host/agent/gui/subscribe";
 
 // ─── GUI-surface catalog (`agent.gui.*`) ──────────────────────────────────
 
+// `agent.gui.listHarnesses` always returns the full catalog (incl. grok), so an
+// unguarded grok value would reach every caller. v1.0 is frozen grok-less (what
+// shipped); v2.0 carries grok; the v2→v1 bridge drops grok for v1.0 clients.
 export const agentGuiListHarnessesV10 = defineRpcContract({
   method: "agent.gui.listHarnesses",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: listGuiHarnessesRequestSchema,
+  responseSchema: listGuiHarnessesResponseSchemaV10,
+});
+
+export const agentGuiListHarnessesV20 = defineRpcContract({
+  method: "agent.gui.listHarnesses",
+  schemaVersion: { major: 2, minor: 0 } as const,
+  requestSchema: listGuiHarnessesRequestSchema,
   responseSchema: listGuiHarnessesResponseSchema,
+});
+
+export const agentGuiListHarnessesUpgradeV1ToV2 = defineUpgradePath<
+  typeof agentGuiListHarnessesV10,
+  typeof agentGuiListHarnessesV20
+>({
+  from: { major: 1, minor: 0 },
+  to: { major: 2, minor: 0 },
+  // Request shape is identical; a grok-less v1.0 response is a valid v2.0
+  // response (grok is purely additive), so both upgrades are identity.
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentGuiListHarnessesDowngradeV2ToV1 = defineDowngradePath<
+  typeof agentGuiListHarnessesV20,
+  typeof agentGuiListHarnessesV10
+>({
+  from: { major: 2, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  // Drop grok so a v1.0 client's strict (grok-less) decode never sees it. The
+  // re-parse also yields the precise v1.0 type without an assertion.
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: listGuiHarnessesResponseSchemaV10.parse({
+      harnesses: response.harnesses.filter((harness) => harness.id !== "grok"),
+    }),
+  }),
 });
 
 export const agentGuiListModelsV10 = defineRpcContract({

--- a/protocol/src/host/agent/gui/unary-schemas.ts
+++ b/protocol/src/host/agent/gui/unary-schemas.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { guiHarnessIdSchema } from "@traycer/protocol/host/agent/shared";
+import {
+  guiHarnessIdSchema,
+  guiHarnessIdSchemaV10,
+} from "@traycer/protocol/host/agent/shared";
 import {
   ALL_PERMISSION_MODES,
   permissionModeSchema,
@@ -122,6 +125,17 @@ export type ListGuiHarnessesRequest = z.infer<
 
 export const listGuiHarnessesResponseSchema = z.object({
   harnesses: z.array(guiHarnessOptionSchema),
+});
+
+// ── Frozen protocol-v1.0 (grok-less) catalog row + response ────────────────
+// A v1.0 client predates grok; the v2.0 line of `agent.gui.listHarnesses` adds
+// it, and the v2→v1 downgrade bridge filters grok out for v1.0 callers so their
+// strict (grok-less) decode never sees a value it can't parse.
+export const guiHarnessOptionSchemaV10 = guiHarnessOptionSchema.extend({
+  id: guiHarnessIdSchemaV10,
+});
+export const listGuiHarnessesResponseSchemaV10 = z.object({
+  harnesses: z.array(guiHarnessOptionSchemaV10),
 });
 export type ListGuiHarnessesResponse = z.infer<
   typeof listGuiHarnessesResponseSchema

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -50,8 +50,26 @@ export const guiHarnessIdSchema = harnessIdSchema.extract([
   "opencode",
   "traycer",
   "cursor",
+  "grok",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
+
+/**
+ * Frozen grok-less harness id set as shipped in protocol v1.0. Used only by the
+ * frozen v1.0 response schema of `agent.gui.listHarnesses` so a v1.0 client
+ * (which predates grok) negotiates a wire that can never carry it; the v2.0 line
+ * adds grok and a v2→v1 downgrade bridge filters it for v1.0 callers. Do NOT add
+ * new harnesses here — extend the latest `guiHarnessIdSchema` and bump the
+ * method's major with a bridge instead.
+ */
+export const guiHarnessIdSchemaV10 = harnessIdSchema.extract([
+  "claude",
+  "codex",
+  "opencode",
+  "traycer",
+  "cursor",
+]);
+export type GuiHarnessIdV10 = z.infer<typeof guiHarnessIdSchemaV10>;
 
 export const tuiHarnessIdSchema = harnessIdSchema.extract([
   "claude",
@@ -104,6 +122,7 @@ export const agentFacingHarnessIdSchema = harnessIdSchema.extract([
   "opencode",
   "traycer",
   "cursor",
+  "grok",
 ]);
 export type AgentFacingHarnessId = z.infer<typeof agentFacingHarnessIdSchema>;
 
@@ -385,6 +404,24 @@ export const listAgentsResponseSchema = z.object({
   agents: z.array(agentSummarySchema),
 });
 export type ListAgentsResponse = z.infer<typeof listAgentsResponseSchema>;
+
+// ── Frozen protocol-v1.0 (grok-less) agent.list response ───────────────────
+// `agent.list` enumerates every agent in the epic — including grok chats a newer
+// client created — and the `traycer` CLI inlines the protocol at build time, so
+// an old (grok-less) CLI would hit a strict enum on a grok row. v1.0 is frozen
+// grok-less; the v2.0 line carries grok and a v2→v1 bridge drops grok agents for
+// v1.0 callers. Do not add new harnesses here — bump the major with a bridge.
+export const agentSummarySchemaV10 = agentSummarySchema.extend({
+  harnessId: harnessIdSchema
+    .extract(["claude", "codex", "opencode", "traycer", "cursor"])
+    .nullable(),
+});
+export const listAgentsResponseSchemaV10 = listAgentsResponseSchema.extend({
+  agents: z.array(agentSummarySchemaV10),
+});
+export type ListAgentsResponseV10 = z.infer<
+  typeof listAgentsResponseSchemaV10
+>;
 
 /**
  * `agent.sendMessage@1.0` - fire-and-forget enqueue from one agent to

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -18,8 +18,24 @@ export const providerIdSchema = z.enum([
   "opencode",
   "cursor",
   "traycer",
+  "grok",
 ]);
 export type ProviderId = z.infer<typeof providerIdSchema>;
+
+/**
+ * Frozen grok-less provider id set as shipped in protocol v1.0. Used only by the
+ * frozen v1.0 `providers.list` response so a v1.0 client never receives the grok
+ * provider; the v2.0 line adds it with a v2→v1 downgrade bridge. Do not add new
+ * providers here.
+ */
+export const providerIdSchemaV10 = z.enum([
+  "claude-code",
+  "codex",
+  "opencode",
+  "cursor",
+  "traycer",
+]);
+export type ProviderIdV10 = z.infer<typeof providerIdSchemaV10>;
 
 /** Human-readable provider names, shared by the host and the GUI. */
 export const PROVIDER_DISPLAY_NAMES: Record<ProviderId, string> = {
@@ -28,6 +44,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderId, string> = {
   opencode: "OpenCode",
   cursor: "Cursor",
   traycer: "Traycer",
+  grok: "Grok",
 };
 
 /**
@@ -195,6 +212,16 @@ export const providersListResponseSchema = z.object({
   providers: z.array(providerCliStateSchema),
 });
 export type ProvidersListResponse = z.infer<typeof providersListResponseSchema>;
+
+// Frozen protocol-v1.0 (grok-less) provider state + list response. The v2.0 line
+// of `providers.list` adds grok; the v2→v1 bridge filters it for v1.0 callers.
+export const providerCliStateSchemaV10 = providerCliStateSchema.extend({
+  providerId: providerIdSchemaV10,
+});
+export const providersListResponseSchemaV10 = z.object({
+  providers: z.array(providerCliStateSchemaV10),
+});
+export type ProvidersListResponseV10 = z.infer<typeof providersListResponseSchemaV10>;
 
 export const providersSetSelectionRequestSchema = z.object({
   providerId: providerIdSchema,

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -1,10 +1,17 @@
-import { defineVersionedRpcRegistry } from "@traycer/protocol/framework/index";
+import {
+  defineDowngradePath,
+  defineUpgradePath,
+  defineVersionedRpcRegistry,
+} from "@traycer/protocol/framework/index";
 import { defineVersionedStreamRpcRegistry } from "@traycer/protocol/framework/versioned-stream-rpc";
 import {
   agentCreateV10,
   agentGetTranscriptV10,
   agentListHarnessModelsV10,
+  agentListDowngradeV2ToV1,
+  agentListUpgradeV1ToV2,
   agentListV10,
+  agentListV20,
   agentSelectionGuideV10,
   agentSelectionGuideGlobalGetV10,
   agentSelectionGuideGlobalOnboardingDraftGetV10,
@@ -20,7 +27,10 @@ import {
 import {
   agentGuiGetPlanV10,
   agentGuiListCommandsV10,
+  agentGuiListHarnessesDowngradeV2ToV1,
+  agentGuiListHarnessesUpgradeV1ToV2,
   agentGuiListHarnessesV10,
+  agentGuiListHarnessesV20,
   agentGuiListModelsV10,
   chatSubscribeV10,
 } from "@traycer/protocol/host/agent/gui/contracts";
@@ -170,6 +180,7 @@ import {
   providersStartLoginResponseSchema,
   providersListRequestSchema,
   providersListResponseSchema,
+  providersListResponseSchemaV10,
   providersRemoveCustomPathRequestSchema,
   providersRemoveCustomPathResponseSchema,
   providersSetApiKeyRequestSchema,
@@ -344,11 +355,47 @@ export const worktreeGetBindingV10 = defineRpcContract({
 // provider's resolved binary path + version, lets the user override the
 // binary per provider, and previews a candidate-path version without
 // committing it. Schemas live in `protocol/host/provider-schemas.ts`.
+// `providers.list` always returns every provider (incl. grok); v1.0 is frozen
+// grok-less, v2.0 carries grok, and the v2→v1 bridge drops grok for v1.0 clients.
 export const providersListV10 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: providersListRequestSchema,
+  responseSchema: providersListResponseSchemaV10,
+});
+
+export const providersListV20 = defineRpcContract({
+  method: "providers.list",
+  schemaVersion: { major: 2, minor: 0 } as const,
+  requestSchema: providersListRequestSchema,
   responseSchema: providersListResponseSchema,
+});
+
+export const providersListUpgradeV1ToV2 = defineUpgradePath<
+  typeof providersListV10,
+  typeof providersListV20
+>({
+  from: { major: 1, minor: 0 },
+  to: { major: 2, minor: 0 },
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const providersListDowngradeV2ToV1 = defineDowngradePath<
+  typeof providersListV20,
+  typeof providersListV10
+>({
+  from: { major: 2, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: providersListResponseSchemaV10.parse({
+      providers: response.providers.filter(
+        (provider) => provider.providerId !== "grok",
+      ),
+    }),
+  }),
 });
 
 export const providersSetSelectionV10 = defineRpcContract({
@@ -560,6 +607,16 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
       },
       downgradePathsFromLatest: {},
     },
+    2: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentGuiListHarnessesV20,
+          upgradeFromPreviousVersion: agentGuiListHarnessesUpgradeV1ToV2,
+        },
+      },
+      downgradePathsFromLatest: { 1: agentGuiListHarnessesDowngradeV2ToV1 },
+    },
   },
   "agent.gui.listModels": {
     1: {
@@ -751,6 +808,16 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
         },
       },
       downgradePathsFromLatest: {},
+    },
+    2: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentListV20,
+          upgradeFromPreviousVersion: agentListUpgradeV1ToV2,
+        },
+      },
+      downgradePathsFromLatest: { 1: agentListDowngradeV2ToV1 },
     },
   },
   "agent.sendMessage": {
@@ -1628,7 +1695,18 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
       },
       downgradePathsFromLatest: {},
     },
+    2: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: providersListV20,
+          upgradeFromPreviousVersion: providersListUpgradeV1ToV2,
+        },
+      },
+      downgradePathsFromLatest: { 1: providersListDowngradeV2ToV1 },
+    },
   },
+
   "providers.setSelection": {
     1: {
       latestMinor: 0,

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -62,6 +62,7 @@ export const guiHarnessIdSchema = z.enum([
   "opencode",
   "traycer",
   "cursor",
+  "grok",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 

--- a/protocol/src/persistence/epic/senders.ts
+++ b/protocol/src/persistence/epic/senders.ts
@@ -124,11 +124,27 @@ export type TraycerChatSessionAnchor = z.infer<
   typeof traycerChatSessionAnchorSchema
 >;
 
+// Grok (ACP) resumes at session granularity only — `session/load` reloads the
+// whole ACP session, with no per-message truncation/fork point — so the anchor
+// carries just the ACP session id (no provider-native user-message id like the
+// others). `sessionId` is that ACP session id.
+export const grokChatSessionAnchorSchema = z.object({
+  harnessId: z.literal("grok"),
+  hostId: z.string(),
+  sessionId: z.string(),
+  sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
+  createdAt: z.number(),
+});
+export type GrokChatSessionAnchor = z.infer<
+  typeof grokChatSessionAnchorSchema
+>;
+
 export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   claudeChatSessionAnchorSchema,
   codexChatSessionAnchorSchema,
   openCodeChatSessionAnchorSchema,
   cursorChatSessionAnchorSchema,
   traycerChatSessionAnchorSchema,
+  grokChatSessionAnchorSchema,
 ]);
 export type ChatSessionAnchor = z.infer<typeof chatSessionAnchorSchema>;


### PR DESCRIPTION
Adds **Grok (xAI)** as a GUI harness across the wire protocol and the GUI renderer — the open-source half of SuperGrok / X support. The host-side ACP harness is a separate `traycer-internal` PR on the matching `traycer/traycer-support-for-supergrok` branch.

## Protocol
- Register `grok` in the harness + provider id enums, add a grok `user_message.anchor_resolved` schema, and a persisted grok `ChatSessionAnchor`.
- **Non-breaking versioning**: `grok` is purely additive, but a strict `z.enum` on an old client would reject it. The catalogs that always emit grok get a per-method **major bump + v2→v1 downgrade bridge** that filters grok for v1.0 clients — `agent.gui.listHarnesses`, `providers.list`, and `agent.list`. Frozen grok-less v1.0 schemas plus `grok-versioning.test.ts` assert old clients never receive a value they can't parse.

## GUI
- Grok in the model picker (lobehub `Grok/Mono` icon), provider settings, onboarding lists, and the composer reauth gate.
- `agentProviderLabel` converted to an exhaustive switch (it was silently falling through to "Codex").

## Testing
- `protocol` + `gui-app` compile clean; `grok-versioning.test.ts` 3/3; `pre-commit run --all-files` passes (build · compile · lint · format).
