### PR TITLE
Proactive token refresh + credential-update stream frame

### DIFF
--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -473,6 +473,7 @@ describe("RunnerIpcBridge", () => {
         RunnerHostInvoke.workspaceFoldersPick,
         RunnerHostInvoke.validateAuthToken,
         RunnerHostInvoke.validateAuthTokenIdentity,
+        RunnerHostInvoke.refreshAuthToken,
         RunnerHostInvoke.exchangeAuthCode,
         RunnerHostInvoke.notificationShow,
         RunnerHostInvoke.openExternalLink,

--- a/clients/desktop/src/electron-main/ipc/auth-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/auth-ipc.ts
@@ -4,6 +4,7 @@ import {
 } from "../../ipc-contracts/ipc-channels";
 import {
   exchangeCodeForTokens,
+  refreshAuthTokenViaHttp,
   validateAuthTokenIdentityViaHttp,
   validateAuthTokenViaHttp,
 } from "@traycer-clients/shared/auth/auth-validation";
@@ -40,6 +41,20 @@ export function registerAuthIpc(bridge: RunnerIpcBridge): void {
       assertString(token, "validateAuthTokenIdentity");
       assertString(refreshToken, "validateAuthTokenIdentity.refreshToken");
       return validateAuthTokenIdentityViaHttp(
+        bridge.options.authnBaseUrl,
+        token,
+        refreshToken,
+      );
+    },
+  );
+
+  bridge.handleInvoke(
+    RunnerHostInvoke.refreshAuthToken,
+    async (_event, token: unknown, refreshToken: unknown) => {
+      assertString(token, "refreshAuthToken");
+      assertString(refreshToken, "refreshAuthToken.refreshToken");
+      // Run in main so renderer-origin CORS does not block the authn refresh.
+      return refreshAuthTokenViaHttp(
         bridge.options.authnBaseUrl,
         token,
         refreshToken,

--- a/clients/desktop/src/electron-preload/auth-bridge.ts
+++ b/clients/desktop/src/electron-preload/auth-bridge.ts
@@ -4,6 +4,7 @@ import {
   RunnerHostInvoke,
 } from "../ipc-contracts/ipc-channels";
 import type {
+  AuthTokenRefreshResult,
   AuthTokenValidationResult,
   StoredAuthTokens,
 } from "@traycer-clients/shared/platform/runner-host";
@@ -58,6 +59,10 @@ export interface AuthBridgeSurface {
     token: string,
     refreshToken: string,
   ): Promise<AuthIdentityValidationResult>;
+  refreshAuthToken(
+    token: string,
+    refreshToken: string,
+  ): Promise<AuthTokenRefreshResult>;
   exchangeAuthCode(
     code: string,
     codeVerifier: string,
@@ -81,6 +86,13 @@ export function buildAuthBridge(): AuthBridgeSurface {
         token,
         refreshToken,
       ) as Promise<AuthIdentityValidationResult>,
+
+    refreshAuthToken: (token, refreshToken) =>
+      ipcRenderer.invoke(
+        RunnerHostInvoke.refreshAuthToken,
+        token,
+        refreshToken,
+      ) as Promise<AuthTokenRefreshResult>,
 
     exchangeAuthCode: (code, codeVerifier) =>
       ipcRenderer.invoke(

--- a/clients/desktop/src/electron-preload/auth-bridge.ts
+++ b/clients/desktop/src/electron-preload/auth-bridge.ts
@@ -4,11 +4,11 @@ import {
   RunnerHostInvoke,
 } from "../ipc-contracts/ipc-channels";
 import type {
-  AuthTokenRefreshResult,
   AuthTokenValidationResult,
   StoredAuthTokens,
 } from "@traycer-clients/shared/platform/runner-host";
 import type { AuthIdentityValidationResult } from "@traycer-clients/shared/auth/auth-validation-types";
+import type { AuthTokenRefreshResult } from "../ipc-contracts/auth-types";
 import type { DesktopAuthSessionSnapshot } from "../ipc-contracts/window-types";
 import { subscribe, type Disposable, type Listener } from "./subscribe";
 

--- a/clients/desktop/src/ipc-contracts/auth-types.ts
+++ b/clients/desktop/src/ipc-contracts/auth-types.ts
@@ -1,0 +1,8 @@
+/**
+ * Desktop IPC re-export of the shared auth result contracts. The canonical
+ * definitions live in `@traycer-clients/shared/platform/runner-host`; this file
+ * lets the Electron preload bridge import them from `src/ipc-contracts/` (per
+ * the preload boundary rule) rather than reaching into the shared package,
+ * mirroring how `host-management-types.ts` re-exports the host contract.
+ */
+export type { AuthTokenRefreshResult } from "@traycer-clients/shared/platform/runner-host";

--- a/clients/desktop/src/ipc-contracts/ipc-channels.ts
+++ b/clients/desktop/src/ipc-contracts/ipc-channels.ts
@@ -11,6 +11,7 @@
 export const RunnerHostInvoke = {
   validateAuthToken: "runnerHost:auth:validateToken",
   validateAuthTokenIdentity: "runnerHost:auth:validateTokenIdentity",
+  refreshAuthToken: "runnerHost:auth:refreshToken",
   exchangeAuthCode: "runnerHost:auth:exchangeAuthCode",
   openExternalLink: "runnerHost:openExternalLink",
   getRegisteredUrlSchemes: "runnerHost:getRegisteredUrlSchemes",

--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -82,6 +82,7 @@ function buildFakeBridge(
       },
     }),
     validateAuthTokenIdentity: async () => ({ kind: "rejected" as const }),
+    refreshAuthToken: async () => ({ kind: "network-error" as const }),
     exchangeAuthCode: async () => null,
     openExternalLink: async () => undefined,
     getRegisteredUrlSchemes: async () => [],

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -1,5 +1,6 @@
 import type {
   AuthCallbackResult,
+  AuthTokenRefreshResult,
   AuthTokenValidationResult,
   CliInstallManifestSnapshot,
   HostAvailableSnapshot,
@@ -126,6 +127,10 @@ export interface DesktopPreloadBridge {
     token: string,
     refreshToken: string,
   ): Promise<AuthIdentityValidationResult>;
+  refreshAuthToken(
+    token: string,
+    refreshToken: string,
+  ): Promise<AuthTokenRefreshResult>;
   exchangeAuthCode(
     code: string,
     codeVerifier: string,
@@ -677,6 +682,13 @@ export class DesktopRunnerHost implements IRunnerHost {
     refreshToken: string,
   ): Promise<AuthIdentityValidationResult> {
     return this.bridge.validateAuthTokenIdentity(token, refreshToken);
+  }
+
+  refreshAuthToken(
+    token: string,
+    refreshToken: string,
+  ): Promise<AuthTokenRefreshResult> {
+    return this.bridge.refreshAuthToken(token, refreshToken);
   }
 
   exchangeAuthCode(

--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -167,6 +167,7 @@ function createBaseRunnerHost(): IRunnerHost {
     validateAuthToken: () => Promise.resolve({ kind: "rejected" as const }),
     validateAuthTokenIdentity: () =>
       Promise.resolve({ kind: "rejected" as const }),
+    refreshAuthToken: () => Promise.resolve({ kind: "network-error" as const }),
     exchangeAuthCode: () => Promise.resolve(null),
     openExternalLink: () => Promise.resolve(),
     getRegisteredUrlSchemes: () => Promise.resolve([]),

--- a/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
@@ -153,6 +153,7 @@ function makeHost(tray: IHostTray, management: IHostManagement): IRunnerHost {
     validateAuthToken: () => Promise.resolve({ kind: "rejected" as const }),
     validateAuthTokenIdentity: () =>
       Promise.resolve({ kind: "rejected" as const }),
+    refreshAuthToken: () => Promise.resolve({ kind: "network-error" as const }),
     exchangeAuthCode: () => Promise.resolve(null),
     openExternalLink: () => Promise.resolve(),
     getRegisteredUrlSchemes: () => Promise.resolve([]),

--- a/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
@@ -131,6 +131,8 @@ function createRunnerHost(menu: FakeDesktopMenu): FakeRunnerHost {
       validateAuthToken: () => Promise.resolve({ kind: "rejected" as const }),
       validateAuthTokenIdentity: () =>
         Promise.resolve({ kind: "rejected" as const }),
+      refreshAuthToken: () =>
+        Promise.resolve({ kind: "network-error" as const }),
       exchangeAuthCode: () => Promise.resolve(null),
       openExternalLink: () => Promise.resolve(),
       getRegisteredUrlSchemes: () => Promise.resolve([]),

--- a/clients/gui-app/src/hooks/host/use-host-stream-client-for.ts
+++ b/clients/gui-app/src/hooks/host/use-host-stream-client-for.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import { DEFAULT_DIAL_TIMEOUT_MS } from "@traycer-clients/shared/host-transport/transport-config";
 import { createWhatwgStreamWebSocketFactory } from "@traycer-clients/shared/host-transport/whatwg-stream-ws-factory";
@@ -165,6 +165,22 @@ export function useHostStreamClientBindingFor(
     };
   }, [auth, endpointHostId, endpointWebsocketUrl, globalClient, transportKey]);
   useCloseWsStreamClientOnReplace(binding?.client ?? null);
+
+  // Push the rotated bearer onto this client's open sessions whenever a token
+  // refresh rotates the credential lease in place, so the host updates each
+  // connection's credential without a reconnect (`credentialUpdate`). Same-user
+  // rotation is silent on `onChange`, so we subscribe to the dedicated
+  // `onBearerRotated` signal.
+  const client = binding?.client ?? null;
+  useEffect(() => {
+    if (client === null) {
+      return;
+    }
+    return globalClient.onBearerRotated(() => {
+      client.notifyBearerRotated();
+    });
+  }, [client, globalClient]);
+
   return binding;
 }
 

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -625,13 +625,34 @@ export class AuthService {
     if (this.currentRevalidation !== null) {
       return this.currentRevalidation;
     }
-    const revalidation = this.revalidateCurrentContextOnce().finally(() => {
-      if (this.currentRevalidation === revalidation) {
-        this.currentRevalidation = null;
-      }
-    });
+    const revalidation = this.revalidateAfterPendingForceRefresh().finally(
+      () => {
+        if (this.currentRevalidation === revalidation) {
+          this.currentRevalidation = null;
+        }
+      },
+    );
     this.currentRevalidation = revalidation;
     return revalidation;
+  }
+
+  /**
+   * Serializes against an in-flight proactive force-refresh before revalidating.
+   * Both paths spend the same single-use refresh token, so overlapping would
+   * double-spend it and sign the user out on the loser path. `forceRefreshOnce`
+   * awaits us in reverse, making the lock mutual. Deadlock-free: each path checks
+   * the other's flag once, synchronously, so only the later starter ever waits.
+   * Runs inside the `currentRevalidation` single-flight, so concurrent callers
+   * coalesce onto this one promise.
+   */
+  private async revalidateAfterPendingForceRefresh(): Promise<ValidationOutcome | null> {
+    if (this.currentForceRefresh !== null) {
+      await this.currentForceRefresh;
+      if (this.isDisposed()) {
+        return null;
+      }
+    }
+    return this.revalidateCurrentContextOnce();
   }
 
   /**
@@ -936,6 +957,13 @@ export class AuthService {
     this.currentBearer = newToken;
     this.emitSessionSnapshot();
     this.refreshScheduler.start();
+    // Propagate the rotated pair to the machine-local CLI/host credentials. On
+    // the proactive path the renderer is the SOLE refresher (the host hasn't
+    // 401'd, so its own revalidator hasn't run), so without this the local
+    // credential file keeps the now-spent token pair and later host/CLI flows
+    // fail to refresh. Best-effort, mirroring sign-in provisioning; a no-op on
+    // shells without a local CLI.
+    await this.ensureLocalProvisioning(newToken, newRefreshToken);
   }
 
   /**

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -487,6 +487,11 @@ export class AuthService {
     if (this.disposed) {
       return;
     }
+    // Stop the proactive refresh timer up front: `clearStoredAuth()` below is
+    // awaited (storage clear + CLI deprovision), and a timer firing during that
+    // window would race a `forceRefresh` against the credential removal.
+    // `applySignedOut()` stops it again, idempotently.
+    this.refreshScheduler.stop();
     this.clearPendingTimeout();
     this.clearPendingCodeVerifier();
     await this.clearStoredAuth();

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -15,6 +15,12 @@ import {
 } from "@traycer-clients/shared/auth/request-context-provider";
 import { rotateAndPersistBearer } from "@traycer-clients/shared/auth/bearer-revalidator";
 import {
+  createProactiveRefreshScheduler,
+  DEFAULT_REFRESH_LEAD_MS,
+  DEFAULT_REFRESH_MIN_DELAY_MS,
+  type ProactiveRefreshScheduler,
+} from "@traycer-clients/shared/auth/token-refresh-scheduler";
+import {
   CODE_CHALLENGE_METHOD,
   deriveCodeChallenge,
   generateCodeVerifier,
@@ -199,6 +205,13 @@ export class AuthService {
   private callbackDisposable: Disposable | null = null;
   private pendingTimeoutHandle: number | null = null;
   private currentRevalidation: Promise<ValidationOutcome | null> | null = null;
+  // Single-flight guard for the proactive force-refresh path so the refresh
+  // scheduler can't stack overlapping `/api/v3/auth/refresh` rotations.
+  private currentForceRefresh: Promise<void> | null = null;
+  // Proactively rotates the bearer shortly before its ~4h TTL so a long-open
+  // session never carries a dead token into a live host call. Constructed in the
+  // constructor; armed on every bearer (re)assignment, stopped on sign-out.
+  private readonly refreshScheduler: ProactiveRefreshScheduler;
   private disposed = false;
   // PKCE verifier generated at `signIn()` start, held in memory AND mirrored to
   // secure storage (`PKCE_VERIFIER_STORAGE_KEY`) until the matching callback
@@ -245,6 +258,16 @@ export class AuthService {
     this.tokenStore = new AuthTokenStore(options.runnerHost.tokenStore);
     this.contextProvider = new DefaultRequestContextProvider({
       origin: "renderer",
+    });
+    this.refreshScheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => this.currentBearer,
+      revalidate: () => this.forceRefresh(),
+      now: () => Date.now(),
+      setTimer: (handler, ms) => AuthService.scheduleTimeout(handler, ms),
+      clearTimer: (handle) => AuthService.cancelTimeout(handle),
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
     });
     const initialAuth = useAuthStore.getState();
     this.lastEmittedStatus = initialAuth.status;
@@ -571,6 +594,7 @@ export class AuthService {
           session.user.userSubscription.subscriptionStatus,
         );
       this.emitSessionSnapshot();
+      this.refreshScheduler.start();
       return;
     }
     this.applySignedIn(session.token, session.user, session.profile);
@@ -720,6 +744,7 @@ export class AuthService {
           );
         this.currentProfile = profile;
         this.emitSessionSnapshot();
+        this.refreshScheduler.start();
       }
       return outcome;
     }
@@ -736,6 +761,181 @@ export class AuthService {
       );
     }
     return outcome;
+  }
+
+  /**
+   * Proactively rotates the access token ahead of its TTL. Driven by the
+   * refresh scheduler shortly before `exp`.
+   *
+   * Unlike `revalidateCurrentContext` - which validates against `/api/v3/user`
+   * and only refreshes on a 401 - this ALWAYS force-refreshes against
+   * `/api/v3/auth/refresh`, so a still-valid-but-soon-to-expire bearer is
+   * renewed before the host's connection-captured copy can go stale (the
+   * overnight-session 401). Identity is unchanged on success, so it rotates the
+   * live lease in place (observably silent on the provider) and persists,
+   * without re-fetching the full user. Single-flight, and serialized against the
+   * reactive `revalidateCurrentContext` path so the two can't double-spend the
+   * single-use refresh token; a no-op when signed out or when no refresh
+   * credential is available.
+   */
+  private forceRefresh(): Promise<void> {
+    if (this.currentForceRefresh !== null) {
+      return this.currentForceRefresh;
+    }
+    const op = this.forceRefreshOnce().finally(() => {
+      if (this.currentForceRefresh === op) {
+        this.currentForceRefresh = null;
+      }
+    });
+    this.currentForceRefresh = op;
+    return op;
+  }
+
+  private async forceRefreshOnce(): Promise<void> {
+    if (this.isDisposed()) {
+      return;
+    }
+    // Defer to an in-flight reactive revalidation. Both paths draw on the same
+    // single-use refresh token, so running concurrently would double-spend it
+    // and leave whichever loses holding a dead credential (and, for this path,
+    // wrongly signing the user out). Awaiting here serializes the proactive and
+    // reactive refreshes within this window - the "shared lock" the two paths
+    // were missing. Cross-window siblings (separate `AuthService` instances)
+    // can't be awaited; the store re-reads below cover that race instead.
+    if (this.currentRevalidation !== null) {
+      await this.currentRevalidation;
+      if (this.isDisposed()) {
+        return;
+      }
+    }
+    const ctx = this.contextProvider.current();
+    if (ctx === null || this.currentBearer === null) {
+      return;
+    }
+    const userId = ctx.identity.userId;
+    const currentToken = this.currentBearer;
+    const stored = await this.tokenStore.load();
+    if (this.isDisposed()) {
+      return;
+    }
+    const refreshToken = stored?.refreshToken ?? "";
+    if (refreshToken.length === 0) {
+      // No refresh credential to rotate against - leave the bearer for the
+      // reactive 401 path to handle at actual expiry.
+      return;
+    }
+    // The persisted bearer already moved on from ours: a sibling window or the
+    // reactive 401 path rotated it. Do NOT adopt it here - the GUI's shell token
+    // slot is shared across windows and can hold a DIFFERENT user's bearer (a
+    // window that signed in before its session snapshot projected to us), so
+    // blind-rotating this context's lease to it under the current `userId` would
+    // bind a foreign identity. Leave reconciliation to the validated cross-window
+    // projection path (`ingestProjectedSessionSnapshot`), which confirms the
+    // token maps to the same user before applying it.
+    if (stored !== null && stored.token !== currentToken) {
+      return;
+    }
+    const result = await this.runnerHost.refreshAuthToken(
+      currentToken,
+      refreshToken,
+    );
+    if (this.isDisposed()) {
+      return;
+    }
+    if (result.kind === "network-error") {
+      // Transient; the scheduler retries on its floor delay.
+      return;
+    }
+    if (result.kind === "rejected") {
+      await this.signOutIfRefreshCredentialDead(currentToken);
+      return;
+    }
+    await this.applyProactiveRefresh(
+      userId,
+      currentToken,
+      result.token,
+      result.refreshToken,
+    );
+  }
+
+  /**
+   * Reject handler for the proactive refresh. Our single-use refresh token was
+   * rejected; sign out ONLY if this is a genuine expiry. If the persisted bearer
+   * has moved on from `refreshedAgainst`, a sibling (the reactive 401 path or
+   * another window) already rotated successfully and merely spent the refresh
+   * token first - the session is alive, so leave it intact and let the validated
+   * projection path adopt the winner's bearer. Only a store still holding our
+   * now-dead token is a real expiry that must sign out.
+   */
+  private async signOutIfRefreshCredentialDead(
+    refreshedAgainst: string,
+  ): Promise<void> {
+    const afterReject = await this.tokenStore.load();
+    if (this.isDisposed()) {
+      return;
+    }
+    if (
+      afterReject !== null &&
+      afterReject.token.length > 0 &&
+      afterReject.token !== refreshedAgainst
+    ) {
+      return;
+    }
+    await this.clearStoredAuth();
+    this.setLastError(AUTH_ERROR_SESSION_EXPIRED);
+    this.applySignedOut();
+  }
+
+  /**
+   * Success handler for the proactive refresh: persist + rotate to the freshly
+   * minted bearer, unless a concurrent winner intervened. A sign-out / cross-user
+   * transition during the round trip, or a sibling that rotated the shared store
+   * mid-refresh (a token differing from both `refreshedAgainst` and the one we
+   * just minted), both abort our write - we neither clobber the winner nor
+   * blind-adopt it (the shared shell slot can hold a different user); the
+   * validated projection path reconciles instead.
+   */
+  private async applyProactiveRefresh(
+    userId: string,
+    refreshedAgainst: string,
+    newToken: string,
+    newRefreshToken: string,
+  ): Promise<void> {
+    const live = this.contextProvider.current();
+    if (live === null || live.identity.userId !== userId) {
+      return;
+    }
+    const latest = await this.tokenStore.load();
+    if (this.isDisposed()) {
+      return;
+    }
+    if (
+      latest !== null &&
+      latest.token.length > 0 &&
+      latest.token !== refreshedAgainst &&
+      latest.token !== newToken
+    ) {
+      return;
+    }
+    await rotateAndPersistBearer({
+      newTokens: { token: newToken, refreshToken: newRefreshToken },
+      persist: (tokens) => this.tokenStore.save(tokens),
+      rotate: (token) => {
+        if (this.isDisposed()) {
+          return;
+        }
+        this.contextProvider.rotateCurrentBearer({
+          userId,
+          bearerToken: token,
+        });
+      },
+    });
+    if (this.isDisposed()) {
+      return;
+    }
+    this.currentBearer = newToken;
+    this.emitSessionSnapshot();
+    this.refreshScheduler.start();
   }
 
   /**
@@ -1021,6 +1221,7 @@ export class AuthService {
       return;
     }
     this.disposed = true;
+    this.refreshScheduler.stop();
     this.clearPendingTimeout();
     if (this.callbackDisposable !== null) {
       this.callbackDisposable.dispose();
@@ -1210,6 +1411,7 @@ export class AuthService {
       .getState()
       .setSubscriptionStatus(user.userSubscription.subscriptionStatus);
     this.emitSessionSnapshot();
+    this.refreshScheduler.start();
   }
 
   /**
@@ -1221,6 +1423,7 @@ export class AuthService {
     if (this.disposed) {
       return;
     }
+    this.refreshScheduler.stop();
     this.contextProvider.signOut();
     this.currentBearer = null;
     this.currentProfile = null;

--- a/clients/gui-app/src/lib/host/stream-runtime.tsx
+++ b/clients/gui-app/src/lib/host/stream-runtime.tsx
@@ -87,6 +87,20 @@ export function HostStreamProvider(props: HostStreamProviderProps): ReactNode {
     transportKey,
   );
 
+  // On an in-place bearer rotation (token refresh), push the fresh credential
+  // onto the app-wide stream client's open sessions so the host updates each
+  // connection's lease without a reconnect.
+  const wsStreamClient = value?.wsStreamClient ?? null;
+  const hostClient = binding?.hostClient ?? null;
+  useEffect(() => {
+    if (wsStreamClient === null || hostClient === null) {
+      return;
+    }
+    return hostClient.onBearerRotated(() => {
+      wsStreamClient.notifyBearerRotated();
+    });
+  }, [wsStreamClient, hostClient]);
+
   return (
     <StreamRuntimeContext.Provider value={value}>
       {props.children}

--- a/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
@@ -150,6 +150,7 @@ function createBaseRunnerHost(): IRunnerHost {
     validateAuthToken: () => Promise.resolve({ kind: "rejected" as const }),
     validateAuthTokenIdentity: () =>
       Promise.resolve({ kind: "rejected" as const }),
+    refreshAuthToken: () => Promise.resolve({ kind: "network-error" as const }),
     exchangeAuthCode: () => Promise.resolve(null),
     openExternalLink: () => Promise.resolve(),
     getRegisteredUrlSchemes: () => Promise.resolve([]),

--- a/clients/shared/auth/__tests__/token-refresh-scheduler.test.ts
+++ b/clients/shared/auth/__tests__/token-refresh-scheduler.test.ts
@@ -233,4 +233,33 @@ describe("createProactiveRefreshScheduler", () => {
     await clock.advance(8 * HOUR_MS);
     expect(revalidate).not.toHaveBeenCalled();
   });
+
+  it("clamps a far-future exp so the timer can't overflow and fire immediately", async () => {
+    const clock = makeFakeClock();
+    // exp 100 days out → the raw delay far exceeds the 32-bit timer ceiling,
+    // which would overflow and fire near-instantly without the clamp.
+    const token: string = tokenExpiringAtMs(100 * 24 * HOUR_MS);
+    const revalidate = vi.fn(async () => {});
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => token,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    scheduler.start();
+    // A timer is armed (not fired synchronously) and stays pending well past the
+    // floor - it must NOT have collapsed into an immediate fire.
+    expect(clock.pendingCount()).toBe(1);
+    await clock.advance(DEFAULT_REFRESH_MIN_DELAY_MS * 1000);
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(clock.pendingCount()).toBe(1);
+
+    scheduler.stop();
+  });
 });

--- a/clients/shared/auth/__tests__/token-refresh-scheduler.test.ts
+++ b/clients/shared/auth/__tests__/token-refresh-scheduler.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createProactiveRefreshScheduler,
+  DEFAULT_REFRESH_LEAD_MS,
+  DEFAULT_REFRESH_MIN_DELAY_MS,
+} from "../token-refresh-scheduler";
+
+const HOUR_MS = 60 * 60_000;
+
+function base64url(value: string): string {
+  return btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** A JWS-shaped token whose payload carries `exp` (epoch ms → seconds). */
+function tokenExpiringAtMs(expMs: number): string {
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64url(
+    JSON.stringify({ id: "user-1", exp: Math.trunc(expMs / 1000) }),
+  );
+  return `${header}.${payload}.signature`;
+}
+
+type FakeTimer = { id: number; cb: () => void; at: number };
+
+function makeFakeClock() {
+  let now = 0;
+  let nextId = 1;
+  let timers: FakeTimer[] = [];
+  return {
+    now: () => now,
+    setTimer: (cb: () => void, ms: number): number => {
+      const id = nextId++;
+      timers.push({ id, cb, at: now + ms });
+      return id;
+    },
+    clearTimer: (id: number): void => {
+      timers = timers.filter((t) => t.id !== id);
+    },
+    pendingCount: (): number => timers.length,
+    async advance(ms: number): Promise<void> {
+      now += ms;
+      const due = timers.filter((t) => t.at <= now).sort((a, b) => a.at - b.at);
+      for (const timer of due) {
+        timers = timers.filter((t) => t.id !== timer.id);
+        timer.cb();
+        // Flush the microtask chain so the async onFire (revalidate + re-arm)
+        // settles before the next assertion.
+        for (let i = 0; i < 8; i++) {
+          await Promise.resolve();
+        }
+      }
+    },
+  };
+}
+
+describe("createProactiveRefreshScheduler", () => {
+  it("refreshes once the scheduled fire lands inside the lead window", async () => {
+    const clock = makeFakeClock();
+    let token: string | null = tokenExpiringAtMs(4 * HOUR_MS);
+    const revalidate = vi.fn(async () => {
+      // Simulate a rotation to a fresh 4h token off the current clock.
+      token = tokenExpiringAtMs(clock.now() + 4 * HOUR_MS);
+    });
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => token,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    scheduler.start();
+    expect(revalidate).not.toHaveBeenCalled();
+
+    // Advance to the scheduled fire (exp - lead). The token is now within the
+    // lead window, so onFire refreshes.
+    await clock.advance(4 * HOUR_MS - DEFAULT_REFRESH_LEAD_MS);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    // Re-armed off the rotated token; a future refresh is pending.
+    expect(clock.pendingCount()).toBe(1);
+
+    scheduler.stop();
+    expect(clock.pendingCount()).toBe(0);
+  });
+
+  it("skips the refresh and re-arms when the token was already refreshed out of band", async () => {
+    const clock = makeFakeClock();
+    let token: string | null = tokenExpiringAtMs(4 * HOUR_MS);
+    const revalidate = vi.fn(async () => {});
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => token,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    scheduler.start();
+    // A reactive 401 refresh rotated the bearer before our timer fired: the
+    // live token now expires well beyond the lead window.
+    token = tokenExpiringAtMs(clock.now() + 4 * HOUR_MS + 4 * HOUR_MS);
+
+    await clock.advance(4 * HOUR_MS - DEFAULT_REFRESH_LEAD_MS);
+    expect(revalidate).not.toHaveBeenCalled();
+    // Still armed (off the fresher token), so it keeps watching.
+    expect(clock.pendingCount()).toBe(1);
+  });
+
+  it("retries on the min-delay floor when a refresh leaves the bearer unchanged", async () => {
+    const clock = makeFakeClock();
+    // The token never rotates - models a network-error refresh that leaves the
+    // bearer untouched, so each fire stays inside the lead window and must
+    // re-arm on the floor rather than refreshing immediately in a tight spin.
+    const token: string = tokenExpiringAtMs(4 * HOUR_MS);
+    const revalidate = vi.fn(async () => {});
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => token,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    scheduler.start();
+    await clock.advance(4 * HOUR_MS - DEFAULT_REFRESH_LEAD_MS);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    // Re-armed at the floor (token still unchanged + inside the lead window).
+    expect(clock.pendingCount()).toBe(1);
+
+    // The retry lands exactly one floor-delay later, not immediately.
+    await clock.advance(DEFAULT_REFRESH_MIN_DELAY_MS - 1);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    await clock.advance(1);
+    expect(revalidate).toHaveBeenCalledTimes(2);
+
+    scheduler.stop();
+    expect(clock.pendingCount()).toBe(0);
+  });
+
+  it("does not re-arm when stopped while a refresh is in flight", async () => {
+    const clock = makeFakeClock();
+    const token: string = tokenExpiringAtMs(4 * HOUR_MS);
+    let resolveRefresh: (() => void) | null = null;
+    const revalidate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => token,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    scheduler.start();
+    // Fire the scheduled refresh; onFire suspends on the unresolved revalidate.
+    await clock.advance(4 * HOUR_MS - DEFAULT_REFRESH_LEAD_MS);
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    expect(clock.pendingCount()).toBe(0);
+
+    // Stop mid-flight, then let the refresh settle: the post-await `stopped`
+    // guard must suppress the re-arm so no timer is left scheduled.
+    scheduler.stop();
+    resolveRefresh?.();
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+    expect(clock.pendingCount()).toBe(0);
+  });
+
+  it("disables scheduling for a token with no decodable exp", async () => {
+    const clock = makeFakeClock();
+    const revalidate = vi.fn(async () => {});
+    const diagnostics: string[] = [];
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => "not-a-decodable-jwt",
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: (message) => diagnostics.push(message),
+    });
+
+    scheduler.start();
+    expect(clock.pendingCount()).toBe(0);
+    expect(diagnostics).toEqual([
+      "proactive token refresh disabled: access token carries no decodable exp",
+    ]);
+
+    await clock.advance(8 * HOUR_MS);
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+
+  it("disarms when signed out and stays silent", async () => {
+    const clock = makeFakeClock();
+    const revalidate = vi.fn(async () => {});
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => null,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    scheduler.start();
+    expect(clock.pendingCount()).toBe(0);
+    await clock.advance(8 * HOUR_MS);
+    expect(revalidate).not.toHaveBeenCalled();
+  });
+});

--- a/clients/shared/auth/auth-validation.ts
+++ b/clients/shared/auth/auth-validation.ts
@@ -26,6 +26,7 @@
 import { authRecordRegistry } from "@traycer/protocol/auth/registry";
 import { getRecordSchema } from "@traycer/protocol/framework/index";
 import type {
+  AuthTokenRefreshResult,
   AuthTokenValidationResult,
   AuthValidationProfile,
 } from "../platform/runner-host";
@@ -35,21 +36,13 @@ export type {
   AuthIdentityValidationResult,
   AuthIdentityValidResult,
 } from "./auth-validation-types";
+export type { AuthTokenRefreshResult } from "../platform/runner-host";
 
 const authenticatedUserResponseSchema = getRecordSchema(
   authRecordRegistry,
   "authenticated-user-response",
   "latest",
 );
-
-export type AuthTokenRefreshResult =
-  | {
-      readonly kind: "refreshed";
-      readonly token: string;
-      readonly refreshToken: string;
-    }
-  | { readonly kind: "rejected" }
-  | { readonly kind: "network-error" };
 
 /**
  * Shared bearer-token validation helper used by runner-host implementations.

--- a/clients/shared/auth/jwt-exp.ts
+++ b/clients/shared/auth/jwt-exp.ts
@@ -1,0 +1,58 @@
+/**
+ * Reads the `exp` claim from a host access token WITHOUT verifying it.
+ *
+ * The host is the sole authority on token validity (signature, owner binding,
+ * revocation). The client decodes `exp` only to schedule a *proactive* refresh
+ * shortly before the token would expire, so a long-open session never carries a
+ * dead bearer into a live cloud call. A token that cannot be decoded simply
+ * disables proactive scheduling for that token - the reactive refresh-on-401
+ * path still covers it - so every failure maps to `null` rather than throwing.
+ */
+
+/**
+ * Epoch milliseconds at which `token` expires, or `null` when the token is not
+ * a decodable JWT or carries no finite numeric `exp` claim. The returned value
+ * is in milliseconds (the JWT `exp` claim is seconds since the epoch per
+ * RFC 7519; this multiplies into the millisecond clock the schedulers use).
+ */
+export function readAccessTokenExpiryMs(token: string): number | null {
+  const segments = token.split(".");
+  if (segments.length < 2) {
+    return null;
+  }
+  const expSeconds = readExpSeconds(decodeJwtSegment(segments[1]));
+  return expSeconds === null ? null : Math.trunc(expSeconds * 1000);
+}
+
+/**
+ * Decodes one base64url JWT segment into its parsed JSON value, or `null` if
+ * the segment is not valid base64url-encoded JSON.
+ */
+function decodeJwtSegment(segment: string): unknown {
+  const base64 = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+  let json: string;
+  try {
+    json = atob(padded);
+  } catch {
+    return null;
+  }
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts a finite numeric `exp` (in seconds) from a decoded JWT payload, or
+ * `null` when absent / non-numeric. The `"exp" in value` narrowing lets us read
+ * the claim off `unknown` without an unsafe assertion.
+ */
+function readExpSeconds(value: unknown): number | null {
+  if (typeof value !== "object" || value === null || !("exp" in value)) {
+    return null;
+  }
+  const exp = value.exp;
+  return typeof exp === "number" && Number.isFinite(exp) ? exp : null;
+}

--- a/clients/shared/auth/request-context-provider.ts
+++ b/clients/shared/auth/request-context-provider.ts
@@ -67,6 +67,15 @@ export type RequestContextListener = (ctx: RequestContext | null) => void;
 export interface RequestContextProvider {
   current(): RequestContext | null;
   onChange(listener: RequestContextListener): RequestContextSubscription;
+  /**
+   * Fires whenever the active context's bearer is rotated in place (same-user
+   * refresh) - the transition `onChange` is deliberately silent about, because
+   * the context reference is unchanged. Subscribers that must propagate a fresh
+   * bearer to already-open connections (the stream transport's in-place
+   * `credentialUpdate`) listen here; everything that keys on identity keeps
+   * using `onChange`. Carries no value: listeners re-read the live lease.
+   */
+  onBearerRotated(listener: () => void): RequestContextSubscription;
 }
 
 export interface MintRequestContextOptions {
@@ -136,6 +145,7 @@ export class DefaultRequestContextProvider implements RequestContextProvider {
   >;
   private currentContext: RequestContext | null = null;
   private readonly listeners = new Set<RequestContextListener>();
+  private readonly bearerRotationListeners = new Set<() => void>();
   private disposed = false;
 
   constructor(options: DefaultRequestContextProviderOptions) {
@@ -153,6 +163,16 @@ export class DefaultRequestContextProvider implements RequestContextProvider {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  onBearerRotated(listener: () => void): RequestContextSubscription {
+    if (this.disposed) {
+      return () => {};
+    }
+    this.bearerRotationListeners.add(listener);
+    return () => {
+      this.bearerRotationListeners.delete(listener);
     };
   }
 
@@ -205,6 +225,9 @@ export class DefaultRequestContextProvider implements RequestContextProvider {
       userId: options.userId,
       bearerToken: options.bearerToken,
     });
+    for (const listener of [...this.bearerRotationListeners]) {
+      listener();
+    }
   }
 
   /**
@@ -239,6 +262,7 @@ export class DefaultRequestContextProvider implements RequestContextProvider {
       previous.abort("request-context-provider-disposed");
     }
     this.listeners.clear();
+    this.bearerRotationListeners.clear();
   }
 
   private assertNotDisposed(): void {

--- a/clients/shared/auth/token-refresh-scheduler.ts
+++ b/clients/shared/auth/token-refresh-scheduler.ts
@@ -1,0 +1,143 @@
+/**
+ * Proactive access-token refresh scheduler shared by the Desktop renderer and
+ * the CLI/monitor.
+ *
+ * Both clients already refresh *reactively* - on a host `UNAUTHORIZED` the
+ * `auth-aware-messenger` (unary RPC) and `StreamAuthRevalidator` (stream) call
+ * `revalidateCurrentContext()`, which refreshes, rotates the bearer lease, and
+ * persists. What neither does today is refresh *before* the ~4h token TTL, so a
+ * session left open overnight carries a dead bearer into the next live cloud
+ * call (e.g. the host's `/api/v3/user` lookup on an A2A send) and 401s.
+ *
+ * This scheduler closes that gap: it decodes the access token's `exp` and arms
+ * a timer to invoke the SAME single-flight `revalidate` shortly before expiry,
+ * then re-arms off whichever token the refresh settled on. It never owns the
+ * refresh mechanics - only the timing - so the reactive paths and this proactive
+ * one share one rotation primitive and can't drift.
+ *
+ * The scheduler is timer- and clock-injected so it is environment-agnostic
+ * (`window.setTimeout` in the renderer, `setTimeout` in the CLI) and
+ * deterministically testable.
+ */
+import { readAccessTokenExpiryMs } from "./jwt-exp";
+
+/** Refresh this long before the token's `exp`. */
+export const DEFAULT_REFRESH_LEAD_MS = 10 * 60_000;
+
+/**
+ * Floor for the scheduled delay. Doubles as the retry cadence: when a refresh
+ * leaves the bearer unchanged (network error) or the token is already inside
+ * the lead window at arm time, the next attempt is scheduled this far out
+ * rather than immediately, so a persistent outage can't spin the timer.
+ */
+export const DEFAULT_REFRESH_MIN_DELAY_MS = 60_000;
+
+export interface ProactiveRefreshScheduler {
+  /** (Re-)arm off the current token. Idempotent; safe to call on every rotation. */
+  start(): void;
+  /** Cancel any pending refresh and stop re-arming. */
+  stop(): void;
+}
+
+export interface ProactiveRefreshSchedulerOptions<THandle> {
+  /** Current access token, or `null` when signed out (disarms the scheduler). */
+  readonly getToken: () => string | null;
+  /**
+   * Single-flight refresh that rotates + persists the bearer. Its return value
+   * is ignored - the scheduler re-reads `getToken()` afterwards to re-arm - so
+   * the renderer's `ValidationOutcome | null` and the CLI's `RevalidateOutcome`
+   * both satisfy this shape.
+   */
+  readonly revalidate: () => Promise<unknown>;
+  readonly now: () => number;
+  readonly setTimer: (handler: () => void, ms: number) => THandle;
+  readonly clearTimer: (handle: THandle) => void;
+  readonly leadMs: number;
+  readonly minDelayMs: number;
+  /** Optional diagnostic sink; `null` to stay silent. */
+  readonly onDiagnostic: ((message: string) => void) | null;
+}
+
+export function createProactiveRefreshScheduler<THandle>(
+  options: ProactiveRefreshSchedulerOptions<THandle>,
+): ProactiveRefreshScheduler {
+  let handle: THandle | null = null;
+  let stopped = true;
+
+  const clearScheduled = (): void => {
+    if (handle !== null) {
+      options.clearTimer(handle);
+      handle = null;
+    }
+  };
+
+  const arm = (): void => {
+    clearScheduled();
+    if (stopped) {
+      return;
+    }
+    const token = options.getToken();
+    if (token === null || token.length === 0) {
+      return;
+    }
+    const expMs = readAccessTokenExpiryMs(token);
+    if (expMs === null) {
+      options.onDiagnostic?.(
+        "proactive token refresh disabled: access token carries no decodable exp",
+      );
+      return;
+    }
+    const delay = Math.max(
+      expMs - options.leadMs - options.now(),
+      options.minDelayMs,
+    );
+    handle = options.setTimer(() => {
+      void onFire();
+    }, delay);
+  };
+
+  const onFire = async (): Promise<void> => {
+    handle = null;
+    if (stopped) {
+      return;
+    }
+    const token = options.getToken();
+    if (token === null || token.length === 0) {
+      return;
+    }
+    const expMs = readAccessTokenExpiryMs(token);
+    if (expMs === null) {
+      return;
+    }
+    // Another path (reactive 401 refresh, cross-window rotation) may have
+    // already refreshed the bearer, pushing `exp` past the lead window. Re-arm
+    // off the newer token instead of burning a single-use refresh token.
+    if (expMs - options.now() > options.leadMs) {
+      arm();
+      return;
+    }
+    options.onDiagnostic?.("proactively refreshing access token before expiry");
+    try {
+      await options.revalidate();
+    } catch {
+      // `revalidate` is a boundary that maps failures to outcomes rather than
+      // throwing; guard anyway so a rejection can never escape the background
+      // timer as an unhandled rejection. The re-arm below retries on the floor.
+    }
+    if (stopped) {
+      return;
+    }
+    arm();
+  };
+
+  return {
+    start(): void {
+      stopped = false;
+      arm();
+    },
+    stop(): void {
+      stopped = true;
+      clearScheduled();
+    },
+  };
+}

--- a/clients/shared/auth/token-refresh-scheduler.ts
+++ b/clients/shared/auth/token-refresh-scheduler.ts
@@ -32,6 +32,15 @@ export const DEFAULT_REFRESH_LEAD_MS = 10 * 60_000;
  */
 export const DEFAULT_REFRESH_MIN_DELAY_MS = 60_000;
 
+/**
+ * Cap for a scheduled delay. `setTimeout`/`setInterval` coerce the delay to a
+ * 32-bit signed int; anything above 2^31-1 ms (~24.8 days) overflows and the
+ * timer fires almost immediately. A far-future (or malformed-but-huge) `exp`
+ * could produce such a delay, so we clamp: the timer fires at the cap, re-arms,
+ * and converges once the token is actually inside the lead window.
+ */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 export interface ProactiveRefreshScheduler {
   /** (Re-)arm off the current token. Idempotent; safe to call on every rotation. */
   start(): void;
@@ -87,9 +96,9 @@ export function createProactiveRefreshScheduler<THandle>(
       );
       return;
     }
-    const delay = Math.max(
-      expMs - options.leadMs - options.now(),
-      options.minDelayMs,
+    const delay = Math.min(
+      Math.max(expMs - options.leadMs - options.now(), options.minDelayMs),
+      MAX_TIMER_DELAY_MS,
     );
     handle = options.setTimer(() => {
       void onFire();

--- a/clients/shared/host-client/host-client.ts
+++ b/clients/shared/host-client/host-client.ts
@@ -83,6 +83,7 @@ export class HostClient<Registry extends VersionedRpcRegistry> {
   private readonly changeHandlers = new Set<
     (event: HostClientChangeEvent) => void
   >();
+  private readonly bearerRotationHandlers = new Set<() => void>();
 
   constructor(options: HostClientOptions<Registry>) {
     this.registry = options.registry;
@@ -225,6 +226,29 @@ export class HostClient<Registry extends VersionedRpcRegistry> {
     return () => {
       this.changeHandlers.delete(handler);
     };
+  }
+
+  /**
+   * Subscribes to in-place bearer rotations (same-user token refresh). Distinct
+   * from `onChange`, which only fires on identity transitions; rotation keeps
+   * the same context reference. Stream transports listen here to push the fresh
+   * credential onto open connections (`credentialUpdate`) without a reconnect.
+   */
+  onBearerRotated(handler: () => void): HostClientUnsubscribe {
+    this.bearerRotationHandlers.add(handler);
+    return () => {
+      this.bearerRotationHandlers.delete(handler);
+    };
+  }
+
+  /**
+   * Fires every `onBearerRotated` subscriber. Called by `HostRuntime` when the
+   * `RequestContextProvider` rotates the active context's bearer in place.
+   */
+  notifyBearerRotated(): void {
+    for (const handler of [...this.bearerRotationHandlers]) {
+      handler();
+    }
   }
 
   /**

--- a/clients/shared/host-client/host-runtime.ts
+++ b/clients/shared/host-client/host-runtime.ts
@@ -70,6 +70,7 @@ export class HostRuntime<Registry extends VersionedRpcRegistry> {
   private disposed = false;
   private readonly disposables: Disposable[] = [];
   private contextUnsubscribe: (() => void) | null = null;
+  private bearerRotationUnsubscribe: (() => void) | null = null;
 
   constructor(options: HostRuntimeOptions<Registry>) {
     this.runnerHost = options.runnerHost;
@@ -104,6 +105,14 @@ export class HostRuntime<Registry extends VersionedRpcRegistry> {
       this.hostClient.setRequestContext(ctx);
     });
 
+    // Same-user token refresh rotates the lease in place (silent on `onChange`);
+    // forward it so stream transports can push the fresh credential onto open
+    // connections without a reconnect.
+    this.bearerRotationUnsubscribe =
+      this.requestContextProvider.onBearerRotated(() => {
+        this.hostClient.notifyBearerRotated();
+      });
+
     this.disposables.push(
       this.directory.onSelectionChange((entry) => {
         this.hostClient.bind(entry);
@@ -127,6 +136,10 @@ export class HostRuntime<Registry extends VersionedRpcRegistry> {
     if (this.contextUnsubscribe !== null) {
       this.contextUnsubscribe();
       this.contextUnsubscribe = null;
+    }
+    if (this.bearerRotationUnsubscribe !== null) {
+      this.bearerRotationUnsubscribe();
+      this.bearerRotationUnsubscribe = null;
     }
     for (const disposable of this.disposables) {
       disposable.dispose();

--- a/clients/shared/host-client/mock/mock-runner-host.ts
+++ b/clients/shared/host-client/mock/mock-runner-host.ts
@@ -1,6 +1,7 @@
 import type { Disposable } from "../../platform/uri-callback";
 import type {
   AuthCallbackResult,
+  AuthTokenRefreshResult,
   AuthTokenValidationResult,
   IHostPicker,
   IHostManagement,
@@ -22,6 +23,7 @@ import type {
   TrayIndicatorState,
 } from "../../platform/runner-host";
 import {
+  refreshAuthTokenViaHttp,
   validateAuthTokenIdentityViaHttp,
   validateAuthTokenViaHttp,
 } from "../../auth/auth-validation";
@@ -167,6 +169,13 @@ export class MockRunnerHost implements IRunnerHost {
       token,
       refreshToken,
     );
+  }
+
+  refreshAuthToken(
+    token: string,
+    refreshToken: string,
+  ): Promise<AuthTokenRefreshResult> {
+    return refreshAuthTokenViaHttp(this.authnBaseUrl, token, refreshToken);
   }
 
   /** Last (code, verifier) passed to exchangeAuthCode, for test assertions. */

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -166,6 +166,35 @@ function makeRequestContext(bearer: string): RequestContext {
   });
 }
 
+/**
+ * A client whose bearer can be rotated in place via the returned `ctx`, so
+ * `credentialUpdate` tests can refresh the credential and assert what the client
+ * pushes onto the open session.
+ */
+function makeRotatableClient(
+  factory: IStreamWebSocketFactory,
+  bearer: string,
+): {
+  readonly client: WsStreamClient<typeof hostStreamRpcRegistry>;
+  readonly ctx: RequestContext;
+} {
+  const ctx = makeRequestContext(bearer);
+  const client = new WsStreamClient({
+    registry: hostStreamRpcRegistry,
+    endpoint: () => mockLocalHostEntry,
+    bearer: () => ctx.credentials,
+    auth: null,
+    webSocketFactory: factory,
+    dialTimeoutMs: 1000,
+    openAckTimeoutMs: 1000,
+    pingIntervalMs: 25_000,
+    pongTimeoutMs: 50_000,
+    initialBackoffMs: 10,
+    maxBackoffMs: 1_000,
+  });
+  return { client, ctx };
+}
+
 async function flush(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
@@ -254,6 +283,62 @@ describe("WsStreamClient", () => {
     });
 
     expect(statuses).toContain("open");
+
+    session.close();
+  });
+
+  it("pushes a credentialUpdate frame on bearer rotation when the host advertises support", async () => {
+    const { factory, sockets } = makeFactory();
+    const { client, ctx } = makeRotatableClient(factory, "token-1");
+
+    const session = client.subscribe("epic.subscribe", { epicId: "epic-1" });
+    await flush();
+    const stub = sockets[0].socket;
+    stub.fireOpen();
+    stub.fireText({
+      kind: "openAck",
+      manifest: buildStreamManifest(hostStreamRpcRegistry),
+      capabilities: ["credentialUpdate"],
+    });
+    const sentBeforeRotation = stub.textSent.length;
+
+    ctx.credentials.rotateBearerToken({
+      userId: ctx.identity.userId,
+      bearerToken: "token-2",
+    });
+    client.notifyBearerRotated();
+
+    expect(stub.textSent).toHaveLength(sentBeforeRotation + 1);
+    expect(parseText(stub.textSent[sentBeforeRotation])).toEqual({
+      kind: "credentialUpdate",
+      token: "token-2",
+    });
+
+    session.close();
+  });
+
+  it("does not push a credentialUpdate frame when the host did not advertise support", async () => {
+    const { factory, sockets } = makeFactory();
+    const { client, ctx } = makeRotatableClient(factory, "token-1");
+
+    const session = client.subscribe("epic.subscribe", { epicId: "epic-1" });
+    await flush();
+    const stub = sockets[0].socket;
+    stub.fireOpen();
+    // Older host: openAck omits `capabilities` (schema defaults it to []).
+    stub.fireText({
+      kind: "openAck",
+      manifest: buildStreamManifest(hostStreamRpcRegistry),
+    });
+    const sentBeforeRotation = stub.textSent.length;
+
+    ctx.credentials.rotateBearerToken({
+      userId: ctx.identity.userId,
+      bearerToken: "token-2",
+    });
+    client.notifyBearerRotated();
+
+    expect(stub.textSent).toHaveLength(sentBeforeRotation);
 
     session.close();
   });

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -343,6 +343,43 @@ describe("WsStreamClient", () => {
     session.close();
   });
 
+  it("reconciles a bearer rotation that happened during the handshake (before openAck)", async () => {
+    const { factory, sockets } = makeFactory();
+    const { client, ctx } = makeRotatableClient(factory, "token-1");
+
+    const session = client.subscribe("epic.subscribe", { epicId: "epic-1" });
+    await flush();
+    const stub = sockets[0].socket;
+    stub.fireOpen();
+    // The open frame carried token-1. Rotate BEFORE the openAck arrives: the
+    // session isn't subscribed yet, so this push is dropped at the time.
+    ctx.credentials.rotateBearerToken({
+      userId: ctx.identity.userId,
+      bearerToken: "token-2",
+    });
+    client.notifyBearerRotated();
+    const credentialUpdatesBeforeAck = stub.textSent.filter(
+      (raw) => parseText(raw).kind === "credentialUpdate",
+    );
+    expect(credentialUpdatesBeforeAck).toHaveLength(0);
+
+    // openAck (capability-advertising) → on becoming subscribed the client
+    // reconciles the missed rotation and pushes exactly one credentialUpdate.
+    stub.fireText({
+      kind: "openAck",
+      manifest: buildStreamManifest(hostStreamRpcRegistry),
+      capabilities: ["credentialUpdate"],
+    });
+
+    const credentialUpdates = stub.textSent
+      .map((raw) => parseText(raw))
+      .filter((frame) => frame.kind === "credentialUpdate");
+    expect(credentialUpdates).toHaveLength(1);
+    expect(credentialUpdates[0].token).toBe("token-2");
+
+    session.close();
+  });
+
   it("does not dial or send an open frame without an authenticated request context", async () => {
     const { factory, sockets } = makeFactory();
     const client = makeClient({

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -724,6 +724,18 @@ class StreamSession<
     this.lastPongAt = Date.now();
     this.startHeartbeat();
     this.transitionTo("open", null);
+    // If the bearer rotated DURING the handshake - after the open frame was sent
+    // but before we became `subscribed` - that rotation's `notifyBearerRotated`
+    // was dropped (we weren't subscribed yet) and the open frame carried the now
+    // stale token. Reconcile once here so the host still gets the fresh bearer in
+    // place. No-op on the common path where the bearer is unchanged.
+    if (
+      this.supportsCredentialUpdate &&
+      this.openFrameToken !== null &&
+      this.currentBearerToken() !== this.openFrameToken
+    ) {
+      this.pushCredentialUpdate();
+    }
   }
 
   private handleFatalErrorFrame(parsed: object): void {

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -18,9 +18,11 @@ import {
   hostStreamOpenAckFrameSchema,
   hostStreamFatalErrorFrameSchema,
   streamMethodFrameEnvelopeSchema,
+  STREAM_CAPABILITY_CREDENTIAL_UPDATE,
   type ClientStreamOpenFrame,
   type ClientStreamSubscribeFrame,
   type ClientStreamFatalErrorFrame,
+  type ClientStreamCredentialUpdateFrame,
 } from "@traycer/protocol/framework/stream-ws-protocol";
 import type {
   IStreamSession,
@@ -195,6 +197,23 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
    * host re-run its subscribe handler (re-registering the live request
    * context) within seconds of wake. No-op on a closed client.
    */
+  /**
+   * Pushes the freshly-rotated bearer onto every open session so each host
+   * connection updates its credential lease IN PLACE, with no reconnect. Called
+   * by the owner right after a proactive (or reactive) token refresh rotates the
+   * lease. Sessions that are mid-reconnect - or whose host did not advertise
+   * `credentialUpdate` support - simply skip; their next open frame already
+   * carries the fresh bearer. No-op on a closed client.
+   */
+  notifyBearerRotated(): void {
+    if (this.closed) {
+      return;
+    }
+    for (const session of Array.from(this.ownedSessions)) {
+      session.pushCredentialUpdate();
+    }
+  }
+
   reconnectAll(reason: string): void {
     if (this.closed) {
       return;
@@ -297,6 +316,10 @@ class StreamSession<
 
   private activeSocket: StreamWebSocketLike | null = null;
   private openFrameToken: string | null = null;
+  // Whether the host advertised `credentialUpdate` support in the current
+  // connection's openAck. Gates `pushCredentialUpdate`; reset on every
+  // reconnect and re-read from the next openAck.
+  private supportsCredentialUpdate = false;
   private phase: SessionPhase = "idle";
   private pendingBinaryEnvelope: StreamFrameEnvelope | null = null;
   private dialTimer: TimerHandle | null = null;
@@ -369,6 +392,37 @@ class StreamSession<
     this.reconnectAttempt = 0;
     this.slowClientReconnectStreak = 0;
     this.onTransportDrop();
+  }
+
+  /**
+   * Pushes the current bearer onto this open connection so the host rotates its
+   * credential lease in place - no reconnect. No-op unless the session is fully
+   * `subscribed` AND the host advertised `credentialUpdate` support in its
+   * openAck; a mid-reconnect session just carries the fresh bearer in its next
+   * open frame. Called by `WsStreamClient.notifyBearerRotated`.
+   */
+  pushCredentialUpdate(): void {
+    if (this.disposed) {
+      return;
+    }
+    if (this.phase !== "subscribed" || !this.supportsCredentialUpdate) {
+      return;
+    }
+    const socket = this.activeSocket;
+    if (socket === null) {
+      return;
+    }
+    const token = this.currentBearerToken();
+    if (token === null) {
+      return;
+    }
+    const frame: ClientStreamCredentialUpdateFrame = {
+      kind: "credentialUpdate",
+      token,
+    };
+    if (!this.sendControlText(socket, frame)) {
+      this.onSendFailure(socket);
+    }
   }
 
   // ---- Internal wiring -------------------------------------------------- //
@@ -619,6 +673,9 @@ class StreamSession<
       clearTimeout(this.openAckTimer);
       this.openAckTimer = null;
     }
+    this.supportsCredentialUpdate = ackParse.data.capabilities.includes(
+      STREAM_CAPABILITY_CREDENTIAL_UPDATE,
+    );
 
     const myManifest = buildStreamManifest(this.config.registry);
     const compat = checkStreamCompatibility(
@@ -926,6 +983,7 @@ class StreamSession<
     }
     this.activeSocket = null;
     this.openFrameToken = null;
+    this.supportsCredentialUpdate = false;
     this.phase = "idle";
     this.pendingBinaryEnvelope = null;
     this.transitionTo("reconnecting", null);
@@ -996,7 +1054,8 @@ class StreamSession<
     frame:
       | ClientStreamOpenFrame
       | ClientStreamSubscribeFrame
-      | ClientStreamFatalErrorFrame,
+      | ClientStreamFatalErrorFrame
+      | ClientStreamCredentialUpdateFrame,
   ): boolean {
     try {
       socket.send(JSON.stringify(frame));

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -81,6 +81,20 @@ export interface IRunnerHost {
   ): Promise<AuthIdentityValidationResult>;
 
   /**
+   * Force-refreshes the access token against authn's `POST /api/v3/auth/refresh`
+   * WITHOUT a prior `/api/v3/user` validation, rotating both the bearer and the
+   * refresh token. The proactive refresh scheduler calls this shortly before the
+   * ~4h TTL so a long-open session never carries a dead bearer into a live host
+   * call. Desktop shells run this in Electron main so renderer-origin CORS does
+   * not block the authn request; browser/test shells may call the shared
+   * `refreshAuthTokenViaHttp` helper directly.
+   */
+  refreshAuthToken(
+    token: string,
+    refreshToken: string,
+  ): Promise<AuthTokenRefreshResult>;
+
+  /**
    * Exchanges a one-time PKCE `code` (from the sign-in callback) + the
    * `codeVerifier` the renderer generated at sign-in start for the real token
    * pair. Like `validateAuthToken`, desktop shells perform this in Electron
@@ -487,6 +501,22 @@ export type AuthTokenValidResult =
 
 export type AuthTokenValidationResult =
   | AuthTokenValidResult
+  | { readonly kind: "rejected" }
+  | { readonly kind: "network-error" };
+
+/**
+ * Outcome of a forced access-token refresh (`POST /api/v3/auth/refresh`),
+ * independent of any `/api/v3/user` validation. `refreshed` rotates BOTH the
+ * bearer and the refresh token; `rejected` means the refresh credential is dead
+ * (revoked / expired) and the session must sign out; `network-error` is
+ * transient and leaves the current credential untouched so a retry can follow.
+ */
+export type AuthTokenRefreshResult =
+  | {
+      readonly kind: "refreshed";
+      readonly token: string;
+      readonly refreshToken: string;
+    }
   | { readonly kind: "rejected" }
   | { readonly kind: "network-error" };
 

--- a/clients/traycer-cli/src/commands/monitor.ts
+++ b/clients/traycer-cli/src/commands/monitor.ts
@@ -8,11 +8,17 @@ import {
   type AgentInboxMessage,
   type AgentInboxNotice,
 } from "@traycer/protocol/host/agent/inbox";
+import { CredentialLeaseReleasedError } from "@traycer/protocol/auth/request-context";
 import { MutableBearerLease } from "../../../shared/auth/bearer-source";
 import {
   createBearerRevalidator,
   type RevalidateOutcome,
 } from "../../../shared/auth/bearer-revalidator";
+import {
+  createProactiveRefreshScheduler,
+  DEFAULT_REFRESH_LEAD_MS,
+  DEFAULT_REFRESH_MIN_DELAY_MS,
+} from "../../../shared/auth/token-refresh-scheduler";
 import { createWhatwgStreamWebSocketFactory } from "../../../shared/host-transport/whatwg-stream-ws-factory";
 import type {
   IStreamSession,
@@ -192,6 +198,34 @@ export async function runMonitor(args: MonitorArgs): Promise<void> {
     maxBackoffMs: MAX_BACKOFF_MS,
   });
 
+  // Proactively refresh the bearer shortly before its ~4h TTL so a long-running
+  // monitor never carries a dead token into a reconnect (or hands the host a
+  // stale credential it would 401 on). The reactive refresh-on-`UNAUTHORIZED`
+  // loop in `runInboxSubscription` stays as the safety net; this just rotates
+  // ahead of expiry. The scheduler shares the same single-flight `revalidator`,
+  // so a proactive and reactive refresh can't race into a double rotation.
+  const refreshScheduler = createProactiveRefreshScheduler<NodeJS.Timeout>({
+    getToken: () => readLeaseBearer(lease),
+    revalidate: async () => {
+      const outcome = await revalidator.revalidateCurrentContext();
+      if (outcome === "rotated") {
+        // Push the fresh bearer onto the open inbox stream so the host updates
+        // its captured credential in place - no reconnect. The reactive
+        // UNAUTHORIZED path already re-dials with the fresh token, so it needs
+        // no push.
+        client.notifyBearerRotated();
+      }
+      return outcome;
+    },
+    now: () => Date.now(),
+    setTimer: (handler, ms) => setTimeout(handler, ms),
+    clearTimer: (handle) => clearTimeout(handle),
+    leadMs: DEFAULT_REFRESH_LEAD_MS,
+    minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+    onDiagnostic: (message) => diag(message),
+  });
+  refreshScheduler.start();
+
   diag(`inbox monitor starting — agent=${agentId} epic=${epicId}`);
   logger.info("Monitor subscription loop starting", {
     environment: config.environment,
@@ -201,12 +235,32 @@ export async function runMonitor(args: MonitorArgs): Promise<void> {
   try {
     await runInboxSubscription(client, revalidator, { agentId, epicId }, logger);
   } finally {
+    refreshScheduler.stop();
     clearInterval(poll);
     logger.info("Monitor subscription loop stopped", {
       environment: config.environment,
       agentId,
       epicId,
     });
+  }
+}
+
+/**
+ * Reads the lease's current bearer, mapping the "no bearer" throw
+ * (`CredentialLeaseReleasedError`, raised on an empty token) to `null` so the
+ * refresh scheduler treats it as "signed out, nothing to schedule".
+ */
+function readLeaseBearer(lease: MutableBearerLease): string | null {
+  try {
+    return lease.getBearerToken();
+  } catch (cause) {
+    // Only the "no bearer / signed out" signal maps to null. Any other lease
+    // failure is a real bug; rethrow it rather than silently disabling the
+    // refresh scheduler and masking it as a benign signed-out state.
+    if (cause instanceof CredentialLeaseReleasedError) {
+      return null;
+    }
+    throw cause;
   }
 }
 

--- a/protocol/src/framework/__tests__/stream-ws-protocol.test.ts
+++ b/protocol/src/framework/__tests__/stream-ws-protocol.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  hostStreamOpenAckFrameSchema,
+  clientStreamCredentialUpdateFrameSchema,
+  STREAM_CAPABILITY_CREDENTIAL_UPDATE,
+} from "@traycer/protocol/framework/stream-ws-protocol";
+
+/**
+ * Cross-version compatibility contract for the `/stream` control frames.
+ *
+ * Clients and the host ship independently, so the `openAck` capabilities
+ * mechanism and the `credentialUpdate` frame MUST degrade gracefully across a
+ * version skew. The frames are framework-level (not per-method version
+ * negotiated), so that safety rests entirely on Zod tolerance + the client's
+ * capability gate. These tests pin that behaviour so a future edit can't
+ * silently make a schema `.strict()` (which would make an older client reject a
+ * newer host's `openAck` and drop the connection).
+ */
+describe("stream-ws-protocol cross-version compatibility", () => {
+  const manifest = { "epic.subscribe": { major: 1, minor: 0 } };
+
+  describe("hostStreamOpenAckFrame (host -> client)", () => {
+    it("strips unknown keys instead of rejecting (older client tolerates a newer host's additive fields)", () => {
+      // A future host adds a field this version's client has never heard of.
+      // The schema MUST strip it, not reject — otherwise the connection drops.
+      const parsed = hostStreamOpenAckFrameSchema.safeParse({
+        kind: "openAck",
+        manifest,
+        capabilities: [STREAM_CAPABILITY_CREDENTIAL_UPDATE],
+        someFutureField: { nested: true },
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect("someFutureField" in parsed.data).toBe(false);
+      }
+    });
+
+    it("defaults `capabilities` to [] when absent (newer client tolerates an older host's ack)", () => {
+      const parsed = hostStreamOpenAckFrameSchema.safeParse({
+        kind: "openAck",
+        manifest,
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.capabilities).toEqual([]);
+      }
+    });
+
+    it("preserves an advertised capabilities array", () => {
+      const parsed = hostStreamOpenAckFrameSchema.safeParse({
+        kind: "openAck",
+        manifest,
+        capabilities: [STREAM_CAPABILITY_CREDENTIAL_UPDATE],
+      });
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.capabilities).toContain(
+          STREAM_CAPABILITY_CREDENTIAL_UPDATE,
+        );
+      }
+    });
+
+    it("models an older client's openAck schema (kind + manifest only) accepting a newer host's ack", () => {
+      // Reconstruct the pre-capabilities schema a previously-shipped client
+      // carries, and prove a newer host's ack (with `capabilities`) still parses.
+      const legacyOpenAck = z.object({
+        kind: z.literal("openAck"),
+        manifest: z.record(
+          z.string(),
+          z.object({ major: z.number(), minor: z.number() }),
+        ),
+      });
+      const parsed = legacyOpenAck.safeParse({
+        kind: "openAck",
+        manifest,
+        capabilities: [STREAM_CAPABILITY_CREDENTIAL_UPDATE],
+      });
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe("clientStreamCredentialUpdateFrame (client -> host)", () => {
+    it("accepts a valid frame", () => {
+      const parsed = clientStreamCredentialUpdateFrameSchema.safeParse({
+        kind: "credentialUpdate",
+        token: "rotated-bearer",
+      });
+      expect(parsed.success).toBe(true);
+    });
+
+    it("rejects a missing or empty token", () => {
+      expect(
+        clientStreamCredentialUpdateFrameSchema.safeParse({
+          kind: "credentialUpdate",
+        }).success,
+      ).toBe(false);
+      expect(
+        clientStreamCredentialUpdateFrameSchema.safeParse({
+          kind: "credentialUpdate",
+          token: "",
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  it("pins the wire value of the credentialUpdate capability tag", () => {
+    // This string is on the wire; changing it silently breaks negotiation.
+    expect(STREAM_CAPABILITY_CREDENTIAL_UPDATE).toBe("credentialUpdate");
+  });
+});

--- a/protocol/src/framework/stream-ws-protocol.ts
+++ b/protocol/src/framework/stream-ws-protocol.ts
@@ -33,11 +33,34 @@ import type { SchemaVersion } from "@traycer/protocol/framework/index";
  * control-path and application-path handlers.
  */
 
+/**
+ * Capability tag a host advertises in `openAck.capabilities` when it accepts
+ * the `credentialUpdate` control frame (in-place bearer rotation on a live
+ * stream connection, no reconnect). A client MUST only send `credentialUpdate`
+ * after seeing this tag in the host's `openAck`; against an older host that
+ * omits it the client stays silent and relies on reconnect-time re-auth. This
+ * keeps a newer-client / older-host pairing from tripping the host's
+ * unknown-frame guard and dropping the connection.
+ */
+export const STREAM_CAPABILITY_CREDENTIAL_UPDATE = "credentialUpdate";
+
 /** First frame sent by the client: bearer token + per-method canonicals. */
 export type ClientStreamOpenFrame = {
   readonly kind: "open";
   readonly token: string;
   readonly manifest: ConnectionManifest;
+};
+
+/**
+ * Pushes a freshly-rotated bearer onto an already-open stream connection so the
+ * host updates the connection's credential lease in place - without a reconnect.
+ * Sent only after a proactive/reactive token refresh and only when the host
+ * advertised `credentialUpdate` support in its `openAck`. The host re-verifies
+ * the token (signature + owner binding) and rotates only on a same-user match.
+ */
+export type ClientStreamCredentialUpdateFrame = {
+  readonly kind: "credentialUpdate";
+  readonly token: string;
 };
 
 /**
@@ -62,10 +85,17 @@ export type ClientStreamFatalErrorFrame = {
   readonly details: FatalErrorDetails;
 };
 
-/** Host ack of the open + manifest. */
+/** Host ack of the open + manifest, plus the control-frame capabilities it accepts. */
 export type HostStreamOpenAckFrame = {
   readonly kind: "openAck";
   readonly manifest: ConnectionManifest;
+  /**
+   * Optional, additive control-frame capabilities (e.g.
+   * `credentialUpdate`). A client only uses a capability it finds here; an
+   * older host omits the field entirely and the schema defaults it to `[]`,
+   * so a newer client safely reads "none supported".
+   */
+  readonly capabilities: readonly string[];
 };
 
 /** Fatal error from the host (auth or compat rejection). */
@@ -87,6 +117,11 @@ export const clientStreamSubscribeFrameSchema = z.object({
   params: z.unknown(),
 });
 
+export const clientStreamCredentialUpdateFrameSchema = z.object({
+  kind: z.literal("credentialUpdate"),
+  token: z.string().min(1),
+});
+
 export const clientStreamFatalErrorFrameSchema = z.object({
   kind: z.literal("fatalError"),
   details: fatalErrorDetailsSchema,
@@ -95,6 +130,10 @@ export const clientStreamFatalErrorFrameSchema = z.object({
 export const hostStreamOpenAckFrameSchema = z.object({
   kind: z.literal("openAck"),
   manifest: connectionManifestSchema,
+  // Backward-compat: an older host omits `capabilities`; default to none so a
+  // newer client parsing an older host's ack still succeeds and treats every
+  // capability as unsupported.
+  capabilities: z.array(z.string()).default([]),
 });
 
 export const hostStreamFatalErrorFrameSchema = z.object({


### PR DESCRIPTION
## Problem

A session left open past the access token's ~4h TTL (e.g. an overnight chat) carries a **dead bearer** into the next live host call. The host validates a WS connection once at the open frame (local JWKS), then trusts the captured token for the connection's lifetime — so when a cloud call like `GET /api/v3/user` fires (A2A send to a GUI receiver), authn-v3 returns **401** and the tool fails: `Failed to fetch authenticated user '…': status 401`.

The client only refreshed **reactively** (on a host `UNAUTHORIZED`), and an idle stream never triggers that — so the token just rots in place.

## Fix (two halves)

**1. Proactive refresh.** A shared scheduler decodes the access token's `exp` and refreshes ~10m before the TTL, rotating the bearer ahead of expiry.
- `clients/shared/auth/jwt-exp.ts` + `token-refresh-scheduler.ts` (env-agnostic, timer/clock-injected)
- `IRunnerHost.refreshAuthToken` force-refresh primitive (renderer only *validated* before; an idle stream never 401s, so proactive refresh must actually rotate) — wired through desktop IPC + mock
- `AuthService.forceRefresh` driven by the scheduler; CLI `monitor` wired too

**2. Credential-update stream frame.** The rotated bearer is pushed onto **already-open** connections in place — no reconnect.
- Versioned `credentialUpdate` client→host frame + `openAck.capabilities` negotiation (older host omits it → client stays silent and relies on reconnect re-auth)
- `WsStreamClient.notifyBearerRotated()` pushes to capability-advertising subscribed sessions
- `RequestContextProvider.onBearerRotated` → `HostClient` → the renderer's stream owners; CLI pushes after a proactive rotation

The reactive refresh-on-401 paths stay as defense-in-depth.

> Host-side handling of the `credentialUpdate` frame (in-place lease rotation) lands in the internal `traycer-host` PR that bumps this submodule.

## Testing

- New unit tests: proactive scheduler (lead-window refresh, out-of-band skip, floor retry, stop-mid-flight, undecodable-exp), `WsStreamClient` capability capture + push gating
- `protocol`, `traycer-cli`, `gui-app`, `desktop` compile clean
- Affected suites green: shared 70 · cli 6 · gui-app 73

🤖 Generated with [Claude Code](https://claude.com/claude-code)