### PR TITLE
fix(gui-app): stop terminal reattach loop

### DIFF
--- a/clients/gui-app/src/hooks/agent/__tests__/use-terminal-tile-bootstrap-refetch-stability.test.tsx
+++ b/clients/gui-app/src/hooks/agent/__tests__/use-terminal-tile-bootstrap-refetch-stability.test.tsx
@@ -1,0 +1,195 @@
+import "../../../../__tests__/test-browser-apis";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { UseTerminalSessionHandleArgs } from "@/lib/registries/terminal-session-registry";
+
+// A live session handle must survive `terminal.list` REFETCHES. The handle
+// gate used to derive from `hostHasSession`, which degrades to `null`
+// whenever the list query is in flight - so any invalidation of
+// `terminal.list` released the handle (closing the PTY stream), reacquired
+// it when the refetch settled, and the fresh subscription's snapshot pushed
+// metadata that invalidated the list again: an endless subscribe/release
+// loop that left reattached terminals blank. The handle may only be
+// released on a SETTLED list that shows the session gone or exited.
+
+let mockList: {
+  data: { sessions: ReadonlyArray<Record<string, unknown>> } | undefined;
+  isFetching: boolean;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: () => Promise<unknown>;
+};
+let mockCreate: {
+  isError: boolean;
+  isIdle: boolean;
+  isSuccess: boolean;
+  error: Error | null;
+  reset: () => void;
+  mutate: Mock;
+};
+let handleCalls: UseTerminalSessionHandleArgs[];
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useOpenEpicId: () => "epic-1",
+}));
+
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => ({
+    hostId: "host-1",
+    label: "Host 1",
+    kind: "local",
+    websocketUrl: "ws://127.0.0.1:1/rpc",
+    version: null,
+    status: "available",
+  }),
+}));
+
+vi.mock("@/hooks/host/use-host-client-for", () => ({
+  useHostClientFor: () => ({
+    request: () => new Promise(() => {}),
+    getActiveHostId: () => "host-1",
+    getRequestContextUserId: () => "user-1",
+    onChange: () => () => undefined,
+  }),
+}));
+
+vi.mock("@/hooks/terminal/use-terminal-list-query", () => ({
+  useTerminalList: () => mockList,
+}));
+
+vi.mock("@/hooks/terminal/use-terminal-create-mutation", () => ({
+  useTerminalCreate: () => mockCreate,
+}));
+
+// Capture the args the bootstrap feeds the session handle so the tests can
+// assert on the `enabled` / `reattachMode` the registry would act on.
+vi.mock("@/lib/registries/terminal-session-registry", () => ({
+  useTerminalSessionHandle: (args: UseTerminalSessionHandleArgs) => {
+    handleCalls.push(args);
+    return null;
+  },
+}));
+
+import { useTerminalTileBootstrap } from "../use-terminal-tile-bootstrap";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function runBootstrap() {
+  return renderHook(
+    () =>
+      useTerminalTileBootstrap({
+        hostId: "host-1",
+        sessionId: "term-1",
+        instanceId: "inst-1",
+        sessionKind: "terminal",
+        preparePayload: () =>
+          Promise.resolve({
+            tuiHarnessId: null,
+            cwd: "/work/repo",
+            shellCommand: null,
+            shellArgs: null,
+            worktreeBusyPaths: [],
+          }),
+      }),
+    { wrapper },
+  );
+}
+
+function lastHandleArgs(): UseTerminalSessionHandleArgs {
+  const last = handleCalls.at(-1);
+  if (last === undefined)
+    throw new Error("useTerminalSessionHandle not called");
+  return last;
+}
+
+describe("useTerminalTileBootstrap handle gate across list refetches", () => {
+  beforeEach(() => {
+    handleCalls = [];
+    mockCreate = {
+      isError: false,
+      isIdle: true,
+      isSuccess: false,
+      error: null,
+      reset: () => undefined,
+      mutate: vi.fn(),
+    };
+    mockList = {
+      data: {
+        sessions: [
+          { sessionId: "term-1", sessionKind: "terminal", status: "running" },
+        ],
+      },
+      isFetching: false,
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: () => Promise.resolve({}),
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps the handle enabled (live) while terminal.list is refetching", async () => {
+    const { rerender } = runBootstrap();
+    await waitFor(() => {
+      expect(lastHandleArgs().enabled).toBe(true);
+    });
+    expect(lastHandleArgs().reattachMode).toBe("live");
+
+    // Background refetch in flight: previous data is retained. The handle
+    // must stay enabled - releasing it here is the reattach-loop regression.
+    mockList.isFetching = true;
+    rerender();
+
+    expect(lastHandleArgs().enabled).toBe(true);
+    expect(lastHandleArgs().reattachMode).toBe("live");
+    // And the in-flight window must not trigger a spurious create either.
+    expect(mockCreate.mutate).not.toHaveBeenCalled();
+  });
+
+  it("releases the handle when a SETTLED list shows the session exited", async () => {
+    const { rerender } = runBootstrap();
+    await waitFor(() => {
+      expect(lastHandleArgs().enabled).toBe(true);
+    });
+
+    mockList.data = {
+      sessions: [
+        { sessionId: "term-1", sessionKind: "terminal", status: "exited" },
+      ],
+    };
+    mockList.isFetching = false;
+    rerender();
+
+    expect(lastHandleArgs().enabled).toBe(false);
+  });
+
+  it("keeps the handle disabled until the first list resolves", () => {
+    mockList.data = undefined;
+    mockList.isPending = true;
+
+    runBootstrap();
+
+    expect(lastHandleArgs().enabled).toBe(false);
+  });
+});

--- a/clients/gui-app/src/hooks/agent/use-terminal-tile-bootstrap.ts
+++ b/clients/gui-app/src/hooks/agent/use-terminal-tile-bootstrap.ts
@@ -110,15 +110,26 @@ export function useTerminalTileBootstrap(
   const list = useTerminalList(epicId, hostClient);
   const create = useTerminalCreate(hostClient);
 
+  // The last SETTLED list's verdict on the session, kept stable across
+  // background refetches (TanStack keeps previous `data` while refetching).
+  // The session HANDLE gate below derives from this, NOT from
+  // `hostHasSession`: `hostHasSession` degrades to `null` while
+  // `terminal.list` is in flight, and gating the handle on that tore down the
+  // live PTY stream on every list invalidation - a subscribe whose snapshot
+  // changed store metadata touching the list cache then re-subscribed,
+  // re-snapshotted, and invalidated again, bouncing the subscription forever
+  // and leaving reattached terminals blank.
+  const sessionListedRunning =
+    list.data !== undefined &&
+    list.data.sessions.some(
+      (s) =>
+        s.sessionId === input.sessionId &&
+        s.sessionKind === input.sessionKind &&
+        s.status === "running",
+    );
+
   const hostHasSession =
-    list.data === undefined || list.isFetching
-      ? null
-      : list.data.sessions.some(
-          (s) =>
-            s.sessionId === input.sessionId &&
-            s.sessionKind === input.sessionKind &&
-            s.status === "running",
-        );
+    list.data === undefined || list.isFetching ? null : sessionListedRunning;
 
   // The host still reports a session it has seen EXIT for ~60s (its
   // grace window) with `status: "exited"`. For a plain terminal that is
@@ -227,9 +238,13 @@ export function useTerminalTileBootstrap(
     preparePayload,
   ]);
 
-  const reattachMode: TerminalReattachMode =
-    hostHasSession === true ? "live" : "fresh";
-  const sessionReady = hostHasSession === true || create.isSuccess;
+  // Immune to background refetches by design (see `sessionListedRunning`):
+  // a live handle is only released when a SETTLED list shows the session
+  // gone or exited, never because a refetch is merely in flight.
+  const reattachMode: TerminalReattachMode = sessionListedRunning
+    ? "live"
+    : "fresh";
+  const sessionReady = sessionListedRunning || create.isSuccess;
 
   const handle = useTerminalSessionHandle({
     hostId: input.hostId,

--- a/clients/gui-app/src/lib/registries/__tests__/terminal-session-registry-metadata-cache.test.tsx
+++ b/clients/gui-app/src/lib/registries/__tests__/terminal-session-registry-metadata-cache.test.tsx
@@ -1,0 +1,218 @@
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, renderHook, waitFor, act } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { vi } from "vitest";
+import type { TerminalStreamCallbacks } from "@traycer-clients/shared/host-transport/terminal-stream-client";
+import type {
+  ListTerminalsResponse,
+  TerminalSessionInfo,
+} from "@traycer/protocol/host/terminal/unary-schemas";
+import { hostQueryKeys } from "@/lib/query-keys";
+
+// Regression coverage for the terminal reattach loop: stream-pushed metadata
+// (snapshot / `sessionUpdated` title + activeProcessName) must be written
+// into the cached `terminal.list` rows via `setQueriesData`, NEVER via
+// `invalidateQueries`. Invalidating refetched the list, the tile bootstrap's
+// fetch gate released the session handle, the re-subscribe's snapshot
+// re-set the metadata, and the cycle repeated forever - bouncing the PTY
+// stream ~3x/second and leaving reattached terminals permanently blank.
+
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => null,
+}));
+
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => null,
+}));
+
+vi.mock("@/hooks/host/use-host-stream-client-for", () => ({
+  authenticatedHostStreamKey: () => null,
+}));
+
+// The acquire effect keys on `openTransport` identity, so the mocked factory
+// must return a REFERENTIALLY STABLE function - a fresh closure per render
+// would release/reacquire the handle in an endless effect loop.
+vi.mock("@/lib/host/use-durable-stream-transport", () => {
+  const stableOpenTransport = () => {
+    throw new Error("not reachable: test factory override is installed");
+  };
+  return {
+    useDurableStreamTransportFactory: () => stableOpenTransport,
+  };
+});
+
+vi.mock("@/lib/host/owned-durable-stream-client", () => ({
+  openOwnedDurableStreamClient: () => {
+    throw new Error("not reachable: test factory override is installed");
+  },
+}));
+
+import {
+  __setTerminalStreamClientFactoryForTests,
+  disposeAllTerminalSessions,
+  useTerminalSessionHandle,
+} from "../terminal-session-registry";
+
+const HOST_ID = "host-1";
+const EPIC_ID = "epic-1";
+const SESSION_ID = "term-1";
+
+const listKey = [
+  ...hostQueryKeys.methodScope(HOST_ID, "terminal.list"),
+  { epicId: EPIC_ID },
+] as const;
+
+function sessionInfo(
+  overrides: Partial<TerminalSessionInfo>,
+): TerminalSessionInfo {
+  return {
+    sessionId: SESSION_ID,
+    epicId: EPIC_ID,
+    sessionKind: "terminal",
+    cwd: "/work/repo",
+    shellCommand: "/bin/zsh",
+    shellArgs: [],
+    cols: 80,
+    rows: 24,
+    status: "running",
+    exitCode: null,
+    exitReason: null,
+    createdAt: 1,
+    title: "Setup: repo",
+    activeProcessName: null,
+    ...overrides,
+  };
+}
+
+function setup() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const otherSession = sessionInfo({
+    sessionId: "term-other",
+    title: "other",
+  });
+  queryClient.setQueryData<ListTerminalsResponse>(listKey, {
+    sessions: [sessionInfo({}), otherSession],
+  });
+
+  let capturedCallbacks: TerminalStreamCallbacks | null = null;
+  let factoryCalls = 0;
+  __setTerminalStreamClientFactoryForTests(
+    (_sessionId, _cols, _rows, callbacks) => {
+      factoryCalls += 1;
+      capturedCallbacks = callbacks;
+      return { sendAction: () => undefined, close: () => undefined };
+    },
+  );
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+
+  const rendered = renderHook(
+    () =>
+      useTerminalSessionHandle({
+        hostId: HOST_ID,
+        epicId: EPIC_ID,
+        sessionId: SESSION_ID,
+        instanceId: "inst-1",
+        cols: 80,
+        rows: 24,
+        reattachMode: "live",
+        kind: "terminal",
+        enabled: true,
+      }),
+    { wrapper },
+  );
+
+  return {
+    queryClient,
+    otherSession,
+    rendered,
+    callbacks: () => {
+      if (capturedCallbacks === null) {
+        throw new Error("stream callbacks not captured");
+      }
+      return capturedCallbacks;
+    },
+    factoryCalls: () => factoryCalls,
+  };
+}
+
+describe("useTerminalSessionHandle metadata -> terminal.list cache", () => {
+  afterEach(() => {
+    cleanup();
+    disposeAllTerminalSessions();
+    __setTerminalStreamClientFactoryForTests(null);
+  });
+
+  it("patches the cached row from a snapshot without invalidating the query", async () => {
+    const harness = setup();
+    await waitFor(() => {
+      expect(harness.rendered.result.current).not.toBeNull();
+    });
+
+    act(() => {
+      harness.callbacks().onSnapshot(
+        {
+          kind: "snapshot",
+          hasBinaryPayload: false,
+          sessionId: SESSION_ID,
+          session: sessionInfo({ activeProcessName: "bun" }),
+          scrollback: "",
+          ackCreditSupported: true,
+        },
+        "",
+      );
+    });
+
+    const data =
+      harness.queryClient.getQueryData<ListTerminalsResponse>(listKey);
+    expect(data).toBeDefined();
+    const patched = data?.sessions.find((s) => s.sessionId === SESSION_ID);
+    expect(patched?.activeProcessName).toBe("bun");
+    expect(patched?.title).toBe("Setup: repo");
+    // The untouched sibling row must be reference-equal (no spurious churn).
+    const sibling = data?.sessions.find((s) => s.sessionId === "term-other");
+    expect(sibling).toBe(harness.otherSession);
+
+    // THE regression assertion: the query must not be invalidated - an
+    // invalidation is what fed the reattach loop.
+    expect(harness.queryClient.getQueryState(listKey)?.isInvalidated).toBe(
+      false,
+    );
+    // And this handle's own subscription was never bounced.
+    expect(harness.factoryCalls()).toBe(1);
+  });
+
+  it("patches the cached row from a sessionUpdated frame without invalidating", async () => {
+    const harness = setup();
+    await waitFor(() => {
+      expect(harness.rendered.result.current).not.toBeNull();
+    });
+
+    act(() => {
+      harness.callbacks().onSessionUpdated({
+        kind: "sessionUpdated",
+        hasBinaryPayload: false,
+        sessionId: SESSION_ID,
+        session: sessionInfo({ title: "renamed", activeProcessName: "vim" }),
+      });
+    });
+
+    const data =
+      harness.queryClient.getQueryData<ListTerminalsResponse>(listKey);
+    const patched = data?.sessions.find((s) => s.sessionId === SESSION_ID);
+    expect(patched?.title).toBe("renamed");
+    expect(patched?.activeProcessName).toBe("vim");
+    expect(harness.queryClient.getQueryState(listKey)?.isInvalidated).toBe(
+      false,
+    );
+    expect(harness.factoryCalls()).toBe(1);
+  });
+});

