### PR TITLE
fix(gui-app): truncate composer placeholder

### DIFF
--- a/clients/gui-app/src/components/chat/composer/chat-composer-editor-slot.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer-editor-slot.tsx
@@ -62,7 +62,7 @@ export function ChatComposerEditorSlot(props: ChatComposerEditorSlotProps) {
       isActive={isActive}
       disabled={false}
       placeholder={isNarrow ? NARROW_PLACEHOLDER : PLACEHOLDER}
-      editorClassName="min-h-9"
+      editorClassName="max-h-[3.5lh] min-h-9"
       onSnapshot={onSnapshot}
       onSubmit={onSubmit}
       onPaste={onPaste}

--- a/clients/gui-app/src/editor-core/styles/editor.css
+++ b/clients/gui-app/src/editor-core/styles/editor.css
@@ -583,6 +583,25 @@
   float: left;
 }
 
+[data-composer-editor].is-editor-empty,
+[data-composer-editor] .is-editor-empty:first-child {
+  position: relative;
+}
+
+[data-composer-editor].is-editor-empty::before,
+[data-composer-editor] .is-editor-empty:first-child::before {
+  position: absolute;
+  inset-inline: 0;
+  top: 0;
+  display: block;
+  width: 100%;
+  height: auto;
+  float: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /*
  * `@user` mention chip rendered by `@tiptap/extension-mention`. We wrap the
  * default span in muted-on-accent pill styling matching the rest of the


### PR DESCRIPTION
## Summary
- truncate the chat composer placeholder instead of allowing it to wrap on smaller widths
- cap the chat composer input height to about 3.5 lines so overflow is visibly scrollable sooner

## Verification
- bun run compile
- pre-commit hooks during signed commit, including nx affected checks