### PR TITLE
Add extended logging across CLI, desktop, and GUI

### DIFF
--- a/clients/desktop/src/electron-main/app/logger.ts
+++ b/clients/desktop/src/electron-main/app/logger.ts
@@ -61,7 +61,9 @@ export function redactLogText(value: string): string {
     : redacted;
 }
 
-export function sanitizeLogFields(fields: Record<string, unknown>): SafeLogFields {
+export function sanitizeLogFields(
+  fields: Record<string, unknown>,
+): SafeLogFields {
   return sanitizeLogRecord(fields, 0);
 }
 

--- a/clients/desktop/src/electron-main/app/logger.ts
+++ b/clients/desktop/src/electron-main/app/logger.ts
@@ -22,6 +22,8 @@ const SENSITIVE_KEY_PATTERN =
 const SENSITIVE_QUERY_PARAM_PATTERN =
   /([?&](?:access_token|refresh_token|id_token|token|code|code_verifier|password|secret|client_secret|api_key|authorization)=)([^&#\s]+)/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const SENSITIVE_INLINE_VALUE_PATTERN =
+  /(\b(?:access[_-]?token|refresh[_-]?token|id[_-]?token|token|code[_-]?verifier|password|secret|client[_-]?secret|api[_-]?key|authorization|cookie|credential)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;}&]+)/gi;
 
 /**
  * Configures `electron-log` so the desktop shell, the renderer, and any
@@ -52,10 +54,15 @@ export function resolveDesktopLogPath(): string {
 export function redactLogText(value: string): string {
   const redacted = value
     .replace(SENSITIVE_QUERY_PARAM_PATTERN, "$1<redacted>")
-    .replace(BEARER_PATTERN, "Bearer <redacted>");
+    .replace(BEARER_PATTERN, "Bearer <redacted>")
+    .replace(SENSITIVE_INLINE_VALUE_PATTERN, "$1<redacted>");
   return redacted.length > MAX_LOG_STRING_LENGTH
     ? `${redacted.slice(0, MAX_LOG_STRING_LENGTH)}...<truncated>`
     : redacted;
+}
+
+export function sanitizeLogFields(fields: Record<string, unknown>): SafeLogFields {
+  return sanitizeLogRecord(fields, 0);
 }
 
 export function sanitizeLogValue(value: unknown, depth: number): SafeLogValue {
@@ -73,16 +80,7 @@ export function sanitizeLogValue(value: unknown, depth: number): SafeLogValue {
     return describeLogError(value);
   }
   if (isRecord(value)) {
-    const sanitized: Record<string, SafeLogValue> = {};
-    for (const [key, entry] of Object.entries(value).slice(
-      0,
-      MAX_LOG_OBJECT_KEYS,
-    )) {
-      sanitized[key] = SENSITIVE_KEY_PATTERN.test(key)
-        ? "<redacted>"
-        : sanitizeLogValue(entry, depth + 1);
-    }
-    return sanitized;
+    return sanitizeLogRecord(value, depth);
   }
   if (typeof value === "undefined") return "<undefined>";
   return redactLogText(String(value));
@@ -106,6 +104,22 @@ export function describeLogError(error: unknown): SafeLogFields {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeLogRecord(
+  value: Record<string, unknown>,
+  depth: number,
+): Record<string, SafeLogValue> {
+  const sanitized: Record<string, SafeLogValue> = {};
+  for (const [key, entry] of Object.entries(value).slice(
+    0,
+    MAX_LOG_OBJECT_KEYS,
+  )) {
+    sanitized[key] = SENSITIVE_KEY_PATTERN.test(key)
+      ? "<redacted>"
+      : sanitizeLogValue(entry, depth + 1);
+  }
+  return sanitized;
 }
 
 export { log };

--- a/clients/desktop/src/electron-main/auth/loopback-callback-server.ts
+++ b/clients/desktop/src/electron-main/auth/loopback-callback-server.ts
@@ -48,6 +48,7 @@ export async function startLoopbackCallbackServer(
       try {
         url = new URL(req.url ?? "/", "http://127.0.0.1");
       } catch {
+        log.warn("[auth] dev loopback callback rejected malformed request");
         res.writeHead(400, { "Content-Type": "text/plain; charset=utf-8" });
         res.end("bad request");
         return;

--- a/clients/desktop/src/electron-main/cli/cli-discovery.ts
+++ b/clients/desktop/src/electron-main/cli/cli-discovery.ts
@@ -233,6 +233,9 @@ export async function readCliManifest(): Promise<CliInstallManifest | null> {
   try {
     parsed = JSON.parse(raw);
   } catch {
+    log.warn("[cli] install manifest is not valid JSON", {
+      path: CLI_MANIFEST_PATH,
+    });
     return null;
   }
   if (parsed === null || typeof parsed !== "object") return null;
@@ -242,6 +245,9 @@ export async function readCliManifest(): Promise<CliInstallManifest | null> {
     typeof obj.binaryPath !== "string" ||
     typeof obj.installedAt !== "string"
   ) {
+    log.warn("[cli] install manifest has invalid shape", {
+      path: CLI_MANIFEST_PATH,
+    });
     return null;
   }
   const source = typeof obj.source === "string" ? obj.source : "manual";
@@ -332,6 +338,9 @@ export async function readDesktopReconcileState(): Promise<DesktopReconcileState
   try {
     parsed = JSON.parse(raw);
   } catch {
+    log.warn("[cli] desktop reconcile state is not valid JSON", {
+      path: DESKTOP_RECONCILE_STATE_PATH,
+    });
     return null;
   }
   if (parsed === null || typeof parsed !== "object") return null;

--- a/clients/desktop/src/electron-main/cli/traycer-cli.ts
+++ b/clients/desktop/src/electron-main/cli/traycer-cli.ts
@@ -596,6 +596,9 @@ export async function streamTraycerCliJson<T>(
         } catch {
           // Not JSON - the CLI shouldn't emit non-JSON in `--json` mode
           // but be tolerant of stray output.
+          log.warn("[traycer-cli] ignored non-JSON stdout line", {
+            lineLength: line.length,
+          });
           continue;
         }
         const event = parseNdjsonEvent(parsed);
@@ -787,6 +790,9 @@ function extractTerminalEnvelope(
     try {
       parsed = JSON.parse(line);
     } catch {
+      log.warn("[traycer-cli] ignored non-JSON terminal stdout line", {
+        lineLength: line.length,
+      });
       continue;
     }
     const event = parseNdjsonEvent(parsed);

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -487,8 +487,14 @@ async function readRegistryCache(): Promise<RegistryUpdateCacheFile | null> {
   }
   try {
     const parsed: unknown = JSON.parse(text);
-    if (!isPlainObject(parsed)) return null;
-    if (typeof parsed.checkedAt !== "string") return null;
+    if (!isPlainObject(parsed)) {
+      log.warn("[host-management] registry cache has invalid shape", { path });
+      return null;
+    }
+    if (typeof parsed.checkedAt !== "string") {
+      log.warn("[host-management] registry cache missing checkedAt", { path });
+      return null;
+    }
     // Defence-in-depth: even though the filename is environment-scoped, also
     // gate on the `environment` field embedded in the snapshot. If an older
     // build (or a manual edit) put the wrong environment in this file, treat
@@ -497,6 +503,14 @@ async function readRegistryCache(): Promise<RegistryUpdateCacheFile | null> {
       typeof parsed.environment === "string" &&
       parsed.environment !== activeEnvironment
     ) {
+      log.info(
+        "[host-management] ignored registry cache for other environment",
+        {
+          path,
+          cacheEnvironment: parsed.environment,
+          activeEnvironment,
+        },
+      );
       return null;
     }
     return {

--- a/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
+++ b/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
@@ -1,6 +1,6 @@
 import { ipcMain, type IpcMainEvent, type IpcMainInvokeEvent } from "electron";
 import { randomUUID } from "node:crypto";
-import { log } from "../app/logger";
+import { describeLogError, log } from "../app/logger";
 import type { DesktopTrayController } from "../tray/tray";
 import {
   RunnerHostEvent,
@@ -349,13 +349,28 @@ export class RunnerIpcBridge {
     const target = this.windowRegistry.getMruRecord();
     if (target === null) {
       this.pendingAuthCallbacks.push(result);
+      log.info("[auth] callback queued until renderer is ready", {
+        resultKind: authCallbackKind(result),
+        pendingCount: this.pendingAuthCallbacks.length,
+      });
       return;
     }
-    this.safeSendToWindow(
+    const delivered = this.safeSendToWindow(
       target.windowId,
       RunnerHostEvent.authCallback,
       result,
     );
+    if (delivered) {
+      log.info("[auth] callback delivered to renderer", {
+        resultKind: authCallbackKind(result),
+        windowId: target.windowId,
+      });
+    } else {
+      log.warn("[auth] callback delivery failed", {
+        resultKind: authCallbackKind(result),
+        windowId: target.windowId,
+      });
+    }
   }
 
   deliverNotificationClick(payload: unknown): void {
@@ -548,7 +563,23 @@ export class RunnerIpcBridge {
         });
         throw new Error(`IPC sender not trusted for channel ${channel}`);
       }
-      return handler(event, ...args);
+      try {
+        return Promise.resolve(handler(event, ...args)).catch(
+          (err: unknown) => {
+            log.warn("[runner-ipc] invoke handler failed", {
+              channel,
+              error: describeLogError(err),
+            });
+            throw err;
+          },
+        );
+      } catch (err) {
+        log.warn("[runner-ipc] invoke handler threw", {
+          channel,
+          error: describeLogError(err),
+        });
+        throw err;
+      }
     });
   }
 
@@ -620,6 +651,12 @@ export class RunnerIpcBridge {
         if (settled) return;
         settled = true;
         this.freshSnapshotWaiters.delete(requestId);
+        log.warn("[runner-ipc] fresh unsynced snapshot timed out", {
+          windowId: record.windowId,
+          timeoutMs,
+          fallbackCount:
+            this.unsyncedEditsSnapshots.get(record.windowId)?.length ?? 0,
+        });
         resolve(this.unsyncedEditsSnapshots.get(record.windowId) ?? []);
       }, timeoutMs);
       this.freshSnapshotWaiters.set(requestId, {
@@ -644,6 +681,11 @@ export class RunnerIpcBridge {
         settled = true;
         clearTimeout(timer);
         this.freshSnapshotWaiters.delete(requestId);
+        log.warn("[runner-ipc] fresh unsynced snapshot request not delivered", {
+          windowId: record.windowId,
+          fallbackCount:
+            this.unsyncedEditsSnapshots.get(record.windowId)?.length ?? 0,
+        });
         resolve(this.unsyncedEditsSnapshots.get(record.windowId) ?? []);
       }
     });
@@ -683,8 +725,12 @@ export class RunnerIpcBridge {
     }
     const target = this.windowRegistry.getMruRecord();
     if (target === null) {
+      log.info("[auth] pending callbacks still waiting for renderer", {
+        pendingCount: this.pendingAuthCallbacks.length,
+      });
       return;
     }
+    const pendingCount = this.pendingAuthCallbacks.length;
     for (const result of this.pendingAuthCallbacks.splice(0)) {
       this.safeSendToWindow(
         target.windowId,
@@ -692,6 +738,10 @@ export class RunnerIpcBridge {
         result,
       );
     }
+    log.info("[auth] pending callbacks flushed", {
+      pendingCount,
+      windowId: target.windowId,
+    });
   }
 
   replayCurrentStateToWindow(windowId: string): void {
@@ -739,10 +789,20 @@ export class RunnerIpcBridge {
         ? this.windowRegistry.getMruRecord()
         : this.windowRegistry.getRecordById(ownerWindowId);
     if (target === null) {
+      log.warn("[runner-ipc] no renderer target for event", {
+        channel,
+        hasEpicId: epicId !== null,
+        ownerWindowId,
+      });
       return;
     }
     this.windowRegistry.focusById(target.windowId);
-    this.safeSendToWindow(target.windowId, channel, payload);
+    if (!this.safeSendToWindow(target.windowId, channel, payload)) {
+      log.warn("[runner-ipc] renderer event delivery failed", {
+        channel,
+        windowId: target.windowId,
+      });
+    }
   }
 
   private resolveRendererHostedCommandTarget(
@@ -824,6 +884,10 @@ export class RunnerIpcBridge {
     this.quitDecisionWaiters.length = 0;
     this.quitDecisionWaiters.push(...retained);
   }
+}
+
+function authCallbackKind(result: AuthCallbackParseResult): "code" | "error" {
+  return "code" in result ? "code" : "error";
 }
 
 class SingleWindowRegistry implements IpcWindowRegistry {

--- a/clients/desktop/src/electron-main/main-process.ts
+++ b/clients/desktop/src/electron-main/main-process.ts
@@ -1,6 +1,6 @@
 import { app } from "electron";
 import { DESKTOP_APP_NAME } from "../config";
-import { log } from "./app/logger";
+import { initLogger, log } from "./app/logger";
 import { runDesktopStartup } from "./startup/desktop-startup";
 
 // Electron keys both the single-instance lock and the entire userData directory
@@ -23,6 +23,8 @@ app.setName(DESKTOP_APP_NAME);
 // and the renderer provisions it post-sign-in via the `host ensure` IPC.
 const gotLock = app.requestSingleInstanceLock();
 if (!gotLock) {
+  initLogger();
+  log.info("[desktop] single-instance lock unavailable - quitting");
   app.quit();
 } else {
   void runDesktopStartup().catch((err) => {

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -168,6 +168,10 @@ function deliverAuthCallback(
     state.bridge.deliverAuthCallback(result);
   } else {
     state.pendingDeepLinks.push(result);
+    log.info("[auth] callback queued before IPC bridge was ready", {
+      resultKind: "code" in result ? "code" : "error",
+      pendingCount: state.pendingDeepLinks.length,
+    });
   }
 }
 
@@ -379,11 +383,22 @@ async function runWindowPhase(state: BootState): Promise<AppServices> {
   // first startup renderer has installed its listeners.
   if (state.pendingDeepLinks.length > 0) {
     const deepLinkTarget = windowRegistry.records()[0];
-    deepLinkTarget?.window.webContents.once("did-finish-load", () => {
-      for (const result of state.pendingDeepLinks.splice(0)) {
-        bridge.deliverAuthCallback(result);
-      }
-    });
+    if (deepLinkTarget === undefined) {
+      log.warn("[auth] startup callbacks pending with no renderer window", {
+        pendingCount: state.pendingDeepLinks.length,
+      });
+    } else {
+      deepLinkTarget.window.webContents.once("did-finish-load", () => {
+        const pendingCount = state.pendingDeepLinks.length;
+        for (const result of state.pendingDeepLinks.splice(0)) {
+          bridge.deliverAuthCallback(result);
+        }
+        log.info("[auth] startup callbacks drained after first renderer load", {
+          pendingCount,
+          windowId: deepLinkTarget.windowId,
+        });
+      });
+    }
   }
 
   for (const record of windowRegistry.records()) {

--- a/clients/desktop/src/electron-main/windows/window-factory.ts
+++ b/clients/desktop/src/electron-main/windows/window-factory.ts
@@ -8,9 +8,8 @@ import { createInitialRouteArg } from "../../ipc-contracts/window-bootstrap";
 import {
   log,
   redactLogText,
-  sanitizeLogValue,
+  sanitizeLogFields,
   type SafeLogFields,
-  type SafeLogValue,
 } from "../app/logger";
 import { safelyOpenExternal, installNavigationGuard } from "../app/security";
 import { installContextMenu } from "../app/spell-check";
@@ -238,11 +237,7 @@ function parseStructuredRendererLog(
 function sanitizeRendererFields(
   fields: Record<string, unknown>,
 ): SafeLogFields {
-  const sanitized: Record<string, SafeLogValue> = {};
-  for (const [key, value] of Object.entries(fields)) {
-    sanitized[key] = sanitizeLogValue(value, 0);
-  }
-  return sanitized;
+  return sanitizeLogFields(fields);
 }
 
 function logStructuredRendererEntry(

--- a/clients/desktop/src/electron-main/windows/window-factory.ts
+++ b/clients/desktop/src/electron-main/windows/window-factory.ts
@@ -5,7 +5,13 @@ import {
 } from "electron";
 import { canOpenDevTools, isDevBuild } from "../../config";
 import { createInitialRouteArg } from "../../ipc-contracts/window-bootstrap";
-import { log } from "../app/logger";
+import {
+  log,
+  redactLogText,
+  sanitizeLogValue,
+  type SafeLogFields,
+  type SafeLogValue,
+} from "../app/logger";
 import { safelyOpenExternal, installNavigationGuard } from "../app/security";
 import { installContextMenu } from "../app/spell-check";
 import { installResponsivenessListeners } from "../app/responsiveness";
@@ -14,6 +20,7 @@ import { installPerWindowPlatformHooks } from "../ipc/platform-ipc";
 
 // Vite dev server served by the `make dev-desktop` orchestrator.
 const DEV_RENDERER_URL = "http://localhost:5173";
+const STRUCTURED_RENDERER_LOG_PREFIX = "[traycer-gui]";
 
 export interface MainWindowOptions {
   readonly preloadPath: string;
@@ -134,11 +141,20 @@ export function createMainWindow(options: MainWindowOptions): BrowserWindow {
   window.webContents.on(
     "console-message",
     (details: Event<WebContentsConsoleMessageEventParams>) => {
+      const structured = parseStructuredRendererLog(details.message);
       const entry = {
-        message: details.message,
+        message:
+          structured === null
+            ? redactLogText(details.message)
+            : structured.message,
         line: details.lineNumber,
-        source: details.sourceId,
+        source: sanitizeRendererSource(details.sourceId),
+        ...(structured === null ? {} : { fields: structured.fields }),
       };
+      if (structured !== null) {
+        logStructuredRendererEntry(structured.level, entry);
+        return;
+      }
       if (canOpenDevTools) {
         log.info("[renderer]", { level: details.level, ...entry });
         return;
@@ -182,4 +198,94 @@ export async function loadMainWindow(
 
 export interface MainWindowLoadTarget {
   loadURL(url: string): Promise<void>;
+}
+
+type StructuredRendererLogLevel = "debug" | "info" | "warn" | "error";
+
+interface StructuredRendererLog {
+  readonly level: StructuredRendererLogLevel;
+  readonly message: string;
+  readonly fields: SafeLogFields;
+}
+
+function parseStructuredRendererLog(
+  message: string,
+): StructuredRendererLog | null {
+  if (!message.startsWith(STRUCTURED_RENDERER_LOG_PREFIX)) {
+    return null;
+  }
+  const rawJson = message.slice(STRUCTURED_RENDERER_LOG_PREFIX.length).trim();
+  try {
+    const parsed: unknown = JSON.parse(rawJson);
+    if (!isRecord(parsed)) return null;
+    const level = parsed.level;
+    const logMessage = parsed.message;
+    if (!isRendererLogLevel(level) || typeof logMessage !== "string") {
+      return null;
+    }
+    return {
+      level,
+      message: redactLogText(logMessage),
+      fields: isRecord(parsed.fields)
+        ? sanitizeRendererFields(parsed.fields)
+        : {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeRendererFields(
+  fields: Record<string, unknown>,
+): SafeLogFields {
+  const sanitized: Record<string, SafeLogValue> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    sanitized[key] = sanitizeLogValue(value, 0);
+  }
+  return sanitized;
+}
+
+function logStructuredRendererEntry(
+  level: StructuredRendererLogLevel,
+  entry: SafeLogFields,
+): void {
+  if (level === "error") {
+    log.error("[renderer]", entry);
+    return;
+  }
+  if (level === "warn") {
+    log.warn("[renderer]", entry);
+    return;
+  }
+  if (level === "info") {
+    log.info("[renderer]", entry);
+    return;
+  }
+  log.debug("[renderer]", entry);
+}
+
+function sanitizeRendererSource(sourceId: string): string {
+  try {
+    const url = new URL(sourceId);
+    url.search = "";
+    url.hash = "";
+    return redactLogText(url.toString());
+  } catch {
+    return redactLogText(sourceId);
+  }
+}
+
+function isRendererLogLevel(
+  value: unknown,
+): value is StructuredRendererLogLevel {
+  return (
+    value === "debug" ||
+    value === "info" ||
+    value === "warn" ||
+    value === "error"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }

--- a/clients/desktop/src/renderer-shell/secure-local-storage.ts
+++ b/clients/desktop/src/renderer-shell/secure-local-storage.ts
@@ -101,10 +101,9 @@ export function removeEncryptedItem(key: string): void {
 
 function describeStorageError(error: unknown): {
   readonly name: string;
-  readonly message: string;
 } {
   if (error instanceof Error) {
-    return { name: error.name, message: error.message };
+    return { name: error.name };
   }
-  return { name: typeof error, message: String(error) };
+  return { name: typeof error };
 }

--- a/clients/desktop/src/renderer-shell/secure-local-storage.ts
+++ b/clients/desktop/src/renderer-shell/secure-local-storage.ts
@@ -82,7 +82,11 @@ export function readEncryptedItem(key: string): string | null {
   try {
     const value = getEncryptStorage().getItem<string>(key);
     return typeof value === "string" && value.length > 0 ? value : null;
-  } catch {
+  } catch (error) {
+    console.warn("[secure-local-storage] encrypted item read failed", {
+      key,
+      error: describeStorageError(error),
+    });
     return null;
   }
 }
@@ -93,4 +97,14 @@ export function writeEncryptedItem(key: string, value: string): void {
 
 export function removeEncryptedItem(key: string): void {
   getEncryptStorage().removeItem(key);
+}
+
+function describeStorageError(error: unknown): {
+  readonly name: string;
+  readonly message: string;
+} {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message };
+  }
+  return { name: typeof error, message: String(error) };
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/artifact-child-index.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/artifact-child-index.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/stores/epics/canvas/types";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
+import { appLogger } from "@/lib/logger";
 
 interface ArtifactChildIndexProps {
   readonly parentId: string;
@@ -93,9 +94,12 @@ function ChildIndexRow(props: {
     if (treeNode !== null && type !== null) {
       reason = `non-artifact node type=${type}`;
     }
-    console.warn(
-      `[artifact-child-index] skipping child row for child=${childId} viewTab=${viewTabId} host=${hostId}: ${reason}`,
-    );
+    appLogger.warn("[artifact-child-index] skipping child row", {
+      childId,
+      viewTabId,
+      hostId,
+      reason,
+    });
     return null;
   }
 

--- a/clients/gui-app/src/components/errors/root-error-boundary.tsx
+++ b/clients/gui-app/src/components/errors/root-error-boundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import type { AppRouter } from "@/router";
 import { AppErrorScreen } from "@/components/errors/app-error-screen";
+import { appLogger } from "@/lib/logger";
 
 interface RootErrorBoundaryProps {
   /** Router instance used to navigate home from outside `RouterProvider`. */
@@ -35,14 +36,10 @@ export class RootErrorBoundary extends Component<
   }
 
   override componentDidCatch(error: unknown, info: ErrorInfo): void {
-    // Boundary-level trace: an uncaught renderer error that escaped every
-    // route-level handler. Logged at the boundary (the error + component stack,
-    // never user content) so the desktop console bridge captures fatal crashes.
-    // eslint-disable-next-line no-console
-    console.error(
+    appLogger.errorSummary(
       "[renderer] uncaught error reached RootErrorBoundary",
+      { componentStack: info.componentStack ?? null },
       error,
-      info.componentStack,
     );
   }
 

--- a/clients/gui-app/src/editor-core/nodes/mermaid/use-mermaid-png-download.ts
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/use-mermaid-png-download.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { svgToPngBlob } from "@/editor-core/nodes/mermaid/mermaid-service";
 import { readMermaidPalette } from "@/editor-core/nodes/mermaid/mermaid-theme";
 import { saveBlobToDisk } from "@/lib/files/save-blob-to-disk";
+import { appLogger } from "@/lib/logger";
 import { runnerMutationKeys } from "@/lib/query-keys";
 
 export interface UseMermaidPngDownloadParams {
@@ -44,7 +45,7 @@ export function useMermaidPngDownload(
       }
     },
     onError: (err) => {
-      console.error("[mermaid] download failed", err);
+      appLogger.errorSummary("[mermaid] download failed", {}, err);
       toast.error("Failed to download diagram");
     },
   });

