### PR TITLE
feat(gui-app): inherit artifact tab title from the doc's leading H1

### DIFF
--- a/clients/gui-app/__tests__/editor-core/artifact-toolbar.test.tsx
+++ b/clients/gui-app/__tests__/editor-core/artifact-toolbar.test.tsx
@@ -23,6 +23,7 @@ function mountToolbarEditor(): Editor {
       user,
       onCommentShortcut: null,
       placeholderText: "Start writing…",
+      titlePlaceholderText: "Untitled",
     }),
   });
 }

--- a/clients/gui-app/__tests__/editor-core/build-artifact-extensions.test.ts
+++ b/clients/gui-app/__tests__/editor-core/build-artifact-extensions.test.ts
@@ -20,6 +20,7 @@ function createArtifactEditor(): Editor {
       user,
       onCommentShortcut: null,
       placeholderText: "Start writing…",
+      titlePlaceholderText: "Untitled",
     }),
   });
 }
@@ -187,6 +188,7 @@ describe("buildArtifactExtensions", () => {
         user,
         onCommentShortcut: null,
         placeholderText: "Start writing…",
+        titlePlaceholderText: "Untitled",
       }),
     });
 
@@ -234,6 +236,7 @@ describe("buildArtifactExtensions", () => {
         user,
         onCommentShortcut: null,
         placeholderText: "Start writing…",
+        titlePlaceholderText: "Untitled",
       }),
     });
     editorA.commands.setContent("# H\n\n- [ ] todo\n\n```js\nfoo();\n```\n", {
@@ -256,6 +259,7 @@ describe("buildArtifactExtensions", () => {
         user,
         onCommentShortcut: null,
         placeholderText: "Start writing…",
+        titlePlaceholderText: "Untitled",
       }),
     });
 

--- a/clients/gui-app/__tests__/editor-core/fence-promotion-plugin.test.ts
+++ b/clients/gui-app/__tests__/editor-core/fence-promotion-plugin.test.ts
@@ -17,6 +17,7 @@ function createEditor(): Editor {
       user,
       onCommentShortcut: null,
       placeholderText: "Start writing…",
+      titlePlaceholderText: "Untitled",
     }),
   });
 }

--- a/clients/gui-app/__tests__/editor-core/mermaid-node-view.test.tsx
+++ b/clients/gui-app/__tests__/editor-core/mermaid-node-view.test.tsx
@@ -85,6 +85,7 @@ function mountMermaidEditor(opts: {
       user,
       onCommentShortcut: null,
       placeholderText: "Start writing…",
+      titlePlaceholderText: "Untitled",
     }),
   });
   // Insert a mermaidBlock directly so we don't go through markdown parse.

