### PR TITLE
Keep active sessions through registry caps

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/session-registry.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/session-registry.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createChatSessionStore } from "@/stores/chats/chat-session-store";
+import {
+  createChatSessionStore,
+  type ChatSessionStoreHandle,
+} from "@/stores/chats/chat-session-store";
 import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
 import {
   ChatSessionRegistry,
@@ -198,21 +201,7 @@ describe("ChatSessionRegistry", () => {
       () => owned.handle,
     );
     hostIds.set(acquired, "host-original");
-    acquired.store.setState({
-      runStatus: "running",
-      activeTurn: {
-        turnId: "turn-1",
-        status: "running",
-        harnessId: "codex",
-        model: "gpt-5-codex",
-        agentMode: "regular",
-        userMessageId: "message-1",
-        startedAt: 1,
-        updatedAt: 1,
-        reasoningEffort: null,
-        serviceTier: null,
-      },
-    });
+    markRunning(acquired);
 
     // The tile lease can disappear during a transient offline/null directory
     // state. The active turn must keep the retained session handle alive past
@@ -260,21 +249,7 @@ describe("ChatSessionRegistry", () => {
       SCOPE,
       () => owned.handle,
     );
-    acquired.store.setState({
-      runStatus: "running",
-      activeTurn: {
-        turnId: "turn-1",
-        status: "running",
-        harnessId: "codex",
-        model: "gpt-5-codex",
-        agentMode: "regular",
-        userMessageId: "message-1",
-        startedAt: 1,
-        updatedAt: 1,
-        reasoningEffort: null,
-        serviceTier: null,
-      },
-    });
+    markRunning(acquired);
 
     registry.release("epic-1", "chat-1");
     vi.advanceTimersByTime(MAX_ACTIVE_CHAT_IDLE_DEFER_MS + TTL_MS);
@@ -370,6 +345,34 @@ describe("ChatSessionRegistry", () => {
     expect(registry.peek("epic-1", "chat-c")).toBe(c.handle);
   });
 
+  it("does not evict lease-free active sessions to satisfy the warm cap", () => {
+    const registry = new ChatSessionRegistry({
+      idleTtlMs: TTL_MS,
+      maxWarmSessions: 2,
+    });
+    const active = createHandle("epic-1", "chat-active");
+    const b = createHandle("epic-1", "chat-b");
+    const c = createHandle("epic-1", "chat-c");
+    registry.acquire("epic-1", "chat-active", SCOPE, () => active.handle);
+    registry.acquire("epic-1", "chat-b", SCOPE, () => b.handle);
+    registry.acquire("epic-1", "chat-c", SCOPE, () => c.handle);
+
+    markRunning(active.handle);
+
+    registry.release("epic-1", "chat-active");
+    vi.advanceTimersByTime(1_000);
+    registry.release("epic-1", "chat-b");
+    vi.advanceTimersByTime(1_000);
+    registry.release("epic-1", "chat-c");
+
+    expect(active.closeCount()).toBe(0);
+    expect(b.closeCount()).toBe(1);
+    expect(c.closeCount()).toBe(0);
+    expect(registry.peek("epic-1", "chat-active")).toBe(active.handle);
+    expect(registry.peek("epic-1", "chat-b")).toBeNull();
+    expect(registry.peek("epic-1", "chat-c")).toBe(c.handle);
+  });
+
   it("never evicts leased sessions to satisfy the warm cap", () => {
     const registry = new ChatSessionRegistry({
       idleTtlMs: TTL_MS,
@@ -425,3 +428,21 @@ describe("ChatSessionRegistry", () => {
     expect(listener).toHaveBeenCalledTimes(2);
   });
 });
+
+function markRunning(handle: ChatSessionStoreHandle): void {
+  handle.store.setState({
+    runStatus: "running",
+    activeTurn: {
+      turnId: "turn-1",
+      status: "running",
+      harnessId: "codex",
+      model: "gpt-5-codex",
+      agentMode: "regular",
+      userMessageId: "message-1",
+      startedAt: 1,
+      updatedAt: 1,
+      reasoningEffort: null,
+      serviceTier: null,
+    },
+  });
+}

--- a/clients/gui-app/src/stores/chats/session-registry.ts
+++ b/clients/gui-app/src/stores/chats/session-registry.ts
@@ -32,8 +32,9 @@ export const MAX_ACTIVE_CHAT_IDLE_DEFER_MS = 60 * 60 * 1_000;
  * bounds retention in time; this bounds it in count, so cycling through many
  * chats inside one TTL window cannot pin an unbounded set of finished
  * transcripts and open websockets. Oldest-released inactive sessions are
- * disposed first; leased sessions and sessions with active chat work never
- * count toward (or get evicted by) the cap.
+ * disposed first. Leased sessions are outside the warm pool. Lease-free
+ * sessions with active chat work are never evicted by the cap, but they still
+ * contribute to overflow and can crowd out older inactive warm sessions.
  */
 export const DEFAULT_MAX_WARM_CHAT_SESSIONS = 6;
 
@@ -58,7 +59,8 @@ export interface ChatSessionRegistryOptions {
  * sessions are additionally count-bounded by `maxWarmSessions`
  * (oldest-released evicted first) so the TTL window alone cannot accumulate an
  * unbounded set. Idle sessions with active work are retained until the work
- * settles or the active defer cap elapses.
+ * settles or the active defer cap elapses, though they still contribute to the
+ * overflow count while selecting inactive eviction candidates.
  */
 export class ChatSessionRegistry {
   private readonly entries = new Map<string, RegistryEntry>();

--- a/clients/gui-app/src/stores/chats/session-registry.ts
+++ b/clients/gui-app/src/stores/chats/session-registry.ts
@@ -28,11 +28,12 @@ export const DEFAULT_CHAT_IDLE_TTL_MS = 10 * 60 * 1_000;
 export const MAX_ACTIVE_CHAT_IDLE_DEFER_MS = 60 * 60 * 1_000;
 
 /**
- * Upper bound on lease-free warm sessions held at once. The idle TTL bounds
- * retention in time; this bounds it in count, so cycling through many chats
- * inside one TTL window cannot pin an unbounded set of full transcripts and
- * open websockets. Oldest-released sessions are disposed first; leased
- * sessions never count toward (and are never evicted by) the cap.
+ * Upper bound on inactive lease-free warm sessions held at once. The idle TTL
+ * bounds retention in time; this bounds it in count, so cycling through many
+ * chats inside one TTL window cannot pin an unbounded set of finished
+ * transcripts and open websockets. Oldest-released inactive sessions are
+ * disposed first; leased sessions and sessions with active chat work never
+ * count toward (or get evicted by) the cap.
  */
 export const DEFAULT_MAX_WARM_CHAT_SESSIONS = 6;
 
@@ -53,9 +54,11 @@ export interface ChatSessionRegistryOptions {
  * until it goes untouched for `idleTtlMs`, at which point it is disposed.
  * Re-opening or otherwise touching the session resets that window. Leased
  * sessions (a currently-rendered tile) never expire - only the idle clock
- * runs - so a window with many open chat tiles keeps them all. Idle sessions
- * are additionally count-bounded by `maxWarmSessions` (oldest-released
- * evicted first) so the TTL window alone cannot accumulate an unbounded set.
+ * runs - so a window with many open chat tiles keeps them all. Inactive idle
+ * sessions are additionally count-bounded by `maxWarmSessions`
+ * (oldest-released evicted first) so the TTL window alone cannot accumulate an
+ * unbounded set. Idle sessions with active work are retained until the work
+ * settles or the active defer cap elapses.
  */
 export class ChatSessionRegistry {
   private readonly entries = new Map<string, RegistryEntry>();
@@ -218,7 +221,9 @@ export class ChatSessionRegistry {
 
   /**
    * Enforces the warm cap after a release transitions an entry to lease-free.
-   * Only lease-free entries are candidates; the oldest-released go first.
+   * Only inactive lease-free entries are candidates; the oldest-released go
+   * first. Active lease-free sessions stay retained so passive tab/header
+   * progress readers still have the `runStatus` snapshot after a tile unmounts.
    */
   private evictWarmOverflow(): void {
     // Total size bounds the idle count, so an under-cap registry skips the
@@ -229,10 +234,13 @@ export class ChatSessionRegistry {
     );
     const overflow = idle.length - this.maxWarmSessions;
     if (overflow <= 0) return;
-    idle.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
-    for (const entry of idle.slice(0, overflow)) {
+    const candidates = idle.filter((entry) => !hasActiveChatWork(entry.handle));
+    candidates.sort((a, b) => a.lastUsedAt - b.lastUsedAt);
+    const evicted = candidates.slice(0, overflow);
+    for (const entry of evicted) {
       this.disposeEntry(entry);
     }
+    if (evicted.length === 0) return;
     this.notify();
   }
 

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/session-registry.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/session-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
 import { OpenEpicSessionRegistry } from "@/stores/epics/open-epic/session-registry";
 import {
   createOpenEpicStore,
@@ -144,6 +145,45 @@ describe("OpenEpicSessionRegistry", () => {
     expect(mountedB.disposed).toBe(false);
   });
 
+  it("does not evict clean sessions with active agent work", () => {
+    const registry = new OpenEpicSessionRegistry({ maxLive: 2 });
+    const active = buildTestHandle("active", true);
+    const inactiveA = buildTestHandle("inactive-a", true);
+    const inactiveB = buildTestHandle("inactive-b", true);
+
+    markAgentWorking(active, "chat-active");
+    registry.acquire("active", () => h(active));
+    registry.acquire("inactive-a", () => h(inactiveA));
+    registry.acquire("inactive-b", () => h(inactiveB));
+
+    expect(registry.size()).toBe(2);
+    expect(active.disposed).toBe(false);
+    expect(inactiveA.disposed).toBe(true);
+    expect(inactiveB.disposed).toBe(false);
+    expect(registry.get("active")).not.toBeNull();
+  });
+
+  it("auto-prunes overflow when active agent work clears", () => {
+    const registry = new OpenEpicSessionRegistry({ maxLive: 1 });
+    const activeA = buildTestHandle("active-a", true);
+    const activeB = buildTestHandle("active-b", true);
+
+    markAgentWorking(activeA, "chat-a");
+    markAgentWorking(activeB, "chat-b");
+    registry.acquire("active-a", () => h(activeA));
+    registry.acquire("active-b", () => h(activeB));
+
+    expect(registry.size()).toBe(2);
+    expect(activeA.disposed).toBe(false);
+    expect(activeB.disposed).toBe(false);
+
+    clearAgentWorking(activeA);
+
+    expect(registry.size()).toBe(1);
+    expect(activeA.disposed).toBe(true);
+    expect(activeB.disposed).toBe(false);
+  });
+
   it("does not evict dirty entries even when above the cap (soft-cap overflow)", () => {
     const registry = new OpenEpicSessionRegistry({ maxLive: 5 });
     const handles: TestHandle[] = [];
@@ -267,3 +307,15 @@ describe("OpenEpicSessionRegistry", () => {
     expect(registry.get("e0")).toBeNull();
   });
 });
+
+function markAgentWorking(handle: TestHandle, agentId: string): void {
+  handle.handle.awareness.setLocalState({
+    [AGENT_WORKING_AWARENESS_FIELD]: [agentId],
+  });
+}
+
+function clearAgentWorking(handle: TestHandle): void {
+  handle.handle.awareness.setLocalState({
+    [AGENT_WORKING_AWARENESS_FIELD]: [],
+  });
+}

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -164,6 +164,13 @@ export class OpenEpicSessionRegistry {
       unsubscribeAwareness: null,
       lastEligibilityKey: eligibilityKeyFor(handle),
     };
+    const handleEligibilityChange = (): void => {
+      const nextKey = eligibilityKeyFor(handle);
+      if (nextKey === entry.lastEligibilityKey) return;
+      entry.lastEligibilityKey = nextKey;
+      this.prune();
+      this.emit();
+    };
     // Subscribe to the underlying store so prune-relevant changes trigger a
     // registry-level emit. Per-keystroke `projection.revision` bumps fire
     // the subscription too; gate on an "eligibility key" so the
@@ -174,25 +181,8 @@ export class OpenEpicSessionRegistry {
     const maybeSubscribe = handle.store.subscribe;
     entry.unsubscribe =
       typeof maybeSubscribe === "function"
-        ? maybeSubscribe.call(handle.store, () => {
-            const nextKey = eligibilityKeyFor(handle);
-            if (nextKey === entry.lastEligibilityKey) return;
-            entry.lastEligibilityKey = nextKey;
-            // A tracked session's state changed (e.g. dirty/reconnecting →
-            // clean). If the registry is currently above the soft cap, the
-            // newly clean entry makes prune() able to make progress; when
-            // we're at or below the cap, prune() short-circuits.
-            this.prune();
-            this.emit();
-          })
+        ? maybeSubscribe.call(handle.store, handleEligibilityChange)
         : null;
-    const handleEligibilityChange = (): void => {
-      const nextKey = eligibilityKeyFor(handle);
-      if (nextKey === entry.lastEligibilityKey) return;
-      entry.lastEligibilityKey = nextKey;
-      this.prune();
-      this.emit();
-    };
     entry.unsubscribeAwareness =
       typeof handle.awareness.on === "function" &&
       typeof handle.awareness.off === "function"
@@ -315,12 +305,12 @@ export class OpenEpicSessionRegistry {
 
 function hasActiveAgentWork(handle: OpenEpicStoreHandle): boolean {
   if (typeof handle.awareness.getStates !== "function") return false;
-  for (const state of handle.awareness.getStates().values()) {
+  return Array.from(handle.awareness.getStates().values()).some((state) => {
     const working: unknown = state[AGENT_WORKING_AWARENESS_FIELD];
-    if (!Array.isArray(working)) continue;
-    if (working.some((id) => typeof id === "string")) return true;
-  }
-  return false;
+    return (
+      Array.isArray(working) && working.some((id) => typeof id === "string")
+    );
+  });
 }
 
 function resolveUnsyncedTitle(

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -193,10 +193,16 @@ export class OpenEpicSessionRegistry {
       this.prune();
       this.emit();
     };
-    handle.awareness.on("change", handleEligibilityChange);
-    entry.unsubscribeAwareness = () => {
-      handle.awareness.off("change", handleEligibilityChange);
-    };
+    entry.unsubscribeAwareness =
+      typeof handle.awareness.on === "function" &&
+      typeof handle.awareness.off === "function"
+        ? () => {
+            handle.awareness.off("change", handleEligibilityChange);
+          }
+        : null;
+    if (entry.unsubscribeAwareness !== null) {
+      handle.awareness.on("change", handleEligibilityChange);
+    }
     this.entries.set(epicId, entry);
     this.prune();
     this.emit();
@@ -308,6 +314,7 @@ export class OpenEpicSessionRegistry {
 }
 
 function hasActiveAgentWork(handle: OpenEpicStoreHandle): boolean {
+  if (typeof handle.awareness.getStates !== "function") return false;
   for (const state of handle.awareness.getStates().values()) {
     const working: unknown = state[AGENT_WORKING_AWARENESS_FIELD];
     if (!Array.isArray(working)) continue;

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -1,17 +1,18 @@
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
 import { appLogger } from "@/lib/logger";
 import { useSyncExternalStore } from "react";
+import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
 
 /**
  * MRU registry for live Epic sessions. Keeps up to 5 open in the background
- * so tab-switching is instant; evicts the oldest **clean / synced** handle
- * once the cap is exceeded.
+ * so tab-switching is instant; evicts the oldest **clean / synced / inactive**
+ * handle once the cap is exceeded.
  *
  * Soft-cap rule: if every entry is dirty (unsynced edits pending, or still
- * reconnecting with unflushed writes), the registry temporarily stays above
- * the cap until at least one entry becomes clean, at which point it prunes
- * down to the cap. Closing an Epic tab forcibly disposes that session
- * regardless of the cap.
+ * reconnecting with unflushed writes) or has active agent work, the registry
+ * temporarily stays above the cap until at least one entry becomes clean and
+ * inactive, at which point it prunes down to the cap. Closing an Epic tab
+ * forcibly disposes that session regardless of the cap.
  */
 export const DEFAULT_MAX_LIVE_EPICS = 5;
 const loggedLiveTitleReadFailures = new Set<string>();
@@ -31,6 +32,7 @@ interface RegistryEntry {
    * the underlying session is gone.
    */
   unsubscribe: (() => void) | null;
+  unsubscribeAwareness: (() => void) | null;
   /**
    * Last-seen value of the only four store fields that affect prune
    * eligibility or the unsynced-edits projection. The zustand
@@ -45,7 +47,7 @@ interface RegistryEntry {
 function eligibilityKeyFor(handle: OpenEpicStoreHandle): string {
   const state = handle.store.getState();
   const metaTitle = state.snapshotMeta?.epicLight?.title ?? "";
-  return `${handle.isClean() ? 1 : 0}:${state.isDirty ? 1 : 0}:${state.unsyncedQueueSize}:${metaTitle}`;
+  return `${handle.isClean() ? 1 : 0}:${hasActiveAgentWork(handle) ? 1 : 0}:${state.isDirty ? 1 : 0}:${state.unsyncedQueueSize}:${metaTitle}`;
 }
 
 /**
@@ -68,7 +70,8 @@ export interface UnsyncedEditsEntry {
  *     most-recently-interacted Epic stays alive.
  *   - `release(epicId)` disposes that entry unconditionally (tab closed).
  *   - `prune()` is run after every acquire; it disposes the least-recently
- *     used clean entries until size <= maxLive, skipping dirty entries.
+ *     used clean/inactive entries until size <= maxLive, skipping dirty or
+ *     active entries.
  */
 export class OpenEpicSessionRegistry {
   private readonly entries = new Map<string, RegistryEntry>();
@@ -158,6 +161,7 @@ export class OpenEpicSessionRegistry {
       lastUsedAt: this.tick(),
       mountedRefs,
       unsubscribe: null,
+      unsubscribeAwareness: null,
       lastEligibilityKey: eligibilityKeyFor(handle),
     };
     // Subscribe to the underlying store so prune-relevant changes trigger a
@@ -182,6 +186,17 @@ export class OpenEpicSessionRegistry {
             this.emit();
           })
         : null;
+    const handleEligibilityChange = (): void => {
+      const nextKey = eligibilityKeyFor(handle);
+      if (nextKey === entry.lastEligibilityKey) return;
+      entry.lastEligibilityKey = nextKey;
+      this.prune();
+      this.emit();
+    };
+    handle.awareness.on("change", handleEligibilityChange);
+    entry.unsubscribeAwareness = () => {
+      handle.awareness.off("change", handleEligibilityChange);
+    };
     this.entries.set(epicId, entry);
     this.prune();
     this.emit();
@@ -259,9 +274,10 @@ export class OpenEpicSessionRegistry {
   }
 
   /**
-   * Evict least-recently-used clean entries until size <= maxLive. If every
-   * entry above the cap is dirty, we stop (soft cap) - the next time a
-   * dirty entry flushes, subsequent `prune()` calls will finish the job.
+   * Evict least-recently-used clean and inactive entries until size <= maxLive.
+   * If every entry above the cap is dirty or active, we stop (soft cap) - the
+   * next time a dirty entry flushes or an active entry goes idle, subsequent
+   * `prune()` calls will finish the job.
    */
   prune(): void {
     if (this.entries.size <= this.maxLive) return;
@@ -272,6 +288,7 @@ export class OpenEpicSessionRegistry {
       if (this.entries.size <= this.maxLive) return;
       if (entry.mountedRefs > 0) continue;
       if (!entry.handle.isClean()) continue;
+      if (hasActiveAgentWork(entry.handle)) continue;
       this.entries.delete(entry.epicId);
       this.disposeEntry(entry);
     }
@@ -279,6 +296,7 @@ export class OpenEpicSessionRegistry {
 
   private disposeEntry(entry: RegistryEntry): void {
     if (entry.unsubscribe !== null) entry.unsubscribe();
+    if (entry.unsubscribeAwareness !== null) entry.unsubscribeAwareness();
     entry.handle.dispose();
     this.releaseListener?.(entry.epicId);
   }
@@ -287,6 +305,15 @@ export class OpenEpicSessionRegistry {
     this.nextTick += 1;
     return this.nextTick;
   }
+}
+
+function hasActiveAgentWork(handle: OpenEpicStoreHandle): boolean {
+  for (const state of handle.awareness.getStates().values()) {
+    const working: unknown = state[AGENT_WORKING_AWARENESS_FIELD];
+    if (!Array.isArray(working)) continue;
+    if (working.some((id) => typeof id === "string")) return true;
+  }
+  return false;
 }
 
 function resolveUnsyncedTitle(


### PR DESCRIPTION
## Summary
- keep active chat sessions from being evicted by the warm chat-session cap
- keep active epic sessions from being evicted by the five-live-epic MRU cap so task-tab activity indicators continue rendering
- add regression coverage for both registry cap paths

## Root cause
Task-level activity indicators read active/waiting state from live epic/chat session registries. Clean background sessions could be pruned once registry caps were exceeded, which removed the local activity source for older task tabs. In practice this meant only the most recent capped set of tabs retained their spinners/question indicators.

## Validation
- `bun run test -- src/stores/epics/open-epic/__tests__/session-registry.test.ts src/stores/chats/__tests__/session-registry.test.ts`
- `bun run compile`
- `bun x -y react-doctor@latest . --verbose --offline --scope changed --blocking warning`
- pre-commit affected build/compile/lint/format hook passed