--- a/clients/gui-app/src/editor-core/nodes/shared/block-error-boundary.tsx
+++ b/clients/gui-app/src/editor-core/nodes/shared/block-error-boundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { appLogger } from "@/lib/logger";
 
 interface BlockErrorBoundaryProps {
   /** Headline shown in the fallback panel. */
@@ -40,12 +41,13 @@ export class BlockErrorBoundary extends Component<
   }
 
   override componentDidCatch(error: Error, info: ErrorInfo): void {
-    // Keep a dev-visible trace without spamming production logs - the
-    // fallback UI already communicates the failure to the user.
-    if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
-      console.error("[artifact-editor] block NodeView crashed", error, info);
-    }
+    appLogger.errorSummary(
+      "[artifact-editor] block NodeView crashed",
+      {
+        componentStack: info.componentStack ?? null,
+      },
+      error,
+    );
   }
 
   private reset = (): void => {

--- a/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
+++ b/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { SPEECH_INPUT_SAMPLE_RATE } from "@traycer/protocol/host/speech/schemas";
 import { SpeechStreamClient } from "@traycer-clients/shared/host-transport/speech-stream-client";
 import { useWsStreamClient } from "@/lib/host/stream-runtime-context";
+import { appLogger, describeLogError } from "@/lib/logger";
 import { useRunnerHost } from "@/providers/use-runner-host";
 
 export type VoiceDictationState =
@@ -110,7 +111,13 @@ export function useVoiceDictation(
     mediaStreamRef.current = null;
     const ctx = audioContextRef.current;
     audioContextRef.current = null;
-    if (ctx !== null) void ctx.close().catch(() => undefined);
+    if (ctx !== null) {
+      void ctx.close().catch((error: unknown) => {
+        appLogger.warn("[voice-dictation] audio context close failed", {
+          error: describeLogError(error),
+        });
+      });
+    }
   }, []);
 
   const teardownAll = useCallback(() => {
@@ -191,6 +198,13 @@ export function useVoiceDictation(
       } catch (error) {
         const denied =
           error instanceof Error && error.name === "NotAllowedError";
+        appLogger.warn(
+          "[voice-dictation] microphone stream acquisition failed",
+          {
+            denied,
+            error: describeLogError(error),
+          },
+        );
         if (denied) setPermissionDenied(true);
         fail(
           denied
@@ -220,7 +234,11 @@ export function useVoiceDictation(
       }
       mediaStreamRef.current = stream;
       if (ctx.state === "suspended") {
-        await ctx.resume().catch(() => undefined);
+        await ctx.resume().catch((error: unknown) => {
+          appLogger.warn("[voice-dictation] audio context resume failed", {
+            error: describeLogError(error),
+          });
+        });
         if (generation !== startGenerationRef.current) return;
       }
       if (ctx.state !== "running") {
@@ -285,10 +303,17 @@ export function useVoiceDictation(
     let ctx: AudioContext;
     try {
       ctx = new AudioContext({ sampleRate: SPEECH_INPUT_SAMPLE_RATE });
-    } catch {
+    } catch (error) {
+      appLogger.warn("[voice-dictation] requested sample rate unsupported", {
+        sampleRate: SPEECH_INPUT_SAMPLE_RATE,
+        error: describeLogError(error),
+      });
       try {
         ctx = new AudioContext();
       } catch (error) {
+        appLogger.warn("[voice-dictation] audio context creation failed", {
+          error: describeLogError(error),
+        });
         fail(
           `Could not start audio capture: ${
             error instanceof Error ? error.message : String(error)

--- a/clients/gui-app/src/hooks/epic/use-epic-send-queued-invites-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-send-queued-invites-mutation.ts
@@ -14,6 +14,7 @@ import {
   type QueuedInvite,
 } from "@/lib/epic-invites";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
+import { appLogger } from "@/lib/logger";
 import { hostQueryKeys, epicMutationKeys } from "@/lib/query-keys";
 
 export interface SendQueuedInvitesArgs {
@@ -106,7 +107,15 @@ export function useEpicSendQueuedInvites(): UseMutationResult<
               succeededReInvites.push(item.invite);
             }
           });
-        } catch {
+        } catch (error) {
+          appLogger.errorSummary(
+            "[epic-invites] queued re-invite batch failed",
+            {
+              epicId,
+              inviteCount: inviteBatches.reInvites.length,
+            },
+            error,
+          );
           // Underlying hook owns the generic error toast.
         }
       }
@@ -138,7 +147,15 @@ export function useEpicSendQueuedInvites(): UseMutationResult<
               succeededNewInvites.push(invite);
             }
           });
-        } catch {
+        } catch (error) {
+          appLogger.errorSummary(
+            "[epic-invites] queued new-invite batch failed",
+            {
+              epicId,
+              inviteCount: inviteBatches.newInvites.length,
+            },
+            error,
+          );
           // Underlying hook owns the generic error toast.
         }
       }

--- a/clients/gui-app/src/hooks/git/use-git-get-file-diffs-batched.ts
+++ b/clients/gui-app/src/hooks/git/use-git-get-file-diffs-batched.ts
@@ -165,7 +165,7 @@ async function fetchPage(options: {
       });
     }
   } catch (error) {
-    if (error instanceof Error && error.name !== "AbortError") {
+    if (!(error instanceof Error && error.name === "AbortError")) {
       appLogger.warn("[git] failed to fetch batched file diffs", {
         hostId: options.hostId,
         fileCount: options.files.length,

--- a/clients/gui-app/src/hooks/git/use-git-get-file-diffs-batched.ts
+++ b/clients/gui-app/src/hooks/git/use-git-get-file-diffs-batched.ts
@@ -9,6 +9,7 @@ import {
 import { useHostClient } from "@/lib/host";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { writeBatchedDiffResponses } from "@/lib/git/write-batched-diff-responses";
+import { appLogger, describeLogErrorSummary } from "@/lib/logger";
 
 const MAX_FILES_PER_PAGE = 10;
 
@@ -165,7 +166,13 @@ async function fetchPage(options: {
     }
   } catch (error) {
     if (error instanceof Error && error.name !== "AbortError") {
-      console.error("Failed to fetch page of diffs:", error);
+      appLogger.warn("[git] failed to fetch batched file diffs", {
+        hostId: options.hostId,
+        fileCount: options.files.length,
+        ignoreWhitespace: options.ignoreWhitespace,
+        aborted: options.signal.aborted,
+        error: describeLogErrorSummary(error),
+      });
     }
   }
 }

--- a/clients/gui-app/src/hooks/runner/use-desktop-app-updates.ts
+++ b/clients/gui-app/src/hooks/runner/use-desktop-app-updates.ts
@@ -4,6 +4,7 @@ import type {
   DesktopAppUpdateSnapshot,
   DesktopAppUpdatesBridge,
 } from "@/lib/windows/types";
+import { appLogger } from "@/lib/logger";
 import { RunnerHostContext } from "@/providers/runner-host-context";
 
 const DESKTOP_APP_UPDATE_IDLE_SNAPSHOT: DesktopAppUpdateSnapshot = {
@@ -99,7 +100,9 @@ class DesktopAppUpdateStore {
       .then((next) => {
         this.accept(next);
       })
-      .catch(() => undefined)
+      .catch((error: unknown) => {
+        appLogger.error("[app-update] snapshot load failed", {}, error);
+      })
       .finally(() => {
         this.snapshotLoadInFlight = false;
       });

--- a/clients/gui-app/src/hooks/tray/use-tray-projection.ts
+++ b/clients/gui-app/src/hooks/tray/use-tray-projection.ts
@@ -3,6 +3,7 @@ import type {
   TrayEpic,
   TrayIndicatorState,
 } from "@traycer-clients/shared/platform/runner-host";
+import { appLogger } from "@/lib/logger";
 import { useRunnerHost } from "@/providers/use-runner-host";
 
 export interface TrayProjection {
@@ -24,12 +25,24 @@ export function useTrayProjection(projection: TrayProjection): void {
     // Fire-and-forget: the Electron preload bridges these calls across IPC,
     // so they return a promise. We do not block the render path on the round
     // trip - the next projection update will replace any in-flight value.
-    void runnerHost.tray.setEpics(projection.epics).catch(() => undefined);
+    void runnerHost.tray.setEpics(projection.epics).catch((error: unknown) => {
+      appLogger.error(
+        "[tray] failed to project epic list",
+        { epicCount: projection.epics.length },
+        error,
+      );
+    });
   }, [runnerHost, projection.epics]);
 
   useEffect(() => {
     void runnerHost.tray
       .setIndicator(projection.indicator)
-      .catch(() => undefined);
+      .catch((error: unknown) => {
+        appLogger.error(
+          "[tray] failed to project indicator state",
+          { indicator: projection.indicator },
+          error,
+        );
+      });
   }, [runnerHost, projection.indicator]);
 }

--- a/clients/gui-app/src/hooks/ui/use-clipboard-copy.ts
+++ b/clients/gui-app/src/hooks/ui/use-clipboard-copy.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { appLogger } from "@/lib/logger";
 
 interface UseClipboardCopyOptions {
   resetMs: number;
@@ -24,7 +25,12 @@ export function useClipboardCopy(
       let writePromise: Promise<void>;
       try {
         writePromise = write();
-      } catch {
+      } catch (error) {
+        appLogger.error(
+          "[clipboard] copy action threw synchronously",
+          {},
+          error,
+        );
         setCopied(false);
         if (onError !== null) onError();
         return;
@@ -36,7 +42,8 @@ export function useClipboardCopy(
           timerRef.current = window.setTimeout(() => setCopied(false), resetMs);
           if (onSuccess !== null) onSuccess();
         },
-        () => {
+        (error: unknown) => {
+          appLogger.error("[clipboard] copy action failed", {}, error);
           setCopied(false);
           if (onError !== null) onError();
         },

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -122,6 +122,18 @@ export const AUTH_ERROR_SESSION_EXPIRED = "session-expired";
  */
 export const AUTH_ERROR_SIGN_IN_FAILED = "sign-in-failed";
 
+function classifyAuthFailureForLog(error: string): string {
+  if (
+    error === AUTH_ERROR_TIMEOUT ||
+    error === AUTH_ERROR_LAUNCH_FAILED ||
+    error === AUTH_ERROR_SESSION_EXPIRED ||
+    error === AUTH_ERROR_SIGN_IN_FAILED
+  ) {
+    return error;
+  }
+  return "external-callback-error";
+}
+
 /**
  * Secure-storage key holding the in-flight PKCE `code_verifier`. Persisted at
  * `signIn()` and consumed at the callback exchange so a cold-start callback
@@ -1050,6 +1062,14 @@ export class AuthService {
     if ("code" in result) {
       if (result.code.length === 0) {
         appLogger.warn("[auth] OAuth callback delivered an empty code", {});
+        this.clearPendingTimeout();
+        if (this.starting) {
+          this.authResolvedDuringStart = true;
+        }
+        void this.applyOAuthCallbackError(
+          AUTH_ERROR_SIGN_IN_FAILED,
+          callbackEpoch,
+        );
         return;
       }
       this.clearPendingTimeout();
@@ -1218,7 +1238,9 @@ export class AuthService {
     if (this.disposed) {
       return;
     }
-    appLogger.warn("[auth] applying auth failure", { errorCode: error });
+    appLogger.warn("[auth] applying auth failure", {
+      errorCode: classifyAuthFailureForLog(error),
+    });
     this.setLastError(error);
     this.applySignedOut();
     await this.clearStoredAuth();

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -28,6 +28,7 @@ import {
 } from "@/stores/auth/auth-store";
 import { normalizeAvatarUrl } from "@/lib/avatar-url";
 import { projectShareableTeams } from "@/hooks/epic/use-epic-shareable-teams";
+import { appLogger, describeLogError } from "@/lib/logger";
 import { AuthTokenStore } from "./auth-token-store";
 
 export interface AuthServiceOptions {
@@ -355,6 +356,9 @@ export class AuthService {
         this.applySignedIn(accepted.token, outcome.user, undefined);
         return;
       }
+      appLogger.warn("[auth] stored session validation failed during startup", {
+        outcome: outcome.kind,
+      });
       await this.clearStoredAuthForStart();
       if (this.shouldStopStartFlow()) {
         return;
@@ -409,7 +413,11 @@ export class AuthService {
     // callback, so we degrade rather than block sign-in.
     await this.runnerHost.secureStorage
       .set(PKCE_VERIFIER_STORAGE_KEY, verifier)
-      .catch(() => {});
+      .catch((error: unknown) => {
+        appLogger.warn("[auth] PKCE verifier persist failed", {
+          error: describeLogError(error),
+        });
+      });
     try {
       const signInUrl = new URL(this.runnerHost.signInUrl);
       signInUrl.searchParams.set(
@@ -421,7 +429,10 @@ export class AuthService {
         CODE_CHALLENGE_METHOD,
       );
       await this.runnerHost.openExternalLink(signInUrl.toString());
-    } catch {
+    } catch (error) {
+      appLogger.warn("[auth] external sign-in launch failed", {
+        error: describeLogError(error),
+      });
       // The shell could not open the external sign-in URL. No callback will
       // arrive, so cancel the pending callback timeout and fail immediately
       // through the same path shell-delivered failures use. This keeps the
@@ -701,9 +712,16 @@ export class AuthService {
       return outcome;
     }
     if (outcome.kind === "rejected") {
+      appLogger.warn("[auth] current session rejected during revalidation", {});
       await this.clearStoredAuth();
       this.setLastError(AUTH_ERROR_SESSION_EXPIRED);
       this.applySignedOut();
+    }
+    if (outcome.kind === "network-error") {
+      appLogger.warn(
+        "[auth] current session revalidation hit network error",
+        {},
+      );
     }
     return outcome;
   }
@@ -745,9 +763,10 @@ export class AuthService {
       // storage to recover - the code can't be exchanged. Warn so the failure
       // is visible in the shipped app log (renderer console is forwarded to the
       // file on warning/error) rather than only manifesting as "Sign-in failed".
-      console.warn(
-        "[auth] sign-in failed: PKCE code verifier missing (cold-start callback with no recoverable verifier)",
-      );
+      appLogger.warn("[auth] sign-in failed: PKCE verifier missing", {
+        callbackKind: "code",
+        expectedEpoch: expectedEpoch ?? "cold-start",
+      });
       await this.applyOAuthCallbackError(
         AUTH_ERROR_SIGN_IN_FAILED,
         expectedEpoch,
@@ -766,6 +785,7 @@ export class AuthService {
       return;
     }
     if (tokens === null) {
+      appLogger.warn("[auth] code exchange returned no tokens", {});
       await this.applyOAuthCallbackError(
         AUTH_ERROR_SIGN_IN_FAILED,
         expectedEpoch,
@@ -789,14 +809,21 @@ export class AuthService {
     }
     if (token.length === 0) {
       if (!this.isOAuthEpochCurrent(expectedOAuthEpoch)) {
+        appLogger.info("[auth] ignored empty token from stale OAuth callback", {
+          expectedEpoch: expectedOAuthEpoch ?? "cold-start",
+        });
         return false;
       }
+      appLogger.warn("[auth] OAuth callback delivered an empty token", {});
       this.clearPendingTimeout();
       this.activeOAuthEpoch = null;
       await this.applyFailure(AUTH_ERROR_SIGN_IN_FAILED);
       return false;
     }
     if (!this.isOAuthEpochCurrent(expectedOAuthEpoch)) {
+      appLogger.info("[auth] ignored stale OAuth callback before validation", {
+        expectedEpoch: expectedOAuthEpoch ?? "cold-start",
+      });
       return false;
     }
     this.clearPendingTimeout();
@@ -809,6 +836,9 @@ export class AuthService {
     // fresh `signIn()` could have minted a new epoch. In that case this
     // callback is stale and must not mutate state.
     if (!this.isOAuthEpochCurrent(expectedOAuthEpoch)) {
+      appLogger.info("[auth] ignored stale OAuth callback after validation", {
+        expectedEpoch: expectedOAuthEpoch ?? "cold-start",
+      });
       return false;
     }
     if (outcome.kind === "valid") {
@@ -840,6 +870,9 @@ export class AuthService {
     }
     // Validation `rejected` OR `network-error`: do not persist. Surface
     // `sign-in-failed` so the header sign-in surface renders a retry CTA.
+    appLogger.warn("[auth] OAuth token validation failed", {
+      outcome: outcome.kind,
+    });
     this.activeOAuthEpoch = null;
     await this.applyFailure(AUTH_ERROR_SIGN_IN_FAILED);
     return false;
@@ -924,7 +957,7 @@ export class AuthService {
     if (attempt === maxAttempts) {
       // Deliberately omit the raw rejection value: a CLI-spawn failure can
       // carry stderr / request context that may include auth material.
-      console.warn(warningMessage);
+      appLogger.warn(warningMessage, { attempts: maxAttempts });
       return;
     }
     await new Promise<void>((resolve) => setTimeout(resolve, attempt * 200));
@@ -1006,10 +1039,17 @@ export class AuthService {
     // hydrate the signed-in state on the next launch.
     const callbackEpoch = this.activeOAuthEpoch;
     if (this.nextEpoch > 0 && callbackEpoch === null) {
+      appLogger.info(
+        "[auth] ignored stale OAuth callback with no active epoch",
+        {
+          nextEpoch: this.nextEpoch,
+        },
+      );
       return;
     }
     if ("code" in result) {
       if (result.code.length === 0) {
+        appLogger.warn("[auth] OAuth callback delivered an empty code", {});
         return;
       }
       this.clearPendingTimeout();
@@ -1046,6 +1086,9 @@ export class AuthService {
       return;
     }
     if (!this.isOAuthEpochCurrent(expectedEpoch)) {
+      appLogger.info("[auth] ignored stale OAuth callback error", {
+        expectedEpoch: expectedEpoch ?? "cold-start",
+      });
       return;
     }
     this.activeOAuthEpoch = null;
@@ -1062,8 +1105,17 @@ export class AuthService {
     }
     this.pendingTimeoutHandle = null;
     if (useAuthStore.getState().status !== "signing-in") {
+      appLogger.info(
+        "[auth] sign-in timeout ignored outside signing-in state",
+        {
+          status: useAuthStore.getState().status,
+        },
+      );
       return;
     }
+    appLogger.warn("[auth] sign-in timed out waiting for callback", {
+      timeoutMs: AUTH_CALLBACK_TIMEOUT_MS,
+    });
     this.activeOAuthEpoch = null;
     this.clearPendingCodeVerifier();
     if (this.starting) {
@@ -1166,6 +1218,7 @@ export class AuthService {
     if (this.disposed) {
       return;
     }
+    appLogger.warn("[auth] applying auth failure", { errorCode: error });
     this.setLastError(error);
     this.applySignedOut();
     await this.clearStoredAuth();
@@ -1207,7 +1260,11 @@ export class AuthService {
     this.pendingCodeVerifier = null;
     void this.runnerHost.secureStorage
       .delete(PKCE_VERIFIER_STORAGE_KEY)
-      .catch(() => {});
+      .catch((error: unknown) => {
+        appLogger.warn("[auth] PKCE verifier delete failed", {
+          error: describeLogError(error),
+        });
+      });
   }
 
   private setLastError(next: string | null): void {

--- a/clients/gui-app/src/lib/auth/manage-subscription-url.ts
+++ b/clients/gui-app/src/lib/auth/manage-subscription-url.ts
@@ -1,3 +1,5 @@
+import { appLogger, describeLogError } from "@/lib/logger";
+
 /**
  * Derives the "Manage subscription" platform URL from the runner host's
  * `authnBaseUrl`. The two URLs are siblings in the desktop `DEPLOY_URLS`
@@ -19,8 +21,12 @@ export function resolveManageSubscriptionUrl(authnBaseUrl: string): string {
       url.pathname = "/";
       return url.toString().replace(/\/$/, "");
     }
-  } catch {
+  } catch (error) {
+    appLogger.warn("[auth] manage subscription URL parse failed", {
+      error: describeLogError(error),
+    });
     // Falls through to the production default.
   }
+  appLogger.info("[auth] using default manage subscription URL", {});
   return "https://platform.traycer.ai";
 }

--- a/clients/gui-app/src/lib/composer/composer-clipboard.ts
+++ b/clients/gui-app/src/lib/composer/composer-clipboard.ts
@@ -5,6 +5,7 @@ import {
   numberValue,
   slashCommandPlainTextFromAttrs,
 } from "@/lib/composer/tiptap-json-content";
+import { appLogger } from "@/lib/logger";
 
 const CLIPBOARD_SCHEMA = "traycer.composer-content";
 const CLIPBOARD_VERSION = 1;
@@ -45,7 +46,10 @@ export async function copyComposerContentToClipboard(
         }),
       ]);
       return;
-    } catch {
+    } catch (error) {
+      appLogger.warn("[composer-clipboard] rich clipboard write failed", {
+        error: error instanceof Error ? error.name : typeof error,
+      });
       await clipboard.writeText(args.plainText);
       return;
     }
@@ -126,7 +130,11 @@ export function parseComposerClipboardHtml(html: string): JsonContent | null {
 function getClipboardData(clipboardData: DataTransfer, type: string): string {
   try {
     return clipboardData.getData(type);
-  } catch {
+  } catch (error) {
+    appLogger.warn("[composer-clipboard] clipboard data read failed", {
+      type,
+      error: error instanceof Error ? error.name : typeof error,
+    });
     return "";
   }
 }

--- a/clients/gui-app/src/lib/composer/landing-image-gc.ts
+++ b/clients/gui-app/src/lib/composer/landing-image-gc.ts
@@ -39,6 +39,7 @@ import {
   type LandingDraftTab,
 } from "@/stores/home/landing-draft-store";
 import { landingComposerLiveImageHashes } from "@/stores/composer/landing-composer-store";
+import { appLogger, describeLogError } from "@/lib/logger";
 
 /**
  * Per-partition byte budget for stored landing images. Flagged TUNABLE — shipped
@@ -80,7 +81,11 @@ export function markLandingDraftsReady(): void {
   // Fire-and-forget startup sweep — best-effort at this boundary. A failure (no
   // IndexedDB in the runtime, a transient DB error) just leaves orphans for the
   // next trigger to reclaim; it must never surface as an unhandled rejection.
-  void reconcile().catch(() => undefined);
+  void reconcile().catch((error: unknown) => {
+    appLogger.warn("[landing-image-gc] startup reconcile failed", {
+      error: describeLogError(error),
+    });
+  });
 }
 
 /** Whether the draft set is known and reconcile is allowed to delete. */

--- a/clients/gui-app/src/lib/epics/deleted-epic-events.ts
+++ b/clients/gui-app/src/lib/epics/deleted-epic-events.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { appLogger, describeLogError } from "@/lib/logger";
 
 const DELETED_EPIC_NOTIFICATION_CHANNEL =
   "traycer-gui-app:deleted-epic-events:v1";
@@ -71,6 +72,11 @@ export function publishDeletedEpicNotification(
     epicIds,
     epicTitlesById: titlesForEpicIds(epicIds, input.epicTitlesById),
   };
+  appLogger.info("[deleted-epic-events] publishing notification", {
+    hostId: input.hostId,
+    epicCount: epicIds.length,
+    sequence,
+  });
   postBroadcastNotification(notification);
   writeStorageNotification(notification);
 }
@@ -113,7 +119,13 @@ function teardownDeletedEpicNotificationTransport(): void {
 
 function handleBroadcastMessage(event: MessageEvent<unknown>): void {
   const notification = parseDeletedEpicNotification(event.data);
-  if (notification === null) return;
+  if (notification === null) {
+    appLogger.warn(
+      "[deleted-epic-events] ignored malformed broadcast message",
+      {},
+    );
+    return;
+  }
   emitIncomingNotification(notification);
 }
 
@@ -121,7 +133,13 @@ function handleStorageEvent(event: StorageEvent): void {
   if (event.key !== DELETED_EPIC_NOTIFICATION_STORAGE_KEY) return;
   if (event.newValue === null) return;
   const notification = parseDeletedEpicNotificationJson(event.newValue);
-  if (notification === null) return;
+  if (notification === null) {
+    appLogger.warn(
+      "[deleted-epic-events] ignored malformed storage message",
+      {},
+    );
+    return;
+  }
   emitIncomingNotification(notification);
 }
 
@@ -177,7 +195,11 @@ function writeStorageNotification(notification: DeletedEpicNotification): void {
       DELETED_EPIC_NOTIFICATION_STORAGE_KEY,
       JSON.stringify(notification),
     );
-  } catch {
+  } catch (error) {
+    appLogger.warn("[deleted-epic-events] storage notification write failed", {
+      epicCount: notification.epicIds.length,
+      error: describeLogError(error),
+    });
     // localStorage can be unavailable in hardened browser contexts. The
     // BroadcastChannel path above is enough when supported.
   }
@@ -195,7 +217,13 @@ function parseDeletedEpicNotificationJson(
 ): DeletedEpicNotification | null {
   try {
     return parseDeletedEpicNotification(JSON.parse(value));
-  } catch {
+  } catch (error) {
+    appLogger.warn(
+      "[deleted-epic-events] storage notification JSON parse failed",
+      {
+        error: describeLogError(error),
+      },
+    );
     return null;
   }
 }

--- a/clients/gui-app/src/lib/history-search.ts
+++ b/clients/gui-app/src/lib/history-search.ts
@@ -6,6 +6,7 @@ import type {
   HistoryWorkspaceRef,
 } from "@/components/home/data/home-page.data";
 import { dedupSortWorkspaces } from "@/components/home/data/home-page.data";
+import { appLogger, describeLogError } from "@/lib/logger";
 
 const historyMatchModeSchema = z.enum(["any", "all"]);
 const historyOwnershipSchema = z.enum(["mine", "shared"]);
@@ -215,7 +216,11 @@ function parseWorkspaceParam(value: string): HistoryWorkspaceRef[] {
     return hostId.length > 0 && workspacePath.length > 0
       ? [{ hostId, workspacePath }]
       : [];
-  } catch {
+  } catch (error) {
+    appLogger.warn("[history-search] workspace parameter parse failed", {
+      valueLength: value.length,
+      error: describeLogError(error),
+    });
     return [];
   }
 }

--- a/clients/gui-app/src/lib/host/durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/durable-stream-transport.ts
@@ -6,6 +6,7 @@ import type { StreamAuthRevalidator } from "@traycer-clients/shared/auth/bearer-
 import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import { buildHostStreamClient } from "@/hooks/host/use-host-stream-client-for";
 import { subscribeStreamWakeReconnect } from "@/lib/host/stream-wake-reconnect";
+import { appLogger } from "@/lib/logger";
 
 export interface DurableStreamTransport {
   readonly wsStreamClient: WsStreamClient<HostStreamRpcRegistry>;
@@ -61,6 +62,9 @@ export function openDurableStreamTransport(params: {
     bearer: params.bearer,
     auth: params.auth,
   });
+  appLogger.info("[stream] durable transport opened", {
+    hasEndpoint: params.endpoint() !== null,
+  });
   const disposers: Array<() => void> = [];
   try {
     disposers.push(
@@ -74,6 +78,7 @@ export function openDurableStreamTransport(params: {
       ),
     );
   } catch (cause) {
+    appLogger.error("[stream] durable transport wiring failed", {}, cause);
     // Roll back every subscription wired so far, then close the socket, so a
     // throw mid-wiring leaves nothing dangling.
     disposers.forEach((dispose) => dispose());
@@ -118,6 +123,7 @@ function subscribeEndpointRedial(
     }
     lastWebsocketUrl = nextWebsocketUrl;
     if (nextWebsocketUrl !== null) {
+      appLogger.info("[stream] durable endpoint changed - reconnecting", {});
       client.reconnectAll("host-endpoint-change");
     }
   });

--- a/clients/gui-app/src/lib/host/host-directory-service.ts
+++ b/clients/gui-app/src/lib/host/host-directory-service.ts
@@ -9,7 +9,7 @@ import type {
   LocalHostSnapshot,
 } from "@traycer-clients/shared/platform/runner-host";
 import type { Disposable } from "@traycer-clients/shared/platform/uri-callback";
-import { appLogger, describeLogError } from "@/lib/logger";
+import { appLogger } from "@/lib/logger";
 
 export interface HostDirectoryServiceOptions {
   readonly runnerHost: IRunnerHost;
@@ -90,7 +90,7 @@ export class HostDirectoryService implements IHostDirectoryService {
       this.localEntry = toLocalEntry(snapshot);
       appLogger.info("[host-directory] local host snapshot changed", {
         hostId: snapshot?.hostId ?? null,
-        hasWebsocketUrl: snapshot !== null && snapshot.websocketUrl !== null,
+        hasWebsocketUrl: snapshot !== null,
         status: snapshot === null ? "missing" : "available",
         version: snapshot?.version ?? null,
       });
@@ -105,14 +105,7 @@ export class HostDirectoryService implements IHostDirectoryService {
   }
 
   async refresh(): Promise<readonly HostDirectoryEntry[]> {
-    try {
-      this.remoteEntries = await this.remoteFetcher();
-    } catch (error) {
-      appLogger.warn("[host-directory] remote refresh failed", {
-        error: describeLogError(error),
-      });
-      throw error;
-    }
+    this.remoteEntries = await this.remoteFetcher();
     this.reconcileSelection();
     this.emit();
     appLogger.info("[host-directory] refresh complete", {

--- a/clients/gui-app/src/lib/host/host-directory-service.ts
+++ b/clients/gui-app/src/lib/host/host-directory-service.ts
@@ -9,6 +9,7 @@ import type {
   LocalHostSnapshot,
 } from "@traycer-clients/shared/platform/runner-host";
 import type { Disposable } from "@traycer-clients/shared/platform/uri-callback";
+import { appLogger, describeLogError } from "@/lib/logger";
 
 export interface HostDirectoryServiceOptions {
   readonly runnerHost: IRunnerHost;
@@ -87,6 +88,12 @@ export class HostDirectoryService implements IHostDirectoryService {
     this.started = true;
     this.localSubscription = this.runnerHost.onLocalHostChange((snapshot) => {
       this.localEntry = toLocalEntry(snapshot);
+      appLogger.info("[host-directory] local host snapshot changed", {
+        hostId: snapshot?.hostId ?? null,
+        hasWebsocketUrl: snapshot !== null && snapshot.websocketUrl !== null,
+        status: snapshot === null ? "missing" : "available",
+        version: snapshot?.version ?? null,
+      });
       this.reconcileSelection();
       this.emit();
     });
@@ -98,9 +105,21 @@ export class HostDirectoryService implements IHostDirectoryService {
   }
 
   async refresh(): Promise<readonly HostDirectoryEntry[]> {
-    this.remoteEntries = await this.remoteFetcher();
+    try {
+      this.remoteEntries = await this.remoteFetcher();
+    } catch (error) {
+      appLogger.warn("[host-directory] remote refresh failed", {
+        error: describeLogError(error),
+      });
+      throw error;
+    }
     this.reconcileSelection();
     this.emit();
+    appLogger.info("[host-directory] refresh complete", {
+      localCount: this.localEntry === null ? 0 : 1,
+      remoteCount: this.remoteEntries.length,
+      totalCount: this.snapshot().length,
+    });
     return this.snapshot();
   }
 
@@ -127,6 +146,10 @@ export class HostDirectoryService implements IHostDirectoryService {
   }
 
   selectById(hostId: string | null): void {
+    appLogger.info("[host-directory] explicit host selection requested", {
+      hostId,
+      clearingSelection: hostId === null,
+    });
     this.explicitSelection = { hostId };
     if (hostId === null) {
       this.setSelected(null);
@@ -226,6 +249,11 @@ export class HostDirectoryService implements IHostDirectoryService {
       return;
     }
     this.selected = entry;
+    appLogger.info("[host-directory] effective host selection changed", {
+      hostId: entry?.hostId ?? null,
+      kind: entry?.kind ?? null,
+      hasWebsocketUrl: entry !== null && entry.websocketUrl !== null,
+    });
     for (const handler of this.selectionListeners) {
       handler(entry);
     }
@@ -240,6 +268,11 @@ export class HostDirectoryService implements IHostDirectoryService {
       }
       if (fresh !== this.selected) {
         this.selected = fresh;
+        appLogger.info("[host-directory] effective host selection refreshed", {
+          hostId: fresh.hostId,
+          kind: fresh.kind,
+          hasWebsocketUrl: fresh.websocketUrl !== null,
+        });
         for (const handler of this.selectionListeners) {
           handler(fresh);
         }

--- a/clients/gui-app/src/lib/host/owned-durable-stream-client.ts
+++ b/clients/gui-app/src/lib/host/owned-durable-stream-client.ts
@@ -1,6 +1,7 @@
 import type { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
+import { appLogger } from "@/lib/logger";
 
 /**
  * Owns a durable transport for the lifetime of one typed stream client — the
@@ -18,6 +19,7 @@ export function openOwnedDurableStreamClient<TClient extends { close(): void }>(
   const transport = openTransport(hostId);
   try {
     const client = build(transport.wsStreamClient);
+    appLogger.info("[stream] owned durable client opened", { hostId });
     return {
       client,
       close: () => {
@@ -26,6 +28,11 @@ export function openOwnedDurableStreamClient<TClient extends { close(): void }>(
       },
     };
   } catch (cause) {
+    appLogger.error(
+      "[stream] owned durable client build failed",
+      { hostId },
+      cause,
+    );
     transport.close();
     throw cause;
   }

--- a/clients/gui-app/src/lib/host/stream-auth-revalidator.ts
+++ b/clients/gui-app/src/lib/host/stream-auth-revalidator.ts
@@ -4,6 +4,7 @@ import type {
   StreamAuthRevalidator,
 } from "@traycer-clients/shared/auth/bearer-revalidator";
 import { useAuthService } from "@/lib/host";
+import { appLogger } from "@/lib/logger";
 
 /**
  * Stream-side auth recovery shared by every LONG-LIVED host stream: the
@@ -30,18 +31,31 @@ export function useStreamAuthRevalidator(): StreamAuthRevalidator {
           // No live signed-in context to revalidate (signed out / provider
           // torn down). Re-dialing without a credential is futile, and the
           // provider rebuilds dependent clients on sign-out anyway.
+          appLogger.warn("[stream-auth] reconnect revalidation rejected", {
+            reason: "no-context",
+          });
           return "rejected";
         }
         if (outcome.kind === "valid") {
           // AuthnV3 accepts the credential (it may have rotated the bearer in
           // place). Re-dial; the open frame reads the live, possibly-fresh
           // bearer.
+          appLogger.info("[stream-auth] reconnect revalidation accepted", {
+            outcome: "valid",
+          });
           return "rotated";
         }
         if (outcome.kind === "network-error") {
+          appLogger.warn(
+            "[stream-auth] reconnect revalidation network error",
+            {},
+          );
           return "network-error";
         }
         // outcome.kind === "rejected": revalidate has already signed out.
+        appLogger.warn("[stream-auth] reconnect revalidation rejected", {
+          reason: "auth-rejected",
+        });
         return "rejected";
       },
     }),

--- a/clients/gui-app/src/lib/host/stream-runtime.tsx
+++ b/clients/gui-app/src/lib/host/stream-runtime.tsx
@@ -76,9 +76,10 @@ export function HostStreamProvider(props: HostStreamProviderProps): ReactNode {
     if (value === null) return;
     appLogger.info("[stream] app stream client created", {
       hostId: readiness.hostId,
-      hasTransport: transportKey !== null,
+      hasTransport:
+        binding !== null && binding.hostClient.getActiveHost() !== null,
     });
-  }, [value, readiness.hostId, transportKey]);
+  }, [binding, readiness.hostId, value]);
   useCloseWsStreamClientOnReplace(value?.wsStreamClient ?? null);
   useStreamWakeReconnect(value?.wsStreamClient ?? null);
   useReconnectStreamOnEndpointChange(

--- a/clients/gui-app/src/lib/host/stream-runtime.tsx
+++ b/clients/gui-app/src/lib/host/stream-runtime.tsx
@@ -19,6 +19,7 @@ import { StreamRuntimeContext } from "@/lib/host/stream-runtime-context";
 import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
 import { useStreamWakeReconnect } from "@/lib/host/stream-wake-reconnect";
+import { appLogger } from "@/lib/logger";
 
 export interface HostStreamProviderProps {
   readonly children: ReactNode;
@@ -71,6 +72,13 @@ export function HostStreamProvider(props: HostStreamProviderProps): ReactNode {
     });
     return { wsStreamClient };
   }, [binding, auth, identityKey]);
+  useEffect(() => {
+    if (value === null) return;
+    appLogger.info("[stream] app stream client created", {
+      hostId: readiness.hostId,
+      hasTransport: transportKey !== null,
+    });
+  }, [value, readiness.hostId, transportKey]);
   useCloseWsStreamClientOnReplace(value?.wsStreamClient ?? null);
   useStreamWakeReconnect(value?.wsStreamClient ?? null);
   useReconnectStreamOnEndpointChange(
@@ -112,6 +120,7 @@ function useReconnectStreamOnEndpointChange(
       transportKey !== null &&
       prev.transportKey !== transportKey
     ) {
+      appLogger.info("[stream] app stream endpoint changed - reconnecting", {});
       client.reconnectAll("host-endpoint-change");
     }
   }, [client, transportKey]);

--- a/clients/gui-app/src/lib/host/stream-wake-reconnect.ts
+++ b/clients/gui-app/src/lib/host/stream-wake-reconnect.ts
@@ -3,6 +3,7 @@ import type { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-s
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import { onWakeReconnect } from "@/lib/host/wake-reconnect";
+import { appLogger } from "@/lib/logger";
 import { useRunnerHost } from "@/providers/use-runner-host";
 
 /**
@@ -17,10 +18,16 @@ export function subscribeStreamWakeReconnect(
   runnerHost: IRunnerHost,
 ): () => void {
   const offOnline = onWakeReconnect(() => {
+    appLogger.info("[stream] wake reconnect requested", {
+      reason: "wake-online",
+    });
     client.reconnectAll("wake-online");
   });
   try {
     const resumeSubscription = runnerHost.onSystemResumed(() => {
+      appLogger.info("[stream] wake reconnect requested", {
+        reason: "wake-resume",
+      });
       client.reconnectAll("wake-resume");
     });
     return () => {
@@ -28,6 +35,7 @@ export function subscribeStreamWakeReconnect(
       resumeSubscription.dispose();
     };
   } catch (cause) {
+    appLogger.error("[stream] wake reconnect subscription failed", {}, cause);
     // Roll back the already-registered 'online' listener if wiring the OS-resume
     // subscription throws, so a failed open never leaks a dangling reconnect
     // callback (the disposer is never returned to the caller in that case).

--- a/clients/gui-app/src/lib/host/wake-reconnect.ts
+++ b/clients/gui-app/src/lib/host/wake-reconnect.ts
@@ -1,3 +1,5 @@
+import { appLogger } from "@/lib/logger";
+
 /**
  * Renderer wake / reconnect signal.
  *
@@ -37,7 +39,8 @@ function notifyWake(): void {
     for (const listener of Array.from(listeners)) {
       try {
         listener();
-      } catch {
+      } catch (error) {
+        appLogger.error("[wake-reconnect] listener failed", {}, error);
         // A failing subscriber must not block the others.
       }
     }

--- a/clients/gui-app/src/lib/logger.ts
+++ b/clients/gui-app/src/lib/logger.ts
@@ -20,6 +20,9 @@ const SENSITIVE_KEY_PATTERN =
 const SENSITIVE_QUERY_PARAM_PATTERN =
   /([?&](?:access_token|refresh_token|id_token|token|code|code_verifier|password|secret|client_secret|api_key|authorization)=)([^&#\s]+)/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const SENSITIVE_INLINE_VALUE_PATTERN =
+  /(\b(?:access[_-]?token|refresh[_-]?token|id[_-]?token|token|code[_-]?verifier|password|secret|client[_-]?secret|api[_-]?key|authorization|cookie|credential)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;}&]+)/gi;
+const NOT_SCALAR_LOG_VALUE = Symbol("not-scalar-log-value");
 
 export const appLogger = {
   debug(message: string, fields: AppLogFields): void {
@@ -49,17 +52,16 @@ export const appLogger = {
 export function redactLogText(value: string): string {
   const redacted = value
     .replace(SENSITIVE_QUERY_PARAM_PATTERN, "$1<redacted>")
-    .replace(BEARER_PATTERN, "Bearer <redacted>");
+    .replace(BEARER_PATTERN, "Bearer <redacted>")
+    .replace(SENSITIVE_INLINE_VALUE_PATTERN, "$1<redacted>");
   return redacted.length > MAX_LOG_STRING_LENGTH
     ? `${redacted.slice(0, MAX_LOG_STRING_LENGTH)}...<truncated>`
     : redacted;
 }
 
 export function sanitizeLogValue(value: unknown, depth: number): AppLogValue {
-  if (value === null) return null;
-  if (typeof value === "string") return redactLogText(value);
-  if (typeof value === "number" || typeof value === "boolean") return value;
-  if (typeof value === "bigint") return value.toString();
+  const scalar = sanitizeScalarLogValue(value);
+  if (scalar !== NOT_SCALAR_LOG_VALUE) return scalar;
   if (depth >= MAX_LOG_DEPTH) return "<max-depth>";
   if (Array.isArray(value)) {
     return value
@@ -81,8 +83,7 @@ export function sanitizeLogValue(value: unknown, depth: number): AppLogValue {
     }
     return sanitized;
   }
-  if (typeof value === "undefined") return "<undefined>";
-  return redactLogText(String(value));
+  return safeLogTextFromUnknown(value);
 }
 
 export function describeLogError(error: unknown): AppLogFields {
@@ -96,7 +97,7 @@ export function describeLogError(error: unknown): AppLogFields {
   }
   return {
     name: typeof error,
-    message: redactLogText(String(error)),
+    message: safeLogTextFromUnknown(error),
     stack: null,
   };
 }
@@ -140,4 +141,32 @@ function emitLog(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizeScalarLogValue(
+  value: unknown,
+): AppLogValue | typeof NOT_SCALAR_LOG_VALUE {
+  if (value === null) return null;
+  if (typeof value === "string") return redactLogText(value);
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "undefined") return "<undefined>";
+  if (typeof value === "function") return "<function>";
+  if (typeof value === "symbol") return value.description ?? "<symbol>";
+  return NOT_SCALAR_LOG_VALUE;
+}
+
+function safeLogTextFromUnknown(value: unknown): string {
+  if (typeof value === "string") return redactLogText(value);
+  if (typeof value === "symbol") {
+    return redactLogText(value.description ?? "<symbol>");
+  }
+  if (typeof value === "function") return "<function>";
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "undefined") return "<undefined>";
+  if (typeof value === "object") return Object.prototype.toString.call(value);
+  return "<unknown>";
 }

--- a/clients/gui-app/src/lib/logger.ts
+++ b/clients/gui-app/src/lib/logger.ts
@@ -1,18 +1,16 @@
-import log from "electron-log";
-import { app } from "electron";
-import { join } from "node:path";
-import { isDevBuild } from "../../config";
+export type AppLogLevel = "debug" | "info" | "warn" | "error";
 
-export type SafeLogValue =
+export type AppLogValue =
   | string
   | number
   | boolean
   | null
-  | readonly SafeLogValue[]
-  | { readonly [key: string]: SafeLogValue };
+  | readonly AppLogValue[]
+  | { readonly [key: string]: AppLogValue };
 
-export type SafeLogFields = Readonly<Record<string, SafeLogValue>>;
+export type AppLogFields = Readonly<Record<string, AppLogValue>>;
 
+const STRUCTURED_LOG_PREFIX = "[traycer-gui]";
 const MAX_LOG_STRING_LENGTH = 1_000;
 const MAX_LOG_DEPTH = 4;
 const MAX_LOG_ARRAY_ITEMS = 20;
@@ -23,31 +21,30 @@ const SENSITIVE_QUERY_PARAM_PATTERN =
   /([?&](?:access_token|refresh_token|id_token|token|code|code_verifier|password|secret|client_secret|api_key|authorization)=)([^&#\s]+)/gi;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 
-/**
- * Configures `electron-log` so the desktop shell, the renderer, and any
- * spawned host-lifecycle diagnostics flow through a single sink.
- *
- * The host itself writes to `~/.traycer/host/host.log` in production and
- * `~/.traycer/host/dev/host.log` in dev - see `host-paths.ts`. Our own
- * main-process log is kept separate at
- * `userData/traycer-desktop.log` so the two are easy to differentiate in
- * support bundles.
- */
-export function initLogger(): void {
-  const logPath = resolveDesktopLogPath();
-  log.transports.file.resolvePathFn = () => logPath;
-  log.transports.file.level = "info";
-  // Console transport is noisy by design (every IPC + lifecycle log).
-  // Shipped builds get the same `info` level the file transport does so
-  // electron-log's stdout/stderr capture doesn't leak debug payloads to a
-  // user's system console; the dev slot keeps `debug`.
-  log.transports.console.level = isDevBuild ? "debug" : "info";
-  log.info("[desktop] logger initialised", { logPath });
-}
-
-export function resolveDesktopLogPath(): string {
-  return join(app.getPath("userData"), "traycer-desktop.log");
-}
+export const appLogger = {
+  debug(message: string, fields: AppLogFields): void {
+    if (!import.meta.env.DEV) return;
+    emitLog("debug", message, fields);
+  },
+  info(message: string, fields: AppLogFields): void {
+    emitLog("info", message, fields);
+  },
+  warn(message: string, fields: AppLogFields): void {
+    emitLog("warn", message, fields);
+  },
+  error(message: string, fields: AppLogFields, error: unknown): void {
+    emitLog("error", message, {
+      ...fields,
+      error: describeLogError(error),
+    });
+  },
+  errorSummary(message: string, fields: AppLogFields, error: unknown): void {
+    emitLog("error", message, {
+      ...fields,
+      error: describeLogErrorSummary(error),
+    });
+  },
+};
 
 export function redactLogText(value: string): string {
   const redacted = value
@@ -58,7 +55,7 @@ export function redactLogText(value: string): string {
     : redacted;
 }
 
-export function sanitizeLogValue(value: unknown, depth: number): SafeLogValue {
+export function sanitizeLogValue(value: unknown, depth: number): AppLogValue {
   if (value === null) return null;
   if (typeof value === "string") return redactLogText(value);
   if (typeof value === "number" || typeof value === "boolean") return value;
@@ -73,7 +70,7 @@ export function sanitizeLogValue(value: unknown, depth: number): SafeLogValue {
     return describeLogError(value);
   }
   if (isRecord(value)) {
-    const sanitized: Record<string, SafeLogValue> = {};
+    const sanitized: Record<string, AppLogValue> = {};
     for (const [key, entry] of Object.entries(value).slice(
       0,
       MAX_LOG_OBJECT_KEYS,
@@ -88,7 +85,7 @@ export function sanitizeLogValue(value: unknown, depth: number): SafeLogValue {
   return redactLogText(String(value));
 }
 
-export function describeLogError(error: unknown): SafeLogFields {
+export function describeLogError(error: unknown): AppLogFields {
   if (error instanceof Error) {
     return {
       name: error.name,
@@ -104,8 +101,43 @@ export function describeLogError(error: unknown): SafeLogFields {
   };
 }
 
+export function describeLogErrorSummary(error: unknown): AppLogFields {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      messageLength: error.message.length,
+      stack: null,
+    };
+  }
+  return {
+    name: typeof error,
+    messageLength: String(error).length,
+    stack: null,
+  };
+}
+
+function emitLog(
+  level: AppLogLevel,
+  message: string,
+  fields: AppLogFields,
+): void {
+  const payload = {
+    source: "gui-app",
+    level,
+    message: redactLogText(message),
+    fields: sanitizeLogValue(fields, 0),
+  };
+  const line = `${STRUCTURED_LOG_PREFIX} ${JSON.stringify(payload)}`;
+  if (level === "error") {
+    console.error(line);
+    return;
+  }
+  // Desktop production forwards renderer warning/error console messages only.
+  // The structured payload preserves the logical level; desktop remaps it back
+  // to info/warn/error when writing traycer-desktop.log.
+  console.warn(line);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
-
-export { log };

--- a/clients/gui-app/src/lib/perf/main-thread-block-probe.ts
+++ b/clients/gui-app/src/lib/perf/main-thread-block-probe.ts
@@ -1,5 +1,5 @@
-/* eslint-disable no-console -- console is the intended diagnostic sink for
-   this profiling-only probe; there is no telemetry pipeline in gui-app yet. */
+import { appLogger } from "@/lib/logger";
+
 /**
  * Renderer main-thread block probe.
  *
@@ -75,14 +75,19 @@ export function startMainThreadBlockProbe(): void {
       if (entry.duration < REPORT_THRESHOLD_MS) continue;
       const blockedMs = Math.round(entry.duration);
       const atMs = Math.round(entry.startTime);
-      console.warn(
-        `[main-thread-block] ${blockedMs}ms blocked at ${atMs}ms (${attributionLabel(entry)})`,
-      );
+      appLogger.warn("[main-thread-block] renderer main thread blocked", {
+        blockedMs,
+        atMs,
+        attribution: attributionLabel(entry),
+      });
     }
   });
   try {
     observer.observe({ entryTypes: ["longtask"] });
-  } catch {
+  } catch (error) {
+    appLogger.warn("[main-thread-block] observer start failed", {
+      error: error instanceof Error ? error.name : typeof error,
+    });
     // `longtask` not observable in this engine; leave the probe inert.
     started = false;
   }

--- a/clients/gui-app/src/lib/perf/terminal-load-perf.ts
+++ b/clients/gui-app/src/lib/perf/terminal-load-perf.ts
@@ -1,5 +1,5 @@
-/* eslint-disable no-console -- console is the intended diagnostic sink for
-   this profiling-only module; there is no telemetry pipeline in gui-app yet. */
+import { appLogger } from "@/lib/logger";
+
 /**
  * First-time load instrumentation for terminal and TUI (terminal-agent) tiles.
  *
@@ -24,13 +24,12 @@
  *
  * Each phase is recorded once (the first occurrence) per session, keyed by
  * `sessionId`, so re-renders and reattach frames don't perturb the numbers.
- * On `first-render` the timeline is logged as a console table of per-phase
- * deltas and a `performance.measure` is emitted for each span so the spans
- * also show up in the browser Performance panel.
+ * On `first-render` the timeline is logged as a structured renderer event and
+ * a `performance.measure` is emitted for each span so the spans also show up in
+ * the browser Performance panel.
  *
  * Gating: on by default in dev, off under test, and opt-in for production
- * builds via `localStorage["traycer:perf:terminal"] = "1"`. No telemetry sink
- * exists in this app yet, so console is the established diagnostic surface.
+ * builds via `localStorage["traycer:perf:terminal"] = "1"`.
  */
 
 // Ordered so the summary table and the adjacent-span measures read top-to-bottom
@@ -143,7 +142,13 @@ function finishTerminalLoad(
           markName(sessionId, previousPhase),
           markName(sessionId, phase),
         );
-      } catch {
+      } catch (error) {
+        appLogger.debug("[terminal-perf] span measure skipped", {
+          sessionId,
+          fromPhase: previousPhase,
+          toPhase: phase,
+          error: error instanceof Error ? error.name : typeof error,
+        });
         // A mark may be missing if a phase was skipped; the table still
         // reports the spans we did capture.
       }
@@ -153,11 +158,12 @@ function finishTerminalLoad(
   }
 
   const totalMs = roundMs(previous - timeline.startedAt);
-  console.groupCollapsed(
-    `[terminal-perf] ${timeline.kind} ${sessionId} first paint in ${totalMs}ms`,
-  );
-  console.table(table);
-  console.groupEnd();
+  appLogger.info("[terminal-perf] first paint measured", {
+    sessionId,
+    kind: timeline.kind,
+    totalMs,
+    phases: table,
+  });
 }
 
 /**
@@ -169,7 +175,7 @@ export function markXtermChunkLoad(durationMs: number): void {
   if (!instrumentationEnabled()) return;
   if (chunkLoadLogged) return;
   chunkLoadLogged = true;
-  console.info(
-    `[terminal-perf] xterm chunk loaded in ${roundMs(durationMs)}ms (first terminal only)`,
-  );
+  appLogger.info("[terminal-perf] xterm chunk loaded", {
+    durationMs: roundMs(durationMs),
+  });
 }

--- a/clients/gui-app/src/lib/persist/wipe.ts
+++ b/clients/gui-app/src/lib/persist/wipe.ts
@@ -21,6 +21,7 @@
 
 import { PERSIST_PREFIX } from "@/lib/persist/keys";
 import { flushActiveDesktopPerWindowProjection } from "@/lib/windows/per-window-projection-debounce";
+import { appLogger, describeLogError } from "@/lib/logger";
 
 // The `:` boundary is load-bearing: a bare `startsWith(PERSIST_PREFIX)` would
 // also sweep a hypothetical `traycer-gui-appX:foo` key. Anchoring on the colon
@@ -34,7 +35,7 @@ const PERSIST_KEY_BOUNDARY = `${PERSIST_PREFIX}:`;
 // never any other future `traycer-gui-app:`-prefixed db.
 const LANDING_IMAGE_DB_SUFFIX = ":landing-images";
 
-function sweepStorage(storage: Storage): void {
+function sweepStorage(storage: Storage): number {
   // Collect keys first, then remove: mutating during index iteration shifts the
   // remaining indices and would skip keys.
   const keysToRemove: string[] = [];
@@ -47,6 +48,7 @@ function sweepStorage(storage: Storage): void {
   for (const key of keysToRemove) {
     storage.removeItem(key);
   }
+  return keysToRemove.length;
 }
 
 // Wrap `indexedDB.deleteDatabase` (an async `IDBOpenDBRequest`) in a promise
@@ -86,7 +88,13 @@ function indexedDBFactory(): IDBFactory | undefined {
 // not a wipe failure.
 async function deleteLandingImageDatabases(): Promise<void> {
   const factory = indexedDBFactory();
-  if (typeof factory?.databases !== "function") return;
+  if (typeof factory?.databases !== "function") {
+    appLogger.info(
+      "[persist] landing image database enumeration unavailable",
+      {},
+    );
+    return;
+  }
   const databases = await factory.databases();
   const names = databases
     .map((db) => db.name)
@@ -99,16 +107,29 @@ async function deleteLandingImageDatabases(): Promise<void> {
   // Best-effort per partition: a single db whose delete errors must not abort the
   // rest of the wipe or — critically — the reload (step 4), which is the real
   // recovery and tears down every connection anyway. The bytes are re-pasteable.
+  let failedCount = 0;
   await Promise.all(
     names.map((name) =>
-      deleteDatabaseAwaitable(factory, name).catch(() => undefined),
+      deleteDatabaseAwaitable(factory, name).catch((error: unknown) => {
+        failedCount += 1;
+        appLogger.warn("[persist] landing image database delete failed", {
+          error: describeLogError(error),
+        });
+      }),
     ),
   );
+  appLogger.info("[persist] landing image database delete complete", {
+    databaseCount: names.length,
+    failedCount,
+  });
 }
 
 export async function clearAllPersistedStores(args: {
   hostClear: (() => Promise<void>) | null;
 }): Promise<void> {
+  appLogger.info("[persist] clearing local GUI state", {
+    hasHostClear: args.hostClear !== null,
+  });
   // 1. Drain any pending debounced projection push FIRST. This flushes it to
   //    the host and clears `pendingPatch`, so the beforeunload/pagehide flush
   //    fired during the reload below can't re-push pre-wipe state and re-create
@@ -118,12 +139,25 @@ export async function clearAllPersistedStores(args: {
   // it (older preload) the drain above is the degraded fallback; in web mode
   // `hostClear` is null and there is nothing host-side to clear.
   if (args.hostClear !== null) {
-    await args.hostClear();
+    try {
+      await args.hostClear();
+    } catch (error) {
+      appLogger.warn("[persist] host-side state clear failed", {
+        error: describeLogError(error),
+      });
+      throw error;
+    }
+  } else {
+    appLogger.info("[persist] host-side state clear unavailable", {});
   }
 
   // 2. Blanket-prefix sweep across BOTH storages.
-  sweepStorage(window.localStorage);
-  sweepStorage(window.sessionStorage);
+  const localStorageCount = sweepStorage(window.localStorage);
+  const sessionStorageCount = sweepStorage(window.sessionStorage);
+  appLogger.info("[persist] browser storage sweep complete", {
+    localStorageCount,
+    sessionStorageCount,
+  });
 
   // 3. Drop every landing-image IndexedDB partition (one per runtime window).
   //    The localStorage sweep above already removed the draft keys that point
@@ -132,5 +166,6 @@ export async function clearAllPersistedStores(args: {
   await deleteLandingImageDatabases();
 
   // 4. Reload last.
+  appLogger.info("[persist] local GUI state clear complete - reloading", {});
   window.location.reload();
 }

--- a/clients/gui-app/src/lib/persistent-history.ts
+++ b/clients/gui-app/src/lib/persistent-history.ts
@@ -4,6 +4,7 @@ import {
   type HistoryState,
   type RouterHistory,
 } from "@tanstack/react-router";
+import { appLogger, describeLogError } from "@/lib/logger";
 
 /**
  * `ParsedHistoryState` is not exported from `@tanstack/react-router`, so we
@@ -78,7 +79,11 @@ function loadPersistedState(windowId: string | null): PersistedState {
       parsed.entries.length - 1,
     );
     return { entries: parsed.entries, index: safeIndex };
-  } catch {
+  } catch (error) {
+    appLogger.warn("[history] persisted route state load failed", {
+      windowId,
+      error: describeLogError(error),
+    });
     return { entries: ["/"], index: 0 };
   }
 }
@@ -128,7 +133,12 @@ function persistState(
       buildStorageKey(windowId),
       JSON.stringify({ entries: capped, index: cappedIndex }),
     );
-  } catch {
+  } catch (error) {
+    appLogger.warn("[history] persisted route state write failed", {
+      windowId,
+      entryCount: entries.length,
+      error: describeLogError(error),
+    });
     // localStorage unavailable (private mode, quota, disabled) - fail silent.
   }
 }
@@ -138,7 +148,11 @@ function clearPersistedState(windowId: string | null): void {
   if (windowId === null) return;
   try {
     window.localStorage.removeItem(buildStorageKey(windowId));
-  } catch {
+  } catch (error) {
+    appLogger.warn("[history] persisted route state clear failed", {
+      windowId,
+      error: describeLogError(error),
+    });
     // localStorage unavailable (private mode, quota, disabled) - fail silent.
   }
 }
@@ -155,7 +169,11 @@ function consumeShellOverride(
     const key = buildConsumedInitialRouteKey(windowId, normalized);
     if (window.sessionStorage.getItem(key) === "true") return null;
     window.sessionStorage.setItem(key, "true");
-  } catch {
+  } catch (error) {
+    appLogger.warn("[history] initial route consume marker failed", {
+      windowId,
+      error: describeLogError(error),
+    });
     // sessionStorage unavailable - keep the explicit route so boot still works.
   }
   return normalized;

--- a/clients/gui-app/src/lib/persistent-history.ts
+++ b/clients/gui-app/src/lib/persistent-history.ts
@@ -69,11 +69,18 @@ function buildConsumedInitialRouteKey(
 function loadPersistedState(windowId: string | null): PersistedState {
   if (typeof window === "undefined") return { entries: ["/"], index: 0 };
   if (windowId === null) return { entries: ["/"], index: 0 };
+  const storageKey = buildStorageKey(windowId);
   try {
-    const raw = window.localStorage.getItem(buildStorageKey(windowId));
+    const raw = window.localStorage.getItem(storageKey);
     if (raw === null) return { entries: ["/"], index: 0 };
     const parsed: unknown = JSON.parse(raw);
-    if (!isPersistedState(parsed)) return { entries: ["/"], index: 0 };
+    if (!isPersistedState(parsed)) {
+      appLogger.warn("[history] persisted route state rejected", {
+        windowId,
+      });
+      removePersistedState(storageKey);
+      return { entries: ["/"], index: 0 };
+    }
     const safeIndex = Math.min(
       Math.max(parsed.index, 0),
       parsed.entries.length - 1,
@@ -84,7 +91,16 @@ function loadPersistedState(windowId: string | null): PersistedState {
       windowId,
       error: describeLogError(error),
     });
+    removePersistedState(storageKey);
     return { entries: ["/"], index: 0 };
+  }
+}
+
+function removePersistedState(storageKey: string): void {
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch {
+    // Keep route recovery best-effort; the load failure was already logged.
   }
 }
 

--- a/clients/gui-app/src/lib/query-client.ts
+++ b/clients/gui-app/src/lib/query-client.ts
@@ -1,7 +1,47 @@
-import { QueryClient } from "@tanstack/react-query";
+import {
+  MutationCache,
+  QueryCache,
+  QueryClient,
+  type QueryKey,
+} from "@tanstack/react-query";
 import { RetryableTransportError } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  appLogger,
+  describeLogErrorSummary,
+  type AppLogValue,
+} from "@/lib/logger";
+
+const SAFE_QUERY_KEY_MARKERS = new Set([
+  "auth",
+  "host",
+  "git",
+  "capabilities",
+  "listChangedFiles",
+  "fileDiff",
+]);
 
 export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error, query) => {
+      appLogger.warn("[query] request failed", {
+        queryKey: summarizeQueryKey(query.queryKey),
+        failureCount: query.state.fetchFailureCount,
+        fetchStatus: query.state.fetchStatus,
+        status: query.state.status,
+        error: describeLogErrorSummary(error),
+      });
+    },
+  }),
+  mutationCache: new MutationCache({
+    onError: (error, _variables, _context, mutation) => {
+      appLogger.warn("[mutation] request failed", {
+        mutationKey: summarizeQueryKey(mutation.options.mutationKey ?? []),
+        failureCount: mutation.state.failureCount,
+        status: mutation.state.status,
+        error: describeLogErrorSummary(error),
+      });
+    },
+  }),
   defaultOptions: {
     queries: {
       staleTime: 60 * 1000,
@@ -16,3 +56,33 @@ export const queryClient = new QueryClient({
     },
   },
 });
+
+function summarizeQueryKey(queryKey: QueryKey): AppLogValue {
+  return queryKey.slice(0, 4).map((part) => {
+    if (typeof part === "string") {
+      return safeQueryKeyString(part);
+    }
+    if (Array.isArray(part)) {
+      return "array";
+    }
+    if (part !== null && typeof part === "object") {
+      return "object";
+    }
+    return typeof part;
+  });
+}
+
+function safeQueryKeyString(value: string): string {
+  if (SAFE_QUERY_KEY_MARKERS.has(value)) {
+    return value;
+  }
+  if (value.startsWith("runner.")) {
+    return value;
+  }
+  if (value.includes("/") || value.includes("\\") || value.length > 80) {
+    return "string";
+  }
+  return value.includes(".") && /^[a-zA-Z0-9_.:-]+$/.test(value)
+    ? value
+    : "string";
+}

--- a/clients/gui-app/src/lib/terminal-theme-scheduler.ts
+++ b/clients/gui-app/src/lib/terminal-theme-scheduler.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from "@xterm/xterm";
+import { appLogger } from "@/lib/logger";
 
 /**
  * Coalesce xterm.js texture-atlas clears across all mounted terminals into a
@@ -22,7 +23,10 @@ function flush(): void {
     if (addon === null) continue;
     try {
       addon.clearTextureAtlas();
-    } catch {
+    } catch (error) {
+      appLogger.warn("[terminal-theme] texture atlas clear failed", {
+        error: error instanceof Error ? error.name : typeof error,
+      });
       // Addon was disposed mid-frame; xterm's own renderer takes over.
     }
   }

--- a/clients/gui-app/src/providers/host-runtime-provider.tsx
+++ b/clients/gui-app/src/providers/host-runtime-provider.tsx
@@ -28,6 +28,7 @@ import type { VersionedRpcRegistry } from "@traycer/protocol/framework/index";
 import { AuthService } from "@/lib/auth/auth-service";
 import { HostDirectoryService } from "@/lib/host/host-directory-service";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { appLogger } from "@/lib/logger";
 import { useRunnerHost } from "@/providers/use-runner-host";
 
 export interface HostRuntimeBinding<Registry extends VersionedRpcRegistry> {
@@ -222,29 +223,52 @@ export function createHostRuntime<
 
       const activeRuntime = runtime;
       void (async () => {
-        await auth.start();
-        if (isDisposed()) {
+        let phase = "auth.start";
+        try {
+          appLogger.info("[host-runtime] startup begin", {
+            hasCustomMessenger: messengerFactory !== null,
+            hasRemoteFetcher: remoteFetcher !== null,
+          });
+          await auth.start();
+          if (isDisposed()) {
+            auth.dispose();
+            activeRuntime.dispose();
+            directory.dispose();
+            return;
+          }
+          phase = "directory.start";
+          await directory.start();
+          if (isDisposed()) {
+            auth.dispose();
+            activeRuntime.dispose();
+            directory.dispose();
+            return;
+          }
+          phase = "runtime.start";
+          activeRuntime.start();
+          const nextBinding = {
+            runtime: activeRuntime,
+            hostClient: activeRuntime.hostClient,
+            directory,
+            auth,
+          };
+          setLatestBindingSnapshot(nextBinding);
+          setBinding(nextBinding);
+          appLogger.info("[host-runtime] startup complete", {
+            hostCardinality: directory.getCardinality(),
+            hasLocalHost: directory.getLocalEntry() !== null,
+          });
+        } catch (error) {
+          appLogger.error("[host-runtime] startup failed", { phase }, error);
           auth.dispose();
           activeRuntime.dispose();
           directory.dispose();
+          if (!isDisposed()) {
+            setLatestBindingSnapshot(null);
+            setBinding(null);
+          }
           return;
         }
-        await directory.start();
-        if (isDisposed()) {
-          auth.dispose();
-          activeRuntime.dispose();
-          directory.dispose();
-          return;
-        }
-        activeRuntime.start();
-        const nextBinding = {
-          runtime: activeRuntime,
-          hostClient: activeRuntime.hostClient,
-          directory,
-          auth,
-        };
-        setLatestBindingSnapshot(nextBinding);
-        setBinding(nextBinding);
       })();
 
       return () => {

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -14,6 +14,7 @@ import { useSyncExternalStore } from "react";
  * regardless of the cap.
  */
 export const DEFAULT_MAX_LIVE_EPICS = 5;
+const loggedLiveTitleReadFailures = new Set<string>();
 
 export interface OpenEpicSessionRegistryOptions {
   readonly maxLive: number;
@@ -304,11 +305,14 @@ function readLiveTitle(handle: OpenEpicStoreHandle, epicId: string): string {
     const title = epicMap.get("title");
     return typeof title === "string" ? title : "";
   } catch (error) {
-    appLogger.error(
-      "[open-epic-session-registry] failed to read live title",
-      { epicId },
-      error,
-    );
+    if (!loggedLiveTitleReadFailures.has(epicId)) {
+      loggedLiveTitleReadFailures.add(epicId);
+      appLogger.error(
+        "[open-epic-session-registry] failed to read live title",
+        { epicId },
+        error,
+      );
+    }
     return "";
   }
 }

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -1,4 +1,5 @@
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import { appLogger } from "@/lib/logger";
 import { useSyncExternalStore } from "react";
 
 /**
@@ -221,7 +222,7 @@ export class OpenEpicSessionRegistry {
       const state = entry.handle.store.getState();
       if (!state.isDirty) continue;
       const title = resolveUnsyncedTitle(
-        readLiveTitle(entry.handle),
+        readLiveTitle(entry.handle, entry.epicId),
         state.snapshotMeta?.epicLight?.title ?? "",
         entry.epicId,
       );
@@ -297,12 +298,17 @@ function resolveUnsyncedTitle(
   return epicId;
 }
 
-function readLiveTitle(handle: OpenEpicStoreHandle): string {
+function readLiveTitle(handle: OpenEpicStoreHandle, epicId: string): string {
   try {
     const epicMap = handle.doc.getMap("epic");
     const title = epicMap.get("title");
     return typeof title === "string" ? title : "";
-  } catch {
+  } catch (error) {
+    appLogger.error(
+      "[open-epic-session-registry] failed to read live title",
+      { epicId },
+      error,
+    );
     return "";
   }
 }

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -57,6 +57,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import { createEpicProjector, type EpicProjector } from "./epic-projector";
 import { useAuthStore } from "@/stores/auth/auth-store";
+import { appLogger } from "@/lib/logger";
 
 /**
  * Factory contract for the stream-client layer. Production wires this to
@@ -1350,9 +1351,10 @@ export function createOpenEpicStore(
               // diagnose failed migrations from a renderer console dump even
               // when the host log is unavailable; the modal copy itself is
               // fixed and never displays this string.
-              console.warn(
-                `[epic-migration] host reported migrationFailed for epic=${epicId}: ${reason}`,
-              );
+              appLogger.warn("[epic-migration] host reported migrationFailed", {
+                epicId,
+                reason,
+              });
               set({
                 migration: ERROR_MIGRATION_SLICE,
               });
@@ -1384,9 +1386,9 @@ export function createOpenEpicStore(
                 // `hasConnectedOnce` keeps this to genuine RE-connections (wake)
                 // - not the first connect or a `requestFreshSnapshot` re-open,
                 // which would pollute the trace.
-                console.warn(
-                  `[epic-stream] cloud sync connected epic=${epicId}`,
-                );
+                appLogger.info("[epic-stream] cloud sync connected", {
+                  epicId,
+                });
               }
               // A genuine cloud "connected" frame is the ONLY thing that latches
               // "connected once" - never the optimistic default - so a new
@@ -1413,9 +1415,10 @@ export function createOpenEpicStore(
                 // `warn` is the only info-ish console level lint permits here.
                 // Gated on `hasConnectedOnce` so it marks only RE-connections
                 // (wake), not the initial connect or a fresh-snapshot re-open.
-                console.warn(
-                  `[epic-stream] transport open (context registered) epic=${epicId}`,
-                );
+                appLogger.info("[epic-stream] transport open", {
+                  epicId,
+                  contextRegistered: true,
+                });
               }
               const nextStatus = syncCurrentConnectionStatus();
               hasFreshRootSnapshotForOpenCycle = false;

--- a/clients/traycer-cli/src/auth/login-flow.ts
+++ b/clients/traycer-cli/src/auth/login-flow.ts
@@ -19,6 +19,7 @@ import {
 } from "../../../shared/auth/pkce";
 import { writeCredentials } from "../store/credentials";
 import { config } from "../config";
+import { createCliLogger, type ILogger } from "../logger";
 
 const CALLBACK_PATH = "/callback";
 const CODE_QUERY_PARAM = "code";
@@ -185,7 +186,12 @@ interface LoginSuccess {
 }
 
 export async function runLoginFlow(): Promise<LoginSuccess> {
+  const logger = createCliLogger(config.environment);
   const { authnBaseUrl, cloudUiBaseUrl } = config;
+  logger.info("Login flow started", {
+    environment: config.environment,
+    platform: osPlatform(),
+  });
   // PKCE (RFC 7636): the verifier stays in this process; only its S256
   // challenge goes to cloud-ui, which issues a one-time `code` (not tokens) in
   // the redirect. A sibling process that races the loopback callback gets a
@@ -194,7 +200,14 @@ export async function runLoginFlow(): Promise<LoginSuccess> {
   const state = randomUUID();
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await deriveCodeChallenge(codeVerifier);
-  const { port, server, waitForCallback } = await startCallbackServer(state);
+  const { port, server, waitForCallback } = await startCallbackServer(
+    state,
+    logger,
+  );
+  logger.info("Login callback server started", {
+    environment: config.environment,
+    port,
+  });
   // State has to live INSIDE the redirect_uri's query string, not as a
   // top-level param on the cloud-ui URL. The Traycer web UI's callback page
   // builds the final redirect via
@@ -222,8 +235,15 @@ export async function runLoginFlow(): Promise<LoginSuccess> {
   let code: string;
   try {
     ({ code } = await waitForCallback());
+    logger.info("Login callback received authorization code", {
+      environment: config.environment,
+      hasCode: code.length > 0,
+    });
   } finally {
     server.close();
+    logger.debug("Login callback server closed", {
+      environment: config.environment,
+    });
   }
 
   // Exchange the one-time code (+ our verifier) for the token pair.
@@ -233,12 +253,21 @@ export async function runLoginFlow(): Promise<LoginSuccess> {
     codeVerifier,
   );
   if (exchange.kind !== "exchanged") {
+    logger.warn("Login code exchange failed", {
+      environment: config.environment,
+      outcome: exchange.kind,
+    });
     throw new Error(
       exchange.kind === "rejected"
         ? "Sign-in succeeded but the authorization code could not be exchanged."
         : "Sign-in succeeded but the authn service is unreachable.",
     );
   }
+  logger.info("Login code exchange succeeded", {
+    environment: config.environment,
+    hasToken: exchange.token.length > 0,
+    hasRefreshToken: exchange.refreshToken.length > 0,
+  });
   const token = exchange.token;
   const refreshToken = exchange.refreshToken;
 
@@ -248,6 +277,10 @@ export async function runLoginFlow(): Promise<LoginSuccess> {
     refreshToken,
   );
   if (validation.kind !== "valid") {
+    logger.warn("Login token validation failed", {
+      environment: config.environment,
+      outcome: validation.kind,
+    });
     throw new Error(
       validation.kind === "rejected"
         ? "Sign-in succeeded but the token was rejected by the authn service."
@@ -280,6 +313,11 @@ export async function runLoginFlow(): Promise<LoginSuccess> {
     savedAt: new Date().toISOString(),
     user: creds.user,
   });
+  logger.info("Login credentials persisted", {
+    environment: config.environment,
+    tokenRotatedDuringValidation: finalToken !== token,
+    refreshTokenRotatedDuringValidation: finalRefreshToken !== refreshToken,
+  });
   return creds;
 }
 
@@ -293,7 +331,10 @@ interface CallbackServer {
   readonly waitForCallback: () => Promise<CallbackCode>;
 }
 
-async function startCallbackServer(expectedState: string): Promise<CallbackServer> {
+async function startCallbackServer(
+  expectedState: string,
+  logger: ILogger,
+): Promise<CallbackServer> {
   let resolveToken: (result: CallbackCode) => void = () => {};
   let rejectToken: (err: Error) => void = () => {};
   const tokenPromise = new Promise<CallbackCode>((resolve, reject) => {
@@ -304,12 +345,20 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     const url = new URL(req.url ?? "/", `http://127.0.0.1`);
     if (url.pathname !== CALLBACK_PATH) {
+      logger.warn("Login callback rejected unexpected path", {
+        environment: config.environment,
+        path: url.pathname,
+      });
       res.writeHead(404, { "Content-Type": "text/plain" });
       res.end("not found");
       return;
     }
     const incomingState = url.searchParams.get(STATE_QUERY_PARAM);
     if (incomingState !== expectedState) {
+      logger.warn("Login callback rejected state mismatch", {
+        environment: config.environment,
+        hasState: incomingState !== null,
+      });
       res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
       res.end(
         callbackHtml(
@@ -326,6 +375,11 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
     const oauthError = url.searchParams.get("error");
     if (oauthError !== null && oauthError.length > 0) {
       const description = url.searchParams.get("error_description");
+      logger.warn("Login callback received OAuth error", {
+        environment: config.environment,
+        oauthError,
+        hasDescription: description !== null && description.length > 0,
+      });
       const detail =
         description !== null && description.length > 0
           ? `${oauthError}: ${description}`
@@ -342,6 +396,9 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
     }
     const code = url.searchParams.get(CODE_QUERY_PARAM);
     if (code === null || code.length === 0) {
+      logger.warn("Login callback missing authorization code", {
+        environment: config.environment,
+      });
       res.writeHead(400, { "Content-Type": "text/html; charset=utf-8" });
       res.end(
         callbackHtml(
@@ -353,6 +410,10 @@ async function startCallbackServer(expectedState: string): Promise<CallbackServe
       return;
     }
     res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+    logger.info("Login callback accepted", {
+      environment: config.environment,
+      hasCode: true,
+    });
     res.end(
       callbackHtml("success", "You can close this window and return to your terminal."),
     );

--- a/clients/traycer-cli/src/auth/validate.ts
+++ b/clients/traycer-cli/src/auth/validate.ts
@@ -1,4 +1,6 @@
 import { validateAuthTokenViaHttp } from "../../../shared/auth/auth-validation";
+import { config } from "../config";
+import { createCliLogger } from "../logger";
 import {
   readCredentials,
   writeCredentials,
@@ -17,16 +19,37 @@ export type ValidationOutcome =
  * returning so a follow-up call uses the new bearer.
  */
 export async function validateStoredCredentials(): Promise<ValidationOutcome> {
+  const logger = createCliLogger(config.environment);
   const stored = await readCredentials();
-  if (stored === null) return { kind: "no-credentials" };
+  if (stored === null) {
+    logger.info("Stored credential validation skipped; no credentials", {
+      environment: config.environment,
+    });
+    return { kind: "no-credentials" };
+  }
 
+  logger.info("Stored credential validation started", {
+    environment: config.environment,
+    hasToken: stored.token.length > 0,
+    hasRefreshToken: stored.refreshToken.length > 0,
+  });
   const result = await validateAuthTokenViaHttp(
     stored.authnBaseUrl,
     stored.token,
     stored.refreshToken,
   );
-  if (result.kind === "rejected") return { kind: "rejected" };
-  if (result.kind === "network-error") return { kind: "network-error" };
+  if (result.kind === "rejected") {
+    logger.warn("Stored credential validation rejected", {
+      environment: config.environment,
+    });
+    return { kind: "rejected" };
+  }
+  if (result.kind === "network-error") {
+    logger.warn("Stored credential validation hit network error", {
+      environment: config.environment,
+    });
+    return { kind: "network-error" };
+  }
 
   const nextToken =
     "refreshedToken" in result ? result.refreshedToken : stored.token;
@@ -55,5 +78,11 @@ export async function validateStoredCredentials(): Promise<ValidationOutcome> {
       }
     : stored;
   if (refreshed !== stored) await writeCredentials(refreshed);
+  logger.info("Stored credential validation succeeded", {
+    environment: config.environment,
+    tokenChanged,
+    userChanged,
+    credentialsPersisted: refreshed !== stored,
+  });
   return { kind: "valid", credentials: refreshed };
 }

--- a/clients/traycer-cli/src/commands/__tests__/agent-title-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-title-from-hook.test.ts
@@ -10,6 +10,7 @@ import {
 import { buildAgentTitleFromHookCommand } from "../agent-title-from-hook";
 import type { CommandContext } from "../../runner/runner";
 import type { RuntimeContext } from "../../runner/runtime";
+import { noopLogger } from "../../logger";
 import { callHostRpcFastFail } from "../../internal/host-rpc";
 import { cliError, CLI_ERROR_CODES } from "../../runner/errors";
 
@@ -33,6 +34,7 @@ function makeRuntime(): RuntimeContext {
     noBootstrap: false,
     nonInteractive: false,
     environment: "production",
+    logger: noopLogger,
   };
 }
 

--- a/clients/traycer-cli/src/commands/__tests__/auto-bootstrap-integration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/auto-bootstrap-integration.test.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 import type { CommandContext } from "../../runner/runner";
 import type { RuntimeContext } from "../../runner/runtime";
+import { noopLogger } from "../../logger";
 import type { AutoBootstrapDecision } from "../../host/auto-bootstrap";
 
 // Pin Core Flow 7 wiring: `traycer login` and `traycer host status`
@@ -49,6 +50,7 @@ function makeRuntime(overrides: Partial<RuntimeContext>): RuntimeContext {
     noBootstrap: false,
     nonInteractive: false,
     environment: "production",
+    logger: noopLogger,
     ...overrides,
   };
 }

--- a/clients/traycer-cli/src/commands/__tests__/login-token.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/login-token.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildLoginCommand } from "../login";
 import type { CommandContext } from "../../runner/runner";
 import type { RuntimeContext } from "../../runner/runtime";
+import { noopLogger } from "../../logger";
 import { CLI_ERROR_CODES, CliError } from "../../runner/errors";
 import { validateAuthTokenViaHttp } from "../../../../shared/auth/auth-validation";
 import { readCredentials, writeCredentials } from "../../store/credentials";
@@ -27,6 +28,7 @@ function makeRuntime(overrides: Partial<RuntimeContext>): RuntimeContext {
     noBootstrap: false,
     nonInteractive: false,
     environment: "production",
+    logger: noopLogger,
     ...overrides,
   };
 }

--- a/clients/traycer-cli/src/commands/cli-mark-source.ts
+++ b/clients/traycer-cli/src/commands/cli-mark-source.ts
@@ -43,7 +43,16 @@ export function buildCliMarkSourceCommand(
   args: CliMarkSourceArgs,
 ): CommandFn {
   return async (ctx): Promise<CommandResult> => {
+    ctx.runtime.logger.info("CLI mark-source command started", {
+      environment: ctx.runtime.environment,
+      source: args.source,
+      hasBinaryPath: args.binaryPath.length > 0,
+      hasVersion: args.version.length > 0,
+    });
     if (args.source === "manual") {
+      ctx.runtime.logger.warn("CLI mark-source rejected manual source", {
+        environment: ctx.runtime.environment,
+      });
       throw cliError({
         code: CLI_ERROR_CODES.INVALID_ARGUMENT,
         message:
@@ -54,6 +63,10 @@ export function buildCliMarkSourceCommand(
       });
     }
     if (!PM_HOOK_SOURCES.has(args.source as CliInstallSource)) {
+      ctx.runtime.logger.warn("CLI mark-source rejected invalid source", {
+        environment: ctx.runtime.environment,
+        source: args.source,
+      });
       throw cliError({
         code: CLI_ERROR_CODES.INVALID_ARGUMENT,
         message: `cli mark-source: invalid source '${args.source}'; expected one of ${[...PM_HOOK_SOURCES].join(", ")}`,
@@ -81,7 +94,19 @@ export async function writeMarkSource(opts: {
   readonly version: string;
   readonly reason: "cli-mark-source" | "cli-re-anchor";
 }): Promise<CommandResult> {
+  opts.ctx.runtime.logger.info("CLI install source write started", {
+    environment: opts.ctx.runtime.environment,
+    reason: opts.reason,
+    source: opts.source,
+    hasBinaryPath: opts.binaryPath.length > 0,
+    version: opts.version,
+  });
   if (!VALID_CLI_INSTALL_SOURCES.has(opts.source)) {
+    opts.ctx.runtime.logger.warn("CLI install source write rejected invalid source", {
+      environment: opts.ctx.runtime.environment,
+      reason: opts.reason,
+      source: opts.source,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.INVALID_ARGUMENT,
       message: `${opts.reason}: invalid source '${opts.source}'`,
@@ -92,7 +117,13 @@ export async function writeMarkSource(opts: {
   let binaryStat: Stats;
   try {
     binaryStat = await stat(opts.binaryPath);
-  } catch {
+  } catch (err) {
+    opts.ctx.runtime.logger.warn("CLI install source write binary path missing", {
+      environment: opts.ctx.runtime.environment,
+      reason: opts.reason,
+      errorName: err instanceof Error ? err.name : "Error",
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
     throw cliError({
       code: CLI_ERROR_CODES.INVALID_ARGUMENT,
       message: `${opts.reason}: binary path does not exist: ${opts.binaryPath}`,
@@ -101,6 +132,10 @@ export async function writeMarkSource(opts: {
     });
   }
   if (!binaryStat.isFile()) {
+    opts.ctx.runtime.logger.warn("CLI install source write rejected non-file binary path", {
+      environment: opts.ctx.runtime.environment,
+      reason: opts.reason,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.INVALID_ARGUMENT,
       message: `${opts.reason}: binary path is not a regular file: ${opts.binaryPath}`,
@@ -109,6 +144,10 @@ export async function writeMarkSource(opts: {
     });
   }
   if (opts.version.length === 0) {
+    opts.ctx.runtime.logger.warn("CLI install source write rejected empty version", {
+      environment: opts.ctx.runtime.environment,
+      reason: opts.reason,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.INVALID_ARGUMENT,
       message: `${opts.reason}: --installed-version is required and must be non-empty`,
@@ -125,6 +164,12 @@ export async function writeMarkSource(opts: {
     },
     async () => {
       const previous = await readCliManifest(opts.ctx.runtime.environment);
+      opts.ctx.runtime.logger.debug("CLI install source write read previous manifest", {
+        environment: opts.ctx.runtime.environment,
+        reason: opts.reason,
+        hadPreviousManifest: previous !== null,
+        previousSource: previous?.source ?? null,
+      });
       const next: CliInstallManifest = {
         version: opts.version,
         installedAt: new Date().toISOString(),
@@ -136,6 +181,13 @@ export async function writeMarkSource(opts: {
         pendingUpgrade: null,
       };
       await writeCliManifest(opts.ctx.runtime.environment, next);
+      opts.ctx.runtime.logger.info("CLI install source manifest written", {
+        environment: opts.ctx.runtime.environment,
+        reason: opts.reason,
+        source: opts.source,
+        version: opts.version,
+        hadPreviousManifest: previous !== null,
+      });
       return {
         data: {
           previous,

--- a/clients/traycer-cli/src/commands/cli-mark-source.ts
+++ b/clients/traycer-cli/src/commands/cli-mark-source.ts
@@ -11,6 +11,7 @@ import {
 import type { CommandFn, CommandResult } from "../runner/runner";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import { withCliLock } from "../store/cli-lock";
+import { errorFromUnknown } from "../logger";
 
 // `traycer cli mark-source` - internal, hidden command. Package-manager
 // install hooks (Homebrew formula post_install, winget/Scoop post-install
@@ -28,10 +29,12 @@ import { withCliLock } from "../store/cli-lock";
 // Allowed sources here are the PM hooks + the special `desktop` slot.
 // `manual` is explicitly excluded - re-anchoring a manual install is the
 // `cli re-anchor` command's job.
-const PM_HOOK_SOURCES: ReadonlySet<CliInstallSource> = new Set<CliInstallSource>([
+const PM_HOOK_SOURCE_VALUES: readonly CliInstallSource[] = [
   "desktop",
   ...PACKAGE_MANAGER_CLI_SOURCES,
-]);
+];
+const PM_HOOK_SOURCES: ReadonlySet<CliInstallSource> =
+  new Set<CliInstallSource>(PM_HOOK_SOURCE_VALUES);
 
 export interface CliMarkSourceArgs {
   readonly source: string;
@@ -43,9 +46,10 @@ export function buildCliMarkSourceCommand(
   args: CliMarkSourceArgs,
 ): CommandFn {
   return async (ctx): Promise<CommandResult> => {
+    const source = parsePmHookSource(args.source);
     ctx.runtime.logger.info("CLI mark-source command started", {
       environment: ctx.runtime.environment,
-      source: args.source,
+      isKnownSource: source !== null,
       hasBinaryPath: args.binaryPath.length > 0,
       hasVersion: args.version.length > 0,
     });
@@ -62,10 +66,10 @@ export function buildCliMarkSourceCommand(
         exitCode: 1,
       });
     }
-    if (!PM_HOOK_SOURCES.has(args.source as CliInstallSource)) {
+    if (source === null) {
       ctx.runtime.logger.warn("CLI mark-source rejected invalid source", {
         environment: ctx.runtime.environment,
-        source: args.source,
+        isKnownSource: false,
       });
       throw cliError({
         code: CLI_ERROR_CODES.INVALID_ARGUMENT,
@@ -76,12 +80,19 @@ export function buildCliMarkSourceCommand(
     }
     return writeMarkSource({
       ctx,
-      source: args.source as CliInstallSource,
+      source: source,
       binaryPath: args.binaryPath,
       version: args.version,
       reason: "cli-mark-source",
     });
   };
+}
+
+function parsePmHookSource(value: string): CliInstallSource | null {
+  for (const source of PM_HOOK_SOURCE_VALUES) {
+    if (source === value) return source;
+  }
+  return null;
 }
 
 // Shared internal: validates the binary path + version and writes the
@@ -99,7 +110,7 @@ export async function writeMarkSource(opts: {
     reason: opts.reason,
     source: opts.source,
     hasBinaryPath: opts.binaryPath.length > 0,
-    version: opts.version,
+    hasVersion: opts.version.length > 0,
   });
   if (!VALID_CLI_INSTALL_SOURCES.has(opts.source)) {
     opts.ctx.runtime.logger.warn("CLI install source write rejected invalid source", {
@@ -118,11 +129,12 @@ export async function writeMarkSource(opts: {
   try {
     binaryStat = await stat(opts.binaryPath);
   } catch (err) {
+    const error = errorFromUnknown(err);
     opts.ctx.runtime.logger.warn("CLI install source write binary path missing", {
       environment: opts.ctx.runtime.environment,
       reason: opts.reason,
-      errorName: err instanceof Error ? err.name : "Error",
-      errorMessage: err instanceof Error ? err.message : String(err),
+      errorName: error.name,
+      errorCode: readErrorCode(err),
     });
     throw cliError({
       code: CLI_ERROR_CODES.INVALID_ARGUMENT,
@@ -185,7 +197,7 @@ export async function writeMarkSource(opts: {
         environment: opts.ctx.runtime.environment,
         reason: opts.reason,
         source: opts.source,
-        version: opts.version,
+        hasVersion: opts.version.length > 0,
         hadPreviousManifest: previous !== null,
       });
       return {
@@ -200,4 +212,10 @@ export async function writeMarkSource(opts: {
       };
     },
   );
+}
+
+function readErrorCode(error: unknown): string | null {
+  if (error === null || typeof error !== "object") return null;
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : null;
 }

--- a/clients/traycer-cli/src/commands/cli-upgrade.ts
+++ b/clients/traycer-cli/src/commands/cli-upgrade.ts
@@ -28,6 +28,11 @@ import {
 import type { Environment } from "../runner/environment";
 import type { CommandFn, CommandResult } from "../runner/runner";
 import { CLI_ERROR_CODES, CliError, cliError } from "../runner/errors";
+import {
+  createCliLogger,
+  errorFromUnknown,
+  type ILogger,
+} from "../logger";
 import { withCliLock } from "../store/cli-lock";
 
 // `traycer cli upgrade` - self-upgrade the installed CLI binary.
@@ -77,6 +82,11 @@ const UPGRADE_HINT_FOR_SOURCE: Record<CliInstallSource, string> = {
 
 export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
   return async (ctx): Promise<CommandResult> => {
+    ctx.runtime.logger.info("CLI upgrade command started", {
+      environment: ctx.runtime.environment,
+      dryRun: args.dryRun,
+      hasTargetVersionOverride: args.targetVersion !== null,
+    });
     return withCliLock(
       {
         environment: ctx.runtime.environment,
@@ -87,6 +97,9 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
       async () => {
         const manifest = await readCliManifest(ctx.runtime.environment);
         if (manifest === null) {
+          ctx.runtime.logger.warn("CLI upgrade refused because manifest is missing", {
+            environment: ctx.runtime.environment,
+          });
           throw cliError({
             code: CLI_ERROR_CODES.CLI_UPGRADE_NO_MANIFEST,
             message:
@@ -103,6 +116,11 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
         // the ownership contract spelled out in the Tech Plan.
         if (PACKAGE_MANAGER_CLI_SOURCES.has(manifest.source)) {
           const hint = UPGRADE_HINT_FOR_SOURCE[manifest.source];
+          ctx.runtime.logger.warn("CLI upgrade refused package-manager-owned install", {
+            environment: ctx.runtime.environment,
+            source: manifest.source,
+            currentVersion: manifest.version,
+          });
           throw cliError({
             code: CLI_ERROR_CODES.CLI_UPGRADE_PACKAGE_MANAGER_OWNED,
             message: `cli upgrade: CLI is installed via ${manifest.source}; self-upgrade is disabled to keep package-manager ownership intact. ${hint}`,
@@ -125,7 +143,18 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
         });
         const versions = await fetchCliVersions();
         const targetVersion = args.targetVersion ?? versions.latest;
+        ctx.runtime.logger.info("CLI upgrade target resolved", {
+          environment: ctx.runtime.environment,
+          currentVersion: manifest.version,
+          targetVersion,
+          source: manifest.source,
+          latestVersion: versions.latest,
+        });
         if (manifest.version === targetVersion) {
+          ctx.runtime.logger.info("CLI upgrade no-op; already current", {
+            environment: ctx.runtime.environment,
+            version: targetVersion,
+          });
           return {
             data: {
               status: "already-current",
@@ -142,6 +171,12 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
         const platformKey = currentCliPlatformKey();
         const asset = resolveCliAsset(versions, platformKey);
         if (args.dryRun) {
+          ctx.runtime.logger.info("CLI upgrade dry-run completed", {
+            environment: ctx.runtime.environment,
+            currentVersion: manifest.version,
+            targetVersion,
+            platformKey,
+          });
           return {
             data: {
               status: "dry-run",
@@ -161,9 +196,16 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
         // tempdir if the install directory isn't writable (e.g. desktop
         // staged the CLI under a system path).
         const installDir = dirname(manifest.binaryPath);
-        const stagingRoot = (await directoryWritable(installDir))
+        const installDirWritable = await directoryWritable(installDir);
+        const stagingRoot = installDirWritable
           ? installDir
           : await mkdtemp(join(tmpdir(), "traycer-cli-upgrade-"));
+        ctx.runtime.logger.info("CLI upgrade staging root selected", {
+          environment: ctx.runtime.environment,
+          installDirWritable,
+          stagingInInstallDir: installDirWritable,
+          platformKey,
+        });
         const stagedBinaryPath = join(
           stagingRoot,
           `traycer-${targetVersion}-${platformKey}${binaryExtension()}`,
@@ -196,6 +238,15 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
             signal: null,
           });
         } catch (cause) {
+          ctx.runtime.logger.error(
+            "CLI upgrade download failed",
+            {
+              environment: ctx.runtime.environment,
+              targetVersion,
+              platformKey,
+            },
+            errorFromUnknown(cause),
+          );
           if (cause instanceof Error && (cause as { code?: string }).code !== undefined) {
             throw cause;
           }
@@ -211,6 +262,12 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
         if (process.platform !== "win32") {
           await chmod(stagedBinaryPath, 0o755);
         }
+        ctx.runtime.logger.info("CLI upgrade staged binary ready", {
+          environment: ctx.runtime.environment,
+          targetVersion,
+          platformKey,
+          sizeBytes: asset.sizeBytes,
+        });
 
         ctx.progress({
           stage: "swap",
@@ -220,9 +277,11 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
           totalBytes: null,
         });
         const swap = await tryReplaceLiveBinary({
+          environment: ctx.runtime.environment,
           stagedBinaryPath,
           livePath: manifest.binaryPath,
           expectedSha256: asset.sha256,
+          logger: ctx.runtime.logger,
         });
         if (swap.status === "replaced") {
           await updateCliManifest(ctx.runtime.environment, {
@@ -230,6 +289,12 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
             binaryPath: manifest.binaryPath,
             installedAt: new Date().toISOString(),
             pendingUpgrade: null,
+          });
+          ctx.runtime.logger.info("CLI upgrade replaced live binary", {
+            environment: ctx.runtime.environment,
+            previousVersion: manifest.version,
+            currentVersion: targetVersion,
+            source: manifest.source,
           });
           return {
             data: {
@@ -251,6 +316,13 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
             stagedAt: new Date().toISOString(),
             reason: "binary-locked",
           },
+        });
+        ctx.runtime.logger.warn("CLI upgrade staged pending upgrade", {
+          environment: ctx.runtime.environment,
+          previousVersion: manifest.version,
+          targetVersion,
+          source: manifest.source,
+          reason: "binary-locked",
         });
         return {
           data: {
@@ -278,6 +350,7 @@ interface ReplaceResult {
 }
 
 async function tryReplaceLiveBinary(opts: {
+  readonly environment: Environment;
   readonly stagedBinaryPath: string;
   readonly livePath: string;
   // Optional digest the live path is expected to hold after a
@@ -288,6 +361,7 @@ async function tryReplaceLiveBinary(opts: {
   // helper callers that don't have the asset manifest in scope may pass
   // `null` to skip the check - the rename path doesn't touch bytes.
   readonly expectedSha256: string | null;
+  readonly logger: ILogger;
 }): Promise<ReplaceResult> {
   // On Windows the rename will fail with EBUSY/EPERM if the live binary
   // is mapped into a running process. We catch those, treat them as
@@ -296,13 +370,25 @@ async function tryReplaceLiveBinary(opts: {
   // is open, but EACCES from a read-only filesystem still indicates
   // "we can't swap, keep it staged".
   try {
+    opts.logger.info("CLI upgrade attempting live binary replacement", {
+      environment: opts.environment,
+      expectedSha256: opts.expectedSha256 !== null,
+    });
     await rename(opts.stagedBinaryPath, opts.livePath);
+    opts.logger.info("CLI upgrade live binary replacement succeeded", {
+      environment: opts.environment,
+      strategy: "rename",
+    });
     return { status: "replaced", errorMessage: null };
   } catch (err) {
     const code = err !== null && typeof err === "object" && "code" in err
       ? String((err as { code: unknown }).code)
       : null;
     if (code === "EBUSY" || code === "EPERM" || code === "EACCES" || code === "ETXTBSY") {
+      opts.logger.warn("CLI upgrade live binary is locked", {
+        environment: opts.environment,
+        errorCode: code,
+      });
       return {
         status: "locked",
         errorMessage: err instanceof Error ? err.message : String(err),
@@ -312,6 +398,10 @@ async function tryReplaceLiveBinary(opts: {
     // operator's intent (replace the binary) still completes when the
     // staging dir isn't on the same volume.
     if (code === "EXDEV") {
+      opts.logger.info("CLI upgrade falling back to cross-device copy", {
+        environment: opts.environment,
+        expectedSha256: opts.expectedSha256 !== null,
+      });
       try {
         await copyFile(opts.stagedBinaryPath, opts.livePath);
         // Re-verify the destination digest. A partial-write or a hostile
@@ -321,6 +411,13 @@ async function tryReplaceLiveBinary(opts: {
         if (opts.expectedSha256 !== null) {
           const actual = await hashFileSha256(opts.livePath);
           if (actual !== opts.expectedSha256) {
+            opts.logger.error(
+              "CLI upgrade post-copy hash mismatch",
+              {
+                environment: opts.environment,
+              },
+              null,
+            );
             try {
               await unlink(opts.livePath);
             } catch {
@@ -341,12 +438,28 @@ async function tryReplaceLiveBinary(opts: {
         }
         try {
           await unlink(opts.stagedBinaryPath);
-        } catch {
+        } catch (unlinkErr) {
+          opts.logger.warn("CLI upgrade failed to remove staged copy after fallback", {
+            environment: opts.environment,
+            errorName: errorFromUnknown(unlinkErr).name,
+            errorMessage: errorFromUnknown(unlinkErr).message,
+          });
           // Staged copy is harmless if it lingers.
         }
+        opts.logger.info("CLI upgrade live binary replacement succeeded", {
+          environment: opts.environment,
+          strategy: "copy",
+        });
         return { status: "replaced", errorMessage: null };
       } catch (copyErr) {
         if (copyErr instanceof CliError) throw copyErr;
+        opts.logger.error(
+          "CLI upgrade cross-device copy failed",
+          {
+            environment: opts.environment,
+          },
+          errorFromUnknown(copyErr),
+        );
         throw cliError({
           code: CLI_ERROR_CODES.CLI_UPGRADE_REPLACE_FAILED,
           message: `cli upgrade: cross-device fallback copy failed: ${copyErr instanceof Error ? copyErr.message : String(copyErr)}`,
@@ -355,6 +468,14 @@ async function tryReplaceLiveBinary(opts: {
         });
       }
     }
+    opts.logger.error(
+      "CLI upgrade live binary replacement failed",
+      {
+        environment: opts.environment,
+        errorCode: code ?? "unknown",
+      },
+      errorFromUnknown(err),
+    );
     throw cliError({
       code: CLI_ERROR_CODES.CLI_UPGRADE_REPLACE_FAILED,
       message: `cli upgrade: replace failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -426,21 +547,44 @@ export type FinalizePendingCliUpgradeOutcome =
 export async function finalizePendingCliUpgrade(opts: {
   readonly environment: Environment;
 }): Promise<FinalizePendingCliUpgradeOutcome> {
+  const logger = createCliLogger(opts.environment);
+  logger.info("CLI pending upgrade finalization started", {
+    environment: opts.environment,
+  });
   const manifest = await readCliManifest(opts.environment);
-  if (manifest === null) return { status: "no-manifest" };
+  if (manifest === null) {
+    logger.info("CLI pending upgrade finalization skipped; no manifest", {
+      environment: opts.environment,
+    });
+    return { status: "no-manifest" };
+  }
   const pending = manifest.pendingUpgrade;
-  if (pending === null) return { status: "no-pending" };
+  if (pending === null) {
+    logger.info("CLI pending upgrade finalization skipped; no pending upgrade", {
+      environment: opts.environment,
+      currentVersion: manifest.version,
+      source: manifest.source,
+    });
+    return { status: "no-pending" };
+  }
   if (
     !(await pendingUpgradeFinalisable({
       stagedBinaryPath: pending.stagedBinaryPath,
     }))
   ) {
+    logger.warn("CLI pending upgrade staged binary missing", {
+      environment: opts.environment,
+      currentVersion: manifest.version,
+      pendingVersion: pending.version,
+      reason: pending.reason,
+    });
     return {
       status: "staged-binary-missing",
       stagedBinaryPath: pending.stagedBinaryPath,
     };
   }
   const swap = await tryReplaceLiveBinary({
+    environment: opts.environment,
     stagedBinaryPath: pending.stagedBinaryPath,
     livePath: manifest.binaryPath,
     // The manifest doesn't preserve the asset digest after `cli upgrade`
@@ -449,8 +593,14 @@ export async function finalizePendingCliUpgrade(opts: {
     // the rename path is byte-for-byte safe, and an EXDEV fallback in
     // the helper is rare (staging dir is sibling to the live binary).
     expectedSha256: null,
+    logger,
   });
   if (swap.status === "locked") {
+    logger.warn("CLI pending upgrade still locked", {
+      environment: opts.environment,
+      currentVersion: manifest.version,
+      pendingVersion: pending.version,
+    });
     return {
       status: "still-locked",
       stagedBinaryPath: pending.stagedBinaryPath,
@@ -463,6 +613,11 @@ export async function finalizePendingCliUpgrade(opts: {
     version: pending.version,
     binaryPath: manifest.binaryPath,
     installedAt,
+  });
+  logger.info("CLI pending upgrade finalized", {
+    environment: opts.environment,
+    previousVersion: manifest.version,
+    version: pending.version,
   });
   return {
     status: "finalised",
@@ -483,8 +638,22 @@ export async function readPendingCliUpgrade(opts: {
   readonly binaryPath: string;
   readonly source: CliInstallSource;
 } | null> {
+  const logger = createCliLogger(opts.environment);
   const manifest = await readCliManifest(opts.environment);
-  if (manifest === null || manifest.pendingUpgrade === null) return null;
+  if (manifest === null || manifest.pendingUpgrade === null) {
+    logger.debug("CLI pending upgrade read found nothing pending", {
+      environment: opts.environment,
+      hasManifest: manifest !== null,
+    });
+    return null;
+  }
+  logger.info("CLI pending upgrade read found pending upgrade", {
+    environment: opts.environment,
+    currentVersion: manifest.version,
+    pendingVersion: manifest.pendingUpgrade.version,
+    source: manifest.source,
+    reason: manifest.pendingUpgrade.reason,
+  });
   return {
     pending: manifest.pendingUpgrade,
     currentVersion: manifest.version,

--- a/clients/traycer-cli/src/commands/host-install.ts
+++ b/clients/traycer-cli/src/commands/host-install.ts
@@ -40,6 +40,13 @@ export interface HostInstallArgs {
 
 export function buildHostInstallCommand(args: HostInstallArgs): CommandFn {
   return async (ctx): Promise<CommandResult> => {
+    ctx.runtime.logger.info("Host install command started", {
+      environment: ctx.runtime.environment,
+      sourceKind: args.fromPath !== null ? "local-file" : "registry",
+      versionRequest: args.fromPath !== null ? "local-file" : args.versionRequest,
+      enableLinger: args.enableLinger,
+      allowSelfInvocation: args.allowSelfInvocation,
+    });
     const source: InstallSourceArg =
       args.fromPath !== null
         ? { kind: "local-file", path: args.fromPath }
@@ -53,6 +60,9 @@ export function buildHostInstallCommand(args: HostInstallArgs): CommandFn {
         enableLinger: args.enableLinger,
         allowSelfInvocation: args.allowSelfInvocation,
       },
+    });
+    ctx.runtime.logger.debug("Host install command lifecycle created", {
+      environment: ctx.runtime.environment,
     });
     const result = await withCliLock(
       {
@@ -72,6 +82,13 @@ export function buildHostInstallCommand(args: HostInstallArgs): CommandFn {
           recordVersionOverride: null,
         }),
     );
+    ctx.runtime.logger.info("Host install command completed", {
+      environment: ctx.runtime.environment,
+      version: result.record.version,
+      previousVersion: result.previous?.version ?? null,
+      postSwapAction: handle.state.postSwapAction,
+      hasPostSwapError: handle.state.postSwapError !== null,
+    });
     const lifecycleData = {
       priorServiceState: handle.state.priorState,
       stoppedBeforeSwap: handle.state.stoppedBeforeSwap,

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -297,7 +297,7 @@ export async function runHostStart(
 
   for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
     process.on(sig, () => {
-      logger.warn("Host supervisor forwarding signal to child", {
+      logger.debug("Host supervisor forwarding signal to child", {
         environment: opts.environment,
         signal: sig,
         childPidKnown: child.pid !== undefined,

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -22,6 +22,11 @@ import {
   listEnvOverrides,
   type EnvOverrideValue,
 } from "../store/config-store";
+import {
+  createCliLogger,
+  errorFromUnknown,
+  type ILogger,
+} from "../logger";
 
 // `traycer host start` is the long-running supervisor invoked by the OS
 // service manager (launchd, systemd-user, or Windows Scheduled Task). The
@@ -151,6 +156,7 @@ export interface RunHostStartDeps extends ResolveHostStartTargetDeps {
   // not depend on the function returning.
   readonly exit: (code: number) => void;
   readonly onError: (message: string) => void;
+  readonly logger: ILogger | null;
 }
 
 const defaultRunDeps: RunHostStartDeps = {
@@ -165,6 +171,7 @@ const defaultRunDeps: RunHostStartDeps = {
   onError: (message) => {
     console.error(message);
   },
+  logger: null,
 };
 
 // Long-running entrypoint invoked by the OS service manager. Resolves
@@ -179,12 +186,23 @@ export async function runHostStart(
   injected: Partial<RunHostStartDeps>,
 ): Promise<void> {
   const deps: RunHostStartDeps = { ...defaultRunDeps, ...injected };
+  const logger = deps.logger ?? createCliLogger(opts.environment);
+
+  logger.info("Host supervisor starting", {
+    environment: opts.environment,
+    hasCwdOverride: opts.cwd !== null,
+  });
 
   let target: HostStartTarget;
   try {
     target = await resolveHostStartTarget(opts, deps);
   } catch (err) {
     if (err instanceof CliError) {
+      logger.warn("Host supervisor target resolution failed", {
+        environment: opts.environment,
+        code: err.code,
+        exitCode: err.exitCode,
+      });
       const detailLine = JSON.stringify({
         code: err.code,
         message: err.message,
@@ -202,10 +220,26 @@ export async function runHostStart(
       deps.onError(detailLine);
       return deps.exit(err.exitCode);
     }
+    logger.error(
+      "Host supervisor target resolution threw unexpectedly",
+      { environment: opts.environment, exitCode: 1 },
+      errorFromUnknown(err),
+    );
     throw err;
   }
 
+  logger.info("Host supervisor target resolved", {
+    environment: opts.environment,
+    version: target.record.version,
+    argCount: target.args.length,
+    hasCwdOverride: opts.cwd !== null,
+  });
+
   const envOverrides = await deps.readEnvOverrides();
+  logger.debug("Host supervisor loaded env overrides", {
+    environment: opts.environment,
+    overrideCount: Object.keys(envOverrides).length,
+  });
   const env: NodeJS.ProcessEnv = {
     ...applyEnvOverrides(process.env, envOverrides),
     TERM_PROGRAM: "traycer",
@@ -242,6 +276,11 @@ export async function runHostStart(
     });
   } catch (cause) {
     const message = cause instanceof Error ? cause.message : String(cause);
+    logger.error(
+      "Host supervisor spawn failed",
+      { environment: opts.environment, exitCode: 66 },
+      errorFromUnknown(cause),
+    );
     await deps.writeMarker(opts.environment, "failed-to-spawn", {
       shell: undefined,
       args: undefined,
@@ -258,10 +297,21 @@ export async function runHostStart(
 
   for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
     process.on(sig, () => {
+      logger.warn("Host supervisor forwarding signal to child", {
+        environment: opts.environment,
+        signal: sig,
+        childPidKnown: child.pid !== undefined,
+      });
       if (child.pid !== undefined) {
         try {
           child.kill(sig);
-        } catch {
+        } catch (cause) {
+          logger.warn("Host supervisor failed to forward signal", {
+            environment: opts.environment,
+            signal: sig,
+            errorName: errorFromUnknown(cause).name,
+            errorMessage: errorFromUnknown(cause).message,
+          });
           // Child may have already exited.
         }
       }
@@ -273,6 +323,11 @@ export async function runHostStart(
     // and the process is about to exit anyway; the OS flushes the log
     // append on close.
     if (signal !== null) {
+      logger.warn("Host child exited by signal", {
+        environment: opts.environment,
+        signal,
+        exitCode: 128 + signalNumber(signal),
+      });
       void deps.writeMarker(opts.environment, "killed", {
         shell: undefined,
         args: undefined,
@@ -284,6 +339,10 @@ export async function runHostStart(
       return deps.exit(128 + signalNumber(signal));
     }
     if (code === null || code === 0) {
+      logger.info("Host child exited cleanly", {
+        environment: opts.environment,
+        exitCode: code ?? 0,
+      });
       void deps.writeMarker(opts.environment, "exited", {
         shell: undefined,
         args: undefined,
@@ -294,6 +353,14 @@ export async function runHostStart(
       });
       return deps.exit(code ?? 0);
     }
+    logger.error(
+      "Host child exited with non-zero status",
+      {
+        environment: opts.environment,
+        exitCode: code,
+      },
+      null,
+    );
     void deps.writeMarker(opts.environment, "crashed", {
       shell: undefined,
       args: undefined,

--- a/clients/traycer-cli/src/commands/host-uninstall.ts
+++ b/clients/traycer-cli/src/commands/host-uninstall.ts
@@ -19,6 +19,10 @@ export function buildHostUninstallCommand(
   args: HostUninstallArgs,
 ): CommandFn {
   return async (ctx): Promise<CommandResult> => {
+    ctx.runtime.logger.info("Host uninstall command started", {
+      environment: ctx.runtime.environment,
+      all: args.all,
+    });
     return withCliLock(
       {
         environment: ctx.runtime.environment,
@@ -29,6 +33,9 @@ export function buildHostUninstallCommand(
       async () => {
         let serviceUninstalled = false;
         if (args.all) {
+          ctx.runtime.logger.warn("Host uninstall command will deregister service and purge runtime", {
+            environment: ctx.runtime.environment,
+          });
           ctx.progress({
             stage: "service-stop",
             message: `stopping service for ${ctx.runtime.environment} environment`,
@@ -43,11 +50,20 @@ export function buildHostUninstallCommand(
           // forces removal regardless.
           try {
             await controller.stop(label);
-          } catch {
+          } catch (err) {
+            ctx.runtime.logger.warn("Host uninstall service stop failed; continuing", {
+              environment: ctx.runtime.environment,
+              errorName: err instanceof Error ? err.name : "Error",
+              errorMessage: err instanceof Error ? err.message : String(err),
+            });
             // Service may not be running; proceed.
           }
           await controller.uninstall({ label });
           serviceUninstalled = true;
+          ctx.runtime.logger.info("Host uninstall service deregistered", {
+            environment: ctx.runtime.environment,
+            label: label.id,
+          });
         }
         ctx.progress({
           stage: "uninstall",
@@ -61,6 +77,13 @@ export function buildHostUninstallCommand(
           // --all also clears environment runtime state (pid metadata,
           // log) - the host is gone, those are just stale files.
           purgeChannelRuntime: args.all,
+        });
+        ctx.runtime.logger.info("Host uninstall command completed", {
+          environment: ctx.runtime.environment,
+          serviceUninstalled,
+          removedInstallDir: result.removedInstallDir,
+          purgedRuntime: result.purgedRuntime,
+          hadInstallRecord: result.removedRecord !== null,
         });
         return {
           data: {

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -14,6 +14,9 @@ import { withCliLock } from "../store/cli-lock";
 // pointed at a half-replaced install dir (especially relevant on
 // Windows where executable locks block the rename otherwise).
 export const hostUpdateCommand: CommandFn = async (ctx): Promise<CommandResult> => {
+  ctx.runtime.logger.info("Host update command started", {
+    environment: ctx.runtime.environment,
+  });
   return withCliLock(
     {
       environment: ctx.runtime.environment,
@@ -27,6 +30,9 @@ export const hostUpdateCommand: CommandFn = async (ctx): Promise<CommandResult> 
       );
       const previous = await readHostInstallRecord(ctx.runtime.environment);
       if (previous === null) {
+        ctx.runtime.logger.warn("Host update refused because host is not installed", {
+          environment: ctx.runtime.environment,
+        });
         throw cliError({
           code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
           message: `host update: no host installed for environment=${ctx.runtime.environment}; run 'traycer host install latest' first`,
@@ -40,6 +46,10 @@ export const hostUpdateCommand: CommandFn = async (ctx): Promise<CommandResult> 
       const handle = createServiceInstallLifecycle({
         environment: ctx.runtime.environment,
         bootstrap: null,
+      });
+      ctx.runtime.logger.debug("Host update lifecycle created", {
+        environment: ctx.runtime.environment,
+        previousVersion: previous.version,
       });
       const result = await installHost({
         environment: ctx.runtime.environment,
@@ -59,6 +69,14 @@ export const hostUpdateCommand: CommandFn = async (ctx): Promise<CommandResult> 
         previous.version === result.record.version
           ? `host already at ${result.record.version} (no-op)`
           : `updated host ${previous.version} → ${result.record.version}`;
+      ctx.runtime.logger.info("Host update command completed", {
+        environment: ctx.runtime.environment,
+        previousVersion: previous.version,
+        version: result.record.version,
+        changed: previous.version !== result.record.version,
+        postSwapAction: handle.state.postSwapAction,
+        hasPostSwapError: handle.state.postSwapError !== null,
+      });
       return {
         data: {
           version: result.record.version,

--- a/clients/traycer-cli/src/commands/login.ts
+++ b/clients/traycer-cli/src/commands/login.ts
@@ -11,7 +11,15 @@ import { readCredentials, writeCredentials } from "../store/credentials";
 // subcommands (`host ensure` / `host install`). A user signing in should
 // never trigger a host download as a side effect.
 export const loginCommand: CommandFn = async (ctx): Promise<CommandResult> => {
+  ctx.runtime.logger.info("Interactive login command started", {
+    environment: ctx.runtime.environment,
+  });
   const result = await runLoginFlow();
+  ctx.runtime.logger.info("Interactive login command completed", {
+    environment: ctx.runtime.environment,
+    hasUserId: result.user.id.length > 0,
+    hasEmail: result.user.email.length > 0,
+  });
 
   const humanSignedIn = `Signed in as ${result.user.email || result.user.name || result.user.id}.`;
   const data = {
@@ -44,7 +52,14 @@ export function buildLoginCommand(opts: {
 
 function loginWithToken(rawToken: string): CommandFn {
   return async (ctx): Promise<CommandResult> => {
+    ctx.runtime.logger.info("Token login command started", {
+      environment: ctx.runtime.environment,
+      tokenFlagUsesStdin: rawToken === "-",
+    });
     if (rawToken !== "-") {
+      ctx.runtime.logger.warn("Token login rejected literal token argument", {
+        environment: ctx.runtime.environment,
+      });
       throw cliError({
         code: CLI_ERROR_CODES.INVALID_ARGUMENT,
         message:
@@ -56,7 +71,15 @@ function loginWithToken(rawToken: string): CommandFn {
     const { token, refreshToken } = parseStdinCredentials(
       await readTokenFromStdin(),
     );
+    ctx.runtime.logger.info("Token login stdin payload parsed", {
+      environment: ctx.runtime.environment,
+      hasToken: token.length > 0,
+      hasRefreshToken: refreshToken.length > 0,
+    });
     if (token.length === 0) {
+      ctx.runtime.logger.warn("Token login rejected empty token payload", {
+        environment: ctx.runtime.environment,
+      });
       throw cliError({
         code: CLI_ERROR_CODES.INVALID_ARGUMENT,
         message: "login: --token - received no token on stdin.",
@@ -76,6 +99,9 @@ function loginWithToken(rawToken: string): CommandFn {
       refreshToken,
     );
     if (validation.kind === "network-error") {
+      ctx.runtime.logger.warn("Token login validation hit network error", {
+        environment: ctx.runtime.environment,
+      });
       throw cliError({
         code: CLI_ERROR_CODES.AUTH_NETWORK,
         message: "Could not reach the authn service; check your network.",
@@ -84,6 +110,10 @@ function loginWithToken(rawToken: string): CommandFn {
       });
     }
     if (validation.kind !== "valid") {
+      ctx.runtime.logger.warn("Token login validation rejected token", {
+        environment: ctx.runtime.environment,
+        outcome: validation.kind,
+      });
       throw cliError({
         code: CLI_ERROR_CODES.AUTH_REJECTED,
         message: "The provided token was rejected by the authn service.",
@@ -122,6 +152,13 @@ function loginWithToken(rawToken: string): CommandFn {
       authnBaseUrl,
       savedAt: new Date().toISOString(),
       user,
+    });
+    ctx.runtime.logger.info("Token login credentials persisted", {
+      environment: ctx.runtime.environment,
+      tokenRotatedDuringValidation: finalToken !== token,
+      refreshTokenFromStdin: refreshToken.length > 0,
+      refreshTokenRotatedDuringValidation: rotatedRefreshToken.length > 0,
+      hasFinalRefreshToken: finalRefreshToken.length > 0,
     });
     return {
       data: { user, bootstrap: null },

--- a/clients/traycer-cli/src/commands/monitor.ts
+++ b/clients/traycer-cli/src/commands/monitor.ts
@@ -77,6 +77,10 @@ export type MonitorArgs = {
   readonly epicId: string | null;
 };
 
+type EndpointResolutionLogState = {
+  value: string | null;
+};
+
 export async function runMonitor(args: MonitorArgs): Promise<void> {
   const logger = createCliLogger(config.environment);
   const agentId = args.agentId ?? process.env.TRAYCER_AGENT_ID ?? null;
@@ -137,7 +141,11 @@ export async function runMonitor(args: MonitorArgs): Promise<void> {
   // are serialized (no out-of-order clobber) and a good endpoint is never
   // overwritten with `null` (a momentarily-absent pid file keeps the last-known
   // URL; dials simply retry until a fresh one appears).
-  let endpoint = await tryResolveStreamEndpoint(logger);
+  const endpointResolutionLogState: EndpointResolutionLogState = { value: null };
+  let endpoint = await tryResolveStreamEndpoint(
+    logger,
+    endpointResolutionLogState,
+  );
   logger.info("Monitor initial endpoint resolution completed", {
     environment: config.environment,
     hasEndpoint: endpoint !== null,
@@ -150,9 +158,9 @@ export async function runMonitor(args: MonitorArgs): Promise<void> {
       return;
     }
     pollInFlight = true;
-    void tryResolveStreamEndpoint(logger)
+    void tryResolveStreamEndpoint(logger, endpointResolutionLogState)
       .then((next) => {
-        if (next !== null) {
+        if (next !== null && !sameEndpoint(endpoint, next)) {
           endpoint = next;
           logger.debug("Monitor endpoint refreshed", {
             environment: config.environment,
@@ -433,23 +441,50 @@ function handleServerFrame(
 
 async function tryResolveStreamEndpoint(
   logger: ILogger,
+  logState: EndpointResolutionLogState,
 ): Promise<HostTransportEndpoint | null> {
   const metadata = await readHostPidMetadata(config.environment);
   if (metadata === null) {
-    logger.debug("Monitor endpoint metadata missing", {
-      environment: config.environment,
+    logEndpointResolution(logState, "missing", () => {
+      logger.debug("Monitor endpoint metadata missing", {
+        environment: config.environment,
+      });
     });
     return null;
   }
   if (!isValidLocalHostWebsocketUrl(metadata.websocketUrl)) {
-    logger.warn("Monitor endpoint metadata advertised invalid websocket URL", {
-      environment: config.environment,
-      hostId: metadata.hostId,
+    logEndpointResolution(logState, `invalid:${metadata.hostId}`, () => {
+      logger.warn("Monitor endpoint metadata advertised invalid websocket URL", {
+        environment: config.environment,
+        hostId: metadata.hostId,
+      });
     });
     return null;
   }
   // `WsStreamClient` maps the `/rpc` URL to `/stream` itself.
+  logState.value = `ready:${metadata.hostId}:${metadata.websocketUrl}`;
   return { hostId: metadata.hostId, websocketUrl: metadata.websocketUrl };
+}
+
+function sameEndpoint(
+  current: HostTransportEndpoint | null,
+  next: HostTransportEndpoint,
+): boolean {
+  return (
+    current !== null &&
+    current.hostId === next.hostId &&
+    current.websocketUrl === next.websocketUrl
+  );
+}
+
+function logEndpointResolution(
+  state: EndpointResolutionLogState,
+  key: string,
+  write: () => void,
+): void {
+  if (state.value === key) return;
+  state.value = key;
+  write();
 }
 
 function printInboxMessage(item: AgentInboxMessage): void {

--- a/clients/traycer-cli/src/commands/monitor.ts
+++ b/clients/traycer-cli/src/commands/monitor.ts
@@ -24,6 +24,7 @@ import type { HostTransportEndpoint } from "../../../shared/host-transport/ws-rp
 import { WsStreamClient } from "../../../shared/host-transport/ws-stream-client";
 import { DEFAULT_DIAL_TIMEOUT_MS } from "../../../shared/host-transport/transport-config";
 import { config } from "../config";
+import { createCliLogger, type ILogger } from "../logger";
 import {
   isValidLocalHostWebsocketUrl,
   readHostPidMetadata,
@@ -77,25 +78,50 @@ export type MonitorArgs = {
 };
 
 export async function runMonitor(args: MonitorArgs): Promise<void> {
+  const logger = createCliLogger(config.environment);
   const agentId = args.agentId ?? process.env.TRAYCER_AGENT_ID ?? null;
   const epicId = args.epicId ?? process.env.TRAYCER_EPIC_ID ?? null;
 
+  logger.info("Monitor resolving target", {
+    environment: config.environment,
+    agentIdPresent: agentId !== null && agentId.length > 0,
+    epicIdPresent: epicId !== null && epicId.length > 0,
+    agentIdFromArg: args.agentId !== null,
+    epicIdFromArg: args.epicId !== null,
+  });
+
   if (agentId === null || agentId.length === 0) {
+    logger.warn("Monitor missing agent id", {
+      environment: config.environment,
+    });
     throw new Error(
       "traycer monitor: agent id required — pass --agent-id or set TRAYCER_AGENT_ID.",
     );
   }
   if (epicId === null || epicId.length === 0) {
+    logger.warn("Monitor missing epic id", {
+      environment: config.environment,
+    });
     throw new Error(
       "traycer monitor: epic id required — pass --epic-id or set TRAYCER_EPIC_ID.",
     );
   }
   const auth = await resolveHostAuth();
   if (auth === null) {
+    logger.warn("Monitor cannot start without credentials", {
+      environment: config.environment,
+      agentId,
+      epicId,
+    });
     throw new Error(
       "traycer monitor: not signed in — run `traycer login` to authenticate.",
     );
   }
+  logger.info("Monitor credentials resolved", {
+    environment: config.environment,
+    agentId,
+    epicId,
+  });
 
   const lease = new MutableBearerLease(auth.token, auth.userId);
   const revalidator = createBearerRevalidator({
@@ -111,17 +137,27 @@ export async function runMonitor(args: MonitorArgs): Promise<void> {
   // are serialized (no out-of-order clobber) and a good endpoint is never
   // overwritten with `null` (a momentarily-absent pid file keeps the last-known
   // URL; dials simply retry until a fresh one appears).
-  let endpoint = await tryResolveStreamEndpoint();
+  let endpoint = await tryResolveStreamEndpoint(logger);
+  logger.info("Monitor initial endpoint resolution completed", {
+    environment: config.environment,
+    hasEndpoint: endpoint !== null,
+    agentId,
+    epicId,
+  });
   let pollInFlight = false;
   const poll = setInterval(() => {
     if (pollInFlight) {
       return;
     }
     pollInFlight = true;
-    void tryResolveStreamEndpoint()
+    void tryResolveStreamEndpoint(logger)
       .then((next) => {
         if (next !== null) {
           endpoint = next;
+          logger.debug("Monitor endpoint refreshed", {
+            environment: config.environment,
+            hostId: next.hostId,
+          });
         }
       })
       .finally(() => {
@@ -149,10 +185,20 @@ export async function runMonitor(args: MonitorArgs): Promise<void> {
   });
 
   diag(`inbox monitor starting — agent=${agentId} epic=${epicId}`);
+  logger.info("Monitor subscription loop starting", {
+    environment: config.environment,
+    agentId,
+    epicId,
+  });
   try {
-    await runInboxSubscription(client, revalidator, { agentId, epicId });
+    await runInboxSubscription(client, revalidator, { agentId, epicId }, logger);
   } finally {
     clearInterval(poll);
+    logger.info("Monitor subscription loop stopped", {
+      environment: config.environment,
+      agentId,
+      epicId,
+    });
   }
 }
 
@@ -178,6 +224,7 @@ function runInboxSubscription(
   client: WsStreamClient<HostStreamRpcRegistry>,
   revalidator: InboxRevalidator,
   target: InboxTarget,
+  logger: ILogger,
 ): Promise<never> {
   return new Promise<never>((_resolve, reject) => {
     let session: IStreamSession | null = null;
@@ -204,6 +251,15 @@ function runInboxSubscription(
         return;
       }
       settled = true;
+      logger.error(
+        "Monitor subscription failed",
+        {
+          environment: config.environment,
+          agentId: target.agentId,
+          epicId: target.epicId,
+        },
+        error,
+      );
       clearHealthTimer();
       clearRetryTimer();
       session?.close();
@@ -218,11 +274,17 @@ function runInboxSubscription(
     const subscribe = (): void => {
       clearRetryTimer();
       session?.close();
+      logger.info("Monitor subscribing to inbox stream", {
+        environment: config.environment,
+        method: SUBSCRIBE_METHOD,
+        agentId: target.agentId,
+        epicId: target.epicId,
+      });
       const next = client.subscribe(SUBSCRIBE_METHOD, target);
       session = next;
       next.onServerFrame((envelope) => {
         markHealthy();
-        handleServerFrame(envelope);
+        handleServerFrame(envelope, target, logger);
       });
       next.onStatusChange((status, reason) => {
         void onStatusChange(status, reason);
@@ -239,6 +301,11 @@ function runInboxSubscription(
       diag(`stream ${status}`);
       clearHealthTimer();
       if (status === "open") {
+        logger.info("Monitor stream opened", {
+          environment: config.environment,
+          agentId: target.agentId,
+          epicId: target.epicId,
+        });
         // Sustained openness (past the subscribe-accept window) is health.
         healthTimer = setTimeout(markHealthy, HEALTHY_OPEN_MS);
         return;
@@ -251,6 +318,12 @@ function runInboxSubscription(
         return;
       }
       if (reason.details.code !== "UNAUTHORIZED") {
+        logger.warn("Monitor stream closed with non-auth fatal error", {
+          environment: config.environment,
+          code: reason.details.code,
+          agentId: target.agentId,
+          epicId: target.epicId,
+        });
         fail(
           new Error(
             `traycer monitor: host closed the stream: ${reason.details.reason}`,
@@ -264,6 +337,13 @@ function runInboxSubscription(
       if (settled) {
         return;
       }
+      logger.info("Monitor auth revalidation completed", {
+        environment: config.environment,
+        outcome,
+        authRefreshCount,
+        agentId: target.agentId,
+        epicId: target.epicId,
+      });
       if (outcome === "rotated") {
         authRefreshCount += 1;
         if (authRefreshCount > MAX_CONSECUTIVE_AUTH_REFRESHES) {
@@ -283,11 +363,23 @@ function runInboxSubscription(
           return;
         }
         diag("bearer refreshed after auth rejection — re-subscribing");
+        logger.info("Monitor bearer refreshed after auth rejection", {
+          environment: config.environment,
+          authRefreshCount,
+          agentId: target.agentId,
+          epicId: target.epicId,
+        });
         subscribe();
         return;
       }
       if (outcome === "network-error") {
         diag(`auth refresh unavailable — retrying in ${AUTH_RETRY_DELAY_MS}ms`);
+        logger.warn("Monitor auth refresh unavailable; retry scheduled", {
+          environment: config.environment,
+          retryDelayMs: AUTH_RETRY_DELAY_MS,
+          agentId: target.agentId,
+          epicId: target.epicId,
+        });
         retryTimer = setTimeout(subscribe, AUTH_RETRY_DELAY_MS);
         return;
       }
@@ -298,27 +390,62 @@ function runInboxSubscription(
   });
 }
 
-function handleServerFrame(envelope: StreamFrameEnvelope): void {
+function handleServerFrame(
+  envelope: StreamFrameEnvelope,
+  target: InboxTarget,
+  logger: ILogger,
+): void {
   const parsed = agentInboxSubscribeServerFrameSchema.safeParse(envelope);
   if (!parsed.success) {
     diag(`dropping unrecognized frame kind=${String(envelope.kind)}`);
+    logger.warn("Monitor dropped unrecognized inbox frame", {
+      environment: config.environment,
+      frameKind: String(envelope.kind),
+      issueCount: parsed.error.issues.length,
+      agentId: target.agentId,
+      epicId: target.epicId,
+    });
     return;
   }
   if (parsed.data.kind === "message") {
+    logger.info("Monitor received inbox message frame", {
+      environment: config.environment,
+      agentId: target.agentId,
+      epicId: target.epicId,
+      fromAgentId: parsed.data.item.fromAgentId,
+      hasReply: parsed.data.item.reply !== null,
+    });
     printInboxMessage(parsed.data.item);
     return;
   }
   if (parsed.data.kind === "notice") {
+    logger.info("Monitor received inbox notice frame", {
+      environment: config.environment,
+      agentId: target.agentId,
+      epicId: target.epicId,
+      receiverAgentId: parsed.data.notice.receiverAgentId,
+      reason: parsed.data.notice.reason,
+      droppedReceiverCount: parsed.data.notice.droppedReceivers?.length ?? 0,
+    });
     printInboxNotice(parsed.data.notice);
   }
 }
 
-async function tryResolveStreamEndpoint(): Promise<HostTransportEndpoint | null> {
+async function tryResolveStreamEndpoint(
+  logger: ILogger,
+): Promise<HostTransportEndpoint | null> {
   const metadata = await readHostPidMetadata(config.environment);
   if (metadata === null) {
+    logger.debug("Monitor endpoint metadata missing", {
+      environment: config.environment,
+    });
     return null;
   }
   if (!isValidLocalHostWebsocketUrl(metadata.websocketUrl)) {
+    logger.warn("Monitor endpoint metadata advertised invalid websocket URL", {
+      environment: config.environment,
+      hostId: metadata.hostId,
+    });
     return null;
   }
   // `WsStreamClient` maps the `/rpc` URL to `/stream` itself.

--- a/clients/traycer-cli/src/commands/service-install.ts
+++ b/clients/traycer-cli/src/commands/service-install.ts
@@ -20,6 +20,11 @@ export function buildServiceInstallCommand(
   args: ServiceInstallArgs,
 ): CommandFn {
   return async (ctx): Promise<CommandResult> => {
+    ctx.runtime.logger.info("Service install command started", {
+      environment: ctx.runtime.environment,
+      enableLinger: args.enableLinger,
+      allowSelfInvocation: args.allowSelfInvocation,
+    });
     return withCliLock(
       {
         environment: ctx.runtime.environment,
@@ -33,6 +38,11 @@ export function buildServiceInstallCommand(
           environment: ctx.runtime.environment,
           override: null,
           allowSelfInvocation: args.allowSelfInvocation,
+        });
+        ctx.runtime.logger.debug("Service install CLI invocation resolved", {
+          environment: ctx.runtime.environment,
+          label: label.id,
+          argCount: cli.args.length,
         });
         ctx.progress({
           stage: "register",
@@ -51,6 +61,12 @@ export function buildServiceInstallCommand(
           platform === "win32"
             ? windowsTaskName(label)
             : serviceManifestPath(label);
+        ctx.runtime.logger.info("Service install command completed", {
+          environment: ctx.runtime.environment,
+          label: label.id,
+          platform,
+          enableLinger: args.enableLinger,
+        });
         return {
           data: {
             label: label.id,

--- a/clients/traycer-cli/src/commands/service-uninstall.ts
+++ b/clients/traycer-cli/src/commands/service-uninstall.ts
@@ -10,6 +10,9 @@ import { withCliLock } from "../store/cli-lock";
 // cleanly. Does NOT remove the host install dir; that's
 // `host uninstall --all`.
 export const serviceUninstallCommand: CommandFn = async (ctx): Promise<CommandResult> => {
+  ctx.runtime.logger.info("Service uninstall command started", {
+    environment: ctx.runtime.environment,
+  });
   return withCliLock(
     {
       environment: ctx.runtime.environment,
@@ -19,6 +22,10 @@ export const serviceUninstallCommand: CommandFn = async (ctx): Promise<CommandRe
     },
     async () => {
       const label = serviceLabelFor(ctx.runtime.environment);
+      ctx.runtime.logger.debug("Service uninstall label resolved", {
+        environment: ctx.runtime.environment,
+        label: label.id,
+      });
       ctx.progress({
         stage: "deregister",
         message: `deregistering service '${label.id}'`,
@@ -27,6 +34,10 @@ export const serviceUninstallCommand: CommandFn = async (ctx): Promise<CommandRe
         totalBytes: null,
       });
       await createServiceController().uninstall({ label });
+      ctx.runtime.logger.info("Service uninstall command completed", {
+        environment: ctx.runtime.environment,
+        label: label.id,
+      });
       return {
         data: { label: label.id, environment: label.environment },
         human: `service '${label.id}' deregistered`,

--- a/clients/traycer-cli/src/host/__tests__/auto-bootstrap.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/auto-bootstrap.test.ts
@@ -8,6 +8,7 @@ import {
   type Mock,
 } from "vitest";
 import type { RuntimeContext } from "../../runner/runtime";
+import { noopLogger } from "../../logger";
 
 // Pin Ticket a440ec2d: auto-bootstrap must distinguish "host already
 // installed but service missing" (service-only repair) from "no host
@@ -59,6 +60,10 @@ vi.mock("../../store/cli-lock", () => ({
   withCliLock: mocks.withCliLockMock,
 }));
 
+vi.mock("../busy-check", () => ({
+  assertHostNotBusy: vi.fn(async () => undefined),
+}));
+
 const {
   installHostMock,
   resolveBundledHostArchiveMock,
@@ -84,6 +89,7 @@ function makeRuntime(overrides: Partial<RuntimeContext>): RuntimeContext {
     noBootstrap: false,
     nonInteractive: false,
     environment: "production",
+    logger: noopLogger,
     ...overrides,
   };
 }

--- a/clients/traycer-cli/src/host/__tests__/ensure.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/ensure.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeContext } from "../../runner/runtime";
+import { noopLogger } from "../../logger";
 
 // Pins the `host ensure` state machine: a lock-free fast no-op when the
 // host is already installed + registered + running, and the three
@@ -75,6 +76,7 @@ function makeRuntime(): RuntimeContext {
     noBootstrap: false,
     nonInteractive: false,
     environment: "production",
+    logger: noopLogger,
   };
 }
 

--- a/clients/traycer-cli/src/host/auto-bootstrap.ts
+++ b/clients/traycer-cli/src/host/auto-bootstrap.ts
@@ -1,6 +1,7 @@
 import { config } from "../config";
 import type { InstallSourceArg } from "../installer";
 import { resolveBundledHostArchive } from "../installer/bundled-host";
+import { errorFromUnknown, type LogFields } from "../logger";
 import { readHostInstallRecord } from "../manifest/host-install";
 import { CliError } from "../runner/errors";
 import type { ProgressInfo } from "../runner/output";
@@ -75,7 +76,12 @@ export async function detectBootstrapState(
   let hostInstalled = false;
   try {
     hostInstalled = (await readHostInstallRecord(runtime.environment)) !== null;
-  } catch {
+  } catch (err) {
+    runtime.logger.warn("Auto-bootstrap install record probe failed", {
+      environment: runtime.environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     hostInstalled = false;
   }
 
@@ -84,10 +90,20 @@ export async function detectBootstrapState(
     const label = serviceLabelFor(runtime.environment);
     const status = await createServiceController().status(label);
     serviceRegistered = status.state !== "not-installed";
-  } catch {
+  } catch (err) {
+    runtime.logger.warn("Auto-bootstrap service status probe failed", {
+      environment: runtime.environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     serviceRegistered = false;
   }
 
+  runtime.logger.debug("Auto-bootstrap state detected", {
+    environment: runtime.environment,
+    hostInstalled,
+    serviceRegistered,
+  });
   return { hostInstalled, serviceRegistered };
 }
 
@@ -98,9 +114,19 @@ export async function detectBootstrapState(
 export async function evaluateAutoBootstrap(
   opts: AutoBootstrapOptions,
 ): Promise<AutoBootstrapDecision> {
+  opts.runtime.logger.info("Auto-bootstrap evaluation started", {
+    environment: opts.runtime.environment,
+    trigger: opts.trigger,
+    noBootstrap: opts.runtime.noBootstrap,
+    nonInteractive: opts.runtime.nonInteractive,
+  });
   const state = await detectBootstrapState(opts.runtime);
 
   if (state.hostInstalled && state.serviceRegistered) {
+    opts.runtime.logger.info("Auto-bootstrap skipped; host already ready", {
+      environment: opts.runtime.environment,
+      trigger: opts.trigger,
+    });
     return {
       status: "ready",
       reason: "already-installed",
@@ -113,6 +139,12 @@ export async function evaluateAutoBootstrap(
   }
 
   if (opts.runtime.noBootstrap) {
+    opts.runtime.logger.info("Auto-bootstrap skipped by flag", {
+      environment: opts.runtime.environment,
+      trigger: opts.trigger,
+      hostInstalled: state.hostInstalled,
+      serviceRegistered: state.serviceRegistered,
+    });
     return {
       status: "skipped",
       reason: "explicit-no-bootstrap",
@@ -125,6 +157,12 @@ export async function evaluateAutoBootstrap(
   }
 
   if (opts.runtime.nonInteractive) {
+    opts.runtime.logger.info("Auto-bootstrap skipped in non-interactive runtime", {
+      environment: opts.runtime.environment,
+      trigger: opts.trigger,
+      hostInstalled: state.hostInstalled,
+      serviceRegistered: state.serviceRegistered,
+    });
     return {
       status: "skipped",
       reason: "noninteractive-cannot-prompt",
@@ -141,6 +179,10 @@ export async function evaluateAutoBootstrap(
   // `maybeAutoBootstrap` so the shared core actually fires; this evaluator
   // stays pure.
   if (state.hostInstalled && !state.serviceRegistered) {
+    opts.runtime.logger.info("Auto-bootstrap selected service repair", {
+      environment: opts.runtime.environment,
+      trigger: opts.trigger,
+    });
     return {
       status: "service-registered",
       reason: "service-registered",
@@ -153,6 +195,12 @@ export async function evaluateAutoBootstrap(
   }
 
   // "would proceed to a full install" placeholder.
+  opts.runtime.logger.info("Auto-bootstrap selected full install", {
+    environment: opts.runtime.environment,
+    trigger: opts.trigger,
+    hostInstalled: state.hostInstalled,
+    serviceRegistered: state.serviceRegistered,
+  });
   return {
     status: "installed",
     reason: "installed",
@@ -179,6 +227,12 @@ export async function maybeAutoBootstrap(
   const decision = await evaluateAutoBootstrap(opts);
   if (decision.status !== "service-registered" && decision.status !== "installed") {
     // "skipped" or "ready" - nothing to do.
+    opts.runtime.logger.info("Auto-bootstrap returning without provisioning", {
+      environment: opts.runtime.environment,
+      trigger: opts.trigger,
+      status: decision.status,
+      reason: decision.reason,
+    });
     return decision;
   }
   const isServiceOnly = decision.status === "service-registered";
@@ -189,6 +243,12 @@ export async function maybeAutoBootstrap(
     // registry fallback uses the CLI's stamped supported host version when
     // present.
     const source = await resolveAutoBootstrapSource();
+    opts.runtime.logger.info("Auto-bootstrap source resolved", {
+      environment: opts.runtime.environment,
+      trigger: opts.trigger,
+      serviceOnly: isServiceOnly,
+      ...installSourceLogFields(source),
+    });
     const isOwnBuild = source.kind === "local-file";
     const targetVersion =
       source.kind === "registry" && source.versionRequest !== "latest"
@@ -221,8 +281,28 @@ export async function maybeAutoBootstrap(
       force: false,
       onProgress: opts.onProgress,
     });
-    return projectProvisionResult(result);
+    const projected = projectProvisionResult(result);
+    opts.runtime.logger.info("Auto-bootstrap provisioning completed", {
+      environment: opts.runtime.environment,
+      trigger: opts.trigger,
+      status: projected.status,
+      reason: projected.reason,
+      action: result.action,
+      hostInstalled: projected.hostInstalled,
+      serviceRegistered: projected.serviceRegistered,
+      hasPostSwapError: projected.postSwapError !== null,
+    });
+    return projected;
   } catch (cause) {
+    opts.runtime.logger.error(
+      "Auto-bootstrap provisioning failed",
+      {
+        environment: opts.runtime.environment,
+        trigger: opts.trigger,
+        serviceOnly: isServiceOnly,
+      },
+      errorFromUnknown(cause),
+    );
     const post = await detectBootstrapState(opts.runtime);
     const error = toErrorPayload(cause);
     return {
@@ -235,6 +315,16 @@ export async function maybeAutoBootstrap(
       error,
     };
   }
+}
+
+function installSourceLogFields(source: InstallSourceArg): LogFields {
+  if (source.kind === "local-file") {
+    return { sourceKind: "local-file" };
+  }
+  return {
+    sourceKind: "registry",
+    versionRequest: source.versionRequest,
+  };
 }
 
 function projectProvisionResult(

--- a/clients/traycer-cli/src/host/auto-bootstrap.ts
+++ b/clients/traycer-cli/src/host/auto-bootstrap.ts
@@ -1,7 +1,7 @@
 import { config } from "../config";
 import type { InstallSourceArg } from "../installer";
 import { resolveBundledHostArchive } from "../installer/bundled-host";
-import { errorFromUnknown, type LogFields } from "../logger";
+import { errorFromUnknown } from "../logger";
 import { readHostInstallRecord } from "../manifest/host-install";
 import { CliError } from "../runner/errors";
 import type { ProgressInfo } from "../runner/output";
@@ -9,6 +9,7 @@ import type { RuntimeContext } from "../runner/runtime";
 import { createServiceController, serviceLabelFor } from "../service";
 import { provisionHost, type HostProvisionResult } from "./provision";
 import { defaultRegistryHostVersionRequest } from "./supported-host-version";
+import { installSourceLogFields } from "./install-source-log-fields";
 
 // Centralized auto-bootstrap for the standalone CLI. Per Core Flow 7
 // (Standalone CLI First-Run), commands like `traycer login` and any
@@ -315,16 +316,6 @@ export async function maybeAutoBootstrap(
       error,
     };
   }
-}
-
-function installSourceLogFields(source: InstallSourceArg): LogFields {
-  if (source.kind === "local-file") {
-    return { sourceKind: "local-file" };
-  }
-  return {
-    sourceKind: "registry",
-    versionRequest: source.versionRequest,
-  };
 }
 
 function projectProvisionResult(

--- a/clients/traycer-cli/src/host/ensure.ts
+++ b/clients/traycer-cli/src/host/ensure.ts
@@ -1,6 +1,7 @@
 import { config } from "../config";
 import type { InstallSourceArg } from "../installer";
 import { resolveBundledHostArchive } from "../installer/bundled-host";
+import type { LogFields } from "../logger";
 import type { ProgressInfo } from "../runner/output";
 import type { RuntimeContext } from "../runner/runtime";
 import {
@@ -46,6 +47,15 @@ export interface EnsureHostOptions {
 export async function ensureHost(
   opts: EnsureHostOptions,
 ): Promise<HostEnsureResult> {
+  opts.runtime.logger.info("Host ensure started", {
+    environment: opts.runtime.environment,
+    hasExplicitVersion: opts.versionRequest !== null,
+    hasFromPath: opts.fromPath !== null,
+    enableLinger: opts.enableLinger,
+    allowSelfInvocation: opts.allowSelfInvocation,
+    noServiceRegister: opts.noServiceRegister,
+    force: opts.force,
+  });
   // Resolve the source up front (a cheap path probe - no network/download)
   // so we can key idempotency on it. Our own bundled host resolves to a
   // local-file; it shares this build's `config.version`, so we stamp that as
@@ -54,13 +64,24 @@ export async function ensureHost(
   // while an unchanged build is a no-op. An explicit `--release <semver>`
   // resolves to a registry source and keeps the real semver as its target.
   const source = await resolveEnsureSource(opts);
+  opts.runtime.logger.info("Host ensure source resolved", {
+    environment: opts.runtime.environment,
+    ...installSourceLogFields(source),
+  });
   const isOwnBuild = source.kind === "local-file";
   const targetVersion = isOwnBuild
     ? config.version
     : source.kind === "registry" && source.versionRequest !== "latest"
       ? source.versionRequest
       : null;
-  return provisionHost({
+  opts.runtime.logger.debug("Host ensure provisioning target computed", {
+    environment: opts.runtime.environment,
+    sourceKind: source.kind,
+    targetVersion: targetVersion ?? "presence-only",
+    recordVersionOverride: isOwnBuild ? "cli-build-version" : "none",
+    registerService: !opts.noServiceRegister,
+  });
+  const result = await provisionHost({
     runtime: opts.runtime,
     resolveInstallSource: () => Promise.resolve(source),
     targetVersion,
@@ -72,6 +93,15 @@ export async function ensureHost(
     force: opts.force,
     onProgress: opts.onProgress,
   });
+  opts.runtime.logger.info("Host ensure completed", {
+    environment: opts.runtime.environment,
+    action: result.action,
+    installed: result.installed,
+    registered: result.registered,
+    running: result.running,
+    hasPostSwapError: result.postSwapError !== null,
+  });
+  return result;
 }
 
 async function resolveEnsureSource(
@@ -90,5 +120,15 @@ async function resolveEnsureSource(
   return {
     kind: "registry",
     versionRequest: defaultRegistryHostVersionRequest(),
+  };
+}
+
+function installSourceLogFields(source: InstallSourceArg): LogFields {
+  if (source.kind === "local-file") {
+    return { sourceKind: "local-file" };
+  }
+  return {
+    sourceKind: "registry",
+    versionRequest: source.versionRequest,
   };
 }

--- a/clients/traycer-cli/src/host/ensure.ts
+++ b/clients/traycer-cli/src/host/ensure.ts
@@ -1,7 +1,6 @@
 import { config } from "../config";
 import type { InstallSourceArg } from "../installer";
 import { resolveBundledHostArchive } from "../installer/bundled-host";
-import type { LogFields } from "../logger";
 import type { ProgressInfo } from "../runner/output";
 import type { RuntimeContext } from "../runner/runtime";
 import {
@@ -9,6 +8,7 @@ import {
   type HostProvisionResult,
 } from "./provision";
 import { defaultRegistryHostVersionRequest } from "./supported-host-version";
+import { installSourceLogFields } from "./install-source-log-fields";
 
 // `host ensure` - the desktop's post-auth provisioning call. A thin
 // source-resolving wrapper over the shared `provisionHost` core
@@ -120,15 +120,5 @@ async function resolveEnsureSource(
   return {
     kind: "registry",
     versionRequest: defaultRegistryHostVersionRequest(),
-  };
-}
-
-function installSourceLogFields(source: InstallSourceArg): LogFields {
-  if (source.kind === "local-file") {
-    return { sourceKind: "local-file" };
-  }
-  return {
-    sourceKind: "registry",
-    versionRequest: source.versionRequest,
   };
 }

--- a/clients/traycer-cli/src/host/install-source-log-fields.ts
+++ b/clients/traycer-cli/src/host/install-source-log-fields.ts
@@ -1,0 +1,12 @@
+import type { InstallSourceArg } from "../installer";
+import type { LogFields } from "../logger";
+
+export function installSourceLogFields(source: InstallSourceArg): LogFields {
+  if (source.kind === "local-file") {
+    return { sourceKind: "local-file" };
+  }
+  return {
+    sourceKind: "registry",
+    versionRequest: source.versionRequest,
+  };
+}

--- a/clients/traycer-cli/src/host/pid-metadata.ts
+++ b/clients/traycer-cli/src/host/pid-metadata.ts
@@ -1,5 +1,7 @@
 import { readFile } from "node:fs/promises";
 import type { Environment } from "../runner/environment";
+import { config } from "../config";
+import { createCliLogger, errorFromUnknown } from "../logger";
 import { hostPidMetadataPath } from "../store/paths";
 
 // Mirror of the writer contract owned by the host (the external
@@ -18,19 +20,35 @@ export interface HostPidMetadata {
 export async function readHostPidMetadata(
   environment: Environment | undefined,
 ): Promise<HostPidMetadata | null> {
+  const logger = createCliLogger(environment ?? config.environment);
   let raw: string;
   try {
     raw = await readFile(hostPidMetadataPath(environment), "utf8");
-  } catch {
+  } catch (err) {
+    logger.debug("Host pid metadata read returned absent", {
+      environment: environment ?? "production",
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     return null;
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    logger.warn("Host pid metadata JSON parse failed", {
+      environment: environment ?? "production",
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     return null;
   }
-  if (parsed === null || typeof parsed !== "object") return null;
+  if (parsed === null || typeof parsed !== "object") {
+    logger.warn("Host pid metadata rejected non-object payload", {
+      environment: environment ?? "production",
+    });
+    return null;
+  }
   const obj = parsed as Record<string, unknown>;
   if (
     typeof obj.pid !== "number" ||
@@ -39,8 +57,22 @@ export async function readHostPidMetadata(
     typeof obj.websocketUrl !== "string" ||
     typeof obj.startedAt !== "string"
   ) {
+    logger.warn("Host pid metadata rejected malformed payload", {
+      environment: environment ?? "production",
+      hasPid: typeof obj.pid === "number",
+      hasHostId: typeof obj.hostId === "string",
+      hasVersion: typeof obj.version === "string",
+      hasWebsocketUrl: typeof obj.websocketUrl === "string",
+      hasStartedAt: typeof obj.startedAt === "string",
+    });
     return null;
   }
+  logger.debug("Host pid metadata read completed", {
+    environment: environment ?? "production",
+    hostId: obj.hostId,
+    pid: obj.pid,
+    version: obj.version,
+  });
   return {
     pid: obj.pid,
     hostId: obj.hostId,

--- a/clients/traycer-cli/src/host/pid-metadata.ts
+++ b/clients/traycer-cli/src/host/pid-metadata.ts
@@ -20,16 +20,19 @@ export interface HostPidMetadata {
 export async function readHostPidMetadata(
   environment: Environment | undefined,
 ): Promise<HostPidMetadata | null> {
-  const logger = createCliLogger(environment ?? config.environment);
+  const logEnvironment = environment ?? config.environment;
+  const logger = createCliLogger(logEnvironment);
   let raw: string;
   try {
     raw = await readFile(hostPidMetadataPath(environment), "utf8");
   } catch (err) {
-    logger.debug("Host pid metadata read returned absent", {
-      environment: environment ?? "production",
-      errorName: errorFromUnknown(err).name,
-      errorMessage: errorFromUnknown(err).message,
-    });
+    if (readErrorCode(err) !== "ENOENT") {
+      logger.debug("Host pid metadata read failed", {
+        environment: logEnvironment,
+        errorName: errorFromUnknown(err).name,
+        errorCode: readErrorCode(err),
+      });
+    }
     return null;
   }
   let parsed: unknown;
@@ -37,7 +40,7 @@ export async function readHostPidMetadata(
     parsed = JSON.parse(raw);
   } catch (err) {
     logger.warn("Host pid metadata JSON parse failed", {
-      environment: environment ?? "production",
+      environment: logEnvironment,
       errorName: errorFromUnknown(err).name,
       errorMessage: errorFromUnknown(err).message,
     });
@@ -45,7 +48,7 @@ export async function readHostPidMetadata(
   }
   if (parsed === null || typeof parsed !== "object") {
     logger.warn("Host pid metadata rejected non-object payload", {
-      environment: environment ?? "production",
+      environment: logEnvironment,
     });
     return null;
   }
@@ -58,7 +61,7 @@ export async function readHostPidMetadata(
     typeof obj.startedAt !== "string"
   ) {
     logger.warn("Host pid metadata rejected malformed payload", {
-      environment: environment ?? "production",
+      environment: logEnvironment,
       hasPid: typeof obj.pid === "number",
       hasHostId: typeof obj.hostId === "string",
       hasVersion: typeof obj.version === "string",
@@ -68,7 +71,7 @@ export async function readHostPidMetadata(
     return null;
   }
   logger.debug("Host pid metadata read completed", {
-    environment: environment ?? "production",
+    environment: logEnvironment,
     hostId: obj.hostId,
     pid: obj.pid,
     version: obj.version,
@@ -107,4 +110,10 @@ export function isValidLocalHostWebsocketUrl(websocketUrl: string): boolean {
   }
   const port = Number.parseInt(parsed.port, 10);
   return Number.isInteger(port) && port >= 1 && port <= 65_535;
+}
+
+function readErrorCode(error: unknown): string | null {
+  if (error === null || typeof error !== "object") return null;
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : null;
 }

--- a/clients/traycer-cli/src/host/provision.ts
+++ b/clients/traycer-cli/src/host/provision.ts
@@ -2,6 +2,7 @@ import { installHost, type InstallSourceArg } from "../installer";
 import { readHostInstallRecord } from "../manifest/host-install";
 import type { ProgressInfo } from "../runner/output";
 import type { RuntimeContext } from "../runner/runtime";
+import { errorFromUnknown } from "../logger";
 import {
   createServiceController,
   serviceLabelFor,
@@ -92,16 +93,43 @@ export async function provisionHost(
   const progress = opts.onProgress ?? noopProgress;
   const controller = createServiceController();
   const label = serviceLabelFor(opts.runtime.environment);
+  opts.runtime.logger.info("Host provisioning started", {
+    environment: opts.runtime.environment,
+    registerService: opts.registerService,
+    force: opts.force,
+    targetVersion: opts.targetVersion ?? "presence-only",
+    recordVersionOverride: opts.recordVersionOverride !== null,
+    lockReason: opts.lockReason,
+  });
 
   // Lock-free fast path: a healthy, already-provisioned host is the
   // overwhelmingly common case (persistent service across launches).
-  const fast = await readProvisionState(controller, label, opts.runtime.environment);
+  const fast = await readProvisionState(controller, label, opts.runtime);
+  opts.runtime.logger.debug("Host provisioning fast-path state read", {
+    environment: opts.runtime.environment,
+    installed: fast.installed,
+    registered: fast.registered,
+    running: fast.running,
+    hasVersion: fast.version !== null,
+  });
   // `--force` (the desktop "Force restart", D5) must reinstall + restart even
   // when the install record already matches, so it never takes the satisfied
   // no-op fast path.
   if (!opts.force && isSatisfied(fast, opts.targetVersion, opts.registerService)) {
+    opts.runtime.logger.info("Host provisioning fast-path satisfied", {
+      environment: opts.runtime.environment,
+      installed: fast.installed,
+      registered: fast.registered,
+      running: fast.running,
+      registerService: opts.registerService,
+    });
     return noopResult(fast);
   }
+  opts.runtime.logger.info("Host provisioning entering CLI lock", {
+    environment: opts.runtime.environment,
+    lockReason: opts.lockReason,
+    force: opts.force,
+  });
 
   return withCliLock(
     {
@@ -117,12 +145,25 @@ export async function provisionHost(
       const state = await readProvisionState(
         controller,
         label,
-        opts.runtime.environment,
+        opts.runtime,
       );
+      opts.runtime.logger.debug("Host provisioning locked state read", {
+        environment: opts.runtime.environment,
+        installed: state.installed,
+        registered: state.registered,
+        running: state.running,
+        hasVersion: state.version !== null,
+      });
       if (
         !opts.force &&
         isSatisfied(state, opts.targetVersion, opts.registerService)
       ) {
+        opts.runtime.logger.info("Host provisioning satisfied after lock recheck", {
+          environment: opts.runtime.environment,
+          installed: state.installed,
+          registered: state.registered,
+          running: state.running,
+        });
         return noopResult(state);
       }
       // Bytes present + at target with host-owned registration: there is
@@ -133,6 +174,11 @@ export async function provisionHost(
         versionSatisfied(state, opts.targetVersion) &&
         !opts.registerService
       ) {
+        opts.runtime.logger.info("Host provisioning no-op for host-owned service registration", {
+          environment: opts.runtime.environment,
+          installed: state.installed,
+          hasVersion: state.version !== null,
+        });
         return noopResult(state);
       }
       // Every remaining path replaces or cycles a LIVE host - reinstall
@@ -146,7 +192,16 @@ export async function provisionHost(
       // status drift where the controller reports stopped while a process is
       // still live and busy).
       if (!opts.force) {
+        opts.runtime.logger.info("Host provisioning running busy guard", {
+          environment: opts.runtime.environment,
+          reason: opts.lockReason,
+        });
         await assertHostNotBusy(opts.runtime.environment);
+      } else {
+        opts.runtime.logger.warn("Host provisioning skipped busy guard because force=true", {
+          environment: opts.runtime.environment,
+          reason: opts.lockReason,
+        });
       }
       // Reinstall when the bytes are absent/stale, OR when forced (D5: Force =
       // reinstall + restart onto this build even if the install record matches).
@@ -155,12 +210,24 @@ export async function provisionHost(
         !state.installed ||
         !versionSatisfied(state, opts.targetVersion)
       ) {
+        opts.runtime.logger.info("Host provisioning selected install branch", {
+          environment: opts.runtime.environment,
+          force: opts.force,
+          installed: state.installed,
+          versionSatisfied: versionSatisfied(state, opts.targetVersion),
+        });
         return runInstall(opts, controller, label, progress);
       }
       if (!state.registered) {
+        opts.runtime.logger.info("Host provisioning selected service-register branch", {
+          environment: opts.runtime.environment,
+        });
         return runServiceRegister(opts, controller, label, progress);
       }
       // installed + registered + stopped → start.
+      opts.runtime.logger.info("Host provisioning selected service-start branch", {
+        environment: opts.runtime.environment,
+      });
       return runStart(opts, controller, label, state, progress);
     },
   );
@@ -173,6 +240,13 @@ async function runInstall(
   progress: (info: ProgressInfo) => void,
 ): Promise<HostProvisionResult> {
   const source = await opts.resolveInstallSource();
+  opts.runtime.logger.info("Host provisioning install source resolved", {
+    environment: opts.runtime.environment,
+    sourceKind: source.kind,
+    versionRequest:
+      source.kind === "registry" ? source.versionRequest : "local-file",
+    registerService: opts.registerService,
+  });
   progress({
     stage: "host-provision",
     message:
@@ -195,6 +269,10 @@ async function runInstall(
         },
       })
     : null;
+  opts.runtime.logger.debug("Host provisioning install lifecycle prepared", {
+    environment: opts.runtime.environment,
+    lifecycleEnabled: handle !== null,
+  });
   // Already inside the per-environment CLI lock - call installHost directly
   // (it expects the caller to hold the lock).
   const result = await installHost({
@@ -204,7 +282,16 @@ async function runInstall(
     lifecycle: handle !== null ? handle.lifecycle : INERT_LIFECYCLE,
     recordVersionOverride: opts.recordVersionOverride,
   });
-  const post = await readProvisionState(controller, label, opts.runtime.environment);
+  const post = await readProvisionState(controller, label, opts.runtime);
+  opts.runtime.logger.info("Host provisioning install branch completed", {
+    environment: opts.runtime.environment,
+    version: result.record.version,
+    previousVersion: result.previous?.version ?? null,
+    registered: post.registered,
+    running: post.running,
+    postSwapAction: handle !== null ? handle.state.postSwapAction : "none",
+    hasPostSwapError: handle !== null && handle.state.postSwapError !== null,
+  });
   return {
     installed: true,
     registered: post.registered,
@@ -249,8 +336,19 @@ async function runServiceRegister(
     override: null,
     allowSelfInvocation: opts.allowSelfInvocation,
   });
+  opts.runtime.logger.debug("Host provisioning service CLI invocation resolved", {
+    environment: opts.runtime.environment,
+    argCount: cli.args.length,
+    enableLinger: opts.enableLinger,
+    allowSelfInvocation: opts.allowSelfInvocation,
+  });
   await controller.install({ label, cli, enableLinger: opts.enableLinger });
-  const post = await readProvisionState(controller, label, opts.runtime.environment);
+  const post = await readProvisionState(controller, label, opts.runtime);
+  opts.runtime.logger.info("Host provisioning service-register branch completed", {
+    environment: opts.runtime.environment,
+    registered: post.registered,
+    running: post.running,
+  });
   return {
     installed: true,
     registered: post.registered,
@@ -277,7 +375,12 @@ async function runStart(
     totalBytes: null,
   });
   await controller.start(label);
-  const post = await readProvisionState(controller, label, opts.runtime.environment);
+  const post = await readProvisionState(controller, label, opts.runtime);
+  opts.runtime.logger.info("Host provisioning service-start branch completed", {
+    environment: opts.runtime.environment,
+    registered: post.registered,
+    running: post.running,
+  });
   return {
     installed: true,
     registered: post.registered,
@@ -292,19 +395,24 @@ async function runStart(
 async function readProvisionState(
   controller: ServiceController,
   label: ServiceLabel,
-  environment: RuntimeContext["environment"],
+  runtime: RuntimeContext,
 ): Promise<ProvisionState> {
   // A malformed install record (or status probe failure) is treated as
   // "not present" so provisioning self-heals rather than wedging.
   let recordVersion: string | null = null;
   let installed = false;
   try {
-    const record = await readHostInstallRecord(environment);
+    const record = await readHostInstallRecord(runtime.environment);
     if (record !== null) {
       installed = true;
       recordVersion = record.version;
     }
-  } catch {
+  } catch (err) {
+    runtime.logger.warn("Host provisioning install record probe failed", {
+      environment: runtime.environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     installed = false;
   }
   let registered = false;
@@ -313,7 +421,12 @@ async function readProvisionState(
     const status = await controller.status(label);
     registered = status.state !== "not-installed";
     running = status.state === "running";
-  } catch {
+  } catch (err) {
+    runtime.logger.warn("Host provisioning service status probe failed", {
+      environment: runtime.environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     registered = false;
     running = false;
   }

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env -S bun
 import "./sentry";
+import * as Sentry from "@sentry/node";
 import { Command, CommanderError, type Command as CommanderCommand } from "commander";
 import { config } from "./config";
 import { buildCliMarkSourceCommand } from "./commands/cli-mark-source";
@@ -50,6 +51,11 @@ import { serviceStatusCommand } from "./commands/service-status";
 import { serviceUninstallCommand } from "./commands/service-uninstall";
 import { whoamiCommand } from "./commands/whoami";
 import { CLI_ERROR_CODES, cliError } from "./runner/errors";
+import {
+  createCliLogger,
+  errorFromUnknown,
+  type ILogger,
+} from "./logger";
 import {
   addRunnerFlags,
   extractRunnerFlags,
@@ -313,6 +319,11 @@ addRunnerFlags(
       "Working directory for the host (defaults to the install directory)",
     ),
 ).action(async (opts) => {
+  const logger = createCliLogger(config.environment);
+  logger.info("Host supervisor command invoked", {
+    environment: config.environment,
+    hasCwdOverride: typeof opts.cwd === "string",
+  });
   await runHostStart(
     {
       environment: config.environment,
@@ -1222,12 +1233,25 @@ function registerMonitorCommand(program: Command): void {
       )
       .option("--epic-id <id>", "Epic (defaults to $TRAYCER_EPIC_ID)"),
   ).action(async (opts: Record<string, unknown>) => {
+    const logger = createCliLogger(config.environment);
+    logger.info("Monitor command invoked", {
+      environment: config.environment,
+      hasAgentIdArg: typeof opts.agentId === "string",
+      hasEpicIdArg: typeof opts.epicId === "string",
+      hasAgentIdEnv: typeof process.env.TRAYCER_AGENT_ID === "string",
+      hasEpicIdEnv: typeof process.env.TRAYCER_EPIC_ID === "string",
+    });
     try {
       await runMonitor({
         agentId: typeof opts.agentId === "string" ? opts.agentId : null,
         epicId: typeof opts.epicId === "string" ? opts.epicId : null,
       });
     } catch (err) {
+      logger.error(
+        "Monitor command failed",
+        { exitCode: 1 },
+        errorFromUnknown(err),
+      );
       process.stderr.write(
         `[traycer monitor] fatal: ${
           err instanceof Error ? err.message : String(err)
@@ -1247,7 +1271,13 @@ function registerMonitorCommand(program: Command): void {
 // suffix produced by `bun build --compile --target=bun-windows-x64`.
 const entryArgv = typeof process !== "undefined" ? process.argv[1] : undefined;
 if (isTraycerCliEntrypoint(entryArgv)) {
+  const entryLogger = createCliLogger(config.environment);
+  installProcessFailureHandlers(entryLogger);
   const program = buildProgram();
+  entryLogger.info("CLI entrypoint parsing argv", {
+    environment: config.environment,
+    argvLength: process.argv.length,
+  });
   program
     .parseAsync(process.argv)
     .catch((err) => {
@@ -1259,6 +1289,11 @@ if (isTraycerCliEntrypoint(entryArgv)) {
         // override) so we wrap it in a single `result/ok` envelope rather than
         // leaking raw prose onto an NDJSON stream.
         if (err.exitCode === 0) {
+          entryLogger.info("Commander handled informational exit", {
+            json: jsonMode,
+            commanderCode: err.code,
+            exitCode: err.exitCode,
+          });
           if (jsonMode) {
             const event = {
               type: "result",
@@ -1274,6 +1309,11 @@ if (isTraycerCliEntrypoint(entryArgv)) {
         // envelope so downstream consumers see a coded `result/error`;
         // in human mode commander already wrote the message to stderr
         // (via the configureOutput passthrough above).
+        entryLogger.warn("Commander parse failed", {
+          json: jsonMode,
+          commanderCode: err.code,
+          exitCode: err.exitCode || 1,
+        });
         if (jsonMode) {
           const event = {
             type: "result",
@@ -1292,7 +1332,68 @@ if (isTraycerCliEntrypoint(entryArgv)) {
         }
         process.exit(err.exitCode || 1);
       }
-      console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+      const error = errorFromUnknown(err);
+      entryLogger.error(
+        "CLI entrypoint failed outside Commander",
+        { exitCode: 1 },
+        error,
+      );
+      Sentry.captureException(err);
+      if (argvRequestsJson(program)) {
+        const event = {
+          type: "result",
+          status: "error",
+          error: {
+            code: CLI_ERROR_CODES.UNEXPECTED,
+            message: "Unexpected CLI failure. See the CLI log for details.",
+            details: null,
+          },
+          timestamp: new Date().toISOString(),
+        };
+        process.stdout.write(`${JSON.stringify(event)}\n`);
+      } else {
+        process.stderr.write(
+          `error: unexpected CLI failure [code=${CLI_ERROR_CODES.UNEXPECTED}]\n`,
+        );
+      }
+      process.exit(1);
+    });
+}
+
+let fatalExitInProgress = false;
+
+function installProcessFailureHandlers(logger: ILogger): void {
+  process.on("unhandledRejection", (reason) => {
+    exitAfterUnhandledFailure(logger, "Unhandled CLI promise rejection", reason);
+  });
+  process.on("uncaughtException", (err) => {
+    exitAfterUnhandledFailure(logger, "Uncaught CLI exception", err);
+  });
+}
+
+function exitAfterUnhandledFailure(
+  logger: ILogger,
+  message: string,
+  cause: unknown,
+): void {
+  if (fatalExitInProgress) {
+    return;
+  }
+  fatalExitInProgress = true;
+  const error = errorFromUnknown(cause);
+  logger.error(message, { exitCode: 1 }, error);
+  Sentry.captureException(cause);
+  process.stderr.write(
+    `error: unexpected CLI failure [code=${CLI_ERROR_CODES.UNEXPECTED}]\n`,
+  );
+  void Sentry.flush(2000)
+    .catch((flushErr) => {
+      logger.warn("Sentry flush failed after process-level failure", {
+        errorName: errorFromUnknown(flushErr).name,
+        errorMessage: errorFromUnknown(flushErr).message,
+      });
+    })
+    .finally(() => {
       process.exit(1);
     });
 }

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -25,6 +25,7 @@ import {
 import type { ProgressInfo } from "../runner/output";
 import type { Environment } from "../runner/environment";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
+import { createCliLogger, errorFromUnknown } from "../logger";
 import {
   hostHomeDir,
   hostInstallDir,
@@ -113,9 +114,21 @@ export interface InstallHostResult {
 export async function installHost(
   opts: InstallHostOptions,
 ): Promise<InstallHostResult> {
+  const logger = createCliLogger(opts.environment);
   const platform = currentInstallPlatform();
   const arch = currentInstallArch();
   const previous = await readHostInstallRecord(opts.environment);
+  logger.info("Host install started", {
+    environment: opts.environment,
+    platform,
+    arch,
+    sourceKind: opts.source.kind,
+    versionRequest:
+      opts.source.kind === "registry" ? opts.source.versionRequest : "local-file",
+    hasPreviousInstall: previous !== null,
+    lifecycleEnabled: opts.lifecycle !== null,
+    recordVersionOverride: opts.recordVersionOverride !== null,
+  });
 
   await ensureHostHomeDir(opts.environment);
   await ensureHostStagingRoot(opts.environment);
@@ -125,6 +138,14 @@ export async function installHost(
     source: opts.source,
     onProgress: opts.onProgress,
     recordVersionOverride: opts.recordVersionOverride,
+  });
+  logger.info("Host install staging completed", {
+    environment: opts.environment,
+    sourceKind: opts.source.kind,
+    version: staging.version,
+    archiveIsTemporary: staging.archiveIsTemporary,
+    sizeBytes: staging.sizeBytes,
+    hasArchiveSha256: staging.archiveSha256 !== null,
   });
 
   // Track whether the staging dir has been renamed into the install
@@ -144,11 +165,19 @@ export async function installHost(
       source: staging.archivePath,
       targetDir: staging.stagingDir,
     });
+    logger.info("Host install archive extracted", {
+      environment: opts.environment,
+      version: staging.version,
+    });
 
     const executablePath = await resolveHostExecutable(
       staging.stagingDir,
       osPlatform(),
     );
+    logger.debug("Host install executable resolved", {
+      environment: opts.environment,
+      version: staging.version,
+    });
 
     // Stop the OS service immediately before the swap, never earlier:
     // verify-before-replace means we must not disturb the running
@@ -160,6 +189,10 @@ export async function installHost(
         percent: null,
         bytes: null,
         totalBytes: null,
+      });
+      logger.info("Host install running lifecycle before swap", {
+        environment: opts.environment,
+        version: staging.version,
       });
       await opts.lifecycle.beforeSwap();
     }
@@ -176,6 +209,11 @@ export async function installHost(
       stagingDir: staging.stagingDir,
     });
     swapped = true;
+    logger.info("Host install atomic swap completed", {
+      environment: opts.environment,
+      version: staging.version,
+      replacedPreviousInstall: previous !== null,
+    });
 
     const finalExecutablePath = executablePath.replace(
       staging.stagingDir,
@@ -195,6 +233,13 @@ export async function installHost(
       executablePath: finalExecutablePath,
     };
     await writeHostInstallRecord(opts.environment, record);
+    logger.info("Host install record written", {
+      environment: opts.environment,
+      version: record.version,
+      sourceKind: record.source.kind,
+      hasArchiveSha256: record.archiveSha256 !== null,
+      sizeBytes: record.sizeBytes,
+    });
 
     // Post-swap start/restart. Per the Tech Plan, failures here do
     // not roll back the install: the new host stays in place and
@@ -209,9 +254,18 @@ export async function installHost(
         bytes: null,
         totalBytes: null,
       });
+      logger.info("Host install running lifecycle after swap", {
+        environment: opts.environment,
+        version: record.version,
+      });
       await opts.lifecycle.afterSwap();
     }
 
+    logger.info("Host install completed", {
+      environment: opts.environment,
+      version: record.version,
+      previousVersion: previous?.version ?? null,
+    });
     return { record, previous };
   } finally {
     // Best-effort sweep of the per-attempt staging archive (if any). The
@@ -219,10 +273,28 @@ export async function installHost(
     // clean up the leftover archive copy and (on a thrown attempt) the
     // staging dir that never made it through `atomicSwap`.
     if (staging.archiveIsTemporary) {
-      await rm(staging.archivePath, { force: true });
+      await rm(staging.archivePath, { force: true }).catch((err) => {
+        logger.warn("Host install failed to remove temporary archive", {
+          environment: opts.environment,
+          errorName: errorFromUnknown(err).name,
+          errorMessage: errorFromUnknown(err).message,
+        });
+      });
     }
     if (!swapped) {
-      await rm(staging.stagingDir, { recursive: true, force: true });
+      await rm(staging.stagingDir, { recursive: true, force: true }).catch(
+        (err) => {
+          logger.warn("Host install failed to remove staging directory", {
+            environment: opts.environment,
+            errorName: errorFromUnknown(err).name,
+            errorMessage: errorFromUnknown(err).message,
+          });
+        },
+      );
+      logger.warn("Host install cleaned up unswapped staging attempt", {
+        environment: opts.environment,
+        version: staging.version,
+      });
     }
   }
 }
@@ -273,10 +345,16 @@ interface StageOptions {
 }
 
 async function stageInstall(opts: StageOptions): Promise<StageResult> {
+  const logger = createCliLogger(opts.environment);
   const stagingRoot = hostStagingRoot(opts.environment);
   const stagingDir = await mkdtemp(join(stagingRoot, "stage-"));
+  logger.debug("Host install staging directory created", {
+    environment: opts.environment,
+    sourceKind: opts.source.kind,
+  });
   if (opts.source.kind === "local-file") {
     return stageLocalFile({
+      environment: opts.environment,
       sourcePath: opts.source.path,
       stagingDir,
       onProgress: opts.onProgress,
@@ -297,6 +375,7 @@ async function stageInstall(opts: StageOptions): Promise<StageResult> {
 }
 
 interface StageLocalOptions {
+  readonly environment: Environment;
   readonly sourcePath: string;
   readonly stagingDir: string;
   readonly onProgress: (info: ProgressInfo) => void;
@@ -306,10 +385,16 @@ interface StageLocalOptions {
 }
 
 async function stageLocalFile(opts: StageLocalOptions): Promise<StageResult> {
+  const logger = createCliLogger(opts.environment);
   let sourceStat: Stats;
   try {
     sourceStat = await stat(opts.sourcePath);
-  } catch {
+  } catch (err) {
+    logger.warn("Host install local source missing", {
+      environment: opts.environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.HOST_SOURCE_MISSING,
       message: `host install: source path does not exist: ${opts.sourcePath}`,
@@ -327,6 +412,10 @@ async function stageLocalFile(opts: StageLocalOptions): Promise<StageResult> {
   if (sourceStat.isDirectory()) {
     archiveSha256 = null;
     sizeBytes = 0;
+    logger.info("Host install staging local directory source", {
+      environment: opts.environment,
+      recordVersionOverride: opts.recordVersion !== null,
+    });
   } else {
     opts.onProgress({
       stage: "verify",
@@ -337,6 +426,11 @@ async function stageLocalFile(opts: StageLocalOptions): Promise<StageResult> {
     });
     archiveSha256 = await hashFileSha256(opts.sourcePath);
     sizeBytes = sourceStat.size;
+    logger.info("Host install hashed local archive source", {
+      environment: opts.environment,
+      sizeBytes,
+      recordVersionOverride: opts.recordVersion !== null,
+    });
   }
   const version = opts.recordVersion ?? deriveLocalVersion(opts.sourcePath);
   return {
@@ -364,8 +458,14 @@ interface StageRegistryOptions {
 async function stageRegistry(
   opts: StageRegistryOptions,
 ): Promise<StageResult> {
+  const logger = createCliLogger(opts.environment);
   const client = await createDefaultRegistryClient(opts.environment);
   const platformKey = currentHostPlatformKey();
+  logger.info("Host install resolving registry asset", {
+    environment: opts.environment,
+    versionRequest: opts.versionRequest,
+    platformKey,
+  });
   opts.onProgress({
     stage: "resolve",
     message: `resolving host ${opts.versionRequest} for ${platformKey}`,
@@ -377,6 +477,12 @@ async function stageRegistry(
     opts.versionRequest,
     platformKey,
   );
+  logger.info("Host install registry asset resolved", {
+    environment: opts.environment,
+    version: entry.version,
+    platformKey,
+    sizeBytes: asset.sizeBytes,
+  });
   opts.onProgress({
     stage: "download",
     message: `downloading host ${entry.version}`,
@@ -397,6 +503,11 @@ async function stageRegistry(
       totalBytes: progress.totalBytes,
     });
   });
+  logger.info("Host install registry archive verified", {
+    environment: opts.environment,
+    version: entry.version,
+    sizeBytes: asset.sizeBytes,
+  });
   return {
     archivePath: verified.archivePath,
     archiveIsTemporary: true,
@@ -416,6 +527,7 @@ interface AtomicSwapOptions {
 }
 
 async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
+  const logger = createCliLogger(opts.environment);
   const target = hostInstallDir(opts.environment);
   const trash = `${target}.old-${Date.now()}`;
   await mkdir(hostHomeDir(opts.environment), { recursive: true });
@@ -430,6 +542,10 @@ async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
     () => true,
     () => false,
   );
+  logger.info("Host install atomic swap starting", {
+    environment: opts.environment,
+    targetExists,
+  });
   if (targetExists) {
     // Move the existing install aside before renaming the new one in,
     // so the rename target is empty. We delete the trash copy after
@@ -440,6 +556,14 @@ async function atomicSwap(opts: AtomicSwapOptions): Promise<void> {
   try {
     await rename(opts.stagingDir, target);
   } catch (cause) {
+    logger.error(
+      "Host install atomic swap failed",
+      {
+        environment: opts.environment,
+        targetExists,
+      },
+      errorFromUnknown(cause),
+    );
     // Restore the previous install if the rename of the new one fails.
     if (targetExists) {
       await rename(trash, target).catch(() => undefined);

--- a/clients/traycer-cli/src/installer/uninstall.ts
+++ b/clients/traycer-cli/src/installer/uninstall.ts
@@ -5,6 +5,7 @@ import {
   type HostInstallRecord,
 } from "../manifest/host-install";
 import type { Environment } from "../runner/environment";
+import { createCliLogger, errorFromUnknown } from "../logger";
 import {
   hostInstallDir,
   hostLogPath,
@@ -33,15 +34,33 @@ export interface UninstallHostResult {
 export async function uninstallHost(
   opts: UninstallHostOptions,
 ): Promise<UninstallHostResult> {
+  const logger = createCliLogger(opts.environment);
+  logger.info("Host uninstall started", {
+    environment: opts.environment,
+    purgeChannelRuntime: opts.purgeChannelRuntime,
+  });
   const previous = await readHostInstallRecord(opts.environment);
+  logger.debug("Host uninstall read install record", {
+    environment: opts.environment,
+    hadInstallRecord: previous !== null,
+  });
   let removedInstallDir = false;
   try {
     await rm(hostInstallDir(opts.environment), { recursive: true, force: true });
     removedInstallDir = true;
-  } catch {
+  } catch (err) {
+    logger.warn("Host uninstall failed to remove install directory", {
+      environment: opts.environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     removedInstallDir = false;
   }
   await deleteHostInstallRecord(opts.environment);
+  logger.info("Host uninstall deleted install record", {
+    environment: opts.environment,
+    removedInstallDir,
+  });
   // Sweep any stale `<installDir>.old-*` siblings the atomic swap left
   // behind after a crash. Best-effort; never blocks the uninstall.
   await sweepOldTrash(hostInstallDir(opts.environment));
@@ -54,8 +73,17 @@ export async function uninstallHost(
     await rm(hostPidMetadataPath(opts.environment), { force: true });
     await rm(hostLogPath(opts.environment), { force: true });
     purgedRuntime = true;
+    logger.warn("Host uninstall purged runtime files", {
+      environment: opts.environment,
+    });
   }
 
+  logger.info("Host uninstall completed", {
+    environment: opts.environment,
+    removedInstallDir,
+    purgedRuntime,
+    hadInstallRecord: previous !== null,
+  });
   return {
     removedRecord: previous,
     removedInstallDir,

--- a/clients/traycer-cli/src/internal/host-auth.ts
+++ b/clients/traycer-cli/src/internal/host-auth.ts
@@ -1,4 +1,6 @@
 import type { BearerStore } from "../../../shared/auth/bearer-revalidator";
+import { config } from "../config";
+import { createCliLogger } from "../logger";
 import {
   deleteCredentials,
   readCredentials,
@@ -32,10 +34,22 @@ export interface HostAuth {
  * host with an empty bearer.
  */
 export async function resolveHostAuth(): Promise<HostAuth | null> {
+  const logger = createCliLogger(config.environment);
   const stored = await readCredentials();
   if (stored === null || stored.token.length === 0) {
+    logger.info("Host auth credentials unavailable", {
+      environment: config.environment,
+      hasStoredCredentials: stored !== null,
+      hasToken: stored !== null && stored.token.length > 0,
+    });
     return null;
   }
+  logger.debug("Host auth credentials resolved", {
+    environment: config.environment,
+    hasStoredCredentials: true,
+    hasToken: true,
+    hasRefreshToken: stored.refreshToken.length > 0,
+  });
   return {
     token: stored.token,
     authnBaseUrl: stored.authnBaseUrl,
@@ -54,14 +68,27 @@ export async function resolveHostAuth(): Promise<HostAuth | null> {
  */
 export const cliBearerStore: BearerStore = {
   read: async () => {
+    const logger = createCliLogger(config.environment);
     const stored = await readCredentials();
+    logger.debug("Bearer store read completed", {
+      environment: config.environment,
+      hasStoredCredentials: stored !== null,
+      hasToken: stored !== null && stored.token.length > 0,
+      hasRefreshToken: stored !== null && stored.refreshToken.length > 0,
+    });
     return stored === null
       ? null
       : { token: stored.token, refreshToken: stored.refreshToken };
   },
   write: async (tokens) => {
+    const logger = createCliLogger(config.environment);
     const stored = await readCredentials();
     if (stored === null) {
+      logger.warn("Bearer store skipped token write because credentials disappeared", {
+        environment: config.environment,
+        receivedToken: tokens.token.length > 0,
+        receivedRefreshToken: tokens.refreshToken.length > 0,
+      });
       return;
     }
     await writeCredentials({
@@ -70,8 +97,17 @@ export const cliBearerStore: BearerStore = {
       refreshToken: tokens.refreshToken,
       savedAt: new Date().toISOString(),
     });
+    logger.info("Bearer store persisted rotated credentials", {
+      environment: config.environment,
+      receivedToken: tokens.token.length > 0,
+      receivedRefreshToken: tokens.refreshToken.length > 0,
+    });
   },
   clear: async () => {
+    const logger = createCliLogger(config.environment);
     await deleteCredentials();
+    logger.warn("Bearer store cleared credentials", {
+      environment: config.environment,
+    });
   },
 };

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -23,6 +23,7 @@ import type { HostTransportEndpoint } from "../../../shared/host-transport/ws-rp
 import { WsRpcClient } from "../../../shared/host-transport/ws-rpc-client";
 import { createWhatwgWebSocketFactory } from "../../../shared/host-transport/whatwg-ws-factory";
 import { config } from "../config";
+import { createCliLogger, errorFromUnknown } from "../logger";
 import {
   isValidLocalHostWebsocketUrl,
   readHostPidMetadata,
@@ -58,8 +59,18 @@ export async function callHostRpc<
   method: Method,
   params: RequestOfMethod<HostRpcRegistry, Method>,
 ): Promise<ResponseOfMethod<HostRpcRegistry, Method>> {
+  const logger = createCliLogger(config.environment);
+  logger.info("Host RPC requested", {
+    environment: config.environment,
+    method,
+    retryPolicy: "default",
+  });
   const auth = await resolveHostAuth();
   if (auth === null) {
+    logger.warn("Host RPC blocked by missing credentials", {
+      environment: config.environment,
+      method,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.AUTH_NO_CREDENTIALS,
       message: "traycer: not signed in - run `traycer login` to authenticate.",
@@ -95,8 +106,18 @@ export async function callHostRpcFastFail<
   method: Method,
   params: RequestOfMethod<HostRpcRegistry, Method>,
 ): Promise<ResponseOfMethod<HostRpcRegistry, Method>> {
+  const logger = createCliLogger(config.environment);
+  logger.info("Host RPC requested", {
+    environment: config.environment,
+    method,
+    retryPolicy: "fast-fail",
+  });
   const auth = await resolveHostAuth();
   if (auth === null) {
+    logger.warn("Host RPC fast-fail call blocked by missing credentials", {
+      environment: config.environment,
+      method,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.AUTH_NO_CREDENTIALS,
       message: "traycer: not signed in - run `traycer login` to authenticate.",
@@ -129,8 +150,20 @@ export async function callHostRpcAtEndpoint<
   params: RequestOfMethod<HostRpcRegistry, Method>,
   endpoint: HostTransportEndpoint,
 ): Promise<ResponseOfMethod<HostRpcRegistry, Method>> {
+  const logger = createCliLogger(config.environment);
+  logger.info("Host RPC requested at explicit endpoint", {
+    environment: config.environment,
+    method,
+    retryPolicy: "default",
+    hostId: endpoint.hostId,
+  });
   const auth = await resolveHostAuth();
   if (auth === null) {
+    logger.warn("Host RPC explicit-endpoint call blocked by missing credentials", {
+      environment: config.environment,
+      method,
+      hostId: endpoint.hostId,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.AUTH_NO_CREDENTIALS,
       message: "traycer: not signed in - run `traycer login` to authenticate.",
@@ -156,6 +189,7 @@ async function requestAtEndpoint<
   auth: HostAuth,
   retryPolicy: TransportRetryPolicy,
 ): Promise<ResponseOfMethod<HostRpcRegistry, Method>> {
+  const logger = createCliLogger(config.environment);
   const lease = new MutableBearerLease(auth.token, auth.userId);
   const revalidator = createBearerRevalidator({
     authnBaseUrl: auth.authnBaseUrl,
@@ -181,7 +215,28 @@ async function requestAtEndpoint<
     retryPolicy,
   );
 
-  return messenger.request(method, params);
+  try {
+    const response = await messenger.request(method, params);
+    logger.info("Host RPC completed", {
+      environment: config.environment,
+      method,
+      retryPolicy: retryPolicyLabel(retryPolicy),
+      hostId: endpoint.hostId,
+    });
+    return response;
+  } catch (err) {
+    logger.error(
+      "Host RPC failed",
+      {
+        environment: config.environment,
+        method,
+        retryPolicy: retryPolicyLabel(retryPolicy),
+        hostId: endpoint.hostId,
+      },
+      errorFromUnknown(err),
+    );
+    throw err;
+  }
 }
 
 /**
@@ -189,17 +244,17 @@ async function requestAtEndpoint<
  * pid file advertises the unary endpoint URL verbatim.
  */
 async function resolveEndpoint(): Promise<HostTransportEndpoint> {
+  const logger = createCliLogger(config.environment);
   const metadata = await readHostPidMetadata(config.environment);
   // Liveness check, not just presence: a stopped/crashed host can leave a
   // stale pid.json behind (the same reason `host status` checks
   // `isProcessAlive`). Catching a dead pid here is what lets `mapHostRpcError`
   // treat a transport `RPC_ERROR` as a genuine host error rather than
   // overloading it to mean "not running".
-  if (
-    metadata === null ||
-    !isProcessAlive(metadata.pid) ||
-    !isValidLocalHostWebsocketUrl(metadata.websocketUrl)
-  ) {
+  if (metadata === null) {
+    logger.warn("Host RPC endpoint resolution failed; metadata missing", {
+      environment: config.environment,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
       message:
@@ -208,6 +263,38 @@ async function resolveEndpoint(): Promise<HostTransportEndpoint> {
       exitCode: 1,
     });
   }
+  if (!isProcessAlive(metadata.pid)) {
+    logger.warn("Host RPC endpoint resolution failed; process is not alive", {
+      environment: config.environment,
+      hostId: metadata.hostId,
+      pid: metadata.pid,
+    });
+    throw cliError({
+      code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
+      message:
+        "traycer: host not running - pid metadata is absent, malformed, advertises an invalid local WebSocket endpoint, or names a process that is no longer alive.",
+      details: null,
+      exitCode: 1,
+    });
+  }
+  if (!isValidLocalHostWebsocketUrl(metadata.websocketUrl)) {
+    logger.warn("Host RPC endpoint resolution failed; websocket URL invalid", {
+      environment: config.environment,
+      hostId: metadata.hostId,
+    });
+    throw cliError({
+      code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
+      message:
+        "traycer: host not running - pid metadata is absent, malformed, advertises an invalid local WebSocket endpoint, or names a process that is no longer alive.",
+      details: null,
+      exitCode: 1,
+    });
+  }
+  logger.debug("Host RPC endpoint resolved", {
+    environment: config.environment,
+    hostId: metadata.hostId,
+    pid: metadata.pid,
+  });
   return { hostId: metadata.hostId, websocketUrl: metadata.websocketUrl };
 }
 
@@ -238,6 +325,10 @@ export async function toAgentCliError<T>(call: Promise<T>): Promise<T> {
 export function parseUserInput<T>(schema: ZodType<T>, value: unknown): T {
   const parsed = schema.safeParse(value);
   if (parsed.success) return parsed.data;
+  createCliLogger(config.environment).warn("CLI user input validation failed", {
+    environment: config.environment,
+    issueCount: parsed.error.issues.length,
+  });
   const detail = parsed.error.issues
     .map((issue) =>
       issue.path.length > 0
@@ -264,6 +355,10 @@ export function parseUserInput<T>(schema: ZodType<T>, value: unknown): T {
 export function parseHostResponse<T>(schema: ZodType<T>, value: unknown): T {
   const parsed = schema.safeParse(value);
   if (parsed.success) return parsed.data;
+  createCliLogger(config.environment).warn("Host RPC response validation failed", {
+    environment: config.environment,
+    issueCount: parsed.error.issues.length,
+  });
   throw cliError({
     code: CLI_ERROR_CODES.HOST_INCOMPATIBLE,
     message:
@@ -275,6 +370,10 @@ export function parseHostResponse<T>(schema: ZodType<T>, value: unknown): T {
 
 function hostRpcToCliError(err: unknown): unknown {
   if (!(err instanceof HostRpcError)) return err;
+  createCliLogger(config.environment).warn("Mapping host RPC wire error to CLI error", {
+    environment: config.environment,
+    hostRpcCode: err.code,
+  });
   return mapHostRpcError(err);
 }
 
@@ -350,4 +449,8 @@ function isAccessDenied(err: HostRpcError): boolean {
     err.code === "RPC_ERROR" &&
     /does not have (?:access|[\w ]*permission)/i.test(err.message)
   );
+}
+
+function retryPolicyLabel(policy: TransportRetryPolicy): "default" | "fast-fail" {
+  return policy === NO_RETRY_TRANSPORT_POLICY ? "fast-fail" : "default";
 }

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -225,16 +225,14 @@ async function requestAtEndpoint<
     });
     return response;
   } catch (err) {
-    logger.error(
-      "Host RPC failed",
-      {
-        environment: config.environment,
-        method,
-        retryPolicy: retryPolicyLabel(retryPolicy),
-        hostId: endpoint.hostId,
-      },
-      errorFromUnknown(err),
-    );
+    const error = errorFromUnknown(err);
+    logger.debug("Host RPC failed; propagating to command boundary", {
+      environment: config.environment,
+      method,
+      retryPolicy: retryPolicyLabel(retryPolicy),
+      hostId: endpoint.hostId,
+      errorName: error.name,
+    });
     throw err;
   }
 }

--- a/clients/traycer-cli/src/logger.ts
+++ b/clients/traycer-cli/src/logger.ts
@@ -1,6 +1,7 @@
 import { appendFileSync, chmodSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { Environment } from "./runner/environment";
+import { CliError } from "./runner/errors";
 import { cliLogPath } from "./store/paths";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
@@ -90,16 +91,15 @@ export function errorFromUnknown(value: unknown): Error {
 
 function serializeError(error: Error): {
   readonly name: string;
-  readonly message: string;
-  readonly stack: string | null;
+  readonly code: string | null;
+  readonly hasMessage: boolean;
+  readonly hasStack: boolean;
 } {
   return {
     name: error.name,
-    message: sanitizeText(error.message),
-    stack:
-      typeof error.stack === "string"
-        ? sanitizeText(error.stack)
-        : null,
+    code: error instanceof CliError ? error.code : null,
+    hasMessage: error.message.length > 0,
+    hasStack: typeof error.stack === "string" && error.stack.length > 0,
   };
 }
 
@@ -116,14 +116,20 @@ function sanitizeLogValueInner(
   if (
     key !== null &&
     SENSITIVE_FIELD_PATTERN.test(key) &&
-    (typeof value === "string" || Array.isArray(value) || typeof value === "object")
+    (typeof value === "string" ||
+      Array.isArray(value) ||
+      typeof value === "object")
   ) {
     return "[redacted]";
   }
   if (typeof value === "string") {
     return sanitizeText(value);
   }
-  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
     return value;
   }
   if (depth >= MAX_LOG_DEPTH) {

--- a/clients/traycer-cli/src/logger.ts
+++ b/clients/traycer-cli/src/logger.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, chmodSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { Environment } from "./runner/environment";
 import { cliLogPath } from "./store/paths";
@@ -23,8 +23,9 @@ export interface ILogger {
 }
 
 const MAX_LOG_STRING_LENGTH = 1_000;
+const MAX_LOG_DEPTH = 4;
 const SENSITIVE_FIELD_PATTERN =
-  /token|secret|password|authorization|bearer|credential|refresh|cookie|verifier/i;
+  /token|secret|password|authorization|bearer|credential|refresh|cookie|verifier|api[_-]?key/i;
 const SENSITIVE_TEXT_PATTERNS: ReadonlyArray<{
   readonly pattern: RegExp;
   readonly replacement: string;
@@ -35,7 +36,7 @@ const SENSITIVE_TEXT_PATTERNS: ReadonlyArray<{
   },
   {
     pattern:
-      /((?:access[_-]?token|accessToken|refresh[_-]?token|refreshToken|token|authorization|password|secret|cookie|code[_-]?verifier|codeVerifier)\s*[:=]\s*)("[^"]*"|'[^']*'|[^&\s,}]+)/gi,
+      /((?:access[_-]?token|accessToken|refresh[_-]?token|refreshToken|token|authorization|password|secret|cookie|code[_-]?verifier|codeVerifier|api[_-]?key|apiKey)\s*[:=]\s*)("[^"]*"|'[^']*'|[^&\s,}]+)/gi,
     replacement: "$1[redacted]",
   },
 ];
@@ -68,6 +69,7 @@ export function createCliLogger(environment: Environment): ILogger {
         })}\n`,
         { mode: 0o600 },
       );
+      chmodSync(path, 0o600);
     } catch {
       // Logging must never change CLI behavior.
     }
@@ -102,6 +104,15 @@ function serializeError(error: Error): {
 }
 
 function sanitizeLogValue(value: LogValue, key: string | null): LogValue {
+  return sanitizeLogValueInner(value, key, 0, new WeakSet<object>());
+}
+
+function sanitizeLogValueInner(
+  value: LogValue,
+  key: string | null,
+  depth: number,
+  seen: WeakSet<object>,
+): LogValue {
   if (
     key !== null &&
     SENSITIVE_FIELD_PATTERN.test(key) &&
@@ -115,13 +126,22 @@ function sanitizeLogValue(value: LogValue, key: string | null): LogValue {
   if (typeof value === "number" || typeof value === "boolean" || value === null) {
     return value;
   }
+  if (depth >= MAX_LOG_DEPTH) {
+    return "[max-depth]";
+  }
+  if (seen.has(value)) {
+    return "[circular]";
+  }
+  seen.add(value);
   if (Array.isArray(value)) {
-    return value.map((entry) => sanitizeLogValue(entry, null));
+    return value.map((entry) =>
+      sanitizeLogValueInner(entry, null, depth + 1, seen),
+    );
   }
   return Object.fromEntries(
     Object.entries(value).map(([entryKey, entryValue]) => [
       entryKey,
-      sanitizeLogValue(entryValue, entryKey),
+      sanitizeLogValueInner(entryValue, entryKey, depth + 1, seen),
     ]),
   );
 }

--- a/clients/traycer-cli/src/logger.ts
+++ b/clients/traycer-cli/src/logger.ts
@@ -1,0 +1,141 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import type { Environment } from "./runner/environment";
+import { cliLogPath } from "./store/paths";
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly LogValue[]
+  | { readonly [key: string]: LogValue };
+
+export type LogFields = { readonly [key: string]: LogValue };
+
+export interface ILogger {
+  debug(message: string, fields: LogFields): void;
+  info(message: string, fields: LogFields): void;
+  warn(message: string, fields: LogFields): void;
+  error(message: string, fields: LogFields, error: Error | null): void;
+}
+
+const MAX_LOG_STRING_LENGTH = 1_000;
+const SENSITIVE_FIELD_PATTERN =
+  /token|secret|password|authorization|bearer|credential|refresh|cookie|verifier/i;
+const SENSITIVE_TEXT_PATTERNS: ReadonlyArray<{
+  readonly pattern: RegExp;
+  readonly replacement: string;
+}> = [
+  {
+    pattern: /Bearer\s+[A-Za-z0-9._~+/-]+=*/gi,
+    replacement: "Bearer [redacted]",
+  },
+  {
+    pattern:
+      /((?:access[_-]?token|accessToken|refresh[_-]?token|refreshToken|token|authorization|password|secret|cookie|code[_-]?verifier|codeVerifier)\s*[:=]\s*)("[^"]*"|'[^']*'|[^&\s,}]+)/gi,
+    replacement: "$1[redacted]",
+  },
+];
+
+export const noopLogger: ILogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
+
+export function createCliLogger(environment: Environment): ILogger {
+  const path = cliLogPath(environment);
+  const write = (
+    level: LogLevel,
+    message: string,
+    fields: LogFields,
+    error: Error | null,
+  ): void => {
+    try {
+      mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+      appendFileSync(
+        path,
+        `${JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level,
+          message: sanitizeText(message),
+          fields: sanitizeLogValue(fields, null),
+          error: error === null ? null : serializeError(error),
+        })}\n`,
+        { mode: 0o600 },
+      );
+    } catch {
+      // Logging must never change CLI behavior.
+    }
+  };
+
+  return {
+    debug: (message, fields) => write("debug", message, fields, null),
+    info: (message, fields) => write("info", message, fields, null),
+    warn: (message, fields) => write("warn", message, fields, null),
+    error: (message, fields, error) => write("error", message, fields, error),
+  };
+}
+
+export function errorFromUnknown(value: unknown): Error {
+  if (value instanceof Error) return value;
+  return new Error(String(value));
+}
+
+function serializeError(error: Error): {
+  readonly name: string;
+  readonly message: string;
+  readonly stack: string | null;
+} {
+  return {
+    name: error.name,
+    message: sanitizeText(error.message),
+    stack:
+      typeof error.stack === "string"
+        ? sanitizeText(error.stack)
+        : null,
+  };
+}
+
+function sanitizeLogValue(value: LogValue, key: string | null): LogValue {
+  if (
+    key !== null &&
+    SENSITIVE_FIELD_PATTERN.test(key) &&
+    (typeof value === "string" || Array.isArray(value) || typeof value === "object")
+  ) {
+    return "[redacted]";
+  }
+  if (typeof value === "string") {
+    return sanitizeText(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean" || value === null) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeLogValue(entry, null));
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([entryKey, entryValue]) => [
+      entryKey,
+      sanitizeLogValue(entryValue, entryKey),
+    ]),
+  );
+}
+
+function truncateString(value: string): string {
+  if (value.length <= MAX_LOG_STRING_LENGTH) return value;
+  return `${value.slice(0, MAX_LOG_STRING_LENGTH)}...<truncated>`;
+}
+
+function sanitizeText(value: string): string {
+  return truncateString(
+    SENSITIVE_TEXT_PATTERNS.reduce(
+      (current, entry) => current.replace(entry.pattern, entry.replacement),
+      value,
+    ),
+  );
+}

--- a/clients/traycer-cli/src/manifest/cli-manifest.ts
+++ b/clients/traycer-cli/src/manifest/cli-manifest.ts
@@ -1,5 +1,5 @@
 import { readFile, rename, writeFile } from "node:fs/promises";
-import { createCliLogger, errorFromUnknown } from "../logger";
+import { createCliLogger } from "../logger";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import type { Environment } from "../runner/environment";
 import { cliManifestPath, ensureCliHomeDir } from "../store/paths";
@@ -295,11 +295,6 @@ export async function readCliManifest(
     // Only a missing file means "no manifest"; a real fault (EACCES/EIO)
     // must surface rather than be misread as an absent install.
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-      logger.warn("CLI manifest read failed", {
-        environment,
-        errorName: errorFromUnknown(err).name,
-        errorMessage: errorFromUnknown(err).message,
-      });
       throw err;
     }
     const distributionSource = readDistributionInstallSourceFromEnv();
@@ -339,7 +334,7 @@ export async function readCliManifest(
     logger.info("CLI manifest synthesized from system source marker", {
       environment,
       source: systemMarker.source,
-      version: systemMarker.version,
+      hasVersion: systemMarker.version.length > 0,
     });
     return {
       version: systemMarker.version,
@@ -352,14 +347,7 @@ export async function readCliManifest(
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch (err) {
-    logger.error(
-      "CLI manifest JSON parse failed",
-      {
-        environment,
-      },
-      errorFromUnknown(err),
-    );
+  } catch {
     throw cliError({
       code: CLI_ERROR_CODES.CLI_MANIFEST_INVALID,
       message: `CLI manifest ${path} is not valid JSON; refusing to overwrite`,
@@ -417,7 +405,7 @@ export async function readCliManifest(
   };
   logger.info("CLI manifest read completed", {
     environment,
-    version: manifest.version,
+    hasVersion: manifest.version.length > 0,
     source: manifest.source,
     hasPendingUpgrade: manifest.pendingUpgrade !== null,
   });
@@ -433,7 +421,7 @@ export async function writeCliManifest(
   const logger = createCliLogger(environment);
   logger.info("CLI manifest write started", {
     environment,
-    version: manifest.version,
+    hasVersion: manifest.version.length > 0,
     source: manifest.source,
     hasPendingUpgrade: manifest.pendingUpgrade !== null,
   });
@@ -447,7 +435,7 @@ export async function writeCliManifest(
   await rename(tmp, target);
   logger.info("CLI manifest write completed", {
     environment,
-    version: manifest.version,
+    hasVersion: manifest.version.length > 0,
     source: manifest.source,
     hasPendingUpgrade: manifest.pendingUpgrade !== null,
   });
@@ -499,7 +487,7 @@ export async function updateCliManifest(
   await writeCliManifest(environment, next);
   logger.info("CLI manifest update completed", {
     environment,
-    version: next.version,
+    hasVersion: next.version.length > 0,
     source: next.source,
     hasPendingUpgrade: next.pendingUpgrade !== null,
   });
@@ -519,7 +507,8 @@ export async function clearPendingUpgrade(
   createCliLogger(environment).info("CLI manifest clearing pending upgrade", {
     environment,
     promoted: promotedInstall !== null,
-    promotedVersion: promotedInstall?.version ?? null,
+    hasPromotedVersion:
+      promotedInstall !== null && promotedInstall.version.length > 0,
   });
   if (promotedInstall === null) {
     return updateCliManifest(environment, { pendingUpgrade: null });

--- a/clients/traycer-cli/src/manifest/cli-manifest.ts
+++ b/clients/traycer-cli/src/manifest/cli-manifest.ts
@@ -1,4 +1,5 @@
 import { readFile, rename, writeFile } from "node:fs/promises";
+import { createCliLogger, errorFromUnknown } from "../logger";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import type { Environment } from "../runner/environment";
 import { cliManifestPath, ensureCliHomeDir } from "../store/paths";
@@ -282,6 +283,10 @@ async function readSystemSourceMarker(): Promise<SystemSourceMarker | null> {
 export async function readCliManifest(
   environment: Environment,
 ): Promise<CliInstallManifest | null> {
+  const logger = createCliLogger(environment);
+  logger.debug("CLI manifest read started", {
+    environment,
+  });
   const path = cliManifestPath(environment);
   let raw: string;
   try {
@@ -289,9 +294,23 @@ export async function readCliManifest(
   } catch (err) {
     // Only a missing file means "no manifest"; a real fault (EACCES/EIO)
     // must surface rather than be misread as an absent install.
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      logger.warn("CLI manifest read failed", {
+        environment,
+        errorName: errorFromUnknown(err).name,
+        errorMessage: errorFromUnknown(err).message,
+      });
+      throw err;
+    }
     const distributionSource = readDistributionInstallSourceFromEnv();
     if (distributionSource !== null) {
+      logger.info("CLI manifest synthesized from distribution environment", {
+        environment,
+        source: distributionSource,
+        hasVersionEnv:
+          typeof process.env.TRAYCER_CLI_VERSION === "string" &&
+          process.env.TRAYCER_CLI_VERSION.length > 0,
+      });
       return {
         version:
           typeof process.env.TRAYCER_CLI_VERSION === "string" &&
@@ -304,9 +323,24 @@ export async function readCliManifest(
         pendingUpgrade: null,
       };
     }
-    if (environment !== "production") return null;
+    if (environment !== "production") {
+      logger.debug("CLI manifest missing for non-production environment", {
+        environment,
+      });
+      return null;
+    }
     const systemMarker = await readSystemSourceMarker();
-    if (systemMarker === null) return null;
+    if (systemMarker === null) {
+      logger.debug("CLI manifest missing and no system source marker found", {
+        environment,
+      });
+      return null;
+    }
+    logger.info("CLI manifest synthesized from system source marker", {
+      environment,
+      source: systemMarker.source,
+      version: systemMarker.version,
+    });
     return {
       version: systemMarker.version,
       installedAt: new Date(0).toISOString(),
@@ -318,7 +352,14 @@ export async function readCliManifest(
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    logger.error(
+      "CLI manifest JSON parse failed",
+      {
+        environment,
+      },
+      errorFromUnknown(err),
+    );
     throw cliError({
       code: CLI_ERROR_CODES.CLI_MANIFEST_INVALID,
       message: `CLI manifest ${path} is not valid JSON; refusing to overwrite`,
@@ -367,13 +408,20 @@ export async function readCliManifest(
       exitCode: 1,
     });
   }
-  return {
+  const manifest = {
     version: obj.version,
     installedAt: obj.installedAt,
     binaryPath: obj.binaryPath,
     source: obj.source,
     pendingUpgrade: readPendingUpgrade(obj.pendingUpgrade, path),
   };
+  logger.info("CLI manifest read completed", {
+    environment,
+    version: manifest.version,
+    source: manifest.source,
+    hasPendingUpgrade: manifest.pendingUpgrade !== null,
+  });
+  return manifest;
 }
 
 // Write a complete manifest atomically. Callers must supply every
@@ -382,6 +430,13 @@ export async function writeCliManifest(
   environment: Environment,
   manifest: CliInstallManifest,
 ): Promise<void> {
+  const logger = createCliLogger(environment);
+  logger.info("CLI manifest write started", {
+    environment,
+    version: manifest.version,
+    source: manifest.source,
+    hasPendingUpgrade: manifest.pendingUpgrade !== null,
+  });
   await ensureCliHomeDir(environment);
   const target = cliManifestPath(environment);
   const tmp = `${target}.tmp`;
@@ -390,6 +445,12 @@ export async function writeCliManifest(
     mode: 0o600,
   });
   await rename(tmp, target);
+  logger.info("CLI manifest write completed", {
+    environment,
+    version: manifest.version,
+    source: manifest.source,
+    hasPendingUpgrade: manifest.pendingUpgrade !== null,
+  });
 }
 
 // Read-modify-write convenience. Requires an existing manifest -
@@ -403,8 +464,19 @@ export async function updateCliManifest(
   environment: Environment,
   patch: Partial<Omit<CliInstallManifest, never>>,
 ): Promise<CliInstallManifest> {
+  const logger = createCliLogger(environment);
+  logger.info("CLI manifest update started", {
+    environment,
+    patchesVersion: patch.version !== undefined,
+    patchesBinaryPath: patch.binaryPath !== undefined,
+    patchesSource: patch.source !== undefined,
+    patchesPendingUpgrade: patch.pendingUpgrade !== undefined,
+  });
   const current = await readCliManifest(environment);
   if (current === null) {
+    logger.warn("CLI manifest update refused missing manifest", {
+      environment,
+    });
     throw cliError({
       code: CLI_ERROR_CODES.CLI_MANIFEST_INVALID,
       message: `CLI manifest for environment=${environment} does not exist; cannot patch a missing install`,
@@ -425,6 +497,12 @@ export async function updateCliManifest(
         : patch.pendingUpgrade,
   };
   await writeCliManifest(environment, next);
+  logger.info("CLI manifest update completed", {
+    environment,
+    version: next.version,
+    source: next.source,
+    hasPendingUpgrade: next.pendingUpgrade !== null,
+  });
   return next;
 }
 
@@ -438,6 +516,11 @@ export async function clearPendingUpgrade(
     readonly installedAt: string;
   } | null,
 ): Promise<CliInstallManifest> {
+  createCliLogger(environment).info("CLI manifest clearing pending upgrade", {
+    environment,
+    promoted: promotedInstall !== null,
+    promotedVersion: promotedInstall?.version ?? null,
+  });
   if (promotedInstall === null) {
     return updateCliManifest(environment, { pendingUpgrade: null });
   }

--- a/clients/traycer-cli/src/manifest/host-install.ts
+++ b/clients/traycer-cli/src/manifest/host-install.ts
@@ -102,10 +102,12 @@ export async function readHostInstallRecord(
   try {
     raw = await readFile(path, "utf8");
   } catch (err) {
+    if (readErrorCode(err) !== "ENOENT") {
+      throw err;
+    }
     logger.debug("Host install record read returned absent", {
       environment,
       errorName: errorFromUnknown(err).name,
-      errorMessage: errorFromUnknown(err).message,
     });
     return null;
   }
@@ -235,6 +237,12 @@ export async function readHostInstallRecord(
     hasArchiveSha256: record.archiveSha256 !== null,
   });
   return record;
+}
+
+function readErrorCode(error: unknown): string | null {
+  if (error === null || typeof error !== "object") return null;
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : null;
 }
 
 export async function writeHostInstallRecord(

--- a/clients/traycer-cli/src/manifest/host-install.ts
+++ b/clients/traycer-cli/src/manifest/host-install.ts
@@ -1,5 +1,6 @@
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import type { Environment } from "../runner/environment";
+import { createCliLogger, errorFromUnknown } from "../logger";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import {
   hostInstallRecordPath,
@@ -92,17 +93,33 @@ function parseSource(value: unknown, path: string): HostInstallSource {
 export async function readHostInstallRecord(
   environment: Environment,
 ): Promise<HostInstallRecord | null> {
+  const logger = createCliLogger(environment);
+  logger.debug("Host install record read started", {
+    environment,
+  });
   const path = hostInstallRecordPath(environment);
   let raw: string;
   try {
     raw = await readFile(path, "utf8");
-  } catch {
+  } catch (err) {
+    logger.debug("Host install record read returned absent", {
+      environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     return null;
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    logger.error(
+      "Host install record JSON parse failed",
+      {
+        environment,
+      },
+      errorFromUnknown(err),
+    );
     throw cliError({
       code: CLI_ERROR_CODES.HOST_INSTALL_RECORD_INVALID,
       message: `host install record ${path} is not valid JSON; refusing to overwrite`,
@@ -197,7 +214,7 @@ export async function readHostInstallRecord(
       exitCode: 1,
     });
   }
-  return {
+  const record = {
     version: obj.version,
     platform: obj.platform,
     arch: obj.arch,
@@ -209,12 +226,29 @@ export async function readHostInstallRecord(
     sizeBytes: obj.sizeBytes,
     executablePath: obj.executablePath,
   };
+  logger.info("Host install record read completed", {
+    environment,
+    version: record.version,
+    platform: record.platform,
+    arch: record.arch,
+    sourceKind: record.source.kind,
+    hasArchiveSha256: record.archiveSha256 !== null,
+  });
+  return record;
 }
 
 export async function writeHostInstallRecord(
   environment: Environment,
   record: HostInstallRecord,
 ): Promise<void> {
+  const logger = createCliLogger(environment);
+  logger.info("Host install record write started", {
+    environment,
+    version: record.version,
+    platform: record.platform,
+    arch: record.arch,
+    sourceKind: record.source.kind,
+  });
   await ensureHostInstallDir(environment);
   const target = hostInstallRecordPath(environment);
   const tmp = `${target}.tmp`;
@@ -223,15 +257,30 @@ export async function writeHostInstallRecord(
     mode: 0o600,
   });
   await rename(tmp, target);
+  logger.info("Host install record write completed", {
+    environment,
+    version: record.version,
+  });
 }
 
 export async function deleteHostInstallRecord(
   environment: Environment,
 ): Promise<boolean> {
+  const logger = createCliLogger(environment);
   try {
     await unlink(hostInstallRecordPath(environment));
+    logger.info("Host install record deleted", {
+      environment,
+      deleted: true,
+    });
     return true;
-  } catch {
+  } catch (err) {
+    logger.debug("Host install record delete skipped or failed", {
+      environment,
+      deleted: false,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     return false;
   }
 }

--- a/clients/traycer-cli/src/registry/client.ts
+++ b/clients/traycer-cli/src/registry/client.ts
@@ -104,7 +104,10 @@ export async function createRegistryClient(
         "host registry: no trusted signing keys are configured for this build, " +
         "so host versions cannot be verified. This is expected for local/dev " +
         "builds; install from a local archive with 'traycer host install --from <path>'.",
-      details: { sources: trustedKeySet.sources, environment: opts.environment },
+      details: {
+        sources: trustedKeySet.sources,
+        environment: opts.environment,
+      },
       exitCode: 1,
     });
   }
@@ -151,7 +154,7 @@ export async function createRegistryClient(
       cachedManifest = manifest;
       logger.info("Registry manifest parsed", {
         environment: opts.environment,
-        latest: manifest.latest,
+        hasLatest: manifest.latest.length > 0,
         versionCount: manifest.versions.length,
       });
       return manifest;
@@ -164,21 +167,24 @@ export async function createRegistryClient(
       readonly entry: HostVersionEntry;
       readonly asset: HostPlatformAsset;
     }> {
-      const manifest = cachedManifest ?? (await (this as RegistryClient).fetchManifest());
-      const resolvedVersion =
-        versionRequest === "latest" ? manifest.latest : versionRequest;
+      const manifest =
+        cachedManifest ?? (await (this as RegistryClient).fetchManifest());
+      const requestedLatest = versionRequest === "latest";
+      const resolvedVersion = requestedLatest
+        ? manifest.latest
+        : versionRequest;
       logger.info("Registry asset resolution started", {
         environment: opts.environment,
-        versionRequest,
-        resolvedVersion,
+        requestedLatest,
         platformKey,
       });
-      const entry = manifest.versions.find((v) => v.version === resolvedVersion);
+      const entry = manifest.versions.find(
+        (v) => v.version === resolvedVersion,
+      );
       if (entry === undefined) {
         logger.warn("Registry version not found", {
           environment: opts.environment,
-          versionRequest,
-          resolvedVersion,
+          requestedLatest,
           availableVersionCount: manifest.versions.length,
         });
         throw cliError({
@@ -195,7 +201,7 @@ export async function createRegistryClient(
       if (entry.yanked) {
         logger.warn("Registry refused yanked version", {
           environment: opts.environment,
-          resolvedVersion,
+          requestedLatest,
           hasDeprecationReason: entry.deprecationReason !== null,
         });
         // Yanked versions are refused for install. The Tech Plan reserves
@@ -213,10 +219,11 @@ export async function createRegistryClient(
       }
       const asset = entry.platforms[platformKey];
       if (asset === undefined || !asset.available) {
-        const reason = asset?.unavailableReason ?? "no asset published for this platform";
+        const reason =
+          asset?.unavailableReason ?? "no asset published for this platform";
         logger.warn("Registry asset unavailable for platform", {
           environment: opts.environment,
-          resolvedVersion,
+          requestedLatest,
           platformKey,
           hasUnavailableReason:
             asset !== undefined && asset.unavailableReason !== null,
@@ -234,9 +241,8 @@ export async function createRegistryClient(
       }
       logger.info("Registry asset resolved", {
         environment: opts.environment,
-        resolvedVersion,
+        requestedLatest,
         platformKey,
-        sizeBytes: asset.sizeBytes,
       });
       return { entry, asset };
     },
@@ -244,7 +250,10 @@ export async function createRegistryClient(
     async downloadAndVerify(
       entry: HostVersionEntry,
       asset: HostPlatformAsset,
-      onProgress: (progress: { downloadedBytes: number; totalBytes: number }) => void,
+      onProgress: (progress: {
+        downloadedBytes: number;
+        totalBytes: number;
+      }) => void,
     ): Promise<{
       readonly archivePath: string;
       readonly archiveSha256: string;
@@ -254,21 +263,21 @@ export async function createRegistryClient(
       if (!asset.available) {
         logger.warn("Registry download refused unavailable asset", {
           environment: opts.environment,
-          version: entry.version,
           hasUnavailableReason: asset.unavailableReason !== null,
         });
         throw cliError({
           code: CLI_ERROR_CODES.REGISTRY_VERSION_NOT_FOUND,
           message: `host registry: asset for version '${entry.version}' is marked unavailable`,
-          details: { version: entry.version, unavailableReason: asset.unavailableReason },
+          details: {
+            version: entry.version,
+            unavailableReason: asset.unavailableReason,
+          },
           exitCode: 1,
         });
       }
       const tmpDir = await mkdtemp(join(tmpdir(), "traycer-host-dl-"));
       logger.info("Registry download started", {
         environment: opts.environment,
-        version: entry.version,
-        sizeBytes: asset.sizeBytes,
       });
       // Track whether we succeeded so the `finally` block can clean up
       // the tmpdir on failure. On success the caller (installer) is
@@ -298,7 +307,6 @@ export async function createRegistryClient(
             "Registry signature key mismatch",
             {
               environment: opts.environment,
-              version: entry.version,
             },
             null,
           );
@@ -315,8 +323,7 @@ export async function createRegistryClient(
         succeeded = true;
         logger.info("Registry download and verification completed", {
           environment: opts.environment,
-          version: entry.version,
-          downloadedBytes: download.downloadedBytes,
+          downloadedExpectedBytes: download.downloadedBytes === asset.sizeBytes,
         });
         return {
           archivePath,
@@ -333,16 +340,16 @@ export async function createRegistryClient(
         // empty dir behind, which the OS cleans up on reboot anyway.
         if (!succeeded) {
           await rm(tmpDir, { recursive: true, force: true }).catch((err) => {
-            logger.warn("Registry failed to clean temporary download directory", {
-              environment: opts.environment,
-              version: entry.version,
-              errorName: errorFromUnknown(err).name,
-              errorMessage: errorFromUnknown(err).message,
-            });
+            logger.warn(
+              "Registry failed to clean temporary download directory",
+              {
+                environment: opts.environment,
+                errorName: errorFromUnknown(err).name,
+              },
+            );
           });
           logger.warn("Registry cleaned failed download attempt", {
             environment: opts.environment,
-            version: entry.version,
           });
         }
       }

--- a/clients/traycer-cli/src/registry/client.ts
+++ b/clients/traycer-cli/src/registry/client.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Environment } from "../runner/environment";
+import { createCliLogger, errorFromUnknown } from "../logger";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import { downloadToFile, fetchText } from "./fetch-resource";
 import { parseHostVersionsManifest } from "./manifest-schema";
@@ -69,9 +70,18 @@ const DEFAULT_TRANSPORT: RegistryTransport = {
 export async function createRegistryClient(
   opts: CreateRegistryClientOptions,
 ): Promise<RegistryClient> {
+  const logger = createCliLogger(opts.environment);
   const transport = opts.transport ?? DEFAULT_TRANSPORT;
   const manifestUrlInfo = resolveManifestUrl();
   const trustedKeySet = await loadTrustedKeys();
+  logger.info("Registry client created", {
+    environment: opts.environment,
+    customTransport: opts.transport !== null,
+    requireTrustedKeys: opts.requireTrustedKeys,
+    trustedKeyCount: trustedKeySet.keys.length,
+    trustedKeySourceCount: trustedKeySet.sources.length,
+    manifestUrl: manifestUrlInfo.url,
+  });
 
   // Fail loudly at construction time, not at the first verify call:
   // if no trusted keys are configured for a real environment, every
@@ -80,6 +90,14 @@ export async function createRegistryClient(
   // `requireTrustedKeys: false` (only legitimate in unit tests that
   // substitute the verify chain via a fake transport).
   if (trustedKeySet.keys.length === 0 && opts.requireTrustedKeys) {
+    logger.error(
+      "Registry client missing trusted signing keys",
+      {
+        environment: opts.environment,
+        sourceCount: trustedKeySet.sources.length,
+      },
+      null,
+    );
     throw cliError({
       code: CLI_ERROR_CODES.HOST_VERIFY_FAILED,
       message:
@@ -95,12 +113,30 @@ export async function createRegistryClient(
 
   return {
     async fetchManifest(): Promise<HostVersionsManifest> {
-      if (cachedManifest !== null) return cachedManifest;
+      if (cachedManifest !== null) {
+        logger.debug("Registry manifest cache hit", {
+          environment: opts.environment,
+          versionCount: cachedManifest.versions.length,
+        });
+        return cachedManifest;
+      }
+      logger.info("Registry manifest fetch started", {
+        environment: opts.environment,
+        manifestUrl: manifestUrlInfo.url,
+      });
       const body = await transport.fetchText(manifestUrlInfo.url);
       let parsedJson: unknown;
       try {
         parsedJson = JSON.parse(body);
       } catch (err) {
+        logger.error(
+          "Registry manifest JSON parse failed",
+          {
+            environment: opts.environment,
+            manifestUrl: manifestUrlInfo.url,
+          },
+          errorFromUnknown(err),
+        );
         throw cliError({
           code: CLI_ERROR_CODES.REGISTRY_UNAVAILABLE,
           message: `host registry: manifest at ${manifestUrlInfo.url} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
@@ -113,6 +149,11 @@ export async function createRegistryClient(
         manifestUrlInfo.url,
       );
       cachedManifest = manifest;
+      logger.info("Registry manifest parsed", {
+        environment: opts.environment,
+        latest: manifest.latest,
+        versionCount: manifest.versions.length,
+      });
       return manifest;
     },
 
@@ -126,8 +167,20 @@ export async function createRegistryClient(
       const manifest = cachedManifest ?? (await (this as RegistryClient).fetchManifest());
       const resolvedVersion =
         versionRequest === "latest" ? manifest.latest : versionRequest;
+      logger.info("Registry asset resolution started", {
+        environment: opts.environment,
+        versionRequest,
+        resolvedVersion,
+        platformKey,
+      });
       const entry = manifest.versions.find((v) => v.version === resolvedVersion);
       if (entry === undefined) {
+        logger.warn("Registry version not found", {
+          environment: opts.environment,
+          versionRequest,
+          resolvedVersion,
+          availableVersionCount: manifest.versions.length,
+        });
         throw cliError({
           code: CLI_ERROR_CODES.REGISTRY_VERSION_NOT_FOUND,
           message: `host registry: version '${resolvedVersion}' not found in manifest at ${manifestUrlInfo.url}`,
@@ -140,6 +193,11 @@ export async function createRegistryClient(
         });
       }
       if (entry.yanked) {
+        logger.warn("Registry refused yanked version", {
+          environment: opts.environment,
+          resolvedVersion,
+          hasDeprecationReason: entry.deprecationReason !== null,
+        });
         // Yanked versions are refused for install. The Tech Plan reserves
         // a future `--force` repair path; until that lands we fail with
         // a clean code so Desktop can route to the failure card.
@@ -156,6 +214,13 @@ export async function createRegistryClient(
       const asset = entry.platforms[platformKey];
       if (asset === undefined || !asset.available) {
         const reason = asset?.unavailableReason ?? "no asset published for this platform";
+        logger.warn("Registry asset unavailable for platform", {
+          environment: opts.environment,
+          resolvedVersion,
+          platformKey,
+          hasUnavailableReason:
+            asset !== undefined && asset.unavailableReason !== null,
+        });
         throw cliError({
           code: CLI_ERROR_CODES.REGISTRY_VERSION_NOT_FOUND,
           message: `host registry: version '${resolvedVersion}' has no available asset for ${platformKey}: ${reason}`,
@@ -167,6 +232,12 @@ export async function createRegistryClient(
           exitCode: 1,
         });
       }
+      logger.info("Registry asset resolved", {
+        environment: opts.environment,
+        resolvedVersion,
+        platformKey,
+        sizeBytes: asset.sizeBytes,
+      });
       return { entry, asset };
     },
 
@@ -181,6 +252,11 @@ export async function createRegistryClient(
       readonly signatureVerifiedAt: string;
     }> {
       if (!asset.available) {
+        logger.warn("Registry download refused unavailable asset", {
+          environment: opts.environment,
+          version: entry.version,
+          hasUnavailableReason: asset.unavailableReason !== null,
+        });
         throw cliError({
           code: CLI_ERROR_CODES.REGISTRY_VERSION_NOT_FOUND,
           message: `host registry: asset for version '${entry.version}' is marked unavailable`,
@@ -189,6 +265,11 @@ export async function createRegistryClient(
         });
       }
       const tmpDir = await mkdtemp(join(tmpdir(), "traycer-host-dl-"));
+      logger.info("Registry download started", {
+        environment: opts.environment,
+        version: entry.version,
+        sizeBytes: asset.sizeBytes,
+      });
       // Track whether we succeeded so the `finally` block can clean up
       // the tmpdir on failure. On success the caller (installer) is
       // responsible for moving the archive out and removing the dir.
@@ -213,6 +294,14 @@ export async function createRegistryClient(
         // the signature itself - otherwise the publisher could swap the
         // signing key after the fact without changing the manifest.
         if (verifyResult.keyId !== asset.publicKeyId) {
+          logger.error(
+            "Registry signature key mismatch",
+            {
+              environment: opts.environment,
+              version: entry.version,
+            },
+            null,
+          );
           throw cliError({
             code: CLI_ERROR_CODES.HOST_VERIFY_FAILED,
             message: `host registry: signature key id '${verifyResult.keyId}' does not match manifest publicKeyId '${asset.publicKeyId}'`,
@@ -224,6 +313,11 @@ export async function createRegistryClient(
           });
         }
         succeeded = true;
+        logger.info("Registry download and verification completed", {
+          environment: opts.environment,
+          version: entry.version,
+          downloadedBytes: download.downloadedBytes,
+        });
         return {
           archivePath,
           archiveSha256: download.sha256,
@@ -238,9 +332,18 @@ export async function createRegistryClient(
         // pathological case (rm fails on a tmpdir) leaves at worst the
         // empty dir behind, which the OS cleans up on reboot anyway.
         if (!succeeded) {
-          await rm(tmpDir, { recursive: true, force: true }).catch(
-            () => undefined,
-          );
+          await rm(tmpDir, { recursive: true, force: true }).catch((err) => {
+            logger.warn("Registry failed to clean temporary download directory", {
+              environment: opts.environment,
+              version: entry.version,
+              errorName: errorFromUnknown(err).name,
+              errorMessage: errorFromUnknown(err).message,
+            });
+          });
+          logger.warn("Registry cleaned failed download attempt", {
+            environment: opts.environment,
+            version: entry.version,
+          });
         }
       }
     },

--- a/clients/traycer-cli/src/runner/runner.ts
+++ b/clients/traycer-cli/src/runner/runner.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/node";
+import { errorFromUnknown } from "../logger";
 import { toCliError } from "./errors";
 import { createOutput, type Output, type ProgressInfo } from "./output";
 import {
@@ -55,20 +56,46 @@ export async function runCommand(
     output,
     progress: (info) => output.progress(info),
   };
+  runtime.logger.info("CLI command started", {
+    environment: runtime.environment,
+    json: runtime.json,
+    quiet: runtime.quiet,
+    noProgress: runtime.noProgress,
+    noBootstrap: runtime.noBootstrap,
+    nonInteractive: runtime.nonInteractive,
+  });
   let result: CommandResult;
   try {
     result = await fn(ctx);
   } catch (err) {
     Sentry.captureException(err);
     const cliErr = toCliError(err);
+    runtime.logger.error(
+      "CLI command failed",
+      {
+        code: cliErr.code,
+        exitCode: cliErr.exitCode,
+        emittedAsJson: runtime.json,
+      },
+      errorFromUnknown(err),
+    );
     output.emitError(cliErr.code, cliErr.message, cliErr.details);
     try {
       await Sentry.flush(2000);
-    } catch {
+    } catch (flushErr) {
+      runtime.logger.warn("Sentry flush failed after command error", {
+        errorName: errorFromUnknown(flushErr).name,
+        errorMessage: errorFromUnknown(flushErr).message,
+      });
       // best-effort; do not let a flush failure prevent exit
     }
     process.exit(cliErr.exitCode);
   }
+  runtime.logger.info("CLI command completed", {
+    exitCode: result.exitCode,
+    emittedAsJson: runtime.json,
+    hasHumanOutput: result.human !== null,
+  });
   if (runtime.json) {
     output.emitResult(result.data);
   } else if (result.human !== null && !runtime.quiet) {

--- a/clients/traycer-cli/src/runner/runtime.ts
+++ b/clients/traycer-cli/src/runner/runtime.ts
@@ -1,5 +1,6 @@
 import type { Environment } from "./environment";
 import { config } from "../config";
+import { createCliLogger, type ILogger } from "../logger";
 
 // Single centralised read of `process.env` typed as the readonly env map
 // every runner-aware code path consumes. Threading this through one
@@ -30,6 +31,7 @@ export interface RuntimeContext {
   readonly noBootstrap: boolean;
   readonly nonInteractive: boolean;
   readonly environment: Environment;
+  readonly logger: ILogger;
 }
 
 function envFlag(value: string | undefined): boolean {
@@ -58,5 +60,6 @@ export function resolveRuntimeContext(
     noBootstrap: flags.noBootstrap === true,
     nonInteractive,
     environment,
+    logger: createCliLogger(environment),
   };
 }

--- a/clients/traycer-cli/src/service/index.ts
+++ b/clients/traycer-cli/src/service/index.ts
@@ -1,4 +1,6 @@
 import { platform as osPlatform } from "node:os";
+import { config } from "../config";
+import { createCliLogger } from "../logger";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import type { CliInvocation } from "./cli-binary";
 import type { ServiceLabel } from "./label";
@@ -63,9 +65,37 @@ export function formatServiceLifecycleWarning(
 // so callers don't re-resolve per call.
 export function createServiceController(): ServiceController {
   const platform = osPlatform();
-  if (platform === "darwin") return createMacosController(null);
-  if (platform === "linux") return createLinuxController(null);
-  if (platform === "win32") return createWindowsController(null);
+  const logger = createCliLogger(config.environment);
+  logger.debug("Service controller resolving platform backend", {
+    environment: config.environment,
+    platform,
+  });
+  if (platform === "darwin") {
+    logger.info("Service controller selected macOS backend", {
+      environment: config.environment,
+    });
+    return createMacosController(null);
+  }
+  if (platform === "linux") {
+    logger.info("Service controller selected Linux backend", {
+      environment: config.environment,
+    });
+    return createLinuxController(null);
+  }
+  if (platform === "win32") {
+    logger.info("Service controller selected Windows backend", {
+      environment: config.environment,
+    });
+    return createWindowsController(null);
+  }
+  logger.error(
+    "Service controller unsupported platform",
+    {
+      environment: config.environment,
+      platform,
+    },
+    null,
+  );
   throw cliError({
     code: CLI_ERROR_CODES.SERVICE_UNSUPPORTED_PLATFORM,
     message: `service controller: unsupported platform '${platform}' (expected darwin|linux|win32)`,

--- a/clients/traycer-cli/src/store/credentials.ts
+++ b/clients/traycer-cli/src/store/credentials.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { chmod, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { config } from "../config";
+import { createCliLogger, errorFromUnknown } from "../logger";
 import { cliCredentialsPath, ensureCliHomeDir } from "./paths";
 
 // ~/.traycer/cli/credentials shape. Stored as JSON with mode 0600 so other
@@ -23,19 +24,35 @@ export interface StoredCredentials {
 }
 
 export async function readCredentials(): Promise<StoredCredentials | null> {
+  const logger = createCliLogger(config.environment);
   let raw: string;
   try {
     raw = await readFile(cliCredentialsPath(config.environment), "utf8");
-  } catch {
+  } catch (err) {
+    logger.debug("Credentials read returned absent", {
+      environment: config.environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     return null;
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    logger.warn("Credentials JSON parse failed", {
+      environment: config.environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     return null;
   }
-  if (parsed === null || typeof parsed !== "object") return null;
+  if (parsed === null || typeof parsed !== "object") {
+    logger.warn("Credentials rejected non-object payload", {
+      environment: config.environment,
+    });
+    return null;
+  }
   const obj = parsed as Record<string, unknown>;
   const user = obj.user;
   if (
@@ -46,6 +63,14 @@ export async function readCredentials(): Promise<StoredCredentials | null> {
     user === null ||
     typeof user !== "object"
   ) {
+    logger.warn("Credentials rejected malformed top-level payload", {
+      environment: config.environment,
+      hasToken: typeof obj.token === "string",
+      hasRefreshToken: typeof obj.refreshToken === "string",
+      hasAuthnBaseUrl: typeof obj.authnBaseUrl === "string",
+      hasSavedAt: typeof obj.savedAt === "string",
+      hasUser: user !== null && typeof user === "object",
+    });
     return null;
   }
   const userObj = user as Record<string, unknown>;
@@ -54,8 +79,19 @@ export async function readCredentials(): Promise<StoredCredentials | null> {
     typeof userObj.email !== "string" ||
     typeof userObj.name !== "string"
   ) {
+    logger.warn("Credentials rejected malformed user payload", {
+      environment: config.environment,
+      hasUserId: typeof userObj.id === "string",
+      hasUserEmail: typeof userObj.email === "string",
+      hasUserName: typeof userObj.name === "string",
+    });
     return null;
   }
+  logger.debug("Credentials read completed", {
+    environment: config.environment,
+    hasToken: obj.token.length > 0,
+    hasRefreshToken: obj.refreshToken.length > 0,
+  });
   return {
     token: obj.token,
     refreshToken: obj.refreshToken,
@@ -66,6 +102,12 @@ export async function readCredentials(): Promise<StoredCredentials | null> {
 }
 
 export async function writeCredentials(creds: StoredCredentials): Promise<void> {
+  const logger = createCliLogger(config.environment);
+  logger.info("Credentials write started", {
+    environment: config.environment,
+    hasToken: creds.token.length > 0,
+    hasRefreshToken: creds.refreshToken.length > 0,
+  });
   await ensureCliHomeDir(config.environment);
   const target = cliCredentialsPath(config.environment);
   // Unique temp name per write: the Desktop re-seeds via a spawned
@@ -83,13 +125,27 @@ export async function writeCredentials(creds: StoredCredentials): Promise<void> 
   // could have looser bits - re-chmod before the rename to be safe.
   await chmod(tmp, 0o600);
   await rename(tmp, target);
+  logger.info("Credentials write completed", {
+    environment: config.environment,
+  });
 }
 
 export async function deleteCredentials(): Promise<boolean> {
+  const logger = createCliLogger(config.environment);
   try {
     await unlink(cliCredentialsPath(config.environment));
+    logger.warn("Credentials deleted", {
+      environment: config.environment,
+      deleted: true,
+    });
     return true;
-  } catch {
+  } catch (err) {
+    logger.debug("Credentials delete skipped or failed", {
+      environment: config.environment,
+      deleted: false,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
     return false;
   }
 }

--- a/clients/traycer-cli/src/store/credentials.ts
+++ b/clients/traycer-cli/src/store/credentials.ts
@@ -29,10 +29,12 @@ export async function readCredentials(): Promise<StoredCredentials | null> {
   try {
     raw = await readFile(cliCredentialsPath(config.environment), "utf8");
   } catch (err) {
+    if (readErrorCode(err) !== "ENOENT") {
+      throw err;
+    }
     logger.debug("Credentials read returned absent", {
       environment: config.environment,
       errorName: errorFromUnknown(err).name,
-      errorMessage: errorFromUnknown(err).message,
     });
     return null;
   }
@@ -134,7 +136,7 @@ export async function deleteCredentials(): Promise<boolean> {
   const logger = createCliLogger(config.environment);
   try {
     await unlink(cliCredentialsPath(config.environment));
-    logger.warn("Credentials deleted", {
+    logger.info("Credentials deleted", {
       environment: config.environment,
       deleted: true,
     });
@@ -148,4 +150,10 @@ export async function deleteCredentials(): Promise<boolean> {
     });
     return false;
   }
+}
+
+function readErrorCode(error: unknown): string | null {
+  if (error === null || typeof error !== "object") return null;
+  const code = Reflect.get(error, "code");
+  return typeof code === "string" ? code : null;
 }

--- a/clients/traycer-cli/src/store/paths.ts
+++ b/clients/traycer-cli/src/store/paths.ts
@@ -34,6 +34,7 @@ const HOST_INSTALL_SUBDIR = "install";
 // from the host root. Named "install-staging" for clarity.
 const HOST_STAGING_SUBDIR = "install-staging";
 const HOST_INSTALL_RECORD_FILENAME = "install.json";
+const CLI_LOG_FILENAME = "cli.log";
 const HOST_LOG_FILENAME = "host.log";
 const HOST_PID_FILENAME = "pid.json";
 
@@ -73,6 +74,9 @@ export function cliManifestPath(environment: Environment): string {
 }
 export function cliLockPath(environment: Environment): string {
   return join(cliHomeDir(environment), ".lock");
+}
+export function cliLogPath(environment: Environment): string {
+  return join(cliHomeDir(environment), CLI_LOG_FILENAME);
 }
 // Marker the detached pending-CLI-upgrade finalize helper writes after
 // it attempts the live-binary swap. The next CLI invocation (Doctor,


### PR DESCRIPTION
## Summary
- add redacted structured logging across traycer-cli command/runtime paths
- add desktop logging for GUI log remapping, IPC/auth, CLI discovery, host lifecycle, tray, and updater boundaries
- add GUI structured logging for auth, host runtime/directories/streams, persistence/event parsing, query/mutation boundaries, clipboard/voice/performance/editor flows, and unhandled runtime failures
- avoid logging secrets or user-authored content by using identifiers, counts, booleans, and summary-only error metadata where needed

## Verification
- `bun run --cwd clients/traycer-cli compile`
- `bun run --cwd clients/traycer-cli test`
- `bun run --cwd clients/desktop compile`
- `bun run --cwd clients/desktop test` (passed on rerun after an Electron install race)
- `bun run --cwd clients/gui-app compile`
- `bun run --cwd clients/gui-app test`
- `git diff --check`
- `bun run --cwd clients/gui-app react-doctor` (fails on existing warning-level diagnostics: landing-image-gc cycles, unused exports, and host-ready-gate memo warning)
