### PR TITLE
Improve Worktrees settings UX

### DIFF
--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -288,20 +288,89 @@ codeFontSize` in muted styling while `null`; any tick/type pins an
     client-sequenced (`envOverrideSet` new → `envOverrideDelete` old) with an
     inline unique-key + `/^[A-Za-z_][A-Za-z0-9_]*$/` guard.
 - `Worktrees` Host-wide management of the git worktrees Traycer creates under
-  `~/.traycer/worktrees/`. A host selector (default = active host, gated on
-  `useHostReachability`) drives a disk-truth list - so orphaned worktrees
-  whose owning chat/agent was deleted still appear - grouped by repo and showing
-  branch, path, an **In use** badge, an **Orphaned** badge (no resolvable main
-  repo), and an uncommitted-change count. The selected host is reached through
-  a **transient per-host client** (`useHostClientFor`) so picking a host
-  never swaps the app-wide active host or reloads the Epic list. Backed by the
-  host `worktree.listAllForHost` / `worktree.deleteByPath` RPCs through
-  `useHostQuery` / `useHostMutation`. Delete is disabled for in-use rows
-  (server-rejected as a backstop) and requires an extra confirm that names the
-  change count when the worktree is dirty; orphan dirs git no longer tracks fall
-  back to an `fs.rm` cleanup host-side. Setup/teardown script editing is NOT
+  `~/.traycer/worktrees/`, presented as a calm inspection-and-cleanup list, not
+  a delete console. A host selector (default = active host, gated on
+  `useHostReachability`, demoted to quiet toolbar chrome rather than a
+  dominant control) drives a disk-truth list - so orphaned worktrees whose
+  owning chat/agent was deleted still appear - grouped by repo under quiet,
+  collapsible headers (`WorktreeRepoHeader`) that stay visually secondary to
+  row status. The selected host is reached through a **transient per-host
+  client** (`useHostClientFor`) so picking a host never swaps the app-wide
+  active host or reloads the Epic list. Backed by the host
+  `worktree.listAllForHost` / `worktree.deleteByPath` RPCs through
+  `useHostQuery` / `useHostMutation`. Setup/teardown script editing is NOT
   here - the create-worktree flow owns it, and scripts otherwise live in the
   committed `.traycer/environment.json`.
+  - **Evidence tiers, not a safety verdict.** Each row leads with exactly one
+    loud status pill (`WorktreeTierPill`, classification shared with the
+    Task-delete dialog and the `traycer-housekeeping` skill via
+    `classify-worktree.ts`) naming a PROVEN fact, never a generic "Safe"
+    label. **Merged**, **At base commit**, and **Unreferenced** are the three
+    green tiers - each requires positive, host-validated proof (a merged PR at
+    the live HEAD or local ancestry into the default branch; never advanced
+    from the worktree's birth commit; or clean, fully pushed, and unreferenced
+    by any Task) - and are deliberately kept distinct rather than collapsed
+    into one badge. **Review** is the amber catch-all for anything unproven or
+    with would-be-lost state (dirty, unpushed/local-only commits, a detached
+    HEAD, an unmerged owned-submodule branch, or unverified branch status).
+    **Orphaned** means git can't remove the worktree normally (missing/broken
+    metadata) and its delete routes through a forced host-side `fs.rm`
+    cleanup. **In use** means an active chat or agent references it - both
+    selection and delete are disabled, not just delete. Hovering any pill
+    shows the concrete proof or reason (`WORKTREE_TIER_TOOLTIP`), and the
+    risk-bearing facts behind a tier (uncommitted count, ahead/behind,
+    detached HEAD, unmerged submodule) render inline on the row
+    (`WorktreeSecondaryFacts`) without hover or expansion.
+  - **`Checking` and `Unknown` are enrichment states layered on top of a
+    tier, not tiers themselves.** A row's tier depends on host-probed
+    branch/PR activity that resolves after the base list loads. While that
+    probe is in flight the pill reads **Checking…** - dashed border, animated,
+    full-contrast text, never the muted/green treatment a resolved-safe pill
+    uses, because pending status must never look safe - and delete is
+    disabled with an explicit "status is still being checked" reason; the row
+    stays visible under an active status filter instead of silently matching
+    or disappearing. If the probe settles to an error (host unreachable,
+    git/gh probe timed out) the pill reads a static **Unknown** (amber,
+    dashed, a distinct icon from Review so it never reads as a confirmed risk
+    finding) - it remains deletable, but only through an explicit
+    unknown-risk confirmation (`unknownRiskDeleteDialogCopy`) that names the
+    branch/activity status as unverified, never the generic confirmation a
+    proven tier gets.
+  - **Delete is reached through a persistent row overflow**
+    (`WorktreeRowActions`: copy path, manage scripts, delete, in that order)
+    rather than a hover-only icon, so a resting row never shows a destructive
+    affordance. Confirmation copy escalates with what the row actually risks -
+    discard-N-uncommitted-changes, unpushed/local-only commits, the
+    unknown-risk copy above, forced cleanup for orphaned rows, or a plain
+    confirmation for a proven-green row (`deleteDialogCopy` /
+    `singleWorktreeDeleteDialogCopy`). On confirm the row is re-checked
+    against current state; if it became ineligible in the interim the delete
+    is skipped and the user is told why instead of proceeding on stale
+    information.
+  - **Selection and bulk delete** use always-keyboard-reachable checkboxes
+    plus a tri-state toolbar select-all toggle (`WorktreeSelectAllToggle`,
+    scoped to currently-visible selectable rows) instead of a permanent
+    header row. Selecting rows never inserts chrome above the list; a
+    contextual selection bar (`WorktreeSelectionActionBar`) floats over the
+    bottom of the list, out of flow, so entering or leaving selection never
+    shifts rows under the cursor. If any selected row is still `Checking`,
+    bulk delete is disabled with a count of how many are still pending. The
+    bulk confirmation (`WorktreeBulkDeleteDialog` /
+    `summarizeBulkWorktreeDelete`) aggregates the selected rows by class
+    (never one warning per row), names concrete dirty-loss counts, adds a
+    neutral unverified-branch-status caveat and a separate unknown-risk
+    caveat for rows whose enrichment failed, and lists what was excluded from
+    the selection (in-use, still-checking, or otherwise not selected).
+    Confirm re-checks every selected row and skips/names any that became
+    ineligible; in-use rows can never be selected or deleted, and explain why
+    inline.
+  - Background delete progress renders as a non-intrusive strip
+    (`WorktreeDeleteProgressStrip`) that stays visible through partial
+    failures until dismissed. A quiet `Task {label}` caption
+    (`TaskMergeRollupBadge`) beside a resolved Task chip reports that Task's
+    aggregate merge progress across every worktree it owns - deliberately
+    plain muted text, not a colored badge, so it never competes with or is
+    mistaken for the row's own tier pill.
 - `Host` The active host-management surface for the native-packaging flow.
   Three top-level rows - **Status** (running / stopped / not-installed, with
   version + listen URL + pid), **Actions** (Restart, or Install host when

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-row-overflow.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-row-overflow.test.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { WorktreeHostEntryV11 } from "@traycer/protocol/host/index";
 import { WorktreesList } from "@/components/settings/panels/worktrees-settings-panel";
+import { installWorktreeVirtualizerOffsetHeight } from "./worktrees-virtualizer-test-utils";
 
 function entry(
   over: Partial<WorktreeHostEntryV11> & {
@@ -37,35 +38,17 @@ function entry(
   };
 }
 
-// jsdom has no layout, so the virtualizer's `offsetHeight` reads would all be
-// zero and window the single test row out of the DOM. Mirrors the same shim
-// worktrees-settings-panel.test.tsx installs.
-let offsetHeightDescriptor: PropertyDescriptor | undefined;
+let restoreOffsetHeight: (() => void) | null = null;
 
 beforeEach(() => {
-  offsetHeightDescriptor = Object.getOwnPropertyDescriptor(
-    HTMLElement.prototype,
-    "offsetHeight",
-  );
-  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
-    configurable: true,
-    get(this: HTMLElement): number {
-      if (this.dataset.testid === "worktrees-virtual-scroll") return 100_000;
-      if (this.hasAttribute("data-index")) return 80;
-      return 0;
-    },
-  });
+  restoreOffsetHeight = installWorktreeVirtualizerOffsetHeight(() => 100_000);
 });
 
 afterEach(() => {
-  if (offsetHeightDescriptor !== undefined) {
-    Object.defineProperty(
-      HTMLElement.prototype,
-      "offsetHeight",
-      offsetHeightDescriptor,
-    );
+  if (restoreOffsetHeight !== null) {
+    restoreOffsetHeight();
   }
-  offsetHeightDescriptor = undefined;
+  restoreOffsetHeight = null;
   cleanup();
 });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-row-overflow.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-row-overflow.test.tsx
@@ -1,0 +1,179 @@
+// This file deliberately does NOT mock "@/components/ui/dropdown-menu" (unlike
+// worktrees-settings-panel.test.tsx, which renders it inline + always-open for
+// easy assertions on the Filter/Sort menus). This file keeps the REAL primitive
+// so row-utility menu mounting and keyboard access are tested against Radix.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { WorktreeHostEntryV11 } from "@traycer/protocol/host/index";
+import { WorktreesList } from "@/components/settings/panels/worktrees-settings-panel";
+
+function entry(
+  over: Partial<WorktreeHostEntryV11> & {
+    worktreePath: string;
+    branch: string;
+  },
+): WorktreeHostEntryV11 {
+  return {
+    repoLabel: "acme/app",
+    repoIdentifier: { owner: "acme", repo: "app" },
+    inUse: false,
+    uncommittedCount: 0,
+    gitRemovable: true,
+    scripts: null,
+    owners: [],
+    lastActivityAt: null,
+    branchStatus: null,
+    createdAt: null,
+    prState: null,
+    prNumber: null,
+    prUrl: null,
+    mergedHeadShaMatches: false,
+    submodules: [],
+    atBaseCommit: false,
+    ...over,
+  };
+}
+
+// jsdom has no layout, so the virtualizer's `offsetHeight` reads would all be
+// zero and window the single test row out of the DOM. Mirrors the same shim
+// worktrees-settings-panel.test.tsx installs.
+let offsetHeightDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  offsetHeightDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetHeight",
+  );
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get(this: HTMLElement): number {
+      if (this.dataset.testid === "worktrees-virtual-scroll") return 100_000;
+      if (this.hasAttribute("data-index")) return 80;
+      return 0;
+    },
+  });
+});
+
+afterEach(() => {
+  if (offsetHeightDescriptor !== undefined) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "offsetHeight",
+      offsetHeightDescriptor,
+    );
+  }
+  offsetHeightDescriptor = undefined;
+  cleanup();
+});
+
+function renderSingleRow(
+  overrides: Partial<WorktreeHostEntryV11> & {
+    worktreePath: string;
+    branch: string;
+  },
+): void {
+  const worktree = entry(overrides);
+  const queryClient = new QueryClient();
+  const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{props.children}</TooltipProvider>
+    </QueryClientProvider>
+  );
+  render(
+    <Wrapper>
+      <WorktreesList
+        openStreamTransport={() => {
+          throw new Error("delete is not exercised in this test file");
+        }}
+        hostId="host-a"
+        worktrees={[worktree]}
+        enrichedByPath={new Map([[worktree.worktreePath, worktree]])}
+        erroredPaths={new Set()}
+        onVisiblePathsChange={() => {}}
+        taskTitlesByEpicId={new Map()}
+        toolbarProps={{
+          hosts: [],
+          value: null,
+          onChange: () => {},
+          onRefresh: () => Promise.resolve(),
+          refreshing: false,
+          canRefresh: true,
+        }}
+      />
+    </Wrapper>,
+  );
+}
+
+describe("WorktreesList row overflow (real DropdownMenu)", () => {
+  it("keeps all row actions in the compact overflow menu", () => {
+    renderSingleRow({ worktreePath: "/wt/alpha", branch: "feat-alpha" });
+
+    // Resting row: one quiet overflow trigger; no menu items or destructive
+    // controls are mounted until the user opens it.
+    screen.getByRole("button", { name: "Worktree actions for feat-alpha" });
+    expect(screen.queryByRole("menuitem")).toBeNull();
+    expect(
+      screen.queryByRole("menuitem", { name: "Delete worktree feat-alpha" }),
+    ).toBeNull();
+
+    // Radix's DropdownMenuTrigger opens on pointerdown, not the click event.
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Worktree actions for feat-alpha" }),
+      { button: 0 },
+    );
+
+    // Opened: utilities and destructive delete share the same compact menu.
+    screen.getByRole("menuitem", { name: "Copy path" });
+    screen.getByRole("menuitem", { name: "Manage script" });
+    const deleteItem = screen.getByRole("menuitem", {
+      name: "Delete worktree feat-alpha",
+    });
+    expect(deleteItem.getAttribute("data-variant")).toBe("destructive");
+  });
+
+  it("opens and activates an item entirely from the keyboard", () => {
+    renderSingleRow({ worktreePath: "/wt/alpha", branch: "feat-alpha" });
+
+    const trigger = screen.getByRole("button", {
+      name: "Worktree actions for feat-alpha",
+    });
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    // Enter opens the menu (Radix's own keydown handling, not a native
+    // browser button-activation shortcut) and moves focus into it.
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    const scriptsItem = screen.getByRole("menuitem", {
+      name: "Manage script",
+    });
+
+    // Activate it from the keyboard, not by clicking.
+    fireEvent.keyDown(scriptsItem, { key: "Enter" });
+
+    screen.getByTestId("worktree-script-review-dialog");
+  });
+
+  it("disables the delete item for an in-use row without hiding it", () => {
+    renderSingleRow({
+      worktreePath: "/wt/busy",
+      branch: "feat-busy",
+      inUse: true,
+    });
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Worktree actions for feat-busy" }),
+      { button: 0 },
+    );
+
+    // Copy path and manage scripts stay usable while the row is in use.
+    screen.getByRole("menuitem", { name: "Copy path" });
+    screen.getByRole("menuitem", { name: "Manage script" });
+    const deleteItem = screen.getByRole("menuitem", {
+      name: "Delete worktree (in use by an active chat or agent)",
+    });
+    expect(deleteItem.getAttribute("aria-disabled")).toBe("true");
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel-states.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel-states.test.tsx
@@ -78,12 +78,9 @@ vi.mock("@/hooks/epics/use-cloud-epic-tasks-query", () => ({
 }));
 
 import { WorktreesSettingsPanel } from "@/components/settings/panels/worktrees-settings-panel";
+import { installWorktreeVirtualizerOffsetHeight } from "./worktrees-virtualizer-test-utils";
 
-// jsdom has no layout, so `@tanstack/react-virtual` (which sizes the scroll
-// viewport and measures items via `offsetHeight`) sees zero everywhere and
-// would window the populated-list scenario down to nothing. Feed it a real
-// height, mirroring `worktrees-settings-panel.test.tsx`.
-let offsetHeightDescriptor: PropertyDescriptor | undefined;
+let restoreOffsetHeight: (() => void) | null = null;
 
 function host(
   over: Partial<HostDirectoryEntry> & { hostId: string },
@@ -113,18 +110,7 @@ function renderPanel(): void {
 }
 
 beforeEach(() => {
-  offsetHeightDescriptor = Object.getOwnPropertyDescriptor(
-    HTMLElement.prototype,
-    "offsetHeight",
-  );
-  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
-    configurable: true,
-    get(this: HTMLElement): number {
-      if (this.dataset.testid === "worktrees-virtual-scroll") return 100_000;
-      if (this.hasAttribute("data-index")) return 80;
-      return 0;
-    },
-  });
+  restoreOffsetHeight = installWorktreeVirtualizerOffsetHeight(() => 100_000);
   state.activeHostId = null;
   state.hosts = [];
   state.reachability = { status: "reachable", hostLabel: "Host A" };
@@ -150,14 +136,10 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
-  if (offsetHeightDescriptor !== undefined) {
-    Object.defineProperty(
-      HTMLElement.prototype,
-      "offsetHeight",
-      offsetHeightDescriptor,
-    );
+  if (restoreOffsetHeight !== null) {
+    restoreOffsetHeight();
   }
-  offsetHeightDescriptor = undefined;
+  restoreOffsetHeight = null;
 });
 
 describe("WorktreesSettingsPanel host-scoped states", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel-states.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel-states.test.tsx
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { WorktreeHostEntryV11 } from "@traycer/protocol/host/index";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+
+// `WorktreesSettingsPanel` sits above `WorktreesList` (covered exhaustively by
+// `worktrees-settings-panel.test.tsx`) and owns the host-scoped states from
+// core flows "Enter And Orient" / "Host And Connectivity States": no host
+// selected, checking reachability, offline, not signed in, loading, error,
+// and empty. None of those states are reachable through `WorktreesList`
+// directly (it is only ever mounted once a host is reachable and signed in),
+// so this file mocks the host-scoped hooks `WorktreesSettingsPanel` composes
+// and drives each state independently.
+const state = vi.hoisted(() => ({
+  activeHostId: null as string | null,
+  hosts: [] as HostDirectoryEntry[],
+  reachability: {
+    status: "reachable",
+    hostLabel: "Host A",
+  },
+  client: null as object | null,
+  hostQuery: {
+    data: undefined as
+      { worktrees: readonly WorktreeHostEntryV11[] } | undefined,
+    fetchStatus: "idle",
+    status: "pending",
+    isPending: true,
+    isError: false,
+    isSuccess: false,
+    error: null as { message: string } | null,
+    isFetching: false,
+    refetch: vi.fn(() => Promise.resolve()),
+  },
+  enrichment: {
+    enrichedByPath: new Map<string, WorktreeHostEntryV11>(),
+    erroredPaths: new Set<string>(),
+    reportVisiblePaths: vi.fn(),
+    enriching: false,
+  },
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => state.activeHostId,
+}));
+
+vi.mock("@/hooks/host/use-host-directory-list-query", () => ({
+  useHostDirectoryList: () => ({ data: state.hosts }),
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: () => state.reachability,
+}));
+
+vi.mock("@/hooks/host/use-host-client-for", () => ({
+  useHostClientFor: () => state.client,
+}));
+
+vi.mock("@/hooks/host/use-host-query", () => ({
+  useHostQuery: () => state.hostQuery,
+}));
+
+vi.mock("@/components/settings/panels/worktrees-enrichment", () => ({
+  useWorktreeActivityEnrichment: () => state.enrichment,
+}));
+
+vi.mock("@/lib/host/use-worktree-delete-stream-transport", () => ({
+  useWorktreeDeleteStreamTransportFactory: () => () => ({
+    wsStreamClient: {},
+    close: () => {},
+  }),
+}));
+
+vi.mock("@/hooks/epics/use-cloud-epic-tasks-query", () => ({
+  useCloudEpicTasksQuery: () => ({ currentUserId: null, tasks: [] }),
+}));
+
+import { WorktreesSettingsPanel } from "@/components/settings/panels/worktrees-settings-panel";
+
+// jsdom has no layout, so `@tanstack/react-virtual` (which sizes the scroll
+// viewport and measures items via `offsetHeight`) sees zero everywhere and
+// would window the populated-list scenario down to nothing. Feed it a real
+// height, mirroring `worktrees-settings-panel.test.tsx`.
+let offsetHeightDescriptor: PropertyDescriptor | undefined;
+
+function host(
+  over: Partial<HostDirectoryEntry> & { hostId: string },
+): HostDirectoryEntry {
+  return {
+    label: over.hostId,
+    kind: "local",
+    websocketUrl: null,
+    version: null,
+    status: "available",
+    ...over,
+  };
+}
+
+function renderPanel(): void {
+  const queryClient = new QueryClient();
+  const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{props.children}</TooltipProvider>
+    </QueryClientProvider>
+  );
+  render(
+    <Wrapper>
+      <WorktreesSettingsPanel />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  offsetHeightDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetHeight",
+  );
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get(this: HTMLElement): number {
+      if (this.dataset.testid === "worktrees-virtual-scroll") return 100_000;
+      if (this.hasAttribute("data-index")) return 80;
+      return 0;
+    },
+  });
+  state.activeHostId = null;
+  state.hosts = [];
+  state.reachability = { status: "reachable", hostLabel: "Host A" };
+  state.client = null;
+  state.hostQuery = {
+    data: undefined,
+    fetchStatus: "idle",
+    status: "pending",
+    isPending: true,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    isFetching: false,
+    refetch: vi.fn(() => Promise.resolve()),
+  };
+  state.enrichment = {
+    enrichedByPath: new Map(),
+    erroredPaths: new Set(),
+    reportVisiblePaths: vi.fn(),
+    enriching: false,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  if (offsetHeightDescriptor !== undefined) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "offsetHeight",
+      offsetHeightDescriptor,
+    );
+  }
+  offsetHeightDescriptor = undefined;
+});
+
+describe("WorktreesSettingsPanel host-scoped states", () => {
+  it("prompts to select a host when none is selected", () => {
+    state.hosts = [host({ hostId: "host-a" })];
+    state.activeHostId = null;
+
+    renderPanel();
+
+    screen.getByText("Select a host to manage its worktrees.");
+  });
+
+  it("shows a reachability check while the host is being probed", () => {
+    state.hosts = [host({ hostId: "host-a", label: "Host A" })];
+    state.activeHostId = "host-a";
+    state.reachability = { status: "checking", hostLabel: "Host A" };
+
+    renderPanel();
+
+    screen.getByText("Checking Host A…");
+  });
+
+  it("shows an offline message and disables refresh when the host is unreachable", () => {
+    state.hosts = [host({ hostId: "host-a", label: "Host A" })];
+    state.activeHostId = "host-a";
+    state.reachability = { status: "unreachable", hostLabel: "Host A" };
+
+    renderPanel();
+
+    screen.getByText(
+      "Host A is offline. Worktrees can only be managed on a reachable host.",
+    );
+    const refresh = screen.getByRole("button", { name: "Refresh worktrees" });
+    expect(refresh.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("prompts sign-in when the host is reachable but no client is bound", () => {
+    state.hosts = [host({ hostId: "host-a" })];
+    state.activeHostId = "host-a";
+    state.reachability = { status: "reachable", hostLabel: "Host A" };
+    state.client = null;
+
+    renderPanel();
+
+    screen.getByText("Sign in to manage worktrees on this host.");
+  });
+
+  it("shows a loading state while the base listing is pending", () => {
+    state.hosts = [host({ hostId: "host-a" })];
+    state.activeHostId = "host-a";
+    state.client = {};
+    state.hostQuery = {
+      ...state.hostQuery,
+      isPending: true,
+      status: "pending",
+    };
+
+    renderPanel();
+
+    screen.getByText("Loading worktrees…");
+  });
+
+  it("surfaces the query error message with a working refresh retry path", () => {
+    state.hosts = [host({ hostId: "host-a" })];
+    state.activeHostId = "host-a";
+    state.client = {};
+    state.hostQuery = {
+      ...state.hostQuery,
+      isPending: false,
+      isError: true,
+      status: "error",
+      error: { message: "Could not reach the worktree service." },
+    };
+
+    renderPanel();
+
+    screen.getByText("Could not reach the worktree service.");
+    const refresh = screen.getByRole("button", { name: "Refresh worktrees" });
+    expect(refresh.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("says nothing was created when the host's list is empty", () => {
+    state.hosts = [host({ hostId: "host-a" })];
+    state.activeHostId = "host-a";
+    state.client = {};
+    state.hostQuery = {
+      ...state.hostQuery,
+      isPending: false,
+      isSuccess: true,
+      status: "success",
+      data: { worktrees: [] },
+    };
+
+    renderPanel();
+
+    screen.getByText("No worktrees created on this host.");
+  });
+
+  it("renders the host select alongside the full toolbar once the list is populated", () => {
+    state.hosts = [
+      host({ hostId: "host-a", label: "Host A" }),
+      host({ hostId: "host-b", label: "Host B" }),
+    ];
+    state.activeHostId = "host-a";
+    state.client = {};
+    const cleanWorktree = {
+      repoLabel: "acme/app",
+      repoIdentifier: { owner: "acme", repo: "app" },
+      worktreePath: "/wt/clean",
+      branch: "feat-clean",
+      inUse: false,
+      uncommittedCount: 0,
+      gitRemovable: true,
+      scripts: null,
+      owners: [],
+      lastActivityAt: null,
+      branchStatus: null,
+      createdAt: null,
+      prState: null,
+      prNumber: null,
+      prUrl: null,
+      mergedHeadShaMatches: false,
+      submodules: [],
+      atBaseCommit: false,
+    } satisfies WorktreeHostEntryV11;
+    state.hostQuery = {
+      ...state.hostQuery,
+      isPending: false,
+      isSuccess: true,
+      status: "success",
+      data: { worktrees: [cleanWorktree] },
+    };
+    state.enrichment = {
+      enrichedByPath: new Map([["/wt/clean", cleanWorktree]]),
+      erroredPaths: new Set(),
+      reportVisiblePaths: vi.fn(),
+      enriching: false,
+    };
+
+    renderPanel();
+
+    screen.getByTestId("worktrees-host-select");
+    screen.getByPlaceholderText("Search repo, branch, path, or Task");
+    screen.getByTestId("worktrees-filter-trigger");
+    screen.getByTestId("worktrees-sort-trigger");
+    screen.getByRole("button", { name: "Refresh worktrees" });
+    screen.getByText("feat-clean");
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -22,6 +22,10 @@ import { WorktreesList } from "@/components/settings/panels/worktrees-settings-p
 import { __resetWorktreeDeleteRunForTests } from "@/components/settings/panels/use-worktree-delete-run";
 import { hostQueryKeys } from "@/lib/query-keys";
 import { WORKTREE_BINDING_INVALIDATIONS } from "@/hooks/worktree/invalidations";
+import {
+  installWorktreeVirtualizerOffsetHeight,
+  WORKTREE_TEST_VIRTUAL_ITEM_HEIGHT,
+} from "./worktrees-virtualizer-test-utils";
 
 // The delete is a stream: mock the wrapper so a test can drive server frames
 // (started / phase / output / complete / failed) and assert the modal + cache
@@ -229,44 +233,21 @@ const WORKTREES: WorktreeHostEntryV11[] = [
   entry({ worktreePath: "/wt/busy", branch: "feat-busy", inUse: true }),
 ];
 
-// jsdom has no layout, so `@tanstack/react-virtual` (which sizes the scroll
-// viewport and measures items via `offsetHeight`) sees zero everywhere and would
-// window down to nothing. Feed it a real height for the scroll element
-// (`worktrees-virtual-scroll`) and a fixed height per measured virtual item
-// (`data-index`); everything else keeps jsdom's zero. A tall default viewport
-// renders every row (so the behavioural tests still find their rows); the
-// windowing test shrinks `virtualViewportHeight` to force a real window.
-const VIRTUAL_ITEM_TEST_HEIGHT = 80;
 let virtualViewportHeight = 100_000;
-let offsetHeightDescriptor: PropertyDescriptor | undefined;
+let restoreOffsetHeight: (() => void) | null = null;
 
 beforeEach(() => {
   virtualViewportHeight = 100_000;
-  offsetHeightDescriptor = Object.getOwnPropertyDescriptor(
-    HTMLElement.prototype,
-    "offsetHeight",
+  restoreOffsetHeight = installWorktreeVirtualizerOffsetHeight(
+    () => virtualViewportHeight,
   );
-  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
-    configurable: true,
-    get(this: HTMLElement): number {
-      if (this.dataset.testid === "worktrees-virtual-scroll") {
-        return virtualViewportHeight;
-      }
-      if (this.hasAttribute("data-index")) return VIRTUAL_ITEM_TEST_HEIGHT;
-      return 0;
-    },
-  });
 });
 
 afterEach(() => {
-  if (offsetHeightDescriptor !== undefined) {
-    Object.defineProperty(
-      HTMLElement.prototype,
-      "offsetHeight",
-      offsetHeightDescriptor,
-    );
+  if (restoreOffsetHeight !== null) {
+    restoreOffsetHeight();
   }
-  offsetHeightDescriptor = undefined;
+  restoreOffsetHeight = null;
 });
 
 // Treat every passed worktree as already-enriched (its base entry IS its enriched
@@ -863,6 +844,7 @@ describe("WorktreesList delete flow", () => {
     // unverified caveat instead of a single stacked warning.
     screen.getByText("Delete 2 worktrees?");
     screen.getByTestId("worktree-bulk-delete-dirty-loss");
+    screen.getByText("1 not selected: 1 in use");
     fireEvent.click(screen.getByTestId("confirm-action"));
 
     expect(streamMock.paths).toEqual(["/wt/clean", "/wt/dirty"]);
@@ -1481,10 +1463,10 @@ describe("WorktreesList confirm-time re-check", () => {
 
     fireEvent.click(screen.getByTestId("confirm-action"));
 
-    // The now-ineligible row is excluded from the started delete and named in the
-    // class-summarized drop toast (its freshest class is dirty).
+    // The now-ineligible row is excluded from the started delete and named by the
+    // lock reason instead of by its underlying git facts.
     expect(streamMock.paths).toEqual(["/wt/a", "/wt/b"]);
-    expect(toastMock.messages.join("\n")).toContain("1 dirty");
+    expect(toastMock.messages.join("\n")).toContain("1 in use");
   });
 
   it("filter → Merged then select-all picks only the Merged rows (fast path)", () => {
@@ -2354,7 +2336,7 @@ describe("WorktreesList virtualization + per-viewport enrichment", () => {
 
   it("renders only a windowed subset of a large list, not every row", () => {
     // A short viewport forces a real window: far fewer rows mount than exist.
-    virtualViewportHeight = 3 * VIRTUAL_ITEM_TEST_HEIGHT;
+    virtualViewportHeight = 3 * WORKTREE_TEST_VIRTUAL_ITEM_HEIGHT;
     const worktrees = manyWorktrees(60);
     renderList({
       hostId: "host-a",
@@ -2374,7 +2356,7 @@ describe("WorktreesList virtualization + per-viewport enrichment", () => {
   });
 
   it("reports only the on-screen worktree paths (drives the per-visible query)", () => {
-    virtualViewportHeight = 3 * VIRTUAL_ITEM_TEST_HEIGHT;
+    virtualViewportHeight = 3 * WORKTREE_TEST_VIRTUAL_ITEM_HEIGHT;
     const worktrees = manyWorktrees(60);
     const onVisiblePathsChange = vi.fn<(paths: readonly string[]) => void>();
     render(

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -43,7 +43,12 @@ vi.mock("sonner", () => ({
     message: (message: string) => {
       toastMock.messages.push(message);
     },
-    error: () => {},
+    success: (message: string) => {
+      toastMock.messages.push(message);
+    },
+    error: (message: string) => {
+      toastMock.messages.push(message);
+    },
   },
 }));
 
@@ -57,13 +62,21 @@ vi.mock("@/components/ui/dropdown-menu", () => {
     readonly children: ReactNode;
     readonly onSelect?: () => void;
     readonly disabled?: boolean;
+    readonly "aria-label"?: string;
+    readonly className?: string;
+    readonly title?: string;
+    readonly variant?: string;
     readonly "data-testid"?: string;
   }): ReactNode => (
     <button
       type="button"
+      aria-label={props["aria-label"]}
+      className={props.className}
+      data-variant={props.variant}
       data-testid={props["data-testid"]}
       disabled={props.disabled ?? false}
       onClick={props.onSelect}
+      title={props.title}
     >
       {props.children}
     </button>
@@ -89,8 +102,13 @@ vi.mock("@/components/ui/dropdown-menu", () => {
     DropdownMenuTrigger: passthrough,
     DropdownMenuContent: (props: {
       readonly children: ReactNode;
+      readonly className?: string;
       readonly "data-testid"?: string;
-    }) => <div data-testid={props["data-testid"]}>{props.children}</div>,
+    }) => (
+      <div className={props.className} data-testid={props["data-testid"]}>
+        {props.children}
+      </div>
+    ),
     DropdownMenuItem: item,
     DropdownMenuCheckboxItem: checkboxItem,
     DropdownMenuSeparator: () => <div role="separator" />,
@@ -367,7 +385,7 @@ describe("WorktreesList delete flow", () => {
     const busyButton = screen.getByRole("button", {
       name: /in use by an active chat or agent/i,
     });
-    expect(busyButton.getAttribute("aria-disabled")).toBe("true");
+    expect(busyButton.hasAttribute("disabled")).toBe(true);
   });
 
   it("keeps a stable toolbar; the selection action bar is separate and only shown when selecting", () => {
@@ -392,8 +410,166 @@ describe("WorktreesList delete flow", () => {
       "Refresh worktrees",
     ]);
     const actionBar = screen.getByTestId("worktrees-selection-action-bar");
+    expect(actionBar.className).toContain("border-border");
+    expect(actionBar.className).toContain("ring-foreground");
+    expect(actionBar.className).toContain("bg-popover");
     within(actionBar).getByText("1 selected");
-    within(actionBar).getByTestId("worktrees-list-delete-selected");
+    within(actionBar).getByText("Delete 1 worktree");
+    expect(
+      within(actionBar).getByTestId("worktrees-list-delete-selected").className,
+    ).toContain("whitespace-nowrap");
+  });
+
+  it("selecting the first row does not insert a new top bar that shifts the list", () => {
+    renderDefault();
+    const scrollRegion = screen.getByTestId("worktrees-virtual-scroll");
+    const wrapper = scrollRegion.parentElement;
+    // The scroll region is the first thing in its wrapper before any
+    // selection - nothing sits above it in flow.
+    expect(scrollRegion.previousElementSibling).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select worktree feat-clean" }),
+    );
+
+    // Selecting the first row must not insert a new bar ABOVE the list: the
+    // scroll region keeps its position, and the contextual action bar that
+    // appears is an out-of-flow overlay inside the SAME wrapper, not a
+    // preceding sibling that would push the list down.
+    expect(scrollRegion.previousElementSibling).toBeNull();
+    const actionBar = screen.getByTestId("worktrees-selection-action-bar");
+    expect(actionBar.parentElement).toBe(wrapper);
+    expect(actionBar.className).toContain("absolute");
+  });
+
+  it("clears the selection and hides the action bar and count", () => {
+    renderDefault();
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select worktree feat-clean" }),
+    );
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select worktree feat-dirty" }),
+    );
+    expect(screen.getByText("2 selected")).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId("worktrees-clear-selection-inline"));
+
+    expect(screen.queryByTestId("worktrees-selection-action-bar")).toBeNull();
+    expect(screen.queryByText("2 selected")).toBeNull();
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select worktree feat-clean" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
+  it("gives the scroll viewport a minimum bottom clearance while selecting, and removes it once cleared", () => {
+    renderDefault();
+    const scrollRegion = screen.getByTestId("worktrees-virtual-scroll");
+    expect(scrollRegion.style.paddingBottom).toBe("");
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select worktree feat-clean" }),
+    );
+
+    // jsdom reports a zero-height action bar (no real layout), so the
+    // clearance mechanism falls back to its seeded minimum rather than
+    // collapsing to zero - the same floor the old fixed `pb-16` provided.
+    expect(scrollRegion.style.paddingBottom).toBe("64px");
+
+    fireEvent.click(screen.getByTestId("worktrees-clear-selection-inline"));
+
+    expect(scrollRegion.style.paddingBottom).toBe("");
+  });
+
+  it("grows the scroll clearance to match a taller (wrapped) action bar instead of the fixed minimum", () => {
+    renderDefault();
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select worktree feat-clean" }),
+    );
+    const actionBar = screen.getByTestId("worktrees-selection-action-bar");
+    // Simulate the bar wrapping to two lines (narrow width, or the
+    // `Checking` notice pushing it taller) by measuring taller than the
+    // seeded minimum clearance.
+    Object.defineProperty(actionBar, "getBoundingClientRect", {
+      configurable: true,
+      value: () => ({
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 96,
+        top: 0,
+        right: 300,
+        bottom: 96,
+        left: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    // Force a re-render of the same mounted action bar (no unmount, so the
+    // mocked node and its override survive) so the height observer's
+    // snapshot is re-read against the taller measurement.
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select worktree feat-dirty" }),
+    );
+
+    const scrollRegion = screen.getByTestId("worktrees-virtual-scroll");
+    // 96px measured height + the bar's own gap/offset clearance (32px),
+    // clearly exceeding the 64px seeded minimum - proving the clearance
+    // tracks the bar's real rendered height rather than a hard-coded value.
+    expect(scrollRegion.style.paddingBottom).toBe("128px");
+  });
+
+  it("excludes an in-use row and a backgrounded-deleting row from selection and select-all", () => {
+    renderDefault();
+    confirmDelete("feat-dirty");
+    act(() => {
+      streamMock.callbacks?.onStarted(true);
+      streamMock.callbacks?.onPhase("teardown");
+    });
+    // Backgrounds the running delete so the row stays locked as "deleting".
+    fireEvent.click(screen.getByTestId("worktree-delete-close-button"));
+
+    const busyCheckbox = screen.getByRole("checkbox", {
+      name: "Select worktree feat-busy",
+    });
+    expect(busyCheckbox.getAttribute("aria-disabled")).toBe("true");
+    // The dirty row's own checkbox is now locked while its delete runs.
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select worktree feat-dirty" })
+        .getAttribute("aria-disabled"),
+    ).toBe("true");
+
+    // Select-all only picks up the one remaining selectable row (feat-clean).
+    fireEvent.click(screen.getByTestId("worktrees-select-all"));
+    expect(screen.getByText("1 selected")).not.toBeNull();
+    expect(busyCheckbox.getAttribute("aria-checked")).toBe("false");
+
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(streamMock.paths).toEqual(["/wt/dirty", "/wt/clean"]);
+  });
+
+  it("select-all-visible only picks rows matching an active search", () => {
+    renderDefault();
+
+    fireEvent.change(
+      screen.getByRole("searchbox", { name: "Search worktrees" }),
+      { target: { value: "dirty" } },
+    );
+    expect(
+      screen.queryByRole("button", { name: "Delete worktree feat-clean" }),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByTestId("worktrees-select-all"));
+    expect(screen.getByText("1 selected")).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(streamMock.paths).toEqual(["/wt/dirty"]);
   });
 
   it("collapses and expands a repo section", () => {
@@ -418,6 +594,18 @@ describe("WorktreesList delete flow", () => {
 
     screen.getByRole("button", { name: "Delete worktree feat-clean" });
     screen.getByRole("button", { name: "Delete worktree feat-api-clean" });
+
+    const headerWrappers = screen
+      .getAllByTestId("worktree-repo-header")
+      .map((header) => header.closest("[data-index]"));
+    expect(
+      headerWrappers.filter((wrapper) => wrapper?.className.includes("sticky")),
+    ).toHaveLength(1);
+    expect(
+      headerWrappers.filter((wrapper) =>
+        wrapper?.className.includes("absolute"),
+      ).length,
+    ).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: "Collapse acme/app" }));
 
@@ -484,32 +672,96 @@ describe("WorktreesList delete flow", () => {
     expect(streamMock.paths).toEqual(["/wt/api-clean"]);
   });
 
-  it("shows row delete controls only on worktree row hover or focus", () => {
+  it("keeps row actions in one compact overflow with destructive delete", () => {
     renderDefault();
 
-    const reviewButton = screen.getByRole("button", {
-      name: "Manage scripts for worktree feat-clean",
+    const row = screen
+      .getByText("feat-clean")
+      .closest('[data-testid="worktree-row"]');
+    if (row === null) throw new Error("expected feat-clean row");
+
+    const trigger = within(row as HTMLElement).getByRole("button", {
+      name: "Worktree actions for feat-clean",
     });
-    const deleteButton = screen.getByRole("button", {
+    expect(trigger.className).not.toContain("opacity-0");
+    expect(trigger.className).not.toContain("group-hover/worktree-row");
+
+    const menu = within(row as HTMLElement).getByTestId(
+      "worktree-row-actions-menu",
+    );
+    expect(menu.className).toContain("w-max");
+    expect(menu.className).toContain("14rem");
+    expect(
+      within(menu).getByRole("button", { name: "Manage script" }),
+    ).not.toBeNull();
+    expect(within(menu).getByTestId("worktree-row-copy-path")).not.toBeNull();
+    const deleteButton = within(menu).getByRole("button", {
       name: "Delete worktree feat-clean",
     });
+    expect(deleteButton.getAttribute("data-variant")).toBe("destructive");
+  });
 
-    const actionGroup = deleteButton.parentElement;
-    expect(actionGroup?.className).toContain("opacity-0");
-    expect(actionGroup?.className).toContain(
-      "group-hover/worktree-row:opacity-100",
+  it("copies the worktree path through the overflow menu", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    try {
+      renderDefault();
+
+      const row = screen
+        .getByText("feat-clean")
+        .closest('[data-testid="worktree-row"]');
+      if (row === null) throw new Error("expected feat-clean row");
+      const menu = within(row as HTMLElement).getByTestId(
+        "worktree-row-actions-menu",
+      );
+      const copyButton = within(menu).getByTestId("worktree-row-copy-path");
+
+      await act(async () => {
+        fireEvent.click(copyButton);
+        await Promise.resolve();
+      });
+
+      expect(writeText).toHaveBeenCalledWith("/wt/clean");
+      expect(toastMock.messages).toContain("Copied worktree path");
+    } finally {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+  });
+
+  it("shows an error toast when the clipboard copy fails", () => {
+    // jsdom has no navigator.clipboard by default, so the copy attempt
+    // synchronously fails - this is the everyday jsdom/test-env path.
+    renderDefault();
+
+    const row = screen
+      .getByText("feat-clean")
+      .closest('[data-testid="worktree-row"]');
+    if (row === null) throw new Error("expected feat-clean row");
+    const menu = within(row as HTMLElement).getByTestId(
+      "worktree-row-actions-menu",
     );
-    expect(actionGroup?.className).toContain("focus-within:opacity-100");
-    expect(reviewButton.parentElement).toBe(actionGroup);
+    const copyButton = within(menu).getByTestId("worktree-row-copy-path");
+
+    fireEvent.click(copyButton);
+
+    expect(toastMock.messages).toContain("Couldn't copy path to clipboard.");
+    expect(toastMock.messages).not.toContain("Copied worktree path");
   });
 
   it("saves reviewed scripts before a later delete starts", async () => {
     vi.useFakeTimers();
     renderDefault();
 
+    const row = screen
+      .getByText("feat-clean")
+      .closest('[data-testid="worktree-row"]');
+    if (row === null) throw new Error("expected feat-clean row");
     fireEvent.click(
-      screen.getByRole("button", {
-        name: "Manage scripts for worktree feat-clean",
+      within(row as HTMLElement).getByRole("button", {
+        name: "Manage script",
       }),
     );
 
@@ -1866,6 +2118,197 @@ describe("WorktreesList v1.1 signals", () => {
       "Delete worktree feat-unknown",
     ]);
   });
+
+  it("keeps distinct labels for all three green tiers: Merged, At base commit, Unreferenced", () => {
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [
+        entry({
+          worktreePath: "/wt/merged",
+          branch: "feat-merged",
+          branchStatus: { ahead: 0, behind: 0, mergedIntoDefault: true },
+        }),
+        entry({
+          worktreePath: "/wt/at-base",
+          branch: "feat-at-base",
+          atBaseCommit: true,
+        }),
+        entry({
+          worktreePath: "/wt/unreferenced",
+          branch: "feat-unreferenced",
+          branchStatus: { ahead: 0, behind: 0, mergedIntoDefault: false },
+        }),
+      ],
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+    const pills = screen.getAllByTestId("worktree-tier-pill");
+    const tiers = pills.map((pill) => pill.getAttribute("data-tier"));
+    expect(tiers).toEqual(
+      expect.arrayContaining(["merged", "at-base-commit", "unreferenced"]),
+    );
+    // Three proven-green tiers never collapse into one generic "Safe" label.
+    // Scoped to the pills themselves - the (always-open, per test mock) tier
+    // filter menu also lists these same three labels as menu items.
+    const labels = pills.map((pill) => pill.textContent);
+    expect(labels).toContain("Merged");
+    expect(labels).toContain("At base commit");
+    expect(labels).toContain("Unreferenced");
+  });
+
+  it("keeps risk-bearing facts visible without hover for Review, Unknown, Orphaned, and dirty/unpushed rows", () => {
+    const reviewRow = entry({
+      worktreePath: "/wt/review",
+      branch: "feat-review",
+      uncommittedCount: 2,
+      branchStatus: { ahead: 3, behind: 0, mergedIntoDefault: false },
+    });
+    const orphanRow = entry({
+      worktreePath: "/wt/orphan",
+      branch: "feat-orphan",
+      gitRemovable: false,
+    });
+    const unknownRow = entry({
+      worktreePath: "/wt/unknown",
+      branch: "feat-unknown-risk",
+    });
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [reviewRow, orphanRow, unknownRow],
+      // Review + Orphaned are enriched (ready); Unknown is left out of the
+      // overlay and named in `erroredPaths`, so it settles to a static Unknown
+      // pill rather than an infinite Checking spinner.
+      enrichedByPath: new Map([
+        [reviewRow.worktreePath, reviewRow],
+        [orphanRow.worktreePath, orphanRow],
+      ]),
+      erroredPaths: new Set([unknownRow.worktreePath]),
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    // Every risk fact below is asserted directly against the rendered DOM -
+    // no hover, focus, or expansion interaction fires before these queries.
+    screen.getByText("3 ahead · 2 uncommitted changes");
+    screen.getByText("git can't remove");
+    screen.getByText("branch status unknown");
+
+    const tiers = screen
+      .getAllByTestId("worktree-tier-pill")
+      .map((pill) => pill.getAttribute("data-tier"));
+    expect(tiers).toEqual(
+      expect.arrayContaining(["review", "orphaned", "unknown"]),
+    );
+  });
+
+  it("renders Checking and Unknown pills with distinct, non-green styling", () => {
+    const readyRow = entry({
+      worktreePath: "/wt/ready",
+      branch: "feat-ready",
+      branchStatus: { ahead: 0, behind: 0, mergedIntoDefault: true },
+    });
+    const pendingRow = entry({
+      worktreePath: "/wt/pending",
+      branch: "feat-pending",
+    });
+    const unknownRow = entry({
+      worktreePath: "/wt/unknown",
+      branch: "feat-unknown",
+    });
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [readyRow, pendingRow, unknownRow],
+      // `pendingRow` is left out of the overlay entirely (still Checking);
+      // `unknownRow` is out of the overlay AND settled to an error (Unknown).
+      enrichedByPath: new Map([[readyRow.worktreePath, readyRow]]),
+      erroredPaths: new Set([unknownRow.worktreePath]),
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    const pills = screen.getAllByTestId("worktree-tier-pill");
+    const mergedPill = pills.find(
+      (pill) => pill.getAttribute("data-tier") === "merged",
+    );
+    const pendingPill = pills.find(
+      (pill) => pill.getAttribute("data-tier") === "pending",
+    );
+    const unknownPill = pills.find(
+      (pill) => pill.getAttribute("data-tier") === "unknown",
+    );
+    if (
+      mergedPill === undefined ||
+      pendingPill === undefined ||
+      unknownPill === undefined
+    ) {
+      throw new Error("expected merged, pending, and unknown pills");
+    }
+
+    // Neither pending nor unknown ever claims the proven-green treatment.
+    expect(mergedPill.className).toContain("emerald");
+    expect(pendingPill.className).not.toContain("emerald");
+    expect(unknownPill.className).not.toContain("emerald");
+
+    // Both read as visibly unresolved (dashed border), distinct from every
+    // resolved tier pill's solid border - and each still carries its own
+    // accessible text label, never color alone.
+    expect(pendingPill.className).toContain("border-dashed");
+    expect(unknownPill.className).toContain("border-dashed");
+    expect(mergedPill.className).not.toContain("border-dashed");
+    screen.getByText("Checking…");
+    screen.getByText("Unknown");
+  });
+
+  it("demotes the Task merge rollup to quiet text, distinct from the row's own tier pill", () => {
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [
+        entry({
+          worktreePath: "/wt/alpha",
+          branch: "feat-alpha",
+          owners: [
+            {
+              epicId: "epic-1",
+              ownerKind: "chat",
+              ownerId: "chat-1",
+              updatedAt: 1,
+            },
+          ],
+          prState: "merged",
+          prNumber: 20,
+          mergedHeadShaMatches: true,
+        }),
+      ],
+      taskTitlesByEpicId: new Map([["epic-1", "Payments revamp"]]),
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      onVisiblePathsChange: undefined,
+    });
+
+    const tierPill = screen.getByTestId("worktree-tier-pill");
+    const rollup = screen.getByTestId("task-merge-rollup");
+
+    // The rollup carries no icon and no Badge chrome (border/background) - it
+    // cannot be mistaken for the row's own loud worktree-tier signal, which
+    // keeps its icon and colored border.
+    expect(rollup.querySelector("svg")).toBeNull();
+    expect(rollup.className).not.toContain("border");
+    expect(rollup.className).not.toContain("bg-emerald");
+    expect(rollup.className).not.toContain("bg-amber");
+    expect(tierPill.querySelector("svg")).not.toBeNull();
+
+    // Wording scopes it to the Task, distinct from the row's own tier label -
+    // both happen to say "Merged" for different subjects, so the prefix is
+    // what keeps them from reading as the same claim.
+    expect(rollup.textContent).toBe("Task Merged");
+    expect(tierPill.textContent).not.toBe(rollup.textContent);
+  });
 });
 
 describe("WorktreesList virtualization + per-viewport enrichment", () => {
@@ -1980,10 +2423,15 @@ describe("WorktreesList virtualization + per-viewport enrichment", () => {
       taskTitlesByEpicId: undefined,
     });
 
-    // Base fields paint immediately (branch names, delete affordances).
+    // Base fields paint immediately (branch names, delete affordances) - the
+    // delete affordance is present but disabled while the row is Checking.
     screen.getByText("feat-a");
     screen.getByText("feat-b");
-    screen.getByRole("button", { name: "Delete worktree feat-a" });
+    expect(
+      screen.getAllByRole("button", {
+        name: "Delete worktree (status is still being checked)",
+      }),
+    ).toHaveLength(2);
     // Every tier pill is the neutral pending state - NOT a base-only tier that
     // would flip once the probes land. A base-only classify would call /wt/b
     // "Review"; it must not, while pending.
@@ -2059,9 +2507,11 @@ describe("WorktreesList virtualization + per-viewport enrichment", () => {
     fireEvent.click(screen.getByTestId("worktrees-filter-merged"));
 
     // The enriched Merged row stays; the still-pending row is KEPT (shown as
-    // "Checking…"), not dropped.
+    // "Checking…"), not dropped - its delete affordance is disabled, not absent.
     screen.getByRole("button", { name: "Delete worktree feat-merged" });
-    screen.getByRole("button", { name: "Delete worktree feat-pending" });
+    screen.getByRole("button", {
+      name: "Delete worktree (status is still being checked)",
+    });
     screen.getByText("Checking…");
   });
 
@@ -2183,5 +2633,343 @@ describe("WorktreesList virtualization + per-viewport enrichment", () => {
       screen.getByTestId("worktree-tier-pill").getAttribute("data-tier"),
     ).toBe("merged");
     expect(screen.queryByText("Unknown")).toBeNull();
+  });
+});
+
+describe("WorktreesList status-aware delete safety", () => {
+  afterEach(() => {
+    cleanup();
+    __resetWorktreeDeleteRunForTests();
+    streamMock.paths = [];
+    streamMock.callbacksByPath.clear();
+    toastMock.messages = [];
+  });
+
+  // Returns the tree directly (no intermediate wrapper component, unlike
+  // `renderList`'s locally-scoped `Wrapper`) so a later `.rerender(...)` call
+  // with this same helper keeps the SAME root element type across renders -
+  // required for React to preserve component state (selection,
+  // `pendingDeleteTargets`) instead of remounting the whole subtree.
+  function statusAwareElement(args: {
+    readonly queryClient: QueryClient;
+    readonly worktrees: readonly WorktreeHostEntryV11[];
+    readonly enrichedByPath: ReadonlyMap<string, WorktreeHostEntryV11>;
+    readonly erroredPaths: ReadonlySet<string>;
+  }): ReactNode {
+    return (
+      <QueryClientProvider client={args.queryClient}>
+        <TooltipProvider>
+          <WorktreesList
+            openStreamTransport={() => stubOpenStreamTransport()}
+            hostId="host-a"
+            worktrees={args.worktrees}
+            enrichedByPath={args.enrichedByPath}
+            erroredPaths={args.erroredPaths}
+            onVisiblePathsChange={vi.fn()}
+            taskTitlesByEpicId={new Map()}
+            toolbarProps={testToolbarProps()}
+          />
+        </TooltipProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  it("disables the row delete button while Checking and blocks the confirmation", () => {
+    const pendingRow = entry({
+      worktreePath: "/wt/pending",
+      branch: "feat-pending",
+    });
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [pendingRow],
+      // Never enriched - the row stays "Checking…" for the whole test.
+      enrichedByPath: new Map(),
+      erroredPaths: undefined,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    const deleteButton = screen.getByRole("button", {
+      name: "Delete worktree (status is still being checked)",
+    });
+    expect(deleteButton.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(deleteButton);
+    expect(screen.queryByText("Delete worktree?")).toBeNull();
+    expect(screen.queryByTestId("confirm-action")).toBeNull();
+  });
+
+  it("disables bulk delete and names how many selected rows are still Checking", () => {
+    const mergedRow = entry({
+      worktreePath: "/wt/merged",
+      branch: "feat-merged",
+      branchStatus: { ahead: 0, behind: 0, mergedIntoDefault: true },
+    });
+    const pendingRow = entry({
+      worktreePath: "/wt/pending",
+      branch: "feat-pending",
+    });
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [mergedRow, pendingRow],
+      enrichedByPath: new Map([[mergedRow.worktreePath, mergedRow]]),
+      erroredPaths: undefined,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    selectRows(["feat-merged", "feat-pending"]);
+
+    const deleteSelected = screen.getByTestId("worktrees-list-delete-selected");
+    expect(deleteSelected.hasAttribute("disabled")).toBe(true);
+    screen.getByText("1 selected worktree is still checking status");
+
+    fireEvent.click(deleteSelected);
+    expect(screen.queryByText(/^Delete \d+ worktrees\?$/)).toBeNull();
+  });
+
+  it("opens an unknown-risk confirmation for a settled-error row instead of the generic one", () => {
+    const erroredRow = entry({
+      worktreePath: "/wt/errored",
+      branch: "feat-errored",
+    });
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [erroredRow],
+      enrichedByPath: new Map(),
+      erroredPaths: new Set([erroredRow.worktreePath]),
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete worktree feat-errored" }),
+    );
+    screen.getByText("Delete worktree with unknown status?");
+    expect(screen.getByTestId("confirm-action").textContent).toContain(
+      "Delete anyway",
+    );
+
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(streamMock.paths).toEqual(["/wt/errored"]);
+  });
+
+  it("includes an unknown-risk caveat in the bulk summary when selected rows include an Unknown row", () => {
+    const mergedRow = entry({
+      worktreePath: "/wt/merged",
+      branch: "feat-merged",
+      branchStatus: { ahead: 0, behind: 0, mergedIntoDefault: true },
+    });
+    const erroredRow = entry({
+      worktreePath: "/wt/errored",
+      branch: "feat-errored",
+    });
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [mergedRow, erroredRow],
+      enrichedByPath: new Map([[mergedRow.worktreePath, mergedRow]]),
+      erroredPaths: new Set([erroredRow.worktreePath]),
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    selectRows(["feat-merged", "feat-errored"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+
+    screen.getByText("Delete 2 worktrees?");
+    screen.getByTestId("worktree-bulk-delete-unknown-caveat");
+
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect([...streamMock.paths].sort()).toEqual(["/wt/errored", "/wt/merged"]);
+  });
+
+  it("clears a stale single-row delete target that regresses to Checking, names it in the drop toast, and does not reopen once it settles", () => {
+    const readyRow = entry({ worktreePath: "/wt/ready", branch: "feat-ready" });
+    const queryClient = new QueryClient();
+    const rendered = render(
+      statusAwareElement({
+        queryClient,
+        worktrees: [readyRow],
+        enrichedByPath: new Map([[readyRow.worktreePath, readyRow]]),
+        erroredPaths: new Set(),
+      }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete worktree feat-ready" }),
+    );
+    screen.getByText("Delete worktree?");
+
+    // A refresh re-arms the row's enrichment while the confirmation is open -
+    // it regresses from ready back to Checking. The only pending target
+    // dropped to zero eligible rows, so the confirmation - which can no
+    // longer be trusted - closes, the drop is named, and the stale intent is
+    // cleared (not just visually hidden).
+    rendered.rerender(
+      statusAwareElement({
+        queryClient,
+        worktrees: [readyRow],
+        enrichedByPath: new Map(),
+        erroredPaths: new Set(),
+      }),
+    );
+
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    expect(streamMock.paths).toEqual([]);
+    expect(toastMock.messages.join("\n")).toContain("still checking status");
+
+    // The row later settles back to ready. Since the stale intent was already
+    // cleared (not merely hidden), the old confirmation must NOT silently
+    // reopen without the user choosing Delete again.
+    rendered.rerender(
+      statusAwareElement({
+        queryClient,
+        worktrees: [readyRow],
+        enrichedByPath: new Map([[readyRow.worktreePath, readyRow]]),
+        erroredPaths: new Set(),
+      }),
+    );
+
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    expect(screen.queryByText("Delete worktree?")).toBeNull();
+    expect(streamMock.paths).toEqual([]);
+  });
+
+  it("clears a stale bulk delete target set when every selected row regresses to Checking, and does not reopen once settled", () => {
+    const readyA = entry({ worktreePath: "/wt/a", branch: "feat-a" });
+    const readyB = entry({ worktreePath: "/wt/b", branch: "feat-b" });
+    const queryClient = new QueryClient();
+    const rendered = render(
+      statusAwareElement({
+        queryClient,
+        worktrees: [readyA, readyB],
+        enrichedByPath: new Map([
+          [readyA.worktreePath, readyA],
+          [readyB.worktreePath, readyB],
+        ]),
+        erroredPaths: new Set(),
+      }),
+    );
+
+    selectRows(["feat-a", "feat-b"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    screen.getByText("Delete 2 worktrees?");
+
+    // Both selected rows regress to Checking while the bulk confirmation is
+    // open - every pending target drops, unlike the mixed-drop case where a
+    // sibling stays eligible.
+    rendered.rerender(
+      statusAwareElement({
+        queryClient,
+        worktrees: [readyA, readyB],
+        enrichedByPath: new Map(),
+        erroredPaths: new Set(),
+      }),
+    );
+
+    expect(screen.queryByText("Delete 2 worktrees?")).toBeNull();
+    expect(screen.queryByTestId("worktree-bulk-delete-dialog")).toBeNull();
+    expect(streamMock.paths).toEqual([]);
+    expect(toastMock.messages.join("\n")).toContain("still checking status");
+
+    // Both rows later settle back to ready - the stale bulk intent was
+    // already cleared, so the old bulk confirmation must not reopen.
+    rendered.rerender(
+      statusAwareElement({
+        queryClient,
+        worktrees: [readyA, readyB],
+        enrichedByPath: new Map([
+          [readyA.worktreePath, readyA],
+          [readyB.worktreePath, readyB],
+        ]),
+        erroredPaths: new Set(),
+      }),
+    );
+
+    expect(screen.queryByText("Delete 2 worktrees?")).toBeNull();
+    expect(screen.queryByTestId("worktree-bulk-delete-dialog")).toBeNull();
+    expect(streamMock.paths).toEqual([]);
+  });
+
+  it("skips a row that regresses to Checking mid-dialog, names it in the drop toast, and still deletes its still-eligible sibling", () => {
+    const readyA = entry({ worktreePath: "/wt/a", branch: "feat-a" });
+    const readyB = entry({ worktreePath: "/wt/b", branch: "feat-b" });
+    const queryClient = new QueryClient();
+    const rendered = render(
+      statusAwareElement({
+        queryClient,
+        worktrees: [readyA, readyB],
+        enrichedByPath: new Map([
+          [readyA.worktreePath, readyA],
+          [readyB.worktreePath, readyB],
+        ]),
+        erroredPaths: new Set(),
+      }),
+    );
+
+    selectRows(["feat-a", "feat-b"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    screen.getByText("Delete 2 worktrees?");
+
+    // /wt/b regresses to Checking while the bulk confirmation is open; /wt/a
+    // stays ready.
+    rendered.rerender(
+      statusAwareElement({
+        queryClient,
+        worktrees: [readyA, readyB],
+        enrichedByPath: new Map([[readyA.worktreePath, readyA]]),
+        erroredPaths: new Set(),
+      }),
+    );
+
+    // Only one target remains eligible, so the dialog re-resolves to the
+    // single-row confirmation for /wt/a.
+    screen.getByText("Delete worktree?");
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    expect(streamMock.paths).toEqual(["/wt/a"]);
+    expect(toastMock.messages.join("\n")).toContain("still checking status");
+  });
+
+  it("names permanent dirty loss and unknown risk for an Unknown row with uncommitted changes", () => {
+    const dirtyErroredRow = entry({
+      worktreePath: "/wt/errored-dirty",
+      branch: "feat-errored-dirty",
+      uncommittedCount: 5,
+    });
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [dirtyErroredRow],
+      // Never enriched, but settled to an error - Unknown, not Checking. The
+      // uncommitted count is still known: it is a cheap base-listing field.
+      enrichedByPath: new Map(),
+      erroredPaths: new Set([dirtyErroredRow.worktreePath]),
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Delete worktree feat-errored-dirty",
+      }),
+    );
+
+    // Leads with the known, stronger dirty-loss warning...
+    screen.getByText("Discard 5 uncommitted changes?");
+    screen.getByText(/will be permanently lost/i);
+    expect(screen.getByTestId("confirm-action").textContent).toContain(
+      "Delete and discard",
+    );
+    // ...and still names the unverified branch/activity risk, rather than
+    // silently dropping it because a stronger warning already fired.
+    screen.getByText(/could not be verified/i);
+
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(streamMock.paths).toEqual(["/wt/errored-dirty"]);
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-virtualizer-test-utils.ts
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-virtualizer-test-utils.ts
@@ -1,0 +1,33 @@
+export const WORKTREE_TEST_VIRTUAL_ITEM_HEIGHT = 80;
+
+export function installWorktreeVirtualizerOffsetHeight(
+  getViewportHeight: () => number,
+): () => void {
+  const previousDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "offsetHeight",
+  );
+  Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+    configurable: true,
+    get(this: HTMLElement): number {
+      if (this.dataset.testid === "worktrees-virtual-scroll") {
+        return getViewportHeight();
+      }
+      if (this.hasAttribute("data-index")) {
+        return WORKTREE_TEST_VIRTUAL_ITEM_HEIGHT;
+      }
+      return 0;
+    },
+  });
+  return () => {
+    if (previousDescriptor === undefined) {
+      Reflect.deleteProperty(HTMLElement.prototype, "offsetHeight");
+      return;
+    }
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "offsetHeight",
+      previousDescriptor,
+    );
+  };
+}

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -1,14 +1,18 @@
 import {
+  memo,
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useReducer,
   useRef,
   useState,
+  useSyncExternalStore,
   type ReactNode,
+  type RefCallback,
 } from "react";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { defaultRangeExtractor, useVirtualizer } from "@tanstack/react-virtual";
 import { toast } from "sonner";
 import {
   AlertTriangle,
@@ -16,6 +20,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  Copy,
   CopyMinus,
   CopyPlus,
   FileSliders,
@@ -25,6 +30,7 @@ import {
   HelpCircle,
   ListFilter,
   Minus,
+  MoreHorizontal,
   RefreshCw,
   Search,
   Trash2,
@@ -70,6 +76,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
@@ -84,7 +91,6 @@ import {
 } from "@/components/ui/dialog";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
-import { CopyTextButton } from "@/components/copy-text-button";
 import { ScriptsReviewDialog } from "@/components/workspaces/scripts-review-dialog";
 import { type RepoScriptsSeed } from "@/components/workspaces/repo-scripts-form";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
@@ -92,6 +98,7 @@ import { useHostDirectoryList } from "@/hooks/host/use-host-directory-list-query
 import { useHostReachability } from "@/hooks/agent/use-host-reachability";
 import { useHostClientFor } from "@/hooks/host/use-host-client-for";
 import { useHostQuery } from "@/hooks/host/use-host-query";
+import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 import { useWorktreeDeleteStreamTransportFactory } from "@/lib/host/use-worktree-delete-stream-transport";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
@@ -140,6 +147,53 @@ const EMPTY_TASK_TITLES: ReadonlyMap<string, string> = new Map();
 const WORKTREE_ROW_ESTIMATE_PX = 88;
 const WORKTREE_REPO_HEADER_ESTIMATE_PX = 40;
 const WORKTREE_VIRTUAL_OVERSCAN = 8;
+
+// Scroll-viewport clearance for the floating selection action bar (see
+// `WorktreeSelectionActionBar`). The bar's real height is measured live via
+// `useObservedHeight` so a wrapped bar (narrow width, or the `Checking`
+// notice pushing it to two lines) still gets full clearance. `GAP_PX` covers
+// the bar's own `bottom-4` offset plus breathing room above it; `MIN_PX`
+// matches the bar's normal single-line height and only seeds the very first
+// frame, before the observer reports a real measurement.
+const WORKTREE_ACTION_BAR_GAP_PX = 32;
+const WORKTREE_ACTION_BAR_MIN_CLEARANCE_PX = 64;
+
+/**
+ * Live element-height observer: a callback ref plus `useSyncExternalStore` over
+ * a `ResizeObserver`, so the caller reads the CURRENT rendered height of
+ * whatever DOM node the ref attaches to - re-rendering exactly when that height
+ * changes (including back to 0 once the node unmounts). Mirrors the
+ * `useComposerNarrowObserver` pattern in
+ * `src/components/home/composer/composer-narrow-hooks.ts`; kept local here
+ * because nothing else in the app needs it yet.
+ */
+function useObservedHeight(): {
+  readonly ref: RefCallback<HTMLDivElement>;
+  readonly height: number;
+} {
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+  const ref = useCallback((nextElement: HTMLDivElement | null) => {
+    setElement(nextElement);
+  }, []);
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (element === null) return () => {};
+      const observer = new ResizeObserver(onStoreChange);
+      observer.observe(element);
+      return () => observer.disconnect();
+    },
+    [element],
+  );
+  const getSnapshot = useCallback(() => {
+    if (element === null) return 0;
+    return element.getBoundingClientRect().height;
+  }, [element]);
+  const getServerSnapshot = useCallback(() => 0, []);
+  return {
+    ref,
+    height: useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot),
+  };
+}
 
 /**
  * Host-wide worktree management. Lists every git worktree under the selected
@@ -223,7 +277,7 @@ function WorktreesToolbar(props: {
   });
 
   return (
-    <div className="flex flex-col gap-2 border-b border-border/40 bg-muted/20 px-5 py-3">
+    <div className="flex flex-col gap-2 border-b border-border/40 px-5 py-2.5">
       <div className="flex items-center justify-between gap-2">
         <HostSelect hosts={hosts} value={value} onChange={onChange} />
         <div
@@ -418,6 +472,13 @@ function WorktreeSortMenu(props: {
   );
 }
 
+/**
+ * Host picker - visible so the user always knows which host they're managing,
+ * but deliberately lower-emphasis than the search/filter/sort/refresh cluster:
+ * no border or filled background at rest, muted text, only gaining contrast on
+ * hover/open. It stays a real `Select` (keyboard-reachable, same interaction
+ * model), just styled to read as ambient context rather than a primary action.
+ */
 function HostSelect(props: {
   readonly hosts: readonly HostDirectoryEntry[];
   readonly value: string | null;
@@ -425,7 +486,12 @@ function HostSelect(props: {
 }): ReactNode {
   return (
     <Select value={props.value ?? undefined} onValueChange={props.onChange}>
-      <SelectTrigger size="sm" className="w-[min(60vw,15rem)]">
+      <SelectTrigger
+        size="sm"
+        aria-label="Select a host"
+        data-testid="worktrees-host-select"
+        className="w-[min(60vw,15rem)] border-transparent bg-transparent px-2 text-muted-foreground shadow-none hover:bg-accent/40 hover:text-foreground data-[state=open]:bg-accent/40 data-[state=open]:text-foreground dark:bg-transparent dark:hover:bg-accent/40"
+      >
         <SelectValue placeholder="Select a host" />
       </SelectTrigger>
       <SelectContent>
@@ -795,9 +861,14 @@ export function WorktreesList(props: {
     [mergedWorktrees],
   );
   const [searchText, setSearchText] = useState("");
+  const deferredSearchText = useDeferredValue(searchText);
   const [sortMode, setSortMode] = useState<WorktreeSortMode>("newest");
   const [tierFilters, setTierFilters] =
     useState<WorktreeTierFilterSet>(EMPTY_TIER_FILTER);
+  const searchHaystackByPath = useMemo(
+    () => buildWorktreeSearchHaystackByPath(worktrees, taskTitlesByEpicId),
+    [worktrees, taskTitlesByEpicId],
+  );
   // Only offer filter options for tiers actually present in this host's list.
   // Un-enriched rows have no known tier, so they cannot contribute an option -
   // the menu grows as rows scroll into view and enrich.
@@ -825,8 +896,8 @@ export function WorktreesList(props: {
   const filteredWorktrees = useMemo(() => {
     const searched = filterWorktrees(
       mergedWorktrees,
-      searchText,
-      taskTitlesByEpicId,
+      deferredSearchText,
+      searchHaystackByPath,
     );
     const effectiveTiers = new Set(
       availableTiers.filter((tier) => tierFilters.has(tier)),
@@ -839,8 +910,8 @@ export function WorktreesList(props: {
     );
   }, [
     mergedWorktrees,
-    searchText,
-    taskTitlesByEpicId,
+    deferredSearchText,
+    searchHaystackByPath,
     tierFilters,
     availableTiers,
     isPending,
@@ -906,16 +977,16 @@ export function WorktreesList(props: {
       ),
     [collapsedRepoKeys, groups],
   );
-  const visibleWorktreePathSet = useMemo(
-    () => new Set(mergedWorktrees.map((entry) => entry.worktreePath)),
-    [mergedWorktrees],
+  const listedWorktreePathSet = useMemo(
+    () => new Set(worktrees.map((entry) => entry.worktreePath)),
+    [worktrees],
   );
   useEffect(() => {
-    clearCompletedDeletedMissingFromList(visibleWorktreePathSet);
+    clearCompletedDeletedMissingFromList(listedWorktreePathSet);
   }, [
     backgrounded,
     clearCompletedDeletedMissingFromList,
-    visibleWorktreePathSet,
+    listedWorktreePathSet,
   ]);
   const backgroundedDeleteStatusByPath = useMemo(
     () =>
@@ -952,6 +1023,28 @@ export function WorktreesList(props: {
     [selectablePathSet, selectedPaths, visibleWorktrees],
   );
   const selectedCount = selectedTargets.length;
+  // Live-measured height of the floating selection action bar (see
+  // `WorktreeSelectionActionBar` / `WORKTREE_ACTION_BAR_GAP_PX`), so the scroll
+  // viewport's bottom clearance tracks the bar's REAL rendered height - including
+  // a wrapped two-line bar (narrow width, or the `Checking` notice) - instead of
+  // a fixed padding that can undershoot it.
+  const actionBarHeightObserver = useObservedHeight();
+  const actionBarClearancePx =
+    selectedCount > 0
+      ? Math.max(
+          actionBarHeightObserver.height + WORKTREE_ACTION_BAR_GAP_PX,
+          WORKTREE_ACTION_BAR_MIN_CLEARANCE_PX,
+        )
+      : 0;
+  // Selected rows whose tier isn't known yet - bulk delete is disabled while
+  // any exist (mirrors the single-row guard: pending status is not safe).
+  const checkingSelectedCount = useMemo(
+    () =>
+      selectedTargets.filter(
+        (entry) => enrichmentStateFor(entry.worktreePath) === "pending",
+      ).length,
+    [selectedTargets, enrichmentStateFor],
+  );
   // Freshest listing keyed by path, so a pending delete captured at dialog-open
   // is always re-resolved to its CURRENT entry (a background refresh may have
   // made a row in-use / mid-delete since the dialog opened).
@@ -961,11 +1054,14 @@ export function WorktreesList(props: {
   );
   // Re-resolve the pending targets against the freshest listing and split into
   // the rows still eligible to delete vs. the ones dropped (gone from the list,
-  // or now in-use / mid-delete). All selection is user-driven now, so the only
-  // confirm-time gate is "still selectable"; a hand-picked dirty / ahead row
-  // proceeds with its FRESHEST loss copy (per-row opt-in is intentional). Both
-  // the dialog copy and the confirm action read from this, so what the user sees
-  // is what gets deleted.
+  // now in-use / mid-delete, or regressed to `Checking`). All selection is
+  // user-driven now, so the remaining confirm-time gates are "still selectable"
+  // and "not Checking"; a hand-picked dirty / ahead row proceeds with its
+  // FRESHEST loss copy (per-row opt-in is intentional). Both the dialog copy
+  // and the confirm action read from this, so what the user sees is what gets
+  // deleted - a row that opened confirmation while ready/unknown but becomes
+  // `Checking` before confirm (e.g. a refresh re-arms its enrichment) must not
+  // delete, matching the rule that `Checking` rows are never deletable.
   const pendingResolution = useMemo(() => {
     if (pendingDeleteTargets === null) return null;
     const kept: WorktreeHostEntryV11[] = [];
@@ -976,20 +1072,59 @@ export function WorktreesList(props: {
         dropped.push(captured);
         continue;
       }
-      if (selectablePathSet.has(fresh.worktreePath)) kept.push(fresh);
+      const stillEligible =
+        selectablePathSet.has(fresh.worktreePath) &&
+        enrichmentStateFor(fresh.worktreePath) !== "pending";
+      if (stillEligible) kept.push(fresh);
       else dropped.push(fresh);
     }
     return { kept, dropped };
-  }, [pendingDeleteTargets, selectablePathSet, worktreesByPath]);
+  }, [
+    pendingDeleteTargets,
+    selectablePathSet,
+    worktreesByPath,
+    enrichmentStateFor,
+  ]);
   const keptDeleteTargets = pendingResolution?.kept ?? null;
-  const singleDialogCopy =
+  const singleDeleteTarget =
     keptDeleteTargets !== null && keptDeleteTargets.length === 1
-      ? deleteDialogCopy(keptDeleteTargets[0])
+      ? keptDeleteTargets[0]
       : null;
+  const singleDialogCopy =
+    singleDeleteTarget === null
+      ? null
+      : singleWorktreeDeleteDialogCopy(
+          singleDeleteTarget,
+          enrichmentStateFor(singleDeleteTarget.worktreePath),
+        );
   const bulkDeleteSummary =
     keptDeleteTargets !== null && keptDeleteTargets.length > 1
-      ? summarizeBulkWorktreeDelete(keptDeleteTargets, visibleWorktrees)
+      ? summarizeBulkWorktreeDelete(
+          keptDeleteTargets,
+          visibleWorktrees,
+          erroredPaths,
+        )
       : null;
+  // A non-null resolution that drops EVERY pending target (most commonly
+  // because they all regressed to `Checking`) never renders a dialog -
+  // `singleDialogCopy` and `bulkDeleteSummary` are both null for zero kept
+  // targets - so nothing else clears `pendingDeleteTargets`. Left alone, that
+  // stale intent would silently reopen the old confirmation once the rows
+  // settle back to ready/unknown, without the user choosing Delete again.
+  // Clear it and tell the user why, using the same skipped-row message the
+  // confirm-time drop path uses.
+  useEffect(() => {
+    if (pendingResolution === null) return;
+    const { kept, dropped } = pendingResolution;
+    if (kept.length > 0 || dropped.length === 0) return;
+    toast.message(
+      worktreeDropMessage(
+        dropped,
+        (worktreePath) => enrichmentStateFor(worktreePath) === "pending",
+      ),
+    );
+    setPendingDeleteTargets(null);
+  }, [pendingResolution, enrichmentStateFor]);
   const progressSummary = useMemo(
     () => summarizeWorktreeDeleteRuns(runs),
     [runs],
@@ -1058,14 +1193,35 @@ export function WorktreesList(props: {
   }, [allReposCollapsed, repoKeys]);
   const requestDeleteTargets = useCallback(
     (targets: ReadonlyArray<WorktreeHostEntryV11>) => {
-      const deletableTargets = targets.filter((entry) =>
-        selectablePathSet.has(entry.worktreePath),
+      // A `Checking` row's tier isn't known yet, so it never opens a delete
+      // confirmation - not even a generic one - until enrichment settles.
+      const deletableTargets = targets.filter(
+        (entry) =>
+          selectablePathSet.has(entry.worktreePath) &&
+          enrichmentStateFor(entry.worktreePath) !== "pending",
       );
       if (deletableTargets.length === 0) return;
       setPendingDeleteTargets(deletableTargets);
     },
-    [selectablePathSet],
+    [selectablePathSet, enrichmentStateFor],
   );
+  const requestDeleteTarget = useCallback(
+    (target: WorktreeHostEntryV11) => {
+      requestDeleteTargets([target]);
+    },
+    [requestDeleteTargets],
+  );
+  const requestDeleteSelectedTargets = useCallback(() => {
+    requestDeleteTargets(selectedTargets);
+  }, [requestDeleteTargets, selectedTargets]);
+  const openScriptReviewFor = useCallback((target: WorktreeHostEntryV11) => {
+    const reviewedScriptsByPath = reviewedScriptsByPathRef.current;
+    setPendingScriptReview({
+      target,
+      scripts:
+        reviewedScriptsByPath?.get(target.worktreePath) ?? target.scripts,
+    });
+  }, []);
 
   const clearSelectionForTargets = (
     targets: ReadonlyArray<WorktreeHostEntryV11>,
@@ -1077,11 +1233,17 @@ export function WorktreesList(props: {
   const handleConfirm = (): void => {
     if (pendingResolution === null || pendingDeleteTargets === null) return;
     // `pendingResolution` already re-resolved each pending path to its freshest
-    // entry and split kept vs. dropped (gone from the list, or now in-use /
-    // mid-delete). Start the run on the FRESHEST kept entries, and name the drops.
+    // entry and split kept vs. dropped (gone from the list, now in-use / mid-
+    // delete, or regressed to Checking). Start the run on the FRESHEST kept
+    // entries, and name the drops.
     const { kept, dropped } = pendingResolution;
     if (dropped.length > 0) {
-      toast.message(worktreeDropMessage(dropped));
+      toast.message(
+        worktreeDropMessage(
+          dropped,
+          (worktreePath) => enrichmentStateFor(worktreePath) === "pending",
+        ),
+      );
     }
     if (kept.length === 1) {
       start(kept[0], reviewedScriptsByPath.get(kept[0].worktreePath) ?? null);
@@ -1128,22 +1290,58 @@ export function WorktreesList(props: {
     () => buildWorktreeFlatItems(groups, collapsedRepoKeys),
     [groups, collapsedRepoKeys],
   );
+  const stickyHeaderIndexes = useMemo(
+    () =>
+      flatItems.flatMap((item, index) =>
+        item.kind === "header" ? [index] : [],
+      ),
+    [flatItems],
+  );
   const scrollParentRef = useRef<HTMLDivElement>(null);
+  const getScrollElement = useCallback(() => scrollParentRef.current, []);
+  const estimateVirtualItemSize = useCallback(
+    (index: number) =>
+      flatItems[index].kind === "header"
+        ? WORKTREE_REPO_HEADER_ESTIMATE_PX
+        : WORKTREE_ROW_ESTIMATE_PX,
+    [flatItems],
+  );
+  const getVirtualItemKey = useCallback(
+    (index: number) => worktreeFlatItemKey(flatItems[index]),
+    [flatItems],
+  );
+  const activeStickyHeaderIndexRef = useRef<number | null>(null);
+  const extractWorktreeVirtualRange = useCallback<typeof defaultRangeExtractor>(
+    (range) => {
+      if (stickyHeaderIndexes.length === 0) {
+        activeStickyHeaderIndexRef.current = null;
+        return defaultRangeExtractor(range);
+      }
+      const activeHeaderIndex = stickyHeaderIndexes.reduce(
+        (latest, index) => (index <= range.startIndex ? index : latest),
+        stickyHeaderIndexes[0],
+      );
+      activeStickyHeaderIndexRef.current = activeHeaderIndex;
+      return [
+        ...new Set([activeHeaderIndex, ...defaultRangeExtractor(range)]),
+      ].sort((left, right) => left - right);
+    },
+    [stickyHeaderIndexes],
+  );
   // `useVirtualizer` returns fresh function identities each render; the React
   // Compiler already skips memoizing this component for it, and this component
   // memoizes its own derived data with `useMemo`, so the compat warning is noise.
   // eslint-disable-next-line react-hooks/incompatible-library
   const virtualizer = useVirtualizer({
     count: flatItems.length,
-    getScrollElement: () => scrollParentRef.current,
-    estimateSize: (index) =>
-      flatItems[index].kind === "header"
-        ? WORKTREE_REPO_HEADER_ESTIMATE_PX
-        : WORKTREE_ROW_ESTIMATE_PX,
-    getItemKey: (index) => worktreeFlatItemKey(flatItems[index]),
+    getScrollElement,
+    estimateSize: estimateVirtualItemSize,
+    getItemKey: getVirtualItemKey,
+    rangeExtractor: extractWorktreeVirtualRange,
     overscan: WORKTREE_VIRTUAL_OVERSCAN,
   });
   const virtualItems = virtualizer.getVirtualItems();
+  const isVirtualizerScrolling = virtualizer.isScrolling;
   // The worktree paths actually on screen right now - the driver of per-viewport
   // enrichment. Repo-header items carry no path. Keyed by the joined string so the
   // report fires only when the on-screen SET changes, not on every scroll tick
@@ -1162,10 +1360,16 @@ export function WorktreesList(props: {
   const onScreenPathsKey = onScreenPaths.join("\n");
   const lastReportedPathsRef = useRef<string | null>(null);
   useEffect(() => {
+    if (isVirtualizerScrolling) return;
     if (lastReportedPathsRef.current === onScreenPathsKey) return;
     lastReportedPathsRef.current = onScreenPathsKey;
     onVisiblePathsChange(onScreenPaths);
-  }, [onScreenPathsKey, onScreenPaths, onVisiblePathsChange]);
+  }, [
+    isVirtualizerScrolling,
+    onScreenPathsKey,
+    onScreenPaths,
+    onVisiblePathsChange,
+  ]);
 
   return (
     <WorktreeListRenderProfiler
@@ -1192,10 +1396,17 @@ export function WorktreesList(props: {
         <WorktreesToolbar
           {...props.toolbarProps}
           selectionControls={
-            <WorktreesRepoExpansionControl
-              allCollapsed={allReposCollapsed}
-              onToggle={toggleAllReposCollapsed}
-            />
+            <>
+              <WorktreeSelectAllToggle
+                selectableCount={selectableWorktreePaths.length}
+                selectedCount={selectedCount}
+                onToggle={toggleSelectAllVisible}
+              />
+              <WorktreesRepoExpansionControl
+                allCollapsed={allReposCollapsed}
+                onToggle={toggleAllReposCollapsed}
+              />
+            </>
           }
           filterControls={
             <WorktreesFilterControls
@@ -1210,108 +1421,126 @@ export function WorktreesList(props: {
             />
           }
         />
-        <WorktreeSelectionActionBar
-          selectedCount={selectedCount}
-          onDelete={() => {
-            requestDeleteTargets(selectedTargets);
-          }}
-          onClear={clearSelection}
-        />
         <WorktreeDeleteProgressStrip
           summary={progressSummary}
           onDismiss={dismissTerminalBackgrounded}
         />
 
-        {groups.length === 0 ? null : (
-          <WorktreeSelectAllHeader
-            selectableCount={selectableWorktreePaths.length}
-            selectedCount={selectedCount}
-            onToggle={toggleSelectAllVisible}
-          />
-        )}
-
-        <div
-          ref={scrollParentRef}
-          data-testid="worktrees-virtual-scroll"
-          className="min-h-0 flex-1 overflow-y-auto"
-        >
-          {groups.length === 0 ? (
-            <WorktreesStateMessage tone="muted" spinner={false}>
-              No worktrees match your search.
-            </WorktreesStateMessage>
-          ) : (
-            <div
-              className="relative w-full"
-              style={{ height: `${virtualizer.getTotalSize()}px` }}
-            >
-              {virtualItems.map((virtualItem) => {
-                const item = flatItems[virtualItem.index];
-                return (
-                  <div
-                    key={virtualItem.key}
-                    data-index={virtualItem.index}
-                    ref={virtualizer.measureElement}
-                    className="absolute top-0 left-0 w-full"
-                    style={{ transform: `translateY(${virtualItem.start}px)` }}
-                  >
-                    {item.kind === "header" ? (
-                      <div
-                        className={cn(
-                          item.showDivider && "border-t border-border/40",
-                        )}
-                      >
-                        <WorktreeRepoHeader
-                          label={item.group.label}
-                          count={item.group.items.length}
-                          collapsed={item.collapsed}
-                          onToggle={() =>
-                            toggleRepoCollapsed(item.group, item.collapsed)
-                          }
-                        />
-                      </div>
-                    ) : (
-                      <div
-                        className={cn(
-                          !item.firstInGroup && "border-t border-border/30",
-                        )}
-                      >
-                        <WorktreeRow
-                          entry={item.entry}
-                          enrichment={enrichmentStateFor(
-                            item.entry.worktreePath,
+        {/*
+         * Relatively-positioned wrapper so the contextual selection bar can be
+         * anchored to the bottom of the list as an ABSOLUTELY-positioned
+         * overlay. Being out of flow means its mount/unmount when a selection
+         * starts or clears never shifts the scroll region or the rows inside
+         * it - the "no inserted top bar" product rule holds regardless of
+         * selection state.
+         */}
+        <div className="relative min-h-0 flex-1">
+          <div
+            ref={scrollParentRef}
+            data-testid="worktrees-virtual-scroll"
+            className="absolute inset-0 overflow-y-auto"
+            style={
+              actionBarClearancePx > 0
+                ? { paddingBottom: actionBarClearancePx }
+                : undefined
+            }
+          >
+            {groups.length === 0 ? (
+              <WorktreesStateMessage tone="muted" spinner={false}>
+                No worktrees match your search.
+              </WorktreesStateMessage>
+            ) : (
+              <div
+                className="relative w-full"
+                style={{ height: `${virtualizer.getTotalSize()}px` }}
+              >
+                {virtualItems.map((virtualItem) => {
+                  const item = flatItems[virtualItem.index];
+                  const isStickyHeader =
+                    item.kind === "header" &&
+                    virtualItem.index === activeStickyHeaderIndexRef.current;
+                  return (
+                    <div
+                      key={virtualItem.key}
+                      data-index={virtualItem.index}
+                      ref={virtualizer.measureElement}
+                      className={cn(
+                        "left-0 w-full",
+                        isStickyHeader
+                          ? "sticky top-0 z-30 bg-background"
+                          : "absolute top-0",
+                      )}
+                      style={
+                        isStickyHeader
+                          ? undefined
+                          : {
+                              transform: `translateY(${virtualItem.start}px)`,
+                            }
+                      }
+                    >
+                      {item.kind === "header" ? (
+                        <div
+                          className={cn(
+                            "bg-background",
+                            item.showDivider && "border-t border-border/40",
                           )}
-                          taskTitlesByEpicId={taskTitlesByEpicId}
-                          taskRollupByEpicId={taskRollupByEpicId}
-                          deleteStatus={
-                            backgroundedDeleteStatusByPath.get(
+                        >
+                          <WorktreeRepoHeader
+                            group={item.group}
+                            collapsed={item.collapsed}
+                            onToggle={toggleRepoCollapsed}
+                          />
+                        </div>
+                      ) : (
+                        <div
+                          className={cn(
+                            !item.firstInGroup && "border-t border-border/30",
+                          )}
+                        >
+                          <WorktreeRow
+                            entry={item.entry}
+                            enrichment={enrichmentStateFor(
                               item.entry.worktreePath,
-                            ) ?? null
-                          }
-                          selected={selectedPaths.has(item.entry.worktreePath)}
-                          canSelect={selectablePathSet.has(
-                            item.entry.worktreePath,
-                          )}
-                          onToggleSelection={() =>
-                            toggleSelection(item.entry.worktreePath)
-                          }
-                          onManageScripts={() =>
-                            setPendingScriptReview({
-                              target: item.entry,
-                              scripts:
-                                reviewedScriptsByPath.get(
-                                  item.entry.worktreePath,
-                                ) ?? item.entry.scripts,
-                            })
-                          }
-                          onDelete={() => requestDeleteTargets([item.entry])}
-                        />
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+                            )}
+                            taskTitlesByEpicId={taskTitlesByEpicId}
+                            taskRollupByEpicId={taskRollupByEpicId}
+                            deleteStatus={
+                              backgroundedDeleteStatusByPath.get(
+                                item.entry.worktreePath,
+                              ) ?? null
+                            }
+                            selected={selectedPaths.has(
+                              item.entry.worktreePath,
+                            )}
+                            canSelect={selectablePathSet.has(
+                              item.entry.worktreePath,
+                            )}
+                            onToggleSelection={toggleSelection}
+                            onManageScripts={openScriptReviewFor}
+                            onDelete={requestDeleteTarget}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+          {selectedCount > 0 ? (
+            <div
+              ref={actionBarHeightObserver.ref}
+              className="absolute inset-x-8 bottom-4 z-30 flex flex-wrap items-center gap-3 rounded-lg border border-border/80 bg-popover px-5 py-3 shadow-2xl ring-1 ring-foreground/10"
+              data-testid="worktrees-selection-action-bar"
+            >
+              <WorktreeSelectionActionBar
+                selectedCount={selectedCount}
+                checkingCount={checkingSelectedCount}
+                onDelete={requestDeleteSelectedTargets}
+                onClear={clearSelection}
+              />
             </div>
-          )}
+          ) : null}
         </div>
 
         <ConfirmDestructiveDialog
@@ -1381,14 +1610,16 @@ function WorktreeDeleteProgressStrip(props: {
 }
 
 /**
- * Standard tri-state global select-all header - one row above the list, its
- * checkbox aligned with the row checkboxes. Selects/deselects every CURRENTLY-
- * VISIBLE, selectable row (post-filter + post-search, across all repo groups).
- * Indeterminate when some-but-not-all are selected; disabled when nothing
- * selectable. In-use / mid-delete rows keep disabled row checkboxes and are
- * excluded here (standard table behavior).
+ * Standard tri-state select-all - lives as a quiet toggle in the persistent
+ * toolbar action group (next to Collapse/Expand all and Refresh) instead of a
+ * dedicated header row above the list, so there is no permanent chrome bar
+ * sitting before the content. Selects/deselects every CURRENTLY-VISIBLE,
+ * selectable row (post-filter + post-search, across all repo groups, minus
+ * collapsed groups). Indeterminate when some-but-not-all are selected;
+ * disabled when nothing is selectable. In-use / mid-delete rows are excluded
+ * from the selectable count (standard table behavior).
  */
-function WorktreeSelectAllHeader(props: {
+function WorktreeSelectAllToggle(props: {
   readonly selectableCount: number;
   readonly selectedCount: number;
   readonly onToggle: () => void;
@@ -1401,29 +1632,37 @@ function WorktreeSelectAllHeader(props: {
   let indicator: ReactNode = null;
   if (allSelected) indicator = <Check className="size-3" />;
   else if (indeterminate) indicator = <Minus className="size-3" />;
+  const label = "Select all visible worktrees";
   return (
-    <div className="flex items-center gap-3 border-b border-border/40 bg-muted/10 px-5 py-1.5">
-      <div className="flex w-5 shrink-0 items-center justify-center">
-        <button
-          type="button"
-          role="checkbox"
-          aria-checked={ariaChecked}
-          aria-label="Select all worktrees"
-          data-testid="worktrees-select-all"
-          disabled={props.selectableCount === 0}
-          onClick={props.onToggle}
-          className={cn(
-            "flex size-4 items-center justify-center rounded-sm border transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
-            allSelected || indeterminate
-              ? "border-primary bg-primary text-primary-foreground"
-              : "border-border bg-background text-transparent hover:border-foreground",
-          )}
-        >
-          {indicator}
-        </button>
-      </div>
-      <span className="text-ui-xs text-muted-foreground">Select all</span>
-    </div>
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={ariaChecked}
+      aria-label={label}
+      title={label}
+      data-testid="worktrees-select-all"
+      disabled={props.selectableCount === 0}
+      onClick={props.onToggle}
+      className={cn(
+        "flex h-7 shrink-0 items-center gap-1.5 rounded-sm border px-2 text-ui-xs font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
+        allSelected || indeterminate
+          ? "border-border bg-muted text-foreground"
+          : "border-border bg-background text-muted-foreground hover:border-foreground hover:bg-muted hover:text-foreground",
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "flex size-3.5 items-center justify-center rounded-[0.1875rem] border",
+          allSelected || indeterminate
+            ? "border-foreground/70 bg-foreground text-background"
+            : "border-muted-foreground/50",
+        )}
+      >
+        {indicator}
+      </span>
+      <span>Select all</span>
+    </button>
   );
 }
 
@@ -1437,24 +1676,55 @@ function worktreeSelectAllAriaChecked(
 }
 
 /**
- * Contextual action bar - present ONLY while a selection is active (empty =
- * absent, so the page has no permanent selection chrome). Shows the count, a
- * destructive "Delete N…" primary action, and a "Clear".
+ * Contextual action bar content - present ONLY while a selection is active
+ * (empty = absent, so the page has no permanent selection chrome). The caller
+ * (`WorktreesList`) wraps this in the absolutely-positioned overlay div that
+ * floats over the BOTTOM of the list (out of flow, so mounting/unmounting
+ * while selecting/clearing never shifts row positions) and owns the ref that
+ * measures that wrapper's real height - see `useObservedHeight` and
+ * `WORKTREE_ACTION_BAR_GAP_PX`. Shows the count, a destructive "Delete N…"
+ * primary action, and a "Clear". While one or more selected rows are still
+ * `Checking` their tier isn't known yet, so bulk delete is disabled and a
+ * notice names how many are still pending - the same "pending status is not
+ * safe" rule the single-row delete button enforces.
  */
 function WorktreeSelectionActionBar(props: {
   readonly selectedCount: number;
+  readonly checkingCount: number;
   readonly onDelete: () => void;
   readonly onClear: () => void;
 }): ReactNode {
-  if (props.selectedCount === 0) return null;
-  return (
-    <div
-      className="flex flex-wrap items-center gap-3 border-b border-border/40 bg-muted/20 px-5 py-2"
-      data-testid="worktrees-selection-action-bar"
+  const blockedByChecking = props.checkingCount > 0;
+  const selectedWorktreeNoun =
+    props.selectedCount === 1 ? "worktree" : "worktrees";
+  const deleteButton = (
+    <Button
+      type="button"
+      variant="destructive"
+      size="sm"
+      disabled={blockedByChecking}
+      onClick={props.onDelete}
+      aria-label={`Delete ${props.selectedCount} selected ${selectedWorktreeNoun}`}
+      data-testid="worktrees-list-delete-selected"
+      className="shrink-0 whitespace-nowrap"
     >
+      <Trash2 className="size-4" />
+      Delete {props.selectedCount} {selectedWorktreeNoun}
+    </Button>
+  );
+  return (
+    <>
       <span className="text-ui-sm font-medium text-foreground">
         {props.selectedCount} selected
       </span>
+      {blockedByChecking ? (
+        <span
+          className="text-ui-xs text-muted-foreground"
+          data-testid="worktrees-selection-checking-notice"
+        >
+          {worktreeCheckingNoticeText(props.checkingCount)}
+        </span>
+      ) : null}
       <div className="ml-auto flex items-center gap-1">
         <Button
           type="button"
@@ -1466,20 +1736,26 @@ function WorktreeSelectionActionBar(props: {
           <X className="size-4" />
           Clear
         </Button>
-        <Button
-          type="button"
-          variant="destructive"
-          size="sm"
-          onClick={props.onDelete}
-          aria-label={`Delete ${props.selectedCount} selected worktrees`}
-          data-testid="worktrees-list-delete-selected"
-        >
-          <Trash2 className="size-4" />
-          Delete {props.selectedCount}…
-        </Button>
+        {blockedByChecking ? (
+          <TooltipWrapper
+            label={worktreeCheckingNoticeText(props.checkingCount)}
+            side="top"
+            sideOffset={undefined}
+            align="end"
+          >
+            <span className="inline-flex shrink-0">{deleteButton}</span>
+          </TooltipWrapper>
+        ) : (
+          deleteButton
+        )}
       </div>
-    </div>
+    </>
   );
+}
+
+function worktreeCheckingNoticeText(checkingCount: number): string {
+  const plural = checkingCount === 1 ? "worktree is" : "worktrees are";
+  return `${checkingCount} selected ${plural} still checking status`;
 }
 
 /**
@@ -1529,6 +1805,14 @@ function WorktreeBulkDeleteDialog(props: {
                     data-testid="worktree-bulk-delete-caveat"
                   >
                     {summary.unverifiedCaveat}
+                  </p>
+                ) : null}
+                {summary.unknownRiskCaveat !== null ? (
+                  <p
+                    className="text-ui-sm leading-relaxed text-amber-700 dark:text-amber-400"
+                    data-testid="worktree-bulk-delete-unknown-caveat"
+                  >
+                    {summary.unknownRiskCaveat}
                   </p>
                 ) : null}
                 {summary.exclusions !== null ? (
@@ -1590,40 +1874,68 @@ type WorktreeScriptReviewDraft = {
   readonly scripts: RepoScriptsSeed | null;
 };
 
-function WorktreeRepoHeader(props: {
-  readonly label: string;
-  readonly count: number;
+/**
+ * Repo group header - a quiet sticky divider, not a second status row: no
+ * filled high-emphasis background, and muted/regular-weight text so it never
+ * competes with a row's bold branch name or colored tier pill. Collapse/expand
+ * stays a full-width button for a generous hit target; the chevron carries the
+ * only state-change affordance.
+ */
+const WorktreeRepoHeader = memo(function WorktreeRepoHeader(props: {
+  readonly group: WorktreeRepoGroup;
   readonly collapsed: boolean;
-  readonly onToggle: () => void;
+  readonly onToggle: (group: WorktreeRepoGroup, collapsed: boolean) => void;
 }): ReactNode {
-  const action = props.collapsed ? "Expand" : "Collapse";
+  const { collapsed, group, onToggle } = props;
+  const handleToggle = useCallback(() => {
+    onToggle(group, collapsed);
+  }, [onToggle, group, collapsed]);
+  const action = collapsed ? "Expand" : "Collapse";
   return (
     <button
       type="button"
-      aria-expanded={!props.collapsed}
-      aria-label={`${action} ${props.label}`}
-      className="flex w-full min-w-0 items-center gap-2 bg-muted/30 px-5 py-2 text-left transition-colors hover:bg-accent/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
-      onClick={props.onToggle}
+      aria-expanded={!collapsed}
+      aria-label={`${action} ${group.label}`}
+      data-testid="worktree-repo-header"
+      className="flex w-full min-w-0 items-center gap-2 border-b border-border/40 bg-background px-5 py-1.5 text-left transition-colors hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50"
+      onClick={handleToggle}
     >
       <ChevronRight
         className={cn(
           "size-3.5 shrink-0 text-muted-foreground transition-transform",
-          !props.collapsed && "rotate-90",
+          !collapsed && "rotate-90",
         )}
         aria-hidden
       />
-      <FolderGit2 className="size-4 shrink-0 text-muted-foreground" />
-      <span className="min-w-0 flex-1 truncate text-ui-sm font-medium text-foreground">
-        {props.label}
+      <FolderGit2 className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate text-ui-sm font-normal text-muted-foreground">
+        {group.label}
       </span>
       <span className="shrink-0 text-ui-xs text-muted-foreground">
-        {props.count}
+        {group.items.length}
       </span>
     </button>
   );
+});
+
+/**
+ * Why a row's delete affordance is disabled, if at all - `in-use` takes
+ * priority (it also blocks selection), then `checking` (a `Checking` row's
+ * tier isn't known yet, so its delete confirmation can't be trusted). An
+ * `Unknown` row (settled enrichment error) is NOT disabled here - it is still
+ * deletable, just through the unknown-risk confirmation instead of the
+ * generic one.
+ */
+function worktreeDeleteDisabledReason(
+  entry: WorktreeHostEntryV11,
+  enrichment: WorktreeEnrichmentState,
+): "in-use" | "checking" | null {
+  if (entry.inUse) return "in-use";
+  if (enrichment === "pending") return "checking";
+  return null;
 }
 
-function WorktreeRow(props: {
+const WorktreeRow = memo(function WorktreeRow(props: {
   readonly entry: WorktreeHostEntryV11;
   // This row's activity-enrichment state, driving the tier pill: `pending` (still
   // in flight → "Checking…"), `unknown` (settled to error → non-animated fallback),
@@ -1634,9 +1946,9 @@ function WorktreeRow(props: {
   readonly deleteStatus: WorktreeRowDeleteStatus | null;
   readonly selected: boolean;
   readonly canSelect: boolean;
-  readonly onToggleSelection: () => void;
-  readonly onManageScripts: () => void;
-  readonly onDelete: () => void;
+  readonly onToggleSelection: (worktreePath: string) => void;
+  readonly onManageScripts: (target: WorktreeHostEntryV11) => void;
+  readonly onDelete: (target: WorktreeHostEntryV11) => void;
 }): ReactNode {
   const {
     entry,
@@ -1653,6 +1965,23 @@ function WorktreeRow(props: {
   const deleting = deleteStatus !== null;
   const selectedForDelete = selected && canSelect;
   const classification = classifyWorktree(entry);
+  const toggleSelection = useCallback(() => {
+    onToggleSelection(entry.worktreePath);
+  }, [onToggleSelection, entry.worktreePath]);
+  const manageScripts = useCallback(() => {
+    onManageScripts(entry);
+  }, [onManageScripts, entry]);
+  const deleteWorktree = useCallback(() => {
+    onDelete(entry);
+  }, [onDelete, entry]);
+  const { copy: copyToClipboard } = useClipboardCopy({
+    resetMs: 2000,
+    onSuccess: () => toast.success("Copied worktree path"),
+    onError: () => toast.error("Couldn't copy path to clipboard."),
+  });
+  const copyPath = useCallback(() => {
+    copyToClipboard(entry.worktreePath);
+  }, [copyToClipboard, entry.worktreePath]);
   return (
     <div
       aria-busy={deleting}
@@ -1660,7 +1989,7 @@ function WorktreeRow(props: {
       className={cn(
         "group/worktree-row relative flex items-center gap-3 px-5 py-3 transition-colors",
         deleting ? "pointer-events-none opacity-50" : "hover:bg-accent/30",
-        selectedForDelete && "bg-accent/40 ring-1 ring-inset ring-primary/40",
+        selectedForDelete && "bg-muted/25",
       )}
     >
       <div className="flex w-5 shrink-0 items-center justify-center">
@@ -1669,7 +1998,7 @@ function WorktreeRow(props: {
           selected={selected}
           canSelect={canSelect}
           deleting={deleting}
-          onToggleSelection={onToggleSelection}
+          onToggleSelection={toggleSelection}
         />
       </div>
       <div className="min-w-0 flex-1 space-y-1 pr-10">
@@ -1689,10 +2018,6 @@ function WorktreeRow(props: {
             taskTitlesByEpicId={taskTitlesByEpicId}
             taskRollupByEpicId={taskRollupByEpicId}
           />
-          <WorktreePathAffordance
-            worktreePath={entry.worktreePath}
-            disabled={deleting}
-          />
         </div>
       </div>
       {deleting ? (
@@ -1707,16 +2032,18 @@ function WorktreeRow(props: {
       ) : null}
       {!deleting ? (
         <WorktreeRowActions
-          inUse={entry.inUse}
-          onManageScripts={onManageScripts}
-          onDelete={onDelete}
+          deleteDisabledReason={worktreeDeleteDisabledReason(entry, enrichment)}
+          onCopyPath={copyPath}
+          onManageScripts={manageScripts}
+          onDelete={deleteWorktree}
+          triggerLabel={`Worktree actions for ${branchLabel(entry)}`}
           label={`Delete worktree ${branchLabel(entry)}`}
-          scriptsLabel={`Manage scripts for worktree ${branchLabel(entry)}`}
+          scriptsLabel="Manage script"
         />
       ) : null}
     </div>
   );
-}
+});
 
 /**
  * Evidence-tier pill. Leads every row with a TEXT label (never color-only, for
@@ -1728,9 +2055,10 @@ function WorktreeTierPill(props: {
   readonly tier: WorktreeTier;
   readonly state: WorktreeEnrichmentState;
 }): ReactNode {
-  // While the activity probe is still in flight the tier isn't known yet - show a
-  // neutral "Checking…" spinner rather than a base-only tier that would flip (e.g.
-  // Review -> Merged) once the probes land.
+  // While the activity probe is still in flight the tier isn't known yet. A
+  // dashed border + full-contrast text (never the muted/faded treatment a
+  // resolved-safe pill would use) reads as "still resolving", not "quiet and
+  // fine" - pending status is not safe, so it must not look neutral-safe.
   if (props.state === "pending") {
     return (
       <TooltipWrapper
@@ -1741,7 +2069,7 @@ function WorktreeTierPill(props: {
       >
         <Badge
           variant="outline"
-          className="gap-1 font-medium border-border/40 bg-muted/30 text-muted-foreground"
+          className="gap-1 font-medium border-dashed border-border bg-muted/40 text-foreground"
           data-testid="worktree-tier-pill"
           data-tier="pending"
         >
@@ -1758,7 +2086,10 @@ function WorktreeTierPill(props: {
   // The probe SETTLED to an error (host unreachable, gh/git probe timed out). The
   // tier stays unknowable, so read a static "Unknown" - NEVER an infinite spinner.
   // Like a pending row, this row is excluded from the green / tier-filtered cohorts
-  // upstream; a refresh or scrolling it back into view retries the probe.
+  // upstream; a refresh or scrolling it back into view retries the probe. Styled in
+  // the same caution family the unknown-risk delete confirmation already uses
+  // (amber), but with a dashed border and a distinct icon/label so it never reads
+  // as the proven "Review" tier - this is unresolved, not a confirmed risk finding.
   if (props.state === "unknown") {
     return (
       <TooltipWrapper
@@ -1769,7 +2100,7 @@ function WorktreeTierPill(props: {
       >
         <Badge
           variant="outline"
-          className="gap-1 font-medium border-border/40 bg-muted/20 text-muted-foreground/80"
+          className="gap-1 font-medium border-dashed border-amber-600/40 bg-amber-500/5 text-amber-700 dark:border-amber-400/40 dark:text-amber-300/90"
           data-testid="worktree-tier-pill"
           data-tier="unknown"
         >
@@ -1865,34 +2196,6 @@ function WorktreeSecondaryFacts(props: {
 }
 
 /**
- * The full worktree path leaves the scan line (it is long and low-signal) but
- * stays one hover/click away: a copy-path affordance whose tooltip is the full
- * path. Confirmation dialogs still list full paths - delete is path-addressed.
- */
-function WorktreePathAffordance(props: {
-  readonly worktreePath: string;
-  readonly disabled: boolean;
-}): ReactNode {
-  return (
-    <TooltipWrapper
-      label={props.worktreePath}
-      side="top"
-      sideOffset={undefined}
-      align="start"
-    >
-      <span className="inline-flex shrink-0">
-        <CopyTextButton
-          value={props.worktreePath}
-          label={null}
-          ariaLabel={`Copy path ${props.worktreePath}`}
-          disabled={props.disabled}
-        />
-      </span>
-    </TooltipWrapper>
-  );
-}
-
-/**
  * Task association resolved from `owners[].epicId`. Owners in the same epic
  * collapse to one entry. An epic with a resolved title renders a chip; an epic
  * whose title is unknown (deleted / not cached / other user) is DEMOTED to muted
@@ -1948,13 +2251,19 @@ function WorktreeTaskAssociation(props: {
 }
 
 /**
- * True-AND Task merge rollup badge, sitting beside a resolved Task chip. `Merged`
- * (fully-merged green) means every owned branch - the superproject binding branch
- * and each owned submodule - has a HEAD-validated merged PR; `Merged N/M` (muted
- * amber) is the honest partial when some but not all have landed (the classic
- * "submodule PR merged, superproject gitlink bump still open" case). Renders
- * nothing when there's no merged progress to claim (no PR anywhere, or a pre-M4
- * host with no submodule/PR facts) - the chip then shows just the Task title.
+ * True-AND Task merge rollup - a QUIET caption beside a resolved Task chip, never
+ * a colored Badge: the row's own worktree tier pill is the row's one loud signal,
+ * and this rollup speaks to the Task's aggregate progress across every worktree it
+ * owns, a different scope that must not compete with or be mistaken for that pill
+ * (it previously reused the tier pill's exact green/GitMerge treatment for
+ * `merged`, which read as a second worktree-tier signal). Plain muted text, no
+ * icon, no border/background, and a "Task" prefix carries the distinction instead.
+ * `Merged` means every owned branch - the superproject binding branch and each
+ * owned submodule - has a HEAD-validated merged PR; `Merged N/M` is the honest
+ * partial when some but not all have landed (the classic "submodule PR merged,
+ * superproject gitlink bump still open" case). Renders nothing when there's no
+ * merged progress to claim (no PR anywhere, or a pre-M4 host with no submodule/PR
+ * facts) - the chip then shows just the Task title.
  */
 function TaskMergeRollupBadge(props: {
   readonly rollup: TaskMergeRollup | null;
@@ -1963,14 +2272,8 @@ function TaskMergeRollupBadge(props: {
   if (rollup === null || rollup.status === "none") return null;
   const fullyMerged = rollup.status === "merged";
   return (
-    <Badge
-      variant="outline"
-      className={cn(
-        "gap-1 font-medium",
-        fullyMerged
-          ? "border-emerald-600/30 bg-emerald-500/10 text-emerald-700 dark:border-emerald-400/30 dark:text-emerald-300"
-          : "border-amber-600/25 bg-amber-500/10 text-amber-700 dark:border-amber-400/25 dark:text-amber-300",
-      )}
+    <span
+      className="text-ui-xs text-muted-foreground"
       data-testid="task-merge-rollup"
       data-rollup-status={rollup.status}
       title={
@@ -1979,9 +2282,8 @@ function TaskMergeRollupBadge(props: {
           : `${rollup.merged} of ${rollup.total} owned branches merged`
       }
     >
-      <GitMerge className="size-3" aria-hidden />
-      {taskMergeRollupLabel(rollup)}
-    </Badge>
+      Task {taskMergeRollupLabel(rollup)}
+    </span>
   );
 }
 
@@ -2048,7 +2350,7 @@ function WorktreeSelectionControl(props: {
         }),
         props.canSelect ? "cursor-pointer" : "cursor-not-allowed",
         props.selected && props.canSelect
-          ? "border-primary bg-primary text-primary-foreground"
+          ? "border-foreground/70 bg-foreground text-background"
           : "border-border bg-background text-transparent hover:border-foreground",
       )}
       onClick={(event) => {
@@ -2072,84 +2374,90 @@ function WorktreeSelectionControl(props: {
   );
 }
 
+const WORKTREE_DELETE_DISABLED_COPY: Record<
+  "in-use" | "checking",
+  { readonly ariaLabel: string }
+> = {
+  "in-use": {
+    ariaLabel: "Delete worktree (in use by an active chat or agent)",
+  },
+  checking: {
+    ariaLabel: "Delete worktree (status is still being checked)",
+  },
+};
+
+/**
+ * Persistent row-end actions: one quiet overflow trigger at rest. Utilities and
+ * destructive delete live together inside the compact menu; delete stays visually
+ * destructive and still carries branch-specific accessible copy.
+ */
 function WorktreeRowActions(props: {
-  readonly inUse: boolean;
+  readonly deleteDisabledReason: "in-use" | "checking" | null;
+  readonly onCopyPath: () => void;
   readonly onManageScripts: () => void;
   readonly onDelete: () => void;
+  readonly triggerLabel: string;
   readonly label: string;
   readonly scriptsLabel: string;
 }): ReactNode {
+  const deleteDisabled = props.deleteDisabledReason !== null;
+  const deleteLabel =
+    props.deleteDisabledReason === null
+      ? props.label
+      : WORKTREE_DELETE_DISABLED_COPY[props.deleteDisabledReason].ariaLabel;
   return (
-    <div className="absolute right-5 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 transition-opacity group-hover/worktree-row:opacity-100 focus-within:opacity-100">
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        aria-label={props.scriptsLabel}
-        aria-haspopup="dialog"
-        onClick={props.onManageScripts}
-        className="text-muted-foreground hover:bg-muted hover:text-foreground"
-      >
-        <FileSliders className="size-4" />
-      </Button>
-      <WorktreeDeleteButton
-        inUse={props.inUse}
-        onDelete={props.onDelete}
-        label={props.label}
-      />
+    <div className="absolute right-4 top-1/2 flex -translate-y-1/2 items-center gap-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={props.triggerLabel}
+            data-testid="worktree-row-actions-trigger"
+            className="text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          className="w-max min-w-32 max-w-[min(80vw,14rem)] p-1.5"
+          data-testid="worktree-row-actions-menu"
+        >
+          <DropdownMenuItem
+            data-testid="worktree-row-copy-path"
+            onSelect={props.onCopyPath}
+            className="gap-2 px-2 py-2"
+          >
+            <Copy className="size-3.5" aria-hidden />
+            Copy path
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            data-testid="worktree-row-manage-scripts"
+            aria-haspopup="dialog"
+            onSelect={props.onManageScripts}
+            className="items-start gap-2 whitespace-normal px-2 py-2 text-left leading-snug"
+          >
+            <FileSliders className="size-3.5" aria-hidden />
+            {props.scriptsLabel}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            data-testid="worktree-row-delete"
+            variant="destructive"
+            aria-label={deleteLabel}
+            title={deleteLabel}
+            disabled={deleteDisabled}
+            onSelect={props.onDelete}
+            className="gap-2 px-2 py-2"
+          >
+            <Trash2 className="size-3.5" aria-hidden />
+            Delete worktree
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
-}
-
-function WorktreeDeleteButton(props: {
-  readonly inUse: boolean;
-  readonly onDelete: () => void;
-  readonly label: string;
-}): ReactNode {
-  if (props.inUse) {
-    const button = (
-      <button
-        type="button"
-        aria-disabled="true"
-        aria-label="Delete worktree (in use by an active chat or agent)"
-        className={cn(
-          "inline-flex size-7 cursor-not-allowed items-center justify-center rounded-sm text-muted-foreground/50 outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-        )}
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-        }}
-      >
-        <Trash2 className="size-4" />
-      </button>
-    );
-    return (
-      <TooltipWrapper
-        label="In use by an active chat or agent"
-        side="top"
-        sideOffset={undefined}
-        align="end"
-      >
-        {button}
-      </TooltipWrapper>
-    );
-  }
-  const button = (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      aria-label={props.label}
-      aria-haspopup="dialog"
-      onClick={props.onDelete}
-      className={cn(
-        "text-muted-foreground hover:bg-destructive/10 hover:text-destructive",
-      )}
-    >
-      <Trash2 className="size-4" />
-    </Button>
-  );
-  return button;
 }
 
 function WorktreeScriptReviewDialog(props: {
@@ -2307,12 +2615,24 @@ function compareByCreatedAt(
 function filterWorktrees(
   worktrees: readonly WorktreeHostEntryV11[],
   searchText: string,
-  taskTitlesByEpicId: ReadonlyMap<string, string>,
+  searchHaystackByPath: ReadonlyMap<string, string>,
 ): readonly WorktreeHostEntryV11[] {
   const needle = searchText.trim().toLowerCase();
   if (needle.length === 0) return worktrees;
   return worktrees.filter((entry) =>
-    worktreeSearchHaystack(entry, taskTitlesByEpicId).includes(needle),
+    (searchHaystackByPath.get(entry.worktreePath) ?? "").includes(needle),
+  );
+}
+
+function buildWorktreeSearchHaystackByPath(
+  worktrees: readonly WorktreeHostEntryV11[],
+  taskTitlesByEpicId: ReadonlyMap<string, string>,
+): ReadonlyMap<string, string> {
+  return new Map(
+    worktrees.map((entry) => [
+      entry.worktreePath,
+      worktreeSearchHaystack(entry, taskTitlesByEpicId),
+    ]),
   );
 }
 
@@ -2378,14 +2698,84 @@ function deleteDialogCopy(entry: WorktreeHostEntryV11): {
 }
 
 /**
+ * Confirmation copy for an `Unknown` row - its enrichment settled to an error,
+ * so none of the honest-loss facts `deleteDialogCopy` relies on (ahead/behind,
+ * merge state) were ever proven. Names that explicitly instead of falling back
+ * to the generic "clean" copy, which would understate the risk. `uncommittedCount`
+ * is a cheap base-listing field available even when activity enrichment failed,
+ * so a dirty Unknown row still leads with the known, stronger dirty-loss
+ * warning - the unknown-risk caveat is ADDED, never substituted for it.
+ */
+function unknownRiskDeleteDialogCopy(entry: WorktreeHostEntryV11): {
+  readonly title: string;
+  readonly description: string;
+  readonly actionLabel: string;
+} {
+  const branch = branchLabel(entry);
+  if (entry.uncommittedCount > 0) {
+    const count = entry.uncommittedCount;
+    const plural = count === 1 ? "" : "s";
+    return {
+      title: `Discard ${count} uncommitted change${plural}?`,
+      description: `${branch} has ${count} uncommitted change${plural} that will be permanently lost. Its branch and activity status also could not be verified, so Traycer cannot confirm the rest of this worktree is safe to remove either. Traycer runs the repo's teardown script, then force-removes ${entry.worktreePath}.`,
+      actionLabel: "Delete and discard",
+    };
+  }
+  return {
+    title: "Delete worktree with unknown status?",
+    description: `${branch}'s branch and activity status could not be verified, so Traycer cannot confirm this worktree is safe to remove or free of unpushed work. Traycer runs the repo's teardown script, then removes ${entry.worktreePath}.`,
+    actionLabel: "Delete anyway",
+  };
+}
+
+/**
+ * Single-row delete confirmation copy. An `Unknown` row (settled enrichment
+ * error) is deletable, but only through explicit unknown-risk copy - never the
+ * generic confirmation, which would understate that its branch/activity
+ * status was never proven.
+ */
+function singleWorktreeDeleteDialogCopy(
+  entry: WorktreeHostEntryV11,
+  enrichment: WorktreeEnrichmentState,
+): {
+  readonly title: string;
+  readonly description: string;
+  readonly actionLabel: string;
+} {
+  if (enrichment === "unknown") return unknownRiskDeleteDialogCopy(entry);
+  return deleteDialogCopy(entry);
+}
+
+/**
  * Toast copy when confirm-time re-check drops rows that stopped qualifying,
  * class-summarized to stay consistent with the confirmation's exclusion line.
+ * A row that regressed to `Checking` (a refresh/retry re-armed its enrichment
+ * between dialog-open and confirm) is named separately - `worktreeDeleteClass`
+ * only sees the base, un-enriched fields for such a row and would otherwise
+ * mislabel it (e.g. "unreferenced (branch status unverified)") instead of
+ * naming the real reason it was dropped.
  */
