### PR TITLE
[codex] Fix command palette page navigation

### DIFF
--- a/clients/gui-app/src/components/command-palette/__tests__/command-palette.test.tsx
+++ b/clients/gui-app/src/components/command-palette/__tests__/command-palette.test.tsx
@@ -59,6 +59,26 @@ function getVisibleCommandRows(root: ParentNode): ReadonlyArray<HTMLElement> {
   ).filter((row) => row.closest("[hidden]") === null);
 }
 
+function installPaletteListLayout(
+  list: HTMLElement,
+  rows: ReadonlyArray<HTMLElement>,
+): void {
+  Object.defineProperty(list, "clientHeight", {
+    configurable: true,
+    value: 144,
+  });
+  rows.forEach((row) => {
+    Object.defineProperty(row, "offsetHeight", {
+      configurable: true,
+      value: 36,
+    });
+  });
+}
+
+function getCommandSearchInput(): HTMLElement {
+  return screen.getByRole("combobox", { name: "Search commands" });
+}
+
 describe("<CommandPalette />", () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -101,7 +121,7 @@ describe("<CommandPalette />", () => {
       expect(firstRows[0].getAttribute("data-selected")).toBe("true");
     });
 
-    fireEvent.keyDown(screen.getByLabelText("Search commands"), {
+    fireEvent.keyDown(getCommandSearchInput(), {
       key: "ArrowDown",
     });
     await waitFor(() => {
@@ -111,6 +131,55 @@ describe("<CommandPalette />", () => {
     fireEvent.pointerMove(firstRows[0]);
     await waitFor(() => {
       expect(firstRows[0].getAttribute("data-selected")).toBe("true");
+    });
+  });
+
+  it("moves the selected row by a viewport with PageUp and PageDown", async () => {
+    render(wrap(<div>app</div>));
+    act(() => {
+      useCommandPaletteStore.getState().setOpen(true);
+    });
+    const list = await screen.findByTestId("command-palette-list");
+
+    const rows = getVisibleCommandRows(document.body);
+    expect(rows.length).toBeGreaterThan(3);
+    installPaletteListLayout(list, rows);
+    await waitFor(() => {
+      expect(rows[0].getAttribute("data-selected")).toBe("true");
+    });
+
+    const input = getCommandSearchInput();
+    fireEvent.keyDown(input, { key: "PageDown" });
+    await waitFor(() => {
+      expect(rows[3].getAttribute("data-selected")).toBe("true");
+    });
+
+    fireEvent.keyDown(input, { key: "PageUp" });
+    await waitFor(() => {
+      expect(rows[0].getAttribute("data-selected")).toBe("true");
+    });
+  });
+
+  it("skips hidden rows when moving the selected row by a viewport", async () => {
+    render(wrap(<div>app</div>));
+    act(() => {
+      useCommandPaletteStore.getState().setOpen(true);
+    });
+    const list = await screen.findByTestId("command-palette-list");
+
+    const rows = getVisibleCommandRows(document.body);
+    expect(rows.length).toBeGreaterThan(4);
+    installPaletteListLayout(list, rows);
+    rows[1].hidden = true;
+    await waitFor(() => {
+      expect(rows[0].getAttribute("data-selected")).toBe("true");
+    });
+
+    fireEvent.keyDown(getCommandSearchInput(), {
+      key: "PageDown",
+    });
+    await waitFor(() => {
+      expect(rows[4].getAttribute("data-selected")).toBe("true");
     });
   });
 

--- a/clients/gui-app/src/components/command-palette/command-palette-shell.tsx
+++ b/clients/gui-app/src/components/command-palette/command-palette-shell.tsx
@@ -16,7 +16,12 @@
  * (`>`, `#`, `@`, `?`). The input shows the raw query with the prefix visible;
  * a custom cmdk filter strips the prefix before substring matching.
  */
-import { useCallback, useMemo, type ComponentType } from "react";
+import {
+  useCallback,
+  useMemo,
+  type ComponentType,
+  type KeyboardEvent,
+} from "react";
 import {
   Command,
   CommandEmpty,
@@ -38,6 +43,7 @@ import { PinToggle } from "@/components/command-palette/pin-toggle";
 import { SubpageView } from "@/components/command-palette/palette-cmdk";
 import {
   buildCmdkValue,
+  handlePalettePageNavigation,
   paletteFilter,
   usePaletteController,
   usePaletteScrollReset,
@@ -114,6 +120,12 @@ export function CommandPaletteShell(props: CommandPaletteShellProps) {
   // auto-selected first match stays in view instead of cmdk's scroll landing
   // off-target.
   const { listRef, handleQueryChange } = usePaletteScrollReset(setQuery);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      handlePalettePageNavigation(event, listRef);
+    },
+    [listRef],
+  );
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
@@ -147,7 +159,11 @@ export function CommandPaletteShell(props: CommandPaletteShellProps) {
           <DialogTitle>Command Palette</DialogTitle>
           <DialogDescription>Search for a command to run.</DialogDescription>
         </DialogHeader>
-        <Command filter={paletteFilter}>
+        <Command
+          filter={paletteFilter}
+          label="Search commands"
+          onKeyDown={handleKeyDown}
+        >
           <PaletteQueryProvider value={query}>
             <CommandInput
               value={query}

--- a/clients/gui-app/src/components/command-palette/palette-cmdk-controller.ts
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk-controller.ts
@@ -4,7 +4,13 @@
  * that owns the sub-page stack + item dispatch. Split out from the view
  * components (`palette-cmdk.tsx`) so each file stays fast-refresh friendly.
  */
-import { useCallback, useRef, useState, type RefObject } from "react";
+import {
+  useCallback,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
 import { defaultFilter } from "cmdk";
 import { runCommandItem } from "@/lib/commands/dispatch";
 import { isPathLikeQuery, matchesPathQuery } from "@/lib/commands/path-query";
@@ -51,6 +57,55 @@ export function usePaletteScrollReset(
     [setQuery],
   );
   return { listRef, handleQueryChange };
+}
+
+type PalettePageDirection = "up" | "down";
+
+function pointerMoveEvent(): Event {
+  if (typeof PointerEvent === "function") {
+    return new PointerEvent("pointermove", { bubbles: true });
+  }
+  return new MouseEvent("pointermove", { bubbles: true });
+}
+
+export function movePaletteSelectionByPage(
+  list: HTMLElement,
+  direction: PalettePageDirection,
+): void {
+  const items = Array.from(
+    list.querySelectorAll<HTMLElement>('[data-slot="command-item"]'),
+  ).filter((el) => el.closest("[hidden]") === null);
+  if (items.length === 0) return;
+
+  const rowHeight = items[0]?.offsetHeight || 36;
+  const pageSize = Math.max(1, Math.floor(list.clientHeight / rowHeight) - 1);
+  const selectedIndex = items.findIndex(
+    (el) => el.getAttribute("data-selected") === "true",
+  );
+  // When nothing is selected yet, anchor just outside the list so the first
+  // page lands on the first/last row.
+  const unselectedAnchor = direction === "down" ? -1 : items.length;
+  const from = selectedIndex === -1 ? unselectedAnchor : selectedIndex;
+  const delta = direction === "down" ? pageSize : -pageSize;
+  const targetIndex = Math.min(items.length - 1, Math.max(0, from + delta));
+  const target = items[targetIndex];
+
+  target.dispatchEvent(pointerMoveEvent());
+  target.scrollIntoView({ block: "nearest" });
+}
+
+export function handlePalettePageNavigation(
+  event: KeyboardEvent,
+  listRef: RefObject<HTMLDivElement | null>,
+): boolean {
+  if (event.key !== "PageDown" && event.key !== "PageUp") return false;
+
+  event.preventDefault();
+  const list = listRef.current;
+  if (list !== null) {
+    movePaletteSelectionByPage(list, event.key === "PageDown" ? "down" : "up");
+  }
+  return true;
 }
 
 export function paletteFilter(

--- a/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/command-palette/palette-cmdk";
 import {
   paletteFilter,
+  handlePalettePageNavigation,
   usePaletteController,
   usePaletteScrollReset,
 } from "@/components/command-palette/palette-cmdk-controller";
@@ -89,34 +90,6 @@ export function PaneOpener(props: PaneOpenerProps) {
   // first match in view by snapping the scroll container back to the top.
   const { listRef, handleQueryChange } = usePaletteScrollReset(setQuery);
 
-  // cmdk only navigates by ArrowUp/Down/Home/End. Page Up/Down jump a viewport:
-  // we find the target row in the DOM and select it with a single `pointermove`
-  // (cmdk selects an item on pointer-move), then scroll it into view. A loop of
-  // synthetic arrow keys does NOT work - cmdk derives "next" from the
-  // not-yet-committed selection, so every key in one tick lands on the same row.
-  const pageMove = (direction: "up" | "down") => {
-    const list = listRef.current;
-    if (list === null) return;
-    const items = Array.from(
-      list.querySelectorAll<HTMLElement>('[data-slot="command-item"]'),
-    );
-    if (items.length === 0) return;
-    const rowHeight = items[0].offsetHeight || 36;
-    const pageSize = Math.max(1, Math.floor(list.clientHeight / rowHeight) - 1);
-    const selectedIndex = items.findIndex(
-      (el) => el.getAttribute("data-selected") === "true",
-    );
-    // When nothing is selected yet, anchor just outside the list so the first
-    // page lands on the first/last row.
-    const unselectedAnchor = direction === "down" ? -1 : items.length;
-    const from = selectedIndex === -1 ? unselectedAnchor : selectedIndex;
-    const delta = direction === "down" ? pageSize : -pageSize;
-    const targetIndex = Math.min(items.length - 1, Math.max(0, from + delta));
-    const target = items[targetIndex];
-    target.dispatchEvent(new PointerEvent("pointermove", { bubbles: true }));
-    target.scrollIntoView({ block: "nearest" });
-  };
-
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     // Escape backs out of a sub-page; at the root it does nothing (the pane
     // stays empty/open, still a drop target).
@@ -126,10 +99,7 @@ export function PaneOpener(props: PaneOpenerProps) {
       popSubpage();
       return;
     }
-    if (event.key === "PageDown" || event.key === "PageUp") {
-      event.preventDefault();
-      pageMove(event.key === "PageDown" ? "down" : "up");
-    }
+    handlePalettePageNavigation(event, listRef);
   };
 
   return (


### PR DESCRIPTION
## Summary

- Add shared PageUp/PageDown navigation for cmdk-backed palette lists.
- Wire the CMD-K command palette to use the shared page navigation handler.
- Reuse the same helper in the in-pane opener to keep both palette surfaces aligned.
- Add a regression test covering PageDown/PageUp selection movement.

## Root Cause

cmdk handles arrow, Home, and End navigation, but the modal command palette never intercepted PageUp/PageDown. The in-pane opener had a local DOM-backed implementation, so CMD-K lacked the same viewport jump behavior.

## Validation

- `bun run compile` from `clients/gui-app`
- `bun run test src/components/command-palette/__tests__/command-palette.test.tsx` from `clients/gui-app`
- `bun x eslint src/components/command-palette/palette-cmdk-controller.ts src/components/command-palette/command-palette-shell.tsx src/components/epic-canvas/canvas/pane-opener.tsx src/components/command-palette/__tests__/command-palette.test.tsx --max-warnings 0` from `clients/gui-app`
- `bun x -y react-doctor@latest . --verbose --offline --scope changed --no-score` from `clients/gui-app`
