### PR TITLE
Add iFlow harness protocol support

### DIFF
--- a/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
+++ b/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
@@ -17,6 +17,7 @@ import { useTabProvidersList } from "@/hooks/providers/use-tab-providers-list-qu
 function providerIdForHarness(harnessId: GuiHarnessId): ProviderId | null {
   if (harnessId === "traycer") return null;
   if (harnessId === "grok") return "grok";
+  if (harnessId === "iflow") return "iflow";
   return TUI_HARNESS_ID_TO_PROVIDER_ID[harnessId];
 }
 

--- a/clients/gui-app/src/components/home/data/harness-icon-map.ts
+++ b/clients/gui-app/src/components/home/data/harness-icon-map.ts
@@ -3,6 +3,7 @@ import {
   CodexIcon,
   CursorIcon,
   GrokIcon,
+  IflowIcon,
   OpenCodeIcon,
   TraycerIcon,
   type HarnessIcon,
@@ -21,4 +22,5 @@ export const PROVIDER_ICON_CONFIG: Record<ProviderId, HarnessIconConfig> = {
   traycer: { Icon: TraycerIcon, className: "text-foreground" },
   cursor: { Icon: CursorIcon, className: "text-foreground" },
   grok: { Icon: GrokIcon, className: "text-foreground" },
+  iflow: { Icon: IflowIcon, className: "text-foreground" },
 };

--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -20,6 +20,17 @@ export const OpenCodeIcon: HarnessIcon = (props) => <OpenCodeMono {...props} />;
 export const CursorIcon: HarnessIcon = (props) => <CursorMono {...props} />;
 export const GrokIcon: HarnessIcon = (props) => <GrokMono {...props} />;
 
+// iFlow does not have a lobehub entry; keep a simple mono wordmark rather than
+// substituting a different vendor's brand logo.
+export const IflowIcon: HarnessIcon = (props) => (
+  <svg {...props} viewBox="0 0 24 24" fill="none">
+    <path
+      d="M5.25 8.2H8.1v10.3H5.25V8.2Zm1.42-3.1c.95 0 1.58.58 1.58 1.42 0 .83-.63 1.42-1.58 1.42-.93 0-1.56-.59-1.56-1.42 0-.84.63-1.42 1.56-1.42ZM11.15 5.6h8.15v2.45h-5.22v2.95h4.62v2.4h-4.62v5.1h-2.93V5.6Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
 // Traycer does not have a lobehub entry — hand-rolled from the brand mark.
 export const TraycerIcon: HarnessIcon = (props) => (
   <svg {...props} viewBox="0 0 211 218" fill="currentColor">

--- a/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
@@ -20,6 +20,7 @@ const TOUR_PROVIDERS: ReadonlyArray<{
   { id: "opencode", harnessId: "opencode" },
   { id: "cursor", harnessId: "cursor" },
   { id: "grok", harnessId: "grok" },
+  { id: "iflow", harnessId: "iflow" },
 ];
 
 type InstallState = "detected" | "missing" | "pending";

--- a/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
@@ -349,6 +349,12 @@ const PROVIDERS: ReadonlyArray<{
     status: "SuperGrok / X",
     capabilities: ["gui"],
   },
+  {
+    harnessId: "iflow",
+    label: "iFlow",
+    status: "CLI login or API key",
+    capabilities: ["gui"],
+  },
 ];
 
 const PALETTE_ROWS = [

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -100,6 +100,8 @@ const PROVIDER_DESCRIPTIONS: Record<ProviderId, string> = {
     "Cursor agent - SDK-driven chats authenticated with your Cursor API key.",
   traycer: "Traycer's managed harness uses the selected OpenCode CLI binary.",
   grok: "Grok agent - xAI's coding CLI via your SuperGrok / X subscription.",
+  iflow:
+    "iFlow agent - run the iFlow CLI manually for native login, or use IFLOW_API_KEY / OpenAI-compatible settings.",
 };
 
 const TERMINAL_AGENT_ARGS_PLACEHOLDER: Record<
@@ -122,6 +124,7 @@ function terminalAgentArgsPlaceholder(providerId: ProviderId): string {
     case "cursor":
     case "traycer":
     case "grok":
+    case "iflow":
       return "CLI arguments (optional)";
   }
 }
@@ -133,6 +136,7 @@ const HARNESS_ICON_ID: Record<ProviderId, HarnessIconId> = {
   cursor: "cursor",
   traycer: "traycer",
   grok: "grok",
+  iflow: "iflow",
 };
 
 // Grid keeps the columns aligned across header + rows; `minmax(0,1fr)` on
@@ -731,6 +735,8 @@ function envNamePlaceholder(providerId: ProviderId): string {
       return "CURSOR_API_KEY";
     case "grok":
       return "XAI_API_KEY";
+    case "iflow":
+      return "IFLOW_API_KEY";
   }
 }
 

--- a/clients/gui-app/src/lib/chat/sender-display.ts
+++ b/clients/gui-app/src/lib/chat/sender-display.ts
@@ -148,5 +148,7 @@ function agentProviderLabel(provider: GuiHarnessId): string {
       return "Cursor";
     case "grok":
       return "Grok";
+    case "iflow":
+      return "iFlow";
   }
 }

