### PR TITLE
fix(gui-app): gate resources.subscribe behind resource-UI settings

### DIFF
--- a/clients/gui-app/src/providers/__tests__/resources-stream-mount.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/resources-stream-mount.test.tsx
@@ -1,0 +1,113 @@
+import "../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { ResourcesStreamMount } from "@/providers/resources-stream-mount";
+import { __setResourcesStreamClientFactoryForTests } from "@/providers/resources-stream-factory-override";
+import { resourcesRegistry } from "@/stores/resources/resources-registry";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+
+function installStubFactory(): void {
+  __setResourcesStreamClientFactoryForTests(() => ({
+    close: () => undefined,
+  }));
+}
+
+function setResourceUiSettings(
+  showGlobalResourceMonitor: boolean,
+  showNavigatorResourceStats: boolean,
+): void {
+  useSettingsStore.setState({
+    showGlobalResourceMonitor,
+    showNavigatorResourceStats,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  __setResourcesStreamClientFactoryForTests(null);
+  resourcesRegistry.disposeAll();
+  setResourceUiSettings(true, false);
+});
+
+describe("<ResourcesStreamMount />", () => {
+  it("acquires nothing when both resource-UI settings are off", () => {
+    installStubFactory();
+    setResourceUiSettings(false, false);
+
+    render(<ResourcesStreamMount epicId="epic-1" />);
+
+    expect(resourcesRegistry.get("epic-1")).toBeNull();
+  });
+
+  it("acquires the registry entry when the global monitor setting is on", () => {
+    installStubFactory();
+    setResourceUiSettings(true, false);
+
+    render(<ResourcesStreamMount epicId="epic-1" />);
+
+    expect(resourcesRegistry.get("epic-1")).not.toBeNull();
+  });
+
+  it("acquires the registry entry when the navigator chips setting is on", () => {
+    installStubFactory();
+    setResourceUiSettings(false, true);
+
+    render(<ResourcesStreamMount epicId="epic-1" />);
+
+    expect(resourcesRegistry.get("epic-1")).not.toBeNull();
+  });
+
+  it("acquires live when a setting flips on mid-session, without remounting", () => {
+    installStubFactory();
+    setResourceUiSettings(false, false);
+
+    render(<ResourcesStreamMount epicId="epic-1" />);
+    expect(resourcesRegistry.get("epic-1")).toBeNull();
+
+    act(() => {
+      setResourceUiSettings(true, false);
+    });
+
+    expect(resourcesRegistry.get("epic-1")).not.toBeNull();
+  });
+
+  it("releases live when the last-on setting flips off mid-session", () => {
+    installStubFactory();
+    setResourceUiSettings(true, false);
+
+    render(<ResourcesStreamMount epicId="epic-1" />);
+    expect(resourcesRegistry.get("epic-1")).not.toBeNull();
+
+    act(() => {
+      setResourceUiSettings(false, false);
+    });
+
+    expect(resourcesRegistry.get("epic-1")).toBeNull();
+  });
+
+  it("keeps the entry held while at least one setting stays on", () => {
+    installStubFactory();
+    setResourceUiSettings(true, true);
+
+    render(<ResourcesStreamMount epicId="epic-1" />);
+    expect(resourcesRegistry.get("epic-1")).not.toBeNull();
+
+    act(() => {
+      setResourceUiSettings(false, true);
+    });
+
+    expect(resourcesRegistry.get("epic-1")).not.toBeNull();
+  });
+
+  it("releases the entry on unmount", () => {
+    installStubFactory();
+    setResourceUiSettings(true, false);
+
+    const { unmount } = render(<ResourcesStreamMount epicId="epic-1" />);
+    expect(resourcesRegistry.get("epic-1")).not.toBeNull();
+
+    unmount();
+
+    expect(resourcesRegistry.get("epic-1")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/providers/resources-stream-mount.tsx
+++ b/clients/gui-app/src/providers/resources-stream-mount.tsx
@@ -10,6 +10,7 @@ import {
   type ResourcesStreamClientFactory,
 } from "@/stores/resources/resources-store";
 import { getResourcesStreamClientFactoryOverride } from "@/providers/resources-stream-factory-override";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 
 export interface ResourcesStreamMountProps {
   readonly epicId: string;
@@ -24,6 +25,11 @@ export interface ResourcesStreamMountProps {
  *
  * Deferred until the stream client binds (`useWsStreamClient()` is `null` during
  * the initial host-hydration gap); the effect re-runs when it becomes available.
+ *
+ * Gated behind the settings that actually consume resource data (the header
+ * popover and the sidebar chips) — with both off, no consumer would ever read
+ * the entry, so the stream stays closed. Both booleans join the effect deps so
+ * toggling a setting live acquires/releases without remounting the pane.
  */
 export function ResourcesStreamMount(
   props: ResourcesStreamMountProps,
@@ -32,9 +38,16 @@ export function ResourcesStreamMount(
   const wsStreamClient = useWsStreamClient();
   const resourcesSupport = useStreamMethodSupport("resources.subscribe");
   const resourcesUnsupported = resourcesSupport === "unsupported";
+  const showGlobalResourceMonitor = useSettingsStore(
+    (state) => state.showGlobalResourceMonitor,
+  );
+  const showNavigatorResourceStats = useSettingsStore(
+    (state) => state.showNavigatorResourceStats,
+  );
+  const streamWanted = showGlobalResourceMonitor || showNavigatorResourceStats;
 
   useEffect(() => {
-    if (resourcesUnsupported) return;
+    if (resourcesUnsupported || !streamWanted) return;
     const override = getResourcesStreamClientFactoryOverride();
     if (override === null && wsStreamClient === null) return;
     // Token identifies the transport this entry is bound to; a host swap changes
@@ -61,7 +74,7 @@ export function ResourcesStreamMount(
     return () => {
       resourcesRegistry.release(epicId);
     };
-  }, [epicId, resourcesUnsupported, wsStreamClient]);
+  }, [epicId, resourcesUnsupported, streamWanted, wsStreamClient]);
 
   return null;
 }


### PR DESCRIPTION
## Summary
- `ResourcesStreamMount` acquired a `resources.subscribe` stream for every open epic pane unconditionally, even when neither resource-usage setting was on.
- Gates acquisition behind `showGlobalResourceMonitor || showNavigatorResourceStats`, with both settings joined into the effect's deps so a live toggle acquires/releases without remounting the pane.
- No consumer-side changes needed — chips/popover already degrade to the empty-store fallback when no registry entry exists.

Part of a host+GUI perf fix for the resource-tracking sampler feature (traycer-internal #4257 follow-up). Companion host-side PR: traycerai/traycer-internal (two-tier sampler cadence + collision-safe change key).

## Related issue

Root-caused as part of investigating post-v1.1.4 sluggishness — the resource tracker's 1Hz sampler plus this always-on stream were the primary contributors.

## Test plan
- [x] `bun run compile` (gui-app)
- [x] `bun run test` (gui-app, full suite: 522 files / 4335 tests passed)
- [x] `react-doctor --diff main` on touched files — no findings
- [x] New test coverage: both-settings-off (no acquire), either-setting-on (acquire), live toggle-on/off, one-of-two-off (stays held), unmount (releases)