### PR TITLE
fix(gui): keep artifact editor focus during title/tab renames

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -1,5 +1,5 @@
 import "../../../../__tests__/test-browser-apis";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 import {
@@ -213,6 +213,21 @@ function lastNavigateSearchPatch(): Readonly<Record<string, unknown>> {
   const result: unknown = search({});
   if (!isRecord(result)) throw new Error("expected search patch result");
   return result;
+}
+
+/**
+ * The applied-nested-target focus restore runs inside a `requestAnimationFrame`.
+ * Await two frames (wrapped in `act` so React state settles) to let that
+ * scheduled `.focus()` land before asserting.
+ */
+async function flushFocusRestore(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => resolve());
+      });
+    });
+  });
 }
 
 describe("useEpicRouteSynchronization", () => {
@@ -673,5 +688,79 @@ describe("useEpicRouteSynchronization", () => {
       "group-1",
       "removed-chat",
     );
+  });
+
+  it("keeps editor focus when a canvas mutation re-runs an already-applied nested focus target", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-current",
+      [specTile("artifact-current", "tile-current", "Current artifact")],
+      "tile-current",
+    );
+
+    // Mirror the canvas DOM the focus restore queries: the selected tab layer
+    // (an ancestor with `tabIndex=-1`) wraps the editable artifact body, just
+    // like pane → tab layer → ProseMirror surface in the app.
+    const paneEl = document.createElement("div");
+    paneEl.setAttribute("data-group-id", "pane-current");
+    paneEl.setAttribute("data-active", "true");
+    paneEl.tabIndex = -1;
+    const tileEl = document.createElement("div");
+    tileEl.setAttribute("data-tab-instance-id", "tile-current");
+    tileEl.setAttribute("data-selected", "true");
+    tileEl.tabIndex = -1;
+    const editorEl = document.createElement("textarea");
+    tileEl.appendChild(editorEl);
+    paneEl.appendChild(tileEl);
+    document.body.appendChild(paneEl);
+
+    try {
+      const hook = renderHook(
+        (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+        {
+          initialProps: {
+            epicId: EPIC_ID,
+            tabId: TAB_ID,
+            focusedAt: undefined,
+            focusArtifactId: undefined,
+            focusThreadId: undefined,
+            focusPaneId: "pane-current",
+            focusTileInstanceId: "tile-current",
+          },
+        },
+      );
+
+      // First application of the target legitimately restores focus to the tab
+      // container - a genuine tab switch has no deeper focus to preserve.
+      await waitFor(() => {
+        expect(document.activeElement).toBe(tileEl);
+      });
+
+      // The user clicks into the body and starts typing.
+      editorEl.focus();
+      expect(document.activeElement).toBe(editorEl);
+
+      // A title rename (Notion-style doc-title-follow, or a tab rename) mutates
+      // the canvas, so `useEpicCanvas` hands back a new identity and the focus
+      // effect re-runs with the SAME, still-applied target. It must not yank
+      // focus back up to the tab container and eject the user from edit mode.
+      testState.canvasTiles = {
+        "tile-current": specTile("artifact-current", "tile-current", "Renamed"),
+      };
+      hook.rerender({
+        epicId: EPIC_ID,
+        tabId: TAB_ID,
+        focusedAt: undefined,
+        focusArtifactId: undefined,
+        focusThreadId: undefined,
+        focusPaneId: "pane-current",
+        focusTileInstanceId: "tile-current",
+      });
+      await flushFocusRestore();
+
+      expect(document.activeElement).toBe(editorEl);
+    } finally {
+      paneEl.remove();
+    }
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -763,4 +763,75 @@ describe("useEpicRouteSynchronization", () => {
       paneEl.remove();
     }
   });
+
+  it("does not re-focus the tile when a rename fires while focus sits outside it (tab-strip rename)", async () => {
+    testState.nestedFocusEnabled = true;
+    setSinglePaneCanvas(
+      "pane-current",
+      [specTile("artifact-current", "tile-current", "Current artifact")],
+      "tile-current",
+    );
+
+    // The tab-strip rename input lives in the pane but OUTSIDE the tile layer,
+    // mirroring the real DOM (strip is a sibling of the tab body).
+    const paneEl = document.createElement("div");
+    paneEl.setAttribute("data-group-id", "pane-current");
+    paneEl.setAttribute("data-active", "true");
+    paneEl.tabIndex = -1;
+    const renameInputEl = document.createElement("input");
+    const tileEl = document.createElement("div");
+    tileEl.setAttribute("data-tab-instance-id", "tile-current");
+    tileEl.setAttribute("data-selected", "true");
+    tileEl.tabIndex = -1;
+    paneEl.appendChild(renameInputEl);
+    paneEl.appendChild(tileEl);
+    document.body.appendChild(paneEl);
+
+    try {
+      const hook = renderHook(
+        (intent: EpicRouteFocusIntent) => useEpicRouteSynchronization(intent),
+        {
+          initialProps: {
+            epicId: EPIC_ID,
+            tabId: TAB_ID,
+            focusedAt: undefined,
+            focusArtifactId: undefined,
+            focusThreadId: undefined,
+            focusPaneId: "pane-current",
+            focusTileInstanceId: "tile-current",
+          },
+        },
+      );
+
+      // Tab was activated earlier: its focus restore has already run once.
+      await waitFor(() => {
+        expect(document.activeElement).toBe(tileEl);
+      });
+
+      // The user opens the tab's rename input and commits. Focus is in the
+      // strip input (not the tile) and the commit mutates the canvas.
+      renameInputEl.focus();
+      expect(document.activeElement).toBe(renameInputEl);
+
+      testState.canvasTiles = {
+        "tile-current": specTile("artifact-current", "tile-current", "Renamed"),
+      };
+      hook.rerender({
+        epicId: EPIC_ID,
+        tabId: TAB_ID,
+        focusedAt: undefined,
+        focusArtifactId: undefined,
+        focusThreadId: undefined,
+        focusPaneId: "pane-current",
+        focusTileInstanceId: "tile-current",
+      });
+      await flushFocusRestore();
+
+      // The rename did not change the focus target, so the restore must not
+      // fire and stamp the stray selection ring onto the tile.
+      expect(document.activeElement).toBe(renameInputEl);
+    } finally {
+      paneEl.remove();
+    }
+  });
 });

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -481,6 +481,15 @@ function focusNestedRouteTarget(target: NestedFocusTarget): void {
   if (element === null) {
     return;
   }
+  // The pane / tab container is an ancestor of the tile's editing surface, and
+  // this effect re-runs on every canvas mutation (a title rename, for one). If
+  // focus already lives inside the target, moving it up to the container would
+  // blur that deeper element - ejecting a user mid-type from the artifact body.
+  // Only pull focus up when it is currently elsewhere, i.e. a genuine
+  // pane/tab switch that this restore is meant to service.
+  if (element.contains(document.activeElement)) {
+    return;
+  }
   element.focus({ preventScroll: true });
 }
 

