### PR TITLE
Fix queued edit cancel draft restore

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -131,6 +131,24 @@ const QUEUED_CONTENT: JsonContent = {
     },
   ],
 };
+const SECOND_QUEUED_CONTENT: JsonContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Second queued prompt" }],
+    },
+  ],
+};
+const PENDING_DRAFT_CONTENT: JsonContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "pending message" }],
+    },
+  ],
+};
 const QUEUED_SETTINGS: ChatRunSettings = {
   harnessId: "codex",
   model: "queued-model",
@@ -579,15 +597,7 @@ describe("<ChatTile />", () => {
     useComposerDraftStore.setState({
       drafts: {
         [CHAT_ARTIFACT.id]: {
-          content: {
-            type: "doc",
-            content: [
-              {
-                type: "paragraph",
-                content: [{ type: "text", text: "pending message" }],
-              },
-            ],
-          },
+          content: PENDING_DRAFT_CONTENT,
           selection: null,
           resetEpoch: 0,
         },
@@ -1855,7 +1865,8 @@ describe("<ChatTile />", () => {
     expect(settingsFrame?.settings).toEqual(UPDATED_QUEUE_SETTINGS);
   });
 
-  it("cancels queued edit mode from the composer without clearing the draft", async () => {
+  it("cancels queued edit mode from the composer and clears the queued content when there was no previous draft", async () => {
+    useComposerDraftStore.setState({ drafts: {} });
     chatHarness.teardown();
     chatHarness.install("owner", [
       {
@@ -1886,6 +1897,9 @@ describe("<ChatTile />", () => {
       screen.getByRole("button", { name: "Edit queued message" }),
     );
     expect(screen.getByTestId("queue-edit-draft-pill")).not.toBeNull();
+    expect(screen.getByTestId("composer-editor").textContent).toBe(
+      "Queued prompt",
+    );
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -1896,13 +1910,151 @@ describe("<ChatTile />", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("queue-edit-draft-pill")).toBeNull();
     });
+    expect(screen.getByTestId("composer-editor").textContent).toBe("");
+
+    const sendButton = screen.getByRole("button", { name: "Send" });
+    if (!(sendButton instanceof HTMLButtonElement)) {
+      throw new Error("expected send button");
+    }
+    expect(sendButton.disabled).toBe(true);
+    expect(chatHarness.sent).toHaveLength(0);
+  });
+
+  it("cancels queued edit mode from the composer and restores the previous draft", async () => {
+    chatHarness.teardown();
+    chatHarness.install("owner", [
+      {
+        queueItemId: "queue-1",
+        messageId: "message-queue-1",
+        message: {
+          kind: "user",
+          content: QUEUED_CONTENT,
+        },
+        sender: { type: "user", userId: "owner-1" },
+        settings: QUEUED_SETTINGS,
+        accountContext: { type: "PERSONAL" as const },
+        delivery: "next_turn",
+        status: "pending",
+        targetTurnId: null,
+        steerRequest: null,
+        fallbackReason: null,
+        createdAt: 2,
+        updatedAt: 2,
+      },
+    ]);
+
+    renderChatTile();
+
+    await waitForChatTileLoaded();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit queued message" }),
+    );
+    expect(screen.getByTestId("queue-edit-draft-pill")).not.toBeNull();
+    expect(screen.getByTestId("composer-editor").textContent).toBe(
+      "Queued prompt",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Cancel queued message editing",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("queue-edit-draft-pill")).toBeNull();
+    });
+    expect(screen.getByTestId("composer-editor").textContent).toBe(
+      "pending message",
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     expect(chatHarness.sent).toHaveLength(1);
     const frame = chatHarness.sent[0];
     if (frame.kind !== "send") throw new Error("expected send frame");
-    expect(frame.content).toEqual(QUEUED_CONTENT);
+    expect(frame.content).toEqual(PENDING_DRAFT_CONTENT);
+  });
+
+  it("keeps the original draft snapshot when switching queued items before cancelling edit", async () => {
+    chatHarness.teardown();
+    chatHarness.install("owner", [
+      {
+        queueItemId: "queue-1",
+        messageId: "message-queue-1",
+        message: {
+          kind: "user",
+          content: QUEUED_CONTENT,
+        },
+        sender: { type: "user", userId: "owner-1" },
+        settings: QUEUED_SETTINGS,
+        accountContext: { type: "PERSONAL" as const },
+        delivery: "next_turn",
+        status: "pending",
+        targetTurnId: null,
+        steerRequest: null,
+        fallbackReason: null,
+        createdAt: 2,
+        updatedAt: 2,
+      },
+      {
+        queueItemId: "queue-2",
+        messageId: "message-queue-2",
+        message: {
+          kind: "user",
+          content: SECOND_QUEUED_CONTENT,
+        },
+        sender: { type: "user", userId: "owner-1" },
+        settings: QUEUED_SETTINGS,
+        accountContext: { type: "PERSONAL" as const },
+        delivery: "next_turn",
+        status: "pending",
+        targetTurnId: null,
+        steerRequest: null,
+        fallbackReason: null,
+        createdAt: 3,
+        updatedAt: 3,
+      },
+    ]);
+
+    renderChatTile();
+
+    await waitForChatTileLoaded();
+
+    const editButtons = screen.getAllByRole("button", {
+      name: "Edit queued message",
+    });
+    const firstEditButton = editButtons[0];
+    const secondEditButton = editButtons[1];
+    if (
+      !(firstEditButton instanceof HTMLButtonElement) ||
+      !(secondEditButton instanceof HTMLButtonElement)
+    ) {
+      throw new Error("expected queued edit buttons");
+    }
+
+    fireEvent.click(firstEditButton);
+    expect(screen.getByTestId("composer-editor").textContent).toBe(
+      "Queued prompt",
+    );
+
+    fireEvent.click(secondEditButton);
+    expect(screen.getByTestId("composer-editor").textContent).toBe(
+      "Second queued prompt",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Cancel queued message editing",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("queue-edit-draft-pill")).toBeNull();
+    });
+    expect(screen.getByTestId("composer-editor").textContent).toBe(
+      "pending message",
+    );
   });
 
   // The composer render-count proof lives in `chat-tile-composer-rerender.test.tsx`

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -698,6 +698,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const replaceDraftContent = useComposerDraftStore(
     (state) => state.replaceDraft,
   );
+  const clearDraftContent = useComposerDraftStore((state) => state.clearDraft);
   const defaultPermission = useSettingsStore(
     (state) => state.defaultPermission,
   );
@@ -1307,6 +1308,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     handle,
     nodeId: node.id,
     replaceDraftContent,
+    clearDraftContent,
     currentComposerSettings,
     currentEpicId,
     editingQueueItemId: uiState.editingQueueItemId,

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   ChatQueuedItem,
   ChatRunSettings,
@@ -10,7 +10,17 @@ import {
   type SteerSettingsDecision,
 } from "@/lib/chats/decide-steer-settings";
 import type { ChatActions } from "@/hooks/chats/use-chat-actions";
+import {
+  EMPTY_COMPOSER_DRAFT,
+  useComposerDraftStore,
+} from "@/stores/composer/composer-draft-store";
 import type { ChatTileUiAction } from "./chat-tile-session-state";
+
+interface QueuedEditDraftSnapshot {
+  readonly hadDraft: boolean;
+  readonly content: JsonContent;
+  readonly selection: { readonly from: number; readonly to: number } | null;
+}
 
 export interface ChatQueueActionsInput {
   readonly chatActions: ChatActions;
@@ -19,8 +29,9 @@ export interface ChatQueueActionsInput {
   readonly replaceDraftContent: (
     nodeId: string,
     content: JsonContent,
-    context: null,
+    selection: { readonly from: number; readonly to: number } | null,
   ) => void;
+  readonly clearDraftContent: (nodeId: string) => void;
   readonly currentComposerSettings: ChatRunSettings;
   readonly currentEpicId: string;
   readonly editingQueueItemId: string | null;
@@ -58,8 +69,8 @@ export interface ChatQueueActionsResult {
  * callback lives here because it drives `restampQueuedItemSettings` and the
  * live permission-mode update (both queue-scoped side effects).
  *
- * All callbacks preserve the same `useCallback` dependency structure as the
- * original view-model so memoized children are not disturbed.
+ * Callbacks stay memoized around stable queue/action inputs so memoized
+ * children are not disturbed during streaming updates.
  */
 export function useChatQueueActions(
   input: ChatQueueActionsInput,
@@ -69,6 +80,7 @@ export function useChatQueueActions(
     handle,
     nodeId,
     replaceDraftContent,
+    clearDraftContent,
     currentComposerSettings,
     currentEpicId,
     editingQueueItemId,
@@ -86,6 +98,20 @@ export function useChatQueueActions(
       { readonly kind: "interrupt_restart" }
     >;
   } | null>(null);
+  const queuedEditRestoreDraftRef = useRef<QueuedEditDraftSnapshot | null>(
+    null,
+  );
+
+  const restoreQueuedEditDraft = useCallback((): void => {
+    const snapshot = queuedEditRestoreDraftRef.current;
+    queuedEditRestoreDraftRef.current = null;
+    if (snapshot === null) return;
+    if (!snapshot.hadDraft) {
+      clearDraftContent(nodeId);
+      return;
+    }
+    replaceDraftContent(nodeId, snapshot.content, snapshot.selection);
+  }, [clearDraftContent, nodeId, replaceDraftContent]);
 
   const editQueuedItem = useCallback(
     (item: ChatQueuedItem): void => {
@@ -96,6 +122,14 @@ export function useChatQueueActions(
         dispatchUi({ type: "setEditingQueueItemId", editingQueueItemId: null });
         return;
       }
+      if (queuedEditRestoreDraftRef.current === null) {
+        const draft = useComposerDraftStore.getState().drafts[nodeId];
+        queuedEditRestoreDraftRef.current = {
+          hadDraft: draft !== undefined,
+          content: draft?.content ?? EMPTY_COMPOSER_DRAFT.content,
+          selection: draft?.selection ?? null,
+        };
+      }
       replaceDraftContent(nodeId, item.message.content, null);
       dispatchUi({
         type: "setEditingQueueItemId",
@@ -105,15 +139,31 @@ export function useChatQueueActions(
     [chatActions, dispatchUi, nodeId, replaceDraftContent],
   );
 
+  useEffect(() => {
+    if (editingQueueItemId === null) {
+      queuedEditRestoreDraftRef.current = null;
+      return;
+    }
+    if (activeEditingQueueItemId !== null) return;
+    restoreQueuedEditDraft();
+    dispatchUi({ type: "setEditingQueueItemId", editingQueueItemId: null });
+  }, [
+    activeEditingQueueItemId,
+    dispatchUi,
+    editingQueueItemId,
+    restoreQueuedEditDraft,
+  ]);
+
   const cancelQueuedItem = useCallback(
     (item: ChatQueuedItem): void => {
       const actionId = chatActions.queueCancel(item.queueItemId);
       if (actionId === null) return;
       if (editingQueueItemId === item.queueItemId) {
+        restoreQueuedEditDraft();
         dispatchUi({ type: "setEditingQueueItemId", editingQueueItemId: null });
       }
     },
-    [chatActions, dispatchUi, editingQueueItemId],
+    [chatActions, dispatchUi, editingQueueItemId, restoreQueuedEditDraft],
   );
 
   const abortSteerQueuedItem = useCallback(
@@ -127,8 +177,9 @@ export function useChatQueueActions(
   );
 
   const cancelQueueEditMode = useCallback((): void => {
+    restoreQueuedEditDraft();
     dispatchUi({ type: "setEditingQueueItemId", editingQueueItemId: null });
-  }, [dispatchUi]);
+  }, [dispatchUi, restoreQueuedEditDraft]);
 
   const reorderQueuedItem = useCallback(
     (item: ChatQueuedItem, beforeQueueItemId: string | null): void => {


### PR DESCRIPTION
## Summary

- Make queued-message edit mode transactional by snapshotting the composer draft before overlaying queued content
- Restore the original draft, or clear the composer when none existed, when queued edit is cancelled
- Cover empty draft, existing draft restore, queued-item switching, and update a stale session-anchor fixture for compile

## Verification

- bun run test src/components/epic-canvas/__tests__/chat-tile.test.tsx
- bun run test src/stores/chats/__tests__/rendered-messages.test.tsx
- bun run compile
- pre-commit commit hook: build / compile / lint / format affected checks passed
