### PR TITLE
Fix usage limit state and refresh handling

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
@@ -62,7 +62,7 @@ describe("<RateLimitIconButton />", () => {
         providerId: "codex",
         windowLabel: "5h",
         usedPercent: 70,
-        severity: "yellow",
+        severity: "blue",
         degraded: false,
       },
       {
@@ -79,7 +79,7 @@ describe("<RateLimitIconButton />", () => {
     expect(hasClass(button, "opacity-[0.55]")).toBe(false);
     const fills = within(button).getAllByTestId("rate-limit-bar-fill");
     expect(fills).toHaveLength(2);
-    expect(fills[0].className).toContain("yellow-500");
+    expect(fills[0].className).toContain("blue-500");
     expect(fills[0].style.width).toBe("70%");
     expect(fills[1].className).toContain("blue-500");
     expect(fills[1].style.width).toBe("40%");
@@ -120,7 +120,7 @@ describe("<RateLimitIconButton />", () => {
         providerId: "claude-code",
         windowLabel: "5h",
         usedPercent: 65,
-        severity: "yellow",
+        severity: "blue",
         degraded: true,
       },
       {

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -154,6 +154,7 @@ vi.mock("@/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn", () => ({
 }));
 
 import { RateLimitPopover } from "@/components/layout/header/rate-limit-popover";
+import { useRateLimitPopoverStore } from "@/stores/rate-limits/rate-limit-popover-store";
 
 const NOW = Date.now();
 
@@ -207,7 +208,7 @@ function degradedRetainedResult(
     isPending: false,
     isFetching: false,
     isError: false,
-    dataUpdatedAt: NOW - 90_000,
+    dataUpdatedAt: NOW - 1_000,
     refetch: vi.fn(() => Promise.resolve({})),
   };
 }
@@ -385,6 +386,8 @@ beforeEach(() => {
   mocks.lastUseHostQueriesProviderIds = null;
   mocks.authUser = coldAuthUser();
   useAccountContextStore.setState({ accountContext: { type: "PERSONAL" } });
+  useRateLimitPopoverStore.setState({ activeTab: "overview" });
+  useRateLimitPopoverStore.persist.clearStorage();
   onClose = vi.fn();
 });
 
@@ -490,6 +493,41 @@ describe("<RateLimitPopover /> rail", () => {
     expect(screen.getByText("Codex")).toBeTruthy();
     // ...but the single-provider detail tab surfaces it.
     expect(screen.getByText("Pro 5x")).toBeTruthy();
+  });
+
+  it("reopens on the last selected provider tab", () => {
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+    const first = renderPopover();
+    expect(screen.queryByText("Pro 5x")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    expect(screen.getByText("Pro 5x")).toBeTruthy();
+
+    first.unmount();
+    renderPopover();
+    expect(
+      screen.getByRole("tab", { name: "Codex" }).getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(screen.getByText("Pro 5x")).toBeTruthy();
+  });
+
+  it("falls back to Overview when the remembered provider is not available", () => {
+    useRateLimitPopoverStore.setState({ activeTab: "claude-code" });
+    mocks.configured = [{ providerId: "codex", lane: "ephemeralProcess" }];
+    mocks.results = { codex: readyResult(codexReady()) };
+
+    renderPopover();
+
+    expect(
+      screen
+        .getByRole("tab", { name: "Overview" })
+        .getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("tab", { name: "Codex" }).getAttribute("aria-selected"),
+    ).toBe("false");
+    expect(screen.queryByText("Pro 5x")).toBeNull();
   });
 
   it("shows a relative countdown for a short window and an absolute date for a weekly one", () => {
@@ -664,6 +702,8 @@ describe("<RateLimitPopover /> per-provider states", () => {
     expect(
       screen.getByText(/· couldn't fetch usage — will retry/),
     ).toBeTruthy();
+    expect(screen.getByText(/^Updated \d+m ago ·/)).toBeTruthy();
+    expect(screen.queryByText(/^Updated Just now ·/)).toBeNull();
     expect(screen.queryByText(/· refresh failed/)).toBeNull();
     // The retained reading itself is still rendered (dimmed), not replaced by
     // an error message.

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -74,15 +74,11 @@ import {
   TraycerAccountSelect,
   TraycerSubscriptionView,
 } from "@/components/settings/panels/traycer-subscription-views";
+import {
+  useRateLimitPopoverStore,
+  type RateLimitPopoverTab,
+} from "@/stores/rate-limits/rate-limit-popover-store";
 import { cn } from "@/lib/utils";
-
-/**
- * The Overview tab (always pinned first), one tab per connected host-RPC
- * provider, and - when the account is eligible - the GUI-sourced "traycer" tab.
- * `"traycer"` is a synthetic entry: it is NOT a `RateLimitProviderId` and does
- * not flow through `useConfiguredRateLimitProviders()`.
- */
-type RateLimitTab = "overview" | RateLimitProviderId | "traycer";
 
 /**
  * A rail/Overview entry, in draw order: either a host-RPC provider or the
@@ -146,9 +142,8 @@ function orderRailTabs(
  * connected provider) and a detail pane, mirroring the composer's model-picker
  * shell (Core Flows: "same interaction family as the composer's model picker").
  * The whole body is a child of `PopoverContent`, so Radix only mounts it - and
- * runs its queries and tab state - while the popover is open; `activeTab`
- * therefore resets to Overview on every open (Core Flows: "Landing tab is
- * always Overview").
+ * runs its queries - while the popover is open. The selected tab is persisted
+ * separately so reopening restores the provider the user last inspected.
  */
 export function RateLimitPopover({
   onClose,
@@ -200,7 +195,8 @@ function RateLimitPopoverBody({
     () => orderRailTabs(providers, traycerSubscription.eligible),
     [providers, traycerSubscription.eligible],
   );
-  const [activeTab, setActiveTab] = useState<RateLimitTab>("overview");
+  const activeTab = useRateLimitPopoverStore((state) => state.activeTab);
+  const setActiveTab = useRateLimitPopoverStore((state) => state.setActiveTab);
 
   // Zero-state only when there is genuinely nothing to show: no host-RPC
   // providers AND no eligible Traycer tab.
@@ -211,13 +207,13 @@ function RateLimitPopoverBody({
   // A credential removed (or Traycer becoming ineligible) mid-session can drop
   // the active tab from the rail; fall back to Overview rather than rendering a
   // tab that no longer exists.
-  const validTabs = new Set<RateLimitTab>([
+  const validTabs = new Set<RateLimitPopoverTab>([
     "overview",
     ...railTabs.map((tab) =>
       tab.kind === "traycer" ? "traycer" : tab.providerId,
     ),
   ]);
-  const resolvedTab: RateLimitTab = validTabs.has(activeTab)
+  const resolvedTab: RateLimitPopoverTab = validTabs.has(activeTab)
     ? activeTab
     : "overview";
 
@@ -263,7 +259,7 @@ function RateLimitPopoverBody({
 function RateLimitDetailPane({
   tab,
 }: {
-  readonly tab: Exclude<RateLimitTab, "overview">;
+  readonly tab: Exclude<RateLimitPopoverTab, "overview">;
 }): ReactNode {
   return tab === "traycer" ? (
     <TraycerRateLimitBlock variant="popover-detail" onReady={null} />
@@ -296,8 +292,8 @@ function RateLimitRail({
   readonly railTabs: ReadonlyArray<RailTabDescriptor>;
   readonly providers: ReadonlyArray<ConfiguredRateLimitProvider>;
   readonly traycerRefreshTarget: TraycerRefreshTarget;
-  readonly activeTab: RateLimitTab;
-  readonly onSelect: (tab: RateLimitTab) => void;
+  readonly activeTab: RateLimitPopoverTab;
+  readonly onSelect: (tab: RateLimitPopoverTab) => void;
   readonly onClose: () => void;
 }): ReactNode {
   const { openSettings } = useSystemTabModalActions();
@@ -672,6 +668,10 @@ function RateLimitProviderBlock({
     envelope: query.data,
   };
   const state = resolvePopoverProviderRateLimitState(queryState);
+  const updatedAt =
+    state.kind === "ready"
+      ? (query.data?.lastGoodAt ?? query.dataUpdatedAt)
+      : query.dataUpdatedAt;
   useEffect(() => {
     if (state.kind !== "cold" && onReady !== null) onReady();
   }, [state.kind, onReady]);
@@ -708,7 +708,7 @@ function RateLimitProviderBlock({
         <div className="flex items-center gap-1.5">
           <UsageLimitUpdatedLabel
             ready={state.kind === "ready"}
-            updatedAt={query.dataUpdatedAt}
+            updatedAt={updatedAt}
             refreshing={isRefreshing}
             degraded={state.kind === "ready" && state.degraded}
             degradedReason={

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-section.test.tsx
@@ -188,9 +188,7 @@ describe("ProviderRateLimitForProvider", () => {
     expect(screen.getByText(/^Resets in /)).toBeTruthy();
   });
 
-  it("colors a window's bar yellow at/above 60% used and red above 85% used", () => {
-    // The Settings card now shares the same four-tier severity scale as the
-    // popover (item 6 feedback: "different UX looks weird").
+  it("keeps usage blue through 85% and red above 85% used", () => {
     mocks.data = envelope({
       ...CLAUDE_RATE_LIMITS,
       fiveHour: {
@@ -208,13 +206,14 @@ describe("ProviderRateLimitForProvider", () => {
       <ProviderRateLimitForProvider providerId="claude-code" />,
     );
 
-    expect(container.querySelectorAll(".bg-yellow-500").length).toBeGreaterThan(
+    expect(container.querySelectorAll(".bg-yellow-500").length).toBe(0);
+    expect(container.querySelectorAll(".bg-blue-500").length).toBeGreaterThan(
       0,
     );
     expect(container.querySelectorAll(".bg-red-500").length).toBeGreaterThan(0);
   });
 
-  it("keeps the bar blue below the yellow threshold", () => {
+  it("keeps the bar blue below the red threshold", () => {
     mocks.data = envelope(CLAUDE_RATE_LIMITS);
     const { container } = render(
       <ProviderRateLimitForProvider providerId="claude-code" />,

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -117,11 +117,11 @@ describe("CodexRateLimitView (extended fields)", () => {
     expect(screen.getByText("68% used")).toBeTruthy();
   });
 
-  it("renders the popover variant as '% used' with a four-tier bar color", () => {
+  it("renders the popover variant as '% used' with the shared blue/red bar color", () => {
     const { container } = render(
       <CodexRateLimitView data={codex} variant="popover-detail" />,
     );
-    // primary 4% used -> blue tier; secondary 68% used -> yellow tier.
+    // primary 4% used and secondary 68% used both stay blue.
     expect(screen.getByText("Current session")).toBeTruthy();
     expect(screen.getByText("4% used")).toBeTruthy();
     expect(screen.getByText("Weekly")).toBeTruthy();
@@ -129,9 +129,7 @@ describe("CodexRateLimitView (extended fields)", () => {
     expect(container.querySelectorAll(".bg-blue-500").length).toBeGreaterThan(
       0,
     );
-    expect(container.querySelectorAll(".bg-yellow-500").length).toBeGreaterThan(
-      0,
-    );
+    expect(container.querySelectorAll(".bg-yellow-500").length).toBe(0);
   });
 
   it("draws every popover window track with a foreground-opacity fill so an empty bar stays visible", () => {
@@ -160,6 +158,13 @@ describe("CodexRateLimitView (extended fields)", () => {
     expect(screen.getByText("0% used")).toBeTruthy();
     const tracks = container.querySelectorAll(".bg-foreground\\/15");
     expect(tracks.length).toBeGreaterThan(0);
+    expect(container.querySelectorAll(".bg-green-500").length).toBe(0);
+    const fill = container.querySelector(".bg-blue-500");
+    expect(fill).toBeInstanceOf(HTMLElement);
+    if (!(fill instanceof HTMLElement)) {
+      throw new Error("Expected a blue rate-limit fill");
+    }
+    expect(fill.style.width).toBe("0%");
   });
 
   it("shows a relative countdown for a short popover window", () => {

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
@@ -216,7 +216,7 @@ function CreditBreakdownView({
  * through: a header line (`label` left, a `detail` slot right - a reset line
  * plus percent for windows, a plain amount line for credit/uncapped-usage
  * buckets), then a bar spanning the row's *full* width on its own line below,
- * colored by the shared 4-tier severity scale (`window-severity.ts`).
+ * colored by the shared severity scale (`window-severity.ts`).
  *
  * The bar is deliberately on its own line rather than beside the text (as it
  * used to be): sitting the label and bar on the same line made the bar's

--- a/clients/gui-app/src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
+++ b/clients/gui-app/src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
@@ -217,7 +217,7 @@ describe("useHeaderRateLimitBars", () => {
         providerId: "claude-code",
         windowLabel: "5h",
         usedPercent: 70,
-        severity: "yellow",
+        severity: "blue",
         degraded: false,
       },
     ]);
@@ -269,7 +269,7 @@ describe("useHeaderRateLimitBars", () => {
         providerId: "claude-code",
         windowLabel: "Weekly",
         usedPercent: 64,
-        severity: "yellow",
+        severity: "blue",
         degraded: false,
       },
     ]);
@@ -340,7 +340,7 @@ describe("useHeaderRateLimitBars", () => {
         providerId: "codex",
         windowLabel: "5h",
         usedPercent: 65,
-        severity: "yellow",
+        severity: "blue",
         degraded: true,
       },
       {
@@ -380,7 +380,7 @@ describe("useHeaderRateLimitBars", () => {
         providerId: "codex",
         windowLabel: "5h",
         usedPercent: 65,
-        severity: "yellow",
+        severity: "blue",
         degraded: true,
       },
       {

--- a/clients/gui-app/src/lib/__tests__/relative-time.test.ts
+++ b/clients/gui-app/src/lib/__tests__/relative-time.test.ts
@@ -64,10 +64,11 @@ describe("formatRelativeTimestamp", () => {
 describe("formatResetCountdown", () => {
   const now = Date.parse("2026-04-23T12:00:00.000Z");
 
-  it("renders '0s' for deltas under one minute", () => {
+  it("renders seconds for deltas under one minute", () => {
     expect(formatResetCountdown(now, now)).toBe("0s");
-    expect(formatResetCountdown(now + 5_000, now)).toBe("0s");
-    expect(formatResetCountdown(now + (MINUTE_MS - 1), now)).toBe("0s");
+    expect(formatResetCountdown(now + 999, now)).toBe("1s");
+    expect(formatResetCountdown(now + 5_000, now)).toBe("5s");
+    expect(formatResetCountdown(now + (MINUTE_MS - 1), now)).toBe("59s");
   });
 
   it("renders minute buckets once a full minute away", () => {

--- a/clients/gui-app/src/lib/__tests__/relative-time.test.ts
+++ b/clients/gui-app/src/lib/__tests__/relative-time.test.ts
@@ -64,10 +64,10 @@ describe("formatRelativeTimestamp", () => {
 describe("formatResetCountdown", () => {
   const now = Date.parse("2026-04-23T12:00:00.000Z");
 
-  it("renders 'now' for deltas under one minute (regression: was unreachable under Math.ceil)", () => {
-    expect(formatResetCountdown(now, now)).toBe("now");
-    expect(formatResetCountdown(now + 5_000, now)).toBe("now");
-    expect(formatResetCountdown(now + (MINUTE_MS - 1), now)).toBe("now");
+  it("renders '0s' for deltas under one minute", () => {
+    expect(formatResetCountdown(now, now)).toBe("0s");
+    expect(formatResetCountdown(now + 5_000, now)).toBe("0s");
+    expect(formatResetCountdown(now + (MINUTE_MS - 1), now)).toBe("0s");
   });
 
   it("renders minute buckets once a full minute away", () => {
@@ -89,8 +89,8 @@ describe("formatResetCountdown", () => {
     expect(formatResetCountdown(now + 4 * DAY_MS, now)).toBe("4d");
   });
 
-  it("clamps a past resetsAt to 'now' rather than a negative duration", () => {
-    expect(formatResetCountdown(now - 10_000, now)).toBe("now");
+  it("clamps a past resetsAt to '0s' rather than a negative duration", () => {
+    expect(formatResetCountdown(now - 10_000, now)).toBe("0s");
   });
 });
 

--- a/clients/gui-app/src/lib/persist/__tests__/keys.test.ts
+++ b/clients/gui-app/src/lib/persist/__tests__/keys.test.ts
@@ -19,6 +19,8 @@ import {
 
 describe("persist key builders — output-preserving against current source", () => {
   it("emits the current localStorage key for each of the 18 static stores", () => {
+    // Source: src/stores/onboarding/onboarding-store.ts
+    expect(persistKey("onboarding")).toBe("traycer-gui-app:onboarding");
     // Source: src/stores/command-palette/command-palette-store.ts
     expect(persistKey("command-palette")).toBe(
       "traycer-gui-app:command-palette",

--- a/clients/gui-app/src/lib/persist/__tests__/keys.test.ts
+++ b/clients/gui-app/src/lib/persist/__tests__/keys.test.ts
@@ -18,7 +18,7 @@ import {
 // would make the test circular and unable to catch a divergence.
 
 describe("persist key builders — output-preserving against current source", () => {
-  it("emits the current localStorage key for each of the 16 static stores", () => {
+  it("emits the current localStorage key for each of the 18 static stores", () => {
     // Source: src/stores/command-palette/command-palette-store.ts
     expect(persistKey("command-palette")).toBe(
       "traycer-gui-app:command-palette",
@@ -61,6 +61,10 @@ describe("persist key builders — output-preserving against current source", ()
     // Source: src/stores/tabs/settings-section-store.ts (NOT a divergence)
     expect(persistKey("settings-section")).toBe(
       "traycer-gui-app:settings-section",
+    );
+    // Source: src/stores/rate-limits/rate-limit-popover-store.ts
+    expect(persistKey("rate-limit-popover")).toBe(
+      "traycer-gui-app:rate-limit-popover",
     );
     // Source: src/stores/tabs/store.ts
     expect(persistKey("tabs")).toBe("traycer-gui-app:tabs");

--- a/clients/gui-app/src/lib/persist/__tests__/store-persist-names.test.ts
+++ b/clients/gui-app/src/lib/persist/__tests__/store-persist-names.test.ts
@@ -12,6 +12,7 @@ import { useLeftPanelStore } from "@/stores/epics/left-panel-store";
 import { useFileTreeStore } from "@/stores/file-tree/file-tree-store";
 import { useHistorySearchStore } from "@/stores/home/history-search-store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useRateLimitPopoverStore } from "@/stores/rate-limits/rate-limit-popover-store";
 import { useHostUpdateBannerStore } from "@/stores/settings/host-update-banner-store";
 import { useKeybindingStore } from "@/stores/settings/keybinding-store";
 import { useLocalSnapshotClearStore } from "@/stores/settings/local-snapshot-clear-store";
@@ -46,7 +47,7 @@ interface StorePersistHandle {
 const STORE_PERSIST_NAME_CASES: ReadonlyArray<
   [label: string, store: StorePersistHandle, expectedName: string]
 > = [
-  // ── 16 static singletons ─────────────────────────────────────────────────
+  // ── 17 static singletons ─────────────────────────────────────────────────
   [
     "useCommandPaletteStore",
     useCommandPaletteStore,
@@ -92,6 +93,11 @@ const STORE_PERSIST_NAME_CASES: ReadonlyArray<
     "useSettingsSectionStore",
     useSettingsSectionStore,
     "traycer-gui-app:settings-section",
+  ],
+  [
+    "useRateLimitPopoverStore",
+    useRateLimitPopoverStore,
+    "traycer-gui-app:rate-limit-popover",
   ],
   ["useTabsStore", useTabsStore, "traycer-gui-app:tabs"],
   [

--- a/clients/gui-app/src/lib/persist/keys.ts
+++ b/clients/gui-app/src/lib/persist/keys.ts
@@ -95,7 +95,7 @@ export const PERSIST_STORES = [
   { camelName: "epicCanvas", leaf: "epic-canvas", kind: "scoped" },
   { camelName: "openEpic", leaf: "open-epic", kind: "scoped" },
 
-  // ── Static zustand stores (17) ───────────────────────────────────────────
+  // ── Static zustand stores (18) ───────────────────────────────────────────
   { camelName: "onboarding", leaf: "onboarding", kind: "static" },
   { camelName: "commandPalette", leaf: "command-palette", kind: "static" },
   { camelName: "composerDraft", leaf: "composer-drafts", kind: "static" },
@@ -127,6 +127,11 @@ export const PERSIST_STORES = [
   },
   { camelName: "settings", leaf: "settings", kind: "static" },
   { camelName: "settingsSection", leaf: "settings-section", kind: "static" },
+  {
+    camelName: "rateLimitPopover",
+    leaf: "rate-limit-popover",
+    kind: "static",
+  },
   { camelName: "tabs", leaf: "tabs", kind: "static" },
   {
     camelName: "workspaceFolders",

--- a/clients/gui-app/src/lib/rate-limits/__tests__/window-severity.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/window-severity.test.ts
@@ -6,21 +6,11 @@ import {
 } from "@/lib/rate-limits/window-severity";
 
 describe("rateLimitWindowSeverity", () => {
-  it("returns green at 0% used (100% available)", () => {
-    expect(rateLimitWindowSeverity(0)).toBe("green");
-    // A clock-skewed negative reading still reads as fully available.
-    expect(rateLimitWindowSeverity(-5)).toBe("green");
-  });
-
-  it("returns blue above 0% and under 60% used", () => {
-    expect(rateLimitWindowSeverity(0.1)).toBe("blue");
-    expect(rateLimitWindowSeverity(59.9)).toBe("blue");
-  });
-
-  it("returns yellow for 60-85% used, inclusive of both bounds", () => {
-    expect(rateLimitWindowSeverity(60)).toBe("yellow");
-    expect(rateLimitWindowSeverity(70)).toBe("yellow");
-    expect(rateLimitWindowSeverity(85)).toBe("yellow");
+  it("returns blue at and below 85% used", () => {
+    expect(rateLimitWindowSeverity(-5)).toBe("blue");
+    expect(rateLimitWindowSeverity(0)).toBe("blue");
+    expect(rateLimitWindowSeverity(60)).toBe("blue");
+    expect(rateLimitWindowSeverity(85)).toBe("blue");
   });
 
   it("returns red over 85% used", () => {
@@ -31,22 +21,15 @@ describe("rateLimitWindowSeverity", () => {
 
 describe("rateLimitWindowSeverityBarClassName", () => {
   it("maps each severity to a distinct fill color", () => {
-    expect(rateLimitWindowSeverityBarClassName("green")).toContain("green-500");
     expect(rateLimitWindowSeverityBarClassName("blue")).toContain("blue-500");
-    expect(rateLimitWindowSeverityBarClassName("yellow")).toContain(
-      "yellow-500",
-    );
     expect(rateLimitWindowSeverityBarClassName("red")).toContain("red-500");
   });
 });
 
 describe("rateLimitWindowFillPercent", () => {
-  it("fills the whole track at 0% used (or below) for the full green bar", () => {
-    expect(rateLimitWindowFillPercent(0)).toBe(100);
-    expect(rateLimitWindowFillPercent(-3)).toBe(100);
-  });
-
-  it("tracks the real used percentage otherwise, clamped to [0, 100]", () => {
+  it("tracks the real used percentage, clamped to [0, 100]", () => {
+    expect(rateLimitWindowFillPercent(-3)).toBe(0);
+    expect(rateLimitWindowFillPercent(0)).toBe(0);
     expect(rateLimitWindowFillPercent(40)).toBe(40);
     expect(rateLimitWindowFillPercent(85)).toBe(85);
     expect(rateLimitWindowFillPercent(150)).toBe(100);

--- a/clients/gui-app/src/lib/rate-limits/window-severity.ts
+++ b/clients/gui-app/src/lib/rate-limits/window-severity.ts
@@ -1,24 +1,14 @@
 /**
- * Fixed severity scale for a single rate-limit window's used percentage -
- * shared by the header glyph (Rate Limit Bar Icon - Core Flows, "Icon
- * composition") and every bar `MeterRow` renders ("Provider detail view"
- * explicitly reuses these same thresholds) - the single scale every
- * provider's capped and uncapped bars share, so no row anywhere uses a
- * different palette or thresholds.
- *
- * `"green"` is a distinct fourth tier for a window at 0% used (100% available):
- * it renders as a fully-filled green bar (see `rateLimitWindowFillPercent`) so
- * "nothing used yet" reads unambiguously as healthy, rather than as an empty
- * blue-tier bar.
+ * Fixed severity scale for a single rate-limit window's used percentage,
+ * shared by the header glyph and every `MeterRow` bar. Usage stays blue
+ * through 85%, then turns red; 0% used renders as an empty blue bar.
  */
-export type RateLimitWindowSeverity = "green" | "blue" | "yellow" | "red";
+export type RateLimitWindowSeverity = "blue" | "red";
 
 export function rateLimitWindowSeverity(
   usedPercent: number,
 ): RateLimitWindowSeverity {
-  if (usedPercent <= 0) return "green";
   if (usedPercent > 85) return "red";
-  if (usedPercent >= 60) return "yellow";
   return "blue";
 }
 
@@ -29,24 +19,15 @@ export function rateLimitWindowSeverityBarClassName(
   switch (severity) {
     case "red":
       return "bg-red-500 dark:bg-red-400";
-    case "yellow":
-      return "bg-yellow-500 dark:bg-yellow-400";
     case "blue":
       return "bg-blue-500 dark:bg-blue-400";
-    case "green":
-      return "bg-green-500 dark:bg-green-400";
   }
 }
 
 /**
- * The width (0-100) a severity-colored window bar should fill. A window at 0%
- * used (100% available) fills the whole track - paired with the `"green"`
- * severity - so it reads as a full green bar rather than an empty one;
- * otherwise the bar tracks the real used percentage, clamped to [0, 100]. This
- * is the *fill* only: callers still derive any "% left/used" text from the real
- * `usedPercent`, not from this forced-full value.
+ * The width (0-100) a severity-colored window bar should fill. This tracks the
+ * real used percentage, clamped to [0, 100].
  */
 export function rateLimitWindowFillPercent(usedPercent: number): number {
-  if (usedPercent <= 0) return 100;
   return Math.min(100, Math.max(0, usedPercent));
 }

--- a/clients/gui-app/src/lib/relative-time.ts
+++ b/clients/gui-app/src/lib/relative-time.ts
@@ -1,5 +1,6 @@
 import { useSyncExternalStore } from "react";
 
+const SECOND_MS = 1_000;
 const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
@@ -94,14 +95,18 @@ export function useRelativeTimestamp(createdAt: number): string {
  * Pure future-facing countdown formatter, the mirror of
  * `formatRelativeTimestamp` for a reset time instead of a creation time.
  *
- * Buckets: "0s" (<1m away) / `${n}m` / `${h}h ${m}m` (m omitted when 0) /
+ * Buckets: `${n}s` (<1m away) / `${n}m` / `${h}h ${m}m` (m omitted when 0) /
  * `${d}d`. A past `resetsAt` (clock skew, or the window rolled over between
  * fetch and render) clamps to "0s" rather than a negative duration.
  */
 export function formatResetCountdown(resetsAt: number, now: number): string {
   const diffMs = Math.max(0, resetsAt - now);
   const minutes = Math.floor(diffMs / MINUTE_MS);
-  if (minutes < 1) return "0s";
+  if (minutes < 1) {
+    if (diffMs === 0) return "0s";
+    const seconds = Math.max(1, Math.floor(diffMs / SECOND_MS));
+    return `${seconds}s`;
+  }
   if (minutes < 60) return `${minutes}m`;
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;

--- a/clients/gui-app/src/lib/relative-time.ts
+++ b/clients/gui-app/src/lib/relative-time.ts
@@ -94,14 +94,14 @@ export function useRelativeTimestamp(createdAt: number): string {
  * Pure future-facing countdown formatter, the mirror of
  * `formatRelativeTimestamp` for a reset time instead of a creation time.
  *
- * Buckets: "now" (<1m away) / `${n}m` / `${h}h ${m}m` (m omitted when 0) /
+ * Buckets: "0s" (<1m away) / `${n}m` / `${h}h ${m}m` (m omitted when 0) /
  * `${d}d`. A past `resetsAt` (clock skew, or the window rolled over between
- * fetch and render) clamps to "now" rather than a negative duration.
+ * fetch and render) clamps to "0s" rather than a negative duration.
  */
 export function formatResetCountdown(resetsAt: number, now: number): string {
   const diffMs = Math.max(0, resetsAt - now);
   const minutes = Math.floor(diffMs / MINUTE_MS);
-  if (minutes < 1) return "now";
+  if (minutes < 1) return "0s";
   if (minutes < 60) return `${minutes}m`;
   const hours = Math.floor(minutes / 60);
   const remainingMinutes = minutes % 60;

--- a/clients/gui-app/src/providers/host-runtime-provider.tsx
+++ b/clients/gui-app/src/providers/host-runtime-provider.tsx
@@ -206,9 +206,14 @@ export function createHostRuntime<
       // failure (`RetryableTransportError`) re-dials on a short backoff before
       // the auth-aware wrapper or the query layer ever see it. The auth wrapper
       // only acts on `UNAUTHORIZED`, never a retryable transport error, so the
-      // two never contend.
+      // two never contend. When auth revalidation really rotates the bearer,
+      // retry the same RPC once against the fresh lease; some usage-limit
+      // queries intentionally disable TanStack retry, so the refresh loop must
+      // complete in the transport layer.
       const messenger: IHostMessenger<Registry> = createRetryingMessenger(
-        createAuthAwareMessenger(rawMessenger, auth, null),
+        createAuthAwareMessenger(rawMessenger, auth, {
+          retry: { bearer },
+        }),
         DEFAULT_TRANSPORT_RETRY_POLICY,
       );
 

--- a/clients/gui-app/src/stores/rate-limits/__tests__/rate-limit-popover-store.test.ts
+++ b/clients/gui-app/src/stores/rate-limits/__tests__/rate-limit-popover-store.test.ts
@@ -1,0 +1,60 @@
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { CURRENT_PERSIST_VERSION, STORE_KEYS, persistKey } from "@/lib/persist";
+import { useRateLimitPopoverStore } from "@/stores/rate-limits/rate-limit-popover-store";
+
+const PERSIST_KEY = persistKey(STORE_KEYS.rateLimitPopover);
+
+function resetStore(): void {
+  window.localStorage.clear();
+  useRateLimitPopoverStore.setState({ activeTab: "overview" });
+}
+
+describe("useRateLimitPopoverStore", () => {
+  beforeEach(resetStore);
+  afterEach(resetStore);
+
+  it("initializes on Overview", () => {
+    expect(useRateLimitPopoverStore.getState().activeTab).toBe("overview");
+  });
+
+  it("persists the last selected provider tab", async () => {
+    useRateLimitPopoverStore.getState().setActiveTab("codex");
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    const raw = window.localStorage.getItem(PERSIST_KEY);
+    expect(JSON.parse(raw ?? "{}")).toEqual({
+      state: { activeTab: "codex" },
+      version: CURRENT_PERSIST_VERSION,
+    });
+  });
+
+  it("rehydrates a valid saved tab", async () => {
+    window.localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({
+        state: { activeTab: "claude-code" },
+        version: CURRENT_PERSIST_VERSION,
+      }),
+    );
+
+    await useRateLimitPopoverStore.persist.rehydrate();
+
+    expect(useRateLimitPopoverStore.getState().activeTab).toBe("claude-code");
+  });
+
+  it("falls back to Overview when persisted tab data is invalid", async () => {
+    window.localStorage.setItem(
+      PERSIST_KEY,
+      JSON.stringify({
+        state: { activeTab: "missing-provider" },
+        version: CURRENT_PERSIST_VERSION,
+      }),
+    );
+
+    await useRateLimitPopoverStore.persist.rehydrate();
+
+    expect(useRateLimitPopoverStore.getState().activeTab).toBe("overview");
+  });
+});

--- a/clients/gui-app/src/stores/rate-limits/rate-limit-popover-store.ts
+++ b/clients/gui-app/src/stores/rate-limits/rate-limit-popover-store.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import { rateLimitCapableProviderIdSchema } from "@traycer/protocol/host/rate-limit";
+import { basePersistOptions, persistKey, STORE_KEYS } from "@/lib/persist";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+/**
+ * The Overview tab, one tab per connected host-RPC provider, and - when the
+ * account is eligible - the GUI-sourced "traycer" tab. `"traycer"` is a
+ * synthetic entry: it is NOT a `RateLimitProviderId` and does not flow through
+ * `useConfiguredRateLimitProviders()`.
+ */
+export type RateLimitPopoverTab = "overview" | RateLimitProviderId | "traycer";
+
+interface RateLimitPopoverStoreState {
+  readonly activeTab: RateLimitPopoverTab;
+  readonly setActiveTab: (tab: RateLimitPopoverTab) => void;
+}
+
+const RATE_LIMIT_POPOVER_PERSIST_KEY = persistKey(STORE_KEYS.rateLimitPopover);
+
+function persistedActiveTab(persistedState: unknown): RateLimitPopoverTab {
+  if (typeof persistedState !== "object" || persistedState === null) {
+    return "overview";
+  }
+  if (!("activeTab" in persistedState)) return "overview";
+  const activeTab = persistedState.activeTab;
+  if (activeTab === "overview" || activeTab === "traycer") return activeTab;
+  const result = rateLimitCapableProviderIdSchema.safeParse(activeTab);
+  return result.success ? result.data : "overview";
+}
+
+export const useRateLimitPopoverStore = create<RateLimitPopoverStoreState>()(
+  persist(
+    (set, get) => ({
+      activeTab: "overview",
+      setActiveTab: (activeTab) => {
+        if (get().activeTab === activeTab) return;
+        set({ activeTab });
+      },
+    }),
+    {
+      ...basePersistOptions(RATE_LIMIT_POPOVER_PERSIST_KEY),
+      storage: createJSONStorage(() => localStorage),
+      merge: (persistedState, currentState) => ({
+        ...currentState,
+        activeTab: persistedActiveTab(persistedState),
+      }),
+      partialize: (state) => ({
+        activeTab: state.activeTab,
+      }),
+    },
+  ),
+);

--- a/clients/shared/host-transport/auth-aware-messenger.ts
+++ b/clients/shared/host-transport/auth-aware-messenger.ts
@@ -11,10 +11,8 @@ import {
 /**
  * Optional retry policy for the auth-aware wrapper.
  *
- * The Desktop renderer omits this: on `UNAUTHORIZED` it revalidates (rotating
- * the credential lease in place) and rethrows, leaving the retry to the query
- * layer, which re-issues the request against the rotated lease. The CLI has no
- * query layer, so it opts in: after a revalidation that actually rotated the
+ * The CLI and renderer use this when a caller must complete the refresh loop
+ * inside the transport layer: after a revalidation that actually rotated the
  * bearer, the wrapper retries the request once on the rotated value.
  *
  * Retry is gated on the bearer *changing* (compared before/after revalidation)


### PR DESCRIPTION
## Summary
- update usage-limit severity/fill rules so bars stay blue through 85%, turn red above 85%, and render 0% usage as an empty fill
- show reset countdowns at zero as `0s` and keep stale usage displays tied to the last successful refresh timestamp
- route GUI host RPC usage calls through the auth-aware retry path for bearer refresh on 401s
- persist the usage-limit popover's last selected provider tab, with Overview fallback when unavailable

## Verification
- `bun run test -- src/components/layout/header/__tests__/rate-limit-popover.test.tsx src/stores/rate-limits/__tests__/rate-limit-popover-store.test.ts src/lib/persist/__tests__/keys.test.ts`
- `bun run test -- src/lib/persist/__tests__/store-persist-names.test.ts src/lib/persist/__tests__/keys.test.ts src/stores/rate-limits/__tests__/rate-limit-popover-store.test.ts`
- `bun run compile` from `clients/gui-app`
- `bun run compile` from repo root
- `npx -y react-doctor@latest . --verbose --diff main --offline --no-score` from `clients/gui-app`
- `bun x vitest run --config clients/shared/vitest.config.ts clients/shared/host-transport/__tests__/auth-aware-messenger.test.ts`
- pre-commit affected lint/format/compile/build hook passed during commit

Note: full `bun run react-doctor` still reports unrelated pre-existing findings outside this changeset.