### PR TITLE
fix(gui-auth): re-provision full token pair to CLI on reactive refresh

### DIFF
--- a/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
@@ -1285,5 +1285,108 @@ describe("AuthService", () => {
       expect(cli.lastLoginToken).toBe("fresh-token");
       expect(cli.lastLoginRefreshToken).toBe("fresh-token-refresh");
     });
+
+    it("re-provisions the FULL pair to the local CLI on a reactive refresh", async () => {
+      const cli = new MockTraycerCli();
+      const host = new MockRunnerHost({
+        signInUrl:
+          "https://auth.traycer.ai/sign-in?redirect_uri=traycer%3A%2F%2Fauth",
+        authnBaseUrl: "http://localhost:5005",
+        localHost: null,
+        hosts: [],
+        workspaceFolderPickerPaths: undefined,
+        hasLocalHost: undefined,
+        traycerCli: cli,
+      });
+      const service = trackService(new AuthService({ runnerHost: host }));
+      await service.start();
+      await service.signIn();
+      host.emitAuthCallback({ code: "old-token" });
+      await vi.waitFor(() => {
+        expect(useAuthStore.getState().status).toBe("signed-in");
+      });
+      // First sign-in provisions the full pair up front.
+      expect(cli.lastLoginToken).toBe("old-token");
+      expect(cli.lastLoginRefreshToken).toBe("old-token-refresh");
+
+      // A reactive revalidation 401s on the current bearer, refreshes once, and
+      // rotates the live lease in place.
+      restoreFetch();
+      restoreFetch = installFetch((input, init) => {
+        const url = typeof input === "string" ? input : String(input);
+        if (
+          url === VALIDATION_URL &&
+          init?.headers?.Authorization === "Bearer old-token"
+        ) {
+          return status(401);
+        }
+        if (
+          url === REFRESH_URL &&
+          init?.headers?.Authorization === "Bearer old-token"
+        ) {
+          return okWithRefreshToken("rotated-token");
+        }
+        if (
+          url === VALIDATION_URL &&
+          init?.headers?.Authorization === "Bearer rotated-token"
+        ) {
+          return okWithProfile();
+        }
+        return status(500);
+      });
+
+      const outcome = await service.revalidateCurrentContext();
+
+      expect(outcome?.kind).toBe("valid");
+      expect(service.getCurrentSessionSnapshot().token).toBe("rotated-token");
+      // Fix (2): the reactive rotate path now re-provisions the FULL pair, so the
+      // CLI file never holds the fresh bearer beside the now-spent refresh token.
+      expect(cli.lastLoginToken).toBe("rotated-token");
+      expect(cli.lastLoginRefreshToken).toBe("rotated-token-refresh");
+    });
+
+    it("still provisions the FULL pair to the local CLI on a proactive refresh", async () => {
+      const cli = new MockTraycerCli();
+      const host = new MockRunnerHost({
+        signInUrl:
+          "https://auth.traycer.ai/sign-in?redirect_uri=traycer%3A%2F%2Fauth",
+        authnBaseUrl: "http://localhost:5005",
+        localHost: null,
+        hosts: [],
+        workspaceFolderPickerPaths: undefined,
+        hasLocalHost: undefined,
+        traycerCli: cli,
+      });
+      // 5m of life left → inside the proactive lead window, so an OS resume
+      // drives an immediate force-refresh against `/api/v3/auth/refresh`.
+      const nearExpiry = jwtExpiringInMs(5 * 60_000);
+      await host.tokenStore.set({
+        token: nearExpiry,
+        refreshToken: `${nearExpiry}-refresh`,
+      });
+      const service = trackService(new AuthService({ runnerHost: host }));
+      await service.start();
+      expect(useAuthStore.getState().status).toBe("signed-in");
+
+      const rotated = jwtExpiringInMs(4 * 60 * 60_000);
+      restoreFetch();
+      restoreFetch = installFetch((input) => {
+        const url = typeof input === "string" ? input : String(input);
+        if (url === REFRESH_URL) {
+          return okWithRefreshToken(rotated);
+        }
+        return okWithProfile();
+      });
+
+      host.emitSystemResumed();
+
+      await vi.waitFor(() => {
+        expect(service.getCurrentSessionSnapshot().token).toBe(rotated);
+      });
+      await vi.waitFor(() => {
+        expect(cli.lastLoginToken).toBe(rotated);
+      });
+      expect(cli.lastLoginRefreshToken).toBe(`${rotated}-refresh`);
+    });
   });
 });

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -801,6 +801,16 @@ export class AuthService {
         this.currentProfile = profile;
         this.emitSessionSnapshot();
         this.refreshScheduler.start();
+        // Re-provision the FULL pair to the machine-local CLI/host credentials.
+        // The snapshot emit above drives `CliCredentialSeeder`, which re-seeds
+        // the bearer ONLY (empty refresh token), so the file would keep the
+        // now-spent refresh token beside the fresh bearer and later host/CLI
+        // refreshes would fail. Mirrors the proactive path's full-pair
+        // re-provision; best-effort and a no-op on shells without a local CLI.
+        await this.ensureLocalProvisioning(
+          accepted.token,
+          accepted.refreshToken,
+        );
       }
       return outcome;
     }


### PR DESCRIPTION
Part of the **auth refresh-token grace window** work (client-side; ticket `fix2-reactive-reprovision`).

The GUI re-seeds the CLI credentials file, but on a **reactive** refresh only the bearer was re-seeded (refresh token left stale) — so the file could hold a fresh bearer beside a spent refresh token. This adds `ensureLocalProvisioning(token, refreshToken)` on the reactive rotate path (`revalidateCurrentContextOnce`), mirroring the proactive path, so the file always carries the full rotated pair.

- `clients/gui-app/src/lib/auth/auth-service.ts`: full-pair re-provision on the same-user reactive rotate branch.
- Seeder dedupe (`CliCredentialSeeder`) confirmed unaffected.

Tests: gui-app auth suite 44/44 (2 new + 42 existing); eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
