### PR TITLE
Fix Claude extra usage currency display

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -324,6 +324,29 @@ describe("ClaudeRateLimitView", () => {
       0,
     );
   });
+
+  it("formats extra usage cents as dollar amounts", () => {
+    const claude: ClaudeRateLimits = {
+      provider: "claude-code",
+      available: true,
+      subscriptionType: "max",
+      fiveHour: null,
+      sevenDay: null,
+      sevenDayOpus: null,
+      sevenDaySonnet: null,
+      modelScoped: [],
+      extraUsage: {
+        isEnabled: true,
+        monthlyLimit: 10000,
+        usedCredits: 2360,
+        utilization: 24,
+      },
+    };
+    render(<ClaudeRateLimitView data={claude} variant="settings" />);
+    expect(screen.getByText("Extra usage")).toBeTruthy();
+    expect(screen.getByText("$23.60 / $100.00")).toBeTruthy();
+    expect(screen.queryByText("2360.00 / 10000.00")).toBeNull();
+  });
 });
 
 describe("OpenRouterRateLimitView", () => {

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -114,6 +114,11 @@ function formatProviderCurrency(value: number): string {
   return `$${value.toFixed(2)}`;
 }
 
+/** Claude Code reports extra-usage spend/limit values in cents. */
+function formatClaudeExtraUsageCents(value: number): string {
+  return formatProviderCurrency(value / 100);
+}
+
 /** Relative countdown ("Resets in 4h 7m") - ticks on the shared 60s clock. */
 function RelativeResetLine({
   resetsAt,
@@ -588,7 +593,7 @@ function ClaudeExtraUsageRow({
       <MeterRow
         label="Extra usage"
         usedPercent={usedPercent}
-        detail={`${extraUsage.usedCredits.toFixed(2)} / ${extraUsage.monthlyLimit.toFixed(2)}`}
+        detail={`${formatClaudeExtraUsageCents(extraUsage.usedCredits)} / ${formatClaudeExtraUsageCents(extraUsage.monthlyLimit)}`}
       />
     );
   }


### PR DESCRIPTION
## Summary
- Convert Claude Code extra-usage cents to dollar display values in the provider rate-limit UI
- Add a regression test for 2360 / 10000 rendering as .60 / .00

## Verification
- bun run test -- src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
- bun run compile
- npx -y react-doctor@latest . --verbose --diff main --offline --no-score
- bun x eslint src/components/settings/panels/provider-rate-limit-views.tsx src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx --max-warnings 0
- git -C traycer diff --check