### PR TITLE
Show command summaries on approval cards

### DIFF
--- a/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
@@ -602,6 +602,7 @@ function ApprovalSegmentCard({
     <ResolvedApprovalSegment
       toolName={segment.toolName}
       description={segment.description}
+      inputSummary={segment.inputSummary}
       inputDetail={segment.inputDetail}
       decision={segment.decision}
       variant="card"

--- a/clients/gui-app/src/components/chat/segments/__tests__/approval-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/approval-segment.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ResolvedApprovalSegment } from "@/components/chat/segments/approval-segment";
+
+describe("<ResolvedApprovalSegment />", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the approval input summary in the resolved header", () => {
+    render(
+      <ResolvedApprovalSegment
+        toolName="bash"
+        description="OpenCode requests bash permission"
+        inputSummary="find . -name '*.sentry' | head -50"
+        inputDetail={null}
+        decision={{ approved: false, reason: null }}
+        variant="card"
+      />,
+    );
+
+    expect(screen.getByText("Denied")).toBeTruthy();
+    expect(screen.getByText("bash")).toBeTruthy();
+    expect(screen.getByText("find . -name '*.sentry' | head -50")).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/chat/segments/activity-group-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/activity-group-segment.tsx
@@ -153,6 +153,7 @@ function ActivityChildSegment(props: ActivityChildSegmentProps) {
         <ResolvedApprovalSegment
           toolName={segment.toolName}
           description={segment.description}
+          inputSummary={segment.inputSummary}
           inputDetail={segment.inputDetail}
           decision={segment.decision}
           variant="row"

--- a/clients/gui-app/src/components/chat/segments/approval-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/approval-segment.tsx
@@ -10,6 +10,7 @@ import { ToolInputPanel } from "./tool-input-panel";
 interface ResolvedApprovalSegmentProps {
   toolName: string | null;
   description: string | null;
+  inputSummary: string | null;
   // Precomputed expand body for the pending tool's input (raw input not stored).
   inputDetail: ToolInputDetail | null;
   decision: ApprovalDecision;
@@ -23,10 +24,23 @@ interface ResolvedApprovalSegmentProps {
  * `isWorkStep`), so this component does not accept Approve/Deny callbacks.
  */
 export function ResolvedApprovalSegment(props: ResolvedApprovalSegmentProps) {
-  const { toolName, description, inputDetail, decision, variant } = props;
+  const {
+    toolName,
+    description,
+    inputSummary,
+    inputDetail,
+    decision,
+    variant,
+  } = props;
   const [open, setOpen] = useState<boolean>(false);
   const label = toolName ?? description ?? "approval";
-  const header = <ResolvedApprovalHeader label={label} decision={decision} />;
+  const header = (
+    <ResolvedApprovalHeader
+      label={label}
+      inputSummary={inputSummary}
+      decision={decision}
+    />
+  );
   const body = (
     <ResolvedApprovalBody
       description={description}
@@ -70,9 +84,10 @@ export function ResolvedApprovalSegment(props: ResolvedApprovalSegmentProps) {
 
 function ResolvedApprovalHeader(props: {
   label: string;
+  inputSummary: string | null;
   decision: ApprovalDecision;
 }) {
-  const { label, decision } = props;
+  const { label, inputSummary, decision } = props;
   const verdictLabel = decision.approved ? "Approved" : "Denied";
   const VerdictIcon = decision.approved ? Check : X;
   return (
@@ -95,9 +110,21 @@ function ResolvedApprovalHeader(props: {
       <span aria-hidden className="shrink-0 text-muted-foreground/40">
         ·
       </span>
-      <span className="min-w-0 flex-1 truncate font-mono text-code-sm text-muted-foreground">
+      <span className="shrink-0 font-mono text-code-sm text-muted-foreground">
         {label}
       </span>
+      {inputSummary !== null ? (
+        <>
+          <span aria-hidden className="shrink-0 text-muted-foreground/40">
+            ·
+          </span>
+          <span className="min-w-0 flex-1 truncate font-mono text-code-sm text-muted-foreground">
+            {inputSummary}
+          </span>
+        </>
+      ) : (
+        <span aria-hidden className="flex-1" />
+      )}
       {!decision.approved && decision.reason !== null ? (
         <span
           className="@max-[28rem]:hidden shrink-0 truncate text-ui-xs text-destructive/80"

--- a/clients/gui-app/src/components/chat/segments/composer-slot-approval-queue.tsx
+++ b/clients/gui-app/src/components/chat/segments/composer-slot-approval-queue.tsx
@@ -1,5 +1,6 @@
 import { Check, ShieldAlert, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { deriveToolInputSummary } from "@/lib/segment-summary";
 import type { ChatApprovalState } from "@traycer/protocol/host/agent/gui/subscribe";
 
 interface ComposerSlotApprovalQueueProps {
@@ -94,13 +95,27 @@ interface ApprovalRowProps {
 
 function ApprovalRow(props: ApprovalRowProps) {
   const { approval, canAct, onDecision } = props;
+  const inputSummary = deriveToolInputSummary(
+    approval.toolName,
+    approval.input,
+  );
   const headline =
     approval.description.length > 0 ? approval.description : approval.toolName;
   return (
-    <div className="flex flex-col gap-1.5 py-2 first:pt-0 last:pb-0">
-      <span className="font-mono text-code-sm text-foreground/80">
-        {approval.toolName}
-      </span>
+    <div className="flex min-w-0 flex-col gap-1.5 py-2 first:pt-0 last:pb-0">
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 font-mono text-code-sm text-foreground/80">
+        <span className="shrink-0">{approval.toolName}</span>
+        {inputSummary !== null ? (
+          <>
+            <span aria-hidden className="shrink-0 text-muted-foreground/40">
+              ·
+            </span>
+            <span className="min-w-0 break-words text-muted-foreground">
+              {inputSummary}
+            </span>
+          </>
+        ) : null}
+      </div>
       <p className="m-0 text-foreground/85">{headline}</p>
       <div className="flex items-center justify-end gap-2">
         <Button

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -1056,7 +1056,10 @@ describe("<ChatTile />", () => {
           approvalId: "approval-1",
           toolName: "bash",
           description: "Run tests",
-          input: null,
+          input: {
+            metadata: { command: "bun test | head -50" },
+            pattern: ["bun test", "head -50"],
+          },
           planId: null,
           actions: [],
           requestedAt: 3,
@@ -1072,6 +1075,9 @@ describe("<ChatTile />", () => {
     ).not.toBe(0);
     expect(within(fileQueue).getByText("/repo/src/app.ts")).not.toBeNull();
     expect(within(fileQueue).getByText("Edit")).not.toBeNull();
+    expect(
+      within(genericQueue).getByText("bun test | head -50"),
+    ).not.toBeNull();
 
     fireEvent.click(within(fileQueue).getByRole("button", { name: "Approve" }));
 

--- a/protocol/src/host/agent/gui/__tests__/tool-input-detail.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/tool-input-detail.test.ts
@@ -22,6 +22,19 @@ describe("deriveToolInputDetail", () => {
     ).toEqual({ kind: "command", command: "npm run build" });
   });
 
+  it("uses nested metadata command for OpenCode shell approvals", () => {
+    expect(
+      deriveToolInputDetail("bash", {
+        type: "bash",
+        metadata: { command: "find . -name '*.sentry' | head -50" },
+        pattern: ["find . -name '*.sentry'", "head -50"],
+      }),
+    ).toEqual({
+      kind: "command",
+      command: "find . -name '*.sentry' | head -50",
+    });
+  });
+
   it("humanizes an arbitrary object into label/value fields (no JSON braces)", () => {
     expect(
       deriveToolInputDetail("create_issue", {

--- a/protocol/src/host/agent/gui/__tests__/tool-input-summary.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/tool-input-summary.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from "vitest";
 import { deriveToolInputSummary } from "../tool-input-summary";
 
 describe("deriveToolInputSummary", () => {
+  it("summarizes OpenCode shell approvals from nested metadata command", () => {
+    expect(
+      deriveToolInputSummary("bash", {
+        type: "bash",
+        metadata: { command: "find . -name '*.sentry' | head -50" },
+        pattern: ["find . -name '*.sentry'", "head -50"],
+      }),
+    ).toBe("find . -name '*.sentry' | head -50");
+  });
+
   it("summarizes comment thread list inputs", () => {
     expect(
       deriveToolInputSummary("traycer_list_comment_threads", {

--- a/protocol/src/host/agent/gui/tool-input-detail.ts
+++ b/protocol/src/host/agent/gui/tool-input-detail.ts
@@ -185,10 +185,16 @@ export function deriveToolInputDetail(
         };
   }
 
+  const metadata = asRecord(record["metadata"]);
   const command =
     asString(record["command"]) ??
     asString(record["cmd"]) ??
-    asString(record["script"]);
+    asString(record["script"]) ??
+    (metadata === null
+      ? null
+      : (asString(metadata["command"]) ??
+        asString(metadata["cmd"]) ??
+        asString(metadata["script"])));
   if (command !== null) return { kind: "command", command };
 
   const name = toolName.toLowerCase();

--- a/protocol/src/host/agent/gui/tool-input-summary.ts
+++ b/protocol/src/host/agent/gui/tool-input-summary.ts
@@ -80,10 +80,16 @@ function summarizeUrl(record: Record<string, unknown>): string | null {
 }
 
 function summarizeCommand(record: Record<string, unknown>): string | null {
+  const metadata = asRecord(record["metadata"]);
   const cmd =
     asString(record["command"]) ??
     asString(record["cmd"]) ??
-    asString(record["script"]);
+    asString(record["script"]) ??
+    (metadata === null
+      ? null
+      : (asString(metadata["command"]) ??
+        asString(metadata["cmd"]) ??
+        asString(metadata["script"])));
   if (cmd === null) return null;
   return trim(cmd);
 }
@@ -113,14 +119,19 @@ function summarizeCommentThreadStatus(
   let threadCount = 0;
   let status: string | null = null;
   for (const update of updates) {
-    if (update === null || typeof update !== "object" || Array.isArray(update)) {
+    if (
+      update === null ||
+      typeof update !== "object" ||
+      Array.isArray(update)
+    ) {
       continue;
     }
     const updateRecord = update as Record<string, unknown>;
     const threadIds = updateRecord["threadIds"];
     if (Array.isArray(threadIds)) {
-      threadCount += threadIds.filter((value) => typeof value === "string")
-        .length;
+      threadCount += threadIds.filter(
+        (value) => typeof value === "string",
+      ).length;
     }
     status ??= asString(updateRecord["status"]);
   }


### PR DESCRIPTION
## Summary

- Derive shell command summaries from nested `metadata.command` in approval/tool input payloads.
- Show input summaries in live approval cards and resolved approval headers.
- Cover OpenCode approval payloads where `pattern` is split but `metadata.command` contains the full command.

## Validation

- `bun run test -- src/host/agent/gui/__tests__/tool-input-summary.test.ts src/host/agent/gui/__tests__/tool-input-detail.test.ts`
- `bun run test -- src/components/epic-canvas/__tests__/chat-tile.test.tsx src/components/chat/segments/__tests__/approval-segment.test.tsx`
- `bun run compile` in `protocol`
- `bun run compile` in `clients/gui-app`
- `bun x -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score` in `clients/gui-app`
- `git diff --check`