### PR TITLE
fix(gui): recover usage limit refreshes

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
@@ -35,7 +35,7 @@ afterEach(() => {
 describe("<RateLimitIconButton />", () => {
   it("renders a clickable icon button with an accessible name, even with no bars", () => {
     renderIcon();
-    const button = screen.getByRole("button", { name: "Rate limits" });
+    const button = screen.getByRole("button", { name: "Usage limits" });
     expect(button).toBeTruthy();
   });
 

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -500,7 +500,7 @@ describe("<RateLimitPopover /> Overview progressive reveal", () => {
     mocks.results = { codex: coldResult(), "claude-code": coldResult() };
     renderPopover();
 
-    expect(screen.getByText("Fetching rate limits")).toBeTruthy();
+    expect(screen.getByText("Fetching usage limits")).toBeTruthy();
     // Neither provider's own reading is visible yet - only the combined loader.
     expect(screen.queryByText("Current session")).toBeNull();
     expect(screen.queryByText("4% used")).toBeNull();
@@ -522,7 +522,7 @@ describe("<RateLimitPopover /> Overview progressive reveal", () => {
     rerender(popoverElement());
 
     // The combined loader is gone now that one provider has data...
-    expect(screen.queryByText("Fetching rate limits")).toBeNull();
+    expect(screen.queryByText("Fetching usage limits")).toBeNull();
     // ...Codex's own section is visible...
     expect(
       screen.getByText("Codex").closest('[class*="gap-4"]')?.className,
@@ -589,6 +589,19 @@ describe("<RateLimitPopover /> per-provider states", () => {
     expect(document.querySelectorAll(".opacity-60").length).toBeGreaterThan(0);
   });
 
+  it("shows Refreshing instead of an updated timestamp while a refresh is in progress", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.draining = true;
+    renderPopover();
+
+    const label = screen.getByText("Refreshing");
+    expect(label).toBeTruthy();
+    expect(label.className).toContain("working-text-shimmer");
+    expect(screen.getByTestId("usage-limit-refreshing-dots")).toBeTruthy();
+    expect(screen.queryByText(/^Updated /)).toBeNull();
+  });
+
   it("shows a plain error message with no inline retry control when a fetch never succeeded", () => {
     mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
     mocks.results = {
@@ -603,7 +616,7 @@ describe("<RateLimitPopover /> per-provider states", () => {
     };
     renderPopover();
     expect(
-      screen.getByText("Couldn't load rate limits right now."),
+      screen.getByText("Couldn't load usage limits right now."),
     ).toBeTruthy();
     // No separate "Retry" link - the header's own refresh icon already covers
     // it (feedback: "we already have a reload button"). That icon is
@@ -631,7 +644,7 @@ describe("<RateLimitPopover /> per-provider states", () => {
     };
     renderPopover();
     expect(
-      screen.getByText("Rate limits unavailable — the CLI isn't installed"),
+      screen.getByText("Usage limits unavailable — the CLI isn't installed"),
     ).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/layout/header/rate-limit-icon.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-icon.tsx
@@ -39,7 +39,7 @@ export function RateLimitIconButton(): ReactNode {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <TooltipWrapper
-        label="Rate limits"
+        label="Usage limits"
         side="top"
         sideOffset={6}
         align={undefined}
@@ -49,7 +49,7 @@ export function RateLimitIconButton(): ReactNode {
             type="button"
             variant="ghost"
             size="icon-sm"
-            aria-label="Rate limits"
+            aria-label="Usage limits"
             data-testid="rate-limit-header-button"
             className={cn(
               "text-muted-foreground hover:text-foreground",

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -128,7 +128,7 @@ export function RateLimitPopover({
       sideOffset={8}
       collisionPadding={12}
       role="dialog"
-      aria-label="Rate limits"
+      aria-label="Usage limits"
       className="w-[min(92vw,30rem)] gap-0 overflow-hidden rounded-xl p-0"
       // Radix auto-focuses the first focusable child on open. Here that's the
       // Overview rail tab, whose `TooltipWrapper` opens the tooltip on focus
@@ -275,7 +275,7 @@ function RateLimitRail({
     <div className="flex min-h-0 flex-col items-center border-r bg-muted/20 p-1.5">
       <div
         role="tablist"
-        aria-label="Rate limit providers"
+        aria-label="Usage limit providers"
         aria-orientation="vertical"
         className="flex min-h-0 flex-1 flex-col items-center gap-1.5 overflow-y-auto"
       >
@@ -285,11 +285,7 @@ function RateLimitRail({
           onSelect={() => onSelect("overview")}
           icon={<Gauge className="size-4" />}
         />
-        <div
-          role="separator"
-          aria-orientation="horizontal"
-          className="my-0.5 h-px w-5 bg-border"
-        />
+        <div aria-hidden className="my-0.5 h-px w-5 bg-border" />
         {railTabs.map((tab) =>
           tab.kind === "traycer" ? (
             <RailTab
@@ -379,8 +375,8 @@ function RailTab({
  * than painted as its own blank/loading section - it's revealed in place once
  * its data arrives, so the list grows one provider at a time instead of every
  * slot appearing empty up front. While nothing has reported ready yet, a
- * single centered "Fetching rate limits" indicator stands in for the whole
- * list (feedback: "just a modal centered fetching rate limits instead of
+ * single centered "Fetching usage limits" indicator stands in for the whole
+ * list (feedback: "just a modal centered fetching usage limits instead of
  * empty provider sections").
  */
 function RateLimitOverview({
@@ -449,7 +445,7 @@ function RateLimitOverviewLoading(): ReactNode {
   return (
     <div className="flex flex-1 items-center justify-center gap-2 py-10 text-ui-sm text-muted-foreground">
       <MutedAgentSpinner />
-      Fetching rate limits
+      Fetching usage limits
     </div>
   );
 }
@@ -591,7 +587,7 @@ function RateLimitProviderBlock({
   );
   const queryState: ProviderRateLimitQueryState = {
     isPending: query.isPending,
-    isFetching: query.isFetching,
+    isFetching: isRefreshing,
     isError: query.isError,
     providerRateLimits: query.data?.providerRateLimits,
   };
@@ -630,9 +626,11 @@ function RateLimitProviderBlock({
           ) : null}
         </div>
         <div className="flex items-center gap-1.5">
-          <RateLimitUpdatedLabel
-            state={state}
+          <UsageLimitUpdatedLabel
+            ready={state.kind === "ready"}
             updatedAt={query.dataUpdatedAt}
+            refreshing={isRefreshing}
+            degraded={state.kind === "ready" && state.degraded}
           />
           {/* Overview has its own "Refresh all" on the rail (item 2 feedback:
               a per-provider icon there was redundant); only the single-provider
@@ -660,15 +658,44 @@ function RateLimitProviderBlock({
  * failed" appended when a last-known-good reading is being shown after a failed
  * poll (Core Flows degraded state).
  */
-function RateLimitUpdatedLabel({
-  state,
+function UsageLimitUpdatedLabel({
+  ready,
   updatedAt,
+  refreshing,
+  degraded,
 }: {
-  readonly state: PopoverProviderRateLimitState;
+  readonly ready: boolean;
   readonly updatedAt: number;
+  readonly refreshing: boolean;
+  readonly degraded: boolean;
 }): ReactNode {
-  if (state.kind !== "ready" || updatedAt === 0) return null;
-  return <UpdatedAgoText updatedAt={updatedAt} degraded={state.degraded} />;
+  if (!ready) return null;
+  if (refreshing) return <RefreshingText />;
+  if (updatedAt === 0) return null;
+  return <UpdatedAgoText updatedAt={updatedAt} degraded={degraded} />;
+}
+
+function RefreshingText(): ReactNode {
+  return (
+    <span className="inline-flex items-baseline gap-1 text-ui-xs text-muted-foreground">
+      <span className="working-text-shimmer text-ui-xs">Refreshing</span>
+      <RefreshingWorkingDots />
+    </span>
+  );
+}
+
+function RefreshingWorkingDots(): ReactNode {
+  return (
+    <span
+      aria-hidden="true"
+      className="working-dots text-current"
+      data-testid="usage-limit-refreshing-dots"
+    >
+      <span />
+      <span />
+      <span />
+    </span>
+  );
 }
 
 function UpdatedAgoText({
@@ -698,12 +725,12 @@ function RateLimitProviderBody({
       return <RateLimitDetailSkeleton />;
     case "error":
       return (
-        <RateLimitErrorMessage message="Couldn't load rate limits right now." />
+        <RateLimitErrorMessage message="Couldn't load usage limits right now." />
       );
     case "unavailable":
       return (
         <RateLimitErrorMessage
-          message={`Rate limits unavailable — ${formatUnavailableReason(state.reason)}`}
+          message={`Usage limits unavailable — ${formatUnavailableReason(state.reason)}`}
         />
       );
     case "ready":
@@ -810,12 +837,12 @@ function TraycerRateLimitBlock({
           ) : null}
         </div>
         <div className="flex items-center gap-1.5">
-          {state.kind === "ready" && query.dataUpdatedAt !== 0 ? (
-            <UpdatedAgoText
-              updatedAt={query.dataUpdatedAt}
-              degraded={state.degraded}
-            />
-          ) : null}
+          <UsageLimitUpdatedLabel
+            ready={state.kind === "ready"}
+            updatedAt={query.dataUpdatedAt}
+            refreshing={query.isFetching}
+            degraded={state.kind === "ready" && state.degraded}
+          />
           {/* Overview has its own "Refresh all" on the rail (item 2 feedback);
               only the single-provider detail tab keeps this one. */}
           {!overview ? (

--- a/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
@@ -93,22 +93,22 @@ const NODE_META: Readonly<
 };
 
 const TASKS = [
-  "Team rate limits",
+  "Team usage limits",
   "Billing service",
   "Usage sync audit",
 ] as const;
 
 const TASK_SCENES = [
   {
-    chat: "Team rate limits",
+    chat: "Team usage limits",
     terminal: "billing-service run",
     terminalHarness: "claude",
     secondChat: "Grace-period plan",
-    spec: "rate-limits.spec",
+    spec: "usage-limits.spec",
     ticket: "Grace-period rollout",
     review: "Risk review",
-    canvas: "Team rate limits",
-    preview: "rate-limits.spec",
+    canvas: "Team usage limits",
+    preview: "usage-limits.spec",
   },
   {
     chat: "Billing service",
@@ -195,7 +195,7 @@ const STORY_STEPS = [
   {
     pane: "gui",
     kind: "user",
-    text: "We need team rate limits without locking existing customers out.",
+    text: "We need team usage limits without locking existing customers out.",
     to: null,
   },
   {
@@ -204,14 +204,14 @@ const STORY_STEPS = [
     text: "I'll split this into implementation, verification, and risk review.",
     to: null,
   },
-  { pane: "gui", kind: "spec", text: "rate-limits.spec", to: null },
+  { pane: "gui", kind: "spec", text: "usage-limits.spec", to: null },
   {
     pane: "gui",
     kind: "handoff",
-    text: "Claude Code, implement the billing-service check from rate-limits.spec.",
+    text: "Claude Code, implement the billing-service check from usage-limits.spec.",
     to: "claude",
   },
-  { pane: "claude", kind: "term", text: "reading rate-limits.spec", to: null },
+  { pane: "claude", kind: "term", text: "reading usage-limits.spec", to: null },
   {
     pane: "claude",
     kind: "blocked",
@@ -1129,7 +1129,7 @@ function ChatPane(props: {
   const userCopy =
     props.scene === "task-tabs"
       ? `Continue ${TASKS[props.activeTaskIndex].toLowerCase()}`
-      : "Let's ship team rate limits.";
+      : "Let's ship team usage limits.";
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex min-h-0 flex-1 flex-col justify-end gap-2 p-3">

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -202,7 +202,7 @@ codeFontSize` in muted styling while `null`; any tick/type pins an
     pay-as-you-go). Each bar is shown only when that bucket's total > 0; amounts
     are `$`-denominated. Credit-based vs rate-limit-based is decided exactly like
     the extension (`isCreditBasedPricing` - V3 plans are credit-based); **legacy /
-    v2 (rate-limit) plans** instead render a **Rate limit** section with the
+    v2 (usage-limit) plans** instead render a **Usage limit** section with the
     recharge rate ("New artifact every N minutes", from `rechargeRateSeconds`)
     plus the Bundle bar. The extension's live "Artifact Used" bar is omitted -
     `totalTokens`/`remainingTokens` come from the inference `GetRateLimitUsage`

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
@@ -126,7 +126,7 @@ describe("ProviderRateLimitForProvider", () => {
     cleanup();
   });
 
-  it("renders nothing for a provider without native rate limits", () => {
+  it("renders nothing for a provider without native usage limits", () => {
     const { container } = render(
       <ProviderRateLimitForProvider providerId="traycer" />,
     );
@@ -137,8 +137,8 @@ describe("ProviderRateLimitForProvider", () => {
     mocks.isPending = true;
     mocks.isFetching = true;
     render(<ProviderRateLimitForProvider providerId="claude-code" />);
-    expect(screen.getByText("Rate limits")).toBeTruthy();
-    expect(screen.getByText("Loading rate limits")).toBeTruthy();
+    expect(screen.getByText("Usage limits")).toBeTruthy();
+    expect(screen.getByText("Loading usage limits")).toBeTruthy();
   });
 
   it("renders nothing (not an eternal spinner) while pending but not fetching", () => {
@@ -148,8 +148,8 @@ describe("ProviderRateLimitForProvider", () => {
     mocks.isPending = true;
     mocks.isFetching = false;
     render(<ProviderRateLimitForProvider providerId="claude-code" />);
-    expect(screen.getByText("Rate limits")).toBeTruthy();
-    expect(screen.queryByText("Loading rate limits")).toBeNull();
+    expect(screen.getByText("Usage limits")).toBeTruthy();
+    expect(screen.queryByText("Loading usage limits")).toBeNull();
   });
 
   it("renders the Claude Code rate-limit detail once loaded", () => {
@@ -235,7 +235,7 @@ describe("ProviderRateLimitForProvider", () => {
     mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
     render(<ProviderRateLimitForProvider providerId="codex" />);
 
-    expect(screen.getByText("Rate limit reached")).toBeTruthy();
+    expect(screen.getByText("Usage limit reached")).toBeTruthy();
   });
 
   it("does not show a plan badge (the provider auth badge above already shows it)", () => {
@@ -281,7 +281,7 @@ describe("ProviderRateLimitForProvider", () => {
     render(<ProviderRateLimitForProvider providerId="codex" />);
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Refresh rate limits" }),
+      screen.getByRole("button", { name: "Refresh usage limits" }),
     );
 
     expect(mocks.enqueue).toHaveBeenCalledWith("codex", expect.anything(), {
@@ -297,7 +297,7 @@ describe("ProviderRateLimitForProvider", () => {
     render(<ProviderRateLimitForProvider providerId="codex" />);
 
     expect(
-      screen.getByRole("button", { name: "Refresh rate limits" }),
+      screen.getByRole("button", { name: "Refresh usage limits" }),
     ).toHaveProperty("disabled", true);
   });
 });

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
@@ -53,11 +53,11 @@ function ProviderRateLimitSettingsCard({
     <div className="mb-3 flex flex-col gap-3 rounded-lg border border-border/60 p-3">
       <div className="flex items-center justify-between gap-2">
         <div className="text-ui-sm font-medium text-foreground">
-          Rate limits
+          Usage limits
         </div>
         <RefreshIconButton
           onRefresh={refresh}
-          label="Refresh rate limits"
+          label="Refresh usage limits"
           // `isRefreshing` (from useProviderRateLimitRefresh) already folds in
           // the ephemeralProcess `draining` flag, so this stays disabled for a
           // "Refresh all" round's full duration, not just this provider's slice.
@@ -66,7 +66,7 @@ function ProviderRateLimitSettingsCard({
       </div>
       <ProviderRateLimitBody
         isPending={query.isPending}
-        isFetching={query.isFetching}
+        isFetching={query.isFetching || isRefreshing}
         isError={query.isError}
         providerRateLimits={query.data?.providerRateLimits}
       />

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -288,7 +288,7 @@ function ProviderNumberRow({
 // showing the raw value. Falls back to `titleCaseFromToken` for any value
 // not listed here (forward-compat with a new value before this map updates).
 const CODEX_RATE_LIMIT_REACHED_LABELS: Record<string, string> = {
-  rate_limit_reached: "Rate limit reached",
+  rate_limit_reached: "Usage limit reached",
   workspace_owner_credits_depleted: "Workspace credits depleted",
   workspace_member_credits_depleted: "Workspace credits depleted",
   workspace_owner_usage_limit_reached: "Workspace usage limit reached",
@@ -725,14 +725,14 @@ export function ProviderRateLimitBody(
   if (state.kind === "loading") {
     return (
       <div className="flex items-center gap-2 text-ui-sm text-muted-foreground">
-        <MutedAgentSpinner /> Loading rate limits
+        <MutedAgentSpinner /> Loading usage limits
       </div>
     );
   }
   if (state.kind === "error") {
     return (
       <div className="text-ui-sm text-destructive">
-        Couldn't load rate limits. Try refreshing.
+        Couldn't load usage limits. Try refreshing.
       </div>
     );
   }
@@ -741,7 +741,7 @@ export function ProviderRateLimitBody(
   if (!data.available) {
     return (
       <p className="text-ui-xs text-muted-foreground">
-        Rate limits unavailable — {formatUnavailableReason(data.reason)}
+        Usage limits unavailable — {formatUnavailableReason(data.reason)}
       </p>
     );
   }

--- a/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-query-options.test.ts
+++ b/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-query-options.test.ts
@@ -4,12 +4,14 @@ import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-
 describe("providerRateLimitQueryOptions", () => {
   it("gives an httpFetch provider its own refetchInterval and keeps TanStack's default refetchOnMount", () => {
     const { options } = providerRateLimitQueryOptions("openrouter");
+    expect(options?.enabled).toBe(true);
     expect(options?.refetchInterval).toBe(5 * 60 * 1000);
     expect(options?.refetchOnMount).toBe(true);
   });
 
-  it("disables both refetchInterval and refetchOnMount for an ephemeralProcess provider", () => {
+  it("disables the query observer, refetchInterval, and refetchOnMount for an ephemeralProcess provider", () => {
     const { options } = providerRateLimitQueryOptions("codex");
+    expect(options?.enabled).toBe(false);
     expect(options?.refetchInterval).toBe(false);
     expect(options?.refetchOnMount).toBe(false);
   });

--- a/clients/gui-app/src/hooks/host/provider-rate-limit-query-options.ts
+++ b/clients/gui-app/src/hooks/host/provider-rate-limit-query-options.ts
@@ -36,8 +36,9 @@ const HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS = 5 * 60 * 1000;
  *   `queryFn` on every popover/Settings-card open (a fresh mount) whenever the
  *   cached data is stale - a direct host call that bypasses the queue and can
  *   overlap a fetch it's already draining. `useRefreshProviderRateLimitsOnMount`
- *   is the queue-routed replacement every `ephemeralProcess` consumer pairs
- *   with this hook to get the same "fresh data on open" behavior safely.
+ *   and `RateLimitQueueProvider` are the queue-routed replacements. The query
+ *   observer is disabled for this lane so it observes the shared cache state
+ *   without ever initiating its own subprocess-spawning request.
  */
 export function providerRateLimitQueryOptions(
   providerId: RateLimitProviderId,
@@ -50,6 +51,7 @@ export function providerRateLimitQueryOptions(
     method: "host.getRateLimitUsage",
     params: { accountContext: DEFAULT_ACCOUNT_CONTEXT, providerId },
     options: {
+      enabled: isHttpFetch,
       retry: false,
       staleTime: PROVIDER_RATE_LIMITS_STALE_TIME_MS,
       refetchInterval: isHttpFetch

--- a/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
+++ b/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
@@ -44,9 +44,19 @@ describe("resolvePopoverProviderRateLimitState", () => {
     expect(state.kind).toBe("cold");
   });
 
-  it("is an error when the first fetch failed with no data", () => {
+  it("is cold while a disabled queue-owned observer is pending without fetching", () => {
     const state = resolvePopoverProviderRateLimitState({
       isPending: true,
+      isFetching: false,
+      isError: false,
+      providerRateLimits: null,
+    });
+    expect(state.kind).toBe("cold");
+  });
+
+  it("is an error when the first fetch failed with no data", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: false,
       isFetching: false,
       isError: true,
       providerRateLimits: undefined,

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -65,7 +65,7 @@ const RATE_LIMIT_UNAVAILABLE_REASON_LABELS: Record<
   invalid_response: "the CLI returned an unexpected response",
   timeout: "the request timed out",
   connection_failed: "couldn't connect to the CLI",
-  sdk_incompatible: "this SDK version doesn't support rate limits",
+  sdk_incompatible: "this SDK version doesn't support usage limits",
   rate_limits_not_available: "not available for this account",
   insufficient_permissions:
     "this account doesn't have permission to view usage",
@@ -110,13 +110,13 @@ export function resolvePopoverProviderRateLimitState(
 ): PopoverProviderRateLimitState {
   const snapshot = props.providerRateLimits ?? null;
   if (snapshot === null) {
-    // Nothing usable yet. `isPending` alone stays `true` forever for a
-    // disabled query (e.g. a host that goes unreachable while this tab is
-    // open, mirroring `resolveProviderRateLimitViewState`'s same fix) - only
-    // treat it as a cold load in flight (skeleton) when a fetch is actually
-    // happening; a failed fetch, or a pending-but-not-fetching query that will
-    // never resolve on its own, both fall through to the retryable error copy.
-    return props.isPending && props.isFetching
+    // Nothing usable yet. `ephemeralProcess` queries are queue-owned and
+    // therefore disabled as query observers; before the queue starts, they can
+    // be pending-but-not-fetching without that representing a failed read.
+    // Once a queued fetch actually fails, TanStack moves the observer out of
+    // `isPending` and into `isError`, revealing retryable error content instead
+    // of staying hidden in Overview.
+    return props.isFetching || props.isPending
       ? { kind: "cold" }
       : { kind: "error" };
   }

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
@@ -5,9 +5,9 @@
  * per-provider refresh icon and `RateLimitRefreshAllButton` both depend on to
  * stay in sync. Uses the shared harness's real `HostClient` +
  * `MockHostMessenger` and PRODUCTION QueryClient configuration: this exact
- * flow - data freshly loaded, then a force:true enqueue - is where the
- * inherited global staleTime silently no-oped the real app's refresh while a
- * bare staleTime-0 test client passed.
+ * flow - disabled observer mounted, first snapshot loaded by the queue, then
+ * a force:true enqueue - is where the inherited global staleTime silently
+ * no-oped the real app's refresh while a bare staleTime-0 test client passed.
  */
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
@@ -25,13 +25,19 @@ import {
   createRateLimitSharingHarness,
 } from "@/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness";
 
+const EXPECTED_RATE_LIMIT_USAGE = {
+  totalTokens: 0,
+  remainingTokens: 0,
+  providerRateLimits: null,
+};
+
 describe("enqueueRateLimitFetch keeps a mounted useHostProviderRateLimitsQuery observer's isFetching in sync", () => {
   afterEach(() => {
     cleanup();
     __resetRateLimitQueueForTests();
   });
 
-  it("flips isFetching true on the observer while a force:true enqueue is in flight, then false once it settles", async () => {
+  it("populates a disabled Codex observer from the queue and reflects a later force:true enqueue's fetch state", async () => {
     const harness = createRateLimitSharingHarness();
     const { method, params, options } = providerRateLimitQueryOptions("codex");
     const rendered = renderHook(
@@ -39,9 +45,11 @@ describe("enqueueRateLimitFetch keeps a mounted useHostProviderRateLimitsQuery o
       { wrapper: createQueryClientWrapper(harness.queryClient) },
     );
 
-    // Let the initial mount fetch settle (the harness resolves it immediately).
-    await waitFor(() => expect(rendered.result.current.isPending).toBe(false));
+    // Codex is an `ephemeralProcess` provider: the mounted observer is disabled
+    // and must not start a subprocess-spawning request on its own.
+    expect(rendered.result.current.isPending).toBe(true);
     expect(rendered.result.current.isFetching).toBe(false);
+    expect(rendered.result.current.data).toBeUndefined();
 
     configureRateLimitQueue({
       hostId: mockLocalHostEntry.hostId,
@@ -51,14 +59,25 @@ describe("enqueueRateLimitFetch keeps a mounted useHostProviderRateLimitsQuery o
     });
 
     void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+
+    await waitFor(() =>
+      expect(rendered.result.current.data).toEqual(EXPECTED_RATE_LIMIT_USAGE),
+    );
+    expect(rendered.result.current.isPending).toBe(false);
+    expect(rendered.result.current.isFetching).toBe(false);
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
       force: true,
     });
 
-    // The second call is the one the harness blocks - the observer mounted
-    // independently of the queue must see this as in flight.
+    // The second call is the one the harness blocks. The disabled observer,
+    // mounted independently of the queue, must still see it as in flight.
     await waitFor(() => expect(rendered.result.current.isFetching).toBe(true));
 
     harness.resolvePendingResponse();
     await waitFor(() => expect(rendered.result.current.isFetching).toBe(false));
+    expect(rendered.result.current.data).toEqual(EXPECTED_RATE_LIMIT_USAGE);
   });
 });

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
@@ -189,6 +189,38 @@ describe("ephemeral-fetch-queue", () => {
     expect(isRateLimitQueueDraining()).toBe(false);
   });
 
+  it("a failed first read does not make a provider look fresh; an automatic enqueue retries and recovers", async () => {
+    const queryClient = newQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    await flush();
+    settlers[0].fail();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(
+      queryClient.getQueryState(keyFor("claude-code"))?.dataUpdatedAt,
+    ).toBe(0);
+
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    await flush();
+
+    expect(request).toHaveBeenCalledTimes(2);
+    settlers[1].ok();
+    await flush();
+    expect(queryClient.getQueryState(keyFor("claude-code"))?.data).toEqual(
+      response(),
+    );
+    expect(
+      queryClient.getQueryState(keyFor("claude-code"))?.dataUpdatedAt,
+    ).toBeGreaterThan(0);
+  });
+
   it("exposes an external-store draining signal that flips with in-flight work", async () => {
     const queryClient = newQueryClient();
     const { request, settlers } = makeControllableRequest();

--- a/clients/gui-app/src/providers/__tests__/rate-limit-queue-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/rate-limit-queue-provider.test.tsx
@@ -104,15 +104,26 @@ describe("<RateLimitQueueProvider />", () => {
     expect(configureSpy).toHaveBeenLastCalledWith(null);
   });
 
-  it("polls only ephemeralProcess providers each interval, and not before the first tick", () => {
+  it("enqueues only ephemeralProcess providers immediately when they are configured", () => {
     mocks.configured = [
       { providerId: "codex", lane: "ephemeralProcess" },
       { providerId: "openrouter", lane: "httpFetch" },
     ];
     render(tree());
 
-    // No immediate tick on mount - the per-provider query owns initial load.
-    expect(enqueueSpy).not.toHaveBeenCalled();
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("polls only ephemeralProcess providers each interval after the immediate enqueue", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "openrouter", lane: "httpFetch" },
+    ];
+    render(tree());
+    enqueueSpy.mockClear();
 
     act(() => {
       vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
@@ -129,6 +140,7 @@ describe("<RateLimitQueueProvider />", () => {
   it("pauses the interval while the document is hidden and resumes when visible again (guardrail 2)", () => {
     mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
     render(tree());
+    enqueueSpy.mockClear();
 
     act(() => {
       changeVisibility("hidden");
@@ -152,6 +164,7 @@ describe("<RateLimitQueueProvider />", () => {
   it("keeps polling when the window loses focus but stays visible - never keys off blur (guardrail 4)", () => {
     mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
     render(tree());
+    enqueueSpy.mockClear();
 
     // OS focus moves elsewhere (e.g. Traycer visible on a second monitor). The
     // document stays "visible", so nothing must pause.
@@ -170,6 +183,7 @@ describe("<RateLimitQueueProvider />", () => {
       { providerId: "claude-code", lane: "ephemeralProcess" },
     ];
     const { rerender } = render(tree());
+    enqueueSpy.mockClear();
 
     act(() => {
       vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
@@ -183,6 +197,12 @@ describe("<RateLimitQueueProvider />", () => {
       mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
       rerender(tree());
     });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    enqueueSpy.mockClear();
+
     act(() => {
       vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
     });

--- a/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
+++ b/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
@@ -29,7 +29,11 @@ export const EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS = 5 * 60 * 1000;
  *    on host loss so a stale client can't service an enqueue.
  * 2. Drives the single shared interval timer for the `ephemeralProcess` lane,
  *    walking the currently-configured providers and enqueuing a `force: false`
- *    pull for each (the queue serializes them, one subprocess at a time).
+ *    pull for each (the queue serializes them, one subprocess at a time). It
+ *    also enqueues the same safe pull immediately when the configured
+ *    `ephemeralProcess` provider set changes, so the header glyph/popover can
+ *    recover from a failed first read without waiting for a transient surface
+ *    mount.
  *
  * The timer PAUSES on `document.visibilityState === "hidden"` (window truly
  * minimized/backgrounded) and resumes when the window is shown again - matching
@@ -85,10 +89,19 @@ export function RateLimitQueueProvider(): null {
     ephemeralProviderIdsRef.current = ephemeralProviderIds;
   }, [ephemeralProviderIds]);
 
+  useEffect(() => {
+    if (hostId === null) return;
+    ephemeralProviderIds.forEach((providerId) => {
+      void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+        force: false,
+      });
+    });
+  }, [hostId, ephemeralProviderIds]);
+
   // The single shared interval timer, gated on host presence and paused while
   // the window is hidden. Initial per-provider data still populates through the
-  // per-provider query's own fetch-on-mount; this timer only does the periodic
-  // background refresh.
+  // immediate effect above and per-surface queue enqueue-on-mount; this timer
+  // only does the periodic background refresh.
   useEffect(() => {
     if (hostId === null) return;
     let intervalHandle: number | null = null;


### PR DESCRIPTION
## Summary
- rename provider-facing rate-limit popover/settings copy to Usage limits while preserving the Traycer legacy plan label as Rate limit
- make Codex/Claude usage-limit observers queue-owned so initial-load failures can recover on later automatic or manual refreshes
- show Refreshing with shimmer text and working dots while usage-limit reloads are in progress

## Companion PR
- Host Claude transient unavailable retry: https://github.com/traycerai/traycer-internal/pull/4237

## Tests
- bun run test -- src/hooks/host/__tests__/provider-rate-limit-query-options.test.ts src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx src/providers/__tests__/rate-limit-queue-provider.test.tsx src/components/layout/header/__tests__/rate-limit-popover.test.tsx src/components/layout/header/__tests__/rate-limit-icon.test.tsx src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
- bun run compile
- bun run lint
- npx -y react-doctor@latest . --verbose --diff main --offline --no-score
- pre-commit workspace checks on commit