### PR TITLE
fix(desktop): sign Windows builds with SHA-256 digests only

### DIFF
--- a/clients/desktop/package.json
+++ b/clients/desktop/package.json
@@ -172,6 +172,11 @@
     "win": {
       "artifactName": "traycer-desktop-windows-${arch}.${ext}",
       "icon": "icon.ico",
+      "signtoolOptions": {
+        "signingHashAlgorithms": [
+          "sha256"
+        ]
+      },
       "target": [
         {
           "target": "nsis",


### PR DESCRIPTION
## Problem

The first signed Windows desktop release attempt (internal run 29049129845) failed in electron-builder's signing queue. The command it generated for the first file was:

```
signtool.exe sign /t http://timestamp.digicert.com /sha1 <thumbprint> /s My ... traycer.exe
```

No `/fd` flag → signtool defaults to a **SHA-1 file digest**. Our signing key lives in SSL.com's eSigner cloud HSM, which refuses SHA-1 digests outright — the CNG provider surfaced it as:

```
invalid hash length - CnP5CZq7dldOSh/fYZAHTUVu1P8=   (20 bytes = SHA-1)
```

This is electron-builder 26's default when signing from the certificate store (`windowsSignToolManager.js`): `signingHashAlgorithms == null` → `["sha1", "sha256"]` dual-signing, with the SHA-1 pass first. The MSI target is worse — MSI cannot be dual-signed, so the default degrades to **SHA-1 only**, which would fail even if the exe pass survived.

## Fix

Pin `win.signtoolOptions.signingHashAlgorithms` to `["sha256"]`. Every Windows target (NSIS, MSI, nested exes) then gets a single SHA-256 signature with the RFC 3161 countersignature (`/tr … /td sha256 /fd sha256`), which is exactly the invocation that already signs the CLI and host binaries successfully.

Nothing is lost by dropping the SHA-1 pass: SHA-1 Authenticode has been rejected by Windows since ~2016; every OS the desktop app supports validates SHA-256.

Unsigned builds are unaffected — without `certificateSha1` electron-builder skips signing entirely and this option is inert (local `package`/`package:dir` builds included).

The CLI `-c.win.signtoolOptions.*` flags the release workflow passes deep-merge with this file config, so certificate selection stays workflow-provided while the digest policy is version-controlled here. (A `-c.` flag can't express this option: yargs dot-notation can't produce a one-element array and a bare string fails the config schema's `array|null` validation.)