### PR TITLE
Update history titles after generation

### DIFF
--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx
@@ -315,4 +315,53 @@ describe("useEpicCreate", () => {
       { value: "shared", count: 0 },
     ]);
   });
+
+  it("preserves an existing generated title when the live epic session is gone", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const cachedGeneratedTask = makeTask({
+      id: "new",
+      title: "Generated history title",
+      createdBy: "user-1",
+      updatedAt: 2,
+      repos: [],
+      workspaces: [],
+    });
+    const staleCreateResponseTask = makeTask({
+      id: "new",
+      title: "Initial user prompt",
+      createdBy: "user-1",
+      updatedAt: 2,
+      repos: [],
+      workspaces: [],
+    });
+    const queryKey = cloudEpicTasksQueryKey(
+      "host-1",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    queryClient.setQueryData<ListTasksResponse>(queryKey, {
+      tasks: [cachedGeneratedTask],
+      hasMore: false,
+    });
+
+    renderHook(() => useEpicCreate(), { wrapper: makeWrapper(queryClient) });
+    const options = testState.capturedOptions;
+    if (options === null) throw new Error("expected mutation options");
+
+    options.onSuccess(
+      { task: staleCreateResponseTask },
+      {},
+      options.onMutate(),
+    );
+
+    expect(
+      queryClient.getQueryData<ListTasksResponse>(queryKey)?.tasks[0]?.epic
+        ?.light?.title,
+    ).toBe("Generated history title");
+  });
 });

