### PR TITLE
fix(gui-app): edit chat messages in the composer; gate composer during worktree setup

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
@@ -293,7 +293,7 @@ describe("<UserMessageBody /> agent messages", () => {
         imageAttachment("second.png"),
       ],
     };
-    const actions = editingUserActions(STRUCTURED_IMAGE_USER_CONTENT);
+    const actions = editingUserActions();
     const view = render(<UserMessageBody actions={null} message={message} />);
 
     expect(screen.getByLabelText("Attached Image#1: first.png")).not.toBeNull();
@@ -424,6 +424,51 @@ describe("<UserMessageBody /> agent messages", () => {
       clipboard.restore();
     }
   });
+
+  it("highlights the bubble of the message being edited in the composer", () => {
+    const actionsFor = (isEditTarget: boolean) => ({
+      type: "user" as const,
+      enabled: true,
+      confirmingDelete: false,
+      isEditTarget,
+      onEdit: () => undefined,
+      onDeleteRequest: () => undefined,
+      onDeleteConfirm: () => undefined,
+      onDeleteCancel: () => undefined,
+    });
+
+    const { rerender } = render(
+      <TooltipProvider>
+        <UserMessageBody
+          actions={actionsFor(false)}
+          message={{
+            ...plainUserMessage("original prompt"),
+            structuredContent: null,
+          }}
+        />
+      </TooltipProvider>,
+    );
+    const bubble = screen.getByText("original prompt").closest(".rounded-2xl");
+    expect(bubble?.className).not.toContain("ring-primary/40");
+
+    // Message-edit mode targets this message: the bubble gains the highlight
+    // ring anchoring the composer's "Editing message" pill.
+    rerender(
+      <TooltipProvider>
+        <UserMessageBody
+          actions={actionsFor(true)}
+          message={{
+            ...plainUserMessage("original prompt"),
+            structuredContent: null,
+          }}
+        />
+      </TooltipProvider>,
+    );
+    const highlighted = screen
+      .getByText("original prompt")
+      .closest(".rounded-2xl");
+    expect(highlighted?.className).toContain("ring-primary/40");
+  });
 });
 
 function agentMessage(content: string): ChatMessageModel {
@@ -494,23 +539,12 @@ function imageAttachment(name: string) {
   };
 }
 
