### PR TITLE
feat(gui): create child chats through the shared new-conversation modal

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/chat-row-child-create.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/chat-row-child-create.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import type { WorktreeBindingEntry } from "@traycer/protocol/host/worktree-schemas";
-import { buildChildChatCreateInput } from "../use-chat-row-child-create";
 import { buildOwnerWorkspaceInheritanceSeed } from "@/lib/worktree/owner-workspace-inheritance-seed";
 import { buildFixedHostWorkspaceControlsScope } from "@/components/home/host-workspace-selector/host-workspace-controls-scope";
 import { resolveOwnerWorkspaceInheritanceSeed } from "@/hooks/worktree/use-owner-workspace-inheritance-seed";
@@ -273,45 +272,6 @@ describe("child conversation workspace seed", () => {
           isPrimary: true,
         },
       ],
-    });
-  });
-
-  it("passes the inherited intent through the child chat create request", () => {
-    const seed = buildOwnerWorkspaceInheritanceSeed({
-      binding: {
-        entries: [
-          bindingEntry({
-            workspacePath: "/repo/source",
-            mode: "worktree",
-            worktreePath: "/worktrees/feature",
-          }),
-        ],
-      },
-      stagedIntent: null,
-      fallbackWorkspaceFolders: [],
-    });
-
-    expect(
-      buildChildChatCreateInput({
-        epicId: "epic-1",
-        parentId: "parent-1",
-        chatId: "child-1",
-        workspaceSeed: seed,
-      }),
-    ).toMatchObject({
-      epicId: "epic-1",
-      parentId: "parent-1",
-      chatId: "child-1",
-      title: "",
-      worktreeIntent: {
-        entries: [
-          {
-            kind: "import",
-            workspacePath: "/repo/source",
-            worktreePath: "/worktrees/feature",
-          },
-        ],
-      },
     });
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type ReactNode,
   type RefObject,
 } from "react";
 import { useStore } from "zustand";
@@ -52,13 +53,16 @@ import {
   useLatestConversationWorkspaceSeed,
   type LatestConversationWorkspaceSeed,
 } from "@/hooks/worktree/use-latest-conversation-workspace-seed";
+import { useOwnerWorkspaceInheritanceSeed } from "@/hooks/worktree/use-owner-workspace-inheritance-seed";
 import { useEpicStore } from "@/hooks/use-epic-store";
 import { useHostClient } from "@/lib/host";
 import { LEADER_SCOPE_NEW_CONVERSATION_MODAL } from "@/lib/keybindings/leader-scope";
 import {
   useEpicConnectionStatus,
+  useEpicNodeWorkspaceFolders,
   useEpicPermissionRole,
 } from "@/lib/epic-selectors";
+import { displayTitle } from "@/lib/display-title";
 import { isEditableRole } from "@/lib/epic-permissions";
 import { buildChatRunSettings } from "@/lib/composer/chat-run-settings";
 import { contentIsSubmittable } from "@/lib/composer/composer-content";
@@ -158,6 +162,7 @@ export function NewConversationModalAction(
       epicId: props.epicId,
       tabId: props.tabId,
       placement: ACTIVE_TILE_PLACEMENT,
+      parentId: null,
     });
   }, [openModal, props.disabled, props.epicId, props.tabId]);
   const trigger = (
@@ -232,6 +237,7 @@ export function NewConversationModalHost(props: {
       epicId={props.epicId}
       tabId={props.tabId}
       placement={isOpen ? request.placement : ACTIVE_TILE_PLACEMENT}
+      parentId={isOpen ? request.parentId : null}
       open={isOpen}
       onOpenChange={(next) => {
         if (!next) closeModal();
@@ -244,6 +250,7 @@ function NewConversationModalDialog(props: {
   readonly epicId: string;
   readonly tabId: string;
   readonly placement: ConversationTilePlacement;
+  readonly parentId: string | null;
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
 }) {
@@ -297,6 +304,7 @@ function NewConversationModalDialog(props: {
               epicId={props.epicId}
               tabId={props.tabId}
               placement={props.placement}
+              parentId={props.parentId}
               dismissPickerRef={dismissPickerRef}
               onSubmitted={() => props.onOpenChange(false)}
             />
@@ -307,14 +315,53 @@ function NewConversationModalDialog(props: {
   );
 }
 
+/**
+ * Modal title row. For a child chat (`parentId !== null`) the chat/terminal
+ * switcher is hidden (child creation is chat-only here - the row's own dropdown
+ * covers a child terminal agent) and a muted subtext names the parent chat.
+ */
+function NewConversationModalHeader(props: {
+  readonly composerMode: ComposerMode;
+  readonly parentId: string | null;
+  readonly switcher: ReactNode;
+}) {
+  const { composerMode, parentId, switcher } = props;
+  const isChildChat = parentId !== null;
+  const parentChatTitle = useEpicStore((state) =>
+    parentId !== null && Object.hasOwn(state.chats.byId, parentId)
+      ? state.chats.byId[parentId].title
+      : null,
+  );
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <div className="flex min-w-0 items-center justify-between">
+        <span className="text-sm font-medium text-foreground">
+          {composerMode === "chat"
+            ? "Start a new chat"
+            : "Start a new terminal agent"}
+        </span>
+        {isChildChat ? null : switcher}
+      </div>
+      {isChildChat ? (
+        <span className="truncate text-ui-xs text-muted-foreground">
+          Creating a child chat from{" "}
+          {displayTitle(parentChatTitle ?? "", "chat")}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
 function NewConversationModalBody(props: {
   readonly epicId: string;
   readonly tabId: string;
   readonly placement: ConversationTilePlacement;
+  readonly parentId: string | null;
   readonly dismissPickerRef: RefObject<(() => boolean) | null>;
   readonly onSubmitted: () => void;
 }) {
-  const { epicId, tabId, placement, dismissPickerRef, onSubmitted } = props;
+  const { epicId, tabId, placement, parentId, dismissPickerRef, onSubmitted } =
+    props;
   const permissionRole = useEpicPermissionRole();
   const connectionStatus = useEpicConnectionStatus();
   const isDisconnected = connectionStatus === "closed";
@@ -332,7 +379,8 @@ function NewConversationModalBody(props: {
       dismissPickerRef.current = null;
     };
   }, [dismissPickerRef]);
-  const latestWorkspaceSeed = useLatestConversationWorkspaceSeed(epicId);
+  const hostClient = useHostClient();
+  const latestWorkspaceSeed = useModalWorkspaceSeed(epicId, parentId);
   const seed = useNewConversationModalSeed(epicId, latestWorkspaceSeed);
   // Subscribe to the NON-content draft fields only. `content` is rewritten on
   // every keystroke (see `handleSnapshot`); subscribing to the whole patch here
@@ -406,7 +454,6 @@ function NewConversationModalBody(props: {
     toolbarStore,
     (state) => state.selection.harnessId,
   );
-  const hostClient = useHostClient();
   const mentionIntent = useMemo(
     () =>
       effectiveWorktreeIntent({
@@ -486,14 +533,11 @@ function NewConversationModalBody(props: {
     </button>
   );
   const header = (
-    <div className="flex min-w-0 items-center justify-between">
-      <span className="text-sm font-medium text-foreground">
-        {draftComposerMode === "chat"
-          ? "Start a new chat"
-          : "Start a new terminal agent"}
-      </span>
-      {switcher}
-    </div>
+    <NewConversationModalHeader
+      composerMode={draftComposerMode}
+      parentId={parentId}
+      switcher={switcher}
+    />
   );
   const cleanupAfterSubmit = useCallback((): void => {
     clearDraft(epicId);
@@ -585,7 +629,7 @@ function NewConversationModalBody(props: {
     createChat.mutate(
       {
         epicId,
-        parentId: null,
+        parentId,
         title: "",
         chatId,
         settings,
@@ -621,6 +665,7 @@ function NewConversationModalBody(props: {
     createChat,
     epicId,
     hostClient,
+    parentId,
     placement,
     rememberEpicIntent,
     setEpicRunSettings,
@@ -640,7 +685,7 @@ function NewConversationModalBody(props: {
         .create({
           epicId,
           tabId,
-          parentId: null,
+          parentId,
           title: "",
           placement: toTuiPlacement(placement),
           harnessId: launch.harnessId,
@@ -658,6 +703,7 @@ function NewConversationModalBody(props: {
       canMutate,
       cleanupAfterSubmit,
       epicId,
+      parentId,
       placement,
       rememberEpicIntent,
       tabId,
@@ -704,6 +750,43 @@ function NewConversationModalBody(props: {
       onStartTerminal={handleStartTerminal}
       onSnapshot={handleSnapshot}
     />
+  );
+}
+
+/**
+ * Workspace seed that drives the modal's workspace controls + submit intent.
+ * For a child chat (per-row `+`, `parentId !== null`) it inherits the PARENT
+ * chat's binding so the child lands in the parent's worktree - matching the
+ * eager row-create path (`useChatRowChildCreate`) this modal replaces. Read on
+ * the active host (the modal always creates there); an unbound/remote parent
+ * falls back to an empty workspace the user can adjust via the controls. For a
+ * top-level chat it falls back to the latest-conversation seed.
+ */
+function useModalWorkspaceSeed(
+  epicId: string,
+  parentId: string | null,
+): LatestConversationWorkspaceSeed | null {
+  const hostClient = useHostClient();
+  const latestConversationSeed = useLatestConversationWorkspaceSeed(epicId);
+  const parentWorkspaceFolders = useEpicNodeWorkspaceFolders(parentId ?? "");
+  const parentInheritance = useOwnerWorkspaceInheritanceSeed({
+    client: hostClient,
+    epicId,
+    ownerId: parentId ?? "",
+    ownerKind: "chat",
+    enabled: parentId !== null,
+    fallbackWorkspaceFolders: parentWorkspaceFolders,
+  });
+  return useMemo(
+    () =>
+      parentId !== null && parentInheritance.seed !== null
+        ? {
+            ...parentInheritance.seed,
+            sourceOwnerId: parentId,
+            sourceOwnerKind: "chat",
+          }
+        : latestConversationSeed,
+    [latestConversationSeed, parentId, parentInheritance.seed],
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/use-chat-row-child-create.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/use-chat-row-child-create.ts
@@ -1,12 +1,4 @@
-import {
-  startTransition,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { v4 as uuidv4 } from "uuid";
+import { useCallback, useMemo, useState } from "react";
 import type { EpicNodeKind } from "@/lib/artifacts/node-display";
 import { useCreateTuiAgentForClient } from "@/hooks/agent/use-create-tui-agent";
 import type { TerminalAgentWorktreeCreateInput } from "@/components/epic-canvas/hooks/use-terminal-agent-worktree-gate";
@@ -16,13 +8,8 @@ import { useHostClientFor } from "@/hooks/host/use-host-client-for";
 import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
 import { dialableHostEndpoint } from "@/lib/host/transport-key";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
-import {
-  useEpicCreateChatForHostClient,
-  type CreateChatMutationInput,
-} from "@/hooks/epic/use-epic-chat-mutations";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { useHostClient } from "@/lib/host/runtime";
-import { displayTitle } from "@/lib/display-title";
 import {
   useEpicNodeHostId,
   useEpicNodeOwnerKind,
@@ -30,17 +17,15 @@ import {
 } from "@/lib/epic-selectors";
 import type { ForkWorkspaceSeed } from "@/lib/worktree/fork-workspace-seed";
 import { useOwnerWorkspaceInheritanceSeed } from "@/hooks/worktree/use-owner-workspace-inheritance-seed";
-import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
-import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
+import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
+import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
 import {
   pendingChildTerminalAgentStagingKey,
   useWorktreeIntentStagingStore,
   type WorktreeStagingKey,
 } from "@/stores/worktree/worktree-intent-staging-store";
 import { useWorktreeIntentMemoryStore } from "@/stores/worktree/worktree-intent-memory-store";
-import { openProjectedSidebarNodeInTabWhenAvailable } from "./open-projected-sidebar-node";
-import { computeArtifactNodeAddChildPending } from "./epic-sidebar-tree-shared";
 import { resolveRowChildHost } from "./chat-row-child-host";
 
 export interface ChatRowChildCreate {
@@ -59,21 +44,6 @@ export interface ChatRowChildCreate {
   readonly workspaceInheritanceBlocked: boolean;
 }
 
-export function buildChildChatCreateInput(input: {
-  readonly epicId: string;
-  readonly parentId: string;
-  readonly chatId: string;
-  readonly workspaceSeed: ForkWorkspaceSeed | null;
-}): CreateChatMutationInput {
-  return {
-    epicId: input.epicId,
-    parentId: input.parentId,
-    title: "",
-    chatId: input.chatId,
-    worktreeIntent: input.workspaceSeed?.intent ?? null,
-  };
-}
-
 export function useChatRowChildCreate(args: {
   readonly epicId: string;
   readonly tabId: string;
@@ -82,8 +52,6 @@ export function useChatRowChildCreate(args: {
   readonly ensureExpanded: (id: string) => void;
 }): ChatRowChildCreate {
   const { epicId, tabId, nodeId, canMutate, ensureExpanded } = args;
-  const epicHandle = useOpenEpicHandle();
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
   const [addMenuOpen, onAddMenuOpenChange] = useState(false);
   const rowHostId = useEpicNodeHostId(nodeId);
   const parentOwnerKind = useEpicNodeOwnerKind(nodeId);
@@ -118,7 +86,6 @@ export function useChatRowChildCreate(args: {
       }),
     [createHostClient, createHostId],
   );
-  const createChild = useEpicCreateChatForHostClient(createHostClient);
   const terminalAgentCreate = useCreateTuiAgentForClient(
     createHostClient,
     createHostId ?? UNKNOWN_HOST_PLACEHOLDER,
@@ -140,92 +107,24 @@ export function useChatRowChildCreate(args: {
   const workspaceInheritanceUnavailable = childWorkspace.unavailable;
   const parentBindingBlocked =
     parentBindingPending || workspaceInheritanceUnavailable;
-  const [pendingChildName, setPendingChildName] = useState<string | null>(null);
-  const pendingProjectedOpenCancelRef = useRef<(() => void) | null>(null);
-
-  useEffect(() => {
-    const cancelRef = pendingProjectedOpenCancelRef;
-    return () => {
-      cancelRef.current?.();
-      cancelRef.current = null;
-    };
-  }, []);
-
-  const clearPendingChildCreate = useCallback(() => {
-    pendingProjectedOpenCancelRef.current?.();
-    pendingProjectedOpenCancelRef.current = null;
-    startTransition(() => {
-      setPendingChildName(null);
-    });
-  }, []);
-
-  const openProjectedChildInTab = useCallback(
-    (
-      projectedNodeId: string,
-      onBeforeOpen: ((node: EpicNodeRef) => void) | null,
-    ) => {
-      pendingProjectedOpenCancelRef.current?.();
-      pendingProjectedOpenCancelRef.current =
-        openProjectedSidebarNodeInTabWhenAvailable({
-          epicHandle,
-          tabId,
-          nodeId: projectedNodeId,
-          fallbackHostId: createHostId ?? UNKNOWN_HOST_PLACEHOLDER,
-          openTileInTab,
-          onBeforeOpen,
-          onOpened: () => {
-            pendingProjectedOpenCancelRef.current = null;
-            startTransition(() => {
-              setPendingChildName(null);
-            });
-          },
-          onUnavailable: () => {
-            pendingProjectedOpenCancelRef.current = null;
-            startTransition(() => {
-              setPendingChildName(null);
-            });
-          },
-          onCleanup: null,
-        });
-    },
-    [createHostId, epicHandle, openTileInTab, tabId],
-  );
 
   const onAddChild = useCallback(
     (type: EpicNodeKind) => {
       if (!canMutate || hostUnavailable || parentBindingBlocked) return;
       if (type !== "chat") return;
-      ensureExpanded(nodeId);
-      setPendingChildName(displayTitle("", "chat"));
-      createChild.mutate(
-        buildChildChatCreateInput({
-          epicId,
-          chatId: uuidv4(),
-          parentId: nodeId,
-          workspaceSeed: childWorkspace.seed,
-        }),
-        {
-          onSuccess: (result) => {
-            openProjectedChildInTab(result.chatId, null);
-          },
-          onError: () => {
-            clearPendingChildCreate();
-          },
-        },
-      );
+      // Consistency with the chats-panel "+": open the shared New Conversation
+      // modal seeded as a child of this row (compose-first) instead of eagerly
+      // creating an empty child chat tile. The modal reads the parent binding
+      // to inherit its worktree and creates the child with `parentId` on submit.
+      useNewConversationModalStore.getState().setComposerMode(epicId, "chat");
+      useNewConversationModalOpenStore.getState().open({
+        epicId,
+        tabId,
+        placement: ACTIVE_TILE_PLACEMENT,
+        parentId: nodeId,
+      });
     },
-    [
-      canMutate,
-      clearPendingChildCreate,
-      createChild,
-      childWorkspace.seed,
-      hostUnavailable,
-      parentBindingBlocked,
-      ensureExpanded,
-      epicId,
-      nodeId,
-      openProjectedChildInTab,
-    ],
+    [canMutate, epicId, hostUnavailable, nodeId, parentBindingBlocked, tabId],
   );
 
   const onAddTerminalAgent = useCallback(
@@ -281,12 +180,6 @@ export function useChatRowChildCreate(args: {
     ],
   );
 
-  const addChildIsPending = computeArtifactNodeAddChildPending({
-    pendingChildName,
-    pendingChildRealId: null,
-    createArtifactPending: createChild.isPending,
-  });
-
   return {
     onAddChild,
     onAddTerminalAgent,
@@ -295,8 +188,10 @@ export function useChatRowChildCreate(args: {
     terminalAgentWorkspaceSeed: childWorkspace.seed,
     terminalAgentHostScope,
     terminalAgentStagingKey,
-    pendingChildName,
-    addChildIsPending,
+    // Child chats are now composed in the shared modal, so the row no longer
+    // shows an optimistic pending placeholder for them (the modal owns that UX).
+    pendingChildName: null,
+    addChildIsPending: false,
     tuiAgentPending: terminalAgentCreate.isPending,
     hostUnavailable,
     workspaceInheritanceBlocked: parentBindingBlocked,

--- a/clients/gui-app/src/lib/commands/__tests__/composer.source.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/composer.source.test.tsx
@@ -293,6 +293,7 @@ describe("composerSource", () => {
       epicId: "epic-1",
       tabId: "epic-1",
       placement: { kind: "active-tile" },
+      parentId: null,
     });
     expect(
       useNewConversationModalStore.getState().draftPatchesByEpicId["epic-1"]
@@ -337,6 +338,7 @@ describe("composerSource", () => {
       epicId: "epic-1",
       tabId: "epic-1",
       placement: { kind: "split", groupId: activeGroupId, position: "right" },
+      parentId: null,
     });
     expect(
       useNewConversationModalStore.getState().draftPatchesByEpicId["epic-1"]

--- a/clients/gui-app/src/lib/commands/sources/composer.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/composer.source.ts
@@ -188,7 +188,7 @@ function openNewConversationModal(
   useNewConversationModalStore.getState().setComposerMode(epicId, mode);
   useNewConversationModalOpenStore
     .getState()
-    .open({ epicId, tabId, placement });
+    .open({ epicId, tabId, placement, parentId: null });
 }
 
 function buildNewChatReplaceItem(args: {

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
@@ -256,6 +256,7 @@ describe("Chats opener sub-page", () => {
       epicId: "epic-1",
       tabId: "tab-1",
       placement: { kind: "target-group", groupId: "group-1" },
+      parentId: null,
     });
     expect(
       useNewConversationModalStore.getState().draftPatchesByEpicId["epic-1"]
@@ -332,6 +333,7 @@ describe("TUI opener sub-page", () => {
       epicId: "epic-1",
       tabId: "tab-1",
       placement: { kind: "target-group", groupId: "group-1" },
+      parentId: null,
     });
     expect(
       useNewConversationModalStore.getState().draftPatchesByEpicId["epic-1"]

--- a/clients/gui-app/src/lib/commands/sources/open/chats-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/chats-subpage.ts
@@ -39,6 +39,7 @@ export function useChatsOpenerItems(
           epicId: ctx.activeEpicId,
           tabId: ctx.activeTabId,
           placement: { kind: "target-group", groupId: ctx.targetGroupId },
+          parentId: null,
         });
       },
     });

--- a/clients/gui-app/src/lib/commands/sources/open/tui-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/tui-subpage.ts
@@ -34,6 +34,7 @@ export function useTuiOpenerItems(
           epicId: ctx.activeEpicId,
           tabId: ctx.activeTabId,
           placement: { kind: "target-group", groupId: ctx.targetGroupId },
+          parentId: null,
         });
       },
     });

--- a/clients/gui-app/src/stores/epics/new-conversation-modal-open-store.ts
+++ b/clients/gui-app/src/stores/epics/new-conversation-modal-open-store.ts
@@ -17,6 +17,14 @@ export interface NewConversationModalOpenRequest {
   readonly epicId: string;
   readonly tabId: string;
   readonly placement: ConversationTilePlacement;
+  /**
+   * Parent conversation id when the modal was opened to create a CHILD chat
+   * (the per-row `+` in the chats tree). `null` for a top-level chat (sidebar
+   * panel `+`, ⌘K palette, in-pane PaneOpener). The body threads this into
+   * `epic.createChat` and seeds the workspace from the parent's binding so a
+   * child inherits the parent's worktree.
+   */
+  readonly parentId: string | null;
 }
 
 interface NewConversationModalOpenStore {


### PR DESCRIPTION
## Problem

The chats-panel **"+"** opens the New Conversation modal (compose-first), but the per-row **"+" → New chat** eagerly created an empty child chat *tile* instead — two different UXs for the same "start a chat" action.

## Change

Route the per-row **New chat** action through the **same** modal, seeded as a child of that row.

- The modal open-request carries a `parentId` (`null` for top-level). The body threads it into `epic.createChat` (and the terminal path) so submit creates a **child**, and seeds the workspace from the **parent chat's binding** (via `useOwnerWorkspaceInheritanceSeed` on the active host) so the child **inherits the parent's worktree** — preserving the behavior of the eager path it replaces.
- In child mode the modal shows a **muted subtext naming the parent chat** and **hides the chat/terminal switcher** (child creation is chat-only here; the row's own dropdown still offers a child terminal agent).
- Removes the row's now-dead optimistic create / pending-placeholder / tile-open machinery (and the obsolete `buildChildChatCreateInput` + its test). The terminal-agent path and the row's host resolution are unchanged.

All other open-request callers (⌘K palette, in-pane openers) pass `parentId: null` and keep creating top-level chats.

### Scoping notes
- Child chats are created on the **active host** (like the chats-panel `+`). A reachable *remote*-host parent falls back to an empty, user-adjustable workspace rather than the remote binding.
- The row no longer renders an optimistic pending child placeholder for chats — the modal owns that UX now.

## Testing

- `bun run compile` — clean · `bun run lint` (changed files) — clean · `react-doctor --scope changed` — no issues
- `bun run test src/components/epic-canvas/sidebar src/lib/commands src/components/chat` — **665 passed** (updated the open-request shape assertions to include `parentId`)
- `pre-commit run` — all hooks pass (incl. nx-affected build/compile/lint/format) + DCO sign-off

Not visually verified in a running app (needs the local dev stack).

_Follow-up to #158 (the scroll fix), rebased onto `main` after that merged._