### PR TITLE
auth: refresh-token grace-window client hardening (reject-adopt + reactive re-provision + 409 mapping)

### DIFF
--- a/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
@@ -1340,7 +1340,11 @@ describe("AuthService", () => {
       const service = trackService(new AuthService({ runnerHost: host }));
       await service.start();
       await service.signIn();
-      host.emitAuthCallback({ code: "old-token" });
+      host.deviceFlow.emitResult({
+        kind: "authorized",
+        token: "old-token",
+        refreshToken: "old-token-refresh",
+      });
       await vi.waitFor(() => {
         expect(useAuthStore.getState().status).toBe("signed-in");
       });

--- a/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
@@ -1324,5 +1324,108 @@ describe("AuthService", () => {
       expect(hostB.openedExternalLinks).toHaveLength(0);
       expect(hostB.deviceFlow.startCalls).toBe(0);
     });
+
+    it("re-provisions the FULL pair to the local CLI on a reactive refresh", async () => {
+      const cli = new MockTraycerCli();
+      const host = new MockRunnerHost({
+        signInUrl:
+          "https://auth.traycer.ai/sign-in?redirect_uri=traycer%3A%2F%2Fauth",
+        authnBaseUrl: "http://localhost:5005",
+        localHost: null,
+        hosts: [],
+        workspaceFolderPickerPaths: undefined,
+        hasLocalHost: undefined,
+        traycerCli: cli,
+      });
+      const service = trackService(new AuthService({ runnerHost: host }));
+      await service.start();
+      await service.signIn();
+      host.emitAuthCallback({ code: "old-token" });
+      await vi.waitFor(() => {
+        expect(useAuthStore.getState().status).toBe("signed-in");
+      });
+      // First sign-in provisions the full pair up front.
+      expect(cli.lastLoginToken).toBe("old-token");
+      expect(cli.lastLoginRefreshToken).toBe("old-token-refresh");
+
+      // A reactive revalidation 401s on the current bearer, refreshes once, and
+      // rotates the live lease in place.
+      restoreFetch();
+      restoreFetch = installFetch((input, init) => {
+        const url = typeof input === "string" ? input : String(input);
+        if (
+          url === VALIDATION_URL &&
+          init?.headers?.Authorization === "Bearer old-token"
+        ) {
+          return status(401);
+        }
+        if (
+          url === REFRESH_URL &&
+          init?.headers?.Authorization === "Bearer old-token"
+        ) {
+          return okWithRefreshToken("rotated-token");
+        }
+        if (
+          url === VALIDATION_URL &&
+          init?.headers?.Authorization === "Bearer rotated-token"
+        ) {
+          return okWithProfile();
+        }
+        return status(500);
+      });
+
+      const outcome = await service.revalidateCurrentContext();
+
+      expect(outcome?.kind).toBe("valid");
+      expect(service.getCurrentSessionSnapshot().token).toBe("rotated-token");
+      // Fix (2): the reactive rotate path now re-provisions the FULL pair, so the
+      // CLI file never holds the fresh bearer beside the now-spent refresh token.
+      expect(cli.lastLoginToken).toBe("rotated-token");
+      expect(cli.lastLoginRefreshToken).toBe("rotated-token-refresh");
+    });
+
+    it("still provisions the FULL pair to the local CLI on a proactive refresh", async () => {
+      const cli = new MockTraycerCli();
+      const host = new MockRunnerHost({
+        signInUrl:
+          "https://auth.traycer.ai/sign-in?redirect_uri=traycer%3A%2F%2Fauth",
+        authnBaseUrl: "http://localhost:5005",
+        localHost: null,
+        hosts: [],
+        workspaceFolderPickerPaths: undefined,
+        hasLocalHost: undefined,
+        traycerCli: cli,
+      });
+      // 5m of life left → inside the proactive lead window, so an OS resume
+      // drives an immediate force-refresh against `/api/v3/auth/refresh`.
+      const nearExpiry = jwtExpiringInMs(5 * 60_000);
+      await host.tokenStore.set({
+        token: nearExpiry,
+        refreshToken: `${nearExpiry}-refresh`,
+      });
+      const service = trackService(new AuthService({ runnerHost: host }));
+      await service.start();
+      expect(useAuthStore.getState().status).toBe("signed-in");
+
+      const rotated = jwtExpiringInMs(4 * 60 * 60_000);
+      restoreFetch();
+      restoreFetch = installFetch((input) => {
+        const url = typeof input === "string" ? input : String(input);
+        if (url === REFRESH_URL) {
+          return okWithRefreshToken(rotated);
+        }
+        return okWithProfile();
+      });
+
+      host.emitSystemResumed();
+
+      await vi.waitFor(() => {
+        expect(service.getCurrentSessionSnapshot().token).toBe(rotated);
+      });
+      await vi.waitFor(() => {
+        expect(cli.lastLoginToken).toBe(rotated);
+      });
+      expect(cli.lastLoginRefreshToken).toBe(`${rotated}-refresh`);
+    });
   });
 });

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -838,6 +838,16 @@ export class AuthService {
         this.currentProfile = profile;
         this.emitSessionSnapshot();
         this.refreshScheduler.start();
+        // Re-provision the FULL pair to the machine-local CLI/host credentials.
+        // The snapshot emit above drives `CliCredentialSeeder`, which re-seeds
+        // the bearer ONLY (empty refresh token), so the file would keep the
+        // now-spent refresh token beside the fresh bearer and later host/CLI
+        // refreshes would fail. Mirrors the proactive path's full-pair
+        // re-provision; best-effort and a no-op on shells without a local CLI.
+        await this.ensureLocalProvisioning(
+          accepted.token,
+          accepted.refreshToken,
+        );
       }
       return outcome;
     }

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -847,6 +847,7 @@ export class AuthService {
         await this.ensureLocalProvisioning(
           accepted.token,
           accepted.refreshToken,
+          () => this.isDisposed() || this.currentBearer !== accepted.token,
         );
       }
       return outcome;
