### PR TITLE
fix(gui-app): show viewer-locked create actions as disabled with tooltips

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/add-node-dropdown.tsx
+++ b/clients/gui-app/src/components/epic-canvas/add-node-dropdown.tsx
@@ -101,8 +101,8 @@ export interface AddArtifactDropdownProps {
    */
   tuiAgentPending: boolean | undefined;
   disabled: boolean | undefined;
-  /** Tooltip text to show when disabled. Omit when no special message needed. */
-  disabledTooltip: string | undefined;
+  /** Tooltip text to show when disabled. `null` when no special message needed. */
+  disabledTooltip: string | null;
   disabledTypes: ReadonlyArray<EpicNodeKind> | undefined;
   /**
    * Optional set of kinds to omit from the dropdown.
@@ -157,7 +157,7 @@ export function AddNodeDropdown(props: AddArtifactDropdownProps) {
   if (disabled) {
     return (
       <TooltipWrapper
-        label={disabledTooltip ?? null}
+        label={disabledTooltip}
         side="top"
         sideOffset={undefined}
         align={undefined}

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -50,7 +50,7 @@ import {
   useLeftPanelStore,
   type LeftPanelId,
 } from "@/stores/epics/left-panel-store";
-import { isEditablePermissionRole } from "@/lib/epic-collaborator-roles";
+import { isEditableRole } from "@/lib/epic-permissions";
 
 interface TabGroupViewProps {
   readonly epicId: string;
@@ -114,7 +114,7 @@ export const TabGroupView = memo(function TabGroupView(
   );
   const renameTab = useRenameCanvasTab(epicId, tabId);
   const permissionRole = useEpicPermissionRole();
-  const canRenameTabs = isEditablePermissionRole(permissionRole);
+  const canRenameTabs = isEditableRole(permissionRole);
 
   // Per-pane boolean (not the raw `activePaneId`) so switching the active
   // pane re-renders only the two panes whose active state flips, not all of

--- a/clients/gui-app/src/components/epic-canvas/renderers/story-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/story-tile.tsx
@@ -22,6 +22,7 @@ import {
   useEpicSnapshotMeta,
 } from "@/lib/epic-selectors";
 import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import { isEditableRole } from "@/lib/epic-permissions";
 import { cn } from "@/lib/utils";
 
 interface StoryTileProps {
@@ -46,7 +47,7 @@ function StatusPill(props: {
   const epicId = meta?.epicLight?.id ?? "";
   const liveArtifact = useEpicArtifact(artifactId);
   const role = useEpicPermissionRole();
-  const canEdit = role === "owner" || role === "editor";
+  const canEdit = isEditableRole(role);
   const connectionStatus = useEpicConnectionStatus();
   const isDisconnected = connectionStatus === "closed";
   const updateStatus = useEpicUpdateArtifactStatus();

--- a/clients/gui-app/src/components/epic-canvas/renderers/ticket-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/ticket-tile.tsx
@@ -15,6 +15,7 @@ import {
   useEpicSnapshotMeta,
 } from "@/lib/epic-selectors";
 import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import { isEditableRole } from "@/lib/epic-permissions";
 import { cn } from "@/lib/utils";
 
 interface TicketTileProps {
@@ -39,7 +40,7 @@ function StatusPill(props: {
   const epicId = meta?.epicLight?.id ?? "";
   const liveArtifact = useEpicArtifact(artifactId);
   const role = useEpicPermissionRole();
-  const canEdit = role === "owner" || role === "editor";
+  const canEdit = isEditableRole(role);
   const connectionStatus = useEpicConnectionStatus();
   const isDisconnected = connectionStatus === "closed";
   const updateStatus = useEpicUpdateArtifactStatus();

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -1740,9 +1740,7 @@ function ArtifactAddChildButton(props: ArtifactAddChildButtonProps) {
       excludeTypes={ARTIFACT_PANEL_EXCLUDED_TYPES}
       disabledTypes={undefined}
       disabled={!canMutate || addChildIsPending}
-      disabledTooltip={
-        isDisconnected ? "Reconnect to make changes." : undefined
-      }
+      disabledTooltip={isDisconnected ? "Reconnect to make changes." : null}
     >
       <Button
         type="button"

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -16,6 +16,10 @@ import {
   type EpicNodeKind,
 } from "@/lib/artifacts/node-display";
 import { AddNodeDropdown } from "@/components/epic-canvas/add-node-dropdown";
+import {
+  ARIA_DISABLED_TRIGGER_CLASS,
+  resolveDisabledPresentation,
+} from "@/lib/disabled-presentation";
 import { ARTIFACT_PANEL_EXCLUDED_TYPES } from "@/components/epic-canvas/add-node-options";
 import {
   computeDescendantCountsFromTree,
@@ -1722,6 +1726,12 @@ function ArtifactAddChildButton(props: ArtifactAddChildButtonProps) {
     isDisconnected,
     onAdd,
   } = props;
+  const disabled = !canMutate || addChildIsPending;
+  const disabledTooltip = isDisconnected ? "Reconnect to make changes." : null;
+  const { ariaDisabled, nativeDisabled } = resolveDisabledPresentation(
+    disabled,
+    disabledTooltip,
+  );
   return (
     <AddNodeDropdown
       open={undefined}
@@ -1739,20 +1749,22 @@ function ArtifactAddChildButton(props: ArtifactAddChildButtonProps) {
       tuiAgentPending={undefined}
       excludeTypes={ARTIFACT_PANEL_EXCLUDED_TYPES}
       disabledTypes={undefined}
-      disabled={!canMutate || addChildIsPending}
-      disabledTooltip={isDisconnected ? "Reconnect to make changes." : null}
+      disabled={disabled}
+      disabledTooltip={disabledTooltip}
     >
       <Button
         type="button"
         variant="ghost"
         size="icon-xs"
         aria-label="Add child artifact"
+        aria-disabled={ariaDisabled ? true : undefined}
         data-testid={`epic-sidebar-add-${nodeId}`}
         className={cn(
           "absolute right-7 top-1/2 -translate-y-1/2",
+          ARIA_DISABLED_TRIGGER_CLASS,
           rowAddControlRevealClass(addChildIsPending),
         )}
-        disabled={!canMutate || addChildIsPending}
+        disabled={nativeDisabled}
       >
         {addChildIsPending ? (
           <AgentSpinningDots

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -122,6 +122,10 @@ import {
   type EpicTreeRecord,
 } from "@/lib/epic-selectors";
 import { isEditableRole, mutationDisabledHint } from "@/lib/epic-permissions";
+import {
+  ARIA_DISABLED_TRIGGER_CLASS,
+  resolveDisabledPresentation,
+} from "@/lib/disabled-presentation";
 import { displayTitle, tuiAgentDisplayTitle } from "@/lib/display-title";
 import { useEpicDeleteChat } from "@/hooks/epic/use-epic-chat-mutations";
 import {
@@ -1696,10 +1700,10 @@ function TreePanelActions(props: TreePanelActionsProps) {
     "create artifacts",
   );
   const artifactsAddDisabled = !canMutate || addIsPending;
-  const artifactsAriaDisabled =
-    artifactsAddDisabled && artifactsDisabledTooltip !== null;
-  const artifactsNativeDisabled =
-    artifactsAddDisabled && !artifactsAriaDisabled;
+  const artifactsPresentation = resolveDisabledPresentation(
+    artifactsAddDisabled,
+    artifactsDisabledTooltip,
+  );
 
   return (
     <div className="flex items-center gap-0.5">
@@ -1761,13 +1765,13 @@ function TreePanelActions(props: TreePanelActionsProps) {
             variant="ghost"
             size="icon-sm"
             aria-label={props.addLabel}
-            aria-disabled={artifactsAriaDisabled ? true : undefined}
+            aria-disabled={artifactsPresentation.ariaDisabled ? true : undefined}
             data-testid={props.triggerTestId}
             className={cn(
               "text-muted-foreground hover:text-foreground",
-              "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground",
+              ARIA_DISABLED_TRIGGER_CLASS,
             )}
-            disabled={artifactsNativeDisabled}
+            disabled={artifactsPresentation.nativeDisabled}
           >
             {addIsPending ? (
               <AgentSpinningDots

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -1698,7 +1698,8 @@ function TreePanelActions(props: TreePanelActionsProps) {
   const artifactsAddDisabled = !canMutate || addIsPending;
   const artifactsAriaDisabled =
     artifactsAddDisabled && artifactsDisabledTooltip !== null;
-  const artifactsNativeDisabled = artifactsAddDisabled && !artifactsAriaDisabled;
+  const artifactsNativeDisabled =
+    artifactsAddDisabled && !artifactsAriaDisabled;
 
   return (
     <div className="flex items-center gap-0.5">

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -1765,7 +1765,9 @@ function TreePanelActions(props: TreePanelActionsProps) {
             variant="ghost"
             size="icon-sm"
             aria-label={props.addLabel}
-            aria-disabled={artifactsPresentation.ariaDisabled ? true : undefined}
+            aria-disabled={
+              artifactsPresentation.ariaDisabled ? true : undefined
+            }
             data-testid={props.triggerTestId}
             className={cn(
               "text-muted-foreground hover:text-foreground",

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -121,7 +121,7 @@ import {
   type EpicTuiAgentProjection,
   type EpicTreeRecord,
 } from "@/lib/epic-selectors";
-import { isEditableRole } from "@/lib/epic-permissions";
+import { isEditableRole, mutationDisabledHint } from "@/lib/epic-permissions";
 import { displayTitle, tuiAgentDisplayTitle } from "@/lib/display-title";
 import { useEpicDeleteChat } from "@/hooks/epic/use-epic-chat-mutations";
 import {
@@ -1690,6 +1690,16 @@ function TreePanelActions(props: TreePanelActionsProps) {
     ],
   );
 
+  const artifactsDisabledTooltip = mutationDisabledHint(
+    permissionRole,
+    isDisconnected,
+    "create artifacts",
+  );
+  const artifactsAddDisabled = !canMutate || addIsPending;
+  const artifactsAriaDisabled =
+    artifactsAddDisabled && artifactsDisabledTooltip !== null;
+  const artifactsNativeDisabled = artifactsAddDisabled && !artifactsAriaDisabled;
+
   return (
     <div className="flex items-center gap-0.5">
       <Button
@@ -1708,20 +1718,24 @@ function TreePanelActions(props: TreePanelActionsProps) {
       >
         <CopyMinus className="size-4" />
       </Button>
-      {canEdit && props.panelId === "chats" ? (
+      {props.panelId === "chats" ? (
         <NewConversationModalAction
           epicId={props.epicId}
           tabId={props.tabId}
           parentId={null}
           size="icon-sm"
           disabled={!canMutate || addIsPending}
-          disabledTooltip={isDisconnected ? "Reconnect to make changes." : null}
+          disabledTooltip={mutationDisabledHint(
+            permissionRole,
+            isDisconnected,
+            "create chats",
+          )}
           triggerLabel={props.addLabel}
           triggerTestId={props.triggerTestId}
           actionRevealClassName=""
         />
       ) : null}
-      {canEdit && props.panelId !== "chats" ? (
+      {props.panelId !== "chats" ? (
         <AddNodeDropdown
           open={undefined}
           onOpenChange={undefined}
@@ -1738,19 +1752,21 @@ function TreePanelActions(props: TreePanelActionsProps) {
           tuiAgentPending={undefined}
           excludeTypes={props.excludeTypes}
           disabledTypes={undefined}
-          disabled={!canMutate || addIsPending}
-          disabledTooltip={
-            isDisconnected ? "Reconnect to make changes." : undefined
-          }
+          disabled={artifactsAddDisabled}
+          disabledTooltip={artifactsDisabledTooltip}
         >
           <Button
             type="button"
             variant="ghost"
             size="icon-sm"
             aria-label={props.addLabel}
+            aria-disabled={artifactsAriaDisabled ? true : undefined}
             data-testid={props.triggerTestId}
-            className="text-muted-foreground hover:text-foreground"
-            disabled={!canMutate || addIsPending}
+            className={cn(
+              "text-muted-foreground hover:text-foreground",
+              "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground",
+            )}
+            disabled={artifactsNativeDisabled}
           >
             {addIsPending ? (
               <AgentSpinningDots

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -66,6 +66,10 @@ import {
 } from "@/lib/epic-selectors";
 import { displayTitle } from "@/lib/display-title";
 import { isEditableRole, mutationDisabledHint } from "@/lib/epic-permissions";
+import {
+  ARIA_DISABLED_TRIGGER_CLASS,
+  resolveDisabledPresentation,
+} from "@/lib/disabled-presentation";
 import { buildChatRunSettings } from "@/lib/composer/chat-run-settings";
 import { contentIsSubmittable } from "@/lib/composer/composer-content";
 import { buildSubmittedChatJSONContent } from "@/lib/composer/tiptap-json-content";
@@ -175,14 +179,13 @@ export function NewConversationModalAction(
       parentId: props.parentId,
     });
   }, [openModal, props.disabled, props.epicId, props.parentId, props.tabId]);
-  // A natively `disabled` button swallows pointer events, so a Radix tooltip
-  // anchored on it never opens on hover - the "locked, not hidden" design
-  // depends on the explanation being reachable. When there is a tooltip to
-  // show, disable via `aria-disabled` instead (still blocked via `handleOpen`'s
-  // early return) and style the disabled look manually; fall back to native
-  // `disabled` only when there is no tooltip to surface (e.g. brief pending).
-  const ariaDisabled = props.disabled && props.disabledTooltip !== null;
-  const nativeDisabled = props.disabled && !ariaDisabled;
+  // Activation while aria-disabled stays blocked via `handleOpen`'s early
+  // return; see `disabled-presentation.ts` for why native `disabled` can't
+  // carry the tooltip.
+  const { ariaDisabled, nativeDisabled } = resolveDisabledPresentation(
+    props.disabled,
+    props.disabledTooltip,
+  );
   const trigger = (
     <Button
       type="button"
@@ -193,7 +196,7 @@ export function NewConversationModalAction(
       data-testid={props.triggerTestId}
       className={cn(
         "text-muted-foreground hover:text-foreground",
-        "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground",
+        ARIA_DISABLED_TRIGGER_CLASS,
         props.actionRevealClassName,
       )}
       disabled={nativeDisabled}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -65,7 +65,7 @@ import {
   useEpicPermissionRole,
 } from "@/lib/epic-selectors";
 import { displayTitle } from "@/lib/display-title";
-import { isEditableRole } from "@/lib/epic-permissions";
+import { isEditableRole, mutationDisabledHint } from "@/lib/epic-permissions";
 import { buildChatRunSettings } from "@/lib/composer/chat-run-settings";
 import { contentIsSubmittable } from "@/lib/composer/composer-content";
 import { buildSubmittedChatJSONContent } from "@/lib/composer/tiptap-json-content";
@@ -175,18 +175,28 @@ export function NewConversationModalAction(
       parentId: props.parentId,
     });
   }, [openModal, props.disabled, props.epicId, props.parentId, props.tabId]);
+  // A natively `disabled` button swallows pointer events, so a Radix tooltip
+  // anchored on it never opens on hover - the "locked, not hidden" design
+  // depends on the explanation being reachable. When there is a tooltip to
+  // show, disable via `aria-disabled` instead (still blocked via `handleOpen`'s
+  // early return) and style the disabled look manually; fall back to native
+  // `disabled` only when there is no tooltip to surface (e.g. brief pending).
+  const ariaDisabled = props.disabled && props.disabledTooltip !== null;
+  const nativeDisabled = props.disabled && !ariaDisabled;
   const trigger = (
     <Button
       type="button"
       variant="ghost"
       size={props.size}
       aria-label={props.triggerLabel}
+      aria-disabled={ariaDisabled ? true : undefined}
       data-testid={props.triggerTestId}
       className={cn(
         "text-muted-foreground hover:text-foreground",
+        "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground",
         props.actionRevealClassName,
       )}
-      disabled={props.disabled}
+      disabled={nativeDisabled}
       onClick={handleOpen}
     >
       <Plus className={props.size === "icon-xs" ? "size-3" : "size-4"} />
@@ -533,7 +543,7 @@ function NewConversationModalBody(props: {
   const canSubmit =
     canMutate && !isSubmitting && workspaceCanStart && hasSubmittableContent;
   const composerDisabledHint =
-    mutationDisabledHint(canMutate, isDisconnected) ??
+    mutationDisabledHint(permissionRole, isDisconnected, "make changes") ??
     workspaceAvailability.disabledHint;
   const paste = useComposerPaste(editorRef);
   const { dictationControl, dictationPreparing } = useComposerDictation({
@@ -947,15 +957,6 @@ function toTuiPlacement(
     return { kind: "target-group", groupId: placement.groupId };
   }
   return { kind: "active-tile" };
-}
-
-function mutationDisabledHint(
-  canMutate: boolean,
-  isDisconnected: boolean,
-): string | null {
-  if (canMutate) return null;
-  if (isDisconnected) return "Reconnect to make changes.";
-  return "You don't have permission to make changes.";
 }
 
 function effectiveWorktreeIntent(input: {

--- a/clients/gui-app/src/components/home/data/home-page.data.ts
+++ b/clients/gui-app/src/components/home/data/home-page.data.ts
@@ -148,9 +148,7 @@ function buildHistoryItem(args: {
 }
 
 export function canEditHistoryItemTitle(item: HistoryItem): boolean {
-  return (
-    item.taskType === "epic" && isEditableRole(item.permissionRole)
-  );
+  return item.taskType === "epic" && isEditableRole(item.permissionRole);
 }
 
 export function canDeleteHistoryItem(item: HistoryItem): boolean {

--- a/clients/gui-app/src/components/home/data/home-page.data.ts
+++ b/clients/gui-app/src/components/home/data/home-page.data.ts
@@ -6,7 +6,7 @@ import type {
 } from "@traycer/protocol/host/epic/unary-schemas";
 import { formatDistanceToNow } from "date-fns";
 import { displayTitle } from "@/lib/display-title";
-import { isEditablePermissionRole } from "@/lib/epic-collaborator-roles";
+import { isEditableRole } from "@/lib/epic-permissions";
 
 export type HistoryRecencyBucket = "today" | "yesterday" | "earlier";
 export type HistoryItemTaskType = "epic" | "phase";
@@ -149,12 +149,12 @@ function buildHistoryItem(args: {
 
 export function canEditHistoryItemTitle(item: HistoryItem): boolean {
   return (
-    item.taskType === "epic" && isEditablePermissionRole(item.permissionRole)
+    item.taskType === "epic" && isEditableRole(item.permissionRole)
   );
 }
 
 export function canDeleteHistoryItem(item: HistoryItem): boolean {
-  return isEditablePermissionRole(item.permissionRole);
+  return isEditableRole(item.permissionRole);
 }
 
 function historyPermissionRole(

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -40,7 +40,7 @@ import {
   useRegisteredEpicTitleGenerating,
 } from "@/lib/epic-selectors";
 import { displayTitle } from "@/lib/display-title";
-import { isEditablePermissionRole } from "@/lib/epic-collaborator-roles";
+import { isEditableRole } from "@/lib/epic-permissions";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import { getHostBindingSnapshot } from "@/lib/host/runtime";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
@@ -144,7 +144,7 @@ export const TabItem = memo(function TabItem(props: TabItemProps) {
     tab.kind === "epic" ? tab.epicId : null,
   );
   const canEditTitle =
-    tab.kind === "epic" && isEditablePermissionRole(permissionRole);
+    tab.kind === "epic" && isEditableRole(permissionRole);
   // Epic tabs can carry an empty name; render through `displayTitle` so it falls
   // back to "Untitled epic". Other kinds render their name verbatim.
   const resolvedTabName = liveEpicTitle ?? tab.name;

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -143,8 +143,7 @@ export const TabItem = memo(function TabItem(props: TabItemProps) {
   const permissionRole = useRegisteredEpicPermissionRole(
     tab.kind === "epic" ? tab.epicId : null,
   );
-  const canEditTitle =
-    tab.kind === "epic" && isEditableRole(permissionRole);
+  const canEditTitle = tab.kind === "epic" && isEditableRole(permissionRole);
   // Epic tabs can carry an empty name; render through `displayTitle` so it falls
   // back to "Untitled epic". Other kinds render their name verbatim.
   const resolvedTabName = liveEpicTitle ?? tab.name;

--- a/clients/gui-app/src/lib/__tests__/epic-permissions.test.ts
+++ b/clients/gui-app/src/lib/__tests__/epic-permissions.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isEditableRole, mutationDisabledHint } from "@/lib/epic-permissions";
+
+describe("isEditableRole", () => {
+  it("treats owner and editor as editable", () => {
+    expect(isEditableRole("owner")).toBe(true);
+    expect(isEditableRole("editor")).toBe(true);
+  });
+
+  it("treats viewer and null as not editable", () => {
+    expect(isEditableRole("viewer")).toBe(false);
+    expect(isEditableRole(null)).toBe(false);
+  });
+});
+
+describe("mutationDisabledHint", () => {
+  it("returns null for an editable, connected role", () => {
+    expect(mutationDisabledHint("editor", false, "create chats")).toBeNull();
+    expect(mutationDisabledHint("owner", false, "create chats")).toBeNull();
+  });
+
+  it("explains a viewer's restriction with the given action", () => {
+    expect(mutationDisabledHint("viewer", false, "create chats")).toBe(
+      "Viewers cannot create chats.",
+    );
+    expect(mutationDisabledHint("viewer", false, "create artifacts")).toBe(
+      "Viewers cannot create artifacts.",
+    );
+  });
+
+  it("prefers the reconnect hint over the role hint when both apply", () => {
+    expect(mutationDisabledHint("viewer", true, "create chats")).toBe(
+      "Reconnect to make changes.",
+    );
+  });
+
+  it("surfaces the reconnect hint for an editable role while disconnected", () => {
+    expect(mutationDisabledHint("editor", true, "create chats")).toBe(
+      "Reconnect to make changes.",
+    );
+  });
+});

--- a/clients/gui-app/src/lib/disabled-presentation.ts
+++ b/clients/gui-app/src/lib/disabled-presentation.ts
@@ -1,0 +1,26 @@
+/**
+ * Presentation split for a disabled control that must still surface a
+ * tooltip. A natively `disabled` button swallows pointer events, so a Radix
+ * tooltip anchored on it never opens on hover - the "locked, not hidden"
+ * pattern depends on the explanation being reachable. When there is tooltip
+ * copy to show, the control disables via `aria-disabled` (the caller blocks
+ * activation itself) and styles the disabled look with
+ * `ARIA_DISABLED_TRIGGER_CLASS`; native `disabled` is kept only when there is
+ * no tooltip to surface (e.g. a brief pending state).
+ */
+export interface DisabledPresentation {
+  readonly ariaDisabled: boolean;
+  readonly nativeDisabled: boolean;
+}
+
+export function resolveDisabledPresentation(
+  disabled: boolean,
+  tooltip: string | null,
+): DisabledPresentation {
+  const ariaDisabled = disabled && tooltip !== null;
+  return { ariaDisabled, nativeDisabled: disabled && !ariaDisabled };
+}
+
+/** Matches the native disabled look on an `aria-disabled` trigger. */
+export const ARIA_DISABLED_TRIGGER_CLASS =
+  "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground";

--- a/clients/gui-app/src/lib/epic-collaborator-roles.ts
+++ b/clients/gui-app/src/lib/epic-collaborator-roles.ts
@@ -21,7 +21,3 @@ export const EPIC_COLLABORATOR_ROLE_LABELS: Readonly<
   editor: "Editor",
   viewer: "Viewer",
 };
