### PR TITLE
fix(gui-app): stop start-page task creation stranding the epic tab on infinite loading

### DIFF
--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -33,7 +33,10 @@ import { useLandingComposerStore } from "@/stores/composer/landing-composer-stor
 import { useInitialChatHandoffStore } from "@/stores/epics/initial-chat-handoff-store";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
-import { markEpicCreatedThisSession } from "@/lib/epics/session-created-epics";
+import {
+  markEpicCreatedThisSession,
+  unmarkEpicCreatedThisSession,
+} from "@/lib/epics/session-created-epics";
 import {
   existingEpicTabIntent,
   navigateToTabIntent,
@@ -365,6 +368,9 @@ export function useLandingComposerActions(): LandingComposerActions {
           }
         })
         .catch(() => {
+          // The epic never landed on the host: drop the create marker so its
+          // orphaned tab is no longer exempt from existence reconciliation.
+          unmarkEpicCreatedThisSession(epicId);
           useComposerRunSettingsStore.getState().clearEpicRunSettings([epicId]);
           useEpicCanvasStore.getState().clearEpicTitlePending(epicId);
           useEpicCanvasStore.getState().clearChatTitlePending(chatId);
@@ -525,22 +531,31 @@ export function useLandingComposerActions(): LandingComposerActions {
         now,
         chat: null,
       })
-        .then(() =>
-          terminalAgentCreateFn({
-            epicId,
-            tabId,
-            parentId: null,
-            title: "",
-            placement: { kind: "active-tile" },
-            harnessId,
-            model,
-            reasoningEffort,
-            agentMode,
-            forkSourceHarnessSessionId: null,
-            onStatusChange: null,
-            worktreeIntent: workspaceContext.worktreeIntent,
-            terminalAgentArgs,
-          }),
+        .then(
+          () =>
+            terminalAgentCreateFn({
+              epicId,
+              tabId,
+              parentId: null,
+              title: "",
+              placement: { kind: "active-tile" },
+              harnessId,
+              model,
+              reasoningEffort,
+              agentMode,
+              forkSourceHarnessSessionId: null,
+              onStatusChange: null,
+              worktreeIntent: workspaceContext.worktreeIntent,
+              terminalAgentArgs,
+            }),
+          // Only `epic.create` rejection reaches this arm (a later tui-agent
+          // failure goes to the trailing `.catch`). The epic never landed, so
+          // drop the create marker to let the reconciler prune the orphan tab.
+          // A downstream tui-agent failure leaves the marker in place - the epic
+          // exists, so it must stay protected until `epic.listTasks` reflects it.
+          () => {
+            unmarkEpicCreatedThisSession(epicId);
+          },
         )
         .catch(() => undefined);
     },

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -33,6 +33,7 @@ import { useLandingComposerStore } from "@/stores/composer/landing-composer-stor
 import { useInitialChatHandoffStore } from "@/stores/epics/initial-chat-handoff-store";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { markEpicCreatedThisSession } from "@/lib/epics/session-created-epics";
 import {
   existingEpicTabIntent,
   navigateToTabIntent,
@@ -291,6 +292,9 @@ export function useLandingComposerActions(): LandingComposerActions {
       const tabId = useEpicCanvasStore
         .getState()
         .openEpicTab(epicId, epicTitle);
+      // Mark before navigation so the epic-tab existence reconciler never
+      // force-closes this tab while `epic.listTasks` still lags `epic.create`.
+      markEpicCreatedThisSession(epicId);
       // Spinner anchor is the pre-generation title (empty here); it clears once
       // a non-empty title is projected or the backstop fires.
       useEpicCanvasStore.getState().markEpicTitlePending(epicId, epicTitle);
@@ -491,6 +495,10 @@ export function useLandingComposerActions(): LandingComposerActions {
       const tabId = useEpicCanvasStore
         .getState()
         .openEpicTab(epicId, epicTitle);
+      // Terminal-agent create registers no initial-chat handoff, so this
+      // synchronous marker is what keeps the existence reconciler from
+      // force-closing the tab before `epic.listTasks` reflects the new epic.
+      markEpicCreatedThisSession(epicId);
       const activeDraftId = useLandingDraftStore.getState().activeDraftId;
       if (activeDraftId !== null) {
         useLandingDraftStore.getState().closeDraft(activeDraftId);

--- a/clients/gui-app/src/lib/epics/session-created-epics.ts
+++ b/clients/gui-app/src/lib/epics/session-created-epics.ts
@@ -1,0 +1,34 @@
+/**
+ * Epic ids created from the start-page landing composer during the CURRENT app
+ * session - both the GUI-chat flow and the terminal-agent flow. Written
+ * synchronously at create time (before navigation, before the epic-tab
+ * existence reconciler can seed a run), so a freshly-created epic is never
+ * force-closed during the window where `epic.listTasks` still lags
+ * `epic.create`.
+ *
+ * An epic created this session is by definition NOT a stale persisted tab from
+ * a prior session, which is the only thing the existence reconciler should
+ * prune. The GUI-chat flow is also covered by its active initial-chat handoff,
+ * but the terminal-agent flow registers no handoff and its live epic session
+ * may not be in the registry yet when the reconcile close fires (the session
+ * acquire races the reconcile RPC, and on desktop waits on an async ownership
+ * claim) - so this synchronous marker is the deterministic guard both flows
+ * share.
+ *
+ * Entries are cheap (a uuid string, bounded by how many epics a user creates in
+ * one session), so there is no eviction. Cleared on sign-out / user-switch via
+ * `clearSessionCreatedEpics` so a new identity starts fresh.
+ */
+const sessionCreatedEpicIds = new Set<string>();
+
+export function markEpicCreatedThisSession(epicId: string): void {
+  sessionCreatedEpicIds.add(epicId);
+}
+
+export function wasEpicCreatedThisSession(epicId: string): boolean {
+  return sessionCreatedEpicIds.has(epicId);
+}
+
+export function clearSessionCreatedEpics(): void {
+  sessionCreatedEpicIds.clear();
+}

--- a/clients/gui-app/src/lib/epics/session-created-epics.ts
+++ b/clients/gui-app/src/lib/epics/session-created-epics.ts
@@ -25,6 +25,14 @@ export function markEpicCreatedThisSession(epicId: string): void {
   sessionCreatedEpicIds.add(epicId);
 }
 
+/**
+ * Drop a single marker when the optimistic create fails, so a tab whose epic
+ * never landed on the host is no longer exempt from existence reconciliation.
+ */
+export function unmarkEpicCreatedThisSession(epicId: string): void {
+  sessionCreatedEpicIds.delete(epicId);
+}
+
 export function wasEpicCreatedThisSession(epicId: string): boolean {
   return sessionCreatedEpicIds.has(epicId);
 }

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -26,8 +26,41 @@ import {
   collectOpenEpicIds,
   useEpicCanvasStore,
 } from "@/stores/epics/canvas/store";
+import { useInitialChatHandoffStore } from "@/stores/epics/initial-chat-handoff-store";
+import {
+  clearSessionCreatedEpics,
+  markEpicCreatedThisSession,
+} from "@/lib/epics/session-created-epics";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
 
 const STARTUP_EPIC_ID = "epic-startup-compat";
+const STALE_EPIC_ID = "epic-stale-persisted";
+
+const HANDOFF_SETTINGS = {
+  harnessId: "codex",
+  model: "codex-test",
+  permissionMode: "supervised",
+  reasoningEffort: "high",
+  serviceTier: null,
+  agentMode: "epic",
+} satisfies ChatRunSettings;
+
+function registerActiveHandoff(epicId: string): void {
+  useInitialChatHandoffStore.getState().register({
+    hostId: localSnapshot.hostId,
+    userId: "test-user",
+    epicId,
+    chatId: `${epicId}-chat`,
+    content: { type: "doc", content: [] } satisfies JsonContent,
+    settings: HANDOFF_SETTINGS,
+    worktreeIntent: null,
+    placement: { kind: "active-tile" },
+    messageId: `${epicId}-msg`,
+    clientActionId: `${epicId}-cai`,
+    createdAt: 1,
+  });
+}
 
 const localSnapshot: LocalHostSnapshot = {
   hostId: "desktop-pid-1",
@@ -278,7 +311,11 @@ describe("HostCompatibilityProvider startup consumers", () => {
   afterEach(() => {
     cleanup();
     useAuthStore.getState().setSignedOut();
-    useEpicCanvasStore.getState().closeTabsForEpics([STARTUP_EPIC_ID]);
+    useEpicCanvasStore
+      .getState()
+      .closeTabsForEpics([STARTUP_EPIC_ID, STALE_EPIC_ID]);
+    useInitialChatHandoffStore.getState().resetForTests();
+    clearSessionCreatedEpics();
     vi.restoreAllMocks();
     restoreFetch();
   });
@@ -456,6 +493,72 @@ describe("HostCompatibilityProvider startup consumers", () => {
       listTasks.mock.calls.map(([params]) => params.cursor ?? null),
     ).toEqual([null, "repeat"]);
     expect(methods[0]).toBe("host.status");
+    queryClient.clear();
+  });
+
+  it("keeps a freshly-created epic tab whose epic is not yet in the reconcile page but has an active initial-chat handoff", async () => {
+    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
+      tasks: [],
+      hasMore: false,
+    }));
+    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+      harnesses: [],
+    }));
+    const { queryClient } = mountStartupConsumers({
+      hostStatus: () => compatibleHostStatus,
+      listTasks,
+      listHarnesses,
+      onMethod: () => undefined,
+    });
+
+    // `STARTUP_EPIC_ID` stands in for a just-created epic: it carries an active
+    // initial-chat handoff and is not in the (empty) reconcile page because
+    // `epic.listTasks` lags `epic.create`. `STALE_EPIC_ID` is a genuinely-stale
+    // persisted tab (no session, no handoff). Register/open both before the
+    // reconciler run captures `openEpicIds` (host.status resolves on a later
+    // microtask, so this synchronous block wins).
+    act(() => {
+      useEpicCanvasStore.getState().openEpicTab(STALE_EPIC_ID, "Stale");
+      registerActiveHandoff(STARTUP_EPIC_ID);
+    });
+
+    // The unprotected stale tab is pruned - proof the reconciliation ran to
+    // completion - while the handoff-protected fresh tab survives.
+    await waitFor(() => {
+      expect(collectOpenEpicIds()).not.toContain(STALE_EPIC_ID);
+    });
+    expect(collectOpenEpicIds()).toContain(STARTUP_EPIC_ID);
+    queryClient.clear();
+  });
+
+  it("keeps a freshly-created epic tab marked created-this-session (terminal-agent path, no handoff) that is absent from the reconcile page", async () => {
+    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
+      tasks: [],
+      hasMore: false,
+    }));
+    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+      harnesses: [],
+    }));
+    const { queryClient } = mountStartupConsumers({
+      hostStatus: () => compatibleHostStatus,
+      listTasks,
+      listHarnesses,
+      onMethod: () => undefined,
+    });
+
+    // `STARTUP_EPIC_ID` stands in for a terminal-agent epic just created from
+    // the start page: no initial-chat handoff, no live session yet, only the
+    // synchronous create-time marker. `STALE_EPIC_ID` is a genuinely-stale
+    // persisted tab. Both are absent from the (empty) reconcile page.
+    act(() => {
+      useEpicCanvasStore.getState().openEpicTab(STALE_EPIC_ID, "Stale");
+      markEpicCreatedThisSession(STARTUP_EPIC_ID);
+    });
+
+    await waitFor(() => {
+      expect(collectOpenEpicIds()).not.toContain(STALE_EPIC_ID);
+    });
+    expect(collectOpenEpicIds()).toContain(STARTUP_EPIC_ID);
     queryClient.clear();
   });
 

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -36,6 +36,7 @@ import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe
 
 const STARTUP_EPIC_ID = "epic-startup-compat";
 const STALE_EPIC_ID = "epic-stale-persisted";
