### PR TITLE
Refine GUI sign-in approval panel

### DIFF
--- a/clients/gui-app/__tests__/traycer-app.test.tsx
+++ b/clients/gui-app/__tests__/traycer-app.test.tsx
@@ -289,10 +289,11 @@ describe("<TraycerApp />", () => {
     expect(retry).not.toBeNull();
     fireEvent.click(retry);
 
-    // After a new signIn() the error is cleared and the button flips to
-    // "Signing in" again.
-    await screen.findByRole("button", { name: "Signing in" });
+    // After a new signIn() the error is cleared and the active approval panel
+    // takes over instead of showing a separate disabled "Signing in" button.
+    await screen.findByTestId("signin-device-progress");
     expect(screen.queryByTestId("signin-error")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Signing in" })).toBeNull();
   });
 
   it(

--- a/clients/gui-app/__tests__/traycer-app.test.tsx
+++ b/clients/gui-app/__tests__/traycer-app.test.tsx
@@ -291,8 +291,8 @@ describe("<TraycerApp />", () => {
 
     // After a new signIn() the error is cleared and the active approval panel
     // takes over instead of showing a separate disabled "Signing in" button.
-    await screen.findByTestId("signin-device-progress");
-    expect(screen.queryByTestId("signin-error")).toBeNull();
+    await screen.findByRole("heading", { name: "Approve in your browser" });
+    expect(screen.queryByRole("alert")).toBeNull();
     expect(screen.queryByRole("button", { name: "Signing in" })).toBeNull();
   });
 

--- a/clients/gui-app/src/components/auth/auth-landing-page.tsx
+++ b/clients/gui-app/src/components/auth/auth-landing-page.tsx
@@ -2,8 +2,10 @@ import { BrandMark, PhotoBloom } from "@/components/auth/cinematic-backdrop";
 import { SignInButton } from "@/components/layout/header/sign-in-button";
 import { cn } from "@/lib/utils";
 
-const MONO_SCOPE =
+const SIGN_IN_COLOR_VARS =
   "[--primary:#f8f7f2] [--primary-foreground:#050505] [--ring:#f8f7f2]";
+const SIGN_IN_LANE_CLASS =
+  "w-[min(100%,31rem)] pt-[clamp(0.35rem,1.2vh,0.8rem)]";
 
 /**
  * Reads the build-time app version injected by Vite as `VITE_APP_VERSION`.
@@ -22,28 +24,18 @@ export function AuthLandingPage() {
       <PhotoBloom />
 
       <section className="relative z-10 mx-auto flex w-full flex-col items-center justify-center px-[clamp(1.5rem,5vw,4.5rem)] pb-[clamp(5rem,12vh,8rem)] pt-[clamp(4rem,12vh,8rem)] text-center font-heading">
-        <div className="flex w-full max-w-[min(72vw,24rem)] flex-col items-center gap-[clamp(1.2rem,2.8vh,2rem)]">
+        <div className="flex w-full max-w-[min(88vw,31rem)] flex-col items-center gap-[clamp(1.2rem,2.8vh,2rem)]">
           <BrandMark className="h-auto w-[clamp(3.75rem,8vw,5.4rem)] drop-shadow-[0_1.5rem_2.5rem_rgba(0,0,0,0.42)]" />
-          <h1 className="whitespace-nowrap text-title-md font-light leading-none text-white/90 drop-shadow-[0_1rem_2.2rem_rgba(0,0,0,0.48)]">
+          <h1 className="mb-2 text-3xl font-semibold leading-9 tracking-tight">
             Welcome to Traycer
           </h1>
-          <div
-            className={cn(
-              MONO_SCOPE,
-              // Stable hero CTA width: the sign-in surface no longer carries a
-              // wider sibling link to anchor its column, so pin it to a
-              // viewport-capped width. Without this the column shrink-wraps the
-              // bare "Sign in" button and then jumps wider once the signing-in
-              // "Retry" link appears. Sized to fit the longest label on one line.
-              "w-[min(100%,13rem)] pt-[clamp(0.35rem,1.2vh,0.8rem)] [&_[data-testid=signin-button]]:h-[clamp(2.5rem,5.2vh,3rem)] [&_[data-testid=signin-button]]:text-ui-sm [&_[data-testid=signin-button]]:transition-colors [&_[data-testid=signin-button]]:duration-200 [&_[data-testid=signin-button]]:hover:bg-transparent [&_[data-testid=signin-button]]:hover:text-white [&_[data-testid=signin-button]]:hover:border-white/60 [&_[data-testid=signin-controls]]:gap-3",
-            )}
-          >
+          <div className={cn(SIGN_IN_COLOR_VARS, SIGN_IN_LANE_CLASS)}>
             <SignInButton layout="hero" />
           </div>
         </div>
       </section>
 
-      <footer className="pointer-events-none absolute right-0 bottom-0 z-10 flex items-center justify-end px-[clamp(1.25rem,4vw,4rem)] pb-[clamp(1rem,3vh,2rem)] font-mono text-overline text-white/42">
+      <footer className="pointer-events-none absolute right-0 bottom-0 z-10 flex items-center justify-end px-[clamp(1.25rem,4vw,4rem)] pb-[clamp(1rem,3vh,2rem)] font-mono text-overline text-white/[0.42]">
         <span>{resolveAppVersionLabel()}</span>
       </footer>
     </main>

--- a/clients/gui-app/src/components/auth/auth-landing-page.tsx
+++ b/clients/gui-app/src/components/auth/auth-landing-page.tsx
@@ -26,7 +26,7 @@ export function AuthLandingPage() {
       <section className="relative z-10 mx-auto flex w-full flex-col items-center justify-center px-[clamp(1.5rem,5vw,4.5rem)] pb-[clamp(5rem,12vh,8rem)] pt-[clamp(4rem,12vh,8rem)] text-center font-heading">
         <div className="flex w-full max-w-[min(88vw,31rem)] flex-col items-center gap-[clamp(1.2rem,2.8vh,2rem)]">
           <BrandMark className="h-auto w-[clamp(3.75rem,8vw,5.4rem)] drop-shadow-[0_1.5rem_2.5rem_rgba(0,0,0,0.42)]" />
-          <h1 className="mb-2 text-3xl font-semibold leading-9 tracking-tight">
+          <h1 className="mb-2 text-[clamp(2rem,5vw,2.75rem)] font-semibold leading-[clamp(2.25rem,5.5vw,3rem)] tracking-tight">
             Welcome to Traycer
           </h1>
           <div className={cn(SIGN_IN_COLOR_VARS, SIGN_IN_LANE_CLASS)}>

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -382,8 +382,27 @@ describe("<SignInButton />", () => {
     await waitFor(() => {
       expect(result.host.deviceFlow.startCalls).toBe(1);
     });
+    await screen.findByTestId("signin-device-progress");
+    expect(screen.queryByRole("button", { name: "Signing in" })).toBeNull();
+    fireEvent.click(screen.getByTestId("signin-device-fallback-trigger"));
     const code = await screen.findByTestId("signin-device-code");
     expect(code.textContent).toBe("ABCDE-FGHIJ");
+    expect(screen.getByTestId("signin-device-url").textContent).toBe(
+      "https://app.traycer.ai/device",
+    );
+    const writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Copy device code" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy approval address" }),
+    );
+    await waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("ABCDE-FGHIJ");
+      expect(writeText).toHaveBeenCalledWith("https://app.traycer.ai/device");
+    });
     // There is no device-code fallback link anymore.
     expect(screen.queryByTestId("signin-device-code-link")).toBeNull();
     result.cleanupClient();

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -24,6 +24,7 @@ vi.mock("sonner", () => ({
 
 import { toast } from "sonner";
 import { SignInButton } from "@/components/layout/header/sign-in-button";
+import { DeviceCodeProgress } from "@/components/layout/header/sign-in/device-code-progress";
 import {
   hostRpcRegistry,
   HostRuntimeProvider,
@@ -188,6 +189,42 @@ function mountSignInButton(host: MockRunnerHost): MountResult {
   };
 }
 
+function mountDeviceCodeProgress(host: MockRunnerHost): () => void {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  render(
+    <RunnerHostProvider runnerHost={host}>
+      <QueryClientProvider client={queryClient}>
+        <HostRuntimeProvider
+          registry={hostRpcRegistry}
+          messengerFactory={makeMessengerFactory()}
+          invalidator={null}
+          requestId={null}
+          remoteFetcher={() => Promise.resolve([])}
+          fallback={<div data-testid="runtime-fallback">…</div>}
+        >
+          <DeviceCodeProgress
+            isHero
+            progress={{
+              userCode: "ABCDE-FGHIJ",
+              verificationUri: "https://app.traycer.ai/device",
+              verificationUriComplete:
+                "https://app.traycer.ai/device?user_code=ABCDE-FGHIJ",
+              expiresAtMs: 0,
+            }}
+          />
+        </HostRuntimeProvider>
+      </QueryClientProvider>
+    </RunnerHostProvider>,
+  );
+
+  return () => {
+    queryClient.clear();
+  };
+}
+
 function CaptureAuthService(props: {
   readonly onCapture: (auth: AuthService) => void;
 }): null {
@@ -261,6 +298,11 @@ describe("<SignInButton />", () => {
       useAuthStore.getState().setSigningIn();
     });
 
+    expect(screen.queryByRole("button", { name: "Signing in" })).toBeNull();
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", { name: "Sign in" })
+        .disabled,
+    ).toBe(true);
     const retry = await screen.findByTestId("signin-retry-link");
     // `signIn()` restarts the device flow and re-opens the verification page, so
     // a stalled attempt has an immediate escape hatch. Capturing the count
@@ -395,6 +437,7 @@ describe("<SignInButton />", () => {
       configurable: true,
       value: { writeText },
     });
+    expect(screen.queryByText("Copied")).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Copy device code" }));
     fireEvent.click(
       screen.getByRole("button", { name: "Copy approval address" }),
@@ -403,8 +446,19 @@ describe("<SignInButton />", () => {
       expect(writeText).toHaveBeenCalledWith("ABCDE-FGHIJ");
       expect(writeText).toHaveBeenCalledWith("https://app.traycer.ai/device");
     });
+    expect(screen.getAllByText("Copied")).toHaveLength(2);
     // There is no device-code fallback link anymore.
     expect(screen.queryByTestId("signin-device-code-link")).toBeNull();
     result.cleanupClient();
+  });
+
+  it("renders an expired approval status without the waiting spinner", async () => {
+    const cleanupClient = mountDeviceCodeProgress(buildHost());
+
+    expect(await screen.findByText("Approval code expired")).not.toBeNull();
+    expect(screen.getByText("Code expired")).not.toBeNull();
+    expect(screen.queryByTestId("signin-device-spinner")).toBeNull();
+
+    cleanupClient();
   });
 });

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -424,32 +424,44 @@ describe("<SignInButton />", () => {
     await waitFor(() => {
       expect(result.host.deviceFlow.startCalls).toBe(1);
     });
-    await screen.findByTestId("signin-device-progress");
+    await screen.findByRole("heading", { name: "Approve in your browser" });
     expect(screen.queryByRole("button", { name: "Signing in" })).toBeNull();
-    fireEvent.click(screen.getByTestId("signin-device-fallback-trigger"));
-    const code = await screen.findByTestId("signin-device-code");
+    fireEvent.click(screen.getByRole("button", { name: "Use code instead" }));
+    const code = await screen.findByText("ABCDE-FGHIJ");
     expect(code.textContent).toBe("ABCDE-FGHIJ");
-    expect(screen.getByTestId("signin-device-url").textContent).toBe(
+    expect(screen.getByText("https://app.traycer.ai/device").textContent).toBe(
       "https://app.traycer.ai/device",
     );
     const writeText = vi.fn(() => Promise.resolve());
+    const previousClipboard = Object.getOwnPropertyDescriptor(
+      navigator,
+      "clipboard",
+    );
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText },
     });
-    expect(screen.queryByText("Copied")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "Copy device code" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: "Copy approval address" }),
-    );
-    await waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith("ABCDE-FGHIJ");
-      expect(writeText).toHaveBeenCalledWith("https://app.traycer.ai/device");
-    });
-    expect(screen.getAllByText("Copied")).toHaveLength(2);
-    // There is no device-code fallback link anymore.
-    expect(screen.queryByTestId("signin-device-code-link")).toBeNull();
-    result.cleanupClient();
+    try {
+      expect(screen.queryByText("Copied")).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Copy device code" }));
+      fireEvent.click(
+        screen.getByRole("button", { name: "Copy approval address" }),
+      );
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith("ABCDE-FGHIJ");
+        expect(writeText).toHaveBeenCalledWith("https://app.traycer.ai/device");
+      });
+      expect(screen.getAllByText("Copied")).toHaveLength(2);
+      // There is no device-code fallback link anymore.
+      expect(screen.queryByTestId("signin-device-code-link")).toBeNull();
+    } finally {
+      if (previousClipboard === undefined) {
+        Reflect.deleteProperty(navigator, "clipboard");
+      } else {
+        Object.defineProperty(navigator, "clipboard", previousClipboard);
+      }
+      result.cleanupClient();
+    }
   });
 
   it("renders an expired approval status without the waiting spinner", async () => {

--- a/clients/gui-app/src/components/layout/header/sign-in-button.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in-button.tsx
@@ -1,22 +1,18 @@
-import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
-import { Button } from "@/components/ui/button";
-import { useAuthService } from "@/lib/host";
-import { useAuthServiceError } from "@/hooks/auth/use-auth-service-error";
 import { useAuthDeviceProgress } from "@/hooks/auth/use-auth-device-progress";
-import {
-  AUTH_ERROR_DEVICE_DENIED,
-  AUTH_ERROR_DEVICE_EXPIRED,
-  AUTH_ERROR_LAUNCH_FAILED,
-  AUTH_ERROR_SESSION_EXPIRED,
-  AUTH_ERROR_SIGN_IN_FAILED,
-  type AuthService,
-  type DeviceFlowProgress,
-} from "@/lib/auth/auth-service";
-import { useAuthStore, type AuthStatus } from "@/stores/auth/auth-store";
+import { useAuthServiceError } from "@/hooks/auth/use-auth-service-error";
+import { useAuthService } from "@/lib/host";
 import { cn } from "@/lib/utils";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { DeviceCodeProgress } from "./sign-in/device-code-progress";
+import {
+  PrimarySignInButton,
+  RetrySignInButton,
+} from "./sign-in/sign-in-action-buttons";
+import { SignInErrorMessage } from "./sign-in/sign-in-error-message";
+import { type SignInLayout } from "./sign-in/types";
 
 export interface SignInButtonProps {
-  readonly layout: "compact" | "hero";
+  readonly layout: SignInLayout;
 }
 
 /**
@@ -39,19 +35,18 @@ export function SignInButton(props: SignInButtonProps) {
   const status = useAuthStore((state) => state.status);
   const lastError = useAuthServiceError(auth);
   const deviceProgress = useAuthDeviceProgress(auth);
+  const isHero = props.layout === "hero";
+  const isSigningIn = status === "signing-in";
 
   if (status === "signed-in") {
     return null;
   }
 
-  const isSigningIn = status === "signing-in";
-  const isHero = props.layout === "hero";
-
   return (
     <div
       className={cn(
         "flex",
-        isHero && "w-full flex-col gap-4",
+        isHero && "w-full flex-col gap-3",
         !isHero && "gap-2",
         // Compact mode sits in the header's non-wrapping controls row. While the
         // device panel is showing, stack full-width so the verification URL and
@@ -67,191 +62,14 @@ export function SignInButton(props: SignInButtonProps) {
         lastError={lastError}
         isHero={isHero}
       />
-      <DeviceCodeProgress
-        auth={auth}
-        progress={deviceProgress}
-        isHero={isHero}
-      />
-      <PrimarySignInButton
-        auth={auth}
-        isHero={isHero}
-        isSigningIn={isSigningIn}
-      />
-      <RetrySignInButton
-        auth={auth}
-        isHero={isHero}
-        isSigningIn={isSigningIn}
-      />
+      {deviceProgress !== null ? (
+        <DeviceCodeProgress progress={deviceProgress} isHero={isHero} />
+      ) : (
+        <>
+          <PrimarySignInButton isHero={isHero} isSigningIn={isSigningIn} />
+          <RetrySignInButton isHero={isHero} isSigningIn={isSigningIn} />
+        </>
+      )}
     </div>
   );
-}
-
-/**
- * Active device-flow progress. The app already auto-opens the pre-filled
- * approval page; this surface leads with a one-click "open approval page"
- * affordance (re-opening `verification_uri_complete`, code embedded) so the
- * user only ever has to click Approve - never type the code. The code + bare
- * URL remain as a manual fallback, and the spinner keeps it from being a silent
- * wait. Rendered while a device attempt is in flight.
- */
-function DeviceCodeProgress(props: {
-  readonly auth: AuthService;
-  readonly progress: DeviceFlowProgress | null;
-  readonly isHero: boolean;
-}) {
-  const progress = props.progress;
-  if (progress === null) {
-    return null;
-  }
-  return (
-    <div
-      className={cn(
-        "flex flex-col gap-3 rounded-lg border border-border bg-card p-4 text-card-foreground shadow-sm",
-        props.isHero ? "w-full text-ui-sm" : "w-full min-w-0 text-ui-xs",
-      )}
-      data-testid="signin-device-progress"
-    >
-      <span className="font-medium text-foreground">
-        Approve this sign-in in your browser.
-      </span>
-      <Button
-        size={props.isHero ? "default" : "sm"}
-        className="w-full"
-        onClick={() => props.auth.openVerificationPage()}
-        data-testid="signin-open-approval"
-      >
-        Open the approval page
-      </Button>
-      <span className="flex items-center gap-1.5 text-muted-foreground">
-        Waiting for approval
-        <AgentSpinningDots
-          variant="dots"
-          className="ml-0.5"
-          testId="signin-device-spinner"
-        />
-      </span>
-      <span className="flex flex-wrap items-center gap-x-1.5 gap-y-1 border-t border-border pt-3 text-muted-foreground">
-        Or enter
-        <code
-          className="rounded-sm border border-border bg-muted px-1.5 py-0.5 font-mono font-semibold tracking-widest text-foreground"
-          data-testid="signin-device-code"
-        >
-          {progress.userCode}
-        </code>
-        at
-        <span className="min-w-0 break-all font-medium text-foreground">
-          {progress.verificationUri}
-        </span>
-      </span>
-    </div>
-  );
-}
-
-function SignInErrorMessage(props: {
-  readonly status: AuthStatus;
-  readonly lastError: string | null;
-  readonly isHero: boolean;
-}) {
-  if (
-    props.status !== "signed-out" ||
-    props.lastError === null ||
-    props.lastError === AUTH_ERROR_SESSION_EXPIRED
-  ) {
-    return null;
-  }
-
-  return (
-    <span
-      className={cn(
-        "text-destructive",
-        props.isHero ? "text-ui-sm leading-6" : "text-ui-xs",
-      )}
-      data-testid="signin-error"
-      role="alert"
-    >
-      {messageForError(props.lastError)}
-      <span className="sr-only" data-testid="signin-error-detail">
-        {props.lastError}
-      </span>
-    </span>
-  );
-}
-
-function PrimarySignInButton(props: {
-  readonly auth: AuthService;
-  readonly isHero: boolean;
-  readonly isSigningIn: boolean;
-}) {
-  const label = props.isSigningIn ? "Signing in" : "Sign in";
-
-  return (
-    <Button
-      type="button"
-      size={props.isHero ? "lg" : "sm"}
-      variant={props.isHero ? "default" : "outline"}
-      disabled={props.isSigningIn}
-      onClick={() => {
-        void props.auth.signIn();
-      }}
-      data-testid="signin-button"
-      className={cn("cursor-pointer", props.isHero ? "w-full" : null)}
-    >
-      {label}
-      {props.isSigningIn ? (
-        <AgentSpinningDots
-          variant="dots"
-          className="ml-1.5"
-          testId="signin-spinner"
-        />
-      ) : null}
-    </Button>
-  );
-}
-
-function RetrySignInButton(props: {
-  readonly auth: AuthService;
-  readonly isHero: boolean;
-  readonly isSigningIn: boolean;
-}) {
-  if (!props.isSigningIn) return null;
-
-  return (
-    // A stalled browser attempt (callback never returns) would otherwise leave
-    // the user stuck on "Signing in" until the timeout. `signIn()` is
-    // re-entrant - it supersedes the in-flight attempt and re-opens the sign-in
-    // surface - so this gives an immediate escape hatch.
-    <Button
-      type="button"
-      size={props.isHero ? "default" : "sm"}
-      variant="link"
-      data-testid="signin-retry-link"
-      onClick={() => {
-        void props.auth.signIn();
-      }}
-      className={cn(
-        props.isHero ? "h-auto justify-center px-0 py-0 text-ui-sm" : null,
-      )}
-    >
-      Taking too long? Retry
-    </Button>
-  );
-}
-
-function messageForError(error: string): string {
-  if (error === AUTH_ERROR_LAUNCH_FAILED) {
-    return "Could not start sign-in. Please try again.";
-  }
-  if (error === AUTH_ERROR_SESSION_EXPIRED) {
-    return "Session expired - sign in again.";
-  }
-  if (error === AUTH_ERROR_SIGN_IN_FAILED) {
-    return "Sign-in failed - please try again.";
-  }
-  if (error === AUTH_ERROR_DEVICE_DENIED) {
-    return "Request denied - sign in again.";
-  }
-  if (error === AUTH_ERROR_DEVICE_EXPIRED) {
-    return "The code expired - start again.";
-  }
-  return "Sign in failed. Please try again.";
 }

--- a/clients/gui-app/src/components/layout/header/sign-in/copyable-approval-field.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/copyable-approval-field.tsx
@@ -79,7 +79,7 @@ export function CopyableApprovalField(props: {
         )}
         aria-live="polite"
       >
-        Copied
+        {copied ? "Copied" : ""}
       </span>
     </div>
   );

--- a/clients/gui-app/src/components/layout/header/sign-in/copyable-approval-field.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/copyable-approval-field.tsx
@@ -1,0 +1,86 @@
+import { Check, Copy } from "lucide-react";
+import { toast } from "sonner";
+import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
+import { cn } from "@/lib/utils";
+import { COPY_CONFIRMATION_RESET_MS } from "./styles";
+
+const handleCopyError = (): void => {
+  toast.error("Couldn't copy to clipboard.");
+};
+
+export function CopyableApprovalField(props: {
+  readonly label: string;
+  readonly value: string;
+  readonly copyLabel: string;
+  readonly testId: string;
+  readonly isHero: boolean;
+  readonly valueKind: "code" | "url";
+}) {
+  const { copied, copy } = useClipboardCopy({
+    resetMs: COPY_CONFIRMATION_RESET_MS,
+    onSuccess: null,
+    onError: handleCopyError,
+  });
+
+  return (
+    <div className="grid gap-1.5">
+      <span
+        className={cn(
+          "font-mono text-overline uppercase",
+          props.isHero ? "text-white/[0.55]" : "text-muted-foreground",
+        )}
+      >
+        {props.label}
+      </span>
+      <div
+        className={cn(
+          "flex min-w-0 items-center rounded-md border transition-colors",
+          props.isHero
+            ? "border-white/[0.14] bg-black/[0.16] focus-within:border-white/[0.45]"
+            : "border-border bg-background focus-within:border-ring",
+        )}
+      >
+        <span
+          className={cn(
+            "min-w-0 flex-1 px-3 py-2 text-left font-mono font-semibold",
+            props.valueKind === "code"
+              ? "tracking-widest"
+              : "truncate tracking-normal",
+            props.isHero ? "text-white" : "text-foreground",
+          )}
+          title={props.value}
+          data-testid={props.testId}
+        >
+          {props.value}
+        </span>
+        <button
+          type="button"
+          onClick={() => copy(props.value)}
+          aria-label={copied ? "Copied" : props.copyLabel}
+          className={cn(
+            "mr-1 inline-flex size-8 shrink-0 items-center justify-center rounded-md transition-colors focus-visible:ring-1 focus-visible:outline-none",
+            props.isHero
+              ? "text-white/[0.58] hover:bg-white/10 hover:text-white focus-visible:ring-white/[0.55]"
+              : "text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring",
+          )}
+        >
+          {copied ? (
+            <Check className="size-3.5" aria-hidden="true" />
+          ) : (
+            <Copy className="size-3.5" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+      <span
+        className={cn(
+          "min-h-4 text-ui-xs",
+          copied ? "opacity-100" : "opacity-0",
+          props.isHero ? "text-white/[0.62]" : "text-muted-foreground",
+        )}
+        aria-live="polite"
+      >
+        Copied
+      </span>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/layout/header/sign-in/device-code-fallback.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/device-code-fallback.tsx
@@ -1,0 +1,68 @@
+import { ChevronRight } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { type DeviceFlowProgress } from "@/lib/auth/auth-service";
+import { cn } from "@/lib/utils";
+import { CopyableApprovalField } from "./copyable-approval-field";
+
+export function DeviceCodeFallback(props: {
+  readonly progress: DeviceFlowProgress;
+  readonly isHero: boolean;
+}) {
+  return (
+    <Collapsible
+      className={cn(
+        "overflow-hidden rounded-md border",
+        props.isHero
+          ? "border-white/10 bg-black/[0.12]"
+          : "border-border/70 bg-muted/20",
+      )}
+    >
+      <CollapsibleTrigger
+        className={cn(
+          "group flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-ui-xs font-medium transition-colors",
+          props.isHero
+            ? "text-white/[0.72] hover:bg-white/[0.07] hover:text-white"
+            : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+        )}
+        data-testid="signin-device-fallback-trigger"
+      >
+        <span>Use code instead</span>
+        <ChevronRight
+          className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90"
+          aria-hidden="true"
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div
+          className={cn(
+            "grid gap-3 border-t px-3 py-3 text-left",
+            props.isHero
+              ? "border-white/10 text-white/[0.65]"
+              : "border-border/70 text-muted-foreground",
+          )}
+        >
+          <CopyableApprovalField
+            label="Device code"
+            value={props.progress.userCode}
+            copyLabel="Copy device code"
+            testId="signin-device-code"
+            isHero={props.isHero}
+            valueKind="code"
+          />
+          <CopyableApprovalField
+            label="Approval address"
+            value={props.progress.verificationUri}
+            copyLabel="Copy approval address"
+            testId="signin-device-url"
+            isHero={props.isHero}
+            valueKind="url"
+          />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/clients/gui-app/src/components/layout/header/sign-in/device-code-progress.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/device-code-progress.tsx
@@ -1,9 +1,10 @@
-import { Clock, SquareArrowOutUpRight } from "lucide-react";
+import { CircleAlert, Clock, SquareArrowOutUpRight } from "lucide-react";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { useAuthOpenVerificationPageMutation } from "@/hooks/auth/use-auth-open-verification-page-mutation";
+import { useAuthSignInMutation } from "@/hooks/auth/use-auth-sign-in-mutation";
 import { type DeviceFlowProgress } from "@/lib/auth/auth-service";
 import { formatClockDuration } from "@/lib/format-duration";
-import { useAuthService } from "@/lib/host";
 import { cn } from "@/lib/utils";
 import { DeviceCodeFallback } from "./device-code-fallback";
 import { useRemainingDeviceSeconds } from "./use-remaining-device-seconds";
@@ -20,13 +21,14 @@ export function DeviceCodeProgress(props: {
   readonly progress: DeviceFlowProgress;
   readonly isHero: boolean;
 }) {
-  const auth = useAuthService();
+  const openVerificationPageMutation = useAuthOpenVerificationPageMutation();
+  const signInMutation = useAuthSignInMutation();
   const progress = props.progress;
   const remainingSeconds = useRemainingDeviceSeconds(progress.expiresAtMs);
-  const expiryCopy =
-    remainingSeconds === 0
-      ? "Code expired"
-      : `Expires in ${formatClockDuration(remainingSeconds)}`;
+  const isExpired = remainingSeconds === 0;
+  const expiryCopy = isExpired
+    ? "Code expired"
+    : `Expires in ${formatClockDuration(remainingSeconds)}`;
 
   return (
     <div
@@ -56,7 +58,7 @@ export function DeviceCodeProgress(props: {
               ? "h-11 border-white/20 bg-white text-zinc-950 hover:bg-white/90"
               : null,
           )}
-          onClick={() => auth.openVerificationPage()}
+          onClick={() => openVerificationPageMutation.mutate()}
           data-testid="signin-open-approval"
         >
           Open approval page
@@ -71,14 +73,21 @@ export function DeviceCodeProgress(props: {
               : "border-border/70 bg-muted/30 text-muted-foreground",
           )}
         >
-          <div className="flex items-center gap-1">
-            <AgentSpinningDots
-              variant="dots"
-              className="ml-0.5 shrink-0"
-              testId="signin-device-spinner"
-            />
-            <span className="shrink-0">Waiting for approval</span>
-          </div>
+          {isExpired ? (
+            <div className="flex items-center gap-1">
+              <CircleAlert className="size-3.5 shrink-0" aria-hidden="true" />
+              <span className="shrink-0">Approval code expired</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1">
+              <AgentSpinningDots
+                variant="dots"
+                className="ml-0.5 shrink-0"
+                testId="signin-device-spinner"
+              />
+              <span className="shrink-0">Waiting for approval</span>
+            </div>
+          )}
           <div className="flex items-center gap-1">
             <Clock className="size-3.5 shrink-0" aria-hidden="true" />
             <span className="truncate">{expiryCopy}</span>
@@ -93,7 +102,7 @@ export function DeviceCodeProgress(props: {
           variant="link"
           data-testid="signin-retry-link"
           onClick={() => {
-            void auth.signIn();
+            signInMutation.mutate();
           }}
           className={cn(
             "h-auto self-center px-0 py-0",

--- a/clients/gui-app/src/components/layout/header/sign-in/device-code-progress.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/device-code-progress.tsx
@@ -1,0 +1,110 @@
+import { Clock, SquareArrowOutUpRight } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import { type DeviceFlowProgress } from "@/lib/auth/auth-service";
+import { formatClockDuration } from "@/lib/format-duration";
+import { useAuthService } from "@/lib/host";
+import { cn } from "@/lib/utils";
+import { DeviceCodeFallback } from "./device-code-fallback";
+import { useRemainingDeviceSeconds } from "./use-remaining-device-seconds";
+
+/**
+ * Active device-flow progress. The app already auto-opens the pre-filled
+ * approval page; this surface leads with a one-click "open approval page"
+ * affordance (re-opening `verification_uri_complete`, code embedded) so the
+ * user only ever has to click Approve - never type the code. The code + bare
+ * URL remain as a manual fallback, and the spinner keeps it from being a silent
+ * wait. Rendered while a device attempt is in flight.
+ */
+export function DeviceCodeProgress(props: {
+  readonly progress: DeviceFlowProgress;
+  readonly isHero: boolean;
+}) {
+  const auth = useAuthService();
+  const progress = props.progress;
+  const remainingSeconds = useRemainingDeviceSeconds(progress.expiresAtMs);
+  const expiryCopy =
+    remainingSeconds === 0
+      ? "Code expired"
+      : `Expires in ${formatClockDuration(remainingSeconds)}`;
+
+  return (
+    <div
+      className={cn(
+        "flex w-full flex-col overflow-hidden rounded-lg border text-card-foreground shadow-sm",
+        props.isHero
+          ? "border-white/15 bg-white/[0.075] text-white shadow-[0_1.5rem_4rem_rgba(0,0,0,0.34)] backdrop-blur-xl"
+          : "border-border bg-card",
+      )}
+      data-testid="signin-device-progress"
+    >
+      <div className={cn("flex flex-col gap-4", props.isHero ? "p-5" : "p-4")}>
+        <div className="space-y-1.5 text-center">
+          <h2 className="font-heading font-medium tracking-normal">
+            Approve in your browser
+          </h2>
+          <p className="mx-auto max-w-[32ch] leading-5 text-ui-sm text-muted-foreground">
+            After you approve, Traycer will continue here.
+          </p>
+        </div>
+
+        <Button
+          size={props.isHero ? "lg" : "sm"}
+          className={cn(
+            "w-full",
+            props.isHero
+              ? "h-11 border-white/20 bg-white text-zinc-950 hover:bg-white/90"
+              : null,
+          )}
+          onClick={() => auth.openVerificationPage()}
+          data-testid="signin-open-approval"
+        >
+          Open approval page
+          <SquareArrowOutUpRight className="size-4" aria-hidden="true" />
+        </Button>
+
+        <div
+          className={cn(
+            "flex min-w-0 items-center justify-between gap-1.5 rounded-md border px-3 py-2 text-ui-xs",
+            props.isHero
+              ? "border-white/10 bg-black/[0.18] text-white/[0.65]"
+              : "border-border/70 bg-muted/30 text-muted-foreground",
+          )}
+        >
+          <div className="flex items-center gap-1">
+            <AgentSpinningDots
+              variant="dots"
+              className="ml-0.5 shrink-0"
+              testId="signin-device-spinner"
+            />
+            <span className="shrink-0">Waiting for approval</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Clock className="size-3.5 shrink-0" aria-hidden="true" />
+            <span className="truncate">{expiryCopy}</span>
+          </div>
+        </div>
+
+        <DeviceCodeFallback progress={progress} isHero={props.isHero} />
+
+        <Button
+          type="button"
+          size={props.isHero ? "default" : "sm"}
+          variant="link"
+          data-testid="signin-retry-link"
+          onClick={() => {
+            void auth.signIn();
+          }}
+          className={cn(
+            "h-auto self-center px-0 py-0",
+            props.isHero
+              ? "text-ui-sm text-white/[0.72] hover:text-white"
+              : "text-ui-xs",
+          )}
+        >
+          Taking too long? Start over
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/layout/header/sign-in/sign-in-action-buttons.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/sign-in-action-buttons.tsx
@@ -1,6 +1,6 @@
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
-import { useAuthService } from "@/lib/host";
+import { useAuthSignInMutation } from "@/hooks/auth/use-auth-sign-in-mutation";
 import { cn } from "@/lib/utils";
 import { HERO_PRIMARY_BUTTON_CLASS } from "./styles";
 
@@ -8,17 +8,17 @@ export function PrimarySignInButton(props: {
   readonly isHero: boolean;
   readonly isSigningIn: boolean;
 }) {
-  const auth = useAuthService();
-  const label = props.isSigningIn ? "Signing in" : "Sign in";
+  const signInMutation = useAuthSignInMutation();
+  const isPending = props.isSigningIn || signInMutation.isPending;
 
   return (
     <Button
       type="button"
       size={props.isHero ? "lg" : "sm"}
       variant={props.isHero ? "default" : "outline"}
-      disabled={props.isSigningIn}
+      disabled={isPending}
       onClick={() => {
-        void auth.signIn();
+        signInMutation.mutate();
       }}
       data-testid="signin-button"
       className={cn(
@@ -26,8 +26,8 @@ export function PrimarySignInButton(props: {
         props.isHero && HERO_PRIMARY_BUTTON_CLASS,
       )}
     >
-      {label}
-      {props.isSigningIn ? (
+      Sign in
+      {isPending ? (
         <AgentSpinningDots
           variant="dots"
           className="ml-1.5"
@@ -42,7 +42,7 @@ export function RetrySignInButton(props: {
   readonly isHero: boolean;
   readonly isSigningIn: boolean;
 }) {
-  const auth = useAuthService();
+  const signInMutation = useAuthSignInMutation();
 
   if (!props.isSigningIn) return null;
 
@@ -56,8 +56,9 @@ export function RetrySignInButton(props: {
       size={props.isHero ? "default" : "sm"}
       variant="link"
       data-testid="signin-retry-link"
+      disabled={signInMutation.isPending}
       onClick={() => {
-        void auth.signIn();
+        signInMutation.mutate();
       }}
       className={cn(
         props.isHero ? "h-auto justify-center px-0 py-0 text-ui-sm" : null,

--- a/clients/gui-app/src/components/layout/header/sign-in/sign-in-action-buttons.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/sign-in-action-buttons.tsx
@@ -1,0 +1,69 @@
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import { useAuthService } from "@/lib/host";
+import { cn } from "@/lib/utils";
+import { HERO_PRIMARY_BUTTON_CLASS } from "./styles";
+
+export function PrimarySignInButton(props: {
+  readonly isHero: boolean;
+  readonly isSigningIn: boolean;
+}) {
+  const auth = useAuthService();
+  const label = props.isSigningIn ? "Signing in" : "Sign in";
+
+  return (
+    <Button
+      type="button"
+      size={props.isHero ? "lg" : "sm"}
+      variant={props.isHero ? "default" : "outline"}
+      disabled={props.isSigningIn}
+      onClick={() => {
+        void auth.signIn();
+      }}
+      data-testid="signin-button"
+      className={cn(
+        "cursor-pointer",
+        props.isHero && HERO_PRIMARY_BUTTON_CLASS,
+      )}
+    >
+      {label}
+      {props.isSigningIn ? (
+        <AgentSpinningDots
+          variant="dots"
+          className="ml-1.5"
+          testId="signin-spinner"
+        />
+      ) : null}
+    </Button>
+  );
+}
+
+export function RetrySignInButton(props: {
+  readonly isHero: boolean;
+  readonly isSigningIn: boolean;
+}) {
+  const auth = useAuthService();
+
+  if (!props.isSigningIn) return null;
+
+  return (
+    // A stalled browser attempt (callback never returns) would otherwise leave
+    // the user stuck on "Signing in" until the timeout. `signIn()` is
+    // re-entrant - it supersedes the in-flight attempt and re-opens the sign-in
+    // surface - so this gives an immediate escape hatch.
+    <Button
+      type="button"
+      size={props.isHero ? "default" : "sm"}
+      variant="link"
+      data-testid="signin-retry-link"
+      onClick={() => {
+        void auth.signIn();
+      }}
+      className={cn(
+        props.isHero ? "h-auto justify-center px-0 py-0 text-ui-sm" : null,
+      )}
+    >
+      Taking too long? Retry
+    </Button>
+  );
+}

--- a/clients/gui-app/src/components/layout/header/sign-in/sign-in-error-message.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/sign-in-error-message.tsx
@@ -31,7 +31,11 @@ export function SignInErrorMessage(props: {
       role="alert"
     >
       {messageForError(props.lastError)}
-      <span className="sr-only" data-testid="signin-error-detail">
+      <span
+        className="sr-only"
+        data-testid="signin-error-detail"
+        aria-hidden="true"
+      >
         {props.lastError}
       </span>
     </span>

--- a/clients/gui-app/src/components/layout/header/sign-in/sign-in-error-message.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/sign-in-error-message.tsx
@@ -1,0 +1,58 @@
+import {
+  AUTH_ERROR_DEVICE_DENIED,
+  AUTH_ERROR_DEVICE_EXPIRED,
+  AUTH_ERROR_LAUNCH_FAILED,
+  AUTH_ERROR_SESSION_EXPIRED,
+  AUTH_ERROR_SIGN_IN_FAILED,
+} from "@/lib/auth/auth-service";
+import { cn } from "@/lib/utils";
+import { type AuthStatus } from "@/stores/auth/auth-store";
+
+export function SignInErrorMessage(props: {
+  readonly status: AuthStatus;
+  readonly lastError: string | null;
+  readonly isHero: boolean;
+}) {
+  if (
+    props.status !== "signed-out" ||
+    props.lastError === null ||
+    props.lastError === AUTH_ERROR_SESSION_EXPIRED
+  ) {
+    return null;
+  }
+
+  return (
+    <span
+      className={cn(
+        "text-destructive",
+        props.isHero ? "text-ui-sm leading-6" : "text-ui-xs",
+      )}
+      data-testid="signin-error"
+      role="alert"
+    >
+      {messageForError(props.lastError)}
+      <span className="sr-only" data-testid="signin-error-detail">
+        {props.lastError}
+      </span>
+    </span>
+  );
+}
+
+function messageForError(error: string): string {
+  if (error === AUTH_ERROR_LAUNCH_FAILED) {
+    return "Could not start sign-in. Please try again.";
+  }
+  if (error === AUTH_ERROR_SESSION_EXPIRED) {
+    return "Session expired - sign in again.";
+  }
+  if (error === AUTH_ERROR_SIGN_IN_FAILED) {
+    return "Sign-in failed - please try again.";
+  }
+  if (error === AUTH_ERROR_DEVICE_DENIED) {
+    return "Request denied - sign in again.";
+  }
+  if (error === AUTH_ERROR_DEVICE_EXPIRED) {
+    return "The code expired - start again.";
+  }
+  return "Sign in failed. Please try again.";
+}

--- a/clients/gui-app/src/components/layout/header/sign-in/styles.ts
+++ b/clients/gui-app/src/components/layout/header/sign-in/styles.ts
@@ -1,0 +1,4 @@
+export const HERO_PRIMARY_BUTTON_CLASS =
+  "h-[clamp(2.5rem,5.2vh,3rem)] w-[min(100%,13rem)] self-center text-ui-sm transition-colors duration-200 hover:border-white/60 hover:bg-transparent hover:text-white";
+
+export const COPY_CONFIRMATION_RESET_MS = 1600;

--- a/clients/gui-app/src/components/layout/header/sign-in/types.ts
+++ b/clients/gui-app/src/components/layout/header/sign-in/types.ts
@@ -1,0 +1,1 @@
+export type SignInLayout = "compact" | "hero";

--- a/clients/gui-app/src/components/layout/header/sign-in/use-remaining-device-seconds.ts
+++ b/clients/gui-app/src/components/layout/header/sign-in/use-remaining-device-seconds.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export function useRemainingDeviceSeconds(expiresAtMs: number): number {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setNowMs(Date.now());
+    }, 1000);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  return remainingSecondsUntil(expiresAtMs, nowMs);
+}
+
+function remainingSecondsUntil(expiresAtMs: number, nowMs: number): number {
+  return Math.max(0, Math.ceil((expiresAtMs - nowMs) / 1000));
+}

--- a/clients/gui-app/src/hooks/auth/use-auth-open-verification-page-mutation.ts
+++ b/clients/gui-app/src/hooks/auth/use-auth-open-verification-page-mutation.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+import { useAuthService } from "@/lib/host";
+import { authMutationKeys } from "@/lib/query-keys";
+
+export function useAuthOpenVerificationPageMutation() {
+  const auth = useAuthService();
+  return useMutation({
+    mutationKey: authMutationKeys.openVerificationPage(),
+    mutationFn: () => {
+      auth.openVerificationPage();
+      return Promise.resolve();
+    },
+  });
+}

--- a/clients/gui-app/src/hooks/auth/use-auth-sign-in-mutation.ts
+++ b/clients/gui-app/src/hooks/auth/use-auth-sign-in-mutation.ts
@@ -1,0 +1,11 @@
+import { useMutation } from "@tanstack/react-query";
+import { useAuthService } from "@/lib/host";
+import { authMutationKeys } from "@/lib/query-keys";
+
+export function useAuthSignInMutation() {
+  const auth = useAuthService();
+  return useMutation({
+    mutationKey: authMutationKeys.signIn(),
+    mutationFn: () => auth.signIn(),
+  });
+}

--- a/clients/gui-app/src/hooks/auth/use-auth-sign-in-mutation.ts
+++ b/clients/gui-app/src/hooks/auth/use-auth-sign-in-mutation.ts
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/react-query";
+import { toastFromAuthError } from "@/lib/auth-error-toast";
 import { useAuthService } from "@/lib/host";
 import { authMutationKeys } from "@/lib/query-keys";
 
@@ -7,5 +8,6 @@ export function useAuthSignInMutation() {
   return useMutation({
     mutationKey: authMutationKeys.signIn(),
     mutationFn: () => auth.signIn(),
+    onError: (error) => toastFromAuthError(error, "Couldn't start sign-in."),
   });
 }

--- a/clients/gui-app/src/lib/auth-error-toast.ts
+++ b/clients/gui-app/src/lib/auth-error-toast.ts
@@ -1,0 +1,11 @@
+import { toast } from "sonner";
+import { readErrorMessage } from "@/lib/read-error-message";
+
+export function toastFromAuthError(error: unknown, fallback: string): void {
+  const message = readErrorMessage(error);
+  if (message !== null) {
+    toast.error(fallback, { description: message });
+    return;
+  }
+  toast.error(fallback);
+}

--- a/clients/gui-app/src/lib/query-keys/auth-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/auth-mutation-keys.ts
@@ -1,0 +1,4 @@
+export const authMutationKeys = {
+  signIn: () => ["auth", "signIn"] as const,
+  openVerificationPage: () => ["auth", "openVerificationPage"] as const,
+};

--- a/clients/gui-app/src/lib/query-keys/index.ts
+++ b/clients/gui-app/src/lib/query-keys/index.ts
@@ -12,6 +12,7 @@ export { gitQueryKeys } from "@/lib/query-keys/git-query-keys";
 export { gitMutationKeys } from "@/lib/query-keys/git-mutation-keys";
 export { workspaceMutationKeys } from "@/lib/query-keys/workspace-mutation-keys";
 export { authQueryKeys } from "@/lib/query-keys/auth-query-keys";
+export { authMutationKeys } from "@/lib/query-keys/auth-mutation-keys";
 export {
   runnerMutationKeys,
   runnerQueryKeys,


### PR DESCRIPTION
## Summary
- redesign the GUI device approval sign-in state into a wider approval panel with primary browser CTA, inline status, and collapsed manual fallback
- add copyable device code and approval address fields
- split the sign-in surface into focused components under layout/header/sign-in
- keep the auth landing page responsible for page composition instead of styling sign-in internals via test-id selectors

## Verification
- pre-commit run --all-files
- bun run test -- src/components/layout/__tests__/sign-in-button.test.tsx __tests__/traycer-app.test.tsx
- bun run compile
- npx -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score