### PR TITLE
Fix directional pane focus

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/use-collab-tile-editor.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-collab-tile-editor.ts
@@ -94,6 +94,7 @@ export function useCollabTileEditor(
       editorProps: {
         attributes: {
           class: ARTIFACT_EDITOR_CONTENT_CLASS,
+          "data-artifact-editor": "",
         },
       },
     },

--- a/clients/gui-app/src/lib/keybindings/__tests__/tile-geometry.test.ts
+++ b/clients/gui-app/src/lib/keybindings/__tests__/tile-geometry.test.ts
@@ -133,3 +133,43 @@ describe("readTileRects excludes split resize handles", () => {
     expect(findNeighbor(paneB, rects, "left")).toBe("pane-A");
   });
 });
+
+describe("readTileRects normalizes pane-scoped child markers", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  function appendPaneBox(
+    parent: HTMLElement,
+    id: string,
+    box: [number, number, number, number],
+  ): HTMLElement {
+    const [x, y, width, height] = box;
+    const el = document.createElement("div");
+    el.setAttribute("data-group-id", id);
+    parent.append(el);
+    vi.spyOn(el, "getBoundingClientRect").mockReturnValue(
+      new DOMRect(x, y, width, height),
+    );
+    return el;
+  }
+
+  it("keeps one full-pane rect per pane id so child strips cannot win focus search", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    const paneA = appendPaneBox(container, "pane-A", [0, 0, 500, 600]);
+    appendPaneBox(paneA, "pane-A", [0, 0, 500, 36]);
+    const paneB = appendPaneBox(container, "pane-B", [500, 0, 500, 600]);
+    appendPaneBox(paneB, "pane-B", [500, 0, 500, 36]);
+
+    const rects = readTileRects(container);
+
+    expect(rects).toEqual([
+      rect("pane-A", [0, 0, 500, 600]),
+      rect("pane-B", [500, 0, 500, 600]),
+    ]);
+    expect(findNeighbor(rects[0], rects, "right")).toBe("pane-B");
+  });
+});

--- a/clients/gui-app/src/lib/keybindings/dispatch.ts
+++ b/clients/gui-app/src/lib/keybindings/dispatch.ts
@@ -41,6 +41,9 @@ import {
   type SettingsSectionId,
 } from "@/lib/settings-sections";
 
+const GROUP_EDITOR_FOCUS_TARGET_SELECTOR =
+  "[data-composer-editor], [data-artifact-editor]";
+
 // ---------------------------------------------------------------------------
 // Narrow router adapter - decouples dispatch from `@tanstack/react-router`'s
 // full `AppRouter` type so tests can supply a tiny fake without reaching for
@@ -614,26 +617,37 @@ function focusGroupInDirection(
   const nextId = findNeighbor(active, rects, dir);
   if (nextId === null) return false;
   useEpicCanvasStore.getState().setActiveTilePane(tab.tabId, nextId);
+  focusGroupEditor(nextId);
+  return true;
+}
+
+function focusGroupEditor(groupId: string): boolean {
+  if (typeof document === "undefined") return false;
+  const group = document.querySelector<HTMLElement>(groupIdSelector(groupId));
+  const editor = group?.querySelector<HTMLElement>(
+    GROUP_EDITOR_FOCUS_TARGET_SELECTOR,
+  );
+  if (editor === undefined || editor === null) return false;
+  editor.focus({ preventScroll: true });
   return true;
 }
 
 function focusActiveGroupEditor(router: KeybindingRouter): boolean {
-  if (typeof document === "undefined") return false;
   const tab = getActiveTab(router);
   if (tab !== null) {
     const target = getActiveGroupAndTab(tab.tabId);
-    if (target !== null) {
-      const group = document.querySelector<HTMLElement>(
-        `[data-group-id="${CSS.escape(target.groupId)}"]`,
-      );
-      const editor = group?.querySelector<HTMLElement>(
-        "[data-composer-editor]",
-      );
-      if (editor) {
-        editor.focus();
-        return true;
-      }
-    }
+    if (target !== null && focusGroupEditor(target.groupId)) return true;
   }
   return focusActiveComposer();
+}
+
+function groupIdSelector(groupId: string): string {
+  return `[data-group-id="${escapeAttributeSelectorValue(groupId)}"]`;
+}
+
+function escapeAttributeSelectorValue(value: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(value);
+  }
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }

