### PR TITLE
fix(auth): re-read/adopt on reject in shared bearer revalidator

### DIFF
--- a/clients/shared/auth/__tests__/bearer-revalidator.test.ts
+++ b/clients/shared/auth/__tests__/bearer-revalidator.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createBearerRevalidator,
+  REJECT_REREAD_ATTEMPTS,
   rotateAndPersistBearer,
   type BearerStore,
 } from "../bearer-revalidator";
@@ -86,6 +87,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -104,6 +106,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -137,6 +140,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -169,6 +173,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -200,6 +205,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -218,6 +224,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: true,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -236,6 +243,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -253,6 +261,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: true,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -261,5 +270,92 @@ describe("createBearerRevalidator", () => {
     expect(store.cleared).toBe(false);
     expect(store.writes).toEqual([]);
     expect(lease.getBearerToken()).toBe("stale");
+  });
+
+  it("adopts a sibling's freshly-persisted token on reject instead of signing out", async () => {
+    refreshMock.mockResolvedValue({ kind: "rejected" });
+    const lease = new MutableBearerLease("stale", "u1");
+    // read() #1 (pre-refresh) returns "stale" (== current → refresh); read() #2
+    // (reject re-read) finds the winner's freshly-persisted token.
+    let reads = 0;
+    const store: BearerStore = {
+      read: async () => {
+        reads += 1;
+        return reads === 1 ? tokens("stale") : tokens("winner");
+      },
+      write: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    };
+    const revalidator = createBearerRevalidator({
+      authnBaseUrl: AUTHN,
+      lease,
+      store,
+      // Even with clearOnReject true (the GUI's sign-out posture), an adoptable
+      // sibling token must win over the clear.
+      clearOnReject: true,
+      delay: async () => undefined,
+    });
+
+    const outcome = await revalidator.revalidateCurrentContext();
+
+    expect(outcome).toBe("rotated");
+    expect(lease.getBearerToken()).toBe("winner");
+    // Adopt-only: never write (no double-write) and never clear.
+    expect(store.write).not.toHaveBeenCalled();
+    expect(store.clear).not.toHaveBeenCalled();
+  });
+
+  it("bounded poll on reject catches a slightly-delayed sibling write", async () => {
+    refreshMock.mockResolvedValue({ kind: "rejected" });
+    const lease = new MutableBearerLease("stale", "u1");
+    // The store stays pinned to "stale" until the first inter-poll delay fires,
+    // at which point the sibling has persisted "winner".
+    const state = { token: "stale" };
+    const store: BearerStore = {
+      read: async () => tokens(state.token),
+      write: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    };
+    const delay = vi.fn(async () => {
+      state.token = "winner";
+    });
+    const revalidator = createBearerRevalidator({
+      authnBaseUrl: AUTHN,
+      lease,
+      store,
+      clearOnReject: true,
+      delay,
+    });
+
+    const outcome = await revalidator.revalidateCurrentContext();
+
+    expect(outcome).toBe("rotated");
+    expect(lease.getBearerToken()).toBe("winner");
+    // Pre-refresh read + first reject read both saw "stale"; one delay, then the
+    // second reject read adopted "winner".
+    expect(delay).toHaveBeenCalledTimes(1);
+    expect(store.clear).not.toHaveBeenCalled();
+  });
+
+  it("rejects (and clears when clearOnReject) when the store never holds a newer token", async () => {
+    refreshMock.mockResolvedValue({ kind: "rejected" });
+    const lease = new MutableBearerLease("stale", "u1");
+    const store = makeStore("stale");
+    const delay = vi.fn(async () => undefined);
+    const revalidator = createBearerRevalidator({
+      authnBaseUrl: AUTHN,
+      lease,
+      store,
+      clearOnReject: true,
+      delay,
+    });
+
+    const outcome = await revalidator.revalidateCurrentContext();
+
+    expect(outcome).toBe("rejected");
+    expect(store.cleared).toBe(true);
+    expect(store.writes).toEqual([]);
+    // Poll exhausted its budget: one delay per gap between the re-reads.
+    expect(delay).toHaveBeenCalledTimes(REJECT_REREAD_ATTEMPTS - 1);
   });
 });