--- a/clients/gui-app/__tests__/editor-core/wireframe-node-view.test.tsx
+++ b/clients/gui-app/__tests__/editor-core/wireframe-node-view.test.tsx
@@ -32,6 +32,7 @@ function mountWireframeEditor(opts: {
       user,
       onCommentShortcut: null,
       placeholderText: "Start writing…",
+      titlePlaceholderText: "Untitled",
     }),
   });
   editor.commands.insertContent({

--- a/clients/gui-app/src/components/chat/composer/picker/__tests__/use-mention-items.test.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/__tests__/use-mention-items.test.ts
@@ -154,6 +154,7 @@ function artifact(
     createdAt: 0,
     updatedAt: fields.updatedAt,
     status: fields.status,
+    createdManually: false,
   };
 }
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-editor-seed.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/artifact-editor-seed.test.ts
@@ -1,0 +1,48 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { seedArtifactTitleHeading } from "../artifact-editor-seed";
+
+const editors: Editor[] = [];
+
+function makeEditor(content: string): Editor {
+  const editor = new Editor({ extensions: [StarterKit], content });
+  editors.push(editor);
+  return editor;
+}
+
+afterEach(() => {
+  editors.splice(0).forEach((editor) => editor.destroy());
+});
+
+describe("seedArtifactTitleHeading", () => {
+  it("seeds an empty leading H1 followed by an empty paragraph into an empty doc", () => {
+    const editor = makeEditor("");
+    expect(seedArtifactTitleHeading(editor)).toBe(true);
+    const doc = editor.state.doc;
+    expect(doc.childCount).toBe(2);
+    expect(doc.child(0).type.name).toBe("heading");
+    expect(doc.child(0).attrs.level).toBe(1);
+    expect(doc.child(0).textContent).toBe("");
+    expect(doc.child(1).type.name).toBe("paragraph");
+    // Tiptap's `isEmpty` is a text-content heuristic, so a doc of empty-text
+    // nodes still reads empty - which is what keeps the whole-empty-editor
+    // placeholder rule rendering the title hint on the seeded empty heading.
+    expect(editor.isEmpty).toBe(true);
+  });
+
+  it("leaves a non-empty doc untouched", () => {
+    const editor = makeEditor("<p>existing content</p>");
+    const before = editor.getHTML();
+    expect(seedArtifactTitleHeading(editor)).toBe(false);
+    expect(editor.getHTML()).toBe(before);
+  });
+
+  it("does not prepend a second heading when the doc already opens on one", () => {
+    const editor = makeEditor("<h1>Existing title</h1><p>body</p>");
+    expect(seedArtifactTitleHeading(editor)).toBe(false);
+    expect(editor.state.doc.child(0).textContent).toBe("Existing title");
+    expect(editor.state.doc.childCount).toBe(2);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/use-artifact-doc-title-follow.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/use-artifact-doc-title-follow.test.ts
@@ -1,0 +1,52 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import { leadingDocTitle } from "../use-artifact-doc-title-follow";
+
+const editors: Editor[] = [];
+
+function makeEditor(content: string): Editor {
+  const editor = new Editor({
+    extensions: [StarterKit],
+    content,
+  });
+  editors.push(editor);
+  return editor;
+}
+
+afterEach(() => {
+  editors.splice(0).forEach((editor) => editor.destroy());
+});
+
+describe("leadingDocTitle", () => {
+  it("reads a leading level-1 heading as the doc title, trimmed", () => {
+    const editor = makeEditor("<h1>  Roadmap 2026 </h1><p>body</p>");
+    expect(leadingDocTitle(editor)).toBe("Roadmap 2026");
+  });
+
+  it("flattens inline marks to plain heading text", () => {
+    const editor = makeEditor("<h1>Road<strong>map</strong></h1>");
+    expect(leadingDocTitle(editor)).toBe("Roadmap");
+  });
+
+  it("ignores a heading that is not the first block", () => {
+    const editor = makeEditor("<p>intro</p><h1>Roadmap</h1>");
+    expect(leadingDocTitle(editor)).toBeNull();
+  });
+
+  it("ignores a leading heading deeper than level 1", () => {
+    const editor = makeEditor("<h2>Roadmap</h2>");
+    expect(leadingDocTitle(editor)).toBeNull();
+  });
+
+  it("treats an empty or whitespace-only leading heading as no title", () => {
+    const editor = makeEditor("<h1>   </h1><p>body</p>");
+    expect(leadingDocTitle(editor)).toBeNull();
+  });
+
+  it("returns null for an empty document", () => {
+    const editor = makeEditor("");
+    expect(leadingDocTitle(editor)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/use-artifact-doc-title-follow.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/use-artifact-doc-title-follow.test.ts
@@ -2,7 +2,10 @@ import "../../../../../__tests__/test-browser-apis";
 import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
-import { leadingDocTitle } from "../use-artifact-doc-title-follow";
+import {
+  leadingDocTitle,
+  nextTitleFollow,
+} from "../use-artifact-doc-title-follow";
 
 const editors: Editor[] = [];
 
@@ -17,6 +20,100 @@ function makeEditor(content: string): Editor {
 
 afterEach(() => {
   editors.splice(0).forEach((editor) => editor.destroy());
+});
+
+const DEFAULT_TITLE = "New spec";
+
+/**
+ * Mirrors the hook's state machine: threads `lastDocTitle` through a sequence
+ * of edits and applies each rename to the simulated artifact title (as the
+ * local Y.Doc rename does). `set:X` models an external rename (sidebar / other
+ * client) that mutates the artifact title without a doc event.
+ */
+function drive(
+  steps: ReadonlyArray<
+    { readonly type: string | null } | { readonly set: string }
+  >,
+  opts: { readonly createdManually: boolean },
+): string {
+  let lastDocTitle: string | null = null;
+  let artifactTitle = DEFAULT_TITLE;
+  for (const step of steps) {
+    if ("set" in step) {
+      artifactTitle = step.set;
+      continue;
+    }
+    const result = nextTitleFollow({
+      nextDocTitle: step.type,
+      lastDocTitle,
+      artifactTitle,
+      defaultTitle: DEFAULT_TITLE,
+      createdManually: opts.createdManually,
+    });
+    lastDocTitle = result.lastDocTitle;
+    if (result.renameTo !== null) artifactTitle = result.renameTo;
+  }
+  return artifactTitle;
+}
+
+describe("nextTitleFollow", () => {
+  it("renames from the default title as the heading is first typed", () => {
+    expect(drive([{ type: "Roadmap" }], { createdManually: true })).toBe(
+      "Roadmap",
+    );
+  });
+
+  it("keeps following across successive heading edits", () => {
+    expect(
+      drive([{ type: "Road" }, { type: "Roadmap" }, { type: "Roadmap 2026" }], {
+        createdManually: true,
+      }),
+    ).toBe("Roadmap 2026");
+  });
+
+  it("follows again after the heading is cleared and retyped", () => {
+    // The regression CodeRabbit flagged: clearing (null) must not sever the
+    // link, so retyping renames the artifact rather than stranding the old title.
+    expect(
+      drive([{ type: "Foo" }, { type: null }, { type: "Bar" }], {
+        createdManually: true,
+      }),
+    ).toBe("Bar");
+  });
+
+  it("keeps the last title while the heading is empty (never renames to empty)", () => {
+    expect(
+      drive([{ type: "Foo" }, { type: null }], { createdManually: true }),
+    ).toBe("Foo");
+  });
+
+  it("stops following after an explicit external rename", () => {
+    expect(
+      drive([{ type: "Foo" }, { set: "Custom title" }, { type: "Foobar" }], {
+        createdManually: true,
+      }),
+    ).toBe("Custom title");
+  });
+
+  it("does not revive the link when cleared and retyped after an external rename", () => {
+    expect(
+      drive(
+        [
+          { type: "Foo" },
+          { set: "Custom title" },
+          { type: null },
+          { type: "Bar" },
+        ],
+        { createdManually: true },
+      ),
+    ).toBe("Custom title");
+  });
+
+  it("never renames an agent-created (not manually created) artifact", () => {
+    expect(drive([{ type: "Roadmap" }], { createdManually: false })).toBe(
+      DEFAULT_TITLE,
+    );
+  });
 });
 
 describe("leadingDocTitle", () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/artifact-editor-seed.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/artifact-editor-seed.ts
@@ -1,0 +1,26 @@
+import type { Editor } from "@tiptap/core";
+
+/**
+ * Notion-style title line: seed a fresh hand-created artifact's body with an
+ * empty level-1 heading (the title) followed by an empty paragraph (the
+ * body), so the doc opens on a title the user types into and the tab title
+ * follows via `useArtifactDocTitleFollow`.
+ *
+ * Seeds ONLY when the editor is empty - the caller gates this behind the
+ * one-shot create-focus token, which is set exclusively by the manual "+"
+ * create flow on the creating client, so no collaborator ever races in a
+ * second heading. Returns whether it seeded, so the caller can decide where
+ * to drop the caret.
+ *
+ * `setContent` (not `insertContent`) because the empty doc is a single empty
+ * paragraph we want to replace wholesale; it emits an update so the new nodes
+ * sync into the Y.Doc body fragment like any other edit.
+ */
+export function seedArtifactTitleHeading(editor: Editor): boolean {
+  if (!editor.isEmpty) return false;
+  editor.commands.setContent({
+    type: "doc",
+    content: [{ type: "heading", attrs: { level: 1 } }, { type: "paragraph" }],
+  });
+  return true;
+}

--- a/clients/gui-app/src/components/epic-canvas/renderers/collab-tile-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/collab-tile-body.tsx
@@ -56,7 +56,16 @@ import {
   shouldHandleArtifactEditorBackgroundFocus,
 } from "./artifact-editor-background-focus";
 import { createArtifactEditorFindAdapter } from "../tile-find/artifact-editor-find-adapter";
+import { seedArtifactTitleHeading } from "./artifact-editor-seed";
+import { useArtifactDocTitleFollow } from "./use-artifact-doc-title-follow";
 import { useCollabTileEditor } from "./use-collab-tile-editor";
+
+/**
+ * Hint shown inside the empty leading title heading of a freshly seeded
+ * hand-created artifact. Kind-agnostic - the body hint below already carries
+ * the per-kind guidance.
+ */
+const ARTIFACT_TITLE_PLACEHOLDER = "Untitled";
 
 interface CollabTileBodyProps {
   readonly node: EpicNodeRef;
@@ -244,21 +253,38 @@ function CollabTileBodyEditor(props: CollabTileBodyEditorProps) {
     onCommentShortcut,
     anchorScope: commentsSupported ? { epicId, artifactId: node.id } : null,
     placeholderText: hasChildren ? "" : kindPlaceholder,
+    titlePlaceholderText: ARTIFACT_TITLE_PLACEHOLDER,
   });
 
-  // One-shot focus handoff from the create flows: when this tile exists
-  // because the user just created an empty spec/ticket/story/review, drop
-  // the caret at the start of the placeholder line as soon as the editor
-  // mounts. Gated on `isActive` so a user who tabbed away mid-create doesn't
-  // get focus yanked. Emptiness is checked BEFORE consuming the token:
-  // content can land in the Y.Doc ahead of this effect, and a doc that
-  // already has content must not silently burn the request.
+  // Notion-style title inheritance: a hand-created artifact whose title still
+  // follows the doc renames itself from the leading `# ` heading as the user
+  // types, so the tab / sidebar title mirrors the document title.
+  useArtifactDocTitleFollow({
+    editor,
+    epicId,
+    node,
+    viewTabId,
+    editable,
+  });
+
+  // One-shot handoff from the create flows: when this tile exists because the
+  // user just hand-created an empty spec/ticket/story/review, seed the
+  // Notion-style title line (an empty `# ` heading + body paragraph) and drop
+  // the caret into the title so the user types a title first - which the tab
+  // then follows via `useArtifactDocTitleFollow`. Gated on `isActive` so a
+  // user who tabbed away mid-create doesn't get focus yanked. Emptiness is
+  // checked BEFORE consuming the token: content can land in the Y.Doc ahead
+  // of this effect, and a doc that already has content must not silently burn
+  // the request (nor get a stray heading prepended). The token is set only by
+  // the manual "+" create flow on the creating client, so no collaborator
+  // races in a second heading.
   useEffect(() => {
     if (editor === null) return;
     if (!isActive || !editable) return;
     if (!isEpicArtifactKind(node.type)) return;
     if (!editor.isEmpty) return;
     if (!consumeArtifactEditorFocus(node.id, node.instanceId)) return;
+    seedArtifactTitleHeading(editor);
     editor.commands.focus("start");
   }, [editor, isActive, editable, node.id, node.instanceId, node.type]);
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-artifact-doc-title-follow.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-artifact-doc-title-follow.ts
@@ -33,6 +33,57 @@ export function leadingDocTitle(editor: Editor): string | null {
 }
 
 /**
+ * Pure decision for one editor update: given the current leading heading text
+ * and the accumulated follow state, decide whether the artifact should be
+ * renamed and what the tracked "last heading" becomes.
+ *
+ * The title *follows the doc* while it is empty, still the create-flow default
+ * ("New <kind>"), or equal to the last heading text this reducer tracked (i.e.
+ * the title was derived from the doc). An explicit rename (sidebar, another
+ * client) makes `artifactTitle` diverge from all three, permanently breaking
+ * the link so a deliberate title is never clobbered.
+ *
+ * `lastDocTitle` only ever advances to a NON-NULL heading: clearing the heading
+ * (`nextDocTitle === null`) preserves it, so clearing then retyping still reads
+ * as "following the doc" and renames again - the bug a naive
+ * `lastDocTitle = nextDocTitle` on every update would introduce (the tracked
+ * value goes null on clear and never matches `artifactTitle` on retype).
+ */
+export function nextTitleFollow(params: {
+  readonly nextDocTitle: string | null;
+  readonly lastDocTitle: string | null;
+  readonly artifactTitle: string;
+  readonly defaultTitle: string;
+  readonly createdManually: boolean;
+}): { readonly renameTo: string | null; readonly lastDocTitle: string | null } {
+  const {
+    nextDocTitle,
+    lastDocTitle,
+    artifactTitle,
+    defaultTitle,
+    createdManually,
+  } = params;
+  // Heading cleared or not a leading H1: keep the last title (never rename to
+  // empty) AND keep `lastDocTitle` so a later retype still follows.
+  if (nextDocTitle === null) return { renameTo: null, lastDocTitle };
+  if (nextDocTitle === lastDocTitle) return { renameTo: null, lastDocTitle };
+  // Heading text genuinely changed - this is now the tracked value regardless
+  // of whether we end up renaming.
+  if (!createdManually) return { renameTo: null, lastDocTitle: nextDocTitle };
+  if (artifactTitle === nextDocTitle) {
+    return { renameTo: null, lastDocTitle: nextDocTitle };
+  }
+  const titleFollowsDoc =
+    artifactTitle.length === 0 ||
+    artifactTitle === defaultTitle ||
+    artifactTitle === lastDocTitle;
+  return {
+    renameTo: titleFollowsDoc ? nextDocTitle : null,
+    lastDocTitle: nextDocTitle,
+  };
+}
+
+/**
  * Notion-style title inheritance for hand-created artifacts: while the
  * artifact's title still *follows* the document, editing the doc's leading
  * `# ` heading renames the artifact, so the canvas tab / sidebar / breadcrumb
@@ -98,24 +149,22 @@ export function useArtifactDocTitleFollow(params: {
 
     const onUpdate = ({ transaction }: EditorEvents["update"]): void => {
       if (!transaction.docChanged) return;
-      const nextDocTitle = leadingDocTitle(editor);
-      const prevDocTitle = lastDocTitle;
-      lastDocTitle = nextDocTitle;
-      if (nextDocTitle === null || nextDocTitle === prevDocTitle) return;
       const state = handle.store.getState();
       const artifact = Object.hasOwn(state.artifacts.byId, artifactId)
         ? state.artifacts.byId[artifactId]
         : null;
-      if (artifact === null || !artifact.createdManually) return;
-      if (artifact.title === nextDocTitle) return;
-      const titleFollowsDoc =
-        artifact.title.length === 0 ||
-        artifact.title === defaultTitle ||
-        artifact.title === prevDocTitle;
-      if (!titleFollowsDoc) return;
-      state.renameArtifact(artifactId, nextDocTitle);
-      renameArtifactInTab(viewTabId, artifactId, nextDocTitle);
-      pendingPersistTitle = nextDocTitle;
+      const result = nextTitleFollow({
+        nextDocTitle: leadingDocTitle(editor),
+        lastDocTitle,
+        artifactTitle: artifact?.title ?? "",
+        defaultTitle,
+        createdManually: artifact?.createdManually ?? false,
+      });
+      lastDocTitle = result.lastDocTitle;
+      if (result.renameTo === null) return;
+      state.renameArtifact(artifactId, result.renameTo);
+      renameArtifactInTab(viewTabId, artifactId, result.renameTo);
+      pendingPersistTitle = result.renameTo;
       if (persistTimer !== null) window.clearTimeout(persistTimer);
       persistTimer = window.setTimeout(
         flushPersist,

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-artifact-doc-title-follow.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-artifact-doc-title-follow.ts
@@ -1,0 +1,145 @@
+import type { Editor, EditorEvents } from "@tiptap/core";
+import { useEffect } from "react";
+import { useEpicRenameArtifact } from "@/hooks/epic/use-epic-node-mutations";
+import {
+  DEFAULT_EPIC_NODE_NAMES,
+  isEpicArtifactKind,
+} from "@/lib/artifacts/node-display";
+import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+
+/**
+ * Trailing debounce for the authoritative `epic.renameArtifact` persist. The
+ * local Y.Doc rename below is applied per doc change so the tab / sidebar
+ * title tracks typing live; the RPC only needs to land once the title
+ * settles.
+ */
+const RENAME_PERSIST_DEBOUNCE_MS = 800;
+
+/**
+ * The document's own title: the text of a level-1 heading sitting at the very
+ * top of the body, or `null` when the doc doesn't start with one. Mirrors the
+ * host's disk-ingest fallback (`parseBody` in epic-file-sync), which reads a
+ * leading `# ` line - not a heading further down - as the artifact title.
+ */
+export function leadingDocTitle(editor: Editor): string | null {
+  const first = editor.state.doc.firstChild;
+  if (first === null || first.type.name !== "heading") return null;
+  const level: unknown = first.attrs["level"];
+  if (level !== 1) return null;
+  const text = first.textContent.trim();
+  return text.length > 0 ? text : null;
+}
+
+/**
+ * Notion-style title inheritance for hand-created artifacts: while the
+ * artifact's title still *follows* the document, editing the doc's leading
+ * `# ` heading renames the artifact, so the canvas tab / sidebar / breadcrumb
+ * title mirrors what the author typed instead of staying "New spec".
+ *
+ * The title follows the doc while it is empty, still the create-flow default
+ * ("New <kind>"), or equal to the heading's previous value (i.e. it was
+ * derived from the doc). An explicit rename (sidebar inline rename, another
+ * client) breaks the link: the follow check fails from then on, so a
+ * deliberate title is never clobbered by body edits. Deleting the heading
+ * keeps the last title - an artifact never renames to empty.
+ *
+ * Scope guards: only artifact kinds (spec/ticket/story/review), only
+ * `createdManually` records (agent-created artifacts have authored titles),
+ * and only for editors (the local rename action and the RPC both reject
+ * viewers anyway).
+ *
+ * Write path matches the sidebar rename: local Y.Doc rename (live title
+ * everywhere + host stream sync), tab-ref name snapshot, then the
+ * authoritative `epic.renameArtifact` RPC debounced behind typing and flushed
+ * on unmount. The rename touches only artifact metadata - never the body
+ * fragment - so it cannot re-trigger the editor update this hook listens to.
+ */
+export function useArtifactDocTitleFollow(params: {
+  readonly editor: Editor | null;
+  readonly epicId: string;
+  readonly node: EpicNodeRef;
+  readonly viewTabId: string;
+  readonly editable: boolean;
+}): void {
+  const { editor, epicId, node, viewTabId, editable } = params;
+  const artifactId = node.id;
+  const nodeType = node.type;
+  const handle = useOpenEpicHandle();
+  const renameArtifactInTab = useEpicCanvasStore((s) => s.renameArtifactInTab);
+  const renameArtifact = useEpicRenameArtifact();
+  // TanStack Query keeps `mutate` referentially stable, so depending on it
+  // does not re-subscribe the editor listener on every mutation state change.
+  const persistRename = renameArtifact.mutate;
+
+  useEffect(() => {
+    if (editor === null || !editable) return;
+    if (!isEpicArtifactKind(nodeType)) return;
+    const defaultTitle = DEFAULT_EPIC_NODE_NAMES[nodeType];
+    let lastDocTitle = leadingDocTitle(editor);
+    let pendingPersistTitle: string | null = null;
+    let persistTimer: number | null = null;
+
+    const flushPersist = (): void => {
+      persistTimer = null;
+      const title = pendingPersistTitle;
+      pendingPersistTitle = null;
+      if (title === null) return;
+      const artifacts = handle.store.getState().artifacts;
+      const artifact = Object.hasOwn(artifacts.byId, artifactId)
+        ? artifacts.byId[artifactId]
+        : null;
+      // A competing rename (sidebar, another client) superseded the debounced
+      // value while it waited - that path persists its own title.
+      if (artifact === null || artifact.title !== title) return;
+      persistRename({ epicId, artifactId, title });
+    };
+
+    const onUpdate = ({ transaction }: EditorEvents["update"]): void => {
+      if (!transaction.docChanged) return;
+      const nextDocTitle = leadingDocTitle(editor);
+      const prevDocTitle = lastDocTitle;
+      lastDocTitle = nextDocTitle;
+      if (nextDocTitle === null || nextDocTitle === prevDocTitle) return;
+      const state = handle.store.getState();
+      const artifact = Object.hasOwn(state.artifacts.byId, artifactId)
+        ? state.artifacts.byId[artifactId]
+        : null;
+      if (artifact === null || !artifact.createdManually) return;
+      if (artifact.title === nextDocTitle) return;
+      const titleFollowsDoc =
+        artifact.title.length === 0 ||
+        artifact.title === defaultTitle ||
+        artifact.title === prevDocTitle;
+      if (!titleFollowsDoc) return;
+      state.renameArtifact(artifactId, nextDocTitle);
+      renameArtifactInTab(viewTabId, artifactId, nextDocTitle);
+      pendingPersistTitle = nextDocTitle;
+      if (persistTimer !== null) window.clearTimeout(persistTimer);
+      persistTimer = window.setTimeout(
+        flushPersist,
+        RENAME_PERSIST_DEBOUNCE_MS,
+      );
+    };
+
+    editor.on("update", onUpdate);
+    return () => {
+      editor.off("update", onUpdate);
+      if (persistTimer !== null) {
+        window.clearTimeout(persistTimer);
+        flushPersist();
+      }
+    };
+  }, [
+    editor,
+    editable,
+    nodeType,
+    artifactId,
+    epicId,
+    viewTabId,
+    handle,
+    renameArtifactInTab,
+    persistRename,
+  ]);
+}

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-collab-tile-editor.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-collab-tile-editor.ts
@@ -43,6 +43,11 @@ interface UseCollabTileEditorParams {
    * differently.
    */
   readonly placeholderText: string;
+  /**
+   * Hint shown inside an empty leading level-1 heading (the Notion-style
+   * title line). Kind-agnostic.
+   */
+  readonly titlePlaceholderText: string;
 }
 
 /**
@@ -63,6 +68,7 @@ export function useCollabTileEditor(
     onCommentShortcut,
     anchorScope,
     placeholderText,
+    titlePlaceholderText,
   } = params;
 
   const setAnchorPositions = useAnchorPositionsStore((s) => s.setForArtifact);
@@ -77,6 +83,7 @@ export function useCollabTileEditor(
           user,
           onCommentShortcut,
           placeholderText,
+          titlePlaceholderText,
         }),
         ...(anchorScope === null
           ? []
@@ -111,6 +118,7 @@ export function useCollabTileEditor(
       anchorScope?.epicId,
       anchorScope?.artifactId,
       placeholderText,
+      titlePlaceholderText,
     ],
   );
 

--- a/clients/gui-app/src/editor-core/extensions/__tests__/resolve-artifact-placeholder-text.test.ts
+++ b/clients/gui-app/src/editor-core/extensions/__tests__/resolve-artifact-placeholder-text.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveArtifactPlaceholderText } from "../build-artifact-extensions";
+
+const TITLE = "Untitled";
+const BODY = "Describe what you want to build…";
+
+function resolve(params: {
+  nodeTypeName: string;
+  headingLevel: number | null;
+  pos: number;
+}): string {
+  return resolveArtifactPlaceholderText({
+    ...params,
+    titlePlaceholderText: TITLE,
+    placeholderText: BODY,
+  });
+}
+
+describe("resolveArtifactPlaceholderText", () => {
+  it("returns the title hint for an empty leading level-1 heading", () => {
+    expect(resolve({ nodeTypeName: "heading", headingLevel: 1, pos: 0 })).toBe(
+      TITLE,
+    );
+  });
+
+  it("returns the body hint for a leading paragraph (whole-empty doc)", () => {
+    expect(
+      resolve({ nodeTypeName: "paragraph", headingLevel: null, pos: 0 }),
+    ).toBe(BODY);
+  });
+
+  it("returns the body hint for a level-1 heading that is not the first node", () => {
+    expect(resolve({ nodeTypeName: "heading", headingLevel: 1, pos: 12 })).toBe(
+      BODY,
+    );
+  });
+
+  it("returns the body hint for a leading heading deeper than level 1", () => {
+    expect(resolve({ nodeTypeName: "heading", headingLevel: 2, pos: 0 })).toBe(
+      BODY,
+    );
+  });
+});

--- a/clients/gui-app/src/editor-core/extensions/build-artifact-extensions.ts
+++ b/clients/gui-app/src/editor-core/extensions/build-artifact-extensions.ts
@@ -54,6 +54,34 @@ export interface BuildArtifactExtensionsParams {
    * `.tc-editor-prose .is-editor-empty::before` rule in `styles/editor.css`.
    */
   readonly placeholderText: string;
+  /**
+   * Hint rendered inside an empty leading level-1 heading - the Notion-style
+   * "title line" a hand-created artifact opens on (see
+   * `seedArtifactTitleHeading`). Distinct from `placeholderText` (the body
+   * hint) so the title line prompts for a title, not a description.
+   */
+  readonly titlePlaceholderText: string;
+}
+
+/**
+ * Placeholder text for a given empty node: the title hint for the doc's
+ * leading level-1 heading (the "title line"), else the body hint. Exported for
+ * unit tests; the live wiring passes this to `Placeholder`'s function form.
+ */
+export function resolveArtifactPlaceholderText(params: {
+  readonly nodeTypeName: string;
+  readonly headingLevel: number | null;
+  readonly pos: number;
+  readonly titlePlaceholderText: string;
+  readonly placeholderText: string;
+}): string {
+  const isLeadingTitleHeading =
+    params.pos === 0 &&
+    params.nodeTypeName === "heading" &&
+    params.headingLevel === 1;
+  return isLeadingTitleHeading
+    ? params.titlePlaceholderText
+    : params.placeholderText;
 }
 
 /**
@@ -78,8 +106,15 @@ const lowlight = createLowlight(common);
 export function buildArtifactExtensions(
   params: BuildArtifactExtensionsParams,
 ): AnyExtension[] {
-  const { doc, fragment, awareness, user, onCommentShortcut, placeholderText } =
-    params;
+  const {
+    doc,
+    fragment,
+    awareness,
+    user,
+    onCommentShortcut,
+    placeholderText,
+    titlePlaceholderText,
+  } = params;
   const provider: ArtifactAwarenessProvider = { awareness };
 
   return [
@@ -136,7 +171,17 @@ export function buildArtifactExtensions(
     // selection. Mounted on every artifact editor; tiles that don't support
     // comments pass `onCommentShortcut: null` so the keystroke is a no-op.
     CommentShortcutExtension.configure({ onTrigger: onCommentShortcut }),
-    Placeholder.configure({ placeholder: placeholderText }),
+    Placeholder.configure({
+      placeholder: ({ node, pos }) =>
+        resolveArtifactPlaceholderText({
+          nodeTypeName: node.type.name,
+          headingLevel:
+            typeof node.attrs.level === "number" ? node.attrs.level : null,
+          pos,
+          titlePlaceholderText,
+          placeholderText,
+        }),
+    }),
   ];
 }
 

--- a/clients/gui-app/src/editor-core/styles/editor.css
+++ b/clients/gui-app/src/editor-core/styles/editor.css
@@ -615,6 +615,23 @@
   float: left;
 }
 
+/*
+ * Per-node placeholder for the CURRENT empty block (Tiptap's `Placeholder`
+ * flags it `.is-empty` with `showOnlyCurrent`, the default). Powers the
+ * Notion-style empty title line ("Untitled") and the body hint on the focused
+ * empty paragraph of a freshly seeded hand-created artifact - see
+ * `seedArtifactTitleHeading` / `resolveArtifactPlaceholderText`. Excludes the
+ * whole-empty-editor first child, which the rule above already renders.
+ */
+.tc-editor-prose .is-empty:not(.is-editor-empty)::before {
+  content: attr(data-placeholder);
+  color: var(--color-muted-foreground, hsl(0 0% 45%));
+  opacity: 0.6;
+  pointer-events: none;
+  height: 0;
+  float: left;
+}
+
 [data-composer-editor].is-editor-empty,
 [data-composer-editor] .is-editor-empty:first-child {
   position: relative;

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-subpages.test.tsx
@@ -103,6 +103,7 @@ function artifact(id: string, title: string): ArtifactProjection {
     createdAt: 0,
     updatedAt: 0,
     status: null,
+    createdManually: false,
   };
 }
 

--- a/clients/gui-app/src/stores/epics/open-epic/projection-helpers.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/projection-helpers.ts
@@ -229,6 +229,7 @@ export function projectArtifact(
     createdAt: readMaybeNumber(entry, "createdAt"),
     updatedAt: readMaybeNumber(entry, "updatedAt"),
     status,
+    createdManually: readMaybeBoolean(entry, "createdManually"),
   };
 }
 
@@ -361,7 +362,8 @@ export function artifactProjectionsEq(
     a.artifactRoomId === b.artifactRoomId &&
     a.createdAt === b.createdAt &&
     a.updatedAt === b.updatedAt &&
-    a.status === b.status
+    a.status === b.status &&
+    a.createdManually === b.createdManually
   );
 }
 

--- a/clients/gui-app/src/stores/epics/open-epic/types.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/types.ts
@@ -36,6 +36,13 @@ export interface ArtifactProjection {
   readonly updatedAt: number;
   /** Status numeric code (0=Todo, 1=InProgress, 2=Done). Null for spec/review. */
   readonly status: number | null;
+  /**
+   * True for artifacts the user created by hand (host `epic.createArtifact`
+   * RPC or a file authored directly on disk), false for agent-created ones.
+   * Gates hand-authoring affordances like the doc-title → artifact-title
+   * follow in the collab editor.
+   */
+  readonly createdManually: boolean;
 }
 
 export interface ArtifactsSlice {


### PR DESCRIPTION
## Summary

Manually-created artifacts now follow a Notion-style title model: the canvas tab / sidebar / breadcrumb title mirrors the document's leading `# ` heading while the title still follows the doc, and new hand-created artifacts open on an empty H1 "title line" with the caret in it.

- **Project `createdManually`** into `ArtifactProjection` (+ equality) so the GUI can gate hand-authoring behavior on it. The host already stamps this flag on the create RPC and disk-authored files; it was streamed to the client but never projected.
- **`useArtifactDocTitleFollow`** — renames the artifact from the leading level-1 heading as the user types. The title follows the doc while it's empty, still the `"New <kind>"` default, or equal to the heading's previous value; an explicit rename (sidebar, another client) breaks the link so a deliberate title is never clobbered. Local Y.Doc rename for a live title + a debounced `epic.renameArtifact` persist flushed on unmount. Touches only artifact metadata, never the body fragment, so it can't feed back into the editor `update` it listens to.
- **Seed new hand-created artifacts** with an empty H1 + body paragraph, gated on the one-shot create-focus token (set only by the manual "+" create flow, on the creating client) and on `editor.isEmpty`, so no collaborator races in a second heading and a doc that already streamed content is never touched.
- **Per-node placeholder** — `"Untitled"` in the empty title heading, the existing kind hint in the body.

## Related issue

<!-- none -->

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
