### PR TITLE
Simplify rate limit usage fetch copy

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -699,9 +699,7 @@ describe("<RateLimitPopover /> per-provider states", () => {
       codex: degradedRetainedResult(codexReady(), "usage_fetch_failed"),
     };
     renderPopover();
-    expect(
-      screen.getByText(/· couldn't fetch usage — will retry/),
-    ).toBeTruthy();
+    expect(screen.getByText(/· failed to fetch usage/)).toBeTruthy();
     expect(screen.getByText(/^Updated \d+m ago ·/)).toBeTruthy();
     expect(screen.queryByText(/^Updated Just now ·/)).toBeNull();
     expect(screen.queryByText(/· refresh failed/)).toBeNull();

--- a/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
+++ b/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
@@ -48,7 +48,7 @@ describe("formatUnavailableReason", () => {
 
   it("maps the transient usage-fetch-failed reason to retry-oriented copy, distinct from the account-capability wording", () => {
     expect(formatUnavailableReason("usage_fetch_failed")).toBe(
-      "couldn't fetch usage — will retry",
+      "failed to fetch usage",
     );
     expect(formatUnavailableReason("usage_fetch_failed")).not.toBe(
       formatUnavailableReason("rate_limits_not_available"),

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -85,7 +85,7 @@ const RATE_LIMIT_UNAVAILABLE_REASON_LABELS: Record<
   // capability problem like `rate_limits_not_available`. Distinct wording is
   // the point: this recovers on its own (the queue's post-failure cool-down
   // plus the next poll), so it must never read like a permanent account issue.
-  usage_fetch_failed: "couldn't fetch usage — will retry",
+  usage_fetch_failed: "failed to fetch usage",
 };
 
 export function formatUnavailableReason(


### PR DESCRIPTION
## Summary
- Changes the transient usage-fetch-failed label to "failed to fetch usage"
- Updates rate-limit content and popover tests for the new copy

## Validation
- bun run test --run src/lib/__tests__/provider-rate-limit-content.test.ts src/components/layout/header/__tests__/rate-limit-popover.test.tsx
- bun run lint
- bun run compile
- npx -y react-doctor@latest . --scope changed --base origin/main --offline --no-score
- pre-commit affected workspace checks