+const FRESH_EPIC_ID = "epic-fresh-created";
 
 const HANDOFF_SETTINGS = {
   harnessId: "codex",
@@ -241,6 +242,27 @@ function epicTask(epicId: string): ListTasksResponse["tasks"][number] {
   };
 }
 
+// Shared harness for the "freshly-created epic survives reconciliation" tests.
+// `epic.listTasks` returns only the pre-existing startup tab, so a just-created
+// epic (absent from the page while epic.listTasks lags epic.create) is pruned
+// unless a protection guard exempts it.
+function mountReconcilerHarness(): { readonly queryClient: QueryClient } {
+  const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
+    tasks: [epicTask(STARTUP_EPIC_ID)],
+    hasMore: false,
+  }));
+  const listHarnesses = vi.fn((): ListHarnessesResponse => ({
+    harnesses: [],
+  }));
+  const { queryClient } = mountStartupConsumers({
+    hostStatus: () => compatibleHostStatus,
+    listTasks,
+    listHarnesses,
+    onMethod: () => undefined,
+  });
+  return { queryClient };
+}
+
 function installAuthFetch(): () => void {
   const originalFetch: unknown = (globalThis as { fetch?: unknown }).fetch;
   Object.defineProperty(globalThis, "fetch", {
@@ -313,7 +335,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
     useAuthStore.getState().setSignedOut();
     useEpicCanvasStore
       .getState()
-      .closeTabsForEpics([STARTUP_EPIC_ID, STALE_EPIC_ID]);
+      .closeTabsForEpics([STARTUP_EPIC_ID, STALE_EPIC_ID, FRESH_EPIC_ID]);
     useInitialChatHandoffStore.getState().resetForTests();
     clearSessionCreatedEpics();
     vi.restoreAllMocks();
@@ -496,69 +518,45 @@ describe("HostCompatibilityProvider startup consumers", () => {
     queryClient.clear();
   });
 
-  it("keeps a freshly-created epic tab whose epic is not yet in the reconcile page but has an active initial-chat handoff", async () => {
-    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
-      tasks: [],
-      hasMore: false,
-    }));
-    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
-      harnesses: [],
-    }));
-    const { queryClient } = mountStartupConsumers({
-      hostStatus: () => compatibleHostStatus,
-      listTasks,
-      listHarnesses,
-      onMethod: () => undefined,
-    });
+  it("keeps a freshly-created epic tab absent from the reconcile page but protected by an active initial-chat handoff", async () => {
+    const { queryClient } = mountReconcilerHarness();
 
-    // `STARTUP_EPIC_ID` stands in for a just-created epic: it carries an active
-    // initial-chat handoff and is not in the (empty) reconcile page because
-    // `epic.listTasks` lags `epic.create`. `STALE_EPIC_ID` is a genuinely-stale
-    // persisted tab (no session, no handoff). Register/open both before the
-    // reconciler run captures `openEpicIds` (host.status resolves on a later
-    // microtask, so this synchronous block wins).
+    // FRESH_EPIC_ID models a just-created epic: absent from the reconcile page
+    // (epic.listTasks lags epic.create) but carrying an active initial-chat
+    // handoff. STALE_EPIC_ID is a genuinely-stale persisted tab with no
+    // protection. Both are opened before the reconciler run captures
+    // openEpicIds (host.status resolves on a later microtask, so this
+    // synchronous block wins).
     act(() => {
+      useEpicCanvasStore.getState().openEpicTab(FRESH_EPIC_ID, "Fresh");
       useEpicCanvasStore.getState().openEpicTab(STALE_EPIC_ID, "Stale");
-      registerActiveHandoff(STARTUP_EPIC_ID);
+      registerActiveHandoff(FRESH_EPIC_ID);
     });
 
-    // The unprotected stale tab is pruned - proof the reconciliation ran to
+    // The unprotected stale tab is pruned - proof reconciliation ran to
     // completion - while the handoff-protected fresh tab survives.
     await waitFor(() => {
       expect(collectOpenEpicIds()).not.toContain(STALE_EPIC_ID);
     });
-    expect(collectOpenEpicIds()).toContain(STARTUP_EPIC_ID);
+    expect(collectOpenEpicIds()).toContain(FRESH_EPIC_ID);
     queryClient.clear();
   });
 
