### PR TITLE
fix(gui): keep artifact replace match in view

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/tile-find/__tests__/artifact-editor-find-adapter.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/tile-find/__tests__/artifact-editor-find-adapter.test.ts
@@ -300,6 +300,45 @@ describe("createArtifactEditorFindAdapter", () => {
     unsubscribe();
   });
 
+  it("scrolls the newly current match after replace-current", () => {
+    const frames = installAnimationFrameQueue();
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+    const editor = makeEditor(
+      "<p>one needle two needle three needle four needle</p>",
+      true,
+    );
+    const adapter = makeAdapter(editor, "spec", "replace-current-scroll");
+
+    void adapter.search({ requestId: 1, query: "needle", matchCase: false });
+    void adapter.next();
+    void adapter.next();
+    frames.flushFrames();
+    scrollIntoView.mockClear();
+    expectCurrentElementToBeMatch(editor, 2);
+
+    void requireReplace(adapter).replaceCurrent({
+      requestId: 2,
+      query: "needle",
+      matchCase: false,
+      replaceText: "done",
+    });
+
+    expect(editor.getText()).toBe(
+      "one needle two needle three done four needle",
+    );
+    expect(getArtifactFindState(editor).currentIndex).toBe(2);
+    expectCurrentElementToBeMatch(editor, 2);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    frames.runNextFrame();
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: "center",
+      inline: "nearest",
+    });
+  });
+
   it("dispatches replace-all as one undoable editor transaction", () => {
     const editor = makeEditor("<p>foo foo foo</p>", true);
     const adapter = makeAdapter(editor, "review", "replace-all");

--- a/clients/gui-app/src/components/epic-canvas/tile-find/artifact-editor-find-adapter.ts
+++ b/clients/gui-app/src/components/epic-canvas/tile-find/artifact-editor-find-adapter.ts
@@ -188,9 +188,10 @@ export function createArtifactEditorFindAdapter(
       editor.state.tr.insertText(input.replaceText, match.from, match.to),
       input,
       preferredPosition,
-    ).scrollIntoView();
+    );
     editor.view.dispatch(tr);
     publish();
+    scheduleCurrentScroll();
   };
 
   const dispatchReplaceAll = (input: TileReplaceInput): void => {
@@ -224,9 +225,10 @@ export function createArtifactEditorFindAdapter(
         editor.state.tr,
       );
     editor.view.dispatch(
-      setArtifactFindSearchMeta(tr, input, preferredPosition).scrollIntoView(),
+      setArtifactFindSearchMeta(tr, input, preferredPosition),
     );
     publish();
+    scheduleCurrentScroll();
   };
 
   return {


### PR DESCRIPTION
## Summary
- keep artifact find replace-current / replace-all scrolling tied to the updated active find decoration
- add a regression that replaces the current artifact match and verifies the newly current match is scrolled after the replacement

## Validation
- bun run test src/components/epic-canvas/tile-find/__tests__/artifact-editor-find-adapter.test.ts
- bun run compile