### PR TITLE
Add Kimi ACP protocol and GUI support

### DIFF
--- a/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
+++ b/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
@@ -10,13 +10,13 @@ import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { useTabProvidersList } from "@/hooks/providers/use-tab-providers-list-query";
 
 // The harness id set is a superset of the provider-CLI id set (it also carries
-// `traycer`, which has no provider-CLI login). Only CLI harnesses gate. Grok is
-// GUI-only (not in the TUI map) but DOES gate — its `grok login` subscription /
-// XAI_API_KEY auth surfaces as a provider, mirroring the host's
-// `harnessIdToProviderId`.
+// `traycer`, which has no provider-CLI login). Only CLI harnesses gate. Grok and
+// Kimi are GUI-only (not in the TUI map) but DO gate through their CLI login
+// providers, mirroring the host's `harnessIdToProviderId`.
 function providerIdForHarness(harnessId: GuiHarnessId): ProviderId | null {
   if (harnessId === "traycer") return null;
   if (harnessId === "grok") return "grok";
+  if (harnessId === "kimi") return "kimi";
   return TUI_HARNESS_ID_TO_PROVIDER_ID[harnessId];
 }
 

--- a/clients/gui-app/src/components/home/data/harness-icon-map.ts
+++ b/clients/gui-app/src/components/home/data/harness-icon-map.ts
@@ -3,6 +3,7 @@ import {
   CodexIcon,
   CursorIcon,
   GrokIcon,
+  KimiIcon,
   OpenCodeIcon,
   TraycerIcon,
   type HarnessIcon,
@@ -21,4 +22,5 @@ export const PROVIDER_ICON_CONFIG: Record<ProviderId, HarnessIconConfig> = {
   traycer: { Icon: TraycerIcon, className: "text-foreground" },
   cursor: { Icon: CursorIcon, className: "text-foreground" },
   grok: { Icon: GrokIcon, className: "text-foreground" },
+  kimi: { Icon: KimiIcon, className: "text-foreground" },
 };

--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -4,6 +4,7 @@ import ClaudeColor from "@lobehub/icons/es/Claude/components/Color";
 import OpenCodeMono from "@lobehub/icons/es/OpenCode/components/Mono";
 import CursorMono from "@lobehub/icons/es/Cursor/components/Mono";
 import GrokMono from "@lobehub/icons/es/Grok/components/Mono";
+import KimiMono from "@lobehub/icons/es/Kimi/components/Mono";
 
 export type HarnessIcon = (props: SVGProps<SVGSVGElement>) => ReactElement;
 
@@ -19,6 +20,7 @@ export const ClaudeAIIcon: HarnessIcon = (props) => <ClaudeColor {...props} />;
 export const OpenCodeIcon: HarnessIcon = (props) => <OpenCodeMono {...props} />;
 export const CursorIcon: HarnessIcon = (props) => <CursorMono {...props} />;
 export const GrokIcon: HarnessIcon = (props) => <GrokMono {...props} />;
+export const KimiIcon: HarnessIcon = (props) => <KimiMono {...props} />;
 
 // Traycer does not have a lobehub entry — hand-rolled from the brand mark.
 export const TraycerIcon: HarnessIcon = (props) => (

--- a/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
@@ -20,6 +20,7 @@ const TOUR_PROVIDERS: ReadonlyArray<{
   { id: "opencode", harnessId: "opencode" },
   { id: "cursor", harnessId: "cursor" },
   { id: "grok", harnessId: "grok" },
+  { id: "kimi", harnessId: "kimi" },
 ];
 
 type InstallState = "detected" | "missing" | "pending";

--- a/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
@@ -349,6 +349,12 @@ const PROVIDERS: ReadonlyArray<{
     status: "SuperGrok / X",
     capabilities: ["gui"],
   },
+  {
+    harnessId: "kimi",
+    label: "Kimi",
+    status: "Kimi account",
+    capabilities: ["gui"],
+  },
 ];
 
 const PALETTE_ROWS = [

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -100,6 +100,7 @@ const PROVIDER_DESCRIPTIONS: Record<ProviderId, string> = {
     "Cursor agent - SDK-driven chats authenticated with your Cursor API key.",
   traycer: "Traycer's managed harness uses the selected OpenCode CLI binary.",
   grok: "Grok agent - xAI's coding CLI via your SuperGrok / X subscription.",
+  kimi: "Kimi agent - MoonshotAI's coding CLI via your Kimi account.",
 };
 
 const TERMINAL_AGENT_ARGS_PLACEHOLDER: Record<
@@ -122,6 +123,7 @@ function terminalAgentArgsPlaceholder(providerId: ProviderId): string {
     case "cursor":
     case "traycer":
     case "grok":
+    case "kimi":
       return "CLI arguments (optional)";
   }
 }
@@ -133,6 +135,7 @@ const HARNESS_ICON_ID: Record<ProviderId, HarnessIconId> = {
   cursor: "cursor",
   traycer: "traycer",
   grok: "grok",
+  kimi: "kimi",
 };
 
 // Grid keeps the columns aligned across header + rows; `minmax(0,1fr)` on
@@ -731,6 +734,8 @@ function envNamePlaceholder(providerId: ProviderId): string {
       return "CURSOR_API_KEY";
     case "grok":
       return "XAI_API_KEY";
+    case "kimi":
+      return "KIMI_API_KEY";
   }
 }
 

