### PR TITLE
fix(gui-app): scroll broken in New Conversation modal's branch/worktree pickers

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -24,6 +24,7 @@ import {
   NO_SESSION_OBJECT_URL,
 } from "@/components/chat/composer/attachments/attachment-strip";
 import { useEpicImageFetcher } from "@/lib/attachments/use-attachment-blob-src";
+import { DialogOverlayBoundaryContext } from "@/providers/dialog-overlay-boundary-context";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
 import { createComposerPickerStore } from "@/components/chat/composer/picker/composer-picker-store";
 import { useComposerPickerItems } from "@/components/chat/composer/picker/use-composer-picker-items";
@@ -280,9 +281,19 @@ function NewConversationModalDialog(props: {
   // (first Escape closes only the picker); once it's closed the call returns
   // false and Escape falls through to dismiss the dialog (second Escape).
   const dismissPickerRef = useRef<(() => boolean) | null>(null);
+  // The workspace controls' nested Branch/Location popovers portal to
+  // `document.body` by default, landing as a DOM sibling of this dialog - the
+  // dialog's scroll-lock then swallows wheel input over their scrollable
+  // lists even though the lists themselves scroll fine (see
+  // `DialogOverlayBoundaryContext`). Publishing this dialog's own content node
+  // lets those nested overlays portal inside it instead, so the lock
+  // recognizes their content as its own.
+  const [overlayBoundaryEl, setOverlayBoundaryEl] =
+    useState<HTMLElement | null>(null);
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent
+        ref={setOverlayBoundaryEl}
         className="w-[min(92vw,48rem)] max-w-[min(92vw,48rem)] gap-3 p-4 sm:max-w-[min(92vw,48rem)]"
         data-testid="epic-sidebar-new-conversation-modal"
         data-leader-scope={LEADER_SCOPE_NEW_CONVERSATION_MODAL}
@@ -308,16 +319,18 @@ function NewConversationModalDialog(props: {
           New chat or terminal agent
         </DialogTitle>
         {props.open ? (
-          <SurfaceActivityProvider active>
-            <NewConversationModalBody
-              epicId={props.epicId}
-              tabId={props.tabId}
-              placement={props.placement}
-              parentId={props.parentId}
-              dismissPickerRef={dismissPickerRef}
-              onSubmitted={() => props.onOpenChange(false)}
-            />
-          </SurfaceActivityProvider>
+          <DialogOverlayBoundaryContext.Provider value={overlayBoundaryEl}>
+            <SurfaceActivityProvider active>
+              <NewConversationModalBody
+                epicId={props.epicId}
+                tabId={props.tabId}
+                placement={props.placement}
+                parentId={props.parentId}
+                dismissPickerRef={dismissPickerRef}
+                onSubmitted={() => props.onOpenChange(false)}
+              />
+            </SurfaceActivityProvider>
+          </DialogOverlayBoundaryContext.Provider>
         ) : null}
       </DialogContent>
     </Dialog>

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx
@@ -134,6 +134,7 @@ describe("FolderLocationControl", () => {
         <FolderLocationControl
           item={item(over)}
           uncommittedByPath={EMPTY_COUNTS}
+          boundaryEl={null}
           readOnly={false}
         />
       </TooltipProvider>,

--- a/clients/gui-app/src/components/home/host-workspace-selector/folder-branch-control.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/folder-branch-control.tsx
@@ -91,7 +91,6 @@ export function FolderBranchControl(props: {
           align="start"
           collisionPadding={12}
           container={props.boundaryEl ?? undefined}
-          collisionBoundary={props.boundaryEl ?? undefined}
           className="w-[min(92vw,22rem)] gap-0 p-2.5"
           data-testid="folder-branch-popover"
           onInteractOutside={(event) =>
@@ -179,7 +178,6 @@ export function FolderBranchControl(props: {
         align="start"
         collisionPadding={12}
         container={props.boundaryEl ?? undefined}
-        collisionBoundary={props.boundaryEl ?? undefined}
         className="w-[min(92vw,22rem)] gap-0 p-2.5"
         data-testid="folder-branch-popover"
         onInteractOutside={(event) =>

--- a/clients/gui-app/src/components/home/host-workspace-selector/folder-location-control.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/folder-location-control.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   Check,
   ChevronDown,
@@ -79,6 +79,8 @@ export function FolderLocationControl(props: {
   readonly item: WorkspaceRunItem;
   /** Host-wide uncommitted counts keyed by worktree path (optional annotation). */
   readonly uncommittedByPath: ReadonlyMap<string, number>;
+  /** Collision boundary for the menu (in-epic rows live in a popover). */
+  readonly boundaryEl: HTMLElement | null;
   readonly readOnly: boolean;
 }) {
   const { item } = props;
@@ -159,14 +161,36 @@ export function FolderLocationControl(props: {
   }
 
   return (
+    <FolderLocationMenu
+      item={item}
+      value={value}
+      trigger={trigger}
+      importRows={importRows}
+      uncommittedByPath={props.uncommittedByPath}
+      boundaryEl={props.boundaryEl}
+    />
+  );
+}
+
+function FolderLocationMenu(props: {
+  readonly item: WorkspaceRunItem;
+  readonly value: FolderLocationValue;
+  readonly trigger: ReactNode;
+  readonly importRows: ReadonlyArray<UnifiedPickerWorktreeRow>;
+  readonly uncommittedByPath: ReadonlyMap<string, number>;
+  readonly boundaryEl: HTMLElement | null;
+}) {
+  const { item, value, importRows } = props;
+  return (
     // Non-modal so the menu's focus scope doesn't trap focus back into the menu:
     // that trap is what stole the search autofocus in the "Existing worktree"
     // submenu (its search input lives outside the roving menu-item focus).
     <DropdownMenu modal={false}>
-      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuTrigger asChild>{props.trigger}</DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
         data-testid="folder-location-menu"
+        container={props.boundaryEl ?? undefined}
         className="w-[min(80vw,15rem)]"
       >
         <DropdownMenuItem

--- a/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
@@ -135,6 +135,7 @@ function FolderRowBody(props: {
       <FolderLocationControl
         item={item}
         uncommittedByPath={props.uncommittedByPath}
+        boundaryEl={props.boundaryEl}
         readOnly={props.readOnly}
       />
       <FolderBranchControl

--- a/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/workspace-folder-summary-control.tsx
@@ -10,6 +10,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { preserveWhenNestedOverlay } from "./preserve-when-nested-overlay";
+import { useDialogOverlayBoundaryEl } from "@/providers/dialog-overlay-boundary-context";
 import {
   AddFolderButton,
   type AddFolderHandler,
@@ -55,6 +56,12 @@ export function WorkspaceFolderSummaryControl(props: {
   // overlay (stacked above) from the host dialog (an ancestor) - see
   // preserveWhenNestedOverlay.
   const contentRef = useRef<HTMLDivElement>(null);
+  // Non-null only inside a modal dialog (the New Conversation modal) - see
+  // `DialogOverlayBoundaryContext`. Containing this popover inside the
+  // dialog's own DOM (instead of the default `document.body` portal) keeps it
+  // - and the branch/location popovers nested inside it - within the
+  // dialog's scroll-lock boundary, so wheel scrolling their lists works.
+  const dialogBoundaryEl = useDialogOverlayBoundaryEl();
 
   const handleExternalAddFolder = async (): Promise<boolean> => {
     setOverlayState({
@@ -163,6 +170,7 @@ export function WorkspaceFolderSummaryControl(props: {
         side={props.popoverSide}
         align="start"
         collisionPadding={12}
+        container={dialogBoundaryEl ?? undefined}
         className="w-fit max-w-[min(92vw,40rem)] max-h-[min(var(--radix-popover-content-available-height),32rem)] gap-0 overflow-y-auto p-3"
         data-testid={props.popoverTestId}
         onInteractOutside={(event) =>
@@ -181,7 +189,7 @@ export function WorkspaceFolderSummaryControl(props: {
           updatePending={props.updatePending}
           onEditEnvironment={props.onEditEnvironment}
           readOnly={false}
-          nestedInPopover={false}
+          nestedInPopover={dialogBoundaryEl !== null}
           bindingResolved={props.bindingResolved}
         />
       </PopoverContent>

--- a/clients/gui-app/src/components/ui/dropdown-menu.tsx
+++ b/clients/gui-app/src/components/ui/dropdown-menu.tsx
@@ -29,14 +29,23 @@ function DropdownMenuTrigger({
   );
 }
 
+type DropdownMenuContentProps = React.ComponentProps<
+  typeof DropdownMenuPrimitive.Content
+> & {
+  readonly container?: React.ComponentProps<
+    typeof DropdownMenuPrimitive.Portal
+  >["container"];
+};
+
 function DropdownMenuContent({
   className,
   align = "start",
   sideOffset = 4,
+  container,
   ...props
-}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+}: DropdownMenuContentProps) {
   return (
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={container}>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}

--- a/clients/gui-app/src/providers/dialog-overlay-boundary-context.ts
+++ b/clients/gui-app/src/providers/dialog-overlay-boundary-context.ts
@@ -1,0 +1,19 @@
+import { createContext, use } from "react";
+
+/**
+ * DOM node that nested Radix overlays (Popover/DropdownMenu) should portal
+ * into instead of `document.body`. A modal Radix `Dialog` runs a body
+ * scroll-lock that only recognizes wheel/touch scrolling on content that is
+ * an actual DOM descendant of the dialog - an overlay portalled to
+ * `document.body` renders as a DOM sibling of the dialog instead, so the lock
+ * silently swallows wheel input over it even though the content itself
+ * scrolls fine (e.g. via a dragged scrollbar or a programmatic `scrollTop`).
+ * `null` outside a modal dialog, where portalling to `document.body` is fine.
+ */
+export const DialogOverlayBoundaryContext = createContext<HTMLElement | null>(
+  null,
+);
+
+export function useDialogOverlayBoundaryEl(): HTMLElement | null {
+  return use(DialogOverlayBoundaryContext);
+}


### PR DESCRIPTION
## Summary
- The New Conversation modal's Branch and Existing-worktree pickers portalled to `document.body`, landing as DOM siblings of the modal's Radix Dialog instead of descendants — the dialog's scroll-lock only recognizes wheel input on content inside its own boundary, so it silently swallowed scrolling on these lists even though they scrolled fine via scrollbar drag or a programmatic `scrollTop`.
- Added `DialogOverlayBoundaryContext`, published from the dialog's own content node, so the nested Branch/Location overlays portal inside the dialog instead of `document.body`. Home/landing and other in-epic surfaces have no such ancestor, so they're unaffected.
- Fixed a follow-up regression from the same change: the boundary element was also passed as the popover's `collisionBoundary`, which shrank Radix's available-space calculation down to the tiny folder-row element and clipped the Location dropdown to one item. Removed that from all three affected spots, keeping only `container`.

## Test plan
- [x] `bun run compile` (gui-app, desktop)
- [x] `bun run lint` (gui-app)
- [x] `bun run test` (gui-app) — 3602 passed
- [x] `react-doctor` — no issues
- [x] Verified live in a running dev-desktop instance: both pickers now wheel-scroll correctly with intact layout inside the New Conversation modal; Home/landing page unaffected