### PR TITLE
Keep RPC sessions open until requests settle

### DIFF
--- a/clients/shared/host-transport/__tests__/ws-rpc-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-rpc-client.test.ts
@@ -267,6 +267,7 @@ describe("WsRpcClient", () => {
       schemaVersion: { major: 1, minor: 0 },
       params: { message: "hi" },
     });
+    expect(stub.closed).toBeNull();
 
     stub.fireMessage({
       kind: "response",
@@ -834,6 +835,7 @@ describe("WsRpcClient", () => {
       schemaVersion: { major: 1, minor: 0 },
       params: {},
     });
+    expect(sockets[0].socket.closed).toBeNull();
 
     sockets[0].socket.fireMessage({
       kind: "response",
@@ -845,6 +847,7 @@ describe("WsRpcClient", () => {
     });
 
     await expect(pending).resolves.toEqual({ summary: "ready" });
+    expect(sockets[0].socket.closed).toEqual({ code: 1000, reason: "ok" });
   });
 
   it("throws E_HOST_UNSUPPORTED when an absent optional method declares unsupported", async () => {

--- a/clients/shared/host-transport/ws-rpc-client.ts
+++ b/clients/shared/host-transport/ws-rpc-client.ts
@@ -271,7 +271,7 @@ export class WsRpcClient<
 
       const methodRegistry = this.registry[method] as MethodVersionRegistry;
       if (hostCanonical === undefined) {
-        return executeUnavailableMethodDegrade(
+        return await executeUnavailableMethodDegrade(
           this.registry,
           session,
           method,
@@ -284,7 +284,7 @@ export class WsRpcClient<
         );
       }
 
-      return executeAvailableMethodRequest<
+      return await executeAvailableMethodRequest<
         RequestOfMethod<Registry, Method>,
         ResponseOfMethod<Registry, Method>
       >(


### PR DESCRIPTION
## Summary

- await direct and fallback RPC execution inside the request try/finally boundary
- keep the WebSocket open while the response promise is pending, then close it after settlement
- add regression assertions for both the direct and fallback request paths

## Context

Follow-up to #272 for a valid late review finding that arrived seconds before its auto-merge.

## Validation

- WsRpcClient tests: 26 passed
- bun run compile
- shared workspace lint and Prettier checks
- pre-commit run --all-files