### PR TITLE
fix(protocol): tolerate absent wakeTriggers when decoding raw stored blocks

### DIFF
--- a/protocol/src/persistence/epic/__tests__/content-blocks.test.ts
+++ b/protocol/src/persistence/epic/__tests__/content-blocks.test.ts
@@ -268,6 +268,32 @@ describe("autonomousResumeBlockSchema wakeup persistence compat", () => {
     timestamp: 1,
   };
 
+  it("decodes a raw pre-wakeTriggers stored block (v1.1.3 data, NO schema parse) without throwing", () => {
+    // The host's storage hot path (`decodeStoredBlock` in
+    // `chat-message-collections.ts`) calls this function on raw Yjs JSON
+    // WITHOUT a schema parse, so `.default([])` never runs: every
+    // autonomous_resume block written before the wakeTriggers key existed
+    // lacks it entirely. Regression: this exact shape crashed every chat
+    // open with "Cannot read properties of undefined (reading 'length')".
+    const rawV113Stored = {
+      ...baseFields,
+      triggers: [
+        {
+          kind: "command" as const,
+          title: "cmd",
+          status: "completed" as const,
+          summary: "ran",
+          blockId: "",
+          outputFile: null,
+        },
+      ],
+      wakeTriggers: undefined,
+    };
+    const decoded = decodeAutonomousResumeBlock(rawV113Stored);
+    expect(decoded.triggers.map((t) => t.kind)).toEqual(["command"]);
+    expect("wakeTriggers" in decoded).toBe(false);
+  });
+
   it("parses a legacy pre-fix block with kind:'wakeup' inline in triggers (rc/dev data)", () => {
     const legacy = {
       ...baseFields,

--- a/protocol/src/persistence/epic/content-blocks.ts
+++ b/protocol/src/persistence/epic/content-blocks.ts
@@ -505,17 +505,30 @@ export type AutonomousResumeBlock = z.infer<
   typeof domainAutonomousResumeBlockSchema
 >;
 
+// The raw stored shape of an `autonomous_resume` block as read straight off a
+// Yjs doc, BEFORE any schema parse: every block written before the
+// `wakeTriggers` key existed (v1.1.3 and every earlier build) simply lacks it,
+// and the storage hot path (`decodeStoredBlock` in
+// `chat-message-collections.ts`) deliberately skips the schema parse that
+// would default it. Any function consuming stored blocks must be total over
+// this shape - `.default([])` only exists after a parse.
+export type RawStoredAutonomousResumeBlock = Omit<
+  PersistedAutonomousResumeBlock,
+  "wakeTriggers"
+> & { wakeTriggers: AutonomousResumeWakeTrigger[] | undefined };
+
 // Merges `wakeTriggers` into `triggers` (wakeup entries last, matching
 // construction order in `buildAutonomousResumeBlock`) and accepts legacy
 // stored `kind: "wakeup"` entries already inline in `triggers` unchanged.
-// Idempotent: decoding an already-domain-shaped block (no `wakeTriggers`) is a
-// no-op, since a re-parse through `persistedAutonomousResumeBlockSchema`
-// defaults the missing key to `[]`.
+// Total over every shape ever persisted: a pre-`wakeTriggers` block (absent
+// key) and an already-domain-shaped block are both returned unchanged - the
+// function itself tolerates the missing key rather than relying on a schema
+// parse the raw storage path never runs.
 export function decodeAutonomousResumeBlock(
-  stored: PersistedAutonomousResumeBlock,
+  stored: RawStoredAutonomousResumeBlock,
 ): AutonomousResumeBlock {
   const { wakeTriggers, ...rest } = stored;
-  if (wakeTriggers.length === 0) return rest;
+  if (wakeTriggers === undefined || wakeTriggers.length === 0) return rest;
   return {
     ...rest,
     triggers: [


### PR DESCRIPTION
## Summary

Fast-follow to #205 — fixes a crash shipped in the latest internal rc that makes **every chat containing any `autonomous_resume` block written by an older build fail to open** (`CHAT_OPEN_FAILED: Cannot read properties of undefined (reading 'length')`).

- **Root cause**: `decodeAutonomousResumeBlock`'s input type promised `wakeTriggers` is always an array, but that's only true after a zod parse applies `.default([])`. The host's storage hot path (`decodeStoredBlock` in `chat-message-collections.ts`) deliberately calls it on **raw Yjs JSON with no schema parse**, and every block persisted before the key existed (v1.1.3 and all earlier builds) simply lacks it. One function, two callers, two contracts — and the storage boundary's type assertion hid it from the compiler.
- **Fix**: make the decoder total over every shape ever persisted — input typed as the raw stored shape (`wakeTriggers: T[] | undefined`), missing key returns the block unchanged. No behavior change for post-fix data.
- Blast radius of the bug was wider than the enum bug #205 fixed: it hit blocks with plain command/monitor/subagent triggers too, not just wakeup ones.

## Test plan
- [x] New regression test calls the decoder directly on the raw v1.1.3 shape (no schema parse) — fails with the exact production error against the pre-fix code, passes with the fix
- [x] Companion host-side test (internal repo) replays a byte-genuine key-absent stored block through `denormalizeMessages`: confirmed it reproduces the production crash against unfixed protocol (1 failed/17 passed) and passes with this fix (18/18)
- [x] Full `@traycer/protocol` suite: 518/518 passing; compile clean