--- a/clients/gui-app/src/lib/keybindings/tile-geometry.ts
+++ b/clients/gui-app/src/lib/keybindings/tile-geometry.ts
@@ -127,23 +127,32 @@ export function findNeighbor(
  *
  * Invariant: every `data-group-id` value is a leaf PANE id. The pane wrapper
  * plus its pane-scoped children (`tab-strip.tsx`, `pane-opener.tsx`) all reuse
- * the owning pane's id, so duplicate ids here are harmless. Split resize
- * handles must NOT use `data-group-id` - their id is a split-GROUP id that no
- * pane matches, so a handle on the seam would win the `findNeighbor` search and
- * make `setActivePane` silently no-op. Handles therefore carry
- * `data-resize-group-id` instead (see `resize-handle.tsx`) and are excluded.
+ * the owning pane's id, so normalize duplicates down to the largest observed
+ * rect for that id. Split resize handles must NOT use `data-group-id` - their
+ * id is a split-GROUP id that no pane matches, so a handle on the seam would
+ * win the `findNeighbor` search and make `setActivePane` silently no-op.
+ * Handles therefore carry `data-resize-group-id` instead
+ * (see `resize-handle.tsx`) and are excluded.
  */
 export function readTileRects(root: ParentNode): Array<TileRect> {
   const nodes = root.querySelectorAll<HTMLElement>("[data-group-id]");
-  const result: Array<TileRect> = [];
+  const byId = new Map<string, TileRect>();
   nodes.forEach((node) => {
     const id = node.getAttribute("data-group-id");
     if (id === null || id.length === 0) return;
     const r = node.getBoundingClientRect();
-    result.push({
+    const next = {
       id,
       rect: { x: r.x, y: r.y, width: r.width, height: r.height },
-    });
+    };
+    const current = byId.get(id);
+    if (current === undefined || rectArea(next) > rectArea(current)) {
+      byId.set(id, next);
+    }
   });
-  return result;
+  return Array.from(byId.values());
+}
+
+function rectArea(tileRect: TileRect): number {
+  return tileRect.rect.width * tileRect.rect.height;
 }

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
@@ -139,6 +139,8 @@ describe("dispatchAction", () => {
   });
 
   afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
     setSystemTabModalApi(null);
@@ -221,6 +223,38 @@ describe("dispatchAction", () => {
     expect(calls.length).toBe(0);
     expect(useEpicCanvasStore.getState().activeTabId).toBe(beforeHeaderTabId);
     expect(canvasTabIds(tabId)).toEqual(["spec-a", "spec-b"]);
+  });
+
+  it("focuses the target pane editor after directional group focus", () => {
+    const tabId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-pane-focus", "Pane Focus");
+    useEpicCanvasStore.getState().openTileInTab(tabId, specRef("spec-a"));
+    const sourcePaneId =
+      useEpicCanvasStore.getState().canvasByTabId[tabId]?.activePaneId ?? null;
+    if (sourcePaneId === null) throw new Error("expected source pane");
+
+    useEpicCanvasStore
+      .getState()
+      .splitPaneWithNode(tabId, sourcePaneId, "right", specRef("spec-b"));
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+    const targetPaneId =
+      collectPanes(canvas?.root ?? null).find(
+        (pane) => pane.id !== sourcePaneId,
+      )?.id ?? null;
+    if (targetPaneId === null) throw new Error("expected target pane");
+    useEpicCanvasStore.getState().setActiveTilePane(tabId, sourcePaneId);
+
+    appendFocusPane(sourcePaneId, [0, 0, 500, 600]);
+    const targetEditor = appendFocusPane(targetPaneId, [500, 0, 500, 600]);
+
+    const { router } = buildRouter(`/epics/epic-pane-focus/${tabId}`);
+
+    expect(dispatchAction("group.focus.right", router)).toBe(true);
+    expect(
+      useEpicCanvasStore.getState().canvasByTabId[tabId]?.activePaneId,
+    ).toBe(targetPaneId);
+    expect(document.activeElement).toBe(targetEditor);
   });
 
   it("does not close hidden epic canvas tabs while a non-detail route is active", () => {
@@ -308,6 +342,25 @@ describe("dispatchAction", () => {
     expect(canvasTabIds(tabId)).toEqual(["spec-a"]);
   });
 });
+
+function appendFocusPane(
+  paneId: string,
+  box: [number, number, number, number],
+): HTMLElement {
+  const [x, y, width, height] = box;
+  const pane = document.createElement("div");
+  pane.setAttribute("data-group-id", paneId);
+  document.body.append(pane);
+  vi.spyOn(pane, "getBoundingClientRect").mockReturnValue(
+    new DOMRect(x, y, width, height),
+  );
+
+  const editor = document.createElement("button");
+  editor.type = "button";
+  editor.setAttribute("data-artifact-editor", "");
+  pane.append(editor);
+  return editor;
+}
 
 // Fire a leader digit through the base scopes, the way the provider's keydown
 // handler does: register the scopes for this router, match a synthetic


### PR DESCRIPTION
## Summary
- Fix directional pane focus so the target pane receives browser focus after group focus up/down/left/right.
- Normalize duplicate pane DOM markers to the full pane rect before spatial neighbor lookup.
- Mark artifact editors as pane focus targets alongside chat composers.

## Root cause
Pane focus commands updated canvas active-pane state, but artifact editors had no pane-scoped focus target, so keyboard focus could remain in the previous pane. The geometry reader also treated pane-scoped child elements with duplicate data-group-id values as separate candidate rects.

## Validation
- bun run test src/lib/keybindings/__tests__/tile-geometry.test.ts src/providers/__tests__/keybinding-provider.test.ts
- bun run compile
- npx -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score
