### PR TITLE
Fix task mention lookup and labels

### DIFF
--- a/clients/gui-app/src/components/chat/composer/picker/__tests__/use-mention-items.test.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/__tests__/use-mention-items.test.ts
@@ -4,6 +4,7 @@ import {
   buildCurrentEpicArtifactMentionEntries,
   epicChatMentionEntriesFromChats,
   mergeCurrentEpicArtifactMentions,
+  mergeTaskAndArtifactMentionEntries,
 } from "../use-mention-items";
 import type {
   ArtifactProjection,
@@ -86,8 +87,8 @@ describe("epicChatMentionEntriesFromChats", () => {
       "",
     );
     expect(entry.label).toBe("Untitled chat");
-    expect(entry.epicTitle).toBe("Untitled epic");
-    expect(entry.description).toBe("Untitled epic");
+    expect(entry.epicTitle).toBe("Untitled task");
+    expect(entry.description).toBe("Untitled task");
   });
 
   it("skips chat ids missing from the byId projection", () => {
@@ -340,5 +341,80 @@ describe("mergeCurrentEpicArtifactMentions", () => {
     );
     const merged = mergeCurrentEpicArtifactMentions(local, [], "epic-cur");
     expect(merged.map((e) => e.id)).toEqual(["spec:epic-cur:only-local"]);
+  });
+});
+
+describe("mergeTaskAndArtifactMentionEntries", () => {
+  it("keeps cached task suggestions ahead of host fallback suggestions and de-dupes by id", () => {
+    const local: ReadonlyArray<EpicMentionEntry> = [
+      {
+        kind: "epic",
+        id: "epic:task-1",
+        token: "epic:task-1",
+        epicId: "task-1",
+        label: "Cached task",
+        description: "1 spec",
+        status: "active",
+        updatedAt: 20,
+      },
+    ];
+    const cloud: ReadonlyArray<EpicMentionEntry> = [
+      {
+        kind: "epic",
+        id: "epic:task-1",
+        token: "epic:task-1",
+        epicId: "task-1",
+        label: "Host task",
+        description: "1 spec",
+        status: "active",
+        updatedAt: 10,
+      },
+      {
+        kind: "epic",
+        id: "epic:task-2",
+        token: "epic:task-2",
+        epicId: "task-2",
+        label: "Host-only task",
+        description: "",
+        status: "active",
+        updatedAt: 30,
+      },
+    ];
+
+    expect(
+      mergeTaskAndArtifactMentionEntries(local, cloud).map((entry) => [
+        entry.id,
+        entry.label,
+      ]),
+    ).toEqual([
+      ["epic:task-1", "Cached task"],
+      ["epic:task-2", "Host-only task"],
+    ]);
+  });
+
+  it("normalizes legacy untitled task copy without changing mention tokens", () => {
+    const [entry] = mergeTaskAndArtifactMentionEntries(
+      [],
+      [
+        {
+          kind: "epic",
+          id: "epic:task-1",
+          token: "epic:task-1",
+          epicId: "task-1",
+          label: "Untitled epic",
+          description: "",
+          status: "active",
+          updatedAt: 10,
+        },
+      ],
+    );
+
+    expect(entry).toMatchObject({
+      kind: "epic",
+      id: "epic:task-1",
+      token: "epic:task-1",
+      epicId: "task-1",
+      label: "Untitled task",
+    });
   });
 });

--- a/clients/gui-app/src/components/chat/composer/picker/__tests__/use-mention-items.test.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/__tests__/use-mention-items.test.ts
@@ -91,6 +91,17 @@ describe("epicChatMentionEntriesFromChats", () => {
     expect(entry.description).toBe("Untitled task");
   });
 
