### PR TITLE
feat(gui-app): @mention menu preview, compaction, and search stability

### DIFF
--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -591,6 +591,7 @@ function InlineUserMessageEditor({
         disabled={editing.pending}
         placeholder="Edit message"
         editorClassName="max-h-[min(60vh,18rem)] min-h-9 overflow-y-auto text-ui leading-7 text-foreground"
+        stabilizeImageAttachmentCaret={false}
         onSnapshot={onSnapshot}
         onSubmit={submit}
         onPaste={NOOP_CLIPBOARD}

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-image-attachment-flow.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-image-attachment-flow.test.tsx
@@ -22,7 +22,7 @@ describe("composer image attachment flow", () => {
     editor.commands.setContent(paragraphText("hello"));
     editor.commands.setTextSelection(1);
 
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
 
     expect(paragraphChildTypes(editor)).toEqual(["imageAttachment", "text"]);
     expect(imageIds(editor)).toEqual(["img-1"]);
@@ -33,7 +33,7 @@ describe("composer image attachment flow", () => {
     editor.commands.setContent(paragraphText("hello"));
     editor.commands.setTextSelection(editor.state.doc.content.size - 1);
 
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
 
     expect(paragraphChildTypes(editor)).toEqual(["text", "imageAttachment"]);
     expect(imageIds(editor)).toEqual(["img-1"]);
@@ -57,7 +57,7 @@ describe("composer image attachment flow", () => {
     if (slash === null) throw new Error("expected slash command");
     editor.commands.setTextSelection(slash.pos + slash.size);
 
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
 
     expect(paragraphChildTypes(editor)).toEqual([
       "slashCommand",
@@ -71,7 +71,7 @@ describe("composer image attachment flow", () => {
     editor.commands.setContent(paragraphText("abcdef"));
     editor.commands.setTextSelection({ from: 2, to: 5 });
 
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
 
     expect(editor.state.doc.textContent).toBe("abcdef");
     expect(imageIds(editor)).toEqual(["img-1"]);
@@ -85,11 +85,11 @@ describe("composer image attachment flow", () => {
   it("preserves insertion order for multiple images", () => {
     const editor = makeEditor();
 
-    insertImageAttachmentsCommand(editor, [
-      imageAttrs("img-1"),
-      imageAttrs("img-2"),
-      imageAttrs("img-3"),
-    ]);
+    insertImageAttachmentsCommand(
+      editor,
+      [imageAttrs("img-1"), imageAttrs("img-2"), imageAttrs("img-3")],
+      false,
+    );
 
     expect(imageIds(editor)).toEqual(["img-1", "img-2", "img-3"]);
   });
@@ -97,7 +97,7 @@ describe("composer image attachment flow", () => {
   it("keeps a pasted image as a positional inline atom when text is typed after it", () => {
     const editor = makeEditor();
 
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
     editor.commands.insertContent("hello");
 
     expect(editor.getJSON()).toEqual({
@@ -123,13 +123,59 @@ describe("composer image attachment flow", () => {
     ).not.toBeNull();
   });
 
+  it("adds a stable caret boundary after a terminal image when requested", () => {
+    const editor = makeEditor();
+
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], true);
+
+    expect(paragraphInlineSequence(editor)).toEqual(["image:img-1", "text: "]);
+    expect(editor.state.selection.from).toBe(2);
+    expect(editor.state.selection.$from.nodeAfter?.text).toBe(" ");
+  });
+
+  it("keeps typed text before the terminal image caret boundary", () => {
+    const editor = makeEditor();
+
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], true);
+    editor.commands.insertContent("hello");
+
+    expect(paragraphInlineSequence(editor)).toEqual([
+      "image:img-1",
+      "text:hello ",
+    ]);
+    expect(editor.state.selection.from).toBe(7);
+    expect(editor.state.selection.$from.nodeAfter?.text).toBe(" ");
+  });
+
+  it("does not add a caret boundary when the inserted image is followed by content", () => {
+    const editor = makeEditor();
+    editor.commands.setContent(paragraphText("hello"));
+    editor.commands.setTextSelection(1);
+
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], true);
+
+    expect(paragraphInlineSequence(editor)).toEqual([
+      "image:img-1",
+      "text:hello",
+    ]);
+  });
+
+  it("undoes a terminal image insertion and its caret boundary together", () => {
+    const editor = makeEditor();
+
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], true);
+    editor.commands.undo();
+
+    expect(paragraphInlineSequence(editor)).toEqual([]);
+  });
+
   it("removes the matching inline image atom by id", () => {
     const editor = makeEditor();
-    insertImageAttachmentsCommand(editor, [
-      imageAttrs("img-1"),
-      imageAttrs("img-2"),
-      imageAttrs("img-3"),
-    ]);
+    insertImageAttachmentsCommand(
+      editor,
+      [imageAttrs("img-1"), imageAttrs("img-2"), imageAttrs("img-3")],
+      false,
+    );
 
     editor.commands.removeImageAttachmentById("img-2");
 
@@ -185,6 +231,24 @@ function paragraphChildTypes(editor: Editor): string[] {
     types.push(node.type.name);
   });
   return types;
+}
+
+function paragraphInlineSequence(editor: Editor): string[] {
+  const first = editor.state.doc.firstChild;
+  if (first === null) return [];
+  const sequence: string[] = [];
+  first.forEach((node) => {
+    if (node.type.name === "imageAttachment") {
+      sequence.push(`image:${node.attrs.id}`);
+      return;
+    }
+    if (node.isText) {
+      sequence.push(`text:${node.text ?? ""}`);
+      return;
+    }
+    sequence.push(node.type.name);
+  });
+  return sequence;
 }
 
 function imageIds(editor: Editor): string[] {

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-mention-flow.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-mention-flow.test.tsx
@@ -109,6 +109,7 @@ describe("composer mention flow", () => {
         description: "",
         icon: FAKE_ICON,
         action: { kind: "complete", mention: fileMention("src/foo.ts") },
+        preview: null,
       },
     });
 
@@ -147,6 +148,7 @@ describe("composer mention flow", () => {
         description: "",
         icon: FAKE_ICON,
         action: { kind: "complete", mention: fileMention("src/foo.ts") },
+        preview: null,
       },
     });
 
@@ -178,6 +180,7 @@ describe("composer mention flow", () => {
         description: "",
         icon: FAKE_ICON,
         action: { kind: "complete", mention: fileMention("platform.ts") },
+        preview: null,
       },
     });
 

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-picker-store.test.ts
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-picker-store.test.ts
@@ -34,6 +34,7 @@ function fakeMentionEntry(id: string, label: string): MentionMenuEntry {
     description: "",
     icon: FAKE_ICON,
     action: { kind: "back" },
+    preview: null,
   };
 }
 
@@ -50,6 +51,7 @@ function slashCommand(name: string): SlashCommand {
     kind: "slash-command",
     metadata: {},
     source: "provider",
+    preview: { kind: "text", primary: "", secondary: null, mono: false },
   };
 }
 

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-render-isolation.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-render-isolation.test.tsx
@@ -26,6 +26,7 @@ interface HarnessProps {
     readonly from: number;
     readonly to: number;
   } | null;
+  readonly stabilizeImageAttachmentCaret: boolean;
 }
 
 function Harness({
@@ -33,6 +34,7 @@ function Harness({
   handleRef,
   initialContent,
   initialSelection,
+  stabilizeImageAttachmentCaret,
 }: HarnessProps) {
   const [pickerStore] = useState<ComposerPickerStore>(() =>
     createComposerPickerStore(),
@@ -52,6 +54,7 @@ function Harness({
         isActive={false}
         disabled={false}
         slashProviderId="claude"
+        stabilizeImageAttachmentCaret={stabilizeImageAttachmentCaret}
         onSnapshot={() => undefined}
         onSubmit={() => undefined}
         onPaste={() => undefined}
@@ -80,6 +83,7 @@ describe("ComposerPromptEditor render isolation", () => {
         handleRef={handleRef}
         initialContent={emptyContent()}
         initialSelection={null}
+        stabilizeImageAttachmentCaret={false}
       />,
     );
     await act(async () => {
@@ -112,6 +116,7 @@ describe("ComposerPromptEditor render isolation", () => {
         handleRef={handleRef}
         initialContent={legacyImageContent("abcdef")}
         initialSelection={{ from: 7, to: 7 }}
+        stabilizeImageAttachmentCaret={false}
       />,
     );
     await act(async () => {
@@ -143,6 +148,7 @@ describe("ComposerPromptEditor render isolation", () => {
         handleRef={handleRef}
         initialContent={emptyContent()}
         initialSelection={null}
+        stabilizeImageAttachmentCaret={false}
       />,
     );
     await act(async () => {
@@ -171,6 +177,37 @@ describe("ComposerPromptEditor render isolation", () => {
     );
   });
 
+  it("stabilizes a terminal image atom with real inline text content when requested", async () => {
+    const handleRef: { current: ComposerPromptEditorHandle | null } = {
+      current: null,
+    };
+    render(
+      <Harness
+        profileRender={NOOP_PROFILE}
+        handleRef={handleRef}
+        initialContent={emptyContent()}
+        initialSelection={null}
+        stabilizeImageAttachmentCaret
+      />,
+    );
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const handle = handleRef.current;
+    expect(handle).not.toBeNull();
+    if (handle === null) throw new Error("editor handle missing");
+    act(() => {
+      handle.insertImageAttachments([imageAttrs("img-1")]);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(document.querySelector("br.ProseMirror-trailingBreak")).toBeNull();
+    expect(inlineSequence(handle.getJSON())).toEqual(["image:img-1", "text: "]);
+  });
+
   it("renumbers visible image atom chips from document order", async () => {
     const handleRef: { current: ComposerPromptEditorHandle | null } = {
       current: null,
@@ -181,6 +218,7 @@ describe("ComposerPromptEditor render isolation", () => {
         handleRef={handleRef}
         initialContent={duplicateImageContent()}
         initialSelection={null}
+        stabilizeImageAttachmentCaret={false}
       />,
     );
     await act(async () => {
@@ -204,6 +242,7 @@ describe("ComposerPromptEditor render isolation", () => {
         handleRef={handleRef}
         initialContent={singleImageContent()}
         initialSelection={{ from: 1, to: 1 }}
+        stabilizeImageAttachmentCaret={false}
       />,
     );
     await act(async () => {
@@ -233,6 +272,7 @@ describe("ComposerPromptEditor render isolation", () => {
           handleRef={{ current: null }}
           initialContent={mixedChipContent()}
           initialSelection={null}
+          stabilizeImageAttachmentCaret={false}
         />
       </TooltipProvider>,
     );

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
@@ -334,7 +334,7 @@ describe("composer rich clipboard paste", () => {
 
   it("converts a slash command paste when images appear before it", () => {
     const editor = makeEditor(KNOWN_SLASH_NAMES);
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
 
     pastePlainText(editor, "/plan review the diff");
 

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-slash-flow.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-slash-flow.test.tsx
@@ -56,6 +56,12 @@ function planCommand(): SlashCommand {
     kind: "slash-command",
     metadata: {},
     source: "provider",
+    preview: {
+      kind: "text",
+      primary: "Plan something",
+      secondary: null,
+      mono: false,
+    },
   };
 }
 
@@ -75,7 +81,7 @@ describe("composer slash flow", () => {
 
   it("opens picker when user types / after a leading image", async () => {
     const { editor, pickerStore } = makeFixture();
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
 
     editor.commands.insertContent("/");
     await flush();
@@ -157,7 +163,7 @@ describe("composer slash flow", () => {
 
   it("keeps a slash chip when only images precede it", async () => {
     const { editor } = makeFixture();
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
     editor.commands.insertContent({
       type: "slashCommand",
       attrs: { commandName: "plan" },
@@ -170,7 +176,7 @@ describe("composer slash flow", () => {
   it("strips a slash chip when real text appears before leading images", async () => {
     const { editor } = makeFixture();
     editor.commands.insertContent("hello ");
-    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")]);
+    insertImageAttachmentsCommand(editor, [imageAttrs("img-1")], false);
     editor.commands.insertContent({
       type: "slashCommand",
       attrs: { commandName: "plan" },

--- a/clients/gui-app/src/components/chat/composer/chat-composer-editor-slot.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer-editor-slot.tsx
@@ -63,6 +63,7 @@ export function ChatComposerEditorSlot(props: ChatComposerEditorSlotProps) {
       disabled={false}
       placeholder={isNarrow ? NARROW_PLACEHOLDER : PLACEHOLDER}
       editorClassName="max-h-[3.5lh] min-h-9"
+      stabilizeImageAttachmentCaret
       onSnapshot={onSnapshot}
       onSubmit={onSubmit}
       onPaste={onPaste}

--- a/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
+++ b/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
@@ -67,6 +67,7 @@ export interface ComposerPromptEditorProps {
   readonly pickerStore: ComposerPickerStore;
   readonly placeholder: string;
   readonly editorClassName: string | undefined;
+  readonly stabilizeImageAttachmentCaret: boolean;
   readonly isActive: boolean;
   readonly disabled: boolean;
   readonly slashProviderId: GuiHarnessId;
@@ -91,6 +92,7 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     pickerStore,
     placeholder,
     editorClassName,
+    stabilizeImageAttachmentCaret,
     isActive,
     disabled,
     slashProviderId,
@@ -276,9 +278,13 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
   const insertImageAttachments = useCallback(
     (attrs: ReadonlyArray<ImageAttachmentAttrs>) => {
       if (editor === null) return;
-      insertImageAttachmentsCommand(editor, attrs);
+      insertImageAttachmentsCommand(
+        editor,
+        attrs,
+        stabilizeImageAttachmentCaret,
+      );
     },
-    [editor],
+    [editor, stabilizeImageAttachmentCaret],
   );
 
   const removeImageAttachmentById = useCallback(

--- a/clients/gui-app/src/components/chat/composer/menu/__tests__/mention-preview-panel.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/__tests__/mention-preview-panel.test.tsx
@@ -1,0 +1,459 @@
+import "../../../../../../__tests__/test-browser-apis";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { MentionPreview } from "@/lib/composer/types";
+
+import { MentionPreviewPanel } from "../mention-preview-panel";
+import { panelFitFor } from "../mention-preview-panel-fit";
+
+afterEach(() => {
+  cleanup();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+function makeListRef(activeRow: HTMLElement | null): {
+  current: HTMLDivElement | null;
+} {
+  const list = document.createElement("div");
+  document.body.appendChild(list);
+  if (activeRow !== null) list.appendChild(activeRow);
+  return { current: list };
+}
+
+function makeActiveRow(): HTMLElement {
+  const row = document.createElement("div");
+  row.setAttribute("data-active", "true");
+  return row;
+}
+
+describe("panelFitFor", () => {
+  it("shows the panel unconstrained when there's ample room on the chosen side", () => {
+    const fit = panelFitFor(500, 400);
+    expect(fit.fits).toBe(true);
+    expect(fit.maxWidthPx).toBe(500);
+    expect(fit.maxHeightPx).toBe(400);
+  });
+
+  it("shrinks the panel to the available space instead of letting it overflow", () => {
+    // Regression: the panel's CSS width can request up to 22rem (352px). At
+    // 220px available, that used to still report `fits: true` with nothing
+    // capping the rendered width, so the panel rendered past the viewport
+    // edge. It must now report a maxWidthPx that clamps it to what's there.
+    const fit = panelFitFor(220, 300);
+    expect(fit.fits).toBe(true);
+    expect(fit.maxWidthPx).toBe(220);
+    expect(fit.maxHeightPx).toBe(300);
+  });
+
+  it("hides the panel once available width drops below the readable minimum", () => {
+    const fit = panelFitFor(100, 300);
+    expect(fit.fits).toBe(false);
+  });
+
+  it("hides the panel once available height drops below the readable minimum", () => {
+    const fit = panelFitFor(300, 30);
+    expect(fit.fits).toBe(false);
+  });
+
+  it("clamps negative available space to 0 instead of an invalid CSS length", () => {
+    // The reference can already overflow the boundary before `size` runs,
+    // so floating-ui's available space can go negative. A negative
+    // max-width/max-height is invalid and silently dropped by the CSSOM,
+    // which would leave the panel unconstrained - clamp to 0 so it's always
+    // a settable value, and `fits` (0 < 160) still hides the panel.
+    const fit = panelFitFor(-16, -16);
+    expect(fit.fits).toBe(false);
+    expect(fit.maxWidthPx).toBe(0);
+    expect(fit.maxHeightPx).toBe(0);
+  });
+});
+
+describe("MentionPreviewPanel", () => {
+  it("renders nothing when the active preview is null", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    render(
+      <MentionPreviewPanel listRef={listRef} activeIndex={0} preview={null} />,
+    );
+    await flush();
+    expect(
+      document.querySelector('[data-slot="mention-preview-panel"]'),
+    ).toBeNull();
+  });
+
+  it("renders the primary and secondary preview content for a text kind", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "text",
+      primary: "Fix login redirect bug",
+      secondary: "Epic: Auth revamp",
+      mono: false,
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    expect(screen.getByText("Fix login redirect bug")).toBeTruthy();
+    expect(screen.getByText("Epic: Auth revamp")).toBeTruthy();
+  });
+
+  it("omits the secondary line when null", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "text",
+      primary: "some-branch",
+      secondary: null,
+      mono: true,
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    const panel = document.querySelector('[data-slot="mention-preview-panel"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.textContent).toBe("some-branch");
+  });
+
+  it("renders monospace only when the text preview says so, driven by `mono`", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "text",
+      primary: "/Users/anurag/project/src/index.ts",
+      secondary: null,
+      mono: true,
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    const pathEl = screen.getByText("/Users/anurag/project/src/index.ts");
+    expect(pathEl.className).toContain("font-mono");
+
+    cleanup();
+
+    const titleListRef = makeListRef(makeActiveRow());
+    const titlePreview: MentionPreview = {
+      kind: "text",
+      primary: "Add the follow-selection side preview panel",
+      secondary: null,
+      mono: false,
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={titleListRef}
+        activeIndex={0}
+        preview={titlePreview}
+      />,
+    );
+    await flush();
+    const titleEl = screen.getByText(
+      "Add the follow-selection side preview panel",
+    );
+    expect(titleEl.className).not.toContain("font-mono");
+  });
+
+  it("never renders monospace for a slash-bearing title with mono: false", async () => {
+    // Regression: monospace must come from the explicit `mono` flag, not a
+    // heuristic on `primary`'s content - a title like "UI/UX" or
+    // "client/server" contains a slash but is not a path.
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "text",
+      primary: "Redesign the client/server handshake for UI/UX consistency",
+      secondary: null,
+      mono: false,
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    const titleEl = screen.getByText(
+      "Redesign the client/server handshake for UI/UX consistency",
+    );
+    expect(titleEl.className).not.toContain("font-mono");
+  });
+
+  it("is pointer-events-none and aria-hidden so it never intercepts input", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "text",
+      primary: "a1b2c3d",
+      secondary: "Fix bug",
+      mono: true,
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    const panel = document.querySelector('[data-slot="mention-preview-panel"]');
+    expect(panel).not.toBeNull();
+    expect(panel?.getAttribute("aria-hidden")).toBe("true");
+    expect(panel?.className).toContain("pointer-events-none");
+  });
+
+  it("follows content updates instantly across activeIndex changes", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const { rerender } = render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={{
+          kind: "text",
+          primary: "row-one",
+          secondary: null,
+          mono: false,
+        }}
+      />,
+    );
+    await flush();
+    expect(screen.getByText("row-one")).toBeTruthy();
+
+    rerender(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={1}
+        preview={{
+          kind: "text",
+          primary: "row-two",
+          secondary: "second row detail",
+          mono: false,
+        }}
+      />,
+    );
+    await flush();
+    expect(screen.queryByText("row-one")).toBeNull();
+    expect(screen.getByText("row-two")).toBeTruthy();
+    expect(screen.getByText("second row detail")).toBeTruthy();
+  });
+
+  it("wires the size middleware's available space into inline max-width/max-height", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "text",
+      primary: "wired up",
+      secondary: null,
+      mono: false,
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    const panel = document.querySelector<HTMLElement>(
+      '[data-slot="mention-preview-panel"]',
+    );
+    expect(panel).not.toBeNull();
+    // jsdom has no real layout, so the exact px values just reflect its
+    // fixed viewport - `panelFitFor` above covers the interesting
+    // shrink-vs-hide thresholds. This only proves the `apply` callback ran
+    // and constrained the element, per the fix.
+    expect(panel?.style.maxWidth.endsWith("px")).toBe(true);
+    expect(panel?.style.maxHeight.endsWith("px")).toBe(true);
+  });
+
+  it("renders a path kind as a breadcrumb tree with an absolute-path footer", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "path",
+      tree: {
+        rootLabel: "trayer/clients/gui-app/src/components",
+        midDirs: ["home", "toolbar"],
+        leaf: "composer-toolbar.tsx",
+        leafIsFile: true,
+      },
+      footer: {
+        text: "/Users/anurag/traycer-staging/trayer/clients/gui-app/src/components/home/toolbar/composer-toolbar.tsx",
+        mono: true,
+      },
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    expect(
+      screen.getByText("trayer/clients/gui-app/src/components"),
+    ).toBeTruthy();
+    expect(screen.getByText("home")).toBeTruthy();
+    expect(screen.getByText("toolbar")).toBeTruthy();
+    expect(screen.getByText("composer-toolbar.tsx")).toBeTruthy();
+    const footerEl = screen.getByText(
+      "/Users/anurag/traycer-staging/trayer/clients/gui-app/src/components/home/toolbar/composer-toolbar.tsx",
+    );
+    expect(footerEl.className).toContain("font-mono");
+  });
+
+  it("collapses a deep path to the root row + at most 2 mid dirs + leaf", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "path",
+      tree: {
+        rootLabel: "a/b/c/d/e/f",
+        midDirs: ["g", "h"],
+        leaf: "deep-file.ts",
+        leafIsFile: true,
+      },
+      footer: { text: "/repo/a/b/c/d/e/f/g/h/deep-file.ts", mono: true },
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    const panel = document.querySelector('[data-slot="mention-preview-panel"]');
+    expect(panel).not.toBeNull();
+    // Root row + 2 mid dirs + leaf = 4 rows max, never more regardless of
+    // how many segments `rootLabel` represents.
+    expect(screen.getByText("a/b/c/d/e/f")).toBeTruthy();
+    expect(screen.getByText("g")).toBeTruthy();
+    expect(screen.getByText("h")).toBeTruthy();
+    expect(screen.getByText("deep-file.ts")).toBeTruthy();
+  });
+
+  it("middle-elides an overlong root label, keeping the first segment and deepest dir", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const longRoot =
+      "workspace-root/packages/some-service/src/very/deeply/nested/module/tree";
+    const preview: MentionPreview = {
+      kind: "path",
+      tree: {
+        rootLabel: longRoot,
+        midDirs: [],
+        leaf: "index.ts",
+        leafIsFile: true,
+      },
+      footer: { text: `/repo/${longRoot}/index.ts`, mono: true },
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    expect(screen.queryByText(longRoot)).toBeNull();
+    expect(screen.getByText("workspace-root/…/tree")).toBeTruthy();
+  });
+
+  it("renders a folder-leaf path with a folder icon instead of a file-type icon", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "path",
+      tree: {
+        rootLabel: "src",
+        midDirs: [],
+        leaf: "auth",
+        leafIsFile: false,
+      },
+      footer: { text: "/repo/src/auth", mono: true },
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    expect(screen.getByText("auth")).toBeTruthy();
+  });
+
+  it("renders a worktree path with a branch footer instead of a duplicated absolute path", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "path",
+      tree: {
+        rootLabel: "/home/u/.traycer/worktrees",
+        midDirs: ["o", "r"],
+        leaf: "feature-worktree",
+        leafIsFile: false,
+      },
+      footer: { text: "feature", mono: false },
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    expect(screen.getByText("/home/u/.traycer/worktrees")).toBeTruthy();
+    expect(screen.getByText("feature-worktree")).toBeTruthy();
+    const footerEl = screen.getByText("feature");
+    expect(footerEl.className).not.toContain("font-mono");
+  });
+
+  it("renders no footer line when the path preview's footer is null", async () => {
+    const listRef = makeListRef(makeActiveRow());
+    const preview: MentionPreview = {
+      kind: "path",
+      tree: {
+        rootLabel: "/home/u/.traycer/worktrees",
+        midDirs: ["o", "r"],
+        leaf: "feature",
+        leafIsFile: false,
+      },
+      footer: null,
+    };
+    render(
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={0}
+        preview={preview}
+      />,
+    );
+    await flush();
+
+    const panel = document.querySelector('[data-slot="mention-preview-panel"]');
+    expect(panel?.textContent).toBe("/home/u/.traycer/worktreesorfeature");
+  });
+});

--- a/clients/gui-app/src/components/chat/composer/menu/composer-menu.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/composer-menu.tsx
@@ -29,15 +29,19 @@ import {
   mentionProviderRegistry,
   type MentionFlowStep,
 } from "@/lib/composer/mentions";
+import type { MentionPreview } from "@/lib/composer/types";
 import { cn } from "@/lib/utils";
 
-import type {
-  ComposerPickerItem,
-  ComposerPickerStore,
+import {
+  pickerItemPreview,
+  type ComposerPickerItem,
+  type ComposerPickerStore,
 } from "../picker/composer-picker-store";
 
 import { MentionMenuItem } from "./mention-menu-item";
+import { MentionPreviewPanel } from "./mention-preview-panel";
 import { SlashMenuItem } from "./slash-menu-item";
+import { ZERO_DOM_RECT } from "./zero-dom-rect";
 
 const SLASH_MENU_COPY = {
   header: "Slash commands",
@@ -51,27 +55,13 @@ const MENU_HEIGHT_ESTIMATE = 280;
 
 type LockedPlacement = Extract<Placement, "bottom-start" | "top-start">;
 
-const ZERO_RECT: DOMRect =
-  typeof DOMRect === "function"
-    ? new DOMRect(0, 0, 0, 0)
-    : {
-        x: 0,
-        y: 0,
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        width: 0,
-        height: 0,
-        toJSON: () => ({}),
-      };
-
 interface MenuSlice {
   readonly open: boolean;
   readonly kind: "mention" | "slash" | null;
   readonly items: ReadonlyArray<ComposerPickerItem>;
   readonly activeIndex: number;
   readonly loading: boolean;
+  readonly fetching: boolean;
   readonly step: MentionFlowStep;
 }
 
@@ -81,6 +71,7 @@ function selectMenuSlice(state: {
   items: ReadonlyArray<ComposerPickerItem>;
   activeIndex: number;
   loading: boolean;
+  fetching: boolean;
   step: MentionFlowStep;
 }): MenuSlice {
   return {
@@ -89,6 +80,7 @@ function selectMenuSlice(state: {
     items: state.items,
     activeIndex: state.activeIndex,
     loading: state.loading,
+    fetching: state.fetching,
     step: state.step,
   };
 }
@@ -100,7 +92,7 @@ export interface ComposerMenuProps {
 export function ComposerMenu(props: ComposerMenuProps) {
   const { pickerStore } = props;
   const slice = useStore(pickerStore, useShallow(selectMenuSlice));
-  const { open, kind, items, activeIndex, loading, step } = slice;
+  const { open, kind, items, activeIndex, loading, fetching, step } = slice;
 
   const baseMenuId = useId();
   const menuId = `${baseMenuId}-menu`;
@@ -115,6 +107,7 @@ export function ComposerMenu(props: ComposerMenuProps) {
       items={items}
       activeIndex={activeIndex}
       loading={loading}
+      fetching={fetching}
       step={step}
       menuId={menuId}
     />
@@ -127,13 +120,22 @@ interface ComposerMenuPortalProps {
   readonly items: ReadonlyArray<ComposerPickerItem>;
   readonly activeIndex: number;
   readonly loading: boolean;
+  readonly fetching: boolean;
   readonly step: MentionFlowStep;
   readonly menuId: string;
 }
 
 function ComposerMenuPortal(props: ComposerMenuPortalProps) {
-  const { pickerStore, kind, items, activeIndex, loading, step, menuId } =
-    props;
+  const {
+    pickerStore,
+    kind,
+    items,
+    activeIndex,
+    loading,
+    fetching,
+    step,
+    menuId,
+  } = props;
   const listRef = useRef<HTMLDivElement | null>(null);
   const floatingRef = useRef<HTMLDivElement | null>(null);
 
@@ -141,6 +143,11 @@ function ComposerMenuPortal(props: ComposerMenuPortalProps) {
     () => items.map((item, index) => renderPickerItem(item, index, menuId)),
     [items, menuId],
   );
+
+  const activePreview = useMemo<MentionPreview | null>(() => {
+    if (activeIndex < 0 || activeIndex >= items.length) return null;
+    return pickerItemPreview(items[activeIndex]);
+  }, [items, activeIndex]);
 
   const copy = useMemo(() => {
     if (kind === "mention") return mentionProviderRegistry.menuCopy(step);
@@ -168,6 +175,10 @@ function ComposerMenuPortal(props: ComposerMenuPortalProps) {
     timeoutMs: COMPOSER_ARTIFACT_REFRESH_TIMEOUT_MS,
   });
 
+  // MentionPreviewPanel does its own pre-paint scrollIntoView for rows that
+  // have a preview (see its layout effect), but it early-returns before
+  // that when there's no preview - this passive effect is what still
+  // scrolls the active row into view for those.
   useEffect(() => {
     const list = listRef.current;
     if (list === null) return;
@@ -184,7 +195,7 @@ function ComposerMenuPortal(props: ComposerMenuPortalProps) {
     const virtualReference = {
       getBoundingClientRect: (): DOMRect => {
         const rect = pickerStore.getState().clientRect?.() ?? null;
-        return rect ?? ZERO_RECT;
+        return rect ?? ZERO_DOM_RECT;
       },
     };
 
@@ -248,11 +259,20 @@ function ComposerMenuPortal(props: ComposerMenuPortalProps) {
         // names render in full, with a comfortable floor (min-w) and a
         // viewport-aware ceiling (max-w) past which items truncate. floating-ui's
         // shift() keeps the grown menu on-screen (CLAUDE.md sizing).
-        className="pointer-events-auto fixed top-0 left-0 z-50 w-max min-w-[min(90vw,16rem)] max-w-[min(92vw,42rem)] overflow-hidden rounded-xl border border-border/70 bg-popover text-popover-foreground shadow-lg"
+        className="pointer-events-auto fixed top-0 left-0 z-50 w-max min-w-[min(90vw,16rem)] max-w-[min(90vw,26rem)] overflow-hidden rounded-xl border border-border/70 bg-popover text-popover-foreground shadow-lg"
       >
         <div className="flex items-center justify-between gap-2 border-b border-border/60 px-3 py-1.5">
-          <div className="min-w-0 truncate text-overline font-medium uppercase text-muted-foreground/70">
-            {headerLabel}
+          <div className="flex min-w-0 items-center gap-1.5">
+            <div className="min-w-0 truncate text-overline font-medium uppercase text-muted-foreground/70">
+              {headerLabel}
+            </div>
+            {fetching && !loading ? (
+              <AgentSpinningDots
+                testId={undefined}
+                variant={undefined}
+                className="text-muted-foreground/60"
+              />
+            ) : null}
           </div>
           {refreshAvailable ? (
             <Button
@@ -296,7 +316,16 @@ function ComposerMenuPortal(props: ComposerMenuPortalProps) {
     </RemoveScroll>
   );
 
-  return createPortal(menu, document.body);
+  return (
+    <>
+      {createPortal(menu, document.body)}
+      <MentionPreviewPanel
+        listRef={listRef}
+        activeIndex={activeIndex}
+        preview={activePreview}
+      />
+    </>
+  );
 }
 
 function selectInitialPlacement(store: ComposerPickerStore): LockedPlacement {

--- a/clients/gui-app/src/components/chat/composer/menu/mention-menu-item.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/mention-menu-item.tsx
@@ -12,14 +12,11 @@ export function MentionMenuItem(props: MentionMenuItemProps) {
   return (
     <div className="flex min-w-0 items-center gap-2 px-1 py-0.5">
       <span className="shrink-0">{entry.icon}</span>
-      <span className="min-w-0 truncate text-ui-sm font-medium text-foreground">
+      <span className="min-w-0 flex-1 truncate text-ui-sm font-medium text-foreground">
         {entry.label}
       </span>
       {trailing ? (
-        <span
-          className="ml-auto min-w-0 shrink truncate text-ui-xs text-muted-foreground/70"
-          title={trailing}
-        >
+        <span className="min-w-0 shrink max-w-[45%] truncate text-ui-xs text-muted-foreground/70">
           {trailing}
         </span>
       ) : null}

--- a/clients/gui-app/src/components/chat/composer/menu/mention-menu-item.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/mention-menu-item.tsx
@@ -16,7 +16,10 @@ export function MentionMenuItem(props: MentionMenuItemProps) {
         {entry.label}
       </span>
       {trailing ? (
-        <span className="min-w-0 shrink max-w-[45%] truncate text-ui-xs text-muted-foreground/70">
+        <span
+          className="min-w-0 shrink max-w-[45%] truncate text-ui-xs text-muted-foreground/70"
+          title={entry.preview === null ? trailing : undefined}
+        >
           {trailing}
         </span>
       ) : null}

--- a/clients/gui-app/src/components/chat/composer/menu/mention-preview-panel-fit.ts
+++ b/clients/gui-app/src/components/chat/composer/menu/mention-preview-panel-fit.ts
@@ -1,0 +1,33 @@
+// Below this, the panel would render unreadably small (or entirely
+// off-viewport, since main-axis shift is disabled) - hide it instead.
+const PANEL_MIN_WIDTH_PX = 160;
+const PANEL_MIN_HEIGHT_PX = 48;
+
+/**
+ * Given the space the `size` middleware measured on the chosen (post-flip)
+ * side, decide whether the panel shows at all, and how far to shrink it
+ * below its CSS-declared `w-[min(90vw,22rem)]` ceiling so it never renders
+ * past the viewport edge - `shift`'s main axis is disabled, so nothing else
+ * pulls it back on screen once the requested width no longer fits.
+ *
+ * `availableWidth`/`availableHeight` can go negative (the reference itself
+ * already overflows the boundary before this middleware runs); clamp to 0
+ * since a negative CSS length is invalid and gets silently dropped, which
+ * would leave the panel unconstrained instead of hidden.
+ */
+export function panelFitFor(
+  availableWidth: number,
+  availableHeight: number,
+): {
+  readonly fits: boolean;
+  readonly maxWidthPx: number;
+  readonly maxHeightPx: number;
+} {
+  return {
+    fits:
+      availableWidth >= PANEL_MIN_WIDTH_PX &&
+      availableHeight >= PANEL_MIN_HEIGHT_PX,
+    maxWidthPx: Math.max(0, availableWidth),
+    maxHeightPx: Math.max(0, availableHeight),
+  };
+}

--- a/clients/gui-app/src/components/chat/composer/menu/mention-preview-panel.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/mention-preview-panel.tsx
@@ -1,0 +1,257 @@
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type ReactElement,
+  type RefObject,
+} from "react";
+import { createPortal } from "react-dom";
+import { Folder } from "lucide-react";
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset,
+  shift,
+  size,
+} from "@floating-ui/dom";
+
+import { MaterialFileIcon } from "@/components/material-file-icon";
+import type { MentionPreview } from "@/lib/composer/types";
+import type { MentionPathTree } from "@/lib/path";
+import { cn } from "@/lib/utils";
+
+import { panelFitFor } from "./mention-preview-panel-fit";
+import { ZERO_DOM_RECT } from "./zero-dom-rect";
+
+const PANEL_GUTTER_PX = 6;
+const PANEL_BOUNDARY_PADDING_PX = 8;
+// The root row absorbs the full relative-path prefix as one string; past
+// this many characters it stops fitting the panel's fixed width on one
+// line, so it gets middle-elided instead of left to CSS tail-truncate.
+const ROOT_LABEL_CHAR_BUDGET = 42;
+// Tree rows never exceed 4 (root + up to 2 mid dirs + leaf) by construction
+// of `mentionPathTree`'s hierarchy algorithm.
+const TREE_ROW_INDENT_CLASSES = ["pl-0", "pl-4", "pl-8", "pl-12"] as const;
+
+export interface MentionPreviewPanelProps {
+  readonly listRef: RefObject<HTMLDivElement | null>;
+  readonly activeIndex: number;
+  readonly preview: MentionPreview | null;
+}
+
+/**
+ * Info-only preview panel pinned beside the composer's @mention/slash menu.
+ * Anchored to the active row (via a floating-ui virtual reference reading
+ * its live rect), so it tracks the highlighted row vertically as selection
+ * changes. Placement prefers the right; `flip` falls back to the left; the
+ * `size` gate hides the panel entirely once neither side has room, rather
+ * than letting it render past the viewport edge or overlap the list.
+ */
+export function MentionPreviewPanel(props: MentionPreviewPanelProps) {
+  const { listRef, activeIndex, preview } = props;
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [fits, setFits] = useState(false);
+
+  useLayoutEffect(() => {
+    const panel = panelRef.current;
+    if (panel === null) return;
+
+    // Scroll the active row into view before measuring/positioning below.
+    // The menu's own scrollIntoView (composer-menu.tsx) runs in a *passive*
+    // effect that fires after paint, while this positioning effect runs
+    // before paint - on keyboard nav past the list's visible edge, that
+    // ordering would otherwise measure the pre-scroll rect and paint one
+    // frame at the stale spot before autoUpdate catches the scroll and
+    // jumps. Doing it here settles scroll and position in the same
+    // pre-paint pass. Keep the menu's own effect: it's still needed for
+    // rows with no preview, where this component returns null below before
+    // ever running. `block: "nearest"` no-ops once already visible, so the
+    // duplicate scroll for preview rows is harmless.
+    listRef.current
+      ?.querySelector<HTMLElement>('[data-active="true"]')
+      ?.scrollIntoView({ block: "nearest" });
+
+    const activeRowRect = (): DOMRect => {
+      const list = listRef.current;
+      const active =
+        list?.querySelector<HTMLElement>('[data-active="true"]') ?? null;
+      return active?.getBoundingClientRect() ?? ZERO_DOM_RECT;
+    };
+    const virtualReference = {
+      getBoundingClientRect: activeRowRect,
+      contextElement: listRef.current ?? undefined,
+    };
+
+    const reposition = (): void => {
+      void computePosition(virtualReference, panel, {
+        placement: "right-start",
+        middleware: [
+          offset(PANEL_GUTTER_PX),
+          flip({
+            fallbackPlacements: ["left-start"],
+            padding: PANEL_BOUNDARY_PADDING_PX,
+          }),
+          shift({
+            mainAxis: false,
+            crossAxis: true,
+            padding: PANEL_BOUNDARY_PADDING_PX,
+          }),
+          size({
+            padding: PANEL_BOUNDARY_PADDING_PX,
+            apply: ({ availableWidth, availableHeight, elements }) => {
+              const fit = panelFitFor(availableWidth, availableHeight);
+              setFits(fit.fits);
+              elements.floating.style.maxWidth = `${fit.maxWidthPx}px`;
+              elements.floating.style.maxHeight = `${fit.maxHeightPx}px`;
+            },
+          }),
+        ],
+      }).then(({ x, y }) => {
+        panel.style.transform = `translate3d(${Math.round(x)}px, ${Math.round(
+          y,
+        )}px, 0)`;
+      });
+    };
+
+    reposition();
+    return autoUpdate(virtualReference, panel, reposition);
+  }, [listRef, activeIndex, preview]);
+
+  if (preview === null) return null;
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      data-slot="mention-preview-panel"
+      role="presentation"
+      aria-hidden
+      className={cn(
+        "pointer-events-none fixed top-0 left-0 z-50 w-[min(90vw,22rem)] overflow-hidden rounded-xl border border-border/70 bg-popover text-popover-foreground shadow-lg",
+        !fits && "invisible",
+      )}
+    >
+      <div className="max-h-[min(50vh,16rem)] overflow-y-auto px-3 py-2">
+        <PreviewBody preview={preview} />
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function PreviewBody(props: {
+  readonly preview: MentionPreview;
+}): ReactElement {
+  const { preview } = props;
+  switch (preview.kind) {
+    case "text":
+      return (
+        <>
+          <div
+            className={cn(
+              "min-w-0 text-ui-sm text-foreground",
+              preview.mono && "font-mono wrap-anywhere",
+            )}
+          >
+            {preview.primary}
+          </div>
+          {preview.secondary !== null ? (
+            <div className="mt-1 min-w-0 text-ui-xs text-muted-foreground/70">
+              {preview.secondary}
+            </div>
+          ) : null}
+        </>
+      );
+    case "path":
+      return (
+        <>
+          <PathTreeRows tree={preview.tree} />
+          {preview.footer !== null ? (
+            <div
+              className={cn(
+                "mt-1.5 min-w-0 text-ui-xs text-muted-foreground/70",
+                preview.footer.mono && "font-mono wrap-anywhere",
+              )}
+            >
+              {preview.footer.text}
+            </div>
+          ) : null}
+        </>
+      );
+  }
+}
+
+interface PathTreeRow {
+  readonly key: string;
+  readonly label: string;
+  readonly depth: number;
+  readonly isLeaf: boolean;
+}
+
+function pathTreeRows(tree: MentionPathTree): ReadonlyArray<PathTreeRow> {
+  const dirLabels = [
+    middleElideRootLabel(tree.rootLabel),
+    ...tree.midDirs,
+  ].filter((label) => label.length > 0);
+  const dirRows = dirLabels.map((label, depth) => ({
+    key: `dir-${depth}`,
+    label,
+    depth,
+    isLeaf: false,
+  }));
+  return [
+    ...dirRows,
+    { key: "leaf", label: tree.leaf, depth: dirRows.length, isLeaf: true },
+  ];
+}
+
+function PathTreeRows(props: { readonly tree: MentionPathTree }): ReactElement {
+  const { tree } = props;
+  const rows = pathTreeRows(tree);
+  return (
+    <div className="min-w-0">
+      {rows.map((row) => (
+        <div
+          key={row.key}
+          className={cn(
+            "flex min-w-0 items-center gap-1.5 py-0.5",
+            TREE_ROW_INDENT_CLASSES[row.depth],
+          )}
+        >
+          {row.isLeaf && tree.leafIsFile ? (
+            <MaterialFileIcon
+              filename={row.label}
+              className="size-3.5 shrink-0"
+            />
+          ) : (
+            <Folder
+              className="size-3.5 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+          )}
+          <span className="min-w-0 truncate text-ui-sm text-foreground">
+            {row.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The root row absorbs the full relative prefix as one string, which can
+ * overflow the panel's fixed width for deep trees. Elide the middle instead
+ * of letting CSS truncate the tail, so the outermost root segment and the
+ * deepest (nearest-to-leaf) directory - the two ends a reader orients from -
+ * stay visible.
+ */
+function middleElideRootLabel(rootLabel: string): string {
+  if (rootLabel.length <= ROOT_LABEL_CHAR_BUDGET) return rootLabel;
+  const isAbsolute = rootLabel.startsWith("/");
+  const segments = (isAbsolute ? rootLabel.slice(1) : rootLabel).split("/");
+  if (segments.length <= 2) return rootLabel;
+  const first = segments[0];
+  const last = segments[segments.length - 1];
+  return `${isAbsolute ? "/" : ""}${first}/…/${last}`;
+}

--- a/clients/gui-app/src/components/chat/composer/menu/slash-menu-item.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/slash-menu-item.tsx
@@ -12,10 +12,7 @@ export function SlashMenuItem(props: SlashMenuItemProps) {
       <span className="shrink-0 font-mono text-code text-foreground">
         /{command.name}
       </span>
-      <span
-        className="min-w-0 flex-1 truncate text-ui-xs text-muted-foreground/70"
-        title={command.description}
-      >
+      <span className="min-w-0 flex-1 truncate text-ui-xs text-muted-foreground/70">
         {command.description}
         {argHint.length > 0 ? (
           <span className="ml-1 font-mono text-code-xs">{argHint}</span>

--- a/clients/gui-app/src/components/chat/composer/menu/zero-dom-rect.ts
+++ b/clients/gui-app/src/components/chat/composer/menu/zero-dom-rect.ts
@@ -1,0 +1,21 @@
+/**
+ * Zero-size fallback for a floating-ui virtual reference's
+ * `getBoundingClientRect()` when nothing is measurable yet (e.g. the caret
+ * or active row rect isn't available on the first render). `DOMRect` isn't
+ * guaranteed to exist as a constructible global in every environment this
+ * module can load in, so fall back to a plain object of the same shape.
+ */
+export const ZERO_DOM_RECT: DOMRect =
+  typeof DOMRect === "function"
+    ? new DOMRect(0, 0, 0, 0)
+    : {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        toJSON: () => ({}),
+      };

--- a/clients/gui-app/src/components/chat/composer/picker/composer-picker-store.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/composer-picker-store.ts
@@ -4,7 +4,7 @@ import {
   type MentionFlowStep,
   type MentionMenuEntry,
 } from "@/lib/composer/mentions";
-import type { SlashCommand } from "@/lib/composer/types";
+import type { MentionPreview, SlashCommand } from "@/lib/composer/types";
 
 export type ComposerPickerKind = "mention" | "slash";
 
@@ -25,6 +25,17 @@ export type ComposerPickerItem =
       readonly command: SlashCommand;
     };
 
+/**
+ * Uniform preview lookup for either picker item shape - the side preview
+ * panel reads the active item via this instead of branching on `kind` itself.
+ */
+export function pickerItemPreview(
+  item: ComposerPickerItem,
+): MentionPreview | null {
+  if (item.kind === "mention") return item.entry.preview;
+  return item.command.preview;
+}
+
 export type ComposerPickerCommit = (item: ComposerPickerItem) => void;
 
 export type ComposerPickerClientRect = () => DOMRect | null;
@@ -40,6 +51,13 @@ export interface ComposerPickerState {
   readonly itemsForStepId: string | null;
   readonly activeIndex: number;
   readonly loading: boolean;
+  /**
+   * Background-refetch indicator, distinct from `loading`: true while a
+   * mention/slash query is refetching behind `placeholderData` (prior results
+   * still shown), so the menu header can show a subtle spinner without the
+   * list collapsing the way the full `loading` state implies.
+   */
+  readonly fetching: boolean;
   readonly commit: ComposerPickerCommit | null;
   /**
    * Latest viewport rect of the suggestion range (trigger char + query).
@@ -86,6 +104,7 @@ export interface ComposerPickerActions {
     readonly step: MentionFlowStep;
     readonly loading: boolean;
   }) => void;
+  readonly setFetching: (fetching: boolean) => void;
   readonly setActiveIndex: (index: number) => void;
   readonly moveActive: (direction: 1 | -1) => void;
   readonly commitActiveItem: () => boolean;
@@ -112,6 +131,7 @@ const INITIAL_STATE: ComposerPickerState = {
   itemsForStepId: null,
   activeIndex: 0,
   loading: false,
+  fetching: false,
   commit: null,
   clientRect: null,
   knownSlashCommands: null,
@@ -148,6 +168,7 @@ export function createComposerPickerStore(): ComposerPickerStore {
         itemsForStepId: null,
         activeIndex: 0,
         loading: false,
+        fetching: false,
         commit,
         clientRect,
       });
@@ -187,6 +208,7 @@ export function createComposerPickerStore(): ComposerPickerStore {
         itemsForStepId: null,
         activeIndex: 0,
         loading: false,
+        fetching: false,
       });
     },
 
@@ -221,6 +243,11 @@ export function createComposerPickerStore(): ComposerPickerStore {
       }
       if (previous.loading === loading) return;
       set({ loading });
+    },
+
+    setFetching: (fetching) => {
+      if (get().fetching === fetching) return;
+      set({ fetching });
     },
 
     setActiveIndex: (index) => {

--- a/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
@@ -196,12 +196,18 @@ export function useMentionItems(params: UseMentionItemsParams): void {
     [active, debouncedRequestContext, step],
   );
 
-  const { data: workspaceEntries, isLoading: workspaceLoading } =
-    useWorkspaceEntries({ requests: workspaceRequests, client: hostClient });
-  const { data: remoteEpicEntries, isLoading: epicLoading } =
-    useEpicMentionEntries({
-      requests: epicRequests,
-    });
+  const {
+    data: workspaceEntries,
+    isLoading: workspaceLoading,
+    isFetching: workspaceFetching,
+  } = useWorkspaceEntries({ requests: workspaceRequests, client: hostClient });
+  const {
+    data: remoteEpicEntries,
+    isLoading: epicLoading,
+    isFetching: epicFetching,
+  } = useEpicMentionEntries({
+    requests: epicRequests,
+  });
   const epicTitleByIdFromCache = useMemo(() => {
     if (cachedEpicTasks.length === 0) return EMPTY_TITLE_MAP;
     const titles = new Map<string, string>();
@@ -299,6 +305,11 @@ export function useMentionItems(params: UseMentionItemsParams): void {
     ((workspaceRequests.length > 0 && workspaceLoading) ||
       (epicRequests.length > 0 && epicLoading));
 
+  const fetching =
+    active &&
+    ((workspaceRequests.length > 0 && workspaceFetching) ||
+      (epicRequests.length > 0 && epicFetching));
+
   useEffect(() => {
     if (!active) return;
     pickerStore.getState().setItems({
@@ -309,6 +320,11 @@ export function useMentionItems(params: UseMentionItemsParams): void {
       loading,
     });
   }, [active, items, loading, pickerStore, query, step]);
+
+  useEffect(() => {
+    if (!active) return;
+    pickerStore.getState().setFetching(fetching);
+  }, [active, fetching, pickerStore]);
 }
 
 const EMPTY_CHAT_ENTRIES: ReadonlyArray<EpicChatMentionEntry> = [];

--- a/clients/gui-app/src/components/chat/composer/picker/use-slash-items.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/use-slash-items.ts
@@ -42,7 +42,11 @@ export function useSlashItems(params: UseSlashItemsParams): void {
   const slice = useStore(pickerStore, useShallow(selectSlashSlice));
   const { active, query } = slice;
 
-  const { data: commands, isLoading } = useSlashCommands(query, {
+  const {
+    data: commands,
+    isLoading,
+    isFetching,
+  } = useSlashCommands(query, {
     hostClient,
     harnessId,
     workingDirectories,
@@ -69,6 +73,11 @@ export function useSlashItems(params: UseSlashItemsParams): void {
       loading: isLoading,
     });
   }, [active, isLoading, items, pickerStore, query]);
+
+  useEffect(() => {
+    if (!active) return;
+    pickerStore.getState().setFetching(isFetching);
+  }, [active, isFetching, pickerStore]);
 }
 
 const STATIC_STEP = { kind: "root" as const };

--- a/clients/gui-app/src/components/home/composer/composer-body.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-body.tsx
@@ -101,6 +101,7 @@ export function ComposerBody({
                 disabled={false}
                 placeholder={COMPOSER_PLACEHOLDER}
                 editorClassName={editorClassName}
+                stabilizeImageAttachmentCaret={false}
                 onSnapshot={onSnapshot}
                 onSubmit={onSubmit}
                 onPaste={paste.onPaste}

--- a/clients/gui-app/src/components/layout/__tests__/desktop-zoom-controller.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-zoom-controller.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { LazyMotion, domAnimation } from "motion/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 import { DesktopZoomController } from "@/components/layout/bridges/desktop-zoom-controller";
@@ -158,6 +159,9 @@ describe("<DesktopZoomController />", () => {
     expect(zoomIsland.contains(zoomOutButton)).toBe(true);
     expect(zoomIsland.contains(resetButton)).toBe(false);
     expect(percent.textContent).toBe("125%");
+    expect(resetButton.className).toContain("bg-popover");
+    expect(resetButton.className).toContain("dark:bg-popover");
+    expect(resetButton.className).not.toMatch(/dark:bg-input/);
 
     fireEvent.click(zoomOutButton);
     fireEvent.click(zoomInButton);
@@ -177,7 +181,11 @@ describe("<DesktopZoomController />", () => {
     act(() => {
       vi.advanceTimersByTime(2_000);
     });
-    expect(screen.queryByTestId("desktop-zoom-indicator")).toBeNull();
+    const exitingIndicator = screen.getByTestId("desktop-zoom-indicator");
+    expect(exitingIndicator.getAttribute("style")).toContain("opacity: 0");
+    expect(exitingIndicator.getAttribute("style")).toContain(
+      "translateY(8px) scale(0.98)",
+    );
   });
 });
 
@@ -193,7 +201,9 @@ function createQueryClient(): QueryClient {
 function renderWithQueryClient(children: ReactNode): void {
   render(
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>{children}</TooltipProvider>
+      <TooltipProvider>
+        <LazyMotion features={domAnimation}>{children}</LazyMotion>
+      </TooltipProvider>
     </QueryClientProvider>,
   );
 }

--- a/clients/gui-app/src/components/layout/__tests__/desktop-zoom-controller.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-zoom-controller.test.tsx
@@ -181,11 +181,14 @@ describe("<DesktopZoomController />", () => {
     act(() => {
       vi.advanceTimersByTime(2_000);
     });
+    // Still mounted during the AnimatePresence exit (not removed instantly), with
+    // an inline style Motion drives toward the exit target. Assert the animated
+    // properties are present rather than Motion's exact serialization, which can
+    // change across versions.
     const exitingIndicator = screen.getByTestId("desktop-zoom-indicator");
-    expect(exitingIndicator.getAttribute("style")).toContain("opacity: 0");
-    expect(exitingIndicator.getAttribute("style")).toContain(
-      "translateY(8px) scale(0.98)",
-    );
+    const exitStyle = exitingIndicator.getAttribute("style") ?? "";
+    expect(exitStyle).toMatch(/opacity/);
+    expect(exitStyle).toMatch(/transform/);
   });
 });
 

--- a/clients/gui-app/src/components/layout/bridges/desktop-zoom-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/desktop-zoom-controller.tsx
@@ -200,6 +200,7 @@ function DesktopZoomIndicator(props: {
     <AnimatePresence initial={false}>
       {zoom !== null && percent !== null ? (
         <m.div
+          key="desktop-zoom-indicator"
           initial={{ opacity: 0, y: 8, scale: 0.98 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
           exit={{ opacity: 0, y: 8, scale: 0.98 }}

--- a/clients/gui-app/src/components/layout/bridges/desktop-zoom-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/desktop-zoom-controller.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Minus, Plus, RotateCcw } from "lucide-react";
+import { AnimatePresence } from "motion/react";
+import * as m from "motion/react-m";
 import { Button } from "@/components/ui/button";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
@@ -10,6 +12,7 @@ import {
   useRunnerZoomStepOutMutation,
 } from "@/hooks/runner/use-runner-zoom";
 import { registerDynamicActionHandler } from "@/lib/keybindings/dispatch";
+import { cn } from "@/lib/utils";
 import { formatZoomPercent } from "@/lib/windows/format-zoom-percent";
 import type { DesktopZoomBridge } from "@/lib/windows/types";
 
@@ -18,6 +21,7 @@ const WHEEL_STEP_THRESHOLD_PX = 80;
 const LINE_DELTA_PX = 16;
 const PAGE_DELTA_PX = 800;
 const PINCH_STEP_RATIO = 1.08;
+const INDICATOR_TRANSITION = { duration: 0.16, ease: "easeOut" } as const;
 
 export function DesktopZoomController() {
   const zoom = useDesktopZoomBridge();
@@ -192,88 +196,95 @@ function DesktopZoomIndicator(props: {
     };
   }, [zoom]);
 
-  if (zoom === null || percent === null) {
-    return null;
-  }
-
   return (
-    <div
-      className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-1/2 z-[70] flex -translate-x-1/2 items-center gap-2 text-popover-foreground"
-      role="status"
-      aria-live="polite"
-      data-testid="desktop-zoom-indicator"
-    >
-      <div
-        className="flex h-10 min-w-36 items-center rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg"
-        data-testid="desktop-zoom-level-island"
-      >
-        <TooltipWrapper
-          label="Zoom out"
-          side="top"
-          sideOffset={8}
-          align="center"
+    <AnimatePresence initial={false}>
+      {zoom !== null && percent !== null ? (
+        <m.div
+          initial={{ opacity: 0, y: 8, scale: 0.98 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: 8, scale: 0.98 }}
+          transition={INDICATOR_TRANSITION}
+          className="fixed bottom-[max(1rem,env(safe-area-inset-bottom))] left-1/2 z-[70] flex -translate-x-1/2 items-center gap-2 text-popover-foreground"
+          role="status"
+          aria-live="polite"
+          data-testid="desktop-zoom-indicator"
         >
+          <div
+            className="flex h-10 min-w-36 items-center rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg"
+            data-testid="desktop-zoom-level-island"
+          >
+            <TooltipWrapper
+              label="Zoom out"
+              side="top"
+              sideOffset={8}
+              align="center"
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Zoom out"
+                className="size-8 rounded-sm text-muted-foreground hover:text-foreground"
+                onClick={() => {
+                  void actions.stepOut().catch(() => undefined);
+                }}
+              >
+                <Minus aria-hidden="true" />
+              </Button>
+            </TooltipWrapper>
+            <div
+              className="flex min-w-16 flex-1 items-center justify-center px-2 text-ui-sm font-semibold tabular-nums"
+              data-testid="desktop-zoom-percent"
+            >
+              {formatZoomPercent(percent)}
+            </div>
+            <TooltipWrapper
+              label="Zoom in"
+              side="top"
+              sideOffset={8}
+              align="center"
+            >
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Zoom in"
+                className="size-8 rounded-sm text-muted-foreground hover:text-foreground"
+                onClick={() => {
+                  void actions.stepIn().catch(() => undefined);
+                }}
+              >
+                <Plus aria-hidden="true" />
+              </Button>
+            </TooltipWrapper>
+          </div>
           <Button
             type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Zoom out"
-            className="size-8 rounded-sm text-muted-foreground hover:text-foreground"
+            variant="outline"
+            size="sm"
+            className={cn(
+              "h-10 rounded-md border-border bg-popover px-4 text-popover-foreground shadow-lg hover:bg-accent hover:text-accent-foreground",
+              "dark:border-border dark:bg-popover dark:hover:bg-accent",
+            )}
+            data-testid="desktop-zoom-reset-island"
+            disabled={resetPending}
             onClick={() => {
-              void actions.stepOut().catch(() => undefined);
+              void actions.reset().catch(() => undefined);
             }}
           >
-            <Minus aria-hidden="true" />
+            <RotateCcw aria-hidden="true" />
+            Reset to 100%
+            {resetPending ? (
+              <AgentSpinningDots
+                className="ml-1 text-current"
+                testId="desktop-zoom-reset-pending"
+                variant="dots2"
+              />
+            ) : null}
           </Button>
-        </TooltipWrapper>
-        <div
-          className="flex min-w-16 flex-1 items-center justify-center px-2 text-ui-sm font-semibold tabular-nums"
-          data-testid="desktop-zoom-percent"
-        >
-          {formatZoomPercent(percent)}
-        </div>
-        <TooltipWrapper
-          label="Zoom in"
-          side="top"
-          sideOffset={8}
-          align="center"
-        >
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Zoom in"
-            className="size-8 rounded-sm text-muted-foreground hover:text-foreground"
-            onClick={() => {
-              void actions.stepIn().catch(() => undefined);
-            }}
-          >
-            <Plus aria-hidden="true" />
-          </Button>
-        </TooltipWrapper>
-      </div>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="h-10 rounded-md border-border bg-popover px-4 text-popover-foreground shadow-lg hover:bg-accent hover:text-accent-foreground"
-        data-testid="desktop-zoom-reset-island"
-        disabled={resetPending}
-        onClick={() => {
-          void actions.reset().catch(() => undefined);
-        }}
-      >
-        <RotateCcw aria-hidden="true" />
-        Reset to 100%
-        {resetPending ? (
-          <AgentSpinningDots
-            className="ml-1 text-current"
-            testId="desktop-zoom-reset-pending"
-            variant="dots2"
-          />
-        ) : null}
-      </Button>
-    </div>
+        </m.div>
+      ) : null}
+    </AnimatePresence>
   );
 }
 

--- a/clients/gui-app/src/hooks/composer/__tests__/use-slash-commands.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-slash-commands.test.tsx
@@ -12,6 +12,7 @@ const mockState = vi.hoisted(() => ({
   }>,
   data: null as ListGuiAgentCommandsResponse | null,
   isPending: false,
+  isFetching: false,
   error: null as Error | null,
 }));
 
@@ -32,6 +33,7 @@ vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
     return {
       data: mockState.data,
       isPending: mockState.isPending,
+      isFetching: mockState.isFetching,
       error: mockState.error,
     };
   },
@@ -70,6 +72,7 @@ describe("useSlashCommands", () => {
       ],
     };
     mockState.isPending = false;
+    mockState.isFetching = false;
     mockState.error = null;
   });
 

--- a/clients/gui-app/src/hooks/composer/use-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-composer-paste.ts
@@ -209,6 +209,7 @@ export function useComposerPaste(editorRef: {
 export function insertImageAttachmentsCommand(
   editor: Editor,
   attrs: ReadonlyArray<ImageAttachmentAttrs>,
+  stabilizeCaretBoundary: boolean,
 ): void {
   if (attrs.length === 0) return;
   let chain = editor.chain();
@@ -216,4 +217,21 @@ export function insertImageAttachmentsCommand(
     chain = chain.insertImageAttachment(attr);
   }
   chain.run();
+  if (stabilizeCaretBoundary) {
+    stabilizeTerminalImageAttachmentCaret(editor);
+  }
+}
+
+function stabilizeTerminalImageAttachmentCaret(editor: Editor): void {
+  const { selection } = editor.state;
+  if (!selection.empty) return;
+  const { $from } = selection;
+  if (!$from.parent.inlineContent) return;
+  const nodeBefore = $from.nodeBefore;
+  if (nodeBefore?.type.name !== "imageAttachment") return;
+  if ($from.nodeAfter !== null) return;
+
+  const boundaryPos = selection.from;
+  editor.commands.insertContent({ type: "text", text: " " });
+  editor.commands.setTextSelection(boundaryPos);
 }

--- a/clients/gui-app/src/hooks/composer/use-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-composer-paste.ts
@@ -232,6 +232,9 @@ function stabilizeTerminalImageAttachmentCaret(editor: Editor): void {
   if ($from.nodeAfter !== null) return;
 
   const boundaryPos = selection.from;
-  editor.commands.insertContent({ type: "text", text: " " });
-  editor.commands.setTextSelection(boundaryPos);
+  editor
+    .chain()
+    .insertContent({ type: "text", text: " " })
+    .setTextSelection(boundaryPos)
+    .run();
 }

--- a/clients/gui-app/src/hooks/composer/use-epic-mention-entries.ts
+++ b/clients/gui-app/src/hooks/composer/use-epic-mention-entries.ts
@@ -1,3 +1,4 @@
+import { keepPreviousData } from "@tanstack/react-query";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { EpicMentionSuggestion } from "@traycer/protocol/host/index";
 import type { HostRpcRegistry } from "@/lib/host";
@@ -30,7 +31,7 @@ export function useEpicMentionEntries(
   const queries = useHostQueries<HostRpcRegistry, EpicMentionMethod>({
     client,
     requests: params.requests,
-    options: { staleTime: 15_000 },
+    options: { staleTime: 15_000, placeholderData: keepPreviousData },
   });
 
   return {

--- a/clients/gui-app/src/hooks/composer/use-slash-commands.ts
+++ b/clients/gui-app/src/hooks/composer/use-slash-commands.ts
@@ -1,13 +1,21 @@
 import { useMemo } from "react";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
-import type { GuiHarnessId } from "@traycer/protocol/host/index";
+import type {
+  GuiAgentCommandOption,
+  GuiHarnessId,
+} from "@traycer/protocol/host/index";
 import { useGuiHarnessCommandsQuery } from "@/hooks/harnesses/use-gui-harness-catalog";
 import type { HostRpcRegistry } from "@/lib/host";
-import type { ProviderSlashCommand, SlashCommand } from "@/lib/composer/types";
+import type {
+  MentionPreview,
+  ProviderSlashCommand,
+  SlashCommand,
+} from "@/lib/composer/types";
 
 export interface UseSlashCommandsResult {
   data: ReadonlyArray<SlashCommand>;
   isLoading: boolean;
+  isFetching: boolean;
   error: Error | null;
 }
 
@@ -53,6 +61,7 @@ export function useSlashCommands(
     ).map((command): ProviderSlashCommand => ({
       ...command,
       source: "provider",
+      preview: slashCommandPreview(command),
     }));
     return dedupeSlashCommands(providerCommands).toSorted(compareCommandNames);
   }, [commandsQuery.data?.commands]);
@@ -77,7 +86,25 @@ export function useSlashCommands(
   return {
     data,
     isLoading: params.enabled && commandsQuery.isPending,
+    isFetching: params.enabled && commandsQuery.isFetching,
     error: commandsQuery.error,
+  };
+}
+
+/**
+ * The full command description plus its usage hint (when the command takes
+ * arguments), as the preview panel's single named field for a slash entry.
+ */
+function slashCommandPreview(command: GuiAgentCommandOption): MentionPreview {
+  const usage = command.argumentHint;
+  return {
+    kind: "text",
+    primary:
+      usage === null || usage.length === 0
+        ? command.description
+        : `${command.description} ${usage}`,
+    secondary: null,
+    mono: false,
   };
 }
 

--- a/clients/gui-app/src/hooks/composer/use-workspace-entries.ts
+++ b/clients/gui-app/src/hooks/composer/use-workspace-entries.ts
@@ -1,3 +1,4 @@
+import { keepPreviousData } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { WorkspaceMentionSuggestion } from "@traycer/protocol/host/index";
@@ -16,6 +17,7 @@ export interface UseWorkspaceEntriesParams {
 export interface UseWorkspaceEntriesResult {
   data: ReadonlyArray<WorkspaceMentionSuggestion>;
   isLoading: boolean;
+  isFetching: boolean;
   error: HostRpcError | null;
 }
 
@@ -25,12 +27,13 @@ export function useWorkspaceEntries(
   const queries = useHostQueries<HostRpcRegistry, WorkspaceMentionMethod>({
     client: params.client,
     requests: params.requests,
-    options: { staleTime: 30_000 },
+    options: { staleTime: 30_000, placeholderData: keepPreviousData },
   });
 
   return {
     data: queries.flatMap((query) => query.data?.entries ?? EMPTY),
     isLoading: queries.some((query) => query.isLoading),
+    isFetching: queries.some((query) => query.isFetching),
     error: queries.find((query) => query.error !== null)?.error ?? null,
   };
 }

--- a/clients/gui-app/src/hooks/host/use-host-queries.ts
+++ b/clients/gui-app/src/hooks/host/use-host-queries.ts
@@ -34,7 +34,7 @@ export interface UseHostQueriesOptions<
       HostRpcError,
       ResponseOfMethod<Registry, Method>
     >,
-    "staleTime" | "enabled" | "gcTime" | "refetchInterval"
+    "staleTime" | "enabled" | "gcTime" | "refetchInterval" | "placeholderData"
   > | null;
 }
 

--- a/clients/gui-app/src/lib/__tests__/path.test.ts
+++ b/clients/gui-app/src/lib/__tests__/path.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { mentionPathTree } from "../path";
+
+describe("mentionPathTree", () => {
+  it("collapses a deep path to a 4-row tree: root prefix + 2 mid dirs + leaf", () => {
+    expect(
+      mentionPathTree(
+        "trayer/clients/gui-app/src/components/home/toolbar/composer-toolbar.tsx",
+        true,
+      ),
+    ).toEqual({
+      rootLabel: "trayer/clients/gui-app/src/components",
+      midDirs: ["home", "toolbar"],
+      leaf: "composer-toolbar.tsx",
+      leafIsFile: true,
+    });
+  });
+
+  it("renders a shallow path as root + 1 mid dir + leaf", () => {
+    expect(mentionPathTree("authn-v3/src/sentry.ts", true)).toEqual({
+      rootLabel: "authn-v3",
+      midDirs: ["src"],
+      leaf: "sentry.ts",
+      leafIsFile: true,
+    });
+  });
+
+  it("renders a root-level file with no dir rows", () => {
+    expect(mentionPathTree(".gitattributes", true)).toEqual({
+      rootLabel: "",
+      midDirs: [],
+      leaf: ".gitattributes",
+      leafIsFile: true,
+    });
+  });
+
+  it("marks a folder leaf as leafIsFile: false", () => {
+    // Folder relPaths carry a trailing slash from the host.
+    expect(mentionPathTree("src/auth/", false)).toEqual({
+      rootLabel: "src",
+      midDirs: [],
+      leaf: "auth",
+      leafIsFile: false,
+    });
+  });
+
+  it("never exceeds 2 mid dirs regardless of path depth", () => {
+    const tree = mentionPathTree("a/b/c/d/e/f/g/h/deep-file.ts", true);
+    expect(tree.midDirs.length).toBeLessThanOrEqual(2);
+    expect(tree).toEqual({
+      rootLabel: "a/b/c/d/e/f",
+      midDirs: ["g", "h"],
+      leaf: "deep-file.ts",
+      leafIsFile: true,
+    });
+  });
+
+  it("preserves the leading slash on an absolute worktree path", () => {
+    expect(
+      mentionPathTree("/home/u/.traycer/worktrees/o/r/feature", false),
+    ).toEqual({
+      rootLabel: "/home/u/.traycer/worktrees",
+      midDirs: ["o", "r"],
+      leaf: "feature",
+      leafIsFile: false,
+    });
+  });
+
+  it("handles a shallow absolute path with no mid dirs", () => {
+    expect(mentionPathTree("/repo/feature-branch", false)).toEqual({
+      rootLabel: "/repo",
+      midDirs: [],
+      leaf: "feature-branch",
+      leafIsFile: false,
+    });
+  });
+
+  it("preserves the absolute marker on the leaf for a single-segment absolute path", () => {
+    // Regression: with no directory rows, rootLabel is "" and previously
+    // nothing carried the leading "/" - a worktree mounted at "/repo" would
+    // render identically to a relative dir named "repo". The leaf now
+    // carries the marker instead.
+    expect(mentionPathTree("/repo", false)).toEqual({
+      rootLabel: "",
+      midDirs: [],
+      leaf: "/repo",
+      leafIsFile: false,
+    });
+  });
+});

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type {
   ComposerMentionProviderContext,
+  MentionFlowStep,
   MentionMenuEntry,
 } from "../providers";
 import { mentionProviderRegistry, ROOT_MENTION_STEP } from "../providers";
@@ -350,6 +351,208 @@ describe("mention provider registry", () => {
     ).toMatchObject({
       method: "epic.mentionEpics",
       params: { query: "" },
+    });
+  });
+});
+
+describe("mention preview payloads", () => {
+  it("previews a file entry as a path breadcrumb tree with its absolute-path footer", () => {
+    const step: MentionFlowStep = {
+      kind: "provider",
+      providerId: "files",
+      stepId: "root",
+      workspacePath: null,
+    };
+    const entries = mentionProviderRegistry.entries(
+      step,
+      context({
+        workspaceEntries: [
+          {
+            kind: "file",
+            id: "file:/repo:src/auth.ts",
+            label: "auth.ts",
+            relPath: "src/auth.ts",
+            absolutePath: "/repo/src/auth.ts",
+            workspacePath: "/repo",
+            description: "src",
+          },
+        ],
+      }),
+    );
+    expect(entries[1].preview).toEqual({
+      kind: "path",
+      tree: {
+        rootLabel: "src",
+        midDirs: [],
+        leaf: "auth.ts",
+        leafIsFile: true,
+      },
+      footer: { text: "/repo/src/auth.ts", mono: true },
+    });
+  });
+
+  it("previews a folder entry as a path tree with leafIsFile: false", () => {
+    const step: MentionFlowStep = {
+      kind: "provider",
+      providerId: "folders",
+      stepId: "root",
+      workspacePath: null,
+    };
+    const entries = mentionProviderRegistry.entries(
+      step,
+      context({
+        workspaceEntries: [
+          {
+            kind: "folder",
+            id: "folder:/repo:src/auth/",
+            label: "auth",
+            relPath: "src/auth/",
+            absolutePath: "/repo/src/auth",
+            workspacePath: "/repo",
+            description: "src",
+          },
+        ],
+      }),
+    );
+    expect(entries[1].preview).toEqual({
+      kind: "path",
+      tree: {
+        rootLabel: "src",
+        midDirs: [],
+        leaf: "auth",
+        leafIsFile: false,
+      },
+      footer: { text: "/repo/src/auth", mono: true },
+    });
+  });
+
+  it("previews a worktree entry as a path tree built from its absolute path, with the branch as footer", () => {
+    const step: MentionFlowStep = {
+      kind: "provider",
+      providerId: "worktree",
+      stepId: "root",
+      workspacePath: null,
+    };
+    const entries = mentionProviderRegistry.entries(
+      step,
+      context({
+        workspaceEntries: [
+          {
+            kind: "worktree",
+            id: "worktree:/repo:/home/u/.traycer/worktrees/o/r/feature",
+            label: "feature",
+            worktreePath: "/home/u/.traycer/worktrees/o/r/feature",
+            workspacePath: "/repo",
+            branch: "feature",
+            isMain: false,
+            description: "/home/u/.traycer/worktrees/o/r/feature",
+          },
+        ],
+      }),
+    );
+    expect(entries[1].preview).toEqual({
+      kind: "path",
+      tree: {
+        rootLabel: "/home/u/.traycer/worktrees",
+        midDirs: ["o", "r"],
+        leaf: "feature",
+        leafIsFile: false,
+      },
+      footer: { text: "feature", mono: false },
+    });
+  });
+
+  it("previews a detached worktree (no branch) with no footer, not a duplicated path", () => {
+    const step: MentionFlowStep = {
+      kind: "provider",
+      providerId: "worktree",
+      stepId: "root",
+      workspacePath: null,
+    };
+    const entries = mentionProviderRegistry.entries(
+      step,
+      context({
+        workspaceEntries: [
+          {
+            kind: "worktree",
+            id: "worktree:/repo:/home/u/.traycer/worktrees/o/r/detached",
+            label: "detached",
+            worktreePath: "/home/u/.traycer/worktrees/o/r/detached",
+            workspacePath: "/repo",
+            branch: null,
+            isMain: false,
+            description: "/home/u/.traycer/worktrees/o/r/detached",
+          },
+        ],
+      }),
+    );
+    expect(entries[1].preview).toMatchObject({ kind: "path", footer: null });
+  });
+
+  it("previews an artifact entry with its full title and parent epic title", () => {
+    const step: MentionFlowStep = {
+      kind: "provider",
+      providerId: "spec",
+      stepId: "root",
+      workspacePath: null,
+    };
+    const entries = mentionProviderRegistry.entries(
+      step,
+      context({
+        epicEntries: [
+          {
+            kind: "epic-artifact",
+            id: "spec:epic-1:spec-1",
+            token: "spec:epic-1/spec-1",
+            epicId: "epic-1",
+            epicTitle: "Auth epic",
+            artifactId: "spec-1",
+            artifactType: "spec",
+            label: "Auth spec",
+            description: "Auth epic",
+            status: null,
+            updatedAt: 20,
+          },
+        ],
+      }),
+    );
+    expect(entries[1].preview).toEqual({
+      kind: "text",
+      primary: "Auth spec",
+      secondary: "Auth epic",
+      mono: false,
+    });
+  });
+
+  it("previews a git commit entry with its full hash and derived subject", () => {
+    const step: MentionFlowStep = {
+      kind: "provider",
+      providerId: "git",
+      stepId: "commits",
+      workspacePath: "/repo",
+    };
+    const entries = mentionProviderRegistry.entries(
+      step,
+      context({
+        workspaceEntries: [
+          {
+            kind: "git",
+            id: "git:commit:/repo:abc1234567890",
+            label: "abc1234 Fix bug in parser",
+            description: "Jane Doe - 2024-01-01 - repo",
+            workspacePath: "/repo",
+            gitType: "against_commit",
+            branchName: null,
+            commitHash: "abc1234567890",
+          },
+        ],
+      }),
+    );
+    expect(entries[1].preview).toEqual({
+      kind: "text",
+      primary: "abc1234567890",
+      secondary: "Fix bug in parser",
+      mono: true,
     });
   });
 });

--- a/clients/gui-app/src/lib/composer/mentions/mention-entry-display.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/mention-entry-display.tsx
@@ -1,0 +1,159 @@
+import {
+  Folder,
+  FolderGit2,
+  GitBranch,
+  Layers,
+  type LucideIcon,
+} from "lucide-react";
+import type { ReactElement } from "react";
+import { MaterialFileIcon } from "@/components/material-file-icon";
+import { EPIC_NODE_ICONS } from "@/lib/artifacts/node-display";
+import type {
+  EpicMentionEntry,
+  MentionPreview,
+  WorkspaceEntry,
+} from "@/lib/composer/types";
+import { dirnameOfPath, mentionPathTree } from "@/lib/path";
+import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+
+/**
+ * Row-display mapping for @mention suggestion entries: the picker's
+ * detail/description text, full preview payload, and icon, derived per
+ * entry kind. Extracted out of `providers.tsx` (provider registration +
+ * routing) to keep that file focused - `suggestionEntry` there is the only
+ * caller.
+ */
+export const MENU_ICON_CLASS = "size-4 shrink-0 text-muted-foreground";
+
+export function detailForSuggestion(
+  entry: WorkspaceEntry | EpicMentionEntry,
+): string {
+  if (entry.kind === "file" || entry.kind === "folder") {
+    return dirnameOfPath(entry.relPath);
+  }
+  if (entry.kind === "epic-chat") return entry.epicTitle;
+  if (entry.kind === "epic-artifact") return entry.epicTitle;
+  return "";
+}
+
+export function descriptionForSuggestion(
+  entry: WorkspaceEntry | EpicMentionEntry,
+): string {
+  if (entry.kind === "epic-artifact" && entry.description === entry.epicTitle) {
+    return "";
+  }
+  if (entry.kind === "epic-chat" && entry.description === entry.epicTitle) {
+    return "";
+  }
+  return entry.description;
+}
+
+export function previewForSuggestion(
+  entry: WorkspaceEntry | EpicMentionEntry,
+): MentionPreview | null {
+  switch (entry.kind) {
+    case "file":
+    case "folder":
+      return {
+        kind: "path",
+        tree: mentionPathTree(entry.relPath, entry.kind === "file"),
+        footer: { text: entry.absolutePath, mono: true },
+      };
+    case "worktree":
+      return {
+        kind: "path",
+        tree: mentionPathTree(entry.worktreePath, false),
+        footer:
+          entry.branch === null ? null : { text: entry.branch, mono: false },
+      };
+    case "git":
+      return previewForGitSuggestion(entry);
+    case "epic":
+      return {
+        kind: "text",
+        primary: entry.label,
+        secondary: null,
+        mono: false,
+      };
+    case "epic-artifact":
+    case "epic-chat":
+      return {
+        kind: "text",
+        primary: entry.label,
+        secondary: entry.epicTitle,
+        mono: false,
+      };
+  }
+}
+
+function previewForGitSuggestion(
+  entry: Extract<WorkspaceEntry, { kind: "git" }>,
+): MentionPreview | null {
+  switch (entry.gitType) {
+    case "against_uncommitted_changes":
+      return null;
+    case "against_branch":
+      return {
+        kind: "text",
+        primary: entry.branchName,
+        secondary: null,
+        mono: true,
+      };
+    case "against_commit":
+      return {
+        kind: "text",
+        primary: entry.commitHash,
+        secondary: commitSubjectFromLabel(entry.label),
+        mono: true,
+      };
+  }
+}
+
+/**
+ * The host bakes a commit row's label as `${shortHash} ${subject}` (see
+ * `buildGitCommitSuggestion`) with no separate subject field over the wire;
+ * strip the leading short-hash token to recover the subject for the preview.
+ */
+function commitSubjectFromLabel(label: string): string {
+  const spaceIndex = label.indexOf(" ");
+  return spaceIndex === -1 ? "" : label.slice(spaceIndex + 1);
+}
+
+export function iconForSuggestion(
+  entry: WorkspaceEntry | EpicMentionEntry,
+): ReactElement {
+  if (entry.kind === "file") {
+    return <MaterialFileIcon filename={entry.relPath} className="size-4" />;
+  }
+  if (entry.kind === "folder") return folderIcon();
+  if (entry.kind === "worktree") return worktreeIcon();
+  if (entry.kind === "epic") return epicIcon();
+  if (entry.kind === "epic-artifact") return artifactIcon(entry.artifactType);
+  if (entry.kind === "epic-chat") return epicNodeIcon("chat");
+  return gitIcon();
+}
+
+export function folderIcon(): ReactElement {
+  return <Folder className={MENU_ICON_CLASS} aria-hidden />;
+}
+
+export function gitIcon(): ReactElement {
+  return <GitBranch className={MENU_ICON_CLASS} aria-hidden />;
+}
+
+export function worktreeIcon(): ReactElement {
+  return <FolderGit2 className={MENU_ICON_CLASS} aria-hidden />;
+}
+
+export function epicIcon(): ReactElement {
+  return <Layers className={MENU_ICON_CLASS} aria-hidden />;
+}
+
+export function artifactIcon(kind: EpicArtifactKind): ReactElement {
+  return epicNodeIcon(kind);
+}
+
+export function epicNodeIcon(kind: "chat" | EpicArtifactKind): ReactElement {
+  const Icon: LucideIcon = EPIC_NODE_ICONS[kind];
+  return <Icon className={MENU_ICON_CLASS} aria-hidden />;
+}

--- a/clients/gui-app/src/lib/composer/mentions/mention-entry-display.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/mention-entry-display.tsx
@@ -122,15 +122,22 @@ function commitSubjectFromLabel(label: string): string {
 export function iconForSuggestion(
   entry: WorkspaceEntry | EpicMentionEntry,
 ): ReactElement {
-  if (entry.kind === "file") {
-    return <MaterialFileIcon filename={entry.relPath} className="size-4" />;
+  switch (entry.kind) {
+    case "file":
+      return <MaterialFileIcon filename={entry.relPath} className="size-4" />;
+    case "folder":
+      return folderIcon();
+    case "worktree":
+      return worktreeIcon();
+    case "git":
+      return gitIcon();
+    case "epic":
+      return epicIcon();
+    case "epic-artifact":
+      return artifactIcon(entry.artifactType);
+    case "epic-chat":
+      return epicNodeIcon("chat");
   }
-  if (entry.kind === "folder") return folderIcon();
-  if (entry.kind === "worktree") return worktreeIcon();
-  if (entry.kind === "epic") return epicIcon();
-  if (entry.kind === "epic-artifact") return artifactIcon(entry.artifactType);
-  if (entry.kind === "epic-chat") return epicNodeIcon("chat");
-  return gitIcon();
 }
 
 export function folderIcon(): ReactElement {

--- a/clients/gui-app/src/lib/composer/mentions/providers.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/providers.tsx
@@ -1,33 +1,34 @@
-import {
-  CornerUpLeft,
-  File,
-  Folder,
-  FolderGit2,
-  GitBranch,
-  Layers,
-  type LucideIcon,
-} from "lucide-react";
+import { CornerUpLeft, File } from "lucide-react";
 import type { ReactElement } from "react";
 import { isSubsequence } from "@traycer/protocol/utils/text/fuzzy";
-import { MaterialFileIcon } from "@/components/material-file-icon";
-import {
-  EPIC_NODE_ICONS,
-  EPIC_NODE_LABELS,
-} from "@/lib/artifacts/node-display";
+import { EPIC_NODE_LABELS } from "@/lib/artifacts/node-display";
 import type {
   EpicChatMentionEntry,
   EpicMentionEntry,
   MentionAttachment,
+  MentionPreview,
   WorkspaceEntry,
 } from "@/lib/composer/types";
-import { basenameOfPath, dirnameOfPath } from "@/lib/path";
+import { basenameOfPath } from "@/lib/path";
 import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import type { RequestOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
 import { mentionAttachmentFromSuggestion } from "./attachments";
+import {
+  artifactIcon,
+  descriptionForSuggestion,
+  detailForSuggestion,
+  epicIcon,
+  epicNodeIcon,
+  folderIcon,
+  gitIcon,
+  iconForSuggestion,
+  MENU_ICON_CLASS,
+  previewForSuggestion,
+  worktreeIcon,
+} from "./mention-entry-display";
 import { taskMentionQueryForRequest } from "./task-mention-helpers";
 
-const MENU_ICON_CLASS = "size-4 shrink-0 text-muted-foreground";
 const EMPTY_MENU_ENTRIES: ReadonlyArray<MentionMenuEntry> = [];
 const EMPTY_WORKSPACE_REQUESTS: ReadonlyArray<MentionWorkspaceRequest> = [];
 const EMPTY_EPIC_REQUESTS: ReadonlyArray<MentionEpicRequest> = [];
@@ -61,6 +62,11 @@ export interface MentionMenuEntry {
   readonly description: string;
   readonly icon: ReactElement;
   readonly action: MentionMenuAction;
+  /**
+   * Full, untruncated preview content for the side preview panel. `null` for
+   * `Back` and category-navigate rows, which have nothing to preview.
+   */
+  readonly preview: MentionPreview | null;
 }
 
 export type WorkspacePathMentionMethod =
@@ -786,6 +792,7 @@ function navigateEntry(args: NavigateEntryArgs): MentionMenuEntry {
     description: args.description,
     icon: args.icon,
     action: { kind: "navigate", step: args.step },
+    preview: null,
   };
 }
 
@@ -797,6 +804,7 @@ function backEntry(description: string): MentionMenuEntry {
     description,
     icon: <CornerUpLeft className={MENU_ICON_CLASS} aria-hidden />,
     action: { kind: "back" },
+    preview: null,
   };
 }
 
@@ -813,6 +821,7 @@ function suggestionEntry(
       description: descriptionForSuggestion(entry),
       icon: iconForSuggestion(entry),
       action: { kind: "complete", mention },
+      preview: previewForSuggestion(entry),
     },
   ];
 }
@@ -928,66 +937,6 @@ function gitMethodForStep(stepId: string): WorkspaceGitMentionMethod {
   return "workspace.mentionGitRoot";
 }
 
-function detailForSuggestion(entry: WorkspaceEntry | EpicMentionEntry): string {
-  if (entry.kind === "file" || entry.kind === "folder") {
-    return dirnameOfPath(entry.relPath);
-  }
-  if (entry.kind === "epic-chat") return entry.epicTitle;
-  if (entry.kind === "epic-artifact") return entry.epicTitle;
-  return "";
-}
-
-function descriptionForSuggestion(
-  entry: WorkspaceEntry | EpicMentionEntry,
-): string {
-  if (entry.kind === "epic-artifact" && entry.description === entry.epicTitle) {
-    return "";
-  }
-  if (entry.kind === "epic-chat" && entry.description === entry.epicTitle) {
-    return "";
-  }
-  return entry.description;
-}
-
-function iconForSuggestion(
-  entry: WorkspaceEntry | EpicMentionEntry,
-): ReactElement {
-  if (entry.kind === "file") {
-    return <MaterialFileIcon filename={entry.relPath} className="size-4" />;
-  }
-  if (entry.kind === "folder") return folderIcon();
-  if (entry.kind === "worktree") return worktreeIcon();
-  if (entry.kind === "epic") return epicIcon();
-  if (entry.kind === "epic-artifact") return artifactIcon(entry.artifactType);
-  if (entry.kind === "epic-chat") return epicNodeIcon("chat");
-  return gitIcon();
-}
-
 function fileIcon(): ReactElement {
   return <File className={MENU_ICON_CLASS} aria-hidden />;
-}
-
-function folderIcon(): ReactElement {
-  return <Folder className={MENU_ICON_CLASS} aria-hidden />;
-}
-
-function gitIcon(): ReactElement {
-  return <GitBranch className={MENU_ICON_CLASS} aria-hidden />;
-}
-
-function worktreeIcon(): ReactElement {
-  return <FolderGit2 className={MENU_ICON_CLASS} aria-hidden />;
-}
-
-function epicIcon(): ReactElement {
-  return <Layers className={MENU_ICON_CLASS} aria-hidden />;
-}
-
-function artifactIcon(kind: EpicArtifactKind): ReactElement {
-  return epicNodeIcon(kind);
-}
-
-function epicNodeIcon(kind: "chat" | EpicArtifactKind): ReactElement {
-  const Icon: LucideIcon = EPIC_NODE_ICONS[kind];
-  return <Icon className={MENU_ICON_CLASS} aria-hidden />;
 }

--- a/clients/gui-app/src/lib/composer/types.ts
+++ b/clients/gui-app/src/lib/composer/types.ts
@@ -5,6 +5,7 @@ import type {
   WorkspaceMentionSuggestion,
 } from "@traycer/protocol/host/index";
 import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+import type { MentionPathTree } from "@/lib/path";
 
 export type PathKind = "file" | "folder";
 export type EntityMentionContextType =
@@ -114,8 +115,37 @@ export type MentionAttachment =
   | EntityMentionAttachment;
 export type Attachment = ImageAttachment | MentionAttachment;
 
+/**
+ * Full, untruncated preview content for a picker row - the side preview panel
+ * reads this instead of the (possibly CSS-truncated) `label`/`detail`/
+ * `description` the row renders.
+ *
+ * `kind: "path"` covers real filesystem paths (file/folder/worktree): `tree`
+ * is the breadcrumb hierarchy and `footer` is the muted line underneath it
+ * (the absolute path for file/folder; the branch name for a worktree, since
+ * its tree already IS the absolute path). `kind: "text"` covers everything
+ * else (git branch/commit, epic, artifact, chat, slash) - `secondary` carries
+ * a second value only for kinds that have one (parent epic title, commit
+ * subject), otherwise `null`. `mono` is set at the source (git hashes/branch
+ * names) rather than inferred from `primary`'s shape, so a title containing a
+ * slash (e.g. "UI/UX") never gets mistaken for a path.
+ */
+export type MentionPreview =
+  | {
+      readonly kind: "path";
+      readonly tree: MentionPathTree;
+      readonly footer: { readonly text: string; readonly mono: boolean } | null;
+    }
+  | {
+      readonly kind: "text";
+      readonly primary: string;
+      readonly secondary: string | null;
+      readonly mono: boolean;
+    };
+
 export type ProviderSlashCommand = GuiAgentCommandOption & {
   source: "provider";
+  preview: MentionPreview;
 };
 
 export type SlashCommand = ProviderSlashCommand;

--- a/clients/gui-app/src/lib/path.ts
+++ b/clients/gui-app/src/lib/path.ts
@@ -11,3 +11,54 @@ export function dirnameOfPath(path: string): string {
   if (slashIndex === -1) return "";
   return trimmed.slice(0, slashIndex);
 }
+
+/**
+ * A path decomposed for the @mention preview's breadcrumb tree: the leaf
+ * (file/folder/worktree-dir name) plus its nearest ancestor directories,
+ * split into a `rootLabel` (the absorbed deeper prefix, "" when the leaf
+ * sits at the root) and up to 2 `midDirs` rows - so the tree never exceeds
+ * 4 rows regardless of how deep the path goes.
+ */
+export type MentionPathTree = {
+  readonly rootLabel: string;
+  readonly midDirs: readonly string[];
+  readonly leaf: string;
+  readonly leafIsFile: boolean;
+};
+
+/**
+ * Splits `path` into a breadcrumb tree: leaf + its up-to-3 nearest ancestor
+ * directories, with everything deeper absorbed into `rootLabel` as one
+ * relative-path string; `midDirs` holds the 1-2 rows in between. `path` may
+ * be workspace-relative (file/folder) or absolute (worktree, which lives
+ * outside the workspace root) - an absolute input keeps its leading `/` on
+ * `rootLabel` (or on `leaf` when there are no directory rows to carry it) so
+ * the tree still reads as an absolute path.
+ */
+export function mentionPathTree(
+  path: string,
+  leafIsFile: boolean,
+): MentionPathTree {
+  const trimmed = path.replace(/\/+$/, "");
+  const isAbsolute = trimmed.startsWith("/");
+  const segments = trimmed.split("/").filter((segment) => segment.length > 0);
+  if (segments.length === 0) {
+    return { rootLabel: "", midDirs: [], leaf: "", leafIsFile };
+  }
+  const leafSegment = segments[segments.length - 1];
+  const dirs = segments.slice(0, -1);
+  const topIndex = Math.max(0, dirs.length - 3);
+  const rootDirs = dirs.slice(0, topIndex + 1);
+  const rootLabel =
+    rootDirs.length === 0
+      ? ""
+      : `${isAbsolute ? "/" : ""}${rootDirs.join("/")}`;
+  const midDirs = dirs.slice(topIndex + 1);
+  // With no directory rows, rootLabel is "" and nothing else carries the
+  // absolute marker - fold it onto the leaf instead so a single-segment
+  // absolute path (e.g. a worktree mounted at "/repo") doesn't render
+  // identically to a relative dir named "repo".
+  const leaf =
+    isAbsolute && dirs.length === 0 ? `/${leafSegment}` : leafSegment;
+  return { rootLabel, midDirs, leaf, leafIsFile };
+}


### PR DESCRIPTION
## Summary

Two commits, kept separate, on the chat composer:

1. **`fix(gui-app): stabilize the image-attachment caret in the composer`** — keeps the caret from jumping around inline image attachments in the chat composer (and the terminal image-attachment path) on paste/insert.
2. **`feat(gui-app): mention preview panel, compact menu, and search stability`** — the @mention/slash menu work below.

## @mention / slash menu

- **Follow-selection preview panel** anchored to the highlighted row. File/folder/worktree rows render a **breadcrumb tree** (the leaf + its 3 nearest ancestor directories, with the deeper prefix collapsed into the top row and middle-elided when long) plus the **full absolute path** in a muted footer; other kinds (git, epic, spec/ticket/story/review, chat, slash) show title/detail text. Positioned right → flip-left → hide so it never covers the list.
- **Compact menu**: max width reduced to `26rem` with label-priority truncation, now that the preview panel carries the full untruncated value.
- **Search stability**: `placeholderData: keepPreviousData` on the mention queries so results persist through each keystroke's refetch (no height pump, no "Loading…" flash), plus a subtle non-layout-shifting header spinner keyed on `isFetching`.
- **Refactor**: extracted the mention-entry display mapping (detail / description / icon / preview) out of `providers.tsx` into `mention-entry-display.tsx`.

## Zoom

- Fixed the **"Reset to 100%"** control rendering translucent in dark mode (the shared `outline` button variant leaked `dark:bg-input/30`); it now matches the opaque zoom island.

## Testing

- `bun run compile` clean · gui-app test suite green · `pre-commit run` green (hygiene + build/compile/lint/format via nx affected) · `react-doctor` clean.
- No live-browser E2E in this environment (no dev server) — behavior verified by unit/component tests + code review. A visual pass in the desktop app is still worth doing for the preview-panel positioning and the compact menu.

All commits are DCO signed-off.
