### PR TITLE
fix(protocol): keep chat.subscribe compatible with host-v1.0.0

### DIFF
--- a/clients/shared/host-transport/__tests__/chat-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/chat-stream-client.test.ts
@@ -188,7 +188,7 @@ describe("ChatStreamClient", () => {
     expect(parseText(sockets[0].textSent[1])).toEqual({
       kind: "subscribe",
       method: "chat.subscribe",
-      schemaVersion: { major: 1, minor: 0 },
+      schemaVersion: { major: 1, minor: 1 },
       params: { epicId: "epic-1", chatId: "chat-1" },
     });
 

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -227,13 +227,6 @@ function parseText(raw: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function expectedEpicOpenManifest(): Record<string, unknown> {
-  return {
-    ...buildStreamManifest(hostStreamRpcRegistry),
-    "chat.subscribe": { major: 1, minor: 0 },
-  };
-}
-
 describe("WsStreamClient", () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -273,10 +266,15 @@ describe("WsStreamClient", () => {
     const openFrame = parseText(stub.textSent[0]);
     expect(openFrame.kind).toBe("open");
     expect(openFrame.token).toBe("token-abc");
-    // Non-chat streams advertise a chat v1 compatibility line in the open frame
-    // so already-deployed hosts can reach the method-specific subscribe check.
-    const expectedManifest = expectedEpicOpenManifest();
-    expect(openFrame.manifest).toEqual(expectedManifest);
+    // The open frame's manifest is the client's raw canonical - no per-method
+    // substitution needed. A same-major minor skew (e.g. host-v1.0.0's
+    // chat.subscribe@1.0 vs this client's @1.1) is safe for the old host's own
+    // full-manifest check: `canBridgeStream` trusts an older peer receiving a
+    // newer minor unconditionally (additive minors), so it never poisons an
+    // unrelated method's open handshake the way the old major bump once did.
+    expect(openFrame.manifest).toEqual(
+      buildStreamManifest(hostStreamRpcRegistry),
+    );
 
     stub.fireText({
       kind: "openAck",
@@ -313,9 +311,12 @@ describe("WsStreamClient", () => {
     const stub = sockets[0].socket;
     stub.fireOpen();
 
+    // A hypothetical peer on some future, unbridgeable chat.subscribe major -
+    // exercises method isolation, independent of chat.subscribe's real,
+    // currently-bridgeable version history.
     const skewedManifest = {
       ...buildStreamManifest(hostStreamRpcRegistry),
-      "chat.subscribe": { major: 1, minor: 0 },
+      "chat.subscribe": { major: 2, minor: 0 },
     };
     stub.fireText({ kind: "openAck", manifest: skewedManifest });
 
@@ -352,6 +353,50 @@ describe("WsStreamClient", () => {
     expect(openFrame.manifest).toEqual(
       buildStreamManifest(hostStreamRpcRegistry),
     );
+
+    session.close();
+  });
+
+  // Regression test for the release-v1.1.0 RC incident: the compatibility
+  // check correctly determined chat.subscribe@1.1 bridges to a host still on
+  // @1.0, but the subscribe frame kept declaring this client's own canonical
+  // (1.1) regardless - a version host-v1.0.0's dispatch table has never heard
+  // of, so it rejected the subscribe outright even though the handshake
+  // passed. The client must downgrade what it declares to the version the
+  // host actually advertised.
+  it("declares the host's own chat.subscribe version when the host is still on 1.0", async () => {
+    const { factory, sockets } = makeFactory();
+    const client = makeClient({
+      factory,
+      authToken: "token-abc",
+      pingIntervalMs: 25_000,
+      pongTimeoutMs: 50_000,
+      initialBackoffMs: 10,
+      maxBackoffMs: 1_000,
+    });
+
+    const session = client.subscribe("chat.subscribe", {
+      epicId: "epic-1",
+      chatId: "chat-1",
+    });
+    await flush();
+
+    const stub = sockets[0].socket;
+    stub.fireOpen();
+
+    const hostV100Manifest = {
+      ...buildStreamManifest(hostStreamRpcRegistry),
+      "chat.subscribe": { major: 1, minor: 0 },
+    };
+    stub.fireText({ kind: "openAck", manifest: hostV100Manifest });
+
+    expect(stub.textSent).toHaveLength(2);
+    expect(parseText(stub.textSent[1])).toEqual({
+      kind: "subscribe",
+      method: "chat.subscribe",
+      schemaVersion: { major: 1, minor: 0 },
+      params: { epicId: "epic-1", chatId: "chat-1" },
+    });
 
     session.close();
   });

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import { buildStreamManifest } from "@traycer/protocol/framework/stream-compat";
+import {
+  defineStreamRpcContract,
+  defineVersionedStreamRpcRegistry,
+} from "@traycer/protocol/framework/versioned-stream-rpc";
 import {
   createRequestContext,
   identityFromAuthenticatedUser,
@@ -396,6 +401,100 @@ describe("WsStreamClient", () => {
       method: "chat.subscribe",
       schemaVersion: { major: 1, minor: 0 },
       params: { epicId: "epic-1", chatId: "chat-1" },
+    });
+
+    session.close();
+  });
+
+  // chat.subscribe's own openRequestSchema never changed across 1.0/1.1, so
+  // the test above can't prove `prepareStreamSubscribeRequest` actually
+  // reprojects params through the older contract - only that it downgrades
+  // the declared version. A synthetic method with a genuinely different
+  // open-request shape per minor closes that gap.
+  it("rewrites the subscribe params onto the host's older contract when the open-request shape changed", async () => {
+    const openRequestSchemaV10 = z.object({ id: z.string() });
+    const openRequestSchemaV11 = z.object({
+      id: z.string(),
+      locale: z.string().nullable(),
+    });
+    const frameSchemas = {
+      serverFrameSchema: z.discriminatedUnion("kind", [
+        z.object({
+          kind: z.literal("snapshot"),
+          hasBinaryPayload: z.literal(false),
+          id: z.string(),
+        }),
+      ]),
+      clientFrameSchema: z.discriminatedUnion("kind", [
+        z.object({
+          kind: z.literal("noop"),
+          hasBinaryPayload: z.literal(false),
+        }),
+      ]),
+    };
+    const versionSkewRegistry = defineVersionedStreamRpcRegistry({
+      "version-skew.subscribe": {
+        1: {
+          latestMinor: 1,
+          versions: {
+            0: {
+              contract: defineStreamRpcContract({
+                method: "version-skew.subscribe",
+                schemaVersion: { major: 1, minor: 0 } as const,
+                openRequestSchema: openRequestSchemaV10,
+                ...frameSchemas,
+              }),
+            },
+            1: {
+              contract: defineStreamRpcContract({
+                method: "version-skew.subscribe",
+                schemaVersion: { major: 1, minor: 1 } as const,
+                openRequestSchema: openRequestSchemaV11,
+                ...frameSchemas,
+              }),
+            },
+          },
+        },
+      },
+    });
+
+    const { factory, sockets } = makeFactory();
+    const client = new WsStreamClient({
+      registry: versionSkewRegistry,
+      endpoint: () => mockLocalHostEntry,
+      bearer: () => makeRequestContext("t")?.credentials ?? null,
+      auth: null,
+      webSocketFactory: factory,
+      dialTimeoutMs: 1000,
+      openAckTimeoutMs: 1000,
+      pingIntervalMs: 25_000,
+      pongTimeoutMs: 50_000,
+      initialBackoffMs: 10,
+      maxBackoffMs: 1_000,
+    });
+
+    const session = client.subscribe("version-skew.subscribe", {
+      id: "item-1",
+      locale: "en-US",
+    });
+    await flush();
+
+    const stub = sockets[0].socket;
+    stub.fireOpen();
+
+    stub.fireText({
+      kind: "openAck",
+      manifest: { "version-skew.subscribe": { major: 1, minor: 0 } },
+    });
+
+    expect(stub.textSent).toHaveLength(2);
+    expect(parseText(stub.textSent[1])).toEqual({
+      kind: "subscribe",
+      method: "version-skew.subscribe",
+      schemaVersion: { major: 1, minor: 0 },
+      // `locale` is stripped - the 1.0 contract the host actually has never
+      // declared that field, so the params get reprojected onto it.
+      params: { id: "item-1" },
     });
 
     session.close();

--- a/clients/shared/host-transport/chat-stream-client.ts
+++ b/clients/shared/host-transport/chat-stream-client.ts
@@ -13,7 +13,7 @@ import type {
 import type { WsStreamClient } from "./ws-stream-client";
 
 /**
- * Typed handlers for a `chat.subscribe@2.0` session. The GUI chat store binds
+ * Typed handlers for a `chat.subscribe@1.1` session. The GUI chat store binds
  * these directly into Zustand so raw stream envelopes do not leak into React.
  */
 export interface ChatStreamCallbacks {

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -1,4 +1,8 @@
-import type { VersionedStreamRpcRegistry } from "@traycer/protocol/framework/versioned-stream-rpc";
+import type {
+  SchemaVersion,
+  StreamMethodVersionRegistry,
+  VersionedStreamRpcRegistry,
+} from "@traycer/protocol/framework/versioned-stream-rpc";
 import {
   buildStreamManifest,
   checkStreamMethodCompatibility,
@@ -13,10 +17,7 @@ import type {
   RevalidateOutcome,
   StreamAuthRevalidator,
 } from "@traycer-clients/shared/auth/bearer-revalidator";
-import type {
-  ConnectionManifest,
-  FatalErrorDetails,
-} from "@traycer/protocol/framework/ws-protocol";
+import type { FatalErrorDetails } from "@traycer/protocol/framework/ws-protocol";
 import {
   hostStreamOpenAckFrameSchema,
   hostStreamFatalErrorFrameSchema,
@@ -535,10 +536,7 @@ class StreamSession<
       this.onTransportDrop();
       return;
     }
-    const manifest = streamOpenManifestForMethod(
-      this.config.registry,
-      this.config.method,
-    );
+    const manifest = buildStreamManifest(this.config.registry);
     const openFrame: ClientStreamOpenFrame = {
       kind: "open",
       token,
@@ -715,11 +713,18 @@ class StreamSession<
       return;
     }
 
+    const prepared = prepareStreamSubscribeRequest(
+      this.config.registry,
+      this.config.method,
+      myManifest[this.config.method],
+      ackParse.data.manifest[this.config.method],
+      this.config.params,
+    );
     const subscribeFrame: ClientStreamSubscribeFrame = {
       kind: "subscribe",
       method: this.config.method,
-      schemaVersion: myManifest[this.config.method],
-      params: this.config.params,
+      schemaVersion: prepared.onWireVersion,
+      params: prepared.onWirePayload,
     };
     if (!this.sendControlText(socket, subscribeFrame)) {
       this.onSendFailure(socket);
@@ -1146,19 +1151,48 @@ class StreamSession<
   }
 }
 
-function streamOpenManifestForMethod(
+interface PreparedStreamSubscribeRequest {
+  readonly onWireVersion: SchemaVersion;
+  readonly onWirePayload: unknown;
+}
+
+/**
+ * Computes what the `subscribe` control frame should actually declare on the
+ * wire - the streaming analog of `ws-rpc-client.ts`'s `prepareRequestPayload`.
+ *
+ * `checkStreamMethodCompatibility` already proved `mine`/`theirs` are
+ * bridgeable before this runs. For a same-major minor skew that only ever
+ * means one thing: MY OWN registry carries a contract at the peer's exact
+ * (older) minor - that's what made `canBridgeStream()` return `true`. Per the
+ * framework's asymmetric contract, the older side never transforms, so the
+ * newer side is the one that must downgrade what it declares: sending my own
+ * canonical here would declare a minor the older peer's dispatch table has
+ * never heard of, even though the abstract compatibility check passed (this
+ * is what broke `chat.subscribe@1.1` against host-v1.0.0 - the compat check
+ * passed, but the client still declared `1.1`, which host-v1.0.0's registry
+ * has no contract for). Cross-major skew never reaches here: streams have no
+ * cross-major bridge, so `compat.ok` would already be `false`.
+ */
+function prepareStreamSubscribeRequest(
   registry: VersionedStreamRpcRegistry,
   method: string,
-): ConnectionManifest {
-  const manifest = buildStreamManifest(registry);
-  if (method !== "chat.subscribe" && manifest["chat.subscribe"]?.major === 2) {
-    // Older hosts checked the full manifest before subscribe. For non-chat
-    // streams, advertise the last pre-v2 chat line only in the open manifest so
-    // old hosts can reach subscribe; the real method version is still checked
-    // from the canonical manifest after openAck.
-    return { ...manifest, "chat.subscribe": { major: 1, minor: 0 } };
+  myCanonical: SchemaVersion,
+  theirCanonical: SchemaVersion,
+  params: unknown,
+): PreparedStreamSubscribeRequest {
+  if (
+    myCanonical.major !== theirCanonical.major ||
+    myCanonical.minor <= theirCanonical.minor
+  ) {
+    return { onWireVersion: myCanonical, onWirePayload: params };
   }
-  return manifest;
+  const methodRegistry = registry[method] as StreamMethodVersionRegistry;
+  const olderLine = methodRegistry[myCanonical.major];
+  const olderEntry = olderLine.versions[theirCanonical.minor];
+  return {
+    onWireVersion: theirCanonical,
+    onWirePayload: olderEntry.contract.openRequestSchema.parse(params),
+  };
 }
 
 type SessionPhase = "idle" | "dialing" | "awaitingOpenAck" | "subscribed";

--- a/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
+++ b/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
@@ -317,6 +317,27 @@ describe("stream compatibility", () => {
     );
     expect(fullConnection.ok).toBe(true);
 
+    // Mirrored host-role check: host-v1.0.0 itself, running this same check
+    // from its own (older) side against a 1.1 client's manifest, must reach
+    // the same verdict - the host's own subscribe-time compatibility gate
+    // runs with `selfRole: "host"`, not "client".
+    const fullConnectionAsHost = checkStreamCompatibility(
+      hostStreamRpcRegistry,
+      hostV100Manifest,
+      currentManifest,
+      "host",
+    );
+    expect(fullConnectionAsHost.ok).toBe(true);
+
+    const chatSubscribeAsHost = checkStreamMethodCompatibility(
+      hostStreamRpcRegistry,
+      hostV100Manifest,
+      currentManifest,
+      "host",
+      "chat.subscribe",
+    );
+    expect(chatSubscribeAsHost.ok).toBe(true);
+
     const chatSubscribe = checkStreamMethodCompatibility(
       hostStreamRpcRegistry,
       currentManifest,

--- a/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
+++ b/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
@@ -26,7 +26,7 @@ describe("validateVersionedStreamRpcRegistry", () => {
       validateVersionedStreamRpcRegistry(hostStreamRpcRegistry);
     }).not.toThrow();
     expect(hostStreamRpcRegistry["epic.subscribe"][1].latestMinor).toBe(0);
-    expect(hostStreamRpcRegistry["chat.subscribe"][2].latestMinor).toBe(0);
+    expect(hostStreamRpcRegistry["chat.subscribe"][1].latestMinor).toBe(1);
     expect(
       hostStreamRpcRegistry["notifications.subscribe"][1].latestMinor,
     ).toBe(0);
@@ -262,15 +262,18 @@ describe("validateVersionedStreamRpcRegistry", () => {
 describe("stream compatibility", () => {
   it("allows a compatible subscribed method when another stream method has major skew", () => {
     const currentManifest = buildStreamManifest(hostStreamRpcRegistry);
-    const olderChatManifest = {
+    // A hypothetical peer on some future, unbridgeable chat.subscribe major -
+    // exercises the method-isolation property below, independent of
+    // chat.subscribe's real, currently-bridgeable version history.
+    const skewedManifest = {
       ...currentManifest,
-      "chat.subscribe": { major: 1, minor: 0 },
+      "chat.subscribe": { major: 2, minor: 0 },
     };
 
     const fullConnection = checkStreamCompatibility(
       hostStreamRpcRegistry,
       currentManifest,
-      olderChatManifest,
+      skewedManifest,
       "host",
     );
     expect(fullConnection.ok).toBe(false);
@@ -278,7 +281,7 @@ describe("stream compatibility", () => {
     const epicSubscribe = checkStreamMethodCompatibility(
       hostStreamRpcRegistry,
       currentManifest,
-      olderChatManifest,
+      skewedManifest,
       "host",
       "epic.subscribe",
     );
@@ -287,10 +290,40 @@ describe("stream compatibility", () => {
     const chatSubscribe = checkStreamMethodCompatibility(
       hostStreamRpcRegistry,
       currentManifest,
-      olderChatManifest,
+      skewedManifest,
       "host",
       "chat.subscribe",
     );
     expect(chatSubscribe.ok).toBe(false);
+  });
+
+  // Regression guard for the release-v1.1.0 RC incident: chat.subscribe
+  // bumped to a new major (dropping the v1.0 registration entirely) and broke
+  // every host still running host-v1.0.0. Fixed by keeping chat.subscribe on
+  // major 1 and shipping the background-items controls as an additive 1.1
+  // minor, so a 1.1 app must still bridge to a host that only advertises 1.0.
+  it("bridges chat.subscribe@1.1 to a host still on chat.subscribe@1.0 (host-v1.0.0)", () => {
+    const currentManifest = buildStreamManifest(hostStreamRpcRegistry);
+    const hostV100Manifest = {
+      ...currentManifest,
+      "chat.subscribe": { major: 1, minor: 0 },
+    };
+
+    const fullConnection = checkStreamCompatibility(
+      hostStreamRpcRegistry,
+      currentManifest,
+      hostV100Manifest,
+      "client",
+    );
+    expect(fullConnection.ok).toBe(true);
+
+    const chatSubscribe = checkStreamMethodCompatibility(
+      hostStreamRpcRegistry,
+      currentManifest,
+      hostV100Manifest,
+      "client",
+      "chat.subscribe",
+    );
+    expect(chatSubscribe.ok).toBe(true);
   });
 });

--- a/protocol/src/host/agent/gui/__tests__/chat-subscribe.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/chat-subscribe.test.ts
@@ -3,7 +3,8 @@ import {
   chatQueuedItemSchema,
   chatSubscribeClientFrameSchema,
   chatSubscribeServerFrameSchema,
-  chatSubscribeV20,
+  chatSubscribeV10,
+  chatSubscribeV11,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import { getRecordSchema } from "@traycer/protocol/framework/index";
 import type {
@@ -62,19 +63,50 @@ const event: ChatEvent = {
   metadata: null,
 };
 
-describe("chat.subscribe@2.0 open request", () => {
+describe("chat.subscribe@1.1 open request", () => {
   it("requires an epicId and chatId", () => {
-    const parsed = chatSubscribeV20.openRequestSchema.parse({
+    const parsed = chatSubscribeV11.openRequestSchema.parse({
       epicId: "epic-1",
       chatId: "chat-1",
     });
 
     expect(parsed).toEqual({ epicId: "epic-1", chatId: "chat-1" });
-    expect(() => chatSubscribeV20.openRequestSchema.parse({})).toThrow();
+    expect(() => chatSubscribeV11.openRequestSchema.parse({})).toThrow();
   });
 });
 
-describe("chat.subscribe@2.0 server frames", () => {
+describe("chat.subscribe@1.0 (frozen host-v1.0.0 shape)", () => {
+  it("parses the actionAck shape host-v1.0.0 actually emits, before background-items existed", () => {
+    expect(
+      chatSubscribeV10.serverFrameSchema.parse({
+        kind: "actionAck",
+        hasBinaryPayload: false,
+        epicId: "epic-1",
+        chatId: "chat-1",
+        clientActionId: "action-1",
+        action: "send",
+        status: "accepted",
+        reason: null,
+        code: null,
+      }),
+    ).toMatchObject({ kind: "actionAck", status: "accepted" });
+  });
+
+  it("does not know the v1.1 background-stop client actions - host-v1.0.0 never learned them", () => {
+    expect(
+      chatSubscribeV10.clientFrameSchema.safeParse({
+        kind: "stopBackgroundItem",
+        hasBinaryPayload: false,
+        epicId: "epic-1",
+        chatId: "chat-1",
+        clientActionId: "action-1",
+        taskId: "task-1",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("chat.subscribe@1.1 server frames", () => {
   it("parses queued steer-requested items with durable steer metadata", () => {
     const parsed = chatQueuedItemSchema.parse({
       queueItemId: "queue-1",
@@ -297,6 +329,24 @@ describe("chat.subscribe@2.0 server frames", () => {
     });
   });
 
+  it("defaults backgroundStopTaskIds to [] on a chat.subscribe@1.0-shaped ack (host-v1.0.0 never sends it)", () => {
+    expect(
+      chatSubscribeServerFrameSchema.parse({
+        kind: "actionAck",
+        hasBinaryPayload: false,
+        epicId: "epic-1",
+        chatId: "chat-1",
+        clientActionId: "action-1",
+        action: "send",
+        status: "accepted",
+        reason: null,
+        code: null,
+        // backgroundStopTaskIds omitted - the exact shape a chat.subscribe@1.0
+        // host emits, since it predates background-items support entirely.
+      }),
+    ).toMatchObject({ kind: "actionAck", backgroundStopTaskIds: [] });
+  });
+
   it("parses durable event and live block delta frames separately", () => {
     expect(
       chatSubscribeServerFrameSchema.parse({
@@ -449,7 +499,7 @@ describe("chat.subscribe@2.0 server frames", () => {
   });
 });
 
-describe("chat.subscribe@2.0 client frames", () => {
+describe("chat.subscribe@1.1 client frames", () => {
   it("requires clientActionId on owner action frames", () => {
     expect(
       chatSubscribeClientFrameSchema.parse({

--- a/protocol/src/host/agent/gui/contracts.ts
+++ b/protocol/src/host/agent/gui/contracts.ts
@@ -15,7 +15,10 @@ import {
   listGuiHarnessesResponseSchemaV10,
   guiHarnessOptionSchemaV10,
 } from "@traycer/protocol/host/agent/gui/unary-schemas";
-import { chatSubscribeV20 } from "@traycer/protocol/host/agent/gui/subscribe";
+import {
+  chatSubscribeV10,
+  chatSubscribeV11,
+} from "@traycer/protocol/host/agent/gui/subscribe";
 
 // ─── GUI-surface catalog (`agent.gui.*`) ──────────────────────────────────
 
@@ -90,4 +93,4 @@ export const agentGuiGetPlanV10 = defineRpcContract({
   responseSchema: getGuiAgentPlanResponseSchema,
 });
 
-export { chatSubscribeV20 };
+export { chatSubscribeV10, chatSubscribeV11 };

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -729,8 +729,26 @@ const chatActionSchemaV10 = z.enum([
   "revertFileChanges",
 ]);
 
-const chatSnapshotSchemaV10 = chatSnapshotSchema.omit({
-  backgroundItems: true,
+const chatSubscribeOpenRequestSchemaV10 = z.object({
+  epicId: z.string(),
+  chatId: z.string(),
+});
+
+// Pinned field-for-field, not derived via `.omit()` from `chatSnapshotSchema`
+// - a later required field added to the live schema must not silently leak
+// into this frozen contract.
+const chatSnapshotSchemaV10 = z.object({
+  chat: chatSchema,
+  access: chatAccessSchema,
+  queue: chatQueueStateSchema,
+  runStatus: chatRunStatusSchema,
+  activeTurn: chatActiveTurnSchema.nullable(),
+  pendingApprovals: z.array(chatApprovalStateSchema),
+  pendingInterviews: z.array(chatPendingInterviewStateSchema),
+  worktreeBinding: worktreeBindingSchema.nullable(),
+  missingWorktreePaths: z.array(z.string()),
+  pendingFileEditApprovals: z.array(chatFileEditApprovalStateSchema),
+  accumulatedFileChanges: z.array(chatAccumulatedFileChangeSchema),
 });
 
 const chatSubscribeServerFrameSchemaV10 = z.discriminatedUnion("kind", [
@@ -1004,7 +1022,7 @@ const chatSubscribeClientFrameSchemaV10 = z.discriminatedUnion("kind", [
 export const chatSubscribeV10 = defineStreamRpcContract({
   method: "chat.subscribe",
   schemaVersion: { major: 1, minor: 0 } as const,
-  openRequestSchema: chatSubscribeOpenRequestSchema,
+  openRequestSchema: chatSubscribeOpenRequestSchemaV10,
   serverFrameSchema: chatSubscribeServerFrameSchemaV10,
   clientFrameSchema: chatSubscribeClientFrameSchemaV10,
 });

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -1,6 +1,11 @@
 /**
- * `chat.subscribe@2.0` - versioned streaming-RPC contract for a single
- * host-owned GUI chat session.
+ * `chat.subscribe@1.1` - versioned streaming-RPC contract for a single
+ * host-owned GUI chat session. `chat.subscribe@1.0` (frozen, near the bottom
+ * of this file) is the exact shape shipped in host-v1.0.0; `@1.1` only adds
+ * the background-items controls on top of it, additively, so a `1.1` app
+ * still bridges to a host still on `1.0`. Streams have no cross-major
+ * downgrade bridge (see `stream-compat.ts`'s `canBridgeStream()`), so once a
+ * method ships, its major must never move again - only additive minors.
  *
  * This stream is intentionally text-frame-only. The existing `epic.subscribe`
  * stream remains responsible for Y.Doc binary updates; chat execution frames
@@ -370,8 +375,11 @@ export const chatSubscribeServerFrameSchema = z.discriminatedUnion("kind", [
     reason: z.string().nullable(),
     code: z.string().nullable(),
     // For background stop-all, task ids whose provider stop request was accepted
-    // even when the aggregate action is rejected for partial failure.
-    backgroundStopTaskIds: z.array(z.string()),
+    // even when the aggregate action is rejected for partial failure. Defaulted
+    // so a `chat.subscribe@1.0` host (no background-items support) still
+    // parses - it never emits a background-stop ack, so `[]` is the correct
+    // reading, not a lossy fallback.
+    backgroundStopTaskIds: z.array(z.string()).default([]),
   }),
   z.object({
     kind: z.literal("messageAccepted"),
@@ -691,9 +699,321 @@ export type ChatSubscribeClientFrame = z.infer<
   typeof chatSubscribeClientFrameSchema
 >;
 
-export const chatSubscribeV20 = defineStreamRpcContract({
+// ─── Frozen `chat.subscribe@1.0` shape (host-v1.0.0, as shipped) ──────────
+//
+// Sourced verbatim from `release-v1.0.0` and kept registered (never edited)
+// so `chatSubscribeV10` below stays an honest record of what that host
+// actually speaks - `canBridgeStream()` needs the `{1,0}` line to be present
+// in the registry to bridge a `1.1` app down to it. Do not add fields or
+// variants here; extend the live schemas above instead.
+
+const chatActionSchemaV10 = z.enum([
+  "send",
+  "deleteMessageSuffix",
+  "editUserMessage",
+  "stop",
+  "resumeQueue",
+  "queueEdit",
+  "queueCancel",
+  "queueReorder",
+  "queueSteerNow",
+  "queueAbortSteer",
+  "queueSettingsUpdate",
+  "queueSettingsRestamp",
+  "activePermissionModeUpdate",
+  "approvalDecision",
+  "fileEditApprovalDecision",
+  "interviewAnswer",
+  "interviewError",
+  "restoreCheckpoint",
+  "revertFileChanges",
+]);
+
+const chatSnapshotSchemaV10 = chatSnapshotSchema.omit({
+  backgroundItems: true,
+});
+
+const chatSubscribeServerFrameSchemaV10 = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("snapshot"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    snapshot: chatSnapshotSchemaV10,
+  }),
+  z.object({
+    kind: z.literal("actionAck"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    clientActionId: z.string(),
+    action: chatActionSchemaV10,
+    status: chatActionAckStatusSchema,
+    reason: z.string().nullable(),
+    code: z.string().nullable(),
+  }),
+  z.object({
+    kind: z.literal("messageAccepted"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    message: userMessageSchema,
+  }),
+  z.object({
+    kind: z.literal("queueChanged"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    queue: chatQueueStateSchema,
+  }),
+  z.object({
+    kind: z.literal("turnStateChanged"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    runStatus: chatRunStatusSchema,
+    activeTurn: chatActiveTurnSchema.nullable(),
+  }),
+  z.object({
+    kind: z.literal("blockDelta"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    event: runtimeEventSchema,
+  }),
+  z.object({
+    kind: z.literal("approvalRequested"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    approval: chatApprovalStateSchema,
+  }),
+  z.object({
+    kind: z.literal("approvalResolved"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    approvalId: z.string(),
+    decision: runtimeApprovalDecisionSchema,
+    resolvedAt: z.number(),
+  }),
+  z.object({
+    kind: z.literal("fileEditApprovalRequested"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    approval: chatFileEditApprovalStateSchema,
+  }),
+  z.object({
+    kind: z.literal("fileEditApprovalResolved"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    approvalId: z.string(),
+    decision: runtimeApprovalDecisionSchema,
+    resolvedAt: z.number(),
+  }),
+  z.object({
+    kind: z.literal("interviewRequested"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    blockId: z.string(),
+    requestedAt: z.number(),
+  }),
+  z.object({
+    kind: z.literal("interviewAnswered"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    blockId: z.string(),
+    answers: z.array(runtimeInterviewAnswerSchema),
+    resolvedAt: z.number(),
+  }),
+  z.object({
+    kind: z.literal("interviewErrored"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    blockId: z.string(),
+    reason: z.string(),
+    resolvedAt: z.number(),
+  }),
+  z.object({
+    kind: z.literal("eventAppended"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    event: chatEventSchema,
+  }),
+  z.object({
+    kind: z.literal("restoreStarted"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    ...restoreStartedManifestSchema.shape,
+  }),
+  z.object({
+    kind: z.literal("restoreProgress"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    checkpointId: z.string(),
+    processedCount: z.number(),
+    totalCount: z.number(),
+  }),
+  z.object({
+    kind: z.literal("restoreCompleted"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    checkpointId: z.string(),
+    finishedAt: z.number(),
+    results: z.array(restoreResultEntrySchema),
+  }),
+  z.object({
+    kind: z.literal("errorNotice"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    notice: chatErrorNoticeSchema,
+  }),
+  z.object({
+    kind: z.literal("worktreeStateChanged"),
+    ...textFrameFields,
+    ...chatReferenceFields,
+    worktreeBinding: worktreeBindingSchema.nullable(),
+    missingWorktreePaths: z.array(z.string()),
+  }),
+  z.object({
+    kind: z.literal("pong"),
+    ...textFrameFields,
+  }),
+]);
+
+const chatSubscribeClientFrameSchemaV10 = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("send"),
+    ...ownerActionFrameFields,
+    messageId: z.string(),
+    content: jsonContentSchema,
+    sender: userMessageSenderSchema,
+    settings: chatRunSettingsSchema,
+    accountContext: accountContextSchema,
+    deliveryPolicy: chatQueueDeliveryPolicySchema.default("auto"),
+    worktreeIntent: worktreeIntentSchema.nullable().default(null),
+  }),
+  z.object({
+    kind: z.literal("deleteMessageSuffix"),
+    ...ownerActionFrameFields,
+    fromMessageId: z.string(),
+  }),
+  z.object({
+    kind: z.literal("editUserMessage"),
+    ...ownerActionFrameFields,
+    targetMessageId: z.string(),
+    messageId: z.string(),
+    content: jsonContentSchema,
+    sender: userMessageSenderSchema,
+    settings: chatRunSettingsSchema,
+    accountContext: accountContextSchema,
+    revertFileChanges: z.boolean(),
+    revertArtifacts: z.boolean().default(true),
+  }),
+  z.object({
+    kind: z.literal("stop"),
+    ...ownerActionFrameFields,
+    turnId: z.string().nullable(),
+  }),
+  z.object({
+    kind: z.literal("resumeQueue"),
+    ...ownerActionFrameFields,
+  }),
+  z.object({
+    kind: z.literal("queueEdit"),
+    ...ownerActionFrameFields,
+    queueItemId: z.string(),
+    content: jsonContentSchema,
+  }),
+  z.object({
+    kind: z.literal("queueCancel"),
+    ...ownerActionFrameFields,
+    queueItemId: z.string(),
+  }),
+  z.object({
+    kind: z.literal("queueReorder"),
+    ...ownerActionFrameFields,
+    queueItemId: z.string(),
+    beforeQueueItemId: z.string().nullable(),
+  }),
+  z.object({
+    kind: z.literal("queueSteerNow"),
+    ...ownerActionFrameFields,
+    queueItemId: z.string(),
+    newSettings: chatRunSettingsSchema.nullable().default(null),
+  }),
+  z.object({
+    kind: z.literal("queueAbortSteer"),
+    ...ownerActionFrameFields,
+    queueItemId: z.string(),
+  }),
+  z.object({
+    kind: z.literal("queueSettingsUpdate"),
+    ...ownerActionFrameFields,
+    queueItemId: z.string(),
+    settings: chatRunSettingsSchema,
+    accountContext: accountContextSchema,
+  }),
+  z.object({
+    kind: z.literal("queueSettingsRestamp"),
+    ...ownerActionFrameFields,
+    settings: chatRunSettingsSchema,
+    accountContext: accountContextSchema,
+    excludeQueueItemId: z.string().nullable(),
+  }),
+  z.object({
+    kind: z.literal("activePermissionModeUpdate"),
+    ...ownerActionFrameFields,
+    permissionMode: permissionModeSchema,
+  }),
+  z.object({
+    kind: z.literal("approvalDecision"),
+    ...ownerActionFrameFields,
+    approvalId: z.string(),
+    decision: runtimeApprovalDecisionSchema,
+  }),
+  z.object({
+    kind: z.literal("fileEditApprovalDecision"),
+    ...ownerActionFrameFields,
+    approvalId: z.string(),
+    decision: runtimeApprovalDecisionSchema,
+  }),
+  z.object({
+    kind: z.literal("interviewAnswer"),
+    ...ownerActionFrameFields,
+    blockId: z.string(),
+    answers: z.array(runtimeInterviewAnswerSchema),
+  }),
+  z.object({
+    kind: z.literal("interviewError"),
+    ...ownerActionFrameFields,
+    blockId: z.string(),
+    reason: z.string(),
+  }),
+  z.object({
+    kind: z.literal("restoreCheckpoint"),
+    ...ownerActionFrameFields,
+    checkpointId: z.string(),
+    revertArtifacts: z.boolean().default(true),
+  }),
+  z.object({
+    kind: z.literal("revertFileChanges"),
+    ...ownerActionFrameFields,
+    fromMessageId: z.string().nullable(),
+    filePaths: z.array(z.string()).nullable(),
+    revertArtifacts: z.boolean().default(true),
+  }),
+  z.object({
+    kind: z.literal("ping"),
+    ...textFrameFields,
+  }),
+]);
+
+export const chatSubscribeV10 = defineStreamRpcContract({
   method: "chat.subscribe",
-  schemaVersion: { major: 2, minor: 0 } as const,
+  schemaVersion: { major: 1, minor: 0 } as const,
+  openRequestSchema: chatSubscribeOpenRequestSchema,
+  serverFrameSchema: chatSubscribeServerFrameSchemaV10,
+  clientFrameSchema: chatSubscribeClientFrameSchemaV10,
+});
+
+// ─── Live `chat.subscribe@1.1` contract ────────────────────────────────────
+
+export const chatSubscribeV11 = defineStreamRpcContract({
+  method: "chat.subscribe",
+  schemaVersion: { major: 1, minor: 1 } as const,
   openRequestSchema: chatSubscribeOpenRequestSchema,
   serverFrameSchema: chatSubscribeServerFrameSchema,
   clientFrameSchema: chatSubscribeClientFrameSchema,

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -33,7 +33,8 @@ import {
   agentGuiListHarnessesV10,
   agentGuiListHarnessesV20,
   agentGuiListModelsV10,
-  chatSubscribeV20,
+  chatSubscribeV10,
+  chatSubscribeV11,
 } from "@traycer/protocol/host/agent/gui/contracts";
 import {
   agentTuiGenerateTitleV10,
@@ -2549,7 +2550,7 @@ export type HostRpcRegistry = typeof hostRpcRegistry;
  * Combined streaming-RPC registry for the `/stream` WS manifest.
  *
  * One manifest per `/stream` WS: `epic.subscribe@1.0`,
- * `chat.subscribe@2.0`, `notifications.subscribe@1.0`,
+ * `chat.subscribe@1.1`, `notifications.subscribe@1.0`,
  * `terminal.subscribe@1.0`, `git.subscribeStatus@1.0`,
  * `agent.inbox.subscribe@1.0`, `speech.dictate@1.0`, and
  * `migration.run@1.0` are negotiated from this registry. Later minors within
@@ -2561,7 +2562,12 @@ export type HostRpcRegistry = typeof hostRpcRegistry;
  *
  * 1. Add new methods as top-level keys.
  * 2. Add new minors within a major line for additive changes.
- * 3. Add new majors only when a sub-schema actually breaks compatibility.
+ * 3. Add new majors only when a sub-schema actually breaks compatibility -
+ *    and never for a shipped method with a peer still in the field, since a
+ *    stream major bump has no downgrade bridge (see `chat.subscribe`'s
+ *    history: `1.0` is frozen and kept registered forever; `1.1` added
+ *    background-items controls as an additive minor instead of a major, to
+ *    stay compatible with host-v1.0.0).
  */
 export const hostStreamRpcRegistry = defineVersionedStreamRpcRegistry({
   "epic.subscribe": {
@@ -2575,11 +2581,14 @@ export const hostStreamRpcRegistry = defineVersionedStreamRpcRegistry({
     },
   },
   "chat.subscribe": {
-    2: {
-      latestMinor: 0,
+    1: {
+      latestMinor: 1,
       versions: {
         0: {
-          contract: chatSubscribeV20,
+          contract: chatSubscribeV10,
+        },
+        1: {
+          contract: chatSubscribeV11,
         },
       },
     },

--- a/protocol/src/persistence/epic/content-blocks.ts
+++ b/protocol/src/persistence/epic/content-blocks.ts
@@ -450,8 +450,8 @@ export type AutonomousResumeTrigger = z.infer<
 // the turn resumed (which backgrounded command/Monitor/subagent completed). The
 // turn carries no user message, so without this the resume looks abrupt. Usually
 // one trigger; can be several if multiple settled while idle before the model
-// woke. This block is surfaced through `chat.subscribe@2.0`; older 1.x stream
-// clients must upgrade instead of receiving an unknown discriminated-union
+// woke. This block is surfaced through `chat.subscribe@1.1`; older 1.0 stream
+// peers must upgrade instead of receiving an unknown discriminated-union
 // variant they cannot parse.
 export const autonomousResumeBlockSchema = z.object({
   ...baseBlockFields,


### PR DESCRIPTION
## Summary

The `release-v1.1.0` RC bumped `chat.subscribe` to a new major (`2.0`) and deleted the old `1.0` contract from the registry. Streams have no cross-major downgrade bridge (unlike unary RPCs), so this permanently broke chat for every host still on `host-v1.0.0` with `Incompatible methods: chat.subscribe`.

- Collapses the change to an additive `1.1` minor instead. The only genuinely non-additive field (`actionAck.backgroundStopTaskIds`) now defaults to `[]` instead of being required.
- Restores the frozen `chat.subscribe@1.0` contract (sourced verbatim from `release-v1.0.0`) and keeps it registered alongside `1.1` so `canBridgeStream()` can find it.
- Fixes a second, independent bug surfaced while verifying this against a real `host-v1.0.0`: the stream client always declared its own canonical `schemaVersion` in the `subscribe` frame, even when negotiation determined the host only speaks an older minor. Added `prepareStreamSubscribeRequest` (mirroring the unary client's `prepareRequestPayload`) so the client downgrades what it declares on the wire to the version the peer actually has.
- Retires `streamOpenManifestForMethod`, a hand-rolled workaround from the original breaking commit that special-cased `chat.subscribe`'s major-2 version to protect other streams' open-frame manifests. Confirmed dead now that chat.subscribe stays on major 1.

## Test plan

- [x] `bun run compile` (protocol, traycer-cli, gui-app, desktop) - clean
- [x] `bun run lint` (protocol, clients/shared) - clean
- [x] Added regression tests: `versioned-stream-rpc.test.ts` (compat-check bridges `1.1` app to `1.0` host), `ws-stream-client.test.ts` (subscribe frame declares the host's `1.0`, not the client's own `1.1`), `chat-subscribe.test.ts` (frozen `1.0` contract shape)
- [x] Full vitest run across `protocol`, `clients/shared`, `clients/gui-app`, `clients/desktop`, `clients/traycer-cli` - all pass (pre-existing unrelated `issue-reporter.test.ts` failures confirmed present on `main` too)