### PR TITLE
fix(gui-app): unstick header tab close button and reorder highlight

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -331,9 +331,14 @@ describe("<TabStrip />", () => {
     expect(hoverChrome?.className).toContain("group-hover/tab:opacity-100");
     // :focus-visible (keyboard-only), NOT :focus-within - a mouse-drag reorder
     // focuses the tab div without activating it, and :focus-within would leave
-    // this accent chrome stuck lit on the inactive tab. See tab-strip-item.tsx.
+    // this accent chrome stuck lit on the inactive tab. The has-[:focus-visible]
+    // gate keeps it lit when the separate close button (a descendant tab stop)
+    // takes keyboard focus. See tab-strip-item.tsx.
     expect(hoverChrome?.className).toContain(
       "group-focus-visible/tab:opacity-100",
+    );
+    expect(hoverChrome?.className).toContain(
+      "group-has-[:focus-visible]/tab:opacity-100",
     );
     expect(hoverChrome?.querySelector("svg")).toBeNull();
   });

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -329,8 +329,11 @@ describe("<TabStrip />", () => {
     expect(closeSlot.className).not.toContain("group-hover/tab:w-5");
     expect(hoverChrome?.className).toContain("rounded-md");
     expect(hoverChrome?.className).toContain("group-hover/tab:opacity-100");
+    // :focus-visible (keyboard-only), NOT :focus-within - a mouse-drag reorder
+    // focuses the tab div without activating it, and :focus-within would leave
+    // this accent chrome stuck lit on the inactive tab. See tab-strip-item.tsx.
     expect(hoverChrome?.className).toContain(
-      "group-focus-within/tab:opacity-100",
+      "group-focus-visible/tab:opacity-100",
     );
     expect(hoverChrome?.querySelector("svg")).toBeNull();
   });

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -576,7 +576,7 @@ function TabChrome(props: { readonly isActive: boolean }) {
     return (
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-x-2 inset-y-1 rounded-md bg-accent/45 opacity-0 transition-opacity duration-150 ease-out group-focus-visible/tab:opacity-100 group-hover/tab:opacity-100"
+        className="pointer-events-none absolute inset-x-2 inset-y-1 rounded-md bg-accent/45 opacity-0 transition-opacity duration-150 ease-out group-focus-visible/tab:opacity-100 group-has-[:focus-visible]/tab:opacity-100 group-hover/tab:opacity-100"
       />
     );
   }

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -549,7 +549,7 @@ function TabTrailingSlot(props: TabTrailingSlotProps) {
             onClose();
           }}
           className={cn(
-            "header-tab-close-button pointer-events-none size-5 text-muted-foreground hover:text-foreground [-webkit-app-region:no-drag]",
+            "header-tab-close-button size-5 text-muted-foreground hover:text-foreground [-webkit-app-region:no-drag]",
             active &&
               "text-foreground/70 hover:bg-accent hover:text-accent-foreground",
           )}
@@ -576,7 +576,7 @@ function TabChrome(props: { readonly isActive: boolean }) {
     return (
       <span
         aria-hidden
-        className="pointer-events-none absolute inset-x-2 inset-y-1 rounded-md bg-accent/45 opacity-0 transition-opacity duration-150 ease-out group-focus-within/tab:opacity-100 group-hover/tab:opacity-100"
+        className="pointer-events-none absolute inset-x-2 inset-y-1 rounded-md bg-accent/45 opacity-0 transition-opacity duration-150 ease-out group-focus-visible/tab:opacity-100 group-hover/tab:opacity-100"
       />
     );
   }

--- a/clients/gui-app/src/index.css
+++ b/clients/gui-app/src/index.css
@@ -1137,15 +1137,33 @@
     opacity: 0;
   }
 