+  it("keeps a literal Untitled epic title unchanged for chat descriptions", () => {
+    const [entry] = epicChatMentionEntriesFromChats(
+      chatsSlice([chat("c1", "Planning", null, 0)]),
+      "epic-1",
+      "Untitled epic",
+    );
+
+    expect(entry.epicTitle).toBe("Untitled epic");
+    expect(entry.description).toBe("Untitled epic");
+  });
+
   it("skips chat ids missing from the byId projection", () => {
     const presentChat = chat("c1", "Planning", null, 200);
     const entries = epicChatMentionEntriesFromChats(
@@ -392,7 +403,7 @@ describe("mergeTaskAndArtifactMentionEntries", () => {
     ]);
   });
 
-  it("normalizes legacy untitled task copy without changing mention tokens", () => {
+  it("keeps literal host task labels unchanged while preserving mention tokens", () => {
     const [entry] = mergeTaskAndArtifactMentionEntries(
       [],
       [
@@ -414,7 +425,7 @@ describe("mergeTaskAndArtifactMentionEntries", () => {
       id: "epic:task-1",
       token: "epic:task-1",
       epicId: "task-1",
-      label: "Untitled task",
+      label: "Untitled epic",
     });
   });
 });

--- a/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
@@ -31,7 +31,7 @@ import {
   type MentionWorkspaceRequest,
 } from "@/lib/composer/mentions";
 import { buildEpicMentionSuggestionsFromTasks } from "@/lib/composer/mentions/local-epic-suggestions";
-import { displayTitle } from "@/lib/display-title";
+import { displayTitle, UNTITLED_EPIC_TITLE } from "@/lib/display-title";
 import type {
   EpicChatMentionEntry,
   EpicMentionEntry,
@@ -49,6 +49,7 @@ const EMPTY_WORKSPACE_REQUESTS: ReadonlyArray<MentionWorkspaceRequest> = [];
 const EMPTY_EPIC_REQUESTS: ReadonlyArray<MentionEpicRequest> = [];
 const EMPTY_WORKSPACE_ENTRIES: ReadonlyArray<WorkspaceEntry> = [];
 const EMPTY_EPIC_ENTRIES: ReadonlyArray<EpicMentionEntry> = [];
+const UNTITLED_TASK_TITLE = "Untitled task";
 
 export interface UseMentionItemsParams {
   readonly pickerStore: ComposerPickerStore;
@@ -197,7 +198,7 @@ export function useMentionItems(params: UseMentionItemsParams): void {
 
   const { data: workspaceEntries, isLoading: workspaceLoading } =
     useWorkspaceEntries({ requests: workspaceRequests, client: hostClient });
-  const { data: artifactEpicEntries, isLoading: epicLoading } =
+  const { data: remoteEpicEntries, isLoading: epicLoading } =
     useEpicMentionEntries({
       requests: epicRequests,
     });
@@ -212,16 +213,28 @@ export function useMentionItems(params: UseMentionItemsParams): void {
     }
     return titles;
   }, [cachedEpicTasks]);
-  const enrichedArtifactEntries = useMemo<
+  const enrichedRemoteEpicEntries = useMemo<
     ReadonlyArray<EpicMentionEntry>
   >(() => {
-    const enrichedCloud = artifactEpicEntries.map((entry) => {
-      if (entry.kind !== "epic-artifact") return entry;
+    const enrichedCloud = remoteEpicEntries.map((entry) => {
+      const normalizedEntry = normalizeTaskMentionEntry(entry);
+      if (normalizedEntry.kind !== "epic-artifact") return normalizedEntry;
       const cachedTitle = epicTitleByIdFromCache.get(entry.epicId);
-      if (cachedTitle === undefined || entry.epicTitle === cachedTitle) {
-        return entry;
+      if (
+        cachedTitle === undefined ||
+        normalizedEntry.epicTitle === cachedTitle
+      ) {
+        return normalizedEntry;
       }
-      return { ...entry, epicTitle: cachedTitle };
+      const epicTitle = normalizeTaskTitleText(cachedTitle);
+      return {
+        ...normalizedEntry,
+        epicTitle,
+        description:
+          normalizedEntry.description === normalizedEntry.epicTitle
+            ? epicTitle
+            : normalizedEntry.description,
+      };
     });
     if (currentEpicId === null) {
       return enrichedCloud.length === 0 ? EMPTY_EPIC_ENTRIES : enrichedCloud;
@@ -233,16 +246,17 @@ export function useMentionItems(params: UseMentionItemsParams): void {
     );
     return merged.length === 0 ? EMPTY_EPIC_ENTRIES : merged;
   }, [
-    artifactEpicEntries,
+    remoteEpicEntries,
     epicTitleByIdFromCache,
     currentEpicId,
     localArtifactEntries,
   ]);
   const epicEntries = useMemo<ReadonlyArray<EpicMentionEntry>>(() => {
-    if (localEpicSuggestions.length === 0) return enrichedArtifactEntries;
-    if (enrichedArtifactEntries.length === 0) return localEpicSuggestions;
-    return [...localEpicSuggestions, ...enrichedArtifactEntries];
-  }, [enrichedArtifactEntries, localEpicSuggestions]);
+    return mergeTaskAndArtifactMentionEntries(
+      localEpicSuggestions,
+      enrichedRemoteEpicEntries,
+    );
+  }, [enrichedRemoteEpicEntries, localEpicSuggestions]);
 
   const resolvedContext = useMemo<ComposerMentionProviderContext>(
     () => ({
@@ -337,7 +351,7 @@ export function epicChatMentionEntriesFromChats(
   rawEpicTitle: string,
 ): ReadonlyArray<EpicChatMentionEntry> {
   if (chats.allIds.length === 0) return EMPTY_CHAT_ENTRIES;
-  const epicTitle = displayTitle(rawEpicTitle, "epic");
+  const epicTitle = taskMentionTitle(rawEpicTitle);
   const entries = chats.allIds.flatMap((id) => {
     if (!Object.hasOwn(chats.byId, id)) return [];
     const chat = chats.byId[id];
@@ -401,7 +415,7 @@ export function buildCurrentEpicArtifactMentionEntries(
 ): ReadonlyArray<EpicMentionArtifactSuggestion> {
   if (artifacts.allIds.length === 0) return EMPTY_ARTIFACT_ENTRIES;
   const normalizedQuery = query.trim().toLowerCase();
-  const epicTitle = displayTitle(rawEpicTitle, "epic");
+  const epicTitle = taskMentionTitle(rawEpicTitle);
   const entries = artifacts.allIds.flatMap((id) => {
     if (!Object.hasOwn(artifacts.byId, id)) return [];
     const artifact = artifacts.byId[id];
@@ -447,4 +461,69 @@ export function mergeCurrentEpicArtifactMentions(
       .filter((entry) => !isCurrentEpicArtifact(entry))
       .toSorted(byRecency),
   ];
+}
+
+export function mergeTaskAndArtifactMentionEntries(
+  localTaskEntries: ReadonlyArray<EpicMentionEntry>,
+  cloudAndArtifactEntries: ReadonlyArray<EpicMentionEntry>,
+): ReadonlyArray<EpicMentionEntry> {
+  if (localTaskEntries.length === 0 && cloudAndArtifactEntries.length === 0) {
+    return EMPTY_EPIC_ENTRIES;
+  }
+
+  const merged: EpicMentionEntry[] = [];
+  const seenTaskIds = new Set<string>();
+
+  for (const entry of localTaskEntries) {
+    const normalized = normalizeTaskMentionEntry(entry);
+    merged.push(normalized);
+    if (normalized.kind === "epic") seenTaskIds.add(normalized.id);
+  }
+
+  for (const entry of cloudAndArtifactEntries) {
+    const normalized = normalizeTaskMentionEntry(entry);
+    if (normalized.kind === "epic" && seenTaskIds.has(normalized.id)) {
+      continue;
+    }
+    merged.push(normalized);
+    if (normalized.kind === "epic") seenTaskIds.add(normalized.id);
+  }
+
+  return merged.length === 0 ? EMPTY_EPIC_ENTRIES : merged;
+}
+
+function normalizeTaskMentionEntry(entry: EpicMentionEntry): EpicMentionEntry {
+  if (entry.kind === "epic") {
+    const label = normalizeTaskTitleText(entry.label);
+    return label === entry.label ? entry : { ...entry, label };
+  }
+
+  if (entry.kind === "epic-artifact") {
+    const epicTitle = normalizeTaskTitleText(entry.epicTitle);
+    const description =
+      entry.description === entry.epicTitle
+        ? epicTitle
+        : normalizeTaskTitleText(entry.description);
+    return epicTitle === entry.epicTitle && description === entry.description
+      ? entry
+      : { ...entry, epicTitle, description };
+  }
+
+  const epicTitle = normalizeTaskTitleText(entry.epicTitle);
+  const description =
+    entry.description === entry.epicTitle
+      ? epicTitle
+      : normalizeTaskTitleText(entry.description);
+  return epicTitle === entry.epicTitle && description === entry.description
+    ? entry
+    : { ...entry, epicTitle, description };
+}
+
+function taskMentionTitle(rawTitle: string): string {
+  const title = displayTitle(rawTitle, "epic");
+  return normalizeTaskTitleText(title);
+}
+
+function normalizeTaskTitleText(title: string): string {
+  return title === UNTITLED_EPIC_TITLE ? UNTITLED_TASK_TITLE : title;
 }

--- a/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
@@ -31,7 +31,8 @@ import {
   type MentionWorkspaceRequest,
 } from "@/lib/composer/mentions";
 import { buildEpicMentionSuggestionsFromTasks } from "@/lib/composer/mentions/local-epic-suggestions";
-import { displayTitle, UNTITLED_EPIC_TITLE } from "@/lib/display-title";
+import { taskMentionTitleFromRawTitle } from "@/lib/composer/mentions/task-mention-helpers";
+import { displayTitle } from "@/lib/display-title";
 import type {
   EpicChatMentionEntry,
   EpicMentionEntry,
@@ -49,7 +50,6 @@ const EMPTY_WORKSPACE_REQUESTS: ReadonlyArray<MentionWorkspaceRequest> = [];
 const EMPTY_EPIC_REQUESTS: ReadonlyArray<MentionEpicRequest> = [];
 const EMPTY_WORKSPACE_ENTRIES: ReadonlyArray<WorkspaceEntry> = [];
 const EMPTY_EPIC_ENTRIES: ReadonlyArray<EpicMentionEntry> = [];
-const UNTITLED_TASK_TITLE = "Untitled task";
 
 export interface UseMentionItemsParams {
   readonly pickerStore: ComposerPickerStore;
@@ -208,7 +208,6 @@ export function useMentionItems(params: UseMentionItemsParams): void {
     for (const task of cachedEpicTasks) {
       const light = task.epic?.light;
       if (light === null || light === undefined) continue;
-      if (light.title.length === 0) continue;
       titles.set(light.id, light.title);
     }
     return titles;
@@ -220,13 +219,9 @@ export function useMentionItems(params: UseMentionItemsParams): void {
       const normalizedEntry = normalizeTaskMentionEntry(entry);
       if (normalizedEntry.kind !== "epic-artifact") return normalizedEntry;
       const cachedTitle = epicTitleByIdFromCache.get(entry.epicId);
-      if (
-        cachedTitle === undefined ||
-        normalizedEntry.epicTitle === cachedTitle
-      ) {
-        return normalizedEntry;
-      }
-      const epicTitle = normalizeTaskTitleText(cachedTitle);
+      if (cachedTitle === undefined) return normalizedEntry;
+      const epicTitle = taskMentionTitle(cachedTitle);
+      if (normalizedEntry.epicTitle === epicTitle) return normalizedEntry;
       return {
         ...normalizedEntry,
         epicTitle,
@@ -471,59 +466,33 @@ export function mergeTaskAndArtifactMentionEntries(
     return EMPTY_EPIC_ENTRIES;
   }
 
-  const merged: EpicMentionEntry[] = [];
-  const seenTaskIds = new Set<string>();
+  const normalizedLocalEntries = localTaskEntries.map(
+    normalizeTaskMentionEntry,
+  );
+  const seenTaskIds = normalizedLocalEntries.reduce((ids, entry) => {
+    if (entry.kind === "epic") ids.add(entry.id);
+    return ids;
+  }, new Set<string>());
+  const normalizedCloudEntries = cloudAndArtifactEntries
+    .map(normalizeTaskMentionEntry)
+    .filter((entry) => {
+      if (entry.kind !== "epic") return true;
+      if (seenTaskIds.has(entry.id)) return false;
+      seenTaskIds.add(entry.id);
+      return true;
+    });
 
-  for (const entry of localTaskEntries) {
-    const normalized = normalizeTaskMentionEntry(entry);
-    merged.push(normalized);
-    if (normalized.kind === "epic") seenTaskIds.add(normalized.id);
-  }
-
-  for (const entry of cloudAndArtifactEntries) {
-    const normalized = normalizeTaskMentionEntry(entry);
-    if (normalized.kind === "epic" && seenTaskIds.has(normalized.id)) {
-      continue;
-    }
-    merged.push(normalized);
-    if (normalized.kind === "epic") seenTaskIds.add(normalized.id);
-  }
-
+  const merged: ReadonlyArray<EpicMentionEntry> = [
+    ...normalizedLocalEntries,
+    ...normalizedCloudEntries,
+  ];
   return merged.length === 0 ? EMPTY_EPIC_ENTRIES : merged;
 }
 
 function normalizeTaskMentionEntry(entry: EpicMentionEntry): EpicMentionEntry {
-  if (entry.kind === "epic") {
-    const label = normalizeTaskTitleText(entry.label);
-    return label === entry.label ? entry : { ...entry, label };
-  }
-
-  if (entry.kind === "epic-artifact") {
-    const epicTitle = normalizeTaskTitleText(entry.epicTitle);
-    const description =
-      entry.description === entry.epicTitle
-        ? epicTitle
-        : normalizeTaskTitleText(entry.description);
-    return epicTitle === entry.epicTitle && description === entry.description
-      ? entry
-      : { ...entry, epicTitle, description };
-  }
-
-  const epicTitle = normalizeTaskTitleText(entry.epicTitle);
-  const description =
-    entry.description === entry.epicTitle
-      ? epicTitle
-      : normalizeTaskTitleText(entry.description);
-  return epicTitle === entry.epicTitle && description === entry.description
-    ? entry
-    : { ...entry, epicTitle, description };
+  return entry;
 }
 
 function taskMentionTitle(rawTitle: string): string {
-  const title = displayTitle(rawTitle, "epic");
-  return normalizeTaskTitleText(title);
-}
-
-function normalizeTaskTitleText(title: string): string {
-  return title === UNTITLED_EPIC_TITLE ? UNTITLED_TASK_TITLE : title;
+  return taskMentionTitleFromRawTitle(rawTitle);
 }

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts
@@ -65,6 +65,33 @@ describe("buildEpicMentionSuggestionsFromTasks", () => {
     ).toEqual(["epic:task-1"]);
   });
 
+  it("keeps alias query ranking neutral instead of promoting title matches", () => {
+    const tasks = [
+      task(
+        epic({
+          id: "older-title-match",
+          title: "Task cleanup",
+          initialUserPrompt: "",
+          updatedAt: 10,
+        }),
+      ),
+      task(
+        epic({
+          id: "newer-neutral",
+          title: "Billing flow",
+          initialUserPrompt: "",
+          updatedAt: 30,
+        }),
+      ),
+    ];
+
+    expect(
+      buildEpicMentionSuggestionsFromTasks(tasks, "task", 25).map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(["epic:newer-neutral", "epic:older-title-match"]);
+  });
+
   it("uses task copy for empty titles while preserving epic tokens", () => {
     const [entry] = buildEpicMentionSuggestionsFromTasks(
       [

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts
@@ -86,10 +86,15 @@ describe("buildEpicMentionSuggestionsFromTasks", () => {
     ];
 
     expect(
-      buildEpicMentionSuggestionsFromTasks(tasks, "task", 25).map(
-        (entry) => entry.id,
+      ["task", "epic"].map((alias) =>
+        buildEpicMentionSuggestionsFromTasks(tasks, alias, 25).map(
+          (entry) => entry.id,
+        ),
       ),
-    ).toEqual(["epic:newer-neutral", "epic:older-title-match"]);
+    ).toEqual([
+      ["epic:newer-neutral", "epic:older-title-match"],
+      ["epic:newer-neutral", "epic:older-title-match"],
+    ]);
   });
 
   it("uses task copy for empty titles while preserving epic tokens", () => {

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts
@@ -87,4 +87,27 @@ describe("buildEpicMentionSuggestionsFromTasks", () => {
       label: "Untitled task",
     });
   });
+
+  it("keeps a literal Untitled epic title unchanged", () => {
+    const [entry] = buildEpicMentionSuggestionsFromTasks(
+      [
+        task(
+          epic({
+            id: "task-1",
+            title: "Untitled epic",
+            initialUserPrompt: "",
+            updatedAt: 10,
+          }),
+        ),
+      ],
+      "",
+      25,
+    );
+
+    expect(entry).toMatchObject({
+      id: "epic:task-1",
+      token: "epic:task-1",
+      label: "Untitled epic",
+    });
+  });
 });

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type {
+  EpicLight,
+  TaskLight,
+} from "@traycer/protocol/host/epic/unary-schemas";
+
+import { buildEpicMentionSuggestionsFromTasks } from "../local-epic-suggestions";
+
+function epic(fields: {
+  readonly id: string;
+  readonly title: string;
+  readonly initialUserPrompt: string;
+  readonly updatedAt: number;
+}): EpicLight {
+  return {
+    id: fields.id,
+    title: fields.title,
+    initialUserPrompt: fields.initialUserPrompt,
+    ticketCount: 0,
+    specCount: 0,
+    storyCount: 0,
+    reviewCount: 0,
+    status: "active",
+    createdAt: 0,
+    updatedAt: fields.updatedAt,
+    createdBy: "user-1",
+    version: "1.0.0",
+  };
+}
+
+function task(light: EpicLight): TaskLight {
+  return {
+    epic: {
+      light,
+      permission: null,
+      repos: [],
+      workspaces: [],
+      roomInfo: null,
+    },
+  };
+}
+
+describe("buildEpicMentionSuggestionsFromTasks", () => {
+  it("matches the new task label and the legacy epic label", () => {
+    const tasks = [
+      task(
+        epic({
+          id: "task-1",
+          title: "Auth flow",
+          initialUserPrompt: "",
+          updatedAt: 10,
+        }),
+      ),
+    ];
+
+    expect(
+      buildEpicMentionSuggestionsFromTasks(tasks, "task", 25).map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(["epic:task-1"]);
+    expect(
+      buildEpicMentionSuggestionsFromTasks(tasks, "epic", 25).map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(["epic:task-1"]);
+  });
+
+  it("uses task copy for empty titles while preserving epic tokens", () => {
+    const [entry] = buildEpicMentionSuggestionsFromTasks(
+      [
+        task(
+          epic({
+            id: "task-1",
+            title: "",
+            initialUserPrompt: "",
+            updatedAt: 10,
+          }),
+        ),
+      ],
+      "",
+      25,
+    );
+
+    expect(entry).toMatchObject({
+      id: "epic:task-1",
+      token: "epic:task-1",
+      label: "Untitled task",
+    });
+  });
+});

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
@@ -47,7 +47,7 @@ describe("mention provider registry", () => {
       "Folders",
       "Worktrees",
       "Git",
-      "Epic",
+      "Task",
       "Spec",
       "Ticket",
       "Story",
@@ -82,7 +82,7 @@ describe("mention provider registry", () => {
       "Folders",
       "Worktrees",
       "Git",
-      "Epic",
+      "Task",
       "Chat",
       "Spec",
       "Ticket",
@@ -318,18 +318,38 @@ describe("mention provider registry", () => {
       "workspace.mentionWorktrees",
     ]);
 
-    // `epic.mentionEpics` is intentionally absent: the picker derives epic
-    // suggestions from the cached cloud-tasks history slice, so the host
-    // RPC fan-out for that kind has been removed (see `EpicMentionProvider`).
     const epicRequests = mentionProviderRegistry.epicRequests(
       ROOT_MENTION_STEP,
       context({ query: "login" }),
     );
     expect(epicRequests.map((request) => request.method)).toEqual([
+      "epic.mentionEpics",
       "epic.mentionSpecs",
       "epic.mentionTickets",
       "epic.mentionStories",
       "epic.mentionReviews",
     ]);
+  });
+
+  it("keeps task and epic provider aliases backward-compatible for task requests", () => {
+    expect(
+      mentionProviderRegistry.epicRequests(
+        ROOT_MENTION_STEP,
+        context({ query: "task" }),
+      )[0],
+    ).toMatchObject({
+      method: "epic.mentionEpics",
+      params: { query: "" },
+    });
+
+    expect(
+      mentionProviderRegistry.epicRequests(
+        ROOT_MENTION_STEP,
+        context({ query: "epic" }),
+      )[0],
+    ).toMatchObject({
+      method: "epic.mentionEpics",
+      params: { query: "" },
+    });
   });
 });

--- a/clients/gui-app/src/lib/composer/mentions/local-epic-suggestions.ts
+++ b/clients/gui-app/src/lib/composer/mentions/local-epic-suggestions.ts
@@ -57,12 +57,12 @@ function rankEpics(
 
 function scoreEpic(epic: EpicLight, normalizedQuery: string): number | null {
   if (normalizedQuery.length === 0) return 0;
+  if (isTaskMentionAliasQuery(normalizedQuery)) return 250;
   const label = taskMentionDisplayTitle(epic).toLowerCase();
   const id = `epic:${epic.id}`.toLowerCase();
   if (label === normalizedQuery || id === normalizedQuery) return 0;
   if (label.startsWith(normalizedQuery)) return 100;
   if (label.includes(normalizedQuery)) return 200;
-  if (isTaskMentionAliasQuery(normalizedQuery)) return 250;
   if (id.includes(normalizedQuery)) return 300;
   if (
     isSubsequence(normalizedQuery, label) ||

--- a/clients/gui-app/src/lib/composer/mentions/local-epic-suggestions.ts
+++ b/clients/gui-app/src/lib/composer/mentions/local-epic-suggestions.ts
@@ -4,7 +4,15 @@ import type {
 } from "@traycer/protocol/host/epic/unary-schemas";
 import type { EpicLight } from "@traycer/protocol/host/epic/unary-schemas";
 import { isSubsequence } from "@traycer/protocol/utils/text/fuzzy";
-import { epicDisplayTitle } from "@/lib/display-title";
+import { epicDisplayTitle, UNTITLED_EPIC_TITLE } from "@/lib/display-title";
+
+const UNTITLED_TASK_TITLE = "Untitled task";
+const TASK_QUERY_ALIASES: ReadonlySet<string> = new Set([
+  "task",
+  "tasks",
+  "epic",
+  "epics",
+]);
 
 export function buildEpicMentionSuggestionsFromTasks(
   tasks: ReadonlyArray<TaskLight>,
@@ -24,7 +32,7 @@ function buildSuggestion(epic: EpicLight): EpicMentionEpicSuggestion {
     id: `epic:${epic.id}`,
     token: `epic:${epic.id}`,
     epicId: epic.id,
-    label: epicDisplayTitle(epic),
+    label: taskMentionDisplayTitle(epic),
     description: countDescription(epic),
     status: epic.status,
     updatedAt: epic.updatedAt,
@@ -54,11 +62,12 @@ function rankEpics(
 
 function scoreEpic(epic: EpicLight, normalizedQuery: string): number | null {
   if (normalizedQuery.length === 0) return 0;
-  const label = epicDisplayTitle(epic).toLowerCase();
+  const label = taskMentionDisplayTitle(epic).toLowerCase();
   const id = `epic:${epic.id}`.toLowerCase();
   if (label === normalizedQuery || id === normalizedQuery) return 0;
   if (label.startsWith(normalizedQuery)) return 100;
   if (label.includes(normalizedQuery)) return 200;
+  if (TASK_QUERY_ALIASES.has(normalizedQuery)) return 250;
   if (id.includes(normalizedQuery)) return 300;
   if (
     isSubsequence(normalizedQuery, label) ||
@@ -67,6 +76,11 @@ function scoreEpic(epic: EpicLight, normalizedQuery: string): number | null {
     return 400 + label.length;
   }
   return null;
+}
+
+function taskMentionDisplayTitle(epic: EpicLight): string {
+  const label = epicDisplayTitle(epic);
+  return label === UNTITLED_EPIC_TITLE ? UNTITLED_TASK_TITLE : label;
 }
 
 function countDescription(epic: EpicLight): string {

--- a/clients/gui-app/src/lib/composer/mentions/local-epic-suggestions.ts
+++ b/clients/gui-app/src/lib/composer/mentions/local-epic-suggestions.ts
@@ -4,15 +4,10 @@ import type {
 } from "@traycer/protocol/host/epic/unary-schemas";
 import type { EpicLight } from "@traycer/protocol/host/epic/unary-schemas";
 import { isSubsequence } from "@traycer/protocol/utils/text/fuzzy";
-import { epicDisplayTitle, UNTITLED_EPIC_TITLE } from "@/lib/display-title";
-
-const UNTITLED_TASK_TITLE = "Untitled task";
-const TASK_QUERY_ALIASES: ReadonlySet<string> = new Set([
-  "task",
-  "tasks",
-  "epic",
-  "epics",
-]);
+import {
+  isTaskMentionAliasQuery,
+  taskMentionDisplayTitle,
+} from "./task-mention-helpers";
 
 export function buildEpicMentionSuggestionsFromTasks(
   tasks: ReadonlyArray<TaskLight>,
@@ -67,7 +62,7 @@ function scoreEpic(epic: EpicLight, normalizedQuery: string): number | null {
   if (label === normalizedQuery || id === normalizedQuery) return 0;
   if (label.startsWith(normalizedQuery)) return 100;
   if (label.includes(normalizedQuery)) return 200;
-  if (TASK_QUERY_ALIASES.has(normalizedQuery)) return 250;
+  if (isTaskMentionAliasQuery(normalizedQuery)) return 250;
   if (id.includes(normalizedQuery)) return 300;
   if (
     isSubsequence(normalizedQuery, label) ||
@@ -76,11 +71,6 @@ function scoreEpic(epic: EpicLight, normalizedQuery: string): number | null {
     return 400 + label.length;
   }
   return null;
-}
-
-function taskMentionDisplayTitle(epic: EpicLight): string {
-  const label = epicDisplayTitle(epic);
-  return label === UNTITLED_EPIC_TITLE ? UNTITLED_TASK_TITLE : label;
 }
 
 function countDescription(epic: EpicLight): string {

--- a/clients/gui-app/src/lib/composer/mentions/providers.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/providers.tsx
@@ -30,6 +30,12 @@ const MENU_ICON_CLASS = "size-4 shrink-0 text-muted-foreground";
 const EMPTY_MENU_ENTRIES: ReadonlyArray<MentionMenuEntry> = [];
 const EMPTY_WORKSPACE_REQUESTS: ReadonlyArray<MentionWorkspaceRequest> = [];
 const EMPTY_EPIC_REQUESTS: ReadonlyArray<MentionEpicRequest> = [];
+const TASK_PROVIDER_QUERY_ALIASES: ReadonlySet<string> = new Set([
+  "task",
+  "tasks",
+  "epic",
+  "epics",
+]);
 
 export type MentionProviderId =
   | "files"
@@ -474,8 +480,8 @@ class GitMentionProvider extends ComposerMentionProvider {
 class EpicMentionProvider extends ComposerMentionProvider {
   readonly id = "epic" as const;
   readonly rootOrder = 40;
-  protected readonly label = "Epic";
-  protected readonly description = "Accessible epics";
+  protected readonly label = "Task";
+  protected readonly description = "Accessible tasks";
 
   rootEntry(_context: ComposerMentionProviderContext): MentionMenuEntry | null {
     return providerEntry({
@@ -496,16 +502,16 @@ class EpicMentionProvider extends ComposerMentionProvider {
   }
 
   rootEpicRequests(
-    _context: ComposerMentionProviderContext,
+    context: ComposerMentionProviderContext,
   ): ReadonlyArray<MentionEpicRequest> {
-    return EMPTY_EPIC_REQUESTS;
+    return [epicTaskRequest(context)];
   }
 
   epicRequests(
     _step: MentionFlowStep,
-    _context: ComposerMentionProviderContext,
+    context: ComposerMentionProviderContext,
   ): ReadonlyArray<MentionEpicRequest> {
-    return EMPTY_EPIC_REQUESTS;
+    return this.rootEpicRequests(context);
   }
 
   stepEntries(
@@ -521,7 +527,7 @@ class EpicMentionProvider extends ComposerMentionProvider {
   }
 
   menuCopy(_step: MentionFlowStep): MentionMenuCopy {
-    return { header: "Epics", empty: "No matching epics" };
+    return { header: "Tasks", empty: "No matching tasks" };
   }
 }
 
@@ -529,7 +535,7 @@ class ChatMentionProvider extends ComposerMentionProvider {
   readonly id = "chat" as const;
   readonly rootOrder = 45;
   protected readonly label = "Chat";
-  protected readonly description = "Epic chats";
+  protected readonly description = "Task chats";
 
   rootEntry(context: ComposerMentionProviderContext): MentionMenuEntry | null {
     if (context.currentEpicId === null) return null;
@@ -914,6 +920,23 @@ function epicRequest(
       limit: context.limit,
     },
   };
+}
+
+function epicTaskRequest(
+  context: ComposerMentionProviderContext,
+): MentionEpicRequest {
+  return {
+    method: "epic.mentionEpics",
+    params: {
+      query: taskProviderMentionQuery(context.query),
+      limit: context.limit,
+    },
+  };
+}
+
+function taskProviderMentionQuery(query: string): string {
+  const normalizedQuery = query.trim().toLowerCase();
+  return TASK_PROVIDER_QUERY_ALIASES.has(normalizedQuery) ? "" : query.trim();
 }
 
 function gitMethodForStep(stepId: string): WorkspaceGitMentionMethod {

--- a/clients/gui-app/src/lib/composer/mentions/providers.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/providers.tsx
@@ -25,17 +25,12 @@ import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import type { RequestOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
 import { mentionAttachmentFromSuggestion } from "./attachments";
+import { taskMentionQueryForRequest } from "./task-mention-helpers";
 
 const MENU_ICON_CLASS = "size-4 shrink-0 text-muted-foreground";
 const EMPTY_MENU_ENTRIES: ReadonlyArray<MentionMenuEntry> = [];
 const EMPTY_WORKSPACE_REQUESTS: ReadonlyArray<MentionWorkspaceRequest> = [];
 const EMPTY_EPIC_REQUESTS: ReadonlyArray<MentionEpicRequest> = [];
-const TASK_PROVIDER_QUERY_ALIASES: ReadonlySet<string> = new Set([
-  "task",
-  "tasks",
-  "epic",
-  "epics",
-]);
 
 export type MentionProviderId =
   | "files"
@@ -928,15 +923,10 @@ function epicTaskRequest(
   return {
     method: "epic.mentionEpics",
     params: {
-      query: taskProviderMentionQuery(context.query),
+      query: taskMentionQueryForRequest(context.query),
       limit: context.limit,
     },
   };
-}
-
-function taskProviderMentionQuery(query: string): string {
-  const normalizedQuery = query.trim().toLowerCase();
-  return TASK_PROVIDER_QUERY_ALIASES.has(normalizedQuery) ? "" : query.trim();
 }
 
 function gitMethodForStep(stepId: string): WorkspaceGitMentionMethod {

--- a/clients/gui-app/src/lib/composer/mentions/task-mention-helpers.ts
+++ b/clients/gui-app/src/lib/composer/mentions/task-mention-helpers.ts
@@ -1,0 +1,32 @@
+import { epicDisplayTitle, UNTITLED_EPIC_TITLE } from "@/lib/display-title";
+
+const TASK_MENTION_ALIASES: ReadonlySet<string> = new Set([
+  "task",
+  "tasks",
+  "epic",
+  "epics",
+]);
+
+export const UNTITLED_TASK_TITLE = "Untitled task";
+
+export function isTaskMentionAliasQuery(query: string): boolean {
+  return TASK_MENTION_ALIASES.has(query.trim().toLowerCase());
+}
+
+export function taskMentionQueryForRequest(query: string): string {
+  const trimmed = query.trim();
+  return isTaskMentionAliasQuery(trimmed) ? "" : trimmed;
+}
+
+export function taskMentionDisplayTitle(epic: {
+  readonly title: string;
+  readonly initialUserPrompt: string;
+}): string {
+  if (epic.title.length > 0) return epic.title;
+  const label = epicDisplayTitle(epic);
+  return label === UNTITLED_EPIC_TITLE ? UNTITLED_TASK_TITLE : label;
+}
+
+export function taskMentionTitleFromRawTitle(rawTitle: string): string {
+  return rawTitle.length > 0 ? rawTitle : UNTITLED_TASK_TITLE;
+}


### PR DESCRIPTION
## Summary
- Restore task mention lookup for exact alias queries like `@ task` and legacy `@ epic`.
- Rename user-facing Epic mention labels/copy to Task while preserving `epic:<id>` and `contextType: "epic"` compatibility.
- Merge local cached task suggestions with host-backed task/artifact mention results and add coverage.

## Testing
- `bun run test -- src/lib/composer/mentions/__tests__/providers.test.tsx src/lib/composer/mentions/__tests__/local-epic-suggestions.test.ts src/components/chat/composer/picker/__tests__/use-mention-items.test.ts src/hooks/composer/__tests__/use-epic-mention-entries.test.tsx`
- `bun run compile`
- `npx -y react-doctor@latest . --verbose --diff origin/main --offline --no-score`
- `git diff --check`