### PR TITLE
Fix harness listing CLI protocol compatibility

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/agent-harness-catalog.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-harness-catalog.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAgentListHarnessesCommand } from "../agent-list-harnesses";
+import { buildAgentListHarnessModelsCommand } from "../agent-list-harness-models";
+import { callHostRpc } from "../../internal/host-rpc";
+import { noopLogger } from "../../logger";
+import type { CommandContext } from "../../runner/runner";
+import type { RuntimeContext } from "../../runner/runtime";
+
+vi.mock("../../internal/host-rpc", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../internal/host-rpc")
+  >("../../internal/host-rpc");
+  return {
+    ...actual,
+    callHostRpc: vi.fn(),
+  };
+});
+
+const rpcMock = vi.mocked(callHostRpc);
+const PREV_ENV = {
+  epic: process.env.TRAYCER_EPIC_ID,
+  agent: process.env.TRAYCER_AGENT_ID,
+};
+
+function makeRuntime(): RuntimeContext {
+  return {
+    json: false,
+    quiet: false,
+    noProgress: false,
+    noBootstrap: false,
+    nonInteractive: false,
+    environment: "production",
+    logger: noopLogger,
+  };
+}
+
+function makeCtx(): CommandContext {
+  return {
+    runtime: makeRuntime(),
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.TRAYCER_EPIC_ID;
+  delete process.env.TRAYCER_AGENT_ID;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  if (PREV_ENV.epic === undefined) delete process.env.TRAYCER_EPIC_ID;
+  else process.env.TRAYCER_EPIC_ID = PREV_ENV.epic;
+  if (PREV_ENV.agent === undefined) delete process.env.TRAYCER_AGENT_ID;
+  else process.env.TRAYCER_AGENT_ID = PREV_ENV.agent;
+});
+
+describe("agent harness catalog commands", () => {
+  it("lists harness models without requiring epic or sender context", async () => {
+    rpcMock.mockResolvedValue({
+      harnessId: "codex",
+      models: [],
+    });
+
+    const result = await buildAgentListHarnessModelsCommand({
+      epicId: null,
+      senderAgentId: null,
+      harnessId: "codex",
+    })(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.listHarnessModels", {
+      epicId: null,
+      senderAgentId: null,
+      harnessId: "codex",
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("lists enabled harnesses without fetching every model catalog", async () => {
+    rpcMock.mockImplementation(async (method) => {
+      if (method === "agent.gui.listHarnesses") {
+        return {
+          harnesses: [
+            {
+              id: "codex",
+              label: "Codex",
+              enabled: true,
+              available: true,
+              error: null,
+              modes: ["gui", "tui"],
+              requiresApiKey: false,
+              supportedPermissionModes: [],
+              availabilityPending: false,
+            },
+            {
+              id: "openrouter",
+              label: "OpenRouter",
+              enabled: true,
+              available: false,
+              error: "Missing API key",
+              modes: ["gui"],
+              requiresApiKey: true,
+              supportedPermissionModes: [],
+              availabilityPending: false,
+            },
+            {
+              id: "grok",
+              label: "Grok",
+              enabled: false,
+              available: false,
+              error: "Disabled in Settings -> Providers",
+              modes: ["gui"],
+              requiresApiKey: false,
+              supportedPermissionModes: [],
+              availabilityPending: false,
+            },
+          ],
+        };
+      }
+      if (method === "agent.listHarnessModels") {
+        throw new Error("list-harnesses must not fetch models");
+      }
+      return {
+        harnessId: "unexpected",
+        models: [],
+      };
+    });
+
+    const result = await buildAgentListHarnessesCommand()(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.gui.listHarnesses", {});
+    expect(rpcMock).not.toHaveBeenCalledWith(
+      "agent.listHarnessModels",
+      expect.anything(),
+    );
+    expect(result.data).toMatchObject({
+      harnesses: [
+        {
+          id: "codex",
+          label: "Codex",
+          available: true,
+        },
+        {
+          id: "openrouter",
+          label: "OpenRouter",
+          available: false,
+          error: "Missing API key",
+        },
+      ],
+    });
+    expect(result.human).not.toContain("grok");
+    expect(result.human).toContain("codex - Codex");
+    expect(result.human).toContain("openrouter - OpenRouter [unavailable");
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -202,6 +202,7 @@ describe("traycer CLI entrypoint registration", () => {
       expect(help).toContain("transcript [options]");
       expect(help).not.toContain("create [options]");
       expect(help).not.toContain("selection-guide [options]");
+      expect(help).not.toContain("list-harnesses [options]");
       expect(help).not.toContain("list-harness-models [options]");
       expect(help).not.toContain("send [options]");
       expect(help).not.toContain("inbox [options]");
@@ -213,6 +214,19 @@ describe("traycer CLI entrypoint registration", () => {
         process.env.TRAYCER_AGENT_CLI_SURFACE = originalSurface;
       }
     }
+  });
+
+  it("registers agent harness catalog commands with current harness help", () => {
+    const program = buildProgram();
+    const agent = expectCommand(program, ["agent"]);
+    const create = expectCommand(program, ["agent", "create"]);
+    const listHarnesses = expectCommand(program, ["agent", "list-harnesses"]);
+    const listModels = expectCommand(program, ["agent", "list-harness-models"]);
+
+    expect(create.helpInformation()).toContain("openrouter");
+    expect(findSubcommand(agent, "list-harnesses")).toBe(listHarnesses);
+    expect(listModels.helpInformation()).toContain("openrouter");
+    expect(listModels.helpInformation()).toContain("<harness>");
   });
 
   it("host free-port-and-restart exposes --pid and --port so Doctor's free-port fix can be invoked", () => {

--- a/clients/traycer-cli/src/commands/agent-list-harness-models.ts
+++ b/clients/traycer-cli/src/commands/agent-list-harness-models.ts
@@ -9,7 +9,7 @@ import {
   parseUserInput,
   toAgentCliError,
 } from "../internal/host-rpc";
-import { resolveEpicId, resolveSenderAgentId } from "../internal/agent-context";
+import { readEpicId, readTuiAgentId } from "../internal/agent-context";
 import type { CommandFn } from "../runner/runner";
 
 export function buildAgentListHarnessModelsCommand(opts: {
@@ -18,21 +18,33 @@ export function buildAgentListHarnessModelsCommand(opts: {
   readonly harnessId: string;
 }): CommandFn {
   return async () => {
-    const epicId = resolveEpicId(opts.epicId);
-    const senderAgentId = resolveSenderAgentId(opts.senderAgentId);
-    const request = parseUserInput(listHarnessModelsRequestSchema, {
+    const epicId = readEpicId(opts.epicId);
+    const senderAgentId = readTuiAgentId(opts.senderAgentId);
+    const response = await listSingleHarnessModels(
+      opts.harnessId,
       epicId,
       senderAgentId,
-      harnessId: opts.harnessId,
-    });
-    const result = await toAgentCliError(
-      callHostRpc("agent.listHarnessModels", request),
     );
-    const response = parseHostResponse(listHarnessModelsResponseSchema, result);
     return {
       data: response,
       human: formatListHarnessModelsResponse(response),
       exitCode: 0,
     };
   };
+}
+
+async function listSingleHarnessModels(
+  harnessId: string,
+  epicId: string | null,
+  senderAgentId: string | null,
+) {
+  const request = parseUserInput(listHarnessModelsRequestSchema, {
+    epicId,
+    senderAgentId,
+    harnessId,
+  });
+  const result = await toAgentCliError(
+    callHostRpc("agent.listHarnessModels", request),
+  );
+  return parseHostResponse(listHarnessModelsResponseSchema, result);
 }

--- a/clients/traycer-cli/src/commands/agent-list-harnesses.ts
+++ b/clients/traycer-cli/src/commands/agent-list-harnesses.ts
@@ -1,0 +1,48 @@
+import {
+  formatListHarnessesResponse,
+  type FormattableHarnessSummary,
+} from "@traycer/protocol/agent/agent-harnesses";
+import {
+  listGuiHarnessesRequestSchema,
+  listGuiHarnessesResponseSchema,
+  type GuiHarnessOption,
+} from "@traycer/protocol/host/agent/gui/unary-schemas";
+import {
+  callHostRpc,
+  parseHostResponse,
+  parseUserInput,
+  toAgentCliError,
+} from "../internal/host-rpc";
+import type { CommandFn } from "../runner/runner";
+
+export function buildAgentListHarnessesCommand(): CommandFn {
+  return async () => {
+    const result = await toAgentCliError(
+      callHostRpc(
+        "agent.gui.listHarnesses",
+        parseUserInput(listGuiHarnessesRequestSchema, {}),
+      ),
+    );
+    const catalog = parseHostResponse(listGuiHarnessesResponseSchema, result);
+    const response = {
+      harnesses: catalog.harnesses
+        .filter((harness) => harness.enabled)
+        .map(harnessSummary),
+    };
+    return {
+      data: response,
+      human: formatListHarnessesResponse(response),
+      exitCode: 0,
+    };
+  };
+}
+
+function harnessSummary(harness: GuiHarnessOption): FormattableHarnessSummary {
+  return {
+    id: harness.id,
+    label: harness.label,
+    available: harness.available,
+    availabilityPending: harness.availabilityPending,
+    error: harness.error,
+  };
+}

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -6,12 +6,14 @@ import {
   CommanderError,
   type Command as CommanderCommand,
 } from "commander";
+import { AGENT_FACING_HARNESS_ID_LIST } from "@traycer/protocol/host/agent/shared";
 import { config } from "./config";
 import { buildCliMarkSourceCommand } from "./commands/cli-mark-source";
 import { buildCliReAnchorCommand } from "./commands/cli-re-anchor";
 import { buildCliUpgradeCommand } from "./commands/cli-upgrade";
 import { buildAgentCreateCommand } from "./commands/agent-create";
 import { buildAgentActivityFromHookCommand } from "./commands/agent-activity-from-hook";
+import { buildAgentListHarnessesCommand } from "./commands/agent-list-harnesses";
 import { buildAgentListHarnessModelsCommand } from "./commands/agent-list-harness-models";
 import { buildAgentListCommand } from "./commands/agent-list";
 import { buildAgentSelectionGuideCommand } from "./commands/agent-selection-guide";
@@ -86,6 +88,19 @@ export function extractActionPositionals(
       );
     }
     return [undefined];
+  });
+}
+
+function expectRequiredPositional(
+  value: string | undefined,
+  name: string,
+): string {
+  if (typeof value === "string") return value;
+  throw cliError({
+    code: CLI_ERROR_CODES.INVALID_ARGUMENT,
+    message: `traycer: ${name} is required.`,
+    details: null,
+    exitCode: 1,
   });
 }
 
@@ -949,6 +964,7 @@ function registerWorktreeCommands(program: Command): void {
 function registerAgentCommands(program: Command): void {
   const cliSurface = resolveAgentCliSurface(readonlyEnv());
   const readonlyHidden = { hidden: cliSurface === "readonly" };
+  const harnessHelp = `Harness id: ${AGENT_FACING_HARNESS_ID_LIST}`;
   const agent = program
     .command("agent")
     .description("Agent inspection and communication for the calling agent");
@@ -987,10 +1003,7 @@ function registerAgentCommands(program: Command): void {
         "Creating (parent) agent (defaults to $TRAYCER_AGENT_ID)",
       )
       .option("--surface <surface>", "Child surface: 'gui' or 'tui'")
-      .option(
-        "--harness <id>",
-        "Harness id: claude, codex, opencode, traycer, or cursor",
-      )
+      .option("--harness <id>", harnessHelp)
       .option("--model <id>", "Model id for the child agent")
       .option("--agent-mode <mode>", "Agent mode: regular or epic")
       .option(
@@ -1066,25 +1079,30 @@ function registerAgentCommands(program: Command): void {
 
   withRunner(
     agent
+      .command("list-harnesses", readonlyHidden)
+      .description("List enabled harnesses."),
+    () => buildAgentListHarnessesCommand(),
+  );
+
+  withRunner(
+    agent
       .command("list-harness-models", readonlyHidden)
-      .description(
-        "List the available models (and available params) for a harness.",
+      .description("List available models (and params) for one harness.")
+      .argument("<harness>", harnessHelp)
+      .option(
+        "--epic-id <id>",
+        "Optional epic context (defaults to $TRAYCER_EPIC_ID)",
       )
-      .argument(
-        "<harness>",
-        "Harness id: claude, codex, opencode, traycer, or cursor",
-      )
-      .option("--epic-id <id>", "Epic (defaults to $TRAYCER_EPIC_ID)")
       .option(
         "--sender-agent-id <id>",
-        "Calling agent (defaults to $TRAYCER_AGENT_ID)",
+        "Optional calling-agent context (defaults to $TRAYCER_AGENT_ID)",
       ),
     (opts, args) =>
       buildAgentListHarnessModelsCommand({
         epicId: typeof opts.epicId === "string" ? opts.epicId : null,
         senderAgentId:
           typeof opts.senderAgentId === "string" ? opts.senderAgentId : null,
-        harnessId: args[0] ?? "",
+        harnessId: expectRequiredPositional(args[0], "harness"),
       }),
   );
 

--- a/protocol/src/agent/agent-harnesses.ts
+++ b/protocol/src/agent/agent-harnesses.ts
@@ -1,0 +1,31 @@
+export type FormattableHarnessSummary = {
+  readonly id: string;
+  readonly label: string;
+  readonly available: boolean;
+  readonly availabilityPending: boolean;
+  readonly error: string | null;
+};
+
+export type FormattableListHarnessesResponse = {
+  readonly harnesses: readonly FormattableHarnessSummary[];
+};
+
+export function formatListHarnessesResponse(
+  response: FormattableListHarnessesResponse,
+): string {
+  if (response.harnesses.length === 0) {
+    return "No enabled harnesses found.";
+  }
+  return `Each line is: harness-id - label [status]
+
+${response.harnesses.map(formatHarnessSummary).join("\n")}`;
+}
+
+function formatHarnessSummary(harness: FormattableHarnessSummary): string {
+  const status = harness.availabilityPending
+    ? " [pending]"
+    : harness.available
+      ? ""
+      : ` [unavailable${harness.error === null ? "" : `: ${harness.error}`}]`;
+  return `${harness.id} - ${harness.label}${status}`;
+}

--- a/protocol/src/host/agent/__tests__/agent-schemas.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-schemas.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
+import { downgradeRequestAcrossMajors } from "@traycer/protocol/framework/index";
+import { agentListHarnessModelsDowngradeV2ToV1 } from "@traycer/protocol/host/agent/contracts";
 import {
   agentSelectionGuideResponseSchema,
   createAgentRequestSchema,
   hostRpcRegistry,
   getGuiAgentPlanRequestSchema,
   getGuiAgentPlanResponseSchema,
+  listHarnessModelsRequestSchema,
+  listHarnessModelsRequestSchemaV10,
   listHarnessModelsResponseSchema,
   listAgentsResponseSchema,
   listGuiAgentCommandsRequestSchema,
@@ -42,6 +46,119 @@ describe("agent host schemas", () => {
     ).toMatchObject({
       harnessId: "codex",
       commands: [{ name: "frontend-design", kind: "skill" }],
+    });
+  });
+
+  it("defaults agent.listHarnessModels context fields to null", () => {
+    expect(
+      listHarnessModelsRequestSchema.parse({
+        harnessId: "codex",
+      }),
+    ).toEqual({
+      epicId: null,
+      senderAgentId: null,
+      harnessId: "codex",
+    });
+  });
+
+  it("keeps agent.listHarnessModels v1.0 request context required", () => {
+    expect(
+      listHarnessModelsRequestSchemaV10.safeParse({
+        epicId: null,
+        senderAgentId: null,
+        harnessId: "codex",
+      }).success,
+    ).toBe(false);
+    expect(
+      listHarnessModelsRequestSchemaV10.parse({
+        epicId: "epic-1",
+        senderAgentId: "agent-1",
+        harnessId: "codex",
+      }),
+    ).toEqual({
+      epicId: "epic-1",
+      senderAgentId: "agent-1",
+      harnessId: "codex",
+    });
+  });
+
+  it("downgrades contextual agent.listHarnessModels v2.0 requests to v1.0", () => {
+    expect(
+      agentListHarnessModelsDowngradeV2ToV1.downgradeRequest({
+        epicId: "epic-1",
+        senderAgentId: "agent-1",
+        harnessId: "codex",
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        epicId: "epic-1",
+        senderAgentId: "agent-1",
+        harnessId: "codex",
+      },
+    });
+  });
+
+  it("downgrades contextual agent.listHarnessModels through the host registry", () => {
+    expect(
+      downgradeRequestAcrossMajors(
+        hostRpcRegistry["agent.listHarnessModels"],
+        2,
+        1,
+        {
+          epicId: "epic-1",
+          senderAgentId: "agent-1",
+          harnessId: "codex",
+        },
+      ),
+    ).toEqual({
+      ok: true,
+      value: {
+        epicId: "epic-1",
+        senderAgentId: "agent-1",
+        harnessId: "codex",
+      },
+    });
+  });
+
+  it("rejects no-context agent.listHarnessModels v2.0 downgrades", () => {
+    expect(
+      agentListHarnessModelsDowngradeV2ToV1.downgradeRequest({
+        epicId: null,
+        senderAgentId: null,
+        harnessId: "codex",
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "DOWNGRADE_UNSUPPORTED" },
+    });
+    expect(
+      agentListHarnessModelsDowngradeV2ToV1.downgradeRequest({
+        epicId: "epic-1",
+        senderAgentId: null,
+        harnessId: "codex",
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "DOWNGRADE_UNSUPPORTED" },
+    });
+  });
+
+  it("rejects no-context agent.listHarnessModels registry downgrades", () => {
+    expect(
+      downgradeRequestAcrossMajors(
+        hostRpcRegistry["agent.listHarnessModels"],
+        2,
+        1,
+        {
+          epicId: null,
+          senderAgentId: null,
+          harnessId: "codex",
+        },
+      ),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "DOWNGRADE_UNSUPPORTED" },
     });
   });
 
@@ -242,6 +359,10 @@ describe("agent host schemas", () => {
       hostRpcRegistry["agent.listHarnessModels"][1].versions[0].contract
         .schemaVersion,
     ).toEqual({ major: 1, minor: 0 });
+    expect(
+      hostRpcRegistry["agent.listHarnessModels"][2].versions[0].contract
+        .schemaVersion,
+    ).toEqual({ major: 2, minor: 0 });
     expect(
       hostRpcRegistry["agent.list"][1].versions[0].contract.schemaVersion,
     ).toEqual({ major: 1, minor: 0 });

--- a/protocol/src/host/agent/__tests__/agent-schemas.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-schemas.test.ts
@@ -7,8 +7,8 @@ import {
   hostRpcRegistry,
   getGuiAgentPlanRequestSchema,
   getGuiAgentPlanResponseSchema,
-  listHarnessModelsRequestSchema,
   listHarnessModelsRequestSchemaV10,
+  listHarnessModelsRequestSchemaV20,
   listHarnessModelsResponseSchema,
   listAgentsResponseSchema,
   listGuiAgentCommandsRequestSchema,
@@ -51,7 +51,7 @@ describe("agent host schemas", () => {
 
   it("defaults agent.listHarnessModels context fields to null", () => {
     expect(
-      listHarnessModelsRequestSchema.parse({
+      listHarnessModelsRequestSchemaV20.parse({
         harnessId: "codex",
       }),
     ).toEqual({
@@ -253,6 +253,7 @@ describe("agent host schemas", () => {
       }),
     ).toMatchObject({
       senderAgentId: "agent-1",
+      name: null,
       surface: null,
       harnessId: "claude",
       model: "opus-4.7",

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -19,6 +19,7 @@ import {
   getAgentTranscriptRequestSchema,
   getAgentTranscriptResponseSchema,
   listHarnessModelsRequestSchema,
+  listHarnessModelsRequestSchemaV10,
   listHarnessModelsResponseSchema,
   listAgentsRequestSchema,
   listAgentsResponseSchema,
@@ -89,8 +90,54 @@ export const agentSelectionGuideGlobalResetV10 = defineRpcContract({
 export const agentListHarnessModelsV10 = defineRpcContract({
   method: "agent.listHarnessModels",
   schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: listHarnessModelsRequestSchemaV10,
+  responseSchema: listHarnessModelsResponseSchema,
+});
+
+export const agentListHarnessModelsV20 = defineRpcContract({
+  method: "agent.listHarnessModels",
+  schemaVersion: { major: 2, minor: 0 } as const,
   requestSchema: listHarnessModelsRequestSchema,
   responseSchema: listHarnessModelsResponseSchema,
+});
+
+export const agentListHarnessModelsUpgradeV1ToV2 = defineUpgradePath<
+  typeof agentListHarnessModelsV10,
+  typeof agentListHarnessModelsV20
+>({
+  from: { major: 1, minor: 0 },
+  to: { major: 2, minor: 0 },
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const agentListHarnessModelsDowngradeV2ToV1 = defineDowngradePath<
+  typeof agentListHarnessModelsV20,
+  typeof agentListHarnessModelsV10
+>({
+  from: { major: 2, minor: 0 },
+  to: { major: 1, minor: 0 },
+  downgradeRequest: (request) => {
+    if (request.epicId === null || request.senderAgentId === null) {
+      return {
+        ok: false,
+        error: {
+          code: "DOWNGRADE_UNSUPPORTED",
+          message:
+            "agent.listHarnessModels without epic and sender agent context requires a newer Traycer host.",
+        },
+      };
+    }
+    return {
+      ok: true,
+      value: {
+        epicId: request.epicId,
+        senderAgentId: request.senderAgentId,
+        harnessId: request.harnessId,
+      },
+    };
+  },
+  downgradeResponse: (response) => ({ ok: true, value: response }),
 });
 
 export const agentListV10 = defineRpcContract({

--- a/protocol/src/host/agent/contracts.ts
+++ b/protocol/src/host/agent/contracts.ts
@@ -18,8 +18,8 @@ import {
   agentSelectionGuideGlobalSetResponseSchema,
   getAgentTranscriptRequestSchema,
   getAgentTranscriptResponseSchema,
-  listHarnessModelsRequestSchema,
   listHarnessModelsRequestSchemaV10,
+  listHarnessModelsRequestSchemaV20,
   listHarnessModelsResponseSchema,
   listAgentsRequestSchema,
   listAgentsResponseSchema,
@@ -97,7 +97,7 @@ export const agentListHarnessModelsV10 = defineRpcContract({
 export const agentListHarnessModelsV20 = defineRpcContract({
   method: "agent.listHarnessModels",
   schemaVersion: { major: 2, minor: 0 } as const,
-  requestSchema: listHarnessModelsRequestSchema,
+  requestSchema: listHarnessModelsRequestSchemaV20,
   responseSchema: listHarnessModelsResponseSchema,
 });
 

--- a/protocol/src/host/agent/gui/unary-schemas.ts
+++ b/protocol/src/host/agent/gui/unary-schemas.ts
@@ -29,6 +29,7 @@ export type HarnessSurface = z.infer<typeof harnessSurfaceSchema>;
 export const guiHarnessOptionSchema = z.object({
   id: guiHarnessIdSchema,
   label: z.string(),
+  enabled: z.boolean().default(true),
   available: z.boolean(),
   error: z.string().nullable(),
   modes: z.array(harnessSurfaceSchema),

--- a/protocol/src/host/agent/gui/unary-schemas.ts
+++ b/protocol/src/host/agent/gui/unary-schemas.ts
@@ -29,6 +29,9 @@ export type HarnessSurface = z.infer<typeof harnessSurfaceSchema>;
 export const guiHarnessOptionSchema = z.object({
   id: guiHarnessIdSchema,
   label: z.string(),
+  // Controls whether the harness is included in downstream filtering and shown
+  // in the CLI. This is distinct from `available` and `availabilityPending`,
+  // which describe the current host-side availability probe state.
   enabled: z.boolean().default(true),
   available: z.boolean(),
   error: z.string().nullable(),

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -123,7 +123,7 @@ export function canParticipateInA2A(target: {
 // renderer routes to the right UI. Other RPCs address the agent by id and
 // resolve `surface` from storage; they do not carry it on the wire.
 
-export const agentFacingHarnessIdSchema = harnessIdSchema.extract([
+export const AGENT_FACING_HARNESS_IDS = [
   "claude",
   "codex",
   "opencode",
@@ -137,6 +137,12 @@ export const agentFacingHarnessIdSchema = harnessIdSchema.extract([
   "copilot",
   "kilocode",
   "openrouter",
+] as const;
+
+export const AGENT_FACING_HARNESS_ID_LIST = AGENT_FACING_HARNESS_IDS.join(", ");
+
+export const agentFacingHarnessIdSchema = harnessIdSchema.extract([
+  ...AGENT_FACING_HARNESS_IDS,
 ]);
 export type AgentFacingHarnessId = z.infer<typeof agentFacingHarnessIdSchema>;
 
@@ -318,9 +324,18 @@ export type AgentSelectionGuideGlobalResetResponse = z.infer<
   typeof agentSelectionGuideGlobalResetResponseSchema
 >;
 
-export const listHarnessModelsRequestSchema = z.object({
+export const listHarnessModelsRequestSchemaV10 = z.object({
   epicId: z.string(),
   senderAgentId: z.string(),
+  harnessId: agentFacingHarnessIdSchema,
+});
+export type ListHarnessModelsRequestV10 = z.infer<
+  typeof listHarnessModelsRequestSchemaV10
+>;
+
+export const listHarnessModelsRequestSchema = z.object({
+  epicId: z.string().nullable().default(null),
+  senderAgentId: z.string().nullable().default(null),
   harnessId: agentFacingHarnessIdSchema,
 });
 export type ListHarnessModelsRequest = z.infer<

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -334,13 +334,14 @@ export type ListHarnessModelsRequestV10 = z.infer<
   typeof listHarnessModelsRequestSchemaV10
 >;
 
-export const listHarnessModelsRequestSchema = z.object({
+export const listHarnessModelsRequestSchemaV20 = z.object({
   epicId: z.string().nullable().default(null),
   senderAgentId: z.string().nullable().default(null),
   harnessId: agentFacingHarnessIdSchema,
 });
+export const listHarnessModelsRequestSchema = listHarnessModelsRequestSchemaV20;
 export type ListHarnessModelsRequest = z.infer<
-  typeof listHarnessModelsRequestSchema
+  typeof listHarnessModelsRequestSchemaV20
 >;
 
 export const harnessModelSummarySchema = z.object({

--- a/protocol/src/host/agent/tui/unary-schemas.ts
+++ b/protocol/src/host/agent/tui/unary-schemas.ts
@@ -14,6 +14,9 @@ import { GENERATE_TITLE_SOURCE_TEXT_MAX_CHARS } from "@traycer/protocol/host/epi
 export const tuiHarnessOptionSchema = z.object({
   id: tuiHarnessIdSchema,
   label: z.string(),
+  // Controls whether the harness is included in downstream filtering and shown
+  // in the CLI. This is distinct from `available` and `availabilityPending`,
+  // which describe the current host-side availability probe state.
   enabled: z.boolean().default(true),
   available: z.boolean(),
   error: z.string().nullable(),

--- a/protocol/src/host/agent/tui/unary-schemas.ts
+++ b/protocol/src/host/agent/tui/unary-schemas.ts
@@ -14,6 +14,7 @@ import { GENERATE_TITLE_SOURCE_TEXT_MAX_CHARS } from "@traycer/protocol/host/epi
 export const tuiHarnessOptionSchema = z.object({
   id: tuiHarnessIdSchema,
   label: z.string(),
+  enabled: z.boolean().default(true),
   available: z.boolean(),
   error: z.string().nullable(),
   // True while the host's availability probe for this harness is still running

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -8,7 +8,10 @@ import { defineVersionedStreamRpcRegistry } from "@traycer/protocol/framework/ve
 import {
   agentCreateV10,
   agentGetTranscriptV10,
+  agentListHarnessModelsDowngradeV2ToV1,
   agentListHarnessModelsV10,
+  agentListHarnessModelsV20,
+  agentListHarnessModelsUpgradeV1ToV2,
   agentListDowngradeV2ToV1,
   agentListUpgradeV1ToV2,
   agentListV10,
@@ -1339,6 +1342,18 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
         },
       },
       downgradePathsFromLatest: {},
+    },
+    2: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: agentListHarnessModelsV20,
+          upgradeFromPreviousVersion: agentListHarnessModelsUpgradeV1ToV2,
+        },
+      },
+      downgradePathsFromLatest: {
+        1: agentListHarnessModelsDowngradeV2ToV1,
+      },
     },
   },
   "agent.list": {


### PR DESCRIPTION
## Summary
- freeze `agent.listHarnessModels@1.0` with required context and add nullable-context `@2.0`
- add v2→v1 downgrade behavior that maps contextual requests and rejects no-context requests with `DOWNGRADE_UNSUPPORTED`
- split `agent list-harnesses` from `agent list-harness-models <harness>` so listing harnesses no longer fetches every model catalog
- update harness help text to use the shared agent-facing harness list

## Tests
- `bun run --filter @traycer/protocol test -- src/host/agent/__tests__/agent-schemas.test.ts src/host/agent/gui/__tests__/grok-versioning.test.ts src/host/__tests__/released-surface-compat.test.ts`
- `bun run --filter @traycer/protocol compile`
- `bun run --filter @traycer-clients/traycer-cli test -- src/commands/__tests__/agent-harness-catalog.test.ts src/commands/__tests__/cli-entrypoint-registration.test.ts`
- `bun run --filter @traycer-clients/traycer-cli compile`
- `git -C traycer diff --check`