-  it("keeps a freshly-created epic tab marked created-this-session (terminal-agent path, no handoff) that is absent from the reconcile page", async () => {
-    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
-      tasks: [],
-      hasMore: false,
-    }));
-    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
-      harnesses: [],
-    }));
-    const { queryClient } = mountStartupConsumers({
-      hostStatus: () => compatibleHostStatus,
-      listTasks,
-      listHarnesses,
-      onMethod: () => undefined,
-    });
+  it("keeps a freshly-created epic tab absent from the reconcile page but marked created-this-session (terminal-agent path, no handoff)", async () => {
+    const { queryClient } = mountReconcilerHarness();
 
-    // `STARTUP_EPIC_ID` stands in for a terminal-agent epic just created from
-    // the start page: no initial-chat handoff, no live session yet, only the
-    // synchronous create-time marker. `STALE_EPIC_ID` is a genuinely-stale
-    // persisted tab. Both are absent from the (empty) reconcile page.
+    // Terminal-agent create registers no initial-chat handoff, so only the
+    // synchronous created-this-session marker protects FRESH_EPIC_ID here.
     act(() => {
+      useEpicCanvasStore.getState().openEpicTab(FRESH_EPIC_ID, "Fresh");
       useEpicCanvasStore.getState().openEpicTab(STALE_EPIC_ID, "Stale");
-      markEpicCreatedThisSession(STARTUP_EPIC_ID);
+      markEpicCreatedThisSession(FRESH_EPIC_ID);
     });
 
     await waitFor(() => {
       expect(collectOpenEpicIds()).not.toContain(STALE_EPIC_ID);
     });
-    expect(collectOpenEpicIds()).toContain(STARTUP_EPIC_ID);
+    expect(collectOpenEpicIds()).toContain(FRESH_EPIC_ID);
     queryClient.clear();
   });
 

