### PR TITLE
Gate startup RPCs on host compatibility

### DIFF
--- a/clients/gui-app/src/components/__tests__/local-host-gate.test.tsx
+++ b/clients/gui-app/src/components/__tests__/local-host-gate.test.tsx
@@ -634,13 +634,45 @@ describe("LocalHostGate", () => {
     expect(screen.queryByText(/Force restart/i)).toBeNull();
     expect(screen.queryByText(/Force update/i)).toBeNull();
     expect(screen.queryByText(/Retry check/i)).toBeNull();
-    expect(
-      screen.getByTestId("local-host-incompatible-update").textContent,
-    ).toContain("Update host");
+    expect(screen.queryByRole("button", { name: "Update host" })).toBeNull();
     expect(screen.queryByTestId("gate-children")).toBeNull();
     expect(activeMessenger?.calls.map((entry) => entry.method)).not.toContain(
       "epic.listTasks",
     );
+  });
+
+  it("shows a retryable error when the compatibility probe fails after retries", async () => {
+    useAuthStore.getState().setSignedIn(
+      {
+        userId: "test-user",
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      { userId: "test-user", username: "Test User" },
+      [],
+    );
+    mountGateWithRuntime(
+      makeHost(validSnapshot),
+      localEntry,
+      () => {
+        throw new HostRpcError({
+          code: "RPC_ERROR",
+          message: "status probe failed",
+          requestId: "req-status",
+          method: "host.status",
+          fatalDetails: null,
+        });
+      },
+      <div data-testid="gate-children">children</div>,
+    );
+
+    expect(
+      await screen.findByText(
+        "Could not verify host compatibility. status probe failed",
+      ),
+    ).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Retry" })).not.toBeNull();
+    expect(screen.queryByTestId("gate-children")).toBeNull();
   });
 
   it("treats downgrade-unsupported as a terminal normal-launch compatibility failure", async () => {
@@ -716,8 +748,7 @@ describe("LocalHostGate", () => {
       <div data-testid="gate-children">children</div>,
     );
 
-    const update = await screen.findByTestId("local-host-incompatible-update");
-    expect(update.textContent).toContain("Update host");
+    const update = await screen.findByRole("button", { name: "Update host" });
     fireEvent.click(update);
 
     await waitFor(() => {
@@ -783,12 +814,10 @@ describe("LocalHostGate", () => {
     expect(
       screen.getByTestId("local-host-incompatible-reason").textContent,
     ).toContain("Incompatible methods: epic.listTasks");
-    const refresh = screen.getByTestId("local-host-incompatible-busy-refresh");
-    expect(refresh.textContent).toContain("Refresh");
+    const refresh = screen.getByRole("button", { name: "Refresh" });
     expect(
-      screen.getByTestId("local-host-incompatible-busy-force-update")
-        .textContent,
-    ).toContain("Force update host");
+      screen.getByRole("button", { name: "Force update host" }),
+    ).not.toBeNull();
     expect(screen.queryByText(/Force restart/i)).toBeNull();
     expect(screen.queryByText(/Retry update/i)).toBeNull();
 
@@ -801,9 +830,9 @@ describe("LocalHostGate", () => {
       expect.objectContaining({ force: false }),
     );
 
-    const forceUpdate = await screen.findByTestId(
-      "local-host-incompatible-busy-force-update",
-    );
+    const forceUpdate = await screen.findByRole("button", {
+      name: "Force update host",
+    });
     fireEvent.click(forceUpdate);
 
     await waitFor(() => {

--- a/clients/gui-app/src/components/__tests__/local-host-gate.test.tsx
+++ b/clients/gui-app/src/components/__tests__/local-host-gate.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   act,
   cleanup,
@@ -16,6 +16,11 @@ import type {
 } from "@traycer-clients/shared/platform/runner-host";
 import type { Disposable } from "@traycer-clients/shared/platform/uri-callback";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import {
+  HostRpcError,
+  type ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import {
   LOCAL_HOST_SLOW_START_THRESHOLD_MS,
@@ -24,6 +29,20 @@ import {
 } from "@/components/local-host-gate";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { useAuthStore } from "@/stores/auth/auth-store";
+import {
+  HostCompatibilityProvider,
+  hostRpcRegistry,
+  HostRuntimeProvider,
+  useHostClient,
+  type HostRpcRegistry,
+  type MessengerFactory,
+} from "@/lib/host";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import {
+  CURRENT_EPIC_VERSION,
+  CURRENT_PHASE_VERSION,
+} from "@traycer-clients/shared/epic/epic-version";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 const validSnapshot: LocalHostSnapshot = {
   hostId: "desktop-pid-1",
@@ -51,6 +70,18 @@ const remoteEntry: HostDirectoryEntry = {
   version: "1.2.3",
   status: "available",
 };
+
+type HostStatusResponse = ResponseOfMethod<HostRpcRegistry, "host.status">;
+type HostStatusHandler = () => Promise<HostStatusResponse> | HostStatusResponse;
+
+const compatibleHostStatus: HostStatusResponse = {
+  ready: true,
+  hostVersion: "1.2.3",
+  protocolVersion: { major: 1, minor: 0 },
+};
+
+let activeMessenger: MockHostMessenger<HostRpcRegistry> | null = null;
+let restoreFetch: () => void = () => undefined;
 
 function makeHost(snapshot: LocalHostSnapshot | null): MockRunnerHost {
   return new MockRunnerHost({
@@ -157,6 +188,33 @@ function withQueryClient(children: ReactNode): ReactNode {
   );
 }
 
+function seedStoredToken(host: MockRunnerHost): void {
+  void host.tokenStore.set({
+    token: "test-token",
+    refreshToken: "test-refresh-token",
+  });
+}
+
+function buildMessengerFactory(
+  hostStatus: HostStatusHandler,
+): MessengerFactory<HostRpcRegistry> {
+  return (args) => {
+    const messenger = new MockHostMessenger<HostRpcRegistry>({
+      registry: args.registry,
+      requestId: () => `req-${Math.random().toString(36).slice(2, 8)}`,
+      handlers: {
+        "host.status": () => hostStatus(),
+        "epic.listTasks": () => ({
+          tasks: [],
+          hasMore: false,
+        }),
+      },
+    });
+    activeMessenger = messenger;
+    return messenger;
+  };
+}
+
 function mountGate(
   host: MockRunnerHost,
   selectedEntry: HostDirectoryEntry | null,
@@ -178,6 +236,68 @@ function mountGate(
       </RunnerHostProvider>,
     ),
   );
+}
+
+function mountGateWithRuntime(
+  host: MockRunnerHost,
+  selectedEntry: HostDirectoryEntry | null,
+  hostStatus: HostStatusHandler,
+  children: ReactNode,
+): void {
+  if (useAuthStore.getState().status === "signed-in") {
+    seedStoredToken(host);
+  }
+  render(
+    <RunnerHostProvider runnerHost={host}>
+      <QueryClientProvider client={buildQueryClient()}>
+        <TooltipProvider>
+          <HostRuntimeProvider
+            registry={hostRpcRegistry}
+            messengerFactory={buildMessengerFactory(hostStatus)}
+            invalidator={null}
+            requestId={null}
+            remoteFetcher={() => Promise.resolve([])}
+            fallback={<div data-testid="runtime-fallback">runtime loading</div>}
+          >
+            <HostCompatibilityProvider>
+              <LocalHostGate
+                bypass={false}
+                selectedEntry={selectedEntry}
+                loading={
+                  <div data-testid="gate-loading">
+                    Starting local Traycer Host…
+                  </div>
+                }
+                provisioningLoading={null}
+                unavailable={
+                  <div data-testid="gate-unavailable">unavailable</div>
+                }
+              >
+                {children}
+              </LocalHostGate>
+            </HostCompatibilityProvider>
+          </HostRuntimeProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </RunnerHostProvider>,
+  );
+}
+
+function HostBackedTasksProbe(): ReactNode {
+  const client = useHostClient();
+  useHostQuery<HostRpcRegistry, "epic.listTasks">({
+    client,
+    method: "epic.listTasks",
+    params: {
+      limit: 20,
+      filters: null,
+      sort: "recent",
+      extensionPhaseVersion: String(CURRENT_PHASE_VERSION),
+      extensionEpicVersion: String(CURRENT_EPIC_VERSION),
+    },
+    options: null,
+  });
+  return <div data-testid="gate-children">children</div>;
 }
 
 function mountGateWithRealUnavailable(
@@ -211,11 +331,80 @@ function advancePastSlowStartThreshold(): void {
   });
 }
 
+function installAuthFetch(): () => void {
+  const originalFetch: unknown = (globalThis as { fetch?: unknown }).fetch;
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    writable: true,
+    value: (input: unknown): Promise<Response> => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.endsWith("/api/v3/user")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              user: {
+                id: "user-1",
+                name: "Test User",
+                providerId: "gh-1",
+                providerHandle: "test-user",
+                providerType: "GITHUB",
+                email: "test@example.com",
+                avatarUrl: null,
+                activatedAt: null,
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                lastSeenAt: null,
+                privacyMode: false,
+                isLearningEnabled: true,
+              },
+              userSubscription: {
+                id: "sub-1",
+                userID: "user-1",
+                orgID: null,
+                teamID: null,
+                customerId: "cus-1",
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                subscriptionExpiry: null,
+                trialEndsAt: null,
+                subscriptionStatus: "FREE",
+                hasPaymentMethod: false,
+                isInTrial: false,
+                rechargeRateSeconds: 0,
+              },
+              teamSubscriptions: [],
+              payAsYouGoUsage: { allowPayAsYouGo: false },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.reject(
+        new Error(`unexpected fetch in local-host-gate test: ${url}`),
+      );
+    },
+  });
+  return () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
+  };
+}
+
 describe("LocalHostGate", () => {
+  beforeEach(() => {
+    activeMessenger = null;
+    restoreFetch = installAuthFetch();
+  });
+
   afterEach(() => {
     cleanup();
     useAuthStore.getState().setSignedOut();
     vi.useRealTimers();
+    vi.restoreAllMocks();
+    restoreFetch();
   });
 
   it("passes children through when the user is signed out, even on a null snapshot", () => {
@@ -335,8 +524,7 @@ describe("LocalHostGate", () => {
     });
   });
 
-  it("auto-transitions from Stage 1 loading to children when a valid snapshot arrives before the threshold", () => {
-    vi.useFakeTimers();
+  it("auto-transitions from Stage 1 loading to children when a valid snapshot arrives", async () => {
     useAuthStore.getState().setSignedIn(
       {
         userId: "test-user",
@@ -347,31 +535,25 @@ describe("LocalHostGate", () => {
       [],
     );
     const host = makeHost(null);
-    mountGateWithRealUnavailable(host, localEntry);
+    mountGateWithRuntime(
+      host,
+      localEntry,
+      () => compatibleHostStatus,
+      <div data-testid="gate-children">children</div>,
+    );
 
-    expect(screen.queryByTestId("gate-loading")).not.toBeNull();
-    expect(screen.queryByTestId("local-host-retry")).toBeNull();
-
-    // Partial advance - still within the loading window.
-    act(() => {
-      vi.advanceTimersByTime(
-        Math.floor(LOCAL_HOST_SLOW_START_THRESHOLD_MS / 2),
-      );
+    await waitFor(() => {
+      expect(screen.queryByTestId("gate-loading")).not.toBeNull();
     });
-    expect(screen.queryByTestId("gate-loading")).not.toBeNull();
-    expect(screen.queryByTestId("local-host-retry")).toBeNull();
 
     act(() => {
       host.setLocalHost(validSnapshot);
     });
 
-    expect(screen.queryByTestId("gate-children")).not.toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByTestId("gate-children")).not.toBeNull();
+    });
     expect(screen.queryByTestId("gate-loading")).toBeNull();
-    expect(screen.queryByTestId("local-host-unavailable")).toBeNull();
-
-    // Advancing further must not flip children back to unavailable.
-    advancePastSlowStartThreshold();
-    expect(screen.queryByTestId("gate-children")).not.toBeNull();
     expect(screen.queryByTestId("local-host-unavailable")).toBeNull();
   });
 
@@ -385,15 +567,254 @@ describe("LocalHostGate", () => {
       { userId: "test-user", username: "Test User" },
       [],
     );
-    mountGate(makeHost(validSnapshot), localEntry);
+    mountGateWithRuntime(
+      makeHost(validSnapshot),
+      localEntry,
+      () => compatibleHostStatus,
+      <div data-testid="gate-children">children</div>,
+    );
 
     await waitFor(() => {
       expect(screen.queryByTestId("gate-children")).not.toBeNull();
     });
   });
 
-  it("flips from children to Stage 1 loading, then Stage 2 unavailable, when a previously-valid snapshot becomes null", () => {
-    vi.useFakeTimers();
+  it("keeps the initializing host card while the initial compatibility probe is pending", async () => {
+    useAuthStore.getState().setSignedIn(
+      {
+        userId: "test-user",
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      { userId: "test-user", username: "Test User" },
+      [],
+    );
+    mountGateWithRuntime(
+      makeHost(validSnapshot),
+      localEntry,
+      () => new Promise<HostStatusResponse>(() => undefined),
+      <div data-testid="gate-children">children</div>,
+    );
+
+    expect(await screen.findByTestId("gate-loading")).not.toBeNull();
+    expect(screen.queryByTestId("local-host-compat-checking")).toBeNull();
+    expect(screen.queryByTestId("local-host-incompatible")).toBeNull();
+    expect(screen.queryByTestId("gate-children")).toBeNull();
+  });
+
+  it("blocks children and shows the protocol reason when the initial host is incompatible", async () => {
+    useAuthStore.getState().setSignedIn(
+      {
+        userId: "test-user",
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      { userId: "test-user", username: "Test User" },
+      [],
+    );
+    mountGateWithRuntime(
+      makeHost(validSnapshot),
+      localEntry,
+      () => {
+        throw new HostRpcError({
+          code: "INCOMPATIBLE",
+          message: "Incompatible methods: worktree.readScriptsAtRef",
+          requestId: "req-status",
+          method: "host.status",
+          fatalDetails: null,
+        });
+      },
+      <HostBackedTasksProbe />,
+    );
+
+    expect(await screen.findByTestId("local-host-incompatible")).not.toBeNull();
+    expect(
+      screen.getByTestId("local-host-incompatible-reason").textContent,
+    ).toContain("Incompatible methods: worktree.readScriptsAtRef");
+    expect(screen.queryByText(/Force restart/i)).toBeNull();
+    expect(screen.queryByText(/Force update/i)).toBeNull();
+    expect(screen.queryByText(/Retry check/i)).toBeNull();
+    expect(
+      screen.getByTestId("local-host-incompatible-update").textContent,
+    ).toContain("Update host");
+    expect(screen.queryByTestId("gate-children")).toBeNull();
+    expect(activeMessenger?.calls.map((entry) => entry.method)).not.toContain(
+      "epic.listTasks",
+    );
+  });
+
+  it("treats downgrade-unsupported as a terminal normal-launch compatibility failure", async () => {
+    useAuthStore.getState().setSignedIn(
+      {
+        userId: "test-user",
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      { userId: "test-user", username: "Test User" },
+      [],
+    );
+    mountGateWithRuntime(
+      makeHost(validSnapshot),
+      localEntry,
+      () => {
+        throw new HostRpcError({
+          code: "DOWNGRADE_UNSUPPORTED",
+          message: "No downgrade bridge for called method",
+          requestId: "req-status",
+          method: "host.status",
+          fatalDetails: null,
+        });
+      },
+      <div data-testid="gate-children">children</div>,
+    );
+
+    expect(await screen.findByTestId("local-host-incompatible")).not.toBeNull();
+    expect(
+      screen.getByTestId("local-host-incompatible-reason").textContent,
+    ).toContain("No downgrade bridge for called method");
+    expect(screen.queryByTestId("gate-children")).toBeNull();
+  });
+
+  it("normal-launch Update host calls ensureHost with force=true", async () => {
+    useAuthStore.getState().setSignedIn(
+      {
+        userId: "test-user",
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      { userId: "test-user", username: "Test User" },
+      [],
+    );
+    const ensureHost = vi.fn((): Promise<HostEnsureResult> =>
+      Promise.resolve({
+        action: "provisioned",
+        running: true,
+        version: "1.2.4",
+      }),
+    );
+    mountGateWithRuntime(
+      new MockRunnerHost({
+        signInUrl: "https://auth.traycer.invalid/sign-in",
+        authnBaseUrl: "http://localhost:5005",
+        localHost: validSnapshot,
+        hosts: [],
+        workspaceFolderPickerPaths: undefined,
+        hasLocalHost: undefined,
+        traycerCli: undefined,
+        hostManagement: makeHostManagement(ensureHost),
+      }),
+      localEntry,
+      () => {
+        throw new HostRpcError({
+          code: "INCOMPATIBLE",
+          message: "Incompatible methods",
+          requestId: "req-status",
+          method: "host.status",
+          fatalDetails: null,
+        });
+      },
+      <div data-testid="gate-children">children</div>,
+    );
+
+    const update = await screen.findByTestId("local-host-incompatible-update");
+    expect(update.textContent).toContain("Update host");
+    fireEvent.click(update);
+
+    await waitFor(() => {
+      expect(ensureHost).toHaveBeenCalledWith(
+        expect.objectContaining({ force: true }),
+      );
+    });
+  });
+
+  it("busy incompatible host can refresh busy status or force update", async () => {
+    useAuthStore.getState().setSignedIn(
+      {
+        userId: "test-user",
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      { userId: "test-user", username: "Test User" },
+      [],
+    );
+    const hostRef: { current: MockRunnerHost | null } = { current: null };
+    const ensureHost = vi.fn((): Promise<HostEnsureResult> => {
+      const currentHost = hostRef.current;
+      if (currentHost === null) {
+        return Promise.reject(new Error("host not mounted"));
+      }
+      currentHost.setLocalHost(validSnapshot);
+      return Promise.resolve({
+        action: "host-busy",
+        running: true,
+        version: "1.2.3",
+      });
+    });
+    const host = new MockRunnerHost({
+      signInUrl: "https://auth.traycer.invalid/sign-in",
+      authnBaseUrl: "http://localhost:5005",
+      localHost: null,
+      hosts: [],
+      workspaceFolderPickerPaths: undefined,
+      hasLocalHost: undefined,
+      traycerCli: undefined,
+      hostManagement: makeHostManagement(ensureHost),
+    });
+    hostRef.current = host;
+
+    mountGateWithRuntime(
+      host,
+      localEntry,
+      () => {
+        throw new HostRpcError({
+          code: "INCOMPATIBLE",
+          message: "Incompatible methods: epic.listTasks",
+          requestId: "req-status",
+          method: "host.status",
+          fatalDetails: null,
+        });
+      },
+      <div data-testid="gate-children">children</div>,
+    );
+
+    expect(
+      await screen.findByTestId("local-host-incompatible-busy"),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("local-host-incompatible-reason").textContent,
+    ).toContain("Incompatible methods: epic.listTasks");
+    const refresh = screen.getByTestId("local-host-incompatible-busy-refresh");
+    expect(refresh.textContent).toContain("Refresh");
+    expect(
+      screen.getByTestId("local-host-incompatible-busy-force-update")
+        .textContent,
+    ).toContain("Force update host");
+    expect(screen.queryByText(/Force restart/i)).toBeNull();
+    expect(screen.queryByText(/Retry update/i)).toBeNull();
+
+    fireEvent.click(refresh);
+
+    await waitFor(() => {
+      expect(ensureHost).toHaveBeenCalledTimes(2);
+    });
+    expect(ensureHost).toHaveBeenLastCalledWith(
+      expect.objectContaining({ force: false }),
+    );
+
+    const forceUpdate = await screen.findByTestId(
+      "local-host-incompatible-busy-force-update",
+    );
+    fireEvent.click(forceUpdate);
+
+    await waitFor(() => {
+      expect(ensureHost).toHaveBeenCalledTimes(3);
+    });
+    expect(ensureHost).toHaveBeenLastCalledWith(
+      expect.objectContaining({ force: true }),
+    );
+  });
+
+  it("flips from children to Stage 1 loading, then Stage 2 unavailable, when a previously-valid snapshot becomes null", async () => {
     const host = makeHost(validSnapshot);
     useAuthStore.getState().setSignedIn(
       {
@@ -404,9 +825,18 @@ describe("LocalHostGate", () => {
       { userId: "test-user", username: "Test User" },
       [],
     );
-    mountGate(host, localEntry);
+    mountGateWithRuntime(
+      host,
+      localEntry,
+      () => compatibleHostStatus,
+      <div data-testid="gate-children">children</div>,
+    );
 
-    expect(screen.queryByTestId("gate-children")).not.toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByTestId("gate-children")).not.toBeNull();
+    });
+
+    vi.useFakeTimers();
 
     act(() => {
       host.setLocalHost(null);
@@ -471,7 +901,12 @@ describe("LocalHostGate", () => {
       return originalSubscribe(handler);
     };
 
-    mountGate(host, localEntry);
+    mountGateWithRuntime(
+      host,
+      localEntry,
+      () => compatibleHostStatus,
+      <div data-testid="gate-children">children</div>,
+    );
 
     await waitFor(() => {
       expect(screen.queryByTestId("gate-children")).not.toBeNull();
@@ -520,7 +955,12 @@ describe("LocalHostGate", () => {
       { userId: "test-user", username: "Test User" },
       [],
     );
-    mountGate(makeHost(validSnapshot), null);
+    mountGateWithRuntime(
+      makeHost(validSnapshot),
+      null,
+      () => compatibleHostStatus,
+      <div data-testid="gate-children">children</div>,
+    );
 
     await waitFor(() => {
       expect(screen.queryByTestId("gate-children")).not.toBeNull();

--- a/clients/gui-app/src/components/local-host-gate.tsx
+++ b/clients/gui-app/src/components/local-host-gate.tsx
@@ -172,7 +172,7 @@ export function LocalHostGate(props: LocalHostGateProps) {
         source="busy-keep"
         checking={props.loading}
         onRefreshBusy={provisioning.retry}
-        onForce={provisioning.force}
+        onForce={provisioning.canManageHost ? provisioning.force : null}
         restartError={provisioning.error}
       >
         {props.children}
@@ -205,7 +205,7 @@ export function LocalHostGate(props: LocalHostGateProps) {
         source="normal-ready"
         checking={props.loading}
         onRefreshBusy={null}
-        onForce={provisioning.force}
+        onForce={provisioning.canManageHost ? provisioning.force : null}
         restartError={provisioning.error}
       >
         {props.children}
@@ -270,6 +270,7 @@ interface HostProvisioning {
   // Traycer's background components on this device, so the desktop refused to
   // reinstall. The gate shows the removed surface instead of spinning.
   readonly removed: boolean;
+  readonly canManageHost: boolean;
   readonly retry: () => void;
   // Forced update: re-run ensure with `force`, skipping the busy check, to
   // reinstall + restart onto this build (can end in-progress work).
@@ -371,6 +372,7 @@ function useHostProvisioning(args: {
     progress,
     hostBusy: hasManagement && inBusyKeepFlow,
     removed: hasManagement && removed,
+    canManageHost: hasManagement,
     retry: () => run(false),
     force: () => run(true),
     reinstall,
@@ -386,7 +388,7 @@ interface HostBusyGateProps {
   readonly source: HostCompatibilityGateSource;
   readonly checking: ReactNode;
   readonly onRefreshBusy: (() => void) | null;
-  readonly onForce: () => void;
+  readonly onForce: (() => void) | null;
   readonly restartError: Error | null;
 }
 
@@ -409,6 +411,15 @@ function HostCompatibilityGate(props: HostBusyGateProps) {
       />
     );
   }
+  if (compat.status === "failed") {
+    return (
+      <GateProvisioningError
+        message={`Could not verify host compatibility. ${compat.error.message}`}
+        onRetry={compat.retry}
+        isRetrying={compat.retrying}
+      />
+    );
+  }
   if (compat.status === "compatible") {
     return <>{props.children}</>;
   }
@@ -419,7 +430,7 @@ interface GateIncompatibleBusyProps {
   readonly source: HostCompatibilityGateSource;
   readonly reason: string;
   readonly onRefreshBusy: (() => void) | null;
-  readonly onForce: () => void;
+  readonly onForce: (() => void) | null;
   readonly restartError: Error | null;
 }
 
@@ -481,20 +492,22 @@ function GateIncompatibleHost(props: GateIncompatibleBusyProps) {
                   Refresh
                 </Button>
               ) : null}
-              <Button
-                type="button"
-                size="sm"
-                variant={isBusyKeep ? "destructive" : "default"}
-                className={cn("w-full", !isBusyKeep && "sm:w-auto")}
-                onClick={props.onForce}
-                data-testid={
-                  isBusyKeep
-                    ? "local-host-incompatible-busy-force-update"
-                    : "local-host-incompatible-update"
-                }
-              >
-                {isBusyKeep ? "Force update host" : "Update host"}
-              </Button>
+              {props.onForce !== null ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={isBusyKeep ? "destructive" : "default"}
+                  className={cn("w-full", !isBusyKeep && "sm:w-auto")}
+                  onClick={props.onForce}
+                  data-testid={
+                    isBusyKeep
+                      ? "local-host-incompatible-busy-force-update"
+                      : "local-host-incompatible-update"
+                  }
+                >
+                  {isBusyKeep ? "Force update host" : "Update host"}
+                </Button>
+              ) : null}
             </div>
           </CardContent>
         </Card>

--- a/clients/gui-app/src/components/local-host-gate.tsx
+++ b/clients/gui-app/src/components/local-host-gate.tsx
@@ -19,15 +19,16 @@ import type {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { AppHeader } from "@/components/layout/header/app-header";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useRunnerRequestHostRespawn } from "@/hooks/runner/use-runner-request-host-respawn-mutation";
 import { useRunnerEnsureHost } from "@/hooks/runner/use-runner-ensure-host-mutation";
 import { useRunnerTraycerHostStatusQuery } from "@/hooks/runner/use-runner-traycer-host-status-query";
-import { useHostQuery } from "@/hooks/host/use-host-query";
-import { useHostClient, type HostRpcRegistry } from "@/lib/host";
-import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import { RetryableTransportError } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  describeHostCompatibilityError,
+  useHostCompatibility,
+} from "@/lib/host";
 import { requestAppQuit } from "@/lib/desktop-app-lifecycle";
 import { cn } from "@/lib/utils";
 
@@ -142,8 +143,8 @@ export function LocalHostGate(props: LocalHostGateProps) {
     isReady,
   });
 
-  // Reinstall-progress node, reused by the busy-keep restart branch and the
-  // normal provisioning branch.
+  // Reinstall-progress node, reused by the busy-keep forced update branch and
+  // the normal provisioning branch.
   const provisioningLoadingNode =
     props.provisioningLoading !== null
       ? cloneElement(props.provisioningLoading, {
@@ -157,19 +158,25 @@ export function LocalHostGate(props: LocalHostGateProps) {
 
   // host-busy keep path: the CLI kept a running host that has work in
   // progress. This state is LATCHED (it survives the surfaced host flipping
-  // the snapshot to `ready`, and survives Retry/Force `reset()`), and it takes
+  // the snapshot to `ready`, and survives Retry/forced update `reset()`), and it takes
   // precedence over `isReady` so children never connect to an unprobed busy
-  // host. `HostBusyGate` is isolated in its own component because the compat
+  // host. `HostCompatibilityGate` is isolated in its own component because the compat
   // probe calls `useHostClient`, valid only below the host runtime
-  // provider. A Retry/Force restart in flight shows its progress, not the panel.
+  // provider. A Retry/forced update in flight shows its progress, not the panel.
   if (provisioning.hostBusy) {
     if (provisioning.isProvisioning) {
       return <>{provisioningLoadingNode}</>;
     }
     return (
-      <HostBusyGate onRetry={provisioning.retry} onForce={provisioning.force}>
+      <HostCompatibilityGate
+        source="busy-keep"
+        checking={props.loading}
+        onRefreshBusy={provisioning.retry}
+        onForce={provisioning.force}
+        restartError={provisioning.error}
+      >
         {props.children}
-      </HostBusyGate>
+      </HostCompatibilityGate>
     );
   }
 
@@ -193,7 +200,17 @@ export function LocalHostGate(props: LocalHostGateProps) {
   }
 
   if (isReady) {
-    return <>{props.children}</>;
+    return (
+      <HostCompatibilityGate
+        source="normal-ready"
+        checking={props.loading}
+        onRefreshBusy={null}
+        onForce={provisioning.force}
+        restartError={provisioning.error}
+      >
+        {props.children}
+      </HostCompatibilityGate>
+    );
   }
 
   // Provisioning failed - show the error with a Retry that re-runs ensure.
@@ -254,8 +271,8 @@ interface HostProvisioning {
   // reinstall. The gate shows the removed surface instead of spinning.
   readonly removed: boolean;
   readonly retry: () => void;
-  // Force restart: re-run ensure with `force`, skipping the busy check, to
-  // reinstall + restart onto this build (ends the in-progress work).
+  // Forced update: re-run ensure with `force`, skipping the busy check, to
+  // reinstall + restart onto this build (can end in-progress work).
   readonly force: () => void;
   // Reinstall escape hatch from the removed surface: clear the removal
   // sentinel, then re-run ensure to provision the host again.
@@ -282,10 +299,10 @@ function useHostProvisioning(args: {
 
   // Latch the busy-keep flow from the settled mutation RESULT (a mutation
   // event, not a render effect or a ref read), so it survives the surfaced
-  // host flipping `isReady` true and survives Retry/Force `reset()` (which
+  // host flipping `isReady` true and survives Retry/forced update `reset()` (which
   // clears `ensure.data`). A `host-busy` result enters the flow; any other
   // success exits it. An ERROR deliberately leaves the latch untouched: a
-  // failed Retry/Force must keep us in the busy flow (so we never fall through
+  // failed Retry/forced update must keep us in the busy flow (so we never fall through
   // to rendering children against the still-unprobed busy host), and a failed
   // initial provision leaves the latch at its `false` default (normal error
   // path). Stable handler keeps the provision effect from re-running.
@@ -297,7 +314,7 @@ function useHostProvisioning(args: {
     setRemoved(result.action === "removed");
   }, []);
 
-  // Retry/Force: clear any prior error/progress, then re-run ensure. Only
+  // Retry/forced update: clear any prior error/progress, then re-run ensure. Only
   // `onSuccess` transitions the busy-keep latch; an error leaves it untouched
   // (see markBusyKeep).
   const run = (force: boolean): void => {
@@ -345,7 +362,7 @@ function useHostProvisioning(args: {
     // Report provisioning/error whenever this shell manages the host - NOT
     // gated on `canProvision`, which collapses to false the instant a busy
     // host is surfaced (its snapshot flips `isReady` true). Gating on
-    // `canProvision` would hide Retry/Force restart progress and swallow their
+    // `canProvision` would hide Retry/forced update progress and swallow their
     // errors. `ensure.isPending`/`ensure.error` are only meaningful after a
     // mutation that already required management, so `hasManagement` is the
     // correct gate.
@@ -360,200 +377,128 @@ function useHostProvisioning(args: {
   };
 }
 
-type CompatProbeStatus = "checking" | "compatible" | "incompatible";
-
-const HOST_STATUS_PROBE = {};
-
-// After this long stuck on "checking" (the surfaced host never bound, or the
-// probe kept failing transiently), the checking surface reveals a manual
-// Retry/Force escape so the user is never trapped on the spinner with no way
-// out. Sits above the typical sub-second probe so a healthy keep never flashes
-// the buttons.
-const COMPAT_CHECK_ESCAPE_THRESHOLD_MS = 12_000;
-
-// Terminal handshake verdicts: the host's manifest is genuinely incompatible
-// with this build, so retrying the probe cannot change the answer. Every other
-// error (a transient RPC/connection blip) is non-terminal and is retried.
-function isTerminalCompatError(error: HostRpcError): boolean {
-  return (
-    error.code === "INCOMPATIBLE" || error.code === "DOWNGRADE_UNSUPPORTED"
-  );
-}
-
-// Compat probe for the host-busy keep path (D4). Reuses the existing manifest
-// handshake: calling `host.status` (a pure-local RPC - no cloud I/O) against
-// the surfaced default host either succeeds (compatible) or throws
-// `HostRpcError{INCOMPATIBLE | DOWNGRADE_UNSUPPORTED}` from the openAck
-// negotiation. `host.status` is deliberate (not a cloud-backed method) so a
-// compatible-but-cloud-degraded host still reads "compatible". Until the
-// host binds the underlying query stays disabled and we report "checking"; a
-// transient error is retried (so a network blip never reads as incompatible),
-// and the checking surface reveals a manual Retry/Force escape if it stays
-// stuck, so a never-binding or repeatedly-failing probe is not a dead-end.
+// Shared compat verdict for host-backed launch. The provider owns the
+// `host.status` probe above routed UI and startup warmups; this gate consumes
+// the verdict to either continue into host-backed UI or convert the existing
+// initializing-host surface into an update-required card.
 interface HostBusyGateProps {
   readonly children: ReactNode;
-  readonly onRetry: () => void;
+  readonly source: HostCompatibilityGateSource;
+  readonly checking: ReactNode;
+  readonly onRefreshBusy: (() => void) | null;
   readonly onForce: () => void;
+  readonly restartError: Error | null;
 }
 
-// Rendered only while the CLI kept a busy host (D4 keep path). Probes the
-// surfaced host's compatibility and renders the keep / checking / prompt
-// outcome. Isolated so `useHostClient` (valid only below the host runtime
-// provider) is never reached from the gate's other states.
-function HostBusyGate(props: HostBusyGateProps) {
-  const compat = useHostCompatProbe();
-  if (compat === "incompatible") {
+type HostCompatibilityGateSource = "busy-keep" | "normal-ready";
+
+// Rendered once a local host is reachable and the host runtime is mounted.
+// Blocks host-backed children until the shared `/rpc` manifest handshake
+// succeeds. The same gate handles both normal launch and the older busy-host
+// keep flow; only retry copy/wiring differs.
+function HostCompatibilityGate(props: HostBusyGateProps) {
+  const compat = useHostCompatibility();
+  if (compat.status === "incompatible") {
     return (
-      <GateIncompatibleBusy onRetry={props.onRetry} onForce={props.onForce} />
+      <GateIncompatibleHost
+        source={props.source}
+        reason={describeHostCompatibilityError(compat.error)}
+        onRefreshBusy={props.onRefreshBusy}
+        onForce={props.onForce}
+        restartError={props.restartError}
+      />
     );
   }
-  if (compat === "compatible") {
+  if (compat.status === "compatible") {
     return <>{props.children}</>;
   }
-  return <GateCompatChecking onRetry={props.onRetry} onForce={props.onForce} />;
-}
-
-function useHostCompatProbe(): CompatProbeStatus {
-  const client = useHostClient();
-  const probe = useHostQuery<HostRpcRegistry, "host.status">({
-    client,
-    method: "host.status",
-    params: HOST_STATUS_PROBE,
-    options: {
-      // Retry a transient failure a couple of times so a momentary blip never
-      // reads as incompatible, but fail fast on a terminal compat verdict
-      // (retrying an INCOMPATIBLE handshake cannot change the answer) and on a
-      // `RetryableTransportError`, which the transport layer has already retried
-      // to exhaustion - retrying here would stack dial-timeout costs and block
-      // the gate far longer.
-      retry: (failureCount, error) =>
-        !isTerminalCompatError(error) &&
-        !(error instanceof RetryableTransportError) &&
-        failureCount < 2,
-      // A compatible verdict must not bounce back to "checking": Infinity keeps
-      // the success cached with no background refetch, so children stay mounted
-      // even if the host connection later churns. The query key is host-id
-      // scoped, so a genuine host swap still re-probes.
-      staleTime: Infinity,
-    },
-  });
-  if (probe.isSuccess) {
-    return "compatible";
-  }
-  if (probe.error !== null && isTerminalCompatError(probe.error)) {
-    return "incompatible";
-  }
-  return "checking";
-}
-
-interface GateCompatCheckingProps {
-  readonly onRetry: () => void;
-  readonly onForce: () => void;
-}
-
-// "Host is busy — checking compatibility…" surface, shown while the compat
-// probe is in flight or the surfaced host has not yet bound. If it stays
-// stuck past COMPAT_CHECK_ESCAPE_THRESHOLD_MS (the host never bound, or the
-// probe kept failing transiently), it reveals a manual Retry/Force escape so
-// the user is never trapped on the spinner with no way out.
-function GateCompatChecking(props: GateCompatCheckingProps) {
-  const [showEscape, setShowEscape] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setShowEscape(true);
-    }, COMPAT_CHECK_ESCAPE_THRESHOLD_MS);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, []);
-  return (
-    <div
-      data-testid="local-host-compat-checking"
-      className="flex min-h-svh w-full items-center justify-center bg-background p-6 text-foreground"
-    >
-      <Card className="w-full max-w-md">
-        <CardContent className="flex flex-col items-center gap-3 py-6 text-ui-sm">
-          <AgentSpinningDots
-            className={undefined}
-            testId="local-host-compat-checking-spinner"
-            variant={undefined}
-          />
-          <p className="text-center">
-            Your host is busy — checking whether this update can keep using it…
-          </p>
-          {showEscape ? (
-            <div className="flex flex-wrap justify-center gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={props.onRetry}
-                data-testid="local-host-compat-checking-retry"
-              >
-                Retry
-              </Button>
-              <Button
-                type="button"
-                size="sm"
-                variant="destructive"
-                onClick={props.onForce}
-                data-testid="local-host-compat-checking-force"
-              >
-                Force restart (ends running work)
-              </Button>
-            </div>
-          ) : null}
-        </CardContent>
-      </Card>
-    </div>
-  );
+  return <>{props.checking}</>;
 }
 
 interface GateIncompatibleBusyProps {
-  readonly onRetry: () => void;
+  readonly source: HostCompatibilityGateSource;
+  readonly reason: string;
+  readonly onRefreshBusy: (() => void) | null;
   readonly onForce: () => void;
+  readonly restartError: Error | null;
 }
 
-// Shown when the kept busy host is incompatible with this build: Retry
-// re-checks busy, Force reinstalls + restarts (ending the running work).
-function GateIncompatibleBusy(props: GateIncompatibleBusyProps) {
+// Shown when the reachable host is incompatible with this build. Compatible
+// hosts continue automatically; incompatible hosts have one meaningful action:
+// update the local host to the app-compatible version.
+function GateIncompatibleHost(props: GateIncompatibleBusyProps) {
+  const isBusyKeep = props.source === "busy-keep";
   return (
     <div
-      data-testid="local-host-incompatible-busy"
-      className="flex min-h-svh w-full items-center justify-center bg-background p-6 text-foreground"
+      data-testid={
+        isBusyKeep ? "local-host-incompatible-busy" : "local-host-incompatible"
+      }
+      className="flex min-h-svh w-full flex-col bg-background text-foreground"
     >
-      <Card className="w-full max-w-md">
-        <CardContent className="flex flex-col gap-4 py-6 text-ui-sm">
-          <div className="flex flex-col gap-1 text-center">
-            <p className="font-medium">Update paused</p>
-            <p className="text-muted-foreground">
-              Your host has work in progress and is not compatible with this
-              update. Retry the restart, or force a restart now — Force ends the
-              running work.
-            </p>
-          </div>
-          <div className="flex flex-wrap justify-center gap-2">
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              onClick={props.onRetry}
-              data-testid="local-host-incompatible-busy-retry"
+      <AppHeader variant="host-loading" />
+      <div className="flex flex-1 items-center justify-center p-6">
+        <Card className="w-full max-w-md shadow-sm">
+          <CardContent className="flex flex-col items-center gap-4 py-6 text-center text-ui-sm">
+            <div className="flex flex-col gap-2">
+              <p className="text-ui font-medium text-foreground">
+                Host update required
+              </p>
+              <p className="text-muted-foreground">
+                {isBusyKeep
+                  ? "The running host has work in progress and is not compatible with this app update. Refresh to check again, or force update the host. Running work may be interrupted."
+                  : "This Traycer app update is not compatible with the running host. Update the local host before continuing."}
+              </p>
+              <p
+                className="max-w-full break-words rounded-md bg-muted/50 px-3 py-2 text-left text-ui-xs text-muted-foreground"
+                data-testid="local-host-incompatible-reason"
+              >
+                Reason: {props.reason}
+              </p>
+              {props.restartError !== null ? (
+                <p
+                  className="max-w-full break-words text-ui-xs text-destructive"
+                  data-testid="local-host-incompatible-restart-error"
+                >
+                  {props.restartError.message}
+                </p>
+              ) : null}
+            </div>
+            <div
+              className={cn(
+                "grid w-full gap-2",
+                isBusyKeep ? "sm:grid-cols-2" : "sm:flex sm:justify-center",
+              )}
             >
-              Retry restart
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="destructive"
-              onClick={props.onForce}
-              data-testid="local-host-incompatible-busy-force"
-            >
-              Force restart (ends running work)
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+              {isBusyKeep && props.onRefreshBusy !== null ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="w-full"
+                  onClick={props.onRefreshBusy}
+                  data-testid="local-host-incompatible-busy-refresh"
+                >
+                  Refresh
+                </Button>
+              ) : null}
+              <Button
+                type="button"
+                size="sm"
+                variant={isBusyKeep ? "destructive" : "default"}
+                className={cn("w-full", !isBusyKeep && "sm:w-auto")}
+                onClick={props.onForce}
+                data-testid={
+                  isBusyKeep
+                    ? "local-host-incompatible-busy-force-update"
+                    : "local-host-incompatible-update"
+                }
+              >
+                {isBusyKeep ? "Force update host" : "Update host"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/clients/gui-app/src/hooks/runner/use-runner-ensure-host-mutation.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-ensure-host-mutation.ts
@@ -12,9 +12,8 @@ import { runnerMutationKeys, runnerQueryKeys } from "@/lib/query-keys";
 
 export interface EnsureHostVariables {
   readonly onProgress: ((event: HostProgressEvent) => void) | null;
-  // `true` = the user's "Force restart" (skip the busy check and restart a
-  // running host unconditionally). Normal provisioning and "Retry restart"
-  // pass `false`.
+  // `true` = update the host even when a running host would normally be kept
+  // because it has active work. Normal provisioning passes `false`.
   readonly force: boolean;
 }
 

--- a/clients/gui-app/src/lib/epics/epic-tab-existence.ts
+++ b/clients/gui-app/src/lib/epics/epic-tab-existence.ts
@@ -1,30 +1,8 @@
-import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
-import {
-  CURRENT_EPIC_VERSION,
-  CURRENT_PHASE_VERSION,
-} from "@traycer-clients/shared/epic/epic-version";
 import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
-import type { HostRpcRegistry } from "@/lib/host";
-
-const EPIC_TAB_RECONCILE_PAGE_LIMIT = 100;
 
 type FetchEpicListPage = (
   cursor: string | undefined,
 ) => Promise<ListTasksResponse>;
-
-export async function fetchExistingEpicIds(
-  client: HostClient<HostRpcRegistry>,
-): Promise<ReadonlySet<string>> {
-  return fetchExistingEpicIdsFromPages((cursor) =>
-    client.request("epic.listTasks", {
-      limit: EPIC_TAB_RECONCILE_PAGE_LIMIT,
-      cursor,
-      filters: { taskType: "epic" },
-      extensionPhaseVersion: String(CURRENT_PHASE_VERSION),
-      extensionEpicVersion: String(CURRENT_EPIC_VERSION),
-    }),
-  );
-}
 
 export async function fetchExistingEpicIdsFromPages(
   fetchPage: FetchEpicListPage,

--- a/clients/gui-app/src/lib/host/compatibility-provider.tsx
+++ b/clients/gui-app/src/lib/host/compatibility-provider.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+import {
+  HostCompatibilityContext,
+  useHostCompatibilityProbe,
+} from "@/lib/host/compatibility-state";
+
+export function HostCompatibilityProvider(props: {
+  readonly children: ReactNode;
+}): ReactNode {
+  const compatibility = useHostCompatibilityProbe();
+  return (
+    <HostCompatibilityContext.Provider value={compatibility}>
+      {props.children}
+    </HostCompatibilityContext.Provider>
+  );
+}

--- a/clients/gui-app/src/lib/host/compatibility-state.ts
+++ b/clients/gui-app/src/lib/host/compatibility-state.ts
@@ -1,0 +1,85 @@
+import { createContext, use } from "react";
+import {
+  RetryableTransportError,
+  type HostRpcError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostRpcRegistry } from "@traycer/protocol/host/index";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import { useHostClient } from "@/lib/host/runtime";
+
+const HOST_STATUS_PROBE = {};
+
+export type HostCompatibility =
+  | {
+      readonly status: "checking" | "compatible";
+      readonly retry: () => void;
+    }
+  | {
+      readonly status: "incompatible";
+      readonly retry: () => void;
+      readonly error: HostRpcError;
+    };
+
+export const HostCompatibilityContext = createContext<HostCompatibility | null>(
+  null,
+);
+
+export function useHostCompatibility(): HostCompatibility {
+  const compatibility = use(HostCompatibilityContext);
+  if (compatibility === null) {
+    throw new Error(
+      "Host compatibility hooks must be used inside a <HostCompatibilityProvider>.",
+    );
+  }
+  return compatibility;
+}
+
+export function useHostCompatibilityProbe(): HostCompatibility {
+  const client = useHostClient();
+  const probe = useHostQuery<HostRpcRegistry, "host.status">({
+    client,
+    method: "host.status",
+    params: HOST_STATUS_PROBE,
+    options: {
+      // Retry a transient failure a couple of times so a momentary blip never
+      // reads as incompatible, but fail fast on a terminal compat verdict
+      // (retrying an INCOMPATIBLE handshake cannot change the answer) and on a
+      // `RetryableTransportError`, which the transport layer has already retried
+      // to exhaustion - retrying here would stack dial-timeout costs and block
+      // the gate far longer.
+      retry: (failureCount, error) =>
+        !isTerminalHostCompatibilityError(error) &&
+        !(error instanceof RetryableTransportError) &&
+        failureCount < 2,
+      // A compatible verdict must not bounce back to "checking": Infinity keeps
+      // the success cached with no background refetch, so children stay mounted
+      // even if the host connection later churns. The query key is host-id
+      // scoped, so a genuine host swap still re-probes.
+      staleTime: Infinity,
+    },
+  });
+  if (probe.isSuccess) {
+    return { status: "compatible", retry: () => void probe.refetch() };
+  }
+  if (probe.error !== null && isTerminalHostCompatibilityError(probe.error)) {
+    return {
+      status: "incompatible",
+      retry: () => void probe.refetch(),
+      error: probe.error,
+    };
+  }
+  return { status: "checking", retry: () => void probe.refetch() };
+}
+
+export function isTerminalHostCompatibilityError(error: HostRpcError): boolean {
+  return (
+    error.code === "INCOMPATIBLE" || error.code === "DOWNGRADE_UNSUPPORTED"
+  );
+}
+
+export function describeHostCompatibilityError(error: HostRpcError): string {
+  const reason = error.fatalDetails?.reason ?? error.message;
+  return reason.trim().length > 0
+    ? reason
+    : "The host RPC protocol is incompatible with this app.";
+}

--- a/clients/gui-app/src/lib/host/compatibility-state.ts
+++ b/clients/gui-app/src/lib/host/compatibility-state.ts
@@ -15,6 +15,12 @@ export type HostCompatibility =
       readonly retry: () => void;
     }
   | {
+      readonly status: "failed";
+      readonly retry: () => void;
+      readonly retrying: boolean;
+      readonly error: HostRpcError;
+    }
+  | {
       readonly status: "incompatible";
       readonly retry: () => void;
       readonly error: HostRpcError;
@@ -51,6 +57,7 @@ export function useHostCompatibilityProbe(): HostCompatibility {
         !isTerminalHostCompatibilityError(error) &&
         !(error instanceof RetryableTransportError) &&
         failureCount < 2,
+      retryDelay: 0,
       // A compatible verdict must not bounce back to "checking": Infinity keeps
       // the success cached with no background refetch, so children stay mounted
       // even if the host connection later churns. The query key is host-id
@@ -65,6 +72,14 @@ export function useHostCompatibilityProbe(): HostCompatibility {
     return {
       status: "incompatible",
       retry: () => void probe.refetch(),
+      error: probe.error,
+    };
+  }
+  if (probe.isError) {
+    return {
+      status: "failed",
+      retry: () => void probe.refetch(),
+      retrying: probe.isFetching,
       error: probe.error,
     };
   }

--- a/clients/gui-app/src/lib/host/index.ts
+++ b/clients/gui-app/src/lib/host/index.ts
@@ -2,6 +2,13 @@ export {
   hostRpcRegistry,
   type HostRpcRegistry,
 } from "@traycer/protocol/host/index";
+export { HostCompatibilityProvider } from "@/lib/host/compatibility-provider";
+export {
+  describeHostCompatibilityError,
+  isTerminalHostCompatibilityError,
+  useHostCompatibility,
+  type HostCompatibility,
+} from "@/lib/host/compatibility-state";
 export {
   HostRuntimeContext,
   HostRuntimeProvider,

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -429,6 +429,36 @@ describe("HostCompatibilityProvider startup consumers", () => {
     queryClient.clear();
   });
 
+  it("treats repeated reconciliation cursors as terminal before pruning persisted epic tabs", async () => {
+    const methods: string[] = [];
+    const listTasks = vi.fn((params: ListTasksRequest): ListTasksResponse =>
+      params.cursor === undefined
+        ? { tasks: [], hasMore: true, nextCursor: "repeat" }
+        : { tasks: [], hasMore: true, nextCursor: "repeat" },
+    );
+    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+      harnesses: [],
+    }));
+    const { queryClient } = mountStartupConsumers({
+      hostStatus: () => compatibleHostStatus,
+      listTasks,
+      listHarnesses,
+      onMethod: (method) => {
+        methods.push(method);
+      },
+    });
+
+    await waitFor(() => {
+      expect(collectOpenEpicIds()).not.toContain(STARTUP_EPIC_ID);
+    });
+    expect(listTasks).toHaveBeenCalledTimes(2);
+    expect(
+      listTasks.mock.calls.map(([params]) => params.cursor ?? null),
+    ).toEqual([null, "repeat"]);
+    expect(methods[0]).toBe("host.status");
+    queryClient.clear();
+  });
+
   it("retries tab reconciliation after an in-flight compatibility interruption", async () => {
     const listTasksDeferred = createDeferred<ListTasksResponse>();
     const methods: string[] = [];

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import {
+  HostRpcError,
+  type ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { LocalHostSnapshot } from "@traycer-clients/shared/platform/runner-host";
+import {
+  HostCompatibilityProvider,
+  hostRpcRegistry,
+  HostRuntimeProvider,
+  useHostCompatibility,
+  type HostRpcRegistry,
+  type MessengerFactory,
+} from "@/lib/host";
+import { EpicTabExistenceReconciler } from "@/providers/epic-tab-existence-reconciler";
+import { HarnessCatalogPrefetcher } from "@/providers/harness-catalog-prefetcher";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+
+const STARTUP_EPIC_ID = "epic-startup-compat";
+
+const localSnapshot: LocalHostSnapshot = {
+  hostId: "desktop-pid-1",
+  websocketUrl: "ws://127.0.0.1:4917/rpc",
+  version: "1.2.3",
+  pid: 4242,
+  systemHostName: "hardiks-macbook",
+  displayName: "hardiks-macbook",
+};
+
+type HostStatusResponse = ResponseOfMethod<HostRpcRegistry, "host.status">;
+type ListTasksResponse = ResponseOfMethod<HostRpcRegistry, "epic.listTasks">;
+type ListHarnessesResponse = ResponseOfMethod<
+  HostRpcRegistry,
+  "agent.gui.listHarnesses"
+>;
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+}
+
+interface StartupConsumersOptions {
+  readonly hostStatus: () => Promise<HostStatusResponse> | HostStatusResponse;
+  readonly listTasks: () => ListTasksResponse;
+  readonly listHarnesses: () => ListHarnessesResponse;
+  readonly onMethod: (method: string) => void;
+}
+
+const compatibleHostStatus: HostStatusResponse = {
+  ready: true,
+  hostVersion: "1.2.3",
+  protocolVersion: { major: 1, minor: 0 },
+};
+
+let restoreFetch: () => void = () => undefined;
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveDeferred: (value: T) => void = () => {
+    throw new Error("deferred resolver was not initialized");
+  };
+  const promise = new Promise<T>((resolve) => {
+    resolveDeferred = resolve;
+  });
+  return { promise, resolve: resolveDeferred };
+}
+
+function buildQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function buildMessengerFactory(
+  options: StartupConsumersOptions,
+): MessengerFactory<HostRpcRegistry> {
+  return (args) =>
+    new MockHostMessenger<HostRpcRegistry>({
+      registry: args.registry,
+      requestId: () => `req-${Math.random().toString(36).slice(2, 8)}`,
+      handlers: {
+        "host.status": () => {
+          options.onMethod("host.status");
+          return options.hostStatus();
+        },
+        "epic.listTasks": () => {
+          options.onMethod("epic.listTasks");
+          return options.listTasks();
+        },
+        "agent.gui.listHarnesses": () => {
+          options.onMethod("agent.gui.listHarnesses");
+          return options.listHarnesses();
+        },
+      },
+    });
+}
+
+function mountStartupConsumers(options: StartupConsumersOptions): QueryClient {
+  const host = new MockRunnerHost({
+    signInUrl: "https://auth.traycer.invalid/sign-in",
+    authnBaseUrl: "http://localhost:5005",
+    localHost: localSnapshot,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+  void host.tokenStore.set({
+    token: "test-token",
+    refreshToken: "test-refresh-token",
+  });
+  useAuthStore.getState().setSignedIn(
+    {
+      userId: "test-user",
+      userName: "Test User",
+      email: "test@example.com",
+    },
+    { userId: "test-user", username: "Test User" },
+    [],
+  );
+  useEpicCanvasStore.getState().openEpicTab(STARTUP_EPIC_ID, "Startup Compat");
+
+  const queryClient = buildQueryClient();
+  render(
+    <RunnerHostProvider runnerHost={host}>
+      <QueryClientProvider client={queryClient}>
+        <HostRuntimeProvider
+          registry={hostRpcRegistry}
+          messengerFactory={buildMessengerFactory(options)}
+          invalidator={null}
+          requestId={null}
+          remoteFetcher={() => Promise.resolve([])}
+          fallback={<div data-testid="runtime-fallback">runtime loading</div>}
+        >
+          <HostCompatibilityProvider>
+            <CompatibilityStatusProbe />
+            <EpicTabExistenceReconciler />
+            <HarnessCatalogPrefetcher />
+          </HostCompatibilityProvider>
+        </HostRuntimeProvider>
+      </QueryClientProvider>
+    </RunnerHostProvider>,
+  );
+  return queryClient;
+}
+
+function CompatibilityStatusProbe(): ReactNode {
+  const compatibility = useHostCompatibility();
+  return <div data-testid="compat-status">{compatibility.status}</div>;
+}
+
+function installAuthFetch(): () => void {
+  const originalFetch: unknown = (globalThis as { fetch?: unknown }).fetch;
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    writable: true,
+    value: (input: unknown): Promise<Response> => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.endsWith("/api/v3/user")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              user: {
+                id: "test-user",
+                name: "Test User",
+                providerId: "gh-1",
+                providerHandle: "test-user",
+                providerType: "GITHUB",
+                email: "test@example.com",
+                avatarUrl: null,
+                activatedAt: null,
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                lastSeenAt: null,
+                privacyMode: false,
+                isLearningEnabled: true,
+              },
+              userSubscription: {
+                id: "sub-1",
+                userID: "test-user",
+                orgID: null,
+                teamID: null,
+                customerId: "cus-1",
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                subscriptionExpiry: null,
+                trialEndsAt: null,
+                subscriptionStatus: "FREE",
+                hasPaymentMethod: false,
+                isInTrial: false,
+                rechargeRateSeconds: 0,
+              },
+              teamSubscriptions: [],
+              payAsYouGoUsage: { allowPayAsYouGo: false },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.reject(
+        new Error(`unexpected fetch in host compatibility test: ${url}`),
+      );
+    },
+  });
+  return () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
+  };
+}
+
+describe("HostCompatibilityProvider startup consumers", () => {
+  beforeEach(() => {
+    restoreFetch = installAuthFetch();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useAuthStore.getState().setSignedOut();
+    useEpicCanvasStore.getState().closeTabsForEpics([STARTUP_EPIC_ID]);
+    vi.restoreAllMocks();
+    restoreFetch();
+  });
+
+  it("holds startup host RPC consumers until host.status succeeds", async () => {
+    const hostStatus = createDeferred<HostStatusResponse>();
+    const methods: string[] = [];
+    const listTasks = vi.fn((): ListTasksResponse => ({
+      tasks: [],
+      hasMore: false,
+    }));
+    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+      harnesses: [],
+    }));
+    const queryClient = mountStartupConsumers({
+      hostStatus: () => hostStatus.promise,
+      listTasks,
+      listHarnesses,
+      onMethod: (method) => {
+        methods.push(method);
+      },
+    });
+
+    await waitFor(() => {
+      expect(methods).toEqual(["host.status"]);
+    });
+    expect(listTasks).not.toHaveBeenCalled();
+    expect(listHarnesses).not.toHaveBeenCalled();
+    expect(screen.getByTestId("compat-status").textContent).toBe("checking");
+
+    act(() => {
+      hostStatus.resolve(compatibleHostStatus);
+    });
+
+    await waitFor(() => {
+      expect(listTasks).toHaveBeenCalledTimes(1);
+      expect(listHarnesses).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId("compat-status").textContent).toBe("compatible");
+    expect(methods[0]).toBe("host.status");
+    expect(methods).toEqual(
+      expect.arrayContaining([
+        "host.status",
+        "epic.listTasks",
+        "agent.gui.listHarnesses",
+      ]),
+    );
+    queryClient.clear();
+  });
+
+  it("does not start startup host RPC consumers after an incompatible status verdict", async () => {
+    const methods: string[] = [];
+    const listTasks = vi.fn((): ListTasksResponse => ({
+      tasks: [],
+      hasMore: false,
+    }));
+    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+      harnesses: [],
+    }));
+    const queryClient = mountStartupConsumers({
+      hostStatus: () => {
+        throw new HostRpcError({
+          code: "INCOMPATIBLE",
+          message: "Incompatible methods: epic.listTasks",
+          requestId: "req-status",
+          method: "host.status",
+          fatalDetails: null,
+        });
+      },
+      listTasks,
+      listHarnesses,
+      onMethod: (method) => {
+        methods.push(method);
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("compat-status").textContent).toBe(
+        "incompatible",
+      );
+    });
+    expect(methods).toEqual(["host.status"]);
+    expect(listTasks).not.toHaveBeenCalled();
+    expect(listHarnesses).not.toHaveBeenCalled();
+    queryClient.clear();
+  });
+});

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -48,9 +48,15 @@ interface Deferred<T> {
 
 interface StartupConsumersOptions {
   readonly hostStatus: () => Promise<HostStatusResponse> | HostStatusResponse;
-  readonly listTasks: () => ListTasksResponse;
-  readonly listHarnesses: () => ListHarnessesResponse;
+  readonly listTasks: () => Promise<ListTasksResponse> | ListTasksResponse;
+  readonly listHarnesses: () =>
+    Promise<ListHarnessesResponse> | ListHarnessesResponse;
   readonly onMethod: (method: string) => void;
+}
+
+interface StartupConsumersMount {
+  readonly queryClient: QueryClient;
+  readonly host: MockRunnerHost;
 }
 
 const compatibleHostStatus: HostStatusResponse = {
@@ -104,7 +110,9 @@ function buildMessengerFactory(
     });
 }
 
-function mountStartupConsumers(options: StartupConsumersOptions): QueryClient {
+function mountStartupConsumers(
+  options: StartupConsumersOptions,
+): StartupConsumersMount {
   const host = new MockRunnerHost({
     signInUrl: "https://auth.traycer.invalid/sign-in",
     authnBaseUrl: "http://localhost:5005",
@@ -150,12 +158,22 @@ function mountStartupConsumers(options: StartupConsumersOptions): QueryClient {
       </QueryClientProvider>
     </RunnerHostProvider>,
   );
-  return queryClient;
+  return { queryClient, host };
 }
 
 function CompatibilityStatusProbe(): ReactNode {
   const compatibility = useHostCompatibility();
-  return <div data-testid="compat-status">{compatibility.status}</div>;
+  return (
+    <div role="status" aria-label="Host compatibility status">
+      {compatibility.status}
+    </div>
+  );
+}
+
+function getCompatibilityStatusText(): string | null {
+  return screen.getByRole("status", {
+    name: "Host compatibility status",
+  }).textContent;
 }
 
 function installAuthFetch(): () => void {
@@ -243,7 +261,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
     const listHarnesses = vi.fn((): ListHarnessesResponse => ({
       harnesses: [],
     }));
-    const queryClient = mountStartupConsumers({
+    const { queryClient } = mountStartupConsumers({
       hostStatus: () => hostStatus.promise,
       listTasks,
       listHarnesses,
@@ -257,7 +275,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
     });
     expect(listTasks).not.toHaveBeenCalled();
     expect(listHarnesses).not.toHaveBeenCalled();
-    expect(screen.getByTestId("compat-status").textContent).toBe("checking");
+    expect(getCompatibilityStatusText()).toBe("checking");
 
     act(() => {
       hostStatus.resolve(compatibleHostStatus);
@@ -267,7 +285,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
       expect(listTasks).toHaveBeenCalledTimes(1);
       expect(listHarnesses).toHaveBeenCalledTimes(1);
     });
-    expect(screen.getByTestId("compat-status").textContent).toBe("compatible");
+    expect(getCompatibilityStatusText()).toBe("compatible");
     expect(methods[0]).toBe("host.status");
     expect(methods).toEqual(
       expect.arrayContaining([
@@ -288,7 +306,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
     const listHarnesses = vi.fn((): ListHarnessesResponse => ({
       harnesses: [],
     }));
-    const queryClient = mountStartupConsumers({
+    const { queryClient } = mountStartupConsumers({
       hostStatus: () => {
         throw new HostRpcError({
           code: "INCOMPATIBLE",
@@ -306,13 +324,87 @@ describe("HostCompatibilityProvider startup consumers", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByTestId("compat-status").textContent).toBe(
-        "incompatible",
-      );
+      expect(getCompatibilityStatusText()).toBe("incompatible");
     });
     expect(methods).toEqual(["host.status"]);
     expect(listTasks).not.toHaveBeenCalled();
     expect(listHarnesses).not.toHaveBeenCalled();
+    queryClient.clear();
+  });
+
+  it("surfaces exhausted non-terminal status probe failures without starting startup consumers", async () => {
+    const methods: string[] = [];
+    const listTasks = vi.fn((): ListTasksResponse => ({
+      tasks: [],
+      hasMore: false,
+    }));
+    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+      harnesses: [],
+    }));
+    const { queryClient } = mountStartupConsumers({
+      hostStatus: () => {
+        throw new HostRpcError({
+          code: "RPC_ERROR",
+          message: "status probe failed",
+          requestId: "req-status",
+          method: "host.status",
+          fatalDetails: null,
+        });
+      },
+      listTasks,
+      listHarnesses,
+      onMethod: (method) => {
+        methods.push(method);
+      },
+    });
+
+    await waitFor(() => {
+      expect(getCompatibilityStatusText()).toBe("failed");
+    });
+    expect(methods).toEqual(["host.status", "host.status", "host.status"]);
+    expect(listTasks).not.toHaveBeenCalled();
+    expect(listHarnesses).not.toHaveBeenCalled();
+    queryClient.clear();
+  });
+
+  it("retries tab reconciliation after an in-flight compatibility interruption", async () => {
+    const listTasksDeferred = createDeferred<ListTasksResponse>();
+    const methods: string[] = [];
+    const listTasks = vi.fn(() => listTasksDeferred.promise);
+    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+      harnesses: [],
+    }));
+    const { queryClient, host } = mountStartupConsumers({
+      hostStatus: () => compatibleHostStatus,
+      listTasks,
+      listHarnesses,
+      onMethod: (method) => {
+        methods.push(method);
+      },
+    });
+
+    await waitFor(() => {
+      expect(listTasks).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      host.setLocalHost(null);
+    });
+    await waitFor(() => {
+      expect(getCompatibilityStatusText()).toBe("checking");
+    });
+
+    act(() => {
+      host.setLocalHost(localSnapshot);
+    });
+    await waitFor(() => {
+      expect(listTasks).toHaveBeenCalledTimes(2);
+    });
+
+    act(() => {
+      listTasksDeferred.resolve({ tasks: [], hasMore: false });
+    });
+    expect(methods[0]).toBe("host.status");
     queryClient.clear();
   });
 });

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -6,6 +6,7 @@ import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import {
   HostRpcError,
+  type RequestOfMethod,
   type ResponseOfMethod,
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { LocalHostSnapshot } from "@traycer-clients/shared/platform/runner-host";
@@ -21,7 +22,10 @@ import { EpicTabExistenceReconciler } from "@/providers/epic-tab-existence-recon
 import { HarnessCatalogPrefetcher } from "@/providers/harness-catalog-prefetcher";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { useAuthStore } from "@/stores/auth/auth-store";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import {
+  collectOpenEpicIds,
+  useEpicCanvasStore,
+} from "@/stores/epics/canvas/store";
 
 const STARTUP_EPIC_ID = "epic-startup-compat";
 
@@ -36,6 +40,7 @@ const localSnapshot: LocalHostSnapshot = {
 
 type HostStatusResponse = ResponseOfMethod<HostRpcRegistry, "host.status">;
 type ListTasksResponse = ResponseOfMethod<HostRpcRegistry, "epic.listTasks">;
+type ListTasksRequest = RequestOfMethod<HostRpcRegistry, "epic.listTasks">;
 type ListHarnessesResponse = ResponseOfMethod<
   HostRpcRegistry,
   "agent.gui.listHarnesses"
@@ -48,7 +53,9 @@ interface Deferred<T> {
 
 interface StartupConsumersOptions {
   readonly hostStatus: () => Promise<HostStatusResponse> | HostStatusResponse;
-  readonly listTasks: () => Promise<ListTasksResponse> | ListTasksResponse;
+  readonly listTasks: (
+    params: ListTasksRequest,
+  ) => Promise<ListTasksResponse> | ListTasksResponse;
   readonly listHarnesses: () =>
     Promise<ListHarnessesResponse> | ListHarnessesResponse;
   readonly onMethod: (method: string) => void;
@@ -98,9 +105,9 @@ function buildMessengerFactory(
           options.onMethod("host.status");
           return options.hostStatus();
         },
-        "epic.listTasks": () => {
+        "epic.listTasks": (params) => {
           options.onMethod("epic.listTasks");
-          return options.listTasks();
+          return options.listTasks(params);
         },
         "agent.gui.listHarnesses": () => {
           options.onMethod("agent.gui.listHarnesses");
@@ -174,6 +181,31 @@ function getCompatibilityStatusText(): string | null {
   return screen.getByRole("status", {
     name: "Host compatibility status",
   }).textContent;
+}
+
+function epicTask(epicId: string): ListTasksResponse["tasks"][number] {
+  return {
+    epic: {
+      light: {
+        id: epicId,
+        title: epicId,
+        initialUserPrompt: "",
+        ticketCount: 0,
+        specCount: 0,
+        storyCount: 0,
+        reviewCount: 0,
+        status: "active",
+        createdAt: 0,
+        updatedAt: 0,
+        createdBy: "test",
+        version: "2.0.0",
+      },
+      permission: null,
+      repos: [],
+      workspaces: [],
+      roomInfo: null,
+    },
+  };
 }
 
 function installAuthFetch(): () => void {
@@ -254,7 +286,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
   it("holds startup host RPC consumers until host.status succeeds", async () => {
     const hostStatus = createDeferred<HostStatusResponse>();
     const methods: string[] = [];
-    const listTasks = vi.fn((): ListTasksResponse => ({
+    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
       tasks: [],
       hasMore: false,
     }));
@@ -299,7 +331,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
 
   it("does not start startup host RPC consumers after an incompatible status verdict", async () => {
     const methods: string[] = [];
-    const listTasks = vi.fn((): ListTasksResponse => ({
+    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
       tasks: [],
       hasMore: false,
     }));
@@ -334,7 +366,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
 
   it("surfaces exhausted non-terminal status probe failures without starting startup consumers", async () => {
     const methods: string[] = [];
-    const listTasks = vi.fn((): ListTasksResponse => ({
+    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
       tasks: [],
       hasMore: false,
     }));
@@ -367,10 +399,42 @@ describe("HostCompatibilityProvider startup consumers", () => {
     queryClient.clear();
   });
 
+  it("fetches every reconciliation page before pruning persisted epic tabs", async () => {
+    const methods: string[] = [];
+    const listTasks = vi.fn((params: ListTasksRequest): ListTasksResponse =>
+      params.cursor === undefined
+        ? { tasks: [], hasMore: true, nextCursor: "page-2" }
+        : { tasks: [epicTask(STARTUP_EPIC_ID)], hasMore: false },
+    );
+    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+      harnesses: [],
+    }));
+    const { queryClient } = mountStartupConsumers({
+      hostStatus: () => compatibleHostStatus,
+      listTasks,
+      listHarnesses,
+      onMethod: (method) => {
+        methods.push(method);
+      },
+    });
+
+    await waitFor(() => {
+      expect(listTasks).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      listTasks.mock.calls.map(([params]) => params.cursor ?? null),
+    ).toEqual([null, "page-2"]);
+    expect(collectOpenEpicIds()).toContain(STARTUP_EPIC_ID);
+    expect(methods[0]).toBe("host.status");
+    queryClient.clear();
+  });
+
   it("retries tab reconciliation after an in-flight compatibility interruption", async () => {
     const listTasksDeferred = createDeferred<ListTasksResponse>();
     const methods: string[] = [];
-    const listTasks = vi.fn(() => listTasksDeferred.promise);
+    const listTasks = vi.fn(
+      (_params: ListTasksRequest) => listTasksDeferred.promise,
+    );
     const listHarnesses = vi.fn((): ListHarnessesResponse => ({
       harnesses: [],
     }));

--- a/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
+++ b/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
@@ -26,6 +26,7 @@ import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-sett
 
 const EPIC_TAB_RECONCILE_PAGE_LIMIT = 100;
 const EMPTY_EXISTING_EPIC_IDS: ReadonlyArray<string> = [];
+const EMPTY_SEEN_RECONCILE_CURSORS: ReadonlySet<string> = new Set();
 
 export function EpicTabExistenceReconciler() {
   const seed = usePersistedEpicTabReconcileSeed();
@@ -45,6 +46,7 @@ interface ReconcileRun extends ReconcileSeed {
 interface ReconcilePage {
   readonly existingEpicIds: ReadonlyArray<string>;
   readonly cursor: string | undefined;
+  readonly seenCursors: ReadonlySet<string>;
 }
 
 function usePersistedEpicTabReconcileSeed(): ReconcileSeed | null {
@@ -101,6 +103,7 @@ function EpicTabReconciliationRun(props: { readonly seed: ReconcileSeed }) {
       page={{
         existingEpicIds: EMPTY_EXISTING_EPIC_IDS,
         cursor: undefined,
+        seenCursors: EMPTY_SEEN_RECONCILE_CURSORS,
       }}
     />
   );
@@ -112,15 +115,20 @@ function EpicTabReconciliationPage(props: {
 }) {
   const client = useHostClient();
   const completionAppliedRef = useRef(false);
+  const {
+    cursor: pageCursor,
+    existingEpicIds: previousExistingEpicIds,
+    seenCursors,
+  } = props.page;
   const reconcileParams = useMemo(
     () => ({
       limit: EPIC_TAB_RECONCILE_PAGE_LIMIT,
-      cursor: props.page.cursor,
+      cursor: pageCursor,
       filters: { taskType: "epic" as const },
       extensionPhaseVersion: String(CURRENT_PHASE_VERSION),
       extensionEpicVersion: String(CURRENT_EPIC_VERSION),
     }),
-    [props.page.cursor],
+    [pageCursor],
   );
   const existingEpicsQuery = useHostQuery<HostRpcRegistry, "epic.listTasks">({
     client,
@@ -134,15 +142,27 @@ function EpicTabReconciliationPage(props: {
   const nextPage = useMemo((): ReconcilePage | null => {
     if (!existingEpicsQuery.isSuccess) return null;
     const existingEpicIds = mergeExistingEpicIds(
-      props.page.existingEpicIds,
+      previousExistingEpicIds,
       existingEpicsQuery.data,
     );
     const cursor = nextReconcileCursor(existingEpicsQuery.data);
-    return { existingEpicIds, cursor: cursor ?? undefined };
+    if (cursor === null || seenCursors.has(cursor)) {
+      return {
+        existingEpicIds,
+        cursor: undefined,
+        seenCursors,
+      };
+    }
+    return {
+      existingEpicIds,
+      cursor,
+      seenCursors: addSeenReconcileCursor(seenCursors, cursor),
+    };
   }, [
     existingEpicsQuery.data,
     existingEpicsQuery.isSuccess,
-    props.page.existingEpicIds,
+    previousExistingEpicIds,
+    seenCursors,
   ]);
   const terminalExistingEpicIds =
     nextPage !== null && nextPage.cursor === undefined
@@ -189,6 +209,15 @@ function nextReconcileCursor(page: ListTasksResponse): string | null {
   if (typeof page.nextCursor !== "string") return null;
   if (page.nextCursor.length === 0) return null;
   return page.nextCursor;
+}
+
+function addSeenReconcileCursor(
+  seenCursors: ReadonlySet<string>,
+  cursor: string,
+): ReadonlySet<string> {
+  const nextSeenCursors = new Set(seenCursors);
+  nextSeenCursors.add(cursor);
+  return nextSeenCursors;
 }
 
 function useVisibleEpicIds(): ReadonlyArray<string> {

--- a/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
+++ b/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
@@ -10,6 +10,7 @@ import {
   CURRENT_PHASE_VERSION,
 } from "@traycer-clients/shared/epic/epic-version";
 import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
+import { useShallow } from "zustand/react/shallow";
 import {
   useHostClient,
   useHostCompatibility,
@@ -20,11 +21,7 @@ import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readine
 import { missingEpicIds } from "@/lib/epics/epic-tab-existence";
 import { useWindowsBridgeHydrated } from "@/providers/windows-bridge-context";
 import { useAuthStore } from "@/stores/auth/auth-store";
-import {
-  useEpicCanvasStore,
-  useOpenEpicTabs,
-} from "@/stores/epics/canvas/store";
-import type { EpicViewTab } from "@/stores/epics/canvas/types";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
 
 const EPIC_TAB_RECONCILE_PAGE_LIMIT = 100;
@@ -60,11 +57,7 @@ function usePersistedEpicTabReconcileSeed(): ReconcileSeed | null {
     (state) => state.contextMetadata?.userId ?? null,
   );
   const canvasHydrationVersion = useEpicCanvasHydrationVersion();
-  const openEpicTabs = useOpenEpicTabs();
-  const openEpicIds = useMemo(
-    () => collectEpicIds(openEpicTabs),
-    [openEpicTabs],
-  );
+  const openEpicIds = useVisibleEpicIds();
 
   const identity = useMemo(() => {
     if (!windowsHydrated) return null;
@@ -198,15 +191,19 @@ function nextReconcileCursor(page: ListTasksResponse): string | null {
   return page.nextCursor;
 }
 
-function collectEpicIds(
-  tabs: ReadonlyArray<EpicViewTab>,
-): ReadonlyArray<string> {
-  const seen = new Set<string>();
-  return tabs.flatMap((tab) => {
-    if (seen.has(tab.epicId)) return [];
-    seen.add(tab.epicId);
-    return [tab.epicId];
-  });
+function useVisibleEpicIds(): ReadonlyArray<string> {
+  return useEpicCanvasStore(
+    useShallow((state) => {
+      const seen = new Set<string>();
+      return state.openTabOrder
+        .map((tabId) => state.tabsById[tabId])
+        .flatMap((tab) => {
+          if (tab === undefined || seen.has(tab.epicId)) return [];
+          seen.add(tab.epicId);
+          return [tab.epicId];
+        });
+    }),
+  );
 }
 
 function useEpicCanvasHydrationVersion(): number {

--- a/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
+++ b/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
@@ -1,24 +1,56 @@
-import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import { useHostClient, useHostCompatibility } from "@/lib/host";
-import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
 import {
-  fetchExistingEpicIds,
-  missingEpicIds,
-} from "@/lib/epics/epic-tab-existence";
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import {
+  CURRENT_EPIC_VERSION,
+  CURRENT_PHASE_VERSION,
+} from "@traycer-clients/shared/epic/epic-version";
+import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
+import {
+  useHostClient,
+  useHostCompatibility,
+  type HostRpcRegistry,
+} from "@/lib/host";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
+import { missingEpicIds } from "@/lib/epics/epic-tab-existence";
 import { useWindowsBridgeHydrated } from "@/providers/windows-bridge-context";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import {
-  collectOpenEpicIds,
   useEpicCanvasStore,
+  useOpenEpicTabs,
 } from "@/stores/epics/canvas/store";
+import type { EpicViewTab } from "@/stores/epics/canvas/types";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
 
+const EPIC_TAB_RECONCILE_PAGE_LIMIT = 100;
+const EMPTY_EXISTING_EPIC_IDS: ReadonlyArray<string> = [];
+
 export function EpicTabExistenceReconciler() {
-  useReconcilePersistedEpicTabs();
-  return null;
+  const seed = usePersistedEpicTabReconcileSeed();
+  if (seed === null) return null;
+  return <EpicTabReconciliationRun key={seed.identity} seed={seed} />;
 }
 
-function useReconcilePersistedEpicTabs(): void {
+interface ReconcileSeed {
+  readonly identity: string;
+  readonly openEpicIds: ReadonlyArray<string>;
+}
+
+interface ReconcileRun extends ReconcileSeed {
+  readonly attempt: number;
+}
+
+interface ReconcilePage {
+  readonly existingEpicIds: ReadonlyArray<string>;
+  readonly cursor: string | undefined;
+}
+
+function usePersistedEpicTabReconcileSeed(): ReconcileSeed | null {
   const client = useHostClient();
   const compatibility = useHostCompatibility();
   const readiness = useReactiveHostReadiness(client);
@@ -28,7 +60,11 @@ function useReconcilePersistedEpicTabs(): void {
     (state) => state.contextMetadata?.userId ?? null,
   );
   const canvasHydrationVersion = useEpicCanvasHydrationVersion();
-  const [reconciledIdentities] = useState(() => new Set<string>());
+  const openEpicTabs = useOpenEpicTabs();
+  const openEpicIds = useMemo(
+    () => collectEpicIds(openEpicTabs),
+    [openEpicTabs],
+  );
 
   const identity = useMemo(() => {
     if (!windowsHydrated) return null;
@@ -48,41 +84,129 @@ function useReconcilePersistedEpicTabs(): void {
     windowsHydrated,
   ]);
 
-  useEffect(() => {
-    if (identity === null) return;
-    if (reconciledIdentities.has(identity)) return;
-    reconciledIdentities.add(identity);
+  return useMemo(() => {
+    if (identity === null) return null;
+    if (openEpicIds.length === 0) return null;
+    return { identity, openEpicIds };
+  }, [identity, openEpicIds]);
+}
 
-    const openEpicIds = collectOpenEpicIds();
-    if (openEpicIds.length === 0) return;
+let nextReconcileAttempt = 0;
 
-    let cancelled = false;
-    let settled = false;
-    void fetchExistingEpicIds(client)
-      .then((existingEpicIds) => {
-        settled = true;
-        if (cancelled) return;
-        const staleEpicIds = missingEpicIds(openEpicIds, existingEpicIds);
-        if (staleEpicIds.length === 0) return;
-        useComposerRunSettingsStore
-          .getState()
-          .clearEpicRunSettings(staleEpicIds);
-        useEpicCanvasStore.getState().closeTabsForEpics(staleEpicIds);
-      })
-      .catch(() => {
-        settled = true;
-        if (!cancelled) {
-          reconciledIdentities.delete(identity);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-      if (!settled) {
-        reconciledIdentities.delete(identity);
-      }
+function EpicTabReconciliationRun(props: { readonly seed: ReconcileSeed }) {
+  const [run] = useState<ReconcileRun>(() => {
+    nextReconcileAttempt += 1;
+    return {
+      ...props.seed,
+      attempt: nextReconcileAttempt,
     };
-  }, [client, identity, reconciledIdentities]);
+  });
+
+  return (
+    <EpicTabReconciliationPage
+      run={run}
+      page={{
+        existingEpicIds: EMPTY_EXISTING_EPIC_IDS,
+        cursor: undefined,
+      }}
+    />
+  );
+}
+
+function EpicTabReconciliationPage(props: {
+  readonly run: ReconcileRun;
+  readonly page: ReconcilePage;
+}) {
+  const client = useHostClient();
+  const completionAppliedRef = useRef(false);
+  const reconcileParams = useMemo(
+    () => ({
+      limit: EPIC_TAB_RECONCILE_PAGE_LIMIT,
+      cursor: props.page.cursor,
+      filters: { taskType: "epic" as const },
+      extensionPhaseVersion: String(CURRENT_PHASE_VERSION),
+      extensionEpicVersion: String(CURRENT_EPIC_VERSION),
+    }),
+    [props.page.cursor],
+  );
+  const existingEpicsQuery = useHostQuery<HostRpcRegistry, "epic.listTasks">({
+    client,
+    method: "epic.listTasks",
+    params: reconcileParams,
+    cacheKeyIdentity: [props.run.identity, props.run.attempt],
+    options: {
+      enabled: true,
+    },
+  });
+  const nextPage = useMemo((): ReconcilePage | null => {
+    if (!existingEpicsQuery.isSuccess) return null;
+    const existingEpicIds = mergeExistingEpicIds(
+      props.page.existingEpicIds,
+      existingEpicsQuery.data,
+    );
+    const cursor = nextReconcileCursor(existingEpicsQuery.data);
+    return { existingEpicIds, cursor: cursor ?? undefined };
+  }, [
+    existingEpicsQuery.data,
+    existingEpicsQuery.isSuccess,
+    props.page.existingEpicIds,
+  ]);
+  const terminalExistingEpicIds =
+    nextPage !== null && nextPage.cursor === undefined
+      ? nextPage.existingEpicIds
+      : null;
+
+  useEffect(() => {
+    if (terminalExistingEpicIds === null) return;
+    if (completionAppliedRef.current) return;
+    completionAppliedRef.current = true;
+    const staleEpicIds = missingEpicIds(
+      props.run.openEpicIds,
+      new Set(terminalExistingEpicIds),
+    );
+    if (staleEpicIds.length > 0) {
+      useComposerRunSettingsStore.getState().clearEpicRunSettings(staleEpicIds);
+      useEpicCanvasStore.getState().closeTabsForEpics(staleEpicIds);
+    }
+  }, [props.run.openEpicIds, terminalExistingEpicIds]);
+
+  if (nextPage === null) return null;
+  if (nextPage.cursor === undefined) return null;
+
+  return <EpicTabReconciliationPage run={props.run} page={nextPage} />;
+}
+
+function mergeExistingEpicIds(
+  previousIds: ReadonlyArray<string>,
+  page: ListTasksResponse,
+): ReadonlyArray<string> {
+  return Array.from(
+    new Set([
+      ...previousIds,
+      ...page.tasks.flatMap((task) => {
+        const epicId = task.epic?.light?.id ?? null;
+        return epicId === null ? [] : [epicId];
+      }),
+    ]),
+  );
+}
+
+function nextReconcileCursor(page: ListTasksResponse): string | null {
+  if (!page.hasMore) return null;
+  if (typeof page.nextCursor !== "string") return null;
+  if (page.nextCursor.length === 0) return null;
+  return page.nextCursor;
+}
+
+function collectEpicIds(
+  tabs: ReadonlyArray<EpicViewTab>,
+): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  return tabs.flatMap((tab) => {
+    if (seen.has(tab.epicId)) return [];
+    seen.add(tab.epicId);
+    return [tab.epicId];
+  });
 }
 
 function useEpicCanvasHydrationVersion(): number {

--- a/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
+++ b/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, useSyncExternalStore } from "react";
-import { useHostClient } from "@/lib/host";
+import { useHostClient, useHostCompatibility } from "@/lib/host";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
 import {
   fetchExistingEpicIds,
@@ -20,6 +20,7 @@ export function EpicTabExistenceReconciler() {
 
 function useReconcilePersistedEpicTabs(): void {
   const client = useHostClient();
+  const compatibility = useHostCompatibility();
   const readiness = useReactiveHostReadiness(client);
   const windowsHydrated = useWindowsBridgeHydrated();
   const authStatus = useAuthStore((state) => state.status);
@@ -32,6 +33,7 @@ function useReconcilePersistedEpicTabs(): void {
   const identity = useMemo(() => {
     if (!windowsHydrated) return null;
     if (authStatus !== "signed-in") return null;
+    if (compatibility.status !== "compatible") return null;
     if (readiness.hostId === null) return null;
     if (authUserId === null) return null;
     if (readiness.requestContextUserId !== authUserId) return null;
@@ -40,6 +42,7 @@ function useReconcilePersistedEpicTabs(): void {
     authStatus,
     authUserId,
     canvasHydrationVersion,
+    compatibility.status,
     readiness.hostId,
     readiness.requestContextUserId,
     windowsHydrated,

--- a/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
+++ b/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
@@ -57,8 +57,10 @@ function useReconcilePersistedEpicTabs(): void {
     if (openEpicIds.length === 0) return;
 
     let cancelled = false;
+    let settled = false;
     void fetchExistingEpicIds(client)
       .then((existingEpicIds) => {
+        settled = true;
         if (cancelled) return;
         const staleEpicIds = missingEpicIds(openEpicIds, existingEpicIds);
         if (staleEpicIds.length === 0) return;
@@ -68,6 +70,7 @@ function useReconcilePersistedEpicTabs(): void {
         useEpicCanvasStore.getState().closeTabsForEpics(staleEpicIds);
       })
       .catch(() => {
+        settled = true;
         if (!cancelled) {
           reconciledIdentities.delete(identity);
         }
@@ -75,6 +78,9 @@ function useReconcilePersistedEpicTabs(): void {
 
     return () => {
       cancelled = true;
+      if (!settled) {
+        reconciledIdentities.delete(identity);
+      }
     };
   }, [client, identity, reconciledIdentities]);
 }

--- a/clients/gui-app/src/providers/harness-catalog-prefetcher.tsx
+++ b/clients/gui-app/src/providers/harness-catalog-prefetcher.tsx
@@ -1,4 +1,5 @@
 import { useGuiHarnessCatalog } from "@/hooks/harnesses/use-gui-harness-catalog";
+import { useHostCompatibility } from "@/lib/host";
 
 /**
  * Renderer-side warmup for the GUI harness catalog. The host already
@@ -6,6 +7,8 @@ import { useGuiHarnessCatalog } from "@/hooks/harnesses/use-gui-harness-catalog"
  * model catalog warm before the user opens a new-chat picker.
  */
 export function HarnessCatalogPrefetcher() {
-  useGuiHarnessCatalog(null, { enabled: true, subscribed: true });
+  const compatibility = useHostCompatibility();
+  const active = compatibility.status === "compatible";
+  useGuiHarnessCatalog(null, { enabled: active, subscribed: active });
   return null;
 }

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -8,6 +8,7 @@ import { RootErrorBoundary } from "@/components/errors/root-error-boundary";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import {
+  HostCompatibilityProvider,
   HostRuntimeProvider,
   type HostRpcRegistry,
   type MessengerFactory,
@@ -78,9 +79,9 @@ export interface TraycerAppProps {
  *
  * Mounts the documented provider stack - outer to inner -
  *   RunnerHostProvider → QueryClientProvider → ThemeProvider →
- *   TooltipProvider → HostRuntimeProvider → auth-scoped lifecycle providers
- *   → RunnerHostBridges → LocalHostGate → RouterProvider → HostPicker
- *   → Toaster.
+ *   TooltipProvider → HostRuntimeProvider → HostCompatibilityProvider →
+ *   auth-scoped lifecycle providers → RunnerHostBridges → LocalHostGate →
+ *   RouterProvider → HostPicker → Toaster.
  *
  * Concrete shells (Electron, Capacitor, gui-app-dev preview) construct a
  * `IRunnerHost` at bootstrap and pass it alongside the shared
@@ -120,9 +121,11 @@ export function TraycerApp(props: TraycerAppProps): ReactNode {
                     remoteFetcher={props.remoteFetcher}
                     fallback={hostRuntimeFallback}
                   >
-                    <RootErrorBoundary router={router}>
-                      <TraycerAuthenticatedRuntime router={router} />
-                    </RootErrorBoundary>
+                    <HostCompatibilityProvider>
+                      <RootErrorBoundary router={router}>
+                        <TraycerAuthenticatedRuntime router={router} />
+                      </RootErrorBoundary>
+                    </HostCompatibilityProvider>
                   </HostRuntimeProvider>
                 </KeybindingProvider>
               </TooltipProvider>

--- a/clients/shared/host-client/__tests__/mock-host-messenger.test.ts
+++ b/clients/shared/host-client/__tests__/mock-host-messenger.test.ts
@@ -81,6 +81,49 @@ describe("MockHostMessenger", () => {
     );
   });
 
+  it("rewraps handler HostRpcError with the current request metadata", async () => {
+    const fatalDetails = {
+      code: "INCOMPATIBLE",
+      reason: "host protocol mismatch",
+      incompatibleMethods: [],
+      upgradeGuidance: null,
+    };
+    const messenger = new MockHostMessenger<typeof registry>({
+      registry,
+      handlers: {
+        "host.echo": () => {
+          throw new HostRpcError({
+            code: "INCOMPATIBLE",
+            message: "handler supplied metadata",
+            requestId: "handler-req",
+            method: "handler.method",
+            fatalDetails,
+          });
+        },
+      },
+      requestId: () => "req-current",
+    });
+
+    await expect(
+      messenger.request("host.echo", { message: "x" }),
+    ).rejects.toSatisfy(
+      (err: unknown) =>
+        err instanceof HostRpcError &&
+        err.code === "INCOMPATIBLE" &&
+        err.message === "handler supplied metadata" &&
+        err.requestId === "req-current" &&
+        err.method === "host.echo" &&
+        err.fatalDetails === fatalDetails,
+    );
+
+    const responseEvent = messenger.phases[4];
+    if (responseEvent.kind !== "response") {
+      throw new Error("expected response phase at index 4");
+    }
+    expect(responseEvent.error?.requestId).toBe("req-current");
+    expect(responseEvent.error?.method).toBe("host.echo");
+  });
+
   it("emits phase hooks in the WS lifecycle order on the happy path", async () => {
     const messenger = new MockHostMessenger<typeof registry>({
       registry,

--- a/clients/shared/host-client/mock/mock-host-messenger.ts
+++ b/clients/shared/host-client/mock/mock-host-messenger.ts
@@ -169,15 +169,22 @@ export class MockHostMessenger<
       result = await handler(params);
     } catch (cause) {
       if (cause instanceof HostRpcError) {
+        const error = new HostRpcError({
+          code: cause.code,
+          message: cause.message,
+          requestId,
+          method,
+          fatalDetails: cause.fatalDetails,
+        });
         this.emit({
           kind: "response",
           method,
           requestId,
           result: null,
-          error: cause,
+          error,
         });
         this.emit({ kind: "close", method, requestId });
-        throw cause;
+        throw error;
       }
       const error = new HostRpcError({
         code: "RPC_ERROR",

--- a/clients/shared/host-client/mock/mock-host-messenger.ts
+++ b/clients/shared/host-client/mock/mock-host-messenger.ts
@@ -168,6 +168,17 @@ export class MockHostMessenger<
     try {
       result = await handler(params);
     } catch (cause) {
+      if (cause instanceof HostRpcError) {
+        this.emit({
+          kind: "response",
+          method,
+          requestId,
+          result: null,
+          error: cause,
+        });
+        this.emit({ kind: "close", method, requestId });
+        throw cause;
+      }
       const error = new HostRpcError({
         code: "RPC_ERROR",
         message: cause instanceof Error ? cause.message : String(cause),


### PR DESCRIPTION
## Summary
- add a shared host compatibility provider that owns the `host.status` launch probe
- block routed host-backed UI plus startup consumers like `epic.listTasks` and `agent.gui.listHarnesses` until compatibility succeeds
- show the host update-required surface in the same shell layout as the local-host initializing card
- distinguish normal `Update host` from busy-host `Refresh` / `Force update host` actions
- preserve thrown `HostRpcError` codes in the mock host messenger for compatibility tests

## Validation
- `bun run test -- src/components/__tests__/local-host-gate.test.tsx src/providers/__tests__/host-compatibility-provider.test.tsx`
- `bun run test -- src/components/__tests__/epics-list.test.tsx`
- touched-file `eslint --max-warnings 0`
- `bun run compile`
- `npx -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score`
- pre-commit affected Nx hook passed during signed commit