--- a/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
@@ -27,6 +27,7 @@ import { cloudEpicTasksQueryKeyMatchesScope } from "@/lib/cloud-epic-tasks-query
 import type { ListCloudTasksRequest } from "@/lib/cloud-epic-tasks-query";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 
 interface CreateEpicMutationContext {
   readonly hostId: string | null;
@@ -127,17 +128,20 @@ function mergeTaskIntoCloudTasksResponse(
   request: ListCloudTasksRequest,
   userId: string,
 ): ListTasksResponse {
-  const projection = taskProjection(task);
-  if (projection === null) return response;
+  const incomingProjection = taskProjection(task);
+  if (incomingProjection === null) return response;
   const existingTask = response.tasks.find(
-    (existing) => taskProjection(existing)?.id === projection.id,
+    (existing) => taskProjection(existing)?.id === incomingProjection.id,
   );
+  const taskToMerge = taskWithPreferredEpicTitle(task, existingTask);
+  const projection = taskProjection(taskToMerge);
+  if (projection === null) return response;
   if (!taskProjectionMatchesRequest(projection, request, userId)) {
     return response;
   }
   const tasks = response.tasks
     .filter((existing) => taskProjection(existing)?.id !== projection.id)
-    .concat(task)
+    .concat(taskToMerge)
     .sort((left, right) =>
       compareTaskLights(
         left,
@@ -553,4 +557,38 @@ function relevanceScore(task: TaskProjection, query: string): number {
 function normalizedQuery(request: ListCloudTasksRequest): string | null {
   const query = request.filters?.query?.trim().toLowerCase();
   return query === undefined || query.length === 0 ? null : query;
+}
+
+function taskWithPreferredEpicTitle(
+  task: TaskLight,
+  existingTask: TaskLight | undefined,
+): TaskLight {
+  const epic = task.epic;
+  const light = epic?.light;
+  if (epic === null || epic === undefined) return task;
+  if (light === null || light === undefined) return task;
+  const title = liveOpenEpicTitle(light.id) ?? cachedEpicTitle(existingTask);
+  if (title === null || title === light.title) return task;
+  return {
+    ...task,
+    epic: {
+      ...epic,
+      light: {
+        ...light,
+        title,
+      },
+    },
+  };
+}
+
+function cachedEpicTitle(task: TaskLight | undefined): string | null {
+  const title = task?.epic?.light?.title;
+  return title === undefined || title.trim().length === 0 ? null : title;
+}
+
+function liveOpenEpicTitle(epicId: string): string | null {
+  const handle = getOpenEpicRegistry().peek(epicId);
+  if (handle === null) return null;
+  const title = handle.store.getState().epic.title.trim();
+  return title.length > 0 ? title : null;
 }

--- a/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-session-provider.test.tsx
@@ -1,7 +1,12 @@
 import "../../../__tests__/test-browser-apis";
 import { useEffect } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import type {
+  ListTasksResponse,
+  TaskLight,
+} from "@traycer/protocol/host/epic/unary-schemas";
 
 const hostState = vi.hoisted((): { id: string | null } => ({ id: "host-a" }));
 const authServiceStub = vi.hoisted(() => ({
@@ -47,6 +52,10 @@ import { setDesktopEpicOwnershipBridge } from "@/lib/windows/desktop-epic-owners
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import {
+  LIST_CLOUD_TASKS_REQUEST,
+  cloudEpicTasksQueryKey,
+} from "@/lib/cloud-epic-tasks-query";
 import type {
   DesktopOwnershipClaimResult,
   DesktopPerWindowStatePatch,
@@ -191,6 +200,35 @@ function resetCanvasStore(): void {
     mostRecentTabIdByEpicId: {},
     artifactTreeByEpicId: {},
   });
+}
+
+function makeHistoryTask(
+  id: string,
+  title: string,
+  createdBy: string,
+): TaskLight {
+  return {
+    epic: {
+      light: {
+        id,
+        title,
+        initialUserPrompt: "Investigate the title update bug",
+        ticketCount: 0,
+        specCount: 0,
+        storyCount: 0,
+        reviewCount: 0,
+        status: "draft",
+        createdAt: 1,
+        updatedAt: 1,
+        createdBy,
+        version: "1",
+      },
+      permission: null,
+      repos: [],
+      workspaces: [],
+      roomInfo: null,
+    },
+  };
 }
 
 describe("<EpicSessionProvider />", () => {
@@ -395,6 +433,64 @@ describe("<EpicSessionProvider />", () => {
     });
     expect(streams).toHaveLength(1);
     expect(__getOpenEpicRegistryForTests().size()).toBe(1);
+  });
+
+  it("patches cached history titles when a generated epic title lands", async () => {
+    const queryClient = new QueryClient();
+    const sessionUserId = "alice@example.com";
+    const cloudTasksUserId = "cloud-user-1";
+    useAuthStore.setState({
+      contextMetadata: { userId: cloudTasksUserId, username: sessionUserId },
+    });
+    const queryKey = cloudEpicTasksQueryKey(
+      "host-a",
+      cloudTasksUserId,
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    queryClient.setQueryData<ListTasksResponse>(queryKey, {
+      tasks: [makeHistoryTask("epic-session-test", "", cloudTasksUserId)],
+      hasMore: false,
+    });
+    const seenHandles: OpenEpicStoreHandle[] = [];
+    __setEpicStreamClientFactoryForTests((_epicId, _callbacks) => ({
+      applyUpdate: () => undefined,
+      awareness: () => undefined,
+      applyArtifactRoomUpdate: () => undefined,
+      artifactRoomAwareness: () => undefined,
+      retryMigration: () => undefined,
+      close: () => undefined,
+    }));
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EpicSessionProvider
+          epicId="epic-session-test"
+          tabId="epic-session-test"
+        >
+          <HandleProbe
+            onHandle={(handle) => {
+              seenHandles.push(handle);
+            }}
+          />
+        </EpicSessionProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(seenHandles).toHaveLength(1);
+    });
+    expect(seenHandles[0].userId).toBe(sessionUserId);
+
+    act(() => {
+      seenHandles[0].store.getState().setEpicTitle("Generated history title");
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<ListTasksResponse>(queryKey)?.tasks[0]?.epic
+          ?.light?.title,
+      ).toBe("Generated history title");
+    });
   });
 
   it("claims desktop epic ownership before acquiring a renderer session", async () => {

--- a/clients/gui-app/src/providers/epic-session-provider.tsx
+++ b/clients/gui-app/src/providers/epic-session-provider.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useEffectEvent, useState, type ReactNode } from "react";
+import {
+  use,
+  useEffect,
+  useEffectEvent,
+  useState,
+  type ReactNode,
+} from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { QueryClientContext, type QueryClient } from "@tanstack/react-query";
 import {
   createOpenEpicStore,
   type EpicStreamClientFactory,
@@ -12,6 +19,7 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useAuthService } from "@/lib/host";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { updateEpicTitleInCloudTaskCaches } from "@/lib/cloud-epic-tasks-query/cache";
 import {
   claimDesktopEpicOwnership,
   getDesktopEpicOwnershipBridge,
@@ -47,13 +55,17 @@ export function EpicSessionProvider(
   const openTransport = useDurableStreamTransportFactory();
   const activeHostId = useReactiveActiveHostId();
   const authService = useAuthService();
+  const queryClient = use(QueryClientContext);
   const navigate = useNavigate();
   const desktopBridge = getDesktopEpicOwnershipBridge();
   // Persisted state (`lastFocusedArtifactId`) is bucketed under the active
   // user's email so a different signed-in identity on this device cannot
   // restore prior-user focus state. Email is the only stable identity field
   // surfaced through `AuthProfile`; null means signed-out / hydrating.
-  const userId = useAuthStore((state) => state.profile?.email ?? null);
+  const sessionUserId = useAuthStore((state) => state.profile?.email ?? null);
+  const cloudTasksUserId = useAuthStore(
+    (state) => state.contextMetadata?.userId ?? null,
+  );
 
   // When the host terminates the epic stream with `UNAUTHORIZED`, the
   // current context bearer is no longer accepted. Re-validate the live
@@ -114,7 +126,7 @@ export function EpicSessionProvider(
     };
   }, [desktopBridge, epicId, navigate, ownershipKey, tabId]);
 
-  const sessionKey = `${epicId}\x1f${activeHostId ?? "host:none"}\x1f${userId ?? "user:none"}`;
+  const sessionKey = `${epicId}\x1f${activeHostId ?? "host:none"}\x1f${sessionUserId ?? "user:none"}`;
   const [session, setSession] = useState<MountedSessionState | null>(null);
 
   useEffect(() => {
@@ -135,7 +147,10 @@ export function EpicSessionProvider(
     const existing = registry.get(epicId);
     if (existing !== null) {
       const existingHostId = handleHostIds.get(existing) ?? null;
-      if (existing.userId !== userId || existingHostId !== activeHostId) {
+      if (
+        existing.userId !== sessionUserId ||
+        existingHostId !== activeHostId
+      ) {
         registry.release(epicId);
       }
     }
@@ -187,7 +202,7 @@ export function EpicSessionProvider(
       createOpenEpicStore({
         epicId: id,
         streamClientFactory,
-        userId,
+        userId: sessionUserId,
         onAuthError: handleSessionAuthError,
       }),
     );
@@ -207,15 +222,61 @@ export function EpicSessionProvider(
     openTransport,
     ownershipClaimed,
     sessionKey,
-    userId,
+    sessionUserId,
   ]);
 
   const handle =
     ownershipClaimed && session?.key === sessionKey ? session.handle : null;
+  useCloudTaskTitleCacheSync({
+    activeHostId,
+    epicId,
+    handle,
+    queryClient,
+    userId: cloudTasksUserId,
+  });
 
   return (
     <EpicSessionContext.Provider value={handle}>
       {children}
     </EpicSessionContext.Provider>
   );
+}
+
+interface CloudTaskTitleCacheSyncArgs {
+  readonly activeHostId: string | null;
+  readonly epicId: string;
+  readonly handle: OpenEpicStoreHandle | null;
+  readonly queryClient: QueryClient | undefined;
+  readonly userId: string | null;
+}
+
+function useCloudTaskTitleCacheSync(args: CloudTaskTitleCacheSyncArgs): void {
+  const { activeHostId, epicId, handle, queryClient, userId } = args;
+  useEffect(() => {
+    if (activeHostId === null) return;
+    if (handle === null) return;
+    if (queryClient === undefined) return;
+    if (userId === null) return;
+
+    let lastSyncedTitle: string | null = null;
+    const syncTitle = (): void => {
+      const title = normalizeGeneratedTitle(handle.store.getState().epic.title);
+      if (title === null || title === lastSyncedTitle) return;
+      lastSyncedTitle = title;
+      updateEpicTitleInCloudTaskCaches(
+        queryClient,
+        { hostId: activeHostId, userId },
+        epicId,
+        title,
+      );
+    };
+
+    syncTitle();
+    return handle.store.subscribe(syncTitle);
+  }, [activeHostId, epicId, handle, queryClient, userId]);
+}
+
+function normalizeGeneratedTitle(title: string): string | null {
+  const trimmed = title.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }


### PR DESCRIPTION
## Summary
- Sync non-empty live generated epic titles into cached cloud task history rows.
- Prevent late `epic.create` responses from re-inserting the prompt-derived title after the generated title has already landed.
- Add regression coverage for generated title updates patching the cached history list.

## Tests
- `bun run test src/providers/__tests__/epic-session-provider.test.tsx`
- `bun run test src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx`
- `bun run compile`
- `npx -y react-doctor@latest . --verbose --offline --scope changed`
