### PR TITLE
fix(gui-app): reliable worktree bulk-delete with persistent progress

### DIFF
--- a/clients/gui-app/src/components/layout/bridges/worktree-delete-progress-toast-bridge.tsx
+++ b/clients/gui-app/src/components/layout/bridges/worktree-delete-progress-toast-bridge.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import {
+  useWorktreeDeleteProgressSummary,
+  worktreeDeleteProgressDetail,
+  type WorktreeDeleteProgressSummary,
+} from "@/components/settings/panels/use-worktree-delete-run";
+
+const WORKTREE_DELETE_PROGRESS_TOAST_ID = "worktree-delete-progress";
+
+export function WorktreeDeleteProgressToastBridge(): null {
+  const summary = useWorktreeDeleteProgressSummary();
+  const lastToastKeyRef = useRef<string | null>(null);
+  // Whether the toast currently on screen is one that will NOT expire on its
+  // own: the in-progress loading toast and the failure toast both use
+  // `duration: Infinity`. A plain success toast keeps its short default
+  // duration. Tracked so that when the runs drain we dismiss the former two but
+  // leave a success toast to live out its time.
+  const lastToastPersistentRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (summary.total === 0) {
+      if (lastToastPersistentRef.current) {
+        toast.dismiss(WORKTREE_DELETE_PROGRESS_TOAST_ID);
+      }
+      lastToastKeyRef.current = null;
+      lastToastPersistentRef.current = false;
+      return;
+    }
+
+    const toastKey = worktreeDeleteToastKey(summary);
+    if (lastToastKeyRef.current === toastKey) return;
+    lastToastKeyRef.current = toastKey;
+    lastToastPersistentRef.current = summary.active > 0 || summary.failed > 0;
+    showWorktreeDeleteProgressToast(summary);
+  }, [summary]);
+
+  return null;
+}
+
+function showWorktreeDeleteProgressToast(
+  summary: WorktreeDeleteProgressSummary,
+): void {
+  const description = worktreeDeleteProgressDetail(summary);
+  if (summary.active > 0) {
+    toast.loading("Deleting worktrees", {
+      id: WORKTREE_DELETE_PROGRESS_TOAST_ID,
+      description,
+      duration: Infinity,
+    });
+    return;
+  }
+  if (summary.failed === 0) {
+    toast.success(`Deleted ${worktreeCountLabel(summary.deleted)}`, {
+      id: WORKTREE_DELETE_PROGRESS_TOAST_ID,
+      description,
+    });
+    return;
+  }
+  // A failure toast persists (no auto-expiry) and is directly dismissable, so a
+  // user who never reopens the Worktrees panel to dismiss the strip can still
+  // clear it.
+  toast.error(worktreeDeleteFailureTitle(summary), {
+    id: WORKTREE_DELETE_PROGRESS_TOAST_ID,
+    description,
+    duration: Infinity,
+    closeButton: true,
+  });
+}
+
+function worktreeDeleteToastKey(
+  summary: WorktreeDeleteProgressSummary,
+): string {
+  const phase = summary.active > 0 ? "active" : "terminal";
+  return [
+    phase,
+    summary.total,
+    summary.deleted,
+    summary.failed,
+    summary.active,
+  ].join(":");
+}
+
+function worktreeDeleteFailureTitle(
+  summary: WorktreeDeleteProgressSummary,
+): string {
+  if (summary.deleted === 0) {
+    return `Couldn't delete ${worktreeCountLabel(summary.total)}`;
+  }
+  return `Deleted ${summary.deleted} of ${worktreeCountLabel(summary.total)}`;
+}
+
+function worktreeCountLabel(count: number): string {
+  return count === 1 ? "1 worktree" : `${count} worktrees`;
+}

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -82,6 +82,13 @@ function stubStreamClient(): WsStreamClient<HostStreamRpcRegistry> {
   });
 }
 
