### PR TITLE
Track history navigation and contain queue drags

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/queued-message-surface.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/queued-message-surface.test.tsx
@@ -40,9 +40,41 @@ interface TestCollisionArgs {
   } | null;
 }
 
+interface TestTransform {
+  readonly x: number;
+  readonly y: number;
+  readonly scaleX: number;
+  readonly scaleY: number;
+}
+
+interface TestClientRect {
+  readonly width: number;
+  readonly height: number;
+  readonly top: number;
+  readonly bottom: number;
+  readonly left: number;
+  readonly right: number;
+}
+
+type TestDndModifier = (args: {
+  readonly activatorEvent: Event | null;
+  readonly active: null;
+  readonly activeNodeRect: TestClientRect | null;
+  readonly draggingNodeRect: TestClientRect | null;
+  readonly containerNodeRect: TestClientRect | null;
+  readonly over: null;
+  readonly overlayNodeRect: TestClientRect | null;
+  readonly scrollableAncestors: ReadonlyArray<Element>;
+  readonly scrollableAncestorRects: ReadonlyArray<TestClientRect>;
+  readonly transform: TestTransform;
+  readonly windowRect: TestClientRect | null;
+}) => TestTransform;
+
 interface CapturedDndContextProps {
   readonly children: ReactNode;
+  readonly autoScroll: boolean;
   readonly collisionDetection: (args: TestCollisionArgs) => unknown;
+  readonly modifiers: ReadonlyArray<TestDndModifier>;
   readonly onDragStart: TestDndHandler;
   readonly onDragMove: TestDndHandler;
   readonly onDragOver: TestDndHandler;
@@ -488,6 +520,59 @@ describe("<QueuedMessagePanel />", () => {
     expect(onReorder).toHaveBeenCalledWith(second, "queue-1");
   });
 
+  it("contains queue drags inside the queue scroll region without edge auto-scroll", () => {
+    renderPanel({
+      queue: queueState([
+        queuedItem("queue-1", "First queued prompt", "pending"),
+        queuedItem("queue-2", "Second queued prompt", "pending"),
+      ]),
+      readOnly: false,
+      canAct: true,
+      onReorder: null,
+    });
+
+    const provider = testState.providerProps;
+    expect(provider).not.toBeNull();
+    if (provider === null) return;
+
+    expect(provider.autoScroll).toBe(false);
+    expect(provider.modifiers).toHaveLength(1);
+
+    const [modifier] = provider.modifiers;
+    const sourceRect = makeClientRect({
+      top: 100,
+      left: 20,
+      width: 300,
+      height: 40,
+    });
+    const scrollRegionRect = makeClientRect({
+      top: 120,
+      left: 10,
+      width: 320,
+      height: 120,
+    });
+
+    expect(
+      modifier(
+        makeModifierArgs({
+          transform: { x: -40, y: -120, scaleX: 1, scaleY: 1 },
+          draggingNodeRect: sourceRect,
+          scrollableAncestorRects: [scrollRegionRect],
+        }),
+      ),
+    ).toEqual({ x: -10, y: 20, scaleX: 1, scaleY: 1 });
+
+    expect(
+      modifier(
+        makeModifierArgs({
+          transform: { x: 40, y: 200, scaleX: 1, scaleY: 1 },
+          draggingNodeRect: sourceRect,
+          scrollableAncestorRects: [scrollRegionRect],
+        }),
+      ),
+    ).toEqual({ x: 10, y: 100, scaleX: 1, scaleY: 1 });
+  });
+
   it("renders received A2A items as read-only rows with a sender badge", () => {
     renderPanel({
       queue: queueState([
@@ -701,5 +786,41 @@ function makeDndEvent(input: {
             data: { current: input.target.data },
             rect: { top: input.target.top, height: input.target.height },
           },
+  };
+}
+
+function makeModifierArgs(input: {
+  readonly transform: TestTransform;
+  readonly draggingNodeRect: TestClientRect | null;
+  readonly scrollableAncestorRects: ReadonlyArray<TestClientRect>;
+}) {
+  return {
+    activatorEvent: null,
+    active: null,
+    activeNodeRect: null,
+    draggingNodeRect: input.draggingNodeRect,
+    containerNodeRect: null,
+    over: null,
+    overlayNodeRect: null,
+    scrollableAncestors: [],
+    scrollableAncestorRects: input.scrollableAncestorRects,
+    transform: input.transform,
+    windowRect: null,
+  };
+}
+
+function makeClientRect(input: {
+  readonly top: number;
+  readonly left: number;
+  readonly width: number;
+  readonly height: number;
+}): TestClientRect {
+  return {
+    width: input.width,
+    height: input.height,
+    top: input.top,
+    bottom: input.top + input.height,
+    left: input.left,
+    right: input.left + input.width,
   };
 }

--- a/clients/gui-app/src/components/chat/queued-message-reorder-dnd.ts
+++ b/clients/gui-app/src/components/chat/queued-message-reorder-dnd.ts
@@ -14,12 +14,52 @@ import {
   type DragMoveEvent,
   type DragOverEvent,
   type DragStartEvent,
+  type ClientRect,
+  type Modifiers,
 } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { CSS, type Transform } from "@dnd-kit/utilities";
 import type { ChatQueuedItem } from "@traycer/protocol/host/agent/gui/subscribe";
 
 const QUEUED_MESSAGE_DND_TYPE = "queued-message";
+
+interface QueuedMessageDragModifierInput {
+  readonly draggingNodeRect: ClientRect | null;
+  readonly scrollableAncestorRects: ReadonlyArray<ClientRect>;
+  readonly transform: Transform;
+}
+
+const restrictQueuedMessageDragToScrollContainer = (
+  args: QueuedMessageDragModifierInput,
+): Transform => {
+  const { draggingNodeRect, scrollableAncestorRects, transform } = args;
+  if (draggingNodeRect === null || scrollableAncestorRects.length === 0) {
+    return transform;
+  }
+  const scrollContainerRect = scrollableAncestorRects[0];
+
+  return {
+    ...transform,
+    x: clampTransformAxis({
+      currentStart: draggingNodeRect.left,
+      currentEnd: draggingNodeRect.right,
+      boundaryStart: scrollContainerRect.left,
+      boundaryEnd: scrollContainerRect.right,
+      transformValue: transform.x,
+    }),
+    y: clampTransformAxis({
+      currentStart: draggingNodeRect.top,
+      currentEnd: draggingNodeRect.bottom,
+      boundaryStart: scrollContainerRect.top,
+      boundaryEnd: scrollContainerRect.bottom,
+      transformValue: transform.y,
+    }),
+  };
+};
+
+export const QUEUED_MESSAGE_DND_MODIFIERS: Modifiers = [
+  restrictQueuedMessageDragToScrollContainer,
+];
 
 interface QueuedMessageDndData {
   readonly kind: typeof QUEUED_MESSAGE_DND_TYPE;
@@ -382,4 +422,20 @@ function readQueuedMessageDndData(value: unknown): QueuedMessageDndData | null {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function clampTransformAxis(input: {
+  readonly currentStart: number;
+  readonly currentEnd: number;
+  readonly boundaryStart: number;
+  readonly boundaryEnd: number;
+  readonly transformValue: number;
+}): number {
+  if (input.currentStart + input.transformValue <= input.boundaryStart) {
+    return input.boundaryStart - input.currentStart;
+  }
+  if (input.currentEnd + input.transformValue >= input.boundaryEnd) {
+    return input.boundaryEnd - input.currentEnd;
+  }
+  return input.transformValue;
 }

--- a/clients/gui-app/src/components/chat/queued-message-surface.tsx
+++ b/clients/gui-app/src/components/chat/queued-message-surface.tsx
@@ -49,6 +49,7 @@ import type {
 import { QueuedMessageContentPreview } from "@/components/chat/queued-message-content-preview";
 import { isReceivedAgentResponse } from "@/components/chat/chat-queue-utils";
 import {
+  QUEUED_MESSAGE_DND_MODIFIERS,
   useQueuedMessageReorderDnd,
   useQueuedMessageRowSortable,
   type QueuedMessageDropPreview,
@@ -184,7 +185,9 @@ export function QueuedMessagePanel(props: QueuedMessagePanelProps) {
         >
           <DndContext
             sensors={sensors}
+            autoScroll={false}
             collisionDetection={reorderDnd.collisionDetection}
+            modifiers={QUEUED_MESSAGE_DND_MODIFIERS}
             onDragStart={reorderDnd.handleDragStart}
             onDragMove={reorderDnd.handleDragMove}
             onDragOver={reorderDnd.handleDragOver}

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -10,6 +10,7 @@ export enum AnalyticsEvent {
   CommandPaletteOpened = "command_palette_opened",
   TerminalOpened = "terminal_opened",
   HarnessChanged = "harness_changed",
+  HistoryNavigationUsed = "history_navigation_used",
 }
 
 export class Analytics {

--- a/clients/gui-app/src/lib/commands/actions/__tests__/history-navigation.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/history-navigation.test.ts
@@ -6,6 +6,7 @@ import {
 } from "@tanstack/react-router";
 import { createPersistentMemoryHistory } from "@/lib/persistent-history";
 import { goBack, goForward } from "@/lib/commands/actions/history-navigation";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 const WINDOW_ID = "history-nav-action-test-window";
 
@@ -31,6 +32,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   window.localStorage.clear();
 });
@@ -39,11 +41,13 @@ describe("goBack / goForward", () => {
   it("no-op when the history carries no controller brand (browser/web)", () => {
     const history = createMemoryHistory({ initialEntries: ["/a", "/b"] });
     const goSpy = vi.spyOn(history, "go");
+    const trackSpy = vi.spyOn(Analytics.getInstance(), "track");
 
     goBack({ history });
     goForward({ history });
 
     expect(goSpy).not.toHaveBeenCalled();
+    expect(trackSpy).not.toHaveBeenCalled();
   });
 
   it("calls go(-1) on the PASSED router's history when a controller reports canGoBack", () => {
@@ -57,6 +61,22 @@ describe("goBack / goForward", () => {
     expect(goSpy).toHaveBeenCalledWith(-1);
   });
 
+  it("tracks successful back navigation off the navigation call stack", () => {
+    vi.useFakeTimers();
+    const history = seedPersistentHistory(["/epics/e1/t1", "/draft/d1"], 1);
+    vi.spyOn(history, "go").mockImplementation(() => {});
+    const trackSpy = vi.spyOn(Analytics.getInstance(), "track");
+
+    goBack({ history });
+
+    expect(trackSpy).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(trackSpy).toHaveBeenCalledWith(
+      AnalyticsEvent.HistoryNavigationUsed,
+      { direction: "back" },
+    );
+  });
+
   it("calls go(1) on the PASSED router's history when a controller reports canGoForward", () => {
     // index 0 of 2 entries → canGoForward() is true.
     const history = seedPersistentHistory(["/epics/e1/t1", "/draft/d1"], 0);
@@ -66,6 +86,35 @@ describe("goBack / goForward", () => {
 
     expect(goSpy).toHaveBeenCalledTimes(1);
     expect(goSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("tracks successful forward navigation off the navigation call stack", () => {
+    vi.useFakeTimers();
+    const history = seedPersistentHistory(["/epics/e1/t1", "/draft/d1"], 0);
+    vi.spyOn(history, "go").mockImplementation(() => {});
+    const trackSpy = vi.spyOn(Analytics.getInstance(), "track");
+
+    goForward({ history });
+
+    expect(trackSpy).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(trackSpy).toHaveBeenCalledWith(
+      AnalyticsEvent.HistoryNavigationUsed,
+      { direction: "forward" },
+    );
+  });
+
+  it("keeps analytics failures from affecting navigation", () => {
+    vi.useFakeTimers();
+    const history = seedPersistentHistory(["/epics/e1/t1", "/draft/d1"], 1);
+    const goSpy = vi.spyOn(history, "go").mockImplementation(() => {});
+    vi.spyOn(Analytics.getInstance(), "track").mockImplementation(() => {
+      throw new Error("analytics failed");
+    });
+
+    expect(() => goBack({ history })).not.toThrow();
+    expect(goSpy).toHaveBeenCalledWith(-1);
+    expect(() => vi.runAllTimers()).not.toThrow();
   });
 
   it("no-op at the start boundary: goBack does NOT call go when canGoBack is false", () => {

--- a/clients/gui-app/src/lib/commands/actions/history-navigation.ts
+++ b/clients/gui-app/src/lib/commands/actions/history-navigation.ts
@@ -1,5 +1,6 @@
 import type { RouterHistory } from "@tanstack/react-router";
 import { getHistoryController } from "@/lib/persistent-history";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /**
  * The single function every back/forward surface calls. Takes the **current**
@@ -28,6 +29,7 @@ export function goBack(router: HistoryNavRouter): void {
   const controller = getHistoryController(router.history);
   if (controller === null || !controller.canGoBack()) return;
   router.history.go(-1);
+  trackHistoryNavigationUsed("back");
 }
 
 /**
@@ -40,4 +42,21 @@ export function goForward(router: HistoryNavRouter): void {
   const controller = getHistoryController(router.history);
   if (controller === null || !controller.canGoForward()) return;
   router.history.go(1);
+  trackHistoryNavigationUsed("forward");
+}
+
+type HistoryNavigationDirection = "back" | "forward";
+
+function trackHistoryNavigationUsed(
+  direction: HistoryNavigationDirection,
+): void {
+  globalThis.setTimeout(() => {
+    try {
+      Analytics.getInstance().track(AnalyticsEvent.HistoryNavigationUsed, {
+        direction,
+      });
+    } catch {
+      // Analytics is best-effort and must never affect navigation.
+    }
+  }, 0);
 }


### PR DESCRIPTION
## Summary
- track successful back/forward history navigation with best-effort analytics
- contain queued-message drag movement inside the queue scroll region and disable dnd-kit edge auto-scroll
- add regression coverage for history navigation analytics and queue DnD containment

## Verification
- pre-commit run --files clients/gui-app/src/lib/analytics.ts clients/gui-app/src/lib/commands/actions/history-navigation.ts clients/gui-app/src/lib/commands/actions/__tests__/history-navigation.test.ts clients/gui-app/src/components/chat/__tests__/queued-message-surface.test.tsx clients/gui-app/src/components/chat/queued-message-reorder-dnd.ts clients/gui-app/src/components/chat/queued-message-surface.tsx
- bun run test src/lib/commands/actions/__tests__/history-navigation.test.ts src/components/chat/__tests__/queued-message-reorder-dnd.test.ts src/components/chat/__tests__/queued-message-surface.test.tsx