### PR TITLE
Hide disabled sidebar header actions at rest

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -837,6 +837,9 @@ describe("epic sidebar selection mode", () => {
     expect(markAllReadButton.className).toContain(
       "disabled:group-hover/panel-section:opacity-50",
     );
+    expect(markAllReadButton.className).toContain(
+      "disabled:group-focus-within/panel-section:opacity-50",
+    );
 
     testState.unreadArtifactIds = new Set(["ticket-child"]);
     rerender(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -820,7 +820,7 @@ describe("epic sidebar selection mode", () => {
     ).not.toBeNull();
   });
 
-  it("keeps mark-all-read visible and disables it when no artifacts are unread", () => {
+  it("keeps mark-all-read hidden at rest and disables it when no artifacts are unread", () => {
     seedArtifactTree();
     testState.activePanelId = "artifacts";
 
@@ -828,13 +828,15 @@ describe("epic sidebar selection mode", () => {
       <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
     );
 
-    expect(
-      screen
-        .getByRole("button", {
-          name: "Mark all unread artifacts as read",
-        })
-        .matches(":disabled"),
-    ).toBe(true);
+    const markAllReadButton = screen.getByRole("button", {
+      name: "Mark all unread artifacts as read",
+    });
+
+    expect(markAllReadButton.matches(":disabled")).toBe(true);
+    expect(markAllReadButton.className).toContain("disabled:opacity-0");
+    expect(markAllReadButton.className).toContain(
+      "disabled:group-hover/panel-section:opacity-50",
+    );
 
     testState.unreadArtifactIds = new Set(["ticket-child"]);
     rerender(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-tree-shared.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-tree-shared.ts
@@ -27,9 +27,14 @@ export const EMPTY_PRE_ACK_LIST: ReadonlyArray<{
  * selection, collapse-all). Hidden until the `group/panel-section` is hovered
  * or a child is focused, so the header stays quiet at rest. The filter trigger
  * layers its own active-state override so an applied filter remains visible.
+ *
+ * Disabled shadcn buttons carry `disabled:opacity-50`, which would otherwise
+ * pin these controls visible at rest because the pseudo-class outranks the base
+ * `opacity-0`. The disabled overrides keep them hidden until the section is
+ * revealed, then show them dimmed to signal that they are unavailable.
  */
 export const PANEL_HEADER_ACTION_REVEAL_CLASS =
-  "opacity-0 transition-opacity focus-visible:opacity-100 group-hover/panel-section:opacity-100 group-focus-within/panel-section:opacity-100";
+  "opacity-0 transition-opacity disabled:opacity-0 focus-visible:opacity-100 group-hover/panel-section:opacity-100 group-focus-within/panel-section:opacity-100 disabled:group-hover/panel-section:opacity-50 disabled:group-focus-within/panel-section:opacity-50";
 
 /**
  * Reveal-on-hover styling for a tree row's inline "+" add control. Hidden at


### PR DESCRIPTION
## Summary
- keep disabled sidebar header actions hidden at rest so the artifact mark-as-read button follows the hover-only pattern
- reveal disabled header actions as dimmed when the panel section is hovered or focused
- add a regression test covering the mark-all-read button's disabled hidden-at-rest classes

## Testing
- `bun run test -- src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx` *(fails: existing `@testing-library/react` module resolution issue from `__tests__/test-browser-apis.ts`)*
- `bun run compile` *(fails: existing gui-app missing-module and unrelated type errors)*
- `bun run react-doctor` *(fails: existing unrelated diagnostics in settings/composer/layout files)*