--- a/clients/shared/auth/bearer-revalidator.ts
+++ b/clients/shared/auth/bearer-revalidator.ts
@@ -35,6 +35,18 @@ export interface BearerStore {
 export type RevalidateOutcome = "rotated" | "rejected" | "network-error";
 
 /**
+ * Reject re-read poll cadence. After a refresh is rejected we re-read the store
+ * a few times before treating the credential as dead: a sibling that won the
+ * same single-use rotation may have just persisted a fresh pair to the shared
+ * store. The reject's own round-trip usually already gives the winner enough
+ * time, so the first re-read typically suffices; these bound a slightly-delayed
+ * sibling write (~`POLL_INTERVAL_MS * (ATTEMPTS - 1)` worst case) without
+ * letting a genuine reject hang.
+ */
+export const REJECT_REREAD_POLL_INTERVAL_MS = 100;
+export const REJECT_REREAD_ATTEMPTS = 5;
+
+/**
  * Stream-side auth recovery hook the `/stream` transport invokes after the
  * host rejects an open frame with `UNAUTHORIZED`. Returns the normalized
  * outcome the transport acts on:
@@ -88,16 +100,31 @@ export async function rotateAndPersistBearer(args: {
  *      writing: if a sibling rotated *during* the round trip, adopt theirs
  *      rather than clobbering it; else persist our rotation.
  *   3. Rotate the active lease to whichever token we settled on.
+ *   4. If the refresh is *rejected*, re-read the store once more (a short bounded
+ *      poll). A sibling that won the same single-use rotation outside the
+ *      server's grace window - or while Redis was down / before that coordination
+ *      shipped - may have already persisted a fresh token. If the store now holds
+ *      a token different from `current`, adopt it and report `rotated` rather than
+ *      signing the user out. Only a store still pinned to `current` is a genuine
+ *      reject. (A store whose access token *equals* `current` but whose refresh
+ *      token is stale is a separate staleness case handled by full-pair
+ *      re-provision, not here.)
  *
  * `clearOnReject` controls whether a rejected refresh wipes the store: the
  * renderer signs the user out (true); the CLI leaves credentials in place so a
  * transient authn outage doesn't force a re-login (false).
+ *
+ * `delay` is the awaitable sleep between reject re-read polls, injected so the
+ * poll is deterministic in tests and environment-agnostic in production (mirrors
+ * the proactive scheduler's timer injection); real callers back it with
+ * `setTimeout`.
  */
 export function createBearerRevalidator(args: {
   readonly authnBaseUrl: string;
   readonly lease: BearerLease;
   readonly store: BearerStore;
   readonly clearOnReject: boolean;
+  readonly delay: (ms: number) => Promise<void>;
 }): AuthRevalidator & {
   revalidateCurrentContext(): Promise<RevalidateOutcome>;
 } {
@@ -140,6 +167,37 @@ export function createBearerRevalidator(args: {
           return "network-error";
         }
         if (result.kind === "rejected") {
+          // A loser of a concurrent rotation can be rejected even though the
+          // winner already persisted a fresh token to the shared store. Re-read
+          // before treating the credential as dead; a bounded poll covers a
+          // slightly-delayed sibling write. Adopt any non-empty token that
+          // differs from `current` (same shape as the pre-/post-refresh adopt
+          // branches) and never clear - clearing would clobber the winner's pair
+          // and sign the user out. This is a sequential read/wait loop, not an
+          // array transform, so an explicit bounded loop reads clearest.
+          let adopted: string | null = null;
+          for (
+            let attempt = 0;
+            attempt < REJECT_REREAD_ATTEMPTS;
+            attempt += 1
+          ) {
+            const persisted = await args.store.read();
+            if (
+              persisted !== null &&
+              persisted.token.length > 0 &&
+              persisted.token !== current
+            ) {
+              adopted = persisted.token;
+              break;
+            }
+            if (attempt < REJECT_REREAD_ATTEMPTS - 1) {
+              await args.delay(REJECT_REREAD_POLL_INTERVAL_MS);
+            }
+          }
+          if (adopted !== null) {
+            args.lease.rotate(adopted);
+            return "rotated";
+          }
           if (args.clearOnReject) {
             await args.store.clear();
           }

--- a/clients/traycer-cli/src/commands/monitor.ts
+++ b/clients/traycer-cli/src/commands/monitor.ts
@@ -139,6 +139,7 @@ export async function runMonitor(args: MonitorArgs): Promise<void> {
     lease,
     store: cliBearerStore,
     clearOnReject: false,
+    delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   });
 
   // The shared client reads `endpoint()` on every (re)connect, so a poller that

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -196,6 +196,7 @@ async function requestAtEndpoint<
     lease,
     store: cliBearerStore,
     clearOnReject: false,
+    delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   });
 
   const messenger = createRetryingMessenger<HostRpcRegistry>(


### PR DESCRIPTION
Part of the **auth refresh-token grace window** work (client-side hardening; ticket `fix1-reject-adopt`).

When a refresh is rejected but a sibling process already rotated and persisted a fresh token, the shared `createBearerRevalidator` now re-reads the store (a short bounded poll) and **adopts** the sibling's token instead of concluding `rejected` — closing a spurious-failure window for racing refreshers (CLI monitor + one-shot commands) whose refresh lands outside the server-side grace window.

- `clients/shared/auth/bearer-revalidator.ts`: reject-path bounded poll + adopt (injected `delay`; `REJECT_REREAD_POLL_INTERVAL_MS=100`, `REJECT_REREAD_ATTEMPTS=5`).
- CLI call sites (`host-rpc.ts`, `monitor.ts`) pass the delay factory.
- GUI intentionally unchanged — it has its own identity-safe guard (`signOutIfRefreshCredentialDead`); the GUI must not blind-adopt (shared multi-window token slot).

Tests: 12 bearer-revalidator + 82 auth suite green; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
