### PR TITLE
fix(auth): refresh token on device wake so long sessions survive sleep

### DIFF
--- a/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
@@ -194,6 +194,26 @@ function status(code: number): Promise<Response> {
   return Promise.resolve(new Response(null, { status: code }));
 }
 
+function base64url(value: string): string {
+  return btoa(value).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * A JWS-shaped access token whose payload carries a decodable `exp`, so the
+ * proactive refresh scheduler arms off it (the arbitrary opaque strings the
+ * other tests use carry no `exp` and leave the scheduler disabled).
+ */
+function jwtExpiringInMs(fromNowMs: number): string {
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = base64url(
+    JSON.stringify({
+      id: "user-1",
+      exp: Math.trunc((Date.now() + fromNowMs) / 1000),
+    }),
+  );
+  return `${header}.${payload}.signature`;
+}
+
 describe("AuthService", () => {
   let restoreFetch: () => void = () => undefined;
 
@@ -339,6 +359,75 @@ describe("AuthService", () => {
     expect(ctxAfter?.credentials.getBearerToken()).toBe("rotated-token");
     expect(reemits).toEqual([]);
     expect(service.getCurrentSessionSnapshot().token).toBe("rotated-token");
+  });
+
+  it("proactively refreshes the bearer on OS resume when the token is inside the lead window", async () => {
+    const { service, host } = makeService();
+    // 5m of life left → inside the ~10m proactive lead window. During a sleep
+    // the scheduler's monotonic timer is frozen, so without a wake hook this
+    // bearer would rot; the OS resume signal must drive an immediate refresh.
+    const nearExpiry = jwtExpiringInMs(5 * 60_000);
+    await host.tokenStore.set({
+      token: nearExpiry,
+      refreshToken: `${nearExpiry}-refresh`,
+    });
+    await service.start();
+    expect(useAuthStore.getState().status).toBe("signed-in");
+    expect(service.getCurrentSessionSnapshot().token).toBe(nearExpiry);
+
+    const provider = service.getRequestContextProvider();
+    const ctxBefore = provider.current();
+    const rotated = jwtExpiringInMs(4 * 60 * 60_000);
+    const refreshAuth: string[] = [];
+    restoreFetch();
+    restoreFetch = installFetch((input, init) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url === REFRESH_URL) {
+        refreshAuth.push(String(init?.headers?.Authorization));
+        return okWithRefreshToken(rotated);
+      }
+      return okWithProfile();
+    });
+
+    // Electron powerMonitor resume bridged through the runner host.
+    host.emitSystemResumed();
+
+    await vi.waitFor(() => {
+      expect(service.getCurrentSessionSnapshot().token).toBe(rotated);
+    });
+    expect(refreshAuth).toEqual([`Bearer ${nearExpiry}`]);
+    // Same-user rotation mutates the existing context's lease in place.
+    expect(provider.current()).toBe(ctxBefore);
+    expect(provider.current()?.credentials.getBearerToken()).toBe(rotated);
+  });
+
+  it("does not refresh on OS resume when the bearer is still well within its TTL", async () => {
+    const { service, host } = makeService();
+    const farExpiry = jwtExpiringInMs(4 * 60 * 60_000);
+    await host.tokenStore.set({
+      token: farExpiry,
+      refreshToken: `${farExpiry}-refresh`,
+    });
+    await service.start();
+    expect(service.getCurrentSessionSnapshot().token).toBe(farExpiry);
+
+    let refreshed = false;
+    restoreFetch();
+    restoreFetch = installFetch((input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url === REFRESH_URL) {
+        refreshed = true;
+        return okWithRefreshToken(jwtExpiringInMs(4 * 60 * 60_000));
+      }
+      return okWithProfile();
+    });
+
+    host.emitSystemResumed();
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+    expect(refreshed).toBe(false);
+    expect(service.getCurrentSessionSnapshot().token).toBe(farExpiry);
   });
 
   it("aborts the current context and emits null on cross-user revalidation", async () => {

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -34,6 +34,7 @@ import {
 } from "@/stores/auth/auth-store";
 import { normalizeAvatarUrl } from "@/lib/avatar-url";
 import { projectShareableTeams } from "@/hooks/epic/use-epic-shareable-teams";
+import { onWakeReconnect } from "@/lib/host/wake-reconnect";
 import { appLogger, describeLogError } from "@/lib/logger";
 import { AuthTokenStore } from "./auth-token-store";
 
@@ -212,6 +213,8 @@ export class AuthService {
   // session never carries a dead token into a live host call. Constructed in the
   // constructor; armed on every bearer (re)assignment, stopped on sign-out.
   private readonly refreshScheduler: ProactiveRefreshScheduler;
+  // Teardown hooks for the OS-wake refresh listeners, released in `dispose()`.
+  private readonly wakeDisposers: Array<() => void> = [];
   private disposed = false;
   // PKCE verifier generated at `signIn()` start, held in memory AND mirrored to
   // secure storage (`PKCE_VERIFIER_STORAGE_KEY`) until the matching callback
@@ -269,6 +272,7 @@ export class AuthService {
       minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
       onDiagnostic: null,
     });
+    this.installWakeRefreshListeners();
     const initialAuth = useAuthStore.getState();
     this.lastEmittedStatus = initialAuth.status;
     // Watch the public auth store ONLY to relay status transitions to
@@ -279,6 +283,32 @@ export class AuthService {
     this.authStoreUnsubscribe = useAuthStore.subscribe((state) => {
       this.emit(state.status);
     });
+  }
+
+  /**
+   * Refresh the bearer on device wake, since the scheduler's `setTimeout` is
+   * frozen during sleep and would otherwise rot the token past its TTL. Mirrors
+   * `subscribeStreamWakeReconnect`'s two triggers: `window 'online'` (network
+   * back) and `onSystemResumed` (Electron resume). `notifyResumed` is a no-op
+   * while signed out; the resume wiring is best-effort so it can't wedge
+   * construction, leaving the `online` listener as the fallback.
+   */
+  private installWakeRefreshListeners(): void {
+    this.wakeDisposers.push(
+      onWakeReconnect(() => {
+        this.refreshScheduler.notifyResumed();
+      }),
+    );
+    try {
+      const resume = this.runnerHost.onSystemResumed(() => {
+        this.refreshScheduler.notifyResumed();
+      });
+      this.wakeDisposers.push(() => resume.dispose());
+    } catch (error) {
+      appLogger.warn("[auth] OS-resume wake refresh unavailable", {
+        error: describeLogError(error),
+      });
+    }
   }
 
   /**
@@ -1255,6 +1285,10 @@ export class AuthService {
     }
     this.disposed = true;
     this.refreshScheduler.stop();
+    for (const disposeWake of this.wakeDisposers) {
+      disposeWake();
+    }
+    this.wakeDisposers.length = 0;
     this.clearPendingTimeout();
     if (this.callbackDisposable !== null) {
       this.callbackDisposable.dispose();

--- a/clients/shared/auth/__tests__/token-refresh-scheduler.test.ts
+++ b/clients/shared/auth/__tests__/token-refresh-scheduler.test.ts
@@ -37,6 +37,12 @@ function makeFakeClock() {
       timers = timers.filter((t) => t.id !== id);
     },
     pendingCount: (): number => timers.length,
+    // Advance the wall clock WITHOUT firing any timer - models an OS suspend,
+    // where `Date.now()` keeps moving but the monotonic `setTimeout` countdown
+    // is frozen, so an armed timer does not fire while the device sleeps.
+    jump(ms: number): void {
+      now += ms;
+    },
     async advance(ms: number): Promise<void> {
       now += ms;
       const due = timers.filter((t) => t.at <= now).sort((a, b) => a.at - b.at);
@@ -232,6 +238,103 @@ describe("createProactiveRefreshScheduler", () => {
     expect(clock.pendingCount()).toBe(0);
     await clock.advance(8 * HOUR_MS);
     expect(revalidate).not.toHaveBeenCalled();
+  });
+
+  it("refreshes on notifyResumed when a sleep pushed the token into the lead window", async () => {
+    const clock = makeFakeClock();
+    let token: string | null = tokenExpiringAtMs(4 * HOUR_MS);
+    const revalidate = vi.fn(async () => {
+      token = tokenExpiringAtMs(clock.now() + 4 * HOUR_MS);
+    });
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => token,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    scheduler.start();
+    expect(clock.pendingCount()).toBe(1);
+
+    // The device sleeps until the token is inside the lead window. The armed
+    // timer's monotonic countdown is frozen, so it never fires - the bearer just
+    // rots in place (the overnight-session bug).
+    clock.jump(4 * HOUR_MS - DEFAULT_REFRESH_LEAD_MS + 60_000);
+    expect(revalidate).not.toHaveBeenCalled();
+
+    // Wake: re-evaluate against the wall clock → token inside the lead window →
+    // refresh now. The stale frozen timer is dropped and a fresh one armed off
+    // the rotated token (so the count stays at exactly one).
+    scheduler.notifyResumed();
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+    expect(revalidate).toHaveBeenCalledTimes(1);
+    expect(clock.pendingCount()).toBe(1);
+
+    scheduler.stop();
+    expect(clock.pendingCount()).toBe(0);
+  });
+
+  it("re-arms without refreshing on notifyResumed when the token is still outside the lead window", async () => {
+    const clock = makeFakeClock();
+    const token: string = tokenExpiringAtMs(4 * HOUR_MS);
+    const revalidate = vi.fn(async () => {});
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => token,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    scheduler.start();
+    // A short nap that leaves the token well clear of the lead window.
+    clock.jump(60_000);
+
+    scheduler.notifyResumed();
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+    expect(revalidate).not.toHaveBeenCalled();
+    // Still armed (off the same, still-valid token), so it keeps watching.
+    expect(clock.pendingCount()).toBe(1);
+
+    scheduler.stop();
+  });
+
+  it("notifyResumed is a no-op while stopped", async () => {
+    const clock = makeFakeClock();
+    const token: string = tokenExpiringAtMs(60_000);
+    const revalidate = vi.fn(async () => {});
+
+    const scheduler = createProactiveRefreshScheduler<number>({
+      getToken: () => token,
+      revalidate,
+      now: clock.now,
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
+      leadMs: DEFAULT_REFRESH_LEAD_MS,
+      minDelayMs: DEFAULT_REFRESH_MIN_DELAY_MS,
+      onDiagnostic: null,
+    });
+
+    // Never started (or already stopped): a wake signal must not refresh or arm.
+    scheduler.notifyResumed();
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(clock.pendingCount()).toBe(0);
   });
 
   it("clamps a far-future exp so the timer can't overflow and fire immediately", async () => {

--- a/clients/shared/auth/auth-validation.ts
+++ b/clients/shared/auth/auth-validation.ts
@@ -175,8 +175,7 @@ type UserFetchResult =
   | {
       readonly kind: "failed";
       readonly result:
-        | { readonly kind: "rejected" }
-        | { readonly kind: "network-error" };
+        { readonly kind: "rejected" } | { readonly kind: "network-error" };
     };
 
 async function fetchUserResponse(

--- a/clients/shared/auth/token-refresh-scheduler.ts
+++ b/clients/shared/auth/token-refresh-scheduler.ts
@@ -15,6 +15,11 @@
  * refresh mechanics - only the timing - so the reactive paths and this proactive
  * one share one rotation primitive and can't drift.
  *
+ * The delay is measured from the wall-clock `exp`, but `setTimeout` counts down
+ * in MONOTONIC time, frozen while the OS sleeps - so a session that sleeps
+ * through the TTL wakes with a dead bearer and a stale timer. `notifyResumed()`
+ * is the wake hook: it re-evaluates against the wall clock at once.
+ *
  * The scheduler is timer- and clock-injected so it is environment-agnostic
  * (`window.setTimeout` in the renderer, `setTimeout` in the CLI) and
  * deterministically testable.
@@ -46,6 +51,12 @@ export interface ProactiveRefreshScheduler {
   start(): void;
   /** Cancel any pending refresh and stop re-arming. */
   stop(): void;
+  /**
+   * Re-evaluate now (drop the sleep-frozen timer, refresh if inside the lead
+   * window, else re-arm) - call on device wake. No-op while stopped, so it is
+   * safe to call on every wake regardless of auth state.
+   */
+  notifyResumed(): void;
 }
 
 export interface ProactiveRefreshSchedulerOptions<THandle> {
@@ -147,6 +158,15 @@ export function createProactiveRefreshScheduler<THandle>(
     stop(): void {
       stopped = true;
       clearScheduled();
+    },
+    notifyResumed(): void {
+      if (stopped) {
+        return;
+      }
+      // Drop the sleep-frozen timer and re-run the fire evaluation now; the
+      // single-flight `revalidate` coalesces with any concurrent reactive refresh.
+      clearScheduled();
+      void onFire();
     },
   };
 }

--- a/clients/shared/host-transport/i-stream-session.ts
+++ b/clients/shared/host-transport/i-stream-session.ts
@@ -25,10 +25,7 @@ import type { FatalErrorDetails } from "@traycer/protocol/framework/ws-protocol"
  *   - `close()` is idempotent and stops further reconnect attempts.
  */
 export type StreamConnectionStatus =
-  | "connecting"
-  | "open"
-  | "reconnecting"
-  | "closed";
+  "connecting" | "open" | "reconnecting" | "closed";
 
 /**
  * Reason surfaced alongside `"closed"` transitions so the consumer can

--- a/clients/shared/host-transport/ws-stream-factory.ts
+++ b/clients/shared/host-transport/ws-stream-factory.ts
@@ -29,8 +29,7 @@ export interface StreamWebSocketBinaryMessageEvent {
 }
 
 export type StreamWebSocketMessageEvent =
-  | StreamWebSocketTextMessageEvent
-  | StreamWebSocketBinaryMessageEvent;
+  StreamWebSocketTextMessageEvent | StreamWebSocketBinaryMessageEvent;
 
 /**
  * Subset of the native WebSocket surface required by `WsStreamClient`. The

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -345,11 +345,7 @@ export interface TraycerPidMetadata {
 }
 
 export type BootstrapPhase =
-  | "starting"
-  | "exited"
-  | "crashed"
-  | "killed"
-  | "failed-to-spawn";
+  "starting" | "exited" | "crashed" | "killed" | "failed-to-spawn";
 
 export interface BootstrapMarkerEntry {
   readonly timestamp: string;
@@ -476,8 +472,7 @@ export interface IServiceHost {
  * message.
  */
 export type AuthCallbackResult =
-  | { readonly code: string }
-  | { readonly error: string };
+  { readonly code: string } | { readonly error: string };
 
 export interface AuthValidationProfile {
   readonly userId: string;


### PR DESCRIPTION
## Summary

The proactive refresh scheduler added in #83 arms a `setTimeout` whose monotonic countdown freezes while the OS is suspended, so a session that sleeps through the ~4h token TTL wakes with a dead bearer and the next live host call (a resumed long-running task spawning a sub-agent) 401s — only the reactive 401 path recovers, after a user-visible failure. This adds `ProactiveRefreshScheduler.notifyResumed()` to re-evaluate the refresh deadline against the wall clock immediately, and wires the renderer's `AuthService` to the OS-wake signals (`onSystemResumed` + `window 'online'`) the stream transports already use, so on wake the bearer refreshes and propagates to the host in place via the existing `credentialUpdate` push before that first call. Tests cover the new scheduler hook and the AuthService wake wiring.

## Related issue

Closes #103

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`) — `pre-commit` not installed in this environment
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
