### PR TITLE
fix(host): stop cli-lock wedging forever on PID reuse, gate host update on busy check

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -103,7 +103,9 @@ function fakeCtx(): CommandContext {
 
 describe("buildHostUpdateCommand busy-check gating", () => {
   afterEach(() => {
-    vi.clearAllMocks();
+    // resetAllMocks (not clearAllMocks) so a mockResolvedValue/
+    // mockRejectedValue configured in one test can't leak into the next.
+    vi.resetAllMocks();
   });
 
   it("rejects with E_HOST_BUSY without --force, and never calls installHost", async () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-update.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `host update` must refuse to restart a busy host unless `--force` is
+// passed - matching the same `assertHostNotBusy` gate `provisionHost`
+// already applies to install/uninstall/service-cycle. Before this change
+// `host-update.ts` skipped the gate entirely.
+
+const mocks = vi.hoisted(() => ({
+  assertHostNotBusyMock: vi.fn(),
+  installHostMock: vi.fn(),
+  readHostInstallRecordMock: vi.fn(),
+}));
+
+vi.mock("../../host/busy-check", () => ({
+  assertHostNotBusy: mocks.assertHostNotBusyMock,
+}));
+
+vi.mock("../../installer", () => ({
+  installHost: mocks.installHostMock,
+}));
+
+vi.mock("../../manifest/host-install", () => ({
+  readHostInstallRecord: mocks.readHostInstallRecordMock,
+}));
+
+vi.mock("../../store/cli-lock", () => ({
+  withCliLock: (
+    _opts: unknown,
+    fn: (handle: {
+      path: string;
+      metadata: Record<string, unknown>;
+      release: () => Promise<void>;
+    }) => Promise<unknown>,
+  ) =>
+    fn({
+      path: "/tmp/.lock",
+      metadata: {},
+      release: async () => {},
+    }),
+}));
+
+vi.mock("../../service/install-lifecycle", () => ({
+  createServiceInstallLifecycle: () => ({
+    lifecycle: {
+      beforeSwap: async () => {},
+      afterSwap: async () => {},
+    },
+    state: {
+      priorState: "stopped",
+      stoppedBeforeSwap: false,
+      postSwapAction: "none",
+      postSwapError: null,
+    },
+  }),
+}));
+
+import { buildHostUpdateCommand } from "../host-update";
+import { CLI_ERROR_CODES } from "../../runner/errors";
+import type { CommandContext } from "../../runner/runner";
+import type { HostInstallRecord } from "../../manifest/host-install";
+
+function sampleRecord(version: string): HostInstallRecord {
+  return {
+    version,
+    platform: "darwin",
+    arch: "arm64",
+    installedAt: "2026-01-01T00:00:00.000Z",
+    source: { kind: "registry", value: version },
+    archiveSha256: "a".repeat(64),
+    signatureVerifiedAt: "2026-01-01T00:00:00.000Z",
+    signatureKeyId: "test-key",
+    sizeBytes: 1,
+    executablePath: "/tmp/traycer-host",
+  };
+}
+
+function fakeCtx(): CommandContext {
+  return {
+    runtime: {
+      json: false,
+      quiet: false,
+      noProgress: false,
+      noBootstrap: false,
+      nonInteractive: false,
+      environment: "production",
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+    },
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+describe("buildHostUpdateCommand busy-check gating", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects with E_HOST_BUSY without --force, and never calls installHost", async () => {
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("1.0.0"));
+    mocks.assertHostNotBusyMock.mockRejectedValue(
+      Object.assign(new Error("busy"), { code: CLI_ERROR_CODES.HOST_BUSY }),
+    );
+    const command = buildHostUpdateCommand({ force: false });
+    await expect(command(fakeCtx())).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.HOST_BUSY,
+    });
+    expect(mocks.assertHostNotBusyMock).toHaveBeenCalledWith("production");
+    expect(mocks.installHostMock).not.toHaveBeenCalled();
+  });
+
+  it("skips the busy check and proceeds when --force is passed", async () => {
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("1.0.0"));
+    mocks.installHostMock.mockResolvedValue({
+      record: sampleRecord("2.0.0"),
+      previous: sampleRecord("1.0.0"),
+    });
+    const command = buildHostUpdateCommand({ force: true });
+    const result = await command(fakeCtx());
+    expect(mocks.assertHostNotBusyMock).not.toHaveBeenCalled();
+    expect(mocks.installHostMock).toHaveBeenCalled();
+    expect(result.data).toMatchObject({ version: "2.0.0" });
+  });
+
+  it("proceeds past the busy check when the host is idle", async () => {
+    mocks.readHostInstallRecordMock.mockResolvedValue(sampleRecord("1.0.0"));
+    mocks.assertHostNotBusyMock.mockResolvedValue(undefined);
+    mocks.installHostMock.mockResolvedValue({
+      record: sampleRecord("1.0.0"),
+      previous: sampleRecord("1.0.0"),
+    });
+    const command = buildHostUpdateCommand({ force: false });
+    const result = await command(fakeCtx());
+    expect(mocks.assertHostNotBusyMock).toHaveBeenCalledWith("production");
+    expect(mocks.installHostMock).toHaveBeenCalled();
+    expect(result.human).toContain("no-op");
+  });
+});

