### PR TITLE
Address provider ordering review follow-up

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -887,9 +887,10 @@ describe("<HarnessModelPicker />", () => {
     await openPicker();
     const claudeTab = screen.getByRole("tab", { name: "Claude" });
 
-    expect(
-      screen.getAllByRole("tab").map((tab) => tab.getAttribute("aria-label")),
-    ).toEqual(["Codex", "Claude"]);
+    expect(screen.getAllByRole("tab")).toEqual([
+      screen.getByRole("tab", { name: "Codex" }),
+      screen.getByRole("tab", { name: "Claude" }),
+    ]);
     expect(claudeTab.getAttribute("data-degraded")).toBe("true");
 
     fireEvent.click(claudeTab);

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
@@ -7,6 +7,7 @@ import type {
   HarnessOption,
   ProviderId,
 } from "@/components/home/data/landing-options";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { usePickerProviderLeaderForIndex } from "@/providers/keybinding-context";
 import { leaderDigitFor } from "@/components/ui/leader-digit-shortcuts";
 import { PickerLeaderBadge } from "@/components/home/pickers/harness-model-picker-leader-badge";
@@ -25,7 +26,7 @@ interface ProviderRailProps {
   readonly fallbackHarnesses: ReadonlyArray<HarnessOption>;
   readonly activeProviderId: ProviderId;
   readonly lockedHarnessId: ProviderId | null;
-  readonly degradedProviderIds: ReadonlySet<ProviderId>;
+  readonly degradedHarnessIds: ReadonlySet<GuiHarnessId>;
   readonly pending: boolean;
   readonly onProviderChange: (providerId: ProviderId) => void;
   readonly onOpenProviderSettings: () => void;
@@ -38,7 +39,7 @@ export function ProviderRail(props: ProviderRailProps) {
     fallbackHarnesses,
     activeProviderId,
     lockedHarnessId,
-    degradedProviderIds,
+    degradedHarnessIds,
     pending,
     onProviderChange,
     onOpenProviderSettings,
@@ -47,7 +48,7 @@ export function ProviderRail(props: ProviderRailProps) {
   const visibleHarnesses = visibleRailHarnesses(
     harnesses,
     fallbackHarnesses,
-    degradedProviderIds,
+    degradedHarnessIds,
   );
 
   return (
@@ -70,7 +71,7 @@ export function ProviderRail(props: ProviderRailProps) {
             harness={harness}
             index={index}
             active={harness.id === activeProviderId}
-            degraded={railHarnessDegraded(harness, degradedProviderIds)}
+            degraded={railHarnessDegraded(harness, degradedHarnessIds)}
             disabled={
               lockedHarnessId !== null && harness.id !== lockedHarnessId
             }

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
@@ -8,6 +8,7 @@ import type {
   HarnessOption,
   ProviderId,
 } from "@/components/home/data/landing-options";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
 import type { HarnessModelRow } from "@/components/home/data/harness-model-search";
 import type { VirtuosoHandle } from "react-virtuoso";
@@ -33,7 +34,7 @@ interface HarnessModelPickerPanelProps {
   readonly fallbackHarnesses: ReadonlyArray<HarnessOption>;
   readonly resolvedActiveProviderId: ProviderId;
   readonly lockedHarnessId: ProviderId | null;
-  readonly degradedProviderIds: ReadonlySet<ProviderId>;
+  readonly degradedHarnessIds: ReadonlySet<GuiHarnessId>;
   readonly catalogHarnessesLoading: boolean;
   readonly onProviderChange: (providerId: ProviderId) => void;
   readonly onRefreshCatalog: () => Promise<void>;
@@ -74,7 +75,7 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
     fallbackHarnesses,
     resolvedActiveProviderId,
     lockedHarnessId,
-    degradedProviderIds,
+    degradedHarnessIds,
     catalogHarnessesLoading,
     onProviderChange,
     onRefreshCatalog,
@@ -139,7 +140,7 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
           fallbackHarnesses={fallbackHarnesses}
           activeProviderId={resolvedActiveProviderId}
           lockedHarnessId={lockedHarnessId}
-          degradedProviderIds={degradedProviderIds}
+          degradedHarnessIds={degradedHarnessIds}
           pending={catalogHarnessesLoading}
           onProviderChange={onProviderChange}
           onRefresh={onRefreshCatalog}

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -56,6 +56,7 @@ import { useRegisterActiveModelPicker } from "@/hooks/command-palette/use-regist
 import { useBindingForAction } from "@/stores/settings/keybinding-store";
 import { formatChordForDisplay } from "@/lib/keybindings/chord";
 import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
 import {
   providerIdToGuiHarnessId,
@@ -65,7 +66,7 @@ import {
 export type { ReasoningFooterConfig, ServiceTierFooterConfig };
 
 const EMPTY_MODELS: ReadonlyArray<ModelOption> = [];
-const EMPTY_DEGRADED_PROVIDER_IDS: ReadonlySet<ProviderId> = new Set();
+const EMPTY_DEGRADED_HARNESS_IDS: ReadonlySet<GuiHarnessId> = new Set();
 
 interface HarnessModelPickerProps {
   /** Per-composer toolbar store; the picker subscribes to the selection /
@@ -183,11 +184,11 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     enabled: activityEnabled,
     subscribed: activityEnabled,
   });
-  const degradedProviderIds = useMemo(
+  const degradedHarnessIds = useMemo(
     () =>
       providersQuery.data === undefined
-        ? EMPTY_DEGRADED_PROVIDER_IDS
-        : degradedProviderIdsFromProviderStates(providersQuery.data.providers),
+        ? EMPTY_DEGRADED_HARNESS_IDS
+        : degradedHarnessIdsFromProviderStates(providersQuery.data.providers),
     [providersQuery.data],
   );
   const harnesses = useMemo(
@@ -195,10 +196,10 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
       activityEnabled && harnessesQuery.data !== undefined
         ? orderModelPickerHarnesses(
             restrictToTui(harnessesQuery.data.harnesses, tuiOnly),
-            degradedProviderIds,
+            degradedHarnessIds,
           )
         : [],
-    [activityEnabled, degradedProviderIds, harnessesQuery.data, tuiOnly],
+    [activityEnabled, degradedHarnessIds, harnessesQuery.data, tuiOnly],
   );
   const selectedHarness = harnesses.find(
     (harness) => harness.id === selection.harnessId,
@@ -223,9 +224,9 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
     () =>
       orderModelPickerHarnesses(
         restrictToTui(catalog.harnesses, tuiOnly),
-        degradedProviderIds,
+        degradedHarnessIds,
       ),
-    [catalog.harnesses, degradedProviderIds, tuiOnly],
+    [catalog.harnesses, degradedHarnessIds, tuiOnly],
   );
   const refreshCatalog = useRefreshHarnessCatalog();
   const selectedModels = selectedModelsQuery.data?.models ?? EMPTY_MODELS;
@@ -261,12 +262,12 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
         catalogHarnesses,
         activeProviderId,
         selection.harnessId,
-        degradedProviderIds,
+        degradedHarnessIds,
       ),
     [
       activeProviderId,
       catalogHarnesses,
-      degradedProviderIds,
+      degradedHarnessIds,
       lockedHarnessId,
       selection.harnessId,
     ],
@@ -384,9 +385,8 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
   // the badges. Both handlers are pure state writes, so the search input keeps
   // focus and the user can keep typing after switching.
   const railHarnesses = useMemo(
-    () =>
-      visibleRailHarnesses(catalogHarnesses, harnesses, degradedProviderIds),
-    [catalogHarnesses, degradedProviderIds, harnesses],
+    () => visibleRailHarnesses(catalogHarnesses, harnesses, degradedHarnessIds),
+    [catalogHarnesses, degradedHarnessIds, harnesses],
   );
   // ⌥-reasoning is armed whenever the selected model exposes thinking levels.
   // The footer always reflects the selected model (not the browsed rail), so
@@ -470,7 +470,7 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
         fallbackHarnesses={harnesses}
         resolvedActiveProviderId={resolvedActiveProviderId}
         lockedHarnessId={lockedHarnessId}
-        degradedProviderIds={degradedProviderIds}
+        degradedHarnessIds={degradedHarnessIds}
         catalogHarnessesLoading={catalog.harnessesLoading}
         onProviderChange={handleProviderChange}
         onRefreshCatalog={refreshCatalog}
@@ -528,18 +528,18 @@ function restrictToTui<T extends HarnessOption>(
 
 function orderModelPickerHarnesses<T extends HarnessOption>(
   harnesses: ReadonlyArray<T>,
-  degradedProviderIds: ReadonlySet<ProviderId>,
+  degradedHarnessIds: ReadonlySet<GuiHarnessId>,
 ): ReadonlyArray<T> {
   return sortGuiHarnessesByProviderOrder(harnesses).toSorted(
     (left, right) =>
-      Number(railHarnessDegraded(left, degradedProviderIds)) -
-      Number(railHarnessDegraded(right, degradedProviderIds)),
+      Number(railHarnessDegraded(left, degradedHarnessIds)) -
+      Number(railHarnessDegraded(right, degradedHarnessIds)),
   );
 }
 
-function degradedProviderIdsFromProviderStates(
+function degradedHarnessIdsFromProviderStates(
   providers: ReadonlyArray<ProviderCliState>,
-): ReadonlySet<ProviderId> {
+): ReadonlySet<GuiHarnessId> {
   return new Set(
     providers.flatMap((provider) =>
       providerNeedsPickerReauth(provider)
@@ -561,10 +561,10 @@ function resolveActiveProviderId(
   harnesses: ReadonlyArray<HarnessOption>,
   activeProviderId: ProviderId,
   selectedProviderId: ProviderId,
-  degradedProviderIds: ReadonlySet<ProviderId>,
+  degradedHarnessIds: ReadonlySet<GuiHarnessId>,
 ): ProviderId {
   const selectable = (harness: HarnessOption): boolean =>
-    harness.available || railHarnessDegraded(harness, degradedProviderIds);
+    harness.available || railHarnessDegraded(harness, degradedHarnessIds);
   if (
     harnesses.some(
       (harness) => harness.id === activeProviderId && selectable(harness),

--- a/clients/gui-app/src/components/home/pickers/harness-rail-providers.ts
+++ b/clients/gui-app/src/components/home/pickers/harness-rail-providers.ts
@@ -1,7 +1,5 @@
-import type {
-  HarnessOption,
-  ProviderId,
-} from "@/components/home/data/landing-options";
+import type { HarnessOption } from "@/components/home/data/landing-options";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { sortGuiHarnessesByProviderOrder } from "@/lib/provider-ordering";
 
 /**
@@ -15,32 +13,32 @@ import { sortGuiHarnessesByProviderOrder } from "@/lib/provider-ordering";
 export function visibleRailHarnesses(
   harnesses: ReadonlyArray<HarnessOption>,
   fallbackHarnesses: ReadonlyArray<HarnessOption>,
-  degradedProviderIds: ReadonlySet<ProviderId>,
+  degradedHarnessIds: ReadonlySet<GuiHarnessId>,
 ): ReadonlyArray<HarnessOption> {
   const source = harnesses.length > 0 ? harnesses : fallbackHarnesses;
   const visible = source.filter((harness) =>
-    railHarnessVisible(harness, degradedProviderIds),
+    railHarnessVisible(harness, degradedHarnessIds),
   );
   return sortGuiHarnessesByProviderOrder(visible).toSorted(
     (left, right) =>
-      Number(railHarnessDegraded(left, degradedProviderIds)) -
-      Number(railHarnessDegraded(right, degradedProviderIds)),
+      Number(railHarnessDegraded(left, degradedHarnessIds)) -
+      Number(railHarnessDegraded(right, degradedHarnessIds)),
   );
 }
 
 export function railHarnessDegraded(
   harness: HarnessOption,
-  degradedProviderIds: ReadonlySet<ProviderId>,
+  degradedHarnessIds: ReadonlySet<GuiHarnessId>,
 ): boolean {
   return (
     !harness.available &&
-    (harness.requiresApiKey || degradedProviderIds.has(harness.id))
+    (harness.requiresApiKey || degradedHarnessIds.has(harness.id))
   );
 }
 
 function railHarnessVisible(
   harness: HarnessOption,
-  degradedProviderIds: ReadonlySet<ProviderId>,
+  degradedHarnessIds: ReadonlySet<GuiHarnessId>,
 ): boolean {
-  return harness.available || railHarnessDegraded(harness, degradedProviderIds);
+  return harness.available || railHarnessDegraded(harness, degradedHarnessIds);
 }

--- a/clients/gui-app/src/lib/provider-ordering.ts
+++ b/clients/gui-app/src/lib/provider-ordering.ts
@@ -1,45 +1,29 @@
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 
-interface ProviderOrderEntry {
-  readonly providerId: ProviderId;
-  readonly guiHarnessId: GuiHarnessId;
-}
+const GUI_HARNESS_BY_PROVIDER_ID = {
+  codex: "codex",
+  "claude-code": "claude",
+  opencode: "opencode",
+  traycer: "traycer",
+  openrouter: "openrouter",
+  droid: "droid",
+  cursor: "cursor",
+  copilot: "copilot",
+  grok: "grok",
+  kiro: "kiro",
+  kilocode: "kilocode",
+  kimi: "kimi",
+  qwen: "qwen",
+} satisfies Readonly<Record<ProviderId, GuiHarnessId>>;
 
-const DEFAULT_PROVIDER_ORDER: ReadonlyArray<ProviderOrderEntry> = [
-  { providerId: "codex", guiHarnessId: "codex" },
-  { providerId: "claude-code", guiHarnessId: "claude" },
-  { providerId: "opencode", guiHarnessId: "opencode" },
-  { providerId: "traycer", guiHarnessId: "traycer" },
-  { providerId: "openrouter", guiHarnessId: "openrouter" },
-  { providerId: "droid", guiHarnessId: "droid" },
-  { providerId: "cursor", guiHarnessId: "cursor" },
-  { providerId: "copilot", guiHarnessId: "copilot" },
-  { providerId: "grok", guiHarnessId: "grok" },
-  { providerId: "kiro", guiHarnessId: "kiro" },
-  { providerId: "kilocode", guiHarnessId: "kilocode" },
-  { providerId: "kimi", guiHarnessId: "kimi" },
-  { providerId: "qwen", guiHarnessId: "qwen" },
-];
-
-const DEFAULT_GUI_HARNESS_ORDER = DEFAULT_PROVIDER_ORDER.map(
-  (entry) => entry.guiHarnessId,
-);
-const DEFAULT_PROVIDER_ID_ORDER = DEFAULT_PROVIDER_ORDER.map(
-  (entry) => entry.providerId,
-);
-const GUI_HARNESS_BY_PROVIDER_ID = new Map(
-  DEFAULT_PROVIDER_ORDER.map(providerOrderMapEntry),
-);
+const DEFAULT_PROVIDER_ID_ORDER = Object.keys(GUI_HARNESS_BY_PROVIDER_ID);
+const DEFAULT_GUI_HARNESS_ORDER = Object.values(GUI_HARNESS_BY_PROVIDER_ID);
 
 const UNKNOWN_PROVIDER_RANK = Number.MAX_SAFE_INTEGER;
 
 export function providerIdToGuiHarnessId(providerId: ProviderId): GuiHarnessId {
-  const guiHarnessId = GUI_HARNESS_BY_PROVIDER_ID.get(providerId);
-  if (guiHarnessId === undefined) {
-    throw new Error(`Provider is missing GUI harness mapping: ${providerId}`);
-  }
-  return guiHarnessId;
+  return GUI_HARNESS_BY_PROVIDER_ID[providerId];
 }
 
 export function sortGuiHarnessesByProviderOrder<
@@ -64,12 +48,6 @@ function rankInOrder<T extends string>(
 ): number {
   const index = order.indexOf(value);
   return index === -1 ? UNKNOWN_PROVIDER_RANK : index;
-}
-
-function providerOrderMapEntry(
-  entry: ProviderOrderEntry,
-): readonly [ProviderId, GuiHarnessId] {
-  return [entry.providerId, entry.guiHarnessId];
 }
 
 function stableSortByRank<T>(


### PR DESCRIPTION
## Summary
- Verified the merged baseline still had the three review issues.
- Switched provider ordering to an exhaustive ProviderId-to-GuiHarnessId record and derive sorting order from it.
- Renamed degraded provider-id plumbing to degraded harness IDs and typed it as GuiHarnessId-based.
- Updated the picker tab-order test to compare role-query tab elements by accessible names instead of reading aria-label.

## Skipped
- None. All requested findings were still valid on origin/main.

## Validation
- bun run test src/components/home/__tests__/harness-model-picker.test.tsx src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
- bun run compile
- bun x -y react-doctor@latest . --verbose --offline --scope changed --blocking warning
- git diff --check
- pre-commit hook: workspace checks and DCO sign-off passed