-function worktreeDropMessage(dropped: readonly WorktreeHostEntryV11[]): string {
-  const summary = countWorktreeClasses(dropped, WORKTREE_EXCLUSION_ORDER);
+function worktreeDropMessage(
+  dropped: readonly WorktreeHostEntryV11[],
+  isChecking: (worktreePath: string) => boolean,
+): string {
+  const checkingDropped = dropped.filter((entry) =>
+    isChecking(entry.worktreePath),
+  );
+  const otherDropped = dropped.filter(
+    (entry) => !isChecking(entry.worktreePath),
+  );
+  const parts = [
+    ...(checkingDropped.length === 0
+      ? []
+      : [`${checkingDropped.length} still checking status`]),
+    ...(otherDropped.length === 0
+      ? []
+      : [countWorktreeClasses(otherDropped, WORKTREE_EXCLUSION_ORDER)]),
+  ];
   const plural = dropped.length === 1 ? "" : "s";
   const verb = dropped.length === 1 ? "was" : "were";
-  return `${dropped.length} worktree${plural} became ineligible and ${verb} skipped: ${summary}.`;
+  return `${dropped.length} worktree${plural} became ineligible and ${verb} skipped: ${parts.join(", ")}.`;
 }
 
 interface WorktreeBulkDeleteSummary {
@@ -2395,6 +2785,7 @@ interface WorktreeBulkDeleteSummary {
   readonly classSummary: string;
   readonly dirtyLoss: string | null;
   readonly unverifiedCaveat: string | null;
+  readonly unknownRiskCaveat: string | null;
   readonly exclusions: string | null;
   readonly paths: readonly string[];
 }
@@ -2504,13 +2895,17 @@ function countWorktreeClasses(
  * Confirmation copy for a multi-worktree delete. Aggregates the SELECTED targets
  * by class (never 38 stacked warnings), names concrete loss for dirty rows, and
  * — for the null-status cohort — uses deliberately NEUTRAL caveat wording (never
- * "safe" / "loss-free"). Also names what was left out of the selection so the
- * exclusion is transparent. Full paths are carried for the expandable list;
- * delete is path-addressed.
+ * "safe" / "loss-free"). Separately, `unknownPaths` (rows whose enrichment
+ * settled to an error - the pill reads "Unknown") get their own unknown-risk
+ * caveat: unlike the unverified-branch-status cohort, these rows carry NO
+ * proven facts at all, not even a classified tier. Also names what was left
+ * out of the selection so the exclusion is transparent. Full paths are carried
+ * for the expandable list; delete is path-addressed.
  */
 function summarizeBulkWorktreeDelete(
   targets: ReadonlyArray<WorktreeHostEntryV11>,
   visible: readonly WorktreeHostEntryV11[],
+  unknownPaths: ReadonlySet<string>,
 ): WorktreeBulkDeleteSummary {
   const targetPaths = new Set(targets.map((entry) => entry.worktreePath));
   const dirtyTargets = targets.filter((entry) => entry.uncommittedCount > 0);
@@ -2532,6 +2927,15 @@ function summarizeBulkWorktreeDelete(
   const unverifiedCaveat = hasUnverified
     ? "For the worktrees with unverified branch status: branch status was unavailable, the branch refs are expected to remain, and unpushed work is not proven. Commit, stash, or push anything you want to keep first."
     : null;
+  const unknownTargets = targets.filter((entry) =>
+    unknownPaths.has(entry.worktreePath),
+  );
+  const unknownRiskCaveat =
+    unknownTargets.length === 0
+      ? null
+      : `Activity status for ${unknownTargets.length} worktree${
+          unknownTargets.length === 1 ? "" : "s"
+        } could not be checked. Traycer cannot confirm those are safe to remove or free of unpushed work. Commit, stash, or push anything you want to keep first.`;
   const excluded = visible.filter(
     (entry) => !entry.inUse && !targetPaths.has(entry.worktreePath),
   );
@@ -2547,6 +2951,7 @@ function summarizeBulkWorktreeDelete(
     classSummary: countWorktreeClasses(targets, WORKTREE_DELETE_SUMMARY_ORDER),
     dirtyLoss,
     unverifiedCaveat,
+    unknownRiskCaveat,
     exclusions:
       exclusionSummary === null
         ? null

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -2793,6 +2793,7 @@ interface WorktreeBulkDeleteSummary {
 // Buckets a worktree into exactly one delete class, cautionary signals first so
 // a would-be-lost row is never mislabeled as a proven-clean one.
 type WorktreeDeleteClass =
+  | "in-use"
   | "merged"
   | "at-base"
   | "clean"
@@ -2803,11 +2804,13 @@ type WorktreeDeleteClass =
   | "dirty";
 
 function worktreeDeleteClass(entry: WorktreeHostEntryV11): WorktreeDeleteClass {
+  if (entry.inUse) return "in-use";
   // Derive the tier-level bucket from the ONE shared classifier so the bulk copy
   // and the row pill can never disagree (no parallel precedence ladder). The
-  // green tiers and orphaned map 1:1; only the amber `review` tier (and an
-  // in-use row that reached here via the drop-message summary) fans out into the
-  // finer would-be-lost sub-classes for honest loss copy.
+  // green tiers and orphaned map 1:1; in-use is a lock reason, so it is named as
+  // such when a row is excluded or dropped rather than bucketed by its git facts.
+  // Only the amber `review` tier fans out into finer would-be-lost sub-classes
+  // for honest loss copy.
   const tier = classifyWorktreeTier(entry);
   if (tier === "merged") return "merged";
   if (tier === "at-base-commit") return "at-base";
@@ -2819,8 +2822,7 @@ function worktreeDeleteClass(entry: WorktreeHostEntryV11): WorktreeDeleteClass {
 /**
  * Sub-classifies a non-green, non-orphaned row into its would-be-lost bucket for
  * the delete copy - cautionary signals first. Called only for the `review` tier
- * (and an in-use row summarized as a confirm-time drop), so the green/orphaned
- * cases are already handled by the shared classifier above.
+ * now that green, orphaned, and in-use cases are already handled above.
  */
 function worktreeReviewLossClass(
   entry: WorktreeHostEntryV11,
@@ -2839,6 +2841,7 @@ function worktreeReviewLossClass(
 }
 
 const WORKTREE_DELETE_CLASS_LABEL: Record<WorktreeDeleteClass, string> = {
+  "in-use": "in use",
   merged: "merged",
   "at-base": "at base commit",
   clean: "clean (no local-only commits)",
@@ -2860,8 +2863,10 @@ const WORKTREE_DELETE_SUMMARY_ORDER: readonly WorktreeDeleteClass[] = [
   "detached",
   "orphaned",
   "dirty",
+  "in-use",
 ];
 const WORKTREE_EXCLUSION_ORDER: readonly WorktreeDeleteClass[] = [
+  "in-use",
   "dirty",
   "unmerged",
   "detached",
@@ -2937,7 +2942,7 @@ function summarizeBulkWorktreeDelete(
           unknownTargets.length === 1 ? "" : "s"
         } could not be checked. Traycer cannot confirm those are safe to remove or free of unpushed work. Commit, stash, or push anything you want to keep first.`;
   const excluded = visible.filter(
-    (entry) => !entry.inUse && !targetPaths.has(entry.worktreePath),
+    (entry) => !targetPaths.has(entry.worktreePath),
   );
   const exclusionSummary =
     excluded.length === 0


### PR DESCRIPTION
## Summary
- Redesign the Worktrees settings list hierarchy, toolbar chrome, row actions, and selection/bulk-delete experience.
- Preserve safety semantics for Checking, Unknown, dirty, in-use, and unverified worktrees while making destructive actions clearer.
- Add focused coverage for row overflow behavior, selection action bar behavior, sticky repo headers, host/list states, and status-aware delete safety.

## Verification
- `pre-commit run --all-files`
- Commit hook: DCO sign-off and Nx affected compile/lint/format

## Notes
- Live browser/screenshot verification was not run in this environment.