### PR TITLE
fix(host): stop post-uninstall respawn and stuck removed-state UI

### DIFF
--- a/clients/gui-app/src/components/local-host-gate.tsx
+++ b/clients/gui-app/src/components/local-host-gate.tsx
@@ -359,6 +359,32 @@ function useHostProvisioning(args: {
     );
   }, [canProvision, args.isReady, mutate, markBusyKeep]);
 
+  // Direct removal-sentinel check, independent of the one-shot `ensureHost`
+  // effect above. That effect never re-fires once `attemptedRef` is set -
+  // typically right after the very first sign-in, long before the user ever
+  // visits Settings -> Danger Zone - so it cannot notice a removal that
+  // happens later in the same session. Re-checking the sentinel is a cheap
+  // read, not a provisioning attempt, so unlike the ensure effect it is safe
+  // to re-run on every not-ready transition; it short-circuits straight to
+  // the removed surface per `getRemovalState`'s contract instead of falling
+  // through to the generic unavailable/Retry card until a reload re-mounts
+  // this hook and resets `attemptedRef`.
+  useEffect(() => {
+    if (!canProvision || args.isReady) {
+      return;
+    }
+    const management = runnerHost.hostManagement;
+    let cancelled = false;
+    void management.getRemovalState().then((removalState) => {
+      if (!cancelled && removalState.removedByUser) {
+        setRemoved(true);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [canProvision, args.isReady, runnerHost]);
+
   return {
     // Report provisioning/error whenever this shell manages the host - NOT
     // gated on `canProvision`, which collapses to false the instant a busy

--- a/clients/gui-app/src/components/local-host-gate.tsx
+++ b/clients/gui-app/src/components/local-host-gate.tsx
@@ -8,6 +8,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import type {
   BootstrapMarkerEntry,
@@ -24,12 +25,14 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useRunnerRequestHostRespawn } from "@/hooks/runner/use-runner-request-host-respawn-mutation";
 import { useRunnerEnsureHost } from "@/hooks/runner/use-runner-ensure-host-mutation";
+import { useRunnerHostRemovalStateQuery } from "@/hooks/runner/use-runner-host-removal-state-query";
 import { useRunnerTraycerHostStatusQuery } from "@/hooks/runner/use-runner-traycer-host-status-query";
 import {
   describeHostCompatibilityError,
   useHostCompatibility,
 } from "@/lib/host";
 import { requestAppQuit } from "@/lib/desktop-app-lifecycle";
+import { runnerQueryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
 
 /**
@@ -289,6 +292,7 @@ function useHostProvisioning(args: {
   readonly isReady: boolean;
 }): HostProvisioning {
   const runnerHost = useRunnerHost();
+  const queryClient = useQueryClient();
   const ensure = useRunnerEnsureHost();
   const attemptedRef = useRef(false);
   const [progress, setProgress] = useState<HostProgressEvent | null>(null);
@@ -297,6 +301,14 @@ function useHostProvisioning(args: {
   const canProvision = args.enabled && runnerHost.hostManagement !== null;
   const hasManagement = runnerHost.hostManagement !== null;
   const { mutate, reset } = ensure;
+
+  // Kept in sync so the stable `markBusyKeep` callback below can read the
+  // latest management instance without widening its dependency array (see
+  // that callback's comment on why it must stay stable).
+  const hostManagementRef = useRef(runnerHost.hostManagement);
+  useEffect(() => {
+    hostManagementRef.current = runnerHost.hostManagement;
+  }, [runnerHost.hostManagement]);
 
   // Latch the busy-keep flow from the settled mutation RESULT (a mutation
   // event, not a render effect or a ref read), so it survives the surfaced
@@ -307,13 +319,27 @@ function useHostProvisioning(args: {
   // to rendering children against the still-unprobed busy host), and a failed
   // initial provision leaves the latch at its `false` default (normal error
   // path). Stable handler keeps the provision effect from re-running.
-  const markBusyKeep = useCallback((result: HostEnsureResult): void => {
-    setInBusyKeepFlow(result.action === "host-busy");
-    // The desktop refused to reinstall a user-removed host; latch the removed
-    // surface. Any other settled result (provisioned/already-ready after a
-    // reinstall) clears it.
-    setRemoved(result.action === "removed");
-  }, []);
+  const markBusyKeep = useCallback(
+    (result: HostEnsureResult): void => {
+      setInBusyKeepFlow(result.action === "host-busy");
+      // The desktop refused to reinstall a user-removed host; latch the removed
+      // surface. Any other settled result (provisioned/already-ready after a
+      // reinstall) clears it.
+      setRemoved(result.action === "removed");
+      // `ensureHost`'s own removal check is the freshest possible truth, so
+      // write it straight into the removal-state query cache too - a
+      // response-equals-state cache write (not a guess) that keeps the
+      // direct removal-sentinel query (below) from re-asserting a stale
+      // `true` it fetched before this settle.
+      const management = hostManagementRef.current;
+      if (management !== null) {
+        queryClient.setQueryData(runnerQueryKeys.hostRemovalState(management), {
+          removedByUser: result.action === "removed",
+        });
+      }
+    },
+    [queryClient],
+  );
 
   // Retry/forced update: clear any prior error/progress, then re-run ensure. Only
   // `onSuccess` transitions the busy-keep latch; an error leaves it untouched
@@ -335,8 +361,13 @@ function useHostProvisioning(args: {
     const management = runnerHost.hostManagement;
     if (management === null) return;
     // Optimistically drop the removed latch so the surface flips to the
-    // provisioning spinner immediately.
+    // provisioning spinner immediately. Also mirror it into the removal-state
+    // query cache - otherwise a `true` it fetched before this click would
+    // still OR back in below and hold the surface on `removed`.
     setRemoved(false);
+    queryClient.setQueryData(runnerQueryKeys.hostRemovalState(management), {
+      removedByUser: false,
+    });
     void management.clearRemoval().then(
       () => run(false),
       () => {
@@ -344,6 +375,9 @@ function useHostProvisioning(args: {
         // back to `removed`. Restore the removed surface instead of flashing a
         // spinner through a wasted round-trip; the user can retry Reinstall.
         setRemoved(true);
+        queryClient.setQueryData(runnerQueryKeys.hostRemovalState(management), {
+          removedByUser: true,
+        });
       },
     );
   };
@@ -363,27 +397,16 @@ function useHostProvisioning(args: {
   // effect above. That effect never re-fires once `attemptedRef` is set -
   // typically right after the very first sign-in, long before the user ever
   // visits Settings -> Danger Zone - so it cannot notice a removal that
-  // happens later in the same session. Re-checking the sentinel is a cheap
-  // read, not a provisioning attempt, so unlike the ensure effect it is safe
-  // to re-run on every not-ready transition; it short-circuits straight to
+  // happens later in the same session. The query re-activates on every
+  // not-ready transition (see its `enabled`), and its result is read directly
+  // below (derived, not synced into state) so it short-circuits straight to
   // the removed surface per `getRemovalState`'s contract instead of falling
   // through to the generic unavailable/Retry card until a reload re-mounts
   // this hook and resets `attemptedRef`.
-  useEffect(() => {
-    if (!canProvision || args.isReady) {
-      return;
-    }
-    const management = runnerHost.hostManagement;
-    let cancelled = false;
-    void management.getRemovalState().then((removalState) => {
-      if (!cancelled && removalState.removedByUser) {
-        setRemoved(true);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [canProvision, args.isReady, runnerHost]);
+  const removalState = useRunnerHostRemovalStateQuery({
+    enabled: canProvision && !args.isReady,
+  });
+  const isRemoved = removed || removalState.data?.removedByUser === true;
 
   return {
     // Report provisioning/error whenever this shell manages the host - NOT
@@ -397,7 +420,7 @@ function useHostProvisioning(args: {
     error: hasManagement ? ensure.error : null,
     progress,
     hostBusy: hasManagement && inBusyKeepFlow,
-    removed: hasManagement && removed,
+    removed: hasManagement && isRemoved,
     canManageHost: hasManagement,
     retry: () => run(false),
     force: () => run(true),

--- a/clients/gui-app/src/hooks/runner/use-runner-host-removal-state-query.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-host-removal-state-query.ts
@@ -1,0 +1,54 @@
+import {
+  queryOptions,
+  useQuery,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type {
+  HostRemovalState,
+  IHostManagement,
+} from "@traycer-clients/shared/platform/runner-host";
+import { useRunnerHost } from "@/providers/use-runner-host";
+import { runnerQueryKeys } from "@/lib/query-keys";
+
+export interface UseRunnerHostRemovalStateQueryOptions {
+  readonly enabled: boolean;
+}
+
+function hostRemovalStateQueryOptions(
+  management: IHostManagement | null,
+  enabled: boolean,
+) {
+  return queryOptions<HostRemovalState>({
+    queryKey:
+      management !== null
+        ? runnerQueryKeys.hostRemovalState(management)
+        : ["runner.host.removalState", "disabled"],
+    queryFn: () => {
+      if (management === null) {
+        throw new Error("Host management unavailable on this runner host");
+      }
+      return management.getRemovalState();
+    },
+    enabled: enabled && management !== null,
+    // Always re-check on activation rather than serve a cached "not removed"
+    // answer - this query exists specifically to notice a removal that
+    // happened while it was disabled (see the host gate's usage).
+    staleTime: 0,
+  });
+}
+
+/**
+ * Reads the persisted "removed by user" sentinel directly via
+ * `IHostManagement.getRemovalState()`, independent of `ensureHost`'s one-shot
+ * auto-provision. Consumed by `useHostProvisioning` in `local-host-gate.tsx`
+ * so a removal that happens after the initial connect (Settings -> Danger
+ * Zone -> Remove Traycer) is picked up without requiring a reload.
+ */
+export function useRunnerHostRemovalStateQuery(
+  opts: UseRunnerHostRemovalStateQueryOptions,
+): UseQueryResult<HostRemovalState> {
+  const runnerHost = useRunnerHost();
+  return useQuery(
+    hostRemovalStateQueryOptions(runnerHost.hostManagement, opts.enabled),
+  );
+}

--- a/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
@@ -82,6 +82,10 @@ export const runnerQueryKeys = {
   hostCliManifest: (management: object) =>
     ["runner.host.cliManifest", management] as const,
   hostName: (management: object) => ["runner.host.name", management] as const,
+  // Direct removal-sentinel read used by the host gate, independent of
+  // `ensureHost`'s one-shot auto-provision result.
+  hostRemovalState: (management: object) =>
+    ["runner.host.removalState", management] as const,
   /**
    * Stable cache key for the placeholder ServiceStatusSnapshot used by
    * Settings → Host when the shell does not expose `IServiceHost`. The

--- a/clients/traycer-cli/src/commands/host-uninstall.ts
+++ b/clients/traycer-cli/src/commands/host-uninstall.ts
@@ -43,9 +43,24 @@ export function buildHostUninstallCommand(args: HostUninstallArgs): CommandFn {
           });
           const controller = createServiceController();
           const label = serviceLabelFor(ctx.runtime.environment);
-          // Best-effort stop before uninstall so any held file handles
-          // release cleanly. Tolerate failures - the uninstall path
-          // forces removal regardless.
+          // Deregister BEFORE waiting for the process to exit. On macOS the
+          // running job stays under launchd's `KeepAlive` supervision until
+          // its registration is torn down (`uninstall` -> `launchctl
+          // bootout`); stopping first and deregistering after leaves a
+          // window where a non-clean SIGTERM exit gets treated as a
+          // failed/crashed exit and launchd respawns the host before we
+          // ever reach `uninstall`. Deregistering first removes that
+          // supervision so no exit outcome can trigger a respawn.
+          await controller.uninstall({ label });
+          serviceUninstalled = true;
+          ctx.runtime.logger.info("Host uninstall service deregistered", {
+            environment: ctx.runtime.environment,
+            label: label.id,
+          });
+          // Best-effort: confirm the process actually exited so any held
+          // file handles release before the install dir is removed below.
+          // Tolerate failures - the uninstall path forces removal
+          // regardless.
           try {
             await controller.stop(label);
           } catch (err) {
@@ -59,12 +74,6 @@ export function buildHostUninstallCommand(args: HostUninstallArgs): CommandFn {
             );
             // Service may not be running; proceed.
           }
-          await controller.uninstall({ label });
-          serviceUninstalled = true;
-          ctx.runtime.logger.info("Host uninstall service deregistered", {
-            environment: ctx.runtime.environment,
-            label: label.id,
-          });
         }
         ctx.progress({
           stage: "uninstall",


### PR DESCRIPTION
## Summary
- Deregister the launchd service (`controller.uninstall`) before waiting for the host process to exit in the `--all` uninstall path, instead of after. The prior stop-then-deregister order left the job under launchd's `KeepAlive: {SuccessfulExit:false, Crashed:true}` supervision during the wait window - any non-clean SIGTERM exit could get respawned before deregistration ever ran.
- Add a direct removal-sentinel check (`getRemovalState()`) in `useHostProvisioning` (local host gate), independent of the one-shot `ensureHost` effect. That effect only ever fires once per session (typically right after sign-in), so it never notices a removal that happens later (e.g. Settings → Danger Zone → Remove Traycer) and the UI got stuck on the generic "unavailable/Retry" card until a full reload.

## Test plan
- [x] `bun run --filter @traycer-clients/traycer-cli compile`
- [x] `bun run --filter @traycer-clients/gui-app compile`
- [x] `eslint` on both changed files (nx affected lint via pre-commit)
- [ ] Manual repro on macOS: Settings → Danger Zone → Remove Traycer, confirm the host does not respawn and the removed surface appears without a reload