### PR TITLE
Group OpenRouter models by vendor in the model picker

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/harness-model-search.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-search.test.ts
@@ -424,6 +424,33 @@ describe("harness model search", () => {
     ).toBe("Owl Alpha");
   });
 
+  it("keeps host order when only some models carry group metadata (partial rollout)", () => {
+    const rows = buildHarnessModelRows(OPENROUTER_HARNESS, [
+      model({
+        harnessId: "openrouter",
+        slug: "openrouter:z-ai/glm-4.6",
+        label: "Z.ai: GLM 4.6",
+        metadata: {
+          openCodeProviderId: "z-ai",
+          openCodeProviderLabel: "Z.ai",
+        },
+      }),
+      model({
+        harnessId: "openrouter",
+        slug: "openrouter:unannotated",
+        label: "Unannotated",
+        metadata: {},
+      }),
+    ]);
+
+    // Mixed annotated/unannotated: not reordered (sorting by group would float
+    // the empty-group model to the top), so the host-preferred order is kept.
+    expect(rows.map((row) => row.value)).toEqual([
+      "openrouter:z-ai/glm-4.6",
+      "openrouter:unannotated",
+    ]);
+  });
+
   it("adds capacity metadata on model rows", () => {
     const rows = buildHarnessModelRows(CLAUDE_HARNESS, [
       model({

--- a/clients/gui-app/src/components/home/__tests__/harness-model-search.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-search.test.ts
@@ -46,6 +46,16 @@ const OPENCODE_HARNESS: HarnessOption = {
   supportedPermissionModes: [...ALL_PERMISSION_MODES],
 };
 
+const OPENROUTER_HARNESS: HarnessOption = {
+  id: "openrouter",
+  label: "OpenRouter",
+  available: true,
+  error: null,
+  modes: ["gui"],
+  requiresApiKey: true,
+  supportedPermissionModes: [...ALL_PERMISSION_MODES],
+};
+
 function model(overrides: Partial<ModelOption>): ModelOption {
   const base: ModelOption = {
     harnessId: "codex",
@@ -341,6 +351,77 @@ describe("harness model search", () => {
       "Anthropic: Claude Opus",
       "Anthropic: Claude Sonnet",
     ]);
+  });
+
+  it("groups OpenRouter models by vendor and trims the redundant vendor prefix from rows", () => {
+    const models = [
+      model({
+        harnessId: "openrouter",
+        slug: "openrouter:anthropic/claude-opus",
+        label: "Anthropic: Claude Opus",
+        metadata: {
+          openCodeProviderId: "anthropic",
+          openCodeProviderLabel: "Anthropic",
+        },
+      }),
+      model({
+        harnessId: "openrouter",
+        slug: "openrouter:~openai/gpt-latest",
+        label: "OpenAI GPT Latest",
+        metadata: {
+          openCodeProviderId: "openai",
+          openCodeProviderLabel: "OpenAI",
+        },
+      }),
+      model({
+        harnessId: "openrouter",
+        slug: "openrouter:openrouter/owl-alpha",
+        label: "Owl Alpha",
+        metadata: {
+          openCodeProviderId: "openrouter",
+          openCodeProviderLabel: "OpenRouter",
+        },
+      }),
+      model({
+        harnessId: "openrouter",
+        slug: "openrouter:z-ai/glm-4.6",
+        label: "Z.ai: GLM 4.6",
+        metadata: {
+          openCodeProviderId: "z-ai",
+          openCodeProviderLabel: "Z.ai",
+        },
+      }),
+    ];
+    const rows = buildHarnessModelRows(OPENROUTER_HARNESS, models);
+
+    // Harness-agnostic grouping off the host-declared metadata, by vendor label.
+    // browseLabel drops the vendor prefix the name carries: ": " for normal names
+    // ("Z.ai: GLM 4.6" -> "GLM 4.6"), " " for the "latest" aliases ("OpenAI GPT
+    // Latest" -> "GPT Latest"); a label with no vendor prefix ("Owl Alpha") is
+    // left untouched.
+    expect(
+      rows.map((row) => [row.providerGroupLabel, row.browseLabel]),
+    ).toEqual([
+      ["Anthropic", "Claude Opus"],
+      ["OpenAI", "GPT Latest"],
+      ["OpenRouter", "Owl Alpha"],
+      ["Z.ai", "GLM 4.6"],
+    ]);
+    // The full vendor-qualified label is preserved for search.
+    expect(rows[3]?.label).toBe("Z.ai: GLM 4.6");
+    // The collapsed trigger shows the trimmed name.
+    expect(
+      findModelLabel(models, {
+        harnessId: "openrouter",
+        modelSlug: "openrouter:z-ai/glm-4.6",
+      }),
+    ).toBe("GLM 4.6");
+    expect(
+      findModelLabel(models, {
+        harnessId: "openrouter",
+        modelSlug: "openrouter:openrouter/owl-alpha",
+      }),
+    ).toBe("Owl Alpha");
   });
 
   it("adds capacity metadata on model rows", () => {

--- a/clients/gui-app/src/components/home/data/harness-model-search.ts
+++ b/clients/gui-app/src/components/home/data/harness-model-search.ts
@@ -20,18 +20,18 @@ export interface HarnessModelRow {
   readonly harnessLabel: string;
   readonly label: string;
   /**
-   * Primary text shown when browsing a single provider (no search query). For
-   * OpenCode models this drops the upstream-provider prefix that `label`
-   * carries, because the provider is rendered as a group header instead
-   * (`Perplexity: Sonar` → `Sonar` under a `Perplexity` header). Equal to
-   * `label` for every other harness and in search mode.
+   * Primary text shown when browsing within a provider (no search query). For
+   * grouped harnesses this drops the prefix `label` may carry, because the
+   * provider/vendor is rendered as a group header instead (`Perplexity: Sonar` →
+   * `Sonar` under a `Perplexity` header). Equal to `label` for ungrouped
+   * harnesses and in search mode.
    */
   readonly browseLabel: string;
   /**
-   * Stable upstream-provider ID this row groups under in browse mode (OpenCode
-   * only). Section boundaries key off this, NOT the display label, so two
-   * providers that happen to share a name don't collapse into one group.
-   * `null` for single-provider harnesses (not grouped).
+   * Stable group id this row groups under in browse mode - the host's declared
+   * provider/vendor for grouped harnesses (OpenCode, OpenRouter). Section
+   * boundaries key off this, NOT the display label, so two groups that happen to
+   * share a name don't collapse into one. `null` for ungrouped harnesses.
    */
   readonly providerGroupId: string | null;
   /**
@@ -74,12 +74,14 @@ export function buildHarnessModelRows(
   harness: HarnessOption,
   models: ReadonlyArray<ModelOption>,
 ): ReadonlyArray<HarnessModelRow> {
-  // OpenCode fans out across many upstream providers; order its models by
-  // provider (then name) so the contiguous runs line up with the provider
-  // group headers the picker renders. Other harnesses keep host order - the
-  // first model is the preferred one and stays first.
-  const orderedModels =
-    harness.id === "opencode" ? sortByOpenCodeProvider(models) : models;
+  // When the host declares per-model groups (OpenCode by provider, OpenRouter by
+  // vendor), order by group so contiguous runs line up with the group headers
+  // the picker renders. Ungrouped harnesses keep host order - the first model is
+  // the preferred one and stays first.
+  const isGrouped = models.some(
+    (model) => modelMetadataString(model.metadata.openCodeProviderId).length > 0,
+  );
+  const orderedModels = isGrouped ? sortByProviderGroup(models) : models;
   return orderedModels.map((model) => modelRow(harness, model));
 }
 
@@ -185,11 +187,12 @@ function modelRow(harness: HarnessOption, model: ModelOption): HarnessModelRow {
   const openCodeProviderId = modelMetadataString(
     model.metadata.openCodeProviderId,
   );
-  const isOpenCode = harness.id === "opencode";
-  // Group by the stable provider id; fall back to the id as header text when
-  // the label is missing so such models still group (rather than scattering).
+  // Group by the stable group id whenever the host declares one in the model
+  // list (OpenCode by upstream provider, OpenRouter by vendor prefix) - the
+  // renderer is harness-agnostic. Fall back to the id as header text when the
+  // label is missing so such models still group rather than scattering.
   const providerGroupId =
-    isOpenCode && openCodeProviderId.length > 0 ? openCodeProviderId : null;
+    openCodeProviderId.length > 0 ? openCodeProviderId : null;
   const providerGroupLabel = openCodeGroupLabel(
     providerGroupId,
     openCodeProviderLabel,
@@ -221,12 +224,12 @@ function rowId(harnessId: ProviderId, value: string): string {
 }
 
 /**
- * Orders OpenCode models by provider name, then provider id, then model name -
- * so the picker's contiguous runs align with the (id-keyed) group headers.
- * Sorting by id within an equal name keeps two same-named providers as distinct
- * adjacent sections instead of interleaving them.
+ * Orders grouped models by group label, then group id, then model name - so the
+ * picker's contiguous runs align with the (id-keyed) group headers. Sorting by
+ * id within an equal label keeps two same-named groups as distinct adjacent
+ * sections instead of interleaving them.
  */
-function sortByOpenCodeProvider(
+function sortByProviderGroup(
   models: ReadonlyArray<ModelOption>,
 ): ReadonlyArray<ModelOption> {
   return models.toSorted((left, right) => {

--- a/clients/gui-app/src/components/home/data/harness-model-search.ts
+++ b/clients/gui-app/src/components/home/data/harness-model-search.ts
@@ -76,11 +76,16 @@ export function buildHarnessModelRows(
 ): ReadonlyArray<HarnessModelRow> {
   // When the host declares per-model groups (OpenCode by provider, OpenRouter by
   // vendor), order by group so contiguous runs line up with the group headers
-  // the picker renders. Ungrouped harnesses keep host order - the first model is
-  // the preferred one and stays first.
-  const isGrouped = models.some(
-    (model) => modelMetadataString(model.metadata.openCodeProviderId).length > 0,
-  );
+  // the picker renders. Reorder only when EVERY model is annotated: a partially
+  // annotated list (a transitional/skewed host that tags only some models) keeps
+  // host order rather than floating the unannotated models to the top. Ungrouped
+  // harnesses keep host order too - the first model is preferred and stays first.
+  const isGrouped =
+    models.length > 0 &&
+    models.every(
+      (model) =>
+        modelMetadataString(model.metadata.openCodeProviderId).length > 0,
+    );
   const orderedModels = isGrouped ? sortByProviderGroup(models) : models;
   return orderedModels.map((model) => modelRow(harness, model));
 }

--- a/clients/gui-app/src/components/home/data/landing-options.ts
+++ b/clients/gui-app/src/components/home/data/landing-options.ts
@@ -246,7 +246,9 @@ export function findModelLabel(
 }
 
 export function modelDisplayLabel(model: ModelOption): string {
-  if (model.harnessId !== "opencode") return model.label;
+  // Harness-agnostic: strip the group prefix the label may carry when the host
+  // declared a group (OpenCode `Anthropic: Claude` -> `Claude`). OpenRouter
+  // labels carry no such prefix, so this is a no-op for them.
   const providerLabel = modelMetadataString(
     model.metadata.openCodeProviderLabel,
   );
@@ -281,8 +283,14 @@ export function modelMetadataString(value: unknown): string {
 }
 
 function stripProviderPrefix(label: string, providerLabel: string): string {
-  const prefix = `${providerLabel}: `;
-  return label.startsWith(prefix) ? label.slice(prefix.length) : label;
+  // Names carry the vendor as a prefix - "Z.ai: GLM 5.2", or for OpenRouter's
+  // "latest" aliases "Anthropic Claude Haiku Latest". Trim it (": " or " "
+  // separator) since the vendor is already shown as the group header.
+  for (const separator of [": ", " "]) {
+    const prefix = `${providerLabel}${separator}`;
+    if (label.startsWith(prefix)) return label.slice(prefix.length);
+  }
+  return label;
 }
 
 const NO_REASONING_OPTIONS: ReadonlyArray<ReasoningLevelOption> = [];

--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -8,18 +8,19 @@ import QwenMono from "@lobehub/icons/es/Qwen/components/Mono";
 import KiroMono from "@lobehub/icons/es/Kiro/components/Mono";
 import KiloCodeMono from "@lobehub/icons/es/KiloCode/components/Mono";
 import GithubCopilotMono from "@lobehub/icons/es/GithubCopilot/components/Mono";
-import { Bot, Route } from "lucide-react";
+import OpenRouterMono from "@lobehub/icons/es/OpenRouter/components/Mono";
+import { Bot } from "lucide-react";
 import KimiMono from "@lobehub/icons/es/Kimi/components/Mono";
 
 export type HarnessIcon = (props: SVGProps<SVGSVGElement>) => ReactElement;
 
 // Brand logos come from @lobehub/icons (every provider lives there, so we don't
-// hand-roll SVGs). We import the leaf component files rather than each provider's
-// barrel: the barrel also pulls the `Combine`/`Avatar` variants, which depend on
-// `@lobehub/ui` + antd - peers we don't install - and would break Vite's dep
-// prebundle. The mono variants paint with `currentColor`, so they follow the
-// light/dark theme via the `text-*` class applied by `HarnessIcon`; Claude uses
-// the colored sunburst so it keeps its brand orange in both themes.
+// hand-roll SVGs). Most imports use leaf component files to avoid pulling extra
+// variants; this includes OpenRouter, whose package barrels pull generated
+// feature exports that are not needed here. The mono variants paint with
+// `currentColor`, so they follow the light/dark theme via the `text-*` class
+// applied by `HarnessIcon`; Claude uses the colored sunburst so it keeps its
+// brand orange in both themes.
 export const CodexIcon: HarnessIcon = (props) => <CodexMono {...props} />;
 export const ClaudeAIIcon: HarnessIcon = (props) => <ClaudeColor {...props} />;
 export const OpenCodeIcon: HarnessIcon = (props) => <OpenCodeMono {...props} />;
@@ -32,7 +33,9 @@ export const CopilotIcon: HarnessIcon = (props) => (
   <GithubCopilotMono {...props} />
 );
 export const DroidIcon: HarnessIcon = (props) => <Bot {...props} />;
-export const OpenRouterIcon: HarnessIcon = (props) => <Route {...props} />;
+export const OpenRouterIcon: HarnessIcon = (props) => (
+  <OpenRouterMono {...props} />
+);
 export const KimiIcon: HarnessIcon = (props) => <KimiMono {...props} />;
 
 // Traycer does not have a lobehub entry — hand-rolled from the brand mark.

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
@@ -45,7 +45,7 @@ export function ProviderRail(props: ProviderRailProps) {
       <div
         role="tablist"
         aria-label="Model providers"
-        className="compact-scrollbar flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto overscroll-contain px-1 [scrollbar-gutter:stable]"
+        className="no-scrollbar flex min-h-0 flex-1 flex-col items-center gap-1 overflow-y-auto overscroll-contain px-1"
       >
         {pending && visibleHarnesses.length === 0 ? (
           <span className="mt-1 flex size-8 items-center justify-center rounded-lg text-muted-foreground">


### PR DESCRIPTION
## What

Group OpenRouter models by vendor in the model picker (like OpenCode groups by provider), and trim the redundant vendor prefix from each row.

## Changes

- Drive provider-grouping off the host-declared `metadata.openCodeProviderId/Label` for **any** harness, removing the `harness.id === "opencode"` branches — OpenRouter now groups by vendor.
- Trim the redundant `Vendor: ` / `Vendor ` prefix from each row's browse label (the vendor is shown as the group header); handles OpenRouter's `~latest` alias names.
- Correct the OpenRouter rail icon; hide the provider rail scrollbar.

**No protocol/wire change** — grouping rides the existing open `metadata` record, so it's version-skew-safe across older/newer hosts.

## Companion PR

Host side (route OpenRouter via a distinct `traycer-openrouter` provider, emit the vendor-group metadata): `traycerai/traycer-internal#4149`.

## Testing

`bun run compile`, the harness-model-search + picker suites, and `react-doctor` (changed files) all pass.