-function editingUserActions(content: JsonContent): ChatMessageUserActions {
+function editingUserActions(): ChatMessageUserActions {
   return {
     type: "user",
     enabled: true,
     confirmingDelete: false,
-    editing: {
-      initialContent: content,
-      currentContent: content,
-      pending: false,
-      canSubmit: false,
-      slashProviderId: "claude",
-      mentionRoots: [],
-      currentEpicId: "epic-1",
-      onSnapshot: () => undefined,
-      onSubmit: () => undefined,
-      onCancel: () => undefined,
-    },
+    isEditTarget: true,
     onEdit: () => undefined,
     onDeleteRequest: () => undefined,
     onDeleteConfirm: () => undefined,

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -19,23 +19,10 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import type {
-  ClipboardEventHandler,
-  DragEventHandler,
-  KeyboardEvent,
-} from "react";
 import type { JsonContent } from "@traycer/protocol/common/registry";
-import {
-  ComposerPromptEditor,
-  type ComposerPromptEditorHandle,
-} from "@/components/chat/composer/composer-prompt-editor";
-import { ChatComposerAttachmentsStrip } from "@/components/chat/composer/chat-composer-attachments-strip";
 import { ComposerContentRenderer } from "@/components/chat/composer/content-renderer";
-import { createComposerPickerStore } from "@/components/chat/composer/picker/composer-picker-store";
-import { useComposerPickerItems } from "@/components/chat/composer/picker/use-composer-picker-items";
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
-import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 import {
   composerClipboardPlainText,
@@ -62,21 +49,13 @@ import {
   useChatFindForcedOpen,
   useSetChatFindForcedOpen,
 } from "@/stores/chats/chat-find-force-store-context";
-import type {
-  ChatMessageEditing,
-  ChatMessageUserActions,
-} from "./chat-message";
+import type { ChatMessageUserActions } from "./chat-message";
 import { ChatUserMessageContent } from "./chat-user-message-content";
 import { UserMessageAttachmentGallery } from "./user-message-attachment-gallery";
-import { ComposerArea } from "@/components/home/composer/composer-shell";
 import { LivePulse } from "@/components/ui/live-pulse";
 import { AgentReferenceMarkdown } from "./segments/agent-reference-markdown";
 import { SegmentCard } from "./segments/segment-card";
 import { SegmentPanel } from "./segments/segment-panel";
-
-const NOOP: () => void = () => undefined;
-const NOOP_CLIPBOARD: ClipboardEventHandler<HTMLElement> = () => undefined;
-const NOOP_DRAG: DragEventHandler<HTMLElement> = () => undefined;
 
 // Keep long prompts compact: ~3-4 lines (leading-7 ≈ 28px/line) stay visible
 // before the bubble clamps and fades, with "Show more" revealing the rest.
@@ -97,8 +76,6 @@ export function UserMessageBody({
   actions,
   message,
 }: UserBodyProps): ReactNode {
-  const editing = actions?.editing ?? null;
-
   if (message.role !== "user") {
     return (
       <>
@@ -114,10 +91,6 @@ export function UserMessageBody({
         </div>
       </>
     );
-  }
-
-  if (editing !== null) {
-    return <InlineUserMessageEditor editing={editing} />;
   }
 
   if (message.agentSenderInfo !== null) {
@@ -377,7 +350,7 @@ function UserMessageDisplayView({
         </div>
       ) : null}
       <div className="relative min-w-0 max-w-full">
-        <div className="rounded-lg border border-border/50 bg-muted/30 px-4 py-3 text-ui leading-7 text-foreground [overflow-wrap:anywhere]">
+        <div className={userMessageBubbleClassName(actions)}>
           <UserMessageAttachmentGallery
             attachments={message.attachments}
             align="start"
@@ -424,6 +397,23 @@ function UserMessageDisplayView({
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * Bubble chrome for a user prompt. Deliberately NOT input-like: a filled,
+ * borderless bubble with a squared bottom-right corner (the classic sent-
+ * message cue), so a short prompt sitting above the composer never reads as
+ * a second text field. The edit-target variant is the transcript anchor for
+ * the composer's "Editing message" pill: it highlights the message whose
+ * content is currently loaded into the bottom composer.
+ */
+function userMessageBubbleClassName(
+  actions: ChatMessageUserActions | null,
+): string {
+  return cn(
+    "rounded-2xl rounded-br-md bg-muted/60 px-4 py-3 text-ui leading-7 text-foreground [overflow-wrap:anywhere]",
+    actions?.isEditTarget === true && "ring-1 ring-primary/40",
   );
 }
 
@@ -493,181 +483,12 @@ function userMessageSteerBadgeLabel(badge: ChatMessageSteerBadge): string {
   return "Steered";
 }
 
-function InlineUserMessageEditor({
-  editing,
-}: {
-  editing: ChatMessageEditing;
-}): ReactNode {
-  const [pickerStore] = useState(() => createComposerPickerStore());
-  const hostClient = useTabHostClient();
-  const editorRef = useRef<ComposerPromptEditorHandle | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const focusFrameRef = useRef<number | null>(null);
-  const visibilityFrameRef = useRef<number | null>(null);
-
-  // Without this, the picker opens empty - nothing writes items into the store.
-  useComposerPickerItems({
-    pickerStore,
-    hostClient,
-    harnessId: editing.slashProviderId,
-    mentionRoots: editing.mentionRoots,
-    currentEpicId: editing.currentEpicId,
-    // The inline editor mounts only while a message is being edited - active.
-    isActive: true,
-  });
-
-  const submit = useCallback(() => {
-    if (!editing.canSubmit || editing.pending) return;
-    editing.onSubmit();
-  }, [editing]);
-
-  const cancel = useCallback(() => {
-    if (editing.pending) return;
-    editing.onCancel();
-  }, [editing]);
-
-  const removeImageAttachment = useCallback((id: string) => {
-    editorRef.current?.removeImageAttachmentById(id);
-  }, []);
-
-  const onSnapshot = useCallback(
-    (content: JsonContent, selection: { from: number; to: number }) => {
-      editing.onSnapshot(content, selection);
-      if (visibilityFrameRef.current !== null) {
-        cancelAnimationFrame(visibilityFrameRef.current);
-      }
-      visibilityFrameRef.current = requestAnimationFrame(() => {
-        visibilityFrameRef.current = null;
-        scrollIntoViewOnlyIfNeeded(containerRef.current);
-      });
-    },
-    [editing],
-  );
-
-  useLayoutEffect(() => {
-    const focusFrame = focusFrameRef;
-    const visibilityFrame = visibilityFrameRef;
-    // ComposerMenu is now caret-anchored (portal'd to body, positioned by
-    // floating-ui), so it picks the best direction at open-time on its own.
-    // No headroom-reserving scroll needed.
-    const scrollSnapshot = captureScrollSnapshot(containerRef.current);
-    let attempt = 0;
-    const focusWhenReady = (): void => {
-      editorRef.current?.focusAtEnd();
-      restoreScrollSnapshot(scrollSnapshot);
-      attempt += 1;
-      if (attempt >= 4) {
-        focusFrameRef.current = null;
-        return;
-      }
-      focusFrameRef.current = requestAnimationFrame(focusWhenReady);
-    };
-    focusWhenReady();
-    return () => {
-      if (focusFrame.current !== null) {
-        cancelAnimationFrame(focusFrame.current);
-      }
-      if (visibilityFrame.current !== null) {
-        cancelAnimationFrame(visibilityFrame.current);
-      }
-    };
-  }, []);
-  const handleEditorKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key !== "Escape") return;
-      event.preventDefault();
-      cancel();
-    },
-    [cancel],
-  );
-  const editor = useMemo(
-    () => (
-      <ComposerPromptEditor
-        ref={editorRef}
-        pickerStore={pickerStore}
-        initialContent={editing.initialContent}
-        initialSelection={null}
-        slashProviderId={editing.slashProviderId}
-        isActive
-        disabled={editing.pending}
-        placeholder="Edit message"
-        editorClassName="max-h-[min(60vh,18rem)] min-h-9 overflow-y-auto text-ui leading-7 text-foreground"
-        stabilizeImageAttachmentCaret={false}
-        onSnapshot={onSnapshot}
-        onSubmit={submit}
-        onPaste={NOOP_CLIPBOARD}
-        onDragOver={NOOP_DRAG}
-        onDrop={NOOP_DRAG}
-        onKeyDown={handleEditorKeyDown}
-        onFocus={NOOP}
-        onBlur={NOOP}
-        onEditorReady={null}
-      />
-    ),
-    [editing, handleEditorKeyDown, onSnapshot, pickerStore, submit],
-  );
-  const editorSlot = useMemo(
-    () => (
-      <>
-        <ChatComposerAttachmentsStrip
-          content={editing.currentContent}
-          editingQueueItemId={null}
-          onCancelQueueEdit={null}
-          onRemoveImage={removeImageAttachment}
-        />
-        {editor}
-      </>
-    ),
-    [editing.currentContent, editor, removeImageAttachment],
-  );
-  const toolbar = useMemo(
-    () => (
-      <div className="flex justify-end gap-1 px-4 pb-3 pt-2">
-        <MessageActionButton
-          label="Cancel edit"
-          variant="secondary"
-          size="default"
-          tooltip
-          disabled={editing.pending}
-          className={undefined}
-          onClick={cancel}
-        >
-          Cancel
-        </MessageActionButton>
-        <MessageActionButton
-          label="Send edit"
-          variant="default"
-          size="default"
-          tooltip
-          disabled={!editing.canSubmit || editing.pending}
-          className={undefined}
-          onClick={submit}
-        >
-          Send
-        </MessageActionButton>
-      </div>
-    ),
-    [cancel, editing.canSubmit, editing.pending, submit],
-  );
-
-  return (
-    <div ref={containerRef} className="w-full">
-      <ComposerArea
-        pickerStore={pickerStore}
-        overlay={null}
-        editor={editorSlot}
-        toolbar={toolbar}
-      />
-    </div>
-  );
-}
-
 function MessageActionBar({
   actions,
 }: {
   actions: ChatMessageUserActions;
 }): ReactNode {
-  if (!actions.enabled && actions.editing === null) return null;
+  if (!actions.enabled) return null;
 
   if (actions.confirmingDelete) {
     return (
@@ -814,76 +635,4 @@ function MessageCopyButton({
       )}
     </MessageActionButton>
   );
-}
-
-function scrollIntoViewOnlyIfNeeded(element: HTMLElement | null): void {
-  if (element === null) return;
-  const rect = element.getBoundingClientRect();
-  const scrollContainer = nearestScrollContainer(element);
-  const containerRect = scrollContainer?.getBoundingClientRect() ?? null;
-  const viewportBottom =
-    containerRect?.bottom ??
-    window.visualViewport?.height ??
-    document.documentElement.clientHeight;
-  const viewportTop = containerRect?.top ?? 0;
-  const padding = 16;
-  if (rect.bottom > viewportBottom - padding) {
-    scrollByAmount(scrollContainer, rect.bottom - viewportBottom + padding);
-    return;
-  }
-  if (rect.top < viewportTop + padding) {
-    scrollByAmount(scrollContainer, rect.top - viewportTop - padding);
-  }
-}
-
-type ScrollSnapshot = {
-  readonly container: HTMLElement | null;
-  readonly left: number;
-  readonly top: number;
-};
-
-function captureScrollSnapshot(element: HTMLElement | null): ScrollSnapshot {
-  const scrollContainer =
-    element === null ? null : nearestScrollContainer(element);
-  if (scrollContainer === null) {
-    return { container: null, left: window.scrollX, top: window.scrollY };
-  }
-  return {
-    container: scrollContainer,
-    left: scrollContainer.scrollLeft,
-    top: scrollContainer.scrollTop,
-  };
-}
-
-function restoreScrollSnapshot(snapshot: ScrollSnapshot): void {
-  if (snapshot.container === null) {
-    window.scrollTo(snapshot.left, snapshot.top);
-    return;
-  }
-  snapshot.container.scrollLeft = snapshot.left;
-  snapshot.container.scrollTop = snapshot.top;
-}
-
-function nearestScrollContainer(element: HTMLElement): HTMLElement | null {
-  let parent = element.parentElement;
-  while (parent !== null) {
-    const overflowY = window.getComputedStyle(parent).overflowY;
-    if (
-      overflowY === "auto" ||
-      overflowY === "scroll" ||
-      overflowY === "overlay"
-    ) {
-      return parent;
-    }
-    parent = parent.parentElement;
-  }
-  return null;
-}
-
-function scrollByAmount(element: HTMLElement | null, top: number): void {
-  if (element === null) {
-    window.scrollBy({ top, behavior: "auto" });
-    return;
-  }
-  element.scrollBy({ top, behavior: "auto" });
 }

--- a/clients/gui-app/src/components/chat/chat-message.tsx
+++ b/clients/gui-app/src/components/chat/chat-message.tsx
@@ -1,8 +1,6 @@
 import { memo, type ReactElement } from "react";
 import { cn } from "@/lib/utils";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
-import type { JsonContent } from "@traycer/protocol/common/registry";
-import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { AssistantMessageBody } from "./chat-message-assistant-body";
 import { chatFindSegmentUnitId } from "./chat-find";
 import { UserMessageBody } from "./chat-message-user-body";
@@ -17,22 +15,6 @@ interface ChatMessageProps {
   nextStepActions: NextStepActionHandler | null;
 }
 
-export interface ChatMessageEditing {
-  readonly initialContent: JsonContent;
-  readonly currentContent: JsonContent;
-  readonly pending: boolean;
-  readonly canSubmit: boolean;
-  readonly slashProviderId: GuiHarnessId;
-  readonly mentionRoots: ReadonlyArray<string>;
-  readonly currentEpicId: string | null;
-  readonly onSnapshot: (
-    content: JsonContent,
-    selection: { from: number; to: number },
-  ) => void;
-  readonly onSubmit: () => void;
-  readonly onCancel: () => void;
-}
-
 export interface ChatMessageForkAction {
   readonly enabled: boolean;
   readonly pending: boolean;
@@ -43,7 +25,13 @@ export interface ChatMessageUserActions {
   readonly type: "user";
   readonly enabled: boolean;
   readonly confirmingDelete: boolean;
-  readonly editing: ChatMessageEditing | null;
+  /**
+   * True when this message is the target of the composer's active
+   * message-edit mode (the pencil loaded its content into the bottom
+   * composer). The bubble highlights so the composer's "Editing message"
+   * pill has a visible anchor in the transcript.
+   */
+  readonly isEditTarget: boolean;
   readonly onEdit: () => void;
   readonly onDeleteRequest: () => void;
   readonly onDeleteConfirm: () => void;

--- a/clients/gui-app/src/components/chat/composer/chat-composer-attachments-strip.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer-attachments-strip.tsx
@@ -4,6 +4,7 @@ import {
   AttachmentStrip,
   NO_SESSION_OBJECT_URL,
 } from "@/components/chat/composer/attachments/attachment-strip";
+import { MessageEditDraftPill } from "@/components/chat/composer/message-edit-draft-pill";
 import { QueueEditDraftPill } from "@/components/chat/composer/queue-edit-draft-pill";
 import { useEpicImageFetcher } from "@/lib/attachments/use-attachment-blob-src";
 
@@ -11,6 +12,8 @@ interface ChatComposerAttachmentsStripProps {
   readonly content: JsonContent;
   readonly editingQueueItemId: string | null;
   readonly onCancelQueueEdit: (() => void) | null;
+  readonly messageEditActive: boolean;
+  readonly onCancelMessageEdit: () => void;
   readonly onRemoveImage: (id: string) => void;
 }
 
@@ -23,6 +26,10 @@ export function ChatComposerAttachmentsStrip(
       <QueueEditDraftPill
         editingQueueItemId={props.editingQueueItemId}
         onCancel={props.onCancelQueueEdit}
+      />
+      <MessageEditDraftPill
+        active={props.messageEditActive}
+        onCancel={props.onCancelMessageEdit}
       />
       <AttachmentStrip
         content={props.content}

--- a/clients/gui-app/src/components/chat/composer/chat-composer.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer.tsx
@@ -65,6 +65,21 @@ interface ChatComposerProps {
   readonly activeTurnStatus: ChatActiveTurn["status"] | null;
   readonly editingQueueItemId: string | null;
   readonly onCancelQueueEdit: (() => void) | null;
+  /**
+   * True while the composer is the edit surface for a persisted message (the
+   * pencil loaded its content as the draft). Renders the "Editing message"
+   * pill above the editor; submit is routed to `editUserMessage` by the
+   * owner's `onSubmitMessage`.
+   */
+  readonly messageEditActive: boolean;
+  /** Ends message-edit mode from the pill; the draft stays as typed. */
+  readonly onCancelMessageEdit: () => void;
+  /**
+   * Worktree setup is provisioning for this chat. A fresh new-message send is
+   * blocked (it would stack a second message); editing the pending message is
+   * still allowed. See `setupInFlight` in the chat tile.
+   */
+  readonly setupInFlight: boolean;
   readonly hasPendingApprovals: boolean;
   readonly stopDisabled: boolean;
   readonly onStopTurn: (() => void) | null;
@@ -87,6 +102,9 @@ interface ChatComposerProps {
   readonly topSlot: ReactNode | null;
 }
 
+const SETUP_IN_FLIGHT_SEND_HINT =
+  "Setting up the worktree… edit your message above to change it.";
+
 export interface ChatComposerSubmitInput {
   readonly content: JsonContent;
   readonly contentText: string;
@@ -108,6 +126,9 @@ function ChatComposerImpl(props: ChatComposerProps) {
     activeTurnStatus,
     editingQueueItemId,
     onCancelQueueEdit,
+    messageEditActive,
+    onCancelMessageEdit,
+    setupInFlight,
     hasPendingApprovals,
     stopDisabled,
     onStopTurn,
@@ -182,7 +203,13 @@ function ChatComposerImpl(props: ChatComposerProps) {
   // host. When the provider CLI is signed out it blocks send and mounts the
   // re-auth banner above the composer; a doomed turn can't start.
   const reauthGate = useProviderReauthGate(harnessId, isActive);
-  const sendBlocked = sendDisabled === true || reauthGate.signedOut;
+  // While worktree setup is provisioning, a fresh new-message send is blocked
+  // so it can't stack a second message onto the one that triggered setup - but
+  // editing that pending message (messageEditActive) stays allowed, since that
+  // is the sanctioned way to change it. Not applied in edit mode.
+  const newSendBlockedBySetup = setupInFlight && !messageEditActive;
+  const sendBlocked =
+    sendDisabled === true || reauthGate.signedOut || newSendBlockedBySetup;
   const selectedModel = useStore(toolbarStore, (s) => s.selectedModel);
   const imagesUnsupported = imageAttachmentsUnsupported(
     draftHasImages,
@@ -268,6 +295,8 @@ function ChatComposerImpl(props: ChatComposerProps) {
                 content={draftContent}
                 editingQueueItemId={editingQueueItemId}
                 onCancelQueueEdit={onCancelQueueEdit}
+                messageEditActive={messageEditActive}
+                onCancelMessageEdit={onCancelMessageEdit}
                 onRemoveImage={removeImage}
               />
             }
@@ -297,7 +326,11 @@ function ChatComposerImpl(props: ChatComposerProps) {
                 hasPendingApprovals={hasPendingApprovals}
                 stopDisabled={stopDisabled}
                 onStopTurn={onStopTurn}
-                composerDisabledHint={workspaceAvailability.disabledHint}
+                composerDisabledHint={
+                  newSendBlockedBySetup
+                    ? SETUP_IN_FLIGHT_SEND_HINT
+                    : workspaceAvailability.disabledHint
+                }
                 dictation={dictationControl}
                 dictationPreparing={dictationPreparing}
                 settingsLocked={false}

--- a/clients/gui-app/src/components/chat/composer/edit-draft-pill.tsx
+++ b/clients/gui-app/src/components/chat/composer/edit-draft-pill.tsx
@@ -1,0 +1,36 @@
+import { PencilLine, X } from "lucide-react";
+
+interface EditDraftPillProps {
+  /** Pill label, e.g. "Editing" (queue item) or "Editing message". */
+  readonly label: string;
+  readonly cancelAriaLabel: string;
+  readonly onCancel: () => void;
+  readonly testId: string;
+}
+
+/**
+ * Shared "editing a draft" marker rendered above the composer editor. Both the
+ * queue-item and message edit modes use it; only the label, the cancel
+ * aria-label, and the test id differ. Callers own the visibility guard (each
+ * edit mode returns null when inactive) and pass a stable `onCancel`.
+ */
+export function EditDraftPill(props: EditDraftPillProps) {
+  return (
+    <div
+      className="mb-2 inline-flex max-w-full items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-ui-xs text-primary"
+      data-testid={props.testId}
+    >
+      <PencilLine className="size-3.5 shrink-0" aria-hidden />
+      <span className="min-w-0 truncate font-medium">{props.label}</span>
+      <button
+        type="button"
+        className="inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-primary/85 transition-colors hover:bg-primary/15 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label={props.cancelAriaLabel}
+        onClick={props.onCancel}
+      >
+        <X className="size-3" aria-hidden />
+        <span>Cancel</span>
+      </button>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/chat/composer/message-edit-draft-pill.tsx
+++ b/clients/gui-app/src/components/chat/composer/message-edit-draft-pill.tsx
@@ -1,4 +1,4 @@
-import { PencilLine, X } from "lucide-react";
+import { EditDraftPill } from "@/components/chat/composer/edit-draft-pill";
 
 interface MessageEditDraftPillProps {
   readonly active: boolean;
@@ -13,23 +13,12 @@ interface MessageEditDraftPillProps {
  */
 export function MessageEditDraftPill(props: MessageEditDraftPillProps) {
   if (!props.active) return null;
-
   return (
-    <div
-      className="mb-2 inline-flex max-w-full items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-ui-xs text-primary"
-      data-testid="message-edit-draft-pill"
-    >
-      <PencilLine className="size-3.5 shrink-0" aria-hidden />
-      <span className="min-w-0 truncate font-medium">Editing message</span>
-      <button
-        type="button"
-        className="inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-primary/85 transition-colors hover:bg-primary/15 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        aria-label="Cancel message editing"
-        onClick={props.onCancel}
-      >
-        <X className="size-3" aria-hidden />
-        <span>Cancel</span>
-      </button>
-    </div>
+    <EditDraftPill
+      label="Editing message"
+      cancelAriaLabel="Cancel message editing"
+      onCancel={props.onCancel}
+      testId="message-edit-draft-pill"
+    />
   );
 }

--- a/clients/gui-app/src/components/chat/composer/message-edit-draft-pill.tsx
+++ b/clients/gui-app/src/components/chat/composer/message-edit-draft-pill.tsx
@@ -1,0 +1,35 @@
+import { PencilLine, X } from "lucide-react";
+
+interface MessageEditDraftPillProps {
+  readonly active: boolean;
+  readonly onCancel: () => void;
+}
+
+/**
+ * "Editing message" marker shown above the composer editor while the draft is
+ * a persisted message loaded for editing (the message-edit sibling of
+ * `QueueEditDraftPill`). Submitting replaces that message (trim + resubmit);
+ * Cancel ends edit mode and keeps the text as a plain draft.
+ */
+export function MessageEditDraftPill(props: MessageEditDraftPillProps) {
+  if (!props.active) return null;
+
+  return (
+    <div
+      className="mb-2 inline-flex max-w-full items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-ui-xs text-primary"
+      data-testid="message-edit-draft-pill"
+    >
+      <PencilLine className="size-3.5 shrink-0" aria-hidden />
+      <span className="min-w-0 truncate font-medium">Editing message</span>
+      <button
+        type="button"
+        className="inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-primary/85 transition-colors hover:bg-primary/15 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        aria-label="Cancel message editing"
+        onClick={props.onCancel}
+      >
+        <X className="size-3" aria-hidden />
+        <span>Cancel</span>
+      </button>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/chat/composer/queue-edit-draft-pill.tsx
+++ b/clients/gui-app/src/components/chat/composer/queue-edit-draft-pill.tsx
@@ -1,4 +1,4 @@
-import { PencilLine, X } from "lucide-react";
+import { EditDraftPill } from "@/components/chat/composer/edit-draft-pill";
 
 interface QueueEditDraftPillProps {
   readonly editingQueueItemId: string | null;
@@ -9,24 +9,12 @@ export function QueueEditDraftPill(props: QueueEditDraftPillProps) {
   if (props.editingQueueItemId === null || props.onCancel === null) {
     return null;
   }
-
   return (
-    <div
-      className="mb-2 inline-flex max-w-full items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-ui-xs text-primary"
-      data-queue-item-id={props.editingQueueItemId}
-      data-testid="queue-edit-draft-pill"
-    >
-      <PencilLine className="size-3.5 shrink-0" aria-hidden />
-      <span className="min-w-0 truncate font-medium">Editing</span>
-      <button
-        type="button"
-        className="inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-primary/85 transition-colors hover:bg-primary/15 hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        aria-label="Cancel queued message editing"
-        onClick={props.onCancel}
-      >
-        <X className="size-3" aria-hidden />
-        <span>Cancel</span>
-      </button>
-    </div>
+    <EditDraftPill
+      label="Editing"
+      cancelAriaLabel="Cancel queued message editing"
+      onCancel={props.onCancel}
+      testId="queue-edit-draft-pill"
+    />
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
@@ -28,9 +28,19 @@ let composerRenderCount = 0;
 vi.mock("@/components/chat/composer/chat-composer", () => ({
   ChatComposer: (props: {
     readonly workspaceControls: import("react").ReactNode | null;
+    readonly messageEditActive: boolean;
+    readonly setupInFlight: boolean;
   }) => {
     composerRenderCount += 1;
-    return <div data-testid="composer-stub">{props.workspaceControls}</div>;
+    return (
+      <div
+        data-testid="composer-stub"
+        data-message-edit-active={String(props.messageEditActive)}
+        data-setup-in-flight={String(props.setupInFlight)}
+      >
+        {props.workspaceControls}
+      </div>
+    );
   },
 }));
 // The dock legitimately re-renders per token; stub it so the test isolates the
@@ -178,6 +188,9 @@ const COMPOSER: ChatLowerComposerState = {
     </>
   ),
   workspaceAvailability: WORKSPACE_COMPOSER_READY,
+  messageEditActive: false,
+  onCancelMessageEdit: () => undefined,
+  setupInFlight: false,
 };
 
 // ── Per-token (dock-only) inputs: fresh identity each token, like the real app ─
@@ -260,6 +273,54 @@ describe("composer isolation from per-token dock churn", () => {
     // Run status flips idle -> running: a genuine composer input change.
     rerender(<ChatLowerInteractionSurfaces {...props(TURN_RUNNING, 1)} />);
     expect(composerRenderCount).toBe(2);
+  });
+
+  it("threads message-edit mode into the composer (single edit surface)", () => {
+    const { rerender } = render(
+      <ChatLowerInteractionSurfaces {...props(TURN_IDLE, 0)} />,
+    );
+    expect(
+      screen
+        .getByTestId("composer-stub")
+        .getAttribute("data-message-edit-active"),
+    ).toBe("false");
+
+    // A message edit begins: the bottom composer becomes THE edit surface
+    // (pill + edit-routed submit) - no second input box anywhere.
+    rerender(
+      <ChatLowerInteractionSurfaces
+        {...{
+          ...props(TURN_IDLE, 1),
+          composer: { ...COMPOSER, messageEditActive: true },
+        }}
+      />,
+    );
+    expect(
+      screen
+        .getByTestId("composer-stub")
+        .getAttribute("data-message-edit-active"),
+    ).toBe("true");
+  });
+
+  it("threads setup-in-flight into the composer (blocks fresh send)", () => {
+    const { rerender } = render(
+      <ChatLowerInteractionSurfaces {...props(TURN_IDLE, 0)} />,
+    );
+    expect(
+      screen.getByTestId("composer-stub").getAttribute("data-setup-in-flight"),
+    ).toBe("false");
+
+    rerender(
+      <ChatLowerInteractionSurfaces
+        {...{
+          ...props(TURN_IDLE, 1),
+          composer: { ...COMPOSER, setupInFlight: true },
+        }}
+      />,
+    );
+    expect(
+      screen.getByTestId("composer-stub").getAttribute("data-setup-in-flight"),
+    ).toBe("true");
   });
 
   it("does not re-render the composer when the context usage leaf updates", async () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -758,7 +758,7 @@ describe("<ChatTile />", () => {
     expect(frame.fromMessageId).toBe("message-1");
   });
 
-  it("sends edit-user-message from the inline editor with current composer settings", async () => {
+  it("sends edit-user-message from the composer with current composer settings", async () => {
     useComposerRunSettingsStore.setState({
       globalLastRunSettings: QUEUED_SETTINGS,
     });
@@ -784,8 +784,12 @@ describe("<ChatTile />", () => {
 
     await waitForChatTileLoaded();
 
+    // The pencil loads the message into the BOTTOM composer (edit mode pill);
+    // the composer's own Send then submits the edit with the live toolbar
+    // settings - the full toolbar applies to an edit resubmit.
     fireEvent.click(getButtonByAriaLabel("Edit message"));
-    fireEvent.click(getButtonByAriaLabel("Send edit"));
+    expect(screen.getByTestId("message-edit-draft-pill")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     expect(chatHarness.sent).toHaveLength(1);
     const frame = chatHarness.sent[0];
@@ -796,46 +800,44 @@ describe("<ChatTile />", () => {
     expect(frame.settings).toEqual(UPDATED_QUEUE_SETTINGS);
   });
 
-  it("clears the inline editor after an edit action is accepted", async () => {
+  it("ends message-edit mode once the edit frame is sent", async () => {
     renderChatTile();
 
     await waitForChatTileLoaded();
 
     fireEvent.click(getButtonByAriaLabel("Edit message"));
-    expect(getButtonByAriaLabel("Send edit")).not.toBeNull();
+    expect(screen.getByTestId("message-edit-draft-pill")).not.toBeNull();
 
-    fireEvent.click(getButtonByAriaLabel("Send edit"));
-    await waitFor(() => {
-      const sendEditButton = getButtonByAriaLabel("Send edit");
-      if (!(sendEditButton instanceof HTMLButtonElement)) {
-        throw new Error("expected send edit button");
-      }
-      expect(sendEditButton.disabled).toBe(true);
-    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
 
     const frame = chatHarness.sent[0];
     if (frame.kind !== "editUserMessage") {
       throw new Error("expected editUserMessage frame");
     }
 
-    act(() => {
-      chatHarness.callbacks().onActionAck({
-        kind: "actionAck",
-        hasBinaryPayload: false,
-        epicId: EPIC_ID,
-        chatId: CHAT_ARTIFACT.id,
-        clientActionId: frame.clientActionId,
-        action: "editUserMessage",
-        status: "accepted",
-        reason: null,
-        code: null,
-        backgroundStopTaskIds: [],
-      });
-    });
-
+    // Edit mode clears as soon as the frame is on the wire (the optimistic
+    // echo and pending-action gating take over) - no lingering pill.
     await waitFor(() => {
-      expect(queryButtonByAriaLabel("Send edit")).toBeNull();
+      expect(screen.queryByTestId("message-edit-draft-pill")).toBeNull();
     });
+  });
+
+  it("cancelling message-edit mode keeps the composer draft", async () => {
+    renderChatTile();
+
+    await waitForChatTileLoaded();
+
+    fireEvent.click(getButtonByAriaLabel("Edit message"));
+    expect(screen.getByTestId("message-edit-draft-pill")).not.toBeNull();
+
+    fireEvent.click(getButtonByAriaLabel("Cancel message editing"));
+    expect(screen.queryByTestId("message-edit-draft-pill")).toBeNull();
+
+    // The next submit is a plain send (not an edit): the draft text stays in
+    // the composer as a normal draft.
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(chatHarness.sent).toHaveLength(1);
+    expect(chatHarness.sent[0].kind).toBe("send");
   });
 
   it("seeds composer settings from last-used local settings", async () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -1,15 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
   ChatActiveTurn,
   ChatQueueState,
   ChatRunSettings,
+  ChatRunStatus,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { ChatMessage } from "@/stores/composer/chat-store";
+import type { ChatSessionState } from "@/stores/chats/chat-session-store";
 import {
-  chatMessageEditingForInlineEdit,
+  canModifyChatMessages,
+  chatTileUiReducer,
+  createInitialChatTileUiState,
   resolvedTurnStatus,
-  type InlineEditState,
 } from "../chat-tile-session-state";
 
 const CONTENT: JsonContent = {
@@ -52,40 +55,62 @@ const MESSAGE: ChatMessage = {
   steerBadge: null,
 };
 
-function inlineEditState(dirty: boolean): InlineEditState {
-  return {
-    targetMessageId: "persisted-message-1",
-    originalMessage: MESSAGE,
-    initialContent: CONTENT,
-    currentContent: CONTENT,
-    dirty,
-    pendingClientActionId: null,
-    pendingMessageId: null,
-  };
-}
-
-function renderInlineEdit(dirty: boolean) {
-  const editing = chatMessageEditingForInlineEdit({
-    editing: inlineEditState(dirty),
-    canModifyMessages: true,
-    editSettings: SETTINGS,
-    mentionRoots: [],
-    currentEpicId: "epic-1",
-    onSnapshot: vi.fn(),
-    onSubmit: vi.fn(),
-    onCancel: vi.fn(),
+describe("chatTileUiReducer edit-mode exclusivity", () => {
+  // The bottom composer hosts BOTH edit modes (queued item and persisted
+  // message); the reducer must never let them be active simultaneously -
+  // they would fight over the same draft.
+  it("beginInlineEdit ends queue-edit mode", () => {
+    const withQueueEdit = chatTileUiReducer(createInitialChatTileUiState(), {
+      type: "setEditingQueueItemId",
+      editingQueueItemId: "queue-1",
+    });
+    const next = chatTileUiReducer(withQueueEdit, {
+      type: "beginInlineEdit",
+      targetMessageId: "persisted-message-1",
+      originalMessage: MESSAGE,
+    });
+    expect(next.inlineEdit?.targetMessageId).toBe("persisted-message-1");
+    expect(next.editingQueueItemId).toBeNull();
   });
 
-  if (editing === null) {
-    throw new Error("Expected inline edit view model");
-  }
-  return editing;
-}
+  it("entering queue-edit mode ends a message edit", () => {
+    const withMessageEdit = chatTileUiReducer(createInitialChatTileUiState(), {
+      type: "beginInlineEdit",
+      targetMessageId: "persisted-message-1",
+      originalMessage: MESSAGE,
+    });
+    const next = chatTileUiReducer(withMessageEdit, {
+      type: "setEditingQueueItemId",
+      editingQueueItemId: "queue-1",
+    });
+    expect(next.editingQueueItemId).toBe("queue-1");
+    expect(next.inlineEdit).toBeNull();
+  });
 
-describe("chatMessageEditingForInlineEdit", () => {
-  it("requires a dirty edit before enabling submit", () => {
-    expect(renderInlineEdit(false).canSubmit).toBe(false);
-    expect(renderInlineEdit(true).canSubmit).toBe(true);
+  it("clearing queue-edit mode leaves an active message edit alone", () => {
+    const withMessageEdit = chatTileUiReducer(createInitialChatTileUiState(), {
+      type: "beginInlineEdit",
+      targetMessageId: "persisted-message-1",
+      originalMessage: MESSAGE,
+    });
+    const next = chatTileUiReducer(withMessageEdit, {
+      type: "setEditingQueueItemId",
+      editingQueueItemId: null,
+    });
+    expect(next.inlineEdit?.targetMessageId).toBe("persisted-message-1");
+  });
+
+  it("beginInlineEdit dismisses a pending delete confirmation", () => {
+    const withConfirm = chatTileUiReducer(createInitialChatTileUiState(), {
+      type: "setConfirmingDeleteMessageId",
+      confirmingDeleteMessageId: "persisted-message-1",
+    });
+    const next = chatTileUiReducer(withConfirm, {
+      type: "beginInlineEdit",
+      targetMessageId: "persisted-message-1",
+      originalMessage: MESSAGE,
+    });
+    expect(next.confirmingDeleteMessageId).toBeNull();
   });
 });
 
@@ -101,6 +126,82 @@ const ACTIVE_TURN: ChatActiveTurn = {
   startedAt: 0,
   updatedAt: 0,
 };
+
+function stateSlice(overrides: {
+  readonly runStatus: ChatRunStatus;
+  readonly activeTurn: ChatActiveTurn | null;
+}): Pick<
+  ChatSessionState,
+  | "runStatus"
+  | "activeTurn"
+  | "queue"
+  | "pendingUserMessages"
+  | "pendingActions"
+> {
+  return {
+    runStatus: overrides.runStatus,
+    activeTurn: overrides.activeTurn,
+    queue: { status: "idle", items: [] },
+    pendingUserMessages: [],
+    pendingActions: {},
+  };
+}
+
+describe("canModifyChatMessages during worktree setup", () => {
+  // Editing must NOT unlock mid-setup while the turn is still live (the host
+  // would reject editUserMessage with an active turn) - only after the user
+  // stops and the host settles the turn to `activeTurn === null`.
+  it("keeps edit disabled while setup runs with a live turn", () => {
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        setupInFlight: true,
+        state: stateSlice({ runStatus: "running", activeTurn: ACTIVE_TURN }),
+      }),
+    ).toBe(false);
+  });
+
+  it("enables edit once the turn settles during setup (post-stop)", () => {
+    // Setup script still running (runStatus lingers non-idle), but the stopped
+    // turn has cleared `activeTurn` - the setup-triggering message is editable.
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        setupInFlight: true,
+        state: stateSlice({ runStatus: "stopping", activeTurn: null }),
+      }),
+    ).toBe(true);
+  });
+
+  it("still requires canAct during setup", () => {
+    expect(
+      canModifyChatMessages({
+        canAct: false,
+        setupInFlight: true,
+        state: stateSlice({ runStatus: "stopping", activeTurn: null }),
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps normal (non-setup) gating when no setup is in flight", () => {
+    // A genuine running turn (not setup) stays locked via runStatus.
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        setupInFlight: false,
+        state: stateSlice({ runStatus: "running", activeTurn: ACTIVE_TURN }),
+      }),
+    ).toBe(false);
+    // Idle with nothing pending is editable as before.
+    expect(
+      canModifyChatMessages({
+        canAct: true,
+        setupInFlight: false,
+        state: stateSlice({ runStatus: "idle", activeTurn: null }),
+      }),
+    ).toBe(true);
+  });
+});
 
 const EMPTY_QUEUE: ChatQueueState = { status: "idle", items: [] };
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
@@ -121,6 +121,21 @@ export interface ChatLowerComposerState {
   /** The Location / Mode+branch / Environment chip cluster (+ context usage). */
   readonly workspaceControls: ReactNode;
   readonly workspaceAvailability: WorkspaceComposerAvailability;
+  /**
+   * True while the composer is editing a persisted message (the pencil loaded
+   * its content as the draft). The composer shows the "Editing message" pill
+   * and its submit routes to `editUserMessage` instead of a fresh send.
+   */
+  readonly messageEditActive: boolean;
+  /** Ends message-edit mode from the pill; the draft stays as typed. */
+  readonly onCancelMessageEdit: () => void;
+  /**
+   * Worktree setup is provisioning for this chat. A fresh new-message send is
+   * blocked (it would stack a second message onto the one that triggered
+   * setup); editing the pending message is still allowed. See `setupInFlight`
+   * in the chat tile.
+   */
+  readonly setupInFlight: boolean;
 }
 
 interface ComposerSurfaceModel {
@@ -453,6 +468,9 @@ function LiveChatComposer(props: {
       activeTurnStatus={model.turn.activeTurnStatus}
       editingQueueItemId={model.queue.editingItem?.queueItemId ?? null}
       onCancelQueueEdit={model.queue.onCancelEdit}
+      messageEditActive={model.composer.messageEditActive}
+      onCancelMessageEdit={model.composer.onCancelMessageEdit}
+      setupInFlight={model.composer.setupInFlight}
       hasPendingApprovals={props.hasPendingApprovals}
       stopDisabled={model.turn.stopDisabled}
       onStopTurn={model.turn.onStopTurn}
@@ -509,6 +527,9 @@ export function InertChatComposer(props: {
       activeTurnStatus={null}
       editingQueueItemId={null}
       onCancelQueueEdit={null}
+      messageEditActive={false}
+      onCancelMessageEdit={NOOP_CANCEL_MESSAGE_EDIT}
+      setupInFlight={false}
       hasPendingApprovals={false}
       stopDisabled
       onStopTurn={null}
@@ -519,6 +540,8 @@ export function InertChatComposer(props: {
     />
   );
 }
+
+const NOOP_CANCEL_MESSAGE_EDIT = (): void => undefined;
 
 function ComposerSlotShell(props: {
   readonly children: ReactNode;

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -1,8 +1,6 @@
 import { toast } from "sonner";
 import type { JsonContent } from "@traycer/protocol/common/registry";
-import type {
-  ChatRunStatus,
-} from "@traycer/protocol/host/agent/gui/subscribe";
+import type { ChatRunStatus } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { RestoreResultEntry } from "@traycer/protocol/persistence/epic/checkpoint-manifests";
 import type { UserMessageSender } from "@traycer/protocol/persistence/epic/schemas";
 import type { AuthProfile } from "@/stores/auth/auth-store";

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -1,13 +1,11 @@
 import { toast } from "sonner";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
-  ChatRunSettings,
   ChatRunStatus,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { RestoreResultEntry } from "@traycer/protocol/persistence/epic/checkpoint-manifests";
 import type { UserMessageSender } from "@traycer/protocol/persistence/epic/schemas";
 import type { AuthProfile } from "@/stores/auth/auth-store";
-import type { ChatMessageEditing } from "@/components/chat/chat-message";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
 import type {
   ChatSessionState,
@@ -15,28 +13,18 @@ import type {
 } from "@/stores/chats/chat-session-store";
 import { isTransientLiveAssistantMessageId } from "@/lib/chat/transient-live-assistant-message-id";
 import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-json-content";
-import { containsImageAtoms } from "@/lib/composer/image-atoms";
 import type { PendingInterviewView } from "./chat-tile-types";
 
 /**
- * Fallback harness id used when the inline-edit settings do not carry a
- * resolved harness. This occurs only while the composer settings are being
- * initialised (before the first snapshot resolves the harness from the
- * persisted chat settings or the epic/global run-settings seed). The value
- * "claude" matches the host's default harness so the slash-command provider
- * in the inline editor loads the right set of slash commands in the brief
- * window before the real harness is known.
+ * An in-progress message edit. The edit surface is the BOTTOM COMPOSER (the
+ * message content is loaded into it as the draft, mirroring queue-item
+ * editing), so this state only carries the routing target: which persisted
+ * message the next composer submit replaces. `originalMessage` keeps the
+ * edited row renderable if it drops out of the rendered list mid-edit.
  */
-const DEFAULT_SLASH_PROVIDER_ID = "claude";
-
 export interface InlineEditState {
   readonly targetMessageId: string;
   readonly originalMessage: ChatMessageModel;
-  readonly initialContent: JsonContent;
-  readonly currentContent: JsonContent;
-  readonly dirty: boolean;
-  readonly pendingClientActionId: string | null;
-  readonly pendingMessageId: string | null;
 }
 
 export interface ChatTileUiState {
@@ -59,17 +47,6 @@ export type ChatTileUiAction =
       readonly type: "beginInlineEdit";
       readonly targetMessageId: string;
       readonly originalMessage: ChatMessageModel;
-      readonly initialContent: JsonContent;
-    }
-  | {
-      readonly type: "updateInlineEditContent";
-      readonly content: JsonContent;
-    }
-  | {
-      readonly type: "markInlineEditPending";
-      readonly targetMessageId: string;
-      readonly clientActionId: string;
-      readonly messageId: string;
     }
   | {
       readonly type: "clearInlineEdit";
@@ -94,9 +71,14 @@ export function chatTileUiReducer(
 ): ChatTileUiState {
   switch (action.type) {
     case "setEditingQueueItemId":
+      // The composer hosts BOTH edit modes (queue item and message), so
+      // entering queue-edit mode must end an open message edit - the two
+      // would otherwise fight over the same draft.
       return {
         ...state,
         editingQueueItemId: action.editingQueueItemId,
+        inlineEdit:
+          action.editingQueueItemId === null ? state.inlineEdit : null,
       };
     case "setConfirmingDeleteMessageId":
       return {
@@ -104,43 +86,15 @@ export function chatTileUiReducer(
         confirmingDeleteMessageId: action.confirmingDeleteMessageId,
       };
     case "beginInlineEdit":
+      // Symmetric exclusivity: starting a message edit ends queue-edit mode.
       return {
         ...state,
         inlineEdit: {
           targetMessageId: action.targetMessageId,
           originalMessage: action.originalMessage,
-          initialContent: action.initialContent,
-          currentContent: action.initialContent,
-          dirty: false,
-          pendingClientActionId: null,
-          pendingMessageId: null,
         },
+        editingQueueItemId: null,
         confirmingDeleteMessageId: null,
-      };
-    case "updateInlineEditContent":
-      if (state.inlineEdit === null) return state;
-      if (state.inlineEdit.pendingClientActionId !== null) return state;
-      return {
-        ...state,
-        inlineEdit: {
-          ...state.inlineEdit,
-          currentContent: action.content,
-          dirty: true,
-          pendingClientActionId: null,
-          pendingMessageId: null,
-        },
-      };
-    case "markInlineEditPending":
-      if (state.inlineEdit?.targetMessageId !== action.targetMessageId) {
-        return state;
-      }
-      return {
-        ...state,
-        inlineEdit: {
-          ...state.inlineEdit,
-          pendingClientActionId: action.clientActionId,
-          pendingMessageId: action.messageId,
-        },
       };
     case "clearInlineEdit":
       return {
@@ -226,40 +180,19 @@ export function resolvedTurnStatus(
   return isQueueRunnable || hasVisibleBackgroundWork ? null : turnStatus;
 }
 
-export function normalizeInlineEditForSession(
-  inlineEdit: InlineEditState | null,
-  state: Pick<
-    ChatSessionState,
-    "messages" | "pendingActions" | "acceptedActions"
-  >,
-): InlineEditState | null {
-  if (inlineEdit === null) return null;
-  if (
-    inlineEdit.pendingMessageId !== null &&
-    state.messages.some(
-      (message) =>
-        message.role === "user" &&
-        message.messageId === inlineEdit.pendingMessageId,
-    )
-  ) {
-    return null;
-  }
-  if (inlineEdit.pendingClientActionId === null) return inlineEdit;
-  if (Object.hasOwn(state.pendingActions, inlineEdit.pendingClientActionId)) {
-    return inlineEdit;
-  }
-  if (Object.hasOwn(state.acceptedActions, inlineEdit.pendingClientActionId)) {
-    return null;
-  }
-  return {
-    ...inlineEdit,
-    pendingClientActionId: null,
-    pendingMessageId: null,
-  };
-}
-
 export function canModifyChatMessages(input: {
   readonly canAct: boolean;
+  /**
+   * Worktree setup for this chat is provisioning (creating / setting-up),
+   * derived from the setup card events - see {@link setupRowsInFlight}. During
+   * this window the host-owned `runStatus`/pending flags stay non-idle for the
+   * whole (slow) setup, which would otherwise keep edit disabled. Once the user
+   * stops (the host settles the turn → `activeTurn === null`) we allow editing
+   * the setup-triggering message so it can be fixed and re-run, even though the
+   * setup script is still running. Gated on `activeTurn === null` so a genuine
+   * agent turn (activeTurn set, e.g. before stop or after setup) stays blocked.
+   */
+  readonly setupInFlight: boolean;
   readonly state: Pick<
     ChatSessionState,
     | "runStatus"
@@ -270,6 +203,7 @@ export function canModifyChatMessages(input: {
   >;
 }): boolean {
   if (!input.canAct) return false;
+  if (input.setupInFlight) return input.state.activeTurn === null;
   // `runStatus` is the host-owned source of truth for an in-progress run and
   // covers windows `activeTurn` misses - the pre-turn `turnActivating` phase
   // (provider/worktree setup) and stop-during-activation both report a non-idle
@@ -406,71 +340,6 @@ export function forkableAssistantMessageId(
     return null;
   }
   return message.persistentMessageId;
-}
-
-export function inlineEditLocksMessageActions(
-  inlineEdit: InlineEditState | null,
-  persistentMessageId: string,
-): boolean {
-  if (inlineEdit === null) return false;
-  if (inlineEdit.targetMessageId === persistentMessageId) return false;
-  return inlineEdit.dirty || inlineEdit.pendingClientActionId !== null;
-}
-
-export function inlineEditForPersistentMessage(
-  inlineEdit: InlineEditState | null,
-  persistentMessageId: string,
-): InlineEditState | null {
-  if (inlineEdit === null) return null;
-  if (inlineEdit.targetMessageId !== persistentMessageId) return null;
-  return inlineEdit;
-}
-
-export function inlineEditIsPending(
-  inlineEdit: InlineEditState | null,
-): boolean {
-  return inlineEdit !== null && inlineEdit.pendingClientActionId !== null;
-}
-
-function inlineEditHasDraftContent(inlineEdit: InlineEditState): boolean {
-  return (
-    extractPlainTextFromComposerJSONContent(inlineEdit.currentContent).trim()
-      .length > 0 || containsImageAtoms(inlineEdit.currentContent)
-  );
-}
-
-export function chatMessageEditingForInlineEdit(input: {
-  readonly editing: InlineEditState | null;
-  readonly canModifyMessages: boolean;
-  readonly editSettings: ChatRunSettings | null;
-  readonly mentionRoots: ReadonlyArray<string>;
-  readonly currentEpicId: string;
-  readonly onSnapshot: (
-    content: JsonContent,
-    selection: { from: number; to: number },
-  ) => void;
-  readonly onSubmit: () => void;
-  readonly onCancel: () => void;
-}): ChatMessageEditing | null {
-  if (input.editing === null) return null;
-  const editing = input.editing;
-  const pending = inlineEditIsPending(editing);
-  return {
-    initialContent: editing.initialContent,
-    currentContent: editing.currentContent,
-    pending,
-    canSubmit:
-      input.canModifyMessages &&
-      input.editSettings !== null &&
-      editing.dirty &&
-      inlineEditHasDraftContent(editing),
-    slashProviderId: input.editSettings?.harnessId ?? DEFAULT_SLASH_PROVIDER_ID,
-    mentionRoots: input.mentionRoots,
-    currentEpicId: input.currentEpicId,
-    onSnapshot: input.onSnapshot,
-    onSubmit: input.onSubmit,
-    onCancel: input.onCancel,
-  };
 }
 
 export function chatTileCanAct(

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -87,6 +87,7 @@ import {
   useRenderedMessages,
   type RenderedMessagesDisplayContext,
 } from "@/stores/chats/rendered-messages";
+import { worktreeSetupInFlight } from "@/stores/chats/setup-card-rows";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
 import { useHostClient, useHostBinding } from "@/lib/host";
@@ -159,7 +160,6 @@ import {
 import {
   chatTileUiReducer,
   createInitialChatTileUiState,
-  normalizeInlineEditForSession,
   canModifyChatMessages,
   shouldGenerateChatTitleForSubmittedMessage,
   showRestoreResultToast,
@@ -1087,12 +1087,25 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     ],
   );
   const nextStepSettings = currentComposerSettings;
-  const editSettings = nextStepSettings;
-  const canModifyMessages = canModifyChatMessages({ canAct, state });
-  const activeInlineEdit = normalizeInlineEditForSession(
-    uiState.inlineEdit,
-    state,
+  // Worktree setup in flight for THIS chat (creating / setting-up), from the
+  // same setup-card events the transcript renders. Authoritative for both the
+  // edit gate and the composer's fresh-send block during the setup window,
+  // where the host-owned runStatus desyncs. Memoized on events (a pure walk).
+  const setupInFlight = useMemo(
+    () =>
+      worktreeSetupInFlight(state.events, {
+        epicId: currentEpicId,
+        ownerId: node.id,
+        ownerKind: "chat",
+      }),
+    [state.events, currentEpicId, node.id],
   );
+  const canModifyMessages = canModifyChatMessages({
+    canAct,
+    setupInFlight,
+    state,
+  });
+  const activeInlineEdit = uiState.inlineEdit;
 
   const displayedMessages = useMemo(() => {
     if (activeInlineEdit === null) return renderedMessages;
@@ -1167,14 +1180,18 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     [chatActions],
   );
 
-  const { messageActionsFor, revertOnEdit } = useChatMessageActions({
+  const {
+    messageActionsFor,
+    submitActiveMessageEdit,
+    cancelActiveMessageEdit,
+    revertOnEdit,
+  } = useChatMessageActions({
     dispatchUi,
+    handle,
     activeInlineEdit,
     canModifyMessages,
     canAct,
     currentComposerSettings,
-    editSettings,
-    mentionRoots,
     currentEpicId,
     node,
     chatTitle: projectedChatTitle ?? state.chat?.title ?? null,
@@ -1187,6 +1204,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     setForkTarget,
     worktreeBinding: state.worktreeBinding,
     revertOnEditOpen: uiState.revertOnEditOpen,
+    replaceDraftContent,
   });
 
   const submitMessage = useCallback(
@@ -1214,6 +1232,16 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         dispatchUi({ type: "setEditingQueueItemId", editingQueueItemId: null });
         return true;
       }
+      // Message-edit mode: the composer's draft replaces the target message
+      // (trim + resubmit host-side). Mutually exclusive with queue-edit mode
+      // via the UI reducer. Returns false when the revert-on-edit dialog
+      // opened, keeping the draft in place until the dialog decides.
+      if (activeInlineEdit !== null) {
+        return submitActiveMessageEdit({
+          content: input.content,
+          settings: input.settings,
+        });
+      }
       const expectedTitle = state.chat?.title ?? node.name;
       const shouldMarkTitlePending = shouldGenerateChatTitleForSubmittedMessage(
         {
@@ -1238,6 +1266,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     },
     [
       activeEditingQueueItemId,
+      activeInlineEdit,
       canAct,
       chatActions,
       node.id,
@@ -1246,6 +1275,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       state.chat,
       state.messages,
       state.pendingUserMessages,
+      submitActiveMessageEdit,
     ],
   );
   const sendNextStep = useCallback(
@@ -1460,6 +1490,10 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     ],
   );
 
+  // Boolean-only projection of the message-edit state: only open/close
+  // transitions matter to the composer (the pill), not which message is
+  // targeted, so the composer model never depends on the edit object itself.
+  const messageEditActive = activeInlineEdit !== null;
   const lowerComposer = useMemo(
     () => ({
       sessionSettingsSeed: state.currentComposerSettings ?? chatSettingsSeed,
@@ -1472,6 +1506,9 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       onSettingsChange: handleComposerSettingsChange,
       workspaceControls,
       workspaceAvailability,
+      messageEditActive,
+      onCancelMessageEdit: cancelActiveMessageEdit,
+      setupInFlight,
     }),
     [
       state.currentComposerSettings,
@@ -1485,6 +1522,9 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       handleComposerSettingsChange,
       workspaceControls,
       workspaceAvailability,
+      messageEditActive,
+      cancelActiveMessageEdit,
+      setupInFlight,
     ],
   );
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-message-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-message-actions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { WorktreeBinding } from "@traycer/protocol/host/worktree-schemas";
@@ -11,7 +11,11 @@ import {
   type WorktreeStagingKey,
 } from "@/stores/worktree/worktree-intent-staging-store";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
-import type { ChatSessionState } from "@/stores/chats/chat-session-store";
+import { EMPTY_COMPOSER_DRAFT } from "@/stores/composer/composer-draft-store";
+import type {
+  ChatSessionState,
+  ChatSessionStoreHandle,
+} from "@/stores/chats/chat-session-store";
 import type { AuthProfile } from "@/stores/auth/auth-store";
 import type { ChatForkDialogTarget } from "@/components/chat/chat-fork-dialog";
 import type { EpicNodeRef } from "@/stores/epics/canvas/types";
@@ -19,15 +23,10 @@ import {
   hasUndoableFileEditsFromMessage,
   scopedArtifactCountFromMessage,
 } from "@/lib/chat/file-edits-below-message";
-import { buildSubmittedChatJSONContent } from "@/lib/composer/tiptap-json-content";
 import type { ChatActions } from "@/hooks/chats/use-chat-actions";
 import {
-  chatMessageEditingForInlineEdit,
   editablePersistentMessageId,
   forkableAssistantMessageId,
-  inlineEditForPersistentMessage,
-  inlineEditIsPending,
-  inlineEditLocksMessageActions,
   userMessageSenderForProfile,
 } from "./chat-tile-session-state";
 import type {
@@ -35,14 +34,28 @@ import type {
   InlineEditState,
 } from "./chat-tile-session-state";
 
+/** A composer submit captured for the message-edit path. */
+export interface MessageEditSubmission {
+  /** Already-submitted composer JSON (image atoms inline). */
+  readonly content: JsonContent;
+  readonly settings: ChatRunSettings;
+}
+
 export interface ChatMessageActionsInput {
   readonly dispatchUi: (action: ChatTileUiAction) => void;
+  /**
+   * Session-store handle for call-time reads (`getState()`) inside submit
+   * callbacks. `submitActiveMessageEdit` flows into the composer's
+   * `onSubmitMessage`, so it must NOT close over the per-snapshot
+   * `messages`/`events` arrays - that identity churn would re-render the
+   * composer on every streamed token (see steerQueuedItemNow for the same
+   * pattern).
+   */
+  readonly handle: ChatSessionStoreHandle;
   readonly activeInlineEdit: InlineEditState | null;
   readonly canModifyMessages: boolean;
   readonly canAct: boolean;
   readonly currentComposerSettings: ChatRunSettings;
-  readonly editSettings: ChatRunSettings;
-  readonly mentionRoots: ReadonlyArray<string>;
   readonly currentEpicId: string;
   readonly node: EpicNodeRef;
   readonly chatTitle: string | null;
@@ -57,12 +70,35 @@ export interface ChatMessageActionsInput {
   // picker so a fork starts from the same folders / worktree modes.
   readonly worktreeBinding: WorktreeBinding | null;
   readonly revertOnEditOpen: boolean;
+  /**
+   * Draft-store writer for this chat's bottom composer. The pencil loads the
+   * edited message's content into the composer through this (mirroring
+   * queue-item editing), and a dialog-path submit clears it after the edit
+   * frame is accepted.
+   */
+  readonly replaceDraftContent: (
+    nodeId: string,
+    content: JsonContent,
+    context: null,
+  ) => void;
 }
 
 export interface ChatMessageActionsResult {
   readonly messageActionsFor: (
     message: ChatMessageModel,
   ) => ChatMessageActions | null;
+  /**
+   * Routes a bottom-composer submit into the active message edit. Returns
+   * true when the edit frame was sent (the composer should clear); false when
+   * nothing was sent - either no edit is active, a guard failed, or the
+   * revert-on-edit dialog was opened (the draft must stay put until the
+   * dialog decides).
+   */
+  readonly submitActiveMessageEdit: (
+    submission: MessageEditSubmission,
+  ) => boolean;
+  /** Ends message-edit mode; the composer keeps its text as a plain draft. */
+  readonly cancelActiveMessageEdit: () => void;
   readonly revertOnEdit: {
     readonly open: boolean;
     readonly onOpenChange: (open: boolean) => void;
@@ -73,8 +109,11 @@ export interface ChatMessageActionsResult {
 }
 
 /**
- * Encapsulates the inline-edit lifecycle (begin, update, submit, delete) and the
- * `messageActionsFor` factory that wires them into the per-message action surface.
+ * Encapsulates message-level actions (edit, delete, fork) and the
+ * message-edit lifecycle. Editing happens in the BOTTOM COMPOSER: the pencil
+ * loads the message content as the composer draft (exactly like editing a
+ * queued item), the composer's full toolbar applies to the resubmit, and the
+ * chat tile routes the next submit here via `submitActiveMessageEdit`.
  *
  * All callbacks preserve the same `useCallback` dependency structure as the
  * original view-model so memoized children are not disturbed.
@@ -84,12 +123,11 @@ export function useChatMessageActions(
 ): ChatMessageActionsResult {
   const {
     dispatchUi,
+    handle,
     activeInlineEdit,
     canModifyMessages,
     canAct,
     currentComposerSettings,
-    editSettings,
-    mentionRoots,
     currentEpicId,
     node,
     chatTitle,
@@ -101,105 +139,119 @@ export function useChatMessageActions(
     confirmingDeleteMessageId,
     setForkTarget,
     worktreeBinding,
+    replaceDraftContent,
   } = input;
 
-  const beginInlineEdit = useCallback(
+  // The submit captured while the revert-on-edit dialog decides. A ref (not
+  // state): it is written and consumed within user-action handlers only and
+  // must never trigger renders.
+  const pendingEditSubmission = useRef<MessageEditSubmission | null>(null);
+
+  const beginMessageEdit = useCallback(
     (message: ChatMessageModel) => {
       if (!canModifyMessages) return;
       if (message.persistentMessageId === null) return;
       if (message.structuredContent === null) return;
-      const persistentMessageId = message.persistentMessageId;
-      if (
-        activeInlineEdit !== null &&
-        activeInlineEdit.targetMessageId !== persistentMessageId &&
-        activeInlineEdit.dirty
-      ) {
-        return;
-      }
-      const content = structuredClone(message.structuredContent);
+      // Load the message into the bottom composer as the edit draft. The
+      // reducer clears queue-edit mode (the two edit modes share the draft).
+      replaceDraftContent(
+        node.id,
+        structuredClone(message.structuredContent),
+        null,
+      );
       dispatchUi({
         type: "beginInlineEdit",
-        targetMessageId: persistentMessageId,
+        targetMessageId: message.persistentMessageId,
         originalMessage: message,
-        initialContent: content,
       });
     },
-    [activeInlineEdit, canModifyMessages, dispatchUi],
+    [canModifyMessages, dispatchUi, node.id, replaceDraftContent],
   );
 
-  const updateInlineEdit = useCallback(
-    (content: JsonContent, _selection: { from: number; to: number }) => {
-      dispatchUi({ type: "updateInlineEditContent", content });
-    },
-    [dispatchUi],
-  );
-
+  /**
+   * Sends the edit frame for the stashed submission. Returns true when the
+   * frame went out (edit mode cleared); the caller owns clearing the
+   * composer draft for its path.
+   */
   const performEditSubmit = useCallback(
-    (revertFileChanges: boolean, revertArtifacts: boolean) => {
-      // Always dismiss the modal first - if any guard below bails (the inline
-      // edit was invalidated by an incoming snapshot, etc.) the modal must not
-      // be left open with dead buttons.
+    (revertFileChanges: boolean, revertArtifacts: boolean): boolean => {
+      // Always dismiss the modal first - if any guard below bails (the edit
+      // was invalidated by an incoming snapshot, etc.) the modal must not be
+      // left open with dead buttons.
       dispatchUi({ type: "setRevertOnEditOpen", open: false });
-      if (activeInlineEdit === null) return;
-      if (!canModifyMessages) return;
+      const submission = pendingEditSubmission.current;
+      pendingEditSubmission.current = null;
+      if (submission === null) return false;
+      if (activeInlineEdit === null) return false;
+      if (!canModifyMessages) return false;
       const sender = userMessageSenderForProfile(profile);
-      if (sender === null) return;
+      if (sender === null) return false;
       const sent = chatActions.editUserMessage({
         targetMessageId: activeInlineEdit.targetMessageId,
-        content: buildSubmittedChatJSONContent(activeInlineEdit.currentContent),
+        content: submission.content,
         sender,
-        settings: editSettings,
+        settings: submission.settings,
         revertFileChanges,
         revertArtifacts,
       });
-      if (sent === null) return;
-      dispatchUi({
-        type: "markInlineEditPending",
-        targetMessageId: activeInlineEdit.targetMessageId,
-        clientActionId: sent.clientActionId,
-        messageId: sent.messageId,
-      });
+      if (sent === null) return false;
+      dispatchUi({ type: "clearInlineEdit" });
       dispatchUi({
         type: "setConfirmingDeleteMessageId",
         confirmingDeleteMessageId: null,
       });
+      return true;
+    },
+    [activeInlineEdit, canModifyMessages, chatActions, dispatchUi, profile],
+  );
+
+  const submitActiveMessageEdit = useCallback(
+    (submission: MessageEditSubmission): boolean => {
+      if (activeInlineEdit === null) return false;
+      if (!canModifyMessages) return false;
+      if (userMessageSenderForProfile(profile) === null) return false;
+      pendingEditSubmission.current = submission;
+      // Editing a message with reversible edits below it prompts for a revert
+      // first; the composer keeps the draft until the dialog decides. Read the
+      // live history at call time (not the per-snapshot props) so this
+      // callback stays stream-stable - it feeds the composer's submit path.
+      const session = handle.store.getState();
+      if (
+        hasUndoableFileEditsFromMessage(
+          session.messages,
+          session.events,
+          activeInlineEdit.targetMessageId,
+        )
+      ) {
+        dispatchUi({ type: "setRevertOnEditOpen", open: true });
+        return false;
+      }
+      return performEditSubmit(false, true);
     },
     [
       activeInlineEdit,
       canModifyMessages,
-      chatActions,
       dispatchUi,
-      editSettings,
+      handle.store,
+      performEditSubmit,
       profile,
     ],
   );
 
-  const submitInlineEdit = useCallback(() => {
-    if (activeInlineEdit === null) return;
-    if (!canModifyMessages) return;
-    if (userMessageSenderForProfile(profile) === null) return;
-    // Editing a previous message with reversible edits below it prompts for
-    // a revert first; otherwise submit straight through.
-    if (
-      hasUndoableFileEditsFromMessage(
-        messages,
-        events,
-        activeInlineEdit.targetMessageId,
-      )
-    ) {
-      dispatchUi({ type: "setRevertOnEditOpen", open: true });
-      return;
-    }
-    performEditSubmit(false, true);
-  }, [
-    activeInlineEdit,
-    canModifyMessages,
-    dispatchUi,
-    events,
-    messages,
-    performEditSubmit,
-    profile,
-  ]);
+  const cancelActiveMessageEdit = useCallback(() => {
+    dispatchUi({ type: "clearInlineEdit" });
+  }, [dispatchUi]);
+
+  // Dialog-path submits bypass the composer's own submit/clear cycle, so the
+  // draft (still holding the edited text) is cleared here once the frame is
+  // accepted.
+  const performDialogEditSubmit = useCallback(
+    (revertFileChanges: boolean, revertArtifacts: boolean): void => {
+      if (!performEditSubmit(revertFileChanges, revertArtifacts)) return;
+      replaceDraftContent(node.id, EMPTY_COMPOSER_DRAFT.content, null);
+    },
+    [node.id, performEditSubmit, replaceDraftContent],
+  );
 
   const deleteMessageSuffix = useCallback(
     (messageId: string) => {
@@ -258,37 +310,14 @@ export function useChatMessageActions(
       }
       const persistentMessageId = editablePersistentMessageId(message);
       if (persistentMessageId === null) return null;
-      if (
-        inlineEditLocksMessageActions(activeInlineEdit, persistentMessageId)
-      ) {
-        return null;
-      }
-
-      const editing = inlineEditForPersistentMessage(
-        activeInlineEdit,
-        persistentMessageId,
-      );
-      if (!canModifyMessages && editing === null) return null;
-      const pending = inlineEditIsPending(editing);
+      if (!canModifyMessages) return null;
 
       return {
         type: "user",
-        enabled: canModifyMessages && !pending,
+        enabled: canModifyMessages,
         confirmingDelete: confirmingDeleteMessageId === persistentMessageId,
-        editing: chatMessageEditingForInlineEdit({
-          editing,
-          canModifyMessages,
-          editSettings,
-          mentionRoots,
-          currentEpicId,
-          onSnapshot: updateInlineEdit,
-          onSubmit: submitInlineEdit,
-          onCancel: () => {
-            if (pending) return;
-            dispatchUi({ type: "clearInlineEdit" });
-          },
-        }),
-        onEdit: () => beginInlineEdit(message),
+        isEditTarget: activeInlineEdit?.targetMessageId === persistentMessageId,
+        onEdit: () => beginMessageEdit(message),
         onDeleteRequest: () => {
           dispatchUi({ type: "clearInlineEdit" });
           dispatchUi({
@@ -309,7 +338,7 @@ export function useChatMessageActions(
     },
     [
       activeInlineEdit,
-      beginInlineEdit,
+      beginMessageEdit,
       canAct,
       canModifyMessages,
       chatParentId,
@@ -319,13 +348,9 @@ export function useChatMessageActions(
       currentEpicId,
       deleteMessageSuffix,
       dispatchUi,
-      editSettings,
-      mentionRoots,
       node.id,
       node.name,
       setForkTarget,
-      submitInlineEdit,
-      updateInlineEdit,
       worktreeBinding,
     ],
   );
@@ -351,12 +376,14 @@ export function useChatMessageActions(
 
   return {
     messageActionsFor,
+    submitActiveMessageEdit,
+    cancelActiveMessageEdit,
     revertOnEdit: {
       open: input.revertOnEditOpen,
       onOpenChange: handleRevertOnEditOpenChange,
       onRevert: (revertArtifacts: boolean) =>
-        performEditSubmit(true, revertArtifacts),
-      onDontRevert: () => performEditSubmit(false, true),
+        performDialogEditSubmit(true, revertArtifacts),
+      onDontRevert: () => performDialogEditSubmit(false, true),
       artifactCount: revertOnEditArtifactCount,
     },
   };

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-message-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-message-actions.ts
@@ -240,6 +240,12 @@ export function useChatMessageActions(
 
   const cancelActiveMessageEdit = useCallback(() => {
     dispatchUi({ type: "clearInlineEdit" });
+    // Also discard any submission stashed for the revert-on-edit dialog and
+    // close it: cancelling the edit while that dialog is open would otherwise
+    // leave `pendingEditSubmission` pointed at the now-cleared target and the
+    // dialog able to fire an edit against it.
+    pendingEditSubmission.current = null;
+    dispatchUi({ type: "setRevertOnEditOpen", open: false });
   }, [dispatchUi]);
 
   // Dialog-path submits bypass the composer's own submit/clear cycle, so the

--- a/clients/gui-app/src/stores/chats/__tests__/setup-card-rows.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/setup-card-rows.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { ChatEvent } from "@traycer/protocol/persistence/epic/schemas";
 import {
   buildSetupCardRows,
+  worktreeSetupInFlight,
   type SetupCardBinding,
 } from "@/stores/chats/setup-card-rows";
 
@@ -639,5 +640,74 @@ describe("buildSetupCardRows", () => {
       setupEvent("setup.cancelled", { workspacePath: "/web" }, null),
     ]);
     expect(row.model.aggregate.state).toBe("failed");
+  });
+});
+
+describe("worktreeSetupInFlight", () => {
+  it("is false with no setup events", () => {
+    expect(worktreeSetupInFlight([], BINDING)).toBe(false);
+  });
+
+  it("is true while a worktree is creating (git worktree add)", () => {
+    expect(
+      worktreeSetupInFlight(
+        [setupEvent("setup.creating", { workspacePath: "/api" }, null)],
+        BINDING,
+      ),
+    ).toBe(true);
+  });
+
+  it("is true while the setup script is running", () => {
+    expect(
+      worktreeSetupInFlight(
+        [setupEvent("setup.running", { workspacePath: "/api" }, null)],
+        BINDING,
+      ),
+    ).toBe(true);
+  });
+
+  it("is false once every workspace has settled", () => {
+    expect(
+      worktreeSetupInFlight(
+        [
+          setupEvent("setup.running", { workspacePath: "/api" }, null),
+          setupEvent("setup.succeeded", { workspacePath: "/api" }, null),
+        ],
+        BINDING,
+      ),
+    ).toBe(false);
+  });
+
+  it("stays in-flight when one repo is still setting up beside a failed sibling", () => {
+    // The aggregate rolls up to `failed`, but a repo is still provisioning -
+    // the signal must key off the per-workspace state, not the rollup.
+    expect(
+      worktreeSetupInFlight(
+        [
+          setupEvent("setup.running", { workspacePath: "/api" }, null),
+          setupEvent("setup.running", { workspacePath: "/web" }, null),
+          setupEvent(
+            "setup.failed",
+            { workspacePath: "/api", setupExitCode: 1 },
+            null,
+          ),
+        ],
+        BINDING,
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for a historical setting-up window stranded by worktree.missing", () => {
+    // The window is closed by the boundary (isActive: false), so it must not
+    // read as in-flight even though its last state is `setting-up`.
+    expect(
+      worktreeSetupInFlight(
+        [
+          setupEvent("setup.running", { workspacePath: "/api" }, null),
+          setupEvent("worktree.missing", { workspacePath: "/api" }, null),
+        ],
+        BINDING,
+      ),
+    ).toBe(false);
   });
 });

--- a/clients/gui-app/src/stores/chats/__tests__/setup-card-rows.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/setup-card-rows.test.ts
@@ -678,6 +678,30 @@ describe("worktreeSetupInFlight", () => {
     ).toBe(false);
   });
 
+  it("is false when every workspace has terminally failed", () => {
+    // No workspace is creating/setting-up, so setup is not in flight even
+    // though the aggregate rolls up to `failed`.
+    expect(
+      worktreeSetupInFlight(
+        [
+          setupEvent("setup.running", { workspacePath: "/api" }, null),
+          setupEvent("setup.running", { workspacePath: "/web" }, null),
+          setupEvent(
+            "setup.failed",
+            { workspacePath: "/api", setupExitCode: 1 },
+            null,
+          ),
+          setupEvent(
+            "setup.failed",
+            { workspacePath: "/web", setupExitCode: 1 },
+            null,
+          ),
+        ],
+        BINDING,
+      ),
+    ).toBe(false);
+  });
+
   it("stays in-flight when one repo is still setting up beside a failed sibling", () => {
     // The aggregate rolls up to `failed`, but a repo is still provisioning -
     // the signal must key off the per-workspace state, not the rollup.

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -53,6 +53,7 @@ import type { ContentBlock } from "@traycer/protocol/persistence/epic/schemas";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
 import {
   buildSetupCardRows,
+  setupRowsInFlight,
   type SetupCardRow,
 } from "@/stores/chats/setup-card-rows";
 
@@ -914,26 +915,10 @@ export function useRenderedMessages(
     // included so the indicator's `createdAt` floor sits above them and the row
     // sorts BELOW the just-sent message instead of jumping above it.
     // Suppress the pre-turn "Working…" indicator only while the LIVE setup
-    // lifecycle is in flight: the open (current) window has a workspace still
-    // `setting-up`, so the card itself stands in for the awaited turn. Two
-    // guards matter:
-    //  - `row.isActive` (NOT the row state): a window closed by a boundary
-    //    (`worktree.missing` / re-bind) can be stranded at `setting-up` when the
-    //    worktree vanished mid-setup, and that historical card must never gate a
-    //    later normal turn.
-    //  - per-workspace `setting-up` (NOT the rolled-up `aggregate.state`): the
-    //    rollup ranks `failed` above `setting-up`, so a multi-repo window with
-    //    one failed + one still-running repo rolls up to `failed`; keying off the
-    //    aggregate would wrongly un-suppress the indicator while a repo is still
-    //    in flight (a stray "Working…" beside the live card).
-    const setupGating = setupCardRows.some(
-      (row) =>
-        row.isActive &&
-        row.model.workspaces.some(
-          (workspace) =>
-            workspace.state === "creating" || workspace.state === "setting-up",
-        ),
-    );
+    // lifecycle is in flight: the card itself stands in for the awaited turn.
+    // `setupRowsInFlight` is the shared signal (also gates the composer/edit in
+    // the chat tile) - see its doc for the `isActive` + per-workspace guards.
+    const setupGating = setupRowsInFlight(setupCardRows);
     const trailing = setupGating
       ? []
       : renderPendingRunIndicator({

--- a/clients/gui-app/src/stores/chats/setup-card-rows.ts
+++ b/clients/gui-app/src/stores/chats/setup-card-rows.ts
@@ -347,6 +347,42 @@ function workspaceStateFor(type: ChatEvent["type"]): SetupWorkspaceState {
 }
 
 /**
+ * True when the LIVE setup lifecycle is still provisioning - the open
+ * (`isActive`) window has a workspace `creating` (git worktree add) or
+ * `setting-up` (setup script). Keys off `row.isActive` + the per-workspace
+ * state (NOT the rolled-up aggregate, which ranks `failed` above `setting-up`)
+ * so a multi-repo window with one failed + one still-running repo still reads
+ * as in-flight. A historical window stranded at `setting-up` (worktree vanished
+ * mid-setup) is `isActive: false` and never counts. This is the authoritative
+ * "worktree setup is happening now" signal - derived from the same `setup.*`
+ * events as the visible setup card, so it stays in step with what the user
+ * sees, unlike the host-owned `runStatus` which desyncs across the setup window.
+ */
+export function setupRowsInFlight(rows: ReadonlyArray<SetupCardRow>): boolean {
+  return rows.some(
+    (row) =>
+      row.isActive &&
+      row.model.workspaces.some(
+        (workspace) =>
+          workspace.state === "creating" || workspace.state === "setting-up",
+      ),
+  );
+}
+
+/**
+ * Convenience wrapper: whether this owner has a worktree setup in flight,
+ * projected straight from its chat events. Callers outside the transcript
+ * projection (e.g. the composer/edit gating in the chat tile) use this so they
+ * read the same signal the setup card renders from.
+ */
+export function worktreeSetupInFlight(
+  events: ReadonlyArray<ChatEvent>,
+  binding: SetupCardBinding,
+): boolean {
+  return setupRowsInFlight(buildSetupCardRows(events, binding));
+}
+
+/**
  * Roll the per-workspace states up to one aggregate state, most-severe-first:
  * a `failed` workspace dominates (it owns the retry call-to-action), then any
  * still-running `setting-up`, then any still-`creating` worktree (both are work


### PR DESCRIPTION
## What

Reworks in-chat message editing and the composer's behaviour during worktree setup.

- **Edit in the composer, not an inline editor.** The pencil loads the message into the bottom composer with an "Editing message" pill and the full toolbar (model / permission / attachments); submit routes to `editUserMessage`. The old under-bubble inline editor is removed. Queue-edit and message-edit are mutually exclusive, so there is exactly one submit surface at a time.
- **During worktree setup** (a new event-derived `worktreeSetupInFlight` signal, shared with `rendered-messages`):
  - editing the setup-triggering message unlocks once the turn settles after **Stop** (relies on the host abort-aware setup gate);
  - a fresh new-message send is **blocked** so a second message can't stack on top of the one that triggered setup (edit-submit stays allowed).
- **Bubble restyle** so a short user prompt never reads as a text input.

## Testing

`bun run compile`, `bun run lint`, `react-doctor` clean; new/updated tests in `setup-card-rows.test.ts`, `chat-tile-session-state.test.ts`, `chat-tile-composer-rerender.test.tsx`, `chat-tile.test.tsx`, `chat-message-user-body.test.tsx`. Full `epic-canvas` + `chat` + `chats` suites pass.

> Pairs with the host-side abort-aware setup gate in the internal repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)