### PR TITLE
Fix cached provider usage visibility

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -91,6 +91,7 @@ const mocks = vi.hoisted<MockState>(() => ({
 
 vi.mock("@/hooks/rate-limits/use-configured-rate-limit-providers", () => ({
   useConfiguredRateLimitProviders: () => mocks.configured,
+  useVisibleRateLimitProviders: () => mocks.configured,
 }));
 vi.mock("@/hooks/rate-limits/use-is-rate-limit-queue-draining", () => ({
   useIsRateLimitQueueDraining: () => mocks.draining,

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -32,7 +32,7 @@ import {
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import type { RateLimitUnavailableReason } from "@traycer/protocol/host";
 import {
-  useConfiguredRateLimitProviders,
+  useVisibleRateLimitProviders,
   type ConfiguredRateLimitProvider,
 } from "@/hooks/rate-limits/use-configured-rate-limit-providers";
 import { useIsRateLimitQueueDraining } from "@/hooks/rate-limits/use-is-rate-limit-queue-draining";
@@ -178,11 +178,11 @@ function RateLimitPopoverBody({
 }: {
   readonly onClose: () => void;
 }): ReactNode {
-  const configured = useConfiguredRateLimitProviders();
+  const displayProviders = useVisibleRateLimitProviders();
   // Rail order matches the app's standard provider order everywhere else.
   const providers = useMemo(
-    () => sortProviderStatesByProviderOrder(configured),
-    [configured],
+    () => sortProviderStatesByProviderOrder(displayProviders),
+    [displayProviders],
   );
 
   // Traycer is a GUI-only rail entry (AuthService subscription, not a host RPC),

--- a/clients/gui-app/src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
+++ b/clients/gui-app/src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
@@ -33,6 +33,7 @@ vi.mock("@/lib/host", () => ({
 }));
 vi.mock("@/hooks/rate-limits/use-configured-rate-limit-providers", () => ({
   useConfiguredRateLimitProviders: () => mocks.configured,
+  useVisibleRateLimitProviders: () => mocks.configured,
 }));
 // Production calls `useHostQueriesWithResponseMap` (not the plain
 // `useHostQueries`) - see that hook's own doc comment - so this mock exports

--- a/clients/gui-app/src/hooks/rate-limits/__tests__/use-visible-rate-limit-providers.test.tsx
+++ b/clients/gui-app/src/hooks/rate-limits/__tests__/use-visible-rate-limit-providers.test.tsx
@@ -166,6 +166,24 @@ describe("useVisibleRateLimitProviders", () => {
     ]);
   });
 
+  it("includes a configured provider even when no usage cache entry exists", () => {
+    mocks.providers = [
+      providerState({
+        providerId: "codex",
+        status: "authenticated",
+        enabled: true,
+        authPending: false,
+        availabilityPending: false,
+      }),
+    ];
+
+    const { result } = renderHook(() => useVisibleRateLimitProviders());
+
+    expect(result.current).toEqual([
+      { providerId: "codex", lane: "ephemeralProcess" },
+    ]);
+  });
+
   it("includes a signed-in provider with a cached fetch error so the popover can show refreshable error state", () => {
     mocks.providers = [
       providerState({

--- a/clients/gui-app/src/hooks/rate-limits/__tests__/use-visible-rate-limit-providers.test.tsx
+++ b/clients/gui-app/src/hooks/rate-limits/__tests__/use-visible-rate-limit-providers.test.tsx
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import type {
+  ProviderAuthStatus,
+  ProviderCliState,
+} from "@traycer/protocol/host/provider-schemas";
+import type {
+  AvailableProviderRateLimits,
+  ProviderRateLimitEnvelope,
+} from "@/lib/rate-limits/rate-limit-envelope";
+import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
+
+interface MockQueryResult {
+  readonly data: ProviderRateLimitEnvelope | undefined;
+  readonly isError: boolean;
+}
+
+interface MockState {
+  providers: readonly ProviderCliState[];
+  results: Map<RateLimitProviderId, MockQueryResult>;
+}
+
+const mocks = vi.hoisted<MockState>(() => ({
+  providers: [],
+  results: new Map(),
+}));
+
+vi.mock("@/hooks/providers/use-providers-list-query", () => ({
+  useProvidersList: () => ({ data: { providers: mocks.providers } }),
+}));
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => null,
+}));
+vi.mock("@/hooks/host/use-host-queries", () => ({
+  useHostQueriesWithResponseMap: (args: {
+    readonly requests: ReadonlyArray<{
+      readonly params: { readonly providerId: RateLimitProviderId };
+    }>;
+  }) =>
+    args.requests.map(
+      (request) =>
+        mocks.results.get(request.params.providerId) ?? {
+          data: undefined,
+          isError: false,
+        },
+    ),
+}));
+
+import {
+  useConfiguredRateLimitProviders,
+  useVisibleRateLimitProviders,
+} from "@/hooks/rate-limits/use-configured-rate-limit-providers";
+
+const NOW = Date.now();
+
+function auth(status: ProviderAuthStatus): ProviderCliState["auth"] {
+  return { status, badgeText: null, label: null, detail: null };
+}
+
+function providerState(args: {
+  readonly providerId: RateLimitProviderId;
+  readonly status: ProviderAuthStatus;
+  readonly enabled: boolean;
+  readonly authPending: boolean;
+  readonly availabilityPending: boolean;
+}): ProviderCliState {
+  return {
+    enabled: args.enabled,
+    disabledBy: null,
+    selected: { kind: "bundled" },
+    candidates: [],
+    authPending: args.authPending,
+    checkedAt: null,
+    apiKey: { supported: false, configured: false, source: null },
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
+    availabilityPending: args.availabilityPending,
+    providerId: args.providerId,
+    auth: auth(args.status),
+  };
+}
+
+function codexLimits(): AvailableProviderRateLimits {
+  return {
+    provider: "codex",
+    available: true,
+    planType: "pro_5x",
+    limitId: null,
+    limitName: null,
+    primary: {
+      usedPercent: 12,
+      resetsAt: NOW + 60 * 60 * 1000,
+      durationMinutes: 300,
+    },
+    secondary: null,
+    extraWindows: [],
+    credits: null,
+    individualLimit: null,
+    resetCredits: null,
+    rateLimitReachedType: null,
+  };
+}
+
+function envelope(
+  data: AvailableProviderRateLimits,
+): ProviderRateLimitEnvelope {
+  return {
+    latest: data,
+    lastGood: data,
+    lastGoodAt: NOW - 60_000,
+    lastFailureAt: null,
+  };
+}
+
+beforeEach(() => {
+  mocks.providers = [];
+  mocks.results = new Map();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useVisibleRateLimitProviders", () => {
+  it("keeps the strict configured hook gated by provider auth state", () => {
+    mocks.providers = [
+      providerState({
+        providerId: "codex",
+        status: "unavailable",
+        enabled: true,
+        authPending: false,
+        availabilityPending: false,
+      }),
+    ];
+    mocks.results.set("codex", {
+      data: envelope(codexLimits()),
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useConfiguredRateLimitProviders());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("includes a signed-in provider with cached usage data when account-status probing is unavailable", () => {
+    mocks.providers = [
+      providerState({
+        providerId: "codex",
+        status: "unavailable",
+        enabled: true,
+        authPending: false,
+        availabilityPending: false,
+      }),
+    ];
+    mocks.results.set("codex", {
+      data: envelope(codexLimits()),
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useVisibleRateLimitProviders());
+
+    expect(result.current).toEqual([
+      { providerId: "codex", lane: "ephemeralProcess" },
+    ]);
+  });
+
+  it("includes a signed-in provider with a cached fetch error so the popover can show refreshable error state", () => {
+    mocks.providers = [
+      providerState({
+        providerId: "codex",
+        status: "unavailable",
+        enabled: true,
+        authPending: false,
+        availabilityPending: false,
+      }),
+    ];
+    mocks.results.set("codex", { data: undefined, isError: true });
+
+    const { result } = renderHook(() => useVisibleRateLimitProviders());
+
+    expect(result.current).toEqual([
+      { providerId: "codex", lane: "ephemeralProcess" },
+    ]);
+  });
+
+  it("does not show an unconfigured provider before the usage cache has any state for it", () => {
+    mocks.providers = [
+      providerState({
+        providerId: "codex",
+        status: "unavailable",
+        enabled: true,
+        authPending: false,
+        availabilityPending: false,
+      }),
+    ];
+
+    const { result } = renderHook(() => useVisibleRateLimitProviders());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("does not keep showing a signed-out provider from stale cached usage", () => {
+    mocks.providers = [
+      providerState({
+        providerId: "codex",
+        status: "unauthenticated",
+        enabled: true,
+        authPending: false,
+        availabilityPending: false,
+      }),
+    ];
+    mocks.results.set("codex", {
+      data: envelope(codexLimits()),
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useVisibleRateLimitProviders());
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/clients/gui-app/src/hooks/rate-limits/use-configured-rate-limit-providers.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-configured-rate-limit-providers.ts
@@ -1,16 +1,74 @@
 import { useMemo } from "react";
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+import { useHostQueriesWithResponseMap } from "@/hooks/host/use-host-queries";
+import {
+  providerRateLimitQueryOptions,
+  type ProviderRateLimitTanstackOptions,
+} from "@/hooks/host/provider-rate-limit-query-options";
 import { useProvidersList } from "@/hooks/providers/use-providers-list-query";
+import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import {
   isRateLimitCapableProvider,
   isRateLimitProviderConfigured,
+  PROVIDER_RATE_LIMITS_STALE_TIME_MS,
   rateLimitFetchLane,
   type RateLimitFetchLane,
   type RateLimitProviderId,
 } from "@/lib/rate-limit-providers";
+import {
+  mapResponseToProviderRateLimitEnvelope,
+  type ProviderRateLimitEnvelope,
+} from "@/lib/rate-limits/rate-limit-envelope";
 
 export interface ConfiguredRateLimitProvider {
   readonly providerId: RateLimitProviderId;
   readonly lane: RateLimitFetchLane;
+}
+
+interface RateLimitProviderCandidate extends ConfiguredRateLimitProvider {
+  readonly configured: boolean;
+}
+
+interface ProviderRateLimitCacheState {
+  readonly data: ProviderRateLimitEnvelope | undefined;
+  readonly isError: boolean;
+}
+
+const PASSIVE_PROVIDER_RATE_LIMIT_OPTIONS: ProviderRateLimitTanstackOptions = {
+  enabled: false,
+  retry: false,
+  staleTime: PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+  refetchInterval: false,
+  refetchIntervalInBackground: false,
+  refetchOnMount: false,
+};
+
+function hasProviderRateLimitCacheState(
+  query: ProviderRateLimitCacheState | undefined,
+): boolean {
+  if (query === undefined) return false;
+  if (query.isError) return true;
+  const envelope = query.data;
+  if (envelope === undefined) return false;
+  return envelope.latest !== null || envelope.lastGood !== null;
+}
+
+function rateLimitProviderCandidates(
+  providers: readonly ProviderCliState[],
+): ReadonlyArray<RateLimitProviderCandidate> {
+  return providers.flatMap((state) => {
+    const providerId = state.providerId;
+    if (!state.enabled) return [];
+    if (!isRateLimitCapableProvider(providerId)) return [];
+    if (state.auth.status === "unauthenticated") return [];
+    return [
+      {
+        providerId,
+        lane: rateLimitFetchLane(providerId),
+        configured: isRateLimitProviderConfigured(state),
+      },
+    ];
+  });
 }
 
 /**
@@ -34,11 +92,63 @@ export function useConfiguredRateLimitProviders(): ReadonlyArray<ConfiguredRateL
   const providers = providersQuery.data?.providers;
   return useMemo(() => {
     if (providers === undefined) return [];
-    return providers.flatMap((state) => {
-      const providerId = state.providerId;
-      if (!isRateLimitCapableProvider(providerId)) return [];
-      if (!isRateLimitProviderConfigured(state)) return [];
-      return [{ providerId, lane: rateLimitFetchLane(providerId) }];
-    });
+    return rateLimitProviderCandidates(providers).flatMap((provider) =>
+      provider.configured
+        ? [{ providerId: provider.providerId, lane: provider.lane }]
+        : [],
+    );
   }, [providers]);
+}
+
+/**
+ * Rate-limit providers that should be displayed in user-facing surfaces
+ * (header glyph / popover). This deliberately has a wider gate than
+ * `useConfiguredRateLimitProviders()`: the queue still polls only providers
+ * whose account probe currently says a usage pull is safe, but display also
+ * includes a provider once the shared provider-usage query cache has data or an
+ * error for it. Settings > Providers reads the same cache unconditionally for
+ * the selected provider, so this keeps cached usage/error state visible in the
+ * popover even when the CLI is signed in but the provider account-status probe
+ * is temporarily `unavailable` ("Could not check account status").
+ *
+ * The cache observers below are passive (`enabled: false`) and only subscribe
+ * to the existing `host.getRateLimitUsage` provider-pull keys. They do not
+ * spawn extra CLI subprocesses or HTTP fetches.
+ */
+export function useVisibleRateLimitProviders(): ReadonlyArray<ConfiguredRateLimitProvider> {
+  const client = useHostClient();
+  const providersQuery = useProvidersList({ enabled: true, subscribed: true });
+  const providers = providersQuery.data?.providers;
+  const candidates = useMemo(
+    () =>
+      providers === undefined ? [] : rateLimitProviderCandidates(providers),
+    [providers],
+  );
+
+  const cacheQueries = useHostQueriesWithResponseMap<
+    HostRpcRegistry,
+    "host.getRateLimitUsage",
+    ProviderRateLimitEnvelope
+  >({
+    client,
+    requests: candidates.map((provider) => {
+      const { method, params } = providerRateLimitQueryOptions(
+        provider.providerId,
+      );
+      return { method, params };
+    }),
+    options: PASSIVE_PROVIDER_RATE_LIMIT_OPTIONS,
+    mapResponse: mapResponseToProviderRateLimitEnvelope,
+  });
+
+  return useMemo(
+    () =>
+      candidates.flatMap((provider, index) =>
+        provider.configured ||
+        hasProviderRateLimitCacheState(cacheQueries[index])
+          ? [{ providerId: provider.providerId, lane: provider.lane }]
+          : [],
+      ),
+    [cacheQueries, candidates],
+  );
 }

--- a/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
@@ -7,7 +7,7 @@ import {
   providerRateLimitQueryOptions,
   type ProviderRateLimitTanstackOptions,
 } from "@/hooks/host/provider-rate-limit-query-options";
-import { useConfiguredRateLimitProviders } from "@/hooks/rate-limits/use-configured-rate-limit-providers";
+import { useVisibleRateLimitProviders } from "@/hooks/rate-limits/use-configured-rate-limit-providers";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import type { RateLimitProviderId } from "@/lib/rate-limit-providers";
 import {
@@ -198,12 +198,12 @@ function selectGlyphBars(
  */
 export function useHeaderRateLimitBars(): ReadonlyArray<HeaderRateLimitBar> {
   const client = useHostClient();
-  const configured = useConfiguredRateLimitProviders();
-  const configuredIds = new Set(
-    configured.map((provider) => provider.providerId),
+  const displayProviders = useVisibleRateLimitProviders();
+  const displayProviderIds = new Set(
+    displayProviders.map((provider) => provider.providerId),
   );
   const glyphProviders = GLYPH_PROVIDER_IDS.filter((id) =>
-    configuredIds.has(id),
+    displayProviderIds.has(id),
   );
 
   // `useHostQueriesWithResponseMap` applies one shared `options` object to


### PR DESCRIPTION
## Summary
- keep Claude/Codex usage providers visible in the header popover when the account-status probe is temporarily unavailable but shared usage cache data or error state exists
- leave the strict configured-provider hook in place for polling/queue eligibility so background subprocess polling does not widen
- switch the popover rail and header glyph to the display-oriented provider list

## Verification
- bun run test -- src/hooks/rate-limits/__tests__/use-visible-rate-limit-providers.test.tsx src/components/layout/header/__tests__/rate-limit-popover.test.tsx src/hooks/rate-limits/__tests__/use-header-rate-limit-bars.test.tsx
- bun run compile
- bun x -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score