### PR TITLE
fix(protocol): keep inline marks continuous across text-node boundaries

### DIFF
--- a/protocol/src/common/__tests__/json-content-serializer-marks.test.ts
+++ b/protocol/src/common/__tests__/json-content-serializer-marks.test.ts
@@ -83,6 +83,30 @@ describe("inline mark serialization across text-node boundaries", () => {
     expect(toMarkdown(doc)).toBe("*a **b `c` d** e*");
   });
 
+  it("keeps an inner mark open when an outer mark ends before it", () => {
+    // `_**b** i_`: bold ends after "b" but italic continues. Continuation
+    // ordering opens italic outermost, so bold closes without forcing an
+    // italic close/reopen (which would double the delimiters).
+    const doc = paragraphDoc([
+      text("b", [{ type: "bold" }, { type: "italic" }]),
+      text(" i", [{ type: "italic" }]),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("***b** i*");
+  });
+
+  it("keeps a link continuous when a nested bold ends before it", () => {
+    const doc = paragraphDoc([
+      text("b", [
+        { type: "bold" },
+        { type: "link", attrs: { href: "http://example.com" } },
+      ]),
+      text(" i", [{ type: "link", attrs: { href: "http://example.com" } }]),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("[**b** i](http://example.com)");
+  });
+
   it("closes and reopens a code mark when a new mark starts inside it", () => {
     // Nothing may open inside inline code - markdown renders nested
     // delimiters literally - so the code mark closes and reopens innermost.

--- a/protocol/src/common/__tests__/json-content-serializer-marks.test.ts
+++ b/protocol/src/common/__tests__/json-content-serializer-marks.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+
+import type { JsonContent } from "../registry";
+import { jsonContentToMarkdown } from "../json-content-serializer";
+
+/**
+ * Regression tests for inline mark serialization at text-node boundaries.
+ *
+ * A continuous mark that contains a nested mark splits into several
+ * ProseMirror text nodes (`**bold `code` bold**` is three nodes). The
+ * serializer used to wrap each node independently, emitting
+ * `**bold **` + `` **`code`** `` + `** bold**` - the doubled `****` runs
+ * re-parse as literal asterisks and corrupt every artifact whose content
+ * nests marks. Delimiters must open and close only where the mark set
+ * actually changes.
+ */
+
+function text(
+  value: string,
+  marks: { type: string; attrs?: Record<string, unknown> }[] | undefined,
+): JsonContent {
+  return marks
+    ? { type: "text", text: value, marks }
+    : { type: "text", text: value };
+}
+
+function paragraphDoc(content: JsonContent[]): JsonContent {
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content }],
+  };
+}
+
+function toMarkdown(content: JsonContent): string {
+  return jsonContentToMarkdown(content, {
+    mentionFormat: "llm",
+    platform: "POSIX",
+  });
+}
+
+describe("inline mark serialization across text-node boundaries", () => {
+  it("keeps a bold span continuous around nested inline code", () => {
+    const doc = paragraphDoc([
+      text("has ", undefined),
+      text("no ", [{ type: "bold" }]),
+      text("MergeProvenance", [{ type: "bold" }, { type: "code" }]),
+      text(" table", [{ type: "bold" }]),
+      text(" end", undefined),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("has **no `MergeProvenance` table** end");
+  });
+
+  it("keeps a bold span continuous around a nested link", () => {
+    const doc = paragraphDoc([
+      text("see ", undefined),
+      text("the ", [{ type: "bold" }]),
+      text("docs", [
+        { type: "bold" },
+        { type: "link", attrs: { href: "http://example.com" } },
+      ]),
+      text(" here", [{ type: "bold" }]),
+      text(" now", undefined),
+    ]);
+
+    expect(toMarkdown(doc)).toBe(
+      "see **the [docs](http://example.com) here** now",
+    );
+  });
+
+  it("handles deep nesting where mark order shifts with schema rank", () => {
+    // ProseMirror sorts marks by schema rank, so the italic span's nodes
+    // carry [italic], [bold, italic], [bold, code, italic] - the italic
+    // mark changes position but the span is continuous.
+    const doc = paragraphDoc([
+      text("a ", [{ type: "italic" }]),
+      text("b ", [{ type: "bold" }, { type: "italic" }]),
+      text("c", [{ type: "bold" }, { type: "code" }, { type: "italic" }]),
+      text(" d", [{ type: "bold" }, { type: "italic" }]),
+      text(" e", [{ type: "italic" }]),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("*a **b `c` d** e*");
+  });
+
+  it("closes and reopens a code mark when a new mark starts inside it", () => {
+    // Nothing may open inside inline code - markdown renders nested
+    // delimiters literally - so the code mark closes and reopens innermost.
+    const doc = paragraphDoc([
+      text("a", [{ type: "code" }]),
+      text("b", [{ type: "bold" }, { type: "code" }]),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("`a`**`b`**");
+  });
+
+  it("still delimits adjacent spans separated by plain text", () => {
+    const doc = paragraphDoc([
+      text("a ", undefined),
+      text("x", [{ type: "code" }]),
+      text(" b ", undefined),
+      text("y", [{ type: "code" }]),
+      text(" c", undefined),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("a `x` b `y` c");
+  });
+
+  it("splits adjacent links with different targets", () => {
+    const doc = paragraphDoc([
+      text("one", [{ type: "link", attrs: { href: "http://a.example" } }]),
+      text("two", [{ type: "link", attrs: { href: "http://b.example" } }]),
+    ]);
+
+    expect(toMarkdown(doc)).toBe(
+      "[one](http://a.example)[two](http://b.example)",
+    );
+  });
+
+  it("closes open marks before non-text inline nodes", () => {
+    const doc = paragraphDoc([
+      text("start ", [{ type: "bold" }]),
+      {
+        type: "mention",
+        attrs: {
+          contextType: "file",
+          id: "src/app.ts",
+          relPath: "src/app.ts",
+        },
+      },
+      text(" finish", [{ type: "bold" }]),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("**start **@src/app.ts** finish**");
+  });
+
+  it("renders links without an href as plain text", () => {
+    const doc = paragraphDoc([
+      text("plain", [{ type: "link", attrs: {} }]),
+      text(" after", undefined),
+    ]);
+
+    expect(toMarkdown(doc)).toBe("plain after");
+  });
+
+  it("round-trips a paragraph shaped like the corrupted artifact", () => {
+    const doc = paragraphDoc([
+      text("Therefore ", undefined),
+      text("container.isBound(TOKENS.MergeProvenanceService)", [
+        { type: "code" },
+      ]),
+      text(" at ", undefined),
+      text("runtime.ts:220", [{ type: "code" }]),
+      text(" is ", undefined),
+      text("always false", [{ type: "bold" }]),
+      text(" in production → ", undefined),
+      text("mergeProvenanceService = null", [{ type: "code" }]),
+      text(".", undefined),
+    ]);
+
+    expect(toMarkdown(doc)).toBe(
+      "Therefore `container.isBound(TOKENS.MergeProvenanceService)` at `runtime.ts:220` is **always false** in production → `mergeProvenanceService = null`.",
+    );
+  });
+});

--- a/protocol/src/common/json-content-serializer.ts
+++ b/protocol/src/common/json-content-serializer.ts
@@ -139,8 +139,27 @@ function renderableMarks(
  * node's mark set, regardless of its position there: ProseMirror stores
  * marks sorted by schema rank, so `[italic]` followed by `[bold, italic]`
  * is a continuous italic span gaining bold, not an italic/bold swap.
+ *
+ * Newly opened marks nest by continuation length - a mark that spans more
+ * of the remaining run opens first (outermost). Without this, `_**b** i_`
+ * would open bold outside italic (schema-rank order), and bold ending
+ * after "b" would force italic closed and reopened, doubling delimiters.
  */
 function serializeTextRun(nodes: JsonContent[]): string {
+  const textNodes = nodes.filter((node) => Boolean(node.text));
+  const nodeMarks = textNodes.map((node) => renderableMarks(node.marks));
+
+  const continuation = (key: string, start: number): number => {
+    let end = start;
+    while (
+      end < nodeMarks.length &&
+      nodeMarks[end].some((mark) => mark.key === key)
+    ) {
+      end++;
+    }
+    return end - start;
+  };
+
   let out = "";
   let open: RenderableMark[] = [];
 
@@ -151,9 +170,8 @@ function serializeTextRun(nodes: JsonContent[]): string {
     open = open.slice(0, depth);
   };
 
-  for (const node of nodes) {
-    if (!node.text) continue;
-    const marks = renderableMarks(node.marks);
+  textNodes.forEach((node, index) => {
+    const marks = nodeMarks[index];
     const nextKeys = new Set(marks.map((mark) => mark.key));
 
     let keep = 0;
@@ -171,14 +189,22 @@ function serializeTextRun(nodes: JsonContent[]): string {
     }
 
     closeDownTo(keep);
-    for (const mark of marks) {
-      if (!keptKeys.has(mark.key)) {
-        out += mark.open;
-        open.push(mark);
-      }
+
+    const toOpen = marks
+      .filter((mark) => !keptKeys.has(mark.key))
+      .sort(
+        (a, b) => continuation(b.key, index) - continuation(a.key, index),
+      );
+    const ordered = [
+      ...toOpen.filter((mark) => mark.type !== "code"),
+      ...toOpen.filter((mark) => mark.type === "code"),
+    ];
+    for (const mark of ordered) {
+      out += mark.open;
+      open.push(mark);
     }
-    out += node.text;
-  }
+    out += node.text ?? "";
+  });
 
   closeDownTo(0);
   return out;

--- a/protocol/src/common/json-content-serializer.ts
+++ b/protocol/src/common/json-content-serializer.ts
@@ -192,9 +192,7 @@ function serializeTextRun(nodes: JsonContent[]): string {
 
     const toOpen = marks
       .filter((mark) => !keptKeys.has(mark.key))
-      .sort(
-        (a, b) => continuation(b.key, index) - continuation(a.key, index),
-      );
+      .sort((a, b) => continuation(b.key, index) - continuation(a.key, index));
     const ordered = [
       ...toOpen.filter((mark) => mark.type !== "code"),
       ...toOpen.filter((mark) => mark.type === "code"),

--- a/protocol/src/common/json-content-serializer.ts
+++ b/protocol/src/common/json-content-serializer.ts
@@ -70,39 +70,118 @@ function escapeXmlContent(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function serializeTextWithMarks(
-  text: string,
+interface RenderableMark {
+  key: string;
+  type: string;
+  open: string;
+  close: string;
+}
+
+function markDelimiters(mark: {
+  type: string;
+  attrs?: Record<string, unknown>;
+}): { open: string; close: string } | null {
+  switch (mark.type) {
+    case "bold":
+      return { open: "**", close: "**" };
+    case "italic":
+      return { open: "*", close: "*" };
+    case "code":
+      return { open: "`", close: "`" };
+    case "strike":
+      return { open: "~~", close: "~~" };
+    case "link": {
+      const href = mark.attrs?.href;
+      if (typeof href === "string" && href.length > 0) {
+        return { open: "[", close: `](${href})` };
+      }
+      return null;
+    }
+    default:
+      return null;
+  }
+}
+
+// Maps a node's marks to the delimiters the serializer can render, keeping
+// the stored order except `code`, which is forced innermost: markdown
+// renders formatting delimiters inside inline code literally, so the
+// backticks must hug the text.
+function renderableMarks(
   marks: JsonContent["marks"] | undefined,
-): string {
-  if (!marks || marks.length === 0) return text;
+): RenderableMark[] {
+  if (!marks || marks.length === 0) return [];
+  const rendered = marks.flatMap((mark) => {
+    const delimiters = markDelimiters(mark);
+    if (!delimiters) return [];
+    return [
+      {
+        key: `${mark.type}:${JSON.stringify(mark.attrs ?? {})}`,
+        type: mark.type,
+        ...delimiters,
+      },
+    ];
+  });
+  return [
+    ...rendered.filter((mark) => mark.type !== "code"),
+    ...rendered.filter((mark) => mark.type === "code"),
+  ];
+}
 
-  let result = text;
-  const reversedMarks = [...marks].reverse();
+/**
+ * Serializes a run of consecutive inline text nodes, emitting mark
+ * delimiters only where the mark set changes between nodes. Wrapping each
+ * node independently corrupts continuous marks that contain nested marks:
+ * `**bold `code` bold**` splits into three text nodes and would serialize
+ * as `**bold **` + `` **`code`** `` + `** bold**`, whose doubled `****`
+ * runs re-parse as literal asterisks.
+ *
+ * A mark stays open across a boundary when it is still present in the next
+ * node's mark set, regardless of its position there: ProseMirror stores
+ * marks sorted by schema rank, so `[italic]` followed by `[bold, italic]`
+ * is a continuous italic span gaining bold, not an italic/bold swap.
+ */
+function serializeTextRun(nodes: JsonContent[]): string {
+  let out = "";
+  let open: RenderableMark[] = [];
 
-  for (const mark of reversedMarks) {
-    switch (mark.type) {
-      case "bold":
-        result = `**${result}**`;
-        break;
-      case "italic":
-        result = `*${result}*`;
-        break;
-      case "code":
-        result = `\`${result}\``;
-        break;
-      case "strike":
-        result = `~~${result}~~`;
-        break;
-      case "link": {
-        const href = mark.attrs?.href;
-        if (typeof href === "string" && href.length > 0) {
-          result = `[${result}](${href})`;
-        }
-        break;
+  const closeDownTo = (depth: number): void => {
+    for (let i = open.length - 1; i >= depth; i--) {
+      out += open[i].close;
+    }
+    open = open.slice(0, depth);
+  };
+
+  for (const node of nodes) {
+    if (!node.text) continue;
+    const marks = renderableMarks(node.marks);
+    const nextKeys = new Set(marks.map((mark) => mark.key));
+
+    let keep = 0;
+    while (keep < open.length && nextKeys.has(open[keep].key)) {
+      keep++;
+    }
+    // Inline code renders nested delimiters literally, so nothing may open
+    // inside a kept code mark - close it and reopen it innermost instead.
+    // A kept code mark is always at the top of the stack (code sorts last).
+    const keptKeys = new Set(open.slice(0, keep).map((mark) => mark.key));
+    const hasNewMarks = marks.some((mark) => !keptKeys.has(mark.key));
+    if (hasNewMarks && keep > 0 && open[keep - 1].type === "code") {
+      keep--;
+      keptKeys.delete(open[keep].key);
+    }
+
+    closeDownTo(keep);
+    for (const mark of marks) {
+      if (!keptKeys.has(mark.key)) {
+        out += mark.open;
+        open.push(mark);
       }
     }
+    out += node.text;
   }
-  return result;
+
+  closeDownTo(0);
+  return out;
 }
 
 function getValidationMarker(nodeId: string, ctx: SerializerContext): string {
@@ -383,7 +462,7 @@ function serializeSlashCommand(
 
 function serializeText(node: JsonContent): string {
   if (node.type !== "text" || !node.text) return "";
-  return serializeTextWithMarks(node.text, node.marks);
+  return serializeTextRun([node]);
 }
 
 function serializeHardBreak(): string {
@@ -634,10 +713,28 @@ function serializeChildren(
 ): string {
   if (!content) return "";
 
+  // Consecutive text nodes serialize as one run so mark delimiters land only
+  // where the mark set actually changes; non-text inline nodes (mention,
+  // hardBreak, …) end the run and close any open marks.
   const parts: string[] = [];
+  let textRun: JsonContent[] = [];
+  const flushTextRun = (): void => {
+    if (textRun.length > 0) {
+      parts.push(serializeTextRun(textRun));
+      textRun = [];
+    }
+  };
+
   for (const child of content) {
-    parts.push(serializeNode(child, ctx));
+    if (child.type === "text") {
+      textRun.push(child);
+    } else {
+      flushTextRun();
+      parts.push(serializeNode(child, ctx));
+    }
   }
+  flushTextRun();
+
   return parts.join("");
 }
 


### PR DESCRIPTION
## Summary

- `jsonContentToMarkdown` wrapped **each text node independently** in its mark delimiters. A continuous mark containing a nested mark splits into several ProseMirror text nodes (`**bold `code` bold**` is three), so it serialized as `**bold **` + `**`code`**` + `** bold**` — the doubled `****` runs re-parse as literal asterisks and corrupt every artifact whose content nests marks (bold around inline code, links inside bold, deep nesting). This is the serializer half of the artifact formatting corruption; the mark-bleed half was fixed host-side in the internal repo.
- Consecutive text nodes now serialize as one run: delimiters open and close only where the mark set actually changes. A mark stays open across a boundary when it is still present in the next node's mark set regardless of position — ProseMirror sorts marks by schema rank, so a continuous italic span reads `[italic]` then `[bold, italic]`.
- Inline code is forced innermost and closes/reopens when a new mark would otherwise open inside it, since markdown renders delimiters inside inline code literally.
- Non-text inline nodes (mention, hardBreak) end the run and close any open marks, unchanged from before.

## Test plan

- [x] New `protocol/src/common/__tests__/json-content-serializer-marks.test.ts`: bold-wrapping-code, link-in-bold, deep nesting with rank-shifted mark order, code close/reopen guard, adjacent spans, per-target link splitting, marks closing before mentions, empty-href links, and a paragraph shaped like the corrupted artifact.
- [x] Verified the three nested-mark regression tests are red without the fix (3 failed / 6 passed) and all 9 green with it.
- [x] Full protocol suite: 635 passed (55 files). `tsc --noEmit` clean. Pre-commit workspace checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)