### PR TITLE
fix(auth): time-box token validation, refresh, and code exchange

### DIFF
--- a/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
@@ -40,6 +40,16 @@ const MOCK_DEVICE_USER_CODE = "ABCDE-FGHIJ";
 const MOCK_DEVICE_VERIFICATION_URI_COMPLETE =
   "https://app.traycer.ai/device?user_code=ABCDE-FGHIJ";
 
+// Collapse consecutive identical entries so an ordered validate -> refresh
+// assertion tolerates the auth boundary's bounded retry (a transient 5xx /
+// transport error is re-driven a few times before the flow advances) without
+// coupling the test to the exact attempt count.
+function collapseConsecutiveCalls(calls: readonly string[]): string[] {
+  return calls.filter(
+    (call, index) => index === 0 || call !== calls[index - 1],
+  );
+}
+
 const trackedServices: AuthService[] = [];
 
 function makeService(): { service: AuthService; host: MockRunnerHost } {
@@ -546,7 +556,10 @@ describe("AuthService", () => {
     expect(service.getCurrentSessionSnapshot().token).toBeNull();
     expect(service.getLastError()).toBe(AUTH_ERROR_SESSION_EXPIRED);
     expect(await host.tokenStore.get()).toBeNull();
-    expect(calls).toEqual([`GET ${VALIDATION_URL}`, `POST ${REFRESH_URL}`]);
+    expect(collapseConsecutiveCalls(calls)).toEqual([
+      `GET ${VALIDATION_URL}`,
+      `POST ${REFRESH_URL}`,
+    ]);
   });
 
   it("clears tokenStore and surfaces session-expired when validation rejects with 401 on start()", async () => {
@@ -641,7 +654,10 @@ describe("AuthService", () => {
     expect(service.getCurrentSessionSnapshot().token).toBeNull();
     expect(await host.tokenStore.get()).toBeNull();
     expect(service.getLastError()).toBe(AUTH_ERROR_SESSION_EXPIRED);
-    expect(calls).toEqual([`GET ${VALIDATION_URL}`, `POST ${REFRESH_URL}`]);
+    expect(collapseConsecutiveCalls(calls)).toEqual([
+      `GET ${VALIDATION_URL}`,
+      `POST ${REFRESH_URL}`,
+    ]);
   });
 
   it("opens the device verification page and flips to signing-in on signIn()", async () => {
@@ -766,9 +782,15 @@ describe("AuthService", () => {
       refreshToken: "net-fail-token-refresh",
     });
 
-    await vi.waitFor(() => {
-      expect(service.getLastError()).toBe(AUTH_ERROR_SIGN_IN_FAILED);
-    });
+    // The device-poll token validation now retries transient failures on a
+    // bounded backoff, so the surfaced error can arrive after the default 1s
+    // waitFor budget - allow for the full retry window.
+    await vi.waitFor(
+      () => {
+        expect(service.getLastError()).toBe(AUTH_ERROR_SIGN_IN_FAILED);
+      },
+      { timeout: 5000 },
+    );
     expect(useAuthStore.getState().status).toBe("signed-out");
     expect(service.getCurrentSessionSnapshot().token).toBeNull();
     expect(await host.tokenStore.get()).toBeNull();

--- a/clients/shared/auth/__tests__/auth-validation.test.ts
+++ b/clients/shared/auth/__tests__/auth-validation.test.ts
@@ -10,8 +10,10 @@
  * "Token validation/refresh preserves full AuthenticatedUser when minting
  * or updating client contexts."
  */
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  AUTH_FETCH_MAX_ATTEMPTS,
+  exchangeCodeForTokens,
   refreshAuthTokenViaHttp,
   validateAuthTokenIdentityViaHttp,
   type AuthIdentityValidationResult,
@@ -21,11 +23,13 @@ import { createAuthenticatedUserFixture } from "../../test-fixtures/authenticate
 const AUTHN_BASE_URL = "https://authn.example.test";
 const USER_ENDPOINT = `${AUTHN_BASE_URL}/api/v3/user`;
 const REFRESH_ENDPOINT = `${AUTHN_BASE_URL}/api/v3/auth/refresh`;
+const EXCHANGE_ENDPOINT = `${AUTHN_BASE_URL}/api/v3/auth/exchange-code`;
 
 interface MockFetchCall {
   readonly url: string;
   readonly method: string;
   readonly authorization: string | null;
+  readonly hasSignal: boolean;
 }
 
 interface MockSpec {
@@ -54,6 +58,7 @@ function installMockFetch(specs: ReadonlyArray<MockSpec>): MockFetchCall[] {
       url,
       method,
       authorization: headers.get("Authorization"),
+      hasSignal: init?.signal instanceof AbortSignal,
     });
     const spec = specs[index] ?? specs[specs.length - 1];
     index++;
@@ -80,6 +85,7 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  vi.useRealTimers();
 });
 
 describe("validateAuthTokenIdentityViaHttp - full AuthenticatedUser", () => {
@@ -176,18 +182,77 @@ describe("validateAuthTokenIdentityViaHttp - full AuthenticatedUser", () => {
     expect(result.kind).toBe("rejected");
   });
 
-  it("returns network-error when transport fails", async () => {
+  it("returns network-error when transport fails after exhausting retries", async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
     globalThis.fetch = (async (): Promise<Response> => {
+      attempts += 1;
       throw new TypeError("network failure");
     }) as typeof fetch;
 
-    const result = await validateAuthTokenIdentityViaHttp(
+    const pending = validateAuthTokenIdentityViaHttp(
       AUTHN_BASE_URL,
       "bearer",
       "bearer-refresh",
     );
+    await vi.runAllTimersAsync();
+    const result = await pending;
 
     expect(result.kind).toBe("network-error");
+    // The initial user lookup and the follow-up refresh each exhaust the cap,
+    // and the whole thing settles in bounded time instead of hanging.
+    expect(attempts).toBe(AUTH_FETCH_MAX_ATTEMPTS * 2);
+  });
+
+  it("time-boxes each request with an AbortSignal and maps a timeout to network-error", async () => {
+    vi.useFakeTimers();
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init: RequestInit | undefined,
+    ): Promise<Response> => {
+      calls.push({
+        url: USER_ENDPOINT,
+        method: init?.method ?? "GET",
+        authorization: null,
+        hasSignal: init?.signal instanceof AbortSignal,
+      });
+      // Mirror what a fired `AbortSignal.timeout` throws into `fetch`.
+      throw new DOMException("The operation timed out.", "TimeoutError");
+    }) as typeof fetch;
+
+    const pending = validateAuthTokenIdentityViaHttp(
+      AUTHN_BASE_URL,
+      "bearer",
+      "bearer-refresh",
+    );
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result.kind).toBe("network-error");
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((call) => call.hasSignal)).toBe(true);
+  });
+
+  it("retries a transient user-lookup failure and then succeeds", async () => {
+    vi.useFakeTimers();
+    installMockFetch([
+      { status: 503, body: { error: "unavailable" } },
+      { status: 200, body: serializeAuthenticatedUserForHttp() },
+    ]);
+
+    const pending = validateAuthTokenIdentityViaHttp(
+      AUTHN_BASE_URL,
+      "bearer",
+      "bearer-refresh",
+    );
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    expect(result.kind).toBe("valid");
+    // One transient 5xx retried straight into a success - no refresh round trip.
+    expect(calls).toHaveLength(2);
+    expect(calls.every((call) => call.url === USER_ENDPOINT)).toBe(true);
+    expect(calls.every((call) => call.hasSignal)).toBe(true);
   });
 
   it("returns rejected when the response body fails AuthenticatedUser parsing", async () => {
@@ -206,19 +271,23 @@ describe("validateAuthTokenIdentityViaHttp - full AuthenticatedUser", () => {
 });
 
 describe("refreshAuthTokenViaHttp - status mapping", () => {
-  it("maps a 409 (refresh grace window in progress) to network-error", async () => {
+  it("maps a 409 (refresh grace window in progress) to network-error and retries", async () => {
+    vi.useFakeTimers();
     installMockFetch([{ status: 409, body: { error: "in progress" } }]);
 
-    const result = await refreshAuthTokenViaHttp(
+    const pending = refreshAuthTokenViaHttp(
       AUTHN_BASE_URL,
       "stale-bearer",
       "stale-refresh",
     );
+    await vi.runAllTimersAsync();
+    const result = await pending;
 
     // A concurrent refresher is mid-rotation: transient/retriable, NOT a dead
-    // credential. Must NOT downgrade to `rejected` (which signs the GUI out).
+    // credential. Must NOT downgrade to `rejected` (which signs the GUI out) -
+    // the bounded retry re-drives to land on the winner's replayed pair.
     expect(result.kind).toBe("network-error");
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(AUTH_FETCH_MAX_ATTEMPTS);
     expect(calls[0].url).toBe(REFRESH_ENDPOINT);
     expect(calls[0].method).toBe("POST");
   });
@@ -255,5 +324,61 @@ describe("refreshAuthTokenViaHttp - status mapping", () => {
     }
     expect(result.token).toBe("rotated-bearer");
     expect(result.refreshToken).toBe("rotated-refresh");
+  });
+});
+
+describe("exchangeCodeForTokens - timeout without retry", () => {
+  it("attaches an AbortSignal and maps a transport failure to network-error without retrying", async () => {
+    let attempts = 0;
+    globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init: RequestInit | undefined,
+    ): Promise<Response> => {
+      attempts += 1;
+      calls.push({
+        url: EXCHANGE_ENDPOINT,
+        method: init?.method ?? "GET",
+        authorization: null,
+        hasSignal: init?.signal instanceof AbortSignal,
+      });
+      // Mirror what a fired `AbortSignal.timeout` throws into `fetch`.
+      throw new DOMException("The operation timed out.", "TimeoutError");
+    }) as typeof fetch;
+
+    const result = await exchangeCodeForTokens(
+      AUTHN_BASE_URL,
+      "pkce-code",
+      "pkce-verifier",
+    );
+
+    expect(result.kind).toBe("network-error");
+    // The PKCE code is single-use, so a lost/timed-out response must NOT be
+    // replayed: exactly one attempt, unlike validation/refresh.
+    expect(attempts).toBe(1);
+    expect(calls[0].hasSignal).toBe(true);
+  });
+
+  it("returns the exchanged token pair on success", async () => {
+    installMockFetch([
+      {
+        status: 200,
+        body: { token: "exchanged-bearer", refreshToken: "exchanged-refresh" },
+      },
+    ]);
+
+    const result = await exchangeCodeForTokens(
+      AUTHN_BASE_URL,
+      "pkce-code",
+      "pkce-verifier",
+    );
+
+    expect(result.kind).toBe("exchanged");
+    if (result.kind !== "exchanged") {
+      throw new Error("expected exchanged result");
+    }
+    expect(result.token).toBe("exchanged-bearer");
+    expect(result.refreshToken).toBe("exchanged-refresh");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(EXCHANGE_ENDPOINT);
   });
 });

--- a/clients/shared/auth/__tests__/auth-validation.test.ts
+++ b/clients/shared/auth/__tests__/auth-validation.test.ts
@@ -78,6 +78,19 @@ function serializeAuthenticatedUserForHttp(): unknown {
   return JSON.parse(JSON.stringify(user));
 }
 
+// A real `Response` (so it stays `Response`-typed with no casts) whose body read
+// rejects with a `TimeoutError` - mirrors `AbortSignal.timeout` firing during
+// `response.json()`, after the status/headers have already arrived.
+function responseWithAbortingBody(status: number): Response {
+  const response = new Response("{}", { status });
+  Object.defineProperty(response, "json", {
+    value: async () => {
+      throw new DOMException("The operation timed out.", "TimeoutError");
+    },
+  });
+  return response;
+}
+
 beforeEach(() => {
   originalFetch = globalThis.fetch;
   calls = [];
@@ -255,6 +268,35 @@ describe("validateAuthTokenIdentityViaHttp - full AuthenticatedUser", () => {
     expect(calls.every((call) => call.hasSignal)).toBe(true);
   });
 
+  it("retries a user lookup whose body read times out (mid-read abort maps to network-error)", async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    globalThis.fetch = (async (): Promise<Response> => {
+      attempts += 1;
+      if (attempts === 1) {
+        return responseWithAbortingBody(200);
+      }
+      return new Response(JSON.stringify(serializeAuthenticatedUserForHttp()), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const pending = validateAuthTokenIdentityViaHttp(
+      AUTHN_BASE_URL,
+      "bearer",
+      "bearer-refresh",
+    );
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    // A timeout during response.json() (after headers) is transient, so the
+    // lookup retries and succeeds instead of collapsing to a `rejected` sign-out.
+    expect(result.kind).toBe("valid");
+    expect(attempts).toBe(2);
+    vi.useRealTimers();
+  });
+
   it("returns rejected when the response body fails AuthenticatedUser parsing", async () => {
     installMockFetch([
       { status: 200, body: { user: { id: "u" }, partial: true } },
@@ -325,6 +367,38 @@ describe("refreshAuthTokenViaHttp - status mapping", () => {
     expect(result.token).toBe("rotated-bearer");
     expect(result.refreshToken).toBe("rotated-refresh");
   });
+
+  it("retries a refresh whose body read times out (mid-read abort maps to network-error)", async () => {
+    vi.useFakeTimers();
+    let attempts = 0;
+    globalThis.fetch = (async (): Promise<Response> => {
+      attempts += 1;
+      if (attempts === 1) {
+        return responseWithAbortingBody(200);
+      }
+      return new Response(
+        JSON.stringify({
+          token: "rotated-bearer",
+          refreshToken: "rotated-refresh",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const pending = refreshAuthTokenViaHttp(
+      AUTHN_BASE_URL,
+      "stale-bearer",
+      "stale-refresh",
+    );
+    await vi.runAllTimersAsync();
+    const result = await pending;
+
+    // A mid-read timeout on a 200 is transient, not a bad body: it retries into
+    // the rotated pair rather than downgrading to `rejected` (a sign-out).
+    expect(result.kind).toBe("refreshed");
+    expect(attempts).toBe(2);
+    vi.useRealTimers();
+  });
 });
 
 describe("exchangeCodeForTokens - timeout without retry", () => {
@@ -380,5 +454,42 @@ describe("exchangeCodeForTokens - timeout without retry", () => {
     expect(result.refreshToken).toBe("exchanged-refresh");
     expect(calls).toHaveLength(1);
     expect(calls[0].url).toBe(EXCHANGE_ENDPOINT);
+  });
+
+  it("maps a body-read timeout to network-error (transient), still without retrying", async () => {
+    let attempts = 0;
+    globalThis.fetch = (async (): Promise<Response> => {
+      attempts += 1;
+      return responseWithAbortingBody(200);
+    }) as typeof fetch;
+
+    const result = await exchangeCodeForTokens(
+      AUTHN_BASE_URL,
+      "pkce-code",
+      "pkce-verifier",
+    );
+
+    // A mid-read timeout is transient (the caller can retry the whole sign-in),
+    // NOT a consumed code - so it must not be a terminal `rejected`.
+    expect(result.kind).toBe("network-error");
+    expect(attempts).toBe(1);
+  });
+
+  it("maps a genuinely malformed 2xx body to rejected (a parse failure stays terminal)", async () => {
+    globalThis.fetch = (async (): Promise<Response> =>
+      new Response("not-json{", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+
+    const result = await exchangeCodeForTokens(
+      AUTHN_BASE_URL,
+      "pkce-code",
+      "pkce-verifier",
+    );
+
+    // A SyntaxError from response.json() is NOT an abort/timeout, so it stays a
+    // terminal `rejected` - proving the transient/terminal distinction holds.
+    expect(result.kind).toBe("rejected");
   });
 });

--- a/clients/shared/auth/auth-validation.ts
+++ b/clients/shared/auth/auth-validation.ts
@@ -45,6 +45,60 @@ const authenticatedUserResponseSchema = getRecordSchema(
 );
 
 /**
+ * Per-attempt ceiling and bounded exponential-backoff retry for the auth
+ * boundary's HTTP calls (`/api/v3/user`, `/api/v3/auth/refresh`).
+ *
+ * Every attempt is time-boxed with `AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS)`
+ * so a stalled/half-open socket can no longer hang the caller indefinitely -
+ * previously an un-timed-out `fetch` here could block `auth.start()` (and, through
+ * it, the renderer's "Initializing Traycer Host…" gate) until the OS TCP timeout,
+ * i.e. many minutes. A fired timeout rejects the `fetch`, which the surrounding
+ * `catch` already collapses to `network-error`; that outcome (plus a 5xx or a 409
+ * refresh-grace race) is the only one re-driven. A terminal `rejected`/`valid`
+ * returns on the first attempt.
+ *
+ * Total wall-clock is bounded to `AUTH_FETCH_MAX_ATTEMPTS` attempts spaced by an
+ * exponential backoff capped at `AUTH_FETCH_RETRY_MAX_DELAY_MS`.
+ */
+export const AUTH_FETCH_MAX_ATTEMPTS = 3;
+const AUTH_FETCH_TIMEOUT_MS = 10_000;
+const AUTH_FETCH_RETRY_BASE_DELAY_MS = 500;
+const AUTH_FETCH_RETRY_MAX_DELAY_MS = 4_000;
+
+/**
+ * Runs `attempt`, then re-drives it while `isTransient(outcome)` holds, up to
+ * `AUTH_FETCH_MAX_ATTEMPTS` total invocations. Never throws: `attempt` is a
+ * boundary helper that already maps every transport failure (including a fired
+ * per-attempt timeout) to a typed outcome, so there is nothing to catch here.
+ */
+async function withAuthNetworkRetry<T>(
+  attempt: () => Promise<T>,
+  isTransient: (outcome: T) => boolean,
+): Promise<T> {
+  let outcome = await attempt();
+  for (
+    let retry = 1;
+    retry < AUTH_FETCH_MAX_ATTEMPTS && isTransient(outcome);
+    retry += 1
+  ) {
+    await delayFor(authRetryDelayMs(retry));
+    outcome = await attempt();
+  }
+  return outcome;
+}
+
+function authRetryDelayMs(retry: number): number {
+  const candidate = AUTH_FETCH_RETRY_BASE_DELAY_MS * 2 ** (retry - 1);
+  return Math.min(candidate, AUTH_FETCH_RETRY_MAX_DELAY_MS);
+}
+
+function delayFor(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
  * Shared bearer-token validation helper used by runner-host implementations.
  *
  * Browser-only hosts (tests, preview, mobile webview) call this directly with
@@ -182,6 +236,20 @@ async function fetchUserResponse(
   authnBaseUrl: string,
   token: string,
 ): Promise<UserFetchResult> {
+  return withAuthNetworkRetry(
+    () => fetchUserResponseOnce(authnBaseUrl, token),
+    isUserFetchTransient,
+  );
+}
+
+function isUserFetchTransient(result: UserFetchResult): boolean {
+  return result.kind === "failed" && result.result.kind === "network-error";
+}
+
+async function fetchUserResponseOnce(
+  authnBaseUrl: string,
+  token: string,
+): Promise<UserFetchResult> {
   let response: Response;
   try {
     response = await fetch(authnApiUrl(authnBaseUrl, "api/v3/user"), {
@@ -190,8 +258,12 @@ async function fetchUserResponse(
         Authorization: `Bearer ${token}`,
         Accept: "application/json",
       },
+      signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
     });
   } catch {
+    // A thrown `fetch` - a transport failure OR the per-attempt
+    // `AbortSignal.timeout` firing (a `TimeoutError`) - is transient and
+    // retriable, so both collapse to `network-error`.
     return { kind: "failed", result: { kind: "network-error" } };
   }
 
@@ -213,16 +285,37 @@ async function fetchUserResponse(
 }
 
 /**
- * Single-shot token refresh against the authn service's `/api/v3/auth/refresh`
- * endpoint. Post raw-JWS cutover the access token (`token`, the bearer) and the
+ * Token refresh against the authn service's `/api/v3/auth/refresh` endpoint.
+ * Post raw-JWS cutover the access token (`token`, the bearer) and the
  * `refreshToken` are separate: the bearer goes in the `Authorization` header and
  * the `refreshToken` in the request body (the endpoint requires it). A success
  * rotates BOTH, so we return the new `{ token, refreshToken }` for the caller to
  * persist. Exported so the CLI's host-auth boundary can refresh a stale bearer
- * on a host `401` without re-running a full `/api/v3/user` validation round
- * trip.
+ * on a host `401` without re-running a full `/api/v3/user` validation round trip.
+ *
+ * Each attempt is time-boxed by `AbortSignal.timeout` and transient outcomes
+ * (transport failure, timeout, 5xx, or a 409 grace-window race) are retried on a
+ * bounded exponential backoff via {@link withAuthNetworkRetry}; a `rejected`
+ * (dead credential) returns on the first attempt. Replaying the same
+ * `refreshToken` on a retry is safe: if the prior attempt's write was lost the
+ * authn grace window replays the winner's rotated pair (the 409 path).
  */
 export async function refreshAuthTokenViaHttp(
+  authnBaseUrl: string,
+  token: string,
+  refreshToken: string,
+): Promise<AuthTokenRefreshResult> {
+  return withAuthNetworkRetry(
+    () => refreshAuthTokenOnceViaHttp(authnBaseUrl, token, refreshToken),
+    isRefreshTransient,
+  );
+}
+
+function isRefreshTransient(result: AuthTokenRefreshResult): boolean {
+  return result.kind === "network-error";
+}
+
+async function refreshAuthTokenOnceViaHttp(
   authnBaseUrl: string,
   token: string,
   refreshToken: string,
@@ -237,6 +330,7 @@ export async function refreshAuthTokenViaHttp(
         "Content-Type": "application/json",
       },
       body: JSON.stringify({ refreshToken }),
+      signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
     });
   } catch {
     return { kind: "network-error" };
@@ -291,7 +385,12 @@ export type AuthCodeExchangeResult =
  * endpoint - no bearer; the code is the credential.
  *
  * A `4xx` is a terminal `rejected` (bad/expired/used code, or a PKCE mismatch);
- * any other non-2xx or a transport failure is a transient `network-error`.
+ * any other non-2xx or a transport failure is a transient `network-error`. The
+ * request is time-boxed by `AbortSignal.timeout` (a fired timeout surfaces as
+ * `network-error` via the `catch`); unlike validation/refresh it is deliberately
+ * NOT retried, because the `code` is single-use - replaying it after a lost
+ * response would be rejected as already-consumed. The sign-in callback surfaces
+ * the `network-error` as a retry CTA instead.
  */
 export async function exchangeCodeForTokens(
   authnBaseUrl: string,
@@ -309,6 +408,7 @@ export async function exchangeCodeForTokens(
           "Content-Type": "application/json",
         },
         body: JSON.stringify({ code, code_verifier: codeVerifier }),
+        signal: AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS),
       },
     );
   } catch {

--- a/clients/shared/auth/auth-validation.ts
+++ b/clients/shared/auth/auth-validation.ts
@@ -525,7 +525,9 @@ export async function readRotatedTokens(
   try {
     body = await response.json();
   } catch (error) {
-    return isAbortOrTimeout(error) ? { kind: "transient" } : { kind: "invalid" };
+    return isAbortOrTimeout(error)
+      ? { kind: "transient" }
+      : { kind: "invalid" };
   }
 
   if (body === null || typeof body !== "object") {

--- a/clients/shared/auth/auth-validation.ts
+++ b/clients/shared/auth/auth-validation.ts
@@ -99,6 +99,22 @@ function delayFor(ms: number): Promise<void> {
 }
 
 /**
+ * True for an abort/timeout thrown while reading a response body *after* the
+ * headers arrived - the per-attempt `AbortSignal.timeout` (a `TimeoutError`) or
+ * a caller abort (`AbortError`) firing during `response.json()`. Such a failure
+ * is transient/retriable and must surface as `network-error`, NOT be collapsed
+ * into a terminal `rejected`/invalid body the way a genuine parse failure is.
+ */
+function isAbortOrTimeout(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  );
+}
+
+/**
  * Shared bearer-token validation helper used by runner-host implementations.
  *
  * Browser-only hosts (tests, preview, mobile webview) call this directly with
@@ -278,7 +294,13 @@ async function fetchUserResponseOnce(
   let body: unknown;
   try {
     body = await response.json();
-  } catch {
+  } catch (error) {
+    // A timeout/abort firing mid-body-read (after headers) is transient, not a
+    // dead credential - classify it like a pre-headers abort. A genuinely
+    // malformed 2xx body stays `rejected`.
+    if (isAbortOrTimeout(error)) {
+      return { kind: "failed", result: { kind: "network-error" } };
+    }
     return { kind: "failed", result: { kind: "rejected" } };
   }
   return { kind: "ok", body };
@@ -359,7 +381,10 @@ async function refreshAuthTokenOnceViaHttp(
   }
 
   const rotated = await readRotatedTokens(response);
-  if (rotated === null) {
+  if (rotated.kind === "transient") {
+    return { kind: "network-error" };
+  }
+  if (rotated.kind === "invalid") {
     return { kind: "rejected" };
   }
   return {
@@ -429,7 +454,10 @@ export async function exchangeCodeForTokens(
   }
 
   const tokens = await readRotatedTokens(response);
-  if (tokens === null) {
+  if (tokens.kind === "transient") {
+    return { kind: "network-error" };
+  }
+  if (tokens.kind === "invalid") {
     return { kind: "rejected" };
   }
   return {
@@ -466,37 +494,57 @@ function projectProfile(body: unknown): AuthValidationProfile | null {
 }
 
 /**
+ * Outcome of reading the rotated `{ token, refreshToken }` pair from a 2xx
+ * token-mint body:
+ *   - `ok`        - a valid non-empty pair;
+ *   - `invalid`   - the body is malformed or missing a field (terminal);
+ *   - `transient` - the body read was aborted/timed out after headers arrived
+ *                   (retriable; must NOT be treated as a bad body).
+ */
+export type RotatedTokensOutcome =
+  | {
+      readonly kind: "ok";
+      readonly token: string;
+      readonly refreshToken: string;
+    }
+  | { readonly kind: "invalid" }
+  | { readonly kind: "transient" };
+
+/**
  * Parses the rotated `{ token, refreshToken }` pair from a 2xx token-mint
  * response body. Exported so the device-flow client (`device-auth.ts`) can
  * reuse the exact same 200-body shape that `exchange-code` / `refresh` use,
- * without duplicating the field validation. Returns `null` when the body is
- * missing either non-empty string field.
+ * without duplicating the field validation. A body-read abort/timeout is
+ * reported as `transient` so callers keep it retriable instead of collapsing it
+ * into a terminal bad-body outcome; a malformed/missing-field body is `invalid`.
  */
 export async function readRotatedTokens(
   response: Response,
-): Promise<{ readonly token: string; readonly refreshToken: string } | null> {
+): Promise<RotatedTokensOutcome> {
+  let body: unknown;
   try {
-    const body: unknown = await response.json();
-    if (body === null || typeof body !== "object") {
-      return null;
-    }
-
-    const record = body as Record<string, unknown>;
-    const token = record.token;
-    const refreshToken = record.refreshToken;
-    if (
-      typeof token !== "string" ||
-      token.length === 0 ||
-      typeof refreshToken !== "string" ||
-      refreshToken.length === 0
-    ) {
-      return null;
-    }
-
-    return { token, refreshToken };
-  } catch {
-    return null;
+    body = await response.json();
+  } catch (error) {
+    return isAbortOrTimeout(error) ? { kind: "transient" } : { kind: "invalid" };
   }
+
+  if (body === null || typeof body !== "object") {
+    return { kind: "invalid" };
+  }
+
+  const record = body as Record<string, unknown>;
+  const token = record.token;
+  const refreshToken = record.refreshToken;
+  if (
+    typeof token !== "string" ||
+    token.length === 0 ||
+    typeof refreshToken !== "string" ||
+    refreshToken.length === 0
+  ) {
+    return { kind: "invalid" };
+  }
+
+  return { kind: "ok", token, refreshToken };
 }
 
 function authnApiUrl(authnBaseUrl: string, path: string): string {

--- a/clients/shared/auth/device-auth.ts
+++ b/clients/shared/auth/device-auth.ts
@@ -190,11 +190,11 @@ export async function pollDeviceToken(
 
   if (response.status === 200) {
     const tokens = await readRotatedTokens(response);
-    // A 200 whose body fails validation is treated as transient: the loop
-    // re-polls (and, since the server consumed the code on mint, will then see
-    // a terminal `invalid`). This never silently drops a real success on a
-    // momentary parse hiccup.
-    if (tokens === null) {
+    // A 200 whose body fails validation OR whose read aborts/times out is
+    // treated as transient: the loop re-polls (and, since the server consumed
+    // the code on mint, will then see a terminal `invalid`). This never silently
+    // drops a real success on a momentary parse hiccup.
+    if (tokens.kind !== "ok") {
       return { kind: "network-error" };
     }
     return {


### PR DESCRIPTION
## Problem

The renderer's **"Initializing Traycer Host…"** screen is gated on `HostRuntimeProvider` completing `auth.start()`, which validates the stored session against the Traycer cloud (`GET /api/v3/user`, and `POST /api/v3/auth/refresh` on a 401) from the Electron main process.

Those `fetch` calls carried **no `AbortSignal`/timeout**. When the connection to the cloud stalls (offline, captive portal, half-open TCP, slow DNS), the call hangs until the OS TCP timeout — **minutes**. Because host-runtime startup is strictly sequential (`auth.start()` → `directory.start()` → `runtime.start()`), the renderer never reaches the step that dials the **local** host WebSocket. So:

- nothing is ever connected to the (healthy) local host;
- **restarting the host does nothing** — the host is never the blocker, the gate is upstream of the dial;
- it only self-recovers when the stalled fetch finally settles (observed: 10–20 min).

## Fix

Time-box the auth-boundary HTTP calls with `AbortSignal.timeout(AUTH_FETCH_TIMEOUT_MS)`. A fired timeout rejects the `fetch`, which the existing `catch` already maps to `network-error`.

- **Validation (`/api/v3/user`) and refresh (`/api/v3/auth/refresh`)** additionally get a bounded exponential-backoff retry (`withAuthNetworkRetry`) that re-drives **only** on `network-error` — a transport failure, a fired timeout, a 5xx, or a 409 refresh-grace race. A terminal `rejected`/`valid` returns on the first attempt, so a genuinely dead credential still signs out immediately.
- **Code exchange (`/api/v3/auth/exchange-code`)** gets the same timeout but is **deliberately not retried**: the PKCE `code` is single-use, so replaying it after a lost response would be rejected as already-consumed. The sign-in callback surfaces the `network-error` as a retry CTA instead.

Startup is now bounded to `AUTH_FETCH_MAX_ATTEMPTS` (3) attempts per retried call:

| Scenario | Before | After |
|---|---|---|
| Transient stall | 10–20 min hang | ~10s (times out, retry succeeds) |
| Fully offline | ~indefinite | bounded, then `network-error` → signed-out / retry |
| Healthy | instant | instant (no retries) |

Replaying the same `refreshToken` on a retry is safe: if a prior attempt's write was lost, the authn grace window replays the winner's rotated pair (the existing 409 path).

## Testing

- `clients/shared/auth/__tests__/auth-validation.test.ts`: 13/13 pass. Added coverage for the attached `AbortSignal`, the timeout → `network-error` mapping, transient-then-success retry, retry exhaustion, 409 retry, and the code-exchange path (signal attached + timeout → `network-error` with **exactly one** attempt / no retry). Fake timers keep the retry tests deterministic and instant.
- Type-checks clean for `@traycer-clients/traycer-cli` and `@traycer-clients/desktop`, which both consume the changed `shared/auth` code.

## Follow-up (out of scope)

A deeper change — decoupling the local host WebSocket dial from the cloud auth precheck so the host UI comes up while auth revalidates in the background — is intentionally deferred (it needs auth-state-machine changes).