+function stubOpenStreamTransport() {
+  return {
+    wsStreamClient: stubStreamClient(),
+    close: vi.fn(),
+  };
+}
+
 function entry(
   over: Partial<WorktreeHostEntry> & { worktreePath: string; branch: string },
 ): WorktreeHostEntry {
@@ -137,7 +144,7 @@ function renderList(args: {
   return render(
     <Wrapper>
       <WorktreesList
-        streamClient={stubStreamClient()}
+        openStreamTransport={() => stubOpenStreamTransport()}
         hostId={args.hostId}
         worktrees={args.worktrees}
         toolbarProps={testToolbarProps()}
@@ -436,6 +443,8 @@ describe("WorktreesList delete flow", () => {
     fireEvent.click(screen.getByTestId("confirm-action"));
 
     expect(streamMock.paths).toEqual(["/wt/clean", "/wt/dirty"]);
+    screen.getByText("Deleting worktrees");
+    screen.getByText("0/2 deleted");
     expect(screen.queryByTestId("worktree-delete-progress-modal")).toBeNull();
     expect(screen.getAllByTestId("worktree-row-deleting-spinner")).toHaveLength(
       2,
@@ -472,6 +481,7 @@ describe("WorktreesList delete flow", () => {
     fireEvent.click(screen.getByTestId("confirm-action"));
 
     expect(streamMock.paths).toEqual(["/wt/clean", "/wt/dirty"]);
+    screen.getByText("0/3 deleted");
     expect(screen.getAllByTestId("worktree-row-deleting-spinner")).toHaveLength(
       3,
     );
@@ -487,6 +497,7 @@ describe("WorktreesList delete flow", () => {
       callbacksFor("/wt/clean").onComplete(true);
     });
 
+    screen.getByText("1/3 deleted");
     expect(streamMock.paths).toEqual([
       "/wt/clean",
       "/wt/dirty",
@@ -500,6 +511,7 @@ describe("WorktreesList delete flow", () => {
     act(() => {
       callbacksFor("/wt/dirty").onComplete(true);
     });
+    screen.getByText("2/3 deleted");
     expect(screen.getAllByTestId("worktree-row-deleting-spinner")).toHaveLength(
       3,
     );
@@ -508,6 +520,7 @@ describe("WorktreesList delete flow", () => {
     act(() => {
       callbacksFor("/wt/api-clean").onComplete(true);
     });
+    screen.getByText("3/3 deleted");
     expect(invalidateSpy).toHaveBeenCalledTimes(
       WORKTREE_BINDING_INVALIDATIONS.length + 2,
     );
@@ -558,9 +571,11 @@ describe("WorktreesList delete flow", () => {
       "/wt/web-clean",
     ]);
     expect(callbacksFor("/wt/web-clean")).toBeDefined();
-    expect(screen.getByTestId("worktree-delete-error").textContent).toContain(
-      "cannot subscribe /wt/api-clean",
-    );
+    // A batch item failing to start is surfaced non-modally in the progress
+    // strip (1 deleted, 1 failed, 2 still running) - it must not pop a modal
+    // over the siblings that are still deleting.
+    expect(screen.queryByTestId("worktree-delete-progress-modal")).toBeNull();
+    screen.getByText("1/4 deleted, 1 failed");
   });
 
   it("shows a plain confirm for a clean worktree", () => {
@@ -663,7 +678,7 @@ describe("WorktreesList delete flow", () => {
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           <WorktreesList
-            streamClient={stubStreamClient()}
+            openStreamTransport={() => stubOpenStreamTransport()}
             hostId="host-b"
             worktrees={WORKTREES}
             toolbarProps={testToolbarProps()}
@@ -709,7 +724,7 @@ describe("WorktreesList delete flow", () => {
     // The worktree's row carries the in-progress treatment and is no longer
     // selectable for deletion.
     expect(screen.getByTestId("worktree-row-deleting-spinner")).not.toBeNull();
-    screen.getByText(/Deleting/);
+    screen.getByText("Deleting…");
     expect(
       screen.queryByRole("button", { name: "Delete worktree feat-clean" }),
     ).toBeNull();
@@ -734,7 +749,32 @@ describe("WorktreesList delete flow", () => {
     renderDefault();
 
     expect(screen.getByTestId("worktree-row-deleting-spinner")).not.toBeNull();
-    screen.getByText(/Deleting/);
+    screen.getByText("Deleting…");
+    expect(
+      screen.queryByRole("button", { name: "Delete worktree feat-clean" }),
+    ).toBeNull();
+  });
+
+  it("backgrounds a foreground delete when the list unmounts", () => {
+    const rendered = renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: WORKTREES,
+    });
+    confirmDelete("feat-clean");
+    act(() => {
+      callbacksFor("/wt/clean").onStarted(true);
+      callbacksFor("/wt/clean").onPhase("teardown");
+    });
+
+    rendered.unmount();
+    expect(streamMock.closeCount).toBe(0);
+
+    renderDefault();
+
+    expect(screen.queryByTestId("worktree-delete-progress-modal")).toBeNull();
+    screen.getByText("0/1 deleted");
+    expect(screen.getByTestId("worktree-row-deleting-spinner")).not.toBeNull();
     expect(
       screen.queryByRole("button", { name: "Delete worktree feat-clean" }),
     ).toBeNull();
@@ -816,7 +856,7 @@ describe("WorktreesList delete flow", () => {
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           <WorktreesList
-            streamClient={stubStreamClient()}
+            openStreamTransport={() => stubOpenStreamTransport()}
             hostId="host-a"
             worktrees={WORKTREES.filter(
               (worktree) => worktree.worktreePath !== "/wt/clean",
@@ -849,5 +889,56 @@ describe("WorktreesList delete flow", () => {
     expect(screen.getByTestId("worktree-delete-error").textContent).toContain(
       "is busy",
     );
+  });
+
+  it("closes a completed foreground delete instead of backgrounding it", () => {
+    renderDefault();
+    confirmDelete("feat-clean");
+    act(() => {
+      streamMock.callbacks?.onStarted(true);
+      streamMock.callbacks?.onComplete(true);
+    });
+    // Terminal success: the modal now offers an explicit Close.
+    screen.getByText("Worktree deleted");
+
+    fireEvent.click(screen.getByTestId("worktree-delete-close-button"));
+
+    // Close fully dismisses the finished delete - it must NOT background it
+    // (which would leave a deleting row and fire a spurious progress strip).
+    expect(screen.queryByTestId("worktree-delete-progress-modal")).toBeNull();
+    expect(screen.queryByTestId("worktree-row-deleting-spinner")).toBeNull();
+    expect(screen.queryByText("1/1 deleted")).toBeNull();
+    screen.getByRole("button", { name: "Delete worktree feat-clean" });
+  });
+
+  it("surfaces a batch failure in the strip without a modal, and Dismiss clears it", () => {
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: WORKTREES,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Select worktrees" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    // Two selectable worktrees go to the background (the in-use one cannot be
+    // selected); one succeeds and one fails.
+    expect(streamMock.paths).toEqual(["/wt/clean", "/wt/dirty"]);
+    act(() => {
+      callbacksFor("/wt/clean").onComplete(true);
+      callbacksFor("/wt/dirty").onFailed("Worktree /wt/dirty is busy");
+    });
+
+    // A batch failure must not pop a modal; it shows in the strip with a count.
+    expect(screen.queryByTestId("worktree-delete-progress-modal")).toBeNull();
+    screen.getByText("Some worktrees couldn't be deleted");
+    screen.getByText("1/2 deleted, 1 failed");
+
+    // The settled-with-failures strip offers an explicit Dismiss that clears it.
+    fireEvent.click(screen.getByTestId("worktree-delete-progress-dismiss"));
+    expect(screen.queryByText("1/2 deleted, 1 failed")).toBeNull();
+    expect(screen.queryByTestId("worktree-delete-progress-dismiss")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
+++ b/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
@@ -10,6 +10,8 @@ import type { WorktreeEntryScripts } from "@traycer/protocol/host/worktree-schem
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import { WorktreeDeleteStreamClient } from "@traycer-clients/shared/host-transport/worktree-delete-stream-client";
+import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
+import { openOwnedDurableStreamClient } from "@/lib/host/owned-durable-stream-client";
 
 export interface LogSegment {
   /** Monotonic per-run id (append-only), so React keys are stable. */
@@ -45,16 +47,23 @@ const QUEUED_RUN: WorktreeDeleteRunState = {
 // Each stream can run teardown scripts plus git removal; cap fanout so a large
 // multi-repo selection cannot saturate the host or websocket transport.
 const MAX_PARALLEL_DELETE_STREAMS = 2;
-const UNREACHABLE_MESSAGE = "This host is no longer reachable.";
 const CONNECTION_LOST_MESSAGE =
   "Lost connection to the host before the delete finished.";
 
 export interface WorktreeDeleteRunRecord {
   readonly key: string;
   readonly hostId: string;
+  readonly batchKey: string | null;
   readonly target: WorktreeHostEntry;
   readonly run: WorktreeDeleteRunState;
   readonly backgrounded: boolean;
+}
+
+export interface WorktreeDeleteProgressSummary {
+  readonly total: number;
+  readonly deleted: number;
+  readonly failed: number;
+  readonly active: number;
 }
 
 interface WorktreeDeleteRunStore {
@@ -63,6 +72,7 @@ interface WorktreeDeleteRunStore {
   readonly begin: (input: {
     readonly key: string;
     readonly hostId: string;
+    readonly batchKey: string | null;
     readonly target: WorktreeHostEntry;
     readonly run: WorktreeDeleteRunState;
     readonly backgrounded: boolean;
@@ -74,6 +84,9 @@ interface WorktreeDeleteRunStore {
   readonly completeRun: (key: string, deleted: boolean) => void;
   readonly failRun: (key: string, error: string) => void;
   readonly setBackgrounded: (key: string, backgrounded: boolean) => void;
+  readonly backgroundForegroundForHost: (hostId: string) => void;
+  readonly clearTerminalBackgroundedForHost: (hostId: string) => void;
+  readonly clearSettledSuccessesForHostIfQuiescent: (hostId: string) => void;
   readonly clearCompletedDeletedMissingFromList: (
     hostId: string,
     visibleWorktreePaths: ReadonlySet<string>,
@@ -90,6 +103,7 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
       runs: upsertRun(state.runs, {
         key: input.key,
         hostId: input.hostId,
+        batchKey: input.batchKey,
         target: input.target,
         run: input.run,
         backgrounded: input.backgrounded,
@@ -119,8 +133,14 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
         runs: state.runs.map((candidate) =>
           candidate.key === key ? updated : candidate,
         ),
+        // Re-surface a SINGLE backgrounded delete's modal on a soft failure so
+        // the user sees why. A batch item (`batchKey !== null`) stays in the
+        // background - popping a modal over the still-running siblings is the
+        // bug we are avoiding; its failure shows in the progress strip/toast.
         foregroundKey:
-          record.backgrounded && !deleted ? key : state.foregroundKey,
+          record.backgrounded && !deleted && record.batchKey === null
+            ? key
+            : state.foregroundKey,
       };
     }),
   failRun: (key, error) =>
@@ -143,7 +163,13 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
               }
             : candidate,
         ),
-        foregroundKey: record.backgrounded ? key : state.foregroundKey,
+        // Same rule as `completeRun`: re-surface a single backgrounded delete's
+        // modal on failure, but never pop one for a batch item - batch failures
+        // surface non-modally in the progress strip/toast.
+        foregroundKey:
+          record.backgrounded && record.batchKey === null
+            ? key
+            : state.foregroundKey,
       };
     }),
   setBackgrounded: (key, backgrounded) =>
@@ -156,6 +182,83 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
           ? null
           : state.foregroundKey,
     })),
+  backgroundForegroundForHost: (hostId) =>
+    set((state) => {
+      const key = state.foregroundKey;
+      if (key === null) return state;
+      const record = state.runs.find(
+        (candidate) => candidate.key === key && candidate.hostId === hostId,
+      );
+      if (record === undefined || worktreeRunIsTerminal(record.run)) {
+        return state;
+      }
+      return {
+        runs: state.runs.map((candidate) =>
+          candidate.key === key
+            ? { ...candidate, backgrounded: true }
+            : candidate,
+        ),
+        foregroundKey: null,
+      };
+    }),
+  // Acknowledge path for the per-host progress strip: drop every settled
+  // (deleted / failed / soft-failed) backgrounded run for the host so a batch
+  // that finished with failures stops occupying the strip and the app-wide
+  // toast.
+  clearTerminalBackgroundedForHost: (hostId) =>
+    set((state) => {
+      const runs = state.runs.filter(
+        (record) =>
+          !(
+            record.hostId === hostId &&
+            record.backgrounded &&
+            worktreeRunIsTerminal(record.run)
+          ),
+      );
+      if (runs.length === state.runs.length) return state;
+      return {
+        runs,
+        foregroundKey:
+          state.foregroundKey !== null &&
+          !runs.some((record) => record.key === state.foregroundKey)
+            ? null
+            : state.foregroundKey,
+      };
+    }),
+  // Drop a host's successfully-deleted backgrounded runs when nothing for that
+  // host is still in flight. The mounted list prunes these via
+  // `clearCompletedDeletedMissingFromList`, but a host the user has navigated
+  // away from has no mounted list, so without this its successes linger in the
+  // app-wide toast forever. Gated on quiescence so it never drops the deleted
+  // tally of a batch that is still running.
+  clearSettledSuccessesForHostIfQuiescent: (hostId) =>
+    set((state) => {
+      const hostBackgrounded = state.runs.filter(
+        (record) => record.hostId === hostId && record.backgrounded,
+      );
+      const anyActive = hostBackgrounded.some(
+        (record) => !worktreeRunIsTerminal(record.run),
+      );
+      if (anyActive) return state;
+      const runs = state.runs.filter(
+        (record) =>
+          !(
+            record.hostId === hostId &&
+            record.backgrounded &&
+            record.run.status === "complete" &&
+            record.run.deleted
+          ),
+      );
+      if (runs.length === state.runs.length) return state;
+      return {
+        runs,
+        foregroundKey:
+          state.foregroundKey !== null &&
+          !runs.some((record) => record.key === state.foregroundKey)
+            ? null
+            : state.foregroundKey,
+      };
+    }),
   clearCompletedDeletedMissingFromList: (hostId, visibleWorktreePaths) =>
     set((state) => {
       const runs = state.runs.filter((record) => {
@@ -190,13 +293,14 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
  * pair owns its own stream, so backgrounding one delete does not release or
  * overwrite another in-flight delete.
  */
-const clientRefs = new Map<string, WorktreeDeleteStreamClient>();
+const clientRefs = new Map<string, { close(): void }>();
 
 interface QueuedWorktreeDelete {
   readonly key: string;
+  readonly hostId: string;
   readonly target: WorktreeHostEntry;
   readonly scripts: WorktreeEntryScripts | null;
-  readonly streamClient: WsStreamClient<HostStreamRpcRegistry>;
+  readonly openStreamTransport: (hostId: string) => DurableStreamTransport;
   readonly onSettled: () => void;
 }
 
@@ -216,7 +320,7 @@ const pendingSettledCallbacks = new Set<() => void>();
  */
 export function useWorktreeDeleteRun(
   hostId: string,
-  streamClient: WsStreamClient<HostStreamRpcRegistry> | null,
+  openStreamTransport: (hostId: string) => DurableStreamTransport,
   onSettled: () => void,
 ): {
   readonly target: WorktreeHostEntry | null;
@@ -227,15 +331,16 @@ export function useWorktreeDeleteRun(
     target: WorktreeHostEntry,
     scripts: WorktreeEntryScripts | null,
   ) => void;
-  readonly startBackgrounded: (
-    target: WorktreeHostEntry,
-    scripts: WorktreeEntryScripts | null,
+  readonly startBatchBackgrounded: (
+    targets: ReadonlyArray<WorktreeHostEntry>,
+    scriptsByPath: ReadonlyMap<string, WorktreeEntryScripts>,
   ) => void;
   readonly clearCompletedDeletedMissingFromList: (
     visibleWorktreePaths: ReadonlySet<string>,
   ) => void;
   readonly background: () => void;
   readonly close: () => void;
+  readonly dismissTerminalBackgrounded: () => void;
 } {
   const { runs, foregroundKey, begin, setBackgrounded, clear } =
     useWorktreeDeleteRunStore(
@@ -281,6 +386,7 @@ export function useWorktreeDeleteRun(
       target: WorktreeHostEntry,
       scripts: WorktreeEntryScripts | null,
       backgrounded: boolean,
+      batchKey: string | null,
     ) => {
       const key = worktreeDeleteRunKey(hostId, target.worktreePath);
       if (
@@ -293,43 +399,41 @@ export function useWorktreeDeleteRun(
       // redirect the cache invalidation to the wrong host scope (the live
       // `onSettledRef` would otherwise rebind to the newly-selected host).
       const onSettled = onSettledRef.current;
-      if (streamClient === null) {
-        begin({
-          key,
-          hostId,
-          target,
-          backgrounded: false,
-          run: {
-            ...INITIAL_RUN,
-            status: "failed",
-            error: UNREACHABLE_MESSAGE,
-          },
-        });
-        return;
-      }
-      begin({ key, hostId, target, run: QUEUED_RUN, backgrounded });
+      begin({ key, hostId, batchKey, target, run: QUEUED_RUN, backgrounded });
       queuedDeletes.push({
         key,
+        hostId,
         target,
         scripts,
-        streamClient,
+        openStreamTransport,
         onSettled,
       });
       drainDeleteQueue();
     },
-    [begin, hostId, streamClient],
+    [begin, hostId, openStreamTransport],
   );
   const start = useCallback(
     (target: WorktreeHostEntry, scripts: WorktreeEntryScripts | null) => {
-      startDelete(target, scripts, false);
+      startDelete(target, scripts, false, null);
     },
     [startDelete],
   );
-  const startBackgrounded = useCallback(
-    (target: WorktreeHostEntry, scripts: WorktreeEntryScripts | null) => {
-      startDelete(target, scripts, true);
+  const startBatchBackgrounded = useCallback(
+    (
+      targets: ReadonlyArray<WorktreeHostEntry>,
+      scriptsByPath: ReadonlyMap<string, WorktreeEntryScripts>,
+    ) => {
+      const batchKey = nextWorktreeDeleteBatchKey(hostId);
+      targets.forEach((target) => {
+        startDelete(
+          target,
+          scriptsByPath.get(target.worktreePath) ?? null,
+          true,
+          batchKey,
+        );
+      });
     },
-    [startDelete],
+    [hostId, startDelete],
   );
   const clearCompletedDeletedMissingFromList = useCallback(
     (visibleWorktreePaths: ReadonlySet<string>): void => {
@@ -337,6 +441,9 @@ export function useWorktreeDeleteRun(
     },
     [clearCompletedDeletedMissingFromStore, hostId],
   );
+  const dismissTerminalBackgrounded = useCallback(() => {
+    clearTerminalBackgroundedWorktreeDeletesForHost(hostId);
+  }, [hostId]);
 
   return {
     target: visibleRecord?.target ?? null,
@@ -344,10 +451,11 @@ export function useWorktreeDeleteRun(
     backgrounded: visibleRecord?.backgrounded ?? false,
     runs: visibleRuns,
     start,
-    startBackgrounded,
+    startBatchBackgrounded,
     clearCompletedDeletedMissingFromList,
     background,
     close,
+    dismissTerminalBackgrounded,
   };
 }
 
@@ -357,7 +465,58 @@ export function __resetWorktreeDeleteRunForTests(): void {
   queuedDeletes.length = 0;
   activeDeleteStreamCount = 0;
   pendingSettledCallbacks.clear();
+  batchSequence = 0;
   useWorktreeDeleteRunStore.getState().clearAll();
+}
+
+export function useWorktreeDeleteProgressSummary(): WorktreeDeleteProgressSummary {
+  // `summarizeProgress` builds a fresh object each call, so compare the result
+  // shallowly: without this the selector returns a new reference every render,
+  // which makes `useSyncExternalStore` re-render in an infinite loop.
+  return useWorktreeDeleteRunStore(
+    useShallow((state) =>
+      summarizeProgress(state.runs.filter((record) => record.backgrounded)),
+    ),
+  );
+}
+
+export function summarizeWorktreeDeleteRuns(
+  runs: readonly WorktreeDeleteRunRecord[],
+): WorktreeDeleteProgressSummary {
+  return summarizeProgress(runs.filter((record) => record.backgrounded));
+}
+
+export function backgroundForegroundWorktreeDeleteForHost(
+  hostId: string,
+): void {
+  useWorktreeDeleteRunStore.getState().backgroundForegroundForHost(hostId);
+}
+
+export function clearTerminalBackgroundedWorktreeDeletesForHost(
+  hostId: string,
+): void {
+  useWorktreeDeleteRunStore.getState().clearTerminalBackgroundedForHost(hostId);
+}
+
+export function clearSettledWorktreeDeleteSuccessesForHostIfQuiescent(
+  hostId: string,
+): void {
+  useWorktreeDeleteRunStore
+    .getState()
+    .clearSettledSuccessesForHostIfQuiescent(hostId);
+}
+
+/**
+ * Detail line shared by the in-panel progress strip and the app-wide progress
+ * toast so the two surfaces cannot drift (e.g. one pluralizing "failed"). Reads
+ * "2/5 deleted" or "2/5 deleted, 1 failed".
+ */
+export function worktreeDeleteProgressDetail(
+  summary: WorktreeDeleteProgressSummary,
+): string {
+  const base = `${summary.deleted}/${summary.total} deleted`;
+  if (summary.failed === 0) return base;
+  return `${base}, ${summary.failed} failed`;
 }
 
 function drainDeleteQueue(): void {
@@ -392,46 +551,58 @@ function startQueuedDelete(item: QueuedWorktreeDelete): void {
   };
 
   try {
-    const client = new WorktreeDeleteStreamClient({
-      wsStreamClient: item.streamClient,
-      worktreePath: item.target.worktreePath,
-      scripts: item.scripts,
-      callbacks: {
-        onStarted: (hasTeardown) =>
-          useWorktreeDeleteRunStore
-            .getState()
-            .updateRun(item.key, (run) => ({ ...run, hasTeardown })),
-        onPhase: (phase) =>
-          useWorktreeDeleteRunStore
-            .getState()
-            .updateRun(item.key, (run) => ({ ...run, activePhase: phase })),
-        onOutput: (channel, chunk) =>
-          useWorktreeDeleteRunStore.getState().updateRun(item.key, (run) => ({
-            ...run,
-            log: [...run.log, { id: run.log.length, channel, text: chunk }],
-          })),
-        onComplete: (deleted) => {
-          useWorktreeDeleteRunStore.getState().completeRun(item.key, deleted);
-          closeDeleteClient(item.key);
-          settle();
-        },
-        onFailed: (reason) => {
-          useWorktreeDeleteRunStore.getState().failRun(item.key, reason);
-          closeDeleteClient(item.key);
-          settle();
-        },
-        onConnectionStatus: (status, reason) => {
-          // Only a drop BEFORE a terminal app frame is an error; a caller close
-          // after terminal frames is a no-op because `settle` is idempotent.
-          if (status !== "closed" || reason === null) return;
-          useWorktreeDeleteRunStore
-            .getState()
-            .failRun(item.key, CONNECTION_LOST_MESSAGE);
-          closeDeleteClient(item.key);
-          settle();
-        },
-      },
-    });
+    const client = openOwnedDurableStreamClient(
+      item.openStreamTransport,
+      item.hostId,
+      (wsStreamClient: WsStreamClient<HostStreamRpcRegistry>) =>
+        new WorktreeDeleteStreamClient({
+          wsStreamClient,
+          worktreePath: item.target.worktreePath,
+          scripts: item.scripts,
+          callbacks: {
+            onStarted: (hasTeardown) =>
+              useWorktreeDeleteRunStore
+                .getState()
+                .updateRun(item.key, (run) => ({ ...run, hasTeardown })),
+            onPhase: (phase) =>
+              useWorktreeDeleteRunStore
+                .getState()
+                .updateRun(item.key, (run) => ({ ...run, activePhase: phase })),
+            onOutput: (channel, chunk) =>
+              useWorktreeDeleteRunStore
+                .getState()
+                .updateRun(item.key, (run) => ({
+                  ...run,
+                  log: [
+                    ...run.log,
+                    { id: run.log.length, channel, text: chunk },
+                  ],
+                })),
+            onComplete: (deleted) => {
+              useWorktreeDeleteRunStore
+                .getState()
+                .completeRun(item.key, deleted);
+              closeDeleteClient(item.key);
+              settle();
+            },
+            onFailed: (reason) => {
+              useWorktreeDeleteRunStore.getState().failRun(item.key, reason);
+              closeDeleteClient(item.key);
+              settle();
+            },
+            onConnectionStatus: (status, reason) => {
+              // Only a terminal stream close BEFORE an app-level terminal frame
+              // is an error. Recoverable reconnects surface as "reconnecting".
+              if (status !== "closed" || reason === null) return;
+              useWorktreeDeleteRunStore
+                .getState()
+                .failRun(item.key, CONNECTION_LOST_MESSAGE);
+              closeDeleteClient(item.key);
+              settle();
+            },
+          },
+        }),
+    );
     clientRefs.set(item.key, client);
   } catch (error) {
     useWorktreeDeleteRunStore
@@ -450,6 +621,61 @@ function closeDeleteClient(key: string): void {
   const client = clientRefs.get(key);
   clientRefs.delete(key);
   client?.close();
+}
+
+function summarizeProgress(
+  runs: readonly WorktreeDeleteRunRecord[],
+): WorktreeDeleteProgressSummary {
+  const scopedRuns = activeProgressScope(runs);
+  const total = scopedRuns.length;
+  const deleted = scopedRuns.filter(
+    (record) => record.run.status === "complete" && record.run.deleted,
+  ).length;
+  const failed = scopedRuns.filter(
+    (record) =>
+      record.run.status === "failed" ||
+      (record.run.status === "complete" && !record.run.deleted),
+  ).length;
+  return {
+    total,
+    deleted,
+    failed,
+    active: Math.max(0, total - deleted - failed),
+  };
+}
+
+function worktreeRunIsTerminal(run: WorktreeDeleteRunState): boolean {
+  return run.status === "complete" || run.status === "failed";
+}
+
+function activeProgressScope(
+  runs: readonly WorktreeDeleteRunRecord[],
+): readonly WorktreeDeleteRunRecord[] {
+  const groups = progressGroups(runs);
+  const activeGroups = groups.filter((group) =>
+    group.some((record) => !worktreeRunIsTerminal(record.run)),
+  );
+  if (activeGroups.length > 0) {
+    return activeGroups.flatMap((group) => group);
+  }
+  if (groups.length === 0) return [];
+  return groups[groups.length - 1];
+}
+
+function progressGroups(
+  runs: readonly WorktreeDeleteRunRecord[],
+): ReadonlyArray<ReadonlyArray<WorktreeDeleteRunRecord>> {
+  const groups = new Map<string, WorktreeDeleteRunRecord[]>();
+  runs.forEach((record) => {
+    const key = record.batchKey ?? record.key;
+    const existing = groups.get(key);
+    if (existing === undefined) {
+      groups.set(key, [record]);
+      return;
+    }
+    existing.push(record);
+  });
+  return [...groups.values()];
 }
 
 function flushSettledCallbacksIfIdle(): void {
@@ -478,4 +704,11 @@ function shouldShowProgress(record: WorktreeDeleteRunRecord): boolean {
 
 function worktreeDeleteRunKey(hostId: string, worktreePath: string): string {
   return `${hostId}\u0000${worktreePath}`;
+}
+
+let batchSequence = 0;
+
+function nextWorktreeDeleteBatchKey(hostId: string): string {
+  batchSequence += 1;
+  return `${hostId}\u0000batch\u0000${batchSequence}`;
 }

--- a/clients/gui-app/src/components/settings/panels/worktree-delete-progress-modal.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-delete-progress-modal.tsx
@@ -24,13 +24,12 @@ export interface WorktreeDeleteProgressModalProps {
 }
 
 /**
- * Progress card for a worktree delete, shown inside a section-scoped modal that
- * covers only the Worktrees settings window (never the whole screen). It shows
- * a phased step indicator (teardown → remove) and, when a teardown script runs,
- * a collapsible pane streaming its stdout/stderr. While the delete is running
- * the action reads "Run in background", which dismisses the modal and lets the
- * worktree's row carry the in-progress state; once terminal it offers an
- * explicit Close.
+ * Progress card for a worktree delete, shown inside the viewport-anchored
+ * Worktrees delete overlay. It shows a phased step indicator (teardown →
+ * remove) and, when a teardown script runs, a collapsible pane streaming its
+ * stdout/stderr. While the delete is running the action reads
+ * "Run in background", which dismisses the modal and lets the worktree's row
+ * carry the in-progress state; once terminal it offers an explicit Close.
  */
 export function WorktreeDeleteProgressModal(
   props: WorktreeDeleteProgressModalProps,

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -22,10 +22,8 @@ import {
 } from "lucide-react";
 import type { WorktreeHostEntry } from "@traycer/protocol/host/index";
 import type { WorktreeEntryScripts } from "@traycer/protocol/host/worktree-schemas";
-import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
-import type { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import { cn } from "@/lib/utils";
 import {
   withMemberAdded,
@@ -55,13 +53,19 @@ import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-i
 import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query";
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
 import { useHostClientFor } from "@/hooks/host/use-host-client-for";
-import { useHostStreamClientFor } from "@/hooks/host/use-host-stream-client-for";
 import { useHostQuery } from "@/hooks/host/use-host-query";
+import { useWorktreeDeleteStreamTransportFactory } from "@/lib/host/use-worktree-delete-stream-transport";
+import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
 import { WORKTREE_BINDING_INVALIDATIONS } from "@/hooks/worktree/invalidations";
 import {
+  backgroundForegroundWorktreeDeleteForHost,
+  clearSettledWorktreeDeleteSuccessesForHostIfQuiescent,
+  summarizeWorktreeDeleteRuns,
   useWorktreeDeleteRun,
+  worktreeDeleteProgressDetail,
   type WorktreeDeleteRunState,
+  type WorktreeDeleteProgressSummary,
 } from "@/components/settings/panels/use-worktree-delete-run";
 import { WorktreeDeleteProgressModal } from "@/components/settings/panels/worktree-delete-progress-modal";
 
@@ -95,9 +99,12 @@ export function WorktreesSettingsPanel(): ReactNode {
     [hosts, effectiveId],
   );
   const client = useHostClientFor(selectedEntry);
-  // One-shot `worktree.deleteByPath` stream: no auth revalidator, a terminal
-  // auth rejection surfaces the failure rather than silently reconnecting.
-  const streamClient = useHostStreamClientFor(selectedEntry, null);
+  // One-shot `worktree.deleteByPath` stream transport: it survives the panel
+  // unmounting (a backgrounded delete keeps its socket) but wires no proactive
+  // reconnect and no auth revalidation, so an OS wake / host respawn does not
+  // silently re-subscribe and re-run the delete pipeline. A dropped socket
+  // surfaces the failure instead.
+  const openStreamTransport = useWorktreeDeleteStreamTransportFactory();
 
   return (
     <SettingsPanelShell
@@ -107,7 +114,7 @@ export function WorktreesSettingsPanel(): ReactNode {
     >
       <WorktreesBody
         client={client}
-        streamClient={streamClient}
+        openStreamTransport={openStreamTransport}
         hostId={effectiveId}
         hosts={hosts}
         value={effectiveId}
@@ -193,13 +200,13 @@ function HostSelect(props: {
 
 function WorktreesBody(props: {
   readonly client: HostClient<HostRpcRegistry> | null;
-  readonly streamClient: WsStreamClient<HostStreamRpcRegistry> | null;
+  readonly openStreamTransport: (hostId: string) => DurableStreamTransport;
   readonly hostId: string | null;
   readonly hosts: readonly HostDirectoryEntry[];
   readonly value: string | null;
   readonly onChange: (hostId: string) => void;
 }): ReactNode {
-  const { client, streamClient, hostId, hosts, value, onChange } = props;
+  const { client, openStreamTransport, hostId, hosts, value, onChange } = props;
   const reachability = useHostReachability(hostId ?? "");
   const reachable = hostId !== null && reachability.status === "reachable";
   const listQuery = useHostQuery({
@@ -267,7 +274,7 @@ function WorktreesBody(props: {
     listOwnsToolbar = true;
     content = (
       <WorktreesList
-        streamClient={streamClient}
+        openStreamTransport={openStreamTransport}
         hostId={hostId}
         worktrees={listQuery.data.worktrees}
         toolbarProps={toolbarProps}
@@ -291,7 +298,7 @@ function WorktreesBody(props: {
 // actions); branches are independent, not reducible nesting.
 // eslint-disable-next-line complexity
 export function WorktreesList(props: {
-  readonly streamClient: WsStreamClient<HostStreamRpcRegistry> | null;
+  readonly openStreamTransport: (hostId: string) => DurableStreamTransport;
   readonly hostId: string;
   readonly worktrees: readonly WorktreeHostEntry[];
   readonly toolbarProps: {
@@ -303,7 +310,7 @@ export function WorktreesList(props: {
     readonly canRefresh: boolean;
   };
 }): ReactNode {
-  const { hostId, worktrees, streamClient } = props;
+  const { hostId, worktrees, openStreamTransport } = props;
   const queryClient = useQueryClient();
 
   // Refresh the host-wide list plus the shared worktree/binding caches the
@@ -319,11 +326,12 @@ export function WorktreesList(props: {
     backgrounded,
     runs,
     start,
-    startBackgrounded,
+    startBatchBackgrounded,
     clearCompletedDeletedMissingFromList,
     background,
     close,
-  } = useWorktreeDeleteRun(hostId, streamClient, invalidate);
+    dismissTerminalBackgrounded,
+  } = useWorktreeDeleteRun(hostId, openStreamTransport, invalidate);
   const [selectedPaths, setSelectedPaths] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -407,6 +415,22 @@ export function WorktreesList(props: {
     pendingDeleteTargets === null
       ? null
       : deleteDialogCopyForTargets(pendingDeleteTargets);
+  const progressSummary = useMemo(
+    () => summarizeWorktreeDeleteRuns(runs),
+    [runs],
+  );
+  useEffect(
+    () => () => {
+      // The Worktrees view is going away (Settings closed, section switched, or
+      // host swapped). Keep an in-progress foreground delete alive in the
+      // background (the store no-ops if it is already terminal), and drop this
+      // host's settled successes the now-unmounted list can no longer prune -
+      // otherwise they linger in the app-wide progress toast.
+      backgroundForegroundWorktreeDeleteForHost(hostId);
+      clearSettledWorktreeDeleteSuccessesForHostIfQuiescent(hostId);
+    },
+    [hostId],
+  );
 
   const toggleSelection = useCallback(
     (worktreePath: string) => {
@@ -466,12 +490,7 @@ export function WorktreesList(props: {
         reviewedScriptsByPath.get(targets[0].worktreePath) ?? null,
       );
     } else {
-      targets.forEach((target) => {
-        startBackgrounded(
-          target,
-          reviewedScriptsByPath.get(target.worktreePath) ?? null,
-        );
-      });
+      startBatchBackgrounded(targets, reviewedScriptsByPath);
     }
     setSelectedPaths((prev) => removeSelectedWorktrees(prev, targets));
     setSelectionMode(false);
@@ -479,9 +498,13 @@ export function WorktreesList(props: {
   };
 
   const handleCloseModal = (): void => {
-    // While running, the action backgrounds the delete: keep the stream alive
-    // and let the row carry progress. Once terminal, it closes for good.
-    if (run !== null && worktreeRowDeleteStatus(run) !== null) {
+    // While the delete is still running, "Run in background" keeps the stream
+    // alive and lets the row carry progress. Once terminal - success OR failure
+    // - "Close" tears it down for good. Gate on the live run status, NOT
+    // `worktreeRowDeleteStatus` (which reports a just-deleted complete run as
+    // still "deleting"): otherwise clicking "Close" on a finished delete would
+    // background it and fire a spurious progress toast instead of dismissing.
+    if (run !== null && (run.status === "queued" || run.status === "running")) {
       background();
       return;
     }
@@ -502,12 +525,12 @@ export function WorktreesList(props: {
   return (
     <div className="flex flex-col">
       {confirmed !== null && run !== null ? (
-        <div className="absolute inset-0 z-20 flex items-center justify-center p-4">
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
           <div
             aria-hidden
             className="absolute inset-0 bg-background/80 backdrop-blur-sm"
           />
-          <div className="relative z-10 max-h-full w-[min(100%,32rem)] overflow-y-auto rounded-lg border border-border/60 bg-card shadow-lg">
+          <div className="relative z-10 max-h-[min(80vh,40rem)] w-[min(92vw,32rem)] overflow-y-auto rounded-lg border border-border/60 bg-card shadow-lg">
             <WorktreeDeleteProgressModal
               target={confirmed}
               run={run}
@@ -539,6 +562,10 @@ export function WorktreesList(props: {
           </>
         }
       />
+      <WorktreeDeleteProgressStrip
+        summary={progressSummary}
+        onDismiss={dismissTerminalBackgrounded}
+      />
 
       {groups.map((group) => {
         const collapsed = collapsedRepoKeys.has(group.key);
@@ -557,8 +584,8 @@ export function WorktreesList(props: {
               <div className="flex flex-col divide-y divide-border/30">
                 {group.items.map((entry) => {
                   // The row carries the in-progress treatment only once the delete
-                  // is sent to the background; while the scoped modal is up
-                  // (foreground) the modal alone shows progress - no duplication.
+                  // is sent to the background; while the foreground modal is up
+                  // the modal alone shows progress - no duplication.
                   const deleteStatus =
                     backgroundedDeleteStatusByPath.get(entry.worktreePath) ??
                     null;
@@ -613,6 +640,49 @@ export function WorktreesList(props: {
       />
     </div>
   );
+}
+
+function WorktreeDeleteProgressStrip(props: {
+  readonly summary: WorktreeDeleteProgressSummary;
+  readonly onDismiss: () => void;
+}): ReactNode {
+  if (props.summary.total === 0) return null;
+  // Once nothing is in flight, a batch that ended with failures stays put so the
+  // user notices; offer an explicit Dismiss to clear it (and the app-wide toast)
+  // rather than leaving it stuck forever.
+  const showDismiss = props.summary.active === 0 && props.summary.failed > 0;
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/40 bg-muted/20 px-5 py-2">
+      <span className="text-ui-sm font-medium text-foreground">
+        {worktreeDeleteProgressTitle(props.summary)}
+      </span>
+      <div className="flex items-center gap-3">
+        <span className="text-ui-xs text-muted-foreground">
+          {worktreeDeleteProgressDetail(props.summary)}
+        </span>
+        {showDismiss ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={props.onDismiss}
+            data-testid="worktree-delete-progress-dismiss"
+          >
+            Dismiss
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function worktreeDeleteProgressTitle(
+  summary: WorktreeDeleteProgressSummary,
+): string {
+  if (summary.active > 0) return "Deleting worktrees";
+  if (summary.failed === 0) return "Worktrees deleted";
+  if (summary.deleted === 0) return "Couldn't delete worktrees";
+  return "Some worktrees couldn't be deleted";
 }
 
 type WorktreeScriptReviewDraft = {

--- a/clients/gui-app/src/lib/host/one-shot-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/one-shot-stream-transport.ts
@@ -1,0 +1,51 @@
+import type { BearerSourceProvider } from "@traycer-clients/shared/auth/bearer-source";
+import type { HostEndpointProvider } from "@traycer-clients/shared/host-transport/ws-rpc-client";
+import { buildHostStreamClient } from "@/hooks/host/use-host-stream-client-for";
+import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
+import { appLogger } from "@/lib/logger";
+
+/**
+ * Builds a module-ownable host stream transport for a ONE-SHOT, side-effecting
+ * host operation (Settings ▸ Worktrees `worktree.deleteByPath`) that must
+ * OUTLIVE the React tile that started it - so a backgrounded delete keeps its
+ * socket when the panel unmounts - but must NOT silently re-issue itself.
+ *
+ * Unlike `openDurableStreamTransport` (the chat / terminal / epic warm sessions)
+ * this deliberately wires NONE of the proactive reconnect triggers:
+ *  - no wake re-dial (`subscribeStreamWakeReconnect`),
+ *  - no endpoint-change re-dial (`subscribeEndpointRedial`),
+ *  - `auth: null`, so an `UNAUTHORIZED` rejection is terminal rather than a
+ *    revalidate-then-redial.
+ *
+ * Every reconnect re-sends the stream's `subscribe` frame, which makes the host
+ * re-run the subscribe handler. For a warm snapshot session that is harmless (it
+ * re-snapshots); for a one-shot delete it would re-execute the teardown script
+ * and git removal - duplicating side effects or failing an already-removed
+ * worktree. So here a dropped socket surfaces the failure instead of being
+ * papered over by a forced re-subscribe. `WsStreamClient` still owns its passive
+ * backoff reconnect; the point is that nothing FORCES a reconnect that re-runs
+ * the delete.
+ *
+ * `endpoint`/`bearer` are read live per dial so a credential rotation is
+ * reflected. The returned `close()` tears down the socket; the owning delete run
+ * calls it exactly once, when the delete settles or is cancelled.
+ */
+export function openOneShotStreamTransport(params: {
+  readonly endpoint: HostEndpointProvider;
+  readonly bearer: BearerSourceProvider;
+}): DurableStreamTransport {
+  const wsStreamClient = buildHostStreamClient({
+    endpoint: params.endpoint,
+    bearer: params.bearer,
+    auth: null,
+  });
+  appLogger.info("[stream] one-shot transport opened", {
+    hasEndpoint: params.endpoint() !== null,
+  });
+  return {
+    wsStreamClient,
+    close: () => {
+      wsStreamClient.close();
+    },
+  };
+}

--- a/clients/gui-app/src/lib/host/use-worktree-delete-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/use-worktree-delete-stream-transport.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useHostClient, useHostDirectory } from "@/lib/host";
+import { openOneShotStreamTransport } from "@/lib/host/one-shot-stream-transport";
+import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
+import { dialableHostEndpoint } from "@/lib/host/transport-key";
+
+/**
+ * Opener for the Settings ▸ Worktrees `worktree.deleteByPath` stream transport.
+ *
+ * The delete is a ONE-SHOT, side-effecting host operation (teardown script + git
+ * removal). It must survive the Worktrees tile unmounting so a backgrounded
+ * delete keeps its socket (ownership lives in `useWorktreeDeleteRun`), but it
+ * must NOT silently re-run if the machine sleeps/wakes or the host respawns -
+ * every reconnect re-sends the stream's `subscribe` frame, which re-runs the
+ * pipeline host-side. So unlike the chat/terminal durable factory this wires no
+ * wake/endpoint re-dial and passes `auth: null` (see `openOneShotStreamTransport`):
+ * a dropped socket surfaces the failure instead of re-issuing the delete.
+ *
+ * `endpoint`/`bearer` are read live per dial through a ref refreshed each render
+ * so a credential rotation is reflected, mirroring the durable factory's
+ * stale-capture-proofing.
+ */
+export function useWorktreeDeleteStreamTransportFactory(): (
+  hostId: string,
+) => DurableStreamTransport {
+  const directory = useHostDirectory();
+  const globalClient = useHostClient();
+  const liveRef = useRef({ directory, globalClient });
+  useEffect(() => {
+    liveRef.current = { directory, globalClient };
+  });
+  return useCallback(
+    (hostId: string) =>
+      openOneShotStreamTransport({
+        endpoint: () =>
+          dialableHostEndpoint(liveRef.current.directory.findById(hostId)),
+        bearer: () =>
+          liveRef.current.globalClient.getRequestContext()?.credentials ?? null,
+      }),
+    [],
+  );
+}

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -1,6 +1,7 @@
 import { HostPicker } from "@/components/layout/header/host-picker";
 import { AppUpdateToastController } from "@/components/layout/bridges/app-update-toast-controller";
 import { RunnerHostBridges } from "@/components/layout/bridges/runner-host-bridges";
+import { WorktreeDeleteProgressToastBridge } from "@/components/layout/bridges/worktree-delete-progress-toast-bridge";
 import { CenteredCard } from "@/components/centered-card";
 import { RootErrorBoundary } from "@/components/errors/root-error-boundary";
 import { Toaster } from "@/components/ui/sonner";
@@ -186,6 +187,7 @@ function TraycerAppRuntimeSurface(props: TraycerAppRuntimeSurfaceProps) {
     <>
       <RunnerHostBridges />
       <AppUpdateToastController />
+      <WorktreeDeleteProgressToastBridge />
       <CliCredentialSeeder />
       <HarnessCatalogPrefetcher />
       <RouterProvider router={props.router} />


### PR DESCRIPTION
## Summary

Bulk and "delete all" worktree removal in **Settings ▸ Worktrees** could lose the
host connection mid-delete (a false "connection lost" error modal) while the
delete kept running in the background, block the worktree list, and push the
progress modal far off-screen on long lists. This makes the delete path reliable
and gives it **persistent progress** that survives closing the panel, switching
settings sections, or moving to another tab.

## Changes

**Reliability**

- Each delete now owns a **one-shot** stream transport. It outlives the Worktrees
  panel (a backgrounded delete keeps its socket), but deliberately wires **no**
  wake-reconnect, **no** endpoint re-dial, and `auth: null`. Every reconnect
  re-sends the stream's `subscribe` frame, which re-runs the host pipeline
  (teardown script + git removal); for a one-shot delete that would duplicate
  side effects or fail an already-removed worktree. A dropped socket now surfaces
  the failure instead of silently re-running.

**In-progress UX (single + multi delete)**

- Count progress ("2/12 deleted") in a persistent per-host strip and an app-wide
  toast that survive navigation.
- Batch failures surface non-modally in the strip/toast with an explicit
  **Dismiss**, instead of popping a modal over still-running siblings. A single
  backgrounded delete still re-surfaces its modal on failure.
- "Close" on a finished delete dismisses it cleanly (gated on the live run
  status) rather than backgrounding it and firing a spurious toast.
- Settled successes on a host you have navigated away from are pruned on unmount
  so they cannot linger in the app-wide toast.
- The foreground delete modal is anchored to the viewport so it stays on-screen
  for long lists.
- Stabilized the progress-summary selector (`useShallow`) to avoid a
  `useSyncExternalStore` render loop.

## Testing

- `bun run compile` — clean
- Full `gui-app` Vitest suite — **415 files / 3155 tests pass** (adds tests for
  batch progress, batch-failure surfacing + Dismiss, close-on-complete, and
  unmount/background handling)
- `eslint --max-warnings 0` on changed files and `react-doctor --scope changed` —
  clean
- `pre-commit run` — all hooks pass
