### PR TITLE
Set default permission mode to full access

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -875,7 +875,7 @@ describe("<ChatTile />", () => {
     // The toolbar stays editable mid-turn; the note only appears once the user
     // actually changes permission (live-mirror + steer reconcile the change).
     await waitFor(() => {
-      expect(getButtonByAriaLabel("Supervised").disabled).toBe(false);
+      expect(getButtonByAriaLabel("Full access").disabled).toBe(false);
       expect(
         screen.queryByText("New mode applies to the next turn"),
       ).toBeNull();
@@ -893,7 +893,7 @@ describe("<ChatTile />", () => {
     });
 
     await waitFor(() => {
-      expect(getButtonByAriaLabel("Supervised").disabled).toBe(false);
+      expect(getButtonByAriaLabel("Full access").disabled).toBe(false);
       expect(
         screen.queryByText("New mode applies to the next turn"),
       ).toBeNull();
@@ -1004,7 +1004,7 @@ describe("<ChatTile />", () => {
 
     // Approval-pending is still turn-in-progress, but the toolbar stays editable.
     await waitFor(() => {
-      expect(getButtonByAriaLabel("Supervised").disabled).toBe(false);
+      expect(getButtonByAriaLabel("Full access").disabled).toBe(false);
       expect(
         screen.queryByText("New mode applies to the next turn"),
       ).toBeNull();

--- a/clients/gui-app/src/components/home/data/landing-options.ts
+++ b/clients/gui-app/src/components/home/data/landing-options.ts
@@ -88,7 +88,7 @@ export const PERMISSION_OPTIONS: ReadonlyArray<PermissionOption> = [
   FULL_ACCESS_PERMISSION_OPTION,
 ];
 
-export const DEFAULT_PERMISSION: PermissionMode = "supervised";
+export const DEFAULT_PERMISSION: PermissionMode = "full_access";
 
 export function findPermissionLabel(mode: PermissionMode): string {
   return findPermissionOption(mode).label;

--- a/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
+++ b/clients/gui-app/src/stores/settings/__tests__/settings-store.test.ts
@@ -1,6 +1,9 @@
 import "../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { DEFAULT_AGENT_MODE } from "@/components/home/data/landing-options";
+import {
+  DEFAULT_AGENT_MODE,
+  DEFAULT_PERMISSION,
+} from "@/components/home/data/landing-options";
 import { DEFAULT_EPIC_NODE_ICON_COLORS } from "@/lib/artifacts/node-display";
 import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
 import { useSettingsStore } from "@/stores/settings/settings-store";
@@ -10,7 +13,7 @@ function resetSettingsStore(): void {
   useSettingsStore.setState({
     artifactIconColorMode: "byType",
     artifactIconColors: DEFAULT_EPIC_NODE_ICON_COLORS,
-    defaultPermission: "supervised",
+    defaultPermission: DEFAULT_PERMISSION,
     defaultAgentMode: DEFAULT_AGENT_MODE,
     defaultEditor: "vscode",
     notifyOnChatTurnComplete: true,
@@ -207,8 +210,8 @@ describe("useSettingsStore", () => {
     expect(useSettingsStore.getState().pinContextUsageBreakdown).toBe(false);
   });
 
-  it("defaults new chats to supervised permissions", () => {
-    expect(useSettingsStore.getState().defaultPermission).toBe("supervised");
+  it("defaults new chats to full access permissions", () => {
+    expect(useSettingsStore.getState().defaultPermission).toBe("full_access");
   });
 
   it("defaults new runs to epic mode", () => {


### PR DESCRIPTION
## Summary
- Default the GUI first-run/fallback permission mode to Full access.
- Update the focused settings-store test to assert the new default.

## Verification
- bun run test src/stores/settings/__tests__/settings-store.test.ts
- bun run compile
- bun run react-doctor (fails on pre-existing unrelated repo-wide diagnostics)
- npx -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score