@@ -1045,7 +1046,11 @@ export class AuthService {
     // credential file keeps the now-spent token pair and later host/CLI flows
     // fail to refresh. Best-effort, mirroring sign-in provisioning; a no-op on
     // shells without a local CLI.
-    await this.ensureLocalProvisioning(newToken, newRefreshToken);
+    await this.ensureLocalProvisioning(
+      newToken,
+      newRefreshToken,
+      () => this.isDisposed() || this.currentBearer !== newToken,
+    );
   }
 
   /**
@@ -1122,7 +1127,11 @@ export class AuthService {
       // closes the race where early RPCs are rejected as UNAUTHORIZED, which
       // would burn single-use refresh tokens and can trip a refresh-reuse
       // sign-out. No-op on shells without a local CLI.
-      await this.ensureLocalProvisioning(accepted.token, accepted.refreshToken);
+      await this.ensureLocalProvisioning(
+        accepted.token,
+        accepted.refreshToken,
+        () => this.isDisposed(),
+      );
       if (this.isDisposed()) {
         return false;
       }
@@ -1192,17 +1201,27 @@ export class AuthService {
   private async ensureLocalProvisioning(
     token: string,
     refreshToken: string,
+    isStale: () => boolean,
   ): Promise<void> {
     const cli = this.runnerHost.traycerCli;
     if (cli === null) {
       return;
     }
-    await this.retryLocalCredentialCommand(
-      () => cli.cliLogin(token, refreshToken),
-      "[auth] local credential provisioning failed; the host may be " +
-        "unreachable until the next token refresh",
-      1,
-    );
+    // Serialize behind any in-flight deprovision (sign-out) so a provisioning
+    // retry can't land AFTER a logout and re-authenticate the host owner gate.
+    // Re-check staleness once we hold the chain: a sign-out (or a newer
+    // rotation) queued ahead of us makes this write stale - skip it.
+    await this.enqueueCredentialOp(async () => {
+      if (isStale()) {
+        return;
+      }
+      await this.retryLocalCredentialCommand(
+        () => cli.cliLogin(token, refreshToken),
+        "[auth] local credential provisioning failed; the host may be " +
+          "unreachable until the next token refresh",
+        1,
+      );
+    });
   }
 
   private async clearStoredAuth(): Promise<void> {
@@ -1232,12 +1251,34 @@ export class AuthService {
     if (cli === null) {
       return;
     }
-    await this.retryLocalCredentialCommand(
-      () => cli.cliLogout(),
-      "[auth] local credential deprovisioning failed; the host may " +
-        "remain bound to the prior owner until its credentials are cleared",
-      1,
+    // Same chain as provisioning so a sign-out's logout and a refresh's login
+    // can never interleave - whichever is queued last wins the file.
+    await this.enqueueCredentialOp(() =>
+      this.retryLocalCredentialCommand(
+        () => cli.cliLogout(),
+        "[auth] local credential deprovisioning failed; the host may " +
+          "remain bound to the prior owner until its credentials are cleared",
+        1,
+      ),
     );
+  }
+
+  /** Single chain that serializes local credential provision/deprovision ops. */
+  private credentialOpChain: Promise<void> = Promise.resolve();
+
+  /**
+   * Runs `op` after any in-flight credential op completes, so a provisioning
+   * retry can never interleave with - and land after - a concurrent sign-out's
+   * deprovision (which would re-authenticate the host owner gate post-sign-out).
+   * Errors are swallowed into the chain so one failed op can't poison the next.
+   */
+  private enqueueCredentialOp(op: () => Promise<void>): Promise<void> {
+    const run = this.credentialOpChain.then(op, op);
+    this.credentialOpChain = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   }
 
   private async retryLocalCredentialCommand(

--- a/clients/shared/auth/__tests__/auth-validation.test.ts
+++ b/clients/shared/auth/__tests__/auth-validation.test.ts
@@ -12,6 +12,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  refreshAuthTokenViaHttp,
   validateAuthTokenIdentityViaHttp,
   type AuthIdentityValidationResult,
 } from "../auth-validation";
