### PR TITLE
fix(gui-app): use official Sourcegraph Amp brand icon

### DIFF
--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -41,11 +41,24 @@ export const OpenRouterIcon: HarnessIcon = (props) => (
 );
 export const KimiIcon: HarnessIcon = (props) => <KimiMono {...props} />;
 
-// Amp (Ampcode / Sourcegraph) has no lobehub entry — hand-rolled placeholder
-// bolt mark. Paints with `currentColor`, so it follows the light/dark theme.
+// Amp (Ampcode / Sourcegraph) has no lobehub entry — the official brand mark
+// (three ascending bars) from coder/registry's `sourcegraph-amp.svg`. Painted in
+// Amp's brand red so it keeps its identity in both light and dark themes, like
+// the Claude colored sunburst.
 export const AmpIcon: HarnessIcon = (props) => (
-  <svg {...props} viewBox="0 0 24 24" fill="currentColor">
-    <path d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66.19-.34.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21z" />
+  <svg {...props} viewBox="0 0 19 19" fill="none">
+    <path
+      fill="#F34E3F"
+      d="M3.41508 17.2983L7.88484 12.7653L9.51146 18.9412L11.8745 18.2949L9.52018 9.32758L0.69527 6.93747L0.066864 9.35199L6.13926 11.0015L1.68806 15.5279L3.41508 17.2983Z"
+    />
+    <path
+      fill="#F34E3F"
+      d="M16.3044 12.0436L18.6675 11.3973L16.3132 2.43003L7.48824 0.0399246L6.85984 2.45444L14.312 4.47881L16.3044 12.0436Z"
+    />
+    <path
+      fill="#F34E3F"
+      d="M12.9126 15.4902L15.2756 14.8439L12.9213 5.87659L4.09639 3.48648L3.46799 5.901L10.9201 7.92537L12.9126 15.4902Z"
+    />
   </svg>
 );
 


### PR DESCRIPTION
Replace the hand-rolled placeholder bolt mark for the Amp (Ampcode) harness with
the official three-bar Amp brand icon from coder/registry's `sourcegraph-amp.svg`,
painted in Amp brand red (`#F34E3F`) so it keeps its identity in both light and
dark themes (mirrors the Claude colored sunburst).

Paired with the Amp host-adapter changes in `traycerai/traycer-internal`.
