### PR TITLE
fix(gui): preserve restored window state on quit

### DIFF
--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -770,6 +770,7 @@ describe("RunnerIpcBridge", () => {
       ownership,
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
     windowA.sentMessages.length = 0;
@@ -819,7 +820,12 @@ describe("RunnerIpcBridge", () => {
     bridge.dispose();
   });
 
-  it("removes closed windows from per-window restore state and ownership", async () => {
+  it("prunes a closed window's per-window restore state + ownership on a deliberate mid-session close (other windows remain)", async () => {
+    // Closing one of several open windows is a deliberate mid-session close, not
+    // a quit gesture: the closed window's restore snapshot must be pruned so a
+    // relaunch does not resurrect it, while the remaining window's snapshot
+    // survives untouched. (Last-window / quit-in-progress closes PRESERVE the
+    // snapshot instead - covered by the two tests below.)
     const mod = await import("../register-runner-ipc");
     const registry = new FakeWindowRegistry();
     const windowA = buildWindow();
@@ -848,6 +854,7 @@ describe("RunnerIpcBridge", () => {
       ownership,
       perWindowState,
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
     windowA.sentMessages.length = 0;
@@ -891,6 +898,113 @@ describe("RunnerIpcBridge", () => {
     bridge.dispose();
   });
 
+  it("preserves the per-window restore snapshot when the LAST window closes (quit/leave gesture)", async () => {
+    // Win/Linux: last-window `closed` fires this listener BEFORE
+    // `window-all-closed` -> `app.quit()`, so `quitState` is not yet set. macOS:
+    // a red-light close of the last window keeps the app alive. Either way the
+    // snapshot must survive so a later quit -> relaunch (or dock `activate`)
+    // restores it.
+    const mod = await import("../register-runner-ipc");
+    const registry = new FakeWindowRegistry();
+    const windowA = buildWindow();
+    registry.add("window-a", 101, windowA);
+    const ownership = new EpicWindowOwnership(null);
+    ownership.claim("tab-a", "epic-a", "window-a");
+    const perWindowState = new PerWindowState(null);
+    perWindowState.update("window-a", {
+      epicTabs: [{ id: "tab-a", epicId: "epic-a", name: "Alpha" }],
+      activeTabId: "tab-a",
+    });
+    const bridge = new mod.RunnerIpcBridge({
+      host: new FakeHost(),
+      authnBaseUrl: "http://localhost:5005",
+      authRedirectUri: null,
+      tray: null,
+      zoomController: undefined,
+      windowRegistry: registry,
+      ownership,
+      perWindowState,
+      authSession: new DesktopAuthSession(),
+      quitState: undefined,
+    });
+    bridge.install();
+
+    const closeHandler = ipcMainState.handlers.get(
+      RunnerHostInvoke.windowsRequestClose,
+    );
+    if (closeHandler === undefined) {
+      throw new Error("windowsRequestClose handler missing");
+    }
+
+    await closeHandler(sender(101), "window-a");
+
+    expect(registry.closeRequests).toEqual(["window-a"]);
+    expect(registry.records()).toEqual([]);
+    // The snapshot is preserved (NOT cleared) for restore.
+    expect(perWindowState.get("window-a")).toMatchObject({
+      epicTabs: [{ id: "tab-a", epicId: "epic-a", name: "Alpha" }],
+      activeTabId: "tab-a",
+    });
+    bridge.dispose();
+  });
+
+  it("preserves closing windows while the shell is quitting, even when others remain", async () => {
+    // Defense-in-depth for the quit sequence: if a window `closed` event races
+    // the registry-change listener while more windows are still open during a
+    // quit, the snapshot must NOT be pruned - all windows' state is restored on
+    // the next launch.
+    const mod = await import("../register-runner-ipc");
+    const registry = new FakeWindowRegistry();
+    const windowA = buildWindow();
+    const windowB = buildWindow();
+    registry.add("window-a", 101, windowA);
+    registry.add("window-b", 202, windowB);
+    const ownership = new EpicWindowOwnership(null);
+    ownership.claim("tab-b", "epic-b", "window-b");
+    const perWindowState = new PerWindowState(null);
+    perWindowState.update("window-a", {
+      epicTabs: [{ id: "tab-a", epicId: "epic-a", name: "Alpha" }],
+      activeTabId: "tab-a",
+    });
+    perWindowState.update("window-b", {
+      epicTabs: [{ id: "tab-b", epicId: "epic-b", name: "Beta" }],
+      activeTabId: "tab-b",
+    });
+    const bridge = new mod.RunnerIpcBridge({
+      host: new FakeHost(),
+      authnBaseUrl: "http://localhost:5005",
+      authRedirectUri: null,
+      tray: null,
+      zoomController: undefined,
+      windowRegistry: registry,
+      ownership,
+      perWindowState,
+      authSession: new DesktopAuthSession(),
+      quitState: { isQuitting: () => true },
+    });
+    bridge.install();
+
+    const closeHandler = ipcMainState.handlers.get(
+      RunnerHostInvoke.windowsRequestClose,
+    );
+    if (closeHandler === undefined) {
+      throw new Error("windowsRequestClose handler missing");
+    }
+
+    // window-a is closed while window-b remains open, but the shell is quitting.
+    await closeHandler(sender(101), "window-a");
+
+    expect(perWindowState.get("window-a")).toMatchObject({
+      epicTabs: [{ id: "tab-a", epicId: "epic-a", name: "Alpha" }],
+      activeTabId: "tab-a",
+    });
+    expect(perWindowState.get("window-b")).toMatchObject({
+      epicTabs: [{ id: "tab-b", epicId: "epic-b", name: "Beta" }],
+      activeTabId: "tab-b",
+    });
+    bridge.dispose();
+  });
+
   it("moves an owned Epic into a prepared new window through the canonical open-in-new-window IPC", async () => {
     const mod = await import("../register-runner-ipc");
     const registry = new FakeWindowRegistry();
@@ -917,6 +1031,7 @@ describe("RunnerIpcBridge", () => {
       ownership,
       perWindowState,
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
 
@@ -978,6 +1093,7 @@ describe("RunnerIpcBridge", () => {
       ownership,
       perWindowState,
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
 
@@ -1037,6 +1153,7 @@ describe("RunnerIpcBridge", () => {
       ownership,
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
 
@@ -1104,6 +1221,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
     windowA.sentMessages.length = 0;
@@ -1147,6 +1265,7 @@ describe("RunnerIpcBridge", () => {
       ownership,
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
     windowA.sentMessages.length = 0;
@@ -1215,6 +1334,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
     windowA.sentMessages.length = 0;
@@ -1298,6 +1418,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
     windowA.sentMessages.length = 0;
@@ -1345,6 +1466,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
 
@@ -1413,6 +1535,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
 
@@ -1583,6 +1706,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState: new PerWindowState(null),
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
 
@@ -1698,6 +1822,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState,
       authSession: new DesktopAuthSession(),
+      quitState: undefined,
     });
     bridge.install();
 
@@ -1752,6 +1877,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState: new PerWindowState(null),
       authSession,
+      quitState: undefined,
     });
     bridge.install();
 
@@ -2368,6 +2494,7 @@ describe("RunnerIpcBridge", () => {
       ownership: new EpicWindowOwnership(null),
       perWindowState,
       authSession,
+      quitState: undefined,
     });
     bridge.install();
     windowA.sentMessages.length = 0;

--- a/clients/desktop/src/electron-main/ipc/__tests__/windows-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/windows-ipc.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { shouldPreserveClosedWindowSnapshot } from "../windows-ipc";
+
+describe("shouldPreserveClosedWindowSnapshot", () => {
+  it("prunes a deliberate mid-session close (not quitting, other windows remain)", () => {
+    expect(
+      shouldPreserveClosedWindowSnapshot({
+        quitting: false,
+        remainingWindowCount: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves the last-window close (Win/Linux window-all-closed race, macOS red-light close)", () => {
+    expect(
+      shouldPreserveClosedWindowSnapshot({
+        quitting: false,
+        remainingWindowCount: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves every closing window while quitting, even when others remain", () => {
+    expect(
+      shouldPreserveClosedWindowSnapshot({
+        quitting: true,
+        remainingWindowCount: 2,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves a quit that also happens to close the last window", () => {
+    expect(
+      shouldPreserveClosedWindowSnapshot({
+        quitting: true,
+        remainingWindowCount: 0,
+      }),
+    ).toBe(true);
+  });
+});

--- a/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
+++ b/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
@@ -131,6 +131,16 @@ export interface IpcPerWindowState {
   off(event: "change", listener: (change: PerWindowStateChange) => void): void;
 }
 
+/**
+ * Read-only view of the shell's quit lifecycle. The concrete `ShellQuitState`
+ * (main-process startup) structurally satisfies this. The windows registry-change
+ * listener consults it so a `closed` event that is part of a quit does not prune
+ * the per-window restore snapshot.
+ */
+export interface IpcShellQuitState {
+  isQuitting(): boolean;
+}
+
 type IpcAuthSessionChangeListener = (
   snapshot: DesktopAuthSessionSnapshot,
 ) => void;
@@ -257,6 +267,7 @@ export interface RunnerIpcRegistryOptions {
   readonly authSession: IpcDesktopAuthSession;
   readonly support?: IpcSupportService;
   readonly zoomController: IpcZoomController | undefined;
+  readonly quitState?: IpcShellQuitState;
 }
 
 export type RunnerIpcBridgeOptions =
@@ -281,6 +292,7 @@ export class RunnerIpcBridge {
   readonly authSession: IpcDesktopAuthSession;
   readonly support: IpcSupportService;
   readonly zoomController: IpcZoomController;
+  readonly quitState: IpcShellQuitState;
   readonly disposeFns: Array<() => void> = [];
   private readonly syncListeners: Array<{
     channel: string;
@@ -315,6 +327,7 @@ export class RunnerIpcBridge {
       this.authSession = options.authSession;
       this.support = options.support ?? new NullSupportService();
       this.zoomController = options.zoomController ?? new NullZoomController();
+      this.quitState = options.quitState ?? new NeverQuittingShellState();
     } else {
       this.windowRegistry = new SingleWindowRegistry(options.window);
       this.ownership = new NullEpicWindowOwnership();
@@ -322,6 +335,7 @@ export class RunnerIpcBridge {
       this.authSession = new DesktopAuthSession();
       this.support = new NullSupportService();
       this.zoomController = options.zoomController ?? new NullZoomController();
+      this.quitState = new NeverQuittingShellState();
     }
   }
 
@@ -970,6 +984,16 @@ class SingleWindowRegistry implements IpcWindowRegistry {
   on(_event: "change", _listener: IpcWindowRegistryChangeListener): void {}
 
   off(_event: "change", _listener: IpcWindowRegistryChangeListener): void {}
+}
+
+// Default quit-state for the single-window `window:` bridge variant (and any
+// registry-mode caller that omits `quitState`): the shell is never quitting, so
+// the registry-change listener falls back to the "last remaining window"
+// heuristic alone.
+class NeverQuittingShellState implements IpcShellQuitState {
+  isQuitting(): boolean {
+    return false;
+  }
 }
 
 class NullEpicWindowOwnership implements IpcEpicWindowOwnership {

--- a/clients/desktop/src/electron-main/ipc/windows-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/windows-ipc.ts
@@ -105,12 +105,25 @@ export function registerWindowsIpc(bridge: RunnerIpcBridge): void {
     const nextLiveWindowIds = new Set(
       bridge.windowRegistry.records().map((record) => record.windowId),
     );
+    // Only a deliberate mid-session close (other windows still open, not
+    // quitting) prunes the durable per-window restore snapshot. A close that is
+    // really a quit/leave gesture must preserve it - see
+    // `shouldPreserveClosedWindowSnapshot`.
+    const preserveClosedSnapshots = shouldPreserveClosedWindowSnapshot({
+      quitting: bridge.quitState.isQuitting(),
+      remainingWindowCount: nextLiveWindowIds.size,
+    });
     for (const windowId of liveWindowIds) {
       if (nextLiveWindowIds.has(windowId)) {
         continue;
       }
+      // Ownership is regenerated from the restored window snapshots at startup
+      // (`reconcileRestoredWindows`), so releasing it here is safe for restore
+      // and keeps live-session ownership consistent with the closed window.
       bridge.ownership.releaseWindow(windowId);
-      bridge.perWindowState.clear(windowId);
+      if (!preserveClosedSnapshots) {
+        bridge.perWindowState.clear(windowId);
+      }
     }
     liveWindowIds = nextLiveWindowIds;
     bridge.pruneClosedWindowState();
@@ -123,6 +136,32 @@ export function registerWindowsIpc(bridge: RunnerIpcBridge): void {
   });
 
   bridge.fanOut(RunnerHostEvent.windowsChange, bridge.windowRegistry.list());
+}
+
+/**
+ * Decides whether a window that just vanished from the registry should KEEP its
+ * durable per-window restore snapshot (open epic tabs, pane layout, drafts).
+ *
+ * Preserve when the close is really a quit/leave gesture:
+ *  - `quitting` - the shell has begun quitting (Cmd+Q / "Quit Traycer" / the
+ *    auto-update install re-quit). During quit no close should destroy state,
+ *    so ALL closing windows are preserved regardless of how many remain.
+ *  - `remainingWindowCount === 0` - this was the last remaining window. On
+ *    Win/Linux the native `closed` event (and this listener) fire BEFORE
+ *    `window-all-closed` -> `app.quit()` -> `before-quit`, so the `quitting`
+ *    flag is not yet set on that path; the last-window check covers the race.
+ *    On macOS a red-light close of the last window keeps the app alive, and the
+ *    snapshot must survive so a later quit -> relaunch, or a dock `activate`,
+ *    restores it.
+ *
+ * Prune only a deliberate mid-session close: another window is still open and
+ * the shell is not quitting, so relaunch must not resurrect the closed window.
+ */
+export function shouldPreserveClosedWindowSnapshot(input: {
+  readonly quitting: boolean;
+  readonly remainingWindowCount: number;
+}): boolean {
+  return input.quitting || input.remainingWindowCount === 0;
 }
 
 async function openEpicInNewWindow(

--- a/clients/desktop/src/electron-main/startup/__tests__/activate-window-plan.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/activate-window-plan.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import type { PerWindowSnapshot } from "../../../ipc-contracts/window-types";
+import type { RestorableWindowEntry } from "../../windows/desktop-state-store";
+import { planActivateWithoutLiveWindow } from "../activate-window-plan";
+
+function snapshot(patch: Partial<PerWindowSnapshot>): PerWindowSnapshot {
+  return {
+    epicTabs: [],
+    activeTabId: null,
+    canvasByTabId: {},
+    landingDrafts: [],
+    activeLandingDraftId: null,
+    ...patch,
+  };
+}
+
+function entry(
+  windowId: string,
+  patch: Partial<PerWindowSnapshot>,
+): RestorableWindowEntry {
+  return { windowId, snapshot: snapshot(patch) };
+}
+
+describe("planActivateWithoutLiveWindow", () => {
+  it("mints a blank window when there are no restorable entries", () => {
+    expect(planActivateWithoutLiveWindow([])).toEqual({ kind: "create-blank" });
+  });
+
+  it("mints a blank window when the only entries carry no tabs or drafts", () => {
+    expect(planActivateWithoutLiveWindow([entry("window-a", {})])).toEqual({
+      kind: "create-blank",
+    });
+  });
+
+  it("restores a window preserved with open epic tabs (macOS red-light-close then activate)", () => {
+    const preserved = entry("window-a", {
+      epicTabs: [{ id: "tab-a", epicId: "epic-a", name: "Alpha" }],
+      activeTabId: "tab-a",
+    });
+    expect(planActivateWithoutLiveWindow([preserved])).toEqual({
+      kind: "restore",
+      entries: [preserved],
+    });
+  });
+
+  it("restores a window preserved with only landing drafts", () => {
+    const preserved = entry("window-a", {
+      landingDrafts: [
+        {
+          id: "draft-a",
+          content: {},
+          selection: null,
+          lastTouchedAt: 0,
+          settings: null,
+          composerMode: null,
+          workspace: null,
+        },
+      ],
+      activeLandingDraftId: "draft-a",
+    });
+    expect(planActivateWithoutLiveWindow([preserved])).toEqual({
+      kind: "restore",
+      entries: [preserved],
+    });
+  });
+
+  it("restores only the content-bearing entries and drops empty ones", () => {
+    const withTabs = entry("window-a", {
+      epicTabs: [{ id: "tab-a", epicId: "epic-a", name: "Alpha" }],
+      activeTabId: "tab-a",
+    });
+    const empty = entry("window-b", {});
+    expect(planActivateWithoutLiveWindow([withTabs, empty])).toEqual({
+      kind: "restore",
+      entries: [withTabs],
+    });
+  });
+});

--- a/clients/desktop/src/electron-main/startup/__tests__/shell-quit-state.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/shell-quit-state.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { shouldPreserveClosedWindowSnapshot } from "../../ipc/windows-ipc";
+import { ShellQuitState } from "../shell-quit-state";
+
+describe("ShellQuitState", () => {
+  it("starts not quitting", () => {
+    expect(new ShellQuitState().isQuitting()).toBe(false);
+  });
+
+  it("marks quitting and reports it", () => {
+    const state = new ShellQuitState();
+    state.markQuitting();
+    expect(state.isQuitting()).toBe(true);
+  });
+
+  it("markQuitting is idempotent across the multi-pass quit", () => {
+    const state = new ShellQuitState();
+    state.markQuitting();
+    state.markQuitting();
+    expect(state.isQuitting()).toBe(true);
+  });
+
+  it("resetQuitting reverts to not-quitting after an aborted quit", () => {
+    const state = new ShellQuitState();
+    state.markQuitting();
+    state.resetQuitting();
+    expect(state.isQuitting()).toBe(false);
+  });
+
+  it("resetQuitting is idempotent when no quit was in progress", () => {
+    const state = new ShellQuitState();
+    state.resetQuitting();
+    expect(state.isQuitting()).toBe(false);
+  });
+
+  it("a quit attempt can be re-armed after resetQuitting", () => {
+    const state = new ShellQuitState();
+    state.markQuitting();
+    state.resetQuitting();
+    state.markQuitting();
+    expect(state.isQuitting()).toBe(true);
+  });
+
+  it("pins the regression: an aborted quit must not preserve a later non-last window close", () => {
+    // Mirrors `before-quit` in desktop-startup.ts: the first pass marks
+    // quitting, then a stay-alive branch (install failure / rejected quit
+    // decision / failed fresh-snapshot query) fires and must reset the flag -
+    // otherwise a later mid-session close of a non-last window is wrongly
+    // treated as part of that abandoned quit and its restore snapshot
+    // survives when it should be pruned.
+    const state = new ShellQuitState();
+    state.markQuitting();
+    state.resetQuitting();
+
+    const preserve = shouldPreserveClosedWindowSnapshot({
+      quitting: state.isQuitting(),
+      remainingWindowCount: 1,
+    });
+    expect(preserve).toBe(false);
+  });
+});

--- a/clients/desktop/src/electron-main/startup/activate-window-plan.ts
+++ b/clients/desktop/src/electron-main/startup/activate-window-plan.ts
@@ -1,0 +1,40 @@
+import type { RestorableWindowEntry } from "../windows/desktop-state-store";
+
+/**
+ * What `app.on("activate")` should do when there is no live window to focus.
+ *
+ * On macOS a red-light close of the last window keeps the app alive but leaves
+ * no window. Previously `activate` (dock click / re-open) minted a BLANK window,
+ * discarding the tabs/canvas/drafts the user had open. Now that those closes
+ * preserve the per-window restore snapshot (see
+ * `shouldPreserveClosedWindowSnapshot`), `activate` restores the preserved
+ * window(s) instead - reusing each window's original id so its preserved
+ * snapshot rebinds, exactly mirroring startup reconciliation. If nothing is
+ * restorable, fall back to a blank window.
+ */
+export type ActivateWithoutLiveWindowPlan =
+  | {
+      readonly kind: "restore";
+      readonly entries: readonly RestorableWindowEntry[];
+    }
+  | { readonly kind: "create-blank" };
+
+export function planActivateWithoutLiveWindow(
+  restorableEntries: readonly RestorableWindowEntry[],
+): ActivateWithoutLiveWindowPlan {
+  const restorable = restorableEntries.filter(hasRestorableContent);
+  if (restorable.length === 0) {
+    return { kind: "create-blank" };
+  }
+  return { kind: "restore", entries: restorable };
+}
+
+// A window with neither open epic tabs nor landing drafts restores to the same
+// blank landing surface a fresh window shows, so there is nothing to preserve;
+// treat it as "no content" and let the blank-window fallback handle it.
+function hasRestorableContent(entry: RestorableWindowEntry): boolean {
+  return (
+    entry.snapshot.epicTabs.length > 0 ||
+    entry.snapshot.landingDrafts.length > 0
+  );
+}

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -65,6 +65,9 @@ import { DesktopAuthSession } from "../auth/desktop-auth-session";
 import { DesktopSupportService } from "../app/support";
 import { MenuController } from "../menu/menu-controller";
 import { initialRouteForWindowSnapshot } from "./window-initial-route";
+import { ShellQuitState } from "./shell-quit-state";
+import { planActivateWithoutLiveWindow } from "./activate-window-plan";
+import type { RestorableWindowEntry } from "../windows/desktop-state-store";
 import { readResolutionTestDisplay } from "../windows/resolution-test-env";
 import { installNotificationActivationHandler } from "../notifications";
 import {
@@ -118,6 +121,20 @@ import { installHostWakeRecovery } from "./host-wake-recovery";
 import { DESKTOP_APP_NAME } from "../../config";
 
 const APP_DISPLAY_NAME = DESKTOP_APP_NAME;
+
+// Per-window fresh-snapshot query budget during `before-quit`. Each renderer,
+// on receiving `getFreshUnsyncedSnapshot`, first AWAITS its debounced per-window
+// projection flush (open epic tabs / pane layout / drafts -> main's
+// `PerWindowState`) and only then replies. So by the time this query resolves,
+// main's per-window state - and thus the subsequent `desktopStateStore.flush()`
+// - already reflects the latest layout. 200ms comfortably covers the two local
+// IPC round-trips (projection `update`, then the fresh-snapshot reply) a
+// responsive renderer needs - they are same-machine calls over a small JSON
+// payload, typically well under ~20ms combined. It is deliberately NOT larger:
+// the ceiling exists to bound how long quit hangs when a renderer is frozen
+// (where no timeout would help), and the cached ambient snapshot is the
+// fail-safe fallback on timeout.
+const QUIT_FRESH_UNSYNCED_SNAPSHOT_TIMEOUT_MS = 200;
 
 /**
  * Phased desktop boot.
@@ -372,6 +389,11 @@ async function runWindowPhase(state: BootState): Promise<AppServices> {
 
   const tray = await createTraySafe(createMruWindowProxy(windowRegistry));
 
+  // Flipped once `before-quit` fires (any quit path). The windows registry-change
+  // listener reads it so a `closed` event that is part of a quit never prunes the
+  // per-window restore snapshot.
+  const shellQuitState = new ShellQuitState();
+
   log.debug("[desktop] authn base URL", { authnBaseUrl: config.authnBaseUrl });
   const bridge = new RunnerIpcBridge({
     host,
@@ -387,6 +409,7 @@ async function runWindowPhase(state: BootState): Promise<AppServices> {
     authSession,
     support,
     zoomController: createdZoomController,
+    quitState: shellQuitState,
   });
   bridge.install();
   state.bridge = bridge;
@@ -444,6 +467,7 @@ async function runWindowPhase(state: BootState): Promise<AppServices> {
     tray,
     desktopStateStore,
     windowGeometryPersistence,
+    quitState: shellQuitState,
   });
 
   return { host, menu, windowRegistry, zoomController: createdZoomController };
@@ -662,6 +686,7 @@ interface LifecycleServices {
   readonly tray: DesktopTrayController | null;
   readonly desktopStateStore: DesktopStateStore;
   readonly windowGeometryPersistence: WindowGeometryPersistence;
+  readonly quitState: ShellQuitState;
 }
 
 function wireAppLifecycle(state: BootState, services: LifecycleServices): void {
@@ -674,6 +699,20 @@ function wireAppLifecycle(state: BootState, services: LifecycleServices): void {
 
   app.on("activate", () => {
     if (services.windowRegistry.focusMru()) {
+      return;
+    }
+    // No live window to focus (e.g. macOS red-light close of the last window
+    // left the app running). Restore the preserved window snapshot(s) rather
+    // than minting a blank window, so a close-then-reopen keeps the user's tabs,
+    // canvas, and drafts. Falls back to a blank window when nothing restorable
+    // survives.
+    const plan = planActivateWithoutLiveWindow(
+      services.desktopStateStore.getRestorableWindowEntries(),
+    );
+    if (plan.kind === "restore") {
+      for (const entry of plan.entries) {
+        restorePreservedWindowOnActivate(services, entry);
+      }
       return;
     }
     void services.windowRegistry.create({
@@ -715,6 +754,11 @@ function wireAppLifecycle(state: BootState, services: LifecycleServices): void {
   };
 
   app.on("before-quit", (event) => {
+    // Mark the shell as quitting on the FIRST pass, before any preventDefault or
+    // async work, so the windows registry-change listener preserves every
+    // closing window's restore snapshot for the remainder of the quit - even the
+    // non-last windows a Cmd+Q closes. Idempotent across the multi-pass quit.
+    services.quitState.markQuitting();
     if (quitAuthorized) {
       teardownShellObservers();
       return;
@@ -777,6 +821,7 @@ function wireAppLifecycle(state: BootState, services: LifecycleServices): void {
             log.info(
               "[desktop] before-quit - install failed during reconcile, staying open",
             );
+            services.quitState.resetQuitting();
             return;
           }
           authorizeQuitAfterFlush();
@@ -786,7 +831,7 @@ function wireAppLifecycle(state: BootState, services: LifecycleServices): void {
 
     event.preventDefault();
     void activeBridge
-      .requestFreshUnsyncedSnapshot(200)
+      .requestFreshUnsyncedSnapshot(QUIT_FRESH_UNSYNCED_SNAPSHOT_TIMEOUT_MS)
       .then((snapshot) => {
         if (!activeBridge.hasUnsyncedEdits()) {
           log.info(
@@ -808,11 +853,33 @@ function wireAppLifecycle(state: BootState, services: LifecycleServices): void {
           })
           .catch((err) => {
             log.warn("[desktop] quit decision failed - staying alive", err);
+            services.quitState.resetQuitting();
           });
       })
       .catch((err) => {
         log.warn("[desktop] fresh-snapshot query failed - staying alive", err);
+        services.quitState.resetQuitting();
       });
+  });
+}
+
+// Recreate a preserved window on macOS `activate`, reusing its original id so
+// the in-memory + on-disk per-window snapshot rebinds to it (the renderer reads
+// its snapshot by window id). Mirrors the startup restore path.
+function restorePreservedWindowOnActivate(
+  services: LifecycleServices,
+  entry: RestorableWindowEntry,
+): void {
+  services.windowRegistry.createWithId({
+    windowId: entry.windowId,
+    initialRoute: initialRouteForWindowSnapshot(entry.snapshot),
+    beforeLoad: null,
+  });
+  void services.windowRegistry.loadById(entry.windowId).catch((err) => {
+    log.warn("[desktop] activate restore window load failed", {
+      windowId: entry.windowId,
+      err,
+    });
   });
 }
 

--- a/clients/desktop/src/electron-main/startup/shell-quit-state.ts
+++ b/clients/desktop/src/electron-main/startup/shell-quit-state.ts
@@ -1,0 +1,39 @@
+/**
+ * Tracks whether the desktop shell has begun quitting.
+ *
+ * Set once `before-quit` fires - on ANY quit path: Cmd+Q / "Quit Traycer",
+ * the auto-update install re-quit, and the Win/Linux `window-all-closed` ->
+ * `app.quit()` cascade. Read by the windows IPC registry-change listener so a
+ * window `closed` event that is part of a quit never destroys the per-window
+ * restore snapshot.
+ *
+ * This is deliberately a tiny, explicitly-injected service (not a module-global
+ * singleton) so it composes through the same dependency wiring as the rest of
+ * the shell services and stays trivially testable.
+ */
+export interface ShellQuitStateReader {
+  isQuitting(): boolean;
+}
+
+export class ShellQuitState implements ShellQuitStateReader {
+  private quitting = false;
+
+  isQuitting(): boolean {
+    return this.quitting;
+  }
+
+  markQuitting(): void {
+    this.quitting = true;
+  }
+
+  /**
+   * Reverts to not-quitting. Called from every `before-quit` stay-alive
+   * branch (host-update-install failure, dirty-edit decision rejected/failed,
+   * fresh-snapshot query failed) so a later mid-session window close is not
+   * mistaken for part of that aborted quit attempt. Idempotent - safe to call
+   * even when a quit was never in progress.
+   */
+  resetQuitting(): void {
+    this.quitting = false;
+  }
+}

--- a/clients/gui-app/src/components/layout/__tests__/quit-intercept-bridge.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/quit-intercept-bridge.test.tsx
@@ -17,6 +17,11 @@ import {
 } from "@testing-library/react";
 import * as Y from "yjs";
 import { QuitInterceptBridge } from "@/components/layout/bridges/quit-intercept-bridge";
+import {
+  setActiveDesktopPerWindowProjectionBridge,
+  type DesktopPerWindowProjectionBridge,
+} from "@/lib/windows/per-window-projection-debounce";
+import { appLogger } from "@/lib/logger";
 import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
 
@@ -240,6 +245,7 @@ describe("QuitInterceptBridge", () => {
     vi.useRealTimers();
     clearRegistry();
     clearRunnerHost();
+    setActiveDesktopPerWindowProjectionBridge(null);
   });
 
   it("is a no-op when window.runnerHost.appLifecycle is undefined", () => {
@@ -508,6 +514,117 @@ describe("QuitInterceptBridge", () => {
       vi.advanceTimersByTime(200);
     });
     expect(fake.setUnsyncedEditsSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("defers the fresh-snapshot reply until the per-window projection flush has landed in main", async () => {
+    // The quit intercept must not answer main until the debounced per-window
+    // projection (tabs/canvas/drafts) has been flushed to main, so main's
+    // subsequent `desktopStateStore.flush()` persists the latest layout.
+    const fake = installAppLifecycleFake();
+    const registry = __getOpenEpicRegistryForTests();
+    const handleA = buildHandle("eA", "Alpha");
+    registry.acquire("eA", () => handleA);
+    handleA.setDirty(true, 4);
+
+    let resolveFlush: (() => void) | null = null;
+    const flushBridge: DesktopPerWindowProjectionBridge = {
+      update: () => Promise.resolve(),
+      flush: () =>
+        new Promise<void>((resolve) => {
+          resolveFlush = resolve;
+        }),
+      dispose: () => undefined,
+    };
+    setActiveDesktopPerWindowProjectionBridge(flushBridge);
+
+    render(<QuitInterceptBridge />);
+
+    act(() => {
+      fake.emitFreshQuery({ requestId: "req-flush" });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Flush still pending -> the reply must NOT have gone out yet.
+    expect(fake.respondFreshUnsyncedSnapshot).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveFlush?.();
+      await Promise.resolve();
+    });
+
+    expect(fake.respondFreshUnsyncedSnapshot).toHaveBeenCalledTimes(1);
+    expect(fake.respondFreshUnsyncedSnapshot.mock.calls[0][0].requestId).toBe(
+      "req-flush",
+    );
+  });
+
+  it("still replies to the fresh-snapshot query when the projection flush rejects", async () => {
+    // A failed projection write must not make main wait out its fresh-snapshot
+    // timeout and fall back to stale state - the reply still goes out.
+    const fake = installAppLifecycleFake();
+    const registry = __getOpenEpicRegistryForTests();
+    const handleA = buildHandle("eA", "Alpha");
+    registry.acquire("eA", () => handleA);
+    handleA.setDirty(true, 4);
+
+    const flushBridge: DesktopPerWindowProjectionBridge = {
+      update: () => Promise.resolve(),
+      flush: () => Promise.reject(new Error("projection flush failed")),
+      dispose: () => undefined,
+    };
+    setActiveDesktopPerWindowProjectionBridge(flushBridge);
+
+    render(<QuitInterceptBridge />);
+
+    act(() => {
+      fake.emitFreshQuery({ requestId: "req-reject" });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(fake.respondFreshUnsyncedSnapshot).toHaveBeenCalledTimes(1);
+    expect(fake.respondFreshUnsyncedSnapshot.mock.calls[0][0].requestId).toBe(
+      "req-reject",
+    );
+  });
+
+  it("does not leave an unhandled rejection when the fresh-snapshot reply IPC itself rejects", async () => {
+    // `respondFreshUnsyncedSnapshot` is an `ipcRenderer.invoke` that can
+    // reject (main handler removed / sender gone). The response chain must
+    // terminate in a `.catch` rather than surfacing an unhandled rejection.
+    const errorSpy = vi
+      .spyOn(appLogger, "error")
+      .mockImplementation(() => undefined);
+    const fake = installAppLifecycleFake();
+    fake.respondFreshUnsyncedSnapshot.mockImplementation(() =>
+      Promise.reject(new Error("ipc channel closed")),
+    );
+    const registry = __getOpenEpicRegistryForTests();
+    const handleA = buildHandle("eA", "Alpha");
+    registry.acquire("eA", () => handleA);
+    handleA.setDirty(true, 4);
+
+    render(<QuitInterceptBridge />);
+
+    act(() => {
+      fake.emitFreshQuery({ requestId: "req-ipc-rejects" });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[quit-intercept] fresh-snapshot reply failed",
+      { requestId: "req-ipc-rejects" },
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
   });
 
   it("preserves quit interception when the desktop bridge has not added fresh-query hooks yet", () => {

--- a/clients/gui-app/src/components/layout/bridges/quit-intercept-bridge.tsx
+++ b/clients/gui-app/src/components/layout/bridges/quit-intercept-bridge.tsx
@@ -14,6 +14,7 @@ import {
   type UnsyncedEditsEntry,
 } from "@/stores/epics/open-epic/session-registry";
 import { flushActiveDesktopPerWindowProjection } from "@/lib/windows/per-window-projection-debounce";
+import { appLogger } from "@/lib/logger";
 
 /**
  * Terminal decision returned by the renderer to the Electron main process
@@ -116,10 +117,19 @@ export function QuitInterceptBridge(): null | React.ReactElement {
 
   useDebouncedPushSnapshot(appLifecycle, liveUnsynced, cancelAmbientPushRef);
 
-  // Respond to main's fresh-snapshot query synchronously from the live
-  // registry. This is the authoritative source of truth during `before-quit`
-  // - cancel any in-flight ambient debounce so main does not observe a
-  // stale push right after our fresh reply.
+  // Respond to main's fresh-snapshot query from the live registry. This is the
+  // authoritative source of truth during `before-quit` - cancel any in-flight
+  // ambient debounce so main does not observe a stale push right after our fresh
+  // reply.
+  //
+  // Crucially, AWAIT the per-window projection flush before replying: the flush
+  // resolves only once its `perWindowState.update` IPC has been processed by
+  // main, so main's `PerWindowState` (and the `desktopStateStore.flush()` it
+  // runs right after this query resolves) already reflects the latest tabs /
+  // canvas / drafts. Because we await the projection IPC before sending the
+  // reply IPC, main processes them in order and the layout can't be lost to the
+  // quit. Reply even if the flush rejects - a failed projection write must not
+  // make main wait out its fresh-snapshot timeout and fall back to stale state.
   useEffect(() => {
     if (appLifecycle === null) return;
     const onGet = appLifecycle.onGetFreshUnsyncedSnapshot;
@@ -128,9 +138,20 @@ export function QuitInterceptBridge(): null | React.ReactElement {
     const subscription = onGet((request) => {
       cancelAmbientPushRef.current();
       const snapshot = registry.getUnsyncedEdits();
-      void flushActiveDesktopPerWindowProjection().then(() =>
-        respond({ requestId: request.requestId, snapshot }),
-      );
+      const reply = (): Promise<void> =>
+        respond({ requestId: request.requestId, snapshot });
+      void flushActiveDesktopPerWindowProjection()
+        .then(reply, reply)
+        .catch((error: unknown) => {
+          // `reply()` itself is an `ipcRenderer.invoke` that can reject (main
+          // handler removed / sender gone). Never rethrow - main's own
+          // fresh-snapshot timeout is the fallback.
+          appLogger.error(
+            "[quit-intercept] fresh-snapshot reply failed",
+            { requestId: request.requestId },
+            error,
+          );
+        });
     });
     return () => {
       subscription.dispose();

--- a/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
+++ b/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
@@ -211,6 +211,101 @@ describe("createPersistentMemoryHistory", () => {
 
     expect(secondWindow.location.pathname).toBe("/draft/shared");
   });
+
+  it("preserves the full remembered stack and cursor on a cold restore whose shell override matches the current entry", () => {
+    // Simulates the Bug 2 cold restore: a full quit wiped sessionStorage (so the
+    // consumed-marker is absent and the override applies), and main derives the
+    // initial route from the SAME snapshot the stack was persisted under - so the
+    // override equals the persisted current entry. The deep back/forward history
+    // must survive rather than collapse to a single entry.
+    const entries = [
+      "/epics/epic-a/tab-a",
+      "/epics/epic-b/tab-b",
+      "/draft/draft-a",
+      "/epics/epic-c/tab-c",
+      "/draft/draft-b",
+      "/epics/epic-d/tab-d",
+      "/draft/552a2b55",
+    ];
+    window.localStorage.setItem(
+      storageKey("window-a"),
+      JSON.stringify({ entries, index: 6 }),
+    );
+
+    const history = createPersistentMemoryHistory(
+      "/draft/552a2b55",
+      "window-a",
+    );
+    const controller = controllerOf(history);
+
+    expect(controller.getEntries()).toEqual(entries);
+    expect(controller.getIndex()).toBe(6);
+    expect(history.location.pathname).toBe("/draft/552a2b55");
+    expect(readPersisted("window-a")).toEqual({ entries, index: 6 });
+  });
+
+  it("appends the shell override and truncates forward history when it differs from the current entry", () => {
+    // Cursor sits back-deep in the stack; the override is a route not equal to
+    // the current entry. It is treated like a fresh navigation: forward entries
+    // are dropped, the override is appended, and back history up to the previous
+    // current entry survives.
+    window.localStorage.setItem(
+      storageKey("window-a"),
+      JSON.stringify({
+        entries: [
+          "/epics/epic-a/tab-a",
+          "/epics/epic-b/tab-b",
+          "/epics/epic-c/tab-c",
+          "/epics/epic-d/tab-d",
+        ],
+        index: 1,
+      }),
+    );
+
+    const history = createPersistentMemoryHistory("/draft/draft-z", "window-a");
+    const controller = controllerOf(history);
+
+    expect(controller.getEntries()).toEqual([
+      "/epics/epic-a/tab-a",
+      "/epics/epic-b/tab-b",
+      "/draft/draft-z",
+    ]);
+    expect(controller.getIndex()).toBe(2);
+    expect(history.location.pathname).toBe("/draft/draft-z");
+  });
+
+  it("caps an oversized remembered stack around the cursor when the override matches the current entry", () => {
+    // A legacy/oversized persisted stack (200 entries) whose cursor is the tail.
+    // The matching override keeps the full stack, then `capStackInPlace` bounds
+    // it to MAX_ENTRIES around the cursor without dropping the current entry.
+    const oversized = Array.from(
+      { length: 200 },
+      (_unused, i) => `/epics/epic-${i}/tab-${i}`,
+    );
+    const current = oversized[oversized.length - 1];
+    window.localStorage.setItem(
+      storageKey("window-a"),
+      JSON.stringify({ entries: oversized, index: oversized.length - 1 }),
+    );
+
+    const history = createPersistentMemoryHistory(current, "window-a");
+    const controller = controllerOf(history);
+
+    expect(controller.getEntries().length).toBe(100);
+    expect(controller.getEntries()[controller.getIndex()]).toBe(current);
+    expect(history.location.pathname).toBe(current);
+  });
+
+  it("seeds the override alone on a fresh window with nothing remembered", () => {
+    const history = createPersistentMemoryHistory(
+      "/epics/epic-a/tab-a",
+      "window-a",
+    );
+    const controller = controllerOf(history);
+
+    expect(controller.getEntries()).toEqual(["/epics/epic-a/tab-a"]);
+    expect(controller.getIndex()).toBe(0);
+  });
 });
 
 describe("getHistoryController", () => {

--- a/clients/gui-app/src/lib/has-restored-tabs.ts
+++ b/clients/gui-app/src/lib/has-restored-tabs.ts
@@ -1,0 +1,21 @@
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useTabsStore } from "@/stores/tabs/store";
+
+/**
+ * `true` when this window already holds restorable content - an open tab, a
+ * canvas epic tab, or a landing draft.
+ *
+ * Reads the three stores synchronously, so callers must decide when it is safe
+ * to trust the answer. In Electron the stores are authoritative only AFTER
+ * `WindowsBridgeProvider` has applied the per-window desktop snapshot; before
+ * that they hold stale localStorage residue. Route guards run on preload and
+ * cannot await hydration, so the `/draft/new` creation path re-checks this once
+ * `useWindowsBridgeHydrated()` reports the snapshot has landed.
+ */
+export function hasRestoredTabs(): boolean {
+  if (useTabsStore.getState().stripOrder.length > 0) return true;
+  if (useEpicCanvasStore.getState().openTabOrder.length > 0) return true;
+  if (useLandingDraftStore.getState().drafts.length > 0) return true;
+  return false;
+}

--- a/clients/gui-app/src/lib/persistent-history.ts
+++ b/clients/gui-app/src/lib/persistent-history.ts
@@ -143,20 +143,27 @@ function buildConsumedInitialRouteKey(
   return `${CONSUMED_INITIAL_ROUTE_KEY_PREFIX}:${windowId ?? "unknown"}:${initialRoute}`;
 }
 
-function loadPersistedState(windowId: string | null): PersistedState {
-  if (typeof window === "undefined") return { entries: ["/"], index: 0 };
-  if (windowId === null) return { entries: ["/"], index: 0 };
+/**
+ * Loads this window's remembered stack, or `null` when nothing usable is
+ * stored (no key, rejected shape, or read failure). Returning `null` - rather
+ * than a `{ entries: ["/"], index: 0 }` default - lets the seed logic tell a
+ * genuinely empty window apart from one whose current entry happens to be `/`,
+ * which matters when merging a shell override into the remembered stack.
+ */
+function loadPersistedState(windowId: string | null): PersistedState | null {
+  if (typeof window === "undefined") return null;
+  if (windowId === null) return null;
   const storageKey = buildStorageKey(windowId);
   try {
     const raw = window.localStorage.getItem(storageKey);
-    if (raw === null) return { entries: ["/"], index: 0 };
+    if (raw === null) return null;
     const parsed: unknown = JSON.parse(raw);
     if (!isPersistedState(parsed)) {
       appLogger.warn("[history] persisted route state rejected", {
         windowId,
       });
       removePersistedState(storageKey);
-      return { entries: ["/"], index: 0 };
+      return null;
     }
     const safeIndex = Math.min(
       Math.max(parsed.index, 0),
@@ -169,7 +176,7 @@ function loadPersistedState(windowId: string | null): PersistedState {
       error: describeLogError(error),
     });
     removePersistedState(storageKey);
-    return { entries: ["/"], index: 0 };
+    return null;
   }
 }
 
@@ -357,10 +364,53 @@ function capStackInPlace(
 }
 
 /**
- * Creates a router history seeded from the explicit `initialRoute` override,
- * or from this window's `localStorage` history when the shell provides no
- * route. Intended for the Electron renderer only - the browser web app should
- * use TanStack's default browser history.
+ * Resolves the seed stack (entries + cursor) from the remembered stack and the
+ * shell override. The override is MERGED into the remembered stack rather than
+ * replacing it, so a cold restore keeps the window's back/forward history:
+ *
+ * - No override → restore the remembered stack verbatim (or the bare landing
+ *   when nothing is stored).
+ * - Bare-`/` override → landing seed; the caller has already cleared any
+ *   remembered stack (see `createPersistentMemoryHistory`).
+ * - Override with nothing stored → seed the override alone (fresh window).
+ * - Override equals the remembered current entry → keep the full remembered
+ *   stack + cursor unchanged. This is the restored-launch common case: main
+ *   derives the initial route FROM the same snapshot the stack was persisted
+ *   under, so the two agree and the deep back-history survives. (Bug fix: the
+ *   old code reset to `[override], index 0`, collapsing the stack on every cold
+ *   restore because the sessionStorage consumed-marker never survives a quit.)
+ * - Override differs from the remembered current entry → treat it like a fresh
+ *   navigation: drop forward entries beyond the cursor, append the override,
+ *   and point the cursor at it. Back history up to the previous current entry
+ *   survives.
+ */
+function computeSeededStack(
+  persisted: PersistedState | null,
+  shellOverride: string | null,
+): { entries: string[]; index: number } {
+  if (shellOverride === null) {
+    if (persisted === null) return { entries: ["/"], index: 0 };
+    return { entries: [...persisted.entries], index: persisted.index };
+  }
+  if (shellOverride === "/") return { entries: ["/"], index: 0 };
+  if (persisted === null) return { entries: [shellOverride], index: 0 };
+  if (persisted.entries[persisted.index] === shellOverride) {
+    return { entries: [...persisted.entries], index: persisted.index };
+  }
+  return {
+    entries: [
+      ...persisted.entries.slice(0, persisted.index + 1),
+      shellOverride,
+    ],
+    index: persisted.index + 1,
+  };
+}
+
+/**
+ * Creates a router history seeded from the explicit `initialRoute` override
+ * merged into this window's `localStorage` history, or from that history alone
+ * when the shell provides no route. Intended for the Electron renderer only -
+ * the browser web app should use TanStack's default browser history.
  */
 export function createPersistentMemoryHistory(
   initialRoute: string | null,
@@ -369,15 +419,22 @@ export function createPersistentMemoryHistory(
   const persisted = loadPersistedState(windowId);
   const shellOverride = consumeShellOverride(initialRoute, windowId);
   if (shellOverride === "/") {
+    // A bare-`/` shell override is the deliberate "start at the landing" signal:
+    // the zero-restorable-windows cold start and the auth-fallback redirect both
+    // funnel through it. Discard the remembered stack rather than merging - the
+    // landing is meant to be a clean start, not the tail of a deep back-history
+    // to routes the snapshot no longer references. `persistState` already refuses
+    // to write a `/` current entry, so the immediate persist below leaves
+    // localStorage cleared.
     clearPersistedState(windowId);
   }
 
-  const entries: string[] =
-    shellOverride !== null ? [shellOverride] : [...persisted.entries];
+  const seed = computeSeededStack(persisted, shellOverride);
+  const entries: string[] = seed.entries;
   const states: LocationState[] = entries.map((_entry, i) =>
     makeInitialState(i),
   );
-  let index = shellOverride !== null ? 0 : persisted.index;
+  let index = seed.index;
   // Bound a legacy/oversized seed before anything reads the stack.
   index = capStackInPlace(entries, states, index);
 

--- a/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
@@ -384,6 +384,36 @@ describe("<WindowsBridgeProvider />", () => {
     });
   });
 
+  it("still marks hydration complete when the per-window snapshot fetch rejects", async () => {
+    const fake = createDesktopWindowsBridge();
+    const failingBridge = {
+      ...fake.bridge,
+      perWindowState: {
+        ...fake.bridge.perWindowState,
+        get: () => Promise.reject(new Error("perWindowState.get failed")),
+      },
+    } satisfies DesktopWindowsBridge;
+
+    render(
+      <RunnerHostProvider
+        runnerHost={createRunnerHostWithWindows(failingBridge)}
+      >
+        <WindowsBridgeProvider>
+          <HydrationProbe />
+        </WindowsBridgeProvider>
+      </RunnerHostProvider>,
+    );
+
+    expect(screen.getByTestId("hydration-state").textContent).toBe("pending");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("hydration-state").textContent).toBe(
+        "hydrated",
+      );
+    });
+    expect(fake.perWindowUpdates).toEqual([]);
+  });
+
   it("does not write the restored per-window snapshot back during first hydration", async () => {
     vi.useFakeTimers();
     const fake = createDesktopWindowsBridge();

--- a/clients/gui-app/src/providers/windows-bridge-provider.tsx
+++ b/clients/gui-app/src/providers/windows-bridge-provider.tsx
@@ -7,6 +7,7 @@ import {
 import { WindowsBridgeContext } from "@/providers/windows-bridge-context";
 import type { WindowsBridgeContextValue } from "@/providers/windows-bridge-context";
 import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
+import { appLogger } from "@/lib/logger";
 import {
   applyEpicCanvasDesktopProjection,
   setEpicCanvasDesktopProjectionBridge,
@@ -146,6 +147,18 @@ function installDesktopWindowsBridge(
     bridge.perWindowState,
     DESKTOP_PER_WINDOW_PROJECTION_DEBOUNCE_MS,
   );
+  // Best-effort flush on document teardown (reload / navigation / a window close
+  // that does NOT route through the quit intercept). Unlike the `before-quit`
+  // fresh-snapshot path - which AWAITS this same flush before answering main -
+  // unload handlers cannot await a promise, so we can only kick the flush and
+  // return. `flush()` enqueues the pending patch's `perWindowState.update` IPC
+  // send on the microtask queue, which the browser drains before it proceeds
+  // with the unload, so the send does leave the renderer. Residual gap: if a
+  // prior projection `update` is still in flight when this fires, the new patch
+  // is chained behind it and may not send before teardown; and main is not
+  // guaranteed to finish processing an in-flight send before the renderer dies.
+  // The deliberate quit path (Cmd+Q / "Quit Traycer") does not rely on this - it
+  // uses the awaited fresh-snapshot flush - so this remains a fallback only.
   const flushProjection = (): void => {
     void projectionBridge.flush();
   };
@@ -166,9 +179,22 @@ function installDesktopWindowsBridge(
 
   void (async () => {
     if (isCancelled()) return;
-    const snapshot = await bridge.perWindowState.get();
-    if (isCancelled()) return;
-    applyPerWindowSnapshot(snapshot);
+    try {
+      const snapshot = await bridge.perWindowState.get();
+      if (isCancelled()) return;
+      applyPerWindowSnapshot(snapshot);
+    } catch (error) {
+      if (isCancelled()) return;
+      // Fall back to not applying a snapshot (empty/absent snapshot
+      // semantics) rather than leaving hydration permanently pending - a
+      // route gated on `useWindowsBridgeHydrated()` (e.g. `/draft/new`) would
+      // otherwise spin forever.
+      appLogger.error(
+        "[windows-bridge] per-window snapshot hydration failed",
+        {},
+        error,
+      );
+    }
     queueMicrotask(() => {
       if (!lifecycle.cancelled) {
         completeWindowsBridgeHydration(hydrationRequest);

--- a/clients/gui-app/src/routes/__tests__/draft-new-route.test.tsx
+++ b/clients/gui-app/src/routes/__tests__/draft-new-route.test.tsx
@@ -1,0 +1,104 @@
+import "../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { WindowsBridgeContext } from "@/providers/windows-bridge-context";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useTabsStore } from "@/stores/tabs/store";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  createDraftAndReplaceRoute: vi.fn(),
+}));
+
+vi.mock("@/lib/draft-entry-route", () => ({
+  createDraftAndReplaceRoute: mocks.createDraftAndReplaceRoute,
+}));
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@tanstack/react-router")>();
+  return { ...actual, useNavigate: () => mocks.navigate };
+});
+
+import { DraftNewRoute } from "@/routes/draft-new-route-components";
+
+function renderGated(hasHydrated: boolean) {
+  return render(
+    <WindowsBridgeContext.Provider value={{ bridge: null, hasHydrated }}>
+      <DraftNewRoute />
+    </WindowsBridgeContext.Provider>,
+  );
+}
+
+beforeEach(() => {
+  mocks.navigate.mockReset();
+  mocks.createDraftAndReplaceRoute.mockReset();
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+  useTabsStore.setState({
+    stripOrder: [],
+    systemTabs: { history: null, settings: null },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DraftNewRoute hydration gate", () => {
+  it("does not mint a draft or navigate until the windows bridge has hydrated", () => {
+    renderGated(false);
+
+    expect(mocks.createDraftAndReplaceRoute).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("mints a draft once hydrated when no tabs were restored", async () => {
+    renderGated(true);
+
+    await waitFor(() => {
+      expect(mocks.createDraftAndReplaceRoute).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it("routes back to the restored workspace instead of minting when hydration reveals a restored tab", async () => {
+    useTabsStore.setState({
+      stripOrder: [{ kind: "history", id: "history" }],
+      systemTabs: {
+        history: {
+          id: "history",
+          kind: "history",
+          name: "History",
+          lastPath: null,
+        },
+        settings: null,
+      },
+    });
+
+    renderGated(true);
+
+    await waitFor(() => {
+      expect(mocks.navigate).toHaveBeenCalledWith({ to: "/", replace: true });
+    });
+    expect(mocks.createDraftAndReplaceRoute).not.toHaveBeenCalled();
+  });
+
+  it("defers the decision through a pending→hydrated transition (no draft while pending)", async () => {
+    const view = renderGated(false);
+    expect(mocks.createDraftAndReplaceRoute).not.toHaveBeenCalled();
+
+    view.rerender(
+      <WindowsBridgeContext.Provider
+        value={{ bridge: null, hasHydrated: true }}
+      >
+        <DraftNewRoute />
+      </WindowsBridgeContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.createDraftAndReplaceRoute).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/clients/gui-app/src/routes/draft-new-route-components.tsx
+++ b/clients/gui-app/src/routes/draft-new-route-components.tsx
@@ -2,16 +2,33 @@ import { useEffect, useRef } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { createDraftAndReplaceRoute } from "@/lib/draft-entry-route";
+import { hasRestoredTabs } from "@/lib/has-restored-tabs";
+import { useWindowsBridgeHydrated } from "@/providers/windows-bridge-context";
 
 export function DraftNewRoute() {
   const navigate = useNavigate();
-  const didCreateRef = useRef(false);
+  // In Electron the `/` guard may redirect here off a stale-empty store read
+  // (the per-window snapshot lands asynchronously). Wait for the windows-bridge
+  // snapshot before deciding, so we don't mint a spurious draft over restored
+  // content. In the browser there is no snapshot: `useWindowsBridgeHydrated()`
+  // reports `true` immediately, so this gate is a no-op there.
+  const hydrated = useWindowsBridgeHydrated();
+  const didActRef = useRef(false);
 
   useEffect(() => {
-    if (didCreateRef.current) return;
-    didCreateRef.current = true;
+    if (!hydrated) return;
+    if (didActRef.current) return;
+    didActRef.current = true;
+    // Hydration may have revealed tabs/drafts the stale `/` read missed, or a
+    // draft this window already minted (guards the signed-out → signed-in
+    // `beforeLoad` replay against a duplicate mint). Hand the user back to the
+    // restored workspace instead of creating another draft.
+    if (hasRestoredTabs()) {
+      void navigate({ to: "/", replace: true });
+      return;
+    }
     createDraftAndReplaceRoute(navigate);
-  }, [navigate]);
+  }, [hydrated, navigate]);
 
   return (
     <div className="flex min-h-0 flex-1 items-center justify-center">

--- a/clients/gui-app/src/routes/index.tsx
+++ b/clients/gui-app/src/routes/index.tsx
@@ -1,11 +1,14 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { RootLandingPage } from "@/components/layout/root-landing-page";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
-import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
-import { useTabsStore } from "@/stores/tabs/store";
+import { hasRestoredTabs } from "@/lib/has-restored-tabs";
 
 export const Route = createFileRoute("/")({
-  // Sends a signed-in user with no restored tabs to a fresh draft.
+  // Sends a signed-in user with no restored tabs to a fresh draft. In Electron
+  // the stores this reads are only authoritative after the windows-bridge
+  // snapshot has hydrated; `beforeLoad` runs on preload and cannot await that,
+  // so a stale-empty read here may over-redirect to `/draft/new`. That is safe:
+  // `DraftNewRoute` gates the actual draft creation on hydration and re-checks
+  // `hasRestoredTabs()` before minting (see draft-new-route-components.tsx).
   beforeLoad: ({ context }) => {
     if (context.getAuthSnapshot().status !== "signed-in") return;
     if (hasRestoredTabs()) return;
@@ -13,10 +16,3 @@ export const Route = createFileRoute("/")({
   },
   component: RootLandingPage,
 });
-
-function hasRestoredTabs(): boolean {
-  if (useTabsStore.getState().stripOrder.length > 0) return true;
-  if (useEpicCanvasStore.getState().openTabOrder.length > 0) return true;
-  if (useLandingDraftStore.getState().drafts.length > 0) return true;
-  return false;
-}


### PR DESCRIPTION
## Summary
- preserve per-window restore snapshots during quit and last-window close paths
- keep restored route history instead of collapsing it to the shell initialRoute
- gate fresh draft creation on per-window hydration and await projection flush during quit

## Verification
- pre-commit run --all-files