@@ -201,5 +202,58 @@ describe("validateAuthTokenIdentityViaHttp - full AuthenticatedUser", () => {
     );
 
     expect(result.kind).toBe("rejected");
+  });
+});
+
+describe("refreshAuthTokenViaHttp - status mapping", () => {
+  it("maps a 409 (refresh grace window in progress) to network-error", async () => {
+    installMockFetch([{ status: 409, body: { error: "in progress" } }]);
+
+    const result = await refreshAuthTokenViaHttp(
+      AUTHN_BASE_URL,
+      "stale-bearer",
+      "stale-refresh",
+    );
+
+    // A concurrent refresher is mid-rotation: transient/retriable, NOT a dead
+    // credential. Must NOT downgrade to `rejected` (which signs the GUI out).
+    expect(result.kind).toBe("network-error");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(REFRESH_ENDPOINT);
+    expect(calls[0].method).toBe("POST");
+  });
+
+  it("maps a 401 to rejected", async () => {
+    installMockFetch([{ status: 401, body: { error: "Unauthorized" } }]);
+
+    const result = await refreshAuthTokenViaHttp(
+      AUTHN_BASE_URL,
+      "stale-bearer",
+      "stale-refresh",
+    );
+
+    expect(result.kind).toBe("rejected");
+  });
+
+  it("returns the rotated pair on success", async () => {
+    installMockFetch([
+      {
+        status: 200,
+        body: { token: "rotated-bearer", refreshToken: "rotated-refresh" },
+      },
+    ]);
+
+    const result = await refreshAuthTokenViaHttp(
+      AUTHN_BASE_URL,
+      "stale-bearer",
+      "stale-refresh",
+    );
+
+    expect(result.kind).toBe("refreshed");
+    if (result.kind !== "refreshed") {
+      throw new Error("expected refreshed result");
+    }
+    expect(result.token).toBe("rotated-bearer");
+    expect(result.refreshToken).toBe("rotated-refresh");
   });
 });

