### PR TITLE
Stack update toast action buttons

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
@@ -36,7 +36,10 @@ type ToastOptions = {
   cancel?: ToastAction;
 };
 
-type ToastCall = (message: string, options: ToastOptions | undefined) => void;
+type ToastCall = (
+  message: ReactNode,
+  options: ToastOptions | undefined,
+) => void;
 
 const toastMock = vi.hoisted(() => {
   const actions: {
@@ -396,17 +399,27 @@ describe("desktop app update UI", () => {
     });
     await waitFor(() => {
       expect(toastMock).toHaveBeenCalledWith(
-        "Update available",
+        expect.anything(),
         expect.objectContaining({ id: "traycer-app-update" }),
       );
     });
 
-    const download = toastMock.actions.action;
-    if (download === null) {
-      throw new Error("Expected a Download action");
+    const [message, options] = toastMock.mock.lastCall ?? [];
+    if (message === undefined || options === undefined) {
+      throw new Error("Expected update available toast content");
     }
-    download();
+    expect(options.action).toBeUndefined();
+    expect(options.cancel).toBeUndefined();
+    render(<>{message}</>);
+    screen.getByText("Update available");
+    screen.getByText("Version 1.2.3 is ready to download.");
+
+    const downloadButton = screen.getByRole("button", { name: "Download" });
+    const laterButton = screen.getByRole("button", { name: "Later" });
+    fireEvent.click(downloadButton);
     expect(bridge.downloadUpdate).toHaveBeenCalledTimes(1);
+    fireEvent.click(laterButton);
+    expect(toastMock.dismiss).toHaveBeenCalledWith("traycer-app-update");
   });
 
   it("explains why a blocked update can't be installed instead of offering Download", async () => {
@@ -472,17 +485,24 @@ describe("desktop app update UI", () => {
     });
     await waitFor(() => {
       expect(toastMock).toHaveBeenCalledWith(
-        "Update ready to install",
+        expect.anything(),
         expect.objectContaining({ id: "traycer-app-update" }),
       );
     });
 
-    const restart = toastMock.actions.action;
-    if (restart === null) {
-      throw new Error("Expected a Restart action");
+    const [message, options] = toastMock.mock.lastCall ?? [];
+    if (message === undefined || options === undefined) {
+      throw new Error("Expected update ready toast content");
     }
+    expect(options.action).toBeUndefined();
+    expect(options.cancel).toBeUndefined();
+    render(<>{message}</>);
+    screen.getByText("Update ready to install");
+    screen.getByText("Restart Traycer to finish updating.");
+
+    const restart = screen.getByRole("button", { name: "Restart" });
     expect(useDesktopDialogStore.getState().activeDialog).toBeNull();
-    restart();
+    fireEvent.click(restart);
     expect(useDesktopDialogStore.getState().activeDialog).toBe(
       "confirm-restart-update",
     );

--- a/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
@@ -414,10 +414,14 @@ describe("desktop app update UI", () => {
     screen.getByText("Update available");
     screen.getByText("Version 1.2.3 is ready to download.");
 
-    const downloadButton = screen.getByRole("button", { name: "Download" });
+    const downloadButton = screen.getByRole("button", {
+      name: "Download",
+    });
     const laterButton = screen.getByRole("button", { name: "Later" });
     fireEvent.click(downloadButton);
+    fireEvent.click(downloadButton);
     expect(bridge.downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(downloadButton.hasAttribute("disabled")).toBe(true);
     fireEvent.click(laterButton);
     expect(toastMock.dismiss).toHaveBeenCalledWith("traycer-app-update");
   });

--- a/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useDesktopAppUpdates } from "@/hooks/runner/use-desktop-app-updates";
@@ -195,6 +195,17 @@ function AppUpdateActionToastContent(props: {
   readonly actionLabel: string;
   readonly onAction: () => void;
 }) {
+  const actionHandledRef = useRef(false);
+  const [actionHandled, setActionHandled] = useState(false);
+
+  function handleAction(): void {
+    if (actionHandledRef.current) return;
+    actionHandledRef.current = true;
+    setActionHandled(true);
+    toast.dismiss(APP_UPDATE_TOAST_ID);
+    props.onAction();
+  }
+
   return (
     <div className="flex items-center gap-4">
       <div className="min-w-0 flex-1">
@@ -206,7 +217,8 @@ function AppUpdateActionToastContent(props: {
           type="button"
           size="sm"
           className="w-full min-w-max"
-          onClick={props.onAction}
+          disabled={actionHandled}
+          onClick={handleAction}
         >
           {props.actionLabel}
         </Button>

--- a/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
@@ -87,21 +87,18 @@ function showAppUpdateToast(
       }
       // A quiet, dismissible heads-up - the header button is the persistent
       // fallback once it's dismissed.
-      toast("Update available", {
-        id: APP_UPDATE_TOAST_ID,
-        description: updateAvailableDescription(snapshot.latestVersion),
-        duration: Infinity,
-        action: {
-          label: "Download",
-          onClick: actions.onDownload,
+      toast(
+        <AppUpdateActionToastContent
+          title="Update available"
+          description={updateAvailableDescription(snapshot.latestVersion)}
+          actionLabel="Download"
+          onAction={actions.onDownload}
+        />,
+        {
+          id: APP_UPDATE_TOAST_ID,
+          duration: Infinity,
         },
-        cancel: {
-          label: "Later",
-          onClick: () => {
-            toast.dismiss(APP_UPDATE_TOAST_ID);
-          },
-        },
-      });
+      );
       return;
     case "downloading":
       toast.loading("Downloading update…", {
@@ -114,21 +111,18 @@ function showAppUpdateToast(
       });
       return;
     case "ready":
-      toast("Update ready to install", {
-        id: APP_UPDATE_TOAST_ID,
-        description: "Restart Traycer to finish updating.",
-        duration: Infinity,
-        action: {
-          label: "Restart",
-          onClick: actions.onRestart,
+      toast(
+        <AppUpdateActionToastContent
+          title="Update ready to install"
+          description="Restart Traycer to finish updating."
+          actionLabel="Restart"
+          onAction={actions.onRestart}
+        />,
+        {
+          id: APP_UPDATE_TOAST_ID,
+          duration: Infinity,
         },
-        cancel: {
-          label: "Later",
-          onClick: () => {
-            toast.dismiss(APP_UPDATE_TOAST_ID);
-          },
-        },
-      });
+      );
       return;
     case "error":
       toast.error("Couldn't update Traycer", {
@@ -192,6 +186,43 @@ function isManualFeedbackSnapshot(snapshot: DesktopAppUpdateSnapshot): boolean {
     (snapshot.status === "checking" ||
       snapshot.status === "up-to-date" ||
       snapshot.status === "unavailable")
+  );
+}
+
+function AppUpdateActionToastContent(props: {
+  readonly title: string;
+  readonly description: string;
+  readonly actionLabel: string;
+  readonly onAction: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-4">
+      <div className="min-w-0 flex-1">
+        <div className="font-medium">{props.title}</div>
+        <div className="mt-1 text-muted-foreground">{props.description}</div>
+      </div>
+      <div className="grid shrink-0 grid-cols-1 gap-1.5">
+        <Button
+          type="button"
+          size="sm"
+          className="w-full min-w-max"
+          onClick={props.onAction}
+        >
+          {props.actionLabel}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="w-full min-w-max"
+          onClick={() => {
+            toast.dismiss(APP_UPDATE_TOAST_ID);
+          }}
+        >
+          Later
+        </Button>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Render app update toasts with custom content so actions stack vertically in two same-width rows.
- Apply the same stacked action pattern to both Download/Later and Restart/Later update states.
- Update app update UI tests to exercise the custom toast buttons.

## Verification
- bun run test src/components/layout/__tests__/app-update-ui.test.tsx
- bun run compile
- npx -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score
- bun x prettier --check src/components/layout/bridges/app-update-toast-controller.tsx src/components/layout/__tests__/app-update-ui.test.tsx