### PR TITLE
Global resource monitor + popover UX fixes

### DIFF
--- a/clients/gui-app/src/components/layout/header/app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/app-header.tsx
@@ -11,6 +11,7 @@ import { NotificationsBell } from "@/components/notifications/notifications-bell
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
+import { useTitleBarDraggingSuppressed } from "@/stores/layout/title-bar-drag-store";
 
 // Frameless-desktop detection: Electron's preload bridge exposes
 // `window.runnerHost` via `contextBridge.exposeInMainWorld`. Browser
@@ -26,6 +27,17 @@ function isFramelessDesktop(): boolean {
 // `-webkit-app-region` isn't in the standard CSSProperties typings.
 const DRAG_STYLE = { WebkitAppRegion: "drag" } as CSSProperties;
 const NO_DRAG_STYLE = { WebkitAppRegion: "no-drag" } as CSSProperties;
+
+// Drag style for the header's title-bar spacers: only frameless desktop shells
+// use them as an OS drag region, and only while no header overlay needs the
+// title bar to receive clicks (see `useTitleBarDraggingSuppressed`).
+function titleBarSpacerStyle(
+  framelessDesktop: boolean,
+  dragSuppressed: boolean,
+): CSSProperties | undefined {
+  if (!framelessDesktop) return undefined;
+  return dragSuppressed ? NO_DRAG_STYLE : DRAG_STYLE;
+}
 
 export type AppHeaderVariant = "app" | "host-loading";
 
@@ -50,6 +62,12 @@ export function AppHeader(props: AppHeaderProps): ReactNode {
   const showGlobalResourceMonitor = useSettingsStore(
     (state) => state.showGlobalResourceMonitor,
   );
+  // A header-anchored overlay (e.g. the resource monitor) needs the title bar to
+  // stop swallowing clicks so a click there dismisses it. Drop drag while any
+  // such overlay is open; restore it once they all close.
+  const dragSuppressed = useTitleBarDraggingSuppressed();
+  const draggable = framelessDesktop && !dragSuppressed;
+  const spacerDragStyle = titleBarSpacerStyle(framelessDesktop, dragSuppressed);
 
   return (
     <header
@@ -83,13 +101,13 @@ export function AppHeader(props: AppHeaderProps): ReactNode {
         <div
           aria-hidden
           className="relative z-10 hidden h-full shrink-0 basis-[clamp(2rem,6vw,6rem)] md:block"
-          style={DRAG_STYLE}
+          style={spacerDragStyle}
         />
       ) : null}
       <div
         className={cn(
           "relative z-10 flex min-w-0 flex-1 items-center",
-          framelessDesktop && "[-webkit-app-region:drag]",
+          draggable && "[-webkit-app-region:drag]",
         )}
       >
         {showTabStrip ? <TabStrip /> : null}
@@ -102,7 +120,7 @@ export function AppHeader(props: AppHeaderProps): ReactNode {
             ? "hidden shrink-0 basis-[clamp(2rem,6vw,6rem)] md:block"
             : "min-w-0 flex-1",
         )}
-        style={framelessDesktop ? DRAG_STYLE : undefined}
+        style={spacerDragStyle}
       />
       <div
         className="relative z-10 flex shrink-0 items-center gap-2"

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -519,6 +519,45 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.queryByRole("dialog", { name: "Resources" })).toBeNull();
   });
 
+  it("keeps the resources panel open when selecting a sort option", async () => {
+    const stub = installStubFactory();
+    render(
+      <TooltipProvider>
+        <ResourcesStreamMount epicId="epic-1" />
+        <ResourceMonitorPopover className={undefined} />
+      </TooltipProvider>,
+    );
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          app: app(),
+          owners: [owner({})],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(await screen.findByText("Traycer Host")).not.toBeNull();
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Sort resource rows" }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" },
+    );
+    const cpuItem = screen.getByRole("menuitemradio", { name: "CPU" });
+
+    // Choosing a sort option closes the menu but must leave the Resources
+    // dialog (and its tray content) intact, and apply the selected sort.
+    fireEvent.click(cpuItem);
+
+    expect(screen.queryByRole("menuitemradio", { name: "CPU" })).toBeNull();
+    expect(screen.getByRole("dialog", { name: "Resources" })).not.toBeNull();
+    expect(screen.getByText("Traycer Host")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Sort resource rows" }).textContent,
+    ).toContain("CPU");
+  });
+
   it("stays open when focus moves to newly loaded content outside the panel", async () => {
     const stub = installStubFactory();
     const outside = document.createElement("input");

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -20,6 +20,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { ResourcesStreamMount } from "@/providers/resources-stream-mount";
 import { __setResourcesStreamClientFactoryForTests } from "@/providers/resources-stream-factory-override";
 import { resourcesRegistry } from "@/stores/resources/resources-registry";
+import { useTitleBarDragStore } from "@/stores/layout/title-bar-drag-store";
 
 type MockEpicIntentInput = Readonly<Record<string, unknown>>;
 type MockEpicIntent = MockEpicIntentInput & { readonly kind: "epic" };
@@ -257,6 +258,7 @@ afterEach(() => {
   canvasMock.resolveTargetTabForEpic.mockClear();
   __setResourcesStreamClientFactoryForTests(null);
   resourcesRegistry.disposeAll();
+  useTitleBarDragStore.setState({ suppressors: new Set() });
 });
 
 describe("ResourceMonitorPopover", () => {
@@ -418,6 +420,32 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.getByText("2 open terminals")).not.toBeNull();
     expect(screen.getAllByText("89%").length).toBeGreaterThan(0);
     expect(screen.getAllByText("1000 MB").length).toBeGreaterThan(0);
+  });
+
+  it("suppresses title-bar dragging only while the panel is open", () => {
+    const stub = installStubFactory();
+
+    render(
+      <TooltipProvider>
+        <ResourcesStreamMount epicId="epic-1" />
+        <ResourceMonitorPopover className={undefined} />
+      </TooltipProvider>,
+    );
+
+    act(() => {
+      stub.emit().onSnapshot(projection({ owners: [owner({})] }));
+    });
+
+    const isSuppressed = () =>
+      useTitleBarDragStore.getState().suppressors.has("resource-monitor");
+
+    expect(isSuppressed()).toBe(false);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(isSuppressed()).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(isSuppressed()).toBe(false);
   });
 
   it("keeps the resources panel open when clicking inside it to dismiss the sort menu", async () => {

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -383,12 +383,25 @@ describe("ResourceMonitorPopover", () => {
                 epicId: "epic-1",
                 ownerId: "term-idle",
               },
-              rootPids: [],
+              rootPids: [900],
               activeProcessName: "idle-shell",
-              processCount: 0,
+              processCount: 1,
               cpuPercent: 77,
               rssBytes: 900 * 1024 * 1024,
-              processes: [],
+              // A bare shell with nothing running under it: its whole tree is a
+              // single process, so the terminal owner row is hidden entirely
+              // while its metrics still fold into the aggregate below.
+              processes: [
+                resourceProcess({
+                  pid: 900,
+                  parentPid: null,
+                  rootPid: 900,
+                  name: "zsh",
+                  command: "/usr/bin/idle-zsh",
+                  cpuPercent: 0,
+                  rssBytes: 4 * 1024 * 1024,
+                }),
+              ],
             }),
           ],
         }),
