### PR TITLE
gui: recover unresolved workspace rows from disk metadata

### DIFF
--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -4,11 +4,96 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ActiveHostWorkspaceControls } from "../host-workspace-selector";
+import type { WorktreeWorkspaceSummary } from "@traycer/protocol/host/worktree-schemas";
+import type { ResolvedFolder } from "@/lib/workspace/resolved-folder";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
-const mocks = vi.hoisted(() => ({
-  pickAndPrepareFolders: vi.fn(() => Promise.resolve(null)),
-  selectHost: vi.fn(),
-}));
+interface MockSummariesQuery {
+  readonly data:
+    | {
+        readonly workspaces: readonly WorktreeWorkspaceSummary[];
+      }
+    | undefined;
+  readonly isFetching: boolean;
+  readonly isPending: boolean;
+  readonly isLoading: boolean;
+}
+
+interface MockHostClient {
+  getActiveHost(): {
+    readonly hostId: string;
+    readonly label: string;
+    readonly kind: "local";
+    readonly websocketUrl: string;
+    readonly version: string;
+    readonly status: "available";
+  };
+  getActiveHostId(): string;
+  getRequestContextUserId(): string;
+  request(): Promise<never>;
+  onChange(): () => void;
+}
+
+function createMockHostClient(): MockHostClient {
+  return {
+    getActiveHost: () => ({
+      hostId: "host-home",
+      label: "Home Mac",
+      kind: "local",
+      websocketUrl: "ws://127.0.0.1:4917/rpc",
+      version: "0.0.0-test",
+      status: "available",
+    }),
+    getActiveHostId: () => "host-home",
+    getRequestContextUserId: () => "user-home",
+    request: () => Promise.reject(new Error("unexpected request")),
+    onChange: () => () => undefined,
+  };
+}
+
+const mocks = vi.hoisted(() => {
+  const hostClient: { current: MockHostClient | null } = {
+    current: createMockHostClient(),
+  };
+  const resolvedWorkspace: {
+    current: { readonly folders: readonly ResolvedFolder[] };
+  } = {
+    current: { folders: [] },
+  };
+  const summariesQuery: { current: MockSummariesQuery } = {
+    current: {
+      data: { workspaces: [] },
+      isFetching: false,
+      isPending: false,
+      isLoading: false,
+    },
+  };
+  return {
+    pickAndPrepareFolders: vi.fn(() => Promise.resolve(null)),
+    selectHost: vi.fn(),
+    listByWorkspacePathsForClient: vi.fn(),
+    hostClient,
+    resolvedWorkspace,
+    summariesQuery,
+  };
+});
+
+const GIT_SUMMARY: WorktreeWorkspaceSummary = {
+  workspacePath: "/workspace/app",
+  isGitRepo: true,
+  repoIdentifier: { owner: "acme", repo: "app" },
+  mainBranch: "development",
+  worktrees: [
+    {
+      worktreePath: "/workspace/app",
+      branch: "development",
+      head: null,
+      isMain: true,
+      isLocked: false,
+    },
+  ],
+  scripts: null,
+};
 
 vi.mock("@/components/ui/select", () => ({
   Select: (props: { readonly children: ReactNode }) => (
@@ -47,19 +132,7 @@ vi.mock("@/lib/host", () => ({
   useHostBinding: () => ({
     directory: { selectById: mocks.selectHost },
   }),
-  useHostClient: () => ({
-    getActiveHost: () => ({
-      hostId: "host-home",
-      label: "Home Mac",
-      kind: "local",
-      websocketUrl: "ws://127.0.0.1:4917/rpc",
-      version: "0.0.0-test",
-      status: "available",
-    }),
-    getActiveHostId: () => "host-home",
-    getRequestContextUserId: () => "user-home",
-    request: vi.fn(),
-  }),
+  useHostClient: () => mocks.hostClient.current,
 }));
 
 vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
@@ -82,7 +155,7 @@ vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
 }));
 
 vi.mock("@/hooks/workspace/use-resolved-workspace-folders-query", () => ({
-  useResolvedWorkspaceFolders: () => ({ folders: [] }),
+  useResolvedWorkspaceFolders: () => mocks.resolvedWorkspace.current,
 }));
 
 vi.mock("@/hooks/worktree/use-worktree-list-by-workspace-paths-query", () => ({
@@ -90,10 +163,16 @@ vi.mock("@/hooks/worktree/use-worktree-list-by-workspace-paths-query", () => ({
     data: { workspaces: [] },
     isFetching: false,
   }),
-  useWorktreeListByWorkspacePathsForClient: () => ({
-    data: { workspaces: [] },
-    isLoading: false,
-  }),
+  useWorktreeListByWorkspacePathsForClient: (
+    client: unknown,
+    args: {
+      readonly workspacePaths: readonly string[];
+      readonly enabled: boolean;
+    },
+  ) => {
+    mocks.listByWorkspacePathsForClient(client, args);
+    return mocks.summariesQuery.current;
+  },
 }));
 
 vi.mock("@/hooks/host/use-host-queries", () => ({
@@ -118,19 +197,21 @@ vi.mock("@/hooks/workspace/use-workspace-folder-actions", () => ({
   }),
 }));
 
-function renderControl() {
+function renderControl(layout: "inline" | "stacked") {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
   render(
     <QueryClientProvider client={queryClient}>
-      <ActiveHostWorkspaceControls
-        stagingKey={{ surface: "landing", draftId: null }}
-        workspaceSeed={null}
-        seedIntent={null}
-        layout="inline"
-        hostScope={{ kind: "active" }}
-      />
+      <TooltipProvider>
+        <ActiveHostWorkspaceControls
+          stagingKey={{ surface: "landing", draftId: null }}
+          workspaceSeed={null}
+          seedIntent={null}
+          layout={layout}
+          hostScope={{ kind: "active" }}
+        />
+      </TooltipProvider>
     </QueryClientProvider>,
   );
   return queryClient;
@@ -140,6 +221,15 @@ describe("landing workspace summary empty state", () => {
   beforeEach(() => {
     mocks.pickAndPrepareFolders.mockClear();
     mocks.selectHost.mockClear();
+    mocks.listByWorkspacePathsForClient.mockClear();
+    mocks.hostClient.current = createMockHostClient();
+    mocks.resolvedWorkspace.current = { folders: [] };
+    mocks.summariesQuery.current = {
+      data: { workspaces: [] },
+      isFetching: false,
+      isPending: false,
+      isLoading: false,
+    };
   });
 
   afterEach(() => {
@@ -147,7 +237,7 @@ describe("landing workspace summary empty state", () => {
   });
 
   it("shows Add folder directly instead of a no-folder summary trigger", () => {
-    const queryClient = renderControl();
+    const queryClient = renderControl("inline");
 
     expect(screen.getByTestId("home-workspace-summary-control")).toBeTruthy();
     expect(screen.getByTestId("composer-host-trigger")).toBeTruthy();
@@ -158,6 +248,96 @@ describe("landing workspace summary empty state", () => {
 
     fireEvent.click(screen.getByTestId("folder-add"));
     expect(mocks.pickAndPrepareFolders).toHaveBeenCalledTimes(1);
+
+    queryClient.clear();
+  });
+
+  it("queries disk metadata for unresolved folders and renders them usable when git exists", () => {
+    mocks.resolvedWorkspace.current = {
+      folders: [
+        {
+          kind: "unresolved",
+          path: "/workspace/app",
+          name: "app",
+          repoIdentifier: { owner: "acme", repo: "app" },
+        },
+      ],
+    };
+    mocks.summariesQuery.current = {
+      data: { workspaces: [GIT_SUMMARY] },
+      isFetching: false,
+      isPending: false,
+      isLoading: false,
+    };
+
+    const queryClient = renderControl("stacked");
+
+    expect(mocks.listByWorkspacePathsForClient).toHaveBeenCalledWith(
+      expect.anything(),
+      { workspacePaths: ["/workspace/app"], enabled: true },
+    );
+    expect(screen.queryByText("Unavailable")).toBeNull();
+    expect(screen.getByTestId("folder-location-trigger").textContent).toContain(
+      "New worktree",
+    );
+
+    queryClient.clear();
+  });
+
+  it("shows loading while unresolved folder disk metadata is still pending", () => {
+    mocks.resolvedWorkspace.current = {
+      folders: [
+        {
+          kind: "unresolved",
+          path: "/workspace/app",
+          name: "app",
+          repoIdentifier: { owner: "acme", repo: "app" },
+        },
+      ],
+    };
+    mocks.summariesQuery.current = {
+      data: undefined,
+      isFetching: true,
+      isPending: true,
+      isLoading: true,
+    };
+
+    const queryClient = renderControl("stacked");
+
+    expect(screen.getByTestId("folder-row-loading").textContent).toContain(
+      "Loading folder metadata",
+    );
+    expect(screen.queryByText("Unavailable")).toBeNull();
+
+    queryClient.clear();
+  });
+
+  it("shows unavailable, not loading, when unresolved metadata query is disabled by a missing host client", () => {
+    mocks.hostClient.current = null;
+    mocks.resolvedWorkspace.current = {
+      folders: [
+        {
+          kind: "unresolved",
+          path: "/workspace/app",
+          name: "app",
+          repoIdentifier: { owner: "acme", repo: "app" },
+        },
+      ],
+    };
+    mocks.summariesQuery.current = {
+      data: undefined,
+      isFetching: false,
+      isPending: true,
+      isLoading: false,
+    };
+
+    const queryClient = renderControl("stacked");
+
+    expect(screen.queryByTestId("folder-row-loading")).toBeNull();
+    expect(screen.getByText("Unavailable")).toBeTruthy();
+    expect(screen.getByTestId("folder-row-locate").textContent).toContain(
+      "Locate folder",
+    );
 
     queryClient.clear();
   });

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -95,6 +95,15 @@ const GIT_SUMMARY: WorktreeWorkspaceSummary = {
   scripts: null,
 };
 
+const NON_GIT_SUMMARY: WorktreeWorkspaceSummary = {
+  workspacePath: "/workspace/app",
+  isGitRepo: false,
+  repoIdentifier: null,
+  mainBranch: null,
+  worktrees: [],
+  scripts: null,
+};
+
 vi.mock("@/components/ui/select", () => ({
   Select: (props: { readonly children: ReactNode }) => (
     <div>{props.children}</div>
@@ -279,6 +288,40 @@ describe("landing workspace summary empty state", () => {
     expect(screen.queryByText("Unavailable")).toBeNull();
     expect(screen.getByTestId("folder-location-trigger").textContent).toContain(
       "New worktree",
+    );
+
+    queryClient.clear();
+  });
+
+  it("renders unresolved folders with non-git disk metadata as local-only folders", async () => {
+    mocks.resolvedWorkspace.current = {
+      folders: [
+        {
+          kind: "unresolved",
+          path: "/workspace/app",
+          name: "app",
+          repoIdentifier: { owner: "acme", repo: "app" },
+        },
+      ],
+    };
+    mocks.summariesQuery.current = {
+      data: { workspaces: [NON_GIT_SUMMARY] },
+      isFetching: false,
+      isPending: false,
+      isLoading: false,
+    };
+
+    const queryClient = renderControl("stacked");
+    const trigger = screen.getByTestId("folder-location-trigger");
+
+    expect(screen.queryByText("Unavailable")).toBeNull();
+    expect(screen.queryByTestId("folder-row-locate")).toBeNull();
+    expect(trigger.textContent).toContain("Local");
+    expect(trigger.getAttribute("aria-disabled")).toBe("true");
+
+    fireEvent.focus(trigger);
+    expect((await screen.findByRole("tooltip")).textContent).toContain(
+      "Worktrees require a Git repository",
     );
 
     queryClient.clear();

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -103,6 +103,7 @@ import {
   workspaceRunBranchLabel,
 } from "./workspace-run-item";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
+import { appLogger } from "@/lib/logger";
 
 /**
  * `home` swaps the bound directory; `chat` clones the chat on switch;
@@ -342,6 +343,7 @@ export function ActiveHostWorkspaceControls(
             Workspaces
           </DropdownMenuLabel>
           <HomeWorkspaceRows
+            activeHostId={activeHostId}
             workspaceSource={workspaceSource}
             resolvedFolders={resolved.folders}
             activeHostClient={activeHostClient}
@@ -369,6 +371,7 @@ export function ActiveHostWorkspaceControls(
   );
   return (
     <HomeWorkspaceRows
+      activeHostId={activeHostId}
       workspaceSource={workspaceSource}
       resolvedFolders={resolved.folders}
       activeHostClient={activeHostClient}
@@ -395,6 +398,7 @@ function fixedUnavailableHostEntry(
 }
 
 function HomeWorkspaceRows(props: {
+  readonly activeHostId: string | null;
   readonly workspaceSource: HomeWorkspaceSource;
   readonly resolvedFolders: ReadonlyArray<ResolvedFolder>;
   readonly activeHostClient: HostClient<HostRpcRegistry> | null;
@@ -435,10 +439,7 @@ function HomeWorkspaceRows(props: {
     return folders.length > 0;
   }, [folderActions, workspaceSource]);
   const queryableFolderPaths = useMemo<ReadonlyArray<string>>(
-    () =>
-      resolvedFolders.flatMap((entry) =>
-        entry.kind === "unresolved" ? [] : [entry.path],
-      ),
+    () => [...new Set(resolvedFolders.map((entry) => entry.path))],
     [resolvedFolders],
   );
   const summariesQuery = useWorktreeListByWorkspacePathsForClient(
@@ -460,8 +461,7 @@ function HomeWorkspaceRows(props: {
   const gitSummaries = useMemo<ReadonlyArray<WorktreeWorkspaceSummary>>(
     () =>
       resolvedFolders.flatMap((entry) => {
-        if (entry.kind === "unresolved") return [];
-        const summary = summariesByPath.get(entry.path) ?? null;
+        const summary = summaryForResolvedFolder(entry, summariesByPath);
         return summary !== null && summary.isGitRepo ? [summary] : [];
       }),
     [resolvedFolders, summariesByPath],
@@ -548,6 +548,37 @@ function HomeWorkspaceRows(props: {
     })),
     options: { enabled: true },
   });
+
+  useEffect(() => {
+    appLogger.debug("[workspace-selector] folder metadata resolution", {
+      activeHostId: props.activeHostId,
+      folderCount: resolvedFolders.length,
+      folders: resolvedFolders.map((entry) => ({
+        kind: entry.kind,
+        path: entry.path,
+        repoIdentifier: repoIdentifierLogValue(
+          repoIdentifierForResolvedFolder(entry),
+        ),
+      })),
+      queriedPaths: queryableFolderPaths,
+      summaryFetching: summariesQuery.isFetching,
+      summaryPending: summariesQuery.isPending,
+      summaries:
+        summariesQuery.data?.workspaces.map((summary) => ({
+          path: summary.workspacePath,
+          isGitRepo: summary.isGitRepo,
+          repoIdentifier: repoIdentifierLogValue(summary.repoIdentifier),
+          worktreeCount: summary.worktrees.length,
+        })) ?? [],
+    });
+  }, [
+    props.activeHostId,
+    queryableFolderPaths,
+    resolvedFolders,
+    summariesQuery.data,
+    summariesQuery.isFetching,
+    summariesQuery.isPending,
+  ]);
   const branchesByValidationPath = useMemo<
     ReadonlyMap<string, ReadonlyArray<WorktreeBranch> | null>
   >(() => {
@@ -847,6 +878,11 @@ function hostOptionLabel(host: HostDirectoryEntry): string {
   return host.status === "unavailable" ? `${label} (offline)` : label;
 }
 
+type UnresolvedWorkspaceFolder = Extract<
+  ResolvedFolder,
+  { readonly kind: "unresolved" }
+>;
+
 function workspaceRunItemForResolvedFolder(input: {
   readonly entry: ResolvedFolder;
   readonly activeHostClient: HostClient<HostRpcRegistry> | null;
@@ -861,16 +897,19 @@ function workspaceRunItemForResolvedFolder(input: {
   readonly summariesByPath: ReadonlyMap<string, WorktreeWorkspaceSummary>;
   readonly workspaceSource: HomeWorkspaceSource;
 }): WorkspaceRunItem {
+  const summary = summaryForResolvedFolder(input.entry, input.summariesByPath);
   if (input.entry.kind === "unresolved") {
-    return unresolvedWorkspaceRunItem({
-      path: input.entry.path,
-      name: input.entry.name,
+    const unresolvedItem = workspaceRunItemForUnresolvedFolder({
+      activeHostClient: input.activeHostClient,
+      entry: input.entry,
+      isFetchingSummaries: input.isFetchingSummaries,
       onLocate: input.onLocate,
-      onRemove: () => input.workspaceSource.removeFolder(input.entry.path),
+      summary,
+      workspaceSource: input.workspaceSource,
     });
+    if (unresolvedItem !== null) return unresolvedItem;
   }
 
-  const summary = input.summariesByPath.get(input.entry.path) ?? null;
   const capturedEntry = currentCapturedEntry(
     input.workspaceSource.capturedIntent,
     input.entry.path,
@@ -912,7 +951,8 @@ function workspaceRunItemForResolvedFolder(input: {
     summary,
     currentIntent: capturedEntry,
     defaultNewBranchName,
-    repoIdentifier: summary?.repoIdentifier ?? null,
+    repoIdentifier:
+      summary?.repoIdentifier ?? repoIdentifierForResolvedFolder(input.entry),
     isPrimary,
     hostClient: input.activeHostClient,
     modeDisabled: false,
@@ -937,6 +977,35 @@ function workspaceRunItemForResolvedFolder(input: {
     onLocate: null,
     onRemove: () => input.workspaceSource.removeFolder(input.entry.path),
   };
+}
+
+function workspaceRunItemForUnresolvedFolder(input: {
+  readonly activeHostClient: HostClient<HostRpcRegistry> | null;
+  readonly entry: UnresolvedWorkspaceFolder;
+  readonly isFetchingSummaries: boolean;
+  readonly onLocate: () => void;
+  readonly summary: WorktreeWorkspaceSummary | null;
+  readonly workspaceSource: HomeWorkspaceSource;
+}): WorkspaceRunItem | null {
+  if (input.summary !== null && input.summary.isGitRepo) return null;
+  const onRemove = (): void =>
+    input.workspaceSource.removeFolder(input.entry.path);
+  if (input.summary === null && input.isFetchingSummaries) {
+    return pendingWorkspaceRunItem({
+      path: input.entry.path,
+      name: input.entry.name,
+      repoIdentifier: input.entry.repoIdentifier,
+      hostClient: input.activeHostClient,
+      onRemove,
+    });
+  }
+  return unresolvedWorkspaceRunItem({
+    path: input.entry.path,
+    name: input.entry.name,
+    repoIdentifier: input.entry.repoIdentifier,
+    onLocate: input.onLocate,
+    onRemove,
+  });
 }
 
 function currentCapturedEntry(
@@ -1005,6 +1074,7 @@ function removeDisabledReasonFor(
 function unresolvedWorkspaceRunItem(input: {
   readonly path: string;
   readonly name: string;
+  readonly repoIdentifier: WorktreeWorkspaceSummary["repoIdentifier"];
   readonly onLocate: () => void;
   readonly onRemove: () => void;
 }): WorkspaceRunItem {
@@ -1024,7 +1094,7 @@ function unresolvedWorkspaceRunItem(input: {
     summary: null,
     currentIntent: null,
     defaultNewBranchName: "",
-    repoIdentifier: null,
+    repoIdentifier: input.repoIdentifier,
     isPrimary: false,
     hostClient: null,
     modeDisabled: true,
@@ -1037,6 +1107,66 @@ function unresolvedWorkspaceRunItem(input: {
     onLocate: input.onLocate,
     onRemove: input.onRemove,
   };
+}
+
+function pendingWorkspaceRunItem(input: {
+  readonly path: string;
+  readonly name: string;
+  readonly repoIdentifier: WorktreeWorkspaceSummary["repoIdentifier"];
+  readonly hostClient: HostClient<HostRpcRegistry> | null;
+  readonly onRemove: () => void;
+}): WorkspaceRunItem {
+  return {
+    key: input.path,
+    displayName: input.name,
+    displayPath: input.path,
+    unresolved: false,
+    metadataPending: true,
+    missing: false,
+    isGitRepo: false,
+    mode: "local",
+    branchLabel: "Loading",
+    hoverLabel: `${input.name} · loading`,
+    summary: null,
+    currentIntent: null,
+    defaultNewBranchName: "",
+    repoIdentifier: input.repoIdentifier,
+    isPrimary: false,
+    hostClient: input.hostClient,
+    modeDisabled: true,
+    modeDisabledReason: "Loading folder metadata",
+    removeDisabled: false,
+    removeDisabledReason: null,
+    removePending: false,
+    onSelectMode: () => undefined,
+    onEmit: () => undefined,
+    onLocate: null,
+    onRemove: input.onRemove,
+  };
+}
+
+function summaryForResolvedFolder(
+  entry: ResolvedFolder,
+  summariesByPath: ReadonlyMap<string, WorktreeWorkspaceSummary>,
+): WorktreeWorkspaceSummary | null {
+  const summary = summariesByPath.get(entry.path) ?? null;
+  if (summary === null) return null;
+  const repoIdentifier = repoIdentifierForResolvedFolder(entry);
+  if (repoIdentifier === null) return summary;
+  return { ...summary, repoIdentifier };
+}
+
+function repoIdentifierForResolvedFolder(
+  entry: ResolvedFolder,
+): WorktreeWorkspaceSummary["repoIdentifier"] {
+  return entry.kind === "local-only" ? null : entry.repoIdentifier;
+}
+
+function repoIdentifierLogValue(
+  repoIdentifier: WorktreeWorkspaceSummary["repoIdentifier"],
+): string | null {
+  if (repoIdentifier === null) return null;
+  return `${repoIdentifier.owner}/${repoIdentifier.repo}`;
 }
 
 function branchForSummary(

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -103,7 +103,6 @@ import {
   workspaceRunBranchLabel,
 } from "./workspace-run-item";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
-import { appLogger } from "@/lib/logger";
 
 /**
  * `home` swaps the bound directory; `chat` clones the chat on switch;
@@ -343,7 +342,6 @@ export function ActiveHostWorkspaceControls(
             Workspaces
           </DropdownMenuLabel>
           <HomeWorkspaceRows
-            activeHostId={activeHostId}
             workspaceSource={workspaceSource}
             resolvedFolders={resolved.folders}
             activeHostClient={activeHostClient}
@@ -371,7 +369,6 @@ export function ActiveHostWorkspaceControls(
   );
   return (
     <HomeWorkspaceRows
-      activeHostId={activeHostId}
       workspaceSource={workspaceSource}
       resolvedFolders={resolved.folders}
       activeHostClient={activeHostClient}
@@ -398,7 +395,6 @@ function fixedUnavailableHostEntry(
 }
 
 function HomeWorkspaceRows(props: {
-  readonly activeHostId: string | null;
   readonly workspaceSource: HomeWorkspaceSource;
   readonly resolvedFolders: ReadonlyArray<ResolvedFolder>;
   readonly activeHostClient: HostClient<HostRpcRegistry> | null;
@@ -549,36 +545,6 @@ function HomeWorkspaceRows(props: {
     options: { enabled: true },
   });
 
-  useEffect(() => {
-    appLogger.debug("[workspace-selector] folder metadata resolution", {
-      activeHostId: props.activeHostId,
-      folderCount: resolvedFolders.length,
-      folders: resolvedFolders.map((entry) => ({
-        kind: entry.kind,
-        path: entry.path,
-        repoIdentifier: repoIdentifierLogValue(
-          repoIdentifierForResolvedFolder(entry),
-        ),
-      })),
-      queriedPaths: queryableFolderPaths,
-      summaryFetching: summariesQuery.isFetching,
-      summaryPending: summariesQuery.isPending,
-      summaries:
-        summariesQuery.data?.workspaces.map((summary) => ({
-          path: summary.workspacePath,
-          isGitRepo: summary.isGitRepo,
-          repoIdentifier: repoIdentifierLogValue(summary.repoIdentifier),
-          worktreeCount: summary.worktrees.length,
-        })) ?? [],
-    });
-  }, [
-    props.activeHostId,
-    queryableFolderPaths,
-    resolvedFolders,
-    summariesQuery.data,
-    summariesQuery.isFetching,
-    summariesQuery.isPending,
-  ]);
   const branchesByValidationPath = useMemo<
     ReadonlyMap<string, ReadonlyArray<WorktreeBranch> | null>
   >(() => {
@@ -910,11 +876,16 @@ function workspaceRunItemForResolvedFolder(input: {
     if (unresolvedItem !== null) return unresolvedItem;
   }
 
-  const capturedEntry = currentCapturedEntry(
+  const capturedEntryForPath = currentCapturedEntry(
     input.workspaceSource.capturedIntent,
     input.entry.path,
   );
-  const mode = deriveHomeRowMode(capturedEntry, summary?.isGitRepo ?? false);
+  const isGitRepo = summary?.isGitRepo ?? false;
+  const capturedEntry = supportedCapturedEntryForSummary(
+    capturedEntryForPath,
+    isGitRepo,
+  );
+  const mode = deriveHomeRowMode(capturedEntry, isGitRepo);
   const defaultNewBranchName =
     input.defaultBranchByPath[input.entry.path] ?? "";
   const currentBranch = branchForSummary(summary);
@@ -939,7 +910,7 @@ function workspaceRunItemForResolvedFolder(input: {
     unresolved: false,
     metadataPending: summary === null && input.isFetchingSummaries,
     missing: false,
-    isGitRepo: summary?.isGitRepo ?? false,
+    isGitRepo,
     mode,
     branchLabel,
     hoverLabel: workspaceRunHoverLabel(
@@ -987,10 +958,10 @@ function workspaceRunItemForUnresolvedFolder(input: {
   readonly summary: WorktreeWorkspaceSummary | null;
   readonly workspaceSource: HomeWorkspaceSource;
 }): WorkspaceRunItem | null {
-  if (input.summary !== null && input.summary.isGitRepo) return null;
+  if (input.summary !== null) return null;
   const onRemove = (): void =>
     input.workspaceSource.removeFolder(input.entry.path);
-  if (input.summary === null && input.isFetchingSummaries) {
+  if (input.isFetchingSummaries) {
     return pendingWorkspaceRunItem({
       path: input.entry.path,
       name: input.entry.name,
@@ -1017,6 +988,14 @@ function currentCapturedEntry(
       (intentEntry) => intentEntry.workspacePath === workspacePath,
     ) ?? null
   );
+}
+
+function supportedCapturedEntryForSummary(
+  capturedEntry: WorktreeFolderIntent | null,
+  isGitRepo: boolean,
+): WorktreeFolderIntent | null {
+  if (isGitRepo) return capturedEntry;
+  return capturedEntry?.kind === "local" ? capturedEntry : null;
 }
 
 function emitHomeRowMode(input: {
@@ -1160,13 +1139,6 @@ function repoIdentifierForResolvedFolder(
   entry: ResolvedFolder,
 ): WorktreeWorkspaceSummary["repoIdentifier"] {
   return entry.kind === "local-only" ? null : entry.repoIdentifier;
-}
-
-function repoIdentifierLogValue(
-  repoIdentifier: WorktreeWorkspaceSummary["repoIdentifier"],
-): string | null {
-  if (repoIdentifier === null) return null;
-  return `${repoIdentifier.owner}/${repoIdentifier.repo}`;
 }
 
 function branchForSummary(
@@ -2092,7 +2064,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
 // No staged pick yet (`capturedEntry === null`): a git folder reflects the
 // default (new worktree); a non-git folder can only be Local. The seeding effect
 // stages a pick shortly after mount, so this is the transient pre-seed state. A
-// staged entry's own kind always wins.
+// supported staged entry's own kind wins.
 function deriveHomeRowMode(
   capturedEntry: WorktreeFolderIntent | null,
   isGitRepo: boolean,


### PR DESCRIPTION
## Summary
- Query disk metadata for unresolved workspace rows instead of skipping them.
- Recover unresolved repo rows into normal git/worktree controls when the host confirms the path is a valid git repository.
- Avoid treating disabled host queries as active metadata loading, so offline/not-ready hosts still show the actionable unavailable state.
- Add landing/new-conversation selector regression coverage.

## Tests
- `bun run --cwd traycer/clients/gui-app test -- src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx`
- `bun run --cwd traycer/clients/gui-app compile`
- `bun run --cwd traycer/clients/gui-app lint`
- `bun x -y react-doctor@latest . --verbose --offline --blocking warning --scope changed`