--- a/clients/gui-app/src/lib/chat/sender-display.ts
+++ b/clients/gui-app/src/lib/chat/sender-display.ts
@@ -148,5 +148,7 @@ function agentProviderLabel(provider: GuiHarnessId): string {
       return "Cursor";
     case "grok":
       return "Grok";
+    case "kimi":
+      return "Kimi";
   }
 }

--- a/protocol/src/common/_internal/schemas.ts
+++ b/protocol/src/common/_internal/schemas.ts
@@ -55,4 +55,5 @@ export const harnessIdSchema = z.enum([
   "traycer",
   "cursor",
   "grok",
+  "kimi",
 ]);

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -62,13 +62,14 @@ export const agentSelectionGuideGlobalGetV10 = defineRpcContract({
   responseSchema: agentSelectionGuideGlobalGetResponseSchema,
 });
 
-export const agentSelectionGuideGlobalOnboardingDraftGetV10 =
-  defineRpcContract({
+export const agentSelectionGuideGlobalOnboardingDraftGetV10 = defineRpcContract(
+  {
     method: "agent.selectionGuide.getGlobalOnboardingDraft",
     schemaVersion: { major: 1, minor: 0 } as const,
     requestSchema: agentSelectionGuideGlobalOnboardingDraftGetRequestSchema,
     responseSchema: agentSelectionGuideGlobalOnboardingDraftGetResponseSchema,
-  });
+  },
+);
 
 export const agentSelectionGuideGlobalSetV10 = defineRpcContract({
   method: "agent.selectionGuide.setGlobal",
@@ -111,8 +112,9 @@ export const agentListUpgradeV1ToV2 = defineUpgradePath<
 >({
   from: { major: 1, minor: 0 },
   to: { major: 2, minor: 0 },
-  // A grok-less v1.0 response is a valid v2.0 response (grok is purely
-  // additive), and the request shape is identical — both upgrades are identity.
+  // A v1.0 response without ACP GUI harness agents is a valid v2.0 response
+  // (they are purely additive), and the request shape is identical - both
+  // upgrades are identity.
   upgradeRequest: (request) => request,
   upgradeResponse: (response) => response,
 });
@@ -124,13 +126,15 @@ export const agentListDowngradeV2ToV1 = defineDowngradePath<
   from: { major: 2, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
-  // Drop grok agents so a v1.0 client's strict (grok-less) decode never sees
-  // one. The re-parse yields the precise v1.0 type without an assertion.
+  // Drop ACP GUI harness agents so a v1.0 client's strict decode never sees
+  // them. The re-parse yields the precise v1.0 type without an assertion.
   downgradeResponse: (response) => ({
     ok: true,
     value: listAgentsResponseSchemaV10.parse({
       ...response,
-      agents: response.agents.filter((agent) => agent.harnessId !== "grok"),
+      agents: response.agents.filter(
+        (agent) => agent.harnessId !== "grok" && agent.harnessId !== "kimi",
+      ),
     }),
   }),
 });

--- a/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
@@ -65,42 +65,62 @@ function providerState(providerId: string) {
   };
 }
 