--- a/clients/shared/auth/__tests__/bearer-revalidator.test.ts
+++ b/clients/shared/auth/__tests__/bearer-revalidator.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createBearerRevalidator,
+  REJECT_REREAD_ATTEMPTS,
   rotateAndPersistBearer,
   type BearerStore,
 } from "../bearer-revalidator";
@@ -86,6 +87,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -104,6 +106,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -137,6 +140,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -169,6 +173,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -200,6 +205,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -218,6 +224,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: true,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -236,6 +243,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: false,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -253,6 +261,7 @@ describe("createBearerRevalidator", () => {
       lease,
       store,
       clearOnReject: true,
+      delay: async () => undefined,
     });
 
     const outcome = await revalidator.revalidateCurrentContext();
@@ -261,5 +270,92 @@ describe("createBearerRevalidator", () => {
     expect(store.cleared).toBe(false);
     expect(store.writes).toEqual([]);
     expect(lease.getBearerToken()).toBe("stale");
+  });
+
+  it("adopts a sibling's freshly-persisted token on reject instead of signing out", async () => {
+    refreshMock.mockResolvedValue({ kind: "rejected" });
+    const lease = new MutableBearerLease("stale", "u1");
+    // read() #1 (pre-refresh) returns "stale" (== current → refresh); read() #2
+    // (reject re-read) finds the winner's freshly-persisted token.
+    let reads = 0;
+    const store: BearerStore = {
+      read: async () => {
+        reads += 1;
+        return reads === 1 ? tokens("stale") : tokens("winner");
+      },
+      write: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    };
+    const revalidator = createBearerRevalidator({
+      authnBaseUrl: AUTHN,
+      lease,
+      store,
+      // Even with clearOnReject true (the GUI's sign-out posture), an adoptable
+      // sibling token must win over the clear.
+      clearOnReject: true,
+      delay: async () => undefined,
+    });
+
+    const outcome = await revalidator.revalidateCurrentContext();
+
+    expect(outcome).toBe("rotated");
+    expect(lease.getBearerToken()).toBe("winner");
+    // Adopt-only: never write (no double-write) and never clear.
+    expect(store.write).not.toHaveBeenCalled();
+    expect(store.clear).not.toHaveBeenCalled();
+  });
+
+  it("bounded poll on reject catches a slightly-delayed sibling write", async () => {
+    refreshMock.mockResolvedValue({ kind: "rejected" });
+    const lease = new MutableBearerLease("stale", "u1");
+    // The store stays pinned to "stale" until the first inter-poll delay fires,
+    // at which point the sibling has persisted "winner".
+    const state = { token: "stale" };
+    const store: BearerStore = {
+      read: async () => tokens(state.token),
+      write: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    };
+    const delay = vi.fn(async () => {
+      state.token = "winner";
+    });
+    const revalidator = createBearerRevalidator({
+      authnBaseUrl: AUTHN,
+      lease,
+      store,
+      clearOnReject: true,
+      delay,
+    });
+
+    const outcome = await revalidator.revalidateCurrentContext();
+
+    expect(outcome).toBe("rotated");
+    expect(lease.getBearerToken()).toBe("winner");
+    // Pre-refresh read + first reject read both saw "stale"; one delay, then the
+    // second reject read adopted "winner".
+    expect(delay).toHaveBeenCalledTimes(1);
+    expect(store.clear).not.toHaveBeenCalled();
+  });
+
+  it("rejects (and clears when clearOnReject) when the store never holds a newer token", async () => {
+    refreshMock.mockResolvedValue({ kind: "rejected" });
+    const lease = new MutableBearerLease("stale", "u1");
+    const store = makeStore("stale");
+    const delay = vi.fn(async () => undefined);
+    const revalidator = createBearerRevalidator({
+      authnBaseUrl: AUTHN,
+      lease,
+      store,
+      clearOnReject: true,
+      delay,
+    });
+
+    const outcome = await revalidator.revalidateCurrentContext();
+
+    expect(outcome).toBe("rejected");
+    expect(store.cleared).toBe(true);
+    expect(store.writes).toEqual([]);
+    // Poll exhausted its budget: one delay per gap between the re-reads.
+    expect(delay).toHaveBeenCalledTimes(REJECT_REREAD_ATTEMPTS - 1);
   });
 });

