### PR TITLE
feat(desktop): make Windows native window controls theme-aware

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/window-effects-title-bar-overlay.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/window-effects-title-bar-overlay.test.ts
@@ -1,0 +1,126 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { IpcMainInvokeEvent } from "electron";
+import { handleSetTitleBarOverlay } from "../window-effects";
+
+/**
+ * On Windows the native min/max/close controls are drawn by Electron from the
+ * `titleBarOverlay` colors. `handleSetTitleBarOverlay` lets the renderer push
+ * theme-derived colors so the controls follow the active theme instead of the
+ * static dark launch defaults. It is Windows-only (mac uses the WCO with
+ * OS-drawn glyphs; Linux uses default chrome).
+ */
+
+const setTitleBarOverlay = vi.fn();
+const fromWebContents = vi.fn();
+
+vi.mock("electron", () => ({
+  app: { dock: undefined },
+  nativeImage: {
+    createFromDataURL: vi.fn(),
+    createFromPath: vi.fn(),
+  },
+  BrowserWindow: {
+    fromWebContents: (...args: unknown[]): unknown => fromWebContents(...args),
+  },
+}));
+
+vi.mock("electron-log", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("../logger", () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+interface FakeWindow {
+  isDestroyed(): boolean;
+  setTitleBarOverlay(options: unknown): void;
+}
+
+function fakeWindow(destroyed: boolean): FakeWindow {
+  return {
+    isDestroyed: () => destroyed,
+    setTitleBarOverlay,
+  };
+}
+
+// The handler only reads `event.sender`, which the mocked `fromWebContents`
+// ignores. Annotate as `unknown` first so the cast to the full Electron event
+// type is a single, explicit assertion.
+const rawEvent: unknown = { sender: {} };
+const event = rawEvent as IpcMainInvokeEvent;
+
+let originalPlatform: PropertyDescriptor | undefined;
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeAll(() => {
+  originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+});
+afterAll(() => {
+  if (originalPlatform !== undefined) {
+    Object.defineProperty(process, "platform", originalPlatform);
+  }
+});
+beforeEach(() => {
+  setTitleBarOverlay.mockClear();
+  fromWebContents.mockReset();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleSetTitleBarOverlay", () => {
+  it("applies the renderer-provided colors to the sender window on Windows", () => {
+    setPlatform("win32");
+    fromWebContents.mockReturnValue(fakeWindow(false));
+
+    handleSetTitleBarOverlay(event, "#1e1e2e", "#cdd6f4");
+
+    expect(setTitleBarOverlay).toHaveBeenCalledWith({
+      color: "#1e1e2e",
+      symbolColor: "#cdd6f4",
+    });
+  });
+
+  it("is a no-op off Windows (mac/Linux draw their own controls)", () => {
+    setPlatform("linux");
+    fromWebContents.mockReturnValue(fakeWindow(false));
+
+    handleSetTitleBarOverlay(event, "#1e1e2e", "#cdd6f4");
+
+    expect(setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-string colors", () => {
+    setPlatform("win32");
+    fromWebContents.mockReturnValue(fakeWindow(false));
+
+    handleSetTitleBarOverlay(event, 123, null);
+
+    expect(setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+
+  it("ignores a destroyed sender window", () => {
+    setPlatform("win32");
+    fromWebContents.mockReturnValue(fakeWindow(true));
+
+    handleSetTitleBarOverlay(event, "#1e1e2e", "#cdd6f4");
+
+    expect(setTitleBarOverlay).not.toHaveBeenCalled();
+  });
+});

--- a/clients/desktop/src/electron-main/app/window-effects.ts
+++ b/clients/desktop/src/electron-main/app/window-effects.ts
@@ -112,6 +112,26 @@ export function handleSetContentProtection(
 }
 
 /**
+ * Windows-only: repaints the native window controls (min/max/close) drawn by
+ * Chromium's Window Controls Overlay. The `BrowserWindow`'s `titleBarOverlay`
+ * colors are static after creation, so the renderer pushes theme-derived
+ * colors here on every theme change to keep the controls in sync with the
+ * active theme / light-dark mode. macOS draws OS-native traffic lights and
+ * Linux uses default chrome, so both are no-ops.
+ */
+export function handleSetTitleBarOverlay(
+  event: IpcMainInvokeEvent,
+  color: unknown,
+  symbolColor: unknown,
+): void {
+  if (process.platform !== "win32") return;
+  if (typeof color !== "string" || typeof symbolColor !== "string") return;
+  const resolved = resolveSenderWindow(event);
+  if (resolved === null) return;
+  resolved.window.setTitleBarOverlay({ color, symbolColor });
+}
+
+/**
  * Windows-only: places a 16×16 overlay on the bottom-right corner of the
  * taskbar button (e.g., a red dot for "needs attention", a number badge,
  * or a checkmark for "task complete"). Renderer passes a data-URL or

--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -587,6 +587,7 @@ describe("RunnerIpcBridge", () => {
         RunnerHostInvoke.certTrustDismissPending,
         RunnerHostInvoke.certTrustSystemDialog,
         RunnerHostInvoke.windowSetOverlayIcon,
+        RunnerHostInvoke.windowSetTitleBarOverlay,
         RunnerHostInvoke.displayList,
         RunnerHostInvoke.fileDropWriteTemporary,
         RunnerHostInvoke.fileDropCopyTemporary,

--- a/clients/desktop/src/electron-main/ipc/platform-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/platform-ipc.ts
@@ -7,6 +7,7 @@ import {
   handleSetOverlayIcon,
   handleSetProgressBar,
   handleSetRepresentedFilename,
+  handleSetTitleBarOverlay,
 } from "../app/window-effects";
 import {
   handleGetMetrics,
@@ -356,6 +357,13 @@ export function registerPlatformIpc(bridge: RunnerIpcBridge): void {
     RunnerHostInvoke.windowSetOverlayIcon,
     (event, image: unknown, description: unknown) => {
       handleSetOverlayIcon(event, image, description);
+    },
+  );
+
+  bridge.handleInvoke(
+    RunnerHostInvoke.windowSetTitleBarOverlay,
+    (event, color: unknown, symbolColor: unknown) => {
+      handleSetTitleBarOverlay(event, color, symbolColor);
     },
   );
 

--- a/clients/desktop/src/electron-preload/platform-bridge.ts
+++ b/clients/desktop/src/electron-preload/platform-bridge.ts
@@ -113,6 +113,7 @@ export interface PlatformBridgeSurface {
   };
   windowEx: {
     setOverlayIcon(image: string | null, description: string): Promise<void>;
+    setTitleBarOverlay(color: string, symbolColor: string): Promise<void>;
   };
 }
 
@@ -310,6 +311,12 @@ export function buildPlatformBridge(): PlatformBridgeSurface {
           RunnerHostInvoke.windowSetOverlayIcon,
           image,
           description,
+        ) as Promise<void>,
+      setTitleBarOverlay: (color, symbolColor) =>
+        ipcRenderer.invoke(
+          RunnerHostInvoke.windowSetTitleBarOverlay,
+          color,
+          symbolColor,
         ) as Promise<void>,
     },
   };

--- a/clients/desktop/src/ipc-contracts/ipc-channels.ts
+++ b/clients/desktop/src/ipc-contracts/ipc-channels.ts
@@ -128,6 +128,9 @@ export const RunnerHostInvoke = {
   certTrustDismissPending: "runnerHost:cert:dismissPending",
   certTrustSystemDialog: "runnerHost:cert:systemDialog",
   windowSetOverlayIcon: "runnerHost:window:setOverlayIcon",
+  // Windows-only: repaints the native min/max/close controls (Chromium's
+  // Window Controls Overlay) with the renderer's theme-derived colors.
+  windowSetTitleBarOverlay: "runnerHost:window:setTitleBarOverlay",
   displayList: "runnerHost:display:list",
   gpuAccelerationGet: "runnerHost:gpu:get",
   gpuAccelerationSet: "runnerHost:gpu:set",

--- a/clients/gui-app/src/lib/__tests__/title-bar-overlay-colors.test.ts
+++ b/clients/gui-app/src/lib/__tests__/title-bar-overlay-colors.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { deriveTitleBarOverlayColors } from "@/lib/title-bar-overlay-colors";
+
+/**
+ * The Windows native min/max/close controls are drawn by Electron from the
+ * `titleBarOverlay` colors. They must track the app's active theme + light/dark
+ * mode, so the derived overlay colors are read from the same `--canvas` /
+ * `--canvas-foreground` surface tokens the header itself paints with.
+ */
+describe("deriveTitleBarOverlayColors", () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute("style");
+  });
+
+  it("converts oklch surface tokens to rgb so Chromium's overlay can parse them", () => {
+    // Tailwind stores several presets' surfaces as `oklch()` literals, which the
+    // native overlay can't parse - they must land as `rgb(...)`.
+    document.documentElement.style.setProperty("--canvas", "oklch(1 0 0)");
+    document.documentElement.style.setProperty(
+      "--canvas-foreground",
+      "oklch(0 0 0)",
+    );
+
+    const colors = deriveTitleBarOverlayColors(document);
+
+    expect(colors).toEqual({
+      color: "rgb(255, 255, 255)",
+      symbolColor: "rgb(0, 0, 0)",
+    });
+    expect(colors.color).not.toContain("oklch");
+  });
+
+  it("tracks the active surface so a light theme yields light controls (not the dark default)", () => {
+    document.documentElement.style.setProperty("--canvas", "#ffffff");
+    document.documentElement.style.setProperty(
+      "--canvas-foreground",
+      "#171717",
+    );
+
+    const colors = deriveTitleBarOverlayColors(document);
+
+    expect(colors.color).toBe("#ffffff");
+    expect(colors.symbolColor).toBe("#171717");
+    expect(colors.color).not.toBe("#0b0b0d");
+  });
+
+  it("falls back to the dark shell defaults when the surface tokens are unset", () => {
+    expect(deriveTitleBarOverlayColors(document)).toEqual({
+      color: "#0b0b0d",
+      symbolColor: "#e5e5e5",
+    });
+  });
+});

--- a/clients/gui-app/src/lib/keybindings/platform.ts
+++ b/clients/gui-app/src/lib/keybindings/platform.ts
@@ -38,6 +38,26 @@ export function isMac(): boolean {
   return IS_MAC;
 }
 
+// Detect Windows via the same UA Client Hints signal as `detectMac`
+// (`navigator.userAgentData.platform` reports "Windows"), falling back to the UA
+// string ("Windows NT ...") for engines without UA-CH. Like the mac check it is
+// robust against the desktop app's custom User-Agent, which never sets UA-CH
+// metadata.
+function detectWindows(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const uaPlatform = navigator.userAgentData?.platform;
+  if (uaPlatform !== undefined && uaPlatform !== "") {
+    return uaPlatform.toLowerCase().includes("win");
+  }
+  return navigator.userAgent.toLowerCase().includes("win");
+}
+
+const IS_WINDOWS = detectWindows();
+
+export function isWindows(): boolean {
+  return IS_WINDOWS;
+}
+
 export function modLabel(): string {
   return isMac() ? "⌘" : "Ctrl";
 }

--- a/clients/gui-app/src/lib/title-bar-overlay-colors.ts
+++ b/clients/gui-app/src/lib/title-bar-overlay-colors.ts
@@ -1,0 +1,40 @@
+import { resolveCssColor } from "@/lib/css-color";
+
+/**
+ * Overlay colors for the Windows native window controls (min/max/close).
+ *
+ * On Windows the frameless shell hands Chromium's Window Controls Overlay these
+ * colors via Electron's `titleBarOverlay`. Kept in its own module (no theme /
+ * store imports) so the derivation stays a pure function of the CSS cascade.
+ */
+export interface TitleBarOverlayColors {
+  /** Overlay background - matches the header's `bg-canvas` surface. */
+  readonly color: string;
+  /** Glyph color for the min/max/close symbols. */
+  readonly symbolColor: string;
+}
+
+// Dark shell defaults - the pre-theme launch colors baked into the
+// `BrowserWindow` (`window-factory.ts`). Used only if the surface tokens are
+// somehow unset so the controls never fall back to an unstyled state.
+const FALLBACK_COLOR = "#0b0b0d";
+const FALLBACK_SYMBOL_COLOR = "#e5e5e5";
+
+/**
+ * Reads the overlay background + symbol colors from the same `--canvas` /
+ * `--canvas-foreground` tokens the app header paints with, resolved to
+ * `rgb(...)` - the format Chromium's overlay accepts (Tailwind stores tokens as
+ * `oklch()` literals the native overlay can't parse).
+ */
+export function deriveTitleBarOverlayColors(
+  doc: Document,
+): TitleBarOverlayColors {
+  return {
+    color: resolveCssColor(doc, "--canvas", FALLBACK_COLOR),
+    symbolColor: resolveCssColor(
+      doc,
+      "--canvas-foreground",
+      FALLBACK_SYMBOL_COLOR,
+    ),
+  };
+}

--- a/clients/gui-app/src/lib/title-bar-overlay-theme.ts
+++ b/clients/gui-app/src/lib/title-bar-overlay-theme.ts
@@ -12,36 +12,34 @@
  *
  * Imperative module-load installer (mirrors `theme-applier.ts` and
  * `window-controls-overlay.ts`): it subscribes outside React so the native
- * controls update in lockstep with the DOM cascade. On the browser shell (no
- * `window.runnerHost`) and on macOS/Linux (no overlay-color surface) the push
- * target is absent, so the module no-ops.
+ * controls update in lockstep with the DOM cascade. The whole bridge is
+ * Windows-only - macOS draws OS-native traffic lights, Linux uses default
+ * chrome, and main drops the push off `win32` - so the installer short-circuits
+ * on any other OS instead of emitting IPC main would ignore. On the browser
+ * shell there is no `window.runnerHost`, so the push target is absent and the
+ * module no-ops there too.
  */
 
 import { deriveTitleBarOverlayColors } from "@/lib/title-bar-overlay-colors";
+import { isWindows } from "@/lib/keybindings/platform";
 import { subscribeResolvedTheme } from "@/lib/theme-applier";
 
 interface TitleBarOverlaySink {
   setTitleBarOverlay(color: string, symbolColor: string): void;
 }
 
-interface RunnerHostWithOverlay {
-  readonly platform?: {
-    readonly windowEx?: Partial<TitleBarOverlaySink>;
-  };
+// Structural view of the desktop preload's `runnerHost.platform.windowEx`
+// surface, typed locally so gui-app stays browser-safe and doesn't import from
+// the desktop package (mirrors the sibling `desktop-*.ts` host bridges).
+interface RunnerHostWindowShape {
+  readonly platform:
+    { readonly windowEx: TitleBarOverlaySink | undefined } | undefined;
 }
 
 function getOverlaySink(): TitleBarOverlaySink | null {
-  if (typeof window === "undefined") return null;
-  const runnerHost = (window as { runnerHost?: RunnerHostWithOverlay })
+  const host = (globalThis as { runnerHost?: RunnerHostWindowShape })
     .runnerHost;
-  const windowEx = runnerHost?.platform?.windowEx;
-  if (
-    windowEx === undefined ||
-    typeof windowEx.setTitleBarOverlay !== "function"
-  ) {
-    return null;
-  }
-  return windowEx as TitleBarOverlaySink;
+  return host?.platform?.windowEx ?? null;
 }
 
 let installed = false;
@@ -50,6 +48,9 @@ function install(): void {
   if (installed) return;
   installed = true;
   if (typeof document === "undefined") return;
+  // Only Windows draws its controls from `titleBarOverlay`; elsewhere the push
+  // is a no-op in main, so skip the subscription rather than churn IPC.
+  if (!isWindows()) return;
   const sink = getOverlaySink();
   if (sink === null) return;
   const push = (): void => {

--- a/clients/gui-app/src/lib/title-bar-overlay-theme.ts
+++ b/clients/gui-app/src/lib/title-bar-overlay-theme.ts
@@ -1,0 +1,65 @@
+/**
+ * Keeps the Windows native window controls (min/max/close) in sync with the
+ * active theme.
+ *
+ * On Windows the frameless shell hands Chromium's Window Controls Overlay the
+ * button colors via Electron's `titleBarOverlay`. Those colors are static once
+ * the `BrowserWindow` is created, so without this bridge the controls stay on
+ * the dark launch defaults and clash with a light theme (or a differently-
+ * colored preset). This module re-derives the overlay colors from the live CSS
+ * cascade on every theme change and pushes them to main, which calls
+ * `setTitleBarOverlay`.
+ *
+ * Imperative module-load installer (mirrors `theme-applier.ts` and
+ * `window-controls-overlay.ts`): it subscribes outside React so the native
+ * controls update in lockstep with the DOM cascade. On the browser shell (no
+ * `window.runnerHost`) and on macOS/Linux (no overlay-color surface) the push
+ * target is absent, so the module no-ops.
+ */
+
+import { deriveTitleBarOverlayColors } from "@/lib/title-bar-overlay-colors";
+import { subscribeResolvedTheme } from "@/lib/theme-applier";
+
+interface TitleBarOverlaySink {
+  setTitleBarOverlay(color: string, symbolColor: string): void;
+}
+
+interface RunnerHostWithOverlay {
+  readonly platform?: {
+    readonly windowEx?: Partial<TitleBarOverlaySink>;
+  };
+}
+
+function getOverlaySink(): TitleBarOverlaySink | null {
+  if (typeof window === "undefined") return null;
+  const runnerHost = (window as { runnerHost?: RunnerHostWithOverlay })
+    .runnerHost;
+  const windowEx = runnerHost?.platform?.windowEx;
+  if (
+    windowEx === undefined ||
+    typeof windowEx.setTitleBarOverlay !== "function"
+  ) {
+    return null;
+  }
+  return windowEx as TitleBarOverlaySink;
+}
+
+let installed = false;
+
+function install(): void {
+  if (installed) return;
+  installed = true;
+  if (typeof document === "undefined") return;
+  const sink = getOverlaySink();
+  if (sink === null) return;
+  const push = (): void => {
+    const { color, symbolColor } = deriveTitleBarOverlayColors(document);
+    sink.setTitleBarOverlay(color, symbolColor);
+  };
+  // Sync the launch-time dark defaults to the persisted theme immediately, then
+  // track every subsequent theme-mode / preset change.
+  push();
+  subscribeResolvedTheme(push);
+}
+
+install();

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -41,6 +41,10 @@ import { createAppRouter, type AppRouter } from "@/router";
 // load (mirrors `theme-applier.ts`). The class drives the `wco:`
 // Tailwind variant so titlebar insets toggle on fullscreen.
 import "@/lib/window-controls-overlay";
+// Side-effect import: keeps the Windows native min/max/close controls in
+// sync with the active theme by pushing theme-derived overlay colors to the
+// desktop shell on every theme change (no-op on web / mac / Linux).
+import "@/lib/title-bar-overlay-theme";
 import { startMainThreadBlockProbe } from "@/lib/perf/main-thread-block-probe";
 
 // Surface renderer main-thread stalls (Long Tasks) so slow-feeling RPCs caused


### PR DESCRIPTION
## Summary

On Windows the frameless desktop shell draws the native min/max/close controls from Chromium's Window Controls Overlay, whose colors come from Electron's `titleBarOverlay`. Those colors are **frozen at `BrowserWindow` creation** — pinned to the dark launch defaults (`#0b0b0d` / `#e5e5e5`) — so the controls stayed dark under a light theme or a differently-colored preset, clashing with the header.

This PR makes the controls track the active theme + light/dark mode by re-deriving the overlay colors from the live CSS cascade on every theme change and pushing them to main via a new Windows-only `setTitleBarOverlay` IPC path.

## How it works

- **Renderer** (`title-bar-overlay-theme.ts`) — a module-load installer (mirroring `theme-applier.ts` / `window-controls-overlay.ts`) subscribes to resolved-theme changes outside React and pushes overlay colors derived from the same `--canvas` / `--canvas-foreground` tokens the app header paints with (`bg-canvas` / `text-canvas-foreground`). Colors are converted oklch → rgb via culori because Chromium's overlay can't parse `oklch()`. An initial push reconciles the launch defaults against the persisted theme.
- **Main** (`handleSetTitleBarOverlay` in `window-effects.ts`) — Windows-only handler that validates the payload, resolves the sender window, and calls `win.setTitleBarOverlay({ color, symbolColor })` (height is retained). No-op off `win32`.
- **IPC** — new `runnerHost:window:setTitleBarOverlay` channel wired through `ipc-channels` → `platform-bridge` → `platform-ipc`.

Because the overlay only exists on Windows (macOS draws OS-native traffic lights, Linux uses default chrome), the whole bridge is gated to Windows: a new `isWindows()` platform helper short-circuits the installer on other OSes so mac/Linux don't emit an IPC round-trip main would just drop.

## Correctness notes

- `--canvas` / `--canvas-foreground` are redefined per `:root` (light), `.dark`, and every per-preset `[data-theme]` / `.dark[data-theme]` block, so the controls follow **both** the accent preset and the light/dark variant.
- `subscribeResolvedTheme` fires on theme-mode change, preset change, and system-preference change (while in "system" mode) — all the cases that alter those tokens.
- Fallback colors exactly match the `window-factory.ts` launch defaults, so the controls never fall back to an unstyled state.

## Testing

- `bun run compile` — clean (desktop + gui-app)
- `bunx vitest run` on the affected specs — 44 tests pass (main-process handler, IPC channel registration, color derivation)
- ESLint clean on changed files

Native visual confirmation on Windows still pending a manual check on hardware.
