### PR TITLE
fix(gui-app): forward durable stream bearer rotations

### DIFF
--- a/clients/gui-app/src/lib/host/__tests__/durable-stream-transport.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/durable-stream-transport.test.ts
@@ -3,10 +3,10 @@ import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-ru
 import type { StreamAuthRevalidator } from "@traycer-clients/shared/auth/bearer-revalidator";
 
 // `openDurableStreamTransport` is the single place "durable stream = transport +
-// auth + wake" is assembled. These tests pin its two load-bearing guarantees:
-// the teardown order, and that a failure while wiring wake never leaks the
-// socket. The socket builder and wake wiring are mocked so the test is about
-// the assembly contract, not the real transport.
+// auth + bearer rotation + wake" is assembled. These tests pin its load-bearing
+// guarantees: forwarding rotations, teardown order, and that a failure while
+// wiring wake never leaks the socket. The socket builder and wake wiring are
+// mocked so the test is about the assembly contract, not the real transport.
 const mocks = vi.hoisted(() => ({
   buildHostStreamClient: vi.fn(),
   subscribeStreamWakeReconnect: vi.fn(),
@@ -43,6 +43,7 @@ function buildParams(closeWs: () => void) {
       closeWs();
     }),
     reconnectAll: vi.fn(),
+    notifyBearerRotated: vi.fn(),
   };
   mocks.buildHostStreamClient.mockReturnValue(fakeWs);
   return {
@@ -53,6 +54,11 @@ function buildParams(closeWs: () => void) {
       bearer: () => null,
       auth: AUTH,
       runnerHost: RUNNER_HOST,
+      subscribeBearerRotation: (_onRotation: () => void) => {
+        return () => {
+          order.push("bearer");
+        };
+      },
       // No endpoint ever moves in these assembly tests; return a no-op disposer.
       subscribeEndpointChange: () => () => undefined,
     },
@@ -89,12 +95,46 @@ describe("openDurableStreamTransport", () => {
 
     // Disposing wake before closing the socket avoids a wake firing
     // `reconnectAll` on a socket that is being torn down.
-    expect(order).toEqual(["wake", "ws"]);
+    expect(order).toEqual(["bearer", "wake", "ws"]);
+  });
+
+  it("forwards bearer rotations to the built socket and removes the listener before close", () => {
+    const { order, params, fakeWs } = buildParams(() => undefined);
+    const disposeWake = vi.fn(() => {
+      order.push("wake");
+    });
+    let bearerListener: (() => void) | null = null;
+    const disposeBearer = vi.fn(() => {
+      order.push("bearer");
+      bearerListener = null;
+    });
+    mocks.subscribeStreamWakeReconnect.mockReturnValue(disposeWake);
+    params.subscribeBearerRotation = (listener: () => void) => {
+      bearerListener = listener;
+      return disposeBearer;
+    };
+    const fireBearerRotation = (): void => {
+      if (bearerListener !== null) {
+        bearerListener();
+      }
+    };
+
+    const transport = openDurableStreamTransport(params);
+
+    fireBearerRotation();
+    expect(fakeWs.notifyBearerRotated).toHaveBeenCalledTimes(1);
+
+    transport.close();
+    expect(disposeBearer).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["bearer", "wake", "ws"]);
+
+    fireBearerRotation();
+    expect(fakeWs.notifyBearerRotated).toHaveBeenCalledTimes(1);
   });
 
   it("closes the half-built socket and rethrows if wiring wake throws", () => {
     const closeWs = vi.fn();
-    const { params, fakeWs } = buildParams(closeWs);
+    const { order, params, fakeWs } = buildParams(closeWs);
     const wakeError = new Error("wake wiring failed");
     mocks.subscribeStreamWakeReconnect.mockImplementation(() => {
       throw wakeError;
@@ -105,6 +145,7 @@ describe("openDurableStreamTransport", () => {
     // half-registered listener leaks for the lifetime of the window.
     expect(fakeWs.close).toHaveBeenCalledTimes(1);
     expect(closeWs).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["bearer", "ws"]);
   });
 
   it("re-dials at once when the host's dialable endpoint moves, not on benign re-emits", () => {
@@ -121,6 +162,7 @@ describe("openDurableStreamTransport", () => {
       bearer: () => null,
       auth: AUTH,
       runnerHost: RUNNER_HOST,
+      subscribeBearerRotation: () => () => undefined,
       subscribeEndpointChange: (onChange: () => void) => {
         fireDirectoryChange = onChange;
         return () => undefined;

--- a/clients/gui-app/src/lib/host/durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/durable-stream-transport.ts
@@ -31,6 +31,9 @@ export interface DurableStreamTransport {
  *    new `websocketUrl` while the session is warm (no tile mounted to recompute
  *    a memo) reconnects to the new address instead of retrying the dead one.
  *  - `bearer` + `auth` provide UNAUTHORIZED revalidate+reconnect.
+ *  - bearer-rotation forwarding pushes `credentialUpdate` frames to already-open
+ *    sessions after same-user token refresh, so long-lived streams do not keep
+ *    stale host-side request contexts.
  *  - wake re-dial (`window 'online'` + OS resume) is wired here.
  *  - endpoint-change re-dial: when the bound host moves to a NEW dialable
  *    endpoint while the app is awake (a Settings-page restart / re-provision -
@@ -51,6 +54,12 @@ export function openDurableStreamTransport(params: {
   readonly auth: StreamAuthRevalidator;
   readonly runnerHost: IRunnerHost;
   /**
+   * Subscribes to same-user bearer rotations. The durable transport forwards the
+   * event to its owned stream client so open host connections rotate credentials
+   * in place via `credentialUpdate`.
+   */
+  readonly subscribeBearerRotation: (onRotation: () => void) => () => void;
+  /**
    * Subscribes to host-directory changes for the bound host, returning a
    * disposer. The callback fires on ANY directory change; this module filters it
    * down to a genuine dialable-endpoint move before re-dialing.
@@ -67,6 +76,11 @@ export function openDurableStreamTransport(params: {
   });
   const disposers: Array<() => void> = [];
   try {
+    disposers.push(
+      params.subscribeBearerRotation(() => {
+        wsStreamClient.notifyBearerRotated();
+      }),
+    );
     disposers.push(
       subscribeStreamWakeReconnect(wsStreamClient, params.runnerHost),
     );

--- a/clients/gui-app/src/lib/host/use-durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/use-durable-stream-transport.ts
@@ -40,6 +40,8 @@ export function useDurableStreamTransportFactory(): (
           liveRef.current.globalClient.getRequestContext()?.credentials ?? null,
         auth: liveRef.current.auth,
         runnerHost: liveRef.current.runnerHost,
+        subscribeBearerRotation: (onRotation) =>
+          liveRef.current.globalClient.onBearerRotated(onRotation),
         // Fires on any directory change; `openDurableStreamTransport` filters it
         // down to a genuine endpoint MOVE for THIS `hostId` before re-dialing,
         // so a host restart / re-provision reconnects the session at once


### PR DESCRIPTION
## Summary

Forward same-user bearer rotations through GUI durable stream transports so long-lived chat/terminal/epic session streams push `credentialUpdate` frames to open host connections. This keeps host-side request contexts fresh after token refresh and prevents durable chat sessions from holding stale bearer material that can break A2A agent creation.

Adds regression coverage for durable transport bearer-rotation forwarding, listener disposal order, and rollback cleanup when wake wiring fails.

## Related issue

N/A

## Verification

- `bun run test src/lib/host/__tests__/durable-stream-transport.test.ts`
- `bun run compile`
- `npx -y react-doctor@latest . --verbose --scope changed --offline --no-score`
- Commit pre-commit hooks passed, including the repo's `build · compile · lint · format (nx affected)` hook

Note: full `bun run react-doctor` still reports pre-existing unrelated findings outside the changed files.

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
