### PR TITLE
[codex] Support named agent creation

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -191,6 +191,13 @@ describe("traycer CLI entrypoint registration", () => {
     expectCommand(program, ["agent", "turn-ended-from-hook"]);
   });
 
+  it("agent create exposes --name for a child agent display name", () => {
+    const program = buildProgram();
+    const cmd = expectCommand(program, ["agent", "create"]);
+    const flags = cmd.options.map((o) => o.long);
+    expect(flags).toContain("--name");
+  });
+
   it("limits readonly agent CLI help to inspection commands", () => {
     const originalSurface = process.env.TRAYCER_AGENT_CLI_SURFACE;
     process.env.TRAYCER_AGENT_CLI_SURFACE = "readonly";

--- a/clients/traycer-cli/src/commands/agent-create.ts
+++ b/clients/traycer-cli/src/commands/agent-create.ts
@@ -28,6 +28,7 @@ import type { CommandFn } from "../runner/runner";
 export function buildAgentCreateCommand(opts: {
   readonly epicId: string | null;
   readonly senderAgentId: string | null;
+  readonly name: string | null;
   readonly surface: string | null;
   readonly harness: string | null;
   readonly model: string | null;
@@ -48,6 +49,7 @@ export function buildAgentCreateCommand(opts: {
     const request = parseUserInput(createAgentRequestSchema, {
       senderAgentId,
       epicId,
+      name: opts.name,
       surface: opts.surface,
       harnessId: opts.harness,
       model: opts.model,

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -987,6 +987,7 @@ function registerAgentCommands(program: Command): void {
         "Creating (parent) agent (defaults to $TRAYCER_AGENT_ID)",
       )
       .option("--surface <surface>", "Child surface: 'gui' or 'tui'")
+      .option("--name <name>", "Display name for the child agent")
       .option(
         "--harness <id>",
         "Harness id: claude, codex, opencode, traycer, or cursor",
@@ -1022,6 +1023,7 @@ function registerAgentCommands(program: Command): void {
         epicId: typeof opts.epicId === "string" ? opts.epicId : null,
         senderAgentId:
           typeof opts.senderAgentId === "string" ? opts.senderAgentId : null,
+        name: typeof opts.name === "string" ? opts.name : null,
         surface: typeof opts.surface === "string" ? opts.surface : null,
         harness: typeof opts.harness === "string" ? opts.harness : null,
         model: typeof opts.model === "string" ? opts.model : null,

--- a/protocol/src/host/agent/__tests__/agent-schemas.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-schemas.test.ts
@@ -96,6 +96,7 @@ describe("agent host schemas", () => {
       createAgentRequestSchema.parse({
         senderAgentId: "agent-1",
         epicId: "epic-1",
+        name: "Review agent",
         surface: "gui",
         harnessId: "codex",
         model: "gpt-5.4",
@@ -105,6 +106,7 @@ describe("agent host schemas", () => {
       }),
     ).toMatchObject({
       senderAgentId: "agent-1",
+      name: "Review agent",
       surface: "gui",
       harnessId: "codex",
       model: "gpt-5.4",

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -189,6 +189,7 @@ export type CreateAgentWorkspace = z.infer<typeof createAgentWorkspaceSchema>;
 export const createAgentRequestSchema = z.object({
   senderAgentId: z.string(),
   epicId: z.string(),
+  name: z.string().min(1).nullable().default(null),
   surface: z.enum(["gui", "tui"]).nullable(),
   harnessId: agentFacingHarnessIdSchema.nullable(),
   model: z.string().nullable(),


### PR DESCRIPTION
## Summary
- add optional `name` to `agent.create` protocol requests
- expose `--name` on `traycer agent create`
- cover the protocol schema and CLI command registration

## Compatibility
- old clients can omit `name`; the schema defaults it to `null`
- new clients talking to older hosts may have the field ignored by older schemas

## Validation
- `bun run --filter @traycer/protocol compile`
- `bun run --filter @traycer/protocol test src/host/agent/__tests__/agent-schemas.test.ts`
- `bun run --filter @traycer-clients/traycer-cli test src/commands/__tests__/agent-create.test.ts`

Note: full CLI workspace checks are currently blocked locally by existing `tar` / `node-stream-zip` dependency resolution and Commander test typing issues.
