### PR TITLE
fix(gui-app): add missing coveredUntilMessageId to a codex session-anchor test fixture

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
@@ -740,6 +740,7 @@ describe("useRenderedMessages", () => {
         codexTurnId: "turn-1",
         codexUserMessageId: "codex-user-1",
         createdAt: 1000,
+        coveredUntilMessageId: null,
       },
     };
 


### PR DESCRIPTION
## Summary

#187 added a required `coveredUntilMessageId` field to every chat-session anchor schema (and the active session chain) in `protocol/src/persistence/epic/senders.ts`, but one test literal in `rendered-messages.test.tsx` wasn't updated for it.

`main` has not actually compiled since #187 merged - its own "pre-commit" check reported green in 11 seconds (versus ~3 minutes for a real run), which points to a stale `pre-commit` hook-cache hit rather than the check actually re-running. Verified independently: a clean checkout of `origin/main` with a fresh `bun install` and a direct `tsc -b` reproduces the exact same error with none of the changes from unrelated PR #189 present.

This is a one-line fix: add the missing field with the same `null` default the schema specifies for legacy/no-context anchors.

## Test plan

- [x] `bun run compile` passes across all 4 projects (protocol, gui-app, traycer-cli, desktop) on a fresh install
- [x] `rendered-messages.test.tsx` (67 tests) passes
- [x] `bun run lint` clean
- [x] Pre-commit hooks passed on a genuine (non-cached) run