### PR TITLE
Fix shared provider ordering and list rendering

### DIFF
--- a/clients/gui-app/src/components/home/hooks/__tests__/use-composer-toolbar-store.test.tsx
+++ b/clients/gui-app/src/components/home/hooks/__tests__/use-composer-toolbar-store.test.tsx
@@ -124,12 +124,12 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     cleanup();
   });
 
-  it("falls back to the first available provider when the default is unavailable", async () => {
+  it("falls back by provider order when the default is unavailable", async () => {
     seedDefault("opencode");
     harnessesData.value = {
       harnesses: [
-        { id: "codex", available: true },
         { id: "claude", available: true },
+        { id: "codex", available: true },
         { id: "opencode", available: false },
       ],
     };
@@ -183,13 +183,14 @@ describe("useComposerToolbarStore selection reconciliation", () => {
   it("reroutes a GUI-only selection off the terminal surface", async () => {
     // `traycer` is selectable in chat but can't back a terminal agent. On the
     // terminal surface (`tuiOnly`) it must reroute to the first available
-    // TUI-capable harness instead of being carried forward un-launchable.
+    // TUI-capable harness in provider order instead of being carried forward
+    // un-launchable.
     seedDefault("traycer");
     harnessesData.value = {
       harnesses: [
         { id: "traycer", available: true, modes: ["gui"] },
-        { id: "codex", available: true, modes: ["gui", "tui"] },
         { id: "claude", available: true, modes: ["gui", "tui"] },
+        { id: "codex", available: true, modes: ["gui", "tui"] },
       ],
     };
 

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
@@ -1,0 +1,50 @@
+import "../../../../__tests__/test-browser-apis";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/hooks/providers/use-providers-list-query", () => ({
+  useProvidersList: () => ({
+    data: { providers: [] },
+    isPending: false,
+    isError: false,
+    fetchStatus: "idle",
+  }),
+}));
+
+vi.mock("@/hooks/providers/use-providers-set-enabled-mutation", () => ({
+  useProvidersSetEnabled: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+  }),
+}));
+
+import { OnboardingDetectedAgents } from "@/components/onboarding/onboarding-detected-agents";
+
+describe("OnboardingDetectedAgents", () => {
+  it("renders providers in the shared provider order", () => {
+    render(<OnboardingDetectedAgents />);
+
+    const expectedNames = [
+      "Codex",
+      "Claude Code",
+      "OpenCode",
+      "Traycer Inference",
+      "OpenRouter",
+      "Droid",
+      "Cursor",
+      "Copilot",
+      "Grok",
+      "Kiro",
+      "Kilo Code",
+      "Kimi",
+      "Qwen Code",
+    ];
+
+    expect(
+      screen.getAllByRole("listitem").map((row) => {
+        const text = row.textContent;
+        return expectedNames.find((name) => text.includes(name)) ?? "";
+      }),
+    ).toEqual(expectedNames);
+  });
+});

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
@@ -39,10 +39,11 @@ describe("OnboardingDetectedAgents", () => {
       "Kimi",
       "Qwen Code",
     ];
+    const textOrEmpty = (text: string | null): string => text ?? "";
 
     expect(
       screen.getAllByRole("listitem").map((row) => {
-        const text = row.textContent;
+        const text = textOrEmpty(row.textContent);
         return expectedNames.find((name) => text.includes(name)) ?? "";
       }),
     ).toEqual(expectedNames);

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
@@ -1,0 +1,54 @@
+import "../../../../__tests__/test-browser-apis";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { LazyMotion, domAnimation } from "motion/react";
+import { OnboardingDiorama } from "@/components/onboarding/onboarding-diorama";
+import type { OnboardingAgentGuideState } from "@/components/onboarding/onboarding-diorama";
+
+const agentGuide: OnboardingAgentGuideState = {
+  value: "",
+  generatedDefaultContent: "",
+  loading: false,
+  saving: false,
+  error: false,
+  onValueChange: vi.fn(),
+  onRevertToDefault: vi.fn(),
+};
+
+describe("OnboardingDiorama", () => {
+  it("renders the provider picker in the shared provider order", () => {
+    render(
+      <LazyMotion features={domAnimation}>
+        <OnboardingDiorama stage={3} agentGuide={agentGuide} />
+      </LazyMotion>,
+    );
+
+    const list = screen.getByRole("list", {
+      name: "Diorama harness options",
+    });
+    const expectedNames = [
+      "Codex",
+      "Claude Code",
+      "OpenCode",
+      "Traycer Inference",
+      "OpenRouter",
+      "Droid",
+      "Cursor",
+      "Copilot",
+      "Grok",
+      "Kiro",
+      "Kilo Code",
+      "Kimi",
+      "Qwen Code",
+    ];
+
+    expect(
+      within(list)
+        .getAllByRole("listitem")
+        .map((row) => {
+          const text = row.textContent;
+          return expectedNames.find((name) => text.includes(name)) ?? "";
+        }),
+    ).toEqual(expectedNames);
+  });
+});

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
@@ -41,12 +41,13 @@ describe("OnboardingDiorama", () => {
       "Kimi",
       "Qwen Code",
     ];
+    const textOrEmpty = (text: string | null): string => text ?? "";
 
     expect(
       within(list)
         .getAllByRole("listitem")
         .map((row) => {
-          const text = row.textContent;
+          const text = textOrEmpty(row.textContent);
           return expectedNames.find((name) => text.includes(name)) ?? "";
         }),
     ).toEqual(expectedNames);

--- a/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
@@ -118,7 +118,16 @@ function installBadge(
 function accountDescription(state: ProviderCliState | undefined): ReactNode {
   if (state === undefined) return null;
   const account = accountLineFor(state);
-  return <span title={account.title ?? undefined}>{account.text}</span>;
+  return (
+    <span
+      title={account.title ?? undefined}
+      className={cn(
+        account.tone === "good" ? "text-[#7fd6a4]" : "text-white/45",
+      )}
+    >
+      {account.text}
+    </span>
+  );
 }
 
 function ProviderEnableSwitch(props: {

--- a/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
@@ -1,40 +1,20 @@
 import {
-  PROVIDER_DISPLAY_NAMES,
   type ProviderCliState,
   type ProviderId,
 } from "@traycer/protocol/host/provider-schemas";
-import type { GuiHarnessId } from "@traycer/protocol/host/agent/shared";
-import { HarnessIcon } from "@/components/home/pickers/harness-icon";
+import type { ReactNode } from "react";
+import { ProviderList } from "@/components/providers/provider-list";
+import type { ProviderListRow } from "@/components/providers/provider-list";
 import { Switch } from "@/components/ui/switch";
 import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
 import { useProvidersSetEnabled } from "@/hooks/providers/use-providers-set-enabled-mutation";
+import {
+  ORDERED_PROVIDERS,
+  providerDisplayName,
+} from "@/lib/provider-ordering";
 import { cn } from "@/lib/utils";
 
-const TOUR_PROVIDERS: ReadonlyArray<{
-  id: ProviderId;
-  harnessId: GuiHarnessId;
-}> = [
-  { id: "traycer", harnessId: "traycer" },
-  { id: "claude-code", harnessId: "claude" },
-  { id: "codex", harnessId: "codex" },
-  { id: "opencode", harnessId: "opencode" },
-  { id: "cursor", harnessId: "cursor" },
-  { id: "openrouter", harnessId: "openrouter" },
-  { id: "grok", harnessId: "grok" },
-  { id: "qwen", harnessId: "qwen" },
-  { id: "kiro", harnessId: "kiro" },
-  { id: "droid", harnessId: "droid" },
-  { id: "kimi", harnessId: "kimi" },
-  { id: "copilot", harnessId: "copilot" },
-  { id: "kilocode", harnessId: "kilocode" },
-];
-
 type InstallState = "detected" | "missing" | "pending";
-
-function providerDisplayName(providerId: ProviderId): string {
-  if (providerId === "traycer") return "Traycer Inference";
-  return PROVIDER_DISPLAY_NAMES[providerId];
-}
 
 function installStateFor(state: ProviderCliState | undefined): InstallState {
   if (state === undefined) return "pending";
@@ -99,6 +79,48 @@ function installLabelFor(
   return INSTALL_LABELS[installState];
 }
 
+function providerStateFor(
+  providers: readonly ProviderCliState[] | undefined,
+  providerId: ProviderId,
+): ProviderCliState | undefined {
+  return providers?.find((provider) => provider.providerId === providerId);
+}
+
+function enabledForProvider(state: ProviderCliState | undefined): boolean {
+  return state?.enabled ?? false;
+}
+
+function disablingLastEnabledFor(
+  state: ProviderCliState | undefined,
+  enabled: boolean,
+  enabledProviderCount: number,
+): boolean {
+  if (state === undefined) return false;
+  return enabled && enabledProviderCount <= 1;
+}
+
+function installBadge(
+  installDetected: boolean,
+  installLabel: string,
+): ReactNode {
+  return (
+    <span
+      className={cn(
+        "font-mono text-overline uppercase tracking-wider",
+        installDetected ? "text-[#7fd6a4]" : "text-white/40",
+      )}
+    >
+      {installLabel}
+    </span>
+  );
+}
+
+function accountDescription(state: ProviderCliState | undefined): ReactNode {
+  if (state === undefined) return null;
+  const account = accountLineFor(state);
+  return <span title={account.title ?? undefined}>{account.text}</span>;
+}
+
 function ProviderEnableSwitch(props: {
   readonly providerId: ProviderId;
   readonly name: string;
@@ -134,84 +156,6 @@ function ProviderEnableSwitch(props: {
   );
 }
 
-function ProviderRow(props: {
-  readonly tourProvider: {
-    readonly id: ProviderId;
-    readonly harnessId: GuiHarnessId;
-  };
-  readonly state: ProviderCliState | undefined;
-  readonly hostUnavailable: boolean;
-  readonly enabledProviderCount: number;
-  readonly isSettingEnabled: boolean;
-  readonly onSetEnabled: (providerId: ProviderId, enabled: boolean) => void;
-}) {
-  const {
-    tourProvider,
-    state,
-    hostUnavailable,
-    enabledProviderCount,
-    isSettingEnabled,
-    onSetEnabled,
-  } = props;
-  const enabled = state?.enabled ?? false;
-  const traycerProvider = tourProvider.id === "traycer";
-  const installState = traycerProvider ? "detected" : installStateFor(state);
-  const account = state === undefined ? null : accountLineFor(state);
-  const dim = state !== undefined && !enabled;
-  const installLabel = installLabelFor(
-    traycerProvider,
-    hostUnavailable,
-    installState,
-  );
-  const installDetected =
-    traycerProvider || (!hostUnavailable && installState === "detected");
-  const disablingLastEnabled =
-    state !== undefined && enabled && enabledProviderCount <= 1;
-  const name = providerDisplayName(tourProvider.id);
-
-  return (
-    <li className="flex flex-col gap-1">
-      <div className="flex items-center gap-2.5">
-        <HarnessIcon
-          harnessId={tourProvider.harnessId}
-          className={cn("size-4", dim ? "text-white/35" : "text-white/85")}
-        />
-        <span
-          className={cn("text-ui-sm", dim ? "text-white/40" : "text-white/85")}
-        >
-          {name}
-        </span>
-        <span
-          className={cn(
-            "font-mono text-overline uppercase tracking-wider",
-            installDetected ? "text-[#7fd6a4]" : "text-white/40",
-          )}
-        >
-          {installLabel}
-        </span>
-        {state !== undefined ? (
-          <ProviderEnableSwitch
-            providerId={state.providerId}
-            name={name}
-            enabled={enabled}
-            disablingLastEnabled={disablingLastEnabled}
-            isSettingEnabled={isSettingEnabled}
-            onSetEnabled={onSetEnabled}
-          />
-        ) : null}
-      </div>
-      {account !== null ? (
-        <p
-          title={account.title ?? undefined}
-          className="min-w-0 truncate pl-[1.625rem] text-ui-xs text-white/45"
-        >
-          {account.text}
-        </p>
-      ) : null}
-    </li>
-  );
-}
-
 /**
  * The agents act's provider panel. Once past sign-in the host's
  * `providers.list` returns real state, so each row shows the CLI, its
@@ -237,22 +181,52 @@ export function OnboardingDetectedAgents() {
   const handleSetEnabled = (providerId: ProviderId, enabled: boolean): void => {
     setEnabled.mutate({ providerId, enabled });
   };
+  const rows = ORDERED_PROVIDERS.map(({ providerId }): ProviderListRow => {
+    const state = providerStateFor(providers, providerId);
+    const enabled = enabledForProvider(state);
+    const traycerProvider = providerId === "traycer";
+    const installState = traycerProvider ? "detected" : installStateFor(state);
+    const installLabel = installLabelFor(
+      traycerProvider,
+      hostUnavailable,
+      installState,
+    );
+    const installDetected =
+      traycerProvider || (!hostUnavailable && installState === "detected");
+    const disablingLastEnabled = disablingLastEnabledFor(
+      state,
+      enabled,
+      enabledProviderCount,
+    );
+    const name = providerDisplayName(providerId);
+    return {
+      providerId,
+      active: false,
+      dimmed: state !== undefined && !enabled,
+      enabled: state?.enabled ?? null,
+      badge: installBadge(installDetected, installLabel),
+      description: accountDescription(state),
+      trailing:
+        state === undefined ? null : (
+          <ProviderEnableSwitch
+            providerId={state.providerId}
+            name={name}
+            enabled={enabled}
+            disablingLastEnabled={disablingLastEnabled}
+            isSettingEnabled={setEnabled.isPending}
+            onSetEnabled={handleSetEnabled}
+          />
+        ),
+      onSelect: null,
+    };
+  });
 
   return (
-    <ul aria-label="Coding agent CLIs" className="flex flex-col gap-2.5">
-      {TOUR_PROVIDERS.map((tourProvider) => (
-        <ProviderRow
-          key={tourProvider.id}
-          tourProvider={tourProvider}
-          state={providers?.find(
-            (provider) => provider.providerId === tourProvider.id,
-          )}
-          hostUnavailable={hostUnavailable}
-          enabledProviderCount={enabledProviderCount}
-          isSettingEnabled={setEnabled.isPending}
-          onSetEnabled={handleSetEnabled}
-        />
-      ))}
-    </ul>
+    <ProviderList
+      ariaLabel="Coding agent CLIs"
+      variant="onboarding"
+      rows={rows}
+      className="my-auto flex max-h-full min-h-0 w-full flex-col gap-2.5 overflow-y-auto overscroll-contain pr-2"
+    />
   );
 }

--- a/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
@@ -34,8 +34,10 @@ import { AgentSelectionGuideEditorSurface } from "@/components/agent-selection-g
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { OnboardingClaudeTui } from "@/components/onboarding/onboarding-claude-tui";
 import { OnboardingOpencodeTui } from "@/components/onboarding/onboarding-opencode-tui";
+import { ProviderList } from "@/components/providers/provider-list";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import type { GuiHarnessId } from "@traycer/protocol/host/agent/shared";
+import { ORDERED_PROVIDERS } from "@/lib/provider-ordering";
 import { cn } from "@/lib/utils";
 
 interface OnboardingDioramaProps {
@@ -70,7 +72,6 @@ type SceneId =
   | "agent-guide"
   | "command-theme";
 
-type CapabilityId = "gui" | "terminal";
 type NavigationPhase = "single" | "drag-1" | "split-1" | "drag-2" | "split-2";
 type MeshAgentId = "gui" | "claude" | "opencode";
 type SpotlightRegion =
@@ -306,92 +307,6 @@ const SIDEBAR_PANEL_RAIL_ITEMS: ReadonlyArray<{
 function taskSceneFor(index: number): TaskScene {
   return TASK_SCENES[index] ?? TASK_SCENES[0];
 }
-
-const PROVIDERS: ReadonlyArray<{
-  readonly harnessId: GuiHarnessId;
-  readonly label: string;
-  readonly status: string;
-  readonly capabilities: ReadonlyArray<CapabilityId>;
-}> = [
-  {
-    harnessId: "traycer",
-    label: "Traycer Inference",
-    status: "Built in · ready",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "claude",
-    label: "Claude Code",
-    status: "Installed · signed in",
-    capabilities: ["gui", "terminal"],
-  },
-  {
-    harnessId: "codex",
-    label: "Codex",
-    status: "Installed · signed in",
-    capabilities: ["gui", "terminal"],
-  },
-  {
-    harnessId: "opencode",
-    label: "OpenCode",
-    status: "Installed",
-    capabilities: ["gui", "terminal"],
-  },
-  {
-    harnessId: "cursor",
-    label: "Cursor",
-    status: "API key set",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "openrouter",
-    label: "OpenRouter",
-    status: "API key set",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "grok",
-    label: "Grok",
-    status: "SuperGrok / X",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "qwen",
-    label: "Qwen Code",
-    status: "API key / OAuth",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "kiro",
-    label: "Kiro",
-    status: "Kiro login / API key",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "droid",
-    label: "Droid",
-    status: "Factory account",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "kimi",
-    label: "Kimi",
-    status: "Kimi account",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "copilot",
-    label: "Copilot",
-    status: "GitHub Copilot",
-    capabilities: ["gui"],
-  },
-  {
-    harnessId: "kilocode",
-    label: "Kilo Code",
-    status: "Kilo login",
-    capabilities: ["gui"],
-  },
-];
 
 const PALETTE_ROWS = [
   { label: "New task", hint: "Cmd N" },
@@ -1289,31 +1204,26 @@ function OpenHarnessPicker() {
       <div className="border-b border-border px-2.5 py-1.5 text-overline uppercase tracking-wider text-muted-foreground">
         Select harness
       </div>
-      <ul className="flex flex-col p-1">
-        {PROVIDERS.map((provider) => {
-          const active = provider.harnessId === "claude";
-          return (
-            <li
-              key={provider.harnessId}
-              className={cn(
-                "flex items-center gap-2 rounded px-2 py-1 text-ui-xs",
-                active
-                  ? "bg-accent text-accent-foreground"
-                  : "text-foreground/80",
-              )}
-            >
-              <HarnessIcon
-                harnessId={provider.harnessId}
-                className="size-3.5 shrink-0"
-              />
-              <span className="min-w-0 flex-1 truncate">{provider.label}</span>
-              {active ? (
-                <Check className="size-3 shrink-0 text-[var(--term-ansi-green)]" />
-              ) : null}
-            </li>
-          );
+      <ProviderList
+        ariaLabel="Diorama harness options"
+        variant="diorama"
+        className="p-1"
+        rows={ORDERED_PROVIDERS.map(({ providerId }) => {
+          const active = providerId === "claude-code";
+          return {
+            providerId,
+            active,
+            dimmed: false,
+            enabled: null,
+            badge: null,
+            description: null,
+            trailing: active ? (
+              <Check className="size-3 shrink-0 text-[var(--term-ansi-green)]" />
+            ) : null,
+            onSelect: null,
+          };
         })}
-      </ul>
+      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -82,6 +82,29 @@ const ONBOARDING_STYLE = `
   padding-bottom: var(--onboarding-stage-bottom-pad);
 }
 
+/* When the mini-app is dropped (providers act), the providers list owns the
+   remaining space so long provider catalogs can scroll. */
+.onboarding-stage-content--solo {
+  grid-template-rows: minmax(0, 1fr);
+}
+
+.onboarding-stage-content--solo .onboarding-copy-rail {
+  align-self: stretch;
+  min-height: 0;
+}
+
+.onboarding-stage-content--solo .onboarding-copy-rail > :last-child {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+}
+
+.onboarding-stage-content--solo .onboarding-copy {
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
 .onboarding-copy-rail {
   padding-top: var(--onboarding-copy-rail-top);
 }
@@ -250,30 +273,6 @@ const ONBOARDING_STYLE = `
     left: var(--onboarding-action-inset);
     right: var(--onboarding-action-inset);
   }
-
-  /* When the mini-app is dropped (providers act): keep the heading pinned at
-     the top (it must not move across screens), and center only the providers
-     list in the remaining space below it. */
-  .onboarding-stage-content--solo {
-    grid-template-rows: minmax(0, 1fr);
-  }
-  .onboarding-stage-content--solo .onboarding-copy-rail {
-    align-self: stretch;
-    min-height: 0;
-  }
-  .onboarding-stage-content--solo .onboarding-copy-rail > :last-child {
-    display: flex;
-    min-height: 0;
-    flex: 1 1 auto;
-    flex-direction: column;
-  }
-  .onboarding-stage-content--solo .onboarding-copy {
-    min-height: 0;
-    flex: 1 1 auto;
-  }
-  .onboarding-stage-content--solo .onboarding-addon {
-    margin-block: auto;
-  }
 }
 
 @media (max-width: 639px) {
@@ -305,6 +304,7 @@ function resolveAppVersionLabel(): string {
 function ActCopy(props: { act: OnboardingAct }) {
   const { act } = props;
   const headingRef = useRef<HTMLHeadingElement | null>(null);
+  const isAgentsAct = act.addon === "agents";
 
   useEffect(() => {
     headingRef.current?.focus({ preventScroll: true });
@@ -316,7 +316,10 @@ function ActCopy(props: { act: OnboardingAct }) {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.28, ease: ACT_EASE }}
-      className="onboarding-copy flex w-full flex-col items-center text-center lg:items-start lg:text-left"
+      className={cn(
+        "onboarding-copy flex min-h-0 w-full flex-col items-center text-center lg:items-start lg:text-left",
+        isAgentsAct && "h-full",
+      )}
     >
       <p className="onboarding-copy-kicker hidden font-mono leading-normal font-medium tracking-[0.07em] text-white/55 uppercase lg:block">
         {act.eyebrow}
@@ -333,8 +336,8 @@ function ActCopy(props: { act: OnboardingAct }) {
           {act.body}
         </p>
       </div>
-      {act.addon === "agents" ? (
-        <div className="onboarding-addon w-full self-center pt-1 text-left lg:self-start">
+      {isAgentsAct ? (
+        <div className="onboarding-addon flex min-h-0 w-full flex-1 flex-col self-center overflow-hidden pt-1 text-left lg:self-start">
           <OnboardingDetectedAgents />
         </div>
       ) : null}
@@ -646,11 +649,11 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
             <div
               className={cn(
                 "onboarding-stage-content relative mx-auto grid h-full min-h-0 w-full max-w-[104rem] items-start overflow-hidden",
-                // No mini-app on stacked (providers act): single centered column.
+                // The providers act needs a stretched copy rail so its list can scroll.
                 act.addon === "agents" && "onboarding-stage-content--solo",
               )}
             >
-              <div className="onboarding-copy-rail flex min-w-0 flex-col items-center lg:items-start">
+              <div className="onboarding-copy-rail flex min-h-0 min-w-0 flex-col items-center lg:items-start">
                 <div className="hidden w-full justify-center lg:flex lg:justify-start">
                   <ProgressRail activeIndex={step} />
                 </div>

--- a/clients/gui-app/src/components/providers/provider-list.tsx
+++ b/clients/gui-app/src/components/providers/provider-list.tsx
@@ -1,0 +1,148 @@
+import type { ReactNode } from "react";
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { HarnessIcon } from "@/components/home/pickers/harness-icon";
+import {
+  providerDisplayName,
+  providerIdToGuiHarnessId,
+  sortProviderStatesByProviderOrder,
+} from "@/lib/provider-ordering";
+import { cn } from "@/lib/utils";
+
+export type ProviderListVariant = "settings" | "onboarding" | "diorama";
+
+export interface ProviderListRow {
+  readonly providerId: ProviderId;
+  readonly active: boolean;
+  readonly dimmed: boolean;
+  readonly enabled: boolean | null;
+  readonly badge: ReactNode | null;
+  readonly description: ReactNode | null;
+  readonly trailing: ReactNode | null;
+  readonly onSelect: ((providerId: ProviderId) => void) | null;
+}
+
+export function ProviderList(props: {
+  readonly rows: ReadonlyArray<ProviderListRow>;
+  readonly variant: ProviderListVariant;
+  readonly ariaLabel: string;
+  readonly className: string;
+}) {
+  const { rows, variant, ariaLabel, className } = props;
+  const orderedRows = sortProviderStatesByProviderOrder(rows);
+  return (
+    <ul aria-label={ariaLabel} className={cn("flex flex-col", className)}>
+      {orderedRows.map((row) => (
+        <ProviderListItem key={row.providerId} row={row} variant={variant} />
+      ))}
+    </ul>
+  );
+}
+
+function ProviderListItem(props: {
+  readonly row: ProviderListRow;
+  readonly variant: ProviderListVariant;
+}) {
+  const { row, variant } = props;
+  const onSelect = row.onSelect;
+  const rowContent = (
+    <>
+      <div className={innerClassName()}>
+        <HarnessIcon
+          harnessId={providerIdToGuiHarnessId(row.providerId)}
+          className={iconClassName(variant, row.dimmed)}
+        />
+        <span className={labelClassName(variant, row.dimmed)}>
+          {providerDisplayName(row.providerId)}
+        </span>
+        {row.badge}
+        {trailingFor(row, variant)}
+      </div>
+      {row.description !== null ? (
+        <div className={descriptionClassName(variant)}>{row.description}</div>
+      ) : null}
+    </>
+  );
+
+  return (
+    <li className={liClassName(variant)}>
+      {onSelect === null ? (
+        <div className={rowClassName(variant, row.active, row.dimmed)}>
+          {rowContent}
+        </div>
+      ) : (
+        <button
+          type="button"
+          aria-label={providerDisplayName(row.providerId)}
+          data-active={row.active}
+          onClick={() => onSelect(row.providerId)}
+          className={rowClassName(variant, row.active, row.dimmed)}
+        >
+          {rowContent}
+        </button>
+      )}
+    </li>
+  );
+}
+
+function trailingFor(
+  row: ProviderListRow,
+  variant: ProviderListVariant,
+): ReactNode {
+  if (row.trailing !== null) return row.trailing;
+  if (variant !== "settings" || row.enabled !== false) return null;
+  return (
+    <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
+  );
+}
+
+function liClassName(variant: ProviderListVariant): string {
+  if (variant === "onboarding") return "flex flex-col gap-1";
+  return "min-w-0";
+}
+
+function innerClassName(): string {
+  return "flex w-full min-w-0 items-center gap-2.5";
+}
+
+function rowClassName(
+  variant: ProviderListVariant,
+  active: boolean,
+  dimmed: boolean,
+): string {
+  if (variant === "settings") {
+    return cn(
+      "flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-ui-sm transition-colors",
+      active
+        ? "bg-accent text-accent-foreground"
+        : "text-foreground/70 hover:bg-accent/60 hover:text-accent-foreground",
+    );
+  }
+  if (variant === "diorama") {
+    return cn(
+      "flex w-full items-center gap-2 rounded px-2 py-1 text-left text-ui-xs",
+      active ? "bg-accent text-accent-foreground" : "text-foreground/80",
+    );
+  }
+  return cn("min-w-0", dimmed && "opacity-60");
+}
+
+function iconClassName(variant: ProviderListVariant, dimmed: boolean): string {
+  if (variant === "onboarding") {
+    return cn("size-4", dimmed ? "text-white/35" : "text-white/85");
+  }
+  if (variant === "diorama") return "size-3.5 shrink-0";
+  return "";
+}
+
+function labelClassName(variant: ProviderListVariant, dimmed: boolean): string {
+  if (variant === "settings") return "min-w-0 flex-1 truncate";
+  if (variant === "diorama") return "min-w-0 flex-1 truncate";
+  return cn("text-ui-sm", dimmed ? "text-white/40" : "text-white/85");
+}
+
+function descriptionClassName(variant: ProviderListVariant): string {
+  if (variant === "onboarding") {
+    return "min-w-0 truncate pl-[1.625rem] text-ui-xs text-white/45";
+  }
+  return "min-w-0 truncate";
+}

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -34,7 +34,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { FilePathTooltip } from "@/components/file-path-tooltip";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
-import { HarnessIcon } from "@/components/home/pickers/harness-icon";
+import { ProviderList } from "@/components/providers/provider-list";
 import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
 import { useProvidersSetSelection } from "@/hooks/providers/use-providers-set-selection-mutation";
 import { useProvidersAddCustomPath } from "@/hooks/providers/use-providers-add-custom-path-mutation";
@@ -402,34 +402,21 @@ function ProvidersRailLayout({
         aria-label="Providers"
         className="flex w-[clamp(10rem,22vw,14rem)] shrink-0 flex-col gap-1 overflow-y-auto border-r border-border/60 p-2"
       >
-        {orderedProviders.map((state) => {
-          const selected = state.providerId === active.providerId;
-          return (
-            <button
-              key={state.providerId}
-              type="button"
-              aria-label={PROVIDER_DISPLAY_NAMES[state.providerId]}
-              data-active={selected}
-              onClick={() => setActiveId(state.providerId)}
-              className={cn(
-                "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-ui-sm transition-colors",
-                selected
-                  ? "bg-accent text-accent-foreground"
-                  : "text-foreground/70 hover:bg-accent/60 hover:text-accent-foreground",
-              )}
-            >
-              <HarnessIcon
-                harnessId={providerIdToGuiHarnessId(state.providerId)}
-              />
-              <span className="flex-1 truncate">
-                {PROVIDER_DISPLAY_NAMES[state.providerId]}
-              </span>
-              {state.enabled ? null : (
-                <span className="size-1.5 shrink-0 rounded-full bg-muted-foreground/50" />
-              )}
-            </button>
-          );
-        })}
+        <ProviderList
+          ariaLabel="Providers"
+          variant="settings"
+          className="gap-1"
+          rows={orderedProviders.map((state) => ({
+            providerId: state.providerId,
+            active: state.providerId === active.providerId,
+            dimmed: false,
+            enabled: state.enabled,
+            badge: null,
+            description: null,
+            trailing: null,
+            onSelect: setActiveId,
+          }))}
+        />
       </nav>
       <div className="min-h-0 min-w-0 flex-1 overflow-y-auto p-5">
         <ProviderDetail

--- a/clients/gui-app/src/lib/provider-ordering.ts
+++ b/clients/gui-app/src/lib/provider-ordering.ts
@@ -23,7 +23,19 @@ const PROVIDER_ID_ORDER = [
   "kilocode",
   "kimi",
   "qwen",
-] satisfies ReadonlyArray<ProviderId>;
+] as const satisfies ReadonlyArray<ProviderId>;
+
+type MissingProviderIdFromOrder = Exclude<
+  ProviderId,
+  (typeof PROVIDER_ID_ORDER)[number]
+>;
+
+type ExhaustiveOrderedProviders = [MissingProviderIdFromOrder] extends [never]
+  ? ReadonlyArray<OrderedProvider>
+  : readonly [
+      "Missing ProviderId in PROVIDER_ID_ORDER",
+      MissingProviderIdFromOrder,
+    ];
 
 const GUI_HARNESS_BY_PROVIDER_ID = {
   codex: "codex",
@@ -41,7 +53,7 @@ const GUI_HARNESS_BY_PROVIDER_ID = {
   qwen: "qwen",
 } satisfies Readonly<Record<ProviderId, GuiHarnessId>>;
 
-export const ORDERED_PROVIDERS: ReadonlyArray<OrderedProvider> =
+export const ORDERED_PROVIDERS: ExhaustiveOrderedProviders =
   PROVIDER_ID_ORDER.map((providerId) => ({
     providerId,
     harnessId: GUI_HARNESS_BY_PROVIDER_ID[providerId],

--- a/clients/gui-app/src/lib/provider-ordering.ts
+++ b/clients/gui-app/src/lib/provider-ordering.ts
@@ -1,5 +1,29 @@
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
-import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import {
+  PROVIDER_DISPLAY_NAMES,
+  type ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
+
+export interface OrderedProvider {
+  readonly providerId: ProviderId;
+  readonly harnessId: GuiHarnessId;
+}
+
+const PROVIDER_ID_ORDER = [
+  "codex",
+  "claude-code",
+  "opencode",
+  "traycer",
+  "openrouter",
+  "droid",
+  "cursor",
+  "copilot",
+  "grok",
+  "kiro",
+  "kilocode",
+  "kimi",
+  "qwen",
+] satisfies ReadonlyArray<ProviderId>;
 
 const GUI_HARNESS_BY_PROVIDER_ID = {
   codex: "codex",
@@ -17,13 +41,26 @@ const GUI_HARNESS_BY_PROVIDER_ID = {
   qwen: "qwen",
 } satisfies Readonly<Record<ProviderId, GuiHarnessId>>;
 
-const DEFAULT_PROVIDER_ID_ORDER = Object.keys(GUI_HARNESS_BY_PROVIDER_ID);
-const DEFAULT_GUI_HARNESS_ORDER = Object.values(GUI_HARNESS_BY_PROVIDER_ID);
+export const ORDERED_PROVIDERS: ReadonlyArray<OrderedProvider> =
+  PROVIDER_ID_ORDER.map((providerId) => ({
+    providerId,
+    harnessId: GUI_HARNESS_BY_PROVIDER_ID[providerId],
+  }));
+
+const DEFAULT_PROVIDER_ID_ORDER = PROVIDER_ID_ORDER;
+const DEFAULT_GUI_HARNESS_ORDER = ORDERED_PROVIDERS.map(
+  (provider) => provider.harnessId,
+);
 
 const UNKNOWN_PROVIDER_RANK = Number.MAX_SAFE_INTEGER;
 
 export function providerIdToGuiHarnessId(providerId: ProviderId): GuiHarnessId {
   return GUI_HARNESS_BY_PROVIDER_ID[providerId];
+}
+
+export function providerDisplayName(providerId: ProviderId): string {
+  if (providerId === "traycer") return "Traycer Inference";
+  return PROVIDER_DISPLAY_NAMES[providerId];
 }
 
 export function sortGuiHarnessesByProviderOrder<

--- a/clients/gui-app/src/stores/composer/composer-toolbar-store.ts
+++ b/clients/gui-app/src/stores/composer/composer-toolbar-store.ts
@@ -17,6 +17,7 @@ import {
   type ServiceTier,
 } from "@/components/home/data/landing-options";
 import { buildChatRunSettings } from "@/lib/composer/chat-run-settings";
+import { sortGuiHarnessesByProviderOrder } from "@/lib/provider-ordering";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /**
@@ -357,7 +358,7 @@ function effectiveSelectionFromHarnesses(
 ): HarnessModelSelection {
   if (harnesses === undefined) return selection;
   let firstEligible: HarnessOption | null = null;
-  for (const harness of harnesses) {
+  for (const harness of sortGuiHarnessesByProviderOrder(harnesses)) {
     if (!harness.available) continue;
     // On the terminal surface only TUI-capable harnesses are eligible, so a
     // GUI-only selection carried over from chat is rerouted off it - mirroring


### PR DESCRIPTION
## Summary
- centralize provider ordering, display names, and harness mapping in provider-ordering
- add shared ProviderList used by onboarding, the onboarding diorama picker, and Settings > Providers while preserving enabled/disabled state
- make the onboarding provider act scroll and use the shared provider order for landing/composer fallback selection

## Verification
- bun run compile
- focused ESLint on touched provider/onboarding/settings/composer files
- bun run test src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx src/components/onboarding/__tests__/onboarding-diorama.test.tsx src/components/onboarding/__tests__/onboarding-page.test.tsx src/components/settings/panels/__tests__/providers-settings-panel.test.tsx src/components/home/hooks/__tests__/use-composer-toolbar-store.test.tsx src/components/home/__tests__/harness-model-picker.test.tsx
- pre-commit affected workspace checks passed during commit

## Notes
- bun run react-doctor still exits non-zero on existing unrelated findings in diagnostics-settings-panel, landing-image-gc cycles, unused exports, and host-ready-gate.