### PR TITLE
feat(cli,protocol): resync TUI harnessSessionId from hook payloads (Claude + OpenCode)

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAgentActivityFromHookCommand } from "../agent-activity-from-hook";
-import type { CommandContext } from "../../runner/runner";
-import type { RuntimeContext } from "../../runner/runtime";
-import { noopLogger } from "../../logger";
 import { callHostRpcFastFail } from "../../internal/host-rpc";
 import { cliError, CLI_ERROR_CODES } from "../../runner/errors";
+import {
+  makeCtx,
+  restoreAgentIdentityEnv,
+  restoreStdin,
+  setAgentIdentityEnv,
+  stubStdin,
+} from "./hook-test-helpers";
 
 vi.mock("../../internal/host-rpc", async () => {
   const actual = await vi.importActual<
@@ -18,72 +22,18 @@ vi.mock("../../internal/host-rpc", async () => {
 
 const rpcMock = vi.mocked(callHostRpcFastFail);
 
-function makeRuntime(): RuntimeContext {
-  return {
-    json: false,
-    quiet: false,
-    noProgress: false,
-    noBootstrap: false,
-    nonInteractive: false,
-    environment: "production",
-    logger: noopLogger,
-  };
-}
-
-function makeCtx(): CommandContext {
-  return {
-    runtime: makeRuntime(),
-    output: {
-      progress: vi.fn(),
-      human: vi.fn(),
-      humanRequired: vi.fn(),
-      emitResult: vi.fn(),
-      emitError: vi.fn(),
-    },
-    progress: vi.fn(),
-  };
-}
-
-const realStdin = Object.getOwnPropertyDescriptor(process, "stdin");
-
-function stubStdin(value: {
-  isTTY: boolean;
-  chunks: ReadonlyArray<string>;
-}): void {
-  Object.defineProperty(process, "stdin", {
-    configurable: true,
-    value: {
-      isTTY: value.isTTY,
-      async *[Symbol.asyncIterator]() {
-        for (const chunk of value.chunks) yield Buffer.from(chunk);
-      },
-    },
-  });
-}
-
-const PREV_ENV = {
-  epic: process.env.TRAYCER_EPIC_ID,
-  agent: process.env.TRAYCER_AGENT_ID,
-};
-
 beforeEach(() => {
   vi.clearAllMocks();
   rpcMock.mockResolvedValue({ accepted: true });
-  process.env.TRAYCER_EPIC_ID = "epic-1";
-  process.env.TRAYCER_AGENT_ID = "agent-1";
+  setAgentIdentityEnv();
 });
 
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   vi.clearAllMocks();
-  if (realStdin !== undefined) {
-    Object.defineProperty(process, "stdin", realStdin);
-  }
-  if (PREV_ENV.epic === undefined) delete process.env.TRAYCER_EPIC_ID;
-  else process.env.TRAYCER_EPIC_ID = PREV_ENV.epic;
-  if (PREV_ENV.agent === undefined) delete process.env.TRAYCER_AGENT_ID;
-  else process.env.TRAYCER_AGENT_ID = PREV_ENV.agent;
+  restoreStdin();
+  restoreAgentIdentityEnv();
 });
 
 describe("buildAgentActivityFromHookCommand", () => {

--- a/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAgentActivityFromHookCommand } from "../agent-activity-from-hook";
+import type { CommandContext } from "../../runner/runner";
+import type { RuntimeContext } from "../../runner/runtime";
+import { noopLogger } from "../../logger";
+import { callHostRpcFastFail } from "../../internal/host-rpc";
+import { cliError, CLI_ERROR_CODES } from "../../runner/errors";
+
+vi.mock("../../internal/host-rpc", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../internal/host-rpc")
+  >("../../internal/host-rpc");
+  return {
+    ...actual,
+    callHostRpcFastFail: vi.fn(),
+  };
+});
+
+const rpcMock = vi.mocked(callHostRpcFastFail);
+
+function makeRuntime(): RuntimeContext {
+  return {
+    json: false,
+    quiet: false,
+    noProgress: false,
+    noBootstrap: false,
+    nonInteractive: false,
+    environment: "production",
+    logger: noopLogger,
+  };
+}
+
+function makeCtx(): CommandContext {
+  return {
+    runtime: makeRuntime(),
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+const realStdin = Object.getOwnPropertyDescriptor(process, "stdin");
+
+function stubStdin(value: {
+  isTTY: boolean;
+  chunks: ReadonlyArray<string>;
+}): void {
+  Object.defineProperty(process, "stdin", {
+    configurable: true,
+    value: {
+      isTTY: value.isTTY,
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of value.chunks) yield Buffer.from(chunk);
+      },
+    },
+  });
+}
+
+const PREV_ENV = {
+  epic: process.env.TRAYCER_EPIC_ID,
+  agent: process.env.TRAYCER_AGENT_ID,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rpcMock.mockResolvedValue({ accepted: true });
+  process.env.TRAYCER_EPIC_ID = "epic-1";
+  process.env.TRAYCER_AGENT_ID = "agent-1";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  if (realStdin !== undefined) {
+    Object.defineProperty(process, "stdin", realStdin);
+  }
+  if (PREV_ENV.epic === undefined) delete process.env.TRAYCER_EPIC_ID;
+  else process.env.TRAYCER_EPIC_ID = PREV_ENV.epic;
+  if (PREV_ENV.agent === undefined) delete process.env.TRAYCER_AGENT_ID;
+  else process.env.TRAYCER_AGENT_ID = PREV_ENV.agent;
+});
+
+describe("buildAgentActivityFromHookCommand", () => {
+  it("sends the observed Claude session id read from the hook stdin payload", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-live-9", cwd: "/tmp" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "claude",
+      event: "start",
+      observedHarnessSessionId: "sess-live-9",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({ accepted: true, reason: null });
+  });
+
+  it("carries the observed id on the stop edge too", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-live-stop" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "stop",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "claude",
+      event: "stop",
+      observedHarnessSessionId: "sess-live-stop",
+    });
+  });
+
+  it("never reads stdin for a non-claude provider (observed id stays null)", async () => {
+    // A payload IS present on stdin, but a codex activity edge must not consume
+    // it - only claude stamps a resumable session id.
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "should-be-ignored" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "codex",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "codex",
+      event: "start",
+      observedHarnessSessionId: null,
+    });
+  });
+
+  it("sends a null observed id when the payload has no session_id", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ cwd: "/tmp" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "claude",
+      event: "start",
+      observedHarnessSessionId: null,
+    });
+  });
+
+  it("sends a null observed id when stdin is non-JSON", async () => {
+    stubStdin({ isTTY: false, chunks: ["not json"] });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "agent.tui.recordActivity",
+      expect.objectContaining({ observedHarnessSessionId: null }),
+    );
+  });
+
+  it("sends a null observed id when stdin is a TTY", async () => {
+    stubStdin({ isTTY: true, chunks: [] });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith(
+      "agent.tui.recordActivity",
+      expect.objectContaining({ observedHarnessSessionId: null }),
+    );
+  });
+
+  it("exits cleanly without an RPC call when identity context is missing", async () => {
+    delete process.env.TRAYCER_EPIC_ID;
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "s" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "missing-context",
+    });
+  });
+
+  it("noops with exit 0 when the host is not running", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    rpcMock.mockRejectedValueOnce(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
+        message: "traycer: host not running",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "s" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "claude",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "host-unreachable",
+    });
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-activity-from-hook.test.ts
@@ -164,6 +164,57 @@ describe("buildAgentActivityFromHookCommand", () => {
     });
   });
 
