### PR TITLE
Support provider grouping labels in model picker

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/harness-model-search.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-search.test.ts
@@ -56,6 +56,16 @@ const OPENROUTER_HARNESS: HarnessOption = {
   supportedPermissionModes: [...ALL_PERMISSION_MODES],
 };
 
+const KILOCODE_HARNESS: HarnessOption = {
+  id: "kilocode",
+  label: "Kilo Code",
+  available: true,
+  error: null,
+  modes: ["gui", "tui"],
+  requiresApiKey: false,
+  supportedPermissionModes: [...ALL_PERMISSION_MODES],
+};
+
 function model(overrides: Partial<ModelOption>): ModelOption {
   const base: ModelOption = {
     harnessId: "codex",
@@ -422,6 +432,58 @@ describe("harness model search", () => {
         modelSlug: "openrouter:openrouter/owl-alpha",
       }),
     ).toBe("Owl Alpha");
+  });
+
+  it("groups Kilo Code models by provider and trims the '/' provider prefix from rows", () => {
+    const models = [
+      model({
+        harnessId: "kilocode",
+        slug: "kilo/amazon/nova-pro-v1",
+        label: "Kilo Gateway/Amazon: Nova Pro 1.0",
+        metadata: {
+          openCodeProviderId: "kilo",
+          openCodeProviderLabel: "Kilo Gateway",
+        },
+      }),
+      model({
+        harnessId: "kilocode",
+        slug: "openrouter/anthropic/claude-3-haiku",
+        label: "OpenRouter/Claude 3 Haiku",
+        metadata: {
+          openCodeProviderId: "openrouter",
+          openCodeProviderLabel: "OpenRouter",
+        },
+      }),
+      model({
+        harnessId: "kilocode",
+        slug: "google-vertex/gemini-2.5-pro",
+        label: "Vertex/Gemini 2.5 Pro",
+        metadata: {
+          openCodeProviderId: "google-vertex",
+          openCodeProviderLabel: "Vertex",
+        },
+      }),
+    ];
+    const rows = buildHarnessModelRows(KILOCODE_HARNESS, models);
+
+    // Grouped off the host-declared provider; browseLabel drops the
+    // "<Provider>/" prefix Kilo's names carry (the "/" separator).
+    expect(
+      rows.map((row) => [row.providerGroupLabel, row.browseLabel]),
+    ).toEqual([
+      ["Kilo Gateway", "Amazon: Nova Pro 1.0"],
+      ["OpenRouter", "Claude 3 Haiku"],
+      ["Vertex", "Gemini 2.5 Pro"],
+    ]);
+    // The full "<Provider>/<Model>" name is preserved for search.
+    expect(rows[0]?.label).toBe("Kilo Gateway/Amazon: Nova Pro 1.0");
+    // The collapsed trigger shows the trimmed name.
+    expect(
+      findModelLabel(models, {
+        harnessId: "kilocode",
+        modelSlug: "google-vertex/gemini-2.5-pro",
+      }),
+    ).toBe("Gemini 2.5 Pro");
   });
 
   it("keeps host order when only some models carry group metadata (partial rollout)", () => {

--- a/clients/gui-app/src/components/home/data/landing-options.ts
+++ b/clients/gui-app/src/components/home/data/landing-options.ts
@@ -283,10 +283,11 @@ export function modelMetadataString(value: unknown): string {
 }
 
 function stripProviderPrefix(label: string, providerLabel: string): string {
-  // Names carry the vendor as a prefix - "Z.ai: GLM 5.2", or for OpenRouter's
-  // "latest" aliases "Anthropic Claude Haiku Latest". Trim it (": " or " "
-  // separator) since the vendor is already shown as the group header.
-  for (const separator of [": ", " "]) {
+  // Names carry the provider/vendor as a prefix - "Z.ai: GLM 5.2", OpenRouter's
+  // "latest" aliases "Anthropic Claude Haiku Latest", or Kilo's "OpenRouter/Aion
+  // -1.0". Trim it (": ", " ", or "/" separator) since the provider is already
+  // shown as the group header.
+  for (const separator of [": ", " ", "/"]) {
     const prefix = `${providerLabel}${separator}`;
     if (label.startsWith(prefix)) return label.slice(prefix.length);
   }


### PR DESCRIPTION
## Summary
- allow provider-prefix trimming for slash-separated labels such as Kilo OpenRouter/Model names
- add model picker coverage for Kilocode provider grouping

## Verification
- pre-commit run --all-files

Companion host PR: https://github.com/traycerai/traycer-internal/pull/4151