--- a/clients/gui-app/src/providers/auth-lifecycle-bridge.tsx
+++ b/clients/gui-app/src/providers/auth-lifecycle-bridge.tsx
@@ -3,6 +3,7 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { disposeAllChatSessions } from "@/lib/registries/chat-session-registry";
 import { disposeAllTerminalSessions } from "@/lib/registries/terminal-session-registry";
 import { disposeAllOpenEpicSessions } from "@/lib/registries/epic-session-registry";
+import { clearSessionCreatedEpics } from "@/lib/epics/session-created-epics";
 import {
   useAuthIdentityTransition,
   type AuthIdentityTransition,
@@ -35,6 +36,10 @@ export function EpicSessionLifecycleBridge(
       disposeAllOpenEpicSessions();
       disposeAllChatSessions();
       disposeAllTerminalSessions();
+      // Drop the "created this session" markers so a new identity's persisted
+      // tabs are reconciled normally instead of being protected by the prior
+      // identity's create markers.
+      clearSessionCreatedEpics();
     }
   }, []);
 

--- a/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
+++ b/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
@@ -19,10 +19,16 @@ import {
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
 import { missingEpicIds } from "@/lib/epics/epic-tab-existence";
+import { wasEpicCreatedThisSession } from "@/lib/epics/session-created-epics";
+import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import { useWindowsBridgeHydrated } from "@/providers/windows-bridge-context";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
+import {
+  selectHasActiveInitialChatHandoffForEpic,
+  useInitialChatHandoffStore,
+} from "@/stores/epics/initial-chat-handoff-store";
 
 const EPIC_TAB_RECONCILE_PAGE_LIMIT = 100;
 const EMPTY_EXISTING_EPIC_IDS: ReadonlyArray<string> = [];
@@ -173,9 +179,19 @@ function EpicTabReconciliationPage(props: {
     if (terminalExistingEpicIds === null) return;
     if (completionAppliedRef.current) return;
     completionAppliedRef.current = true;
-    const staleEpicIds = missingEpicIds(
-      props.run.openEpicIds,
-      new Set(terminalExistingEpicIds),
+    // Never force-close an epic this session just created (or is creating):
+    // `epic.listTasks` lags `epic.create` (that lag is exactly why
+    // `useEpicCreate.onSuccess` manually patches the cloud-tasks cache), so a
+    // freshly-created epic is legitimately absent from the reconcile page for a
+    // short window. Closing its tab strands the route on a loading skeleton
+    // that never recovers. Such epics carry a live open-epic session and/or an
+    // active initial-chat handoff; a genuinely-stale persisted tab (its epic
+    // deleted while the app was closed) carries neither. A remote delete of an
+    // OPEN epic is handled by `EpicAccessCoordinator` (via the live session's
+    // `epicDeleted` / `accessLost` / unavailable-`snapshotFetchError` signals),
+    // not here, so this exclusion cannot hide a real "epic is gone" signal.
+    const staleEpicIds = closableStaleEpicIds(
+      missingEpicIds(props.run.openEpicIds, new Set(terminalExistingEpicIds)),
     );
     if (staleEpicIds.length > 0) {
       useComposerRunSettingsStore.getState().clearEpicRunSettings(staleEpicIds);
@@ -187,6 +203,34 @@ function EpicTabReconciliationPage(props: {
   if (nextPage.cursor === undefined) return null;
 
   return <EpicTabReconciliationPage run={props.run} page={nextPage} />;
+}
+
+/**
+ * Drop epics that must never be force-closed by existence reconciliation. An
+ * epic is protected when ANY of these hold:
+ *  - it was created from the start page this session (synchronous marker set at
+ *    create time - the deterministic guard both the GUI-chat and terminal-agent
+ *    landing flows share);
+ *  - it has a live open-epic session in the registry (`peek` reads without
+ *    disturbing MRU ordering);
+ *  - it has an active (non-failed) initial-chat handoff (the GUI-chat flow).
+ * Each marks an epic this session opened or created, for which a transient
+ * `epic.listTasks` miss is propagation lag rather than a deletion. Evaluated
+ * fresh here, at close time, so a session/handoff that appears after the
+ * reconcile RPC resolves still counts.
+ */
+function closableStaleEpicIds(
+  candidateEpicIds: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  if (candidateEpicIds.length === 0) return candidateEpicIds;
+  const handoffState = useInitialChatHandoffStore.getState();
+  const registry = getOpenEpicRegistry();
+  return candidateEpicIds.filter(
+    (epicId) =>
+      !wasEpicCreatedThisSession(epicId) &&
+      registry.peek(epicId) === null &&
+      !selectHasActiveInitialChatHandoffForEpic(handoffState, epicId),
+  );
 }
 
 function mergeExistingEpicIds(


### PR DESCRIPTION
## Problem

Creating a task from the start page (landing composer) put the new epic tab into a permanent loading state. The task was created on the host, but the tab was stuck on the loading skeleton until a reload or a close-and-reopen. It only reproduced when there was **no prior epic tab open**.

## Root cause

`EpicTabExistenceReconciler` prunes open epic tabs whose epic is absent from the host's `epic.listTasks`. `epic.listTasks` lags `epic.create` (the same lag `useEpicCreate.onSuccess` already patches around in the cloud-tasks cache), so a freshly-created epic is legitimately missing from the reconcile page for a short window and gets treated as stale.

`closeTabsForEpics` then deletes the tab from `tabsById` / `openTabOrder` / `canvasByTabId` without navigating, so `EpicRouteTabSync` falls back to rendering `<EpicShell>`'s loading skeleton — and its recovery effect never re-runs (its deps don't change when the tab record disappears), so the route is stranded.

Why only with no prior epic tab: the reconciler run is keyed by `identity` (`host:user:hydrationVersion`), **not** by `openEpicIds`, and it captures `openEpicIds` once. With 0 open epics the seed is null, so creating the first epic mounts a fresh run that reconciles the just-created epic. With a tab already open, the run mounted earlier with a captured set that never includes the new epic, so it is never reconciled.

This is a follow-up to the reconciler rework in #148 (reactive, `openEpicIds.length > 0`-gated seeding).

## Fix

Never let existence reconciliation force-close an epic this session created or opened:

- **`session-created-epics.ts`** (new): a session-scoped marker set synchronously at create time by **both** landing flows — GUI-chat (`finalizeSubmission`) and terminal-agent (`dispatchTerminalAgent`) — before navigation, so it is set before the reconciler can seed a run. Cleared on sign-out / user-switch in `auth-lifecycle-bridge`.
- **`epic-tab-existence-reconciler.tsx`**: `closableStaleEpicIds` excludes any epic that was created this session, has a live open-epic session (`registry.peek`), or has an active initial-chat handoff. All three are evaluated fresh at close time, and the filtered set feeds both `clearEpicRunSettings` and `closeTabsForEpics`.

Remote deletes of an **open** epic are still handled by `EpicAccessCoordinator` (via the live session's `epicDeleted` / `accessLost` / unavailable-`snapshotFetchError` signals), so this exclusion cannot mask a real "epic is gone" signal. The reconciler continues to prune genuinely-stale persisted tabs (no session, no handoff, not created this session).

## Testing

- Added cold-start regression tests in `host-compatibility-provider.test.tsx`: a freshly-created epic absent from an empty `epic.listTasks` page survives when protected by an active handoff, and when protected by the created-this-session marker (terminal-agent path, no handoff/session) — each alongside a genuinely-stale tab that is still pruned (proving reconciliation ran to completion).
- `tsc -b`: clean.
- Full gui-app vitest suite: 3527 passed, 1 skipped, 0 failed.
- `react-doctor` (changed files vs `main`): no issues.
