### PR TITLE
feat: add configurable log levels (Settings → Diagnostics)

### DIFF
--- a/clients/desktop/src/electron-main/app/desktop-log-level.ts
+++ b/clients/desktop/src/electron-main/app/desktop-log-level.ts
@@ -1,0 +1,92 @@
+import log from "electron-log";
+import { app } from "electron";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  DEFAULT_LOG_LEVEL,
+  isLogLevel,
+  type LogLevel,
+} from "@traycer/protocol/config/log-level";
+import { createJsonFileStore } from "./json-file-store";
+
+const STORE_FILE_NAME = "desktop-log-level.json";
+
+interface DesktopLogLevelState {
+  readonly level: LogLevel;
+}
+
+const DEFAULT_STATE: DesktopLogLevelState = { level: DEFAULT_LOG_LEVEL };
+
+function parseState(value: unknown): DesktopLogLevelState {
+  if (value !== null && typeof value === "object") {
+    const obj = value as Partial<DesktopLogLevelState>;
+    if (isLogLevel(obj.level)) return { level: obj.level };
+  }
+  return DEFAULT_STATE;
+}
+
+function storePath(): string {
+  return join(app.getPath("userData"), STORE_FILE_NAME);
+}
+
+// `app.getPath("userData")` is only valid after the app module boots, so the
+// store is created lazily per call rather than at module load (mirrors the GPU
+// preference store).
+function getStore() {
+  return createJsonFileStore<DesktopLogLevelState>(
+    storePath(),
+    DEFAULT_STATE,
+    parseState,
+  );
+}
+
+// electron-log's level vocabulary differs slightly from ours: `trace` maps to
+// its most-verbose `silly`; the rest line up one-to-one.
+type ElectronLogLevel =
+  | "error"
+  | "warn"
+  | "info"
+  | "verbose"
+  | "debug"
+  | "silly";
+const ELECTRON_LOG_LEVEL: Record<LogLevel, ElectronLogLevel> = {
+  trace: "silly",
+  debug: "debug",
+  info: "info",
+  warn: "warn",
+  error: "error",
+};
+
+/**
+ * Applies the desktop threshold to electron-log's file transport — the sink
+ * that persists both the main process's own logs and the renderer's forwarded
+ * console logs into `traycer-desktop.log`. Raising it to `debug` is what support
+ * asks for when collecting a repro.
+ */
+export function applyDesktopLogLevel(level: LogLevel): void {
+  log.transports.file.level = ELECTRON_LOG_LEVEL[level];
+}
+
+/**
+ * Synchronous startup read, before the event loop is pumping (mirrors the GPU
+ * preference). Never throws — a missing or unreadable file yields the default.
+ */
+export function readDesktopLogLevelSync(): LogLevel {
+  try {
+    const raw = readFileSync(storePath(), "utf8");
+    return parseState(JSON.parse(raw)).level;
+  } catch {
+    return DEFAULT_LOG_LEVEL;
+  }
+}
+
+export async function getDesktopLogLevel(): Promise<LogLevel> {
+  return (await getStore().load()).level;
+}
+
+export async function setDesktopLogLevel(level: LogLevel): Promise<LogLevel> {
+  await getStore().save({ level });
+  applyDesktopLogLevel(level);
+  log.info("[log-level] desktop level updated", { level });
+  return level;
+}

--- a/clients/desktop/src/electron-main/app/logger.ts
+++ b/clients/desktop/src/electron-main/app/logger.ts
@@ -2,6 +2,10 @@ import log from "electron-log";
 import { app } from "electron";
 import { join } from "node:path";
 import { isDevBuild } from "../../config";
+import {
+  applyDesktopLogLevel,
+  readDesktopLogLevelSync,
+} from "./desktop-log-level";
 
 export type SafeLogValue =
   | string
