### PR TITLE
fix(gui-app): Droid API-key UX — provider-aware placeholder + store reauth key as secret

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/provider-reauth-banner.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   awaitLoginMutate: vi.fn(),
   cancelLoginMutate: vi.fn(),
   setEnvOverrideMutate: vi.fn(),
+  setApiKeyMutate: vi.fn(),
   refreshProviders: vi.fn(() => Promise.resolve()),
   openExternalLink: vi.fn(),
   hostKind: "local",
@@ -61,6 +62,12 @@ vi.mock("@/hooks/providers/use-providers-cancel-login-mutation", () => ({
 vi.mock("@/hooks/providers/use-providers-set-env-override-mutation", () => ({
   useProvidersSetEnvOverride: () => ({
     mutate: mocks.setEnvOverrideMutate,
+    isPending: false,
+  }),
+}));
+vi.mock("@/hooks/providers/use-providers-set-api-key-mutation", () => ({
+  useProvidersSetApiKey: () => ({
+    mutate: mocks.setApiKeyMutate,
     isPending: false,
   }),
 }));
@@ -162,7 +169,7 @@ function droidState(): ProviderCliState {
     },
     authPending: false,
     checkedAt: null,
-    apiKey: { supported: false, configured: false, source: null },
+    apiKey: { supported: true, configured: false, source: null },
     terminalAgentArgs: "",
     envOverrides: [],
     loginCapability: DROID_CAP,
@@ -175,6 +182,7 @@ describe("<ProviderReauthBanner />", () => {
     mocks.awaitLoginMutate.mockClear();
     mocks.cancelLoginMutate.mockClear();
     mocks.setEnvOverrideMutate.mockClear();
+    mocks.setApiKeyMutate.mockClear();
     mocks.refreshProviders.mockClear();
     mocks.hostKind = "local";
   });
@@ -206,6 +214,23 @@ describe("<ProviderReauthBanner />", () => {
     ).toBeDefined();
     expect(screen.getByRole("button", { name: "Save" })).toBeDefined();
     expect(mocks.startLoginMutate).not.toHaveBeenCalled();
+  });
+
+  it("stores a pasted Droid key as the encrypted API-key secret, not an env override", () => {
+    render(<ProviderReauthBanner providerId="droid" state={droidState()} />);
+
+    const input = screen.getByPlaceholderText("Paste your FACTORY_API_KEY");
+    fireEvent.change(input, { target: { value: "  fk-droid-123  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    // Droid has an encrypted host-side key store, so the banner persists the key
+    // as that secret (`providers.setApiKey`) — exactly like Settings > Providers —
+    // rather than a plaintext env override.
+    expect(mocks.setApiKeyMutate).toHaveBeenCalledWith(
+      { providerId: "droid", apiKey: "fk-droid-123" },
+      expect.anything(),
+    );
+    expect(mocks.setEnvOverrideMutate).not.toHaveBeenCalled();
   });
 
   it("re-checks sign-in status via the manual Refresh button", () => {

--- a/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
+++ b/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
@@ -27,6 +27,7 @@ import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import { useProvidersCancelLogin } from "@/hooks/providers/use-providers-cancel-login-mutation";
 import { useProvidersSetEnvOverride } from "@/hooks/providers/use-providers-set-env-override-mutation";
+import { useProvidersSetApiKey } from "@/hooks/providers/use-providers-set-api-key-mutation";
 import { useProvidersStartLogin } from "@/hooks/providers/use-providers-start-login-mutation";
 import { useProvidersAwaitLogin } from "@/hooks/providers/use-providers-await-login-mutation";
 import { useTabRefreshProviders } from "@/hooks/providers/use-tab-refresh-providers";
@@ -206,6 +207,10 @@ function ReauthBannerInner({
 }) {
   const providerLabel = PROVIDER_DISPLAY_NAMES[providerId];
   const { envVars, canOauth } = deriveLoginOptions(state, isLocalHost);
+  // Providers with a host-side encrypted API-key store (Cursor / Droid) save the
+  // pasted key as that secret (`providers.setApiKey`) rather than a plaintext env
+  // override, matching how Settings > Providers stores it.
+  const apiKeySupported = state?.apiKey.supported ?? false;
 
   // No reconnect method available from here: a provider with no web login, or an
   // OAuth-only provider on a remote host (loopback unreachable) with no paste
@@ -241,6 +246,7 @@ function ReauthBannerInner({
           providerId={providerId}
           envVars={envVars}
           secondary={canOauth}
+          apiKeySupported={apiKeySupported}
         />
       ) : null}
     </ReauthBannerShell>
@@ -340,20 +346,28 @@ function OAuthReauthForm({
   );
 }
 
-// Paste a fresh credential (API key / OAuth token) into one of the provider's
-// supported env vars, written via `providers.setEnvOverride` on the tab host,
-// then immediately force-probes auth. If the probe returns authenticated the gate
-// unmounts this banner; if still unauthenticated (bad token) we stay mounted and
-// show an inline error so the user can try again without a page reload.
+// Paste a fresh credential into the provider's reconnect path, then immediately
+// force-probe auth. Providers with a host-side encrypted API-key store (Cursor /
+// Droid) save it as that secret via `providers.setApiKey` — the same path as
+// Settings > Providers; OAuth-token providers (Claude Code / Grok) write the
+// chosen credential var via `providers.setEnvOverride`. If the probe returns
+// authenticated the gate unmounts this banner; if still unauthenticated (bad
+// token) we stay mounted and show an inline error so the user can retry without a
+// page reload.
 function TokenReauthForm({
   providerId,
   envVars,
   secondary,
+  apiKeySupported,
 }: {
   readonly providerId: ProviderId;
   readonly envVars: ReadonlyArray<string>;
   // True when rendered beneath the OAuth button as the fallback option.
   readonly secondary: boolean;
+  // True when the provider has an encrypted host-side API-key store (Cursor /
+  // Droid), so the pasted key is saved as that secret instead of a plaintext env
+  // override.
+  readonly apiKeySupported: boolean;
 }) {
   const inputId = useId();
   const [draft, setDraft] = useState("");
@@ -361,6 +375,7 @@ function TokenReauthForm({
   const [probing, setProbing] = useState(false);
   const [tokenError, setTokenError] = useState<string | null>(null);
   const setEnvOverride = useProvidersSetEnvOverride();
+  const setApiKey = useProvidersSetApiKey();
   const refreshProviders = useTabRefreshProviders();
   const queryClient = useQueryClient();
   const tabHostId = useTabHostId();
@@ -372,55 +387,62 @@ function TokenReauthForm({
       ? pickedVar
       : (envVars[0] ?? "");
 
-  const busy = setEnvOverride.isPending || probing;
+  const busy = setEnvOverride.isPending || setApiKey.isPending || probing;
+
+  // Shared post-write step: force-probe auth after the credential is stored.
+  // `useTabRefreshProviders` writes the fresh probe result into the query cache
+  // synchronously in its `onSuccess` before `mutateAsync` resolves, so by the
+  // time the `.then()` runs the cache already holds the updated auth status. Read
+  // it directly rather than using `finally` (which fires on both success and
+  // failure, causing a false "not accepted" flash when the token is valid and the
+  // gate is about to unmount this component).
+  const afterWrite = (): void => {
+    setDraft("");
+    setProbing(true);
+    void refreshProviders()
+      .then(() => {
+        setProbing(false);
+        const data = queryClient.getQueryData<
+          ResponseOfMethod<HostRpcRegistry, "providers.list">
+        >(
+          hostQueryKeys.method<HostRpcRegistry, "providers.list">(
+            tabHostId,
+            "providers.list",
+            {},
+          ),
+        );
+        const providerState = data?.providers.find(
+          (p) => p.providerId === providerId,
+        );
+        if (providerState?.auth.status === "unauthenticated") {
+          setTokenError("Token not accepted — double-check and try again.");
+        }
+        // If authenticated, the gate reads the updated cache and unmounts this
+        // banner. No action needed here.
+      })
+      .catch(() => {
+        setProbing(false);
+        setTokenError("Couldn't verify token — please try again.");
+      });
+  };
 
   const onSave = (): void => {
     const trimmed = draft.trim();
     if (trimmed.length === 0 || activeVar === "" || busy) return;
     setTokenError(null);
-    setEnvOverride.mutate(
-      { providerId, key: activeVar, value: trimmed },
-      {
-        onSuccess: () => {
-          setDraft("");
-          setProbing(true);
-          // Force-probe after the override is written. `useTabRefreshProviders`
-          // writes the fresh probe result into the query cache synchronously in
-          // its `onSuccess` before `mutateAsync` resolves, so by the time the
-          // `.then()` runs below the cache already holds the updated auth status.
-          // Read it directly rather than using `finally` (which fires on both
-          // success and failure, causing a false "not accepted" flash when the
-          // token is valid and the gate is about to unmount this component).
-          void refreshProviders()
-            .then(() => {
-              setProbing(false);
-              const data = queryClient.getQueryData<
-                ResponseOfMethod<HostRpcRegistry, "providers.list">
-              >(
-                hostQueryKeys.method<HostRpcRegistry, "providers.list">(
-                  tabHostId,
-                  "providers.list",
-                  {},
-                ),
-              );
-              const providerState = data?.providers.find(
-                (p) => p.providerId === providerId,
-              );
-              if (providerState?.auth.status === "unauthenticated") {
-                setTokenError(
-                  "Token not accepted — double-check and try again.",
-                );
-              }
-              // If authenticated, the gate reads the updated cache and unmounts
-              // this banner. No action needed here.
-            })
-            .catch(() => {
-              setProbing(false);
-              setTokenError("Couldn't verify token — please try again.");
-            });
-        },
-      },
-    );
+    if (apiKeySupported) {
+      // Cursor / Droid: store as the encrypted host-side secret, exactly like
+      // Settings > Providers.
+      setApiKey.mutate(
+        { providerId, apiKey: trimmed },
+        { onSuccess: afterWrite },
+      );
+    } else {
+      setEnvOverride.mutate(
+        { providerId, key: activeVar, value: trimmed },
+        { onSuccess: afterWrite },
+      );
+    }
   };
 
   return (

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -876,7 +876,7 @@ function ApiKeySection({ state }: { readonly state: ProviderCliState }) {
           placeholder={
             state.apiKey.source === "stored"
               ? "Replace stored key…"
-              : "Paste your Cursor API key"
+              : `Paste your ${PROVIDER_DISPLAY_NAMES[providerId]} API key`
           }
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
@@ -910,8 +910,8 @@ function ApiKeySection({ state }: { readonly state: ProviderCliState }) {
       </div>
       <p className="text-ui-xs text-muted-foreground">
         {state.apiKey.source === "env"
-          ? "Using CURSOR_API_KEY from your shell environment. Save a key here to override it."
-          : "Stored encrypted on this device. Falls back to CURSOR_API_KEY from your shell when unset."}
+          ? `Using ${envNamePlaceholder(providerId)} from your shell environment. Save a key here to override it.`
+          : `Stored encrypted on this device. Falls back to ${envNamePlaceholder(providerId)} from your shell when unset.`}
       </p>
     </div>
   );


### PR DESCRIPTION
Follow-up to #90 (Droid provider). Two GUI fixes for Droid's API-key auth UX; no host/protocol changes.

## Bug 1 — Settings > Providers showed Cursor's placeholder for Droid
The API-key field's placeholder and shell-fallback hint were hardcoded to `Cursor` / `CURSOR_API_KEY` for every API-key provider. They're now derived per-provider from `PROVIDER_DISPLAY_NAMES[providerId]` and the existing `envNamePlaceholder(providerId)` helper, so Droid shows **"Paste your Droid API key"** and references **FACTORY_API_KEY**.

## Bug 2 — Chat reauth modal stored the key as a plaintext env override
The composer reauth banner's token paste form wrote every credential via `providers.setEnvOverride` (plaintext). Providers with an encrypted host-side key store (`apiKey.supported` — Cursor / Droid) now save via **`providers.setApiKey`**, the same encrypted-secret path as Settings > Providers. OAuth-token providers (Claude Code / Grok, which expose `token.vars` but are not API-key-backed) keep `setEnvOverride`. The host already prefers the stored key and injects it as `FACTORY_API_KEY` at spawn, so no host change is required.

Also corrected a stale test fixture (`droidState()` had `apiKey.supported: false`, which never matched production) and added a test asserting the Droid reauth save uses the encrypted secret rather than an env override.

## Validation
gui-app compile · provider-reauth-banner tests (10) · providers-settings-panel tests (4) · prettier · eslint · react-doctor (no issues).