### PR TITLE
feat(protocol,gui-app): rate-limit header icon and popover for Codex, Claude Code, OpenRouter, Kilo Code, and Traycer

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/app-shell-lifecycle-bridges.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-shell-lifecycle-bridges.test.tsx
@@ -52,6 +52,10 @@ vi.mock("@/components/notifications/notifications-bell", () => ({
   NotificationsBell: () => <div data-testid="notifications-bell" />,
 }));
 
+vi.mock("@/components/layout/header/rate-limit-icon", () => ({
+  RateLimitIconButton: () => <div data-testid="rate-limit-header-button" />,
+}));
+
 vi.mock("@/components/auth/user-menu", () => ({
   UserMenu: () => <div data-testid="user-menu" />,
 }));

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
@@ -67,6 +67,10 @@ vi.mock("@/components/notifications/notifications-bell", () => ({
   NotificationsBell: () => null,
 }));
 
+vi.mock("@/components/layout/header/rate-limit-icon", () => ({
+  RateLimitIconButton: () => null,
+}));
+
 vi.mock("@/components/auth/user-menu", () => ({
   UserMenu: () => <div data-testid="user-menu" />,
 }));

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
@@ -1,0 +1,143 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { HeaderRateLimitBar } from "@/hooks/rate-limits/use-header-rate-limit-bars";
+
+let bars: ReadonlyArray<HeaderRateLimitBar> = [];
+
+vi.mock("@/hooks/rate-limits/use-header-rate-limit-bars", () => ({
+  useHeaderRateLimitBars: () => bars,
+}));
+
+import { RateLimitIconButton } from "@/components/layout/header/rate-limit-icon";
+
+function renderIcon() {
+  return render(
+    <TooltipProvider>
+      <RateLimitIconButton />
+    </TooltipProvider>,
+  );
+}
+
+// Exact class-token membership, not substring containment - the button's base
+// variant classes always carry `disabled:opacity-50`, which would otherwise
+// false-positive a substring check for the bare `opacity-50` utility.
+function hasClass(element: Element, className: string): boolean {
+  return element.className.split(/\s+/).includes(className);
+}
+
+afterEach(() => {
+  cleanup();
+  bars = [];
+});
+
+describe("<RateLimitIconButton />", () => {
+  it("renders a clickable icon button with an accessible name, even with no bars", () => {
+    renderIcon();
+    const button = screen.getByRole("button", { name: "Rate limits" });
+    expect(button).toBeTruthy();
+  });
+
+  it("renders zero providers configured as a muted, pre-filled placeholder glyph", () => {
+    bars = [];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    expect(hasClass(button, "opacity-50")).toBe(true);
+    expect(hasClass(button, "opacity-[0.55]")).toBe(false);
+    const tracks = within(button).getAllByTestId("rate-limit-bar-track");
+    expect(tracks).toHaveLength(2);
+    const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(fills).toHaveLength(2);
+    expect(fills[0].style.width).toBe("75%");
+    expect(fills[1].style.width).toBe("60%");
+    for (const fill of fills) {
+      expect(hasClass(fill, "bg-muted-foreground")).toBe(true);
+    }
+  });
+
+  it("renders one bar per configured provider (Codex + Claude Code)", () => {
+    bars = [
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 70,
+        severity: "yellow",
+        degraded: false,
+      },
+      {
+        providerId: "claude-code",
+        windowLabel: "5h",
+        usedPercent: 40,
+        severity: "blue",
+        degraded: false,
+      },
+    ];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    expect(hasClass(button, "opacity-50")).toBe(false);
+    expect(hasClass(button, "opacity-[0.55]")).toBe(false);
+    const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(fills).toHaveLength(2);
+    expect(fills[0].className).toContain("yellow-500");
+    expect(fills[0].style.width).toBe("70%");
+    expect(fills[1].className).toContain("blue-500");
+    expect(fills[1].style.width).toBe("40%");
+  });
+
+  it("renders both of a single provider's windows without a key collision", () => {
+    // Single-provider case: both bars share a providerId and are disambiguated
+    // by windowLabel in the React key - both must still render.
+    bars = [
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 92,
+        severity: "red",
+        degraded: false,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "Weekly",
+        usedPercent: 20,
+        severity: "blue",
+        degraded: false,
+      },
+    ];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(fills).toHaveLength(2);
+    expect(fills[0].className).toContain("red-500");
+    expect(fills[0].style.width).toBe("92%");
+    expect(fills[1].className).toContain("blue-500");
+    expect(fills[1].style.width).toBe("20%");
+  });
+
+  it("dims the whole glyph when a contributing bar's last poll failed (degraded)", () => {
+    bars = [
+      {
+        providerId: "claude-code",
+        windowLabel: "5h",
+        usedPercent: 65,
+        severity: "yellow",
+        degraded: true,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 30,
+        severity: "blue",
+        degraded: false,
+      },
+    ];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    expect(hasClass(button, "opacity-[0.55]")).toBe(true);
+    expect(hasClass(button, "opacity-50")).toBe(false);
+    // Degraded dims the whole icon container, not the individual bar - both
+    // bars keep their own severity fill.
+    const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(fills).toHaveLength(2);
+  });
+});

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -45,6 +45,10 @@ type MockState = {
   // `useHostQueries`, so a test can assert it reused the real lane options
   // (e.g. `retry: false`) instead of dropping them.
   lastUseHostQueriesOptions: { retry?: boolean } | null;
+  // Provider ids of the last `requests` batch passed to `useHostQueries`, so
+  // a test can assert the button subscribes to EVERY configured httpFetch
+  // provider's query state, not just the first.
+  lastUseHostQueriesProviderIds: ReadonlyArray<string> | null;
 };
 
 function coldAuthUser(): MockAuthUser {
@@ -65,6 +69,7 @@ const mocks = vi.hoisted<MockState>(() => ({
   openSettings: vi.fn(),
   enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
   lastUseHostQueriesOptions: null,
+  lastUseHostQueriesProviderIds: null,
   authUser: {
     data: null,
     isPending: false,
@@ -94,6 +99,9 @@ vi.mock("@/hooks/host/use-host-queries", () => ({
     options: { retry?: boolean } | null;
   }) => {
     mocks.lastUseHostQueriesOptions = args.options;
+    mocks.lastUseHostQueriesProviderIds = args.requests.map(
+      (request) => request.params.providerId,
+    );
     return args.requests.map(
       (request) =>
         mocks.results[request.params.providerId] ?? readyResult(null),
@@ -313,6 +321,7 @@ beforeEach(() => {
   mocks.openSettings = vi.fn();
   mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
   mocks.lastUseHostQueriesOptions = null;
+  mocks.lastUseHostQueriesProviderIds = null;
   mocks.authUser = coldAuthUser();
   useAccountContextStore.setState({ accountContext: { type: "PERSONAL" } });
   onClose = vi.fn();
@@ -660,12 +669,21 @@ describe("<RateLimitPopover /> Refresh all", () => {
     expect((refreshAll as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it("passes the httpFetch lane's real query options (e.g. retry: false) to useHostQueries instead of the QueryClient defaults", () => {
-    // Regression: an earlier version passed `options: null`, so this batch of
-    // queries silently inherited the global QueryClient's default retry
+  it("passes the httpFetch lane's real query options (e.g. retry: false) to useHostQueries for every configured httpFetch provider", () => {
+    // Regression 1: an earlier version passed `options: null`, so this batch
+    // of queries silently inherited the global QueryClient's default retry
     // policy for the exact same query key `RateLimitProviderBlock`'s own
     // `useHostProviderRateLimitsQuery` deliberately sets `retry: false` for.
-    mocks.configured = [{ providerId: "kilocode", lane: "httpFetch" }];
+    // Regression 2 (review feedback): both httpFetch providers are configured
+    // here - not just one - because production derives the shared options from
+    // `httpFetchProviders[0]` (safe today: `providerRateLimitQueryOptions`
+    // branches on lane, never provider id, so all httpFetch options are
+    // identical) and must still subscribe to EVERY provider's query state.
+    // Passed in non-canonical order to exercise the sort in front of `[0]`.
+    mocks.configured = [
+      { providerId: "kilocode", lane: "httpFetch" },
+      { providerId: "openrouter", lane: "httpFetch" },
+    ];
     mocks.results = {
       kilocode: readyResult({
         provider: "kilocode",
@@ -673,9 +691,25 @@ describe("<RateLimitPopover /> Refresh all", () => {
         creditBalance: 9,
         passState: null,
       }),
+      openrouter: readyResult({
+        provider: "openrouter",
+        available: true,
+        limit: 100,
+        limitRemaining: 40,
+        dailySpend: 5,
+        weeklySpend: 12,
+        monthlySpend: 30,
+        totalCredits: 100,
+        totalUsage: 60,
+        balance: 40,
+      }),
     };
     renderPopover();
     expect(mocks.lastUseHostQueriesOptions?.retry).toBe(false);
+    expect([...(mocks.lastUseHostQueriesProviderIds ?? [])].sort()).toEqual([
+      "kilocode",
+      "openrouter",
+    ]);
   });
 
   it("keeps a single ephemeralProcess provider's own refresh button disabled while the queue is draining, even though its own isFetching has already settled", () => {

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -359,8 +359,12 @@ describe("<RateLimitPopover /> rail", () => {
     // Both provider blocks render their header name (rail buttons are icon-only).
     expect(screen.getByText("Codex")).toBeTruthy();
     expect(screen.getByText("Claude Code")).toBeTruthy();
-    // Popover variant renders "% used" copy (codex primary 4% used).
-    expect(screen.getByText("5h · 4% used")).toBeTruthy();
+    // Popover variant renders "% used" copy (codex primary 4% used, claude
+    // fiveHour 22% used - both windows are the 5-hour session window, so the
+    // bare "Current session" label renders once per provider).
+    expect(screen.getAllByText("Current session")).toHaveLength(2);
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("22% used")).toBeTruthy();
     // Overview is condensed: the plan/tier label ("Pro 5x") is detail-only.
     expect(screen.queryByText("Pro 5x")).toBeNull();
   });
@@ -421,9 +425,91 @@ describe("<RateLimitPopover /> rail", () => {
     };
     renderPopover();
     // Fixup C #1: 5h primary -> relative countdown; weekly secondary -> absolute
-    // weekday-tagged date. Both split the same way as the Settings card.
+    // weekday-tagged time. Both split the same way as the Settings card.
     expect(screen.getByText(/^Resets in /)).toBeTruthy();
-    expect(screen.getByText(/^Resets .+\([A-Za-z]{3}\) /)).toBeTruthy();
+    expect(
+      screen.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
+    ).toBeTruthy();
+  });
+});
+
+function coldResult(): QueryResult {
+  return {
+    data: undefined,
+    isPending: true,
+    isFetching: true,
+    isError: false,
+    dataUpdatedAt: 0,
+    refetch: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+describe("<RateLimitPopover /> Overview progressive reveal", () => {
+  function popoverElement() {
+    return (
+      <QueryClientProvider client={new QueryClient()}>
+        <TooltipProvider>
+          <Popover open>
+            <PopoverTrigger>trigger</PopoverTrigger>
+            <RateLimitPopover onClose={onClose} />
+          </Popover>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  it("shows one centered loading indicator, no per-provider sections, while nothing has resolved yet", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = { codex: coldResult(), "claude-code": coldResult() };
+    renderPopover();
+
+    expect(screen.getByText("Fetching rate limits")).toBeTruthy();
+    // Neither provider's own reading is visible yet - only the combined loader.
+    expect(screen.queryByText("Current session")).toBeNull();
+    expect(screen.queryByText("4% used")).toBeNull();
+  });
+
+  it("reveals a provider in place as it resolves, hiding still-cold siblings, and drops the combined loader", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = { codex: coldResult(), "claude-code": coldResult() };
+    const { rerender } = renderPopover();
+
+    // Codex resolves first; Claude Code is still in flight.
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": coldResult(),
+    };
+    rerender(popoverElement());
+
+    // The combined loader is gone now that one provider has data...
+    expect(screen.queryByText("Fetching rate limits")).toBeNull();
+    // ...Codex's own section is visible...
+    expect(
+      screen.getByText("Codex").closest('[class*="gap-4"]')?.className,
+    ).not.toContain("hidden");
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    // ...but Claude Code's still-cold section is hidden, not painted as its
+    // own blank/loading block.
+    expect(
+      screen.getByText("Claude Code").closest('[class*="gap-4"]')?.className,
+    ).toContain("hidden");
+
+    // Claude Code resolves next - both sections are now visible.
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    rerender(popoverElement());
+    expect(
+      screen.getByText("Claude Code").closest('[class*="gap-4"]')?.className,
+    ).not.toContain("hidden");
   });
 });
 
@@ -441,7 +527,18 @@ describe("<RateLimitPopover /> per-provider states", () => {
       },
     };
     renderPopover();
-    expect(screen.getByTestId("rate-limit-detail-skeleton")).toBeTruthy();
+    const skeleton = screen.getByTestId("rate-limit-detail-skeleton");
+    expect(skeleton).toBeTruthy();
+    // Regression: several dark theme presets set `--muted` equal to
+    // `--popover`, so a plain `bg-muted` skeleton block is the same color as
+    // the popover background and reads as an empty section, not a loading
+    // one. Each block overrides that with `bg-foreground/15`, which contrasts
+    // against any background without needing a border.
+    const blocks = skeleton.querySelectorAll('[data-slot="skeleton"]');
+    expect(blocks.length).toBeGreaterThan(0);
+    blocks.forEach((block) => {
+      expect(block.className).toContain("bg-foreground/15");
+    });
   });
 
   it("dims stale content and notes a failed refresh when degraded", () => {
@@ -458,7 +555,7 @@ describe("<RateLimitPopover /> per-provider states", () => {
     expect(document.querySelectorAll(".opacity-60").length).toBeGreaterThan(0);
   });
 
-  it("shows a plain retry message when a fetch never succeeded", () => {
+  it("shows a plain error message with no inline retry control when a fetch never succeeded", () => {
     mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
     mocks.results = {
       codex: {
@@ -474,8 +571,14 @@ describe("<RateLimitPopover /> per-provider states", () => {
     expect(
       screen.getByText("Couldn't load rate limits right now."),
     ).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-    // Codex is ephemeralProcess -> retry routes through the serial queue.
+    // No separate "Retry" link - the header's own refresh icon already covers
+    // it (feedback: "we already have a reload button"). That icon is
+    // detail-tab-only (Overview relies on "Refresh all"), so switch there first.
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Codex" }));
+    // Codex is ephemeralProcess -> the header's refresh routes through the
+    // serial queue, same as retrying used to.
     expect(mocks.enqueue).toHaveBeenCalledWith(
       "codex",
       { type: "PERSONAL" },
@@ -675,9 +778,13 @@ describe("<RateLimitPopover /> Traycer tab", () => {
     expect(screen.getByText("$30.00 / $100.00")).toBeTruthy();
     // Detail tab surfaces the same Personal/Team picker as the Settings card.
     expect(screen.getByRole("combobox", { name: "Account" })).toBeTruthy();
+    // Plan/tier chip next to the name - the trailing "_V3" pricing-generation
+    // tag is stripped (matching Cloud UI's own Settings pages), so "PRO_V3"
+    // reads as "Pro", not "Pro V3".
+    expect(screen.getByText("Pro")).toBeTruthy();
   });
 
-  it("renders a condensed Traycer block with no picker on Overview", () => {
+  it("renders a condensed Traycer block with no picker or plan chip on Overview", () => {
     mocks.configured = [];
     mocks.authUser = readyAuthUser(
       authUserFixture({ status: "PRO_V3", withTeam: true }),
@@ -686,6 +793,27 @@ describe("<RateLimitPopover /> Traycer tab", () => {
     // Overview reflects the selected account's numbers, but exposes no controls.
     expect(screen.getByText("$30.00 / $100.00")).toBeTruthy();
     expect(screen.queryByRole("combobox", { name: "Account" })).toBeNull();
+    // Overview is condensed, same as the host-RPC providers' plan chip.
+    expect(screen.queryByText("Pro")).toBeNull();
+  });
+
+  it("reflects the selected account's own plan in the chip, not the personal account's", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: true }),
+    );
+    // The fixture's team subscription is on "ULTRA_1X_V3" - selecting the
+    // team account should show that plan in the chip, not the personal one.
+    useAccountContextStore.setState({
+      accountContext: { type: "TEAM", teamId: "team-1" },
+    });
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
+    // "ULTRA_1X_V3" reads as the bare "Ultra" tier name (matching
+    // `subscriptionPlanLabel`'s own tier-name mapping), not the personal
+    // account's "Pro".
+    expect(screen.getByText("Ultra")).toBeTruthy();
+    expect(screen.queryByText("Pro")).toBeNull();
   });
 
   it("refetches the subscription from the Traycer tab's refresh button", () => {

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -44,7 +44,7 @@ type MockState = {
   // Last `options` object `RateLimitRefreshAllButton` passed to
   // `useHostQueries`, so a test can assert it reused the real lane options
   // (e.g. `retry: false`) instead of dropping them.
-  lastUseHostQueriesOptions: { retry?: boolean } | null;
+  lastUseHostQueriesOptions: { retry: boolean | undefined } | null;
   // Provider ids of the last `requests` batch passed to `useHostQueries`, so
   // a test can assert the button subscribes to EVERY configured httpFetch
   // provider's query state, not just the first.
@@ -96,7 +96,7 @@ vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
 vi.mock("@/hooks/host/use-host-queries", () => ({
   useHostQueries: (args: {
     requests: ReadonlyArray<{ params: { providerId: string } }>;
-    options: { retry?: boolean } | null;
+    options: { retry: boolean | undefined } | null;
   }) => {
     mocks.lastUseHostQueriesOptions = args.options;
     mocks.lastUseHostQueriesProviderIds = args.requests.map(

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -1,0 +1,704 @@
+import "../../../../../__tests__/test-browser-apis";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ProviderRateLimits } from "@traycer/protocol/host";
+import type { AuthenticatedUser } from "@traycer/protocol/auth";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { Popover, PopoverTrigger } from "@/components/ui/popover";
+import { useAccountContextStore } from "@/stores/auth/account-context-store";
+
+type QueryResult = {
+  data: { providerRateLimits: ProviderRateLimits | null } | undefined;
+  isPending: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  dataUpdatedAt: number;
+  refetch: () => Promise<unknown>;
+};
+
+type MockAuthUser = {
+  data: AuthenticatedUser | null;
+  isPending: boolean;
+  isError: boolean;
+  isFetching: boolean;
+  dataUpdatedAt: number;
+  refetch: Mock<(...args: unknown[]) => Promise<unknown>>;
+};
+
+type MockState = {
+  configured: ReadonlyArray<{ providerId: string; lane: string }>;
+  results: Record<string, QueryResult>;
+  draining: boolean;
+  openSettings: Mock<(...args: unknown[]) => void>;
+  enqueue: Mock<(...args: unknown[]) => Promise<void>>;
+  authUser: MockAuthUser;
+};
+
+function coldAuthUser(): MockAuthUser {
+  return {
+    data: null,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    dataUpdatedAt: 0,
+    refetch: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+const mocks = vi.hoisted<MockState>(() => ({
+  configured: [],
+  results: {},
+  draining: false,
+  openSettings: vi.fn(),
+  enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  authUser: {
+    data: null,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    dataUpdatedAt: 0,
+    refetch: vi.fn(() => Promise.resolve({})),
+  },
+}));
+
+vi.mock("@/hooks/rate-limits/use-configured-rate-limit-providers", () => ({
+  useConfiguredRateLimitProviders: () => mocks.configured,
+}));
+vi.mock("@/hooks/rate-limits/use-is-rate-limit-queue-draining", () => ({
+  useIsRateLimitQueueDraining: () => mocks.draining,
+}));
+vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
+  useHostProviderRateLimitsQuery: (providerId: string) =>
+    mocks.results[providerId] ?? readyResult(null),
+}));
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-1",
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  // Wrapper (not `mocks.enqueue` directly) so `beforeEach` can swap the spy -
+  // an object-literal binding would freeze the original fn at module load.
+  enqueueRateLimitFetch: (...args: unknown[]) => mocks.enqueue(...args),
+}));
+vi.mock("@/stores/tabs/use-system-tab-modal", () => ({
+  useSystemTabModalActions: () => ({ openSettings: mocks.openSettings }),
+}));
+// The Traycer tab reads the signed-in user's subscription (AuthService), not a
+// host RPC. Default is a signed-out/cold user -> no Traycer tab, so the
+// host-RPC-provider tests below behave exactly as before.
+vi.mock("@/hooks/auth/use-auth-user-query", () => ({
+  useAuthUser: () => mocks.authUser,
+}));
+// The aperture usage query + its turn-refresh only mount inside the shared
+// RateLimitView (rate-limit-based Traycer plans). Stub them so no real host
+// query fires; the Traycer tests below use a credit-based plan anyway.
+vi.mock("@/hooks/host/use-host-rate-limit-usage-query", () => ({
+  useHostRateLimitUsageQuery: () => ({ data: undefined }),
+}));
+vi.mock("@/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn", () => ({
+  useRefreshRateLimitUsageOnTraycerTurn: () => {},
+}));
+
+import { RateLimitPopover } from "@/components/layout/header/rate-limit-popover";
+
+const NOW = Date.now();
+
+function readyResult(
+  providerRateLimits: ProviderRateLimits | null,
+): QueryResult {
+  return {
+    data: { providerRateLimits },
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    dataUpdatedAt: NOW - 90_000,
+    refetch: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+function claudeReady(): ProviderRateLimits {
+  return {
+    provider: "claude-code",
+    available: true,
+    subscriptionType: "max",
+    fiveHour: {
+      usedPercent: 22,
+      resetsAt: NOW + 60 * 60 * 1000,
+      durationMinutes: 300,
+    },
+    sevenDay: null,
+    sevenDayOpus: null,
+    sevenDaySonnet: null,
+    modelScoped: [],
+    extraUsage: null,
+  };
+}
+
+function codexReady(): ProviderRateLimits {
+  return {
+    provider: "codex",
+    available: true,
+    planType: "pro_5x",
+    limitId: null,
+    limitName: null,
+    primary: {
+      usedPercent: 4,
+      resetsAt: NOW + 60 * 60 * 1000,
+      durationMinutes: 300,
+    },
+    secondary: null,
+    extraWindows: [],
+    credits: null,
+    individualLimit: null,
+    resetCredits: null,
+    rateLimitReachedType: null,
+  };
+}
+
+const EPOCH = new Date(0);
+
+function baseSubscription() {
+  return {
+    id: "sub",
+    userID: "u1",
+    orgID: null,
+    teamID: null,
+    customerId: "cus",
+    createdAt: EPOCH,
+    updatedAt: EPOCH,
+    subscriptionExpiry: null,
+    trialEndsAt: null,
+    hasPaymentMethod: true,
+    rechargeRateSeconds: 60,
+  };
+}
+
+function authUserFixture(overrides: {
+  status: "PRO_V3" | "FREE";
+  withTeam: boolean;
+}): AuthenticatedUser {
+  return {
+    user: {
+      id: "u1",
+      name: "Ada",
+      providerId: "p1",
+      providerHandle: "ada",
+      providerType: "GITHUB",
+      email: "ada@example.com",
+      avatarUrl: null,
+      activatedAt: EPOCH,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+      lastSeenAt: EPOCH,
+      privacyMode: false,
+      isLearningEnabled: true,
+    },
+    userSubscription: {
+      ...baseSubscription(),
+      subscriptionStatus: overrides.status,
+      isInTrial: false,
+      totalPlanCredits: 100,
+      credit: {
+        id: "c1",
+        userId: "u1",
+        customerId: "cus",
+        bonusCredits: 0,
+        consumedFromPlan: 30,
+        consumedFromBonus: 0,
+        lastResetAt: EPOCH,
+      },
+    },
+    payAsYouGoUsage: { allowPayAsYouGo: false },
+    teamSubscriptions: overrides.withTeam
+      ? [
+          {
+            ...baseSubscription(),
+            teamID: "team-1",
+            subscriptionStatus: "ULTRA_1X_V3",
+            isInTrial: false,
+            totalPlanCredits: 500,
+            hasActiveBundle: false,
+            bundleSummary: {
+              bundleTotal: 0,
+              bundleConsumed: 0,
+              bundleRemaining: 0,
+            },
+            credit: {
+              id: "c2",
+              userId: "u1",
+              customerId: "cus",
+              orgId: "team-1",
+              bonusCredits: 0,
+              consumedFromPlan: 100,
+              consumedFromBonus: 0,
+              lastResetAt: EPOCH,
+            },
+            team: {
+              id: "team-1",
+              slug: "acme",
+              avatarUrl: null,
+              privacyMode: false,
+              createdAt: EPOCH,
+              updatedAt: EPOCH,
+            },
+          },
+        ]
+      : [],
+  };
+}
+
+function readyAuthUser(data: AuthenticatedUser): MockAuthUser {
+  return {
+    data,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    dataUpdatedAt: NOW - 60_000,
+    refetch: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+let onClose: () => void;
+
+function renderPopover() {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <TooltipProvider>
+        <Popover open>
+          <PopoverTrigger>trigger</PopoverTrigger>
+          <RateLimitPopover onClose={onClose} />
+        </Popover>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mocks.configured = [];
+  mocks.results = {};
+  mocks.draining = false;
+  mocks.openSettings = vi.fn();
+  mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
+  mocks.authUser = coldAuthUser();
+  useAccountContextStore.setState({ accountContext: { type: "PERSONAL" } });
+  onClose = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("<RateLimitPopover /> zero-provider state", () => {
+  it("shows a single CTA with no rail when nothing is configured", () => {
+    mocks.configured = [];
+    renderPopover();
+    expect(
+      screen.getByText("Connect Claude Code or Codex to see usage here."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("tablist")).toBeNull();
+  });
+
+  it("opens provider settings and closes the popover from the CTA", () => {
+    mocks.configured = [];
+    renderPopover();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open provider settings" }),
+    );
+    expect(mocks.openSettings).toHaveBeenCalledWith({
+      section: "providers",
+      resetToGeneral: false,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("<RateLimitPopover /> rail", () => {
+  it("pins Overview first, then one tab per provider in app order", () => {
+    // Passed out of order; the rail must sort to codex, claude-code, ...
+    mocks.configured = [
+      { providerId: "kilocode", lane: "httpFetch" },
+      { providerId: "codex", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      kilocode: readyResult({
+        provider: "kilocode",
+        available: true,
+        creditBalance: 5,
+        passState: null,
+      }),
+    };
+    renderPopover();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Overview",
+      "Codex",
+      "Kilo Code",
+    ]);
+  });
+
+  it("lands on Overview, stacking every provider's condensed block", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    renderPopover();
+    // Both provider blocks render their header name (rail buttons are icon-only).
+    expect(screen.getByText("Codex")).toBeTruthy();
+    expect(screen.getByText("Claude Code")).toBeTruthy();
+    // Popover variant renders "% used" copy (codex primary 4% used).
+    expect(screen.getByText("5h · 4% used")).toBeTruthy();
+    // Overview is condensed: the plan/tier label ("Pro 5x") is detail-only.
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+  });
+
+  it("draws a divider only between consecutive condensed blocks (no header row)", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    renderPopover();
+    // Fixup C #4: the "All providers" header (and its divider) is gone; only the
+    // between-block dividers remain: 2 providers -> 1 divider. PopoverContent
+    // portals to body.
+    expect(document.querySelectorAll('[class*="bg-border/70"]').length).toBe(1);
+  });
+
+  it("switches to a single provider detail (with plan label) on tab click", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    renderPopover();
+    // Overview is condensed, so the plan label isn't shown there...
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    expect(screen.getByText("Codex")).toBeTruthy();
+    // ...but the single-provider detail tab surfaces it.
+    expect(screen.getByText("Pro 5x")).toBeTruthy();
+  });
+
+  it("shows a relative countdown for a short window and an absolute date for a weekly one", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: readyResult({
+        provider: "codex",
+        available: true,
+        planType: "pro_5x",
+        limitId: null,
+        limitName: null,
+        primary: {
+          usedPercent: 4,
+          resetsAt: NOW + 60 * 60 * 1000,
+          durationMinutes: 300,
+        },
+        secondary: {
+          usedPercent: 40,
+          resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+          durationMinutes: 10080,
+        },
+        extraWindows: [],
+        credits: null,
+        individualLimit: null,
+        resetCredits: null,
+        rateLimitReachedType: null,
+      }),
+    };
+    renderPopover();
+    // Fixup C #1: 5h primary -> relative countdown; weekly secondary -> absolute
+    // weekday-tagged date. Both split the same way as the Settings card.
+    expect(screen.getByText(/^Resets in /)).toBeTruthy();
+    expect(screen.getByText(/^Resets .+\([A-Za-z]{3}\) /)).toBeTruthy();
+  });
+});
+
+describe("<RateLimitPopover /> per-provider states", () => {
+  it("shows skeleton bars (not a spinner) on cold load", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: {
+        data: undefined,
+        isPending: true,
+        isFetching: true,
+        isError: false,
+        dataUpdatedAt: 0,
+        refetch: vi.fn(() => Promise.resolve({})),
+      },
+    };
+    renderPopover();
+    expect(screen.getByTestId("rate-limit-detail-skeleton")).toBeTruthy();
+  });
+
+  it("dims stale content and notes a failed refresh when degraded", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: {
+        ...readyResult(codexReady()),
+        isError: true,
+      },
+    };
+    renderPopover();
+    expect(screen.getByText(/· refresh failed/)).toBeTruthy();
+    // PopoverContent portals to document.body, outside the render container.
+    expect(document.querySelectorAll(".opacity-60").length).toBeGreaterThan(0);
+  });
+
+  it("shows a plain retry message when a fetch never succeeded", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: {
+        data: undefined,
+        isPending: false,
+        isFetching: false,
+        isError: true,
+        dataUpdatedAt: 0,
+        refetch: vi.fn(() => Promise.resolve({})),
+      },
+    };
+    renderPopover();
+    expect(
+      screen.getByText("Couldn't load rate limits right now."),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    // Codex is ephemeralProcess -> retry routes through the serial queue.
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "codex",
+      { type: "PERSONAL" },
+      { force: true },
+    );
+  });
+
+  it("maps an available:false reason to a plain-language message", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: readyResult({
+        provider: "codex",
+        available: false,
+        reason: "cli_not_found",
+      }),
+    };
+    renderPopover();
+    expect(
+      screen.getByText("Rate limits unavailable — the CLI isn't installed"),
+    ).toBeTruthy();
+  });
+});
+
+describe("<RateLimitPopover /> Refresh all", () => {
+  it("is disabled while the queue is draining", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.draining = true;
+    renderPopover();
+    const refreshAll = screen.getByRole("button", { name: "Refresh all" });
+    expect((refreshAll as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("enqueues each ephemeralProcess provider with force:true", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh all" }));
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "codex",
+      { type: "PERSONAL" },
+      { force: true },
+    );
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "claude-code",
+      { type: "PERSONAL" },
+      { force: true },
+    );
+  });
+});
+
+describe("<RateLimitPopover /> rail settings", () => {
+  it("opens provider settings and closes the popover from the rail settings icon", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: "Provider settings" }));
+    expect(mocks.openSettings).toHaveBeenCalledWith({
+      section: "providers",
+      resetToGeneral: false,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("<RateLimitPopover /> per-provider refresh", () => {
+  it("routes an httpFetch provider's refresh through refetch, not the queue", () => {
+    const refetch = vi.fn(() => Promise.resolve({}));
+    mocks.configured = [{ providerId: "kilocode", lane: "httpFetch" }];
+    mocks.results = {
+      kilocode: {
+        ...readyResult({
+          provider: "kilocode",
+          available: true,
+          creditBalance: 9,
+          passState: null,
+        }),
+        refetch,
+      },
+    };
+    renderPopover();
+    // The per-provider refresh only lives in the single-provider detail tab now
+    // (item 2 feedback: Overview keeps only the rail's "Refresh all").
+    fireEvent.click(screen.getByRole("tab", { name: "Kilo Code" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Kilo Code" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+});
+
+// Guards that a stacked Overview keeps each provider's block scoped, and that
+// it has no per-provider refresh controls (item 2 feedback: only the rail's
+// "Refresh all" - the single-provider detail tab keeps its own).
+describe("<RateLimitPopover /> Overview block scoping", () => {
+  it("shows no per-provider refresh controls on Overview, only Refresh all", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    renderPopover();
+    expect(screen.queryByRole("button", { name: "Refresh Codex" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Refresh Claude Code" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Refresh all" })).toBeTruthy();
+    // Rail buttons are icon-only, so each provider name appears exactly once -
+    // in its own block header, confirming the blocks are stacked (not merged).
+    expect(screen.getAllByText("Codex").length).toBe(1);
+  });
+
+  it("keeps the per-provider refresh control in the single-provider detail tab", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    expect(screen.getByRole("button", { name: "Refresh Codex" })).toBeTruthy();
+  });
+});
+
+describe("<RateLimitPopover /> Traycer tab", () => {
+  it("adds a Traycer tab for a paid account, even with no host-RPC providers", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: false }),
+    );
+    renderPopover();
+    // Eligible Traycer alone keeps the rail (not the zero-provider CTA).
+    expect(
+      screen.queryByText("Connect Claude Code or Codex to see usage here."),
+    ).toBeNull();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Overview",
+      "Traycer Inference",
+    ]);
+  });
+
+  it("omits the Traycer tab for a free, unbundled account", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "FREE", withTeam: false }),
+    );
+    renderPopover();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Overview",
+      "Codex",
+    ]);
+  });
+
+  it("orders the Traycer tab per PROVIDER_ID_ORDER (after Codex, before Kilo Code)", () => {
+    mocks.configured = [
+      { providerId: "kilocode", lane: "httpFetch" },
+      { providerId: "codex", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      kilocode: readyResult({
+        provider: "kilocode",
+        available: true,
+        creditBalance: 5,
+        passState: null,
+      }),
+    };
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: false }),
+    );
+    renderPopover();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Overview",
+      "Codex",
+      "Traycer Inference",
+      "Kilo Code",
+    ]);
+  });
+
+  it("shows the subscription detail with an account picker on the Traycer tab", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: true }),
+    );
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
+    // Shared subscription view: plan credit breakdown (30 of 100).
+    expect(screen.getByText("$30.00 / $100.00")).toBeTruthy();
+    // Detail tab surfaces the same Personal/Team picker as the Settings card.
+    expect(screen.getByRole("combobox", { name: "Account" })).toBeTruthy();
+  });
+
+  it("renders a condensed Traycer block with no picker on Overview", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: true }),
+    );
+    renderPopover();
+    // Overview reflects the selected account's numbers, but exposes no controls.
+    expect(screen.getByText("$30.00 / $100.00")).toBeTruthy();
+    expect(screen.queryByRole("combobox", { name: "Account" })).toBeNull();
+  });
+
+  it("refetches the subscription from the Traycer tab's refresh button", () => {
+    mocks.configured = [];
+    const authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: false }),
+    );
+    mocks.authUser = authUser;
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh Traycer Inference" }),
+    );
+    expect(authUser.refetch).toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -678,6 +678,16 @@ describe("<RateLimitPopover /> Refresh all", () => {
     expect(mocks.lastUseHostQueriesOptions?.retry).toBe(false);
   });
 
+  it("keeps a single ephemeralProcess provider's own refresh button disabled while the queue is draining, even though its own isFetching has already settled", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.draining = true;
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    const refreshCodex = screen.getByRole("button", { name: "Refresh Codex" });
+    expect((refreshCodex as HTMLButtonElement).disabled).toBe(true);
+  });
+
   it("enqueues each ephemeralProcess provider with force:true", () => {
     mocks.configured = [
       { providerId: "codex", lane: "ephemeralProcess" },

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -41,6 +41,10 @@ type MockState = {
   openSettings: Mock<(...args: unknown[]) => void>;
   enqueue: Mock<(...args: unknown[]) => Promise<void>>;
   authUser: MockAuthUser;
+  // Last `options` object `RateLimitRefreshAllButton` passed to
+  // `useHostQueries`, so a test can assert it reused the real lane options
+  // (e.g. `retry: false`) instead of dropping them.
+  lastUseHostQueriesOptions: { retry?: boolean } | null;
 };
 
 function coldAuthUser(): MockAuthUser {
@@ -60,6 +64,7 @@ const mocks = vi.hoisted<MockState>(() => ({
   draining: false,
   openSettings: vi.fn(),
   enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  lastUseHostQueriesOptions: null,
   authUser: {
     data: null,
     isPending: false,
@@ -86,11 +91,14 @@ vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
 vi.mock("@/hooks/host/use-host-queries", () => ({
   useHostQueries: (args: {
     requests: ReadonlyArray<{ params: { providerId: string } }>;
-  }) =>
-    args.requests.map(
+    options: { retry?: boolean } | null;
+  }) => {
+    mocks.lastUseHostQueriesOptions = args.options;
+    return args.requests.map(
       (request) =>
         mocks.results[request.params.providerId] ?? readyResult(null),
-    ),
+    );
+  },
 }));
 vi.mock("@/lib/host", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/host")>();
@@ -304,6 +312,7 @@ beforeEach(() => {
   mocks.draining = false;
   mocks.openSettings = vi.fn();
   mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
+  mocks.lastUseHostQueriesOptions = null;
   mocks.authUser = coldAuthUser();
   useAccountContextStore.setState({ accountContext: { type: "PERSONAL" } });
   onClose = vi.fn();
@@ -649,6 +658,24 @@ describe("<RateLimitPopover /> Refresh all", () => {
     renderPopover();
     const refreshAll = screen.getByRole("button", { name: "Refresh all" });
     expect((refreshAll as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("passes the httpFetch lane's real query options (e.g. retry: false) to useHostQueries instead of the QueryClient defaults", () => {
+    // Regression: an earlier version passed `options: null`, so this batch of
+    // queries silently inherited the global QueryClient's default retry
+    // policy for the exact same query key `RateLimitProviderBlock`'s own
+    // `useHostProviderRateLimitsQuery` deliberately sets `retry: false` for.
+    mocks.configured = [{ providerId: "kilocode", lane: "httpFetch" }];
+    mocks.results = {
+      kilocode: readyResult({
+        provider: "kilocode",
+        available: true,
+        creditBalance: 9,
+        passState: null,
+      }),
+    };
+    renderPopover();
+    expect(mocks.lastUseHostQueriesOptions?.retry).toBe(false);
   });
 
   it("enqueues each ephemeralProcess provider with force:true", () => {

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -80,6 +80,22 @@ vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
   useHostProviderRateLimitsQuery: (providerId: string) =>
     mocks.results[providerId] ?? readyResult(null),
 }));
+// `RateLimitRefreshAllButton` reads each configured httpFetch provider's
+// query state directly (to fold its `isFetching` into the button's own
+// spinner) via the same fixture map every other mocked query hook here uses.
+vi.mock("@/hooks/host/use-host-queries", () => ({
+  useHostQueries: (args: {
+    requests: ReadonlyArray<{ params: { providerId: string } }>;
+  }) =>
+    args.requests.map(
+      (request) =>
+        mocks.results[request.params.providerId] ?? readyResult(null),
+    ),
+}));
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return { ...actual, useHostClient: () => null };
+});
 vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
   useReactiveActiveHostId: () => "host-1",
 }));
@@ -607,6 +623,29 @@ describe("<RateLimitPopover /> Refresh all", () => {
     mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
     mocks.results = { codex: readyResult(codexReady()) };
     mocks.draining = true;
+    renderPopover();
+    const refreshAll = screen.getByRole("button", { name: "Refresh all" });
+    expect((refreshAll as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("is disabled while an httpFetch provider is fetching, even though the ephemeralProcess queue isn't draining", () => {
+    // Regression: "Refresh all" used to read only the ephemeralProcess queue's
+    // draining flag, so an all-httpFetch popover (or one mid-invalidation on
+    // just its httpFetch providers) never visibly spun despite actively
+    // refreshing.
+    mocks.configured = [{ providerId: "kilocode", lane: "httpFetch" }];
+    mocks.results = {
+      kilocode: {
+        ...readyResult({
+          provider: "kilocode",
+          available: true,
+          creditBalance: 9,
+          passState: null,
+        }),
+        isFetching: true,
+      },
+    };
+    mocks.draining = false;
     renderPopover();
     const refreshAll = screen.getByRole("button", { name: "Refresh all" });
     expect((refreshAll as HTMLButtonElement).disabled).toBe(true);

--- a/clients/gui-app/src/components/layout/header/app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/app-header.tsx
@@ -4,6 +4,7 @@ import { TabStrip } from "@/components/layout/tabs/tab-strip";
 import { AppUpdateHeaderButton } from "@/components/layout/header/app-update-button";
 import { HistoryButton } from "@/components/layout/header/history-button";
 import { HistoryNavButtons } from "@/components/layout/header/history-nav-buttons";
+import { RateLimitIconButton } from "@/components/layout/header/rate-limit-icon";
 import { SignInButton } from "@/components/layout/header/sign-in-button";
 import { NotificationsBell } from "@/components/notifications/notifications-bell";
 import { cn } from "@/lib/utils";
@@ -103,6 +104,7 @@ export function AppHeader(props: AppHeaderProps): ReactNode {
         style={framelessDesktop ? NO_DRAG_STYLE : undefined}
       >
         {!navDisabled ? <AppUpdateHeaderButton /> : null}
+        {!navDisabled ? <RateLimitIconButton /> : null}
         {!navDisabled ? <HistoryButton /> : null}
         {showBell ? <HeaderNotificationsBell /> : null}
         <HeaderIdentity showAppSettings={!navDisabled} />

--- a/clients/gui-app/src/components/layout/header/rate-limit-icon.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-icon.tsx
@@ -1,0 +1,103 @@
+import { useState, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverTrigger } from "@/components/ui/popover";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { RateLimitPopover } from "@/components/layout/header/rate-limit-popover";
+import { useHeaderRateLimitBars } from "@/hooks/rate-limits/use-header-rate-limit-bars";
+import {
+  rateLimitWindowFillPercent,
+  rateLimitWindowSeverityBarClassName,
+} from "@/lib/rate-limits/window-severity";
+import { cn } from "@/lib/utils";
+
+/**
+ * Fixed placeholder fill percentages for the neutral/no-data glyph (Core
+ * Flows wireframe, CodexBar-style generic pre-filled look) - shown both when
+ * zero providers are configured and while every provider's first fetch is
+ * still pending. Not real usage data.
+ */
+const PLACEHOLDER_BAR_PERCENTAGES: ReadonlyArray<number> = [75, 60];
+
+/**
+ * Header trigger for the provider rate-limit popover. Same `TooltipWrapper` +
+ * `Button variant="ghost" size="icon-sm"` structural pattern as
+ * `HistoryButton`, always visible per Core Flows' "Entry point & visibility"
+ * (position consistency + feature discovery beat hiding an empty state).
+ * Clicking opens the popover in any glyph state, including empty (which lands on
+ * the zero-provider CTA).
+ *
+ * Never gates on data loading: `useHeaderRateLimitBars` returns `[]` both
+ * before any provider has data and when zero providers are configured, and
+ * both render the same neutral glyph - there is no separate loading state.
+ */
+export function RateLimitIconButton(): ReactNode {
+  const [open, setOpen] = useState(false);
+  const bars = useHeaderRateLimitBars();
+  const isEmpty = bars.length === 0;
+  const isDegraded = !isEmpty && bars.some((bar) => bar.degraded);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <TooltipWrapper
+        label="Rate limits"
+        side="top"
+        sideOffset={6}
+        align={undefined}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Rate limits"
+            data-testid="rate-limit-header-button"
+            className={cn(
+              "text-muted-foreground hover:text-foreground",
+              isEmpty && "opacity-50",
+              isDegraded && "opacity-[0.55]",
+            )}
+          >
+            <span
+              aria-hidden
+              className="inline-flex flex-col items-start gap-[2.5px]"
+            >
+              {isEmpty
+                ? PLACEHOLDER_BAR_PERCENTAGES.map((percent) => (
+                    <span
+                      key={percent}
+                      data-testid="rate-limit-bar-track"
+                      className="relative h-1 w-4 overflow-hidden rounded-[2px] bg-muted"
+                    >
+                      <span
+                        data-testid="rate-limit-bar-fill"
+                        className="absolute inset-y-0 left-0 rounded-[2px] bg-muted-foreground"
+                        style={{ width: `${percent}%` }}
+                      />
+                    </span>
+                  ))
+                : bars.map((bar) => (
+                    <span
+                      key={`${bar.providerId}-${bar.windowLabel}`}
+                      data-testid="rate-limit-bar-track"
+                      className="relative h-1 w-4 overflow-hidden rounded-[2px] bg-muted"
+                    >
+                      <span
+                        data-testid="rate-limit-bar-fill"
+                        className={cn(
+                          "absolute inset-y-0 left-0 rounded-[2px]",
+                          rateLimitWindowSeverityBarClassName(bar.severity),
+                        )}
+                        style={{
+                          width: `${rateLimitWindowFillPercent(bar.usedPercent)}%`,
+                        }}
+                      />
+                    </span>
+                  ))}
+            </span>
+          </Button>
+        </PopoverTrigger>
+      </TooltipWrapper>
+      <RateLimitPopover onClose={() => setOpen(false)} />
+    </Popover>
+  );
+}

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -406,24 +406,28 @@ function RateLimitRefreshAllButton({
   // gets its `() => Promise<void>` contract without gating the spinner on the
   // fetches themselves - the queue's `draining` state (below) owns that.
   const refreshAll = (): Promise<void> => {
-    for (const provider of providers) {
-      if (provider.lane !== "httpFetch") continue;
-      void queryClient.invalidateQueries({
-        queryKey: queryKeys.hostMethod<
-          HostRpcRegistry,
-          "host.getRateLimitUsage"
-        >(hostId, "host.getRateLimitUsage", {
-          accountContext: DEFAULT_ACCOUNT_CONTEXT,
-          providerId: provider.providerId,
-        }),
+    providers
+      .filter((provider) => provider.lane === "httpFetch")
+      .forEach((provider) => {
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.hostMethod<
+            HostRpcRegistry,
+            "host.getRateLimitUsage"
+          >(hostId, "host.getRateLimitUsage", {
+            accountContext: DEFAULT_ACCOUNT_CONTEXT,
+            providerId: provider.providerId,
+          }),
+        });
       });
-    }
-    for (const provider of providers) {
-      if (provider.lane !== "ephemeralProcess") continue;
-      void enqueueRateLimitFetch(provider.providerId, DEFAULT_ACCOUNT_CONTEXT, {
-        force: true,
+    providers
+      .filter((provider) => provider.lane === "ephemeralProcess")
+      .forEach((provider) => {
+        void enqueueRateLimitFetch(
+          provider.providerId,
+          DEFAULT_ACCOUNT_CONTEXT,
+          { force: true },
+        );
       });
-    }
     return Promise.resolve();
   };
 

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -22,13 +22,13 @@ import {
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useHostQueries } from "@/hooks/host/use-host-queries";
 import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
-import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import {
   useConfiguredRateLimitProviders,
   type ConfiguredRateLimitProvider,
 } from "@/hooks/rate-limits/use-configured-rate-limit-providers";
 import { useIsRateLimitQueueDraining } from "@/hooks/rate-limits/use-is-rate-limit-queue-draining";
+import { useProviderRateLimitRefresh } from "@/hooks/rate-limits/use-provider-rate-limit-refresh";
 import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
 import {
   formatUnavailableReason,
@@ -43,10 +43,7 @@ import {
   sortProviderStatesByProviderOrder,
 } from "@/lib/provider-ordering";
 import { queryKeys } from "@/lib/query-keys";
-import {
-  rateLimitFetchLane,
-  type RateLimitProviderId,
-} from "@/lib/rate-limit-providers";
+import { type RateLimitProviderId } from "@/lib/rate-limit-providers";
 import { useRelativeTimestamp } from "@/lib/relative-time";
 import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
@@ -584,12 +581,14 @@ function RateLimitProviderBlock({
   readonly onReady: (() => void) | null;
 }): ReactNode {
   const query = useHostProviderRateLimitsQuery(providerId);
-  // Fresh-data-on-open for the ephemeralProcess lane, routed through the
-  // shared serial queue rather than TanStack's own (deliberately disabled)
-  // refetch-on-mount - see providerRateLimitQueryOptions' doc comment.
-  useRefreshProviderRateLimitsOnMount(providerId);
-  const draining = useIsRateLimitQueueDraining();
-  const lane = rateLimitFetchLane(providerId);
+  // Single source of truth for this provider's refresh action + spinner state
+  // (fresh-on-open, queue routing, and the ephemeralProcess `draining` fold-in),
+  // shared verbatim with the Settings card so they can't drift apart.
+  const { refresh, isRefreshing } = useProviderRateLimitRefresh(
+    providerId,
+    query.isFetching,
+    query.refetch,
+  );
   const queryState: ProviderRateLimitQueryState = {
     isPending: query.isPending,
     isFetching: query.isFetching,
@@ -600,19 +599,6 @@ function RateLimitProviderBlock({
   useEffect(() => {
     if (state.kind !== "cold" && onReady !== null) onReady();
   }, [state.kind, onReady]);
-
-  // ephemeralProcess: a manual refresh must go through the serial queue
-  // (`force: true`) so it can't spawn a subprocess overlapping a scheduled tick.
-  // httpFetch: refetch the query directly - no subprocess to bound.
-  const refresh = async (): Promise<void> => {
-    if (lane === "ephemeralProcess") {
-      await enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
-        force: true,
-      });
-      return;
-    }
-    await query.refetch();
-  };
 
   // Chip next to the name, single-provider tab only (Overview stays
   // condensed - same scoping the plan/tier line used before it moved into
@@ -655,20 +641,11 @@ function RateLimitProviderBlock({
             <RefreshIconButton
               onRefresh={refresh}
               label={`Refresh ${providerDisplayName(providerId)}`}
-              // ephemeralProcess providers refresh one at a time through the
-              // shared serial queue: this provider's OWN `isFetching` can
-              // already be back to `false` (its turn in the round settled)
-              // while "Refresh all" is still working through a LATER provider
-              // in the same round (`draining` stays true for the whole
-              // round). Folding `draining` in here keeps this button disabled
-              // for the round's full duration, not just this provider's own
-              // slice of it - matching "Refresh all" being in progress" as
-              // the gating condition, not "my own fetch is in flight".
-              // httpFetch providers refresh concurrently (no shared queue),
-              // so their own `isFetching` is already the complete signal.
-              refreshing={
-                query.isFetching || (lane === "ephemeralProcess" && draining)
-              }
+              // `isRefreshing` (from useProviderRateLimitRefresh) already folds
+              // in the ephemeralProcess `draining` flag, so this button stays
+              // disabled for a "Refresh all" round's full duration, not just
+              // this provider's own slice of it.
+              refreshing={isRefreshing}
             />
           ) : null}
         </div>

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -1,7 +1,15 @@
-import { useMemo, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Gauge, Settings } from "lucide-react";
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { Badge } from "@/components/ui/badge";
+import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { PopoverContent } from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
@@ -22,6 +30,7 @@ import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
 import {
   formatUnavailableReason,
   resolvePopoverProviderRateLimitState,
+  resolveProviderPlanLabel,
   type PopoverProviderRateLimitState,
 } from "@/lib/provider-rate-limit-content";
 import type { HostRpcRegistry } from "@/lib/host";
@@ -50,6 +59,7 @@ import {
   parseAccountContextValue,
   resolveTraycerSubscriptionState,
   selectSubscription,
+  subscriptionPlanLabel,
   type TraycerSubscriptionState,
 } from "@/lib/auth/traycer-subscription-content";
 import {
@@ -224,9 +234,13 @@ function RateLimitDetailPane({
   readonly tab: Exclude<RateLimitTab, "overview">;
 }): ReactNode {
   return tab === "traycer" ? (
-    <TraycerRateLimitBlock variant="popover-detail" />
+    <TraycerRateLimitBlock variant="popover-detail" onReady={null} />
   ) : (
-    <RateLimitProviderBlock providerId={tab} variant="popover-detail" />
+    <RateLimitProviderBlock
+      providerId={tab}
+      variant="popover-detail"
+      onReady={null}
+    />
   );
 }
 
@@ -356,29 +370,86 @@ function RailTab({
  * Traycer account picker are single-provider-tab detail, not shown here. The
  * "Refresh all" and settings controls live on the rail (shared across every
  * tab), so this pane is pure content - no header row, and dividers only
- * *between* consecutive blocks (`index > 0`). Not capped at 3 (unlike the header
- * glyph) - it's a scroll, not a summary.
+ * *between* consecutive blocks. Not capped at 3 (unlike the header glyph) -
+ * it's a scroll, not a summary.
+ *
+ * Every tab's block stays mounted the whole time (so its query keeps running
+ * regardless of what's visible), but a tab that hasn't reported readiness yet
+ * (`onReady`, fired once its own state moves past `cold`) is hidden rather
+ * than painted as its own blank/loading section - it's revealed in place once
+ * its data arrives, so the list grows one provider at a time instead of every
+ * slot appearing empty up front. While nothing has reported ready yet, a
+ * single centered "Fetching rate limits" indicator stands in for the whole
+ * list (feedback: "just a modal centered fetching rate limits instead of
+ * empty provider sections").
  */
 function RateLimitOverview({
   railTabs,
 }: {
   readonly railTabs: ReadonlyArray<RailTabDescriptor>;
 }): ReactNode {
+  const [readyKeys, setReadyKeys] = useState<ReadonlySet<string>>(new Set());
+  const markReady = useCallback((key: string) => {
+    setReadyKeys((prev) => {
+      if (prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  }, []);
+
+  const anyReady = readyKeys.size > 0;
+  const readyOrder = railTabs
+    .filter((tab) => readyKeys.has(railTabProviderId(tab)))
+    .map(railTabProviderId);
+
   return (
-    <div className="flex flex-col gap-4">
-      {railTabs.map((tab, index) => (
-        <div key={railTabProviderId(tab)} className="flex flex-col gap-4">
-          {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
-          {tab.kind === "traycer" ? (
-            <TraycerRateLimitBlock variant="popover-overview" />
-          ) : (
-            <RateLimitProviderBlock
-              providerId={tab.providerId}
-              variant="popover-overview"
-            />
-          )}
-        </div>
-      ))}
+    <div className="flex min-h-full flex-col gap-4">
+      {!anyReady ? <RateLimitOverviewLoading /> : null}
+      {railTabs.map((tab) => {
+        const key = railTabProviderId(tab);
+        const isReady = readyKeys.has(key);
+        const showDivider = isReady && readyOrder.indexOf(key) > 0;
+        const onReady = () => markReady(key);
+        return (
+          <div
+            key={key}
+            className={cn("flex flex-col gap-4", !isReady && "hidden")}
+          >
+            {showDivider ? (
+              <div aria-hidden className="h-px bg-border/70" />
+            ) : null}
+            {tab.kind === "traycer" ? (
+              <TraycerRateLimitBlock
+                variant="popover-overview"
+                onReady={onReady}
+              />
+            ) : (
+              <RateLimitProviderBlock
+                providerId={tab.providerId}
+                variant="popover-overview"
+                onReady={onReady}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * The Overview's combined "nothing has arrived yet" state - a single centered
+ * indicator standing in for every provider's still-blank section, rather than
+ * painting N blank/loading sections at once. `flex-1` on a `min-h-full`
+ * column centers it within the popover's full pane height rather than
+ * collapsing to the height of the (hidden, zero-height) sibling blocks.
+ */
+function RateLimitOverviewLoading(): ReactNode {
+  return (
+    <div className="flex flex-1 items-center justify-center gap-2 py-10 text-ui-sm text-muted-foreground">
+      <MutedAgentSpinner />
+      Fetching rate limits
     </div>
   );
 }
@@ -449,18 +520,28 @@ function RateLimitRefreshAllButton({
 type PopoverBlockVariant = "popover-detail" | "popover-overview";
 
 /**
- * One provider's block - a header (name + "Updated Xm ago" + per-provider
- * refresh) over its state-driven body. Shared by the single-provider tab
- * (`variant="popover-detail"`, full detail) and each Overview entry
- * (`variant="popover-overview"`, condensed), so both render an identical header
- * over a variant-scoped body.
+ * One provider's block - a header (name + plan/tier chip + "Updated Xm ago" +
+ * per-provider refresh) over its state-driven body. Shared by the
+ * single-provider tab (`variant="popover-detail"`, full detail) and each
+ * Overview entry (`variant="popover-overview"`, condensed). The plan/tier
+ * chip (`resolveProviderPlanLabel`) is single-provider-tab only, same scoping
+ * Overview already applies to every other detail field; the rest of the
+ * header renders identically across both variants.
+ *
+ * `onReady` fires once (and again on every later state change, harmlessly -
+ * the callback is expected to be idempotent) `state.kind` moves past `cold`,
+ * so `RateLimitOverview` can reveal this block in place instead of painting
+ * it as a blank/loading section from mount. `null` on the single-provider
+ * detail tab, which always renders regardless of state.
  */
 function RateLimitProviderBlock({
   providerId,
   variant,
+  onReady,
 }: {
   readonly providerId: RateLimitProviderId;
   readonly variant: PopoverBlockVariant;
+  readonly onReady: (() => void) | null;
 }): ReactNode {
   const query = useHostProviderRateLimitsQuery(providerId);
   const lane = rateLimitFetchLane(providerId);
@@ -471,6 +552,9 @@ function RateLimitProviderBlock({
     providerRateLimits: query.data?.providerRateLimits,
   };
   const state = resolvePopoverProviderRateLimitState(queryState);
+  useEffect(() => {
+    if (state.kind !== "cold" && onReady !== null) onReady();
+  }, [state.kind, onReady]);
 
   // ephemeralProcess: a manual refresh must go through the serial queue
   // (`force: true`) so it can't spawn a subprocess overlapping a scheduled tick.
@@ -485,12 +569,35 @@ function RateLimitProviderBlock({
     await query.refetch();
   };
 
+  // Chip next to the name, single-provider tab only (Overview stays
+  // condensed - same scoping the plan/tier line used before it moved into
+  // this header). `null` for a provider that doesn't report a plan/tier
+  // (`resolveProviderPlanLabel`), so no chip renders for e.g. OpenRouter.
+  const planLabel =
+    variant === "popover-detail" && state.kind === "ready"
+      ? resolveProviderPlanLabel(state.data)
+      : null;
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-ui-sm font-medium text-foreground">
-          {providerDisplayName(providerId)}
-        </span>
+        <div className="flex min-w-0 items-center gap-1.5">
+          {/* Overview stacks every provider's block in one scrollable list with
+              no rail-tab context alongside it, so the name alone doesn't say
+              which provider this is; the single-provider detail tab already has
+              that context from its selected rail icon. */}
+          {variant === "popover-overview" ? (
+            <HarnessIcon harnessId={providerIdToGuiHarnessId(providerId)} />
+          ) : null}
+          <span className="text-ui-sm font-medium text-foreground">
+            {providerDisplayName(providerId)}
+          </span>
+          {planLabel !== null ? (
+            <Badge variant="secondary" className="font-normal">
+              {planLabel}
+            </Badge>
+          ) : null}
+        </div>
         <div className="flex items-center gap-1.5">
           <RateLimitUpdatedLabel
             state={state}
@@ -508,11 +615,7 @@ function RateLimitProviderBlock({
           ) : null}
         </div>
       </div>
-      <RateLimitProviderBody
-        state={state}
-        onRetry={refresh}
-        variant={variant}
-      />
+      <RateLimitProviderBody state={state} variant={variant} />
     </div>
   );
 }
@@ -550,11 +653,9 @@ function UpdatedAgoText({
 
 function RateLimitProviderBody({
   state,
-  onRetry,
   variant,
 }: {
   readonly state: PopoverProviderRateLimitState;
-  readonly onRetry: () => Promise<void>;
   readonly variant: PopoverBlockVariant;
 }): ReactNode {
   switch (state.kind) {
@@ -562,16 +663,12 @@ function RateLimitProviderBody({
       return <RateLimitDetailSkeleton />;
     case "error":
       return (
-        <RateLimitErrorMessage
-          message="Couldn't load rate limits right now."
-          onRetry={onRetry}
-        />
+        <RateLimitErrorMessage message="Couldn't load rate limits right now." />
       );
     case "unavailable":
       return (
         <RateLimitErrorMessage
           message={`Rate limits unavailable — ${formatUnavailableReason(state.reason)}`}
-          onRetry={onRetry}
         />
       );
     case "ready":
@@ -590,16 +687,23 @@ function RateLimitProviderBody({
  * `RateLimitProviderBlock`. Its data is the signed-in user's subscription
  * (`useAuthUser`) for the globally-selected account (`useAccountContextStore`),
  * NOT a `host.getRateLimitUsage` provider pull. Header mirrors the provider
- * blocks (name + "Updated Xm ago" + refresh); the detail variant adds the same
- * Personal/Team picker the Settings card uses, so switching accounts here
- * updates the global selection (and therefore Overview, the Settings card, and
- * what a Traycer run bills). Both variants render through the shared
- * `TraycerSubscriptionView`.
+ * blocks (name + plan/tier chip + "Updated Xm ago" + refresh) - the chip
+ * (`subscriptionPlanLabel`) reflects whichever account is currently selected
+ * and is single-provider-tab only, same scoping
+ * `RateLimitProviderBlock` applies to its own plan chip; the detail variant
+ * adds the same Personal/Team picker the Settings card uses, so switching
+ * accounts here updates the global selection (and therefore Overview, the
+ * Settings card, and what a Traycer run bills). Both variants render through
+ * the shared `TraycerSubscriptionView`. `onReady` mirrors
+ * `RateLimitProviderBlock`'s own - fires once `state.kind` moves past `cold`,
+ * `null` on the single-provider detail tab.
  */
 function TraycerRateLimitBlock({
   variant,
+  onReady,
 }: {
   readonly variant: PopoverBlockVariant;
+  readonly onReady: (() => void) | null;
 }): ReactNode {
   const query = useAuthUser();
   const storedAccountContext = useAccountContextStore((s) => s.accountContext);
@@ -617,11 +721,22 @@ function TraycerRateLimitBlock({
     isError: query.isError,
     subscription,
   });
+  useEffect(() => {
+    if (state.kind !== "cold" && onReady !== null) onReady();
+  }, [state.kind, onReady]);
 
   const overview = variant === "popover-overview";
   const rateLimitBased =
     subscription !== null &&
     !isCreditBasedPricing(subscription.subscriptionStatus);
+  // Chip next to the name, single-provider tab only - same scoping
+  // `resolveProviderPlanLabel` uses for the host-RPC providers' plan chip.
+  // Reflects whichever account (personal/team) is currently selected, since
+  // `subscription` is already resolved against that selection.
+  const planLabel =
+    !overview && subscription !== null
+      ? subscriptionPlanLabel(subscription.subscriptionStatus)
+      : null;
 
   // Refetch the subscription, and - only for rate-limit-based plans, whose
   // aperture bar is live host data - invalidate that exact query so the mounted
@@ -646,9 +761,19 @@ function TraycerRateLimitBlock({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-ui-sm font-medium text-foreground">
-          {providerDisplayName("traycer")}
-        </span>
+        <div className="flex min-w-0 items-center gap-1.5">
+          {overview ? (
+            <HarnessIcon harnessId={providerIdToGuiHarnessId("traycer")} />
+          ) : null}
+          <span className="text-ui-sm font-medium text-foreground">
+            {providerDisplayName("traycer")}
+          </span>
+          {planLabel !== null ? (
+            <Badge variant="secondary" className="font-normal">
+              {planLabel}
+            </Badge>
+          ) : null}
+        </div>
         <div className="flex items-center gap-1.5">
           {state.kind === "ready" && query.dataUpdatedAt !== 0 ? (
             <UpdatedAgoText
@@ -679,27 +804,22 @@ function TraycerRateLimitBlock({
           }
         />
       ) : null}
-      <TraycerRateLimitBody state={state} onRetry={refresh} />
+      <TraycerRateLimitBody state={state} />
     </div>
   );
 }
 
 function TraycerRateLimitBody({
   state,
-  onRetry,
 }: {
   readonly state: TraycerSubscriptionState;
-  readonly onRetry: () => Promise<void>;
 }): ReactNode {
   switch (state.kind) {
     case "cold":
       return <RateLimitDetailSkeleton />;
     case "error":
       return (
-        <RateLimitErrorMessage
-          message="Couldn't load your Traycer subscription right now."
-          onRetry={onRetry}
-        />
+        <RateLimitErrorMessage message="Couldn't load your Traycer subscription right now." />
       );
     case "empty":
       return (
@@ -716,33 +836,29 @@ function TraycerRateLimitBody({
   }
 }
 
+// No inline retry action here - the block's own header refresh icon (detail
+// tab) or the rail's "Refresh all" (Overview) already covers it, so a second
+// retry control right below the message would just be a redundant control
+// for the same action.
 function RateLimitErrorMessage({
   message,
-  onRetry,
 }: {
   readonly message: string;
-  readonly onRetry: () => Promise<void>;
 }): ReactNode {
-  return (
-    <div className="flex flex-col items-start gap-1.5">
-      <p className="text-ui-xs text-muted-foreground">{message}</p>
-      <button
-        type="button"
-        onClick={() => {
-          void onRetry();
-        }}
-        className="rounded text-ui-xs font-medium text-primary outline-none transition-colors hover:text-primary/80 hover:underline focus-visible:ring-2 focus-visible:ring-ring/60"
-      >
-        Retry
-      </button>
-    </div>
-  );
+  return <p className="text-ui-xs text-muted-foreground">{message}</p>;
 }
 
 /**
  * Cold load (first open this session, no data yet): skeleton bars previewing
  * the eventual window layout, not a spinner replacing the panel (Core Flows -
  * a deliberate difference from the Settings card's spinner).
+ *
+ * Each block overrides `Skeleton`'s default `bg-muted` fill with
+ * `bg-foreground/15`, same reasoning as `MeterRow`'s track: several dark
+ * theme presets set `--muted` equal to `--popover`, so a plain `bg-muted`
+ * skeleton can end up the same color as the popover background and read as
+ * an empty section instead of a loading one. An opacity overlay on
+ * `--foreground` contrasts against any background without needing a border.
  */
 function RateLimitDetailSkeleton(): ReactNode {
   return (
@@ -753,10 +869,10 @@ function RateLimitDetailSkeleton(): ReactNode {
       {[0, 1].map((row) => (
         <div key={row} className="flex flex-col gap-1.5">
           <div className="flex items-center justify-between">
-            <Skeleton className="h-3 w-16" />
-            <Skeleton className="h-3 w-10" />
+            <Skeleton className="h-3 w-16 bg-foreground/15" />
+            <Skeleton className="h-3 w-10 bg-foreground/15" />
           </div>
-          <Skeleton className="h-1.5 w-full rounded-full" />
+          <Skeleton className="h-1.5 w-full rounded-full bg-foreground/15" />
         </div>
       ))}
     </div>

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -588,6 +588,7 @@ function RateLimitProviderBlock({
   // shared serial queue rather than TanStack's own (deliberately disabled)
   // refetch-on-mount - see providerRateLimitQueryOptions' doc comment.
   useRefreshProviderRateLimitsOnMount(providerId);
+  const draining = useIsRateLimitQueueDraining();
   const lane = rateLimitFetchLane(providerId);
   const queryState: ProviderRateLimitQueryState = {
     isPending: query.isPending,
@@ -654,7 +655,20 @@ function RateLimitProviderBlock({
             <RefreshIconButton
               onRefresh={refresh}
               label={`Refresh ${providerDisplayName(providerId)}`}
-              refreshing={query.isFetching}
+              // ephemeralProcess providers refresh one at a time through the
+              // shared serial queue: this provider's OWN `isFetching` can
+              // already be back to `false` (its turn in the round settled)
+              // while "Refresh all" is still working through a LATER provider
+              // in the same round (`draining` stays true for the whole
+              // round). Folding `draining` in here keeps this button disabled
+              // for the round's full duration, not just this provider's own
+              // slice of it - matching "Refresh all" being in progress" as
+              // the gating condition, not "my own fetch is in flight".
+              // httpFetch providers refresh concurrently (no shared queue),
+              // so their own `isFetching` is already the complete signal.
+              refreshing={
+                query.isFetching || (lane === "ephemeralProcess" && draining)
+              }
             />
           ) : null}
         </div>

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -483,6 +483,20 @@ function RateLimitRefreshAllButton({
   const httpFetchProviders = providers.filter(
     (provider) => provider.lane === "httpFetch",
   );
+  // Every httpFetch provider resolves to the exact same lane options (the
+  // `isHttpFetch` branch in `providerRateLimitQueryOptions` doesn't vary by
+  // provider id) - reusing the first one's is safe without the "verify every
+  // request shares one lane" check `useHeaderRateLimitBars` needs (that hook's
+  // provider list isn't pre-filtered to a single lane the way `httpFetchProviders`
+  // is here). Passing this through (rather than `null`) matters:
+  // `RateLimitProviderBlock`'s own query for these same providers sets
+  // `retry: false`, and TanStack keys retry/staleTime/refetchOnMount per query
+  // key - an unset `options` here would silently inherit the global
+  // QueryClient's defaults (one retry) for this same key instead.
+  const httpFetchOptions =
+    httpFetchProviders.length === 0
+      ? null
+      : providerRateLimitQueryOptions(httpFetchProviders[0].providerId).options;
   const httpFetchQueries = useHostQueries<
     HostRpcRegistry,
     "host.getRateLimitUsage"
@@ -494,7 +508,7 @@ function RateLimitRefreshAllButton({
       );
       return { method, params };
     }),
-    options: null,
+    options: httpFetchOptions,
   });
   const refreshing =
     draining || httpFetchQueries.some((query) => query.isFetching);

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -20,6 +20,9 @@ import {
   type ProviderRateLimitQueryState,
 } from "@/components/settings/panels/provider-rate-limit-views";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
+import { useHostQueries } from "@/hooks/host/use-host-queries";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import {
   useConfiguredRateLimitProviders,
@@ -33,7 +36,7 @@ import {
   resolveProviderPlanLabel,
   type PopoverProviderRateLimitState,
 } from "@/lib/provider-rate-limit-content";
-import type { HostRpcRegistry } from "@/lib/host";
+import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import {
   providerDisplayName,
   providerIdToGuiHarnessId,
@@ -459,8 +462,14 @@ function RateLimitOverviewLoading(): ReactNode {
  * refresh one at a time through the shared serial queue (`force: true`), while
  * httpFetch providers refresh concurrently alongside via a direct query
  * invalidation - a plain GET has no subprocess cost to serialize. `refreshing`
- * is wired to the queue's draining state so the icon spins and the button stays
- * disabled until the round finishes, so it can't be re-triggered mid-round.
+ * combines both lanes' real query state - the queue's draining flag for
+ * ephemeralProcess (which stays true a beat longer than any single provider's
+ * `isFetching`, covering the "still waiting behind an earlier provider in the
+ * queue" gap) and each configured httpFetch provider's own `isFetching` (read
+ * via `useHostQueries` against the exact same query keys the invalidation
+ * below targets) - so the icon spins for the whole round regardless of which
+ * lane(s) are actually configured, not just when an ephemeralProcess provider
+ * happens to be in the mix.
  */
 function RateLimitRefreshAllButton({
   providers,
@@ -470,26 +479,43 @@ function RateLimitRefreshAllButton({
   const draining = useIsRateLimitQueueDraining();
   const queryClient = useQueryClient();
   const hostId = useReactiveActiveHostId();
+  const client = useHostClient();
+  const httpFetchProviders = providers.filter(
+    (provider) => provider.lane === "httpFetch",
+  );
+  const httpFetchQueries = useHostQueries<
+    HostRpcRegistry,
+    "host.getRateLimitUsage"
+  >({
+    client,
+    requests: httpFetchProviders.map((provider) => {
+      const { method, params } = providerRateLimitQueryOptions(
+        provider.providerId,
+      );
+      return { method, params };
+    }),
+    options: null,
+  });
+  const refreshing =
+    draining || httpFetchQueries.some((query) => query.isFetching);
 
   // Fire-and-forget, not awaited: httpFetch providers refresh concurrently via a
   // direct invalidation while ephemeralProcess providers queue through the
   // shared serial lane. Returns an already-resolved promise so `RefreshIconButton`
   // gets its `() => Promise<void>` contract without gating the spinner on the
-  // fetches themselves - the queue's `draining` state (below) owns that.
+  // fetches themselves - `refreshing` (above) owns that.
   const refreshAll = (): Promise<void> => {
-    providers
-      .filter((provider) => provider.lane === "httpFetch")
-      .forEach((provider) => {
-        void queryClient.invalidateQueries({
-          queryKey: queryKeys.hostMethod<
-            HostRpcRegistry,
-            "host.getRateLimitUsage"
-          >(hostId, "host.getRateLimitUsage", {
-            accountContext: DEFAULT_ACCOUNT_CONTEXT,
-            providerId: provider.providerId,
-          }),
-        });
+    httpFetchProviders.forEach((provider) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.hostMethod<
+          HostRpcRegistry,
+          "host.getRateLimitUsage"
+        >(hostId, "host.getRateLimitUsage", {
+          accountContext: DEFAULT_ACCOUNT_CONTEXT,
+          providerId: provider.providerId,
+        }),
       });
+    });
     providers
       .filter((provider) => provider.lane === "ephemeralProcess")
       .forEach((provider) => {
@@ -506,7 +532,7 @@ function RateLimitRefreshAllButton({
     <RefreshIconButton
       onRefresh={refreshAll}
       label="Refresh all"
-      refreshing={draining}
+      refreshing={refreshing}
       className="mt-1"
     />
   );
@@ -544,6 +570,10 @@ function RateLimitProviderBlock({
   readonly onReady: (() => void) | null;
 }): ReactNode {
   const query = useHostProviderRateLimitsQuery(providerId);
+  // Fresh-data-on-open for the ephemeralProcess lane, routed through the
+  // shared serial queue rather than TanStack's own (deliberately disabled)
+  // refetch-on-mount - see providerRateLimitQueryOptions' doc comment.
+  useRefreshProviderRateLimitsOnMount(providerId);
   const lane = rateLimitFetchLane(providerId);
   const queryState: ProviderRateLimitQueryState = {
     isPending: query.isPending,

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -1,0 +1,790 @@
+import { useMemo, useState, type ReactNode } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Gauge, Settings } from "lucide-react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { PopoverContent } from "@/components/ui/popover";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { RefreshIconButton } from "@/components/refresh-icon-button";
+import { HarnessIcon } from "@/components/home/pickers/harness-icon";
+import {
+  ProviderRateLimitDetail,
+  type ProviderRateLimitQueryState,
+} from "@/components/settings/panels/provider-rate-limit-views";
+import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import {
+  useConfiguredRateLimitProviders,
+  type ConfiguredRateLimitProvider,
+} from "@/hooks/rate-limits/use-configured-rate-limit-providers";
+import { useIsRateLimitQueueDraining } from "@/hooks/rate-limits/use-is-rate-limit-queue-draining";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+import {
+  formatUnavailableReason,
+  resolvePopoverProviderRateLimitState,
+  type PopoverProviderRateLimitState,
+} from "@/lib/provider-rate-limit-content";
+import type { HostRpcRegistry } from "@/lib/host";
+import {
+  providerDisplayName,
+  providerIdToGuiHarnessId,
+  sortProviderStatesByProviderOrder,
+} from "@/lib/provider-ordering";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+import { useRelativeTimestamp } from "@/lib/relative-time";
+import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { useAuthUser } from "@/hooks/auth/use-auth-user-query";
+import {
+  resolveAccountContext,
+  useAccountContextStore,
+} from "@/stores/auth/account-context-store";
+import {
+  accountContextValue,
+  isCreditBasedPricing,
+  isTraycerEligible,
+  parseAccountContextValue,
+  resolveTraycerSubscriptionState,
+  selectSubscription,
+  type TraycerSubscriptionState,
+} from "@/lib/auth/traycer-subscription-content";
+import {
+  TraycerAccountSelect,
+  TraycerSubscriptionView,
+} from "@/components/settings/panels/traycer-subscription-views";
+import { cn } from "@/lib/utils";
+
+/**
+ * The Overview tab (always pinned first), one tab per connected host-RPC
+ * provider, and - when the account is eligible - the GUI-sourced "traycer" tab.
+ * `"traycer"` is a synthetic entry: it is NOT a `RateLimitProviderId` and does
+ * not flow through `useConfiguredRateLimitProviders()`.
+ */
+type RateLimitTab = "overview" | RateLimitProviderId | "traycer";
+
+/**
+ * A rail/Overview entry, in draw order: either a host-RPC provider or the
+ * synthetic Traycer entry. `railTabProviderId` maps each to a `ProviderId` so a
+ * single `sortProviderStatesByProviderOrder` positions Traycer at its
+ * `PROVIDER_ID_ORDER` slot among the providers.
+ */
+type RailTabDescriptor =
+  | { readonly kind: "provider"; readonly providerId: RateLimitProviderId }
+  | { readonly kind: "traycer" };
+
+function railTabProviderId(tab: RailTabDescriptor): ProviderId {
+  return tab.kind === "traycer" ? "traycer" : tab.providerId;
+}
+
+function orderRailTabs(
+  providers: ReadonlyArray<ConfiguredRateLimitProvider>,
+  includeTraycer: boolean,
+): ReadonlyArray<RailTabDescriptor> {
+  const descriptors: RailTabDescriptor[] = providers.map((provider) => ({
+    kind: "provider",
+    providerId: provider.providerId,
+  }));
+  if (includeTraycer) descriptors.push({ kind: "traycer" });
+  return sortProviderStatesByProviderOrder(
+    descriptors.map((descriptor) => ({
+      providerId: railTabProviderId(descriptor),
+      descriptor,
+    })),
+  ).map((entry) => entry.descriptor);
+}
+
+/**
+ * The header rate-limit popover content: a left rail (Overview + one tab per
+ * connected provider) and a detail pane, mirroring the composer's model-picker
+ * shell (Core Flows: "same interaction family as the composer's model picker").
+ * The whole body is a child of `PopoverContent`, so Radix only mounts it - and
+ * runs its queries and tab state - while the popover is open; `activeTab`
+ * therefore resets to Overview on every open (Core Flows: "Landing tab is
+ * always Overview").
+ */
+export function RateLimitPopover({
+  onClose,
+}: {
+  readonly onClose: () => void;
+}): ReactNode {
+  return (
+    <PopoverContent
+      side="bottom"
+      align="end"
+      sideOffset={8}
+      collisionPadding={12}
+      role="dialog"
+      aria-label="Rate limits"
+      className="w-[min(92vw,30rem)] gap-0 overflow-hidden rounded-xl p-0"
+      // Radix auto-focuses the first focusable child on open. Here that's the
+      // Overview rail tab, whose `TooltipWrapper` opens the tooltip on focus
+      // (keyboard a11y) - so it would pop open the instant the popover mounts
+      // and never receive a mouseleave/blur to close it. This popover has no
+      // field to type into (unlike the composer's model picker, whose first
+      // focusable is its search input, so it wants and keeps the auto-focus), so
+      // opting out of the initial focus is harmless and stops the stuck tooltip.
+      onOpenAutoFocus={(event) => event.preventDefault()}
+    >
+      <RateLimitPopoverBody onClose={onClose} />
+    </PopoverContent>
+  );
+}
+
+function RateLimitPopoverBody({
+  onClose,
+}: {
+  readonly onClose: () => void;
+}): ReactNode {
+  const configured = useConfiguredRateLimitProviders();
+  // Rail order matches the app's standard provider order everywhere else.
+  const providers = useMemo(
+    () => sortProviderStatesByProviderOrder(configured),
+    [configured],
+  );
+
+  // Traycer is a GUI-only rail entry (AuthService subscription, not a host RPC),
+  // gated on the *selected* account being paid or credit-bundled. Recomputed
+  // reactively from the auth query + account-context store, so the tab appears /
+  // disappears live as either changes - not snapshotted at popover-open time.
+  const authQuery = useAuthUser();
+  const storedAccountContext = useAccountContextStore((s) => s.accountContext);
+  const traycerEligible = useMemo(() => {
+    const user = authQuery.data ?? null;
+    const teams = user?.teamSubscriptions ?? [];
+    const teamIds = new Set(teams.map((team) => team.team.id));
+    const resolved = resolveAccountContext(storedAccountContext, teamIds);
+    const subscription = selectSubscription(user, resolved, teams);
+    return subscription !== null && isTraycerEligible(subscription);
+  }, [authQuery.data, storedAccountContext]);
+
+  const railTabs = useMemo(
+    () => orderRailTabs(providers, traycerEligible),
+    [providers, traycerEligible],
+  );
+  const [activeTab, setActiveTab] = useState<RateLimitTab>("overview");
+
+  // Zero-state only when there is genuinely nothing to show: no host-RPC
+  // providers AND no eligible Traycer tab.
+  if (providers.length === 0 && !traycerEligible) {
+    return <RateLimitZeroState onClose={onClose} />;
+  }
+
+  // A credential removed (or Traycer becoming ineligible) mid-session can drop
+  // the active tab from the rail; fall back to Overview rather than rendering a
+  // tab that no longer exists.
+  const validTabs = new Set<RateLimitTab>([
+    "overview",
+    ...railTabs.map((tab) =>
+      tab.kind === "traycer" ? "traycer" : tab.providerId,
+    ),
+  ]);
+  const resolvedTab: RateLimitTab = validTabs.has(activeTab)
+    ? activeTab
+    : "overview";
+
+  // A *fixed* height (not `max-h`), plus an explicit `minmax(0,1fr)` grid row,
+  // is what makes the popover a stable box across tabs and lets its panes
+  // scroll: a `max-h` on a single-`auto`-row grid lets the row size to content,
+  // so the detail pane grew unbounded (tall content clipped, no scrollbar) and
+  // the whole popover resized per tab. `minmax(0,1fr)` pins the row to the
+  // container height regardless of content, and both columns stretch into it
+  // with their own `min-h-0` + `overflow-y-auto`, so each scrolls internally.
+  return (
+    <div className="grid h-[min(58vh,22rem)] grid-cols-[3rem_minmax(0,1fr)] grid-rows-[minmax(0,1fr)] overflow-hidden">
+      <RateLimitRail
+        railTabs={railTabs}
+        providers={providers}
+        activeTab={resolvedTab}
+        onSelect={setActiveTab}
+        onClose={onClose}
+      />
+      <div className="min-h-0 min-w-0 overflow-y-auto p-3">
+        {resolvedTab === "overview" ? (
+          <RateLimitOverview railTabs={railTabs} />
+        ) : (
+          <RateLimitDetailPane tab={resolvedTab} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The single-tab detail pane: the synthetic Traycer block, or a host-RPC
+ * provider block. Split out so `RateLimitPopoverBody` picks Overview-vs-detail
+ * with one ternary instead of a nested one.
+ */
+function RateLimitDetailPane({
+  tab,
+}: {
+  readonly tab: Exclude<RateLimitTab, "overview">;
+}): ReactNode {
+  return tab === "traycer" ? (
+    <TraycerRateLimitBlock variant="popover-detail" />
+  ) : (
+    <RateLimitProviderBlock providerId={tab} variant="popover-detail" />
+  );
+}
+
+/**
+ * The left rail: an Overview tab, one tab per connected provider, then a
+ * "Refresh all" and a "Provider settings" icon pinned to the bottom - the same
+ * structural shell as the composer model picker's `ProviderRail` (scrollable
+ * `role="tablist"` as a `flex-1` sibling, action icons after it). The two
+ * bottom icons are deliberately siblings of the tablist, not tabs inside it, so
+ * only real tab elements live under `role="tablist"` for correct screen-reader
+ * nav.
+ */
+function RateLimitRail({
+  railTabs,
+  providers,
+  activeTab,
+  onSelect,
+  onClose,
+}: {
+  readonly railTabs: ReadonlyArray<RailTabDescriptor>;
+  readonly providers: ReadonlyArray<ConfiguredRateLimitProvider>;
+  readonly activeTab: RateLimitTab;
+  readonly onSelect: (tab: RateLimitTab) => void;
+  readonly onClose: () => void;
+}): ReactNode {
+  const { openSettings } = useSystemTabModalActions();
+  const openProviderSettings = (): void => {
+    onClose();
+    openSettings({ section: "providers", resetToGeneral: false });
+  };
+  return (
+    <div className="flex min-h-0 flex-col items-center border-r bg-muted/20 p-1.5">
+      <div
+        role="tablist"
+        aria-label="Rate limit providers"
+        aria-orientation="vertical"
+        className="flex min-h-0 flex-1 flex-col items-center gap-1.5 overflow-y-auto"
+      >
+        <RailTab
+          label="Overview"
+          selected={activeTab === "overview"}
+          onSelect={() => onSelect("overview")}
+          icon={<Gauge className="size-4" />}
+        />
+        <div
+          role="separator"
+          aria-orientation="horizontal"
+          className="my-0.5 h-px w-5 bg-border"
+        />
+        {railTabs.map((tab) =>
+          tab.kind === "traycer" ? (
+            <RailTab
+              key="traycer"
+              label={providerDisplayName("traycer")}
+              selected={activeTab === "traycer"}
+              onSelect={() => onSelect("traycer")}
+              icon={
+                <HarnessIcon harnessId={providerIdToGuiHarnessId("traycer")} />
+              }
+            />
+          ) : (
+            <RailTab
+              key={tab.providerId}
+              label={providerDisplayName(tab.providerId)}
+              selected={activeTab === tab.providerId}
+              onSelect={() => onSelect(tab.providerId)}
+              icon={
+                <HarnessIcon
+                  harnessId={providerIdToGuiHarnessId(tab.providerId)}
+                />
+              }
+            />
+          ),
+        )}
+      </div>
+      <RateLimitRefreshAllButton providers={providers} />
+      <button
+        type="button"
+        aria-label="Provider settings"
+        title="Provider settings"
+        onClick={openProviderSettings}
+        className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        <Settings className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+function RailTab({
+  label,
+  selected,
+  onSelect,
+  icon,
+}: {
+  readonly label: string;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+  readonly icon: ReactNode;
+}): ReactNode {
+  return (
+    <TooltipWrapper label={label} side="right" sideOffset={6} align={undefined}>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={selected}
+        aria-label={label}
+        title={label}
+        onClick={onSelect}
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60",
+          selected && "bg-accent text-foreground",
+        )}
+      >
+        {icon}
+      </button>
+    </TooltipWrapper>
+  );
+}
+
+/**
+ * The Overview tab: every rail entry's *condensed* block
+ * (`variant="popover-overview"`), in rail order, each separated by a divider.
+ * For host-RPC providers that's their 5h/Weekly windows plus credit/balance
+ * figures; for the Traycer entry it's the tier badge + credit/rate-limit
+ * breakdown. Per-model breakdowns, spend controls, badges, plan labels, and the
+ * Traycer account picker are single-provider-tab detail, not shown here. The
+ * "Refresh all" and settings controls live on the rail (shared across every
+ * tab), so this pane is pure content - no header row, and dividers only
+ * *between* consecutive blocks (`index > 0`). Not capped at 3 (unlike the header
+ * glyph) - it's a scroll, not a summary.
+ */
+function RateLimitOverview({
+  railTabs,
+}: {
+  readonly railTabs: ReadonlyArray<RailTabDescriptor>;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-4">
+      {railTabs.map((tab, index) => (
+        <div key={railTabProviderId(tab)} className="flex flex-col gap-4">
+          {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
+          {tab.kind === "traycer" ? (
+            <TraycerRateLimitBlock variant="popover-overview" />
+          ) : (
+            <RateLimitProviderBlock
+              providerId={tab.providerId}
+              variant="popover-overview"
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The rail's icon-only "Refresh all" (Core Flows): ephemeralProcess providers
+ * refresh one at a time through the shared serial queue (`force: true`), while
+ * httpFetch providers refresh concurrently alongside via a direct query
+ * invalidation - a plain GET has no subprocess cost to serialize. `refreshing`
+ * is wired to the queue's draining state so the icon spins and the button stays
+ * disabled until the round finishes, so it can't be re-triggered mid-round.
+ */
+function RateLimitRefreshAllButton({
+  providers,
+}: {
+  readonly providers: ReadonlyArray<ConfiguredRateLimitProvider>;
+}): ReactNode {
+  const draining = useIsRateLimitQueueDraining();
+  const queryClient = useQueryClient();
+  const hostId = useReactiveActiveHostId();
+
+  // Fire-and-forget, not awaited: httpFetch providers refresh concurrently via a
+  // direct invalidation while ephemeralProcess providers queue through the
+  // shared serial lane. Returns an already-resolved promise so `RefreshIconButton`
+  // gets its `() => Promise<void>` contract without gating the spinner on the
+  // fetches themselves - the queue's `draining` state (below) owns that.
+  const refreshAll = (): Promise<void> => {
+    for (const provider of providers) {
+      if (provider.lane !== "httpFetch") continue;
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.hostMethod<
+          HostRpcRegistry,
+          "host.getRateLimitUsage"
+        >(hostId, "host.getRateLimitUsage", {
+          accountContext: DEFAULT_ACCOUNT_CONTEXT,
+          providerId: provider.providerId,
+        }),
+      });
+    }
+    for (const provider of providers) {
+      if (provider.lane !== "ephemeralProcess") continue;
+      void enqueueRateLimitFetch(provider.providerId, DEFAULT_ACCOUNT_CONTEXT, {
+        force: true,
+      });
+    }
+    return Promise.resolve();
+  };
+
+  return (
+    <RefreshIconButton
+      onRefresh={refreshAll}
+      label="Refresh all"
+      refreshing={draining}
+      className="mt-1"
+    />
+  );
+}
+
+/**
+ * The two popover surfaces a provider's block renders on: the single-provider
+ * tab (full detail) and the Overview tab (condensed). Both draw windows the
+ * same way; they differ only in how much detail is shown.
+ */
+type PopoverBlockVariant = "popover-detail" | "popover-overview";
+
+/**
+ * One provider's block - a header (name + "Updated Xm ago" + per-provider
+ * refresh) over its state-driven body. Shared by the single-provider tab
+ * (`variant="popover-detail"`, full detail) and each Overview entry
+ * (`variant="popover-overview"`, condensed), so both render an identical header
+ * over a variant-scoped body.
+ */
+function RateLimitProviderBlock({
+  providerId,
+  variant,
+}: {
+  readonly providerId: RateLimitProviderId;
+  readonly variant: PopoverBlockVariant;
+}): ReactNode {
+  const query = useHostProviderRateLimitsQuery(providerId);
+  const lane = rateLimitFetchLane(providerId);
+  const queryState: ProviderRateLimitQueryState = {
+    isPending: query.isPending,
+    isFetching: query.isFetching,
+    isError: query.isError,
+    providerRateLimits: query.data?.providerRateLimits,
+  };
+  const state = resolvePopoverProviderRateLimitState(queryState);
+
+  // ephemeralProcess: a manual refresh must go through the serial queue
+  // (`force: true`) so it can't spawn a subprocess overlapping a scheduled tick.
+  // httpFetch: refetch the query directly - no subprocess to bound.
+  const refresh = async (): Promise<void> => {
+    if (lane === "ephemeralProcess") {
+      await enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+        force: true,
+      });
+      return;
+    }
+    await query.refetch();
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-ui-sm font-medium text-foreground">
+          {providerDisplayName(providerId)}
+        </span>
+        <div className="flex items-center gap-1.5">
+          <RateLimitUpdatedLabel
+            state={state}
+            updatedAt={query.dataUpdatedAt}
+          />
+          {/* Overview has its own "Refresh all" on the rail (item 2 feedback:
+              a per-provider icon there was redundant); only the single-provider
+              detail tab keeps this one. */}
+          {variant === "popover-detail" ? (
+            <RefreshIconButton
+              onRefresh={refresh}
+              label={`Refresh ${providerDisplayName(providerId)}`}
+              refreshing={query.isFetching}
+            />
+          ) : null}
+        </div>
+      </div>
+      <RateLimitProviderBody
+        state={state}
+        onRetry={refresh}
+        variant={variant}
+      />
+    </div>
+  );
+}
+
+/**
+ * "Updated Xm ago", only once a reading actually exists - and "· refresh
+ * failed" appended when a last-known-good reading is being shown after a failed
+ * poll (Core Flows degraded state).
+ */
+function RateLimitUpdatedLabel({
+  state,
+  updatedAt,
+}: {
+  readonly state: PopoverProviderRateLimitState;
+  readonly updatedAt: number;
+}): ReactNode {
+  if (state.kind !== "ready" || updatedAt === 0) return null;
+  return <UpdatedAgoText updatedAt={updatedAt} degraded={state.degraded} />;
+}
+
+function UpdatedAgoText({
+  updatedAt,
+  degraded,
+}: {
+  readonly updatedAt: number;
+  readonly degraded: boolean;
+}): ReactNode {
+  const ago = useRelativeTimestamp(updatedAt);
+  return (
+    <span className="text-ui-xs text-muted-foreground">
+      {degraded ? `Updated ${ago} · refresh failed` : `Updated ${ago}`}
+    </span>
+  );
+}
+
+function RateLimitProviderBody({
+  state,
+  onRetry,
+  variant,
+}: {
+  readonly state: PopoverProviderRateLimitState;
+  readonly onRetry: () => Promise<void>;
+  readonly variant: PopoverBlockVariant;
+}): ReactNode {
+  switch (state.kind) {
+    case "cold":
+      return <RateLimitDetailSkeleton />;
+    case "error":
+      return (
+        <RateLimitErrorMessage
+          message="Couldn't load rate limits right now."
+          onRetry={onRetry}
+        />
+      );
+    case "unavailable":
+      return (
+        <RateLimitErrorMessage
+          message={`Rate limits unavailable — ${formatUnavailableReason(state.reason)}`}
+          onRetry={onRetry}
+        />
+      );
+    case "ready":
+      // Degraded (stale, latest poll failed): dim the reading in place rather
+      // than replacing it with an error (Core Flows).
+      return (
+        <div className={cn(state.degraded && "opacity-60")}>
+          <ProviderRateLimitDetail data={state.data} variant={variant} />
+        </div>
+      );
+  }
+}
+
+/**
+ * The synthetic "Traycer" block - the GUI-sourced analogue of
+ * `RateLimitProviderBlock`. Its data is the signed-in user's subscription
+ * (`useAuthUser`) for the globally-selected account (`useAccountContextStore`),
+ * NOT a `host.getRateLimitUsage` provider pull. Header mirrors the provider
+ * blocks (name + "Updated Xm ago" + refresh); the detail variant adds the same
+ * Personal/Team picker the Settings card uses, so switching accounts here
+ * updates the global selection (and therefore Overview, the Settings card, and
+ * what a Traycer run bills). Both variants render through the shared
+ * `TraycerSubscriptionView`.
+ */
+function TraycerRateLimitBlock({
+  variant,
+}: {
+  readonly variant: PopoverBlockVariant;
+}): ReactNode {
+  const query = useAuthUser();
+  const storedAccountContext = useAccountContextStore((s) => s.accountContext);
+  const setAccountContext = useAccountContextStore((s) => s.setAccountContext);
+  const queryClient = useQueryClient();
+  const hostId = useReactiveActiveHostId();
+
+  const user = query.data ?? null;
+  const teams = user?.teamSubscriptions ?? [];
+  const teamIds = new Set(teams.map((team) => team.team.id));
+  const resolved = resolveAccountContext(storedAccountContext, teamIds);
+  const subscription = selectSubscription(user, resolved, teams);
+  const state = resolveTraycerSubscriptionState({
+    isPending: query.isPending,
+    isError: query.isError,
+    subscription,
+  });
+
+  const overview = variant === "popover-overview";
+  const rateLimitBased =
+    subscription !== null &&
+    !isCreditBasedPricing(subscription.subscriptionStatus);
+
+  // Refetch the subscription, and - only for rate-limit-based plans, whose
+  // aperture bar is live host data - invalidate that exact query so the mounted
+  // `RateLimitView` refetches it too. `exact: true` targets only the aperture
+  // `{ accountContext }` key, never the providers' `{ accountContext, providerId }`
+  // pulls (which a Traycer refresh can't have changed).
+  const refresh = async (): Promise<void> => {
+    await query.refetch();
+    if (rateLimitBased) {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.hostMethod<
+          HostRpcRegistry,
+          "host.getRateLimitUsage"
+        >(hostId, "host.getRateLimitUsage", {
+          accountContext: storedAccountContext,
+        }),
+        exact: true,
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-ui-sm font-medium text-foreground">
+          {providerDisplayName("traycer")}
+        </span>
+        <div className="flex items-center gap-1.5">
+          {state.kind === "ready" && query.dataUpdatedAt !== 0 ? (
+            <UpdatedAgoText
+              updatedAt={query.dataUpdatedAt}
+              degraded={state.degraded}
+            />
+          ) : null}
+          {/* Overview has its own "Refresh all" on the rail (item 2 feedback);
+              only the single-provider detail tab keeps this one. */}
+          {!overview ? (
+            <RefreshIconButton
+              onRefresh={refresh}
+              label={`Refresh ${providerDisplayName("traycer")}`}
+              refreshing={query.isFetching}
+            />
+          ) : null}
+        </div>
+      </div>
+      {/* Detail tab only: the account picker, matching the Settings card. Renders
+          nothing when the user has no teams. Overview just reflects the global
+          selection with no controls, like every other Overview block. */}
+      {!overview ? (
+        <TraycerAccountSelect
+          teams={teams}
+          value={accountContextValue(resolved)}
+          onValueChange={(value) =>
+            setAccountContext(parseAccountContextValue(value))
+          }
+        />
+      ) : null}
+      <TraycerRateLimitBody state={state} onRetry={refresh} />
+    </div>
+  );
+}
+
+function TraycerRateLimitBody({
+  state,
+  onRetry,
+}: {
+  readonly state: TraycerSubscriptionState;
+  readonly onRetry: () => Promise<void>;
+}): ReactNode {
+  switch (state.kind) {
+    case "cold":
+      return <RateLimitDetailSkeleton />;
+    case "error":
+      return (
+        <RateLimitErrorMessage
+          message="Couldn't load your Traycer subscription right now."
+          onRetry={onRetry}
+        />
+      );
+    case "empty":
+      return (
+        <p className="text-ui-xs text-muted-foreground">
+          No subscription found for this account.
+        </p>
+      );
+    case "ready":
+      return (
+        <div className={cn(state.degraded && "opacity-60")}>
+          <TraycerSubscriptionView subscription={state.subscription} />
+        </div>
+      );
+  }
+}
+
+function RateLimitErrorMessage({
+  message,
+  onRetry,
+}: {
+  readonly message: string;
+  readonly onRetry: () => Promise<void>;
+}): ReactNode {
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      <p className="text-ui-xs text-muted-foreground">{message}</p>
+      <button
+        type="button"
+        onClick={() => {
+          void onRetry();
+        }}
+        className="rounded text-ui-xs font-medium text-primary outline-none transition-colors hover:text-primary/80 hover:underline focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Cold load (first open this session, no data yet): skeleton bars previewing
+ * the eventual window layout, not a spinner replacing the panel (Core Flows -
+ * a deliberate difference from the Settings card's spinner).
+ */
+function RateLimitDetailSkeleton(): ReactNode {
+  return (
+    <div
+      className="flex flex-col gap-3"
+      data-testid="rate-limit-detail-skeleton"
+    >
+      {[0, 1].map((row) => (
+        <div key={row} className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-3 w-10" />
+          </div>
+          <Skeleton className="h-1.5 w-full rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Zero-provider state (Core Flows): no rail, no tabs - a single CTA linking to
+ * Settings › Providers, since there's nothing yet to switch between.
+ */
+function RateLimitZeroState({
+  onClose,
+}: {
+  readonly onClose: () => void;
+}): ReactNode {
+  const { openSettings } = useSystemTabModalActions();
+  const openProviderSettings = (): void => {
+    onClose();
+    openSettings({ section: "providers", resetToGeneral: false });
+  };
+  return (
+    <div className="flex flex-col items-start gap-3 p-4">
+      <p className="text-ui-sm text-muted-foreground">
+        Connect Claude Code or Codex to see usage here.
+      </p>
+      <button
+        type="button"
+        onClick={openProviderSettings}
+        className="inline-flex items-center gap-1.5 rounded-md bg-accent px-2.5 py-1.5 text-ui-xs font-medium text-foreground outline-none transition-colors hover:bg-accent/80 focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        Open provider settings
+      </button>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
@@ -137,8 +137,10 @@ describe("ProviderRateLimitForProvider", () => {
     mocks.data = { providerRateLimits: CLAUDE_RATE_LIMITS };
     render(<ProviderRateLimitForProvider providerId="claude-code" />);
 
-    expect(screen.getByText("5h · 12% used")).toBeTruthy();
-    expect(screen.getByText("Weekly · 55% used")).toBeTruthy();
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("12% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("55% used")).toBeTruthy();
   });
 
   it("does not show a subscription-plan badge (the provider auth badge above already shows it)", () => {
@@ -204,8 +206,10 @@ describe("ProviderRateLimitForProvider", () => {
     mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
     render(<ProviderRateLimitForProvider providerId="codex" />);
 
-    expect(screen.getByText("5h · 42% used")).toBeTruthy();
-    expect(screen.getByText("Weekly · 80% used")).toBeTruthy();
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("42% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("80% used")).toBeTruthy();
   });
 
   it("maps a rateLimitReachedType token to a destructive badge", () => {
@@ -230,21 +234,26 @@ describe("ProviderRateLimitForProvider", () => {
     expect(screen.getByText("$12.50")).toBeTruthy();
   });
 
-  it("renders the spend-control row with used/limit and a relative reset line", () => {
+  it("renders the spend-control row with used/limit and an absolute reset time", () => {
     mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
     render(<ProviderRateLimitForProvider providerId="codex" />);
 
-    // Scoped to the spend-limit row's own container: the 5-hour window above
-    // it also renders a relative "Resets in " line, so an unscoped query
-    // would match two elements.
+    // Scoped to the spend-limit row's own container: the current-session
+    // window above it also renders a reset line, so an unscoped query would
+    // match two elements.
     const spendLimitRow = screen
       .getByText("Spend limit")
       .closest("div.flex.flex-col.gap-1");
     expect(spendLimitRow).not.toBeNull();
     const spendLimitScope = within(spendLimitRow as HTMLElement);
     expect(spendLimitScope.getByText("42.00 / 100.00")).toBeTruthy();
-    // `CodexSpendControlRow` always passes `weekly={false}` to `ResetLine`,
-    // so this renders the relative countdown, not the exact date/time.
-    expect(spendLimitScope.getByText(/^Resets in /)).toBeTruthy();
+    // Regression: `CodexSpendControlRow` used to hardcode `weekly={false}`,
+    // always forcing a relative countdown regardless of the real reset time.
+    // `CODEX_SPEND_LIMIT_RESETS_AT` is 5 days out, so the reset line now
+    // correctly reads as an absolute weekday/time, not "Resets in ...".
+    expect(
+      spendLimitScope.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
+    ).toBeTruthy();
+    expect(spendLimitScope.queryByText(/^Resets in /)).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
@@ -1,5 +1,11 @@
 import "../../../../../__tests__/test-browser-apis";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderRateLimits } from "@traycer/protocol/host";
 import { formatResetDateTime } from "@/lib/relative-time";
@@ -11,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   isError: false,
   isFetching: false,
   refetch: vi.fn(() => Promise.resolve({})),
+  draining: false,
+  enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
 }));
 
 vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
@@ -25,8 +33,17 @@ vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
 vi.mock("@/hooks/host/use-refresh-provider-rate-limits-on-turn", () => ({
   useRefreshProviderRateLimitsOnTurn: () => {},
 }));
+vi.mock("@/hooks/host/use-refresh-provider-rate-limits-on-mount", () => ({
+  useRefreshProviderRateLimitsOnMount: () => {},
+}));
 vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
   useReactiveActiveHostId: () => "host-1",
+}));
+vi.mock("@/hooks/rate-limits/use-is-rate-limit-queue-draining", () => ({
+  useIsRateLimitQueueDraining: () => mocks.draining,
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  enqueueRateLimitFetch: (...args: unknown[]) => mocks.enqueue(...args),
 }));
 
 import { ProviderRateLimitForProvider } from "../provider-rate-limit-section";
@@ -101,6 +118,8 @@ describe("ProviderRateLimitForProvider", () => {
     mocks.isPending = false;
     mocks.isError = false;
     mocks.isFetching = false;
+    mocks.draining = false;
+    mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
   });
 
   afterEach(() => {
@@ -255,5 +274,30 @@ describe("ProviderRateLimitForProvider", () => {
       spendLimitScope.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
     ).toBeTruthy();
     expect(spendLimitScope.queryByText(/^Resets in /)).toBeNull();
+  });
+
+  it("routes a Codex (ephemeralProcess) manual refresh through the shared queue with force:true, not a bare query.refetch()", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh rate limits" }),
+    );
+
+    expect(mocks.enqueue).toHaveBeenCalledWith("codex", expect.anything(), {
+      force: true,
+    });
+    expect(mocks.refetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the refresh button disabled while the shared queue is draining, even once this provider's own isFetching has settled", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    mocks.isFetching = false;
+    mocks.draining = true;
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    expect(
+      screen.getByRole("button", { name: "Refresh rate limits" }),
+    ).toHaveProperty("disabled", true);
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
@@ -43,10 +43,12 @@ const CLAUDE_RATE_LIMITS: ProviderRateLimits = {
   fiveHour: {
     usedPercent: 12,
     resetsAt: CLAUDE_FIVE_HOUR_RESETS_AT,
+    durationMinutes: 300,
   },
   sevenDay: {
     usedPercent: 55,
     resetsAt: CLAUDE_SEVEN_DAY_RESETS_AT,
+    durationMinutes: 10080,
   },
   sevenDayOpus: null,
   sevenDaySonnet: null,
@@ -65,14 +67,19 @@ const CODEX_RATE_LIMITS: ProviderRateLimits = {
   // settings card no longer shows it - the provider auth badge above
   // already does.
   planType: "plus",
+  limitId: null,
+  limitName: null,
   primary: {
     usedPercent: 42,
     resetsAt: CODEX_PRIMARY_RESETS_AT,
+    durationMinutes: 300,
   },
   secondary: {
     usedPercent: 80,
     resetsAt: CODEX_SECONDARY_RESETS_AT,
+    durationMinutes: 10080,
   },
+  extraWindows: [],
   credits: {
     hasCredits: true,
     unlimited: false,
@@ -84,6 +91,7 @@ const CODEX_RATE_LIMITS: ProviderRateLimits = {
     remainingPercent: 58,
     resetsAt: CODEX_SPEND_LIMIT_RESETS_AT,
   },
+  resetCredits: null,
   rateLimitReachedType: "rate_limit_reached",
 };
 
@@ -129,10 +137,8 @@ describe("ProviderRateLimitForProvider", () => {
     mocks.data = { providerRateLimits: CLAUDE_RATE_LIMITS };
     render(<ProviderRateLimitForProvider providerId="claude-code" />);
 
-    expect(screen.getByText("5-hour")).toBeTruthy();
-    expect(screen.getByText("Weekly")).toBeTruthy();
-    expect(screen.getByText("12% / 100%")).toBeTruthy();
-    expect(screen.getByText("55% / 100%")).toBeTruthy();
+    expect(screen.getByText("5h · 12% used")).toBeTruthy();
+    expect(screen.getByText("Weekly · 55% used")).toBeTruthy();
   });
 
   it("does not show a subscription-plan badge (the provider auth badge above already shows it)", () => {
@@ -153,45 +159,53 @@ describe("ProviderRateLimitForProvider", () => {
     expect(screen.getByText(/^Resets in /)).toBeTruthy();
   });
 
-  it("colors a window's bar amber above 70% used and red above 90% used", () => {
+  it("colors a window's bar yellow at/above 60% used and red above 85% used", () => {
+    // The Settings card now shares the same four-tier severity scale as the
+    // popover (item 6 feedback: "different UX looks weird").
     mocks.data = {
       providerRateLimits: {
         ...CLAUDE_RATE_LIMITS,
-        fiveHour: { usedPercent: 75, resetsAt: CLAUDE_FIVE_HOUR_RESETS_AT },
-        sevenDay: { usedPercent: 95, resetsAt: CLAUDE_SEVEN_DAY_RESETS_AT },
+        fiveHour: {
+          usedPercent: 75,
+          resetsAt: CLAUDE_FIVE_HOUR_RESETS_AT,
+          durationMinutes: 300,
+        },
+        sevenDay: {
+          usedPercent: 95,
+          resetsAt: CLAUDE_SEVEN_DAY_RESETS_AT,
+          durationMinutes: 10080,
+        },
       },
     };
     const { container } = render(
       <ProviderRateLimitForProvider providerId="claude-code" />,
     );
 
-    expect(container.querySelectorAll(".bg-amber-500").length).toBeGreaterThan(
+    expect(container.querySelectorAll(".bg-yellow-500").length).toBeGreaterThan(
       0,
     );
-    expect(
-      container.querySelectorAll(".bg-destructive").length,
-    ).toBeGreaterThan(0);
+    expect(container.querySelectorAll(".bg-red-500").length).toBeGreaterThan(0);
   });
 
-  it("keeps the bar at the default color at or below 70% used", () => {
+  it("keeps the bar blue below the yellow threshold", () => {
     mocks.data = { providerRateLimits: CLAUDE_RATE_LIMITS };
     const { container } = render(
       <ProviderRateLimitForProvider providerId="claude-code" />,
     );
 
-    expect(container.querySelectorAll(".bg-amber-500").length).toBe(0);
-    expect(container.querySelectorAll(".bg-destructive").length).toBe(0);
-    expect(container.querySelectorAll(".bg-primary").length).toBeGreaterThan(0);
+    expect(container.querySelectorAll(".bg-yellow-500").length).toBe(0);
+    expect(container.querySelectorAll(".bg-red-500").length).toBe(0);
+    expect(container.querySelectorAll(".bg-blue-500").length).toBeGreaterThan(
+      0,
+    );
   });
 
   it("renders the Codex rate-limit detail once loaded", () => {
     mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
     render(<ProviderRateLimitForProvider providerId="codex" />);
 
-    expect(screen.getByText("5-hour")).toBeTruthy();
-    expect(screen.getByText("Weekly")).toBeTruthy();
-    expect(screen.getByText("42% / 100%")).toBeTruthy();
-    expect(screen.getByText("80% / 100%")).toBeTruthy();
+    expect(screen.getByText("5h · 42% used")).toBeTruthy();
+    expect(screen.getByText("Weekly · 80% used")).toBeTruthy();
   });
 
   it("maps a rateLimitReachedType token to a destructive badge", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -1,0 +1,322 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ProviderRateLimits } from "@traycer/protocol/host";
+import {
+  CodexRateLimitView,
+  KiloCodeRateLimitView,
+  OpenRouterRateLimitView,
+  ProviderRateLimitDetail,
+} from "../provider-rate-limit-views";
+
+type CodexRateLimits = Extract<ProviderRateLimits, { provider: "codex" }>;
+type OpenRouterRateLimits = Extract<
+  ProviderRateLimits,
+  { provider: "openrouter" }
+>;
+type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
+
+const NOW = Date.now();
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CodexRateLimitView (extended fields)", () => {
+  const codex: CodexRateLimits = {
+    provider: "codex",
+    available: true,
+    planType: "pro_5x",
+    limitId: "base",
+    limitName: null,
+    primary: {
+      usedPercent: 4,
+      resetsAt: NOW + 60 * 60 * 1000,
+      durationMinutes: 300,
+    },
+    secondary: {
+      usedPercent: 68,
+      resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+      durationMinutes: 10080,
+    },
+    extraWindows: [
+      {
+        limitId: "gpt5",
+        limitName: "GPT-5",
+        primary: {
+          usedPercent: 20,
+          resetsAt: NOW + 2 * 60 * 60 * 1000,
+          durationMinutes: 300,
+        },
+        secondary: null,
+      },
+    ],
+    credits: null,
+    individualLimit: null,
+    resetCredits: { availableCount: 3 },
+    rateLimitReachedType: null,
+  };
+
+  it("labels windows from their real duration (not a hardcoded 5-hour/Weekly)", () => {
+    render(<CodexRateLimitView data={codex} variant="settings" />);
+    expect(screen.getByText("5h · 4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly · 68% used")).toBeTruthy();
+  });
+
+  it("shows the plan/tier label from planType in the popover detail tab", () => {
+    render(<CodexRateLimitView data={codex} variant="popover-detail" />);
+    // `planType` ("pro_5x") title-cased - NOT `limitName` (a bucket id).
+    expect(screen.getByText("Pro 5x")).toBeTruthy();
+  });
+
+  it("omits any plan/tier label in the settings variant", () => {
+    render(<CodexRateLimitView data={codex} variant="settings" />);
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+  });
+
+  it("renders each extraWindow as its own labeled row (limit name + duration)", () => {
+    render(<CodexRateLimitView data={codex} variant="settings" />);
+    expect(screen.getByText("GPT-5 · 5h · 20% used")).toBeTruthy();
+  });
+
+  it("renders the manual reset-credits block", () => {
+    render(<CodexRateLimitView data={codex} variant="settings" />);
+    expect(screen.getByText("Manual resets")).toBeTruthy();
+    expect(screen.getByText("3 available")).toBeTruthy();
+  });
+
+  it("renders a generic day/hour duration for an off-standard window", () => {
+    render(
+      <CodexRateLimitView
+        data={{
+          ...codex,
+          limitName: null,
+          extraWindows: [],
+          primary: {
+            usedPercent: 4,
+            resetsAt: NOW + 60 * 60 * 1000,
+            durationMinutes: 360,
+          },
+          secondary: {
+            usedPercent: 68,
+            resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+            durationMinutes: 30 * 24 * 60,
+          },
+        }}
+        variant="settings"
+      />,
+    );
+    expect(screen.getByText("6h · 4% used")).toBeTruthy();
+    expect(screen.getByText("30d · 68% used")).toBeTruthy();
+  });
+
+  it("renders the popover variant as '% used' with a four-tier bar color", () => {
+    const { container } = render(
+      <CodexRateLimitView data={codex} variant="popover-detail" />,
+    );
+    // primary 4% used -> blue tier; secondary 68% used -> yellow tier.
+    expect(screen.getByText("5h · 4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly · 68% used")).toBeTruthy();
+    expect(container.querySelectorAll(".bg-blue-500").length).toBeGreaterThan(
+      0,
+    );
+    expect(container.querySelectorAll(".bg-yellow-500").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("draws every popover window track with a border so an empty bar stays visible", () => {
+    // Regression (Issue 3): several dark presets set --muted == --popover, so a
+    // borderless bg-muted track vanished at 0% fill. A 0%-used window must still
+    // show a bordered, empty track.
+    const { container } = render(
+      <CodexRateLimitView
+        data={{
+          ...codex,
+          secondary: null,
+          extraWindows: [],
+          resetCredits: null,
+          primary: {
+            usedPercent: 0,
+            resetsAt: NOW + 60 * 60 * 1000,
+            durationMinutes: 300,
+          },
+        }}
+        variant="popover-detail"
+      />,
+    );
+    expect(screen.getByText("5h · 0% used")).toBeTruthy();
+    const tracks = container.querySelectorAll(".bg-muted.border-border");
+    expect(tracks.length).toBeGreaterThan(0);
+  });
+
+  it("shows a relative countdown for a short popover window", () => {
+    // Fixup C #1: the popover reverts to the same relative-for-short /
+    // exact-for-weekly split as the Settings card. `primary` is a 5h window, so
+    // it reads as a relative countdown ("Resets in 4h 7m"), not an absolute date.
+    render(
+      <CodexRateLimitView
+        data={{ ...codex, secondary: null, extraWindows: [] }}
+        variant="popover-detail"
+      />,
+    );
+    expect(screen.getByText(/^Resets in /)).toBeTruthy();
+    expect(screen.queryByText(/\([A-Za-z]{3}\) /)).toBeNull();
+  });
+
+  it("shows an absolute weekday-tagged date for a weekly popover window", () => {
+    // The weekly (10080-min) `secondary` window keeps the absolute reset line
+    // ("Resets Jul 11, 2026 (Tue) 3:35 AM"), since "Resets in 3d" is too coarse.
+    render(
+      <CodexRateLimitView
+        data={{ ...codex, primary: null, extraWindows: [] }}
+        variant="popover-detail"
+      />,
+    );
+    expect(screen.getByText(/^Resets .+\([A-Za-z]{3}\) /)).toBeTruthy();
+    expect(screen.queryByText(/^Resets in /)).toBeNull();
+  });
+
+  it("condenses the popover Overview to only the 5h/Weekly windows (credits dropped)", () => {
+    // Item 3 feedback: Overview drops Credits too, along with per-model
+    // extraWindows, the reset-credits block, and the plan label; it keeps only
+    // the primary/secondary windows.
+    render(
+      <CodexRateLimitView
+        data={{
+          ...codex,
+          credits: { unlimited: true, hasCredits: true, balance: null },
+        }}
+        variant="popover-overview"
+      />,
+    );
+    // Kept: primary (4% used) + secondary (68% used) windows.
+    expect(screen.getByText("5h · 4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly · 68% used")).toBeTruthy();
+    // Dropped: plan label, per-model extraWindow row, reset-credits block, and
+    // Credits.
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+    expect(screen.queryByText("GPT-5 · 5h · 20% used")).toBeNull();
+    expect(screen.queryByText("Manual resets")).toBeNull();
+    expect(screen.queryByText("Credits")).toBeNull();
+  });
+});
+
+describe("OpenRouterRateLimitView", () => {
+  const openRouter: OpenRouterRateLimits = {
+    provider: "openrouter",
+    available: true,
+    limit: 100,
+    limitRemaining: 40,
+    dailySpend: 5,
+    weeklySpend: 12,
+    monthlySpend: 30,
+    totalCredits: 100,
+    totalUsage: 60,
+    balance: 40,
+  };
+
+  it("renders a usage bar from limit/limitRemaining", () => {
+    render(<OpenRouterRateLimitView data={openRouter} variant="settings" />);
+    expect(screen.getByText("Credits")).toBeTruthy();
+    expect(screen.getByText("$60.00 / $100.00")).toBeTruthy();
+  });
+
+  it("renders the uncapped spend/credit figures as plain rows", () => {
+    render(<OpenRouterRateLimitView data={openRouter} variant="settings" />);
+    expect(screen.getByText("Balance")).toBeTruthy();
+    expect(screen.getByText("Spent this month")).toBeTruthy();
+    expect(screen.getByText("$30.00")).toBeTruthy();
+  });
+
+  it("omits the bar when there is no hard limit", () => {
+    render(
+      <OpenRouterRateLimitView
+        data={{ ...openRouter, limit: null, limitRemaining: null }}
+        variant="settings"
+      />,
+    );
+    expect(screen.queryByText("Credits")).toBeNull();
+    // The uncapped figures still render.
+    expect(screen.getByText("Balance")).toBeTruthy();
+  });
+
+  it("condenses the Overview to only the Credits bar and Balance", () => {
+    // Issue 2d: Overview keeps the balance-shaped fields, drops the total /
+    // per-period spend rows.
+    render(
+      <OpenRouterRateLimitView data={openRouter} variant="popover-overview" />,
+    );
+    expect(screen.getByText("Credits")).toBeTruthy();
+    expect(screen.getByText("Balance")).toBeTruthy();
+    expect(screen.queryByText("Spent this month")).toBeNull();
+    expect(screen.queryByText("Total credits")).toBeNull();
+  });
+});
+
+describe("KiloCodeRateLimitView", () => {
+  const kilo: KiloCodeRateLimits = {
+    provider: "kilocode",
+    available: true,
+    creditBalance: 25.5,
+    passState: "active",
+  };
+
+  it("renders the credit balance and pass state as plain rows (no bar)", () => {
+    const { container } = render(
+      <KiloCodeRateLimitView data={kilo} variant="settings" />,
+    );
+    expect(screen.getByText("Credit balance")).toBeTruthy();
+    expect(screen.getByText("$25.50")).toBeTruthy();
+    expect(screen.getByText("Kilo Pass")).toBeTruthy();
+    expect(screen.getByText("Active")).toBeTruthy();
+    // No computable percentage -> no fill bar.
+    expect(container.querySelectorAll(".bg-primary").length).toBe(0);
+  });
+
+  it("condenses the Overview to only the credit balance (drops Kilo Pass)", () => {
+    render(<KiloCodeRateLimitView data={kilo} variant="popover-overview" />);
+    expect(screen.getByText("Credit balance")).toBeTruthy();
+    expect(screen.queryByText("Kilo Pass")).toBeNull();
+  });
+});
+
+describe("ProviderRateLimitDetail dispatch", () => {
+  it("dispatches to the OpenRouter view", () => {
+    render(
+      <ProviderRateLimitDetail
+        data={{
+          provider: "openrouter",
+          available: true,
+          limit: null,
+          limitRemaining: null,
+          dailySpend: null,
+          weeklySpend: null,
+          monthlySpend: null,
+          totalCredits: null,
+          totalUsage: null,
+          balance: 12,
+        }}
+        variant="settings"
+      />,
+    );
+    expect(screen.getByText("Balance")).toBeTruthy();
+    expect(screen.getByText("$12.00")).toBeTruthy();
+  });
+
+  it("dispatches to the Kilo Code view", () => {
+    render(
+      <ProviderRateLimitDetail
+        data={{
+          provider: "kilocode",
+          available: true,
+          creditBalance: 7,
+          passState: null,
+        }}
+        variant="settings"
+      />,
+    );
+    expect(screen.getByText("Credit balance")).toBeTruthy();
+    expect(screen.getByText("$7.00")).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import type { ProviderRateLimits } from "@traycer/protocol/host";
 import {
+  ClaudeRateLimitView,
   CodexRateLimitView,
   KiloCodeRateLimitView,
   OpenRouterRateLimitView,
@@ -10,6 +11,10 @@ import {
 } from "../provider-rate-limit-views";
 
 type CodexRateLimits = Extract<ProviderRateLimits, { provider: "codex" }>;
+type ClaudeRateLimits = Extract<
+  ProviderRateLimits,
+  { provider: "claude-code" }
+>;
 type OpenRouterRateLimits = Extract<
   ProviderRateLimits,
   { provider: "openrouter" }
@@ -59,24 +64,24 @@ describe("CodexRateLimitView (extended fields)", () => {
 
   it("labels windows from their real duration (not a hardcoded 5-hour/Weekly)", () => {
     render(<CodexRateLimitView data={codex} variant="settings" />);
-    expect(screen.getByText("5h · 4% used")).toBeTruthy();
-    expect(screen.getByText("Weekly · 68% used")).toBeTruthy();
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("68% used")).toBeTruthy();
   });
 
-  it("shows the plan/tier label from planType in the popover detail tab", () => {
+  it("never renders the plan/tier label itself - the header popover owns that chip", () => {
+    // `resolveProviderPlanLabel` (provider-rate-limit-content.test.ts) covers the
+    // planType -> "Pro 5x" mapping; the popover header's own test coverage
+    // (rate-limit-popover.test.tsx) covers the chip actually rendering.
     render(<CodexRateLimitView data={codex} variant="popover-detail" />);
-    // `planType` ("pro_5x") title-cased - NOT `limitName` (a bucket id).
-    expect(screen.getByText("Pro 5x")).toBeTruthy();
-  });
-
-  it("omits any plan/tier label in the settings variant", () => {
-    render(<CodexRateLimitView data={codex} variant="settings" />);
     expect(screen.queryByText("Pro 5x")).toBeNull();
   });
 
   it("renders each extraWindow as its own labeled row (limit name + duration)", () => {
     render(<CodexRateLimitView data={codex} variant="settings" />);
-    expect(screen.getByText("GPT-5 · 5h · 20% used")).toBeTruthy();
+    expect(screen.getByText("GPT-5 · Current session")).toBeTruthy();
+    expect(screen.getByText("20% used")).toBeTruthy();
   });
 
   it("renders the manual reset-credits block", () => {
@@ -106,8 +111,10 @@ describe("CodexRateLimitView (extended fields)", () => {
         variant="settings"
       />,
     );
-    expect(screen.getByText("6h · 4% used")).toBeTruthy();
-    expect(screen.getByText("30d · 68% used")).toBeTruthy();
+    expect(screen.getByText("6h")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("30d")).toBeTruthy();
+    expect(screen.getByText("68% used")).toBeTruthy();
   });
 
   it("renders the popover variant as '% used' with a four-tier bar color", () => {
@@ -115,8 +122,10 @@ describe("CodexRateLimitView (extended fields)", () => {
       <CodexRateLimitView data={codex} variant="popover-detail" />,
     );
     // primary 4% used -> blue tier; secondary 68% used -> yellow tier.
-    expect(screen.getByText("5h · 4% used")).toBeTruthy();
-    expect(screen.getByText("Weekly · 68% used")).toBeTruthy();
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("68% used")).toBeTruthy();
     expect(container.querySelectorAll(".bg-blue-500").length).toBeGreaterThan(
       0,
     );
@@ -125,10 +134,12 @@ describe("CodexRateLimitView (extended fields)", () => {
     );
   });
 
-  it("draws every popover window track with a border so an empty bar stays visible", () => {
-    // Regression (Issue 3): several dark presets set --muted == --popover, so a
-    // borderless bg-muted track vanished at 0% fill. A 0%-used window must still
-    // show a bordered, empty track.
+  it("draws every popover window track with a foreground-opacity fill so an empty bar stays visible", () => {
+    // Regression (Issue 3): several dark presets set --muted == --popover, so
+    // a `bg-muted` track vanished at 0% fill. The track now fills with
+    // `bg-foreground/15` instead, which contrasts against any background
+    // regardless of theme - a 0%-used window must still show a visible,
+    // empty track, with no border needed to keep it that way.
     const { container } = render(
       <CodexRateLimitView
         data={{
@@ -145,8 +156,9 @@ describe("CodexRateLimitView (extended fields)", () => {
         variant="popover-detail"
       />,
     );
-    expect(screen.getByText("5h · 0% used")).toBeTruthy();
-    const tracks = container.querySelectorAll(".bg-muted.border-border");
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("0% used")).toBeTruthy();
+    const tracks = container.querySelectorAll(".bg-foreground\\/15");
     expect(tracks.length).toBeGreaterThan(0);
   });
 
@@ -161,19 +173,21 @@ describe("CodexRateLimitView (extended fields)", () => {
       />,
     );
     expect(screen.getByText(/^Resets in /)).toBeTruthy();
-    expect(screen.queryByText(/\([A-Za-z]{3}\) /)).toBeNull();
+    expect(screen.queryByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}/)).toBeNull();
   });
 
-  it("shows an absolute weekday-tagged date for a weekly popover window", () => {
+  it("shows an absolute weekday-tagged time for a weekly popover window", () => {
     // The weekly (10080-min) `secondary` window keeps the absolute reset line
-    // ("Resets Jul 11, 2026 (Tue) 3:35 AM"), since "Resets in 3d" is too coarse.
+    // ("Resets Sat 3:35 AM"), since "Resets in 3d" is too coarse.
     render(
       <CodexRateLimitView
         data={{ ...codex, primary: null, extraWindows: [] }}
         variant="popover-detail"
       />,
     );
-    expect(screen.getByText(/^Resets .+\([A-Za-z]{3}\) /)).toBeTruthy();
+    expect(
+      screen.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
+    ).toBeTruthy();
     expect(screen.queryByText(/^Resets in /)).toBeNull();
   });
 
@@ -191,14 +205,53 @@ describe("CodexRateLimitView (extended fields)", () => {
       />,
     );
     // Kept: primary (4% used) + secondary (68% used) windows.
-    expect(screen.getByText("5h · 4% used")).toBeTruthy();
-    expect(screen.getByText("Weekly · 68% used")).toBeTruthy();
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("68% used")).toBeTruthy();
     // Dropped: plan label, per-model extraWindow row, reset-credits block, and
     // Credits.
     expect(screen.queryByText("Pro 5x")).toBeNull();
-    expect(screen.queryByText("GPT-5 · 5h · 20% used")).toBeNull();
+    expect(screen.queryByText("GPT-5 · Current session")).toBeNull();
     expect(screen.queryByText("Manual resets")).toBeNull();
     expect(screen.queryByText("Credits")).toBeNull();
+  });
+});
+
+describe("ClaudeRateLimitView", () => {
+  it("shows an absolute weekday-tagged time for a far per-model reset, even though modelScoped carries no durationMinutes", () => {
+    // Regression: `modelScoped` entries never carry a `durationMinutes` (the
+    // SDK's per-model usage has no separate duration field), so a
+    // duration-based "is this weekly-scale" check always fell back to the
+    // relative countdown for these rows, no matter how far away the real
+    // reset was ("Fable" usage showed "Resets in 3d" instead of "Resets Tue
+    // 5:29 PM"). The reset-format decision is now based on the real
+    // `resetsAt` delta instead, so a 3-day-out per-model reset gets the same
+    // absolute treatment a weekly window does.
+    const claude: ClaudeRateLimits = {
+      provider: "claude-code",
+      available: true,
+      subscriptionType: "max",
+      fiveHour: null,
+      sevenDay: null,
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      modelScoped: [
+        {
+          displayName: "Fable",
+          usedPercent: 12,
+          resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+          durationMinutes: null,
+        },
+      ],
+      extraUsage: null,
+    };
+    render(<ClaudeRateLimitView data={claude} variant="settings" />);
+    expect(screen.getByText("Fable")).toBeTruthy();
+    expect(
+      screen.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/^Resets in /)).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -253,6 +253,72 @@ describe("ClaudeRateLimitView", () => {
     ).toBeTruthy();
     expect(screen.queryByText(/^Resets in /)).toBeNull();
   });
+
+  it("sets the model-scoped rows off with a divider, not a 'Per-model' heading", () => {
+    // Same header-less group treatment CodexRateLimitView gives its per-model
+    // (Spark) extraWindows: the rows' own display names already say which
+    // model each is, so the group gets a hairline divider instead of a label.
+    const claude: ClaudeRateLimits = {
+      provider: "claude-code",
+      available: true,
+      subscriptionType: "max",
+      fiveHour: {
+        usedPercent: 12,
+        resetsAt: NOW + 60 * 60 * 1000,
+        durationMinutes: 300,
+      },
+      sevenDay: {
+        usedPercent: 55,
+        resetsAt: NOW + 2 * 24 * 60 * 60 * 1000,
+        durationMinutes: 10080,
+      },
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      modelScoped: [
+        {
+          displayName: "Fable",
+          usedPercent: 12,
+          resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+          durationMinutes: null,
+        },
+      ],
+      extraUsage: null,
+    };
+    const { container } = render(
+      <ClaudeRateLimitView data={claude} variant="settings" />,
+    );
+    expect(screen.queryByText("Per-model")).toBeNull();
+    // Exactly one divider: between the fixed windows and the model-scoped
+    // group (extraUsage is null, so no second one).
+    expect(container.querySelectorAll('[class*="bg-border/70"]').length).toBe(
+      1,
+    );
+    expect(screen.getByText("Fable")).toBeTruthy();
+  });
+
+  it("renders no divider when only the fixed windows are present", () => {
+    const claude: ClaudeRateLimits = {
+      provider: "claude-code",
+      available: true,
+      subscriptionType: "max",
+      fiveHour: {
+        usedPercent: 12,
+        resetsAt: NOW + 60 * 60 * 1000,
+        durationMinutes: 300,
+      },
+      sevenDay: null,
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      modelScoped: [],
+      extraUsage: null,
+    };
+    const { container } = render(
+      <ClaudeRateLimitView data={claude} variant="settings" />,
+    );
+    expect(container.querySelectorAll('[class*="bg-border/70"]').length).toBe(
+      0,
+    );
+  });
 });
 
 describe("OpenRouterRateLimitView", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
@@ -143,7 +143,6 @@ describe("TraycerSubscriptionSection", () => {
 
   it("renders the personal subscription by default", () => {
     render(<TraycerSubscriptionSection />);
-    expect(screen.getByText("Pro")).toBeDefined();
     // Plan bucket: 30 consumed of 100 total (extension's consumed/total wording).
     expect(screen.getByText("$30.00 / $100.00")).toBeDefined();
   });
@@ -155,7 +154,6 @@ describe("TraycerSubscriptionSection", () => {
         .getState()
         .setAccountContext({ type: "TEAM", teamId: "team-1" });
     });
-    expect(screen.getByText("Ultra 1x")).toBeDefined();
     // Plan bucket: 100 consumed of 500 total.
     expect(screen.getByText("$100.00 / $500.00")).toBeDefined();
   });
@@ -172,7 +170,6 @@ describe("TraycerSubscriptionSection", () => {
       },
     };
     render(<TraycerSubscriptionSection />);
-    expect(screen.getByText("Pro Plus")).toBeDefined();
     expect(screen.getByText("Rate limit")).toBeDefined();
     // 1800s → 30 minutes recharge.
     expect(screen.getByText("30 minutes")).toBeDefined();

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
@@ -7,18 +7,14 @@
  */
 import type { ReactNode } from "react";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
-import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { ProviderRateLimitBody } from "@/components/settings/panels/provider-rate-limit-views";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
-import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
-import { useIsRateLimitQueueDraining } from "@/hooks/rate-limits/use-is-rate-limit-queue-draining";
-import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+import { useProviderRateLimitRefresh } from "@/hooks/rate-limits/use-provider-rate-limit-refresh";
 import {
   isRateLimitCapableProvider,
-  rateLimitFetchLane,
   type RateLimitProviderId,
 } from "@/lib/rate-limit-providers";
 
@@ -41,29 +37,17 @@ function ProviderRateLimitSettingsCard({
 }): ReactNode {
   const hostId = useReactiveActiveHostId();
   const query = useHostProviderRateLimitsQuery(providerId);
-  // Fresh-data-on-open for the ephemeralProcess lane, routed through the
-  // shared serial queue rather than TanStack's own (deliberately disabled)
-  // refetch-on-mount - see providerRateLimitQueryOptions' doc comment.
-  useRefreshProviderRateLimitsOnMount(providerId);
+  // Single source of truth for this provider's refresh action + spinner state
+  // (fresh-on-open, queue routing, and the ephemeralProcess `draining` fold-in),
+  // shared verbatim with the popover's per-provider block.
+  const { refresh, isRefreshing } = useProviderRateLimitRefresh(
+    providerId,
+    query.isFetching,
+    query.refetch,
+  );
   // Keep the bars live: a turn on this provider finishing while the card is
   // open re-fetches usage. Only mounted here, so it costs nothing elsewhere.
   useRefreshProviderRateLimitsOnTurn(providerId, hostId);
-  const draining = useIsRateLimitQueueDraining();
-  const lane = rateLimitFetchLane(providerId);
-
-  // Same split the popover's `RateLimitProviderBlock` uses: an ephemeralProcess
-  // manual refresh must go through the serial queue (`force: true`) so it can't
-  // spawn a subprocess overlapping one the queue is already running - a bare
-  // `query.refetch()` here would call the host directly, bypassing that bound.
-  const refresh = async (): Promise<void> => {
-    if (lane === "ephemeralProcess") {
-      await enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
-        force: true,
-      });
-      return;
-    }
-    await query.refetch();
-  };
 
   return (
     <div className="mb-3 flex flex-col gap-3 rounded-lg border border-border/60 p-3">
@@ -74,13 +58,10 @@ function ProviderRateLimitSettingsCard({
         <RefreshIconButton
           onRefresh={refresh}
           label="Refresh rate limits"
-          // See the popover's identical comment: an ephemeralProcess
-          // provider's own `isFetching` can settle before the shared queue's
-          // round does (another provider queued behind it is still running),
-          // so fold in `draining` to keep this disabled for the whole round.
-          refreshing={
-            query.isFetching || (lane === "ephemeralProcess" && draining)
-          }
+          // `isRefreshing` (from useProviderRateLimitRefresh) already folds in
+          // the ephemeralProcess `draining` flag, so this stays disabled for a
+          // "Refresh all" round's full duration, not just this provider's slice.
+          refreshing={isRefreshing}
         />
       </div>
       <ProviderRateLimitBody

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
@@ -10,6 +10,7 @@ import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { ProviderRateLimitBody } from "@/components/settings/panels/provider-rate-limit-views";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
+import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import {
@@ -36,6 +37,10 @@ function ProviderRateLimitSettingsCard({
 }): ReactNode {
   const hostId = useReactiveActiveHostId();
   const query = useHostProviderRateLimitsQuery(providerId);
+  // Fresh-data-on-open for the ephemeralProcess lane, routed through the
+  // shared serial queue rather than TanStack's own (deliberately disabled)
+  // refetch-on-mount - see providerRateLimitQueryOptions' doc comment.
+  useRefreshProviderRateLimitsOnMount(providerId);
   // Keep the bars live: a turn on this provider finishing while the card is
   // open re-fetches usage. Only mounted here, so it costs nothing elsewhere.
   useRefreshProviderRateLimitsOnTurn(providerId, hostId);

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
@@ -7,14 +7,18 @@
  */
 import type { ReactNode } from "react";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { ProviderRateLimitBody } from "@/components/settings/panels/provider-rate-limit-views";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useIsRateLimitQueueDraining } from "@/hooks/rate-limits/use-is-rate-limit-queue-draining";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
 import {
   isRateLimitCapableProvider,
+  rateLimitFetchLane,
   type RateLimitProviderId,
 } from "@/lib/rate-limit-providers";
 
@@ -44,6 +48,22 @@ function ProviderRateLimitSettingsCard({
   // Keep the bars live: a turn on this provider finishing while the card is
   // open re-fetches usage. Only mounted here, so it costs nothing elsewhere.
   useRefreshProviderRateLimitsOnTurn(providerId, hostId);
+  const draining = useIsRateLimitQueueDraining();
+  const lane = rateLimitFetchLane(providerId);
+
+  // Same split the popover's `RateLimitProviderBlock` uses: an ephemeralProcess
+  // manual refresh must go through the serial queue (`force: true`) so it can't
+  // spawn a subprocess overlapping one the queue is already running - a bare
+  // `query.refetch()` here would call the host directly, bypassing that bound.
+  const refresh = async (): Promise<void> => {
+    if (lane === "ephemeralProcess") {
+      await enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+        force: true,
+      });
+      return;
+    }
+    await query.refetch();
+  };
 
   return (
     <div className="mb-3 flex flex-col gap-3 rounded-lg border border-border/60 p-3">
@@ -52,11 +72,15 @@ function ProviderRateLimitSettingsCard({
           Rate limits
         </div>
         <RefreshIconButton
-          onRefresh={async () => {
-            await query.refetch();
-          }}
+          onRefresh={refresh}
           label="Refresh rate limits"
-          refreshing={query.isFetching}
+          // See the popover's identical comment: an ephemeralProcess
+          // provider's own `isFetching` can settle before the shared queue's
+          // round does (another provider queued behind it is still running),
+          // so fold in `draining` to keep this disabled for the whole round.
+          refreshing={
+            query.isFetching || (lane === "ephemeralProcess" && draining)
+          }
         />
       </div>
       <ProviderRateLimitBody

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -299,6 +299,36 @@ function formatRateLimitReachedType(value: string): string {
   return CODEX_RATE_LIMIT_REACHED_LABELS[value] ?? titleCaseFromToken(value);
 }
 
+/**
+ * Stacks a detail view's content groups vertically with a hairline divider
+ * between consecutive groups that actually render (feedback: "show separator
+ * between global limits, Spark limits, credits and manual resets" - it looked
+ * cluttered without them). `null` groups are dropped before dividers are
+ * placed, so a divider never renders before the first visible group or after
+ * the last. Shared by `CodexRateLimitView` and `ClaudeRateLimitView` so the
+ * divider rules can't drift between providers.
+ */
+function RateLimitGroupStack({
+  groups,
+}: {
+  readonly groups: ReadonlyArray<{
+    readonly key: string;
+    readonly node: ReactNode;
+  }>;
+}): ReactNode {
+  const rendered = groups.filter((group) => group.node !== null);
+  return (
+    <div className="flex flex-col gap-3">
+      {rendered.map((group, index) => (
+        <div key={group.key} className="flex flex-col gap-3">
+          {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
+          {group.node}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function CodexRateLimitView({
   data,
   variant,
@@ -367,20 +397,8 @@ export function CodexRateLimitView({
       <CodexResetCreditsRow resetCredits={data.resetCredits} />
     ) : null;
 
-  // Groups are separated by a divider only where both the preceding and the
-  // current group actually render (feedback: "show separator between global
-  // limits, Spark limits, credits and manual resets" - it looked cluttered
-  // without them). Overview never gets here with more than `globalLimits`.
-  const groups: ReadonlyArray<{
-    readonly key: string;
-    readonly node: ReactNode;
-  }> = [
-    { key: "global", node: globalLimits },
-    { key: "per-model", node: perModelLimits },
-    { key: "credits", node: credits },
-    { key: "manual-resets", node: manualResets },
-  ].filter((group) => group.node !== null);
-
+  // Overview never gets here with more than `globalLimits`; the divider
+  // placement rules live on `RateLimitGroupStack`.
   return (
     <div className="flex flex-col gap-3">
       {!overview && data.rateLimitReachedType !== null ? (
@@ -390,12 +408,14 @@ export function CodexRateLimitView({
           </Badge>
         </div>
       ) : null}
-      {groups.map((group, index) => (
-        <div key={group.key} className="flex flex-col gap-3">
-          {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
-          {group.node}
-        </div>
-      ))}
+      <RateLimitGroupStack
+        groups={[
+          { key: "global", node: globalLimits },
+          { key: "per-model", node: perModelLimits },
+          { key: "credits", node: credits },
+          { key: "manual-resets", node: manualResets },
+        ]}
+      />
     </div>
   );
 }
@@ -527,27 +547,16 @@ export function ClaudeRateLimitView({
       <ClaudeExtraUsageRow extraUsage={data.extraUsage} />
     ) : null;
 
-  // Same divider rule as `CodexRateLimitView`: a hairline only where both the
-  // preceding and the current group actually render. Overview never gets here
-  // with more than `globalLimits`.
-  const groups: ReadonlyArray<{
-    readonly key: string;
-    readonly node: ReactNode;
-  }> = [
-    { key: "global", node: globalLimits },
-    { key: "per-model", node: perModelLimits },
-    { key: "extra-usage", node: extraUsage },
-  ].filter((group) => group.node !== null);
-
+  // Overview never gets here with more than `globalLimits`; the divider
+  // placement rules live on `RateLimitGroupStack`.
   return (
-    <div className="flex flex-col gap-3">
-      {groups.map((group, index) => (
-        <div key={group.key} className="flex flex-col gap-3">
-          {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
-          {group.node}
-        </div>
-      ))}
-    </div>
+    <RateLimitGroupStack
+      groups={[
+        { key: "global", node: globalLimits },
+        { key: "per-model", node: perModelLimits },
+        { key: "extra-usage", node: extraUsage },
+      ]}
+    />
   );
 }
 

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -471,7 +471,8 @@ export function ClaudeRateLimitView({
   // Opus/Sonnet weekly buckets, per-model rows, and extra-usage bar are
   // single-provider-tab detail.
   const overview = isOverviewVariant(variant);
-  return (
+
+  const globalLimits: ReactNode = (
     <div className="flex flex-col gap-3">
       <ProviderWindowRow
         window={data.fiveHour}
@@ -497,27 +498,55 @@ export function ClaudeRateLimitView({
           qualifier="Sonnet"
         />
       ) : null}
-      {!overview && data.modelScoped.length > 0 ? (
-        <div className="flex flex-col gap-1.5">
-          <span className="text-ui-sm font-medium text-foreground">
-            Per-model
-          </span>
-          {data.modelScoped.map((entry) => (
-            // `displayName` alone isn't guaranteed unique across entries -
-            // fold in `resetsAt` (an array index would defeat reconciliation
-            // on reorder/filter, and ESLint's `no-array-index-key` disallows
-            // it outright).
-            <RateLimitWindowRow
-              key={`${entry.displayName}-${entry.resetsAt}`}
-              label={entry.displayName}
-              window={entry}
-            />
-          ))}
+    </div>
+  );
+
+  // Each model-scoped window is its own labeled row - no "Per-model" heading;
+  // the rows' display names already say which model each is, and the group is
+  // set off by a divider instead, the same header-less treatment
+  // `CodexRateLimitView` gives its per-model (Spark) `extraWindows`.
+  const perModelLimits: ReactNode =
+    !overview && data.modelScoped.length > 0 ? (
+      <div className="flex flex-col gap-3">
+        {data.modelScoped.map((entry) => (
+          // `displayName` alone isn't guaranteed unique across entries -
+          // fold in `resetsAt` (an array index would defeat reconciliation
+          // on reorder/filter, and ESLint's `no-array-index-key` disallows
+          // it outright).
+          <RateLimitWindowRow
+            key={`${entry.displayName}-${entry.resetsAt}`}
+            label={entry.displayName}
+            window={entry}
+          />
+        ))}
+      </div>
+    ) : null;
+
+  const extraUsage: ReactNode =
+    !overview && data.extraUsage !== null && data.extraUsage.isEnabled ? (
+      <ClaudeExtraUsageRow extraUsage={data.extraUsage} />
+    ) : null;
+
+  // Same divider rule as `CodexRateLimitView`: a hairline only where both the
+  // preceding and the current group actually render. Overview never gets here
+  // with more than `globalLimits`.
+  const groups: ReadonlyArray<{
+    readonly key: string;
+    readonly node: ReactNode;
+  }> = [
+    { key: "global", node: globalLimits },
+    { key: "per-model", node: perModelLimits },
+    { key: "extra-usage", node: extraUsage },
+  ].filter((group) => group.node !== null);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {groups.map((group, index) => (
+        <div key={group.key} className="flex flex-col gap-3">
+          {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
+          {group.node}
         </div>
-      ) : null}
-      {!overview && data.extraUsage !== null && data.extraUsage.isEnabled ? (
-        <ClaudeExtraUsageRow extraUsage={data.extraUsage} />
-      ) : null}
+      ))}
     </div>
   );
 }

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -8,18 +8,51 @@ import type { ReactNode } from "react";
 import type {
   ProviderRateLimits,
   ProviderRateLimitWindow,
-  RateLimitUnavailableReason,
 } from "@traycer/protocol/host";
 import { Badge } from "@/components/ui/badge";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import {
   UsageBar,
   type UsageBarTone,
-} from "@/components/settings/panels/traycer-subscription-section";
+} from "@/components/settings/panels/traycer-subscription-views";
 import { contextUsageTone } from "@/components/chat/context-usage";
-import { resolveProviderRateLimitViewState } from "@/lib/provider-rate-limit-content";
+import {
+  formatUnavailableReason,
+  resolveProviderRateLimitViewState,
+} from "@/lib/provider-rate-limit-content";
 import { formatResetDateTime, useResetCountdown } from "@/lib/relative-time";
+import {
+  rateLimitWindowFillPercent,
+  rateLimitWindowSeverity,
+  rateLimitWindowSeverityBarClassName,
+} from "@/lib/rate-limits/window-severity";
 import { cn } from "@/lib/utils";
+
+/**
+ * Which surface a provider's detail is rendered on. Every window/bar draws
+ * identically across all three - the Settings › Providers card and both
+ * popover surfaces share one row renderer (`RateLimitWindowRow`), so they can
+ * never visually drift (feedback: "different UX looks weird"). The only thing
+ * this enum still drives is how much detail is shown:
+ *
+ * - `"settings"` / `"popover-detail"`: the provider's full detail (every
+ *   window, credits, spend, reset credits, plan label, badges).
+ * - `"popover-overview"`: the header popover's Overview tab - condensed to
+ *   only the primary/secondary (5h/Weekly) windows plus credit/balance
+ *   figures, dropping per-model `extraWindows`, reset credits, the
+ *   rate-limit-reached badge, the plan/tier label, and per-provider spend
+ *   controls, which stay in the single-provider tab.
+ */
+export type RateLimitViewVariant =
+  "settings" | "popover-detail" | "popover-overview";
+
+/**
+ * The condensed Overview surface. Fields the single-provider detail keeps but
+ * Overview drops are gated on `!isOverviewVariant(variant)`.
+ */
+function isOverviewVariant(variant: RateLimitViewVariant): boolean {
+  return variant === "popover-overview";
+}
 
 /** Shared read of a provider rate-limit query, independent of host scope. */
 export interface ProviderRateLimitQueryState {
@@ -38,17 +71,53 @@ type ClaudeRateLimits = Extract<
   ProviderRateLimits,
   { provider: "claude-code" }
 >;
+type OpenRouterRateLimits = Extract<
+  ProviderRateLimits,
+  { provider: "openrouter" }
+>;
+type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
 
-function formatUsagePercent(value: number): string {
-  return `${Math.round(value)}%`;
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = MINUTES_PER_HOUR * 24;
+const MINUTES_PER_WEEK = MINUTES_PER_DAY * 7;
+
+/**
+ * A window's label from its real duration, not a hardcoded "5-hour"/"Weekly"
+ * (Core Flows: "if the provider tells us the window is 6 hours, that's what's
+ * shown"). Every `ProviderRateLimitWindow` now carries `durationMinutes`, so
+ * Codex's primary/secondary, Claude's fixed buckets, and Codex's per-model
+ * `extraWindows` all label from the same formatter. `10080` (a 7-day window)
+ * reads as "Weekly" rather than "7d" since that's the product's own wording;
+ * anything else falls back to whole-day / whole-hour / raw-minute forms.
+ */
+function formatWindowDuration(minutes: number | null): string {
+  if (minutes === null || minutes <= 0) return "Usage";
+  if (minutes === MINUTES_PER_WEEK) return "Weekly";
+  if (minutes % MINUTES_PER_DAY === 0) return `${minutes / MINUTES_PER_DAY}d`;
+  if (minutes % MINUTES_PER_HOUR === 0) return `${minutes / MINUTES_PER_HOUR}h`;
+  return `${minutes}m`;
 }
 
 /**
- * Rate-limit severity scale: >70% used is a warning, >90% is critical - a
- * single source of truth for both the bar's fill color (`usageBarTone`) and
- * the adjacent percent/reset text color (`windowTone`), so a window's whole
- * row changes color together instead of the bar and its text drifting at
- * different thresholds. Distinct from the shared `contextUsageTone` (a
+ * Whether a window's reset should show as an exact date/time rather than a
+ * relative countdown: a day-or-longer window ("Resets in 3d" is too coarse to
+ * act on). Generalizes the old per-bucket `weekly` flag from `durationMinutes`,
+ * so a provider-reported 6-hour window stays a countdown while a weekly one
+ * shows the date.
+ */
+function isWeeklyScale(minutes: number | null): boolean {
+  return minutes !== null && minutes >= MINUTES_PER_DAY;
+}
+
+/** $-denominated value (credits, balance, spend). */
+function formatProviderCurrency(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+/**
+ * Rate-limit severity scale: >70% used is a warning, >90% is critical - used
+ * only for the uncapped `UsageBar` bars (OpenRouter/Claude extra-usage) that
+ * have no fixed 100% ceiling. Distinct from the shared `contextUsageTone` (a
  * LEFT/remaining-percent scale for the unrelated context-window chip, with
  * its own thresholds) - rate limits report a USED percentage and warrant
  * their own scale.
@@ -57,12 +126,6 @@ function rateLimitSeverity(usedPercent: number): UsageBarTone | null {
   if (usedPercent > 90) return "critical";
   if (usedPercent > 70) return "warning";
   return null;
-}
-
-function windowTone(severity: UsageBarTone | null): string {
-  if (severity === "critical") return "text-destructive";
-  if (severity === "warning") return "text-amber-500 dark:text-amber-400";
-  return "text-muted-foreground";
 }
 
 function usageBarTone(usedPercent: number): UsageBarTone | undefined {
@@ -138,7 +201,31 @@ function ResetLine({
   );
 }
 
-/** A single window row: a labeled `UsageBar` plus its reset line. */
+/**
+ * A single window row - a compact two-row cell with the bar as a side element
+ * (the Claude "Plan usage limits" layout the popover is modeled on), shared
+ * identically by the Settings card and both popover surfaces so they can never
+ * visually drift. Row 1 is the label folded with "% used" in normal (not bold)
+ * weight; row 2 is just the reset line, muted and lower-opacity. The bar sits
+ * to the right, a fixed wide meter vertically centered against the two stacked
+ * rows, its fill+color tracking "% used" via `rateLimitWindowSeverity` (the
+ * exact scale + colors the header glyph uses) - always computed from the
+ * *real* `usedPercent`, never the `rateLimitWindowFillPercent` value that
+ * force-fills the 0%-used green bar.
+ *
+ * The track carries a `border-border` outline so it stays visible even at 0%
+ * fill: several dark theme presets set `--muted` equal to `--popover`, so a
+ * borderless `bg-muted` empty track would be the same color as the popover
+ * background and read as "nothing there".
+ *
+ * Reset uses a relative-for-short / exact-for-weekly split (via `weekly`): a
+ * short window shows a relative countdown ("Resets in 4h 7m"), a weekly-scale
+ * one an absolute date/time ("Resets Jul 11, 2026 (Tue) 3:35 AM") since
+ * "Resets in 3d" is too coarse to act on. Choosing the leaf
+ * (`RelativeResetLine`/`ExactResetLine`) by `weekly` keeps both leaves' hook
+ * calls unconditional. Renders nothing for a `null` window so call sites can
+ * pass optional windows directly.
+ */
 function RateLimitWindowRow({
   label,
   window,
@@ -149,35 +236,111 @@ function RateLimitWindowRow({
   readonly weekly: boolean;
 }): ReactNode {
   if (window === null) return null;
-  const severity = rateLimitSeverity(window.usedPercent);
-  const resetLine = (
-    <ResetLine
-      resetsAt={window.resetsAt}
-      tone={windowTone(severity)}
-      weekly={weekly}
-    />
+  const usedPercent = Math.round(
+    Math.min(100, Math.max(0, window.usedPercent)),
   );
+  const severity = rateLimitWindowSeverity(window.usedPercent);
+  const fillPercent = rateLimitWindowFillPercent(window.usedPercent);
   return (
-    <div className="flex flex-col gap-1">
-      <UsageBar
-        label={label}
-        consumed={window.usedPercent}
-        total={100}
-        tone={severity ?? undefined}
-        formatValue={formatUsagePercent}
-      />
-      <div className="flex justify-end">{resetLine}</div>
+    <div className="flex items-center gap-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-ui-sm text-foreground">
+          {label} · {usedPercent}% used
+        </span>
+        <ResetLine
+          resetsAt={window.resetsAt}
+          tone="text-muted-foreground/70"
+          weekly={weekly}
+        />
+      </div>
+      <div className="h-1.5 w-24 shrink-0 overflow-hidden rounded-full border border-border bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            rateLimitWindowSeverityBarClassName(severity),
+          )}
+          style={{ width: `${fillPercent}%` }}
+        />
+      </div>
     </div>
   );
 }
 
-const CODEX_WINDOW_LABELS = { primary: "5-hour", secondary: "Weekly" } as const;
-const CLAUDE_WINDOW_LABELS = {
-  fiveHour: "5-hour",
-  sevenDay: "Weekly",
-  sevenDayOpus: "Weekly (Opus)",
-  sevenDaySonnet: "Weekly (Sonnet)",
-} as const;
+/**
+ * A window row whose label is composed from the window's real duration
+ * (`formatWindowDuration`) plus, where a provider distinguishes otherwise
+ * same-duration windows, a name prefix (Codex's per-model limit name) or a
+ * trailing qualifier (Claude's "(Opus)"/"(Sonnet)"). `weekly` is derived from
+ * the duration too, so the whole "labels come from `durationMinutes`, not a
+ * hardcoded 5-hour/Weekly" rule lives in one place. Renders nothing for a
+ * `null` window so call sites can pass optional windows directly.
+ */
+// The label's base: a named window with a known duration reads "Name · 5h", a
+// named window with no duration falls back to just the name, and an unnamed
+// window is the bare duration. Split out to keep `ProviderWindowRow` free of a
+// nested ternary.
+function windowBaseLabel(
+  namePrefix: string | null,
+  durationMinutes: number | null,
+  duration: string,
+): string {
+  if (namePrefix === null) return duration;
+  if (durationMinutes === null) return namePrefix;
+  return `${namePrefix} · ${duration}`;
+}
+
+function ProviderWindowRow({
+  window,
+  namePrefix,
+  qualifier,
+}: {
+  readonly window: ProviderRateLimitWindow | null;
+  readonly namePrefix: string | null;
+  readonly qualifier: string | null;
+}): ReactNode {
+  if (window === null) return null;
+  const duration = formatWindowDuration(window.durationMinutes);
+  const base = windowBaseLabel(namePrefix, window.durationMinutes, duration);
+  const label = qualifier !== null ? `${base} (${qualifier})` : base;
+  return (
+    <RateLimitWindowRow
+      label={label}
+      window={window}
+      weekly={isWeeklyScale(window.durationMinutes)}
+    />
+  );
+}
+
+/** A provider's plan/tier label (Core Flows: shown "where the provider reports one"). */
+function ProviderPlanLabel({ label }: { readonly label: string }): ReactNode {
+  return <div className="text-ui-xs text-muted-foreground">{label}</div>;
+}
+
+/**
+ * A neutral labeled number (no bar, no severity color) - for values with no
+ * computable "% of limit" (Core Flows: "Windows without a percentage"), e.g.
+ * OpenRouter's spend/credits and Kilo Code's balance. Renders nothing when the
+ * provider didn't report the value.
+ */
+function ProviderNumberRow({
+  label,
+  value,
+  format,
+}: {
+  readonly label: string;
+  readonly value: number | null;
+  readonly format: (value: number) => string;
+}): ReactNode {
+  if (value === null) return null;
+  return (
+    <div className="flex items-center justify-between text-ui-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono text-ui-xs text-foreground">
+        {format(value)}
+      </span>
+    </div>
+  );
+}
 
 // Codex's `RateLimitReachedType` enum (host `harnesses/codex/protocol`) -
 // lowercase tokens on the wire, so the badge needs a display map rather than
@@ -197,34 +360,129 @@ function formatRateLimitReachedType(value: string): string {
 
 export function CodexRateLimitView({
   data,
+  variant,
 }: {
   readonly data: CodexRateLimits;
+  readonly variant: RateLimitViewVariant;
 }): ReactNode {
+  // Overview keeps only the primary/secondary (5h/Weekly) windows; the badge,
+  // plan label, credits, per-model extraWindows, spend control, and reset
+  // credits are single-provider-tab detail (`!isOverviewVariant`).
+  const overview = isOverviewVariant(variant);
+
+  const globalLimits: ReactNode = (
+    <div className="flex flex-col gap-3">
+      <ProviderWindowRow
+        window={data.primary}
+        namePrefix={null}
+        qualifier={null}
+      />
+      <ProviderWindowRow
+        window={data.secondary}
+        namePrefix={null}
+        qualifier={null}
+      />
+    </div>
+  );
+
+  // Each per-model sub-limit becomes its own labeled window row (Core Flows:
+  // "no separate UI concept needed"), named by its `limitName`.
+  const perModelLimits: ReactNode =
+    !overview && data.extraWindows.length > 0 ? (
+      <div className="flex flex-col gap-3">
+        {data.extraWindows.map((extraWindow) => (
+          <div key={extraWindow.limitId} className="flex flex-col gap-3">
+            <ProviderWindowRow
+              window={extraWindow.primary}
+              namePrefix={extraWindow.limitName ?? extraWindow.limitId}
+              qualifier={null}
+            />
+            <ProviderWindowRow
+              window={extraWindow.secondary}
+              namePrefix={extraWindow.limitName ?? extraWindow.limitId}
+              qualifier={null}
+            />
+          </div>
+        ))}
+      </div>
+    ) : null;
+
+  const credits: ReactNode =
+    !overview && (data.credits !== null || data.individualLimit !== null) ? (
+      <div className="flex flex-col gap-3">
+        {data.credits !== null ? (
+          <CodexCreditsRow credits={data.credits} />
+        ) : null}
+        {data.individualLimit !== null ? (
+          <CodexSpendControlRow limit={data.individualLimit} />
+        ) : null}
+      </div>
+    ) : null;
+
+  const manualResets: ReactNode =
+    !overview && data.resetCredits !== null ? (
+      <CodexResetCreditsRow resetCredits={data.resetCredits} />
+    ) : null;
+
+  // Groups are separated by a divider only where both the preceding and the
+  // current group actually render (feedback: "show separator between global
+  // limits, Spark limits, credits and manual resets" - it looked cluttered
+  // without them). Overview never gets here with more than `globalLimits`.
+  const groups: ReadonlyArray<{
+    readonly key: string;
+    readonly node: ReactNode;
+  }> = [
+    { key: "global", node: globalLimits },
+    { key: "per-model", node: perModelLimits },
+    { key: "credits", node: credits },
+    { key: "manual-resets", node: manualResets },
+  ].filter((group) => group.node !== null);
+
   return (
     <div className="flex flex-col gap-3">
-      {data.rateLimitReachedType !== null ? (
+      {!overview && data.rateLimitReachedType !== null ? (
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant="destructive">
             {formatRateLimitReachedType(data.rateLimitReachedType)}
           </Badge>
         </div>
       ) : null}
-      <RateLimitWindowRow
-        label={CODEX_WINDOW_LABELS.primary}
-        window={data.primary}
-        weekly={false}
-      />
-      <RateLimitWindowRow
-        label={CODEX_WINDOW_LABELS.secondary}
-        window={data.secondary}
-        weekly
-      />
-      {data.credits !== null ? (
-        <CodexCreditsRow credits={data.credits} />
+      {/* Plan/tier label (wireframe: "Pro 5x" under the provider name) is the
+          subscription tier - `planType` - not `limitName` (which is a rate-limit
+          *bucket* id, already surfaced by each extra-window's own label). Shown
+          only in the popover's single-provider detail tab; the Settings card
+          deliberately omits any plan-ish line (its auth badge above already
+          shows the plan), and Overview is condensed. */}
+      {variant === "popover-detail" && data.planType !== null ? (
+        <ProviderPlanLabel label={titleCaseFromToken(data.planType)} />
       ) : null}
-      {data.individualLimit !== null ? (
-        <CodexSpendControlRow limit={data.individualLimit} />
-      ) : null}
+      {groups.map((group, index) => (
+        <div key={group.key} className="flex flex-col gap-3">
+          {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
+          {group.node}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Codex's periodic allowance of manual limit resets (Core Flows: "a manual
+ * reset-credits block ... with a count"). The live `account/rateLimits/read`
+ * shape is just `{ availableCount }` (no per-credit expiry array), so this is a
+ * single count row.
+ */
+function CodexResetCreditsRow({
+  resetCredits,
+}: {
+  readonly resetCredits: NonNullable<CodexRateLimits["resetCredits"]>;
+}): ReactNode {
+  return (
+    <div className="flex items-center justify-between text-ui-sm">
+      <span className="text-muted-foreground">Manual resets</span>
+      <span className="font-mono text-ui-xs text-foreground">
+        {resetCredits.availableCount} available
+      </span>
     </div>
   );
 }
@@ -271,32 +529,42 @@ function CodexSpendControlRow({
 
 export function ClaudeRateLimitView({
   data,
+  variant,
 }: {
   readonly data: ClaudeRateLimits;
+  readonly variant: RateLimitViewVariant;
 }): ReactNode {
+  // Overview keeps only the 5h (`fiveHour`) and Weekly (`sevenDay`) windows; the
+  // Opus/Sonnet weekly buckets, per-model rows, and extra-usage bar are
+  // single-provider-tab detail.
+  const overview = isOverviewVariant(variant);
   return (
     <div className="flex flex-col gap-3">
-      <RateLimitWindowRow
-        label={CLAUDE_WINDOW_LABELS.fiveHour}
+      <ProviderWindowRow
         window={data.fiveHour}
-        weekly={false}
+        namePrefix={null}
+        qualifier={null}
       />
-      <RateLimitWindowRow
-        label={CLAUDE_WINDOW_LABELS.sevenDay}
+      <ProviderWindowRow
         window={data.sevenDay}
-        weekly
+        namePrefix={null}
+        qualifier={null}
       />
-      <RateLimitWindowRow
-        label={CLAUDE_WINDOW_LABELS.sevenDayOpus}
-        window={data.sevenDayOpus}
-        weekly
-      />
-      <RateLimitWindowRow
-        label={CLAUDE_WINDOW_LABELS.sevenDaySonnet}
-        window={data.sevenDaySonnet}
-        weekly
-      />
-      {data.modelScoped.length > 0 ? (
+      {!overview ? (
+        <ProviderWindowRow
+          window={data.sevenDayOpus}
+          namePrefix={null}
+          qualifier="Opus"
+        />
+      ) : null}
+      {!overview ? (
+        <ProviderWindowRow
+          window={data.sevenDaySonnet}
+          namePrefix={null}
+          qualifier="Sonnet"
+        />
+      ) : null}
+      {!overview && data.modelScoped.length > 0 ? (
         <div className="flex flex-col gap-1.5">
           <span className="text-ui-sm font-medium text-foreground">
             Per-model
@@ -310,12 +578,12 @@ export function ClaudeRateLimitView({
               key={`${entry.displayName}-${entry.resetsAt}`}
               label={entry.displayName}
               window={entry}
-              weekly
+              weekly={isWeeklyScale(entry.durationMinutes)}
             />
           ))}
         </div>
       ) : null}
-      {data.extraUsage !== null && data.extraUsage.isEnabled ? (
+      {!overview && data.extraUsage !== null && data.extraUsage.isEnabled ? (
         <ClaudeExtraUsageRow extraUsage={data.extraUsage} />
       ) : null}
     </div>
@@ -359,29 +627,124 @@ function ClaudeExtraUsageRow({
   return null;
 }
 
-// Exhaustive set of `reason` codes the host emits (`provider-rate-limits.ts`,
-// `rate-limits/{codex,claude}.ts`, `rate-limits/common.ts`) - the wire field
-// is a machine identifier, not display copy. Falls back to a lowercased,
-// space-joined rendering of any code not listed here.
-// `Record<RateLimitUnavailableReason, string>` (not `Record<string, string>`)
-// makes this exhaustive at compile time: adding a reason to the protocol's
-// closed enum without adding a label here fails the build instead of
-// silently falling through to a raw, underscore-joined reason code.
-const RATE_LIMIT_UNAVAILABLE_REASON_LABELS: Record<
-  RateLimitUnavailableReason,
-  string
-> = {
-  cli_not_found: "the CLI isn't installed",
-  unsupported_provider: "this provider isn't supported",
-  invalid_response: "the CLI returned an unexpected response",
-  timeout: "the request timed out",
-  connection_failed: "couldn't connect to the CLI",
-  sdk_incompatible: "this SDK version doesn't support rate limits",
-  rate_limits_not_available: "not available for this account",
-};
+/**
+ * OpenRouter's usage detail: a request/credit bar when a hard `limit` exists,
+ * plus its uncapped spend/credit/balance figures as plain neutral rows (Core
+ * Flows: "Windows without a percentage" - no fabricated percentage, no severity
+ * color). All figures are $-denominated OpenRouter credits.
+ */
+export function OpenRouterRateLimitView({
+  data,
+  variant,
+}: {
+  readonly data: OpenRouterRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  // Overview keeps only the Credits bar and Balance; the total-credit/usage and
+  // per-period spend figures are single-provider-tab detail.
+  const overview = isOverviewVariant(variant);
+  return (
+    <div className="flex flex-col gap-3">
+      <OpenRouterCreditBar
+        limit={data.limit}
+        limitRemaining={data.limitRemaining}
+      />
+      <ProviderNumberRow
+        label="Balance"
+        value={data.balance}
+        format={formatProviderCurrency}
+      />
+      {!overview ? (
+        <>
+          <ProviderNumberRow
+            label="Total credits"
+            value={data.totalCredits}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Total usage"
+            value={data.totalUsage}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Spent today"
+            value={data.dailySpend}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Spent this week"
+            value={data.weeklySpend}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Spent this month"
+            value={data.monthlySpend}
+            format={formatProviderCurrency}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
 
-function formatUnavailableReason(reason: RateLimitUnavailableReason): string {
-  return RATE_LIMIT_UNAVAILABLE_REASON_LABELS[reason];
+// Only OpenRouter's `limit`/`limitRemaining` pair yields a computable "% of
+// limit"; the derived percentage matches the header glyph's exact
+// `((limit - limitRemaining) / limit) * 100`, so the bar's fill/color tracks
+// the same number. Absent a hard limit, no bar renders (the spend rows stand
+// alone).
+function OpenRouterCreditBar({
+  limit,
+  limitRemaining,
+}: {
+  readonly limit: number | null;
+  readonly limitRemaining: number | null;
+}): ReactNode {
+  if (limit === null || limitRemaining === null || limit <= 0) return null;
+  const consumed = Math.max(0, limit - limitRemaining);
+  const usedPercent = (consumed / limit) * 100;
+  return (
+    <UsageBar
+      label="Credits"
+      consumed={consumed}
+      total={limit}
+      tone={usageBarTone(usedPercent)}
+      formatValue={formatProviderCurrency}
+    />
+  );
+}
+
+/**
+ * Kilo Code's usage detail: a credit balance and Kilo Pass state, both as plain
+ * neutral rows. No computable percentage exists for Kilo Code, so it never
+ * renders a bar (Core Flows: "Windows without a percentage").
+ */
+export function KiloCodeRateLimitView({
+  data,
+  variant,
+}: {
+  readonly data: KiloCodeRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  // Overview keeps only the credit balance; Kilo Pass state is
+  // single-provider-tab detail.
+  const overview = isOverviewVariant(variant);
+  return (
+    <div className="flex flex-col gap-3">
+      <ProviderNumberRow
+        label="Credit balance"
+        value={data.creditBalance}
+        format={formatProviderCurrency}
+      />
+      {!overview && data.passState !== null ? (
+        <div className="flex items-center justify-between text-ui-sm">
+          <span className="text-muted-foreground">Kilo Pass</span>
+          <span className="font-mono text-ui-xs text-foreground">
+            {titleCaseFromToken(data.passState)}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 export function ProviderRateLimitBody(
@@ -416,16 +779,36 @@ export function ProviderRateLimitBody(
       </p>
     );
   }
-  return <ProviderRateLimitDetail data={data} />;
+  return <ProviderRateLimitDetail data={data} variant="settings" />;
 }
 
-function ProviderRateLimitDetail({
+/**
+ * Renders one provider's available-arm detail. Exhaustive over every
+ * `available: true` arm (`data.provider` is now four-way, not the old binary
+ * codex/claude split), so a new provider arm added to the wire union fails the
+ * build here until it gets a view. Exported so the header popover reuses the
+ * exact same per-provider bodies the Settings card shows (Core Flows: "both
+ * read the same underlying provider usage data, so they never disagree").
+ */
+export function ProviderRateLimitDetail({
   data,
+  variant,
 }: {
   readonly data: AvailableProviderRateLimits;
+  readonly variant: RateLimitViewVariant;
 }): ReactNode {
-  if (data.provider === "codex") {
-    return <CodexRateLimitView data={data} />;
+  switch (data.provider) {
+    case "codex":
+      return <CodexRateLimitView data={data} variant={variant} />;
+    case "claude-code":
+      return <ClaudeRateLimitView data={data} variant={variant} />;
+    // OpenRouter/Kilo Code report no usage *windows* (only credit/spend bars and
+    // plain figures), so the settings/popover window distinction doesn't apply -
+    // but `variant` still drives the Overview-vs-detail trim (Overview shows
+    // only their balance/credit fields).
+    case "openrouter":
+      return <OpenRouterRateLimitView data={data} variant={variant} />;
+    case "kilocode":
+      return <KiloCodeRateLimitView data={data} variant={variant} />;
   }
-  return <ClaudeRateLimitView data={data} />;
 }

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -11,17 +11,18 @@ import type {
 } from "@traycer/protocol/host";
 import { Badge } from "@/components/ui/badge";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
-import {
-  MeterRow,
-  UsageBar,
-  type UsageBarTone,
-} from "@/components/settings/panels/traycer-subscription-views";
+import { MeterRow } from "@/components/settings/panels/traycer-subscription-views";
 import { contextUsageTone } from "@/components/chat/context-usage";
 import {
   formatUnavailableReason,
   resolveProviderRateLimitViewState,
+  titleCaseFromToken,
 } from "@/lib/provider-rate-limit-content";
-import { formatResetDateTime, useResetCountdown } from "@/lib/relative-time";
+import {
+  formatResetDateTime,
+  useIsFarReset,
+  useResetCountdown,
+} from "@/lib/relative-time";
 import { cn } from "@/lib/utils";
 
 /**
@@ -32,12 +33,12 @@ import { cn } from "@/lib/utils";
  * this enum still drives is how much detail is shown:
  *
  * - `"settings"` / `"popover-detail"`: the provider's full detail (every
- *   window, credits, spend, reset credits, plan label, badges).
+ *   window, credits, spend, reset credits, badges).
  * - `"popover-overview"`: the header popover's Overview tab - condensed to
  *   only the primary/secondary (5h/Weekly) windows plus credit/balance
  *   figures, dropping per-model `extraWindows`, reset credits, the
- *   rate-limit-reached badge, the plan/tier label, and per-provider spend
- *   controls, which stay in the single-provider tab.
+ *   rate-limit-reached badge, and per-provider spend controls, which stay in
+ *   the single-provider tab.
  */
 export type RateLimitViewVariant =
   "settings" | "popover-detail" | "popover-overview";
@@ -76,6 +77,7 @@ type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
 const MINUTES_PER_HOUR = 60;
 const MINUTES_PER_DAY = MINUTES_PER_HOUR * 24;
 const MINUTES_PER_WEEK = MINUTES_PER_DAY * 7;
+const MINUTES_PER_SESSION = MINUTES_PER_HOUR * 5;
 
 /**
  * A window's label from its real duration, not a hardcoded "5-hour"/"Weekly"
@@ -84,61 +86,22 @@ const MINUTES_PER_WEEK = MINUTES_PER_DAY * 7;
  * Codex's primary/secondary, Claude's fixed buckets, and Codex's per-model
  * `extraWindows` all label from the same formatter. `10080` (a 7-day window)
  * reads as "Weekly" rather than "7d" since that's the product's own wording;
- * anything else falls back to whole-day / whole-hour / raw-minute forms.
+ * the well-known 5-hour rolling window both Codex and Claude use reads as
+ * "Current session" - a provider-reported 6-hour window still falls back to
+ * the generic "6h" form, since that isn't the same known quota.
  */
 function formatWindowDuration(minutes: number | null): string {
   if (minutes === null || minutes <= 0) return "Usage";
   if (minutes === MINUTES_PER_WEEK) return "Weekly";
+  if (minutes === MINUTES_PER_SESSION) return "Current session";
   if (minutes % MINUTES_PER_DAY === 0) return `${minutes / MINUTES_PER_DAY}d`;
   if (minutes % MINUTES_PER_HOUR === 0) return `${minutes / MINUTES_PER_HOUR}h`;
   return `${minutes}m`;
 }
 
-/**
- * Whether a window's reset should show as an exact date/time rather than a
- * relative countdown: a day-or-longer window ("Resets in 3d" is too coarse to
- * act on). Generalizes the old per-bucket `weekly` flag from `durationMinutes`,
- * so a provider-reported 6-hour window stays a countdown while a weekly one
- * shows the date.
- */
-function isWeeklyScale(minutes: number | null): boolean {
-  return minutes !== null && minutes >= MINUTES_PER_DAY;
-}
-
 /** $-denominated value (credits, balance, spend). */
 function formatProviderCurrency(value: number): string {
   return `$${value.toFixed(2)}`;
-}
-
-/**
- * Rate-limit severity scale: >70% used is a warning, >90% is critical - used
- * only for the uncapped `UsageBar` bars (OpenRouter/Claude extra-usage) that
- * have no fixed 100% ceiling. Distinct from the shared `contextUsageTone` (a
- * LEFT/remaining-percent scale for the unrelated context-window chip, with
- * its own thresholds) - rate limits report a USED percentage and warrant
- * their own scale.
- */
-function rateLimitSeverity(usedPercent: number): UsageBarTone | null {
-  if (usedPercent > 90) return "critical";
-  if (usedPercent > 70) return "warning";
-  return null;
-}
-
-function usageBarTone(usedPercent: number): UsageBarTone | undefined {
-  return rateLimitSeverity(usedPercent) ?? undefined;
-}
-
-/**
- * `snake_case`/lowercase-token → Title Case, for any enum value that isn't in
- * one of the display-name maps below (a forward-compat fallback for values
- * the host adds before this map is updated).
- */
-function titleCaseFromToken(value: string): string {
-  return value
-    .split("_")
-    .filter((word) => word.length > 0)
-    .map((word) => `${word[0].toUpperCase()}${word.slice(1)}`)
-    .join(" ");
 }
 
 /** Relative countdown ("Resets in 4h 7m") - ticks on the shared 60s clock. */
@@ -155,7 +118,7 @@ function RelativeResetLine({
 }
 
 /**
- * Exact date/time ("Resets Jul 4, 2026 12:10 AM") - for weekly-scale windows,
+ * Exact weekday/time ("Resets Sat 3:35 AM") - for weekly-scale windows,
  * where a relative countdown ("Resets in 3d") is too coarse to act on. Pure,
  * no clock subscription.
  */
@@ -174,23 +137,23 @@ function ExactResetLine({
 }
 
 /**
- * Dispatches to `RelativeResetLine` or `ExactResetLine` by `weekly` - a
- * static, per-window fact (which array field this is), never toggling for a
- * given row instance, so choosing the component at this level (rather than
- * conditionally calling one hook or the other inside a single component)
- * keeps both leaves' hook calls unconditional.
+ * Dispatches to `RelativeResetLine` or `ExactResetLine` by whether `resetsAt`
+ * is far enough away (`useIsFarReset` - the real time remaining, not a
+ * window's nominal duration, since not every window carries one; see that
+ * function's own doc). Calling the hook unconditionally here, then choosing
+ * which leaf to render, keeps both leaves' own hook calls (or lack thereof)
+ * unconditional per render.
  */
 function ResetLine({
   resetsAt,
   tone,
-  weekly,
 }: {
   readonly resetsAt: number | null;
   readonly tone: string;
-  readonly weekly: boolean;
 }): ReactNode {
+  const isFar = useIsFarReset(resetsAt);
   if (resetsAt === null) return null;
-  return weekly ? (
+  return isFar ? (
     <ExactResetLine resetsAt={resetsAt} tone={tone} />
   ) : (
     <RelativeResetLine resetsAt={resetsAt} tone={tone} />
@@ -198,35 +161,59 @@ function ResetLine({
 }
 
 /**
+ * The right-hand `detail` slot for a window row: "{percent}% used" followed
+ * by the reset line (a relative countdown for a near window - "Resets in 4h
+ * 7m" - or an absolute weekday/time for a far one - "Resets Sat 3:35 AM",
+ * since "Resets in 3d" is too coarse to act on), separated by a middle dot -
+ * dropped entirely when there's no reset to show. `tone` is left to
+ * `MeterRow`'s own wrapping span (this slot never overrides it), unlike
+ * `CodexSpendControlRow`'s reset line, which needs its own severity-driven
+ * tone outside a `MeterRow`.
+ */
+function WindowMeterDetail({
+  resetsAt,
+  usedPercent,
+}: {
+  readonly resetsAt: number | null;
+  readonly usedPercent: number;
+}): ReactNode {
+  const percent = Math.round(Math.min(100, Math.max(0, usedPercent)));
+  return (
+    <span className="flex items-center gap-1">
+      <span>{percent}% used</span>
+      {resetsAt !== null ? (
+        <>
+          <span aria-hidden="true">·</span>
+          <ResetLine resetsAt={resetsAt} tone="" />
+        </>
+      ) : null}
+    </span>
+  );
+}
+
+/**
  * A single window row, shared identically by the Settings card and both
  * popover surfaces so they can never visually drift - delegates to the
- * shared `MeterRow` shell (`traycer-subscription-views.tsx`), passing the
- * reset line as its `subtext` slot: a relative countdown for a short window
- * ("Resets in 4h 7m"), an absolute date/time for a weekly-scale one ("Resets
- * Jul 11, 2026 (Tue) 3:35 AM") since "Resets in 3d" is too coarse to act on.
- * Choosing the leaf (`RelativeResetLine`/`ExactResetLine`) by `weekly` keeps
- * both leaves' hook calls unconditional. Renders nothing for a `null` window
- * so call sites can pass optional windows directly.
+ * shared `MeterRow` shell (`traycer-subscription-views.tsx`), passing
+ * `WindowMeterDetail` as its `detail` slot. Renders nothing for a `null`
+ * window so call sites can pass optional windows directly.
  */
 function RateLimitWindowRow({
   label,
   window,
-  weekly,
 }: {
   readonly label: string;
   readonly window: ProviderRateLimitWindow | null;
-  readonly weekly: boolean;
 }): ReactNode {
   if (window === null) return null;
   return (
     <MeterRow
       label={label}
       usedPercent={window.usedPercent}
-      subtext={
-        <ResetLine
+      detail={
+        <WindowMeterDetail
           resetsAt={window.resetsAt}
-          tone="text-muted-foreground/70"
-          weekly={weekly}
+          usedPercent={window.usedPercent}
         />
       }
     />
@@ -237,9 +224,7 @@ function RateLimitWindowRow({
  * A window row whose label is composed from the window's real duration
  * (`formatWindowDuration`) plus, where a provider distinguishes otherwise
  * same-duration windows, a name prefix (Codex's per-model limit name) or a
- * trailing qualifier (Claude's "(Opus)"/"(Sonnet)"). `weekly` is derived from
- * the duration too, so the whole "labels come from `durationMinutes`, not a
- * hardcoded 5-hour/Weekly" rule lives in one place. Renders nothing for a
+ * trailing qualifier (Claude's "(Opus)"/"(Sonnet)"). Renders nothing for a
  * `null` window so call sites can pass optional windows directly.
  */
 // The label's base: a named window with a known duration reads "Name · 5h", a
@@ -269,18 +254,7 @@ function ProviderWindowRow({
   const duration = formatWindowDuration(window.durationMinutes);
   const base = windowBaseLabel(namePrefix, window.durationMinutes, duration);
   const label = qualifier !== null ? `${base} (${qualifier})` : base;
-  return (
-    <RateLimitWindowRow
-      label={label}
-      window={window}
-      weekly={isWeeklyScale(window.durationMinutes)}
-    />
-  );
-}
-
-/** A provider's plan/tier label (Core Flows: shown "where the provider reports one"). */
-function ProviderPlanLabel({ label }: { readonly label: string }): ReactNode {
-  return <div className="text-ui-xs text-muted-foreground">{label}</div>;
+  return <RateLimitWindowRow label={label} window={window} />;
 }
 
 /**
@@ -333,8 +307,10 @@ export function CodexRateLimitView({
   readonly variant: RateLimitViewVariant;
 }): ReactNode {
   // Overview keeps only the primary/secondary (5h/Weekly) windows; the badge,
-  // plan label, credits, per-model extraWindows, spend control, and reset
-  // credits are single-provider-tab detail (`!isOverviewVariant`).
+  // credits, per-model extraWindows, spend control, and reset credits are
+  // single-provider-tab detail (`!isOverviewVariant`). The plan/tier label
+  // isn't part of this body at all - the header popover renders it as a chip
+  // next to the provider name (`resolveProviderPlanLabel`).
   const overview = isOverviewVariant(variant);
 
   const globalLimits: ReactNode = (
@@ -414,15 +390,6 @@ export function CodexRateLimitView({
           </Badge>
         </div>
       ) : null}
-      {/* Plan/tier label (wireframe: "Pro 5x" under the provider name) is the
-          subscription tier - `planType` - not `limitName` (which is a rate-limit
-          *bucket* id, already surfaced by each extra-window's own label). Shown
-          only in the popover's single-provider detail tab; the Settings card
-          deliberately omits any plan-ish line (its auth badge above already
-          shows the plan), and Overview is condensed. */}
-      {variant === "popover-detail" && data.planType !== null ? (
-        <ProviderPlanLabel label={titleCaseFromToken(data.planType)} />
-      ) : null}
       {groups.map((group, index) => (
         <div key={group.key} className="flex flex-col gap-3">
           {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
@@ -487,7 +454,6 @@ function CodexSpendControlRow({
         <ResetLine
           resetsAt={limit.resetsAt}
           tone={contextUsageTone(limit.remainingPercent)}
-          weekly={false}
         />
       </div>
     </div>
@@ -545,7 +511,6 @@ export function ClaudeRateLimitView({
               key={`${entry.displayName}-${entry.resetsAt}`}
               label={entry.displayName}
               window={entry}
-              weekly={isWeeklyScale(entry.durationMinutes)}
             />
           ))}
         </div>
@@ -572,12 +537,10 @@ function ClaudeExtraUsageRow({
         ? (extraUsage.usedCredits / extraUsage.monthlyLimit) * 100
         : 0;
     return (
-      <UsageBar
+      <MeterRow
         label="Extra usage"
-        consumed={extraUsage.usedCredits}
-        total={extraUsage.monthlyLimit}
-        tone={usageBarTone(usedPercent)}
-        formatValue={(value) => value.toFixed(2)}
+        usedPercent={usedPercent}
+        detail={`${extraUsage.usedCredits.toFixed(2)} / ${extraUsage.monthlyLimit.toFixed(2)}`}
       />
     );
   }
@@ -670,12 +633,10 @@ function OpenRouterCreditBar({
   const consumed = Math.max(0, limit - limitRemaining);
   const usedPercent = (consumed / limit) * 100;
   return (
-    <UsageBar
+    <MeterRow
       label="Credits"
-      consumed={consumed}
-      total={limit}
-      tone={usageBarTone(usedPercent)}
-      formatValue={formatProviderCurrency}
+      usedPercent={usedPercent}
+      detail={`${formatProviderCurrency(consumed)} / ${formatProviderCurrency(limit)}`}
     />
   );
 }

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -12,6 +12,7 @@ import type {
 import { Badge } from "@/components/ui/badge";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import {
+  MeterRow,
   UsageBar,
   type UsageBarTone,
 } from "@/components/settings/panels/traycer-subscription-views";
@@ -21,11 +22,6 @@ import {
   resolveProviderRateLimitViewState,
 } from "@/lib/provider-rate-limit-content";
 import { formatResetDateTime, useResetCountdown } from "@/lib/relative-time";
-import {
-  rateLimitWindowFillPercent,
-  rateLimitWindowSeverity,
-  rateLimitWindowSeverityBarClassName,
-} from "@/lib/rate-limits/window-severity";
 import { cn } from "@/lib/utils";
 
 /**
@@ -202,29 +198,15 @@ function ResetLine({
 }
 
 /**
- * A single window row - a compact two-row cell with the bar as a side element
- * (the Claude "Plan usage limits" layout the popover is modeled on), shared
- * identically by the Settings card and both popover surfaces so they can never
- * visually drift. Row 1 is the label folded with "% used" in normal (not bold)
- * weight; row 2 is just the reset line, muted and lower-opacity. The bar sits
- * to the right, a fixed wide meter vertically centered against the two stacked
- * rows, its fill+color tracking "% used" via `rateLimitWindowSeverity` (the
- * exact scale + colors the header glyph uses) - always computed from the
- * *real* `usedPercent`, never the `rateLimitWindowFillPercent` value that
- * force-fills the 0%-used green bar.
- *
- * The track carries a `border-border` outline so it stays visible even at 0%
- * fill: several dark theme presets set `--muted` equal to `--popover`, so a
- * borderless `bg-muted` empty track would be the same color as the popover
- * background and read as "nothing there".
- *
- * Reset uses a relative-for-short / exact-for-weekly split (via `weekly`): a
- * short window shows a relative countdown ("Resets in 4h 7m"), a weekly-scale
- * one an absolute date/time ("Resets Jul 11, 2026 (Tue) 3:35 AM") since
- * "Resets in 3d" is too coarse to act on. Choosing the leaf
- * (`RelativeResetLine`/`ExactResetLine`) by `weekly` keeps both leaves' hook
- * calls unconditional. Renders nothing for a `null` window so call sites can
- * pass optional windows directly.
+ * A single window row, shared identically by the Settings card and both
+ * popover surfaces so they can never visually drift - delegates to the
+ * shared `MeterRow` shell (`traycer-subscription-views.tsx`), passing the
+ * reset line as its `subtext` slot: a relative countdown for a short window
+ * ("Resets in 4h 7m"), an absolute date/time for a weekly-scale one ("Resets
+ * Jul 11, 2026 (Tue) 3:35 AM") since "Resets in 3d" is too coarse to act on.
+ * Choosing the leaf (`RelativeResetLine`/`ExactResetLine`) by `weekly` keeps
+ * both leaves' hook calls unconditional. Renders nothing for a `null` window
+ * so call sites can pass optional windows directly.
  */
 function RateLimitWindowRow({
   label,
@@ -236,33 +218,18 @@ function RateLimitWindowRow({
   readonly weekly: boolean;
 }): ReactNode {
   if (window === null) return null;
-  const usedPercent = Math.round(
-    Math.min(100, Math.max(0, window.usedPercent)),
-  );
-  const severity = rateLimitWindowSeverity(window.usedPercent);
-  const fillPercent = rateLimitWindowFillPercent(window.usedPercent);
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="text-ui-sm text-foreground">
-          {label} · {usedPercent}% used
-        </span>
+    <MeterRow
+      label={label}
+      usedPercent={window.usedPercent}
+      subtext={
         <ResetLine
           resetsAt={window.resetsAt}
           tone="text-muted-foreground/70"
           weekly={weekly}
         />
-      </div>
-      <div className="h-1.5 w-24 shrink-0 overflow-hidden rounded-full border border-border bg-muted">
-        <div
-          className={cn(
-            "h-full rounded-full transition-all",
-            rateLimitWindowSeverityBarClassName(severity),
-          )}
-          style={{ width: `${fillPercent}%` }}
-        />
-      </div>
-    </div>
+      }
+    />
   );
 }
 

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
@@ -3,125 +3,36 @@
  * provider. A global account-context selector (Personal / each Team) drives
  * which subscription is rendered. Data comes from `useAuthUser` (TanStack
  * Query) - never the auth store, which keeps only its narrow projections.
+ *
+ * This card owns its query wiring (`useAuthUser`, `useRefreshCreditsOnTraycerTurn`,
+ * and - inside the shared `RateLimitView` - `useHostRateLimitUsageQuery` +
+ * `useRefreshRateLimitUsageOnTraycerTurn`) and renders through the shared,
+ * host/query-free views in `traycer-subscription-views.tsx`, so it and the
+ * header popover's Traycer tab can never disagree.
  */
 import { ExternalLink } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
-import type {
-  AuthenticatedUser,
-  SubscriptionStatus,
-  TraycerTeamSubscription,
-  TraycerUserSubscription,
-} from "@traycer/protocol/auth";
+import type { AuthenticatedUser } from "@traycer/protocol/auth";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
-import { Badge } from "@/components/ui/badge";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
+import {
+  TraycerAccountSelect,
+  TraycerSubscriptionView,
+} from "@/components/settings/panels/traycer-subscription-views";
 import { resolveManageSubscriptionUrl } from "@/lib/auth/manage-subscription-url";
+import {
+  accountContextValue,
+  parseAccountContextValue,
+  selectSubscription,
+  type TraycerSubscription,
+} from "@/lib/auth/traycer-subscription-content";
 import { useAuthUser } from "@/hooks/auth/use-auth-user-query";
 import { useRefreshCreditsOnTraycerTurn } from "@/hooks/auth/use-refresh-credits-on-traycer-turn";
-import { useHostRateLimitUsageQuery } from "@/hooks/host/use-host-rate-limit-usage-query";
-import { useRefreshRateLimitUsageOnTraycerTurn } from "@/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import {
   resolveAccountContext,
   useAccountContextStore,
-  type AccountContext,
 } from "@/stores/auth/account-context-store";
-import { cn } from "@/lib/utils";
-
-const PERSONAL_VALUE = "personal";
-const TEAM_VALUE_PREFIX = "team:";
-
-// ponytail: hand-rolled label map - there's no shared SubscriptionStatus →
-// display-name helper in the repo. Add tiers here as the enum grows.
-const TIER_LABELS: Record<SubscriptionStatus, string> = {
-  PENDING: "Pending",
-  FREE: "Free",
-  PRO_LEGACY: "Pro",
-  PRO: "Pro",
-  PRO_PLUS: "Pro Plus",
-  LITE: "Lite",
-  LITE_V2: "Lite",
-  PRO_V2: "Pro",
-  PRO_PLUS_V2: "Pro Plus",
-  LITE_V3: "Lite",
-  PRO_V3: "Pro",
-  ULTRA_1X_V3: "Ultra 1x",
-  ULTRA_2X_V3: "Ultra 2x",
-  ULTRA_3X_V3: "Ultra 3x",
-  ULTRA_4X_V3: "Ultra 4x",
-  ULTRA_5X_V3: "Ultra 5x",
-  BYOA_V3: "BYOA",
-};
-
-function isPaid(status: SubscriptionStatus): boolean {
-  return status !== "FREE" && status !== "PENDING";
-}
-
-// V3 plans bill against credits; every other (legacy / v2) plan is rate-limit
-// based. Ported from an internal shared package's `isCreditBasedPricing`
-// (clients can't import that package). Credit plans → credit breakdown; the
-// rest → rate limit.
-const CREDIT_BASED_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
-  "FREE",
-  "LITE_V3",
-  "PRO_V3",
-  "ULTRA_1X_V3",
-  "ULTRA_2X_V3",
-  "ULTRA_3X_V3",
-  "ULTRA_4X_V3",
-  "ULTRA_5X_V3",
-  "BYOA_V3",
-]);
-
-function isCreditBasedPricing(status: SubscriptionStatus): boolean {
-  return CREDIT_BASED_STATUSES.has(status);
-}
-
-// Mirrors the extension's `formatRechargeRate`: minutes under a day, else days.
-function formatRechargeRate(rechargeRateSeconds: number): string | null {
-  if (rechargeRateSeconds <= 0) return null;
-  const SECONDS_PER_DAY = 86_400;
-  const SECONDS_PER_MINUTE = 60;
-  if (rechargeRateSeconds < SECONDS_PER_DAY) {
-    const minutes = Math.round(rechargeRateSeconds / SECONDS_PER_MINUTE);
-    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
-  }
-  const days = Math.round(rechargeRateSeconds / SECONDS_PER_DAY);
-  return `${days} ${days === 1 ? "day" : "days"}`;
-}
-
-type Subscription = TraycerUserSubscription | TraycerTeamSubscription;
-
-// Picks the subscription for the resolved context: the user's own, or the
-// matching team's. Null when the user isn't loaded or the team has no sub.
-function selectSubscription(
-  user: AuthenticatedUser | null,
-  resolved: AccountContext,
-  teams: readonly TraycerTeamSubscription[],
-): Subscription | null {
-  if (user === null) return null;
-  if (resolved.type === "PERSONAL") return user.userSubscription;
-  return teams.find((t) => t.team.id === resolved.teamId) ?? null;
-}
-
-function accountContextValue(context: AccountContext): string {
-  return context.type === "PERSONAL"
-    ? PERSONAL_VALUE
-    : `${TEAM_VALUE_PREFIX}${context.teamId}`;
-}
-
-function parseAccountContextValue(value: string): AccountContext {
-  return value.startsWith(TEAM_VALUE_PREFIX)
-    ? { type: "TEAM", teamId: value.slice(TEAM_VALUE_PREFIX.length) }
-    : { type: "PERSONAL" };
-}
 
 export function TraycerSubscriptionSection() {
   const query = useAuthUser();
@@ -167,29 +78,13 @@ export function TraycerSubscriptionSection() {
         </div>
       </div>
 
-      {teams.length > 0 ? (
-        <Select
-          value={accountContextValue(resolved)}
-          onValueChange={(value) =>
-            setAccountContext(parseAccountContextValue(value))
-          }
-        >
-          <SelectTrigger size="sm" aria-label="Account" className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={PERSONAL_VALUE}>Personal</SelectItem>
-            {teams.map((team) => (
-              <SelectItem
-                key={team.team.id}
-                value={`${TEAM_VALUE_PREFIX}${team.team.id}`}
-              >
-                {team.team.slug}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ) : null}
+      <TraycerAccountSelect
+        teams={teams}
+        value={accountContextValue(resolved)}
+        onValueChange={(value) =>
+          setAccountContext(parseAccountContextValue(value))
+        }
+      />
 
       <SubscriptionBody query={query} subscription={subscription} />
     </div>
@@ -201,7 +96,7 @@ function SubscriptionBody({
   subscription,
 }: {
   readonly query: UseQueryResult<AuthenticatedUser | null>;
-  readonly subscription: Subscription | null;
+  readonly subscription: TraycerSubscription | null;
 }) {
   if (query.isPending) {
     return (
@@ -224,276 +119,5 @@ function SubscriptionBody({
       </div>
     );
   }
-  return <SubscriptionDetail subscription={subscription} />;
-}
-
-function SubscriptionDetail({
-  subscription,
-}: {
-  readonly subscription: Subscription;
-}) {
-  const status = subscription.subscriptionStatus;
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant={isPaid(status) ? "default" : "secondary"}>
-          {TIER_LABELS[status]}
-        </Badge>
-        {subscription.isInTrial ? <Badge variant="outline">Trial</Badge> : null}
-      </div>
-
-      {isCreditBasedPricing(status) ? (
-        <CreditBreakdownView breakdown={creditBreakdown(subscription)} />
-      ) : (
-        <RateLimitView subscription={subscription} />
-      )}
-    </div>
-  );
-}
-
-// Artifact token counts aren't dollars - integers as-is, fractional usage to
-// 3dp, mirroring the extension's `${consumed.toFixed(3)} / ${totalTokens}`.
-function formatArtifactTokens(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(3);
-}
-
-// Rate-limit (legacy / v2) plans don't bill credits - they throttle artifact
-// generation and refill at a recharge rate. Mirrors the extension's
-// `RateLimitBasedPlanUsageDisplay` (recharge rate + artifact bar + bundle bar).
-// Live artifact usage comes from aperture via `host.getRateLimitUsage`; when
-// aperture is off or has no data (totalTokens === 0) we show "unavailable"
-// rather than a 0-left bar (decision 2).
-function RateLimitView({
-  subscription,
-}: {
-  readonly subscription: Subscription;
-}) {
-  const usageQuery = useHostRateLimitUsageQuery();
-  // Keep the bar live: a Traycer turn finishing while this card is open
-  // re-fetches usage. Only mounted here, so it costs nothing elsewhere.
-  useRefreshRateLimitUsageOnTraycerTurn();
-
-  const recharge = formatRechargeRate(subscription.rechargeRateSeconds);
-  const usage = usageQuery.data ?? null;
-  const artifactTotal = usage?.totalTokens ?? 0;
-  const artifactConsumed = Math.max(
-    0,
-    artifactTotal - (usage?.remainingTokens ?? 0),
-  );
-  const bundle = subscription.bundleSummary;
-  const bundleTotal = bundle?.bundleTotal ?? 0;
-  const bundleConsumed = Math.max(
-    0,
-    bundleTotal - (bundle?.bundleRemaining ?? 0),
-  );
-  return (
-    <div className="flex flex-col gap-3">
-      <span className="text-ui-sm font-medium text-foreground">Rate limit</span>
-      {recharge !== null ? (
-        <div className="flex items-center justify-between text-ui-sm">
-          <span className="text-muted-foreground">New artifact every</span>
-          <span className="font-medium text-foreground">{recharge}</span>
-        </div>
-      ) : null}
-      {artifactTotal > 0 ? (
-        <UsageBar
-          label="Artifacts"
-          consumed={artifactConsumed}
-          total={artifactTotal}
-          tone={undefined}
-          formatValue={formatArtifactTokens}
-        />
-      ) : (
-        <p className="text-ui-xs text-muted-foreground">
-          Live artifact usage is unavailable.
-        </p>
-      )}
-      {bundleTotal > 0 ? (
-        <UsageBar
-          label="Bundle"
-          consumed={bundleConsumed}
-          total={bundleTotal}
-          tone={undefined}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-// Local mirror of the extension's `getCreditBreakdown` (the helper lives in
-// an internal shared package, which clients can't import). Three buckets -
-// Plan, Bonus, Bundle - tracked as consumed/total, matching the extension's
-// wording.
-interface CreditBreakdown {
-  readonly planTotal: number;
-  readonly planConsumed: number;
-  readonly bonusTotal: number;
-  readonly bonusConsumed: number;
-  readonly bundleTotal: number;
-  readonly bundleConsumed: number;
-  readonly totalAvailable: number;
-  readonly totalConsumed: number;
-}
-
-function creditBreakdown(subscription: Subscription): CreditBreakdown {
-  const credit = subscription.credit;
-  const planTotal = subscription.totalPlanCredits ?? 0;
-  const planRemaining = Math.max(
-    0,
-    planTotal - (credit?.consumedFromPlan ?? 0),
-  );
-  const planConsumed = Math.max(0, planTotal - planRemaining);
-  const bonusTotal = credit?.bonusCredits ?? 0;
-  const bonusConsumed = credit?.consumedFromBonus ?? 0;
-  const bundleTotal = subscription.bundleSummary?.bundleTotal ?? 0;
-  const bundleRemaining = subscription.bundleSummary?.bundleRemaining ?? 0;
-  const bundleConsumed = Math.max(0, bundleTotal - bundleRemaining);
-  return {
-    planTotal,
-    planConsumed,
-    bonusTotal,
-    bonusConsumed,
-    bundleTotal,
-    bundleConsumed,
-    totalAvailable: planTotal + bonusTotal + bundleTotal,
-    totalConsumed: planConsumed + bonusConsumed + bundleConsumed,
-  };
-}
-
-// $-denominated credits. ponytail: 2dp currency rather than the extension's odd
-// 3dp - decimals aren't part of the naming the user asked us to match.
-function formatCredits(value: number): string {
-  return `$${value.toFixed(2)}`;
-}
-
-function usageColor(percentUsed: number, bonusInUse: boolean): string {
-  if (percentUsed < 50) return "text-green-500";
-  if (percentUsed < 90) return bonusInUse ? "text-blue-500" : "text-yellow-500";
-  return "text-red-500";
-}
-
-function CreditBreakdownView({
-  breakdown,
-}: {
-  readonly breakdown: CreditBreakdown;
-}) {
-  if (breakdown.totalAvailable <= 0) {
-    return (
-      <div className="text-ui-sm text-muted-foreground">
-        No credit usage to display for this plan.
-      </div>
-    );
-  }
-  const percentUsed = Math.min(
-    100,
-    (breakdown.totalConsumed / breakdown.totalAvailable) * 100,
-  );
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <span className="text-ui-sm font-medium text-foreground">
-          Credit breakdown
-        </span>
-        <span
-          className={cn(
-            "text-ui-xs font-medium",
-            usageColor(percentUsed, breakdown.bonusConsumed > 0),
-          )}
-        >
-          {percentUsed.toFixed(0)}% used
-        </span>
-      </div>
-      {breakdown.planTotal > 0 ? (
-        <UsageBar
-          label="Plan"
-          consumed={breakdown.planConsumed}
-          total={breakdown.planTotal}
-          tone={undefined}
-        />
-      ) : null}
-      {breakdown.bonusTotal > 0 ? (
-        <UsageBar
-          label="Bonus"
-          consumed={breakdown.bonusConsumed}
-          total={breakdown.bonusTotal}
-          accent
-          tone={undefined}
-        />
-      ) : null}
-      {breakdown.bundleTotal > 0 ? (
-        <UsageBar
-          label="Bundle"
-          consumed={breakdown.bundleConsumed}
-          total={breakdown.bundleTotal}
-          tone={undefined}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-/** Overrides the bar fill's default color - see `UsageBar`'s `tone` prop. */
-export type UsageBarTone = "warning" | "critical";
-
-function usageBarFillClassName(
-  accent: boolean | undefined,
-  tone: UsageBarTone | undefined,
-): string {
-  if (tone === "critical") return "bg-destructive";
-  if (tone === "warning") return "bg-amber-500 dark:bg-amber-400";
-  return accent ? "bg-blue-400" : "bg-primary";
-}
-
-/**
- * Reusable consumed/total bar: a label + `format(consumed) / format(total)`
- * text row above a percent-fill track. Exported so other settings surfaces
- * (e.g. `provider-rate-limit-views.tsx`) reuse the same bar chrome instead of
- * building parallel markup - the whole point of matching this card's design
- * language.
- */
-export function UsageBar({
-  label,
-  consumed,
-  total,
-  accent,
-  tone,
-  formatValue,
-}: {
-  readonly label: string;
-  readonly consumed: number;
-  readonly total: number;
-  readonly accent?: boolean;
-  // Overrides the fill color regardless of `accent` - callers with their own
-  // usage-severity thresholds (e.g. rate-limit windows) pass this instead of
-  // the default primary/accent color. `undefined` for callers (the credit
-  // and bundle bars here) that don't want severity-based coloring.
-  readonly tone: UsageBarTone | undefined;
-  // Defaults to $-denominated credits; artifact bars pass a token formatter.
-  readonly formatValue?: (value: number) => string;
-}) {
-  const format = formatValue ?? formatCredits;
-  const percent = total > 0 ? Math.min(100, (consumed / total) * 100) : 0;
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center justify-between text-ui-sm">
-        <span
-          className={cn("text-muted-foreground", accent && "text-blue-400")}
-        >
-          {label}
-        </span>
-        <span className="font-mono text-ui-xs text-foreground">
-          {format(consumed)} / {format(total)}
-        </span>
-      </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-        <div
-          className={cn(
-            "h-full rounded-full transition-all",
-            usageBarFillClassName(accent, tone),
-          )}
-          style={{ width: `${percent}%` }}
-        />
-      </div>
-    </div>
-  );
+  return <TraycerSubscriptionView subscription={subscription} />;
 }

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
@@ -13,7 +13,7 @@
  * to drop, so the Overview-vs-detail difference is purely the surrounding
  * chrome (the account picker, the "Manage subscription" link), which each
  * caller composes around this body. Each bucket (Plan/Bonus/Bundle/Artifacts)
- * renders through `CreditMeterRow`, the same label-plus-side-bar row the
+ * renders through `CreditMeterRow`, the same shared `MeterRow` shell the
  * Codex/Claude windows use, so Traycer's own bars read identically
  * (feedback: "bar similar to claude/codex").
  *
@@ -213,39 +213,53 @@ function CreditBreakdownView({
 
 /**
  * The shared meter-row shell every rate-limit/credit row in the app renders
- * through: "{label} · {percent}% used" over a `subtext` slot (a reset line for
- * windows, a plain amount line for credit buckets), with a severity-colored
- * side bar from `window-severity.ts`. Centralizing this is what keeps the
- * Codex/Claude windows (`RateLimitWindowRow` in `provider-rate-limit-views.tsx`)
- * and Traycer's own bars (`CreditMeterRow` below) from drifting apart visually
- * - each computes its own `usedPercent` and composes its own `subtext`, but
- * both render through this one layout.
+ * through: a header line (`label` left, a `detail` slot right - a reset line
+ * plus percent for windows, a plain amount line for credit/uncapped-usage
+ * buckets), then a bar spanning the row's *full* width on its own line below,
+ * colored by the shared 4-tier severity scale (`window-severity.ts`).
  *
- * The track carries a `border-border` outline so it stays visible even at 0%
- * fill: several dark theme presets set `--muted` equal to `--popover`, so a
- * borderless `bg-muted` empty track would be the same color as the popover
- * background and read as "nothing there".
+ * The bar is deliberately on its own line rather than beside the text (as it
+ * used to be): sitting the label and bar on the same line made the bar's
+ * start position and width drift with label length - a short "5h" row and a
+ * long per-model label ended up with visibly different bar widths on the same
+ * screen (feedback: "different width bars ... looking weird"). Putting the
+ * bar on a `w-full` line of its own means every row's bar is the same width
+ * regardless of what the label or detail text says, for every provider.
+ *
+ * Centralizing this is what keeps the Codex/Claude windows (`RateLimitWindowRow`
+ * in `provider-rate-limit-views.tsx`), Traycer's own bars (`CreditMeterRow`
+ * below), and the uncapped OpenRouter/Claude-extra-usage bars from drifting
+ * apart visually - each computes its own `usedPercent` and composes its own
+ * `detail`, but all of them render through this one layout and one severity
+ * scale.
+ *
+ * The track fills with `bg-foreground/15` rather than `bg-muted`, and carries
+ * no border: several dark theme presets set `--muted` equal to `--popover`,
+ * so a plain `bg-muted` track (with or without a border ring) can end up the
+ * same color as the popover background and read as "nothing there" (or as an
+ * unwanted outline where none was wanted - feedback: "keep the bar design
+ * like this [flat, no outline]"). An opacity overlay on `--foreground` is
+ * guaranteed to contrast against any background, in every theme, without
+ * needing a border to stay visible at 0% fill.
  */
 export function MeterRow({
   label,
   usedPercent,
-  subtext,
+  detail,
 }: {
   readonly label: string;
   readonly usedPercent: number;
-  readonly subtext: ReactNode;
+  readonly detail: ReactNode;
 }): ReactNode {
   const severity = rateLimitWindowSeverity(usedPercent);
   const fillPercent = rateLimitWindowFillPercent(usedPercent);
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="text-ui-sm text-foreground">
-          {label} · {Math.round(Math.min(100, Math.max(0, usedPercent)))}% used
-        </span>
-        {subtext}
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-3 text-ui-sm">
+        <span className="text-foreground">{label}</span>
+        <span className="text-ui-xs text-muted-foreground/70">{detail}</span>
       </div>
-      <div className="h-1.5 w-24 shrink-0 overflow-hidden rounded-full border border-border bg-muted">
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-foreground/15">
         <div
           className={cn(
             "h-full rounded-full transition-all",
@@ -279,64 +293,7 @@ function CreditMeterRow({
     <MeterRow
       label={label}
       usedPercent={usedPercent}
-      subtext={
-        <span className="text-ui-xs text-muted-foreground/70">
-          {formatValue(consumed)} / {formatValue(total)}
-        </span>
-      }
+      detail={`${formatValue(consumed)} / ${formatValue(total)}`}
     />
-  );
-}
-
-/** Overrides the bar fill's default color - see `UsageBar`'s `tone` prop. */
-export type UsageBarTone = "warning" | "critical";
-
-function usageBarFillClassName(tone: UsageBarTone | undefined): string {
-  if (tone === "critical") return "bg-destructive";
-  if (tone === "warning") return "bg-amber-500 dark:bg-amber-400";
-  return "bg-primary";
-}
-
-/**
- * Reusable consumed/total bar: a label + `format(consumed) / format(total)`
- * text row above a percent-fill track. Exported so other settings surfaces
- * (e.g. `provider-rate-limit-views.tsx`'s uncapped OpenRouter/Claude-extra-usage
- * bars) reuse the same bar chrome instead of building parallel markup.
- */
-export function UsageBar({
-  label,
-  consumed,
-  total,
-  tone,
-  formatValue,
-}: {
-  readonly label: string;
-  readonly consumed: number;
-  readonly total: number;
-  // Overrides the fill color for callers with their own usage-severity
-  // thresholds (e.g. rate-limit windows). `undefined` renders the default
-  // primary color.
-  readonly tone: UsageBarTone | undefined;
-  readonly formatValue: (value: number) => string;
-}): ReactNode {
-  const percent = total > 0 ? Math.min(100, (consumed / total) * 100) : 0;
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center justify-between text-ui-sm">
-        <span className="text-muted-foreground">{label}</span>
-        <span className="font-mono text-ui-xs text-foreground">
-          {formatValue(consumed)} / {formatValue(total)}
-        </span>
-      </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full border border-border bg-muted">
-        <div
-          className={cn(
-            "h-full rounded-full transition-all",
-            usageBarFillClassName(tone),
-          )}
-          style={{ width: `${percent}%` }}
-        />
-      </div>
-    </div>
   );
 }

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
@@ -1,0 +1,309 @@
+/**
+ * Presentational, query-free views for the Traycer subscription surface, shared
+ * by the Settings › Providers › Traycer card (`traycer-subscription-section.tsx`)
+ * and the header rate-limit popover's "Traycer" tab (`rate-limit-popover.tsx`) -
+ * the same "one renderer, two surfaces" split `provider-rate-limit-views.tsx`
+ * uses for the host-RPC providers, so the card and the popover can never
+ * disagree.
+ *
+ * `TraycerSubscriptionView` is the shared body (credit/rate-limit breakdown -
+ * no tier/trial badge; feedback: "badge is not needed, just show plan, bonus
+ * and credits"). Unlike `ProviderRateLimitDetail`, it is NOT
+ * variant-parameterized: the Traycer body has no per-model / extra-window rows
+ * to drop, so the Overview-vs-detail difference is purely the surrounding
+ * chrome (the account picker, the "Manage subscription" link), which each
+ * caller composes around this body. Each bucket (Plan/Bonus/Bundle/Artifacts)
+ * renders through `CreditMeterRow`, the same label-plus-side-bar row the
+ * Codex/Claude windows use, so Traycer's own bars read identically
+ * (feedback: "bar similar to claude/codex").
+ *
+ * The lone exception to "query-free" is `RateLimitView`, which keeps its own
+ * `useHostRateLimitUsageQuery` + turn-refresh exactly as before: rendering it
+ * only for rate-limit-based plans IS the tier-gate that stops the aperture pull
+ * from firing on credit-based plans, so lifting the query to the callers would
+ * either break that gate or mount it for every plan.
+ */
+import type { ReactNode } from "react";
+import type { TraycerTeamSubscription } from "@traycer/protocol/auth";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useHostRateLimitUsageQuery } from "@/hooks/host/use-host-rate-limit-usage-query";
+import { useRefreshRateLimitUsageOnTraycerTurn } from "@/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn";
+import {
+  PERSONAL_VALUE,
+  TEAM_VALUE_PREFIX,
+  creditBreakdown,
+  formatArtifactTokens,
+  formatCredits,
+  formatRechargeRate,
+  isCreditBasedPricing,
+  type CreditBreakdown,
+  type TraycerSubscription,
+} from "@/lib/auth/traycer-subscription-content";
+import {
+  rateLimitWindowFillPercent,
+  rateLimitWindowSeverity,
+  rateLimitWindowSeverityBarClassName,
+} from "@/lib/rate-limits/window-severity";
+import { cn } from "@/lib/utils";
+
+/**
+ * The Personal / Team account picker, shared by the Settings card header and the
+ * popover's Traycer detail tab. Renders nothing when the user has no teams (the
+ * only choice is Personal, so a one-option select is noise) - the caller can
+ * always render it unconditionally.
+ */
+export function TraycerAccountSelect({
+  teams,
+  value,
+  onValueChange,
+}: {
+  readonly teams: readonly TraycerTeamSubscription[];
+  readonly value: string;
+  readonly onValueChange: (value: string) => void;
+}): ReactNode {
+  if (teams.length === 0) return null;
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger size="sm" aria-label="Account" className="w-full">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={PERSONAL_VALUE}>Personal</SelectItem>
+        {teams.map((team) => (
+          <SelectItem
+            key={team.team.id}
+            value={`${TEAM_VALUE_PREFIX}${team.team.id}`}
+          >
+            {team.team.slug}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+/**
+ * The shared subscription body: either the credit breakdown (V3 credit plans)
+ * or the rate-limit view (legacy / v2 plans) - now the single source both
+ * surfaces render through.
+ */
+export function TraycerSubscriptionView({
+  subscription,
+}: {
+  readonly subscription: TraycerSubscription;
+}): ReactNode {
+  const status = subscription.subscriptionStatus;
+  return isCreditBasedPricing(status) ? (
+    <CreditBreakdownView breakdown={creditBreakdown(subscription)} />
+  ) : (
+    <RateLimitView subscription={subscription} />
+  );
+}
+
+// Rate-limit (legacy / v2) plans don't bill credits - they throttle artifact
+// generation and refill at a recharge rate. Mirrors the extension's
+// `RateLimitBasedPlanUsageDisplay` (recharge rate + artifact bar + bundle bar).
+// Live artifact usage comes from aperture via `host.getRateLimitUsage`; when
+// aperture is off or has no data (totalTokens === 0) we show "unavailable"
+// rather than a 0-left bar (decision 2). Only rendered for rate-limit plans, so
+// its `useHostRateLimitUsageQuery` mount is the implicit tier-gate.
+function RateLimitView({
+  subscription,
+}: {
+  readonly subscription: TraycerSubscription;
+}) {
+  const usageQuery = useHostRateLimitUsageQuery();
+  // Keep the bar live: a Traycer turn finishing while this is on screen
+  // re-fetches usage. Only mounted here, so it costs nothing elsewhere.
+  useRefreshRateLimitUsageOnTraycerTurn();
+
+  const recharge = formatRechargeRate(subscription.rechargeRateSeconds);
+  const usage = usageQuery.data ?? null;
+  const artifactTotal = usage?.totalTokens ?? 0;
+  const artifactConsumed = Math.max(
+    0,
+    artifactTotal - (usage?.remainingTokens ?? 0),
+  );
+  const bundle = subscription.bundleSummary;
+  const bundleTotal = bundle?.bundleTotal ?? 0;
+  const bundleConsumed = Math.max(
+    0,
+    bundleTotal - (bundle?.bundleRemaining ?? 0),
+  );
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-ui-sm font-medium text-foreground">Rate limit</span>
+      {recharge !== null ? (
+        <div className="flex items-center justify-between text-ui-sm">
+          <span className="text-muted-foreground">New artifact every</span>
+          <span className="font-medium text-foreground">{recharge}</span>
+        </div>
+      ) : null}
+      {artifactTotal > 0 ? (
+        <CreditMeterRow
+          label="Artifacts"
+          consumed={artifactConsumed}
+          total={artifactTotal}
+          formatValue={formatArtifactTokens}
+        />
+      ) : (
+        <p className="text-ui-xs text-muted-foreground">
+          Live artifact usage is unavailable.
+        </p>
+      )}
+      {bundleTotal > 0 ? (
+        <CreditMeterRow
+          label="Bundle"
+          consumed={bundleConsumed}
+          total={bundleTotal}
+          formatValue={formatCredits}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function CreditBreakdownView({
+  breakdown,
+}: {
+  readonly breakdown: CreditBreakdown;
+}): ReactNode {
+  if (breakdown.totalAvailable <= 0) {
+    return (
+      <div className="text-ui-sm text-muted-foreground">
+        No credit usage to display for this plan.
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      {breakdown.planTotal > 0 ? (
+        <CreditMeterRow
+          label="Plan"
+          consumed={breakdown.planConsumed}
+          total={breakdown.planTotal}
+          formatValue={formatCredits}
+        />
+      ) : null}
+      {breakdown.bonusTotal > 0 ? (
+        <CreditMeterRow
+          label="Bonus"
+          consumed={breakdown.bonusConsumed}
+          total={breakdown.bonusTotal}
+          formatValue={formatCredits}
+        />
+      ) : null}
+      {breakdown.bundleTotal > 0 ? (
+        <CreditMeterRow
+          label="Bundle"
+          consumed={breakdown.bundleConsumed}
+          total={breakdown.bundleTotal}
+          formatValue={formatCredits}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * A credit/balance meter row - matching the Codex/Claude window rows exactly:
+ * "{label} · {percent}% used" over a muted amount line, with the same
+ * severity-colored side bar from `window-severity.ts`, so Traycer's own bars
+ * read identically to the other providers' (feedback: "bar similar to
+ * claude/codex").
+ */
+function CreditMeterRow({
+  label,
+  consumed,
+  total,
+  formatValue,
+}: {
+  readonly label: string;
+  readonly consumed: number;
+  readonly total: number;
+  readonly formatValue: (value: number) => string;
+}): ReactNode {
+  const usedPercent = total > 0 ? (consumed / total) * 100 : 0;
+  const severity = rateLimitWindowSeverity(usedPercent);
+  const fillPercent = rateLimitWindowFillPercent(usedPercent);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-ui-sm text-foreground">
+          {label} · {Math.round(Math.min(100, Math.max(0, usedPercent)))}% used
+        </span>
+        <span className="text-ui-xs text-muted-foreground/70">
+          {formatValue(consumed)} / {formatValue(total)}
+        </span>
+      </div>
+      <div className="h-1.5 w-24 shrink-0 overflow-hidden rounded-full border border-border bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            rateLimitWindowSeverityBarClassName(severity),
+          )}
+          style={{ width: `${fillPercent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Overrides the bar fill's default color - see `UsageBar`'s `tone` prop. */
+export type UsageBarTone = "warning" | "critical";
+
+function usageBarFillClassName(tone: UsageBarTone | undefined): string {
+  if (tone === "critical") return "bg-destructive";
+  if (tone === "warning") return "bg-amber-500 dark:bg-amber-400";
+  return "bg-primary";
+}
+
+/**
+ * Reusable consumed/total bar: a label + `format(consumed) / format(total)`
+ * text row above a percent-fill track. Exported so other settings surfaces
+ * (e.g. `provider-rate-limit-views.tsx`'s uncapped OpenRouter/Claude-extra-usage
+ * bars) reuse the same bar chrome instead of building parallel markup.
+ */
+export function UsageBar({
+  label,
+  consumed,
+  total,
+  tone,
+  formatValue,
+}: {
+  readonly label: string;
+  readonly consumed: number;
+  readonly total: number;
+  // Overrides the fill color for callers with their own usage-severity
+  // thresholds (e.g. rate-limit windows). `undefined` renders the default
+  // primary color.
+  readonly tone: UsageBarTone | undefined;
+  readonly formatValue: (value: number) => string;
+}): ReactNode {
+  const percent = total > 0 ? Math.min(100, (consumed / total) * 100) : 0;
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between text-ui-sm">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-mono text-ui-xs text-foreground">
+          {formatValue(consumed)} / {formatValue(total)}
+        </span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            usageBarFillClassName(tone),
+          )}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
@@ -212,11 +212,56 @@ function CreditBreakdownView({
 }
 
 /**
- * A credit/balance meter row - matching the Codex/Claude window rows exactly:
- * "{label} · {percent}% used" over a muted amount line, with the same
- * severity-colored side bar from `window-severity.ts`, so Traycer's own bars
- * read identically to the other providers' (feedback: "bar similar to
- * claude/codex").
+ * The shared meter-row shell every rate-limit/credit row in the app renders
+ * through: "{label} · {percent}% used" over a `subtext` slot (a reset line for
+ * windows, a plain amount line for credit buckets), with a severity-colored
+ * side bar from `window-severity.ts`. Centralizing this is what keeps the
+ * Codex/Claude windows (`RateLimitWindowRow` in `provider-rate-limit-views.tsx`)
+ * and Traycer's own bars (`CreditMeterRow` below) from drifting apart visually
+ * - each computes its own `usedPercent` and composes its own `subtext`, but
+ * both render through this one layout.
+ *
+ * The track carries a `border-border` outline so it stays visible even at 0%
+ * fill: several dark theme presets set `--muted` equal to `--popover`, so a
+ * borderless `bg-muted` empty track would be the same color as the popover
+ * background and read as "nothing there".
+ */
+export function MeterRow({
+  label,
+  usedPercent,
+  subtext,
+}: {
+  readonly label: string;
+  readonly usedPercent: number;
+  readonly subtext: ReactNode;
+}): ReactNode {
+  const severity = rateLimitWindowSeverity(usedPercent);
+  const fillPercent = rateLimitWindowFillPercent(usedPercent);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-ui-sm text-foreground">
+          {label} · {Math.round(Math.min(100, Math.max(0, usedPercent)))}% used
+        </span>
+        {subtext}
+      </div>
+      <div className="h-1.5 w-24 shrink-0 overflow-hidden rounded-full border border-border bg-muted">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            rateLimitWindowSeverityBarClassName(severity),
+          )}
+          style={{ width: `${fillPercent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A credit/balance meter row - matching the Codex/Claude window rows exactly
+ * via the shared `MeterRow` shell, so Traycer's own bars read identically to
+ * the other providers' (feedback: "bar similar to claude/codex").
  */
 function CreditMeterRow({
   label,
@@ -230,28 +275,16 @@ function CreditMeterRow({
   readonly formatValue: (value: number) => string;
 }): ReactNode {
   const usedPercent = total > 0 ? (consumed / total) * 100 : 0;
-  const severity = rateLimitWindowSeverity(usedPercent);
-  const fillPercent = rateLimitWindowFillPercent(usedPercent);
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="text-ui-sm text-foreground">
-          {label} · {Math.round(Math.min(100, Math.max(0, usedPercent)))}% used
-        </span>
+    <MeterRow
+      label={label}
+      usedPercent={usedPercent}
+      subtext={
         <span className="text-ui-xs text-muted-foreground/70">
           {formatValue(consumed)} / {formatValue(total)}
         </span>
-      </div>
-      <div className="h-1.5 w-24 shrink-0 overflow-hidden rounded-full border border-border bg-muted">
-        <div
-          className={cn(
-            "h-full rounded-full transition-all",
-            rateLimitWindowSeverityBarClassName(severity),
-          )}
-          style={{ width: `${fillPercent}%` }}
-        />
-      </div>
-    </div>
+      }
+    />
   );
 }
 
@@ -295,7 +328,7 @@ export function UsageBar({
           {formatValue(consumed)} / {formatValue(total)}
         </span>
       </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+      <div className="h-1.5 w-full overflow-hidden rounded-full border border-border bg-muted">
         <div
           className={cn(
             "h-full rounded-full transition-all",

--- a/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-invalidate-sharing.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-invalidate-sharing.test.tsx
@@ -7,7 +7,7 @@
  * `MockHostMessenger`, not a fully mocked query hook.
  */
 import { afterEach, describe, expect, it } from "vitest";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -17,6 +17,7 @@ import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtur
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { createAppQueryClient } from "@/lib/query-client";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
 import { queryKeys } from "@/lib/query-keys";
@@ -38,9 +39,10 @@ describe("invalidateQueries keeps a mounted useHostProviderRateLimitsQuery obser
   });
 
   it("flips isFetching true on the observer while the invalidation-triggered refetch is in flight", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    // Production QueryClient configuration - same reasoning as the
+    // ephemeral-fetch-queue sharing test: a bare test client's staleTime-0
+    // defaults exercise different fetch semantics than the app runs.
+    const queryClient = createAppQueryClient();
     let callCount = 0;
     const pending = { current: makeControllableResponse() };
     const client = new HostClient<HostRpcRegistry>({

--- a/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-invalidate-sharing.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-invalidate-sharing.test.tsx
@@ -3,35 +3,23 @@
  * httpFetch provider's query key (what `RateLimitRefreshAllButton` issues)
  * flips `isFetching` on an already-mounted `useHostProviderRateLimitsQuery`
  * observer for that same provider - the mechanism `RateLimitProviderBlock`'s
- * per-provider refresh icon depends on. Uses a real `HostClient` +
- * `MockHostMessenger`, not a fully mocked query hook.
+ * per-provider refresh icon depends on. Uses the shared harness's real
+ * `HostClient` + `MockHostMessenger` and PRODUCTION QueryClient
+ * configuration - a bare test client's staleTime-0 defaults exercise
+ * different fetch semantics than the app runs.
  */
 import { afterEach, describe, expect, it } from "vitest";
-import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
-import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
-import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
-import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
-import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
-import { createAppQueryClient } from "@/lib/query-client";
+import type { HostRpcRegistry } from "@/lib/host";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
 import { queryKeys } from "@/lib/query-keys";
-
-function makeControllableResponse() {
-  let resolveFn: (() => void) | null = null;
-  const promise = new Promise<void>((resolve) => {
-    resolveFn = resolve;
-  });
-  return {
-    promise,
-    resolve: () => resolveFn?.(),
-  };
-}
+import {
+  createQueryClientWrapper,
+  createRateLimitSharingHarness,
+} from "@/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness";
 
 describe("invalidateQueries keeps a mounted useHostProviderRateLimitsQuery observer's isFetching in sync (httpFetch lane)", () => {
   afterEach(() => {
@@ -39,53 +27,12 @@ describe("invalidateQueries keeps a mounted useHostProviderRateLimitsQuery obser
   });
 
   it("flips isFetching true on the observer while the invalidation-triggered refetch is in flight", async () => {
-    // Production QueryClient configuration - same reasoning as the
-    // ephemeral-fetch-queue sharing test: a bare test client's staleTime-0
-    // defaults exercise different fetch semantics than the app runs.
-    const queryClient = createAppQueryClient();
-    let callCount = 0;
-    const pending = { current: makeControllableResponse() };
-    const client = new HostClient<HostRpcRegistry>({
-      registry: hostRpcRegistry,
-      invalidator: createHostQueryInvalidator(queryClient),
-      messenger: new MockHostMessenger<HostRpcRegistry>({
-        registry: hostRpcRegistry,
-        requestId: () => "req-1",
-        handlers: {
-          "host.getRateLimitUsage": async () => {
-            callCount += 1;
-            if (callCount === 1) {
-              return {
-                totalTokens: 0,
-                remainingTokens: 0,
-                providerRateLimits: null,
-              };
-            }
-            await pending.current.promise;
-            return {
-              totalTokens: 0,
-              remainingTokens: 0,
-              providerRateLimits: null,
-            };
-          },
-        },
-      }),
-    });
-    client.bind(mockLocalHostEntry);
-    client.setRequestContext(
-      createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
-    );
-
-    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
-      <QueryClientProvider client={queryClient}>
-        {props.children}
-      </QueryClientProvider>
-    );
+    const harness = createRateLimitSharingHarness();
     const { method, params, options } =
       providerRateLimitQueryOptions("openrouter");
     const rendered = renderHook(
-      () => useHostQuery({ client, method, params, options }),
-      { wrapper: Wrapper },
+      () => useHostQuery({ client: harness.client, method, params, options }),
+      { wrapper: createQueryClientWrapper(harness.queryClient) },
     );
 
     await waitFor(() => expect(rendered.result.current.isPending).toBe(false));
@@ -93,7 +40,7 @@ describe("invalidateQueries keeps a mounted useHostProviderRateLimitsQuery obser
 
     // Exactly what `RateLimitRefreshAllButton.refreshAll` issues for an
     // httpFetch provider.
-    void queryClient.invalidateQueries({
+    void harness.queryClient.invalidateQueries({
       queryKey: queryKeys.hostMethod<HostRpcRegistry, "host.getRateLimitUsage">(
         mockLocalHostEntry.hostId,
         "host.getRateLimitUsage",
@@ -103,7 +50,7 @@ describe("invalidateQueries keeps a mounted useHostProviderRateLimitsQuery obser
 
     await waitFor(() => expect(rendered.result.current.isFetching).toBe(true));
 
-    pending.current.resolve();
+    harness.resolvePendingResponse();
     await waitFor(() => expect(rendered.result.current.isFetching).toBe(false));
   });
 });

--- a/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-invalidate-sharing.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-invalidate-sharing.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * End-to-end proof that a `queryClient.invalidateQueries` call for an
+ * httpFetch provider's query key (what `RateLimitRefreshAllButton` issues)
+ * flips `isFetching` on an already-mounted `useHostProviderRateLimitsQuery`
+ * observer for that same provider - the mechanism `RateLimitProviderBlock`'s
+ * per-provider refresh icon depends on. Uses a real `HostClient` +
+ * `MockHostMessenger`, not a fully mocked query hook.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import { queryKeys } from "@/lib/query-keys";
+
+function makeControllableResponse() {
+  let resolveFn: (() => void) | null = null;
+  const promise = new Promise<void>((resolve) => {
+    resolveFn = resolve;
+  });
+  return {
+    promise,
+    resolve: () => resolveFn?.(),
+  };
+}
+
+describe("invalidateQueries keeps a mounted useHostProviderRateLimitsQuery observer's isFetching in sync (httpFetch lane)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("flips isFetching true on the observer while the invalidation-triggered refetch is in flight", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    let callCount = 0;
+    const pending = { current: makeControllableResponse() };
+    const client = new HostClient<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      invalidator: createHostQueryInvalidator(queryClient),
+      messenger: new MockHostMessenger<HostRpcRegistry>({
+        registry: hostRpcRegistry,
+        requestId: () => "req-1",
+        handlers: {
+          "host.getRateLimitUsage": async () => {
+            callCount += 1;
+            if (callCount === 1) {
+              return {
+                totalTokens: 0,
+                remainingTokens: 0,
+                providerRateLimits: null,
+              };
+            }
+            await pending.current.promise;
+            return {
+              totalTokens: 0,
+              remainingTokens: 0,
+              providerRateLimits: null,
+            };
+          },
+        },
+      }),
+    });
+    client.bind(mockLocalHostEntry);
+    client.setRequestContext(
+      createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
+    );
+
+    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+    const { method, params, options } =
+      providerRateLimitQueryOptions("openrouter");
+    const rendered = renderHook(
+      () => useHostQuery({ client, method, params, options }),
+      { wrapper: Wrapper },
+    );
+
+    await waitFor(() => expect(rendered.result.current.isPending).toBe(false));
+    expect(rendered.result.current.isFetching).toBe(false);
+
+    // Exactly what `RateLimitRefreshAllButton.refreshAll` issues for an
+    // httpFetch provider.
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.hostMethod<HostRpcRegistry, "host.getRateLimitUsage">(
+        mockLocalHostEntry.hostId,
+        "host.getRateLimitUsage",
+        { accountContext: DEFAULT_ACCOUNT_CONTEXT, providerId: "openrouter" },
+      ),
+    });
+
+    await waitFor(() => expect(rendered.result.current.isFetching).toBe(true));
+
+    pending.current.resolve();
+    await waitFor(() => expect(rendered.result.current.isFetching).toBe(false));
+  });
+});

--- a/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-query-options.test.ts
+++ b/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-query-options.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+
+describe("providerRateLimitQueryOptions", () => {
+  it("gives an httpFetch provider its own refetchInterval and keeps TanStack's default refetchOnMount", () => {
+    const { options } = providerRateLimitQueryOptions("openrouter");
+    expect(options?.refetchInterval).toBe(5 * 60 * 1000);
+    expect(options?.refetchOnMount).toBe(true);
+  });
+
+  it("disables both refetchInterval and refetchOnMount for an ephemeralProcess provider", () => {
+    const { options } = providerRateLimitQueryOptions("codex");
+    expect(options?.refetchInterval).toBe(false);
+    expect(options?.refetchOnMount).toBe(false);
+  });
+});

--- a/clients/gui-app/src/hooks/host/__tests__/use-refresh-provider-rate-limits-on-mount.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-refresh-provider-rate-limits-on-mount.test.tsx
@@ -1,0 +1,63 @@
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  enqueueRateLimitFetch: vi.fn(() => Promise.resolve()),
+}));
+
+import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+const enqueueSpy = vi.mocked(enqueueRateLimitFetch);
+
+function setup(providerId: RateLimitProviderId) {
+  return renderHook(
+    ({ id }: { id: RateLimitProviderId }) =>
+      useRefreshProviderRateLimitsOnMount(id),
+    { initialProps: { id: providerId } },
+  );
+}
+
+describe("useRefreshProviderRateLimitsOnMount", () => {
+  beforeEach(() => {
+    enqueueSpy.mockClear();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("enqueues a force:false pull for an ephemeralProcess provider on mount", () => {
+    setup("codex");
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("no-ops on mount for an httpFetch provider - its query keeps TanStack's own refetchOnMount", () => {
+    setup("openrouter");
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  it("enqueues again when the provider id changes to a different ephemeralProcess provider", () => {
+    const { rerender } = setup("codex");
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    rerender({ id: "claude-code" });
+    expect(enqueueSpy).toHaveBeenCalledTimes(2);
+    expect(enqueueSpy).toHaveBeenLastCalledWith(
+      "claude-code",
+      DEFAULT_ACCOUNT_CONTEXT,
+      { force: false },
+    );
+  });
+
+  it("does not re-enqueue on a re-render with the same provider id", () => {
+    const { rerender } = setup("codex");
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    rerender({ id: "codex" });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/hooks/host/__tests__/use-refresh-provider-rate-limits-on-turn.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-refresh-provider-rate-limits-on-turn.test.tsx
@@ -1,0 +1,123 @@
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
+import type { ReactNode } from "react";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+// Capture the turn-completion subscriber so tests can fire synthetic completions.
+const sub = vi.hoisted(() => ({
+  handler: null as null | ((completion: { harnessId: GuiHarnessId }) => void),
+}));
+vi.mock("@/lib/notifications/chat-turn-completion", () => ({
+  subscribeChatTurnCompletions: (
+    cb: (completion: { harnessId: GuiHarnessId }) => void,
+  ) => {
+    sub.handler = cb;
+    return () => {
+      sub.handler = null;
+    };
+  },
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  enqueueRateLimitFetch: vi.fn(() => Promise.resolve()),
+}));
+
+import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+const enqueueSpy = vi.mocked(enqueueRateLimitFetch);
+
+function fireTurn(harnessId: GuiHarnessId): void {
+  act(() => {
+    sub.handler?.({ harnessId });
+  });
+}
+
+function setup(providerId: RateLimitProviderId | null, hostId: string | null) {
+  const queryClient = new QueryClient();
+  const invalidateSpy = vi
+    .spyOn(queryClient, "invalidateQueries")
+    .mockResolvedValue(undefined);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  renderHook(() => useRefreshProviderRateLimitsOnTurn(providerId, hostId), {
+    wrapper,
+  });
+  return { invalidateSpy };
+}
+
+function defineVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+describe("useRefreshProviderRateLimitsOnTurn", () => {
+  beforeEach(() => {
+    sub.handler = null;
+    enqueueSpy.mockClear();
+    defineVisibility("visible");
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("routes an ephemeralProcess provider's turn completion through the serial queue, not a direct invalidate", () => {
+    const { invalidateSpy } = setup("codex", "host-a");
+    fireTurn("codex");
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("invalidates an httpFetch provider's query directly and never touches the queue", () => {
+    const { invalidateSpy } = setup("openrouter", "host-a");
+    fireTurn("openrouter");
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  it("still enqueues an ephemeralProcess turn completion while the window is hidden (guardrail 3)", () => {
+    defineVisibility("hidden");
+    setup("codex", "host-a");
+    fireTurn("codex");
+    // The visibility pause applies ONLY to the interval timer - a background
+    // turn finishing while the user is away must still refresh that provider.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("ignores completions from a different provider's harness", () => {
+    const { invalidateSpy } = setup("codex", "host-a");
+    fireTurn("claude");
+    expect(enqueueSpy).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("throttles bursts of matching completions to the outer cooldown", () => {
+    setup("codex", "host-a");
+    fireTurn("codex");
+    fireTurn("codex");
+    fireTurn("codex");
+    // The outer cooldown ref bounds the queue path to at most once per window.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops while providerId is null", () => {
+    const { invalidateSpy } = setup(null, "host-a");
+    // No subscription is created, so there is nothing to fire; assert the
+    // effect took the null branch and wired nothing up.
+    expect(sub.handler).toBeNull();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/hooks/host/provider-rate-limit-query-options.ts
+++ b/clients/gui-app/src/hooks/host/provider-rate-limit-query-options.ts
@@ -23,11 +23,21 @@ const HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS = 5 * 60 * 1000;
  * - `httpFetch` (openrouter, kilocode): its own `refetchInterval`, with
  *   `refetchIntervalInBackground: false` set explicitly (not left to the
  *   TanStack default) since these are now persistent app-shell subscriptions -
- *   no polling while the tab is hidden.
+ *   no polling while the tab is hidden. `refetchOnMount` stays at TanStack's
+ *   own default (`true`): a plain GET has no subprocess to bound, so letting a
+ *   popover/Settings-card remount refetch directly when stale is exactly
+ *   "fetch fresh data on open" with no downside.
  * - `ephemeralProcess` (codex, claude-code): no `refetchInterval` at all. Their
  *   background refresh is driven entirely by the serial queue's interval timer
  *   writing fresh data into this exact query key; adding an interval here would
- *   spawn subprocesses outside the queue and defeat its concurrency bound.
+ *   spawn subprocesses outside the queue and defeat its concurrency bound. For
+ *   the exact same reason, `refetchOnMount` is forced to `false`: TanStack's
+ *   default would otherwise fire a refetch straight through this query's own
+ *   `queryFn` on every popover/Settings-card open (a fresh mount) whenever the
+ *   cached data is stale - a direct host call that bypasses the queue and can
+ *   overlap a fetch it's already draining. `useRefreshProviderRateLimitsOnMount`
+ *   is the queue-routed replacement every `ephemeralProcess` consumer pairs
+ *   with this hook to get the same "fresh data on open" behavior safely.
  */
 export function providerRateLimitQueryOptions(
   providerId: RateLimitProviderId,
@@ -46,6 +56,7 @@ export function providerRateLimitQueryOptions(
         ? HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS
         : false,
       refetchIntervalInBackground: false,
+      refetchOnMount: isHttpFetch ? true : false,
     },
   };
 }

--- a/clients/gui-app/src/hooks/host/provider-rate-limit-query-options.ts
+++ b/clients/gui-app/src/hooks/host/provider-rate-limit-query-options.ts
@@ -1,13 +1,33 @@
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import type { UseHostQueryOptions } from "@/hooks/host/use-host-query";
-import { PROVIDER_RATE_LIMITS_STALE_TIME_MS } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
 import type { HostRpcRegistry } from "@/lib/host";
-import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+import {
+  PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+/**
+ * Independent background refresh cadence for the `httpFetch` lane (openrouter,
+ * kilocode). A plain credential-based GET, so it just polls on its own timer -
+ * it never enters the `ephemeralProcess` serial queue.
+ */
+const HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
  * The method/params/options `useHostProviderRateLimitsQuery` builds its query
  * from - split out so a future host-scoped variant (e.g. tab-scoped) can
  * reuse the same shape without duplicating it.
+ *
+ * Branches on the fetch lane for background polling:
+ * - `httpFetch` (openrouter, kilocode): its own `refetchInterval`, with
+ *   `refetchIntervalInBackground: false` set explicitly (not left to the
+ *   TanStack default) since these are now persistent app-shell subscriptions -
+ *   no polling while the tab is hidden.
+ * - `ephemeralProcess` (codex, claude-code): no `refetchInterval` at all. Their
+ *   background refresh is driven entirely by the serial queue's interval timer
+ *   writing fresh data into this exact query key; adding an interval here would
+ *   spawn subprocesses outside the queue and defeat its concurrency bound.
  */
 export function providerRateLimitQueryOptions(
   providerId: RateLimitProviderId,
@@ -15,12 +35,17 @@ export function providerRateLimitQueryOptions(
   UseHostQueryOptions<HostRpcRegistry, "host.getRateLimitUsage">,
   "client"
 > {
+  const isHttpFetch = rateLimitFetchLane(providerId) === "httpFetch";
   return {
     method: "host.getRateLimitUsage",
     params: { accountContext: DEFAULT_ACCOUNT_CONTEXT, providerId },
     options: {
       retry: false,
       staleTime: PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+      refetchInterval: isHttpFetch
+        ? HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS
+        : false,
+      refetchIntervalInBackground: false,
     },
   };
 }

--- a/clients/gui-app/src/hooks/host/use-refresh-provider-rate-limits-on-mount.ts
+++ b/clients/gui-app/src/hooks/host/use-refresh-provider-rate-limits-on-mount.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import {
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+/**
+ * On mount (and whenever `providerId` changes to a new provider), ensures an
+ * `ephemeralProcess` provider's rate limits get a fresh-data-on-open pull
+ * through the shared serial queue (`force: false`, so it still no-ops if the
+ * cached data is younger than `PROVIDER_RATE_LIMITS_STALE_TIME_MS`).
+ *
+ * This exists because `providerRateLimitQueryOptions` deliberately sets
+ * `refetchOnMount: false` for this lane: TanStack's own default would
+ * otherwise refetch straight through the query's `queryFn` on every mount,
+ * bypassing the queue's single-subprocess-at-a-time guarantee. Routing the
+ * mount trigger through `enqueueRateLimitFetch` instead means every
+ * popover/Settings-card open (both of which mount this provider's query fresh)
+ * gets the exact same guarantee every other automatic trigger (the interval
+ * timer, a turn completion) already has: never a second subprocess racing one
+ * already queued or in flight.
+ *
+ * `httpFetch` providers (openrouter, kilocode) don't need this: their query
+ * keeps TanStack's default `refetchOnMount`, which is already safe there (a
+ * plain GET, no subprocess to serialize) - this hook no-ops for them.
+ */
+export function useRefreshProviderRateLimitsOnMount(
+  providerId: RateLimitProviderId,
+): void {
+  useEffect(() => {
+    if (rateLimitFetchLane(providerId) !== "ephemeralProcess") return;
+    void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  }, [providerId]);
+}

--- a/clients/gui-app/src/hooks/host/use-refresh-provider-rate-limits-on-turn.ts
+++ b/clients/gui-app/src/hooks/host/use-refresh-provider-rate-limits-on-turn.ts
@@ -5,45 +5,45 @@ import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import { subscribeChatTurnCompletions } from "@/lib/notifications/chat-turn-completion";
 import { providerIdToGuiHarnessId } from "@/lib/provider-ordering";
 import { queryKeys } from "@/lib/query-keys";
-import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+import {
+  PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
 
 /**
- * Shared "how fresh is fresh enough" window for provider rate-limit reads:
- * the `staleTime` on `use-host-provider-rate-limits-query` and the minimum
- * spacing this hook enforces between turn-completion-triggered refetches.
- * Unlike the aperture read (a cheap cloud call), a provider pull spawns a
- * real CLI subprocess (`codex app-server`, or a full `claude` idle
- * `query()`) on the host - a burst of back-to-back turn completions (e.g. a
- * queued run) must not each trigger their own spawn.
- */
-export const PROVIDER_RATE_LIMITS_STALE_TIME_MS = 30_000;
-
-/**
- * While mounted, invalidates `host.getRateLimitUsage` for `hostId` whenever a
+ * While mounted, refreshes `host.getRateLimitUsage` for `hostId` whenever a
  * chat turn on `providerId`'s harness completes - the provider-pull analog of
- * `useRefreshRateLimitUsageOnTraycerTurn`.
+ * `useRefreshRateLimitUsageOnTraycerTurn`. Branches on the provider's fetch
+ * lane:
+ *
+ * - `ephemeralProcess` (codex, claude-code): enqueues onto the shared serial
+ *   queue (`enqueueRateLimitFetch(..., { force: false })`) rather than
+ *   invalidating directly, so a turn completion can't race a scheduled interval
+ *   tick into two overlapping subprocess spawns. This enqueue is deliberately
+ *   NOT gated by window visibility - only the interval timer pauses when hidden;
+ *   a background turn finishing while the user is away must still update data.
+ * - `httpFetch` (openrouter, kilocode): invalidates the query directly (no
+ *   subprocess to bound), exactly as before.
  *
  * Unlike the aperture refresh hook (always default-host scoped, mounted only
  * by the Traycer-only `RateLimitView`), `hostId` is a caller-supplied
  * parameter instead of a hardcoded `useReactiveActiveHostId()` read, so a
  * future tab-scoped consumer can reuse this hook without a rewrite.
  *
- * Invalidates the exact `{ accountContext, providerId }` params key (the same
- * one `useHostProviderRateLimitsQuery` builds), NOT the whole
+ * Targets the exact `{ accountContext, providerId }` params key (the same one
+ * `useHostProviderRateLimitsQuery` builds), NOT the whole
  * `host.getRateLimitUsage` method scope: a method-scope invalidation would
  * also refetch the aperture query and every OTHER provider's query on this
  * host, so e.g. a Codex turn completing would spawn a `claude` subprocess to
  * refresh Claude's rate limits too, for data a Codex turn can't have changed.
  *
- * `invalidateQueries` refetches an actively-observed query immediately
- * regardless of `staleTime` (TanStack only consults `staleTime` for
- * mount/refocus-triggered refetches, not explicit invalidation), so the
- * pinned strip - a persistent, always-mounted surface - would otherwise spawn
- * a fresh CLI subprocess on every single matching turn completion. A local
- * cooldown ref throttles invalidation to at most once per
- * `PROVIDER_RATE_LIMITS_STALE_TIME_MS`, which is what actually bounds that
- * cost; the query's own `staleTime` (set alongside this) separately avoids a
- * redundant refetch when a surface merely remounts within the same window.
+ * Both paths are throttled by an outer cooldown ref to at most once per
+ * `PROVIDER_RATE_LIMITS_STALE_TIME_MS` (a persistent, always-mounted surface
+ * would otherwise refresh on every single matching turn completion); for the
+ * queue path the queue's own 30s freshness floor is a second, independent layer
+ * under this ref.
  *
  * No-ops while `providerId` is `null` (surface isn't gated to a rate-limit
  * -capable provider).
@@ -74,6 +74,21 @@ export function useRefreshProviderRateLimitsOnTurn(
         return;
       }
       lastInvalidatedAtRef.current = now;
+      // ephemeralProcess providers (codex, claude-code) route through the shared
+      // serial queue so this turn-completion refresh can't spawn a subprocess
+      // that overlaps a scheduled interval tick. The queue's own 30s floor is a
+      // second, independent layer under this hook's outer cooldown ref. Crucially
+      // this fires regardless of window visibility - only the interval timer
+      // pauses when hidden, so a background turn finishing while the user is away
+      // still updates that provider's data.
+      if (rateLimitFetchLane(providerId) === "ephemeralProcess") {
+        void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+          force: false,
+        });
+        return;
+      }
+      // httpFetch providers (openrouter, kilocode) never touch the queue - a
+      // plain credential GET has no subprocess to bound, so invalidate directly.
       void queryClient.invalidateQueries({
         queryKey: queryKeys.hostMethod<
           HostRpcRegistry,

--- a/clients/gui-app/src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
+++ b/clients/gui-app/src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitWindow,
+  RateLimitUsageResponseV12,
+} from "@traycer/protocol/host";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+interface MockQueryResult {
+  readonly data: RateLimitUsageResponseV12 | undefined;
+  readonly isError: boolean;
+}
+
+type MockState = {
+  configured: ReadonlyArray<{
+    readonly providerId: RateLimitProviderId;
+    readonly lane: "httpFetch" | "ephemeralProcess";
+  }>;
+  results: Map<RateLimitProviderId, MockQueryResult>;
+};
+
+const mocks = vi.hoisted<MockState>(() => ({
+  configured: [],
+  results: new Map(),
+}));
+
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => null,
+}));
+vi.mock("@/hooks/rate-limits/use-configured-rate-limit-providers", () => ({
+  useConfiguredRateLimitProviders: () => mocks.configured,
+}));
+vi.mock("@/hooks/host/use-host-queries", () => ({
+  useHostQueries: (args: {
+    readonly requests: ReadonlyArray<{
+      readonly params: { readonly providerId: RateLimitProviderId };
+    }>;
+  }) =>
+    args.requests.map(
+      (request) =>
+        mocks.results.get(request.params.providerId) ?? {
+          data: undefined,
+          isError: false,
+        },
+    ),
+}));
+
+import { useHeaderRateLimitBars } from "@/hooks/rate-limits/use-header-rate-limit-bars";
+
+function rlWindow(usedPercent: number): ProviderRateLimitWindow {
+  return { usedPercent, resetsAt: null, durationMinutes: null };
+}
+
+function response(
+  providerRateLimits: ProviderRateLimits,
+): RateLimitUsageResponseV12 {
+  return { totalTokens: 0, remainingTokens: 0, providerRateLimits };
+}
+
+function setProvider(
+  providerId: RateLimitProviderId,
+  lane: "httpFetch" | "ephemeralProcess",
+  result: MockQueryResult,
+): void {
+  mocks.configured = [...mocks.configured, { providerId, lane }];
+  mocks.results.set(providerId, result);
+}
+
+function codexFixture(overrides: {
+  readonly primary?: ProviderRateLimitWindow | null;
+  readonly secondary?: ProviderRateLimitWindow | null;
+  readonly extraWindows?: Array<{
+    limitId: string;
+    limitName: string | null;
+    primary: ProviderRateLimitWindow | null;
+    secondary: ProviderRateLimitWindow | null;
+  }>;
+}): ProviderRateLimits {
+  return {
+    provider: "codex",
+    available: true,
+    planType: null,
+    limitId: null,
+    limitName: null,
+    primary: overrides.primary ?? null,
+    secondary: overrides.secondary ?? null,
+    extraWindows: overrides.extraWindows ?? [],
+    credits: null,
+    individualLimit: null,
+    resetCredits: null,
+    rateLimitReachedType: null,
+  };
+}
+
+function claudeCodeFixture(overrides: {
+  readonly fiveHour?: ProviderRateLimitWindow | null;
+  readonly sevenDay?: ProviderRateLimitWindow | null;
+  readonly sevenDayOpus?: ProviderRateLimitWindow | null;
+  readonly sevenDaySonnet?: ProviderRateLimitWindow | null;
+  readonly modelScoped?: Array<
+    { displayName: string } & ProviderRateLimitWindow
+  >;
+}): ProviderRateLimits {
+  return {
+    provider: "claude-code",
+    available: true,
+    subscriptionType: null,
+    fiveHour: overrides.fiveHour ?? null,
+    sevenDay: overrides.sevenDay ?? null,
+    sevenDayOpus: overrides.sevenDayOpus ?? null,
+    sevenDaySonnet: overrides.sevenDaySonnet ?? null,
+    modelScoped: overrides.modelScoped ?? [],
+    extraUsage: null,
+  };
+}
+
+function openRouterFixture(overrides: {
+  readonly limit: number | null;
+  readonly limitRemaining: number | null;
+}): ProviderRateLimits {
+  return {
+    provider: "openrouter",
+    available: true,
+    limit: overrides.limit,
+    limitRemaining: overrides.limitRemaining,
+    dailySpend: null,
+    weeklySpend: null,
+    monthlySpend: null,
+    totalCredits: null,
+    totalUsage: null,
+    balance: null,
+  };
+}
+
+function kiloCodeFixture(): ProviderRateLimits {
+  return {
+    provider: "kilocode",
+    available: true,
+    creditBalance: 42,
+    passState: null,
+  };
+}
+
+function unavailableFixture(): ProviderRateLimits {
+  return { provider: "codex", available: false, reason: "cli_not_found" };
+}
+
+beforeEach(() => {
+  mocks.configured = [];
+  mocks.results = new Map();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useHeaderRateLimitBars", () => {
+  it("returns no bars when zero providers are configured", () => {
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns no bars for a configured provider with no data yet (cold load)", () => {
+    setProvider("codex", "ephemeralProcess", {
+      data: undefined,
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("shows each provider's 5h window when both Codex and Claude Code are configured, codex first", () => {
+    // Insert Claude first to prove the codex-before-claude order is fixed (from
+    // GLYPH_PROVIDER_IDS / PROVIDER_ID_ORDER), not just insertion order.
+    setProvider("claude-code", "ephemeralProcess", {
+      data: response(
+        claudeCodeFixture({ fiveHour: rlWindow(70), sevenDay: rlWindow(10) }),
+      ),
+      isError: false,
+    });
+    setProvider("codex", "ephemeralProcess", {
+      data: response(
+        codexFixture({ primary: rlWindow(40), secondary: rlWindow(20) }),
+      ),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 40,
+        severity: "blue",
+        degraded: false,
+      },
+      {
+        providerId: "claude-code",
+        windowLabel: "5h",
+        usedPercent: 70,
+        severity: "yellow",
+        degraded: false,
+      },
+    ]);
+  });
+
+  it("fills both bars from Codex's 5h + Weekly windows when only Codex is configured", () => {
+    setProvider("codex", "ephemeralProcess", {
+      data: response(
+        codexFixture({ primary: rlWindow(88), secondary: rlWindow(30) }),
+      ),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 88,
+        severity: "red",
+        degraded: false,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "Weekly",
+        usedPercent: 30,
+        severity: "blue",
+        degraded: false,
+      },
+    ]);
+  });
+
+  it("fills both bars from Claude Code's 5h + Weekly windows when only Claude Code is configured", () => {
+    setProvider("claude-code", "ephemeralProcess", {
+      data: response(
+        claudeCodeFixture({ fiveHour: rlWindow(12), sevenDay: rlWindow(64) }),
+      ),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([
+      {
+        providerId: "claude-code",
+        windowLabel: "5h",
+        usedPercent: 12,
+        severity: "blue",
+        degraded: false,
+      },
+      {
+        providerId: "claude-code",
+        windowLabel: "Weekly",
+        usedPercent: 64,
+        severity: "yellow",
+        degraded: false,
+      },
+    ]);
+  });
+
+  it("returns no bars when a single provider is missing one of its two windows (partial load)", () => {
+    // Partial-load policy: the glyph fills both slots or shows the placeholder.
+    // Claude's 5h has loaded but its Weekly window is absent -> [] (placeholder),
+    // not a lone real bar.
+    setProvider("claude-code", "ephemeralProcess", {
+      data: response(
+        claudeCodeFixture({ fiveHour: rlWindow(20), sevenDay: null }),
+      ),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns no bars when both are configured but one is still cold (partial load)", () => {
+    // Codex loaded, Claude Code still cold -> can't fill both slots -> [].
+    setProvider("codex", "ephemeralProcess", {
+      data: response(
+        codexFixture({ primary: rlWindow(50), secondary: rlWindow(10) }),
+      ),
+      isError: false,
+    });
+    setProvider("claude-code", "ephemeralProcess", {
+      data: undefined,
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("never contributes bars for OpenRouter / Kilo Code (popover-only providers)", () => {
+    setProvider("openrouter", "httpFetch", {
+      data: response(openRouterFixture({ limit: 200, limitRemaining: 50 })),
+      isError: false,
+    });
+    setProvider("kilocode", "httpFetch", {
+      data: response(kiloCodeFixture()),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns no bars for the unavailable arm", () => {
+    setProvider("codex", "ephemeralProcess", {
+      data: response(unavailableFixture()),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("marks both of a single provider's bars degraded when the latest poll errored", () => {
+    setProvider("codex", "ephemeralProcess", {
+      data: response(
+        codexFixture({ primary: rlWindow(65), secondary: rlWindow(15) }),
+      ),
+      isError: true,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 65,
+        severity: "yellow",
+        degraded: true,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "Weekly",
+        usedPercent: 15,
+        severity: "blue",
+        degraded: true,
+      },
+    ]);
+  });
+});

--- a/clients/gui-app/src/hooks/rate-limits/__tests__/use-provider-rate-limit-refresh.test.tsx
+++ b/clients/gui-app/src/hooks/rate-limits/__tests__/use-provider-rate-limit-refresh.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Focused unit coverage for `useProviderRateLimitRefresh` - the single source
+ * of truth for a provider's refresh action + spinner state, shared by the
+ * popover's `RateLimitProviderBlock` and the Settings card. The consumers'
+ * own tests exercise this logic only through their full component trees;
+ * these pin the lane routing and the `draining` fold-in directly, so a
+ * regression is caught even if a consumer's test setup masks it.
+ *
+ * `rateLimitFetchLane` stays REAL (it is a pure provider-id classifier):
+ * codex exercises the ephemeralProcess lane and openrouter the httpFetch
+ * lane, so the routing under test is the true production mapping rather than
+ * a mocked one.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+
+const mocks = vi.hoisted(() => ({
+  draining: false,
+  enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
+}));
+
+vi.mock("@/hooks/rate-limits/use-is-rate-limit-queue-draining", () => ({
+  useIsRateLimitQueueDraining: () => mocks.draining,
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  // Wrapper (not `mocks.enqueue` directly) so `beforeEach` can swap the spy.
+  enqueueRateLimitFetch: (...args: unknown[]) => mocks.enqueue(...args),
+}));
+// No-op the fresh-on-open side effect: it has its own enqueue call that would
+// pollute the spy, and its behavior is covered through the consumers' tests.
+vi.mock("@/hooks/host/use-refresh-provider-rate-limits-on-mount", () => ({
+  useRefreshProviderRateLimitsOnMount: () => {},
+}));
+
+import { useProviderRateLimitRefresh } from "@/hooks/rate-limits/use-provider-rate-limit-refresh";
+
+beforeEach(() => {
+  mocks.draining = false;
+  mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useProviderRateLimitRefresh refresh routing", () => {
+  it("routes an ephemeralProcess provider's refresh through the serial queue with force:true, never a bare refetch", async () => {
+    const refetch = vi.fn(() => Promise.resolve({}));
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("codex", false, refetch),
+    );
+
+    await result.current.refresh();
+
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "codex",
+      DEFAULT_ACCOUNT_CONTEXT,
+      {
+        force: true,
+      },
+    );
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("routes an httpFetch provider's refresh through its own refetch, never the queue", async () => {
+    const refetch = vi.fn(() => Promise.resolve({}));
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("openrouter", false, refetch),
+    );
+
+    await result.current.refresh();
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+});
+
+describe("useProviderRateLimitRefresh isRefreshing", () => {
+  const refetch = () => Promise.resolve({});
+
+  it("reflects the provider's own isFetching on both lanes", () => {
+    const codex = renderHook(() =>
+      useProviderRateLimitRefresh("codex", true, refetch),
+    );
+    expect(codex.result.current.isRefreshing).toBe(true);
+
+    const openrouter = renderHook(() =>
+      useProviderRateLimitRefresh("openrouter", true, refetch),
+    );
+    expect(openrouter.result.current.isRefreshing).toBe(true);
+  });
+
+  it("folds the queue's draining flag in for an ephemeralProcess provider whose own fetch has settled", () => {
+    mocks.draining = true;
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("codex", false, refetch),
+    );
+    expect(result.current.isRefreshing).toBe(true);
+  });
+
+  it("ignores draining for an httpFetch provider - its own isFetching is the complete signal", () => {
+    mocks.draining = true;
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("openrouter", false, refetch),
+    );
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
+  it("is false when nothing is fetching and the queue is idle", () => {
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("codex", false, refetch),
+    );
+    expect(result.current.isRefreshing).toBe(false);
+  });
+});

--- a/clients/gui-app/src/hooks/rate-limits/use-configured-rate-limit-providers.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-configured-rate-limit-providers.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
+import {
+  isRateLimitCapableProvider,
+  isRateLimitProviderConfigured,
+  rateLimitFetchLane,
+  type RateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+export interface ConfiguredRateLimitProvider {
+  readonly providerId: RateLimitProviderId;
+  readonly lane: RateLimitFetchLane;
+}
+
+/**
+ * The currently-configured rate-limit-capable providers on the default host,
+ * each tagged with its fetch lane. Drives both the interval timer (walks the
+ * `ephemeralProcess` entries) and, later, the popover rail.
+ *
+ * Mounted persistently at the app-shell level (via `RateLimitQueueProvider`),
+ * so `providers.list` is subscribed for the window's lifetime rather than
+ * lazily on Settings open. `subscribed: true` keeps it refreshing so a
+ * credential change (login/logout invalidates `providers.list`) re-gates the
+ * set - a removed credential drops its provider here immediately, and the next
+ * timer tick reads the shortened list.
+ *
+ * TanStack's structural sharing keeps `data.providers` referentially stable
+ * across identical polls, so the memoized projection only recomputes on a real
+ * list change.
+ */
+export function useConfiguredRateLimitProviders(): ReadonlyArray<ConfiguredRateLimitProvider> {
+  const providersQuery = useProvidersList({ enabled: true, subscribed: true });
+  const providers = providersQuery.data?.providers;
+  return useMemo(() => {
+    if (providers === undefined) return [];
+    return providers.flatMap((state) => {
+      const providerId = state.providerId;
+      if (!isRateLimitCapableProvider(providerId)) return [];
+      if (!isRateLimitProviderConfigured(state)) return [];
+      return [{ providerId, lane: rateLimitFetchLane(providerId) }];
+    });
+  }, [providers]);
+}

--- a/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
@@ -96,6 +96,14 @@ function toBar(
   };
 }
 
+/** Both slots or neither - the atomic "fully populated or placeholder" pair. */
+function buildPair(
+  first: HeaderRateLimitBar | null,
+  second: HeaderRateLimitBar | null,
+): ReadonlyArray<HeaderRateLimitBar> {
+  return first !== null && second !== null ? [first, second] : [];
+}
+
 /**
  * The glyph's two bars, or `[]` when it can't populate *both* slots:
  *
@@ -117,7 +125,7 @@ function selectGlyphBars(
 ): ReadonlyArray<HeaderRateLimitBar> {
   if (readings.length >= 2) {
     const [first, second] = readings;
-    const bars = [
+    return buildPair(
       toBar(
         first.providerId,
         "5h",
@@ -130,12 +138,11 @@ function selectGlyphBars(
         fiveHourWindow(second.rateLimits),
         second.degraded,
       ),
-    ].filter((bar): bar is HeaderRateLimitBar => bar !== null);
-    return bars.length === 2 ? bars : [];
+    );
   }
   if (readings.length === 1) {
     const [only] = readings;
-    const bars = [
+    return buildPair(
       toBar(
         only.providerId,
         "5h",
@@ -148,8 +155,7 @@ function selectGlyphBars(
         weeklyWindow(only.rateLimits),
         only.degraded,
       ),
-    ].filter((bar): bar is HeaderRateLimitBar => bar !== null);
-    return bars.length === 2 ? bars : [];
+    );
   }
   return [];
 }
@@ -183,16 +189,35 @@ export function useHeaderRateLimitBars(): ReadonlyArray<HeaderRateLimitBar> {
     configuredIds.has(id),
   );
 
+  // `useHostQueries` applies one shared `options` object to every request in
+  // the batch, so it's only safe to reuse a single glyph provider's options if
+  // every glyph provider actually resolves to the same ones (true today: both
+  // are `ephemeralProcess`, never `httpFetch`). Verified here - rather than
+  // just trusted from `GLYPH_PROVIDER_IDS`'s own comment - so a future glyph
+  // provider on a different lane falls back to `null` (TanStack's defaults)
+  // instead of silently borrowing an unrelated provider's refetch behavior.
+  const glyphOptions = glyphProviders.map(
+    (providerId) => providerRateLimitQueryOptions(providerId).options,
+  );
+  const [firstGlyphOptions] = glyphOptions;
+  const sharedGlyphOptions =
+    glyphProviders.length > 0 &&
+    firstGlyphOptions !== null &&
+    glyphOptions.every(
+      (options) =>
+        options !== null &&
+        options.refetchInterval === firstGlyphOptions.refetchInterval,
+    )
+      ? firstGlyphOptions
+      : null;
+
   const results = useHostQueries<HostRpcRegistry, "host.getRateLimitUsage">({
     client,
     requests: glyphProviders.map((providerId) => {
       const { method, params } = providerRateLimitQueryOptions(providerId);
       return { method, params };
     }),
-    options:
-      glyphProviders.length > 0
-        ? providerRateLimitQueryOptions(glyphProviders[0]).options
-        : null,
+    options: sharedGlyphOptions,
   });
 
   const readings = glyphProviders.map((providerId, index) => ({

--- a/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
@@ -1,0 +1,205 @@
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitWindow,
+} from "@traycer/protocol/host";
+import { useHostQueries } from "@/hooks/host/use-host-queries";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import { useConfiguredRateLimitProviders } from "@/hooks/rate-limits/use-configured-rate-limit-providers";
+import { useHostClient, type HostRpcRegistry } from "@/lib/host";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+import {
+  rateLimitWindowSeverity,
+  type RateLimitWindowSeverity,
+} from "@/lib/rate-limits/window-severity";
+
+/**
+ * The two windows a glyph bar can stand for, in fixed draw order: a provider's
+ * 5-hour window and its Weekly window. Also the per-bar disambiguator in the
+ * React key, since a single provider can own *both* bars (see below).
+ */
+export type HeaderRateLimitWindowLabel = "5h" | "Weekly";
+
+export interface HeaderRateLimitBar {
+  readonly providerId: RateLimitProviderId;
+  readonly windowLabel: HeaderRateLimitWindowLabel;
+  readonly usedPercent: number;
+  readonly severity: RateLimitWindowSeverity;
+  /** Most recent poll for this provider errored, but this is last-known-good data. */
+  readonly degraded: boolean;
+}
+
+/**
+ * The only providers that ever occupy a glyph slot, in fixed draw order (codex
+ * before claude-code, matching `PROVIDER_ID_ORDER`). OpenRouter and Kilo Code
+ * are popover-only and never contribute a header bar. Both of these are the
+ * `ephemeralProcess` fetch lane, so the glyph needs a single `useHostQueries`
+ * call and no `httpFetch` plumbing at all.
+ */
+const GLYPH_PROVIDER_IDS = ["codex", "claude-code"] as const;
+
+type GlyphProviderId = (typeof GLYPH_PROVIDER_IDS)[number];
+
+/** A glyph provider's live query state, paired with its id (in draw order). */
+interface GlyphProviderReading {
+  readonly providerId: GlyphProviderId;
+  readonly rateLimits: ProviderRateLimits | null;
+  readonly degraded: boolean;
+}
+
+/** The 5h window a glyph provider reports (Codex `primary`, Claude `fiveHour`). */
+function fiveHourWindow(
+  rateLimits: ProviderRateLimits | null,
+): ProviderRateLimitWindow | null {
+  if (rateLimits === null || !rateLimits.available) return null;
+  switch (rateLimits.provider) {
+    case "codex":
+      return rateLimits.primary;
+    case "claude-code":
+      return rateLimits.fiveHour;
+    // OpenRouter/Kilo Code are never queried for a glyph slot; kept for
+    // exhaustiveness over the union.
+    case "openrouter":
+    case "kilocode":
+      return null;
+  }
+}
+
+/** The Weekly window a glyph provider reports (Codex `secondary`, Claude `sevenDay`). */
+function weeklyWindow(
+  rateLimits: ProviderRateLimits | null,
+): ProviderRateLimitWindow | null {
+  if (rateLimits === null || !rateLimits.available) return null;
+  switch (rateLimits.provider) {
+    case "codex":
+      return rateLimits.secondary;
+    case "claude-code":
+      return rateLimits.sevenDay;
+    case "openrouter":
+    case "kilocode":
+      return null;
+  }
+}
+
+function toBar(
+  providerId: GlyphProviderId,
+  windowLabel: HeaderRateLimitWindowLabel,
+  window: ProviderRateLimitWindow | null,
+  degraded: boolean,
+): HeaderRateLimitBar | null {
+  if (window === null) return null;
+  return {
+    providerId,
+    windowLabel,
+    usedPercent: window.usedPercent,
+    severity: rateLimitWindowSeverity(window.usedPercent),
+    degraded,
+  };
+}
+
+/**
+ * The glyph's two bars, or `[]` when it can't populate *both* slots:
+ *
+ * - Both providers configured: bar 1 is Codex's 5h window, bar 2 is Claude
+ *   Code's 5h window (glyph order).
+ * - Exactly one configured: that provider fills both slots with its 5h and
+ *   Weekly windows.
+ *
+ * Partial-load policy: this returns bars only when it can fill BOTH slots;
+ * anything short of that (a provider still cold, or a window the provider
+ * doesn't report) collapses to `[]`, and the icon then shows its neutral 2-bar
+ * placeholder. The glyph is a single fixed 2-bar unit (the CodexBar pre-filled
+ * look), so it flips atomically from placeholder to fully-populated rather than
+ * ever rendering a half-real / half-neutral mix - simpler and less ambiguous
+ * than padding a lone real bar with a placeholder-shaped one.
+ */
+function selectGlyphBars(
+  readings: ReadonlyArray<GlyphProviderReading>,
+): ReadonlyArray<HeaderRateLimitBar> {
+  if (readings.length >= 2) {
+    const [first, second] = readings;
+    const bars = [
+      toBar(
+        first.providerId,
+        "5h",
+        fiveHourWindow(first.rateLimits),
+        first.degraded,
+      ),
+      toBar(
+        second.providerId,
+        "5h",
+        fiveHourWindow(second.rateLimits),
+        second.degraded,
+      ),
+    ].filter((bar): bar is HeaderRateLimitBar => bar !== null);
+    return bars.length === 2 ? bars : [];
+  }
+  if (readings.length === 1) {
+    const [only] = readings;
+    const bars = [
+      toBar(
+        only.providerId,
+        "5h",
+        fiveHourWindow(only.rateLimits),
+        only.degraded,
+      ),
+      toBar(
+        only.providerId,
+        "Weekly",
+        weeklyWindow(only.rateLimits),
+        only.degraded,
+      ),
+    ].filter((bar): bar is HeaderRateLimitBar => bar !== null);
+    return bars.length === 2 ? bars : [];
+  }
+  return [];
+}
+
+/**
+ * The header glyph's bar data: a fixed two-bar summary scoped to Codex and
+ * Claude Code only. When both are configured the glyph shows each provider's 5h
+ * window (codex first); when only one is configured that provider fills both
+ * bars with its 5h and Weekly windows. OpenRouter/Kilo Code never appear here
+ * (popover-only). See `selectGlyphBars` for the exact selection and the
+ * partial-load policy; a return of `[]` means "render the neutral placeholder".
+ *
+ * Mounting `useHostQueries` here drives the initial fetch-on-mount for the two
+ * glyph providers (both `ephemeralProcess`); the serial queue only bounds their
+ * *subsequent* background/turn/manual triggers. Because this hook no longer
+ * queries the `httpFetch` lane, OpenRouter/Kilo Code are fetched lazily on
+ * popover / Settings open rather than pre-fetched at app-shell mount - which is
+ * fine, since nothing at the shell level displays their usage.
+ *
+ * A provider still cold (no data yet) contributes nothing - callers render the
+ * neutral/placeholder glyph while this returns `[]`, never a loading state, so
+ * the icon never gates header render on a fetch.
+ */
+export function useHeaderRateLimitBars(): ReadonlyArray<HeaderRateLimitBar> {
+  const client = useHostClient();
+  const configured = useConfiguredRateLimitProviders();
+  const configuredIds = new Set(
+    configured.map((provider) => provider.providerId),
+  );
+  const glyphProviders = GLYPH_PROVIDER_IDS.filter((id) =>
+    configuredIds.has(id),
+  );
+
+  const results = useHostQueries<HostRpcRegistry, "host.getRateLimitUsage">({
+    client,
+    requests: glyphProviders.map((providerId) => {
+      const { method, params } = providerRateLimitQueryOptions(providerId);
+      return { method, params };
+    }),
+    options:
+      glyphProviders.length > 0
+        ? providerRateLimitQueryOptions(glyphProviders[0]).options
+        : null,
+  });
+
+  const readings = glyphProviders.map((providerId, index) => ({
+    providerId,
+    rateLimits: results[index].data?.providerRateLimits ?? null,
+    degraded: results[index].isError,
+  }));
+
+  return selectGlyphBars(readings);
+}

--- a/clients/gui-app/src/hooks/rate-limits/use-is-rate-limit-queue-draining.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-is-rate-limit-queue-draining.ts
@@ -1,0 +1,20 @@
+import { useSyncExternalStore } from "react";
+import {
+  isRateLimitQueueDraining,
+  subscribeRateLimitQueueDraining,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+/**
+ * Reactively projects whether the `ephemeralProcess` serial queue currently has
+ * a subprocess fetch in flight. Backs the popover's "disable Refresh-all while
+ * draining" state. Both the subscribe and snapshot functions are stable module
+ * references returning a primitive boolean, so `useSyncExternalStore` never
+ * re-subscribes or tears on identity.
+ */
+export function useIsRateLimitQueueDraining(): boolean {
+  return useSyncExternalStore(
+    subscribeRateLimitQueueDraining,
+    isRateLimitQueueDraining,
+    isRateLimitQueueDraining,
+  );
+}

--- a/clients/gui-app/src/hooks/rate-limits/use-provider-rate-limit-refresh.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-provider-rate-limit-refresh.ts
@@ -1,0 +1,68 @@
+import { useCallback } from "react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
+import { useIsRateLimitQueueDraining } from "@/hooks/rate-limits/use-is-rate-limit-queue-draining";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+import {
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+/**
+ * The single source of truth for "how do I refresh one provider's rate limits,
+ * and is that provider currently refreshing" - shared verbatim by the popover's
+ * per-provider block and the Settings card so their refresh button can never
+ * drift apart again. Both the action and the spinner state are lane-aware:
+ *
+ * - **Action (`refresh`)**:
+ *   - `ephemeralProcess` (codex, claude-code): routes through the shared serial
+ *     queue with `force: true`, so a manual refresh can never spawn a CLI
+ *     subprocess overlapping one the queue is already running. A bare
+ *     `query.refetch()` here would call the host directly and bypass that bound.
+ *   - `httpFetch` (openrouter, kilocode): a plain GET with no subprocess to
+ *     serialize, so it just refetches its own query.
+ *
+ * - **Spinner state (`isRefreshing`)**: `query.isFetching` covers a fetch on
+ *   THIS provider's own query key (whoever triggered it - the queue's
+ *   `fetchQuery`, a direct refetch, an invalidation). For `ephemeralProcess`
+ *   providers it is OR-ed with the queue's `draining` flag, because the queue
+ *   runs providers one at a time: this provider's own `isFetching` can settle
+ *   the instant its turn finishes while "Refresh all" is still working through a
+ *   later provider queued behind it. Gating on `draining` (the whole round)
+ *   rather than only this provider's own fetch keeps the button disabled for as
+ *   long as any refresh in the shared lane is in flight - matching the user's
+ *   "Refresh all is in progress" mental model, not "my own fetch is in flight".
+ *   `httpFetch` providers refresh concurrently (no shared queue), so their own
+ *   `isFetching` is already the complete signal.
+ *
+ * `isFetching` / `refetch` are threaded in from the caller's existing
+ * `useHostProviderRateLimitsQuery` observer rather than opening a second one
+ * here, so there is still exactly one query observer per mounted block.
+ */
+export function useProviderRateLimitRefresh(
+  providerId: RateLimitProviderId,
+  isFetching: boolean,
+  refetch: () => Promise<unknown>,
+): { readonly refresh: () => Promise<void>; readonly isRefreshing: boolean } {
+  const draining = useIsRateLimitQueueDraining();
+  const lane = rateLimitFetchLane(providerId);
+  // Fresh-data-on-open for the ephemeralProcess lane, routed through the shared
+  // serial queue rather than TanStack's own (deliberately disabled)
+  // refetch-on-mount - see providerRateLimitQueryOptions' doc comment. No-ops
+  // for the httpFetch lane, which keeps TanStack's refetch-on-mount instead.
+  useRefreshProviderRateLimitsOnMount(providerId);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (lane === "ephemeralProcess") {
+      await enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+        force: true,
+      });
+      return;
+    }
+    await refetch();
+  }, [lane, providerId, refetch]);
+
+  const isRefreshing = isFetching || (lane === "ephemeralProcess" && draining);
+
+  return { refresh, isRefreshing };
+}

--- a/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
+++ b/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
@@ -3,6 +3,7 @@ import type { ProviderRateLimits } from "@traycer/protocol/host";
 import {
   formatUnavailableReason,
   resolvePopoverProviderRateLimitState,
+  resolveProviderPlanLabel,
 } from "@/lib/provider-rate-limit-content";
 
 const READY: ProviderRateLimits = {
@@ -81,5 +82,86 @@ describe("resolvePopoverProviderRateLimitState", () => {
       providerRateLimits: READY,
     });
     expect(state).toEqual({ kind: "ready", data: READY, degraded: true });
+  });
+});
+
+describe("resolveProviderPlanLabel", () => {
+  it("title-cases Codex's planType", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "codex",
+        available: true,
+        planType: "pro_5x",
+        limitId: null,
+        limitName: null,
+        primary: null,
+        secondary: null,
+        extraWindows: [],
+        credits: null,
+        individualLimit: null,
+        resetCredits: null,
+        rateLimitReachedType: null,
+      }),
+    ).toBe("Pro 5x");
+  });
+
+  it("title-cases Claude Code's subscriptionType", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "claude-code",
+        available: true,
+        subscriptionType: "max",
+        fiveHour: null,
+        sevenDay: null,
+        sevenDayOpus: null,
+        sevenDaySonnet: null,
+        modelScoped: [],
+        extraUsage: null,
+      }),
+    ).toBe("Max");
+  });
+
+  it("is null when a provider didn't report a plan/tier", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "codex",
+        available: true,
+        planType: null,
+        limitId: null,
+        limitName: null,
+        primary: null,
+        secondary: null,
+        extraWindows: [],
+        credits: null,
+        individualLimit: null,
+        resetCredits: null,
+        rateLimitReachedType: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("is always null for providers with no plan/tier concept (OpenRouter, Kilo Code)", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "openrouter",
+        available: true,
+        limit: null,
+        limitRemaining: null,
+        dailySpend: null,
+        weeklySpend: null,
+        monthlySpend: null,
+        totalCredits: null,
+        totalUsage: null,
+        balance: null,
+      }),
+    ).toBeNull();
+    expect(
+      resolveProviderPlanLabel({
+        provider: "kilocode",
+        available: true,
+        creditBalance: null,
+        passState: null,
+      }),
+    ).toBeNull();
   });
 });

--- a/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
+++ b/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderRateLimits } from "@traycer/protocol/host";
+import {
+  formatUnavailableReason,
+  resolvePopoverProviderRateLimitState,
+} from "@/lib/provider-rate-limit-content";
+
+const READY: ProviderRateLimits = {
+  provider: "kilocode",
+  available: true,
+  creditBalance: 10,
+  passState: null,
+};
+
+const UNAVAILABLE: ProviderRateLimits = {
+  provider: "codex",
+  available: false,
+  reason: "cli_not_found",
+};
+
+describe("formatUnavailableReason", () => {
+  it("maps the Droid org-plan gate to plain language", () => {
+    expect(formatUnavailableReason("insufficient_permissions")).toBe(
+      "this account doesn't have permission to view usage",
+    );
+  });
+
+  it("maps the CLI-missing reason", () => {
+    expect(formatUnavailableReason("cli_not_found")).toBe(
+      "the CLI isn't installed",
+    );
+  });
+});
+
+describe("resolvePopoverProviderRateLimitState", () => {
+  it("is a cold load while the first fetch is in flight with no data", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: true,
+      isFetching: true,
+      isError: false,
+      providerRateLimits: undefined,
+    });
+    expect(state.kind).toBe("cold");
+  });
+
+  it("is an error when the first fetch failed with no data", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: true,
+      isFetching: false,
+      isError: true,
+      providerRateLimits: undefined,
+    });
+    expect(state.kind).toBe("error");
+  });
+
+  it("surfaces the provider's own unavailable reason", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: false,
+      isFetching: false,
+      isError: false,
+      providerRateLimits: UNAVAILABLE,
+    });
+    expect(state).toEqual({ kind: "unavailable", reason: "cli_not_found" });
+  });
+
+  it("is ready and not degraded for a fresh available snapshot", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: false,
+      isFetching: false,
+      isError: false,
+      providerRateLimits: READY,
+    });
+    expect(state).toEqual({ kind: "ready", data: READY, degraded: false });
+  });
+
+  it("is ready but degraded when a poll failed over last-known-good data", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: false,
+      isFetching: false,
+      isError: true,
+      providerRateLimits: READY,
+    });
+    expect(state).toEqual({ kind: "ready", data: READY, degraded: true });
+  });
+});

--- a/clients/gui-app/src/lib/__tests__/rate-limit-providers.test.ts
+++ b/clients/gui-app/src/lib/__tests__/rate-limit-providers.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ProviderAuthStatus,
+  ProviderCliState,
+  ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
+import {
+  isRateLimitCapableProvider,
+  isRateLimitProviderConfigured,
+  rateLimitFetchLane,
+} from "@/lib/rate-limit-providers";
+
+function state(
+  overrides: Partial<ProviderCliState> & { readonly providerId: ProviderId },
+): ProviderCliState {
+  return {
+    enabled: true,
+    disabledBy: null,
+    selected: { kind: "bundled" },
+    candidates: [],
+    authPending: false,
+    checkedAt: null,
+    apiKey: { supported: false, configured: false, source: null },
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
+    availabilityPending: false,
+    auth: {
+      status: "authenticated",
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("rateLimitFetchLane", () => {
+  it("maps codex and claude-code to the ephemeralProcess (subprocess) lane", () => {
+    expect(rateLimitFetchLane("codex")).toBe("ephemeralProcess");
+    expect(rateLimitFetchLane("claude-code")).toBe("ephemeralProcess");
+  });
+
+  it("maps openrouter and kilocode to the httpFetch (cheap GET) lane", () => {
+    expect(rateLimitFetchLane("openrouter")).toBe("httpFetch");
+    expect(rateLimitFetchLane("kilocode")).toBe("httpFetch");
+  });
+});
+
+describe("isRateLimitCapableProvider", () => {
+  it("accepts the four rate-limit-capable providers and rejects others", () => {
+    expect(isRateLimitCapableProvider("codex")).toBe(true);
+    expect(isRateLimitCapableProvider("kilocode")).toBe(true);
+    expect(isRateLimitCapableProvider("cursor")).toBe(false);
+    expect(isRateLimitCapableProvider("traycer")).toBe(false);
+  });
+});
+
+describe("isRateLimitProviderConfigured", () => {
+  it("treats authenticated and configured (credential present) as eligible", () => {
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "codex", auth: authStatus("authenticated") }),
+      ),
+    ).toBe(true);
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "openrouter", auth: authStatus("configured") }),
+      ),
+    ).toBe(true);
+  });
+
+  it("excludes providers with no usable credential", () => {
+    for (const status of [
+      "unauthenticated",
+      "unavailable",
+      "unknown",
+    ] as const) {
+      expect(
+        isRateLimitProviderConfigured(
+          state({ providerId: "codex", auth: authStatus(status) }),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("excludes providers whose verdict has not settled", () => {
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "codex", authPending: true }),
+      ),
+    ).toBe(false);
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "codex", availabilityPending: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes a provider the user has disabled", () => {
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "codex", enabled: false }),
+      ),
+    ).toBe(false);
+  });
+});
+
+function authStatus(status: ProviderAuthStatus): ProviderCliState["auth"] {
+  return { status, badgeText: null, label: null, detail: null };
+}

--- a/clients/gui-app/src/lib/__tests__/relative-time.test.ts
+++ b/clients/gui-app/src/lib/__tests__/relative-time.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatRelativeTimestamp,
   formatResetCountdown,
+  formatResetDateTime,
 } from "@/lib/relative-time";
 
 const MINUTE_MS = 60_000;
@@ -89,5 +90,22 @@ describe("formatResetCountdown", () => {
 
   it("clamps a past resetsAt to 'now' rather than a negative duration", () => {
     expect(formatResetCountdown(now - 10_000, now)).toBe("now");
+  });
+});
+
+describe("formatResetDateTime", () => {
+  it("inserts the day-of-week in parentheses between the date and the time", () => {
+    const formatted = formatResetDateTime(
+      Date.parse("2026-07-11T10:35:00.000Z"),
+    );
+    // The (EEE) weekday is the new part vs the old "Jul 11, 2026 3:35 AM": a
+    // three-letter day abbreviation in parentheses. Exact date/time is
+    // TZ/locale-dependent, so assert structure rather than a literal string.
+    expect(formatted).toMatch(/\([A-Za-z]{3}\)/);
+    // The date (carrying the year) is before the weekday; the time (a colon)
+    // is after it.
+    const weekdayIndex = formatted.indexOf("(");
+    expect(formatted.slice(0, weekdayIndex)).toContain("2026");
+    expect(formatted.slice(weekdayIndex)).toMatch(/\d{1,2}:\d{2}/);
   });
 });

--- a/clients/gui-app/src/lib/__tests__/relative-time.test.ts
+++ b/clients/gui-app/src/lib/__tests__/relative-time.test.ts
@@ -3,6 +3,7 @@ import {
   formatRelativeTimestamp,
   formatResetCountdown,
   formatResetDateTime,
+  isFarReset,
 } from "@/lib/relative-time";
 
 const MINUTE_MS = 60_000;
@@ -93,19 +94,28 @@ describe("formatResetCountdown", () => {
   });
 });
 
+describe("isFarReset", () => {
+  const now = Date.parse("2026-04-23T12:00:00.000Z");
+
+  it("is false for a reset under one day away, regardless of a window's nominal duration", () => {
+    expect(isFarReset(now + 23 * HOUR_MS, now)).toBe(false);
+  });
+
+  it("is true at exactly one day away and beyond", () => {
+    expect(isFarReset(now + DAY_MS, now)).toBe(true);
+    expect(isFarReset(now + 3 * DAY_MS, now)).toBe(true);
+  });
+});
+
 describe("formatResetDateTime", () => {
-  it("inserts the day-of-week in parentheses between the date and the time", () => {
+  it("renders a short weekday followed by the time, with no calendar date", () => {
     const formatted = formatResetDateTime(
       Date.parse("2026-07-11T10:35:00.000Z"),
     );
-    // The (EEE) weekday is the new part vs the old "Jul 11, 2026 3:35 AM": a
-    // three-letter day abbreviation in parentheses. Exact date/time is
-    // TZ/locale-dependent, so assert structure rather than a literal string.
-    expect(formatted).toMatch(/\([A-Za-z]{3}\)/);
-    // The date (carrying the year) is before the weekday; the time (a colon)
-    // is after it.
-    const weekdayIndex = formatted.indexOf("(");
-    expect(formatted.slice(0, weekdayIndex)).toContain("2026");
-    expect(formatted.slice(weekdayIndex)).toMatch(/\d{1,2}:\d{2}/);
+    // Exact weekday/time is TZ/locale-dependent, so assert structure rather
+    // than a literal string: a three-letter weekday, then a time with an
+    // AM/PM designator, and no year/date digits leaking back in.
+    expect(formatted).toMatch(/^[A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i);
+    expect(formatted).not.toContain("2026");
   });
 });

--- a/clients/gui-app/src/lib/auth/__tests__/traycer-subscription-content.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/traycer-subscription-content.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AuthenticatedUser,
+  SubscriptionStatus,
+  TraycerTeamSubscription,
+  TraycerUserSubscription,
+} from "@traycer/protocol/auth";
+import {
+  accountContextValue,
+  isCreditBasedPricing,
+  isPaid,
+  isTraycerEligible,
+  parseAccountContextValue,
+  resolveTraycerSubscriptionState,
+  selectSubscription,
+} from "@/lib/auth/traycer-subscription-content";
+
+const EPOCH = new Date(0);
+
+function baseSubscription() {
+  return {
+    id: "sub",
+    userID: "u1",
+    orgID: null,
+    teamID: null,
+    customerId: "cus",
+    createdAt: EPOCH,
+    updatedAt: EPOCH,
+    subscriptionExpiry: null,
+    trialEndsAt: null,
+    hasPaymentMethod: true,
+    rechargeRateSeconds: 60,
+  };
+}
+
+function userSub(overrides: {
+  status: SubscriptionStatus;
+  hasActiveBundle?: boolean;
+}): TraycerUserSubscription {
+  return {
+    ...baseSubscription(),
+    subscriptionStatus: overrides.status,
+    isInTrial: false,
+    hasActiveBundle: overrides.hasActiveBundle,
+  };
+}
+
+function teamSub(teamId: string): TraycerTeamSubscription {
+  return {
+    ...baseSubscription(),
+    teamID: teamId,
+    subscriptionStatus: "ULTRA_1X_V3",
+    isInTrial: false,
+    totalPlanCredits: 500,
+    hasActiveBundle: false,
+    bundleSummary: { bundleTotal: 0, bundleConsumed: 0, bundleRemaining: 0 },
+    team: {
+      id: teamId,
+      slug: "acme",
+      avatarUrl: null,
+      privacyMode: false,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+    },
+  };
+}
+
+function userWith(
+  userSubscription: TraycerUserSubscription,
+  teams: TraycerTeamSubscription[],
+): AuthenticatedUser {
+  return {
+    user: {
+      id: "u1",
+      name: "Ada",
+      providerId: "p1",
+      providerHandle: "ada",
+      providerType: "GITHUB",
+      email: "ada@example.com",
+      avatarUrl: null,
+      activatedAt: EPOCH,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+      lastSeenAt: EPOCH,
+      privacyMode: false,
+      isLearningEnabled: true,
+    },
+    userSubscription,
+    payAsYouGoUsage: { allowPayAsYouGo: false },
+    teamSubscriptions: teams,
+  };
+}
+
+describe("isPaid / isCreditBasedPricing", () => {
+  it("treats only FREE/PENDING as unpaid", () => {
+    expect(isPaid("FREE")).toBe(false);
+    expect(isPaid("PENDING")).toBe(false);
+    expect(isPaid("PRO_V3")).toBe(true);
+    expect(isPaid("PRO_PLUS_V2")).toBe(true);
+  });
+
+  it("marks V3 tiers (and FREE) as credit-based, legacy/v2 as rate-limit", () => {
+    expect(isCreditBasedPricing("PRO_V3")).toBe(true);
+    expect(isCreditBasedPricing("FREE")).toBe(true);
+    expect(isCreditBasedPricing("PRO_PLUS_V2")).toBe(false);
+    expect(isCreditBasedPricing("PRO_LEGACY")).toBe(false);
+  });
+});
+
+describe("isTraycerEligible", () => {
+  it("is eligible on a paid plan", () => {
+    expect(isTraycerEligible(userSub({ status: "PRO_V3" }))).toBe(true);
+  });
+
+  it("is eligible on a free plan that holds an active bundle", () => {
+    expect(
+      isTraycerEligible(userSub({ status: "FREE", hasActiveBundle: true })),
+    ).toBe(true);
+  });
+
+  it("is not eligible on a free, unbundled plan", () => {
+    expect(isTraycerEligible(userSub({ status: "FREE" }))).toBe(false);
+    expect(
+      isTraycerEligible(userSub({ status: "FREE", hasActiveBundle: false })),
+    ).toBe(false);
+  });
+});
+
+describe("selectSubscription", () => {
+  const personal = userSub({ status: "PRO_V3" });
+  const team = teamSub("team-1");
+  const user = userWith(personal, [team]);
+
+  it("returns null when the user isn't loaded", () => {
+    expect(selectSubscription(null, { type: "PERSONAL" }, [])).toBeNull();
+  });
+
+  it("returns the personal subscription for the PERSONAL context", () => {
+    expect(selectSubscription(user, { type: "PERSONAL" }, [team])).toBe(
+      personal,
+    );
+  });
+
+  it("returns the matching team subscription for a TEAM context", () => {
+    expect(
+      selectSubscription(user, { type: "TEAM", teamId: "team-1" }, [team]),
+    ).toBe(team);
+  });
+
+  it("returns null for a TEAM context with no matching team", () => {
+    expect(
+      selectSubscription(user, { type: "TEAM", teamId: "gone" }, [team]),
+    ).toBeNull();
+  });
+});
+
+describe("account-context value round-trip", () => {
+  it("round-trips PERSONAL and TEAM", () => {
+    expect(
+      parseAccountContextValue(accountContextValue({ type: "PERSONAL" })),
+    ).toEqual({
+      type: "PERSONAL",
+    });
+    expect(
+      parseAccountContextValue(
+        accountContextValue({ type: "TEAM", teamId: "team-1" }),
+      ),
+    ).toEqual({ type: "TEAM", teamId: "team-1" });
+  });
+});
+
+describe("resolveTraycerSubscriptionState", () => {
+  const subscription = userSub({ status: "PRO_V3" });
+
+  it("is cold while pending with no subscription yet", () => {
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: true,
+        isError: false,
+        subscription: null,
+      }),
+    ).toEqual({ kind: "cold" });
+  });
+
+  it("is error when the fetch failed with no subscription", () => {
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: false,
+        isError: true,
+        subscription: null,
+      }),
+    ).toEqual({ kind: "error" });
+  });
+
+  it("is empty when loaded but the account has no subscription", () => {
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: false,
+        isError: false,
+        subscription: null,
+      }),
+    ).toEqual({ kind: "empty" });
+  });
+
+  it("is ready when a subscription is present, degraded mirroring isError", () => {
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: false,
+        isError: false,
+        subscription,
+      }),
+    ).toEqual({ kind: "ready", subscription, degraded: false });
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: false,
+        isError: true,
+        subscription,
+      }),
+    ).toEqual({ kind: "ready", subscription, degraded: true });
+  });
+});

--- a/clients/gui-app/src/lib/auth/__tests__/traycer-subscription-content.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/traycer-subscription-content.test.ts
@@ -13,6 +13,7 @@ import {
   parseAccountContextValue,
   resolveTraycerSubscriptionState,
   selectSubscription,
+  subscriptionPlanLabel,
 } from "@/lib/auth/traycer-subscription-content";
 
 const EPOCH = new Date(0);
@@ -217,5 +218,36 @@ describe("resolveTraycerSubscriptionState", () => {
         subscription,
       }),
     ).toEqual({ kind: "ready", subscription, degraded: true });
+  });
+});
+
+describe("subscriptionPlanLabel", () => {
+  it("maps free-tier statuses to BYOA", () => {
+    expect(subscriptionPlanLabel("FREE")).toBe("BYOA");
+    expect(subscriptionPlanLabel("PENDING")).toBe("BYOA");
+  });
+
+  it("maps V3 credit plans", () => {
+    expect(subscriptionPlanLabel("BYOA_V3")).toBe("Sync");
+    expect(subscriptionPlanLabel("LITE_V3")).toBe("Lite");
+    expect(subscriptionPlanLabel("PRO_V3")).toBe("Pro");
+    expect(subscriptionPlanLabel("ULTRA_1X_V3")).toBe("Ultra");
+    expect(subscriptionPlanLabel("ULTRA_2X_V3")).toBe("Ultra+");
+    expect(subscriptionPlanLabel("ULTRA_3X_V3")).toBe("Ultra+");
+    expect(subscriptionPlanLabel("ULTRA_4X_V3")).toBe("Ultra+");
+    expect(subscriptionPlanLabel("ULTRA_5X_V3")).toBe("Ultra+");
+  });
+
+  it("marks legacy lite and pro tiers", () => {
+    expect(subscriptionPlanLabel("LITE")).toBe("Lite (Legacy)");
+    expect(subscriptionPlanLabel("LITE_V2")).toBe("Lite (Legacy)");
+    expect(subscriptionPlanLabel("PRO")).toBe("Pro (Legacy)");
+    expect(subscriptionPlanLabel("PRO_V2")).toBe("Pro (Legacy)");
+    expect(subscriptionPlanLabel("PRO_LEGACY")).toBe("Pro (Legacy)");
+    expect(subscriptionPlanLabel("PRO_PLUS")).toBe("Pro+ (Legacy)");
+  });
+
+  it("maps PRO_PLUS_V2 without a legacy suffix", () => {
+    expect(subscriptionPlanLabel("PRO_PLUS_V2")).toBe("Pro+");
   });
 });

--- a/clients/gui-app/src/lib/auth/traycer-subscription-content.ts
+++ b/clients/gui-app/src/lib/auth/traycer-subscription-content.ts
@@ -15,6 +15,7 @@ import type {
   TraycerTeamSubscription,
   TraycerUserSubscription,
 } from "@traycer/protocol/auth";
+import { titleCaseFromToken } from "@/lib/provider-rate-limit-content";
 
 /** The account-scoped subscription arms the account-context store can select between. */
 export type TraycerSubscription =
@@ -45,6 +46,57 @@ const CREDIT_BASED_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
 
 export function isCreditBasedPricing(status: SubscriptionStatus): boolean {
   return CREDIT_BASED_STATUSES.has(status);
+}
+
+// A trailing `_V2`/`_V3` is an internal pricing-generation tag, not part of
+// the plan's own identity - Cloud UI's own Settings pages never show it
+// (billing-overview.tsx renders the Stripe product's bare name, e.g. "Ultra",
+// never "Ultra V3"). Stripped before title-casing so `ULTRA_5X_V3` reads as
+// "Ultra 5x", not "Ultra 5x V3". `_LEGACY` isn't stripped - unlike `_V2`/`_V3`,
+// it isn't a pricing-generation tag on an otherwise-equivalent tier.
+const VERSION_SUFFIX_PATTERN = /_V\d+$/;
+
+/**
+ * The Traycer plan/tier label for the selected account (Core Flows parity
+ * with Codex/Claude: "shown where the provider reports one") - the header
+ * popover's "Traycer" tab shows this as a chip next to the name, same as
+ * `resolveProviderPlanLabel` does for the host-RPC providers.
+ */
+//eslint-disable-next-line complexity
+export function subscriptionPlanLabel(status: SubscriptionStatus): string {
+  switch (status) {
+    case "FREE":
+    case "PENDING":
+      return "BYOA";
+    case "BYOA_V3":
+      return "Sync";
+    case "LITE_V3":
+      return "Lite";
+    case "LITE_V2":
+    case "LITE":
+      return "Lite (Legacy)";
+    case "PRO_V3":
+      return "Pro";
+    case "PRO_V2":
+    case "PRO":
+    case "PRO_LEGACY":
+      return "Pro (Legacy)";
+    case "PRO_PLUS":
+      return "Pro+ (Legacy)";
+    case "PRO_PLUS_V2":
+      return "Pro+";
+    case "ULTRA_1X_V3":
+      return "Ultra";
+    case "ULTRA_2X_V3":
+    case "ULTRA_3X_V3":
+    case "ULTRA_4X_V3":
+    case "ULTRA_5X_V3":
+      return "Ultra+";
+    default:
+      return titleCaseFromToken(
+        String(status).replace(VERSION_SUFFIX_PATTERN, ""),
+      );
+  }
 }
 
 /**

--- a/clients/gui-app/src/lib/auth/traycer-subscription-content.ts
+++ b/clients/gui-app/src/lib/auth/traycer-subscription-content.ts
@@ -56,47 +56,43 @@ export function isCreditBasedPricing(status: SubscriptionStatus): boolean {
 // it isn't a pricing-generation tag on an otherwise-equivalent tier.
 const VERSION_SUFFIX_PATTERN = /_V\d+$/;
 
+// Every `SubscriptionStatus` this client's protocol version knows about maps
+// to an exact label here. `Partial` (not a bare `Record`) so a status a
+// *newer* backend added that this older client build doesn't know about yet
+// (the protocol is versioned and runtime-negotiated - clients and the host
+// ship independently) still falls through to `subscriptionPlanLabel`'s
+// `titleCaseFromToken` fallback instead of a missing-key crash.
+const PLAN_LABELS: Partial<Record<SubscriptionStatus, string>> = {
+  FREE: "BYOA",
+  PENDING: "BYOA",
+  BYOA_V3: "Sync",
+  LITE_V3: "Lite",
+  LITE_V2: "Lite (Legacy)",
+  LITE: "Lite (Legacy)",
+  PRO_V3: "Pro",
+  PRO_V2: "Pro (Legacy)",
+  PRO: "Pro (Legacy)",
+  PRO_LEGACY: "Pro (Legacy)",
+  PRO_PLUS: "Pro+ (Legacy)",
+  PRO_PLUS_V2: "Pro+",
+  ULTRA_1X_V3: "Ultra",
+  ULTRA_2X_V3: "Ultra+",
+  ULTRA_3X_V3: "Ultra+",
+  ULTRA_4X_V3: "Ultra+",
+  ULTRA_5X_V3: "Ultra+",
+};
+
 /**
  * The Traycer plan/tier label for the selected account (Core Flows parity
  * with Codex/Claude: "shown where the provider reports one") - the header
  * popover's "Traycer" tab shows this as a chip next to the name, same as
  * `resolveProviderPlanLabel` does for the host-RPC providers.
  */
-//eslint-disable-next-line complexity
 export function subscriptionPlanLabel(status: SubscriptionStatus): string {
-  switch (status) {
-    case "FREE":
-    case "PENDING":
-      return "BYOA";
-    case "BYOA_V3":
-      return "Sync";
-    case "LITE_V3":
-      return "Lite";
-    case "LITE_V2":
-    case "LITE":
-      return "Lite (Legacy)";
-    case "PRO_V3":
-      return "Pro";
-    case "PRO_V2":
-    case "PRO":
-    case "PRO_LEGACY":
-      return "Pro (Legacy)";
-    case "PRO_PLUS":
-      return "Pro+ (Legacy)";
-    case "PRO_PLUS_V2":
-      return "Pro+";
-    case "ULTRA_1X_V3":
-      return "Ultra";
-    case "ULTRA_2X_V3":
-    case "ULTRA_3X_V3":
-    case "ULTRA_4X_V3":
-    case "ULTRA_5X_V3":
-      return "Ultra+";
-    default:
-      return titleCaseFromToken(
-        String(status).replace(VERSION_SUFFIX_PATTERN, ""),
-      );
-  }
+  return (
+    PLAN_LABELS[status] ??
+    titleCaseFromToken(String(status).replace(VERSION_SUFFIX_PATTERN, ""))
+  );
 }
 
 /**

--- a/clients/gui-app/src/lib/auth/traycer-subscription-content.ts
+++ b/clients/gui-app/src/lib/auth/traycer-subscription-content.ts
@@ -1,0 +1,194 @@
+/**
+ * Host/query-free logic for the signed-in user's Traycer subscription + credits,
+ * shared by the Settings › Providers › Traycer card
+ * (`traycer-subscription-section.tsx`) and the header rate-limit popover's
+ * "Traycer" tab (`rate-limit-popover.tsx`) - mirroring how
+ * `provider-rate-limit-content.ts` serves both the Settings card and the popover
+ * for the host-RPC providers. Pure functions only: the subscription itself comes
+ * from `useAuthUser`, and the selected account from `useAccountContextStore`, in
+ * the callers.
+ */
+import type { AccountContext } from "@traycer/protocol/common/schemas";
+import type {
+  AuthenticatedUser,
+  SubscriptionStatus,
+  TraycerTeamSubscription,
+  TraycerUserSubscription,
+} from "@traycer/protocol/auth";
+
+/** The account-scoped subscription arms the account-context store can select between. */
+export type TraycerSubscription =
+  TraycerUserSubscription | TraycerTeamSubscription;
+
+export const PERSONAL_VALUE = "personal";
+export const TEAM_VALUE_PREFIX = "team:";
+
+export function isPaid(status: SubscriptionStatus): boolean {
+  return status !== "FREE" && status !== "PENDING";
+}
+
+// V3 plans bill against credits; every other (legacy / v2) plan is rate-limit
+// based. Ported from an internal shared package's `isCreditBasedPricing`
+// (clients can't import that package). Credit plans → credit breakdown; the
+// rest → rate limit.
+const CREDIT_BASED_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
+  "FREE",
+  "LITE_V3",
+  "PRO_V3",
+  "ULTRA_1X_V3",
+  "ULTRA_2X_V3",
+  "ULTRA_3X_V3",
+  "ULTRA_4X_V3",
+  "ULTRA_5X_V3",
+  "BYOA_V3",
+]);
+
+export function isCreditBasedPricing(status: SubscriptionStatus): boolean {
+  return CREDIT_BASED_STATUSES.has(status);
+}
+
+/**
+ * Whether the Traycer rail tab should appear at all: the resolved account is on
+ * a paid plan, or holds an active credit bundle. Free/pending accounts with no
+ * bundle have nothing worth a dedicated tab.
+ */
+export function isTraycerEligible(subscription: TraycerSubscription): boolean {
+  return (
+    isPaid(subscription.subscriptionStatus) ||
+    subscription.hasActiveBundle === true
+  );
+}
+
+// Mirrors the extension's `formatRechargeRate`: minutes under a day, else days.
+export function formatRechargeRate(rechargeRateSeconds: number): string | null {
+  if (rechargeRateSeconds <= 0) return null;
+  const SECONDS_PER_DAY = 86_400;
+  const SECONDS_PER_MINUTE = 60;
+  if (rechargeRateSeconds < SECONDS_PER_DAY) {
+    const minutes = Math.round(rechargeRateSeconds / SECONDS_PER_MINUTE);
+    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  }
+  const days = Math.round(rechargeRateSeconds / SECONDS_PER_DAY);
+  return `${days} ${days === 1 ? "day" : "days"}`;
+}
+
+// Picks the subscription for the resolved context: the user's own, or the
+// matching team's. Null when the user isn't loaded or the team has no sub.
+export function selectSubscription(
+  user: AuthenticatedUser | null,
+  resolved: AccountContext,
+  teams: readonly TraycerTeamSubscription[],
+): TraycerSubscription | null {
+  if (user === null) return null;
+  if (resolved.type === "PERSONAL") return user.userSubscription;
+  return teams.find((t) => t.team.id === resolved.teamId) ?? null;
+}
+
+export function accountContextValue(context: AccountContext): string {
+  return context.type === "PERSONAL"
+    ? PERSONAL_VALUE
+    : `${TEAM_VALUE_PREFIX}${context.teamId}`;
+}
+
+export function parseAccountContextValue(value: string): AccountContext {
+  return value.startsWith(TEAM_VALUE_PREFIX)
+    ? { type: "TEAM", teamId: value.slice(TEAM_VALUE_PREFIX.length) }
+    : { type: "PERSONAL" };
+}
+
+// Artifact token counts aren't dollars - integers as-is, fractional usage to
+// 3dp, mirroring the extension's `${consumed.toFixed(3)} / ${totalTokens}`.
+export function formatArtifactTokens(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(3);
+}
+
+// $-denominated credits. ponytail: 2dp currency rather than the extension's odd
+// 3dp - decimals aren't part of the naming the user asked us to match.
+export function formatCredits(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+// Local mirror of the extension's `getCreditBreakdown` (the helper lives in
+// an internal shared package, which clients can't import). Three buckets -
+// Plan, Bonus, Bundle - tracked as consumed/total, matching the extension's
+// wording.
+export interface CreditBreakdown {
+  readonly planTotal: number;
+  readonly planConsumed: number;
+  readonly bonusTotal: number;
+  readonly bonusConsumed: number;
+  readonly bundleTotal: number;
+  readonly bundleConsumed: number;
+  readonly totalAvailable: number;
+  readonly totalConsumed: number;
+}
+
+export function creditBreakdown(
+  subscription: TraycerSubscription,
+): CreditBreakdown {
+  const credit = subscription.credit;
+  const planTotal = subscription.totalPlanCredits ?? 0;
+  const planRemaining = Math.max(
+    0,
+    planTotal - (credit?.consumedFromPlan ?? 0),
+  );
+  const planConsumed = Math.max(0, planTotal - planRemaining);
+  const bonusTotal = credit?.bonusCredits ?? 0;
+  const bonusConsumed = credit?.consumedFromBonus ?? 0;
+  const bundleTotal = subscription.bundleSummary?.bundleTotal ?? 0;
+  const bundleRemaining = subscription.bundleSummary?.bundleRemaining ?? 0;
+  const bundleConsumed = Math.max(0, bundleTotal - bundleRemaining);
+  return {
+    planTotal,
+    planConsumed,
+    bonusTotal,
+    bonusConsumed,
+    bundleTotal,
+    bundleConsumed,
+    totalAvailable: planTotal + bonusTotal + bundleTotal,
+    totalConsumed: planConsumed + bonusConsumed + bundleConsumed,
+  };
+}
+
+/**
+ * The popover Traycer block's display state - the same cold/error/degraded shape
+ * the host-RPC providers use (`resolvePopoverProviderRateLimitState`), but keyed
+ * off the identity query (`useAuthUser`) rather than a per-provider host pull:
+ *
+ * - `cold`: no user loaded yet and no failure -> skeleton.
+ * - `error`: no user loaded and the fetch failed -> retry message.
+ * - `empty`: the user loaded but the selected account has no subscription.
+ * - `ready`: a subscription is present. `degraded` is true when the latest
+ *   refetch failed while a last-known-good reading is still shown (dimmed).
+ *
+ * The aperture usage query (`useHostRateLimitUsageQuery`) is deliberately NOT an
+ * input here: it's best-effort supplementary data for rate-limit-based plans
+ * only, and its own failure surfaces inline as "usage unavailable" rather than
+ * blocking the whole tab.
+ */
+export type TraycerSubscriptionState =
+  | { readonly kind: "cold" }
+  | { readonly kind: "error" }
+  | { readonly kind: "empty" }
+  | {
+      readonly kind: "ready";
+      readonly subscription: TraycerSubscription;
+      readonly degraded: boolean;
+    };
+
+export function resolveTraycerSubscriptionState(args: {
+  readonly isPending: boolean;
+  readonly isError: boolean;
+  readonly subscription: TraycerSubscription | null;
+}): TraycerSubscriptionState {
+  if (args.subscription !== null) {
+    return {
+      kind: "ready",
+      subscription: args.subscription,
+      degraded: args.isError,
+    };
+  }
+  if (args.isError) return { kind: "error" };
+  if (args.isPending) return { kind: "cold" };
+  return { kind: "empty" };
+}

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -1,5 +1,14 @@
-import type { ProviderRateLimits } from "@traycer/protocol/host";
+import type {
+  ProviderRateLimits,
+  RateLimitUnavailableReason,
+} from "@traycer/protocol/host";
 import type { ProviderRateLimitQueryState } from "@/components/settings/panels/provider-rate-limit-views";
+
+/** The provider snapshot arms that actually carry usage detail. */
+type AvailableProviderRateLimits = Extract<
+  ProviderRateLimits,
+  { available: true }
+>;
 
 /**
  * The loading/error/empty/data branch every rate-limit surface needs.
@@ -35,4 +44,81 @@ export function hasProviderRateLimitContent(
   props: ProviderRateLimitQueryState,
 ): boolean {
   return resolveProviderRateLimitViewState(props).kind !== "empty";
+}
+
+// Exhaustive set of `reason` codes the host emits (`provider-rate-limits.ts`,
+// `rate-limits/{codex,claude,openrouter,kilocode}.ts`, `rate-limits/common.ts`)
+// - the wire field is a machine identifier, not display copy.
+// `Record<RateLimitUnavailableReason, string>` (not `Record<string, string>`)
+// makes this exhaustive at compile time: adding a reason to the protocol's
+// closed enum without adding a label here fails the build instead of silently
+// showing a raw, underscore-joined reason code. Homed here (a non-component
+// module) rather than in `provider-rate-limit-views.tsx` so both the Settings
+// card body and the header popover can share it without a plain-function export
+// breaking that file's React Fast Refresh component-boundary detection.
+const RATE_LIMIT_UNAVAILABLE_REASON_LABELS: Record<
+  RateLimitUnavailableReason,
+  string
+> = {
+  cli_not_found: "the CLI isn't installed",
+  unsupported_provider: "this provider isn't supported",
+  invalid_response: "the CLI returned an unexpected response",
+  timeout: "the request timed out",
+  connection_failed: "couldn't connect to the CLI",
+  sdk_incompatible: "this SDK version doesn't support rate limits",
+  rate_limits_not_available: "not available for this account",
+  insufficient_permissions:
+    "this account doesn't have permission to view usage",
+};
+
+export function formatUnavailableReason(
+  reason: RateLimitUnavailableReason,
+): string {
+  return RATE_LIMIT_UNAVAILABLE_REASON_LABELS[reason];
+}
+
+/**
+ * The header popover's per-provider display state - richer than
+ * `resolveProviderRateLimitViewState` (which the Settings card uses) because
+ * this surface distinguishes cold-load from degraded from never-fetched-error,
+ * each with its own treatment (Core Flows: skeleton bars / dimmed stale reading
+ * / plain-language error + retry):
+ *
+ * - `cold`: no data has ever arrived and no fetch has failed yet -> skeleton.
+ * - `error`: no data has ever arrived and the fetch failed (transport-level,
+ *   not a provider `available: false` response) -> generic retry message.
+ * - `unavailable`: the pull succeeded but the provider reports it can't surface
+ *   usage (CLI missing, wrong account, etc.) -> mapped plain-language message.
+ * - `ready`: usable snapshot present. `degraded` is true when the latest poll
+ *   failed but a last-known-good reading is still shown (dimmed).
+ */
+export type PopoverProviderRateLimitState =
+  | { readonly kind: "cold" }
+  | { readonly kind: "error" }
+  | {
+      readonly kind: "unavailable";
+      readonly reason: RateLimitUnavailableReason;
+    }
+  | {
+      readonly kind: "ready";
+      readonly data: AvailableProviderRateLimits;
+      readonly degraded: boolean;
+    };
+
+export function resolvePopoverProviderRateLimitState(
+  props: ProviderRateLimitQueryState,
+): PopoverProviderRateLimitState {
+  const snapshot = props.providerRateLimits ?? null;
+  if (snapshot === null) {
+    // Nothing usable yet: a failed first fetch is an error, otherwise it's
+    // still a cold load in flight (skeleton).
+    return props.isError ? { kind: "error" } : { kind: "cold" };
+  }
+  if (!snapshot.available) {
+    return { kind: "unavailable", reason: snapshot.reason };
+  }
+  // A last-known-good snapshot is present. `isError` here means the most recent
+  // (background) refetch failed while retaining this data - Core Flows' degraded
+  // state, shown dimmed rather than replaced.
+  return { kind: "ready", data: snapshot, degraded: props.isError };
 }

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -110,9 +110,15 @@ export function resolvePopoverProviderRateLimitState(
 ): PopoverProviderRateLimitState {
   const snapshot = props.providerRateLimits ?? null;
   if (snapshot === null) {
-    // Nothing usable yet: a failed first fetch is an error, otherwise it's
-    // still a cold load in flight (skeleton).
-    return props.isError ? { kind: "error" } : { kind: "cold" };
+    // Nothing usable yet. `isPending` alone stays `true` forever for a
+    // disabled query (e.g. a host that goes unreachable while this tab is
+    // open, mirroring `resolveProviderRateLimitViewState`'s same fix) - only
+    // treat it as a cold load in flight (skeleton) when a fetch is actually
+    // happening; a failed fetch, or a pending-but-not-fetching query that will
+    // never resolve on its own, both fall through to the retryable error copy.
+    return props.isPending && props.isFetching
+      ? { kind: "cold" }
+      : { kind: "error" };
   }
   if (!snapshot.available) {
     return { kind: "unavailable", reason: snapshot.reason };

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -128,3 +128,46 @@ export function resolvePopoverProviderRateLimitState(
   // state, shown dimmed rather than replaced.
   return { kind: "ready", data: snapshot, degraded: props.isError };
 }
+
+/**
+ * `SNAKE_CASE`/`snake_case` token → Title Case, for any enum value that isn't
+ * in one of the bespoke display-name maps elsewhere (a forward-compat
+ * fallback for values a backend adds before those maps update) - used for
+ * provider enum tokens (`provider-rate-limit-views.tsx`, which are already
+ * lowercase) and, directly from `rate-limit-popover.tsx`, Traycer's own
+ * `SubscriptionStatus` (e.g. `"ULTRA_1X_V3"`, upper-case), so the rest of
+ * each word is explicitly lower-cased rather than left as-is. Homed here (a
+ * non-component module) rather than a component file so callers can share it
+ * without a plain-function export breaking that file's React Fast Refresh
+ * component-boundary detection.
+ */
+export function titleCaseFromToken(value: string): string {
+  return value
+    .split("_")
+    .filter((word) => word.length > 0)
+    .map((word) => `${word[0].toUpperCase()}${word.slice(1).toLowerCase()}`)
+    .join(" ");
+}
+
+/**
+ * A provider's plan/tier label, where one is fetched - the header popover
+ * shows this as a chip next to the provider name (Core Flows: "where the
+ * provider reports one"). Only Codex (`planType`) and Claude Code
+ * (`subscriptionType`) currently report a plan/tier; OpenRouter and Kilo Code
+ * have no analogous field, so they always resolve to `null` and render no chip.
+ */
+export function resolveProviderPlanLabel(
+  data: AvailableProviderRateLimits,
+): string | null {
+  switch (data.provider) {
+    case "codex":
+      return data.planType !== null ? titleCaseFromToken(data.planType) : null;
+    case "claude-code":
+      return data.subscriptionType !== null
+        ? titleCaseFromToken(data.subscriptionType)
+        : null;
+    case "openrouter":
+    case "kilocode":
+      return null;
+  }
+}

--- a/clients/gui-app/src/lib/query-client.ts
+++ b/clients/gui-app/src/lib/query-client.ts
@@ -20,42 +20,54 @@ const SAFE_QUERY_KEY_MARKERS = new Set([
   "fileDiff",
 ]);
 
-export const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    onError: (error, query) => {
-      appLogger.warn("[query] request failed", {
-        queryKey: summarizeQueryKey(query.queryKey),
-        failureCount: query.state.fetchFailureCount,
-        fetchStatus: query.state.fetchStatus,
-        status: query.state.status,
-        error: describeLogErrorSummary(error),
-      });
+/**
+ * Builds a `QueryClient` with the app's production configuration. Exported
+ * (rather than only the singleton below) so integration tests can run against
+ * the exact defaults the app runs with - the global `staleTime` in particular
+ * changes `fetchQuery` semantics (it serves still-fresh cache without
+ * fetching), and a test-local bare `new QueryClient()` silently exercises a
+ * different behavior than production.
+ */
+export function createAppQueryClient(): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        appLogger.warn("[query] request failed", {
+          queryKey: summarizeQueryKey(query.queryKey),
+          failureCount: query.state.fetchFailureCount,
+          fetchStatus: query.state.fetchStatus,
+          status: query.state.status,
+          error: describeLogErrorSummary(error),
+        });
+      },
+    }),
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        appLogger.warn("[mutation] request failed", {
+          mutationKey: summarizeQueryKey(mutation.options.mutationKey ?? []),
+          failureCount: mutation.state.failureCount,
+          status: mutation.state.status,
+          error: describeLogErrorSummary(error),
+        });
+      },
+    }),
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+        // A `RetryableTransportError` has already been retried to exhaustion by
+        // the transport layer (`createRetryingMessenger`); retrying it again here
+        // multiplies the dial-timeout cost (transport attempts × query attempts).
+        // Let it surface immediately; everything else keeps the single retry.
+        retry: (failureCount, error) =>
+          !(error instanceof RetryableTransportError) && failureCount < 1,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+      },
     },
-  }),
-  mutationCache: new MutationCache({
-    onError: (error, _variables, _context, mutation) => {
-      appLogger.warn("[mutation] request failed", {
-        mutationKey: summarizeQueryKey(mutation.options.mutationKey ?? []),
-        failureCount: mutation.state.failureCount,
-        status: mutation.state.status,
-        error: describeLogErrorSummary(error),
-      });
-    },
-  }),
-  defaultOptions: {
-    queries: {
-      staleTime: 60 * 1000,
-      // A `RetryableTransportError` has already been retried to exhaustion by
-      // the transport layer (`createRetryingMessenger`); retrying it again here
-      // multiplies the dial-timeout cost (transport attempts × query attempts).
-      // Let it surface immediately; everything else keeps the single retry.
-      retry: (failureCount, error) =>
-        !(error instanceof RetryableTransportError) && failureCount < 1,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-    },
-  },
-});
+  });
+}
+
+export const queryClient = createAppQueryClient();
 
 function summarizeQueryKey(queryKey: QueryKey): AppLogValue {
   return queryKey.slice(0, 4).map((part) => {

--- a/clients/gui-app/src/lib/rate-limit-providers.ts
+++ b/clients/gui-app/src/lib/rate-limit-providers.ts
@@ -1,4 +1,7 @@
-import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import type {
+  ProviderCliState,
+  ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
 import {
   rateLimitCapableProviderIdSchema,
   type RateLimitCapableProviderId,
@@ -15,8 +18,87 @@ import {
  */
 export type RateLimitProviderId = RateLimitCapableProviderId;
 
+/**
+ * Fetch cost class for a rate-limit-capable provider - the load-bearing split
+ * the polling scheduler branches on:
+ *
+ * - `"httpFetch"`: the host resolves a credential it already has and issues a
+ *   plain GET (openrouter, kilocode). Cheap and safe to run concurrently, so
+ *   these poll on their own independent `refetchInterval` and never enter the
+ *   serial queue.
+ * - `"ephemeralProcess"`: the host spawns a real CLI subprocess to read usage
+ *   (codex, claude-code). Expensive; these are funnelled through a shared
+ *   serial queue so an interval tick, a manual refresh, and a turn completion
+ *   can never spawn overlapping subprocesses.
+ */
+export type RateLimitFetchLane = "httpFetch" | "ephemeralProcess";
+
+/**
+ * Shared "how fresh is fresh enough" floor for provider rate-limit reads: the
+ * `staleTime` on the provider rate-limit query, the minimum spacing the
+ * turn-completion refresh hook enforces, and the queue's own automatic-trigger
+ * cooldown. Unlike the aperture read (a cheap cloud call), an
+ * `ephemeralProcess` pull spawns a real CLI subprocess, so a burst of triggers
+ * (a queued run finishing, an interval tick landing next to a turn completion)
+ * must not each spawn their own.
+ *
+ * Homed here - alongside the lane classifier it is conceptually paired with -
+ * rather than in the turn-completion hook, so the queue module, the query
+ * options, and that hook can all read it without an import cycle.
+ */
+export const PROVIDER_RATE_LIMITS_STALE_TIME_MS = 30_000;
+
 export function isRateLimitCapableProvider(
   providerId: ProviderId,
 ): providerId is RateLimitProviderId {
   return rateLimitCapableProviderIdSchema.safeParse(providerId).success;
+}
+
+/**
+ * The one named home for the provider -> lane mapping. Load-bearing in the
+ * query options (which lane gets a `refetchInterval`), the turn-completion
+ * refresh hook (which trigger routes through the serial queue), and the
+ * interval timer (which providers it walks) - so it lives here once rather
+ * than being re-derived at each of those three sites.
+ */
+export function rateLimitFetchLane(
+  providerId: RateLimitProviderId,
+): RateLimitFetchLane {
+  switch (providerId) {
+    case "openrouter":
+    case "kilocode":
+      return "httpFetch";
+    case "codex":
+    case "claude-code":
+      return "ephemeralProcess";
+  }
+}
+
+/**
+ * Whether `state` currently reports valid credentials for a rate-limit pull -
+ * the gate both polling lanes share, read from the same `providers.list` auth
+ * state the popover rail keys off. A provider enters a lane only while this is
+ * `true`; because these subscriptions are now persistent (app-shell level, not
+ * the transient Settings card that re-gates on every mount), a credential
+ * removed mid-session drops the provider out on the very next tick.
+ *
+ * - `authPending` / `availabilityPending`: the host has not settled a verdict
+ *   yet, so acting on the row would be premature - treated as not-yet-eligible.
+ * - `"authenticated"`: verified good credentials.
+ * - `"configured"`: credentials are present but unverified (e.g. an API key set
+ *   for openrouter/kilocode before the first probe) - included because the pull
+ *   itself is what verifies them, and it degrades gracefully if they are bad.
+ * - `"unauthenticated"` / `"unavailable"` / `"unknown"`: no usable credential
+ *   to authenticate a usage call, so the provider is not polled.
+ * - `enabled: false`: the user turned the provider off; don't spend a fetch on
+ *   a provider they have disabled.
+ */
+export function isRateLimitProviderConfigured(
+  state: ProviderCliState,
+): boolean {
+  if (!state.enabled) return false;
+  if (state.authPending || state.availabilityPending) return false;
+  return (
+    state.auth.status === "authenticated" || state.auth.status === "configured"
+  );
 }

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * End-to-end proof that an `enqueueRateLimitFetch` call actually flips
+ * `isFetching` on an already-mounted `useHostProviderRateLimitsQuery`
+ * observer for the same provider - the mechanism `RateLimitProviderBlock`'s
+ * per-provider refresh icon and `RateLimitRefreshAllButton` both depend on to
+ * stay in sync. Uses a real `HostClient` + `MockHostMessenger` (not a fully
+ * mocked query hook) so this exercises the real query-key derivation on both
+ * sides, not just TanStack's own sharing semantics in isolation.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import {
+  __resetRateLimitQueueForTests,
+  configureRateLimitQueue,
+  enqueueRateLimitFetch,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+function makeControllableResponse() {
+  let resolveFn: (() => void) | null = null;
+  const promise = new Promise<void>((resolve) => {
+    resolveFn = resolve;
+  });
+  return {
+    promise,
+    resolve: () => resolveFn?.(),
+  };
+}
+
+describe("enqueueRateLimitFetch keeps a mounted useHostProviderRateLimitsQuery observer's isFetching in sync", () => {
+  afterEach(() => {
+    cleanup();
+    __resetRateLimitQueueForTests();
+  });
+
+  it("flips isFetching true on the observer while a force:true enqueue is in flight, then false once it settles", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    let callCount = 0;
+    const pending = { current: makeControllableResponse() };
+    const client = new HostClient<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      invalidator: createHostQueryInvalidator(queryClient),
+      messenger: new MockHostMessenger<HostRpcRegistry>({
+        registry: hostRpcRegistry,
+        requestId: () => "req-1",
+        handlers: {
+          "host.getRateLimitUsage": async () => {
+            callCount += 1;
+            if (callCount === 1) {
+              return {
+                totalTokens: 0,
+                remainingTokens: 0,
+                providerRateLimits: null,
+              };
+            }
+            await pending.current.promise;
+            return {
+              totalTokens: 0,
+              remainingTokens: 0,
+              providerRateLimits: null,
+            };
+          },
+        },
+      }),
+    });
+    client.bind(mockLocalHostEntry);
+    client.setRequestContext(
+      createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
+    );
+
+    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+    const { method, params, options } = providerRateLimitQueryOptions("codex");
+    const rendered = renderHook(
+      () => useHostQuery({ client, method, params, options }),
+      { wrapper: Wrapper },
+    );
+
+    // Let the initial mount fetch settle (callCount === 1, resolves immediately).
+    await waitFor(() => expect(rendered.result.current.isPending).toBe(false));
+    expect(rendered.result.current.isFetching).toBe(false);
+
+    configureRateLimitQueue({
+      hostId: mockLocalHostEntry.hostId,
+      queryClient,
+      request: (_hostId, rpcMethod, rpcParams) =>
+        client.request(rpcMethod, rpcParams),
+    });
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+
+    // The second call is the one that blocks on `pending` - the observer
+    // mounted independently of the queue must see this as in flight.
+    await waitFor(() => expect(rendered.result.current.isFetching).toBe(true));
+
+    pending.current.resolve();
+    await waitFor(() => expect(rendered.result.current.isFetching).toBe(false));
+  });
+});

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
@@ -3,22 +3,16 @@
  * `isFetching` on an already-mounted `useHostProviderRateLimitsQuery`
  * observer for the same provider - the mechanism `RateLimitProviderBlock`'s
  * per-provider refresh icon and `RateLimitRefreshAllButton` both depend on to
- * stay in sync. Uses a real `HostClient` + `MockHostMessenger` (not a fully
- * mocked query hook) so this exercises the real query-key derivation on both
- * sides, not just TanStack's own sharing semantics in isolation.
+ * stay in sync. Uses the shared harness's real `HostClient` +
+ * `MockHostMessenger` and PRODUCTION QueryClient configuration: this exact
+ * flow - data freshly loaded, then a force:true enqueue - is where the
+ * inherited global staleTime silently no-oped the real app's refresh while a
+ * bare staleTime-0 test client passed.
  */
 import { afterEach, describe, expect, it } from "vitest";
-import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
-import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
-import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
-import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
-import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
-import { createAppQueryClient } from "@/lib/query-client";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
 import {
@@ -26,17 +20,10 @@ import {
   configureRateLimitQueue,
   enqueueRateLimitFetch,
 } from "@/lib/rate-limits/ephemeral-fetch-queue";
-
-function makeControllableResponse() {
-  let resolveFn: (() => void) | null = null;
-  const promise = new Promise<void>((resolve) => {
-    resolveFn = resolve;
-  });
-  return {
-    promise,
-    resolve: () => resolveFn?.(),
-  };
-}
+import {
+  createQueryClientWrapper,
+  createRateLimitSharingHarness,
+} from "@/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness";
 
 describe("enqueueRateLimitFetch keeps a mounted useHostProviderRateLimitsQuery observer's isFetching in sync", () => {
   afterEach(() => {
@@ -45,76 +32,33 @@ describe("enqueueRateLimitFetch keeps a mounted useHostProviderRateLimitsQuery o
   });
 
   it("flips isFetching true on the observer while a force:true enqueue is in flight, then false once it settles", async () => {
-    // Production QueryClient configuration, not a bare test one: the global
-    // `staleTime` default changes `fetchQuery` semantics (it serves
-    // still-fresh cache without fetching), and this exact flow - data freshly
-    // loaded, then a force:true enqueue - is where that difference silently
-    // no-oped the real app's refresh while a staleTime-0 test client passed.
-    const queryClient = createAppQueryClient();
-    let callCount = 0;
-    const pending = { current: makeControllableResponse() };
-    const client = new HostClient<HostRpcRegistry>({
-      registry: hostRpcRegistry,
-      invalidator: createHostQueryInvalidator(queryClient),
-      messenger: new MockHostMessenger<HostRpcRegistry>({
-        registry: hostRpcRegistry,
-        requestId: () => "req-1",
-        handlers: {
-          "host.getRateLimitUsage": async () => {
-            callCount += 1;
-            if (callCount === 1) {
-              return {
-                totalTokens: 0,
-                remainingTokens: 0,
-                providerRateLimits: null,
-              };
-            }
-            await pending.current.promise;
-            return {
-              totalTokens: 0,
-              remainingTokens: 0,
-              providerRateLimits: null,
-            };
-          },
-        },
-      }),
-    });
-    client.bind(mockLocalHostEntry);
-    client.setRequestContext(
-      createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
-    );
-
-    const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
-      <QueryClientProvider client={queryClient}>
-        {props.children}
-      </QueryClientProvider>
-    );
+    const harness = createRateLimitSharingHarness();
     const { method, params, options } = providerRateLimitQueryOptions("codex");
     const rendered = renderHook(
-      () => useHostQuery({ client, method, params, options }),
-      { wrapper: Wrapper },
+      () => useHostQuery({ client: harness.client, method, params, options }),
+      { wrapper: createQueryClientWrapper(harness.queryClient) },
     );
 
-    // Let the initial mount fetch settle (callCount === 1, resolves immediately).
+    // Let the initial mount fetch settle (the harness resolves it immediately).
     await waitFor(() => expect(rendered.result.current.isPending).toBe(false));
     expect(rendered.result.current.isFetching).toBe(false);
 
     configureRateLimitQueue({
       hostId: mockLocalHostEntry.hostId,
-      queryClient,
+      queryClient: harness.queryClient,
       request: (_hostId, rpcMethod, rpcParams) =>
-        client.request(rpcMethod, rpcParams),
+        harness.client.request(rpcMethod, rpcParams),
     });
 
     void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
       force: true,
     });
 
-    // The second call is the one that blocks on `pending` - the observer
-    // mounted independently of the queue must see this as in flight.
+    // The second call is the one the harness blocks - the observer mounted
+    // independently of the queue must see this as in flight.
     await waitFor(() => expect(rendered.result.current.isFetching).toBe(true));
 
-    pending.current.resolve();
+    harness.resolvePendingResponse();
     await waitFor(() => expect(rendered.result.current.isFetching).toBe(false));
   });
 });

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
@@ -8,7 +8,7 @@
  * sides, not just TanStack's own sharing semantics in isolation.
  */
 import { afterEach, describe, expect, it } from "vitest";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -18,6 +18,7 @@ import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtur
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { createAppQueryClient } from "@/lib/query-client";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
 import {
@@ -44,9 +45,12 @@ describe("enqueueRateLimitFetch keeps a mounted useHostProviderRateLimitsQuery o
   });
 
   it("flips isFetching true on the observer while a force:true enqueue is in flight, then false once it settles", async () => {
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    // Production QueryClient configuration, not a bare test one: the global
+    // `staleTime` default changes `fetchQuery` semantics (it serves
+    // still-fresh cache without fetching), and this exact flow - data freshly
+    // loaded, then a force:true enqueue - is where that difference silently
+    // no-oped the real app's refresh while a staleTime-0 test client passed.
+    const queryClient = createAppQueryClient();
     let callCount = 0;
     const pending = { current: makeControllableResponse() };
     const client = new HostClient<HostRpcRegistry>({

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
@@ -1,0 +1,230 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { queryKeys } from "@/lib/query-keys";
+import type { HostRpcRegistry } from "@/lib/host";
+import {
+  __resetRateLimitQueueForTests,
+  configureRateLimitQueue,
+  enqueueRateLimitFetch,
+  isRateLimitQueueDraining,
+  subscribeRateLimitQueueDraining,
+  type RateLimitQueueRequestFn,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+const HOST_ID = "host-1";
+
+// A minimal valid `host.getRateLimitUsage @1.2` response - only the ordering of
+// `request` calls matters to these tests, not the payload.
+function response() {
+  return { totalTokens: 0, remainingTokens: 0, providerRateLimits: null };
+}
+
+function keyFor(providerId: ProviderId) {
+  return queryKeys.hostMethod<HostRpcRegistry, "host.getRateLimitUsage">(
+    HOST_ID,
+    "host.getRateLimitUsage",
+    { accountContext: DEFAULT_ACCOUNT_CONTEXT, providerId },
+  );
+}
+
+// A `request` double whose promises settle only when the test explicitly
+// releases them, so we can observe how many are in flight at any moment.
+function makeControllableRequest() {
+  const calls: Array<ProviderId | undefined> = [];
+  const settlers: Array<{ ok: () => void; fail: () => void }> = [];
+  const request: RateLimitQueueRequestFn = (_hostId, _method, params) => {
+    calls.push(params.providerId);
+    return new Promise((resolve, reject) => {
+      settlers.push({
+        ok: () => resolve(response()),
+        fail: () => reject(new Error("boom")),
+      });
+    });
+  };
+  return { request: vi.fn(request), calls, settlers };
+}
+
+function newQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+// Flush pending microtasks/callbacks so `fetchQuery` has a chance to invoke the
+// queued `queryFn`. Real timers are in effect for these tests.
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("ephemeral-fetch-queue", () => {
+  beforeEach(() => {
+    __resetRateLimitQueueForTests();
+  });
+  afterEach(() => {
+    __resetRateLimitQueueForTests();
+  });
+
+  it("serializes concurrent enqueues across providers - only one request is ever in flight (guardrail 1)", async () => {
+    const queryClient = newQueryClient();
+    const { request, calls, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    // Fire two ephemeralProcess providers concurrently, as a rapid "Refresh all"
+    // across providers would. Force bypasses the freshness floor.
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+
+    await flush();
+    // Despite two concurrent enqueues, only the first provider's request has
+    // started - the second is queued behind it, not spawned in parallel.
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["codex"]);
+
+    // Release the first; only now may the second run.
+    settlers[0].ok();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(["codex", "claude-code"]);
+
+    settlers[1].ok();
+    await flush();
+  });
+
+  it("serializes many rapid same-provider force refreshes one at a time", async () => {
+    const queryClient = newQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    for (let i = 0; i < 4; i++) {
+      void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+        force: true,
+      });
+    }
+
+    await flush();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    settlers[0].ok();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(2);
+
+    settlers[1].ok();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(3);
+
+    settlers[2].ok();
+    settlers[3]?.ok();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(4);
+  });
+
+  it("writes into the same query key the per-provider hook reads", async () => {
+    const queryClient = newQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    await flush();
+    settlers[0].ok();
+    await flush();
+
+    expect(queryClient.getQueryState(keyFor("codex"))?.data).toEqual(
+      response(),
+    );
+  });
+
+  it("force: false no-ops when cached data is still within the freshness floor, force: true bypasses it", async () => {
+    const queryClient = newQueryClient();
+    const { request } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    // Seed fresh data (dataUpdatedAt = now) into the provider's key.
+    queryClient.setQueryData(keyFor("codex"), response());
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    await flush();
+    // Still fresh -> the automatic trigger must not spawn a subprocess.
+    expect(request).not.toHaveBeenCalled();
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    await flush();
+    // A user-initiated refresh bypasses the floor.
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("one provider's failure does not block the next provider's turn", async () => {
+    const queryClient = newQueryClient();
+    const { request, calls, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+
+    await flush();
+    settlers[0].fail();
+    await flush();
+    // The rejection was swallowed by the chain; the queue advanced to the next.
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(["codex", "claude-code"]);
+
+    settlers[1].ok();
+    await flush();
+    expect(isRateLimitQueueDraining()).toBe(false);
+  });
+
+  it("exposes an external-store draining signal that flips with in-flight work", async () => {
+    const queryClient = newQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    const notified: boolean[] = [];
+    const unsubscribe = subscribeRateLimitQueueDraining(() => {
+      notified.push(isRateLimitQueueDraining());
+    });
+
+    expect(isRateLimitQueueDraining()).toBe(false);
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    // Draining flips true synchronously at enqueue, before any await.
+    expect(isRateLimitQueueDraining()).toBe(true);
+    expect(notified.at(-1)).toBe(true);
+
+    await flush();
+    settlers[0].ok();
+    await flush();
+
+    expect(isRateLimitQueueDraining()).toBe(false);
+    expect(notified.at(-1)).toBe(false);
+
+    unsubscribe();
+  });
+
+  it("no-ops (never calls request) while the queue is unconfigured", async () => {
+    const { request } = makeControllableRequest();
+    // No configureRateLimitQueue call.
+    await enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    await flush();
+    expect(request).not.toHaveBeenCalled();
+    expect(isRateLimitQueueDraining()).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 import { queryKeys } from "@/lib/query-keys";
+import { createAppQueryClient } from "@/lib/query-client";
 import type { HostRpcRegistry } from "@/lib/host";
 import {
   __resetRateLimitQueueForTests,
@@ -215,6 +216,66 @@ describe("ephemeral-fetch-queue", () => {
     expect(notified.at(-1)).toBe(false);
 
     unsubscribe();
+  });
+
+  it("force: true actually refetches fresh-cached data under the app QueryClient's global staleTime", async () => {
+    // THE regression that made "Refresh all" look broken in the real app while
+    // every test passed: `fetchQuery` inherits the QueryClient's GLOBAL
+    // `staleTime` default (60s in the app's `query-client.ts`) and serves
+    // still-fresh cache without fetching. The popover's open-time refresh
+    // keeps provider data younger than 60s, so a user's `force: true` refresh
+    // resolved from cache in a microtask - no subprocess, no `isFetching`, a
+    // sub-frame `draining` blip - while the httpFetch lane's
+    // `invalidateQueries` (which always refetches) visibly spun. Every prior
+    // test built a bare `new QueryClient()` (staleTime 0), where `fetchQuery`
+    // always fetches - so the suite exercised semantics the app doesn't run.
+    // This test runs the production configuration.
+    const queryClient = createAppQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    // Seed fresh data (dataUpdatedAt = now), as the popover's open-time
+    // refresh does moments before the user clicks.
+    queryClient.setQueryData(keyFor("codex"), response());
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    expect(isRateLimitQueueDraining()).toBe(true);
+    await flush();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    settlers[0].ok();
+    await flush();
+    expect(isRateLimitQueueDraining()).toBe(false);
+  });
+
+  it("an automatic (force: false) enqueue re-checks freshness at its turn in the lane, not just at enqueue time", async () => {
+    // With `staleTime: 0` on the queue's own `fetchQuery`, the accidental
+    // dedupe the inherited global staleTime used to provide is gone - so the
+    // queue re-checks the freshness floor when a queued automatic fetch's
+    // turn arrives. An automatic trigger enqueued behind a fetch for the same
+    // provider must not re-spawn a subprocess for data that just became fresh.
+    const queryClient = createAppQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    // No cached data yet: both pass their enqueue-time freshness check.
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    await flush();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    settlers[0].ok();
+    await flush();
+    // The automatic turn found the data fresh (the forced fetch just wrote
+    // it) and skipped instead of spawning a second subprocess.
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(isRateLimitQueueDraining()).toBe(false);
   });
 
   it("no-ops (never calls request) while the queue is unconfigured", async () => {

--- a/clients/gui-app/src/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness.tsx
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness.tsx
@@ -1,0 +1,82 @@
+/**
+ * Shared wiring for the two "does a cache-level refresh trigger flip a
+ * mounted observer's isFetching" integration tests (the ephemeral queue's
+ * `enqueueRateLimitFetch` and the httpFetch lane's `invalidateQueries`).
+ * Not a `.test` file - vitest only collects `*.test.ts(x)`.
+ *
+ * Builds the production QueryClient configuration (`createAppQueryClient` -
+ * the global staleTime default changes fetch semantics, see that factory's
+ * doc comment) around a real `HostClient` + `MockHostMessenger` whose
+ * `host.getRateLimitUsage` handler resolves the FIRST call immediately (the
+ * observer's initial mount fetch) and blocks every later call until the test
+ * releases it via `resolvePendingResponse`.
+ */
+import type { ReactNode } from "react";
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { createAppQueryClient } from "@/lib/query-client";
+
+interface RateLimitSharingHarness {
+  readonly queryClient: QueryClient;
+  readonly client: HostClient<HostRpcRegistry>;
+  /** Releases every `host.getRateLimitUsage` call after the first. */
+  readonly resolvePendingResponse: () => void;
+}
+
+// A minimal valid `host.getRateLimitUsage @1.2` response - only fetch timing
+// matters to these tests, not the payload.
+function response() {
+  return { totalTokens: 0, remainingTokens: 0, providerRateLimits: null };
+}
+
+export function createRateLimitSharingHarness(): RateLimitSharingHarness {
+  const queryClient = createAppQueryClient();
+  let callCount = 0;
+  let resolvePending: (() => void) | null = null;
+  const pending = new Promise<void>((resolve) => {
+    resolvePending = resolve;
+  });
+  const client = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: createHostQueryInvalidator(queryClient),
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => "req-1",
+      handlers: {
+        "host.getRateLimitUsage": async () => {
+          callCount += 1;
+          if (callCount === 1) return response();
+          await pending;
+          return response();
+        },
+      },
+    }),
+  });
+  client.bind(mockLocalHostEntry);
+  client.setRequestContext(
+    createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
+  );
+  return {
+    queryClient,
+    client,
+    resolvePendingResponse: () => resolvePending?.(),
+  };
+}
+
+export function createQueryClientWrapper(
+  queryClient: QueryClient,
+): (props: { readonly children: ReactNode }) => ReactNode {
+  return function Wrapper(props: { readonly children: ReactNode }): ReactNode {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+  };
+}

--- a/clients/gui-app/src/lib/rate-limits/__tests__/window-severity.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/window-severity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  rateLimitWindowFillPercent,
+  rateLimitWindowSeverity,
+  rateLimitWindowSeverityBarClassName,
+} from "@/lib/rate-limits/window-severity";
+
+describe("rateLimitWindowSeverity", () => {
+  it("returns green at 0% used (100% available)", () => {
+    expect(rateLimitWindowSeverity(0)).toBe("green");
+    // A clock-skewed negative reading still reads as fully available.
+    expect(rateLimitWindowSeverity(-5)).toBe("green");
+  });
+
+  it("returns blue above 0% and under 60% used", () => {
+    expect(rateLimitWindowSeverity(0.1)).toBe("blue");
+    expect(rateLimitWindowSeverity(59.9)).toBe("blue");
+  });
+
+  it("returns yellow for 60-85% used, inclusive of both bounds", () => {
+    expect(rateLimitWindowSeverity(60)).toBe("yellow");
+    expect(rateLimitWindowSeverity(70)).toBe("yellow");
+    expect(rateLimitWindowSeverity(85)).toBe("yellow");
+  });
+
+  it("returns red over 85% used", () => {
+    expect(rateLimitWindowSeverity(85.1)).toBe("red");
+    expect(rateLimitWindowSeverity(100)).toBe("red");
+  });
+});
+
+describe("rateLimitWindowSeverityBarClassName", () => {
+  it("maps each severity to a distinct fill color", () => {
+    expect(rateLimitWindowSeverityBarClassName("green")).toContain("green-500");
+    expect(rateLimitWindowSeverityBarClassName("blue")).toContain("blue-500");
+    expect(rateLimitWindowSeverityBarClassName("yellow")).toContain(
+      "yellow-500",
+    );
+    expect(rateLimitWindowSeverityBarClassName("red")).toContain("red-500");
+  });
+});
+
+describe("rateLimitWindowFillPercent", () => {
+  it("fills the whole track at 0% used (or below) for the full green bar", () => {
+    expect(rateLimitWindowFillPercent(0)).toBe(100);
+    expect(rateLimitWindowFillPercent(-3)).toBe(100);
+  });
+
+  it("tracks the real used percentage otherwise, clamped to [0, 100]", () => {
+    expect(rateLimitWindowFillPercent(40)).toBe(40);
+    expect(rateLimitWindowFillPercent(85)).toBe(85);
+    expect(rateLimitWindowFillPercent(150)).toBe(100);
+  });
+});

--- a/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
+++ b/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
@@ -1,0 +1,162 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { AccountContext } from "@traycer/protocol/common/schemas";
+import type {
+  RequestOfMethod,
+  ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostRpcRegistry } from "@/lib/host";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+/**
+ * Shared serial fetch lane for the `ephemeralProcess` rate-limit providers
+ * (codex, claude-code) - the only providers this queue serves. Each of their
+ * pulls spawns a real CLI subprocess on the host, so every trigger that can
+ * cause one (the interval timer, a turn completion, a manual "Refresh all")
+ * routes through here to guarantee **at most one subprocess-spawning fetch is
+ * in flight at a time**, no matter how many providers or how fast the clicks.
+ *
+ * `httpFetch` providers (openrouter, kilocode) NEVER touch this queue - they
+ * poll directly via their query's own `refetchInterval`.
+ *
+ * The queue is a plain module holding process-wide state, wired up once from a
+ * long-lived app-shell component (`RateLimitQueueProvider`) via
+ * `configureRateLimitQueue`. The `QueryClient`, host client `request`, and the
+ * default `hostId` are passed in from that React call site rather than reached
+ * for here - `hostId` is bound at configure time (re-bound whenever the default
+ * host changes) so an enqueue can't race a host swap mid-flight: a queued fetch
+ * always writes into the query key of the host it was enqueued for.
+ */
+
+type RateLimitUsageParams = RequestOfMethod<
+  HostRpcRegistry,
+  "host.getRateLimitUsage"
+>;
+type RateLimitUsageResponse = ResponseOfMethod<
+  HostRpcRegistry,
+  "host.getRateLimitUsage"
+>;
+
+export type RateLimitQueueRequestFn = (
+  hostId: string,
+  method: "host.getRateLimitUsage",
+  params: RateLimitUsageParams,
+) => Promise<RateLimitUsageResponse>;
+
+export interface RateLimitQueueConfig {
+  readonly hostId: string;
+  readonly queryClient: QueryClient;
+  readonly request: RateLimitQueueRequestFn;
+}
+
+let deps: RateLimitQueueConfig | null = null;
+// The serial lane itself: every enqueued fetch appends to the tail of this
+// promise chain, so fetch N+1's `fetchQuery` cannot start until fetch N settles.
+let chain: Promise<unknown> = Promise.resolve();
+let inFlightCount = 0;
+const drainingListeners = new Set<() => void>();
+
+function notifyDraining(): void {
+  for (const listener of drainingListeners) listener();
+}
+
+/**
+ * Bind (or, with `null`, unbind) the queue to the default host. Called once
+ * from an app-shell `useEffect` that re-runs on default-host / client change,
+ * and passes `null` on host loss so a stale client can't service an enqueue.
+ */
+export function configureRateLimitQueue(
+  next: RateLimitQueueConfig | null,
+): void {
+  deps = next;
+}
+
+/**
+ * `useSyncExternalStore`-compatible pair for the "a subprocess fetch is
+ * running" signal - a bare promise chain isn't React-observable on its own.
+ * The popover consumes this (via `useIsRateLimitQueueDraining`) to disable
+ * "Refresh all" while the lane is draining.
+ */
+export function subscribeRateLimitQueueDraining(
+  listener: () => void,
+): () => void {
+  drainingListeners.add(listener);
+  return () => {
+    drainingListeners.delete(listener);
+  };
+}
+
+export function isRateLimitQueueDraining(): boolean {
+  return inFlightCount > 0;
+}
+
+/**
+ * Append a rate-limit pull for one `ephemeralProcess` provider to the serial
+ * lane. Returns the tail of the chain so a caller ("Refresh all") can await the
+ * lane draining.
+ *
+ * - `force: false` (interval timer, turn completion): no-op if the query's
+ *   cached data is younger than `PROVIDER_RATE_LIMITS_STALE_TIME_MS`, so
+ *   automatic triggers don't re-spawn a subprocess for still-fresh data.
+ * - `force: true` (user-initiated refresh): always fetches, bypassing that
+ *   floor - a manual refresh must never silently no-op.
+ *
+ * No-ops (returning the current chain) while the queue is unconfigured, mirroring
+ * the host-readiness `enabled` gate the per-provider query uses.
+ */
+export function enqueueRateLimitFetch(
+  providerId: RateLimitProviderId,
+  accountContext: AccountContext,
+  opts: { readonly force: boolean },
+): Promise<unknown> {
+  const current = deps;
+  if (current === null) return chain;
+  const { hostId, queryClient, request } = current;
+  const params: RateLimitUsageParams = { accountContext, providerId };
+  const queryKey = queryKeys.hostMethod<
+    HostRpcRegistry,
+    "host.getRateLimitUsage"
+  >(hostId, "host.getRateLimitUsage", params);
+
+  if (!opts.force) {
+    const updatedAt = queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0;
+    if (Date.now() - updatedAt < PROVIDER_RATE_LIMITS_STALE_TIME_MS) {
+      return chain;
+    }
+  }
+
+  // Named request fn (not an inline closure in `queryFn`) so the host-scoped
+  // key stays the sole cache identity - `request` is stable module state, not a
+  // key input, and inlining it would trip the query plugin's exhaustive-deps
+  // check (mirrors `resolve-artifact-by-path.ts`).
+  const queryFn = (): Promise<RateLimitUsageResponse> =>
+    request(hostId, "host.getRateLimitUsage", params);
+
+  inFlightCount += 1;
+  notifyDraining();
+  chain = chain
+    .then(() => queryClient.fetchQuery({ queryKey, queryFn }))
+    // One provider's failure must not block the next provider's turn in the
+    // lane, and must not reject the shared chain (which every future enqueue
+    // builds on).
+    .catch(() => undefined)
+    .finally(() => {
+      inFlightCount -= 1;
+      notifyDraining();
+    });
+  return chain;
+}
+
+/**
+ * Test-only reset of the module-global lane state so each test starts from a
+ * clean queue (no bound host, empty chain, zero in-flight, no listeners).
+ */
+export function __resetRateLimitQueueForTests(): void {
+  deps = null;
+  chain = Promise.resolve();
+  inFlightCount = 0;
+  drainingListeners.clear();
+}

--- a/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
+++ b/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
@@ -59,6 +59,40 @@ let chain: Promise<unknown> = Promise.resolve();
 let inFlightCount = 0;
 const drainingListeners = new Set<() => void>();
 
+/**
+ * Dev-only (Vite HMR) self-healing for this module's singleton state. An HMR
+ * update that re-executes this module - an edit to it or to anything in its
+ * import chain (`query-keys`, `rate-limit-providers`, `@/lib/host`, ...) -
+ * creates a fresh instance with `deps = null`. `RateLimitQueueProvider`'s
+ * configure effect does not re-run for a bubbled invalidation (its component
+ * and effect deps are unchanged), so nothing would rebind the fresh instance:
+ * every enqueue silently no-ops - buttons stop coordinating, manual refreshes
+ * do nothing - until a full window reload, while the old instance keeps
+ * servicing the interval timer's stale closure so data still looks live.
+ * Carrying the binding across HMR generations closes that gap. Tree-shaken
+ * out of production builds (`import.meta.hot` is statically false there).
+ */
+interface RateLimitQueueHotData {
+  rateLimitQueueDeps?: RateLimitQueueConfig | null;
+}
+// Vite types `hot.data` as `any`; the `unknown` hop + structural guard keeps
+// the read type-safe. The guard also handles Vitest, whose truthy
+// `import.meta.hot` stub carries no `data` object, unlike Vite's dev server.
+function isRateLimitQueueHotData(
+  value: unknown,
+): value is RateLimitQueueHotData {
+  return typeof value === "object" && value !== null;
+}
+const hot = import.meta.hot;
+const hotData: unknown = hot?.data;
+if (hot !== undefined && isRateLimitQueueHotData(hotData)) {
+  const carried = hotData.rateLimitQueueDeps;
+  if (carried !== undefined) deps = carried;
+  hot.dispose(() => {
+    hotData.rateLimitQueueDeps = deps;
+  });
+}
+
 function notifyDraining(): void {
   for (const listener of drainingListeners) listener();
 }
@@ -121,12 +155,11 @@ export function enqueueRateLimitFetch(
     "host.getRateLimitUsage"
   >(hostId, "host.getRateLimitUsage", params);
 
-  if (!opts.force) {
+  const isFresh = (): boolean => {
     const updatedAt = queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0;
-    if (Date.now() - updatedAt < PROVIDER_RATE_LIMITS_STALE_TIME_MS) {
-      return chain;
-    }
-  }
+    return Date.now() - updatedAt < PROVIDER_RATE_LIMITS_STALE_TIME_MS;
+  };
+  if (!opts.force && isFresh()) return chain;
 
   // Named request fn (not an inline closure in `queryFn`) so the host-scoped
   // key stays the sole cache identity - `request` is stable module state, not a
@@ -138,7 +171,24 @@ export function enqueueRateLimitFetch(
   inFlightCount += 1;
   notifyDraining();
   chain = chain
-    .then(() => queryClient.fetchQuery({ queryKey, queryFn }))
+    .then(() => {
+      // Re-checked at this fetch's turn in the lane (not just at enqueue time):
+      // an earlier fetch in the same round may have just refreshed this exact
+      // provider, and an automatic trigger must not re-spawn a subprocess for
+      // data that became fresh while it waited in the queue.
+      if (!opts.force && isFresh()) return undefined;
+      // `staleTime: 0` is load-bearing: `fetchQuery` inherits the app
+      // QueryClient's GLOBAL `staleTime` default (60s in `query-client.ts`)
+      // and serves still-fresh cache without fetching at all. The popover's
+      // open-time refresh keeps this data younger than 60s, so without the
+      // override a user's `force: true` refresh silently no-oped - resolving
+      // from cache in a microtask, spawning no subprocess, flipping
+      // `draining` for under a frame - while the httpFetch lane's
+      // `invalidateQueries` (which always refetches) visibly spun. Freshness
+      // policy for automatic triggers lives in the explicit `isFresh` checks
+      // above, never in `fetchQuery`'s own staleness short-circuit.
+      return queryClient.fetchQuery({ queryKey, queryFn, staleTime: 0 });
+    })
     // One provider's failure must not block the next provider's turn in the
     // lane, and must not reject the shared chain (which every future enqueue
     // builds on).

--- a/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
+++ b/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
@@ -72,8 +72,11 @@ const drainingListeners = new Set<() => void>();
  * Carrying the binding across HMR generations closes that gap. Tree-shaken
  * out of production builds (`import.meta.hot` is statically false there).
  */
+// `undefined` in the union (rather than an optional marker) is the "no
+// generation has stashed a binding yet" state a fresh `hot.data` object
+// starts in.
 interface RateLimitQueueHotData {
-  rateLimitQueueDeps?: RateLimitQueueConfig | null;
+  rateLimitQueueDeps: RateLimitQueueConfig | null | undefined;
 }
 // Vite types `hot.data` as `any`; the `unknown` hop + structural guard keeps
 // the read type-safe. The guard also handles Vitest, whose truthy

--- a/clients/gui-app/src/lib/rate-limits/window-severity.ts
+++ b/clients/gui-app/src/lib/rate-limits/window-severity.ts
@@ -1,11 +1,10 @@
 /**
  * Fixed severity scale for a single rate-limit window's used percentage -
  * shared by the header glyph (Rate Limit Bar Icon - Core Flows, "Icon
- * composition") and the popover's per-window bars ("Provider detail view"
- * explicitly reuses these same thresholds). Deliberately distinct from
- * `rateLimitSeverity` in `provider-rate-limit-views.tsx` (the Settings >
- * Providers card's own two-tier 70%/90% warning/critical scale) - that split is
- * intentional, not drift; see that file's own comment.
+ * composition") and every bar `MeterRow` renders ("Provider detail view"
+ * explicitly reuses these same thresholds) - the single scale every
+ * provider's capped and uncapped bars share, so no row anywhere uses a
+ * different palette or thresholds.
  *
  * `"green"` is a distinct fourth tier for a window at 0% used (100% available):
  * it renders as a fully-filled green bar (see `rateLimitWindowFillPercent`) so

--- a/clients/gui-app/src/lib/rate-limits/window-severity.ts
+++ b/clients/gui-app/src/lib/rate-limits/window-severity.ts
@@ -1,0 +1,53 @@
+/**
+ * Fixed severity scale for a single rate-limit window's used percentage -
+ * shared by the header glyph (Rate Limit Bar Icon - Core Flows, "Icon
+ * composition") and the popover's per-window bars ("Provider detail view"
+ * explicitly reuses these same thresholds). Deliberately distinct from
+ * `rateLimitSeverity` in `provider-rate-limit-views.tsx` (the Settings >
+ * Providers card's own two-tier 70%/90% warning/critical scale) - that split is
+ * intentional, not drift; see that file's own comment.
+ *
+ * `"green"` is a distinct fourth tier for a window at 0% used (100% available):
+ * it renders as a fully-filled green bar (see `rateLimitWindowFillPercent`) so
+ * "nothing used yet" reads unambiguously as healthy, rather than as an empty
+ * blue-tier bar.
+ */
+export type RateLimitWindowSeverity = "green" | "blue" | "yellow" | "red";
+
+export function rateLimitWindowSeverity(
+  usedPercent: number,
+): RateLimitWindowSeverity {
+  if (usedPercent <= 0) return "green";
+  if (usedPercent > 85) return "red";
+  if (usedPercent >= 60) return "yellow";
+  return "blue";
+}
+
+/** Tailwind fill color for a severity tier, matching the Core Flows wireframe's bar colors. */
+export function rateLimitWindowSeverityBarClassName(
+  severity: RateLimitWindowSeverity,
+): string {
+  switch (severity) {
+    case "red":
+      return "bg-red-500 dark:bg-red-400";
+    case "yellow":
+      return "bg-yellow-500 dark:bg-yellow-400";
+    case "blue":
+      return "bg-blue-500 dark:bg-blue-400";
+    case "green":
+      return "bg-green-500 dark:bg-green-400";
+  }
+}
+
+/**
+ * The width (0-100) a severity-colored window bar should fill. A window at 0%
+ * used (100% available) fills the whole track - paired with the `"green"`
+ * severity - so it reads as a full green bar rather than an empty one;
+ * otherwise the bar tracks the real used percentage, clamped to [0, 100]. This
+ * is the *fill* only: callers still derive any "% left/used" text from the real
+ * `usedPercent`, not from this forced-full value.
+ */
+export function rateLimitWindowFillPercent(usedPercent: number): number {
+  if (usedPercent <= 0) return 100;
+  return Math.min(100, Math.max(0, usedPercent));
+}

--- a/clients/gui-app/src/lib/relative-time.ts
+++ b/clients/gui-app/src/lib/relative-time.ts
@@ -128,21 +128,25 @@ export function useResetCountdown(resetsAt: number | null): string | null {
 }
 
 /**
- * Exact reset timestamp (e.g. "Jul 4, 2026 12:10 AM") for long-horizon
- * windows, where a relative countdown ("Resets in 3d") is too coarse to act
- * on. A pure function, not a hook: unlike a relative countdown, an absolute
- * date/time string doesn't go stale as time passes, so it doesn't need to
- * subscribe to the shared tick clock.
+ * Exact reset timestamp with the day-of-week called out (e.g.
+ * "Jul 11, 2026 (Tue) 3:35 AM"), for windows where a relative countdown
+ * ("Resets in 3d") is too coarse to act on. The `(EEE)` weekday between the
+ * date and the time lets a reader see which day a reset lands on without
+ * counting forward from today. A pure function, not a hook: unlike a relative
+ * countdown, an absolute date/time string doesn't go stale as time passes, so
+ * it doesn't need to subscribe to the shared tick clock.
  */
 export function formatResetDateTime(resetsAt: number): string {
-  const date = new Date(resetsAt).toLocaleDateString(undefined, {
+  const date = new Date(resetsAt);
+  const datePart = date.toLocaleDateString(undefined, {
     month: "short",
     day: "numeric",
     year: "numeric",
   });
-  const time = new Date(resetsAt).toLocaleTimeString(undefined, {
+  const weekday = date.toLocaleDateString(undefined, { weekday: "short" });
+  const time = date.toLocaleTimeString(undefined, {
     hour: "numeric",
     minute: "2-digit",
   });
-  return `${date} ${time}`;
+  return `${datePart} (${weekday}) ${time}`;
 }

--- a/clients/gui-app/src/lib/relative-time.ts
+++ b/clients/gui-app/src/lib/relative-time.ts
@@ -128,25 +128,53 @@ export function useResetCountdown(resetsAt: number | null): string | null {
 }
 
 /**
- * Exact reset timestamp with the day-of-week called out (e.g.
- * "Jul 11, 2026 (Tue) 3:35 AM"), for windows where a relative countdown
- * ("Resets in 3d") is too coarse to act on. The `(EEE)` weekday between the
- * date and the time lets a reader see which day a reset lands on without
- * counting forward from today. A pure function, not a hook: unlike a relative
- * countdown, an absolute date/time string doesn't go stale as time passes, so
- * it doesn't need to subscribe to the shared tick clock.
+ * Whether a reset is far enough away that an absolute weekday/time reads
+ * better than a relative countdown ("Resets in 3d" is too coarse to act on).
+ * Based on the real time remaining rather than a window's nominal duration:
+ * some windows (e.g. Claude's per-model `modelScoped` buckets) carry no
+ * `durationMinutes` at all, so gating this decision on duration meant those
+ * windows always fell back to the relative countdown even when their real
+ * reset was days away (regression: Claude's "Fable" per-model window showed
+ * "Resets in 3d" instead of "Resets Tue 5:29 PM"). Every window always has a
+ * real `resetsAt`, so every caller now derives this the same way instead of
+ * each threading through its own duration-based flag (or, worse, hardcoding
+ * one).
+ */
+export function isFarReset(resetsAt: number, now: number): boolean {
+  return resetsAt - now >= DAY_MS;
+}
+
+/**
+ * Subscribes to the shared 60s tick clock and returns whether `resetsAt` is
+ * currently far enough away to warrant `formatResetDateTime` over
+ * `formatResetCountdown` - `false` for a `null` resetsAt (nothing to compare).
+ * Reactive (unlike `formatResetDateTime` itself) so a window that crosses the
+ * one-day threshold while the popover is open flips from absolute to relative
+ * display without a remount.
+ */
+export function useIsFarReset(resetsAt: number | null): boolean {
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  if (resetsAt === null) return false;
+  return isFarReset(resetsAt, sampledNow);
+}
+
+/**
+ * Exact reset time as weekday + time (e.g. "Sat 3:35 AM"), for windows where
+ * a relative countdown ("Resets in 3d") is too coarse to act on. Drops the
+ * calendar date on purpose: these windows reset within the next 7 days, so
+ * the weekday alone disambiguates it, and the shorter string reads better in
+ * a tight row. `hour12: true` is explicit rather than left to locale default
+ * so the AM/PM designator always renders. A pure function, not a hook: unlike
+ * a relative countdown, an absolute time string doesn't go stale as time
+ * passes, so it doesn't need to subscribe to the shared tick clock.
  */
 export function formatResetDateTime(resetsAt: number): string {
   const date = new Date(resetsAt);
-  const datePart = date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
   const weekday = date.toLocaleDateString(undefined, { weekday: "short" });
   const time = date.toLocaleTimeString(undefined, {
     hour: "numeric",
     minute: "2-digit",
+    hour12: true,
   });
-  return `${datePart} (${weekday}) ${time}`;
+  return `${weekday} ${time}`;
 }

--- a/clients/gui-app/src/providers/__tests__/rate-limit-queue-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/rate-limit-queue-provider.test.tsx
@@ -1,0 +1,200 @@
+import "../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { ReactNode } from "react";
+
+type MockState = {
+  hostId: string | null;
+  client: { request: () => Promise<unknown> } | null;
+  configured: ReadonlyArray<{
+    readonly providerId: string;
+    readonly lane: string;
+  }>;
+};
+
+const mocks = vi.hoisted<MockState>(() => ({
+  hostId: "host-a",
+  client: { request: () => Promise.resolve({}) },
+  configured: [],
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => mocks.hostId,
+}));
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => mocks.client,
+}));
+vi.mock("@/hooks/rate-limits/use-configured-rate-limit-providers", () => ({
+  useConfiguredRateLimitProviders: () => mocks.configured,
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  configureRateLimitQueue: vi.fn(),
+  enqueueRateLimitFetch: vi.fn(() => Promise.resolve()),
+}));
+
+import {
+  RateLimitQueueProvider,
+  EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS,
+} from "@/providers/rate-limit-queue-provider";
+import {
+  configureRateLimitQueue,
+  enqueueRateLimitFetch,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+const configureSpy = vi.mocked(configureRateLimitQueue);
+const enqueueSpy = vi.mocked(enqueueRateLimitFetch);
+
+function defineVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+function changeVisibility(state: "visible" | "hidden"): void {
+  defineVisibility(state);
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+function tree(): ReactNode {
+  return (
+    <QueryClientProvider client={new QueryClient()}>
+      <RateLimitQueueProvider />
+    </QueryClientProvider>
+  );
+}
+
+describe("<RateLimitQueueProvider />", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.hostId = "host-a";
+    mocks.client = { request: vi.fn(() => Promise.resolve({})) };
+    mocks.configured = [];
+    configureSpy.mockClear();
+    enqueueSpy.mockClear();
+    defineVisibility("visible");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("binds the serial queue to the default host on mount", () => {
+    render(tree());
+    const config = configureSpy.mock.calls.at(-1)?.[0] ?? null;
+    expect(config).not.toBeNull();
+    expect(config?.hostId).toBe("host-a");
+    expect(typeof config?.request).toBe("function");
+  });
+
+  it("unbinds the queue when the host is lost", () => {
+    const { rerender } = render(tree());
+    configureSpy.mockClear();
+    act(() => {
+      mocks.hostId = null;
+      rerender(tree());
+    });
+    expect(configureSpy).toHaveBeenLastCalledWith(null);
+  });
+
+  it("polls only ephemeralProcess providers each interval, and not before the first tick", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "openrouter", lane: "httpFetch" },
+    ];
+    render(tree());
+
+    // No immediate tick on mount - the per-provider query owns initial load.
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+
+    // Only the ephemeralProcess provider is enqueued; the httpFetch one never
+    // touches the queue.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("pauses the interval while the document is hidden and resumes when visible again (guardrail 2)", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    render(tree());
+
+    act(() => {
+      changeVisibility("hidden");
+    });
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS * 3);
+    });
+    // Minimized/backgrounded: no subprocess-spawning enqueues at all.
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      changeVisibility("visible");
+    });
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+    // Brought back: polling resumes.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps polling when the window loses focus but stays visible - never keys off blur (guardrail 4)", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    render(tree());
+
+    // OS focus moves elsewhere (e.g. Traycer visible on a second monitor). The
+    // document stays "visible", so nothing must pause.
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-gates on the next tick when a credential is removed mid-session, without resetting the timer", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    const { rerender } = render(tree());
+
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+    expect(enqueueSpy).toHaveBeenCalledTimes(2);
+    enqueueSpy.mockClear();
+
+    // claude-code's credential is removed mid-session -> it drops out of the
+    // configured set. The ref updates on re-render; the interval keeps running.
+    act(() => {
+      mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+      rerender(tree());
+    });
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("does not run the interval while there is no host", () => {
+    mocks.hostId = null;
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    render(tree());
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS * 2);
+    });
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/providers/__tests__/rate-limit-queue-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/rate-limit-queue-provider.test.tsx
@@ -82,6 +82,10 @@ describe("<RateLimitQueueProvider />", () => {
     vi.useRealTimers();
   });
 
+  it("polls the ephemeralProcess lane every 5 minutes, matching the httpFetch lane's own refetchInterval", () => {
+    expect(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS).toBe(5 * 60 * 1000);
+  });
+
   it("binds the serial queue to the default host on mount", () => {
     render(tree());
     const config = configureSpy.mock.calls.at(-1)?.[0] ?? null;

--- a/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
+++ b/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
@@ -10,12 +10,15 @@ import {
 } from "@/lib/rate-limits/ephemeral-fetch-queue";
 
 /**
- * Background poll cadence for the `ephemeralProcess` lane (codex, claude-code).
- * Deliberately slack (subprocess spawns are expensive) - the serial queue's 30s
- * freshness floor, turn-completion enqueues, and manual refresh all keep data
- * fresher between ticks.
+ * Background poll cadence for the `ephemeralProcess` lane (codex, claude-code),
+ * matching the `httpFetch` lane's own `refetchInterval`
+ * (`HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS`) so both lanes settle to the
+ * same background freshness regardless of fetch cost class. Still slack
+ * relative to a plain GET (subprocess spawns are expensive) - the serial
+ * queue's 30s freshness floor, turn-completion enqueues, and manual refresh
+ * all keep data fresher between ticks.
  */
-export const EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS = 10 * 60 * 1000;
+export const EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
  * The long-lived app-shell owner of the rate-limit data layer (no rendered

--- a/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
+++ b/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
@@ -94,11 +94,11 @@ export function RateLimitQueueProvider(): null {
       // Defensive: the timer is cleared while hidden, but guard the body too so
       // a tick that races a `visibilitychange` can't spawn a subprocess.
       if (document.visibilityState === "hidden") return;
-      for (const providerId of ephemeralProviderIdsRef.current) {
+      ephemeralProviderIdsRef.current.forEach((providerId) => {
         void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
           force: false,
         });
-      }
+      });
     };
     const start = (): void => {
       if (intervalHandle !== null) return;

--- a/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
+++ b/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { useHostClient } from "@/lib/host";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useConfiguredRateLimitProviders } from "@/hooks/rate-limits/use-configured-rate-limit-providers";
+import {
+  configureRateLimitQueue,
+  enqueueRateLimitFetch,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+/**
+ * Background poll cadence for the `ephemeralProcess` lane (codex, claude-code).
+ * Deliberately slack (subprocess spawns are expensive) - the serial queue's 30s
+ * freshness floor, turn-completion enqueues, and manual refresh all keep data
+ * fresher between ticks.
+ */
+export const EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS = 10 * 60 * 1000;
+
+/**
+ * The long-lived app-shell owner of the rate-limit data layer (no rendered
+ * output). It does two things for the lifetime of the window:
+ *
+ * 1. Binds the `ephemeralProcess` serial queue to the default host
+ *    (`configureRateLimitQueue`), re-binding on host/client swap and unbinding
+ *    on host loss so a stale client can't service an enqueue.
+ * 2. Drives the single shared interval timer for the `ephemeralProcess` lane,
+ *    walking the currently-configured providers and enqueuing a `force: false`
+ *    pull for each (the queue serializes them, one subprocess at a time).
+ *
+ * The timer PAUSES on `document.visibilityState === "hidden"` (window truly
+ * minimized/backgrounded) and resumes when the window is shown again - matching
+ * the same visibility signal TanStack's `focusManager` uses for the httpFetch
+ * lane's `refetchIntervalInBackground: false`. It deliberately does NOT key off
+ * window focus (`blur` / `document.hasFocus()`): the core scenario this feature
+ * exists for is glancing at the icon while Traycer sits visible-but-unfocused on
+ * a second monitor, and pausing on mere focus-loss would break exactly that.
+ *
+ * `httpFetch` providers are intentionally absent here - they poll via their
+ * query's own `refetchInterval` and never enter this queue.
+ */
+export function RateLimitQueueProvider(): null {
+  const hostId = useReactiveActiveHostId();
+  const client = useHostClient();
+  const queryClient = useQueryClient();
+  const configuredProviders = useConfiguredRateLimitProviders();
+
+  // Bind the queue to the default host. Re-runs on host/client swap; the
+  // cleanup + `null` branch clears the binding on host loss (`hostId` flips to
+  // `null`). `hostId` is bound into the queue at configure time (not passed per
+  // enqueue) so a queued fetch can't be reassigned to a different host
+  // mid-flight. `useHostClient()` is non-null once the runtime is mounted, so
+  // only host presence needs gating here.
+  useEffect(() => {
+    if (hostId === null) {
+      configureRateLimitQueue(null);
+      return;
+    }
+    configureRateLimitQueue({
+      hostId,
+      queryClient,
+      request: (_hostId, method, params) => client.request(method, params),
+    });
+    return () => {
+      configureRateLimitQueue(null);
+    };
+  }, [hostId, client, queryClient]);
+
+  // Latest `ephemeralProcess` provider ids, read live by the interval callback
+  // through a ref so a credential change re-gates the walked set on the very
+  // next tick WITHOUT resetting the timer (which a dependency would, pushing the
+  // first tick a full interval into the future on every list change).
+  const ephemeralProviderIds = useMemo(
+    () =>
+      configuredProviders
+        .filter((provider) => provider.lane === "ephemeralProcess")
+        .map((provider) => provider.providerId),
+    [configuredProviders],
+  );
+  const ephemeralProviderIdsRef = useRef(ephemeralProviderIds);
+  useEffect(() => {
+    ephemeralProviderIdsRef.current = ephemeralProviderIds;
+  }, [ephemeralProviderIds]);
+
+  // The single shared interval timer, gated on host presence and paused while
+  // the window is hidden. Initial per-provider data still populates through the
+  // per-provider query's own fetch-on-mount; this timer only does the periodic
+  // background refresh.
+  useEffect(() => {
+    if (hostId === null) return;
+    let intervalHandle: number | null = null;
+
+    const tick = (): void => {
+      // Defensive: the timer is cleared while hidden, but guard the body too so
+      // a tick that races a `visibilitychange` can't spawn a subprocess.
+      if (document.visibilityState === "hidden") return;
+      for (const providerId of ephemeralProviderIdsRef.current) {
+        void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+          force: false,
+        });
+      }
+    };
+    const start = (): void => {
+      if (intervalHandle !== null) return;
+      intervalHandle = window.setInterval(
+        tick,
+        EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS,
+      );
+    };
+    const stop = (): void => {
+      if (intervalHandle === null) return;
+      window.clearInterval(intervalHandle);
+      intervalHandle = null;
+    };
+    const syncToVisibility = (): void => {
+      if (document.visibilityState === "hidden") {
+        stop();
+      } else {
+        start();
+      }
+    };
+
+    syncToVisibility();
+    document.addEventListener("visibilitychange", syncToVisibility);
+    return () => {
+      document.removeEventListener("visibilitychange", syncToVisibility);
+      stop();
+    };
+  }, [hostId]);
+
+  return null;
+}

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -31,6 +31,7 @@ import { HarnessCatalogPrefetcher } from "@/providers/harness-catalog-prefetcher
 import { HistoryPruneProvider } from "@/providers/history-prune-provider";
 import { KeybindingProvider } from "@/providers/keybinding-provider";
 import { NotificationsSessionProvider } from "@/providers/notifications-session-provider";
+import { RateLimitQueueProvider } from "@/providers/rate-limit-queue-provider";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { WindowsBridgeAuthSessionBridge } from "@/providers/windows-bridge-auth-session";
@@ -203,6 +204,7 @@ function TraycerAppRuntimeSurface(props: TraycerAppRuntimeSurfaceProps) {
       <WorktreeDeleteProgressToastBridge />
       <CliCredentialSeeder />
       <HarnessCatalogPrefetcher />
+      <RateLimitQueueProvider />
       <HistoryPruneProvider router={props.router} />
       <RouterProvider router={props.router} />
       <HostPicker />

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -15,33 +15,74 @@ import {
 // `.parse()`/`.safeParse()` for real to catch a regression back to
 // `discriminatedUnion`.
 describe("providerRateLimitsSchema", () => {
-  it("parses an available codex snapshot", () => {
+  it("parses an available codex snapshot with per-limit breakdown and reset credits", () => {
     const codex = {
       provider: "codex" as const,
       available: true as const,
       planType: "plus",
-      primary: { usedPercent: 42, resetsAt: 1735689600000 },
+      limitId: "plus-primary",
+      limitName: "Plus",
+      primary: { usedPercent: 42, resetsAt: 1735689600000, durationMinutes: 300 },
       secondary: null,
+      extraWindows: [
+        {
+          limitId: "plus-secondary",
+          limitName: "Plus (weekly)",
+          primary: { usedPercent: 12, resetsAt: 1735776000000, durationMinutes: 10080 },
+          secondary: null,
+        },
+      ],
       credits: { hasCredits: true, unlimited: false, balance: "10.00" },
       individualLimit: null,
+      resetCredits: {
+        availableCount: 2,
+      },
       rateLimitReachedType: null,
     };
     expect(providerRateLimitsSchema.parse(codex)).toEqual(codex);
   });
 
-  it("parses an available claude-code snapshot", () => {
+  it("parses an available claude-code snapshot with window durations", () => {
     const claudeCode = {
       provider: "claude-code" as const,
       available: true as const,
       subscriptionType: "max",
-      fiveHour: { usedPercent: 10, resetsAt: null },
+      fiveHour: { usedPercent: 10, resetsAt: null, durationMinutes: 300 },
       sevenDay: null,
       sevenDayOpus: null,
       sevenDaySonnet: null,
-      modelScoped: [{ displayName: "Opus", usedPercent: 5, resetsAt: null }],
+      modelScoped: [
+        { displayName: "Opus", usedPercent: 5, resetsAt: null, durationMinutes: null },
+      ],
       extraUsage: null,
     };
     expect(providerRateLimitsSchema.parse(claudeCode)).toEqual(claudeCode);
+  });
+
+  it("parses an available openrouter snapshot", () => {
+    const openRouter = {
+      provider: "openrouter" as const,
+      available: true as const,
+      limit: 100,
+      limitRemaining: 40,
+      dailySpend: 1.5,
+      weeklySpend: 10.25,
+      monthlySpend: 42,
+      totalCredits: 100,
+      totalUsage: 58,
+      balance: 42,
+    };
+    expect(providerRateLimitsSchema.parse(openRouter)).toEqual(openRouter);
+  });
+
+  it("parses an available kilocode snapshot", () => {
+    const kiloCode = {
+      provider: "kilocode" as const,
+      available: true as const,
+      creditBalance: 25.5,
+      passState: "active",
+    };
+    expect(providerRateLimitsSchema.parse(kiloCode)).toEqual(kiloCode);
   });
 
   it("parses an unavailable snapshot for a provider id shared with an available arm", () => {
@@ -60,6 +101,15 @@ describe("providerRateLimitsSchema", () => {
     expect(providerRateLimitsSchema.parse(claudeUnavailable)).toEqual(
       claudeUnavailable,
     );
+  });
+
+  it("parses an unavailable snapshot with the insufficient_permissions reason", () => {
+    const unavailable = {
+      provider: "droid" as const,
+      available: false as const,
+      reason: "insufficient_permissions" as const,
+    };
+    expect(providerRateLimitsSchema.parse(unavailable)).toEqual(unavailable);
   });
 
   it("rejects a reason outside the closed unavailable-reason set", () => {
@@ -98,10 +148,14 @@ describe("rateLimitUsageResponseSchemaV12", () => {
         provider: "codex" as const,
         available: true as const,
         planType: null,
+        limitId: null,
+        limitName: null,
         primary: null,
         secondary: null,
+        extraWindows: [],
         credits: null,
         individualLimit: null,
+        resetCredits: null,
         rateLimitReachedType: null,
       },
     };

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -59,16 +59,22 @@ export type RateLimitUsageRequestV12 = z.infer<
 export const providerRateLimitWindowSchema = z.object({
   usedPercent: z.number(),
   resetsAt: z.number().nullable(),
+  durationMinutes: z.number().nullable(),
 });
 export type ProviderRateLimitWindow = z.infer<
   typeof providerRateLimitWindowSchema
 >;
 
 // Single source of truth for "which providers report account rate limits": the
-// two available arms below tag on it, the host's reader dispatch narrows to it
+// available arms below tag on it, the host's reader dispatch narrows to it
 // (exhaustively), and the GUI derives its `RateLimitProviderId` from it - so
 // adding a provider is one edit the compiler propagates across all three.
-export const rateLimitCapableProviderIdSchema = z.enum(["codex", "claude-code"]);
+export const rateLimitCapableProviderIdSchema = z.enum([
+  "codex",
+  "claude-code",
+  "openrouter",
+  "kilocode",
+]);
 export type RateLimitCapableProviderId = z.infer<
   typeof rateLimitCapableProviderIdSchema
 >;
@@ -77,8 +83,18 @@ const codexRateLimitsSchema = z.object({
   provider: z.literal(rateLimitCapableProviderIdSchema.enum.codex),
   available: z.literal(true),
   planType: z.string().nullable(),
+  limitId: z.string().nullable(),
+  limitName: z.string().nullable(),
   primary: providerRateLimitWindowSchema.nullable(),
   secondary: providerRateLimitWindowSchema.nullable(),
+  extraWindows: z.array(
+    z.object({
+      limitId: z.string(),
+      limitName: z.string().nullable(),
+      primary: providerRateLimitWindowSchema.nullable(),
+      secondary: providerRateLimitWindowSchema.nullable(),
+    }),
+  ),
   credits: z
     .object({
       hasCredits: z.boolean(),
@@ -94,7 +110,42 @@ const codexRateLimitsSchema = z.object({
       resetsAt: z.number(),
     })
     .nullable(),
+  // Verified against a live `account/rateLimits/read` call: the real
+  // `RateLimitResetCreditsSummary` is just `{ availableCount }` - no nested
+  // `credits` array exists (the earlier sketch guessed one from partial
+  // information).
+  resetCredits: z
+    .object({
+      availableCount: z.number(),
+    })
+    .nullable(),
   rateLimitReachedType: z.string().nullable(),
+});
+
+// OpenRouter arm - httpFetch-class provider (a plain GET against OpenRouter's
+// key/credits endpoints, no subprocess). Field names are a sketch, not yet
+// verified against a live call - see the Tech Plan's "Open items".
+const openRouterRateLimitsSchema = z.object({
+  provider: z.literal(rateLimitCapableProviderIdSchema.enum.openrouter),
+  available: z.literal(true),
+  limit: z.number().nullable(),
+  limitRemaining: z.number().nullable(),
+  dailySpend: z.number().nullable(),
+  weeklySpend: z.number().nullable(),
+  monthlySpend: z.number().nullable(),
+  totalCredits: z.number().nullable(),
+  totalUsage: z.number().nullable(),
+  balance: z.number().nullable(),
+});
+
+// Kilo Code arm - httpFetch-class provider (reads its own credential file,
+// no subprocess). Field names are a sketch, not yet verified against a live
+// call - see the Tech Plan's "Open items".
+const kiloCodeRateLimitsSchema = z.object({
+  provider: z.literal(rateLimitCapableProviderIdSchema.enum.kilocode),
+  available: z.literal(true),
+  creditBalance: z.number().nullable(),
+  passState: z.string().nullable(),
 });
 
 const claudeCodeRateLimitsSchema = z.object({
@@ -133,6 +184,7 @@ export const rateLimitUnavailableReasonSchema = z.enum([
   "connection_failed",
   "rate_limits_not_available",
   "sdk_incompatible",
+  "insufficient_permissions",
 ]);
 export type RateLimitUnavailableReason = z.infer<
   typeof rateLimitUnavailableReasonSchema
@@ -159,6 +211,8 @@ const unavailableProviderRateLimitsSchema = z.object({
 export const providerRateLimitsSchema = z.union([
   codexRateLimitsSchema,
   claudeCodeRateLimitsSchema,
+  openRouterRateLimitsSchema,
+  kiloCodeRateLimitsSchema,
   unavailableProviderRateLimitsSchema,
 ]);
 export type ProviderRateLimits = z.infer<typeof providerRateLimitsSchema>;


### PR DESCRIPTION
## Summary

Surfaces per-provider account rate limits as a header icon plus a popover, alongside a matching Settings > Providers card. Builds on #184 (which added the Codex/Claude Code v1.2 schema arms).

- **Protocol**: `providerRateLimitWindowSchema` gains `durationMinutes`; the Codex arm gains `extraWindows` and a `resetCredits` summary; new OpenRouter and Kilo Code provider arms; a new `insufficient_permissions` unavailable reason.
- **Header icon**: a fixed two-bar glyph (Codex + Claude Code 5h windows, falling back to that provider's 5h + Weekly if only one is configured), colored by a four-tier used-percent severity scale (green/blue/yellow/red), polling both the `ephemeralProcess` and `httpFetch` fetch lanes.
- **Popover**: a rail (Overview + one tab per connected provider, plus a GUI-sourced "Traycer" tab gated on non-free-plan-or-active-bundle) and detail panes, reusing one window-row renderer across every provider and the Settings card so they can never visually drift.
- **Settings > Providers**: a rate-limit card for Codex/Claude Code, using the exact same window-row rendering as the popover.
- Traycer's own subscription/credit usage extracted into shared, host/query-free views (`traycer-subscription-content.ts` / `traycer-subscription-views.tsx`) so the Settings card and the popover's Traycer tab read the same data and can never disagree.

Also includes four real-usage feedback rounds refining the icon/popover: bar orientation and placeholder state; popover height/scroll/Overview layout and absolute reset times; reset-time relative/absolute split, 0%-used green bars, a stuck-tooltip fix, and a rail redesign; and a final pass on row typography, bar sizing, popover height, Codex grouping, and consistent "% used" wording across every surface.

## Test plan

- [x] `bun run compile`, `bun run lint`, and the full workspace test suite (3800+ tests) pass
- [x] Pre-commit hooks (nx affected build/compile/lint/format) passed locally
- [x] Manual verification in a running desktop app (not available in this environment) - height/spacing of the redesigned rows and the shrunk popover would benefit from a visual pass