--- a/protocol/src/common/_internal/schemas.ts
+++ b/protocol/src/common/_internal/schemas.ts
@@ -55,4 +55,5 @@ export const harnessIdSchema = z.enum([
   "traycer",
   "cursor",
   "grok",
+  "iflow",
 ]);

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -62,13 +62,14 @@ export const agentSelectionGuideGlobalGetV10 = defineRpcContract({
   responseSchema: agentSelectionGuideGlobalGetResponseSchema,
 });
 
-export const agentSelectionGuideGlobalOnboardingDraftGetV10 =
-  defineRpcContract({
+export const agentSelectionGuideGlobalOnboardingDraftGetV10 = defineRpcContract(
+  {
     method: "agent.selectionGuide.getGlobalOnboardingDraft",
     schemaVersion: { major: 1, minor: 0 } as const,
     requestSchema: agentSelectionGuideGlobalOnboardingDraftGetRequestSchema,
     responseSchema: agentSelectionGuideGlobalOnboardingDraftGetResponseSchema,
-  });
+  },
+);
 
 export const agentSelectionGuideGlobalSetV10 = defineRpcContract({
   method: "agent.selectionGuide.setGlobal",
@@ -111,8 +112,8 @@ export const agentListUpgradeV1ToV2 = defineUpgradePath<
 >({
   from: { major: 1, minor: 0 },
   to: { major: 2, minor: 0 },
-  // A grok-less v1.0 response is a valid v2.0 response (grok is purely
-  // additive), and the request shape is identical — both upgrades are identity.
+  // A v1.0 response without the v2-only harnesses is a valid v2.0 response, and
+  // the request shape is identical — both upgrades are identity.
   upgradeRequest: (request) => request,
   upgradeResponse: (response) => response,
 });
@@ -124,13 +125,15 @@ export const agentListDowngradeV2ToV1 = defineDowngradePath<
   from: { major: 2, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
-  // Drop grok agents so a v1.0 client's strict (grok-less) decode never sees
-  // one. The re-parse yields the precise v1.0 type without an assertion.
+  // Drop v2-only harnesses so a v1.0 client's strict decode never sees one.
+  // The re-parse yields the precise v1.0 type without an assertion.
   downgradeResponse: (response) => ({
     ok: true,
     value: listAgentsResponseSchemaV10.parse({
       ...response,
-      agents: response.agents.filter((agent) => agent.harnessId !== "grok"),
+      agents: response.agents.filter(
+        (agent) => agent.harnessId !== "grok" && agent.harnessId !== "iflow",
+      ),
     }),
   }),
 });

--- a/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
@@ -65,42 +65,62 @@ function providerState(providerId: string) {
   };
 }
 
