### PR TITLE
Improve context usage breakdown UX and add support for pinned breakdown

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
@@ -42,6 +42,12 @@ function percentLeft(usage: TokenUsage | null): number | null {
   return computeEffectiveContextUsage(usage)?.percentLeft ?? null;
 }
 
+function queryCompactContextTrigger() {
+  return screen.queryByRole("button", {
+    name: /open context usage breakdown/i,
+  });
+}
+
 function render(ui: ReactElement) {
   const result = testingRender(
     <TooltipProvider delayDuration={0}>
@@ -354,16 +360,18 @@ describe("ContextUsageChip", () => {
     const pinButton = await screen.findByRole("button", {
       name: "Pin breakdown",
     });
+    pinButton.focus();
     fireEvent.click(pinButton);
     expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(true);
-    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(queryCompactContextTrigger()).toBeNull();
     expect(screen.getByTestId("context-usage-pinned-strip")).toBeTruthy();
 
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Unpin context usage breakdown",
-      }),
-    );
+    const unpinButton = screen.getByRole("button", {
+      name: "Unpin context usage breakdown",
+    });
+    expect(document.activeElement).toBe(unpinButton);
+
+    fireEvent.click(unpinButton);
     expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(false);
     expect(
       screen.getByRole("button", {
@@ -413,7 +421,7 @@ describe("ContextUsageChip", () => {
         name: /Context window 75% left/,
       }),
     ).toBeNull();
-    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(queryCompactContextTrigger()).toBeNull();
 
     const strip = screen.getByTestId("context-usage-pinned-strip");
     expect(
@@ -520,7 +528,7 @@ describe("ContextUsageChip", () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
     const { rerender } = render(<ContextUsageChip usage={RELIABLE_USAGE} />);
 
-    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(queryCompactContextTrigger()).toBeNull();
     expect(screen.getByText("50K / 200K used")).toBeTruthy();
 
     rerender(
@@ -535,7 +543,7 @@ describe("ContextUsageChip", () => {
       />,
     );
 
-    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(queryCompactContextTrigger()).toBeNull();
     await waitFor(() => {
       expect(
         screen.getByTestId("context-usage-pinned-percent-value").textContent,

--- a/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
@@ -3,11 +3,19 @@ import "../../../../__tests__/test-browser-apis";
 import {
   cleanup,
   fireEvent,
-  render,
+  render as testingRender,
   screen,
+  waitFor,
   within,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  domAnimation,
+  hasReducedMotionListener,
+  LazyMotion,
+  prefersReducedMotion,
+} from "motion/react";
+import type { ReactElement } from "react";
 
 import {
   buildContextUsageRows,
@@ -26,13 +34,62 @@ const RELIABLE_USAGE: TokenUsage = {
   contextWindow: 200_000,
 };
 
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion)";
+const defaultMatchMedia = window.matchMedia;
+
 function percentLeft(usage: TokenUsage | null): number | null {
   return computeEffectiveContextUsage(usage)?.percentLeft ?? null;
+}
+
+function render(ui: ReactElement) {
+  const result = testingRender(
+    <LazyMotion features={domAnimation}>{ui}</LazyMotion>,
+  );
+  return {
+    ...result,
+    rerender: (nextUi: ReactElement) =>
+      result.rerender(
+        <LazyMotion features={domAnimation}>{nextUi}</LazyMotion>,
+      ),
+  };
+}
+
+function resetMotionReducedMotionPreference(): void {
+  prefersReducedMotion.current = null;
+  hasReducedMotionListener.current = false;
+}
+
+function restoreDefaultMatchMedia(): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: defaultMatchMedia,
+  });
+}
+
+function installReducedMotionPreference(matches: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query === REDUCED_MOTION_QUERY ? matches : false,
+      media: query,
+      onchange: null,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+  resetMotionReducedMotionPreference();
 }
 
 function resetContextUsageSettings(): void {
   window.localStorage.clear();
   useSettingsStore.setState({ pinContextUsageBreakdown: false });
+  restoreDefaultMatchMedia();
+  resetMotionReducedMotionPreference();
 }
 
 beforeEach(resetContextUsageSettings);
@@ -222,6 +279,9 @@ describe("ContextUsageChip", () => {
       name: /Context window 75% left/,
     });
     expect(button.textContent).toBe("75% context left");
+    expect(screen.queryByTestId("context-usage-pinned-percent-value")).toBe(
+      null,
+    );
     expect(
       screen
         .getByTestId("context-usage-meter")
@@ -351,9 +411,33 @@ describe("ContextUsageChip", () => {
     expect(screen.queryByTestId("context-usage-chip")).toBeNull();
 
     const strip = screen.getByTestId("context-usage-pinned-strip");
-    expect(within(strip).getByText("Context 75%")).toBeTruthy();
+    expect(
+      within(strip).getByTestId("context-usage-pinned-primary").textContent,
+    ).toMatch(/Context\s+75%/);
+    expect(
+      within(strip).getByTestId("context-usage-pinned-percent-value")
+        .textContent,
+    ).toBe("75");
     expect(within(strip).getByText("50K / 200K")).toBeTruthy();
     expect(within(strip).getByText("1.0k")).toBeTruthy();
+  });
+
+  it("keeps detailed popover values on the static text path", async () => {
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Context window 75% left/,
+      }),
+    );
+
+    expect(await screen.findByText("Context window")).toBeTruthy();
+    expect(screen.getByText("75% left")).toBeTruthy();
+    expect(screen.getByText("50K / 200K")).toBeTruthy();
+    expect(screen.getByText("1.0k")).toBeTruthy();
+    expect(screen.queryByTestId("context-usage-pinned-percent-value")).toBe(
+      null,
+    );
   });
 
   it("keeps the pinned strip hidden when the setting is enabled without reliable usage", () => {
@@ -420,7 +504,7 @@ describe("ContextUsageChip", () => {
     expect(within(strip).getByText("Output")).toBeTruthy();
   });
 
-  it("updates the pinned strip from the same usage value", () => {
+  it("updates the pinned strip from the same usage value", async () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
     const { rerender } = render(<ContextUsageChip usage={RELIABLE_USAGE} />);
 
@@ -440,9 +524,39 @@ describe("ContextUsageChip", () => {
     );
 
     expect(screen.queryByTestId("context-usage-chip")).toBeNull();
-    expect(screen.getByText("Context 25%")).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("context-usage-pinned-percent-value").textContent,
+      ).toBe("25");
+    });
     expect(screen.getByText("150K / 200K used")).toBeTruthy();
     expect(screen.queryByText("50K / 200K used")).toBeNull();
+  });
+
+  it("updates the pinned percent instantly when reduced motion is requested", () => {
+    installReducedMotionPreference(true);
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    const { rerender } = render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    expect(
+      screen.getByTestId("context-usage-pinned-percent-value").textContent,
+    ).toBe("75");
+
+    rerender(
+      <ContextUsageChip
+        usage={{
+          inputTokens: 150_000,
+          outputTokens: 2_000,
+          totalTokens: 152_000,
+          contextTokens: 150_000,
+          contextWindow: 200_000,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("context-usage-pinned-percent-value").textContent,
+    ).toBe("25");
   });
 
   it("marks the pinned strip summary and details with container-query collapse classes", () => {

--- a/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
@@ -1,24 +1,45 @@
 import "../../../../__tests__/test-browser-apis";
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
-import type { ReactNode } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { computeEffectiveContextUsage } from "@/components/chat/context-usage";
+import {
+  buildContextUsageRows,
+  computeEffectiveContextUsage,
+  formatContextUsageRowValue,
+} from "@/components/chat/context-usage";
 import { ContextUsageChip } from "@/components/chat/context-usage-chip";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import type { TokenUsage } from "@traycer/protocol/persistence/epic/foundation";
+
+const RELIABLE_USAGE: TokenUsage = {
+  inputTokens: 50_000,
+  outputTokens: 1_000,
+  totalTokens: 51_000,
+  contextTokens: 50_000,
+  contextWindow: 200_000,
+};
 
 function percentLeft(usage: TokenUsage | null): number | null {
   return computeEffectiveContextUsage(usage)?.percentLeft ?? null;
 }
 
-function withTooltipProvider(node: ReactNode): ReactNode {
-  return <TooltipProvider>{node}</TooltipProvider>;
+function resetContextUsageSettings(): void {
+  window.localStorage.clear();
+  useSettingsStore.setState({ pinContextUsageBreakdown: false });
 }
+
+beforeEach(resetContextUsageSettings);
 
 afterEach(() => {
   cleanup();
+  resetContextUsageSettings();
 });
 
 describe("percentLeft", () => {
@@ -131,33 +152,76 @@ describe("percentLeft", () => {
   });
 });
 
+describe("buildContextUsageRows", () => {
+  function rowsFor(usage: TokenUsage) {
+    const effective = computeEffectiveContextUsage(usage);
+    if (effective === null) throw new Error("expected reliable usage");
+    return buildContextUsageRows(usage, effective);
+  }
+
+  it("omits cache and fresh rows when there is no cache", () => {
+    const rows = rowsFor({
+      inputTokens: 50_000,
+      outputTokens: 1_000,
+      totalTokens: 51_000,
+      contextTokens: 50_000,
+      contextWindow: 200_000,
+    });
+
+    expect(rows.map((row) => row.key)).toEqual(["used", "output"]);
+  });
+
+  it("includes fresh and cache rows when cache values are present", () => {
+    const rows = rowsFor({
+      inputTokens: 10_000,
+      outputTokens: 200,
+      totalTokens: 10_200,
+      contextTokens: 50_000,
+      cacheReadInputTokens: 30_000,
+      cacheCreationInputTokens: 10_000,
+      contextWindow: 200_000,
+    });
+
+    expect(rows.map((row) => row.key)).toEqual([
+      "used",
+      "fresh",
+      "cacheRead",
+      "cacheWrite",
+      "output",
+    ]);
+  });
+
+  it("renders the used row as a context-window pair and standalone counts otherwise", () => {
+    const rows = rowsFor({
+      inputTokens: 50_000,
+      outputTokens: 1_000,
+      totalTokens: 51_000,
+      contextTokens: 50_000,
+      contextWindow: 200_000,
+    });
+    const used = rows.find((row) => row.key === "used");
+    const output = rows.find((row) => row.key === "output");
+    if (used === undefined || output === undefined) {
+      throw new Error("expected used and output rows");
+    }
+
+    expect(formatContextUsageRowValue(used)).toBe("50K / 200K");
+    expect(formatContextUsageRowValue(output)).toBe("1.0k");
+  });
+});
+
 describe("ContextUsageChip", () => {
   it("renders nothing when usage is null", () => {
-    const { container } = render(
-      withTooltipProvider(<ContextUsageChip usage={null} />),
-    );
+    const { container } = render(<ContextUsageChip usage={null} />);
     expect(container.firstChild).toBe(null);
   });
 
-  it("renders text usage for a usage with a contextWindow", () => {
-    render(
-      withTooltipProvider(
-        <ContextUsageChip
-          usage={{
-            inputTokens: 50_000,
-            outputTokens: 1_000,
-            totalTokens: 51_000,
-            contextTokens: 50_000,
-            contextWindow: 200_000,
-          }}
-        />,
-      ),
-    );
-    const status = screen.getByRole("status", {
-      name: "Context window 75% left",
+  it("renders a compact button for a usage with a contextWindow", () => {
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    const button = screen.getByRole("button", {
+      name: /Context window 75% left/,
     });
-    expect(status).not.toBeNull();
-    expect(status.textContent).toBe("75% context left");
+    expect(button.textContent).toBe("75% context left");
     expect(
       screen
         .getByTestId("context-usage-meter")
@@ -171,46 +235,225 @@ describe("ContextUsageChip", () => {
     // raw token counts - showing tokens without a denominator is
     // misleading, and any hardcoded window would lie. Chip just hides.
     const { container } = render(
-      withTooltipProvider(
-        <ContextUsageChip
-          usage={{
-            inputTokens: 50_000,
-            outputTokens: 1_000,
-            totalTokens: 51_000,
-            contextTokens: 50_000,
-          }}
-        />,
-      ),
+      <ContextUsageChip
+        usage={{
+          inputTokens: 50_000,
+          outputTokens: 1_000,
+          totalTokens: 51_000,
+          contextTokens: 50_000,
+        }}
+      />,
     );
     expect(container.firstChild).toBe(null);
   });
 
-  it("keeps the detailed hover, folds baseline into used, and rounds the context window row", async () => {
+  it("opens the detailed popover, folds baseline into used, and rounds the context window row", async () => {
     render(
-      withTooltipProvider(
-        <ContextUsageChip
-          usage={{
-            inputTokens: 205_400,
-            outputTokens: 1_000,
-            totalTokens: 206_400,
-            contextTokens: 205_400,
-            contextBaselineTokens: 12_000,
-            cacheReadInputTokens: 100_000,
-            contextWindow: 258_000,
-          }}
-        />,
-      ),
+      <ContextUsageChip
+        usage={{
+          inputTokens: 205_400,
+          outputTokens: 1_000,
+          totalTokens: 206_400,
+          contextTokens: 205_400,
+          contextBaselineTokens: 12_000,
+          cacheReadInputTokens: 100_000,
+          contextWindow: 258_000,
+        }}
+      />,
     );
-    fireEvent.focus(
-      screen.getByRole("status", {
-        name: "Context window 16% left",
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Context window 16% left/,
       }),
     );
 
-    expect(await screen.findAllByText("217K / 258K")).toHaveLength(2);
+    expect(await screen.findByText("Context window")).toBeTruthy();
+    expect(screen.getByText("217K / 258K")).toBeTruthy();
     expect(screen.queryByText("Baseline")).toBeNull();
-    expect(screen.getAllByText("Fresh")).toHaveLength(2);
-    expect(screen.getAllByText("Cache read")).toHaveLength(2);
-    expect(screen.getAllByText("Output")).toHaveLength(2);
+    expect(screen.getByText("Fresh")).toBeTruthy();
+    expect(screen.getByText("Cache read")).toBeTruthy();
+    expect(screen.queryByText("Cache write")).toBeNull();
+    expect(screen.getByText("Output")).toBeTruthy();
+    expect(screen.getByText("1.0k")).toBeTruthy();
+  });
+
+  it("updates the pinned context usage setting from the popover action", async () => {
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Context window 75% left/,
+      }),
+    );
+
+    const pinButton = await screen.findByRole("button", {
+      name: "Pin breakdown",
+    });
+    fireEvent.click(pinButton);
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(true);
+    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(screen.getByTestId("context-usage-pinned-strip")).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Unpin context usage breakdown",
+      }),
+    );
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(false);
+    expect(
+      screen.getByRole("button", {
+        name: /Context window 75% left/,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("preserves trigger focus when the popover opens from a pointer action", async () => {
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    const trigger = screen.getByRole("button", {
+      name: /Context window 75% left/,
+    });
+    trigger.focus();
+    fireEvent.pointerDown(trigger, { pointerType: "mouse" });
+    fireEvent.click(trigger);
+
+    await screen.findByRole("button", {
+      name: "Pin breakdown",
+    });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("moves focus to the popover action when the popover opens from keyboard activation", async () => {
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    const trigger = screen.getByRole("button", {
+      name: /Context window 75% left/,
+    });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter", code: "Enter" });
+    fireEvent.click(trigger);
+
+    const pinButton = await screen.findByRole("button", {
+      name: "Pin breakdown",
+    });
+    expect(document.activeElement).toBe(pinButton);
+  });
+
+  it("renders the pinned strip when the setting is enabled and reliable usage exists", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    expect(
+      screen.queryByRole("button", {
+        name: /Context window 75% left/,
+      }),
+    ).toBeNull();
+    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+
+    const strip = screen.getByTestId("context-usage-pinned-strip");
+    expect(within(strip).getByText("Context 75%")).toBeTruthy();
+    expect(within(strip).getByText("50K / 200K")).toBeTruthy();
+    expect(within(strip).getByText("1.0k")).toBeTruthy();
+  });
+
+  it("keeps the pinned strip hidden when the setting is enabled without reliable usage", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    const { container } = render(
+      <ContextUsageChip
+        usage={{
+          inputTokens: 50_000,
+          outputTokens: 1_000,
+          totalTokens: 51_000,
+          contextTokens: 50_000,
+        }}
+      />,
+    );
+
+    expect(container.firstChild).toBe(null);
+    expect(screen.queryByTestId("context-usage-pinned-strip")).toBeNull();
+  });
+
+  it("unpins from the inline pinned strip action", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Unpin context usage breakdown",
+      }),
+    );
+
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(false);
+    expect(screen.queryByTestId("context-usage-pinned-strip")).toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: /Context window 75% left/,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("moves focus to the restored compact trigger after focused inline unpin", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    const unpinButton = screen.getByRole("button", {
+      name: "Unpin context usage breakdown",
+    });
+    unpinButton.focus();
+    fireEvent.click(unpinButton);
+
+    const trigger = screen.getByRole("button", {
+      name: /Context window 75% left/,
+    });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("omits noisy cache rows from the pinned strip when cache values are absent", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    const strip = screen.getByTestId("context-usage-pinned-strip");
+    expect(within(strip).getByText("Used")).toBeTruthy();
+    expect(within(strip).queryByText("Fresh")).toBeNull();
+    expect(within(strip).queryByText("Cache read")).toBeNull();
+    expect(within(strip).queryByText("Cache write")).toBeNull();
+    expect(within(strip).getByText("Output")).toBeTruthy();
+  });
+
+  it("updates the pinned strip from the same usage value", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    const { rerender } = render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(screen.getByText("50K / 200K used")).toBeTruthy();
+
+    rerender(
+      <ContextUsageChip
+        usage={{
+          inputTokens: 150_000,
+          outputTokens: 2_000,
+          totalTokens: 152_000,
+          contextTokens: 150_000,
+          contextWindow: 200_000,
+        }}
+      />,
+    );
+
+    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(screen.getByText("Context 25%")).toBeTruthy();
+    expect(screen.getByText("150K / 200K used")).toBeTruthy();
+    expect(screen.queryByText("50K / 200K used")).toBeNull();
+  });
+
+  it("marks the pinned strip summary and details with container-query collapse classes", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+
+    expect(
+      screen.getByTestId("context-usage-pinned-summary").className,
+    ).toContain("@max-[34rem]:block");
+    expect(
+      screen.getByTestId("context-usage-pinned-details").className,
+    ).toContain("@max-[34rem]:hidden");
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
@@ -23,6 +23,7 @@ import {
   formatContextUsageRowValue,
 } from "@/components/chat/context-usage";
 import { ContextUsageChip } from "@/components/chat/context-usage-chip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import type { TokenUsage } from "@traycer/protocol/persistence/epic/foundation";
 
@@ -43,13 +44,17 @@ function percentLeft(usage: TokenUsage | null): number | null {
 
 function render(ui: ReactElement) {
   const result = testingRender(
-    <LazyMotion features={domAnimation}>{ui}</LazyMotion>,
+    <TooltipProvider delayDuration={0}>
+      <LazyMotion features={domAnimation}>{ui}</LazyMotion>
+    </TooltipProvider>,
   );
   return {
     ...result,
     rerender: (nextUi: ReactElement) =>
       result.rerender(
-        <LazyMotion features={domAnimation}>{nextUi}</LazyMotion>,
+        <TooltipProvider delayDuration={0}>
+          <LazyMotion features={domAnimation}>{nextUi}</LazyMotion>
+        </TooltipProvider>,
       ),
   };
 }
@@ -420,6 +425,13 @@ describe("ContextUsageChip", () => {
     ).toBe("75");
     expect(within(strip).getByText("50K / 200K")).toBeTruthy();
     expect(within(strip).getByText("1.0k")).toBeTruthy();
+    expect(
+      within(strip)
+        .getByRole("button", {
+          name: "Unpin context usage breakdown",
+        })
+        .hasAttribute("title"),
+    ).toBe(false);
   });
 
   it("keeps detailed popover values on the static text path", async () => {

--- a/clients/gui-app/src/components/chat/context-usage-chip.tsx
+++ b/clients/gui-app/src/components/chat/context-usage-chip.tsx
@@ -1,11 +1,22 @@
-import type { CSSProperties } from "react";
+import { useLayoutEffect, useRef, type CSSProperties, type Ref } from "react";
+import { Pin, PinOff } from "lucide-react";
 import type { TokenUsage } from "@traycer/protocol/persistence/epic/foundation";
-import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { Button } from "@/components/ui/button";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  buildContextUsageRows,
   computeEffectiveContextUsage,
+  formatContextWindowTokens,
+  formatContextUsageRowValue,
+  type ContextUsageRow,
   type EffectiveContextUsage,
 } from "@/components/chat/context-usage";
 import { cn } from "@/lib/utils";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 
 interface ContextUsageChipProps {
   /**
@@ -22,6 +33,24 @@ type ContextUsageMeterStyle = CSSProperties & {
 };
 
 export function ContextUsageChip({ usage }: ContextUsageChipProps) {
+  const preserveFocusOnOpenRef = useRef(false);
+  const pinBreakdownActionRef = useRef<HTMLButtonElement>(null);
+  const compactTriggerRef = useRef<HTMLButtonElement>(null);
+  const focusCompactTriggerAfterUnpinRef = useRef(false);
+  const pinContextUsageBreakdown = useSettingsStore(
+    (s) => s.pinContextUsageBreakdown,
+  );
+  const setPinContextUsageBreakdown = useSettingsStore(
+    (s) => s.setPinContextUsageBreakdown,
+  );
+
+  useLayoutEffect(() => {
+    if (!pinContextUsageBreakdown && focusCompactTriggerAfterUnpinRef.current) {
+      focusCompactTriggerAfterUnpinRef.current = false;
+      compactTriggerRef.current?.focus();
+    }
+  }, [pinContextUsageBreakdown]);
+
   if (usage === null) return null;
   const effective = computeEffectiveContextUsage(usage);
   // The chip ONLY renders when we can compute a reliable percent from the
@@ -34,92 +63,219 @@ export function ContextUsageChip({ usage }: ContextUsageChipProps) {
   if (effective === null) return null;
   const percent = effective.percentLeft;
   const meterStyle = contextUsageMeterStyle(percent);
+  const rows = buildContextUsageRows(usage, effective);
+  const unpinFromPinnedStrip = (restoreFocus: boolean) => {
+    if (restoreFocus) {
+      focusCompactTriggerAfterUnpinRef.current = true;
+    }
+    setPinContextUsageBreakdown(false);
+  };
+
+  if (pinContextUsageBreakdown) {
+    return (
+      <ContextUsagePinnedStrip
+        rows={rows}
+        effective={effective}
+        onUnpin={unpinFromPinnedStrip}
+      />
+    );
+  }
+
   return (
-    <TooltipWrapper
-      label={<ContextUsageBreakdown usage={usage} effective={effective} />}
-      side="top"
-      align="end"
-      sideOffset={6}
-    >
-      <output
-        aria-label={`Context window ${percent}% left`}
-        data-testid="context-usage-chip"
-        className={cn(
-          "shrink-0 cursor-default whitespace-nowrap text-ui-sm font-normal tabular-nums opacity-70",
-          contextUsageTone(percent),
-        )}
-      >
-        <span className="@max-[28rem]:sr-only">{percent}% context left</span>
-        <span
-          aria-hidden
-          data-testid="context-usage-meter"
-          className="hidden size-5 rounded-full bg-[conic-gradient(currentColor_var(--context-usage-percent),var(--muted)_0)] p-[3px] @max-[28rem]:inline-flex"
-          style={meterStyle}
+    <div className="min-w-0 justify-self-end">
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            ref={compactTriggerRef}
+            type="button"
+            aria-label={`Context window ${percent}% left. Open context usage breakdown`}
+            data-testid="context-usage-chip"
+            className={cn(
+              "inline-flex shrink-0 items-center rounded-sm bg-transparent text-ui-sm font-normal tabular-nums whitespace-nowrap opacity-70 transition-colors outline-none hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/50",
+              contextUsageTone(percent),
+            )}
+            onPointerDown={() => {
+              preserveFocusOnOpenRef.current = true;
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                preserveFocusOnOpenRef.current = false;
+              }
+            }}
+          >
+            <span className="@max-[28rem]:sr-only">
+              {percent}% context left
+            </span>
+            <span
+              aria-hidden
+              data-testid="context-usage-meter"
+              className="hidden size-5 rounded-full bg-[conic-gradient(currentColor_var(--context-usage-percent),var(--muted)_0)] p-[3px] @max-[28rem]:inline-flex"
+              style={meterStyle}
+            >
+              <span className="size-full rounded-full bg-canvas" />
+            </span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          side="top"
+          sideOffset={6}
+          aria-label="Context usage breakdown"
+          className="w-[min(90vw,18rem)] gap-2.5 p-2.5"
+          onOpenAutoFocus={(event) => {
+            if (preserveFocusOnOpenRef.current) {
+              event.preventDefault();
+            } else {
+              event.preventDefault();
+              pinBreakdownActionRef.current?.focus();
+            }
+            preserveFocusOnOpenRef.current = false;
+          }}
         >
-          <span className="size-full rounded-full bg-canvas" />
-        </span>
-      </output>
-    </TooltipWrapper>
+          <ContextUsageBreakdown
+            rows={rows}
+            effective={effective}
+            pinned={pinContextUsageBreakdown}
+            onPinnedChange={setPinContextUsageBreakdown}
+            actionRef={pinBreakdownActionRef}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
   );
 }
 
 interface ContextUsageBreakdownProps {
-  readonly usage: TokenUsage;
+  readonly rows: readonly ContextUsageRow[];
   readonly effective: EffectiveContextUsage;
+  readonly pinned: boolean;
+  readonly onPinnedChange: (value: boolean) => void;
+  readonly actionRef: Ref<HTMLButtonElement>;
 }
 
 function ContextUsageBreakdown({
-  usage,
+  rows,
   effective,
+  pinned,
+  onPinnedChange,
+  actionRef,
 }: ContextUsageBreakdownProps) {
-  const cacheRead = usage.cacheReadInputTokens ?? 0;
-  const cacheCreate = usage.cacheCreationInputTokens ?? 0;
-  // Show the same "used / window" pair the headline percent is computed from.
-  // `effective.used` includes fixed baseline tokens when a harness reports
-  // them, but the baseline is not repeated as a separate hover row.
-  const used = effective.used;
-  // "Fresh" = portion of `used` that wasn't served from cache. Hidden when
-  // there's no cache - then "Used" already tells the whole story and "Fresh"
-  // would just duplicate it.
-  const fresh = Math.max(0, used - cacheRead - cacheCreate);
-  const hasCache = cacheRead > 0 || cacheCreate > 0;
   return (
-    <div className="flex flex-col gap-1.5 text-ui-xs">
+    <div className="flex flex-col gap-2 text-ui-xs">
       <div className="flex items-baseline justify-between gap-3 border-b border-border/40 pb-1.5">
-        <span className="font-medium">Token usage</span>
+        <span className="font-medium text-foreground">Context window</span>
         <span className="font-mono tabular-nums">
           {effective.percentLeft}% left
         </span>
       </div>
-      <UsageRow label="Used" value={used} total={effective.window} />
-      {hasCache ? <UsageRow label="Fresh" value={fresh} total={null} /> : null}
-      {cacheRead > 0 ? (
-        <UsageRow label="Cache read" value={cacheRead} total={null} />
-      ) : null}
-      {cacheCreate > 0 ? (
-        <UsageRow label="Cache write" value={cacheCreate} total={null} />
-      ) : null}
-      <UsageRow label="Output" value={usage.outputTokens} total={null} />
+      <div className="flex flex-col gap-1.5">
+        {rows.map((row) => (
+          <UsageRow key={row.key} row={row} />
+        ))}
+      </div>
+      <Button
+        ref={actionRef}
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-1 w-full justify-center"
+        onClick={() => onPinnedChange(!pinned)}
+      >
+        {pinned ? (
+          <PinOff className="size-3.5" aria-hidden />
+        ) : (
+          <Pin className="size-3.5" aria-hidden />
+        )}
+        {pinned ? "Unpin breakdown" : "Pin breakdown"}
+      </Button>
+    </div>
+  );
+}
+
+interface ContextUsagePinnedStripProps {
+  readonly rows: readonly ContextUsageRow[];
+  readonly effective: EffectiveContextUsage;
+  readonly onUnpin: (restoreFocus: boolean) => void;
+}
+
+function ContextUsagePinnedStrip({
+  rows,
+  effective,
+  onUnpin,
+}: ContextUsagePinnedStripProps) {
+  const usedSummary = `${formatContextWindowTokens(effective.used)} / ${formatContextWindowTokens(effective.window)} used`;
+  return (
+    <div
+      data-testid="context-usage-pinned-strip"
+      className="col-span-full min-w-0 border-t border-border/40 pt-2 text-ui-xs"
+    >
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-1 items-baseline gap-3">
+          <span
+            className={cn(
+              "shrink-0 font-medium whitespace-nowrap",
+              contextUsageTone(effective.percentLeft),
+            )}
+          >
+            Context {effective.percentLeft}%
+            <span className="@max-[34rem]:sr-only"> left</span>
+          </span>
+          <span
+            data-testid="context-usage-pinned-summary"
+            className="hidden min-w-0 truncate font-mono tabular-nums text-muted-foreground @max-[34rem]:block"
+          >
+            {usedSummary}
+          </span>
+          <div
+            data-testid="context-usage-pinned-details"
+            className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-3 gap-y-1 @max-[34rem]:hidden"
+          >
+            {rows.map((row) => (
+              <PinnedUsageRow key={row.key} row={row} />
+            ))}
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Unpin context usage breakdown"
+          title="Unpin context usage breakdown"
+          className="text-muted-foreground hover:text-foreground"
+          onClick={(event) => {
+            onUnpin(document.activeElement === event.currentTarget);
+          }}
+        >
+          <PinOff className="size-3.5" aria-hidden />
+        </Button>
+      </div>
     </div>
   );
 }
 
 interface UsageRowProps {
-  readonly label: string;
-  readonly value: number;
-  readonly total: number | undefined | null;
+  readonly row: ContextUsageRow;
 }
 
-function UsageRow({ label, value, total }: UsageRowProps) {
-  const hasTotal = total !== undefined && total !== null;
+function UsageRow({ row }: UsageRowProps) {
   return (
     <div className="flex items-baseline justify-between gap-4">
-      <span>{label}</span>
+      <span>{row.label}</span>
       <span className="font-mono tabular-nums">
-        {hasTotal ? formatContextWindowTokens(value) : formatTokens(value)}
-        {hasTotal ? ` / ${formatContextWindowTokens(total)}` : null}
+        {formatContextUsageRowValue(row)}
       </span>
     </div>
+  );
+}
+
+function PinnedUsageRow({ row }: UsageRowProps) {
+  return (
+    <span className="inline-flex min-w-0 items-baseline gap-1.5 whitespace-nowrap text-muted-foreground">
+      <span>{row.label}</span>
+      <span className="font-mono tabular-nums text-foreground/80">
+        {formatContextUsageRowValue(row)}
+      </span>
+    </span>
   );
 }
 
@@ -134,23 +290,4 @@ function contextUsageMeterStyle(percent: number): ContextUsageMeterStyle {
   return {
     "--context-usage-percent": `${usedPercent}%`,
   };
-}
-
-/**
- * Compact token formatter for the tooltip rows: 1_234 → "1.2k",
- * 1_234_567 → "1.2M". Falls back to raw `toLocaleString` for values < 1k so
- * tiny output-only turns aren't misleadingly rounded.
- */
-function formatTokens(value: number): string {
-  if (value < 1_000) return value.toLocaleString();
-  if (value < 1_000_000) return `${(value / 1_000).toFixed(1)}k`;
-  return `${(value / 1_000_000).toFixed(1)}M`;
-}
-
-function formatContextWindowTokens(value: number): string {
-  if (value < 1_000) return value.toLocaleString();
-  if (value < 1_000_000) {
-    return `${Math.round(value / 1_000).toLocaleString()}K`;
-  }
-  return `${Math.round(value / 1_000_000).toLocaleString()}M`;
 }

--- a/clients/gui-app/src/components/chat/context-usage-chip.tsx
+++ b/clients/gui-app/src/components/chat/context-usage-chip.tsx
@@ -1,5 +1,12 @@
 import { useLayoutEffect, useRef, type CSSProperties, type Ref } from "react";
 import { Pin, PinOff } from "lucide-react";
+import {
+  animate,
+  useMotionValue,
+  useReducedMotion,
+  useTransform,
+} from "motion/react";
+import * as m from "motion/react-m";
 import type { TokenUsage } from "@traycer/protocol/persistence/epic/foundation";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,6 +38,11 @@ interface ContextUsageChipProps {
 type ContextUsageMeterStyle = CSSProperties & {
   readonly "--context-usage-percent": string;
 };
+
+const PINNED_NUMBER_TRANSITION = {
+  duration: 0.16,
+  ease: "easeOut",
+} as const;
 
 export function ContextUsageChip({ usage }: ContextUsageChipProps) {
   const preserveFocusOnOpenRef = useRef(false);
@@ -212,12 +224,19 @@ function ContextUsagePinnedStrip({
       <div className="flex min-w-0 items-center justify-between gap-2">
         <div className="flex min-w-0 flex-1 items-baseline gap-3">
           <span
+            data-testid="context-usage-pinned-primary"
             className={cn(
               "shrink-0 font-medium whitespace-nowrap",
               contextUsageTone(effective.percentLeft),
             )}
           >
-            Context {effective.percentLeft}%
+            Context{" "}
+            <AnimatedPinnedInteger
+              value={effective.percentLeft}
+              testId="context-usage-pinned-percent-value"
+              className="inline-block min-w-[3ch] text-right tabular-nums"
+            />
+            %
             <span className="@max-[34rem]:sr-only"> left</span>
           </span>
           <span
@@ -276,6 +295,48 @@ function PinnedUsageRow({ row }: UsageRowProps) {
         {formatContextUsageRowValue(row)}
       </span>
     </span>
+  );
+}
+
+interface AnimatedPinnedIntegerProps {
+  readonly value: number;
+  readonly testId: string;
+  readonly className: string;
+}
+
+function AnimatedPinnedInteger({
+  value,
+  testId,
+  className,
+}: AnimatedPinnedIntegerProps) {
+  const shouldReduceMotion = useReducedMotion() === true;
+  const animatedValue = useMotionValue(value);
+  const roundedValue = useTransform(animatedValue, (latest) =>
+    Math.round(latest).toString(),
+  );
+
+  useLayoutEffect(() => {
+    if (shouldReduceMotion) {
+      animatedValue.set(value);
+      return;
+    }
+
+    const controls = animate(animatedValue, value, PINNED_NUMBER_TRANSITION);
+    return () => controls.stop();
+  }, [animatedValue, shouldReduceMotion, value]);
+
+  if (shouldReduceMotion) {
+    return (
+      <span data-testid={testId} className={className}>
+        {value}
+      </span>
+    );
+  }
+
+  return (
+    <m.span data-testid={testId} className={className}>
+      {roundedValue}
+    </m.span>
   );
 }
 

--- a/clients/gui-app/src/components/chat/context-usage-chip.tsx
+++ b/clients/gui-app/src/components/chat/context-usage-chip.tsx
@@ -49,6 +49,8 @@ export function ContextUsageChip({ usage }: ContextUsageChipProps) {
   const preserveFocusOnOpenRef = useRef(false);
   const pinBreakdownActionRef = useRef<HTMLButtonElement>(null);
   const compactTriggerRef = useRef<HTMLButtonElement>(null);
+  const pinnedUnpinActionRef = useRef<HTMLButtonElement>(null);
+  const focusPinnedActionAfterPinRef = useRef(false);
   const focusCompactTriggerAfterUnpinRef = useRef(false);
   const pinContextUsageBreakdown = useSettingsStore(
     (s) => s.pinContextUsageBreakdown,
@@ -58,6 +60,11 @@ export function ContextUsageChip({ usage }: ContextUsageChipProps) {
   );
 
   useLayoutEffect(() => {
+    if (pinContextUsageBreakdown && focusPinnedActionAfterPinRef.current) {
+      focusPinnedActionAfterPinRef.current = false;
+      pinnedUnpinActionRef.current?.focus();
+      return;
+    }
     if (!pinContextUsageBreakdown && focusCompactTriggerAfterUnpinRef.current) {
       focusCompactTriggerAfterUnpinRef.current = false;
       compactTriggerRef.current?.focus();
@@ -90,9 +97,17 @@ export function ContextUsageChip({ usage }: ContextUsageChipProps) {
         rows={rows}
         effective={effective}
         onUnpin={unpinFromPinnedStrip}
+        actionRef={pinnedUnpinActionRef}
       />
     );
   }
+
+  const pinFromPopover = (value: boolean, restoreFocus: boolean) => {
+    if (value && restoreFocus) {
+      focusPinnedActionAfterPinRef.current = true;
+    }
+    setPinContextUsageBreakdown(value);
+  };
 
   return (
     <div className="min-w-0 justify-self-end">
@@ -149,7 +164,7 @@ export function ContextUsageChip({ usage }: ContextUsageChipProps) {
             rows={rows}
             effective={effective}
             pinned={pinContextUsageBreakdown}
-            onPinnedChange={setPinContextUsageBreakdown}
+            onPinnedChange={pinFromPopover}
             actionRef={pinBreakdownActionRef}
           />
         </PopoverContent>
@@ -162,7 +177,7 @@ interface ContextUsageBreakdownProps {
   readonly rows: readonly ContextUsageRow[];
   readonly effective: EffectiveContextUsage;
   readonly pinned: boolean;
-  readonly onPinnedChange: (value: boolean) => void;
+  readonly onPinnedChange: (value: boolean, restoreFocus: boolean) => void;
   readonly actionRef: Ref<HTMLButtonElement>;
 }
 
@@ -192,7 +207,12 @@ function ContextUsageBreakdown({
         variant="outline"
         size="sm"
         className="mt-1 w-full justify-center"
-        onClick={() => onPinnedChange(!pinned)}
+        onClick={(event) => {
+          onPinnedChange(
+            !pinned,
+            document.activeElement === event.currentTarget,
+          );
+        }}
       >
         {pinned ? (
           <PinOff className="size-3.5" aria-hidden />
@@ -209,12 +229,14 @@ interface ContextUsagePinnedStripProps {
   readonly rows: readonly ContextUsageRow[];
   readonly effective: EffectiveContextUsage;
   readonly onUnpin: (restoreFocus: boolean) => void;
+  readonly actionRef: Ref<HTMLButtonElement>;
 }
 
 function ContextUsagePinnedStrip({
   rows,
   effective,
   onUnpin,
+  actionRef,
 }: ContextUsagePinnedStripProps) {
   const usedSummary = `${formatContextWindowTokens(effective.used)} / ${formatContextWindowTokens(effective.window)} used`;
   return (
@@ -261,6 +283,7 @@ function ContextUsagePinnedStrip({
           align={undefined}
         >
           <Button
+            ref={actionRef}
             type="button"
             variant="ghost"
             size="icon-xs"

--- a/clients/gui-app/src/components/chat/context-usage-chip.tsx
+++ b/clients/gui-app/src/components/chat/context-usage-chip.tsx
@@ -14,6 +14,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import {
   buildContextUsageRows,
   computeEffectiveContextUsage,
@@ -236,8 +237,7 @@ function ContextUsagePinnedStrip({
               testId="context-usage-pinned-percent-value"
               className="inline-block min-w-[3ch] text-right tabular-nums"
             />
-            %
-            <span className="@max-[34rem]:sr-only"> left</span>
+            %<span className="@max-[34rem]:sr-only"> left</span>
           </span>
           <span
             data-testid="context-usage-pinned-summary"
@@ -254,19 +254,25 @@ function ContextUsagePinnedStrip({
             ))}
           </div>
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          aria-label="Unpin context usage breakdown"
-          title="Unpin context usage breakdown"
-          className="text-muted-foreground hover:text-foreground"
-          onClick={(event) => {
-            onUnpin(document.activeElement === event.currentTarget);
-          }}
+        <TooltipWrapper
+          label="Unpin context usage breakdown"
+          side="top"
+          sideOffset={6}
+          align={undefined}
         >
-          <PinOff className="size-3.5" aria-hidden />
-        </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Unpin context usage breakdown"
+            className="text-muted-foreground hover:text-foreground"
+            onClick={(event) => {
+              onUnpin(document.activeElement === event.currentTarget);
+            }}
+          >
+            <PinOff className="size-3.5" aria-hidden />
+          </Button>
+        </TooltipWrapper>
       </div>
     </div>
   );

--- a/clients/gui-app/src/components/chat/context-usage.ts
+++ b/clients/gui-app/src/components/chat/context-usage.ts
@@ -2,7 +2,7 @@ import type { TokenUsage } from "@traycer/protocol/persistence/epic/foundation";
 
 /**
  * "Tokens occupying the window" / "window size" pair plus the derived "% left",
- * all computed from one place so the chip headline and its tooltip breakdown
+ * all computed from one place so the chip headline and detail breakdowns
  * can't drift. Each harness adapter owns its SDK's cache semantics and emits
  * `contextTokens` as the canonical dynamic occupancy number. Harnesses that
  * report a fixed baseline separately can set `contextBaselineTokens`; the
@@ -37,4 +37,94 @@ export function computeEffectiveContextUsage(
   // `window > 0` is guaranteed above, so the ratio is always finite.
   const clamped = Math.max(0, Math.min(1, 1 - used / window));
   return { used, window, percentLeft: Math.round(clamped * 100) };
+}
+
+/**
+ * One breakdown row shared by every context usage detail surface. A
+ * `total` makes the row render as `value / total` against the context window;
+ * `null` renders the value on its own. Keeping the row model here is the single
+ * source of truth for which rows appear and how cache-derived numbers are
+ * computed, so the surfaces can't drift in their displayed math.
+ */
+export interface ContextUsageRow {
+  readonly key: "used" | "fresh" | "cacheRead" | "cacheWrite" | "output";
+  readonly label: string;
+  readonly value: number;
+  /** Context-window denominator when the row is a `used / window` pair. */
+  readonly total: number | null;
+}
+
+/**
+ * Build the ordered breakdown rows for a usage/effective pair. Cache rows are
+ * omitted when their values are absent so the surfaces never show noisy zeros,
+ * and "Fresh" is hidden without any cache because "Used" already tells the
+ * whole story then.
+ */
+export function buildContextUsageRows(
+  usage: TokenUsage,
+  effective: EffectiveContextUsage,
+): readonly ContextUsageRow[] {
+  const cacheRead = usage.cacheReadInputTokens ?? 0;
+  const cacheCreate = usage.cacheCreationInputTokens ?? 0;
+  // `effective.used` already folds in any fixed baseline tokens; the baseline is
+  // not repeated as its own row.
+  const used = effective.used;
+  // "Fresh" = portion of `used` that wasn't served from cache.
+  const fresh = Math.max(0, used - cacheRead - cacheCreate);
+  const hasCache = cacheRead > 0 || cacheCreate > 0;
+  const rows: ContextUsageRow[] = [
+    { key: "used", label: "Used", value: used, total: effective.window },
+  ];
+  if (hasCache) {
+    rows.push({ key: "fresh", label: "Fresh", value: fresh, total: null });
+  }
+  if (cacheRead > 0) {
+    rows.push({
+      key: "cacheRead",
+      label: "Cache read",
+      value: cacheRead,
+      total: null,
+    });
+  }
+  if (cacheCreate > 0) {
+    rows.push({
+      key: "cacheWrite",
+      label: "Cache write",
+      value: cacheCreate,
+      total: null,
+    });
+  }
+  rows.push({
+    key: "output",
+    label: "Output",
+    value: usage.outputTokens,
+    total: null,
+  });
+  return rows;
+}
+
+/** Render a row's value, as `value / total` when the row carries a denominator. */
+export function formatContextUsageRowValue(row: ContextUsageRow): string {
+  if (row.total === null) return formatTokens(row.value);
+  return `${formatContextWindowTokens(row.value)} / ${formatContextWindowTokens(row.total)}`;
+}
+
+/**
+ * Compact token formatter for standalone counts: 1_234 → "1.2k",
+ * 1_234_567 → "1.2M". Falls back to raw `toLocaleString` for values < 1k so
+ * tiny output-only turns aren't misleadingly rounded.
+ */
+function formatTokens(value: number): string {
+  if (value < 1_000) return value.toLocaleString();
+  if (value < 1_000_000) return `${(value / 1_000).toFixed(1)}k`;
+  return `${(value / 1_000_000).toFixed(1)}M`;
+}
+
+/** Whole-unit token formatter for the `used / window` context-window pair. */
+export function formatContextWindowTokens(value: number): string {
+  if (value < 1_000) return value.toLocaleString();
+  if (value < 1_000_000) {
+    return `${Math.round(value / 1_000).toLocaleString()}K`;
+  }
+  return `${Math.round(value / 1_000_000).toLocaleString()}M`;
 }

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
@@ -10,16 +10,19 @@
  * real view-model memoizes them; only `todo` / `restoreContext` change between
  * simulated tokens.
  */
-import { render } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
 
 // Count every render of the composer subtree by stubbing the leaf `ChatComposer`.
 // `ChatComposerRegion` is the memo boundary, so a render here == a boundary render.
 let composerRenderCount = 0;
 vi.mock("@/components/chat/composer/chat-composer", () => ({
-  ChatComposer: () => {
+  ChatComposer: (props: {
+    readonly workspaceControls: import("react").ReactNode | null;
+  }) => {
     composerRenderCount += 1;
-    return <div data-testid="composer-stub" />;
+    return <div data-testid="composer-stub">{props.workspaceControls}</div>;
   },
 }));
 // The dock legitimately re-renders per token; stub it so the test isolates the
@@ -51,6 +54,40 @@ import {
 import { WORKSPACE_COMPOSER_READY } from "@/lib/composer/workspace-composer-availability";
 import type { ChatRestoreContextValue } from "@/components/chat/chat-restore-context-core";
 import type { PinnedTodoSnapshot } from "@/components/chat/chat-pinned-todos";
+import { ContextUsageChip } from "@/components/chat/context-usage-chip";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import type { TokenUsage } from "@traycer/protocol/persistence/epic/foundation";
+
+const USAGE_PROBE_75: TokenUsage = {
+  inputTokens: 50_000,
+  outputTokens: 1_000,
+  totalTokens: 51_000,
+  contextTokens: 50_000,
+  contextWindow: 200_000,
+};
+
+const USAGE_PROBE_25: TokenUsage = {
+  inputTokens: 150_000,
+  outputTokens: 2_000,
+  totalTokens: 152_000,
+  contextTokens: 150_000,
+  contextWindow: 200_000,
+};
+
+interface UsageProbeState {
+  readonly usage: TokenUsage;
+  readonly setUsage: (usage: TokenUsage) => void;
+}
+
+const useUsageProbeStore = create<UsageProbeState>()((set) => ({
+  usage: USAGE_PROBE_75,
+  setUsage: (usage) => set({ usage }),
+}));
+
+function UsageLeafProbe() {
+  const usage = useUsageProbeStore((s) => s.usage);
+  return <ContextUsageChip usage={usage} />;
+}
 
 // ── Stable composer-relevant props (built once, never re-identified) ──────────
 const RUNTIME: ChatLowerRuntimeState = {
@@ -102,7 +139,7 @@ const COMPOSER: ChatLowerComposerState = {
   workspaceControls: (
     <>
       <span data-testid="worktree-chip" />
-      <span data-testid="usage-chip" />
+      <UsageLeafProbe />
     </>
   ),
   workspaceAvailability: WORKSPACE_COMPOSER_READY,
@@ -152,7 +189,11 @@ function props(
 describe("composer isolation from per-token dock churn", () => {
   beforeEach(() => {
     composerRenderCount = 0;
+    useUsageProbeStore.setState({ usage: USAGE_PROBE_75 });
+    useSettingsStore.setState({ pinContextUsageBreakdown: false });
   });
+
+  afterEach(cleanup);
 
   it("does not re-render the composer when only todo/restoreContext change", () => {
     const { rerender } = render(
@@ -180,5 +221,23 @@ describe("composer isolation from per-token dock churn", () => {
     // Run status flips idle -> running: a genuine composer input change.
     rerender(<ChatLowerInteractionSurfaces {...props(TURN_RUNNING, 1)} />);
     expect(composerRenderCount).toBe(2);
+  });
+
+  it("does not re-render the composer when the context usage leaf updates", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    render(<ChatLowerInteractionSurfaces {...props(TURN_IDLE, 0)} />);
+    expect(composerRenderCount).toBe(1);
+    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(screen.getByText("Context 75%")).toBeTruthy();
+    expect(screen.getByText("50K / 200K used")).toBeTruthy();
+
+    act(() => {
+      useUsageProbeStore.getState().setUsage(USAGE_PROBE_25);
+    });
+
+    expect(composerRenderCount).toBe(1);
+    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(screen.getByText("Context 25%")).toBeTruthy();
+    expect(screen.getByText("150K / 200K used")).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
@@ -10,8 +10,16 @@
  * real view-model memoizes them; only `todo` / `restoreContext` change between
  * simulated tokens.
  */
-import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  render as testingRender,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { domAnimation, LazyMotion } from "motion/react";
+import type { ReactElement } from "react";
 import { create } from "zustand";
 
 // Count every render of the composer subtree by stubbing the leaf `ChatComposer`.
@@ -83,6 +91,19 @@ const useUsageProbeStore = create<UsageProbeState>()((set) => ({
   usage: USAGE_PROBE_75,
   setUsage: (usage) => set({ usage }),
 }));
+
+function render(ui: ReactElement) {
+  const result = testingRender(
+    <LazyMotion features={domAnimation}>{ui}</LazyMotion>,
+  );
+  return {
+    ...result,
+    rerender: (nextUi: ReactElement) =>
+      result.rerender(
+        <LazyMotion features={domAnimation}>{nextUi}</LazyMotion>,
+      ),
+  };
+}
 
 function UsageLeafProbe() {
   const usage = useUsageProbeStore((s) => s.usage);
@@ -223,12 +244,14 @@ describe("composer isolation from per-token dock churn", () => {
     expect(composerRenderCount).toBe(2);
   });
 
-  it("does not re-render the composer when the context usage leaf updates", () => {
+  it("does not re-render the composer when the context usage leaf updates", async () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
     render(<ChatLowerInteractionSurfaces {...props(TURN_IDLE, 0)} />);
     expect(composerRenderCount).toBe(1);
     expect(screen.queryByTestId("context-usage-chip")).toBeNull();
-    expect(screen.getByText("Context 75%")).toBeTruthy();
+    expect(
+      screen.getByTestId("context-usage-pinned-percent-value").textContent,
+    ).toBe("75");
     expect(screen.getByText("50K / 200K used")).toBeTruthy();
 
     act(() => {
@@ -237,7 +260,11 @@ describe("composer isolation from per-token dock churn", () => {
 
     expect(composerRenderCount).toBe(1);
     expect(screen.queryByTestId("context-usage-chip")).toBeNull();
-    expect(screen.getByText("Context 25%")).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("context-usage-pinned-percent-value").textContent,
+      ).toBe("25");
+    });
     expect(screen.getByText("150K / 200K used")).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
@@ -63,6 +63,7 @@ import { WORKSPACE_COMPOSER_READY } from "@/lib/composer/workspace-composer-avai
 import type { ChatRestoreContextValue } from "@/components/chat/chat-restore-context-core";
 import type { PinnedTodoSnapshot } from "@/components/chat/chat-pinned-todos";
 import { ContextUsageChip } from "@/components/chat/context-usage-chip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import type { TokenUsage } from "@traycer/protocol/persistence/epic/foundation";
 
@@ -94,15 +95,25 @@ const useUsageProbeStore = create<UsageProbeState>()((set) => ({
 
 function render(ui: ReactElement) {
   const result = testingRender(
-    <LazyMotion features={domAnimation}>{ui}</LazyMotion>,
+    <TooltipProvider delayDuration={0}>
+      <LazyMotion features={domAnimation}>{ui}</LazyMotion>
+    </TooltipProvider>,
   );
   return {
     ...result,
     rerender: (nextUi: ReactElement) =>
       result.rerender(
-        <LazyMotion features={domAnimation}>{nextUi}</LazyMotion>,
+        <TooltipProvider delayDuration={0}>
+          <LazyMotion features={domAnimation}>{nextUi}</LazyMotion>
+        </TooltipProvider>,
       ),
   };
+}
+
+function queryCompactContextTrigger() {
+  return screen.queryByRole("button", {
+    name: /open context usage breakdown/i,
+  });
 }
 
 function UsageLeafProbe() {
@@ -248,7 +259,7 @@ describe("composer isolation from per-token dock churn", () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
     render(<ChatLowerInteractionSurfaces {...props(TURN_IDLE, 0)} />);
     expect(composerRenderCount).toBe(1);
-    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(queryCompactContextTrigger()).toBeNull();
     expect(
       screen.getByTestId("context-usage-pinned-percent-value").textContent,
     ).toBe("75");
@@ -259,7 +270,7 @@ describe("composer isolation from per-token dock churn", () => {
     });
 
     expect(composerRenderCount).toBe(1);
-    expect(screen.queryByTestId("context-usage-chip")).toBeNull();
+    expect(queryCompactContextTrigger()).toBeNull();
     await waitFor(() => {
       expect(
         screen.getByTestId("context-usage-pinned-percent-value").textContent,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1211,14 +1211,15 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     () => <ContextUsageChipForChat handle={handle} />,
     [handle],
   );
-  // Composer v3 cluster: host select + Workspace rail picker on the left, the
-  // context-usage indicator pushed to the right edge of the row. Per-folder
-  // Environment config lives inside the selected Workspace panel.
+  // Composer v3 cluster: host select + Workspace rail picker on the left, with
+  // the context-usage leaf owning its trailing chip and optional full-width
+  // pinned strip. Per-folder Environment config lives inside the selected
+  // Workspace panel.
   const workspaceControls = useMemo(
     () => (
       <>
         <div className="min-w-0 overflow-hidden">{hostWorkspaceSelector}</div>
-        <div className="min-w-0 justify-self-end">{usageChip}</div>
+        {usageChip}
       </>
     ),
     [hostWorkspaceSelector, usageChip],

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -48,7 +48,9 @@ must be added in BOTH places - the route file under `src/routes/` AND the modal
 
 ## Sections
 
-- `General` App-level preferences: prevent sleep while running, voice input,
+- `General` App-level preferences: chat turn-completion notifications, prevent
+  sleep while running, pin context usage breakdown (global toggle for the
+  always-visible chat context-window breakdown, default off), voice input,
   local snapshot storage management, and data migration.
 - `Appearance` Theme, global artifact icon color mode, type-color customization,
   and typography controls.

--- a/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/stores/migration/migration-run-store";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useOnboardingStore } from "@/stores/onboarding/onboarding-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import {
   localSnapshotClearScopeKey,
   useLocalSnapshotClearStore,
@@ -249,6 +250,7 @@ describe("GeneralSettingsPanel", () => {
     });
     useLocalSnapshotClearStore.setState({ clearedAtByScope: {} });
     useOnboardingStore.setState({ completedAt: null, step: 0 });
+    useSettingsStore.setState({ pinContextUsageBreakdown: false });
   });
 
   afterEach(() => {
@@ -270,6 +272,19 @@ describe("GeneralSettingsPanel", () => {
     fireEvent.click(button);
 
     expect(migrationStart.fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the pinned context usage breakdown row and toggles the setting", () => {
+    renderPanel();
+
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(false);
+    const toggle = screen.getByRole("switch", {
+      name: "Pin context usage breakdown",
+    });
+
+    fireEvent.click(toggle);
+
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(true);
   });
 
   it("navigates to replay onboarding without clearing first-run completion", () => {

--- a/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
@@ -84,6 +84,12 @@ export function GeneralSettingsPanel() {
   const setNotifyOnChatTurnComplete = useSettingsStore(
     (s) => s.setNotifyOnChatTurnComplete,
   );
+  const pinContextUsageBreakdown = useSettingsStore(
+    (s) => s.pinContextUsageBreakdown,
+  );
+  const setPinContextUsageBreakdown = useSettingsStore(
+    (s) => s.setPinContextUsageBreakdown,
+  );
 
   return (
     <SettingsPanelShell title="General">
@@ -106,6 +112,17 @@ export function GeneralSettingsPanel() {
             checked={preventSleepWhileRunning}
             onCheckedChange={setPreventSleepWhileRunning}
             aria-label="Prevent sleep while running"
+          />
+        }
+      />
+      <SettingsRow
+        label="Pin context usage breakdown"
+        description="Keep the context window breakdown visible near the chat composer when usage data is available."
+        control={
+          <Switch
+            checked={pinContextUsageBreakdown}
+            onCheckedChange={setPinContextUsageBreakdown}
+            aria-label="Pin context usage breakdown"
           />
         }
       />

--- a/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
+++ b/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
@@ -14,6 +14,7 @@ function resetSettingsStore(): void {
     defaultAgentMode: DEFAULT_AGENT_MODE,
     defaultEditor: "vscode",
     notifyOnChatTurnComplete: true,
+    pinContextUsageBreakdown: false,
     diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
   });
 }
@@ -159,6 +160,51 @@ describe("useSettingsStore", () => {
     await useSettingsStore.persist.rehydrate();
 
     expect(useSettingsStore.getState().notifyOnChatTurnComplete).toBe(false);
+  });
+
+  it("defaults the pinned context usage breakdown to off", () => {
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(false);
+  });
+
+  it("toggles the pinned context usage breakdown on", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(true);
+  });
+
+  it("persists the pinned context usage breakdown preference", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    const persisted = window.localStorage.getItem("traycer-gui-app:settings");
+
+    expect(persisted ?? "").toContain('"pinContextUsageBreakdown":true');
+  });
+
+  it("rehydrates the pinned context usage breakdown from persisted settings", async () => {
+    window.localStorage.setItem(
+      "traycer-gui-app:settings",
+      JSON.stringify({
+        state: { pinContextUsageBreakdown: true },
+        version: 1,
+      }),
+    );
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(true);
+  });
+
+  it("rehydrates old settings without the field to the default off", async () => {
+    window.localStorage.setItem(
+      "traycer-gui-app:settings",
+      JSON.stringify({
+        state: { artifactIconColorMode: "none" },
+        version: 1,
+      }),
+    );
+
+    await useSettingsStore.persist.rehydrate();
+
+    expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(false);
   });
 
   it("defaults new chats to supervised permissions", () => {

--- a/clients/gui-app/src/stores/settings/settings-store.ts
+++ b/clients/gui-app/src/stores/settings/settings-store.ts
@@ -52,6 +52,12 @@ export interface SettingsState {
    * prompt surfaces on the first unfocused completion.
    */
   notifyOnChatTurnComplete: boolean;
+  /**
+   * Keep the chat context-window breakdown pinned near the composer instead of
+   * the compact-only chip. Global preference, default off; chats without
+   * reliable context-window data still render nothing.
+   */
+  pinContextUsageBreakdown: boolean;
   pointerCursors: boolean;
   uiFontSize: number;
   codeFontSize: number;
@@ -78,6 +84,7 @@ export interface SettingsState {
   setComposerMode: (mode: ComposerMode) => void;
   setPreventSleepWhileRunning: (value: boolean) => void;
   setNotifyOnChatTurnComplete: (value: boolean) => void;
+  setPinContextUsageBreakdown: (value: boolean) => void;
   setPointerCursors: (value: boolean) => void;
   setUiFontSize: (value: number) => void;
   setCodeFontSize: (value: number) => void;
@@ -103,6 +110,7 @@ type PersistedSettingsState = Pick<
   | "composerMode"
   | "preventSleepWhileRunning"
   | "notifyOnChatTurnComplete"
+  | "pinContextUsageBreakdown"
   | "pointerCursors"
   | "uiFontSize"
   | "codeFontSize"
@@ -153,6 +161,7 @@ function partializeSettingsState(state: SettingsState): PersistedSettingsState {
     composerMode: state.composerMode,
     preventSleepWhileRunning: state.preventSleepWhileRunning,
     notifyOnChatTurnComplete: state.notifyOnChatTurnComplete,
+    pinContextUsageBreakdown: state.pinContextUsageBreakdown,
     pointerCursors: state.pointerCursors,
     uiFontSize: state.uiFontSize,
     codeFontSize: state.codeFontSize,
@@ -178,6 +187,7 @@ export const useSettingsStore = create<SettingsState>()(
       composerMode: DEFAULT_COMPOSER_MODE,
       preventSleepWhileRunning: false,
       notifyOnChatTurnComplete: true,
+      pinContextUsageBreakdown: false,
       pointerCursors: true,
       uiFontSize: 15,
       codeFontSize: 12,
@@ -193,6 +203,7 @@ export const useSettingsStore = create<SettingsState>()(
       setComposerMode: makeSetter(set, "composerMode"),
       setPreventSleepWhileRunning: makeSetter(set, "preventSleepWhileRunning"),
       setNotifyOnChatTurnComplete: makeSetter(set, "notifyOnChatTurnComplete"),
+      setPinContextUsageBreakdown: makeSetter(set, "pinContextUsageBreakdown"),
       setPointerCursors: makeSetter(set, "pointerCursors"),
       setUiFontSize: makeClampedFontSizeSetter(set, "uiFontSize"),
       setCodeFontSize: makeClampedFontSizeSetter(set, "codeFontSize"),


### PR DESCRIPTION
## Summary
- replace the hover-only context usage details with a click/focus popover and pin/unpin action
- add a persisted Settings > General toggle for pinning the context usage breakdown
- render the pinned breakdown as the primary context surface, hiding the compact trigger until unpinned
- share context usage row formatting across compact, popover, and pinned states with focused render-isolation coverage

Closes #75


<img width="860" height="237" alt="image" src="https://github.com/user-attachments/assets/65ffa9e5-7adc-45e7-9b90-3197f9555904" />
---
<img width="868" height="94" alt="image" src="https://github.com/user-attachments/assets/5977bf9a-69bf-4279-be68-75730a12b1ae" />

## Test plan
- bun run test -- src/components/chat/__tests__/context-usage-chip.test.tsx src/stores/settings/__tests__/settings-store.test.ts src/components/settings/panels/__tests__/general-settings-panel.test.tsx src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
- bun run compile
- git diff --check
- npx -y react-doctor@latest . --verbose --scope changed --base origin/main --offline --no-score