### PR TITLE
fix(gui-app): hide quote popover behind system overlays

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-messages-transient-row.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages-transient-row.test.tsx
@@ -98,6 +98,7 @@ describe("ChatMessages transient Virtuoso rows", () => {
         nextStepActions={null}
         instanceId="test-instance"
         visible
+        systemOverlayActive={false}
         scrollRequest={null}
       />,
     );

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -55,6 +55,7 @@ import {
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import { useTileFindStore, type TileFindAdapter } from "@/stores/tile-find";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import type { BackgroundItem } from "@traycer/protocol/host/agent/gui/subscribe";
 
 import {
@@ -107,6 +108,72 @@ function minimapItemsFor(
     }));
 }
 
+function rectOf(x: number, y: number, width: number, height: number): DOMRect {
+  return {
+    x,
+    y,
+    width,
+    height,
+    top: y,
+    left: x,
+    right: x + width,
+    bottom: y + height,
+    toJSON: () => ({}),
+  };
+}
+
+function makeClientRects(rects: ReadonlyArray<DOMRect>): DOMRectList {
+  return Object.assign(rects.slice(), {
+    item: (index: number): DOMRect | null => rects[index] ?? null,
+  });
+}
+
+function mockPaintableQuoteSelection(): void {
+  const selectedLine = rectOf(50, 120, 200, 16);
+  vi.spyOn(Range.prototype, "getBoundingClientRect").mockReturnValue(
+    selectedLine,
+  );
+  vi.spyOn(Range.prototype, "getClientRects").mockReturnValue(
+    makeClientRects([selectedLine]),
+  );
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue(
+    rectOf(0, 0, 1000, 600),
+  );
+}
+
+function makeTextAssistantMessage(): ChatMessageModel {
+  const segment: ChatMessageModel["segments"][number] = {
+    id: "assistant-text-1",
+    kind: "text",
+    markdown: "Quotable assistant text.",
+    isStreaming: false,
+  };
+  return {
+    ...makeMessage(1, "assistant"),
+    segments: [segment],
+    completedAt: 2,
+  };
+}
+
+function flushFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+async function dragSelectAssistantText(): Promise<void> {
+  const paragraph = screen.getByText("Quotable assistant text.");
+  const range = document.createRange();
+  range.selectNodeContents(paragraph);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  await act(async () => {
+    paragraph.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+    await flushFrame();
+  });
+}
+
 function chatMessagesJsx(
   messages: ReadonlyArray<ChatMessageModel>,
   opts: {
@@ -114,6 +181,7 @@ function chatMessagesJsx(
     minimapItems: ReadonlyArray<ChatUserMinimapItem>;
     scrollStateKey: string;
     visible: boolean;
+    systemOverlayActive: boolean;
     scrollRequest: ChatMessageScrollRequest | null;
   },
 ): ReactNode {
@@ -130,6 +198,7 @@ function chatMessagesJsx(
         nextStepActions={null}
         instanceId={TILE_FIND_TEST_INSTANCE_ID}
         visible={opts.visible}
+        systemOverlayActive={opts.systemOverlayActive}
         scrollRequest={opts.scrollRequest}
       />
     </VirtuosoMessageListTestingContext.Provider>
@@ -143,6 +212,7 @@ function renderChatMessages(
     minimapItems: ReadonlyArray<ChatUserMinimapItem>;
     scrollStateKey: string;
     visible: boolean;
+    systemOverlayActive: boolean;
     scrollRequest: ChatMessageScrollRequest | null;
   },
 ) {
@@ -173,6 +243,7 @@ function chatMessagesWithTileFindJsx(
       {chatMessagesJsx(messages, {
         ...opts,
         backgroundItems: undefined,
+        systemOverlayActive: false,
         scrollRequest: null,
       })}
     </TileFindContext.Provider>
@@ -185,6 +256,7 @@ function makeDefaultOpts(
     minimapItems: ReadonlyArray<ChatUserMinimapItem>;
     scrollStateKey: string;
     visible: boolean;
+    systemOverlayActive: boolean;
     scrollRequest: ChatMessageScrollRequest | null;
   }>,
 ) {
@@ -195,6 +267,7 @@ function makeDefaultOpts(
       overrides.scrollStateKey ??
       `chat-scroll-test-key-${scrollStateKeySequence++}`,
     visible: overrides.visible ?? true,
+    systemOverlayActive: overrides.systemOverlayActive ?? false,
     scrollRequest: overrides.scrollRequest ?? null,
   };
 }
@@ -207,6 +280,7 @@ function rerenderChatMessages(
     minimapItems: ReadonlyArray<ChatUserMinimapItem>;
     scrollStateKey: string;
     visible: boolean;
+    systemOverlayActive: boolean;
     scrollRequest: ChatMessageScrollRequest | null;
   },
 ): void {
@@ -228,6 +302,8 @@ function rerenderChatMessagesWithTileFind(
 describe("ChatMessages Virtuoso renderer", () => {
   afterEach(() => {
     useTileFindStore.getState().resetForTests();
+    useSettingsStore.getState().setQuoteReplyEnabled(true);
+    window.getSelection()?.removeAllRanges();
     restoreHighlights?.();
     restoreHighlights = null;
     vi.restoreAllMocks();
@@ -250,6 +326,30 @@ describe("ChatMessages Virtuoso renderer", () => {
 
     expect(container.querySelector(".bg-linear-to-b")).toBeNull();
     expect(container.querySelector(".bg-linear-to-t")).not.toBeNull();
+  });
+
+  it("keeps the quote popover hidden while the Settings overlay is active across quote setting toggles", async () => {
+    mockPaintableQuoteSelection();
+    const message = makeTextAssistantMessage();
+    const opts = makeDefaultOpts({ minimapItems: [] });
+    const { rerender } = renderChatMessages([message], opts);
+
+    await dragSelectAssistantText();
+    expect(screen.queryByRole("button", { name: "Quote" })).not.toBeNull();
+
+    const overlayOpts = { ...opts, systemOverlayActive: true };
+    rerenderChatMessages(rerender, [message], overlayOpts);
+    expect(screen.queryByRole("button", { name: "Quote" })).toBeNull();
+
+    act(() => {
+      useSettingsStore.getState().setQuoteReplyEnabled(false);
+    });
+    expect(screen.queryByRole("button", { name: "Quote" })).toBeNull();
+
+    act(() => {
+      useSettingsStore.getState().setQuoteReplyEnabled(true);
+    });
+    expect(screen.queryByRole("button", { name: "Quote" })).toBeNull();
   });
 
   it("hides completed steer labels on user bubbles", async () => {

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -89,6 +89,8 @@ interface ChatMessagesProps {
   instanceId: string;
   /** paneVisible ∧ tab selected: drives the hide/re-show scroll restore. */
   visible: boolean;
+  /** A frontmost system modal overlays the chat; body-portaled quote UI must stay hidden. */
+  systemOverlayActive: boolean;
   scrollRequest: ChatMessageScrollRequest | null;
 }
 
@@ -249,6 +251,7 @@ function ChatMessagesInner(props: ChatMessagesProps) {
     nextStepActions,
     scrollRequest,
     scrollStateKey,
+    systemOverlayActive,
     taskId,
     taskTitle,
     visible,
@@ -321,14 +324,15 @@ function ChatMessagesInner(props: ChatMessagesProps) {
   // too: chat surfaces are keep-alive hidden (display:none) while the popover
   // portals to document.body, so a hidden chat must not keep tracking
   // selections or leave a quote button floating over whichever surface
-  // replaced it.
+  // replaced it. System overlays gate the same body portal path while Settings
+  // or History is frontmost over an otherwise-visible chat.
   const quoteReplyEnabled = useSettingsStore(
     (state) => state.quoteReplyEnabled,
   );
   const transcriptContainerRef = useRef<HTMLDivElement>(null);
   const quoteSelection = useQuoteSelection({
     containerRef: transcriptContainerRef,
-    enabled: quoteReplyEnabled && visible,
+    enabled: quoteReplyEnabled && visible && !systemOverlayActive,
   });
 
   const [listDataState, setListDataState] = useState<ChatListDataState>(() =>

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -132,6 +132,7 @@ import {
   type ComposerRunSettingsEntry,
 } from "@/stores/composer/composer-run-settings-store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
+import { useAnySystemOverlayActive } from "@/stores/tabs/use-system-tab-modal";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import {
   makeSnapshotCumulativeBundleDiffTile,
@@ -483,6 +484,7 @@ function messageIdForBlock(
 function ChatTileSessionView(props: ChatTileSessionViewProps) {
   const view = useChatTileSessionViewModel(props);
   const hostId = useTabHostId();
+  const systemOverlayActive = useAnySystemOverlayActive();
   const openPreview = useEpicCanvasStore((s) => s.openTilePreviewInTab);
   const openPinned = useEpicCanvasStore((s) => s.openTileInTab);
   const [backgroundScrollRequest, setBackgroundScrollRequest] =
@@ -599,6 +601,7 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
             minimapItems={view.minimapItems}
             scrollRequest={backgroundScrollRequest}
             surfaceVisible={view.surfaceVisible}
+            systemOverlayActive={systemOverlayActive}
             getMessageActions={view.getMessageActions}
             nextStepActions={view.nextStepActions}
             planActions={view.planActions}
@@ -1559,6 +1562,7 @@ interface ChatSessionMessagesSurfaceProps {
   readonly minimapItems: ReadonlyArray<ChatUserMinimapItem>;
   readonly scrollRequest: ChatMessageScrollRequest | null;
   readonly surfaceVisible: boolean;
+  readonly systemOverlayActive: boolean;
   readonly getMessageActions: (
     message: ChatMessageModel,
   ) => ChatMessageActions | null;
@@ -1642,6 +1646,7 @@ function ChatSessionMessagesSurface(
               nextStepActions={props.nextStepActions}
               instanceId={props.node.instanceId}
               visible={props.surfaceVisible}
+              systemOverlayActive={props.systemOverlayActive}
             />
           </ChatMarkdownLinkProvider>
         </WorkingVerbContext.Provider>


### PR DESCRIPTION
## Summary
- gate the quote selection popover while any system modal overlay is active
- pass system overlay state from chat tiles into ChatMessages
- add a regression test for Settings overlay + quote toggle behavior

## Tests
- pre-commit run --all-files
- bun run test src/components/chat/__tests__/chat-messages.test.tsx
- bun run test src/components/chat/__tests__/chat-messages-transient-row.test.tsx
- bun run compile
- bun x -y react-doctor@latest . --verbose --scope changed --base origin/main --offline --no-score