--- a/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
+++ b/clients/gui-app/src/components/epic-canvas/hooks/use-epic-route-synchronization.ts
@@ -178,6 +178,14 @@ export function useEpicRouteSynchronization(
     applyNestedRouteFocus,
   ]);
 
+  // The nested-route target we last moved DOM focus to. This effect re-runs on
+  // every canvas mutation - a title rename gives `useEpicCanvas` a new identity
+  // while the applied target stays byte-for-byte the same - and the restore is
+  // only meant to service genuine pane/tab navigation. Gating on an actual
+  // target change keeps a bare rename from re-focusing the tile, which would
+  // eject a user typing in the body or paint a stray selection ring after a
+  // tab-strip rename.
+  const lastRestoredNestedTargetRef = useRef<NestedFocusTarget | null>(null);
   useEffect(() => {
     if (!snapshotLoaded) return;
     if (!nestedFocusEnabled) return;
@@ -189,8 +197,18 @@ export function useEpicRouteSynchronization(
     if (!nestedRouteTargetApplied) {
       return;
     }
+    if (
+      areNestedFocusTargetsEqual(
+        lastRestoredNestedTargetRef.current,
+        resolvedNestedRouteTarget,
+      )
+    ) {
+      return;
+    }
+    const targetToFocus = resolvedNestedRouteTarget;
     const frame = window.requestAnimationFrame(() => {
-      focusNestedRouteTarget(resolvedNestedRouteTarget);
+      lastRestoredNestedTargetRef.current = targetToFocus;
+      focusNestedRouteTarget(targetToFocus);
     });
     return () => {
       window.cancelAnimationFrame(frame);


### PR DESCRIPTION
## Summary

Fixes focus loss in the artifact editor when a title/tab rename re-runs the nested-focus restore effect. Two related fixes to `use-epic-route-synchronization`:

- **Keep editor focus when a title rename re-runs nested focus restore.** Typing into an artifact's leading title heading (or renaming its tab) mutates the canvas, giving `useEpicCanvas` a fresh identity and re-running the nested-focus restore effect with the same, still-applied target. The restore then re-focused the pane/tab container — an ancestor of the ProseMirror surface — blurring the caret and ejecting the user from edit mode (leaving the stray selection ring around the tile). `focusNestedRouteTarget` is now guarded so it only pulls focus up to the container when focus is currently elsewhere (a genuine pane/tab switch); when focus already lives inside the target, the deeper element is left alone.

- **Only restore nested focus on a genuine target change.** The containment guard alone missed the tab-strip rename path: there focus sits in the rename input (outside the tile), so after commit it falls to `<body>` and the restore still re-focused the tile — stamping the stray selection ring even though nothing navigated. The focus restore is now gated on the applied nested target actually changing since the last time focus moved. A bare canvas mutation (a rename gives `useEpicCanvas` a new identity while the target stays identical) no longer re-focuses the tile. The containment guard stays as defense for the create-flow autofocus race on a real target change.

## Testing

Expanded `use-epic-route-synchronization.test.tsx` covering the rename re-run paths and the genuine-target-change gate.
