### PR TITLE
Keep next-step options queueable during active turns

### DIFF
--- a/clients/gui-app/src/components/chat/segments/__tests__/text-segment-next-steps.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/text-segment-next-steps.test.tsx
@@ -109,7 +109,7 @@ describe("TextSegment next steps rendering", () => {
     expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it("locks every option in the block after a successful send", () => {
+  it("keeps unsent options enabled after a successful send", () => {
     const onSend = vi.fn(() => true);
     render(
       <TextSegment
@@ -136,7 +136,15 @@ describe("TextSegment next steps rendering", () => {
       screen.getByRole<HTMLButtonElement>("button", {
         name: "Review the changed files with /review-files",
       }).disabled,
-    ).toBe(true);
+    ).toBe(false);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Review the changed files with /review-files",
+      }),
+    );
+
+    expect(onSend).toHaveBeenCalledTimes(2);
   });
 
   it("copies a prompt from the trailing next step copy button", () => {

--- a/clients/gui-app/src/components/chat/segments/next-steps-action-group.tsx
+++ b/clients/gui-app/src/components/chat/segments/next-steps-action-group.tsx
@@ -4,7 +4,6 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
-import { cn } from "@/lib/utils";
 import type { TraycerNextStepOption } from "@/markdown/traycer-next-steps";
 
 export interface NextStepActionHandler {
@@ -16,9 +15,9 @@ interface NextStepsActionGroupProps {
   readonly blockId: string;
   readonly options: ReadonlyArray<TraycerNextStepOption>;
   readonly complete: boolean;
-  readonly locked: boolean;
+  readonly lockedOptionIds: ReadonlySet<string>;
   readonly actionHandler: NextStepActionHandler | null;
-  readonly onLock: (blockId: string) => void;
+  readonly onLockOption: (blockId: string, optionId: string) => void;
 }
 
 const COPIED_RESET_MS = 1600;
@@ -29,33 +28,30 @@ const handleCopyError = (): void => {
 
 export function NextStepsActionGroup(props: NextStepsActionGroupProps) {
   const actionHandler = props.actionHandler;
-  const disabled =
-    !props.complete ||
-    props.locked ||
-    actionHandler === null ||
-    !actionHandler.canSend;
+  const actionsDisabled =
+    !props.complete || actionHandler === null || !actionHandler.canSend;
 
   return (
     <div
-      className={cn(
-        "not-prose mt-2 flex flex-wrap items-center gap-2",
-        props.locked && "opacity-70",
-      )}
+      className="not-prose mt-2 flex flex-wrap items-center gap-2"
       data-testid="traycer-next-steps"
       data-next-steps-complete={props.complete ? "true" : "false"}
       data-quote-exclude=""
     >
-      {props.options.map((option) => (
-        <NextStepAction
-          key={option.id}
-          option={option}
-          complete={props.complete}
-          disabled={disabled}
-          actionHandler={actionHandler}
-          blockId={props.blockId}
-          onLock={props.onLock}
-        />
-      ))}
+      {props.options.map((option) => {
+        const locked = props.lockedOptionIds.has(option.id);
+        return (
+          <NextStepAction
+            key={option.id}
+            option={option}
+            complete={props.complete}
+            disabled={actionsDisabled || locked}
+            actionHandler={actionHandler}
+            blockId={props.blockId}
+            onLockOption={props.onLockOption}
+          />
+        );
+      })}
     </div>
   );
 }
@@ -66,7 +62,7 @@ interface NextStepActionProps {
   readonly disabled: boolean;
   readonly actionHandler: NextStepActionHandler | null;
   readonly blockId: string;
-  readonly onLock: (blockId: string) => void;
+  readonly onLockOption: (blockId: string, optionId: string) => void;
 }
 
 function NextStepAction(props: NextStepActionProps) {
@@ -93,7 +89,7 @@ function NextStepAction(props: NextStepActionProps) {
         onClick={() => {
           if (props.actionHandler === null || props.disabled) return;
           if (props.actionHandler.onSend(option)) {
-            props.onLock(props.blockId);
+            props.onLockOption(props.blockId, option.id);
           }
         }}
       >

--- a/clients/gui-app/src/components/chat/segments/text-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/text-segment.tsx
@@ -17,16 +17,22 @@ interface TextSegmentProps {
   nextStepActions: NextStepActionHandler | null;
 }
 
+function nextStepOptionLockKey(blockId: string, optionId: string): string {
+  return `${blockId}:${optionId}`;
+}
+
 export function TextSegment(props: TextSegmentProps) {
   const parts = useMemo(
     () => parseTraycerNextStepsMarkdown(props.markdown, props.isStreaming),
     [props.isStreaming, props.markdown],
   );
-  const [lockedBlockIds, setLockedBlockIds] = useState<ReadonlySet<string>>(
+  const [lockedOptionKeys, setLockedOptionKeys] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
-  const lockBlock = useCallback((blockId: string) => {
-    setLockedBlockIds((current) => withMemberAdded(current, blockId));
+  const lockOption = useCallback((blockId: string, optionId: string) => {
+    setLockedOptionKeys((current) =>
+      withMemberAdded(current, nextStepOptionLockKey(blockId, optionId)),
+    );
   }, []);
 
   return (
@@ -38,10 +44,10 @@ export function TextSegment(props: TextSegmentProps) {
         <TextSegmentPart
           key={part.id}
           part={part}
-          locked={lockedBlockIds.has(part.id)}
+          lockedOptionKeys={lockedOptionKeys}
           isStreaming={props.isStreaming}
           nextStepActions={props.nextStepActions}
-          onLock={lockBlock}
+          onLockOption={lockOption}
         />
       ))}
     </div>
@@ -50,10 +56,10 @@ export function TextSegment(props: TextSegmentProps) {
 
 interface TextSegmentPartProps {
   readonly part: TraycerNextStepsPart;
-  readonly locked: boolean;
+  readonly lockedOptionKeys: ReadonlySet<string>;
   readonly isStreaming: boolean;
   readonly nextStepActions: NextStepActionHandler | null;
-  readonly onLock: (blockId: string) => void;
+  readonly onLockOption: (blockId: string, optionId: string) => void;
 }
 
 function TextSegmentPart(props: TextSegmentPartProps) {
@@ -69,6 +75,14 @@ function TextSegmentPart(props: TextSegmentPartProps) {
     );
   }
 
+  const lockedOptionIds = new Set(
+    part.options
+      .filter((option) =>
+        props.lockedOptionKeys.has(nextStepOptionLockKey(part.id, option.id)),
+      )
+      .map((option) => option.id),
+  );
+
   return (
     <>
       {part.prose.length === 0 ? null : (
@@ -83,9 +97,9 @@ function TextSegmentPart(props: TextSegmentPartProps) {
         blockId={part.id}
         options={part.options}
         complete={part.complete}
-        locked={props.locked}
+        lockedOptionIds={lockedOptionIds}
         actionHandler={props.nextStepActions}
-        onLock={props.onLock}
+        onLockOption={props.onLockOption}
       />
     </>
   );

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -1461,6 +1461,41 @@ describe("<ChatTile />", () => {
     expect(chatHarness.sent).toHaveLength(0);
   });
 
+  it("disables next-step sends while a stop request is pending", async () => {
+    renderChatTile();
+
+    await waitForChatTileLoaded();
+
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage(), nextStepsAssistantMessage()],
+        activeTurn: runningActiveTurn(),
+      });
+    });
+
+    const nextStepButton = getButtonContainingText(
+      "/implementation-validation all",
+    );
+    expect(nextStepButton.disabled).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop" }));
+
+    expect(chatHarness.sent).toHaveLength(1);
+    expect(chatHarness.sent[0]?.kind).toBe("stop");
+
+    await waitFor(() => {
+      expect(nextStepButton.disabled).toBe(true);
+    });
+
+    fireEvent.click(nextStepButton);
+
+    expect(chatHarness.sent).toHaveLength(1);
+  });
+
   it("disables next-step sends while a blocking approval is pending", async () => {
     renderChatTile();
 

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -101,6 +101,7 @@ import type { ChatStreamClient } from "@traycer-clients/shared/host-transport/ch
 import type { Message } from "@traycer/protocol/persistence/epic/schemas";
 import type {
   ChatActiveTurn,
+  ChatApprovalState,
   ChatPendingInterviewState,
   ChatQueuedItem,
   ChatRunSettings,
@@ -484,6 +485,29 @@ function runningActiveTurn(): ChatActiveTurn {
     updatedAt: 3,
     reasoningEffort: null,
     serviceTier: null,
+  };
+}
+
+function stoppingActiveTurn(): ChatActiveTurn {
+  return {
+    ...runningActiveTurn(),
+    status: "stopping",
+  };
+}
+
+function approvalState(
+  approvalId: string,
+  kind: ChatApprovalState["kind"],
+): ChatApprovalState {
+  return {
+    kind,
+    approvalId,
+    toolName: kind === "plan" ? "plan" : "bash",
+    description: "Review action",
+    input: null,
+    planId: kind === "plan" ? "plan-1" : null,
+    actions: [],
+    requestedAt: 4,
   };
 }
 
@@ -1382,7 +1406,12 @@ describe("<ChatTile />", () => {
       });
     });
 
-    fireEvent.click(getButtonContainingText("/implementation-validation all"));
+    const nextStepButton = getButtonContainingText(
+      "/implementation-validation all",
+    );
+    expect(nextStepButton.disabled).toBe(false);
+
+    fireEvent.click(nextStepButton);
 
     expect(chatHarness.sent).toHaveLength(1);
     const frame = chatHarness.sent[0];
@@ -1404,6 +1433,99 @@ describe("<ChatTile />", () => {
         },
       ],
     });
+  });
+
+  it("disables next-step sends while a turn is stopping", async () => {
+    renderChatTile();
+
+    await waitForChatTileLoaded();
+
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage(), nextStepsAssistantMessage()],
+        activeTurn: stoppingActiveTurn(),
+      });
+    });
+
+    const nextStepButton = getButtonContainingText(
+      "/implementation-validation all",
+    );
+    expect(nextStepButton.disabled).toBe(true);
+
+    fireEvent.click(nextStepButton);
+
+    expect(chatHarness.sent).toHaveLength(0);
+  });
+
+  it("disables next-step sends while a blocking approval is pending", async () => {
+    renderChatTile();
+
+    await waitForChatTileLoaded();
+
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage(), nextStepsAssistantMessage()],
+        activeTurn: runningActiveTurn(),
+      });
+      chatHarness.callbacks().onApprovalRequested({
+        kind: "approvalRequested",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ARTIFACT.id,
+        approval: approvalState("approval-1", "tool"),
+      });
+    });
+
+    const nextStepButton = getButtonContainingText(
+      "/implementation-validation all",
+    );
+    expect(nextStepButton.disabled).toBe(true);
+
+    fireEvent.click(nextStepButton);
+
+    expect(chatHarness.sent).toHaveLength(0);
+  });
+
+  it("keeps next-step sends enabled for plan-only approvals", async () => {
+    renderChatTile();
+
+    await waitForChatTileLoaded();
+
+    act(() => {
+      emitChatSnapshotWithMessages({
+        callbacks: chatHarness.callbacks(),
+        access: "owner",
+        queueItems: [],
+        settings: SESSION_SETTINGS,
+        messages: [hostUserMessage(), nextStepsAssistantMessage()],
+        activeTurn: runningActiveTurn(),
+      });
+      chatHarness.callbacks().onApprovalRequested({
+        kind: "approvalRequested",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ARTIFACT.id,
+        approval: approvalState("approval-plan-1", "plan"),
+      });
+    });
+
+    const nextStepButton = getButtonContainingText(
+      "/implementation-validation all",
+    );
+    expect(nextStepButton.disabled).toBe(false);
+
+    fireEvent.click(nextStepButton);
+
+    expect(chatHarness.sent).toHaveLength(1);
+    expect(chatHarness.sent[0]?.kind).toBe("send");
   });
 
   it("sends active permission updates when the toolbar permission changes during a turn", async () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1058,8 +1058,8 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   const approvalDecisionPending = Object.values(state.pendingActions).some(
     (action) => action.action === "approvalDecision",
   );
-  const stopDisabled =
-    !canAct || stopPending || composerActiveTurnStatus === "stopping";
+  const turnStopBusy = stopPending || composerActiveTurnStatus === "stopping";
+  const stopDisabled = !canAct || turnStopBusy;
   const chatActions = useChatActions(handle);
   const restoreActionPending = useMemo(
     () =>
@@ -1306,8 +1306,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   );
   const canSendNextStep =
     canAct &&
-    !stopPending &&
-    composerActiveTurnStatus !== "stopping" &&
+    !turnStopBusy &&
     !composerHasBlockingApprovals(
       state.pendingApprovals,
       state.pendingFileEditApprovals.length,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1306,6 +1306,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   );
   const canSendNextStep =
     canAct &&
+    !stopPending &&
     composerActiveTurnStatus !== "stopping" &&
     !composerHasBlockingApprovals(
       state.pendingApprovals,

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -158,6 +158,7 @@ import {
   ChatLowerInteractionSurfaces,
   InertChatComposer,
 } from "./chat-tile-lower-surfaces";
+import { composerHasBlockingApprovals } from "./chat-approval-visibility";
 import {
   chatTileUiReducer,
   createInitialChatTileUiState,
@@ -1303,9 +1304,16 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       state.pendingUserMessages,
     ],
   );
+  const canSendNextStep =
+    canAct &&
+    composerActiveTurnStatus !== "stopping" &&
+    !composerHasBlockingApprovals(
+      state.pendingApprovals,
+      state.pendingFileEditApprovals.length,
+    );
   const sendNextStep = useCallback(
     (option: TraycerNextStepOption): boolean => {
-      if (!canAct) return false;
+      if (!canSendNextStep) return false;
       const sender = userMessageSenderForProfile(profile);
       if (sender === null) return false;
       const content = buildSubmittedChatJSONContent(
@@ -1315,14 +1323,14 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         chatActions.sendMessage(content, sender, nextStepSettings) !== null
       );
     },
-    [canAct, chatActions, nextStepSettings, profile],
+    [canSendNextStep, chatActions, nextStepSettings, profile],
   );
   const nextStepActions = useMemo(
     () => ({
-      canSend: canAct,
+      canSend: canSendNextStep,
       onSend: sendNextStep,
     }),
-    [canAct, sendNextStep],
+    [canSendNextStep, sendNextStep],
   );
   const sendImplementPlanMessage = useCallback((): boolean => {
     if (!canAct) return false;


### PR DESCRIPTION
## Summary
- lock only the clicked next-step option after a successful send so sibling options stay available
- keep next-step sends queueable during normal active turns
- align next-step send gating with composer stop and blocking-approval gates while preserving plan-only approval behavior

## Tests
- bun run test src/components/chat/segments/__tests__/text-segment-next-steps.test.tsx
- bun run test src/components/epic-canvas/__tests__/chat-tile.test.tsx
- bun run compile
- npx -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score
- bun x prettier --check src/components/epic-canvas/renderers/chat-tile.tsx src/components/epic-canvas/__tests__/chat-tile.test.tsx src/components/chat/segments/text-segment.tsx src/components/chat/segments/next-steps-action-group.tsx src/components/chat/segments/__tests__/text-segment-next-steps.test.tsx
- git diff --check