@@ -38,7 +42,10 @@ const SENSITIVE_INLINE_VALUE_PATTERN =
 export function initLogger(): void {
   const logPath = resolveDesktopLogPath();
   log.transports.file.resolvePathFn = () => logPath;
-  log.transports.file.level = "info";
+  // The file transport — which persists both our own logs and the renderer's
+  // forwarded console logs — follows the configured desktop level (default
+  // info), so Settings → log level controls what lands in traycer-desktop.log.
+  applyDesktopLogLevel(readDesktopLogLevelSync());
   // Console transport is noisy by design (every IPC + lifecycle log).
   // Shipped builds get the same `info` level the file transport does so
   // electron-log's stdout/stderr capture doesn't leak debug payloads to a

--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -591,6 +591,8 @@ describe("RunnerIpcBridge", () => {
         RunnerHostInvoke.fileSave,
         RunnerHostInvoke.gpuAccelerationGet,
         RunnerHostInvoke.gpuAccelerationSet,
+        RunnerHostInvoke.logLevelsGet,
+        RunnerHostInvoke.logLevelsSet,
       ].sort(),
     );
     bridge.dispose();

--- a/clients/desktop/src/electron-main/ipc/platform-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/platform-ipc.ts
@@ -59,6 +59,16 @@ import { randomUUID } from "node:crypto";
 import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { RunnerIpcBridge } from "./runner-ipc-bridge";
+import {
+  getDesktopLogLevel,
+  setDesktopLogLevel,
+} from "../app/desktop-log-level";
+import { readLogLevels, setLogLevels } from "@traycer/protocol/config/store";
+import { isLogLevel, type LogLevel } from "@traycer/protocol/config/log-level";
+import type {
+  LogLevelScope,
+  LogLevelsSnapshot,
+} from "../../ipc-contracts/platform-types";
 
 /**
  * Registers IPC handlers that expose platform-integration primitives to the
@@ -384,6 +394,58 @@ export function registerPlatformIpc(bridge: RunnerIpcBridge): void {
       return setHardwareAccelerationPreference(enabled !== false);
     },
   );
+
+  bridge.handleInvoke(
+    RunnerHostInvoke.logLevelsGet,
+    (): Promise<LogLevelsSnapshot> => readLogLevelsSnapshot(),
+  );
+
+  bridge.handleInvoke(
+    RunnerHostInvoke.logLevelsSet,
+    async (_event, input: unknown): Promise<LogLevelsSnapshot> => {
+      const { scope, level } = parseLogLevelsSetInput(input);
+      if (scope === "desktop") {
+        await setDesktopLogLevel(level);
+      } else {
+        const levels = await readLogLevels();
+        await setLogLevels(
+          scope === "cli" ? level : levels.cliLogLevel,
+          scope === "host" ? level : levels.hostLogLevel,
+        );
+      }
+      return readLogLevelsSnapshot();
+    },
+  );
+}
+
+async function readLogLevelsSnapshot(): Promise<LogLevelsSnapshot> {
+  const [levels, desktopLogLevel] = await Promise.all([
+    readLogLevels(),
+    getDesktopLogLevel(),
+  ]);
+  return {
+    cliLogLevel: levels.cliLogLevel,
+    hostLogLevel: levels.hostLogLevel,
+    desktopLogLevel,
+  };
+}
+
+function parseLogLevelsSetInput(input: unknown): {
+  readonly scope: LogLevelScope;
+  readonly level: LogLevel;
+} {
+  if (!isRecord(input)) {
+    throw new Error("logLevels:set requires an object payload");
+  }
+  const scope = input.scope;
+  if (scope !== "cli" && scope !== "host" && scope !== "desktop") {
+    throw new Error("logLevels:set requires scope cli|host|desktop");
+  }
+  const level = input.level;
+  if (!isLogLevel(level)) {
+    throw new Error("logLevels:set requires a valid log level");
+  }
+  return { scope, level };
 }
 
 interface TemporaryDroppedFileInput {

--- a/clients/desktop/src/electron-preload/platform-bridge.ts
+++ b/clients/desktop/src/electron-preload/platform-bridge.ts
@@ -9,6 +9,7 @@ import type {
   DisplayTopology,
   FindInPageStopAction,
   FindResultSnapshot,
+  LogLevel,
   LogLevelScope,
   LogLevelsSnapshot,
   PendingCertificateError,
@@ -16,7 +17,6 @@ import type {
   TrustedCertificateEntry,
   Vibrancy,
 } from "../ipc-contracts/platform-types";
-import type { LogLevel } from "@traycer/protocol/config/log-level";
 import { subscribe, type Disposable, type Listener } from "./subscribe";
 
 export type {

--- a/clients/desktop/src/electron-preload/platform-bridge.ts
+++ b/clients/desktop/src/electron-preload/platform-bridge.ts
@@ -9,11 +9,14 @@ import type {
   DisplayTopology,
   FindInPageStopAction,
   FindResultSnapshot,
+  LogLevelScope,
+  LogLevelsSnapshot,
   PendingCertificateError,
   ProcessMetricsSnapshot,
   TrustedCertificateEntry,
   Vibrancy,
 } from "../ipc-contracts/platform-types";
+import type { LogLevel } from "@traycer/protocol/config/log-level";
 import { subscribe, type Disposable, type Listener } from "./subscribe";
 
 export type {
@@ -116,6 +119,10 @@ export interface PlatformBridgeSurface {
   gpu: {
     getAccelerationEnabled(): Promise<boolean>;
     setAccelerationEnabled(enabled: boolean): Promise<boolean>;
+  };
+  logLevels: {
+    get(): Promise<LogLevelsSnapshot>;
+    set(scope: LogLevelScope, level: LogLevel): Promise<LogLevelsSnapshot>;
   };
   windowEx: {
     setOverlayIcon(image: string | null, description: string): Promise<void>;
@@ -307,6 +314,17 @@ export function buildPlatformBridge(): PlatformBridgeSurface {
           RunnerHostInvoke.gpuAccelerationSet,
           enabled,
         ) as Promise<boolean>,
+    },
+    logLevels: {
+      get: () =>
+        ipcRenderer.invoke(
+          RunnerHostInvoke.logLevelsGet,
+        ) as Promise<LogLevelsSnapshot>,
+      set: (scope, level) =>
+        ipcRenderer.invoke(RunnerHostInvoke.logLevelsSet, {
+          scope,
+          level,
+        }) as Promise<LogLevelsSnapshot>,
     },
     windowEx: {
       setOverlayIcon: (image, description) =>

--- a/clients/desktop/src/ipc-contracts/ipc-channels.ts
+++ b/clients/desktop/src/ipc-contracts/ipc-channels.ts
@@ -123,6 +123,8 @@ export const RunnerHostInvoke = {
   displayList: "runnerHost:display:list",
   gpuAccelerationGet: "runnerHost:gpu:get",
   gpuAccelerationSet: "runnerHost:gpu:set",
+  logLevelsGet: "runnerHost:logLevels:get",
+  logLevelsSet: "runnerHost:logLevels:set",
   // Renderer-driven sleep prevention. The renderer recomputes
   // `preventSleepWhileRunning && anyLocalAgentActive` and pushes the boolean
   // here; main holds a single `powerSaveBlocker` while any window wants it.

--- a/clients/desktop/src/ipc-contracts/platform-types.ts
+++ b/clients/desktop/src/ipc-contracts/platform-types.ts
@@ -1,5 +1,9 @@
 import type { LogLevel } from "@traycer/protocol/config/log-level";
 
+// Re-exported so the preload bridge (which must import only from
+// `src/ipc-contracts/`) can reach the protocol's `LogLevel` through this layer.
+export type { LogLevel };
+
 export interface AccessibilityThemeSnapshot {
   readonly prefersReducedTransparency: boolean;
   readonly shouldUseHighContrastColors: boolean;

--- a/clients/desktop/src/ipc-contracts/platform-types.ts
+++ b/clients/desktop/src/ipc-contracts/platform-types.ts
@@ -1,3 +1,5 @@
+import type { LogLevel } from "@traycer/protocol/config/log-level";
+
 export interface AccessibilityThemeSnapshot {
   readonly prefersReducedTransparency: boolean;
   readonly shouldUseHighContrastColors: boolean;
@@ -97,4 +99,14 @@ export interface TrustedCertificateEntry {
   readonly subject: string;
   readonly issuer: string;
   readonly trustedAt: number;
+}
+
+/** Which logger a Settings change targets. */
+export type LogLevelScope = "cli" | "host" | "desktop";
+
+/** The three configurable thresholds, surfaced together to the renderer. */
+export interface LogLevelsSnapshot {
+  readonly cliLogLevel: LogLevel;
+  readonly hostLogLevel: LogLevel;
+  readonly desktopLogLevel: LogLevel;
 }

--- a/clients/gui-app/src/components/copy-text-button.tsx
+++ b/clients/gui-app/src/components/copy-text-button.tsx
@@ -1,0 +1,62 @@
+import { Check, Copy } from "lucide-react";
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
+
+const COPIED_RESET_MS = 1600;
+
+interface CopyTextButtonProps {
+  readonly value: string;
+  /** Visible label, or `null` to render an icon-only button. */
+  readonly label: string | null;
+  readonly ariaLabel: string;
+  readonly disabled: boolean;
+}
+
+/**
+ * Copies `value` to the clipboard and briefly confirms with a check. With a
+ * `label` it renders an outline button (icon + text) sized to sit next to other
+ * `size="sm"` actions; with `label: null` it renders a compact icon-only
+ * button. Reuses {@link useClipboardCopy}, so an insecure-context clipboard
+ * failure surfaces a toast.
+ */
+export function CopyTextButton(props: CopyTextButtonProps) {
+  const { value, label, ariaLabel, disabled } = props;
+  const { copied, copy } = useClipboardCopy({
+    resetMs: COPIED_RESET_MS,
+    onSuccess: null,
+    onError: () => toast.error("Couldn't copy to clipboard."),
+  });
+  const handleCopy = useCallback(() => copy(value), [copy, value]);
+  const Icon = copied ? Check : Copy;
+
+  if (label === null) {
+    return (
+      <button
+        type="button"
+        onClick={handleCopy}
+        disabled={disabled}
+        aria-label={copied ? "Copied" : ariaLabel}
+        className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground/80 transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50"
+      >
+        <Icon className="size-3.5" aria-hidden />
+      </button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="shrink-0"
+      disabled={disabled}
+      aria-label={copied ? "Copied" : ariaLabel}
+      onClick={handleCopy}
+    >
+      <Icon />
+      {copied ? "Copied" : label}
+    </Button>
+  );
+}

--- a/clients/gui-app/src/components/layout/bridges/runner-host-bridges.tsx
+++ b/clients/gui-app/src/components/layout/bridges/runner-host-bridges.tsx
@@ -3,6 +3,8 @@ import { useNotificationClick } from "@/hooks/notifications/use-notifications";
 import { useTrayEpicsSource } from "@/hooks/tray/use-tray-epics-source";
 import { useTrayProjection } from "@/hooks/tray/use-tray-projection";
 import { useRunnerHost } from "@/providers/use-runner-host";
+import { useRunnerLogLevelsQuery } from "@/hooks/runner/use-runner-log-levels-query";
+import { setAppLogLevel } from "@/lib/logger";
 import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
 import { useTrayProjectionStore } from "@/stores/tray/tray-projection-store";
 
@@ -54,6 +56,16 @@ export function RunnerHostBridges(): null {
       subscription.dispose();
     };
   }, [runnerHost, requestOpenEpic]);