+  /* The close button is inert by default and only becomes clickable once the
+     tab is wide enough and hovered / keyboard-focused. Keep BOTH the `none`
+     default and the `auto` reveal in this same @layer so the reveal wins by
+     specificity. Do NOT put a `pointer-events-none` Tailwind utility on the
+     button: it lands in Tailwind's `utilities` layer, declared after
+     `components`, so it would beat this reveal in every state and leave the
+     button permanently unclickable. */
+  .header-tab-close-button {
+    pointer-events: none;
+  }
+
+  /* Reveal on hover or :focus-visible (NOT :focus-within). A mouse-drag
+     reorder focuses the tab div, and dnd-kit swallows the trailing click so the
+     tab is never activated - with :focus-within the reveal (slot width + close
+     button) would stay stuck lit on that inactive tab until focus moved away.
+     :focus-visible is keyboard-only, so drag focus doesn't trigger it while Tab
+     navigation still does. Keep this in sync with the accent chrome's
+     `group-focus-visible/tab` gate in tab-strip-item.tsx. */
   @container (min-width: 7rem) {
     .group\/tab:hover .header-tab-trailing-slot,
-    .group\/tab:focus-within .header-tab-trailing-slot {
+    .group\/tab:focus-visible .header-tab-trailing-slot {
       width: 1.25rem;
       opacity: 1;
     }
 
     .group\/tab:hover .header-tab-close-button,
-    .group\/tab:focus-within .header-tab-close-button {
+    .group\/tab:focus-visible .header-tab-close-button {
       pointer-events: auto;
     }
   }

--- a/clients/gui-app/src/index.css
+++ b/clients/gui-app/src/index.css
@@ -1148,22 +1148,30 @@
     pointer-events: none;
   }
 
-  /* Reveal on hover or :focus-visible (NOT :focus-within). A mouse-drag
-     reorder focuses the tab div, and dnd-kit swallows the trailing click so the
-     tab is never activated - with :focus-within the reveal (slot width + close
-     button) would stay stuck lit on that inactive tab until focus moved away.
-     :focus-visible is keyboard-only, so drag focus doesn't trigger it while Tab
-     navigation still does. Keep this in sync with the accent chrome's
-     `group-focus-visible/tab` gate in tab-strip-item.tsx. */
+  /* Reveal on hover, or keyboard focus - NOT :focus-within. A mouse-drag reorder
+     focuses the tab div, and dnd-kit swallows the trailing click so the tab is
+     never activated; with :focus-within the reveal (slot width + close button)
+     would stay stuck lit on that inactive tab until focus moved away.
+     Keyboard focus is expressed as :focus-visible (mouse focus doesn't match it,
+     so a drag doesn't stick) across two selectors:
+       - `:focus-visible` for the tab wrapper itself (Tab lands on the tab), and
+       - `:has(:focus-visible)` for a focused descendant - the close button is a
+         SEPARATE tab stop, and when Tab moves onto it the wrapper is no longer
+         :focus-visible, so without this the slot would collapse and hide the
+         very button the user just focused.
+     Keep in sync with the accent chrome's `group-focus-visible/tab` +
+     `group-has-[:focus-visible]/tab` gates in tab-strip-item.tsx. */
   @container (min-width: 7rem) {
     .group\/tab:hover .header-tab-trailing-slot,
-    .group\/tab:focus-visible .header-tab-trailing-slot {
+    .group\/tab:focus-visible .header-tab-trailing-slot,
+    .group\/tab:has(:focus-visible) .header-tab-trailing-slot {
       width: 1.25rem;
       opacity: 1;
     }
 
     .group\/tab:hover .header-tab-close-button,
-    .group\/tab:focus-visible .header-tab-close-button {
+    .group\/tab:focus-visible .header-tab-close-button,
+    .group\/tab:has(:focus-visible) .header-tab-close-button {
       pointer-events: auto;
     }
   }


### PR DESCRIPTION
## Summary

Fixes two header tab strip bugs, both regressions from the tab-strip refactor in #180.

### 1. Close (X) button never closed the tab
The close `<Button>` hard-coded the `pointer-events-none` Tailwind utility, which lands in Tailwind v4's `utilities` cascade layer. The re-enable rule (`pointer-events: auto` on hover/focus) lived in `@layer components`. Cascade-layer order (`theme, base, components, utilities`) means `utilities` wins over `components` regardless of specificity, so the button was permanently `pointer-events: none` - clicks fell through to the tab `<div>` and just re-activated the tab instead of closing it.

**Fix:** move the base `pointer-events: none` default into the same `@layer components` block as the reveal, and drop the utility from the button. Now both rules share a layer and the hover/focus reveal wins by specificity. The `@container (min-width: 7rem)` compact-tab gating is preserved.

### 2. Reordering a tab left the inactive tab stuck highlighted
The tab `<div>` is focusable (`tabIndex={0}`), the dnd-kit drag activator, and the `group/tab` scope - all one node. A mouse-drag reorder focuses it on mousedown, commits via `moveRef` (no activation), and dnd-kit swallows the trailing click, so `activateTab` never runs. Nothing blurs it (dnd-kit's `RestoreFocus` is keyboard-only). The result: an inactive-but-focused tab, and the `:focus-within`-gated accent chrome + trailing-slot/close-button reveals stayed lit until focus moved elsewhere.

**Fix:** gate all three reveals on `:focus-visible` (keyboard-only) instead of `:focus-within`. A mouse-drag focus doesn't match `:focus-visible`, so nothing sticks; keyboard `Tab` navigation still reveals them.

## Changes
- `clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx` - drop `pointer-events-none` from the close button; accent chrome `group-focus-within/tab` → `group-focus-visible/tab`.
- `clients/gui-app/src/index.css` - add the `pointer-events: none` default in `@layer components`; trailing-slot + close-button reveals `:focus-within` → `:focus-visible`.
- `clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx` - update the class-contract assertion to `group-focus-visible/tab`.

## Testing
- `bun run compile` (tsc) clean.
- `bun run test tab-strip use-close-tab-flow` - 44/44 pass (incl. the updated contract test).
- Verified against the compiled Tailwind output: the close button's pointer-events and all three reveals now resolve in the intended cascade layer / `:focus-visible` state.
- Not driven in a real browser in this environment (no headless browser available); both fixes are deterministic CSS cascade / `:focus-visible` behavior. A manual mouse-drag + click-through in the desktop app is still worth a reviewer sanity check.