+  it("reads stdin for an env-identified opencode hook (root-session form)", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "ses-oc-live-2" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "opencode",
+      event: "start",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: null,
+    });
+    await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "opencode",
+      event: "start",
+      observedHarnessSessionId: "ses-oc-live-2",
+    });
+  });
+
+  it("never reads stdin for a session-id-keyed opencode hook", async () => {
+    // The shared-server plugin instance identifies the agent by session id and
+    // never pipes a payload; a stray one must not become an observed id (the
+    // host refuses resyncs from session-id-keyed requests anyway).
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "should-be-ignored" })],
+    });
+    const fn = buildAgentActivityFromHookCommand({
+      provider: "opencode",
+      event: "stop",
+      epicId: null,
+      agentId: null,
+      harnessSessionId: "ses-oc-1",
+    });
+    await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: null,
+      tuiAgentId: null,
+      harnessSessionId: "ses-oc-1",
+      harnessId: "opencode",
+      event: "stop",
+      observedHarnessSessionId: null,
+    });
+  });
+
   it("sends a null observed id when the payload has no session_id", async () => {
     stubStdin({
       isTTY: false,

--- a/clients/traycer-cli/src/commands/__tests__/agent-session-observed-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-session-observed-from-hook.test.ts
@@ -164,13 +164,37 @@ describe("buildAgentSessionObservedFromHookCommand", () => {
     expect(result.data).toEqual({ accepted: false, reason: "no-session" });
   });
 
-  it("noops for a non-claude provider without reading its stdin payload", async () => {
+  it("resyncs the observed opencode root-session id too", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "ses-oc-fresh-1" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "opencode",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "opencode",
+      event: "resync",
+      observedHarnessSessionId: "ses-oc-fresh-1",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({ accepted: true, reason: null });
+  });
+
+  it("noops for a non-resync provider without reading its stdin payload", async () => {
     stubStdin({
       isTTY: false,
       chunks: [JSON.stringify({ session_id: "ignored" })],
     });
     const fn = buildAgentSessionObservedFromHookCommand({
-      provider: "opencode",
+      provider: "codex",
       epicId: null,
       agentId: null,
     });

--- a/clients/traycer-cli/src/commands/__tests__/agent-session-observed-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-session-observed-from-hook.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildAgentSessionObservedFromHookCommand } from "../agent-session-observed-from-hook";
+import type { CommandContext } from "../../runner/runner";
+import type { RuntimeContext } from "../../runner/runtime";
+import { noopLogger } from "../../logger";
+import { callHostRpcFastFail } from "../../internal/host-rpc";
+import { cliError, CLI_ERROR_CODES } from "../../runner/errors";
+import { HostRpcError } from "../../../../shared/host-transport/host-messenger";
+
+vi.mock("../../internal/host-rpc", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../internal/host-rpc")
+  >("../../internal/host-rpc");
+  return {
+    ...actual,
+    callHostRpcFastFail: vi.fn(),
+  };
+});
+
+const rpcMock = vi.mocked(callHostRpcFastFail);
+
+function makeRuntime(): RuntimeContext {
+  return {
+    json: false,
+    quiet: false,
+    noProgress: false,
+    noBootstrap: false,
+    nonInteractive: false,
+    environment: "production",
+    logger: noopLogger,
+  };
+}
+
+function makeCtx(): CommandContext {
+  return {
+    runtime: makeRuntime(),
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+const realStdin = Object.getOwnPropertyDescriptor(process, "stdin");
+
+function stubStdin(value: {
+  isTTY: boolean;
+  chunks: ReadonlyArray<string>;
+}): void {
+  Object.defineProperty(process, "stdin", {
+    configurable: true,
+    value: {
+      isTTY: value.isTTY,
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of value.chunks) yield Buffer.from(chunk);
+      },
+    },
+  });
+}
+
+const PREV_ENV = {
+  epic: process.env.TRAYCER_EPIC_ID,
+  agent: process.env.TRAYCER_AGENT_ID,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rpcMock.mockResolvedValue({ accepted: true });
+  process.env.TRAYCER_EPIC_ID = "epic-1";
+  process.env.TRAYCER_AGENT_ID = "agent-1";
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  if (realStdin !== undefined) {
+    Object.defineProperty(process, "stdin", realStdin);
+  }
+  if (PREV_ENV.epic === undefined) delete process.env.TRAYCER_EPIC_ID;
+  else process.env.TRAYCER_EPIC_ID = PREV_ENV.epic;
+  if (PREV_ENV.agent === undefined) delete process.env.TRAYCER_AGENT_ID;
+  else process.env.TRAYCER_AGENT_ID = PREV_ENV.agent;
+});
+
+describe("buildAgentSessionObservedFromHookCommand", () => {
+  it("resyncs the observed id via a recordActivity resync edge", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [
+        JSON.stringify({ session_id: "sess-fresh-1", source: "resume" }),
+      ],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-1",
+      tuiAgentId: "agent-1",
+      harnessSessionId: null,
+      harnessId: "claude",
+      event: "resync",
+      observedHarnessSessionId: "sess-fresh-1",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({ accepted: true, reason: null });
+  });
+
+  it("prefers --epic-id and --agent-id flags over env", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-flag" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: "epic-flag",
+      agentId: "agent-flag",
+    });
+    await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledWith("agent.tui.recordActivity", {
+      epicId: "epic-flag",
+      tuiAgentId: "agent-flag",
+      harnessSessionId: null,
+      harnessId: "claude",
+      event: "resync",
+      observedHarnessSessionId: "sess-flag",
+    });
+  });
+
+  it("noops when the payload has no session id (nothing to resync)", async () => {
+    stubStdin({ isTTY: false, chunks: [JSON.stringify({ source: "clear" })] });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(result.data).toEqual({ accepted: false, reason: "no-session" });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("noops on empty stdin", async () => {
+    stubStdin({ isTTY: false, chunks: [] });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(result.data).toEqual({ accepted: false, reason: "no-session" });
+  });
+
+  it("noops for a non-claude provider without reading its stdin payload", async () => {
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "ignored" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "opencode",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(result.data).toEqual({ accepted: false, reason: "no-session" });
+  });
+
+  it("noops with exit 0 on unknown provider", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "s" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "bogus",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "unknown-provider",
+    });
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("noops when identity context is missing", async () => {
+    delete process.env.TRAYCER_AGENT_ID;
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "s" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).not.toHaveBeenCalled();
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "missing-context",
+    });
+  });
+
+  it("noops (host-too-old) when the request cannot project onto an older host", async () => {
+    // A newer CLI negotiated recordActivity@1.1, but the running host only
+    // speaks @1.0, whose event enum has no "resync": the transport fails to
+    // project the request locally (before sending) and raises this RPC_ERROR.
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    rpcMock.mockRejectedValueOnce(
+      new HostRpcError({
+        code: "RPC_ERROR",
+        message:
+          "Failed to project request params onto 1.0: Invalid enum value.",
+        requestId: "req-x",
+        method: "agent.tui.recordActivity",
+        fatalDetails: null,
+      }),
+    );
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-x" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "host-too-old",
+    });
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("still surfaces a genuine host RPC_ERROR (distinct from a projection miss)", async () => {
+    // A real host-side RPC_ERROR (e.g. resolver failure) must NOT be swallowed
+    // as host-too-old - only the specific request-projection message is benign.
+    rpcMock.mockRejectedValueOnce(
+      new HostRpcError({
+        code: "RPC_ERROR",
+        message: "terminal agent not found",
+        requestId: "req-y",
+        method: "agent.tui.recordActivity",
+        fatalDetails: null,
+      }),
+    );
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-y" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: null,
+      agentId: null,
+    });
+    await expect(fn(makeCtx())).rejects.toThrow(/terminal agent not found/);
+  });
+
+  it("noops with exit 0 when the host is not running", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    rpcMock.mockRejectedValueOnce(
+      cliError({
+        code: CLI_ERROR_CODES.HOST_NOT_RUNNING,
+        message: "traycer: host not running",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-x" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: null,
+      agentId: null,
+    });
+    const result = await fn(makeCtx());
+
+    expect(rpcMock).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.data).toEqual({
+      accepted: false,
+      reason: "host-unreachable",
+    });
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("still surfaces non-benign host errors (e.g. auth rejected)", async () => {
+    rpcMock.mockRejectedValueOnce(
+      cliError({
+        code: CLI_ERROR_CODES.AUTH_REJECTED,
+        message: "traycer: bearer rejected",
+        details: null,
+        exitCode: 1,
+      }),
+    );
+    stubStdin({
+      isTTY: false,
+      chunks: [JSON.stringify({ session_id: "sess-x" })],
+    });
+    const fn = buildAgentSessionObservedFromHookCommand({
+      provider: "claude",
+      epicId: null,
+      agentId: null,
+    });
+    await expect(fn(makeCtx())).rejects.toThrow(/bearer rejected/);
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/agent-session-observed-from-hook.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-session-observed-from-hook.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildAgentSessionObservedFromHookCommand } from "../agent-session-observed-from-hook";
-import type { CommandContext } from "../../runner/runner";
-import type { RuntimeContext } from "../../runner/runtime";
-import { noopLogger } from "../../logger";
 import { callHostRpcFastFail } from "../../internal/host-rpc";
 import { cliError, CLI_ERROR_CODES } from "../../runner/errors";
 import { HostRpcError } from "../../../../shared/host-transport/host-messenger";
+import {
+  makeCtx,
+  restoreAgentIdentityEnv,
+  restoreStdin,
+  setAgentIdentityEnv,
+  stubStdin,
+} from "./hook-test-helpers";
 
 vi.mock("../../internal/host-rpc", async () => {
   const actual = await vi.importActual<
@@ -19,72 +23,18 @@ vi.mock("../../internal/host-rpc", async () => {
 
 const rpcMock = vi.mocked(callHostRpcFastFail);
 
-function makeRuntime(): RuntimeContext {
-  return {
-    json: false,
-    quiet: false,
-    noProgress: false,
-    noBootstrap: false,
-    nonInteractive: false,
-    environment: "production",
-    logger: noopLogger,
-  };
-}
-
-function makeCtx(): CommandContext {
-  return {
-    runtime: makeRuntime(),
-    output: {
-      progress: vi.fn(),
-      human: vi.fn(),
-      humanRequired: vi.fn(),
-      emitResult: vi.fn(),
-      emitError: vi.fn(),
-    },
-    progress: vi.fn(),
-  };
-}
-
-const realStdin = Object.getOwnPropertyDescriptor(process, "stdin");
-
-function stubStdin(value: {
-  isTTY: boolean;
-  chunks: ReadonlyArray<string>;
-}): void {
-  Object.defineProperty(process, "stdin", {
-    configurable: true,
-    value: {
-      isTTY: value.isTTY,
-      async *[Symbol.asyncIterator]() {
-        for (const chunk of value.chunks) yield Buffer.from(chunk);
-      },
-    },
-  });
-}
-
-const PREV_ENV = {
-  epic: process.env.TRAYCER_EPIC_ID,
-  agent: process.env.TRAYCER_AGENT_ID,
-};
-
 beforeEach(() => {
   vi.clearAllMocks();
   rpcMock.mockResolvedValue({ accepted: true });
-  process.env.TRAYCER_EPIC_ID = "epic-1";
-  process.env.TRAYCER_AGENT_ID = "agent-1";
+  setAgentIdentityEnv();
 });
 
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   vi.clearAllMocks();
-  if (realStdin !== undefined) {
-    Object.defineProperty(process, "stdin", realStdin);
-  }
-  if (PREV_ENV.epic === undefined) delete process.env.TRAYCER_EPIC_ID;
-  else process.env.TRAYCER_EPIC_ID = PREV_ENV.epic;
-  if (PREV_ENV.agent === undefined) delete process.env.TRAYCER_AGENT_ID;
-  else process.env.TRAYCER_AGENT_ID = PREV_ENV.agent;
+  restoreStdin();
+  restoreAgentIdentityEnv();
 });
 
 describe("buildAgentSessionObservedFromHookCommand", () => {

--- a/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/cli-entrypoint-registration.test.ts
@@ -186,9 +186,11 @@ describe("traycer CLI entrypoint registration", () => {
     expect(help).not.toContain("title-from-hook");
     expect(help).not.toContain("activity-from-hook");
     expect(help).not.toContain("turn-ended-from-hook");
+    expect(help).not.toContain("session-observed-from-hook");
     expectCommand(program, ["agent", "title-from-hook"]);
     expectCommand(program, ["agent", "activity-from-hook"]);
     expectCommand(program, ["agent", "turn-ended-from-hook"]);
+    expectCommand(program, ["agent", "session-observed-from-hook"]);
   });
 
   it("agent create exposes --name for a child agent display name", () => {

--- a/clients/traycer-cli/src/commands/__tests__/hook-test-helpers.ts
+++ b/clients/traycer-cli/src/commands/__tests__/hook-test-helpers.ts
@@ -1,0 +1,77 @@
+import { vi } from "vitest";
+import type { CommandContext } from "../../runner/runner";
+import type { RuntimeContext } from "../../runner/runtime";
+import { noopLogger } from "../../logger";
+
+// Shared fixtures for the provider-hook command tests (activity-from-hook /
+// session-observed-from-hook), which drive the same command shape: a mocked
+// runner context, a stubbed `process.stdin`, and TRAYCER_* env save/restore.
+
+export function makeRuntime(): RuntimeContext {
+  return {
+    json: false,
+    quiet: false,
+    noProgress: false,
+    noBootstrap: false,
+    nonInteractive: false,
+    environment: "production",
+    logger: noopLogger,
+  };
+}
+
+export function makeCtx(): CommandContext {
+  return {
+    runtime: makeRuntime(),
+    output: {
+      progress: vi.fn(),
+      human: vi.fn(),
+      humanRequired: vi.fn(),
+      emitResult: vi.fn(),
+      emitError: vi.fn(),
+    },
+    progress: vi.fn(),
+  };
+}
+
+const realStdin = Object.getOwnPropertyDescriptor(process, "stdin");
+
+export function stubStdin(value: {
+  isTTY: boolean;
+  chunks: ReadonlyArray<string>;
+}): void {
+  Object.defineProperty(process, "stdin", {
+    configurable: true,
+    value: {
+      isTTY: value.isTTY,
+      async *[Symbol.asyncIterator]() {
+        for (const chunk of value.chunks) yield Buffer.from(chunk);
+      },
+    },
+  });
+}
+
+export function restoreStdin(): void {
+  if (realStdin !== undefined) {
+    Object.defineProperty(process, "stdin", realStdin);
+  }
+}
+
+// Snapshot the agent-identity env once at import, then set test values on
+// `beforeEach` and restore the snapshot on `afterEach`, so a test that mutates
+// or clears these vars cannot leak into the surrounding process env.
+const PREV_ENV = {
+  epic: process.env.TRAYCER_EPIC_ID,
+  agent: process.env.TRAYCER_AGENT_ID,
+};
+
+export function setAgentIdentityEnv(): void {
+  process.env.TRAYCER_EPIC_ID = "epic-1";
+  process.env.TRAYCER_AGENT_ID = "agent-1";
+}
+
+export function restoreAgentIdentityEnv(): void {
+  if (PREV_ENV.epic === undefined) delete process.env.TRAYCER_EPIC_ID;
+  else process.env.TRAYCER_EPIC_ID = PREV_ENV.epic;
+  if (PREV_ENV.agent === undefined) delete process.env.TRAYCER_AGENT_ID;
+  else process.env.TRAYCER_AGENT_ID = PREV_ENV.agent;
+}

--- a/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
@@ -23,12 +23,17 @@ type NoopReason =
  * `traycer agent activity-from-hook` - invoked by provider TUI lifecycle
  * hooks. It reports provider-native turn start/stop edges to the host.
  *
- * For Claude, it also piggybacks the live `session_id` (stamped on the hook's
+ * It also piggybacks the live provider session id (stamped on the hook's
  * stdin payload) as `observedHarnessSessionId` so the host can resync the
- * stored `harnessSessionId` when Claude implicitly re-ids its session (Esc-Esc
- * rewind, `/clear`, fork-after-`/btw`, …). Only Claude stamps a usable id, so
- * stdin is read for that provider alone; a missing/slow/garbage payload yields
- * `null` and never fails the hook.
+ * stored `harnessSessionId` when the live session drifts under the user
+ * (Claude implicitly re-ids on Esc-Esc rewind, `/clear`, fork-after-`/btw`;
+ * OpenCode re-ids when the user switches/forks sessions inside the TUI).
+ * Stdin is read only where a resumable id is actually piped: every Claude
+ * hook, and OpenCode's env-identified form (the per-TUI plugin instance omits
+ * `--harness-session-id` for root sessions and pipes the id instead - its
+ * session-id-keyed form never pipes a payload, and the host would refuse a
+ * resync from it anyway). A missing/slow/garbage payload yields `null` and
+ * never fails the hook.
  *
  * Like the title hook command, this is intentionally quiet: hooks can fire
  * outside Traycer-managed sessions, and their stdout may be surfaced back into
@@ -58,11 +63,12 @@ export function buildAgentActivityFromHookCommand(opts: {
       return noop("missing-context");
     }
 
-    // Only Claude stamps a resumable `session_id` on its hook stdin; for other
-    // providers there is nothing to resync, so we skip the read entirely
-    // (avoids blocking on a stream they don't pipe a payload to).
+    // Read stdin only where a resumable `session_id` is actually piped (see
+    // the command doc); skipping elsewhere avoids blocking on a stream the
+    // caller never writes to (Codex `notify`, OpenCode session-id-keyed form).
     const observedHarnessSessionId =
-      parsedHarness.data === "claude"
+      parsedHarness.data === "claude" ||
+      (parsedHarness.data === "opencode" && harnessSessionId === null)
         ? await readObservedHarnessSessionId()
         : null;
 

--- a/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-activity-from-hook.ts
@@ -1,5 +1,5 @@
 import {
-  recordTuiAgentActivityRequestSchema,
+  recordTuiAgentActivityRequestSchemaV11,
   recordTuiAgentActivityResponseSchema,
 } from "@traycer/protocol/host/agent/tui/unary-schemas";
 import { tuiHarnessIdSchema } from "@traycer/protocol/host/agent/shared";
@@ -10,6 +10,7 @@ import {
   toAgentCliError,
 } from "../internal/host-rpc";
 import { readEpicId, readTuiAgentId } from "../internal/agent-context";
+import { readObservedHarnessSessionId } from "../internal/hook-stdin";
 import { CliError, CLI_ERROR_CODES } from "../runner/errors";
 import type { CommandFn } from "../runner/runner";
 
@@ -21,6 +22,13 @@ type NoopReason =
 /**
  * `traycer agent activity-from-hook` - invoked by provider TUI lifecycle
  * hooks. It reports provider-native turn start/stop edges to the host.
+ *
+ * For Claude, it also piggybacks the live `session_id` (stamped on the hook's
+ * stdin payload) as `observedHarnessSessionId` so the host can resync the
+ * stored `harnessSessionId` when Claude implicitly re-ids its session (Esc-Esc
+ * rewind, `/clear`, fork-after-`/btw`, …). Only Claude stamps a usable id, so
+ * stdin is read for that provider alone; a missing/slow/garbage payload yields
+ * `null` and never fails the hook.
  *
  * Like the title hook command, this is intentionally quiet: hooks can fire
  * outside Traycer-managed sessions, and their stdout may be surfaced back into
@@ -50,12 +58,21 @@ export function buildAgentActivityFromHookCommand(opts: {
       return noop("missing-context");
     }
 
-    const request = parseUserInput(recordTuiAgentActivityRequestSchema, {
+    // Only Claude stamps a resumable `session_id` on its hook stdin; for other
+    // providers there is nothing to resync, so we skip the read entirely
+    // (avoids blocking on a stream they don't pipe a payload to).
+    const observedHarnessSessionId =
+      parsedHarness.data === "claude"
+        ? await readObservedHarnessSessionId()
+        : null;
+
+    const request = parseUserInput(recordTuiAgentActivityRequestSchemaV11, {
       epicId,
       tuiAgentId,
       harnessSessionId,
       harnessId: parsedHarness.data,
       event,
+      observedHarnessSessionId,
     });
     const rpcResult = await toAgentCliError(
       callHostRpcFastFail("agent.tui.recordActivity", request),

--- a/clients/traycer-cli/src/commands/agent-session-observed-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-session-observed-from-hook.ts
@@ -24,25 +24,27 @@ type NoopReason =
 
 /**
  * `traycer agent session-observed-from-hook --provider <provider>` - invoked
- * by the Claude Code `SessionStart` hook. It reports the live `session_id`
- * (stamped on the hook's stdin payload) to the host so the stored
- * `harnessSessionId` resyncs to whatever the user currently sees in the PTY.
+ * by the Claude Code `SessionStart` hook and by the OpenCode plugin when the
+ * TUI's sighted root session changes. It reports the live session id (stamped
+ * on the hook's stdin payload) to the host so the stored `harnessSessionId`
+ * resyncs to whatever the user currently sees in the PTY.
  *
  * This closes the gap the `start`/`stop` activity hooks leave open: when the
- * user rewinds/forks (Esc-Esc, `/clear`, fork-after-`/btw`) then immediately
- * closes or forks the tab WITHOUT another prompt, `SessionStart` still fires at
- * the drift moment and pushes the fresh id. It is deliberately NOT an activity
- * edge - it rides `agent.tui.recordActivity@1.1` with `event: "resync"`, which
- * the host resolver treats as a pure session write-back that never touches the
- * activity oracle. (A dedicated CLI command keeps the activity command clean; a
- * new RPC method name is impossible - it would fatally break the frozen `/rpc`
- * handshake against a shipped v1.0 host.)
+ * user rewinds/forks/switches sessions then immediately closes or forks the
+ * tab WITHOUT another prompt, this still fires at the drift moment and pushes
+ * the fresh id. It is deliberately NOT an activity edge - it rides
+ * `agent.tui.recordActivity@1.1` with `event: "resync"`, which the host
+ * resolver treats as a pure session write-back that never touches the
+ * activity oracle. (A dedicated CLI command keeps the activity command clean;
+ * a new RPC method name is impossible - it would fatally break the frozen
+ * `/rpc` handshake against a shipped v1.0 host.)
  *
  * Like the other hook commands it is intentionally lenient: an unknown
  * provider, missing `TRAYCER_EPIC_ID` / `TRAYCER_AGENT_ID`, an unreadable
  * `session_id`, or a host-not-running condition all exit cleanly (exit 0,
- * `accepted: false`) with no stderr noise. Only Claude drives resync, so a
- * non-Claude provider reads no id and no-ops.
+ * `accepted: false`) with no stderr noise. Only Claude and OpenCode drive
+ * resync (Codex ships no hook surface), so other providers read no id and
+ * no-op.
  */
 export function buildAgentSessionObservedFromHookCommand(opts: {
   readonly provider: string;
@@ -60,11 +62,14 @@ export function buildAgentSessionObservedFromHookCommand(opts: {
       return noop("missing-context");
     }
 
-    // Resync is Claude-only (only Claude stamps a resumable id and only its
-    // record is registry-safe to rewrite). For any other provider there is
-    // nothing to observe, so we skip the stdin read and no-op.
+    // Resync providers: Claude (SessionStart pipes the live id) and OpenCode
+    // (the per-TUI plugin pipes the sighted root-session id; the host rekeys
+    // its session registry in lockstep). Codex ships no hook surface; for any
+    // other provider there is nothing to observe, so skip the read and no-op.
     const observedHarnessSessionId =
-      harnessId === "claude" ? await readObservedHarnessSessionId() : null;
+      harnessId === "claude" || harnessId === "opencode"
+        ? await readObservedHarnessSessionId()
+        : null;
     if (observedHarnessSessionId === null) {
       return noop("no-session");
     }

--- a/clients/traycer-cli/src/commands/agent-session-observed-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-session-observed-from-hook.ts
@@ -1,0 +1,137 @@
+import {
+  recordTuiAgentActivityRequestSchemaV11,
+  recordTuiAgentActivityResponseSchema,
+} from "@traycer/protocol/host/agent/tui/unary-schemas";
+import { tuiHarnessIdSchema } from "@traycer/protocol/host/agent/shared";
+import {
+  callHostRpcFastFail,
+  isRequestVersionProjectionError,
+  parseHostResponse,
+  parseUserInput,
+  toAgentCliError,
+} from "../internal/host-rpc";
+import { readEpicId, readTuiAgentId } from "../internal/agent-context";
+import { readObservedHarnessSessionId } from "../internal/hook-stdin";
+import { CliError, CLI_ERROR_CODES } from "../runner/errors";
+import type { CommandFn } from "../runner/runner";
+
+type NoopReason =
+  | "missing-context"
+  | "unknown-provider"
+  | "no-session"
+  | "host-too-old"
+  | "host-unreachable";
+
+/**
+ * `traycer agent session-observed-from-hook --provider <provider>` - invoked
+ * by the Claude Code `SessionStart` hook. It reports the live `session_id`
+ * (stamped on the hook's stdin payload) to the host so the stored
+ * `harnessSessionId` resyncs to whatever the user currently sees in the PTY.
+ *
+ * This closes the gap the `start`/`stop` activity hooks leave open: when the
+ * user rewinds/forks (Esc-Esc, `/clear`, fork-after-`/btw`) then immediately
+ * closes or forks the tab WITHOUT another prompt, `SessionStart` still fires at
+ * the drift moment and pushes the fresh id. It is deliberately NOT an activity
+ * edge - it rides `agent.tui.recordActivity@1.1` with `event: "resync"`, which
+ * the host resolver treats as a pure session write-back that never touches the
+ * activity oracle. (A dedicated CLI command keeps the activity command clean; a
+ * new RPC method name is impossible - it would fatally break the frozen `/rpc`
+ * handshake against a shipped v1.0 host.)
+ *
+ * Like the other hook commands it is intentionally lenient: an unknown
+ * provider, missing `TRAYCER_EPIC_ID` / `TRAYCER_AGENT_ID`, an unreadable
+ * `session_id`, or a host-not-running condition all exit cleanly (exit 0,
+ * `accepted: false`) with no stderr noise. Only Claude drives resync, so a
+ * non-Claude provider reads no id and no-ops.
+ */
+export function buildAgentSessionObservedFromHookCommand(opts: {
+  readonly provider: string;
+  readonly epicId: string | null;
+  readonly agentId: string | null;
+}): CommandFn {
+  return async () => {
+    const parsedHarness = tuiHarnessIdSchema.safeParse(opts.provider);
+    if (!parsedHarness.success) return noop("unknown-provider");
+    const harnessId = parsedHarness.data;
+
+    const epicId = readEpicId(opts.epicId);
+    const tuiAgentId = readTuiAgentId(opts.agentId);
+    if (epicId === null || tuiAgentId === null) {
+      return noop("missing-context");
+    }
+
+    // Resync is Claude-only (only Claude stamps a resumable id and only its
+    // record is registry-safe to rewrite). For any other provider there is
+    // nothing to observe, so we skip the stdin read and no-op.
+    const observedHarnessSessionId =
+      harnessId === "claude" ? await readObservedHarnessSessionId() : null;
+    if (observedHarnessSessionId === null) {
+      return noop("no-session");
+    }
+
+    const request = parseUserInput(recordTuiAgentActivityRequestSchemaV11, {
+      epicId,
+      tuiAgentId,
+      harnessSessionId: null,
+      harnessId,
+      event: "resync",
+      observedHarnessSessionId,
+    });
+
+    // Two benign version-skew / liveness conditions degrade to a quiet no-op;
+    // everything else (auth, genuine host errors) still surfaces:
+    //   • host-too-old: a newer CLI vs a host that only speaks
+    //     recordActivity@1.0 has no `event: "resync"`, so the transport fails to
+    //     project this request onto the host's older minor locally, before it is
+    //     sent (unlike the additive `observedHarnessSessionId` field, an unknown
+    //     enum value can't be stripped). A resync against a pre-1.1 host is
+    //     meaningless, so it must not surface as hook noise. Caught on the raw
+    //     transport error, before `toAgentCliError` buckets it as UNEXPECTED.
+    //   • host-unreachable: the hook fires unconditionally and the host may
+    //     simply not be up.
+    const rpcResult = await toAgentCliError(
+      callHostRpcFastFail("agent.tui.recordActivity", request).catch(
+        (err: unknown) => {
+          if (isRequestVersionProjectionError(err)) {
+            return "host-too-old" as const;
+          }
+          throw err;
+        },
+      ),
+    ).catch((err: unknown) => {
+      if (
+        err instanceof CliError &&
+        err.code === CLI_ERROR_CODES.HOST_NOT_RUNNING
+      ) {
+        return "host-unreachable" as const;
+      }
+      throw err;
+    });
+    if (rpcResult === "host-too-old") {
+      return noop("host-too-old");
+    }
+    if (rpcResult === "host-unreachable") {
+      return noop("host-unreachable");
+    }
+
+    const { accepted } = parseHostResponse(
+      recordTuiAgentActivityResponseSchema,
+      rpcResult,
+    );
+    // No `human` line: a SessionStart hook's stdout is surfaced back into the
+    // Claude TUI as context, and a status string would only be noise.
+    return {
+      data: { accepted, reason: null },
+      human: null,
+      exitCode: 0,
+    };
+  };
+}
+
+function noop(reason: NoopReason) {
+  return {
+    data: { accepted: false, reason },
+    human: null,
+    exitCode: 0,
+  };
+}

--- a/clients/traycer-cli/src/commands/agent-title-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-title-from-hook.ts
@@ -12,10 +12,9 @@ import {
   toAgentCliError,
 } from "../internal/host-rpc";
 import { readEpicId, readTuiAgentId } from "../internal/agent-context";
+import { readStdinJson } from "../internal/hook-stdin";
 import { CliError, CLI_ERROR_CODES } from "../runner/errors";
 import type { CommandFn } from "../runner/runner";
-
-const STDIN_READ_TIMEOUT_MS = 5_000;
 
 /**
  * Provider hook payloads we accept on stdin. Each provider hands us a
@@ -172,65 +171,4 @@ function extractPrompt(
   // Cursor TUI exists in the schema but ships no hook payload contract
   // yet; treat as a quiet no-op rather than failing the hook.
   return null;
-}
-
-/**
- * Read stdin as JSON, with a hard timeout. Returns:
- *   - `"timeout"` if the read didn't finish in time (caller noops);
- *   - `null` for an empty stream, unparsable JSON, or a TTY stdin;
- *   - the parsed JSON value otherwise.
- *
- * On timeout we explicitly `destroy()` stdin to release the async iterator
- * and let the event loop exit cleanly. (Without this, `for await (chunk of
- * process.stdin)` keeps the loop alive even after we've resolved.)
- */
-async function readStdinJson(): Promise<unknown | "timeout"> {
-  if (process.stdin.isTTY === true) return null;
-
-  const read = (async (): Promise<string> => {
-    const chunks: Buffer[] = [];
-    for await (const chunk of process.stdin) {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks).toString("utf8");
-  })();
-  // When the timeout branch wins and we call `process.stdin.destroy()`,
-  // the still-pending `for await` iterator above rejects. Attach a
-  // no-op catch so that rejection doesn't bubble up as an unhandled
-  // promise rejection - the timeout outcome is already wired through
-  // `wrappedRead` / `timeout` below.
-  read.catch(() => {});
-
-  let timer: NodeJS.Timeout | undefined;
-  type Outcome = { kind: "ok"; raw: string } | { kind: "timeout" };
-  const timeout = new Promise<Outcome>((resolve) => {
-    timer = setTimeout(
-      () => resolve({ kind: "timeout" }),
-      STDIN_READ_TIMEOUT_MS,
-    );
-  });
-  const wrappedRead = read.then((raw): Outcome => ({ kind: "ok", raw }));
-
-  const winner = await Promise.race([wrappedRead, timeout]);
-  if (timer !== undefined) clearTimeout(timer);
-  if (winner.kind === "timeout") {
-    // Release the async iterator so the process can exit promptly.
-    try {
-      process.stdin.destroy();
-    } catch {
-      // best-effort
-    }
-    return "timeout";
-  }
-  const raw = winner.raw;
-  if (raw.trim().length === 0) return null;
-  return safeJsonParse(raw);
-}
-
-function safeJsonParse(raw: string): unknown {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
 }

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -20,6 +20,7 @@ import { buildAgentSelectionGuideCommand } from "./commands/agent-selection-guid
 import { buildAgentSendCommand } from "./commands/agent-send";
 import { buildAgentTitleFromHookCommand } from "./commands/agent-title-from-hook";
 import { buildAgentTurnEndedFromHookCommand } from "./commands/agent-turn-ended-from-hook";
+import { buildAgentSessionObservedFromHookCommand } from "./commands/agent-session-observed-from-hook";
 import { buildAgentTranscriptCommand } from "./commands/agent-transcript";
 import { buildAgentInboxCommand } from "./commands/agent-inbox";
 import { buildWorkspaceListCommand } from "./commands/workspace-list";
@@ -1305,6 +1306,32 @@ function registerAgentCommands(program: Command): void {
       ),
     (opts) =>
       buildAgentTurnEndedFromHookCommand({
+        provider: typeof opts.provider === "string" ? opts.provider : "",
+        epicId: typeof opts.epicId === "string" ? opts.epicId : null,
+        agentId: typeof opts.agentId === "string" ? opts.agentId : null,
+      }),
+  );
+
+  withRunner(
+    agent
+      .command("session-observed-from-hook", { hidden: true })
+      .description(
+        "Report the live provider session id (read as hook JSON on stdin) so the host resyncs the stored harness session id (Claude SessionStart hook).",
+      )
+      .requiredOption(
+        "--provider <provider>",
+        "Provider hook firing this call: 'claude', 'codex', or 'opencode'",
+      )
+      .option(
+        "--epic-id <id>",
+        "Epic the agent lives in (defaults to $TRAYCER_EPIC_ID)",
+      )
+      .option(
+        "--agent-id <id>",
+        "TUI agent id whose session id to resync (defaults to $TRAYCER_AGENT_ID)",
+      ),
+    (opts) =>
+      buildAgentSessionObservedFromHookCommand({
         provider: typeof opts.provider === "string" ? opts.provider : "",
         epicId: typeof opts.epicId === "string" ? opts.epicId : null,
         agentId: typeof opts.agentId === "string" ? opts.agentId : null,

--- a/clients/traycer-cli/src/internal/hook-stdin.ts
+++ b/clients/traycer-cli/src/internal/hook-stdin.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+
+const STDIN_READ_TIMEOUT_MS = 5_000;
+
+/**
+ * Read stdin as JSON, with a hard timeout. Returns:
+ *   - `"timeout"` if the read didn't finish in time (caller noops);
+ *   - `null` for an empty stream, unparsable JSON, or a TTY stdin;
+ *   - the parsed JSON value otherwise.
+ *
+ * Shared by the provider hook commands (title / activity / session-observed):
+ * each is invoked by a provider hook that pipes its JSON payload on stdin, and
+ * each must degrade to a quiet no-op on a missing/slow/garbage stream rather
+ * than fail the hook.
+ *
+ * On timeout we explicitly `destroy()` stdin to release the async iterator
+ * and let the event loop exit cleanly. (Without this, `for await (chunk of
+ * process.stdin)` keeps the loop alive even after we've resolved.)
+ */
+export async function readStdinJson(): Promise<unknown | "timeout"> {
+  if (process.stdin.isTTY === true) return null;
+
+  const read = (async (): Promise<string> => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks).toString("utf8");
+  })();
+  // When the timeout branch wins and we call `process.stdin.destroy()`,
+  // the still-pending `for await` iterator above rejects. Attach a
+  // no-op catch so that rejection doesn't bubble up as an unhandled
+  // promise rejection - the timeout outcome is already wired through
+  // `wrappedRead` / `timeout` below.
+  read.catch(() => {});
+
+  let timer: NodeJS.Timeout | undefined;
+  type Outcome = { kind: "ok"; raw: string } | { kind: "timeout" };
+  const timeout = new Promise<Outcome>((resolve) => {
+    timer = setTimeout(
+      () => resolve({ kind: "timeout" }),
+      STDIN_READ_TIMEOUT_MS,
+    );
+  });
+  const wrappedRead = read.then((raw): Outcome => ({ kind: "ok", raw }));
+
+  const winner = await Promise.race([wrappedRead, timeout]);
+  if (timer !== undefined) clearTimeout(timer);
+  if (winner.kind === "timeout") {
+    // Release the async iterator so the process can exit promptly.
+    try {
+      process.stdin.destroy();
+    } catch {
+      // best-effort
+    }
+    return "timeout";
+  }
+  const raw = winner.raw;
+  if (raw.trim().length === 0) return null;
+  return safeJsonParse(raw);
+}
+
+// Every Claude Code hook stamps the live `session_id` on its stdin JSON. We
+// extract it with a loose object so unrelated fields on the payload are
+// ignored and a schema drift never fails the hook.
+const observedSessionSchema = z.looseObject({ session_id: z.string() });
+
+/**
+ * Read the live provider `session_id` from the hook stdin payload, for the
+ * Claude TUI session-id resync. Returns the trimmed non-empty id, or `null`
+ * for any benign condition (empty/TTY/timeout stdin, unparsable JSON, missing
+ * or blank `session_id`). Never throws - a resync that can't read an id is a
+ * quiet no-op, never a failed hook.
+ */
+export async function readObservedHarnessSessionId(): Promise<string | null> {
+  const stdin = await readStdinJson();
+  if (stdin === "timeout" || stdin === null) return null;
+  const parsed = observedSessionSchema.safeParse(stdin);
+  if (!parsed.success) return null;
+  const sessionId = parsed.data.session_id.trim();
+  return sessionId.length === 0 ? null : sessionId;
+}
+
+function safeJsonParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}

--- a/clients/traycer-cli/src/internal/hook-stdin.ts
+++ b/clients/traycer-cli/src/internal/hook-stdin.ts
@@ -27,13 +27,6 @@ export async function readStdinJson(): Promise<unknown | "timeout"> {
     }
     return Buffer.concat(chunks).toString("utf8");
   })();
-  // When the timeout branch wins and we call `process.stdin.destroy()`,
-  // the still-pending `for await` iterator above rejects. Attach a
-  // no-op catch so that rejection doesn't bubble up as an unhandled
-  // promise rejection - the timeout outcome is already wired through
-  // `wrappedRead` / `timeout` below.
-  read.catch(() => {});
-
   let timer: NodeJS.Timeout | undefined;
   type Outcome = { kind: "ok"; raw: string } | { kind: "timeout" };
   const timeout = new Promise<Outcome>((resolve) => {
@@ -42,7 +35,17 @@ export async function readStdinJson(): Promise<unknown | "timeout"> {
       STDIN_READ_TIMEOUT_MS,
     );
   });
-  const wrappedRead = read.then((raw): Outcome => ({ kind: "ok", raw }));
+  // `wrappedRead` must never reject: any stdin stream failure - including the
+  // `for await` iterator rejecting when the timeout branch calls
+  // `process.stdin.destroy()` - degrades to the same quiet no-op as an empty
+  // stream (`raw: ""` -> `null`). This is what upholds the "never throws"
+  // contract of `readObservedHarnessSessionId`; a hook must not fail on a
+  // stdin error. It also handles `read`'s rejection, so no separate
+  // unhandled-rejection catch is needed.
+  const wrappedRead = read.then(
+    (raw): Outcome => ({ kind: "ok", raw }),
+    (): Outcome => ({ kind: "ok", raw: "" }),
+  );
 
   const winner = await Promise.race([wrappedRead, timeout]);
   if (timer !== undefined) clearTimeout(timer);

--- a/clients/traycer-cli/src/internal/host-rpc.ts
+++ b/clients/traycer-cli/src/internal/host-rpc.ts
@@ -314,6 +314,35 @@ export async function toAgentCliError<T>(call: Promise<T>): Promise<T> {
   });
 }
 
+// Prefix of the message the shared transport throws when the client is the
+// newer side and its request cannot be projected onto the host's older minor
+// request schema (`prepareRequestPayload` in `ws-rpc-client.ts`). This is a
+// client-side failure raised during request preparation, before anything is
+// sent to the host.
+const REQUEST_PROJECTION_FAILURE_PREFIX =
+  "Failed to project request params onto";
+
+/**
+ * True when `err` is the transport's client-side request-projection failure -
+ * i.e. this CLI negotiated a newer canonical version for the method than the
+ * host speaks, and the request carries a value the host's older minor request
+ * schema cannot represent (e.g. a newer enum value that isn't strippable like an
+ * additive field). The transport raises this as a `RPC_ERROR` locally during
+ * request preparation, so it never reached the host.
+ *
+ * Best-effort hook commands use this to degrade a version-skew miss to a quiet
+ * no-op instead of surfacing it: the call is meaningless against a host too old
+ * to understand it. Matched narrowly (the specific code + preparation message)
+ * so genuine host `RPC_ERROR`s and auth failures still surface.
+ */
+export function isRequestVersionProjectionError(err: unknown): boolean {
+  return (
+    err instanceof HostRpcError &&
+    err.code === "RPC_ERROR" &&
+    err.message.startsWith(REQUEST_PROJECTION_FAILURE_PREFIX)
+  );
+}
+
 /**
  * Validate user-supplied request input against its protocol schema, turning a
  * schema failure into a clean `E_INVALID_ARGUMENT` instead of an uncaught

--- a/protocol/src/host/agent/tui/__tests__/record-activity-projection.test.ts
+++ b/protocol/src/host/agent/tui/__tests__/record-activity-projection.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  recordTuiAgentActivityRequestSchema,
+  recordTuiAgentActivityRequestSchemaV11,
+  type RecordTuiAgentActivityRequestV11,
+} from "@traycer/protocol/host/agent/tui/unary-schemas";
+
+/**
+ * Same-major minor projection: when a newer client (canonical @1.1) talks to a
+ * host that only speaks @1.0, the transport re-parses the request through the
+ * host's older-minor request schema before sending
+ * (`prepareRequestPayload` → `olderEntry.contract.requestSchema.safeParse`). A
+ * value that survives that parse is sent; one that fails raises a client-side
+ * `RPC_ERROR` before anything reaches the host.
+ *
+ * This pins the two cases the session-id resync work relies on:
+ *   • `start`/`stop` (activity hooks) carry the additive `observedHarnessSessionId`
+ *     field, which the v1.0 object schema strips - projection SUCCEEDS, so an old
+ *     host simply loses the resync and still records the activity edge.
+ *   • `resync` (SessionStart hook) is a v1.1-only enum value the v1.0 event enum
+ *     cannot represent - projection FAILS, which the SessionStart CLI command
+ *     turns into a quiet `host-too-old` no-op instead of hook noise.
+ */
+function canonical(
+  overrides: Partial<RecordTuiAgentActivityRequestV11>,
+): RecordTuiAgentActivityRequestV11 {
+  return recordTuiAgentActivityRequestSchemaV11.parse({
+    epicId: "epic-1",
+    tuiAgentId: "agent-1",
+    harnessSessionId: null,
+    harnessId: "claude",
+    event: "start",
+    observedHarnessSessionId: "sess-observed-1",
+    ...overrides,
+  });
+}
+
+describe("recordActivity@1.1 → @1.0 request projection", () => {
+  it("strips observedHarnessSessionId from a start edge (projection succeeds)", () => {
+    const result = recordTuiAgentActivityRequestSchema.safeParse(
+      canonical({ event: "start" }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        epicId: "epic-1",
+        tuiAgentId: "agent-1",
+        harnessSessionId: null,
+        harnessId: "claude",
+        event: "start",
+      });
+      expect(result.data).not.toHaveProperty("observedHarnessSessionId");
+    }
+  });
+
+  it("strips observedHarnessSessionId from a stop edge (projection succeeds)", () => {
+    const result = recordTuiAgentActivityRequestSchema.safeParse(
+      canonical({ event: "stop" }),
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.event).toBe("stop");
+      expect(result.data).not.toHaveProperty("observedHarnessSessionId");
+    }
+  });
+
+  it("rejects the resync edge - a v1.0 host cannot represent it (projection fails)", () => {
+    const result = recordTuiAgentActivityRequestSchema.safeParse(
+      canonical({ event: "resync" }),
+    );
+    expect(result.success).toBe(false);
+  });
+});

--- a/protocol/src/host/agent/tui/contracts.ts
+++ b/protocol/src/host/agent/tui/contracts.ts
@@ -1,4 +1,7 @@
-import { defineRpcContract } from "@traycer/protocol/framework/index";
+import {
+  defineRpcContract,
+  defineUpgradePath,
+} from "@traycer/protocol/framework/index";
 import {
   generateTuiAgentTitleRequestSchema,
   generateTuiAgentTitleResponseSchema,
@@ -7,6 +10,7 @@ import {
   prepareTuiLaunchRequestSchema,
   prepareTuiLaunchResponseSchema,
   recordTuiAgentActivityRequestSchema,
+  recordTuiAgentActivityRequestSchemaV11,
   recordTuiAgentActivityResponseSchema,
   tuiAgentTurnEndedRequestSchema,
   tuiAgentTurnEndedResponseSchema,
@@ -47,4 +51,36 @@ export const agentTuiRecordActivityV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: recordTuiAgentActivityRequestSchema,
   responseSchema: recordTuiAgentActivityResponseSchema,
+});
+
+/**
+ * `agent.tui.recordActivity@1.1` - adds the request-side
+ * `observedHarnessSessionId` (Claude TUI session-id resync) and the pure
+ * `event: "resync"` edge. The response is unchanged from v1.0. See the schema
+ * note in `unary-schemas.ts`.
+ */
+export const agentTuiRecordActivityV11 = defineRpcContract({
+  method: "agent.tui.recordActivity",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: recordTuiAgentActivityRequestSchemaV11,
+  responseSchema: recordTuiAgentActivityResponseSchema,
+});
+
+// A v1.0 request carries no observed id (nothing to resync) and only the
+// `start`/`stop` edges, both of which are a subset of the v1.1 event set. The
+// response is byte-identical, so its upgrade is the identity. A v1.1 peer
+// projects onto a v1.0 host by re-parsing through the (non-strict) v1.0 request
+// schema, which strips `observedHarnessSessionId` on the wire - so no downgrade
+// path is needed for the same-major minor.
+export const agentTuiRecordActivityUpgradeV10ToV11 = defineUpgradePath<
+  typeof agentTuiRecordActivityV10,
+  typeof agentTuiRecordActivityV11
+>({
+  from: agentTuiRecordActivityV10.schemaVersion,
+  to: agentTuiRecordActivityV11.schemaVersion,
+  upgradeRequest: (request) => ({
+    ...request,
+    observedHarnessSessionId: null,
+  }),
+  upgradeResponse: (response) => response,
 });

--- a/protocol/src/host/agent/tui/unary-schemas.ts
+++ b/protocol/src/host/agent/tui/unary-schemas.ts
@@ -214,3 +214,40 @@ export const recordTuiAgentActivityResponseSchema = z.object({
 export type RecordTuiAgentActivityResponse = z.infer<
   typeof recordTuiAgentActivityResponseSchema
 >;
+
+// ─── `agent.tui.recordActivity@1.1` - + observed session-id resync ────────
+//
+// Additive minor bump over v1.0. Two changes, both driven by the Claude TUI
+// session-id resync (Claude implicitly re-ids its session on Esc-Esc rewind,
+// `/clear`, fork-after-`/btw`, etc.; the stored `harnessSessionId` must follow
+// what the user currently sees in the PTY):
+//
+//   • `observedHarnessSessionId` - the live `session_id` Claude stamps on every
+//     hook's stdin payload. The resolver writes it back onto the record's
+//     `harnessSessionId` when it drifts (claude-gated). This is DISTINCT from
+//     the existing `harnessSessionId` request field, which stays an OpenCode
+//     match-or-reject identity guard - never overloaded here. `null` (the
+//     v1.0-upgraded default) means "no observed id / nothing to resync".
+//
+//   • `event: "resync"` - a pure resync edge that is NOT an activity edge: the
+//     resolver performs the session write-back but does NOT touch the activity
+//     oracle. Fired by the Claude `SessionStart` hook (a dedicated CLI command),
+//     which reports the fresh id at the drift moment even when the user rewinds
+//     then immediately closes/forks the tab without another prompt. The existing
+//     `start`/`stop` edges (UserPromptSubmit/Stop) also carry
+//     `observedHarnessSessionId`, so drift on a normal turn resyncs too.
+//
+// A new capability MUST ride a new `{ major, minor }` of an existing method,
+// never a new method name (a new name fatally fails the equal-set `/rpc`
+// handshake against a shipped v1.0.0 host). Adding the `"resync"` enum value is
+// additive-advisory growth: a v1.0 host only ever meets it via the new
+// SessionStart flow it does not have.
+
+export const recordTuiAgentActivityRequestSchemaV11 =
+  recordTuiAgentActivityRequestSchema.extend({
+    event: z.enum(["start", "stop", "resync"]),
+    observedHarnessSessionId: z.string().nullable().default(null),
+  });
+export type RecordTuiAgentActivityRequestV11 = z.infer<
+  typeof recordTuiAgentActivityRequestSchemaV11
+>;

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -56,6 +56,8 @@ import {
   agentTuiListHarnessesV10,
   agentTuiPrepareLaunchV10,
   agentTuiRecordActivityV10,
+  agentTuiRecordActivityV11,
+  agentTuiRecordActivityUpgradeV10ToV11,
 } from "@traycer/protocol/host/agent/tui/contracts";
 import {
   commentsListThreadsV10,
@@ -1434,11 +1436,15 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
   },
   "agent.tui.recordActivity": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: agentTuiRecordActivityV10,
           upgradeFromPreviousVersion: null,
+        },
+        1: {
+          contract: agentTuiRecordActivityV11,
+          upgradeFromPreviousVersion: agentTuiRecordActivityUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},


### PR DESCRIPTION
## What

Keep a TUI agent's stored \`harnessSessionId\` in sync with the session the user is actually looking at, by trusting the live session id that providers stamp on their hook payloads.

Providers implicitly re-id the live session under the user (Claude on Esc-Esc rewind, \`/clear\`, fork-after-\`/btw\`; OpenCode on in-TUI session switch/fork). The id was minted once at launch and never re-synced, so reopen, the fork button, A2A respawn, and transcript reads all targeted the pre-drift session.

## Changes (protocol + CLI only — host side lives in the internal repo)

- **protocol**: additive \`recordActivity@1.1\` (frozen v1.0 + V11 schema + upgrade path) — adds \`observedHarnessSessionId\` and a non-activity \`event: "resync"\`. No new RPC method name (the \`/rpc\` method set is frozen against shipped v1.0 hosts).
- **cli**: shared hook-stdin reader; \`activity-from-hook\` piggybacks the observed id; new \`session-observed-from-hook\` command for the Claude \`SessionStart\` hook and OpenCode root-session sightings. Extended to OpenCode's env-identified hook form. A newer CLI vs a v1.0 host degrades the resync to a quiet no-op.

## Notes

- DCO signed off.
- Pairs with the internal-repo host commits (resolver write-back + registry rekey). Gitlink re-pin is a separate post-merge step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)