### PR TITLE
auth: map authn refresh 409 to network-error in refreshAuthTokenViaHttp

### DIFF
--- a/clients/shared/auth/__tests__/auth-validation.test.ts
+++ b/clients/shared/auth/__tests__/auth-validation.test.ts
@@ -12,6 +12,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  refreshAuthTokenViaHttp,
   validateAuthTokenIdentityViaHttp,
   type AuthIdentityValidationResult,
 } from "../auth-validation";
@@ -201,5 +202,58 @@ describe("validateAuthTokenIdentityViaHttp - full AuthenticatedUser", () => {
     );
 
     expect(result.kind).toBe("rejected");
+  });
+});
+
+describe("refreshAuthTokenViaHttp - status mapping", () => {
+  it("maps a 409 (refresh grace window in progress) to network-error", async () => {
+    installMockFetch([{ status: 409, body: { error: "in progress" } }]);
+
+    const result = await refreshAuthTokenViaHttp(
+      AUTHN_BASE_URL,
+      "stale-bearer",
+      "stale-refresh",
+    );
+
+    // A concurrent refresher is mid-rotation: transient/retriable, NOT a dead
+    // credential. Must NOT downgrade to `rejected` (which signs the GUI out).
+    expect(result.kind).toBe("network-error");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(REFRESH_ENDPOINT);
+    expect(calls[0].method).toBe("POST");
+  });
+
+  it("maps a 401 to rejected", async () => {
+    installMockFetch([{ status: 401, body: { error: "Unauthorized" } }]);
+
+    const result = await refreshAuthTokenViaHttp(
+      AUTHN_BASE_URL,
+      "stale-bearer",
+      "stale-refresh",
+    );
+
+    expect(result.kind).toBe("rejected");
+  });
+
+  it("returns the rotated pair on success", async () => {
+    installMockFetch([
+      {
+        status: 200,
+        body: { token: "rotated-bearer", refreshToken: "rotated-refresh" },
+      },
+    ]);
+
+    const result = await refreshAuthTokenViaHttp(
+      AUTHN_BASE_URL,
+      "stale-bearer",
+      "stale-refresh",
+    );
+
+    expect(result.kind).toBe("refreshed");
+    if (result.kind !== "refreshed") {
+      throw new Error("expected refreshed result");
+    }
+    expect(result.token).toBe("rotated-bearer");
+    expect(result.refreshToken).toBe("rotated-refresh");
   });
 });

--- a/clients/shared/auth/auth-validation.ts
+++ b/clients/shared/auth/auth-validation.ts
@@ -242,6 +242,15 @@ export async function refreshAuthTokenViaHttp(
     return { kind: "network-error" };
   }
 
+  // A 409 means the authn refresh grace window is mid-rotation: a concurrent
+  // refresher won the race and is minting the new pair. This is transient and
+  // retriable, NOT a dead credential, so map it to `network-error` (a retry
+  // re-drives and lands on the winner's replayed pair) rather than `rejected`,
+  // which would sign the GUI out.
+  if (response.status === 409) {
+    return { kind: "network-error" };
+  }
+
   if (
     response.status === 400 ||
     response.status === 401 ||


### PR DESCRIPTION
Client companion to the **authn refresh-token grace window** server change (ticket `c-grace-window`, client half; pairs with the authn-v3 PR in traycerai/traycer-internal).

The new authn grace window returns **HTTP 409** while a concurrent refresh is mid-rotation (the loser should retry, not sign out). This maps `409` → `network-error` in `refreshAuthTokenViaHttp` explicitly — it previously fell through the `status >= 300` catch-all, so this pins the mapping as intentional and tested. `401` → `rejected` / success → `refreshed` unchanged. Backward-compatible.

Tests: shared/auth 9/9; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