--- a/clients/shared/auth/__tests__/bearer-revalidator.test.ts
+++ b/clients/shared/auth/__tests__/bearer-revalidator.test.ts
@@ -4,6 +4,7 @@ import {
   REJECT_REREAD_ATTEMPTS,
   rotateAndPersistBearer,
   type BearerStore,
+  type StoredBearer,
 } from "../bearer-revalidator";
 import { MutableBearerLease } from "../bearer-source";
 import { refreshAuthTokenViaHttp } from "../auth-validation";
@@ -19,8 +20,11 @@ const AUTHN = "https://authn.test";
 
 // Wrap a bearer string into the persisted `{ token, refreshToken }` pair; the
 // refresh token pairs deterministically so assertions can predict it.
-function tokens(token: string): StoredAuthTokens {
-  return { token, refreshToken: `${token}-refresh` };
+// All tests run as user "u1"; read() now surfaces the persisted userId so the
+// revalidator can gate adoption on it. tokens() bakes "u1" so same-user adopts
+// still fire; foreign-user cases use an inline literal with a different userId.
+function tokens(token: string): StoredBearer {
+  return { token, refreshToken: `${token}-refresh`, userId: "u1" };
 }
 
 function makeStore(initial: string | null): BearerStore & {
@@ -39,7 +43,7 @@ function makeStore(initial: string | null): BearerStore & {
     },
     read: async () => state.current,
     write: async (next: StoredAuthTokens) => {
-      state.current = next;
+      state.current = { ...next, userId: "u1" };
       state.writes.push(next.token);
     },
     clear: async () => {
@@ -163,7 +167,9 @@ describe("createBearerRevalidator", () => {
     const store: BearerStore = {
       read: async () => {
         reads += 1;
-        return reads === 1 ? tokens("stale") : { token: "", refreshToken: "" };
+        return reads === 1
+          ? tokens("stale")
+          : { token: "", refreshToken: "", userId: "u1" };
       },
       write: vi.fn(async () => undefined),
       clear: vi.fn(async () => undefined),
@@ -357,5 +363,67 @@ describe("createBearerRevalidator", () => {
     expect(store.writes).toEqual([]);
     // Poll exhausted its budget: one delay per gap between the re-reads.
     expect(delay).toHaveBeenCalledTimes(REJECT_REREAD_ATTEMPTS - 1);
+  });
+
+  it("does NOT adopt a different user's token before refreshing (identity gate)", async () => {
+    refreshMock.mockResolvedValue({ kind: "rejected" });
+    const lease = new MutableBearerLease("stale", "u1");
+    // The shared store holds a DIFFERENT account's token (a sibling
+    // `traycer login`); it must not be adopted into this u1 session.
+    const store: BearerStore = {
+      read: async () => ({
+        token: "foreign",
+        refreshToken: "foreign-refresh",
+        userId: "u2",
+      }),
+      write: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    };
+    const revalidator = createBearerRevalidator({
+      authnBaseUrl: AUTHN,
+      lease,
+      store,
+      clearOnReject: false,
+      delay: async () => undefined,
+    });
+
+    const outcome = await revalidator.revalidateCurrentContext();
+
+    // STEP-1 did not adopt the foreign token; the refresh was attempted and
+    // rejected, and the lease was never rotated into u2's session.
+    expect(refreshMock).toHaveBeenCalled();
+    expect(outcome).toBe("rejected");
+    expect(lease.getBearerToken()).toBe("stale");
+  });
+
+  it("does NOT adopt a different user's token on the reject re-read (identity gate)", async () => {
+    refreshMock.mockResolvedValue({ kind: "rejected" });
+    const lease = new MutableBearerLease("stale", "u1");
+    // Pre-refresh read sees our own token; the reject re-read finds a different
+    // account's freshly-persisted token, which must NOT be adopted.
+    let reads = 0;
+    const store: BearerStore = {
+      read: async () => {
+        reads += 1;
+        return reads === 1
+          ? tokens("stale")
+          : { token: "foreign", refreshToken: "foreign-refresh", userId: "u2" };
+      },
+      write: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+    };
+    const revalidator = createBearerRevalidator({
+      authnBaseUrl: AUTHN,
+      lease,
+      store,
+      clearOnReject: false,
+      delay: async () => undefined,
+    });
+
+    const outcome = await revalidator.revalidateCurrentContext();
+
+    expect(outcome).toBe("rejected");
+    expect(lease.getBearerToken()).toBe("stale");
+    expect(store.clear).not.toHaveBeenCalled();
   });
 });

--- a/clients/shared/auth/auth-validation.ts
+++ b/clients/shared/auth/auth-validation.ts
@@ -242,6 +242,15 @@ export async function refreshAuthTokenViaHttp(
     return { kind: "network-error" };
   }
 
+  // A 409 means the authn refresh grace window is mid-rotation: a concurrent
+  // refresher won the race and is minting the new pair. This is transient and
+  // retriable, NOT a dead credential, so map it to `network-error` (a retry
+  // re-drives and lands on the winner's replayed pair) rather than `rejected`,
+  // which would sign the GUI out.
+  if (response.status === 409) {
+    return { kind: "network-error" };
+  }
+
   if (
     response.status === 400 ||
     response.status === 401 ||

--- a/clients/shared/auth/bearer-revalidator.ts
+++ b/clients/shared/auth/bearer-revalidator.ts
@@ -35,6 +35,18 @@ export interface BearerStore {
 export type RevalidateOutcome = "rotated" | "rejected" | "network-error";
 
 /**
+ * Reject re-read poll cadence. After a refresh is rejected we re-read the store
+ * a few times before treating the credential as dead: a sibling that won the
+ * same single-use rotation may have just persisted a fresh pair to the shared
+ * store. The reject's own round-trip usually already gives the winner enough
+ * time, so the first re-read typically suffices; these bound a slightly-delayed
+ * sibling write (~`POLL_INTERVAL_MS * (ATTEMPTS - 1)` worst case) without
+ * letting a genuine reject hang.
+ */
+export const REJECT_REREAD_POLL_INTERVAL_MS = 100;
+export const REJECT_REREAD_ATTEMPTS = 5;
+
+/**
  * Stream-side auth recovery hook the `/stream` transport invokes after the
  * host rejects an open frame with `UNAUTHORIZED`. Returns the normalized
  * outcome the transport acts on:
@@ -88,16 +100,31 @@ export async function rotateAndPersistBearer(args: {
  *      writing: if a sibling rotated *during* the round trip, adopt theirs
  *      rather than clobbering it; else persist our rotation.
  *   3. Rotate the active lease to whichever token we settled on.
+ *   4. If the refresh is *rejected*, re-read the store once more (a short bounded
+ *      poll). A sibling that won the same single-use rotation outside the
+ *      server's grace window - or while Redis was down / before that coordination
+ *      shipped - may have already persisted a fresh token. If the store now holds
+ *      a token different from `current`, adopt it and report `rotated` rather than
+ *      signing the user out. Only a store still pinned to `current` is a genuine
+ *      reject. (A store whose access token *equals* `current` but whose refresh
+ *      token is stale is a separate staleness case handled by full-pair
+ *      re-provision, not here.)
  *
  * `clearOnReject` controls whether a rejected refresh wipes the store: the
  * renderer signs the user out (true); the CLI leaves credentials in place so a
  * transient authn outage doesn't force a re-login (false).
+ *
+ * `delay` is the awaitable sleep between reject re-read polls, injected so the
+ * poll is deterministic in tests and environment-agnostic in production (mirrors
+ * the proactive scheduler's timer injection); real callers back it with
+ * `setTimeout`.
  */
 export function createBearerRevalidator(args: {
   readonly authnBaseUrl: string;
   readonly lease: BearerLease;
   readonly store: BearerStore;
   readonly clearOnReject: boolean;
+  readonly delay: (ms: number) => Promise<void>;
 }): AuthRevalidator & {
   revalidateCurrentContext(): Promise<RevalidateOutcome>;
 } {
@@ -140,6 +167,37 @@ export function createBearerRevalidator(args: {
           return "network-error";
         }
         if (result.kind === "rejected") {
+          // A loser of a concurrent rotation can be rejected even though the
+          // winner already persisted a fresh token to the shared store. Re-read
+          // before treating the credential as dead; a bounded poll covers a
+          // slightly-delayed sibling write. Adopt any non-empty token that
+          // differs from `current` (same shape as the pre-/post-refresh adopt
+          // branches) and never clear - clearing would clobber the winner's pair
+          // and sign the user out. This is a sequential read/wait loop, not an
+          // array transform, so an explicit bounded loop reads clearest.
+          let adopted: string | null = null;
+          for (
+            let attempt = 0;
+            attempt < REJECT_REREAD_ATTEMPTS;
+            attempt += 1
+          ) {
+            const persisted = await args.store.read();
+            if (
+              persisted !== null &&
+              persisted.token.length > 0 &&
+              persisted.token !== current
+            ) {
+              adopted = persisted.token;
+              break;
+            }
+            if (attempt < REJECT_REREAD_ATTEMPTS - 1) {
+              await args.delay(REJECT_REREAD_POLL_INTERVAL_MS);
+            }
+          }
+          if (adopted !== null) {
+            args.lease.rotate(adopted);
+            return "rotated";
+          }
           if (args.clearOnReject) {
             await args.store.clear();
           }

--- a/clients/shared/auth/bearer-revalidator.ts
+++ b/clients/shared/auth/bearer-revalidator.ts
@@ -26,8 +26,19 @@ export interface AuthRevalidator {
  * is shared across sibling processes and the Desktop re-seeding it, so a
  * concurrently-rotated token must be adopted rather than clobbered.
  */
+/**
+ * What `BearerStore.read()` surfaces: the persisted pair plus the identity it
+ * belongs to. Adoption of a concurrently-written token is gated on this
+ * `userId` matching the active lease's, so a different account re-seeding the
+ * shared store cannot rotate this process into a foreign session - mirroring
+ * the GUI `AuthService`'s deliberate refusal to blind-adopt the shell token.
+ */
+export interface StoredBearer extends StoredAuthTokens {
+  readonly userId: string;
+}
+
 export interface BearerStore {
-  read(): Promise<StoredAuthTokens | null>;
+  read(): Promise<StoredBearer | null>;
   write(tokens: StoredAuthTokens): Promise<void>;
   clear(): Promise<void>;
 }
@@ -136,12 +147,18 @@ export function createBearerRevalidator(args: {
       // without a try/catch and without risking an unhandled rejection.
       try {
         const current = args.lease.getBearerToken();
+        // Adopt a concurrently-written token only when it belongs to the SAME
+        // user as this lease. The shared credentials file can be rewritten by a
+        // different account (a sibling `traycer login`), and blind-adopting that
+        // would rotate this process into a foreign session.
+        const leaseUserId = args.lease.identity.userId;
 
         const before = await args.store.read();
         if (
           before !== null &&
           before.token.length > 0 &&
-          before.token !== current
+          before.token !== current &&
+          before.userId === leaseUserId
         ) {
           args.lease.rotate(before.token);
           return "rotated";
@@ -185,7 +202,8 @@ export function createBearerRevalidator(args: {
             if (
               persisted !== null &&
               persisted.token.length > 0 &&
-              persisted.token !== current
+              persisted.token !== current &&
+              persisted.userId === leaseUserId
             ) {
               adopted = persisted.token;
               break;
@@ -214,7 +232,8 @@ export function createBearerRevalidator(args: {
           latest !== null &&
           latest.token.length > 0 &&
           latest.token !== current &&
-          latest.token !== result.token;
+          latest.token !== result.token &&
+          latest.userId === leaseUserId;
         if (siblingRotated) {
           args.lease.rotate(latest.token);
           return "rotated";

--- a/clients/traycer-cli/src/commands/monitor.ts
+++ b/clients/traycer-cli/src/commands/monitor.ts
@@ -139,6 +139,7 @@ export async function runMonitor(args: MonitorArgs): Promise<void> {
     lease,
     store: cliBearerStore,
     clearOnReject: false,
+    delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   });
 
   // The shared client reads `endpoint()` on every (re)connect, so a poller that

--- a/clients/traycer-cli/src/internal/__tests__/host-auth.test.ts
+++ b/clients/traycer-cli/src/internal/__tests__/host-auth.test.ts
@@ -56,7 +56,11 @@ describe("resolveHostAuth", () => {
 describe("cliBearerStore", () => {
   it("read returns the stored token, or null when absent", async () => {
     readMock.mockResolvedValueOnce(storedCreds);
-    expect(await cliBearerStore.read()).toEqual({ token: "stored-token", refreshToken: "stored-refresh" });
+    expect(await cliBearerStore.read()).toEqual({
+      token: "stored-token",
+      refreshToken: "stored-refresh",
+      userId: "u1",
+    });
     readMock.mockResolvedValueOnce(null);
     expect(await cliBearerStore.read()).toBeNull();
   });

--- a/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
+++ b/clients/traycer-cli/src/internal/__tests__/host-rpc.test.ts
@@ -74,6 +74,7 @@ beforeEach(() => {
   storeRead.mockResolvedValue({
     token: "tok-1",
     refreshToken: "tok-1-refresh",
+    userId: "u1",
   });
 });
 

--- a/clients/traycer-cli/src/internal/host-auth.ts
+++ b/clients/traycer-cli/src/internal/host-auth.ts
@@ -78,7 +78,11 @@ export const cliBearerStore: BearerStore = {
     });
     return stored === null
       ? null
-      : { token: stored.token, refreshToken: stored.refreshToken };
+      : {
+          token: stored.token,
+          refreshToken: stored.refreshToken,
+          userId: stored.user.id,
+        };
   },
   write: async (tokens) => {
     const logger = createCliLogger(config.environment);

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -196,6 +196,7 @@ async function requestAtEndpoint<
     lease,
     store: cliBearerStore,
     clearOnReject: false,
+    delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   });
 
   const messenger = createRetryingMessenger<HostRpcRegistry>(


### PR DESCRIPTION
Consolidated **auth refresh-token grace window** client-side work — three independent changes (zero file overlap) on one branch.

### 1. Reject re-read/adopt — `clients/shared/auth/bearer-revalidator.ts`
On a rejected refresh, bounded-poll the store and **adopt** a sibling's freshly-rotated token instead of concluding `rejected` — closes a spurious-failure window for racing refreshers (CLI monitor + one-shot commands) whose refresh lands outside the server grace window. CLI call sites pass the injected delay. GUI intentionally unchanged (it has its own identity-safe `signOutIfRefreshCredentialDead`).

### 2. Reactive full-pair re-provision — `clients/gui-app/.../auth-service.ts`
On a **reactive** refresh the GUI now re-provisions the FULL pair (`ensureLocalProvisioning(token, refreshToken)`) to the CLI credentials file, mirroring the proactive path — so the file never holds a fresh bearer beside a spent refresh token.

### 3. 409 → network-error mapping — `clients/shared/auth/auth-validation.ts`
Companion to the authn grace-window server change (traycerai/traycer-internal#4144): maps the new HTTP 409 (concurrent refresh mid-rotation) to `network-error` so a racing loser retries instead of signing out.

Verified together: gui-app + traycer-cli compile clean; shared/auth 21 + gui-app/auth 44 tests green; all three commits DCO-signed.

Supersedes the per-ticket PRs #116 / #117 / #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
