### PR TITLE
Fix update flow status surfaces

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/updater.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/updater.test.ts
@@ -133,6 +133,7 @@ describe("desktop app updater", () => {
 
     expect(updater.getAppUpdateSnapshot()).toMatchObject({
       status: "error",
+      downloadProgress: null,
       errorMessage:
         "Traycer ran into a problem while updating. Please try again in a little while.",
       // The download was user-initiated, so its failure is manual-intent.

--- a/clients/desktop/src/electron-main/app/updater.ts
+++ b/clients/desktop/src/electron-main/app/updater.ts
@@ -489,19 +489,24 @@ function clampPercent(percent: number): number {
 
 function emitSnapshot(patch: AppUpdateSnapshotPatch): DesktopAppUpdateSnapshot {
   sequence += 1;
+  const status = patch.status ?? currentSnapshot.status;
+  let downloadProgress: number | null = null;
+  if (status === "downloading") {
+    downloadProgress =
+      patch.downloadProgress === undefined
+        ? currentSnapshot.downloadProgress
+        : patch.downloadProgress;
+  }
   currentSnapshot = {
     ...currentSnapshot,
     sequence,
-    status: patch.status ?? currentSnapshot.status,
+    status,
     installBlockedReason: currentInstallBlockedReason(),
     latestVersion:
       patch.latestVersion === undefined
         ? currentSnapshot.latestVersion
         : patch.latestVersion,
-    downloadProgress:
-      patch.downloadProgress === undefined
-        ? currentSnapshot.downloadProgress
-        : patch.downloadProgress,
+    downloadProgress,
     errorMessage:
       patch.errorMessage === undefined
         ? currentSnapshot.errorMessage

--- a/clients/desktop/src/electron-main/app/updater.ts
+++ b/clients/desktop/src/electron-main/app/updater.ts
@@ -492,10 +492,11 @@ function emitSnapshot(patch: AppUpdateSnapshotPatch): DesktopAppUpdateSnapshot {
   const status = patch.status ?? currentSnapshot.status;
   let downloadProgress: number | null = null;
   if (status === "downloading") {
-    downloadProgress =
+    const nextDownloadProgress =
       patch.downloadProgress === undefined
         ? currentSnapshot.downloadProgress
         : patch.downloadProgress;
+    downloadProgress = nextDownloadProgress ?? 0;
   }
   currentSnapshot = {
     ...currentSnapshot,

--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-channel.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-channel.test.ts
@@ -135,6 +135,7 @@ interface FakeBridge {
     (event: unknown, raw: unknown) => Promise<unknown>
   >;
   readonly fanOut: Mock;
+  readonly disposeFns: Array<() => void>;
   readonly options: {
     readonly host: {
       readonly reloadSnapshotFromDisk: Mock;
@@ -154,6 +155,7 @@ function makeBridge(): FakeBridge {
   return {
     handlers,
     fanOut: vi.fn(),
+    disposeFns: [],
     options: {
       host: {
         reloadSnapshotFromDisk: vi.fn(() => Promise.resolve(null)),

--- a/clients/desktop/src/electron-main/ipc/__tests__/registry-update-cache.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/registry-update-cache.test.ts
@@ -52,6 +52,40 @@ const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
 let workHome: string;
 
+interface RegistryProbeFixture {
+  readonly manifest: RegistryManifestFixture;
+  readonly platformKey: string;
+  readonly manifestUrl: string;
+}
+
+interface RegistryManifestFixture {
+  readonly schemaVersion: 1;
+  readonly generatedAt: string;
+  readonly latest: string;
+  readonly versions: readonly RegistryVersionFixture[];
+}
+
+interface RegistryVersionFixture {
+  readonly version: string;
+  readonly releasedAt: string;
+  readonly releaseNotesUrl: string;
+  readonly yanked: boolean;
+  readonly deprecationReason: string | null;
+  readonly requiredCliVersion: string | null;
+  readonly platforms: Readonly<Record<string, RegistryPlatformAssetFixture>>;
+}
+
+interface RegistryPlatformAssetFixture {
+  readonly available: boolean;
+  readonly unavailableReason: string | null;
+  readonly url: string;
+  readonly sizeBytes: number;
+  readonly sha256: string;
+  readonly signatureUrl: string;
+  readonly signatureAlgorithm: "minisign";
+  readonly publicKeyId: string;
+}
+
 beforeEach(() => {
   workHome = mkdtempSync(join(tmpdir(), "traycer-registry-cache-"));
   process.env.HOME = workHome;
@@ -102,9 +136,10 @@ function registryProbeResult(
   latest: string,
   assetAvailable: boolean,
   unavailableReason: string | null,
-): unknown {
+): RegistryProbeFixture {
   return {
     manifest: {
+      schemaVersion: 1,
       generatedAt: "2026-05-15T00:00:00Z",
       latest,
       versions: [registryVersion(latest, assetAvailable, unavailableReason)],
@@ -118,13 +153,14 @@ function registryVersion(
   version: string,
   assetAvailable: boolean,
   unavailableReason: string | null,
-): unknown {
+): RegistryVersionFixture {
   return {
     version,
     releasedAt: "2026-05-15T00:00:00Z",
     releaseNotesUrl: "https://example.invalid/release-notes",
     yanked: false,
     deprecationReason: null,
+    requiredCliVersion: null,
     platforms: {
       "darwin-arm64": {
         available: assetAvailable,
@@ -133,6 +169,7 @@ function registryVersion(
         sizeBytes: 1024,
         sha256: "abc",
         signatureUrl: "https://example.invalid/host.tar.gz.minisig",
+        signatureAlgorithm: "minisign",
         publicKeyId: "test-key",
       },
     },
@@ -175,17 +212,6 @@ function deferred<T>(): {
     resolveValue = resolve;
   });
   return { promise, resolve: resolveValue };
-}
-
-async function waitForCallCount(
-  mock: { readonly mock: { readonly calls: readonly unknown[] } },
-  count: number,
-): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    if (mock.mock.calls.length >= count) return;
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-  expect(mock.mock.calls.length).toBeGreaterThanOrEqual(count);
 }
 
 // Pre-Ticket 398e84f4 cache layout. Used to assert that an upgraded
@@ -366,10 +392,14 @@ describe("refreshRegistryUpdateState - launch-time probe", () => {
 
   it("serializes concurrent registry refreshes", async () => {
     writeInstallRecord("production", "1.4.1");
-    const firstProbe = deferred<unknown>();
+    const firstProbe = deferred<RegistryProbeFixture>();
+    const firstProbeStarted = deferred<void>();
     const probeSpy = vi
       .fn()
-      .mockReturnValueOnce(firstProbe.promise)
+      .mockImplementationOnce(() => {
+        firstProbeStarted.resolve(undefined);
+        return firstProbe.promise;
+      })
       .mockResolvedValueOnce(registryProbeResult("1.4.2", true, null));
     vi.doMock("../../cli/traycer-cli", () => ({
       runTraycerCliJson: probeSpy,
@@ -380,7 +410,7 @@ describe("refreshRegistryUpdateState - launch-time probe", () => {
       await import("../host-management-ipc");
 
     const first = refreshRegistryUpdateState({ force: true });
-    await waitForCallCount(probeSpy, 1);
+    await firstProbeStarted.promise;
     const second = refreshRegistryUpdateState({ force: true });
 
     expect(probeSpy).toHaveBeenCalledTimes(1);

--- a/clients/desktop/src/electron-main/ipc/__tests__/registry-update-cache.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/registry-update-cache.test.ts
@@ -98,6 +98,96 @@ function writeCache(opts: {
   );
 }
 
+function registryProbeResult(
+  latest: string,
+  assetAvailable: boolean,
+  unavailableReason: string | null,
+): unknown {
+  return {
+    manifest: {
+      generatedAt: "2026-05-15T00:00:00Z",
+      latest,
+      versions: [registryVersion(latest, assetAvailable, unavailableReason)],
+    },
+    platformKey: "darwin-arm64",
+    manifestUrl: "https://example.invalid/versions.json",
+  };
+}
+
+function registryVersion(
+  version: string,
+  assetAvailable: boolean,
+  unavailableReason: string | null,
+): unknown {
+  return {
+    version,
+    releasedAt: "2026-05-15T00:00:00Z",
+    releaseNotesUrl: "https://example.invalid/release-notes",
+    yanked: false,
+    deprecationReason: null,
+    platforms: {
+      "darwin-arm64": {
+        available: assetAvailable,
+        unavailableReason,
+        url: "https://example.invalid/host.tar.gz",
+        sizeBytes: 1024,
+        sha256: "abc",
+        signatureUrl: "https://example.invalid/host.tar.gz.minisig",
+        publicKeyId: "test-key",
+      },
+    },
+  };
+}
+
+function writeInstallRecord(
+  environment: "production" | "dev",
+  version: string,
+): void {
+  const dir =
+    environment === "dev"
+      ? join(workHome, ".traycer", "host", "dev", "install")
+      : join(workHome, ".traycer", "host", "install");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "install.json"),
+    JSON.stringify({
+      version,
+      installedAt: "2026-05-15T00:00:00Z",
+      executablePath: `/tmp/traycer/${version}/host`,
+      source: { kind: "registry", value: version },
+      archiveSha256: "abc",
+      signatureKeyId: "test-key",
+      sizeBytes: 1024,
+      signatureVerifiedAt: "2026-05-15T00:00:00Z",
+      platform: "darwin",
+      arch: "arm64",
+    }),
+    "utf8",
+  );
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+} {
+  let resolveValue: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveValue = resolve;
+  });
+  return { promise, resolve: resolveValue };
+}
+
+async function waitForCallCount(
+  mock: { readonly mock: { readonly calls: readonly unknown[] } },
+  count: number,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (mock.mock.calls.length >= count) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  expect(mock.mock.calls.length).toBeGreaterThanOrEqual(count);
+}
+
 // Pre-Ticket 398e84f4 cache layout. Used to assert that an upgraded
 // Desktop ignores the legacy unscoped file rather than projecting it
 // through as either environment's state.
@@ -125,16 +215,85 @@ describe("refreshRegistryUpdateState - launch-time probe", () => {
     expect(state.installedVersion).toBe("1.4.1");
   });
 
-  it("re-probes when force is true even with a fresh cache", async () => {
-    const probeSpy = vi.fn().mockResolvedValue({
-      manifest: {
-        generatedAt: "2026-05-15T00:00:00Z",
-        latest: "1.4.3",
-        versions: [],
-      },
-      platformKey: "darwin-arm64",
-      manifestUrl: "https://example.invalid/versions.json",
+  it("notifies registry update listeners when state is read from cache", async () => {
+    vi.doMock("../../cli/traycer-cli", () => ({
+      runTraycerCliJson: vi.fn(),
+      streamTraycerCliJson: vi.fn(),
+      TraycerCliError: class extends Error {},
+    }));
+    writeCache({
+      checkedAt: new Date().toISOString(),
+      latestVersion: "1.4.2",
+      installedVersion: "1.4.1",
+      reachable: true,
+      errorMessage: null,
     });
+    const { refreshRegistryUpdateState, onHostRegistryUpdateStateChange } =
+      await import("../host-management-ipc");
+    const listener = vi.fn();
+    const unsubscribe = onHostRegistryUpdateStateChange(listener);
+
+    await refreshRegistryUpdateState({ force: false });
+    unsubscribe();
+
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        latestVersion: "1.4.2",
+        installedVersion: "1.4.1",
+        updateAvailable: true,
+      }),
+    );
+  });
+
+  it("keeps refresh successful when a registry update listener throws", async () => {
+    vi.doMock("../../cli/traycer-cli", () => ({
+      runTraycerCliJson: vi.fn(),
+      streamTraycerCliJson: vi.fn(),
+      TraycerCliError: class extends Error {},
+    }));
+    writeCache({
+      checkedAt: new Date().toISOString(),
+      latestVersion: "1.4.2",
+      installedVersion: "1.4.1",
+      reachable: true,
+      errorMessage: null,
+    });
+    const { refreshRegistryUpdateState, onHostRegistryUpdateStateChange } =
+      await import("../host-management-ipc");
+    const throwingListener = vi.fn(() => {
+      throw new Error("listener failed");
+    });
+    const succeedingListener = vi.fn();
+    const unsubscribeThrowing =
+      onHostRegistryUpdateStateChange(throwingListener);
+    const unsubscribeSucceeding =
+      onHostRegistryUpdateStateChange(succeedingListener);
+
+    const state = await refreshRegistryUpdateState({ force: false });
+    unsubscribeThrowing();
+    unsubscribeSucceeding();
+
+    expect(state).toEqual(
+      expect.objectContaining({
+        latestVersion: "1.4.2",
+        installedVersion: "1.4.1",
+        updateAvailable: true,
+      }),
+    );
+    expect(throwingListener).toHaveBeenCalledOnce();
+    expect(succeedingListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        latestVersion: "1.4.2",
+        installedVersion: "1.4.1",
+        updateAvailable: true,
+      }),
+    );
+  });
+
+  it("re-probes when force is true even with a fresh cache", async () => {
+    const probeSpy = vi
+      .fn()
+      .mockResolvedValue(registryProbeResult("1.4.3", true, null));
     vi.doMock("../../cli/traycer-cli", () => ({
       runTraycerCliJson: probeSpy,
       streamTraycerCliJson: vi.fn(),
@@ -155,15 +314,9 @@ describe("refreshRegistryUpdateState - launch-time probe", () => {
   });
 
   it("re-probes when cache is stale (>= 24h)", async () => {
-    const probeSpy = vi.fn().mockResolvedValue({
-      manifest: {
-        generatedAt: "2026-05-15T00:00:00Z",
-        latest: "1.4.3",
-        versions: [],
-      },
-      platformKey: "darwin-arm64",
-      manifestUrl: "https://example.invalid/versions.json",
-    });
+    const probeSpy = vi
+      .fn()
+      .mockResolvedValue(registryProbeResult("1.4.3", true, null));
     vi.doMock("../../cli/traycer-cli", () => ({
       runTraycerCliJson: probeSpy,
       streamTraycerCliJson: vi.fn(),
@@ -183,6 +336,58 @@ describe("refreshRegistryUpdateState - launch-time probe", () => {
     const state = await refreshRegistryUpdateState({ force: false });
     expect(probeSpy).toHaveBeenCalledOnce();
     expect(state.latestVersion).toBe("1.4.3");
+  });
+
+  it("does not advertise latest when the platform asset is unavailable", async () => {
+    writeInstallRecord("production", "1.4.1");
+    const probeSpy = vi
+      .fn()
+      .mockResolvedValue(
+        registryProbeResult(
+          "1.4.3",
+          false,
+          "Build unavailable for this platform.",
+        ),
+      );
+    vi.doMock("../../cli/traycer-cli", () => ({
+      runTraycerCliJson: probeSpy,
+      streamTraycerCliJson: vi.fn(),
+      TraycerCliError: class extends Error {},
+    }));
+
+    const { refreshRegistryUpdateState } =
+      await import("../host-management-ipc");
+    const state = await refreshRegistryUpdateState({ force: true });
+
+    expect(state.latestVersion).toBeNull();
+    expect(state.installedVersion).toBe("1.4.1");
+    expect(state.updateAvailable).toBe(false);
+  });
+
+  it("serializes concurrent registry refreshes", async () => {
+    writeInstallRecord("production", "1.4.1");
+    const firstProbe = deferred<unknown>();
+    const probeSpy = vi
+      .fn()
+      .mockReturnValueOnce(firstProbe.promise)
+      .mockResolvedValueOnce(registryProbeResult("1.4.2", true, null));
+    vi.doMock("../../cli/traycer-cli", () => ({
+      runTraycerCliJson: probeSpy,
+      streamTraycerCliJson: vi.fn(),
+      TraycerCliError: class extends Error {},
+    }));
+    const { refreshRegistryUpdateState } =
+      await import("../host-management-ipc");
+
+    const first = refreshRegistryUpdateState({ force: true });
+    await waitForCallCount(probeSpy, 1);
+    const second = refreshRegistryUpdateState({ force: true });
+
+    expect(probeSpy).toHaveBeenCalledTimes(1);
+    firstProbe.resolve(registryProbeResult("1.4.2", true, null));
+    await first;
+    await second;
+    expect(probeSpy).toHaveBeenCalledTimes(2);
   });
 
   it("treats registry failures as non-blocking and records reachable=false", async () => {
@@ -294,15 +499,9 @@ describe("refreshRegistryUpdateState - launch-time probe", () => {
   });
 
   it("re-probes a fresh failed cache instead of replaying a stale error", async () => {
-    const probeSpy = vi.fn().mockResolvedValue({
-      manifest: {
-        generatedAt: "2026-05-15T00:00:00Z",
-        latest: "1.4.3",
-        versions: [],
-      },
-      platformKey: "darwin-arm64",
-      manifestUrl: "https://example.invalid/versions.json",
-    });
+    const probeSpy = vi
+      .fn()
+      .mockResolvedValue(registryProbeResult("1.4.3", true, null));
     vi.doMock("../../cli/traycer-cli", () => ({
       runTraycerCliJson: probeSpy,
       streamTraycerCliJson: vi.fn(),
@@ -397,15 +596,9 @@ describe("refreshRegistryUpdateState - environment-scoped cache", () => {
   });
 
   it("dev launch ignores stale prod cache and re-probes when no dev cache exists", async () => {
-    const probeSpy = vi.fn().mockResolvedValue({
-      manifest: {
-        generatedAt: "2026-05-15T00:00:00Z",
-        latest: "DEV-2.0.0",
-        versions: [],
-      },
-      platformKey: "darwin-arm64",
-      manifestUrl: "https://example.invalid/versions.json",
-    });
+    const probeSpy = vi
+      .fn()
+      .mockResolvedValue(registryProbeResult("DEV-2.0.0", true, null));
     vi.doMock("../../cli/traycer-cli", () => ({
       runTraycerCliJson: probeSpy,
       streamTraycerCliJson: vi.fn(),
@@ -439,15 +632,9 @@ describe("refreshRegistryUpdateState - environment-scoped cache", () => {
   });
 
   it("prod launch ignores stale dev cache and re-probes when no prod cache exists", async () => {
-    const probeSpy = vi.fn().mockResolvedValue({
-      manifest: {
-        generatedAt: "2026-05-15T00:00:00Z",
-        latest: "PROD-1.4.2",
-        versions: [],
-      },
-      platformKey: "darwin-arm64",
-      manifestUrl: "https://example.invalid/versions.json",
-    });
+    const probeSpy = vi
+      .fn()
+      .mockResolvedValue(registryProbeResult("PROD-1.4.2", true, null));
     vi.doMock("../../cli/traycer-cli", () => ({
       runTraycerCliJson: probeSpy,
       streamTraycerCliJson: vi.fn(),
@@ -476,15 +663,9 @@ describe("refreshRegistryUpdateState - environment-scoped cache", () => {
   });
 
   it("does not allow a environment-scoped file whose body claims the other environment to leak through (defence in depth)", async () => {
-    const probeSpy = vi.fn().mockResolvedValue({
-      manifest: {
-        generatedAt: "2026-05-15T00:00:00Z",
-        latest: "PROD-1.4.2",
-        versions: [],
-      },
-      platformKey: "darwin-arm64",
-      manifestUrl: "https://example.invalid/versions.json",
-    });
+    const probeSpy = vi
+      .fn()
+      .mockResolvedValue(registryProbeResult("PROD-1.4.2", true, null));
     vi.doMock("../../cli/traycer-cli", () => ({
       runTraycerCliJson: probeSpy,
       streamTraycerCliJson: vi.fn(),

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -52,6 +52,27 @@ import type { RunnerIpcBridge } from "./runner-ipc-bridge";
 
 const LONG_OP_TIMEOUT_MS = 10 * 60_000;
 const REGISTRY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+type HostRegistryUpdateStateListener = (state: HostRegistryUpdateState) => void;
+const registryUpdateStateListeners = new Set<HostRegistryUpdateStateListener>();
+
+export function onHostRegistryUpdateStateChange(
+  listener: HostRegistryUpdateStateListener,
+): () => void {
+  registryUpdateStateListeners.add(listener);
+  return () => {
+    registryUpdateStateListeners.delete(listener);
+  };
+}
+
+function emitHostRegistryUpdateState(state: HostRegistryUpdateState): void {
+  for (const listener of registryUpdateStateListeners) {
+    try {
+      listener(state);
+    } catch (err) {
+      log.warn("[host-management] registry update listener failed", err);
+    }
+  }
+}
 
 /**
  * Active host environment for this Desktop process. Set at boot via
@@ -452,6 +473,8 @@ interface RegistryUpdateCacheFile {
   readonly errorMessage: string | null;
 }
 
+let registryRefreshQueue: Promise<void> = Promise.resolve();
+
 function desktopCacheDir(): string {
   return join(homedir(), ".traycer", "desktop");
 }
@@ -599,20 +622,22 @@ function isVerifyDisabledForBuild(err: unknown): boolean {
 
 async function probeRegistry(): Promise<RegistryUpdateCacheFile> {
   const checkedAt = new Date().toISOString();
-  const installed = await readInstalledHostRecord();
-  const installedVersion = installed?.version ?? null;
   try {
     const snapshot = projectAvailableSnapshot(
       await runTraycerCliJson<unknown>(["host", "available", "--json"]),
     );
+    const installed = await readInstalledHostRecord();
+    const installedVersion = installed?.version ?? null;
     return {
       checkedAt,
-      latestVersion: snapshot.latest === "" ? null : snapshot.latest,
+      latestVersion: availableLatestVersion(snapshot),
       installedVersion,
       reachable: true,
       errorMessage: null,
     };
   } catch (err) {
+    const installed = await readInstalledHostRecord();
+    const installedVersion = installed?.version ?? null;
     if (isVerifyDisabledForBuild(err)) {
       // Pin `latestVersion = installedVersion` so `buildUpdateState`'s
       // diff yields `updateAvailable: false` - the Updates row reads
@@ -642,6 +667,24 @@ async function probeRegistry(): Promise<RegistryUpdateCacheFile> {
   }
 }
 
+function availableLatestVersion(
+  snapshot: HostAvailableSnapshot,
+): string | null {
+  if (snapshot.latest.length === 0) {
+    return null;
+  }
+  const latest = snapshot.versions.find(
+    (entry) => entry.version === snapshot.latest,
+  );
+  if (latest === undefined) {
+    return null;
+  }
+  if (latest.platformAsset === null || !latest.platformAsset.available) {
+    return null;
+  }
+  return latest.version;
+}
+
 // Empty `HostAvailableSnapshot` used by handlers that need to render a
 // "no versions" state without inventing a failure (e.g. dev builds where
 // the registry probe is intentionally disabled).
@@ -663,16 +706,34 @@ function emptyAvailableSnapshot(): HostAvailableSnapshot {
 export async function refreshRegistryUpdateState(opts: {
   readonly force: boolean;
 }): Promise<HostRegistryUpdateState> {
+  const run = registryRefreshQueue.then(
+    () => refreshRegistryUpdateStateSerial(opts),
+    () => refreshRegistryUpdateStateSerial(opts),
+  );
+  registryRefreshQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+async function refreshRegistryUpdateStateSerial(opts: {
+  readonly force: boolean;
+}): Promise<HostRegistryUpdateState> {
   const cache = await readRegistryCache();
   if (!opts.force && cache !== null && cache.reachable) {
     const ageMs = Date.now() - Date.parse(cache.checkedAt);
     if (Number.isFinite(ageMs) && ageMs >= 0 && ageMs < REGISTRY_CACHE_TTL_MS) {
-      return buildUpdateState(cache);
+      const state = buildUpdateState(cache);
+      emitHostRegistryUpdateState(state);
+      return state;
     }
   }
   const fresh = await probeRegistry();
   await writeRegistryCache(fresh);
-  return buildUpdateState(fresh);
+  const state = buildUpdateState(fresh);
+  emitHostRegistryUpdateState(state);
+  return state;
 }
 
 function projectUninstallResult(
@@ -805,6 +866,12 @@ export function narrowPostSwapAction(raw: unknown): PostSwapAction {
 }
 
 export function registerHostManagementIpc(bridge: RunnerIpcBridge): void {
+  bridge.disposeFns.push(
+    onHostRegistryUpdateStateChange((state) => {
+      bridge.fanOut(RunnerHostEvent.hostRegistryUpdateStateChange, state);
+    }),
+  );
+
   bridge.handleInvoke(
     RunnerHostInvoke.traycerHostInstall,
     async (_event, raw: unknown) => {

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -16,6 +16,7 @@ import { HostLifecycle, type HostStartupError } from "../host/host-lifecycle";
 import type { HostRegistryUpdateState } from "../../ipc-contracts/host-management-types";
 import { getHostFsLayout, labelForEnvironment } from "../host/host-paths";
 import {
+  onHostRegistryUpdateStateChange,
   refreshRegistryUpdateState,
   setActiveEnvironment,
 } from "../ipc/host-management-ipc";
@@ -399,6 +400,11 @@ function applyHostUpdateMenuState(
 // never blocks first paint.
 function runDeferred(state: BootState, services: AppServices): void {
   startRendererMemorySampler();
+  state.bridge?.disposeFns.push(
+    onHostRegistryUpdateStateChange((result) => {
+      applyHostUpdateMenuState(services.menu, result);
+    }),
+  );
 
   // Captured (not just fire-and-forget) so the host auto-update idle gate can
   // wait for discovery to settle before trusting the host snapshot - `timed`

--- a/clients/desktop/src/electron-preload/host-management-bridge.ts
+++ b/clients/desktop/src/electron-preload/host-management-bridge.ts
@@ -63,6 +63,9 @@ export interface HostManagementBridgeSurface {
   registryCheck(input: {
     readonly force: boolean;
   }): Promise<HostRegistryUpdateState>;
+  onRegistryUpdateState(handler: (state: HostRegistryUpdateState) => void): {
+    dispose: () => void;
+  };
   freePortAndRestart(
     input: FreePortAndRestartInput,
   ): Promise<FreePortAndRestartInput>;
@@ -183,6 +186,20 @@ export function buildHostManagementBridge(): HostManagementBridgeSurface {
       ipcRenderer.invoke(RunnerHostInvoke.traycerRegistryCheck, {
         force,
       }) as Promise<HostRegistryUpdateState>,
+    onRegistryUpdateState(handler) {
+      const listener = (_event: IpcRendererEvent, payload: unknown): void => {
+        if (!isHostRegistryUpdateState(payload)) return;
+        handler(payload);
+      };
+      ipcRenderer.on(RunnerHostEvent.hostRegistryUpdateStateChange, listener);
+      return {
+        dispose: () =>
+          ipcRenderer.removeListener(
+            RunnerHostEvent.hostRegistryUpdateStateChange,
+            listener,
+          ),
+      };
+    },
     freePortAndRestart: (input) =>
       ipcRenderer.invoke(
         RunnerHostInvoke.traycerFreePortAndRestart,
@@ -201,6 +218,25 @@ export function buildHostManagementBridge(): HostManagementBridgeSurface {
         customName,
       }) as Promise<HostNameSettings>,
   };
+}
+
+function isHostRegistryUpdateState(
+  value: unknown,
+): value is HostRegistryUpdateState {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  const checkedAt = candidate.checkedAt;
+  const latestVersion = candidate.latestVersion;
+  const installedVersion = candidate.installedVersion;
+  const errorMessage = candidate.errorMessage;
+  return (
+    (typeof checkedAt === "string" || checkedAt === null) &&
+    (typeof latestVersion === "string" || latestVersion === null) &&
+    (typeof installedVersion === "string" || installedVersion === null) &&
+    typeof candidate.updateAvailable === "boolean" &&
+    typeof candidate.reachable === "boolean" &&
+    (typeof errorMessage === "string" || errorMessage === null)
+  );
 }
 
 /**

--- a/clients/desktop/src/ipc-contracts/ipc-channels.ts
+++ b/clients/desktop/src/ipc-contracts/ipc-channels.ts
@@ -209,6 +209,11 @@ export const RunnerHostEvent = {
   // `HostTrayCommandListener`. Payloads match the shared
   // `HostTrayCommand` union.
   hostTrayCommand: "runnerHost:event:host:trayCommand",
+  // Main-process registry refreshes (launch probe, auto-update reconcile,
+  // renderer forced checks) fan out here so already-mounted renderer update
+  // surfaces can keep their TanStack Query cache in lockstep.
+  hostRegistryUpdateStateChange:
+    "runnerHost:event:host:registryUpdateStateChange",
 } as const;
 
 /**

--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
   AuthTokenValidationResult,
+  HostRegistryUpdateState,
   LocalHostSnapshot,
   TrayEpic,
   TrayIndicatorState,
@@ -684,6 +685,25 @@ describe("DesktopRunnerHost.onLocalHostChange", () => {
     // The fake bridge increments its internal counter - observable via a
     // subsequent respawn not throwing and the await resolving.
     expect(host.authnBaseUrl).toBe("http://localhost:5005");
+  });
+
+  it("passes host registry update subscriptions through to host management", () => {
+    const fake = buildFakeBridge(null);
+    const disposer = { dispose: vi.fn() };
+    const onRegistryUpdateState = vi.fn(
+      (_handler: (state: HostRegistryUpdateState) => void) => disposer,
+    );
+    fake.bridge.hostManagement.onRegistryUpdateState = onRegistryUpdateState;
+    const host = new DesktopRunnerHost({
+      bridge: fake.bridge,
+      signInUrl: "https://auth.example.invalid/sign-in",
+    });
+    const handler = vi.fn();
+
+    const subscription = host.hostRegistryUpdates.onChange(handler);
+
+    expect(onRegistryUpdateState).toHaveBeenCalledWith(handler);
+    expect(subscription).toBe(disposer);
   });
 
   it("forwards workspace folder picking to the bridge", async () => {

--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -439,6 +439,7 @@ function buildFakeBridge(
         reachable: false,
         errorMessage: null,
       }),
+      onRegistryUpdateState: () => ({ dispose: () => undefined }),
       freePortAndRestart: async (input) => input,
       cliManifest: async () => null,
       getHostName: async () => ({

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -231,6 +231,9 @@ export interface DesktopHostManagementBridge {
   registryCheck(input: {
     readonly force: boolean;
   }): Promise<HostRegistryUpdateState>;
+  onRegistryUpdateState(handler: (state: HostRegistryUpdateState) => void): {
+    dispose: () => void;
+  };
   freePortAndRestart(
     input: FreePortAndRestartInput,
   ): Promise<FreePortAndRestartInput>;
@@ -243,6 +246,12 @@ export interface DesktopHostManagementBridge {
 
 export interface DesktopHostTrayBridge {
   onCommand(handler: (command: HostTrayCommand) => void): {
+    dispose: () => void;
+  };
+}
+
+export interface DesktopHostRegistryUpdatesBridge {
+  onChange(handler: (state: HostRegistryUpdateState) => void): {
     dispose: () => void;
   };
 }
@@ -497,6 +506,7 @@ export class DesktopRunnerHost implements IRunnerHost {
   readonly power: DesktopPowerBridge;
   readonly hostManagement: IHostManagement;
   readonly hostTray: IHostTray;
+  readonly hostRegistryUpdates: DesktopHostRegistryUpdatesBridge;
   readonly deviceFlow: IDeviceFlowHost;
 
   private readonly bridge: DesktopPreloadBridge;
@@ -645,6 +655,10 @@ export class DesktopRunnerHost implements IRunnerHost {
       cliManifest: () => managementBridge.cliManifest(),
       getHostName: () => managementBridge.getHostName(),
       setHostName: (input) => managementBridge.setHostName(input),
+    };
+    this.hostRegistryUpdates = {
+      onChange: (handler) =>
+        toDisposable(managementBridge.onRegistryUpdateState(handler)),
     };
     this.hostTray = {
       onCommand: (handler) =>

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -657,8 +657,7 @@ export class DesktopRunnerHost implements IRunnerHost {
       setHostName: (input) => managementBridge.setHostName(input),
     };
     this.hostRegistryUpdates = {
-      onChange: (handler) =>
-        toDisposable(managementBridge.onRegistryUpdateState(handler)),
+      onChange: (handler) => managementBridge.onRegistryUpdateState(handler),
     };
     this.hostTray = {
       onCommand: (handler) =>

--- a/clients/gui-app/src/components/home/__tests__/host-update-banner.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/host-update-banner.test.tsx
@@ -309,9 +309,9 @@ describe("HostUpdateBanner (Flow 6)", () => {
     });
   });
 
-  it("renders nothing when hostManagement is null (mobile/web)", async () => {
+  it("renders nothing when hostManagement is null (mobile/web)", () => {
     renderBanner(makeHost(null));
-    await new Promise((r) => setTimeout(r, 20));
+
     expect(queryHostUpdateBanner()).toBeNull();
   });
 

--- a/clients/gui-app/src/components/home/__tests__/host-update-banner.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/host-update-banner.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -8,6 +9,7 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HostUpdateBanner } from "@/components/home/host-update-banner";
+import { HostRegistryUpdateListener } from "@/components/layout/bridges/host-registry-update-listener";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import {
   HOST_UPDATE_BANNER_SNOOZE_MS,
@@ -20,6 +22,7 @@ import type {
   IRunnerHost,
 } from "@traycer-clients/shared/platform/runner-host";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import type { DesktopHostRegistryUpdatesBridge } from "@/lib/windows/types";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -118,6 +121,57 @@ function renderBanner(host: IRunnerHost): QueryClient {
   return queryClient;
 }
 
+function renderBannerWithRegistryListener(host: IRunnerHost): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RunnerHostProvider runnerHost={host}>
+        <HostRegistryUpdateListener />
+        <HostUpdateBanner className={undefined} />
+      </RunnerHostProvider>
+    </QueryClientProvider>,
+  );
+  return queryClient;
+}
+
+function createRegistryUpdatesBridge(): {
+  readonly bridge: DesktopHostRegistryUpdatesBridge;
+  readonly emit: (state: HostRegistryUpdateState) => void;
+} {
+  const handlers = new Set<(state: HostRegistryUpdateState) => void>();
+  return {
+    bridge: {
+      onChange: (handler) => {
+        handlers.add(handler);
+        return {
+          dispose: () => {
+            handlers.delete(handler);
+          },
+        };
+      },
+    },
+    emit: (state) => {
+      for (const handler of handlers) {
+        handler(state);
+      }
+    },
+  };
+}
+
+function findHostUpdateBanner(): Promise<HTMLElement> {
+  return screen.findByRole("status", {
+    name: /Traycer host update available: 1\.4\.2/i,
+  });
+}
+
+function queryHostUpdateBanner(): HTMLElement | null {
+  return screen.queryByRole("status", {
+    name: /Traycer host update available/i,
+  });
+}
+
 describe("HostUpdateBanner (Flow 6)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -142,7 +196,7 @@ describe("HostUpdateBanner (Flow 6)", () => {
         }),
     });
     renderBanner(makeHost(management));
-    expect(await screen.findByTestId("host-update-banner")).toBeTruthy();
+    expect(await findHostUpdateBanner()).toBeTruthy();
     expect(screen.getByText(/1\.4\.2/)).toBeTruthy();
     expect(screen.getByRole("button", { name: /Install/i })).toBeTruthy();
   });
@@ -161,7 +215,7 @@ describe("HostUpdateBanner (Flow 6)", () => {
     });
     renderBanner(makeHost(management));
     await new Promise((r) => setTimeout(r, 20));
-    expect(screen.queryByTestId("host-update-banner")).toBeNull();
+    expect(queryHostUpdateBanner()).toBeNull();
   });
 
   it("stays hidden when the registry probe was not reachable", async () => {
@@ -178,7 +232,7 @@ describe("HostUpdateBanner (Flow 6)", () => {
     });
     renderBanner(makeHost(management));
     await new Promise((r) => setTimeout(r, 20));
-    expect(screen.queryByTestId("host-update-banner")).toBeNull();
+    expect(queryHostUpdateBanner()).toBeNull();
   });
 
   it("invokes updateHost when Install is clicked and invalidates the registry cache", async () => {
@@ -220,10 +274,45 @@ describe("HostUpdateBanner (Flow 6)", () => {
     });
   });
 
+  it("hides when the desktop registry update event clears availability", async () => {
+    const updates = createRegistryUpdatesBridge();
+    const management = makeManagement({
+      registryCheck: () =>
+        Promise.resolve<HostRegistryUpdateState>({
+          checkedAt: "2026-05-15T00:00:00Z",
+          latestVersion: "1.4.2",
+          installedVersion: "1.4.1",
+          updateAvailable: true,
+          reachable: true,
+          errorMessage: null,
+        }),
+    });
+    const host = Object.assign(makeHost(management), {
+      hostRegistryUpdates: updates.bridge,
+    });
+    renderBannerWithRegistryListener(host);
+    expect(await findHostUpdateBanner()).toBeTruthy();
+
+    act(() => {
+      updates.emit({
+        checkedAt: "2026-05-15T00:01:00Z",
+        latestVersion: "1.4.2",
+        installedVersion: "1.4.2",
+        updateAvailable: false,
+        reachable: true,
+        errorMessage: null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryHostUpdateBanner()).toBeNull();
+    });
+  });
+
   it("renders nothing when hostManagement is null (mobile/web)", async () => {
     renderBanner(makeHost(null));
     await new Promise((r) => setTimeout(r, 20));
-    expect(screen.queryByTestId("host-update-banner")).toBeNull();
+    expect(queryHostUpdateBanner()).toBeNull();
   });
 
   // Snooze flow - keyed to the persistent `useHostUpdateBannerStore`.
@@ -242,11 +331,11 @@ describe("HostUpdateBanner (Flow 6)", () => {
         }),
     });
     renderBanner(makeHost(management));
-    expect(await screen.findByTestId("host-update-banner")).toBeTruthy();
-    const snoozeBtn = screen.getByTestId("host-update-banner-snooze");
+    expect(await findHostUpdateBanner()).toBeTruthy();
+    const snoozeBtn = screen.getByRole("button", { name: /Remind me later/i });
     fireEvent.click(snoozeBtn);
     await waitFor(() => {
-      expect(screen.queryByTestId("host-update-banner")).toBeNull();
+      expect(queryHostUpdateBanner()).toBeNull();
     });
     // Persisted store should now hold an entry for the snoozed version.
     const snoozes = useHostUpdateBannerStore.getState().snoozeUntilByVersion;
@@ -274,7 +363,7 @@ describe("HostUpdateBanner (Flow 6)", () => {
     });
     renderBanner(makeHost(management));
     await new Promise((r) => setTimeout(r, 20));
-    expect(screen.queryByTestId("host-update-banner")).toBeNull();
+    expect(queryHostUpdateBanner()).toBeNull();
   });
 
   it("re-appears when the snooze entry has expired (snoozeUntil < now)", async () => {
@@ -296,7 +385,7 @@ describe("HostUpdateBanner (Flow 6)", () => {
         }),
     });
     renderBanner(makeHost(management));
-    expect(await screen.findByTestId("host-update-banner")).toBeTruthy();
+    expect(await findHostUpdateBanner()).toBeTruthy();
   });
 
   it("re-arms when latestVersion advances past the snoozed version (snooze is per-version)", async () => {
@@ -318,7 +407,7 @@ describe("HostUpdateBanner (Flow 6)", () => {
         }),
     });
     renderBanner(makeHost(management));
-    expect(await screen.findByTestId("host-update-banner")).toBeTruthy();
+    expect(await findHostUpdateBanner()).toBeTruthy();
   });
 
   it("clears the snooze for the installed version after a successful install via the Install button", async () => {

--- a/clients/gui-app/src/components/home/host-update-banner.tsx
+++ b/clients/gui-app/src/components/home/host-update-banner.tsx
@@ -136,6 +136,7 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
 
   return (
     <output
+      aria-label={`Traycer host update available: ${latestVersion}`}
       data-testid="host-update-banner"
       className={cn(
         "flex items-center gap-2 rounded-md border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-ui-sm text-sky-950 dark:text-sky-100",

--- a/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
@@ -325,7 +325,11 @@ describe("desktop app update UI", () => {
         .getByRole("button", { name: /Restart now/i })
         .hasAttribute("disabled"),
     ).toBe(true);
-    expect(screen.getByTestId("restart-update-confirm-spinner")).toBeTruthy();
+    expect(
+      screen.getByRole("status", {
+        name: /Restart request in progress/i,
+      }),
+    ).toBeTruthy();
     rerender(
       <RestartUpdateDialog
         open={false}

--- a/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
@@ -307,17 +307,52 @@ describe("desktop app update UI", () => {
 
   it("runs the restart action only after the modal is confirmed", () => {
     const onConfirm = vi.fn();
-    render(
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
       <RestartUpdateDialog
         open
-        onOpenChange={() => undefined}
+        onOpenChange={onOpenChange}
         latestVersion="1.2.3"
         onConfirm={onConfirm}
       />,
     );
 
-    fireEvent.click(screen.getByTestId("restart-update-confirm"));
+    fireEvent.click(screen.getByRole("button", { name: /Restart now/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Restart now/i }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(
+      screen
+        .getByRole("button", { name: /Restart now/i })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(screen.getByTestId("restart-update-confirm-spinner")).toBeTruthy();
+    rerender(
+      <RestartUpdateDialog
+        open={false}
+        onOpenChange={onOpenChange}
+        latestVersion="1.2.3"
+        onConfirm={onConfirm}
+      />,
+    );
+    rerender(
+      <RestartUpdateDialog
+        open
+        onOpenChange={onOpenChange}
+        latestVersion="1.2.3"
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Later" }).hasAttribute("disabled"),
+    ).toBe(false);
+    expect(
+      screen
+        .getByRole("button", { name: /Restart now/i })
+        .hasAttribute("disabled"),
+    ).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: /Restart now/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(2);
   });
 
   it("shares one desktop update subscription across update UI consumers", async () => {
@@ -372,7 +407,7 @@ describe("desktop app update UI", () => {
     await waitFor(() => {
       expect(toastMock.info).toHaveBeenCalledWith(
         "Checking for Traycer updates...",
-        { id: "traycer-app-update" },
+        { id: "traycer-app-update", description: null, duration: 4000 },
       );
     });
 
@@ -472,6 +507,40 @@ describe("desktop app update UI", () => {
         expect.objectContaining({
           id: "traycer-app-update",
           description: "50% complete",
+        }),
+      );
+    });
+  });
+
+  it("clears stale download progress copy when the update becomes ready", async () => {
+    const bridge = new FakeAppUpdatesBridge(IDLE_SNAPSHOT);
+    renderWithHost(<AppUpdateToastController />, bridge);
+    await waitFor(() => {
+      expect(bridge.subscriptionCount()).toBe(1);
+    });
+
+    act(() => {
+      bridge.emit(downloadingSnapshot(1, 0));
+    });
+    await waitFor(() => {
+      expect(toastMock.loading).toHaveBeenCalledWith(
+        "Downloading update…",
+        expect.objectContaining({
+          id: "traycer-app-update",
+          description: "0% complete",
+        }),
+      );
+    });
+
+    act(() => {
+      bridge.emit(readySnapshot(2));
+    });
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          id: "traycer-app-update",
+          description: null,
         }),
       );
     });

--- a/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@/lib/windows/types";
 
 const APP_UPDATE_TOAST_ID = "traycer-app-update";
+const APP_UPDATE_TRANSIENT_TOAST_DURATION_MS = 4000;
 
 export function AppUpdateToastController(): null {
   const { bridge, snapshot } = useDesktopAppUpdates();
@@ -70,6 +71,8 @@ function showAppUpdateToast(
       if (snapshot.lastCheckIntent === "manual") {
         toast.info("Checking for Traycer updates...", {
           id: APP_UPDATE_TOAST_ID,
+          description: null,
+          duration: APP_UPDATE_TRANSIENT_TOAST_DURATION_MS,
         });
       }
       return;
@@ -82,6 +85,7 @@ function showAppUpdateToast(
         toast("Update available", {
           id: APP_UPDATE_TOAST_ID,
           description: snapshot.installBlockedReason,
+          duration: APP_UPDATE_TRANSIENT_TOAST_DURATION_MS,
         });
         return;
       }
@@ -96,6 +100,7 @@ function showAppUpdateToast(
         />,
         {
           id: APP_UPDATE_TOAST_ID,
+          description: null,
           duration: Infinity,
         },
       );
@@ -120,6 +125,7 @@ function showAppUpdateToast(
         />,
         {
           id: APP_UPDATE_TOAST_ID,
+          description: null,
           duration: Infinity,
         },
       );
@@ -141,13 +147,16 @@ function showAppUpdateToast(
         id: APP_UPDATE_TOAST_ID,
         description:
           snapshot.currentVersion.length === 0
-            ? undefined
+            ? null
             : `Current version: v${snapshot.currentVersion}`,
+        duration: APP_UPDATE_TRANSIENT_TOAST_DURATION_MS,
       });
       return;
     case "unavailable":
       toast.info("Updates are not available for this build.", {
         id: APP_UPDATE_TOAST_ID,
+        description: null,
+        duration: APP_UPDATE_TRANSIENT_TOAST_DURATION_MS,
       });
       return;
     case "idle":

--- a/clients/gui-app/src/components/layout/bridges/host-registry-update-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/host-registry-update-listener.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { runnerQueryKeys } from "@/lib/query-keys/runner-mutation-keys";
+import { resolveDesktopHostRegistryUpdatesBridge } from "@/lib/windows/desktop-capabilities";
+import { useRunnerHost } from "@/providers/use-runner-host";
+
+export function HostRegistryUpdateListener(): null {
+  const runnerHost = useRunnerHost();
+  const management = runnerHost.hostManagement;
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (management === null) return;
+    const bridge = resolveDesktopHostRegistryUpdatesBridge(runnerHost);
+    if (bridge === null) return;
+    const subscription = bridge.onChange((state) => {
+      queryClient.setQueryData(
+        runnerQueryKeys.hostRegistryUpdate(management),
+        state,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: runnerQueryKeys.hostInstalledRecord(management),
+      });
+    });
+    return () => {
+      subscription.dispose();
+    };
+  }, [runnerHost, management, queryClient]);
+
+  return null;
+}

--- a/clients/gui-app/src/components/layout/dialogs/restart-update-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/restart-update-dialog.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { RotateCcw } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -22,10 +24,28 @@ export interface RestartUpdateDialogProps {
  */
 export function RestartUpdateDialog(props: RestartUpdateDialogProps) {
   const { open, onOpenChange, latestVersion, onConfirm } = props;
+  const [actionState, setActionState] = useState({
+    open,
+    actionHandled: false,
+  });
   const versionLabel =
     latestVersion === null ? "the latest version" : `v${latestVersion}`;
+
+  if (actionState.open !== open) {
+    setActionState({ open, actionHandled: false });
+  }
+
+  const actionHandled =
+    actionState.open === open ? actionState.actionHandled : false;
+
+  function handleConfirm(): void {
+    if (actionHandled) return;
+    setActionState({ open, actionHandled: true });
+    onConfirm();
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={actionHandled ? undefined : onOpenChange}>
       <DialogContent
         showCloseButton={false}
         className="w-[min(92vw,28rem)] gap-0 overflow-hidden p-0 sm:max-w-md"
@@ -51,6 +71,7 @@ export function RestartUpdateDialog(props: RestartUpdateDialogProps) {
             type="button"
             variant="ghost"
             size="sm"
+            disabled={actionHandled}
             onClick={() => {
               onOpenChange(false);
             }}
@@ -61,9 +82,17 @@ export function RestartUpdateDialog(props: RestartUpdateDialogProps) {
           <Button
             type="button"
             size="sm"
-            onClick={onConfirm}
+            disabled={actionHandled}
+            onClick={handleConfirm}
             data-testid="restart-update-confirm"
           >
+            {actionHandled ? (
+              <AgentSpinningDots
+                className={undefined}
+                testId="restart-update-confirm-spinner"
+                variant={undefined}
+              />
+            ) : null}
             Restart now
           </Button>
         </div>

--- a/clients/gui-app/src/components/layout/dialogs/restart-update-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/restart-update-dialog.tsx
@@ -87,11 +87,17 @@ export function RestartUpdateDialog(props: RestartUpdateDialogProps) {
             data-testid="restart-update-confirm"
           >
             {actionHandled ? (
-              <AgentSpinningDots
-                className={undefined}
-                testId="restart-update-confirm-spinner"
-                variant={undefined}
-              />
+              <span
+                role="status"
+                aria-label="Restart request in progress"
+                className="inline-flex"
+              >
+                <AgentSpinningDots
+                  className={undefined}
+                  testId={undefined}
+                  variant={undefined}
+                />
+              </span>
             ) : null}
             Restart now
           </Button>

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
@@ -219,6 +219,40 @@ describe("<HostSettingsPanel /> - mutation flows", () => {
       });
     });
   });
+
+  it("disables advanced install when the registry asset is unavailable", async () => {
+    const installHost = vi.fn(() =>
+      Promise.resolve(makeInstallResult("1.4.2")),
+    );
+    const availableVersions = vi.fn(() =>
+      Promise.resolve(makeUnavailableAvailableSnapshot()),
+    );
+    const { management } = makeManagement({
+      installHost,
+      availableVersions,
+      registryCheck: vi.fn(() =>
+        Promise.resolve<HostRegistryUpdateState>({
+          checkedAt: "2026-05-15T00:00:00Z",
+          latestVersion: "1.4.2",
+          installedVersion: null,
+          updateAvailable: false,
+          reachable: true,
+          errorMessage: null,
+        }),
+      ),
+    });
+
+    renderPanel(makeHost(management, null));
+
+    await openAdvancedDisclosure();
+    expect(
+      await screen.findByText("Build unavailable for this platform."),
+    ).toBeTruthy();
+    const installButton = screen.getByRole("button", { name: "Install" });
+    expect(installButton.hasAttribute("disabled")).toBe(true);
+    fireEvent.click(installButton);
+    expect(installHost).not.toHaveBeenCalled();
+  });
 });
 
 async function openAdvancedDisclosure(): Promise<void> {
@@ -348,6 +382,28 @@ function makeAvailableSnapshot(): HostAvailableSnapshot {
         platformAsset: {
           available: true,
           unavailableReason: null,
+          url: "",
+          sizeBytes: 1024,
+          sha256: "",
+          signatureUrl: "",
+          publicKeyId: "",
+        },
+      },
+    ],
+  };
+}
+
+function makeUnavailableAvailableSnapshot(): HostAvailableSnapshot {
+  const base = makeAvailableSnapshot();
+  const entry = base.versions[0];
+  return {
+    ...base,
+    versions: [
+      {
+        ...entry,
+        platformAsset: {
+          available: false,
+          unavailableReason: "Build unavailable for this platform.",
           url: "",
           sizeBytes: 1024,
           sha256: "",

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
@@ -253,6 +253,37 @@ describe("<HostSettingsPanel /> - mutation flows", () => {
     fireEvent.click(installButton);
     expect(installHost).not.toHaveBeenCalled();
   });
+
+  it("uses the default advanced install reason for blank unavailable reasons", async () => {
+    const availableVersions = vi.fn(() =>
+      Promise.resolve(makeUnavailableAvailableSnapshotWithReason("   ")),
+    );
+    const { management } = makeManagement({
+      availableVersions,
+      registryCheck: vi.fn(() =>
+        Promise.resolve<HostRegistryUpdateState>({
+          checkedAt: "2026-05-15T00:00:00Z",
+          latestVersion: "1.4.2",
+          installedVersion: null,
+          updateAvailable: false,
+          reachable: true,
+          errorMessage: null,
+        }),
+      ),
+    });
+
+    renderPanel(makeHost(management, null));
+
+    await openAdvancedDisclosure();
+    expect(
+      await screen.findByText("Unavailable on this platform."),
+    ).toBeTruthy();
+    const installButton = screen.getByRole("button", { name: "Install" });
+    expect(installButton.hasAttribute("disabled")).toBe(true);
+    expect(installButton.getAttribute("title")).toBe(
+      "Unavailable on this platform.",
+    );
+  });
 });
 
 async function openAdvancedDisclosure(): Promise<void> {
@@ -394,6 +425,14 @@ function makeAvailableSnapshot(): HostAvailableSnapshot {
 }
 
 function makeUnavailableAvailableSnapshot(): HostAvailableSnapshot {
+  return makeUnavailableAvailableSnapshotWithReason(
+    "Build unavailable for this platform.",
+  );
+}
+
+function makeUnavailableAvailableSnapshotWithReason(
+  unavailableReason: string | null,
+): HostAvailableSnapshot {
   const base = makeAvailableSnapshot();
   const entry = base.versions[0];
   return {
@@ -403,7 +442,7 @@ function makeUnavailableAvailableSnapshot(): HostAvailableSnapshot {
         ...entry,
         platformAsset: {
           available: false,
-          unavailableReason: "Build unavailable for this platform.",
+          unavailableReason,
           url: "",
           sizeBytes: 1024,
           sha256: "",

--- a/clients/gui-app/src/components/settings/panels/host-settings-available-versions-list.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-available-versions-list.tsx
@@ -111,6 +111,7 @@ function renderVersionRow(props: {
   readonly onInstallVersion: (version: string) => void;
 }) {
   const { entry, isInstalled, isLatest, anyPending, onInstallVersion } = props;
+  const unavailableReason = platformUnavailableReason(entry);
   return (
     <li
       key={entry.version}
@@ -136,6 +137,11 @@ function renderVersionRow(props: {
         <span className="text-ui-xs text-muted-foreground">
           {formatInstallDate(entry.releasedAt)}
         </span>
+        {unavailableReason !== null ? (
+          <span className="text-ui-xs text-muted-foreground">
+            {unavailableReason}
+          </span>
+        ) : null}
       </div>
       <Button
         variant="secondary"
@@ -144,12 +150,27 @@ function renderVersionRow(props: {
           anyPending ||
           isInstalled ||
           entry.yanked ||
-          entry.platformAsset === null
+          unavailableReason !== null
         }
+        title={unavailableReason === null ? undefined : unavailableReason}
         onClick={() => onInstallVersion(entry.version)}
       >
         Install
       </Button>
     </li>
+  );
+}
+
+function platformUnavailableReason(
+  entry: HostAvailableVersionEntry,
+): string | null {
+  if (entry.platformAsset === null) {
+    return "No asset for this platform.";
+  }
+  if (entry.platformAsset.available) {
+    return null;
+  }
+  return (
+    entry.platformAsset.unavailableReason ?? "Unavailable on this platform."
   );
 }

--- a/clients/gui-app/src/components/settings/panels/host-settings-available-versions-list.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-available-versions-list.tsx
@@ -170,7 +170,8 @@ function platformUnavailableReason(
   if (entry.platformAsset.available) {
     return null;
   }
-  return (
-    entry.platformAsset.unavailableReason ?? "Unavailable on this platform."
-  );
+  const reason = entry.platformAsset.unavailableReason?.trim();
+  return reason === undefined || reason.length === 0
+    ? "Unavailable on this platform."
+    : reason;
 }

--- a/clients/gui-app/src/lib/windows/desktop-capabilities.ts
+++ b/clients/gui-app/src/lib/windows/desktop-capabilities.ts
@@ -1,6 +1,7 @@
 import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import type {
   DesktopAppUpdatesBridge,
+  DesktopHostRegistryUpdatesBridge,
   DesktopMenuBridge,
   DesktopPowerBridge,
   DesktopSupportBridge,
@@ -33,6 +34,14 @@ export function resolveDesktopPowerBridge(
   const value: unknown = Reflect.get(runnerHost, "power");
   return isDesktopPowerBridge(value) ? value : null;
 }
+
+export function resolveDesktopHostRegistryUpdatesBridge(
+  runnerHost: IRunnerHost,
+): DesktopHostRegistryUpdatesBridge | null {
+  const value: unknown = Reflect.get(runnerHost, "hostRegistryUpdates");
+  return isDesktopHostRegistryUpdatesBridge(value) ? value : null;
+}
+
 function isDesktopMenuBridge(value: unknown): value is DesktopMenuBridge {
   return isRecord(value) && typeof value.onCommand === "function";
 }
@@ -61,6 +70,12 @@ function isDesktopAppUpdatesBridge(
 
 function isDesktopPowerBridge(value: unknown): value is DesktopPowerBridge {
   return isRecord(value) && typeof value.setSleepBlocked === "function";
+}
+
+function isDesktopHostRegistryUpdatesBridge(
+  value: unknown,
+): value is DesktopHostRegistryUpdatesBridge {
+  return isRecord(value) && typeof value.onChange === "function";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/clients/gui-app/src/lib/windows/types.ts
+++ b/clients/gui-app/src/lib/windows/types.ts
@@ -1,3 +1,5 @@
+import type { HostRegistryUpdateState } from "@traycer-clients/shared/platform/runner-host";
+
 export type DesktopJsonPrimitive = string | number | boolean | null;
 export type DesktopJsonValue =
   | DesktopJsonPrimitive
@@ -208,6 +210,12 @@ export interface DesktopAppUpdatesBridge {
   downloadUpdate(): Promise<DesktopAppUpdateSnapshot>;
   installUpdate(): Promise<DesktopAppUpdateSnapshot>;
   onChange(handler: (snapshot: DesktopAppUpdateSnapshot) => void): {
+    dispose(): void;
+  };
+}
+
+export interface DesktopHostRegistryUpdatesBridge {
+  onChange(handler: (state: HostRegistryUpdateState) => void): {
     dispose(): void;
   };
 }

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -1,5 +1,6 @@
 import { HostPicker } from "@/components/layout/header/host-picker";
 import { AppUpdateToastController } from "@/components/layout/bridges/app-update-toast-controller";
+import { HostRegistryUpdateListener } from "@/components/layout/bridges/host-registry-update-listener";
 import { RunnerHostBridges } from "@/components/layout/bridges/runner-host-bridges";
 import { WorktreeDeleteProgressToastBridge } from "@/components/layout/bridges/worktree-delete-progress-toast-bridge";
 import { CenteredCard } from "@/components/centered-card";
@@ -187,6 +188,7 @@ function TraycerAppRuntimeSurface(props: TraycerAppRuntimeSurfaceProps) {
   return (
     <>
       <RunnerHostBridges />
+      <HostRegistryUpdateListener />
       <AppUpdateToastController />
       <WorktreeDeleteProgressToastBridge />
       <CliCredentialSeeder />


### PR DESCRIPTION
## Summary
- clear stale desktop update toast metadata and show pending restart/install state in the restart dialog
- keep host registry update state synchronized across native tray/menu and renderer query caches
- make host update availability platform-aware and serialize registry refreshes so older probes cannot overwrite newer state

## Testing
- git diff --check
- bun run test -- src/electron-main/ipc/__tests__/registry-update-cache.test.ts src/electron-main/ipc/__tests__/host-management-channel.test.ts src/electron-main/app/__tests__/updater.test.ts src/renderer-shell/__tests__/desktop-runner-host.test.ts
- bun run test -- src/components/home/__tests__/host-update-banner.test.tsx src/components/layout/__tests__/app-update-ui.test.tsx src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
- bun run compile in clients/desktop
- bun run compile in clients/gui-app

## Notes
- react-doctor was run during the fix pass and still fails on existing unrelated findings outside this change.