### PR TITLE
Add provider notice transcript support

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-activity-groups.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-activity-groups.test.ts
@@ -95,6 +95,20 @@ describe("chat activity grouping", () => {
     ]);
   });
 
+  it("keeps provider notices out of activity groups", () => {
+    const timeline = buildCompleteTimeline([
+      commandSegment("command-1", "pwd", false),
+      providerNoticeSegment("notice-1"),
+      commandSegment("command-2", "ls", false),
+    ]);
+
+    expect(timeline.map((item) => item.kind)).toEqual([
+      "activity_group",
+      "segment",
+      "activity_group",
+    ]);
+  });
+
   it("promotes reasoning to its own segment before operational activity", () => {
     const timeline = buildCompleteTimeline([
       reasoningSegment("reasoning-1", false),
@@ -897,6 +911,21 @@ function reasoningSegment(id: string, isStreaming: boolean): MessageSegment {
     markdown: "Thinking",
     isStreaming,
     durationMs: null,
+  };
+}
+
+function providerNoticeSegment(
+  id: string,
+): Extract<MessageSegment, { kind: "provider_notice" }> {
+  return {
+    id,
+    kind: "provider_notice",
+    status: "completed",
+    tone: "info",
+    title: "Model verification active",
+    message: null,
+    details: [],
+    parentId: null,
   };
 }
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-find-projection.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-find-projection.test.ts
@@ -3,6 +3,7 @@ import "../../../../__tests__/test-browser-apis";
 import { describe, expect, it } from "vitest";
 import {
   buildChatFindRows,
+  chatFindSegmentUnitId,
   chatFindSubagentBodyUnitId,
   chatFindSubagentHeaderUnitId,
   markdownToChatSearchText,
@@ -462,6 +463,97 @@ describe("chat find projection", () => {
     // (bodyFindUnitId=null). Before the fix both projection sites indexed it,
     // counting a phantom match that can never paint; it must now find nothing.
     expect(joined).not.toContain(descriptionOnly);
+  });
+
+  it("indexes a top-level provider notice's title/message/detail text, ungated by any activity group", () => {
+    const assistant: ChatMessageModel = {
+      ...makeMessage(22, "assistant"),
+      segments: [
+        {
+          id: "notice-top",
+          kind: "provider_notice",
+          status: "completed",
+          tone: "warning",
+          title: "Model changed",
+          message: "Codex switched from gpt-5 to gpt-5-safe.",
+          details: [{ label: "Reason", value: "highRiskCyberActivity" }],
+          parentId: null,
+        },
+      ],
+    };
+
+    const row = buildChatFindRows([assistant], TILE_INSTANCE_ID)[0];
+    const noticeUnit = row.units.find(
+      (unit) => unit.unitId === chatFindSegmentUnitId("notice-top"),
+    );
+
+    expect(noticeUnit?.text).toContain("Model changed");
+    expect(noticeUnit?.text).toContain(
+      "Codex switched from gpt-5 to gpt-5-safe.",
+    );
+    expect(noticeUnit?.text).toContain("Reason");
+    expect(noticeUnit?.text).toContain("highRiskCyberActivity");
+    // Not gated behind any collapsible key - it never folds into an activity
+    // group's collapse state.
+    expect(noticeUnit?.owningChain).toEqual([]);
+  });
+
+  it("indexes a nested provider notice inside a sub-agent card, opening the same chain as the sub-agent's own body", () => {
+    const subagentId = "subagent-with-notice";
+    const assistant: ChatMessageModel = {
+      ...makeMessage(23, "assistant"),
+      segments: [
+        {
+          id: subagentId,
+          kind: "subagent",
+          name: "Researcher",
+          agentType: null,
+          task: "Investigate the reroute",
+          progressUpdates: [],
+          result: null,
+          isStreaming: false,
+          endState: null,
+          stopped: false,
+          startedAt: 1,
+          durationMs: null,
+          spawnToolCallId: null,
+          parentId: null,
+          workflowMeta: null,
+          children: [
+            {
+              id: "notice-nested",
+              kind: "provider_notice",
+              status: "completed",
+              tone: "info",
+              title: "Model verification active",
+              message: "Trusted access verification enabled.",
+              details: [
+                { label: "Verifications", value: "trustedAccessForCyber" },
+              ],
+              parentId: subagentId,
+            },
+          ],
+        },
+      ],
+    };
+
+    const row = buildChatFindRows([assistant], TILE_INSTANCE_ID)[0];
+    const renderId = derivePromotedSubagentRenderId(subagentId);
+    const bodyUnit = row.units.find(
+      (unit) => unit.unitId === chatFindSubagentBodyUnitId(renderId),
+    );
+    const noticeUnit = row.units.find(
+      (unit) => unit.unitId === chatFindSegmentUnitId("notice-nested"),
+    );
+
+    expect(noticeUnit?.text).toContain("Model verification active");
+    expect(noticeUnit?.text).toContain("Trusted access verification enabled.");
+    expect(noticeUnit?.text).toContain("Verifications");
+    expect(noticeUnit?.text).toContain("trustedAccessForCyber");
+    // The nested notice opens with the SAME chain as the sub-agent's own
+    // body - expanding the card reveals the notice alongside it.
+    expect(noticeUnit?.owningChain).toEqual(bodyUnit?.owningChain);
+    expect(noticeUnit?.owningChain).toHaveLength(1);
   });
 });
 

--- a/clients/gui-app/src/components/chat/chat-find-projection.ts
+++ b/clients/gui-app/src/components/chat/chat-find-projection.ts
@@ -370,6 +370,8 @@ function segmentSearchText(segment: MessageSegment): ReadonlyArray<string> {
           ),
         ),
       ];
+    case "provider_notice":
+      return providerNoticeSegmentSearchText(segment);
     case "interview":
       return interviewSegmentSearchText(segment);
     case "forked-chat-link":
@@ -505,6 +507,20 @@ function commandSegmentSearchText(
   return [normalizeSearchableText(segment.command)];
 }
 
+function providerNoticeSegmentSearchText(
+  segment: Extract<MessageSegment, { kind: "provider_notice" }>,
+): ReadonlyArray<string> {
+  return [
+    normalizeSearchableText(
+      [
+        segment.title,
+        segment.message ?? "",
+        ...segment.details.flatMap((detail) => [detail.label, detail.value]),
+      ].join(" "),
+    ),
+  ];
+}
+
 // A subagent renders TWO independently-visible regions, so it projects to two
 // find units:
 //   - header (name + agent type): always visible while the parent is open, so
@@ -542,17 +558,31 @@ function subagentSegmentSearchUnits(
       owningChain: bodyChain,
     }),
   ]).concat(
-    segment.children.flatMap((child) =>
-      child.kind === "subagent"
-        ? subagentSegmentSearchUnits({
-            segment: child,
-            renderId: child.id,
-            parentChain: bodyChain,
-            ownKey: deriveSubagentCollapsibleKey(tileInstanceId, child.id),
-            tileInstanceId,
-          })
-        : [],
-    ),
+    segment.children.flatMap((child) => {
+      if (child.kind === "subagent") {
+        return subagentSegmentSearchUnits({
+          segment: child,
+          renderId: child.id,
+          parentChain: bodyChain,
+          ownKey: deriveSubagentCollapsibleKey(tileInstanceId, child.id),
+          tileInstanceId,
+        });
+      }
+      // A nested provider notice renders as a visible row inside this
+      // subagent's own body (see `SubagentChildProviderNotices`), so its
+      // owning chain opens the SAME body key as the subagent's other content
+      // - not a further-nested key of its own.
+      if (child.kind === "provider_notice") {
+        return compactUnits([
+          chatFindUnit({
+            unitId: chatFindSegmentUnitId(child.id),
+            text: segmentSearchText(child).join("\n"),
+            owningChain: bodyChain,
+          }),
+        ]);
+      }
+      return [];
+    }),
   );
 }
 

--- a/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
@@ -31,6 +31,7 @@ import { FileChangeSegment } from "./segments/file-change-segment";
 import { InterviewSegment } from "./segments/interview-segment";
 import type { NextStepActionHandler } from "./segments/next-steps-action-group";
 import { PlanSegment } from "./segments/plan-segment";
+import { ProviderNoticeSegment } from "./segments/provider-notice-segment";
 import { ReasoningSegment } from "./segments/reasoning-segment";
 import { SubagentSegment } from "./segments/subagent-segment";
 import { TextSegment } from "./segments/text-segment";