-describe("grok non-breaking v2→v1 downgrade bridges", () => {
-  it("drops grok from agent.gui.listHarnesses for v1.0 callers", () => {
+describe("ACP harness non-breaking v2→v1 downgrade bridges", () => {
+  it("drops grok and kimi from agent.gui.listHarnesses for v1.0 callers", () => {
     const v2Response = listGuiHarnessesResponseSchema.parse({
-      harnesses: [harnessOption("claude"), harnessOption("grok"), harnessOption("cursor")],
+      harnesses: [
+        harnessOption("claude"),
+        harnessOption("grok"),
+        harnessOption("kimi"),
+        harnessOption("cursor"),
+      ],
     });
 
-    const result = agentGuiListHarnessesDowngradeV2ToV1.downgradeResponse(v2Response);
+    const result =
+      agentGuiListHarnessesDowngradeV2ToV1.downgradeResponse(v2Response);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.harnesses.map((harness) => harness.id)).toEqual(["claude", "cursor"]);
-    // The downgraded value must satisfy the frozen grok-less v1.0 schema — i.e.
-    // a real v1.0 client's strict decode would accept it.
-    expect(() => listGuiHarnessesResponseSchemaV10.parse(result.value)).not.toThrow();
+    expect(result.value.harnesses.map((harness) => harness.id)).toEqual([
+      "claude",
+      "cursor",
+    ]);
+    // The downgraded value must satisfy the frozen v1.0 schema - i.e. a real
+    // v1.0 client's strict decode would accept it.
+    expect(() =>
+      listGuiHarnessesResponseSchemaV10.parse(result.value),
+    ).not.toThrow();
   });
 
-  it("drops grok from providers.list for v1.0 callers", () => {
+  it("drops grok and kimi from providers.list for v1.0 callers", () => {
     const v2Response = providersListResponseSchema.parse({
-      providers: [providerState("cursor"), providerState("grok")],
+      providers: [
+        providerState("cursor"),
+        providerState("grok"),
+        providerState("kimi"),
+      ],
     });
 
     const result = providersListDowngradeV2ToV1.downgradeResponse(v2Response);
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.providers.map((provider) => provider.providerId)).toEqual(["cursor"]);
-    expect(() => providersListResponseSchemaV10.parse(result.value)).not.toThrow();
+    expect(
+      result.value.providers.map((provider) => provider.providerId),
+    ).toEqual(["cursor"]);
+    expect(() =>
+      providersListResponseSchemaV10.parse(result.value),
+    ).not.toThrow();
   });
 
-  it("drops grok agents from agent.list for v1.0 callers", () => {
+  it("drops grok and kimi agents from agent.list for v1.0 callers", () => {
     const v2Response = listAgentsResponseSchema.parse({
       caller: { agentId: "self", canSendMessages: true },
       scope: "all",
       agents: [
         agentSummary("a-claude", "claude"),
         agentSummary("a-grok", "grok"),
+        agentSummary("a-kimi", "kimi"),
         agentSummary("a-null", null),
       ],
     });
@@ -109,8 +129,11 @@ describe("grok non-breaking v2→v1 downgrade bridges", () => {
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.agents.map((agent) => agent.id)).toEqual(["a-claude", "a-null"]);
-    // A real v1.0 client's strict (grok-less) decode must accept the result.
+    expect(result.value.agents.map((agent) => agent.id)).toEqual([
+      "a-claude",
+      "a-null",
+    ]);
+    // A real v1.0 client's strict decode must accept the result.
     expect(() => listAgentsResponseSchemaV10.parse(result.value)).not.toThrow();
   });
 });

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -675,6 +675,14 @@ export const grokUserMessageAnchorResolvedSchema = z.object({
   grokSessionId: z.string().nullable(),
 });
 
+export const kimiUserMessageAnchorResolvedSchema = z.object({
+  harnessId: z.literal("kimi"),
+  sessionId: z.string(),
+  // The ACP session id the `kimi acp` process assigned for this turn.
+  // Null until `session/new` resolves; used to resume the same ACP session.
+  kimiSessionId: z.string().nullable(),
+});
+
 export const userMessageAnchorResolvedEventSchema = z.object({
   ...baseRuntimeEventFields,
   type: z.literal("user_message.anchor_resolved"),
@@ -686,6 +694,7 @@ export const userMessageAnchorResolvedEventSchema = z.object({
     cursorUserMessageAnchorResolvedSchema,
     traycerUserMessageAnchorResolvedSchema,
     grokUserMessageAnchorResolvedSchema,
+    kimiUserMessageAnchorResolvedSchema,
   ]),
 });
 export type UserMessageAnchorResolvedEvent = z.infer<

--- a/protocol/src/host/agent/gui/contracts.ts
+++ b/protocol/src/host/agent/gui/contracts.ts
@@ -18,9 +18,10 @@ import { chatSubscribeV10 } from "@traycer/protocol/host/agent/gui/subscribe";
 
 // ─── GUI-surface catalog (`agent.gui.*`) ──────────────────────────────────
 
-// `agent.gui.listHarnesses` always returns the full catalog (incl. grok), so an
-// unguarded grok value would reach every caller. v1.0 is frozen grok-less (what
-// shipped); v2.0 carries grok; the v2→v1 bridge drops grok for v1.0 clients.
+// `agent.gui.listHarnesses` always returns the full catalog, so unguarded ACP
+// GUI harness ids would reach every caller. v1.0 is frozen without these ids
+// (what shipped); v2.0 carries them; the v2→v1 bridge drops them for v1.0
+// clients.
 export const agentGuiListHarnessesV10 = defineRpcContract({
   method: "agent.gui.listHarnesses",
   schemaVersion: { major: 1, minor: 0 } as const,
@@ -41,8 +42,9 @@ export const agentGuiListHarnessesUpgradeV1ToV2 = defineUpgradePath<
 >({
   from: { major: 1, minor: 0 },
   to: { major: 2, minor: 0 },
-  // Request shape is identical; a grok-less v1.0 response is a valid v2.0
-  // response (grok is purely additive), so both upgrades are identity.
+  // Request shape is identical; a v1.0 response without ACP GUI harnesses is a
+  // valid v2.0 response (they are purely additive), so both upgrades are
+  // identity.
   upgradeRequest: (request) => request,
   upgradeResponse: (response) => response,
 });
@@ -54,12 +56,14 @@ export const agentGuiListHarnessesDowngradeV2ToV1 = defineDowngradePath<
   from: { major: 2, minor: 0 },
   to: { major: 1, minor: 0 },
   downgradeRequest: (request) => ({ ok: true, value: request }),
-  // Drop grok so a v1.0 client's strict (grok-less) decode never sees it. The
-  // re-parse also yields the precise v1.0 type without an assertion.
+  // Drop ACP GUI harnesses so a v1.0 client's strict decode never sees them.
+  // The re-parse also yields the precise v1.0 type without an assertion.
   downgradeResponse: (response) => ({
     ok: true,
     value: listGuiHarnessesResponseSchemaV10.parse({
-      harnesses: response.harnesses.filter((harness) => harness.id !== "grok"),
+      harnesses: response.harnesses.filter(
+        (harness) => harness.id !== "grok" && harness.id !== "kimi",
+      ),
     }),
   }),
 });

--- a/protocol/src/host/agent/gui/unary-schemas.ts
+++ b/protocol/src/host/agent/gui/unary-schemas.ts
@@ -127,10 +127,11 @@ export const listGuiHarnessesResponseSchema = z.object({
   harnesses: z.array(guiHarnessOptionSchema),
 });
 
-// ── Frozen protocol-v1.0 (grok-less) catalog row + response ────────────────
-// A v1.0 client predates grok; the v2.0 line of `agent.gui.listHarnesses` adds
-// it, and the v2→v1 downgrade bridge filters grok out for v1.0 callers so their
-// strict (grok-less) decode never sees a value it can't parse.
+// ── Frozen protocol-v1.0 catalog row + response ────────────────────────────
+// A v1.0 client predates the ACP GUI harnesses; the v2.0 line of
+// `agent.gui.listHarnesses` adds them, and the v2→v1 downgrade bridge filters
+// them out for v1.0 callers so their strict decode never sees a value it can't
+// parse.
 export const guiHarnessOptionSchemaV10 = guiHarnessOptionSchema.extend({
   id: guiHarnessIdSchemaV10,
 });

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -51,16 +51,17 @@ export const guiHarnessIdSchema = harnessIdSchema.extract([
   "traycer",
   "cursor",
   "grok",
+  "kimi",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 
 /**
- * Frozen grok-less harness id set as shipped in protocol v1.0. Used only by the
- * frozen v1.0 response schema of `agent.gui.listHarnesses` so a v1.0 client
- * (which predates grok) negotiates a wire that can never carry it; the v2.0 line
- * adds grok and a v2→v1 downgrade bridge filters it for v1.0 callers. Do NOT add
- * new harnesses here — extend the latest `guiHarnessIdSchema` and bump the
- * method's major with a bridge instead.
+ * Frozen harness id set as shipped in protocol v1.0. Used only by the frozen
+ * v1.0 response schema of `agent.gui.listHarnesses` so a v1.0 client (which
+ * predates the ACP GUI harnesses) negotiates a wire that can never carry them;
+ * the v2.0 line adds them and a v2→v1 downgrade bridge filters them for v1.0
+ * callers. Do NOT add new harnesses here - extend the latest
+ * `guiHarnessIdSchema` and use the existing v2 bridge instead.
  */
 export const guiHarnessIdSchemaV10 = harnessIdSchema.extract([
   "claude",
@@ -123,6 +124,7 @@ export const agentFacingHarnessIdSchema = harnessIdSchema.extract([
   "traycer",
   "cursor",
   "grok",
+  "kimi",
 ]);
 export type AgentFacingHarnessId = z.infer<typeof agentFacingHarnessIdSchema>;
 
@@ -405,12 +407,12 @@ export const listAgentsResponseSchema = z.object({
 });
 export type ListAgentsResponse = z.infer<typeof listAgentsResponseSchema>;
 
-// ── Frozen protocol-v1.0 (grok-less) agent.list response ───────────────────
-// `agent.list` enumerates every agent in the epic — including grok chats a newer
-// client created — and the `traycer` CLI inlines the protocol at build time, so
-// an old (grok-less) CLI would hit a strict enum on a grok row. v1.0 is frozen
-// grok-less; the v2.0 line carries grok and a v2→v1 bridge drops grok agents for
-// v1.0 callers. Do not add new harnesses here — bump the major with a bridge.
+// ── Frozen protocol-v1.0 agent.list response ───────────────────────────────
+// `agent.list` enumerates every agent in the epic - including ACP GUI harness
+// chats a newer client created - and the `traycer` CLI inlines the protocol at
+// build time, so an old CLI would hit a strict enum on those rows. v1.0 is
+// frozen; the v2.0 line carries them and a v2→v1 bridge drops them for v1.0
+// callers. Do not add new harnesses here - use the existing v2 bridge.
 export const agentSummarySchemaV10 = agentSummarySchema.extend({
   harnessId: harnessIdSchema
     .extract(["claude", "codex", "opencode", "traycer", "cursor"])
@@ -419,9 +421,7 @@ export const agentSummarySchemaV10 = agentSummarySchema.extend({
 export const listAgentsResponseSchemaV10 = listAgentsResponseSchema.extend({
   agents: z.array(agentSummarySchemaV10),
 });
-export type ListAgentsResponseV10 = z.infer<
-  typeof listAgentsResponseSchemaV10
->;
+export type ListAgentsResponseV10 = z.infer<typeof listAgentsResponseSchemaV10>;
 
 /**
  * `agent.sendMessage@1.0` - fire-and-forget enqueue from one agent to

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -19,14 +19,15 @@ export const providerIdSchema = z.enum([
   "cursor",
   "traycer",
   "grok",
+  "kimi",
 ]);
 export type ProviderId = z.infer<typeof providerIdSchema>;
 
 /**
- * Frozen grok-less provider id set as shipped in protocol v1.0. Used only by the
- * frozen v1.0 `providers.list` response so a v1.0 client never receives the grok
- * provider; the v2.0 line adds it with a v2→v1 downgrade bridge. Do not add new
- * providers here.
+ * Frozen provider id set as shipped in protocol v1.0. Used only by the frozen
+ * v1.0 `providers.list` response so a v1.0 client never receives the ACP GUI
+ * harness providers; the v2.0 line adds them with a v2→v1 downgrade bridge. Do
+ * not add new providers here.
  */
 export const providerIdSchemaV10 = z.enum([
   "claude-code",
@@ -45,6 +46,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderId, string> = {
   cursor: "Cursor",
   traycer: "Traycer",
   grok: "Grok",
+  kimi: "Kimi",
 };
 
 /**
@@ -177,7 +179,9 @@ export const providerLoginCapabilitySchema = z.object({
    */
   token: z.object({ vars: z.array(z.string()) }).nullable(),
 });
-export type ProviderLoginCapability = z.infer<typeof providerLoginCapabilitySchema>;
+export type ProviderLoginCapability = z.infer<
+  typeof providerLoginCapabilitySchema
+>;
 
 export const providerCliStateSchema = z.object({
   providerId: providerIdSchema,
@@ -213,15 +217,18 @@ export const providersListResponseSchema = z.object({
 });
 export type ProvidersListResponse = z.infer<typeof providersListResponseSchema>;
 
-// Frozen protocol-v1.0 (grok-less) provider state + list response. The v2.0 line
-// of `providers.list` adds grok; the v2→v1 bridge filters it for v1.0 callers.
+// Frozen protocol-v1.0 provider state + list response. The v2.0 line of
+// `providers.list` adds ACP GUI harness providers; the v2→v1 bridge filters
+// them for v1.0 callers.
 export const providerCliStateSchemaV10 = providerCliStateSchema.extend({
   providerId: providerIdSchemaV10,
 });
 export const providersListResponseSchemaV10 = z.object({
   providers: z.array(providerCliStateSchemaV10),
 });
-export type ProvidersListResponseV10 = z.infer<typeof providersListResponseSchemaV10>;
+export type ProvidersListResponseV10 = z.infer<
+  typeof providersListResponseSchemaV10
+>;
 
 export const providersSetSelectionRequestSchema = z.object({
   providerId: providerIdSchema,

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -384,8 +384,9 @@ export const worktreeGetBindingV10 = defineRpcContract({
 // provider's resolved binary path + version, lets the user override the
 // binary per provider, and previews a candidate-path version without
 // committing it. Schemas live in `protocol/host/provider-schemas.ts`.
-// `providers.list` always returns every provider (incl. grok); v1.0 is frozen
-// grok-less, v2.0 carries grok, and the v2→v1 bridge drops grok for v1.0 clients.
+// `providers.list` always returns every provider; v1.0 is frozen without the
+// ACP GUI harness providers, v2.0 carries them, and the v2→v1 bridge drops them
+// for v1.0 clients.
 export const providersListV10 = defineRpcContract({
   method: "providers.list",
   schemaVersion: { major: 1, minor: 0 } as const,
@@ -421,7 +422,8 @@ export const providersListDowngradeV2ToV1 = defineDowngradePath<
     ok: true,
     value: providersListResponseSchemaV10.parse({
       providers: response.providers.filter(
-        (provider) => provider.providerId !== "grok",
+        (provider) =>
+          provider.providerId !== "grok" && provider.providerId !== "kimi",
       ),
     }),
   }),

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -63,6 +63,7 @@ export const guiHarnessIdSchema = z.enum([
   "traycer",
   "cursor",
   "grok",
+  "kimi",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 

--- a/protocol/src/persistence/epic/senders.ts
+++ b/protocol/src/persistence/epic/senders.ts
@@ -135,9 +135,19 @@ export const grokChatSessionAnchorSchema = z.object({
   sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
   createdAt: z.number(),
 });
-export type GrokChatSessionAnchor = z.infer<
-  typeof grokChatSessionAnchorSchema
->;
+export type GrokChatSessionAnchor = z.infer<typeof grokChatSessionAnchorSchema>;
+
+// Kimi (ACP) resumes at session granularity only — `session/load` reloads the
+// whole ACP session, with no per-message truncation/fork point — so the anchor
+// carries just the ACP session id. `sessionId` is that ACP session id.
+export const kimiChatSessionAnchorSchema = z.object({
+  harnessId: z.literal("kimi"),
+  hostId: z.string(),
+  sessionId: z.string(),
+  sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
+  createdAt: z.number(),
+});
+export type KimiChatSessionAnchor = z.infer<typeof kimiChatSessionAnchorSchema>;
 
 export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   claudeChatSessionAnchorSchema,
@@ -146,5 +156,6 @@ export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   cursorChatSessionAnchorSchema,
   traycerChatSessionAnchorSchema,
   grokChatSessionAnchorSchema,
+  kimiChatSessionAnchorSchema,
 ]);
 export type ChatSessionAnchor = z.infer<typeof chatSessionAnchorSchema>;


### PR DESCRIPTION
## Summary
- add `kimi` to the latest protocol harness/provider ids and persistence anchors
- add Kimi GUI presentation in onboarding, settings, provider icons, sender labels, and the reauth gate
- keep protocol v1.0 frozen and filter Grok + Kimi through the existing v2-to-v1 downgrade bridges; no new major bump

## Notes
- Kimi rides the existing Grok v2 protocol line rather than introducing a new schema major.
- The paired internal PR pins the current `MoonshotAI/kimi-cli` package at 1.48.0; that repo is being wound down in favor of `MoonshotAI/kimi-code`, so the pin is intentional for the current rollout.
- Paired internal PR: https://github.com/traycerai/traycer-internal/pull/4132

## Validation
- `bun install --frozen-lockfile`
- `bun run --filter @traycer/protocol compile`
- `bun run --filter @traycer-clients/gui-app compile`
- `bun run --filter @traycer/protocol test -- src/host/agent/gui/__tests__/grok-versioning.test.ts`
- `bun x -y react-doctor@latest . --verbose --offline --blocking warning --scope changed`

Full `bun run --cwd clients/gui-app react-doctor` still reports unrelated existing diagnostics in diagnostics settings / host ready gate areas; changed-scope React Doctor passed.