### PR TITLE
fix(gui-app): clamp long user query bubbles to ~3-4 lines

### DIFF
--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -70,7 +70,9 @@ const NOOP: () => void = () => undefined;
 const NOOP_CLIPBOARD: ClipboardEventHandler<HTMLElement> = () => undefined;
 const NOOP_DRAG: DragEventHandler<HTMLElement> = () => undefined;
 
-const DISPLAY_MAX_HEIGHT_PX = 300;
+// Keep long prompts compact: ~3-4 lines (leading-7 ≈ 28px/line) stay visible
+// before the bubble clamps and fades, with "Show more" revealing the rest.
+const DISPLAY_MAX_HEIGHT_PX = 120;
 
 const COPIED_RESET_MS = 1600;
 
@@ -340,7 +342,7 @@ function UserMessageDisplayView({
               "min-w-0",
               clamped && [
                 "overflow-hidden",
-                "[mask-image:linear-gradient(to_bottom,black_calc(100%-4rem),transparent)]",
+                "[mask-image:linear-gradient(to_bottom,black_calc(100%-3rem),transparent)]",
               ],
             )}
           >


### PR DESCRIPTION
## What

Lower the user message display max-height from `300px` to `120px` and shrink the bottom fade mask from `4rem` to `3rem` so long user prompts stay compact in the chat list (~3–4 lines visible at `leading-7`), instead of occupying a tall block that then truncates.

The existing overflow detection (`ResizeObserver` against `scrollHeight > DISPLAY_MAX_HEIGHT_PX`) and the "Show more / Show less" toggle are unchanged — long prompts simply clamp sooner, and short prompts are unaffected.

## Why

The user query bubble had a large max-height before clamping, leaving a big block of text cut off mid-prompt. A lower cap keeps the conversation scannable while keeping the full prompt one click away.

## Files

- `clients/gui-app/src/components/chat/chat-message-user-body.tsx`