@@ -398,7 +411,10 @@ describe("ResourceMonitorPopover", () => {
     fireEvent.click(screen.getByRole("button", { name: "Resources" }));
 
     expect(screen.getByText("Terminal Alpha")).not.toBeNull();
+    // The whole terminal owner row is hidden - neither its label nor its lone
+    // shell process renders.
     expect(screen.queryByText("idle-shell")).toBeNull();
+    expect(screen.queryByText("/usr/bin/idle-zsh")).toBeNull();
     expect(screen.getByText("2 open terminals")).not.toBeNull();
     expect(screen.getAllByText("89%").length).toBeGreaterThan(0);
     expect(screen.getAllByText("1000 MB").length).toBeGreaterThan(0);

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -51,6 +51,21 @@ const tabNavigationMock = vi.hoisted(() => ({
 
 vi.mock("@/lib/tab-navigation", () => tabNavigationMock);
 
+vi.mock("@/hooks/epics/use-cloud-epic-tasks-query", () => ({
+  useCloudEpicTasksQuery: () => ({
+    tasks: [
+      {
+        epic: {
+          light: {
+            id: "epic-2",
+            title: "Background Task",
+          },
+        },
+      },
+    ],
+  }),
+}));
+
 const canvasMock = vi.hoisted(() => {
   const openTileInTab = vi.fn();
   const setActiveTilePane = vi.fn();
@@ -192,13 +207,14 @@ function projection(
     app: null,
     owners: [],
     epic: null,
+    epics: [],
     ...over,
   };
 }
 
 function installStubFactory(): { emit: () => ResourcesStreamCallbacks } {
   let captured: ResourcesStreamCallbacks | null = null;
-  __setResourcesStreamClientFactoryForTests((_epicId, callbacks) => {
+  __setResourcesStreamClientFactoryForTests((_scope, callbacks) => {
     captured = callbacks;
     return { close: () => undefined };
   });
@@ -263,7 +279,20 @@ describe("ResourceMonitorPopover", () => {
       stub.emit().onSnapshot(
         projection({
           app: app(),
-          owners: [owner({})],
+          owners: [
+            owner({}),
+            owner({
+              owner: {
+                kind: "terminal",
+                hostId: "host-1",
+                epicId: "epic-2",
+                ownerId: "term-closed",
+              },
+              activeProcessName: "bun",
+              cpuPercent: 4,
+              rssBytes: 50 * 1024 * 1024,
+            }),
+          ],
         }),
       );
     });
@@ -273,12 +302,13 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.getByText("Resources")).not.toBeNull();
     expect(await screen.findByText("Traycer Desktop")).not.toBeNull();
     expect(screen.getByText("Renderer")).not.toBeNull();
-    expect(getDesktopMetrics).toHaveBeenCalledTimes(1);
+    expect(getDesktopMetrics).toHaveBeenCalled();
     expect(screen.getByText("Traycer Host")).not.toBeNull();
     expect(screen.getByText("Resource Task")).not.toBeNull();
+    expect(screen.getByText("Background Task")).not.toBeNull();
     expect(screen.getByText("Terminal Alpha")).not.toBeNull();
-    expect(screen.getByText("node dev-server.js")).not.toBeNull();
-    expect(screen.getByText("1 open terminal")).not.toBeNull();
+    expect(screen.getAllByText("node dev-server.js")).toHaveLength(2);
+    expect(screen.getByText("2 open terminals")).not.toBeNull();
     expect(screen.queryByText(/terminal processes/)).toBeNull();
 
     fireEvent.click(screen.getByText("Terminal Alpha"));

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -337,9 +337,9 @@ describe("ResourceMonitorPopover", () => {
 
     const cappedProcessRow = screen
       .getAllByText("node dev-server.js (2 sub-processes)")[0]
-      .closest("[tabindex='0']");
+      .closest("button");
     if (cappedProcessRow === null) {
-      throw new Error("Expected capped process row to be focusable");
+      throw new Error("Expected capped process row to be a focusable button");
     }
     fireEvent.focus(cappedProcessRow);
     const tooltip = await screen.findByRole("tooltip");

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -193,6 +193,24 @@ function owner(
         cpuPercent: 10,
         rssBytes: 60 * 1024 * 1024,
       }),
+      resourceProcess({
+        pid: 102,
+        parentPid: 101,
+        rootPid: 100,
+        name: "sh",
+        command: "/bin/sh",
+        cpuPercent: 0,
+        rssBytes: 2 * 1024 * 1024,
+      }),
+      resourceProcess({
+        pid: 103,
+        parentPid: 102,
+        rootPid: 100,
+        name: "make",
+        command: "make",
+        cpuPercent: 1,
+        rssBytes: 4 * 1024 * 1024,
+      }),
     ],
     ...over,
   };
@@ -307,9 +325,25 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.getByText("Resource Task")).not.toBeNull();
     expect(screen.getByText("Background Task")).not.toBeNull();
     expect(screen.getByText("Terminal Alpha")).not.toBeNull();
-    expect(screen.getAllByText("node dev-server.js")).toHaveLength(2);
+    expect(
+      screen.getAllByText("node dev-server.js (2 sub-processes)"),
+    ).toHaveLength(2);
+    expect(screen.queryByText("/bin/sh")).toBeNull();
+    expect(screen.queryByText("make")).toBeNull();
     expect(screen.getByText("2 open terminals")).not.toBeNull();
     expect(screen.queryByText(/terminal processes/)).toBeNull();
+
+    const cappedProcessRow = screen
+      .getAllByText("node dev-server.js (2 sub-processes)")[0]
+      .closest("[tabindex='0']");
+    if (cappedProcessRow === null) {
+      throw new Error("Expected capped process row to be focusable");
+    }
+    fireEvent.focus(cappedProcessRow);
+    expect((await screen.findByRole("tooltip")).textContent).toContain(
+      "/bin/sh",
+    );
+    expect(screen.getByRole("tooltip").textContent).toContain("make");
 
     fireEvent.click(screen.getByText("Terminal Alpha"));
     expect(canvasMock.setActiveTilePane).toHaveBeenCalledWith(
@@ -323,5 +357,119 @@ describe("ResourceMonitorPopover", () => {
     );
     expect(tabNavigationMock.navigateToTabIntent).toHaveBeenCalledTimes(1);
     expect(canvasMock.openTileInTab).not.toHaveBeenCalled();
+  });
+
+  it("hides terminal rows with no subprocesses while keeping aggregate metrics", () => {
+    const stub = installStubFactory();
+
+    render(
+      <TooltipProvider>
+        <ResourcesStreamMount epicId="epic-1" />
+        <ResourceMonitorPopover className={undefined} />
+      </TooltipProvider>,
+    );
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({}),
+            owner({
+              owner: {
+                kind: "terminal",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "term-idle",
+              },
+              rootPids: [],
+              activeProcessName: "idle-shell",
+              processCount: 0,
+              cpuPercent: 77,
+              rssBytes: 900 * 1024 * 1024,
+              processes: [],
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+
+    expect(screen.getByText("Terminal Alpha")).not.toBeNull();
+    expect(screen.queryByText("idle-shell")).toBeNull();
+    expect(screen.getByText("2 open terminals")).not.toBeNull();
+    expect(screen.getAllByText("89%").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("1000 MB").length).toBeGreaterThan(0);
+  });
+
+  it("keeps the resources panel open when clicking inside it to dismiss the sort menu", async () => {
+    const stub = installStubFactory();
+    render(
+      <TooltipProvider>
+        <ResourcesStreamMount epicId="epic-1" />
+        <ResourceMonitorPopover className={undefined} />
+      </TooltipProvider>,
+    );
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          app: app(),
+          owners: [owner({})],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(await screen.findByText("Traycer Host")).not.toBeNull();
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Sort resource rows" }),
+      {
+        button: 0,
+        ctrlKey: false,
+        pointerType: "mouse",
+      },
+    );
+    expect(screen.getByRole("menuitemradio", { name: "CPU" })).not.toBeNull();
+
+    fireEvent.pointerDown(screen.getByText("Traycer Host"), {
+      button: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.mouseDown(screen.getByText("Traycer Host"), { button: 0 });
+    fireEvent.pointerUp(screen.getByText("Traycer Host"), {
+      button: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.click(screen.getByText("Traycer Host"));
+
+    expect(screen.queryByRole("menuitemradio", { name: "CPU" })).toBeNull();
+    expect(screen.getByRole("dialog", { name: "Resources" })).not.toBeNull();
+    expect(screen.getByText("Traycer Host")).not.toBeNull();
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Sort resource rows" }),
+      {
+        button: 0,
+        ctrlKey: false,
+        pointerType: "mouse",
+      },
+    );
+    expect(screen.getByRole("menuitemradio", { name: "CPU" })).not.toBeNull();
+
+    fireEvent.pointerDown(document.body, {
+      button: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.mouseDown(document.body, { button: 0 });
+    fireEvent.pointerUp(document.body, {
+      button: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.click(document.body);
+
+    expect(screen.queryByRole("menuitemradio", { name: "CPU" })).toBeNull();
+    expect(screen.queryByRole("dialog", { name: "Resources" })).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -472,4 +472,41 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.queryByRole("menuitemradio", { name: "CPU" })).toBeNull();
     expect(screen.queryByRole("dialog", { name: "Resources" })).toBeNull();
   });
+
+  it("stays open when focus moves to newly loaded content outside the panel", async () => {
+    const stub = installStubFactory();
+    const outside = document.createElement("input");
+    document.body.appendChild(outside);
+
+    render(
+      <TooltipProvider>
+        <ResourcesStreamMount epicId="epic-1" />
+        <ResourceMonitorPopover className={undefined} />
+      </TooltipProvider>,
+    );
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          app: app(),
+          owners: [owner({})],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(await screen.findByText("Traycer Host")).not.toBeNull();
+
+    // A task finishing load autofocuses its content: focus lands on an element
+    // outside the popover, which Radix reports as a focus-outside dismissal.
+    act(() => {
+      outside.focus();
+      fireEvent.focusIn(outside);
+    });
+
+    expect(screen.getByRole("dialog", { name: "Resources" })).not.toBeNull();
+    expect(screen.getByText("Traycer Host")).not.toBeNull();
+
+    outside.remove();
+  });
 });

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -340,10 +340,12 @@ describe("ResourceMonitorPopover", () => {
       throw new Error("Expected capped process row to be focusable");
     }
     fireEvent.focus(cappedProcessRow);
-    expect((await screen.findByRole("tooltip")).textContent).toContain(
-      "/bin/sh",
-    );
-    expect(screen.getByRole("tooltip").textContent).toContain("make");
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toContain("/bin/sh");
+    expect(tooltip.textContent).toContain("make");
+    // The collapsed sub-tree carries the same CPU/memory columns as the tree.
+    expect(tooltip.textContent).toContain("2.0 MB");
+    expect(tooltip.textContent).toContain("4.0 MB");
 
     fireEvent.click(screen.getByText("Terminal Alpha"));
     expect(canvasMock.setActiveTilePane).toHaveBeenCalledWith(

--- a/clients/gui-app/src/components/resources/__tests__/resource-usage-chip.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-usage-chip.test.tsx
@@ -77,13 +77,14 @@ function projection(
     app: null,
     owners: [],
     epic: null,
+    epics: [],
     ...over,
   };
 }
 
 function installStubFactory(): { emit: () => ResourcesStreamCallbacks } {
   let captured: ResourcesStreamCallbacks | null = null;
-  __setResourcesStreamClientFactoryForTests((_epicId, callbacks) => {
+  __setResourcesStreamClientFactoryForTests((_scope, callbacks) => {
     captured = callbacks;
     return { close: () => undefined };
   });

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState, useSyncExternalStore } from "react";
 import { useNavigate, type UseNavigateResult } from "@tanstack/react-router";
 import { v4 as uuidv4 } from "uuid";
 import { useShallow } from "zustand/react/shallow";
@@ -15,6 +15,7 @@ import type {
   ResourceOwnerKindWire,
   ResourceProcessSnapshotWire,
 } from "@traycer/protocol/host/resources/subscribe";
+import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
 import type { EpicNodeRecord } from "@/lib/artifacts/node-display";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,6 +35,7 @@ import {
   useGlobalResourceProjection,
   type GlobalResourceEpicEntry,
 } from "@/stores/resources/resources-registry";
+import { GlobalResourcesStreamMount } from "@/providers/resources-stream-mount";
 import type {
   AppResourceUsage,
   TaskResourceSummary,
@@ -55,6 +57,7 @@ import {
   openOrFocusEpicIntent,
 } from "@/lib/tab-navigation";
 import { cn } from "@/lib/utils";
+import { useCloudEpicTasksQuery } from "@/hooks/epics/use-cloud-epic-tasks-query";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { collectPanes } from "@/stores/epics/canvas/tile-tree";
 import type {
@@ -78,6 +81,10 @@ const METRIC_COLS = "flex shrink-0 items-center tabular-nums tracking-tight";
 const CPU_COL = "w-14 text-right";
 const MEM_COL = "w-20 text-right";
 const DESKTOP_RESOURCE_SAMPLE_INTERVAL_MS = 1000;
+const desktopAppResourceListeners = new Set<() => void>();
+let desktopAppResourceSnapshot: DesktopAppResourceUsage | null = null;
+let desktopAppResourceTimer: number | null = null;
+let desktopAppResourceInFlight = false;
 const EMPTY_RESOURCE_SUMMARY: TaskResourceSummary = {
   cpuPercent: 0,
   rssBytes: 0,
@@ -143,32 +150,37 @@ export function ResourceMonitorPopover(props: ResourceMonitorPopoverProps) {
   const [open, setOpen] = useState(false);
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <TooltipWrapper
-        label="Resources"
-        side="top"
-        sideOffset={6}
-        align={undefined}
-      >
-        <PopoverTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Resources"
-            data-testid="resource-monitor-header-button"
-            className={cn(
-              "text-muted-foreground hover:text-foreground",
-              props.className,
-            )}
-          >
-            <Cpu className="size-3.5" />
-          </Button>
-        </PopoverTrigger>
-      </TooltipWrapper>
+    <>
+      <GlobalResourcesStreamMount />
+      <Popover open={open} onOpenChange={setOpen}>
+        <TooltipWrapper
+          label="Resources"
+          side="top"
+          sideOffset={6}
+          align={undefined}
+        >
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Resources"
+              data-testid="resource-monitor-header-button"
+              className={cn(
+                "text-muted-foreground hover:text-foreground",
+                props.className,
+              )}
+            >
+              <Cpu className="size-3.5" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipWrapper>
 
-      {open ? <ResourceMonitorContent onClose={() => setOpen(false)} /> : null}
-    </Popover>
+        {open ? (
+          <ResourceMonitorContent onClose={() => setOpen(false)} />
+        ) : null}
+      </Popover>
+    </>
   );
 }
 
@@ -178,6 +190,7 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
     () => new Set(),
   );
   const projection = useGlobalResourceProjection();
+  const { tasks } = useCloudEpicTasksQuery(undefined, { enabled: true });
   const canvas = useResourceCanvasSnapshot();
   const navigate = useNavigate();
   const openTileInTab = useEpicCanvasStore((state) => state.openTileInTab);
@@ -195,6 +208,7 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
 
   const canvasIndex = useMemo(() => buildCanvasResourceIndex(canvas), [canvas]);
   const recordByOwner = useMemo(() => buildRecordByOwner(canvas), [canvas]);
+  const epicTitleById = useMemo(() => buildEpicTitleById(tasks), [tasks]);
   const taskRows = useMemo(
     () =>
       buildTaskRows({
@@ -202,9 +216,17 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
         canvas,
         canvasIndex,
         recordByOwner,
+        epicTitleById,
         sortOption,
       }),
-    [canvas, canvasIndex, projection.entries, recordByOwner, sortOption],
+    [
+      canvas,
+      canvasIndex,
+      epicTitleById,
+      projection.entries,
+      recordByOwner,
+      sortOption,
+    ],
   );
 
   const toggleOwner = (key: string): void => {
@@ -223,6 +245,7 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
     const opened = openResourceOwner({
       row,
       canvas,
+      epicTitleById,
       openTileInTab,
       setActiveTilePane,
       setActiveTileTab,
@@ -359,49 +382,70 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
 }
 
 function useDesktopAppResourceUsage(): DesktopAppResourceUsage | null {
-  const [usage, setUsage] = useState<DesktopAppResourceUsage | null>(null);
+  return useSyncExternalStore(
+    subscribeDesktopAppResourceUsage,
+    getDesktopAppResourceSnapshot,
+    getDesktopAppResourceSnapshot,
+  );
+}
 
-  useEffect(() => {
-    const bridge = getDesktopDiagnosticsBridge();
-    if (bridge === null) {
-      return;
-    }
-
-    let disposed = false;
-    let inFlight = false;
-
-    const sample = (): void => {
-      if (inFlight) return;
-      inFlight = true;
-      void bridge
-        .getMetrics()
-        .then(
-          (snapshot) => {
-            if (disposed) return;
-            setUsage(desktopAppResourceUsageFromMetrics(snapshot, Date.now()));
-          },
-          () => {
-            if (disposed) return;
-            setUsage(null);
-          },
-        )
-        .finally(() => {
-          inFlight = false;
-        });
-    };
-
-    sample();
-    const timer = window.setInterval(
-      sample,
+function subscribeDesktopAppResourceUsage(listener: () => void): () => void {
+  desktopAppResourceListeners.add(listener);
+  if (desktopAppResourceListeners.size === 1) {
+    sampleDesktopAppResourceUsage();
+    desktopAppResourceTimer = window.setInterval(
+      sampleDesktopAppResourceUsage,
       DESKTOP_RESOURCE_SAMPLE_INTERVAL_MS,
     );
-    return () => {
-      disposed = true;
-      window.clearInterval(timer);
-    };
-  }, []);
+  }
+  return () => {
+    desktopAppResourceListeners.delete(listener);
+    if (
+      desktopAppResourceListeners.size === 0 &&
+      desktopAppResourceTimer !== null
+    ) {
+      window.clearInterval(desktopAppResourceTimer);
+      desktopAppResourceTimer = null;
+    }
+  };
+}
 
-  return usage;
+function getDesktopAppResourceSnapshot(): DesktopAppResourceUsage | null {
+  return desktopAppResourceSnapshot;
+}
+
+function sampleDesktopAppResourceUsage(): void {
+  const bridge = getDesktopDiagnosticsBridge();
+  if (bridge === null) {
+    setDesktopAppResourceSnapshot(null);
+    return;
+  }
+  if (desktopAppResourceInFlight) return;
+  desktopAppResourceInFlight = true;
+  void bridge
+    .getMetrics()
+    .then(
+      (snapshot) => {
+        setDesktopAppResourceSnapshot(
+          desktopAppResourceUsageFromMetrics(snapshot, Date.now()),
+        );
+      },
+      () => {
+        setDesktopAppResourceSnapshot(null);
+      },
+    )
+    .finally(() => {
+      desktopAppResourceInFlight = false;
+    });
+}
+
+function setDesktopAppResourceSnapshot(
+  next: DesktopAppResourceUsage | null,
+): void {
+  desktopAppResourceSnapshot = next;
+  for (const listener of Array.from(desktopAppResourceListeners)) {
+    listener();
+  }
 }
 
 function useResourceCanvasSnapshot(): CanvasResourceSnapshot {
@@ -555,6 +599,20 @@ function desktopResourceSummary(
   };
 }
 
+function buildEpicTitleById(
+  tasks: readonly TaskLight[],
+): ReadonlyMap<string, string> {
+  return new Map(
+    tasks.flatMap((task): [string, string][] => {
+      const light = task.epic?.light ?? null;
+      if (light === null) return [];
+      const title = light.title.trim();
+      if (title.length === 0) return [];
+      return [[light.id, title]];
+    }),
+  );
+}
+
 function TaskResourceSection(props: {
   readonly task: TaskDisplayRow;
   readonly collapsedOwners: ReadonlySet<string>;
@@ -583,6 +641,7 @@ function TaskResourceSection(props: {
       </div>
       {props.task.owners.map((row) => {
         const key = ownerKey(
+          row.snapshot.owner.epicId,
           row.snapshot.owner.kind,
           row.snapshot.owner.ownerId,
         );
@@ -710,12 +769,17 @@ function buildTaskRows(input: {
   readonly canvas: CanvasResourceSnapshot;
   readonly canvasIndex: CanvasResourceIndex;
   readonly recordByOwner: ReadonlyMap<string, EpicNodeRecord>;
+  readonly epicTitleById: ReadonlyMap<string, string>;
   readonly sortOption: ResourceSortOption;
 }): TaskDisplayRow[] {
   const rows = input.entries.flatMap((entry): TaskDisplayRow[] => {
     if (entry.owners.length === 0) return [];
     const owners = entry.owners.map((snapshot): OwnerDisplayRow => {
-      const key = ownerKey(snapshot.owner.kind, snapshot.owner.ownerId);
+      const key = ownerKey(
+        snapshot.owner.epicId,
+        snapshot.owner.kind,
+        snapshot.owner.ownerId,
+      );
       const location = input.canvasIndex.locationByOwner.get(key) ?? null;
       const record = input.recordByOwner.get(key) ?? null;
       return {
@@ -730,7 +794,7 @@ function buildTaskRows(input: {
     return [
       {
         entry,
-        label: taskLabel(entry.epicId, input.canvas),
+        label: taskLabel(entry.epicId, input.canvas, input.epicTitleById),
         tabOrder: taskTabOrder(entry.epicId, input.canvas),
         owners: sortOwnerRows(owners, input.sortOption),
       },
@@ -756,7 +820,7 @@ function buildCanvasResourceIndex(
         const ownerKind =
           ref === undefined ? null : resourceOwnerKindForRef(ref);
         if (ref === undefined || ownerKind === null) return [];
-        const key = ownerKey(ownerKind, ref.id);
+        const key = ownerKey(tab.epicId, ownerKind, ref.id);
         return [
           {
             key,
@@ -791,12 +855,13 @@ function buildRecordByOwner(
   canvas: CanvasResourceSnapshot,
 ): ReadonlyMap<string, EpicNodeRecord> {
   return new Map(
-    Object.values(canvas.artifactTreeByEpicId).flatMap((epicRecords) =>
-      (epicRecords ?? []).flatMap((record): [string, EpicNodeRecord][] => {
-        const kind = resourceOwnerKindForNodeType(record.type);
-        if (kind === null) return [];
-        return [[ownerKey(kind, record.id), record]];
-      }),
+    Object.entries(canvas.artifactTreeByEpicId).flatMap(
+      ([epicId, epicRecords]) =>
+        (epicRecords ?? []).flatMap((record): [string, EpicNodeRecord][] => {
+          const kind = resourceOwnerKindForNodeType(record.type);
+          if (kind === null) return [];
+          return [[ownerKey(epicId, kind, record.id), record]];
+        }),
     ),
   );
 }
@@ -848,6 +913,7 @@ function sortOwnerRows(
 function openResourceOwner(args: {
   readonly row: OwnerDisplayRow;
   readonly canvas: CanvasResourceSnapshot;
+  readonly epicTitleById: ReadonlyMap<string, string>;
   readonly openTileInTab: (tabId: string, node: EpicCanvasTileRef) => void;
   readonly setActiveTilePane: (tabId: string, paneId: string) => void;
   readonly setActiveTileTab: (
@@ -886,7 +952,7 @@ function openResourceOwner(args: {
     .getState()
     .resolveTargetTabForEpic(
       snapshot.owner.epicId,
-      taskLabel(snapshot.owner.epicId, args.canvas),
+      taskLabel(snapshot.owner.epicId, args.canvas, args.epicTitleById),
     );
   args.openTileInTab(targetTabId, {
     id: record.id,
@@ -923,11 +989,17 @@ function findOwnerRecord(
   return records.find((record) => record.id === snapshot.owner.ownerId) ?? null;
 }
 
-function taskLabel(epicId: string, canvas: CanvasResourceSnapshot): string {
+function taskLabel(
+  epicId: string,
+  canvas: CanvasResourceSnapshot,
+  epicTitleById: ReadonlyMap<string, string>,
+): string {
   for (const tabId of canvas.openTabOrder) {
     const tab = canvas.tabsById[tabId];
     if (tab?.epicId === epicId && tab.name.length > 0) return tab.name;
   }
+  const title = epicTitleById.get(epicId);
+  if (title !== undefined && title.length > 0) return title;
   return "Task";
 }
 
@@ -938,8 +1010,12 @@ function taskTabOrder(epicId: string, canvas: CanvasResourceSnapshot): number {
   return index === -1 ? Number.MAX_SAFE_INTEGER : index;
 }
 
-function ownerKey(kind: ResourceOwnerKindWire, ownerId: string): string {
-  return `${kind}\x1f${ownerId}`;
+function ownerKey(
+  epicId: string,
+  kind: ResourceOwnerKindWire,
+  ownerId: string,
+): string {
+  return `${epicId}\x1f${kind}\x1f${ownerId}`;
 }
 
 function resourceOwnerKindForNodeType(

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -307,6 +307,11 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
       aria-label="Resources"
       className="w-[min(92vw,34rem)] gap-0 overflow-hidden rounded-xl p-0"
       onOpenAutoFocus={(event) => event.preventDefault()}
+      // Keep the panel open when focus moves elsewhere (switching tabs, a task
+      // finishing load and autofocusing its content, a terminal grabbing
+      // focus). Only a genuine outside pointer click or Escape should dismiss
+      // it; those go through onPointerDownOutside / onEscapeKeyDown, not here.
+      onFocusOutside={(event) => event.preventDefault()}
       onInteractOutside={(event) => {
         if (!sortMenuOpen) return;
         if (!(event.target instanceof Node)) return;

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState, useSyncExternalStore } from "react";
+import { useMemo, useRef, useState, useSyncExternalStore } from "react";
+import type { MouseEvent, PointerEvent } from "react";
 import { useNavigate, type UseNavigateResult } from "@tanstack/react-router";
 import { v4 as uuidv4 } from "uuid";
 import { useShallow } from "zustand/react/shallow";
@@ -85,6 +86,7 @@ const desktopAppResourceListeners = new Set<() => void>();
 let desktopAppResourceSnapshot: DesktopAppResourceUsage | null = null;
 let desktopAppResourceTimer: number | null = null;
 let desktopAppResourceInFlight = false;
+const MAX_VISIBLE_PROCESS_DEPTH = 2;
 const EMPTY_RESOURCE_SUMMARY: TaskResourceSummary = {
   cpuPercent: 0,
   rssBytes: 0,
@@ -137,6 +139,8 @@ interface TaskDisplayRow {
   readonly entry: GlobalResourceEpicEntry;
   readonly label: string;
   readonly tabOrder: number;
+  readonly cpuPercent: number;
+  readonly rssBytes: number;
   readonly owners: readonly OwnerDisplayRow[];
 }
 
@@ -144,6 +148,12 @@ interface DesktopResourceSummary {
   readonly cpuPercent: number;
   readonly rssBytes: number;
   readonly processCount: number;
+}
+
+interface ProcessDisplayRow {
+  readonly process: ResourceProcessSnapshotWire;
+  readonly depth: number;
+  readonly hiddenDescendants: readonly ResourceProcessSnapshotWire[];
 }
 
 export function ResourceMonitorPopover(props: ResourceMonitorPopoverProps) {
@@ -186,9 +196,13 @@ export function ResourceMonitorPopover(props: ResourceMonitorPopoverProps) {
 
 function ResourceMonitorContent(props: { readonly onClose: () => void }) {
   const [sortOption, setSortOption] = useState<ResourceSortOption>("memory");
+  const [sortMenuOpen, setSortMenuOpen] = useState(false);
   const [collapsedOwners, setCollapsedOwners] = useState<Set<string>>(
     () => new Set(),
   );
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const sortTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const dismissingSortMenuRef = useRef(false);
   const projection = useGlobalResourceProjection();
   const { tasks } = useCloudEpicTasksQuery(undefined, { enabled: true });
   const canvas = useResourceCanvasSnapshot();
@@ -261,6 +275,29 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
       ? (summary.rssBytes / projection.app.hostTotalMemoryBytes) * 100
       : 0;
 
+  const dismissSortMenuFromPanelClick = (
+    event: PointerEvent<HTMLDivElement>,
+  ): void => {
+    if (!sortMenuOpen) return;
+    if (!(event.target instanceof Node)) return;
+    if (sortTriggerRef.current?.contains(event.target) === true) return;
+
+    dismissingSortMenuRef.current = true;
+    setSortMenuOpen(false);
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const swallowDismissedSortMenuClick = (
+    event: MouseEvent<HTMLDivElement>,
+  ): void => {
+    if (!dismissingSortMenuRef.current) return;
+
+    dismissingSortMenuRef.current = false;
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   return (
     <PopoverContent
       align="end"
@@ -270,112 +307,133 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
       aria-label="Resources"
       className="w-[min(92vw,34rem)] gap-0 overflow-hidden rounded-xl p-0"
       onOpenAutoFocus={(event) => event.preventDefault()}
+      onInteractOutside={(event) => {
+        if (!sortMenuOpen) return;
+        if (!(event.target instanceof Node)) return;
+        if (panelRef.current?.contains(event.target) === true) {
+          event.preventDefault();
+        }
+      }}
     >
-      <div className="border-b border-border/60 px-3.5 pb-3 pt-3">
-        <div className="flex items-center justify-between gap-3">
-          <h4 className="truncate text-ui-sm font-medium text-foreground">
-            Resources
-          </h4>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="flex h-6 items-center gap-1 rounded-sm px-1.5 text-ui-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                aria-label="Sort resource rows"
+      <div
+        ref={panelRef}
+        className="min-w-0"
+        onPointerDownCapture={dismissSortMenuFromPanelClick}
+        onClickCapture={swallowDismissedSortMenuClick}
+      >
+        <div className="border-b border-border/60 px-3.5 pb-3 pt-3">
+          <div className="flex items-center justify-between gap-3">
+            <h4 className="truncate text-ui-sm font-medium text-foreground">
+              Resources
+            </h4>
+            <DropdownMenu
+              modal={false}
+              open={sortMenuOpen}
+              onOpenChange={setSortMenuOpen}
+            >
+              <DropdownMenuTrigger asChild>
+                <button
+                  ref={sortTriggerRef}
+                  type="button"
+                  className="flex h-6 items-center gap-1 rounded-sm px-1.5 text-ui-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  aria-label="Sort resource rows"
+                >
+                  <ArrowDownNarrowWide className="size-3.5" />
+                  <span>{SORT_LABELS[sortOption]}</span>
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                <DropdownMenuRadioGroup
+                  value={sortOption}
+                  onValueChange={(value) => {
+                    if (isResourceSortOption(value)) setSortOption(value);
+                  }}
+                >
+                  <DropdownMenuRadioItem value="memory">
+                    Memory
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="cpu">CPU</DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="name">
+                    Name
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="tab">
+                    Tab order
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          {summary === null ? (
+            <div className="mt-4 text-ui-xs text-muted-foreground">
+              Waiting for resource data.
+            </div>
+          ) : (
+            <>
+              <div className="mt-3 grid grid-cols-3 divide-x divide-border/50">
+                <MetricBlock
+                  label="CPU"
+                  value={formatCpuPercent(summary.cpuPercent)}
+                />
+                <MetricBlock
+                  label="Memory"
+                  value={formatMemoryBytes(summary.rssBytes)}
+                />
+                <MetricBlock
+                  label="RAM share"
+                  value={formatCpuPercent(memorySharePercent)}
+                />
+              </div>
+              <div
+                className="mt-3 h-1 w-full overflow-hidden rounded-full bg-muted/60"
+                role="progressbar"
+                aria-label="Tracked RAM share"
+                aria-valuenow={Math.round(memorySharePercent)}
+                aria-valuemin={0}
+                aria-valuemax={100}
               >
-                <ArrowDownNarrowWide className="size-3.5" />
-                <span>{SORT_LABELS[sortOption]}</span>
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-40">
-              <DropdownMenuRadioGroup
-                value={sortOption}
-                onValueChange={(value) => {
-                  if (isResourceSortOption(value)) setSortOption(value);
-                }}
-              >
-                <DropdownMenuRadioItem value="memory">
-                  Memory
-                </DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="cpu">CPU</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="name">Name</DropdownMenuRadioItem>
-                <DropdownMenuRadioItem value="tab">
-                  Tab order
-                </DropdownMenuRadioItem>
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
+                <div
+                  className={cn(
+                    "h-full rounded-full transition-[width] duration-300",
+                    memoryShareBarClass(memorySharePercent),
+                  )}
+                  style={{
+                    width: `${Math.min(100, Math.max(0, memorySharePercent))}%`,
+                  }}
+                />
+              </div>
+              <ResourceCounts summary={summary} />
+            </>
+          )}
         </div>
 
-        {summary === null ? (
-          <div className="mt-4 text-ui-xs text-muted-foreground">
-            Waiting for resource data.
-          </div>
-        ) : (
-          <>
-            <div className="mt-3 grid grid-cols-3 divide-x divide-border/50">
-              <MetricBlock
-                label="CPU"
-                value={formatCpuPercent(summary.cpuPercent)}
-              />
-              <MetricBlock
-                label="Memory"
-                value={formatMemoryBytes(summary.rssBytes)}
-              />
-              <MetricBlock
-                label="RAM share"
-                value={formatCpuPercent(memorySharePercent)}
-              />
+        <div className="max-h-[min(58vh,36rem)] overflow-y-auto">
+          {desktopApp === null ? null : (
+            <DesktopAppResourceSection app={desktopApp} />
+          )}
+          {projection.app === null ? null : (
+            <HostAppResourceSection app={projection.app} />
+          )}
+          {summary === null ? null : (
+            <div className="py-1">
+              {taskRows.length === 0 ? (
+                <div className="px-3.5 py-4 text-center text-ui-xs text-muted-foreground">
+                  No active task process trees.
+                </div>
+              ) : (
+                taskRows.map((task) => (
+                  <TaskResourceSection
+                    key={task.entry.epicId}
+                    task={task}
+                    collapsedOwners={collapsedOwners}
+                    onToggleOwner={toggleOwner}
+                    onOpenOwner={openOwner}
+                  />
+                ))
+              )}
             </div>
-            <div
-              className="mt-3 h-1 w-full overflow-hidden rounded-full bg-muted/60"
-              role="progressbar"
-              aria-label="Tracked RAM share"
-              aria-valuenow={Math.round(memorySharePercent)}
-              aria-valuemin={0}
-              aria-valuemax={100}
-            >
-              <div
-                className={cn(
-                  "h-full rounded-full transition-[width] duration-300",
-                  memoryShareBarClass(memorySharePercent),
-                )}
-                style={{
-                  width: `${Math.min(100, Math.max(0, memorySharePercent))}%`,
-                }}
-              />
-            </div>
-            <ResourceCounts summary={summary} />
-          </>
-        )}
-      </div>
-
-      <div className="max-h-[min(58vh,36rem)] overflow-y-auto">
-        {desktopApp === null ? null : (
-          <DesktopAppResourceSection app={desktopApp} />
-        )}
-        {projection.app === null ? null : (
-          <HostAppResourceSection app={projection.app} />
-        )}
-        {summary === null ? null : (
-          <div className="py-1">
-            {taskRows.length === 0 ? (
-              <div className="px-3.5 py-4 text-center text-ui-xs text-muted-foreground">
-                No active task process trees.
-              </div>
-            ) : (
-              taskRows.map((task) => (
-                <TaskResourceSection
-                  key={task.entry.epicId}
-                  task={task}
-                  collapsedOwners={collapsedOwners}
-                  onToggleOwner={toggleOwner}
-                  onOpenOwner={openOwner}
-                />
-              ))
-            )}
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </PopoverContent>
   );
@@ -562,7 +620,13 @@ function HostAppResourceSection(props: { readonly app: AppResourceUsage }) {
         />
       </div>
       {props.app.process === null ? null : (
-        <ProcessLeafRow process={props.app.process} depth={1} />
+        <ProcessLeafRow
+          processRow={{
+            process: props.app.process,
+            depth: 1,
+            hiddenDescendants: [],
+          }}
+        />
       )}
     </div>
   );
@@ -619,14 +683,6 @@ function TaskResourceSection(props: {
   readonly onToggleOwner: (key: string) => void;
   readonly onOpenOwner: (row: OwnerDisplayRow) => void;
 }) {
-  const ownerCpu = props.task.owners.reduce(
-    (sum, row) => sum + row.snapshot.cpuPercent,
-    0,
-  );
-  const ownerRss = props.task.owners.reduce(
-    (sum, row) => sum + row.snapshot.rssBytes,
-    0,
-  );
   return (
     <div className="border-b border-border/50 py-1 last:border-b-0">
       <div className="flex items-center justify-between px-3.5 py-1.5">
@@ -634,8 +690,8 @@ function TaskResourceSection(props: {
           {props.task.label}
         </span>
         <MetricPair
-          cpuPercent={ownerCpu}
-          rssBytes={ownerRss}
+          cpuPercent={props.task.cpuPercent}
+          rssBytes={props.task.rssBytes}
           className="text-ui-sm text-foreground/90"
         />
       </div>
@@ -716,37 +772,69 @@ function OwnerTreeRow(props: {
       </div>
       {props.collapsed
         ? null
-        : props.row.snapshot.processes.map((process) => (
+        : buildProcessRows(props.row.snapshot.processes).map((processRow) => (
             <ProcessLeafRow
-              key={`${process.rootPid}:${process.pid}`}
-              process={process}
-              depth={processDepth(process, props.row.snapshot.processes)}
+              key={`${processRow.process.rootPid}:${processRow.process.pid}`}
+              processRow={processRow}
             />
           ))}
     </div>
   );
 }
 
-function ProcessLeafRow(props: {
-  readonly process: ResourceProcessSnapshotWire;
-  readonly depth: number;
-}) {
-  return (
+function ProcessLeafRow(props: { readonly processRow: ProcessDisplayRow }) {
+  const hiddenCount = props.processRow.hiddenDescendants.length;
+  const content = (
     <div
+      tabIndex={hiddenCount === 0 ? undefined : 0}
       className="flex items-center justify-between gap-3 px-3.5 py-1 text-muted-foreground transition-colors hover:bg-muted/40"
-      style={{ paddingLeft: `calc(1.25rem + ${props.depth} * 1rem)` }}
+      style={{
+        paddingLeft: `calc(1.25rem + ${props.processRow.depth} * 1rem)`,
+      }}
     >
       <div className="flex min-w-0 items-center gap-1.5">
         <span className="size-1 shrink-0 rounded-full bg-muted-foreground/40" />
         <span className="min-w-0 truncate text-ui-xs">
-          {processLabel(props.process)}
+          {processLeafLabel(props.processRow.process, hiddenCount)}
         </span>
       </div>
       <MetricPair
-        cpuPercent={props.process.cpuPercent}
-        rssBytes={props.process.rssBytes}
+        cpuPercent={props.processRow.process.cpuPercent}
+        rssBytes={props.processRow.process.rssBytes}
         className="text-ui-xs text-muted-foreground/80"
       />
+    </div>
+  );
+  if (hiddenCount === 0) return content;
+  return (
+    <TooltipWrapper
+      label={
+        <HiddenSubprocessTooltip
+          processes={props.processRow.hiddenDescendants}
+        />
+      }
+      side="right"
+      sideOffset={8}
+      align="start"
+    >
+      {content}
+    </TooltipWrapper>
+  );
+}
+
+function HiddenSubprocessTooltip(props: {
+  readonly processes: readonly ResourceProcessSnapshotWire[];
+}) {
+  return (
+    <div className="flex max-h-[min(40vh,18rem)] min-w-0 flex-col gap-1 overflow-y-auto text-left">
+      {props.processes.map((process) => (
+        <div
+          key={`${process.rootPid}:${process.pid}`}
+          className="max-w-full truncate"
+        >
+          {processLabel(process)}
+        </div>
+      ))}
     </div>
   );
 }
@@ -774,28 +862,40 @@ function buildTaskRows(input: {
 }): TaskDisplayRow[] {
   const rows = input.entries.flatMap((entry): TaskDisplayRow[] => {
     if (entry.owners.length === 0) return [];
-    const owners = entry.owners.map((snapshot): OwnerDisplayRow => {
-      const key = ownerKey(
-        snapshot.owner.epicId,
-        snapshot.owner.kind,
-        snapshot.owner.ownerId,
-      );
-      const location = input.canvasIndex.locationByOwner.get(key) ?? null;
-      const record = input.recordByOwner.get(key) ?? null;
-      return {
-        snapshot,
-        label: ownerLabel(snapshot, location, record),
-        canOpen: canOpenOwner(snapshot, location, record),
-        tabOrder:
-          input.canvasIndex.tabOrderByOwner.get(key) ?? Number.MAX_SAFE_INTEGER,
-        location,
-      };
-    });
+    const owners = entry.owners
+      .filter(shouldShowOwnerRow)
+      .map((snapshot): OwnerDisplayRow => {
+        const key = ownerKey(
+          snapshot.owner.epicId,
+          snapshot.owner.kind,
+          snapshot.owner.ownerId,
+        );
+        const location = input.canvasIndex.locationByOwner.get(key) ?? null;
+        const record = input.recordByOwner.get(key) ?? null;
+        return {
+          snapshot,
+          label: ownerLabel(snapshot, location, record),
+          canOpen: canOpenOwner(snapshot, location, record),
+          tabOrder:
+            input.canvasIndex.tabOrderByOwner.get(key) ??
+            Number.MAX_SAFE_INTEGER,
+          location,
+        };
+      });
+    if (owners.length === 0) return [];
     return [
       {
         entry,
         label: taskLabel(entry.epicId, input.canvas, input.epicTitleById),
         tabOrder: taskTabOrder(entry.epicId, input.canvas),
+        cpuPercent: entry.owners.reduce(
+          (sum, snapshot) => sum + snapshot.cpuPercent,
+          0,
+        ),
+        rssBytes: entry.owners.reduce(
+          (sum, snapshot) => sum + snapshot.rssBytes,
+          0,
+        ),
         owners: sortOwnerRows(owners, input.sortOption),
       },
     ];
@@ -873,10 +973,10 @@ function sortTaskRows(
   const sorted = [...rows];
   switch (sortOption) {
     case "memory":
-      sorted.sort((a, b) => ownerRss(b.owners) - ownerRss(a.owners));
+      sorted.sort((a, b) => b.rssBytes - a.rssBytes);
       break;
     case "cpu":
-      sorted.sort((a, b) => ownerCpu(b.owners) - ownerCpu(a.owners));
+      sorted.sort((a, b) => b.cpuPercent - a.cpuPercent);
       break;
     case "name":
       sorted.sort((a, b) => a.label.localeCompare(b.label));
@@ -1018,6 +1118,11 @@ function ownerKey(
   return `${epicId}\x1f${kind}\x1f${ownerId}`;
 }
 
+function shouldShowOwnerRow(snapshot: OwnerResourceSnapshotWire): boolean {
+  if (snapshot.owner.kind !== "terminal") return true;
+  return snapshot.processCount > 0 || snapshot.processes.length > 0;
+}
+
 function resourceOwnerKindForNodeType(
   type: string,
 ): ResourceOwnerKindWire | null {
@@ -1089,13 +1194,41 @@ function processLabel(process: ResourceProcessSnapshotWire): string {
   return `${process.name} (${process.pid})`;
 }
 
+function processLeafLabel(
+  process: ResourceProcessSnapshotWire,
+  hiddenCount: number,
+): string {
+  const label = processLabel(process);
+  if (hiddenCount === 0) return label;
+  return `${label} (${countLabel(hiddenCount, "sub-process", "sub-processes")})`;
+}
+
+function buildProcessRows(
+  processes: readonly ResourceProcessSnapshotWire[],
+): ProcessDisplayRow[] {
+  const byPid = processByPid(processes);
+  return processes.flatMap((process): ProcessDisplayRow[] => {
+    const depth = processDepth(process, byPid);
+    if (depth > MAX_VISIBLE_PROCESS_DEPTH) return [];
+    return [
+      {
+        process,
+        depth,
+        hiddenDescendants:
+          depth === MAX_VISIBLE_PROCESS_DEPTH
+            ? hiddenProcessDescendants(process, processes, byPid)
+            : [],
+      },
+    ];
+  });
+}
+
 function processDepth(
   process: ResourceProcessSnapshotWire,
-  processes: readonly ResourceProcessSnapshotWire[],
+  byPid: ReadonlyMap<number, ResourceProcessSnapshotWire>,
 ): number {
   let depth = process.pid === process.rootPid ? 1 : 2;
   let cursor = process;
-  const byPid = new Map(processes.map((entry) => [entry.pid, entry]));
   const visited = new Set<number>([process.pid]);
   while (cursor.parentPid !== null && cursor.parentPid !== process.rootPid) {
     const parent = byPid.get(cursor.parentPid);
@@ -1107,13 +1240,41 @@ function processDepth(
   return depth;
 }
 
-function ownerCpu(rows: readonly OwnerDisplayRow[]): number {
-  return rows.reduce((sum, row) => sum + row.snapshot.cpuPercent, 0);
+function processByPid(
+  processes: readonly ResourceProcessSnapshotWire[],
+): ReadonlyMap<number, ResourceProcessSnapshotWire> {
+  return new Map(processes.map((entry) => [entry.pid, entry]));
 }
 
-function ownerRss(rows: readonly OwnerDisplayRow[]): number {
-  return rows.reduce((sum, row) => sum + row.snapshot.rssBytes, 0);
+function hiddenProcessDescendants(
+  process: ResourceProcessSnapshotWire,
+  processes: readonly ResourceProcessSnapshotWire[],
+  byPid: ReadonlyMap<number, ResourceProcessSnapshotWire>,
+): ResourceProcessSnapshotWire[] {
+  return processes.filter(
+    (candidate) =>
+      processDepth(candidate, byPid) > MAX_VISIBLE_PROCESS_DEPTH &&
+      isProcessDescendantOf(candidate, process.pid, byPid),
+  );
 }
+
+function isProcessDescendantOf(
+  process: ResourceProcessSnapshotWire,
+  ancestorPid: number,
+  byPid: ReadonlyMap<number, ResourceProcessSnapshotWire>,
+): boolean {
+  let cursor = process;
+  const visited = new Set<number>([process.pid]);
+  while (cursor.parentPid !== null) {
+    if (cursor.parentPid === ancestorPid) return true;
+    const parent = byPid.get(cursor.parentPid);
+    if (parent === undefined || visited.has(parent.pid)) break;
+    visited.add(parent.pid);
+    cursor = parent;
+  }
+  return false;
+}
+
 
 function countLabel(count: number, singular: string, plural: string): string {
   return `${formatProcessCount(count)} ${count === 1 ? singular : plural}`;

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -820,14 +820,13 @@ function OwnerTreeRow(props: {
 
 function ProcessLeafRow(props: { readonly processRow: ProcessDisplayRow }) {
   const hiddenCount = props.processRow.hiddenDescendants.length;
-  const content = (
-    <div
-      tabIndex={hiddenCount === 0 ? undefined : 0}
-      className="flex items-center justify-between gap-3 px-3.5 py-1 text-muted-foreground transition-colors hover:bg-muted/40"
-      style={{
-        paddingLeft: `calc(1.25rem + ${props.processRow.depth} * 1rem)`,
-      }}
-    >
+  const rowClassName =
+    "flex w-full items-center justify-between gap-3 px-3.5 py-1 text-left text-muted-foreground transition-colors hover:bg-muted/40";
+  const rowStyle = {
+    paddingLeft: `calc(1.25rem + ${props.processRow.depth} * 1rem)`,
+  };
+  const inner = (
+    <>
       <div className="flex min-w-0 items-center gap-1.5">
         <span className="size-1 shrink-0 rounded-full bg-muted-foreground/40" />
         <span className="min-w-0 truncate text-ui-xs">
@@ -839,12 +838,31 @@ function ProcessLeafRow(props: { readonly processRow: ProcessDisplayRow }) {
         rssBytes={props.processRow.process.rssBytes}
         className="text-ui-xs text-muted-foreground/80"
       />
-    </div>
+    </>
   );
-  if (hiddenCount === 0) return content;
+  // Leaf rows are static; only a capped row reveals more (its hidden sub-tree),
+  // so it is the one focusable, keyboard-reachable trigger for that tooltip.
+  if (hiddenCount === 0) {
+    return (
+      <div className={rowClassName} style={rowStyle}>
+        {inner}
+      </div>
+    );
+  }
   return (
     <Tooltip>
-      <TooltipTrigger asChild>{content}</TooltipTrigger>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            rowClassName,
+            "cursor-default outline-none focus-visible:bg-muted/40 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
+          )}
+          style={rowStyle}
+        >
+          {inner}
+        </button>
+      </TooltipTrigger>
       <TooltipPrimitive.Portal>
         <TooltipPrimitive.Content
           side="right"

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -153,7 +153,14 @@ interface DesktopResourceSummary {
 interface ProcessDisplayRow {
   readonly process: ResourceProcessSnapshotWire;
   readonly depth: number;
-  readonly hiddenDescendants: readonly ResourceProcessSnapshotWire[];
+  readonly hiddenDescendants: readonly HiddenProcessRow[];
+}
+
+interface HiddenProcessRow {
+  readonly process: ResourceProcessSnapshotWire;
+  // Depth relative to the capped row (the first hidden level is 1) so the
+  // tooltip can indent the collapsed sub-tree the same way the main tree does.
+  readonly depth: number;
 }
 
 export function ResourceMonitorPopover(props: ResourceMonitorPopoverProps) {
@@ -814,9 +821,7 @@ function ProcessLeafRow(props: { readonly processRow: ProcessDisplayRow }) {
   return (
     <TooltipWrapper
       label={
-        <HiddenSubprocessTooltip
-          processes={props.processRow.hiddenDescendants}
-        />
+        <HiddenSubprocessTooltip rows={props.processRow.hiddenDescendants} />
       }
       side="right"
       sideOffset={8}
@@ -828,16 +833,27 @@ function ProcessLeafRow(props: { readonly processRow: ProcessDisplayRow }) {
 }
 
 function HiddenSubprocessTooltip(props: {
-  readonly processes: readonly ResourceProcessSnapshotWire[];
+  readonly rows: readonly HiddenProcessRow[];
 }) {
   return (
-    <div className="flex max-h-[min(40vh,18rem)] min-w-0 flex-col gap-1 overflow-y-auto text-left">
-      {props.processes.map((process) => (
+    <div className="flex max-h-[min(40vh,18rem)] min-w-0 flex-col overflow-y-auto text-left">
+      {props.rows.map((row) => (
         <div
-          key={`${process.rootPid}:${process.pid}`}
-          className="max-w-full truncate"
+          key={`${row.process.rootPid}:${row.process.pid}`}
+          className="flex items-center justify-between gap-3 py-1 text-muted-foreground"
+          style={{ paddingLeft: `calc(${row.depth} * 1rem)` }}
         >
-          {processLabel(process)}
+          <div className="flex min-w-0 items-center gap-1.5">
+            <span className="size-1 shrink-0 rounded-full bg-muted-foreground/40" />
+            <span className="min-w-0 truncate text-ui-xs">
+              {processLabel(row.process)}
+            </span>
+          </div>
+          <MetricPair
+            cpuPercent={row.process.cpuPercent}
+            rssBytes={row.process.rssBytes}
+            className="text-ui-xs text-muted-foreground/80"
+          />
         </div>
       ))}
     </div>
@@ -1255,12 +1271,17 @@ function hiddenProcessDescendants(
   process: ResourceProcessSnapshotWire,
   processes: readonly ResourceProcessSnapshotWire[],
   byPid: ReadonlyMap<number, ResourceProcessSnapshotWire>,
-): ResourceProcessSnapshotWire[] {
-  return processes.filter(
-    (candidate) =>
-      processDepth(candidate, byPid) > MAX_VISIBLE_PROCESS_DEPTH &&
-      isProcessDescendantOf(candidate, process.pid, byPid),
-  );
+): HiddenProcessRow[] {
+  return processes.flatMap((candidate): HiddenProcessRow[] => {
+    const depth = processDepth(candidate, byPid);
+    if (
+      depth <= MAX_VISIBLE_PROCESS_DEPTH ||
+      !isProcessDescendantOf(candidate, process.pid, byPid)
+    ) {
+      return [];
+    }
+    return [{ process: candidate, depth: depth - MAX_VISIBLE_PROCESS_DEPTH }];
+  });
 }
 
 function isProcessDescendantOf(
@@ -1279,7 +1300,6 @@ function isProcessDescendantOf(
   }
   return false;
 }
-
 
 function countLabel(count: number, singular: string, plural: string): string {
   return `${formatProcessCount(count)} ${count === 1 ? singular : plural}`;

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -1,4 +1,10 @@
-import { useMemo, useRef, useState, useSyncExternalStore } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import type { MouseEvent, PointerEvent } from "react";
 import { useNavigate, type UseNavigateResult } from "@tanstack/react-router";
 import { v4 as uuidv4 } from "uuid";
@@ -36,6 +42,7 @@ import {
   useGlobalResourceProjection,
   type GlobalResourceEpicEntry,
 } from "@/stores/resources/resources-registry";
+import { useTitleBarDragStore } from "@/stores/layout/title-bar-drag-store";
 import { GlobalResourcesStreamMount } from "@/providers/resources-stream-mount";
 import type {
   AppResourceUsage,
@@ -165,6 +172,15 @@ interface HiddenProcessRow {
 
 export function ResourceMonitorPopover(props: ResourceMonitorPopoverProps) {
   const [open, setOpen] = useState(false);
+  const setTitleBarDragSuppressed = useTitleBarDragStore(
+    (state) => state.setSuppressed,
+  );
+  // While the panel is open, let the header drop its title-bar drag regions so a
+  // click on the (otherwise event-swallowing) drag area dismisses the popover.
+  useEffect(() => {
+    setTitleBarDragSuppressed("resource-monitor", open);
+    return () => setTitleBarDragSuppressed("resource-monitor", false);
+  }, [open, setTitleBarDragSuppressed]);
 
   return (
     <>

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -38,6 +38,8 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { Tooltip, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
 import {
   useGlobalResourceProjection,
   type GlobalResourceEpicEntry,
@@ -88,6 +90,11 @@ const SORT_LABELS: Record<ResourceSortOption, string> = {
 const METRIC_COLS = "flex shrink-0 items-center tabular-nums tracking-tight";
 const CPU_COL = "w-14 text-right";
 const MEM_COL = "w-20 text-right";
+// The collapsed sub-tree tooltip is a mini-panel mirroring the process tree, so
+// it rides the light popover surface rather than the default inverted (dark)
+// tooltip chip - matching the popover it extends.
+const HIDDEN_SUBPROCESS_TOOLTIP_SURFACE =
+  "z-50 w-fit max-w-[min(90vw,22rem)] origin-(--radix-tooltip-content-transform-origin) rounded-lg bg-popover p-1.5 text-popover-foreground shadow-md ring-1 ring-foreground/10 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95";
 const DESKTOP_RESOURCE_SAMPLE_INTERVAL_MS = 1000;
 const desktopAppResourceListeners = new Set<() => void>();
 let desktopAppResourceSnapshot: DesktopAppResourceUsage | null = null;
@@ -836,16 +843,20 @@ function ProcessLeafRow(props: { readonly processRow: ProcessDisplayRow }) {
   );
   if (hiddenCount === 0) return content;
   return (
-    <TooltipWrapper
-      label={
-        <HiddenSubprocessTooltip rows={props.processRow.hiddenDescendants} />
-      }
-      side="right"
-      sideOffset={8}
-      align="start"
-    >
-      {content}
-    </TooltipWrapper>
+    <Tooltip>
+      <TooltipTrigger asChild>{content}</TooltipTrigger>
+      <TooltipPrimitive.Portal>
+        <TooltipPrimitive.Content
+          side="right"
+          align="start"
+          sideOffset={8}
+          className={HIDDEN_SUBPROCESS_TOOLTIP_SURFACE}
+        >
+          <HiddenSubprocessTooltip rows={props.processRow.hiddenDescendants} />
+          <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-xs bg-popover fill-popover" />
+        </TooltipPrimitive.Content>
+      </TooltipPrimitive.Portal>
+    </Tooltip>
   );
 }
 

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -733,7 +733,8 @@ function OwnerTreeRow(props: {
   readonly onToggle: () => void;
   readonly onOpen: () => void;
 }) {
-  const hasProcesses = props.row.snapshot.processes.length > 0;
+  const processRows = buildProcessRows(props.row.snapshot.processes);
+  const hasProcesses = processRows.length > 0;
   return (
     <div>
       <div className="group flex items-center transition-colors hover:bg-muted/50">
@@ -784,7 +785,7 @@ function OwnerTreeRow(props: {
       </div>
       {props.collapsed
         ? null
-        : buildProcessRows(props.row.snapshot.processes).map((processRow) => (
+        : processRows.map((processRow) => (
             <ProcessLeafRow
               key={`${processRow.process.rootPid}:${processRow.process.pid}`}
               processRow={processRow}
@@ -1141,7 +1142,10 @@ function ownerKey(
 
 function shouldShowOwnerRow(snapshot: OwnerResourceSnapshotWire): boolean {
   if (snapshot.owner.kind !== "terminal") return true;
-  return snapshot.processCount > 0 || snapshot.processes.length > 0;
+  // A terminal always carries its own shell, so "has a process" is always true
+  // and never filters anything. Show a terminal only once it has a sub-process
+  // worth rendering - an idle shell adds no signal over the aggregate metrics.
+  return buildProcessRows(snapshot.processes).length > 0;
 }
 
 function resourceOwnerKindForNodeType(
@@ -1227,6 +1231,11 @@ function processLeafLabel(
 function buildProcessRows(
   processes: readonly ResourceProcessSnapshotWire[],
 ): ProcessDisplayRow[] {
+  // A lone process - a terminal shell with nothing running under it, or an owner
+  // whose whole tree is a single process - is fully described by its owner row,
+  // so it adds no signal as a child row. Render nothing (and no expand chevron)
+  // and let the owner row stand alone.
+  if (processes.length <= 1) return [];
   const byPid = processByPid(processes);
   return processes.flatMap((process): ProcessDisplayRow[] => {
     const depth = processDepth(process, byPid);

--- a/clients/gui-app/src/lib/host/stream-runtime-context.ts
+++ b/clients/gui-app/src/lib/host/stream-runtime-context.ts
@@ -3,6 +3,7 @@ import type {
   StreamMethodSupport,
   WsStreamClient,
 } from "@traycer-clients/shared/host-transport/ws-stream-client";
+import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 
 /**
@@ -44,6 +45,29 @@ export function useStreamMethodSupport(
       return null;
     }
     return client.getMethodSupport(method);
+  }, [client, method]);
+  return useSyncExternalStore(subscribe, getSnapshot, () => null);
+}
+
+export function useStreamMethodSchemaVersion(
+  method: keyof HostStreamRpcRegistry & string,
+): SchemaVersion | null {
+  const value = use(StreamRuntimeContext);
+  const client = value?.wsStreamClient ?? null;
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      if (client === null) {
+        return () => undefined;
+      }
+      return client.subscribeMethodSupport(callback);
+    },
+    [client],
+  );
+  const getSnapshot = useCallback(() => {
+    if (client === null) {
+      return null;
+    }
+    return client.getMethodSchemaVersion(method);
   }, [client, method]);
   return useSyncExternalStore(subscribe, getSnapshot, () => null);
 }

--- a/clients/gui-app/src/lib/host/stream-runtime-context.ts
+++ b/clients/gui-app/src/lib/host/stream-runtime-context.ts
@@ -26,9 +26,17 @@ export function useWsStreamClient(): WsStreamClient<HostStreamRpcRegistry> | nul
   return value === null ? null : value.wsStreamClient;
 }
 
-export function useStreamMethodSupport(
+// Both method-support readers ride the same `subscribeMethodSupport` store and
+// null-client handling; only the per-snapshot read differs. The readers are
+// module-level constants so `getSnapshot`'s identity stays keyed on
+// `[client, method]` alone.
+function useStreamMethodValue<T>(
   method: keyof HostStreamRpcRegistry & string,
-): StreamMethodSupport | null {
+  read: (
+    client: WsStreamClient<HostStreamRpcRegistry>,
+    method: keyof HostStreamRpcRegistry & string,
+  ) => T,
+): T | null {
   const value = use(StreamRuntimeContext);
   const client = value?.wsStreamClient ?? null;
   const subscribe = useCallback(
@@ -44,30 +52,29 @@ export function useStreamMethodSupport(
     if (client === null) {
       return null;
     }
-    return client.getMethodSupport(method);
-  }, [client, method]);
+    return read(client, method);
+  }, [client, method, read]);
   return useSyncExternalStore(subscribe, getSnapshot, () => null);
+}
+
+const readMethodSupport = (
+  client: WsStreamClient<HostStreamRpcRegistry>,
+  method: keyof HostStreamRpcRegistry & string,
+) => client.getMethodSupport(method);
+
+const readMethodSchemaVersion = (
+  client: WsStreamClient<HostStreamRpcRegistry>,
+  method: keyof HostStreamRpcRegistry & string,
+) => client.getMethodSchemaVersion(method);
+
+export function useStreamMethodSupport(
+  method: keyof HostStreamRpcRegistry & string,
+): StreamMethodSupport | null {
+  return useStreamMethodValue(method, readMethodSupport);
 }
 
 export function useStreamMethodSchemaVersion(
   method: keyof HostStreamRpcRegistry & string,
 ): SchemaVersion | null {
-  const value = use(StreamRuntimeContext);
-  const client = value?.wsStreamClient ?? null;
-  const subscribe = useCallback(
-    (callback: () => void) => {
-      if (client === null) {
-        return () => undefined;
-      }
-      return client.subscribeMethodSupport(callback);
-    },
-    [client],
-  );
-  const getSnapshot = useCallback(() => {
-    if (client === null) {
-      return null;
-    }
-    return client.getMethodSchemaVersion(method);
-  }, [client, method]);
-  return useSyncExternalStore(subscribe, getSnapshot, () => null);
+  return useStreamMethodValue(method, readMethodSchemaVersion);
 }

--- a/clients/gui-app/src/providers/resources-stream-mount.tsx
+++ b/clients/gui-app/src/providers/resources-stream-mount.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type ReactNode } from "react";
 import { ResourcesStreamClient } from "@traycer-clients/shared/host-transport/resources-stream-client";
 import {
+  useStreamMethodSchemaVersion,
   useStreamMethodSupport,
   useWsStreamClient,
 } from "@/lib/host/stream-runtime-context";
@@ -14,6 +15,12 @@ import { useSettingsStore } from "@/stores/settings/settings-store";
 
 export interface ResourcesStreamMountProps {
   readonly epicId: string;
+}
+
+function resourcesGlobalSupported(
+  version: { readonly major: number; readonly minor: number } | null,
+): boolean {
+  return version === null || (version.major === 1 && version.minor >= 1);
 }
 
 /**
@@ -56,7 +63,7 @@ export function ResourcesStreamMount(
     const streamClientFactory: ResourcesStreamClientFactory =
       override !== null
         ? override
-        : (id, callbacks) => {
+        : (scope, callbacks) => {
             if (wsStreamClient === null) {
               throw new Error(
                 "ResourcesStreamMount: WsStreamClient missing at open time.",
@@ -64,17 +71,62 @@ export function ResourcesStreamMount(
             }
             return new ResourcesStreamClient({
               wsStreamClient,
-              epicId: id,
+              scope,
               callbacks,
             });
           };
     resourcesRegistry.acquire(epicId, clientToken, () =>
-      createResourcesStore({ epicId, streamClientFactory }),
+      createResourcesStore({
+        scope: { kind: "epic", epicId },
+        streamClientFactory,
+      }),
     );
     return () => {
       resourcesRegistry.release(epicId);
     };
   }, [epicId, resourcesUnsupported, streamWanted, wsStreamClient]);
+
+  return null;
+}
+
+export function GlobalResourcesStreamMount(): ReactNode {
+  const wsStreamClient = useWsStreamClient();
+  const resourcesSupport = useStreamMethodSupport("resources.subscribe");
+  const resourcesVersion = useStreamMethodSchemaVersion("resources.subscribe");
+  const resourcesUnsupported =
+    resourcesSupport === "unsupported" ||
+    (resourcesVersion !== null && !resourcesGlobalSupported(resourcesVersion));
+
+  useEffect(() => {
+    if (resourcesUnsupported) return;
+    const override = getResourcesStreamClientFactoryOverride();
+    if (override === null && wsStreamClient === null) return;
+    const clientToken: unknown = override !== null ? override : wsStreamClient;
+    const streamClientFactory: ResourcesStreamClientFactory =
+      override !== null
+        ? override
+        : (scope, callbacks) => {
+            if (wsStreamClient === null) {
+              throw new Error(
+                "GlobalResourcesStreamMount: WsStreamClient missing at open time.",
+              );
+            }
+            return new ResourcesStreamClient({
+              wsStreamClient,
+              scope,
+              callbacks,
+            });
+          };
+    resourcesRegistry.acquireGlobal(clientToken, () =>
+      createResourcesStore({
+        scope: { kind: "global" },
+        streamClientFactory,
+      }),
+    );
+    return () => {
+      resourcesRegistry.releaseGlobal();
+    };
+  }, [resourcesUnsupported, wsStreamClient]);
 
   return null;
 }

--- a/clients/gui-app/src/stores/layout/title-bar-drag-store.ts
+++ b/clients/gui-app/src/stores/layout/title-bar-drag-store.ts
@@ -1,0 +1,33 @@
+import { create } from "zustand";
+
+/**
+ * Electron title-bar drag regions (`-webkit-app-region: drag`) swallow every
+ * mouse event at the OS level, so a click there never reaches the renderer -
+ * which means a popover anchored in the header can't be dismissed by clicking
+ * the empty title-bar area (Radix never sees the outside pointer-down).
+ *
+ * While such an overlay is open it registers a suppressor here; the header then
+ * drops its drag regions to `no-drag` so a title-bar click lands as an ordinary
+ * outside pointer-down and the overlay dismisses. Keyed per overlay so several
+ * can register independently and dragging only returns once all have closed.
+ */
+interface TitleBarDragState {
+  readonly suppressors: ReadonlySet<string>;
+  readonly setSuppressed: (key: string, suppressed: boolean) => void;
+}
+
+export const useTitleBarDragStore = create<TitleBarDragState>((set) => ({
+  suppressors: new Set<string>(),
+  setSuppressed: (key, suppressed) =>
+    set((state) => {
+      if (state.suppressors.has(key) === suppressed) return state;
+      const suppressors = new Set(state.suppressors);
+      if (suppressed) suppressors.add(key);
+      else suppressors.delete(key);
+      return { suppressors };
+    }),
+}));
+
+export function useTitleBarDraggingSuppressed(): boolean {
+  return useTitleBarDragStore((state) => state.suppressors.size > 0);
+}

--- a/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
+++ b/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
@@ -95,6 +95,7 @@ function projection(
     app: null,
     owners: [],
     epic: null,
+    epics: [],
     ...over,
   };
 }
@@ -109,7 +110,7 @@ function makeFakeClient(): FakeClient {
   let captured: ResourcesStreamCallbacks | null = null;
   let closed = false;
   return {
-    factory: (_epicId, callbacks) => {
+    factory: (_scope, callbacks) => {
       captured = callbacks;
       return {
         close: () => {
@@ -129,7 +130,7 @@ describe("createResourcesStore", () => {
   it("populates owners + epic + sampledAt from the initial snapshot", () => {
     const fake = makeFakeClient();
     const handle = createResourcesStore({
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       streamClientFactory: fake.factory,
     });
 
@@ -157,7 +158,7 @@ describe("createResourcesStore", () => {
   it("treats a missing owner as absent (undefined), not zero", () => {
     const fake = makeFakeClient();
     const handle = createResourcesStore({
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       streamClientFactory: fake.factory,
     });
 
@@ -179,7 +180,7 @@ describe("createResourcesStore", () => {
   it("derives a task summary from the live owner projection", () => {
     const fake = makeFakeClient();
     const handle = createResourcesStore({
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       streamClientFactory: fake.factory,
     });
 
@@ -228,7 +229,7 @@ describe("createResourcesStore", () => {
   it("includes host app usage in the task summary totals", () => {
     const fake = makeFakeClient();
     const handle = createResourcesStore({
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       streamClientFactory: fake.factory,
     });
 
@@ -259,7 +260,7 @@ describe("createResourcesStore", () => {
   it("replaces the epic aggregate on update", () => {
     const fake = makeFakeClient();
     const handle = createResourcesStore({
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       streamClientFactory: fake.factory,
     });
 
@@ -279,7 +280,7 @@ describe("createResourcesStore", () => {
   it("preserves owner object identity when only sampledAt moves, and swaps it when metrics change", () => {
     const fake = makeFakeClient();
     const handle = createResourcesStore({
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       streamClientFactory: fake.factory,
     });
     const key = resourceOwnerKey("terminal", "s1");
@@ -320,7 +321,7 @@ describe("createResourcesStore", () => {
   it("tracks connection status and closes the client on dispose", () => {
     const fake = makeFakeClient();
     const handle = createResourcesStore({
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       streamClientFactory: fake.factory,
     });
 
@@ -344,7 +345,7 @@ describe("resourcesRegistry", () => {
     const acquire = () =>
       resourcesRegistry.acquire(token.id, token, () =>
         createResourcesStore({
-          epicId: token.id,
+          scope: { kind: "epic", epicId: token.id },
           streamClientFactory: fake.factory,
         }),
       );
@@ -368,13 +369,13 @@ describe("resourcesRegistry", () => {
 
     const handleA = resourcesRegistry.acquire("epic-1", "token-a", () =>
       createResourcesStore({
-        epicId: "epic-1",
+        scope: { kind: "epic", epicId: "epic-1" },
         streamClientFactory: first.factory,
       }),
     );
     const handleB = resourcesRegistry.acquire("epic-1", "token-b", () =>
       createResourcesStore({
-        epicId: "epic-1",
+        scope: { kind: "epic", epicId: "epic-1" },
         streamClientFactory: second.factory,
       }),
     );
@@ -389,13 +390,13 @@ describe("resourcesRegistry", () => {
     const second = makeFakeClient();
     resourcesRegistry.acquire("epic-1", "token-a", () =>
       createResourcesStore({
-        epicId: "epic-1",
+        scope: { kind: "epic", epicId: "epic-1" },
         streamClientFactory: first.factory,
       }),
     );
     resourcesRegistry.acquire("epic-2", "token-b", () =>
       createResourcesStore({
-        epicId: "epic-2",
+        scope: { kind: "epic", epicId: "epic-2" },
         streamClientFactory: second.factory,
       }),
     );

--- a/clients/gui-app/src/stores/resources/resources-registry.ts
+++ b/clients/gui-app/src/stores/resources/resources-registry.ts
@@ -1,6 +1,5 @@
 import { useCallback, useSyncExternalStore } from "react";
 import { create, useStore } from "zustand";
-import { useShallow } from "zustand/react/shallow";
 import type { ResourceOwnerKindWire } from "@traycer/protocol/host/resources/subscribe";
 import {
   deriveTaskResourceSummary,
@@ -52,6 +51,7 @@ export interface GlobalResourceProjection {
 
 class ResourcesRegistry {
   private readonly entries = new Map<string, RegistryEntry>();
+  private globalEntry: RegistryEntry | null = null;
   private readonly listeners = new Set<() => void>();
   private readonly globalListeners = new Set<() => void>();
   private globalVersion = 0;
@@ -92,10 +92,22 @@ class ResourcesRegistry {
     if (this.globalProjectionCache?.version === this.globalVersion) {
       return this.globalProjectionCache.projection;
     }
+    if (this.globalEntry !== null) {
+      const projection = this.getGlobalProjectionFromGlobalEntry(
+        this.globalEntry,
+      );
+      this.globalProjectionCache = {
+        version: this.globalVersion,
+        projection,
+      };
+      return projection;
+    }
     const entries = [...this.entries.values()].map((entry) => {
       const state = entry.handle.store.getState();
+      const epicId =
+        entry.handle.scope.kind === "epic" ? entry.handle.scope.epicId : "";
       return {
-        epicId: entry.handle.epicId,
+        epicId,
         sampledAt: state.sampledAt,
         app: state.app,
         owners: [...state.owners.values()],
@@ -123,6 +135,45 @@ class ResourcesRegistry {
     return projection;
   }
 
+  private getGlobalProjectionFromGlobalEntry(
+    entry: RegistryEntry,
+  ): GlobalResourceProjection {
+    const state = entry.handle.store.getState();
+    const owners = [...state.owners.values()];
+    const epics = [...state.epics.values()];
+    const epicIds = [
+      ...new Set([
+        ...owners.map((owner) => owner.owner.epicId),
+        ...epics.map((epic) => epic.epicId),
+      ]),
+    ];
+    const entries = epicIds.map((epicId) => {
+      const scopedOwners = owners.filter(
+        (owner) => owner.owner.epicId === epicId,
+      );
+      const epic = state.epics.get(epicId) ?? null;
+      const sampledAt = Math.max(
+        epic?.sampledAt ?? 0,
+        scopedOwners.reduce((max, owner) => Math.max(max, owner.sampledAt), 0),
+      );
+      return {
+        epicId,
+        sampledAt: sampledAt > 0 ? sampledAt : null,
+        app: state.app,
+        owners: scopedOwners,
+        epic,
+        taskSummary: deriveTaskResourceSummary(null, scopedOwners),
+      };
+    });
+    return {
+      sampledAt: state.sampledAt,
+      app: state.app,
+      owners,
+      entries,
+      summary: deriveTaskResourceSummary(state.app, owners),
+    };
+  }
+
   private subscribeEntry(handle: ResourcesStoreHandle): () => void {
     return handle.store.subscribe(() => {
       this.notifyGlobal();
@@ -132,6 +183,10 @@ class ResourcesRegistry {
   get(epicId: string): ResourcesStoreHandle | null {
     const entry = this.entries.get(epicId);
     return entry === undefined ? null : entry.handle;
+  }
+
+  getGlobal(): ResourcesStoreHandle | null {
+    return this.globalEntry?.handle ?? null;
   }
 
   acquire(
@@ -171,6 +226,37 @@ class ResourcesRegistry {
     return handle;
   }
 
+  acquireGlobal(
+    clientToken: unknown,
+    factory: () => ResourcesStoreHandle,
+  ): ResourcesStoreHandle {
+    if (this.globalEntry !== null) {
+      if (this.globalEntry.clientToken === clientToken) {
+        this.globalEntry.leases += 1;
+        return this.globalEntry.handle;
+      }
+      this.globalEntry.unsubscribeStore();
+      this.globalEntry.handle.dispose();
+      const handle = factory();
+      const unsubscribeStore = this.subscribeEntry(handle);
+      this.globalEntry.handle = handle;
+      this.globalEntry.clientToken = clientToken;
+      this.globalEntry.unsubscribeStore = unsubscribeStore;
+      this.globalEntry.leases += 1;
+      this.notifyGlobal();
+      return handle;
+    }
+    const handle = factory();
+    this.globalEntry = {
+      handle,
+      clientToken,
+      leases: 1,
+      unsubscribeStore: this.subscribeEntry(handle),
+    };
+    this.notifyGlobal();
+    return handle;
+  }
+
   release(epicId: string): void {
     const entry = this.entries.get(epicId);
     if (entry === undefined) return;
@@ -183,13 +269,29 @@ class ResourcesRegistry {
     this.notifyGlobal();
   }
 
+  releaseGlobal(): void {
+    if (this.globalEntry === null) return;
+    this.globalEntry.leases -= 1;
+    if (this.globalEntry.leases > 0) return;
+    const entry = this.globalEntry;
+    this.globalEntry = null;
+    entry.unsubscribeStore();
+    entry.handle.dispose();
+    this.notifyGlobal();
+  }
+
   disposeAll(): void {
-    if (this.entries.size === 0) return;
+    if (this.entries.size === 0 && this.globalEntry === null) return;
     for (const entry of this.entries.values()) {
       entry.unsubscribeStore();
       entry.handle.dispose();
     }
     this.entries.clear();
+    if (this.globalEntry !== null) {
+      this.globalEntry.unsubscribeStore();
+      this.globalEntry.handle.dispose();
+      this.globalEntry = null;
+    }
     this.notify();
     this.notifyGlobal();
   }
@@ -213,12 +315,13 @@ export const resourcesRegistry = new ResourcesRegistry();
 // Stable fallback for `useStore` when no entry exists for an epic yet: every
 // selector resolves to "not tracked" (empty owners / null aggregate).
 const emptyResourcesStore = create<ResourcesState>()(() => ({
-  epicId: "",
+  key: "",
   connectionStatus: "closed",
   sampledAt: null,
   owners: new Map(),
   app: null,
   epic: null,
+  epics: new Map(),
   taskSummary: null,
   dispose: () => undefined,
 }));
@@ -227,9 +330,7 @@ const emptyResourcesStore = create<ResourcesState>()(() => ({
  * Reactively resolves the live store handle for `epicId`, re-rendering when the
  * registry entry is created, rebuilt (host swap), or removed.
  */
-export function useResourcesHandle(
-  epicId: string,
-): ResourcesStoreHandle | null {
+function useResourcesHandle(epicId: string): ResourcesStoreHandle | null {
   const getSnapshot = useCallback(
     () => resourcesRegistry.get(epicId),
     [epicId],
@@ -264,25 +365,6 @@ export function useEpicResourceUsage(epicId: string): EpicResourceUsage | null {
   const handle = useResourcesHandle(epicId);
   const store = handle === null ? emptyResourcesStore : handle.store;
   return useStore(store, (state) => state.epic);
-}
-
-/** Host-app usage sampled with the task projection, or `null` before sampling. */
-export function useAppResourceUsage(epicId: string): AppResourceUsage | null {
-  const handle = useResourcesHandle(epicId);
-  const store = handle === null ? emptyResourcesStore : handle.store;
-  return useStore(store, (state) => state.app);
-}
-
-/** Live owner snapshots for this task, preserving the store's stable owner refs. */
-export function useOwnerResourceUsages(
-  epicId: string,
-): readonly OwnerResourceUsage[] {
-  const handle = useResourcesHandle(epicId);
-  const store = handle === null ? emptyResourcesStore : handle.store;
-  return useStore(
-    store,
-    useShallow((state) => [...state.owners.values()]),
-  );
 }
 
 export function useGlobalResourceProjection(): GlobalResourceProjection {

--- a/clients/gui-app/src/stores/resources/resources-store.ts
+++ b/clients/gui-app/src/stores/resources/resources-store.ts
@@ -5,6 +5,7 @@ import type {
 } from "@traycer-clients/shared/host-transport/i-stream-session";
 import type {
   ResourcesProjectionPayload,
+  ResourcesStreamScope,
   ResourcesStreamCallbacks,
   ResourcesStreamClient,
 } from "@traycer-clients/shared/host-transport/resources-stream-client";
@@ -31,7 +32,7 @@ import type {
 export type ResourcesStreamClientHandle = Pick<ResourcesStreamClient, "close">;
 
 export type ResourcesStreamClientFactory = (
-  epicId: string,
+  scope: ResourcesStreamScope,
   callbacks: ResourcesStreamCallbacks,
 ) => ResourcesStreamClientHandle;
 
@@ -56,8 +57,16 @@ export function resourceOwnerKey(
   return `${kind}\x1f${ownerId}`;
 }
 
+export function globalResourceOwnerKey(
+  epicId: string,
+  kind: ResourceOwnerKindWire,
+  ownerId: string,
+): string {
+  return `${epicId}\x1f${kind}\x1f${ownerId}`;
+}
+
 export interface ResourcesState {
-  readonly epicId: string;
+  readonly key: string;
   readonly connectionStatus: StreamConnectionStatus;
   /** `null` until the first projection lands. */
   readonly sampledAt: number | null;
@@ -71,6 +80,7 @@ export interface ResourcesState {
   readonly app: AppResourceSnapshotWire | null;
   /** `null` when the epic has no tracked owner roots (a valid quiet state). */
   readonly epic: EpicResourceSnapshotWire | null;
+  readonly epics: ReadonlyMap<string, EpicResourceSnapshotWire>;
   /**
    * Renderer-derived task-level summary for the live owner projection. `null`
    * means no tracked owner snapshots are present, not zero usage.
@@ -80,17 +90,19 @@ export interface ResourcesState {
 }
 
 export interface ResourcesStoreOptions {
-  readonly epicId: string;
+  readonly scope: ResourcesStreamScope;
   readonly streamClientFactory: ResourcesStreamClientFactory;
 }
 
 export interface ResourcesStoreHandle {
-  readonly epicId: string;
+  readonly key: string;
+  readonly scope: ResourcesStreamScope;
   readonly store: UseBoundStore<StoreApi<ResourcesState>>;
   readonly dispose: () => void;
 }
 
 const EMPTY_OWNERS: ReadonlyMap<string, OwnerResourceSnapshotWire> = new Map();
+const EMPTY_EPICS: ReadonlyMap<string, EpicResourceSnapshotWire> = new Map();
 
 // Compare only the fields a chip renders. `sampledAt`/`rootPids` move on every
 // host tick even when nothing displayable changed, so excluding them lets an
@@ -178,11 +190,19 @@ function appUsageEqual(
 function mergeOwners(
   previous: ReadonlyMap<string, OwnerResourceSnapshotWire>,
   payload: ResourcesProjectionPayload,
+  scope: ResourcesStreamScope,
 ): ReadonlyMap<string, OwnerResourceSnapshotWire> {
   if (payload.owners.length === 0) return EMPTY_OWNERS;
   const next = new Map<string, OwnerResourceSnapshotWire>();
   for (const owner of payload.owners) {
-    const key = resourceOwnerKey(owner.owner.kind, owner.owner.ownerId);
+    const key =
+      scope.kind === "global"
+        ? globalResourceOwnerKey(
+            owner.owner.epicId,
+            owner.owner.kind,
+            owner.owner.ownerId,
+          )
+        : resourceOwnerKey(owner.owner.kind, owner.owner.ownerId);
     const existing = previous.get(key);
     next.set(
       key,
@@ -244,6 +264,27 @@ function mergeEpic(
   return next;
 }
 
+function mergeEpics(
+  previous: ReadonlyMap<string, EpicResourceSnapshotWire>,
+  payload: ResourcesProjectionPayload,
+): ReadonlyMap<string, EpicResourceSnapshotWire> {
+  if (payload.epics.length === 0) {
+    if (payload.epic === null) return EMPTY_EPICS;
+    return new Map([[payload.epic.epicId, payload.epic]]);
+  }
+  const next = new Map<string, EpicResourceSnapshotWire>();
+  for (const epic of payload.epics) {
+    const existing = previous.get(epic.epicId);
+    next.set(
+      epic.epicId,
+      existing !== undefined && epicUsageEqual(existing, epic)
+        ? existing
+        : epic,
+    );
+  }
+  return next;
+}
+
 function mergeApp(
   previous: AppResourceSnapshotWire | null,
   next: AppResourceSnapshotWire | null,
@@ -268,15 +309,18 @@ export function createResourcesStore(
 ): ResourcesStoreHandle {
   let disposed = false;
   let streamClient: ResourcesStreamClientHandle | null = null;
+  const key =
+    options.scope.kind === "global" ? "__global__" : options.scope.epicId;
 
   const store = create<ResourcesState>()((set) => {
     const applyProjection = (payload: ResourcesProjectionPayload): void => {
       if (disposed) return;
       set((state) => ({
         sampledAt: payload.sampledAt,
-        owners: mergeOwners(state.owners, payload),
+        owners: mergeOwners(state.owners, payload, options.scope),
         app: mergeApp(state.app, payload.app),
         epic: mergeEpic(state.epic, payload.epic),
+        epics: mergeEpics(state.epics, payload),
         taskSummary: mergeTaskSummary(state.taskSummary, payload),
       }));
     };
@@ -293,15 +337,16 @@ export function createResourcesStore(
       },
     };
 
-    streamClient = options.streamClientFactory(options.epicId, callbacks);
+    streamClient = options.streamClientFactory(options.scope, callbacks);
 
     return {
-      epicId: options.epicId,
+      key,
       connectionStatus: "connecting",
       sampledAt: null,
       owners: EMPTY_OWNERS,
       app: null,
       epic: null,
+      epics: EMPTY_EPICS,
       taskSummary: null,
       dispose: () => {
         if (disposed) return;
@@ -315,7 +360,8 @@ export function createResourcesStore(
   });
 
   return {
-    epicId: options.epicId,
+    key,
+    scope: options.scope,
     store,
     dispose: () => {
       store.getState().dispose();

--- a/clients/shared/host-transport/__tests__/resources-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/resources-stream-client.test.ts
@@ -180,7 +180,7 @@ describe("ResourcesStreamClient", () => {
 
     const client = new ResourcesStreamClient({
       wsStreamClient: makeWsStreamClient(factory),
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       callbacks,
     });
     completeHandshake(sockets[0]);
@@ -188,8 +188,11 @@ describe("ResourcesStreamClient", () => {
     expect(parseText(sockets[0].textSent[1])).toEqual({
       kind: "subscribe",
       method: "resources.subscribe",
-      schemaVersion: { major: 1, minor: 0 },
-      params: { epicId: "epic-1" },
+      schemaVersion: { major: 1, minor: 1 },
+      params: {
+        epicId: "epic-1",
+        scope: { kind: "epic", epicId: "epic-1" },
+      },
     });
 
     sockets[0].fireText({
@@ -216,6 +219,7 @@ describe("ResourcesStreamClient", () => {
     expect(snapshots[0].owners[0].owner.ownerId).toBe("s1");
     expect(snapshots[0].owners[0].processes[0].command).toBe("/bin/bash");
     expect(snapshots[0].epic?.epicId).toBe("epic-1");
+    expect(snapshots[0].epics).toEqual([]);
     expect(updates).toHaveLength(1);
     expect(updates[0].owners[0].cpuPercent).toBe(55);
     expect(updates[0].sampledAt).toBe(2_000);
@@ -229,7 +233,7 @@ describe("ResourcesStreamClient", () => {
     const updates: ResourcesProjectionPayload[] = [];
     const client = new ResourcesStreamClient({
       wsStreamClient: makeWsStreamClient(factory),
-      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
       callbacks: {
         onSnapshot: (p) => snapshots.push(p),
         onUpdate: (p) => updates.push(p),

--- a/clients/shared/host-transport/resources-stream-client.ts
+++ b/clients/shared/host-transport/resources-stream-client.ts
@@ -3,6 +3,7 @@ import {
   type AppResourceSnapshotWire,
   type EpicResourceSnapshotWire,
   type OwnerResourceSnapshotWire,
+  type ResourcesSubscribeOpenRequestV11,
   type ResourcesSubscribeServerFrame,
 } from "@traycer/protocol/host/resources/subscribe";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
@@ -26,6 +27,33 @@ export interface ResourcesProjectionPayload {
   readonly app: AppResourceSnapshotWire | null;
   readonly owners: readonly OwnerResourceSnapshotWire[];
   readonly epic: EpicResourceSnapshotWire | null;
+  readonly epics: readonly EpicResourceSnapshotWire[];
+}
+
+export type ResourcesStreamScope =
+  | {
+      readonly kind: "epic";
+      readonly epicId: string;
+    }
+  | {
+      readonly kind: "global";
+    };
+
+const GLOBAL_RESOURCES_EPIC_ID = "__global__";
+
+function openRequestForScope(
+  scope: ResourcesStreamScope,
+): ResourcesSubscribeOpenRequestV11 {
+  if (scope.kind === "epic") {
+    return {
+      epicId: scope.epicId,
+      scope,
+    };
+  }
+  return {
+    epicId: GLOBAL_RESOURCES_EPIC_ID,
+    scope,
+  };
 }
 
 /**
@@ -51,14 +79,14 @@ export interface ResourcesStreamCallbacks {
 
 export interface ResourcesStreamClientOptions {
   readonly wsStreamClient: WsStreamClient<HostStreamRpcRegistry>;
-  readonly epicId: string;
+  readonly scope: ResourcesStreamScope;
   readonly callbacks: ResourcesStreamCallbacks;
 }
 
 /**
  * Typed wrapper over `WsStreamClient` for `resources.subscribe@1.0`.
  *
- * Opens exactly one session on construction (bound to a single `epicId`),
+ * Opens exactly one session on construction (bound to an epic or global scope),
  * binds the callback surface, and exposes `close`. Zod-parses each inbound
  * envelope and dispatches to the typed callback for its `kind`. There are no
  * upstream application frames; closing the session detaches the host-side
@@ -73,9 +101,10 @@ export class ResourcesStreamClient {
     this.callbacks = options.callbacks;
     this.closed = false;
 
-    this.session = options.wsStreamClient.subscribe("resources.subscribe", {
-      epicId: options.epicId,
-    });
+    this.session = options.wsStreamClient.subscribe(
+      "resources.subscribe",
+      openRequestForScope(options.scope),
+    );
     this.session.onServerFrame((envelope, binaryPayload) => {
       this.handleServerFrame(envelope, binaryPayload);
     });
@@ -133,5 +162,6 @@ function toPayload(
     app: frame.app,
     owners: frame.owners,
     epic: frame.epic,
+    epics: frame.epics ?? [],
   };
 }

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -116,6 +116,7 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
   private readonly options: WsStreamClientOptions<Registry>;
   private readonly ownedSessions = new Set<StreamSession<Registry>>();
   private readonly methodSupport = new Map<string, StreamMethodSupport>();
+  private readonly methodSchemaVersions = new Map<string, SchemaVersion>();
   private readonly methodSupportListeners = new Set<() => void>();
   private closed = false;
 
@@ -165,8 +166,8 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
       initialBackoffMs: this.options.initialBackoffMs,
       maxBackoffMs: this.options.maxBackoffMs,
       onDispose: () => removeSession(),
-      onMethodSupport: (nextMethod, support) => {
-        this.setMethodSupport(nextMethod, support);
+      onMethodSupport: (nextMethod, support, schemaVersion) => {
+        this.setMethodSupport(nextMethod, support, schemaVersion);
       },
     });
     removeSession = () => {
@@ -201,6 +202,12 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
     method: Method,
   ): StreamMethodSupport {
     return this.methodSupport.get(method) ?? "unknown";
+  }
+
+  getMethodSchemaVersion<Method extends keyof Registry & string>(
+    method: Method,
+  ): SchemaVersion | null {
+    return this.methodSchemaVersions.get(method) ?? null;
   }
 
   subscribeMethodSupport(listener: () => void): () => void {
@@ -250,9 +257,27 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
     }
   }
 
-  private setMethodSupport(method: string, support: StreamMethodSupport): void {
+  private setMethodSupport(
+    method: string,
+    support: StreamMethodSupport,
+    schemaVersion: SchemaVersion | null,
+  ): void {
     const previous = this.methodSupport.get(method) ?? "unknown";
-    if (previous === support) {
+    const previousVersion = this.methodSchemaVersions.get(method) ?? null;
+    if (
+      schemaVersion === null ||
+      support === "unsupported" ||
+      support === "unknown"
+    ) {
+      this.methodSchemaVersions.delete(method);
+    } else {
+      this.methodSchemaVersions.set(method, schemaVersion);
+    }
+    const nextVersion = this.methodSchemaVersions.get(method) ?? null;
+    if (
+      previous === support &&
+      schemaVersionEqual(previousVersion, nextVersion)
+    ) {
       return;
     }
     this.methodSupport.set(method, support);
@@ -272,6 +297,14 @@ export type ParamsOf<
 > = ExtractOpenRequest<Registry[Method]>;
 
 export type StreamMethodSupport = "unknown" | "supported" | "unsupported";
+
+function schemaVersionEqual(
+  a: SchemaVersion | null,
+  b: SchemaVersion | null,
+): boolean {
+  if (a === null || b === null) return a === b;
+  return a.major === b.major && a.minor === b.minor;
+}
 
 type ExtractOpenRequest<MethodRegistry> =
   MethodRegistry extends Readonly<Record<number, infer Line>>
@@ -308,6 +341,7 @@ interface StreamSessionOptions<Registry extends VersionedStreamRpcRegistry> {
   readonly onMethodSupport: (
     method: keyof Registry & string,
     support: StreamMethodSupport,
+    schemaVersion: SchemaVersion | null,
   ) => void;
 }
 
@@ -731,7 +765,7 @@ class StreamSession<
     }
 
     if (!compat.ok) {
-      this.config.onMethodSupport(this.config.method, "unsupported");
+      this.config.onMethodSupport(this.config.method, "unsupported", null);
       const terminalFrame: ClientStreamFatalErrorFrame = {
         kind: "fatalError",
         details: compat.details,
@@ -766,7 +800,11 @@ class StreamSession<
       this.onSendFailure(socket);
       return;
     }
-    this.config.onMethodSupport(this.config.method, "supported");
+    this.config.onMethodSupport(
+      this.config.method,
+      "supported",
+      ackParse.data.manifest[this.config.method],
+    );
     this.phase = "subscribed";
     this.reconnectAttempt = 0;
     this.noProgressUnauthorizedReconnects = 0;

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -133,7 +133,10 @@ import {
   terminalSubscribeV13,
 } from "@traycer/protocol/host/terminal/contracts";
 import { notificationsSubscribeV10 } from "@traycer/protocol/host/notifications/contracts";
-import { resourcesSubscribeV10 } from "@traycer/protocol/host/resources/subscribe";
+import {
+  resourcesSubscribeV10,
+  resourcesSubscribeV11,
+} from "@traycer/protocol/host/resources/subscribe";
 import {
   speechEnsureModelV10,
   speechGetModelStatusV10,
@@ -2882,10 +2885,13 @@ export const hostStreamRpcRegistry = defineVersionedStreamRpcRegistry({
   },
   "resources.subscribe": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: resourcesSubscribeV10,
+        },
+        1: {
+          contract: resourcesSubscribeV11,
         },
       },
     },

--- a/protocol/src/host/resources/__tests__/resources-subscribe.test.ts
+++ b/protocol/src/host/resources/__tests__/resources-subscribe.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import {
   resourcesSubscribeClientFrameSchema,
+  resourcesSubscribeOpenRequestV11Schema,
   resourcesSubscribeServerFrameSchema,
   resourcesSubscribeV10,
+  resourcesSubscribeV11,
 } from "@traycer/protocol/host/resources/subscribe";
 
 /**
@@ -68,6 +70,32 @@ describe("resources.subscribe@1.0 open request", () => {
   });
 });
 
+describe("resources.subscribe@1.1 open request", () => {
+  it("accepts an explicit global scope", () => {
+    expect(
+      resourcesSubscribeOpenRequestV11Schema.parse({
+        epicId: "__global__",
+        scope: { kind: "global" },
+      }),
+    ).toEqual({
+      epicId: "__global__",
+      scope: { kind: "global" },
+    });
+  });
+
+  it("accepts an explicit epic scope", () => {
+    expect(
+      resourcesSubscribeOpenRequestV11Schema.parse({
+        epicId: "epic-1",
+        scope: { kind: "epic", epicId: "epic-1" },
+      }),
+    ).toEqual({
+      epicId: "epic-1",
+      scope: { kind: "epic", epicId: "epic-1" },
+    });
+  });
+});
+
 describe("resources.subscribe@1.0 server frames", () => {
   it("parses a snapshot frame carrying owners and an epic aggregate", () => {
     const parsed = resourcesSubscribeServerFrameSchema.parse({
@@ -103,6 +131,25 @@ describe("resources.subscribe@1.0 server frames", () => {
       expect(parsed.owners).toEqual([]);
       expect(parsed.epic).toBeNull();
     }
+  });
+
+  it("parses a global snapshot frame carrying all epic aggregates", () => {
+    const parsed = resourcesSubscribeServerFrameSchema.parse({
+      kind: "snapshot",
+      epicId: "__global__",
+      sampledAt: 1_000,
+      app: APP_FIXTURE,
+      owners: [OWNER_FIXTURE],
+      epic: EPIC_FIXTURE,
+      epics: [EPIC_FIXTURE, { ...EPIC_FIXTURE, epicId: "epic-2" }],
+      hasBinaryPayload: false,
+    });
+    expect(parsed.kind).toBe("snapshot");
+    if (parsed.kind !== "snapshot") throw new Error("expected snapshot");
+    expect(parsed.epics?.map((entry) => entry.epicId)).toEqual([
+      "epic-1",
+      "epic-2",
+    ]);
   });
 
   it("accepts a null activeProcessName on an owner snapshot", () => {
@@ -198,8 +245,10 @@ describe("resources.subscribe@1.0 registry membership", () => {
   it("is registered on the stream registry at major 1 / minor 0", () => {
     const entry = hostStreamRpcRegistry["resources.subscribe"];
     expect(entry).toBeDefined();
-    expect(entry[1].latestMinor).toBe(0);
+    expect(entry[1].latestMinor).toBe(1);
     expect(entry[1].versions[0].contract).toBe(resourcesSubscribeV10);
+    expect(entry[1].versions[1].contract).toBe(resourcesSubscribeV11);
     expect(resourcesSubscribeV10.schemaVersion).toEqual({ major: 1, minor: 0 });
+    expect(resourcesSubscribeV11.schemaVersion).toEqual({ major: 1, minor: 1 });
   });
 });

--- a/protocol/src/host/resources/subscribe.ts
+++ b/protocol/src/host/resources/subscribe.ts
@@ -1,6 +1,6 @@
 /**
- * `resources.subscribe@1.0` - versioned streaming-RPC contract for live
- * process-resource snapshots, scoped to a single epic.
+ * `resources.subscribe@1.0` / `@1.1` - versioned streaming-RPC contract for
+ * live process-resource snapshots.
  *
  * Subscribing opens a per-epic view over the host's `ResourceTracker`: the
  * owner snapshots (chats, terminals, terminal-agents) whose `epicId` matches
@@ -38,12 +38,39 @@
 import { z } from "zod";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
 
-export const resourcesSubscribeOpenRequestSchema = z.object({
+export const resourcesSubscribeOpenRequestV10Schema = z.object({
   epicId: z.string(),
 });
-export type ResourcesSubscribeOpenRequest = z.infer<
-  typeof resourcesSubscribeOpenRequestSchema
+export type ResourcesSubscribeOpenRequestV10 = z.infer<
+  typeof resourcesSubscribeOpenRequestV10Schema
 >;
+
+export const resourcesSubscribeScopeSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("epic"),
+    epicId: z.string(),
+  }),
+  z.object({
+    kind: z.literal("global"),
+  }),
+]);
+export type ResourcesSubscribeScopeWire = z.infer<
+  typeof resourcesSubscribeScopeSchema
+>;
+
+export const resourcesSubscribeOpenRequestV11Schema = z.object({
+  // Kept on wire so a newer client can safely downgrade a global probe to
+  // @1.0 without failing client-side request projection.
+  epicId: z.string(),
+  scope: resourcesSubscribeScopeSchema,
+});
+export type ResourcesSubscribeOpenRequestV11 = z.infer<
+  typeof resourcesSubscribeOpenRequestV11Schema
+>;
+
+export const resourcesSubscribeOpenRequestSchema =
+  resourcesSubscribeOpenRequestV10Schema;
+export type ResourcesSubscribeOpenRequest = ResourcesSubscribeOpenRequestV10;
 
 export const resourceOwnerKindSchema = z.enum([
   "chat",
@@ -121,6 +148,7 @@ const resourcesProjectionFields = {
   sampledAt: z.number(),
   app: appResourceSnapshotSchema.nullable(),
   owners: z.array(ownerResourceSnapshotSchema),
+  epics: z.array(epicResourceSnapshotSchema).optional(),
   // `null` when the epic has no tracked owner roots - "not currently tracked",
   // distinct from an aggregate whose totals happen to be zero.
   epic: epicResourceSnapshotSchema.nullable(),
@@ -164,7 +192,15 @@ export type ResourcesSubscribeClientFrame = z.infer<
 export const resourcesSubscribeV10 = defineStreamRpcContract({
   method: "resources.subscribe",
   schemaVersion: { major: 1, minor: 0 } as const,
-  openRequestSchema: resourcesSubscribeOpenRequestSchema,
+  openRequestSchema: resourcesSubscribeOpenRequestV10Schema,
+  serverFrameSchema: resourcesSubscribeServerFrameSchema,
+  clientFrameSchema: resourcesSubscribeClientFrameSchema,
+});
+
+export const resourcesSubscribeV11 = defineStreamRpcContract({
+  method: "resources.subscribe",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  openRequestSchema: resourcesSubscribeOpenRequestV11Schema,
   serverFrameSchema: resourcesSubscribeServerFrameSchema,
   clientFrameSchema: resourcesSubscribeClientFrameSchema,
 });


### PR DESCRIPTION
## Summary

Adds the global resource-monitor subscription and a series of popover UX/polish fixes for the resource monitor in `clients/gui-app`.

### What's included
- **Global resource monitor subscription** — the popover projects resources across all epics, not just the active one.
- **Popover UX fixes**
  - Keep the popover open when focus moves to newly loaded content outside it; only a genuine outside click / Escape dismisses.
  - Dismiss the popover when clicking the Electron **title bar** (drag regions swallow OS-level clicks, so the header drops its drag spacers to `no-drag` while an overlay is open — via a small `title-bar-drag-store`).
  - **Hide idle terminals** with no sub-processes (a bare shell is fully described by its owner row; its metrics still fold into the epic aggregate).
- **Process-tree polish**
  - Style the collapsed sub-tree tooltip like the main tree (bullet + label + CPU/memory columns, depth indentation) and render it on the light **popover surface** instead of the default dark tooltip chip.
  - Make the capped process row a real `<button>` trigger (keyboard-reachable, clears `jsx-a11y/no-noninteractive-tabindex`).

## Testing
- `bun run compile` — clean across all packages
- `bun x vitest run` (resources + layout suites) — green
- `eslint` + `react-doctor` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)