--- a/clients/gui-app/src/lib/registries/terminal-session-registry.ts
+++ b/clients/gui-app/src/lib/registries/terminal-session-registry.ts
@@ -14,7 +14,10 @@ import {
   type TerminalStreamClientFactory,
 } from "@/stores/terminals/terminal-session-store";
 import { TerminalSessionRegistry } from "@/stores/terminals/terminal-session-registry";
-import type { TerminalSessionKind } from "@traycer/protocol/host/terminal/unary-schemas";
+import type {
+  ListTerminalsResponse,
+  TerminalSessionKind,
+} from "@traycer/protocol/host/terminal/unary-schemas";
 
 const registry = new TerminalSessionRegistry();
 
@@ -209,9 +212,42 @@ export function useTerminalSessionHandle(
       previousTitle = state.title;
       previousActiveProcessName = state.activeProcessName;
       if (metadataChanged) {
-        void queryClient.invalidateQueries({
-          queryKey: hostQueryKeys.methodScope(args.hostId, "terminal.list"),
-        });
+        // Patch the cached `terminal.list` rows in place - NEVER invalidate
+        // here. The stream is the authoritative source for these fields
+        // (snapshot / `sessionUpdated` frames), so a refetch adds nothing,
+        // and invalidating was actively harmful: the tile bootstrap gates
+        // this handle on `terminal.list`, so invalidate -> refetch -> handle
+        // released -> re-subscribe -> snapshot re-sets metadata -> invalidate
+        // looped forever, bouncing the PTY stream and leaving reattached
+        // terminals blank. (An explicitly justified `setQueriesData`:
+        // stream-pushed state IS the response state.)
+        queryClient.setQueriesData<ListTerminalsResponse>(
+          { queryKey: hostQueryKeys.methodScope(args.hostId, "terminal.list") },
+          (data) => {
+            if (data === undefined) return undefined;
+            const target = data.sessions.find(
+              (session) => session.sessionId === args.sessionId,
+            );
+            if (
+              target === undefined ||
+              (target.title === state.title &&
+                (target.activeProcessName ?? null) === state.activeProcessName)
+            ) {
+              return data;
+            }
+            return {
+              sessions: data.sessions.map((session) =>
+                session.sessionId === args.sessionId
+                  ? {
+                      ...session,
+                      title: state.title,
+                      activeProcessName: state.activeProcessName,
+                    }
+                  : session,
+              ),
+            };
+          },
+        );
       }
       if (
         statusChanged &&
@@ -222,7 +258,7 @@ export function useTerminalSessionHandle(
         });
       }
     });
-  }, [args.hostId, handle, queryClient]);
+  }, [args.hostId, args.sessionId, handle, queryClient]);
 
   return handle;
 }


### PR DESCRIPTION
## Summary
- patch terminal.list cache rows from terminal stream metadata instead of invalidating the query
- keep terminal session handles enabled across terminal.list background refetches
- add regression coverage for metadata cache patching and refetch-stable reattachment

## Root cause
Opening an existing terminal could enter a subscribe/release loop. A terminal stream snapshot updated title/process metadata, the registry invalidated terminal.list, the bootstrap hook treated the in-flight refetch as "session unknown", and the handle was released before being reacquired and repeating the same cycle.

## Validation
- bun run test src/hooks/agent/__tests__/use-terminal-tile-bootstrap-refetch-stability.test.tsx src/lib/registries/__tests__/terminal-session-registry-metadata-cache.test.tsx
- bun run compile
- bun run lint
- npx -y react-doctor@latest . --verbose --diff origin/main --offline --no-score
- pre-commit affected workspace checks during commit
