### PR TITLE
fix(gui-app): compact provider rail scrollbar

### DIFF
--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
@@ -45,7 +45,7 @@ export function ProviderRail(props: ProviderRailProps) {
       <div
         role="tablist"
         aria-label="Model providers"
-        className="flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto overscroll-contain"
+        className="compact-scrollbar flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto overscroll-contain px-1 [scrollbar-gutter:stable]"
       >
         {pending && visibleHarnesses.length === 0 ? (
           <span className="mt-1 flex size-8 items-center justify-center rounded-lg text-muted-foreground">

--- a/clients/gui-app/src/index.css
+++ b/clients/gui-app/src/index.css
@@ -1021,6 +1021,32 @@
   }
 }
 
+@utility compact-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in oklch, var(--muted-foreground) 35%, transparent)
+    transparent;
+
+  &::-webkit-scrollbar {
+    width: 2px !important;
+    height: 2px !important;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    min-height: 1.25rem;
+    border: 0;
+    border-radius: 9999px;
+    background: color-mix(in oklch, var(--muted-foreground) 35%, transparent);
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+  }
+}
+
 @layer base {
   * {
     scrollbar-width: thin;


### PR DESCRIPTION
## Summary
- Add a compact 2px scrollbar utility for tight picker rails
- Apply it to the model picker provider rail with a stable gutter so the scrollbar does not overlap provider icons
- Leave existing chat scrollbar behavior unchanged

## Verification
- `bun run compile`
- `bun x prettier --check src/index.css src/components/home/pickers/harness-model-picker-group.tsx`
- `npx -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score`

Note: full `bun run react-doctor` still reports unrelated pre-existing findings outside this change.