### PR TITLE
feat(gui-app): use harness brand icon for TUI agents in sidebar and tabs

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-group-view.test.tsx
@@ -45,6 +45,7 @@ vi.mock("@/lib/epic-selectors", () => ({
   useEpicLiveArtifactTitleGenerating: () => false,
   useEpicPermissionRole: () => "owner",
   useEpicSnapshotLoaded: () => true,
+  useMaybeEpicTuiAgentHarnessId: () => null,
 }));
 
 vi.mock("@/components/epic-canvas/renderers/epic-node-tile", async () => {

--- a/clients/gui-app/src/components/epic-canvas/epic-node-tab-icon.tsx
+++ b/clients/gui-app/src/components/epic-canvas/epic-node-tab-icon.tsx
@@ -1,9 +1,11 @@
 import { cn } from "@/lib/utils";
 import { ChatProgressIcon } from "@/components/chat/chat-progress-icon";
+import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import {
   EPIC_NODE_ICONS,
   type EpicNodeKind,
 } from "@/lib/artifacts/node-display";
+import { useMaybeEpicTuiAgentHarnessId } from "@/lib/epic-selectors";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import {
   WORKSPACE_FILE_TAB_KIND,
@@ -47,9 +49,35 @@ export function EpicNodeTabIcon(props: {
       />
     );
   }
+  if (props.node.type === "terminal-agent") {
+    return (
+      <TuiAgentTabIcon nodeId={props.node.id} className={props.className} />
+    );
+  }
   return (
     <StaticEpicNodeIcon type={props.node.type} className={props.className} />
   );
+}
+
+/**
+ * TUI-agent tab/node icon: the underlying harness's brand mark (Claude, Codex,
+ * …) so a terminal agent reads as the tool driving it rather than a generic
+ * bot. Falls back to the static bot glyph when the harness can't be resolved -
+ * a legacy record, or the provider-less drag overlay (see
+ * {@link useMaybeEpicTuiAgentHarnessId}). Brand marks render in their own
+ * colors; they intentionally don't follow the per-type icon-color customization.
+ */
+function TuiAgentTabIcon(props: {
+  readonly nodeId: string;
+  readonly className: string;
+}) {
+  const harnessId = useMaybeEpicTuiAgentHarnessId(props.nodeId);
+  if (harnessId === null) {
+    return (
+      <StaticEpicNodeIcon type="terminal-agent" className={props.className} />
+    );
+  }
+  return <HarnessIcon harnessId={harnessId} className={props.className} />;
 }
 
 export function StaticEpicNodeIcon(props: {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -399,6 +399,7 @@ vi.mock("@/lib/epic-selectors", () => ({
   useEpicPermissionRole: () => testState.permissionRole,
   useEpicTreeIndex: () => testState.tree,
   useEpicTreeNode: (nodeId: string) => testState.tree.nodeById[nodeId] ?? null,
+  useMaybeEpicTuiAgentHarnessId: () => null,
   useRootIds: () => testState.tree.rootIds,
 }));
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -24,6 +24,7 @@ import {
 import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import { cn } from "@/lib/utils";
 import { ChatProgressIcon } from "@/components/chat/chat-progress-icon";
+import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
@@ -76,6 +77,7 @@ import {
   useEpicPermissionRole,
   useEpicTreeIndex,
   useEpicTreeNode,
+  useMaybeEpicTuiAgentHarnessId,
 } from "@/lib/epic-selectors";
 import { isEditableRole } from "@/lib/epic-permissions";
 import { useSettingsStore } from "@/stores/settings/settings-store";
@@ -1324,7 +1326,17 @@ function TerminalAgentProgressIcon(props: {
   readonly iconStyle: { color: string | undefined } | undefined;
 }) {
   const isActive = useEpicActiveAgentIds().has(props.nodeId);
+  const harnessId = useMaybeEpicTuiAgentHarnessId(props.nodeId);
   if (!isActive) {
+    // The underlying harness's brand mark (Claude, Codex, …) so the row reads
+    // as the tool driving the agent. Brand marks keep their own colors and
+    // intentionally don't follow the per-type icon-color customization; the
+    // generic bot glyph is the fallback for unresolved/legacy records.
+    if (harnessId !== null) {
+      return (
+        <HarnessIcon harnessId={harnessId} className="size-3.5 shrink-0" />
+      );
+    }
     return (
       <StaticSidebarNodeIcon
         Icon={props.Icon}

--- a/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import type { TuiHarnessId } from "@traycer/protocol/persistence/epic/schemas";
 import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
@@ -56,6 +56,30 @@ describe("useMaybeEpicTuiAgentHarnessId", () => {
       () => useMaybeEpicTuiAgentHarnessId("agent-1"),
       { wrapper: openEpicWrapper(handle) },
     );
+
+    expect(result.current).toBe("codex");
+  });
+
+  it("updates when tuiAgents.byId changes after mount", () => {
+    const handle = createHandle("epic-live-update");
+
+    const { result } = renderHook(
+      () => useMaybeEpicTuiAgentHarnessId("agent-1"),
+      { wrapper: openEpicWrapper(handle) },
+    );
+
+    expect(result.current).toBeNull();
+
+    act(() => {
+      handle.store.setState({
+        tuiAgents: {
+          allIds: ["agent-1"],
+          byId: {
+            "agent-1": tuiAgent("agent-1", "codex"),
+          },
+        },
+      });
+    });
 
     expect(result.current).toBe("codex");
   });

--- a/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from "react";
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { TuiHarnessId } from "@traycer/protocol/persistence/epic/schemas";
+import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
+import { useMaybeEpicTuiAgentHarnessId } from "@/lib/epic-selectors";
+import {
+  createOpenEpicStore,
+  type EpicStreamClientFactory,
+  type OpenEpicStoreHandle,
+} from "@/stores/epics/open-epic/store";
+import type { TuiAgentProjection } from "@/stores/epics/open-epic/types";
+
+const handles: OpenEpicStoreHandle[] = [];
+
+afterEach(() => {
+  cleanup();
+  for (const handle of handles) {
+    handle.dispose();
+  }
+  handles.length = 0;
+});
+
+describe("useMaybeEpicTuiAgentHarnessId", () => {
+  it("returns null outside an open-epic session", () => {
+    const { result } = renderHook(() =>
+      useMaybeEpicTuiAgentHarnessId("agent-1"),
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it("returns null when no tuiAgents.byId entry matches the node id", () => {
+    const handle = createHandle("epic-missing-agent");
+
+    const { result } = renderHook(
+      () => useMaybeEpicTuiAgentHarnessId("agent-1"),
+      { wrapper: openEpicWrapper(handle) },
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it("returns the matching tuiAgents.byId harnessId", () => {
+    const handle = createHandle("epic-with-agent");
+    handle.store.setState({
+      tuiAgents: {
+        allIds: ["agent-1"],
+        byId: {
+          "agent-1": tuiAgent("agent-1", "codex"),
+        },
+      },
+    });
+
+    const { result } = renderHook(
+      () => useMaybeEpicTuiAgentHarnessId("agent-1"),
+      { wrapper: openEpicWrapper(handle) },
+    );
+
+    expect(result.current).toBe("codex");
+  });
+});
+
+function createHandle(epicId: string): OpenEpicStoreHandle {
+  const handle = createOpenEpicStore({
+    epicId,
+    userId: null,
+    streamClientFactory: fakeStreamClientFactory,
+    onAuthError: null,
+  });
+  handles.push(handle);
+  return handle;
+}
+
+function openEpicWrapper(handle: OpenEpicStoreHandle) {
+  return function OpenEpicWrapper(props: { readonly children: ReactNode }) {
+    return (
+      <EpicSessionContext.Provider value={handle}>
+        {props.children}
+      </EpicSessionContext.Provider>
+    );
+  };
+}
+
+const fakeStreamClientFactory: EpicStreamClientFactory = () => ({
+  applyUpdate: () => undefined,
+  awareness: () => undefined,
+  applyArtifactRoomUpdate: () => undefined,
+  artifactRoomAwareness: () => undefined,
+  retryMigration: () => undefined,
+  close: () => undefined,
+});
+
+function tuiAgent(id: string, harnessId: TuiHarnessId): TuiAgentProjection {
+  return {
+    id,
+    harnessId,
+    title: "Codex",
+    parentId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    userId: null,
+    hostId: "host-a",
+    workspaceFolders: [],
+    model: null,
+    reasoningEffort: null,
+    agentMode: "regular",
+    harnessSessionId: null,
+    terminalAgentArgs: null,
+    terminalShellCommand: null,
+    terminalShellArgs: null,
+  };
+}

--- a/clients/gui-app/src/lib/epic-selectors.ts
+++ b/clients/gui-app/src/lib/epic-selectors.ts
@@ -28,6 +28,7 @@ import { v4 as uuidv4 } from "uuid";
 import * as Y from "yjs";
 import type { Awareness } from "y-protocols/awareness";
 import type { PermissionRole } from "@traycer/protocol/host/epic/unary-schemas";
+import type { TuiHarnessId } from "@traycer/protocol/persistence/epic/schemas";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
 import type { SnapshotMetaEpic } from "@traycer/protocol/host/epic/snapshot-meta";
 import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
@@ -36,7 +37,10 @@ import { displayTitle, tuiAgentDisplayTitle } from "@/lib/display-title";
 import { useEpicStore } from "@/hooks/use-epic-store";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
-import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import {
+  useMaybeOpenEpicHandle,
+  useOpenEpicHandle,
+} from "@/providers/use-open-epic-handle";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import {
   pendingTitleVisibleAutoPurge,
@@ -939,6 +943,38 @@ export function useEpicNodeHostId(nodeId: string): string | null {
     }
     return null;
   });
+}
+
+/**
+ * A terminal-agent row's harness id, read narrowly off `tuiAgents.byId` so a
+ * tab / sidebar row can render the harness's brand icon (Claude, Codex, …) in
+ * place of the generic bot glyph. Returns `null` for chat / artifact rows, for
+ * ids that resolve to nothing, AND when called outside an open-epic session
+ * (e.g. the drag overlay, which mounts at the app shell with no provider). In
+ * every null case the caller falls back to the bot icon.
+ *
+ * Resolves through `useMaybeOpenEpicHandle` + `useSyncExternalStore` (the same
+ * provider-optional pattern as the `useRegistered*` hooks above) so the single
+ * `EpicNodeTabIcon` source can render it both inside the canvas tab strip and in
+ * the provider-less overlay without a conditional hook call. The selected
+ * harness id is a reference-stable primitive, so unrelated store churn does not
+ * re-render the consuming row. See RENDER_PERF_INVARIANTS.md.
+ */
+export function useMaybeEpicTuiAgentHarnessId(
+  nodeId: string,
+): TuiHarnessId | null {
+  const handle = useMaybeOpenEpicHandle();
+  return useSyncExternalStore(
+    (listener) => handle?.store.subscribe(listener) ?? noopSubscribe,
+    () => {
+      if (handle === null) return null;
+      const s = handle.store.getState();
+      return Object.hasOwn(s.tuiAgents.byId, nodeId)
+        ? s.tuiAgents.byId[nodeId].harnessId
+        : null;
+    },
+    () => null,
+  );
 }
 
 export function useEpicNodeOwnerKind(


### PR DESCRIPTION
## Summary

Render the underlying harness's brand icon (Claude / Codex / OpenCode / Cursor) for **terminal-agent (TUI)** nodes in the epic **sidebar tree** and the **canvas tab strip**, replacing the generic `Bot` glyph. GUI chat agents keep their existing icon.

A provider-optional `useMaybeEpicTuiAgentHarnessId` selector resolves the harness per node and falls back to the `Bot` glyph when read **outside an epic session** (e.g. the canvas drag overlay, which mounts at the app shell with no provider), so rules-of-hooks stay valid and nothing throws.

## Changes

- `src/lib/epic-selectors.ts` — new `useMaybeEpicTuiAgentHarnessId(nodeId)` per-node hook (provider-optional, mirrors `useEpicNodeHostId`).
- `src/components/epic-canvas/epic-node-tab-icon.tsx` — `TuiAgentTabIcon` branch driving the canvas tab strip + drag overlay.
- `src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx` — harness brand icon in the idle `TerminalAgentProgressIcon` (running spinner unchanged).
- Two test mocks updated for the new selector export.

`TuiHarnessId` (`claude` | `codex` | `opencode` | `cursor`) is a subset of the GUI `ProviderId`, so it feeds `HarnessIcon` directly. Brand icons render in their own colors and intentionally bypass per-type icon recoloring.

## Verification

- `bun run compile` → clean
- `eslint` (changed files) → clean
- `prettier@3.9.4 --check` → clean
- affected suites (tab-group-view, sidebar selection-mode, canvas) → **63 passing**

Reviewed by an independent Codex (gpt-5.5, xhigh) pass — no material correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
