### PR TITLE
Degrade unsupported resource streams for host compatibility

### DIFF
--- a/clients/gui-app/src/lib/host/stream-runtime-context.ts
+++ b/clients/gui-app/src/lib/host/stream-runtime-context.ts
@@ -1,5 +1,8 @@
-import { createContext, use } from "react";
-import type { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
+import { createContext, use, useCallback, useSyncExternalStore } from "react";
+import type {
+  StreamMethodSupport,
+  WsStreamClient,
+} from "@traycer-clients/shared/host-transport/ws-stream-client";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 
 /**
@@ -20,4 +23,27 @@ export const StreamRuntimeContext = createContext<StreamRuntimeBinding | null>(
 export function useWsStreamClient(): WsStreamClient<HostStreamRpcRegistry> | null {
   const value = use(StreamRuntimeContext);
   return value === null ? null : value.wsStreamClient;
+}
+
+export function useStreamMethodSupport(
+  method: keyof HostStreamRpcRegistry & string,
+): StreamMethodSupport | null {
+  const value = use(StreamRuntimeContext);
+  const client = value?.wsStreamClient ?? null;
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      if (client === null) {
+        return () => undefined;
+      }
+      return client.subscribeMethodSupport(callback);
+    },
+    [client],
+  );
+  const getSnapshot = useCallback(() => {
+    if (client === null) {
+      return null;
+    }
+    return client.getMethodSupport(method);
+  }, [client, method]);
+  return useSyncExternalStore(subscribe, getSnapshot, () => null);
 }

--- a/clients/gui-app/src/providers/resources-stream-mount.tsx
+++ b/clients/gui-app/src/providers/resources-stream-mount.tsx
@@ -1,6 +1,9 @@
 import { useEffect, type ReactNode } from "react";
 import { ResourcesStreamClient } from "@traycer-clients/shared/host-transport/resources-stream-client";
-import { useWsStreamClient } from "@/lib/host/stream-runtime-context";
+import {
+  useStreamMethodSupport,
+  useWsStreamClient,
+} from "@/lib/host/stream-runtime-context";
 import { resourcesRegistry } from "@/stores/resources/resources-registry";
 import {
   createResourcesStore,
@@ -27,8 +30,11 @@ export function ResourcesStreamMount(
 ): ReactNode {
   const { epicId } = props;
   const wsStreamClient = useWsStreamClient();
+  const resourcesSupport = useStreamMethodSupport("resources.subscribe");
+  const resourcesUnsupported = resourcesSupport === "unsupported";
 
   useEffect(() => {
+    if (resourcesUnsupported) return;
     const override = getResourcesStreamClientFactoryOverride();
     if (override === null && wsStreamClient === null) return;
     // Token identifies the transport this entry is bound to; a host swap changes
@@ -55,7 +61,7 @@ export function ResourcesStreamMount(
     return () => {
       resourcesRegistry.release(epicId);
     };
-  }, [epicId, wsStreamClient]);
+  }, [epicId, resourcesUnsupported, wsStreamClient]);
 
   return null;
 }

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -785,6 +785,73 @@ describe("WsStreamClient", () => {
     expect(observedCode).toBe("INCOMPATIBLE");
   });
 
+  it("remembers stream method support after a successful subscribe", async () => {
+    const { factory, sockets } = makeFactory();
+    const client = makeClient({
+      factory,
+      authToken: "t",
+      pingIntervalMs: 25_000,
+      pongTimeoutMs: 50_000,
+      initialBackoffMs: 10,
+      maxBackoffMs: 1_000,
+    });
+    const observed: string[] = [];
+    const unsubscribe = client.subscribeMethodSupport(() => {
+      observed.push(client.getMethodSupport("resources.subscribe"));
+    });
+
+    const session = client.subscribe("resources.subscribe", {
+      epicId: "epic-1",
+    });
+
+    await flush();
+    completeHandshake(sockets[0].socket);
+
+    expect(client.getMethodSupport("resources.subscribe")).toBe("supported");
+    expect(observed).toEqual(["supported"]);
+
+    unsubscribe();
+    session.close();
+  });
+
+  it("remembers a missing stream method as unsupported for newer-client older-host pairs", async () => {
+    const { factory, sockets } = makeFactory();
+    const client = makeClient({
+      factory,
+      authToken: "t",
+      pingIntervalMs: 25_000,
+      pongTimeoutMs: 50_000,
+      initialBackoffMs: 10,
+      maxBackoffMs: 1_000,
+    });
+    const observed: string[] = [];
+    const unsubscribe = client.subscribeMethodSupport(() => {
+      observed.push(client.getMethodSupport("resources.subscribe"));
+    });
+
+    const session = client.subscribe("resources.subscribe", {
+      epicId: "epic-1",
+    });
+
+    await flush();
+    const stub = sockets[0].socket;
+    stub.fireOpen();
+    stub.fireText({
+      kind: "openAck",
+      manifest: {
+        "epic.subscribe": { major: 1, minor: 0 },
+        "chat.subscribe": { major: 1, minor: 2 },
+        "terminal.subscribe": { major: 1, minor: 3 },
+      },
+    });
+
+    expect(client.getMethodSupport("resources.subscribe")).toBe("unsupported");
+    expect(observed).toEqual(["unsupported"]);
+
+    unsubscribe();
+    session.close();
+  });
+
   it("closes the socket after two missed pongs and triggers a reconnect", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: false });
 

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -115,6 +115,8 @@ const INERT_STREAM_SESSION: IStreamSession = {
 export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
   private readonly options: WsStreamClientOptions<Registry>;
   private readonly ownedSessions = new Set<StreamSession<Registry>>();
+  private readonly methodSupport = new Map<string, StreamMethodSupport>();
+  private readonly methodSupportListeners = new Set<() => void>();
   private closed = false;
 
   constructor(options: WsStreamClientOptions<Registry>) {
@@ -163,6 +165,9 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
       initialBackoffMs: this.options.initialBackoffMs,
       maxBackoffMs: this.options.maxBackoffMs,
       onDispose: () => removeSession(),
+      onMethodSupport: (nextMethod, support) => {
+        this.setMethodSupport(nextMethod, support);
+      },
     });
     removeSession = () => {
       this.ownedSessions.delete(session);
@@ -190,6 +195,19 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
    */
   isClosed(): boolean {
     return this.closed;
+  }
+
+  getMethodSupport<Method extends keyof Registry & string>(
+    method: Method,
+  ): StreamMethodSupport {
+    return this.methodSupport.get(method) ?? "unknown";
+  }
+
+  subscribeMethodSupport(listener: () => void): () => void {
+    this.methodSupportListeners.add(listener);
+    return () => {
+      this.methodSupportListeners.delete(listener);
+    };
   }
 
   /**
@@ -231,6 +249,17 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
       session.forceReconnect(reason);
     }
   }
+
+  private setMethodSupport(method: string, support: StreamMethodSupport): void {
+    const previous = this.methodSupport.get(method) ?? "unknown";
+    if (previous === support) {
+      return;
+    }
+    this.methodSupport.set(method, support);
+    for (const listener of Array.from(this.methodSupportListeners)) {
+      listener();
+    }
+  }
 }
 
 /**
@@ -241,6 +270,8 @@ export type ParamsOf<
   Registry extends VersionedStreamRpcRegistry,
   Method extends keyof Registry & string,
 > = ExtractOpenRequest<Registry[Method]>;
+
+export type StreamMethodSupport = "unknown" | "supported" | "unsupported";
 
 type ExtractOpenRequest<MethodRegistry> =
   MethodRegistry extends Readonly<Record<number, infer Line>>
@@ -274,6 +305,10 @@ interface StreamSessionOptions<Registry extends VersionedStreamRpcRegistry> {
   readonly initialBackoffMs: number;
   readonly maxBackoffMs: number;
   readonly onDispose: () => void;
+  readonly onMethodSupport: (
+    method: keyof Registry & string,
+    support: StreamMethodSupport,
+  ) => void;
 }
 
 /**
@@ -696,6 +731,7 @@ class StreamSession<
     }
 
     if (!compat.ok) {
+      this.config.onMethodSupport(this.config.method, "unsupported");
       const terminalFrame: ClientStreamFatalErrorFrame = {
         kind: "fatalError",
         details: compat.details,
@@ -730,6 +766,7 @@ class StreamSession<
       this.onSendFailure(socket);
       return;
     }
+    this.config.onMethodSupport(this.config.method, "supported");
     this.phase = "subscribed";
     this.reconnectAttempt = 0;
     this.noProgressUnauthorizedReconnects = 0;


### PR DESCRIPTION
## Summary
- `WsStreamClient` now remembers per-method stream support learned from the negotiated `openAck`: a successful subscribe marks a method supported, a mirror-incompatible handshake marks it unsupported.
- `ResourcesStreamMount` consults that cache and stops reacquiring `resources.subscribe` once the connected host has proven it does not support the method, so a newer GUI against an older host degrades the resource UI quietly instead of repeatedly opening doomed streams.

## Test plan
- [x] `bun test clients/shared/host-transport/__tests__/ws-stream-client.test.ts clients/shared/host-transport/__tests__/resources-stream-client.test.ts --runInBand`
- [x] `bun run --cwd clients/gui-app test src/components/resources/__tests__/resource-usage-chip.test.tsx src/lib/host/__tests__/stream-runtime.test.tsx`
- [x] `bun run compile`
- [x] `react-doctor --scope changed --base origin/main`
- [x] Manually verified against an old-host/new-UI compatibility setup: UI does not crash/retry, other streams keep working, resource UI stays absent.