--- a/clients/traycer-cli/src/commands/host-update.ts
+++ b/clients/traycer-cli/src/commands/host-update.ts
@@ -1,4 +1,5 @@
 import { installHost } from "../installer";
+import { assertHostNotBusy } from "../host/busy-check";
 import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import type { CommandFn, CommandResult } from "../runner/runner";
 import { formatServiceLifecycleWarning } from "../service";
@@ -13,88 +14,110 @@ import { withCliLock } from "../store/cli-lock";
 // `host install` so an in-place update doesn't leave the OS service
 // pointed at a half-replaced install dir (especially relevant on
 // Windows where executable locks block the rename otherwise).
-export const hostUpdateCommand: CommandFn = async (
-  ctx,
-): Promise<CommandResult> => {
-  ctx.runtime.logger.info("Host update command started", {
-    environment: ctx.runtime.environment,
-  });
-  return withCliLock(
-    {
+export interface HostUpdateArgs {
+  // Skip the busy check and update a running host unconditionally.
+  // Surfaced as `--force`, matching `host ensure`'s flag.
+  readonly force: boolean;
+}
+
+export function buildHostUpdateCommand(args: HostUpdateArgs): CommandFn {
+  return async (ctx): Promise<CommandResult> => {
+    ctx.runtime.logger.info("Host update command started", {
       environment: ctx.runtime.environment,
-      reason: "host-update",
-      waitMs: 30_000,
-      pollIntervalMs: 100,
-    },
-    async () => {
-      const { readHostInstallRecord } =
-        await import("../manifest/host-install");
-      const previous = await readHostInstallRecord(ctx.runtime.environment);
-      if (previous === null) {
-        ctx.runtime.logger.warn(
-          "Host update refused because host is not installed",
-          {
-            environment: ctx.runtime.environment,
-          },
-        );
-        throw cliError({
-          code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
-          message: `host update: no host installed for environment=${ctx.runtime.environment}; run 'traycer host install latest' first`,
-          details: { environment: ctx.runtime.environment },
-          exitCode: 1,
+      force: args.force,
+    });
+    return withCliLock(
+      {
+        environment: ctx.runtime.environment,
+        reason: "host-update",
+        waitMs: 30_000,
+        pollIntervalMs: 100,
+      },
+      async () => {
+        const { readHostInstallRecord } =
+          await import("../manifest/host-install");
+        const previous = await readHostInstallRecord(ctx.runtime.environment);
+        if (previous === null) {
+          ctx.runtime.logger.warn(
+            "Host update refused because host is not installed",
+            {
+              environment: ctx.runtime.environment,
+            },
+          );
+          throw cliError({
+            code: CLI_ERROR_CODES.HOST_NOT_INSTALLED,
+            message: `host update: no host installed for environment=${ctx.runtime.environment}; run 'traycer host install latest' first`,
+            details: { environment: ctx.runtime.environment },
+            exitCode: 1,
+          });
+        }
+        // Every update replaces the bytes of a potentially-LIVE host, same
+        // hazard `provisionHost` guards against - refuse unless the host is
+        // confirmed idle (or unreachable), fail-safe otherwise. `--force`
+        // (matching `host ensure`) skips this for the desktop's "Force
+        // update" path.
+        if (!args.force) {
+          await assertHostNotBusy(ctx.runtime.environment);
+        } else {
+          ctx.runtime.logger.warn(
+            "Host update skipped busy guard because force=true",
+            {
+              environment: ctx.runtime.environment,
+            },
+          );
+        }
+        // `host update` assumes the service is already registered; if it
+        // isn't, leave registration to the operator (`traycer host service
+        // install`) rather than silently bootstrapping on an update path.
+        const handle = createServiceInstallLifecycle({
+          environment: ctx.runtime.environment,
+          bootstrap: null,
         });
-      }
-      // `host update` assumes the service is already registered; if it
-      // isn't, leave registration to the operator (`traycer host service
-      // install`) rather than silently bootstrapping on an update path.
-      const handle = createServiceInstallLifecycle({
-        environment: ctx.runtime.environment,
-        bootstrap: null,
-      });
-      ctx.runtime.logger.debug("Host update lifecycle created", {
-        environment: ctx.runtime.environment,
-        previousVersion: previous.version,
-      });
-      const result = await installHost({
-        environment: ctx.runtime.environment,
-        source: { kind: "registry", versionRequest: "latest" },
-        onProgress: (info) => ctx.progress(info),
-        lifecycle: handle.lifecycle,
-        // Registry update records the registry version; nothing to override.
-        recordVersionOverride: null,
-      });
-      const lifecycleData = {
-        priorServiceState: handle.state.priorState,
-        stoppedBeforeSwap: handle.state.stoppedBeforeSwap,
-        postSwapAction: handle.state.postSwapAction,
-        postSwapError: handle.state.postSwapError,
-      };
-      const baseHuman =
-        previous.version === result.record.version
-          ? `host already at ${result.record.version} (no-op)`
-          : `updated host ${previous.version} → ${result.record.version}`;
-      ctx.runtime.logger.info("Host update command completed", {
-        environment: ctx.runtime.environment,
-        previousVersion: previous.version,
-        version: result.record.version,
-        changed: previous.version !== result.record.version,
-        postSwapAction: handle.state.postSwapAction,
-        hasPostSwapError: handle.state.postSwapError !== null,
-      });
-      return {
-        data: {
-          version: result.record.version,
+        ctx.runtime.logger.debug("Host update lifecycle created", {
+          environment: ctx.runtime.environment,
           previousVersion: previous.version,
-          installedAt: result.record.installedAt,
-          source: result.record.source,
-          serviceLifecycle: lifecycleData,
-        },
-        human:
-          handle.state.postSwapError !== null
-            ? `${baseHuman}; ${formatServiceLifecycleWarning(handle.state.postSwapAction, handle.state.postSwapError)}`
-            : baseHuman,
-        exitCode: 0,
-      };
-    },
-  );
-};
+        });
+        const result = await installHost({
+          environment: ctx.runtime.environment,
+          source: { kind: "registry", versionRequest: "latest" },
+          onProgress: (info) => ctx.progress(info),
+          lifecycle: handle.lifecycle,
+          // Registry update records the registry version; nothing to override.
+          recordVersionOverride: null,
+        });
+        const lifecycleData = {
+          priorServiceState: handle.state.priorState,
+          stoppedBeforeSwap: handle.state.stoppedBeforeSwap,
+          postSwapAction: handle.state.postSwapAction,
+          postSwapError: handle.state.postSwapError,
+        };
+        const baseHuman =
+          previous.version === result.record.version
+            ? `host already at ${result.record.version} (no-op)`
+            : `updated host ${previous.version} → ${result.record.version}`;
+        ctx.runtime.logger.info("Host update command completed", {
+          environment: ctx.runtime.environment,
+          previousVersion: previous.version,
+          version: result.record.version,
+          changed: previous.version !== result.record.version,
+          postSwapAction: handle.state.postSwapAction,
+          hasPostSwapError: handle.state.postSwapError !== null,
+        });
+        return {
+          data: {
+            version: result.record.version,
+            previousVersion: previous.version,
+            installedAt: result.record.installedAt,
+            source: result.record.source,
+            serviceLifecycle: lifecycleData,
+          },
+          human:
+            handle.state.postSwapError !== null
+              ? `${baseHuman}; ${formatServiceLifecycleWarning(handle.state.postSwapAction, handle.state.postSwapError)}`
+              : baseHuman,
+          exitCode: 0,
+        };
+      },
+    );
+  };
+}

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -47,7 +47,7 @@ import { runHostStart } from "./commands/host-start";
 import { hostStatusCommand } from "./commands/host-status";
 import { hostStopCommand } from "./commands/host-stop";
 import { buildHostUninstallCommand } from "./commands/host-uninstall";
-import { hostUpdateCommand } from "./commands/host-update";
+import { buildHostUpdateCommand } from "./commands/host-update";
 import { buildLoginCommand } from "./commands/login";
 import { logoutCommand } from "./commands/logout";
 import { buildServiceInstallCommand } from "./commands/service-install";
@@ -494,8 +494,15 @@ function registerHostCommands(program: Command): void {
   withRunner(
     host
       .command("update")
-      .description("Update the installed host to the latest registry version"),
-    () => hostUpdateCommand,
+      .description("Update the installed host to the latest registry version")
+      .option(
+        "--force",
+        "Update the host even if it has work in progress (skips the busy check).",
+      ),
+    (opts) =>
+      buildHostUpdateCommand({
+        force: opts.force === true,
+      }),
   );
 
   withRunner(

--- a/clients/traycer-cli/src/store/__tests__/cli-lock.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/cli-lock.test.ts
@@ -67,19 +67,27 @@ describe("isProcessAlive", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("returns false when kill(pid, 0) throws ESRCH (process is gone)", () => {
-    vi.spyOn(process, "kill").mockImplementation(() => {
-      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
-    });
-    expect(isProcessAlive(999999)).toBe(false);
-  });
+  // On win32, isProcessAlive never calls process.kill (it shells out to
+  // tasklist instead), so mocking kill here would test nothing there.
+  it.skipIf(process.platform === "win32")(
+    "returns false when kill(pid, 0) throws ESRCH (process is gone)",
+    () => {
+      vi.spyOn(process, "kill").mockImplementation(() => {
+        throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+      });
+      expect(isProcessAlive(999999)).toBe(false);
+    },
+  );
 
-  it("returns true (conservative) when kill(pid, 0) throws EPERM", () => {
-    vi.spyOn(process, "kill").mockImplementation(() => {
-      throw Object.assign(new Error("not permitted"), { code: "EPERM" });
-    });
-    expect(isProcessAlive(1)).toBe(true);
-  });
+  it.skipIf(process.platform === "win32")(
+    "returns true (conservative) when kill(pid, 0) throws EPERM",
+    () => {
+      vi.spyOn(process, "kill").mockImplementation(() => {
+        throw Object.assign(new Error("not permitted"), { code: "EPERM" });
+      });
+      expect(isProcessAlive(1)).toBe(true);
+    },
+  );
 });
 
 describe("acquireCliLock", () => {
@@ -197,6 +205,24 @@ describe("acquireCliLock", () => {
       code: CLI_ERROR_CODES.CLI_LOCK_BUSY,
       message: expect.stringContaining("holder.pid=" + process.pid),
     });
+  });
+
+  it("falls back to the lock file's mtime when startedAt is unparseable, and still breaks past the ceiling", async () => {
+    writeLock({
+      pid: process.pid,
+      reason: "host-update",
+      startedAt: "not-a-real-timestamp",
+    });
+    const old = new Date(Date.now() - MAX_LOCK_AGE_MS - 1000);
+    utimesSync(mocks.lockPath, old, old);
+    const handle = await acquireCliLock({
+      environment: "production",
+      reason: "contender",
+      waitMs: 1000,
+      pollIntervalMs: 50,
+    });
+    expect(handle.metadata.reason).toBe("contender");
+    await handle.release();
   });
 });
 

--- a/clients/traycer-cli/src/store/__tests__/cli-lock.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/cli-lock.test.ts
@@ -1,0 +1,270 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ lockPath: "" }));
+
+vi.mock("../paths", () => ({
+  cliLockPath: () => mocks.lockPath,
+  ensureCliHomeDir: async () => {},
+}));
+
+import {
+  acquireCliLock,
+  isProcessAlive,
+  withCliLock,
+  type CliLockMetadata,
+} from "../cli-lock";
+import { CLI_ERROR_CODES } from "../../runner/errors";
+
+// Ten minutes - kept in sync with MAX_LOCK_AGE_MS in cli-lock.ts (not
+// exported; the regression test below re-derives it from behavior, not
+// from importing the private constant).
+const MAX_LOCK_AGE_MS = 10 * 60 * 1000;
+const EMPTY_LOCK_GRACE_MS = 5000;
+
+function writeLock(overrides: Partial<CliLockMetadata>): void {
+  const meta: CliLockMetadata = {
+    pid: 999999,
+    reason: "old-holder",
+    startedAt: new Date().toISOString(),
+    hostname: null,
+    token: "original-token",
+    ...overrides,
+  };
+  writeFileSync(mocks.lockPath, JSON.stringify(meta, null, 2));
+}
+
+function readLockRaw(): Record<string, unknown> | null {
+  try {
+    return JSON.parse(readFileSync(mocks.lockPath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+describe("isProcessAlive", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns true for a real, currently-running pid", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it("returns false for an invalid pid without probing", () => {
+    const spy = vi.spyOn(process, "kill");
+    expect(isProcessAlive(0)).toBe(false);
+    expect(isProcessAlive(-5)).toBe(false);
+    expect(isProcessAlive(1.5)).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns false when kill(pid, 0) throws ESRCH (process is gone)", () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+    expect(isProcessAlive(999999)).toBe(false);
+  });
+
+  it("returns true (conservative) when kill(pid, 0) throws EPERM", () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("not permitted"), { code: "EPERM" });
+    });
+    expect(isProcessAlive(1)).toBe(true);
+  });
+});
+
+describe("acquireCliLock", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "traycer-cli-lock-test-"));
+    mocks.lockPath = join(workDir, ".lock");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("breaks a lock whose holder pid is dead and acquires immediately", async () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+    writeLock({ pid: 999999, startedAt: new Date().toISOString() });
+    const handle = await acquireCliLock({
+      environment: "production",
+      reason: "new-holder",
+      waitMs: 1000,
+      pollIntervalMs: 50,
+    });
+    expect(handle.metadata.reason).toBe("new-holder");
+    await handle.release();
+  });
+
+  it("throws CLI_LOCK_BUSY when a live holder never frees the lock in time", async () => {
+    // pid === process.pid short-circuits holderAlive() to true without
+    // probing, so this holder reads as genuinely alive throughout.
+    writeLock({
+      pid: process.pid,
+      reason: "host-update",
+      startedAt: new Date().toISOString(),
+    });
+    await expect(
+      acquireCliLock({
+        environment: "production",
+        reason: "contender",
+        waitMs: 200,
+        pollIntervalMs: 50,
+      }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.CLI_LOCK_BUSY,
+      message: expect.stringContaining("holder.pid=" + process.pid),
+    });
+  });
+
+  it("regression: breaks a lock past the age ceiling even though the pid is alive", async () => {
+    // Same live pid as the previous test (guaranteed alive via the
+    // pid === process.pid shortcut - no ESRCH/EPERM involved), but old
+    // enough to exceed MAX_LOCK_AGE_MS. Before the fix this hung until
+    // waitMs regardless of age; this is the exact bug from the report.
+    writeLock({
+      pid: process.pid,
+      reason: "host-update",
+      startedAt: new Date(Date.now() - MAX_LOCK_AGE_MS - 1000).toISOString(),
+    });
+    const handle = await acquireCliLock({
+      environment: "production",
+      reason: "contender",
+      waitMs: 1000,
+      pollIntervalMs: 50,
+    });
+    expect(handle.metadata.reason).toBe("contender");
+    await handle.release();
+  });
+
+  it("does not break an empty/corrupt lock file younger than the grace window", async () => {
+    writeFileSync(mocks.lockPath, "");
+    await expect(
+      acquireCliLock({
+        environment: "production",
+        reason: "contender",
+        waitMs: 200,
+        pollIntervalMs: 50,
+      }),
+    ).rejects.toMatchObject({ code: CLI_ERROR_CODES.CLI_LOCK_BUSY });
+  });
+
+  it("breaks an empty/corrupt lock file older than the grace window", async () => {
+    writeFileSync(mocks.lockPath, "");
+    const old = new Date(Date.now() - EMPTY_LOCK_GRACE_MS - 1000);
+    utimesSync(mocks.lockPath, old, old);
+    const handle = await acquireCliLock({
+      environment: "production",
+      reason: "contender",
+      waitMs: 1000,
+      pollIntervalMs: 50,
+    });
+    expect(handle.metadata.reason).toBe("contender");
+    await handle.release();
+  });
+
+  it("still recognizes a pre-token lock as a live holder, not as corrupt", async () => {
+    const meta = {
+      pid: process.pid,
+      reason: "host-update",
+      startedAt: new Date().toISOString(),
+      hostname: null,
+      // no `token` field at all - a lock written by a pre-fix CLI.
+    };
+    writeFileSync(mocks.lockPath, JSON.stringify(meta));
+    await expect(
+      acquireCliLock({
+        environment: "production",
+        reason: "contender",
+        waitMs: 200,
+        pollIntervalMs: 50,
+      }),
+    ).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.CLI_LOCK_BUSY,
+      message: expect.stringContaining("holder.pid=" + process.pid),
+    });
+  });
+});
+
+describe("release() compare-and-delete", () => {
+  let workDir: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "traycer-cli-lock-release-test-"));
+    mocks.lockPath = join(workDir, ".lock");
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("unlinks the lock file when the token still matches", async () => {
+    await withCliLock(
+      {
+        environment: "production",
+        reason: "r",
+        waitMs: 1000,
+        pollIntervalMs: 50,
+      },
+      async () => {
+        expect(readLockRaw()).not.toBeNull();
+      },
+    );
+    expect(readLockRaw()).toBeNull();
+  });
+
+  it("does not delete another holder's lock file if the token no longer matches", async () => {
+    const handle = await acquireCliLock({
+      environment: "production",
+      reason: "r",
+      waitMs: 1000,
+      pollIntervalMs: 50,
+    });
+    // Simulate a steal: someone else broke the (falsely-stale) lock and
+    // wrote their own metadata while this handle still believes it holds it.
+    const impostor: CliLockMetadata = {
+      pid: 424242,
+      reason: "impostor",
+      startedAt: new Date().toISOString(),
+      hostname: null,
+      token: "impostor-token",
+    };
+    writeFileSync(mocks.lockPath, JSON.stringify(impostor));
+    await handle.release();
+    expect(readLockRaw()).toEqual(impostor);
+  });
+
+  it("falls back to unconditional unlink for a legacy no-token file", async () => {
+    const handle = await acquireCliLock({
+      environment: "production",
+      reason: "r",
+      waitMs: 1000,
+      pollIntervalMs: 50,
+    });
+    // Simulate the file having been rewritten by pre-token-version code.
+    writeFileSync(
+      mocks.lockPath,
+      JSON.stringify({
+        pid: process.pid,
+        reason: "r",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+    await handle.release();
+    expect(readLockRaw()).toBeNull();
+  });
+});

--- a/clients/traycer-cli/src/store/__tests__/cli-lock.test.ts
+++ b/clients/traycer-cli/src/store/__tests__/cli-lock.test.ts
@@ -224,6 +224,24 @@ describe("acquireCliLock", () => {
     expect(handle.metadata.reason).toBe("contender");
     await handle.release();
   });
+
+  it("falls back to the lock file's mtime when startedAt is in the future, and still breaks past the ceiling", async () => {
+    writeLock({
+      pid: process.pid,
+      reason: "host-update",
+      startedAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    const old = new Date(Date.now() - MAX_LOCK_AGE_MS - 1000);
+    utimesSync(mocks.lockPath, old, old);
+    const handle = await acquireCliLock({
+      environment: "production",
+      reason: "contender",
+      waitMs: 1000,
+      pollIntervalMs: 50,
+    });
+    expect(handle.metadata.reason).toBe("contender");
+    await handle.release();
+  });
 });
 
 describe("release() compare-and-delete", () => {

--- a/clients/traycer-cli/src/store/cli-lock.ts
+++ b/clients/traycer-cli/src/store/cli-lock.ts
@@ -282,9 +282,23 @@ export async function acquireCliLock(
       // Age is checked regardless of what the PID check concludes - a
       // recycled-PID impostor would otherwise be read as "alive" forever
       // (see MAX_LOCK_AGE_MS above), so no amount of PID-liveness confidence
-      // exempts a lock from this ceiling.
-      const ageMs = Date.now() - new Date(holder.startedAt).getTime();
-      if (!holderAlive(holder.pid) || ageMs >= MAX_LOCK_AGE_MS) {
+      // exempts a lock from this ceiling. `startedAt` is holder-supplied,
+      // not a trusted clock - an unparseable or future value (corruption,
+      // clock skew) would otherwise make ageMs NaN or negative, which never
+      // satisfies `>=` and silently defeats the ceiling. Fall back to the
+      // lock file's own mtime in that case, since the filesystem - not the
+      // holder - controls that timestamp.
+      const now = Date.now();
+      const startedAtMs = new Date(holder.startedAt).getTime();
+      const ageMs =
+        Number.isFinite(startedAtMs) && startedAtMs <= now
+          ? now - startedAtMs
+          : await lockFileAgeMs(path);
+      if (
+        !holderAlive(holder.pid) ||
+        ageMs === null ||
+        ageMs >= MAX_LOCK_AGE_MS
+      ) {
         await breakStaleLock(path);
         continue;
       }

--- a/clients/traycer-cli/src/store/cli-lock.ts
+++ b/clients/traycer-cli/src/store/cli-lock.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { open, readFile, stat, unlink } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import { hostname as osHostname } from "node:os";
@@ -61,6 +62,10 @@ export interface CliLockMetadata {
   readonly reason: string;
   readonly startedAt: string;
   readonly hostname: string | null;
+  // Per-acquisition nonce so `release()` can verify it still owns the file
+  // before unlinking (see `tryAcquireOnce`). `null` only for a lock written
+  // by a pre-token CLI version - never written by this code.
+  readonly token: string | null;
 }
 
 export interface CliLockHandle {
@@ -90,6 +95,17 @@ const MIN_POLL_MS = 25;
 // land within milliseconds of the open(), so any empty lock file older
 // than this grace window has no live owner and is safe to break.
 const EMPTY_LOCK_GRACE_MS = 5000;
+
+// `isProcessAlive` only proves *some* process currently owns the recorded
+// PID, not that it's the same process that wrote the lock - the OS is free
+// to recycle a PID onto an unrelated process once the original holder
+// exits, and that impostor would otherwise be read as "alive" forever
+// (silently for a same-user reuse, or via the EPERM conservative branch for
+// a different-user reuse). This ceiling is the backstop: no matter how the
+// PID check reads, a lock older than this is force-broken. Generous enough
+// to cover a slow host install (no download timeout today) while still
+// bounding a truly stuck lock to a tolerable wait.
+const MAX_LOCK_AGE_MS = 10 * 60 * 1000;
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -139,6 +155,12 @@ async function readLockMetadata(path: string): Promise<CliLockMetadata | null> {
     reason: obj.reason,
     startedAt: obj.startedAt,
     hostname: typeof obj.hostname === "string" ? obj.hostname : null,
+    // Deliberately not required above alongside pid/reason/startedAt: a
+    // lock written by a pre-token CLI version (e.g. mid self-upgrade with
+    // mixed versions momentarily on disk) must still parse as a valid,
+    // live-checkable holder rather than be swept as "corrupt" on the
+    // 5-second empty-lock grace window.
+    token: typeof obj.token === "string" ? obj.token : null,
   };
 }
 
@@ -210,7 +232,22 @@ async function tryAcquireOnce(
       } catch {
         // Closing twice is a no-op for callers; ignore.
       }
+      // Compare-and-delete: only unlink if the file still carries the token
+      // this handle wrote. If a staleness check (this bug, or a future
+      // false positive) ever broke this lock and someone else re-acquired
+      // it while we were still alive, blindly unlinking here would delete
+      // *their* lock out from under them. A file with no token at all is a
+      // pre-token-version lock (never written by this code) - fall back to
+      // the old unconditional unlink, since there is nothing to compare.
       try {
+        const current = await readLockMetadata(path);
+        if (
+          current !== null &&
+          current.token !== null &&
+          current.token !== meta.token
+        ) {
+          return;
+        }
         await unlink(path);
       } catch {
         // If the file already vanished (e.g. swept by another tool), that's fine.
@@ -233,6 +270,7 @@ export async function acquireCliLock(
     reason: opts.reason,
     startedAt: nowIso(),
     hostname: hostnameSafe(),
+    token: randomUUID(),
   };
   const pollMs = Math.max(MIN_POLL_MS, opts.pollIntervalMs);
   const deadline = Date.now() + Math.max(0, opts.waitMs);
@@ -241,7 +279,12 @@ export async function acquireCliLock(
     if (attempt !== "held") return attempt;
     const holder = await readLockMetadata(path);
     if (holder !== null) {
-      if (!holderAlive(holder.pid)) {
+      // Age is checked regardless of what the PID check concludes - a
+      // recycled-PID impostor would otherwise be read as "alive" forever
+      // (see MAX_LOCK_AGE_MS above), so no amount of PID-liveness confidence
+      // exempts a lock from this ceiling.
+      const ageMs = Date.now() - new Date(holder.startedAt).getTime();
+      if (!holderAlive(holder.pid) || ageMs >= MAX_LOCK_AGE_MS) {
         await breakStaleLock(path);
         continue;
       }


### PR DESCRIPTION
## Summary

A user reported `traycer host update` permanently failing with `another traycer CLI mutation is in progress (holder.pid=..., reason=host-update, ...)`. Killing every Traycer process didn't clear it; deleting `~/.traycer/cli/.lock` by hand did.

Root cause: `cli-lock.ts`'s staleness check uses `process.kill(pid, 0)` to decide if a lock holder is still alive, but that only proves *some* process currently owns that PID — not that it's the original holder. Once the holder died, a recycled PID (same-user reuse read as alive silently, or different-user reuse hitting the existing `EPERM` "be conservative" branch) got treated as alive forever, wedging the lock with no self-recovery.

- Add an age-ceiling backstop (`MAX_LOCK_AGE_MS`, 10 min) that force-breaks a lock regardless of what the PID-liveness check concludes.
- Add a per-acquisition token to the lock metadata so `release()` does compare-and-delete instead of an unconditional unlink, closing a related torn-lock hazard (a false-positive break could otherwise let the original, still-alive holder delete a legitimate new holder's lock out from under it when it finishes). A missing token (pre-fix lock format) falls back to the old unconditional unlink for cross-version compatibility.
- Separately, `host update` was the one lock-guarded command that never checked whether the host had work in progress before restarting it (unlike `provisionHost`'s `assertHostNotBusy` gate used by install/uninstall/service-cycle). It now runs the same busy check, skippable with a new `--force` flag matching `host ensure`.

## Test plan

- [x] `bunx nx run @traycer-clients/traycer-cli:compile`
- [x] `bunx nx run @traycer-clients/traycer-cli:lint`
- [x] `bunx nx run @traycer-clients/traycer-cli:test` (347 tests, including 16 new: `store/__tests__/cli-lock.test.ts` and `commands/__tests__/host-update.test.ts`)
- [x] New regression test reproduces the exact reported failure mode: a lock with an alive `pid` but a `startedAt` past the age ceiling is broken instead of hanging until `waitMs`