### PR TITLE
Enable artifact child drag sources

### DIFF
--- a/clients/gui-app/src/components/chat/segments/artifact-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/artifact-card-segment.tsx
@@ -18,7 +18,7 @@ import { artifactOperationVerb } from "@/lib/chat/artifact-operation-verb";
 import { cn } from "@/lib/utils";
 import type { ArtifactSegmentChange } from "@/stores/composer/chat-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
-import { useChatArtifactDragSource } from "@/components/epic-canvas/dnd/use-chat-artifact-drag-source";
+import { useArtifactDragSource } from "@/components/epic-canvas/dnd/use-artifact-drag-source";
 import { OpenFullDiffControl } from "./open-full-diff-control";
 import { SnapshotHashInlineDiff } from "./snapshot-hash-inline-diff";
 
@@ -517,8 +517,9 @@ function ArtifactCardSegmentContent(props: ArtifactCardSegmentProps) {
     setNodeRef: dragRef,
     listeners: dragListeners,
     isDragging,
-  } = useChatArtifactDragSource({
+  } = useArtifactDragSource({
     epicId,
+    viewTabId: undefined,
     identity:
       activeHostId === null
         ? null

--- a/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-provider.tsx
+++ b/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-provider.tsx
@@ -80,10 +80,10 @@ import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect, useRef, type ReactNode } from "react";
 
 /**
- * A chat-artifact card is the full width of the chat column, so dnd-kit's
- * default overlay anchoring (chip top-left pinned to the dragged node's
- * top-left) leaves the chip far from the pointer when the row is grabbed
- * anywhere but its top-left corner. Center the overlay chip on the cursor for
+ * The artifact-reference drag source can come from wide in-content rows/cards,
+ * so dnd-kit's default overlay anchoring (chip top-left pinned to the dragged
+ * node's top-left) can leave the chip far from the pointer when the row is
+ * grabbed away from its leading edge. Center the overlay chip on the cursor for
  * THIS source only - every other source (sidebar rows, tabs, tiles, rail items)
  * keeps its grab-anchored overlay. Reuses dnd-kit's official
  * `snapCenterToCursor`; the wrapper only gates which source it runs for.

--- a/clients/gui-app/src/components/epic-canvas/dnd/use-artifact-drag-source.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/use-artifact-drag-source.ts
@@ -16,11 +16,11 @@ import {
 } from "@/components/epic-canvas/dnd/dnd";
 
 /**
- * Artifact identity a chat drag source carries. Identity ONLY - no
+ * Artifact identity a drag source carries. Identity ONLY - no
  * `instanceId` (minted per drop at commit time, constraint C2). `null` when the
  * caller has no draggable identity to offer.
  */
-export interface ChatArtifactDragIdentity {
+export interface ArtifactDragIdentity {
   readonly id: string;
   readonly type: EpicArtifactKind;
   readonly name: string;
@@ -28,27 +28,27 @@ export interface ChatArtifactDragIdentity {
 }
 
 /**
- * Shared `chat-artifact` drag-source wiring for both in-chat drag surfaces - the
- * assistant block card (`artifact-card-segment`) and the inline reference chip
- * (`traycer-reference-chip`). Owns the common core: the occurrence-unique drag
- * id, the pure `viewTabId` resolution, the stable identity->payload memo, and
- * the `useDraggable` registration. Each caller keeps its own eligibility gate
- * (`enabled`) and attaches the returned wiring to its own element - the card
- * attaches `setNodeRef` + `listeners` to its whole header row (no
- * `attributes`); the chip additionally spreads `attributes`.
+ * Shared artifact drag-source wiring for artifact references rendered outside
+ * the sidebar tree - chat artifact cards, inline reference chips, and artifact
+ * child-index rows. Owns the common core: the occurrence-unique drag id, the
+ * pure `viewTabId` resolution, the stable identity->payload memo, and the
+ * `useDraggable` registration. Each caller keeps its own eligibility gate
+ * (`enabled`) and attaches the returned wiring to its own element.
  *
  * - C1: `viewTabId` comes from the NON-side-effecting `resolveTabIdForEpic` read
- *   reactively via a selector - never `resolveTargetTabForEpic`, which mutates
- *   tab state and must not run during render. A `null` result (no open tab for
- *   the epic) makes the source non-draggable.
+ *   reactively via a selector when the caller does not already have a tab id -
+ *   never `resolveTargetTabForEpic`, which mutates tab state and must not run
+ *   during render. A `null` result (no open tab for the epic) makes the source
+ *   non-draggable.
  * - C2: the payload carries identity only; the `instanceId` is minted per drop
  *   at commit time, so it is absent here.
  * - C3: the drag id keys on `useId()`, not the artifact id, because the same
  *   artifact can appear many times in one thread.
  */
-export function useChatArtifactDragSource(args: {
+export function useArtifactDragSource(args: {
   readonly epicId: string | undefined;
-  readonly identity: ChatArtifactDragIdentity | null;
+  readonly viewTabId: string | null | undefined;
+  readonly identity: ArtifactDragIdentity | null;
   readonly enabled: boolean;
 }): {
   readonly isDraggable: boolean;
@@ -57,15 +57,17 @@ export function useChatArtifactDragSource(args: {
   readonly attributes: DraggableAttributes;
   readonly isDragging: boolean;
 } {
-  const { epicId, identity, enabled } = args;
+  const { epicId, viewTabId: providedViewTabId, identity, enabled } = args;
   // C3 - occurrence-unique drag id.
   const occurrenceId = useId();
   // C1 - pure resolver read reactively via a selector; `null` => non-draggable.
-  const viewTabId = useEpicCanvasStore((state) =>
+  const resolvedViewTabId = useEpicCanvasStore((state) =>
     epicId === undefined || epicId.length === 0
       ? null
       : resolveTabIdForEpic(state, epicId),
   );
+  const viewTabId =
+    providedViewTabId === undefined ? resolvedViewTabId : providedViewTabId;
   // Depend the memo on the identity's PRIMITIVE fields, not the object: a caller
   // may hand a fresh identity object every render (e.g. a ref that mints a new
   // `instanceId`), and `useDraggable` must not see a new `data` reference each

--- a/clients/gui-app/src/components/epic-canvas/dnd/use-artifact-drag-source.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/use-artifact-drag-source.ts
@@ -62,7 +62,9 @@ export function useArtifactDragSource(args: {
   const occurrenceId = useId();
   // C1 - pure resolver read reactively via a selector; `null` => non-draggable.
   const resolvedViewTabId = useEpicCanvasStore((state) =>
-    epicId === undefined || epicId.length === 0
+    providedViewTabId !== undefined ||
+    epicId === undefined ||
+    epicId.length === 0
       ? null
       : resolveTabIdForEpic(state, epicId),
   );

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-child-index.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-child-index.test.tsx
@@ -27,6 +27,10 @@ const canvas = vi.hoisted(() => ({
   openTilePreviewInTab: vi.fn(),
 }));
 
+const resolveTabIdForEpic = vi.hoisted(() =>
+  vi.fn((_state: typeof canvas, _epicId: string) => "resolved-tab"),
+);
+
 const dnd = vi.hoisted(() => ({
   draggables: [] as CapturedDraggable[],
   setNodeRef: vi.fn(),
@@ -41,7 +45,7 @@ vi.mock("@/lib/epic-selectors", () => ({
 vi.mock("@/stores/epics/canvas/store", () => ({
   useEpicCanvasStore: (selector: (state: typeof canvas) => unknown) =>
     selector(canvas),
-  resolveTabIdForEpic: () => "resolved-tab",
+  resolveTabIdForEpic,
 }));
 
 vi.mock("@/stores/settings/settings-store", () => ({
@@ -93,6 +97,7 @@ describe("<ArtifactChildIndex />", () => {
     projection.childIdsByParent = {};
     projection.nodesById = {};
     canvas.openTilePreviewInTab.mockClear();
+    resolveTabIdForEpic.mockClear();
     dnd.draggables = [];
     dnd.setNodeRef.mockClear();
   });
@@ -132,6 +137,7 @@ describe("<ArtifactChildIndex />", () => {
         hostId: "host-1",
       },
     });
+    expect(resolveTabIdForEpic).not.toHaveBeenCalled();
 
     fireEvent.click(row);
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-child-index.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-child-index.test.tsx
@@ -1,0 +1,171 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ArtifactChildIndex } from "@/components/epic-canvas/renderers/artifact-child-index";
+import { readEpicCanvasDragSourceData } from "@/components/epic-canvas/dnd/dnd";
+
+type TestTreeNode = {
+  readonly type: string | null;
+  readonly title: string;
+  readonly status: number | null;
+};
+
+type CapturedDraggable = {
+  readonly id: string;
+  readonly disabled: boolean;
+  readonly data: unknown;
+};
+
+const projection = vi.hoisted<{
+  childIdsByParent: Record<string, readonly string[]>;
+  nodesById: Record<string, TestTreeNode>;
+}>(() => ({
+  childIdsByParent: {},
+  nodesById: {},
+}));
+
+const canvas = vi.hoisted(() => ({
+  openTilePreviewInTab: vi.fn(),
+}));
+
+const dnd = vi.hoisted(() => ({
+  draggables: [] as CapturedDraggable[],
+  setNodeRef: vi.fn(),
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useChildIdsOf: (parentId: string) =>
+    projection.childIdsByParent[parentId] ?? [],
+  useTreeNodeById: (nodeId: string) => projection.nodesById[nodeId] ?? null,
+}));
+
+vi.mock("@/stores/epics/canvas/store", () => ({
+  useEpicCanvasStore: (selector: (state: typeof canvas) => unknown) =>
+    selector(canvas),
+  resolveTabIdForEpic: () => "resolved-tab",
+}));
+
+vi.mock("@/stores/settings/settings-store", () => ({
+  useSettingsStore: (
+    selector: (state: {
+      artifactIconColorMode: "byType";
+      artifactIconColors: Record<string, string>;
+    }) => unknown,
+  ) =>
+    selector({
+      artifactIconColorMode: "byType",
+      artifactIconColors: {
+        spec: "#fbbf24",
+        ticket: "#a78bfa",
+        story: "#34d399",
+        review: "#fb7185",
+      },
+    }),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  appLogger: {
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@dnd-kit/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/core")>();
+  return {
+    ...actual,
+    useDraggable: (input: CapturedDraggable) => {
+      dnd.draggables.push({
+        id: input.id,
+        disabled: input.disabled,
+        data: input.data,
+      });
+      return {
+        attributes: { "data-dnd-attached": "true" },
+        listeners: {},
+        setNodeRef: dnd.setNodeRef,
+        isDragging: false,
+      };
+    },
+  };
+});
+
+describe("<ArtifactChildIndex />", () => {
+  beforeEach(() => {
+    projection.childIdsByParent = {};
+    projection.nodesById = {};
+    canvas.openTilePreviewInTab.mockClear();
+    dnd.draggables = [];
+    dnd.setNodeRef.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it("emits a draggable artifact payload while preserving click-to-preview", () => {
+    projection.childIdsByParent.parent = ["child-story"];
+    projection.nodesById["child-story"] = {
+      type: "story",
+      title: "Child Story",
+      status: null,
+    };
+
+    render(
+      <ArtifactChildIndex
+        epicId="epic-1"
+        parentId="parent"
+        viewTabId="view-tab-1"
+        hostId="host-1"
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: "Child Story" });
+    expect(row.getAttribute("data-dnd-attached")).toBe("true");
+    expect(dnd.draggables).toHaveLength(1);
+    expect(dnd.draggables[0].id).toMatch(/^chat-artifact:/);
+    expect(dnd.draggables[0].disabled).toBe(false);
+    expect(readEpicCanvasDragSourceData(dnd.draggables[0].data)).toEqual({
+      kind: "chat-artifact",
+      epicId: "epic-1",
+      viewTabId: "view-tab-1",
+      artifact: {
+        id: "child-story",
+        type: "story",
+        name: "Child Story",
+        hostId: "host-1",
+      },
+    });
+
+    fireEvent.click(row);
+
+    expect(canvas.openTilePreviewInTab).toHaveBeenCalledWith(
+      "view-tab-1",
+      expect.objectContaining({
+        id: "child-story",
+        type: "story",
+        name: "Child Story",
+        hostId: "host-1",
+      }),
+    );
+  });
+
+  it("does not render or enable drag for non-artifact child nodes", () => {
+    projection.childIdsByParent.parent = ["child-chat"];
+    projection.nodesById["child-chat"] = {
+      type: "chat",
+      title: "Child Chat",
+      status: null,
+    };
+
+    render(
+      <ArtifactChildIndex
+        epicId="epic-1"
+        parentId="parent"
+        viewTabId="view-tab-1"
+        hostId="host-1"
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Child Chat" })).toBeNull();
+    expect(dnd.draggables).toHaveLength(1);
+    expect(dnd.draggables[0].disabled).toBe(true);
+    expect(dnd.draggables[0].data).toBeUndefined();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/artifact-child-index.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/artifact-child-index.tsx
@@ -5,8 +5,13 @@ import {
   STATUS_DOT_CLASSES,
 } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 import {
+  useArtifactDragSource,
+  type ArtifactDragIdentity,
+} from "@/components/epic-canvas/dnd/use-artifact-drag-source";
+import {
   EPIC_NODE_ICONS,
   isEpicArtifactKind,
+  type EpicNodeKind,
 } from "@/lib/artifacts/node-display";
 import { useChildIdsOf, useTreeNodeById } from "@/lib/epic-selectors";
 import { cn } from "@/lib/utils";
@@ -19,9 +24,18 @@ import { useSettingsStore } from "@/stores/settings/settings-store";
 import { appLogger } from "@/lib/logger";
 
 interface ArtifactChildIndexProps {
+  readonly epicId: string;
   readonly parentId: string;
   readonly viewTabId: string;
   readonly hostId: string;
+}
+
+interface MakeArtifactDragIdentityArgs {
+  readonly childId: string;
+  readonly hostId: string;
+  readonly title: string;
+  readonly treeNodeExists: boolean;
+  readonly type: string | null;
 }
 
 /**
@@ -46,6 +60,7 @@ export function ArtifactChildIndex(props: ArtifactChildIndexProps) {
       {childIds.map((childId) => (
         <ChildIndexRow
           key={childId}
+          epicId={props.epicId}
           childId={childId}
           viewTabId={props.viewTabId}
           hostId={props.hostId}
@@ -56,11 +71,12 @@ export function ArtifactChildIndex(props: ArtifactChildIndexProps) {
 }
 
 function ChildIndexRow(props: {
+  readonly epicId: string;
   readonly childId: string;
   readonly viewTabId: string;
   readonly hostId: string;
 }) {
-  const { childId, viewTabId, hostId } = props;
+  const { epicId, childId, viewTabId, hostId } = props;
   const treeNode = useTreeNodeById(childId);
   const openTilePreviewInTab = useEpicCanvasStore(
     (s) => s.openTilePreviewInTab,
@@ -69,6 +85,26 @@ function ChildIndexRow(props: {
   const iconColors = useSettingsStore((s) => s.artifactIconColors);
   const type = treeNode?.type ?? null;
   const title = treeNode?.title ?? "";
+  const treeNodeExists = treeNode !== null;
+  const dragIdentity = makeArtifactDragIdentity({
+    childId,
+    hostId,
+    title,
+    treeNodeExists,
+    type,
+  });
+  const {
+    isDraggable,
+    setNodeRef: dragRef,
+    listeners: dragListeners,
+    attributes: dragAttributes,
+    isDragging,
+  } = useArtifactDragSource({
+    epicId,
+    viewTabId,
+    identity: dragIdentity,
+    enabled: dragIdentity !== null,
+  });
 
   const open = useCallback(() => {
     if (type === null || !isOpenableEpicNodeKind(type)) return;
@@ -87,18 +123,11 @@ function ChildIndexRow(props: {
   // Children of an artifact are themselves artifacts; the guard keeps the row
   // type-safe and quietly drops any non-artifact node that ever appears here.
   if (treeNode === null || type === null || !isEpicArtifactKind(type)) {
-    let reason = "missing tree node";
-    if (treeNode !== null && type === null) {
-      reason = "missing node type";
-    }
-    if (treeNode !== null && type !== null) {
-      reason = `non-artifact node type=${type}`;
-    }
     appLogger.warn("[artifact-child-index] skipping child row", {
       childId,
       viewTabId,
       hostId,
-      reason,
+      reason: getSkippedChildRowReason(treeNodeExists, type),
     });
     return null;
   }
@@ -106,25 +135,69 @@ function ChildIndexRow(props: {
   const Icon = EPIC_NODE_ICONS[type];
   const iconStyle =
     iconColorMode === "byType" ? { color: iconColors[type] } : undefined;
-  const showStatusDot = computeArtifactNodeStatusDot(type, treeNode.status);
 
   return (
     <button
+      ref={isDraggable ? dragRef : undefined}
+      {...(isDraggable ? dragAttributes : undefined)}
+      {...(isDraggable ? dragListeners : undefined)}
       type="button"
       onClick={open}
       data-testid={`artifact-child-index-row-${childId}`}
-      className="group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted/50"
+      className={cn(
+        "group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-muted/50",
+        isDraggable && "cursor-grab",
+        isDragging && "cursor-grabbing opacity-60",
+      )}
     >
       <Icon className="size-4 shrink-0" style={iconStyle} />
       <span className="min-w-0 flex-1 truncate">{title}</span>
-      {showStatusDot && treeNode.status !== null ? (
-        <span
-          className={cn(
-            "size-2 shrink-0 rounded-full",
-            STATUS_DOT_CLASSES[treeNode.status] ?? "bg-slate-400",
-          )}
-        />
-      ) : null}
+      <ArtifactStatusDot type={type} status={treeNode.status} />
     </button>
+  );
+}
+
+function makeArtifactDragIdentity(
+  args: MakeArtifactDragIdentityArgs,
+): ArtifactDragIdentity | null {
+  if (
+    !args.treeNodeExists ||
+    args.type === null ||
+    !isEpicArtifactKind(args.type) ||
+    args.title.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    id: args.childId,
+    type: args.type,
+    name: args.title,
+    hostId: args.hostId,
+  };
+}
+
+function getSkippedChildRowReason(
+  treeNodeExists: boolean,
+  type: string | null,
+): string {
+  if (!treeNodeExists) return "missing tree node";
+  if (type === null) return "missing node type";
+  return `non-artifact node type=${type}`;
+}
+
+function ArtifactStatusDot(props: {
+  readonly type: EpicNodeKind;
+  readonly status: number | null;
+}) {
+  const showStatusDot = computeArtifactNodeStatusDot(props.type, props.status);
+  if (!showStatusDot || props.status === null) return null;
+  return (
+    <span
+      className={cn(
+        "size-2 shrink-0 rounded-full",
+        STATUS_DOT_CLASSES[props.status] ?? "bg-slate-400",
+      )}
+    />
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/collab-tile-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/collab-tile-body.tsx
@@ -427,6 +427,7 @@ function CollabTileBodyEditor(props: CollabTileBodyEditorProps) {
         </div>
         {isEpicArtifactKind(node.type) ? (
           <ArtifactChildIndex
+            epicId={epicId}
             parentId={node.id}
             viewTabId={viewTabId}
             hostId={node.hostId}

--- a/clients/gui-app/src/markdown/__tests__/traycer-reference-components.test.tsx
+++ b/clients/gui-app/src/markdown/__tests__/traycer-reference-components.test.tsx
@@ -111,7 +111,7 @@ vi.mock("@/stores/epics/canvas/store", () => {
         selector(canvasState),
       { getState: () => canvasState },
     ),
-    // Standalone pure resolver: the shared `useChatArtifactDragSource` hook
+    // Standalone pure resolver: the shared `useArtifactDragSource` hook
     // reads `viewTabId` via `resolveTabIdForEpic(state, epicId)`. Delegate to the
     // same spy by `epicId` so the existing single-arg call assertion holds.
     resolveTabIdForEpic: (_state: typeof canvasState, epicId: string) =>

--- a/clients/gui-app/src/markdown/components/traycer-reference-chip.tsx
+++ b/clients/gui-app/src/markdown/components/traycer-reference-chip.tsx
@@ -4,9 +4,9 @@ import type {
 } from "@dnd-kit/core";
 import { type MouseEvent, type ReactNode } from "react";
 import {
-  useChatArtifactDragSource,
-  type ChatArtifactDragIdentity,
-} from "@/components/epic-canvas/dnd/use-chat-artifact-drag-source";
+  useArtifactDragSource,
+  type ArtifactDragIdentity,
+} from "@/components/epic-canvas/dnd/use-artifact-drag-source";
 import type { EpicNodeRef } from "@/stores/epics/canvas/types";
 import { isEpicArtifactKind } from "@/lib/artifacts/node-display";
 import { cn } from "@/lib/utils";
@@ -79,7 +79,7 @@ function isChatArtifactDragCandidate(
 /**
  * The drag-capable variant, mounted only for same-epic spec/ticket references.
  * Delegates the canvas-store subscription (`viewTabId`) and the `useDraggable`
- * registration to the shared `useChatArtifactDragSource` hook; a non-draggable
+ * registration to the shared `useArtifactDragSource` hook; a non-draggable
  * result (e.g. no open tab for the epic) still renders the same button but
  * disables the drag surface.
  */
@@ -94,7 +94,7 @@ function DraggableReferenceChip(
   // not an artifact kind, which disables the drag surface. This component only
   // mounts for spec/ticket candidates (see `isChatArtifactDragCandidate`), so
   // the shared hook's own gate is `enabled: true`.
-  const identity: ChatArtifactDragIdentity | null =
+  const identity: ArtifactDragIdentity | null =
     sameEpicNodeRef === null || !isEpicArtifactKind(sameEpicNodeRef.type)
       ? null
       : {
@@ -104,7 +104,12 @@ function DraggableReferenceChip(
           hostId: sameEpicNodeRef.hostId,
         };
   const { isDraggable, setNodeRef, listeners, attributes, isDragging } =
-    useChatArtifactDragSource({ epicId, identity, enabled: true });
+    useArtifactDragSource({
+      epicId,
+      viewTabId: undefined,
+      identity,
+      enabled: true,
+    });
 
   return (
     <ReferenceChipButton


### PR DESCRIPTION
## Summary
- Generalize chat artifact drag source handling for artifact references and child index rows
- Add drag payload support to artifact child index rows while preserving click-to-preview behavior
- Cover child index drag payload behavior with a focused test

## Validation
- pre-commit run --all-files
- bun run compile
- bun run lint
- bun run test -- src/components/epic-canvas/renderers/__tests__/artifact-child-index.test.tsx

## Notes
- DCO signed-off commit: 9ea8699