### PR TITLE
Confirm host restart actions

### DIFF
--- a/clients/desktop/src/electron-main/ipc/ipc-parsers.ts
+++ b/clients/desktop/src/electron-main/ipc/ipc-parsers.ts
@@ -314,6 +314,10 @@ export function isDialogHostedMenuCommand(command: MenuCommandId): boolean {
     // so route the install through the same fallback path. The renderer
     // owns the actual CLI mutation; main only needs to make sure *some*
     // renderer receives the command and is focused/visible to the user.
-    command === "host.installUpdate"
+    command === "host.installUpdate" ||
+    // Help -> Restart Host is destructive and renderer-confirmed. Use the
+    // same MRU fallback so menu activation without a focused renderer still
+    // presents the confirmation modal instead of no-oping.
+    command === "host.restart"
   );
 }

--- a/clients/desktop/src/electron-main/menu/__tests__/menu-controller.test.ts
+++ b/clients/desktop/src/electron-main/menu/__tests__/menu-controller.test.ts
@@ -208,12 +208,21 @@ class EmptyWindowRegistry extends EventEmitter implements MenuWindowRegistry {
     readonly initialRoute: string | null;
     readonly beforeLoad: ((windowId: string) => void) | null;
   }> = [];
+  private readonly createError: Error | null;
+
+  constructor(createError: Error | null) {
+    super();
+    this.createError = createError;
+  }
 
   async create(options: {
     readonly initialRoute: string | null;
     readonly beforeLoad: ((windowId: string) => void) | null;
   }): Promise<string> {
     this.createRequests.push(options);
+    if (this.createError !== null) {
+      throw this.createError;
+    }
     return "window-created";
   }
 