-
-export function isEditablePermissionRole(role: PermissionRole | null): boolean {
-  return role === "owner" || role === "editor";
-}

--- a/clients/gui-app/src/lib/epic-permissions.ts
+++ b/clients/gui-app/src/lib/epic-permissions.ts
@@ -12,3 +12,20 @@ import type { PermissionRole } from "@traycer/protocol/host/epic/unary-schemas";
 export function isEditableRole(role: PermissionRole | null): boolean {
   return role === "owner" || role === "editor";
 }
+
+/**
+ * Tooltip copy for a mutation control that is disabled but still visible
+ * ("locked, not hidden" - see the sidebar create actions and the New
+ * Conversation modal). Disconnect takes precedence over role: it is the more
+ * actionable condition (reconnecting fixes it; waiting for a role change does
+ * not).
+ */
+export function mutationDisabledHint(
+  role: PermissionRole | null,
+  isDisconnected: boolean,
+  action: string,
+): string | null {
+  if (isDisconnected) return "Reconnect to make changes.";
+  if (!isEditableRole(role)) return `Viewers cannot ${action}.`;
+  return null;
+}


### PR DESCRIPTION
## Summary

When an epic is shared with the **viewer** role, the sidebar create-chat `+` and create-artifact `+` buttons were removed from the tree entirely — nothing indicated the capability exists but is locked by role, which reads as a broken/missing feature. This PR renders them **disabled instead of hidden**, with a tooltip explaining why:

- Viewer, connected: `Viewers cannot create chats.` / `Viewers cannot create artifacts.`
- Disconnected (any role, takes precedence): `Reconnect to make changes.`

Copy comes from a new shared `mutationDisabledHint()` in `epic-permissions.ts` (unit-tested), which also replaces the New Conversation modal's private hint helper.

This surfaced a latent bug: natively `disabled` buttons swallow pointer events, so the Radix tooltips wrapped around them never opened — even the pre-existing "Reconnect to make changes." hint was unreachable. When there is tooltip copy to show, triggers now use `aria-disabled` (activation guarded in the click handler) with matching disabled styling (`aria-disabled:opacity-50`, `cursor-not-allowed`, neutralized hover), keeping them hover/focus-reachable so the explanation actually appears. Native `disabled` is kept for the brief tooltip-less pending state.

Also consolidates the duplicate role predicates (`isEditablePermissionRole` and two inline `role === \"owner\" || role === \"editor\"` copies) onto the canonical `isEditableRole`.

## Related issue

—

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)