+
+  // Keep the renderer's own log threshold in sync with the configured desktop
+  // level (no-op outside the desktop shell, where the query stays disabled).
+  const logLevels = useRunnerLogLevelsQuery();
+  const desktopLogLevel = logLevels.data?.desktopLogLevel;
+  useEffect(() => {
+    if (desktopLogLevel !== undefined) {
+      setAppLogLevel(desktopLogLevel);
+    }
+  }, [desktopLogLevel]);
 
   return null;
 }

--- a/clients/gui-app/src/components/layout/dialogs/desktop/logs-chooser-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/logs-chooser-dialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useReducer, useState, type ReactNode } from "react";
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { ChevronDown, ChevronUp, FolderOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { CopyTextButton } from "@/components/copy-text-button";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import {
   Dialog,
@@ -297,11 +298,21 @@ function LogTailView(props: { readonly state: LogTailState }): ReactNode {
     }
     return (
       <div className="grid gap-1">
-        {props.state.result.truncated ? (
-          <p className="text-ui-xs text-muted-foreground">
-            Showing last {SUPPORT_LOG_TAIL_LINES} lines.
-          </p>
-        ) : null}
+        <div className="flex items-center justify-between gap-2">
+          {props.state.result.truncated ? (
+            <p className="text-ui-xs text-muted-foreground">
+              Showing last {SUPPORT_LOG_TAIL_LINES} lines.
+            </p>
+          ) : (
+            <span aria-hidden />
+          )}
+          <CopyTextButton
+            value={content}
+            label={null}
+            ariaLabel="Copy log output"
+            disabled={false}
+          />
+        </div>
         <pre className="max-h-72 w-full overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-left font-mono text-code-xs text-muted-foreground">
           {content}
         </pre>

--- a/clients/gui-app/src/components/settings/panels/diagnostics-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/diagnostics-settings-panel.tsx
@@ -1,0 +1,226 @@
+import { useMemo, useState, type ReactNode } from "react";
+import { queryOptions, useMutation, useQuery } from "@tanstack/react-query";
+import { ChevronDown, ChevronUp, FolderOpen } from "lucide-react";
+import { SettingsPanelShell } from "@/components/settings/settings-panel-shell";
+import { LogLevelRow } from "@/components/settings/panels/log-level-row";
+import { Button } from "@/components/ui/button";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { CopyTextButton } from "@/components/copy-text-button";
+import { useRunnerHost } from "@/providers/use-runner-host";
+import { resolveDesktopSupportBridge } from "@/lib/windows/desktop-capabilities";
+import { getLogLevelsBridge } from "@/lib/desktop-log-levels";
+import {
+  runnerMutationKeys,
+  runnerQueryKeys,
+} from "@/lib/query-keys/runner-mutation-keys";
+import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import type {
+  DesktopSupportBridge,
+  DesktopSupportLogDescriptor,
+  DesktopSupportLogTailResult,
+  DesktopSupportSnapshot,
+} from "@/lib/windows/types";
+
+const LOG_TAIL_LINES = 100;
+const PANEL_DESCRIPTION =
+  "Log verbosity for each Traycer component on this machine, plus recent log output. All default to Info — raise a level to Debug when capturing a problem for support, then set it back.";
+
+export function DiagnosticsSettingsPanel() {
+  // Every part of this panel (config + log files) is desktop-only; on the web
+  // shell there is no bridge to read or write through.
+  if (getLogLevelsBridge() === null) {
+    return (
+      <SettingsPanelShell title="Diagnostics" description={PANEL_DESCRIPTION}>
+        <div className="px-5 py-6 text-ui-sm text-muted-foreground">
+          Log configuration is only available on the desktop app.
+        </div>
+      </SettingsPanelShell>
+    );
+  }
+
+  return (
+    <SettingsPanelShell title="Diagnostics" description={PANEL_DESCRIPTION}>
+      <LogLevelRow
+        scope="desktop"
+        label="App log level"
+        description="Verbosity of the desktop app's own logs."
+      />
+      <LogLevelRow
+        scope="cli"
+        label="CLI log level"
+        description="Verbosity of the bundled Traycer CLI's logs."
+      />
+      <LogLevelRow
+        scope="host"
+        label="Host log level"
+        description="Verbosity of the background host process's logs."
+      />
+      <DiagnosticsLogs />
+    </SettingsPanelShell>
+  );
+}
+
+function DiagnosticsLogs(): ReactNode {
+  const runnerHost = useRunnerHost();
+  const support = useMemo(
+    () => resolveDesktopSupportBridge(runnerHost),
+    [runnerHost],
+  );
+
+  const listQuery = useQuery(
+    queryOptions<DesktopSupportSnapshot>({
+      queryKey: runnerQueryKeys.supportLogList(support),
+      queryFn: () => {
+        if (support === null) throw new Error("Logs unavailable.");
+        return support.getSnapshot();
+      },
+      enabled: support !== null,
+      staleTime: 60_000,
+    }),
+  );
+
+  if (support === null) return null;
+
+  return (
+    <>
+      <div className="border-b border-border/40 px-5 py-4 last:border-b-0">
+        <div className="font-medium text-foreground">Logs</div>
+        <p className="text-ui-sm text-muted-foreground">
+          Recent output from each log file. Expand to view the last{" "}
+          {LOG_TAIL_LINES} lines, or reveal the file on disk.
+        </p>
+      </div>
+      <DiagnosticsLogList
+        pending={listQuery.isPending}
+        error={listQuery.isError}
+        logs={listQuery.data?.logs ?? []}
+        support={support}
+      />
+    </>
+  );
+}
+
+function DiagnosticsLogList(props: {
+  readonly pending: boolean;
+  readonly error: boolean;
+  readonly logs: readonly DesktopSupportLogDescriptor[];
+  readonly support: DesktopSupportBridge;
+}): ReactNode {
+  if (props.pending) {
+    return <LogInfoLine>Loading logs…</LogInfoLine>;
+  }
+  if (props.error) {
+    return <LogInfoLine>Couldn&apos;t load log details.</LogInfoLine>;
+  }
+  return (
+    <>
+      {props.logs.map((entry) => (
+        <DiagnosticsLogEntry
+          key={entry.target}
+          entry={entry}
+          support={props.support}
+        />
+      ))}
+    </>
+  );
+}
+
+function LogInfoLine(props: { readonly children: ReactNode }): ReactNode {
+  return (
+    <div className="px-5 py-4 text-ui-sm text-muted-foreground">
+      {props.children}
+    </div>
+  );
+}
+
+function DiagnosticsLogEntry(props: {
+  readonly entry: DesktopSupportLogDescriptor;
+  readonly support: DesktopSupportBridge;
+}): ReactNode {
+  const { entry, support } = props;
+  const [open, setOpen] = useState(false);
+
+  const tailQuery = useQuery(
+    queryOptions<DesktopSupportLogTailResult>({
+      queryKey: runnerQueryKeys.supportLogTail(support, entry.target),
+      queryFn: () =>
+        support.tailLog({ target: entry.target, tailLines: LOG_TAIL_LINES }),
+      enabled: open,
+      staleTime: 5_000,
+    }),
+  );
+
+  const revealMutation = useMutation({
+    mutationKey: runnerMutationKeys.revealLog(),
+    mutationFn: () => support.revealLog(entry.target),
+    onError: (error) =>
+      toastFromRunnerError(error, "Couldn't open the log file"),
+  });
+
+  const Chevron = open ? ChevronUp : ChevronDown;
+
+  const lines = tailQuery.isSuccess ? tailQuery.data.lines : [];
+  const copyValue = lines.join("\n");
+  let tailText = "Loading log output…";
+  if (tailQuery.isError) {
+    tailText = "Couldn't load log output.";
+  } else if (tailQuery.isSuccess) {
+    tailText = lines.length === 0 ? "Log file is empty." : copyValue;
+  }
+
+  return (
+    <div className="border-b border-border/40 px-5 py-4 last:border-b-0">
+      <div className="flex items-start justify-between gap-6">
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((value) => !value)}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          data-testid={`diagnostics-log-toggle-${entry.target}`}
+        >
+          <Chevron className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate font-medium text-foreground">
+            {entry.label}
+          </span>
+        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          {open ? (
+            <CopyTextButton
+              value={copyValue}
+              label="Copy"
+              ariaLabel={`Copy ${entry.label} log`}
+              disabled={copyValue.length === 0}
+            />
+          ) : null}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            disabled={revealMutation.isPending}
+            onClick={() => revealMutation.mutate()}
+          >
+            {revealMutation.isPending ? (
+              <AgentSpinningDots
+                className="text-current"
+                testId={undefined}
+                variant={undefined}
+              />
+            ) : (
+              <FolderOpen />
+            )}
+            Reveal
+          </Button>
+        </div>
+      </div>
+      {open ? (
+        <pre
+          className="mt-3 max-h-52 w-full overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-code-xs text-muted-foreground"
+          data-testid={`diagnostics-log-output-${entry.target}`}
+        >
+          {tailText}
+        </pre>
+      ) : null}
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/settings/panels/log-level-row.tsx
+++ b/clients/gui-app/src/components/settings/panels/log-level-row.tsx
@@ -1,0 +1,84 @@
+import {
+  LOG_LEVELS,
+  isLogLevel,
+  type LogLevel,
+} from "@traycer/protocol/config/log-level";
+import { SettingsRow } from "@/components/settings/settings-row";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useRunnerLogLevelsQuery } from "@/hooks/runner/use-runner-log-levels-query";
+import { useRunnerLogLevelsSet } from "@/hooks/runner/use-runner-log-levels-set-mutation";
+import {
+  getLogLevelsBridge,
+  selectScopeLevel,
+  type LogLevelScope,
+} from "@/lib/desktop-log-levels";
+
+const LOG_LEVEL_LABEL: Record<LogLevel, string> = {
+  trace: "Trace",
+  debug: "Debug",
+  info: "Info (default)",
+  warn: "Warn",
+  error: "Error",
+};
+
+interface LogLevelRowProps {
+  readonly scope: LogLevelScope;
+  readonly label: string;
+  readonly description: string;
+}
+
+/**
+ * One Settings dropdown for a log threshold (desktop / cli / host). Reads the
+ * shared log-levels query (deduped across the rows) and writes through the set
+ * mutation. Renders nothing outside the desktop shell, where the bridge — and
+ * therefore the config — is absent.
+ */
+export function LogLevelRow(props: LogLevelRowProps) {
+  const { scope, label, description } = props;
+  const query = useRunnerLogLevelsQuery();
+  const setMutation = useRunnerLogLevelsSet();
+
+  if (getLogLevelsBridge() === null) return null;
+
+  const value =
+    query.data === undefined ? undefined : selectScopeLevel(query.data, scope);
+
+  return (
+    <SettingsRow
+      label={label}
+      description={description}
+      control={
+        <Select
+          value={value}
+          disabled={query.isPending || query.isError || setMutation.isPending}
+          onValueChange={(next) => {
+            if (isLogLevel(next)) {
+              setMutation.mutate({ scope, level: next });
+            }
+          }}
+        >
+          <SelectTrigger
+            className="w-[min(40vw,9rem)]"
+            aria-label={label}
+            data-testid={`settings-log-level-${scope}`}
+          >
+            <SelectValue placeholder="Loading…" />
+          </SelectTrigger>
+          <SelectContent>
+            {LOG_LEVELS.map((level) => (
+              <SelectItem key={level} value={level}>
+                {LOG_LEVEL_LABEL[level]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      }
+    />
+  );
+}

--- a/clients/gui-app/src/components/settings/settings-modal-content.tsx
+++ b/clients/gui-app/src/components/settings/settings-modal-content.tsx
@@ -7,6 +7,7 @@ import { KeybindingsSettingsPanel } from "@/components/settings/panels/keybindin
 import { ShellSettingsPanel } from "@/components/settings/panels/shell-settings-panel";
 import { WorktreesSettingsPanel } from "@/components/settings/panels/worktrees-settings-panel";
 import { HostSettingsPanel } from "@/components/settings/panels/host-settings-panel";
+import { DiagnosticsSettingsPanel } from "@/components/settings/panels/diagnostics-settings-panel";
 import { ProvidersSettingsPanel } from "@/components/settings/panels/providers-settings-panel";
 import { AgentsSettingsPanel } from "@/components/settings/panels/agents-settings-panel";
 import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
@@ -61,5 +62,7 @@ function SettingsPanelForSection(props: {
       return <WorktreesSettingsPanel />;
     case "host":
       return <HostSettingsPanel />;
+    case "diagnostics":
+      return <DiagnosticsSettingsPanel />;
   }
 }

--- a/clients/gui-app/src/hooks/runner/use-runner-log-levels-query.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-log-levels-query.ts
@@ -1,0 +1,29 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import { runnerQueryKeys } from "@/lib/query-keys/runner-mutation-keys";
+import {
+  getLogLevelsBridge,
+  type LogLevelsSnapshot,
+} from "@/lib/desktop-log-levels";
+
+/**
+ * Reads the three configurable log thresholds (desktop / cli / host) from the
+ * desktop platform bridge. Disabled — and so a permanent no-op — outside the
+ * desktop shell, where there is no bridge to read. `getLogLevelsBridge()` is
+ * resolved inside the fetcher (not captured) so the cache key stays primitive.
+ */
+export function useRunnerLogLevelsQuery() {
+  return useQuery(
+    queryOptions<LogLevelsSnapshot>({
+      queryKey: runnerQueryKeys.logLevels(),
+      queryFn: () => {
+        const bridge = getLogLevelsBridge();
+        if (bridge === null) {
+          throw new Error("Log levels are only available in the desktop app.");
+        }
+        return bridge.get();
+      },
+      enabled: getLogLevelsBridge() !== null,
+      staleTime: 30_000,
+    }),
+  );
+}

--- a/clients/gui-app/src/hooks/runner/use-runner-log-levels-set-mutation.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-log-levels-set-mutation.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { LogLevel } from "@traycer/protocol/config/log-level";
+import {
+  runnerMutationKeys,
+  runnerQueryKeys,
+} from "@/lib/query-keys/runner-mutation-keys";
+import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import {
+  getLogLevelsBridge,
+  type LogLevelScope,
+  type LogLevelsSnapshot,
+} from "@/lib/desktop-log-levels";
+import { setAppLogLevel } from "@/lib/logger";
+
+interface SetLogLevelInput {
+  readonly scope: LogLevelScope;
+  readonly level: LogLevel;
+}
+
+/**
+ * Persists one log threshold through the desktop platform bridge. `set` returns
+ * the full new snapshot (response equals state), so it is written straight into
+ * the query cache rather than refetched, and the renderer's own threshold is
+ * kept in lockstep with the desktop level.
+ */
+export function useRunnerLogLevelsSet() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: runnerMutationKeys.logLevelsSet(),
+    mutationFn: (input: SetLogLevelInput) => {
+      const bridge = getLogLevelsBridge();
+      if (bridge === null) {
+        throw new Error("Log levels are only available in the desktop app.");
+      }
+      return bridge.set(input.scope, input.level);
+    },
+    onSuccess: (snapshot: LogLevelsSnapshot) => {
+      queryClient.setQueryData(runnerQueryKeys.logLevels(), snapshot);
+      setAppLogLevel(snapshot.desktopLogLevel);
+    },
+    onError: (error) =>
+      toastFromRunnerError(error, "Couldn't update log level"),
+  });
+}

--- a/clients/gui-app/src/lib/desktop-log-levels.ts
+++ b/clients/gui-app/src/lib/desktop-log-levels.ts
@@ -25,7 +25,9 @@ export interface LogLevelsBridge {
 }
 
 interface RunnerHostWindowShape {
-  readonly platform: { readonly logLevels?: LogLevelsBridge } | undefined;
+  readonly platform:
+    | { readonly logLevels: LogLevelsBridge | undefined }
+    | undefined;
 }
 
 export function getLogLevelsBridge(): LogLevelsBridge | null {

--- a/clients/gui-app/src/lib/desktop-log-levels.ts
+++ b/clients/gui-app/src/lib/desktop-log-levels.ts
@@ -25,7 +25,7 @@ export interface LogLevelsBridge {
 }
 
 interface RunnerHostWindowShape {
-  readonly platform?: { readonly logLevels?: LogLevelsBridge };
+  readonly platform: { readonly logLevels?: LogLevelsBridge } | undefined;
 }
 
 export function getLogLevelsBridge(): LogLevelsBridge | null {

--- a/clients/gui-app/src/lib/desktop-log-levels.ts
+++ b/clients/gui-app/src/lib/desktop-log-levels.ts
@@ -1,0 +1,49 @@
+import type { LogLevel } from "@traycer/protocol/config/log-level";
+
+/**
+ * Feature-detected access to the desktop-only `platform.logLevels` namespace the
+ * Electron preload installs on `window.runnerHost`. gui-app stays browser-safe,
+ * so this reads the global defensively and returns `null` on shells (web /
+ * gui-app-dev) that don't expose it — there, log-level config simply isn't
+ * available. Typed locally so gui-app doesn't import from the desktop package.
+ */
+
+export type LogLevelScope = "cli" | "host" | "desktop";
+
+export interface LogLevelsSnapshot {
+  readonly cliLogLevel: LogLevel;
+  readonly hostLogLevel: LogLevel;
+  readonly desktopLogLevel: LogLevel;
+}
+
+export interface LogLevelsBridge {
+  readonly get: () => Promise<LogLevelsSnapshot>;
+  readonly set: (
+    scope: LogLevelScope,
+    level: LogLevel,
+  ) => Promise<LogLevelsSnapshot>;
+}
+
+interface RunnerHostWindowShape {
+  readonly platform?: { readonly logLevels?: LogLevelsBridge };
+}
+
+export function getLogLevelsBridge(): LogLevelsBridge | null {
+  const host = (globalThis as { runnerHost?: RunnerHostWindowShape })
+    .runnerHost;
+  return host?.platform?.logLevels ?? null;
+}
+
+export function selectScopeLevel(
+  snapshot: LogLevelsSnapshot,
+  scope: LogLevelScope,
+): LogLevel {
+  switch (scope) {
+    case "cli":
+      return snapshot.cliLogLevel;
+    case "host":
+      return snapshot.hostLogLevel;
+    case "desktop":
+      return snapshot.desktopLogLevel;
+  }
+}

--- a/clients/gui-app/src/lib/logger.ts
+++ b/clients/gui-app/src/lib/logger.ts
@@ -1,3 +1,9 @@
+import {
+  DEFAULT_LOG_LEVEL,
+  logLevelAllows,
+  type LogLevel,
+} from "@traycer/protocol/config/log-level";
+
 export type AppLogLevel = "debug" | "info" | "warn" | "error";
 
 export type AppLogValue =
@@ -24,9 +30,17 @@ const SENSITIVE_INLINE_VALUE_PATTERN =
   /(\b(?:access[_-]?token|refresh[_-]?token|id[_-]?token|token|code[_-]?verifier|password|secret|client[_-]?secret|api[_-]?key|authorization|cookie|credential)\b\s*[:=]\s*)("[^"]*"|'[^']*'|[^\s,;}&]+)/gi;
 const NOT_SCALAR_LOG_VALUE = Symbol("not-scalar-log-value");
 
+// The renderer's threshold, hydrated from the desktop log level over IPC (see
+// LogLevelBridge). Defaults to debug in dev for DX, info otherwise; in the
+// desktop shell the configured `desktopLogLevel` takes over once it loads.
+let appLogLevel: LogLevel = import.meta.env.DEV ? "debug" : DEFAULT_LOG_LEVEL;
+
+export function setAppLogLevel(level: LogLevel): void {
+  appLogLevel = level;
+}
+
 export const appLogger = {
   debug(message: string, fields: AppLogFields): void {
-    if (!import.meta.env.DEV) return;
     emitLog("debug", message, fields);
   },
   info(message: string, fields: AppLogFields): void {
@@ -122,6 +136,7 @@ function emitLog(
   message: string,
   fields: AppLogFields,
 ): void {
+  if (!logLevelAllows(appLogLevel, level)) return;
   const payload = {
     source: "gui-app",
     level,

--- a/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
@@ -28,6 +28,8 @@ export const runnerMutationKeys = {
   uninstallTraycer: () => ["runner.host.uninstallTraycer"] as const,
   reinstallTraycer: () => ["runner.host.reinstallTraycer"] as const,
   supportSubmitReport: () => ["runner.support.submitReport"] as const,
+  // Reveal a log file in the OS file manager (Diagnostics → Logs).
+  revealLog: () => ["runner.support.revealLog"] as const,
   // Force-refresh the registry update probe (bypasses the desktop's 24h
   // on-disk cache). Used by the Settings → Host Updates row's
   // "Check now" / "Retry" buttons so stale cached failures don't survive
@@ -38,6 +40,9 @@ export const runnerMutationKeys = {
   // reloads. Keyed so the destructive action dedups and shows in devtools.
   clearAllLocalData: () => ["runner.clearAllLocalData"] as const,
   mermaidPngDownload: () => ["runner.mermaidPngDownload"] as const,
+  // Settings → log level (desktop/cli/host). Machine-local config, not
+  // host-scoped, so a single static key suffices.
+  logLevelsSet: () => ["runner.logLevels.set"] as const,
 };
 
 export const runnerQueryKeys = {
@@ -83,4 +88,14 @@ export const runnerQueryKeys = {
    * matching query stays `enabled: false`; no fetch ever runs.
    */
   hostStatusNoService: () => ["runner.host.status-no-service"] as const,
+  // The three configurable log thresholds, read together from the desktop
+  // platform bridge. Machine-local, so not host-scoped.
+  logLevels: () => ["runner.logLevels"] as const,
+  // Desktop support log viewer (Diagnostics → Logs). Scoped by the support
+  // bridge object identity so a host/shell swap invalidates cleanly, matching
+  // the other runner-host queries.
+  supportLogList: (support: object | null) =>
+    ["runner.support.logList", support] as const,
+  supportLogTail: (support: object | null, target: string) =>
+    ["runner.support.logTail", support, target] as const,
 };

--- a/clients/gui-app/src/lib/settings-sections.ts
+++ b/clients/gui-app/src/lib/settings-sections.ts
@@ -1,5 +1,6 @@
 import type { LucideIcon } from "lucide-react";
 import {
+  Activity,
   Bot,
   Boxes,
   GitBranch,
@@ -18,7 +19,8 @@ export type SettingsSectionId =
   | "keybindings"
   | "shell"
   | "worktrees"
-  | "host";
+  | "host"
+  | "diagnostics";
 
 export interface SettingsSection {
   id: SettingsSectionId;
@@ -35,4 +37,5 @@ export const SETTINGS_SECTIONS: ReadonlyArray<SettingsSection> = [
   { id: "shell", label: "Shell", icon: TerminalSquare },
   { id: "worktrees", label: "Worktrees", icon: GitBranch },
   { id: "host", label: "Host", icon: Server },
+  { id: "diagnostics", label: "Diagnostics", icon: Activity },
 ];

--- a/clients/gui-app/src/routeTree.gen.ts
+++ b/clients/gui-app/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as SettingsProvidersRouteImport } from "./routes/settings.provide
 import { Route as SettingsKeybindingsRouteImport } from "./routes/settings.keybindings";
 import { Route as SettingsHostRouteImport } from "./routes/settings.host";
 import { Route as SettingsGeneralRouteImport } from "./routes/settings.general";
+import { Route as SettingsDiagnosticsRouteImport } from "./routes/settings.diagnostics";
 import { Route as SettingsAppearanceRouteImport } from "./routes/settings.appearance";
 import { Route as SettingsAgentsRouteImport } from "./routes/settings.agents";
 import { Route as DraftNewRouteImport } from "./routes/draft.new";
@@ -93,6 +94,11 @@ const SettingsGeneralRoute = SettingsGeneralRouteImport.update({
   path: "/general",
   getParentRoute: () => SettingsRoute,
 } as any);
+const SettingsDiagnosticsRoute = SettingsDiagnosticsRouteImport.update({
+  id: "/diagnostics",
+  path: "/diagnostics",
+  getParentRoute: () => SettingsRoute,
+} as any);
 const SettingsAppearanceRoute = SettingsAppearanceRouteImport.update({
   id: "/appearance",
   path: "/appearance",
@@ -128,6 +134,7 @@ export interface FileRoutesByFullPath {
   "/draft/new": typeof DraftNewRoute;
   "/settings/agents": typeof SettingsAgentsRoute;
   "/settings/appearance": typeof SettingsAppearanceRoute;
+  "/settings/diagnostics": typeof SettingsDiagnosticsRoute;
   "/settings/general": typeof SettingsGeneralRoute;
   "/settings/host": typeof SettingsHostRoute;
   "/settings/keybindings": typeof SettingsKeybindingsRoute;
@@ -146,6 +153,7 @@ export interface FileRoutesByTo {
   "/draft/new": typeof DraftNewRoute;
   "/settings/agents": typeof SettingsAgentsRoute;
   "/settings/appearance": typeof SettingsAppearanceRoute;
+  "/settings/diagnostics": typeof SettingsDiagnosticsRoute;
   "/settings/general": typeof SettingsGeneralRoute;
   "/settings/host": typeof SettingsHostRoute;
   "/settings/keybindings": typeof SettingsKeybindingsRoute;
@@ -167,6 +175,7 @@ export interface FileRoutesById {
   "/draft/new": typeof DraftNewRoute;
   "/settings/agents": typeof SettingsAgentsRoute;
   "/settings/appearance": typeof SettingsAppearanceRoute;
+  "/settings/diagnostics": typeof SettingsDiagnosticsRoute;
   "/settings/general": typeof SettingsGeneralRoute;
   "/settings/host": typeof SettingsHostRoute;
   "/settings/keybindings": typeof SettingsKeybindingsRoute;
@@ -189,6 +198,7 @@ export interface FileRouteTypes {
     | "/draft/new"
     | "/settings/agents"
     | "/settings/appearance"
+    | "/settings/diagnostics"
     | "/settings/general"
     | "/settings/host"
     | "/settings/keybindings"
@@ -207,6 +217,7 @@ export interface FileRouteTypes {
     | "/draft/new"
     | "/settings/agents"
     | "/settings/appearance"
+    | "/settings/diagnostics"
     | "/settings/general"
     | "/settings/host"
     | "/settings/keybindings"
@@ -227,6 +238,7 @@ export interface FileRouteTypes {
     | "/draft/new"
     | "/settings/agents"
     | "/settings/appearance"
+    | "/settings/diagnostics"
     | "/settings/general"
     | "/settings/host"
     | "/settings/keybindings"
@@ -341,6 +353,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof SettingsGeneralRouteImport;
       parentRoute: typeof SettingsRoute;
     };
+    "/settings/diagnostics": {
+      id: "/settings/diagnostics";
+      path: "/diagnostics";
+      fullPath: "/settings/diagnostics";
+      preLoaderRoute: typeof SettingsDiagnosticsRouteImport;
+      parentRoute: typeof SettingsRoute;
+    };
     "/settings/appearance": {
       id: "/settings/appearance";
       path: "/appearance";
@@ -394,6 +413,7 @@ const EpicsRouteWithChildren = EpicsRoute._addFileChildren(EpicsRouteChildren);
 interface SettingsRouteChildren {
   SettingsAgentsRoute: typeof SettingsAgentsRoute;
   SettingsAppearanceRoute: typeof SettingsAppearanceRoute;
+  SettingsDiagnosticsRoute: typeof SettingsDiagnosticsRoute;
   SettingsGeneralRoute: typeof SettingsGeneralRoute;
   SettingsHostRoute: typeof SettingsHostRoute;
   SettingsKeybindingsRoute: typeof SettingsKeybindingsRoute;
@@ -407,6 +427,7 @@ interface SettingsRouteChildren {
 const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsAgentsRoute: SettingsAgentsRoute,
   SettingsAppearanceRoute: SettingsAppearanceRoute,
+  SettingsDiagnosticsRoute: SettingsDiagnosticsRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
   SettingsHostRoute: SettingsHostRoute,
   SettingsKeybindingsRoute: SettingsKeybindingsRoute,

--- a/clients/gui-app/src/routes/settings.diagnostics.tsx
+++ b/clients/gui-app/src/routes/settings.diagnostics.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { DiagnosticsSettingsPanel } from "@/components/settings/panels/diagnostics-settings-panel";
+
+export const Route = createFileRoute("/settings/diagnostics")({
+  component: DiagnosticsSettingsPanel,
+});

--- a/clients/gui-app/src/stores/tabs/kinds/settings.tsx
+++ b/clients/gui-app/src/stores/tabs/kinds/settings.tsx
@@ -31,6 +31,8 @@ function settingsRouteOptions(section: SettingsSectionId) {
       return { to: "/settings/worktrees" } as const;
     case "host":
       return { to: "/settings/host" } as const;
+    case "diagnostics":
+      return { to: "/settings/diagnostics" } as const;
   }
 }
 

--- a/clients/traycer-cli/src/logger.ts
+++ b/clients/traycer-cli/src/logger.ts
@@ -3,6 +3,8 @@ import { dirname } from "node:path";
 import type { Environment } from "./runner/environment";
 import { CliError } from "./runner/errors";
 import { cliLogPath } from "./store/paths";
+import { logLevelAllows } from "@traycer/protocol/config/log-level";
+import { readLogLevelsSync } from "@traycer/protocol/config/store";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -51,12 +53,17 @@ export const noopLogger: ILogger = {
 
 export function createCliLogger(environment: Environment): ILogger {
   const path = cliLogPath(environment);
+  // Resolve the client threshold once at construction — config.json is shared
+  // and rarely changes mid-process, and a fresh CLI invocation picks up the
+  // latest level. Defaults to `info`, so debug output is dropped unless raised.
+  const threshold = readLogLevelsSync().cliLogLevel;
   const write = (
     level: LogLevel,
     message: string,
     fields: LogFields,
     error: Error | null,
   ): void => {
+    if (!logLevelAllows(threshold, level)) return;
     try {
       mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
       appendFileSync(

--- a/protocol/src/config/__tests__/store.test.ts
+++ b/protocol/src/config/__tests__/store.test.ts
@@ -22,7 +22,10 @@ import {
   loadEffectiveShellConfig,
   migrateCliConfig,
   readCliConfig,
+  readLogLevels,
+  readLogLevelsSync,
   setEnvOverride,
+  setLogLevels,
   setShell,
   writeCliConfig,
 } from "../store";
@@ -48,9 +51,70 @@ describe("cli config store", () => {
       version: 1 as const,
       shell: { path: "/bin/fish", args: ["-l"] },
       envOverrides: { FOO: "bar" },
+      logs: { cliLogLevel: "info" as const, hostLogLevel: "info" as const },
     };
     await writeCliConfig(cfg);
     expect(await readCliConfig()).toEqual(cfg);
+  });
+
+  it("defaults both log levels to info when the file omits them", async () => {
+    await writeRaw(
+      JSON.stringify({
+        version: 1,
+        shell: { path: null, args: null },
+        envOverrides: {},
+      }),
+    );
+    expect(await readLogLevels()).toEqual({
+      cliLogLevel: "info",
+      hostLogLevel: "info",
+    });
+  });
+
+  it("persists explicit client + host log levels", async () => {
+    await setLogLevels("debug", "warn");
+    expect(await readLogLevels()).toEqual({
+      cliLogLevel: "debug",
+      hostLogLevel: "warn",
+    });
+  });
+
+  it("preserves log levels across an unrelated shell write", async () => {
+    await setLogLevels("trace", "debug");
+    await setShell("/bin/fish", ["-l"]);
+    expect(await readLogLevels()).toEqual({
+      cliLogLevel: "trace",
+      hostLogLevel: "debug",
+    });
+  });
+
+  it("preserves log levels across an env-override write", async () => {
+    await setLogLevels("warn", "error");
+    await setEnvOverride("FOO", "bar");
+    expect(await readLogLevels()).toEqual({
+      cliLogLevel: "warn",
+      hostLogLevel: "error",
+    });
+  });
+
+  it("readLogLevelsSync falls back to info defaults on a missing or corrupt file", async () => {
+    expect(readLogLevelsSync()).toEqual({
+      cliLogLevel: "info",
+      hostLogLevel: "info",
+    });
+    await writeRaw("{ not json");
+    expect(readLogLevelsSync()).toEqual({
+      cliLogLevel: "info",
+      hostLogLevel: "info",
+    });
+  });
+
+  it("readLogLevelsSync reads persisted levels", async () => {
+    await setLogLevels("debug", "trace");
+    expect(readLogLevelsSync()).toEqual({
+      cliLogLevel: "debug",
+      hostLogLevel: "trace",
+    });
   });
 
   it("stores explicit unsets as null env overrides", async () => {
@@ -121,6 +185,7 @@ describe("cli config store", () => {
       version: CLI_CONFIG_VERSION,
       shell: { path: "/bin/zsh", args: null },
       envOverrides: {},
+      logs: { cliLogLevel: "info", hostLogLevel: "info" },
     });
   });
 

--- a/protocol/src/config/index.ts
+++ b/protocol/src/config/index.ts
@@ -8,5 +8,6 @@
  * resolving filesystem APIs.
  */
 export * from "./schema";
+export * from "./log-level";
 export * from "./paths";
 export * from "./store";

--- a/protocol/src/config/log-level.ts
+++ b/protocol/src/config/log-level.ts
@@ -1,0 +1,37 @@
+/**
+ * Log-level vocabulary shared by every Traycer logger — the host, the CLI, the
+ * desktop main process, and the GUI renderer. Kept dependency-free (no zod, no
+ * `node:fs`) so the browser renderer can import it from the `@traycer/protocol`
+ * root without dragging in the filesystem-backed config store. The zod schema
+ * that *persists* these values lives in `./schema` (Node-only).
+ */
+
+export const LOG_LEVELS = ["trace", "debug", "info", "warn", "error"] as const;
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+const LOG_LEVEL_RANK: Record<LogLevel, number> = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+};
+
+/** Default threshold for every surface: quiet (no debug/trace) but never silent. */
+export const DEFAULT_LOG_LEVEL: LogLevel = "info";
+
+export function isLogLevel(value: unknown): value is LogLevel {
+  return (
+    typeof value === "string" &&
+    (LOG_LEVELS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * True when a message at `level` should be emitted under `threshold`. A level is
+ * a threshold: `info` emits info/warn/error and drops debug/trace. There is no
+ * "off" — `error` always passes — so a quiet setting can never hide a failure.
+ */
+export function logLevelAllows(threshold: LogLevel, level: LogLevel): boolean {
+  return LOG_LEVEL_RANK[level] >= LOG_LEVEL_RANK[threshold];
+}

--- a/protocol/src/config/schema.ts
+++ b/protocol/src/config/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { LOG_LEVELS, DEFAULT_LOG_LEVEL } from "./log-level";
 
 /**
  * Current on-disk schema version for `~/.traycer/cli/config.json`. Bump it
@@ -24,6 +25,22 @@ export interface EnvOverrideEntry {
 }
 
 const envOverrideMapSchema = z.record(z.string(), z.string().nullable());
+
+/**
+ * The `logs` block in `~/.traycer/cli/config.json`: two independent thresholds —
+ * one for the client processes (CLI + desktop/renderer), one for the host — both
+ * defaulting to `info` so a fresh install is quiet by default. Additive and
+ * `.default()`-ed, so older config files that lack it keep validating; the only
+ * compatibility cost is that a pre-feature binary's writer drops it on its next
+ * write (the setting then resolves back to the `info` default).
+ */
+export const logsConfigSchema = z
+  .object({
+    cliLogLevel: z.enum(LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
+    hostLogLevel: z.enum(LOG_LEVELS).default(DEFAULT_LOG_LEVEL),
+  })
+  .default({ cliLogLevel: DEFAULT_LOG_LEVEL, hostLogLevel: DEFAULT_LOG_LEVEL });
+export type LogsConfig = z.infer<typeof logsConfigSchema>;
 
 /**
  * Zod schema for `~/.traycer/cli/config.json` - the single on-disk source
@@ -54,6 +71,7 @@ export const cliConfigSchema = z.object({
     })
     .default({ path: null, args: null }),
   envOverrides: envOverrideMapSchema.default({}),
+  logs: logsConfigSchema,
 });
 
 export type CliConfig = z.infer<typeof cliConfigSchema>;
@@ -91,4 +109,5 @@ export const EMPTY_CLI_CONFIG: CliConfig = {
   version: CLI_CONFIG_VERSION,
   shell: { path: null, args: null },
   envOverrides: {},
+  logs: { cliLogLevel: DEFAULT_LOG_LEVEL, hostLogLevel: DEFAULT_LOG_LEVEL },
 };

--- a/protocol/src/config/store.ts
+++ b/protocol/src/config/store.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, readFileSync } from "node:fs";
 import {
   access,
   mkdir,
@@ -19,7 +19,9 @@ import {
   type DetectedShell,
   type EnvOverrideValue,
   type EffectiveShellConfig,
+  type LogsConfig,
 } from "./schema";
+import { DEFAULT_LOG_LEVEL, type LogLevel } from "./log-level";
 
 /**
  * Filesystem-backed config store for `~/.traycer/cli/config.json`, shared
@@ -286,6 +288,7 @@ export async function setShell(
     version: CLI_CONFIG_VERSION,
     shell: { path: nextPath, args: nextArgs },
     envOverrides: current.envOverrides,
+    logs: current.logs,
   });
   return { path: nextPath, args: nextArgs };
 }
@@ -296,7 +299,48 @@ export async function resetShell(): Promise<void> {
     version: CLI_CONFIG_VERSION,
     shell: { path: null, args: null },
     envOverrides: current.envOverrides,
+    logs: current.logs,
   });
+}
+
+/**
+ * Persists the client + host log thresholds, preserving the user's shell and
+ * env-override config. Reads-modify-writes through the schema like every other
+ * mutator, so the rest of `config.json` round-trips untouched.
+ */
+export async function setLogLevels(
+  cliLogLevel: LogLevel,
+  hostLogLevel: LogLevel,
+): Promise<void> {
+  const current = await readCliConfig();
+  await writeCliConfig({
+    version: CLI_CONFIG_VERSION,
+    shell: current.shell,
+    envOverrides: current.envOverrides,
+    logs: { cliLogLevel, hostLogLevel },
+  });
+}
+
+/** The configured client + host log thresholds (defaults when unset). */
+export async function readLogLevels(): Promise<LogsConfig> {
+  return (await readCliConfig()).logs;
+}
+
+/**
+ * Best-effort synchronous read of just the log thresholds, for logger
+ * construction on the hot path. Never throws — any missing/corrupt/invalid
+ * config resolves to the `info` defaults, so a logger can always cheaply decide
+ * its threshold at startup without awaiting or risking a crash.
+ */
+export function readLogLevelsSync(): LogsConfig {
+  try {
+    const raw = readFileSync(cliConfigPath(), "utf8");
+    const result = cliConfigSchema.safeParse(migrateCliConfig(JSON.parse(raw)));
+    if (result.success) return result.data.logs;
+  } catch {
+    // A logger must never crash on a config read — fall through to defaults.
+  }
+  return { cliLogLevel: DEFAULT_LOG_LEVEL, hostLogLevel: DEFAULT_LOG_LEVEL };
 }
 
 export async function listEnvOverrides(): Promise<
@@ -320,6 +364,7 @@ export async function setEnvOverride(
     version: CLI_CONFIG_VERSION,
     shell: current.shell,
     envOverrides: { ...current.envOverrides, [key]: value },
+    logs: current.logs,
   });
 }
 
@@ -334,6 +379,7 @@ export async function deleteEnvOverride(key: string): Promise<boolean> {
     version: CLI_CONFIG_VERSION,
     shell: current.shell,
     envOverrides: nextOverrides,
+    logs: current.logs,
   });
   return true;
 }


### PR DESCRIPTION
## What

Adds a simple, per-component **log-level switcher**, defaulting to `info` so a fresh install stays quiet (the original ask: stop DEBUG noise on normal runs).

- **`protocol`**: `logs.{cliLogLevel, hostLogLevel}` in the existing `~/.traycer/cli/config.json`, threaded through the shell/env config writers so an unrelated write can't drop it. A new dependency-free `config/log-level` module (level vocab + `logLevelAllows`) is shared by every logger and is browser-safe.
- **CLI / desktop-main / renderer** loggers gate their output on the configured threshold. The desktop/renderer level lives in an electron-main JSON store and is read/written over a small `platform` IPC; the host reads `logs.hostLogLevel` (host repo).
- **Settings → Diagnostics** (new left-nav section): three level dropdowns (App / CLI / Host) plus an inline tail-100 log viewer with copy + reveal. The existing **Open Logs** modal also gains a copy button.

## Compatibility

Additive and forward/backward compatible — unknown or older configs resolve to `info`, and there are **no protocol method or version changes**.

## Testing

- `protocol` compile + tests (config round-trip, preserve-`logs`-across-writes).
- gui-app compile (`tsc -b`), ESLint, React Doctor, settings/dialog/smoke tests.
- `pre-commit run --all-files` passes.

> Replaces the earlier, over-scoped #87 (which added a file lock, temporary overrides, an export bundle, and a `host.status` protocol bump). This is the trimmed-down equivalent.