@@ -484,7 +493,7 @@ describe("MenuController", () => {
 
   it("opens a window and retries Restart Host when no renderer is available", async () => {
     const host = new FakeHost();
-    const registry = new EmptyWindowRegistry();
+    const registry = new EmptyWindowRegistry(null);
     const dispatchRendererCommand = vi
       .fn<(_command: MenuCommandId) => boolean>()
       .mockReturnValueOnce(false)
@@ -508,6 +517,70 @@ describe("MenuController", () => {
     expect(dispatchRendererCommand).toHaveBeenNthCalledWith(1, "host.restart");
     expect(dispatchRendererCommand).toHaveBeenNthCalledWith(2, "host.restart");
     expect(host.respawnCalls).toBe(0);
+    controller.dispose();
+  });
+
+  it("logs when Restart Host opens a window but still has no renderer target", async () => {
+    const host = new FakeHost();
+    const registry = new EmptyWindowRegistry(null);
+    const dispatchRendererCommand = vi.fn(() => false);
+    const controller = createController({
+      registry,
+      host,
+      authSession: new DesktopAuthSession(),
+      perWindowState: new PerWindowState(null),
+      dispatchRendererCommand,
+    });
+
+    controller.install();
+    vi.mocked(log.warn).mockClear();
+    runControllerCommand(controller, "host.restart", null);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(registry.createRequests).toEqual([
+      { initialRoute: null, beforeLoad: null },
+    ]);
+    expect(dispatchRendererCommand).toHaveBeenCalledTimes(2);
+    expect(dispatchRendererCommand).toHaveBeenNthCalledWith(1, "host.restart");
+    expect(dispatchRendererCommand).toHaveBeenNthCalledWith(2, "host.restart");
+    expect(host.respawnCalls).toBe(0);
+    expect(log.warn).toHaveBeenCalledWith(
+      "[menu] host.restart had no renderer after opening window",
+      { command: "host.restart" },
+    );
+    controller.dispose();
+  });
+
+  it("logs when Restart Host cannot open a renderer window", async () => {
+    const createError = new Error("create failed");
+    const host = new FakeHost();
+    const registry = new EmptyWindowRegistry(createError);
+    const dispatchRendererCommand = vi.fn(() => false);
+    const controller = createController({
+      registry,
+      host,
+      authSession: new DesktopAuthSession(),
+      perWindowState: new PerWindowState(null),
+      dispatchRendererCommand,
+    });
+
+    controller.install();
+    vi.mocked(log.warn).mockClear();
+    runControllerCommand(controller, "host.restart", null);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(registry.createRequests).toEqual([
+      { initialRoute: null, beforeLoad: null },
+    ]);
+    expect(dispatchRendererCommand).toHaveBeenCalledTimes(1);
+    expect(dispatchRendererCommand).toHaveBeenCalledWith("host.restart");
+    expect(host.respawnCalls).toBe(0);
+    expect(log.warn).toHaveBeenCalledWith(
+      "[menu] host.restart window creation failed",
+      createError,
+    );
     controller.dispose();
   });
 

--- a/clients/desktop/src/electron-main/menu/__tests__/menu-controller.test.ts
+++ b/clients/desktop/src/electron-main/menu/__tests__/menu-controller.test.ts
@@ -203,6 +203,49 @@ class FakeWindowRegistry extends EventEmitter implements MenuWindowRegistry {
   }
 }
 
+class EmptyWindowRegistry extends EventEmitter implements MenuWindowRegistry {
+  readonly createRequests: Array<{
+    readonly initialRoute: string | null;
+    readonly beforeLoad: ((windowId: string) => void) | null;
+  }> = [];
+
+  async create(options: {
+    readonly initialRoute: string | null;
+    readonly beforeLoad: ((windowId: string) => void) | null;
+  }): Promise<string> {
+    this.createRequests.push(options);
+    return "window-created";
+  }
+
+  closeById(_windowId: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  minimizeById(_windowId: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  zoomById(_windowId: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  focusById(_windowId: string): boolean {
+    return false;
+  }
+
+  list(): readonly WindowSummary[] {
+    return [];
+  }
+
+  records(): readonly MenuWindowRecord[] {
+    return [];
+  }
+
+  mostRecentlyFocusedId(): string | null {
+    return null;
+  }
+}
+
 class MultiWindowRegistry extends EventEmitter implements MenuWindowRegistry {
   readonly windowA = new FakeWindow();
   readonly windowB = new FakeWindow();
@@ -415,6 +458,56 @@ describe("MenuController", () => {
     closeTab.click?.(null, null);
 
     expect(dispatchRendererCommand).toHaveBeenCalledWith("epic.closeTab");
+    controller.dispose();
+  });
+
+  it("dispatches Restart Host through the renderer confirmation path", () => {
+    const host = new FakeHost();
+    const registry = new FakeWindowRegistry();
+    const dispatchRendererCommand = vi.fn(() => true);
+    const controller = createController({
+      registry,
+      host,
+      authSession: new DesktopAuthSession(),
+      perWindowState: new PerWindowState(null),
+      dispatchRendererCommand,
+    });
+
+    controller.install();
+    runControllerCommand(controller, "host.restart", null);
+
+    expect(dispatchRendererCommand).toHaveBeenCalledWith("host.restart");
+    expect(host.respawnCalls).toBe(0);
+    expect(registry.createRequests).toEqual([]);
+    controller.dispose();
+  });
+
+  it("opens a window and retries Restart Host when no renderer is available", async () => {
+    const host = new FakeHost();
+    const registry = new EmptyWindowRegistry();
+    const dispatchRendererCommand = vi
+      .fn<(_command: MenuCommandId) => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    const controller = createController({
+      registry,
+      host,
+      authSession: new DesktopAuthSession(),
+      perWindowState: new PerWindowState(null),
+      dispatchRendererCommand,
+    });
+
+    controller.install();
+    runControllerCommand(controller, "host.restart", null);
+    await Promise.resolve();
+
+    expect(registry.createRequests).toEqual([
+      { initialRoute: null, beforeLoad: null },
+    ]);
+    expect(dispatchRendererCommand).toHaveBeenCalledTimes(2);
+    expect(dispatchRendererCommand).toHaveBeenNthCalledWith(1, "host.restart");
+    expect(dispatchRendererCommand).toHaveBeenNthCalledWith(2, "host.restart");
+    expect(host.respawnCalls).toBe(0);
     controller.dispose();
   });
 

--- a/clients/desktop/src/electron-main/menu/menu-controller.ts
+++ b/clients/desktop/src/electron-main/menu/menu-controller.ts
@@ -20,7 +20,6 @@ import type {
 import { buildApplicationMenu } from "./menu-builder";
 import { toMenuHostPresentation, type MenuState } from "./menu-state";
 import { log } from "../app/logger";
-import { respawnHost } from "../app/host-respawn";
 
 export interface MenuManagedWindow {
   isDestroyed(): boolean;
@@ -201,16 +200,29 @@ export class MenuController {
       return;
     }
     if (command === "host.restart") {
-      // Route through the shared respawn entrypoint, NOT `host.respawn`
-      // directly - on macOS shipped builds, `host.respawn` shells to
-      // `traycer host restart` (launchctl kickstart) which cannot
-      // refresh BTM's cached LWCR and would silently no-op for the very
-      // bug this surface exists to recover from. `respawnHost` picks
-      // the SMAppService cycle when the host owns the login item, and
-      // falls back to the CLI path otherwise.
-      void respawnHost(this.options.host).catch((err) => {
-        log.warn("[menu] host.restart failed", err);
-      });
+      // The renderer owns the confirmation modal. Once confirmed, it calls
+      // runnerHost.requestHostRespawn(), which routes back through the shared
+      // main-process respawn entrypoint.
+      if (this.options.dispatchRendererCommand(command)) return;
+
+      void this.options.windowRegistry
+        .create({
+          initialRoute: null,
+          beforeLoad: null,
+        })
+        .then(() => {
+          if (!this.options.dispatchRendererCommand(command)) {
+            log.warn(
+              "[menu] host.restart had no renderer after opening window",
+              {
+                command,
+              },
+            );
+          }
+        })
+        .catch((err) => {
+          log.warn("[menu] host.restart window creation failed", err);
+        });
       return;
     }
     if (command === "host.installUpdate") {

--- a/clients/gui-app/src/components/host/restart-host-confirm-dialog.tsx
+++ b/clients/gui-app/src/components/host/restart-host-confirm-dialog.tsx
@@ -1,0 +1,23 @@
+import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
+
+interface RestartHostConfirmDialogProps {
+  readonly open: boolean;
+  readonly isPending: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly onConfirm: () => void;
+}
+
+export function RestartHostConfirmDialog(props: RestartHostConfirmDialogProps) {
+  return (
+    <ConfirmDestructiveDialog
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      title="Restart host?"
+      description="Restarting will stop in-progress chats, end any running terminal sessions, and cancel in-flight requests against this host."
+      cascadeSummary={null}
+      actionLabel="Restart host"
+      isPending={props.isPending}
+      onConfirm={props.onConfirm}
+    />
+  );
+}

--- a/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
@@ -184,7 +184,7 @@ function createRunnerHost(menu: FakeDesktopMenu): FakeRunnerHost {
       },
       onLocalHostChange: () => ({ dispose: () => undefined }),
       onSystemResumed: () => ({ dispose: () => undefined }),
-      requestHostRespawn: () => Promise.resolve(),
+      requestHostRespawn: vi.fn(() => Promise.resolve()),
       service: null,
       traycerCli: null,
       migration: null,
@@ -602,6 +602,36 @@ describe("<MenuCommandListener />", () => {
       expect(updateHost).toHaveBeenCalledTimes(1);
     });
     expect(updateHost).toHaveBeenCalledWith({ onProgress: null });
+  });
+
+  it("opens a confirmation dialog for host.restart and only respawns after confirm", async () => {
+    const menu = createMenu();
+    const requestHostRespawn = vi.fn(() => Promise.resolve());
+    const runnerHost = Object.assign(createRunnerHost(menu), {
+      requestHostRespawn,
+    });
+
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <RunnerHostProvider runnerHost={runnerHost}>
+          <MenuCommandListener />
+        </RunnerHostProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      menu.emit("host.restart");
+    });
+
+    const dialog = await screen.findByTestId("confirm-destructive-dialog");
+    expect(dialog.textContent).toContain("Restarting will stop");
+    expect(requestHostRespawn).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    await waitFor(() => {
+      expect(requestHostRespawn).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("closes the landing draft from the native menu command", () => {

--- a/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
@@ -11,6 +11,7 @@ import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { runnerMutationKeys, runnerQueryKeys } from "@/lib/query-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
+import { RestartHostConfirmDialog } from "@/components/host/restart-host-confirm-dialog";
 
 /**
  * NP-6: listens for host-scoped tray commands forwarded from the
@@ -145,15 +146,11 @@ export function HostTrayCommandListener() {
 
   return (
     <>
-      <ConfirmDestructiveDialog
+      <RestartHostConfirmDialog
         open={pendingRestart}
         onOpenChange={(open) => {
           if (!open) setPendingRestart(false);
         }}
-        title="Restart host?"
-        description="Restarting will end any running terminal sessions and cancel in-flight requests against this host."
-        cascadeSummary={null}
-        actionLabel="Restart host"
         isPending={restartMutation.isPending}
         onConfirm={() => restartMutation.mutate()}
       />

--- a/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -25,6 +25,7 @@ import {
 } from "@/lib/commands/tile-find";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { RestartHostConfirmDialog } from "@/components/host/restart-host-confirm-dialog";
 
 interface HostWithRequestClose extends IRunnerHost {
   readonly windows: {
@@ -84,6 +85,26 @@ export function MenuCommandListener() {
   );
   const management = runnerHost.hostManagement;
   const service = runnerHost.service;
+  const traycerCli = runnerHost.traycerCli;
+  const [pendingHostRestart, setPendingHostRestart] = useState<boolean>(false);
+
+  const restartHostMutation = useMutation<void>({
+    mutationKey: runnerMutationKeys.requestHostRespawn(),
+    mutationFn: () => runnerHost.requestHostRespawn(),
+    onSuccess: () => {
+      toast.success("Host restart requested");
+      setPendingHostRestart(false);
+      if (traycerCli !== null) {
+        void queryClient.invalidateQueries({
+          queryKey: runnerQueryKeys.traycerHostStatus(traycerCli),
+        });
+      }
+    },
+    onError: (err) => {
+      setPendingHostRestart(false);
+      toastFromRunnerError(err, "Couldn't restart host");
+    },
+  });
 
   const installUpdateMutation = useMutation<HostInstallResult>({
     mutationKey: runnerMutationKeys.hostUpdate(),
@@ -150,6 +171,9 @@ export function MenuCommandListener() {
         installHostUpdate: () => {
           mutateInstallUpdate();
         },
+        requestHostRestart: () => {
+          setPendingHostRestart(true);
+        },
         reportIssue: openReportIssue,
       });
     });
@@ -168,7 +192,19 @@ export function MenuCommandListener() {
     openReportIssue,
   ]);
 
-  return <>{closeTabFlow.unsyncedDialog}</>;
+  return (
+    <>
+      {closeTabFlow.unsyncedDialog}
+      <RestartHostConfirmDialog
+        open={pendingHostRestart}
+        onOpenChange={(open) => {
+          if (!open) setPendingHostRestart(false);
+        }}
+        isPending={restartHostMutation.isPending}
+        onConfirm={() => restartHostMutation.mutate()}
+      />
+    </>
+  );
 }
 
 interface MenuCommandHandlers {
@@ -183,6 +219,7 @@ interface MenuCommandHandlers {
   readonly openFindBar: () => void;
   readonly advanceFind: (forward: boolean) => void;
   readonly installHostUpdate: () => void;
+  readonly requestHostRestart: () => void;
   readonly reportIssue: () => void;
 }
 
@@ -230,6 +267,10 @@ function handleMenuCommand(
   }
   if (payload.command === "host.installUpdate") {
     handlers.installHostUpdate();
+    return;
+  }
+  if (payload.command === "host.restart") {
+    handlers.requestHostRestart();
     return;
   }
   if (payload.command === "window.closeWindow") {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
@@ -39,7 +39,7 @@ afterEach(() => {
 });
 
 describe("<HostSettingsPanel /> - mutation flows", () => {
-  it("calls restartHost and shows a success toast when Restart is clicked", async () => {
+  it("opens a confirmation dialog before restarting the host", async () => {
     const restartHost = vi.fn(() => Promise.resolve());
     const { management } = makeManagement({ restartHost });
 
@@ -47,6 +47,12 @@ describe("<HostSettingsPanel /> - mutation flows", () => {
 
     const restartButton = await waitForButton("Restart");
     fireEvent.click(restartButton);
+
+    const dialog = await screen.findByTestId("confirm-destructive-dialog");
+    expect(dialog.textContent).toContain("in-progress chats");
+    expect(restartHost).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("confirm-action"));
 
     await waitFor(() => {
       expect(restartHost).toHaveBeenCalledTimes(1);

--- a/clients/gui-app/src/components/settings/panels/host-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-panel.tsx
@@ -6,6 +6,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { RestartHostConfirmDialog } from "@/components/host/restart-host-confirm-dialog";
 import { ActionsRow } from "@/components/settings/panels/host-settings-actions-row";
 import { AdvancedDisclosure } from "@/components/settings/panels/host-settings-advanced-disclosure";
 import { DoctorSheet } from "@/components/settings/panels/host-settings-doctor-sheet";
@@ -168,6 +169,7 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
   const [hostNameDraftOverride, setHostNameDraftOverride] = useState<
     string | null
   >(null);
+  const [restartConfirmOpen, setRestartConfirmOpen] = useState<boolean>(false);
   const [includePreReleases, setIncludePreReleases] = useState(false);
   const localHost = useLocalHostSnapshot(runnerHost);
 
@@ -288,13 +290,17 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
     mutationKey: runnerMutationKeys.hostRestart(),
     mutationFn: () => management.restartHost(),
     onSuccess: () => {
+      setRestartConfirmOpen(false);
       toast.success("Host restart requested");
       void queryClient.invalidateQueries({
         queryKey: runnerQueryKeys.hostInstalledRecord(management),
       });
       invalidate();
     },
-    onError: (err) => toastFromRunnerError(err, "Couldn't restart host"),
+    onError: (err) => {
+      setRestartConfirmOpen(false);
+      toastFromRunnerError(err, "Couldn't restart host");
+    },
   });
 
   const registerServiceMutation = useMutation({
@@ -410,8 +416,16 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
         installPending={installMutation.isPending}
         restartPending={restartMutation.isPending}
         onInstall={() => installMutation.mutate(null)}
-        onRestart={() => restartMutation.mutate()}
+        onRestart={() => setRestartConfirmOpen(true)}
         onOpenDoctor={() => setDoctorOpen(true)}
+      />
+      <RestartHostConfirmDialog
+        open={restartConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) setRestartConfirmOpen(false);
+        }}
+        isPending={restartMutation.isPending}
+        onConfirm={() => restartMutation.mutate()}
       />
       {status?.state === "not-installed" ? null : (
         <UpdatesRow


### PR DESCRIPTION
## Summary
- add a shared destructive confirmation dialog for host restarts
- route topbar/tray Restart Host through renderer confirmation before respawning the host
- require confirmation before Settings > Host restart and cover the menu/settings flows with tests
- open a renderer window and retry the confirmation command when Restart Host is triggered with no windows open

## Verification
- make pre-commit-checks
