### PR TITLE
fix(protocol): version host.getRateLimitUsage accountContext as v1.1

### DIFF
--- a/protocol/src/host/rate-limit/contracts.ts
+++ b/protocol/src/host/rate-limit/contracts.ts
@@ -1,12 +1,42 @@
-import { defineRpcContract } from "@traycer/protocol/framework/index";
 import {
-  rateLimitUsageRequestSchema,
+  defineRpcContract,
+  defineUpgradePath,
+} from "@traycer/protocol/framework/index";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import {
+  rateLimitUsageRequestSchemaV10,
+  rateLimitUsageRequestSchemaV11,
   rateLimitUsageResponseSchema,
 } from "@traycer/protocol/host/rate-limit/schemas";
 
 export const hostGetRateLimitUsageV10 = defineRpcContract({
   method: "host.getRateLimitUsage",
   schemaVersion: { major: 1, minor: 0 } as const,
-  requestSchema: rateLimitUsageRequestSchema,
+  requestSchema: rateLimitUsageRequestSchemaV10,
   responseSchema: rateLimitUsageResponseSchema,
+});
+
+export const hostGetRateLimitUsageV11 = defineRpcContract({
+  method: "host.getRateLimitUsage",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: rateLimitUsageRequestSchemaV11,
+  responseSchema: rateLimitUsageResponseSchema,
+});
+
+// Upgrade bridge: an old client's v1.0 request carries no account context, so
+// the host fills the default (PERSONAL) when promoting it to canonical v1.1.
+// The response is unchanged across the minor, so the response upgrade is
+// identity.
+//
+// Spread a fresh copy rather than handing out the shared DEFAULT_ACCOUNT_CONTEXT
+// reference - this object is module-global, so returning it by reference would
+// let any downstream mutation of the upgraded request bleed into the constant.
+export const upgradeRateLimitUsageV10ToV11 = defineUpgradePath<
+  typeof hostGetRateLimitUsageV10,
+  typeof hostGetRateLimitUsageV11
+>({
+  from: hostGetRateLimitUsageV10.schemaVersion,
+  to: hostGetRateLimitUsageV11.schemaVersion,
+  upgradeRequest: () => ({ accountContext: { ...DEFAULT_ACCOUNT_CONTEXT } }),
+  upgradeResponse: (response) => response,
 });

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -4,16 +4,42 @@ import {
   accountContextSchema,
 } from "@traycer/protocol/common/schemas";
 
-export const rateLimitUsageRequestSchema = z
+// v1.0 request: empty, and intentionally NON-strict (no `.strict()`).
+//
+// The framework downgrades a request to an older same-major minor by
+// strip-projecting it through that minor's own request schema
+// (`prepareRequestPayload` in ws-rpc-client: `requestSchema.safeParse(params)`).
+// A new client (canonical v1.1, sends `{ accountContext }`) talking to a
+// released v1.0 host strips that down to `{}` by parsing through THIS schema -
+// which only works if the unknown key is STRIPPED, not rejected. `.strict()`
+// rejects, which would move the break from host to client. Any request schema
+// that is a downgrade target must stay non-strict.
+export const rateLimitUsageRequestSchemaV10 = z.object({});
+export type RateLimitUsageRequestV10 = z.infer<
+  typeof rateLimitUsageRequestSchemaV10
+>;
+
+// v1.1 request: adds `accountContext`. `.strict()` is safe here because v1.1 is
+// the latest minor and so never a downgrade target.
+export const rateLimitUsageRequestSchemaV11 = z
   .object({
     accountContext: accountContextSchema.default(DEFAULT_ACCOUNT_CONTEXT),
   })
   .strict();
-export type RateLimitUsageRequest = z.infer<typeof rateLimitUsageRequestSchema>;
+export type RateLimitUsageRequestV11 = z.infer<
+  typeof rateLimitUsageRequestSchemaV11
+>;
+
+// Canonical request type points at the latest version. There is deliberately no
+// unversioned `rateLimitUsageRequestSchema` value export - an unversioned alias
+// is exactly what invites editing "the" schema in place (the bug this versioning
+// fixes). Consumers pick a specific version.
+export type RateLimitUsageRequest = RateLimitUsageRequestV11;
 
 // Mirrors the aperture rate-limit shape defined in an internal shared package
 // (not in this repo) - the aperture gRPC return shape the Traycer cloud
-// backend maps straight onto this wire contract.
+// backend maps straight onto this wire contract. Unchanged across the v1.0/v1.1
+// minor bump.
 export const rateLimitUsageResponseSchema = z.object({
   totalTokens: z.number(),
   remainingTokens: z.number(),

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -37,7 +37,11 @@ import {
 } from "@traycer/protocol/host/comments/contracts";
 import { hostStatusV10 } from "@traycer/protocol/host/status/contracts";
 import { hostGetRuntimeCapabilitiesV10 } from "@traycer/protocol/host/runtime-capabilities/contracts";
-import { hostGetRateLimitUsageV10 } from "@traycer/protocol/host/rate-limit/contracts";
+import {
+  hostGetRateLimitUsageV10,
+  hostGetRateLimitUsageV11,
+  upgradeRateLimitUsageV10ToV11,
+} from "@traycer/protocol/host/rate-limit/contracts";
 import {
   epicBatchDeleteV10,
   epicBatchUpdateRolesV10,
@@ -479,11 +483,15 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
   },
   "host.getRateLimitUsage": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: hostGetRateLimitUsageV10,
           upgradeFromPreviousVersion: null,
+        },
+        1: {
+          contract: hostGetRateLimitUsageV11,
+          upgradeFromPreviousVersion: upgradeRateLimitUsageV10ToV11,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
accountContext was added in place on v1.0, a silent contract break: the handshake compares version numbers only, so a new client and a released v1.0 host both report "1.0", yet the old host's strict schema rejects the unknown field at request time (RPC_ERROR -> "usage unavailable").

- Revert v1.0 to the empty request and make it NON-strict, so a new client can strip-project its request down to {} for a released v1.0 host (the client-side downgrade in ws-rpc-client uses safeParse, which strips only when the schema is non-strict).
- Ship accountContext as a new v1.1 minor with a v1.0 -> v1.1 upgrade bridge that fills the default (PERSONAL) account for old clients.
- Canonical request type points at v1.1; no unversioned schema export.

## Summary

<!-- What does this change, and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [ ] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Tests added/updated where it makes sense
- [ ] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
