### PR TITLE
Backport July 5 recovery fixes

### DIFF
--- a/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
+++ b/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
@@ -13,8 +13,11 @@ import { useTabProvidersList } from "@/hooks/providers/use-tab-providers-list-qu
 // `traycer`, which has no provider-CLI login). Only CLI harnesses gate. Grok,
 // Qwen, Kiro, Kimi, Droid, Copilot, and Kilo Code are GUI-only (not in the TUI map)
 // but DO gate through their CLI login providers, mirroring the host's
-// `harnessIdToProviderId`.
-function providerIdForHarness(harnessId: GuiHarnessId): ProviderId | null {
+// `harnessIdToProviderId`. Exported so other harness->provider derivations
+// (e.g. the chat provider rate-limit selector) share this single mapping.
+export function providerIdForHarness(
+  harnessId: GuiHarnessId,
+): ProviderId | null {
   if (harnessId === "traycer") return null;
   if (harnessId === "openrouter") return "openrouter";
   if (harnessId === "grok") return "grok";

--- a/clients/gui-app/src/components/chat/context-usage-chip.tsx
+++ b/clients/gui-app/src/components/chat/context-usage-chip.tsx
@@ -18,6 +18,7 @@ import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import {
   buildContextUsageRows,
   computeEffectiveContextUsage,
+  contextUsageTone,
   formatContextWindowTokens,
   formatContextUsageRowValue,
   type ContextUsageRow,
@@ -367,12 +368,6 @@ function AnimatedPinnedInteger({
       {roundedValue}
     </m.span>
   );
-}
-
-function contextUsageTone(percent: number): string {
-  if (percent <= 10) return "text-destructive";
-  if (percent <= 25) return "text-amber-500 dark:text-amber-400";
-  return "text-muted-foreground";
 }
 
 function contextUsageMeterStyle(percent: number): ContextUsageMeterStyle {

--- a/clients/gui-app/src/components/chat/context-usage.ts
+++ b/clients/gui-app/src/components/chat/context-usage.ts
@@ -128,3 +128,17 @@ export function formatContextWindowTokens(value: number): string {
   }
   return `${Math.round(value / 1_000_000).toLocaleString()}M`;
 }
+
+/**
+ * Shared "how much headroom is left" tone scale: `percent` is a LEFT/
+ * remaining percentage (0 = exhausted), not a used percentage - low
+ * remaining reads as destructive/amber. Reused by the context-window chip
+ * and the provider rate-limit views, which invert their native
+ * `usedPercent` (`100 - usedPercent`) before calling this so both surfaces
+ * share one polarity and one set of thresholds.
+ */
+export function contextUsageTone(percent: number): string {
+  if (percent <= 10) return "text-destructive";
+  if (percent <= 25) return "text-amber-500 dark:text-amber-400";
+  return "text-muted-foreground";
+}

--- a/clients/gui-app/src/components/layout/__tests__/app-shell-lifecycle-bridges.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-shell-lifecycle-bridges.test.tsx
@@ -52,6 +52,10 @@ vi.mock("@/components/notifications/notifications-bell", () => ({
   NotificationsBell: () => <div data-testid="notifications-bell" />,
 }));
 
+vi.mock("@/components/layout/header/rate-limit-icon", () => ({
+  RateLimitIconButton: () => <div data-testid="rate-limit-header-button" />,
+}));
+
 vi.mock("@/components/auth/user-menu", () => ({
   UserMenu: () => <div data-testid="user-menu" />,
 }));

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
@@ -67,6 +67,10 @@ vi.mock("@/components/notifications/notifications-bell", () => ({
   NotificationsBell: () => null,
 }));
 
+vi.mock("@/components/layout/header/rate-limit-icon", () => ({
+  RateLimitIconButton: () => null,
+}));
+
 vi.mock("@/components/auth/user-menu", () => ({
   UserMenu: () => <div data-testid="user-menu" />,
 }));

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
@@ -1,0 +1,143 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { HeaderRateLimitBar } from "@/hooks/rate-limits/use-header-rate-limit-bars";
+
+let bars: ReadonlyArray<HeaderRateLimitBar> = [];
+
+vi.mock("@/hooks/rate-limits/use-header-rate-limit-bars", () => ({
+  useHeaderRateLimitBars: () => bars,
+}));
+
+import { RateLimitIconButton } from "@/components/layout/header/rate-limit-icon";
+
+function renderIcon() {
+  return render(
+    <TooltipProvider>
+      <RateLimitIconButton />
+    </TooltipProvider>,
+  );
+}
+
+// Exact class-token membership, not substring containment - the button's base
+// variant classes always carry `disabled:opacity-50`, which would otherwise
+// false-positive a substring check for the bare `opacity-50` utility.
+function hasClass(element: Element, className: string): boolean {
+  return element.className.split(/\s+/).includes(className);
+}
+
+afterEach(() => {
+  cleanup();
+  bars = [];
+});
+
+describe("<RateLimitIconButton />", () => {
+  it("renders a clickable icon button with an accessible name, even with no bars", () => {
+    renderIcon();
+    const button = screen.getByRole("button", { name: "Usage limits" });
+    expect(button).toBeTruthy();
+  });
+
+  it("renders zero providers configured as a muted, pre-filled placeholder glyph", () => {
+    bars = [];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    expect(hasClass(button, "opacity-50")).toBe(true);
+    expect(hasClass(button, "opacity-[0.55]")).toBe(false);
+    const tracks = within(button).getAllByTestId("rate-limit-bar-track");
+    expect(tracks).toHaveLength(2);
+    const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(fills).toHaveLength(2);
+    expect(fills[0].style.width).toBe("75%");
+    expect(fills[1].style.width).toBe("60%");
+    for (const fill of fills) {
+      expect(hasClass(fill, "bg-muted-foreground")).toBe(true);
+    }
+  });
+
+  it("renders one bar per configured provider (Codex + Claude Code)", () => {
+    bars = [
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 70,
+        severity: "yellow",
+        degraded: false,
+      },
+      {
+        providerId: "claude-code",
+        windowLabel: "5h",
+        usedPercent: 40,
+        severity: "blue",
+        degraded: false,
+      },
+    ];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    expect(hasClass(button, "opacity-50")).toBe(false);
+    expect(hasClass(button, "opacity-[0.55]")).toBe(false);
+    const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(fills).toHaveLength(2);
+    expect(fills[0].className).toContain("yellow-500");
+    expect(fills[0].style.width).toBe("70%");
+    expect(fills[1].className).toContain("blue-500");
+    expect(fills[1].style.width).toBe("40%");
+  });
+
+  it("renders both of a single provider's windows without a key collision", () => {
+    // Single-provider case: both bars share a providerId and are disambiguated
+    // by windowLabel in the React key - both must still render.
+    bars = [
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 92,
+        severity: "red",
+        degraded: false,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "Weekly",
+        usedPercent: 20,
+        severity: "blue",
+        degraded: false,
+      },
+    ];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(fills).toHaveLength(2);
+    expect(fills[0].className).toContain("red-500");
+    expect(fills[0].style.width).toBe("92%");
+    expect(fills[1].className).toContain("blue-500");
+    expect(fills[1].style.width).toBe("20%");
+  });
+
+  it("dims the whole glyph when a contributing bar's last poll failed (degraded)", () => {
+    bars = [
+      {
+        providerId: "claude-code",
+        windowLabel: "5h",
+        usedPercent: 65,
+        severity: "yellow",
+        degraded: true,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 30,
+        severity: "blue",
+        degraded: false,
+      },
+    ];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    expect(hasClass(button, "opacity-[0.55]")).toBe(true);
+    expect(hasClass(button, "opacity-50")).toBe(false);
+    // Degraded dims the whole icon container, not the individual bar - both
+    // bars keep their own severity fill.
+    const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(fills).toHaveLength(2);
+  });
+});

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -1,0 +1,955 @@
+import "../../../../../__tests__/test-browser-apis";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ProviderRateLimits } from "@traycer/protocol/host";
+import type { AuthenticatedUser } from "@traycer/protocol/auth";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { Popover, PopoverTrigger } from "@/components/ui/popover";
+import { useAccountContextStore } from "@/stores/auth/account-context-store";
+
+type QueryResult = {
+  data: { providerRateLimits: ProviderRateLimits | null } | undefined;
+  isPending: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  dataUpdatedAt: number;
+  refetch: () => Promise<unknown>;
+};
+
+type MockAuthUser = {
+  data: AuthenticatedUser | null;
+  isPending: boolean;
+  isError: boolean;
+  isFetching: boolean;
+  dataUpdatedAt: number;
+  refetch: Mock<(...args: unknown[]) => Promise<unknown>>;
+};
+
+type MockState = {
+  configured: ReadonlyArray<{ providerId: string; lane: string }>;
+  results: Record<string, QueryResult>;
+  draining: boolean;
+  openSettings: Mock<(...args: unknown[]) => void>;
+  enqueue: Mock<(...args: unknown[]) => Promise<void>>;
+  authUser: MockAuthUser;
+  // Last `options` object `RateLimitRefreshAllButton` passed to
+  // `useHostQueries`, so a test can assert it reused the real lane options
+  // (e.g. `retry: false`) instead of dropping them.
+  lastUseHostQueriesOptions: { retry: boolean | undefined } | null;
+  // Provider ids of the last `requests` batch passed to `useHostQueries`, so
+  // a test can assert the button subscribes to EVERY configured httpFetch
+  // provider's query state, not just the first.
+  lastUseHostQueriesProviderIds: ReadonlyArray<string> | null;
+};
+
+function coldAuthUser(): MockAuthUser {
+  return {
+    data: null,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    dataUpdatedAt: 0,
+    refetch: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+const mocks = vi.hoisted<MockState>(() => ({
+  configured: [],
+  results: {},
+  draining: false,
+  openSettings: vi.fn(),
+  enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  lastUseHostQueriesOptions: null,
+  lastUseHostQueriesProviderIds: null,
+  authUser: {
+    data: null,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    dataUpdatedAt: 0,
+    refetch: vi.fn(() => Promise.resolve({})),
+  },
+}));
+
+vi.mock("@/hooks/rate-limits/use-configured-rate-limit-providers", () => ({
+  useConfiguredRateLimitProviders: () => mocks.configured,
+}));
+vi.mock("@/hooks/rate-limits/use-is-rate-limit-queue-draining", () => ({
+  useIsRateLimitQueueDraining: () => mocks.draining,
+}));
+vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
+  useHostProviderRateLimitsQuery: (providerId: string) =>
+    mocks.results[providerId] ?? readyResult(null),
+}));
+// `RateLimitRefreshAllButton` reads each configured httpFetch provider's
+// query state directly (to fold its `isFetching` into the button's own
+// spinner) via the same fixture map every other mocked query hook here uses.
+vi.mock("@/hooks/host/use-host-queries", () => ({
+  useHostQueries: (args: {
+    requests: ReadonlyArray<{ params: { providerId: string } }>;
+    options: { retry: boolean | undefined } | null;
+  }) => {
+    mocks.lastUseHostQueriesOptions = args.options;
+    mocks.lastUseHostQueriesProviderIds = args.requests.map(
+      (request) => request.params.providerId,
+    );
+    return args.requests.map(
+      (request) =>
+        mocks.results[request.params.providerId] ?? readyResult(null),
+    );
+  },
+}));
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return { ...actual, useHostClient: () => null };
+});
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-1",
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  // Wrapper (not `mocks.enqueue` directly) so `beforeEach` can swap the spy -
+  // an object-literal binding would freeze the original fn at module load.
+  enqueueRateLimitFetch: (...args: unknown[]) => mocks.enqueue(...args),
+}));
+vi.mock("@/stores/tabs/use-system-tab-modal", () => ({
+  useSystemTabModalActions: () => ({ openSettings: mocks.openSettings }),
+}));
+// The Traycer tab reads the signed-in user's subscription (AuthService), not a
+// host RPC. Default is a signed-out/cold user -> no Traycer tab, so the
+// host-RPC-provider tests below behave exactly as before.
+vi.mock("@/hooks/auth/use-auth-user-query", () => ({
+  useAuthUser: () => mocks.authUser,
+}));
+// The aperture usage query + its turn-refresh only mount inside the shared
+// RateLimitView (rate-limit-based Traycer plans). Stub them so no real host
+// query fires; the Traycer tests below use a credit-based plan anyway.
+vi.mock("@/hooks/host/use-host-rate-limit-usage-query", () => ({
+  useHostRateLimitUsageQuery: () => ({ data: undefined }),
+}));
+vi.mock("@/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn", () => ({
+  useRefreshRateLimitUsageOnTraycerTurn: () => {},
+}));
+
+import { RateLimitPopover } from "@/components/layout/header/rate-limit-popover";
+
+const NOW = Date.now();
+
+function readyResult(
+  providerRateLimits: ProviderRateLimits | null,
+): QueryResult {
+  return {
+    data: { providerRateLimits },
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    dataUpdatedAt: NOW - 90_000,
+    refetch: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+function claudeReady(): ProviderRateLimits {
+  return {
+    provider: "claude-code",
+    available: true,
+    subscriptionType: "max",
+    fiveHour: {
+      usedPercent: 22,
+      resetsAt: NOW + 60 * 60 * 1000,
+      durationMinutes: 300,
+    },
+    sevenDay: null,
+    sevenDayOpus: null,
+    sevenDaySonnet: null,
+    modelScoped: [],
+    extraUsage: null,
+  };
+}
+
+function codexReady(): ProviderRateLimits {
+  return {
+    provider: "codex",
+    available: true,
+    planType: "pro_5x",
+    limitId: null,
+    limitName: null,
+    primary: {
+      usedPercent: 4,
+      resetsAt: NOW + 60 * 60 * 1000,
+      durationMinutes: 300,
+    },
+    secondary: null,
+    extraWindows: [],
+    credits: null,
+    individualLimit: null,
+    resetCredits: null,
+    rateLimitReachedType: null,
+  };
+}
+
+const EPOCH = new Date(0);
+
+function baseSubscription() {
+  return {
+    id: "sub",
+    userID: "u1",
+    orgID: null,
+    teamID: null,
+    customerId: "cus",
+    createdAt: EPOCH,
+    updatedAt: EPOCH,
+    subscriptionExpiry: null,
+    trialEndsAt: null,
+    hasPaymentMethod: true,
+    rechargeRateSeconds: 60,
+  };
+}
+
+function authUserFixture(overrides: {
+  status: "PRO_V3" | "FREE";
+  withTeam: boolean;
+}): AuthenticatedUser {
+  return {
+    user: {
+      id: "u1",
+      name: "Ada",
+      providerId: "p1",
+      providerHandle: "ada",
+      providerType: "GITHUB",
+      email: "ada@example.com",
+      avatarUrl: null,
+      activatedAt: EPOCH,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+      lastSeenAt: EPOCH,
+      privacyMode: false,
+      isLearningEnabled: true,
+    },
+    userSubscription: {
+      ...baseSubscription(),
+      subscriptionStatus: overrides.status,
+      isInTrial: false,
+      totalPlanCredits: 100,
+      credit: {
+        id: "c1",
+        userId: "u1",
+        customerId: "cus",
+        bonusCredits: 0,
+        consumedFromPlan: 30,
+        consumedFromBonus: 0,
+        lastResetAt: EPOCH,
+      },
+    },
+    payAsYouGoUsage: { allowPayAsYouGo: false },
+    teamSubscriptions: overrides.withTeam
+      ? [
+          {
+            ...baseSubscription(),
+            teamID: "team-1",
+            subscriptionStatus: "ULTRA_1X_V3",
+            isInTrial: false,
+            totalPlanCredits: 500,
+            hasActiveBundle: false,
+            bundleSummary: {
+              bundleTotal: 0,
+              bundleConsumed: 0,
+              bundleRemaining: 0,
+            },
+            credit: {
+              id: "c2",
+              userId: "u1",
+              customerId: "cus",
+              orgId: "team-1",
+              bonusCredits: 0,
+              consumedFromPlan: 100,
+              consumedFromBonus: 0,
+              lastResetAt: EPOCH,
+            },
+            team: {
+              id: "team-1",
+              slug: "acme",
+              avatarUrl: null,
+              privacyMode: false,
+              createdAt: EPOCH,
+              updatedAt: EPOCH,
+            },
+          },
+        ]
+      : [],
+  };
+}
+
+function readyAuthUser(data: AuthenticatedUser): MockAuthUser {
+  return {
+    data,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    dataUpdatedAt: NOW - 60_000,
+    refetch: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+let onClose: () => void;
+
+function renderPopover() {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <TooltipProvider>
+        <Popover open>
+          <PopoverTrigger>trigger</PopoverTrigger>
+          <RateLimitPopover onClose={onClose} />
+        </Popover>
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  mocks.configured = [];
+  mocks.results = {};
+  mocks.draining = false;
+  mocks.openSettings = vi.fn();
+  mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
+  mocks.lastUseHostQueriesOptions = null;
+  mocks.lastUseHostQueriesProviderIds = null;
+  mocks.authUser = coldAuthUser();
+  useAccountContextStore.setState({ accountContext: { type: "PERSONAL" } });
+  onClose = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("<RateLimitPopover /> zero-provider state", () => {
+  it("shows a single CTA with no rail when nothing is configured", () => {
+    mocks.configured = [];
+    renderPopover();
+    expect(
+      screen.getByText("Connect Claude Code or Codex to see usage here."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("tablist")).toBeNull();
+  });
+
+  it("opens provider settings and closes the popover from the CTA", () => {
+    mocks.configured = [];
+    renderPopover();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open provider settings" }),
+    );
+    expect(mocks.openSettings).toHaveBeenCalledWith({
+      section: "providers",
+      resetToGeneral: false,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("<RateLimitPopover /> rail", () => {
+  it("pins Overview first, then one tab per provider in app order", () => {
+    // Passed out of order; the rail must sort to codex, claude-code, ...
+    mocks.configured = [
+      { providerId: "kilocode", lane: "httpFetch" },
+      { providerId: "codex", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      kilocode: readyResult({
+        provider: "kilocode",
+        available: true,
+        creditBalance: 5,
+        passState: null,
+      }),
+    };
+    renderPopover();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Overview",
+      "Codex",
+      "Kilo Code",
+    ]);
+  });
+
+  it("lands on Overview, stacking every provider's condensed block", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    renderPopover();
+    // Both provider blocks render their header name (rail buttons are icon-only).
+    expect(screen.getByText("Codex")).toBeTruthy();
+    expect(screen.getByText("Claude Code")).toBeTruthy();
+    // Popover variant renders "% used" copy (codex primary 4% used, claude
+    // fiveHour 22% used - both windows are the 5-hour session window, so the
+    // bare "Current session" label renders once per provider).
+    expect(screen.getAllByText("Current session")).toHaveLength(2);
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("22% used")).toBeTruthy();
+    // Overview is condensed: the plan/tier label ("Pro 5x") is detail-only.
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+  });
+
+  it("draws a divider only between consecutive condensed blocks (no header row)", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    renderPopover();
+    // Fixup C #4: the "All providers" header (and its divider) is gone; only the
+    // between-block dividers remain: 2 providers -> 1 divider. PopoverContent
+    // portals to body.
+    expect(document.querySelectorAll('[class*="bg-border/70"]').length).toBe(1);
+  });
+
+  it("switches to a single provider detail (with plan label) on tab click", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    renderPopover();
+    // Overview is condensed, so the plan label isn't shown there...
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    expect(screen.getByText("Codex")).toBeTruthy();
+    // ...but the single-provider detail tab surfaces it.
+    expect(screen.getByText("Pro 5x")).toBeTruthy();
+  });
+
+  it("shows a relative countdown for a short window and an absolute date for a weekly one", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: readyResult({
+        provider: "codex",
+        available: true,
+        planType: "pro_5x",
+        limitId: null,
+        limitName: null,
+        primary: {
+          usedPercent: 4,
+          resetsAt: NOW + 60 * 60 * 1000,
+          durationMinutes: 300,
+        },
+        secondary: {
+          usedPercent: 40,
+          resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+          durationMinutes: 10080,
+        },
+        extraWindows: [],
+        credits: null,
+        individualLimit: null,
+        resetCredits: null,
+        rateLimitReachedType: null,
+      }),
+    };
+    renderPopover();
+    // Fixup C #1: 5h primary -> relative countdown; weekly secondary -> absolute
+    // weekday-tagged time. Both split the same way as the Settings card.
+    expect(screen.getByText(/^Resets in /)).toBeTruthy();
+    expect(
+      screen.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
+    ).toBeTruthy();
+  });
+});
+
+function coldResult(): QueryResult {
+  return {
+    data: undefined,
+    isPending: true,
+    isFetching: true,
+    isError: false,
+    dataUpdatedAt: 0,
+    refetch: vi.fn(() => Promise.resolve({})),
+  };
+}
+
+describe("<RateLimitPopover /> Overview progressive reveal", () => {
+  function popoverElement() {
+    return (
+      <QueryClientProvider client={new QueryClient()}>
+        <TooltipProvider>
+          <Popover open>
+            <PopoverTrigger>trigger</PopoverTrigger>
+            <RateLimitPopover onClose={onClose} />
+          </Popover>
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  it("shows one centered loading indicator, no per-provider sections, while nothing has resolved yet", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = { codex: coldResult(), "claude-code": coldResult() };
+    renderPopover();
+
+    expect(screen.getByText("Fetching usage limits")).toBeTruthy();
+    // Neither provider's own reading is visible yet - only the combined loader.
+    expect(screen.queryByText("Current session")).toBeNull();
+    expect(screen.queryByText("4% used")).toBeNull();
+  });
+
+  it("reveals a provider in place as it resolves, hiding still-cold siblings, and drops the combined loader", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = { codex: coldResult(), "claude-code": coldResult() };
+    const { rerender } = renderPopover();
+
+    // Codex resolves first; Claude Code is still in flight.
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": coldResult(),
+    };
+    rerender(popoverElement());
+
+    // The combined loader is gone now that one provider has data...
+    expect(screen.queryByText("Fetching usage limits")).toBeNull();
+    // ...Codex's own section is visible...
+    expect(
+      screen.getByText("Codex").closest('[class*="gap-4"]')?.className,
+    ).not.toContain("hidden");
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    // ...but Claude Code's still-cold section is hidden, not painted as its
+    // own blank/loading block.
+    expect(
+      screen.getByText("Claude Code").closest('[class*="gap-4"]')?.className,
+    ).toContain("hidden");
+
+    // Claude Code resolves next - both sections are now visible.
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    rerender(popoverElement());
+    expect(
+      screen.getByText("Claude Code").closest('[class*="gap-4"]')?.className,
+    ).not.toContain("hidden");
+  });
+});
+
+describe("<RateLimitPopover /> per-provider states", () => {
+  it("shows skeleton bars (not a spinner) on cold load", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: {
+        data: undefined,
+        isPending: true,
+        isFetching: true,
+        isError: false,
+        dataUpdatedAt: 0,
+        refetch: vi.fn(() => Promise.resolve({})),
+      },
+    };
+    renderPopover();
+    const skeleton = screen.getByTestId("rate-limit-detail-skeleton");
+    expect(skeleton).toBeTruthy();
+    // Regression: several dark theme presets set `--muted` equal to
+    // `--popover`, so a plain `bg-muted` skeleton block is the same color as
+    // the popover background and reads as an empty section, not a loading
+    // one. Each block overrides that with `bg-foreground/15`, which contrasts
+    // against any background without needing a border.
+    const blocks = skeleton.querySelectorAll('[data-slot="skeleton"]');
+    expect(blocks.length).toBeGreaterThan(0);
+    blocks.forEach((block) => {
+      expect(block.className).toContain("bg-foreground/15");
+    });
+  });
+
+  it("dims stale content and notes a failed refresh when degraded", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: {
+        ...readyResult(codexReady()),
+        isError: true,
+      },
+    };
+    renderPopover();
+    expect(screen.getByText(/· refresh failed/)).toBeTruthy();
+    // PopoverContent portals to document.body, outside the render container.
+    expect(document.querySelectorAll(".opacity-60").length).toBeGreaterThan(0);
+  });
+
+  it("shows Refreshing instead of an updated timestamp while a refresh is in progress", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.draining = true;
+    renderPopover();
+
+    const label = screen.getByText("Refreshing");
+    expect(label).toBeTruthy();
+    expect(label.className).toContain("working-text-shimmer");
+    expect(screen.getByTestId("usage-limit-refreshing-dots")).toBeTruthy();
+    expect(screen.queryByText(/^Updated /)).toBeNull();
+  });
+
+  it("shows a plain error message with no inline retry control when a fetch never succeeded", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: {
+        data: undefined,
+        isPending: false,
+        isFetching: false,
+        isError: true,
+        dataUpdatedAt: 0,
+        refetch: vi.fn(() => Promise.resolve({})),
+      },
+    };
+    renderPopover();
+    expect(
+      screen.getByText("Couldn't load usage limits right now."),
+    ).toBeTruthy();
+    // No separate "Retry" link - the header's own refresh icon already covers
+    // it (feedback: "we already have a reload button"). That icon is
+    // detail-tab-only (Overview relies on "Refresh all"), so switch there first.
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Codex" }));
+    // Codex is ephemeralProcess -> the header's refresh routes through the
+    // serial queue, same as retrying used to.
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "codex",
+      { type: "PERSONAL" },
+      { force: true },
+    );
+  });
+
+  it("maps an available:false reason to a plain-language message", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = {
+      codex: readyResult({
+        provider: "codex",
+        available: false,
+        reason: "cli_not_found",
+      }),
+    };
+    renderPopover();
+    expect(
+      screen.getByText("Usage limits unavailable — the CLI isn't installed"),
+    ).toBeTruthy();
+  });
+});
+
+describe("<RateLimitPopover /> Refresh all", () => {
+  it("is disabled while the queue is draining", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.draining = true;
+    renderPopover();
+    const refreshAll = screen.getByRole("button", { name: "Refresh all" });
+    expect((refreshAll as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("is disabled while an httpFetch provider is fetching, even though the ephemeralProcess queue isn't draining", () => {
+    // Regression: "Refresh all" used to read only the ephemeralProcess queue's
+    // draining flag, so an all-httpFetch popover (or one mid-invalidation on
+    // just its httpFetch providers) never visibly spun despite actively
+    // refreshing.
+    mocks.configured = [{ providerId: "kilocode", lane: "httpFetch" }];
+    mocks.results = {
+      kilocode: {
+        ...readyResult({
+          provider: "kilocode",
+          available: true,
+          creditBalance: 9,
+          passState: null,
+        }),
+        isFetching: true,
+      },
+    };
+    mocks.draining = false;
+    renderPopover();
+    const refreshAll = screen.getByRole("button", { name: "Refresh all" });
+    expect((refreshAll as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("passes the httpFetch lane's real query options (e.g. retry: false) to useHostQueries for every configured httpFetch provider", () => {
+    // Regression 1: an earlier version passed `options: null`, so this batch
+    // of queries silently inherited the global QueryClient's default retry
+    // policy for the exact same query key `RateLimitProviderBlock`'s own
+    // `useHostProviderRateLimitsQuery` deliberately sets `retry: false` for.
+    // Regression 2 (review feedback): both httpFetch providers are configured
+    // here - not just one - because production derives the shared options from
+    // `httpFetchProviders[0]` (safe today: `providerRateLimitQueryOptions`
+    // branches on lane, never provider id, so all httpFetch options are
+    // identical) and must still subscribe to EVERY provider's query state.
+    // Passed in non-canonical order to exercise the sort in front of `[0]`.
+    mocks.configured = [
+      { providerId: "kilocode", lane: "httpFetch" },
+      { providerId: "openrouter", lane: "httpFetch" },
+    ];
+    mocks.results = {
+      kilocode: readyResult({
+        provider: "kilocode",
+        available: true,
+        creditBalance: 9,
+        passState: null,
+      }),
+      openrouter: readyResult({
+        provider: "openrouter",
+        available: true,
+        limit: 100,
+        limitRemaining: 40,
+        dailySpend: 5,
+        weeklySpend: 12,
+        monthlySpend: 30,
+        totalCredits: 100,
+        totalUsage: 60,
+        balance: 40,
+      }),
+    };
+    renderPopover();
+    expect(mocks.lastUseHostQueriesOptions?.retry).toBe(false);
+    expect([...(mocks.lastUseHostQueriesProviderIds ?? [])].sort()).toEqual([
+      "kilocode",
+      "openrouter",
+    ]);
+  });
+
+  it("keeps a single ephemeralProcess provider's own refresh button disabled while the queue is draining, even though its own isFetching has already settled", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.draining = true;
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    const refreshCodex = screen.getByRole("button", { name: "Refresh Codex" });
+    expect((refreshCodex as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("enqueues each ephemeralProcess provider with force:true", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh all" }));
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "codex",
+      { type: "PERSONAL" },
+      { force: true },
+    );
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "claude-code",
+      { type: "PERSONAL" },
+      { force: true },
+    );
+  });
+});
+
+describe("<RateLimitPopover /> rail settings", () => {
+  it("opens provider settings and closes the popover from the rail settings icon", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    renderPopover();
+    fireEvent.click(screen.getByRole("button", { name: "Provider settings" }));
+    expect(mocks.openSettings).toHaveBeenCalledWith({
+      section: "providers",
+      resetToGeneral: false,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("<RateLimitPopover /> per-provider refresh", () => {
+  it("routes an httpFetch provider's refresh through refetch, not the queue", () => {
+    const refetch = vi.fn(() => Promise.resolve({}));
+    mocks.configured = [{ providerId: "kilocode", lane: "httpFetch" }];
+    mocks.results = {
+      kilocode: {
+        ...readyResult({
+          provider: "kilocode",
+          available: true,
+          creditBalance: 9,
+          passState: null,
+        }),
+        refetch,
+      },
+    };
+    renderPopover();
+    // The per-provider refresh only lives in the single-provider detail tab now
+    // (item 2 feedback: Overview keeps only the rail's "Refresh all").
+    fireEvent.click(screen.getByRole("tab", { name: "Kilo Code" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Kilo Code" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+});
+
+// Guards that a stacked Overview keeps each provider's block scoped, and that
+// it has no per-provider refresh controls (item 2 feedback: only the rail's
+// "Refresh all" - the single-provider detail tab keeps its own).
+describe("<RateLimitPopover /> Overview block scoping", () => {
+  it("shows no per-provider refresh controls on Overview, only Refresh all", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+    };
+    renderPopover();
+    expect(screen.queryByRole("button", { name: "Refresh Codex" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Refresh Claude Code" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Refresh all" })).toBeTruthy();
+    // Rail buttons are icon-only, so each provider name appears exactly once -
+    // in its own block header, confirming the blocks are stacked (not merged).
+    expect(screen.getAllByText("Codex").length).toBe(1);
+  });
+
+  it("keeps the per-provider refresh control in the single-provider detail tab", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    expect(screen.getByRole("button", { name: "Refresh Codex" })).toBeTruthy();
+  });
+});
+
+describe("<RateLimitPopover /> Traycer tab", () => {
+  it("adds a Traycer tab for a paid account, even with no host-RPC providers", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: false }),
+    );
+    renderPopover();
+    // Eligible Traycer alone keeps the rail (not the zero-provider CTA).
+    expect(
+      screen.queryByText("Connect Claude Code or Codex to see usage here."),
+    ).toBeNull();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Overview",
+      "Traycer Inference",
+    ]);
+  });
+
+  it("omits the Traycer tab for a free, unbundled account", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "FREE", withTeam: false }),
+    );
+    renderPopover();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Overview",
+      "Codex",
+    ]);
+  });
+
+  it("orders the Traycer tab per PROVIDER_ID_ORDER (after Codex, before Kilo Code)", () => {
+    mocks.configured = [
+      { providerId: "kilocode", lane: "httpFetch" },
+      { providerId: "codex", lane: "ephemeralProcess" },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      kilocode: readyResult({
+        provider: "kilocode",
+        available: true,
+        creditBalance: 5,
+        passState: null,
+      }),
+    };
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: false }),
+    );
+    renderPopover();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs.map((tab) => tab.getAttribute("aria-label"))).toEqual([
+      "Overview",
+      "Codex",
+      "Traycer Inference",
+      "Kilo Code",
+    ]);
+  });
+
+  it("shows the subscription detail with an account picker on the Traycer tab", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: true }),
+    );
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
+    // Shared subscription view: plan credit breakdown (30 of 100).
+    expect(screen.getByText("$30.00 / $100.00")).toBeTruthy();
+    // Detail tab surfaces the same Personal/Team picker as the Settings card.
+    expect(screen.getByRole("combobox", { name: "Account" })).toBeTruthy();
+    // Plan/tier chip next to the name - the trailing "_V3" pricing-generation
+    // tag is stripped (matching Cloud UI's own Settings pages), so "PRO_V3"
+    // reads as "Pro", not "Pro V3".
+    expect(screen.getByText("Pro")).toBeTruthy();
+  });
+
+  it("renders a condensed Traycer block with no picker or plan chip on Overview", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: true }),
+    );
+    renderPopover();
+    // Overview reflects the selected account's numbers, but exposes no controls.
+    expect(screen.getByText("$30.00 / $100.00")).toBeTruthy();
+    expect(screen.queryByRole("combobox", { name: "Account" })).toBeNull();
+    // Overview is condensed, same as the host-RPC providers' plan chip.
+    expect(screen.queryByText("Pro")).toBeNull();
+  });
+
+  it("reflects the selected account's own plan in the chip, not the personal account's", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: true }),
+    );
+    // The fixture's team subscription is on "ULTRA_1X_V3" - selecting the
+    // team account should show that plan in the chip, not the personal one.
+    useAccountContextStore.setState({
+      accountContext: { type: "TEAM", teamId: "team-1" },
+    });
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
+    // "ULTRA_1X_V3" reads as the bare "Ultra" tier name (matching
+    // `subscriptionPlanLabel`'s own tier-name mapping), not the personal
+    // account's "Pro".
+    expect(screen.getByText("Ultra")).toBeTruthy();
+    expect(screen.queryByText("Pro")).toBeNull();
+  });
+
+  it("refetches the subscription from the Traycer tab's refresh button", () => {
+    mocks.configured = [];
+    const authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: false }),
+    );
+    mocks.authUser = authUser;
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh Traycer Inference" }),
+    );
+    expect(authUser.refetch).toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/components/layout/header/app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/app-header.tsx
@@ -4,6 +4,7 @@ import { TabStrip } from "@/components/layout/tabs/tab-strip";
 import { AppUpdateHeaderButton } from "@/components/layout/header/app-update-button";
 import { HistoryButton } from "@/components/layout/header/history-button";
 import { HistoryNavButtons } from "@/components/layout/header/history-nav-buttons";
+import { RateLimitIconButton } from "@/components/layout/header/rate-limit-icon";
 import { SignInButton } from "@/components/layout/header/sign-in-button";
 import { NotificationsBell } from "@/components/notifications/notifications-bell";
 import { cn } from "@/lib/utils";
@@ -103,6 +104,7 @@ export function AppHeader(props: AppHeaderProps): ReactNode {
         style={framelessDesktop ? NO_DRAG_STYLE : undefined}
       >
         {!navDisabled ? <AppUpdateHeaderButton /> : null}
+        {!navDisabled ? <RateLimitIconButton /> : null}
         {!navDisabled ? <HistoryButton /> : null}
         {showBell ? <HeaderNotificationsBell /> : null}
         <HeaderIdentity showAppSettings={!navDisabled} />

--- a/clients/gui-app/src/components/layout/header/rate-limit-icon.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-icon.tsx
@@ -1,0 +1,103 @@
+import { useState, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverTrigger } from "@/components/ui/popover";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { RateLimitPopover } from "@/components/layout/header/rate-limit-popover";
+import { useHeaderRateLimitBars } from "@/hooks/rate-limits/use-header-rate-limit-bars";
+import {
+  rateLimitWindowFillPercent,
+  rateLimitWindowSeverityBarClassName,
+} from "@/lib/rate-limits/window-severity";
+import { cn } from "@/lib/utils";
+
+/**
+ * Fixed placeholder fill percentages for the neutral/no-data glyph (Core
+ * Flows wireframe, CodexBar-style generic pre-filled look) - shown both when
+ * zero providers are configured and while every provider's first fetch is
+ * still pending. Not real usage data.
+ */
+const PLACEHOLDER_BAR_PERCENTAGES: ReadonlyArray<number> = [75, 60];
+
+/**
+ * Header trigger for the provider rate-limit popover. Same `TooltipWrapper` +
+ * `Button variant="ghost" size="icon-sm"` structural pattern as
+ * `HistoryButton`, always visible per Core Flows' "Entry point & visibility"
+ * (position consistency + feature discovery beat hiding an empty state).
+ * Clicking opens the popover in any glyph state, including empty (which lands on
+ * the zero-provider CTA).
+ *
+ * Never gates on data loading: `useHeaderRateLimitBars` returns `[]` both
+ * before any provider has data and when zero providers are configured, and
+ * both render the same neutral glyph - there is no separate loading state.
+ */
+export function RateLimitIconButton(): ReactNode {
+  const [open, setOpen] = useState(false);
+  const bars = useHeaderRateLimitBars();
+  const isEmpty = bars.length === 0;
+  const isDegraded = !isEmpty && bars.some((bar) => bar.degraded);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <TooltipWrapper
+        label="Usage limits"
+        side="top"
+        sideOffset={6}
+        align={undefined}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Usage limits"
+            data-testid="rate-limit-header-button"
+            className={cn(
+              "text-muted-foreground hover:text-foreground",
+              isEmpty && "opacity-50",
+              isDegraded && "opacity-[0.55]",
+            )}
+          >
+            <span
+              aria-hidden
+              className="inline-flex flex-col items-start gap-[2.5px]"
+            >
+              {isEmpty
+                ? PLACEHOLDER_BAR_PERCENTAGES.map((percent) => (
+                    <span
+                      key={percent}
+                      data-testid="rate-limit-bar-track"
+                      className="relative h-1 w-4 overflow-hidden rounded-[2px] bg-muted"
+                    >
+                      <span
+                        data-testid="rate-limit-bar-fill"
+                        className="absolute inset-y-0 left-0 rounded-[2px] bg-muted-foreground"
+                        style={{ width: `${percent}%` }}
+                      />
+                    </span>
+                  ))
+                : bars.map((bar) => (
+                    <span
+                      key={`${bar.providerId}-${bar.windowLabel}`}
+                      data-testid="rate-limit-bar-track"
+                      className="relative h-1 w-4 overflow-hidden rounded-[2px] bg-muted"
+                    >
+                      <span
+                        data-testid="rate-limit-bar-fill"
+                        className={cn(
+                          "absolute inset-y-0 left-0 rounded-[2px]",
+                          rateLimitWindowSeverityBarClassName(bar.severity),
+                        )}
+                        style={{
+                          width: `${rateLimitWindowFillPercent(bar.usedPercent)}%`,
+                        }}
+                      />
+                    </span>
+                  ))}
+            </span>
+          </Button>
+        </PopoverTrigger>
+      </TooltipWrapper>
+      <RateLimitPopover onClose={() => setOpen(false)} />
+    </Popover>
+  );
+}

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -1,0 +1,972 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Gauge, Settings } from "lucide-react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { Badge } from "@/components/ui/badge";
+import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
+import { PopoverContent } from "@/components/ui/popover";
+import { Skeleton } from "@/components/ui/skeleton";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { RefreshIconButton } from "@/components/refresh-icon-button";
+import { HarnessIcon } from "@/components/home/pickers/harness-icon";
+import {
+  ProviderRateLimitDetail,
+  type ProviderRateLimitQueryState,
+} from "@/components/settings/panels/provider-rate-limit-views";
+import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
+import { useHostQueries } from "@/hooks/host/use-host-queries";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import {
+  useConfiguredRateLimitProviders,
+  type ConfiguredRateLimitProvider,
+} from "@/hooks/rate-limits/use-configured-rate-limit-providers";
+import { useIsRateLimitQueueDraining } from "@/hooks/rate-limits/use-is-rate-limit-queue-draining";
+import { useProviderRateLimitRefresh } from "@/hooks/rate-limits/use-provider-rate-limit-refresh";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+import {
+  formatUnavailableReason,
+  resolvePopoverProviderRateLimitState,
+  resolveProviderPlanLabel,
+  type PopoverProviderRateLimitState,
+} from "@/lib/provider-rate-limit-content";
+import { useHostClient, type HostRpcRegistry } from "@/lib/host";
+import {
+  providerDisplayName,
+  providerIdToGuiHarnessId,
+  sortProviderStatesByProviderOrder,
+} from "@/lib/provider-ordering";
+import { queryKeys } from "@/lib/query-keys";
+import { type RateLimitProviderId } from "@/lib/rate-limit-providers";
+import { useRelativeTimestamp } from "@/lib/relative-time";
+import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { useAuthUser } from "@/hooks/auth/use-auth-user-query";
+import {
+  resolveAccountContext,
+  useAccountContextStore,
+} from "@/stores/auth/account-context-store";
+import {
+  accountContextValue,
+  isCreditBasedPricing,
+  isTraycerEligible,
+  parseAccountContextValue,
+  resolveTraycerSubscriptionState,
+  selectSubscription,
+  subscriptionPlanLabel,
+  type TraycerSubscriptionState,
+} from "@/lib/auth/traycer-subscription-content";
+import {
+  TraycerAccountSelect,
+  TraycerSubscriptionView,
+} from "@/components/settings/panels/traycer-subscription-views";
+import { cn } from "@/lib/utils";
+
+/**
+ * The Overview tab (always pinned first), one tab per connected host-RPC
+ * provider, and - when the account is eligible - the GUI-sourced "traycer" tab.
+ * `"traycer"` is a synthetic entry: it is NOT a `RateLimitProviderId` and does
+ * not flow through `useConfiguredRateLimitProviders()`.
+ */
+type RateLimitTab = "overview" | RateLimitProviderId | "traycer";
+
+/**
+ * A rail/Overview entry, in draw order: either a host-RPC provider or the
+ * synthetic Traycer entry. `railTabProviderId` maps each to a `ProviderId` so a
+ * single `sortProviderStatesByProviderOrder` positions Traycer at its
+ * `PROVIDER_ID_ORDER` slot among the providers.
+ */
+type RailTabDescriptor =
+  | { readonly kind: "provider"; readonly providerId: RateLimitProviderId }
+  | { readonly kind: "traycer" };
+
+function railTabProviderId(tab: RailTabDescriptor): ProviderId {
+  return tab.kind === "traycer" ? "traycer" : tab.providerId;
+}
+
+function orderRailTabs(
+  providers: ReadonlyArray<ConfiguredRateLimitProvider>,
+  includeTraycer: boolean,
+): ReadonlyArray<RailTabDescriptor> {
+  const descriptors: RailTabDescriptor[] = providers.map((provider) => ({
+    kind: "provider",
+    providerId: provider.providerId,
+  }));
+  if (includeTraycer) descriptors.push({ kind: "traycer" });
+  return sortProviderStatesByProviderOrder(
+    descriptors.map((descriptor) => ({
+      providerId: railTabProviderId(descriptor),
+      descriptor,
+    })),
+  ).map((entry) => entry.descriptor);
+}
+
+/**
+ * The header rate-limit popover content: a left rail (Overview + one tab per
+ * connected provider) and a detail pane, mirroring the composer's model-picker
+ * shell (Core Flows: "same interaction family as the composer's model picker").
+ * The whole body is a child of `PopoverContent`, so Radix only mounts it - and
+ * runs its queries and tab state - while the popover is open; `activeTab`
+ * therefore resets to Overview on every open (Core Flows: "Landing tab is
+ * always Overview").
+ */
+export function RateLimitPopover({
+  onClose,
+}: {
+  readonly onClose: () => void;
+}): ReactNode {
+  return (
+    <PopoverContent
+      side="bottom"
+      align="end"
+      sideOffset={8}
+      collisionPadding={12}
+      role="dialog"
+      aria-label="Usage limits"
+      className="w-[min(92vw,30rem)] gap-0 overflow-hidden rounded-xl p-0"
+      // Radix auto-focuses the first focusable child on open. Here that's the
+      // Overview rail tab, whose `TooltipWrapper` opens the tooltip on focus
+      // (keyboard a11y) - so it would pop open the instant the popover mounts
+      // and never receive a mouseleave/blur to close it. This popover has no
+      // field to type into (unlike the composer's model picker, whose first
+      // focusable is its search input, so it wants and keeps the auto-focus), so
+      // opting out of the initial focus is harmless and stops the stuck tooltip.
+      onOpenAutoFocus={(event) => event.preventDefault()}
+    >
+      <RateLimitPopoverBody onClose={onClose} />
+    </PopoverContent>
+  );
+}
+
+function RateLimitPopoverBody({
+  onClose,
+}: {
+  readonly onClose: () => void;
+}): ReactNode {
+  const configured = useConfiguredRateLimitProviders();
+  // Rail order matches the app's standard provider order everywhere else.
+  const providers = useMemo(
+    () => sortProviderStatesByProviderOrder(configured),
+    [configured],
+  );
+
+  // Traycer is a GUI-only rail entry (AuthService subscription, not a host RPC),
+  // gated on the *selected* account being paid or credit-bundled. Recomputed
+  // reactively from the auth query + account-context store, so the tab appears /
+  // disappears live as either changes - not snapshotted at popover-open time.
+  const authQuery = useAuthUser();
+  const storedAccountContext = useAccountContextStore((s) => s.accountContext);
+  const traycerEligible = useMemo(() => {
+    const user = authQuery.data ?? null;
+    const teams = user?.teamSubscriptions ?? [];
+    const teamIds = new Set(teams.map((team) => team.team.id));
+    const resolved = resolveAccountContext(storedAccountContext, teamIds);
+    const subscription = selectSubscription(user, resolved, teams);
+    return subscription !== null && isTraycerEligible(subscription);
+  }, [authQuery.data, storedAccountContext]);
+
+  const railTabs = useMemo(
+    () => orderRailTabs(providers, traycerEligible),
+    [providers, traycerEligible],
+  );
+  const [activeTab, setActiveTab] = useState<RateLimitTab>("overview");
+
+  // Zero-state only when there is genuinely nothing to show: no host-RPC
+  // providers AND no eligible Traycer tab.
+  if (providers.length === 0 && !traycerEligible) {
+    return <RateLimitZeroState onClose={onClose} />;
+  }
+
+  // A credential removed (or Traycer becoming ineligible) mid-session can drop
+  // the active tab from the rail; fall back to Overview rather than rendering a
+  // tab that no longer exists.
+  const validTabs = new Set<RateLimitTab>([
+    "overview",
+    ...railTabs.map((tab) =>
+      tab.kind === "traycer" ? "traycer" : tab.providerId,
+    ),
+  ]);
+  const resolvedTab: RateLimitTab = validTabs.has(activeTab)
+    ? activeTab
+    : "overview";
+
+  // A *fixed* height (not `max-h`), plus an explicit `minmax(0,1fr)` grid row,
+  // is what makes the popover a stable box across tabs and lets its panes
+  // scroll: a `max-h` on a single-`auto`-row grid lets the row size to content,
+  // so the detail pane grew unbounded (tall content clipped, no scrollbar) and
+  // the whole popover resized per tab. `minmax(0,1fr)` pins the row to the
+  // container height regardless of content, and both columns stretch into it
+  // with their own `min-h-0` + `overflow-y-auto`, so each scrolls internally.
+  return (
+    <div className="grid h-[min(58vh,22rem)] grid-cols-[3rem_minmax(0,1fr)] grid-rows-[minmax(0,1fr)] overflow-hidden">
+      <RateLimitRail
+        railTabs={railTabs}
+        providers={providers}
+        activeTab={resolvedTab}
+        onSelect={setActiveTab}
+        onClose={onClose}
+      />
+      <div className="min-h-0 min-w-0 overflow-y-auto p-3">
+        {resolvedTab === "overview" ? (
+          <RateLimitOverview railTabs={railTabs} />
+        ) : (
+          <RateLimitDetailPane tab={resolvedTab} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The single-tab detail pane: the synthetic Traycer block, or a host-RPC
+ * provider block. Split out so `RateLimitPopoverBody` picks Overview-vs-detail
+ * with one ternary instead of a nested one.
+ */
+function RateLimitDetailPane({
+  tab,
+}: {
+  readonly tab: Exclude<RateLimitTab, "overview">;
+}): ReactNode {
+  return tab === "traycer" ? (
+    <TraycerRateLimitBlock variant="popover-detail" onReady={null} />
+  ) : (
+    <RateLimitProviderBlock
+      providerId={tab}
+      variant="popover-detail"
+      onReady={null}
+    />
+  );
+}
+
+/**
+ * The left rail: an Overview tab, one tab per connected provider, then a
+ * "Refresh all" and a "Provider settings" icon pinned to the bottom - the same
+ * structural shell as the composer model picker's `ProviderRail` (scrollable
+ * `role="tablist"` as a `flex-1` sibling, action icons after it). The two
+ * bottom icons are deliberately siblings of the tablist, not tabs inside it, so
+ * only real tab elements live under `role="tablist"` for correct screen-reader
+ * nav.
+ */
+function RateLimitRail({
+  railTabs,
+  providers,
+  activeTab,
+  onSelect,
+  onClose,
+}: {
+  readonly railTabs: ReadonlyArray<RailTabDescriptor>;
+  readonly providers: ReadonlyArray<ConfiguredRateLimitProvider>;
+  readonly activeTab: RateLimitTab;
+  readonly onSelect: (tab: RateLimitTab) => void;
+  readonly onClose: () => void;
+}): ReactNode {
+  const { openSettings } = useSystemTabModalActions();
+  const openProviderSettings = (): void => {
+    onClose();
+    openSettings({ section: "providers", resetToGeneral: false });
+  };
+  return (
+    <div className="flex min-h-0 flex-col items-center border-r bg-muted/20 p-1.5">
+      <div
+        role="tablist"
+        aria-label="Usage limit providers"
+        aria-orientation="vertical"
+        className="flex min-h-0 flex-1 flex-col items-center gap-1.5 overflow-y-auto"
+      >
+        <RailTab
+          label="Overview"
+          selected={activeTab === "overview"}
+          onSelect={() => onSelect("overview")}
+          icon={<Gauge className="size-4" />}
+        />
+        <div aria-hidden className="my-0.5 h-px w-5 bg-border" />
+        {railTabs.map((tab) =>
+          tab.kind === "traycer" ? (
+            <RailTab
+              key="traycer"
+              label={providerDisplayName("traycer")}
+              selected={activeTab === "traycer"}
+              onSelect={() => onSelect("traycer")}
+              icon={
+                <HarnessIcon harnessId={providerIdToGuiHarnessId("traycer")} />
+              }
+            />
+          ) : (
+            <RailTab
+              key={tab.providerId}
+              label={providerDisplayName(tab.providerId)}
+              selected={activeTab === tab.providerId}
+              onSelect={() => onSelect(tab.providerId)}
+              icon={
+                <HarnessIcon
+                  harnessId={providerIdToGuiHarnessId(tab.providerId)}
+                />
+              }
+            />
+          ),
+        )}
+      </div>
+      <RateLimitRefreshAllButton providers={providers} />
+      <button
+        type="button"
+        aria-label="Provider settings"
+        title="Provider settings"
+        onClick={openProviderSettings}
+        className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        <Settings className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+function RailTab({
+  label,
+  selected,
+  onSelect,
+  icon,
+}: {
+  readonly label: string;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+  readonly icon: ReactNode;
+}): ReactNode {
+  return (
+    <TooltipWrapper label={label} side="right" sideOffset={6} align={undefined}>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={selected}
+        aria-label={label}
+        title={label}
+        onClick={onSelect}
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60",
+          selected && "bg-accent text-foreground",
+        )}
+      >
+        {icon}
+      </button>
+    </TooltipWrapper>
+  );
+}
+
+/**
+ * The Overview tab: every rail entry's *condensed* block
+ * (`variant="popover-overview"`), in rail order, each separated by a divider.
+ * For host-RPC providers that's their 5h/Weekly windows plus credit/balance
+ * figures; for the Traycer entry it's the tier badge + credit/rate-limit
+ * breakdown. Per-model breakdowns, spend controls, badges, plan labels, and the
+ * Traycer account picker are single-provider-tab detail, not shown here. The
+ * "Refresh all" and settings controls live on the rail (shared across every
+ * tab), so this pane is pure content - no header row, and dividers only
+ * *between* consecutive blocks. Not capped at 3 (unlike the header glyph) -
+ * it's a scroll, not a summary.
+ *
+ * Every tab's block stays mounted the whole time (so its query keeps running
+ * regardless of what's visible), but a tab that hasn't reported readiness yet
+ * (`onReady`, fired once its own state moves past `cold`) is hidden rather
+ * than painted as its own blank/loading section - it's revealed in place once
+ * its data arrives, so the list grows one provider at a time instead of every
+ * slot appearing empty up front. While nothing has reported ready yet, a
+ * single centered "Fetching usage limits" indicator stands in for the whole
+ * list (feedback: "just a modal centered fetching usage limits instead of
+ * empty provider sections").
+ */
+function RateLimitOverview({
+  railTabs,
+}: {
+  readonly railTabs: ReadonlyArray<RailTabDescriptor>;
+}): ReactNode {
+  const [readyKeys, setReadyKeys] = useState<ReadonlySet<string>>(new Set());
+  const markReady = useCallback((key: string) => {
+    setReadyKeys((prev) => {
+      if (prev.has(key)) return prev;
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  }, []);
+
+  const anyReady = readyKeys.size > 0;
+  const readyOrder = railTabs
+    .filter((tab) => readyKeys.has(railTabProviderId(tab)))
+    .map(railTabProviderId);
+
+  return (
+    <div className="flex min-h-full flex-col gap-4">
+      {!anyReady ? <RateLimitOverviewLoading /> : null}
+      {railTabs.map((tab) => {
+        const key = railTabProviderId(tab);
+        const isReady = readyKeys.has(key);
+        const showDivider = isReady && readyOrder.indexOf(key) > 0;
+        const onReady = () => markReady(key);
+        return (
+          <div
+            key={key}
+            className={cn("flex flex-col gap-4", !isReady && "hidden")}
+          >
+            {showDivider ? (
+              <div aria-hidden className="h-px bg-border/70" />
+            ) : null}
+            {tab.kind === "traycer" ? (
+              <TraycerRateLimitBlock
+                variant="popover-overview"
+                onReady={onReady}
+              />
+            ) : (
+              <RateLimitProviderBlock
+                providerId={tab.providerId}
+                variant="popover-overview"
+                onReady={onReady}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * The Overview's combined "nothing has arrived yet" state - a single centered
+ * indicator standing in for every provider's still-blank section, rather than
+ * painting N blank/loading sections at once. `flex-1` on a `min-h-full`
+ * column centers it within the popover's full pane height rather than
+ * collapsing to the height of the (hidden, zero-height) sibling blocks.
+ */
+function RateLimitOverviewLoading(): ReactNode {
+  return (
+    <div className="flex flex-1 items-center justify-center gap-2 py-10 text-ui-sm text-muted-foreground">
+      <MutedAgentSpinner />
+      Fetching usage limits
+    </div>
+  );
+}
+
+/**
+ * The rail's icon-only "Refresh all" (Core Flows): ephemeralProcess providers
+ * refresh one at a time through the shared serial queue (`force: true`), while
+ * httpFetch providers refresh concurrently alongside via a direct query
+ * invalidation - a plain GET has no subprocess cost to serialize. `refreshing`
+ * combines both lanes' real query state - the queue's draining flag for
+ * ephemeralProcess (which stays true a beat longer than any single provider's
+ * `isFetching`, covering the "still waiting behind an earlier provider in the
+ * queue" gap) and each configured httpFetch provider's own `isFetching` (read
+ * via `useHostQueries` against the exact same query keys the invalidation
+ * below targets) - so the icon spins for the whole round regardless of which
+ * lane(s) are actually configured, not just when an ephemeralProcess provider
+ * happens to be in the mix.
+ */
+function RateLimitRefreshAllButton({
+  providers,
+}: {
+  readonly providers: ReadonlyArray<ConfiguredRateLimitProvider>;
+}): ReactNode {
+  const draining = useIsRateLimitQueueDraining();
+  const queryClient = useQueryClient();
+  const hostId = useReactiveActiveHostId();
+  const client = useHostClient();
+  const httpFetchProviders = providers.filter(
+    (provider) => provider.lane === "httpFetch",
+  );
+  // Every httpFetch provider resolves to the exact same lane options (the
+  // `isHttpFetch` branch in `providerRateLimitQueryOptions` doesn't vary by
+  // provider id) - reusing the first one's is safe without the "verify every
+  // request shares one lane" check `useHeaderRateLimitBars` needs (that hook's
+  // provider list isn't pre-filtered to a single lane the way `httpFetchProviders`
+  // is here). Passing this through (rather than `null`) matters:
+  // `RateLimitProviderBlock`'s own query for these same providers sets
+  // `retry: false`, and TanStack keys retry/staleTime/refetchOnMount per query
+  // key - an unset `options` here would silently inherit the global
+  // QueryClient's defaults (one retry) for this same key instead.
+  const httpFetchOptions =
+    httpFetchProviders.length === 0
+      ? null
+      : providerRateLimitQueryOptions(httpFetchProviders[0].providerId).options;
+  const httpFetchQueries = useHostQueries<
+    HostRpcRegistry,
+    "host.getRateLimitUsage"
+  >({
+    client,
+    requests: httpFetchProviders.map((provider) => {
+      const { method, params } = providerRateLimitQueryOptions(
+        provider.providerId,
+      );
+      return { method, params };
+    }),
+    options: httpFetchOptions,
+  });
+  const refreshing =
+    draining || httpFetchQueries.some((query) => query.isFetching);
+
+  // Fire-and-forget, not awaited: httpFetch providers refresh concurrently via a
+  // direct invalidation while ephemeralProcess providers queue through the
+  // shared serial lane. Returns an already-resolved promise so `RefreshIconButton`
+  // gets its `() => Promise<void>` contract without gating the spinner on the
+  // fetches themselves - `refreshing` (above) owns that.
+  const refreshAll = (): Promise<void> => {
+    httpFetchProviders.forEach((provider) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.hostMethod<
+          HostRpcRegistry,
+          "host.getRateLimitUsage"
+        >(hostId, "host.getRateLimitUsage", {
+          accountContext: DEFAULT_ACCOUNT_CONTEXT,
+          providerId: provider.providerId,
+        }),
+      });
+    });
+    providers
+      .filter((provider) => provider.lane === "ephemeralProcess")
+      .forEach((provider) => {
+        void enqueueRateLimitFetch(
+          provider.providerId,
+          DEFAULT_ACCOUNT_CONTEXT,
+          { force: true },
+        );
+      });
+    return Promise.resolve();
+  };
+
+  return (
+    <RefreshIconButton
+      onRefresh={refreshAll}
+      label="Refresh all"
+      refreshing={refreshing}
+      className="mt-1"
+    />
+  );
+}
+
+/**
+ * The two popover surfaces a provider's block renders on: the single-provider
+ * tab (full detail) and the Overview tab (condensed). Both draw windows the
+ * same way; they differ only in how much detail is shown.
+ */
+type PopoverBlockVariant = "popover-detail" | "popover-overview";
+
+/**
+ * One provider's block - a header (name + plan/tier chip + "Updated Xm ago" +
+ * per-provider refresh) over its state-driven body. Shared by the
+ * single-provider tab (`variant="popover-detail"`, full detail) and each
+ * Overview entry (`variant="popover-overview"`, condensed). The plan/tier
+ * chip (`resolveProviderPlanLabel`) is single-provider-tab only, same scoping
+ * Overview already applies to every other detail field; the rest of the
+ * header renders identically across both variants.
+ *
+ * `onReady` fires once (and again on every later state change, harmlessly -
+ * the callback is expected to be idempotent) `state.kind` moves past `cold`,
+ * so `RateLimitOverview` can reveal this block in place instead of painting
+ * it as a blank/loading section from mount. `null` on the single-provider
+ * detail tab, which always renders regardless of state.
+ */
+function RateLimitProviderBlock({
+  providerId,
+  variant,
+  onReady,
+}: {
+  readonly providerId: RateLimitProviderId;
+  readonly variant: PopoverBlockVariant;
+  readonly onReady: (() => void) | null;
+}): ReactNode {
+  const query = useHostProviderRateLimitsQuery(providerId);
+  // Single source of truth for this provider's refresh action + spinner state
+  // (fresh-on-open, queue routing, and the ephemeralProcess `draining` fold-in),
+  // shared verbatim with the Settings card so they can't drift apart.
+  const { refresh, isRefreshing } = useProviderRateLimitRefresh(
+    providerId,
+    query.isFetching,
+    query.refetch,
+  );
+  const queryState: ProviderRateLimitQueryState = {
+    isPending: query.isPending,
+    isFetching: isRefreshing,
+    isError: query.isError,
+    providerRateLimits: query.data?.providerRateLimits,
+  };
+  const state = resolvePopoverProviderRateLimitState(queryState);
+  useEffect(() => {
+    if (state.kind !== "cold" && onReady !== null) onReady();
+  }, [state.kind, onReady]);
+
+  // Chip next to the name, single-provider tab only (Overview stays
+  // condensed - same scoping the plan/tier line used before it moved into
+  // this header). `null` for a provider that doesn't report a plan/tier
+  // (`resolveProviderPlanLabel`), so no chip renders for e.g. OpenRouter.
+  const planLabel =
+    variant === "popover-detail" && state.kind === "ready"
+      ? resolveProviderPlanLabel(state.data)
+      : null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          {/* Overview stacks every provider's block in one scrollable list with
+              no rail-tab context alongside it, so the name alone doesn't say
+              which provider this is; the single-provider detail tab already has
+              that context from its selected rail icon. */}
+          {variant === "popover-overview" ? (
+            <HarnessIcon harnessId={providerIdToGuiHarnessId(providerId)} />
+          ) : null}
+          <span className="text-ui-sm font-medium text-foreground">
+            {providerDisplayName(providerId)}
+          </span>
+          {planLabel !== null ? (
+            <Badge variant="secondary" className="font-normal">
+              {planLabel}
+            </Badge>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <UsageLimitUpdatedLabel
+            ready={state.kind === "ready"}
+            updatedAt={query.dataUpdatedAt}
+            refreshing={isRefreshing}
+            degraded={state.kind === "ready" && state.degraded}
+          />
+          {/* Overview has its own "Refresh all" on the rail (item 2 feedback:
+              a per-provider icon there was redundant); only the single-provider
+              detail tab keeps this one. */}
+          {variant === "popover-detail" ? (
+            <RefreshIconButton
+              onRefresh={refresh}
+              label={`Refresh ${providerDisplayName(providerId)}`}
+              // `isRefreshing` (from useProviderRateLimitRefresh) already folds
+              // in the ephemeralProcess `draining` flag, so this button stays
+              // disabled for a "Refresh all" round's full duration, not just
+              // this provider's own slice of it.
+              refreshing={isRefreshing}
+            />
+          ) : null}
+        </div>
+      </div>
+      <RateLimitProviderBody state={state} variant={variant} />
+    </div>
+  );
+}
+
+/**
+ * "Updated Xm ago", only once a reading actually exists - and "· refresh
+ * failed" appended when a last-known-good reading is being shown after a failed
+ * poll (Core Flows degraded state).
+ */
+function UsageLimitUpdatedLabel({
+  ready,
+  updatedAt,
+  refreshing,
+  degraded,
+}: {
+  readonly ready: boolean;
+  readonly updatedAt: number;
+  readonly refreshing: boolean;
+  readonly degraded: boolean;
+}): ReactNode {
+  if (!ready) return null;
+  if (refreshing) return <RefreshingText />;
+  if (updatedAt === 0) return null;
+  return <UpdatedAgoText updatedAt={updatedAt} degraded={degraded} />;
+}
+
+function RefreshingText(): ReactNode {
+  return (
+    <span className="inline-flex items-baseline gap-1 text-ui-xs text-muted-foreground">
+      <span className="working-text-shimmer text-ui-xs">Refreshing</span>
+      <RefreshingWorkingDots />
+    </span>
+  );
+}
+
+function RefreshingWorkingDots(): ReactNode {
+  return (
+    <span
+      aria-hidden="true"
+      className="working-dots text-current"
+      data-testid="usage-limit-refreshing-dots"
+    >
+      <span />
+      <span />
+      <span />
+    </span>
+  );
+}
+
+function UpdatedAgoText({
+  updatedAt,
+  degraded,
+}: {
+  readonly updatedAt: number;
+  readonly degraded: boolean;
+}): ReactNode {
+  const ago = useRelativeTimestamp(updatedAt);
+  return (
+    <span className="text-ui-xs text-muted-foreground">
+      {degraded ? `Updated ${ago} · refresh failed` : `Updated ${ago}`}
+    </span>
+  );
+}
+
+function RateLimitProviderBody({
+  state,
+  variant,
+}: {
+  readonly state: PopoverProviderRateLimitState;
+  readonly variant: PopoverBlockVariant;
+}): ReactNode {
+  switch (state.kind) {
+    case "cold":
+      return <RateLimitDetailSkeleton />;
+    case "error":
+      return (
+        <RateLimitErrorMessage message="Couldn't load usage limits right now." />
+      );
+    case "unavailable":
+      return (
+        <RateLimitErrorMessage
+          message={`Usage limits unavailable — ${formatUnavailableReason(state.reason)}`}
+        />
+      );
+    case "ready":
+      // Degraded (stale, latest poll failed): dim the reading in place rather
+      // than replacing it with an error (Core Flows).
+      return (
+        <div className={cn(state.degraded && "opacity-60")}>
+          <ProviderRateLimitDetail data={state.data} variant={variant} />
+        </div>
+      );
+  }
+}
+
+/**
+ * The synthetic "Traycer" block - the GUI-sourced analogue of
+ * `RateLimitProviderBlock`. Its data is the signed-in user's subscription
+ * (`useAuthUser`) for the globally-selected account (`useAccountContextStore`),
+ * NOT a `host.getRateLimitUsage` provider pull. Header mirrors the provider
+ * blocks (name + plan/tier chip + "Updated Xm ago" + refresh) - the chip
+ * (`subscriptionPlanLabel`) reflects whichever account is currently selected
+ * and is single-provider-tab only, same scoping
+ * `RateLimitProviderBlock` applies to its own plan chip; the detail variant
+ * adds the same Personal/Team picker the Settings card uses, so switching
+ * accounts here updates the global selection (and therefore Overview, the
+ * Settings card, and what a Traycer run bills). Both variants render through
+ * the shared `TraycerSubscriptionView`. `onReady` mirrors
+ * `RateLimitProviderBlock`'s own - fires once `state.kind` moves past `cold`,
+ * `null` on the single-provider detail tab.
+ */
+function TraycerRateLimitBlock({
+  variant,
+  onReady,
+}: {
+  readonly variant: PopoverBlockVariant;
+  readonly onReady: (() => void) | null;
+}): ReactNode {
+  const query = useAuthUser();
+  const storedAccountContext = useAccountContextStore((s) => s.accountContext);
+  const setAccountContext = useAccountContextStore((s) => s.setAccountContext);
+  const queryClient = useQueryClient();
+  const hostId = useReactiveActiveHostId();
+
+  const user = query.data ?? null;
+  const teams = user?.teamSubscriptions ?? [];
+  const teamIds = new Set(teams.map((team) => team.team.id));
+  const resolved = resolveAccountContext(storedAccountContext, teamIds);
+  const subscription = selectSubscription(user, resolved, teams);
+  const state = resolveTraycerSubscriptionState({
+    isPending: query.isPending,
+    isError: query.isError,
+    subscription,
+  });
+  useEffect(() => {
+    if (state.kind !== "cold" && onReady !== null) onReady();
+  }, [state.kind, onReady]);
+
+  const overview = variant === "popover-overview";
+  const rateLimitBased =
+    subscription !== null &&
+    !isCreditBasedPricing(subscription.subscriptionStatus);
+  // Chip next to the name, single-provider tab only - same scoping
+  // `resolveProviderPlanLabel` uses for the host-RPC providers' plan chip.
+  // Reflects whichever account (personal/team) is currently selected, since
+  // `subscription` is already resolved against that selection.
+  const planLabel =
+    !overview && subscription !== null
+      ? subscriptionPlanLabel(subscription.subscriptionStatus)
+      : null;
+
+  // Refetch the subscription, and - only for rate-limit-based plans, whose
+  // aperture bar is live host data - invalidate that exact query so the mounted
+  // `RateLimitView` refetches it too. `exact: true` targets only the aperture
+  // `{ accountContext }` key, never the providers' `{ accountContext, providerId }`
+  // pulls (which a Traycer refresh can't have changed).
+  const refresh = async (): Promise<void> => {
+    await query.refetch();
+    if (rateLimitBased) {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.hostMethod<
+          HostRpcRegistry,
+          "host.getRateLimitUsage"
+        >(hostId, "host.getRateLimitUsage", {
+          accountContext: storedAccountContext,
+        }),
+        exact: true,
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-1.5">
+          {overview ? (
+            <HarnessIcon harnessId={providerIdToGuiHarnessId("traycer")} />
+          ) : null}
+          <span className="text-ui-sm font-medium text-foreground">
+            {providerDisplayName("traycer")}
+          </span>
+          {planLabel !== null ? (
+            <Badge variant="secondary" className="font-normal">
+              {planLabel}
+            </Badge>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <UsageLimitUpdatedLabel
+            ready={state.kind === "ready"}
+            updatedAt={query.dataUpdatedAt}
+            refreshing={query.isFetching}
+            degraded={state.kind === "ready" && state.degraded}
+          />
+          {/* Overview has its own "Refresh all" on the rail (item 2 feedback);
+              only the single-provider detail tab keeps this one. */}
+          {!overview ? (
+            <RefreshIconButton
+              onRefresh={refresh}
+              label={`Refresh ${providerDisplayName("traycer")}`}
+              refreshing={query.isFetching}
+            />
+          ) : null}
+        </div>
+      </div>
+      {/* Detail tab only: the account picker, matching the Settings card. Renders
+          nothing when the user has no teams. Overview just reflects the global
+          selection with no controls, like every other Overview block. */}
+      {!overview ? (
+        <TraycerAccountSelect
+          teams={teams}
+          value={accountContextValue(resolved)}
+          onValueChange={(value) =>
+            setAccountContext(parseAccountContextValue(value))
+          }
+        />
+      ) : null}
+      <TraycerRateLimitBody state={state} />
+    </div>
+  );
+}
+
+function TraycerRateLimitBody({
+  state,
+}: {
+  readonly state: TraycerSubscriptionState;
+}): ReactNode {
+  switch (state.kind) {
+    case "cold":
+      return <RateLimitDetailSkeleton />;
+    case "error":
+      return (
+        <RateLimitErrorMessage message="Couldn't load your Traycer subscription right now." />
+      );
+    case "empty":
+      return (
+        <p className="text-ui-xs text-muted-foreground">
+          No subscription found for this account.
+        </p>
+      );
+    case "ready":
+      return (
+        <div className={cn(state.degraded && "opacity-60")}>
+          <TraycerSubscriptionView subscription={state.subscription} />
+        </div>
+      );
+  }
+}
+
+// No inline retry action here - the block's own header refresh icon (detail
+// tab) or the rail's "Refresh all" (Overview) already covers it, so a second
+// retry control right below the message would just be a redundant control
+// for the same action.
+function RateLimitErrorMessage({
+  message,
+}: {
+  readonly message: string;
+}): ReactNode {
+  return <p className="text-ui-xs text-muted-foreground">{message}</p>;
+}
+
+/**
+ * Cold load (first open this session, no data yet): skeleton bars previewing
+ * the eventual window layout, not a spinner replacing the panel (Core Flows -
+ * a deliberate difference from the Settings card's spinner).
+ *
+ * Each block overrides `Skeleton`'s default `bg-muted` fill with
+ * `bg-foreground/15`, same reasoning as `MeterRow`'s track: several dark
+ * theme presets set `--muted` equal to `--popover`, so a plain `bg-muted`
+ * skeleton can end up the same color as the popover background and read as
+ * an empty section instead of a loading one. An opacity overlay on
+ * `--foreground` contrasts against any background without needing a border.
+ */
+function RateLimitDetailSkeleton(): ReactNode {
+  return (
+    <div
+      className="flex flex-col gap-3"
+      data-testid="rate-limit-detail-skeleton"
+    >
+      {[0, 1].map((row) => (
+        <div key={row} className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-3 w-16 bg-foreground/15" />
+            <Skeleton className="h-3 w-10 bg-foreground/15" />
+          </div>
+          <Skeleton className="h-1.5 w-full rounded-full bg-foreground/15" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Zero-provider state (Core Flows): no rail, no tabs - a single CTA linking to
+ * Settings › Providers, since there's nothing yet to switch between.
+ */
+function RateLimitZeroState({
+  onClose,
+}: {
+  readonly onClose: () => void;
+}): ReactNode {
+  const { openSettings } = useSystemTabModalActions();
+  const openProviderSettings = (): void => {
+    onClose();
+    openSettings({ section: "providers", resetToGeneral: false });
+  };
+  return (
+    <div className="flex flex-col items-start gap-3 p-4">
+      <p className="text-ui-sm text-muted-foreground">
+        Connect Claude Code or Codex to see usage here.
+      </p>
+      <button
+        type="button"
+        onClick={openProviderSettings}
+        className="inline-flex items-center gap-1.5 rounded-md bg-accent px-2.5 py-1.5 text-ui-xs font-medium text-foreground outline-none transition-colors hover:bg-accent/80 focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        Open provider settings
+      </button>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
@@ -93,22 +93,22 @@ const NODE_META: Readonly<
 };
 
 const TASKS = [
-  "Team rate limits",
+  "Team usage limits",
   "Billing service",
   "Usage sync audit",
 ] as const;
 
 const TASK_SCENES = [
   {
-    chat: "Team rate limits",
+    chat: "Team usage limits",
     terminal: "billing-service run",
     terminalHarness: "claude",
     secondChat: "Grace-period plan",
-    spec: "rate-limits.spec",
+    spec: "usage-limits.spec",
     ticket: "Grace-period rollout",
     review: "Risk review",
-    canvas: "Team rate limits",
-    preview: "rate-limits.spec",
+    canvas: "Team usage limits",
+    preview: "usage-limits.spec",
   },
   {
     chat: "Billing service",
@@ -195,7 +195,7 @@ const STORY_STEPS = [
   {
     pane: "gui",
     kind: "user",
-    text: "We need team rate limits without locking existing customers out.",
+    text: "We need team usage limits without locking existing customers out.",
     to: null,
   },
   {
@@ -204,14 +204,14 @@ const STORY_STEPS = [
     text: "I'll split this into implementation, verification, and risk review.",
     to: null,
   },
-  { pane: "gui", kind: "spec", text: "rate-limits.spec", to: null },
+  { pane: "gui", kind: "spec", text: "usage-limits.spec", to: null },
   {
     pane: "gui",
     kind: "handoff",
-    text: "Claude Code, implement the billing-service check from rate-limits.spec.",
+    text: "Claude Code, implement the billing-service check from usage-limits.spec.",
     to: "claude",
   },
-  { pane: "claude", kind: "term", text: "reading rate-limits.spec", to: null },
+  { pane: "claude", kind: "term", text: "reading usage-limits.spec", to: null },
   {
     pane: "claude",
     kind: "blocked",
@@ -1129,7 +1129,7 @@ function ChatPane(props: {
   const userCopy =
     props.scene === "task-tabs"
       ? `Continue ${TASKS[props.activeTaskIndex].toLowerCase()}`
-      : "Let's ship team rate limits.";
+      : "Let's ship team usage limits.";
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex min-h-0 flex-1 flex-col justify-end gap-2 p-3">

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -202,7 +202,7 @@ codeFontSize` in muted styling while `null`; any tick/type pins an
     pay-as-you-go). Each bar is shown only when that bucket's total > 0; amounts
     are `$`-denominated. Credit-based vs rate-limit-based is decided exactly like
     the extension (`isCreditBasedPricing` - V3 plans are credit-based); **legacy /
-    v2 (rate-limit) plans** instead render a **Rate limit** section with the
+    v2 (usage-limit) plans** instead render a **Usage limit** section with the
     recharge rate ("New artifact every N minutes", from `rechargeRateSeconds`)
     plus the Bundle bar. The extension's live "Artifact Used" bar is omitted -
     `totalTokens`/`remainingTokens` come from the inference `GetRateLimitUsage`

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
@@ -1,0 +1,303 @@
+import "../../../../../__tests__/test-browser-apis";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderRateLimits } from "@traycer/protocol/host";
+import { formatResetDateTime } from "@/lib/relative-time";
+
+const mocks = vi.hoisted(() => ({
+  data: undefined as
+    { providerRateLimits: ProviderRateLimits | null } | undefined,
+  isPending: false,
+  isError: false,
+  isFetching: false,
+  refetch: vi.fn(() => Promise.resolve({})),
+  draining: false,
+  enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
+}));
+
+vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
+  useHostProviderRateLimitsQuery: () => ({
+    data: mocks.data,
+    isPending: mocks.isPending,
+    isError: mocks.isError,
+    isFetching: mocks.isFetching,
+    refetch: mocks.refetch,
+  }),
+}));
+vi.mock("@/hooks/host/use-refresh-provider-rate-limits-on-turn", () => ({
+  useRefreshProviderRateLimitsOnTurn: () => {},
+}));
+vi.mock("@/hooks/host/use-refresh-provider-rate-limits-on-mount", () => ({
+  useRefreshProviderRateLimitsOnMount: () => {},
+}));
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-1",
+}));
+vi.mock("@/hooks/rate-limits/use-is-rate-limit-queue-draining", () => ({
+  useIsRateLimitQueueDraining: () => mocks.draining,
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  enqueueRateLimitFetch: (...args: unknown[]) => mocks.enqueue(...args),
+}));
+
+import { ProviderRateLimitForProvider } from "../provider-rate-limit-section";
+
+const CLAUDE_FIVE_HOUR_RESETS_AT = Date.now() + 60 * 60 * 1000;
+const CLAUDE_SEVEN_DAY_RESETS_AT = Date.now() + 2 * 24 * 60 * 60 * 1000;
+
+const CLAUDE_RATE_LIMITS: ProviderRateLimits = {
+  provider: "claude-code",
+  available: true,
+  // The SDK reports this as a lowercase token ("max"), but the settings card
+  // no longer shows it - the provider auth badge above already does.
+  subscriptionType: "max",
+  fiveHour: {
+    usedPercent: 12,
+    resetsAt: CLAUDE_FIVE_HOUR_RESETS_AT,
+    durationMinutes: 300,
+  },
+  sevenDay: {
+    usedPercent: 55,
+    resetsAt: CLAUDE_SEVEN_DAY_RESETS_AT,
+    durationMinutes: 10080,
+  },
+  sevenDayOpus: null,
+  sevenDaySonnet: null,
+  modelScoped: [],
+  extraUsage: null,
+};
+
+const CODEX_PRIMARY_RESETS_AT = Date.now() + 3 * 60 * 60 * 1000;
+const CODEX_SECONDARY_RESETS_AT = Date.now() + 4 * 24 * 60 * 60 * 1000;
+const CODEX_SPEND_LIMIT_RESETS_AT = Date.now() + 5 * 24 * 60 * 60 * 1000;
+
+const CODEX_RATE_LIMITS: ProviderRateLimits = {
+  provider: "codex",
+  available: true,
+  // Real Codex `PlanType` values are lowercase tokens ("plus"), but the
+  // settings card no longer shows it - the provider auth badge above
+  // already does.
+  planType: "plus",
+  limitId: null,
+  limitName: null,
+  primary: {
+    usedPercent: 42,
+    resetsAt: CODEX_PRIMARY_RESETS_AT,
+    durationMinutes: 300,
+  },
+  secondary: {
+    usedPercent: 80,
+    resetsAt: CODEX_SECONDARY_RESETS_AT,
+    durationMinutes: 10080,
+  },
+  extraWindows: [],
+  credits: {
+    hasCredits: true,
+    unlimited: false,
+    balance: "$12.50",
+  },
+  individualLimit: {
+    limit: "100.00",
+    used: "42.00",
+    remainingPercent: 58,
+    resetsAt: CODEX_SPEND_LIMIT_RESETS_AT,
+  },
+  resetCredits: null,
+  rateLimitReachedType: "rate_limit_reached",
+};
+
+describe("ProviderRateLimitForProvider", () => {
+  beforeEach(() => {
+    mocks.data = undefined;
+    mocks.isPending = false;
+    mocks.isError = false;
+    mocks.isFetching = false;
+    mocks.draining = false;
+    mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing for a provider without native usage limits", () => {
+    const { container } = render(
+      <ProviderRateLimitForProvider providerId="traycer" />,
+    );
+    expect(container.firstChild).toBe(null);
+  });
+
+  it("renders the card with a loading state before data arrives", () => {
+    mocks.isPending = true;
+    mocks.isFetching = true;
+    render(<ProviderRateLimitForProvider providerId="claude-code" />);
+    expect(screen.getByText("Usage limits")).toBeTruthy();
+    expect(screen.getByText("Loading usage limits")).toBeTruthy();
+  });
+
+  it("renders nothing (not an eternal spinner) while pending but not fetching", () => {
+    // A query that's `enabled: false` (e.g. an unreachable host) stays
+    // `isPending: true` forever without ever fetching - the card must not
+    // show a permanent loading spinner for that state.
+    mocks.isPending = true;
+    mocks.isFetching = false;
+    render(<ProviderRateLimitForProvider providerId="claude-code" />);
+    expect(screen.getByText("Usage limits")).toBeTruthy();
+    expect(screen.queryByText("Loading usage limits")).toBeNull();
+  });
+
+  it("renders the Claude Code rate-limit detail once loaded", () => {
+    mocks.data = { providerRateLimits: CLAUDE_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="claude-code" />);
+
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("12% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("55% used")).toBeTruthy();
+  });
+
+  it("does not show a subscription-plan badge (the provider auth badge above already shows it)", () => {
+    mocks.data = { providerRateLimits: CLAUDE_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="claude-code" />);
+    expect(screen.queryByText("Max")).toBeNull();
+  });
+
+  it("shows an exact reset date/time for the weekly window, and a relative countdown for the 5-hour one", () => {
+    mocks.data = { providerRateLimits: CLAUDE_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="claude-code" />);
+
+    expect(
+      screen.getByText(
+        `Resets ${formatResetDateTime(CLAUDE_SEVEN_DAY_RESETS_AT)}`,
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText(/^Resets in /)).toBeTruthy();
+  });
+
+  it("colors a window's bar yellow at/above 60% used and red above 85% used", () => {
+    // The Settings card now shares the same four-tier severity scale as the
+    // popover (item 6 feedback: "different UX looks weird").
+    mocks.data = {
+      providerRateLimits: {
+        ...CLAUDE_RATE_LIMITS,
+        fiveHour: {
+          usedPercent: 75,
+          resetsAt: CLAUDE_FIVE_HOUR_RESETS_AT,
+          durationMinutes: 300,
+        },
+        sevenDay: {
+          usedPercent: 95,
+          resetsAt: CLAUDE_SEVEN_DAY_RESETS_AT,
+          durationMinutes: 10080,
+        },
+      },
+    };
+    const { container } = render(
+      <ProviderRateLimitForProvider providerId="claude-code" />,
+    );
+
+    expect(container.querySelectorAll(".bg-yellow-500").length).toBeGreaterThan(
+      0,
+    );
+    expect(container.querySelectorAll(".bg-red-500").length).toBeGreaterThan(0);
+  });
+
+  it("keeps the bar blue below the yellow threshold", () => {
+    mocks.data = { providerRateLimits: CLAUDE_RATE_LIMITS };
+    const { container } = render(
+      <ProviderRateLimitForProvider providerId="claude-code" />,
+    );
+
+    expect(container.querySelectorAll(".bg-yellow-500").length).toBe(0);
+    expect(container.querySelectorAll(".bg-red-500").length).toBe(0);
+    expect(container.querySelectorAll(".bg-blue-500").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("renders the Codex rate-limit detail once loaded", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("42% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("80% used")).toBeTruthy();
+  });
+
+  it("maps a rateLimitReachedType token to a destructive badge", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    expect(screen.getByText("Usage limit reached")).toBeTruthy();
+  });
+
+  it("does not show a plan badge (the provider auth badge above already shows it)", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    expect(screen.queryByText("Plus")).toBeNull();
+  });
+
+  it("renders the credits row", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    expect(screen.getByText("Credits")).toBeTruthy();
+    expect(screen.getByText("$12.50")).toBeTruthy();
+  });
+
+  it("renders the spend-control row with used/limit and an absolute reset time", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    // Scoped to the spend-limit row's own container: the current-session
+    // window above it also renders a reset line, so an unscoped query would
+    // match two elements.
+    const spendLimitRow = screen
+      .getByText("Spend limit")
+      .closest("div.flex.flex-col.gap-1");
+    expect(spendLimitRow).not.toBeNull();
+    const spendLimitScope = within(spendLimitRow as HTMLElement);
+    expect(spendLimitScope.getByText("42.00 / 100.00")).toBeTruthy();
+    // Regression: `CodexSpendControlRow` used to hardcode `weekly={false}`,
+    // always forcing a relative countdown regardless of the real reset time.
+    // `CODEX_SPEND_LIMIT_RESETS_AT` is 5 days out, so the reset line now
+    // correctly reads as an absolute weekday/time, not "Resets in ...".
+    expect(
+      spendLimitScope.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
+    ).toBeTruthy();
+    expect(spendLimitScope.queryByText(/^Resets in /)).toBeNull();
+  });
+
+  it("routes a Codex (ephemeralProcess) manual refresh through the shared queue with force:true, not a bare query.refetch()", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh usage limits" }),
+    );
+
+    expect(mocks.enqueue).toHaveBeenCalledWith("codex", expect.anything(), {
+      force: true,
+    });
+    expect(mocks.refetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps the refresh button disabled while the shared queue is draining, even once this provider's own isFetching has settled", () => {
+    mocks.data = { providerRateLimits: CODEX_RATE_LIMITS };
+    mocks.isFetching = false;
+    mocks.draining = true;
+    render(<ProviderRateLimitForProvider providerId="codex" />);
+
+    expect(
+      screen.getByRole("button", { name: "Refresh usage limits" }),
+    ).toHaveProperty("disabled", true);
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -1,0 +1,441 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ProviderRateLimits } from "@traycer/protocol/host";
+import {
+  ClaudeRateLimitView,
+  CodexRateLimitView,
+  KiloCodeRateLimitView,
+  OpenRouterRateLimitView,
+  ProviderRateLimitDetail,
+} from "../provider-rate-limit-views";
+
+type CodexRateLimits = Extract<ProviderRateLimits, { provider: "codex" }>;
+type ClaudeRateLimits = Extract<
+  ProviderRateLimits,
+  { provider: "claude-code" }
+>;
+type OpenRouterRateLimits = Extract<
+  ProviderRateLimits,
+  { provider: "openrouter" }
+>;
+type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
+
+const NOW = Date.now();
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CodexRateLimitView (extended fields)", () => {
+  const codex: CodexRateLimits = {
+    provider: "codex",
+    available: true,
+    planType: "pro_5x",
+    limitId: "base",
+    limitName: null,
+    primary: {
+      usedPercent: 4,
+      resetsAt: NOW + 60 * 60 * 1000,
+      durationMinutes: 300,
+    },
+    secondary: {
+      usedPercent: 68,
+      resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+      durationMinutes: 10080,
+    },
+    extraWindows: [
+      {
+        limitId: "gpt5",
+        limitName: "GPT-5",
+        primary: {
+          usedPercent: 20,
+          resetsAt: NOW + 2 * 60 * 60 * 1000,
+          durationMinutes: 300,
+        },
+        secondary: null,
+      },
+    ],
+    credits: null,
+    individualLimit: null,
+    resetCredits: { availableCount: 3 },
+    rateLimitReachedType: null,
+  };
+
+  it("labels windows from their real duration (not a hardcoded 5-hour/Weekly)", () => {
+    render(<CodexRateLimitView data={codex} variant="settings" />);
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("68% used")).toBeTruthy();
+  });
+
+  it("never renders the plan/tier label itself - the header popover owns that chip", () => {
+    // `resolveProviderPlanLabel` (provider-rate-limit-content.test.ts) covers the
+    // planType -> "Pro 5x" mapping; the popover header's own test coverage
+    // (rate-limit-popover.test.tsx) covers the chip actually rendering.
+    render(<CodexRateLimitView data={codex} variant="popover-detail" />);
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+  });
+
+  it("renders each extraWindow as its own labeled row (limit name + duration)", () => {
+    render(<CodexRateLimitView data={codex} variant="settings" />);
+    expect(screen.getByText("GPT-5 · Current session")).toBeTruthy();
+    expect(screen.getByText("20% used")).toBeTruthy();
+  });
+
+  it("renders the manual reset-credits block", () => {
+    render(<CodexRateLimitView data={codex} variant="settings" />);
+    expect(screen.getByText("Manual resets")).toBeTruthy();
+    expect(screen.getByText("3 available")).toBeTruthy();
+  });
+
+  it("renders a generic day/hour duration for an off-standard window", () => {
+    render(
+      <CodexRateLimitView
+        data={{
+          ...codex,
+          limitName: null,
+          extraWindows: [],
+          primary: {
+            usedPercent: 4,
+            resetsAt: NOW + 60 * 60 * 1000,
+            durationMinutes: 360,
+          },
+          secondary: {
+            usedPercent: 68,
+            resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+            durationMinutes: 30 * 24 * 60,
+          },
+        }}
+        variant="settings"
+      />,
+    );
+    expect(screen.getByText("6h")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("30d")).toBeTruthy();
+    expect(screen.getByText("68% used")).toBeTruthy();
+  });
+
+  it("renders the popover variant as '% used' with a four-tier bar color", () => {
+    const { container } = render(
+      <CodexRateLimitView data={codex} variant="popover-detail" />,
+    );
+    // primary 4% used -> blue tier; secondary 68% used -> yellow tier.
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("68% used")).toBeTruthy();
+    expect(container.querySelectorAll(".bg-blue-500").length).toBeGreaterThan(
+      0,
+    );
+    expect(container.querySelectorAll(".bg-yellow-500").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("draws every popover window track with a foreground-opacity fill so an empty bar stays visible", () => {
+    // Regression (Issue 3): several dark presets set --muted == --popover, so
+    // a `bg-muted` track vanished at 0% fill. The track now fills with
+    // `bg-foreground/15` instead, which contrasts against any background
+    // regardless of theme - a 0%-used window must still show a visible,
+    // empty track, with no border needed to keep it that way.
+    const { container } = render(
+      <CodexRateLimitView
+        data={{
+          ...codex,
+          secondary: null,
+          extraWindows: [],
+          resetCredits: null,
+          primary: {
+            usedPercent: 0,
+            resetsAt: NOW + 60 * 60 * 1000,
+            durationMinutes: 300,
+          },
+        }}
+        variant="popover-detail"
+      />,
+    );
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("0% used")).toBeTruthy();
+    const tracks = container.querySelectorAll(".bg-foreground\\/15");
+    expect(tracks.length).toBeGreaterThan(0);
+  });
+
+  it("shows a relative countdown for a short popover window", () => {
+    // Fixup C #1: the popover reverts to the same relative-for-short /
+    // exact-for-weekly split as the Settings card. `primary` is a 5h window, so
+    // it reads as a relative countdown ("Resets in 4h 7m"), not an absolute date.
+    render(
+      <CodexRateLimitView
+        data={{ ...codex, secondary: null, extraWindows: [] }}
+        variant="popover-detail"
+      />,
+    );
+    expect(screen.getByText(/^Resets in /)).toBeTruthy();
+    expect(screen.queryByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}/)).toBeNull();
+  });
+
+  it("shows an absolute weekday-tagged time for a weekly popover window", () => {
+    // The weekly (10080-min) `secondary` window keeps the absolute reset line
+    // ("Resets Sat 3:35 AM"), since "Resets in 3d" is too coarse.
+    render(
+      <CodexRateLimitView
+        data={{ ...codex, primary: null, extraWindows: [] }}
+        variant="popover-detail"
+      />,
+    );
+    expect(
+      screen.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/^Resets in /)).toBeNull();
+  });
+
+  it("condenses the popover Overview to only the 5h/Weekly windows (credits dropped)", () => {
+    // Item 3 feedback: Overview drops Credits too, along with per-model
+    // extraWindows, the reset-credits block, and the plan label; it keeps only
+    // the primary/secondary windows.
+    render(
+      <CodexRateLimitView
+        data={{
+          ...codex,
+          credits: { unlimited: true, hasCredits: true, balance: null },
+        }}
+        variant="popover-overview"
+      />,
+    );
+    // Kept: primary (4% used) + secondary (68% used) windows.
+    expect(screen.getByText("Current session")).toBeTruthy();
+    expect(screen.getByText("4% used")).toBeTruthy();
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("68% used")).toBeTruthy();
+    // Dropped: plan label, per-model extraWindow row, reset-credits block, and
+    // Credits.
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+    expect(screen.queryByText("GPT-5 · Current session")).toBeNull();
+    expect(screen.queryByText("Manual resets")).toBeNull();
+    expect(screen.queryByText("Credits")).toBeNull();
+  });
+});
+
+describe("ClaudeRateLimitView", () => {
+  it("shows an absolute weekday-tagged time for a far per-model reset, even though modelScoped carries no durationMinutes", () => {
+    // Regression: `modelScoped` entries never carry a `durationMinutes` (the
+    // SDK's per-model usage has no separate duration field), so a
+    // duration-based "is this weekly-scale" check always fell back to the
+    // relative countdown for these rows, no matter how far away the real
+    // reset was ("Fable" usage showed "Resets in 3d" instead of "Resets Tue
+    // 5:29 PM"). The reset-format decision is now based on the real
+    // `resetsAt` delta instead, so a 3-day-out per-model reset gets the same
+    // absolute treatment a weekly window does.
+    const claude: ClaudeRateLimits = {
+      provider: "claude-code",
+      available: true,
+      subscriptionType: "max",
+      fiveHour: null,
+      sevenDay: null,
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      modelScoped: [
+        {
+          displayName: "Fable",
+          usedPercent: 12,
+          resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+          durationMinutes: null,
+        },
+      ],
+      extraUsage: null,
+    };
+    render(<ClaudeRateLimitView data={claude} variant="settings" />);
+    expect(screen.getByText("Fable")).toBeTruthy();
+    expect(
+      screen.getByText(/^Resets [A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/^Resets in /)).toBeNull();
+  });
+
+  it("sets the model-scoped rows off with a divider, not a 'Per-model' heading", () => {
+    // Same header-less group treatment CodexRateLimitView gives its per-model
+    // (Spark) extraWindows: the rows' own display names already say which
+    // model each is, so the group gets a hairline divider instead of a label.
+    const claude: ClaudeRateLimits = {
+      provider: "claude-code",
+      available: true,
+      subscriptionType: "max",
+      fiveHour: {
+        usedPercent: 12,
+        resetsAt: NOW + 60 * 60 * 1000,
+        durationMinutes: 300,
+      },
+      sevenDay: {
+        usedPercent: 55,
+        resetsAt: NOW + 2 * 24 * 60 * 60 * 1000,
+        durationMinutes: 10080,
+      },
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      modelScoped: [
+        {
+          displayName: "Fable",
+          usedPercent: 12,
+          resetsAt: NOW + 3 * 24 * 60 * 60 * 1000,
+          durationMinutes: null,
+        },
+      ],
+      extraUsage: null,
+    };
+    const { container } = render(
+      <ClaudeRateLimitView data={claude} variant="settings" />,
+    );
+    expect(screen.queryByText("Per-model")).toBeNull();
+    // Exactly one divider: between the fixed windows and the model-scoped
+    // group (extraUsage is null, so no second one).
+    expect(container.querySelectorAll('[class*="bg-border/70"]').length).toBe(
+      1,
+    );
+    expect(screen.getByText("Fable")).toBeTruthy();
+  });
+
+  it("renders no divider when only the fixed windows are present", () => {
+    const claude: ClaudeRateLimits = {
+      provider: "claude-code",
+      available: true,
+      subscriptionType: "max",
+      fiveHour: {
+        usedPercent: 12,
+        resetsAt: NOW + 60 * 60 * 1000,
+        durationMinutes: 300,
+      },
+      sevenDay: null,
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      modelScoped: [],
+      extraUsage: null,
+    };
+    const { container } = render(
+      <ClaudeRateLimitView data={claude} variant="settings" />,
+    );
+    expect(container.querySelectorAll('[class*="bg-border/70"]').length).toBe(
+      0,
+    );
+  });
+});
+
+describe("OpenRouterRateLimitView", () => {
+  const openRouter: OpenRouterRateLimits = {
+    provider: "openrouter",
+    available: true,
+    limit: 100,
+    limitRemaining: 40,
+    dailySpend: 5,
+    weeklySpend: 12,
+    monthlySpend: 30,
+    totalCredits: 100,
+    totalUsage: 60,
+    balance: 40,
+  };
+
+  it("renders a usage bar from limit/limitRemaining", () => {
+    render(<OpenRouterRateLimitView data={openRouter} variant="settings" />);
+    expect(screen.getByText("Credits")).toBeTruthy();
+    expect(screen.getByText("$60.00 / $100.00")).toBeTruthy();
+  });
+
+  it("renders the uncapped spend/credit figures as plain rows", () => {
+    render(<OpenRouterRateLimitView data={openRouter} variant="settings" />);
+    expect(screen.getByText("Balance")).toBeTruthy();
+    expect(screen.getByText("Spent this month")).toBeTruthy();
+    expect(screen.getByText("$30.00")).toBeTruthy();
+  });
+
+  it("omits the bar when there is no hard limit", () => {
+    render(
+      <OpenRouterRateLimitView
+        data={{ ...openRouter, limit: null, limitRemaining: null }}
+        variant="settings"
+      />,
+    );
+    expect(screen.queryByText("Credits")).toBeNull();
+    // The uncapped figures still render.
+    expect(screen.getByText("Balance")).toBeTruthy();
+  });
+
+  it("condenses the Overview to only the Credits bar and Balance", () => {
+    // Issue 2d: Overview keeps the balance-shaped fields, drops the total /
+    // per-period spend rows.
+    render(
+      <OpenRouterRateLimitView data={openRouter} variant="popover-overview" />,
+    );
+    expect(screen.getByText("Credits")).toBeTruthy();
+    expect(screen.getByText("Balance")).toBeTruthy();
+    expect(screen.queryByText("Spent this month")).toBeNull();
+    expect(screen.queryByText("Total credits")).toBeNull();
+  });
+});
+
+describe("KiloCodeRateLimitView", () => {
+  const kilo: KiloCodeRateLimits = {
+    provider: "kilocode",
+    available: true,
+    creditBalance: 25.5,
+    passState: "active",
+  };
+
+  it("renders the credit balance and pass state as plain rows (no bar)", () => {
+    const { container } = render(
+      <KiloCodeRateLimitView data={kilo} variant="settings" />,
+    );
+    expect(screen.getByText("Credit balance")).toBeTruthy();
+    expect(screen.getByText("$25.50")).toBeTruthy();
+    expect(screen.getByText("Kilo Pass")).toBeTruthy();
+    expect(screen.getByText("Active")).toBeTruthy();
+    // No computable percentage -> no fill bar.
+    expect(container.querySelectorAll(".bg-primary").length).toBe(0);
+  });
+
+  it("condenses the Overview to only the credit balance (drops Kilo Pass)", () => {
+    render(<KiloCodeRateLimitView data={kilo} variant="popover-overview" />);
+    expect(screen.getByText("Credit balance")).toBeTruthy();
+    expect(screen.queryByText("Kilo Pass")).toBeNull();
+  });
+});
+
+describe("ProviderRateLimitDetail dispatch", () => {
+  it("dispatches to the OpenRouter view", () => {
+    render(
+      <ProviderRateLimitDetail
+        data={{
+          provider: "openrouter",
+          available: true,
+          limit: null,
+          limitRemaining: null,
+          dailySpend: null,
+          weeklySpend: null,
+          monthlySpend: null,
+          totalCredits: null,
+          totalUsage: null,
+          balance: 12,
+        }}
+        variant="settings"
+      />,
+    );
+    expect(screen.getByText("Balance")).toBeTruthy();
+    expect(screen.getByText("$12.00")).toBeTruthy();
+  });
+
+  it("dispatches to the Kilo Code view", () => {
+    render(
+      <ProviderRateLimitDetail
+        data={{
+          provider: "kilocode",
+          available: true,
+          creditBalance: 7,
+          passState: null,
+        }}
+        variant="settings"
+      />,
+    );
+    expect(screen.getByText("Credit balance")).toBeTruthy();
+    expect(screen.getByText("$7.00")).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -154,6 +154,22 @@ vi.mock("@/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn", () => ({
   useRefreshRateLimitUsageOnTraycerTurn: () => {},
 }));
 
+// Provider rate-limit query + its refresh hook (ProviderRateLimitForProvider,
+// mounted for every codex/claude-code provider row). Same reason: no host
+// client/QueryClient in this harness.
+vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
+  useHostProviderRateLimitsQuery: () => ({
+    data: undefined,
+    isPending: false,
+    isError: false,
+    isFetching: false,
+    refetch: () => Promise.resolve({}),
+  }),
+}));
+vi.mock("@/hooks/host/use-refresh-provider-rate-limits-on-turn", () => ({
+  useRefreshProviderRateLimitsOnTurn: () => {},
+}));
+
 // Host picker plumbing: a single active host and no transient client means
 // the panel renders inline (no runtime-context re-provide), and `useHostBinding`
 // returns null without a `<HostRuntimeProvider>`.

--- a/clients/gui-app/src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
@@ -143,7 +143,6 @@ describe("TraycerSubscriptionSection", () => {
 
   it("renders the personal subscription by default", () => {
     render(<TraycerSubscriptionSection />);
-    expect(screen.getByText("Pro")).toBeDefined();
     // Plan bucket: 30 consumed of 100 total (extension's consumed/total wording).
     expect(screen.getByText("$30.00 / $100.00")).toBeDefined();
   });
@@ -155,7 +154,6 @@ describe("TraycerSubscriptionSection", () => {
         .getState()
         .setAccountContext({ type: "TEAM", teamId: "team-1" });
     });
-    expect(screen.getByText("Ultra 1x")).toBeDefined();
     // Plan bucket: 100 consumed of 500 total.
     expect(screen.getByText("$100.00 / $500.00")).toBeDefined();
   });
@@ -172,7 +170,6 @@ describe("TraycerSubscriptionSection", () => {
       },
     };
     render(<TraycerSubscriptionSection />);
-    expect(screen.getByText("Pro Plus")).toBeDefined();
     expect(screen.getByText("Rate limit")).toBeDefined();
     // 1800s → 30 minutes recharge.
     expect(screen.getByText("30 minutes")).toBeDefined();

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
@@ -1,0 +1,75 @@
+/**
+ * Settings > Providers rate-limit card for Codex / Claude Code: mirrors
+ * `TraycerSubscriptionForProvider`'s gate shape in
+ * `providers-settings-panel.tsx` (a tiny provider-id switch mounted inside
+ * `ProviderDetail`), but for the two rate-limit-capable CLI providers
+ * instead of `traycer`.
+ */
+import type { ReactNode } from "react";
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { RefreshIconButton } from "@/components/refresh-icon-button";
+import { ProviderRateLimitBody } from "@/components/settings/panels/provider-rate-limit-views";
+import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
+import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useProviderRateLimitRefresh } from "@/hooks/rate-limits/use-provider-rate-limit-refresh";
+import {
+  isRateLimitCapableProvider,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+// Gates the card the same way `TraycerSubscriptionForProvider` gates the
+// subscription card: the rate-limit query never fires while viewing another
+// provider, and `ProviderDetail` stays a flat mount list.
+export function ProviderRateLimitForProvider({
+  providerId,
+}: {
+  readonly providerId: ProviderId;
+}): ReactNode {
+  if (!isRateLimitCapableProvider(providerId)) return null;
+  return <ProviderRateLimitSettingsCard providerId={providerId} />;
+}
+
+function ProviderRateLimitSettingsCard({
+  providerId,
+}: {
+  readonly providerId: RateLimitProviderId;
+}): ReactNode {
+  const hostId = useReactiveActiveHostId();
+  const query = useHostProviderRateLimitsQuery(providerId);
+  // Single source of truth for this provider's refresh action + spinner state
+  // (fresh-on-open, queue routing, and the ephemeralProcess `draining` fold-in),
+  // shared verbatim with the popover's per-provider block.
+  const { refresh, isRefreshing } = useProviderRateLimitRefresh(
+    providerId,
+    query.isFetching,
+    query.refetch,
+  );
+  // Keep the bars live: a turn on this provider finishing while the card is
+  // open re-fetches usage. Only mounted here, so it costs nothing elsewhere.
+  useRefreshProviderRateLimitsOnTurn(providerId, hostId);
+
+  return (
+    <div className="mb-3 flex flex-col gap-3 rounded-lg border border-border/60 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-ui-sm font-medium text-foreground">
+          Usage limits
+        </div>
+        <RefreshIconButton
+          onRefresh={refresh}
+          label="Refresh usage limits"
+          // `isRefreshing` (from useProviderRateLimitRefresh) already folds in
+          // the ephemeralProcess `draining` flag, so this stays disabled for a
+          // "Refresh all" round's full duration, not just this provider's slice.
+          refreshing={isRefreshing}
+        />
+      </div>
+      <ProviderRateLimitBody
+        isPending={query.isPending}
+        isFetching={query.isFetching || isRefreshing}
+        isError={query.isError}
+        providerRateLimits={query.data?.providerRateLimits}
+      />
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -1,0 +1,780 @@
+/**
+ * Bespoke per-provider rate-limit views for the Settings > Providers card
+ * (`provider-rate-limit-section.tsx`). Kept host/query-free - the card owns
+ * its own host-scoped query + refresh wiring and hands this module plain
+ * data, so the data-to-UI mapping lives in exactly one place.
+ */
+import type { ReactNode } from "react";
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitWindow,
+} from "@traycer/protocol/host";
+import { Badge } from "@/components/ui/badge";
+import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
+import { MeterRow } from "@/components/settings/panels/traycer-subscription-views";
+import { contextUsageTone } from "@/components/chat/context-usage";
+import {
+  formatUnavailableReason,
+  resolveProviderRateLimitViewState,
+  titleCaseFromToken,
+} from "@/lib/provider-rate-limit-content";
+import {
+  formatResetDateTime,
+  useIsFarReset,
+  useResetCountdown,
+} from "@/lib/relative-time";
+import { cn } from "@/lib/utils";
+
+/**
+ * Which surface a provider's detail is rendered on. Every window/bar draws
+ * identically across all three - the Settings › Providers card and both
+ * popover surfaces share one row renderer (`RateLimitWindowRow`), so they can
+ * never visually drift (feedback: "different UX looks weird"). The only thing
+ * this enum still drives is how much detail is shown:
+ *
+ * - `"settings"` / `"popover-detail"`: the provider's full detail (every
+ *   window, credits, spend, reset credits, badges).
+ * - `"popover-overview"`: the header popover's Overview tab - condensed to
+ *   only the primary/secondary (5h/Weekly) windows plus credit/balance
+ *   figures, dropping per-model `extraWindows`, reset credits, the
+ *   rate-limit-reached badge, and per-provider spend controls, which stay in
+ *   the single-provider tab.
+ */
+export type RateLimitViewVariant =
+  "settings" | "popover-detail" | "popover-overview";
+
+/**
+ * The condensed Overview surface. Fields the single-provider detail keeps but
+ * Overview drops are gated on `!isOverviewVariant(variant)`.
+ */
+function isOverviewVariant(variant: RateLimitViewVariant): boolean {
+  return variant === "popover-overview";
+}
+
+/** Shared read of a provider rate-limit query, independent of host scope. */
+export interface ProviderRateLimitQueryState {
+  readonly isPending: boolean;
+  readonly isFetching: boolean;
+  readonly isError: boolean;
+  readonly providerRateLimits: ProviderRateLimits | null | undefined;
+}
+
+type AvailableProviderRateLimits = Extract<
+  ProviderRateLimits,
+  { available: true }
+>;
+type CodexRateLimits = Extract<ProviderRateLimits, { provider: "codex" }>;
+type ClaudeRateLimits = Extract<
+  ProviderRateLimits,
+  { provider: "claude-code" }
+>;
+type OpenRouterRateLimits = Extract<
+  ProviderRateLimits,
+  { provider: "openrouter" }
+>;
+type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
+
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = MINUTES_PER_HOUR * 24;
+const MINUTES_PER_WEEK = MINUTES_PER_DAY * 7;
+const MINUTES_PER_SESSION = MINUTES_PER_HOUR * 5;
+
+/**
+ * A window's label from its real duration, not a hardcoded "5-hour"/"Weekly"
+ * (Core Flows: "if the provider tells us the window is 6 hours, that's what's
+ * shown"). Every `ProviderRateLimitWindow` now carries `durationMinutes`, so
+ * Codex's primary/secondary, Claude's fixed buckets, and Codex's per-model
+ * `extraWindows` all label from the same formatter. `10080` (a 7-day window)
+ * reads as "Weekly" rather than "7d" since that's the product's own wording;
+ * the well-known 5-hour rolling window both Codex and Claude use reads as
+ * "Current session" - a provider-reported 6-hour window still falls back to
+ * the generic "6h" form, since that isn't the same known quota.
+ */
+function formatWindowDuration(minutes: number | null): string {
+  if (minutes === null || minutes <= 0) return "Usage";
+  if (minutes === MINUTES_PER_WEEK) return "Weekly";
+  if (minutes === MINUTES_PER_SESSION) return "Current session";
+  if (minutes % MINUTES_PER_DAY === 0) return `${minutes / MINUTES_PER_DAY}d`;
+  if (minutes % MINUTES_PER_HOUR === 0) return `${minutes / MINUTES_PER_HOUR}h`;
+  return `${minutes}m`;
+}
+
+/** $-denominated value (credits, balance, spend). */
+function formatProviderCurrency(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+/** Relative countdown ("Resets in 4h 7m") - ticks on the shared 60s clock. */
+function RelativeResetLine({
+  resetsAt,
+  tone,
+}: {
+  readonly resetsAt: number;
+  readonly tone: string;
+}): ReactNode {
+  const countdown = useResetCountdown(resetsAt);
+  if (countdown === null) return null;
+  return <span className={cn("text-ui-xs", tone)}>Resets in {countdown}</span>;
+}
+
+/**
+ * Exact weekday/time ("Resets Sat 3:35 AM") - for weekly-scale windows,
+ * where a relative countdown ("Resets in 3d") is too coarse to act on. Pure,
+ * no clock subscription.
+ */
+function ExactResetLine({
+  resetsAt,
+  tone,
+}: {
+  readonly resetsAt: number;
+  readonly tone: string;
+}): ReactNode {
+  return (
+    <span className={cn("text-ui-xs", tone)}>
+      Resets {formatResetDateTime(resetsAt)}
+    </span>
+  );
+}
+
+/**
+ * Dispatches to `RelativeResetLine` or `ExactResetLine` by whether `resetsAt`
+ * is far enough away (`useIsFarReset` - the real time remaining, not a
+ * window's nominal duration, since not every window carries one; see that
+ * function's own doc). Calling the hook unconditionally here, then choosing
+ * which leaf to render, keeps both leaves' own hook calls (or lack thereof)
+ * unconditional per render.
+ */
+function ResetLine({
+  resetsAt,
+  tone,
+}: {
+  readonly resetsAt: number | null;
+  readonly tone: string;
+}): ReactNode {
+  const isFar = useIsFarReset(resetsAt);
+  if (resetsAt === null) return null;
+  return isFar ? (
+    <ExactResetLine resetsAt={resetsAt} tone={tone} />
+  ) : (
+    <RelativeResetLine resetsAt={resetsAt} tone={tone} />
+  );
+}
+
+/**
+ * The right-hand `detail` slot for a window row: "{percent}% used" followed
+ * by the reset line (a relative countdown for a near window - "Resets in 4h
+ * 7m" - or an absolute weekday/time for a far one - "Resets Sat 3:35 AM",
+ * since "Resets in 3d" is too coarse to act on), separated by a middle dot -
+ * dropped entirely when there's no reset to show. `tone` is left to
+ * `MeterRow`'s own wrapping span (this slot never overrides it), unlike
+ * `CodexSpendControlRow`'s reset line, which needs its own severity-driven
+ * tone outside a `MeterRow`.
+ */
+function WindowMeterDetail({
+  resetsAt,
+  usedPercent,
+}: {
+  readonly resetsAt: number | null;
+  readonly usedPercent: number;
+}): ReactNode {
+  const percent = Math.round(Math.min(100, Math.max(0, usedPercent)));
+  return (
+    <span className="flex items-center gap-1">
+      <span>{percent}% used</span>
+      {resetsAt !== null ? (
+        <>
+          <span aria-hidden="true">·</span>
+          <ResetLine resetsAt={resetsAt} tone="" />
+        </>
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * A single window row, shared identically by the Settings card and both
+ * popover surfaces so they can never visually drift - delegates to the
+ * shared `MeterRow` shell (`traycer-subscription-views.tsx`), passing
+ * `WindowMeterDetail` as its `detail` slot. Renders nothing for a `null`
+ * window so call sites can pass optional windows directly.
+ */
+function RateLimitWindowRow({
+  label,
+  window,
+}: {
+  readonly label: string;
+  readonly window: ProviderRateLimitWindow | null;
+}): ReactNode {
+  if (window === null) return null;
+  return (
+    <MeterRow
+      label={label}
+      usedPercent={window.usedPercent}
+      detail={
+        <WindowMeterDetail
+          resetsAt={window.resetsAt}
+          usedPercent={window.usedPercent}
+        />
+      }
+    />
+  );
+}
+
+/**
+ * A window row whose label is composed from the window's real duration
+ * (`formatWindowDuration`) plus, where a provider distinguishes otherwise
+ * same-duration windows, a name prefix (Codex's per-model limit name) or a
+ * trailing qualifier (Claude's "(Opus)"/"(Sonnet)"). Renders nothing for a
+ * `null` window so call sites can pass optional windows directly.
+ */
+// The label's base: a named window with a known duration reads "Name · 5h", a
+// named window with no duration falls back to just the name, and an unnamed
+// window is the bare duration. Split out to keep `ProviderWindowRow` free of a
+// nested ternary.
+function windowBaseLabel(
+  namePrefix: string | null,
+  durationMinutes: number | null,
+  duration: string,
+): string {
+  if (namePrefix === null) return duration;
+  if (durationMinutes === null) return namePrefix;
+  return `${namePrefix} · ${duration}`;
+}
+
+function ProviderWindowRow({
+  window,
+  namePrefix,
+  qualifier,
+}: {
+  readonly window: ProviderRateLimitWindow | null;
+  readonly namePrefix: string | null;
+  readonly qualifier: string | null;
+}): ReactNode {
+  if (window === null) return null;
+  const duration = formatWindowDuration(window.durationMinutes);
+  const base = windowBaseLabel(namePrefix, window.durationMinutes, duration);
+  const label = qualifier !== null ? `${base} (${qualifier})` : base;
+  return <RateLimitWindowRow label={label} window={window} />;
+}
+
+/**
+ * A neutral labeled number (no bar, no severity color) - for values with no
+ * computable "% of limit" (Core Flows: "Windows without a percentage"), e.g.
+ * OpenRouter's spend/credits and Kilo Code's balance. Renders nothing when the
+ * provider didn't report the value.
+ */
+function ProviderNumberRow({
+  label,
+  value,
+  format,
+}: {
+  readonly label: string;
+  readonly value: number | null;
+  readonly format: (value: number) => string;
+}): ReactNode {
+  if (value === null) return null;
+  return (
+    <div className="flex items-center justify-between text-ui-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-mono text-ui-xs text-foreground">
+        {format(value)}
+      </span>
+    </div>
+  );
+}
+
+// Codex's `RateLimitReachedType` enum (host `harnesses/codex/protocol`) -
+// lowercase tokens on the wire, so the badge needs a display map rather than
+// showing the raw value. Falls back to `titleCaseFromToken` for any value
+// not listed here (forward-compat with a new value before this map updates).
+const CODEX_RATE_LIMIT_REACHED_LABELS: Record<string, string> = {
+  rate_limit_reached: "Usage limit reached",
+  workspace_owner_credits_depleted: "Workspace credits depleted",
+  workspace_member_credits_depleted: "Workspace credits depleted",
+  workspace_owner_usage_limit_reached: "Workspace usage limit reached",
+  workspace_member_usage_limit_reached: "Workspace usage limit reached",
+};
+
+function formatRateLimitReachedType(value: string): string {
+  return CODEX_RATE_LIMIT_REACHED_LABELS[value] ?? titleCaseFromToken(value);
+}
+
+/**
+ * Stacks a detail view's content groups vertically with a hairline divider
+ * between consecutive groups that actually render (feedback: "show separator
+ * between global limits, Spark limits, credits and manual resets" - it looked
+ * cluttered without them). `null` groups are dropped before dividers are
+ * placed, so a divider never renders before the first visible group or after
+ * the last. Shared by `CodexRateLimitView` and `ClaudeRateLimitView` so the
+ * divider rules can't drift between providers.
+ */
+function RateLimitGroupStack({
+  groups,
+}: {
+  readonly groups: ReadonlyArray<{
+    readonly key: string;
+    readonly node: ReactNode;
+  }>;
+}): ReactNode {
+  const rendered = groups.filter((group) => group.node !== null);
+  return (
+    <div className="flex flex-col gap-3">
+      {rendered.map((group, index) => (
+        <div key={group.key} className="flex flex-col gap-3">
+          {index > 0 ? <div aria-hidden className="h-px bg-border/70" /> : null}
+          {group.node}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function CodexRateLimitView({
+  data,
+  variant,
+}: {
+  readonly data: CodexRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  // Overview keeps only the primary/secondary (5h/Weekly) windows; the badge,
+  // credits, per-model extraWindows, spend control, and reset credits are
+  // single-provider-tab detail (`!isOverviewVariant`). The plan/tier label
+  // isn't part of this body at all - the header popover renders it as a chip
+  // next to the provider name (`resolveProviderPlanLabel`).
+  const overview = isOverviewVariant(variant);
+
+  const globalLimits: ReactNode = (
+    <div className="flex flex-col gap-3">
+      <ProviderWindowRow
+        window={data.primary}
+        namePrefix={null}
+        qualifier={null}
+      />
+      <ProviderWindowRow
+        window={data.secondary}
+        namePrefix={null}
+        qualifier={null}
+      />
+    </div>
+  );
+
+  // Each per-model sub-limit becomes its own labeled window row (Core Flows:
+  // "no separate UI concept needed"), named by its `limitName`.
+  const perModelLimits: ReactNode =
+    !overview && data.extraWindows.length > 0 ? (
+      <div className="flex flex-col gap-3">
+        {data.extraWindows.map((extraWindow) => (
+          <div key={extraWindow.limitId} className="flex flex-col gap-3">
+            <ProviderWindowRow
+              window={extraWindow.primary}
+              namePrefix={extraWindow.limitName ?? extraWindow.limitId}
+              qualifier={null}
+            />
+            <ProviderWindowRow
+              window={extraWindow.secondary}
+              namePrefix={extraWindow.limitName ?? extraWindow.limitId}
+              qualifier={null}
+            />
+          </div>
+        ))}
+      </div>
+    ) : null;
+
+  const credits: ReactNode =
+    !overview && (data.credits !== null || data.individualLimit !== null) ? (
+      <div className="flex flex-col gap-3">
+        {data.credits !== null ? (
+          <CodexCreditsRow credits={data.credits} />
+        ) : null}
+        {data.individualLimit !== null ? (
+          <CodexSpendControlRow limit={data.individualLimit} />
+        ) : null}
+      </div>
+    ) : null;
+
+  const manualResets: ReactNode =
+    !overview && data.resetCredits !== null ? (
+      <CodexResetCreditsRow resetCredits={data.resetCredits} />
+    ) : null;
+
+  // Overview never gets here with more than `globalLimits`; the divider
+  // placement rules live on `RateLimitGroupStack`.
+  return (
+    <div className="flex flex-col gap-3">
+      {!overview && data.rateLimitReachedType !== null ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="destructive">
+            {formatRateLimitReachedType(data.rateLimitReachedType)}
+          </Badge>
+        </div>
+      ) : null}
+      <RateLimitGroupStack
+        groups={[
+          { key: "global", node: globalLimits },
+          { key: "per-model", node: perModelLimits },
+          { key: "credits", node: credits },
+          { key: "manual-resets", node: manualResets },
+        ]}
+      />
+    </div>
+  );
+}
+
+/**
+ * Codex's periodic allowance of manual limit resets (Core Flows: "a manual
+ * reset-credits block ... with a count"). The live `account/rateLimits/read`
+ * shape is just `{ availableCount }` (no per-credit expiry array), so this is a
+ * single count row.
+ */
+function CodexResetCreditsRow({
+  resetCredits,
+}: {
+  readonly resetCredits: NonNullable<CodexRateLimits["resetCredits"]>;
+}): ReactNode {
+  return (
+    <div className="flex items-center justify-between text-ui-sm">
+      <span className="text-muted-foreground">Manual resets</span>
+      <span className="font-mono text-ui-xs text-foreground">
+        {resetCredits.availableCount} available
+      </span>
+    </div>
+  );
+}
+
+function CodexCreditsRow({
+  credits,
+}: {
+  readonly credits: NonNullable<CodexRateLimits["credits"]>;
+}): ReactNode {
+  const label = credits.unlimited
+    ? "Unlimited"
+    : (credits.balance ?? (credits.hasCredits ? "Available" : "None"));
+  return (
+    <div className="flex items-center justify-between text-ui-sm">
+      <span className="text-muted-foreground">Credits</span>
+      <span className="font-mono text-ui-xs text-foreground">{label}</span>
+    </div>
+  );
+}
+
+function CodexSpendControlRow({
+  limit,
+}: {
+  readonly limit: NonNullable<CodexRateLimits["individualLimit"]>;
+}): ReactNode {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between text-ui-sm">
+        <span className="text-muted-foreground">Spend limit</span>
+        <span className="font-mono text-ui-xs text-foreground">
+          {limit.used} / {limit.limit}
+        </span>
+      </div>
+      <div className="flex justify-end">
+        <ResetLine
+          resetsAt={limit.resetsAt}
+          tone={contextUsageTone(limit.remainingPercent)}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ClaudeRateLimitView({
+  data,
+  variant,
+}: {
+  readonly data: ClaudeRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  // Overview keeps only the 5h (`fiveHour`) and Weekly (`sevenDay`) windows; the
+  // Opus/Sonnet weekly buckets, per-model rows, and extra-usage bar are
+  // single-provider-tab detail.
+  const overview = isOverviewVariant(variant);
+
+  const globalLimits: ReactNode = (
+    <div className="flex flex-col gap-3">
+      <ProviderWindowRow
+        window={data.fiveHour}
+        namePrefix={null}
+        qualifier={null}
+      />
+      <ProviderWindowRow
+        window={data.sevenDay}
+        namePrefix={null}
+        qualifier={null}
+      />
+      {!overview ? (
+        <ProviderWindowRow
+          window={data.sevenDayOpus}
+          namePrefix={null}
+          qualifier="Opus"
+        />
+      ) : null}
+      {!overview ? (
+        <ProviderWindowRow
+          window={data.sevenDaySonnet}
+          namePrefix={null}
+          qualifier="Sonnet"
+        />
+      ) : null}
+    </div>
+  );
+
+  // Each model-scoped window is its own labeled row - no "Per-model" heading;
+  // the rows' display names already say which model each is, and the group is
+  // set off by a divider instead, the same header-less treatment
+  // `CodexRateLimitView` gives its per-model (Spark) `extraWindows`.
+  const perModelLimits: ReactNode =
+    !overview && data.modelScoped.length > 0 ? (
+      <div className="flex flex-col gap-3">
+        {data.modelScoped.map((entry) => (
+          // `displayName` alone isn't guaranteed unique across entries -
+          // fold in `resetsAt` (an array index would defeat reconciliation
+          // on reorder/filter, and ESLint's `no-array-index-key` disallows
+          // it outright).
+          <RateLimitWindowRow
+            key={`${entry.displayName}-${entry.resetsAt}`}
+            label={entry.displayName}
+            window={entry}
+          />
+        ))}
+      </div>
+    ) : null;
+
+  const extraUsage: ReactNode =
+    !overview && data.extraUsage !== null && data.extraUsage.isEnabled ? (
+      <ClaudeExtraUsageRow extraUsage={data.extraUsage} />
+    ) : null;
+
+  // Overview never gets here with more than `globalLimits`; the divider
+  // placement rules live on `RateLimitGroupStack`.
+  return (
+    <RateLimitGroupStack
+      groups={[
+        { key: "global", node: globalLimits },
+        { key: "per-model", node: perModelLimits },
+        { key: "extra-usage", node: extraUsage },
+      ]}
+    />
+  );
+}
+
+function ClaudeExtraUsageRow({
+  extraUsage,
+}: {
+  readonly extraUsage: NonNullable<ClaudeRateLimits["extraUsage"]>;
+}): ReactNode {
+  // `monthlyLimit`/`usedCredits` give a ratio-based bar without depending on
+  // the ambiguous 0-1-vs-0-100 scale of `utilization` (open item on the wire
+  // contract - see the tech plan). `utilization` is only ever shown as raw
+  // supplementary text.
+  if (extraUsage.monthlyLimit !== null && extraUsage.usedCredits !== null) {
+    const usedPercent =
+      extraUsage.monthlyLimit > 0
+        ? (extraUsage.usedCredits / extraUsage.monthlyLimit) * 100
+        : 0;
+    return (
+      <MeterRow
+        label="Extra usage"
+        usedPercent={usedPercent}
+        detail={`${extraUsage.usedCredits.toFixed(2)} / ${extraUsage.monthlyLimit.toFixed(2)}`}
+      />
+    );
+  }
+  if (extraUsage.utilization !== null) {
+    return (
+      <div className="flex items-center justify-between text-ui-sm">
+        <span className="text-muted-foreground">Extra usage</span>
+        <span className="font-mono text-ui-xs text-foreground">
+          {extraUsage.utilization}
+        </span>
+      </div>
+    );
+  }
+  return null;
+}
+
+/**
+ * OpenRouter's usage detail: a request/credit bar when a hard `limit` exists,
+ * plus its uncapped spend/credit/balance figures as plain neutral rows (Core
+ * Flows: "Windows without a percentage" - no fabricated percentage, no severity
+ * color). All figures are $-denominated OpenRouter credits.
+ */
+export function OpenRouterRateLimitView({
+  data,
+  variant,
+}: {
+  readonly data: OpenRouterRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  // Overview keeps only the Credits bar and Balance; the total-credit/usage and
+  // per-period spend figures are single-provider-tab detail.
+  const overview = isOverviewVariant(variant);
+  return (
+    <div className="flex flex-col gap-3">
+      <OpenRouterCreditBar
+        limit={data.limit}
+        limitRemaining={data.limitRemaining}
+      />
+      <ProviderNumberRow
+        label="Balance"
+        value={data.balance}
+        format={formatProviderCurrency}
+      />
+      {!overview ? (
+        <>
+          <ProviderNumberRow
+            label="Total credits"
+            value={data.totalCredits}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Total usage"
+            value={data.totalUsage}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Spent today"
+            value={data.dailySpend}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Spent this week"
+            value={data.weeklySpend}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="Spent this month"
+            value={data.monthlySpend}
+            format={formatProviderCurrency}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+// Only OpenRouter's `limit`/`limitRemaining` pair yields a computable "% of
+// limit"; the derived percentage matches the header glyph's exact
+// `((limit - limitRemaining) / limit) * 100`, so the bar's fill/color tracks
+// the same number. Absent a hard limit, no bar renders (the spend rows stand
+// alone).
+function OpenRouterCreditBar({
+  limit,
+  limitRemaining,
+}: {
+  readonly limit: number | null;
+  readonly limitRemaining: number | null;
+}): ReactNode {
+  if (limit === null || limitRemaining === null || limit <= 0) return null;
+  const consumed = Math.max(0, limit - limitRemaining);
+  const usedPercent = (consumed / limit) * 100;
+  return (
+    <MeterRow
+      label="Credits"
+      usedPercent={usedPercent}
+      detail={`${formatProviderCurrency(consumed)} / ${formatProviderCurrency(limit)}`}
+    />
+  );
+}
+
+/**
+ * Kilo Code's usage detail: a credit balance and Kilo Pass state, both as plain
+ * neutral rows. No computable percentage exists for Kilo Code, so it never
+ * renders a bar (Core Flows: "Windows without a percentage").
+ */
+export function KiloCodeRateLimitView({
+  data,
+  variant,
+}: {
+  readonly data: KiloCodeRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  // Overview keeps only the credit balance; Kilo Pass state is
+  // single-provider-tab detail.
+  const overview = isOverviewVariant(variant);
+  return (
+    <div className="flex flex-col gap-3">
+      <ProviderNumberRow
+        label="Credit balance"
+        value={data.creditBalance}
+        format={formatProviderCurrency}
+      />
+      {!overview && data.passState !== null ? (
+        <div className="flex items-center justify-between text-ui-sm">
+          <span className="text-muted-foreground">Kilo Pass</span>
+          <span className="font-mono text-ui-xs text-foreground">
+            {titleCaseFromToken(data.passState)}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function ProviderRateLimitBody(
+  props: ProviderRateLimitQueryState,
+): ReactNode {
+  const state = resolveProviderRateLimitViewState(props);
+  // `isPending` alone stays `true` forever for a disabled query (e.g. a chat
+  // tab bound to an unreachable host, where `useHostQuery` never enables) -
+  // `resolveProviderRateLimitViewState` also gates on `isFetching` so that
+  // case falls through to the `empty` branch below instead of an eternal
+  // spinner.
+  if (state.kind === "loading") {
+    return (
+      <div className="flex items-center gap-2 text-ui-sm text-muted-foreground">
+        <MutedAgentSpinner /> Loading usage limits
+      </div>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="text-ui-sm text-destructive">
+        Couldn't load usage limits. Try refreshing.
+      </div>
+    );
+  }
+  if (state.kind === "empty") return null;
+  const data = state.data;
+  if (!data.available) {
+    return (
+      <p className="text-ui-xs text-muted-foreground">
+        Usage limits unavailable — {formatUnavailableReason(data.reason)}
+      </p>
+    );
+  }
+  return <ProviderRateLimitDetail data={data} variant="settings" />;
+}
+
+/**
+ * Renders one provider's available-arm detail. Exhaustive over every
+ * `available: true` arm (`data.provider` is now four-way, not the old binary
+ * codex/claude split), so a new provider arm added to the wire union fails the
+ * build here until it gets a view. Exported so the header popover reuses the
+ * exact same per-provider bodies the Settings card shows (Core Flows: "both
+ * read the same underlying provider usage data, so they never disagree").
+ */
+export function ProviderRateLimitDetail({
+  data,
+  variant,
+}: {
+  readonly data: AvailableProviderRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  switch (data.provider) {
+    case "codex":
+      return <CodexRateLimitView data={data} variant={variant} />;
+    case "claude-code":
+      return <ClaudeRateLimitView data={data} variant={variant} />;
+    // OpenRouter/Kilo Code report no usage *windows* (only credit/spend bars and
+    // plain figures), so the settings/popover window distinction doesn't apply -
+    // but `variant` still drives the Overview-vs-detail trim (Overview shows
+    // only their balance/credit fields).
+    case "openrouter":
+      return <OpenRouterRateLimitView data={data} variant={variant} />;
+    case "kilocode":
+      return <KiloCodeRateLimitView data={data} variant={variant} />;
+  }
+}

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -65,6 +65,7 @@ import {
 import { ProviderAuthBadge, ProviderAuthLine } from "./provider-auth-display";
 import { EnvOverrideEditor } from "./env-override-editor";
 import { TraycerSubscriptionSection } from "./traycer-subscription-section";
+import { ProviderRateLimitForProvider } from "./provider-rate-limit-section";
 
 type ProviderId = ProviderCliState["providerId"];
 type ProvidersListQuery = UseQueryResult<
@@ -565,6 +566,7 @@ function ProviderDetail({
       </div>
 
       <TraycerSubscriptionForProvider providerId={providerId} />
+      <ProviderRateLimitForProvider providerId={providerId} />
 
       <div
         className={cn(

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
@@ -3,125 +3,36 @@
  * provider. A global account-context selector (Personal / each Team) drives
  * which subscription is rendered. Data comes from `useAuthUser` (TanStack
  * Query) - never the auth store, which keeps only its narrow projections.
+ *
+ * This card owns its query wiring (`useAuthUser`, `useRefreshCreditsOnTraycerTurn`,
+ * and - inside the shared `RateLimitView` - `useHostRateLimitUsageQuery` +
+ * `useRefreshRateLimitUsageOnTraycerTurn`) and renders through the shared,
+ * host/query-free views in `traycer-subscription-views.tsx`, so it and the
+ * header popover's Traycer tab can never disagree.
  */
 import { ExternalLink } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
-import type {
-  AuthenticatedUser,
-  SubscriptionStatus,
-  TraycerTeamSubscription,
-  TraycerUserSubscription,
-} from "@traycer/protocol/auth";
+import type { AuthenticatedUser } from "@traycer/protocol/auth";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
-import { Badge } from "@/components/ui/badge";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
+import {
+  TraycerAccountSelect,
+  TraycerSubscriptionView,
+} from "@/components/settings/panels/traycer-subscription-views";
 import { resolveManageSubscriptionUrl } from "@/lib/auth/manage-subscription-url";
+import {
+  accountContextValue,
+  parseAccountContextValue,
+  selectSubscription,
+  type TraycerSubscription,
+} from "@/lib/auth/traycer-subscription-content";
 import { useAuthUser } from "@/hooks/auth/use-auth-user-query";
 import { useRefreshCreditsOnTraycerTurn } from "@/hooks/auth/use-refresh-credits-on-traycer-turn";
-import { useHostRateLimitUsageQuery } from "@/hooks/host/use-host-rate-limit-usage-query";
-import { useRefreshRateLimitUsageOnTraycerTurn } from "@/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import {
   resolveAccountContext,
   useAccountContextStore,
-  type AccountContext,
 } from "@/stores/auth/account-context-store";
-import { cn } from "@/lib/utils";
-
-const PERSONAL_VALUE = "personal";
-const TEAM_VALUE_PREFIX = "team:";
-
-// ponytail: hand-rolled label map - there's no shared SubscriptionStatus →
-// display-name helper in the repo. Add tiers here as the enum grows.
-const TIER_LABELS: Record<SubscriptionStatus, string> = {
-  PENDING: "Pending",
-  FREE: "Free",
-  PRO_LEGACY: "Pro",
-  PRO: "Pro",
-  PRO_PLUS: "Pro Plus",
-  LITE: "Lite",
-  LITE_V2: "Lite",
-  PRO_V2: "Pro",
-  PRO_PLUS_V2: "Pro Plus",
-  LITE_V3: "Lite",
-  PRO_V3: "Pro",
-  ULTRA_1X_V3: "Ultra 1x",
-  ULTRA_2X_V3: "Ultra 2x",
-  ULTRA_3X_V3: "Ultra 3x",
-  ULTRA_4X_V3: "Ultra 4x",
-  ULTRA_5X_V3: "Ultra 5x",
-  BYOA_V3: "BYOA",
-};
-
-function isPaid(status: SubscriptionStatus): boolean {
-  return status !== "FREE" && status !== "PENDING";
-}
-
-// V3 plans bill against credits; every other (legacy / v2) plan is rate-limit
-// based. Ported from an internal shared package's `isCreditBasedPricing`
-// (clients can't import that package). Credit plans → credit breakdown; the
-// rest → rate limit.
-const CREDIT_BASED_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
-  "FREE",
-  "LITE_V3",
-  "PRO_V3",
-  "ULTRA_1X_V3",
-  "ULTRA_2X_V3",
-  "ULTRA_3X_V3",
-  "ULTRA_4X_V3",
-  "ULTRA_5X_V3",
-  "BYOA_V3",
-]);
-
-function isCreditBasedPricing(status: SubscriptionStatus): boolean {
-  return CREDIT_BASED_STATUSES.has(status);
-}
-
-// Mirrors the extension's `formatRechargeRate`: minutes under a day, else days.
-function formatRechargeRate(rechargeRateSeconds: number): string | null {
-  if (rechargeRateSeconds <= 0) return null;
-  const SECONDS_PER_DAY = 86_400;
-  const SECONDS_PER_MINUTE = 60;
-  if (rechargeRateSeconds < SECONDS_PER_DAY) {
-    const minutes = Math.round(rechargeRateSeconds / SECONDS_PER_MINUTE);
-    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
-  }
-  const days = Math.round(rechargeRateSeconds / SECONDS_PER_DAY);
-  return `${days} ${days === 1 ? "day" : "days"}`;
-}
-
-type Subscription = TraycerUserSubscription | TraycerTeamSubscription;
-
-// Picks the subscription for the resolved context: the user's own, or the
-// matching team's. Null when the user isn't loaded or the team has no sub.
-function selectSubscription(
-  user: AuthenticatedUser | null,
-  resolved: AccountContext,
-  teams: readonly TraycerTeamSubscription[],
-): Subscription | null {
-  if (user === null) return null;
-  if (resolved.type === "PERSONAL") return user.userSubscription;
-  return teams.find((t) => t.team.id === resolved.teamId) ?? null;
-}
-
-function accountContextValue(context: AccountContext): string {
-  return context.type === "PERSONAL"
-    ? PERSONAL_VALUE
-    : `${TEAM_VALUE_PREFIX}${context.teamId}`;
-}
-
-function parseAccountContextValue(value: string): AccountContext {
-  return value.startsWith(TEAM_VALUE_PREFIX)
-    ? { type: "TEAM", teamId: value.slice(TEAM_VALUE_PREFIX.length) }
-    : { type: "PERSONAL" };
-}
 
 export function TraycerSubscriptionSection() {
   const query = useAuthUser();
@@ -167,29 +78,13 @@ export function TraycerSubscriptionSection() {
         </div>
       </div>
 
-      {teams.length > 0 ? (
-        <Select
-          value={accountContextValue(resolved)}
-          onValueChange={(value) =>
-            setAccountContext(parseAccountContextValue(value))
-          }
-        >
-          <SelectTrigger size="sm" aria-label="Account" className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={PERSONAL_VALUE}>Personal</SelectItem>
-            {teams.map((team) => (
-              <SelectItem
-                key={team.team.id}
-                value={`${TEAM_VALUE_PREFIX}${team.team.id}`}
-              >
-                {team.team.slug}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      ) : null}
+      <TraycerAccountSelect
+        teams={teams}
+        value={accountContextValue(resolved)}
+        onValueChange={(value) =>
+          setAccountContext(parseAccountContextValue(value))
+        }
+      />
 
       <SubscriptionBody query={query} subscription={subscription} />
     </div>
@@ -201,7 +96,7 @@ function SubscriptionBody({
   subscription,
 }: {
   readonly query: UseQueryResult<AuthenticatedUser | null>;
-  readonly subscription: Subscription | null;
+  readonly subscription: TraycerSubscription | null;
 }) {
   if (query.isPending) {
     return (
@@ -224,246 +119,5 @@ function SubscriptionBody({
       </div>
     );
   }
-  return <SubscriptionDetail subscription={subscription} />;
-}
-
-function SubscriptionDetail({
-  subscription,
-}: {
-  readonly subscription: Subscription;
-}) {
-  const status = subscription.subscriptionStatus;
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant={isPaid(status) ? "default" : "secondary"}>
-          {TIER_LABELS[status]}
-        </Badge>
-        {subscription.isInTrial ? <Badge variant="outline">Trial</Badge> : null}
-      </div>
-
-      {isCreditBasedPricing(status) ? (
-        <CreditBreakdownView breakdown={creditBreakdown(subscription)} />
-      ) : (
-        <RateLimitView subscription={subscription} />
-      )}
-    </div>
-  );
-}
-
-// Artifact token counts aren't dollars - integers as-is, fractional usage to
-// 3dp, mirroring the extension's `${consumed.toFixed(3)} / ${totalTokens}`.
-function formatArtifactTokens(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(3);
-}
-
-// Rate-limit (legacy / v2) plans don't bill credits - they throttle artifact
-// generation and refill at a recharge rate. Mirrors the extension's
-// `RateLimitBasedPlanUsageDisplay` (recharge rate + artifact bar + bundle bar).
-// Live artifact usage comes from aperture via `host.getRateLimitUsage`; when
-// aperture is off or has no data (totalTokens === 0) we show "unavailable"
-// rather than a 0-left bar (decision 2).
-function RateLimitView({
-  subscription,
-}: {
-  readonly subscription: Subscription;
-}) {
-  const usageQuery = useHostRateLimitUsageQuery();
-  // Keep the bar live: a Traycer turn finishing while this card is open
-  // re-fetches usage. Only mounted here, so it costs nothing elsewhere.
-  useRefreshRateLimitUsageOnTraycerTurn();
-
-  const recharge = formatRechargeRate(subscription.rechargeRateSeconds);
-  const usage = usageQuery.data ?? null;
-  const artifactTotal = usage?.totalTokens ?? 0;
-  const artifactConsumed = Math.max(
-    0,
-    artifactTotal - (usage?.remainingTokens ?? 0),
-  );
-  const bundle = subscription.bundleSummary;
-  const bundleTotal = bundle?.bundleTotal ?? 0;
-  const bundleConsumed = Math.max(
-    0,
-    bundleTotal - (bundle?.bundleRemaining ?? 0),
-  );
-  return (
-    <div className="flex flex-col gap-3">
-      <span className="text-ui-sm font-medium text-foreground">Rate limit</span>
-      {recharge !== null ? (
-        <div className="flex items-center justify-between text-ui-sm">
-          <span className="text-muted-foreground">New artifact every</span>
-          <span className="font-medium text-foreground">{recharge}</span>
-        </div>
-      ) : null}
-      {artifactTotal > 0 ? (
-        <UsageBar
-          label="Artifacts"
-          consumed={artifactConsumed}
-          total={artifactTotal}
-          formatValue={formatArtifactTokens}
-        />
-      ) : (
-        <p className="text-ui-xs text-muted-foreground">
-          Live artifact usage is unavailable.
-        </p>
-      )}
-      {bundleTotal > 0 ? (
-        <UsageBar
-          label="Bundle"
-          consumed={bundleConsumed}
-          total={bundleTotal}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-// Local mirror of the extension's `getCreditBreakdown` (the helper lives in
-// an internal shared package, which clients can't import). Three buckets -
-// Plan, Bonus, Bundle - tracked as consumed/total, matching the extension's
-// wording.
-interface CreditBreakdown {
-  readonly planTotal: number;
-  readonly planConsumed: number;
-  readonly bonusTotal: number;
-  readonly bonusConsumed: number;
-  readonly bundleTotal: number;
-  readonly bundleConsumed: number;
-  readonly totalAvailable: number;
-  readonly totalConsumed: number;
-}
-
-function creditBreakdown(subscription: Subscription): CreditBreakdown {
-  const credit = subscription.credit;
-  const planTotal = subscription.totalPlanCredits ?? 0;
-  const planRemaining = Math.max(
-    0,
-    planTotal - (credit?.consumedFromPlan ?? 0),
-  );
-  const planConsumed = Math.max(0, planTotal - planRemaining);
-  const bonusTotal = credit?.bonusCredits ?? 0;
-  const bonusConsumed = credit?.consumedFromBonus ?? 0;
-  const bundleTotal = subscription.bundleSummary?.bundleTotal ?? 0;
-  const bundleRemaining = subscription.bundleSummary?.bundleRemaining ?? 0;
-  const bundleConsumed = Math.max(0, bundleTotal - bundleRemaining);
-  return {
-    planTotal,
-    planConsumed,
-    bonusTotal,
-    bonusConsumed,
-    bundleTotal,
-    bundleConsumed,
-    totalAvailable: planTotal + bonusTotal + bundleTotal,
-    totalConsumed: planConsumed + bonusConsumed + bundleConsumed,
-  };
-}
-
-// $-denominated credits. ponytail: 2dp currency rather than the extension's odd
-// 3dp - decimals aren't part of the naming the user asked us to match.
-function formatCredits(value: number): string {
-  return `$${value.toFixed(2)}`;
-}
-
-function usageColor(percentUsed: number, bonusInUse: boolean): string {
-  if (percentUsed < 50) return "text-green-500";
-  if (percentUsed < 90) return bonusInUse ? "text-blue-500" : "text-yellow-500";
-  return "text-red-500";
-}
-
-function CreditBreakdownView({
-  breakdown,
-}: {
-  readonly breakdown: CreditBreakdown;
-}) {
-  if (breakdown.totalAvailable <= 0) {
-    return (
-      <div className="text-ui-sm text-muted-foreground">
-        No credit usage to display for this plan.
-      </div>
-    );
-  }
-  const percentUsed = Math.min(
-    100,
-    (breakdown.totalConsumed / breakdown.totalAvailable) * 100,
-  );
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex items-center justify-between">
-        <span className="text-ui-sm font-medium text-foreground">
-          Credit breakdown
-        </span>
-        <span
-          className={cn(
-            "text-ui-xs font-medium",
-            usageColor(percentUsed, breakdown.bonusConsumed > 0),
-          )}
-        >
-          {percentUsed.toFixed(0)}% used
-        </span>
-      </div>
-      {breakdown.planTotal > 0 ? (
-        <UsageBar
-          label="Plan"
-          consumed={breakdown.planConsumed}
-          total={breakdown.planTotal}
-        />
-      ) : null}
-      {breakdown.bonusTotal > 0 ? (
-        <UsageBar
-          label="Bonus"
-          consumed={breakdown.bonusConsumed}
-          total={breakdown.bonusTotal}
-          accent
-        />
-      ) : null}
-      {breakdown.bundleTotal > 0 ? (
-        <UsageBar
-          label="Bundle"
-          consumed={breakdown.bundleConsumed}
-          total={breakdown.bundleTotal}
-        />
-      ) : null}
-    </div>
-  );
-}
-
-function UsageBar({
-  label,
-  consumed,
-  total,
-  accent,
-  formatValue,
-}: {
-  readonly label: string;
-  readonly consumed: number;
-  readonly total: number;
-  readonly accent?: boolean;
-  // Defaults to $-denominated credits; artifact bars pass a token formatter.
-  readonly formatValue?: (value: number) => string;
-}) {
-  const format = formatValue ?? formatCredits;
-  const percent = total > 0 ? Math.min(100, (consumed / total) * 100) : 0;
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-center justify-between text-ui-sm">
-        <span
-          className={cn("text-muted-foreground", accent && "text-blue-400")}
-        >
-          {label}
-        </span>
-        <span className="font-mono text-ui-xs text-foreground">
-          {format(consumed)} / {format(total)}
-        </span>
-      </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-        <div
-          className={cn(
-            "h-full rounded-full transition-all",
-            accent ? "bg-blue-400" : "bg-primary",
-          )}
-          style={{ width: `${percent}%` }}
-        />
-      </div>
-    </div>
-  );
+  return <TraycerSubscriptionView subscription={subscription} />;
 }

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
@@ -1,0 +1,299 @@
+/**
+ * Presentational, query-free views for the Traycer subscription surface, shared
+ * by the Settings › Providers › Traycer card (`traycer-subscription-section.tsx`)
+ * and the header rate-limit popover's "Traycer" tab (`rate-limit-popover.tsx`) -
+ * the same "one renderer, two surfaces" split `provider-rate-limit-views.tsx`
+ * uses for the host-RPC providers, so the card and the popover can never
+ * disagree.
+ *
+ * `TraycerSubscriptionView` is the shared body (credit/rate-limit breakdown -
+ * no tier/trial badge; feedback: "badge is not needed, just show plan, bonus
+ * and credits"). Unlike `ProviderRateLimitDetail`, it is NOT
+ * variant-parameterized: the Traycer body has no per-model / extra-window rows
+ * to drop, so the Overview-vs-detail difference is purely the surrounding
+ * chrome (the account picker, the "Manage subscription" link), which each
+ * caller composes around this body. Each bucket (Plan/Bonus/Bundle/Artifacts)
+ * renders through `CreditMeterRow`, the same shared `MeterRow` shell the
+ * Codex/Claude windows use, so Traycer's own bars read identically
+ * (feedback: "bar similar to claude/codex").
+ *
+ * The lone exception to "query-free" is `RateLimitView`, which keeps its own
+ * `useHostRateLimitUsageQuery` + turn-refresh exactly as before: rendering it
+ * only for rate-limit-based plans IS the tier-gate that stops the aperture pull
+ * from firing on credit-based plans, so lifting the query to the callers would
+ * either break that gate or mount it for every plan.
+ */
+import type { ReactNode } from "react";
+import type { TraycerTeamSubscription } from "@traycer/protocol/auth";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useHostRateLimitUsageQuery } from "@/hooks/host/use-host-rate-limit-usage-query";
+import { useRefreshRateLimitUsageOnTraycerTurn } from "@/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn";
+import {
+  PERSONAL_VALUE,
+  TEAM_VALUE_PREFIX,
+  creditBreakdown,
+  formatArtifactTokens,
+  formatCredits,
+  formatRechargeRate,
+  isCreditBasedPricing,
+  type CreditBreakdown,
+  type TraycerSubscription,
+} from "@/lib/auth/traycer-subscription-content";
+import {
+  rateLimitWindowFillPercent,
+  rateLimitWindowSeverity,
+  rateLimitWindowSeverityBarClassName,
+} from "@/lib/rate-limits/window-severity";
+import { cn } from "@/lib/utils";
+
+/**
+ * The Personal / Team account picker, shared by the Settings card header and the
+ * popover's Traycer detail tab. Renders nothing when the user has no teams (the
+ * only choice is Personal, so a one-option select is noise) - the caller can
+ * always render it unconditionally.
+ */
+export function TraycerAccountSelect({
+  teams,
+  value,
+  onValueChange,
+}: {
+  readonly teams: readonly TraycerTeamSubscription[];
+  readonly value: string;
+  readonly onValueChange: (value: string) => void;
+}): ReactNode {
+  if (teams.length === 0) return null;
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger size="sm" aria-label="Account" className="w-full">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={PERSONAL_VALUE}>Personal</SelectItem>
+        {teams.map((team) => (
+          <SelectItem
+            key={team.team.id}
+            value={`${TEAM_VALUE_PREFIX}${team.team.id}`}
+          >
+            {team.team.slug}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+/**
+ * The shared subscription body: either the credit breakdown (V3 credit plans)
+ * or the rate-limit view (legacy / v2 plans) - now the single source both
+ * surfaces render through.
+ */
+export function TraycerSubscriptionView({
+  subscription,
+}: {
+  readonly subscription: TraycerSubscription;
+}): ReactNode {
+  const status = subscription.subscriptionStatus;
+  return isCreditBasedPricing(status) ? (
+    <CreditBreakdownView breakdown={creditBreakdown(subscription)} />
+  ) : (
+    <RateLimitView subscription={subscription} />
+  );
+}
+
+// Rate-limit (legacy / v2) plans don't bill credits - they throttle artifact
+// generation and refill at a recharge rate. Mirrors the extension's
+// `RateLimitBasedPlanUsageDisplay` (recharge rate + artifact bar + bundle bar).
+// Live artifact usage comes from aperture via `host.getRateLimitUsage`; when
+// aperture is off or has no data (totalTokens === 0) we show "unavailable"
+// rather than a 0-left bar (decision 2). Only rendered for rate-limit plans, so
+// its `useHostRateLimitUsageQuery` mount is the implicit tier-gate.
+function RateLimitView({
+  subscription,
+}: {
+  readonly subscription: TraycerSubscription;
+}) {
+  const usageQuery = useHostRateLimitUsageQuery();
+  // Keep the bar live: a Traycer turn finishing while this is on screen
+  // re-fetches usage. Only mounted here, so it costs nothing elsewhere.
+  useRefreshRateLimitUsageOnTraycerTurn();
+
+  const recharge = formatRechargeRate(subscription.rechargeRateSeconds);
+  const usage = usageQuery.data ?? null;
+  const artifactTotal = usage?.totalTokens ?? 0;
+  const artifactConsumed = Math.max(
+    0,
+    artifactTotal - (usage?.remainingTokens ?? 0),
+  );
+  const bundle = subscription.bundleSummary;
+  const bundleTotal = bundle?.bundleTotal ?? 0;
+  const bundleConsumed = Math.max(
+    0,
+    bundleTotal - (bundle?.bundleRemaining ?? 0),
+  );
+  return (
+    <div className="flex flex-col gap-3">
+      <span className="text-ui-sm font-medium text-foreground">Rate limit</span>
+      {recharge !== null ? (
+        <div className="flex items-center justify-between text-ui-sm">
+          <span className="text-muted-foreground">New artifact every</span>
+          <span className="font-medium text-foreground">{recharge}</span>
+        </div>
+      ) : null}
+      {artifactTotal > 0 ? (
+        <CreditMeterRow
+          label="Artifacts"
+          consumed={artifactConsumed}
+          total={artifactTotal}
+          formatValue={formatArtifactTokens}
+        />
+      ) : (
+        <p className="text-ui-xs text-muted-foreground">
+          Live artifact usage is unavailable.
+        </p>
+      )}
+      {bundleTotal > 0 ? (
+        <CreditMeterRow
+          label="Bundle"
+          consumed={bundleConsumed}
+          total={bundleTotal}
+          formatValue={formatCredits}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function CreditBreakdownView({
+  breakdown,
+}: {
+  readonly breakdown: CreditBreakdown;
+}): ReactNode {
+  if (breakdown.totalAvailable <= 0) {
+    return (
+      <div className="text-ui-sm text-muted-foreground">
+        No credit usage to display for this plan.
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      {breakdown.planTotal > 0 ? (
+        <CreditMeterRow
+          label="Plan"
+          consumed={breakdown.planConsumed}
+          total={breakdown.planTotal}
+          formatValue={formatCredits}
+        />
+      ) : null}
+      {breakdown.bonusTotal > 0 ? (
+        <CreditMeterRow
+          label="Bonus"
+          consumed={breakdown.bonusConsumed}
+          total={breakdown.bonusTotal}
+          formatValue={formatCredits}
+        />
+      ) : null}
+      {breakdown.bundleTotal > 0 ? (
+        <CreditMeterRow
+          label="Bundle"
+          consumed={breakdown.bundleConsumed}
+          total={breakdown.bundleTotal}
+          formatValue={formatCredits}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The shared meter-row shell every rate-limit/credit row in the app renders
+ * through: a header line (`label` left, a `detail` slot right - a reset line
+ * plus percent for windows, a plain amount line for credit/uncapped-usage
+ * buckets), then a bar spanning the row's *full* width on its own line below,
+ * colored by the shared 4-tier severity scale (`window-severity.ts`).
+ *
+ * The bar is deliberately on its own line rather than beside the text (as it
+ * used to be): sitting the label and bar on the same line made the bar's
+ * start position and width drift with label length - a short "5h" row and a
+ * long per-model label ended up with visibly different bar widths on the same
+ * screen (feedback: "different width bars ... looking weird"). Putting the
+ * bar on a `w-full` line of its own means every row's bar is the same width
+ * regardless of what the label or detail text says, for every provider.
+ *
+ * Centralizing this is what keeps the Codex/Claude windows (`RateLimitWindowRow`
+ * in `provider-rate-limit-views.tsx`), Traycer's own bars (`CreditMeterRow`
+ * below), and the uncapped OpenRouter/Claude-extra-usage bars from drifting
+ * apart visually - each computes its own `usedPercent` and composes its own
+ * `detail`, but all of them render through this one layout and one severity
+ * scale.
+ *
+ * The track fills with `bg-foreground/15` rather than `bg-muted`, and carries
+ * no border: several dark theme presets set `--muted` equal to `--popover`,
+ * so a plain `bg-muted` track (with or without a border ring) can end up the
+ * same color as the popover background and read as "nothing there" (or as an
+ * unwanted outline where none was wanted - feedback: "keep the bar design
+ * like this [flat, no outline]"). An opacity overlay on `--foreground` is
+ * guaranteed to contrast against any background, in every theme, without
+ * needing a border to stay visible at 0% fill.
+ */
+export function MeterRow({
+  label,
+  usedPercent,
+  detail,
+}: {
+  readonly label: string;
+  readonly usedPercent: number;
+  readonly detail: ReactNode;
+}): ReactNode {
+  const severity = rateLimitWindowSeverity(usedPercent);
+  const fillPercent = rateLimitWindowFillPercent(usedPercent);
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between gap-3 text-ui-sm">
+        <span className="text-foreground">{label}</span>
+        <span className="text-ui-xs text-muted-foreground/70">{detail}</span>
+      </div>
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-foreground/15">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            rateLimitWindowSeverityBarClassName(severity),
+          )}
+          style={{ width: `${fillPercent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A credit/balance meter row - matching the Codex/Claude window rows exactly
+ * via the shared `MeterRow` shell, so Traycer's own bars read identically to
+ * the other providers' (feedback: "bar similar to claude/codex").
+ */
+function CreditMeterRow({
+  label,
+  consumed,
+  total,
+  formatValue,
+}: {
+  readonly label: string;
+  readonly consumed: number;
+  readonly total: number;
+  readonly formatValue: (value: number) => string;
+}): ReactNode {
+  const usedPercent = total > 0 ? (consumed / total) * 100 : 0;
+  return (
+    <MeterRow
+      label={label}
+      usedPercent={usedPercent}
+      detail={`${formatValue(consumed)} / ${formatValue(total)}`}
+    />
+  );
+}

--- a/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-invalidate-sharing.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-invalidate-sharing.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * End-to-end proof that a `queryClient.invalidateQueries` call for an
+ * httpFetch provider's query key (what `RateLimitRefreshAllButton` issues)
+ * flips `isFetching` on an already-mounted `useHostProviderRateLimitsQuery`
+ * observer for that same provider - the mechanism `RateLimitProviderBlock`'s
+ * per-provider refresh icon depends on. Uses the shared harness's real
+ * `HostClient` + `MockHostMessenger` and PRODUCTION QueryClient
+ * configuration - a bare test client's staleTime-0 defaults exercise
+ * different fetch semantics than the app runs.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { HostRpcRegistry } from "@/lib/host";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  createQueryClientWrapper,
+  createRateLimitSharingHarness,
+} from "@/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness";
+
+describe("invalidateQueries keeps a mounted useHostProviderRateLimitsQuery observer's isFetching in sync (httpFetch lane)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("flips isFetching true on the observer while the invalidation-triggered refetch is in flight", async () => {
+    const harness = createRateLimitSharingHarness();
+    const { method, params, options } =
+      providerRateLimitQueryOptions("openrouter");
+    const rendered = renderHook(
+      () => useHostQuery({ client: harness.client, method, params, options }),
+      { wrapper: createQueryClientWrapper(harness.queryClient) },
+    );
+
+    await waitFor(() => expect(rendered.result.current.isPending).toBe(false));
+    expect(rendered.result.current.isFetching).toBe(false);
+
+    // Exactly what `RateLimitRefreshAllButton.refreshAll` issues for an
+    // httpFetch provider.
+    void harness.queryClient.invalidateQueries({
+      queryKey: queryKeys.hostMethod<HostRpcRegistry, "host.getRateLimitUsage">(
+        mockLocalHostEntry.hostId,
+        "host.getRateLimitUsage",
+        { accountContext: DEFAULT_ACCOUNT_CONTEXT, providerId: "openrouter" },
+      ),
+    });
+
+    await waitFor(() => expect(rendered.result.current.isFetching).toBe(true));
+
+    harness.resolvePendingResponse();
+    await waitFor(() => expect(rendered.result.current.isFetching).toBe(false));
+  });
+});

--- a/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-query-options.test.ts
+++ b/clients/gui-app/src/hooks/host/__tests__/provider-rate-limit-query-options.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+
+describe("providerRateLimitQueryOptions", () => {
+  it("gives an httpFetch provider its own refetchInterval and keeps TanStack's default refetchOnMount", () => {
+    const { options } = providerRateLimitQueryOptions("openrouter");
+    expect(options?.enabled).toBe(true);
+    expect(options?.refetchInterval).toBe(5 * 60 * 1000);
+    expect(options?.refetchOnMount).toBe(true);
+  });
+
+  it("disables the query observer, refetchInterval, and refetchOnMount for an ephemeralProcess provider", () => {
+    const { options } = providerRateLimitQueryOptions("codex");
+    expect(options?.enabled).toBe(false);
+    expect(options?.refetchInterval).toBe(false);
+    expect(options?.refetchOnMount).toBe(false);
+  });
+});

--- a/clients/gui-app/src/hooks/host/__tests__/use-refresh-provider-rate-limits-on-mount.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-refresh-provider-rate-limits-on-mount.test.tsx
@@ -1,0 +1,63 @@
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  enqueueRateLimitFetch: vi.fn(() => Promise.resolve()),
+}));
+
+import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+const enqueueSpy = vi.mocked(enqueueRateLimitFetch);
+
+function setup(providerId: RateLimitProviderId) {
+  return renderHook(
+    ({ id }: { id: RateLimitProviderId }) =>
+      useRefreshProviderRateLimitsOnMount(id),
+    { initialProps: { id: providerId } },
+  );
+}
+
+describe("useRefreshProviderRateLimitsOnMount", () => {
+  beforeEach(() => {
+    enqueueSpy.mockClear();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("enqueues a force:false pull for an ephemeralProcess provider on mount", () => {
+    setup("codex");
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("no-ops on mount for an httpFetch provider - its query keeps TanStack's own refetchOnMount", () => {
+    setup("openrouter");
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  it("enqueues again when the provider id changes to a different ephemeralProcess provider", () => {
+    const { rerender } = setup("codex");
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    rerender({ id: "claude-code" });
+    expect(enqueueSpy).toHaveBeenCalledTimes(2);
+    expect(enqueueSpy).toHaveBeenLastCalledWith(
+      "claude-code",
+      DEFAULT_ACCOUNT_CONTEXT,
+      { force: false },
+    );
+  });
+
+  it("does not re-enqueue on a re-render with the same provider id", () => {
+    const { rerender } = setup("codex");
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    rerender({ id: "codex" });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/hooks/host/__tests__/use-refresh-provider-rate-limits-on-turn.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-refresh-provider-rate-limits-on-turn.test.tsx
@@ -1,0 +1,123 @@
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
+import type { ReactNode } from "react";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+// Capture the turn-completion subscriber so tests can fire synthetic completions.
+const sub = vi.hoisted(() => ({
+  handler: null as null | ((completion: { harnessId: GuiHarnessId }) => void),
+}));
+vi.mock("@/lib/notifications/chat-turn-completion", () => ({
+  subscribeChatTurnCompletions: (
+    cb: (completion: { harnessId: GuiHarnessId }) => void,
+  ) => {
+    sub.handler = cb;
+    return () => {
+      sub.handler = null;
+    };
+  },
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  enqueueRateLimitFetch: vi.fn(() => Promise.resolve()),
+}));
+
+import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+const enqueueSpy = vi.mocked(enqueueRateLimitFetch);
+
+function fireTurn(harnessId: GuiHarnessId): void {
+  act(() => {
+    sub.handler?.({ harnessId });
+  });
+}
+
+function setup(providerId: RateLimitProviderId | null, hostId: string | null) {
+  const queryClient = new QueryClient();
+  const invalidateSpy = vi
+    .spyOn(queryClient, "invalidateQueries")
+    .mockResolvedValue(undefined);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  renderHook(() => useRefreshProviderRateLimitsOnTurn(providerId, hostId), {
+    wrapper,
+  });
+  return { invalidateSpy };
+}
+
+function defineVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+describe("useRefreshProviderRateLimitsOnTurn", () => {
+  beforeEach(() => {
+    sub.handler = null;
+    enqueueSpy.mockClear();
+    defineVisibility("visible");
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("routes an ephemeralProcess provider's turn completion through the serial queue, not a direct invalidate", () => {
+    const { invalidateSpy } = setup("codex", "host-a");
+    fireTurn("codex");
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("invalidates an httpFetch provider's query directly and never touches the queue", () => {
+    const { invalidateSpy } = setup("openrouter", "host-a");
+    fireTurn("openrouter");
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+
+  it("still enqueues an ephemeralProcess turn completion while the window is hidden (guardrail 3)", () => {
+    defineVisibility("hidden");
+    setup("codex", "host-a");
+    fireTurn("codex");
+    // The visibility pause applies ONLY to the interval timer - a background
+    // turn finishing while the user is away must still refresh that provider.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("ignores completions from a different provider's harness", () => {
+    const { invalidateSpy } = setup("codex", "host-a");
+    fireTurn("claude");
+    expect(enqueueSpy).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("throttles bursts of matching completions to the outer cooldown", () => {
+    setup("codex", "host-a");
+    fireTurn("codex");
+    fireTurn("codex");
+    fireTurn("codex");
+    // The outer cooldown ref bounds the queue path to at most once per window.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops while providerId is null", () => {
+    const { invalidateSpy } = setup(null, "host-a");
+    // No subscription is created, so there is nothing to fire; assert the
+    // effect took the null branch and wired nothing up.
+    expect(sub.handler).toBeNull();
+    expect(enqueueSpy).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/hooks/host/provider-rate-limit-query-options.ts
+++ b/clients/gui-app/src/hooks/host/provider-rate-limit-query-options.ts
@@ -1,0 +1,64 @@
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { UseHostQueryOptions } from "@/hooks/host/use-host-query";
+import type { HostRpcRegistry } from "@/lib/host";
+import {
+  PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+/**
+ * Independent background refresh cadence for the `httpFetch` lane (openrouter,
+ * kilocode). A plain credential-based GET, so it just polls on its own timer -
+ * it never enters the `ephemeralProcess` serial queue.
+ */
+const HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * The method/params/options `useHostProviderRateLimitsQuery` builds its query
+ * from - split out so a future host-scoped variant (e.g. tab-scoped) can
+ * reuse the same shape without duplicating it.
+ *
+ * Branches on the fetch lane for background polling:
+ * - `httpFetch` (openrouter, kilocode): its own `refetchInterval`, with
+ *   `refetchIntervalInBackground: false` set explicitly (not left to the
+ *   TanStack default) since these are now persistent app-shell subscriptions -
+ *   no polling while the tab is hidden. `refetchOnMount` stays at TanStack's
+ *   own default (`true`): a plain GET has no subprocess to bound, so letting a
+ *   popover/Settings-card remount refetch directly when stale is exactly
+ *   "fetch fresh data on open" with no downside.
+ * - `ephemeralProcess` (codex, claude-code): no `refetchInterval` at all. Their
+ *   background refresh is driven entirely by the serial queue's interval timer
+ *   writing fresh data into this exact query key; adding an interval here would
+ *   spawn subprocesses outside the queue and defeat its concurrency bound. For
+ *   the exact same reason, `refetchOnMount` is forced to `false`: TanStack's
+ *   default would otherwise fire a refetch straight through this query's own
+ *   `queryFn` on every popover/Settings-card open (a fresh mount) whenever the
+ *   cached data is stale - a direct host call that bypasses the queue and can
+ *   overlap a fetch it's already draining. `useRefreshProviderRateLimitsOnMount`
+ *   and `RateLimitQueueProvider` are the queue-routed replacements. The query
+ *   observer is disabled for this lane so it observes the shared cache state
+ *   without ever initiating its own subprocess-spawning request.
+ */
+export function providerRateLimitQueryOptions(
+  providerId: RateLimitProviderId,
+): Omit<
+  UseHostQueryOptions<HostRpcRegistry, "host.getRateLimitUsage">,
+  "client"
+> {
+  const isHttpFetch = rateLimitFetchLane(providerId) === "httpFetch";
+  return {
+    method: "host.getRateLimitUsage",
+    params: { accountContext: DEFAULT_ACCOUNT_CONTEXT, providerId },
+    options: {
+      enabled: isHttpFetch,
+      retry: false,
+      staleTime: PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+      refetchInterval: isHttpFetch
+        ? HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS
+        : false,
+      refetchIntervalInBackground: false,
+      refetchOnMount: isHttpFetch ? true : false,
+    },
+  };
+}

--- a/clients/gui-app/src/hooks/host/use-host-provider-rate-limits-query.ts
+++ b/clients/gui-app/src/hooks/host/use-host-provider-rate-limits-query.ts
@@ -1,0 +1,33 @@
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import { useHostClient, type HostRpcRegistry } from "@/lib/host";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+/**
+ * Provider-account rate limits (Codex / Claude Code CLI) for the default
+ * host, read via the same `host.getRateLimitUsage` RPC the aperture query
+ * (`useHostRateLimitUsageQuery`) uses - `providerId` in `params` selects the
+ * `@1.2` provider-pull branch instead of the `accountContext` aperture
+ * branch, so the two hooks produce distinct query keys without colliding.
+ * `accountContext` is still sent because the request schema requires it
+ * (default-valued in `@1.1`); the provider-pull resolver ignores it.
+ *
+ * Takes a non-null `RateLimitProviderId` rather than `ProviderId | null`:
+ * every caller already gates on `isRateLimitCapableProvider` (or a prop
+ * typed `RateLimitProviderId`) before mounting the component that calls this
+ * hook, so a `null` branch here would be dead - and a `providerId ?? undefined`
+ * coercion in `params` would hash to the exact same query key as the
+ * aperture query's `{ accountContext }`, silently sharing its cache entry.
+ *
+ * Default-host scoped, for the Settings > Providers card
+ * (`ProviderRateLimitSettingsCard`).
+ */
+export function useHostProviderRateLimitsQuery(
+  providerId: RateLimitProviderId,
+) {
+  const client = useHostClient();
+  return useHostQuery<HostRpcRegistry, "host.getRateLimitUsage">({
+    client,
+    ...providerRateLimitQueryOptions(providerId),
+  });
+}

--- a/clients/gui-app/src/hooks/host/use-refresh-provider-rate-limits-on-mount.ts
+++ b/clients/gui-app/src/hooks/host/use-refresh-provider-rate-limits-on-mount.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import {
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+/**
+ * On mount (and whenever `providerId` changes to a new provider), ensures an
+ * `ephemeralProcess` provider's rate limits get a fresh-data-on-open pull
+ * through the shared serial queue (`force: false`, so it still no-ops if the
+ * cached data is younger than `PROVIDER_RATE_LIMITS_STALE_TIME_MS`).
+ *
+ * This exists because `providerRateLimitQueryOptions` deliberately sets
+ * `refetchOnMount: false` for this lane: TanStack's own default would
+ * otherwise refetch straight through the query's `queryFn` on every mount,
+ * bypassing the queue's single-subprocess-at-a-time guarantee. Routing the
+ * mount trigger through `enqueueRateLimitFetch` instead means every
+ * popover/Settings-card open (both of which mount this provider's query fresh)
+ * gets the exact same guarantee every other automatic trigger (the interval
+ * timer, a turn completion) already has: never a second subprocess racing one
+ * already queued or in flight.
+ *
+ * `httpFetch` providers (openrouter, kilocode) don't need this: their query
+ * keeps TanStack's default `refetchOnMount`, which is already safe there (a
+ * plain GET, no subprocess to serialize) - this hook no-ops for them.
+ */
+export function useRefreshProviderRateLimitsOnMount(
+  providerId: RateLimitProviderId,
+): void {
+  useEffect(() => {
+    if (rateLimitFetchLane(providerId) !== "ephemeralProcess") return;
+    void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  }, [providerId]);
+}

--- a/clients/gui-app/src/hooks/host/use-refresh-provider-rate-limits-on-turn.ts
+++ b/clients/gui-app/src/hooks/host/use-refresh-provider-rate-limits-on-turn.ts
@@ -1,0 +1,103 @@
+import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { HostRpcRegistry } from "@traycer/protocol/host/index";
+import { subscribeChatTurnCompletions } from "@/lib/notifications/chat-turn-completion";
+import { providerIdToGuiHarnessId } from "@/lib/provider-ordering";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+/**
+ * While mounted, refreshes `host.getRateLimitUsage` for `hostId` whenever a
+ * chat turn on `providerId`'s harness completes - the provider-pull analog of
+ * `useRefreshRateLimitUsageOnTraycerTurn`. Branches on the provider's fetch
+ * lane:
+ *
+ * - `ephemeralProcess` (codex, claude-code): enqueues onto the shared serial
+ *   queue (`enqueueRateLimitFetch(..., { force: false })`) rather than
+ *   invalidating directly, so a turn completion can't race a scheduled interval
+ *   tick into two overlapping subprocess spawns. This enqueue is deliberately
+ *   NOT gated by window visibility - only the interval timer pauses when hidden;
+ *   a background turn finishing while the user is away must still update data.
+ * - `httpFetch` (openrouter, kilocode): invalidates the query directly (no
+ *   subprocess to bound), exactly as before.
+ *
+ * Unlike the aperture refresh hook (always default-host scoped, mounted only
+ * by the Traycer-only `RateLimitView`), `hostId` is a caller-supplied
+ * parameter instead of a hardcoded `useReactiveActiveHostId()` read, so a
+ * future tab-scoped consumer can reuse this hook without a rewrite.
+ *
+ * Targets the exact `{ accountContext, providerId }` params key (the same one
+ * `useHostProviderRateLimitsQuery` builds), NOT the whole
+ * `host.getRateLimitUsage` method scope: a method-scope invalidation would
+ * also refetch the aperture query and every OTHER provider's query on this
+ * host, so e.g. a Codex turn completing would spawn a `claude` subprocess to
+ * refresh Claude's rate limits too, for data a Codex turn can't have changed.
+ *
+ * Both paths are throttled by an outer cooldown ref to at most once per
+ * `PROVIDER_RATE_LIMITS_STALE_TIME_MS` (a persistent, always-mounted surface
+ * would otherwise refresh on every single matching turn completion); for the
+ * queue path the queue's own 30s freshness floor is a second, independent layer
+ * under this ref.
+ *
+ * No-ops while `providerId` is `null` (surface isn't gated to a rate-limit
+ * -capable provider).
+ */
+export function useRefreshProviderRateLimitsOnTurn(
+  providerId: RateLimitProviderId | null,
+  hostId: string | null,
+): void {
+  const queryClient = useQueryClient();
+  const lastInvalidatedAtRef = useRef(0);
+
+  useEffect(() => {
+    // Reset the cooldown whenever this effect re-runs for a new hostId/
+    // providerId pair - otherwise a provider switch on the same mounted
+    // component (e.g. the chat's selected harness changes) inherits the
+    // previous provider's cooldown timestamp and can skip its own first,
+    // otherwise-due invalidation.
+    lastInvalidatedAtRef.current = 0;
+    if (providerId === null) return;
+    const harnessId = providerIdToGuiHarnessId(providerId);
+    return subscribeChatTurnCompletions((completion) => {
+      if (completion.harnessId !== harnessId) return;
+      const now = Date.now();
+      if (
+        now - lastInvalidatedAtRef.current <
+        PROVIDER_RATE_LIMITS_STALE_TIME_MS
+      ) {
+        return;
+      }
+      lastInvalidatedAtRef.current = now;
+      // ephemeralProcess providers (codex, claude-code) route through the shared
+      // serial queue so this turn-completion refresh can't spawn a subprocess
+      // that overlaps a scheduled interval tick. The queue's own 30s floor is a
+      // second, independent layer under this hook's outer cooldown ref. Crucially
+      // this fires regardless of window visibility - only the interval timer
+      // pauses when hidden, so a background turn finishing while the user is away
+      // still updates that provider's data.
+      if (rateLimitFetchLane(providerId) === "ephemeralProcess") {
+        void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+          force: false,
+        });
+        return;
+      }
+      // httpFetch providers (openrouter, kilocode) never touch the queue - a
+      // plain credential GET has no subprocess to bound, so invalidate directly.
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.hostMethod<
+          HostRpcRegistry,
+          "host.getRateLimitUsage"
+        >(hostId, "host.getRateLimitUsage", {
+          accountContext: DEFAULT_ACCOUNT_CONTEXT,
+          providerId,
+        }),
+      });
+    });
+  }, [queryClient, hostId, providerId]);
+}

--- a/clients/gui-app/src/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn.ts
+++ b/clients/gui-app/src/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn.ts
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import { subscribeChatTurnCompletions } from "@/lib/notifications/chat-turn-completion";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useAccountContextStore } from "@/stores/auth/account-context-store";
 import { queryKeys } from "@/lib/query-keys";
 
 /**
@@ -10,19 +12,31 @@ import { queryKeys } from "@/lib/query-keys";
  * `subscribeChatTurnCompletions` trigger the credit refresh uses, so the
  * usage bar moves in step with credits.
  *
+ * Invalidates the exact `{ accountContext }` params key
+ * (`useHostRateLimitUsageQuery`'s own key), not the whole
+ * `host.getRateLimitUsage` method scope: a method-scope invalidation would
+ * also refetch any actively-observed provider-pull query on this host (see
+ * `useRefreshProviderRateLimitsOnTurn`), spawning a CLI subprocess on every
+ * Traycer turn even though a Traycer turn can't have changed a Codex/Claude
+ * account's rate limits.
+ *
  * Mounted by `RateLimitView` (rate-limit tiers only), mirroring
  * `useRefreshCreditsOnTraycerTurn`.
  */
 export function useRefreshRateLimitUsageOnTraycerTurn(): void {
   const queryClient = useQueryClient();
   const hostId = useReactiveActiveHostId();
+  const accountContext = useAccountContextStore((s) => s.accountContext);
 
   useEffect(() => {
     return subscribeChatTurnCompletions((completion) => {
       if (completion.harnessId !== "traycer") return;
       void queryClient.invalidateQueries({
-        queryKey: queryKeys.hostMethodScope(hostId, "host.getRateLimitUsage"),
+        queryKey: queryKeys.hostMethod<
+          HostRpcRegistry,
+          "host.getRateLimitUsage"
+        >(hostId, "host.getRateLimitUsage", { accountContext }),
       });
     });
-  }, [queryClient, hostId]);
+  }, [queryClient, hostId, accountContext]);
 }

--- a/clients/gui-app/src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
+++ b/clients/gui-app/src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
@@ -1,0 +1,337 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitWindow,
+  RateLimitUsageResponseV12,
+} from "@traycer/protocol/host";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+interface MockQueryResult {
+  readonly data: RateLimitUsageResponseV12 | undefined;
+  readonly isError: boolean;
+}
+
+type MockState = {
+  configured: ReadonlyArray<{
+    readonly providerId: RateLimitProviderId;
+    readonly lane: "httpFetch" | "ephemeralProcess";
+  }>;
+  results: Map<RateLimitProviderId, MockQueryResult>;
+};
+
+const mocks = vi.hoisted<MockState>(() => ({
+  configured: [],
+  results: new Map(),
+}));
+
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => null,
+}));
+vi.mock("@/hooks/rate-limits/use-configured-rate-limit-providers", () => ({
+  useConfiguredRateLimitProviders: () => mocks.configured,
+}));
+vi.mock("@/hooks/host/use-host-queries", () => ({
+  useHostQueries: (args: {
+    readonly requests: ReadonlyArray<{
+      readonly params: { readonly providerId: RateLimitProviderId };
+    }>;
+  }) =>
+    args.requests.map(
+      (request) =>
+        mocks.results.get(request.params.providerId) ?? {
+          data: undefined,
+          isError: false,
+        },
+    ),
+}));
+
+import { useHeaderRateLimitBars } from "@/hooks/rate-limits/use-header-rate-limit-bars";
+
+function rlWindow(usedPercent: number): ProviderRateLimitWindow {
+  return { usedPercent, resetsAt: null, durationMinutes: null };
+}
+
+function response(
+  providerRateLimits: ProviderRateLimits,
+): RateLimitUsageResponseV12 {
+  return { totalTokens: 0, remainingTokens: 0, providerRateLimits };
+}
+
+function setProvider(
+  providerId: RateLimitProviderId,
+  lane: "httpFetch" | "ephemeralProcess",
+  result: MockQueryResult,
+): void {
+  mocks.configured = [...mocks.configured, { providerId, lane }];
+  mocks.results.set(providerId, result);
+}
+
+function codexFixture(overrides: {
+  readonly primary?: ProviderRateLimitWindow | null;
+  readonly secondary?: ProviderRateLimitWindow | null;
+  readonly extraWindows?: Array<{
+    limitId: string;
+    limitName: string | null;
+    primary: ProviderRateLimitWindow | null;
+    secondary: ProviderRateLimitWindow | null;
+  }>;
+}): ProviderRateLimits {
+  return {
+    provider: "codex",
+    available: true,
+    planType: null,
+    limitId: null,
+    limitName: null,
+    primary: overrides.primary ?? null,
+    secondary: overrides.secondary ?? null,
+    extraWindows: overrides.extraWindows ?? [],
+    credits: null,
+    individualLimit: null,
+    resetCredits: null,
+    rateLimitReachedType: null,
+  };
+}
+
+function claudeCodeFixture(overrides: {
+  readonly fiveHour?: ProviderRateLimitWindow | null;
+  readonly sevenDay?: ProviderRateLimitWindow | null;
+  readonly sevenDayOpus?: ProviderRateLimitWindow | null;
+  readonly sevenDaySonnet?: ProviderRateLimitWindow | null;
+  readonly modelScoped?: Array<
+    { displayName: string } & ProviderRateLimitWindow
+  >;
+}): ProviderRateLimits {
+  return {
+    provider: "claude-code",
+    available: true,
+    subscriptionType: null,
+    fiveHour: overrides.fiveHour ?? null,
+    sevenDay: overrides.sevenDay ?? null,
+    sevenDayOpus: overrides.sevenDayOpus ?? null,
+    sevenDaySonnet: overrides.sevenDaySonnet ?? null,
+    modelScoped: overrides.modelScoped ?? [],
+    extraUsage: null,
+  };
+}
+
+function openRouterFixture(overrides: {
+  readonly limit: number | null;
+  readonly limitRemaining: number | null;
+}): ProviderRateLimits {
+  return {
+    provider: "openrouter",
+    available: true,
+    limit: overrides.limit,
+    limitRemaining: overrides.limitRemaining,
+    dailySpend: null,
+    weeklySpend: null,
+    monthlySpend: null,
+    totalCredits: null,
+    totalUsage: null,
+    balance: null,
+  };
+}
+
+function kiloCodeFixture(): ProviderRateLimits {
+  return {
+    provider: "kilocode",
+    available: true,
+    creditBalance: 42,
+    passState: null,
+  };
+}
+
+function unavailableFixture(): ProviderRateLimits {
+  return { provider: "codex", available: false, reason: "cli_not_found" };
+}
+
+beforeEach(() => {
+  mocks.configured = [];
+  mocks.results = new Map();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useHeaderRateLimitBars", () => {
+  it("returns no bars when zero providers are configured", () => {
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns no bars for a configured provider with no data yet (cold load)", () => {
+    setProvider("codex", "ephemeralProcess", {
+      data: undefined,
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("shows each provider's 5h window when both Codex and Claude Code are configured, codex first", () => {
+    // Insert Claude first to prove the codex-before-claude order is fixed (from
+    // GLYPH_PROVIDER_IDS / PROVIDER_ID_ORDER), not just insertion order.
+    setProvider("claude-code", "ephemeralProcess", {
+      data: response(
+        claudeCodeFixture({ fiveHour: rlWindow(70), sevenDay: rlWindow(10) }),
+      ),
+      isError: false,
+    });
+    setProvider("codex", "ephemeralProcess", {
+      data: response(
+        codexFixture({ primary: rlWindow(40), secondary: rlWindow(20) }),
+      ),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 40,
+        severity: "blue",
+        degraded: false,
+      },
+      {
+        providerId: "claude-code",
+        windowLabel: "5h",
+        usedPercent: 70,
+        severity: "yellow",
+        degraded: false,
+      },
+    ]);
+  });
+
+  it("fills both bars from Codex's 5h + Weekly windows when only Codex is configured", () => {
+    setProvider("codex", "ephemeralProcess", {
+      data: response(
+        codexFixture({ primary: rlWindow(88), secondary: rlWindow(30) }),
+      ),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 88,
+        severity: "red",
+        degraded: false,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "Weekly",
+        usedPercent: 30,
+        severity: "blue",
+        degraded: false,
+      },
+    ]);
+  });
+
+  it("fills both bars from Claude Code's 5h + Weekly windows when only Claude Code is configured", () => {
+    setProvider("claude-code", "ephemeralProcess", {
+      data: response(
+        claudeCodeFixture({ fiveHour: rlWindow(12), sevenDay: rlWindow(64) }),
+      ),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([
+      {
+        providerId: "claude-code",
+        windowLabel: "5h",
+        usedPercent: 12,
+        severity: "blue",
+        degraded: false,
+      },
+      {
+        providerId: "claude-code",
+        windowLabel: "Weekly",
+        usedPercent: 64,
+        severity: "yellow",
+        degraded: false,
+      },
+    ]);
+  });
+
+  it("returns no bars when a single provider is missing one of its two windows (partial load)", () => {
+    // Partial-load policy: the glyph fills both slots or shows the placeholder.
+    // Claude's 5h has loaded but its Weekly window is absent -> [] (placeholder),
+    // not a lone real bar.
+    setProvider("claude-code", "ephemeralProcess", {
+      data: response(
+        claudeCodeFixture({ fiveHour: rlWindow(20), sevenDay: null }),
+      ),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns no bars when both are configured but one is still cold (partial load)", () => {
+    // Codex loaded, Claude Code still cold -> can't fill both slots -> [].
+    setProvider("codex", "ephemeralProcess", {
+      data: response(
+        codexFixture({ primary: rlWindow(50), secondary: rlWindow(10) }),
+      ),
+      isError: false,
+    });
+    setProvider("claude-code", "ephemeralProcess", {
+      data: undefined,
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("never contributes bars for OpenRouter / Kilo Code (popover-only providers)", () => {
+    setProvider("openrouter", "httpFetch", {
+      data: response(openRouterFixture({ limit: 200, limitRemaining: 50 })),
+      isError: false,
+    });
+    setProvider("kilocode", "httpFetch", {
+      data: response(kiloCodeFixture()),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("returns no bars for the unavailable arm", () => {
+    setProvider("codex", "ephemeralProcess", {
+      data: response(unavailableFixture()),
+      isError: false,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([]);
+  });
+
+  it("marks both of a single provider's bars degraded when the latest poll errored", () => {
+    setProvider("codex", "ephemeralProcess", {
+      data: response(
+        codexFixture({ primary: rlWindow(65), secondary: rlWindow(15) }),
+      ),
+      isError: true,
+    });
+    const { result } = renderHook(() => useHeaderRateLimitBars());
+    expect(result.current).toEqual([
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 65,
+        severity: "yellow",
+        degraded: true,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "Weekly",
+        usedPercent: 15,
+        severity: "blue",
+        degraded: true,
+      },
+    ]);
+  });
+});

--- a/clients/gui-app/src/hooks/rate-limits/__tests__/use-provider-rate-limit-refresh.test.tsx
+++ b/clients/gui-app/src/hooks/rate-limits/__tests__/use-provider-rate-limit-refresh.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Focused unit coverage for `useProviderRateLimitRefresh` - the single source
+ * of truth for a provider's refresh action + spinner state, shared by the
+ * popover's `RateLimitProviderBlock` and the Settings card. The consumers'
+ * own tests exercise this logic only through their full component trees;
+ * these pin the lane routing and the `draining` fold-in directly, so a
+ * regression is caught even if a consumer's test setup masks it.
+ *
+ * `rateLimitFetchLane` stays REAL (it is a pure provider-id classifier):
+ * codex exercises the ephemeralProcess lane and openrouter the httpFetch
+ * lane, so the routing under test is the true production mapping rather than
+ * a mocked one.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+
+const mocks = vi.hoisted(() => ({
+  draining: false,
+  enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
+}));
+
+vi.mock("@/hooks/rate-limits/use-is-rate-limit-queue-draining", () => ({
+  useIsRateLimitQueueDraining: () => mocks.draining,
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  // Wrapper (not `mocks.enqueue` directly) so `beforeEach` can swap the spy.
+  enqueueRateLimitFetch: (...args: unknown[]) => mocks.enqueue(...args),
+}));
+// No-op the fresh-on-open side effect: it has its own enqueue call that would
+// pollute the spy, and its behavior is covered through the consumers' tests.
+vi.mock("@/hooks/host/use-refresh-provider-rate-limits-on-mount", () => ({
+  useRefreshProviderRateLimitsOnMount: () => {},
+}));
+
+import { useProviderRateLimitRefresh } from "@/hooks/rate-limits/use-provider-rate-limit-refresh";
+
+beforeEach(() => {
+  mocks.draining = false;
+  mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useProviderRateLimitRefresh refresh routing", () => {
+  it("routes an ephemeralProcess provider's refresh through the serial queue with force:true, never a bare refetch", async () => {
+    const refetch = vi.fn(() => Promise.resolve({}));
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("codex", false, refetch),
+    );
+
+    await result.current.refresh();
+
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "codex",
+      DEFAULT_ACCOUNT_CONTEXT,
+      {
+        force: true,
+      },
+    );
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("routes an httpFetch provider's refresh through its own refetch, never the queue", async () => {
+    const refetch = vi.fn(() => Promise.resolve({}));
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("openrouter", false, refetch),
+    );
+
+    await result.current.refresh();
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+});
+
+describe("useProviderRateLimitRefresh isRefreshing", () => {
+  const refetch = () => Promise.resolve({});
+
+  it("reflects the provider's own isFetching on both lanes", () => {
+    const codex = renderHook(() =>
+      useProviderRateLimitRefresh("codex", true, refetch),
+    );
+    expect(codex.result.current.isRefreshing).toBe(true);
+
+    const openrouter = renderHook(() =>
+      useProviderRateLimitRefresh("openrouter", true, refetch),
+    );
+    expect(openrouter.result.current.isRefreshing).toBe(true);
+  });
+
+  it("folds the queue's draining flag in for an ephemeralProcess provider whose own fetch has settled", () => {
+    mocks.draining = true;
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("codex", false, refetch),
+    );
+    expect(result.current.isRefreshing).toBe(true);
+  });
+
+  it("ignores draining for an httpFetch provider - its own isFetching is the complete signal", () => {
+    mocks.draining = true;
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("openrouter", false, refetch),
+    );
+    expect(result.current.isRefreshing).toBe(false);
+  });
+
+  it("is false when nothing is fetching and the queue is idle", () => {
+    const { result } = renderHook(() =>
+      useProviderRateLimitRefresh("codex", false, refetch),
+    );
+    expect(result.current.isRefreshing).toBe(false);
+  });
+});

--- a/clients/gui-app/src/hooks/rate-limits/use-configured-rate-limit-providers.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-configured-rate-limit-providers.ts
@@ -1,0 +1,44 @@
+import { useMemo } from "react";
+import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
+import {
+  isRateLimitCapableProvider,
+  isRateLimitProviderConfigured,
+  rateLimitFetchLane,
+  type RateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+export interface ConfiguredRateLimitProvider {
+  readonly providerId: RateLimitProviderId;
+  readonly lane: RateLimitFetchLane;
+}
+
+/**
+ * The currently-configured rate-limit-capable providers on the default host,
+ * each tagged with its fetch lane. Drives both the interval timer (walks the
+ * `ephemeralProcess` entries) and, later, the popover rail.
+ *
+ * Mounted persistently at the app-shell level (via `RateLimitQueueProvider`),
+ * so `providers.list` is subscribed for the window's lifetime rather than
+ * lazily on Settings open. `subscribed: true` keeps it refreshing so a
+ * credential change (login/logout invalidates `providers.list`) re-gates the
+ * set - a removed credential drops its provider here immediately, and the next
+ * timer tick reads the shortened list.
+ *
+ * TanStack's structural sharing keeps `data.providers` referentially stable
+ * across identical polls, so the memoized projection only recomputes on a real
+ * list change.
+ */
+export function useConfiguredRateLimitProviders(): ReadonlyArray<ConfiguredRateLimitProvider> {
+  const providersQuery = useProvidersList({ enabled: true, subscribed: true });
+  const providers = providersQuery.data?.providers;
+  return useMemo(() => {
+    if (providers === undefined) return [];
+    return providers.flatMap((state) => {
+      const providerId = state.providerId;
+      if (!isRateLimitCapableProvider(providerId)) return [];
+      if (!isRateLimitProviderConfigured(state)) return [];
+      return [{ providerId, lane: rateLimitFetchLane(providerId) }];
+    });
+  }, [providers]);
+}

--- a/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
@@ -1,0 +1,230 @@
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitWindow,
+} from "@traycer/protocol/host";
+import { useHostQueries } from "@/hooks/host/use-host-queries";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import { useConfiguredRateLimitProviders } from "@/hooks/rate-limits/use-configured-rate-limit-providers";
+import { useHostClient, type HostRpcRegistry } from "@/lib/host";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+import {
+  rateLimitWindowSeverity,
+  type RateLimitWindowSeverity,
+} from "@/lib/rate-limits/window-severity";
+
+/**
+ * The two windows a glyph bar can stand for, in fixed draw order: a provider's
+ * 5-hour window and its Weekly window. Also the per-bar disambiguator in the
+ * React key, since a single provider can own *both* bars (see below).
+ */
+export type HeaderRateLimitWindowLabel = "5h" | "Weekly";
+
+export interface HeaderRateLimitBar {
+  readonly providerId: RateLimitProviderId;
+  readonly windowLabel: HeaderRateLimitWindowLabel;
+  readonly usedPercent: number;
+  readonly severity: RateLimitWindowSeverity;
+  /** Most recent poll for this provider errored, but this is last-known-good data. */
+  readonly degraded: boolean;
+}
+
+/**
+ * The only providers that ever occupy a glyph slot, in fixed draw order (codex
+ * before claude-code, matching `PROVIDER_ID_ORDER`). OpenRouter and Kilo Code
+ * are popover-only and never contribute a header bar. Both of these are the
+ * `ephemeralProcess` fetch lane, so the glyph needs a single `useHostQueries`
+ * call and no `httpFetch` plumbing at all.
+ */
+const GLYPH_PROVIDER_IDS = ["codex", "claude-code"] as const;
+
+type GlyphProviderId = (typeof GLYPH_PROVIDER_IDS)[number];
+
+/** A glyph provider's live query state, paired with its id (in draw order). */
+interface GlyphProviderReading {
+  readonly providerId: GlyphProviderId;
+  readonly rateLimits: ProviderRateLimits | null;
+  readonly degraded: boolean;
+}
+
+/** The 5h window a glyph provider reports (Codex `primary`, Claude `fiveHour`). */
+function fiveHourWindow(
+  rateLimits: ProviderRateLimits | null,
+): ProviderRateLimitWindow | null {
+  if (rateLimits === null || !rateLimits.available) return null;
+  switch (rateLimits.provider) {
+    case "codex":
+      return rateLimits.primary;
+    case "claude-code":
+      return rateLimits.fiveHour;
+    // OpenRouter/Kilo Code are never queried for a glyph slot; kept for
+    // exhaustiveness over the union.
+    case "openrouter":
+    case "kilocode":
+      return null;
+  }
+}
+
+/** The Weekly window a glyph provider reports (Codex `secondary`, Claude `sevenDay`). */
+function weeklyWindow(
+  rateLimits: ProviderRateLimits | null,
+): ProviderRateLimitWindow | null {
+  if (rateLimits === null || !rateLimits.available) return null;
+  switch (rateLimits.provider) {
+    case "codex":
+      return rateLimits.secondary;
+    case "claude-code":
+      return rateLimits.sevenDay;
+    case "openrouter":
+    case "kilocode":
+      return null;
+  }
+}
+
+function toBar(
+  providerId: GlyphProviderId,
+  windowLabel: HeaderRateLimitWindowLabel,
+  window: ProviderRateLimitWindow | null,
+  degraded: boolean,
+): HeaderRateLimitBar | null {
+  if (window === null) return null;
+  return {
+    providerId,
+    windowLabel,
+    usedPercent: window.usedPercent,
+    severity: rateLimitWindowSeverity(window.usedPercent),
+    degraded,
+  };
+}
+
+/** Both slots or neither - the atomic "fully populated or placeholder" pair. */
+function buildPair(
+  first: HeaderRateLimitBar | null,
+  second: HeaderRateLimitBar | null,
+): ReadonlyArray<HeaderRateLimitBar> {
+  return first !== null && second !== null ? [first, second] : [];
+}
+
+/**
+ * The glyph's two bars, or `[]` when it can't populate *both* slots:
+ *
+ * - Both providers configured: bar 1 is Codex's 5h window, bar 2 is Claude
+ *   Code's 5h window (glyph order).
+ * - Exactly one configured: that provider fills both slots with its 5h and
+ *   Weekly windows.
+ *
+ * Partial-load policy: this returns bars only when it can fill BOTH slots;
+ * anything short of that (a provider still cold, or a window the provider
+ * doesn't report) collapses to `[]`, and the icon then shows its neutral 2-bar
+ * placeholder. The glyph is a single fixed 2-bar unit (the CodexBar pre-filled
+ * look), so it flips atomically from placeholder to fully-populated rather than
+ * ever rendering a half-real / half-neutral mix - simpler and less ambiguous
+ * than padding a lone real bar with a placeholder-shaped one.
+ */
+function selectGlyphBars(
+  readings: ReadonlyArray<GlyphProviderReading>,
+): ReadonlyArray<HeaderRateLimitBar> {
+  if (readings.length >= 2) {
+    const [first, second] = readings;
+    return buildPair(
+      toBar(
+        first.providerId,
+        "5h",
+        fiveHourWindow(first.rateLimits),
+        first.degraded,
+      ),
+      toBar(
+        second.providerId,
+        "5h",
+        fiveHourWindow(second.rateLimits),
+        second.degraded,
+      ),
+    );
+  }
+  if (readings.length === 1) {
+    const [only] = readings;
+    return buildPair(
+      toBar(
+        only.providerId,
+        "5h",
+        fiveHourWindow(only.rateLimits),
+        only.degraded,
+      ),
+      toBar(
+        only.providerId,
+        "Weekly",
+        weeklyWindow(only.rateLimits),
+        only.degraded,
+      ),
+    );
+  }
+  return [];
+}
+
+/**
+ * The header glyph's bar data: a fixed two-bar summary scoped to Codex and
+ * Claude Code only. When both are configured the glyph shows each provider's 5h
+ * window (codex first); when only one is configured that provider fills both
+ * bars with its 5h and Weekly windows. OpenRouter/Kilo Code never appear here
+ * (popover-only). See `selectGlyphBars` for the exact selection and the
+ * partial-load policy; a return of `[]` means "render the neutral placeholder".
+ *
+ * Mounting `useHostQueries` here drives the initial fetch-on-mount for the two
+ * glyph providers (both `ephemeralProcess`); the serial queue only bounds their
+ * *subsequent* background/turn/manual triggers. Because this hook no longer
+ * queries the `httpFetch` lane, OpenRouter/Kilo Code are fetched lazily on
+ * popover / Settings open rather than pre-fetched at app-shell mount - which is
+ * fine, since nothing at the shell level displays their usage.
+ *
+ * A provider still cold (no data yet) contributes nothing - callers render the
+ * neutral/placeholder glyph while this returns `[]`, never a loading state, so
+ * the icon never gates header render on a fetch.
+ */
+export function useHeaderRateLimitBars(): ReadonlyArray<HeaderRateLimitBar> {
+  const client = useHostClient();
+  const configured = useConfiguredRateLimitProviders();
+  const configuredIds = new Set(
+    configured.map((provider) => provider.providerId),
+  );
+  const glyphProviders = GLYPH_PROVIDER_IDS.filter((id) =>
+    configuredIds.has(id),
+  );
+
+  // `useHostQueries` applies one shared `options` object to every request in
+  // the batch, so it's only safe to reuse a single glyph provider's options if
+  // every glyph provider actually resolves to the same ones (true today: both
+  // are `ephemeralProcess`, never `httpFetch`). Verified here - rather than
+  // just trusted from `GLYPH_PROVIDER_IDS`'s own comment - so a future glyph
+  // provider on a different lane falls back to `null` (TanStack's defaults)
+  // instead of silently borrowing an unrelated provider's refetch behavior.
+  const glyphOptions = glyphProviders.map(
+    (providerId) => providerRateLimitQueryOptions(providerId).options,
+  );
+  const [firstGlyphOptions] = glyphOptions;
+  const sharedGlyphOptions =
+    glyphProviders.length > 0 &&
+    firstGlyphOptions !== null &&
+    glyphOptions.every(
+      (options) =>
+        options !== null &&
+        options.refetchInterval === firstGlyphOptions.refetchInterval,
+    )
+      ? firstGlyphOptions
+      : null;
+
+  const results = useHostQueries<HostRpcRegistry, "host.getRateLimitUsage">({
+    client,
+    requests: glyphProviders.map((providerId) => {
+      const { method, params } = providerRateLimitQueryOptions(providerId);
+      return { method, params };
+    }),
+    options: sharedGlyphOptions,
+  });
+
+  const readings = glyphProviders.map((providerId, index) => ({
+    providerId,
+    rateLimits: results[index].data?.providerRateLimits ?? null,
+    degraded: results[index].isError,
+  }));
+
+  return selectGlyphBars(readings);
+}

--- a/clients/gui-app/src/hooks/rate-limits/use-is-rate-limit-queue-draining.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-is-rate-limit-queue-draining.ts
@@ -1,0 +1,20 @@
+import { useSyncExternalStore } from "react";
+import {
+  isRateLimitQueueDraining,
+  subscribeRateLimitQueueDraining,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+/**
+ * Reactively projects whether the `ephemeralProcess` serial queue currently has
+ * a subprocess fetch in flight. Backs the popover's "disable Refresh-all while
+ * draining" state. Both the subscribe and snapshot functions are stable module
+ * references returning a primitive boolean, so `useSyncExternalStore` never
+ * re-subscribes or tears on identity.
+ */
+export function useIsRateLimitQueueDraining(): boolean {
+  return useSyncExternalStore(
+    subscribeRateLimitQueueDraining,
+    isRateLimitQueueDraining,
+    isRateLimitQueueDraining,
+  );
+}

--- a/clients/gui-app/src/hooks/rate-limits/use-provider-rate-limit-refresh.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-provider-rate-limit-refresh.ts
@@ -1,0 +1,68 @@
+import { useCallback } from "react";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
+import { useIsRateLimitQueueDraining } from "@/hooks/rate-limits/use-is-rate-limit-queue-draining";
+import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+import {
+  rateLimitFetchLane,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+/**
+ * The single source of truth for "how do I refresh one provider's rate limits,
+ * and is that provider currently refreshing" - shared verbatim by the popover's
+ * per-provider block and the Settings card so their refresh button can never
+ * drift apart again. Both the action and the spinner state are lane-aware:
+ *
+ * - **Action (`refresh`)**:
+ *   - `ephemeralProcess` (codex, claude-code): routes through the shared serial
+ *     queue with `force: true`, so a manual refresh can never spawn a CLI
+ *     subprocess overlapping one the queue is already running. A bare
+ *     `query.refetch()` here would call the host directly and bypass that bound.
+ *   - `httpFetch` (openrouter, kilocode): a plain GET with no subprocess to
+ *     serialize, so it just refetches its own query.
+ *
+ * - **Spinner state (`isRefreshing`)**: `query.isFetching` covers a fetch on
+ *   THIS provider's own query key (whoever triggered it - the queue's
+ *   `fetchQuery`, a direct refetch, an invalidation). For `ephemeralProcess`
+ *   providers it is OR-ed with the queue's `draining` flag, because the queue
+ *   runs providers one at a time: this provider's own `isFetching` can settle
+ *   the instant its turn finishes while "Refresh all" is still working through a
+ *   later provider queued behind it. Gating on `draining` (the whole round)
+ *   rather than only this provider's own fetch keeps the button disabled for as
+ *   long as any refresh in the shared lane is in flight - matching the user's
+ *   "Refresh all is in progress" mental model, not "my own fetch is in flight".
+ *   `httpFetch` providers refresh concurrently (no shared queue), so their own
+ *   `isFetching` is already the complete signal.
+ *
+ * `isFetching` / `refetch` are threaded in from the caller's existing
+ * `useHostProviderRateLimitsQuery` observer rather than opening a second one
+ * here, so there is still exactly one query observer per mounted block.
+ */
+export function useProviderRateLimitRefresh(
+  providerId: RateLimitProviderId,
+  isFetching: boolean,
+  refetch: () => Promise<unknown>,
+): { readonly refresh: () => Promise<void>; readonly isRefreshing: boolean } {
+  const draining = useIsRateLimitQueueDraining();
+  const lane = rateLimitFetchLane(providerId);
+  // Fresh-data-on-open for the ephemeralProcess lane, routed through the shared
+  // serial queue rather than TanStack's own (deliberately disabled)
+  // refetch-on-mount - see providerRateLimitQueryOptions' doc comment. No-ops
+  // for the httpFetch lane, which keeps TanStack's refetch-on-mount instead.
+  useRefreshProviderRateLimitsOnMount(providerId);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (lane === "ephemeralProcess") {
+      await enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+        force: true,
+      });
+      return;
+    }
+    await refetch();
+  }, [lane, providerId, refetch]);
+
+  const isRefreshing = isFetching || (lane === "ephemeralProcess" && draining);
+
+  return { refresh, isRefreshing };
+}

--- a/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
+++ b/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderRateLimits } from "@traycer/protocol/host";
+import {
+  formatUnavailableReason,
+  resolvePopoverProviderRateLimitState,
+  resolveProviderPlanLabel,
+} from "@/lib/provider-rate-limit-content";
+
+const READY: ProviderRateLimits = {
+  provider: "kilocode",
+  available: true,
+  creditBalance: 10,
+  passState: null,
+};
+
+const UNAVAILABLE: ProviderRateLimits = {
+  provider: "codex",
+  available: false,
+  reason: "cli_not_found",
+};
+
+describe("formatUnavailableReason", () => {
+  it("maps the Droid org-plan gate to plain language", () => {
+    expect(formatUnavailableReason("insufficient_permissions")).toBe(
+      "this account doesn't have permission to view usage",
+    );
+  });
+
+  it("maps the CLI-missing reason", () => {
+    expect(formatUnavailableReason("cli_not_found")).toBe(
+      "the CLI isn't installed",
+    );
+  });
+});
+
+describe("resolvePopoverProviderRateLimitState", () => {
+  it("is a cold load while the first fetch is in flight with no data", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: true,
+      isFetching: true,
+      isError: false,
+      providerRateLimits: undefined,
+    });
+    expect(state.kind).toBe("cold");
+  });
+
+  it("is cold while a disabled queue-owned observer is pending without fetching", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: true,
+      isFetching: false,
+      isError: false,
+      providerRateLimits: null,
+    });
+    expect(state.kind).toBe("cold");
+  });
+
+  it("is an error when the first fetch failed with no data", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: false,
+      isFetching: false,
+      isError: true,
+      providerRateLimits: undefined,
+    });
+    expect(state.kind).toBe("error");
+  });
+
+  it("surfaces the provider's own unavailable reason", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: false,
+      isFetching: false,
+      isError: false,
+      providerRateLimits: UNAVAILABLE,
+    });
+    expect(state).toEqual({ kind: "unavailable", reason: "cli_not_found" });
+  });
+
+  it("is ready and not degraded for a fresh available snapshot", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: false,
+      isFetching: false,
+      isError: false,
+      providerRateLimits: READY,
+    });
+    expect(state).toEqual({ kind: "ready", data: READY, degraded: false });
+  });
+
+  it("is ready but degraded when a poll failed over last-known-good data", () => {
+    const state = resolvePopoverProviderRateLimitState({
+      isPending: false,
+      isFetching: false,
+      isError: true,
+      providerRateLimits: READY,
+    });
+    expect(state).toEqual({ kind: "ready", data: READY, degraded: true });
+  });
+});
+
+describe("resolveProviderPlanLabel", () => {
+  it("title-cases Codex's planType", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "codex",
+        available: true,
+        planType: "pro_5x",
+        limitId: null,
+        limitName: null,
+        primary: null,
+        secondary: null,
+        extraWindows: [],
+        credits: null,
+        individualLimit: null,
+        resetCredits: null,
+        rateLimitReachedType: null,
+      }),
+    ).toBe("Pro 5x");
+  });
+
+  it("title-cases Claude Code's subscriptionType", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "claude-code",
+        available: true,
+        subscriptionType: "max",
+        fiveHour: null,
+        sevenDay: null,
+        sevenDayOpus: null,
+        sevenDaySonnet: null,
+        modelScoped: [],
+        extraUsage: null,
+      }),
+    ).toBe("Max");
+  });
+
+  it("is null when a provider didn't report a plan/tier", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "codex",
+        available: true,
+        planType: null,
+        limitId: null,
+        limitName: null,
+        primary: null,
+        secondary: null,
+        extraWindows: [],
+        credits: null,
+        individualLimit: null,
+        resetCredits: null,
+        rateLimitReachedType: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("is always null for providers with no plan/tier concept (OpenRouter, Kilo Code)", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "openrouter",
+        available: true,
+        limit: null,
+        limitRemaining: null,
+        dailySpend: null,
+        weeklySpend: null,
+        monthlySpend: null,
+        totalCredits: null,
+        totalUsage: null,
+        balance: null,
+      }),
+    ).toBeNull();
+    expect(
+      resolveProviderPlanLabel({
+        provider: "kilocode",
+        available: true,
+        creditBalance: null,
+        passState: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/__tests__/rate-limit-providers.test.ts
+++ b/clients/gui-app/src/lib/__tests__/rate-limit-providers.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ProviderAuthStatus,
+  ProviderCliState,
+  ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
+import {
+  isRateLimitCapableProvider,
+  isRateLimitProviderConfigured,
+  rateLimitFetchLane,
+} from "@/lib/rate-limit-providers";
+
+function state(
+  overrides: Partial<ProviderCliState> & { readonly providerId: ProviderId },
+): ProviderCliState {
+  return {
+    enabled: true,
+    disabledBy: null,
+    selected: { kind: "bundled" },
+    candidates: [],
+    authPending: false,
+    checkedAt: null,
+    apiKey: { supported: false, configured: false, source: null },
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
+    availabilityPending: false,
+    auth: {
+      status: "authenticated",
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    ...overrides,
+  };
+}
+
+describe("rateLimitFetchLane", () => {
+  it("maps codex and claude-code to the ephemeralProcess (subprocess) lane", () => {
+    expect(rateLimitFetchLane("codex")).toBe("ephemeralProcess");
+    expect(rateLimitFetchLane("claude-code")).toBe("ephemeralProcess");
+  });
+
+  it("maps openrouter and kilocode to the httpFetch (cheap GET) lane", () => {
+    expect(rateLimitFetchLane("openrouter")).toBe("httpFetch");
+    expect(rateLimitFetchLane("kilocode")).toBe("httpFetch");
+  });
+});
+
+describe("isRateLimitCapableProvider", () => {
+  it("accepts the four rate-limit-capable providers and rejects others", () => {
+    expect(isRateLimitCapableProvider("codex")).toBe(true);
+    expect(isRateLimitCapableProvider("kilocode")).toBe(true);
+    expect(isRateLimitCapableProvider("cursor")).toBe(false);
+    expect(isRateLimitCapableProvider("traycer")).toBe(false);
+  });
+});
+
+describe("isRateLimitProviderConfigured", () => {
+  it("treats authenticated and configured (credential present) as eligible", () => {
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "codex", auth: authStatus("authenticated") }),
+      ),
+    ).toBe(true);
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "openrouter", auth: authStatus("configured") }),
+      ),
+    ).toBe(true);
+  });
+
+  it("excludes providers with no usable credential", () => {
+    for (const status of [
+      "unauthenticated",
+      "unavailable",
+      "unknown",
+    ] as const) {
+      expect(
+        isRateLimitProviderConfigured(
+          state({ providerId: "codex", auth: authStatus(status) }),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("excludes providers whose verdict has not settled", () => {
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "codex", authPending: true }),
+      ),
+    ).toBe(false);
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "codex", availabilityPending: true }),
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes a provider the user has disabled", () => {
+    expect(
+      isRateLimitProviderConfigured(
+        state({ providerId: "codex", enabled: false }),
+      ),
+    ).toBe(false);
+  });
+});
+
+function authStatus(status: ProviderAuthStatus): ProviderCliState["auth"] {
+  return { status, badgeText: null, label: null, detail: null };
+}

--- a/clients/gui-app/src/lib/__tests__/relative-time.test.ts
+++ b/clients/gui-app/src/lib/__tests__/relative-time.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatRelativeTimestamp } from "@/lib/relative-time";
+import {
+  formatRelativeTimestamp,
+  formatResetCountdown,
+  formatResetDateTime,
+  isFarReset,
+} from "@/lib/relative-time";
 
 const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
@@ -53,5 +58,64 @@ describe("formatRelativeTimestamp", () => {
 
   it("clamps future timestamps to 'Just now' rather than rendering negative deltas", () => {
     expect(formatRelativeTimestamp(now + 10_000, now)).toBe("Just now");
+  });
+});
+
+describe("formatResetCountdown", () => {
+  const now = Date.parse("2026-04-23T12:00:00.000Z");
+
+  it("renders 'now' for deltas under one minute (regression: was unreachable under Math.ceil)", () => {
+    expect(formatResetCountdown(now, now)).toBe("now");
+    expect(formatResetCountdown(now + 5_000, now)).toBe("now");
+    expect(formatResetCountdown(now + (MINUTE_MS - 1), now)).toBe("now");
+  });
+
+  it("renders minute buckets once a full minute away", () => {
+    expect(formatResetCountdown(now + MINUTE_MS, now)).toBe("1m");
+    expect(formatResetCountdown(now + 2 * MINUTE_MS, now)).toBe("2m");
+    expect(formatResetCountdown(now + 59 * MINUTE_MS, now)).toBe("59m");
+  });
+
+  it("renders hour+minute buckets, omitting minutes when exactly on the hour", () => {
+    expect(formatResetCountdown(now + HOUR_MS, now)).toBe("1h");
+    expect(formatResetCountdown(now + HOUR_MS + 30 * MINUTE_MS, now)).toBe(
+      "1h 30m",
+    );
+    expect(formatResetCountdown(now + 23 * HOUR_MS, now)).toBe("23h");
+  });
+
+  it("renders day buckets past 24 hours", () => {
+    expect(formatResetCountdown(now + DAY_MS, now)).toBe("1d");
+    expect(formatResetCountdown(now + 4 * DAY_MS, now)).toBe("4d");
+  });
+
+  it("clamps a past resetsAt to 'now' rather than a negative duration", () => {
+    expect(formatResetCountdown(now - 10_000, now)).toBe("now");
+  });
+});
+
+describe("isFarReset", () => {
+  const now = Date.parse("2026-04-23T12:00:00.000Z");
+
+  it("is false for a reset under one day away, regardless of a window's nominal duration", () => {
+    expect(isFarReset(now + 23 * HOUR_MS, now)).toBe(false);
+  });
+
+  it("is true at exactly one day away and beyond", () => {
+    expect(isFarReset(now + DAY_MS, now)).toBe(true);
+    expect(isFarReset(now + 3 * DAY_MS, now)).toBe(true);
+  });
+});
+
+describe("formatResetDateTime", () => {
+  it("renders a short weekday followed by the time, with no calendar date", () => {
+    const formatted = formatResetDateTime(
+      Date.parse("2026-07-11T10:35:00.000Z"),
+    );
+    // Exact weekday/time is TZ/locale-dependent, so assert structure rather
+    // than a literal string: a three-letter weekday, then a time with an
+    // AM/PM designator, and no year/date digits leaking back in.
+    expect(formatted).toMatch(/^[A-Za-z]{3} \d{1,2}:\d{2}\s?[AP]M$/i);
+    expect(formatted).not.toContain("2026");
   });
 });

--- a/clients/gui-app/src/lib/auth/__tests__/traycer-subscription-content.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/traycer-subscription-content.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AuthenticatedUser,
+  SubscriptionStatus,
+  TraycerTeamSubscription,
+  TraycerUserSubscription,
+} from "@traycer/protocol/auth";
+import {
+  accountContextValue,
+  isCreditBasedPricing,
+  isPaid,
+  isTraycerEligible,
+  parseAccountContextValue,
+  resolveTraycerSubscriptionState,
+  selectSubscription,
+  subscriptionPlanLabel,
+} from "@/lib/auth/traycer-subscription-content";
+
+const EPOCH = new Date(0);
+
+function baseSubscription() {
+  return {
+    id: "sub",
+    userID: "u1",
+    orgID: null,
+    teamID: null,
+    customerId: "cus",
+    createdAt: EPOCH,
+    updatedAt: EPOCH,
+    subscriptionExpiry: null,
+    trialEndsAt: null,
+    hasPaymentMethod: true,
+    rechargeRateSeconds: 60,
+  };
+}
+
+function userSub(overrides: {
+  status: SubscriptionStatus;
+  hasActiveBundle?: boolean;
+}): TraycerUserSubscription {
+  return {
+    ...baseSubscription(),
+    subscriptionStatus: overrides.status,
+    isInTrial: false,
+    hasActiveBundle: overrides.hasActiveBundle,
+  };
+}
+
+function teamSub(teamId: string): TraycerTeamSubscription {
+  return {
+    ...baseSubscription(),
+    teamID: teamId,
+    subscriptionStatus: "ULTRA_1X_V3",
+    isInTrial: false,
+    totalPlanCredits: 500,
+    hasActiveBundle: false,
+    bundleSummary: { bundleTotal: 0, bundleConsumed: 0, bundleRemaining: 0 },
+    team: {
+      id: teamId,
+      slug: "acme",
+      avatarUrl: null,
+      privacyMode: false,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+    },
+  };
+}
+
+function userWith(
+  userSubscription: TraycerUserSubscription,
+  teams: TraycerTeamSubscription[],
+): AuthenticatedUser {
+  return {
+    user: {
+      id: "u1",
+      name: "Ada",
+      providerId: "p1",
+      providerHandle: "ada",
+      providerType: "GITHUB",
+      email: "ada@example.com",
+      avatarUrl: null,
+      activatedAt: EPOCH,
+      createdAt: EPOCH,
+      updatedAt: EPOCH,
+      lastSeenAt: EPOCH,
+      privacyMode: false,
+      isLearningEnabled: true,
+    },
+    userSubscription,
+    payAsYouGoUsage: { allowPayAsYouGo: false },
+    teamSubscriptions: teams,
+  };
+}
+
+describe("isPaid / isCreditBasedPricing", () => {
+  it("treats only FREE/PENDING as unpaid", () => {
+    expect(isPaid("FREE")).toBe(false);
+    expect(isPaid("PENDING")).toBe(false);
+    expect(isPaid("PRO_V3")).toBe(true);
+    expect(isPaid("PRO_PLUS_V2")).toBe(true);
+  });
+
+  it("marks V3 tiers (and FREE) as credit-based, legacy/v2 as rate-limit", () => {
+    expect(isCreditBasedPricing("PRO_V3")).toBe(true);
+    expect(isCreditBasedPricing("FREE")).toBe(true);
+    expect(isCreditBasedPricing("PRO_PLUS_V2")).toBe(false);
+    expect(isCreditBasedPricing("PRO_LEGACY")).toBe(false);
+  });
+});
+
+describe("isTraycerEligible", () => {
+  it("is eligible on a paid plan", () => {
+    expect(isTraycerEligible(userSub({ status: "PRO_V3" }))).toBe(true);
+  });
+
+  it("is eligible on a free plan that holds an active bundle", () => {
+    expect(
+      isTraycerEligible(userSub({ status: "FREE", hasActiveBundle: true })),
+    ).toBe(true);
+  });
+
+  it("is not eligible on a free, unbundled plan", () => {
+    expect(isTraycerEligible(userSub({ status: "FREE" }))).toBe(false);
+    expect(
+      isTraycerEligible(userSub({ status: "FREE", hasActiveBundle: false })),
+    ).toBe(false);
+  });
+});
+
+describe("selectSubscription", () => {
+  const personal = userSub({ status: "PRO_V3" });
+  const team = teamSub("team-1");
+  const user = userWith(personal, [team]);
+
+  it("returns null when the user isn't loaded", () => {
+    expect(selectSubscription(null, { type: "PERSONAL" }, [])).toBeNull();
+  });
+
+  it("returns the personal subscription for the PERSONAL context", () => {
+    expect(selectSubscription(user, { type: "PERSONAL" }, [team])).toBe(
+      personal,
+    );
+  });
+
+  it("returns the matching team subscription for a TEAM context", () => {
+    expect(
+      selectSubscription(user, { type: "TEAM", teamId: "team-1" }, [team]),
+    ).toBe(team);
+  });
+
+  it("returns null for a TEAM context with no matching team", () => {
+    expect(
+      selectSubscription(user, { type: "TEAM", teamId: "gone" }, [team]),
+    ).toBeNull();
+  });
+});
+
+describe("account-context value round-trip", () => {
+  it("round-trips PERSONAL and TEAM", () => {
+    expect(
+      parseAccountContextValue(accountContextValue({ type: "PERSONAL" })),
+    ).toEqual({
+      type: "PERSONAL",
+    });
+    expect(
+      parseAccountContextValue(
+        accountContextValue({ type: "TEAM", teamId: "team-1" }),
+      ),
+    ).toEqual({ type: "TEAM", teamId: "team-1" });
+  });
+});
+
+describe("resolveTraycerSubscriptionState", () => {
+  const subscription = userSub({ status: "PRO_V3" });
+
+  it("is cold while pending with no subscription yet", () => {
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: true,
+        isError: false,
+        subscription: null,
+      }),
+    ).toEqual({ kind: "cold" });
+  });
+
+  it("is error when the fetch failed with no subscription", () => {
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: false,
+        isError: true,
+        subscription: null,
+      }),
+    ).toEqual({ kind: "error" });
+  });
+
+  it("is empty when loaded but the account has no subscription", () => {
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: false,
+        isError: false,
+        subscription: null,
+      }),
+    ).toEqual({ kind: "empty" });
+  });
+
+  it("is ready when a subscription is present, degraded mirroring isError", () => {
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: false,
+        isError: false,
+        subscription,
+      }),
+    ).toEqual({ kind: "ready", subscription, degraded: false });
+    expect(
+      resolveTraycerSubscriptionState({
+        isPending: false,
+        isError: true,
+        subscription,
+      }),
+    ).toEqual({ kind: "ready", subscription, degraded: true });
+  });
+});
+
+describe("subscriptionPlanLabel", () => {
+  it("maps free-tier statuses to BYOA", () => {
+    expect(subscriptionPlanLabel("FREE")).toBe("BYOA");
+    expect(subscriptionPlanLabel("PENDING")).toBe("BYOA");
+  });
+
+  it("maps V3 credit plans", () => {
+    expect(subscriptionPlanLabel("BYOA_V3")).toBe("Sync");
+    expect(subscriptionPlanLabel("LITE_V3")).toBe("Lite");
+    expect(subscriptionPlanLabel("PRO_V3")).toBe("Pro");
+    expect(subscriptionPlanLabel("ULTRA_1X_V3")).toBe("Ultra");
+    expect(subscriptionPlanLabel("ULTRA_2X_V3")).toBe("Ultra+");
+    expect(subscriptionPlanLabel("ULTRA_3X_V3")).toBe("Ultra+");
+    expect(subscriptionPlanLabel("ULTRA_4X_V3")).toBe("Ultra+");
+    expect(subscriptionPlanLabel("ULTRA_5X_V3")).toBe("Ultra+");
+  });
+
+  it("marks legacy lite and pro tiers", () => {
+    expect(subscriptionPlanLabel("LITE")).toBe("Lite (Legacy)");
+    expect(subscriptionPlanLabel("LITE_V2")).toBe("Lite (Legacy)");
+    expect(subscriptionPlanLabel("PRO")).toBe("Pro (Legacy)");
+    expect(subscriptionPlanLabel("PRO_V2")).toBe("Pro (Legacy)");
+    expect(subscriptionPlanLabel("PRO_LEGACY")).toBe("Pro (Legacy)");
+    expect(subscriptionPlanLabel("PRO_PLUS")).toBe("Pro+ (Legacy)");
+  });
+
+  it("maps PRO_PLUS_V2 without a legacy suffix", () => {
+    expect(subscriptionPlanLabel("PRO_PLUS_V2")).toBe("Pro+");
+  });
+});

--- a/clients/gui-app/src/lib/auth/traycer-subscription-content.ts
+++ b/clients/gui-app/src/lib/auth/traycer-subscription-content.ts
@@ -1,0 +1,242 @@
+/**
+ * Host/query-free logic for the signed-in user's Traycer subscription + credits,
+ * shared by the Settings › Providers › Traycer card
+ * (`traycer-subscription-section.tsx`) and the header rate-limit popover's
+ * "Traycer" tab (`rate-limit-popover.tsx`) - mirroring how
+ * `provider-rate-limit-content.ts` serves both the Settings card and the popover
+ * for the host-RPC providers. Pure functions only: the subscription itself comes
+ * from `useAuthUser`, and the selected account from `useAccountContextStore`, in
+ * the callers.
+ */
+import type { AccountContext } from "@traycer/protocol/common/schemas";
+import type {
+  AuthenticatedUser,
+  SubscriptionStatus,
+  TraycerTeamSubscription,
+  TraycerUserSubscription,
+} from "@traycer/protocol/auth";
+import { titleCaseFromToken } from "@/lib/provider-rate-limit-content";
+
+/** The account-scoped subscription arms the account-context store can select between. */
+export type TraycerSubscription =
+  TraycerUserSubscription | TraycerTeamSubscription;
+
+export const PERSONAL_VALUE = "personal";
+export const TEAM_VALUE_PREFIX = "team:";
+
+export function isPaid(status: SubscriptionStatus): boolean {
+  return status !== "FREE" && status !== "PENDING";
+}
+
+// V3 plans bill against credits; every other (legacy / v2) plan is rate-limit
+// based. Ported from an internal shared package's `isCreditBasedPricing`
+// (clients can't import that package). Credit plans → credit breakdown; the
+// rest → rate limit.
+const CREDIT_BASED_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
+  "FREE",
+  "LITE_V3",
+  "PRO_V3",
+  "ULTRA_1X_V3",
+  "ULTRA_2X_V3",
+  "ULTRA_3X_V3",
+  "ULTRA_4X_V3",
+  "ULTRA_5X_V3",
+  "BYOA_V3",
+]);
+
+export function isCreditBasedPricing(status: SubscriptionStatus): boolean {
+  return CREDIT_BASED_STATUSES.has(status);
+}
+
+// A trailing `_V2`/`_V3` is an internal pricing-generation tag, not part of
+// the plan's own identity - Cloud UI's own Settings pages never show it
+// (billing-overview.tsx renders the Stripe product's bare name, e.g. "Ultra",
+// never "Ultra V3"). Stripped before title-casing so `ULTRA_5X_V3` reads as
+// "Ultra 5x", not "Ultra 5x V3". `_LEGACY` isn't stripped - unlike `_V2`/`_V3`,
+// it isn't a pricing-generation tag on an otherwise-equivalent tier.
+const VERSION_SUFFIX_PATTERN = /_V\d+$/;
+
+// Every `SubscriptionStatus` this client's protocol version knows about maps
+// to an exact label here. `Partial` (not a bare `Record`) so a status a
+// *newer* backend added that this older client build doesn't know about yet
+// (the protocol is versioned and runtime-negotiated - clients and the host
+// ship independently) still falls through to `subscriptionPlanLabel`'s
+// `titleCaseFromToken` fallback instead of a missing-key crash.
+const PLAN_LABELS: Partial<Record<SubscriptionStatus, string>> = {
+  FREE: "BYOA",
+  PENDING: "BYOA",
+  BYOA_V3: "Sync",
+  LITE_V3: "Lite",
+  LITE_V2: "Lite (Legacy)",
+  LITE: "Lite (Legacy)",
+  PRO_V3: "Pro",
+  PRO_V2: "Pro (Legacy)",
+  PRO: "Pro (Legacy)",
+  PRO_LEGACY: "Pro (Legacy)",
+  PRO_PLUS: "Pro+ (Legacy)",
+  PRO_PLUS_V2: "Pro+",
+  ULTRA_1X_V3: "Ultra",
+  ULTRA_2X_V3: "Ultra+",
+  ULTRA_3X_V3: "Ultra+",
+  ULTRA_4X_V3: "Ultra+",
+  ULTRA_5X_V3: "Ultra+",
+};
+
+/**
+ * The Traycer plan/tier label for the selected account (Core Flows parity
+ * with Codex/Claude: "shown where the provider reports one") - the header
+ * popover's "Traycer" tab shows this as a chip next to the name, same as
+ * `resolveProviderPlanLabel` does for the host-RPC providers.
+ */
+export function subscriptionPlanLabel(status: SubscriptionStatus): string {
+  return (
+    PLAN_LABELS[status] ??
+    titleCaseFromToken(String(status).replace(VERSION_SUFFIX_PATTERN, ""))
+  );
+}
+
+/**
+ * Whether the Traycer rail tab should appear at all: the resolved account is on
+ * a paid plan, or holds an active credit bundle. Free/pending accounts with no
+ * bundle have nothing worth a dedicated tab.
+ */
+export function isTraycerEligible(subscription: TraycerSubscription): boolean {
+  return (
+    isPaid(subscription.subscriptionStatus) ||
+    subscription.hasActiveBundle === true
+  );
+}
+
+// Mirrors the extension's `formatRechargeRate`: minutes under a day, else days.
+export function formatRechargeRate(rechargeRateSeconds: number): string | null {
+  if (rechargeRateSeconds <= 0) return null;
+  const SECONDS_PER_DAY = 86_400;
+  const SECONDS_PER_MINUTE = 60;
+  if (rechargeRateSeconds < SECONDS_PER_DAY) {
+    const minutes = Math.round(rechargeRateSeconds / SECONDS_PER_MINUTE);
+    return `${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  }
+  const days = Math.round(rechargeRateSeconds / SECONDS_PER_DAY);
+  return `${days} ${days === 1 ? "day" : "days"}`;
+}
+
+// Picks the subscription for the resolved context: the user's own, or the
+// matching team's. Null when the user isn't loaded or the team has no sub.
+export function selectSubscription(
+  user: AuthenticatedUser | null,
+  resolved: AccountContext,
+  teams: readonly TraycerTeamSubscription[],
+): TraycerSubscription | null {
+  if (user === null) return null;
+  if (resolved.type === "PERSONAL") return user.userSubscription;
+  return teams.find((t) => t.team.id === resolved.teamId) ?? null;
+}
+
+export function accountContextValue(context: AccountContext): string {
+  return context.type === "PERSONAL"
+    ? PERSONAL_VALUE
+    : `${TEAM_VALUE_PREFIX}${context.teamId}`;
+}
+
+export function parseAccountContextValue(value: string): AccountContext {
+  return value.startsWith(TEAM_VALUE_PREFIX)
+    ? { type: "TEAM", teamId: value.slice(TEAM_VALUE_PREFIX.length) }
+    : { type: "PERSONAL" };
+}
+
+// Artifact token counts aren't dollars - integers as-is, fractional usage to
+// 3dp, mirroring the extension's `${consumed.toFixed(3)} / ${totalTokens}`.
+export function formatArtifactTokens(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(3);
+}
+
+// $-denominated credits. ponytail: 2dp currency rather than the extension's odd
+// 3dp - decimals aren't part of the naming the user asked us to match.
+export function formatCredits(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+// Local mirror of the extension's `getCreditBreakdown` (the helper lives in
+// an internal shared package, which clients can't import). Three buckets -
+// Plan, Bonus, Bundle - tracked as consumed/total, matching the extension's
+// wording.
+export interface CreditBreakdown {
+  readonly planTotal: number;
+  readonly planConsumed: number;
+  readonly bonusTotal: number;
+  readonly bonusConsumed: number;
+  readonly bundleTotal: number;
+  readonly bundleConsumed: number;
+  readonly totalAvailable: number;
+  readonly totalConsumed: number;
+}
+
+export function creditBreakdown(
+  subscription: TraycerSubscription,
+): CreditBreakdown {
+  const credit = subscription.credit;
+  const planTotal = subscription.totalPlanCredits ?? 0;
+  const planRemaining = Math.max(
+    0,
+    planTotal - (credit?.consumedFromPlan ?? 0),
+  );
+  const planConsumed = Math.max(0, planTotal - planRemaining);
+  const bonusTotal = credit?.bonusCredits ?? 0;
+  const bonusConsumed = credit?.consumedFromBonus ?? 0;
+  const bundleTotal = subscription.bundleSummary?.bundleTotal ?? 0;
+  const bundleRemaining = subscription.bundleSummary?.bundleRemaining ?? 0;
+  const bundleConsumed = Math.max(0, bundleTotal - bundleRemaining);
+  return {
+    planTotal,
+    planConsumed,
+    bonusTotal,
+    bonusConsumed,
+    bundleTotal,
+    bundleConsumed,
+    totalAvailable: planTotal + bonusTotal + bundleTotal,
+    totalConsumed: planConsumed + bonusConsumed + bundleConsumed,
+  };
+}
+
+/**
+ * The popover Traycer block's display state - the same cold/error/degraded shape
+ * the host-RPC providers use (`resolvePopoverProviderRateLimitState`), but keyed
+ * off the identity query (`useAuthUser`) rather than a per-provider host pull:
+ *
+ * - `cold`: no user loaded yet and no failure -> skeleton.
+ * - `error`: no user loaded and the fetch failed -> retry message.
+ * - `empty`: the user loaded but the selected account has no subscription.
+ * - `ready`: a subscription is present. `degraded` is true when the latest
+ *   refetch failed while a last-known-good reading is still shown (dimmed).
+ *
+ * The aperture usage query (`useHostRateLimitUsageQuery`) is deliberately NOT an
+ * input here: it's best-effort supplementary data for rate-limit-based plans
+ * only, and its own failure surfaces inline as "usage unavailable" rather than
+ * blocking the whole tab.
+ */
+export type TraycerSubscriptionState =
+  | { readonly kind: "cold" }
+  | { readonly kind: "error" }
+  | { readonly kind: "empty" }
+  | {
+      readonly kind: "ready";
+      readonly subscription: TraycerSubscription;
+      readonly degraded: boolean;
+    };
+
+export function resolveTraycerSubscriptionState(args: {
+  readonly isPending: boolean;
+  readonly isError: boolean;
+  readonly subscription: TraycerSubscription | null;
+}): TraycerSubscriptionState {
+  if (args.subscription !== null) {
+    return {
+      kind: "ready",
+      subscription: args.subscription,
+      degraded: args.isError,
+    };
+  }
+  if (args.isError) return { kind: "error" };
+  if (args.isPending) return { kind: "cold" };
+  return { kind: "empty" };
+}

--- a/clients/gui-app/src/lib/host/__tests__/durable-stream-transport.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/durable-stream-transport.test.ts
@@ -3,10 +3,10 @@ import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-ru
 import type { StreamAuthRevalidator } from "@traycer-clients/shared/auth/bearer-revalidator";
 
 // `openDurableStreamTransport` is the single place "durable stream = transport +
-// auth + wake" is assembled. These tests pin its two load-bearing guarantees:
-// the teardown order, and that a failure while wiring wake never leaks the
-// socket. The socket builder and wake wiring are mocked so the test is about
-// the assembly contract, not the real transport.
+// auth + bearer rotation + wake" is assembled. These tests pin its load-bearing
+// guarantees: forwarding rotations, teardown order, and that a failure while
+// wiring wake never leaks the socket. The socket builder and wake wiring are
+// mocked so the test is about the assembly contract, not the real transport.
 const mocks = vi.hoisted(() => ({
   buildHostStreamClient: vi.fn(),
   subscribeStreamWakeReconnect: vi.fn(),
@@ -43,6 +43,7 @@ function buildParams(closeWs: () => void) {
       closeWs();
     }),
     reconnectAll: vi.fn(),
+    notifyBearerRotated: vi.fn(),
   };
   mocks.buildHostStreamClient.mockReturnValue(fakeWs);
   return {
@@ -53,6 +54,11 @@ function buildParams(closeWs: () => void) {
       bearer: () => null,
       auth: AUTH,
       runnerHost: RUNNER_HOST,
+      subscribeBearerRotation: (_onRotation: () => void) => {
+        return () => {
+          order.push("bearer");
+        };
+      },
       // No endpoint ever moves in these assembly tests; return a no-op disposer.
       subscribeEndpointChange: () => () => undefined,
     },
@@ -89,12 +95,46 @@ describe("openDurableStreamTransport", () => {
 
     // Disposing wake before closing the socket avoids a wake firing
     // `reconnectAll` on a socket that is being torn down.
-    expect(order).toEqual(["wake", "ws"]);
+    expect(order).toEqual(["bearer", "wake", "ws"]);
+  });
+
+  it("forwards bearer rotations to the built socket and removes the listener before close", () => {
+    const { order, params, fakeWs } = buildParams(() => undefined);
+    const disposeWake = vi.fn(() => {
+      order.push("wake");
+    });
+    let bearerListener: (() => void) | null = null;
+    const disposeBearer = vi.fn(() => {
+      order.push("bearer");
+      bearerListener = null;
+    });
+    mocks.subscribeStreamWakeReconnect.mockReturnValue(disposeWake);
+    params.subscribeBearerRotation = (listener: () => void) => {
+      bearerListener = listener;
+      return disposeBearer;
+    };
+    const fireBearerRotation = (): void => {
+      if (bearerListener !== null) {
+        bearerListener();
+      }
+    };
+
+    const transport = openDurableStreamTransport(params);
+
+    fireBearerRotation();
+    expect(fakeWs.notifyBearerRotated).toHaveBeenCalledTimes(1);
+
+    transport.close();
+    expect(disposeBearer).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["bearer", "wake", "ws"]);
+
+    fireBearerRotation();
+    expect(fakeWs.notifyBearerRotated).toHaveBeenCalledTimes(1);
   });
 
   it("closes the half-built socket and rethrows if wiring wake throws", () => {
     const closeWs = vi.fn();
-    const { params, fakeWs } = buildParams(closeWs);
+    const { order, params, fakeWs } = buildParams(closeWs);
     const wakeError = new Error("wake wiring failed");
     mocks.subscribeStreamWakeReconnect.mockImplementation(() => {
       throw wakeError;
@@ -105,6 +145,7 @@ describe("openDurableStreamTransport", () => {
     // half-registered listener leaks for the lifetime of the window.
     expect(fakeWs.close).toHaveBeenCalledTimes(1);
     expect(closeWs).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["bearer", "ws"]);
   });
 
   it("re-dials at once when the host's dialable endpoint moves, not on benign re-emits", () => {
@@ -121,6 +162,7 @@ describe("openDurableStreamTransport", () => {
       bearer: () => null,
       auth: AUTH,
       runnerHost: RUNNER_HOST,
+      subscribeBearerRotation: () => () => undefined,
       subscribeEndpointChange: (onChange: () => void) => {
         fireDirectoryChange = onChange;
         return () => undefined;

--- a/clients/gui-app/src/lib/host/durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/durable-stream-transport.ts
@@ -31,6 +31,9 @@ export interface DurableStreamTransport {
  *    new `websocketUrl` while the session is warm (no tile mounted to recompute
  *    a memo) reconnects to the new address instead of retrying the dead one.
  *  - `bearer` + `auth` provide UNAUTHORIZED revalidate+reconnect.
+ *  - bearer-rotation forwarding pushes `credentialUpdate` frames to already-open
+ *    sessions after same-user token refresh, so long-lived streams do not keep
+ *    stale host-side request contexts.
  *  - wake re-dial (`window 'online'` + OS resume) is wired here.
  *  - endpoint-change re-dial: when the bound host moves to a NEW dialable
  *    endpoint while the app is awake (a Settings-page restart / re-provision -
@@ -51,6 +54,12 @@ export function openDurableStreamTransport(params: {
   readonly auth: StreamAuthRevalidator;
   readonly runnerHost: IRunnerHost;
   /**
+   * Subscribes to same-user bearer rotations. The durable transport forwards the
+   * event to its owned stream client so open host connections rotate credentials
+   * in place via `credentialUpdate`.
+   */
+  readonly subscribeBearerRotation: (onRotation: () => void) => () => void;
+  /**
    * Subscribes to host-directory changes for the bound host, returning a
    * disposer. The callback fires on ANY directory change; this module filters it
    * down to a genuine dialable-endpoint move before re-dialing.
@@ -67,6 +76,11 @@ export function openDurableStreamTransport(params: {
   });
   const disposers: Array<() => void> = [];
   try {
+    disposers.push(
+      params.subscribeBearerRotation(() => {
+        wsStreamClient.notifyBearerRotated();
+      }),
+    );
     disposers.push(
       subscribeStreamWakeReconnect(wsStreamClient, params.runnerHost),
     );

--- a/clients/gui-app/src/lib/host/use-durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/use-durable-stream-transport.ts
@@ -40,6 +40,8 @@ export function useDurableStreamTransportFactory(): (
           liveRef.current.globalClient.getRequestContext()?.credentials ?? null,
         auth: liveRef.current.auth,
         runnerHost: liveRef.current.runnerHost,
+        subscribeBearerRotation: (onRotation) =>
+          liveRef.current.globalClient.onBearerRotated(onRotation),
         // Fires on any directory change; `openDurableStreamTransport` filters it
         // down to a genuine endpoint MOVE for THIS `hostId` before re-dialing,
         // so a host restart / re-provision reconnects the session at once

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -1,0 +1,173 @@
+import type {
+  ProviderRateLimits,
+  RateLimitUnavailableReason,
+} from "@traycer/protocol/host";
+import type { ProviderRateLimitQueryState } from "@/components/settings/panels/provider-rate-limit-views";
+
+/** The provider snapshot arms that actually carry usage detail. */
+type AvailableProviderRateLimits = Extract<
+  ProviderRateLimits,
+  { available: true }
+>;
+
+/**
+ * The loading/error/empty/data branch every rate-limit surface needs.
+ * `ProviderRateLimitBody` renders from this, and `hasProviderRateLimitContent`
+ * derives its boolean from it, so the two can't drift out of sync the way two
+ * independently-written boolean checks could.
+ */
+export type ProviderRateLimitViewState =
+  | { readonly kind: "loading" }
+  | { readonly kind: "error" }
+  | { readonly kind: "empty" }
+  | { readonly kind: "data"; readonly data: ProviderRateLimits };
+
+export function resolveProviderRateLimitViewState(
+  props: ProviderRateLimitQueryState,
+): ProviderRateLimitViewState {
+  if (props.isPending && props.isFetching) return { kind: "loading" };
+  if (props.isError) return { kind: "error" };
+  const data = props.providerRateLimits ?? null;
+  if (data === null) return { kind: "empty" };
+  return { kind: "data", data };
+}
+
+/**
+ * Whether `ProviderRateLimitBody` would render visible content for `props`.
+ * Lets a caller that wraps the body in its own chrome (a border, padding)
+ * skip that chrome when the body would render nothing, instead of always
+ * painting an empty section. Kept out of `provider-rate-limit-views.tsx` (a
+ * component-only file) since a plain function export there breaks React Fast
+ * Refresh's component-boundary detection.
+ */
+export function hasProviderRateLimitContent(
+  props: ProviderRateLimitQueryState,
+): boolean {
+  return resolveProviderRateLimitViewState(props).kind !== "empty";
+}
+
+// Exhaustive set of `reason` codes the host emits (`provider-rate-limits.ts`,
+// `rate-limits/{codex,claude,openrouter,kilocode}.ts`, `rate-limits/common.ts`)
+// - the wire field is a machine identifier, not display copy.
+// `Record<RateLimitUnavailableReason, string>` (not `Record<string, string>`)
+// makes this exhaustive at compile time: adding a reason to the protocol's
+// closed enum without adding a label here fails the build instead of silently
+// showing a raw, underscore-joined reason code. Homed here (a non-component
+// module) rather than in `provider-rate-limit-views.tsx` so both the Settings
+// card body and the header popover can share it without a plain-function export
+// breaking that file's React Fast Refresh component-boundary detection.
+const RATE_LIMIT_UNAVAILABLE_REASON_LABELS: Record<
+  RateLimitUnavailableReason,
+  string
+> = {
+  cli_not_found: "the CLI isn't installed",
+  unsupported_provider: "this provider isn't supported",
+  invalid_response: "the CLI returned an unexpected response",
+  timeout: "the request timed out",
+  connection_failed: "couldn't connect to the CLI",
+  sdk_incompatible: "this SDK version doesn't support usage limits",
+  rate_limits_not_available: "not available for this account",
+  insufficient_permissions:
+    "this account doesn't have permission to view usage",
+};
+
+export function formatUnavailableReason(
+  reason: RateLimitUnavailableReason,
+): string {
+  return RATE_LIMIT_UNAVAILABLE_REASON_LABELS[reason];
+}
+
+/**
+ * The header popover's per-provider display state - richer than
+ * `resolveProviderRateLimitViewState` (which the Settings card uses) because
+ * this surface distinguishes cold-load from degraded from never-fetched-error,
+ * each with its own treatment (Core Flows: skeleton bars / dimmed stale reading
+ * / plain-language error + retry):
+ *
+ * - `cold`: no data has ever arrived and no fetch has failed yet -> skeleton.
+ * - `error`: no data has ever arrived and the fetch failed (transport-level,
+ *   not a provider `available: false` response) -> generic retry message.
+ * - `unavailable`: the pull succeeded but the provider reports it can't surface
+ *   usage (CLI missing, wrong account, etc.) -> mapped plain-language message.
+ * - `ready`: usable snapshot present. `degraded` is true when the latest poll
+ *   failed but a last-known-good reading is still shown (dimmed).
+ */
+export type PopoverProviderRateLimitState =
+  | { readonly kind: "cold" }
+  | { readonly kind: "error" }
+  | {
+      readonly kind: "unavailable";
+      readonly reason: RateLimitUnavailableReason;
+    }
+  | {
+      readonly kind: "ready";
+      readonly data: AvailableProviderRateLimits;
+      readonly degraded: boolean;
+    };
+
+export function resolvePopoverProviderRateLimitState(
+  props: ProviderRateLimitQueryState,
+): PopoverProviderRateLimitState {
+  const snapshot = props.providerRateLimits ?? null;
+  if (snapshot === null) {
+    // Nothing usable yet. `ephemeralProcess` queries are queue-owned and
+    // therefore disabled as query observers; before the queue starts, they can
+    // be pending-but-not-fetching without that representing a failed read.
+    // Once a queued fetch actually fails, TanStack moves the observer out of
+    // `isPending` and into `isError`, revealing retryable error content instead
+    // of staying hidden in Overview.
+    return props.isFetching || props.isPending
+      ? { kind: "cold" }
+      : { kind: "error" };
+  }
+  if (!snapshot.available) {
+    return { kind: "unavailable", reason: snapshot.reason };
+  }
+  // A last-known-good snapshot is present. `isError` here means the most recent
+  // (background) refetch failed while retaining this data - Core Flows' degraded
+  // state, shown dimmed rather than replaced.
+  return { kind: "ready", data: snapshot, degraded: props.isError };
+}
+
+/**
+ * `SNAKE_CASE`/`snake_case` token → Title Case, for any enum value that isn't
+ * in one of the bespoke display-name maps elsewhere (a forward-compat
+ * fallback for values a backend adds before those maps update) - used for
+ * provider enum tokens (`provider-rate-limit-views.tsx`, which are already
+ * lowercase) and, directly from `rate-limit-popover.tsx`, Traycer's own
+ * `SubscriptionStatus` (e.g. `"ULTRA_1X_V3"`, upper-case), so the rest of
+ * each word is explicitly lower-cased rather than left as-is. Homed here (a
+ * non-component module) rather than a component file so callers can share it
+ * without a plain-function export breaking that file's React Fast Refresh
+ * component-boundary detection.
+ */
+export function titleCaseFromToken(value: string): string {
+  return value
+    .split("_")
+    .filter((word) => word.length > 0)
+    .map((word) => `${word[0].toUpperCase()}${word.slice(1).toLowerCase()}`)
+    .join(" ");
+}
+
+/**
+ * A provider's plan/tier label, where one is fetched - the header popover
+ * shows this as a chip next to the provider name (Core Flows: "where the
+ * provider reports one"). Only Codex (`planType`) and Claude Code
+ * (`subscriptionType`) currently report a plan/tier; OpenRouter and Kilo Code
+ * have no analogous field, so they always resolve to `null` and render no chip.
+ */
+export function resolveProviderPlanLabel(
+  data: AvailableProviderRateLimits,
+): string | null {
+  switch (data.provider) {
+    case "codex":
+      return data.planType !== null ? titleCaseFromToken(data.planType) : null;
+    case "claude-code":
+      return data.subscriptionType !== null
+        ? titleCaseFromToken(data.subscriptionType)
+        : null;
+    case "openrouter":
+    case "kilocode":
+      return null;
+  }
+}

--- a/clients/gui-app/src/lib/query-client.ts
+++ b/clients/gui-app/src/lib/query-client.ts
@@ -20,42 +20,54 @@ const SAFE_QUERY_KEY_MARKERS = new Set([
   "fileDiff",
 ]);
 
-export const queryClient = new QueryClient({
-  queryCache: new QueryCache({
-    onError: (error, query) => {
-      appLogger.warn("[query] request failed", {
-        queryKey: summarizeQueryKey(query.queryKey),
-        failureCount: query.state.fetchFailureCount,
-        fetchStatus: query.state.fetchStatus,
-        status: query.state.status,
-        error: describeLogErrorSummary(error),
-      });
+/**
+ * Builds a `QueryClient` with the app's production configuration. Exported
+ * (rather than only the singleton below) so integration tests can run against
+ * the exact defaults the app runs with - the global `staleTime` in particular
+ * changes `fetchQuery` semantics (it serves still-fresh cache without
+ * fetching), and a test-local bare `new QueryClient()` silently exercises a
+ * different behavior than production.
+ */
+export function createAppQueryClient(): QueryClient {
+  return new QueryClient({
+    queryCache: new QueryCache({
+      onError: (error, query) => {
+        appLogger.warn("[query] request failed", {
+          queryKey: summarizeQueryKey(query.queryKey),
+          failureCount: query.state.fetchFailureCount,
+          fetchStatus: query.state.fetchStatus,
+          status: query.state.status,
+          error: describeLogErrorSummary(error),
+        });
+      },
+    }),
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => {
+        appLogger.warn("[mutation] request failed", {
+          mutationKey: summarizeQueryKey(mutation.options.mutationKey ?? []),
+          failureCount: mutation.state.failureCount,
+          status: mutation.state.status,
+          error: describeLogErrorSummary(error),
+        });
+      },
+    }),
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+        // A `RetryableTransportError` has already been retried to exhaustion by
+        // the transport layer (`createRetryingMessenger`); retrying it again here
+        // multiplies the dial-timeout cost (transport attempts × query attempts).
+        // Let it surface immediately; everything else keeps the single retry.
+        retry: (failureCount, error) =>
+          !(error instanceof RetryableTransportError) && failureCount < 1,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+      },
     },
-  }),
-  mutationCache: new MutationCache({
-    onError: (error, _variables, _context, mutation) => {
-      appLogger.warn("[mutation] request failed", {
-        mutationKey: summarizeQueryKey(mutation.options.mutationKey ?? []),
-        failureCount: mutation.state.failureCount,
-        status: mutation.state.status,
-        error: describeLogErrorSummary(error),
-      });
-    },
-  }),
-  defaultOptions: {
-    queries: {
-      staleTime: 60 * 1000,
-      // A `RetryableTransportError` has already been retried to exhaustion by
-      // the transport layer (`createRetryingMessenger`); retrying it again here
-      // multiplies the dial-timeout cost (transport attempts × query attempts).
-      // Let it surface immediately; everything else keeps the single retry.
-      retry: (failureCount, error) =>
-        !(error instanceof RetryableTransportError) && failureCount < 1,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
-    },
-  },
-});
+  });
+}
+
+export const queryClient = createAppQueryClient();
 
 function summarizeQueryKey(queryKey: QueryKey): AppLogValue {
   return queryKey.slice(0, 4).map((part) => {

--- a/clients/gui-app/src/lib/rate-limit-providers.ts
+++ b/clients/gui-app/src/lib/rate-limit-providers.ts
@@ -1,0 +1,104 @@
+import type {
+  ProviderCliState,
+  ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
+import {
+  rateLimitCapableProviderIdSchema,
+  type RateLimitCapableProviderId,
+} from "@traycer/protocol/host/rate-limit";
+
+/**
+ * The two providers `host.getRateLimitUsage @1.2`'s `providerRateLimits`
+ * union reports full native detail for. Every other `ProviderId` (including
+ * `traycer`, which uses the flat aperture fields on the same RPC) resolves
+ * to the `available: false` arm if ever queried - the GUI simply never asks
+ * for it. Re-exported from the protocol's own enum (rather than hand-listed
+ * here again) so the host's dispatch, the wire schema's two available arms,
+ * and this GUI type can't silently drift apart.
+ */
+export type RateLimitProviderId = RateLimitCapableProviderId;
+
+/**
+ * Fetch cost class for a rate-limit-capable provider - the load-bearing split
+ * the polling scheduler branches on:
+ *
+ * - `"httpFetch"`: the host resolves a credential it already has and issues a
+ *   plain GET (openrouter, kilocode). Cheap and safe to run concurrently, so
+ *   these poll on their own independent `refetchInterval` and never enter the
+ *   serial queue.
+ * - `"ephemeralProcess"`: the host spawns a real CLI subprocess to read usage
+ *   (codex, claude-code). Expensive; these are funnelled through a shared
+ *   serial queue so an interval tick, a manual refresh, and a turn completion
+ *   can never spawn overlapping subprocesses.
+ */
+export type RateLimitFetchLane = "httpFetch" | "ephemeralProcess";
+
+/**
+ * Shared "how fresh is fresh enough" floor for provider rate-limit reads: the
+ * `staleTime` on the provider rate-limit query, the minimum spacing the
+ * turn-completion refresh hook enforces, and the queue's own automatic-trigger
+ * cooldown. Unlike the aperture read (a cheap cloud call), an
+ * `ephemeralProcess` pull spawns a real CLI subprocess, so a burst of triggers
+ * (a queued run finishing, an interval tick landing next to a turn completion)
+ * must not each spawn their own.
+ *
+ * Homed here - alongside the lane classifier it is conceptually paired with -
+ * rather than in the turn-completion hook, so the queue module, the query
+ * options, and that hook can all read it without an import cycle.
+ */
+export const PROVIDER_RATE_LIMITS_STALE_TIME_MS = 30_000;
+
+export function isRateLimitCapableProvider(
+  providerId: ProviderId,
+): providerId is RateLimitProviderId {
+  return rateLimitCapableProviderIdSchema.safeParse(providerId).success;
+}
+
+/**
+ * The one named home for the provider -> lane mapping. Load-bearing in the
+ * query options (which lane gets a `refetchInterval`), the turn-completion
+ * refresh hook (which trigger routes through the serial queue), and the
+ * interval timer (which providers it walks) - so it lives here once rather
+ * than being re-derived at each of those three sites.
+ */
+export function rateLimitFetchLane(
+  providerId: RateLimitProviderId,
+): RateLimitFetchLane {
+  switch (providerId) {
+    case "openrouter":
+    case "kilocode":
+      return "httpFetch";
+    case "codex":
+    case "claude-code":
+      return "ephemeralProcess";
+  }
+}
+
+/**
+ * Whether `state` currently reports valid credentials for a rate-limit pull -
+ * the gate both polling lanes share, read from the same `providers.list` auth
+ * state the popover rail keys off. A provider enters a lane only while this is
+ * `true`; because these subscriptions are now persistent (app-shell level, not
+ * the transient Settings card that re-gates on every mount), a credential
+ * removed mid-session drops the provider out on the very next tick.
+ *
+ * - `authPending` / `availabilityPending`: the host has not settled a verdict
+ *   yet, so acting on the row would be premature - treated as not-yet-eligible.
+ * - `"authenticated"`: verified good credentials.
+ * - `"configured"`: credentials are present but unverified (e.g. an API key set
+ *   for openrouter/kilocode before the first probe) - included because the pull
+ *   itself is what verifies them, and it degrades gracefully if they are bad.
+ * - `"unauthenticated"` / `"unavailable"` / `"unknown"`: no usable credential
+ *   to authenticate a usage call, so the provider is not polled.
+ * - `enabled: false`: the user turned the provider off; don't spend a fetch on
+ *   a provider they have disabled.
+ */
+export function isRateLimitProviderConfigured(
+  state: ProviderCliState,
+): boolean {
+  if (!state.enabled) return false;
+  if (state.authPending || state.availabilityPending) return false;
+  return (
+    state.auth.status === "authenticated" || state.auth.status === "configured"
+  );
+}

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue-isfetching-sharing.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * End-to-end proof that an `enqueueRateLimitFetch` call actually flips
+ * `isFetching` on an already-mounted `useHostProviderRateLimitsQuery`
+ * observer for the same provider - the mechanism `RateLimitProviderBlock`'s
+ * per-provider refresh icon and `RateLimitRefreshAllButton` both depend on to
+ * stay in sync. Uses the shared harness's real `HostClient` +
+ * `MockHostMessenger` and PRODUCTION QueryClient configuration: this exact
+ * flow - disabled observer mounted, first snapshot loaded by the queue, then
+ * a force:true enqueue - is where the inherited global staleTime silently
+ * no-oped the real app's refresh while a bare staleTime-0 test client passed.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
+import {
+  __resetRateLimitQueueForTests,
+  configureRateLimitQueue,
+  enqueueRateLimitFetch,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+import {
+  createQueryClientWrapper,
+  createRateLimitSharingHarness,
+} from "@/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness";
+
+const EXPECTED_RATE_LIMIT_USAGE = {
+  totalTokens: 0,
+  remainingTokens: 0,
+  providerRateLimits: null,
+};
+
+describe("enqueueRateLimitFetch keeps a mounted useHostProviderRateLimitsQuery observer's isFetching in sync", () => {
+  afterEach(() => {
+    cleanup();
+    __resetRateLimitQueueForTests();
+  });
+
+  it("populates a disabled Codex observer from the queue and reflects a later force:true enqueue's fetch state", async () => {
+    const harness = createRateLimitSharingHarness();
+    const { method, params, options } = providerRateLimitQueryOptions("codex");
+    const rendered = renderHook(
+      () => useHostQuery({ client: harness.client, method, params, options }),
+      { wrapper: createQueryClientWrapper(harness.queryClient) },
+    );
+
+    // Codex is an `ephemeralProcess` provider: the mounted observer is disabled
+    // and must not start a subprocess-spawning request on its own.
+    expect(rendered.result.current.isPending).toBe(true);
+    expect(rendered.result.current.isFetching).toBe(false);
+    expect(rendered.result.current.data).toBeUndefined();
+
+    configureRateLimitQueue({
+      hostId: mockLocalHostEntry.hostId,
+      queryClient: harness.queryClient,
+      request: (_hostId, rpcMethod, rpcParams) =>
+        harness.client.request(rpcMethod, rpcParams),
+    });
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+
+    await waitFor(() =>
+      expect(rendered.result.current.data).toEqual(EXPECTED_RATE_LIMIT_USAGE),
+    );
+    expect(rendered.result.current.isPending).toBe(false);
+    expect(rendered.result.current.isFetching).toBe(false);
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+
+    // The second call is the one the harness blocks. The disabled observer,
+    // mounted independently of the queue, must still see it as in flight.
+    await waitFor(() => expect(rendered.result.current.isFetching).toBe(true));
+
+    harness.resolvePendingResponse();
+    await waitFor(() => expect(rendered.result.current.isFetching).toBe(false));
+    expect(rendered.result.current.data).toEqual(EXPECTED_RATE_LIMIT_USAGE);
+  });
+});

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
@@ -1,0 +1,323 @@
+import { QueryClient } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { queryKeys } from "@/lib/query-keys";
+import { createAppQueryClient } from "@/lib/query-client";
+import type { HostRpcRegistry } from "@/lib/host";
+import {
+  __resetRateLimitQueueForTests,
+  configureRateLimitQueue,
+  enqueueRateLimitFetch,
+  isRateLimitQueueDraining,
+  subscribeRateLimitQueueDraining,
+  type RateLimitQueueRequestFn,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+const HOST_ID = "host-1";
+
+// A minimal valid `host.getRateLimitUsage @1.2` response - only the ordering of
+// `request` calls matters to these tests, not the payload.
+function response() {
+  return { totalTokens: 0, remainingTokens: 0, providerRateLimits: null };
+}
+
+function keyFor(providerId: ProviderId) {
+  return queryKeys.hostMethod<HostRpcRegistry, "host.getRateLimitUsage">(
+    HOST_ID,
+    "host.getRateLimitUsage",
+    { accountContext: DEFAULT_ACCOUNT_CONTEXT, providerId },
+  );
+}
+
+// A `request` double whose promises settle only when the test explicitly
+// releases them, so we can observe how many are in flight at any moment.
+function makeControllableRequest() {
+  const calls: Array<ProviderId | undefined> = [];
+  const settlers: Array<{ ok: () => void; fail: () => void }> = [];
+  const request: RateLimitQueueRequestFn = (_hostId, _method, params) => {
+    calls.push(params.providerId);
+    return new Promise((resolve, reject) => {
+      settlers.push({
+        ok: () => resolve(response()),
+        fail: () => reject(new Error("boom")),
+      });
+    });
+  };
+  return { request: vi.fn(request), calls, settlers };
+}
+
+function newQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+// Flush pending microtasks/callbacks so `fetchQuery` has a chance to invoke the
+// queued `queryFn`. Real timers are in effect for these tests.
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe("ephemeral-fetch-queue", () => {
+  beforeEach(() => {
+    __resetRateLimitQueueForTests();
+  });
+  afterEach(() => {
+    __resetRateLimitQueueForTests();
+  });
+
+  it("serializes concurrent enqueues across providers - only one request is ever in flight (guardrail 1)", async () => {
+    const queryClient = newQueryClient();
+    const { request, calls, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    // Fire two ephemeralProcess providers concurrently, as a rapid "Refresh all"
+    // across providers would. Force bypasses the freshness floor.
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+
+    await flush();
+    // Despite two concurrent enqueues, only the first provider's request has
+    // started - the second is queued behind it, not spawned in parallel.
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(["codex"]);
+
+    // Release the first; only now may the second run.
+    settlers[0].ok();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(["codex", "claude-code"]);
+
+    settlers[1].ok();
+    await flush();
+  });
+
+  it("serializes many rapid same-provider force refreshes one at a time", async () => {
+    const queryClient = newQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    for (let i = 0; i < 4; i++) {
+      void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+        force: true,
+      });
+    }
+
+    await flush();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    settlers[0].ok();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(2);
+
+    settlers[1].ok();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(3);
+
+    settlers[2].ok();
+    settlers[3]?.ok();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(4);
+  });
+
+  it("writes into the same query key the per-provider hook reads", async () => {
+    const queryClient = newQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    await flush();
+    settlers[0].ok();
+    await flush();
+
+    expect(queryClient.getQueryState(keyFor("codex"))?.data).toEqual(
+      response(),
+    );
+  });
+
+  it("force: false no-ops when cached data is still within the freshness floor, force: true bypasses it", async () => {
+    const queryClient = newQueryClient();
+    const { request } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    // Seed fresh data (dataUpdatedAt = now) into the provider's key.
+    queryClient.setQueryData(keyFor("codex"), response());
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    await flush();
+    // Still fresh -> the automatic trigger must not spawn a subprocess.
+    expect(request).not.toHaveBeenCalled();
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    await flush();
+    // A user-initiated refresh bypasses the floor.
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("one provider's failure does not block the next provider's turn", async () => {
+    const queryClient = newQueryClient();
+    const { request, calls, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+
+    await flush();
+    settlers[0].fail();
+    await flush();
+    // The rejection was swallowed by the chain; the queue advanced to the next.
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(["codex", "claude-code"]);
+
+    settlers[1].ok();
+    await flush();
+    expect(isRateLimitQueueDraining()).toBe(false);
+  });
+
+  it("a failed first read does not make a provider look fresh; an automatic enqueue retries and recovers", async () => {
+    const queryClient = newQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    await flush();
+    settlers[0].fail();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(
+      queryClient.getQueryState(keyFor("claude-code"))?.dataUpdatedAt,
+    ).toBe(0);
+
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    await flush();
+
+    expect(request).toHaveBeenCalledTimes(2);
+    settlers[1].ok();
+    await flush();
+    expect(queryClient.getQueryState(keyFor("claude-code"))?.data).toEqual(
+      response(),
+    );
+    expect(
+      queryClient.getQueryState(keyFor("claude-code"))?.dataUpdatedAt,
+    ).toBeGreaterThan(0);
+  });
+
+  it("exposes an external-store draining signal that flips with in-flight work", async () => {
+    const queryClient = newQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    const notified: boolean[] = [];
+    const unsubscribe = subscribeRateLimitQueueDraining(() => {
+      notified.push(isRateLimitQueueDraining());
+    });
+
+    expect(isRateLimitQueueDraining()).toBe(false);
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    // Draining flips true synchronously at enqueue, before any await.
+    expect(isRateLimitQueueDraining()).toBe(true);
+    expect(notified.at(-1)).toBe(true);
+
+    await flush();
+    settlers[0].ok();
+    await flush();
+
+    expect(isRateLimitQueueDraining()).toBe(false);
+    expect(notified.at(-1)).toBe(false);
+
+    unsubscribe();
+  });
+
+  it("force: true actually refetches fresh-cached data under the app QueryClient's global staleTime", async () => {
+    // THE regression that made "Refresh all" look broken in the real app while
+    // every test passed: `fetchQuery` inherits the QueryClient's GLOBAL
+    // `staleTime` default (60s in the app's `query-client.ts`) and serves
+    // still-fresh cache without fetching. The popover's open-time refresh
+    // keeps provider data younger than 60s, so a user's `force: true` refresh
+    // resolved from cache in a microtask - no subprocess, no `isFetching`, a
+    // sub-frame `draining` blip - while the httpFetch lane's
+    // `invalidateQueries` (which always refetches) visibly spun. Every prior
+    // test built a bare `new QueryClient()` (staleTime 0), where `fetchQuery`
+    // always fetches - so the suite exercised semantics the app doesn't run.
+    // This test runs the production configuration.
+    const queryClient = createAppQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    // Seed fresh data (dataUpdatedAt = now), as the popover's open-time
+    // refresh does moments before the user clicks.
+    queryClient.setQueryData(keyFor("codex"), response());
+
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    expect(isRateLimitQueueDraining()).toBe(true);
+    await flush();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    settlers[0].ok();
+    await flush();
+    expect(isRateLimitQueueDraining()).toBe(false);
+  });
+
+  it("an automatic (force: false) enqueue re-checks freshness at its turn in the lane, not just at enqueue time", async () => {
+    // With `staleTime: 0` on the queue's own `fetchQuery`, the accidental
+    // dedupe the inherited global staleTime used to provide is gone - so the
+    // queue re-checks the freshness floor when a queued automatic fetch's
+    // turn arrives. An automatic trigger enqueued behind a fetch for the same
+    // provider must not re-spawn a subprocess for data that just became fresh.
+    const queryClient = createAppQueryClient();
+    const { request, settlers } = makeControllableRequest();
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    // No cached data yet: both pass their enqueue-time freshness check.
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    void enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    await flush();
+    expect(request).toHaveBeenCalledTimes(1);
+
+    settlers[0].ok();
+    await flush();
+    // The automatic turn found the data fresh (the forced fetch just wrote
+    // it) and skipped instead of spawning a second subprocess.
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(isRateLimitQueueDraining()).toBe(false);
+  });
+
+  it("no-ops (never calls request) while the queue is unconfigured", async () => {
+    const { request } = makeControllableRequest();
+    // No configureRateLimitQueue call.
+    await enqueueRateLimitFetch("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+    });
+    await flush();
+    expect(request).not.toHaveBeenCalled();
+    expect(isRateLimitQueueDraining()).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness.tsx
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/provider-rate-limit-sharing-harness.tsx
@@ -1,0 +1,82 @@
+/**
+ * Shared wiring for the two "does a cache-level refresh trigger flip a
+ * mounted observer's isFetching" integration tests (the ephemeral queue's
+ * `enqueueRateLimitFetch` and the httpFetch lane's `invalidateQueries`).
+ * Not a `.test` file - vitest only collects `*.test.ts(x)`.
+ *
+ * Builds the production QueryClient configuration (`createAppQueryClient` -
+ * the global staleTime default changes fetch semantics, see that factory's
+ * doc comment) around a real `HostClient` + `MockHostMessenger` whose
+ * `host.getRateLimitUsage` handler resolves the FIRST call immediately (the
+ * observer's initial mount fetch) and blocks every later call until the test
+ * releases it via `resolvePendingResponse`.
+ */
+import type { ReactNode } from "react";
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { createAppQueryClient } from "@/lib/query-client";
+
+interface RateLimitSharingHarness {
+  readonly queryClient: QueryClient;
+  readonly client: HostClient<HostRpcRegistry>;
+  /** Releases every `host.getRateLimitUsage` call after the first. */
+  readonly resolvePendingResponse: () => void;
+}
+
+// A minimal valid `host.getRateLimitUsage @1.2` response - only fetch timing
+// matters to these tests, not the payload.
+function response() {
+  return { totalTokens: 0, remainingTokens: 0, providerRateLimits: null };
+}
+
+export function createRateLimitSharingHarness(): RateLimitSharingHarness {
+  const queryClient = createAppQueryClient();
+  let callCount = 0;
+  let resolvePending: (() => void) | null = null;
+  const pending = new Promise<void>((resolve) => {
+    resolvePending = resolve;
+  });
+  const client = new HostClient<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    invalidator: createHostQueryInvalidator(queryClient),
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => "req-1",
+      handlers: {
+        "host.getRateLimitUsage": async () => {
+          callCount += 1;
+          if (callCount === 1) return response();
+          await pending;
+          return response();
+        },
+      },
+    }),
+  });
+  client.bind(mockLocalHostEntry);
+  client.setRequestContext(
+    createRequestContextFixture({ origin: "renderer", bearerToken: "tok-1" }),
+  );
+  return {
+    queryClient,
+    client,
+    resolvePendingResponse: () => resolvePending?.(),
+  };
+}
+
+export function createQueryClientWrapper(
+  queryClient: QueryClient,
+): (props: { readonly children: ReactNode }) => ReactNode {
+  return function Wrapper(props: { readonly children: ReactNode }): ReactNode {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {props.children}
+      </QueryClientProvider>
+    );
+  };
+}

--- a/clients/gui-app/src/lib/rate-limits/__tests__/window-severity.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/window-severity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  rateLimitWindowFillPercent,
+  rateLimitWindowSeverity,
+  rateLimitWindowSeverityBarClassName,
+} from "@/lib/rate-limits/window-severity";
+
+describe("rateLimitWindowSeverity", () => {
+  it("returns green at 0% used (100% available)", () => {
+    expect(rateLimitWindowSeverity(0)).toBe("green");
+    // A clock-skewed negative reading still reads as fully available.
+    expect(rateLimitWindowSeverity(-5)).toBe("green");
+  });
+
+  it("returns blue above 0% and under 60% used", () => {
+    expect(rateLimitWindowSeverity(0.1)).toBe("blue");
+    expect(rateLimitWindowSeverity(59.9)).toBe("blue");
+  });
+
+  it("returns yellow for 60-85% used, inclusive of both bounds", () => {
+    expect(rateLimitWindowSeverity(60)).toBe("yellow");
+    expect(rateLimitWindowSeverity(70)).toBe("yellow");
+    expect(rateLimitWindowSeverity(85)).toBe("yellow");
+  });
+
+  it("returns red over 85% used", () => {
+    expect(rateLimitWindowSeverity(85.1)).toBe("red");
+    expect(rateLimitWindowSeverity(100)).toBe("red");
+  });
+});
+
+describe("rateLimitWindowSeverityBarClassName", () => {
+  it("maps each severity to a distinct fill color", () => {
+    expect(rateLimitWindowSeverityBarClassName("green")).toContain("green-500");
+    expect(rateLimitWindowSeverityBarClassName("blue")).toContain("blue-500");
+    expect(rateLimitWindowSeverityBarClassName("yellow")).toContain(
+      "yellow-500",
+    );
+    expect(rateLimitWindowSeverityBarClassName("red")).toContain("red-500");
+  });
+});
+
+describe("rateLimitWindowFillPercent", () => {
+  it("fills the whole track at 0% used (or below) for the full green bar", () => {
+    expect(rateLimitWindowFillPercent(0)).toBe(100);
+    expect(rateLimitWindowFillPercent(-3)).toBe(100);
+  });
+
+  it("tracks the real used percentage otherwise, clamped to [0, 100]", () => {
+    expect(rateLimitWindowFillPercent(40)).toBe(40);
+    expect(rateLimitWindowFillPercent(85)).toBe(85);
+    expect(rateLimitWindowFillPercent(150)).toBe(100);
+  });
+});

--- a/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
+++ b/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
@@ -1,0 +1,215 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { AccountContext } from "@traycer/protocol/common/schemas";
+import type {
+  RequestOfMethod,
+  ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostRpcRegistry } from "@/lib/host";
+import { queryKeys } from "@/lib/query-keys";
+import {
+  PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+  type RateLimitProviderId,
+} from "@/lib/rate-limit-providers";
+
+/**
+ * Shared serial fetch lane for the `ephemeralProcess` rate-limit providers
+ * (codex, claude-code) - the only providers this queue serves. Each of their
+ * pulls spawns a real CLI subprocess on the host, so every trigger that can
+ * cause one (the interval timer, a turn completion, a manual "Refresh all")
+ * routes through here to guarantee **at most one subprocess-spawning fetch is
+ * in flight at a time**, no matter how many providers or how fast the clicks.
+ *
+ * `httpFetch` providers (openrouter, kilocode) NEVER touch this queue - they
+ * poll directly via their query's own `refetchInterval`.
+ *
+ * The queue is a plain module holding process-wide state, wired up once from a
+ * long-lived app-shell component (`RateLimitQueueProvider`) via
+ * `configureRateLimitQueue`. The `QueryClient`, host client `request`, and the
+ * default `hostId` are passed in from that React call site rather than reached
+ * for here - `hostId` is bound at configure time (re-bound whenever the default
+ * host changes) so an enqueue can't race a host swap mid-flight: a queued fetch
+ * always writes into the query key of the host it was enqueued for.
+ */
+
+type RateLimitUsageParams = RequestOfMethod<
+  HostRpcRegistry,
+  "host.getRateLimitUsage"
+>;
+type RateLimitUsageResponse = ResponseOfMethod<
+  HostRpcRegistry,
+  "host.getRateLimitUsage"
+>;
+
+export type RateLimitQueueRequestFn = (
+  hostId: string,
+  method: "host.getRateLimitUsage",
+  params: RateLimitUsageParams,
+) => Promise<RateLimitUsageResponse>;
+
+export interface RateLimitQueueConfig {
+  readonly hostId: string;
+  readonly queryClient: QueryClient;
+  readonly request: RateLimitQueueRequestFn;
+}
+
+let deps: RateLimitQueueConfig | null = null;
+// The serial lane itself: every enqueued fetch appends to the tail of this
+// promise chain, so fetch N+1's `fetchQuery` cannot start until fetch N settles.
+let chain: Promise<unknown> = Promise.resolve();
+let inFlightCount = 0;
+const drainingListeners = new Set<() => void>();
+
+/**
+ * Dev-only (Vite HMR) self-healing for this module's singleton state. An HMR
+ * update that re-executes this module - an edit to it or to anything in its
+ * import chain (`query-keys`, `rate-limit-providers`, `@/lib/host`, ...) -
+ * creates a fresh instance with `deps = null`. `RateLimitQueueProvider`'s
+ * configure effect does not re-run for a bubbled invalidation (its component
+ * and effect deps are unchanged), so nothing would rebind the fresh instance:
+ * every enqueue silently no-ops - buttons stop coordinating, manual refreshes
+ * do nothing - until a full window reload, while the old instance keeps
+ * servicing the interval timer's stale closure so data still looks live.
+ * Carrying the binding across HMR generations closes that gap. Tree-shaken
+ * out of production builds (`import.meta.hot` is statically false there).
+ */
+// `undefined` in the union (rather than an optional marker) is the "no
+// generation has stashed a binding yet" state a fresh `hot.data` object
+// starts in.
+interface RateLimitQueueHotData {
+  rateLimitQueueDeps: RateLimitQueueConfig | null | undefined;
+}
+// Vite types `hot.data` as `any`; the `unknown` hop + structural guard keeps
+// the read type-safe. The guard also handles Vitest, whose truthy
+// `import.meta.hot` stub carries no `data` object, unlike Vite's dev server.
+function isRateLimitQueueHotData(
+  value: unknown,
+): value is RateLimitQueueHotData {
+  return typeof value === "object" && value !== null;
+}
+const hot = import.meta.hot;
+const hotData: unknown = hot?.data;
+if (hot !== undefined && isRateLimitQueueHotData(hotData)) {
+  const carried = hotData.rateLimitQueueDeps;
+  if (carried !== undefined) deps = carried;
+  hot.dispose(() => {
+    hotData.rateLimitQueueDeps = deps;
+  });
+}
+
+function notifyDraining(): void {
+  for (const listener of drainingListeners) listener();
+}
+
+/**
+ * Bind (or, with `null`, unbind) the queue to the default host. Called once
+ * from an app-shell `useEffect` that re-runs on default-host / client change,
+ * and passes `null` on host loss so a stale client can't service an enqueue.
+ */
+export function configureRateLimitQueue(
+  next: RateLimitQueueConfig | null,
+): void {
+  deps = next;
+}
+
+/**
+ * `useSyncExternalStore`-compatible pair for the "a subprocess fetch is
+ * running" signal - a bare promise chain isn't React-observable on its own.
+ * The popover consumes this (via `useIsRateLimitQueueDraining`) to disable
+ * "Refresh all" while the lane is draining.
+ */
+export function subscribeRateLimitQueueDraining(
+  listener: () => void,
+): () => void {
+  drainingListeners.add(listener);
+  return () => {
+    drainingListeners.delete(listener);
+  };
+}
+
+export function isRateLimitQueueDraining(): boolean {
+  return inFlightCount > 0;
+}
+
+/**
+ * Append a rate-limit pull for one `ephemeralProcess` provider to the serial
+ * lane. Returns the tail of the chain so a caller ("Refresh all") can await the
+ * lane draining.
+ *
+ * - `force: false` (interval timer, turn completion): no-op if the query's
+ *   cached data is younger than `PROVIDER_RATE_LIMITS_STALE_TIME_MS`, so
+ *   automatic triggers don't re-spawn a subprocess for still-fresh data.
+ * - `force: true` (user-initiated refresh): always fetches, bypassing that
+ *   floor - a manual refresh must never silently no-op.
+ *
+ * No-ops (returning the current chain) while the queue is unconfigured, mirroring
+ * the host-readiness `enabled` gate the per-provider query uses.
+ */
+export function enqueueRateLimitFetch(
+  providerId: RateLimitProviderId,
+  accountContext: AccountContext,
+  opts: { readonly force: boolean },
+): Promise<unknown> {
+  const current = deps;
+  if (current === null) return chain;
+  const { hostId, queryClient, request } = current;
+  const params: RateLimitUsageParams = { accountContext, providerId };
+  const queryKey = queryKeys.hostMethod<
+    HostRpcRegistry,
+    "host.getRateLimitUsage"
+  >(hostId, "host.getRateLimitUsage", params);
+
+  const isFresh = (): boolean => {
+    const updatedAt = queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0;
+    return Date.now() - updatedAt < PROVIDER_RATE_LIMITS_STALE_TIME_MS;
+  };
+  if (!opts.force && isFresh()) return chain;
+
+  // Named request fn (not an inline closure in `queryFn`) so the host-scoped
+  // key stays the sole cache identity - `request` is stable module state, not a
+  // key input, and inlining it would trip the query plugin's exhaustive-deps
+  // check (mirrors `resolve-artifact-by-path.ts`).
+  const queryFn = (): Promise<RateLimitUsageResponse> =>
+    request(hostId, "host.getRateLimitUsage", params);
+
+  inFlightCount += 1;
+  notifyDraining();
+  chain = chain
+    .then(() => {
+      // Re-checked at this fetch's turn in the lane (not just at enqueue time):
+      // an earlier fetch in the same round may have just refreshed this exact
+      // provider, and an automatic trigger must not re-spawn a subprocess for
+      // data that became fresh while it waited in the queue.
+      if (!opts.force && isFresh()) return undefined;
+      // `staleTime: 0` is load-bearing: `fetchQuery` inherits the app
+      // QueryClient's GLOBAL `staleTime` default (60s in `query-client.ts`)
+      // and serves still-fresh cache without fetching at all. The popover's
+      // open-time refresh keeps this data younger than 60s, so without the
+      // override a user's `force: true` refresh silently no-oped - resolving
+      // from cache in a microtask, spawning no subprocess, flipping
+      // `draining` for under a frame - while the httpFetch lane's
+      // `invalidateQueries` (which always refetches) visibly spun. Freshness
+      // policy for automatic triggers lives in the explicit `isFresh` checks
+      // above, never in `fetchQuery`'s own staleness short-circuit.
+      return queryClient.fetchQuery({ queryKey, queryFn, staleTime: 0 });
+    })
+    // One provider's failure must not block the next provider's turn in the
+    // lane, and must not reject the shared chain (which every future enqueue
+    // builds on).
+    .catch(() => undefined)
+    .finally(() => {
+      inFlightCount -= 1;
+      notifyDraining();
+    });
+  return chain;
+}
+
+/**
+ * Test-only reset of the module-global lane state so each test starts from a
+ * clean queue (no bound host, empty chain, zero in-flight, no listeners).
+ */
+export function __resetRateLimitQueueForTests(): void {
+  deps = null;
+  chain = Promise.resolve();
+  inFlightCount = 0;
+  drainingListeners.clear();
+}

--- a/clients/gui-app/src/lib/rate-limits/window-severity.ts
+++ b/clients/gui-app/src/lib/rate-limits/window-severity.ts
@@ -1,0 +1,52 @@
+/**
+ * Fixed severity scale for a single rate-limit window's used percentage -
+ * shared by the header glyph (Rate Limit Bar Icon - Core Flows, "Icon
+ * composition") and every bar `MeterRow` renders ("Provider detail view"
+ * explicitly reuses these same thresholds) - the single scale every
+ * provider's capped and uncapped bars share, so no row anywhere uses a
+ * different palette or thresholds.
+ *
+ * `"green"` is a distinct fourth tier for a window at 0% used (100% available):
+ * it renders as a fully-filled green bar (see `rateLimitWindowFillPercent`) so
+ * "nothing used yet" reads unambiguously as healthy, rather than as an empty
+ * blue-tier bar.
+ */
+export type RateLimitWindowSeverity = "green" | "blue" | "yellow" | "red";
+
+export function rateLimitWindowSeverity(
+  usedPercent: number,
+): RateLimitWindowSeverity {
+  if (usedPercent <= 0) return "green";
+  if (usedPercent > 85) return "red";
+  if (usedPercent >= 60) return "yellow";
+  return "blue";
+}
+
+/** Tailwind fill color for a severity tier, matching the Core Flows wireframe's bar colors. */
+export function rateLimitWindowSeverityBarClassName(
+  severity: RateLimitWindowSeverity,
+): string {
+  switch (severity) {
+    case "red":
+      return "bg-red-500 dark:bg-red-400";
+    case "yellow":
+      return "bg-yellow-500 dark:bg-yellow-400";
+    case "blue":
+      return "bg-blue-500 dark:bg-blue-400";
+    case "green":
+      return "bg-green-500 dark:bg-green-400";
+  }
+}
+
+/**
+ * The width (0-100) a severity-colored window bar should fill. A window at 0%
+ * used (100% available) fills the whole track - paired with the `"green"`
+ * severity - so it reads as a full green bar rather than an empty one;
+ * otherwise the bar tracks the real used percentage, clamped to [0, 100]. This
+ * is the *fill* only: callers still derive any "% left/used" text from the real
+ * `usedPercent`, not from this forced-full value.
+ */
+export function rateLimitWindowFillPercent(usedPercent: number): number {
+  if (usedPercent <= 0) return 100;
+  return Math.min(100, Math.max(0, usedPercent));
+}

--- a/clients/gui-app/src/lib/relative-time.ts
+++ b/clients/gui-app/src/lib/relative-time.ts
@@ -89,3 +89,92 @@ export function useRelativeTimestamp(createdAt: number): string {
   useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   return formatRelativeTimestamp(createdAt, sampledNow);
 }
+
+/**
+ * Pure future-facing countdown formatter, the mirror of
+ * `formatRelativeTimestamp` for a reset time instead of a creation time.
+ *
+ * Buckets: "now" (<1m away) / `${n}m` / `${h}h ${m}m` (m omitted when 0) /
+ * `${d}d`. A past `resetsAt` (clock skew, or the window rolled over between
+ * fetch and render) clamps to "now" rather than a negative duration.
+ */
+export function formatResetCountdown(resetsAt: number, now: number): string {
+  const diffMs = Math.max(0, resetsAt - now);
+  const minutes = Math.floor(diffMs / MINUTE_MS);
+  if (minutes < 1) return "now";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) {
+    return remainingMinutes > 0
+      ? `${hours}h ${remainingMinutes}m`
+      : `${hours}h`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+/**
+ * Subscribes to the shared 60s tick clock and returns the current countdown
+ * label for `resetsAt` (epoch-ms), or `null` when there is nothing to count
+ * down to. Shares the same clock `useRelativeTimestamp` uses, so a popover
+ * showing several rate-limit windows alongside relative message timestamps
+ * still pays for only one interval.
+ */
+export function useResetCountdown(resetsAt: number | null): string | null {
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  if (resetsAt === null) return null;
+  return formatResetCountdown(resetsAt, sampledNow);
+}
+
+/**
+ * Whether a reset is far enough away that an absolute weekday/time reads
+ * better than a relative countdown ("Resets in 3d" is too coarse to act on).
+ * Based on the real time remaining rather than a window's nominal duration:
+ * some windows (e.g. Claude's per-model `modelScoped` buckets) carry no
+ * `durationMinutes` at all, so gating this decision on duration meant those
+ * windows always fell back to the relative countdown even when their real
+ * reset was days away (regression: Claude's "Fable" per-model window showed
+ * "Resets in 3d" instead of "Resets Tue 5:29 PM"). Every window always has a
+ * real `resetsAt`, so every caller now derives this the same way instead of
+ * each threading through its own duration-based flag (or, worse, hardcoding
+ * one).
+ */
+export function isFarReset(resetsAt: number, now: number): boolean {
+  return resetsAt - now >= DAY_MS;
+}
+
+/**
+ * Subscribes to the shared 60s tick clock and returns whether `resetsAt` is
+ * currently far enough away to warrant `formatResetDateTime` over
+ * `formatResetCountdown` - `false` for a `null` resetsAt (nothing to compare).
+ * Reactive (unlike `formatResetDateTime` itself) so a window that crosses the
+ * one-day threshold while the popover is open flips from absolute to relative
+ * display without a remount.
+ */
+export function useIsFarReset(resetsAt: number | null): boolean {
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  if (resetsAt === null) return false;
+  return isFarReset(resetsAt, sampledNow);
+}
+
+/**
+ * Exact reset time as weekday + time (e.g. "Sat 3:35 AM"), for windows where
+ * a relative countdown ("Resets in 3d") is too coarse to act on. Drops the
+ * calendar date on purpose: these windows reset within the next 7 days, so
+ * the weekday alone disambiguates it, and the shorter string reads better in
+ * a tight row. `hour12: true` is explicit rather than left to locale default
+ * so the AM/PM designator always renders. A pure function, not a hook: unlike
+ * a relative countdown, an absolute time string doesn't go stale as time
+ * passes, so it doesn't need to subscribe to the shared tick clock.
+ */
+export function formatResetDateTime(resetsAt: number): string {
+  const date = new Date(resetsAt);
+  const weekday = date.toLocaleDateString(undefined, { weekday: "short" });
+  const time = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+  return `${weekday} ${time}`;
+}

--- a/clients/gui-app/src/providers/__tests__/rate-limit-queue-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/rate-limit-queue-provider.test.tsx
@@ -1,0 +1,224 @@
+import "../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type { ReactNode } from "react";
+
+type MockState = {
+  hostId: string | null;
+  client: { request: () => Promise<unknown> } | null;
+  configured: ReadonlyArray<{
+    readonly providerId: string;
+    readonly lane: string;
+  }>;
+};
+
+const mocks = vi.hoisted<MockState>(() => ({
+  hostId: "host-a",
+  client: { request: () => Promise.resolve({}) },
+  configured: [],
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => mocks.hostId,
+}));
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => mocks.client,
+}));
+vi.mock("@/hooks/rate-limits/use-configured-rate-limit-providers", () => ({
+  useConfiguredRateLimitProviders: () => mocks.configured,
+}));
+vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
+  configureRateLimitQueue: vi.fn(),
+  enqueueRateLimitFetch: vi.fn(() => Promise.resolve()),
+}));
+
+import {
+  RateLimitQueueProvider,
+  EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS,
+} from "@/providers/rate-limit-queue-provider";
+import {
+  configureRateLimitQueue,
+  enqueueRateLimitFetch,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+const configureSpy = vi.mocked(configureRateLimitQueue);
+const enqueueSpy = vi.mocked(enqueueRateLimitFetch);
+
+function defineVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+function changeVisibility(state: "visible" | "hidden"): void {
+  defineVisibility(state);
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+function tree(): ReactNode {
+  return (
+    <QueryClientProvider client={new QueryClient()}>
+      <RateLimitQueueProvider />
+    </QueryClientProvider>
+  );
+}
+
+describe("<RateLimitQueueProvider />", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.hostId = "host-a";
+    mocks.client = { request: vi.fn(() => Promise.resolve({})) };
+    mocks.configured = [];
+    configureSpy.mockClear();
+    enqueueSpy.mockClear();
+    defineVisibility("visible");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("polls the ephemeralProcess lane every 5 minutes, matching the httpFetch lane's own refetchInterval", () => {
+    expect(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS).toBe(5 * 60 * 1000);
+  });
+
+  it("binds the serial queue to the default host on mount", () => {
+    render(tree());
+    const config = configureSpy.mock.calls.at(-1)?.[0] ?? null;
+    expect(config).not.toBeNull();
+    expect(config?.hostId).toBe("host-a");
+    expect(typeof config?.request).toBe("function");
+  });
+
+  it("unbinds the queue when the host is lost", () => {
+    const { rerender } = render(tree());
+    configureSpy.mockClear();
+    act(() => {
+      mocks.hostId = null;
+      rerender(tree());
+    });
+    expect(configureSpy).toHaveBeenLastCalledWith(null);
+  });
+
+  it("enqueues only ephemeralProcess providers immediately when they are configured", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "openrouter", lane: "httpFetch" },
+    ];
+    render(tree());
+
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("polls only ephemeralProcess providers each interval after the immediate enqueue", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "openrouter", lane: "httpFetch" },
+    ];
+    render(tree());
+    enqueueSpy.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+
+    // Only the ephemeralProcess provider is enqueued; the httpFetch one never
+    // touches the queue.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("pauses the interval while the document is hidden and resumes when visible again (guardrail 2)", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    render(tree());
+    enqueueSpy.mockClear();
+
+    act(() => {
+      changeVisibility("hidden");
+    });
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS * 3);
+    });
+    // Minimized/backgrounded: no subprocess-spawning enqueues at all.
+    expect(enqueueSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      changeVisibility("visible");
+    });
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+    // Brought back: polling resumes.
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps polling when the window loses focus but stays visible - never keys off blur (guardrail 4)", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    render(tree());
+    enqueueSpy.mockClear();
+
+    // OS focus moves elsewhere (e.g. Traycer visible on a second monitor). The
+    // document stays "visible", so nothing must pause.
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-gates on the next tick when a credential is removed mid-session, without resetting the timer", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess" },
+      { providerId: "claude-code", lane: "ephemeralProcess" },
+    ];
+    const { rerender } = render(tree());
+    enqueueSpy.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+    expect(enqueueSpy).toHaveBeenCalledTimes(2);
+    enqueueSpy.mockClear();
+
+    // claude-code's credential is removed mid-session -> it drops out of the
+    // configured set. The ref updates on re-render; the interval keeps running.
+    act(() => {
+      mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+      rerender(tree());
+    });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+    enqueueSpy.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS);
+    });
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    expect(enqueueSpy).toHaveBeenCalledWith("codex", DEFAULT_ACCOUNT_CONTEXT, {
+      force: false,
+    });
+  });
+
+  it("does not run the interval while there is no host", () => {
+    mocks.hostId = null;
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    render(tree());
+    act(() => {
+      vi.advanceTimersByTime(EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS * 2);
+    });
+    expect(enqueueSpy).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
+++ b/clients/gui-app/src/providers/rate-limit-queue-provider.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import { useHostClient } from "@/lib/host";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useConfiguredRateLimitProviders } from "@/hooks/rate-limits/use-configured-rate-limit-providers";
+import {
+  configureRateLimitQueue,
+  enqueueRateLimitFetch,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+/**
+ * Background poll cadence for the `ephemeralProcess` lane (codex, claude-code),
+ * matching the `httpFetch` lane's own `refetchInterval`
+ * (`HTTP_FETCH_RATE_LIMIT_REFETCH_INTERVAL_MS`) so both lanes settle to the
+ * same background freshness regardless of fetch cost class. Still slack
+ * relative to a plain GET (subprocess spawns are expensive) - the serial
+ * queue's 30s freshness floor, turn-completion enqueues, and manual refresh
+ * all keep data fresher between ticks.
+ */
+export const EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * The long-lived app-shell owner of the rate-limit data layer (no rendered
+ * output). It does two things for the lifetime of the window:
+ *
+ * 1. Binds the `ephemeralProcess` serial queue to the default host
+ *    (`configureRateLimitQueue`), re-binding on host/client swap and unbinding
+ *    on host loss so a stale client can't service an enqueue.
+ * 2. Drives the single shared interval timer for the `ephemeralProcess` lane,
+ *    walking the currently-configured providers and enqueuing a `force: false`
+ *    pull for each (the queue serializes them, one subprocess at a time). It
+ *    also enqueues the same safe pull immediately when the configured
+ *    `ephemeralProcess` provider set changes, so the header glyph/popover can
+ *    recover from a failed first read without waiting for a transient surface
+ *    mount.
+ *
+ * The timer PAUSES on `document.visibilityState === "hidden"` (window truly
+ * minimized/backgrounded) and resumes when the window is shown again - matching
+ * the same visibility signal TanStack's `focusManager` uses for the httpFetch
+ * lane's `refetchIntervalInBackground: false`. It deliberately does NOT key off
+ * window focus (`blur` / `document.hasFocus()`): the core scenario this feature
+ * exists for is glancing at the icon while Traycer sits visible-but-unfocused on
+ * a second monitor, and pausing on mere focus-loss would break exactly that.
+ *
+ * `httpFetch` providers are intentionally absent here - they poll via their
+ * query's own `refetchInterval` and never enter this queue.
+ */
+export function RateLimitQueueProvider(): null {
+  const hostId = useReactiveActiveHostId();
+  const client = useHostClient();
+  const queryClient = useQueryClient();
+  const configuredProviders = useConfiguredRateLimitProviders();
+
+  // Bind the queue to the default host. Re-runs on host/client swap; the
+  // cleanup + `null` branch clears the binding on host loss (`hostId` flips to
+  // `null`). `hostId` is bound into the queue at configure time (not passed per
+  // enqueue) so a queued fetch can't be reassigned to a different host
+  // mid-flight. `useHostClient()` is non-null once the runtime is mounted, so
+  // only host presence needs gating here.
+  useEffect(() => {
+    if (hostId === null) {
+      configureRateLimitQueue(null);
+      return;
+    }
+    configureRateLimitQueue({
+      hostId,
+      queryClient,
+      request: (_hostId, method, params) => client.request(method, params),
+    });
+    return () => {
+      configureRateLimitQueue(null);
+    };
+  }, [hostId, client, queryClient]);
+
+  // Latest `ephemeralProcess` provider ids, read live by the interval callback
+  // through a ref so a credential change re-gates the walked set on the very
+  // next tick WITHOUT resetting the timer (which a dependency would, pushing the
+  // first tick a full interval into the future on every list change).
+  const ephemeralProviderIds = useMemo(
+    () =>
+      configuredProviders
+        .filter((provider) => provider.lane === "ephemeralProcess")
+        .map((provider) => provider.providerId),
+    [configuredProviders],
+  );
+  const ephemeralProviderIdsRef = useRef(ephemeralProviderIds);
+  useEffect(() => {
+    ephemeralProviderIdsRef.current = ephemeralProviderIds;
+  }, [ephemeralProviderIds]);
+
+  useEffect(() => {
+    if (hostId === null) return;
+    ephemeralProviderIds.forEach((providerId) => {
+      void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+        force: false,
+      });
+    });
+  }, [hostId, ephemeralProviderIds]);
+
+  // The single shared interval timer, gated on host presence and paused while
+  // the window is hidden. Initial per-provider data still populates through the
+  // immediate effect above and per-surface queue enqueue-on-mount; this timer
+  // only does the periodic background refresh.
+  useEffect(() => {
+    if (hostId === null) return;
+    let intervalHandle: number | null = null;
+
+    const tick = (): void => {
+      // Defensive: the timer is cleared while hidden, but guard the body too so
+      // a tick that races a `visibilitychange` can't spawn a subprocess.
+      if (document.visibilityState === "hidden") return;
+      ephemeralProviderIdsRef.current.forEach((providerId) => {
+        void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+          force: false,
+        });
+      });
+    };
+    const start = (): void => {
+      if (intervalHandle !== null) return;
+      intervalHandle = window.setInterval(
+        tick,
+        EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS,
+      );
+    };
+    const stop = (): void => {
+      if (intervalHandle === null) return;
+      window.clearInterval(intervalHandle);
+      intervalHandle = null;
+    };
+    const syncToVisibility = (): void => {
+      if (document.visibilityState === "hidden") {
+        stop();
+      } else {
+        start();
+      }
+    };
+
+    syncToVisibility();
+    document.addEventListener("visibilitychange", syncToVisibility);
+    return () => {
+      document.removeEventListener("visibilitychange", syncToVisibility);
+      stop();
+    };
+  }, [hostId]);
+
+  return null;
+}

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -31,6 +31,7 @@ import { HarnessCatalogPrefetcher } from "@/providers/harness-catalog-prefetcher
 import { HistoryPruneProvider } from "@/providers/history-prune-provider";
 import { KeybindingProvider } from "@/providers/keybinding-provider";
 import { NotificationsSessionProvider } from "@/providers/notifications-session-provider";
+import { RateLimitQueueProvider } from "@/providers/rate-limit-queue-provider";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { WindowsBridgeAuthSessionBridge } from "@/providers/windows-bridge-auth-session";
@@ -203,6 +204,7 @@ function TraycerAppRuntimeSurface(props: TraycerAppRuntimeSurfaceProps) {
       <WorktreeDeleteProgressToastBridge />
       <CliCredentialSeeder />
       <HarnessCatalogPrefetcher />
+      <RateLimitQueueProvider />
       <HistoryPruneProvider router={props.router} />
       <RouterProvider router={props.router} />
       <HostPicker />

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import {
+  providerRateLimitsSchema,
+  rateLimitUsageRequestSchemaV12,
+  rateLimitUsageResponseSchemaV12,
+} from "@traycer/protocol/host/rate-limit/schemas";
+
+// `providerRateLimitsSchema` is a plain `z.union`, not a `z.discriminatedUnion`,
+// because its "unavailable" arm's `provider` field ranges over the full
+// provider-id enum, which overlaps the `"codex"` / `"claude-code"` literals the
+// other two arms use as their tag. A `z.discriminatedUnion` with that overlap
+// throws a raw (non-`ZodError`) "Duplicate discriminator value" error the first
+// time it's parsed - `safeParse` can't catch it, so these tests must call
+// `.parse()`/`.safeParse()` for real to catch a regression back to
+// `discriminatedUnion`.
+describe("providerRateLimitsSchema", () => {
+  it("parses an available codex snapshot with per-limit breakdown and reset credits", () => {
+    const codex = {
+      provider: "codex" as const,
+      available: true as const,
+      planType: "plus",
+      limitId: "plus-primary",
+      limitName: "Plus",
+      primary: { usedPercent: 42, resetsAt: 1735689600000, durationMinutes: 300 },
+      secondary: null,
+      extraWindows: [
+        {
+          limitId: "plus-secondary",
+          limitName: "Plus (weekly)",
+          primary: { usedPercent: 12, resetsAt: 1735776000000, durationMinutes: 10080 },
+          secondary: null,
+        },
+      ],
+      credits: { hasCredits: true, unlimited: false, balance: "10.00" },
+      individualLimit: null,
+      resetCredits: {
+        availableCount: 2,
+      },
+      rateLimitReachedType: null,
+    };
+    expect(providerRateLimitsSchema.parse(codex)).toEqual(codex);
+  });
+
+  it("parses an available claude-code snapshot with window durations", () => {
+    const claudeCode = {
+      provider: "claude-code" as const,
+      available: true as const,
+      subscriptionType: "max",
+      fiveHour: { usedPercent: 10, resetsAt: null, durationMinutes: 300 },
+      sevenDay: null,
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      modelScoped: [
+        { displayName: "Opus", usedPercent: 5, resetsAt: null, durationMinutes: null },
+      ],
+      extraUsage: null,
+    };
+    expect(providerRateLimitsSchema.parse(claudeCode)).toEqual(claudeCode);
+  });
+
+  it("parses an available openrouter snapshot", () => {
+    const openRouter = {
+      provider: "openrouter" as const,
+      available: true as const,
+      limit: 100,
+      limitRemaining: 40,
+      dailySpend: 1.5,
+      weeklySpend: 10.25,
+      monthlySpend: 42,
+      totalCredits: 100,
+      totalUsage: 58,
+      balance: 42,
+    };
+    expect(providerRateLimitsSchema.parse(openRouter)).toEqual(openRouter);
+  });
+
+  it("parses an available kilocode snapshot", () => {
+    const kiloCode = {
+      provider: "kilocode" as const,
+      available: true as const,
+      creditBalance: 25.5,
+      passState: "active",
+    };
+    expect(providerRateLimitsSchema.parse(kiloCode)).toEqual(kiloCode);
+  });
+
+  it("parses an unavailable snapshot for a provider id shared with an available arm", () => {
+    const unavailable = {
+      provider: "codex" as const,
+      available: false as const,
+      reason: "timeout" as const,
+    };
+    expect(providerRateLimitsSchema.parse(unavailable)).toEqual(unavailable);
+
+    const claudeUnavailable = {
+      provider: "claude-code" as const,
+      available: false as const,
+      reason: "rate_limits_not_available" as const,
+    };
+    expect(providerRateLimitsSchema.parse(claudeUnavailable)).toEqual(
+      claudeUnavailable,
+    );
+  });
+
+  it("parses an unavailable snapshot with the insufficient_permissions reason", () => {
+    const unavailable = {
+      provider: "droid" as const,
+      available: false as const,
+      reason: "insufficient_permissions" as const,
+    };
+    expect(providerRateLimitsSchema.parse(unavailable)).toEqual(unavailable);
+  });
+
+  it("rejects a reason outside the closed unavailable-reason set", () => {
+    const invalid = {
+      provider: "codex" as const,
+      available: false as const,
+      reason: "not_logged_in",
+    };
+    expect(providerRateLimitsSchema.safeParse(invalid).success).toBe(false);
+  });
+});
+
+describe("rateLimitUsageRequestSchemaV12", () => {
+  it("parses a request without providerId, leaving it undefined", () => {
+    const request = rateLimitUsageRequestSchemaV12.parse({
+      accountContext: DEFAULT_ACCOUNT_CONTEXT,
+    });
+    expect(request.providerId).toBeUndefined();
+  });
+
+  it("preserves providerId when the request asks for a specific provider", () => {
+    const request = rateLimitUsageRequestSchemaV12.parse({
+      accountContext: DEFAULT_ACCOUNT_CONTEXT,
+      providerId: "codex",
+    });
+    expect(request.providerId).toBe("codex");
+  });
+});
+
+describe("rateLimitUsageResponseSchemaV12", () => {
+  it("parses a response carrying a provider rate-limit snapshot", () => {
+    const response = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: {
+        provider: "codex" as const,
+        available: true as const,
+        planType: null,
+        limitId: null,
+        limitName: null,
+        primary: null,
+        secondary: null,
+        extraWindows: [],
+        credits: null,
+        individualLimit: null,
+        resetCredits: null,
+        rateLimitReachedType: null,
+      },
+    };
+    expect(rateLimitUsageResponseSchemaV12.parse(response)).toEqual(response);
+  });
+
+  it("parses a response with providerRateLimits: null (aperture-only call)", () => {
+    const response = {
+      totalTokens: 100,
+      remainingTokens: 50,
+      providerRateLimits: null,
+    };
+    expect(rateLimitUsageResponseSchemaV12.parse(response)).toEqual(response);
+  });
+});

--- a/protocol/src/host/rate-limit/contracts.ts
+++ b/protocol/src/host/rate-limit/contracts.ts
@@ -6,7 +6,9 @@ import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import {
   rateLimitUsageRequestSchemaV10,
   rateLimitUsageRequestSchemaV11,
+  rateLimitUsageRequestSchemaV12,
   rateLimitUsageResponseSchema,
+  rateLimitUsageResponseSchemaV12,
 } from "@traycer/protocol/host/rate-limit/schemas";
 
 export const hostGetRateLimitUsageV10 = defineRpcContract({
@@ -38,4 +40,30 @@ export const hostGetRateLimitUsageUpgradeV10ToV11 = defineUpgradePath<
   to: hostGetRateLimitUsageV11.schemaVersion,
   upgradeRequest: () => ({ accountContext: DEFAULT_ACCOUNT_CONTEXT }),
   upgradeResponse: (response) => response,
+});
+
+// v1.2 adds an optional `providerId` to the request and a nullable
+// `providerRateLimits` provider-account snapshot to the response, so the same
+// method can also serve Codex / Claude Code CLI account rate limits. Shipped
+// as a minor (not an in-place change to v1.1) so a v1.1 host still
+// negotiates. See the RPC backward-compat decision log.
+export const hostGetRateLimitUsageV12 = defineRpcContract({
+  method: "host.getRateLimitUsage",
+  schemaVersion: { major: 1, minor: 2 } as const,
+  requestSchema: rateLimitUsageRequestSchemaV12,
+  responseSchema: rateLimitUsageResponseSchemaV12,
+});
+
+// A v1.1 request carries no `providerId`, so it upgrades as-is (still
+// optional in v1.2, so no default is needed). A v1.1 response carries no
+// `providerRateLimits`, so it upgrades to `null` - the same "card hidden"
+// state a v1.2 client gets for an aperture-only call.
+export const hostGetRateLimitUsageUpgradeV11ToV12 = defineUpgradePath<
+  typeof hostGetRateLimitUsageV11,
+  typeof hostGetRateLimitUsageV12
+>({
+  from: hostGetRateLimitUsageV11.schemaVersion,
+  to: hostGetRateLimitUsageV12.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => ({ ...response, providerRateLimits: null }),
 });

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_ACCOUNT_CONTEXT,
   accountContextSchema,
 } from "@traycer/protocol/common/schemas";
+import { providerIdSchema } from "@traycer/protocol/host/provider-schemas";
 
 // `host.getRateLimitUsage` v1.0 request: no fields. Non-strict on purpose so a
 // v1.1 client can Zod-strip its `accountContext` away when projecting the request
@@ -37,4 +38,192 @@ export const rateLimitUsageResponseSchema = z.object({
 });
 export type RateLimitUsageResponse = z.infer<
   typeof rateLimitUsageResponseSchema
+>;
+
+// v1.2 adds provider-account rate limits (Codex / Claude Code CLI), pulled
+// on-demand for a specific provider rather than the Traycer-inference
+// aperture the v1.0/v1.1 fields describe. Added as a minor (NOT an in-place
+// edit to v1.1) so a shipped v1.1 host still negotiates: `providerId` is
+// optional, so an unset field leaves today's aperture behavior unchanged.
+export const rateLimitUsageRequestSchemaV12 =
+  rateLimitUsageRequestSchemaV11.extend({
+    providerId: providerIdSchema.optional(),
+  });
+export type RateLimitUsageRequestV12 = z.infer<
+  typeof rateLimitUsageRequestSchemaV12
+>;
+
+// A normalized rolling rate-limit window, shared by every provider arm below.
+// `resetsAt` is epoch-ms (each provider's native reset representation is
+// normalized to this at the host boundary).
+export const providerRateLimitWindowSchema = z.object({
+  usedPercent: z.number(),
+  resetsAt: z.number().nullable(),
+  durationMinutes: z.number().nullable(),
+});
+export type ProviderRateLimitWindow = z.infer<
+  typeof providerRateLimitWindowSchema
+>;
+
+// Single source of truth for "which providers report account rate limits": the
+// available arms below tag on it, the host's reader dispatch narrows to it
+// (exhaustively), and the GUI derives its `RateLimitProviderId` from it - so
+// adding a provider is one edit the compiler propagates across all three.
+export const rateLimitCapableProviderIdSchema = z.enum([
+  "codex",
+  "claude-code",
+  "openrouter",
+  "kilocode",
+]);
+export type RateLimitCapableProviderId = z.infer<
+  typeof rateLimitCapableProviderIdSchema
+>;
+
+const codexRateLimitsSchema = z.object({
+  provider: z.literal(rateLimitCapableProviderIdSchema.enum.codex),
+  available: z.literal(true),
+  planType: z.string().nullable(),
+  limitId: z.string().nullable(),
+  limitName: z.string().nullable(),
+  primary: providerRateLimitWindowSchema.nullable(),
+  secondary: providerRateLimitWindowSchema.nullable(),
+  extraWindows: z.array(
+    z.object({
+      limitId: z.string(),
+      limitName: z.string().nullable(),
+      primary: providerRateLimitWindowSchema.nullable(),
+      secondary: providerRateLimitWindowSchema.nullable(),
+    }),
+  ),
+  credits: z
+    .object({
+      hasCredits: z.boolean(),
+      unlimited: z.boolean(),
+      balance: z.string().nullable(),
+    })
+    .nullable(),
+  individualLimit: z
+    .object({
+      limit: z.string(),
+      used: z.string(),
+      remainingPercent: z.number(),
+      resetsAt: z.number(),
+    })
+    .nullable(),
+  // Verified against a live `account/rateLimits/read` call: the real
+  // `RateLimitResetCreditsSummary` is just `{ availableCount }` - no nested
+  // `credits` array exists (the earlier sketch guessed one from partial
+  // information).
+  resetCredits: z
+    .object({
+      availableCount: z.number(),
+    })
+    .nullable(),
+  rateLimitReachedType: z.string().nullable(),
+});
+
+// OpenRouter arm - httpFetch-class provider (a plain GET against OpenRouter's
+// key/credits endpoints, no subprocess). Field names are a sketch, not yet
+// verified against a live call - see the Tech Plan's "Open items".
+const openRouterRateLimitsSchema = z.object({
+  provider: z.literal(rateLimitCapableProviderIdSchema.enum.openrouter),
+  available: z.literal(true),
+  limit: z.number().nullable(),
+  limitRemaining: z.number().nullable(),
+  dailySpend: z.number().nullable(),
+  weeklySpend: z.number().nullable(),
+  monthlySpend: z.number().nullable(),
+  totalCredits: z.number().nullable(),
+  totalUsage: z.number().nullable(),
+  balance: z.number().nullable(),
+});
+
+// Kilo Code arm - httpFetch-class provider (reads its own credential file,
+// no subprocess). Field names are a sketch, not yet verified against a live
+// call - see the Tech Plan's "Open items".
+const kiloCodeRateLimitsSchema = z.object({
+  provider: z.literal(rateLimitCapableProviderIdSchema.enum.kilocode),
+  available: z.literal(true),
+  creditBalance: z.number().nullable(),
+  passState: z.string().nullable(),
+});
+
+const claudeCodeRateLimitsSchema = z.object({
+  provider: z.literal(rateLimitCapableProviderIdSchema.enum["claude-code"]),
+  available: z.literal(true),
+  subscriptionType: z.string().nullable(),
+  fiveHour: providerRateLimitWindowSchema.nullable(),
+  sevenDay: providerRateLimitWindowSchema.nullable(),
+  sevenDayOpus: providerRateLimitWindowSchema.nullable(),
+  sevenDaySonnet: providerRateLimitWindowSchema.nullable(),
+  modelScoped: z.array(
+    z.object({ displayName: z.string() }).and(providerRateLimitWindowSchema),
+  ),
+  extraUsage: z
+    .object({
+      isEnabled: z.boolean(),
+      monthlyLimit: z.number().nullable(),
+      usedCredits: z.number().nullable(),
+      utilization: z.number().nullable(),
+    })
+    .nullable(),
+});
+
+// Closed, Traycer-owned set of reasons a provider pull can fail to report
+// rate limits - unlike a provider's own plan/reached-type tokens (owned by
+// that provider, legitimately forward-compat as a bare string), every one of
+// these is emitted by `traycer-host` itself and ships atomically with this
+// schema, so there's no cross-version drift risk in constraining it. Enforces
+// the host's `unavailableRateLimits` call sites and the GUI's display-label
+// map stay exhaustive at compile time instead of silently drifting.
+export const rateLimitUnavailableReasonSchema = z.enum([
+  "cli_not_found",
+  "unsupported_provider",
+  "invalid_response",
+  "timeout",
+  "connection_failed",
+  "rate_limits_not_available",
+  "sdk_incompatible",
+  "insufficient_permissions",
+]);
+export type RateLimitUnavailableReason = z.infer<
+  typeof rateLimitUnavailableReasonSchema
+>;
+
+// Any provider/auth combination that can't report rate limits (API-key auth,
+// not logged in, a timed-out pull, etc). Its `provider` field ranges over the
+// full `providerIdSchema` enum, which overlaps the literal `"codex"` /
+// `"claude-code"` values the two arms above use as their tag - that overlap
+// is why this union is a plain `z.union`, not a `z.discriminatedUnion`.
+// `discriminatedUnion` requires every arm's discriminator value to be
+// unique; two arms claiming `"codex"` (one via `z.literal`, one via this
+// enum) makes Zod throw a raw (non-ZodError) "Duplicate discriminator value"
+// error the first time the schema is parsed, which `safeParse` can't catch.
+const unavailableProviderRateLimitsSchema = z.object({
+  provider: providerIdSchema,
+  available: z.literal(false),
+  reason: rateLimitUnavailableReasonSchema,
+});
+
+// Provider-tagged union of account rate-limit snapshots. Carries each
+// provider's full native detail (not just what today's UI renders) so the
+// schema doesn't need another version bump when the UI grows.
+export const providerRateLimitsSchema = z.union([
+  codexRateLimitsSchema,
+  claudeCodeRateLimitsSchema,
+  openRouterRateLimitsSchema,
+  kiloCodeRateLimitsSchema,
+  unavailableProviderRateLimitsSchema,
+]);
+export type ProviderRateLimits = z.infer<typeof providerRateLimitsSchema>;
+
+// v1.2 response = v1.0/v1.1 flat aperture fields (unchanged) + a nullable
+// provider-account snapshot. Null both when the request didn't ask for a
+// provider (aperture calls) and when a v1.1 host answers a v1.2 request (see
+// the v1.1 -> v1.2 upgrade path).
+export const rateLimitUsageResponseSchemaV12 = rateLimitUsageResponseSchema.extend({
+  providerRateLimits: providerRateLimitsSchema.nullable(),
+});
+export type RateLimitUsageResponseV12 = z.infer<
+  typeof rateLimitUsageResponseSchemaV12
 >;

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -55,7 +55,9 @@ import { hostGetRuntimeCapabilitiesV10 } from "@traycer/protocol/host/runtime-ca
 import {
   hostGetRateLimitUsageV10,
   hostGetRateLimitUsageV11,
+  hostGetRateLimitUsageV12,
   hostGetRateLimitUsageUpgradeV10ToV11,
+  hostGetRateLimitUsageUpgradeV11ToV12,
 } from "@traycer/protocol/host/rate-limit/contracts";
 import {
   epicBatchDeleteV10,
@@ -1070,7 +1072,7 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
   },
   "host.getRateLimitUsage": {
     1: {
-      latestMinor: 1,
+      latestMinor: 2,
       versions: {
         0: {
           contract: hostGetRateLimitUsageV10,
@@ -1079,6 +1081,10 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
         1: {
           contract: hostGetRateLimitUsageV11,
           upgradeFromPreviousVersion: hostGetRateLimitUsageUpgradeV10ToV11,
+        },
+        2: {
+          contract: hostGetRateLimitUsageV12,
+          upgradeFromPreviousVersion: hostGetRateLimitUsageUpgradeV11ToV12,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
## Summary

Backports the narrow upstream fix set needed for:

- durable stream bearer rotation forwarding
- usage-limit refresh recovery

`dbe2261` was not standalone from this fork point, so this PR includes its minimal prerequisite closure:

- `d5d9c27` `feat(protocol,gui-app): surface Codex/Claude Code account rate limits`
- `59df881` `feat(protocol,gui-app): rate-limit header icon and popover`
- `e50a7b3` `fix(gui-app): forward durable stream bearer rotations`
- `dbe2261` `fix(gui): recover usage limit refreshes`

Excluded unrelated ancestry commits and all July 6/7 upstream changes.

## Verification

- `git diff --check --cached`
- `bunx nx run @traycer/protocol:compile`
- `bunx nx run traycer-clients-gui-app:compile`

## Fork boundary

Only the committed upstream-sync slice is in this branch. Local fork identity edits in `package.json`, `bun.lock`, and `ALIAS_ARCHITECT_AUTEUR.md` were left out.
