### PR TITLE
fix(terminal): stop silent TUI-agent deaths on transient stream drops

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-tile-reaped-revive.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-tile-reaped-revive.test.tsx
@@ -1,0 +1,198 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { create } from "zustand";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// A `reaped` exit is the host's idle-reap of an unwatched terminal-agent -
+// lifecycle, not a crash. The tile must NOT close the tab and NOT raise the
+// crash toast; it revives the session in place instead (bootstrap retry →
+// `terminal.create` under the same id → `prepareLaunch` resumes the
+// conversation). This test pins that contract; the sibling
+// `terminal-agent-tile-exit-close` test pins the genuine-exit close path.
+
+const closeCanvasTab = vi.fn();
+const bootstrapRetry = vi.fn();
+const toastError = vi.fn();
+
+const reapedHandle = {
+  epicId: "epic-test",
+  sessionId: "agent-1",
+  dispose: () => undefined,
+  store: create(() => ({
+    status: "exited" as const,
+    exitCode: -1,
+    exitReason: "reaped" as const,
+    effectiveCols: 80,
+    effectiveRows: 24,
+    lastOutputPreview: null,
+    writeInput: () => null,
+    requestResize: () => null,
+    setWriter: () => undefined,
+  })),
+};
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]): void => {
+      toastError(...args);
+    },
+  },
+}));
+
+vi.mock("@/hooks/agent/use-terminal-tile-bootstrap", () => ({
+  TerminalXtermHost: () => null,
+  useTerminalTileBootstrap: () => ({
+    handle: reapedHandle,
+    createIsError: false,
+    createError: null,
+    retry: bootstrapRetry,
+    hostHasSession: false,
+  }),
+}));
+
+vi.mock(
+  "@/components/home/host-workspace-selector/host-workspace-selector",
+  () => ({
+    HostWorkspaceSelector: () => null,
+    // The fork dialog stays mounted under the tile and imports this control.
+    ActiveHostWorkspaceControls: () => null,
+  }),
+);
+
+vi.mock("@/lib/host", () => {
+  const entry = {
+    hostId: "test-host",
+    label: "Test host",
+    kind: "local",
+    websocketUrl: "ws://127.0.0.1:1/rpc",
+    version: null,
+    status: "available",
+  };
+  return {
+    useHostBinding: () => null,
+    useHostClient: () => ({
+      request: () => new Promise(() => {}),
+      getActiveHostId: () => "host-test",
+      getRequestContextUserId: () => "user-test",
+      onChange: () => () => undefined,
+    }),
+    useHostDirectory: () => ({
+      findById: () => entry,
+      onChange: () => ({ dispose: () => undefined }),
+    }),
+  };
+});
+
+vi.mock("@/hooks/host/use-host-client-for", () => ({
+  useHostClientFor: () => ({
+    request: () => new Promise(() => {}),
+    getActiveHostId: () => "host-test",
+    getRequestContextUserId: () => "user-test",
+    onChange: () => () => undefined,
+  }),
+}));
+
+vi.mock("@/lib/host-error-toast", () => ({
+  toastFromHostError: vi.fn(),
+}));
+
+vi.mock("@/hooks/agent/use-agent-stop-controls", () => ({
+  useAgentStopControls: () => ({ self: null, descendants: [] }),
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useOpenEpicId: () => "epic-test",
+  useEpicTerminalAgent: () => ({
+    id: "agent-1",
+    harnessId: "claude" as const,
+    title: "Claude agent",
+    parentId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    hostId: "host-test",
+    harnessSessionId: null,
+    terminalAgentArgs: null,
+    terminalShellCommand: null,
+    terminalShellArgs: null,
+    workspaceFolders: [],
+    model: null,
+    reasoningEffort: null,
+    agentMode: "regular" as const,
+  }),
+}));
+
+vi.mock("@/hooks/agent/use-prepare-tui-launch-mutation", () => ({
+  useAgentStartTerminalSession: () => ({
+    isError: false,
+    isPending: false,
+    isIdle: true,
+    error: null,
+    reset: () => undefined,
+    mutateAsync: () => new Promise(() => {}),
+  }),
+}));
+
+vi.mock("@/stores/epics/canvas/store", () => ({
+  useEpicCanvasStore: (selector: (s: unknown) => unknown) =>
+    selector({ closeCanvasTab }),
+}));
+
+vi.mock("@/hooks/worktree/use-worktree-get-binding-query", () => ({
+  useWorktreeGetBinding: () => ({ data: { binding: null } }),
+}));
+
+import { TuiAgentTile } from "../tui-agent-tile";
+import { TabHostProvider } from "../../tab-host-provider";
+
+function withQueryClient(node: ReactNode): ReactNode {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <TabHostProvider hostId="test-host">{node}</TabHostProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("<TuiAgentTile /> reaped exit revive", () => {
+  beforeEach(() => {
+    closeCanvasTab.mockClear();
+    bootstrapRetry.mockClear();
+    toastError.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("revives in place on a reaped exit - no tab close, no crash toast", async () => {
+    render(
+      withQueryClient(
+        <TuiAgentTile
+          viewTabId="tab-test"
+          node={{
+            id: "agent-1",
+            instanceId: "inst-agent-1",
+            type: "terminal-agent",
+            name: "claude",
+            hostId: "test-host",
+          }}
+          tileId="pane-1"
+          isActive
+        />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(bootstrapRetry).toHaveBeenCalledTimes(1);
+    });
+    expect(closeCanvasTab).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -361,7 +361,7 @@ function TuiAgentTileLive(
     (): boolean => restartSuppressExitRef.current,
     [],
   );
-  const performRestartKill = useCallback((): void => {
+  const armRestartSuppression = useCallback((): void => {
     restartSawSessionGoneRef.current = false;
     restartSuppressExitRef.current = true;
     if (restartSuppressTimerRef.current !== null) {
@@ -371,6 +371,9 @@ function TuiAgentTileLive(
       clearRestartSuppression,
       RESTART_SUPPRESS_TIMEOUT_MS,
     );
+  }, [clearRestartSuppression]);
+  const performRestartKill = useCallback((): void => {
+    armRestartSuppression();
     killTerminalMutate(
       { sessionId },
       {
@@ -379,7 +382,16 @@ function TuiAgentTileLive(
         },
       },
     );
-  }, [clearRestartSuppression, killTerminalMutate, retryTerminal, sessionId]);
+  }, [armRestartSuppression, killTerminalMutate, retryTerminal, sessionId]);
+  // A `reaped` exit is the host's idle-reap of this unwatched agent - pure
+  // lifecycle, not a crash - and the PTY is already gone, so there is
+  // nothing to kill. Arm the same suppression a binding restart uses (no
+  // error toast, no tab close, same safety ceiling) and recreate under the
+  // same id; `prepareLaunch` resumes the conversation transparently.
+  const reviveAfterReap = useCallback((): void => {
+    armRestartSuppression();
+    retryTerminal();
+  }, [armRestartSuppression, retryTerminal]);
   // The kill must target a LIVE session. If session presence is unknown
   // (`terminal.list` refetching → `hostHasSession === null`) or already gone at
   // commit time, do NOT silently drop the rebind (the bug where Update appeared
@@ -494,6 +506,7 @@ function TuiAgentTileLive(
           createError={bootstrap.createError}
           handle={bootstrap.handle}
           onRetry={bootstrap.retry}
+          onReapedExit={reviveAfterReap}
           isActive={props.isActive}
           recovery={props.recovery}
         />
@@ -518,6 +531,8 @@ interface TerminalAgentBodyProps {
   } | null;
   readonly handle: TerminalSessionStoreHandle | null;
   readonly onRetry: () => void;
+  /** Revive (recreate + resume) after the host's idle-reap of this agent. */
+  readonly onReapedExit: () => void;
   readonly isActive: boolean;
   readonly isRestartKillSuppressed: () => boolean;
   readonly recovery: TerminalSessionRecovery;
@@ -592,6 +607,7 @@ function TerminalAgentBody(props: TerminalAgentBodyProps): React.ReactNode {
       tileId={props.tileId}
       isActive={props.isActive}
       isRestartKillSuppressed={props.isRestartKillSuppressed}
+      onReapedExit={props.onReapedExit}
       recovery={props.recovery}
     />
   );
@@ -919,6 +935,8 @@ interface TerminalAgentLiveProps {
   // the live host, and rather than the ref itself (which react-hooks/refs flags
   // when passed across the prop boundary).
   readonly isRestartKillSuppressed: () => boolean;
+  /** Revive (recreate + resume) after the host's idle-reap of this agent. */
+  readonly onReapedExit: () => void;
   readonly recovery: TerminalSessionRecovery;
 }
 
@@ -929,9 +947,14 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
   const status = useStore(handle.store, (s) => s.status);
   const connectionStatus = useStore(handle.store, (s) => s.connectionStatus);
   const exitCode = useStore(handle.store, (s) => s.exitCode);
+  const exitReason = useStore(handle.store, (s) => s.exitReason);
   const lastOutputPreview = useStore(handle.store, (s) => s.lastOutputPreview);
   const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
   const exitToastShownRef = useRef(false);
+  // One revive request per exit: the exit effect can re-run while the store
+  // still reports the same exited state (dep identity churn), and stacking
+  // `terminal.create` retries for one reap would race each other.
+  const reapedReviveRequestedRef = useRef(false);
 
   const isRestartKillSuppressed = props.isRestartKillSuppressed;
   const showExitToast = useCallback(() => {
@@ -940,6 +963,9 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
     // so the latest suppression state applies to this exact exit.
     if (isRestartKillSuppressed()) return;
     if (status !== "exited") return;
+    // A `reaped` exit is the host's idle-reap of an unwatched agent -
+    // lifecycle, not a crash. The exit effect below revives it in place.
+    if (exitReason === "reaped") return;
     if (!exitToastShownRef.current && exitCode !== null && exitCode !== 0) {
       exitToastShownRef.current = true;
       toast.error("Terminal agent exited with an error.", {
@@ -948,9 +974,23 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
           "The agent stopped before reporting a readable error. Try restarting it.",
       });
     }
-  }, [status, exitCode, lastOutputPreview, isRestartKillSuppressed]);
+  }, [
+    status,
+    exitCode,
+    exitReason,
+    lastOutputPreview,
+    isRestartKillSuppressed,
+  ]);
   useActivePaneEffect(showExitToast);
 
+  const onReapedExit = props.onReapedExit;
+  useEffect(() => {
+    if (status === "running") {
+      // A live PTY (fresh spawn or completed revive) re-arms the one-shot so
+      // a later reap - after another long unwatched stretch - revives again.
+      reapedReviveRequestedRef.current = false;
+    }
+  }, [status]);
   useEffect(() => {
     if (status !== "exited") return;
     // Don't close the tab on the kill we issued for a restart - the bootstrap is
@@ -958,6 +998,16 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
     // dropped the terminal the instant folder edits were applied. Read on this
     // exact exit; a genuine later exit sees suppression cleared and closes.
     if (isRestartKillSuppressed()) return;
+    if (exitReason === "reaped") {
+      // Host idle-reap of an unwatched agent: keep the tab open and revive
+      // the session in place (recreate under the same id; `prepareLaunch`
+      // resumes the conversation) instead of closing on a lifecycle event.
+      if (!reapedReviveRequestedRef.current) {
+        reapedReviveRequestedRef.current = true;
+        onReapedExit();
+      }
+      return;
+    }
     // `closeCanvasTab` resolves the tile by its pane tab *instance* id
     // (`pane.tabInstanceIds`), not the content/session id. Passing
     // `handle.sessionId` (the agent record id) silently no-ops, leaving the
@@ -965,6 +1015,8 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
     closeCanvasTab(props.viewTabId, props.tileId, props.instanceId);
   }, [
     status,
+    exitReason,
+    onReapedExit,
     props.instanceId,
     props.viewTabId,
     props.tileId,

--- a/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
+++ b/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
@@ -18,6 +18,10 @@ type TerminalDataFrame = Extract<
   TerminalSubscribeServerFrame,
   { readonly kind: "data" }
 >;
+type TerminalExitFrame = Extract<
+  TerminalSubscribeServerFrame,
+  { readonly kind: "exit" }
+>;
 
 function terminalInfoWithSize(cols: number, rows: number): TerminalSessionInfo {
   return {
@@ -157,6 +161,61 @@ describe("createTerminalSessionStore", () => {
     expect(writes.every((write) => typeof write.onAckable === "function")).toBe(
       true,
     );
+  });
+
+  it("adopts exit code and reason from a reattach snapshot of an exited session", () => {
+    const harness = createHarness();
+
+    const base = snapshot("");
+    emitSnapshot(harness.callbacks(), {
+      ...base,
+      session: {
+        ...base.session,
+        status: "exited",
+        exitCode: -1,
+        exitReason: "reaped",
+      },
+    });
+
+    expect(harness.handle.store.getState()).toMatchObject({
+      status: "exited",
+      exitCode: -1,
+      exitReason: "reaped",
+    });
+  });
+
+  it("treats a snapshot missing exitReason (host predating the field) as null", () => {
+    const harness = createHarness();
+
+    const base = snapshot("");
+    emitSnapshot(harness.callbacks(), {
+      ...base,
+      session: { ...base.session, status: "exited", exitCode: 1 },
+    });
+
+    expect(harness.handle.store.getState()).toMatchObject({
+      status: "exited",
+      exitCode: 1,
+      exitReason: null,
+    });
+  });
+
+  it("leaves exitReason untouched on a live exit frame (snapshot is authoritative)", () => {
+    const harness = createHarness();
+
+    const frame: TerminalExitFrame = {
+      kind: "exit",
+      hasBinaryPayload: false,
+      sessionId: "terminal-1",
+      exitCode: 1,
+    };
+    harness.callbacks().onExit(frame);
+
+    expect(harness.handle.store.getState()).toMatchObject({
+      status: "exited",
+      exitCode: 1,
+      exitReason: null,
+    });
   });
 
   it("marks the session lost when the stream closes before a snapshot", () => {

--- a/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
+++ b/clients/gui-app/src/stores/terminals/__tests__/terminal-session-store.test.ts
@@ -200,9 +200,22 @@ describe("createTerminalSessionStore", () => {
     });
   });
 
-  it("leaves exitReason untouched on a live exit frame (snapshot is authoritative)", () => {
+  it("a live exit frame does not clobber a snapshot-set exitReason (snapshot is authoritative)", () => {
     const harness = createHarness();
 
+    // Seed a non-null reason via the authoritative snapshot path first...
+    const base = snapshot("");
+    emitSnapshot(harness.callbacks(), {
+      ...base,
+      session: {
+        ...base.session,
+        status: "exited",
+        exitCode: -1,
+        exitReason: "reaped",
+      },
+    });
+
+    // ...then a live exit frame (which carries no reason) must leave it intact.
     const frame: TerminalExitFrame = {
       kind: "exit",
       hasBinaryPayload: false,
@@ -214,7 +227,7 @@ describe("createTerminalSessionStore", () => {
     expect(harness.handle.store.getState()).toMatchObject({
       status: "exited",
       exitCode: 1,
-      exitReason: null,
+      exitReason: "reaped",
     });
   });
 

--- a/clients/gui-app/src/stores/terminals/terminal-session-store.ts
+++ b/clients/gui-app/src/stores/terminals/terminal-session-store.ts
@@ -1,7 +1,10 @@
 import { create, type StoreApi, type UseBoundStore } from "zustand";
 import { v4 as uuidv4 } from "uuid";
 import type { TerminalSubscribeClientFrame } from "@traycer/protocol/host/terminal/subscribe";
-import type { TerminalSessionKind } from "@traycer/protocol/host/terminal/unary-schemas";
+import type {
+  TerminalSessionExitReason,
+  TerminalSessionKind,
+} from "@traycer/protocol/host/terminal/unary-schemas";
 import type {
   TerminalStreamCallbacks,
   TerminalStreamClient,
@@ -88,6 +91,13 @@ export interface TerminalSessionState {
   readonly snapshotLoaded: boolean;
   readonly status: TerminalLifecycleStatus;
   readonly exitCode: number | null;
+  /**
+   * Why the PTY ended, from the host's exit frame / exited snapshot.
+   * `null` until exited, and for hosts predating the field (treat as
+   * `process-exit`). A `reaped` exit is host lifecycle - the idle-reap of
+   * an unwatched terminal-agent - and must not be presented as a crash.
+   */
+  readonly exitReason: TerminalSessionExitReason | null;
   readonly effectiveCols: number;
   readonly effectiveRows: number;
   readonly requestedCols: number;
@@ -419,6 +429,7 @@ export function createTerminalSessionStore(
           snapshotLoaded: true,
           status: frame.session.status === "exited" ? "exited" : "running",
           exitCode: frame.session.exitCode,
+          exitReason: frame.session.exitReason ?? null,
           effectiveCols: frame.session.cols,
           effectiveRows: frame.session.rows,
           reattachMode: "live",
@@ -455,6 +466,11 @@ export function createTerminalSessionStore(
       },
       onExit: (frame) => {
         if (disposed || frame.sessionId !== options.sessionId) return;
+        // A live exit frame carries no reason - it is only ever a genuine
+        // process exit or an explicit kill to an attached viewer (a reaped
+        // idle session has no viewer, so it is observed via the reattach
+        // snapshot's `session.exitReason` instead). Leave `exitReason`
+        // untouched here; the snapshot path is authoritative for it.
         set({
           status: "exited",
           exitCode: frame.exitCode,
@@ -511,6 +527,7 @@ export function createTerminalSessionStore(
       snapshotLoaded: false,
       status: "creating",
       exitCode: null,
+      exitReason: null,
       effectiveCols: options.cols,
       effectiveRows: options.rows,
       requestedCols: options.cols,

--- a/clients/shared/host-transport/__tests__/auth-aware-messenger.test.ts
+++ b/clients/shared/host-transport/__tests__/auth-aware-messenger.test.ts
@@ -35,6 +35,24 @@ function rpcError(): HostRpcError {
   });
 }
 
+// A transient host-side rejection (JWKS fetch timeout): wire `code` stays
+// UNAUTHORIZED but `fatalDetails.retryable` marks it recoverable-without-authn.
+function retryableUnauthorizedError(): HostRpcError {
+  return new HostRpcError({
+    code: "UNAUTHORIZED",
+    message: "Signing key unavailable: request timed out",
+    requestId: "req-3",
+    method: METHOD,
+    fatalDetails: {
+      code: "UNAUTHORIZED",
+      reason: "Signing key unavailable: request timed out",
+      incompatibleMethods: null,
+      upgradeGuidance: null,
+      retryable: true,
+    },
+  });
+}
+
 describe("createAuthAwareMessenger", () => {
   it("passes results through without revalidating on success", async () => {
     const revalidate = vi.fn();
@@ -61,6 +79,24 @@ describe("createAuthAwareMessenger", () => {
       HostRpcError,
     );
     expect(revalidate).toHaveBeenCalledTimes(1);
+    expect(inner.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not revalidate a retryable transient UNAUTHORIZED (rethrows for the caller to retry)", async () => {
+    const revalidate = vi.fn();
+    const auth: AuthRevalidator = { revalidateCurrentContext: revalidate };
+    const original = retryableUnauthorizedError();
+    const inner: IHostMessenger<Registry> = {
+      request: vi.fn().mockRejectedValue(original),
+    };
+
+    const wrapped = createAuthAwareMessenger(inner, auth, null);
+    const thrown = await wrapped
+      .request(METHOD, PARAMS)
+      .catch((e: unknown) => e);
+    // Transient host-side failure - the bearer is fine, so no authn churn.
+    expect(thrown).toBe(original);
+    expect(revalidate).not.toHaveBeenCalled();
     expect(inner.request).toHaveBeenCalledTimes(1);
   });
 

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -1340,6 +1340,19 @@ describe("WsStreamClient UNAUTHORIZED auth recovery", () => {
       upgradeGuidance: null,
     },
   } as const;
+  // A transient, host-side rejection (e.g. the host's JWKS fetch timed out): the
+  // wire `code` stays `UNAUTHORIZED` for older clients, but `retryable: true`
+  // tells a newer client the credential is fine and to just reconnect.
+  const RETRYABLE_FATAL = {
+    kind: "fatalError",
+    details: {
+      code: "UNAUTHORIZED",
+      reason: "Signing key unavailable: request timed out",
+      incompatibleMethods: null,
+      upgradeGuidance: null,
+      retryable: true,
+    },
+  } as const;
 
   function wait(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -1504,6 +1517,94 @@ describe("WsStreamClient UNAUTHORIZED auth recovery", () => {
     if (fatalClose?.kind === "fatalError") {
       expect(fatalClose.details.code).toBe("CHAT_INVALID");
     }
+    session.close();
+  });
+
+  it("treats a `retryable` transient rejection as a transport drop: reconnects, never revalidates, never gives up", async () => {
+    const { factory, sockets } = makeFactory();
+    // Even though authn would report the credential current ("rotated"), a
+    // retryable host-side rejection must skip credential recovery entirely.
+    const revalidator = makeAuthRevalidator([
+      "rotated",
+      "rotated",
+      "rotated",
+      "rotated",
+      "rotated",
+    ]);
+    const client = makeAuthClient(factory, revalidator.auth, 5);
+    const statuses: StreamConnectionStatus[] = [];
+    const session = client.subscribe("epic.subscribe", { epicId: "e1" });
+    session.onStatusChange((status) => statuses.push(status));
+
+    await flush();
+    // Drive MORE consecutive rejections than the no-progress bound (3): a
+    // transient host-side rejection must never terminate the session.
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      const socket = sockets[sockets.length - 1].socket;
+      socket.fireOpen();
+      socket.fireText(RETRYABLE_FATAL);
+      await wait(50);
+    }
+
+    // Credential recovery is never engaged for a host-side transient rejection.
+    expect(revalidator.calls.count).toBe(0);
+    // Recoverable throughout - reconnecting, never terminal.
+    expect(statuses).toContain("reconnecting");
+    expect(statuses).not.toContain("closed");
+    // Reconnected well past the no-progress bound (3) that a misclassified
+    // UNAUTHORIZED would have hit - proof the transient path never gives up.
+    expect(sockets.length).toBeGreaterThan(4);
+    session.close();
+  });
+
+  it("clears the no-progress streak on a retryable interlude so a later genuine UNAUTHORIZED still gets the full bound", async () => {
+    const { factory, sockets } = makeFactory();
+    // Every revalidation reports the same never-rotated bearer ("rotated"),
+    // the no-progress case. Enough entries for a 2-cycle then a 3-cycle episode;
+    // the retryable interlude between them never revalidates.
+    const revalidator = makeAuthRevalidator([
+      "rotated",
+      "rotated",
+      "rotated",
+      "rotated",
+      "rotated",
+    ]);
+    // Tiny initial backoff: this episode drives ~5 reconnects and the shared
+    // `reconnectAttempt` escalates the delay each time, so keep it well under
+    // the per-cycle wait so every reconnected socket is live before the next.
+    const client = makeAuthClient(factory, revalidator.auth, 1);
+    const statuses: StreamConnectionStatus[] = [];
+    const session = client.subscribe("epic.subscribe", { epicId: "e1" });
+    session.onStatusChange((status) => statuses.push(status));
+
+    const driveFatal = async (frame: typeof UNAUTHORIZED_FATAL) => {
+      const socket = sockets[sockets.length - 1].socket;
+      socket.fireOpen();
+      socket.fireText(frame);
+      await wait(50);
+    };
+
+    await flush();
+    // Two genuine UNAUTHORIZED cycles: streak climbs to 2 (both re-dial).
+    await driveFatal(UNAUTHORIZED_FATAL);
+    await driveFatal(UNAUTHORIZED_FATAL);
+    expect(statuses).not.toContain("closed");
+
+    // A transient interlude clears the streak back to 0 (and re-dials).
+    await driveFatal(RETRYABLE_FATAL);
+
+    // With the streak cleared, the next two genuine cycles are 1 and 2 - still
+    // recoverable. WITHOUT the reset the first of these would hit 3 and go
+    // terminal here; this is the regression guard for the reset.
+    await driveFatal(UNAUTHORIZED_FATAL);
+    await driveFatal(UNAUTHORIZED_FATAL);
+    expect(statuses).not.toContain("closed");
+
+    // The third post-interlude cycle reaches the bound (3) and goes terminal.
+    await driveFatal(UNAUTHORIZED_FATAL);
+    expect(statuses).toContain("closed");
+    // 2 pre + 3 post revalidations; the retryable interlude never revalidates.
+    expect(revalidator.calls.count).toBe(5);
     session.close();
   });
 

--- a/clients/shared/host-transport/auth-aware-messenger.ts
+++ b/clients/shared/host-transport/auth-aware-messenger.ts
@@ -73,6 +73,13 @@ export function createAuthAwareMessenger<Registry extends VersionedRpcRegistry>(
         if (!(cause instanceof HostRpcError) || cause.code !== "UNAUTHORIZED") {
           throw cause;
         }
+        // A transient, host-side rejection (e.g. a JWKS fetch timeout) rides in
+        // as `code: "UNAUTHORIZED"` with `fatalDetails.retryable === true`. Our
+        // bearer is fine, so revalidating it can't help - rethrow the transient
+        // failure and let the caller retry the request instead of churning authn.
+        if (cause.fatalDetails?.retryable === true) {
+          throw cause;
+        }
         const retry = options?.retry ?? null;
         const before = readBearer(retry);
         try {

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -758,6 +758,23 @@ class StreamSession<
       return;
     }
     const details = termParse.data.details;
+    // `retryable` marks a transient, host-side rejection (e.g. the host's JWKS
+    // fetch timed out while verifying our bearer). Our credential is fine, so
+    // credential revalidation can't help and the no-progress give-up bound must
+    // not apply - treat it exactly like an ordinary transport drop and let the
+    // reconnect backoff ride until the host recovers. Checked before the
+    // `UNAUTHORIZED` branch because the host keeps the wire `code` as
+    // `UNAUTHORIZED` (so older clients still get the credential path).
+    if (details.retryable === true) {
+      // A transient host blip must not count toward the credential give-up
+      // bound, mirroring the `network-error` revalidation outcome: clear any
+      // streak left by a prior genuine `UNAUTHORIZED` episode so a later real
+      // rejection starts from a clean slate.
+      this.noProgressUnauthorizedReconnects = 0;
+      this.teardownSocket(1000, "host-retryable");
+      this.onTransportDrop();
+      return;
+    }
     // `UNAUTHORIZED` is recoverable when an auth revalidator is wired: the
     // host rejected our bearer (e.g. it expired during an overnight sleep),
     // but a single-flight revalidation may rotate a fresh one that the next

--- a/protocol/src/framework/__tests__/ws-protocol.test.ts
+++ b/protocol/src/framework/__tests__/ws-protocol.test.ts
@@ -254,5 +254,45 @@ describe("ws-protocol canonical Zod schemas", () => {
       };
       expect(fatalErrorDetailsSchema.safeParse(details).success).toBe(false);
     });
+
+    it("accepts a `retryable` transient-rejection flag", () => {
+      const details = {
+        code: "UNAUTHORIZED" as const,
+        reason: "Signing key unavailable: request timed out",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+        retryable: true,
+      };
+      const parsed = fatalErrorDetailsSchema.safeParse(details);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.retryable).toBe(true);
+      }
+    });
+
+    it("reads `retryable` as undefined when an older host omits it", () => {
+      const details = {
+        code: "UNAUTHORIZED" as const,
+        reason: "Invalid token",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+      };
+      const parsed = fatalErrorDetailsSchema.safeParse(details);
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.retryable).toBeUndefined();
+      }
+    });
+
+    it("rejects a non-boolean `retryable`", () => {
+      const details = {
+        code: "UNAUTHORIZED",
+        reason: "bad",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+        retryable: "yes",
+      };
+      expect(fatalErrorDetailsSchema.safeParse(details).success).toBe(false);
+    });
   });
 });

--- a/protocol/src/framework/ws-protocol.ts
+++ b/protocol/src/framework/ws-protocol.ts
@@ -68,6 +68,15 @@ export type FatalErrorDetails = {
   readonly reason: string;
   readonly incompatibleMethods: readonly IncompatibleMethodDetails[] | null;
   readonly upgradeGuidance: IncompatibilityUpgradeGuidance | null;
+  /**
+   * When `true`, the rejection is transient and host-side (e.g. the host's
+   * JWKS fetch timed out while verifying the bearer) - NOT a statement about
+   * the credential's authenticity. A client that understands this field should
+   * reconnect with plain backoff instead of running credential recovery or
+   * going terminal. Additive and optional: an older host omits it entirely and
+   * a newer client then reads "not retryable".
+   */
+  readonly retryable?: boolean;
 };
 
 /**
@@ -200,6 +209,11 @@ export const fatalErrorDetailsSchema = z.object({
   reason: z.string(),
   incompatibleMethods: z.array(incompatibleMethodDetailsSchema).nullable(),
   upgradeGuidance: incompatibilityUpgradeGuidanceSchema.nullable(),
+  // Additive/optional: an older host omits it, so a newer client parsing an
+  // older host's frame reads `undefined` (not retryable). Set `true` only for
+  // transient host-side rejections (e.g. a JWKS fetch timeout) that the client
+  // recovers from with plain reconnect backoff, not credential revalidation.
+  retryable: z.boolean().optional(),
 });
 
 /** Canonical schema for the client `open` frame. */

--- a/protocol/src/host/terminal/subscribe.ts
+++ b/protocol/src/host/terminal/subscribe.ts
@@ -138,6 +138,11 @@ const terminalSubscribeServerFrameSchemaV11 = z.discriminatedUnion("kind", [
     ...textFrameFields,
     ...sessionReferenceFields,
     exitCode: z.number().int(),
+    // NB: the exit *reason* lives on the session info (snapshot), not here.
+    // A reap only fires with zero attached viewers, so a `reaped` exit is
+    // never delivered as a live exit frame - it is observed on reattach via
+    // `snapshot.session.exitReason`. Keeping the reason off the frozen
+    // stream frame avoids retroactively widening an already-shipped minor.
   }),
   z.object({
     kind: z.literal("actionAck"),

--- a/protocol/src/host/terminal/unary-schemas.ts
+++ b/protocol/src/host/terminal/unary-schemas.ts
@@ -18,6 +18,20 @@ export type TerminalSessionStatus = z.infer<typeof terminalSessionStatusSchema>;
 export const terminalSessionKindSchema = z.enum(["terminal", "terminal-agent"]);
 export type TerminalSessionKind = z.infer<typeof terminalSessionKindSchema>;
 
+// Why a session's PTY ended. `process-exit` is the process ending on its
+// own; `killed` is an explicit kill (user close, stop, binding restart);
+// `reaped` is the host's idle-reap of an unwatched `terminal-agent` -
+// clients treat a reaped exit as lifecycle (revive silently), never as a
+// crash to report.
+export const terminalSessionExitReasonSchema = z.enum([
+  "process-exit",
+  "killed",
+  "reaped",
+]);
+export type TerminalSessionExitReason = z.infer<
+  typeof terminalSessionExitReasonSchema
+>;
+
 export const terminalSessionInfoSchema = z.object({
   sessionId: z.string(),
   epicId: z.string(),
@@ -29,6 +43,11 @@ export const terminalSessionInfoSchema = z.object({
   rows: z.number().int().positive(),
   status: terminalSessionStatusSchema,
   exitCode: z.number().int().nullable(),
+  // `null` while running; set alongside `exitCode` when the session exits.
+  // Optional so payloads from hosts predating the field still parse -
+  // absent is equivalent to `process-exit` (the only pre-field behavior a
+  // client could assume).
+  exitReason: terminalSessionExitReasonSchema.nullable().optional(),
   createdAt: z.number(),
   // User-supplied display title. `null` means "use the default derived
   // label (basename of cwd / shellCommand)". Lifetime is the session's -


### PR DESCRIPTION
## What

Fixes the *"Terminal agent exited with an error"* toast (and its silent-dead-tab
cousin) that appeared with **no host-side cause** — most reliably reproduced by
**locking and unlocking the macOS screen**.

Two independent fixes, both in the silent-TUI-death family:

### 1. `retryable` fatal-error classification (protocol + shared client)
A transient host→authn JWKS reachability blip was laundered into a client-facing
`UNAUTHORIZED`, and the client's no-progress give-up bound (whose comment assumes
"clock skew / config mismatch") could **permanently kill a session that would
otherwise self-heal**. This bit only in the asymmetric case (host can't reach
JWKS, client can reach authn).

- Additive optional `retryable` flag on the fatal-error frame (`ws-protocol.ts`).
- Host sets `retryable` for the transient `NETWORK_ERROR` class.
- Client short-circuits a `retryable` fatal close into the plain transport-drop
  **backoff-and-reconnect** path instead of the credential-revalidation give-up.

### 2. Typed terminal `exitReason` + reaped-revive (protocol + gui-app)
The host's inbox reaper kills an idle terminal-agent PTY once its viewer detaches
— and "detach" fires on **any** stream drop (wake reconnect on unlock, auth storm,
renderer reload), not just a deliberate tab close. On reattach the GUI saw
`exited(-1)` and rendered it as a crash.

- Optional `exitReason` (`process-exit` | `killed` | `reaped`) on the terminal
  **session info** (`unary-schemas.ts`).
- The GUI treats a `reaped` exit as **host lifecycle**: no crash toast, no tab
  close — it revives the agent in place under the same id so `prepareLaunch`
  resumes the conversation.
- A reap only fires with **zero attached viewers**, so a reaped exit is never a
  live exit frame — it's observed via the reattach snapshot's
  `session.exitReason`. The **frozen `terminal.subscribe` stream frames are left
  untouched** (no retroactive widening of a shipped minor).

The matching **host-side** changes (the detach-grace window before reaping, the
`reaped` kill reason, and PTY lifecycle logging) live in the paired internal-repo
PR that bumps this submodule.

## Compatibility
`retryable` and `exitReason` are both **optional additive** fields — absent
parses as the prior behavior (`process-exit`; non-retryable). Old hosts and old
clients are unaffected.

## Testing
- `bun run compile` clean across all workspaces.
- Protocol (486), shared (253), and gui-app terminal-store/tile suites green,
  including new tests: `retryable` classification + reconnect path, snapshot
  `exitReason` propagation (incl. old-host absent-field compat), and the
  reaped-revive tile contract (no toast, no close, revive).
- gui-app lint + react-doctor clean on the changed files.
- Manually validated the macOS lock/unlock repro: the terminal agent now
  survives the unlock instead of dying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)