### PR TITLE
fix(gui-app): fix runStatus-vs-activeTurn regressions from background-only phase

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
-import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
+import type {
+  ChatActiveTurn,
+  ChatQueueState,
+  ChatRunSettings,
+} from "@traycer/protocol/host/agent/gui/subscribe";
 import type { ChatMessage } from "@/stores/composer/chat-store";
 import {
   chatMessageEditingForInlineEdit,
+  composerStopTurnStatus,
   type InlineEditState,
 } from "../chat-tile-session-state";
 
@@ -81,5 +86,139 @@ describe("chatMessageEditingForInlineEdit", () => {
   it("requires a dirty edit before enabling submit", () => {
     expect(renderInlineEdit(false).canSubmit).toBe(false);
     expect(renderInlineEdit(true).canSubmit).toBe(true);
+  });
+});
+
+const ACTIVE_TURN: ChatActiveTurn = {
+  turnId: "turn-1",
+  status: "running",
+  harnessId: "codex",
+  model: "codex-test",
+  reasoningEffort: null,
+  serviceTier: null,
+  agentMode: "epic",
+  userMessageId: "message-1",
+  startedAt: 0,
+  updatedAt: 0,
+};
+
+const EMPTY_QUEUE: ChatQueueState = { status: "idle", items: [] };
+
+function runnableQueue(itemCount: number): ChatQueueState {
+  return {
+    status: "running",
+    items: Array.from({ length: itemCount }, (_, index) => ({
+      queueItemId: `item-${index}`,
+      messageId: `message-${index}`,
+      message: { kind: "user" as const, content: CONTENT },
+      sender: { type: "user" as const, userId: "owner-1" },
+      settings: SETTINGS,
+      accountContext: { type: "PERSONAL" as const },
+      delivery: "next_turn" as const,
+      status: "pending" as const,
+      targetTurnId: null,
+      steerRequest: null,
+      fallbackReason: null,
+      createdAt: 0,
+      updatedAt: 0,
+    })),
+  };
+}
+
+describe("composerStopTurnStatus", () => {
+  it("passes null through unchanged (idle chat)", () => {
+    expect(
+      composerStopTurnStatus(
+        { activeTurn: null, queue: EMPTY_QUEUE, backgroundItems: undefined },
+        null,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns the turn status when a turn is genuinely active", () => {
+    expect(
+      composerStopTurnStatus(
+        {
+          activeTurn: ACTIVE_TURN,
+          queue: EMPTY_QUEUE,
+          backgroundItems: undefined,
+        },
+        "running",
+      ),
+    ).toBe("running");
+  });
+
+  it("returns the turn status when a turn is genuinely active even alongside a queued item or background work", () => {
+    expect(
+      composerStopTurnStatus(
+        {
+          activeTurn: ACTIVE_TURN,
+          queue: runnableQueue(1),
+          backgroundItems: [
+            { taskId: "t1", kind: "subagent", title: "Sub", blockId: "t1" },
+          ],
+        },
+        "running",
+      ),
+    ).toBe("running");
+  });
+
+  it("falls back to null when runStatus is running purely because of a pending queued item (no active turn)", () => {
+    expect(
+      composerStopTurnStatus(
+        {
+          activeTurn: null,
+          queue: runnableQueue(1),
+          backgroundItems: undefined,
+        },
+        "running",
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to null when runStatus is running purely because of visible background work (no active turn) - the reported regression", () => {
+    expect(
+      composerStopTurnStatus(
+        {
+          activeTurn: null,
+          queue: EMPTY_QUEUE,
+          backgroundItems: [
+            { taskId: "t1", kind: "subagent", title: "Sub", blockId: "t1" },
+          ],
+        },
+        "running",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps the turn status when running is explained by neither the queue nor background work (the pre-turn activating window)", () => {
+    expect(
+      composerStopTurnStatus(
+        { activeTurn: null, queue: EMPTY_QUEUE, backgroundItems: undefined },
+        "running",
+      ),
+    ).toBe("running");
+  });
+
+  it("a paused queue with pending items does not count as runnable", () => {
+    expect(
+      composerStopTurnStatus(
+        {
+          activeTurn: null,
+          queue: { status: "paused", items: runnableQueue(1).items },
+          backgroundItems: undefined,
+        },
+        "running",
+      ),
+    ).toBe("running");
+  });
+
+  it("an empty backgroundItems array does not count as visible background work", () => {
+    expect(
+      composerStopTurnStatus(
+        { activeTurn: null, queue: EMPTY_QUEUE, backgroundItems: [] },
+        "running",
+      ),
+    ).toBe("running");
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -8,7 +8,7 @@ import type {
 import type { ChatMessage } from "@/stores/composer/chat-store";
 import {
   chatMessageEditingForInlineEdit,
-  composerStopTurnStatus,
+  resolvedTurnStatus,
   type InlineEditState,
 } from "../chat-tile-session-state";
 
@@ -125,11 +125,16 @@ function runnableQueue(itemCount: number): ChatQueueState {
   };
 }
 
-describe("composerStopTurnStatus", () => {
+describe("resolvedTurnStatus - no turnInProgress from the host (older-host fallback heuristic)", () => {
   it("passes null through unchanged (idle chat)", () => {
     expect(
-      composerStopTurnStatus(
-        { activeTurn: null, queue: EMPTY_QUEUE, backgroundItems: undefined },
+      resolvedTurnStatus(
+        {
+          activeTurn: null,
+          queue: EMPTY_QUEUE,
+          backgroundItems: undefined,
+          turnInProgress: undefined,
+        },
         null,
       ),
     ).toBeNull();
@@ -137,11 +142,12 @@ describe("composerStopTurnStatus", () => {
 
   it("returns the turn status when a turn is genuinely active", () => {
     expect(
-      composerStopTurnStatus(
+      resolvedTurnStatus(
         {
           activeTurn: ACTIVE_TURN,
           queue: EMPTY_QUEUE,
           backgroundItems: undefined,
+          turnInProgress: undefined,
         },
         "running",
       ),
@@ -150,13 +156,14 @@ describe("composerStopTurnStatus", () => {
 
   it("returns the turn status when a turn is genuinely active even alongside a queued item or background work", () => {
     expect(
-      composerStopTurnStatus(
+      resolvedTurnStatus(
         {
           activeTurn: ACTIVE_TURN,
           queue: runnableQueue(1),
           backgroundItems: [
             { taskId: "t1", kind: "subagent", title: "Sub", blockId: "t1" },
           ],
+          turnInProgress: undefined,
         },
         "running",
       ),
@@ -165,11 +172,12 @@ describe("composerStopTurnStatus", () => {
 
   it("falls back to null when runStatus is running purely because of a pending queued item (no active turn)", () => {
     expect(
-      composerStopTurnStatus(
+      resolvedTurnStatus(
         {
           activeTurn: null,
           queue: runnableQueue(1),
           backgroundItems: undefined,
+          turnInProgress: undefined,
         },
         "running",
       ),
@@ -178,13 +186,14 @@ describe("composerStopTurnStatus", () => {
 
   it("falls back to null when runStatus is running purely because of visible background work (no active turn) - the reported regression", () => {
     expect(
-      composerStopTurnStatus(
+      resolvedTurnStatus(
         {
           activeTurn: null,
           queue: EMPTY_QUEUE,
           backgroundItems: [
             { taskId: "t1", kind: "subagent", title: "Sub", blockId: "t1" },
           ],
+          turnInProgress: undefined,
         },
         "running",
       ),
@@ -193,8 +202,13 @@ describe("composerStopTurnStatus", () => {
 
   it("keeps the turn status when running is explained by neither the queue nor background work (the pre-turn activating window)", () => {
     expect(
-      composerStopTurnStatus(
-        { activeTurn: null, queue: EMPTY_QUEUE, backgroundItems: undefined },
+      resolvedTurnStatus(
+        {
+          activeTurn: null,
+          queue: EMPTY_QUEUE,
+          backgroundItems: undefined,
+          turnInProgress: undefined,
+        },
         "running",
       ),
     ).toBe("running");
@@ -202,11 +216,12 @@ describe("composerStopTurnStatus", () => {
 
   it("a paused queue with pending items does not count as runnable", () => {
     expect(
-      composerStopTurnStatus(
+      resolvedTurnStatus(
         {
           activeTurn: null,
           queue: { status: "paused", items: runnableQueue(1).items },
           backgroundItems: undefined,
+          turnInProgress: undefined,
         },
         "running",
       ),
@@ -215,10 +230,89 @@ describe("composerStopTurnStatus", () => {
 
   it("an empty backgroundItems array does not count as visible background work", () => {
     expect(
-      composerStopTurnStatus(
-        { activeTurn: null, queue: EMPTY_QUEUE, backgroundItems: [] },
+      resolvedTurnStatus(
+        {
+          activeTurn: null,
+          queue: EMPTY_QUEUE,
+          backgroundItems: [],
+          turnInProgress: undefined,
+        },
         "running",
       ),
     ).toBe("running");
+  });
+
+  it("known gap: a turn still activating with another item queued behind it is (incorrectly) treated as not active", () => {
+    // Documents the precision gap the host-sent `turnInProgress` layer
+    // exists to close - see the next describe block.
+    expect(
+      resolvedTurnStatus(
+        {
+          activeTurn: null,
+          queue: runnableQueue(1),
+          backgroundItems: undefined,
+          turnInProgress: undefined,
+        },
+        "running",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("resolvedTurnStatus - turnInProgress present (host-sent, exact)", () => {
+  it("turnInProgress: true overrides the heuristic even when it would say not-active (closes the activating+queued-behind gap)", () => {
+    expect(
+      resolvedTurnStatus(
+        {
+          activeTurn: null,
+          queue: runnableQueue(1),
+          backgroundItems: undefined,
+          turnInProgress: true,
+        },
+        "running",
+      ),
+    ).toBe("running");
+  });
+
+  it("turnInProgress: false overrides the heuristic even when it would say active (background-only phase)", () => {
+    expect(
+      resolvedTurnStatus(
+        {
+          activeTurn: null,
+          queue: EMPTY_QUEUE,
+          backgroundItems: undefined,
+          turnInProgress: false,
+        },
+        "running",
+      ),
+    ).toBeNull();
+  });
+
+  it("turnInProgress: false wins even when activeTurn is (unexpectedly) non-null", () => {
+    expect(
+      resolvedTurnStatus(
+        {
+          activeTurn: ACTIVE_TURN,
+          queue: EMPTY_QUEUE,
+          backgroundItems: undefined,
+          turnInProgress: false,
+        },
+        "running",
+      ),
+    ).toBeNull();
+  });
+
+  it("null turnStatus (already idle) short-circuits regardless of turnInProgress", () => {
+    expect(
+      resolvedTurnStatus(
+        {
+          activeTurn: null,
+          queue: EMPTY_QUEUE,
+          backgroundItems: undefined,
+          turnInProgress: true,
+        },
+        null,
+      ),
+    ).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -171,6 +171,42 @@ export function composerTurnStatus(
   return null;
 }
 
+/**
+ * Narrows {@link composerTurnStatus} to the question the composer's Stop/Send
+ * toggle actually needs: is there a turn the host would let us stop right
+ * now? `runStatus` also reads "running" while a queued item is pending or
+ * visible background work outlives the turn (Bash `run_in_background` / a
+ * subagent / Monitor) - neither of which the host's `stop` action can act on
+ * (it rejects with `NO_ACTIVE_TURN`). Background work already has its own
+ * "stop all background" control, so rather than show a live-but-broken Stop
+ * button, this falls back to `null` - the composer's normal Send state -
+ * exactly as if the chat were idle.
+ *
+ * `activeTurn !== null` covers a genuinely running (or stopping) turn
+ * directly. When it's null but `runStatus` still reads "running", process of
+ * elimination against the queue/background signals is the only way to tell a
+ * pre-turn "activating" window (stoppable) apart from a queue-only or
+ * background-only one (not stoppable) - both look identical on the wire
+ * otherwise.
+ *
+ * Known gap: if a turn is still activating AND another item is queued behind
+ * it, the queue signal is also "runnable", so this can't distinguish that
+ * from a queue-only state and will (narrowly, incorrectly) fall back to Send
+ * during that brief pre-turn window. A precise fix needs a host-sent signal;
+ * not worth a wire-protocol change for this edge.
+ */
+export function composerStopTurnStatus(
+  state: Pick<ChatSessionState, "activeTurn" | "queue" | "backgroundItems">,
+  turnStatus: ChatActiveTurn["status"] | null,
+): ChatActiveTurn["status"] | null {
+  if (turnStatus === null) return null;
+  if (state.activeTurn !== null) return turnStatus;
+  const isQueueRunnable =
+    state.queue.status !== "paused" && state.queue.items.length > 0;
+  const hasVisibleBackgroundWork = (state.backgroundItems?.length ?? 0) > 0;
+  return isQueueRunnable || hasVisibleBackgroundWork ? null : turnStatus;
+}
+
 export function normalizeInlineEditForSession(
   inlineEdit: InlineEditState | null,
   state: Pick<

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -1,7 +1,6 @@
 import { toast } from "sonner";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
-  ChatActiveTurn,
   ChatRunSettings,
   ChatRunStatus,
 } from "@traycer/protocol/host/agent/gui/subscribe";
@@ -159,47 +158,67 @@ export function chatTileUiReducer(
 // ── Pure session helpers (no React dependency) ────────────────────────────────
 
 /**
+ * The composer's turn-status prop shape - a strict subset of
+ * `ChatActiveTurn["status"]` (which also carries terminal values like
+ * `"completed"`/`"errored"` that never apply here). Narrower than that wider
+ * type so callers like `useRenderedMessages`'s `runStatus: ChatRunStatus`
+ * input can consume it directly (`"running"`/`"stopping"` overlap exactly;
+ * `null` maps to `"idle"`).
+ */
+export type ComposerTurnStatus = "running" | "stopping" | null;
+
+/**
  * Maps the host-owned chat `runStatus` onto the composer's turn-status prop
  * shape. `running` shows the stop button, `stopping` shows the "Stopping"
  * affordance, `idle` returns the composer to its send state.
  */
 export function composerTurnStatus(
   runStatus: ChatRunStatus,
-): ChatActiveTurn["status"] | null {
+): ComposerTurnStatus {
   if (runStatus === "running") return "running";
   if (runStatus === "stopping") return "stopping";
   return null;
 }
 
 /**
- * Narrows {@link composerTurnStatus} to the question the composer's Stop/Send
- * toggle actually needs: is there a turn the host would let us stop right
- * now? `runStatus` also reads "running" while a queued item is pending or
- * visible background work outlives the turn (Bash `run_in_background` / a
- * subagent / Monitor) - neither of which the host's `stop` action can act on
- * (it rejects with `NO_ACTIVE_TURN`). Background work already has its own
- * "stop all background" control, so rather than show a live-but-broken Stop
- * button, this falls back to `null` - the composer's normal Send state -
- * exactly as if the chat were idle.
+ * Narrows {@link composerTurnStatus} to the question every turn-scoped
+ * consumer actually needs - the composer's Stop/Send toggle, restore/revert
+ * gating, and the per-row "Working…"/"Stopping…" indicator: is there a turn
+ * genuinely active or activating right now? `runStatus` also reads "running"
+ * while a queued item is pending or visible background work outlives the
+ * turn (Bash `run_in_background` / a subagent / Monitor) - neither of which
+ * corresponds to an active turn. Background work already has its own
+ * "stop all background" control, so rather than show a Stop button that
+ * would fail, block a restore that isn't actually unsafe, or duplicate the
+ * row indicator after the real turn already settled, this falls back to
+ * `null` - exactly as if the chat were idle.
  *
- * `activeTurn !== null` covers a genuinely running (or stopping) turn
- * directly. When it's null but `runStatus` still reads "running", process of
- * elimination against the queue/background signals is the only way to tell a
- * pre-turn "activating" window (stoppable) apart from a queue-only or
- * background-only one (not stoppable) - both look identical on the wire
- * otherwise.
- *
- * Known gap: if a turn is still activating AND another item is queued behind
- * it, the queue signal is also "runnable", so this can't distinguish that
- * from a queue-only state and will (narrowly, incorrectly) fall back to Send
- * during that brief pre-turn window. A precise fix needs a host-sent signal;
- * not worth a wire-protocol change for this edge.
+ * Two layers, in priority order:
+ *  1. `state.turnInProgress`, when present - the host's own
+ *     `isTurnInProgress()`, sent verbatim. Exact, no known gaps.
+ *  2. A local approximation, for an older host that predates the field:
+ *     `activeTurn !== null` covers a genuinely running (or stopping) turn
+ *     directly. When it's null but `runStatus` still reads "running",
+ *     process of elimination against the queue/background signals is the
+ *     only way to tell a pre-turn "activating" window (active) apart from a
+ *     queue-only or background-only one (not active) - both look identical
+ *     on the wire otherwise. Known gap: if a turn is still activating AND
+ *     another item is queued behind it, the queue signal is also "runnable",
+ *     so this can't distinguish that from a queue-only state and will
+ *     (narrowly, incorrectly) fall back to `null` during that brief pre-turn
+ *     window. Layer 1 closes this gap whenever the host supports it.
  */
-export function composerStopTurnStatus(
-  state: Pick<ChatSessionState, "activeTurn" | "queue" | "backgroundItems">,
-  turnStatus: ChatActiveTurn["status"] | null,
-): ChatActiveTurn["status"] | null {
+export function resolvedTurnStatus(
+  state: Pick<
+    ChatSessionState,
+    "activeTurn" | "queue" | "backgroundItems" | "turnInProgress"
+  >,
+  turnStatus: ComposerTurnStatus,
+): ComposerTurnStatus {
   if (turnStatus === null) return null;
+  if (state.turnInProgress !== undefined) {
+    return state.turnInProgress ? turnStatus : null;
+  }
   if (state.activeTurn !== null) return turnStatus;
   const isQueueRunnable =
     state.queue.status !== "paused" && state.queue.items.length > 0;

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -166,6 +166,7 @@ import {
   userMessageSenderForProfile,
   plainTextPromptContent,
   composerTurnStatus,
+  composerStopTurnStatus,
   chatTileCanAct,
   findPendingInterview,
 } from "./chat-tile-session-state";
@@ -978,14 +979,20 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const approvalDecisionPending = Object.values(state.pendingActions).some(
     (action) => action.action === "approvalDecision",
   );
-  // In-progress UI (composer stop button, restore gating, owner-active) is
-  // driven by the host-owned chat `runStatus` - the single source of truth
-  // that covers the first turn and every multi-turn send and flips to
-  // `stopping` the moment a stop is requested. We map it onto the composer's
-  // turn-status prop shape (`running`/`stopping`/null).
+  // In-progress UI (restore gating, owner-active) is driven by the host-owned
+  // chat `runStatus` - the single source of truth that covers the first turn
+  // and every multi-turn send and flips to `stopping` the moment a stop is
+  // requested. We map it onto the composer's turn-status prop shape
+  // (`running`/`stopping`/null).
   const activeTurnStatus = composerTurnStatus(state.runStatus);
+  // The composer's Stop/Send toggle needs a narrower question than the label
+  // above - see `composerStopTurnStatus`'s doc comment.
+  const composerActiveTurnStatus = composerStopTurnStatus(
+    state,
+    activeTurnStatus,
+  );
   const stopDisabled =
-    !canAct || stopPending || activeTurnStatus === "stopping";
+    !canAct || stopPending || composerActiveTurnStatus === "stopping";
   const chatActions = useChatActions(handle);
   const restoreActionPending = useMemo(
     () =>
@@ -1362,11 +1369,11 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
 
   const lowerTurn = useMemo(
     () => ({
-      activeTurnStatus,
+      activeTurnStatus: composerActiveTurnStatus,
       stopDisabled,
       onStopTurn: chatActions.stopTurn,
     }),
-    [activeTurnStatus, stopDisabled, chatActions.stopTurn],
+    [composerActiveTurnStatus, stopDisabled, chatActions.stopTurn],
   );
 
   const lowerInterview = useMemo(

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -166,7 +166,7 @@ import {
   userMessageSenderForProfile,
   plainTextPromptContent,
   composerTurnStatus,
-  composerStopTurnStatus,
+  resolvedTurnStatus,
   chatTileCanAct,
   findPendingInterview,
 } from "./chat-tile-session-state";
@@ -778,6 +778,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       queue: s.queue,
       runStatus: s.runStatus,
       activeTurn: s.activeTurn,
+      turnInProgress: s.turnInProgress,
       pendingApprovals: s.pendingApprovals,
       pendingFileEditApprovals: s.pendingFileEditApprovals,
       pendingInterviews: s.pendingInterviews,
@@ -891,6 +892,21 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     [displayContext],
   );
   const activeTurnId = state.activeTurn?.turnId ?? null;
+  // In-progress UI (restore gating, owner-active, the per-row "Working…" /
+  // "Stopping…" indicator below) is driven by the host-owned chat
+  // `runStatus` - the single source of truth that covers the first turn and
+  // every multi-turn send and flips to `stopping` the moment a stop is
+  // requested. We map it onto the composer's turn-status prop shape
+  // (`running`/`stopping`/null).
+  const activeTurnStatus = composerTurnStatus(state.runStatus);
+  // Several consumers below (the row indicator, the composer Stop/Send
+  // toggle, restore gating) need a narrower question than the label above:
+  // `runStatus` also reads "running" while a queued item is pending or
+  // visible background work outlives the turn (Bash `run_in_background` / a
+  // subagent / Monitor) - neither of which corresponds to an active turn
+  // they can act on or attribute an indicator to. See
+  // `resolvedTurnStatus`'s doc comment for the exact derivation.
+  const composerActiveTurnStatus = resolvedTurnStatus(state, activeTurnStatus);
   const renderedMessages = useRenderedMessages(
     {
       messages: state.messages,
@@ -901,7 +917,12 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       pendingApprovals: state.pendingApprovals,
       pendingFileEditApprovals: state.pendingFileEditApprovals,
       pendingInterviews: state.pendingInterviews,
-      runStatus: state.runStatus,
+      // Narrowed, not the raw `state.runStatus`: this drives the per-row
+      // "Working…"/"Stopping…" indicator, which belongs to a genuinely
+      // active turn - passing the raw value synthesizes a duplicate, live
+      // indicator row during background-only phase (no active turn) even
+      // after the real row has already settled to its "done" footer.
+      runStatus: composerActiveTurnStatus ?? "idle",
       // Binding identity for the in-transcript setup card (replaces the old
       // strip's mount-time tuple): epic + chat owner route the retry mutation
       // and scope the terminal-liveness query; `viewTabId` rides the synthetic
@@ -979,18 +1000,6 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const approvalDecisionPending = Object.values(state.pendingActions).some(
     (action) => action.action === "approvalDecision",
   );
-  // In-progress UI (restore gating, owner-active) is driven by the host-owned
-  // chat `runStatus` - the single source of truth that covers the first turn
-  // and every multi-turn send and flips to `stopping` the moment a stop is
-  // requested. We map it onto the composer's turn-status prop shape
-  // (`running`/`stopping`/null).
-  const activeTurnStatus = composerTurnStatus(state.runStatus);
-  // The composer's Stop/Send toggle needs a narrower question than the label
-  // above - see `composerStopTurnStatus`'s doc comment.
-  const composerActiveTurnStatus = composerStopTurnStatus(
-    state,
-    activeTurnStatus,
-  );
   const stopDisabled =
     !canAct || stopPending || composerActiveTurnStatus === "stopping";
   const chatActions = useChatActions(handle);
@@ -1021,7 +1030,15 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       accessRole: state.access?.role ?? null,
       currentUserId,
       activeHostId,
-      activeTurnStatus,
+      // Restoring/reverting files while a turn is actively writing is unsafe,
+      // but that's a turn-scoped concern, same as the composer's Stop button -
+      // `runStatus` alone also reads non-idle during background-only phase
+      // (Bash `run_in_background` / a subagent / Monitor with no active
+      // turn), which restore/revert can't conflict with. Use the same
+      // narrowed value the Stop button uses instead of the raw one, or this
+      // would show "Wait for the active turn to finish" and block restore
+      // during a window where nothing is actually running against it.
+      activeTurnStatus: composerActiveTurnStatus,
       localSnapshotsClearedAt: localSnapshotClearMarker,
       restore: state.restore,
       restoreActionPending,
@@ -1032,7 +1049,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     [
       accumulatedFileChanges,
       activeHostId,
-      activeTurnStatus,
+      composerActiveTurnStatus,
       chatActions.restoreCheckpoint,
       chatActions.revertFileChanges,
       currentUserId,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -309,6 +309,7 @@ function ChatTileFallbackComposer(props: {
           ownerId: props.node.id,
           binding: null,
           isOwnerActive: false,
+          hasActiveTurn: false,
           // Pre-subscribe setup state: no binding resolved yet, so the chip shows
           // its loading affordance (never a "no folders" terminal state).
           missingWorktreePaths: [],
@@ -1333,6 +1334,14 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
           ownerId: node.id,
           binding: state.worktreeBinding,
           isOwnerActive: activeTurnStatus !== null,
+          // Distinguishes WHY the owner reads active, for the disabled-remove
+          // tooltip wording only (the disable decision itself stays on the
+          // broader `isOwnerActive`, unchanged - a live background Bash/Monitor
+          // could still be reading or writing in the folder even with no
+          // foreground turn active). `false` here means it's active purely
+          // because of visible background work, not a turn the "stop" wording
+          // would make sense for.
+          hasActiveTurn: composerActiveTurnStatus !== null,
           missingWorktreePaths: effectiveMissingPaths,
           bindingResolved: state.snapshotLoaded,
           onBindingCommitted: clearMissingPathsAfterBindingCommit,
@@ -1347,6 +1356,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       effectiveMissingPaths,
       state.snapshotLoaded,
       activeTurnStatus,
+      composerActiveTurnStatus,
       clearMissingPathsAfterBindingCommit,
       viewTabId,
     ],

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -688,6 +688,11 @@ function TerminalAgentPreLaunchToolbar(
           ownerId: props.agent.id,
           binding,
           isOwnerActive: props.isOwnerActive,
+          // Terminal agents have no background-work-outlives-the-turn concept
+          // distinct from PTY output (unlike chat), so there's no narrower
+          // signal to distinguish - this field is unread for this surface kind
+          // (the notice text is fixed regardless), kept equal for consistency.
+          hasActiveTurn: props.isOwnerActive,
           // Surfaced on the chip as a per-folder "missing on disk" indicator.
           // The host-computed signal on `worktree.getBinding` — the actual
           // launch gate is the `prepareLaunch` WORKTREE_MISSING reject, but this

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/active-run-notice.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/active-run-notice.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { activeRunNoticeFor } from "../active-run-notice";
+
+describe("activeRunNoticeFor", () => {
+  it("tells the user to stop the active run when a turn is genuinely active", () => {
+    expect(activeRunNoticeFor("chat", true)).toBe(
+      "Stop the active run before rebinding",
+    );
+  });
+
+  it("tells the user to wait for background tasks when the owner is active purely from background work - the reported regression", () => {
+    expect(activeRunNoticeFor("chat", false)).toBe(
+      "Wait for background tasks to complete before rebinding",
+    );
+  });
+
+  it("always shows the terminal-restart notice for a terminal agent, regardless of hasActiveTurn", () => {
+    expect(activeRunNoticeFor("terminal-agent", true)).toBe(
+      "Terminal will restart after rebinding",
+    );
+    expect(activeRunNoticeFor("terminal-agent", false)).toBe(
+      "Terminal will restart after rebinding",
+    );
+  });
+});

--- a/clients/gui-app/src/components/home/host-workspace-selector/active-run-notice.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/active-run-notice.ts
@@ -1,0 +1,20 @@
+/**
+ * The disabled-remove tooltip's wording for a bound owner surface that reads
+ * active. `isOwnerActive` alone doesn't say why - it also reads true for
+ * visible background work (Bash `run_in_background` / a subagent / Monitor)
+ * outliving an already-completed turn, where there is no active run to stop,
+ * only background tasks to wait out. `hasActiveTurn` distinguishes the two;
+ * it is ignored for `"terminal-agent"`, which has no background-work-outlives-
+ * the-turn concept distinct from PTY output.
+ */
+export function activeRunNoticeFor(
+  surfaceKind: "chat" | "terminal-agent",
+  hasActiveTurn: boolean,
+): string {
+  if (surfaceKind === "terminal-agent") {
+    return "Terminal will restart after rebinding";
+  }
+  return hasActiveTurn
+    ? "Stop the active run before rebinding"
+    : "Wait for background tasks to complete before rebinding";
+}

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -12,6 +12,7 @@ import { useIsMutating } from "@tanstack/react-query";
 import { workspaceMutationKeys } from "@/lib/query-keys";
 import { DropdownMenuLabel } from "@/components/ui/dropdown-menu";
 import { HostSection } from "./host-section";
+import { activeRunNoticeFor } from "./active-run-notice";
 import type {
   WorktreeBinding,
   WorktreeBindingEntry,
@@ -121,6 +122,13 @@ type BoundOwnerSurface = {
   readonly ownerId: string;
   readonly binding: WorktreeBinding | null;
   readonly isOwnerActive: boolean;
+  // Narrower than `isOwnerActive`: is the owner active specifically because
+  // of a genuinely running/activating turn, as opposed to visible background
+  // work (Bash `run_in_background` / a subagent / Monitor) outliving an
+  // already-completed turn? Drives ONLY the disabled-remove tooltip wording -
+  // `isOwnerActive` still decides whether removal is disabled at all (a live
+  // background process could still be touching the folder either way).
+  readonly hasActiveTurn: boolean;
   // The `workspacePath`s whose bound directory is gone on disk (host-computed,
   // delivered on the chat snapshot / `worktreeStateChanged` for chat and on
   // `worktree.getBinding` for terminal-agents). Drives the per-folder "missing"
@@ -1579,10 +1587,10 @@ function InEpicSurface(props: InEpicSurfaceProps) {
           (entry) => entry.hostId === pendingCloneHostId,
         ) ?? null);
 
-  const activeRunNotice =
-    surface.kind === "terminal-agent"
-      ? "Terminal will restart after rebinding"
-      : "Stop the active run before rebinding";
+  const activeRunNotice = activeRunNoticeFor(
+    surface.kind,
+    surface.hasActiveTurn,
+  );
   const activeRunLocksBinding =
     surface.kind === "chat" && surface.isOwnerActive;
 

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -252,6 +252,17 @@ export interface ChatSessionState {
    */
   readonly runStatus: ChatRunStatus;
   readonly activeTurn: ChatActiveTurn | null;
+  /**
+   * The host's own `isTurnInProgress()`: is a turn genuinely active or
+   * activating right now? Narrower than `runStatus !== "idle"`, which also
+   * reads "running" for a pending queued item or visible background work
+   * outliving the turn - neither of which this corresponds to. `undefined`
+   * means an older host that predates this field; consumers should fall back
+   * to their own `runStatus`/`activeTurn`/`queue`/`backgroundItems`-derived
+   * approximation (see `chat-tile-session-state.ts`) rather than treat a
+   * missing value as a fixed true/false for the whole session.
+   */
+  readonly turnInProgress: boolean | undefined;
   readonly pendingApprovals: ReadonlyArray<ChatApprovalState>;
   readonly pendingFileEditApprovals: ReadonlyArray<ChatFileEditApprovalState>;
   readonly pendingInterviews: ReadonlyArray<ChatPendingInterviewState>;
@@ -718,6 +729,7 @@ export function createChatSessionStore(
             ),
             runStatus: frame.snapshot.runStatus,
             activeTurn: frame.snapshot.activeTurn,
+            turnInProgress: frame.snapshot.turnInProgress,
             pendingApprovals: frame.snapshot.pendingApprovals,
             pendingFileEditApprovals: frame.snapshot.pendingFileEditApprovals,
             pendingInterviews: frame.snapshot.pendingInterviews,
@@ -932,6 +944,7 @@ export function createChatSessionStore(
             messages: nextMessages,
             runStatus: frame.runStatus,
             activeTurn: frame.activeTurn,
+            turnInProgress: frame.turnInProgress ?? state.turnInProgress,
             backgroundItems: nextBackgroundItems,
             // Keep background-stop pending state in lockstep with the
             // running-only list: a task that has left the list settled, so its
@@ -1269,6 +1282,7 @@ export function createChatSessionStore(
       queue: EMPTY_QUEUE,
       runStatus: "idle",
       activeTurn: null,
+      turnInProgress: undefined,
       pendingApprovals: [],
       pendingFileEditApprovals: [],
       pendingInterviews: [],

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -99,9 +99,18 @@ export interface RenderedMessagesInput {
   readonly pendingFileEditApprovals?: ReadonlyArray<ChatFileEditApprovalState>;
   readonly pendingInterviews?: ReadonlyArray<ChatPendingInterviewState>;
   /**
-   * Host-owned chat run state. Drives the in-progress indicator on the
-   * active assistant turn's row (`running` → "Working…", `stopping` →
-   * "Stopping…"). `idle` leaves every row indicator-free.
+   * Drives the in-progress indicator on the active assistant turn's row
+   * (`running` → "Working…", `stopping` → "Stopping…"). `idle` leaves every
+   * row indicator-free.
+   *
+   * NOT the raw host `runStatus` - that also reads `"running"` while a
+   * queued item is pending or visible background work (Bash
+   * `run_in_background` / a subagent / Monitor) outlives the turn, neither of
+   * which this indicator belongs to. Passing it raw synthesizes a duplicate,
+   * live "Working…" row alongside the real turn's already-settled "done"
+   * footer. Pass the caller's narrowed turn-status derivation instead (see
+   * `resolvedTurnStatus` in `chat-tile-session-state.ts`), mapping its
+   * `null` to `"idle"`.
    */
   readonly runStatus: ChatRunStatus;
   /**

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -347,6 +347,20 @@ export const chatSnapshotSchema = z.object({
   // Background section and never sends stop actions; a present (possibly empty)
   // array means the controls are supported. This is the capability sentinel.
   backgroundItems: z.array(backgroundItemSchema).optional(),
+  // Whether the host considers a turn genuinely active or activating right
+  // now - exactly its own `isTurnInProgress()` (backs `stop`'s
+  // `NO_ACTIVE_TURN` rejection). Narrower than `runStatus !== "idle"`, which
+  // also reads "running" while a queued item is pending or visible
+  // background work outlives the turn - neither of which corresponds to an
+  // active turn. Consumers that need "is there a turn to stop/attribute an
+  // indicator to/block a restore against" should read this, not derive it
+  // from `runStatus`. OPTIONAL for the same rolling-update reason as
+  // `backgroundItems`: an older host omits it, and the renderer falls back to
+  // its own `runStatus`/`activeTurn`/`queue`/`backgroundItems`-derived
+  // approximation (see `chat-tile-session-state.ts`) rather than treating a
+  // missing value as either "always active" or "never active" - both would
+  // be wrong for the whole session against an older host.
+  turnInProgress: z.boolean().optional(),
 });
 export type ChatSnapshot = z.infer<typeof chatSnapshotSchema>;
 
@@ -406,6 +420,9 @@ export const chatSubscribeServerFrameSchema = z.discriminatedUnion("kind", [
     // Optional for the same capability-sentinel reason as the snapshot field; an
     // older host omits it and the renderer keeps its last snapshot value.
     backgroundItems: z.array(backgroundItemSchema).optional(),
+    // See `chatSnapshotSchema.turnInProgress` - same predicate, same
+    // optionality, same conservative-fallback contract.
+    turnInProgress: z.boolean().optional(),
   }),
   z.object({
     kind: z.literal("blockDelta"),


### PR DESCRIPTION
## Summary

A host-side fix made `runStatus` stay `"running"` after a chat's foreground turn ends, as long as visible background work (Bash `run_in_background` / a subagent / Monitor) is still live - intentional for presence/A2A. Several frontend consumers turned out to conflate that broader "chat is busy" signal with the narrower "there is an active turn" question, causing three related regressions:

1. **Composer Stop button** stayed clickable during background-only phase, throwing `"There is no active turn to stop."` on click.
2. **Restore checkpoint / revert file changes / "review all"** incorrectly blocked with "wait for the active turn to finish" during background-only phase, even though nothing conflicts with a restore.
3. **Duplicate status row**: the per-message "Working…"/"Stopping…" indicator kept synthesizing a live, ticking row alongside the real turn's already-settled "done" footer.

All three now go through one shared derivation, `resolvedTurnStatus()` (renamed from `composerStopTurnStatus`, since it's no longer composer-specific) in `chat-tile-session-state.ts`, computed once per render and reused everywhere.

### Two-layer design (added after initial review)

`resolvedTurnStatus()` now has two layers, in priority order:
1. **`state.turnInProgress`** (new, optional wire field mirroring the host's `isTurnInProgress()`), when the host sends it - exact, no known gaps.
2. **A local elimination heuristic** (`activeTurn` / `queue` / `backgroundItems`), for an older host that predates the field. Has one known, documented precision gap: a turn still activating with another item queued behind it looks identical, on the wire, to a queue-only idle state.

Layer 1 closes layer 2's gap when present; layer 2 remains the fallback - explicitly `undefined`-safe in both directions, so an older host can never leave a control permanently stuck enabled or disabled for the whole session (the earlier draft of this PR got that direction wrong; fixed after review).

A companion host-side PR (not yet raised - needs this to merge and the submodule pin to bump first) wires `turnInProgress: this.isTurnInProgress()` into `broadcastTurn()`/`emitSnapshotToSubscriber()` in `traycer-host`.

## Test plan
- [x] Unit tests for `resolvedTurnStatus()`: idle, genuinely active turn (with/without queue/background noise), queue-only, background-only (the original regression), pre-turn activating window, paused queue, empty background array, the known activating+queued-behind gap, and both `turnInProgress: true`/`false` override cases (19 tests total)
- [x] Full `clients/gui-app` test suite (451 files, 3534 tests) passes
- [x] Full submodule compile (`protocol`, `traycer-cli`, `desktop`, `gui-app`) clean