### PR TITLE
gui-app: nested-focus back/forward navigation

### DIFF
--- a/clients/gui-app/eslint.config.mjs
+++ b/clients/gui-app/eslint.config.mjs
@@ -13,7 +13,10 @@ import pluginQuery from "@tanstack/eslint-plugin-query";
 import pluginRouter from "@tanstack/eslint-plugin-router";
 import { traycerTypeSafetyRestrictions } from "../../eslint/traycer-type-safety-rules.mjs";
 import { traycerClientsImportBoundaryRestrictions } from "../../eslint/traycer-clients-import-boundary-rules.mjs";
-import { nestedFocusBoundaryRestrictions } from "../../eslint/traycer-nested-focus-boundary-rules.mjs";
+import {
+  nestedFocusBoundaryRestrictions,
+  tabNavigationStoreActionRestrictions,
+} from "../../eslint/traycer-nested-focus-boundary-rules.mjs";
 
 // Do not subscribe to the entire Zustand store - reused across the base rules
 // and the overrides that still need to ban it.
@@ -55,23 +58,12 @@ const reactForwardRefCallBan = {
   message:
     "React 19 treats refs as regular props. Type and destructure a `ref` prop instead of wrapping the component in React.forwardRef.",
 };
-const setActiveTabDirectCallBan = {
-  selector:
-    "CallExpression[callee.type='MemberExpression'][callee.property.name='setActiveTab']",
-  message:
-    "Do not call setActiveTab directly - route through navigateToTabIntent in lib/tab-navigation.ts so every entry point performs the same activate-then-navigate dance.",
-};
-const setActiveDraftDirectCallBan = {
-  selector:
-    "CallExpression[callee.type='MemberExpression'][callee.property.name='setActiveDraft']",
-  message:
-    "Do not call setActiveDraft directly - route through navigateToTabIntent in lib/tab-navigation.ts so every entry point performs the same activate-then-navigate dance.",
-};
 const epicTabRouteConstructionBan = {
   selector: "CallExpression[callee.name='epicTabRoute']",
   message:
     "Do not construct epicTabRoute() at the call site - pass an `existingEpicTabIntent({...})` (or similar TabNavigationIntent) to navigateToTabIntent; the route shape is owned by lib/tab-navigation.ts and lib/routes.ts.",
 };
+const tabNavigationStoreActionBans = tabNavigationStoreActionRestrictions([]);
 
 // Every general-purpose app file gets these regardless of the nested-focus-
 // boundary allowlist below - overrides that scope out a boundary action must
@@ -83,8 +75,7 @@ const generalCustomSyntaxRestrictions = [
   forwardRefImportBan,
   forwardRefCallBan,
   reactForwardRefCallBan,
-  setActiveTabDirectCallBan,
-  setActiveDraftDirectCallBan,
+  ...tabNavigationStoreActionBans,
   epicTabRouteConstructionBan,
 ];
 
@@ -244,6 +235,27 @@ export default tseslint.config(
         "error",
         ...traycerTypeSafetyRestrictions,
         noFullStoreSubscription,
+      ],
+    },
+  },
+  {
+    // Router -> store synchronization direction for an already-committed epic
+    // route. This is the inverse of navigateToTabIntent's entry-point seam,
+    // so it may read the store action directly while the rest of the app may
+    // not.
+    files: ["src/routes/epic-tab-route-components.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...traycerTypeSafetyRestrictions,
+        noFullStoreSubscription,
+        ...generalCustomSyntaxRestrictions.filter(
+          (restriction) => !tabNavigationStoreActionBans.includes(restriction),
+        ),
+        ...tabNavigationStoreActionRestrictions([
+          "useEpicCanvasStore.setActiveTab",
+        ]),
+        ...nestedFocusBoundaryRestrictions([]),
       ],
     },
   },

--- a/clients/gui-app/eslint.config.mjs
+++ b/clients/gui-app/eslint.config.mjs
@@ -13,6 +13,7 @@ import pluginQuery from "@tanstack/eslint-plugin-query";
 import pluginRouter from "@tanstack/eslint-plugin-router";
 import { traycerTypeSafetyRestrictions } from "../../eslint/traycer-type-safety-rules.mjs";
 import { traycerClientsImportBoundaryRestrictions } from "../../eslint/traycer-clients-import-boundary-rules.mjs";
+import { nestedFocusBoundaryRestrictions } from "../../eslint/traycer-nested-focus-boundary-rules.mjs";
 
 // Do not subscribe to the entire Zustand store - reused across the base rules
 // and the overrides that still need to ban it.
@@ -22,6 +23,70 @@ const noFullStoreSubscription = {
   message:
     "Do not subscribe to the entire Zustand store. Pass a granular selector: useXxxStore((s) => s.specificField).",
 };
+
+// Named individually (rather than left inline in the base rule array) so
+// per-file overrides can recompose the full set minus one entry, instead of
+// silently dropping all of them the way a from-scratch override array would.
+const jsxKeyNullishCoalesceLiteral = {
+  selector:
+    "JSXAttribute[name.name='key'] > JSXExpressionContainer > LogicalExpression[operator='??'][right.type='Literal']",
+  message:
+    "Do not add literal nullish-coalescing fallbacks to JSX keys. Let the key be undefined unless you need a real identity fallback.",
+};
+const jsxKeyNullishCoalesceTemplate = {
+  selector:
+    "JSXAttribute[name.name='key'] > JSXExpressionContainer > LogicalExpression[operator='??'][right.type='TemplateLiteral'][right.expressions.length=0]",
+  message:
+    "Do not add literal nullish-coalescing fallbacks to JSX keys. Let the key be undefined unless you need a real identity fallback.",
+};
+const forwardRefImportBan = {
+  selector: "ImportSpecifier[imported.name='forwardRef']",
+  message:
+    "React 19 treats refs as regular props. Type and destructure a `ref` prop instead of importing forwardRef.",
+};
+const forwardRefCallBan = {
+  selector: "CallExpression[callee.name='forwardRef']",
+  message:
+    "React 19 treats refs as regular props. Type and destructure a `ref` prop instead of wrapping the component in forwardRef.",
+};
+const reactForwardRefCallBan = {
+  selector:
+    "CallExpression[callee.type='MemberExpression'][callee.object.name='React'][callee.property.name='forwardRef']",
+  message:
+    "React 19 treats refs as regular props. Type and destructure a `ref` prop instead of wrapping the component in React.forwardRef.",
+};
+const setActiveTabDirectCallBan = {
+  selector:
+    "CallExpression[callee.type='MemberExpression'][callee.property.name='setActiveTab']",
+  message:
+    "Do not call setActiveTab directly - route through navigateToTabIntent in lib/tab-navigation.ts so every entry point performs the same activate-then-navigate dance.",
+};
+const setActiveDraftDirectCallBan = {
+  selector:
+    "CallExpression[callee.type='MemberExpression'][callee.property.name='setActiveDraft']",
+  message:
+    "Do not call setActiveDraft directly - route through navigateToTabIntent in lib/tab-navigation.ts so every entry point performs the same activate-then-navigate dance.",
+};
+const epicTabRouteConstructionBan = {
+  selector: "CallExpression[callee.name='epicTabRoute']",
+  message:
+    "Do not construct epicTabRoute() at the call site - pass an `existingEpicTabIntent({...})` (or similar TabNavigationIntent) to navigateToTabIntent; the route shape is owned by lib/tab-navigation.ts and lib/routes.ts.",
+};
+
+// Every general-purpose app file gets these regardless of the nested-focus-
+// boundary allowlist below - overrides that scope out a boundary action must
+// still spread this array back in, not drop it by writing a from-scratch
+// `no-restricted-syntax` value.
+const generalCustomSyntaxRestrictions = [
+  jsxKeyNullishCoalesceLiteral,
+  jsxKeyNullishCoalesceTemplate,
+  forwardRefImportBan,
+  forwardRefCallBan,
+  reactForwardRefCallBan,
+  setActiveTabDirectCallBan,
+  setActiveDraftDirectCallBan,
+  epicTabRouteConstructionBan,
+];
 
 export default tseslint.config(
   { ignores: [...commonIgnores, "src/routeTree.gen.ts"] },
@@ -119,51 +184,8 @@ export default tseslint.config(
         "error",
         ...traycerTypeSafetyRestrictions,
         noFullStoreSubscription,
-        {
-          selector:
-            "JSXAttribute[name.name='key'] > JSXExpressionContainer > LogicalExpression[operator='??'][right.type='Literal']",
-          message:
-            "Do not add literal nullish-coalescing fallbacks to JSX keys. Let the key be undefined unless you need a real identity fallback.",
-        },
-        {
-          selector:
-            "JSXAttribute[name.name='key'] > JSXExpressionContainer > LogicalExpression[operator='??'][right.type='TemplateLiteral'][right.expressions.length=0]",
-          message:
-            "Do not add literal nullish-coalescing fallbacks to JSX keys. Let the key be undefined unless you need a real identity fallback.",
-        },
-        {
-          selector: "ImportSpecifier[imported.name='forwardRef']",
-          message:
-            "React 19 treats refs as regular props. Type and destructure a `ref` prop instead of importing forwardRef.",
-        },
-        {
-          selector: "CallExpression[callee.name='forwardRef']",
-          message:
-            "React 19 treats refs as regular props. Type and destructure a `ref` prop instead of wrapping the component in forwardRef.",
-        },
-        {
-          selector:
-            "CallExpression[callee.type='MemberExpression'][callee.object.name='React'][callee.property.name='forwardRef']",
-          message:
-            "React 19 treats refs as regular props. Type and destructure a `ref` prop instead of wrapping the component in React.forwardRef.",
-        },
-        {
-          selector:
-            "CallExpression[callee.type='MemberExpression'][callee.property.name='setActiveTab']",
-          message:
-            "Do not call setActiveTab directly - route through navigateToTabIntent in lib/tab-navigation.ts so every entry point performs the same activate-then-navigate dance.",
-        },
-        {
-          selector:
-            "CallExpression[callee.type='MemberExpression'][callee.property.name='setActiveDraft']",
-          message:
-            "Do not call setActiveDraft directly - route through navigateToTabIntent in lib/tab-navigation.ts so every entry point performs the same activate-then-navigate dance.",
-        },
-        {
-          selector: "CallExpression[callee.name='epicTabRoute']",
-          message:
-            "Do not construct epicTabRoute() at the call site - pass an `existingEpicTabIntent({...})` (or similar TabNavigationIntent) to navigateToTabIntent; the route shape is owned by lib/tab-navigation.ts and lib/routes.ts.",
-        },
+        ...generalCustomSyntaxRestrictions,
+        ...nestedFocusBoundaryRestrictions([]),
       ],
 
       // ── ESLint core: code quality ───────────────────────────────────────────
@@ -222,6 +244,83 @@ export default tseslint.config(
         "error",
         ...traycerTypeSafetyRestrictions,
         noFullStoreSubscription,
+      ],
+    },
+  },
+
+  // ── Nested-focus-opener boundary allowlist ──────────────────────────────────
+  // See eslint/traycer-nested-focus-boundary-rules.mjs for the contract this
+  // enforces. Every entry below is a verified, empirical exception (grep the
+  // codebase for the two banned AST shapes before adding another) - not a
+  // restatement of the original audit brief, which over-listed several files
+  // that turned out to already be boundary-backed.
+  {
+    // Route -> store sync direction: applies an already-resolved/committed
+    // route target into the canvas (the inverse of the boundary, which goes
+    // store -> route), plus the legacy pre-nested-focus auto-open/cleanup
+    // paths that only run when there is no nested route target yet.
+    files: [
+      "src/components/epic-canvas/hooks/use-epic-route-synchronization.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...traycerTypeSafetyRestrictions,
+        noFullStoreSubscription,
+        ...generalCustomSyntaxRestrictions,
+        ...nestedFocusBoundaryRestrictions([
+          "openTileInTab",
+          "closeCanvasTab",
+          "applyNestedRouteFocus",
+        ]),
+      ],
+    },
+  },
+  {
+    // Blank-root bootstrap: seeds the first and only tile of a brand-new
+    // empty canvas root. There is no prior focus to disambiguate, so there
+    // is nothing meaningful to write to the route.
+    files: ["src/components/epic-canvas/canvas/tile-canvas.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...traycerTypeSafetyRestrictions,
+        noFullStoreSubscription,
+        ...generalCustomSyntaxRestrictions,
+        ...nestedFocusBoundaryRestrictions(["openTileInTab"]),
+      ],
+    },
+  },
+  {
+    // Registers a server-created terminal as a saved background tab without
+    // activating it - prepareOpenTileInBackgroundTabFocusTarget always
+    // returns a null focus delta, so this call never needs a route write.
+    files: ["src/hooks/chats/use-setup-terminal-tab-register-driver.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...traycerTypeSafetyRestrictions,
+        noFullStoreSubscription,
+        ...generalCustomSyntaxRestrictions,
+        ...nestedFocusBoundaryRestrictions(["openTileInBackgroundTab"]),
+      ],
+    },
+  },
+  {
+    // Bulk-delete batches N raw closeCanvasTab calls inside a hand-rolled
+    // `prepare` closure passed to navigateNested, then commits ONE aggregate
+    // post-batch focus target - the same raw-then-diff shape the store's own
+    // prepare*FocusTarget wrappers use internally, just batched. Owned by a
+    // sibling agent's in-progress bulk-delete fixup; re-verify this
+    // classification if that implementation changes shape.
+    files: ["src/components/epic-canvas/sidebar/epic-sidebar.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...traycerTypeSafetyRestrictions,
+        noFullStoreSubscription,
+        ...generalCustomSyntaxRestrictions,
+        ...nestedFocusBoundaryRestrictions(["closeCanvasTab"]),
       ],
     },
   },

--- a/clients/gui-app/src/__tests__/nested-focus-boundary-lint.test.ts
+++ b/clients/gui-app/src/__tests__/nested-focus-boundary-lint.test.ts
@@ -1,0 +1,222 @@
+/// <reference types="node" />
+
+import { Linter } from "eslint";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+type RestrictedSyntaxRestriction = {
+  readonly selector: string;
+  readonly message: string;
+};
+
+type RestrictionFactory = (
+  allowedNames: readonly string[],
+) => readonly RestrictedSyntaxRestriction[];
+
+type LintRuleModule = {
+  readonly nestedFocusBoundaryRestrictions: RestrictionFactory;
+  readonly tabNavigationStoreActionRestrictions: RestrictionFactory;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isRestriction(value: unknown): value is RestrictedSyntaxRestriction {
+  return (
+    isRecord(value) &&
+    typeof value.selector === "string" &&
+    typeof value.message === "string"
+  );
+}
+
+function readRestrictionArray(
+  value: unknown,
+): readonly RestrictedSyntaxRestriction[] {
+  const restrictions = Array.isArray(value) ? value : [];
+  if (restrictions.every(isRestriction)) return restrictions;
+  throw new Error("Expected no-restricted-syntax restriction objects");
+}
+
+function readRestrictionFactory(value: unknown): RestrictionFactory {
+  if (typeof value !== "function") {
+    throw new Error("Expected restriction factory export");
+  }
+  return (allowedNames) =>
+    readRestrictionArray(Reflect.apply(value, undefined, [allowedNames]));
+}
+
+function readLintRuleModule(value: unknown): LintRuleModule {
+  if (!isRecord(value)) throw new Error("Expected lint rule module object");
+  return {
+    nestedFocusBoundaryRestrictions: readRestrictionFactory(
+      value.nestedFocusBoundaryRestrictions,
+    ),
+    tabNavigationStoreActionRestrictions: readRestrictionFactory(
+      value.tabNavigationStoreActionRestrictions,
+    ),
+  };
+}
+
+const lintRuleModuleUrl = pathToFileURL(
+  path.resolve(
+    process.cwd(),
+    "../../eslint/traycer-nested-focus-boundary-rules.mjs",
+  ),
+).href;
+const importedLintRuleModule: unknown = await import(lintRuleModuleUrl);
+const lintRuleModule = readLintRuleModule(importedLintRuleModule);
+
+function lint(
+  code: string,
+  restrictions: readonly RestrictedSyntaxRestriction[],
+) {
+  const linter = new Linter({ configType: "flat" });
+  return linter.verify(
+    code,
+    {
+      languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+      rules: {
+        "no-restricted-syntax": ["error", ...restrictions],
+      },
+    },
+    { filename: "fixture.js" },
+  );
+}
+
+describe("nestedFocusBoundaryRestrictions", () => {
+  const restrictions = lintRuleModule.nestedFocusBoundaryRestrictions([]);
+
+  it.each([
+    {
+      name: "direct concise selector pick",
+      code: "const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);",
+    },
+    {
+      name: "helper-wrapped concise selector pick",
+      code: "const closeCanvasTab = useEpicCanvasStore(useShallow((s) => s.closeCanvasTab));",
+    },
+    {
+      name: "block-bodied selector return",
+      code: "const closeCanvasTab = useEpicCanvasStore((s) => { return s.closeCanvasTab; });",
+    },
+    {
+      name: "direct getState action call",
+      code: 'useEpicCanvasStore.getState().closeCanvasTab("tab-id");',
+    },
+    {
+      name: "literal-computed getState action call",
+      code: 'useEpicCanvasStore.getState()["closeCanvasTab"]("tab-id");',
+    },
+    {
+      name: "getState object destructuring",
+      code: "const { closeCanvasTab } = useEpicCanvasStore.getState();",
+    },
+    {
+      name: "literal-computed getState object destructuring",
+      code: 'const { ["closeCanvasTab"]: closeCanvasTab } = useEpicCanvasStore.getState();',
+    },
+  ])("flags $name", ({ code }) => {
+    expect(lint(code, restrictions)).toHaveLength(1);
+  });
+
+  it("allows boundary-backed and unrelated shapes", () => {
+    expect(
+      lint(
+        `
+          const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+            (s) => s.prepareCloseCanvasTabFocusTarget,
+          );
+          navigateNested({
+            prepare: () => prepareCloseCanvasTabFocusTarget("tab-id"),
+          });
+          otherStore.getState().closeCanvasTab("tab-id");
+          other.closeCanvasTab("tab-id");
+          const x = useEpicCanvasStore((s) =>
+            otherStore((o) => o.closeCanvasTab),
+          );
+          useEpicCanvasStore((s) => helper(() => s.closeCanvasTab));
+        `,
+        restrictions,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("honors allowed raw action names", () => {
+    expect(
+      lint(
+        `
+          const closeCanvasTab = useEpicCanvasStore((s) => {
+            return s.closeCanvasTab;
+          });
+          useEpicCanvasStore.getState()["closeCanvasTab"]("tab-id");
+          const { closeCanvasTab: closeTab } = useEpicCanvasStore.getState();
+          closeTab("tab-id");
+        `,
+        lintRuleModule.nestedFocusBoundaryRestrictions(["closeCanvasTab"]),
+      ),
+    ).toHaveLength(0);
+  });
+});
+
+describe("tabNavigationStoreActionRestrictions", () => {
+  const restrictions = lintRuleModule.tabNavigationStoreActionRestrictions([]);
+
+  it.each([
+    {
+      name: "epic setActiveTab selector pick",
+      code: "const setActiveTab = useEpicCanvasStore((s) => s.setActiveTab);",
+    },
+    {
+      name: "epic setActiveTab getState call",
+      code: 'useEpicCanvasStore.getState().setActiveTab("tab-id");',
+    },
+    {
+      name: "epic setActiveTab computed getState call",
+      code: 'useEpicCanvasStore.getState()["setActiveTab"]("tab-id");',
+    },
+    {
+      name: "epic setActiveTab destructuring",
+      code: "const { setActiveTab } = useEpicCanvasStore.getState();",
+    },
+    {
+      name: "draft setActiveDraft selector pick",
+      code: "const setActiveDraft = useLandingDraftStore((s) => s.setActiveDraft);",
+    },
+    {
+      name: "draft setActiveDraft getState call",
+      code: 'useLandingDraftStore.getState().setActiveDraft("draft-id");',
+    },
+  ])("flags $name", ({ code }) => {
+    expect(lint(code, restrictions)).toHaveLength(1);
+  });
+
+  it("allows unrelated receivers with the same action names", () => {
+    expect(
+      lint(
+        `
+          useRateLimitPopoverStore.getState().setActiveTab("codex");
+          notificationTabs.setActiveTab("unread");
+          other.getState().setActiveDraft("draft-id");
+        `,
+        restrictions,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("honors allowed store/action names", () => {
+    expect(
+      lint(
+        `
+          const setActiveTab = useEpicCanvasStore((s) => s.setActiveTab);
+          useEpicCanvasStore.getState().setActiveTab("tab-id");
+          useLandingDraftStore.getState().setActiveDraft("draft-id");
+        `,
+        lintRuleModule.tabNavigationStoreActionRestrictions([
+          "useEpicCanvasStore.setActiveTab",
+        ]),
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/clients/gui-app/src/__tests__/nested-focus-boundary-mock.ts
+++ b/clients/gui-app/src/__tests__/nested-focus-boundary-mock.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+
+export type PrepareNestedFocusTarget = () => NestedFocusTarget | null;
+
+/**
+ * Shared mock for the nested-focus-opener boundary
+ * (`useEpicNestedFocusNavigation`). The spy runs `prepare` against the REAL
+ * canvas store instead of a stub, so assertions see the actual resulting
+ * canvas state - only the route write itself is skipped. Import this module
+ * first (before importing the component under test) so `vi.mock` registers
+ * before anything pulls in the real hook.
+ *
+ * Mocking the raw canvas store instead of this boundary is exactly the
+ * pattern that let two of the six nested-focus regressions ship with a
+ * passing test suite - this is the one target test authors should reach for.
+ */
+const mockState = vi.hoisted(() => ({
+  navigateNested: vi.fn(
+    (_epicId: string, _tabId: string, prepare: PrepareNestedFocusTarget) =>
+      prepare(),
+  ),
+}));
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => mockState.navigateNested,
+}));
+
+export const nestedFocusBoundaryMock = mockState;

--- a/clients/gui-app/src/__tests__/nested-focus-boundary-mock.ts
+++ b/clients/gui-app/src/__tests__/nested-focus-boundary-mock.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
-import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import type { PrepareNestedFocusTarget } from "@/lib/epic-nested-focus-navigation";
 
-export type PrepareNestedFocusTarget = () => NestedFocusTarget | null;
+export type { PrepareNestedFocusTarget };
 
 /**
  * Shared mock for the nested-focus-opener boundary

--- a/clients/gui-app/src/__tests__/nested-focus-interaction-fixtures.test.tsx
+++ b/clients/gui-app/src/__tests__/nested-focus-interaction-fixtures.test.tsx
@@ -161,6 +161,7 @@ const ROWS: ReadonlyArray<OpenerFixtureRow> = [
       fireEvent.click(row);
     },
     assertFocusWritten: (search) => {
+      expect(search.focusPaneId).toEqual(expect.any(String));
       expect(search.focusTileInstanceId).toEqual(expect.any(String));
     },
   },
@@ -178,6 +179,7 @@ const ROWS: ReadonlyArray<OpenerFixtureRow> = [
       fireEvent.click(button);
     },
     assertFocusWritten: (search) => {
+      expect(search.focusPaneId).toEqual(expect.any(String));
       expect(search.focusTileInstanceId).toEqual(expect.any(String));
     },
   },
@@ -202,6 +204,7 @@ const ROWS: ReadonlyArray<OpenerFixtureRow> = [
       fireEvent.click(row);
     },
     assertFocusWritten: (search) => {
+      expect(search.focusPaneId).toEqual(expect.any(String));
       expect(search.focusTileInstanceId).toEqual(expect.any(String));
     },
   },
@@ -228,6 +231,7 @@ const ROWS: ReadonlyArray<OpenerFixtureRow> = [
       fireEvent.click(button);
     },
     assertFocusWritten: (search) => {
+      expect(search.focusPaneId).toEqual(expect.any(String));
       expect(search.focusTileInstanceId).toEqual(expect.any(String));
     },
   },

--- a/clients/gui-app/src/__tests__/nested-focus-interaction-fixtures.test.tsx
+++ b/clients/gui-app/src/__tests__/nested-focus-interaction-fixtures.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * Table-driven integration harness for the nested-focus-opener boundary: a
+ * REAL canvas store plus a REAL TanStack router (via
+ * `renderNestedFocusFixture`), asserting the ACTUAL
+ * `router.state.location.search.focusPaneId` / `focusTileInstanceId` after a
+ * genuine DOM interaction on a representative opener affordance. This is the
+ * only layer that would still catch the regression class (a leaf calling a
+ * raw canvas store action instead of the boundary) even if the ESLint rule
+ * and the shared test-mock helper both failed to prevent it - lint and
+ * mocked-boundary tests can both pass while the route write silently never
+ * happens; only a real router observes that.
+ *
+ * Coverage table (rows below) plus affordances evaluated and dropped:
+ * - Sidebar terminal open (`TerminalsPanelBody` in `epic-terminal-sidebar.tsx`)
+ *   - dropped: requires host-RPC (`useTerminalList`) and `SnapshotGate`
+ *     plumbing unrelated to the boundary itself. Substituted with the
+ *     `useFocusEpicTerminalSession` row below, which exercises the same
+ *     open-or-focus-terminal boundary call with a lean `TabHostProvider`
+ *     wrapper instead of the full sidebar body's host/query infrastructure.
+ * - Snapshot bundle "File" button (`SnapshotBundleDiffTileContent`)
+ *   - dropped: requires mocking `react-virtuoso`, the bundle-diff
+ *     find-registration hooks, and the diff-content-primitive renderer -
+ *     substantial unrelated surface for one more table row. Already covered
+ *     end to end by its own dedicated
+ *     `snapshot-bundle-diff-file-navigation.test.tsx`.
+ *
+ * Table breadth can grow later; the harness existing at all is the point.
+ */
+import type { ReactElement } from "react";
+import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderNestedFocusFixture } from "@/__tests__/nested-focus-router-harness";
+import { TabHostProvider } from "@/components/epic-canvas/tab-host-provider";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { FileRow } from "@/components/epic-canvas/git-diff/file-row";
+import { useFocusEpicTerminalSession } from "@/components/epic-canvas/renderers/chat-tile-focus-terminal";
+import { ArtifactChildIndex } from "@/components/epic-canvas/renderers/artifact-child-index";
+import { useTraycerReferenceOpenHandler } from "@/markdown/components/use-traycer-reference-open";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { GitChangedFileV11 } from "@traycer/protocol/host";
+import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+
+const epicSelectors = vi.hoisted<{
+  childIdsByParent: Record<string, ReadonlyArray<string>>;
+  nodesById: Record<
+    string,
+    { readonly type: string; readonly title: string; readonly status: null }
+  >;
+  sameEpicNodeRef: EpicNodeRef | null;
+}>(() => ({
+  childIdsByParent: {},
+  nodesById: {},
+  sameEpicNodeRef: null,
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({
+    setNodeRef: vi.fn(),
+    listeners: undefined,
+    attributes: {},
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useChildIdsOf: (parentId: string) =>
+    epicSelectors.childIdsByParent[parentId] ?? [],
+  useTreeNodeById: (nodeId: string) => epicSelectors.nodesById[nodeId] ?? null,
+  epicNodeRefForNodeId: () => epicSelectors.sameEpicNodeRef,
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-1",
+}));
+
+const referenceOpenEpicHandle = vi.hoisted<{
+  handle: {
+    readonly epicId: string;
+    readonly store: { readonly getState: () => object };
+  } | null;
+}>(() => ({
+  handle: null,
+}));
+
+vi.mock("@/providers/use-open-epic-handle", () => ({
+  useMaybeOpenEpicHandle: () => referenceOpenEpicHandle.handle,
+}));
+
+function changedFile(path: string): GitChangedFileV11 {
+  return {
+    path,
+    previousPath: null,
+    status: "modified",
+    stage: "unstaged",
+    isBinary: false,
+    insertions: 3,
+    deletions: 1,
+    sizeBytes: 100,
+    stagedOid: null,
+    worktreeOid: null,
+    gitlink: null,
+  };
+}
+
+function TerminalFocusButton(props: { readonly viewTabId: string }) {
+  const focus = useFocusEpicTerminalSession(props.viewTabId);
+  return (
+    <button type="button" onClick={() => focus("term-1", "/work/repo")}>
+      Focus terminal
+    </button>
+  );
+}
+
+function ReferenceChip(props: {
+  readonly epicId: string;
+  readonly nodeId: string;
+}) {
+  const { onOpen } = useTraycerReferenceOpenHandler({
+    epicId: props.epicId,
+    nodeId: props.nodeId,
+    requiresNode: true,
+  });
+  return (
+    <button type="button" onClick={(event) => onOpen?.(event)}>
+      Reference chip
+    </button>
+  );
+}
+
+interface OpenerFixtureRow {
+  readonly name: string;
+  readonly build: (epicId: string, tabId: string) => ReactElement;
+  readonly interact: () => Promise<void>;
+  readonly assertFocusWritten: (search: {
+    readonly focusPaneId: string | undefined;
+    readonly focusTileInstanceId: string | undefined;
+  }) => void;
+}
+
+const ROWS: ReadonlyArray<OpenerFixtureRow> = [
+  {
+    name: "git file row preview",
+    build: (epicId, tabId) => (
+      <TooltipProvider>
+        <FileRow
+          epicId={epicId}
+          viewTabId={tabId}
+          hostId="host-1"
+          runningDir="/repo"
+          file={changedFile("src/app.ts")}
+          active={false}
+          pathRanges={[]}
+          nested={false}
+        />
+      </TooltipProvider>
+    ),
+    interact: async () => {
+      const row = await screen.findByRole("button", {
+        name: "Modified app.ts in src",
+      });
+      fireEvent.click(row);
+    },
+    assertFocusWritten: (search) => {
+      expect(search.focusTileInstanceId).toEqual(expect.any(String));
+    },
+  },
+  {
+    name: "sidebar terminal open (via useFocusEpicTerminalSession)",
+    build: (_epicId, tabId) => (
+      <TabHostProvider hostId="host-1">
+        <TerminalFocusButton viewTabId={tabId} />
+      </TabHostProvider>
+    ),
+    interact: async () => {
+      const button = await screen.findByRole("button", {
+        name: "Focus terminal",
+      });
+      fireEvent.click(button);
+    },
+    assertFocusWritten: (search) => {
+      expect(search.focusTileInstanceId).toEqual(expect.any(String));
+    },
+  },
+  {
+    name: "artifact child-index row",
+    build: (epicId, tabId) => {
+      epicSelectors.childIdsByParent = { "parent-1": ["child-story"] };
+      epicSelectors.nodesById = {
+        "child-story": { type: "story", title: "Child Story", status: null },
+      };
+      return (
+        <ArtifactChildIndex
+          epicId={epicId}
+          parentId="parent-1"
+          viewTabId={tabId}
+          hostId="host-1"
+        />
+      );
+    },
+    interact: async () => {
+      const row = await screen.findByRole("button", { name: "Child Story" });
+      fireEvent.click(row);
+    },
+    assertFocusWritten: (search) => {
+      expect(search.focusTileInstanceId).toEqual(expect.any(String));
+    },
+  },
+  {
+    name: "markdown reference chip (same-epic node)",
+    build: (epicId, _tabId) => {
+      referenceOpenEpicHandle.handle = {
+        epicId,
+        store: { getState: () => ({}) },
+      };
+      epicSelectors.sameEpicNodeRef = {
+        id: "spec-1",
+        instanceId: "spec-instance-1",
+        type: "spec",
+        name: "Spec One",
+        hostId: "host-1",
+      };
+      return <ReferenceChip epicId={epicId} nodeId="spec-1" />;
+    },
+    interact: async () => {
+      const button = await screen.findByRole("button", {
+        name: "Reference chip",
+      });
+      fireEvent.click(button);
+    },
+    assertFocusWritten: (search) => {
+      expect(search.focusTileInstanceId).toEqual(expect.any(String));
+    },
+  },
+];
+
+function resetCanvas(): void {
+  window.localStorage.clear();
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  epicSelectors.childIdsByParent = {};
+  epicSelectors.nodesById = {};
+  epicSelectors.sameEpicNodeRef = null;
+  referenceOpenEpicHandle.handle = null;
+}
+
+describe("nested focus interaction fixtures", () => {
+  beforeEach(() => {
+    cleanup();
+    resetCanvas();
+  });
+
+  afterEach(cleanup);
+
+  it.each(ROWS)(
+    "commits a nested route focus target for: $name",
+    async (row) => {
+      const epicId = "epic-1";
+      const tabId = useEpicCanvasStore.getState().openEpicTab(epicId, "Epic 1");
+
+      const { router } = renderNestedFocusFixture(
+        epicId,
+        tabId,
+        row.build(epicId, tabId),
+      );
+
+      await row.interact();
+
+      await waitFor(() => {
+        row.assertFocusWritten({
+          focusPaneId: router.state.location.search.focusPaneId,
+          focusTileInstanceId: router.state.location.search.focusTileInstanceId,
+        });
+      });
+    },
+  );
+});

--- a/clients/gui-app/src/__tests__/nested-focus-router-harness.tsx
+++ b/clients/gui-app/src/__tests__/nested-focus-router-harness.tsx
@@ -1,0 +1,45 @@
+import type { ReactElement } from "react";
+import {
+  Outlet,
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { render, type RenderResult } from "@testing-library/react";
+import { createPersistentMemoryHistory } from "@/lib/persistent-history";
+import { normalizeEpicFocusSearch } from "@/routes/epic-route-search";
+
+/**
+ * Mounts `ui` as the `/epics/$epicId/$tabId` route of a REAL TanStack router
+ * backed by a persistent (branded) memory history - the desktop gate
+ * `useEpicNestedFocusNavigation` checks via `getHistoryController` - so a
+ * genuine opener interaction inside `ui` actually writes `focusPaneId` /
+ * `focusTileInstanceId` into `router.state.location.search`, not just into a
+ * mocked spy's call args. Read those fields off the returned `router` after
+ * firing the interaction.
+ */
+export function renderNestedFocusFixture(
+  epicId: string,
+  tabId: string,
+  ui: ReactElement,
+) {
+  const history = createPersistentMemoryHistory(
+    `/epics/${epicId}/${tabId}`,
+    `nested-focus-fixture:${epicId}:${tabId}`,
+  );
+  const rootRoute = createRootRoute({ component: Outlet });
+  const epicTabRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/epics/$epicId/$tabId",
+    validateSearch: (search: Record<string, unknown>) =>
+      normalizeEpicFocusSearch(search),
+    component: () => ui,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([epicTabRoute]),
+    history,
+  });
+  const result: RenderResult = render(<RouterProvider router={router} />);
+  return { router, ...result };
+}

--- a/clients/gui-app/src/components/__tests__/local-host-gate.test.tsx
+++ b/clients/gui-app/src/components/__tests__/local-host-gate.test.tsx
@@ -8,7 +8,15 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
+import {
+  Outlet,
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useRouterState,
+} from "@tanstack/react-router";
 import type {
   HostEnsureResult,
   IHostManagement,
@@ -23,6 +31,7 @@ import {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import {
+  GATE_BYPASS_PATH_PREFIX,
   LOCAL_HOST_SLOW_START_THRESHOLD_MS,
   LocalHostGate,
   LocalHostUnavailable,
@@ -43,6 +52,20 @@ import {
   CURRENT_PHASE_VERSION,
 } from "@traycer-clients/shared/epic/epic-version";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  createPersistentMemoryHistory,
+  getHistoryController,
+} from "@/lib/persistent-history";
+import { goBack, goForward } from "@/lib/commands/actions/history-navigation";
+import {
+  resetSystemTabModalColdLoadForTests,
+  useSystemTabModalController,
+  useSystemTabModalRefreshGuard,
+  type SystemTabModalApi,
+} from "@/stores/tabs/use-system-tab-modal";
+import { systemTabOverlaySearchSchema } from "@/lib/system-tab-overlay-search";
+import { useSettingsSectionStore } from "@/stores/tabs/settings-section-store";
+import { useTabsStore } from "@/stores/tabs/store";
 
 const validSnapshot: LocalHostSnapshot = {
   hostId: "desktop-pid-1",
@@ -1026,6 +1049,303 @@ describe("LocalHostGate", () => {
     expect(screen.queryByTestId("gate-children")).not.toBeNull();
     expect(screen.queryByTestId("gate-unavailable")).toBeNull();
     expect(screen.queryByTestId("gate-loading")).toBeNull();
+  });
+});
+
+describe("LocalHostGate structural stability across the /settings bypass boundary", () => {
+  beforeEach(() => {
+    restoreFetch = installAuthFetch();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useAuthStore.getState().setSignedOut();
+    vi.restoreAllMocks();
+    restoreFetch();
+  });
+
+  it("does not remount children when bypass flips true<->false while the host stays ready", async () => {
+    // Regression coverage for the back-navigation trap: LocalHostGate used to
+    // return `<>{children}</>` on bypass but `<HostCompatibilityGate>
+    // {children}</HostCompatibilityGate>` when ready - different element
+    // types at the same tree position, so React remounted every descendant
+    // (including SystemTabModalHost) on every epic<->settings crossing. Both
+    // branches must now share one element type/tree depth for a signed-in,
+    // ready local host.
+    useAuthStore.getState().setSignedIn(
+      {
+        userId: "test-user",
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      { userId: "test-user", username: "Test User" },
+      [],
+    );
+    const host = makeHost(validSnapshot);
+    seedStoredToken(host);
+    // Stable across rerenders: `HostRuntimeProvider` re-runs its startup
+    // effect (tearing down and rebuilding the whole binding) whenever
+    // `messengerFactory` / `remoteFetcher` change identity, which would mask
+    // the very remount this test checks for.
+    const messengerFactory = buildMessengerFactory(() => compatibleHostStatus);
+    const remoteFetcher = () => Promise.resolve([]);
+    const queryClient = buildQueryClient();
+
+    const mountLog: string[] = [];
+    function MountLogProbe(): ReactNode {
+      useEffect(() => {
+        mountLog.push("mounted");
+        return () => {
+          mountLog.push("unmounted");
+        };
+      }, []);
+      return <div data-testid="gate-children">children</div>;
+    }
+
+    function Harness(props: { readonly bypass: boolean }): ReactNode {
+      return (
+        <RunnerHostProvider runnerHost={host}>
+          <QueryClientProvider client={queryClient}>
+            <TooltipProvider>
+              <HostRuntimeProvider
+                registry={hostRpcRegistry}
+                messengerFactory={messengerFactory}
+                invalidator={null}
+                requestId={null}
+                remoteFetcher={remoteFetcher}
+                fallback={
+                  <div data-testid="runtime-fallback">runtime loading</div>
+                }
+              >
+                <HostCompatibilityProvider>
+                  <LocalHostGate
+                    bypass={props.bypass}
+                    selectedEntry={localEntry}
+                    loading={<div data-testid="gate-loading">loading</div>}
+                    provisioningLoading={null}
+                    unavailable={
+                      <div data-testid="gate-unavailable">unavailable</div>
+                    }
+                  >
+                    <MountLogProbe />
+                  </LocalHostGate>
+                </HostCompatibilityProvider>
+              </HostRuntimeProvider>
+            </TooltipProvider>
+          </QueryClientProvider>
+        </RunnerHostProvider>
+      );
+    }
+
+    const { rerender } = render(<Harness bypass={false} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("gate-children")).not.toBeNull();
+    });
+    expect(mountLog).toEqual(["mounted"]);
+
+    rerender(<Harness bypass />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("gate-children")).not.toBeNull();
+    });
+    expect(mountLog).toEqual(["mounted"]);
+
+    rerender(<Harness bypass={false} />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("gate-children")).not.toBeNull();
+    });
+    expect(mountLog).toEqual(["mounted"]);
+
+    rerender(<Harness bypass />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("gate-children")).not.toBeNull();
+    });
+    expect(mountLog).toEqual(["mounted"]);
+  });
+});
+
+describe("LocalHostGate + system tab modal guard integration", () => {
+  beforeEach(() => {
+    restoreFetch = installAuthFetch();
+    resetSystemTabModalColdLoadForTests();
+    useSettingsSectionStore.setState({ section: null });
+    useTabsStore.setState({ systemTabs: { history: null, settings: null } });
+  });
+
+  afterEach(() => {
+    cleanup();
+    useAuthStore.getState().setSignedOut();
+    vi.restoreAllMocks();
+    restoreFetch();
+    window.localStorage.clear();
+  });
+
+  it("one Back click after promoting the settings overlay leaves settings AND collapses the overlay entry", async () => {
+    // Closes the gap the promotion regression test (which deliberately keeps
+    // a REMOUNTING synthetic gate to isolate layers 2+3) leaves uncovered:
+    // with the REAL fixed LocalHostGate (layer 1) driving `bypass`, back
+    // click #1 from the promoted tab must both leave settings AND collapse
+    // the stray overlay entry in one click - the pre-fix "no bug" behavior
+    // the root-cause artifact's proof section describes for the
+    // non-remounting case.
+    useAuthStore.getState().setSignedIn(
+      {
+        userId: "test-user",
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      { userId: "test-user", username: "Test User" },
+      [],
+    );
+    const host = makeHost(validSnapshot);
+    seedStoredToken(host);
+    const messengerFactory = buildMessengerFactory(() => compatibleHostStatus);
+    const remoteFetcher = () => Promise.resolve([]);
+    const queryClient = buildQueryClient();
+
+    const modalProbe: { current: SystemTabModalApi | null } = { current: null };
+    function ModalHostLike(): ReactNode {
+      useSystemTabModalRefreshGuard();
+      const api = useSystemTabModalController();
+      useEffect(() => {
+        modalProbe.current = api;
+      });
+      return null;
+    }
+
+    function GuardedRootWithRealGate(): ReactNode {
+      const pathname = useRouterState({ select: (s) => s.location.pathname });
+      const bypass = pathname.startsWith(GATE_BYPASS_PATH_PREFIX);
+      return (
+        <LocalHostGate
+          bypass={bypass}
+          selectedEntry={localEntry}
+          loading={<div data-testid="gate-loading">loading</div>}
+          provisioningLoading={null}
+          unavailable={<div data-testid="gate-unavailable">unavailable</div>}
+        >
+          <ModalHostLike />
+          <Outlet />
+        </LocalHostGate>
+      );
+    }
+
+    const windowId = "real-gate-promote-back";
+    window.localStorage.setItem(
+      `traycer-gui-app:last-route:${windowId}`,
+      JSON.stringify({ entries: ["/epics/e/t0", "/epics/e/t1"], index: 1 }),
+    );
+
+    const rootRoute = createRootRoute({
+      validateSearch: (raw) => systemTabOverlaySearchSchema.parse(raw),
+      component: GuardedRootWithRealGate,
+    });
+    const epicRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/epics/$epicId/$tabId",
+      component: () => <div data-testid="epic-route" />,
+    });
+    const settingsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/settings/general",
+      component: () => <div data-testid="settings-route" />,
+    });
+    const router = createRouter({
+      routeTree: rootRoute.addChildren([epicRoute, settingsRoute]),
+      history: createPersistentMemoryHistory(null, windowId),
+    });
+
+    render(
+      <RunnerHostProvider runnerHost={host}>
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <HostRuntimeProvider
+              registry={hostRpcRegistry}
+              messengerFactory={messengerFactory}
+              invalidator={null}
+              requestId={null}
+              remoteFetcher={remoteFetcher}
+              fallback={
+                <div data-testid="runtime-fallback">runtime loading</div>
+              }
+            >
+              <HostCompatibilityProvider>
+                <RouterProvider router={router} />
+              </HostCompatibilityProvider>
+            </HostRuntimeProvider>
+          </TooltipProvider>
+        </QueryClientProvider>
+      </RunnerHostProvider>,
+    );
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/epics/e/t1");
+    });
+    await waitFor(() => expect(modalProbe.current).not.toBeNull());
+
+    act(() => {
+      modalProbe.current?.openSettings({
+        section: null,
+        resetToGeneral: false,
+      });
+    });
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        settingsOverlay: true,
+      }),
+    );
+
+    act(() => {
+      modalProbe.current?.close();
+    });
+    await waitFor(() =>
+      expect(router.state.location.search).not.toHaveProperty(
+        "settingsOverlay",
+      ),
+    );
+
+    act(() => {
+      goForward(router);
+    });
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        settingsOverlay: true,
+      }),
+    );
+
+    act(() => {
+      modalProbe.current?.promoteToTab();
+    });
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/settings/general");
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    act(() => {
+      goBack(router);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    // One click: leaves settings AND the overlay entry is fully collapsed -
+    // no lingering search flag, no dead forward/back step remains.
+    expect(router.state.location.pathname).toBe("/epics/e/t1");
+    expect(router.state.location.search).not.toHaveProperty("settingsOverlay");
+
+    const controller = getHistoryController(router.history);
+    if (controller === null) {
+      throw new Error("expected a persistent controller");
+    }
+    expect(controller.getEntries()).toEqual([
+      "/epics/e/t0",
+      "/epics/e/t1",
+      "/settings/general",
+    ]);
+    expect(controller.getIndex()).toBe(1);
+    expect(controller.canGoBack()).toBe(true);
+    expect(controller.canGoForward()).toBe(true);
   });
 });
 

--- a/clients/gui-app/src/components/chat/__tests__/build-chat-link-policy.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/build-chat-link-policy.test.ts
@@ -91,7 +91,7 @@ vi.mock(
 let pendingCancel: (() => void) | null = null;
 let disposed = false;
 let clickToken = 0;
-const openTilePreviewInTab = vi.fn();
+const previewTileInTab = vi.fn();
 
 function makeDeps(overrides: Partial<ChatLinkPolicyDeps>): ChatLinkPolicyDeps {
   return {
@@ -105,7 +105,7 @@ function makeDeps(overrides: Partial<ChatLinkPolicyDeps>): ChatLinkPolicyDeps {
     queryClient: {} as never,
     client: {} as never,
     navigate: (() => undefined) as never,
-    openTilePreviewInTab,
+    previewTileInTab,
     ...overrides,
   };
 }
@@ -139,7 +139,7 @@ beforeEach(() => {
   pendingCancel = null;
   disposed = false;
   clickToken = 0;
-  openTilePreviewInTab.mockReset();
+  previewTileInTab.mockReset();
   mocks.resolveArtifactByPath.mockReset();
   mocks.openProjectedSidebarNodeInTabWhenAvailable.mockReset();
   mocks.openProjectedSidebarNodeInTabWhenAvailable.mockReturnValue(
@@ -165,7 +165,7 @@ describe("buildChatLinkPolicy", () => {
     const run = buildChatLinkPolicy(makeDeps({}));
     expect(run(fileLink({ isDirectory: true }), lifecycle)).toBe(false);
     expect(mocks.resolveArtifactByPath).not.toHaveBeenCalled();
-    expect(openTilePreviewInTab).not.toHaveBeenCalled();
+    expect(previewTileInTab).not.toHaveBeenCalled();
   });
 
   it("opens a non-artifact path as a workspace-file preview without the RPC", () => {
@@ -177,7 +177,7 @@ describe("buildChatLinkPolicy", () => {
       ["/repo"],
       "src/app.ts",
     );
-    expect(openTilePreviewInTab).toHaveBeenCalledWith(TAB_ID, {
+    expect(previewTileInTab).toHaveBeenCalledWith(TAB_ID, {
       id: "content-1",
     });
   });
@@ -191,7 +191,7 @@ describe("buildChatLinkPolicy", () => {
       42,
       7,
     );
-    expect(openTilePreviewInTab).toHaveBeenCalledTimes(1);
+    expect(previewTileInTab).toHaveBeenCalledTimes(1);
   });
 
   it("resolves a same-epic artifact link and opens it via the projection waiter", async () => {
@@ -220,7 +220,7 @@ describe("buildChatLinkPolicy", () => {
         tabId: TAB_ID,
         nodeId: "artifact-same",
         fallbackHostId: ACTIVE_HOST_ID,
-        openTileInTab: openTilePreviewInTab,
+        openTileInTab: previewTileInTab,
       }),
     );
     // The cancel handle is retained so an unmount can tear the wait down.
@@ -284,13 +284,13 @@ describe("buildChatLinkPolicy", () => {
     run(fileLink({ path: SAME_EPIC_ARTIFACT_PATH }), lifecycle);
     await flush();
 
-    expect(openTilePreviewInTab).toHaveBeenCalledTimes(1);
+    expect(previewTileInTab).toHaveBeenCalledTimes(1);
   });
 
   it("drops the rejected artifact fallback when a newer click has superseded it", async () => {
     // First click's resolve is held open so a newer click can supersede it
     // before it rejects; the second resolves to an artifact (opening via the
-    // projection waiter, not openTilePreviewInTab).
+    // projection waiter, not previewTileInTab).
     let rejectFirstClick: (reason: Error) => void = () => undefined;
     const firstResolve = new Promise<ResolveArtifactByPathResult>(
       (_resolve, reject) => {
@@ -311,7 +311,7 @@ describe("buildChatLinkPolicy", () => {
     rejectFirstClick(new Error("transport"));
     await flush();
 
-    expect(openTilePreviewInTab).not.toHaveBeenCalled();
+    expect(previewTileInTab).not.toHaveBeenCalled();
     expect(
       mocks.openProjectedSidebarNodeInTabWhenAvailable,
     ).toHaveBeenCalledTimes(1);
@@ -336,7 +336,7 @@ describe("buildChatLinkPolicy", () => {
     expect(
       mocks.openProjectedSidebarNodeInTabWhenAvailable,
     ).not.toHaveBeenCalled();
-    expect(openTilePreviewInTab).not.toHaveBeenCalled();
+    expect(previewTileInTab).not.toHaveBeenCalled();
   });
 
   it("treats an artifact path as a plain file when there is no active host", () => {
@@ -345,7 +345,7 @@ describe("buildChatLinkPolicy", () => {
       true,
     );
     expect(mocks.resolveArtifactByPath).not.toHaveBeenCalled();
-    expect(openTilePreviewInTab).toHaveBeenCalledTimes(1);
+    expect(previewTileInTab).toHaveBeenCalledTimes(1);
   });
 
   it("cancels a prior same-epic projection wait on a superseding plain-file click, without re-opening the prior link", async () => {
@@ -372,8 +372,8 @@ describe("buildChatLinkPolicy", () => {
     expect(run(fileLink({ path: "src/app.ts" }), lifecycle)).toBe(true);
     expect(cancelPriorWait).toHaveBeenCalledTimes(1);
     expect(pendingCancel).toBeNull();
-    expect(openTilePreviewInTab).toHaveBeenCalledTimes(1);
-    expect(openTilePreviewInTab).toHaveBeenLastCalledWith(TAB_ID, {
+    expect(previewTileInTab).toHaveBeenCalledTimes(1);
+    expect(previewTileInTab).toHaveBeenLastCalledWith(TAB_ID, {
       id: "content-1",
     });
   });
@@ -433,7 +433,7 @@ describe("buildChatLinkPolicy", () => {
       CHAT_HOST_ID,
       skillPath,
     );
-    expect(openTilePreviewInTab).toHaveBeenCalledWith(TAB_ID, {
+    expect(previewTileInTab).toHaveBeenCalledWith(TAB_ID, {
       id: "abs-content",
     });
   });
@@ -450,6 +450,6 @@ describe("buildChatLinkPolicy", () => {
     await flush();
 
     expect(mocks.workspaceFileRefFromAbsoluteFilePath).not.toHaveBeenCalled();
-    expect(openTilePreviewInTab).not.toHaveBeenCalled();
+    expect(previewTileInTab).not.toHaveBeenCalled();
   });
 });

--- a/clients/gui-app/src/components/chat/__tests__/chat-markdown-link-provider.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-markdown-link-provider.test.tsx
@@ -9,8 +9,11 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { use, type ReactNode } from "react";
 import { ChatMarkdownLinkProvider } from "@/components/chat/chat-markdown-link-provider";
+import { AgentReferenceMarkdown } from "@/components/chat/segments/agent-reference-markdown";
 import { workspaceFileRefFromLinkPath } from "@/components/epic-canvas/workspace-file/workspace-file-link-ref";
 import { workspaceFileTabId } from "@/components/epic-canvas/workspace-file/workspace-file-ref";
+import * as epicTileNavigationModule from "@/hooks/epic/use-epic-tile-navigation";
+import type { EpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import { MarkdownLinkContext } from "@/markdown/links/markdown-link-context";
 import type { MarkdownFileLink } from "@/markdown/links/markdown-link-context";
 import type { FetchResolveArtifactByPathArgs } from "@/lib/host/resolve-artifact-by-path";
@@ -55,6 +58,7 @@ interface EpicRouteFocusLike {
 
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => mocks.navigate,
+  useRouter: () => null,
 }));
 
 vi.mock("@/lib/host", () => ({
@@ -195,6 +199,44 @@ function expectedWorkspaceFileContentId(linkPath: string): string {
 }
 
 describe("ChatMarkdownLinkProvider", () => {
+  it("routes rendered markdown file links through the shared tile navigation hook", () => {
+    const openTilePreviewInTab = vi.fn<
+      EpicTileNavigation["openTilePreviewInTab"]
+    >(() => null);
+    const hookSpy = vi
+      .spyOn(epicTileNavigationModule, "useEpicTileNavigation")
+      .mockReturnValue({
+        openTileInTab: vi.fn(() => null),
+        openTilePreviewInTab,
+        openTileInEpic: vi.fn(() => null),
+        openTilePreviewInEpic: vi.fn(() => null),
+      });
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+
+    try {
+      renderProvider(
+        tabId,
+        <AgentReferenceMarkdown
+          isStreaming={false}
+          markdown="[Open app](src/app.ts)"
+          proseSize="compact"
+          quotable={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("link", { name: "Open app" }));
+
+      expect(openTilePreviewInTab).toHaveBeenCalledWith(
+        tabId,
+        expect.objectContaining({
+          id: workspaceFileTabId(HOST_ID, "/repo", "src/app.ts"),
+        }),
+      );
+    } finally {
+      hookSpy.mockRestore();
+    }
+  });
+
   it("opens chat file links as replaceable preview tabs", () => {
     const store = useEpicCanvasStore.getState();
     const tabId = store.openEpicTab("epic-1", "Epic 1");
@@ -280,9 +322,6 @@ describe("ChatMarkdownLinkProvider", () => {
       kind: "spec",
     });
     const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
-    const openTilePreviewInTab =
-      useEpicCanvasStore.getState().openTilePreviewInTab;
-
     renderProvider(
       tabId,
       <LinkButton
@@ -317,16 +356,12 @@ describe("ChatMarkdownLinkProvider", () => {
         mocks.openProjectedSidebarNodeInTabWhenAvailable,
       ).toHaveBeenCalledTimes(1);
     });
-    expect(
-      mocks.openProjectedSidebarNodeInTabWhenAvailable,
-    ).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tabId,
-        nodeId: "artifact-same",
-        fallbackHostId: ACTIVE_HOST_ID,
-        openTileInTab: openTilePreviewInTab,
-      }),
-    );
+    const openArgs =
+      mocks.openProjectedSidebarNodeInTabWhenAvailable.mock.calls[0][0];
+    expect(openArgs.tabId).toBe(tabId);
+    expect(openArgs.nodeId).toBe("artifact-same");
+    expect(openArgs.fallbackHostId).toBe(ACTIVE_HOST_ID);
+    expect(typeof openArgs.openTileInTab).toBe("function");
     expect(mocks.navigate).not.toHaveBeenCalled();
     // It claimed the click without falling through to a file preview.
     expect(previewTabId(tabId)).toBeNull();

--- a/clients/gui-app/src/components/chat/agent-reference-chip.tsx
+++ b/clients/gui-app/src/components/chat/agent-reference-chip.tsx
@@ -2,12 +2,12 @@ import { Bot } from "lucide-react";
 import { useCallback } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import {
   useEpicArtifactRecords,
   useOpenEpicId,
   type EpicTreeRecord,
 } from "@/lib/epic-selectors";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { cn } from "@/lib/utils";
 
 export function AgentReferenceChip(props: {
@@ -42,17 +42,16 @@ function AgentReferenceButton(props: {
   readonly agent: EpicTreeRecord;
   readonly epicId: string;
 }) {
+  const tileNavigation = useEpicTileNavigation();
   const openAgent = useCallback(() => {
-    const canvas = useEpicCanvasStore.getState();
-    const tabId = canvas.resolveTargetTabForEpic(props.epicId, undefined);
-    canvas.openTileInTab(tabId, {
+    tileNavigation.openTileInEpic(props.epicId, {
       id: props.agent.id,
       instanceId: uuidv4(),
       type: props.agent.type,
       name: props.agent.name,
       hostId: props.agent.hostId,
     });
-  }, [props.agent, props.epicId]);
+  }, [props.agent, props.epicId, tileNavigation]);
 
   return (
     <button

--- a/clients/gui-app/src/components/chat/build-chat-link-policy.ts
+++ b/clients/gui-app/src/components/chat/build-chat-link-policy.ts
@@ -40,10 +40,7 @@ export interface ChatLinkPolicyDeps {
   readonly queryClient: QueryClient;
   readonly client: HostClient<HostRpcRegistry>;
   readonly navigate: UseNavigateResult<string>;
-  readonly openTilePreviewInTab: (
-    tabId: string,
-    node: EpicCanvasTileRef,
-  ) => void;
+  readonly previewTileInTab: (tabId: string, node: EpicCanvasTileRef) => void;
 }
 
 /**
@@ -193,7 +190,7 @@ function resolveAndOpenArtifactLink(
             tabId: deps.tabId,
             nodeId: artifact.artifactId,
             fallbackHostId: resolveHostId,
-            openTileInTab: deps.openTilePreviewInTab,
+            openTileInTab: deps.previewTileInTab,
             onBeforeOpen: null,
             onOpened: () => {
               lifecycle.setPendingProjectedOpenCancel(null);
@@ -288,6 +285,6 @@ function openChatWorkspaceFilePreview(
   if (link.line !== null) {
     setWorkspaceFileRevealTarget(deps.tabId, ref.id, link.line, link.col);
   }
-  deps.openTilePreviewInTab(deps.tabId, ref);
+  deps.previewTileInTab(deps.tabId, ref);
   return true;
 }

--- a/clients/gui-app/src/components/chat/chat-agent-stop-list.tsx
+++ b/clients/gui-app/src/components/chat/chat-agent-stop-list.tsx
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { AgentStopButton } from "@/components/chat/agent-stop-button";
 import type { AgentRow } from "@/hooks/agent/use-agent-stop-controls";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 
 /**
  * A row's `surface` is UI copy ("gui"/"tui"); opening a tile needs the
@@ -73,13 +73,12 @@ export function AgentStopList(props: {
   readonly surface: "composer-panel" | "tui-popover";
 }) {
   const compact = props.surface === "composer-panel";
+  const tileNavigation = useEpicTileNavigation();
   // Opening a sub-agent reuses the same path as the agent-reference chip:
   // resolve the epic's target tab and open (or focus) the agent's tile there.
   const openAgent = useCallback(
     (agent: AgentRow) => {
-      const canvas = useEpicCanvasStore.getState();
-      const tabId = canvas.resolveTargetTabForEpic(props.epicId, undefined);
-      canvas.openTileInTab(tabId, {
+      tileNavigation.openTileInEpic(props.epicId, {
         id: agent.id,
         instanceId: uuidv4(),
         type: nodeKindForSurface(agent.surface),
@@ -87,7 +86,7 @@ export function AgentStopList(props: {
         hostId: agent.hostId,
       });
     },
-    [props.epicId],
+    [props.epicId, tileNavigation],
   );
   return (
     <ul className="m-0 flex list-none flex-col gap-0.5 p-1.5">

--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -25,9 +25,10 @@ import { ActiveHostWorkspaceControls } from "@/components/home/host-workspace-se
 import { SurfaceActivityProvider } from "@/components/home/composer/surface-activity-context";
 import { useComposerToolbarStore } from "@/components/home/hooks/use-composer-toolbar-store";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useEpicCreateChatForHost } from "@/hooks/epic/use-epic-chat-mutations";
 import { buildChatRunSettings } from "@/lib/composer/chat-run-settings";
-import { openCreatedChatWhenProjected } from "@/lib/commands/actions/new-chat";
+import { openCreatedChatWhenProjectedWithNavigation } from "@/lib/commands/actions/new-chat";
 import {
   pendingForkChatStagingKey,
   useWorktreeIntentStagingStore,
@@ -75,6 +76,7 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
   const titleInputId = useId();
   const tabHostId = useTabHostId();
   const createChat = useEpicCreateChatForHost();
+  const navigateNestedFocus = useEpicNestedFocusNavigation();
   const openCancelsRef = useRef<Set<() => void> | null>(null);
 
   useEffect(() => {
@@ -178,12 +180,15 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
       },
       {
         onSuccess: (result) => {
-          const cancel = openCreatedChatWhenProjected({
-            kind: "active-tile",
-            epicId,
-            tabId,
-            chatId: result.chatId,
-            hostId,
+          const cancel = openCreatedChatWhenProjectedWithNavigation({
+            intent: {
+              kind: "active-tile",
+              epicId,
+              tabId,
+              chatId: result.chatId,
+              hostId,
+            },
+            navigateNestedFocus,
           });
           const openCancels = openCancelsRef.current;
           if (openCancels === null) {
@@ -199,6 +204,7 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
     canSubmit,
     createChat,
     epicId,
+    navigateNestedFocus,
     onOpenChange,
     stagingKey,
     tabHostId,

--- a/clients/gui-app/src/components/chat/chat-markdown-link-provider.tsx
+++ b/clients/gui-app/src/components/chat/chat-markdown-link-provider.tsx
@@ -1,7 +1,8 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { useEffect, useMemo, useRef, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import { useHostClient } from "@/lib/host";
 import { useOpenEpicId } from "@/lib/epic-selectors";
 import {
@@ -9,8 +10,8 @@ import {
   type MarkdownLinkPolicy,
 } from "@/markdown/links/markdown-link-context";
 import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { buildChatLinkPolicy } from "@/components/chat/build-chat-link-policy";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
 
 interface ChatMarkdownLinkProviderProps {
   /** The chat tab whose group a file link opens its new tab into. */
@@ -37,8 +38,12 @@ export function ChatMarkdownLinkProvider({
   workspaceRoots,
   children,
 }: ChatMarkdownLinkProviderProps) {
-  const openTilePreviewInTab = useEpicCanvasStore(
-    (s) => s.openTilePreviewInTab,
+  const tileNavigation = useEpicTileNavigation();
+  const previewTileInTab = useCallback(
+    (targetTabId: string, node: EpicCanvasTileRef): void => {
+      tileNavigation.openTilePreviewInTab(targetTabId, node);
+    },
+    [tileNavigation],
   );
   const queryClient = useQueryClient();
   const client = useHostClient();
@@ -80,7 +85,7 @@ export function ChatMarkdownLinkProvider({
         queryClient,
         client,
         navigate,
-        openTilePreviewInTab,
+        previewTileInTab,
       }),
     [
       activeHostId,
@@ -89,7 +94,7 @@ export function ChatMarkdownLinkProvider({
       hostId,
       navigate,
       openEpicId,
-      openTilePreviewInTab,
+      previewTileInTab,
       queryClient,
       tabId,
       workspaceRoots,

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -37,12 +37,12 @@ import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import {
   composerClipboardPlainText,
   copyComposerContentToClipboard,
 } from "@/lib/composer/composer-clipboard";
 import { useEpicArtifact, useOpenEpicId } from "@/lib/epic-selectors";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { cn, formatSingleLine } from "@/lib/utils";
 import { deriveA2AReceivedCollapsibleKey } from "@/components/chat/chat-collapsible-key";
 import {
@@ -176,6 +176,7 @@ function AgentMessageDisplayView({
   );
 
   const epicId = useOpenEpicId();
+  const tileNavigation = useEpicTileNavigation();
   const senderNode = useEpicArtifact(agentSenderInfo.agentId);
   // Resolve the live sender from the epic projection. A chat or
   // terminal-agent is openable as a tab; an absent node (e.g. a
@@ -207,16 +208,14 @@ function AgentMessageDisplayView({
 
   const openSenderTab = useCallback(() => {
     if (openTarget === null) return;
-    const canvas = useEpicCanvasStore.getState();
-    const tabId = canvas.resolveTargetTabForEpic(epicId, undefined);
-    canvas.openTileInTab(tabId, {
+    tileNavigation.openTileInEpic(epicId, {
       id: agentSenderInfo.agentId,
       instanceId: uuidv4(),
       type: openTarget.type,
       name: senderName,
       hostId: openTarget.hostId,
     });
-  }, [openTarget, epicId, agentSenderInfo.agentId, senderName]);
+  }, [agentSenderInfo.agentId, epicId, openTarget, senderName, tileNavigation]);
 
   const header = (
     <>

--- a/clients/gui-app/src/components/chat/segments/__tests__/artifact-card-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/artifact-card-segment.test.tsx
@@ -5,6 +5,7 @@ import { ArtifactCardSegment } from "@/components/chat/segments/artifact-card-se
 import { readEpicCanvasDragSourceData } from "@/components/epic-canvas/dnd/dnd";
 import { commitResolvedCanvasDrop } from "@/components/epic-canvas/dnd/root-dnd-commits";
 import type { EpicArtifactRef } from "@/stores/epics/canvas/types";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 
 type TestArtifactProjection = {
   readonly id: string;
@@ -46,9 +47,25 @@ const projection = vi.hoisted<TestProjectionState>(() => ({
 }));
 
 const canvas = vi.hoisted(() => ({
+  tabsById: {
+    "tab-1": {
+      tabId: "tab-1",
+      epicId: "epic-1",
+      name: "Epic 1",
+    },
+  },
   resolveTargetTabForEpic: vi.fn(() => "tab-1"),
   openTileInTab: vi.fn<(tabId: string, node: EpicArtifactRef) => void>(),
+  prepareOpenTileInTabFocusTarget: vi.fn(
+    (tabId: string, node: EpicArtifactRef) => {
+      canvas.openTileInTab(tabId, node);
+      return null;
+    },
+  ),
 }));
+
+const rawNestedFocus: NavigateNestedFocus = (_epicId, _tabId, prepare) =>
+  prepare();
 
 const dnd = vi.hoisted(() => ({
   draggables: [] as CapturedDraggable[],
@@ -542,11 +559,14 @@ describe("<ArtifactCardSegment />", () => {
     const source = readEpicCanvasDragSourceData(drag.data);
     expect(source).not.toBeNull();
     if (source === null) return;
-    commitResolvedCanvasDrop({
-      source,
-      target: { kind: "empty-shell", epicId: "epic-1", viewTabId: "tab-1" },
-      preview: { kind: "empty-shell" },
-    });
+    commitResolvedCanvasDrop(
+      {
+        source,
+        target: { kind: "empty-shell", epicId: "epic-1", viewTabId: "tab-1" },
+        preview: { kind: "empty-shell" },
+      },
+      rawNestedFocus,
+    );
 
     expect(canvas.openTileInTab).toHaveBeenCalledTimes(1);
     const [tabId, node] = canvas.openTileInTab.mock.calls[0];

--- a/clients/gui-app/src/components/chat/segments/__tests__/forked-chat-link-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/forked-chat-link-segment.test.tsx
@@ -1,10 +1,25 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { paneTabRefs } from "@/stores/epics/canvas/actions";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { collectPanes } from "@/stores/epics/canvas/tile-tree";
 import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
 import { ForkedChatLinkSegment } from "@/components/chat/segments/forked-chat-link-segment";
+
+const testState = vi.hoisted(() => ({
+  navigateNested: vi.fn(
+    (
+      _epicId: string,
+      _tabId: string,
+      prepare: () => NestedFocusTarget | null,
+    ) => prepare(),
+  ),
+}));
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => testState.navigateNested,
+}));
 
 const SOURCE_CHAT: EpicNodeRef = {
   id: "source-chat-1",
@@ -26,6 +41,7 @@ describe("<ForkedChatLinkSegment />", () => {
   beforeEach(() => {
     window.localStorage.clear();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    testState.navigateNested.mockClear();
   });
 
   afterEach(() => {
@@ -53,6 +69,11 @@ describe("<ForkedChatLinkSegment />", () => {
       }),
     );
 
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      "epic-1",
+      viewTabId,
+      expect.any(Function),
+    );
     const state = useEpicCanvasStore.getState();
     expect(state.openTabOrder).toEqual([viewTabId]);
     expect(Object.keys(state.tabsById)).toEqual([viewTabId]);

--- a/clients/gui-app/src/components/chat/segments/artifact-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/artifact-card-segment.tsx
@@ -7,6 +7,7 @@ import type { ArtifactOperationAction } from "@traycer/protocol/persistence/epic
 import { StaticEpicNodeIcon } from "@/components/epic-canvas/epic-node-tab-icon";
 import { STATUS_LABELS } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import { EPIC_NODE_LABELS } from "@/lib/artifacts/node-display";
 import {
   useArtifactById,
@@ -17,7 +18,6 @@ import { artifactDiffRenderable } from "@/lib/chat/artifact-diff-renderable";
 import { artifactOperationVerb } from "@/lib/chat/artifact-operation-verb";
 import { cn } from "@/lib/utils";
 import type { ArtifactSegmentChange } from "@/stores/composer/chat-store";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useArtifactDragSource } from "@/components/epic-canvas/dnd/use-artifact-drag-source";
 import { OpenFullDiffControl } from "./open-full-diff-control";
 import { SnapshotHashInlineDiff } from "./snapshot-hash-inline-diff";
@@ -469,6 +469,7 @@ function ArtifactCardSegmentContent(props: ArtifactCardSegmentProps) {
   const tombstone = useEpicDeletedArtifact(artifactId);
   const epicId = useOpenEpicId();
   const activeHostId = useReactiveActiveHostId();
+  const tileNavigation = useEpicTileNavigation();
   const [diffOpen, setDiffOpen] = useState(false);
 
   // Prefer the tombstone for a delete (the live entry is already gone); else the
@@ -535,9 +536,7 @@ function ArtifactCardSegmentContent(props: ArtifactCardSegmentProps) {
   const openArtifact = (): void => {
     // Re-check the raw conditions so the host id narrows to a non-null string.
     if (isDeleted || live === null || activeHostId === null) return;
-    const canvas = useEpicCanvasStore.getState();
-    const tabId = canvas.resolveTargetTabForEpic(epicId, undefined);
-    canvas.openTileInTab(tabId, {
+    tileNavigation.openTileInEpic(epicId, {
       id: artifactId,
       instanceId: uuidv4(),
       type: displayKind,

--- a/clients/gui-app/src/components/chat/segments/forked-chat-link-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/forked-chat-link-segment.tsx
@@ -1,6 +1,6 @@
 import { GitBranch } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 
 interface ForkedChatLinkSegmentProps {
   readonly viewTabId: string;
@@ -11,10 +11,10 @@ interface ForkedChatLinkSegmentProps {
 
 export function ForkedChatLinkSegment(props: ForkedChatLinkSegmentProps) {
   const { viewTabId, sourceChatId, sourceChatTitle, sourceHostId } = props;
-  const openTileInTab = useEpicCanvasStore((state) => state.openTileInTab);
+  const tileNavigation = useEpicTileNavigation();
 
   const openSourceConversation = (): void => {
-    openTileInTab(viewTabId, {
+    tileNavigation.openTileInTab(viewTabId, {
       id: sourceChatId,
       instanceId: uuidv4(),
       type: "chat",

--- a/clients/gui-app/src/components/chat/segments/tool-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/tool-segment.tsx
@@ -22,7 +22,7 @@ import type {
   ChatProjection,
   TuiAgentProjection,
 } from "@/stores/epics/open-epic/types";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import { cn, formatSingleLine } from "@/lib/utils";
 import { AgentReferenceMarkdown } from "./agent-reference-markdown";
 import { SegmentCard } from "./segment-card";
@@ -570,13 +570,12 @@ function A2ASendToolSegment(
   const receiverNode = useEpicArtifact(send.receiverAgentId);
   const activeHostId = useReactiveActiveHostId();
   const epicId = useOpenEpicId();
+  const tileNavigation = useEpicTileNavigation();
   const receiverName = receiverDisplayName(receiverNode, send.receiverAgentId);
   const openTarget = receiverOpenTarget(receiverNode, activeHostId);
   const openReceiverTab = () => {
     if (openTarget === null) return;
-    const canvas = useEpicCanvasStore.getState();
-    const tabId = canvas.resolveTargetTabForEpic(epicId, undefined);
-    canvas.openTileInTab(tabId, {
+    tileNavigation.openTileInEpic(epicId, {
       id: send.receiverAgentId,
       instanceId: uuidv4(),
       type: openTarget.type,

--- a/clients/gui-app/src/components/chat/segments/use-artifact-row-display.ts
+++ b/clients/gui-app/src/components/chat/segments/use-artifact-row-display.ts
@@ -2,9 +2,9 @@ import { v4 as uuidv4 } from "uuid";
 import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
 import type { CheckpointFileOperation } from "@traycer/protocol/persistence/epic/checkpoint-manifests";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import { EPIC_NODE_LABELS } from "@/lib/artifacts/node-display";
 import { useArtifactById, useOpenEpicId } from "@/lib/epic-selectors";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 
 function nonEmpty(value: string | null | undefined): string | null {
   return value !== null && value !== undefined && value.length > 0
@@ -35,6 +35,7 @@ export function useArtifactRowDisplay(input: {
   const live = useArtifactById(input.artifactId);
   const epicId = useOpenEpicId();
   const activeHostId = useReactiveActiveHostId();
+  const tileNavigation = useEpicTileNavigation();
 
   const displayKind: EpicArtifactKind =
     live?.kind ?? input.artifactKind ?? "spec";
@@ -49,9 +50,7 @@ export function useArtifactRowDisplay(input: {
     if (live === null || activeHostId === null || input.artifactId === null) {
       return;
     }
-    const canvas = useEpicCanvasStore.getState();
-    const tabId = canvas.resolveTargetTabForEpic(epicId, undefined);
-    canvas.openTileInTab(tabId, {
+    tileNavigation.openTileInEpic(epicId, {
       id: input.artifactId,
       instanceId: uuidv4(),
       type: displayKind,

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-route-session-body.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-route-session-body.test.tsx
@@ -48,6 +48,8 @@ const BODY_PROPS = {
   focusedAt: 123,
   focusArtifactId: "artifact-a",
   focusThreadId: "thread-a",
+  focusPaneId: "pane-a",
+  focusTileInstanceId: "tile-a",
 };
 
 describe("<EpicRouteSessionBody />", () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/initial-chat-handoff.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/initial-chat-handoff.test.tsx
@@ -52,6 +52,9 @@ const HANDOFF_SETTINGS = {
 const testState = vi.hoisted(() => ({
   request: vi.fn((_method: string) => Promise.resolve<unknown>({})),
   events: [] as string[],
+  navigateNested: vi.fn(
+    (_epicId: string, _tabId: string, prepare: () => unknown) => prepare(),
+  ),
 }));
 
 vi.mock("@tanstack/react-router", async (importOriginal) => {
@@ -62,6 +65,17 @@ vi.mock("@tanstack/react-router", async (importOriginal) => {
     useNavigate: () => () => undefined,
   };
 });
+
+// The handoff's canvas opens are routed through the nested-focus navigation
+// boundary. Mocking it to synchronously invoke `prepare()` (mirroring
+// `bundle-open-button.test.tsx`) keeps the real canvas-store mutation while
+// letting these tests count navigation attempts directly - the observable
+// signal for the re-entrant re-open regression (the underlying canvas
+// mutation is itself idempotent when the tile is already open, so asserting
+// on canvas state alone cannot detect a duplicate open/navigate attempt).
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => testState.navigateNested,
+}));
 
 vi.mock("@/lib/host", () => ({
   useHostBinding: () => null,
@@ -222,6 +236,7 @@ describe("initial chat handoff route coordinator", () => {
     callbacks = null;
     testState.events.length = 0;
     testState.request.mockClear();
+    testState.navigateNested.mockClear();
     testState.request.mockImplementation((method: string) => {
       testState.events.push(method);
       return Promise.resolve({});
@@ -381,6 +396,99 @@ describe("initial chat handoff route coordinator", () => {
 
     await Promise.resolve();
     expect(handoffStatus()).toBe("pending");
+    queryClient.clear();
+  });
+
+  it("latches the active-tile open once per handoffChatId across multiple projection transitions", async () => {
+    registerPendingHandoff();
+    const queryClient = renderWithProviders(
+      <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>
+        <EpicSessionGate fallback={null}>
+          <CoordinatorOnly epicId={EPIC_ID} tabId={EPIC_ID} />
+        </EpicSessionGate>
+      </EpicSessionProvider>,
+    );
+    if (callbacks === null) throw new Error("expected epic callbacks");
+    const epicCallbacks = callbacks;
+
+    // The coordinator's first transition opens the tile as soon as it
+    // mounts (handoffChatId is registered pre-render) - through the
+    // injected opener exactly once, via the nested-focus navigation
+    // boundary.
+    await waitFor(() => {
+      expect(testState.navigateNested).toHaveBeenCalledTimes(1);
+    });
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      EPIC_ID,
+      expect.any(Function),
+    );
+    expect(canvasChatTabs().filter((tab) => tab.id === CHAT_ID)).toHaveLength(
+      1,
+    );
+
+    // Landing the chat's projection drives further transitions of the
+    // canvas-handoff effect: the projection itself (projectedChatId /
+    // projectedChatTitle change) and the follow-on pending -> waitingChat
+    // status advance. Neither may re-open / re-navigate the already-open
+    // tile.
+    const donor = new Y.Doc();
+    seedDocWithChat(donor);
+    act(() => {
+      epicCallbacks.onConnectionStatus("open", null);
+      epicCallbacks.onSnapshot(makeMeta("owner"), Y.encodeStateAsUpdate(donor));
+    });
+
+    await waitFor(() => {
+      expect(handoffStatus()).toBe("waitingChat");
+    });
+
+    expect(testState.navigateNested).toHaveBeenCalledTimes(1);
+    expect(canvasChatTabs().filter((tab) => tab.id === CHAT_ID)).toHaveLength(
+      1,
+    );
+
+    queryClient.clear();
+  });
+
+  it("reload-style: ref cleared but tile already in the tab skips a duplicate open", async () => {
+    // Simulate a reload: the canvas layout already carries the handoff
+    // chat's tile (persisted from a prior session) before this fresh
+    // coordinator instance mounts - a fresh mount always starts with a
+    // null `openedChatIdRef`.
+    useEpicCanvasStore.getState().openTileInTab(EPIC_ID, {
+      id: CHAT_ID,
+      instanceId: "preexisting-instance",
+      type: "chat",
+      name: "New chat",
+      hostId: HOST_ID,
+    });
+    registerPendingHandoff();
+
+    const queryClient = renderWithProviders(
+      <EpicSessionProvider epicId={EPIC_ID} tabId={EPIC_ID}>
+        <EpicSessionGate fallback={null}>
+          <CoordinatorOnly epicId={EPIC_ID} tabId={EPIC_ID} />
+        </EpicSessionGate>
+      </EpicSessionProvider>,
+    );
+    if (callbacks === null) throw new Error("expected epic callbacks");
+
+    // Wait for the coordinator to mount and its canvas-handoff effect to
+    // run at least once - the pending-create mark fires regardless of
+    // whether the tile-open guard trips, so it is a reliable "mounted and
+    // ran" signal independent of the behavior under test.
+    await waitFor(() => {
+      expect(
+        useEpicCanvasStore.getState().pendingCreateArtifactIds.has(CHAT_ID),
+      ).toBe(true);
+    });
+
+    expect(testState.navigateNested).not.toHaveBeenCalled();
+    expect(canvasChatTabs().filter((tab) => tab.id === CHAT_ID)).toHaveLength(
+      1,
+    );
+
     queryClient.clear();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/root-dnd-commits.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/root-dnd-commits.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@/stores/epics/left-panel-store";
 import { useEpicSidebarExpansionStore } from "@/stores/epics/epic-sidebar-expansion-store";
 import { makeGitFileDiffTile } from "@/lib/git/git-diff-tile";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 
 interface TabStripMoveArgs {
   readonly sourcePaneId: string;
@@ -32,11 +33,42 @@ interface TabSplitArgs {
 
 interface TestCanvasStore {
   promotePreviewInTab: () => void;
-  openTileInTab: () => void;
-  insertNodeOnTabStrip: () => void;
+  openTileInTab: (viewTabId: string, node: unknown) => void;
+  prepareOpenTileInTabFocusTarget: (viewTabId: string, node: unknown) => null;
+  insertNodeOnTabStrip: (
+    viewTabId: string,
+    groupId: string,
+    index: number,
+    node: unknown,
+  ) => void;
+  prepareInsertNodeOnTabStripFocusTarget: (
+    viewTabId: string,
+    groupId: string,
+    index: number,
+    node: unknown,
+  ) => null;
   moveTabOnTabStrip: (viewTabId: string, args: TabStripMoveArgs) => void;
-  splitPaneWithNode: () => void;
+  prepareMoveActiveTabOnTabStripFocusTarget: (
+    viewTabId: string,
+    args: TabStripMoveArgs,
+  ) => null;
+  splitPaneWithNode: (
+    viewTabId: string,
+    groupId: string,
+    position: string,
+    node: unknown,
+  ) => void;
+  prepareSplitPaneWithNodeFocusTarget: (
+    viewTabId: string,
+    groupId: string,
+    position: string,
+    node: unknown,
+  ) => null;
   splitPaneWithTab: (viewTabId: string, args: TabSplitArgs) => void;
+  prepareSplitPaneWithTabFocusTarget: (
+    viewTabId: string,
+    args: TabSplitArgs,
+  ) => null;
   openTileInNewTab: (
     epicId: string,
     node: unknown,
@@ -55,11 +87,49 @@ const testState = vi.hoisted(() => ({
   canvasStore: {
     promotePreviewInTab: vi.fn(),
     openTileInTab: vi.fn(),
+    prepareOpenTileInTabFocusTarget: vi.fn((viewTabId, node) => {
+      testState.canvasStore.openTileInTab(viewTabId, node);
+      return null;
+    }),
     insertNodeOnTabStrip: vi.fn(),
+    prepareInsertNodeOnTabStripFocusTarget: vi.fn(
+      (viewTabId, groupId, index, node) => {
+        testState.canvasStore.insertNodeOnTabStrip(
+          viewTabId,
+          groupId,
+          index,
+          node,
+        );
+        return null;
+      },
+    ),
     moveTabOnTabStrip:
       vi.fn<(viewTabId: string, args: TabStripMoveArgs) => void>(),
+    prepareMoveActiveTabOnTabStripFocusTarget: vi.fn(
+      (viewTabId: string, args: TabStripMoveArgs) => {
+        testState.canvasStore.moveTabOnTabStrip(viewTabId, args);
+        return null;
+      },
+    ),
     splitPaneWithNode: vi.fn(),
+    prepareSplitPaneWithNodeFocusTarget: vi.fn(
+      (viewTabId, groupId, position, node) => {
+        testState.canvasStore.splitPaneWithNode(
+          viewTabId,
+          groupId,
+          position,
+          node,
+        );
+        return null;
+      },
+    ),
     splitPaneWithTab: vi.fn<(viewTabId: string, args: TabSplitArgs) => void>(),
+    prepareSplitPaneWithTabFocusTarget: vi.fn(
+      (viewTabId: string, args: TabSplitArgs) => {
+        testState.canvasStore.splitPaneWithTab(viewTabId, args);
+        return null;
+      },
+    ),
     openTileInNewTab: vi.fn<
       (
         epicId: string,
@@ -103,6 +173,9 @@ const TERMINAL_TILE = {
   hostId: TEST_HOST_ID,
   cwd: "/repo",
 } as const;
+
+const rawNestedFocus: NavigateNestedFocus = (_epicId, _tabId, prepare) =>
+  prepare();
 
 function railSource(
   panelId: "artifacts" | "git-diff" | "file-tree",
@@ -180,7 +253,7 @@ describe("root dnd commits - left panel", () => {
     });
 
     expect(isLeftPanelDropNoop(source, preview)).toBe(false);
-    commitResolvedCanvasDrop({ source, target, preview });
+    commitResolvedCanvasDrop({ source, target, preview }, rawNestedFocus);
 
     expect(useLeftPanelStore.getState().getPanelGroups()).toEqual([
       { panelIds: ["chats"] },
@@ -256,7 +329,7 @@ describe("root dnd commits - left panel", () => {
       activeRect: null,
     });
 
-    commitResolvedCanvasDrop({ source, target, preview });
+    commitResolvedCanvasDrop({ source, target, preview }, rawNestedFocus);
 
     expect(useLeftPanelStore.getState().getPanelGroups()).toEqual([
       { panelIds: ["chats", "file-tree"] },
@@ -298,7 +371,7 @@ describe("root dnd commits - left panel", () => {
       activeRect: null,
     });
 
-    commitResolvedCanvasDrop({ source, target, preview });
+    commitResolvedCanvasDrop({ source, target, preview }, rawNestedFocus);
 
     expect(useLeftPanelStore.getState().getPanelGroups()).toEqual([
       { panelIds: ["chats", "git-diff", "artifacts"] },
@@ -457,11 +530,14 @@ describe("root dnd commits - left panel drop resolver", () => {
     } as const;
 
     expect(isLeftPanelDropNoop(source, preview)).toBe(true);
-    commitResolvedCanvasDrop({
-      source,
-      target: { kind: "left-panel-rail-item", panelId: "chats" },
-      preview,
-    });
+    commitResolvedCanvasDrop(
+      {
+        source,
+        target: { kind: "left-panel-rail-item", panelId: "chats" },
+        preview,
+      },
+      rawNestedFocus,
+    );
 
     expect(useLeftPanelStore.getState().panelGroups).toBe(before);
   });
@@ -481,16 +557,19 @@ describe("root dnd commits - artifact tab commit routing", () => {
   } as const;
 
   it("routes strip previews to moveTabOnTabStrip at the preview index", () => {
-    commitResolvedCanvasDrop({
-      source: ARTIFACT_TAB_SOURCE,
-      target: {
-        kind: "artifact-tab-strip-end",
-        viewTabId: VIEW_TAB_ID,
-        groupId: "group-b",
-        index: 2,
+    commitResolvedCanvasDrop(
+      {
+        source: ARTIFACT_TAB_SOURCE,
+        target: {
+          kind: "artifact-tab-strip-end",
+          viewTabId: VIEW_TAB_ID,
+          groupId: "group-b",
+          index: 2,
+        },
+        preview: { kind: "artifact-tab-strip", groupId: "group-b", index: 2 },
       },
-      preview: { kind: "artifact-tab-strip", groupId: "group-b", index: 2 },
-    });
+      rawNestedFocus,
+    );
 
     expect(testState.canvasStore.moveTabOnTabStrip).toHaveBeenCalledWith(
       VIEW_TAB_ID,
@@ -505,20 +584,23 @@ describe("root dnd commits - artifact tab commit routing", () => {
   });
 
   it("routes body-center previews to moveTabOnTabStrip at the target tab count", () => {
-    commitResolvedCanvasDrop({
-      source: ARTIFACT_TAB_SOURCE,
-      target: {
-        kind: "artifact-tab-group-body",
-        viewTabId: VIEW_TAB_ID,
-        groupId: "group-b",
-        tabCount: 3,
+    commitResolvedCanvasDrop(
+      {
+        source: ARTIFACT_TAB_SOURCE,
+        target: {
+          kind: "artifact-tab-group-body",
+          viewTabId: VIEW_TAB_ID,
+          groupId: "group-b",
+          tabCount: 3,
+        },
+        preview: {
+          kind: "artifact-tab-group-body",
+          groupId: "group-b",
+          position: "center",
+        },
       },
-      preview: {
-        kind: "artifact-tab-group-body",
-        groupId: "group-b",
-        position: "center",
-      },
-    });
+      rawNestedFocus,
+    );
 
     expect(testState.canvasStore.moveTabOnTabStrip).toHaveBeenCalledWith(
       VIEW_TAB_ID,
@@ -533,20 +615,23 @@ describe("root dnd commits - artifact tab commit routing", () => {
   });
 
   it("routes body-edge previews to splitPaneWithTab", () => {
-    commitResolvedCanvasDrop({
-      source: ARTIFACT_TAB_SOURCE,
-      target: {
-        kind: "artifact-tab-group-body",
-        viewTabId: VIEW_TAB_ID,
-        groupId: "group-b",
-        tabCount: 3,
+    commitResolvedCanvasDrop(
+      {
+        source: ARTIFACT_TAB_SOURCE,
+        target: {
+          kind: "artifact-tab-group-body",
+          viewTabId: VIEW_TAB_ID,
+          groupId: "group-b",
+          tabCount: 3,
+        },
+        preview: {
+          kind: "artifact-tab-group-body",
+          groupId: "group-b",
+          position: "right",
+        },
       },
-      preview: {
-        kind: "artifact-tab-group-body",
-        groupId: "group-b",
-        position: "right",
-      },
-    });
+      rawNestedFocus,
+    );
 
     expect(testState.canvasStore.splitPaneWithTab).toHaveBeenCalledWith(
       VIEW_TAB_ID,
@@ -561,11 +646,18 @@ describe("root dnd commits - artifact tab commit routing", () => {
   });
 
   it("commits nothing for an empty-shell preview from a tab source", () => {
-    commitResolvedCanvasDrop({
-      source: ARTIFACT_TAB_SOURCE,
-      target: { kind: "empty-shell", epicId: EPIC_ID, viewTabId: VIEW_TAB_ID },
-      preview: { kind: "empty-shell" },
-    });
+    commitResolvedCanvasDrop(
+      {
+        source: ARTIFACT_TAB_SOURCE,
+        target: {
+          kind: "empty-shell",
+          epicId: EPIC_ID,
+          viewTabId: VIEW_TAB_ID,
+        },
+        preview: { kind: "empty-shell" },
+      },
+      rawNestedFocus,
+    );
 
     expect(testState.canvasStore.moveTabOnTabStrip).not.toHaveBeenCalled();
     expect(testState.canvasStore.splitPaneWithTab).not.toHaveBeenCalled();
@@ -577,16 +669,23 @@ describe("root dnd commits - tile source commit routing", () => {
   afterEach(resetStores);
 
   it("opens a dragged terminal tile on an empty canvas", () => {
-    commitResolvedCanvasDrop({
-      source: {
-        kind: "terminal-tile",
-        epicId: EPIC_ID,
-        viewTabId: VIEW_TAB_ID,
-        tile: TERMINAL_TILE,
+    commitResolvedCanvasDrop(
+      {
+        source: {
+          kind: "terminal-tile",
+          epicId: EPIC_ID,
+          viewTabId: VIEW_TAB_ID,
+          tile: TERMINAL_TILE,
+        },
+        target: {
+          kind: "empty-shell",
+          epicId: EPIC_ID,
+          viewTabId: VIEW_TAB_ID,
+        },
+        preview: { kind: "empty-shell" },
       },
-      target: { kind: "empty-shell", epicId: EPIC_ID, viewTabId: VIEW_TAB_ID },
-      preview: { kind: "empty-shell" },
-    });
+      rawNestedFocus,
+    );
 
     expect(testState.canvasStore.openTileInTab).toHaveBeenCalledWith(
       VIEW_TAB_ID,

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -19,6 +19,7 @@ import {
 interface CanvasStoreSlice {
   readonly renameTab: Mock;
   readonly openTileInTab: Mock;
+  readonly applyNestedRouteFocus: Mock;
   readonly closeCanvasTab: Mock;
   readonly pendingCreateArtifactIds: ReadonlySet<string>;
 }
@@ -30,6 +31,9 @@ interface TestState {
     readonly type: "spec";
     readonly name: string;
   } | null;
+  nestedFocusEnabled: boolean;
+  navigate: Mock;
+  canvasActivePaneId: string | null;
   canvasRoot: TileLayoutNode | null;
   canvasTiles: Readonly<Record<string, EpicCanvasTileRef>>;
   records: ReadonlyArray<{ readonly id: string }>;
@@ -43,12 +47,16 @@ interface TestState {
 const testState = vi.hoisted<TestState>(() => ({
   activeArtifactId: null,
   autoOpenTarget: null,
+  nestedFocusEnabled: false,
+  navigate: vi.fn(),
+  canvasActivePaneId: null,
   canvasRoot: null,
   canvasTiles: {},
   records: [],
   canvasStore: {
     renameTab: vi.fn(),
     openTileInTab: vi.fn(),
+    applyNestedRouteFocus: vi.fn(),
     closeCanvasTab: vi.fn(),
     pendingCreateArtifactIds: new Set<string>(),
   },
@@ -56,6 +64,16 @@ const testState = vi.hoisted<TestState>(() => ({
     setLastFocusedArtifactId: vi.fn(),
     setLastFocusedThreadId: vi.fn(),
   },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => testState.navigate,
+  useRouter: () => ({ history: {} }),
+}));
+
+vi.mock("@/lib/persistent-history", () => ({
+  getHistoryController: () =>
+    testState.nestedFocusEnabled ? { kind: "persistent-history" } : null,
 }));
 
 vi.mock("@/providers/use-open-epic-handle", () => ({
@@ -70,7 +88,9 @@ vi.mock("@/stores/epics/canvas/store", () => ({
   useActiveEpicArtifactId: () => testState.activeArtifactId,
   useEpicCanvas: () => ({
     root: testState.canvasRoot,
+    activePaneId: testState.canvasActivePaneId,
     tilesByInstanceId: testState.canvasTiles,
+    sizesByGroupId: {},
   }),
   useEpicCanvasStore: <T,>(selector: (store: CanvasStoreSlice) => T): T =>
     selector(testState.canvasStore),
@@ -96,6 +116,8 @@ const THREAD_FOCUS_INTENT: EpicRouteFocusIntent = {
   focusedAt: 123,
   focusArtifactId: "artifact-1",
   focusThreadId: "thread-1",
+  focusPaneId: undefined,
+  focusTileInstanceId: undefined,
 };
 
 function resetStores(): void {
@@ -117,6 +139,9 @@ function resetStores(): void {
     artifactByEpicId: {},
   });
   testState.activeArtifactId = null;
+  testState.nestedFocusEnabled = false;
+  testState.navigate.mockClear();
+  testState.canvasActivePaneId = null;
   testState.autoOpenTarget = {
     id: "artifact-1",
     type: "spec",
@@ -127,14 +152,338 @@ function resetStores(): void {
   testState.records = [];
   testState.canvasStore.renameTab.mockClear();
   testState.canvasStore.openTileInTab.mockClear();
+  testState.canvasStore.applyNestedRouteFocus.mockClear();
   testState.canvasStore.closeCanvasTab.mockClear();
   testState.openEpicState.setLastFocusedArtifactId.mockClear();
   testState.openEpicState.setLastFocusedThreadId.mockClear();
 }
 
+function specTile(
+  id: string,
+  instanceId: string,
+  name: string,
+): EpicCanvasTileRef {
+  return {
+    id,
+    instanceId,
+    type: "spec",
+    name,
+    hostId: "host-1",
+  };
+}
+
+function setSinglePaneCanvas(
+  paneId: string,
+  tabs: ReadonlyArray<EpicCanvasTileRef>,
+  activeTabId: string | null,
+): void {
+  testState.canvasActivePaneId = paneId;
+  testState.canvasRoot = {
+    kind: "pane",
+    id: paneId,
+    tabInstanceIds: tabs.map((tab) => tab.instanceId),
+    activeTabId,
+    previewTabId: null,
+    activationHistory: activeTabId === null ? [] : [activeTabId],
+  };
+  testState.canvasTiles = Object.fromEntries(
+    tabs.map((tab) => [tab.instanceId, tab]),
+  );
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSearchUpdater(
+  value: unknown,
+): value is (prev: Readonly<Record<string, unknown>>) => unknown {
+  return typeof value === "function";
+}
+
+function lastNavigateSearchPatch(): Readonly<Record<string, unknown>> {
+  const call = testState.navigate.mock.calls.at(-1);
+  if (call === undefined) throw new Error("expected navigate call");
+  const options: unknown = call[0];
+  if (!isRecord(options)) throw new Error("expected navigate options");
+  const search = options.search;
+  if (!isSearchUpdater(search)) {
+    throw new Error("expected search updater");
+  }
+  const result: unknown = search({});
+  if (!isRecord(result)) throw new Error("expected search patch result");
+  return result;
+}
+
 describe("useEpicRouteSynchronization", () => {
   beforeEach(resetStores);
   afterEach(resetStores);
+
+  it("canonicalizes a desktop route with no nested params to the current canvas focus", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-current",
+      [specTile("artifact-current", "tile-current", "Current artifact")],
+      "tile-current",
+    );
+
+    renderHook(
+      (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+      {
+        initialProps: {
+          epicId: EPIC_ID,
+          tabId: TAB_ID,
+          focusedAt: undefined,
+          focusArtifactId: undefined,
+          focusThreadId: undefined,
+          focusPaneId: undefined,
+          focusTileInstanceId: undefined,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalled();
+    });
+    expect(lastNavigateSearchPatch()).toMatchObject({
+      focusPaneId: "pane-current",
+      focusTileInstanceId: "tile-current",
+    });
+    expect(testState.navigate.mock.calls.at(-1)?.[0]).toMatchObject({
+      to: "/epics/$epicId/$tabId",
+      params: { epicId: EPIC_ID, tabId: TAB_ID },
+      replace: true,
+    });
+  });
+
+  it("lets legacy artifact focus resolve before canonicalizing missing nested params", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-existing",
+      [specTile("artifact-existing", "tile-existing", "Existing artifact")],
+      "tile-existing",
+    );
+
+    const hook = renderHook(
+      (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+      {
+        initialProps: {
+          ...THREAD_FOCUS_INTENT,
+          focusThreadId: undefined,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(testState.canvasStore.openTileInTab).toHaveBeenCalledWith(
+        TAB_ID,
+        expect.objectContaining({
+          id: "artifact-1",
+          type: "spec",
+          name: "Focused artifact",
+        }),
+      );
+    });
+    expect(testState.navigate).not.toHaveBeenCalled();
+
+    testState.activeArtifactId = "artifact-1";
+    setSinglePaneCanvas(
+      "pane-focused",
+      [specTile("artifact-1", "tile-focused", "Focused artifact")],
+      "tile-focused",
+    );
+    hook.rerender({
+      ...THREAD_FOCUS_INTENT,
+      focusThreadId: undefined,
+    });
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalled();
+    });
+    expect(lastNavigateSearchPatch()).toMatchObject({
+      focusPaneId: "pane-focused",
+      focusTileInstanceId: "tile-focused",
+    });
+  });
+
+  it("applies valid nested params with the raw canvas focus action", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-current",
+      [
+        specTile("artifact-a", "tile-a", "Artifact A"),
+        specTile("artifact-b", "tile-b", "Artifact B"),
+      ],
+      "tile-a",
+    );
+
+    renderHook(
+      (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+      {
+        initialProps: {
+          epicId: EPIC_ID,
+          tabId: TAB_ID,
+          focusedAt: undefined,
+          focusArtifactId: undefined,
+          focusThreadId: undefined,
+          focusPaneId: "pane-current",
+          focusTileInstanceId: "tile-b",
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(testState.canvasStore.applyNestedRouteFocus).toHaveBeenCalledWith(
+        TAB_ID,
+        {
+          paneId: "pane-current",
+          tileInstanceId: "tile-b",
+        },
+      );
+    });
+    expect(testState.navigate).not.toHaveBeenCalled();
+    expect(testState.canvasStore.openTileInTab).not.toHaveBeenCalled();
+  });
+
+  it("treats a pane-only route as applied when the active pane contains a tile", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-current",
+      [specTile("artifact-current", "tile-current", "Current artifact")],
+      "tile-current",
+    );
+
+    renderHook(
+      (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+      {
+        initialProps: {
+          epicId: EPIC_ID,
+          tabId: TAB_ID,
+          focusedAt: undefined,
+          focusArtifactId: undefined,
+          focusThreadId: undefined,
+          focusPaneId: "pane-current",
+          focusTileInstanceId: undefined,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(testState.navigate).not.toHaveBeenCalled();
+      expect(
+        testState.canvasStore.applyNestedRouteFocus,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  it("treats mismatched legacy artifact fields as inert when nested params are present", async () => {
+    testState.nestedFocusEnabled = true;
+    testState.activeArtifactId = "artifact-current";
+    setSinglePaneCanvas(
+      "pane-current",
+      [specTile("artifact-current", "tile-current", "Current artifact")],
+      "tile-current",
+    );
+
+    renderHook(
+      (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+      {
+        initialProps: {
+          ...THREAD_FOCUS_INTENT,
+          focusPaneId: "pane-current",
+          focusTileInstanceId: "tile-current",
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(testState.navigate).not.toHaveBeenCalled();
+      expect(testState.canvasStore.openTileInTab).not.toHaveBeenCalled();
+      expect(
+        testState.openEpicState.setLastFocusedArtifactId,
+      ).not.toHaveBeenCalledWith("artifact-1");
+      expect(
+        testState.openEpicState.setLastFocusedThreadId,
+      ).not.toHaveBeenCalled();
+      expect(useLeftPanelStore.getState().isCommentsPanelRevealed(TAB_ID)).toBe(
+        false,
+      );
+      expect(
+        useCommentThreadsStore.getState().activeByEpicId[EPIC_ID],
+      ).toBeUndefined();
+    });
+  });
+
+  it("recovers a stale current nested route to the current valid focus", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-current",
+      [specTile("artifact-current", "tile-current", "Current artifact")],
+      "tile-current",
+    );
+
+    renderHook(
+      (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+      {
+        initialProps: {
+          epicId: EPIC_ID,
+          tabId: TAB_ID,
+          focusedAt: undefined,
+          focusArtifactId: undefined,
+          focusThreadId: undefined,
+          focusPaneId: "pane-current",
+          focusTileInstanceId: "tile-stale",
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalled();
+    });
+    expect(lastNavigateSearchPatch()).toMatchObject({
+      focusPaneId: "pane-current",
+      focusTileInstanceId: "tile-current",
+    });
+    expect(testState.canvasStore.applyNestedRouteFocus).not.toHaveBeenCalled();
+  });
+
+  it("clears stale nested params when no valid current focus exists", async () => {
+    testState.nestedFocusEnabled = true;
+    testState.canvasRoot = {
+      kind: "pane",
+      id: "pane-empty",
+      tabInstanceIds: [],
+      activeTabId: null,
+      previewTabId: null,
+      activationHistory: [],
+    };
+    testState.canvasActivePaneId = "pane-missing";
+    testState.canvasTiles = {};
+
+    renderHook(
+      (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+      {
+        initialProps: {
+          epicId: EPIC_ID,
+          tabId: TAB_ID,
+          focusedAt: undefined,
+          focusArtifactId: undefined,
+          focusThreadId: undefined,
+          focusPaneId: "pane-stale",
+          focusTileInstanceId: undefined,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(testState.navigate).toHaveBeenCalled();
+    });
+    expect(lastNavigateSearchPatch()).toMatchObject({
+      focusPaneId: undefined,
+      focusTileInstanceId: undefined,
+    });
+    expect(testState.canvasStore.applyNestedRouteFocus).not.toHaveBeenCalled();
+  });
 
   it("reveals and activates comments for a focused thread deep link", async () => {
     const hook = renderHook(
@@ -301,6 +650,8 @@ describe("useEpicRouteSynchronization", () => {
           focusedAt: undefined,
           focusArtifactId: undefined,
           focusThreadId: undefined,
+          focusPaneId: undefined,
+          focusTileInstanceId: undefined,
         },
       },
     );

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -51,6 +51,7 @@ import {
   type LeftPanelId,
 } from "@/stores/epics/left-panel-store";
 import { isEditableRole } from "@/lib/epic-permissions";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 
 interface TabGroupViewProps {
   readonly epicId: string;
@@ -92,23 +93,38 @@ export const TabGroupView = memo(function TabGroupView(
 ) {
   const { epicId, tabId, pane } = props;
   const tabs = usePaneTabRefs(tabId, pane);
-  const setActiveTileTab = useEpicCanvasStore((s) => s.setActiveTileTab);
-  const setActiveTilePane = useEpicCanvasStore((s) => s.setActiveTilePane);
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
-  const closeCanvasPane = useEpicCanvasStore((s) => s.closeCanvasPane);
-  const closeOtherCanvasTabs = useEpicCanvasStore(
-    (s) => s.closeOtherCanvasTabs,
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareSetActiveTileTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareSetActiveTileTabFocusTarget,
   );
-  const closeRightCanvasTabs = useEpicCanvasStore(
-    (s) => s.closeRightCanvasTabs,
+  const prepareSetActiveTilePaneFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareSetActiveTilePaneFocusTarget,
   );
-  const closeAllCanvasTabs = useEpicCanvasStore((s) => s.closeAllCanvasTabs);
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
+  const prepareCloseCanvasPaneFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasPaneFocusTarget,
+  );
+  const prepareCloseOtherCanvasTabsFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseOtherCanvasTabsFocusTarget,
+  );
+  const prepareCloseRightCanvasTabsFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseRightCanvasTabsFocusTarget,
+  );
+  const prepareCloseAllCanvasTabsFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseAllCanvasTabsFocusTarget,
+  );
   const promotePreviewInTab = useEpicCanvasStore((s) => s.promotePreviewInTab);
-  const splitPaneEmptyRightInTab = useEpicCanvasStore(
-    (s) => s.splitPaneEmptyRightInTab,
+  const prepareSplitPaneEmptyFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareSplitPaneEmptyFocusTarget,
   );
-  const splitPaneWithTab = useEpicCanvasStore((s) => s.splitPaneWithTab);
-  const openBlankTabInPane = useEpicCanvasStore((s) => s.openBlankTabInPane);
+  const prepareSplitPaneWithTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareSplitPaneWithTabFocusTarget,
+  );
+  const prepareOpenBlankTabInPaneFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenBlankTabInPaneFocusTarget,
+  );
   const setActivePanelIdAndExpand = useLeftPanelStore(
     (s) => s.setActivePanelIdAndExpand,
   );
@@ -131,16 +147,20 @@ export const TabGroupView = memo(function TabGroupView(
 
   const handleSelectTab = useCallback(
     (groupId: string, tileTabId: string) => {
-      setActiveTileTab(tabId, groupId, tileTabId);
+      navigateNested(epicId, tabId, () =>
+        prepareSetActiveTileTabFocusTarget(tabId, groupId, tileTabId),
+      );
     },
-    [setActiveTileTab, tabId],
+    [epicId, navigateNested, prepareSetActiveTileTabFocusTarget, tabId],
   );
 
   const handleCloseTab = useCallback(
     (groupId: string, tileTabId: string) => {
-      closeCanvasTab(tabId, groupId, tileTabId);
+      navigateNested(epicId, tabId, () =>
+        prepareCloseCanvasTabFocusTarget(tabId, groupId, tileTabId),
+      );
     },
-    [closeCanvasTab, tabId],
+    [epicId, navigateNested, prepareCloseCanvasTabFocusTarget, tabId],
   );
 
   const handlePromotePreview = useCallback(
@@ -154,28 +174,44 @@ export const TabGroupView = memo(function TabGroupView(
     (groupId: string) => {
       // The new empty pane self-renders the inline opener (PaneOpener); no
       // explicit trigger needed.
-      splitPaneEmptyRightInTab(tabId, groupId);
+      navigateNested(epicId, tabId, () =>
+        prepareSplitPaneEmptyFocusTarget(tabId, groupId, "horizontal"),
+      );
     },
-    [splitPaneEmptyRightInTab, tabId],
+    [epicId, navigateNested, prepareSplitPaneEmptyFocusTarget, tabId],
   );
 
   const handleCloseGroup = useCallback(
     (groupId: string) => {
-      closeCanvasPane(tabId, groupId);
+      navigateNested(epicId, tabId, () =>
+        prepareCloseCanvasPaneFocusTarget(tabId, groupId),
+      );
     },
-    [closeCanvasPane, tabId],
+    [epicId, navigateNested, prepareCloseCanvasPaneFocusTarget, tabId],
   );
 
   const handleOpenBlankTab = useCallback(
     (groupId: string) => {
-      openBlankTabInPane(tabId, groupId);
+      navigateNested(epicId, tabId, () =>
+        prepareOpenBlankTabInPaneFocusTarget(tabId, groupId),
+      );
     },
-    [openBlankTabInPane, tabId],
+    [epicId, navigateNested, prepareOpenBlankTabInPaneFocusTarget, tabId],
   );
 
   const activatePane = useCallback(() => {
-    if (!globallyActive) setActiveTilePane(tabId, pane.id);
-  }, [globallyActive, pane.id, setActiveTilePane, tabId]);
+    if (globallyActive) return;
+    navigateNested(epicId, tabId, () =>
+      prepareSetActiveTilePaneFocusTarget(tabId, pane.id),
+    );
+  }, [
+    epicId,
+    globallyActive,
+    navigateNested,
+    pane.id,
+    prepareSetActiveTilePaneFocusTarget,
+    tabId,
+  ]);
   const deferredPaneActivationRef = useRef(false);
   const paneRootRef = useRef<HTMLDivElement | null>(null);
 
@@ -225,14 +261,16 @@ export const TabGroupView = memo(function TabGroupView(
       const position = positionFor(axis, leading);
       const tab = tabs.find((t) => t.instanceId === tileTabId);
       if (tab === undefined) return;
-      splitPaneWithTab(tabId, {
-        sourcePaneId: groupId,
-        tabId: tileTabId,
-        targetPaneId: groupId,
-        position,
-      });
+      navigateNested(epicId, tabId, () =>
+        prepareSplitPaneWithTabFocusTarget(tabId, {
+          sourcePaneId: groupId,
+          tabId: tileTabId,
+          targetPaneId: groupId,
+          position,
+        }),
+      );
     },
-    [tabs, splitPaneWithTab, tabId],
+    [epicId, navigateNested, prepareSplitPaneWithTabFocusTarget, tabId, tabs],
   );
 
   const handleRevealInSidebar = useCallback(
@@ -282,6 +320,7 @@ export const TabGroupView = memo(function TabGroupView(
         data-testid="tab-group"
         data-group-id={pane.id}
         data-active={globallyActive ? "true" : "false"}
+        tabIndex={-1}
         className="relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-canvas"
         onPointerDownCapture={handlePointerDownCapture}
         onPointerCancelCapture={handlePointerCancelCapture}
@@ -303,9 +342,17 @@ export const TabGroupView = memo(function TabGroupView(
             menuHandlers={{
               onClose: handleCloseTab,
               onCloseOthers: (gid, tid) =>
-                closeOtherCanvasTabs(tabId, gid, tid),
-              onCloseRight: (gid, tid) => closeRightCanvasTabs(tabId, gid, tid),
-              onCloseAll: (gid) => closeAllCanvasTabs(tabId, gid),
+                navigateNested(epicId, tabId, () =>
+                  prepareCloseOtherCanvasTabsFocusTarget(tabId, gid, tid),
+                ),
+              onCloseRight: (gid, tid) =>
+                navigateNested(epicId, tabId, () =>
+                  prepareCloseRightCanvasTabsFocusTarget(tabId, gid, tid),
+                ),
+              onCloseAll: (gid) =>
+                navigateNested(epicId, tabId, () =>
+                  prepareCloseAllCanvasTabsFocusTarget(tabId, gid),
+                ),
               onSplit: handleSplitFromMenu,
               onRevealInSidebar: handleRevealInSidebar,
               onRename: handleRename,
@@ -338,6 +385,7 @@ export const TabGroupView = memo(function TabGroupView(
                     data-testid="pane-tab-layer"
                     data-tab-instance-id={tab.instanceId}
                     data-selected={selected ? "true" : "false"}
+                    tabIndex={-1}
                     className={cn(
                       "absolute inset-0 min-h-0",
                       selected && "visible pointer-events-auto",
@@ -382,7 +430,10 @@ interface ActiveTabBodyProps {
 
 function ActiveTabBody(props: ActiveTabBodyProps) {
   const { activeTab, epicId, groupId, tabId } = props;
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
   const role = useEpicPermissionRole();
   const snapshotLoaded = useEpicSnapshotLoaded();
   const liveArtifact = useEpicArtifact(activeTab.id);
@@ -417,7 +468,13 @@ function ActiveTabBody(props: ActiveTabBodyProps) {
     return (
       <DeletedArtifactBody
         onClose={() => {
-          closeCanvasTab(tabId, groupId, activeTab.instanceId);
+          navigateNested(epicId, tabId, () =>
+            prepareCloseCanvasTabFocusTarget(
+              tabId,
+              groupId,
+              activeTab.instanceId,
+            ),
+          );
         }}
       />
     );

--- a/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-commits.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-commits.ts
@@ -33,7 +33,6 @@ import { computeTabDropIndex } from "@/components/epic-canvas/dnd/tab-strip-drop
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { findPaneById } from "@/stores/epics/canvas/tile-tree";
 import {
-  isGitDiffTileRef,
   makeOpenableNodeRef,
   type EpicCanvasTileRef,
   type EpicNodeRef,
@@ -61,6 +60,7 @@ import { getHostBindingSnapshot } from "@/lib/host/runtime";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { copyEpicSidebarTabState } from "@/lib/epics/copy-epic-sidebar-tab-state";
 import { useEpicSidebarExpansionStore } from "@/stores/epics/epic-sidebar-expansion-store";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 
 export interface ResolvedEpicCanvasDrop {
   readonly source: EpicCanvasDragSourceData;
@@ -332,39 +332,47 @@ function commitArtifactTabDrop(
   >,
   target: EpicCanvasDropTargetData,
   preview: NonNullable<EpicCanvasDropPreview>,
+  navigateNested: NavigateNestedFocus,
 ): void {
   if (preview.kind === "empty-shell") return;
   const canvasStore = useEpicCanvasStore.getState();
   if (preview.kind === "artifact-tab-strip") {
-    canvasStore.moveTabOnTabStrip(source.viewTabId, {
-      sourcePaneId: source.sourceGroupId,
-      tabId: source.tabId,
-      targetPaneId: preview.groupId,
-      targetIndex: preview.index,
-    });
+    navigateNested(source.epicId, source.viewTabId, () =>
+      canvasStore.prepareMoveActiveTabOnTabStripFocusTarget(source.viewTabId, {
+        sourcePaneId: source.sourceGroupId,
+        tabId: source.tabId,
+        targetPaneId: preview.groupId,
+        targetIndex: preview.index,
+      }),
+    );
   }
   if (
     preview.kind === "artifact-tab-group-body" &&
     preview.position === "center"
   ) {
-    canvasStore.moveTabOnTabStrip(source.viewTabId, {
-      sourcePaneId: source.sourceGroupId,
-      tabId: source.tabId,
-      targetPaneId: preview.groupId,
-      targetIndex:
-        target.kind === "artifact-tab-group-body" ? target.tabCount : 0,
-    });
+    navigateNested(source.epicId, source.viewTabId, () =>
+      canvasStore.prepareMoveActiveTabOnTabStripFocusTarget(source.viewTabId, {
+        sourcePaneId: source.sourceGroupId,
+        tabId: source.tabId,
+        targetPaneId: preview.groupId,
+        targetIndex:
+          target.kind === "artifact-tab-group-body" ? target.tabCount : 0,
+      }),
+    );
   }
   if (
     preview.kind === "artifact-tab-group-body" &&
     preview.position !== "center"
   ) {
-    canvasStore.splitPaneWithTab(source.viewTabId, {
-      sourcePaneId: source.sourceGroupId,
-      tabId: source.tabId,
-      targetPaneId: preview.groupId,
-      position: preview.position,
-    });
+    const position = preview.position;
+    navigateNested(source.epicId, source.viewTabId, () =>
+      canvasStore.prepareSplitPaneWithTabFocusTarget(source.viewTabId, {
+        sourcePaneId: source.sourceGroupId,
+        tabId: source.tabId,
+        targetPaneId: preview.groupId,
+        position,
+      }),
+    );
   }
 }
 
@@ -377,10 +385,15 @@ function commitArtifactTabDrop(
  * separate store).
  */
 function placeResolvedCanvasTile(
-  tile: EpicNodeRef | GitDiffTileRef,
-  target: EpicCanvasDropTargetData,
-  preview: NonNullable<EpicCanvasDropPreview>,
+  resolved: {
+    readonly epicId: string;
+    readonly tile: EpicNodeRef | GitDiffTileRef;
+    readonly target: EpicCanvasDropTargetData;
+    readonly preview: NonNullable<EpicCanvasDropPreview>;
+  },
+  navigateNested: NavigateNestedFocus,
 ): void {
+  const { epicId, tile, target, preview } = resolved;
   if (
     preview.kind === "left-panel-rail" ||
     preview.kind === "left-panel-rail-list" ||
@@ -391,11 +404,9 @@ function placeResolvedCanvasTile(
   const canvasStore = useEpicCanvasStore.getState();
   if (preview.kind === "empty-shell") {
     if (target.kind !== "empty-shell") return;
-    if (isGitDiffTileRef(tile)) {
-      canvasStore.openTileInTab(target.viewTabId, tile);
-      return;
-    }
-    canvasStore.openTileInTab(target.viewTabId, tile);
+    navigateNested(epicId, target.viewTabId, () =>
+      canvasStore.prepareOpenTileInTabFocusTarget(target.viewTabId, tile),
+    );
     return;
   }
   if (target.kind === "empty-shell") return;
@@ -407,35 +418,50 @@ function placeResolvedCanvasTile(
     return;
   }
   if (preview.kind === "artifact-tab-strip") {
-    canvasStore.insertNodeOnTabStrip(
-      target.viewTabId,
-      preview.groupId,
-      preview.index,
-      tile,
+    navigateNested(epicId, target.viewTabId, () =>
+      canvasStore.prepareInsertNodeOnTabStripFocusTarget(
+        target.viewTabId,
+        preview.groupId,
+        preview.index,
+        tile,
+      ),
     );
     return;
   }
   if (preview.position === "center") {
-    canvasStore.insertNodeOnTabStrip(
-      target.viewTabId,
-      preview.groupId,
-      target.kind === "artifact-tab-group-body" ? target.tabCount : 0,
-      tile,
+    navigateNested(epicId, target.viewTabId, () =>
+      canvasStore.prepareInsertNodeOnTabStripFocusTarget(
+        target.viewTabId,
+        preview.groupId,
+        target.kind === "artifact-tab-group-body" ? target.tabCount : 0,
+        tile,
+      ),
     );
     return;
   }
-  canvasStore.splitPaneWithNode(
-    target.viewTabId,
-    preview.groupId,
-    preview.position,
-    tile,
+  const position = preview.position;
+  navigateNested(epicId, target.viewTabId, () =>
+    canvasStore.prepareSplitPaneWithNodeFocusTarget(
+      target.viewTabId,
+      preview.groupId,
+      position,
+      tile,
+    ),
   );
 }
 
-export function commitResolvedCanvasDrop(drop: ResolvedEpicCanvasDrop): void {
+export function commitResolvedCanvasDrop(
+  drop: ResolvedEpicCanvasDrop,
+  navigateNested: NavigateNestedFocus,
+): void {
   if (drop.preview === null) return;
   if (drop.source.kind === ARTIFACT_TAB_DND_TYPE) {
-    commitArtifactTabDrop(drop.source, drop.target, drop.preview);
+    commitArtifactTabDrop(
+      drop.source,
+      drop.target,
+      drop.preview,
+      navigateNested,
+    );
     return;
   }
   if (drop.source.kind === LEFT_PANEL_RAIL_ITEM_DND_TYPE) {
@@ -452,7 +478,15 @@ export function commitResolvedCanvasDrop(drop: ResolvedEpicCanvasDrop): void {
   }
   const tile = sourceToTileRef(drop.source);
   if (tile !== null) {
-    placeResolvedCanvasTile(tile, drop.target, drop.preview);
+    placeResolvedCanvasTile(
+      {
+        epicId: drop.source.epicId,
+        tile,
+        target: drop.target,
+        preview: drop.preview,
+      },
+      navigateNested,
+    );
   }
 }
 

--- a/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-provider.tsx
+++ b/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-provider.tsx
@@ -62,6 +62,7 @@ import {
   existingEpicTabIntent,
   navigateToTabIntent,
 } from "@/lib/tab-navigation";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useTabsStore } from "@/stores/tabs/store";
 import {
@@ -205,6 +206,7 @@ interface RootDndProviderProps {
 
 export function RootDndProvider(props: RootDndProviderProps) {
   const navigate = useNavigate();
+  const navigateNested = useEpicNestedFocusNavigation();
   const lastResolvedDropRef = useRef<ResolvedEpicCanvasDrop | null>(null);
   const lastReparentDropRef = useRef<LastReparentDrop | null>(null);
   const springLoadRef = useRef<SpringLoadEntry | null>(null);
@@ -325,7 +327,7 @@ export function RootDndProvider(props: RootDndProviderProps) {
         } else {
           const drop = lastResolvedDropRef.current;
           if (drop !== null) {
-            commitResolvedCanvasDrop(drop);
+            commitResolvedCanvasDrop(drop, navigateNested);
           }
         }
       } else {
@@ -344,7 +346,7 @@ export function RootDndProvider(props: RootDndProviderProps) {
       clearLastCollisionPointerPoint();
       useEpicDndStore.getState().dragEnded();
     },
-    [navigate, updateDropPreview],
+    [navigate, navigateNested, updateDropPreview],
   );
 
   const handleDragCancel = useCallback(() => {

--- a/clients/gui-app/src/components/epic-canvas/epic-route-session-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/epic-route-session-body.tsx
@@ -12,6 +12,8 @@ export interface EpicRouteSessionBodyProps {
   readonly focusedAt: number | undefined;
   readonly focusArtifactId: string | undefined;
   readonly focusThreadId: string | undefined;
+  readonly focusPaneId: string | undefined;
+  readonly focusTileInstanceId: string | undefined;
 }
 
 export function EpicRouteSessionBody(props: EpicRouteSessionBodyProps) {
@@ -44,6 +46,8 @@ function EpicRouteActiveEffects(props: EpicRouteSessionBodyProps) {
     focusedAt: props.focusedAt,
     focusArtifactId: props.focusArtifactId,
     focusThreadId: props.focusThreadId,
+    focusPaneId: props.focusPaneId,
+    focusTileInstanceId: props.focusTileInstanceId,
   });
   return (
     <>

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/bundle-open-button.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/bundle-open-button.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { nestedFocusBoundaryMock } from "@/__tests__/nested-focus-boundary-mock";
 import { BundleOpenButton } from "../bundle-open-button";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 
@@ -21,6 +22,7 @@ describe("<BundleOpenButton />", () => {
   beforeEach(() => {
     cleanup();
     resetCanvas();
+    nestedFocusBoundaryMock.navigateNested.mockClear();
   });
 
   it("opens a pinned bundle diff tile in the current Epic canvas", () => {
@@ -39,6 +41,11 @@ describe("<BundleOpenButton />", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Open Changes" }));
 
+    expect(nestedFocusBoundaryMock.navigateNested).toHaveBeenCalledWith(
+      "epic-1",
+      tabId,
+      expect.any(Function),
+    );
     const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
     if (canvas?.root?.kind !== "pane") throw new Error("expected pane");
     expect(canvas.root.tabInstanceIds).toHaveLength(1);

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-row-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-row-navigation.test.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { nestedFocusBoundaryMock } from "@/__tests__/nested-focus-boundary-mock";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { GitChangedFileV11 } from "@traycer/protocol/host";
+import { FileRow } from "../file-row";
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({
+    setNodeRef: vi.fn(),
+    listeners: undefined,
+    attributes: {},
+    isDragging: false,
+  }),
+}));
+
+function changedFile(path: string): GitChangedFileV11 {
+  return {
+    path,
+    previousPath: null,
+    status: "modified",
+    stage: "unstaged",
+    isBinary: false,
+    insertions: 3,
+    deletions: 1,
+    sizeBytes: 100,
+    stagedOid: null,
+    worktreeOid: null,
+    gitlink: null,
+  };
+}
+
+function resetCanvas(): void {
+  window.localStorage.clear();
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+}
+
+function renderRow(tabId: string): void {
+  render(
+    <TooltipProvider>
+      <FileRow
+        epicId="epic-1"
+        viewTabId={tabId}
+        hostId="host-1"
+        runningDir="/repo"
+        file={changedFile("src/app.ts")}
+        active={false}
+        pathRanges={[]}
+        nested={false}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("<FileRow /> nested focus navigation", () => {
+  beforeEach(() => {
+    cleanup();
+    resetCanvas();
+    nestedFocusBoundaryMock.navigateNested.mockClear();
+  });
+
+  it("routes single-click preview through nested focus navigation", () => {
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    renderRow(tabId);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Modified app.ts in src" }),
+    );
+
+    expect(nestedFocusBoundaryMock.navigateNested).toHaveBeenCalledWith(
+      "epic-1",
+      tabId,
+      expect.any(Function),
+    );
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+    if (canvas?.root?.kind !== "pane") throw new Error("expected pane");
+    const activeTileId = canvas.root.activeTabId;
+    if (activeTileId === null) throw new Error("expected active tile");
+    const tile = canvas.tilesByInstanceId[activeTileId];
+    if (tile === undefined) throw new Error("expected tile");
+    expect(tile.type).toBe("git-diff");
+  });
+
+  it("routes double-click pinned open through nested focus navigation", () => {
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    renderRow(tabId);
+
+    fireEvent.doubleClick(
+      screen.getByRole("button", { name: "Modified app.ts in src" }),
+    );
+
+    expect(nestedFocusBoundaryMock.navigateNested).toHaveBeenCalledWith(
+      "epic-1",
+      tabId,
+      expect.any(Function),
+    );
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
@@ -1,0 +1,143 @@
+import type { MouseEvent, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { GitChangedFileV11 } from "@traycer/protocol/host";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import { FileTree as GitDiffFileTree } from "../file-tree";
+
+const testState = vi.hoisted(() => ({
+  treePath: "src/app.ts",
+  navigateNested: vi.fn(
+    (
+      _epicId: string,
+      _tabId: string,
+      prepare: () => NestedFocusTarget | null,
+    ) => prepare(),
+  ),
+}));
+
+vi.mock("@pierre/trees/react", () => ({
+  FileTree: (props: {
+    readonly onClick: (event: MouseEvent<HTMLElement>) => void;
+    readonly onDoubleClick: (event: MouseEvent<HTMLElement>) => void;
+    readonly "data-testid": string;
+  }) => (
+    <button
+      type="button"
+      data-testid={props["data-testid"]}
+      onClick={props.onClick}
+      onDoubleClick={props.onDoubleClick}
+    >
+      Git file tree
+    </button>
+  ),
+}));
+
+vi.mock("../git-diff-section", () => ({
+  GitDiffSection: (props: { readonly children: ReactNode }) => (
+    <section>{props.children}</section>
+  ),
+}));
+
+vi.mock("../use-git-panel-active-file", () => ({
+  gitPanelActiveFilePathForGroup: () => null,
+  useGitPanelActiveFile: () => null,
+  useGitPanelRevealSection: () => undefined,
+}));
+
+vi.mock("../use-git-pierre-file-tree-model", () => ({
+  useGitPierreFileTreeModel: (files: ReadonlyArray<GitChangedFileV11>) => ({
+    fileByPath: new Map(files.map((file) => [file.path, file])),
+    model: {
+      getSelectedPaths: () => [],
+      getItem: () => null,
+      scrollToPath: () => undefined,
+    },
+  }),
+}));
+
+vi.mock("@/components/epic-canvas/pierre-tree-adapter", () => ({
+  extractPierreItemPathFromEvent: () => testState.treePath,
+}));
+
+vi.mock("@/components/epic-canvas/dnd/use-pierre-canvas-drag-bridge", () => ({
+  usePierreCanvasDragBridge: () => ({ wrapperProps: {} }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => testState.navigateNested,
+}));
+
+function changedFile(): GitChangedFileV11 {
+  return {
+    path: testState.treePath,
+    previousPath: null,
+    status: "modified",
+    stage: "staged",
+    isBinary: false,
+    insertions: 3,
+    deletions: 1,
+    sizeBytes: 100,
+    stagedOid: null,
+    worktreeOid: null,
+    gitlink: null,
+  };
+}
+
+function resetCanvas(): void {
+  window.localStorage.clear();
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+}
+
+function renderTree(tabId: string): void {
+  const file = changedFile();
+  render(
+    <GitDiffFileTree
+      epicId="epic-1"
+      viewTabId={tabId}
+      hostId="host-1"
+      runningDir="/repo"
+      allFiles={[file]}
+      visibleFiles={[file]}
+      forceExpanded={false}
+      hideEmptySections
+      sectionCollapseController={null}
+      virtualized={false}
+    />,
+  );
+}
+
+describe("<FileTree /> nested focus navigation", () => {
+  beforeEach(() => {
+    cleanup();
+    resetCanvas();
+    testState.navigateNested.mockClear();
+  });
+
+  it("routes tree-row preview through nested focus navigation", () => {
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    renderTree(tabId);
+
+    fireEvent.click(screen.getByTestId("git-pierre-file-tree"));
+
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      "epic-1",
+      tabId,
+      expect.any(Function),
+    );
+  });
+
+  it("routes tree-row pinned open through nested focus navigation", () => {
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    renderTree(tabId);
+
+    fireEvent.doubleClick(screen.getByTestId("git-pierre-file-tree"));
+
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      "epic-1",
+      tabId,
+      expect.any(Function),
+    );
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/git-diff/bundle-open-button.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/bundle-open-button.tsx
@@ -8,12 +8,13 @@ import {
   gitBundleGroupLabel,
   makeGitBundleDiffTile,
 } from "@/lib/git/git-diff-tile";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { GitDiffBundleGroup } from "@/stores/epics/canvas/types";
 import { useDraggable } from "@dnd-kit/core";
 import { FileDiff } from "lucide-react";
 import type { ReactNode } from "react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 export interface BundleOpenButtonProps {
   readonly epicId: string;
@@ -25,7 +26,10 @@ export interface BundleOpenButtonProps {
 }
 
 export function BundleOpenButton(props: BundleOpenButtonProps): ReactNode {
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
   const tile = useMemo(
     () =>
       makeGitBundleDiffTile({
@@ -49,6 +53,17 @@ export function BundleOpenButton(props: BundleOpenButtonProps): ReactNode {
     data: dragData,
     disabled: props.disabled,
   });
+  const openBundle = useCallback(() => {
+    navigateNested(props.epicId, props.viewTabId, () =>
+      prepareOpenTileInTabFocusTarget(props.viewTabId, tile),
+    );
+  }, [
+    navigateNested,
+    prepareOpenTileInTabFocusTarget,
+    props.epicId,
+    props.viewTabId,
+    tile,
+  ]);
 
   return (
     <Button
@@ -59,7 +74,7 @@ export function BundleOpenButton(props: BundleOpenButtonProps): ReactNode {
       size="icon-sm"
       aria-label={`Open ${gitBundleGroupLabel(props.group)}`}
       disabled={props.disabled}
-      onClick={() => openTileInTab(props.viewTabId, tile)}
+      onClick={openBundle}
       className="text-muted-foreground hover:text-foreground"
     >
       <FileDiff className="size-4" />

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-row.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useDraggable } from "@dnd-kit/core";
 import type { GitChangedFile } from "@traycer/protocol/host";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { makeGitFileDiffTileForFile } from "@/lib/git/git-diff-tile";
 import { gitChangedFileTooltipContent } from "@/lib/git/panel-file-rendering";
 import type { HighlightRanges } from "@/lib/git/path-highlight";
@@ -27,8 +28,13 @@ export interface FileRowProps {
 }
 
 export function FileRow(props: FileRowProps): ReactNode {
-  const openPreview = useEpicCanvasStore((s) => s.openTilePreviewInTab);
-  const openPinned = useEpicCanvasStore((s) => s.openTileInTab);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTilePreviewInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTilePreviewInTabFocusTarget,
+  );
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
   const tile = useMemo(
     () =>
       makeGitFileDiffTileForFile({
@@ -40,12 +46,28 @@ export function FileRow(props: FileRowProps): ReactNode {
   );
 
   const onClick = useCallback(() => {
-    openPreview(props.viewTabId, tile);
-  }, [openPreview, props.viewTabId, tile]);
+    navigateNested(props.epicId, props.viewTabId, () =>
+      prepareOpenTilePreviewInTabFocusTarget(props.viewTabId, tile),
+    );
+  }, [
+    navigateNested,
+    prepareOpenTilePreviewInTabFocusTarget,
+    props.epicId,
+    props.viewTabId,
+    tile,
+  ]);
 
   const onDoubleClick = useCallback(() => {
-    openPinned(props.viewTabId, tile);
-  }, [openPinned, props.viewTabId, tile]);
+    navigateNested(props.epicId, props.viewTabId, () =>
+      prepareOpenTileInTabFocusTarget(props.viewTabId, tile),
+    );
+  }, [
+    navigateNested,
+    prepareOpenTileInTabFocusTarget,
+    props.epicId,
+    props.viewTabId,
+    tile,
+  ]);
 
   const dragData = useMemo<EpicCanvasGitDiffTileDragData>(
     () => ({

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
@@ -13,6 +13,7 @@ import {
 import { GIT_PANEL_PIERRE_FILE_TREE_THEME_STYLE } from "@/components/epic-canvas/pierre-tree-theme";
 import { extractPierreItemPathFromEvent } from "@/components/epic-canvas/pierre-tree-adapter";
 import { usePierreCanvasDragBridge } from "@/components/epic-canvas/dnd/use-pierre-canvas-drag-bridge";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import {
   GIT_DIFF_TILE_DND_TYPE,
   getGitDiffTileDragId,
@@ -24,6 +25,7 @@ import type {
   GitDiffBundleGroup,
   GitDiffTileRef,
 } from "@/stores/epics/canvas/types";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
 import { GitDiffSection } from "./git-diff-section";
 import type { GitDiffSectionCollapseController } from "./git-diff-section";
 import { useGitPierreFileTreeModel } from "./use-git-pierre-file-tree-model";
@@ -116,8 +118,13 @@ function isDirectoryHandle(
 }
 
 function GitTreeSectionBody(props: GitTreeSectionBodyProps): ReactNode {
-  const openPreview = useEpicCanvasStore((s) => s.openTilePreviewInTab);
-  const openPinned = useEpicCanvasStore((s) => s.openTileInTab);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTilePreviewInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTilePreviewInTabFocusTarget,
+  );
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
   const { model, fileByPath } = useGitPierreFileTreeModel(props.files);
 
   // Mirror the canvas's focused diff tile into Pierre's selection, expanding
@@ -160,30 +167,35 @@ function GitTreeSectionBody(props: GitTreeSectionBodyProps): ReactNode {
   );
 
   const openFile = useCallback(
-    (treePath: string, open: (tabId: string, tile: GitDiffTileRef) => void) => {
+    (
+      treePath: string,
+      open: (tabId: string, tile: GitDiffTileRef) => NestedFocusTarget | null,
+    ) => {
       const tile = tileForTreePath(treePath);
       if (tile === null) return;
-      open(props.viewTabId, tile);
+      navigateNested(props.epicId, props.viewTabId, () =>
+        open(props.viewTabId, tile),
+      );
     },
-    [tileForTreePath, props.viewTabId],
+    [navigateNested, props.epicId, props.viewTabId, tileForTreePath],
   );
 
   const previewFileFromTreeRow = useCallback(
     (event: MouseEvent<HTMLElement>) => {
       const treePath = extractPierreItemPathFromEvent(event);
       if (treePath === null) return;
-      openFile(treePath, openPreview);
+      openFile(treePath, prepareOpenTilePreviewInTabFocusTarget);
     },
-    [openFile, openPreview],
+    [openFile, prepareOpenTilePreviewInTabFocusTarget],
   );
 
   const pinFileFromTreeRow = useCallback(
     (event: MouseEvent<HTMLElement>) => {
       const treePath = extractPierreItemPathFromEvent(event);
       if (treePath === null) return;
-      openFile(treePath, openPinned);
+      openFile(treePath, prepareOpenTileInTabFocusTarget);
     },
-    [openFile, openPinned],
+    [openFile, prepareOpenTileInTabFocusTarget],
   );
 
   // Bridge Pierre's shadow-DOM rows into the canvas dnd-kit drag flow. The row

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
@@ -13,8 +13,10 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import { useGitGetFileDiffQuery } from "@/hooks/git/use-git-get-file-diff-query";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { DiffViewerPreferences } from "@/lib/diff/diff-viewer-preferences";
+import { useOpenEpicId } from "@/lib/epic-selectors";
 import { makeGitFileDiffTileForFile } from "@/lib/git/git-diff-tile";
 import { BUNDLE_INLINE_LINE_THRESHOLD } from "@/lib/git/bundle-thresholds";
 import { NO_HIGHLIGHT } from "@/lib/git/path-highlight";
@@ -46,7 +48,11 @@ interface BundleFileSectionProps {
 
 export function BundleFileSection(props: BundleFileSectionProps): ReactNode {
   const bundleFindRegistration = useBundleDiffFindRegistrationContext();
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
+  const epicId = useOpenEpicId();
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
   const toggleCollapsed = useEpicCanvasStore(
     (s) => s.toggleGitDiffBundleFileCollapsedInTab,
   );
@@ -58,16 +64,18 @@ export function BundleFileSection(props: BundleFileSectionProps): ReactNode {
   const isLarge = totalChangedLines > BUNDLE_INLINE_LINE_THRESHOLD;
 
   const handleOpenFileTile = useCallback(() => {
-    openTileInTab(
-      props.viewTabId,
-      makeGitFileDiffTileForFile({
-        hostId: props.node.hostId,
-        runningDir: props.node.diff.runningDir,
-        file: props.file,
-      }),
+    const tile = makeGitFileDiffTileForFile({
+      hostId: props.node.hostId,
+      runningDir: props.node.diff.runningDir,
+      file: props.file,
+    });
+    navigateNested(epicId, props.viewTabId, () =>
+      prepareOpenTileInTabFocusTarget(props.viewTabId, tile),
     );
   }, [
-    openTileInTab,
+    epicId,
+    navigateNested,
+    prepareOpenTileInTabFocusTarget,
     props.file,
     props.node.hostId,
     props.node.diff.runningDir,

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -107,13 +107,7 @@ export function useEpicRouteSynchronization(
     resolvedNestedRouteTarget,
     currentNestedTarget,
   );
-  const routeCanHonorLegacyArtifactFocus =
-    !nestedFocusEnabled ||
-    nestedRouteTarget === null ||
-    (focusArtifactId !== undefined &&
-      nestedRouteTargetApplied &&
-      activeArtifactId === focusArtifactId);
-  const routeCanHonorLegacyThreadFocus =
+  const legacyFocusHonorableAfterArtifactActivation =
     !nestedFocusEnabled ||
     nestedRouteTarget === null ||
     (focusArtifactId !== undefined &&
@@ -215,7 +209,10 @@ export function useEpicRouteSynchronization(
 
   useEffect(() => {
     if (!snapshotLoaded) return;
-    if (focusArtifactId !== undefined && !routeCanHonorLegacyArtifactFocus) {
+    if (
+      focusArtifactId !== undefined &&
+      !legacyFocusHonorableAfterArtifactActivation
+    ) {
       return;
     }
     const target = focusArtifactId ?? persistedFocus;
@@ -226,7 +223,7 @@ export function useEpicRouteSynchronization(
     focusArtifactId,
     focusedAt,
     persistedFocus,
-    routeCanHonorLegacyArtifactFocus,
+    legacyFocusHonorableAfterArtifactActivation,
     handle,
     epicId,
     tabId,
@@ -237,7 +234,7 @@ export function useEpicRouteSynchronization(
   useEffect(() => {
     if (!snapshotLoaded) return;
     if (focusThreadId === undefined) return;
-    if (!routeCanHonorLegacyThreadFocus) {
+    if (!legacyFocusHonorableAfterArtifactActivation) {
       return;
     }
     handle.store.getState().setLastFocusedThreadId(focusThreadId);
@@ -245,7 +242,7 @@ export function useEpicRouteSynchronization(
     snapshotLoaded,
     focusThreadId,
     focusedAt,
-    routeCanHonorLegacyThreadFocus,
+    legacyFocusHonorableAfterArtifactActivation,
     handle,
     epicId,
     tabId,
@@ -267,7 +264,7 @@ export function useEpicRouteSynchronization(
     if (!snapshotLoaded) return;
     if (focusThreadId === undefined) return;
     if (focusArtifactId === undefined) return;
-    if (!routeCanHonorLegacyThreadFocus) return;
+    if (!legacyFocusHonorableAfterArtifactActivation) return;
     if (activeArtifactId !== focusArtifactId) return;
     const key = `${epicId}|${focusedAt ?? ""}|${focusThreadId}`;
     if (lastDeepLinkRef.current === key) return;
@@ -281,7 +278,7 @@ export function useEpicRouteSynchronization(
     focusArtifactId,
     focusedAt,
     activeArtifactId,
-    routeCanHonorLegacyThreadFocus,
+    legacyFocusHonorableAfterArtifactActivation,
     epicId,
     tabId,
   ]);

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -1,4 +1,9 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import {
+  useNavigate,
+  useRouter,
+  type UseNavigateResult,
+} from "@tanstack/react-router";
 import { v4 as uuidv4 } from "uuid";
 import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import {
@@ -18,6 +23,17 @@ import { resolveAutoOpenTarget } from "@/lib/epic-auto-open";
 import { useLeftPanelStore } from "@/stores/epics/left-panel-store";
 import { useCommentThreadsStore } from "@/stores/comments/comment-threads-store";
 import { isTileRefRecordBacked } from "@/stores/epics/canvas/tile-schema";
+import { getHistoryController } from "@/lib/persistent-history";
+import {
+  areNestedFocusTargetsEqual,
+  buildNestedFocusSearchPatch,
+  getCurrentNestedFocusTarget,
+  parseNestedFocusTargetFromSearch,
+  resolveNestedFocusTarget,
+  type NestedFocusTarget,
+} from "@/lib/epic-nested-focus-route";
+
+type NavigateFn = UseNavigateResult<string>;
 
 export interface EpicRouteFocusIntent {
   readonly epicId: string;
@@ -25,6 +41,8 @@ export interface EpicRouteFocusIntent {
   readonly focusedAt: number | undefined;
   readonly focusArtifactId: string | undefined;
   readonly focusThreadId: string | undefined;
+  readonly focusPaneId: string | undefined;
+  readonly focusTileInstanceId: string | undefined;
 }
 
 /**
@@ -36,7 +54,17 @@ export interface EpicRouteFocusIntent {
 export function useEpicRouteSynchronization(
   intent: EpicRouteFocusIntent,
 ): void {
-  const { epicId, tabId, focusedAt, focusArtifactId, focusThreadId } = intent;
+  const {
+    epicId,
+    tabId,
+    focusedAt,
+    focusArtifactId,
+    focusThreadId,
+    focusPaneId,
+    focusTileInstanceId,
+  } = intent;
+  const router = useRouter();
+  const navigate = useNavigate();
   const handle = useOpenEpicHandle();
   const snapshotLoaded = useEpicSnapshotLoaded();
   const liveTitle = useEpicTitle();
@@ -45,6 +73,9 @@ export function useEpicRouteSynchronization(
   const currentTab = useEpicTab(tabId);
   const renameTab = useEpicCanvasStore((s) => s.renameTab);
   const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
+  const applyNestedRouteFocus = useEpicCanvasStore(
+    (s) => s.applyNestedRouteFocus,
+  );
   const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
   const pendingCreateArtifactIds = useEpicCanvasStore(
     (s) => s.pendingCreateArtifactIds,
@@ -52,6 +83,42 @@ export function useEpicRouteSynchronization(
   const activeArtifactId = useActiveEpicArtifactId(tabId);
   const canvas = useEpicCanvas(tabId);
   const hasRestoredCanvas = canvas.root !== null;
+  const nestedRouteTarget = useMemo(
+    () =>
+      parseNestedFocusTargetFromSearch({
+        focusPaneId,
+        focusTileInstanceId,
+      }),
+    [focusPaneId, focusTileInstanceId],
+  );
+  const nestedFocusEnabled = getHistoryController(router.history) !== null;
+  const currentNestedTarget = useMemo(
+    () => (hasRestoredCanvas ? getCurrentNestedFocusTarget(canvas) : null),
+    [hasRestoredCanvas, canvas],
+  );
+  const resolvedNestedRouteTarget = useMemo(
+    () =>
+      nestedFocusEnabled && hasRestoredCanvas && nestedRouteTarget !== null
+        ? resolveNestedFocusTarget(canvas, nestedRouteTarget)
+        : null,
+    [nestedFocusEnabled, hasRestoredCanvas, nestedRouteTarget, canvas],
+  );
+  const nestedRouteTargetApplied = isNestedRouteTargetApplied(
+    resolvedNestedRouteTarget,
+    currentNestedTarget,
+  );
+  const routeCanHonorLegacyArtifactFocus =
+    !nestedFocusEnabled ||
+    nestedRouteTarget === null ||
+    (focusArtifactId !== undefined &&
+      nestedRouteTargetApplied &&
+      activeArtifactId === focusArtifactId);
+  const routeCanHonorLegacyThreadFocus =
+    !nestedFocusEnabled ||
+    nestedRouteTarget === null ||
+    (focusArtifactId !== undefined &&
+      nestedRouteTargetApplied &&
+      activeArtifactId === focusArtifactId);
 
   const currentTabName = currentTab?.name ?? null;
   useEffect(() => {
@@ -62,17 +129,130 @@ export function useEpicRouteSynchronization(
   }, [currentTabName, tabId, liveTitle, renameTab]);
 
   useEffect(() => {
+    if (!snapshotLoaded) {
+      return;
+    }
+    if (!nestedFocusEnabled) {
+      return;
+    }
+    if (!hasRestoredCanvas) {
+      return;
+    }
+
+    if (nestedRouteTarget === null) {
+      if (
+        shouldDeferToLegacyArtifactFocus({
+          focusArtifactId,
+          focusThreadId,
+          activeArtifactId,
+        })
+      ) {
+        return;
+      }
+      const target = getCurrentNestedFocusTarget(canvas);
+      if (target === null) {
+        return;
+      }
+      replaceNestedFocusRoute(navigate, { epicId, tabId }, target);
+      return;
+    }
+
+    const resolved = resolveNestedFocusTarget(canvas, nestedRouteTarget);
+    if (resolved === null) {
+      const fallback = getCurrentNestedFocusTarget(canvas);
+      replaceNestedFocusRoute(navigate, { epicId, tabId }, fallback);
+      return;
+    }
+
+    if (!isNestedRouteTargetApplied(resolved, currentNestedTarget)) {
+      applyNestedRouteFocus(tabId, resolved);
+      return;
+    }
+  }, [
+    snapshotLoaded,
+    nestedFocusEnabled,
+    hasRestoredCanvas,
+    nestedRouteTarget,
+    focusArtifactId,
+    focusThreadId,
+    activeArtifactId,
+    canvas,
+    navigate,
+    epicId,
+    tabId,
+    currentNestedTarget,
+    applyNestedRouteFocus,
+  ]);
+
+  useEffect(() => {
     if (!snapshotLoaded) return;
+    if (!nestedFocusEnabled) return;
+    if (!hasRestoredCanvas) return;
+    if (nestedRouteTarget === null) return;
+    if (resolvedNestedRouteTarget === null) {
+      return;
+    }
+    if (!nestedRouteTargetApplied) {
+      return;
+    }
+    const frame = window.requestAnimationFrame(() => {
+      focusNestedRouteTarget(resolvedNestedRouteTarget);
+    });
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [
+    snapshotLoaded,
+    nestedFocusEnabled,
+    hasRestoredCanvas,
+    nestedRouteTarget,
+    resolvedNestedRouteTarget,
+    nestedRouteTargetApplied,
+    currentNestedTarget,
+    epicId,
+    tabId,
+  ]);
+
+  useEffect(() => {
+    if (!snapshotLoaded) return;
+    if (focusArtifactId !== undefined && !routeCanHonorLegacyArtifactFocus) {
+      return;
+    }
     const target = focusArtifactId ?? persistedFocus;
     if (target === null) return;
     handle.store.getState().setLastFocusedArtifactId(target);
-  }, [snapshotLoaded, focusArtifactId, focusedAt, persistedFocus, handle]);
+  }, [
+    snapshotLoaded,
+    focusArtifactId,
+    focusedAt,
+    persistedFocus,
+    routeCanHonorLegacyArtifactFocus,
+    handle,
+    epicId,
+    tabId,
+    activeArtifactId,
+    nestedRouteTarget,
+  ]);
 
   useEffect(() => {
     if (!snapshotLoaded) return;
     if (focusThreadId === undefined) return;
+    if (!routeCanHonorLegacyThreadFocus) {
+      return;
+    }
     handle.store.getState().setLastFocusedThreadId(focusThreadId);
-  }, [snapshotLoaded, focusThreadId, focusedAt, handle]);
+  }, [
+    snapshotLoaded,
+    focusThreadId,
+    focusedAt,
+    routeCanHonorLegacyThreadFocus,
+    handle,
+    epicId,
+    tabId,
+    focusArtifactId,
+    activeArtifactId,
+    nestedRouteTarget,
+  ]);
 
   // When the route handed us a `focusThreadId`, swap the left panel to
   // Comments and activate the matching thread *after* the auto-open
@@ -87,6 +267,7 @@ export function useEpicRouteSynchronization(
     if (!snapshotLoaded) return;
     if (focusThreadId === undefined) return;
     if (focusArtifactId === undefined) return;
+    if (!routeCanHonorLegacyThreadFocus) return;
     if (activeArtifactId !== focusArtifactId) return;
     const key = `${epicId}|${focusedAt ?? ""}|${focusThreadId}`;
     if (lastDeepLinkRef.current === key) return;
@@ -100,6 +281,7 @@ export function useEpicRouteSynchronization(
     focusArtifactId,
     focusedAt,
     activeArtifactId,
+    routeCanHonorLegacyThreadFocus,
     epicId,
     tabId,
   ]);
@@ -107,7 +289,14 @@ export function useEpicRouteSynchronization(
   const lastAutoOpenKey = useRef<string | null>(null);
   useEffect(() => {
     if (!snapshotLoaded) return;
-    if (records.length === 0 && focusArtifactId === undefined) {
+    if (
+      shouldSuppressLegacyAutoOpen({
+        nestedFocusEnabled,
+        nestedRouteTarget,
+        focusArtifactId,
+        recordCount: records.length,
+      })
+    ) {
       return;
     }
 
@@ -130,8 +319,12 @@ export function useEpicRouteSynchronization(
       focusArtifactId ?? null,
       persistedFocus,
     );
-    if (target === null) return;
-    if (activeArtifactId === target.id) return;
+    if (target === null) {
+      return;
+    }
+    if (activeArtifactId === target.id) {
+      return;
+    }
     openTileInTab(tabId, {
       id: target.id,
       instanceId: uuidv4(),
@@ -150,6 +343,8 @@ export function useEpicRouteSynchronization(
     activeArtifactId,
     epicId,
     tabId,
+    nestedFocusEnabled,
+    nestedRouteTarget,
   ]);
 
   const lastSyncedFocus = useRef<string | null>(persistedFocus);
@@ -195,7 +390,122 @@ export function useEpicRouteSynchronization(
     canvas,
     records,
     pendingCreateArtifactIds,
+    epicId,
     tabId,
     closeCanvasTab,
   ]);
+}
+
+function replaceNestedFocusRoute(
+  navigate: NavigateFn,
+  tab: { readonly epicId: string; readonly tabId: string },
+  target: NestedFocusTarget | null,
+): void {
+  void navigate({
+    to: "/epics/$epicId/$tabId",
+    params: { epicId: tab.epicId, tabId: tab.tabId },
+    search: (prev) => ({
+      ...prev,
+      focusedAt: prev.focusedAt,
+      focusArtifactId: prev.focusArtifactId,
+      focusThreadId: prev.focusThreadId,
+      migrationSource: prev.migrationSource,
+      ...buildNestedFocusSearchPatch(target),
+    }),
+    replace: true,
+  });
+}
+
+/**
+ * Whether the legacy auto-open effect should no-op: a committed nested route
+ * target already governs focus, or there is nothing to auto-open yet.
+ */
+function shouldSuppressLegacyAutoOpen(args: {
+  readonly nestedFocusEnabled: boolean;
+  readonly nestedRouteTarget: NestedFocusTarget | null;
+  readonly focusArtifactId: string | undefined;
+  readonly recordCount: number;
+}): boolean {
+  const {
+    nestedFocusEnabled,
+    nestedRouteTarget,
+    focusArtifactId,
+    recordCount,
+  } = args;
+  if (nestedFocusEnabled && nestedRouteTarget !== null) {
+    return true;
+  }
+  if (recordCount === 0 && focusArtifactId === undefined) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Whether the route-sync effect should defer canonicalizing the current
+ * canvas focus into the route because a legacy (`focusArtifactId` /
+ * `focusThreadId`) deep link is still pending activation.
+ */
+function shouldDeferToLegacyArtifactFocus(args: {
+  readonly focusArtifactId: string | undefined;
+  readonly focusThreadId: string | undefined;
+  readonly activeArtifactId: string | null;
+}): boolean {
+  const { focusArtifactId, focusThreadId, activeArtifactId } = args;
+  if (focusArtifactId === undefined && focusThreadId === undefined) {
+    return false;
+  }
+  if (focusArtifactId === undefined) {
+    return true;
+  }
+  if (activeArtifactId !== focusArtifactId) {
+    return true;
+  }
+  return false;
+}
+
+function isNestedRouteTargetApplied(
+  routeTarget: NestedFocusTarget | null,
+  currentTarget: NestedFocusTarget | null,
+): boolean {
+  if (routeTarget === null) return false;
+  if (currentTarget === null) return false;
+  if (routeTarget.tileInstanceId === undefined) {
+    return currentTarget.paneId === routeTarget.paneId;
+  }
+  return areNestedFocusTargetsEqual(currentTarget, routeTarget);
+}
+
+function focusNestedRouteTarget(target: NestedFocusTarget): void {
+  const element =
+    target.tileInstanceId === undefined
+      ? findActivePaneElement(target.paneId)
+      : findSelectedTileElement(target.tileInstanceId);
+  if (element === null) {
+    return;
+  }
+  element.focus({ preventScroll: true });
+}
+
+function findActivePaneElement(paneId: string): HTMLElement | null {
+  const elements = document.querySelectorAll<HTMLElement>(
+    "[data-group-id][data-active='true']",
+  );
+  return (
+    [...elements].find(
+      (element) => element.getAttribute("data-group-id") === paneId,
+    ) ?? null
+  );
+}
+
+function findSelectedTileElement(tileInstanceId: string): HTMLElement | null {
+  const elements = document.querySelectorAll<HTMLElement>(
+    "[data-tab-instance-id][data-selected='true']",
+  );
+  return (
+    [...elements].find(
+      (element) =>
+        element.getAttribute("data-tab-instance-id") === tileInstanceId,
+    ) ?? null
+  );
 }

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-initial-chat-handoff.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-initial-chat-handoff.ts
@@ -13,6 +13,7 @@ import {
   useEpicSnapshotLoaded,
 } from "@/lib/epic-selectors";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
@@ -57,19 +58,28 @@ export function useInitialChatHandoff(epicId: string, tabId: string): void {
   // epic chats. The chat tab is eager-opened (canvas state) + marked
   // pending-create so it survives until this projection catches up.
   const chatRecords = useEpicChatRecords();
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
-  const openTileInPane = useEpicCanvasStore((s) => s.openTileInPane);
-  const splitPaneWithNode = useEpicCanvasStore((s) => s.splitPaneWithNode);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
+  const prepareOpenTileInPaneFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInPaneFocusTarget,
+  );
+  const prepareSplitPaneWithNodeFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareSplitPaneWithNodeFocusTarget,
+  );
   const markArtifactPendingCreate = useEpicCanvasStore(
     (s) => s.markArtifactPendingCreate,
   );
   const unmarkArtifactPendingCreate = useEpicCanvasStore(
     (s) => s.unmarkArtifactPendingCreate,
   );
-  // Opener placements (target-group / split) bypass dedup, so the eager-open
-  // must fire exactly once per chat even as the handoff effect re-runs across
-  // status transitions. The active-tile path is dedup-aware and intentionally
-  // re-opens (keeps the tab label tracking the projected title).
+  // Every placement kind (active-tile, target-group, split) opens exactly
+  // once per chat, even as the handoff effect re-runs across status/
+  // projection transitions. The tab label tracks the projected title live
+  // via `useEpicTabDisplayTitle`'s `liveArtifactTitle` fallback, so
+  // re-opening on each transition is unnecessary and would re-navigate /
+  // steal focus from whatever the user is looking at.
   const openedChatIdRef = useRef<string | null>(null);
   // The chatId whose pending-create mark this hook currently owns. A second
   // in-epic create registers a new handoff under the same {host,user,epic}
@@ -132,9 +142,26 @@ export function useInitialChatHandoff(epicId: string, tabId: string): void {
       handoffStatus,
       handoffPlacement,
       markArtifactPendingCreate,
-      openTileInTab,
-      openTileInPane,
-      splitPaneWithNode,
+      openTileInTab: (targetTabId, node) => {
+        navigateNested(epicId, targetTabId, () =>
+          prepareOpenTileInTabFocusTarget(targetTabId, node),
+        );
+      },
+      openTileInPane: (targetTabId, paneId, node) => {
+        navigateNested(epicId, targetTabId, () =>
+          prepareOpenTileInPaneFocusTarget(targetTabId, paneId, node),
+        );
+      },
+      splitPaneWithNode: (targetTabId, targetPaneId, position, node) => {
+        navigateNested(epicId, targetTabId, () =>
+          prepareSplitPaneWithNodeFocusTarget(
+            targetTabId,
+            targetPaneId,
+            position,
+            node,
+          ),
+        );
+      },
       openedChatIdRef,
       markedChatIdRef,
       projectedChatId,
@@ -149,9 +176,11 @@ export function useInitialChatHandoff(epicId: string, tabId: string): void {
     handoffStatus,
     handoffPlacement,
     markArtifactPendingCreate,
-    openTileInTab,
-    openTileInPane,
-    splitPaneWithNode,
+    epicId,
+    navigateNested,
+    prepareOpenTileInPaneFocusTarget,
+    prepareOpenTileInTabFocusTarget,
+    prepareSplitPaneWithNodeFocusTarget,
     projectedChatId,
     projectedChatTitle,
     scope,
@@ -263,24 +292,24 @@ function runCanvasHandoffTransition(input: CanvasHandoffTransitionInput): void {
     hostId: input.activeHostId ?? UNKNOWN_HOST_PLACEHOLDER,
   };
   const placement = input.handoffPlacement;
-  if (placement.kind === "active-tile") {
-    // Dedup-aware: re-open on each transition so the tab label tracks the
-    // projected title as it lands.
-    input.openTileInTab(input.tabId, node);
-  } else if (
+  // Latch every placement kind once per handoffChatId. The ref guards
+  // re-fires within a session; `tabContainsTile` also guards a reload, where
+  // the canvas layout persists the tile but the ref does not (without it
+  // each reload would stack a duplicate).
+  if (
     input.openedChatIdRef.current !== input.handoffChatId &&
     !tabContainsTile(input.tabId, input.handoffChatId)
   ) {
-    // Opener placements (target-group / split) bypass dedup - open once. The
-    // ref guards re-fires within a session; `tabContainsTile` also guards a
-    // reload, where the canvas layout persists the tile but the ref does not
-    // (without it each reload would stack a duplicate). If the target group is
-    // gone (closed mid-compose, or a stale id rehydrated on reload), fall back
-    // to the active tile so the chat always surfaces instead of vanishing.
     input.openedChatIdRef.current = input.handoffChatId;
-    const effectivePlacement = tabContainsPane(input.tabId, placement.groupId)
-      ? placement
-      : ACTIVE_TILE_PLACEMENT;
+    // Opener placements (target-group / split) bypass dedup. If the target
+    // group is gone (closed mid-compose, or a stale id rehydrated on
+    // reload), fall back to the active tile so the chat always surfaces
+    // instead of vanishing.
+    const effectivePlacement =
+      placement.kind === "active-tile" ||
+      tabContainsPane(input.tabId, placement.groupId)
+        ? placement
+        : ACTIVE_TILE_PLACEMENT;
     openChatNodeWithPlacement(
       {
         openTileInTab: input.openTileInTab,

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-child-index.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-child-index.test.tsx
@@ -2,6 +2,12 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ArtifactChildIndex } from "@/components/epic-canvas/renderers/artifact-child-index";
 import { readEpicCanvasDragSourceData } from "@/components/epic-canvas/dnd/dnd";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type {
+  EpicCanvasTileRef,
+  EpicNodeRef,
+} from "@/stores/epics/canvas/types";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
 
 type TestTreeNode = {
   readonly type: string | null;
@@ -23,17 +29,16 @@ const projection = vi.hoisted<{
   nodesById: {},
 }));
 
-const canvas = vi.hoisted(() => ({
-  openTilePreviewInTab: vi.fn(),
-}));
-
-const resolveTabIdForEpic = vi.hoisted(() =>
-  vi.fn((_state: typeof canvas, _epicId: string) => "resolved-tab"),
-);
-
 const dnd = vi.hoisted(() => ({
   draggables: [] as CapturedDraggable[],
   setNodeRef: vi.fn(),
+}));
+
+const navigation = vi.hoisted(() => ({
+  openTilePreviewInTab: vi.fn(
+    (_tabId: string, _node: EpicCanvasTileRef): NestedFocusTarget | null =>
+      null,
+  ),
 }));
 
 vi.mock("@/lib/epic-selectors", () => ({
@@ -42,10 +47,13 @@ vi.mock("@/lib/epic-selectors", () => ({
   useTreeNodeById: (nodeId: string) => projection.nodesById[nodeId] ?? null,
 }));
 
-vi.mock("@/stores/epics/canvas/store", () => ({
-  useEpicCanvasStore: (selector: (state: typeof canvas) => unknown) =>
-    selector(canvas),
-  resolveTabIdForEpic,
+vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
+  useEpicTileNavigation: () => ({
+    openTilePreviewInTab: navigation.openTilePreviewInTab,
+    openTileInTab: vi.fn(),
+    openTileInEpic: vi.fn(),
+    openTilePreviewInEpic: vi.fn(),
+  }),
 }));
 
 vi.mock("@/stores/settings/settings-store", () => ({
@@ -94,10 +102,17 @@ vi.mock("@dnd-kit/core", async (importOriginal) => {
 
 describe("<ArtifactChildIndex />", () => {
   beforeEach(() => {
+    window.localStorage.clear();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    navigation.openTilePreviewInTab.mockImplementation(
+      (tabId: string, node: EpicCanvasTileRef): NestedFocusTarget | null =>
+        useEpicCanvasStore
+          .getState()
+          .prepareOpenTilePreviewInTabFocusTarget(tabId, node),
+    );
     projection.childIdsByParent = {};
     projection.nodesById = {};
-    canvas.openTilePreviewInTab.mockClear();
-    resolveTabIdForEpic.mockClear();
+    navigation.openTilePreviewInTab.mockClear();
     dnd.draggables = [];
     dnd.setNodeRef.mockClear();
   });
@@ -105,6 +120,9 @@ describe("<ArtifactChildIndex />", () => {
   afterEach(cleanup);
 
   it("emits a draggable artifact payload while preserving click-to-preview", () => {
+    const viewTabId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-1", "Epic");
     projection.childIdsByParent.parent = ["child-story"];
     projection.nodesById["child-story"] = {
       type: "story",
@@ -116,7 +134,7 @@ describe("<ArtifactChildIndex />", () => {
       <ArtifactChildIndex
         epicId="epic-1"
         parentId="parent"
-        viewTabId="view-tab-1"
+        viewTabId={viewTabId}
         hostId="host-1"
       />,
     );
@@ -129,7 +147,7 @@ describe("<ArtifactChildIndex />", () => {
     expect(readEpicCanvasDragSourceData(dnd.draggables[0].data)).toEqual({
       kind: "chat-artifact",
       epicId: "epic-1",
-      viewTabId: "view-tab-1",
+      viewTabId,
       artifact: {
         id: "child-story",
         type: "story",
@@ -137,12 +155,13 @@ describe("<ArtifactChildIndex />", () => {
         hostId: "host-1",
       },
     });
-    expect(resolveTabIdForEpic).not.toHaveBeenCalled();
 
     fireEvent.click(row);
 
-    expect(canvas.openTilePreviewInTab).toHaveBeenCalledWith(
-      "view-tab-1",
+    // A revert to a raw canvas `openTilePreviewInTab` call would still mutate
+    // the store, but would not hit this route-aware boundary spy.
+    expect(navigation.openTilePreviewInTab).toHaveBeenCalledWith(
+      viewTabId,
       expect.objectContaining({
         id: "child-story",
         type: "story",
@@ -150,9 +169,22 @@ describe("<ArtifactChildIndex />", () => {
         hostId: "host-1",
       }),
     );
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+    if (canvas?.root?.kind !== "pane") throw new Error("expected pane");
+    const activeTile =
+      canvas.tilesByInstanceId[canvas.root.activeTabId ?? ""] ?? null;
+    expect(activeTile).toMatchObject({
+      id: "child-story",
+      type: "story",
+      name: "Child Story",
+      hostId: "host-1",
+    } satisfies Partial<EpicNodeRef>);
   });
 
   it("does not render or enable drag for non-artifact child nodes", () => {
+    const viewTabId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-1", "Epic");
     projection.childIdsByParent.parent = ["child-chat"];
     projection.nodesById["child-chat"] = {
       type: "chat",
@@ -164,7 +196,7 @@ describe("<ArtifactChildIndex />", () => {
       <ArtifactChildIndex
         epicId="epic-1"
         parentId="parent"
-        viewTabId="view-tab-1"
+        viewTabId={viewTabId}
         hostId="host-1"
       />,
     );

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-focus-terminal.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-focus-terminal.test.tsx
@@ -1,0 +1,113 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { nestedFocusBoundaryMock } from "@/__tests__/nested-focus-boundary-mock";
+import { TabHostProvider } from "@/components/epic-canvas/tab-host-provider";
+import { useFocusEpicTerminalSession } from "@/components/epic-canvas/renderers/chat-tile-focus-terminal";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { collectPanes } from "@/stores/epics/canvas/tile-tree";
+import type { EpicTerminalRef } from "@/stores/epics/canvas/types";
+
+const EPIC_ID = "epic-1";
+const HOST_ID = "host-1";
+
+const EXISTING_TERMINAL: EpicTerminalRef = {
+  id: "term-existing",
+  instanceId: "inst-term-existing",
+  type: "terminal",
+  name: "shell",
+  titleSource: "manual",
+  hostId: HOST_ID,
+  cwd: "/work/repo",
+};
+
+function renderFocusHook(viewTabId: string) {
+  return renderHook(() => useFocusEpicTerminalSession(viewTabId), {
+    wrapper: (props: { children: React.ReactNode }) => (
+      <TabHostProvider hostId={HOST_ID}>{props.children}</TabHostProvider>
+    ),
+  });
+}
+
+describe("useFocusEpicTerminalSession", () => {
+  beforeEach(() => {
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    nestedFocusBoundaryMock.navigateNested.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("routes focusing an already-open terminal through the nested-focus boundary", () => {
+    const store = useEpicCanvasStore.getState();
+    const viewTabId = store.openEpicTab(EPIC_ID, "Epic");
+    store.openTileInTab(viewTabId, EXISTING_TERMINAL);
+    // Steal focus onto a second tile so the click has to move it back.
+    const otherTerminal: EpicTerminalRef = {
+      ...EXISTING_TERMINAL,
+      id: "term-other",
+      instanceId: "inst-term-other",
+    };
+    store.openTileInTab(viewTabId, otherTerminal);
+
+    const { result } = renderFocusHook(viewTabId);
+    act(() => {
+      result.current(EXISTING_TERMINAL.id, EXISTING_TERMINAL.cwd);
+    });
+
+    // A revert to raw `setActiveTilePane`/`setActiveTileTab` calls would never
+    // invoke this spy, so this assertion fails against the pre-fix code path.
+    expect(nestedFocusBoundaryMock.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      viewTabId,
+      expect.any(Function),
+    );
+
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+    if (canvas === undefined) throw new Error("expected view tab canvas");
+    const pane = collectPanes(canvas.root)[0];
+    expect(pane.activeTabId).toBe(EXISTING_TERMINAL.instanceId);
+  });
+
+  it("routes opening a not-yet-open terminal through the nested-focus boundary", () => {
+    const store = useEpicCanvasStore.getState();
+    const viewTabId = store.openEpicTab(EPIC_ID, "Epic");
+
+    const { result } = renderFocusHook(viewTabId);
+    act(() => {
+      result.current("term-new", "/work/new-repo");
+    });
+
+    expect(nestedFocusBoundaryMock.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      viewTabId,
+      expect.any(Function),
+    );
+
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+    if (canvas === undefined) throw new Error("expected view tab canvas");
+    const pane = collectPanes(canvas.root)[0];
+    const activeTile = canvas.tilesByInstanceId[pane.activeTabId ?? ""] ?? null;
+    expect(activeTile?.id).toBe("term-new");
+    if (activeTile === null || activeTile.type !== "terminal") {
+      throw new Error("expected an active terminal tile");
+    }
+    expect(activeTile.hostId).toBe(HOST_ID);
+    expect(activeTile.cwd).toBe("/work/new-repo");
+  });
+
+  it("is a no-op for a null or empty session id", () => {
+    const store = useEpicCanvasStore.getState();
+    const viewTabId = store.openEpicTab(EPIC_ID, "Epic");
+
+    const { result } = renderFocusHook(viewTabId);
+    act(() => {
+      result.current(null, "/work/repo");
+      result.current("", "/work/repo");
+    });
+
+    expect(nestedFocusBoundaryMock.navigateNested).not.toHaveBeenCalled();
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+    expect(canvas?.root).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-bundle-diff-tile-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-bundle-diff-tile-find.test.tsx
@@ -16,6 +16,12 @@ import {
   useTileFindStore,
   type TileFindStateSnapshot,
 } from "@/stores/tile-find";
+import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
+import {
+  createOpenEpicStore,
+  type EpicStreamClientFactory,
+  type OpenEpicStoreHandle,
+} from "@/stores/epics/open-epic/store";
 import { GitDiffTile } from "../git-diff-tile";
 
 interface VirtuosoMockProps {
@@ -154,6 +160,19 @@ const NODE = makeGitBundleDiffTile({
   bundleGroup: "changes",
 });
 
+const EPIC_ID = "epic-1";
+
+let epicSessionHandle: OpenEpicStoreHandle;
+
+const fakeStreamClientFactory: EpicStreamClientFactory = () => ({
+  applyUpdate: () => undefined,
+  awareness: () => undefined,
+  applyArtifactRoomUpdate: () => undefined,
+  artifactRoomAwareness: () => undefined,
+  retryMigration: () => undefined,
+  close: () => undefined,
+});
+
 describe("<GitDiffTile /> bundle find", () => {
   beforeEach(() => {
     state.renderRows = true;
@@ -161,11 +180,18 @@ describe("<GitDiffTile /> bundle find", () => {
     useSettingsStore.setState({
       diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
     });
+    epicSessionHandle = createOpenEpicStore({
+      epicId: EPIC_ID,
+      userId: null,
+      streamClientFactory: fakeStreamClientFactory,
+      onAuthError: null,
+    });
   });
 
   afterEach(() => {
     cleanup();
     useTileFindStore.getState().resetForTests();
+    epicSessionHandle.dispose();
     vi.restoreAllMocks();
   });
 
@@ -205,22 +231,24 @@ function tileElement(): ReactNode {
   });
   return (
     <QueryClientProvider client={queryClient}>
-      <TabHostProvider hostId="host-1">
-        <TileFindScope
-          node={NODE}
-          viewTabId="view-1"
-          tileId="tile-1"
-          epicId="epic-1"
-          isActive
-        >
-          <GitDiffTile
+      <EpicSessionContext.Provider value={epicSessionHandle}>
+        <TabHostProvider hostId="host-1">
+          <TileFindScope
             node={NODE}
             viewTabId="view-1"
             tileId="tile-1"
+            epicId={EPIC_ID}
             isActive
-          />
-        </TileFindScope>
-      </TabHostProvider>
+          >
+            <GitDiffTile
+              node={NODE}
+              viewTabId="view-1"
+              tileId="tile-1"
+              isActive
+            />
+          </TileFindScope>
+        </TabHostProvider>
+      </EpicSessionContext.Provider>
     </QueryClientProvider>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/snapshot-bundle-diff-file-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/snapshot-bundle-diff-file-navigation.test.tsx
@@ -1,0 +1,184 @@
+import type { ReactNode } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeSnapshotCumulativeBundleDiffTile } from "@/lib/chat/snapshot-diff-tile";
+import type { SnapshotBundleSectionEntry } from "@/lib/chat/snapshot-bundle-section-entries";
+import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+import type { SnapshotDiffTileRef } from "@/stores/epics/canvas/types";
+import {
+  SnapshotBundleDiffTileContent,
+  type SnapshotCumulativeBundleDiffTileRef,
+} from "@/components/epic-canvas/renderers/snapshot-bundle-diff-tile-content";
+
+interface VirtuosoMockProps {
+  readonly data: ReadonlyArray<SnapshotBundleSectionEntry>;
+  readonly itemContent: (
+    index: number,
+    item: SnapshotBundleSectionEntry,
+  ) => ReactNode;
+  readonly computeItemKey: (
+    index: number,
+    item: SnapshotBundleSectionEntry,
+  ) => string;
+}
+
+const testState = vi.hoisted(() => ({
+  navigateNested: vi.fn(
+    (
+      _epicId: string,
+      _tabId: string,
+      prepare: () => NestedFocusTarget | null,
+    ) => prepare(),
+  ),
+  notifySectionMounted: vi.fn(),
+  registerLoadedPatch: vi.fn(),
+}));
+
+vi.mock("react-virtuoso", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+  return {
+    Virtuoso: React.forwardRef<unknown, VirtuosoMockProps>((props, ref) => {
+      React.useImperativeHandle(ref, () => ({
+        getState: (
+          callback: (snapshot: { readonly scrollTop: number }) => void,
+        ) => {
+          callback({ scrollTop: 0 });
+        },
+      }));
+      return (
+        <div data-testid="virtuoso">
+          {props.data.map((item, index) => (
+            <div key={props.computeItemKey(index, item)}>
+              {props.itemContent(index, item)}
+            </div>
+          ))}
+        </div>
+      );
+    }),
+  };
+});
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => testState.navigateNested,
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useOpenEpicId: () => "epic-1",
+}));
+
+vi.mock("@/hooks/scroll/use-bundle-diff-scroll-restoration", () => ({
+  useBundleDiffScrollRestoration: () => ({
+    virtuosoRef: { current: null },
+    restoreStateFrom: undefined,
+    isScrolling: undefined,
+  }),
+}));
+
+vi.mock(
+  "@/components/diff/bundle-diff-find-registration-hooks",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@/components/diff/bundle-diff-find-registration-hooks")
+      >();
+    return {
+      ...actual,
+      useBundleDiffFindNavigation: () => ({
+        setRootElement: vi.fn(),
+      }),
+      useRegisterBundleDiffTileFindAdapter: () => ({
+        notifySectionMounted: testState.notifySectionMounted,
+        registerCoverageState: vi.fn(),
+        registerLoadedPatch: testState.registerLoadedPatch,
+      }),
+    };
+  },
+);
+
+vi.mock("@/components/diff/diff-content-primitive", () => ({
+  DiffContentFrame: (props: { readonly children: ReactNode }) => (
+    <div data-testid="diff-frame">{props.children}</div>
+  ),
+  DiffContentPrimitive: () => <div data-testid="diff-primitive" />,
+}));
+
+const ENTRY: SnapshotBundleSectionEntry = {
+  filePath: "src/app.ts",
+  beforeContent: "old();\n",
+  afterContent: "new();\n",
+  operation: "edit",
+  reason: "snapshot",
+};
+
+describe("<SnapshotBundleDiffTileContent /> file navigation", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    useSettingsStore.setState({
+      diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
+    });
+    testState.navigateNested.mockClear();
+    testState.notifySectionMounted.mockClear();
+    testState.registerLoadedPatch.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it("routes the File button through nested focus as a committed open", () => {
+    const viewTabId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-1", "Epic");
+    const node = snapshotBundleNode();
+
+    render(
+      <TooltipProvider>
+        <SnapshotBundleDiffTileContent
+          node={node}
+          viewTabId={viewTabId}
+          entries={[ENTRY]}
+        />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "File" }));
+
+    // A revert to raw `openTileInTab` would not invoke this route-aware spy.
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      "epic-1",
+      viewTabId,
+      expect.any(Function),
+    );
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+    if (canvas?.root?.kind !== "pane") throw new Error("expected pane");
+    const activeTile =
+      canvas.tilesByInstanceId[canvas.root.activeTabId ?? ""] ?? null;
+    if (activeTile?.type !== "snapshot-diff") {
+      throw new Error("expected active snapshot diff tile");
+    }
+    expect(activeTile.hostId).toBe("host-1");
+    expect(activeTile.diff).toEqual({
+      kind: "snapshot-cumulative",
+      chatId: "chat-1",
+      filePath: ENTRY.filePath,
+    });
+  });
+});
+
+function snapshotBundleNode(): SnapshotCumulativeBundleDiffTileRef {
+  const node: SnapshotDiffTileRef = makeSnapshotCumulativeBundleDiffTile({
+    hostId: "host-1",
+    chatId: "chat-1",
+    filePaths: [ENTRY.filePath],
+  });
+  if (node.diff.kind !== "snapshot-cumulative-bundle") {
+    throw new Error("expected snapshot bundle node");
+  }
+  return {
+    ...node,
+    diff: node.diff,
+  };
+}

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-tile-exit-close.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-tile-exit-close.test.tsx
@@ -1,10 +1,20 @@
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { create } from "zustand";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { collectPanes } from "@/stores/epics/canvas/tile-tree";
+import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
 
 // A terminal-agent tile auto-closes when the harness TUI exits (e.g. the user
 // presses Ctrl+C and the process terminates). The close must target the pane
@@ -12,7 +22,14 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 // `pane.tabInstanceIds`, so passing the content/session id silently no-ops and
 // the dead tab lingers. This test pins that contract.
 
-const closeCanvasTab = vi.fn();
+const testState = vi.hoisted(() => ({
+  reachability: {
+    status: "reachable",
+    hostLabel: "Host A",
+  },
+  navigateResults: [] as Array<NestedFocusTarget | null>,
+  navigateNested: vi.fn(),
+}));
 
 const exitedHandle = {
   epicId: "epic-test",
@@ -20,7 +37,9 @@ const exitedHandle = {
   dispose: () => undefined,
   store: create(() => ({
     status: "exited" as const,
+    connectionStatus: "open" as const,
     exitCode: 0,
+    exitReason: null,
     effectiveCols: 80,
     effectiveRows: 24,
     lastOutputPreview: null,
@@ -29,6 +48,14 @@ const exitedHandle = {
     setWriter: () => undefined,
   })),
 };
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => testState.navigateNested,
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: () => testState.reachability,
+}));
 
 vi.mock("@/hooks/agent/use-terminal-tile-bootstrap", () => ({
   TerminalXtermHost: () => null,
@@ -123,17 +150,15 @@ vi.mock("@/hooks/agent/use-prepare-tui-launch-mutation", () => ({
   }),
 }));
 
-vi.mock("@/stores/epics/canvas/store", () => ({
-  useEpicCanvasStore: (selector: (s: unknown) => unknown) =>
-    selector({ closeCanvasTab }),
-}));
-
 vi.mock("@/hooks/worktree/use-worktree-get-binding-query", () => ({
   useWorktreeGetBinding: () => ({ data: { binding: null } }),
 }));
 
 import { TuiAgentTile } from "../tui-agent-tile";
 import { TabHostProvider } from "../../tab-host-provider";
+
+const EPIC_ID = "epic-1";
+const HOST_ID = "test-host";
 
 function withQueryClient(node: ReactNode): ReactNode {
   const queryClient = new QueryClient({
@@ -148,41 +173,149 @@ function withQueryClient(node: ReactNode): ReactNode {
   );
 }
 
+function resetNavigationSpy(): void {
+  testState.navigateResults = [];
+  testState.navigateNested.mockReset();
+  testState.navigateNested.mockImplementation(
+    (
+      _epicId: string,
+      _tabId: string,
+      prepare: () => NestedFocusTarget | null,
+    ) => {
+      const target = prepare();
+      testState.navigateResults.push(target);
+      return target;
+    },
+  );
+}
+
+function agentNode(id: string, instanceId: string): EpicNodeRef {
+  return {
+    id,
+    instanceId,
+    type: "terminal-agent",
+    name: "claude",
+    hostId: HOST_ID,
+  };
+}
+
+function openAgentFixture(inactiveClose: boolean): {
+  readonly viewTabId: string;
+  readonly paneId: string;
+  readonly closingNode: EpicNodeRef;
+  readonly activeNode: EpicNodeRef;
+} {
+  const store = useEpicCanvasStore.getState();
+  const viewTabId = store.openEpicTab(EPIC_ID, "Epic");
+  const closingNode = agentNode("agent-1", "inst-agent-1");
+  store.openTileInTab(viewTabId, closingNode);
+  const activeNode = inactiveClose
+    ? agentNode("agent-2", "inst-agent-2")
+    : closingNode;
+  if (inactiveClose) store.openTileInTab(viewTabId, activeNode);
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+  if (canvas === undefined) throw new Error("expected view tab canvas");
+  const pane = collectPanes(canvas.root)[0];
+  return { viewTabId, paneId: pane.id, closingNode, activeNode };
+}
+
+function expectTileClosed(viewTabId: string, closedInstanceId: string): void {
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+  if (canvas === undefined) throw new Error("expected view tab canvas");
+  expect(canvas.tilesByInstanceId[closedInstanceId]).toBeUndefined();
+}
+
 describe("<TuiAgentTile /> exit close", () => {
   beforeEach(() => {
-    closeCanvasTab.mockClear();
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    testState.reachability = { status: "reachable", hostLabel: "Host A" };
+    resetNavigationSpy();
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  it("closes the canvas tab by instance id when the harness TUI exits", async () => {
+  it("routes unreachable-banner close for an active tile through the nested-focus boundary", () => {
+    testState.reachability = { status: "unreachable", hostLabel: "Host A" };
+    const fixture = openAgentFixture(false);
+
     render(
       withQueryClient(
         <TuiAgentTile
-          viewTabId="tab-test"
-          node={{
-            id: "agent-1",
-            instanceId: "inst-agent-1",
-            type: "terminal-agent",
-            name: "claude",
-            hostId: "test-host",
-          }}
-          tileId="pane-1"
+          viewTabId={fixture.viewTabId}
+          node={fixture.closingNode}
+          tileId={fixture.paneId}
+          isActive
+        />,
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close tab" }));
+
+    // A revert to raw `closeCanvasTab` would still close the tab but would not
+    // invoke this boundary spy, so this assertion catches the regression.
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      fixture.viewTabId,
+      expect.any(Function),
+    );
+    expect(testState.navigateResults[0]).not.toBeNull();
+    expect(testState.navigateResults[0]?.tileInstanceId).toBeUndefined();
+    expectTileClosed(fixture.viewTabId, fixture.closingNode.instanceId);
+  });
+
+  it("routes harness-exit close for an active tile through the nested-focus boundary", async () => {
+    const fixture = openAgentFixture(false);
+
+    render(
+      withQueryClient(
+        <TuiAgentTile
+          viewTabId={fixture.viewTabId}
+          node={fixture.closingNode}
+          tileId={fixture.paneId}
           isActive
         />,
       ),
     );
 
     await waitFor(() => {
-      expect(closeCanvasTab).toHaveBeenCalled();
+      expect(testState.navigateNested).toHaveBeenCalledWith(
+        EPIC_ID,
+        fixture.viewTabId,
+        expect.any(Function),
+      );
     });
-    // Third arg is the tab *instance* id, not the agent record / session id.
-    expect(closeCanvasTab).toHaveBeenCalledWith(
-      "tab-test",
-      "pane-1",
-      "inst-agent-1",
+    expect(testState.navigateResults[0]).not.toBeNull();
+    expect(testState.navigateResults[0]?.tileInstanceId).toBeUndefined();
+    expectTileClosed(fixture.viewTabId, fixture.closingNode.instanceId);
+  });
+
+  it("closes an inactive exited tile without producing a route-write target", async () => {
+    const fixture = openAgentFixture(true);
+
+    render(
+      withQueryClient(
+        <TuiAgentTile
+          viewTabId={fixture.viewTabId}
+          node={fixture.closingNode}
+          tileId={fixture.paneId}
+          isActive={false}
+        />,
+      ),
     );
+
+    await waitFor(() => {
+      expect(testState.navigateNested).toHaveBeenCalled();
+    });
+    expect(testState.navigateResults[0]).toBeNull();
+    expectTileClosed(fixture.viewTabId, fixture.closingNode.instanceId);
+
+    const canvas =
+      useEpicCanvasStore.getState().canvasByTabId[fixture.viewTabId];
+    if (canvas === undefined) throw new Error("expected view tab canvas");
+    const pane = collectPanes(canvas.root)[0];
+    expect(pane.activeTabId).toBe(fixture.activeNode.instanceId);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-close-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-close-navigation.test.tsx
@@ -1,0 +1,241 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { create } from "zustand";
+import { TabHostProvider } from "@/components/epic-canvas/tab-host-provider";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { collectPanes } from "@/stores/epics/canvas/tile-tree";
+import type { EpicTerminalRef } from "@/stores/epics/canvas/types";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+
+const testState = vi.hoisted(() => ({
+  reachability: {
+    status: "reachable",
+    hostLabel: "Host A",
+  },
+  navigateResults: [] as Array<NestedFocusTarget | null>,
+  navigateNested: vi.fn(),
+}));
+
+const exitedHandle = {
+  epicId: "epic-test",
+  sessionId: "terminal-1",
+  dispose: () => undefined,
+  store: create(() => ({
+    status: "exited" as const,
+    connectionStatus: "open" as const,
+    exitCode: 0,
+    exitReason: null,
+    effectiveCols: 80,
+    effectiveRows: 24,
+    lastOutputPreview: null,
+    writeInput: () => undefined,
+    requestResize: () => undefined,
+    setWriter: () => undefined,
+  })),
+};
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => testState.navigateNested,
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: () => testState.reachability,
+}));
+
+vi.mock("@/hooks/terminal/use-terminal-session-recovery", () => ({
+  useTerminalSessionRecovery: () => ({
+    recoverNonce: 0,
+    recoveryExhausted: false,
+    onManualReconnect: () => undefined,
+    onSessionHealthy: () => undefined,
+    onSessionLost: () => undefined,
+  }),
+}));
+
+vi.mock("@/hooks/agent/use-terminal-tile-bootstrap", () => ({
+  TerminalXtermHost: () => null,
+  useTerminalTileBootstrap: () => ({
+    handle: exitedHandle,
+    createIsError: false,
+    createError: null,
+    retry: () => undefined,
+    hostHasSession: false,
+  }),
+}));
+
+vi.mock("@/lib/perf/terminal-load-perf", () => ({
+  beginTerminalLoad: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  AnalyticsEvent: { TerminalOpened: "TerminalOpened" },
+  Analytics: {
+    getInstance: () => ({ track: vi.fn() }),
+  },
+}));
+
+import { TerminalTile } from "../terminal-tile";
+
+const EPIC_ID = "epic-1";
+const HOST_ID = "host-1";
+
+function withTabHost(node: ReactNode): ReactNode {
+  return <TabHostProvider hostId={HOST_ID}>{node}</TabHostProvider>;
+}
+
+function resetNavigationSpy(): void {
+  testState.navigateResults = [];
+  testState.navigateNested.mockReset();
+  testState.navigateNested.mockImplementation(
+    (
+      _epicId: string,
+      _tabId: string,
+      prepare: () => NestedFocusTarget | null,
+    ) => {
+      const target = prepare();
+      testState.navigateResults.push(target);
+      return target;
+    },
+  );
+}
+
+function terminalNode(id: string, instanceId: string): EpicTerminalRef {
+  return {
+    id,
+    instanceId,
+    type: "terminal",
+    name: "shell",
+    titleSource: "manual",
+    hostId: HOST_ID,
+    cwd: "/work/repo",
+  };
+}
+
+function openTerminalFixture(inactiveClose: boolean): {
+  readonly viewTabId: string;
+  readonly paneId: string;
+  readonly closingNode: EpicTerminalRef;
+  readonly activeNode: EpicTerminalRef;
+} {
+  const store = useEpicCanvasStore.getState();
+  const viewTabId = store.openEpicTab(EPIC_ID, "Epic");
+  const closingNode = terminalNode("terminal-1", "inst-terminal-1");
+  store.openTileInTab(viewTabId, closingNode);
+  const activeNode = inactiveClose
+    ? terminalNode("terminal-2", "inst-terminal-2")
+    : closingNode;
+  if (inactiveClose) store.openTileInTab(viewTabId, activeNode);
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+  if (canvas === undefined) throw new Error("expected view tab canvas");
+  const pane = collectPanes(canvas.root)[0];
+  return { viewTabId, paneId: pane.id, closingNode, activeNode };
+}
+
+function expectTileClosed(viewTabId: string, closedInstanceId: string): void {
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+  if (canvas === undefined) throw new Error("expected view tab canvas");
+  expect(canvas.tilesByInstanceId[closedInstanceId]).toBeUndefined();
+}
+
+describe("<TerminalTile /> close navigation", () => {
+  beforeEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    testState.reachability = { status: "reachable", hostLabel: "Host A" };
+    resetNavigationSpy();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("routes unreachable-banner close for an active tile through the nested-focus boundary", () => {
+    testState.reachability = { status: "unreachable", hostLabel: "Host A" };
+    const fixture = openTerminalFixture(false);
+
+    render(
+      withTabHost(
+        <TerminalTile
+          viewTabId={fixture.viewTabId}
+          node={fixture.closingNode}
+          tileId={fixture.paneId}
+          isActive
+        />,
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close tab" }));
+
+    // A revert to raw `closeCanvasTab` would still close the tab but would not
+    // invoke this boundary spy, so this assertion catches the regression.
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      fixture.viewTabId,
+      expect.any(Function),
+    );
+    expect(testState.navigateResults[0]).not.toBeNull();
+    expect(testState.navigateResults[0]?.tileInstanceId).toBeUndefined();
+    expectTileClosed(fixture.viewTabId, fixture.closingNode.instanceId);
+  });
+
+  it("routes PTY-exit close for an active tile through the nested-focus boundary", async () => {
+    const fixture = openTerminalFixture(false);
+
+    render(
+      withTabHost(
+        <TerminalTile
+          viewTabId={fixture.viewTabId}
+          node={fixture.closingNode}
+          tileId={fixture.paneId}
+          isActive
+        />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(testState.navigateNested).toHaveBeenCalledWith(
+        EPIC_ID,
+        fixture.viewTabId,
+        expect.any(Function),
+      );
+    });
+    expect(testState.navigateResults[0]).not.toBeNull();
+    expect(testState.navigateResults[0]?.tileInstanceId).toBeUndefined();
+    expectTileClosed(fixture.viewTabId, fixture.closingNode.instanceId);
+  });
+
+  it("closes an inactive exited tile without producing a route-write target", async () => {
+    const fixture = openTerminalFixture(true);
+
+    render(
+      withTabHost(
+        <TerminalTile
+          viewTabId={fixture.viewTabId}
+          node={fixture.closingNode}
+          tileId={fixture.paneId}
+          isActive={false}
+        />,
+      ),
+    );
+
+    await waitFor(() => {
+      expect(testState.navigateNested).toHaveBeenCalled();
+    });
+    expect(testState.navigateResults[0]).toBeNull();
+    expectTileClosed(fixture.viewTabId, fixture.closingNode.instanceId);
+
+    const canvas =
+      useEpicCanvasStore.getState().canvasByTabId[fixture.viewTabId];
+    if (canvas === undefined) throw new Error("expected view tab canvas");
+    const pane = collectPanes(canvas.root)[0];
+    expect(pane.activeTabId).toBe(fixture.activeNode.instanceId);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/artifact-child-index.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/artifact-child-index.tsx
@@ -8,6 +8,7 @@ import {
   useArtifactDragSource,
   type ArtifactDragIdentity,
 } from "@/components/epic-canvas/dnd/use-artifact-drag-source";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import {
   EPIC_NODE_ICONS,
   isEpicArtifactKind,
@@ -19,7 +20,6 @@ import {
   isOpenableEpicNodeKind,
   makeOpenableNodeRef,
 } from "@/stores/epics/canvas/types";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import { appLogger } from "@/lib/logger";
 
@@ -78,9 +78,7 @@ function ChildIndexRow(props: {
 }) {
   const { epicId, childId, viewTabId, hostId } = props;
   const treeNode = useTreeNodeById(childId);
-  const openTilePreviewInTab = useEpicCanvasStore(
-    (s) => s.openTilePreviewInTab,
-  );
+  const tileNavigation = useEpicTileNavigation();
   const iconColorMode = useSettingsStore((s) => s.artifactIconColorMode);
   const iconColors = useSettingsStore((s) => s.artifactIconColors);
   const type = treeNode?.type ?? null;
@@ -108,7 +106,7 @@ function ChildIndexRow(props: {
 
   const open = useCallback(() => {
     if (type === null || !isOpenableEpicNodeKind(type)) return;
-    openTilePreviewInTab(
+    tileNavigation.openTilePreviewInTab(
       viewTabId,
       makeOpenableNodeRef({
         id: childId,
@@ -118,7 +116,7 @@ function ChildIndexRow(props: {
         hostId,
       }),
     );
-  }, [type, title, childId, viewTabId, hostId, openTilePreviewInTab]);
+  }, [type, title, childId, viewTabId, hostId, tileNavigation]);
 
   // Children of an artifact are themselves artifacts; the guard keeps the row
   // type-safe and quietly drops any non-artifact node that ever appears here.

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-focus-terminal.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-focus-terminal.ts
@@ -2,6 +2,8 @@ import { useCallback } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { DEFAULT_EPIC_NODE_NAMES } from "@/lib/artifacts/node-display";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
 import {
   findOpenArtifactInTab,
   useEpicCanvasStore,
@@ -13,9 +15,13 @@ import {
 export function useFocusEpicTerminalSession(
   viewTabId: string,
 ): (terminalSessionId: string | null, cwd: string) => void {
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
-  const setActiveTileTab = useEpicCanvasStore((s) => s.setActiveTileTab);
-  const setActiveTilePane = useEpicCanvasStore((s) => s.setActiveTilePane);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
+  const prepareSetActiveTileTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareSetActiveTileTabFocusTarget,
+  );
   // Setup-event terminals inherit the bound host of the chat tile
   // that emitted the event - same artifact, same host binding.
   const activeHostId = useTabHostId();
@@ -23,28 +29,47 @@ export function useFocusEpicTerminalSession(
     (terminalSessionId, cwd) => {
       if (terminalSessionId === null) return;
       if (terminalSessionId.length === 0) return;
+      // This is a committed user open/focus, so the nested route search must
+      // become the new focus authority - otherwise route sync re-applies the
+      // stale target and the tab opens without ever becoming visible.
+      const epicId =
+        useEpicCanvasStore.getState().tabsById[viewTabId]?.epicId ?? null;
+      const commit = (prepare: () => NestedFocusTarget | null): void => {
+        if (epicId === null) {
+          prepare();
+          return;
+        }
+        navigateNested(epicId, viewTabId, prepare);
+      };
       const found = findOpenArtifactInTab(viewTabId, terminalSessionId);
       if (found !== null) {
         // `found` is keyed by content id; activate by the tab's instanceId.
-        setActiveTilePane(viewTabId, found.paneId);
-        setActiveTileTab(viewTabId, found.paneId, found.instanceId);
+        commit(() =>
+          prepareSetActiveTileTabFocusTarget(
+            viewTabId,
+            found.paneId,
+            found.instanceId,
+          ),
+        );
         return;
       }
-      openTileInTab(viewTabId, {
-        id: terminalSessionId,
-        instanceId: uuidv4(),
-        type: "terminal",
-        name: DEFAULT_EPIC_NODE_NAMES.terminal,
-        titleSource: "manual",
-        hostId: activeHostId,
-        cwd,
-      });
+      commit(() =>
+        prepareOpenTileInTabFocusTarget(viewTabId, {
+          id: terminalSessionId,
+          instanceId: uuidv4(),
+          type: "terminal",
+          name: DEFAULT_EPIC_NODE_NAMES.terminal,
+          titleSource: "manual",
+          hostId: activeHostId,
+          cwd,
+        }),
+      );
     },
     [
       activeHostId,
-      openTileInTab,
-      setActiveTilePane,
-      setActiveTileTab,
+      navigateNested,
+      prepareOpenTileInTabFocusTarget,
+      prepareSetActiveTileTabFocusTarget,
       viewTabId,
     ],
   );

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -93,6 +93,7 @@ import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
 import { useHostClient, useHostBinding } from "@/lib/host";
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
 import { useEpicCreateChat } from "@/hooks/epic/use-epic-chat-mutations";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { cloneChatOnHostSwitch } from "@/lib/commands/actions/clone-chat-on-host-switch";
 import { ChatDeadTileBanner } from "./dead-tile-banner";
 import { useHostQuery } from "@/hooks/host/use-host-query";
@@ -121,6 +122,7 @@ import {
   useWorktreeIntentStagingStore,
   worktreeStagingKeyString,
 } from "@/stores/worktree/worktree-intent-staging-store";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import {
   agentModelKey,
   resolveAgentReasoningLabel,
@@ -381,6 +383,7 @@ function useChatCloneOnHostSwitch(args: UseChatCloneOnHostSwitchArgs): {
 } {
   const binding = useHostBinding();
   const createChat = useEpicCreateChat();
+  const navigateNestedFocus = useEpicNestedFocusNavigation();
   const cancelRef = useRef<(() => void) | null>(null);
   const [cloning, setCloning] = useState(false);
 
@@ -406,11 +409,19 @@ function useChatCloneOnHostSwitch(args: UseChatCloneOnHostSwitchArgs): {
       tabId: args.tabId,
       targetHostId: target.hostId,
       directory: binding.directory,
+      navigateNestedFocus,
       createChat: (request, callbacks) => {
         createChat.mutate(request, { onSuccess: callbacks.onSuccess });
       },
     });
-  }, [binding, createChat, args.epicId, args.tabId, args.sourceHostId]);
+  }, [
+    binding,
+    createChat,
+    navigateNestedFocus,
+    args.epicId,
+    args.tabId,
+    args.sourceHostId,
+  ]);
 
   return { clone, cloning };
 }
@@ -533,8 +544,7 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
   const view = useChatTileSessionViewModel(props);
   const hostId = useTabHostId();
   const systemOverlayActive = useAnySystemOverlayActive();
-  const openPreview = useEpicCanvasStore((s) => s.openTilePreviewInTab);
-  const openPinned = useEpicCanvasStore((s) => s.openTileInTab);
+  const tileNavigation = useEpicTileNavigation();
   const [backgroundScrollRequest, setBackgroundScrollRequest] =
     useState<ChatMessageScrollRequest | null>(null);
   const backgroundScrollRequestIdRef = useRef(0);
@@ -587,8 +597,10 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
           filePath: request.filePath,
         });
         return {
-          onClick: () => openPreview(view.viewTabId, tile),
-          onDoubleClick: () => openPinned(view.viewTabId, tile),
+          onClick: () =>
+            tileNavigation.openTilePreviewInTab(view.viewTabId, tile),
+          onDoubleClick: () =>
+            tileNavigation.openTileInTab(view.viewTabId, tile),
         };
       },
       cumulative: (filePath) => {
@@ -598,8 +610,10 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
           filePath,
         });
         return {
-          onClick: () => openPreview(view.viewTabId, tile),
-          onDoubleClick: () => openPinned(view.viewTabId, tile),
+          onClick: () =>
+            tileNavigation.openTilePreviewInTab(view.viewTabId, tile),
+          onDoubleClick: () =>
+            tileNavigation.openTileInTab(view.viewTabId, tile),
         };
       },
       cumulativeBundle: (filePaths) => {
@@ -608,7 +622,7 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
           chatId: view.node.id,
           filePaths,
         });
-        return () => openPinned(view.viewTabId, tile);
+        return () => tileNavigation.openTileInTab(view.viewTabId, tile);
       },
       hash: (request) => {
         const tile = makeSnapshotHashDiffTile({
@@ -620,12 +634,14 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
           title: request.title,
         });
         return {
-          onClick: () => openPreview(view.viewTabId, tile),
-          onDoubleClick: () => openPinned(view.viewTabId, tile),
+          onClick: () =>
+            tileNavigation.openTilePreviewInTab(view.viewTabId, tile),
+          onDoubleClick: () =>
+            tileNavigation.openTileInTab(view.viewTabId, tile),
         };
       },
     }),
-    [hostId, openPinned, openPreview, view.node.id, view.viewTabId],
+    [hostId, tileNavigation, view.node.id, view.viewTabId],
   );
 
   return (

--- a/clients/gui-app/src/components/epic-canvas/renderers/snapshot-bundle-diff-tile-content.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/snapshot-bundle-diff-tile-content.tsx
@@ -25,11 +25,13 @@ import {
   type BundleDiffFindFileNavigationInput,
 } from "@/components/diff/bundle-diff-find-registration-hooks";
 import { useBundleDiffScrollRestoration } from "@/hooks/scroll/use-bundle-diff-scroll-restoration";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import {
   DiffBundleCollapseChevron,
   DiffBundleFileSectionFrame,
 } from "@/components/epic-canvas/git-diff/diff-bundle-file-section";
 import { FileChangeHeader } from "@/components/chat/segments/file-change-segment";
+import { useOpenEpicId } from "@/lib/epic-selectors";
 import { cn } from "@/lib/utils";
 import { getBasename, getDirname } from "@/lib/path/cross-platform-path";
 import type { BundleDiffFindFileInput } from "@/stores/tile-find";
@@ -172,7 +174,11 @@ function SnapshotBundleFileSection(props: {
   const diffViewerPreferences = useSettingsStore(
     (s) => s.diffViewerPreferences,
   );
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
+  const epicId = useOpenEpicId();
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
   const toggleCollapsed = useEpicCanvasStore(
     (s) => s.toggleSnapshotDiffBundleFileCollapsedInTab,
   );
@@ -199,16 +205,18 @@ function SnapshotBundleFileSection(props: {
   );
 
   const handleOpenFileTile = useCallback(() => {
-    openTileInTab(
-      props.viewTabId,
-      makeSnapshotCumulativeDiffTile({
-        hostId: props.node.hostId,
-        chatId: props.node.diff.chatId,
-        filePath: props.entry.filePath,
-      }),
+    const tile = makeSnapshotCumulativeDiffTile({
+      hostId: props.node.hostId,
+      chatId: props.node.diff.chatId,
+      filePath: props.entry.filePath,
+    });
+    navigateNested(epicId, props.viewTabId, () =>
+      prepareOpenTileInTabFocusTarget(props.viewTabId, tile),
     );
   }, [
-    openTileInTab,
+    epicId,
+    navigateNested,
+    prepareOpenTileInTabFocusTarget,
     props.entry.filePath,
     props.node.hostId,
     props.node.diff.chatId,

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
@@ -9,6 +9,7 @@ import {
   type TerminalCreatePayload,
 } from "@/hooks/agent/use-terminal-tile-bootstrap";
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import {
   useTerminalSessionRecovery,
   type TerminalSessionRecovery,
@@ -35,7 +36,11 @@ export interface TerminalTileProps {
 export function TerminalTile(props: TerminalTileProps) {
   const hostId = useTabHostId();
   const reachability = useHostReachability(hostId);
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
+  const closeCanvasTile = useCloseCanvasTileWithNestedFocus(
+    props.viewTabId,
+    props.tileId,
+    props.node.instanceId,
+  );
   // Owns the recovery budget + nonce above the bootstrap subtree so they survive
   // the `recoverNonce`-keyed remount the recovery performs.
   const recovery = useTerminalSessionRecovery({
@@ -55,9 +60,7 @@ export function TerminalTile(props: TerminalTileProps) {
     return (
       <TerminalDeadTileBanner
         hostLabel={reachability.hostLabel}
-        onClose={() =>
-          closeCanvasTab(props.viewTabId, props.tileId, props.node.instanceId)
-        }
+        onClose={closeCanvasTile}
         testId={`terminal-tile-${props.tileId}`}
       />
     );
@@ -170,7 +173,11 @@ function TerminalLive(props: TerminalLiveProps) {
   const connectionStatus = useStore(handle.store, (s) => s.connectionStatus);
   const effectiveCols = useStore(handle.store, (s) => s.effectiveCols);
   const effectiveRows = useStore(handle.store, (s) => s.effectiveRows);
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
+  const closeCanvasTile = useCloseCanvasTileWithNestedFocus(
+    props.viewTabId,
+    props.tileId,
+    props.instanceId,
+  );
 
   const { onSessionLost, onSessionHealthy } = props.recovery;
   // Drive automatic recovery off the lifecycle status. "lost" is the dead-end a
@@ -194,8 +201,8 @@ function TerminalLive(props: TerminalLiveProps) {
     // `closeCanvasTab` resolves the tile by its pane tab *instance* id
     // (`pane.tabInstanceIds`), not the content/session id. Passing
     // `handle.sessionId` silently no-ops, leaving the tab open after exit.
-    closeCanvasTab(props.viewTabId, props.tileId, props.instanceId);
-  }, [status, props.instanceId, props.viewTabId, props.tileId, closeCanvasTab]);
+    closeCanvasTile();
+  }, [status, closeCanvasTile]);
 
   const overlayState = resolveTerminalOverlayState({
     status,
@@ -265,4 +272,33 @@ function TerminalLive(props: TerminalLiveProps) {
       </div>
     </div>
   );
+}
+
+function useCloseCanvasTileWithNestedFocus(
+  viewTabId: string,
+  paneId: string,
+  tileInstanceId: string,
+): () => void {
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
+
+  return useCallback(() => {
+    const epicId =
+      useEpicCanvasStore.getState().tabsById[viewTabId]?.epicId ?? null;
+    const prepare = () =>
+      prepareCloseCanvasTabFocusTarget(viewTabId, paneId, tileInstanceId);
+    if (epicId === null) {
+      prepare();
+      return;
+    }
+    navigateNested(epicId, viewTabId, prepare);
+  }, [
+    navigateNested,
+    paneId,
+    prepareCloseCanvasTabFocusTarget,
+    tileInstanceId,
+    viewTabId,
+  ]);
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
@@ -9,13 +9,11 @@ import {
   type TerminalCreatePayload,
 } from "@/hooks/agent/use-terminal-tile-bootstrap";
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
-import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import {
   useTerminalSessionRecovery,
   type TerminalSessionRecovery,
 } from "@/hooks/terminal/use-terminal-session-recovery";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type {
   TerminalDataWriter,
   TerminalSessionStoreHandle,
@@ -25,6 +23,7 @@ import { TerminalDeadTileBanner } from "./dead-tile-banner";
 import { TerminalConnectionOverlay } from "./terminal-connection-overlay";
 import { resolveTerminalOverlayState } from "./terminal-connection-overlay-state";
 import { Button } from "@/components/ui/button";
+import { useCloseCanvasTileWithNestedFocus } from "./use-close-canvas-tile-with-nested-focus";
 
 export interface TerminalTileProps {
   readonly node: EpicTerminalRef;
@@ -272,33 +271,4 @@ function TerminalLive(props: TerminalLiveProps) {
       </div>
     </div>
   );
-}
-
-function useCloseCanvasTileWithNestedFocus(
-  viewTabId: string,
-  paneId: string,
-  tileInstanceId: string,
-): () => void {
-  const navigateNested = useEpicNestedFocusNavigation();
-  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
-    (s) => s.prepareCloseCanvasTabFocusTarget,
-  );
-
-  return useCallback(() => {
-    const epicId =
-      useEpicCanvasStore.getState().tabsById[viewTabId]?.epicId ?? null;
-    const prepare = () =>
-      prepareCloseCanvasTabFocusTarget(viewTabId, paneId, tileInstanceId);
-    if (epicId === null) {
-      prepare();
-      return;
-    }
-    navigateNested(epicId, viewTabId, prepare);
-  }, [
-    navigateNested,
-    paneId,
-    prepareCloseCanvasTabFocusTarget,
-    tileInstanceId,
-    viewTabId,
-  ]);
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -24,13 +24,11 @@ import {
   type TerminalCreatePayload,
 } from "@/hooks/agent/use-terminal-tile-bootstrap";
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
-import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import {
   useTerminalSessionRecovery,
   type TerminalSessionRecovery,
 } from "@/hooks/terminal/use-terminal-session-recovery";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { beginTerminalLoad } from "@/lib/perf/terminal-load-perf";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { useAgentStartTerminalSession } from "@/hooks/agent/use-prepare-tui-launch-mutation";
@@ -75,6 +73,7 @@ import {
   type WorktreeStagingKey,
 } from "@/stores/worktree/worktree-intent-staging-store";
 import { TerminalAgentForkDialog } from "./terminal-agent-fork-dialog";
+import { useCloseCanvasTileWithNestedFocus } from "./use-close-canvas-tile-with-nested-focus";
 
 const WORKTREE_SETUP_ERROR_CODES: ReadonlyArray<string> = [
   "WORKTREE_SETUP_FAILED",
@@ -1104,33 +1103,4 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
       ) : null}
     </>
   );
-}
-
-function useCloseCanvasTileWithNestedFocus(
-  viewTabId: string,
-  paneId: string,
-  tileInstanceId: string,
-): () => void {
-  const navigateNested = useEpicNestedFocusNavigation();
-  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
-    (s) => s.prepareCloseCanvasTabFocusTarget,
-  );
-
-  return useCallback(() => {
-    const epicId =
-      useEpicCanvasStore.getState().tabsById[viewTabId]?.epicId ?? null;
-    const prepare = () =>
-      prepareCloseCanvasTabFocusTarget(viewTabId, paneId, tileInstanceId);
-    if (epicId === null) {
-      prepare();
-      return;
-    }
-    navigateNested(epicId, viewTabId, prepare);
-  }, [
-    navigateNested,
-    paneId,
-    prepareCloseCanvasTabFocusTarget,
-    tileInstanceId,
-    viewTabId,
-  ]);
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -24,6 +24,7 @@ import {
   type TerminalCreatePayload,
 } from "@/hooks/agent/use-terminal-tile-bootstrap";
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import {
   useTerminalSessionRecovery,
   type TerminalSessionRecovery,
@@ -148,7 +149,11 @@ export interface TuiAgentTileProps {
 export function TuiAgentTile(props: TuiAgentTileProps) {
   const hostId = useTabHostId();
   const reachability = useHostReachability(hostId);
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
+  const closeCanvasTile = useCloseCanvasTileWithNestedFocus(
+    props.viewTabId,
+    props.tileId,
+    props.node.instanceId,
+  );
   // Owns the recovery budget + nonce above the bootstrap subtree so they survive
   // the `recoverNonce`-keyed remount the recovery performs.
   const recovery = useTerminalSessionRecovery({
@@ -168,9 +173,7 @@ export function TuiAgentTile(props: TuiAgentTileProps) {
     return (
       <TerminalDeadTileBanner
         hostLabel={reachability.hostLabel}
-        onClose={() =>
-          closeCanvasTab(props.viewTabId, props.tileId, props.node.instanceId)
-        }
+        onClose={closeCanvasTile}
         testId={`terminal-agent-tile-${props.tileId}`}
       />
     );
@@ -950,7 +953,11 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
   const exitCode = useStore(handle.store, (s) => s.exitCode);
   const exitReason = useStore(handle.store, (s) => s.exitReason);
   const lastOutputPreview = useStore(handle.store, (s) => s.lastOutputPreview);
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
+  const closeCanvasTile = useCloseCanvasTileWithNestedFocus(
+    props.viewTabId,
+    props.tileId,
+    props.instanceId,
+  );
   const exitToastShownRef = useRef(false);
   // One revive request per exit: the exit effect can re-run while the store
   // still reports the same exited state (dep identity churn), and stacking
@@ -1013,15 +1020,12 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
     // (`pane.tabInstanceIds`), not the content/session id. Passing
     // `handle.sessionId` (the agent record id) silently no-ops, leaving the
     // tab open after the harness TUI exits (e.g. Ctrl+C). Use the instance id.
-    closeCanvasTab(props.viewTabId, props.tileId, props.instanceId);
+    closeCanvasTile();
   }, [
     status,
     exitReason,
     onReapedExit,
-    props.instanceId,
-    props.viewTabId,
-    props.tileId,
-    closeCanvasTab,
+    closeCanvasTile,
     isRestartKillSuppressed,
   ]);
 
@@ -1100,4 +1104,33 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
       ) : null}
     </>
   );
+}
+
+function useCloseCanvasTileWithNestedFocus(
+  viewTabId: string,
+  paneId: string,
+  tileInstanceId: string,
+): () => void {
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
+
+  return useCallback(() => {
+    const epicId =
+      useEpicCanvasStore.getState().tabsById[viewTabId]?.epicId ?? null;
+    const prepare = () =>
+      prepareCloseCanvasTabFocusTarget(viewTabId, paneId, tileInstanceId);
+    if (epicId === null) {
+      prepare();
+      return;
+    }
+    navigateNested(epicId, viewTabId, prepare);
+  }, [
+    navigateNested,
+    paneId,
+    prepareCloseCanvasTabFocusTarget,
+    tileInstanceId,
+    viewTabId,
+  ]);
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-close-canvas-tile-with-nested-focus.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-close-canvas-tile-with-nested-focus.ts
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+
+export function useCloseCanvasTileWithNestedFocus(
+  viewTabId: string,
+  paneId: string,
+  tileInstanceId: string,
+): () => void {
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
+
+  return useCallback(() => {
+    const epicId =
+      useEpicCanvasStore.getState().tabsById[viewTabId]?.epicId ?? null;
+    const prepare = () =>
+      prepareCloseCanvasTabFocusTarget(viewTabId, paneId, tileInstanceId);
+    if (epicId === null) {
+      prepare();
+      return;
+    }
+    navigateNested(epicId, viewTabId, prepare);
+  }, [
+    navigateNested,
+    paneId,
+    prepareCloseCanvasTabFocusTarget,
+    tileInstanceId,
+    viewTabId,
+  ]);
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-nested-focus-boundary.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-nested-focus-boundary.test.tsx
@@ -1,0 +1,879 @@
+/**
+ * Proves that the three sidebar open/close flows fixed for the back/forward
+ * navigation regression commit through the route-aware opener boundary
+ * (`useEpicNestedFocusNavigation` -> `prepareOpen.../prepareClose...`)
+ * instead of calling raw canvas store actions directly. See the decision
+ * artifact "Nested Focus Opener Boundary".
+ *
+ * `useEpicNestedFocusNavigation` is mocked with a spy that still invokes the
+ * `prepare` callback (mirrors `file-row-navigation.test.tsx`), so each
+ * assertion checks both that the boundary was called AND that the
+ * underlying prepare/close logic ran with the right arguments.
+ *
+ * Root-create and single-delete still route through a `prepare*FocusTarget`
+ * store action per item, so the canvas store mock deliberately omits raw
+ * `openTileInTab`: a regression back to calling it directly throws instead
+ * of silently passing.
+ *
+ * Bulk delete batches every close into ONE boundary call instead of one per
+ * item - closing each tab through its own `prepareCloseCanvasTabFocusTarget`
+ * would let an intermediate iteration's fallback focus (itself also being
+ * deleted) get pushed as a route entry. Its mock backs `closeCanvasTab` /
+ * `canvasByTabId` with the REAL `closeTab` reducer and the REAL
+ * `getCurrentNestedFocusTarget` reader (both unmocked production code), so
+ * the assertions check an actual post-batch focus target rather than a
+ * canned stand-in. Revert-proofing here comes from asserting `navigateNested`
+ * fires exactly ONCE per batch (a per-item loop fires N times) with a target
+ * that is a genuine survivor / the unchanged current focus.
+ */
+import "../../../../../__tests__/test-browser-apis";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import type { Mock } from "vitest";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import { closeTab } from "@/stores/epics/canvas/actions";
+import type { EpicCanvasState } from "@/stores/epics/canvas/types";
+
+interface TestTreeNode {
+  readonly id: string;
+  readonly parentId: string | null;
+  readonly title: string;
+  readonly type:
+    "spec" | "ticket" | "story" | "review" | "chat" | "terminal-agent";
+  readonly status: number | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+interface TestRecord {
+  readonly id: string;
+  readonly parentId: string | null;
+  readonly name: string;
+  readonly type: TestTreeNode["type"];
+  readonly status: number | null;
+  readonly hostId: string;
+}
+
+interface OpenArtifactLookupEntry {
+  readonly paneId: string;
+  readonly instanceId: string;
+}
+
+interface TestState {
+  readonly navigateNested: Mock;
+  readonly prepareOpenTileInTabFocusTarget: Mock;
+  readonly prepareCloseCanvasTabFocusTarget: Mock;
+  readonly createArtifactMutate: Mock;
+  readonly deleteArtifactMutate: Mock;
+  readonly deleteArtifactMutateAsync: Mock;
+  readonly deleteChatMutateAsync: Mock;
+  readonly deleteTuiAgentMutateAsync: Mock;
+  readonly localDeleteArtifact: Mock;
+  readonly markArtifactSelfDeleted: Mock;
+  readonly unmarkArtifactSelfDeleted: Mock;
+  readonly openArtifactByKey: Map<string, OpenArtifactLookupEntry>;
+  canvasByTabId: Record<string, EpicCanvasState | undefined>;
+  createdArtifactId: string;
+  activeArtifactId: string | null;
+  artifactFilterKinds: ReadonlyArray<string>;
+  collapsedPanelIds: ReadonlySet<string>;
+  expandedIds: ReadonlySet<string>;
+  unreadArtifactIds: ReadonlySet<string>;
+  tree: {
+    readonly rootIds: readonly string[];
+    readonly childrenByParent: Readonly<Record<string, readonly string[]>>;
+    readonly nodeById: Readonly<Record<string, TestTreeNode | undefined>>;
+  };
+  records: readonly TestRecord[];
+  permissionRole: "owner" | "editor" | "viewer" | null;
+}
+
+const testState = vi.hoisted<TestState>(() => ({
+  navigateNested: vi.fn(
+    (
+      _epicId: string,
+      _tabId: string,
+      prepare: () => NestedFocusTarget | null,
+    ) => prepare(),
+  ),
+  prepareOpenTileInTabFocusTarget: vi.fn((): NestedFocusTarget => ({
+    paneId: "pane-new",
+    tileInstanceId: "instance-new",
+  })),
+  prepareCloseCanvasTabFocusTarget: vi.fn((): NestedFocusTarget => ({
+    paneId: "fallback-pane",
+    tileInstanceId: "fallback-instance",
+  })),
+  createArtifactMutate: vi.fn(),
+  deleteArtifactMutate: vi.fn(),
+  deleteArtifactMutateAsync: vi.fn(),
+  deleteChatMutateAsync: vi.fn(),
+  deleteTuiAgentMutateAsync: vi.fn(),
+  localDeleteArtifact: vi.fn(),
+  markArtifactSelfDeleted: vi.fn(),
+  unmarkArtifactSelfDeleted: vi.fn(),
+  openArtifactByKey: new Map<string, OpenArtifactLookupEntry>(),
+  canvasByTabId: {},
+  createdArtifactId: "new-spec-1",
+  activeArtifactId: null,
+  artifactFilterKinds: [],
+  collapsedPanelIds: new Set<string>(),
+  expandedIds: new Set<string>(),
+  unreadArtifactIds: new Set<string>(),
+  tree: {
+    rootIds: [],
+    childrenByParent: {},
+    nodeById: {},
+  },
+  records: [],
+  permissionRole: "owner",
+}));
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => testState.navigateNested,
+}));
+
+vi.mock("@/components/epic-canvas/dnd/epic-canvas-dnd-context-value", () => ({
+  useEpicCanvasDnd: () => ({
+    activeSource: null,
+    dropPreview: null,
+    interactionLocked: false,
+    clearDropPreview: () => undefined,
+  }),
+}));
+
+vi.mock("@/components/epic-canvas/snapshots/snapshot-loading-context", () => ({
+  SnapshotGate: (props: { readonly children: ReactNode }) => props.children,
+}));
+
+vi.mock("@/components/epic-canvas/add-node-dropdown", () => ({
+  AddNodeDropdown: (props: {
+    readonly children: ReactNode;
+    readonly onAdd: (type: string) => void;
+  }) => (
+    <div>
+      {props.children}
+      <button
+        type="button"
+        data-testid="epic-sidebar-add-artifact-root-spec"
+        onClick={() => props.onAdd("spec")}
+      >
+        Add spec
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/epic-canvas/add-node-options", () => ({
+  CHAT_PANEL_EXCLUDED_TYPES: [],
+  ARTIFACT_PANEL_EXCLUDED_TYPES: [],
+}));
+
+vi.mock("@/components/epic-canvas/sidebar/epic-sidebar-filter-menu", () => ({
+  ChatFilterMenu: (props: { readonly disabled: boolean }) => (
+    <button type="button" disabled={props.disabled}>
+      Chat filter
+    </button>
+  ),
+  ArtifactFilterMenu: (props: { readonly disabled: boolean }) => (
+    <button type="button" disabled={props.disabled}>
+      Artifact filter
+    </button>
+  ),
+}));
+
+vi.mock("@/components/epic-canvas/sidebar/epic-terminal-sidebar", () => ({
+  TerminalsPanelActions: () => null,
+  TerminalsPanelBody: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/git-diff/git-diff-panel-body-live", () => ({
+  GitDiffPanelBodyLive: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/git-diff/git-diff-panel-actions", () => ({
+  GitDiffPanelActions: () => null,
+}));
+
+vi.mock(
+  "@/components/epic-canvas/hooks/use-terminal-agent-worktree-gate",
+  () => ({
+    useTerminalAgentWorktreeGate: () => ({
+      isPending: false,
+      requestCreate: vi.fn(),
+    }),
+  }),
+);
+
+vi.mock("@/components/chat/chat-progress-icon", () => ({
+  ChatProgressIcon: () => <span data-testid="chat-sidebar-spinner" />,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: (props: { readonly children: ReactNode }) => props.children,
+  DropdownMenuTrigger: (props: { readonly children: ReactNode }) =>
+    props.children,
+  DropdownMenuContent: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  DropdownMenuItem: (props: {
+    readonly children: ReactNode;
+    readonly onSelect: () => void;
+    readonly "data-testid": string;
+    readonly disabled: boolean;
+  }) => (
+    <button
+      type="button"
+      data-testid={props["data-testid"]}
+      disabled={props.disabled}
+      onClick={props.onSelect}
+    >
+      {props.children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => null,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: (props: { readonly children: ReactNode }) => props.children,
+  TooltipTrigger: (props: { readonly children: ReactNode }) => props.children,
+  TooltipContent: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  Sidebar: (props: {
+    readonly children: ReactNode;
+    readonly "data-testid": string;
+    readonly "data-left-panel-id": string;
+  }) => (
+    <aside
+      data-testid={props["data-testid"]}
+      data-left-panel-id={props["data-left-panel-id"]}
+    >
+      {props.children}
+    </aside>
+  ),
+  SidebarContent: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  SidebarGroup: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  SidebarGroupContent: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-1",
+}));
+
+vi.mock("@/hooks/worktree/use-latest-conversation-workspace-seed", () => ({
+  useLatestConversationWorkspaceSeed: () => null,
+}));
+
+vi.mock("@/hooks/worktree/use-worktree-get-binding-query", () => ({
+  useWorktreeGetBinding: () => ({
+    data: { binding: null, missingWorktreePaths: [] },
+    isError: false,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
+  useEpicCreateChat: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicCreateChatForHostClient: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  useEpicDeleteChat: () => ({
+    mutate: vi.fn(),
+    mutateAsync: testState.deleteChatMutateAsync,
+    isPending: false,
+  }),
+  useEpicRenameChat: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/agent/use-create-tui-agent", () => ({
+  useCreateTuiAgentForClient: () => ({
+    create: vi.fn(() => Promise.resolve(null)),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/host/runtime", () => ({
+  useHostClient: () => ({ getActiveHostId: () => "host-1" }),
+}));
+
+vi.mock("@/hooks/host/use-host-client-for", () => ({
+  useHostClientFor: () => ({ getActiveHostId: () => "host-1" }),
+}));
+
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => ({ hostId: "host-1" }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-node-mutations", () => ({
+  useEpicCreateArtifact: () => ({
+    mutate: (
+      variables: {
+        readonly epicId: string;
+        readonly parentId: string | null;
+        readonly artifactType: string;
+        readonly title: string;
+      },
+      options: {
+        readonly onSuccess: (result: { readonly artifactId: string }) => void;
+        readonly onError: () => void;
+      },
+    ) => {
+      testState.createArtifactMutate(variables);
+      options.onSuccess({ artifactId: testState.createdArtifactId });
+    },
+    isPending: false,
+  }),
+  useEpicDeleteArtifact: () => ({
+    mutate: (
+      variables: { readonly epicId: string; readonly artifactId: string },
+      options: {
+        readonly onSuccess: () => void;
+        readonly onError: () => void;
+      },
+    ) => {
+      testState.deleteArtifactMutate(variables);
+      options.onSuccess();
+    },
+    mutateAsync: testState.deleteArtifactMutateAsync,
+    isPending: false,
+  }),
+  useEpicRenameArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-tui-agent-mutations", () => ({
+  useEpicDeleteTuiAgent: () => ({
+    mutate: vi.fn(),
+    mutateAsync: testState.deleteTuiAgentMutateAsync,
+    isPending: false,
+  }),
+  useEpicRenameTuiAgent: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/providers/use-open-epic-handle", () => ({
+  useOpenEpicHandle: () => ({
+    epicId: "epic-1",
+    store: {
+      getState: () => ({
+        deleteArtifact: testState.localDeleteArtifact,
+        renameArtifact: vi.fn(),
+        chats: { byId: {} },
+        tuiAgents: { byId: {} },
+        artifacts: {
+          byId: {
+            [testState.createdArtifactId]: {
+              id: testState.createdArtifactId,
+              kind: "spec",
+              title: "Spec",
+            },
+          },
+        },
+      }),
+      subscribe: () => () => undefined,
+    },
+  }),
+}));
+
+// Deliberately omits raw `openTileInTab`: a regression back to calling it
+// directly instead of the `prepare*FocusTarget` boundary throws (`... is not
+// a function`) instead of silently passing. `closeCanvasTab` IS present here
+// (the bulk-delete boundary batches through it deliberately - see file
+// header), backed by the real `closeTab` reducer against `canvasByTabId` so
+// `getCurrentNestedFocusTarget` in production code computes a real result.
+vi.mock("@/stores/epics/canvas/store", () => ({
+  findOpenArtifactInTab: (tabId: string, nodeId: string) => {
+    const mapped = testState.openArtifactByKey.get(`${tabId}:${nodeId}`);
+    if (mapped !== undefined) return mapped;
+    const canvas = testState.canvasByTabId[tabId];
+    if (
+      canvas === undefined ||
+      canvas.root === null ||
+      canvas.root.kind !== "pane"
+    ) {
+      return null;
+    }
+    for (const instanceId of canvas.root.tabInstanceIds) {
+      const tile = canvas.tilesByInstanceId[instanceId];
+      if (tile !== undefined && tile.id === nodeId) {
+        return { paneId: canvas.root.id, instanceId };
+      }
+    }
+    return null;
+  },
+  useActiveEpicArtifactId: () => testState.activeArtifactId,
+  useEpicCanvasStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        closeCanvasTab: (tabId: string, paneId: string, tileTabId: string) => {
+          const current = testState.canvasByTabId[tabId];
+          if (current === undefined) return;
+          testState.canvasByTabId[tabId] = closeTab(current, paneId, tileTabId);
+        },
+        markArtifactSelfDeleted: testState.markArtifactSelfDeleted,
+        openTilePreviewInTab: vi.fn(),
+        pendingRootCreatesByEpic: {},
+        preAckRootCreatesByEpic: {},
+        promotePreviewInTab: vi.fn(),
+        prepareOpenTileInTabFocusTarget:
+          testState.prepareOpenTileInTabFocusTarget,
+        prepareCloseCanvasTabFocusTarget:
+          testState.prepareCloseCanvasTabFocusTarget,
+        renameArtifactInTab: vi.fn(),
+        unmarkArtifactSelfDeleted: testState.unmarkArtifactSelfDeleted,
+      }),
+    {
+      getState: () => ({
+        canvasByTabId: testState.canvasByTabId,
+      }),
+    },
+  ),
+  useIsActiveEpicArtifact: () => false,
+}));
+
+vi.mock("@/stores/epics/epic-sidebar-expansion-store", () => ({
+  useEpicSidebarEffectiveExpanded: () => testState.expandedIds,
+  useEpicSidebarExpansionStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      collapse: vi.fn(),
+      collapseAll: vi.fn(),
+      expand: vi.fn(),
+    }),
+}));
+
+vi.mock("@/stores/epics/left-panel-store", () => ({
+  DEFAULT_LEFT_PANEL_ID: "artifacts",
+  isArtifactFilterActive: () => testState.artifactFilterKinds.length > 0,
+  isChatFilterActive: () => false,
+  useAcknowledgedRootCreatePending: () => null,
+  useActiveLeftPanelId: () => "artifacts",
+  useArtifactFilter: () => ({
+    statuses: [],
+    kinds: testState.artifactFilterKinds,
+    read: "all",
+  }),
+  useArtifactSort: () => ({ field: "updated", direction: "desc" }),
+  useChatFilter: () => ({ origin: "all" }),
+  useChatSort: () => ({ field: "updated", direction: "desc" }),
+  useCommentsPanelRevealed: () => false,
+  useEpicLeftPanelStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      clearAcknowledgedRootCreatePending: vi.fn(),
+      clearLocalRootCreatePending: vi.fn(),
+      panelSectionCollapsedByPanelId: {},
+      setAcknowledgedRootCreatePending: vi.fn(),
+      setActivePanelId: vi.fn(),
+      setLocalRootCreatePending: vi.fn(),
+      setPanelSectionWeights: vi.fn(),
+      togglePanelSectionCollapsed: vi.fn(),
+    }),
+  useLeftPanelGroups: () => [{ panelIds: ["artifacts"] }],
+  useLeftPanelSectionCollapsed: (panelId: string) =>
+    testState.collapsedPanelIds.has(panelId),
+  useLocalRootCreatePending: () => null,
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useAncestorIds: () => new Set<string>(),
+  useChildIds: (parentId: string) =>
+    testState.tree.childrenByParent[parentId] ?? [],
+  useEpicActiveAgentIds: () => new Set<string>(),
+  useEpicArtifact: (artifactId: string | null) => {
+    if (artifactId === null) return null;
+    const node = testState.tree.nodeById[artifactId];
+    if (node === undefined) return null;
+    return {
+      id: node.id,
+      kind: node.type,
+      title: node.title,
+      updatedAt: node.updatedAt,
+    };
+  },
+  useEpicArtifactRecords: () => testState.records,
+  useEpicArtifactStatus: (artifactId: string) =>
+    testState.tree.nodeById[artifactId]?.status ?? null,
+  useEpicConnectionStatus: () => "open",
+  useEpicNodeHostId: () => "host-1",
+  useEpicNodeOwnerKind: () => "chat",
+  useEpicNodeWorkspaceFolders: () => [],
+  useEpicPermissionRole: () => testState.permissionRole,
+  useEpicTreeIndex: () => testState.tree,
+  useEpicTreeNode: (nodeId: string) => testState.tree.nodeById[nodeId] ?? null,
+  useMaybeEpicTuiAgentHarnessId: () => null,
+  useRootIds: () => testState.tree.rootIds,
+}));
+
+vi.mock("@/hooks/use-epic-store", () => ({
+  useEpicStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      snapshotLoaded: true,
+      artifacts: {
+        allIds: testState.records
+          .filter((record) => record.type !== "chat")
+          .filter((record) => record.type !== "terminal-agent")
+          .map((record) => record.id),
+        byId: Object.fromEntries(
+          testState.records.map((record) => [
+            record.id,
+            {
+              id: record.id,
+              kind: record.type,
+              status: record.status,
+              title: record.name,
+              updatedAt: 1,
+            },
+          ]),
+        ),
+      },
+    }),
+}));
+
+const seedEpicArtifacts = vi.hoisted(() => vi.fn());
+const markRead = vi.hoisted(() => vi.fn());
+const useArtifactReadStateStoreMock = vi.hoisted(() => {
+  const store = Object.assign(
+    vi.fn((selector: (state: unknown) => unknown) =>
+      selector({
+        lastSeenByArtifact: {},
+        markRead,
+        seedAtByEpic: {},
+        seedEpicArtifacts,
+      }),
+    ),
+    {
+      getState: () => ({
+        lastSeenByArtifact: {},
+        markRead,
+        seedAtByEpic: {},
+        seedEpicArtifacts,
+      }),
+    },
+  );
+  return store;
+});
+
+vi.mock("@/stores/epics/artifact-read-state-store", () => ({
+  isArtifactUnread: (args: { readonly artifactId: string }) =>
+    testState.unreadArtifactIds.has(args.artifactId),
+  useArtifactReadStateStore: useArtifactReadStateStoreMock,
+}));
+
+vi.mock("@/stores/settings/settings-store", () => ({
+  useSettingsStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      artifactIconColorMode: "none",
+      artifactIconColors: {
+        chat: undefined,
+        review: undefined,
+        spec: undefined,
+        story: undefined,
+        ticket: undefined,
+        "terminal-agent": undefined,
+      },
+    }),
+}));
+
+import { EpicLeftPanelHost } from "@/components/epic-canvas/sidebar/epic-sidebar";
+
+const TAB_ID = "tab-1";
+const EPIC_ID = "epic-1";
+
+describe("sidebar navigation boundary (back/forward regression fixes)", () => {
+  beforeEach(() => {
+    testState.deleteArtifactMutateAsync.mockResolvedValue({});
+    testState.deleteChatMutateAsync.mockResolvedValue({});
+    testState.deleteTuiAgentMutateAsync.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    testState.activeArtifactId = null;
+    testState.artifactFilterKinds = [];
+    testState.collapsedPanelIds = new Set<string>();
+    testState.expandedIds = new Set<string>();
+    testState.unreadArtifactIds = new Set<string>();
+    testState.tree = { rootIds: [], childrenByParent: {}, nodeById: {} };
+    testState.records = [];
+    testState.permissionRole = "owner";
+    testState.openArtifactByKey.clear();
+    testState.canvasByTabId = {};
+    testState.createdArtifactId = "new-spec-1";
+  });
+
+  it("routes root-create-then-open through navigateNested + prepareOpenTileInTabFocusTarget", () => {
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    fireEvent.click(screen.getByTestId("epic-sidebar-add-artifact-root-spec"));
+
+    expect(testState.createArtifactMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ epicId: EPIC_ID, parentId: null }),
+    );
+    // The boundary must be the thing that opens the freshly-created tile -
+    // asserting only on `prepareOpenTileInTabFocusTarget` would also pass a
+    // raw `openTileInTab(...)` call reached via some other path, so both the
+    // boundary call and the prepare call underneath it are checked.
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      TAB_ID,
+      expect.any(Function),
+    );
+    expect(testState.prepareOpenTileInTabFocusTarget).toHaveBeenCalledWith(
+      TAB_ID,
+      expect.objectContaining({
+        id: testState.createdArtifactId,
+        type: "spec",
+      }),
+    );
+  });
+
+  it("routes single artifact delete-close through navigateNested + prepareCloseCanvasTabFocusTarget", async () => {
+    seedSingleArtifact();
+    testState.openArtifactByKey.set(`${TAB_ID}:spec-root`, {
+      paneId: "pane-1",
+      instanceId: "instance-1",
+    });
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    fireEvent.click(screen.getByTestId("epic-sidebar-more-spec-root"));
+    fireEvent.click(screen.getByTestId("epic-sidebar-delete-spec-root"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    await waitFor(() => {
+      expect(testState.deleteArtifactMutate).toHaveBeenCalledWith({
+        epicId: EPIC_ID,
+        artifactId: "spec-root",
+      });
+    });
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      TAB_ID,
+      expect.any(Function),
+    );
+    expect(testState.prepareCloseCanvasTabFocusTarget).toHaveBeenCalledWith(
+      TAB_ID,
+      "pane-1",
+      "instance-1",
+    );
+  });
+
+  it("batches bulk delete of 3 open tabs (including the active one) into one navigateNested call that focuses the surviving tile", async () => {
+    seedArtifactTriple();
+    testState.canvasByTabId[TAB_ID] = buildCanvasWithTiles(
+      [
+        { instanceId: "tab-d", contentId: "spec-d", name: "D" },
+        { instanceId: "tab-a", contentId: "spec-a", name: "A" },
+        { instanceId: "tab-b", contentId: "spec-b", name: "B" },
+        { instanceId: "tab-c", contentId: "spec-c", name: "C" },
+      ],
+      "tab-a",
+    );
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select artifacts" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+    fireEvent.click(
+      screen.getByTestId("epic-sidebar-delete-selected-artifacts"),
+    );
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    await waitFor(() => {
+      expect(testState.deleteArtifactMutateAsync).toHaveBeenCalledWith({
+        epicId: EPIC_ID,
+        artifactId: "spec-c",
+      });
+    });
+
+    // Exactly ONE route write for the whole batch - a per-item loop through
+    // `prepareCloseCanvasTabFocusTarget` would fire 3 times and let an
+    // intermediate iteration's fallback (itself also being deleted) leak
+    // into history.
+    expect(testState.navigateNested).toHaveBeenCalledTimes(1);
+    expect(testState.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      TAB_ID,
+      expect.any(Function),
+    );
+    // All 3 deleted tabs are gone; only the untouched 4th tile (D) survives,
+    // and the single prepared target - read from real post-batch canvas
+    // state via `getCurrentNestedFocusTarget`, not a per-item fallback -
+    // must point at that survivor, never at a deleted id.
+    const finalCanvas = testState.canvasByTabId[TAB_ID];
+    expect(finalCanvas.tilesByInstanceId["tab-a"]).toBeUndefined();
+    expect(finalCanvas.tilesByInstanceId["tab-b"]).toBeUndefined();
+    expect(finalCanvas.tilesByInstanceId["tab-c"]).toBeUndefined();
+    expect(finalCanvas.tilesByInstanceId["tab-d"]).toBeDefined();
+    expect(testState.navigateNested.mock.results[0]?.value).toEqual({
+      paneId: "pane-1",
+      tileInstanceId: "tab-d",
+    });
+  });
+
+  it("batches bulk delete of only inactive open tabs into one navigateNested call whose target is the unchanged active tile", async () => {
+    seedArtifactPair();
+    testState.canvasByTabId[TAB_ID] = buildCanvasWithTiles(
+      [
+        { instanceId: "tab-d", contentId: "spec-d", name: "D" },
+        { instanceId: "tab-b", contentId: "spec-b", name: "B" },
+        { instanceId: "tab-c", contentId: "spec-c", name: "C" },
+      ],
+      "tab-d",
+    );
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select artifacts" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+    fireEvent.click(
+      screen.getByTestId("epic-sidebar-delete-selected-artifacts"),
+    );
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    await waitFor(() => {
+      expect(testState.deleteArtifactMutateAsync).toHaveBeenCalledWith({
+        epicId: EPIC_ID,
+        artifactId: "spec-c",
+      });
+    });
+
+    expect(testState.navigateNested).toHaveBeenCalledTimes(1);
+    // Neither closed tab was active, so the post-batch current focus equals
+    // what it already was - the boundary still fires once (closes did
+    // happen), and this unchanged target is what lets the real
+    // `navigateNestedFocus` duplicate-suppression turn it into a no-op
+    // route write; the sidebar code must not special-case this itself.
+    expect(testState.navigateNested.mock.results[0]?.value).toEqual({
+      paneId: "pane-1",
+      tileInstanceId: "tab-d",
+    });
+    const finalCanvas = testState.canvasByTabId[TAB_ID];
+    expect(finalCanvas.tilesByInstanceId["tab-b"]).toBeUndefined();
+    expect(finalCanvas.tilesByInstanceId["tab-c"]).toBeUndefined();
+    expect(finalCanvas.tilesByInstanceId["tab-d"]).toBeDefined();
+    expect(
+      finalCanvas.root?.kind === "pane" ? finalCanvas.root.activeTabId : null,
+    ).toBe("tab-d");
+  });
+});
+
+function seedSingleArtifact(): void {
+  const specRoot = treeNode("spec-root", null, "Root spec", "spec");
+  testState.tree = {
+    rootIds: ["spec-root"],
+    childrenByParent: {},
+    nodeById: { "spec-root": specRoot },
+  };
+  testState.records = [recordFromNode(specRoot)];
+}
+
+function seedArtifactTriple(): void {
+  const nodes = [
+    treeNode("spec-a", null, "A", "spec"),
+    treeNode("spec-b", null, "B", "spec"),
+    treeNode("spec-c", null, "C", "spec"),
+  ];
+  testState.tree = {
+    rootIds: nodes.map((node) => node.id),
+    childrenByParent: {},
+    nodeById: Object.fromEntries(nodes.map((node) => [node.id, node])),
+  };
+  testState.records = nodes.map(recordFromNode);
+}
+
+function seedArtifactPair(): void {
+  const nodes = [
+    treeNode("spec-b", null, "B", "spec"),
+    treeNode("spec-c", null, "C", "spec"),
+  ];
+  testState.tree = {
+    rootIds: nodes.map((node) => node.id),
+    childrenByParent: {},
+    nodeById: Object.fromEntries(nodes.map((node) => [node.id, node])),
+  };
+  testState.records = nodes.map(recordFromNode);
+}
+
+interface CanvasTileFixture {
+  readonly instanceId: string;
+  readonly contentId: string;
+  readonly name: string;
+}
+
+/** Builds a real single-pane `EpicCanvasState` (all `tiles` in one pane) so
+ * `closeTab` / `getCurrentNestedFocusTarget` (both real, unmocked production
+ * code) compute genuine results against it. */
+function buildCanvasWithTiles(
+  tiles: ReadonlyArray<CanvasTileFixture>,
+  activeInstanceId: string,
+): EpicCanvasState {
+  return {
+    root: {
+      kind: "pane",
+      id: "pane-1",
+      tabInstanceIds: tiles.map((tile) => tile.instanceId),
+      activeTabId: activeInstanceId,
+      previewTabId: null,
+      activationHistory: [],
+    },
+    activePaneId: "pane-1",
+    tilesByInstanceId: Object.fromEntries(
+      tiles.map((tile) => [
+        tile.instanceId,
+        {
+          id: tile.contentId,
+          instanceId: tile.instanceId,
+          type: "spec",
+          name: tile.name,
+          hostId: "host-1",
+        },
+      ]),
+    ),
+    sizesByGroupId: {},
+  };
+}
+
+function treeNode(
+  id: string,
+  parentId: string | null,
+  title: string,
+  type: TestTreeNode["type"],
+): TestTreeNode {
+  return {
+    id,
+    parentId,
+    title,
+    type,
+    status: null,
+    createdAt: 1,
+    updatedAt: 2,
+  };
+}
+
+function recordFromNode(node: TestTreeNode): TestRecord {
+  return {
+    id: node.id,
+    parentId: node.parentId,
+    name: node.title,
+    type: node.type,
+    status: node.status,
+    hostId: "host-1",
+  };
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -28,6 +28,7 @@ import {
 import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import { requestArtifactEditorFocus } from "@/lib/artifacts/pending-editor-focus";
 import { openProjectedSidebarNodeInTabWhenAvailable } from "@/components/epic-canvas/sidebar/open-projected-sidebar-node";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { cn } from "@/lib/utils";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
@@ -665,10 +666,15 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
   const { expandedIds, toggleExpanded, ensureExpanded } = expansion;
   const node = useEpicTreeNode(nodeId);
   const childIds = useFilteredPanelChildIds(nodeId, treeFilter);
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
-  const openTilePreviewInTab = useEpicCanvasStore(
-    (s) => s.openTilePreviewInTab,
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
+  const prepareOpenTilePreviewInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTilePreviewInTabFocusTarget,
   );
   const promotePreviewInTab = useEpicCanvasStore((s) => s.promotePreviewInTab);
   const markArtifactSelfDeleted = useEpicCanvasStore(
@@ -764,7 +770,11 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
           tabId,
           nodeId: projectedNodeId,
           fallbackHostId: activeHostId,
-          openTileInTab,
+          openTileInTab: (targetTabId, nodeRef) => {
+            navigateNested(epicId, targetTabId, () =>
+              prepareOpenTileInTabFocusTarget(targetTabId, nodeRef),
+            );
+          },
           onBeforeOpen,
           onOpened: () => {
             pendingProjectedOpenCancelRef.current = null;
@@ -781,7 +791,14 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
           onCleanup: null,
         });
     },
-    [activeHostId, epicHandle, openTileInTab, tabId],
+    [
+      activeHostId,
+      epicHandle,
+      epicId,
+      navigateNested,
+      prepareOpenTileInTabFocusTarget,
+      tabId,
+    ],
   );
 
   const clearPendingChildCreate = useCallback(() => {
@@ -795,20 +812,24 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
   const selectArtifactNode = useCallback(() => {
     if (isRenaming) return;
     if (openableType === null) return;
-    openTilePreviewInTab(tabId, {
-      id: nodeId,
-      instanceId: uuidv4(),
-      type: openableType,
-      name: nodeName,
-      hostId: activeHostId,
-    });
+    navigateNested(epicId, tabId, () =>
+      prepareOpenTilePreviewInTabFocusTarget(tabId, {
+        id: nodeId,
+        instanceId: uuidv4(),
+        type: openableType,
+        name: nodeName,
+        hostId: activeHostId,
+      }),
+    );
   }, [
     activeHostId,
+    epicId,
     isRenaming,
+    navigateNested,
     nodeName,
     nodeId,
-    openTilePreviewInTab,
     openableType,
+    prepareOpenTilePreviewInTabFocusTarget,
     tabId,
   ]);
 
@@ -817,23 +838,33 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
     if (openableType === null) return;
     const found = findOpenArtifactInTab(tabId, nodeId);
     if (found !== null) {
-      promotePreviewInTab(tabId, found.paneId);
-    } else {
-      openTileInTab(tabId, {
-        id: nodeId,
-        instanceId: uuidv4(),
-        type: openableType,
-        name: nodeName,
-        hostId: activeHostId,
+      navigateNested(epicId, tabId, () => {
+        promotePreviewInTab(tabId, found.paneId);
+        return {
+          paneId: found.paneId,
+          tileInstanceId: found.instanceId,
+        };
       });
+    } else {
+      navigateNested(epicId, tabId, () =>
+        prepareOpenTileInTabFocusTarget(tabId, {
+          id: nodeId,
+          instanceId: uuidv4(),
+          type: openableType,
+          name: nodeName,
+          hostId: activeHostId,
+        }),
+      );
     }
   }, [
     activeHostId,
+    epicId,
     isRenaming,
+    navigateNested,
     nodeId,
     nodeName,
     openableType,
-    openTileInTab,
+    prepareOpenTileInTabFocusTarget,
     promotePreviewInTab,
     tabId,
   ]);
@@ -954,7 +985,13 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
       setConfirmDeleteOpen(false);
       const found = findOpenArtifactInTab(tabId, nodeId);
       if (found !== null) {
-        closeCanvasTab(tabId, found.paneId, found.instanceId);
+        navigateNested(epicId, tabId, () =>
+          prepareCloseCanvasTabFocusTarget(
+            tabId,
+            found.paneId,
+            found.instanceId,
+          ),
+        );
       }
     };
     const handleDeleteError = () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -5,6 +5,7 @@
 import { useDraggable } from "@dnd-kit/core";
 import { v4 as uuidv4 } from "uuid";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import {
   useEpicDeleteChat,
   useEpicRenameChat,
@@ -444,10 +445,15 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
   const { expandedIds, toggleExpanded } = expansion;
   const node = useEpicTreeNode(nodeId);
   const childIds = useFilteredPanelChildIds(nodeId, treeFilter);
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
-  const openTilePreviewInTab = useEpicCanvasStore(
-    (s) => s.openTilePreviewInTab,
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
+  const prepareOpenTilePreviewInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTilePreviewInTabFocusTarget,
+  );
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
   );
   const promotePreviewInTab = useEpicCanvasStore((s) => s.promotePreviewInTab);
   const markArtifactSelfDeleted = useEpicCanvasStore(
@@ -508,20 +514,24 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
   const selectChatNode = useCallback(() => {
     if (isRenaming) return;
     if (openableType === null) return;
-    openTilePreviewInTab(tabId, {
-      id: nodeId,
-      instanceId: uuidv4(),
-      type: openableType,
-      name: nodeName,
-      hostId: activeHostId,
-    });
+    navigateNested(epicId, tabId, () =>
+      prepareOpenTilePreviewInTabFocusTarget(tabId, {
+        id: nodeId,
+        instanceId: uuidv4(),
+        type: openableType,
+        name: nodeName,
+        hostId: activeHostId,
+      }),
+    );
   }, [
     activeHostId,
+    epicId,
     isRenaming,
+    navigateNested,
     nodeName,
     nodeId,
-    openTilePreviewInTab,
     openableType,
+    prepareOpenTilePreviewInTabFocusTarget,
     tabId,
   ]);
 
@@ -530,23 +540,33 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
     if (openableType === null) return;
     const found = findOpenArtifactInTab(tabId, nodeId);
     if (found !== null) {
-      promotePreviewInTab(tabId, found.paneId);
-    } else {
-      openTileInTab(tabId, {
-        id: nodeId,
-        instanceId: uuidv4(),
-        type: openableType,
-        name: nodeName,
-        hostId: activeHostId,
+      navigateNested(epicId, tabId, () => {
+        promotePreviewInTab(tabId, found.paneId);
+        return {
+          paneId: found.paneId,
+          tileInstanceId: found.instanceId,
+        };
       });
+    } else {
+      navigateNested(epicId, tabId, () =>
+        prepareOpenTileInTabFocusTarget(tabId, {
+          id: nodeId,
+          instanceId: uuidv4(),
+          type: openableType,
+          name: nodeName,
+          hostId: activeHostId,
+        }),
+      );
     }
   }, [
     activeHostId,
+    epicId,
     isRenaming,
+    navigateNested,
     nodeId,
     nodeName,
     openableType,
-    openTileInTab,
+    prepareOpenTileInTabFocusTarget,
     promotePreviewInTab,
     tabId,
   ]);
@@ -641,7 +661,13 @@ const ChatNode = memo(function ChatNode(props: ChatNodeProps) {
       setConfirmDeleteOpen(false);
       const found = findOpenArtifactInTab(tabId, nodeId);
       if (found !== null) {
-        closeCanvasTab(tabId, found.paneId, found.instanceId);
+        navigateNested(epicId, tabId, () =>
+          prepareCloseCanvasTabFocusTarget(
+            tabId,
+            found.paneId,
+            found.instanceId,
+          ),
+        );
       }
     };
     const handleDeleteError = () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -38,6 +38,7 @@ import {
 } from "@/components/epic-canvas/sidebar/epic-sidebar-filter-menu";
 import { FileTreeWorkspacePicker } from "@/components/epic-canvas/sidebar/file-tree-workspace-picker";
 import { WorkspacePickerWithOpener } from "@/components/worktree/workspace-picker-with-opener";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { PIERRE_FILE_TREE_THEME_STYLE } from "@/components/epic-canvas/pierre-tree-theme";
 import { useWorkspaceListFileTree } from "@/hooks/workspace/use-list-file-tree-query";
 import { useWorktreeListBindingsForEpic } from "@/hooks/worktree/use-worktree-list-bindings-for-epic-query";
@@ -53,6 +54,11 @@ import {
 import type { WorkspaceFileTreeNode } from "@traycer/protocol/host/workspace/unary-schemas";
 import { extractPierreItemPathFromEvent } from "@/components/epic-canvas/pierre-tree-adapter";
 import { type GitStatusEntry } from "@pierre/trees";
+import {
+  getCurrentNestedFocusTarget,
+  type NestedFocusTarget,
+} from "@/lib/epic-nested-focus-route";
+import { EMPTY_CANVAS } from "@/stores/epics/canvas/canvas-state";
 import { PanelGroupSectionHeader } from "@/components/epic-canvas/sidebar/epic-sidebar-header";
 import { PANEL_HEADER_ACTION_REVEAL_CLASS } from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
 import { ChatTreePanelBody } from "@/components/epic-canvas/sidebar/epic-sidebar-chat-tree";
@@ -1102,10 +1108,13 @@ function FileTreePanelBodyForWorkspace(props: {
     [files],
   );
 
-  const openTilePreviewInTab = useEpicCanvasStore(
-    (s) => s.openTilePreviewInTab,
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTilePreviewInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTilePreviewInTabFocusTarget,
   );
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
 
   // Single source of truth for "tree row path -> workspace file ref". Reused by
   // the open handlers and the drag bridge so a row that is not an openable file
@@ -1136,23 +1145,25 @@ function FileTreePanelBodyForWorkspace(props: {
   useEffect(() => {
     const openInTab = (
       treePath: string,
-      open: (tabId: string, ref: WorkspaceFileRef) => void,
+      open: (tabId: string, ref: WorkspaceFileRef) => NestedFocusTarget | null,
     ) => {
       const ref = workspaceFileRefForTreePath(treePath);
       if (ref === null) return;
-      open(props.tabId, ref);
+      navigateNested(props.epicId, props.tabId, () => open(props.tabId, ref));
     };
     handlersRef.current.onSelect = (treePath) => {
-      openInTab(treePath, openTilePreviewInTab);
+      openInTab(treePath, prepareOpenTilePreviewInTabFocusTarget);
     };
     handlersRef.current.onOpen = (treePath) => {
-      openInTab(treePath, openTileInTab);
+      openInTab(treePath, prepareOpenTileInTabFocusTarget);
     };
   }, [
+    navigateNested,
     workspaceFileRefForTreePath,
+    props.epicId,
     props.tabId,
-    openTilePreviewInTab,
-    openTileInTab,
+    prepareOpenTilePreviewInTabFocusTarget,
+    prepareOpenTileInTabFocusTarget,
   ]);
 
   const { model } = useFileTree({
@@ -1335,6 +1346,7 @@ function SidebarBulkDeleteController(props: {
   const liveRecords = useEpicArtifactRecords();
   const tree = useEpicTreeIndex();
   const epicHandle = useOpenEpicHandle();
+  const navigateNested = useEpicNestedFocusNavigation();
   const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
   const markArtifactSelfDeleted = useEpicCanvasStore(
     (s) => s.markArtifactSelfDeleted,
@@ -1406,11 +1418,27 @@ function SidebarBulkDeleteController(props: {
         const failedIds = targets.flatMap((target, index) =>
           results[index].status === "rejected" ? [target.id] : [],
         );
-        successfulIds.forEach((id) => {
+        // Closing several tabs is one focus-relevant change, not N: closing
+        // each through its own `prepareCloseCanvasTabFocusTarget` call would
+        // let an intermediate iteration's fallback focus (e.g. the next
+        // still-being-deleted tab) get pushed as a route entry. Instead,
+        // close every successfully-deleted open tab raw, then compute and
+        // commit the post-batch focus target exactly once.
+        const openTargets = successfulIds.flatMap((id) => {
           const found = findOpenArtifactInTab(props.tabId, id);
-          if (found === null) return;
-          closeCanvasTab(props.tabId, found.paneId, found.instanceId);
+          return found === null ? [] : [found];
         });
+        if (openTargets.length > 0) {
+          navigateNested(props.epicId, props.tabId, () => {
+            openTargets.forEach((found) => {
+              closeCanvasTab(props.tabId, found.paneId, found.instanceId);
+            });
+            const canvas =
+              useEpicCanvasStore.getState().canvasByTabId[props.tabId] ??
+              EMPTY_CANVAS;
+            return getCurrentNestedFocusTarget(canvas);
+          });
+        }
         failedIds.forEach((id) => {
           unmarkArtifactSelfDeleted(id);
         });
@@ -1435,6 +1463,7 @@ function SidebarBulkDeleteController(props: {
     deleteTerminalAgent,
     epicHandle,
     markArtifactSelfDeleted,
+    navigateNested,
     pendingDeleteIds,
     props.epicId,
     props.tabId,
@@ -1568,7 +1597,10 @@ function TreePanelActions(props: TreePanelActionsProps) {
   const canMutate = canEdit && !isDisconnected;
   const epicHandle = useOpenEpicHandle();
   const activeHostId = useReactiveActiveHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
   const createArtifact = useEpicCreateArtifact();
   const setLocalRootCreatePending = useEpicLeftPanelStore(
     (s) => s.setLocalRootCreatePending,
@@ -1598,7 +1630,11 @@ function TreePanelActions(props: TreePanelActionsProps) {
         tabId: props.tabId,
         nodeId,
         fallbackHostId: activeHostId,
-        openTileInTab,
+        openTileInTab: (targetTabId, nodeRef) => {
+          navigateNested(props.epicId, targetTabId, () =>
+            prepareOpenTileInTabFocusTarget(targetTabId, nodeRef),
+          );
+        },
         onBeforeOpen,
         onOpened: () => {
           clearAcknowledgedRootCreatePending(props.epicId, props.panelId);
@@ -1616,7 +1652,8 @@ function TreePanelActions(props: TreePanelActionsProps) {
       activeHostId,
       clearAcknowledgedRootCreatePending,
       epicHandle,
-      openTileInTab,
+      navigateNested,
+      prepareOpenTileInTabFocusTarget,
       projectedOpenCancels,
       props.epicId,
       props.panelId,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -56,6 +56,7 @@ import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { useTerminalKill } from "@/hooks/terminal/use-terminal-kill-mutation";
 import { useTerminalList } from "@/hooks/terminal/use-terminal-list-query";
 import { useTerminalRename } from "@/hooks/terminal/use-terminal-rename-mutation";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useHostClient } from "@/lib/host";
 import { isVisibleRawTerminalSession } from "@/lib/terminals/terminal-session-filters";
 import {
@@ -96,22 +97,43 @@ function TerminalsPanelBodyLive(props: {
   const { epicId, tabId } = props;
   const hostClient = useHostClient();
   const list = useTerminalList(epicId, hostClient);
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
-  const setActiveTileTab = useEpicCanvasStore((s) => s.setActiveTileTab);
-  const setActiveTilePane = useEpicCanvasStore((s) => s.setActiveTilePane);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
+  const prepareSetActiveTileTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareSetActiveTileTabFocusTarget,
+  );
   const activeHostId = useReactiveActiveHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
 
   const openExisting = useCallback(
     (session: TerminalSessionInfo) => {
       const found = findOpenArtifactInTab(tabId, session.sessionId);
       if (found !== null) {
-        setActiveTilePane(tabId, found.paneId);
-        setActiveTileTab(tabId, found.paneId, found.instanceId);
+        navigateNested(epicId, tabId, () =>
+          prepareSetActiveTileTabFocusTarget(
+            tabId,
+            found.paneId,
+            found.instanceId,
+          ),
+        );
         return;
       }
-      openTileInTab(tabId, makeTerminalRef(session, activeHostId, uuidv4()));
+      navigateNested(epicId, tabId, () =>
+        prepareOpenTileInTabFocusTarget(
+          tabId,
+          makeTerminalRef(session, activeHostId, uuidv4()),
+        ),
+      );
     },
-    [activeHostId, openTileInTab, setActiveTilePane, setActiveTileTab, tabId],
+    [
+      activeHostId,
+      epicId,
+      navigateNested,
+      prepareOpenTileInTabFocusTarget,
+      prepareSetActiveTileTabFocusTarget,
+      tabId,
+    ],
   );
 
   // Host keeps exited sessions for a 60s grace window; filter so a
@@ -231,7 +253,10 @@ function TerminalRow(props: TerminalRowProps) {
   const kill = useTerminalKill();
   const rename = useTerminalRename();
   const renameArtifactInTab = useEpicCanvasStore((s) => s.renameArtifactInTab);
-  const closeCanvasTab = useEpicCanvasStore((s) => s.closeCanvasTab);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
   const showNavigatorResourceStats = useSettingsStore(
     (state) => state.showNavigatorResourceStats,
   );
@@ -324,10 +349,19 @@ function TerminalRow(props: TerminalRowProps) {
     if (kill.isPending) return;
     const found = findOpenArtifactInTab(tabId, session.sessionId);
     if (found !== null) {
-      closeCanvasTab(tabId, found.paneId, found.instanceId);
+      navigateNested(epicId, tabId, () =>
+        prepareCloseCanvasTabFocusTarget(tabId, found.paneId, found.instanceId),
+      );
     }
     kill.mutate({ sessionId: session.sessionId });
-  }, [closeCanvasTab, kill, session.sessionId, tabId]);
+  }, [
+    epicId,
+    kill,
+    navigateNested,
+    prepareCloseCanvasTabFocusTarget,
+    session.sessionId,
+    tabId,
+  ]);
 
   const handleDoubleClick = useCallback(() => {
     if (isRenaming) return;

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
@@ -24,6 +24,7 @@ import { WorktreeFolderListBody } from "@/components/worktree/worktree-folder-li
 import { WorktreePickerHostSection } from "@/components/worktree/worktree-picker-host-section";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { useWorktreeListBindingsForEpic } from "@/hooks/worktree/use-worktree-list-bindings-for-epic-query";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { DEFAULT_TERMINAL_TITLE } from "@/lib/terminals/terminal-title";
 import { worktreeRowKey } from "@/lib/worktree/worktree-row-key";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
@@ -40,8 +41,11 @@ export function NewTerminalPicker(props: NewTerminalPickerProps) {
   // written into state via an effect.
   const [explicitRow, setExplicitRow] =
     useState<WorktreeBindingSelectorRow | null>(null);
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
   const activeHostId = useReactiveActiveHostId();
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
 
   // Gated on `isOpen` so the "+" button costs no RPC while idle; the query
   // becomes active only while the popover is open.
@@ -98,17 +102,25 @@ export function NewTerminalPicker(props: NewTerminalPickerProps) {
   const handleLaunch = useCallback(() => {
     if (hasLaunchedRef.current || launchTarget === null) return;
     hasLaunchedRef.current = true;
-    openTileInTab(props.tabId, {
-      id: `term-${uuidv4()}`,
-      instanceId: uuidv4(),
-      type: "terminal",
-      name: DEFAULT_TERMINAL_TITLE,
-      titleSource: "default",
-      hostId: launchTarget.hostId,
-      cwd: launchTarget.cwd,
-    });
+    navigateNested(props.epicId, props.tabId, () =>
+      prepareOpenTileInTabFocusTarget(props.tabId, {
+        id: `term-${uuidv4()}`,
+        instanceId: uuidv4(),
+        type: "terminal",
+        name: DEFAULT_TERMINAL_TITLE,
+        titleSource: "default",
+        hostId: launchTarget.hostId,
+        cwd: launchTarget.cwd,
+      }),
+    );
     setIsOpen(false);
-  }, [launchTarget, openTileInTab, props.tabId]);
+  }, [
+    navigateNested,
+    prepareOpenTileInTabFocusTarget,
+    props.epicId,
+    props.tabId,
+    launchTarget,
+  ]);
 
   const handleSelectRow = useCallback((row: WorktreeBindingSelectorRow) => {
     setExplicitRow(row);

--- a/clients/gui-app/src/components/epic-canvas/workspace-file/workspace-markdown-link-provider.tsx
+++ b/clients/gui-app/src/components/epic-canvas/workspace-file/workspace-markdown-link-provider.tsx
@@ -1,9 +1,9 @@
 import { workspaceFileRefFromWorkspaceMarkdownLink } from "@/components/epic-canvas/workspace-file/workspace-file-link-ref";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import {
   MarkdownLinkContext,
   type MarkdownLinkPolicy,
 } from "@/markdown/links/markdown-link-context";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useMemo, type ReactNode } from "react";
 
 interface WorkspaceMarkdownLinkProviderProps {
@@ -22,9 +22,7 @@ interface WorkspaceMarkdownLinkProviderProps {
 export function WorkspaceMarkdownLinkProvider(
   props: WorkspaceMarkdownLinkProviderProps,
 ) {
-  const openTilePreviewInTab = useEpicCanvasStore(
-    (s) => s.openTilePreviewInTab,
-  );
+  const tileNavigation = useEpicTileNavigation();
   const linkPolicy = useMemo<MarkdownLinkPolicy>(
     () => ({
       openFileLink: (link) => {
@@ -41,16 +39,16 @@ export function WorkspaceMarkdownLinkProvider(
           link.path,
         );
         if (ref === null) return false;
-        openTilePreviewInTab(props.tabId, ref);
+        tileNavigation.openTilePreviewInTab(props.tabId, ref);
         return true;
       },
     }),
     [
-      openTilePreviewInTab,
       props.hostId,
       props.filePath,
       props.tabId,
       props.workspacePath,
+      tileNavigation,
     ],
   );
 

--- a/clients/gui-app/src/components/epic-tabs/__tests__/epic-tab-host.test.tsx
+++ b/clients/gui-app/src/components/epic-tabs/__tests__/epic-tab-host.test.tsx
@@ -6,6 +6,7 @@ import {
   RouterProvider,
   createMemoryHistory,
   createRouter,
+  type RouterHistory,
 } from "@tanstack/react-router";
 import { QueryClient } from "@tanstack/react-query";
 import { routeTree } from "@/routeTree.gen";
@@ -23,6 +24,7 @@ import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { createEmptyCanvas } from "@/stores/epics/canvas/canvas-state";
 import { useLeftPanelStore } from "@/stores/epics/left-panel-store";
 import type { EpicCanvasState } from "@/stores/epics/canvas/types";
+import { createPersistentMemoryHistory } from "@/lib/persistent-history";
 
 // Keep the app shell + cross-cutting bridges out of the way; we only care
 // about the keep-alive pane host under the `/epics` layout.
@@ -110,6 +112,8 @@ vi.mock("@/components/epic-canvas/epic-route-session-body", async () => {
       readonly active: boolean;
       readonly epicId: string;
       readonly tabId: string;
+      readonly focusPaneId: string | undefined;
+      readonly focusTileInstanceId: string | undefined;
     }) => (
       <>
         <SidebarKeybindingBridge tabId={props.tabId} />
@@ -117,6 +121,8 @@ vi.mock("@/components/epic-canvas/epic-route-session-body", async () => {
         <div
           data-active-prop={props.active ? "true" : "false"}
           data-epic-id={props.epicId}
+          data-focus-pane-id={props.focusPaneId ?? ""}
+          data-focus-tile-instance-id={props.focusTileInstanceId ?? ""}
           data-tab-id={props.tabId}
           data-testid="epic-route-session-body"
         />
@@ -175,9 +181,13 @@ function seedTabs(tabIds: ReadonlyArray<readonly [string, string]>): void {
 }
 
 function renderAt(pathname: string) {
+  return renderWithHistory(createMemoryHistory({ initialEntries: [pathname] }));
+}
+
+function renderWithHistory(history: RouterHistory) {
   const router = createRouter({
     routeTree,
-    history: createMemoryHistory({ initialEntries: [pathname] }),
+    history,
     context: {
       queryClient: new QueryClient(),
       getAuthSnapshot: () => useAuthStore.getState(),
@@ -187,6 +197,10 @@ function renderAt(pathname: string) {
   });
   render(<RouterProvider router={router} />);
   return router;
+}
+
+function activeSessionBody(): HTMLElement {
+  return screen.getByTestId("epic-route-session-body");
 }
 
 function paneFor(tabId: string): HTMLElement | null {
@@ -203,6 +217,8 @@ function normalizedEpicSearch() {
     focusArtifactId: undefined,
     focusThreadId: undefined,
     migrationSource: undefined,
+    focusPaneId: undefined,
+    focusTileInstanceId: undefined,
   };
 }
 
@@ -244,6 +260,8 @@ describe("EpicTabHost keep-alive", () => {
           focusArtifactId: undefined,
           focusThreadId: undefined,
           migrationSource: undefined,
+          focusPaneId: undefined,
+          focusTileInstanceId: undefined,
         },
       });
     });
@@ -268,6 +286,8 @@ describe("EpicTabHost keep-alive", () => {
           focusArtifactId: undefined,
           focusThreadId: undefined,
           migrationSource: undefined,
+          focusPaneId: undefined,
+          focusTileInstanceId: undefined,
         },
       });
     });
@@ -275,6 +295,58 @@ describe("EpicTabHost keep-alive", () => {
       expect(paneFor("tab-a")?.getAttribute("data-active")).toBe("true");
     });
     expect(paneFor("tab-b")?.getAttribute("data-active")).toBe("false");
+  });
+
+  it("walks nested focus history inside one retained epic tab", async () => {
+    seedTabs([["tab-a", "epic-a"]]);
+
+    const router = renderWithHistory(
+      createPersistentMemoryHistory(
+        "/epics/epic-a/tab-a?focusPaneId=pane-a&focusTileInstanceId=tile-a",
+        "epic-tab-host-nested-focus-history",
+      ),
+    );
+
+    await waitFor(() => {
+      expect(activeSessionBody().dataset.focusPaneId).toBe("pane-a");
+      expect(activeSessionBody().dataset.focusTileInstanceId).toBe("tile-a");
+    });
+
+    await act(async () => {
+      await router.navigate({
+        to: "/epics/$epicId/$tabId",
+        params: { epicId: "epic-a", tabId: "tab-a" },
+        search: {
+          ...normalizedEpicSearch(),
+          focusPaneId: "pane-b",
+          focusTileInstanceId: "tile-b",
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(activeSessionBody().dataset.focusPaneId).toBe("pane-b");
+      expect(activeSessionBody().dataset.focusTileInstanceId).toBe("tile-b");
+    });
+
+    act(() => {
+      router.history.back();
+    });
+    await waitFor(() => {
+      expect(activeSessionBody().dataset.focusPaneId).toBe("pane-a");
+      expect(activeSessionBody().dataset.focusTileInstanceId).toBe("tile-a");
+    });
+
+    act(() => {
+      router.history.forward();
+    });
+    await waitFor(() => {
+      expect(activeSessionBody().dataset.focusPaneId).toBe("pane-b");
+      expect(activeSessionBody().dataset.focusTileInstanceId).toBe("tile-b");
+    });
+
+    expect(screen.getAllByTestId("epic-route-session-body")).toHaveLength(1);
+    expect(paneFor("tab-a")?.getAttribute("data-active")).toBe("true");
+    expect(useEpicCanvasStore.getState().openTabOrder).toEqual(["tab-a"]);
   });
 
   it("caps mounted panes at MAX_RETAINED_EPIC_TAB_PANES, evicting the least-recently-visited", async () => {
@@ -300,6 +372,8 @@ describe("EpicTabHost keep-alive", () => {
             focusArtifactId: undefined,
             focusThreadId: undefined,
             migrationSource: undefined,
+            focusPaneId: undefined,
+            focusTileInstanceId: undefined,
           },
         });
       });

--- a/clients/gui-app/src/components/epic-tabs/epic-tab-host.tsx
+++ b/clients/gui-app/src/components/epic-tabs/epic-tab-host.tsx
@@ -79,6 +79,8 @@ export function EpicTabHost(props: EpicTabHostProps) {
                   focusedAt={activeSearch?.focusedAt}
                   focusArtifactId={activeSearch?.focusArtifactId}
                   focusThreadId={activeSearch?.focusThreadId}
+                  focusPaneId={activeSearch?.focusPaneId}
+                  focusTileInstanceId={activeSearch?.focusTileInstanceId}
                 />
               </EpicSessionProvider>
             </PaneVisibilityContext.Provider>

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -1045,6 +1045,8 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
         focusArtifactId: undefined,
         focusThreadId: undefined,
         migrationSource: isPhase ? "phase" : undefined,
+        focusPaneId: undefined,
+        focusTileInstanceId: undefined,
       }}
       onClick={openEpicRow}
       aria-label={`Open task ${displayTitle}`}

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/hooks/workspace/use-workspace-binding-remove-entry-mutation";
 import { useWorkspaceBindingAddFolderForClient } from "@/hooks/workspace/use-workspace-binding-add-folder-mutation";
 import { useEpicCreateChat } from "@/hooks/epic/use-epic-chat-mutations";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useResolvedWorkspaceFolders } from "@/hooks/workspace/use-resolved-workspace-folders-query";
 import type { ResolvedFolder } from "@/lib/workspace/resolved-folder";
 import {
@@ -1260,6 +1261,7 @@ interface InEpicSurfaceProps {
 function InEpicSurface(props: InEpicSurfaceProps) {
   const { surface } = props;
   const binding = useHostBinding();
+  const navigateNestedFocus = useEpicNestedFocusNavigation();
   const [editor, dispatchEditor] = useReducer(folderEditorReducer, {
     dirtyPathsSinceResume: new Set<string>(),
   });
@@ -1567,6 +1569,7 @@ function InEpicSurface(props: InEpicSurfaceProps) {
       tabId: surface.tabId,
       targetHostId: pendingCloneHostId,
       directory: binding.directory,
+      navigateNestedFocus,
       createChat: (request, callbacks) => {
         createChat.mutate(request, {
           onSuccess: callbacks.onSuccess,

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
@@ -208,6 +208,8 @@ describe("app route tab-strip navigation", () => {
         focusArtifactId: undefined,
         focusThreadId: undefined,
         migrationSource: undefined,
+        focusPaneId: undefined,
+        focusTileInstanceId: undefined,
       },
     });
     await flushNav();
@@ -224,6 +226,8 @@ describe("app route tab-strip navigation", () => {
         focusArtifactId: undefined,
         focusThreadId: undefined,
         migrationSource: undefined,
+        focusPaneId: undefined,
+        focusTileInstanceId: undefined,
       },
     });
     await flushNav();

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -441,6 +441,8 @@ describe("<TabStrip />", () => {
           focusArtifactId: undefined,
           focusThreadId: undefined,
           migrationSource: undefined,
+          focusPaneId: undefined,
+          focusTileInstanceId: undefined,
         },
       });
       await flushNav();
@@ -796,6 +798,8 @@ describe("<TabStrip />", () => {
         focusArtifactId: undefined,
         focusThreadId: undefined,
         migrationSource: undefined,
+        focusPaneId: undefined,
+        focusTileInstanceId: undefined,
       },
     });
     fireEvent.click(screen.getByTestId("tab-history-history"));
@@ -810,6 +814,8 @@ describe("<TabStrip />", () => {
         focusArtifactId: undefined,
         focusThreadId: undefined,
         migrationSource: undefined,
+        focusPaneId: undefined,
+        focusTileInstanceId: undefined,
       },
     });
     fireEvent.click(screen.getByTestId(`tab-draft-${draftId}`));

--- a/clients/gui-app/src/components/local-host-gate.tsx
+++ b/clients/gui-app/src/components/local-host-gate.tsx
@@ -129,7 +129,7 @@ export function LocalHostGate(props: LocalHostGateProps) {
   // signed-out users, non-local-host shells, non-local selections, and
   // bypass routes (e.g. /settings/shell). Anything else is a signed-in
   // local-host route that must hold until the host is reachable.
-  const passThrough = shouldPassThroughGate({
+  const { passThrough, bypassEligible } = computeGateEligibility({
     authStatus,
     hasLocalHost: runnerHost.hasLocalHost,
     selectedEntry: props.selectedEntry,
@@ -156,7 +156,14 @@ export function LocalHostGate(props: LocalHostGateProps) {
       : props.loading;
 
   if (passThrough) {
-    return <>{props.children}</>;
+    return renderPassThroughGate({
+      bypassEligible,
+      children: props.children,
+      loading: props.loading,
+      canManageHost: provisioning.canManageHost,
+      force: provisioning.force,
+      restartError: provisioning.error,
+    });
   }
 
   // host-busy keep path: the CLI kept a running host that has work in
@@ -172,6 +179,7 @@ export function LocalHostGate(props: LocalHostGateProps) {
     }
     return (
       <HostCompatibilityGate
+        bypass={false}
         source="busy-keep"
         checking={props.loading}
         onRefreshBusy={provisioning.retry}
@@ -205,6 +213,7 @@ export function LocalHostGate(props: LocalHostGateProps) {
   if (isReady) {
     return (
       <HostCompatibilityGate
+        bypass={false}
         source="normal-ready"
         checking={props.loading}
         onRefreshBusy={null}
@@ -240,21 +249,78 @@ export function LocalHostGate(props: LocalHostGateProps) {
   return <>{props.loading}</>;
 }
 
-// True when the gate should render children without requiring a ready
-// host: signed-out users, shells without a local host (mobile/web),
-// explicit non-local selections, and caller-declared bypass routes.
-function shouldPassThroughGate(args: {
+interface PassThroughGateArgs {
+  // `passThrough` is true ONLY because of the `/settings` bypass flag - the
+  // same signed-in, local-host-capable population that also reaches
+  // `isReady` in `LocalHostGate`. That's the boundary this stabilizes:
+  // `bypass` flips on every epic<->settings crossing while the host stays
+  // ready, so THIS population renders through the SAME `HostCompatibilityGate`
+  // chain as `isReady` (`bypass` forcing it to render children outright) so
+  // the two share one element type/tree depth instead of remounting the
+  // whole gated subtree on every crossing. `useHostCompatibility()` is safe
+  // here: `HostCompatibilityProvider` sits above `RouterProvider` and is
+  // always mounted for a signed-in, local-host-capable session by the time
+  // any routed page exists.
+  //
+  // The other `passThrough` reasons (signed-out, no local host, non-local
+  // selection) never depend on `bypass` and never need to match `isReady`'s
+  // tree shape, so they keep the plain short-circuit - which also keeps them
+  // independent of `HostCompatibilityProvider` ever mounting (e.g. a
+  // signed-out user renders immediately).
+  readonly bypassEligible: boolean;
+  readonly children: ReactNode;
+  readonly loading: ReactNode;
+  readonly canManageHost: boolean;
+  readonly force: () => void;
+  readonly restartError: Error | null;
+}
+
+function renderPassThroughGate(args: PassThroughGateArgs): ReactNode {
+  if (!args.bypassEligible) {
+    return <>{args.children}</>;
+  }
+  return (
+    <HostCompatibilityGate
+      bypass
+      source="normal-ready"
+      checking={args.loading}
+      onRefreshBusy={null}
+      onForce={args.canManageHost ? args.force : null}
+      restartError={args.restartError}
+    >
+      {args.children}
+    </HostCompatibilityGate>
+  );
+}
+
+interface GateEligibility {
+  // True when the gate should render children without requiring a ready
+  // host: signed-out users, shells without a local host (mobile/web),
+  // explicit non-local selections, and caller-declared bypass routes.
+  readonly passThrough: boolean;
+  // True for the signed-in, local-host-capable population that can also
+  // reach `isReady` - i.e. `bypass` is the only reason `passThrough` might
+  // be true. `false` for the other short-circuits (signed-out, no local
+  // host, non-local selection), which never depend on `bypass`.
+  readonly bypassEligible: boolean;
+}
+
+function computeGateEligibility(args: {
   readonly authStatus: string;
   readonly hasLocalHost: boolean;
   readonly selectedEntry: HostDirectoryEntry | null;
   readonly bypass: boolean;
-}): boolean {
-  if (args.authStatus !== "signed-in") return true;
-  if (!args.hasLocalHost) return true;
-  if (args.selectedEntry !== null && args.selectedEntry.kind !== "local") {
-    return true;
+}): GateEligibility {
+  if (args.authStatus !== "signed-in") {
+    return { passThrough: true, bypassEligible: false };
   }
-  return args.bypass;
+  if (!args.hasLocalHost) {
+    return { passThrough: true, bypassEligible: false };
+  }
+  if (args.selectedEntry !== null && args.selectedEntry.kind !== "local") {
+    return { passThrough: true, bypassEligible: false };
+  }
+  return { passThrough: args.bypass, bypassEligible: true };
 }
 
 interface ProvisioningLoadingProps {
@@ -439,6 +505,15 @@ interface HostBusyGateProps {
   readonly onRefreshBusy: (() => void) | null;
   readonly onForce: (() => void) | null;
   readonly restartError: Error | null;
+  /**
+   * When `true`, renders `children` outright regardless of `compat.status` -
+   * used by `LocalHostGate`'s `passThrough` branch so it can share this
+   * component's tree shape with the `isReady` branch (see the call site
+   * comment) instead of returning a structurally different element. The
+   * compat hook is still called unconditionally to keep hook order stable
+   * across the bypass flip.
+   */
+  readonly bypass: boolean;
 }
 
 type HostCompatibilityGateSource = "busy-keep" | "normal-ready";
@@ -449,6 +524,9 @@ type HostCompatibilityGateSource = "busy-keep" | "normal-ready";
 // keep flow; only retry copy/wiring differs.
 function HostCompatibilityGate(props: HostBusyGateProps) {
   const compat = useHostCompatibility();
+  if (props.bypass) {
+    return <>{props.children}</>;
+  }
   if (compat.status === "incompatible") {
     return (
       <GateIncompatibleHost

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -1,3 +1,23 @@
+/**
+ * Proves that the resource-monitor popover's owner-open flow commits through
+ * the nested-focus opener boundary instead of raw canvas store mutations
+ * paired with a stale-search `navigateToTabIntent` call. See the decision
+ * artifact "Nested Focus Opener Boundary".
+ *
+ * The resource monitor is a global surface: the owner it opens can live in
+ * the currently active tab, a DIFFERENT open tab, or not be open at all -
+ * unlike same-route openers (chat markdown links, sidebar rows), it must
+ * decide whether to reuse `useEpicNestedFocusNavigation` in place or perform
+ * a cross-route top-level navigation carrying a store-prepared focus target.
+ * `useEpicNestedFocusNavigation` is mocked with a spy that still invokes the
+ * `prepare` callback (mirrors `epic-sidebar-nested-focus-boundary.test.tsx`),
+ * so each assertion checks both that the right boundary path was taken AND
+ * that the underlying `prepare*FocusTarget` store action ran with the right
+ * arguments. The canvas store mock deliberately omits the raw
+ * `openTileInTab` / `setActiveTilePane` / `setActiveTileTab` actions, so a
+ * regression back to calling them directly throws instead of silently
+ * passing.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   act,
@@ -26,23 +46,36 @@ type MockEpicIntent = MockEpicIntentInput & { readonly kind: "epic" };
 
 const routerMock = vi.hoisted(() => ({
   navigate: vi.fn(),
+  pathname: "/epics/epic-1/tab-1",
 }));
 
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => routerMock.navigate,
+  useRouterState: (opts: {
+    readonly select: (state: {
+      readonly location: { readonly pathname: string };
+    }) => unknown;
+  }) => opts.select({ location: { pathname: routerMock.pathname } }),
+}));
+
+const navigateNestedMock = vi.hoisted(() =>
+  vi.fn((_epicId: string, _tabId: string, prepare: () => unknown) => prepare()),
+);
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => navigateNestedMock,
+}));
+
+const historyNavAvailableMock = vi.hoisted(() => ({ enabled: true }));
+
+vi.mock("@/lib/history-navigation/use-history-nav-available", () => ({
+  useHistoryNavAvailable: () => historyNavAvailableMock.enabled,
 }));
 
 const tabNavigationMock = vi.hoisted(() => ({
-  existingEpicTabIntent: vi.fn(
+  existingEpicTabIntentWithNestedFocus: vi.fn(
     (input: MockEpicIntentInput): MockEpicIntent => ({
       kind: "epic",
-      ...input,
-    }),
-  ),
-  openOrFocusEpicIntent: vi.fn(
-    (input: MockEpicIntentInput): MockEpicIntent => ({
-      kind: "epic",
-      tabId: "tab-1",
       ...input,
     }),
   ),
@@ -52,18 +85,14 @@ const tabNavigationMock = vi.hoisted(() => ({
 vi.mock("@/lib/tab-navigation", () => tabNavigationMock);
 
 const canvasMock = vi.hoisted(() => {
-  const openTileInTab = vi.fn();
-  const setActiveTilePane = vi.fn();
-  const setActiveTileTab = vi.fn();
-  const resolveTargetTabForEpic = vi.fn(() => "tab-1");
+  const prepareOpenTileInTabFocusTarget = vi.fn();
+  const prepareSetActiveTileTabFocusTarget = vi.fn();
+  const resolveTargetTabForEpic = vi.fn(() => "tab-2");
   const state = {
-    openTabOrder: ["tab-1"],
+    openTabOrder: ["tab-1", "tab-2"],
     tabsById: {
-      "tab-1": {
-        tabId: "tab-1",
-        epicId: "epic-1",
-        name: "Resource Task",
-      },
+      "tab-1": { tabId: "tab-1", epicId: "epic-1", name: "Resource Task" },
+      "tab-2": { tabId: "tab-2", epicId: "epic-1", name: "Resource Task" },
     },
     canvasByTabId: {
       "tab-1": {
@@ -89,20 +118,49 @@ const canvasMock = vi.hoisted(() => {
         },
         sizesByGroupId: {},
       },
+      "tab-2": {
+        root: {
+          kind: "pane",
+          id: "pane-2",
+          tabInstanceIds: ["tile-term-2"],
+          activeTabId: "tile-term-2",
+          previewTabId: null,
+          activationHistory: ["tile-term-2"],
+        },
+        activePaneId: "pane-2",
+        tilesByInstanceId: {
+          "tile-term-2": {
+            id: "term-2",
+            instanceId: "tile-term-2",
+            type: "terminal",
+            name: "Terminal Beta",
+            titleSource: "manual",
+            hostId: "host-1",
+            cwd: "/work",
+          },
+        },
+        sizesByGroupId: {},
+      },
     },
     artifactTreeByEpicId: {
-      "epic-1": [],
+      "epic-1": [
+        {
+          id: "chat-1",
+          parentId: null,
+          name: "Agent Chat",
+          type: "chat",
+          hostId: "host-1",
+        },
+      ],
     },
-    openTileInTab,
-    setActiveTilePane,
-    setActiveTileTab,
+    prepareOpenTileInTabFocusTarget,
+    prepareSetActiveTileTabFocusTarget,
     resolveTargetTabForEpic,
   };
   return {
     state,
-    openTileInTab,
-    setActiveTilePane,
-    setActiveTileTab,
+    prepareOpenTileInTabFocusTarget,
+    prepareSetActiveTileTabFocusTarget,
     resolveTargetTabForEpic,
   };
 });
@@ -169,15 +227,6 @@ function owner(
         cpuPercent: 2,
         rssBytes: 40 * 1024 * 1024,
       }),
-      resourceProcess({
-        pid: 101,
-        parentPid: 100,
-        rootPid: 100,
-        name: "node",
-        command: "node dev-server.js",
-        cpuPercent: 10,
-        rssBytes: 60 * 1024 * 1024,
-      }),
     ],
     ...over,
   };
@@ -210,23 +259,34 @@ function installStubFactory(): { emit: () => ResourcesStreamCallbacks } {
   };
 }
 
+function renderPopover(): void {
+  render(
+    <TooltipProvider>
+      <ResourcesStreamMount epicId="epic-1" />
+      <ResourceMonitorPopover className={undefined} />
+    </TooltipProvider>,
+  );
+}
+
 afterEach(() => {
   cleanup();
   Reflect.deleteProperty(globalThis, "runnerHost");
   routerMock.navigate.mockReset();
-  tabNavigationMock.existingEpicTabIntent.mockClear();
-  tabNavigationMock.openOrFocusEpicIntent.mockClear();
+  routerMock.pathname = "/epics/epic-1/tab-1";
+  navigateNestedMock.mockClear();
+  historyNavAvailableMock.enabled = true;
+  tabNavigationMock.existingEpicTabIntentWithNestedFocus.mockClear();
   tabNavigationMock.navigateToTabIntent.mockClear();
-  canvasMock.openTileInTab.mockReset();
-  canvasMock.setActiveTilePane.mockReset();
-  canvasMock.setActiveTileTab.mockReset();
-  canvasMock.resolveTargetTabForEpic.mockClear();
+  canvasMock.prepareOpenTileInTabFocusTarget.mockReset();
+  canvasMock.prepareSetActiveTileTabFocusTarget.mockReset();
+  canvasMock.resolveTargetTabForEpic.mockReset();
+  canvasMock.resolveTargetTabForEpic.mockReturnValue("tab-2");
   __setResourcesStreamClientFactoryForTests(null);
   resourcesRegistry.disposeAll();
 });
 
 describe("ResourceMonitorPopover", () => {
-  it("shows global app resources, task process trees, and focuses linked terminal tabs", async () => {
+  it("shows global app resources and task process trees", async () => {
     const stub = installStubFactory();
     const getDesktopMetrics = vi.fn().mockResolvedValue({
       appMetrics: [
@@ -252,12 +312,7 @@ describe("ResourceMonitorPopover", () => {
       },
     });
 
-    render(
-      <TooltipProvider>
-        <ResourcesStreamMount epicId="epic-1" />
-        <ResourceMonitorPopover className={undefined} />
-      </TooltipProvider>,
-    );
+    renderPopover();
 
     act(() => {
       stub.emit().onSnapshot(
@@ -277,21 +332,195 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.getByText("Traycer Host")).not.toBeNull();
     expect(screen.getByText("Resource Task")).not.toBeNull();
     expect(screen.getByText("Terminal Alpha")).not.toBeNull();
-    expect(screen.getByText("node dev-server.js")).not.toBeNull();
     expect(screen.getByText("1 open terminal")).not.toBeNull();
-    expect(screen.queryByText(/terminal processes/)).toBeNull();
+  });
 
-    fireEvent.click(screen.getByText("Terminal Alpha"));
-    expect(canvasMock.setActiveTilePane).toHaveBeenCalledWith(
+  it("commits an already-open owner in the CURRENT tab through the same-route boundary", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [owner({})],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.click(await screen.findByText("Terminal Alpha"));
+
+    // Same-route: must reuse the boundary hook, not a top-level navigation.
+    expect(navigateNestedMock).toHaveBeenCalledWith(
+      "epic-1",
       "tab-1",
-      "pane-1",
+      expect.any(Function),
     );
-    expect(canvasMock.setActiveTileTab).toHaveBeenCalledWith(
+    expect(canvasMock.prepareSetActiveTileTabFocusTarget).toHaveBeenCalledWith(
       "tab-1",
       "pane-1",
       "tile-term-1",
     );
+    expect(
+      tabNavigationMock.existingEpicTabIntentWithNestedFocus,
+    ).not.toHaveBeenCalled();
+    expect(tabNavigationMock.navigateToTabIntent).not.toHaveBeenCalled();
+  });
+
+  it("commits an already-open owner in ANOTHER tab through a single cross-route navigation", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    canvasMock.prepareSetActiveTileTabFocusTarget.mockReturnValue({
+      paneId: "pane-2",
+      tileInstanceId: "tile-term-2",
+    });
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "terminal",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "term-2",
+              },
+              activeProcessName: "vim",
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.click(await screen.findByText("Terminal Beta"));
+
+    // Cross-route: the current-route boundary must NOT be used - the owner's
+    // tab (tab-2) differs from the active route (tab-1).
+    expect(navigateNestedMock).not.toHaveBeenCalled();
+    expect(canvasMock.prepareSetActiveTileTabFocusTarget).toHaveBeenCalledWith(
+      "tab-2",
+      "pane-2",
+      "tile-term-2",
+    );
+    expect(
+      tabNavigationMock.existingEpicTabIntentWithNestedFocus,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        epicId: "epic-1",
+        tabId: "tab-2",
+        nestedFocus: { paneId: "pane-2", tileInstanceId: "tile-term-2" },
+      }),
+    );
     expect(tabNavigationMock.navigateToTabIntent).toHaveBeenCalledTimes(1);
-    expect(canvasMock.openTileInTab).not.toHaveBeenCalled();
+    expect(tabNavigationMock.navigateToTabIntent).toHaveBeenCalledWith(
+      routerMock.navigate,
+      expect.objectContaining({ tabId: "tab-2" }),
+    );
+  });
+
+  it("commits a not-yet-open owner through prepareOpenTileInTabFocusTarget + cross-route navigation", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    canvasMock.resolveTargetTabForEpic.mockReturnValue("tab-2");
+    canvasMock.prepareOpenTileInTabFocusTarget.mockReturnValue({
+      paneId: "pane-2",
+      tileInstanceId: "instance-new",
+    });
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "chat",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "chat-1",
+              },
+              activeProcessName: null,
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.click(await screen.findByText("Agent Chat"));
+
+    expect(canvasMock.resolveTargetTabForEpic).toHaveBeenCalledWith(
+      "epic-1",
+      expect.any(String),
+    );
+    expect(canvasMock.prepareOpenTileInTabFocusTarget).toHaveBeenCalledWith(
+      "tab-2",
+      expect.objectContaining({
+        id: "chat-1",
+        type: "chat",
+        hostId: "host-1",
+      }),
+    );
+    expect(navigateNestedMock).not.toHaveBeenCalled();
+    expect(
+      tabNavigationMock.existingEpicTabIntentWithNestedFocus,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        epicId: "epic-1",
+        tabId: "tab-2",
+        nestedFocus: { paneId: "pane-2", tileInstanceId: "instance-new" },
+      }),
+    );
+    expect(tabNavigationMock.navigateToTabIntent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not carry a prepared nested focus target on browser builds (no persistent history)", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    historyNavAvailableMock.enabled = false;
+    canvasMock.prepareSetActiveTileTabFocusTarget.mockReturnValue({
+      paneId: "pane-2",
+      tileInstanceId: "tile-term-2",
+    });
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "terminal",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "term-2",
+              },
+              activeProcessName: "vim",
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.click(await screen.findByText("Terminal Beta"));
+
+    // The canvas mutation still happens (owner still gets focused), but no
+    // nested search params are written to the URL - matches every other
+    // desktop-only-gated opener's browser-build behavior.
+    expect(canvasMock.prepareSetActiveTileTabFocusTarget).toHaveBeenCalledWith(
+      "tab-2",
+      "pane-2",
+      "tile-term-2",
+    );
+    expect(
+      tabNavigationMock.existingEpicTabIntentWithNestedFocus,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: "tab-2", nestedFocus: null }),
+    );
   });
 });

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate, type UseNavigateResult } from "@tanstack/react-router";
+import {
+  useNavigate,
+  useRouterState,
+  type UseNavigateResult,
+} from "@tanstack/react-router";
 import { v4 as uuidv4 } from "uuid";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -49,10 +53,18 @@ import {
   type DesktopAppProcessGroupUsage,
   type DesktopAppResourceUsage,
 } from "@/lib/resources/desktop-app-resource-usage";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import { useHistoryNavAvailable } from "@/lib/history-navigation/use-history-nav-available";
 import {
-  existingEpicTabIntent,
+  readActiveEpicIdFromPath,
+  readActiveEpicTabIdFromPath,
+} from "@/lib/routes";
+import {
+  existingEpicTabIntentWithNestedFocus,
   navigateToTabIntent,
-  openOrFocusEpicIntent,
+  type EpicRouteFocus,
 } from "@/lib/tab-navigation";
 import { cn } from "@/lib/utils";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
@@ -180,12 +192,21 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
   const projection = useGlobalResourceProjection();
   const canvas = useResourceCanvasSnapshot();
   const navigate = useNavigate();
-  const openTileInTab = useEpicCanvasStore((state) => state.openTileInTab);
-  const setActiveTilePane = useEpicCanvasStore(
-    (state) => state.setActiveTilePane,
+  const navigateNested = useEpicNestedFocusNavigation();
+  const desktopNestedFocusEnabled = useHistoryNavAvailable();
+  const activePathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const activeEpicId = readActiveEpicIdFromPath(activePathname);
+  const activeTabId = readActiveEpicTabIdFromPath(activePathname);
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (state) => state.prepareOpenTileInTabFocusTarget,
   );
-  const setActiveTileTab = useEpicCanvasStore(
-    (state) => state.setActiveTileTab,
+  const prepareSetActiveTileTabFocusTarget = useEpicCanvasStore(
+    (state) => state.prepareSetActiveTileTabFocusTarget,
+  );
+  const resolveTargetTabForEpic = useEpicCanvasStore(
+    (state) => state.resolveTargetTabForEpic,
   );
   const desktopApp = useDesktopAppResourceUsage();
   const summary = useMemo(
@@ -223,10 +244,14 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
     const opened = openResourceOwner({
       row,
       canvas,
-      openTileInTab,
-      setActiveTilePane,
-      setActiveTileTab,
+      prepareOpenTileInTabFocusTarget,
+      prepareSetActiveTileTabFocusTarget,
+      resolveTargetTabForEpic,
       navigate,
+      navigateNested,
+      activeEpicId,
+      activeTabId,
+      desktopNestedFocusEnabled,
     });
     if (opened) props.onClose();
   };
@@ -848,27 +873,43 @@ function sortOwnerRows(
 function openResourceOwner(args: {
   readonly row: OwnerDisplayRow;
   readonly canvas: CanvasResourceSnapshot;
-  readonly openTileInTab: (tabId: string, node: EpicCanvasTileRef) => void;
-  readonly setActiveTilePane: (tabId: string, paneId: string) => void;
-  readonly setActiveTileTab: (
+  readonly prepareOpenTileInTabFocusTarget: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
+  readonly prepareSetActiveTileTabFocusTarget: (
     tabId: string,
     paneId: string,
     tileTabId: string,
-  ) => void;
+  ) => NestedFocusTarget | null;
+  readonly resolveTargetTabForEpic: (
+    epicId: string,
+    name: string | undefined,
+  ) => string;
   readonly navigate: NavigateFn;
+  readonly navigateNested: NavigateNestedFocus;
+  readonly activeEpicId: string | null;
+  readonly activeTabId: string | null;
+  readonly desktopNestedFocusEnabled: boolean;
 }): boolean {
   const location = args.row.location;
   if (location !== null) {
-    args.setActiveTilePane(location.tabId, location.paneId);
-    args.setActiveTileTab(location.tabId, location.paneId, location.tileTabId);
-    navigateToTabIntent(
-      args.navigate,
-      existingEpicTabIntent({
-        epicId: location.epicId,
-        tabId: location.tabId,
-        focus: focusForOwner(args.row.snapshot),
-      }),
-    );
+    commitOwnerFocus({
+      epicId: location.epicId,
+      tabId: location.tabId,
+      focus: focusForOwner(args.row.snapshot),
+      prepare: () =>
+        args.prepareSetActiveTileTabFocusTarget(
+          location.tabId,
+          location.paneId,
+          location.tileTabId,
+        ),
+      navigate: args.navigate,
+      navigateNested: args.navigateNested,
+      activeEpicId: args.activeEpicId,
+      activeTabId: args.activeTabId,
+      desktopNestedFocusEnabled: args.desktopNestedFocusEnabled,
+    });
     return true;
   }
 
@@ -881,28 +922,74 @@ function openResourceOwner(args: {
   }
   const record = findOwnerRecord(args.canvas, snapshot);
   if (record === null) return false;
-  if (record.type !== "chat" && record.type !== "terminal-agent") return false;
-  const targetTabId = useEpicCanvasStore
-    .getState()
-    .resolveTargetTabForEpic(
-      snapshot.owner.epicId,
-      taskLabel(snapshot.owner.epicId, args.canvas),
-    );
-  args.openTileInTab(targetTabId, {
-    id: record.id,
-    instanceId: uuidv4(),
-    type: record.type,
-    name: record.name,
-    hostId: record.hostId,
+  const recordType = record.type;
+  if (recordType !== "chat" && recordType !== "terminal-agent") return false;
+  const targetTabId = args.resolveTargetTabForEpic(
+    snapshot.owner.epicId,
+    taskLabel(snapshot.owner.epicId, args.canvas),
+  );
+  commitOwnerFocus({
+    epicId: snapshot.owner.epicId,
+    tabId: targetTabId,
+    focus: focusForOwner(snapshot),
+    prepare: () =>
+      args.prepareOpenTileInTabFocusTarget(targetTabId, {
+        id: record.id,
+        instanceId: uuidv4(),
+        type: recordType,
+        name: record.name,
+        hostId: record.hostId,
+      }),
+    navigate: args.navigate,
+    navigateNested: args.navigateNested,
+    activeEpicId: args.activeEpicId,
+    activeTabId: args.activeTabId,
+    desktopNestedFocusEnabled: args.desktopNestedFocusEnabled,
   });
+  return true;
+}
+
+/**
+ * Commits an owner's focus target through the nested-focus opener boundary.
+ *
+ * Same-route (the owner's tab is already the active route) delegates to
+ * `useEpicNestedFocusNavigation` so the search patch, duplicate-target skip,
+ * and desktop-only gating stay identical to every other in-place focus
+ * change in the app.
+ *
+ * Cross-route (the owner lives in a different tab, or a different epic, than
+ * the active route) prepares the canvas mutation directly - the canvas store
+ * is global and keyed by tabId, so preparing a background tab is valid -
+ * then commits ONE top-level navigation carrying the prepared nested focus.
+ * Arrival then paints the right pane immediately instead of wiping nested
+ * search and waiting on route-sync canonicalization to self-heal it back in
+ * on a second, asynchronous pass.
+ */
+function commitOwnerFocus(args: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly focus: EpicRouteFocus;
+  readonly prepare: () => NestedFocusTarget | null;
+  readonly navigate: NavigateFn;
+  readonly navigateNested: NavigateNestedFocus;
+  readonly activeEpicId: string | null;
+  readonly activeTabId: string | null;
+  readonly desktopNestedFocusEnabled: boolean;
+}): void {
+  if (args.epicId === args.activeEpicId && args.tabId === args.activeTabId) {
+    args.navigateNested(args.epicId, args.tabId, args.prepare);
+    return;
+  }
+  const nestedFocus = args.prepare();
   navigateToTabIntent(
     args.navigate,
-    openOrFocusEpicIntent({
-      epicId: snapshot.owner.epicId,
-      focus: focusForOwner(snapshot),
+    existingEpicTabIntentWithNestedFocus({
+      epicId: args.epicId,
+      tabId: args.tabId,
+      focus: args.focus,
+      nestedFocus: args.desktopNestedFocusEnabled ? nestedFocus : null,
     }),
   );
-  return true;
 }
 
 function focusForOwner(snapshot: OwnerResourceSnapshotWire) {

--- a/clients/gui-app/src/hooks/agent/__tests__/use-create-tui-agent.test.tsx
+++ b/clients/gui-app/src/hooks/agent/__tests__/use-create-tui-agent.test.tsx
@@ -9,8 +9,12 @@ import type { TuiHarnessId } from "@traycer/protocol/persistence/epic/schemas";
 const hookMocks = vi.hoisted(() => ({
   request: vi.fn<(method: string, payload: unknown) => Promise<unknown>>(),
   openTileInTab: vi.fn(),
+  openTileInPane: vi.fn(),
   markArtifactPendingCreate: vi.fn(),
   unmarkArtifactPendingCreate: vi.fn(),
+  navigateNested: vi.fn(
+    (_epicId: string, _tabId: string, prepare: () => unknown) => prepare(),
+  ),
 }));
 
 const fakeHostClient = {
@@ -29,13 +33,34 @@ vi.mock("@/lib/host/runtime", () => ({
   useHostBinding: () => ({ hostClient: fakeHostClient }),
 }));
 
+// The placeholder open is routed through the nested-focus navigation
+// boundary: `navigateNested` is mocked to synchronously invoke `prepare()`
+// (mirroring `bundle-open-button.test.tsx`), and the `prepare...FocusTarget`
+// store helpers forward to the same `openTileInTab` / `openTileInPane` spies
+// the pre-migration tests asserted on directly, so this proves the boundary
+// is exercised without rewriting every existing assertion.
 vi.mock("@/stores/epics/canvas/store", () => ({
   useEpicCanvasStore: <T,>(selector: (s: unknown) => T): T =>
     selector({
-      openTileInTab: hookMocks.openTileInTab,
+      prepareOpenTileInTabFocusTarget: (tabId: string, node: unknown) => {
+        hookMocks.openTileInTab(tabId, node);
+        return null;
+      },
+      prepareOpenTileInPaneFocusTarget: (
+        tabId: string,
+        paneId: string,
+        node: unknown,
+      ) => {
+        hookMocks.openTileInPane(tabId, paneId, node);
+        return null;
+      },
       markArtifactPendingCreate: hookMocks.markArtifactPendingCreate,
       unmarkArtifactPendingCreate: hookMocks.unmarkArtifactPendingCreate,
     }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => hookMocks.navigateNested,
 }));
 
 vi.mock("sonner", () => ({
@@ -110,8 +135,10 @@ describe("useCreateTuiAgent", () => {
   beforeEach(() => {
     hookMocks.request.mockReset();
     hookMocks.openTileInTab.mockReset();
+    hookMocks.openTileInPane.mockReset();
     hookMocks.markArtifactPendingCreate.mockReset();
     hookMocks.unmarkArtifactPendingCreate.mockReset();
+    hookMocks.navigateNested.mockClear();
   });
 
   afterEach(() => {
@@ -1087,6 +1114,92 @@ describe("useCreateTuiAgent", () => {
       TAB_ID,
       expect.objectContaining({ id: ownerId, type: "terminal-agent" }),
     );
+
+    queryClient.clear();
+  });
+
+  it("routes the active-tile placeholder open through the nested-focus navigation boundary", async () => {
+    const { calls } = setupSequencedMock();
+    const queryClient = makeQueryClient();
+    const { result } = renderHook(() => useCreateTuiAgent(), {
+      wrapper: queryClientWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.create({
+        epicId: EPIC_ID,
+        tabId: TAB_ID,
+        parentId: null,
+        title: "",
+        placement: { kind: "active-tile" },
+        harnessId: "claude",
+        model: null,
+        reasoningEffort: null,
+        agentMode: "regular",
+        forkSourceHarnessSessionId: null,
+        onStatusChange: null,
+        workspaceMode: "inherit",
+        worktreeIntent: null,
+        terminalAgentArgs: null,
+      });
+    });
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(hookMocks.navigateNested).toHaveBeenCalledTimes(1);
+    expect(hookMocks.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      TAB_ID,
+      expect.any(Function),
+    );
+    // The boundary's prepared target actually reached the tab-targeted
+    // opener, not the pane-targeted one.
+    expect(hookMocks.openTileInTab).toHaveBeenCalledTimes(1);
+    expect(hookMocks.openTileInPane).not.toHaveBeenCalled();
+
+    queryClient.clear();
+  });
+
+  it("routes the target-group placeholder open through prepareOpenTileInPaneFocusTarget via the navigation boundary", async () => {
+    const { calls } = setupSequencedMock();
+    const queryClient = makeQueryClient();
+    const { result } = renderHook(() => useCreateTuiAgent(), {
+      wrapper: queryClientWrapper(queryClient),
+    });
+    const groupId = "group-1";
+
+    await act(async () => {
+      await result.current.create({
+        epicId: EPIC_ID,
+        tabId: TAB_ID,
+        parentId: null,
+        title: "",
+        placement: { kind: "target-group", groupId },
+        harnessId: "claude",
+        model: null,
+        reasoningEffort: null,
+        agentMode: "regular",
+        forkSourceHarnessSessionId: null,
+        onStatusChange: null,
+        workspaceMode: "inherit",
+        worktreeIntent: null,
+        terminalAgentArgs: null,
+      });
+    });
+
+    expect(calls.length).toBeGreaterThan(0);
+    expect(hookMocks.navigateNested).toHaveBeenCalledTimes(1);
+    expect(hookMocks.navigateNested).toHaveBeenCalledWith(
+      EPIC_ID,
+      TAB_ID,
+      expect.any(Function),
+    );
+    expect(hookMocks.openTileInPane).toHaveBeenCalledTimes(1);
+    expect(hookMocks.openTileInPane).toHaveBeenCalledWith(
+      TAB_ID,
+      groupId,
+      expect.objectContaining({ type: "terminal-agent" }),
+    );
+    expect(hookMocks.openTileInTab).not.toHaveBeenCalled();
 
     queryClient.clear();
   });

--- a/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
+++ b/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
@@ -17,6 +17,7 @@ import { useEpicCreateTuiAgentForClient } from "@/hooks/epic/use-epic-tui-agent-
 import { useAgentStartTerminalSession } from "@/hooks/agent/use-prepare-tui-launch-mutation";
 import { useWorktreeCreateForClient } from "@/hooks/worktree/use-worktree-create-mutation";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { type HostRpcRegistry, useHostClient } from "@/lib/host";
 import { tuiAgentDisplayTitle } from "@/lib/display-title";
@@ -201,8 +202,13 @@ export function useCreateTuiAgentForClient(
   const startSession = useAgentStartTerminalSession(hostClient);
   const createTuiAgent = useEpicCreateTuiAgentForClient(hostClient);
   const worktreeCreate = useWorktreeCreateForClient(hostClient);
-  const openTileInTab = useEpicCanvasStore((s) => s.openTileInTab);
-  const openTileInPane = useEpicCanvasStore((s) => s.openTileInPane);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
+  const prepareOpenTileInPaneFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInPaneFocusTarget,
+  );
   const markArtifactPendingCreate = useEpicCanvasStore(
     (s) => s.markArtifactPendingCreate,
   );
@@ -249,9 +255,18 @@ export function useCreateTuiAgentForClient(
           pendingTuiHarnessId: input.harnessId,
         };
         if (input.placement.kind === "target-group") {
-          openTileInPane(input.tabId, input.placement.groupId, placeholderRef);
+          const groupId = input.placement.groupId;
+          navigateNested(input.epicId, input.tabId, () =>
+            prepareOpenTileInPaneFocusTarget(
+              input.tabId,
+              groupId,
+              placeholderRef,
+            ),
+          );
         } else {
-          openTileInTab(input.tabId, placeholderRef);
+          navigateNested(input.epicId, input.tabId, () =>
+            prepareOpenTileInTabFocusTarget(input.tabId, placeholderRef),
+          );
         }
       };
 
@@ -360,8 +375,9 @@ export function useCreateTuiAgentForClient(
     [
       startSession,
       createTuiAgent,
-      openTileInTab,
-      openTileInPane,
+      navigateNested,
+      prepareOpenTileInTabFocusTarget,
+      prepareOpenTileInPaneFocusTarget,
       markArtifactPendingCreate,
       unmarkArtifactPendingCreate,
       placeholderHostId,

--- a/clients/gui-app/src/hooks/epic/use-epic-nested-focus-navigation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-nested-focus-navigation.ts
@@ -1,0 +1,62 @@
+import { useCallback } from "react";
+import {
+  type RouterHistory,
+  type UseNavigateResult,
+  useRouter,
+} from "@tanstack/react-router";
+import {
+  navigateNestedFocus,
+  type NavigateNestedFocus,
+} from "@/lib/epic-nested-focus-navigation";
+
+interface NestedFocusRouterLike {
+  readonly history: RouterHistory;
+  readonly navigate: UseNavigateResult<string>;
+  readonly state: {
+    readonly location: {
+      readonly pathname: string;
+      readonly search: Readonly<Record<string, unknown>>;
+    };
+  };
+}
+
+export function useEpicNestedFocusNavigation(): NavigateNestedFocus {
+  const router: unknown = useRouter({ warn: false });
+  return useCallback(
+    (targetEpicId, targetTabId, prepare) => {
+      if (!isNestedFocusRouterLike(router)) {
+        const target = prepare();
+        return target;
+      }
+      return navigateNestedFocus(
+        {
+          history: router.history,
+          navigate: router.navigate,
+          getLocation: () => ({
+            pathname: router.state.location.pathname,
+            search: router.state.location.search,
+          }),
+        },
+        { epicId: targetEpicId, tabId: targetTabId },
+        prepare,
+      );
+    },
+    [router],
+  );
+}
+
+function isNestedFocusRouterLike(
+  value: unknown,
+): value is NestedFocusRouterLike {
+  if (!isRecord(value)) return false;
+  if (!("history" in value) || !isRecord(value.history)) return false;
+  if (typeof value.navigate !== "function") return false;
+  if (!isRecord(value.state)) return false;
+  if (!isRecord(value.state.location)) return false;
+  if (typeof value.state.location.pathname !== "string") return false;
+  return isRecord(value.state.location.search);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/clients/gui-app/src/hooks/epic/use-epic-tile-navigation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-tile-navigation.ts
@@ -1,0 +1,115 @@
+import { useCallback, useMemo } from "react";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import {
+  useEpicCanvasStore,
+  type EpicCanvasStore,
+} from "@/stores/epics/canvas/store";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+
+export interface EpicTileNavigation {
+  readonly openTileInTab: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
+  readonly openTilePreviewInTab: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
+  readonly openTileInEpic: (
+    epicId: string,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
+  readonly openTilePreviewInEpic: (
+    epicId: string,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
+}
+
+export function useEpicTileNavigation(): EpicTileNavigation {
+  const navigateNested = useEpicNestedFocusNavigation();
+
+  const openTileInTab = useCallback(
+    (tabId: string, node: EpicCanvasTileRef): NestedFocusTarget | null => {
+      const store = useEpicCanvasStore.getState();
+      return openPreparedTileInTab({
+        store,
+        navigateNested,
+        tabId,
+        node,
+        preview: false,
+      });
+    },
+    [navigateNested],
+  );
+
+  const openTilePreviewInTab = useCallback(
+    (tabId: string, node: EpicCanvasTileRef): NestedFocusTarget | null => {
+      const store = useEpicCanvasStore.getState();
+      return openPreparedTileInTab({
+        store,
+        navigateNested,
+        tabId,
+        node,
+        preview: true,
+      });
+    },
+    [navigateNested],
+  );
+
+  const openTileInEpic = useCallback(
+    (epicId: string, node: EpicCanvasTileRef): NestedFocusTarget | null => {
+      const tabId = useEpicCanvasStore
+        .getState()
+        .resolveTargetTabForEpic(epicId, undefined);
+      return openTileInTab(tabId, node);
+    },
+    [openTileInTab],
+  );
+
+  const openTilePreviewInEpic = useCallback(
+    (epicId: string, node: EpicCanvasTileRef): NestedFocusTarget | null => {
+      const tabId = useEpicCanvasStore
+        .getState()
+        .resolveTargetTabForEpic(epicId, undefined);
+      return openTilePreviewInTab(tabId, node);
+    },
+    [openTilePreviewInTab],
+  );
+
+  return useMemo(
+    () => ({
+      openTileInTab,
+      openTilePreviewInTab,
+      openTileInEpic,
+      openTilePreviewInEpic,
+    }),
+    [
+      openTileInEpic,
+      openTileInTab,
+      openTilePreviewInEpic,
+      openTilePreviewInTab,
+    ],
+  );
+}
+
+function openPreparedTileInTab(args: {
+  readonly store: EpicCanvasStore;
+  readonly navigateNested: NavigateNestedFocus;
+  readonly tabId: string;
+  readonly node: EpicCanvasTileRef;
+  readonly preview: boolean;
+}): NestedFocusTarget | null {
+  const epicId = args.store.tabsById[args.tabId]?.epicId ?? null;
+  const prepare = () =>
+    args.preview
+      ? useEpicCanvasStore
+          .getState()
+          .prepareOpenTilePreviewInTabFocusTarget(args.tabId, args.node)
+      : useEpicCanvasStore
+          .getState()
+          .prepareOpenTileInTabFocusTarget(args.tabId, args.node);
+  if (epicId === null) return prepare();
+  return args.navigateNested(epicId, args.tabId, prepare);
+}

--- a/clients/gui-app/src/lib/__tests__/epic-nested-focus-navigation.test.ts
+++ b/clients/gui-app/src/lib/__tests__/epic-nested-focus-navigation.test.ts
@@ -1,0 +1,137 @@
+import { createMemoryHistory } from "@tanstack/react-router";
+import { describe, expect, it, vi } from "vitest";
+import {
+  navigateNestedFocus,
+  type NestedFocusLocation,
+} from "@/lib/epic-nested-focus-navigation";
+import { createPersistentMemoryHistory } from "@/lib/persistent-history";
+
+interface CapturedNavigateOptions {
+  readonly search: (prev: Record<string, unknown>) => unknown;
+  readonly replace: boolean;
+}
+
+function isCapturedNavigateOptions(
+  value: unknown,
+): value is CapturedNavigateOptions {
+  if (typeof value !== "object" || value === null) return false;
+  if (!("search" in value) || !("replace" in value)) return false;
+  return (
+    typeof value.search === "function" && typeof value.replace === "boolean"
+  );
+}
+
+function firstNavigateOptions(
+  calls: ReadonlyArray<ReadonlyArray<unknown>>,
+): CapturedNavigateOptions {
+  const firstCall = calls[0];
+  const options = firstCall[0];
+  if (!isCapturedNavigateOptions(options)) {
+    throw new Error("expected navigate search options");
+  }
+  return options;
+}
+
+describe("navigateNestedFocus", () => {
+  it("pushes a nested search patch for persistent desktop history", () => {
+    const history = createPersistentMemoryHistory(
+      "/epics/epic-1/tab-1",
+      "nested-focus-navigation",
+    );
+    const navigate = vi.fn();
+
+    navigateNestedFocus(
+      {
+        history,
+        navigate,
+        getLocation: (): NestedFocusLocation => ({
+          pathname: "/epics/epic-1/tab-1",
+          search: {},
+        }),
+      },
+      { epicId: "epic-1", tabId: "tab-1" },
+      () => ({ paneId: "pane-1", tileInstanceId: "tile-1" }),
+    );
+
+    const options = firstNavigateOptions(navigate.mock.calls);
+    expect(options.replace).toBe(false);
+    expect(options.search({ focusArtifactId: "artifact-1" })).toMatchObject({
+      focusArtifactId: "artifact-1",
+      focusPaneId: "pane-1",
+      focusTileInstanceId: "tile-1",
+    });
+  });
+
+  it("does not navigate duplicate focus targets", () => {
+    const history = createPersistentMemoryHistory(
+      "/epics/epic-1/tab-1?focusPaneId=pane-1&focusTileInstanceId=tile-1",
+      "nested-focus-navigation-duplicate",
+    );
+    const navigate = vi.fn();
+
+    navigateNestedFocus(
+      {
+        history,
+        navigate,
+        getLocation: (): NestedFocusLocation => ({
+          pathname: "/epics/epic-1/tab-1",
+          search: {
+            focusPaneId: "pane-1",
+            focusTileInstanceId: "tile-1",
+          },
+        }),
+      },
+      { epicId: "epic-1", tabId: "tab-1" },
+      () => ({ paneId: "pane-1", tileInstanceId: "tile-1" }),
+    );
+
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not write nested params for memory history", () => {
+    const history = createMemoryHistory({
+      initialEntries: ["/epics/epic-1/tab-1"],
+    });
+    const navigate = vi.fn();
+
+    const target = navigateNestedFocus(
+      {
+        history,
+        navigate,
+        getLocation: (): NestedFocusLocation => ({
+          pathname: "/epics/epic-1/tab-1",
+          search: {},
+        }),
+      },
+      { epicId: "epic-1", tabId: "tab-1" },
+      () => ({ paneId: "pane-1", tileInstanceId: "tile-1" }),
+    );
+
+    expect(target).toEqual({ paneId: "pane-1", tileInstanceId: "tile-1" });
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate null preparation targets", () => {
+    const history = createPersistentMemoryHistory(
+      "/epics/epic-1/tab-1",
+      "nested-focus-navigation-null",
+    );
+    const navigate = vi.fn();
+
+    const target = navigateNestedFocus(
+      {
+        history,
+        navigate,
+        getLocation: (): NestedFocusLocation => ({
+          pathname: "/epics/epic-1/tab-1",
+          search: {},
+        }),
+      },
+      { epicId: "epic-1", tabId: "tab-1" },
+      () => null,
+    );
+
+    expect(target).toBeNull();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/lib/__tests__/epic-nested-focus-navigation.test.ts
+++ b/clients/gui-app/src/lib/__tests__/epic-nested-focus-navigation.test.ts
@@ -134,4 +134,33 @@ describe("navigateNestedFocus", () => {
     expect(target).toBeNull();
     expect(navigate).not.toHaveBeenCalled();
   });
+
+  it("prepares and returns the target without navigating when the current route does not match the tab", () => {
+    const history = createPersistentMemoryHistory(
+      "/epics/epic-1/tab-1",
+      "nested-focus-navigation-cross-route",
+    );
+    const navigate = vi.fn();
+    let prepareCalled = false;
+
+    const target = navigateNestedFocus(
+      {
+        history,
+        navigate,
+        getLocation: (): NestedFocusLocation => ({
+          pathname: "/epics/epic-2/tab-2",
+          search: {},
+        }),
+      },
+      { epicId: "epic-1", tabId: "tab-1" },
+      () => {
+        prepareCalled = true;
+        return { paneId: "pane-1", tileInstanceId: "tile-1" };
+      },
+    );
+
+    expect(prepareCalled).toBe(true);
+    expect(target).toEqual({ paneId: "pane-1", tileInstanceId: "tile-1" });
+    expect(navigate).not.toHaveBeenCalled();
+  });
 });

--- a/clients/gui-app/src/lib/__tests__/epic-nested-focus-route.test.ts
+++ b/clients/gui-app/src/lib/__tests__/epic-nested-focus-route.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  areNestedFocusTargetsEqual,
+  buildNestedFocusSearchPatch,
+  getCurrentNestedFocusTarget,
+  isNestedFocusTargetValid,
+  parseNestedFocusTargetFromHref,
+  parseNestedFocusTargetFromSearch,
+  resolveNestedFocusTarget,
+} from "@/lib/epic-nested-focus-route";
+import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import type {
+  TileGroup,
+  TileLayoutNode,
+  TilePane,
+} from "@/stores/epics/canvas/tile-tree";
+
+const HOST_ID = "host-1";
+
+function tile(instanceId: string): EpicNodeRef {
+  return {
+    id: `artifact-${instanceId}`,
+    instanceId,
+    type: "spec",
+    name: instanceId,
+    hostId: HOST_ID,
+  };
+}
+
+function pane(
+  id: string,
+  tabInstanceIds: ReadonlyArray<string>,
+  activeTabId: string | null,
+): TilePane {
+  return {
+    kind: "pane",
+    id,
+    tabInstanceIds,
+    activeTabId,
+    previewTabId: null,
+    activationHistory: activeTabId === null ? [] : [activeTabId],
+  };
+}
+
+function group(id: string, children: ReadonlyArray<TileLayoutNode>): TileGroup {
+  return {
+    kind: "group",
+    id,
+    direction: "horizontal",
+    children,
+  };
+}
+
+function canvas(root: TileLayoutNode | null, activePaneId: string | null) {
+  const tileRefs = collectTileIds(root).map(tile);
+  return {
+    root,
+    activePaneId,
+    tilesByInstanceId: Object.fromEntries(
+      tileRefs.map((ref) => [ref.instanceId, ref]),
+    ),
+    sizesByGroupId: {},
+  };
+}
+
+function collectTileIds(node: TileLayoutNode | null): ReadonlyArray<string> {
+  if (node === null) return [];
+  if (node.kind === "pane") return node.tabInstanceIds;
+  return node.children.flatMap(collectTileIds);
+}
+
+describe("nested epic focus route helpers", () => {
+  it("parses absent and blank nested search params as no target", () => {
+    expect(parseNestedFocusTargetFromSearch({})).toBeNull();
+    expect(
+      parseNestedFocusTargetFromSearch({
+        focusPaneId: " ",
+        focusTileInstanceId: "tile-1",
+      }),
+    ).toBeNull();
+  });
+
+  it("parses pane-only and blank-tile targets", () => {
+    expect(
+      parseNestedFocusTargetFromSearch({
+        focusPaneId: " pane-1 ",
+      }),
+    ).toEqual({
+      paneId: "pane-1",
+      tileInstanceId: undefined,
+    });
+    expect(
+      parseNestedFocusTargetFromSearch({
+        focusPaneId: "pane-1",
+        focusTileInstanceId: "\t",
+      }),
+    ).toEqual({
+      paneId: "pane-1",
+      tileInstanceId: undefined,
+    });
+  });
+
+  it("reads the explicit active pane and active tab from canvas state", () => {
+    const state = canvas(
+      group("root", [
+        pane("pane-1", ["tile-1"], "tile-1"),
+        pane("pane-2", ["tile-2"], "tile-2"),
+      ]),
+      "pane-2",
+    );
+
+    expect(getCurrentNestedFocusTarget(state)).toEqual({
+      paneId: "pane-2",
+      tileInstanceId: "tile-2",
+    });
+  });
+
+  it("falls back to the first pane tab when activeTabId is null", () => {
+    const state = canvas(pane("pane-1", ["tile-1", "tile-2"], null), "pane-1");
+
+    expect(getCurrentNestedFocusTarget(state)).toEqual({
+      paneId: "pane-1",
+      tileInstanceId: "tile-1",
+    });
+  });
+
+  it("returns pane-only current focus for an empty active pane", () => {
+    const state = canvas(pane("pane-1", [], null), "pane-1");
+
+    expect(getCurrentNestedFocusTarget(state)).toEqual({
+      paneId: "pane-1",
+      tileInstanceId: undefined,
+    });
+  });
+
+  it("validates pane-only targets and rejects stale pane or tile targets", () => {
+    const state = canvas(pane("pane-1", ["tile-1"], "tile-1"), "pane-1");
+
+    expect(
+      isNestedFocusTargetValid(state, {
+        paneId: "pane-1",
+        tileInstanceId: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      resolveNestedFocusTarget(state, {
+        paneId: "stale-pane",
+        tileInstanceId: undefined,
+      }),
+    ).toBeNull();
+    expect(
+      resolveNestedFocusTarget(state, {
+        paneId: "pane-1",
+        tileInstanceId: "stale-tile",
+      }),
+    ).toBeNull();
+  });
+
+  it("compares route targets by pane and tile identity", () => {
+    expect(
+      areNestedFocusTargetsEqual(
+        { paneId: "pane-1", tileInstanceId: "tile-1" },
+        { paneId: "pane-1", tileInstanceId: "tile-1" },
+      ),
+    ).toBe(true);
+    expect(
+      areNestedFocusTargetsEqual(
+        { paneId: "pane-1", tileInstanceId: "tile-1" },
+        { paneId: "pane-1", tileInstanceId: undefined },
+      ),
+    ).toBe(false);
+  });
+
+  it("builds search patches that set or clear nested focus params", () => {
+    expect(
+      buildNestedFocusSearchPatch({
+        paneId: "pane-1",
+        tileInstanceId: "tile-1",
+      }),
+    ).toEqual({
+      focusPaneId: "pane-1",
+      focusTileInstanceId: "tile-1",
+    });
+    expect(buildNestedFocusSearchPatch(null)).toEqual({
+      focusPaneId: undefined,
+      focusTileInstanceId: undefined,
+    });
+  });
+
+  it("parses nested params from persisted history hrefs", () => {
+    expect(
+      parseNestedFocusTargetFromHref(
+        "/epics/epic-1/tab-1?focusPaneId=pane-1&focusTileInstanceId=tile-1#tail",
+      ),
+    ).toEqual({
+      paneId: "pane-1",
+      tileInstanceId: "tile-1",
+    });
+    expect(parseNestedFocusTargetFromHref("/epics/epic-1/tab-1")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
+++ b/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
@@ -603,4 +603,277 @@ describe("PersistentHistoryController", () => {
     expect(persisted.entries.length).toBe(100);
     expect(persisted.entries[persisted.index]).toBe(current);
   });
+
+  describe("adjacent-duplicate collapse on prune", () => {
+    it("collapses entries that become adjacent duplicates after a dead-entry prune (split -> close -> prune)", () => {
+      const focusedTab =
+        "/epics/epic-a/tab-a?focusPaneId=3f92d763&focusTileInstanceId=54fbf184";
+      const splitPane = "/epics/epic-a/tab-a?focusPaneId=c2bd4f75";
+
+      // Splitting an empty pane pushes a pane-only entry.
+      const history = seedStack("window-a", [focusedTab, splitPane]);
+      const controller = controllerOf(history);
+
+      // Closing that pane re-derives the same fallback focus as the original
+      // tab, so its push lands on an href byte-identical to `focusedTab` -
+      // but it is not yet ADJACENT to it (the pane-only entry sits between).
+      history.push(focusedTab);
+      expect(controller.getEntries()).toEqual([
+        focusedTab,
+        splitPane,
+        focusedTab,
+      ]);
+      expect(controller.getIndex()).toBe(2);
+
+      // The eager liveness pruner kills the now-dead pane-only entry, which
+      // makes the two `focusedTab` entries adjacent.
+      const changed = controller.prune((href) => href === splitPane);
+
+      expect(changed).toBe(true);
+      expect(controller.getEntries()).toEqual([focusedTab]);
+      expect(controller.getIndex()).toBe(0);
+      expect(controller.canGoBack()).toBe(false);
+      expect(controller.canGoForward()).toBe(false);
+    });
+
+    it("keeps back/forward free of dead clicks across a collapsed pair (current is the LATER duplicate)", () => {
+      const history = seedStack("window-a", [
+        "/epics/epic-z/tab-z",
+        "/epics/epic-a/tab-a",
+        "/draft/dead-pane",
+      ]);
+      const controller = controllerOf(history);
+
+      // Land back on a duplicate of an earlier entry, with a dead entry
+      // between them.
+      history.push("/epics/epic-a/tab-a");
+      expect(controller.getEntries()).toEqual([
+        "/epics/epic-z/tab-z",
+        "/epics/epic-a/tab-a",
+        "/draft/dead-pane",
+        "/epics/epic-a/tab-a",
+      ]);
+      expect(controller.getIndex()).toBe(3);
+
+      const changed = controller.prune((href) => href === "/draft/dead-pane");
+
+      expect(changed).toBe(true);
+      expect(controller.getEntries()).toEqual([
+        "/epics/epic-z/tab-z",
+        "/epics/epic-a/tab-a",
+      ]);
+      expect(controller.getIndex()).toBe(1);
+      expect(controller.canGoBack()).toBe(true);
+      expect(controller.canGoForward()).toBe(false);
+
+      // A real back step must land on a genuinely different location, not a
+      // dead click that only moves the cursor.
+      history.back();
+      expect(controller.getIndex()).toBe(0);
+      expect(history.location.pathname).toBe("/epics/epic-z/tab-z");
+      expect(history.location.state.__TSR_index).toBe(0);
+
+      history.go(1);
+      expect(controller.getIndex()).toBe(1);
+      expect(history.location.pathname).toBe("/epics/epic-a/tab-a");
+      expect(history.location.state.__TSR_index).toBe(1);
+    });
+
+    it("collapses when the current entry is the EARLIER of two adjacent duplicates", () => {
+      const history = seedStack("window-a", [
+        "/epics/epic-a/tab-a",
+        "/draft/dead-forward",
+        "/epics/epic-a/tab-a",
+      ]);
+      const controller = controllerOf(history);
+
+      // Step back onto the first occurrence; the duplicate and the dead
+      // entry are now forward history.
+      history.go(-2);
+      expect(controller.getIndex()).toBe(0);
+
+      const changed = controller.prune(
+        (href) => href === "/draft/dead-forward",
+      );
+
+      expect(changed).toBe(true);
+      expect(controller.getEntries()).toEqual(["/epics/epic-a/tab-a"]);
+      expect(controller.getIndex()).toBe(0);
+      expect(controller.canGoBack()).toBe(false);
+      expect(controller.canGoForward()).toBe(false);
+    });
+
+    it("persists the collapsed stack", () => {
+      const history = seedStack("window-a", [
+        "/epics/epic-a/tab-a",
+        "/draft/dead-pane",
+      ]);
+      history.push("/epics/epic-a/tab-a");
+
+      const controller = controllerOf(history);
+      controller.prune((href) => href === "/draft/dead-pane");
+
+      expect(readPersisted("window-a")).toEqual({
+        entries: ["/epics/epic-a/tab-a"],
+        index: 0,
+      });
+    });
+
+    it("returns true for a collapse-only prune when no entry is dead but the stack already has adjacent duplicates", () => {
+      // Simulates a legacy persisted stack seeded directly (bypassing the
+      // push/replace collapse guards), already carrying an adjacent
+      // duplicate pair unrelated to any dead entry.
+      window.localStorage.setItem(
+        storageKey("window-a"),
+        JSON.stringify({
+          entries: [
+            "/epics/epic-a/tab-a",
+            "/epics/epic-x/tab-x",
+            "/epics/epic-x/tab-x",
+            "/epics/epic-b/tab-b",
+          ],
+          index: 3,
+        }),
+      );
+
+      const history = createPersistentMemoryHistory(null, "window-a");
+      const controller = controllerOf(history);
+      expect(controller.getEntries()).toEqual([
+        "/epics/epic-a/tab-a",
+        "/epics/epic-x/tab-x",
+        "/epics/epic-x/tab-x",
+        "/epics/epic-b/tab-b",
+      ]);
+      expect(controller.getIndex()).toBe(3);
+
+      // Nothing is dead - the collapse alone must still report a change.
+      const changed = controller.prune(() => false);
+
+      expect(changed).toBe(true);
+      expect(controller.getEntries()).toEqual([
+        "/epics/epic-a/tab-a",
+        "/epics/epic-x/tab-x",
+        "/epics/epic-b/tab-b",
+      ]);
+      expect(controller.getIndex()).toBe(2);
+    });
+
+    it("collapses a run of more than two adjacent duplicates into a single entry, current marker included", () => {
+      window.localStorage.setItem(
+        storageKey("window-a"),
+        JSON.stringify({
+          entries: [
+            "/epics/epic-a/tab-a",
+            "/epics/epic-a/tab-a",
+            "/epics/epic-a/tab-a",
+          ],
+          index: 1,
+        }),
+      );
+
+      const history = createPersistentMemoryHistory(null, "window-a");
+      const controller = controllerOf(history);
+      expect(controller.getIndex()).toBe(1);
+
+      const changed = controller.prune(() => false);
+
+      expect(changed).toBe(true);
+      expect(controller.getEntries()).toEqual(["/epics/epic-a/tab-a"]);
+      expect(controller.getIndex()).toBe(0);
+      expect(controller.canGoBack()).toBe(false);
+      expect(controller.canGoForward()).toBe(false);
+    });
+
+    it("is a no-op when no entry is dead and no adjacent duplicates exist", () => {
+      const history = seedStack("window-a", [
+        "/epics/epic-a/tab-a",
+        "/epics/epic-b/tab-b",
+      ]);
+      const controller = controllerOf(history);
+
+      const changed = controller.prune(() => false);
+
+      expect(changed).toBe(false);
+      expect(controller.getEntries()).toEqual([
+        "/epics/epic-a/tab-a",
+        "/epics/epic-b/tab-b",
+      ]);
+      expect(controller.getIndex()).toBe(1);
+    });
+  });
+
+  describe("adjacent-duplicate collapse on pushState", () => {
+    it("does not create a duplicate entry when the pushed href matches the cursor's entry", () => {
+      const history = seedStack("window-a", [
+        "/epics/epic-a/tab-a",
+        "/epics/epic-b/tab-b",
+      ]);
+      const controller = controllerOf(history);
+
+      history.push("/epics/epic-b/tab-b");
+
+      expect(controller.getEntries()).toEqual([
+        "/epics/epic-a/tab-a",
+        "/epics/epic-b/tab-b",
+      ]);
+      expect(controller.getIndex()).toBe(1);
+      expect(history.location.pathname).toBe("/epics/epic-b/tab-b");
+      expect(history.location.state.__TSR_index).toBe(1);
+
+      expect(readPersisted("window-a")).toEqual({
+        entries: ["/epics/epic-a/tab-a", "/epics/epic-b/tab-b"],
+        index: 1,
+      });
+    });
+
+    it("does not create a duplicate entry when pushing the same href as the very first entry", () => {
+      const history = seedStack("window-a", ["/epics/epic-a/tab-a"]);
+      const controller = controllerOf(history);
+
+      history.push("/epics/epic-a/tab-a");
+
+      expect(controller.getEntries()).toEqual(["/epics/epic-a/tab-a"]);
+      expect(controller.getIndex()).toBe(0);
+      expect(history.location.state.__TSR_index).toBe(0);
+    });
+
+    it("does not create a duplicate when pushing onto a truncated tail at a mid-stack index", () => {
+      const history = seedStack("window-a", [
+        "/epics/epic-a/tab-a",
+        "/epics/epic-b/tab-b",
+        "/epics/epic-c/tab-c",
+      ]);
+      const controller = controllerOf(history);
+
+      // Walk back to the middle entry, then push its own href again - the
+      // forward entry gets truncated as usual, and the push must land on the
+      // (now-tail) existing entry rather than duplicating it.
+      history.back();
+      expect(controller.getIndex()).toBe(1);
+
+      history.push("/epics/epic-b/tab-b");
+
+      expect(controller.getEntries()).toEqual([
+        "/epics/epic-a/tab-a",
+        "/epics/epic-b/tab-b",
+      ]);
+      expect(controller.getIndex()).toBe(1);
+      expect(controller.canGoForward()).toBe(false);
+      expect(history.location.pathname).toBe("/epics/epic-b/tab-b");
+      expect(history.location.state.__TSR_index).toBe(1);
+    });
+
+    it("still pushes a new entry when the href differs from the cursor's entry", () => {
+      const history = seedStack("window-a", ["/epics/epic-a/tab-a"]);
+      const controller = controllerOf(history);
+
+      history.push("/epics/epic-b/tab-b");
+
+      expect(controller.getEntries()).toEqual([
+        "/epics/epic-a/tab-a",
+        "/epics/epic-b/tab-b",
+      ]);
+      expect(controller.getIndex()).toBe(1);
+    });
+  });
 });

--- a/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
+++ b/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
@@ -611,6 +611,114 @@ describe("PersistentHistoryController", () => {
     expect(history.location.state.__TSR_index).toBe(2);
   });
 
+  it("collapses an adjacent duplicate AHEAD created by an in-place replace (no dead forward step)", () => {
+    // Mirrors a cold-load redirect: the current entry is replaced with a path
+    // that already sits ONE STEP AHEAD in the stack (e.g. the guard
+    // replacing a restored overlay entry with the tab route it redirects to,
+    // when that tab route was already the next persisted entry).
+    const history = seedStack("window-a", [
+      "/epics/epic-a/tab-a",
+      "/epics/epic-b/tab-b?settingsOverlay=true",
+      "/settings/general",
+    ]);
+    const controller = controllerOf(history);
+
+    history.back();
+    expect(controller.getIndex()).toBe(1);
+
+    history.replace("/settings/general");
+
+    // The forward duplicate is dropped; the cursor stays on the (now sole)
+    // settings entry instead of leaving a dead forward step ahead of it.
+    expect(controller.getEntries()).toEqual([
+      "/epics/epic-a/tab-a",
+      "/settings/general",
+    ]);
+    expect(controller.getIndex()).toBe(1);
+    expect(controller.canGoForward()).toBe(false);
+    expect(history.location.pathname).toBe("/settings/general");
+
+    // Proof the dead step is gone: canGoForward is false, so a `go(1)` at the
+    // boundary is a guarded no-op in the app's `goForward` helper - but the
+    // controller-level state itself must already reflect no forward entry.
+    expect(controller.getEntries().length).toBe(2);
+  });
+
+  it("restamps __TSR_index contiguously after an ahead-collapse", () => {
+    const history = seedStack("window-a", [
+      "/epics/epic-a/tab-a",
+      "/epics/epic-b/tab-b?settingsOverlay=true",
+      "/settings/general",
+      "/epics/epic-c/tab-c",
+    ]);
+    const controller = controllerOf(history);
+
+    history.go(-2);
+    expect(controller.getIndex()).toBe(1);
+
+    history.replace("/settings/general");
+
+    expect(controller.getEntries()).toEqual([
+      "/epics/epic-a/tab-a",
+      "/settings/general",
+      "/epics/epic-c/tab-c",
+    ]);
+    expect(controller.getIndex()).toBe(1);
+
+    // Walk forward and back across the shifted tail entry; a stale
+    // `__TSR_index` would land `go(n)` on the wrong array position.
+    history.go(1);
+    expect(controller.getIndex()).toBe(2);
+    expect(history.location.pathname).toBe("/epics/epic-c/tab-c");
+    expect(history.location.state.__TSR_index).toBe(2);
+
+    history.back();
+    expect(controller.getIndex()).toBe(1);
+    expect(history.location.pathname).toBe("/settings/general");
+    expect(history.location.state.__TSR_index).toBe(1);
+  });
+
+  it("collapses duplicates on BOTH sides of a single replace", () => {
+    // Current entry sits between two neighbours that both become identical to
+    // it once replaced - the whole run must collapse to a single entry.
+    const history = seedStack("window-a", [
+      "/epics/epic-a/tab-a",
+      "/epics/epic-b/tab-b",
+      "/epics/epic-a/tab-a",
+    ]);
+    const controller = controllerOf(history);
+
+    history.back();
+    expect(controller.getIndex()).toBe(1);
+
+    history.replace("/epics/epic-a/tab-a");
+
+    expect(controller.getEntries()).toEqual(["/epics/epic-a/tab-a"]);
+    expect(controller.getIndex()).toBe(0);
+    expect(controller.canGoBack()).toBe(false);
+    expect(controller.canGoForward()).toBe(false);
+    expect(history.location.state.__TSR_index).toBe(0);
+  });
+
+  it("persists the collapsed stack after an ahead-deduping replace", () => {
+    const history = seedStack("window-a", [
+      "/epics/epic-a/tab-a",
+      "/epics/epic-b/tab-b?historyOverlay=true",
+      "/epics/epic-b/tab-b",
+    ]);
+    const controller = controllerOf(history);
+
+    history.back();
+    expect(controller.getIndex()).toBe(1);
+
+    history.replace("/epics/epic-b/tab-b");
+
+    expect(readPersisted("window-a")).toEqual({
+      entries: ["/epics/epic-a/tab-a", "/epics/epic-b/tab-b"],
+      index: 1,
+    });
+  });
+
   it("persists the collapsed stack after a deduping replace", () => {
     const history = seedStack("window-a", [
       "/epics/epic-a/tab-a",

--- a/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
+++ b/clients/gui-app/src/lib/__tests__/persistent-history.test.ts
@@ -644,6 +644,34 @@ describe("PersistentHistoryController", () => {
     expect(controller.getEntries().length).toBe(2);
   });
 
+  it("keeps the replacement state (not the collapsed neighbour's) on a behind-collapse", () => {
+    const history = seedStack("window-a", [
+      "/epics/epic-a/tab-a",
+      "/epics/epic-b/tab-b",
+      "/epics/epic-b/tab-b?settingsOverlay=true",
+    ]);
+    const controller = controllerOf(history);
+
+    // Record the OLD state key of the entry the collapse will merge into.
+    history.back();
+    const oldNeighbourKey = history.location.state.key;
+    history.forward();
+    expect(controller.getIndex()).toBe(2);
+
+    history.replace("/epics/epic-b/tab-b");
+
+    // The neighbour was dropped and the just-replaced entry survived: the
+    // surviving location carries the state THIS replace minted, not the old
+    // neighbour's - matching the location TanStack caches after a replace.
+    expect(controller.getEntries()).toEqual([
+      "/epics/epic-a/tab-a",
+      "/epics/epic-b/tab-b",
+    ]);
+    expect(controller.getIndex()).toBe(1);
+    expect(history.location.state.key).not.toBe(oldNeighbourKey);
+    expect(history.location.state.__TSR_index).toBe(1);
+  });
+
   it("restamps __TSR_index contiguously after an ahead-collapse", () => {
     const history = seedStack("window-a", [
       "/epics/epic-a/tab-a",

--- a/clients/gui-app/src/lib/commands/actions/__tests__/new-chat.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/new-chat.test.ts
@@ -12,11 +12,14 @@ import {
 import type { CreateChatMutationInput } from "@/hooks/epic/use-epic-chat-mutations";
 import {
   openCreatedChatWhenProjected,
+  openCreatedChatWhenProjectedWithNavigation,
   openNewChatInActiveTile,
   type CreateChatCommand,
   type CreateChatCommandCallbacks,
   type CreatedChatOpenIntent,
 } from "@/lib/commands/actions";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
 import type { WorktreeIntent } from "@traycer/protocol/host/worktree-schemas";
 import { paneTabRefs } from "@/stores/epics/canvas/actions";
 import { collectPanes, findPaneById } from "@/stores/epics/canvas/tile-tree";
@@ -152,6 +155,31 @@ function openIntentsRecorder(): {
   };
 }
 
+interface NestedFocusCall {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly target: NestedFocusTarget | null;
+}
+
+function nestedFocusRecorder(): {
+  readonly calls: NestedFocusCall[];
+  readonly navigateNestedFocus: NavigateNestedFocus;
+} {
+  const calls: NestedFocusCall[] = [];
+  return {
+    calls,
+    navigateNestedFocus: (epicId, tabId, prepare) => {
+      const target = prepare();
+      calls.push({
+        epicId,
+        tabId,
+        target,
+      });
+      return target;
+    },
+  };
+}
+
 describe("new chat command actions", () => {
   beforeEach(() => {
     resetCanvasStore();
@@ -250,6 +278,48 @@ describe("new chat command actions", () => {
     expect(useEpicCanvasStore.getState().artifactTreeByEpicId[EPIC_ID]).toEqual(
       [],
     );
+  });
+
+  it("routes projected chat opens through supplied nested focus navigation", () => {
+    const activeGroupId = seedActiveGroup();
+    const navigation = nestedFocusRecorder();
+
+    openCreatedChatWhenProjectedWithNavigation({
+      intent: {
+        kind: "active-tile",
+        epicId: EPIC_ID,
+        tabId: TAB_ID,
+        chatId: "host-chat",
+        hostId: "test-host",
+      },
+      navigateNestedFocus: navigation.navigateNestedFocus,
+    });
+
+    expect(navigation.calls).toHaveLength(0);
+
+    registryMock.projectChat({ id: "host-chat", title: "Host chat" });
+
+    expect(navigation.calls).toHaveLength(1);
+    const call = navigation.calls[0];
+    expect(call.epicId).toBe(EPIC_ID);
+    expect(call.tabId).toBe(TAB_ID);
+    expect(call.target?.paneId).toBe(activeGroupId);
+    expect(typeof call.target?.tileInstanceId).toBe("string");
+    const target = call.target;
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
+    if (
+      target === null ||
+      target.tileInstanceId === undefined ||
+      canvas === undefined
+    ) {
+      throw new Error("expected route-aware projection to open a chat tile");
+    }
+    expect(canvas.tilesByInstanceId[target.tileInstanceId]).toMatchObject({
+      id: "host-chat",
+      type: "chat",
+      name: "Host chat",
+      hostId: "test-host",
+    });
   });
 
   describe("caller-owned cancellation", () => {

--- a/clients/gui-app/src/lib/commands/actions/__tests__/open-into-target.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/open-into-target.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { openTileIntoTargetGroup } from "@/lib/commands/actions/open-into-target";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import { paneTabRefs } from "@/stores/epics/canvas/actions";
+import { findPaneById } from "@/stores/epics/canvas/tile-tree";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type {
   EpicCanvasTileRef,
@@ -14,8 +18,10 @@ const REF: EpicNodeRef = {
   hostId: "host-A",
 };
 
-const ORIGINAL_OPEN_TILE_IN_GROUP =
-  useEpicCanvasStore.getState().openTileInPane;
+function resetCanvasStore(): void {
+  window.localStorage.clear();
+  useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+}
 
 function installOpenTileInGroupMock() {
   const mock =
@@ -24,28 +30,150 @@ function installOpenTileInGroupMock() {
   return mock;
 }
 
-afterEach(() => {
-  useEpicCanvasStore.setState({
-    openTileInPane: ORIGINAL_OPEN_TILE_IN_GROUP,
+/**
+ * A seeded tab with an active pane, so a `splitPaneEmptyRightInTab` target
+ * group can be carved out - mirrors `new-chat.test.ts`'s `seedActiveGroup`.
+ */
+function seedTabWithEmptyTargetGroup(): {
+  readonly tabId: string;
+  readonly targetGroupId: string;
+} {
+  const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+  useEpicCanvasStore.getState().openTileInTab(tabId, {
+    id: "existing-spec",
+    instanceId: "inst-existing-spec",
+    type: "spec",
+    name: "Existing spec",
+    hostId: "test-host",
   });
+  const sourceGroupId =
+    useEpicCanvasStore.getState().canvasByTabId[tabId]?.activePaneId ?? null;
+  if (sourceGroupId === null) {
+    throw new Error("Expected active group after seeding canvas.");
+  }
+  const targetGroupId = useEpicCanvasStore
+    .getState()
+    .splitPaneEmptyRightInTab(tabId, sourceGroupId);
+  if (targetGroupId === null) {
+    throw new Error("Expected a new empty group after split.");
+  }
+  return { tabId, targetGroupId };
+}
+
+interface NestedFocusCall {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly target: NestedFocusTarget | null;
+}
+
+function nestedFocusRecorder(): {
+  readonly calls: NestedFocusCall[];
+  readonly navigateNestedFocus: NavigateNestedFocus;
+} {
+  const calls: NestedFocusCall[] = [];
+  return {
+    calls,
+    navigateNestedFocus: (epicId, tabId, prepare) => {
+      const target = prepare();
+      calls.push({ epicId, tabId, target });
+      return target;
+    },
+  };
+}
+
+afterEach(() => {
+  resetCanvasStore();
 });
 
 describe("openTileIntoTargetGroup", () => {
   it("routes to canvas openTileInPane with the bound tab + group", () => {
     const mock = installOpenTileInGroupMock();
-    openTileIntoTargetGroup({ tabId: "tab-1", groupId: "group-1", ref: REF });
+    openTileIntoTargetGroup({
+      tabId: "tab-1",
+      groupId: "group-1",
+      ref: REF,
+      navigateNestedFocus: undefined,
+    });
     expect(mock).toHaveBeenCalledWith("tab-1", "group-1", REF);
   });
 
   it("no-ops when the tab id is missing", () => {
     const mock = installOpenTileInGroupMock();
-    openTileIntoTargetGroup({ tabId: null, groupId: "group-1", ref: REF });
+    openTileIntoTargetGroup({
+      tabId: null,
+      groupId: "group-1",
+      ref: REF,
+      navigateNestedFocus: undefined,
+    });
     expect(mock).not.toHaveBeenCalled();
   });
 
   it("no-ops when the target group id is missing", () => {
     const mock = installOpenTileInGroupMock();
-    openTileIntoTargetGroup({ tabId: "tab-1", groupId: null, ref: REF });
+    openTileIntoTargetGroup({
+      tabId: "tab-1",
+      groupId: null,
+      ref: REF,
+      navigateNestedFocus: undefined,
+    });
     expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("routes the open through the nested-focus navigation boundary when the tab resolves to an epic", () => {
+    const { tabId, targetGroupId } = seedTabWithEmptyTargetGroup();
+    const navigation = nestedFocusRecorder();
+
+    openTileIntoTargetGroup({
+      tabId,
+      groupId: targetGroupId,
+      ref: REF,
+      navigateNestedFocus: navigation.navigateNestedFocus,
+    });
+
+    // The boundary was invoked (proving the open routes through it), the
+    // `prepare` callback it ran resolved a real focus target, and the raw
+    // canvas mutation underneath still happened.
+    expect(navigation.calls).toHaveLength(1);
+    const call = navigation.calls[0];
+    expect(call.epicId).toBe("epic-1");
+    expect(call.tabId).toBe(tabId);
+    expect(call.target?.paneId).toBe(targetGroupId);
+    expect(typeof call.target?.tileInstanceId).toBe("string");
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+    if (canvas === undefined) throw new Error("expected a resolvable canvas");
+    const targetPane = findPaneById(canvas.root, targetGroupId);
+    if (targetPane === null) throw new Error("expected a resolvable pane");
+    expect(paneTabRefs(canvas, targetPane).map((tab) => tab.id)).toEqual([
+      "art-a",
+    ]);
+  });
+
+  it("falls back to a raw canvas mutation without navigating when no navigation seam is available", () => {
+    const { tabId, targetGroupId } = seedTabWithEmptyTargetGroup();
+    const mock = installOpenTileInGroupMock();
+
+    openTileIntoTargetGroup({
+      tabId,
+      groupId: targetGroupId,
+      ref: REF,
+      navigateNestedFocus: undefined,
+    });
+
+    expect(mock).toHaveBeenCalledWith(tabId, targetGroupId, REF);
+  });
+
+  it("falls back to a raw canvas mutation without navigating when the tab has no resolvable epic", () => {
+    const mock = installOpenTileInGroupMock();
+    const navigation = nestedFocusRecorder();
+
+    openTileIntoTargetGroup({
+      tabId: "unknown-tab",
+      groupId: "group-1",
+      ref: REF,
+      navigateNestedFocus: navigation.navigateNestedFocus,
+    });
+
+    expect(navigation.calls).toHaveLength(0);
+    expect(mock).toHaveBeenCalledWith("unknown-tab", "group-1", REF);
   });
 });

--- a/clients/gui-app/src/lib/commands/actions/clone-chat-on-host-switch.ts
+++ b/clients/gui-app/src/lib/commands/actions/clone-chat-on-host-switch.ts
@@ -1,10 +1,12 @@
 import type { IHostDirectoryService } from "@traycer-clients/shared/host-client/host-runtime";
 import {
   openCreatedChatWhenProjected,
+  openCreatedChatWhenProjectedWithNavigation,
   openNewChatInActiveTile,
   type CancelFn,
   type CreateChatCommand,
 } from "@/lib/commands/actions/new-chat";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 
 /**
  * Clone-not-migrate flow for switching a chat tab's bound host: chat tabs
@@ -18,6 +20,7 @@ export interface CloneChatOnHostSwitchArgs {
   readonly targetHostId: string;
   readonly directory: IHostDirectoryService;
   readonly createChat: CreateChatCommand;
+  readonly navigateNestedFocus: NavigateNestedFocus | null;
 }
 
 export function cloneChatOnHostSwitch(
@@ -30,6 +33,12 @@ export function cloneChatOnHostSwitch(
     hostId: args.targetHostId,
     worktreeIntent: null,
     createChat: args.createChat,
-    openWhenProjected: openCreatedChatWhenProjected,
+    openWhenProjected: (intent) =>
+      args.navigateNestedFocus === null
+        ? openCreatedChatWhenProjected(intent)
+        : openCreatedChatWhenProjectedWithNavigation({
+            intent,
+            navigateNestedFocus: args.navigateNestedFocus,
+          }),
   });
 }

--- a/clients/gui-app/src/lib/commands/actions/history-navigation.ts
+++ b/clients/gui-app/src/lib/commands/actions/history-navigation.ts
@@ -27,7 +27,12 @@ export interface HistoryNavRouter {
  */
 export function goBack(router: HistoryNavRouter): void {
   const controller = getHistoryController(router.history);
-  if (controller === null || !controller.canGoBack()) return;
+  if (controller === null) {
+    return;
+  }
+  if (!controller.canGoBack()) {
+    return;
+  }
   router.history.go(-1);
   trackHistoryNavigationUsed("back");
 }
@@ -40,7 +45,12 @@ export function goBack(router: HistoryNavRouter): void {
  */
 export function goForward(router: HistoryNavRouter): void {
   const controller = getHistoryController(router.history);
-  if (controller === null || !controller.canGoForward()) return;
+  if (controller === null) {
+    return;
+  }
+  if (!controller.canGoForward()) {
+    return;
+  }
   router.history.go(1);
   trackHistoryNavigationUsed("forward");
 }

--- a/clients/gui-app/src/lib/commands/actions/index.ts
+++ b/clients/gui-app/src/lib/commands/actions/index.ts
@@ -10,11 +10,13 @@ export { duplicateEpicTab } from "./duplicate-tab";
 export { goBack, goForward, type HistoryNavRouter } from "./history-navigation";
 export {
   openCreatedChatWhenProjected,
+  openCreatedChatWhenProjectedWithNavigation,
   openNewChatInActiveTile,
   type CancelFn,
   type CreateChatCommandCallbacks,
   type CreateChatCommand,
   type CreatedChatOpenIntent,
+  type OpenCreatedChatWhenProjectedWithNavigationArgs,
   type NewChatSplitPosition,
 } from "./new-chat";
 export {

--- a/clients/gui-app/src/lib/commands/actions/new-chat.ts
+++ b/clients/gui-app/src/lib/commands/actions/new-chat.ts
@@ -24,6 +24,7 @@ import type { CreateChatMutationInput } from "@/hooks/epic/use-epic-chat-mutatio
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { deriveWorkspaceMode } from "@/lib/worktree/workspace-mode";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 
 const CHAT_PROJECTION_WAIT_MS = 30_000;
 
@@ -79,6 +80,11 @@ export type OpenWhenProjected = (intent: CreatedChatOpenIntent) => CancelFn;
 
 export type CancelFn = () => void;
 
+export interface OpenCreatedChatWhenProjectedWithNavigationArgs {
+  readonly intent: CreatedChatOpenIntent;
+  readonly navigateNestedFocus: NavigateNestedFocus;
+}
+
 export interface OpenNewChatInActiveTileArgs {
   readonly epicId: string;
   readonly tabId: string;
@@ -127,7 +133,23 @@ export function openNewChatInActiveTile(
 export function openCreatedChatWhenProjected(
   intent: CreatedChatOpenIntent,
 ): CancelFn {
-  if (openProjectedChat(intent)) return noop;
+  return openCreatedChatWhenProjectedInternal(intent, rawNestedFocus);
+}
+
+export function openCreatedChatWhenProjectedWithNavigation(
+  args: OpenCreatedChatWhenProjectedWithNavigationArgs,
+): CancelFn {
+  return openCreatedChatWhenProjectedInternal(
+    args.intent,
+    args.navigateNestedFocus,
+  );
+}
+
+function openCreatedChatWhenProjectedInternal(
+  intent: CreatedChatOpenIntent,
+  navigateNestedFocus: NavigateNestedFocus,
+): CancelFn {
+  if (openProjectedChat(intent, navigateNestedFocus)) return noop;
   const handle = getOpenEpicRegistry().get(intent.epicId);
   if (handle === null) return noop;
 
@@ -144,12 +166,15 @@ export function openCreatedChatWhenProjected(
   };
   const unsubscribe = handle.store.subscribe(() => {
     if (cancelled) return;
-    if (!openProjectedChat(intent)) return;
+    if (!openProjectedChat(intent, navigateNestedFocus)) return;
     cleanup();
   });
   timeoutId = window.setTimeout(cleanup, CHAT_PROJECTION_WAIT_MS);
   return cleanup;
 }
+
+const rawNestedFocus: NavigateNestedFocus = (_epicId, _tabId, prepare) =>
+  prepare();
 
 function buildCreateChatRequest(
   epicId: string,
@@ -169,7 +194,10 @@ function buildCreateChatRequest(
   };
 }
 
-function openProjectedChat(intent: CreatedChatOpenIntent): boolean {
+function openProjectedChat(
+  intent: CreatedChatOpenIntent,
+  navigateNestedFocus: NavigateNestedFocus,
+): boolean {
   const handle = getOpenEpicRegistry().get(intent.epicId);
   if (handle === null) return false;
   const state = handle.store.getState();
@@ -186,18 +214,28 @@ function openProjectedChat(intent: CreatedChatOpenIntent): boolean {
   };
   const canvas = useEpicCanvasStore.getState();
   if (intent.kind === "active-tile") {
-    canvas.openTileInTab(intent.tabId, node);
+    navigateNestedFocus(intent.epicId, intent.tabId, () =>
+      canvas.prepareOpenTileInTabFocusTarget(intent.tabId, node),
+    );
     return true;
   }
   if (intent.kind === "target-group") {
-    canvas.openTileInPane(intent.tabId, intent.groupId, node);
+    navigateNestedFocus(intent.epicId, intent.tabId, () =>
+      canvas.prepareOpenTileInPaneFocusTarget(
+        intent.tabId,
+        intent.groupId,
+        node,
+      ),
+    );
     return true;
   }
-  canvas.splitPaneWithNode(
-    intent.tabId,
-    intent.targetGroupId,
-    intent.position,
-    node,
+  navigateNestedFocus(intent.epicId, intent.tabId, () =>
+    canvas.prepareSplitPaneWithNodeFocusTarget(
+      intent.tabId,
+      intent.targetGroupId,
+      intent.position,
+      node,
+    ),
   );
   return true;
 }

--- a/clients/gui-app/src/lib/commands/actions/open-into-target.ts
+++ b/clients/gui-app/src/lib/commands/actions/open-into-target.ts
@@ -3,14 +3,26 @@
  *
  * Canonical opener action: place a tile ref into the palette's bound target
  * group as a fresh instance (no dedup), via the canvas store's
- * `openTileInPane` (see `stores/epics/canvas/actions.ts` → Decision 2 of the
- * pane-opener tech plan). Both the "open" command source's leaves and any
- * future manual UI route through here per the palette → manual-UI parity rule.
+ * `prepareOpenTileInPaneFocusTarget` (see `stores/epics/canvas/store.ts` →
+ * Decision 2 of the pane-opener tech plan). Both the "open" command source's
+ * leaves and any future manual UI route through here per the palette →
+ * manual-UI parity rule.
  *
- * No-ops when there is no bound target group or no active header tab - the
- * opener is only reachable in open-into-target mode, but guarding keeps the
- * delegate safe to call unconditionally from a leaf's `run`.
+ * Routes through the nested-focus navigation boundary (see the
+ * "Nested Focus Opener Boundary" decision) so the open both mutates the
+ * canvas AND writes the `focusPaneId`/`focusTileInstanceId` route params -
+ * `navigateNestedFocus` is threaded in from the caller's `CommandContext.router`
+ * (the same seam `KeybindingRouter.navigateNestedFocus` uses for non-React
+ * dispatch). When the tab has no resolvable epic (e.g. the tab record doesn't
+ * exist yet) or no navigation seam is available, the raw canvas mutation still
+ * runs - only the route write is skipped, matching every other
+ * `prepareX...FocusTarget` caller's no-op-when-no-router-context contract.
+ *
+ * No-ops entirely when there is no bound target group or no active header
+ * tab - the opener is only reachable in open-into-target mode, but guarding
+ * keeps the delegate safe to call unconditionally from a leaf's `run`.
  */
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 
@@ -20,13 +32,28 @@ export interface OpenTileIntoTargetGroupArgs {
   /** Bound canvas tile group id (the opener target). */
   readonly groupId: string | null;
   readonly ref: EpicCanvasTileRef;
+  /**
+   * Nested-focus navigation seam from the caller's `CommandContext.router`.
+   * `undefined` when the router adapter carries no navigation seam (e.g. a
+   * bare test double) - the raw canvas mutation still runs.
+   */
+  readonly navigateNestedFocus: NavigateNestedFocus | undefined;
 }
 
 export function openTileIntoTargetGroup(
   args: OpenTileIntoTargetGroupArgs,
 ): void {
   if (args.tabId === null || args.groupId === null) return;
-  useEpicCanvasStore
-    .getState()
-    .openTileInPane(args.tabId, args.groupId, args.ref);
+  const tabId = args.tabId;
+  const groupId = args.groupId;
+  const prepare = () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareOpenTileInPaneFocusTarget(tabId, groupId, args.ref);
+  const epicId = useEpicCanvasStore.getState().tabsById[tabId]?.epicId ?? null;
+  if (epicId === null || args.navigateNestedFocus === undefined) {
+    prepare();
+    return;
+  }
+  args.navigateNestedFocus(epicId, tabId, prepare);
 }

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
@@ -76,6 +76,8 @@ vi.mock("@/stores/command-palette/command-palette-store", () => ({
 import { useFilesOpenerItems } from "@/lib/commands/sources/open/files-subpage";
 import { useDiffOpenerItems } from "@/lib/commands/sources/open/diff-subpage";
 
+const navigateNestedFocusSpy = vi.fn();
+
 function noopRouter(): KeybindingRouter {
   return {
     getPathname: () => "/",
@@ -91,6 +93,7 @@ function noopRouter(): KeybindingRouter {
     isHistoryNavAvailable: () => false,
     canGoBack: () => false,
     canGoForward: () => false,
+    navigateNestedFocus: navigateNestedFocusSpy,
   };
 }
 
@@ -228,6 +231,9 @@ describe("Files opener sub-page", () => {
     runById(fileItems, "open:files:/ws/alpha:src/a.ts");
     const opened = lastTileOpen();
     expect(opened.groupId).toBe("group-1");
+    // Proves the opener leaf threads the ctx.router navigation seam through
+    // to openTileIntoTargetGroup instead of bypassing it.
+    expect(opened.navigateNestedFocus).toBe(navigateNestedFocusSpy);
     expect(opened.ref.type).toBe("workspace-file");
     expect(opened.ref.id).toContain("src%2Fa.ts");
   });
@@ -331,6 +337,9 @@ describe("Diff opener sub-page", () => {
     runById(diffItems, "open:diff:/ws/alpha:src/changed.ts:unstaged");
     const opened = lastTileOpen();
     expect(opened.groupId).toBe("group-1");
+    // Proves the opener leaf threads the ctx.router navigation seam through
+    // to openTileIntoTargetGroup instead of bypassing it.
+    expect(opened.navigateNestedFocus).toBe(navigateNestedFocusSpy);
     expect(opened.ref.type).toBe("git-diff");
   });
 

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
@@ -9,6 +9,7 @@ import type {
 import type { CommandContext, CommandItem } from "@/lib/commands/types";
 import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
 import type { OpenTileIntoTargetGroupArgs } from "@/lib/commands/actions/open-into-target";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
 import { getBasename } from "@/lib/path/cross-platform-path";
 import { useSettingsStore } from "@/stores/settings/settings-store";
@@ -76,7 +77,7 @@ vi.mock("@/stores/command-palette/command-palette-store", () => ({
 import { useFilesOpenerItems } from "@/lib/commands/sources/open/files-subpage";
 import { useDiffOpenerItems } from "@/lib/commands/sources/open/diff-subpage";
 
-const navigateNestedFocusSpy = vi.fn();
+const navigateNestedFocusSpy = vi.fn<NavigateNestedFocus>();
 
 function noopRouter(): KeybindingRouter {
   return {

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
@@ -187,6 +187,8 @@ import { useArtifactsOpenerItems } from "@/lib/commands/sources/open/artifacts-s
 import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
 import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
 
+const navigateNestedFocusSpy = vi.fn();
+
 function noopRouter(): KeybindingRouter {
   return {
     getPathname: () => "/",
@@ -202,6 +204,7 @@ function noopRouter(): KeybindingRouter {
     isHistoryNavAvailable: () => false,
     canGoBack: () => false,
     canGoForward: () => false,
+    navigateNestedFocus: navigateNestedFocusSpy,
   };
 }
 
@@ -275,6 +278,9 @@ describe("Chats opener sub-page", () => {
     expect(opened.tabId).toBe("tab-1");
     expect(opened.ref.id).toBe("c1");
     expect(opened.ref.type).toBe("chat");
+    // Proves the "existing" opener leaf threads the ctx.router navigation
+    // seam through instead of bypassing it.
+    expect(opened.navigateNestedFocus).toBe(navigateNestedFocusSpy);
   });
 });
 
@@ -296,10 +302,12 @@ describe("Terminals opener sub-page", () => {
     expect(created.ref.hostId).toBe("host-2");
     expect(created.ref.cwd).toBe("/work/traycer-wt/feature-x");
     expect(created.ref.name).toBe("New Terminal");
+    expect(created.navigateNestedFocus).toBe(navigateNestedFocusSpy);
     runById(items, "open:terminals:term-1");
     const existing = lastTileOpen();
     expect(existing.ref.id).toBe("term-1");
     expect(existing.ref.type).toBe("terminal");
+    expect(existing.navigateNestedFocus).toBe(navigateNestedFocusSpy);
   });
 });
 
@@ -312,6 +320,7 @@ describe("Artifacts opener sub-page", () => {
     expect(opened.groupId).toBe("group-1");
     expect(opened.ref.id).toBe("s1");
     expect(opened.ref.type).toBe("spec");
+    expect(opened.navigateNestedFocus).toBe(navigateNestedFocusSpy);
   });
 });
 
@@ -331,6 +340,7 @@ describe("TUI opener sub-page", () => {
     expect(opened.groupId).toBe("group-1");
     expect(opened.ref.id).toBe("a1");
     expect(opened.ref.type).toBe("terminal-agent");
+    expect(opened.navigateNestedFocus).toBe(navigateNestedFocusSpy);
   });
 
   it("Create new TUI agent opens the modal in terminal mode into the target", () => {

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
@@ -5,6 +5,7 @@ import type { WorktreeIntent } from "@traycer/protocol/host/worktree-schemas";
 import type { CommandContext, CommandItem } from "@/lib/commands/types";
 import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
 import type { OpenTileIntoTargetGroupArgs } from "@/lib/commands/actions/open-into-target";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 import {
   EMPTY_PROJECTED_SLICES,
   type ArtifactProjection,
@@ -187,7 +188,7 @@ import { useArtifactsOpenerItems } from "@/lib/commands/sources/open/artifacts-s
 import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
 import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
 
-const navigateNestedFocusSpy = vi.fn();
+const navigateNestedFocusSpy = vi.fn<NavigateNestedFocus>();
 
 function noopRouter(): KeybindingRouter {
   return {

--- a/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
@@ -65,6 +65,7 @@ function changedFileLeaves(
             runningDir: workspacePath,
             file,
           }),
+          navigateNestedFocus: ctx.router.navigateNestedFocus,
         }),
     }),
   );

--- a/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
@@ -67,6 +67,7 @@ function fileLeaves(args: FileLeavesArgs): ReadonlyArray<CommandItem> {
           tabId: ctx.activeTabId,
           groupId: ctx.targetGroupId,
           ref,
+          navigateNestedFocus: ctx.router.navigateNestedFocus,
         });
       },
     }),

--- a/clients/gui-app/src/lib/commands/sources/open/open-leaf.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/open-leaf.ts
@@ -107,6 +107,7 @@ export function openerExistingLeaf(
         tabId: ctx.activeTabId,
         groupId: ctx.targetGroupId,
         ref,
+        navigateNestedFocus: ctx.router.navigateNestedFocus,
       }),
   });
 }

--- a/clients/gui-app/src/lib/commands/sources/open/terminals-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/terminals-subpage.ts
@@ -70,6 +70,7 @@ function terminalFolderItem(
           hostId: row.hostId,
           cwd: row.runningDir,
         },
+        navigateNestedFocus: ctx.router.navigateNestedFocus,
       });
     },
   });

--- a/clients/gui-app/src/lib/epic-nested-focus-navigation.ts
+++ b/clients/gui-app/src/lib/epic-nested-focus-navigation.ts
@@ -1,0 +1,83 @@
+import {
+  type RouterHistory,
+  type UseNavigateResult,
+} from "@tanstack/react-router";
+import {
+  areNestedFocusTargetsEqual,
+  buildNestedFocusSearchPatch,
+  parseNestedFocusTargetFromSearch,
+  type NestedFocusTarget,
+} from "@/lib/epic-nested-focus-route";
+import { getHistoryController } from "@/lib/persistent-history";
+
+export interface NestedFocusLocation {
+  readonly pathname: string;
+  readonly search: Readonly<Record<string, unknown>>;
+}
+
+export interface NestedFocusNavigationRouter {
+  readonly history: RouterHistory;
+  readonly navigate: UseNavigateResult<string>;
+  readonly getLocation: () => NestedFocusLocation;
+}
+
+export type PrepareNestedFocusTarget = () => NestedFocusTarget | null;
+
+export type NavigateNestedFocus = (
+  epicId: string,
+  tabId: string,
+  prepare: PrepareNestedFocusTarget,
+) => NestedFocusTarget | null;
+
+export function navigateNestedFocus(
+  router: NestedFocusNavigationRouter,
+  tab: { readonly epicId: string; readonly tabId: string },
+  prepare: PrepareNestedFocusTarget,
+): NestedFocusTarget | null {
+  const { epicId, tabId } = tab;
+  const target = prepare();
+  if (target === null) {
+    return null;
+  }
+  const controller = getHistoryController(router.history);
+  if (controller === null) {
+    return target;
+  }
+
+  const location = router.getLocation();
+  if (!isCurrentEpicTabRoute(location.pathname, epicId, tabId)) {
+    return target;
+  }
+
+  const currentTarget = parseNestedFocusTargetFromSearch(location.search);
+  if (areNestedFocusTargetsEqual(currentTarget, target)) {
+    return target;
+  }
+
+  void router.navigate({
+    to: "/epics/$epicId/$tabId",
+    params: { epicId, tabId },
+    search: (prev) => ({
+      ...prev,
+      focusedAt: prev.focusedAt,
+      focusArtifactId: prev.focusArtifactId,
+      focusThreadId: prev.focusThreadId,
+      migrationSource: prev.migrationSource,
+      ...buildNestedFocusSearchPatch(target),
+    }),
+    replace: false,
+  });
+
+  return target;
+}
+
+function isCurrentEpicTabRoute(
+  pathname: string,
+  epicId: string,
+  tabId: string,
+): boolean {
+  const parts = pathname.split("/");
+  if (parts.length !== 4) return false;
+  const [_root, scope, routeEpicId, routeTabId] = parts;
+  return scope === "epics" && routeEpicId === epicId && routeTabId === tabId;
+}

--- a/clients/gui-app/src/lib/epic-nested-focus-route.ts
+++ b/clients/gui-app/src/lib/epic-nested-focus-route.ts
@@ -1,0 +1,109 @@
+import type { EpicCanvasState } from "@/stores/epics/canvas/types";
+import { findPaneById } from "@/stores/epics/canvas/tile-tree";
+
+export interface NestedFocusTarget {
+  readonly paneId: string;
+  readonly tileInstanceId: string | undefined;
+}
+
+export interface NestedFocusSearchPatch {
+  readonly focusPaneId: string | undefined;
+  readonly focusTileInstanceId: string | undefined;
+}
+
+function normalizeNestedFocusSearchValue(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const normalized = raw.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function parseNestedFocusTargetFromSearch(
+  search: Readonly<Record<string, unknown>>,
+): NestedFocusTarget | null {
+  const paneId = normalizeNestedFocusSearchValue(search.focusPaneId);
+  if (paneId === undefined) return null;
+  return {
+    paneId,
+    tileInstanceId: normalizeNestedFocusSearchValue(search.focusTileInstanceId),
+  };
+}
+
+export function getCurrentNestedFocusTarget(
+  canvas: EpicCanvasState,
+): NestedFocusTarget | null {
+  if (canvas.activePaneId === null) return null;
+  const pane = findPaneById(canvas.root, canvas.activePaneId);
+  if (pane === null) return null;
+
+  const explicitTabId =
+    pane.activeTabId !== null &&
+    pane.tabInstanceIds.includes(pane.activeTabId) &&
+    canvas.tilesByInstanceId[pane.activeTabId] !== undefined
+      ? pane.activeTabId
+      : undefined;
+  const firstTabId = pane.tabInstanceIds.find(
+    (instanceId) => canvas.tilesByInstanceId[instanceId] !== undefined,
+  );
+
+  return {
+    paneId: pane.id,
+    tileInstanceId: explicitTabId ?? firstTabId,
+  };
+}
+
+export function resolveNestedFocusTarget(
+  canvas: EpicCanvasState,
+  target: NestedFocusTarget,
+): NestedFocusTarget | null {
+  const pane = findPaneById(canvas.root, target.paneId);
+  if (pane === null) return null;
+  if (target.tileInstanceId === undefined) return target;
+  if (!pane.tabInstanceIds.includes(target.tileInstanceId)) return null;
+  if (canvas.tilesByInstanceId[target.tileInstanceId] === undefined) {
+    return null;
+  }
+  return target;
+}
+
+export function isNestedFocusTargetValid(
+  canvas: EpicCanvasState,
+  target: NestedFocusTarget,
+): boolean {
+  return resolveNestedFocusTarget(canvas, target) !== null;
+}
+
+export function areNestedFocusTargetsEqual(
+  left: NestedFocusTarget | null,
+  right: NestedFocusTarget | null,
+): boolean {
+  if (left === null || right === null) return left === right;
+  return (
+    left.paneId === right.paneId && left.tileInstanceId === right.tileInstanceId
+  );
+}
+
+export function buildNestedFocusSearchPatch(
+  target: NestedFocusTarget | null,
+): NestedFocusSearchPatch {
+  return {
+    focusPaneId: target?.paneId,
+    focusTileInstanceId: target?.tileInstanceId,
+  };
+}
+
+export function parseNestedFocusTargetFromHref(
+  href: string,
+): NestedFocusTarget | null {
+  const queryStart = href.indexOf("?");
+  if (queryStart === -1) return null;
+  const hashStart = href.indexOf("#", queryStart);
+  const query =
+    hashStart === -1
+      ? href.slice(queryStart + 1)
+      : href.slice(queryStart + 1, hashStart);
+  const params = new URLSearchParams(query);
+  return parseNestedFocusTargetFromSearch({
+    focusPaneId: params.get("focusPaneId") ?? undefined,
+    focusTileInstanceId: params.get("focusTileInstanceId") ?? undefined,
+  });
+}

--- a/clients/gui-app/src/lib/history-navigation/__tests__/liveness.test.ts
+++ b/clients/gui-app/src/lib/history-navigation/__tests__/liveness.test.ts
@@ -3,10 +3,63 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isHistoryEntryDead } from "@/lib/history-navigation/liveness";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
-import type { EpicViewTab } from "@/stores/epics/canvas/types";
+import type {
+  EpicCanvasState,
+  EpicCanvasTileRef,
+  EpicViewTab,
+  TilePane,
+} from "@/stores/epics/canvas/types";
+import { TILE_KIND_BLANK } from "@/stores/epics/canvas/tile-kinds";
 
 function tab(tabId: string, epicId: string): EpicViewTab {
   return { tabId, epicId, name: "Epic" };
+}
+
+function artifactTile(instanceId: string): EpicCanvasTileRef {
+  return {
+    id: `artifact-${instanceId}`,
+    instanceId,
+    type: "spec",
+    name: instanceId,
+    hostId: "host-1",
+  };
+}
+
+function blankTile(instanceId: string): EpicCanvasTileRef {
+  return {
+    id: instanceId,
+    instanceId,
+    type: TILE_KIND_BLANK,
+    name: "New tab",
+    hostId: "host-1",
+  };
+}
+
+function pane(
+  paneId: string,
+  tabInstanceIds: ReadonlyArray<string>,
+  activeTabId: string | null,
+): TilePane {
+  return {
+    kind: "pane",
+    id: paneId,
+    tabInstanceIds,
+    activeTabId,
+    previewTabId: null,
+    activationHistory: activeTabId === null ? [] : [activeTabId],
+  };
+}
+
+function canvas(
+  root: TilePane,
+  tilesByInstanceId: Record<string, EpicCanvasTileRef | undefined>,
+): EpicCanvasState {
+  return {
+    root,
+    activePaneId: root.id,
+    tilesByInstanceId,
+    sizesByGroupId: {},
+  };
 }
 
 beforeEach(() => {
@@ -64,9 +117,104 @@ describe("isHistoryEntryDead — conservative liveness", () => {
     expect(isHistoryEntryDead("/epics/e1/tGONE")).toBe(false);
   });
 
+  it("prunes a gone-tab nested href even when the epic still has a sibling tab", () => {
+    useEpicCanvasStore.setState({
+      tabsById: { t1: tab("t1", "e1") },
+      openTabOrder: ["t1"],
+    });
+
+    expect(
+      isHistoryEntryDead(
+        "/epics/e1/tGONE?focusPaneId=pane-1&focusTileInstanceId=tile-1",
+      ),
+    ).toBe(true);
+  });
+
   it("prunes an epic-tab href whose tab now belongs to a different epic", () => {
     useEpicCanvasStore.setState({ tabsById: { t1: tab("t1", "e1") } });
     expect(isHistoryEntryDead("/epics/e2/t1")).toBe(true);
+  });
+
+  it("keeps a nested href whose pane and tile still resolve in the exact tab canvas", () => {
+    useEpicCanvasStore.setState({
+      tabsById: { t1: tab("t1", "e1") },
+      canvasByTabId: {
+        t1: canvas(pane("pane-1", ["tile-1"], "tile-1"), {
+          "tile-1": artifactTile("tile-1"),
+        }),
+      },
+    });
+
+    expect(
+      isHistoryEntryDead(
+        "/epics/e1/t1?focusPaneId=pane-1&focusTileInstanceId=tile-1",
+      ),
+    ).toBe(false);
+  });
+
+  it("prunes nested hrefs whose pane is missing from the exact tab canvas", () => {
+    useEpicCanvasStore.setState({
+      tabsById: { t1: tab("t1", "e1") },
+      canvasByTabId: {
+        t1: canvas(pane("pane-live", ["tile-1"], "tile-1"), {
+          "tile-1": artifactTile("tile-1"),
+        }),
+      },
+    });
+
+    expect(
+      isHistoryEntryDead(
+        "/epics/e1/t1?focusPaneId=pane-stale&focusTileInstanceId=tile-1",
+      ),
+    ).toBe(true);
+  });
+
+  it("prunes nested hrefs whose tile is not in the target pane", () => {
+    useEpicCanvasStore.setState({
+      tabsById: { t1: tab("t1", "e1") },
+      canvasByTabId: {
+        t1: canvas(pane("pane-1", ["tile-1"], "tile-1"), {
+          "tile-1": artifactTile("tile-1"),
+          "tile-other": artifactTile("tile-other"),
+        }),
+      },
+    });
+
+    expect(
+      isHistoryEntryDead(
+        "/epics/e1/t1?focusPaneId=pane-1&focusTileInstanceId=tile-other",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps pane-only nested hrefs while the pane exists, even when empty", () => {
+    useEpicCanvasStore.setState({
+      tabsById: { t1: tab("t1", "e1") },
+      canvasByTabId: {
+        t1: canvas(pane("pane-empty", [], null), {}),
+      },
+    });
+
+    expect(isHistoryEntryDead("/epics/e1/t1?focusPaneId=pane-empty")).toBe(
+      false,
+    );
+  });
+
+  it("keeps nested hrefs targeting a live blank tile", () => {
+    useEpicCanvasStore.setState({
+      tabsById: { t1: tab("t1", "e1") },
+      canvasByTabId: {
+        t1: canvas(pane("pane-1", ["blank-1"], "blank-1"), {
+          "blank-1": blankTile("blank-1"),
+        }),
+      },
+    });
+
+    expect(
+      isHistoryEntryDead(
+        "/epics/e1/t1?focusPaneId=pane-1&focusTileInstanceId=blank-1",
+      ),
+    ).toBe(false);
   });
 
   it("keeps a draft href whose id is present in the landing-draft store", () => {

--- a/clients/gui-app/src/lib/history-navigation/liveness.ts
+++ b/clients/gui-app/src/lib/history-navigation/liveness.ts
@@ -1,5 +1,9 @@
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import {
+  parseNestedFocusTargetFromHref,
+  resolveNestedFocusTarget,
+} from "@/lib/epic-nested-focus-route";
 import { hrefPathname } from "@/lib/routes";
 
 /**
@@ -15,11 +19,12 @@ import { hrefPathname } from "@/lib/routes";
  * Two route shapes are prunable, read from the SAME stores the route
  * `beforeLoad` / committed-effect guards consult:
  *
- * - `/epics/$epicId/$tabId` — alive while the exact tab maps to `epicId`; once
- *   that tab is gone, dead ONLY when `resolveTabIdForEpic(epicId)` is null (no
- *   sibling tab). This mirrors the epic route's `beforeLoad`, which redirects a
- *   stale tab to a sibling of the same epic when one exists, so a back step to
- *   it still lands somewhere valid (`src/routes/epics.$epicId.$tabId.tsx`).
+ * - `/epics/$epicId/$tabId` — top-level entries without nested pane/tile params
+ *   are alive while the exact tab maps to `epicId`; once that tab is gone, dead
+ *   ONLY when `resolveTabIdForEpic(epicId)` is null (no sibling tab). Nested
+ *   pane/tile entries are exact session-local targets: they are alive only while
+ *   the original tab maps to the epic and the target resolves in that tab's
+ *   canvas. Sibling tabs must not salvage nested targets.
  * - `/draft/$draftId` — dead when `draftId` is absent from the landing-draft
  *   store (`src/routes/draft-route-components.tsx` redirects to `/` on the same
  *   condition). `/draft/new` is a distinct route and is always kept.
@@ -30,16 +35,30 @@ import { hrefPathname } from "@/lib/routes";
 export function isHistoryEntryDead(href: string): boolean {
   const segments = parsePathSegments(href);
 
-  // /epics/$epicId/$tabId — alive while the exact tab maps to epicId. Once that
-  // tab is gone, dead ONLY when the epic has no resolvable tab: the route's
-  // `beforeLoad` redirects a stale tab to a sibling of the same epic via
-  // `resolveTabIdForEpic`, so a back step there still lands somewhere valid.
+  // /epics/$epicId/$tabId — nested pane/tile targets are exact to this tab's
+  // canvas. Only top-level entries without nested params keep the legacy
+  // sibling-salvage behavior.
   if (segments.length === 3 && segments[0] === "epics") {
     const epicId = segments[1];
     const tabId = segments[2];
+    const nestedTarget = parseNestedFocusTargetFromHref(href);
     const state = useEpicCanvasStore.getState();
-    if (state.tabsById[tabId]?.epicId === epicId) return false;
-    return state.resolveTabIdForEpic(epicId) === null;
+    if (state.tabsById[tabId]?.epicId === epicId) {
+      if (nestedTarget === null) {
+        return false;
+      }
+      const canvas = state.canvasByTabId[tabId];
+      if (canvas === undefined) {
+        return true;
+      }
+      const resolved = resolveNestedFocusTarget(canvas, nestedTarget);
+      return resolved === null;
+    }
+    if (nestedTarget !== null) {
+      return true;
+    }
+    const sibling = state.resolveTabIdForEpic(epicId);
+    return sibling === null;
   }
 
   // /draft/$draftId — dead when the draft id is gone. `/draft/new` is kept.

--- a/clients/gui-app/src/lib/history-navigation/prune-scheduler.ts
+++ b/clients/gui-app/src/lib/history-navigation/prune-scheduler.ts
@@ -56,7 +56,12 @@ export function installPruneScheduler(
   const flush = () => {
     cancelScheduled = null;
     pending = false;
-    if (uninstalled || running) return;
+    if (uninstalled) {
+      return;
+    }
+    if (running) {
+      return;
+    }
     // A router load is mid-flight; re-try next frame rather than prune against a
     // half-applied navigation. Loads settle in a handful of frames, so this is
     // bounded (one callback per frame), never a tight loop.
@@ -65,7 +70,9 @@ export function installPruneScheduler(
       return;
     }
     const controller = getController();
-    if (controller === null) return;
+    if (controller === null) {
+      return;
+    }
     running = true;
     // `finally` (not `catch`) so a throw still re-arms the single-flight gate:
     // leaving `running` stuck `true` would silently disable pruning for the rest

--- a/clients/gui-app/src/lib/keybindings/dispatch.ts
+++ b/clients/gui-app/src/lib/keybindings/dispatch.ts
@@ -11,6 +11,10 @@ import { toggleActiveModelPicker } from "@/lib/commands/active-model-picker-regi
 import { focusActiveComposer } from "@/lib/composer/composer-focus-registry";
 import { tabMatchesPath, tabResolveIntent } from "@/stores/tabs/registry";
 import type { TabNavigationIntent } from "@/lib/tab-navigation/intents";
+import type {
+  NavigateNestedFocus,
+  PrepareNestedFocusTarget,
+} from "@/lib/epic-nested-focus-navigation";
 import type { EpicViewTab } from "@/stores/epics/canvas/types";
 import {
   ACTION_IDS,
@@ -68,6 +72,7 @@ export interface KeybindingRouter {
    * click - see `lib/tab-navigation.ts`.
    */
   readonly navigateToTabIntent: (intent: TabNavigationIntent) => void;
+  readonly navigateNestedFocus?: NavigateNestedFocus;
   /**
    * In-app history back/forward. Delegate to the shared
    * `goBack`/`goForward` actions on the CURRENT router (the live
@@ -439,6 +444,15 @@ function getActiveTab(router: KeybindingRouter): EpicViewTab | null {
   return useEpicCanvasStore.getState().tabsById[tabId] ?? null;
 }
 
+function runNestedFocus(
+  router: KeybindingRouter,
+  tab: { readonly epicId: string; readonly tabId: string },
+  prepare: PrepareNestedFocusTarget,
+) {
+  if (router.navigateNestedFocus === undefined) return prepare();
+  return router.navigateNestedFocus(tab.epicId, tab.tabId, prepare);
+}
+
 function duplicateActiveEpicTab(router: KeybindingRouter): boolean {
   const tabId = getActiveEpicTabId(router);
   if (tabId === null) return false;
@@ -493,12 +507,19 @@ function closeActiveTab(router: KeybindingRouter): boolean {
   if (target.activeTabId === null) {
     if (target.tabInstanceIds.length > 0) return false;
     if (root.kind !== "group") return false;
-    useEpicCanvasStore.getState().closeCanvasPane(tab.tabId, target.id);
+    runNestedFocus(router, tab, () =>
+      useEpicCanvasStore
+        .getState()
+        .prepareCloseCanvasPaneFocusTarget(tab.tabId, target.id),
+    );
     return true;
   }
-  useEpicCanvasStore
-    .getState()
-    .closeCanvasTab(tab.tabId, target.id, target.activeTabId);
+  const activeTabId = target.activeTabId;
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareCloseCanvasTabFocusTarget(tab.tabId, target.id, activeTabId),
+  );
   return true;
 }
 
@@ -507,9 +528,16 @@ function closeOtherTabsInActive(router: KeybindingRouter): boolean {
   if (tab === null) return false;
   const target = getActiveGroupAndTab(tab.tabId);
   if (target === null || target.tabId === null) return false;
-  useEpicCanvasStore
-    .getState()
-    .closeOtherCanvasTabs(tab.tabId, target.groupId, target.tabId);
+  const targetTabId = target.tabId;
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareCloseOtherCanvasTabsFocusTarget(
+        tab.tabId,
+        target.groupId,
+        targetTabId,
+      ),
+  );
   return true;
 }
 
@@ -518,9 +546,16 @@ function closeRightTabsInActive(router: KeybindingRouter): boolean {
   if (tab === null) return false;
   const target = getActiveGroupAndTab(tab.tabId);
   if (target === null || target.tabId === null) return false;
-  useEpicCanvasStore
-    .getState()
-    .closeRightCanvasTabs(tab.tabId, target.groupId, target.tabId);
+  const targetTabId = target.tabId;
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareCloseRightCanvasTabsFocusTarget(
+        tab.tabId,
+        target.groupId,
+        targetTabId,
+      ),
+  );
   return true;
 }
 
@@ -529,7 +564,11 @@ function closeAllTabsInActive(router: KeybindingRouter): boolean {
   if (tab === null) return false;
   const groupId = getActiveGroupId(tab.tabId);
   if (groupId === null) return false;
-  useEpicCanvasStore.getState().closeAllCanvasTabs(tab.tabId, groupId);
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareCloseAllCanvasTabsFocusTarget(tab.tabId, groupId),
+  );
   return true;
 }
 
@@ -547,9 +586,11 @@ function moveTabFocus(router: KeybindingRouter, delta: number): boolean {
   if (idx === -1) return false;
   const count = pane.tabInstanceIds.length;
   const nextInstanceId = pane.tabInstanceIds[(idx + delta + count) % count];
-  useEpicCanvasStore
-    .getState()
-    .setActiveTileTab(tab.tabId, pane.id, nextInstanceId);
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareSetActiveTileTabFocusTarget(tab.tabId, pane.id, nextInstanceId),
+  );
   return true;
 }
 
@@ -565,9 +606,11 @@ function switchActivePaneTabByIndex(
   if (pane === null) return false;
   if (index < 0 || index >= pane.tabInstanceIds.length) return false;
   const nextInstanceId = pane.tabInstanceIds[index];
-  useEpicCanvasStore
-    .getState()
-    .setActiveTileTab(tab.tabId, pane.id, nextInstanceId);
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareSetActiveTileTabFocusTarget(tab.tabId, pane.id, nextInstanceId),
+  );
   return true;
 }
 
@@ -578,7 +621,11 @@ function openBlankTabInActiveGroup(router: KeybindingRouter): boolean {
   if (groupId === null) return false;
   // Reuse-if-active-is-blank is handled in the store action, so repeated
   // presses just re-focus the existing blank tab.
-  useEpicCanvasStore.getState().openBlankTabInPane(tab.tabId, groupId);
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareOpenBlankTabInPaneFocusTarget(tab.tabId, groupId),
+  );
   return true;
 }
 
@@ -591,7 +638,11 @@ function splitActiveGroup(
   const groupId = getActiveGroupId(tab.tabId);
   if (groupId === null) return false;
   // The new empty pane self-renders the inline opener (PaneOpener); no trigger.
-  useEpicCanvasStore.getState().splitPaneEmptyInTab(tab.tabId, groupId, axis);
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareSplitPaneEmptyFocusTarget(tab.tabId, groupId, axis),
+  );
   return true;
 }
 
@@ -600,7 +651,11 @@ function splitActiveGroupRight(router: KeybindingRouter): boolean {
   if (tab === null) return false;
   const groupId = getActiveGroupId(tab.tabId);
   if (groupId === null) return false;
-  useEpicCanvasStore.getState().splitPaneEmptyRightInTab(tab.tabId, groupId);
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareSplitPaneEmptyFocusTarget(tab.tabId, groupId, "horizontal"),
+  );
   return true;
 }
 
@@ -618,7 +673,11 @@ function focusGroupInDirection(
   if (active === undefined) return false;
   const nextId = findNeighbor(active, rects, dir);
   if (nextId === null) return false;
-  useEpicCanvasStore.getState().setActiveTilePane(tab.tabId, nextId);
+  runNestedFocus(router, tab, () =>
+    useEpicCanvasStore
+      .getState()
+      .prepareSetActiveTilePaneFocusTarget(tab.tabId, nextId),
+  );
   focusGroupEditor(nextId);
   return true;
 }

--- a/clients/gui-app/src/lib/keybindings/router-adapter.ts
+++ b/clients/gui-app/src/lib/keybindings/router-adapter.ts
@@ -23,12 +23,18 @@ import {
   navigateToTabIntent,
   openOrFocusEpicIntent,
 } from "@/lib/tab-navigation";
+import { navigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 import type { SettingsSectionId } from "@/lib/settings-sections";
 import { getSystemTabModalApi } from "@/stores/tabs/system-tab-modal-bridge";
 import { routeIntentViaModalBridge } from "@/stores/tabs/system-overlay-registry";
 
 export interface KeybindingRouterSource {
-  readonly state: { readonly location: { readonly pathname: string } };
+  readonly state: {
+    readonly location: {
+      readonly pathname: string;
+      readonly search?: Readonly<Record<string, unknown>>;
+    };
+  };
   // Full `RouterHistory` (not just `subscribe`): the history-navigation seam
   // reads the persistent-history controller brand off it (`getHistoryController`)
   // and walks it via the shared `goBack`/`goForward` actions.
@@ -91,6 +97,19 @@ export function routerAdapterFor(
       }
       navigateToTabIntent(router.navigate, intent);
     },
+    navigateNestedFocus: (epicId, tabId, prepare) =>
+      navigateNestedFocus(
+        {
+          history: router.history,
+          navigate: router.navigate,
+          getLocation: () => ({
+            pathname: router.state.location.pathname,
+            search: router.state.location.search ?? {},
+          }),
+        },
+        { epicId, tabId },
+        prepare,
+      ),
     // Walk the CURRENT router's persistent history; the shared actions no-op
     // when the history carries no controller brand (browser/web build).
     goBack: () => goBackAction(router),

--- a/clients/gui-app/src/lib/persistent-history.ts
+++ b/clients/gui-app/src/lib/persistent-history.ts
@@ -543,10 +543,14 @@ export function createPersistentMemoryHistory(
       // (`use-system-tab-modal.ts`'s focus-tab-first branches) - left
       // uncollapsed, `canGoForward()` would stay true over a byte-identical
       // dead forward step.
+      // Either collapse drops the NEIGHBOUR and keeps the just-replaced entry,
+      // so the state passed to THIS replace survives - the stack stays in
+      // agreement with the location TanStack caches after a replace, instead
+      // of diverging until the next real navigation.
       let collapsedNeighbour = false;
       if (index > 0 && entries[index - 1] === path) {
-        entries.splice(index, 1);
-        states.splice(index, 1);
+        entries.splice(index - 1, 1);
+        states.splice(index - 1, 1);
         index -= 1;
         collapsedNeighbour = true;
       }

--- a/clients/gui-app/src/lib/persistent-history.ts
+++ b/clients/gui-app/src/lib/persistent-history.ts
@@ -42,10 +42,13 @@ export interface PersistentHistoryController {
   canGoBack(): boolean; // index > 0 over the live stack
   canGoForward(): boolean; // index < entries.length - 1
   /**
-   * Removes every NON-current entry for which `isDead(href)` is true, remaps the
-   * index to the surviving current entry, re-stamps `__TSR_index` contiguously,
-   * persists, and notifies CONTROLLER subscribers only. Returns whether the
-   * stack changed.
+   * Removes every NON-current entry for which `isDead(href)` is true, then
+   * collapses any adjacent byte-identical entries the removal left behind (or
+   * that were already present) so no two neighbouring entries ever share an
+   * href - two adjacent identical hrefs are always a dead back/forward step.
+   * Remaps the index to the surviving current entry, re-stamps `__TSR_index`
+   * contiguously, persists, and notifies CONTROLLER subscribers only. Returns
+   * whether the stack changed, including a collapse-only change.
    *
    * Critically load-free: it never calls `history.notify()` and so never drives
    * `router.load()`. The current entry is never pruned.
@@ -356,6 +359,38 @@ function capStackInPlace(
   return index - start;
 }
 
+interface PruneSurvivor {
+  readonly href: string;
+  readonly state: LocationState;
+  readonly wasCurrent: boolean;
+}
+
+/**
+ * Collapses adjacent byte-identical entries in a `prune`-filtered survivor
+ * list. Two adjacent identical hrefs are always a dead back/forward step
+ * (`go(-1)`/`go(1)` moves the cursor but not the rendered location), so this
+ * runs unconditionally over the whole list - not just over runs the dead-entry
+ * filter just made adjacent. When the current entry is part of a collapsed
+ * run, the surviving slot inherits the current marker so the cursor keeps
+ * pointing at the same href (mirrors the current-preserving collapse in
+ * `replaceState`).
+ */
+function collapseAdjacentDuplicates(
+  survivors: ReadonlyArray<PruneSurvivor>,
+): PruneSurvivor[] {
+  return survivors.reduce<PruneSurvivor[]>((collapsed, entry) => {
+    if (collapsed.length === 0) return [entry];
+    const previous = collapsed[collapsed.length - 1];
+    if (previous.href !== entry.href) {
+      return [...collapsed, entry];
+    }
+    if (entry.wasCurrent) {
+      collapsed[collapsed.length - 1] = { ...previous, wasCurrent: true };
+    }
+    return collapsed;
+  }, []);
+}
+
 /**
  * Creates a router history seeded from the explicit `initialRoute` override,
  * or from this window's `localStorage` history when the shell provides no
@@ -406,6 +441,19 @@ export function createPersistentMemoryHistory(
       if (index < entries.length - 1) {
         entries.splice(index + 1);
         states.splice(index + 1);
+      }
+      // The pushed href can land byte-identical to the entry the cursor now
+      // sits on (e.g. a pane close's prepared fallback-focus push re-deriving
+      // the tab it came from). Two adjacent identical hrefs are always a dead
+      // back step, so treat this as landing on the existing entry instead of
+      // manufacturing a duplicate - general adjacent-duplicate guard, mirrors
+      // the collapse in `replaceState`.
+      if (entries[index] === path) {
+        states[index] = state;
+        restampIndices(states);
+        persistState(windowId, entries, index);
+        notifyController();
+        return;
       }
       entries.push(path);
       states.push(state);
@@ -474,12 +522,25 @@ export function createPersistentMemoryHistory(
       // so the index can be remapped after filtering.
       const survivors = entries
         .map((href, i) => ({ href, state: states[i], wasCurrent: i === index }))
-        .filter((entry) => entry.wasCurrent || !isDead(entry.href));
+        .filter((entry) => {
+          if (entry.wasCurrent) {
+            return true;
+          }
+          return !isDead(entry.href);
+        });
 
-      // Current is never pruned, so a same-length result means nothing changed.
-      if (survivors.length === entries.length) return false;
+      // Collapse any adjacent byte-identical entries the dead-entry removal
+      // left behind (or that were already present), so the stack never ends
+      // up with two neighbouring entries that render the same location - a
+      // dead back/forward step.
+      const collapsed = collapseAdjacentDuplicates(survivors);
 
-      const nextIndex = survivors.findIndex((entry) => entry.wasCurrent);
+      // Current is never pruned, and a collapse never drops the sole
+      // surviving current marker, so an unchanged length means nothing
+      // changed at all (neither dead-entry removal nor collapse).
+      if (collapsed.length === entries.length) return false;
+
+      const nextIndex = collapsed.findIndex((entry) => entry.wasCurrent);
       // Mutate the closed-over arrays in place so `getLocation` keeps reading the
       // same references the history was created with, then re-stamp `__TSR_index`
       // contiguously so the next real `go(n)` lands on a location whose `state`
@@ -487,9 +548,9 @@ export function createPersistentMemoryHistory(
       entries.splice(
         0,
         entries.length,
-        ...survivors.map((entry) => entry.href),
+        ...collapsed.map((entry) => entry.href),
       );
-      states.splice(0, states.length, ...survivors.map((entry) => entry.state));
+      states.splice(0, states.length, ...collapsed.map((entry) => entry.state));
       restampIndices(states);
       index = nextIndex;
 

--- a/clients/gui-app/src/lib/persistent-history.ts
+++ b/clients/gui-app/src/lib/persistent-history.ts
@@ -530,17 +530,32 @@ export function createPersistentMemoryHistory(
       entries[index] = path;
       states[index] = state;
       // Collapse an adjacent byte-identical entry created by an in-place
-      // replace. Two identical adjacent entries are always a dead back step
-      // (`go(-1)` moves the cursor but not the rendered href), so dropping the
-      // redundant current entry and stepping the cursor back onto its identical
+      // replace, on EITHER side of the current entry. Two identical adjacent
+      // entries are always a dead back/forward step (`go(-1)`/`go(1)` moves
+      // the cursor but not the rendered href), so dropping the redundant
       // neighbour is correct for ANY replace - this is a general
-      // adjacent-duplicate guard, not overlay-specific. (Its common producer is
-      // the settings/history overlay, whose entry is pushed onto the same path
-      // and differs only by a search-param flag that this `replace` then clears.)
+      // adjacent-duplicate guard, not overlay-specific. The BEHIND case's
+      // common producer is the settings/history overlay, whose entry is
+      // pushed onto the same path and differs only by a search-param flag
+      // that this `replace` then clears. The AHEAD case's producer is a
+      // cold-load redirect replacing a current overlay entry when the route
+      // it redirects to already sits one step ahead in a restored stack
+      // (`use-system-tab-modal.ts`'s focus-tab-first branches) - left
+      // uncollapsed, `canGoForward()` would stay true over a byte-identical
+      // dead forward step.
+      let collapsedNeighbour = false;
       if (index > 0 && entries[index - 1] === path) {
         entries.splice(index, 1);
         states.splice(index, 1);
         index -= 1;
+        collapsedNeighbour = true;
+      }
+      if (index < entries.length - 1 && entries[index + 1] === path) {
+        entries.splice(index + 1, 1);
+        states.splice(index + 1, 1);
+        collapsedNeighbour = true;
+      }
+      if (collapsedNeighbour) {
         restampIndices(states);
       }
       persistState(windowId, entries, index);

--- a/clients/gui-app/src/lib/tab-navigation.ts
+++ b/clients/gui-app/src/lib/tab-navigation.ts
@@ -8,6 +8,7 @@ import { settingsSectionFromPath } from "@/stores/tabs/kinds/settings";
 export {
   draftTabIntent,
   existingEpicTabIntent,
+  existingEpicTabIntentWithNestedFocus,
   historyTabIntent,
   openOrFocusEpicIntent,
   settingsTabIntent,

--- a/clients/gui-app/src/lib/tab-navigation/intents.ts
+++ b/clients/gui-app/src/lib/tab-navigation/intents.ts
@@ -8,6 +8,7 @@
  * `tabRouteOptions`) that themselves need the descriptor registry.
  */
 import type { SettingsSectionId } from "@/lib/settings-sections";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 
 export interface EpicRouteFocus {
@@ -23,6 +24,16 @@ export type TabNavigationIntent =
       readonly epicId: string;
       readonly tabId: string;
       readonly focus: EpicRouteFocus;
+      /**
+       * Store-prepared pane/tile target for a CROSS-ROUTE opener that already
+       * mutated the target tab's canvas before navigating (the canvas store
+       * is global and keyed by tabId, so preparing a background tab is
+       * valid). `null` for every plain tab-switch intent (duplicate, close,
+       * command palette, etc.) - those intentionally wipe nested search and
+       * let route-sync canonicalization refill it from the tab's own current
+       * focus. Only `existingEpicTabIntentWithNestedFocus` sets this.
+       */
+      readonly nestedFocus: NestedFocusTarget | null;
     }
   | { readonly kind: "draft"; readonly draftId: string }
   | { readonly kind: "history" }
@@ -45,6 +56,31 @@ export function existingEpicTabIntent(input: {
     epicId: input.epicId,
     tabId: input.tabId,
     focus: input.focus ?? DEFAULT_EPIC_FOCUS,
+    nestedFocus: null,
+  };
+}
+
+/**
+ * Cross-route variant of `existingEpicTabIntent`: carries a store-prepared
+ * nested focus target (pane/tile) so a single top-level navigation commits
+ * both the header-tab switch and the canvas focus atomically, instead of
+ * wiping nested search and relying on route-sync canonicalization to
+ * self-heal it back in on a later pass. Callers already sitting on the
+ * target epic/tab route should use `useEpicNestedFocusNavigation` directly
+ * instead of this factory.
+ */
+export function existingEpicTabIntentWithNestedFocus(input: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly focus: EpicRouteFocus | undefined;
+  readonly nestedFocus: NestedFocusTarget | null;
+}): Extract<TabNavigationIntent, { kind: "epic" }> {
+  return {
+    kind: "epic",
+    epicId: input.epicId,
+    tabId: input.tabId,
+    focus: input.focus ?? DEFAULT_EPIC_FOCUS,
+    nestedFocus: input.nestedFocus,
   };
 }
 

--- a/clients/gui-app/src/markdown/__tests__/traycer-reference-components.test.tsx
+++ b/clients/gui-app/src/markdown/__tests__/traycer-reference-components.test.tsx
@@ -75,12 +75,14 @@ vi.mock("@/lib/epic-selectors", () => ({
 // non-side-effecting resolver the chip reads for its `viewTabId` (constraint
 // C1), returning a tab id for the open epic and `null` otherwise.
 const {
+  openTilePreviewInEpic,
   openTilePreviewInTab,
   resolveTargetTabForEpic,
   resolveTabIdForEpic,
   useDraggableSpy,
   setNodeRefSpy,
 } = vi.hoisted(() => ({
+  openTilePreviewInEpic: vi.fn(),
   openTilePreviewInTab: vi.fn(),
   resolveTargetTabForEpic: vi.fn(() => "tab-for-open-epic"),
   resolveTabIdForEpic: vi.fn((epicId: string) =>
@@ -98,8 +100,9 @@ const {
   setNodeRefSpy: vi.fn<(element: HTMLElement | null) => void>(),
 }));
 
-// `useEpicCanvasStore` is used both as a selector hook (the chip) and via
-// `.getState()` (the open handler), so the mock is a callable with `getState`.
+// `useEpicCanvasStore` is used as a selector hook by the chip's drag source, so
+// the mock is a callable with `getState` for compatibility with callers that
+// still read the store imperatively.
 vi.mock("@/stores/epics/canvas/store", () => {
   const canvasState = {
     resolveTargetTabForEpic,
@@ -118,6 +121,15 @@ vi.mock("@/stores/epics/canvas/store", () => {
       resolveTabIdForEpic(epicId),
   };
 });
+
+vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
+  useEpicTileNavigation: () => ({
+    openTilePreviewInEpic,
+    openTilePreviewInTab: vi.fn(),
+    openTileInTab: vi.fn(),
+    openTileInEpic: vi.fn(),
+  }),
+}));
 
 vi.mock("@dnd-kit/core", () => ({
   useDraggable: (args: { id: string; disabled: boolean; data: unknown }) => {
@@ -169,6 +181,7 @@ beforeEach(() => {
   mockActiveHostId = "active-host-1";
   navigate.mockClear();
   epicNodeRefForNodeId.mockClear();
+  openTilePreviewInEpic.mockClear();
   openTilePreviewInTab.mockClear();
   resolveTargetTabForEpic.mockClear();
   resolveTabIdForEpic.mockClear();
@@ -198,11 +211,8 @@ describe("legacy traycer-* reference components", () => {
 
     clickRef("Spec One");
 
-    expect(resolveTargetTabForEpic).toHaveBeenCalledWith(
-      OPEN_EPIC_ID,
-      undefined,
-    );
-    expect(openTilePreviewInTab).toHaveBeenCalledWith("tab-for-open-epic", {
+    expect(resolveTargetTabForEpic).not.toHaveBeenCalled();
+    expect(openTilePreviewInEpic).toHaveBeenCalledWith(OPEN_EPIC_ID, {
       id: "spec-1",
       instanceId: "inst-spec",
       type: "spec",
@@ -221,7 +231,7 @@ describe("legacy traycer-* reference components", () => {
 
     clickRef("Chat One");
 
-    expect(openTilePreviewInTab).toHaveBeenCalledWith("tab-for-open-epic", {
+    expect(openTilePreviewInEpic).toHaveBeenCalledWith(OPEN_EPIC_ID, {
       id: "chat-1",
       instanceId: "inst-chat",
       type: "chat",
@@ -243,7 +253,7 @@ describe("legacy traycer-* reference components", () => {
 
     clickRef("Ticket Nine");
 
-    expect(openTilePreviewInTab).not.toHaveBeenCalled();
+    expect(openTilePreviewInEpic).not.toHaveBeenCalled();
     expect(navigateToTabIntent).toHaveBeenCalledTimes(1);
     expect(openOrFocusEpicIntent).toHaveBeenCalledTimes(1);
     const arg = openOrFocusEpicIntent.mock.calls[0][0];
@@ -282,7 +292,7 @@ describe("legacy traycer-* reference components", () => {
 
     clickRef("Some Epic");
 
-    expect(openTilePreviewInTab).not.toHaveBeenCalled();
+    expect(openTilePreviewInEpic).not.toHaveBeenCalled();
     expect(navigateToTabIntent).toHaveBeenCalledTimes(1);
     const arg = openOrFocusEpicIntent.mock.calls[0][0];
     expect(arg.epicId).toBe("epic-other");
@@ -383,7 +393,7 @@ describe("same-epic spec/ticket chips are canvas drag sources", () => {
     ).toBe(true);
     // Drag is purely additive - the pill still opens on click.
     clickRef("Spec One");
-    expect(openTilePreviewInTab).toHaveBeenCalledTimes(1);
+    expect(openTilePreviewInEpic).toHaveBeenCalledTimes(1);
   });
 
   it("a same-epic ticket chip registers a draggable, emits the payload, and wires the drag surface", () => {
@@ -432,7 +442,7 @@ describe("same-epic spec/ticket chips are canvas drag sources", () => {
     // Click semantics are unchanged - it still navigates.
     clickRef("Ticket Nine");
     expect(navigateToTabIntent).toHaveBeenCalledTimes(1);
-    expect(openTilePreviewInTab).not.toHaveBeenCalled();
+    expect(openTilePreviewInEpic).not.toHaveBeenCalled();
   });
 
   it("an inert (none) reference registers no draggable and stays plain text", () => {
@@ -462,7 +472,7 @@ describe("same-epic spec/ticket chips are canvas drag sources", () => {
     expect(button.getAttribute("data-dnd-attached")).toBeNull();
     // Click still opens the same-epic chat tile.
     clickRef("Chat One");
-    expect(openTilePreviewInTab).toHaveBeenCalledTimes(1);
+    expect(openTilePreviewInEpic).toHaveBeenCalledTimes(1);
   });
 
   it("an epic reference registers no draggable (navigate-only)", () => {
@@ -504,8 +514,8 @@ describe("DEFAULT_COMPONENTS wires the legacy reference tags", () => {
 
     clickRef("Spec One");
 
-    expect(openTilePreviewInTab).toHaveBeenCalledWith(
-      "tab-for-open-epic",
+    expect(openTilePreviewInEpic).toHaveBeenCalledWith(
+      OPEN_EPIC_ID,
       expect.objectContaining({ id: "spec-1", type: "spec" }),
     );
   });

--- a/clients/gui-app/src/markdown/components/__tests__/use-traycer-reference-open.test.tsx
+++ b/clients/gui-app/src/markdown/components/__tests__/use-traycer-reference-open.test.tsx
@@ -1,0 +1,119 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCallback, type MouseEvent } from "react";
+import { useTraycerReferenceOpenHandler } from "@/markdown/components/use-traycer-reference-open";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type {
+  EpicCanvasTileRef,
+  EpicNodeRef,
+} from "@/stores/epics/canvas/types";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+
+const testState = vi.hoisted(() => ({
+  testRef: {
+    id: "spec-1",
+    instanceId: "spec-instance-1",
+    type: "spec",
+    name: "Spec One",
+    hostId: "host-1",
+  } satisfies EpicNodeRef,
+  openTilePreviewInEpic: vi.fn(
+    (_epicId: string, _node: EpicCanvasTileRef): NestedFocusTarget | null =>
+      null,
+  ),
+  openEpicHandle: {
+    epicId: "epic-1",
+    store: {
+      getState: () => ({}),
+    },
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-1",
+}));
+
+vi.mock("@/providers/use-open-epic-handle", () => ({
+  useMaybeOpenEpicHandle: () => testState.openEpicHandle,
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  epicNodeRefForNodeId: () => testState.testRef,
+}));
+
+vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
+  useEpicTileNavigation: () => ({
+    openTilePreviewInEpic: testState.openTilePreviewInEpic,
+    openTilePreviewInTab: vi.fn(),
+    openTileInTab: vi.fn(),
+    openTileInEpic: vi.fn(),
+  }),
+}));
+
+describe("useTraycerReferenceOpenHandler", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    testState.openTilePreviewInEpic.mockImplementation(
+      (epicId: string, node: EpicCanvasTileRef): NestedFocusTarget | null => {
+        const store = useEpicCanvasStore.getState();
+        const tabId = store.resolveTargetTabForEpic(epicId, undefined);
+        return store.prepareOpenTilePreviewInTabFocusTarget(tabId, node);
+      },
+    );
+    testState.openTilePreviewInEpic.mockClear();
+  });
+
+  afterEach(cleanup);
+
+  it("routes same-epic reference preview opens through the tile navigation boundary", () => {
+    const viewTabId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-1", "Epic");
+
+    render(<ReferenceButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open reference" }));
+
+    // A revert to the raw canvas preview call would still mutate the store, but
+    // it would bypass this route-aware boundary spy.
+    expect(testState.openTilePreviewInEpic).toHaveBeenCalledWith(
+      "epic-1",
+      testState.testRef,
+    );
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+    if (canvas?.root?.kind !== "pane") throw new Error("expected pane");
+    const activeTile =
+      canvas.tilesByInstanceId[canvas.root.activeTabId ?? ""] ?? null;
+    expect(activeTile).toMatchObject({
+      id: testState.testRef.id,
+      type: testState.testRef.type,
+      name: testState.testRef.name,
+      hostId: testState.testRef.hostId,
+    } satisfies Partial<EpicNodeRef>);
+  });
+});
+
+function ReferenceButton() {
+  const { onOpen } = useTraycerReferenceOpenHandler({
+    epicId: "epic-1",
+    nodeId: testState.testRef.id,
+    requiresNode: true,
+  });
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>): void => {
+      if (onOpen === null) return;
+      onOpen(event);
+    },
+    [onOpen],
+  );
+  return (
+    <button type="button" onClick={handleClick}>
+      Open reference
+    </button>
+  );
+}

--- a/clients/gui-app/src/markdown/components/use-traycer-reference-open.ts
+++ b/clients/gui-app/src/markdown/components/use-traycer-reference-open.ts
@@ -1,13 +1,13 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback, type MouseEvent } from "react";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 import { epicNodeRefForNodeId } from "@/lib/epic-selectors";
 import {
   navigateToTabIntent,
   openOrFocusEpicIntent,
 } from "@/lib/tab-navigation";
 import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
-import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { EpicNodeRef } from "@/stores/epics/canvas/types";
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
 
@@ -96,6 +96,7 @@ export function useTraycerReferenceOpenHandler(input: {
   const handle = useMaybeOpenEpicHandle();
   const activeHostId = useReactiveActiveHostId();
   const navigate = useNavigate();
+  const tileNavigation = useEpicTileNavigation();
 
   const target = resolveOpenTarget({
     epicId: input.epicId,
@@ -115,12 +116,7 @@ export function useTraycerReferenceOpenHandler(input: {
         case "same-epic-node": {
           // Open the resolved node as a replaceable preview tile in the epic's
           // current tab.
-          const canvas = useEpicCanvasStore.getState();
-          const tabId = canvas.resolveTargetTabForEpic(
-            target.epicId,
-            undefined,
-          );
-          canvas.openTilePreviewInTab(tabId, target.ref);
+          tileNavigation.openTilePreviewInEpic(target.epicId, target.ref);
           return;
         }
         case "navigate":
@@ -142,7 +138,7 @@ export function useTraycerReferenceOpenHandler(input: {
           return;
       }
     },
-    [target, navigate],
+    [target, navigate, tileNavigation],
   );
 
   // Only a resolved `same-epic-node` surfaces a ref; `navigate` and `none`

--- a/clients/gui-app/src/routes/__tests__/epic-route-search.test.ts
+++ b/clients/gui-app/src/routes/__tests__/epic-route-search.test.ts
@@ -9,12 +9,16 @@ describe("normalizeEpicFocusSearch", () => {
         focusArtifactId: "   ",
         focusThreadId: "\t",
         migrationSource: "phase",
+        focusPaneId: " ",
+        focusTileInstanceId: "\n",
       }),
     ).toEqual({
       focusedAt: undefined,
       focusArtifactId: undefined,
       focusThreadId: undefined,
       migrationSource: "phase",
+      focusPaneId: undefined,
+      focusTileInstanceId: undefined,
     });
   });
 
@@ -25,12 +29,27 @@ describe("normalizeEpicFocusSearch", () => {
         focusArtifactId: " artifact-1 ",
         focusThreadId: " thread-1 ",
         migrationSource: undefined,
+        focusPaneId: " pane-1 ",
+        focusTileInstanceId: " tile-1 ",
       }),
     ).toEqual({
       focusedAt: 42,
       focusArtifactId: "artifact-1",
       focusThreadId: "thread-1",
       migrationSource: undefined,
+      focusPaneId: "pane-1",
+      focusTileInstanceId: "tile-1",
+    });
+  });
+
+  it("defaults absent nested focus params to undefined", () => {
+    expect(normalizeEpicFocusSearch({})).toEqual({
+      focusedAt: undefined,
+      focusArtifactId: undefined,
+      focusThreadId: undefined,
+      migrationSource: undefined,
+      focusPaneId: undefined,
+      focusTileInstanceId: undefined,
     });
   });
 });

--- a/clients/gui-app/src/routes/__tests__/epics-tab-route.test.tsx
+++ b/clients/gui-app/src/routes/__tests__/epics-tab-route.test.tsx
@@ -56,6 +56,16 @@ vi.mock("@/hooks/epics/use-cloud-epic-tasks-query", () => ({
   useCloudEpicTasksQuery: () => ({ tasks: [] }),
 }));
 
+vi.mock("@/hooks/migration/use-phase-migrate-to-epic-mutation", () => ({
+  usePhaseMigrateToEpic: () => ({
+    data: undefined,
+    error: null,
+    isError: false,
+    isPending: true,
+    mutate: () => undefined,
+  }),
+}));
+
 vi.mock("@/components/onboarding/onboarding-page", () => ({
   OnboardingPage: () => <div data-testid="onboarding-page-stub" />,
 }));
@@ -87,6 +97,7 @@ vi.mock("@/components/epic-canvas/epic-route-session-body", () => ({
 
 const EPIC_ID = "epic-route-loop";
 const TAB_ID = "tab-route-existing";
+const STALE_TAB_ID = "tab-route-stale";
 
 function seedSignedInAuth(): void {
   useAuthStore.getState().setSignedIn(
@@ -163,6 +174,28 @@ describe("/epics/$epicId/$tabId route", () => {
     const state = useEpicCanvasStore.getState();
     expect(state.openTabOrder).toEqual([TAB_ID]);
     expect(Object.keys(state.tabsById)).toEqual([TAB_ID]);
+  });
+
+  it("repairs a stale tab route to a sibling tab without carrying nested focus params", async () => {
+    seedOpenEpicTab();
+
+    const router = renderAt(
+      `/epics/${EPIC_ID}/${STALE_TAB_ID}?focusPaneId=pane-stale&focusTileInstanceId=tile-stale&focusArtifactId=artifact-1&focusThreadId=thread-1&focusedAt=123&migrationSource=phase`,
+    );
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(
+        `/epics/${EPIC_ID}/${TAB_ID}`,
+      );
+    });
+    expect(router.state.location.search).toEqual({
+      focusedAt: 123,
+      focusArtifactId: "artifact-1",
+      focusThreadId: "thread-1",
+      migrationSource: "phase",
+      focusPaneId: undefined,
+      focusTileInstanceId: undefined,
+    });
   });
 
   it("shows the onboarding tour (not the epic) for an un-onboarded user on a deep route", async () => {

--- a/clients/gui-app/src/routes/__tests__/epics.$epicId.test.tsx
+++ b/clients/gui-app/src/routes/__tests__/epics.$epicId.test.tsx
@@ -75,6 +75,8 @@ function mountPhaseMigrationGate() {
           focusArtifactId: undefined,
           focusThreadId: undefined,
           migrationSource: "phase",
+          focusPaneId: undefined,
+          focusTileInstanceId: undefined,
         }}
       />
     ),

--- a/clients/gui-app/src/routes/epic-route-search.ts
+++ b/clients/gui-app/src/routes/epic-route-search.ts
@@ -3,6 +3,8 @@ export interface EpicFocusSearch {
   readonly focusArtifactId: string | undefined;
   readonly focusThreadId: string | undefined;
   readonly migrationSource: "phase" | undefined;
+  readonly focusPaneId: string | undefined;
+  readonly focusTileInstanceId: string | undefined;
 }
 
 export function normalizeEpicFocusSearch(
@@ -13,6 +15,8 @@ export function normalizeEpicFocusSearch(
     focusArtifactId: normalizeString(search.focusArtifactId),
     focusThreadId: normalizeString(search.focusThreadId),
     migrationSource: normalizeMigrationSource(search.migrationSource),
+    focusPaneId: normalizeString(search.focusPaneId),
+    focusTileInstanceId: normalizeString(search.focusTileInstanceId),
   };
 }
 

--- a/clients/gui-app/src/routes/epic-tab-route-components.tsx
+++ b/clients/gui-app/src/routes/epic-tab-route-components.tsx
@@ -170,6 +170,8 @@ function PhaseToEpicMigrationGateInner(props: {
           focusedAt={props.search.focusedAt}
           focusArtifactId={props.search.focusArtifactId}
           focusThreadId={props.search.focusThreadId}
+          focusPaneId={props.search.focusPaneId}
+          focusTileInstanceId={props.search.focusTileInstanceId}
         />
       </EpicSessionProvider>
     );

--- a/clients/gui-app/src/routes/epics.$epicId.$tabId.tsx
+++ b/clients/gui-app/src/routes/epics.$epicId.$tabId.tsx
@@ -17,13 +17,24 @@ export const Route = createFileRoute("/epics/$epicId/$tabId")({
     requireSignedIn(context);
     const state = useEpicCanvasStore.getState();
     const tab = state.tabsById[params.tabId];
-    if (tab?.epicId === params.epicId) return;
+    if (tab?.epicId === params.epicId) {
+      return;
+    }
     const fallback = state.resolveTabIdForEpic(params.epicId);
-    if (fallback === null) return;
+    if (fallback === null) {
+      return;
+    }
     redirect({
       to: "/epics/$epicId/$tabId",
       params: { epicId: params.epicId, tabId: fallback },
-      search,
+      search: {
+        focusedAt: search.focusedAt,
+        focusArtifactId: search.focusArtifactId,
+        focusThreadId: search.focusThreadId,
+        migrationSource: search.migrationSource,
+        focusPaneId: undefined,
+        focusTileInstanceId: undefined,
+      },
       throw: true,
     });
   },

--- a/clients/gui-app/src/routes/epics.$epicId.$tabId.tsx
+++ b/clients/gui-app/src/routes/epics.$epicId.$tabId.tsx
@@ -28,10 +28,7 @@ export const Route = createFileRoute("/epics/$epicId/$tabId")({
       to: "/epics/$epicId/$tabId",
       params: { epicId: params.epicId, tabId: fallback },
       search: {
-        focusedAt: search.focusedAt,
-        focusArtifactId: search.focusArtifactId,
-        focusThreadId: search.focusThreadId,
-        migrationSource: search.migrationSource,
+        ...search,
         focusPaneId: undefined,
         focusTileInstanceId: undefined,
       },

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/store.test.ts
@@ -18,6 +18,7 @@ import {
   makeSelectTabActivation,
   useEpicCanvasStore,
 } from "@/stores/epics/canvas/store";
+import { isBlankTileRef } from "@/stores/epics/canvas/types";
 import { epicCanvasKey } from "@/lib/persist";
 import type {
   EpicCanvasState,
@@ -26,6 +27,10 @@ import type {
   TilePane,
 } from "@/stores/epics/canvas/types";
 import type { DesktopPerWindowSnapshot } from "@/lib/windows/types";
+import {
+  getCurrentNestedFocusTarget,
+  type NestedFocusTarget,
+} from "@/lib/epic-nested-focus-route";
 import { SPEC_A, SPEC_B, SPEC_C, TEST_HOST_ID } from "./canvas-test-fixtures";
 
 // Resolve a pane's tab payloads in strip order via tilesByInstanceId.
@@ -74,6 +79,12 @@ function requirePane(canvas: EpicCanvasState, paneId: string): TilePane {
   const pane = findPaneById(canvas.root, paneId);
   if (pane === null) throw new Error(`Expected pane ${paneId}`);
   return pane;
+}
+
+function requireNestedFocusTarget(tabId: string): NestedFocusTarget {
+  const target = getCurrentNestedFocusTarget(requireCanvas(tabId));
+  if (target === null) throw new Error(`Expected focus target for ${tabId}`);
+  return target;
 }
 
 function requirePersistedCanvasByTabId(): Readonly<Record<string, unknown>> {
@@ -574,6 +585,244 @@ describe("epic canvas store header tabs", () => {
     const afterPane = requirePane(after, paneId);
     expect(afterPane.activeTabId).toBe(SPEC_B.instanceId);
     expect(afterPane.activationHistory).toEqual([SPEC_B.instanceId]);
+  });
+
+  it("applies nested route focus without opening a new canvas tile", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-route-focus", "Epic Route Focus");
+    store.openTileInTab(tabId, SPEC_A);
+    store.openTileInTab(tabId, SPEC_B);
+
+    const before = requireCanvas(tabId);
+    const paneId = before.activePaneId;
+    if (paneId === null) throw new Error("expected active pane");
+    expect(requirePane(before, paneId).activeTabId).toBe(SPEC_B.instanceId);
+    expect(allTabIds(before)).toEqual([SPEC_A.id, SPEC_B.id]);
+
+    store.applyNestedRouteFocus(tabId, {
+      paneId,
+      tileInstanceId: SPEC_A.instanceId,
+    });
+
+    const after = requireCanvas(tabId);
+    expect(requirePane(after, paneId).activeTabId).toBe(SPEC_A.instanceId);
+    expect(after.activePaneId).toBe(paneId);
+    expect(allTabIds(after)).toEqual([SPEC_A.id, SPEC_B.id]);
+  });
+
+  it("prepares exact targets for selecting tabs and focusing panes", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-prepare-select", "Prepare Select");
+    store.openTileInTab(tabId, SPEC_A);
+    store.openTileInTab(tabId, SPEC_B);
+    const sourcePaneId = requireCanvas(tabId).activePaneId;
+    if (sourcePaneId === null) throw new Error("expected source pane");
+
+    expect(
+      store.prepareSetActiveTileTabFocusTarget(
+        tabId,
+        sourcePaneId,
+        SPEC_A.instanceId,
+      ),
+    ).toEqual({ paneId: sourcePaneId, tileInstanceId: SPEC_A.instanceId });
+    expect(
+      store.prepareSetActiveTileTabFocusTarget(
+        tabId,
+        sourcePaneId,
+        SPEC_A.instanceId,
+      ),
+    ).toEqual({ paneId: sourcePaneId, tileInstanceId: SPEC_A.instanceId });
+
+    const emptyTarget = store.prepareSplitPaneEmptyFocusTarget(
+      tabId,
+      sourcePaneId,
+      "horizontal",
+    );
+    if (emptyTarget === null) throw new Error("expected empty pane target");
+    expect(emptyTarget.tileInstanceId).toBeUndefined();
+    expect(
+      store.prepareSetActiveTilePaneFocusTarget(tabId, sourcePaneId),
+    ).toEqual({ paneId: sourcePaneId, tileInstanceId: SPEC_A.instanceId });
+    expect(
+      store.prepareSetActiveTilePaneFocusTarget(tabId, emptyTarget.paneId),
+    ).toEqual(emptyTarget);
+  });
+
+  it("prepares open targets for dedup, preview promotion, blank reuse, and fill-in-place", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-prepare-open", "Prepare Open");
+    store.openTileInTab(tabId, SPEC_A);
+    store.openTileInTab(tabId, SPEC_B);
+    const paneId = requireCanvas(tabId).activePaneId;
+    if (paneId === null) throw new Error("expected pane");
+
+    expect(store.prepareOpenTileInTabFocusTarget(tabId, SPEC_A)).toEqual({
+      paneId,
+      tileInstanceId: SPEC_A.instanceId,
+    });
+
+    const previewTabId = store.openEpicTab(
+      "epic-prepare-preview",
+      "Prepare Preview",
+    );
+    store.openTilePreviewInTab(previewTabId, SPEC_A);
+    const previewPaneId = requireCanvas(previewTabId).activePaneId;
+    if (previewPaneId === null) throw new Error("expected preview pane");
+    expect(
+      requirePane(requireCanvas(previewTabId), previewPaneId).previewTabId,
+    ).toBe(SPEC_A.instanceId);
+    expect(store.prepareOpenTileInTabFocusTarget(previewTabId, SPEC_A)).toEqual(
+      { paneId: previewPaneId, tileInstanceId: SPEC_A.instanceId },
+    );
+    expect(
+      requirePane(requireCanvas(previewTabId), previewPaneId).previewTabId,
+    ).toBeNull();
+
+    const firstBlankTarget = store.prepareOpenBlankTabInPaneFocusTarget(
+      tabId,
+      paneId,
+    );
+    if (firstBlankTarget === null) throw new Error("expected blank target");
+    const blankInstanceId = firstBlankTarget.tileInstanceId;
+    if (blankInstanceId === undefined) throw new Error("expected blank tile");
+    const blankRef = requireCanvas(tabId).tilesByInstanceId[blankInstanceId];
+    if (blankRef === undefined) throw new Error("expected blank ref");
+    expect(isBlankTileRef(blankRef)).toBe(true);
+    expect(store.prepareOpenBlankTabInPaneFocusTarget(tabId, paneId)).toEqual(
+      firstBlankTarget,
+    );
+
+    const fillTarget = store.prepareOpenTileInPaneFocusTarget(
+      tabId,
+      paneId,
+      SPEC_C,
+    );
+    if (fillTarget === null || fillTarget.tileInstanceId === undefined) {
+      throw new Error("expected fill-in-place target");
+    }
+    expect(fillTarget.tileInstanceId).not.toBe(blankInstanceId);
+    expect(
+      requireCanvas(tabId).tilesByInstanceId[fillTarget.tileInstanceId]?.id,
+    ).toBe(SPEC_C.id);
+    expect(
+      store.prepareOpenTileInPaneFocusTarget(tabId, "missing-pane", SPEC_A),
+    ).toBeNull();
+  });
+
+  it("prepares split and active-move targets", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-prepare-split", "Prepare Split");
+    store.openTileInTab(tabId, SPEC_A);
+    const sourcePaneId = requireCanvas(tabId).activePaneId;
+    if (sourcePaneId === null) throw new Error("expected source pane");
+
+    const splitTarget = store.prepareSplitPaneWithNodeFocusTarget(
+      tabId,
+      sourcePaneId,
+      "right",
+      SPEC_B,
+    );
+    if (splitTarget === null || splitTarget.tileInstanceId === undefined) {
+      throw new Error("expected split target");
+    }
+    expect(splitTarget.paneId).not.toBe(sourcePaneId);
+    expect(
+      requireCanvas(tabId).tilesByInstanceId[splitTarget.tileInstanceId]?.id,
+    ).toBe(SPEC_B.id);
+
+    const emptyTarget = store.prepareSplitPaneEmptyFocusTarget(
+      tabId,
+      splitTarget.paneId,
+      "horizontal",
+    );
+    if (emptyTarget === null) throw new Error("expected empty split target");
+    expect(emptyTarget.tileInstanceId).toBeUndefined();
+
+    store.setActiveTileTab(
+      tabId,
+      splitTarget.paneId,
+      splitTarget.tileInstanceId,
+    );
+    const movedTarget = store.prepareMoveActiveTabOnTabStripFocusTarget(tabId, {
+      sourcePaneId: splitTarget.paneId,
+      tabId: splitTarget.tileInstanceId,
+      targetPaneId: emptyTarget.paneId,
+      targetIndex: 0,
+    });
+
+    expect(movedTarget).toEqual({
+      paneId: emptyTarget.paneId,
+      tileInstanceId: splitTarget.tileInstanceId,
+    });
+  });
+
+  it("prepares close fallbacks for active targets and null for inactive close", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-prepare-close", "Prepare Close");
+    store.openTileInTab(tabId, SPEC_A);
+    store.openTileInTab(tabId, SPEC_B);
+    const paneId = requireCanvas(tabId).activePaneId;
+    if (paneId === null) throw new Error("expected pane");
+
+    expect(
+      store.prepareCloseCanvasTabFocusTarget(tabId, paneId, SPEC_B.instanceId),
+    ).toEqual({ paneId, tileInstanceId: SPEC_A.instanceId });
+
+    store.openTileInTab(tabId, SPEC_B);
+    store.setActiveTileTab(tabId, paneId, SPEC_A.instanceId);
+
+    expect(
+      store.prepareCloseCanvasTabFocusTarget(tabId, paneId, SPEC_B.instanceId),
+    ).toBeNull();
+    expect(allTabIds(requireCanvas(tabId))).toEqual([SPEC_A.id]);
+
+    const inactivePaneTarget = store.prepareSplitPaneWithNodeFocusTarget(
+      tabId,
+      paneId,
+      "right",
+      SPEC_C,
+    );
+    if (inactivePaneTarget === null) {
+      throw new Error("expected inactive pane setup");
+    }
+    store.setActiveTilePane(tabId, paneId);
+    expect(
+      store.prepareCloseCanvasPaneFocusTarget(tabId, inactivePaneTarget.paneId),
+    ).toBeNull();
+
+    const emptyFallback = store.prepareCloseAllCanvasTabsFocusTarget(
+      tabId,
+      paneId,
+    );
+    if (emptyFallback === null) {
+      throw new Error("expected empty fallback target");
+    }
+    expect(emptyFallback.paneId).not.toBe(paneId);
+    expect(emptyFallback.tileInstanceId).toBeUndefined();
+    expect(requireNestedFocusTarget(tabId)).toEqual(emptyFallback);
+  });
+
+  it("prepares null for resize layout updates while preserving the raw mutation", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-prepare-resize", "Prepare Resize");
+    store.openTileInTab(tabId, SPEC_A);
+    const paneId = requireCanvas(tabId).activePaneId;
+    if (paneId === null) throw new Error("expected pane");
+    store.splitPaneWithNode(tabId, paneId, "right", SPEC_B);
+    const canvas = requireCanvas(tabId);
+    if (canvas.root === null || canvas.root.kind !== "group") {
+      throw new Error("expected split group");
+    }
+
+    expect(
+      store.prepareResizeSplitFocusTarget(tabId, canvas.root.id, [0.25, 0.75]),
+    ).toBeNull();
+    expect(requireCanvas(tabId).sizesByGroupId[canvas.root.id]).toEqual([
+      0.25, 0.75,
+    ]);
+    expect(requireNestedFocusTarget(tabId)).toEqual(
+      getCurrentNestedFocusTarget(requireCanvas(tabId)),
+    );
   });
 
   it("keeps a freshly-created untitled (empty-name) tab through a projection round-trip", () => {

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -19,6 +19,12 @@ import {
   type EpicNodeKind,
   type EpicNodeRecord,
 } from "@/lib/artifacts/node-display";
+import {
+  areNestedFocusTargetsEqual,
+  getCurrentNestedFocusTarget,
+  resolveNestedFocusTarget,
+  type NestedFocusTarget,
+} from "@/lib/epic-nested-focus-route";
 import { UNTITLED_EPIC_TITLE } from "@/lib/display-title";
 import { createEpicName } from "@/lib/epic-name";
 import type {
@@ -223,17 +229,29 @@ export interface EpicCanvasStore {
    * this one action.
    */
   openTileInTab: (tabId: string, node: EpicCanvasTileRef) => void;
+  prepareOpenTileInTabFocusTarget: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
   /**
    * Open a tile in preview mode (italic tab), replacing the destination
    * pane's existing preview. Same dedup as `openTileInTab`.
    */
   openTilePreviewInTab: (tabId: string, node: EpicCanvasTileRef) => void;
+  prepareOpenTilePreviewInTabFocusTarget: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
   /**
    * Add `node` as a tab in the active pane without changing the active
    * tab/pane (persists a server-created terminal as a saved tab without
    * stealing focus). Idempotent.
    */
   openTileInBackgroundTab: (tabId: string, node: EpicCanvasTileRef) => void;
+  prepareOpenTileInBackgroundTabFocusTarget: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
   /**
    * Opener-only path: open `ref` into the explicit `paneId` as a fresh tab
    * instance, bypassing dedup. A second view of an already-open content id is
@@ -244,12 +262,21 @@ export interface EpicCanvasStore {
     paneId: string,
     ref: EpicCanvasTileRef,
   ) => void;
+  prepareOpenTileInPaneFocusTarget: (
+    tabId: string,
+    paneId: string,
+    ref: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
   /**
    * Open a blank "New tab" in `paneId`, made active. Reuse-if-active-is-blank:
    * a no-op-ish focus when the pane's active tab is already blank.
    * See {@link openBlankTabInPaneCanvas}.
    */
   openBlankTabInPane: (tabId: string, paneId: string) => void;
+  prepareOpenBlankTabInPaneFocusTarget: (
+    tabId: string,
+    paneId: string,
+  ) => NestedFocusTarget | null;
   updateGitDiffTileViewInTab: (
     tabId: string,
     tileId: string,
@@ -271,22 +298,52 @@ export interface EpicCanvasStore {
     filePath: string,
   ) => void;
   promotePreviewInTab: (tabId: string, paneId: string) => void;
+  applyNestedRouteFocus: (tabId: string, target: NestedFocusTarget) => void;
   setActiveTileTab: (tabId: string, paneId: string, tileTabId: string) => void;
+  prepareSetActiveTileTabFocusTarget: (
+    tabId: string,
+    paneId: string,
+    tileTabId: string,
+  ) => NestedFocusTarget | null;
   setActiveTilePane: (tabId: string, paneId: string) => void;
+  prepareSetActiveTilePaneFocusTarget: (
+    tabId: string,
+    paneId: string,
+  ) => NestedFocusTarget | null;
   insertNodeOnTabStrip: (
     tabId: string,
     targetPaneId: string,
     targetIndex: number,
     node: EpicCanvasTileRef,
   ) => void;
+  prepareInsertNodeOnTabStripFocusTarget: (
+    tabId: string,
+    targetPaneId: string,
+    targetIndex: number,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
   moveTabOnTabStrip: (tabId: string, args: TabMoveArgs) => void;
+  prepareMoveActiveTabOnTabStripFocusTarget: (
+    tabId: string,
+    args: TabMoveArgs,
+  ) => NestedFocusTarget | null;
   splitPaneWithNode: (
     tabId: string,
     targetPaneId: string,
     position: EdgeDropPosition,
     node: EpicCanvasTileRef,
   ) => void;
+  prepareSplitPaneWithNodeFocusTarget: (
+    tabId: string,
+    targetPaneId: string,
+    position: EdgeDropPosition,
+    node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
   splitPaneWithTab: (tabId: string, args: TabSplitArgs) => void;
+  prepareSplitPaneWithTabFocusTarget: (
+    tabId: string,
+    args: TabSplitArgs,
+  ) => NestedFocusTarget | null;
   /**
    * Split into a trailing empty pane. Returns the new empty pane's id (which
    * `splitPaneEmpty` makes active) so callers can bind the opener to it, or
@@ -297,30 +354,63 @@ export interface EpicCanvasStore {
     targetPaneId: string,
     direction: SplitDirection,
   ) => string | null;
+  prepareSplitPaneEmptyFocusTarget: (
+    tabId: string,
+    targetPaneId: string,
+    direction: SplitDirection,
+  ) => NestedFocusTarget | null;
   /** Convenience for the explicit far-right split button (horizontal). */
   splitPaneEmptyRightInTab: (
     tabId: string,
     targetPaneId: string,
   ) => string | null;
   closeCanvasTab: (tabId: string, paneId: string, tileTabId: string) => void;
+  prepareCloseCanvasTabFocusTarget: (
+    tabId: string,
+    paneId: string,
+    tileTabId: string,
+  ) => NestedFocusTarget | null;
   closeOtherCanvasTabs: (
     tabId: string,
     paneId: string,
     tileTabId: string,
   ) => void;
+  prepareCloseOtherCanvasTabsFocusTarget: (
+    tabId: string,
+    paneId: string,
+    tileTabId: string,
+  ) => NestedFocusTarget | null;
   closeRightCanvasTabs: (
     tabId: string,
     paneId: string,
     tileTabId: string,
   ) => void;
+  prepareCloseRightCanvasTabsFocusTarget: (
+    tabId: string,
+    paneId: string,
+    tileTabId: string,
+  ) => NestedFocusTarget | null;
   closeAllCanvasTabs: (tabId: string, paneId: string) => void;
+  prepareCloseAllCanvasTabsFocusTarget: (
+    tabId: string,
+    paneId: string,
+  ) => NestedFocusTarget | null;
   closeCanvasPane: (tabId: string, paneId: string) => void;
+  prepareCloseCanvasPaneFocusTarget: (
+    tabId: string,
+    paneId: string,
+  ) => NestedFocusTarget | null;
   /** Commit a group's child fractions (clamped + normalized) on pointer-up. */
   resizeSplitInTab: (
     tabId: string,
     groupId: string,
     sizes: ReadonlyArray<number>,
   ) => void;
+  prepareResizeSplitFocusTarget: (
+    tabId: string,
+    groupId: string,
+    sizes: ReadonlyArray<number>,
+  ) => NestedFocusTarget | null;
   renameArtifactInTab: (
     tabId: string,
     artifactId: string,
@@ -632,6 +722,46 @@ function updateTabCanvas(
       [tabId]: next,
     },
   };
+}
+
+function canvasForExistingTab(
+  state: EpicCanvasStore,
+  tabId: string,
+): EpicCanvasState | null {
+  if (state.tabsById[tabId] === undefined) return null;
+  return state.canvasByTabId[tabId] ?? EMPTY_CANVAS;
+}
+
+function currentNestedFocusTargetForTab(
+  state: EpicCanvasStore,
+  tabId: string,
+): NestedFocusTarget | null {
+  const canvas = canvasForExistingTab(state, tabId);
+  return canvas === null ? null : getCurrentNestedFocusTarget(canvas);
+}
+
+function exactNestedFocusTargetForTab(
+  state: EpicCanvasStore,
+  tabId: string,
+  target: NestedFocusTarget,
+): NestedFocusTarget | null {
+  const canvas = canvasForExistingTab(state, tabId);
+  return canvas === null ? null : resolveNestedFocusTarget(canvas, target);
+}
+
+function changedNestedFocusTarget(
+  before: NestedFocusTarget | null,
+  after: NestedFocusTarget | null,
+): NestedFocusTarget | null {
+  return areNestedFocusTargetsEqual(before, after) ? null : after;
+}
+
+function changedCanvasFocusTarget(
+  before: EpicCanvasState | null,
+  after: EpicCanvasState | null,
+): NestedFocusTarget | null {
+  if (before === null || after === null || before === after) return null;
+  return getCurrentNestedFocusTarget(after);
 }
 
 interface AppendArtifactRecordArgs {
@@ -1043,12 +1173,24 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         );
       },
 
+      prepareOpenTileInTabFocusTarget: (tabId, node) => {
+        get().openTileInTab(tabId, node);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        return after;
+      },
+
       openTilePreviewInTab: (tabId, node) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             openTile(canvas, node, true),
           ),
         );
+      },
+
+      prepareOpenTilePreviewInTabFocusTarget: (tabId, node) => {
+        get().openTilePreviewInTab(tabId, node);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        return after;
       },
 
       openTileInBackgroundTab: (tabId, node) => {
@@ -1059,6 +1201,11 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         );
       },
 
+      prepareOpenTileInBackgroundTabFocusTarget: (tabId, node) => {
+        get().openTileInBackgroundTab(tabId, node);
+        return null;
+      },
+
       openTileInPane: (tabId, paneId, ref) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
@@ -1067,12 +1214,32 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         );
       },
 
+      prepareOpenTileInPaneFocusTarget: (tabId, paneId, ref) => {
+        const before = canvasForExistingTab(get(), tabId);
+        const targetPane =
+          before === null ? null : findPaneById(before.root, paneId);
+        get().openTileInPane(tabId, paneId, ref);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = targetPane === null ? null : after;
+        return target;
+      },
+
       openBlankTabInPane: (tabId, paneId) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             openBlankTabInPaneCanvas(canvas, paneId),
           ),
         );
+      },
+
+      prepareOpenBlankTabInPaneFocusTarget: (tabId, paneId) => {
+        const before = canvasForExistingTab(get(), tabId);
+        const targetPane =
+          before === null ? null : findPaneById(before.root, paneId);
+        get().openBlankTabInPane(tabId, paneId);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = targetPane === null ? null : after;
+        return target;
       },
 
       updateGitDiffTileViewInTab: (tabId, tileId, view) => {
@@ -1115,6 +1282,20 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         );
       },
 
+      applyNestedRouteFocus: (tabId, target) => {
+        set((state) =>
+          updateTabCanvas(state, tabId, (canvas) =>
+            target.tileInstanceId === undefined
+              ? setActivePane(canvas, target.paneId)
+              : setActiveTileTabCanvas(
+                  canvas,
+                  target.paneId,
+                  target.tileInstanceId,
+                ),
+          ),
+        );
+      },
+
       setActiveTileTab: (tabId, paneId, tileTabId) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
@@ -1123,12 +1304,28 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         );
       },
 
+      prepareSetActiveTileTabFocusTarget: (tabId, paneId, tileTabId) => {
+        get().setActiveTileTab(tabId, paneId, tileTabId);
+        const target = exactNestedFocusTargetForTab(get(), tabId, {
+          paneId,
+          tileInstanceId: tileTabId,
+        });
+        return target;
+      },
+
       setActiveTilePane: (tabId, paneId) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             setActivePane(canvas, paneId),
           ),
         );
+      },
+
+      prepareSetActiveTilePaneFocusTarget: (tabId, paneId) => {
+        get().setActiveTilePane(tabId, paneId);
+        const target = currentNestedFocusTargetForTab(get(), tabId);
+        const returned = target?.paneId === paneId ? target : null;
+        return returned;
       },
 
       insertNodeOnTabStrip: (tabId, targetPaneId, targetIndex, node) => {
@@ -1142,6 +1339,21 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             ),
           ),
         );
+      },
+
+      prepareInsertNodeOnTabStripFocusTarget: (
+        tabId,
+        targetPaneId,
+        targetIndex,
+        node,
+      ) => {
+        const before = canvasForExistingTab(get(), tabId);
+        const targetPane =
+          before === null ? null : findPaneById(before.root, targetPaneId);
+        get().insertNodeOnTabStrip(tabId, targetPaneId, targetIndex, node);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = targetPane === null ? null : after;
+        return target;
       },
 
       moveTabOnTabStrip: (tabId, args) => {
@@ -1165,6 +1377,22 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         );
       },
 
+      prepareMoveActiveTabOnTabStripFocusTarget: (tabId, args) => {
+        const beforeCanvas = canvasForExistingTab(get(), tabId);
+        const before = currentNestedFocusTargetForTab(get(), tabId);
+        get().moveTabOnTabStrip(tabId, args);
+        const afterCanvas = canvasForExistingTab(get(), tabId);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target =
+          before?.tileInstanceId !== args.tabId ||
+          beforeCanvas === null ||
+          afterCanvas === null ||
+          beforeCanvas === afterCanvas
+            ? null
+            : changedNestedFocusTarget(before, after);
+        return target;
+      },
+
       splitPaneWithNode: (tabId, targetPaneId, position, node) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
@@ -1174,6 +1402,19 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             }),
           ),
         );
+      },
+
+      prepareSplitPaneWithNodeFocusTarget: (
+        tabId,
+        targetPaneId,
+        position,
+        node,
+      ) => {
+        const before = canvasForExistingTab(get(), tabId);
+        get().splitPaneWithNode(tabId, targetPaneId, position, node);
+        const after = canvasForExistingTab(get(), tabId);
+        const target = changedCanvasFocusTarget(before, after);
+        return target;
       },
 
       splitPaneWithTab: (tabId, args) => {
@@ -1190,6 +1431,14 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             });
           }),
         );
+      },
+
+      prepareSplitPaneWithTabFocusTarget: (tabId, args) => {
+        const before = canvasForExistingTab(get(), tabId);
+        get().splitPaneWithTab(tabId, args);
+        const after = canvasForExistingTab(get(), tabId);
+        const target = changedCanvasFocusTarget(before, after);
+        return target;
       },
 
       splitPaneEmptyInTab: (tabId, targetPaneId, direction) => {
@@ -1209,6 +1458,17 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
           };
         });
         return newPaneId;
+      },
+
+      prepareSplitPaneEmptyFocusTarget: (tabId, targetPaneId, direction) => {
+        const paneId = get().splitPaneEmptyInTab(
+          tabId,
+          targetPaneId,
+          direction,
+        );
+        const target =
+          paneId === null ? null : { paneId, tileInstanceId: undefined };
+        return target;
       },
 
       splitPaneEmptyRightInTab: (tabId, targetPaneId) =>
@@ -1237,6 +1497,22 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         });
       },
 
+      prepareCloseCanvasTabFocusTarget: (tabId, paneId, tileTabId) => {
+        const before = currentNestedFocusTargetForTab(get(), tabId);
+        get().closeCanvasTab(tabId, paneId, tileTabId);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = changedNestedFocusTarget(before, after);
+        return target;
+      },
+
+      prepareCloseOtherCanvasTabsFocusTarget: (tabId, paneId, tileTabId) => {
+        const before = currentNestedFocusTargetForTab(get(), tabId);
+        get().closeOtherCanvasTabs(tabId, paneId, tileTabId);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = changedNestedFocusTarget(before, after);
+        return target;
+      },
+
       closeOtherCanvasTabs: (tabId, paneId, tileTabId) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
@@ -1253,6 +1529,14 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         );
       },
 
+      prepareCloseRightCanvasTabsFocusTarget: (tabId, paneId, tileTabId) => {
+        const before = currentNestedFocusTargetForTab(get(), tabId);
+        get().closeRightCanvasTabs(tabId, paneId, tileTabId);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = changedNestedFocusTarget(before, after);
+        return target;
+      },
+
       closeAllCanvasTabs: (tabId, paneId) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
@@ -1261,10 +1545,26 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         );
       },
 
+      prepareCloseAllCanvasTabsFocusTarget: (tabId, paneId) => {
+        const before = currentNestedFocusTargetForTab(get(), tabId);
+        get().closeAllCanvasTabs(tabId, paneId);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = changedNestedFocusTarget(before, after);
+        return target;
+      },
+
       closeCanvasPane: (tabId, paneId) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) => closePane(canvas, paneId)),
         );
+      },
+
+      prepareCloseCanvasPaneFocusTarget: (tabId, paneId) => {
+        const before = currentNestedFocusTargetForTab(get(), tabId);
+        get().closeCanvasPane(tabId, paneId);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = changedNestedFocusTarget(before, after);
+        return target;
       },
 
       resizeSplitInTab: (tabId, groupId, sizes) => {
@@ -1273,6 +1573,11 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             resizeSplit(canvas, groupId, sizes),
           ),
         );
+      },
+
+      prepareResizeSplitFocusTarget: (tabId, groupId, sizes) => {
+        get().resizeSplitInTab(tabId, groupId, sizes);
+        return null;
       },
 
       renameArtifactInTab: (tabId, artifactId, name) => {

--- a/clients/gui-app/src/stores/tabs/__tests__/system-overlay-promotion-back-nav.test.tsx
+++ b/clients/gui-app/src/stores/tabs/__tests__/system-overlay-promotion-back-nav.test.tsx
@@ -1,0 +1,244 @@
+// Regression test for: back button dead after promoting a system overlay to
+// a tab. Replays: real back history -> open settings overlay -> click-out
+// close -> forward -> promote to tab -> back click, against a `GateLike`
+// component that mirrors `LocalHostGate`'s PRE-FIX structural swap
+// (`<>{children}</>` on bypass vs `<Wrapper>{children}</Wrapper>` when
+// ready), so React remounts the gated subtree on every `/settings` boundary
+// crossing exactly like the real pre-fix bug.
+//
+// `GateLike` is kept REMOUNTING on purpose - it is not the thing layers 2+3
+// fix (that's layer 1, in `local-host-gate.tsx`). It stands in for ANY
+// future ancestor that remounts this subtree, and this test proves the
+// module-scoped cold-load latch (layer 2) plus `replace` semantics on the
+// focus-tab-first redirect (layer 3) defeat the back-button trap even under
+// such a remount, independent of layer 1.
+import "../../../../__tests__/test-browser-apis";
+import { useEffect, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import {
+  Outlet,
+  RouterProvider,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  useRouterState,
+  type RouterHistory,
+} from "@tanstack/react-router";
+import {
+  resetSystemTabModalColdLoadForTests,
+  useSystemTabModalController,
+  useSystemTabModalRefreshGuard,
+  type SystemTabModalApi,
+} from "@/stores/tabs/use-system-tab-modal";
+import {
+  createPersistentMemoryHistory,
+  getHistoryController,
+} from "@/lib/persistent-history";
+import { goBack, goForward } from "@/lib/commands/actions/history-navigation";
+import { useSettingsSectionStore } from "@/stores/tabs/settings-section-store";
+import { useTabsStore } from "@/stores/tabs/store";
+import { systemTabOverlaySearchSchema } from "@/lib/system-tab-overlay-search";
+
+const modalProbe: { current: SystemTabModalApi | null } = { current: null };
+const hostMountLog: string[] = [];
+
+function ModalHostLike() {
+  useSystemTabModalRefreshGuard();
+  const api = useSystemTabModalController();
+  useEffect(() => {
+    hostMountLog.push("mounted");
+    return () => {
+      hostMountLog.push("unmounted");
+    };
+  }, []);
+  useEffect(() => {
+    modalProbe.current = api;
+  });
+  return null;
+}
+
+function CompatGateLike(props: { readonly children: ReactNode }) {
+  return <>{props.children}</>;
+}
+
+// Mirrors `LocalHostGate` PRE-FIX: bypass -> bare children; ready -> children
+// under a wrapper component. Different root element types => React remounts
+// the subtree when `bypass` flips at the /settings boundary.
+function GateLike(props: { readonly children: ReactNode }) {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const bypass = pathname.startsWith("/settings");
+  if (bypass) {
+    return <>{props.children}</>;
+  }
+  return <CompatGateLike>{props.children}</CompatGateLike>;
+}
+
+function GuardedRoot() {
+  return (
+    <GateLike>
+      <ModalHostLike />
+      <Outlet />
+    </GateLike>
+  );
+}
+
+function buildRouter(windowId: string) {
+  const rootRoute = createRootRoute({
+    validateSearch: (raw) => systemTabOverlaySearchSchema.parse(raw),
+    component: GuardedRoot,
+  });
+  const epicRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/epics/$epicId/$tabId",
+    component: () => <div data-testid="epic-route" />,
+  });
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings/general",
+    component: () => <div data-testid="settings-route" />,
+  });
+  const history = createPersistentMemoryHistory(null, windowId);
+  return createRouter({
+    routeTree: rootRoute.addChildren([epicRoute, settingsRoute]),
+    history,
+  });
+}
+
+function seedPersisted(
+  windowId: string,
+  entries: ReadonlyArray<string>,
+  index: number,
+) {
+  window.localStorage.setItem(
+    `traycer-gui-app:last-route:${windowId}`,
+    JSON.stringify({ entries, index }),
+  );
+}
+
+interface SnapshotRouter {
+  readonly history: RouterHistory;
+  readonly state: { readonly location: { readonly href: string } };
+}
+
+function snapshot(router: SnapshotRouter) {
+  const controller = getHistoryController(router.history);
+  if (controller === null) throw new Error("no controller");
+  return {
+    entries: controller.getEntries(),
+    index: controller.getIndex(),
+    canGoBack: controller.canGoBack(),
+    canGoForward: controller.canGoForward(),
+    rendered: router.state.location.href,
+  };
+}
+
+describe("back stays functional after promoting a system overlay to a tab", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    modalProbe.current = null;
+    hostMountLog.length = 0;
+    resetSystemTabModalColdLoadForTests();
+    useSettingsSectionStore.setState({ section: null });
+    useTabsStore.setState({ systemTabs: { history: null, settings: null } });
+  });
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
+
+  it("back click #1 after promotion escapes the overlay entry instead of re-pushing the tab route", async () => {
+    const windowId = "promote-back-nav";
+    seedPersisted(windowId, ["/epics/e/t0", "/epics/e/t1"], 1);
+    const router = buildRouter(windowId);
+    render(<RouterProvider router={router} />);
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/epics/e/t1"),
+    );
+    await waitFor(() => expect(modalProbe.current).not.toBeNull());
+
+    act(() => {
+      modalProbe.current?.openSettings({
+        section: null,
+        resetToGeneral: false,
+      });
+    });
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        settingsOverlay: true,
+      }),
+    );
+
+    act(() => {
+      modalProbe.current?.close();
+    });
+    await waitFor(() =>
+      expect(router.state.location.search).not.toHaveProperty(
+        "settingsOverlay",
+      ),
+    );
+
+    act(() => {
+      goForward(router);
+    });
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({
+        settingsOverlay: true,
+      }),
+    );
+
+    act(() => {
+      modalProbe.current?.promoteToTab();
+    });
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe("/settings/general"),
+    );
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    const before = snapshot(router);
+    expect(before.rendered).toBe("/settings/general");
+
+    act(() => {
+      goBack(router);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+
+    const afterFirstBack = snapshot(router);
+    // The core trap: pre-fix, the guard's cold-load-only redirect re-arms on
+    // the remount this Back triggers and immediately pushes /settings/general
+    // right back on top, leaving `rendered` byte-identical to `before`. With
+    // the module-scoped latch (layer 2) that redirect can never re-fire past
+    // the first ever boot, so the stack the real `history.go(-1)` produced
+    // survives - back click #1 lands on the real underlying page, not a
+    // re-push of /settings/general onto a byte-identical stack.
+    expect(afterFirstBack.rendered).not.toBe(before.rendered);
+    expect(router.state.location.pathname).toBe("/epics/e/t1");
+    expect(afterFirstBack.canGoBack).toBe(true);
+
+    // Note: `GateLike` here still remounts the guard on every /settings
+    // boundary crossing (it is not layer 1's fix), so the auto-close branch's
+    // `lastPathnameRef` is reborn already-equal to the post-navigation
+    // pathname on this exact click and can't detect the change; the stray
+    // `settingsOverlay` search flag on this entry survives one extra click
+    // as a result. That collapse-in-one-click only happens once layer 1
+    // stops the remounts (proven separately in `local-host-gate.test.tsx`).
+    // What matters here is what layers 2+3 alone guarantee: back never
+    // bounces to /settings/general again, and repeated presses make
+    // monotonic progress back to the original entry instead of looping.
+    for (let clicksRemaining = 2; clicksRemaining > 0; clicksRemaining--) {
+      act(() => {
+        goBack(router);
+      });
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+      expect(router.state.location.pathname).not.toBe("/settings/general");
+    }
+
+    expect(router.state.location.pathname).toBe("/epics/e/t0");
+  });
+});

--- a/clients/gui-app/src/stores/tabs/__tests__/use-system-tab-modal.test.tsx
+++ b/clients/gui-app/src/stores/tabs/__tests__/use-system-tab-modal.test.tsx
@@ -12,12 +12,16 @@ import {
 } from "@tanstack/react-router";
 import {
   canPopOverlayEntry,
+  resetSystemTabModalColdLoadForTests,
   useSystemTabModalActions,
   useSystemTabModalController,
   useSystemTabModalRefreshGuard,
   type SystemTabModalApi,
 } from "@/stores/tabs/use-system-tab-modal";
-import { createPersistentMemoryHistory } from "@/lib/persistent-history";
+import {
+  createPersistentMemoryHistory,
+  getHistoryController,
+} from "@/lib/persistent-history";
 import { useSettingsSectionStore } from "@/stores/tabs/settings-section-store";
 import { useTabsStore } from "@/stores/tabs/store";
 import { systemTabOverlaySearchSchema } from "@/lib/system-tab-overlay-search";
@@ -28,7 +32,10 @@ function GuardedRoot() {
 }
 
 function buildRouter(initialPath: string) {
-  const rootRoute = createRootRoute({ component: GuardedRoot });
+  const rootRoute = createRootRoute({
+    validateSearch: (raw) => systemTabOverlaySearchSchema.parse(raw),
+    component: GuardedRoot,
+  });
   const epicRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/epics/$epicId/$tabId",
@@ -42,6 +49,32 @@ function buildRouter(initialPath: string) {
   return createRouter({
     routeTree: rootRoute.addChildren([epicRoute, settingsRoute]),
     history: createMemoryHistory({ initialEntries: [initialPath] }),
+  });
+}
+
+// Same route tree as `buildRouter`, backed by the real persistent history
+// (`createPersistentMemoryHistory`) instead of a plain in-memory one, so
+// tests can assert on `getHistoryController(...)`'s live stack/cursor - the
+// cold-load redirect's `replace` semantics only interact with adjacent-
+// duplicate collapse on the persistent controller, not on `createMemoryHistory`.
+function buildPersistentRouter(windowId: string) {
+  const rootRoute = createRootRoute({
+    validateSearch: (raw) => systemTabOverlaySearchSchema.parse(raw),
+    component: GuardedRoot,
+  });
+  const epicRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/epics/$epicId/$tabId",
+    component: () => <div data-testid="epic-route" />,
+  });
+  const settingsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/settings/general",
+    component: () => <div data-testid="settings-route" />,
+  });
+  return createRouter({
+    routeTree: rootRoute.addChildren([epicRoute, settingsRoute]),
+    history: createPersistentMemoryHistory(null, windowId),
   });
 }
 
@@ -167,8 +200,17 @@ describe("settings section is store-backed, not URL-backed", () => {
 });
 
 describe("useSystemTabModalRefreshGuard", () => {
+  beforeEach(() => {
+    // The cold-load latch is module-scoped ("once per renderer boot"), not
+    // per-hook-instance, so tests must reset it explicitly between cases -
+    // otherwise a prior test's boot consumes it and the redirect below never
+    // gets to fire.
+    resetSystemTabModalColdLoadForTests();
+    useTabsStore.setState({ systemTabs: { history: null, settings: null } });
+  });
   afterEach(() => {
     cleanup();
+    useTabsStore.setState({ systemTabs: { history: null, settings: null } });
   });
 
   it("does not issue a second navigation when no system modal overlay is open", async () => {
@@ -185,6 +227,108 @@ describe("useSystemTabModalRefreshGuard", () => {
     });
 
     expect(navigateSpy).toHaveBeenCalledOnce();
+  });
+
+  it("fires the focus-tab-first redirect exactly once on cold load, using replace", async () => {
+    // Simulates a genuine cold boot: the persisted/restored URL carries an
+    // overlay flag, but the settings tab is already open (e.g. restored from
+    // a prior session). The guard's first-ever effect pass must redirect
+    // straight to the tab and drop the overlay param.
+    useTabsStore.setState({
+      systemTabs: {
+        history: null,
+        settings: {
+          id: "settings",
+          kind: "settings",
+          name: "Settings",
+          lastPath: "/settings/general",
+        },
+      },
+    });
+    const router = buildRouter("/epics/epic-1/tab-1?settingsOverlay=true");
+    const navigateSpy = vi.spyOn(router, "navigate");
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/settings/general");
+    });
+    expect(router.state.location.search).not.toHaveProperty("settingsOverlay");
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(navigateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ replace: true }),
+    );
+
+    // A later in-app crossing back onto an overlay-flagged URL must NOT
+    // re-trigger the cold-load-only redirect. Unlike the old per-instance
+    // ref (which reset on any ancestor remount), the module-scoped latch
+    // stays consumed for the rest of the renderer's life, so this can only
+    // land back on `/settings/general` if the redirect incorrectly re-fires.
+    navigateSpy.mockClear();
+    await router.navigate({
+      to: "/epics/$epicId/$tabId",
+      params: { epicId: "epic-1", tabId: "tab-1" },
+      search: {
+        focusedAt: undefined,
+        focusArtifactId: undefined,
+        focusThreadId: undefined,
+        migrationSource: undefined,
+        focusPaneId: undefined,
+        focusTileInstanceId: undefined,
+        settingsOverlay: true,
+      },
+    });
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/epics/epic-1/tab-1");
+    });
+  });
+
+  it("cold boot onto an overlay entry with the tab route already ahead leaves no dead forward step", async () => {
+    // A restored stack where the redirect target is ALREADY the next
+    // persisted entry (e.g. the user promoted the overlay to a tab in a
+    // prior session, then quit with the cursor back on the overlay entry).
+    // The cold-load redirect's `replace` must collapse that forward
+    // duplicate, not just land on it and leave a dead forward step.
+    useTabsStore.setState({
+      systemTabs: {
+        history: null,
+        settings: {
+          id: "settings",
+          kind: "settings",
+          name: "Settings",
+          lastPath: "/settings/general",
+        },
+      },
+    });
+    const windowId = "cold-boot-overlay-ahead";
+    window.localStorage.setItem(
+      `traycer-gui-app:last-route:${windowId}`,
+      JSON.stringify({
+        entries: [
+          "/epics/epic-1/tab-1",
+          "/epics/epic-1/tab-1?settingsOverlay=true",
+          "/settings/general",
+        ],
+        index: 1,
+      }),
+    );
+    const router = buildPersistentRouter(windowId);
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/settings/general");
+    });
+    expect(router.state.location.search).not.toHaveProperty("settingsOverlay");
+
+    const controller = getHistoryController(router.history);
+    if (controller === null) {
+      throw new Error("expected a persistent controller");
+    }
+    expect(controller.getEntries()).toEqual([
+      "/epics/epic-1/tab-1",
+      "/settings/general",
+    ]);
+    expect(controller.getIndex()).toBe(1);
+    expect(controller.canGoForward()).toBe(false);
   });
 });
 

--- a/clients/gui-app/src/stores/tabs/kinds/epic.tsx
+++ b/clients/gui-app/src/stores/tabs/kinds/epic.tsx
@@ -4,6 +4,7 @@ import {
   epicHasUnsyncedEdits,
   releaseOpenEpicSessionIfUnused,
 } from "@/lib/registries/epic-session-registry";
+import { buildNestedFocusSearchPatch } from "@/lib/epic-nested-focus-route";
 import { epicPathname, epicTabRoute } from "@/lib/routes";
 import { existingEpicTabIntent } from "@/lib/tab-navigation/intents";
 import { duplicateEpicTab } from "@/lib/commands/actions/duplicate-tab";
@@ -47,7 +48,16 @@ export const epicTabModule: TabKindModule<"epic", EpicViewTab> = {
       }),
     routeOptions: (intent) => ({
       ...epicTabRoute({ epicId: intent.epicId, tabId: intent.tabId }),
-      search: intent.focus,
+      // `nestedFocus` is `null` for every plain tab-switch intent, in which
+      // case `buildNestedFocusSearchPatch` contributes `undefined` for both
+      // fields - identical to the old `search: intent.focus` literal, so
+      // wipe-then-canonicalize behavior is unchanged for ordinary switches.
+      // Only `existingEpicTabIntentWithNestedFocus` (cross-route openers)
+      // sets a real target, committing it in this same navigation.
+      search: {
+        ...intent.focus,
+        ...buildNestedFocusSearchPatch(intent.nestedFocus),
+      },
     }),
     activate: (intent) => {
       useLandingDraftStore.getState().clearActiveDraft();

--- a/clients/gui-app/src/stores/tabs/use-system-tab-modal.ts
+++ b/clients/gui-app/src/stores/tabs/use-system-tab-modal.ts
@@ -329,17 +329,35 @@ export function useAnySystemOverlayActive(): boolean {
   });
 }
 
+// Module-scoped: "once per renderer boot," not once per component instance.
+// A component-instance ref would reset every time an ancestor remounts the
+// tree this hook lives in (e.g. a structurally unstable gate flipping across
+// a route boundary), re-arming the focus-tab-first redirect below on every
+// such remount instead of just on genuine app boot / refresh / deep-link.
+// See `resetSystemTabModalColdLoadForTests` for the test-only reset seam.
+let systemTabModalColdLoadReconciled = false;
+
+/** Test-only: resets the module-scoped cold-load latch between test cases. */
+export function resetSystemTabModalColdLoadForTests(): void {
+  systemTabModalColdLoadReconciled = false;
+}
+
 /**
  * Refresh / deep-link guard + path-change auto-close. Mounted once
  * inside `<SystemTabModalHost />`. Two responsibilities:
  *  1. Focus-tab-first, **cold load only**: when the *restored* URL carries an
  *     overlay flag but a strip tab of that kind is already open, navigate to the
- *     tab's route and drop the overlay search params. This runs once, on the
- *     guard's first effect pass (app boot / refresh / deep-link), and never
- *     again. It must NOT fire on later in-app navigations - an overlay entry
- *     left in history (e.g. after promoting the modal to a tab) would otherwise
- *     become a redirect trap that bounces every Back press onto it straight back
- *     to the tab, making the back button look enabled-but-dead.
+ *     tab's route and drop the overlay search params. This runs once per
+ *     renderer boot (app boot / refresh / deep-link), and never again. It
+ *     must NOT fire on later in-app navigations - an overlay entry left in
+ *     history (e.g. after promoting the modal to a tab) would otherwise
+ *     become a redirect trap that bounces every Back press onto it straight
+ *     back to the tab, making the back button look enabled-but-dead. The
+ *     redirect also navigates with `replace`, so even if it were ever to
+ *     fire again it sheds the stale overlay entry in place (the persistent
+ *     history's replace-collapse cleans up an identical neighbor) instead of
+ *     pushing over the same stack - defense in depth alongside the
+ *     once-per-boot latch above.
  *  2. When the underlying path changes while the modal is open, clear
  *     the overlay flags so the modal dismisses.
  */
@@ -350,13 +368,10 @@ export function useSystemTabModalRefreshGuard(): void {
   });
   const router = useRouter();
   const lastPathnameRef = useRef<string>(pathname);
-  // Flipped on the first effect pass so focus-tab-first reconciliation (below)
-  // is a one-time cold-load step, not a reactive redirect.
-  const coldLoadReconciledRef = useRef<boolean>(false);
 
   useEffect(() => {
-    const isColdLoad = !coldLoadReconciledRef.current;
-    coldLoadReconciledRef.current = true;
+    const isColdLoad = !systemTabModalColdLoadReconciled;
+    systemTabModalColdLoadReconciled = true;
 
     if (!overlay.settingsOverlay && !overlay.historyOverlay) {
       lastPathnameRef.current = pathname;
@@ -371,6 +386,7 @@ export function useSystemTabModalRefreshGuard(): void {
       tabActivate(target);
       void router.navigate({
         ...tabRouteOptions(target),
+        replace: true,
         search: (prev) => withOverlayCleared(prev),
       });
       return;
@@ -380,6 +396,7 @@ export function useSystemTabModalRefreshGuard(): void {
       tabActivate(target);
       void router.navigate({
         ...tabRouteOptions(target),
+        replace: true,
         search: (prev) => withOverlayCleared(prev),
       });
       return;

--- a/eslint/traycer-nested-focus-boundary-rules.mjs
+++ b/eslint/traycer-nested-focus-boundary-rules.mjs
@@ -13,6 +13,19 @@
  * boundary to commit to the route. Calling the raw action instead of its
  * `prepare*` counterpart is exactly the bypass this rule bans.
  *
+ * Covered access shapes are direct selector picks (including selectors wrapped
+ * by helpers such as `useShallow`), block-bodied selector returns, direct
+ * `getState().action()` calls (dot and literal-computed access), and object
+ * destructuring directly from `getState()`. Alias flow such as
+ * `const state = useEpicCanvasStore.getState(); state.closeCanvasTab()` is not
+ * expressible soundly with esquery alone because it requires scope/value-flow
+ * tracking; keep that as a known limit rather than adding a broad selector
+ * that would flag unrelated variables. The inverse limit also holds: inside a
+ * block-bodied selector, a `return x.action` in a locally-declared nested
+ * function still matches (the ReturnStatement is a descendant of the anchored
+ * arrow) - a false positive accepted deliberately, since tightening to
+ * top-level returns would miss real conditional returns of a banned action.
+ *
  * Deliberately EXCLUDED (verified against store.ts/actions.ts, not just the
  * initial audit brief):
  * - `promotePreviewInTab`: its reducer (`promotePreview`) only clears
@@ -53,8 +66,79 @@ export const NESTED_FOCUS_BOUNDARY_ACTION_NAMES = [
   "applyNestedRouteFocus",
 ];
 
+export const TAB_NAVIGATION_STORE_ACTION_BANS = [
+  {
+    storeName: "useEpicCanvasStore",
+    actionNames: ["setActiveTab"],
+    message:
+      "Do not access setActiveTab directly - route through navigateToTabIntent in lib/tab-navigation.ts so every entry point performs the same activate-then-navigate dance.",
+  },
+  {
+    storeName: "useLandingDraftStore",
+    actionNames: ["setActiveDraft"],
+    message:
+      "Do not access setActiveDraft directly - route through navigateToTabIntent in lib/tab-navigation.ts so every entry point performs the same activate-then-navigate dance.",
+  },
+];
+
+function storeActionRestrictions(storeName, actionNames, message) {
+  if (actionNames.length === 0) return [];
+
+  const namePattern = actionNames.join("|");
+  return [
+    {
+      selector: `CallExpression[callee.name='${storeName}'] > ArrowFunctionExpression[body.type='MemberExpression'][body.computed=false][body.property.name=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.name='${storeName}'] > CallExpression > ArrowFunctionExpression[body.type='MemberExpression'][body.computed=false][body.property.name=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.name='${storeName}'] > ArrowFunctionExpression[body.type='MemberExpression'][body.computed=true][body.property.type='Literal'][body.property.value=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.name='${storeName}'] > CallExpression > ArrowFunctionExpression[body.type='MemberExpression'][body.computed=true][body.property.type='Literal'][body.property.value=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.name='${storeName}'] > ArrowFunctionExpression[body.type='BlockStatement'] ReturnStatement > MemberExpression[computed=false][property.name=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.name='${storeName}'] > CallExpression > ArrowFunctionExpression[body.type='BlockStatement'] ReturnStatement > MemberExpression[computed=false][property.name=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.name='${storeName}'] > ArrowFunctionExpression[body.type='BlockStatement'] ReturnStatement > MemberExpression[computed=true][property.type='Literal'][property.value=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.name='${storeName}'] > CallExpression > ArrowFunctionExpression[body.type='BlockStatement'] ReturnStatement > MemberExpression[computed=true][property.type='Literal'][property.value=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.type='MemberExpression'][callee.computed=false][callee.property.name=/^(${namePattern})$/][callee.object.type='CallExpression'][callee.object.callee.object.name='${storeName}'][callee.object.callee.property.name='getState']`,
+      message,
+    },
+    {
+      selector: `CallExpression[callee.type='MemberExpression'][callee.computed=true][callee.property.type='Literal'][callee.property.value=/^(${namePattern})$/][callee.object.type='CallExpression'][callee.object.callee.object.name='${storeName}'][callee.object.callee.property.name='getState']`,
+      message,
+    },
+    {
+      selector: `VariableDeclarator[id.type='ObjectPattern'][init.type='CallExpression'][init.callee.object.name='${storeName}'][init.callee.property.name='getState'] > ObjectPattern > Property[key.type='Identifier'][key.name=/^(${namePattern})$/]`,
+      message,
+    },
+    {
+      selector: `VariableDeclarator[id.type='ObjectPattern'][init.type='CallExpression'][init.callee.object.name='${storeName}'][init.callee.property.name='getState'] > ObjectPattern > Property[key.type='Literal'][key.value=/^(${namePattern})$/]`,
+      message,
+    },
+  ];
+}
+
 /**
- * Builds the two `no-restricted-syntax` selectors banning raw access to
+ * Builds the `no-restricted-syntax` selectors banning raw access to
  * `EpicCanvasStore`'s focus-mutating actions, for the names NOT listed in
  * `allowedNames`. Pass `[]` for the fully-restricted general case; pass the
  * specific names a file legitimately needs for a scoped override.
@@ -65,17 +149,22 @@ export function nestedFocusBoundaryRestrictions(allowedNames) {
   );
   if (restrictedNames.length === 0) return [];
 
-  const namePattern = restrictedNames.join("|");
-  return [
-    {
-      selector: `CallExpression[callee.name='useEpicCanvasStore'] > ArrowFunctionExpression[body.type='MemberExpression'][body.property.name=/^(${namePattern})$/]`,
-      message:
-        "Do not select a raw focus-mutating canvas store action. Use useEpicTileNavigation (or useEpicNestedFocusNavigation + the matching prepare...FocusTarget) so the resulting focus is committed to the route.",
-    },
-    {
-      selector: `CallExpression[callee.type='MemberExpression'][callee.property.name=/^(${namePattern})$/][callee.object.type='CallExpression'][callee.object.callee.object.name='useEpicCanvasStore'][callee.object.callee.property.name='getState']`,
-      message:
-        "Do not call a raw focus-mutating canvas store action via getState(). Use useEpicTileNavigation (or useEpicNestedFocusNavigation + the matching prepare...FocusTarget) so the resulting focus is committed to the route.",
-    },
-  ];
+  return storeActionRestrictions(
+    "useEpicCanvasStore",
+    restrictedNames,
+    "Do not access a raw focus-mutating canvas store action. Use useEpicTileNavigation (or useEpicNestedFocusNavigation + the matching prepare...FocusTarget) so the resulting focus is committed to the route.",
+  );
+}
+
+export function tabNavigationStoreActionRestrictions(allowedStoreActions) {
+  return TAB_NAVIGATION_STORE_ACTION_BANS.flatMap((ban) =>
+    storeActionRestrictions(
+      ban.storeName,
+      ban.actionNames.filter(
+        (actionName) =>
+          !allowedStoreActions.includes(`${ban.storeName}.${actionName}`),
+      ),
+      ban.message,
+    ),
+  );
 }

--- a/eslint/traycer-nested-focus-boundary-rules.mjs
+++ b/eslint/traycer-nested-focus-boundary-rules.mjs
@@ -1,0 +1,81 @@
+/**
+ * Bans raw, focus-mutating `useEpicCanvasStore` action access from outside
+ * the nested-focus-opener boundary (`useEpicTileNavigation` /
+ * `useEpicNestedFocusNavigation` -> `prepare...FocusTarget` +
+ * `navigateNested`). Calling one of these actions directly mutates the
+ * canvas but never writes the TanStack route search params
+ * (`focusPaneId` / `focusTileInstanceId`) that back/forward navigation and
+ * reload rely on - the desync this rule exists to prevent shipped six times.
+ *
+ * Every action here has a `prepare<Name>FocusTarget` counterpart on
+ * `EpicCanvasStore` (see `src/stores/epics/canvas/store.ts`) that performs
+ * the same mutation AND returns the resulting `NestedFocusTarget` for the
+ * boundary to commit to the route. Calling the raw action instead of its
+ * `prepare*` counterpart is exactly the bypass this rule bans.
+ *
+ * Deliberately EXCLUDED (verified against store.ts/actions.ts, not just the
+ * initial audit brief):
+ * - `promotePreviewInTab`: its reducer (`promotePreview`) only clears
+ *   `previewTabId`; it never touches `activeTabId`/`activePaneId` and has no
+ *   `prepare*FocusTarget` counterpart at all, so it never needs a route
+ *   write. Called directly today from `epic-sidebar-artifact-tree.tsx`,
+ *   `epic-sidebar-chat-tree.tsx`, `tab-group-view.tsx`, and
+ *   `root-dnd-provider.tsx`.
+ * - `resizeSplitInTab`: `prepareResizeSplitFocusTarget` always returns
+ *   `null` (pure layout, never focus) and is called directly from
+ *   `tile-canvas.tsx` today.
+ * - `openTileInNewTab` / `tearOffTabIntoNewHeaderTab`: header-tab creation,
+ *   not nested-tile focus - no `prepare*FocusTarget` counterpart exists.
+ * - `openTile` (the bare reducer in `actions.ts`): not exposed on the store
+ *   instance/interface at all, so it is unreachable via either AST form
+ *   below.
+ */
+
+export const NESTED_FOCUS_BOUNDARY_ACTION_NAMES = [
+  "openTileInTab",
+  "openTilePreviewInTab",
+  "openTileInBackgroundTab",
+  "openTileInPane",
+  "openBlankTabInPane",
+  "setActiveTileTab",
+  "setActiveTilePane",
+  "insertNodeOnTabStrip",
+  "moveTabOnTabStrip",
+  "splitPaneWithNode",
+  "splitPaneWithTab",
+  "splitPaneEmptyInTab",
+  "splitPaneEmptyRightInTab",
+  "closeCanvasTab",
+  "closeOtherCanvasTabs",
+  "closeRightCanvasTabs",
+  "closeAllCanvasTabs",
+  "closeCanvasPane",
+  "applyNestedRouteFocus",
+];
+
+/**
+ * Builds the two `no-restricted-syntax` selectors banning raw access to
+ * `EpicCanvasStore`'s focus-mutating actions, for the names NOT listed in
+ * `allowedNames`. Pass `[]` for the fully-restricted general case; pass the
+ * specific names a file legitimately needs for a scoped override.
+ */
+export function nestedFocusBoundaryRestrictions(allowedNames) {
+  const restrictedNames = NESTED_FOCUS_BOUNDARY_ACTION_NAMES.filter(
+    (name) => !allowedNames.includes(name),
+  );
+  if (restrictedNames.length === 0) return [];
+
+  const namePattern = restrictedNames.join("|");
+  return [
+    {
+      selector: `CallExpression[callee.name='useEpicCanvasStore'] > ArrowFunctionExpression[body.type='MemberExpression'][body.property.name=/^(${namePattern})$/]`,
+      message:
+        "Do not select a raw focus-mutating canvas store action. Use useEpicTileNavigation (or useEpicNestedFocusNavigation + the matching prepare...FocusTarget) so the resulting focus is committed to the route.",
+    },
+    {
+      selector: `CallExpression[callee.type='MemberExpression'][callee.property.name=/^(${namePattern})$/][callee.object.type='CallExpression'][callee.object.callee.object.name='useEpicCanvasStore'][callee.object.callee.property.name='getState']`,
+      message:
+        "Do not call a raw focus-mutating canvas store action via getState(). Use useEpicTileNavigation (or useEpicNestedFocusNavigation + the matching prepare...FocusTarget) so the resulting focus is committed to the route.",
+    },
+  ];
+}


### PR DESCRIPTION
## Problem

Back/forward navigation only operated at the epic tab level.
The history stack recorded `/epics/$epicId/$tabId` entries, so every pane/tile focus change inside an epic's canvas (tile activation, pane focus, splits, closes) was invisible to back/forward - the buttons acted as a top-level epic switcher instead of walking the user's actual focus trail.

## What this does

**Route-addressable nested focus.**
Nested focus targets (`focusPaneId` / `focusTileInstanceId`) now live in the epic route search params.
Explicit tile/tab activation, pane focus changes, and layout-driven focus changes push history entries; destructive layout operations push the post-operation focus.
Targets are intentionally window/session-scoped, not a shareable cross-window contract.

**Persistent history with liveness pruning.**
A persistent memory history backs the router; entries whose pane/tile targets no longer resolve against the live canvas are pruned aggressively (no best-effort remapping), with adjacent-duplicate collapsing and a frame-scheduled prune pass that defers while a router load is in flight.

**A single navigation boundary.**
All user-gesture focus mutations flow through `prepare*FocusTarget` + `navigateNestedFocus`: the store mutation runs inside `prepare()`, and the resulting target is committed as one route push.
The API is push-only by construction (an audit found every one of ~80 call sites passed `replace: false`, so the option was removed).
Route synchronization keeps its own replace-mode canonicalization and stale recovery, in the opposite direction (route -> store).

**Regression fixes.**
Surfaces that bypassed the boundary and mutated focus without a route entry are migrated: setup-card terminal open, markdown `<traycer-*>` reference chips, artifact child-index rows, snapshot bundle diff file open, resource monitor popover (cross-route prepared navigation), sidebar root-create and single/bulk delete closes, and terminal/TUI banner/exit closes.

**Enforcement so it can't silently regress.**
- A custom ESLint rule (`eslint/traycer-nested-focus-boundary-rules.mjs`) bans raw focus-mutating canvas-store access (19 action names, both hook-selector and `getState()` forms) outside a minimal allowlist (route sync, blank-root bootstrap, background terminal registration, the store itself, tests).
- A shared boundary-mock test helper runs the real `prepare` against the real store, preventing tests from locking in bypass bugs.
- An interaction-fixture harness mounts real components on a real router and asserts `router.state.location.search` after DOM clicks.

## Verification

- `bun run compile`, `bun run lint`, `git diff --check` clean
- `bun run test`: 4400 passed / 1 skipped (532 files)
- `pre-commit run --all-files` green