### PR TITLE
fix(gui): hide provider disabled attribution

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -478,6 +478,53 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(screen.getByText("Checking account")).toBeDefined();
   });
 
+  it("does not render disabled attribution for providers", () => {
+    providerMocks.listResult.data = {
+      providers: [
+        {
+          ...providerState({
+            providerId: "codex",
+            selected: { kind: "bundled" },
+            candidates: [],
+            envOverrides: [],
+          }),
+          enabled: false,
+          disabledBy: {
+            userId: "a7f4dd6c-7f20-44c2-b83b-fdc71c258b80",
+            handle: "teammate",
+            at: 1,
+          },
+        },
+        {
+          ...providerState({
+            providerId: "traycer",
+            selected: { kind: "bundled" },
+            candidates: [],
+            envOverrides: [],
+          }),
+          enabled: false,
+          disabledBy: {
+            userId: "0c8cedd2-b928-4980-bf87-fb9f948c23e5",
+            handle: null,
+            at: 1,
+          },
+        },
+      ],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    expect(screen.queryByText(/Disabled by/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Traycer/i }));
+
+    expect(screen.queryByText(/Disabled by/)).toBeNull();
+  });
+
   it("lists OpenCode CLI candidates for OpenRouter and mutates OpenRouter selection", () => {
     render(
       <TooltipProvider>

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -555,11 +555,6 @@ function ProviderDetail({
             {PROVIDER_DESCRIPTIONS[providerId]}
           </p>
           <ProviderAuthLine state={state} />
-          {!state.enabled && state.disabledBy !== null ? (
-            <p className="mt-0.5 text-ui-xs text-muted-foreground/80">
-              Disabled by {state.disabledBy.handle ?? state.disabledBy.userId}
-            </p>
-          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-2 text-ui-sm">
           <label htmlFor={switchId} className="text-muted-foreground">


### PR DESCRIPTION
## Summary

- Remove the "Disabled by ..." attribution line from provider settings for disabled providers.
- Add a settings panel regression test covering disabled provider states that still carry `disabledBy` metadata.

## Related issue

N/A

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [ ] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

## Verification

- `bun x eslint src/components/settings/panels/providers-settings-panel.tsx src/components/settings/panels/__tests__/providers-settings-panel.test.tsx --cache --fix --max-warnings 0`
- `bun run test src/components/settings/panels/__tests__/providers-settings-panel.test.tsx`
- `bun run compile`
- `npx -y react-doctor@latest . --verbose --diff origin/main --offline --no-score`
- Commit pre-checks: affected Nx compile/lint/format hook passed during `git commit -s`