### PR TITLE
Order providers in picker and settings

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -30,6 +30,7 @@ import type {
   ReasoningLevel,
   ServiceTier,
 } from "@/components/home/data/landing-options";
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
 import type { Key, ReactNode } from "react";
 
 interface CatalogHarness extends HarnessOption {
@@ -51,6 +52,7 @@ const queryMock = vi.hoisted(() => ({
   harnessesError: null as Error | null,
   catalogHarnessesLoading: false,
   modelsLoading: false,
+  providerStates: [] as ProviderCliState[],
   cloneCatalogOnRead: false,
   calls: {
     harnesses: [] as Array<{
@@ -69,6 +71,17 @@ const queryMock = vi.hoisted(() => ({
       readonly subscribed: boolean;
     }>,
   },
+}));
+
+vi.mock("@/hooks/providers/use-providers-list-query", () => ({
+  useProvidersList: (activity: QueryActivity) => ({
+    data: activity.enabled
+      ? { providers: queryMock.providerStates }
+      : undefined,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+  }),
 }));
 
 vi.mock("react-virtuoso", async () => {
@@ -282,6 +295,26 @@ const OPENROUTER_HARNESS: HarnessOption = {
   supportedPermissionModes: [...ALL_PERMISSION_MODES],
 };
 
+const DROID_HARNESS: HarnessOption = {
+  id: "droid",
+  label: "Droid",
+  available: true,
+  error: null,
+  modes: ["gui"],
+  requiresApiKey: false,
+  supportedPermissionModes: [...ALL_PERMISSION_MODES],
+};
+
+const CURSOR_HARNESS: HarnessOption = {
+  id: "cursor",
+  label: "Cursor",
+  available: true,
+  error: null,
+  modes: ["gui"],
+  requiresApiKey: false,
+  supportedPermissionModes: [...ALL_PERMISSION_MODES],
+};
+
 function model(overrides: Partial<ModelOption>): ModelOption {
   const base: ModelOption = {
     harnessId: "codex",
@@ -312,6 +345,32 @@ function catalogHarness(
     models,
     modelsLoading: false,
     modelsError: null,
+  };
+}
+
+function providerCliState(input: {
+  readonly providerId: ProviderCliState["providerId"];
+  readonly authStatus: ProviderCliState["auth"]["status"];
+  readonly apiKey: ProviderCliState["apiKey"];
+}): ProviderCliState {
+  return {
+    providerId: input.providerId,
+    enabled: true,
+    disabledBy: null,
+    selected: { kind: "bundled" },
+    candidates: [],
+    auth: {
+      status: input.authStatus,
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    authPending: false,
+    checkedAt: null,
+    apiKey: input.apiKey,
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
   };
 }
 
@@ -510,6 +569,7 @@ describe("<HarnessModelPicker />", () => {
     queryMock.harnessesError = null;
     queryMock.catalogHarnessesLoading = false;
     queryMock.modelsLoading = false;
+    queryMock.providerStates = [];
     queryMock.cloneCatalogOnRead = false;
     queryMock.calls.harnesses = [];
     queryMock.calls.catalog = [];
@@ -700,7 +760,7 @@ describe("<HarnessModelPicker />", () => {
     });
   });
 
-  it("hides unavailable providers from the rail", async () => {
+  it("hides unavailable providers that are not recoverable from the rail", async () => {
     renderPicker(undefined);
 
     await openPicker();
@@ -713,6 +773,99 @@ describe("<HarnessModelPicker />", () => {
     // Available providers remain selectable.
     expect(screen.getByRole("tab", { name: "Codex" })).not.toBeNull();
     expect(screen.getByRole("tab", { name: "Claude" })).not.toBeNull();
+  });
+
+  it("orders the rail by provider defaults and moves degraded providers down", async () => {
+    const codex = codexModels();
+    const claude = claudeModels();
+    queryMock.harnesses = [
+      OPENROUTER_HARNESS,
+      CURSOR_HARNESS,
+      CLAUDE_HARNESS,
+      DROID_HARNESS,
+      CODEX_HARNESS,
+      OPENCODE_HARNESS,
+    ];
+    queryMock.catalogHarnesses = [
+      catalogHarness(OPENROUTER_HARNESS, []),
+      catalogHarness(CURSOR_HARNESS, []),
+      catalogHarness(CLAUDE_HARNESS, claude),
+      catalogHarness(DROID_HARNESS, []),
+      catalogHarness(CODEX_HARNESS, codex),
+      catalogHarness(OPENCODE_HARNESS, []),
+    ];
+    queryMock.selectedModelsByHarness = new Map([
+      ["codex", codex],
+      ["claude", claude],
+      ["cursor", []],
+      ["droid", []],
+      ["opencode", []],
+      ["openrouter", []],
+    ]);
+
+    renderPicker(undefined);
+
+    await openPicker();
+    const tabs = screen.getAllByRole("tab");
+
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Codex",
+      "Claude",
+      "Droid",
+      "Cursor",
+      "OpenRouter",
+    ]);
+    expect(
+      screen.getByRole("tab", { name: "OpenRouter" }).getAttribute(
+        "data-degraded",
+      ),
+    ).toBe("true");
+    expect(
+      screen.getByRole("tab", { name: "Codex" }).getAttribute(
+        "data-degraded",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps signed-out providers visible as degraded rail items", async () => {
+    const codex = codexModels();
+    const signedOutClaude: HarnessOption = {
+      ...CLAUDE_HARNESS,
+      available: false,
+      error: "Claude is signed out",
+    };
+    queryMock.harnesses = [signedOutClaude, CODEX_HARNESS];
+    queryMock.catalogHarnesses = [
+      catalogHarness(signedOutClaude, []),
+      catalogHarness(CODEX_HARNESS, codex),
+    ];
+    queryMock.selectedModelsByHarness = new Map([
+      ["codex", codex],
+      ["claude", []],
+    ]);
+    queryMock.providerStates = [
+      providerCliState({
+        providerId: "claude-code",
+        authStatus: "unauthenticated",
+        apiKey: { supported: false, configured: false, source: null },
+      }),
+    ];
+
+    renderPicker(undefined);
+
+    await openPicker();
+    const claudeTab = screen.getByRole("tab", { name: "Claude" });
+
+    expect(
+      screen
+        .getAllByRole("tab")
+        .map((tab) => tab.getAttribute("aria-label")),
+    ).toEqual(["Codex", "Claude"]);
+    expect(claudeTab.getAttribute("data-degraded")).toBe("true");
+
+    fireEvent.click(claudeTab);
+
+    expect(screen.getByText("Claude unavailable")).not.toBeNull();
   });
 
   it("keeps unavailable API-key providers visible with a settings CTA", async () => {

--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -70,18 +70,28 @@ const queryMock = vi.hoisted(() => ({
       readonly enabled: boolean;
       readonly subscribed: boolean;
     }>,
+    providers: [] as Array<{
+      readonly enabled: boolean;
+      readonly subscribed: boolean;
+    }>,
   },
 }));
 
 vi.mock("@/hooks/providers/use-providers-list-query", () => ({
-  useProvidersList: (activity: QueryActivity) => ({
-    data: activity.enabled
-      ? { providers: queryMock.providerStates }
-      : undefined,
-    isPending: false,
-    isError: false,
-    isFetching: false,
-  }),
+  useProvidersList: (activity: QueryActivity) => {
+    queryMock.calls.providers.push({
+      enabled: activity.enabled,
+      subscribed: activity.subscribed,
+    });
+    return {
+      data: activity.enabled
+        ? { providers: queryMock.providerStates }
+        : undefined,
+      isPending: false,
+      isError: false,
+      isFetching: false,
+    };
+  },
 }));
 
 vi.mock("react-virtuoso", async () => {
@@ -574,6 +584,7 @@ describe("<HarnessModelPicker />", () => {
     queryMock.calls.harnesses = [];
     queryMock.calls.catalog = [];
     queryMock.calls.models = [];
+    queryMock.calls.providers = [];
     openSettingsMock.mockClear();
     useProvidersFocusStore.getState().clearFocusHarnessId();
   });
@@ -758,6 +769,19 @@ describe("<HarnessModelPicker />", () => {
       enabled: false,
       subscribed: false,
     });
+    expect(queryMock.calls.providers.at(-1)).toEqual({
+      enabled: false,
+      subscribed: false,
+    });
+  });
+
+  it("keeps provider state warm before opening the picker", () => {
+    renderPicker(undefined);
+
+    expect(queryMock.calls.providers.at(-1)).toEqual({
+      enabled: true,
+      subscribed: true,
+    });
   });
 
   it("hides unavailable providers that are not recoverable from the rail", async () => {
@@ -816,14 +840,21 @@ describe("<HarnessModelPicker />", () => {
       "OpenRouter",
     ]);
     expect(
-      screen.getByRole("tab", { name: "OpenRouter" }).getAttribute(
-        "data-degraded",
-      ),
+      screen
+        .getByRole("tab", { name: "OpenRouter" })
+        .getAttribute("data-degraded"),
     ).toBe("true");
+    const openRouterDescriptionId = screen
+      .getByRole("tab", { name: "OpenRouter" })
+      .getAttribute("aria-describedby");
+    if (openRouterDescriptionId === null) {
+      throw new Error("Expected degraded provider to have a description.");
+    }
+    expect(document.getElementById(openRouterDescriptionId)?.textContent).toBe(
+      "Setup required",
+    );
     expect(
-      screen.getByRole("tab", { name: "Codex" }).getAttribute(
-        "data-degraded",
-      ),
+      screen.getByRole("tab", { name: "Codex" }).getAttribute("data-degraded"),
     ).toBeNull();
   });
 
@@ -857,15 +888,15 @@ describe("<HarnessModelPicker />", () => {
     const claudeTab = screen.getByRole("tab", { name: "Claude" });
 
     expect(
-      screen
-        .getAllByRole("tab")
-        .map((tab) => tab.getAttribute("aria-label")),
+      screen.getAllByRole("tab").map((tab) => tab.getAttribute("aria-label")),
     ).toEqual(["Codex", "Claude"]);
     expect(claudeTab.getAttribute("data-degraded")).toBe("true");
 
     fireEvent.click(claudeTab);
 
-    expect(screen.getByText("Claude unavailable")).not.toBeNull();
+    expect(
+      screen.getByRole("option", { name: "Claude unavailable" }),
+    ).not.toBeNull();
   });
 
   it("keeps unavailable API-key providers visible with a settings CTA", async () => {

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
@@ -2,13 +2,18 @@ import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { Settings } from "lucide-react";
-import type { HarnessOption } from "@/components/home/data/landing-options";
-import type { ProviderId } from "@/components/home/data/landing-options";
+import type {
+  HarnessOption,
+  ProviderId,
+} from "@/components/home/data/landing-options";
 import { usePickerProviderLeaderForIndex } from "@/providers/keybinding-context";
 import { leaderDigitFor } from "@/components/ui/leader-digit-shortcuts";
 import { PickerLeaderBadge } from "@/components/home/pickers/harness-model-picker-leader-badge";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
-import { visibleRailHarnesses } from "@/components/home/pickers/harness-rail-providers";
+import {
+  railHarnessDegraded,
+  visibleRailHarnesses,
+} from "@/components/home/pickers/harness-rail-providers";
 import { cn } from "@/lib/utils";
 
 const LOCKED_PROVIDER_TOOLTIP =
@@ -19,6 +24,7 @@ interface ProviderRailProps {
   readonly fallbackHarnesses: ReadonlyArray<HarnessOption>;
   readonly activeProviderId: ProviderId;
   readonly lockedHarnessId: ProviderId | null;
+  readonly degradedProviderIds: ReadonlySet<ProviderId>;
   readonly pending: boolean;
   readonly onProviderChange: (providerId: ProviderId) => void;
   readonly onOpenProviderSettings: () => void;
@@ -31,12 +37,17 @@ export function ProviderRail(props: ProviderRailProps) {
     fallbackHarnesses,
     activeProviderId,
     lockedHarnessId,
+    degradedProviderIds,
     pending,
     onProviderChange,
     onOpenProviderSettings,
     onRefresh,
   } = props;
-  const visibleHarnesses = visibleRailHarnesses(harnesses, fallbackHarnesses);
+  const visibleHarnesses = visibleRailHarnesses(
+    harnesses,
+    fallbackHarnesses,
+    degradedProviderIds,
+  );
 
   return (
     // The settings gear is a sibling of the tablist, not a child - only tab
@@ -58,6 +69,7 @@ export function ProviderRail(props: ProviderRailProps) {
             harness={harness}
             index={index}
             active={harness.id === activeProviderId}
+            degraded={railHarnessDegraded(harness, degradedProviderIds)}
             disabled={
               lockedHarnessId !== null && harness.id !== lockedHarnessId
             }
@@ -87,6 +99,7 @@ interface ProviderRailButtonProps {
   readonly harness: HarnessOption;
   readonly index: number;
   readonly active: boolean;
+  readonly degraded: boolean;
   readonly disabled: boolean;
   readonly onProviderChange: (providerId: ProviderId) => void;
 }
@@ -95,7 +108,8 @@ interface ProviderRailButtonProps {
 // a `.map`). The ⌘-digit badge masks the icon's right edge while the leader is
 // held; switching is pure state (no focus move), so the search box keeps focus.
 function ProviderRailButton(props: ProviderRailButtonProps) {
-  const { harness, index, active, disabled, onProviderChange } = props;
+  const { harness, index, active, degraded, disabled, onProviderChange } =
+    props;
   const leaderModifier = usePickerProviderLeaderForIndex(index);
   return (
     <TooltipWrapper
@@ -113,8 +127,12 @@ function ProviderRailButton(props: ProviderRailButtonProps) {
         title={disabled ? LOCKED_PROVIDER_TOOLTIP : harness.label}
         tabIndex={disabled ? -1 : undefined}
         data-active={active}
+        data-degraded={degraded ? true : undefined}
         className={cn(
           "relative flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60 data-[active=true]:bg-accent data-[active=true]:text-foreground",
+          degraded
+            ? "opacity-60 hover:opacity-80 data-[active=true]:opacity-75"
+            : "",
           "aria-disabled:cursor-not-allowed aria-disabled:opacity-40 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground",
         )}
         onClick={() => {

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
@@ -2,6 +2,7 @@ import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { Settings } from "lucide-react";
+import { useId } from "react";
 import type {
   HarnessOption,
   ProviderId,
@@ -111,6 +112,7 @@ function ProviderRailButton(props: ProviderRailButtonProps) {
   const { harness, index, active, degraded, disabled, onProviderChange } =
     props;
   const leaderModifier = usePickerProviderLeaderForIndex(index);
+  const degradedDescriptionId = useId();
   return (
     <TooltipWrapper
       label={disabled ? LOCKED_PROVIDER_TOOLTIP : null}
@@ -124,6 +126,7 @@ function ProviderRailButton(props: ProviderRailButtonProps) {
         aria-selected={active}
         aria-disabled={disabled ? true : undefined}
         aria-label={harness.label}
+        aria-describedby={degraded ? degradedDescriptionId : undefined}
         title={disabled ? LOCKED_PROVIDER_TOOLTIP : harness.label}
         tabIndex={disabled ? -1 : undefined}
         data-active={active}
@@ -141,6 +144,11 @@ function ProviderRailButton(props: ProviderRailButtonProps) {
         }}
       >
         <HarnessIcon harnessId={harness.id} />
+        {degraded ? (
+          <span id={degradedDescriptionId} className="sr-only">
+            Setup required
+          </span>
+        ) : null}
         <PickerLeaderBadge
           show={leaderModifier !== null && !disabled}
           index={index}

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
@@ -33,6 +33,7 @@ interface HarnessModelPickerPanelProps {
   readonly fallbackHarnesses: ReadonlyArray<HarnessOption>;
   readonly resolvedActiveProviderId: ProviderId;
   readonly lockedHarnessId: ProviderId | null;
+  readonly degradedProviderIds: ReadonlySet<ProviderId>;
   readonly catalogHarnessesLoading: boolean;
   readonly onProviderChange: (providerId: ProviderId) => void;
   readonly onRefreshCatalog: () => Promise<void>;
@@ -73,6 +74,7 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
     fallbackHarnesses,
     resolvedActiveProviderId,
     lockedHarnessId,
+    degradedProviderIds,
     catalogHarnessesLoading,
     onProviderChange,
     onRefreshCatalog,
@@ -137,6 +139,7 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
           fallbackHarnesses={fallbackHarnesses}
           activeProviderId={resolvedActiveProviderId}
           lockedHarnessId={lockedHarnessId}
+          degradedProviderIds={degradedProviderIds}
           pending={catalogHarnessesLoading}
           onProviderChange={onProviderChange}
           onRefresh={onRefreshCatalog}

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -40,7 +40,10 @@ import {
 } from "react";
 import { HarnessModelPickerPanel } from "@/components/home/pickers/harness-model-picker-panel";
 import { useHarnessModelPickerState } from "@/components/home/pickers/harness-model-picker-state";
-import { visibleRailHarnesses } from "@/components/home/pickers/harness-rail-providers";
+import {
+  railHarnessDegraded,
+  visibleRailHarnesses,
+} from "@/components/home/pickers/harness-rail-providers";
 import { usePickerLeaderScope } from "@/components/home/pickers/use-picker-leader-scope";
 import { handleHarnessModelPickerKeyDown } from "@/components/home/pickers/harness-model-picker-keyboard";
 import { deriveHarnessModelPickerPresentation } from "@/components/home/pickers/harness-model-picker-presentation";
@@ -52,10 +55,17 @@ import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
 import { useRegisterActiveModelPicker } from "@/hooks/command-palette/use-register-active-model-picker";
 import { useBindingForAction } from "@/stores/settings/keybinding-store";
 import { formatChordForDisplay } from "@/lib/keybindings/chord";
+import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+import {
+  providerIdToGuiHarnessId,
+  sortGuiHarnessesByProviderOrder,
+} from "@/lib/provider-ordering";
 
 export type { ReasoningFooterConfig, ServiceTierFooterConfig };
 
 const EMPTY_MODELS: ReadonlyArray<ModelOption> = [];
+const EMPTY_DEGRADED_PROVIDER_IDS: ReadonlySet<ProviderId> = new Set();
 
 interface HarnessModelPickerProps {
   /** Per-composer toolbar store; the picker subscribes to the selection /
@@ -169,12 +179,27 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     enabled: activityEnabled,
     subscribed: activityEnabled,
   });
+  const providerStateActive = activityEnabled && visibleOpen;
+  const providersQuery = useProvidersList({
+    enabled: providerStateActive,
+    subscribed: providerStateActive,
+  });
+  const degradedProviderIds = useMemo(
+    () =>
+      providersQuery.data === undefined
+        ? EMPTY_DEGRADED_PROVIDER_IDS
+        : degradedProviderIdsFromProviderStates(providersQuery.data.providers),
+    [providersQuery.data],
+  );
   const harnesses = useMemo(
     () =>
       activityEnabled && harnessesQuery.data !== undefined
-        ? restrictToTui(harnessesQuery.data.harnesses, tuiOnly)
+        ? orderModelPickerHarnesses(
+            restrictToTui(harnessesQuery.data.harnesses, tuiOnly),
+            degradedProviderIds,
+          )
         : [],
-    [activityEnabled, harnessesQuery.data, tuiOnly],
+    [activityEnabled, degradedProviderIds, harnessesQuery.data, tuiOnly],
   );
   const selectedHarness = harnesses.find(
     (harness) => harness.id === selection.harnessId,
@@ -196,8 +221,12 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
   // providers (e.g. `traycer`) are filtered out of the catalog up front so every
   // derived structure (active provider, rows, rail) inherits the restriction.
   const catalogHarnesses = useMemo(
-    () => restrictToTui(catalog.harnesses, tuiOnly),
-    [catalog.harnesses, tuiOnly],
+    () =>
+      orderModelPickerHarnesses(
+        restrictToTui(catalog.harnesses, tuiOnly),
+        degradedProviderIds,
+      ),
+    [catalog.harnesses, degradedProviderIds, tuiOnly],
   );
   const refreshCatalog = useRefreshHarnessCatalog();
   const selectedModels = selectedModelsQuery.data?.models ?? EMPTY_MODELS;
@@ -233,8 +262,15 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
         catalogHarnesses,
         activeProviderId,
         selection.harnessId,
+        degradedProviderIds,
       ),
-    [activeProviderId, catalogHarnesses, lockedHarnessId, selection.harnessId],
+    [
+      activeProviderId,
+      catalogHarnesses,
+      degradedProviderIds,
+      lockedHarnessId,
+      selection.harnessId,
+    ],
   );
   const activeProvider =
     catalogHarnesses.find(
@@ -349,8 +385,8 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
   // the badges. Both handlers are pure state writes, so the search input keeps
   // focus and the user can keep typing after switching.
   const railHarnesses = useMemo(
-    () => visibleRailHarnesses(catalogHarnesses, harnesses),
-    [catalogHarnesses, harnesses],
+    () => visibleRailHarnesses(catalogHarnesses, harnesses, degradedProviderIds),
+    [catalogHarnesses, degradedProviderIds, harnesses],
   );
   // ⌥-reasoning is armed whenever the selected model exposes thinking levels.
   // The footer always reflects the selected model (not the browsed rail), so
@@ -434,6 +470,7 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
         fallbackHarnesses={harnesses}
         resolvedActiveProviderId={resolvedActiveProviderId}
         lockedHarnessId={lockedHarnessId}
+        degradedProviderIds={degradedProviderIds}
         catalogHarnessesLoading={catalog.harnessesLoading}
         onProviderChange={handleProviderChange}
         onRefreshCatalog={refreshCatalog}
@@ -489,13 +526,45 @@ function restrictToTui<T extends HarnessOption>(
   return tuiOnly ? harnesses.filter(isTuiCapable) : harnesses;
 }
 
+function orderModelPickerHarnesses<T extends HarnessOption>(
+  harnesses: ReadonlyArray<T>,
+  degradedProviderIds: ReadonlySet<ProviderId>,
+): ReadonlyArray<T> {
+  return sortGuiHarnessesByProviderOrder(harnesses).toSorted(
+    (left, right) =>
+      Number(railHarnessDegraded(left, degradedProviderIds)) -
+      Number(railHarnessDegraded(right, degradedProviderIds)),
+  );
+}
+
+function degradedProviderIdsFromProviderStates(
+  providers: ReadonlyArray<ProviderCliState>,
+): ReadonlySet<ProviderId> {
+  return new Set(
+    providers.flatMap((provider) =>
+      providerNeedsPickerReauth(provider)
+        ? [providerIdToGuiHarnessId(provider.providerId)]
+        : [],
+    ),
+  );
+}
+
+function providerNeedsPickerReauth(provider: ProviderCliState): boolean {
+  return (
+    provider.enabled &&
+    (provider.auth.status === "unauthenticated" ||
+      (provider.apiKey.supported && !provider.apiKey.configured))
+  );
+}
+
 function resolveActiveProviderId(
   harnesses: ReadonlyArray<HarnessOption>,
   activeProviderId: ProviderId,
   selectedProviderId: ProviderId,
+  degradedProviderIds: ReadonlySet<ProviderId>,
 ): ProviderId {
   const selectable = (harness: HarnessOption): boolean =>
-    harness.available || harness.requiresApiKey;
+    harness.available || railHarnessDegraded(harness, degradedProviderIds);
   if (
     harnesses.some(
       (harness) => harness.id === activeProviderId && selectable(harness),

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -179,10 +179,9 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     enabled: activityEnabled,
     subscribed: activityEnabled,
   });
-  const providerStateActive = activityEnabled && visibleOpen;
   const providersQuery = useProvidersList({
-    enabled: providerStateActive,
-    subscribed: providerStateActive,
+    enabled: activityEnabled,
+    subscribed: activityEnabled,
   });
   const degradedProviderIds = useMemo(
     () =>
@@ -385,7 +384,8 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
   // the badges. Both handlers are pure state writes, so the search input keeps
   // focus and the user can keep typing after switching.
   const railHarnesses = useMemo(
-    () => visibleRailHarnesses(catalogHarnesses, harnesses, degradedProviderIds),
+    () =>
+      visibleRailHarnesses(catalogHarnesses, harnesses, degradedProviderIds),
     [catalogHarnesses, degradedProviderIds, harnesses],
   );
   // ⌥-reasoning is armed whenever the selected model exposes thinking levels.

--- a/clients/gui-app/src/components/home/pickers/harness-rail-providers.ts
+++ b/clients/gui-app/src/components/home/pickers/harness-rail-providers.ts
@@ -1,18 +1,46 @@
-import type { HarnessOption } from "@/components/home/data/landing-options";
+import type {
+  HarnessOption,
+  ProviderId,
+} from "@/components/home/data/landing-options";
+import { sortGuiHarnessesByProviderOrder } from "@/lib/provider-ordering";
 
 /**
- * The providers the rail renders, in order. Disabled/unavailable providers are
- * hidden (the host reports `available: false`), except an enabled API-key
- * provider missing its key (`requiresApiKey`), which stays so its "add key" CTA
- * is reachable. Shared by `ProviderRail` and the picker's ⌘-digit shortcut so
- * the digits line up with the badges on the SAME ordered list.
+ * The providers the rail renders, in order. Disabled/unavailable providers that
+ * are not recoverable from the picker stay hidden. Recoverable degraded
+ * providers (signed out or missing an API key) stay visible, move below the
+ * ready providers, and show the model-list CTA when selected. Shared by
+ * `ProviderRail` and the picker's ⌘-digit shortcut so the digits line up with
+ * the badges on the SAME ordered list.
  */
 export function visibleRailHarnesses(
   harnesses: ReadonlyArray<HarnessOption>,
   fallbackHarnesses: ReadonlyArray<HarnessOption>,
+  degradedProviderIds: ReadonlySet<ProviderId>,
 ): ReadonlyArray<HarnessOption> {
   const source = harnesses.length > 0 ? harnesses : fallbackHarnesses;
-  return source.filter(
-    (harness) => harness.available || harness.requiresApiKey,
+  const visible = source.filter((harness) =>
+    railHarnessVisible(harness, degradedProviderIds),
   );
+  return sortGuiHarnessesByProviderOrder(visible).toSorted(
+    (left, right) =>
+      Number(railHarnessDegraded(left, degradedProviderIds)) -
+      Number(railHarnessDegraded(right, degradedProviderIds)),
+  );
+}
+
+export function railHarnessDegraded(
+  harness: HarnessOption,
+  degradedProviderIds: ReadonlySet<ProviderId>,
+): boolean {
+  return (
+    !harness.available &&
+    (harness.requiresApiKey || degradedProviderIds.has(harness.id))
+  );
+}
+
+function railHarnessVisible(
+  harness: HarnessOption,
+  degradedProviderIds: ReadonlySet<ProviderId>,
+): boolean {
+  return harness.available || railHarnessDegraded(harness, degradedProviderIds);
 }

--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -4,7 +4,13 @@ import type {
   ProviderCliState,
   ProviderSelection,
 } from "@traycer/protocol/host/provider-schemas";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const providerMocks = vi.hoisted(() => ({
@@ -273,6 +279,83 @@ describe("<ProvidersSettingsPanel />", () => {
       providerId: "traycer",
       selection: { kind: "path" },
     });
+  });
+
+  it("orders the provider rail by the default provider order", () => {
+    providerMocks.listResult.data = {
+      providers: [
+        providerState({
+          providerId: "openrouter",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        providerState({
+          providerId: "qwen",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        providerState({
+          providerId: "codex",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        providerState({
+          providerId: "cursor",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        providerState({
+          providerId: "droid",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        providerState({
+          providerId: "kilocode",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        providerState({
+          providerId: "claude-code",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+        providerState({
+          providerId: "copilot",
+          selected: { kind: "bundled" },
+          candidates: [],
+          envOverrides: [],
+        }),
+      ],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Providers" });
+    expect(
+      within(nav)
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual([
+      "Codex",
+      "Claude Code",
+      "OpenRouter",
+      "Droid",
+      "Cursor",
+      "Copilot",
+      "Kilo Code",
+      "Qwen Code",
+    ]);
   });
 
   it("lists OpenCode CLI candidates for OpenRouter and mutates OpenRouter selection", () => {

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -35,7 +35,6 @@ import { Switch } from "@/components/ui/switch";
 import { FilePathTooltip } from "@/components/file-path-tooltip";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
-import type { ProviderId as HarnessIconId } from "@/components/home/data/landing-options";
 import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
 import { useProvidersSetSelection } from "@/hooks/providers/use-providers-set-selection-mutation";
 import { useProvidersAddCustomPath } from "@/hooks/providers/use-providers-add-custom-path-mutation";
@@ -59,6 +58,10 @@ import type { HostRpcRegistry } from "@/lib/host";
 import { HostRuntimeContext, useHostBinding } from "@/lib/host/runtime";
 import { useRelativeTimestamp } from "@/lib/relative-time";
 import { cn } from "@/lib/utils";
+import {
+  providerIdToGuiHarnessId,
+  sortProviderStatesByProviderOrder,
+} from "@/lib/provider-ordering";
 import { ProviderAuthBadge, ProviderAuthLine } from "./provider-auth-display";
 import { EnvOverrideEditor } from "./env-override-editor";
 import { TraycerSubscriptionSection } from "./traycer-subscription-section";
@@ -70,7 +73,7 @@ type ProvidersListQuery = UseQueryResult<
 >;
 
 // The provider to select on mount: the deep-link focus target (mapped from its
-// GUI harness id via `HARNESS_ICON_ID`) when one was requested and is present,
+// GUI harness id) when one was requested and is present,
 // otherwise the first provider in the list.
 function initialActiveProviderId(
   providers: readonly ProviderCliState[],
@@ -78,7 +81,7 @@ function initialActiveProviderId(
   const focusHarnessId = useProvidersFocusStore.getState().focusHarnessId;
   if (focusHarnessId !== null) {
     const match = providers.find(
-      (p) => HARNESS_ICON_ID[p.providerId] === focusHarnessId,
+      (p) => providerIdToGuiHarnessId(p.providerId) === focusHarnessId,
     );
     if (match !== undefined) return match.providerId;
   }
@@ -144,22 +147,6 @@ function terminalAgentArgsPlaceholder(providerId: ProviderId): string {
       return "CLI arguments (optional)";
   }
 }
-
-const HARNESS_ICON_ID: Record<ProviderId, HarnessIconId> = {
-  "claude-code": "claude",
-  codex: "codex",
-  opencode: "opencode",
-  cursor: "cursor",
-  traycer: "traycer",
-  openrouter: "openrouter",
-  grok: "grok",
-  qwen: "qwen",
-  kiro: "kiro",
-  droid: "droid",
-  kimi: "kimi",
-  copilot: "copilot",
-  kilocode: "kilocode",
-};
 
 // Grid keeps the columns aligned across header + rows; `minmax(0,1fr)` on
 // the Path column guarantees it shrinks/truncates instead of pushing the
@@ -386,18 +373,23 @@ function ProvidersRailLayout({
 }: {
   readonly providers: readonly ProviderCliState[];
 }) {
+  const orderedProviders = useMemo(
+    () => sortProviderStatesByProviderOrder(providers),
+    [providers],
+  );
   // A deep-link entry point (e.g. the model picker's "Add API key" CTA) can ask
   // the panel to open on a specific provider via the focus store. Read it once
   // for the initial selection, then clear it so a later manual open starts on
   // the first provider again.
   const [activeId, setActiveId] = useState<ProviderId>(() =>
-    initialActiveProviderId(providers),
+    initialActiveProviderId(orderedProviders),
   );
   useEffect(() => {
     useProvidersFocusStore.getState().clearFocusHarnessId();
   }, []);
   const active =
-    providers.find((p) => p.providerId === activeId) ?? providers[0];
+    orderedProviders.find((p) => p.providerId === activeId) ??
+    orderedProviders[0];
 
   return (
     // Fill the panel body (the shell stretches it to the settings scroll
@@ -406,13 +398,17 @@ function ProvidersRailLayout({
     // overlay - owns the scroll. Height follows the viewport: on shorter
     // screens it shrinks to fit the modal instead of overflowing it.
     <div className="flex h-full">
-      <nav className="flex w-[clamp(10rem,22vw,14rem)] shrink-0 flex-col gap-1 overflow-y-auto border-r border-border/60 p-2">
-        {providers.map((state) => {
+      <nav
+        aria-label="Providers"
+        className="flex w-[clamp(10rem,22vw,14rem)] shrink-0 flex-col gap-1 overflow-y-auto border-r border-border/60 p-2"
+      >
+        {orderedProviders.map((state) => {
           const selected = state.providerId === active.providerId;
           return (
             <button
               key={state.providerId}
               type="button"
+              aria-label={PROVIDER_DISPLAY_NAMES[state.providerId]}
               data-active={selected}
               onClick={() => setActiveId(state.providerId)}
               className={cn(
@@ -422,7 +418,9 @@ function ProvidersRailLayout({
                   : "text-foreground/70 hover:bg-accent/60 hover:text-accent-foreground",
               )}
             >
-              <HarnessIcon harnessId={HARNESS_ICON_ID[state.providerId]} />
+              <HarnessIcon
+                harnessId={providerIdToGuiHarnessId(state.providerId)}
+              />
               <span className="flex-1 truncate">
                 {PROVIDER_DISPLAY_NAMES[state.providerId]}
               </span>
@@ -437,7 +435,7 @@ function ProvidersRailLayout({
         <ProviderDetail
           key={active.providerId}
           state={active}
-          providers={providers}
+          providers={orderedProviders}
         />
       </div>
     </div>
@@ -796,7 +794,7 @@ function TerminalAgentArgsSection({
   const saved = state.terminalAgentArgs;
   const [draft, setDraft] = useState(saved);
 
-  const harnessId = HARNESS_ICON_ID[providerId];
+  const harnessId = providerIdToGuiHarnessId(providerId);
   const supportsTerminalAgent =
     harnessesQuery.data?.harnesses.some(
       (harness) => harness.id === harnessId && harness.modes.includes("tui"),

--- a/clients/gui-app/src/lib/provider-ordering.ts
+++ b/clients/gui-app/src/lib/provider-ordering.ts
@@ -1,69 +1,45 @@
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 
-const DEFAULT_GUI_HARNESS_ORDER: ReadonlyArray<GuiHarnessId> = [
-  "codex",
-  "claude",
-  "opencode",
-  "traycer",
-  "openrouter",
-  "droid",
-  "cursor",
-  "copilot",
-  "grok",
-  "kiro",
-  "kilocode",
-  "kimi",
-  "qwen",
+interface ProviderOrderEntry {
+  readonly providerId: ProviderId;
+  readonly guiHarnessId: GuiHarnessId;
+}
+
+const DEFAULT_PROVIDER_ORDER: ReadonlyArray<ProviderOrderEntry> = [
+  { providerId: "codex", guiHarnessId: "codex" },
+  { providerId: "claude-code", guiHarnessId: "claude" },
+  { providerId: "opencode", guiHarnessId: "opencode" },
+  { providerId: "traycer", guiHarnessId: "traycer" },
+  { providerId: "openrouter", guiHarnessId: "openrouter" },
+  { providerId: "droid", guiHarnessId: "droid" },
+  { providerId: "cursor", guiHarnessId: "cursor" },
+  { providerId: "copilot", guiHarnessId: "copilot" },
+  { providerId: "grok", guiHarnessId: "grok" },
+  { providerId: "kiro", guiHarnessId: "kiro" },
+  { providerId: "kilocode", guiHarnessId: "kilocode" },
+  { providerId: "kimi", guiHarnessId: "kimi" },
+  { providerId: "qwen", guiHarnessId: "qwen" },
 ];
 
-const DEFAULT_PROVIDER_ORDER: ReadonlyArray<ProviderId> = [
-  "codex",
-  "claude-code",
-  "opencode",
-  "traycer",
-  "openrouter",
-  "droid",
-  "cursor",
-  "copilot",
-  "grok",
-  "kiro",
-  "kilocode",
-  "kimi",
-  "qwen",
-];
+const DEFAULT_GUI_HARNESS_ORDER = DEFAULT_PROVIDER_ORDER.map(
+  (entry) => entry.guiHarnessId,
+);
+const DEFAULT_PROVIDER_ID_ORDER = DEFAULT_PROVIDER_ORDER.map(
+  (entry) => entry.providerId,
+);
+const GUI_HARNESS_BY_PROVIDER_ID = new Map(
+  DEFAULT_PROVIDER_ORDER.map(providerOrderMapEntry),
+);
 
 const UNKNOWN_PROVIDER_RANK = Number.MAX_SAFE_INTEGER;
 
 export function providerIdToGuiHarnessId(providerId: ProviderId): GuiHarnessId {
-  switch (providerId) {
-    case "claude-code":
-      return "claude";
-    case "codex":
-      return "codex";
-    case "opencode":
-      return "opencode";
-    case "cursor":
-      return "cursor";
-    case "traycer":
-      return "traycer";
-    case "grok":
-      return "grok";
-    case "qwen":
-      return "qwen";
-    case "kiro":
-      return "kiro";
-    case "droid":
-      return "droid";
-    case "kimi":
-      return "kimi";
-    case "copilot":
-      return "copilot";
-    case "kilocode":
-      return "kilocode";
-    case "openrouter":
-      return "openrouter";
+  const guiHarnessId = GUI_HARNESS_BY_PROVIDER_ID.get(providerId);
+  if (guiHarnessId === undefined) {
+    throw new Error(`Provider is missing GUI harness mapping: ${providerId}`);
   }
+  return guiHarnessId;
 }
 
 export function sortGuiHarnessesByProviderOrder<
@@ -78,7 +54,7 @@ export function sortProviderStatesByProviderOrder<
   T extends { readonly providerId: ProviderId },
 >(providers: ReadonlyArray<T>): ReadonlyArray<T> {
   return stableSortByRank(providers, (provider) =>
-    rankInOrder(DEFAULT_PROVIDER_ORDER, provider.providerId),
+    rankInOrder(DEFAULT_PROVIDER_ID_ORDER, provider.providerId),
   );
 }
 
@@ -88,6 +64,12 @@ function rankInOrder<T extends string>(
 ): number {
   const index = order.indexOf(value);
   return index === -1 ? UNKNOWN_PROVIDER_RANK : index;
+}
+
+function providerOrderMapEntry(
+  entry: ProviderOrderEntry,
+): readonly [ProviderId, GuiHarnessId] {
+  return [entry.providerId, entry.guiHarnessId];
 }
 
 function stableSortByRank<T>(

--- a/clients/gui-app/src/lib/provider-ordering.ts
+++ b/clients/gui-app/src/lib/provider-ordering.ts
@@ -1,0 +1,104 @@
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+
+const DEFAULT_GUI_HARNESS_ORDER: ReadonlyArray<GuiHarnessId> = [
+  "codex",
+  "claude",
+  "opencode",
+  "traycer",
+  "openrouter",
+  "droid",
+  "cursor",
+  "copilot",
+  "grok",
+  "kiro",
+  "kilocode",
+  "kimi",
+  "qwen",
+];
+
+const DEFAULT_PROVIDER_ORDER: ReadonlyArray<ProviderId> = [
+  "codex",
+  "claude-code",
+  "opencode",
+  "traycer",
+  "openrouter",
+  "droid",
+  "cursor",
+  "copilot",
+  "grok",
+  "kiro",
+  "kilocode",
+  "kimi",
+  "qwen",
+];
+
+const UNKNOWN_PROVIDER_RANK = Number.MAX_SAFE_INTEGER;
+
+export function providerIdToGuiHarnessId(providerId: ProviderId): GuiHarnessId {
+  switch (providerId) {
+    case "claude-code":
+      return "claude";
+    case "codex":
+      return "codex";
+    case "opencode":
+      return "opencode";
+    case "cursor":
+      return "cursor";
+    case "traycer":
+      return "traycer";
+    case "grok":
+      return "grok";
+    case "qwen":
+      return "qwen";
+    case "kiro":
+      return "kiro";
+    case "droid":
+      return "droid";
+    case "kimi":
+      return "kimi";
+    case "copilot":
+      return "copilot";
+    case "kilocode":
+      return "kilocode";
+    case "openrouter":
+      return "openrouter";
+  }
+}
+
+export function sortGuiHarnessesByProviderOrder<
+  T extends { readonly id: GuiHarnessId },
+>(harnesses: ReadonlyArray<T>): ReadonlyArray<T> {
+  return stableSortByRank(harnesses, (harness) =>
+    rankInOrder(DEFAULT_GUI_HARNESS_ORDER, harness.id),
+  );
+}
+
+export function sortProviderStatesByProviderOrder<
+  T extends { readonly providerId: ProviderId },
+>(providers: ReadonlyArray<T>): ReadonlyArray<T> {
+  return stableSortByRank(providers, (provider) =>
+    rankInOrder(DEFAULT_PROVIDER_ORDER, provider.providerId),
+  );
+}
+
+function rankInOrder<T extends string>(
+  order: ReadonlyArray<T>,
+  value: T,
+): number {
+  const index = order.indexOf(value);
+  return index === -1 ? UNKNOWN_PROVIDER_RANK : index;
+}
+
+function stableSortByRank<T>(
+  items: ReadonlyArray<T>,
+  rank: (item: T) => number,
+): ReadonlyArray<T> {
+  return items
+    .map((item, index) => ({ item, index, rank: rank(item) }))
+    .toSorted((left, right) => {
+      if (left.rank !== right.rank) return left.rank - right.rank;
+      return left.index - right.index;
+    })
+    .map((entry) => entry.item);
+}


### PR DESCRIPTION
## Summary
- Add a shared provider ordering helper for GUI harness/provider state lists
- Apply the order to Settings > Providers and the model picker rail
- Move unavailable/signed-out or missing-key picker providers below ready providers with reduced opacity
- Keep Droid above Cursor in the requested default order

## Verification
- bun run test src/components/home/__tests__/harness-model-picker.test.tsx src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
- bun run compile
- bun x -y react-doctor@latest . --verbose --offline --scope changed --blocking warning
- git -C traycer diff --check