-describe("grok non-breaking v2→v1 downgrade bridges", () => {
-  it("drops grok from agent.gui.listHarnesses for v1.0 callers", () => {
+describe("grok and iFlow non-breaking v2→v1 downgrade bridges", () => {
+  it("drops grok and iFlow from agent.gui.listHarnesses for v1.0 callers", () => {
     const v2Response = listGuiHarnessesResponseSchema.parse({
-      harnesses: [harnessOption("claude"), harnessOption("grok"), harnessOption("cursor")],
+      harnesses: [
+        harnessOption("claude"),
+        harnessOption("grok"),
+        harnessOption("iflow"),
+        harnessOption("cursor"),
+      ],
     });
 
-    const result = agentGuiListHarnessesDowngradeV2ToV1.downgradeResponse(v2Response);
+    const result =
+      agentGuiListHarnessesDowngradeV2ToV1.downgradeResponse(v2Response);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.harnesses.map((harness) => harness.id)).toEqual(["claude", "cursor"]);
+    expect(result.value.harnesses.map((harness) => harness.id)).toEqual([
+      "claude",
+      "cursor",
+    ]);
     // The downgraded value must satisfy the frozen grok-less v1.0 schema — i.e.
     // a real v1.0 client's strict decode would accept it.
-    expect(() => listGuiHarnessesResponseSchemaV10.parse(result.value)).not.toThrow();
+    expect(() =>
+      listGuiHarnessesResponseSchemaV10.parse(result.value),
+    ).not.toThrow();
   });
 
-  it("drops grok from providers.list for v1.0 callers", () => {
+  it("drops grok and iFlow from providers.list for v1.0 callers", () => {
     const v2Response = providersListResponseSchema.parse({
-      providers: [providerState("cursor"), providerState("grok")],
+      providers: [
+        providerState("cursor"),
+        providerState("grok"),
+        providerState("iflow"),
+      ],
     });
 
     const result = providersListDowngradeV2ToV1.downgradeResponse(v2Response);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.providers.map((provider) => provider.providerId)).toEqual(["cursor"]);
-    expect(() => providersListResponseSchemaV10.parse(result.value)).not.toThrow();
+    expect(
+      result.value.providers.map((provider) => provider.providerId),
+    ).toEqual(["cursor"]);
+    expect(() =>
+      providersListResponseSchemaV10.parse(result.value),
+    ).not.toThrow();
   });
 
-  it("drops grok agents from agent.list for v1.0 callers", () => {
+  it("drops grok and iFlow agents from agent.list for v1.0 callers", () => {
     const v2Response = listAgentsResponseSchema.parse({
       caller: { agentId: "self", canSendMessages: true },
       scope: "all",
       agents: [
         agentSummary("a-claude", "claude"),
         agentSummary("a-grok", "grok"),
+        agentSummary("a-iflow", "iflow"),
         agentSummary("a-null", null),
       ],
     });
@@ -109,7 +129,10 @@ describe("grok non-breaking v2→v1 downgrade bridges", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.agents.map((agent) => agent.id)).toEqual(["a-claude", "a-null"]);
+    expect(result.value.agents.map((agent) => agent.id)).toEqual([
+      "a-claude",
+      "a-null",
+    ]);
     // A real v1.0 client's strict (grok-less) decode must accept the result.
     expect(() => listAgentsResponseSchemaV10.parse(result.value)).not.toThrow();
   });

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -675,6 +675,15 @@ export const grokUserMessageAnchorResolvedSchema = z.object({
   grokSessionId: z.string().nullable(),
 });
 
+export const iflowUserMessageAnchorResolvedSchema = z.object({
+  harnessId: z.literal("iflow"),
+  sessionId: z.string(),
+  // The ACP session id the `iflow --experimental-acp` process assigned for
+  // this turn. Null until `session/new` resolves; used to resume the same ACP
+  // session.
+  iflowSessionId: z.string().nullable(),
+});
+
 export const userMessageAnchorResolvedEventSchema = z.object({
   ...baseRuntimeEventFields,
   type: z.literal("user_message.anchor_resolved"),
@@ -686,6 +695,7 @@ export const userMessageAnchorResolvedEventSchema = z.object({
     cursorUserMessageAnchorResolvedSchema,
     traycerUserMessageAnchorResolvedSchema,
     grokUserMessageAnchorResolvedSchema,
+    iflowUserMessageAnchorResolvedSchema,
   ]),
 });
 export type UserMessageAnchorResolvedEvent = z.infer<

--- a/protocol/src/host/agent/gui/contracts.ts
+++ b/protocol/src/host/agent/gui/contracts.ts
@@ -18,9 +18,9 @@ import { chatSubscribeV10 } from "@traycer/protocol/host/agent/gui/subscribe";
 
 // ─── GUI-surface catalog (`agent.gui.*`) ──────────────────────────────────
 
-// `agent.gui.listHarnesses` always returns the full catalog (incl. grok), so an
-// unguarded grok value would reach every caller. v1.0 is frozen grok-less (what
-// shipped); v2.0 carries grok; the v2→v1 bridge drops grok for v1.0 clients.
+// `agent.gui.listHarnesses` always returns the full catalog, so an unguarded
+// v2-only harness value would reach every caller. v1.0 is frozen without those
+// harnesses; the v2→v1 bridge drops them for v1.0 clients.
 export const agentGuiListHarnessesV10 = defineRpcContract({
   method: "agent.gui.listHarnesses",
   schemaVersion: { major: 1, minor: 0 } as const,
@@ -41,8 +41,8 @@ export const agentGuiListHarnessesUpgradeV1ToV2 = defineUpgradePath<
 >({
   from: { major: 1, minor: 0 },
   to: { major: 2, minor: 0 },
-  // Request shape is identical; a grok-less v1.0 response is a valid v2.0
-  // response (grok is purely additive), so both upgrades are identity.
+  // Request shape is identical; a v1.0 response without the v2-only harnesses is
+  // a valid v2.0 response, so both upgrades are identity.
   upgradeRequest: (request) => request,
   upgradeResponse: (response) => response,
 });
@@ -54,12 +54,14 @@ export const agentGuiListHarnessesDowngradeV2ToV1 = defineDowngradePath<
   from: { major: 2, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
-  // Drop grok so a v1.0 client's strict (grok-less) decode never sees it. The
-  // re-parse also yields the precise v1.0 type without an assertion.
+  // Drop v2-only harnesses so a v1.0 client's strict decode never sees them.
+  // The re-parse also yields the precise v1.0 type without an assertion.
   downgradeResponse: (response) => ({
     ok: true,
     value: listGuiHarnessesResponseSchemaV10.parse({
-      harnesses: response.harnesses.filter((harness) => harness.id !== "grok"),
+      harnesses: response.harnesses.filter(
+        (harness) => harness.id !== "grok" && harness.id !== "iflow",
+      ),
     }),
   }),
 });

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -51,6 +51,7 @@ export const guiHarnessIdSchema = harnessIdSchema.extract([
   "traycer",
   "cursor",
   "grok",
+  "iflow",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 
@@ -123,6 +124,7 @@ export const agentFacingHarnessIdSchema = harnessIdSchema.extract([
   "traycer",
   "cursor",
   "grok",
+  "iflow",
 ]);
 export type AgentFacingHarnessId = z.infer<typeof agentFacingHarnessIdSchema>;
 
@@ -419,9 +421,7 @@ export const agentSummarySchemaV10 = agentSummarySchema.extend({
 export const listAgentsResponseSchemaV10 = listAgentsResponseSchema.extend({
   agents: z.array(agentSummarySchemaV10),
 });
-export type ListAgentsResponseV10 = z.infer<
-  typeof listAgentsResponseSchemaV10
->;
+export type ListAgentsResponseV10 = z.infer<typeof listAgentsResponseSchemaV10>;
 
 /**
  * `agent.sendMessage@1.0` - fire-and-forget enqueue from one agent to

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -19,6 +19,7 @@ export const providerIdSchema = z.enum([
   "cursor",
   "traycer",
   "grok",
+  "iflow",
 ]);
 export type ProviderId = z.infer<typeof providerIdSchema>;
 
@@ -45,6 +46,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderId, string> = {
   cursor: "Cursor",
   traycer: "Traycer",
   grok: "Grok",
+  iflow: "iFlow",
 };
 
 /**
@@ -177,7 +179,9 @@ export const providerLoginCapabilitySchema = z.object({
    */
   token: z.object({ vars: z.array(z.string()) }).nullable(),
 });
-export type ProviderLoginCapability = z.infer<typeof providerLoginCapabilitySchema>;
+export type ProviderLoginCapability = z.infer<
+  typeof providerLoginCapabilitySchema
+>;
 
 export const providerCliStateSchema = z.object({
   providerId: providerIdSchema,
@@ -221,7 +225,9 @@ export const providerCliStateSchemaV10 = providerCliStateSchema.extend({
 export const providersListResponseSchemaV10 = z.object({
   providers: z.array(providerCliStateSchemaV10),
 });
-export type ProvidersListResponseV10 = z.infer<typeof providersListResponseSchemaV10>;
+export type ProvidersListResponseV10 = z.infer<
+  typeof providersListResponseSchemaV10
+>;
 
 export const providersSetSelectionRequestSchema = z.object({
   providerId: providerIdSchema,

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -384,8 +384,8 @@ export const worktreeGetBindingV10 = defineRpcContract({
 // provider's resolved binary path + version, lets the user override the
 // binary per provider, and previews a candidate-path version without
 // committing it. Schemas live in `protocol/host/provider-schemas.ts`.
-// `providers.list` always returns every provider (incl. grok); v1.0 is frozen
-// grok-less, v2.0 carries grok, and the v2→v1 bridge drops grok for v1.0 clients.
+// `providers.list` always returns every provider; v1.0 is frozen without the
+// v2-only providers, and the v2→v1 bridge drops them for v1.0 clients.
 export const providersListV10 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 1, minor: 0 } as const,
@@ -421,7 +421,8 @@ export const providersListDowngradeV2ToV1 = defineDowngradePath<
     ok: true,
     value: providersListResponseSchemaV10.parse({
       providers: response.providers.filter(
-        (provider) => provider.providerId !== "grok",
+        (provider) =>
+          provider.providerId !== "grok" && provider.providerId !== "iflow",
       ),
     }),
   }),

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -63,6 +63,7 @@ export const guiHarnessIdSchema = z.enum([
   "traycer",
   "cursor",
   "grok",
+  "iflow",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 

--- a/protocol/src/persistence/epic/senders.ts
+++ b/protocol/src/persistence/epic/senders.ts
@@ -135,8 +135,20 @@ export const grokChatSessionAnchorSchema = z.object({
   sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
   createdAt: z.number(),
 });
-export type GrokChatSessionAnchor = z.infer<
-  typeof grokChatSessionAnchorSchema
+export type GrokChatSessionAnchor = z.infer<typeof grokChatSessionAnchorSchema>;
+
+// iFlow (ACP) resumes at session granularity only — `session/load` reloads the
+// whole ACP session, with no per-message truncation/fork point. `sessionId` is
+// that ACP session id.
+export const iflowChatSessionAnchorSchema = z.object({
+  harnessId: z.literal("iflow"),
+  hostId: z.string(),
+  sessionId: z.string(),
+  sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
+  createdAt: z.number(),
+});
+export type IflowChatSessionAnchor = z.infer<
+  typeof iflowChatSessionAnchorSchema
 >;
 
 export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
@@ -146,5 +158,6 @@ export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   cursorChatSessionAnchorSchema,
   traycerChatSessionAnchorSchema,
   grokChatSessionAnchorSchema,
+  iflowChatSessionAnchorSchema,
 ]);
 export type ChatSessionAnchor = z.infer<typeof chatSessionAnchorSchema>;


### PR DESCRIPTION
## Summary
- Add `iflow` to provider, GUI harness, agent-facing, persisted harness, and anchor schemas.
- Add iFlow chat/session anchors and GUI runtime anchor support after Grok in the ACP anchor unions.
- Extend the existing v2 -> v1 downgrade filters to drop iFlow alongside Grok, without a new schema major bump.
- Add iFlow GUI presence in provider settings, onboarding, reauth routing/copy, sender labels, and the harness icon map.
- Pair with internal host PR: https://github.com/traycerai/traycer-internal/pull/4127

## iFlow Viability
- Installed `@iflow-ai/iflow-cli` and verified `iflow --version` reports `0.5.19`.
- Verified `iflow --experimental-acp` starts an ACP server and `initialize` succeeds with `iflow-agent` version `0.5.19`.
- This environment is not logged in, so the bounded E2E probe is auth-limited: `session/new` returns `-32000: Authentication required` after a successful ACP handshake.
- The CLI advertises auth methods `oauth-iflow`, `iflow`, and `openai-compatible`.
- Headless login: the paired internal PR does not advertise bare `iflow` as a runnable OAuth command because it exits with `No input provided via stdin` under piped stdio; users can run `iflow` manually or paste `IFLOW_API_KEY`.

## Risk Status
- iFlow is best-effort / at-risk: the vendor posted a shutdown notice dated Apr 17 2026, and iFlow is not listed in the official ACP directory; ACP support is based on the installed npm CLI and an unofficial ACP-directory entry.

## Interview Transport Notes
- iFlow uses vendor ACP method `_iflow/user/questions`.
- Request params shape observed from the CLI bundle: `{ sessionId: string, questions: [{ question: string, header: string, options: [{ label: string, description: string }], multiSelect: boolean }] }`.
- Response shape: `{ answers: Record<string, string | string[]> }`, keyed by each question `header`.
- The parser/formatter lives in the paired internal PR and is registered through the generic ACP interview extension hook.

## Validation
- `bun run --filter @traycer/protocol compile`
- `bun run --filter @traycer-clients/gui-app compile`
- `bun run --filter @traycer/protocol test -- src/host/agent/gui/__tests__/grok-versioning.test.ts`
- `npx -y react-doctor@latest . --verbose --scope changed --base origin/main --offline --no-score --blocking warning` in `clients/gui-app`