@@ -764,6 +765,17 @@ function AssistantSegment({
           durationMs={segment.durationMs}
           summary={segment.summary}
           error={segment.error}
+          findUnitId={findUnitId}
+        />
+      );
+    case "provider_notice":
+      return (
+        <ProviderNoticeSegment
+          status={segment.status}
+          tone={segment.tone}
+          title={segment.title}
+          message={segment.message}
+          details={segment.details}
           findUnitId={findUnitId}
         />
       );

--- a/clients/gui-app/src/components/chat/segments/__tests__/provider-notice-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/provider-notice-segment.test.tsx
@@ -1,0 +1,84 @@
+import "../../../../../__tests__/test-browser-apis";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ProviderNoticeSegment } from "../provider-notice-segment";
+
+describe("<ProviderNoticeSegment />", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders an info-tone notice quietly once completed, with no live pulse", () => {
+    render(
+      <ProviderNoticeSegment
+        status="completed"
+        tone="info"
+        title="Model verification active"
+        message="Trusted access verification enabled."
+        details={[]}
+        findUnitId={null}
+      />,
+    );
+
+    expect(screen.getByText("Model verification active")).toBeDefined();
+    expect(
+      screen.getByText(/Trusted access verification enabled\./),
+    ).toBeDefined();
+    expect(screen.queryByLabelText("Provider notice active")).toBeNull();
+  });
+
+  it("shows the live pulse while streaming", () => {
+    render(
+      <ProviderNoticeSegment
+        status="streaming"
+        tone="info"
+        title="Safety check in progress"
+        message={null}
+        details={[]}
+        findUnitId={null}
+      />,
+    );
+
+    expect(screen.getByLabelText("Provider notice active")).toBeDefined();
+  });
+
+  it("does not render an expand toggle when there are no details", () => {
+    render(
+      <ProviderNoticeSegment
+        status="completed"
+        tone="warning"
+        title="Model changed"
+        message={null}
+        details={[]}
+        findUnitId={null}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("expands to reveal detail label/value pairs on click, without showing raw JSON", () => {
+    render(
+      <ProviderNoticeSegment
+        status="completed"
+        tone="warning"
+        title="Model changed"
+        message="Codex switched from gpt-5 to gpt-5-safe."
+        details={[
+          { label: "Reason", value: "highRiskCyberActivity" },
+          { label: "From", value: "gpt-5" },
+        ]}
+        findUnitId={null}
+      />,
+    );
+
+    expect(screen.queryByText("Reason")).toBeNull();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("Reason")).toBeDefined();
+    expect(screen.getByText("highRiskCyberActivity")).toBeDefined();
+    expect(screen.getByText("From")).toBeDefined();
+    expect(screen.getByText("gpt-5")).toBeDefined();
+    expect(screen.queryByText(/"type":/)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/chat/segments/__tests__/subagent-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/subagent-segment.test.tsx
@@ -918,6 +918,44 @@ describe("<SubagentSegment /> promoted feed", () => {
     expect(screen.queryByText("Sub-agents")).toBeNull();
   });
 
+  it("renders a nested provider notice as a compact row once the card is expanded", () => {
+    render(
+      <SubagentSegment
+        id="test-parent-notice"
+        name="planner"
+        agentType={null}
+        task="Plan the refactor."
+        progressUpdates={[]}
+        result={null}
+        isStreaming
+        endState={null}
+        stopped={false}
+        startedAt={null}
+        durationMs={null}
+        workflowMeta={null}
+        nested={[
+          {
+            id: "notice-1",
+            kind: "provider_notice",
+            status: "completed",
+            tone: "warning",
+            title: "Model changed",
+            message: "Codex switched from gpt-5 to gpt-5-safe.",
+            details: [],
+            parentId: "test-parent-notice",
+          },
+        ]}
+        variant="promoted"
+      />,
+    );
+
+    expect(screen.queryByText("Model changed")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Subagent/ }));
+
+    expect(screen.getByText("Model changed")).toBeTruthy();
+  });
+
   it("renders a second nesting level once the first-level row is itself expanded", () => {
     render(
       <SubagentSegment

--- a/clients/gui-app/src/components/chat/segments/provider-notice-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/provider-notice-segment.tsx
@@ -1,0 +1,114 @@
+import { ChevronDown, ChevronRight, Info, TriangleAlert } from "lucide-react";
+import { useState } from "react";
+import type {
+  ProviderNoticeDetail,
+  ProviderNoticeTone,
+} from "@traycer/protocol/persistence/epic/content-blocks";
+import { useChatMeasuredBooleanToggle } from "@/components/chat/chat-measured-item-change-context";
+import { LivePulse } from "@/components/ui/live-pulse";
+import { cn } from "@/lib/utils";
+
+interface ProviderNoticeSegmentProps {
+  status: "streaming" | "completed" | "errored";
+  tone: ProviderNoticeTone;
+  title: string;
+  message: string | null;
+  details: ReadonlyArray<ProviderNoticeDetail>;
+  findUnitId: string | null;
+}
+
+const TONE_ICON: Record<ProviderNoticeTone, typeof Info> = {
+  info: Info,
+  warning: TriangleAlert,
+};
+
+const TONE_TEXT_CLASS: Record<ProviderNoticeTone, string> = {
+  info: "text-muted-foreground",
+  warning: "text-amber-700 dark:text-amber-300",
+};
+
+export function ProviderNoticeSegment(props: ProviderNoticeSegmentProps) {
+  const { status, tone, title, message, details, findUnitId } = props;
+  const isStreaming = status === "streaming";
+  const [expanded, setExpanded] = useState(false);
+  const toggleExpanded = useChatMeasuredBooleanToggle(setExpanded);
+
+  const hasDetails = details.length > 0;
+  const Icon = TONE_ICON[tone];
+  const toneClass = TONE_TEXT_CLASS[tone];
+  const ExpandIcon = expanded ? ChevronDown : ChevronRight;
+
+  const labelInner = (
+    <div className={cn("flex items-center gap-2 text-ui-xs", toneClass)}>
+      <Icon className="size-3.5 shrink-0" aria-hidden />
+      <span>
+        {title}
+        {message !== null && message.length > 0 ? (
+          <span className="text-muted-foreground/80"> · {message}</span>
+        ) : null}
+      </span>
+      {isStreaming ? (
+        <LivePulse
+          size="xs"
+          tone="active"
+          ariaLabel="Provider notice active"
+          className={undefined}
+        />
+      ) : null}
+      {hasDetails ? (
+        <ExpandIcon className="size-3 shrink-0" aria-hidden />
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div
+      data-chat-find-unit={findUnitId ?? undefined}
+      className="flex w-full flex-col gap-1"
+    >
+      <div className="flex items-center gap-3">
+        <span aria-hidden className="h-px flex-1 bg-border/60" />
+        {hasDetails ? (
+          <button
+            type="button"
+            onClick={toggleExpanded}
+            aria-expanded={expanded}
+            className={cn(
+              "rounded-sm outline-none transition-colors",
+              "hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring",
+            )}
+          >
+            {labelInner}
+          </button>
+        ) : (
+          labelInner
+        )}
+        <span aria-hidden className="h-px flex-1 bg-border/60" />
+      </div>
+      {hasDetails && expanded ? (
+        <div
+          className={cn(
+            "mx-auto w-full max-w-[min(90vw,42rem)]",
+            "rounded-md border border-border/60 bg-muted/30 p-3",
+          )}
+        >
+          <dl className="m-0 flex flex-col gap-1 text-ui-xs">
+            {details.map((detail) => (
+              <div
+                key={`${detail.label}:${detail.value}`}
+                className="flex gap-2"
+              >
+                <dt className="shrink-0 font-medium text-muted-foreground">
+                  {detail.label}
+                </dt>
+                <dd className="m-0 min-w-0 flex-1 text-foreground/85">
+                  {detail.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/chat/segments/subagent-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/subagent-segment.tsx
@@ -21,6 +21,7 @@ import {
   type ChatCollapsibleKey,
 } from "@/components/chat/chat-collapsible-key";
 import {
+  chatFindSegmentUnitId,
   chatFindSubagentBodyUnitId,
   chatFindSubagentHeaderUnitId,
 } from "@/components/chat/chat-find";
@@ -39,6 +40,7 @@ import {
   type ProgressUpdateItem,
 } from "./subagent-display";
 import { AgentReferenceMarkdown } from "./agent-reference-markdown";
+import { ProviderNoticeSegment } from "./provider-notice-segment";
 import { SubagentAvatar } from "./subagent-avatar";
 import { ElapsedTime } from "./segment-elapsed";
 import { SegmentCard } from "./segment-card";
@@ -231,6 +233,7 @@ function CompactSubagentSegment(props: CompactSubagentSegmentProps) {
           </ul>
         </div>
       ) : null}
+      <SubagentChildProviderNotices nested={nested} />
       <SubagentChildrenSection nested={nested} />
       {result !== null ? (
         <SubagentResultPanel result={result} isStreaming={isStreaming} />
@@ -520,6 +523,7 @@ function SubagentDetails(props: SubagentDetailsProps) {
           />
         </div>
       ) : null}
+      <SubagentChildProviderNotices nested={nested} />
       <SubagentChildrenSection nested={nested} />
       {result !== null ? (
         <SubagentResultPanel result={result} isStreaming={isStreaming} />
@@ -574,6 +578,39 @@ function SubagentChildrenSection(props: {
           />
         ))}
       </div>
+    </div>
+  );
+}
+
+/**
+ * Provider notices (Codex model reroute / safety verification / buffering,
+ * etc.) that arrived on THIS subagent's thread - unlike the tool/file_change/
+ * command entries in `nested`, these DO render as visible rows, right where
+ * the notice actually happened for this sub-agent.
+ */
+function SubagentChildProviderNotices(props: {
+  readonly nested: ReadonlyArray<SubagentChildSegment>;
+}) {
+  const notices = props.nested.filter(
+    (
+      child,
+    ): child is Extract<SubagentChildSegment, { kind: "provider_notice" }> =>
+      child.kind === "provider_notice",
+  );
+  if (notices.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1">
+      {notices.map((notice) => (
+        <ProviderNoticeSegment
+          key={notice.id}
+          status={notice.status}
+          tone={notice.tone}
+          title={notice.title}
+          message={notice.message}
+          details={notice.details}
+          findUnitId={chatFindSegmentUnitId(notice.id)}
+        />
+      ))}
     </div>
   );
 }
@@ -800,6 +837,7 @@ function WorkflowCardSegment(props: WorkflowCardSegmentProps) {
           />
         </div>
       ) : null}
+      <SubagentChildProviderNotices nested={nested} />
       <SubagentChildrenSection nested={nested} />
       {result !== null ? (
         <>

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -417,6 +417,7 @@ function nextStepsAssistantMessage(): Message {
         ].join("\n"),
         status: "completed",
         timestamp: 2,
+        providerNotice: null,
       },
     ],
     timestamp: 2,

--- a/clients/gui-app/src/lib/chat/__tests__/content-block-text.test.ts
+++ b/clients/gui-app/src/lib/chat/__tests__/content-block-text.test.ts
@@ -46,7 +46,6 @@ describe("contentBlocksText", () => {
     const text = contentBlocksText(blocks);
     expect(text).toContain("Model changed");
     expect(text).toContain("Codex switched from gpt-5 to gpt-5-safe.");
-    expect(text).toContain("Reason");
-    expect(text).toContain("highRiskCyberActivity");
+    expect(text).toContain("Reason: highRiskCyberActivity");
   });
 });

--- a/clients/gui-app/src/lib/chat/__tests__/content-block-text.test.ts
+++ b/clients/gui-app/src/lib/chat/__tests__/content-block-text.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { ContentBlock } from "@traycer/protocol/persistence/epic/schemas";
+import { contentBlocksText } from "@/lib/chat/content-block-text";
+
+describe("contentBlocksText", () => {
+  it("falls back to the plain text for an ordinary text block", () => {
+    const blocks: ReadonlyArray<ContentBlock> = [
+      {
+        type: "text",
+        blockId: "text-1",
+        status: "completed",
+        timestamp: 1,
+        text: "Hello there.",
+        providerNotice: null,
+      },
+    ];
+
+    expect(contentBlocksText(blocks)).toBe("Hello there.");
+  });
+
+  it("includes provider notice title, message, and detail label/value text", () => {
+    const blocks: ReadonlyArray<ContentBlock> = [
+      {
+        type: "text",
+        blockId: "notice-1",
+        status: "completed",
+        timestamp: 1,
+        text: "Codex switched from gpt-5 to gpt-5-safe.",
+        providerNotice: {
+          harnessId: "codex",
+          noticeKind: "model_rerouted",
+          tone: "warning",
+          title: "Model changed",
+          message: "Codex switched from gpt-5 to gpt-5-safe.",
+          details: [{ label: "Reason", value: "highRiskCyberActivity" }],
+          metadata: {
+            type: "model_rerouted",
+            fromModel: "gpt-5",
+            toModel: "gpt-5-safe",
+            reason: "highRiskCyberActivity",
+          },
+        },
+      },
+    ];
+
+    const text = contentBlocksText(blocks);
+    expect(text).toContain("Model changed");
+    expect(text).toContain("Codex switched from gpt-5 to gpt-5-safe.");
+    expect(text).toContain("Reason");
+    expect(text).toContain("highRiskCyberActivity");
+  });
+});

--- a/clients/gui-app/src/lib/chat/content-block-text.ts
+++ b/clients/gui-app/src/lib/chat/content-block-text.ts
@@ -24,7 +24,7 @@ export function contentBlocksText(blocks: ReadonlyArray<ContentBlock>): string {
 function contentBlockText(block: ContentBlock): string {
   switch (block.type) {
     case "text":
-      return block.text;
+      return textBlockText(block);
     case "reasoning":
       return `Reasoning\n${block.content}`;
     case "tool_call":
@@ -54,6 +54,25 @@ function contentBlockText(block: ContentBlock): string {
     case "artifact_operation":
       return artifactOperationBlockText(block);
   }
+}
+
+function textBlockText(block: Extract<ContentBlock, { type: "text" }>): string {
+  const notice = block.providerNotice;
+  return notice === null ? block.text : providerNoticeText(notice);
+}
+
+function providerNoticeText(
+  notice: NonNullable<
+    Extract<ContentBlock, { type: "text" }>["providerNotice"]
+  >,
+): string {
+  return [
+    notice.title,
+    notice.message ?? "",
+    ...notice.details.flatMap((detail) => [detail.label, detail.value]),
+  ]
+    .filter((part) => part.length > 0)
+    .join(" · ");
 }
 
 function autonomousResumeBlockText(

--- a/clients/gui-app/src/lib/chat/content-block-text.ts
+++ b/clients/gui-app/src/lib/chat/content-block-text.ts
@@ -66,10 +66,17 @@ function providerNoticeText(
     Extract<ContentBlock, { type: "text" }>["providerNotice"]
   >,
 ): string {
+  const detailParts = (detail: (typeof notice.details)[number]) => {
+    const parts = [detail.label, detail.value].filter(
+      (part) => part.length > 0,
+    );
+    return parts.length === 0 ? [] : [parts.join(": ")];
+  };
+
   return [
     notice.title,
     notice.message ?? "",
-    ...notice.details.flatMap((detail) => [detail.label, detail.value]),
+    ...notice.details.flatMap(detailParts),
   ]
     .filter((part) => part.length > 0)
     .join(" · ");

--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
@@ -537,6 +537,7 @@ describe("useRenderedMessages", () => {
                   blockId: "text-1",
                   status: "completed",
                   timestamp: 2010,
+                  providerNotice: null,
                   text: "Normal assistant text.",
                 },
                 {
@@ -593,6 +594,79 @@ describe("useRenderedMessages", () => {
       toolName: "Shell",
       decision: null,
     });
+  });
+
+  it("projects a text block with providerNotice into a provider_notice segment while an ordinary text block stays a text segment", () => {
+    const assistant = assistantMessage("turn-notice", 2000);
+    const { result } = renderHook(() =>
+      useRenderedMessages(
+        {
+          messages: [
+            {
+              ...assistant,
+              blocks: [
+                {
+                  type: "text",
+                  blockId: "text-1",
+                  status: "completed",
+                  timestamp: 2001,
+                  text: "Plain assistant reply.",
+                  providerNotice: null,
+                },
+                {
+                  type: "text",
+                  blockId: "text-2",
+                  status: "completed",
+                  timestamp: 2002,
+                  text: "Codex switched from gpt-5 to gpt-5-safe.",
+                  providerNotice: {
+                    harnessId: "codex",
+                    noticeKind: "model_rerouted",
+                    tone: "warning",
+                    title: "Model changed",
+                    message: "Codex switched from gpt-5 to gpt-5-safe.",
+                    details: [
+                      { label: "Reason", value: "highRiskCyberActivity" },
+                    ],
+                    metadata: {
+                      type: "model_rerouted",
+                      fromModel: "gpt-5",
+                      toModel: "gpt-5-safe",
+                      reason: "highRiskCyberActivity",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+          events: [],
+          pendingUserMessages: [],
+          liveAssistantMessage: null,
+          activeTurn: null,
+          runStatus: "idle",
+          ...BINDING,
+        },
+        displayContext,
+      ),
+    );
+
+    const segments = result.current[0]?.segments ?? [];
+    expect(segments.map((segment) => segment.kind)).toEqual([
+      "text",
+      "provider_notice",
+    ]);
+    const notice = segments[1];
+    if (notice.kind !== "provider_notice") {
+      throw new Error("expected a provider_notice segment");
+    }
+    expect(notice.status).toBe("completed");
+    expect(notice.tone).toBe("warning");
+    expect(notice.title).toBe("Model changed");
+    expect(notice.message).toBe("Codex switched from gpt-5 to gpt-5-safe.");
+    expect(notice.details).toEqual([
+      { label: "Reason", value: "highRiskCyberActivity" },
+    ]);
+    expect(notice.parentId).toBeNull();
   });
 
   it("caches user-message renders by Message reference identity", () => {
@@ -900,6 +974,7 @@ describe("useRenderedMessages", () => {
           text: "Before steer",
           status: "completed",
           timestamp: 2001,
+          providerNotice: null,
         },
         {
           type: "steer",
@@ -917,6 +992,7 @@ describe("useRenderedMessages", () => {
           text: "After steer",
           status: "completed",
           timestamp: 2003,
+          providerNotice: null,
         },
       ],
     };
@@ -983,6 +1059,7 @@ describe("useRenderedMessages", () => {
           text: "Before steer",
           status: "completed",
           timestamp: 2001,
+          providerNotice: null,
         },
       ],
     };
@@ -1013,6 +1090,7 @@ describe("useRenderedMessages", () => {
           text: "After steer",
           status: "completed",
           timestamp: 2003,
+          providerNotice: null,
         },
       ],
     };
@@ -1238,6 +1316,7 @@ describe("useRenderedMessages", () => {
           text: "Thinking aloud",
           status: "streaming",
           timestamp: 2001,
+          providerNotice: null,
         },
         {
           type: "command",
@@ -1259,6 +1338,7 @@ describe("useRenderedMessages", () => {
           text: "Thinking aloud",
           status: "completed",
           timestamp: 2003,
+          providerNotice: null,
         },
         streamingAssistant.blocks[1],
       ],
@@ -1310,6 +1390,7 @@ describe("useRenderedMessages", () => {
           text: "Hel",
           status: "streaming",
           timestamp: 2001,
+          providerNotice: null,
         },
       ],
     };
@@ -1322,6 +1403,7 @@ describe("useRenderedMessages", () => {
           text: "Hello",
           status: "streaming",
           timestamp: 2001,
+          providerNotice: null,
         },
       ],
     };
@@ -1356,6 +1438,66 @@ describe("useRenderedMessages", () => {
     expect(segment.markdown).toBe("Hello");
   });
 
+  it("invalidates the cached provider_notice segment when its title changes without a length or timestamp change", () => {
+    const providerNoticeBlock = (title: string) => ({
+      type: "text" as const,
+      blockId: "text-1",
+      // Fixed fallback text: only the enriched notice fields change below, so
+      // `block.text.length` alone (the ordinary text-block signature) would
+      // NOT catch this update.
+      text: "Notice.",
+      status: "completed" as const,
+      timestamp: 2001,
+      providerNotice: {
+        harnessId: "codex" as const,
+        noticeKind: "model_rerouted" as const,
+        tone: "warning" as const,
+        title,
+        message: null,
+        details: [],
+        metadata: null,
+      },
+    });
+    const before: Message = {
+      ...assistantMessage("turn-1", 2000),
+      blocks: [providerNoticeBlock("Model changed")],
+    };
+    const after: Message = {
+      ...assistantMessage("turn-1", 2000),
+      blocks: [providerNoticeBlock("Model re-verified")],
+    };
+    const input: RenderedMessagesInput = {
+      messages: [before],
+      events: [],
+      pendingUserMessages: [],
+      liveAssistantMessage: null,
+      activeTurn: null,
+      runStatus: "idle",
+      ...BINDING,
+    };
+
+    const { result, rerender } = renderHook(
+      ({ value }: { value: RenderedMessagesInput }) =>
+        useRenderedMessages(value, displayContext),
+      { initialProps: { value: input } },
+    );
+    const firstSegment = result.current[0]?.segments[0];
+    expect(firstSegment.kind).toBe("provider_notice");
+    if (firstSegment.kind !== "provider_notice") {
+      throw new Error("expected a provider_notice segment");
+    }
+    expect(firstSegment.title).toBe("Model changed");
+
+    rerender({ value: { ...input, messages: [after] } });
+
+    const secondSegment = result.current[0]?.segments[0];
+    expect(secondSegment.kind).toBe("provider_notice");
+    if (secondSegment.kind !== "provider_notice") {
+      throw new Error("expected a provider_notice segment");
+    }
+    expect(secondSegment.title).toBe("Model re-verified");
+  });
+
   it("uses host-supplied blocksVersion to invalidate assistant turn cache", () => {
     const assistant: Message = {
       ...assistantMessage("turn-1", 2000),
@@ -1367,6 +1509,7 @@ describe("useRenderedMessages", () => {
           text: "Hello",
           status: "completed",
           timestamp: 2001,
+          providerNotice: null,
         },
       ],
     };
@@ -1407,6 +1550,7 @@ describe("useRenderedMessages", () => {
           text: "Checking.",
           status: "completed",
           timestamp: 2001,
+          providerNotice: null,
         },
         {
           type: "tool_call",
@@ -1500,6 +1644,7 @@ describe("useRenderedMessages", () => {
           text: "Now let's type-check.",
           status: "completed",
           timestamp: 2004,
+          providerNotice: null,
         },
       ],
     };
@@ -1612,6 +1757,7 @@ describe("useRenderedMessages", () => {
           type: "text",
           blockId: "text-1",
           text: "Now let's also check this other thing.",
+          providerNotice: null,
           status: "completed",
           timestamp: 2003,
         },
@@ -2296,6 +2442,134 @@ describe("useRenderedMessages", () => {
     expect(root.children).toEqual([]);
   });
 
+  it("nests a subagent's provider notice under its block via parentBlockId", () => {
+    const assistant: Message = {
+      ...assistantMessage("turn-1", 2000),
+      blocks: [
+        {
+          type: "subagent",
+          agentType: null,
+          blockId: "agent-1",
+          name: "explorer",
+          task: "Investigate the bug.",
+          progressUpdates: [],
+          result: null,
+          status: "streaming",
+          timestamp: 2001,
+          startedAt: 2001,
+          spawnToolCallId: null,
+          stopped: false,
+          workflowMeta: null,
+        },
+        {
+          type: "text",
+          blockId: "notice-1",
+          text: "Codex switched from gpt-5 to gpt-5-safe.",
+          status: "completed",
+          timestamp: 2002,
+          parentBlockId: "agent-1",
+          providerNotice: {
+            harnessId: "codex",
+            noticeKind: "model_rerouted",
+            tone: "warning",
+            title: "Model changed",
+            message: "Codex switched from gpt-5 to gpt-5-safe.",
+            details: [{ label: "Reason", value: "highRiskCyberActivity" }],
+            metadata: {
+              type: "model_rerouted",
+              fromModel: "gpt-5",
+              toModel: "gpt-5-safe",
+              reason: "highRiskCyberActivity",
+            },
+          },
+        },
+      ],
+    };
+
+    const { result } = renderHook(() =>
+      useRenderedMessages(
+        {
+          messages: [assistant],
+          events: [],
+          pendingUserMessages: [],
+          liveAssistantMessage: null,
+          activeTurn: null,
+          runStatus: "idle",
+          ...BINDING,
+        },
+        displayContext,
+      ),
+    );
+
+    const top = result.current[0]?.segments ?? [];
+    // The notice nests under the subagent rather than appearing top-level.
+    expect(top.map((segment) => segment.kind)).toEqual(["subagent"]);
+    const subagent = top[0];
+    if (subagent.kind !== "subagent") {
+      throw new Error("expected a subagent segment");
+    }
+    expect(subagent.children.map((child) => child.kind)).toEqual([
+      "provider_notice",
+    ]);
+    const child = subagent.children[0];
+    if (child.kind !== "provider_notice") {
+      throw new Error("expected a provider_notice child");
+    }
+    expect(child.title).toBe("Model changed");
+    expect(child.parentId).toBe("agent-1");
+  });
+
+  it("keeps a provider notice top-level when its parentBlockId doesn't resolve to a known subagent", () => {
+    const assistant: Message = {
+      ...assistantMessage("turn-1", 2000),
+      blocks: [
+        {
+          type: "text",
+          blockId: "notice-orphan",
+          text: "Codex switched from gpt-5 to gpt-5-safe.",
+          status: "completed",
+          timestamp: 2001,
+          // References a parent id never present in this turn's blocks (the
+          // owning subagent.started was dropped/never arrived) - the fallback
+          // is honest top-level placement, never vanishing.
+          parentBlockId: "agent-missing",
+          providerNotice: {
+            harnessId: "codex",
+            noticeKind: "model_rerouted",
+            tone: "warning",
+            title: "Model changed",
+            message: "Codex switched from gpt-5 to gpt-5-safe.",
+            details: [],
+            metadata: null,
+          },
+        },
+      ],
+    };
+
+    const { result } = renderHook(() =>
+      useRenderedMessages(
+        {
+          messages: [assistant],
+          events: [],
+          pendingUserMessages: [],
+          liveAssistantMessage: null,
+          activeTurn: null,
+          runStatus: "idle",
+          ...BINDING,
+        },
+        displayContext,
+      ),
+    );
+
+    const top = result.current[0]?.segments ?? [];
+    expect(top.map((segment) => segment.kind)).toEqual(["provider_notice"]);
+    const notice = top[0];
+    if (notice.kind !== "provider_notice") {
+      throw new Error("expected a top-level provider_notice segment");
+    }
+    expect(notice.parentId).toBe("agent-missing");
+  });
+
   it("keeps a nested child attached across a parent name re-emit", () => {
     // `timestamp` must advance with the rename, exactly as a real host re-emit
     // always bumps it - otherwise the per-turn render cache (keyed on each
@@ -2561,6 +2835,7 @@ describe("useRenderedMessages", () => {
             text: "a",
             status: "streaming",
             timestamp: 10,
+            providerNotice: null,
           },
         ],
         startedAt: 2000,
@@ -2599,6 +2874,7 @@ describe("useRenderedMessages", () => {
               text: "ab",
               status: "streaming",
               timestamp: 11,
+              providerNotice: null,
             },
           ],
           startedAt: 2000,
@@ -2628,6 +2904,7 @@ describe("useRenderedMessages", () => {
           status: "completed" as const,
           timestamp: 40_000,
           text: "Done",
+          providerNotice: null,
         },
       ],
     };
@@ -2680,6 +2957,7 @@ describe("useRenderedMessages", () => {
           status: "completed" as const,
           timestamp: 42_000,
           text: "Done",
+          providerNotice: null,
         },
       ],
     };
@@ -4215,6 +4493,7 @@ describe("useRenderedMessages head/tail partition", () => {
       parentBlockId: null,
       type: "text",
       text,
+      providerNotice: null,
     };
   }
 

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -208,7 +208,7 @@ function blockContentVersion(block: ContentBlock): number {
   // — this signature runs once per block per render during streaming.
   switch (block.type) {
     case "text":
-      return block.text.length;
+      return textBlockContentVersion(block);
     case "reasoning":
       return block.content.length;
     case "steer":
@@ -218,6 +218,26 @@ function blockContentVersion(block: ContentBlock): number {
     default:
       return 0;
   }
+}
+
+/**
+ * A provider-notice text block is upserted atomically (its rendered fields
+ * replace in place, they never append), so `text.length` alone can't catch a
+ * same-length title/message/detail update. Hash the rendered fields instead;
+ * an ordinary text block (no notice) keeps the cheap length signature.
+ */
+function textBlockContentVersion(
+  block: Extract<ContentBlock, { type: "text" }>,
+): number {
+  const notice = block.providerNotice;
+  if (notice === null) return block.text.length;
+  let hash = hashStringField(TURN_SIGNATURE_HASH_OFFSET, notice.tone);
+  hash = hashStringField(hash, notice.title);
+  hash = hashStringField(hash, notice.message ?? "");
+  return notice.details.reduce((next, detail) => {
+    const withLabel = hashStringField(next, detail.label);
+    return hashStringField(withLabel, detail.value);
+  }, hash);
 }
 
 function planBlockContentVersion(
@@ -2176,11 +2196,15 @@ function isSubagentChildSegment(
   // artifact_operation is intentionally excluded — artifact cards stay
   // top-level (see the BLOCK_HANDLERS["artifact_operation"] handler). A nested
   // subagent (fan-out at any depth) IS eligible - see nestSubagentChildren.
+  // provider_notice IS eligible too - a notice on a subagent's own thread
+  // nests under that card instead of interrupting the top-level transcript;
+  // one with no matching parent (or none) falls through to topLevel below.
   return (
     segment.kind === "tool" ||
     segment.kind === "file_change" ||
     segment.kind === "command" ||
-    segment.kind === "subagent"
+    segment.kind === "subagent" ||
+    segment.kind === "provider_notice"
   );
 }
 
@@ -2694,14 +2718,27 @@ const BLOCK_HANDLERS: {
     block: Extract<ContentBlock, { type: K }>,
   ) => Omit<MessageSegment, "id"> | null;
 } = {
-  text: (block) =>
-    block.text.length === 0
+  text: (block) => {
+    const notice = block.providerNotice;
+    if (notice !== null) {
+      return {
+        kind: "provider_notice",
+        status: block.status,
+        tone: notice.tone,
+        title: notice.title,
+        message: notice.message,
+        details: notice.details,
+        parentId: block.parentBlockId ?? null,
+      };
+    }
+    return block.text.length === 0
       ? null
       : {
           kind: "text",
           markdown: block.text,
           isStreaming: block.status === "streaming",
-        },
+        };
+  },
   reasoning: (block) =>
     block.content.length === 0
       ? null

--- a/clients/gui-app/src/stores/composer/chat-store.ts
+++ b/clients/gui-app/src/stores/composer/chat-store.ts
@@ -26,6 +26,8 @@ import type {
   PlanSource,
   PlanStatus,
   PlanStep,
+  ProviderNoticeDetail,
+  ProviderNoticeTone,
   ToolInputDetail,
   WorkflowMeta,
 } from "@traycer/protocol/persistence/epic/content-blocks";
@@ -136,8 +138,34 @@ export interface ToolSegment {
 
 // Recursive: a subagent's own children can themselves be nested subagent
 // cards (any spawn depth), not just their tool/file_change/command activity.
+// Unlike tool/file_change/command (which only ride along for spawn-tool-call
+// suppression bookkeeping), a nested `ProviderNoticeSegment` DOES render as a
+// visible row inside the owning card - see `SubagentChildProviderNotices` in
+// `subagent-segment.tsx`.
 export type SubagentChildSegment =
-  ToolSegment | FileChangeSegment | CommandSegment | SubagentSegment;
+  | ToolSegment
+  | FileChangeSegment
+  | CommandSegment
+  | SubagentSegment
+  | ProviderNoticeSegment;
+
+// A durable provider-generated notice (Codex model reroute / safety
+// verification / buffering, and future harness equivalents), projected from a
+// `text` content block whose `providerNotice` enrichment is set. Renders as a
+// compact row - see `ProviderNoticeSegment` in
+// `components/chat/segments/provider-notice-segment.tsx`.
+export interface ProviderNoticeSegment {
+  id: string;
+  kind: "provider_notice";
+  status: "streaming" | "completed" | "errored";
+  tone: ProviderNoticeTone;
+  title: string;
+  message: string | null;
+  details: ReadonlyArray<ProviderNoticeDetail>;
+  // Owning subagent block id when this notice arrived on a subagent's thread
+  // (nests under that subagent block). Null for a top-level notice.
+  parentId: string | null;
+}
 
 export interface ReasoningSegment {
   id: string;
@@ -307,6 +335,7 @@ export type MessageSegment =
   | ApprovalSegment
   | ArtifactOperationSegment
   | PlanSegmentModel
+  | ProviderNoticeSegment
   | {
       id: string;
       kind: "todo";

--- a/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
+++ b/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
@@ -26,7 +26,7 @@ describe("validateVersionedStreamRpcRegistry", () => {
       validateVersionedStreamRpcRegistry(hostStreamRpcRegistry);
     }).not.toThrow();
     expect(hostStreamRpcRegistry["epic.subscribe"][1].latestMinor).toBe(0);
-    expect(hostStreamRpcRegistry["chat.subscribe"][1].latestMinor).toBe(4);
+    expect(hostStreamRpcRegistry["chat.subscribe"][1].latestMinor).toBe(3);
     expect(
       hostStreamRpcRegistry["notifications.subscribe"][1].latestMinor,
     ).toBe(0);
@@ -302,7 +302,7 @@ describe("stream compatibility", () => {
   // every host still running host-v1.0.0. Fixed by keeping chat.subscribe on
   // major 1 and shipping the background-items controls as additive minors, so a
   // current app must still bridge to a host that only advertises 1.0.
-  it("bridges chat.subscribe@1.2 to a host still on chat.subscribe@1.0 (host-v1.0.0)", () => {
+  it("bridges chat.subscribe@1.3 to a host still on chat.subscribe@1.0 (host-v1.0.0)", () => {
     const currentManifest = buildStreamManifest(hostStreamRpcRegistry);
     const hostV100Manifest = {
       ...currentManifest,

--- a/protocol/src/host/agent/gui/__tests__/agent-runtime-accumulator.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/agent-runtime-accumulator.test.ts
@@ -2774,3 +2774,188 @@ describe("accumulateEvent - artifact_operation", () => {
     expect(expectArtifactOpBlock(blocks[0]).parentBlockId).toBe("subagent-1");
   });
 });
+
+describe("accumulateEvent - provider_notice.upsert", () => {
+  function expectProviderNoticeTextBlock(
+    block: ContentBlock | undefined,
+  ): TextBlock {
+    if (block?.type !== "text") {
+      throw new Error("Expected a text block");
+    }
+    return block;
+  }
+
+  it("creates a compatibility-safe text block carrying the fallback text and providerNotice enrichment", () => {
+    let blocks = makeBlocks();
+    blocks = accumulateEvent(blocks, {
+      type: "provider_notice.upsert",
+      blockId: "provider-notice:codex:turn-1:model-rerouted",
+      timestamp: 10,
+      parentBlockId: null,
+      harnessId: "codex",
+      noticeKind: "model_rerouted",
+      tone: "warning",
+      status: "completed",
+      title: "Model changed",
+      message: "Codex switched from gpt-5 to gpt-5-safe.",
+      details: [{ label: "Reason", value: "highRiskCyberActivity" }],
+      fallbackText: "Codex switched from gpt-5 to gpt-5-safe (highRiskCyberActivity).",
+      metadata: {
+        type: "model_rerouted",
+        fromModel: "gpt-5",
+        toModel: "gpt-5-safe",
+        reason: "highRiskCyberActivity",
+      },
+    });
+
+    expect(blocks).toHaveLength(1);
+    const block = expectProviderNoticeTextBlock(blocks[0]);
+    expect(block.blockId).toBe("provider-notice:codex:turn-1:model-rerouted");
+    expect(block.status).toBe("completed");
+    expect(block.timestamp).toBe(10);
+    expect(block.text).toBe(
+      "Codex switched from gpt-5 to gpt-5-safe (highRiskCyberActivity).",
+    );
+    expect(block.providerNotice).toEqual({
+      harnessId: "codex",
+      noticeKind: "model_rerouted",
+      tone: "warning",
+      title: "Model changed",
+      message: "Codex switched from gpt-5 to gpt-5-safe.",
+      details: [{ label: "Reason", value: "highRiskCyberActivity" }],
+      metadata: {
+        type: "model_rerouted",
+        fromModel: "gpt-5",
+        toModel: "gpt-5-safe",
+        reason: "highRiskCyberActivity",
+      },
+    });
+  });
+
+  it("replaces the rendered fields and fallback text in place on a repeat upsert for the same blockId (no duplicate row)", () => {
+    let blocks = makeBlocks();
+    blocks = accumulateEvent(blocks, {
+      type: "provider_notice.upsert",
+      blockId: "provider-notice:codex:turn-2:safety-buffering",
+      timestamp: 1,
+      parentBlockId: null,
+      harnessId: "codex",
+      noticeKind: "safety_buffering",
+      tone: "info",
+      status: "streaming",
+      title: "Safety check in progress",
+      message: "Buffering with gpt-5.",
+      details: [{ label: "Model", value: "gpt-5" }],
+      fallbackText: "Codex is running a safety check.",
+      metadata: {
+        type: "safety_buffering",
+        model: "gpt-5",
+        fasterModel: null,
+        useCases: ["cyber"],
+        reasons: ["trustedAccessForCyber"],
+        terminalReason: null,
+      },
+    });
+    blocks = accumulateEvent(blocks, {
+      type: "provider_notice.upsert",
+      blockId: "provider-notice:codex:turn-2:safety-buffering",
+      timestamp: 2,
+      parentBlockId: null,
+      harnessId: "codex",
+      noticeKind: "safety_buffering",
+      tone: "info",
+      status: "completed",
+      title: "Safety check complete",
+      message: null,
+      details: [{ label: "Model", value: "gpt-5" }],
+      fallbackText: "Codex completed a safety check.",
+      metadata: {
+        type: "safety_buffering",
+        model: "gpt-5",
+        fasterModel: null,
+        useCases: ["cyber"],
+        reasons: ["trustedAccessForCyber"],
+        terminalReason: "showBufferingUi=false",
+      },
+    });
+
+    expect(blocks).toHaveLength(1);
+    const block = expectProviderNoticeTextBlock(blocks[0]);
+    expect(block.status).toBe("completed");
+    expect(block.timestamp).toBe(2);
+    expect(block.text).toBe("Codex completed a safety check.");
+    expect(block.providerNotice?.title).toBe("Safety check complete");
+    expect(block.providerNotice?.message).toBeNull();
+    expect(block.providerNotice?.metadata).toEqual({
+      type: "safety_buffering",
+      model: "gpt-5",
+      fasterModel: null,
+      useCases: ["cyber"],
+      reasons: ["trustedAccessForCyber"],
+      terminalReason: "showBufferingUi=false",
+    });
+  });
+
+  it("nests under a parent block when parentBlockId is set (sub-agent thread)", () => {
+    let blocks = makeBlocks();
+    blocks = accumulateEvent(blocks, {
+      type: "provider_notice.upsert",
+      blockId: "provider-notice:codex:turn-3:model-verification",
+      timestamp: 1,
+      parentBlockId: "subagent-1",
+      harnessId: "codex",
+      noticeKind: "model_verification",
+      tone: "info",
+      status: "completed",
+      title: "Model verification active",
+      message: "Trusted access for cyber.",
+      details: [{ label: "Verifications", value: "trustedAccessForCyber" }],
+      fallbackText: "Model verification active: trustedAccessForCyber.",
+      metadata: {
+        type: "model_verification",
+        verifications: ["trustedAccessForCyber"],
+      },
+    });
+
+    expect(expectProviderNoticeTextBlock(blocks[0]).parentBlockId).toBe(
+      "subagent-1",
+    );
+  });
+
+  it("is not treated as an action block: a still-streaming provider notice completes (never interrupted/superseded) on turn end", () => {
+    let blocks = makeBlocks();
+    blocks = accumulateEvent(blocks, {
+      type: "provider_notice.upsert",
+      blockId: "provider-notice:codex:turn-4:safety-buffering",
+      timestamp: 1,
+      parentBlockId: null,
+      harnessId: "codex",
+      noticeKind: "safety_buffering",
+      tone: "info",
+      status: "streaming",
+      title: "Safety check in progress",
+      message: null,
+      details: [],
+      fallbackText: "Codex is running a safety check.",
+      metadata: null,
+    });
+
+    blocks = accumulateEvent(blocks, {
+      type: "turn.interrupted",
+      blockId: "turn",
+      timestamp: 5,
+      turnId: "turn",
+      reason: "Turn interrupted to run a queued steering request.",
+      code: "STEER_RESTART",
+      recoverable: true,
+    });
+
+    const block = expectProviderNoticeTextBlock(blocks[0]);
+    // text/reasoning content is always finalized "completed" regardless of the
+    // terminal turn outcome - a provider notice must never surface as a
+    // misleading "interrupted"/"superseded" action status.
+    expect(block.status).toBe("completed");
+    expect(block.timestamp).toBe(5);
+    expect(block.providerNotice).not.toBeNull();
+  });
+});

--- a/protocol/src/host/agent/gui/__tests__/agent-runtime.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/agent-runtime.test.ts
@@ -3,6 +3,7 @@ import {
   runtimeAgentRunInputSchema,
   runtimeApprovalRequestSchema,
   runtimeEventSchema,
+  runtimeEventSchemaV12,
   runtimePermissionModeSchema,
 } from "@traycer/protocol/host/agent/gui/agent-runtime";
 
@@ -230,6 +231,39 @@ describe("agent runtime stream schema", () => {
         turnId: "turn-2",
       }),
     ).toMatchObject({ type: "turn.completed" });
+  });
+
+  it("accepts a provider_notice.upsert event on the live minor only (chat.subscribe@1.3+)", () => {
+    const event = {
+      type: "provider_notice.upsert",
+      blockId: "provider-notice:codex:turn-1:model-rerouted",
+      timestamp: 1,
+      parentBlockId: null,
+      harnessId: "codex",
+      noticeKind: "model_rerouted",
+      tone: "warning",
+      status: "completed",
+      title: "Model changed",
+      message: "Codex switched from gpt-5 to gpt-5-safe.",
+      details: [{ label: "Reason", value: "highRiskCyberActivity" }],
+      fallbackText: "Codex switched from gpt-5 to gpt-5-safe (highRiskCyberActivity).",
+      metadata: {
+        type: "model_rerouted",
+        fromModel: "gpt-5",
+        toModel: "gpt-5-safe",
+        reason: "highRiskCyberActivity",
+      },
+    };
+
+    expect(runtimeEventSchema.parse(event)).toMatchObject({
+      type: "provider_notice.upsert",
+      noticeKind: "model_rerouted",
+    });
+
+    // The frozen pre-1.3 union must never accept this event - a real 1.2
+    // peer can never produce it, and the wire projection relies on this
+    // rejection staying true (see chat-frame-projection.ts).
+    expect(runtimeEventSchemaV12.safeParse(event).success).toBe(false);
   });
 
   it("rejects unknown runtime event types", () => {

--- a/protocol/src/host/agent/gui/__tests__/agent-runtime.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/agent-runtime.test.ts
@@ -266,6 +266,31 @@ describe("agent runtime stream schema", () => {
     expect(runtimeEventSchemaV12.safeParse(event).success).toBe(false);
   });
 
+  it("rejects a provider_notice.upsert event with an empty legacy fallback text", () => {
+    expect(
+      runtimeEventSchema.safeParse({
+        type: "provider_notice.upsert",
+        blockId: "provider-notice:codex:turn-1:model-rerouted",
+        timestamp: 1,
+        parentBlockId: null,
+        harnessId: "codex",
+        noticeKind: "model_rerouted",
+        tone: "warning",
+        status: "completed",
+        title: "Model changed",
+        message: "Codex switched from gpt-5 to gpt-5-safe.",
+        details: [{ label: "Reason", value: "highRiskCyberActivity" }],
+        fallbackText: "",
+        metadata: {
+          type: "model_rerouted",
+          fromModel: "gpt-5",
+          toModel: "gpt-5-safe",
+          reason: "highRiskCyberActivity",
+        },
+      }).success,
+    ).toBe(false);
+  });
+
   it("rejects unknown runtime event types", () => {
     expect(() =>
       runtimeEventSchema.parse({

--- a/protocol/src/host/agent/gui/__tests__/chat-subscribe.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/chat-subscribe.test.ts
@@ -7,7 +7,6 @@ import {
   chatSubscribeV11,
   chatSubscribeV12,
   chatSubscribeV13,
-  chatSubscribeV14,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import { getRecordSchema } from "@traycer/protocol/framework/index";
 import { autonomousResumeTriggerSchema } from "@traycer/protocol/persistence/epic/content-blocks";
@@ -904,12 +903,8 @@ describe("chat.subscribe@1.3 client frames", () => {
   });
 });
 
-describe("chat.subscribe@1.3 (frozen pre-workflow) server frames", () => {
-  it("declares schemaVersion 1.3 and stays registered for bridging", () => {
-    expect(chatSubscribeV13.schemaVersion).toEqual({ major: 1, minor: 3 });
-  });
-
-  it("does not know the v1.4 workflow background-item kind on snapshot or turn-state frames", () => {
+describe("chat.subscribe@1.2 server frames", () => {
+  it("stays frozen without workflow background items or workflow events", () => {
     const workflowItem = {
       taskId: "wf-task-1",
       kind: "workflow",
@@ -923,7 +918,7 @@ describe("chat.subscribe@1.3 (frozen pre-workflow) server frames", () => {
     };
 
     expect(
-      chatSubscribeV13.serverFrameSchema.safeParse({
+      chatSubscribeV12.serverFrameSchema.safeParse({
         kind: "turnStateChanged",
         hasBinaryPayload: false,
         epicId: "epic-1",
@@ -935,7 +930,7 @@ describe("chat.subscribe@1.3 (frozen pre-workflow) server frames", () => {
     ).toBe(false);
 
     expect(
-      chatSubscribeV13.serverFrameSchema.safeParse({
+      chatSubscribeV12.serverFrameSchema.safeParse({
         kind: "snapshot",
         hasBinaryPayload: false,
         epicId: "epic-1",
@@ -956,46 +951,7 @@ describe("chat.subscribe@1.3 (frozen pre-workflow) server frames", () => {
         },
       }).success,
     ).toBe(false);
-  });
 
-  it("does not know the v1.4 workflow.* blockDelta events", () => {
-    const events = [
-      {
-        type: "workflow.started",
-        blockId: "wf-1",
-        timestamp: 1,
-        name: "review",
-        intent: "Review the diff",
-      },
-      {
-        type: "workflow.progress",
-        blockId: "wf-1",
-        timestamp: 2,
-        activity: { kind: "phase", text: "Find" },
-      },
-      {
-        type: "workflow.completed",
-        blockId: "wf-1",
-        timestamp: 3,
-        outcome: "completed",
-        result: "3 findings",
-      },
-    ];
-
-    for (const event of events) {
-      expect(
-        chatSubscribeV13.serverFrameSchema.safeParse({
-          kind: "blockDelta",
-          hasBinaryPayload: false,
-          epicId: "epic-1",
-          chatId: "chat-1",
-          event,
-        }).success,
-      ).toBe(false);
-    }
-  });
-
-  it("chat.subscribe@1.2 is pinned to the same frozen pre-workflow shape as 1.3", () => {
     expect(
       chatSubscribeV12.serverFrameSchema.safeParse({
         kind: "blockDelta",
@@ -1012,11 +968,37 @@ describe("chat.subscribe@1.3 (frozen pre-workflow) server frames", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("does not know the provider_notice.upsert blockDelta event", () => {
+    expect(
+      chatSubscribeV12.serverFrameSchema.safeParse({
+        kind: "blockDelta",
+        hasBinaryPayload: false,
+        epicId: "epic-1",
+        chatId: "chat-1",
+        event: {
+          type: "provider_notice.upsert",
+          blockId: "provider-notice:codex:turn-1:model-rerouted",
+          timestamp: 1,
+          parentBlockId: null,
+          harnessId: "codex",
+          noticeKind: "model_rerouted",
+          tone: "warning",
+          status: "completed",
+          title: "Model changed",
+          message: null,
+          details: [],
+          fallbackText: "Codex switched models.",
+          metadata: null,
+        },
+      }).success,
+    ).toBe(false);
+  });
 });
 
-describe("chat.subscribe@1.4 server frames", () => {
-  it("declares schemaVersion 1.4", () => {
-    expect(chatSubscribeV14.schemaVersion).toEqual({ major: 1, minor: 4 });
+describe("chat.subscribe@1.3 server frames", () => {
+  it("declares schemaVersion 1.3", () => {
+    expect(chatSubscribeV13.schemaVersion).toEqual({ major: 1, minor: 3 });
   });
 
   it("parses a workflow background item on snapshot and turn-state frames", () => {
@@ -1032,7 +1014,7 @@ describe("chat.subscribe@1.4 server frames", () => {
       agentsFinished: 3,
     };
 
-    const snapshot = chatSubscribeV14.serverFrameSchema.parse({
+    const snapshot = chatSubscribeV13.serverFrameSchema.parse({
       kind: "snapshot",
       hasBinaryPayload: false,
       epicId: "epic-1",
@@ -1057,7 +1039,7 @@ describe("chat.subscribe@1.4 server frames", () => {
       snapshot: { backgroundItems: [workflowItem] },
     });
 
-    const turnState = chatSubscribeV14.serverFrameSchema.parse({
+    const turnState = chatSubscribeV13.serverFrameSchema.parse({
       kind: "turnStateChanged",
       hasBinaryPayload: false,
       epicId: "epic-1",
@@ -1073,7 +1055,7 @@ describe("chat.subscribe@1.4 server frames", () => {
   });
 
   it("defaults new workflow background-item metadata when parsing an old-host frame", () => {
-    const parsed = chatSubscribeV14.serverFrameSchema.parse({
+    const parsed = chatSubscribeV13.serverFrameSchema.parse({
       kind: "turnStateChanged",
       hasBinaryPayload: false,
       epicId: "epic-1",
@@ -1107,7 +1089,7 @@ describe("chat.subscribe@1.4 server frames", () => {
 
   it("round-trips workflow.started / workflow.progress / workflow.completed blockDelta events", () => {
     expect(
-      chatSubscribeV14.serverFrameSchema.parse({
+      chatSubscribeV13.serverFrameSchema.parse({
         kind: "blockDelta",
         hasBinaryPayload: false,
         epicId: "epic-1",
@@ -1124,7 +1106,7 @@ describe("chat.subscribe@1.4 server frames", () => {
     ).toMatchObject({ kind: "blockDelta" });
 
     expect(
-      chatSubscribeV14.serverFrameSchema.parse({
+      chatSubscribeV13.serverFrameSchema.parse({
         kind: "blockDelta",
         hasBinaryPayload: false,
         epicId: "epic-1",
@@ -1142,7 +1124,7 @@ describe("chat.subscribe@1.4 server frames", () => {
     ).toMatchObject({ kind: "blockDelta" });
 
     expect(
-      chatSubscribeV14.serverFrameSchema.parse({
+      chatSubscribeV13.serverFrameSchema.parse({
         kind: "blockDelta",
         hasBinaryPayload: false,
         epicId: "epic-1",
@@ -1156,5 +1138,38 @@ describe("chat.subscribe@1.4 server frames", () => {
         },
       }),
     ).toMatchObject({ kind: "blockDelta" });
+  });
+
+  it("round-trips a provider_notice.upsert blockDelta event", () => {
+    expect(
+      chatSubscribeV13.serverFrameSchema.parse({
+        kind: "blockDelta",
+        hasBinaryPayload: false,
+        epicId: "epic-1",
+        chatId: "chat-1",
+        event: {
+          type: "provider_notice.upsert",
+          blockId: "provider-notice:codex:turn-1:safety-buffering",
+          timestamp: 1,
+          parentBlockId: null,
+          harnessId: "codex",
+          noticeKind: "safety_buffering",
+          tone: "info",
+          status: "streaming",
+          title: "Safety check in progress",
+          message: "Buffering with gpt-5.",
+          details: [{ label: "Model", value: "gpt-5" }],
+          fallbackText: "Codex is running a safety check.",
+          metadata: {
+            type: "safety_buffering",
+            model: "gpt-5",
+            fasterModel: null,
+            useCases: ["cyber"],
+            reasons: ["trustedAccessForCyber"],
+            terminalReason: null,
+          },
+        },
+      }),
+    ).toMatchObject({ kind: "blockDelta", event: { type: "provider_notice.upsert" } });
   });
 });

--- a/protocol/src/host/agent/gui/agent-runtime-accumulator.ts
+++ b/protocol/src/host/agent/gui/agent-runtime-accumulator.ts
@@ -12,6 +12,7 @@ import type {
   PlanAction,
   PlanBlock,
   PlanStep,
+  ProviderNoticeMetadata,
   ToolInputDetail,
   TodoItem,
   WorkflowActivityEntry,
@@ -626,12 +627,55 @@ export function accumulateEvent(
           status: "streaming",
           timestamp: event.timestamp,
           text: event.delta,
+          providerNotice: null,
         },
       ];
     }
 
     case "text.completed":
       return finalizeBlock(blocks, event.blockId, "text", event.timestamp);
+
+    case "provider_notice.upsert": {
+      // Upserts a compatibility-safe `text` block (see
+      // `persistence/epic/content-blocks.ts`'s `providerNotice` field) rather
+      // than a distinct block type. A repeat for the same `blockId` REPLACES
+      // the rendered fields and fallback text - not append-only like
+      // `text.delta` - so a later `showBufferingUi` update or terminal
+      // completion overwrites the prior rendering in place.
+      const providerNotice: ProviderNoticeMetadata = {
+        harnessId: event.harnessId,
+        noticeKind: event.noticeKind,
+        tone: event.tone,
+        title: event.title,
+        message: event.message,
+        details: event.details,
+        metadata: event.metadata,
+      };
+      const existing = findBlockOfType(blocks, event.blockId, "text");
+      if (existing) {
+        const updated = {
+          ...existing,
+          status: event.status,
+          timestamp: event.timestamp,
+          parentBlockId: resolveParentBlockId(event, existing),
+          text: event.fallbackText,
+          providerNotice,
+        };
+        return replaceBlock(blocks, event.blockId, updated);
+      }
+      return [
+        ...blocks,
+        {
+          type: "text",
+          blockId: event.blockId,
+          status: event.status,
+          timestamp: event.timestamp,
+          parentBlockId: resolveParentBlockId(event, undefined),
+          text: event.fallbackText,
+          providerNotice,
+        },
+      ];
+    }
 
     case "reasoning.delta": {
       const existing = findBlockOfType(blocks, event.blockId, "reasoning");

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -667,7 +667,7 @@ export const providerNoticeUpsertEventSchema = z.object({
   title: z.string(),
   message: z.string().nullable(),
   details: z.array(providerNoticeDetailSchema),
-  fallbackText: z.string(),
+  fallbackText: z.string().min(1),
   metadata: providerNoticeNormalizedMetadataSchema.nullable(),
 });
 export type ProviderNoticeUpsertEvent = z.infer<

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -17,6 +17,10 @@ import {
   backgroundTaskOutputSchema,
   diffSourceSchema,
   fileEditReasonSchema,
+  providerNoticeDetailSchema,
+  providerNoticeKindSchema,
+  providerNoticeNormalizedMetadataSchema,
+  providerNoticeToneSchema,
   workflowActivityEntrySchema,
 } from "@traycer/protocol/persistence/epic/content-blocks";
 
@@ -25,11 +29,19 @@ export {
   backgroundTaskOutputSchema,
   diffSourceSchema,
   fileEditReasonSchema,
+  providerNoticeDetailSchema,
+  providerNoticeKindSchema,
+  providerNoticeNormalizedMetadataSchema,
+  providerNoticeToneSchema,
   workflowActivityEntrySchema,
   type AgentMessageSend,
   type BackgroundTaskOutput,
   type DiffSource,
   type FileEditReason,
+  type ProviderNoticeDetail,
+  type ProviderNoticeKind,
+  type ProviderNoticeNormalizedMetadata,
+  type ProviderNoticeTone,
   type WorkflowActivityEntry,
 } from "@traycer/protocol/persistence/epic/content-blocks";
 import { z } from "zod";
@@ -632,6 +644,36 @@ export type WorkflowCompletedEvent = z.infer<
   typeof workflowCompletedEventSchema
 >;
 
+/**
+ * Upserts a durable provider-generated notice (Codex model reroute / safety
+ * verification / buffering, and future equivalents) - see the tech plan.
+ * `chat.subscribe@1.3`-only, like `workflow.*` above. The accumulator writes
+ * this onto a compatibility-safe persisted `text` block (`text: fallbackText`
+ * + `providerNotice` enrichment) rather than a new `ContentBlock.type`, so
+ * older same-major readers still parse the chat - see
+ * `persistence/epic/content-blocks.ts`'s `providerNotice` field. Repeated
+ * events for the same `blockId` replace the rendered fields and fallback
+ * text; this is NOT a content boundary (see
+ * `completionEventsBeforeRuntimeEvent`), so an interleaved notice never
+ * finalizes an active text/reasoning stream.
+ */
+export const providerNoticeUpsertEventSchema = z.object({
+  ...baseRuntimeEventFields,
+  type: z.literal("provider_notice.upsert"),
+  harnessId: guiHarnessIdSchema,
+  noticeKind: providerNoticeKindSchema,
+  tone: providerNoticeToneSchema,
+  status: z.enum(["streaming", "completed"]),
+  title: z.string(),
+  message: z.string().nullable(),
+  details: z.array(providerNoticeDetailSchema),
+  fallbackText: z.string(),
+  metadata: providerNoticeNormalizedMetadataSchema.nullable(),
+});
+export type ProviderNoticeUpsertEvent = z.infer<
+  typeof providerNoticeUpsertEventSchema
+>;
+
 export const fileChangeStartedEventSchema = z.object({
   ...baseRuntimeEventFields,
   type: z.literal("file_change.started"),
@@ -929,12 +971,12 @@ export type ErrorEvent = z.infer<typeof errorEventSchema>;
  */
 export const AUTH_ERROR_CODE = "auth";
 
-// ─── Frozen pre-`workflow.*` runtime-event union (`chat.subscribe@1.3`) ────
+// ─── Frozen pre-`workflow.*` runtime-event union (`chat.subscribe@1.2`) ────
 //
-// Kept so `chat.subscribe@1.3`'s frozen `blockDelta` frame schema (see
-// `subscribe.ts`) parses only events a real 1.3 peer could produce. Do not
-// add the `workflow.*` variants here - a 1.3 peer must never observe them.
-export const runtimeEventSchemaV13 = z.discriminatedUnion("type", [
+// Kept so `chat.subscribe@1.2`'s frozen `blockDelta` frame schema (see
+// `subscribe.ts`) parses only events a real 1.2 peer could produce. Do not
+// add the `workflow.*` variants here - a 1.2 peer must never observe them.
+export const runtimeEventSchemaV12 = z.discriminatedUnion("type", [
   textDeltaEventSchema,
   textCompletedEventSchema,
   reasoningDeltaEventSchema,
@@ -976,9 +1018,10 @@ export const runtimeEventSchemaV13 = z.discriminatedUnion("type", [
 ]);
 
 export const runtimeEventSchema = z.discriminatedUnion("type", [
-  ...runtimeEventSchemaV13.def.options,
+  ...runtimeEventSchemaV12.def.options,
   workflowStartedEventSchema,
   workflowProgressEventSchema,
   workflowCompletedEventSchema,
+  providerNoticeUpsertEventSchema,
 ]);
 export type RuntimeEvent = z.infer<typeof runtimeEventSchema>;

--- a/protocol/src/host/agent/gui/contracts.ts
+++ b/protocol/src/host/agent/gui/contracts.ts
@@ -22,7 +22,6 @@ import {
   chatSubscribeV11,
   chatSubscribeV12,
   chatSubscribeV13,
-  chatSubscribeV14,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 
 // ─── GUI-surface catalog (`agent.gui.*`) ──────────────────────────────────
@@ -160,5 +159,4 @@ export {
   chatSubscribeV11,
   chatSubscribeV12,
   chatSubscribeV13,
-  chatSubscribeV14,
 };

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -1,10 +1,9 @@
 /**
- * `chat.subscribe@1.4` - versioned streaming-RPC contract for a single
- * host-owned GUI chat session. `chat.subscribe@1.0`/`@1.1`/`@1.3` (frozen, near
- * the bottom of this file) are the exact shapes shipped in earlier hosts -
- * `@1.2` has always been byte-identical to `@1.3` in this codebase; later
- * minors only add to them, so a `1.4` app still bridges to hosts that only know
- * `1.0`/`1.1`/`1.2`/`1.3`. Streams have no cross-major downgrade bridge (see
+ * `chat.subscribe@1.3` - versioned streaming-RPC contract for a single
+ * host-owned GUI chat session. `chat.subscribe@1.0`/`@1.1`/`@1.2` (frozen, near
+ * the bottom of this file) are the exact shapes shipped in earlier hosts; later
+ * minors only add to them, so a `1.3` app still bridges to hosts that only know
+ * `1.0`/`1.1`/`1.2`. Streams have no cross-major downgrade bridge (see
  * `stream-compat.ts`'s `canBridgeStream()`), so once a method ships, its major
  * must never move again - only additive minors.
  *
@@ -47,7 +46,7 @@ import {
   chatQueueSteerModeSchema,
   runtimeApprovalDecisionSchema,
   runtimeEventSchema,
-  runtimeEventSchemaV13,
+  runtimeEventSchemaV12,
   runtimeInterviewAnswerSchema,
   runtimePlanActionSchema,
 } from "@traycer/protocol/host/agent/gui/agent-runtime";
@@ -152,7 +151,7 @@ export type ChatAccumulatedFileChange = z.infer<
 /**
  * One currently-running background work item in this chat - a backgrounded
  * subagent, a `run_in_background` command, a Monitor, a scheduled wakeup, or
- * (from `chat.subscribe@1.4`) a workflow run. The host is the only
+ * (from `chat.subscribe@1.3`) a workflow run. The host is the only
  * correctness source for the running set: it removes an item in the same update
  * cycle that finalizes the originating transcript card. Surfaced so the
  * renderer can list running items above the composer, scroll to / expand the
@@ -173,12 +172,12 @@ const backgroundItemBaseFields = {
   parentTaskId: z.string().nullable().default(null),
 } as const;
 
-// ─── Frozen `chat.subscribe@1.3` background-item shapes (pre-`workflow`) ───
+// ─── Frozen `chat.subscribe@1.2` background-item shapes (pre-`workflow`) ───
 //
-// Kept so `chat.subscribe@1.4`'s frozen snapshot/turnStateChanged frame
-// schemas (below) parse only shapes a real 1.3 peer could produce. Do not add
-// the 1.4-only `workflow` kind here - a 1.3 peer must never observe it.
-export const backgroundItemKindSchemaV13 = z.enum([
+// Kept so frozen snapshot/turnStateChanged frame schemas parse only shapes a
+// real 1.2 peer could produce. Do not add the 1.3-only `workflow` kind here -
+// a 1.2 peer must never observe it.
+export const backgroundItemKindSchemaV12 = z.enum([
   "subagent",
   "command",
   "monitor",
@@ -207,12 +206,12 @@ const wakeupBackgroundItemSchema = z.object({
   scheduledFor: z.number(),
 });
 
-export const backgroundItemSchemaV13 = z.discriminatedUnion("kind", [
+export const backgroundItemSchemaV12 = z.discriminatedUnion("kind", [
   runningBackgroundItemSchema,
   wakeupBackgroundItemSchema,
 ]);
 
-// One currently-running WORKFLOW background item (`chat.subscribe@1.4`) - the
+// One currently-running WORKFLOW background item (`chat.subscribe@1.3`) - the
 // aggregate view of a Workflow tool run, not a per-fleet-agent row (inner
 // `agent()` calls have no individually addressable identity on the wire - see
 // the detection findings). `phase`/`activeLabel` mirror the rotating
@@ -229,13 +228,13 @@ const workflowBackgroundItemSchema = z.object({
 });
 
 export const backgroundItemKindSchema = z.enum([
-  ...backgroundItemKindSchemaV13.options,
+  ...backgroundItemKindSchemaV12.options,
   "workflow",
 ]);
 export type BackgroundItemKind = z.infer<typeof backgroundItemKindSchema>;
 
 export const backgroundItemSchema = z.discriminatedUnion("kind", [
-  ...backgroundItemSchemaV13.def.options,
+  ...backgroundItemSchemaV12.def.options,
   workflowBackgroundItemSchema,
 ]);
 export type BackgroundItem = z.infer<typeof backgroundItemSchema>;
@@ -464,8 +463,8 @@ const chatSubscribeTurnStateChangedServerFrameSchema = z.object({
 
 // `blockDelta`'s `event` schema is the one shared-frame shape that changes
 // incompatibly across `chat.subscribe` minors (`runtimeEventSchema` gained
-// `workflow.*` in `1.4`), so it is versioned separately from the rest of the
-// shared frames via this factory - see `chatSubscribeSharedServerFrameSchemasV13`
+// `workflow.*` in `1.3`), so it is versioned separately from the rest of the
+// shared frames via this factory - see `chatSubscribeSharedServerFrameSchemasV12`
 // (frozen) vs `chatSubscribeSharedServerFrameSchemas` (live) below.
 function blockDeltaServerFrameSchema<EventSchema extends z.ZodType>(
   eventSchema: EventSchema,
@@ -607,12 +606,10 @@ const chatSubscribeCommonServerFrameSchemas = [
   }),
 ];
 
-// Frozen for `chat.subscribe@1.3` and earlier (`1.1`, `1.2` have always been
-// byte-identical to `1.3` in this codebase - see the frozen-1.3 section near
-// the bottom of this file).
-const chatSubscribeSharedServerFrameSchemasV13 = [
+// Frozen for `chat.subscribe@1.2` and earlier.
+const chatSubscribeSharedServerFrameSchemasV12 = [
   ...chatSubscribeCommonServerFrameSchemas,
-  blockDeltaServerFrameSchema(runtimeEventSchemaV13),
+  blockDeltaServerFrameSchema(runtimeEventSchemaV12),
 ];
 
 const chatSubscribeSharedServerFrameSchemas = [
@@ -1208,15 +1205,15 @@ const chatSubscribeTurnStateChangedServerFrameSchemaV11 = z.object({
   turnInProgress: z.boolean().optional(),
 });
 
-// `1.1`'s shared frames are pinned to the frozen `1.3` set (not the live one)
+// `1.1`'s shared frames are pinned to the frozen `1.2` set (not the live one)
 // so this frozen contract can never silently absorb a construct added on a
-// later minor - see `chatSubscribeSharedServerFrameSchemasV13` above. This is
-// a pure pin, not a behavior change: until `1.4` added `workflow.*`, the live
+// later minor - see `chatSubscribeSharedServerFrameSchemasV12` above. This is
+// a pure pin, not a behavior change: until `1.3` added `workflow.*`, the live
 // and frozen sets were byte-identical.
 const chatSubscribeServerFrameSchemaV11 = z.discriminatedUnion("kind", [
   chatSubscribeSnapshotServerFrameSchemaV11,
   chatSubscribeTurnStateChangedServerFrameSchemaV11,
-  ...chatSubscribeSharedServerFrameSchemasV13,
+  ...chatSubscribeSharedServerFrameSchemasV12,
 ]);
 
 export const chatSubscribeV11 = defineStreamRpcContract({
@@ -1227,16 +1224,14 @@ export const chatSubscribeV11 = defineStreamRpcContract({
   clientFrameSchema: chatSubscribeClientFrameSchemaBeforeV13,
 });
 
-// ─── Frozen `chat.subscribe@1.3` shape (pre-`workflow`) ────────────────────
+// ─── Frozen `chat.subscribe@1.2` shape (host-v1.1.4, as shipped) ──────────
 //
-// Kept so `chat.subscribe@1.4` clients can still bridge to a host that only
-// advertises `1.3`, and so the in-repo `1.2`/`1.3` contract tests can't
-// silently absorb a `1.4`-only construct (`workflow` background items,
-// `workflow.*` blockDelta events - see `backgroundItemSchemaV13` /
-// `runtimeEventSchemaV13` above). `1.2` and `1.3` have always been
-// byte-identical in this codebase, so both contracts below share this one
-// frozen shape - do not add the `1.4`-only `workflow` kind/fields here.
-const chatSnapshotSchemaV13 = z.object({
+// Kept so `chat.subscribe@1.3` clients can still bridge to a host that only
+// advertises `1.2`, and so the in-repo `1.2` contract tests can't silently
+// absorb a `1.3`-only construct (`pauseQueue` client frames, `workflow`
+// background items, `workflow.*` blockDelta events). Do not add post-1.2
+// fields or variants here.
+const chatSnapshotSchemaV12 = z.object({
   chat: chatSchema,
   access: chatAccessSchema,
   queue: chatQueueStateSchema,
@@ -1248,31 +1243,31 @@ const chatSnapshotSchemaV13 = z.object({
   missingWorktreePaths: z.array(z.string()),
   pendingFileEditApprovals: z.array(chatFileEditApprovalStateSchema),
   accumulatedFileChanges: z.array(chatAccumulatedFileChangeSchema),
-  backgroundItems: z.array(backgroundItemSchemaV13).optional(),
+  backgroundItems: z.array(backgroundItemSchemaV12).optional(),
   turnInProgress: z.boolean().optional(),
 });
 
-const chatSubscribeSnapshotServerFrameSchemaV13 = z.object({
+const chatSubscribeSnapshotServerFrameSchemaV12 = z.object({
   kind: z.literal("snapshot"),
   ...textFrameFields,
   ...chatReferenceFields,
-  snapshot: chatSnapshotSchemaV13,
+  snapshot: chatSnapshotSchemaV12,
 });
 
-const chatSubscribeTurnStateChangedServerFrameSchemaV13 = z.object({
+const chatSubscribeTurnStateChangedServerFrameSchemaV12 = z.object({
   kind: z.literal("turnStateChanged"),
   ...textFrameFields,
   ...chatReferenceFields,
   runStatus: chatRunStatusSchema,
   activeTurn: chatActiveTurnSchema.nullable(),
-  backgroundItems: z.array(backgroundItemSchemaV13).optional(),
+  backgroundItems: z.array(backgroundItemSchemaV12).optional(),
   turnInProgress: z.boolean().optional(),
 });
 
-const chatSubscribeServerFrameSchemaV13 = z.discriminatedUnion("kind", [
-  chatSubscribeSnapshotServerFrameSchemaV13,
-  chatSubscribeTurnStateChangedServerFrameSchemaV13,
-  ...chatSubscribeSharedServerFrameSchemasV13,
+const chatSubscribeServerFrameSchemaV12 = z.discriminatedUnion("kind", [
+  chatSubscribeSnapshotServerFrameSchemaV12,
+  chatSubscribeTurnStateChangedServerFrameSchemaV12,
+  ...chatSubscribeSharedServerFrameSchemasV12,
 ]);
 
 // ─── `chat.subscribe@1.2` contract ─────────────────────────────────────────
@@ -1281,25 +1276,15 @@ export const chatSubscribeV12 = defineStreamRpcContract({
   method: "chat.subscribe",
   schemaVersion: { major: 1, minor: 2 } as const,
   openRequestSchema: chatSubscribeOpenRequestSchema,
-  serverFrameSchema: chatSubscribeServerFrameSchemaV13,
+  serverFrameSchema: chatSubscribeServerFrameSchemaV12,
   clientFrameSchema: chatSubscribeClientFrameSchemaBeforeV13,
 });
 
-// ─── `chat.subscribe@1.3` contract (frozen pre-`workflow`) ─────────────────
+// ─── Live `chat.subscribe@1.3` contract ────────────────────────────────────
 
 export const chatSubscribeV13 = defineStreamRpcContract({
   method: "chat.subscribe",
   schemaVersion: { major: 1, minor: 3 } as const,
-  openRequestSchema: chatSubscribeOpenRequestSchema,
-  serverFrameSchema: chatSubscribeServerFrameSchemaV13,
-  clientFrameSchema: chatSubscribeClientFrameSchema,
-});
-
-// ─── Live `chat.subscribe@1.4` contract ────────────────────────────────────
-
-export const chatSubscribeV14 = defineStreamRpcContract({
-  method: "chat.subscribe",
-  schemaVersion: { major: 1, minor: 4 } as const,
   openRequestSchema: chatSubscribeOpenRequestSchema,
   serverFrameSchema: chatSubscribeServerFrameSchema,
   clientFrameSchema: chatSubscribeClientFrameSchema,

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -48,7 +48,6 @@ import {
   chatSubscribeV11,
   chatSubscribeV12,
   chatSubscribeV13,
-  chatSubscribeV14,
 } from "@traycer/protocol/host/agent/gui/contracts";
 import {
   agentTuiGenerateTitleV10,
@@ -2792,7 +2791,7 @@ export type HostRpcRegistry = typeof hostRpcRegistry;
  * Combined streaming-RPC registry for the `/stream` WS manifest.
  *
  * One manifest per `/stream` WS: `epic.subscribe@1.0`,
- * `chat.subscribe@1.2`, `notifications.subscribe@1.0`,
+ * `chat.subscribe@1.3`, `notifications.subscribe@1.0`,
  * `terminal.subscribe@1.0`, `git.subscribeStatus@1.0`,
  * `resources.subscribe@1.0`, `agent.inbox.subscribe@1.0`,
  * `speech.dictate@1.0`, and
@@ -2825,7 +2824,7 @@ export const hostStreamRpcRegistry = defineVersionedStreamRpcRegistry({
   },
   "chat.subscribe": {
     1: {
-      latestMinor: 4,
+      latestMinor: 3,
       versions: {
         0: {
           contract: chatSubscribeV10,
@@ -2838,9 +2837,6 @@ export const hostStreamRpcRegistry = defineVersionedStreamRpcRegistry({
         },
         3: {
           contract: chatSubscribeV13,
-        },
-        4: {
-          contract: chatSubscribeV14,
         },
       },
     },

--- a/protocol/src/persistence/epic/__tests__/__fixtures__/chat-schema-surface.ts
+++ b/protocol/src/persistence/epic/__tests__/__fixtures__/chat-schema-surface.ts
@@ -1453,6 +1453,199 @@ export const chatSchemaSurfaceBaseline = {
                           },
                           "text": {
                             "type": "string"
+                          },
+                          "providerNotice": {
+                            "default": null,
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "harnessId": {
+                                    "type": "string",
+                                    "enum": [
+                                      "claude",
+                                      "codex",
+                                      "opencode",
+                                      "traycer",
+                                      "cursor",
+                                      "grok",
+                                      "qwen",
+                                      "kiro",
+                                      "droid",
+                                      "kimi",
+                                      "copilot",
+                                      "kilocode",
+                                      "openrouter",
+                                      "amp"
+                                    ]
+                                  },
+                                  "noticeKind": {
+                                    "type": "string",
+                                    "enum": [
+                                      "model_rerouted",
+                                      "model_verification",
+                                      "safety_buffering"
+                                    ]
+                                  },
+                                  "tone": {
+                                    "type": "string",
+                                    "enum": [
+                                      "info",
+                                      "warning"
+                                    ]
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "details": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "label",
+                                        "value"
+                                      ]
+                                    }
+                                  },
+                                  "metadata": {
+                                    "anyOf": [
+                                      {
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "const": "model_rerouted"
+                                              },
+                                              "fromModel": {
+                                                "type": "string"
+                                              },
+                                              "toModel": {
+                                                "type": "string"
+                                              },
+                                              "reason": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "fromModel",
+                                              "toModel",
+                                              "reason"
+                                            ]
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "const": "model_verification"
+                                              },
+                                              "verifications": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "verifications"
+                                            ]
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "const": "safety_buffering"
+                                              },
+                                              "model": {
+                                                "type": "string"
+                                              },
+                                              "fasterModel": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "useCases": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "reasons": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "terminalReason": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "model",
+                                              "fasterModel",
+                                              "useCases",
+                                              "reasons",
+                                              "terminalReason"
+                                            ]
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "harnessId",
+                                  "noticeKind",
+                                  "tone",
+                                  "title",
+                                  "message",
+                                  "details",
+                                  "metadata"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           }
                         },
                         "required": [
@@ -5471,6 +5664,204 @@ export const chatSchemaSurfaceBaseline = {
                           },
                           "text": {
                             "type": "string"
+                          },
+                          "providerNotice": {
+                            "default": null,
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "harnessId": {
+                                    "type": "string",
+                                    "enum": [
+                                      "claude",
+                                      "codex",
+                                      "opencode",
+                                      "traycer",
+                                      "cursor",
+                                      "grok",
+                                      "qwen",
+                                      "kiro",
+                                      "droid",
+                                      "kimi",
+                                      "copilot",
+                                      "kilocode",
+                                      "openrouter",
+                                      "amp"
+                                    ]
+                                  },
+                                  "noticeKind": {
+                                    "type": "string",
+                                    "enum": [
+                                      "model_rerouted",
+                                      "model_verification",
+                                      "safety_buffering"
+                                    ]
+                                  },
+                                  "tone": {
+                                    "type": "string",
+                                    "enum": [
+                                      "info",
+                                      "warning"
+                                    ]
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  },
+                                  "details": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "label",
+                                        "value"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "metadata": {
+                                    "anyOf": [
+                                      {
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "const": "model_rerouted"
+                                              },
+                                              "fromModel": {
+                                                "type": "string"
+                                              },
+                                              "toModel": {
+                                                "type": "string"
+                                              },
+                                              "reason": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "fromModel",
+                                              "toModel",
+                                              "reason"
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "const": "model_verification"
+                                              },
+                                              "verifications": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "verifications"
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "type": {
+                                                "type": "string",
+                                                "const": "safety_buffering"
+                                              },
+                                              "model": {
+                                                "type": "string"
+                                              },
+                                              "fasterModel": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "useCases": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "reasons": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "terminalReason": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "model",
+                                              "fasterModel",
+                                              "useCases",
+                                              "reasons",
+                                              "terminalReason"
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "harnessId",
+                                  "noticeKind",
+                                  "tone",
+                                  "title",
+                                  "message",
+                                  "details",
+                                  "metadata"
+                                ],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           }
                         },
                         "required": [
@@ -5478,7 +5869,8 @@ export const chatSchemaSurfaceBaseline = {
                           "status",
                           "timestamp",
                           "type",
-                          "text"
+                          "text",
+                          "providerNotice"
                         ],
                         "additionalProperties": false
                       },

--- a/protocol/src/persistence/epic/__tests__/content-blocks.test.ts
+++ b/protocol/src/persistence/epic/__tests__/content-blocks.test.ts
@@ -4,12 +4,16 @@ import {
   contentBlockSchema,
   decodeAutonomousResumeBlock,
   encodeAutonomousResumeBlock,
+  providerNoticeMetadataSchema,
+  providerNoticeNormalizedMetadataSchema,
   subAgentBlockSchema,
+  textBlockSchema,
   type ApprovalBlock,
   type AutonomousResumeBlock,
   type FileChangeBlock,
   type InterviewBlock,
   type SubAgentBlock,
+  type TextBlock,
   type ToolCallBlock,
 } from "@traycer/protocol/persistence/epic/content-blocks";
 import { hostStreamRpcRegistry } from "@traycer/protocol/host/index";
@@ -568,5 +572,189 @@ describe("autonomousResumeBlockSchema wakeup persistence compat", () => {
     expect(Object.keys(hostStreamRpcRegistry)).toContain("chat.subscribe");
     expect(() => z.toJSONSchema(contentBlockSchema)).not.toThrow();
     expect(() => z.toJSONSchema(contentBlockSchema, { io: "input" })).not.toThrow();
+  });
+});
+
+describe("textBlockSchema providerNotice (no new persisted block type)", () => {
+  const modelReroutedBlock = {
+    type: "text",
+    blockId: "notice-1",
+    status: "completed",
+    timestamp: 1000,
+    text: "Codex switched from gpt-5 to gpt-5-safe (highRiskCyberActivity).",
+    providerNotice: {
+      harnessId: "codex",
+      noticeKind: "model_rerouted",
+      tone: "warning",
+      title: "Model changed",
+      message: "Codex switched from gpt-5 to gpt-5-safe.",
+      details: [
+        { label: "Reason", value: "highRiskCyberActivity" },
+        { label: "From", value: "gpt-5" },
+        { label: "To", value: "gpt-5-safe" },
+      ],
+      metadata: {
+        type: "model_rerouted",
+        fromModel: "gpt-5",
+        toModel: "gpt-5-safe",
+        reason: "highRiskCyberActivity",
+      },
+    },
+  };
+
+  it("defaults providerNotice to null for a legacy text block (no providerNotice key)", () => {
+    const { providerNotice: _providerNotice, ...legacy } = modelReroutedBlock;
+    const parsed = contentBlockSchema.parse(legacy) as TextBlock;
+    expect(parsed.type).toBe("text");
+    expect(parsed.providerNotice).toBeNull();
+  });
+
+  it("round-trips a model_rerouted provider notice text block", () => {
+    const parsed = contentBlockSchema.parse(modelReroutedBlock) as TextBlock;
+    expect(parsed.type).toBe("text");
+    expect(parsed.text).toBe(modelReroutedBlock.text);
+    expect(parsed.providerNotice).toEqual(modelReroutedBlock.providerNotice);
+  });
+
+  it("round-trips a model_verification provider notice text block", () => {
+    const block = {
+      type: "text",
+      blockId: "notice-2",
+      status: "completed",
+      timestamp: 1001,
+      text: "Model verification active (trustedAccessForCyber).",
+      providerNotice: {
+        harnessId: "codex",
+        noticeKind: "model_verification",
+        tone: "info",
+        title: "Model verification active",
+        message: "trustedAccessForCyber",
+        details: [{ label: "Verifications", value: "trustedAccessForCyber" }],
+        metadata: {
+          type: "model_verification",
+          verifications: ["trustedAccessForCyber"],
+        },
+      },
+    };
+    const parsed = contentBlockSchema.parse(block) as TextBlock;
+    expect(parsed.providerNotice?.metadata).toEqual({
+      type: "model_verification",
+      verifications: ["trustedAccessForCyber"],
+    });
+  });
+
+  it("round-trips a safety_buffering provider notice text block, including a null terminalReason while streaming", () => {
+    const block = {
+      type: "text",
+      blockId: "notice-3",
+      status: "streaming",
+      timestamp: 1002,
+      text: "Safety check in progress.",
+      providerNotice: {
+        harnessId: "codex",
+        noticeKind: "safety_buffering",
+        tone: "info",
+        title: "Safety check in progress",
+        message: "Running gpt-5, may fall back to gpt-5-fast.",
+        details: [
+          { label: "Model", value: "gpt-5" },
+          { label: "Faster model", value: "gpt-5-fast" },
+        ],
+        metadata: {
+          type: "safety_buffering",
+          model: "gpt-5",
+          fasterModel: "gpt-5-fast",
+          useCases: ["cyber"],
+          reasons: ["highRiskCyberActivity"],
+          terminalReason: null,
+        },
+      },
+    };
+    const parsed = contentBlockSchema.parse(block) as TextBlock;
+    expect(parsed.providerNotice?.metadata).toMatchObject({
+      type: "safety_buffering",
+      terminalReason: null,
+    });
+  });
+
+  it("old-reader compat: a pre-providerNotice textBlockSchema parses a providerNotice-bearing block, stripping the unknown key", () => {
+    // Field-for-field copy of `textBlockSchema` as it existed before
+    // `providerNotice` was added - stands in for a released host's baked
+    // schema. A provider-notice text block must stay readable by any
+    // released host as plain assistant text (tech plan: compatibility-safe
+    // persisted shape, no new `ContentBlock.type`).
+    const preProviderNoticeTextBlockSchema = z.object({
+      blockId: z.string(),
+      status: z.enum(["streaming", "completed", "errored"]),
+      timestamp: z.number(),
+      parentBlockId: z.string().nullish(),
+      type: z.literal("text"),
+      text: z.string(),
+    });
+
+    const parsed = preProviderNoticeTextBlockSchema.parse(modelReroutedBlock);
+    expect(parsed.type).toBe("text");
+    expect(parsed.text).toBe(modelReroutedBlock.text);
+    // The enrichment is not retained by the older reader - the base text
+    // field is the faithful degradation.
+    expect("providerNotice" in parsed).toBe(false);
+  });
+
+  it("rejects an unknown normalized-metadata discriminant", () => {
+    const result = providerNoticeNormalizedMetadataSchema.safeParse({
+      type: "unknown_kind",
+      value: "x",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a raw/nested provider payload shape outside the normalized metadata union", () => {
+    // The generated Codex payload shape (raw threadId/turnId/verifications
+    // envelope) must never be accepted as-is - only the normalized,
+    // per-notice-kind facts are allowed.
+    const result = providerNoticeMetadataSchema.safeParse({
+      harnessId: "codex",
+      noticeKind: "model_verification",
+      tone: "info",
+      title: "Model verification active",
+      message: null,
+      details: [],
+      metadata: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        verifications: ["trustedAccessForCyber"],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-JSON-serializable values on normalized metadata fields", () => {
+    const result = providerNoticeNormalizedMetadataSchema.safeParse({
+      type: "model_rerouted",
+      fromModel: "gpt-5",
+      toModel: "gpt-5-safe",
+      reason: () => "highRiskCyberActivity",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("textBlockSchema rejects a providerNotice missing required metadata fields", () => {
+    const result = textBlockSchema.safeParse({
+      type: "text",
+      blockId: "notice-invalid",
+      status: "completed",
+      timestamp: 1,
+      text: "fallback",
+      providerNotice: {
+        harnessId: "codex",
+        noticeKind: "model_rerouted",
+        tone: "warning",
+        // title is required and missing.
+        message: null,
+        details: [],
+        metadata: null,
+      },
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/protocol/src/persistence/epic/__tests__/content-blocks.test.ts
+++ b/protocol/src/persistence/epic/__tests__/content-blocks.test.ts
@@ -728,6 +728,23 @@ describe("textBlockSchema providerNotice (no new persisted block type)", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects provider notice metadata whose type does not match noticeKind", () => {
+    const result = providerNoticeMetadataSchema.safeParse({
+      harnessId: "codex",
+      noticeKind: "model_rerouted",
+      tone: "warning",
+      title: "Model changed",
+      message: null,
+      details: [],
+      metadata: {
+        type: "model_verification",
+        verifications: ["trustedAccessForCyber"],
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("rejects non-JSON-serializable values on normalized metadata fields", () => {
     const result = providerNoticeNormalizedMetadataSchema.safeParse({
       type: "model_rerouted",

--- a/protocol/src/persistence/epic/content-blocks.ts
+++ b/protocol/src/persistence/epic/content-blocks.ts
@@ -111,15 +111,25 @@ export type ProviderNoticeNormalizedMetadata = z.infer<
   typeof providerNoticeNormalizedMetadataSchema
 >;
 
-export const providerNoticeMetadataSchema = z.object({
-  harnessId: harnessIdSchema,
-  noticeKind: providerNoticeKindSchema,
-  tone: providerNoticeToneSchema,
-  title: z.string(),
-  message: z.string().nullable(),
-  details: z.array(providerNoticeDetailSchema),
-  metadata: providerNoticeNormalizedMetadataSchema.nullable(),
-});
+export const providerNoticeMetadataSchema = z
+  .object({
+    harnessId: harnessIdSchema,
+    noticeKind: providerNoticeKindSchema,
+    tone: providerNoticeToneSchema,
+    title: z.string(),
+    message: z.string().nullable(),
+    details: z.array(providerNoticeDetailSchema),
+    metadata: providerNoticeNormalizedMetadataSchema.nullable(),
+  })
+  .superRefine((notice, ctx) => {
+    if (notice.metadata !== null && notice.noticeKind !== notice.metadata.type) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "noticeKind must match metadata.type",
+        path: ["metadata", "type"],
+      });
+    }
+  });
 export type ProviderNoticeMetadata = z.infer<typeof providerNoticeMetadataSchema>;
 
 export const textBlockSchema = z.object({

--- a/protocol/src/persistence/epic/content-blocks.ts
+++ b/protocol/src/persistence/epic/content-blocks.ts
@@ -58,10 +58,84 @@ const artifactKindSchema = getRecordSchema(
   "latest",
 );
 
+// Durable provider-generated notice (Codex model reroute / safety
+// verification / buffering, and future equivalents from other harnesses),
+// carried as an ADDITIVE enrichment on `textBlockSchema` rather than a new
+// `ContentBlock.type` - see `providerNotice` below for why. `harnessId` uses
+// the persistence-layer's broad `harnessIdSchema`, not the host layer's
+// narrower `GuiHarnessId` (persistence cannot import that layer - the
+// dependency runs host -> persistence); mirrors `planSourceSchema.harnessId`.
+export const providerNoticeKindSchema = z.enum([
+  "model_rerouted",
+  "model_verification",
+  "safety_buffering",
+]);
+export type ProviderNoticeKind = z.infer<typeof providerNoticeKindSchema>;
+
+export const providerNoticeToneSchema = z.enum(["info", "warning"]);
+export type ProviderNoticeTone = z.infer<typeof providerNoticeToneSchema>;
+
+export const providerNoticeDetailSchema = z.object({
+  label: z.string(),
+  value: z.string(),
+});
+export type ProviderNoticeDetail = z.infer<typeof providerNoticeDetailSchema>;
+
+// Narrow, JSON-serializable per-notice-kind facts - normalized from the raw
+// provider payload at conversion time. Never carries the raw payload or user
+// code; only the specific fields each notice kind needs to render/search.
+export const providerNoticeNormalizedMetadataSchema = z.discriminatedUnion(
+  "type",
+  [
+    z.object({
+      type: z.literal("model_rerouted"),
+      fromModel: z.string(),
+      toModel: z.string(),
+      reason: z.string(),
+    }),
+    z.object({
+      type: z.literal("model_verification"),
+      verifications: z.array(z.string()),
+    }),
+    z.object({
+      type: z.literal("safety_buffering"),
+      model: z.string(),
+      fasterModel: z.string().nullable(),
+      useCases: z.array(z.string()),
+      reasons: z.array(z.string()),
+      terminalReason: z.string().nullable(),
+    }),
+  ],
+);
+export type ProviderNoticeNormalizedMetadata = z.infer<
+  typeof providerNoticeNormalizedMetadataSchema
+>;
+
+export const providerNoticeMetadataSchema = z.object({
+  harnessId: harnessIdSchema,
+  noticeKind: providerNoticeKindSchema,
+  tone: providerNoticeToneSchema,
+  title: z.string(),
+  message: z.string().nullable(),
+  details: z.array(providerNoticeDetailSchema),
+  metadata: providerNoticeNormalizedMetadataSchema.nullable(),
+});
+export type ProviderNoticeMetadata = z.infer<typeof providerNoticeMetadataSchema>;
+
 export const textBlockSchema = z.object({
   ...baseBlockFields,
   type: z.literal("text"),
   text: z.string(),
+  // Additive enrichment: when set, this text block is a durable provider
+  // notice (Codex model reroute / safety verification / buffering) and a
+  // `chat.subscribe@1.3`+ reader projects it to a compact provider-notice
+  // segment. `text` always carries a concise fallback rendering, so a reader
+  // that strips or predates this key still renders plain assistant text -
+  // this is NOT a new persisted `ContentBlock.type`. Nullable + defaulted so
+  // blocks persisted before this field parse cleanly, and so pre-1.3 stream
+  // subscribers can be projected down to the fallback text (see
+  // `chat-frame-projection.ts`).
+  providerNotice: providerNoticeMetadataSchema.nullable().default(null),
 });
 export type TextBlock = z.infer<typeof textBlockSchema>;
 


### PR DESCRIPTION
## Summary
- add compatibility-safe provider notice metadata on text blocks and live `provider_notice.upsert` runtime events
- collapse unreleased chat.subscribe additions onto live 1.3 and downgrade provider notice frames for older subscribers
- render provider notices in GUI transcript and sub-agent cards, including find/text extraction

## Verification
- pre-commit affected workspace checks passed for the submodule commit
- earlier targeted protocol/gui checks passed during implementation

## Notes
- Internal host changes are in a companion `traycer-internal` PR and pin this submodule commit.