### PR TITLE
feat(resources): host-tree utilization (resources.subscribe@1.2) + resource monitor rework

### DIFF
--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -28,6 +28,8 @@ import {
 } from "@testing-library/react";
 import type {
   AppResourceSnapshotWire,
+  HostTreeResourceSnapshotWire,
+  OtherResourceSnapshotWire,
   OwnerResourceSnapshotWire,
   ResourceProcessSnapshotWire,
 } from "@traycer/protocol/host/resources/subscribe";
@@ -41,6 +43,16 @@ import { ResourcesStreamMount } from "@/providers/resources-stream-mount";
 import { __setResourcesStreamClientFactoryForTests } from "@/providers/resources-stream-factory-override";
 import { resourcesRegistry } from "@/stores/resources/resources-registry";
 import { useTitleBarDragStore } from "@/stores/layout/title-bar-drag-store";
+
+const streamVersionMock = vi.hoisted(() => ({
+  version: null as { readonly major: number; readonly minor: number } | null,
+}));
+
+vi.mock("@/lib/host/stream-runtime-context", () => ({
+  useWsStreamClient: () => null,
+  useStreamMethodSupport: () => null,
+  useStreamMethodSchemaVersion: () => streamVersionMock.version,
+}));
 
 type MockEpicIntentInput = Readonly<Record<string, unknown>>;
 type MockEpicIntent = MockEpicIntentInput & { readonly kind: "epic" };
@@ -68,6 +80,17 @@ vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
 }));
 
 const historyNavAvailableMock = vi.hoisted(() => ({ enabled: true }));
+
+const liveArtifactTitleMock = vi.hoisted(() => ({
+  title: null as string | null,
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useRegisteredEpicLiveArtifactTitle: (
+    _epicId: string,
+    artifactId: string | null,
+  ) => (artifactId === "chat-1" ? liveArtifactTitleMock.title : null),
+}));
 
 vi.mock("@/lib/history-navigation/use-history-nav-available", () => ({
   useHistoryNavAvailable: () => historyNavAvailableMock.enabled,
@@ -275,6 +298,50 @@ function owner(
   };
 }
 
+function hostTree(
+  over: Partial<HostTreeResourceSnapshotWire>,
+): HostTreeResourceSnapshotWire {
+  return {
+    sampledAt: 1_000,
+    processCount: 4,
+    cpuPercent: 10,
+    rssBytes: 400 * 1024 * 1024,
+    ...over,
+  };
+}
+
+function other(
+  over: Partial<OtherResourceSnapshotWire>,
+): OtherResourceSnapshotWire {
+  return {
+    sampledAt: 1_000,
+    rootPids: [500],
+    processCount: 2,
+    cpuPercent: 5,
+    rssBytes: 50 * 1024 * 1024,
+    processes: [
+      resourceProcess({
+        pid: 500,
+        rootPid: 500,
+        name: "worker",
+        command: "worker",
+        cpuPercent: 1,
+        rssBytes: 10 * 1024 * 1024,
+      }),
+      resourceProcess({
+        pid: 501,
+        parentPid: 500,
+        rootPid: 500,
+        name: "child",
+        command: "child",
+        cpuPercent: 4,
+        rssBytes: 40 * 1024 * 1024,
+      }),
+    ],
+    ...over,
+  };
+}
+
 function projection(
   over: Partial<ResourcesProjectionPayload>,
 ): ResourcesProjectionPayload {
@@ -285,6 +352,8 @@ function projection(
     owners: [],
     epic: null,
     epics: [],
+    hostTree: undefined,
+    other: undefined,
     ...over,
   };
 }
@@ -319,6 +388,20 @@ afterEach(() => {
   routerMock.pathname = "/epics/epic-1/tab-1";
   navigateNestedMock.mockClear();
   historyNavAvailableMock.enabled = true;
+  liveArtifactTitleMock.title = null;
+  canvasMock.state.canvasByTabId["tab-1"].tilesByInstanceId["tile-term-1"] = {
+    id: "term-1",
+    instanceId: "tile-term-1",
+    type: "terminal",
+    name: "Terminal Alpha",
+    titleSource: "manual",
+    hostId: "host-1",
+    cwd: "/work",
+  };
+  canvasMock.state.artifactTreeByEpicId["epic-1"][0] = {
+    ...canvasMock.state.artifactTreeByEpicId["epic-1"][0],
+    name: "Agent Chat",
+  };
   tabNavigationMock.existingEpicTabIntentWithNestedFocus.mockClear();
   tabNavigationMock.navigateToTabIntent.mockClear();
   canvasMock.prepareOpenTileInTabFocusTarget.mockReset();
@@ -326,11 +409,223 @@ afterEach(() => {
   canvasMock.resolveTargetTabForEpic.mockReset();
   canvasMock.resolveTargetTabForEpic.mockReturnValue("tab-2");
   __setResourcesStreamClientFactoryForTests(null);
+  streamVersionMock.version = null;
   resourcesRegistry.disposeAll();
   useTitleBarDragStore.setState({ suppressors: new Set() });
 });
 
 describe("ResourceMonitorPopover", () => {
+  it("uses the live chat title when the persisted owner name is untitled", async () => {
+    liveArtifactTitleMock.title = "Generated chat title";
+    canvasMock.state.artifactTreeByEpicId["epic-1"][0] = {
+      ...canvasMock.state.artifactTreeByEpicId["epic-1"][0],
+      name: "Untitled chat",
+    };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "chat",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "chat-1",
+              },
+              activeProcessName: null,
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+
+    expect(await screen.findByText("Generated chat title")).not.toBeNull();
+    expect(screen.queryByText("Untitled chat")).toBeNull();
+  });
+
+  it("updates an auto-titled terminal owner from each resource frame", async () => {
+    canvasMock.state.canvasByTabId["tab-1"].tilesByInstanceId["tile-term-1"] = {
+      ...canvasMock.state.canvasByTabId["tab-1"].tilesByInstanceId[
+        "tile-term-1"
+      ],
+      titleSource: "default",
+    };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub
+        .emit()
+        .onSnapshot(
+          projection({
+            owners: [owner({ activeProcessName: "first-command" })],
+          }),
+        );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(screen.getByText("first-command")).not.toBeNull();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [owner({ activeProcessName: "second-command" })],
+        }),
+      );
+    });
+
+    expect(screen.queryByText("Terminal Alpha")).toBeNull();
+    expect(screen.getByText("second-command")).not.toBeNull();
+  });
+
+  it("uses the host-tree aggregate plus desktop usage for the headline", async () => {
+    const stub = installStubFactory();
+    Reflect.set(globalThis, "runnerHost", {
+      platform: {
+        diagnostics: {
+          getMetrics: vi.fn().mockResolvedValue({
+            appMetrics: [
+              {
+                pid: 10,
+                type: "Browser",
+                cpu: { percentCPUUsage: 1.5 },
+                memory: { workingSetSize: 100 * 1024 },
+              },
+            ],
+          }),
+        },
+      },
+    });
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          app: app(),
+          hostTree: hostTree({}),
+          owners: [owner({ cpuPercent: 99, rssBytes: 900 * 1024 * 1024 })],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(await screen.findByText("12%")).not.toBeNull();
+    expect(screen.getByText("500 MB")).not.toBeNull();
+    expect(screen.getByRole("progressbar").getAttribute("aria-valuenow")).toBe(
+      "24",
+    );
+  });
+
+  it("renders Other as a non-navigable, expandable process-root section", () => {
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub
+        .emit()
+        .onSnapshot(
+          projection({ app: app(), hostTree: hostTree({}), other: other({}) }),
+        );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    // Collapsed by default: only the section header with aggregate totals.
+    expect(screen.getByText("Other")).not.toBeNull();
+    expect(screen.queryByText("worker (1 sub-process)")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand other processes" }),
+    );
+    expect(screen.getByText("worker (1 sub-process)")).not.toBeNull();
+    expect(screen.queryByText("child")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand sub-processes of worker" }),
+    );
+    expect(screen.getByText("child")).not.toBeNull();
+  });
+
+  it("shows compact basename labels for Other roots until expanded", () => {
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          app: app(),
+          hostTree: hostTree({}),
+          other: other({
+            processes: [
+              resourceProcess({
+                pid: 500,
+                rootPid: 500,
+                name: "/Users/dev/.traycer/host/dev/providers/opencode/opencode",
+                command:
+                  "/Users/dev/.traycer/host/dev/providers/opencode/opencode serve",
+                cpuPercent: 1,
+                rssBytes: 10 * 1024 * 1024,
+              }),
+              resourceProcess({
+                pid: 501,
+                parentPid: 500,
+                rootPid: 500,
+                name: "node",
+                command: "node worker.js",
+                cpuPercent: 4,
+                rssBytes: 40 * 1024 * 1024,
+              }),
+            ],
+          }),
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand other processes" }),
+    );
+    // Collapsed root shows the executable basename, not the install path.
+    expect(screen.getByText("opencode (1 sub-process)")).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand sub-processes of /Users/dev/.traycer/host/dev/providers/opencode/opencode serve",
+      }),
+    );
+    // Expanded root reveals the full command for inspection.
+    expect(
+      screen.getByText(
+        "/Users/dev/.traycer/host/dev/providers/opencode/opencode serve",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("keeps the legacy headline and hides Other on resources.subscribe@1.1", () => {
+    streamVersionMock.version = { major: 1, minor: 1 };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          app: app(),
+          hostTree: hostTree({ cpuPercent: 50 }),
+          other: other({}),
+          owners: [owner({ cpuPercent: 2, rssBytes: 100 * 1024 * 1024 })],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    expect(screen.getByText("3.0%")).not.toBeNull();
+    expect(screen.queryByText("Other")).toBeNull();
+  });
+
   it("shows global app resources and task process trees", async () => {
     const stub = installStubFactory();
     const getDesktopMetrics = vi.fn().mockResolvedValue({
@@ -427,46 +722,104 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.getByText("Resource Task")).not.toBeNull();
     expect(screen.getByText("Background Task")).not.toBeNull();
     expect(screen.getByText("Terminal Alpha")).not.toBeNull();
+    // Owner trees start collapsed, so their inclusive values are visible on the
+    // owner rows while no individual process is rendered yet.
     expect(
-      screen.getAllByText("node dev-server.js (2 sub-processes)"),
-    ).toHaveLength(2);
+      screen.queryByText("node dev-server.js (2 sub-processes)"),
+    ).toBeNull();
     expect(screen.queryByText("/bin/sh")).toBeNull();
     expect(screen.queryByText("make")).toBeNull();
     expect(screen.getByText("2 open terminals")).not.toBeNull();
     expect(screen.queryByText(/terminal processes/)).toBeNull();
 
-    const cappedProcessRow = screen
-      .getAllByText("node dev-server.js (2 sub-processes)")[0]
-      .closest("button");
-    if (cappedProcessRow === null) {
-      throw new Error("Expected capped process row to be an expand button");
-    }
-    // Clicking the boundary reveals its whole sub-tree (to the leaves) inline,
-    // with each revealed row carrying its own CPU/memory columns.
-    fireEvent.click(cappedProcessRow);
-    expect(screen.getByText("/bin/sh")).not.toBeNull();
-    expect(screen.getByText("make")).not.toBeNull();
-    expect(screen.getAllByText("2.0 MB").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("4.0 MB").length).toBeGreaterThan(0);
-    // The expanded row drops its "(N sub-processes)" summary; the other owner's
-    // tree stays collapsed (expansion is per-node, and multiple may be open).
-    expect(screen.getByText("node dev-server.js")).not.toBeNull();
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "Expand process tree" })[0],
+    );
     expect(
-      screen.getAllByText("node dev-server.js (2 sub-processes)"),
-    ).toHaveLength(1);
-
-    // Clicking again collapses it back to the summarized boundary.
-    const expandedRow = screen
-      .getByText("node dev-server.js")
-      .closest("button");
-    if (expandedRow === null) {
-      throw new Error("Expected expanded row to be a collapse button");
-    }
-    fireEvent.click(expandedRow);
+      screen.getByText("node dev-server.js (2 sub-processes)"),
+    ).not.toBeNull();
     expect(screen.queryByText("/bin/sh")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand sub-processes of node dev-server.js",
+      }),
+    );
+    expect(screen.getByText("/bin/sh (1 sub-process)")).not.toBeNull();
+    expect(screen.queryByText("make")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand sub-processes of /bin/sh",
+      }),
+    );
+    expect(screen.getByText("make")).not.toBeNull();
+  });
+
+  it("swaps tree values for self values without double-counting visible rows", async () => {
+    const stub = installStubFactory();
+    render(
+      <TooltipProvider delayDuration={0}>
+        <ResourcesStreamMount epicId="epic-1" />
+        <ResourceMonitorPopover className={undefined} />
+      </TooltipProvider>,
+    );
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              cpuPercent: 13,
+              rssBytes: 106 * 1024 * 1024,
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+
+    const ownerRow = screen.getByText("Terminal Alpha").closest("button");
+    if (ownerRow === null) throw new Error("Expected owner row button");
+    expect(ownerRow.textContent).toContain("13%");
+    expect(ownerRow.textContent).toContain("106 MB");
     expect(
-      screen.getAllByText("node dev-server.js (2 sub-processes)"),
-    ).toHaveLength(2);
+      screen.queryByText("node dev-server.js (2 sub-processes)"),
+    ).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand process tree" }),
+    );
+    expect(ownerRow.textContent).toContain("2.0%");
+    expect(ownerRow.textContent).toContain("40.0 MB");
+    const nodeRow = screen
+      .getByText("node dev-server.js (2 sub-processes)")
+      .closest("button");
+    if (nodeRow === null) throw new Error("Expected node row button");
+    expect(nodeRow.textContent).toContain("11%");
+    expect(nodeRow.textContent).toContain("66.0 MB");
+
+    const metrics = ownerRow.querySelector('[data-slot="tooltip-trigger"]');
+    if (metrics === null)
+      throw new Error("Expected owner metric tooltip trigger");
+    fireEvent.pointerMove(metrics);
+    expect(
+      await screen.findAllByText(/Self: 2\.0% CPU · 40\.0 MB memory/),
+    ).not.toHaveLength(0);
+    expect(
+      await screen.findAllByText(/Tree: 13% CPU · 106 MB memory/),
+    ).not.toHaveLength(0);
+
+    fireEvent.click(nodeRow);
+    expect(nodeRow.textContent).toContain("10%");
+    expect(nodeRow.textContent).toContain("60.0 MB");
+    const shellRow = screen
+      .getByText("/bin/sh (1 sub-process)")
+      .closest("button");
+    if (shellRow === null) throw new Error("Expected shell row button");
+    expect(shellRow.textContent).toContain("1.0%");
+    expect(shellRow.textContent).toContain("6.0 MB");
   });
 
   it("commits an already-open owner in the CURRENT tab through the same-route boundary", async () => {
@@ -658,7 +1011,7 @@ describe("ResourceMonitorPopover", () => {
     );
   });
 
-  it("pins root section headers to the top of the scroll region", () => {
+  it("pins an expanded owner row beneath its sticky section header", () => {
     const stub = installStubFactory();
     render(
       <TooltipProvider>
@@ -672,15 +1025,19 @@ describe("ResourceMonitorPopover", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Expand process tree" }),
+    );
 
-    // The section root ("Traycer Host") header sticks so it stays visible as its
-    // rows scroll under it; the current header swaps per section (not stacked).
-    const hostHeader = screen.getByText("Traycer Host").closest(".sticky");
-    expect(hostHeader).not.toBeNull();
-    expect(hostHeader?.className).toContain("top-0");
+    // Layout engines, not jsdom, validate scroll positioning; this verifies the
+    // structural sticky container and its measured section-header offset.
+    const ownerRow = screen.getByText("Terminal Alpha").closest(".sticky");
+    expect(ownerRow).not.toBeNull();
+    expect(ownerRow?.className).toContain("bg-popover");
+    expect(ownerRow?.getAttribute("style")).toContain("top: 0px");
   });
 
-  it("hides terminal rows with no subprocesses while keeping aggregate metrics", () => {
+  it("shows idle terminals even when they have no subprocesses", () => {
     const stub = installStubFactory();
 
     render(
@@ -707,9 +1064,8 @@ describe("ResourceMonitorPopover", () => {
               processCount: 1,
               cpuPercent: 77,
               rssBytes: 900 * 1024 * 1024,
-              // A bare shell with nothing running under it: its whole tree is a
-              // single process, so the terminal owner row is hidden entirely
-              // while its metrics still fold into the aggregate below.
+              // A bare shell with nothing running under it is still a terminal
+              // session and must remain visible in the compact default view.
               processes: [
                 resourceProcess({
                   pid: 900,
@@ -730,9 +1086,7 @@ describe("ResourceMonitorPopover", () => {
     fireEvent.click(screen.getByRole("button", { name: "Resources" }));
 
     expect(screen.getByText("Terminal Alpha")).not.toBeNull();
-    // The whole terminal owner row is hidden - neither its label nor its lone
-    // shell process renders.
-    expect(screen.queryByText("idle-shell")).toBeNull();
+    expect(screen.getByText("idle-shell")).not.toBeNull();
     expect(screen.queryByText("/usr/bin/idle-zsh")).toBeNull();
     expect(screen.getByText("2 open terminals")).not.toBeNull();
     expect(screen.getAllByText("89%").length).toBeGreaterThan(0);

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -448,7 +448,7 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.queryByText("Untitled chat")).toBeNull();
   });
 
-  it("updates an auto-titled terminal owner from each resource frame", async () => {
+  it("updates an auto-titled terminal owner from each resource frame", () => {
     canvasMock.state.canvasByTabId["tab-1"].tilesByInstanceId["tile-term-1"] = {
       ...canvasMock.state.canvasByTabId["tab-1"].tilesByInstanceId[
         "tile-term-1"

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -459,13 +459,11 @@ describe("ResourceMonitorPopover", () => {
     renderPopover();
 
     act(() => {
-      stub
-        .emit()
-        .onSnapshot(
-          projection({
-            owners: [owner({ activeProcessName: "first-command" })],
-          }),
-        );
+      stub.emit().onSnapshot(
+        projection({
+          owners: [owner({ activeProcessName: "first-command" })],
+        }),
+      );
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Resources" }));

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -497,9 +497,10 @@ describe("ResourceMonitorPopover", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Resources" }));
-    // 3 + 5 + 9 single-counted, on both the task header and the owner row;
-    // the double-count bug would show 26% instead.
-    expect(screen.getAllByText("17%").length).toBeGreaterThan(0);
+    // 3 + 5 + 9 single-counted, shown by exactly two elements: the task
+    // header and the owner row. A double-count regression in either
+    // projection drops the count below 2 and surfaces 26% instead.
+    expect(screen.getAllByText("17%")).toHaveLength(2);
     expect(screen.queryByText("26%")).toBeNull();
   });
 

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -448,6 +448,61 @@ describe("ResourceMonitorPopover", () => {
     expect(screen.queryByText("Untitled chat")).toBeNull();
   });
 
+  it("counts a nested tracked root once in owner tree totals", () => {
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              processes: [
+                // PTY root: parent (the host) is outside this list.
+                resourceProcess({
+                  pid: 100,
+                  parentPid: 1,
+                  rootPid: 100,
+                  name: "zsh",
+                  command: "/bin/zsh",
+                  cpuPercent: 3,
+                  rssBytes: 10 * 1024 * 1024,
+                }),
+                resourceProcess({
+                  pid: 101,
+                  parentPid: 100,
+                  rootPid: 100,
+                  name: "node",
+                  command: "node agent.js",
+                  cpuPercent: 5,
+                  rssBytes: 20 * 1024 * 1024,
+                }),
+                // Second tracked root that is an OS descendant of the first
+                // tree: must be counted exactly once (as a child), never as
+                // an additional root.
+                resourceProcess({
+                  pid: 102,
+                  parentPid: 101,
+                  rootPid: 102,
+                  name: "claude",
+                  command: "claude --chat",
+                  cpuPercent: 9,
+                  rssBytes: 30 * 1024 * 1024,
+                }),
+              ],
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    // 3 + 5 + 9 single-counted, on both the task header and the owner row;
+    // the double-count bug would show 26% instead.
+    expect(screen.getAllByText("17%").length).toBeGreaterThan(0);
+    expect(screen.queryByText("26%")).toBeNull();
+  });
+
   it("updates an auto-titled terminal owner from each resource frame", () => {
     canvasMock.state.canvasByTabId["tab-1"].tilesByInstanceId["tile-term-1"] = {
       ...canvasMock.state.canvasByTabId["tab-1"].tilesByInstanceId[

--- a/clients/gui-app/src/components/resources/__tests__/resource-usage-chip.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-usage-chip.test.tsx
@@ -78,6 +78,8 @@ function projection(
     owners: [],
     epic: null,
     epics: [],
+    hostTree: undefined,
+    other: undefined,
     ...over,
   };
 }

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -1000,6 +1000,7 @@ function OwnerTreeRow(props: {
         {processRows.canExpand ? (
           <button
             type="button"
+            aria-expanded={props.expanded}
             onClick={props.onToggle}
             className="ml-3 flex size-6 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
             aria-label={
@@ -1692,14 +1693,15 @@ function buildProcessRows(
   const processByPid = new Map(
     processes.map((process) => [process.pid, process]),
   );
-  const childrenByParent = new Map<number, ResourceProcessSnapshotWire[]>();
-  for (const process of processes) {
-    if (process.parentPid === null || !processByPid.has(process.parentPid))
-      continue;
-    const siblings = childrenByParent.get(process.parentPid) ?? [];
+  const childrenByParent = processes.reduce((byParent, process) => {
+    if (process.parentPid === null || !processByPid.has(process.parentPid)) {
+      return byParent;
+    }
+    const siblings = byParent.get(process.parentPid) ?? [];
     siblings.push(process);
-    childrenByParent.set(process.parentPid, siblings);
-  }
+    byParent.set(process.parentPid, siblings);
+    return byParent;
+  }, new Map<number, ResourceProcessSnapshotWire[]>());
 
   const roots = processes.filter(
     (process) =>

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -23,11 +24,16 @@ import {
 } from "lucide-react";
 import type {
   OwnerResourceSnapshotWire,
+  HostTreeResourceSnapshotWire,
+  OtherResourceSnapshotWire,
   ResourceOwnerKindWire,
   ResourceProcessSnapshotWire,
 } from "@traycer/protocol/host/resources/subscribe";
 import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
 import type { EpicNodeRecord } from "@/lib/artifacts/node-display";
+import { chatDisplayTitle } from "@/lib/display-title";
+import { useRegisteredEpicLiveArtifactTitle } from "@/lib/epic-selectors";
+import { terminalSessionTitle } from "@/lib/terminals/terminal-title";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -48,6 +54,7 @@ import {
 } from "@/stores/resources/resources-registry";
 import { useTitleBarDragStore } from "@/stores/layout/title-bar-drag-store";
 import { GlobalResourcesStreamMount } from "@/providers/resources-stream-mount";
+import { useStreamMethodSchemaVersion } from "@/lib/host/stream-runtime-context";
 import type {
   AppResourceUsage,
   TaskResourceSummary,
@@ -110,7 +117,6 @@ const desktopAppResourceListeners = new Set<() => void>();
 let desktopAppResourceSnapshot: DesktopAppResourceUsage | null = null;
 let desktopAppResourceTimer: number | null = null;
 let desktopAppResourceInFlight = false;
-const MAX_VISIBLE_PROCESS_DEPTH = 2;
 const EMPTY_RESOURCE_SUMMARY: TaskResourceSummary = {
   cpuPercent: 0,
   rssBytes: 0,
@@ -157,6 +163,9 @@ interface OwnerDisplayRow {
   readonly canOpen: boolean;
   readonly tabOrder: number;
   readonly location: OpenOwnerLocation | null;
+  readonly record: EpicNodeRecord | null;
+  readonly treeCpuPercent: number;
+  readonly treeRssBytes: number;
 }
 
 interface TaskDisplayRow {
@@ -177,16 +186,24 @@ interface DesktopResourceSummary {
 interface ProcessDisplayRow {
   readonly process: ResourceProcessSnapshotWire;
   readonly depth: number;
-  // A row at the visible-depth cap that still has descendants is an expand
-  // boundary: clicking it reveals its whole sub-tree (to the leaves) inline.
   readonly canExpand: boolean;
   readonly expanded: boolean;
-  // Descendant count, shown as "(N sub-processes)" while the boundary is closed.
   readonly hiddenCount: number;
+  readonly treeCpuPercent: number;
+  readonly treeRssBytes: number;
+  readonly children: readonly ProcessDisplayRow[];
 }
 
-// No process is expanded; used where visibility (not expansion) is all that
-// matters, e.g. deciding whether an owner row has any process rows to show.
+interface OwnerProcessRows {
+  readonly rows: readonly ProcessDisplayRow[];
+  readonly rootRows: readonly ProcessDisplayRow[];
+  readonly canExpand: boolean;
+  readonly selfCpuPercent: number;
+  readonly selfRssBytes: number;
+  readonly treeCpuPercent: number;
+  readonly treeRssBytes: number;
+}
+
 const NO_EXPANDED_PROCESSES: ReadonlySet<string> = new Set();
 
 // For process rows that can never expand (e.g. the host's single root process).
@@ -242,7 +259,7 @@ export function ResourceMonitorPopover(props: ResourceMonitorPopoverProps) {
 function ResourceMonitorContent(props: { readonly onClose: () => void }) {
   const [sortOption, setSortOption] = useState<ResourceSortOption>("memory");
   const [sortMenuOpen, setSortMenuOpen] = useState(false);
-  const [collapsedOwners, setCollapsedOwners] = useState<Set<string>>(
+  const [expandedOwners, setExpandedOwners] = useState<Set<string>>(
     () => new Set(),
   );
   const [expandedProcesses, setExpandedProcesses] = useState<Set<string>>(
@@ -252,6 +269,7 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
   const sortTriggerRef = useRef<HTMLButtonElement | null>(null);
   const dismissingSortMenuRef = useRef(false);
   const projection = useGlobalResourceProjection();
+  const resourcesVersion = useStreamMethodSchemaVersion("resources.subscribe");
   const { tasks } = useCloudEpicTasksQuery(undefined, { enabled: true });
   const canvas = useResourceCanvasSnapshot();
   const navigate = useNavigate();
@@ -272,9 +290,15 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
     (state) => state.resolveTargetTabForEpic,
   );
   const desktopApp = useDesktopAppResourceUsage();
+  const supportsHostTree = resourcesSubscribeV12Supported(resourcesVersion);
   const summary = useMemo(
-    () => combineResourceSummary(projection.summary, desktopApp),
-    [desktopApp, projection.summary],
+    () =>
+      combineHeadlineResourceSummary(
+        supportsHostTree ? projection.hostTree : null,
+        projection.summary,
+        desktopApp,
+      ),
+    [desktopApp, projection.hostTree, projection.summary, supportsHostTree],
   );
 
   const canvasIndex = useMemo(() => buildCanvasResourceIndex(canvas), [canvas]);
@@ -301,7 +325,7 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
   );
 
   const toggleOwner = (key: string): void => {
-    setCollapsedOwners((previous) => {
+    setExpandedOwners((previous) => {
       const next = new Set(previous);
       if (next.has(key)) {
         next.delete(key);
@@ -503,13 +527,20 @@ function ResourceMonitorContent(props: { readonly onClose: () => void }) {
                   <TaskResourceSection
                     key={task.entry.epicId}
                     task={task}
-                    collapsedOwners={collapsedOwners}
+                    expandedOwners={expandedOwners}
                     expandedProcesses={expandedProcesses}
                     onToggleOwner={toggleOwner}
                     onToggleProcess={toggleProcess}
                     onOpenOwner={openOwner}
                   />
                 ))
+              )}
+              {!supportsHostTree || projection.other === null ? null : (
+                <OtherResourceSection
+                  other={projection.other}
+                  expandedProcesses={expandedProcesses}
+                  onToggleProcess={toggleProcess}
+                />
               )}
             </div>
           )}
@@ -717,7 +748,12 @@ function HostAppResourceSection(props: { readonly app: AppResourceUsage }) {
             canExpand: false,
             expanded: false,
             hiddenCount: 0,
+            treeCpuPercent: props.app.process.cpuPercent,
+            treeRssBytes: props.app.process.rssBytes,
+            children: [],
           }}
+          stickyTop={0}
+          labelMode="full"
           onToggleExpand={noProcessToggle}
         />
       )}
@@ -725,12 +761,31 @@ function HostAppResourceSection(props: { readonly app: AppResourceUsage }) {
   );
 }
 
-function combineResourceSummary(
-  summary: TaskResourceSummary | null,
+function resourcesSubscribeV12Supported(
+  version: { readonly major: number; readonly minor: number } | null,
+): boolean {
+  return version === null || (version.major === 1 && version.minor >= 2);
+}
+
+function combineHeadlineResourceSummary(
+  hostTree: HostTreeResourceSnapshotWire | null,
+  legacySummary: TaskResourceSummary | null,
   desktopApp: DesktopAppResourceUsage | null,
 ): TaskResourceSummary | null {
-  if (summary === null && desktopApp === null) return null;
-  const base = summary ?? EMPTY_RESOURCE_SUMMARY;
+  if (hostTree === null && legacySummary === null && desktopApp === null) {
+    return null;
+  }
+  const base =
+    hostTree === null
+      ? (legacySummary ?? EMPTY_RESOURCE_SUMMARY)
+      : {
+          cpuPercent: hostTree.cpuPercent,
+          rssBytes: hostTree.rssBytes,
+          trackedProcessCount: hostTree.processCount,
+          openTerminalCount: legacySummary?.openTerminalCount ?? 0,
+          tuiAgentCount: legacySummary?.tuiAgentCount ?? 0,
+          guiAgentCount: legacySummary?.guiAgentCount ?? 0,
+        };
   const desktop = desktopResourceSummary(desktopApp);
 
   return {
@@ -772,15 +827,30 @@ function buildEpicTitleById(
 
 function TaskResourceSection(props: {
   readonly task: TaskDisplayRow;
-  readonly collapsedOwners: ReadonlySet<string>;
+  readonly expandedOwners: ReadonlySet<string>;
   readonly expandedProcesses: ReadonlySet<string>;
   readonly onToggleOwner: (key: string) => void;
   readonly onToggleProcess: (key: string) => void;
   readonly onOpenOwner: (row: OwnerDisplayRow) => void;
 }) {
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    const header = headerRef.current;
+    if (header === null) return;
+    const updateHeight = () => setHeaderHeight(header.offsetHeight);
+    updateHeight();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(header);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div className="border-b border-border/50 py-1 last:border-b-0">
       <div
+        ref={headerRef}
         className={cn(
           "flex items-center justify-between px-3.5 py-1.5",
           STICKY_SECTION_HEADER,
@@ -805,8 +875,9 @@ function TaskResourceSection(props: {
           <OwnerTreeRow
             key={key}
             row={row}
-            collapsed={props.collapsedOwners.has(key)}
+            expanded={props.expandedOwners.has(key)}
             expandedProcesses={props.expandedProcesses}
+            stickyTop={headerHeight}
             onToggle={() => props.onToggleOwner(key)}
             onToggleProcess={props.onToggleProcess}
             onOpen={() => props.onOpenOwner(row)}
@@ -817,35 +888,135 @@ function TaskResourceSection(props: {
   );
 }
 
+function OtherResourceSection(props: {
+  readonly other: OtherResourceSnapshotWire;
+  readonly expandedProcesses: ReadonlySet<string>;
+  readonly onToggleProcess: (key: string) => void;
+}) {
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const [headerHeight, setHeaderHeight] = useState(0);
+  // Collapsed by default: the header aggregate says everything most users
+  // need; the per-root breakdown (provider servers, probes, misc children)
+  // is inspect-on-demand, matching collapsed-by-default owner trees.
+  const [expanded, setExpanded] = useState(false);
+  const processRows = buildProcessRows(
+    props.other.processes,
+    props.expandedProcesses,
+    props.other,
+  );
+
+  useLayoutEffect(() => {
+    const header = headerRef.current;
+    if (header === null) return;
+    const updateHeight = () => setHeaderHeight(header.offsetHeight);
+    updateHeight();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(header);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="border-b border-border/50 py-1 last:border-b-0">
+      <div
+        ref={headerRef}
+        className={cn(
+          "flex items-center justify-between px-3.5 py-1.5",
+          STICKY_SECTION_HEADER,
+        )}
+      >
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-label={
+            expanded ? "Collapse other processes" : "Expand other processes"
+          }
+          onClick={() => setExpanded((previous) => !previous)}
+          className="flex min-w-0 items-center gap-1 text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          {expanded ? (
+            <ChevronDown className="size-3.5 shrink-0" />
+          ) : (
+            <ChevronRight className="size-3.5 shrink-0" />
+          )}
+          <span className="min-w-0 truncate text-ui-xs font-semibold uppercase tracking-wide">
+            Other
+          </span>
+        </button>
+        <MetricPair
+          cpuPercent={processRows.treeCpuPercent}
+          rssBytes={processRows.treeRssBytes}
+          className="text-ui-sm text-foreground/90"
+        />
+      </div>
+      {!expanded
+        ? null
+        : processRows.rootRows.map((processRow) => (
+            <ProcessTreeRow
+              key={processRowKey(processRow.process)}
+              processRow={processRow}
+              stickyTop={headerHeight}
+              labelMode="compact-root"
+              onToggleExpand={props.onToggleProcess}
+            />
+          ))}
+    </div>
+  );
+}
+
 function OwnerTreeRow(props: {
   readonly row: OwnerDisplayRow;
-  readonly collapsed: boolean;
+  readonly expanded: boolean;
   readonly expandedProcesses: ReadonlySet<string>;
+  readonly stickyTop: number;
   readonly onToggle: () => void;
   readonly onToggleProcess: (key: string) => void;
   readonly onOpen: () => void;
 }) {
+  const owner = props.row.snapshot.owner;
+  const liveArtifactTitle = useRegisteredEpicLiveArtifactTitle(
+    owner.epicId,
+    owner.kind === "terminal" ? null : owner.ownerId,
+  );
+  const label = ownerLabel(
+    props.row.snapshot,
+    props.row.location,
+    props.row.record,
+    liveArtifactTitle,
+  );
   const processRows = buildProcessRows(
     props.row.snapshot.processes,
     props.expandedProcesses,
+    props.row.snapshot,
   );
-  const hasProcesses = processRows.length > 0;
+  const visibleCpuPercent = props.expanded
+    ? processRows.selfCpuPercent
+    : processRows.treeCpuPercent;
+  const visibleRssBytes = props.expanded
+    ? processRows.selfRssBytes
+    : processRows.treeRssBytes;
   return (
     <div>
-      <div className="group flex items-center transition-colors hover:bg-muted/50">
-        {hasProcesses ? (
+      <div
+        className={cn(
+          "group flex items-center transition-colors hover:bg-muted/50",
+          props.expanded && "sticky z-10 bg-popover",
+        )}
+        style={props.expanded ? { top: props.stickyTop } : undefined}
+      >
+        {processRows.canExpand ? (
           <button
             type="button"
             onClick={props.onToggle}
             className="ml-3 flex size-6 shrink-0 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
             aria-label={
-              props.collapsed ? "Expand process tree" : "Collapse process tree"
+              props.expanded ? "Collapse process tree" : "Expand process tree"
             }
           >
-            {props.collapsed ? (
-              <ChevronRight className="size-3.5" />
-            ) : (
+            {props.expanded ? (
               <ChevronDown className="size-3.5" />
+            ) : (
+              <ChevronRight className="size-3.5" />
             )}
           </button>
         ) : (
@@ -863,7 +1034,7 @@ function OwnerTreeRow(props: {
           )}
         >
           <div className="min-w-0">
-            <div className="truncate text-ui-sm">{props.row.label}</div>
+            <div className="truncate text-ui-sm">{label}</div>
             <div className="truncate text-ui-xs text-muted-foreground">
               {ownerKindLabel(props.row.snapshot.owner.kind)}
               {props.row.snapshot.activeProcessName === null
@@ -871,19 +1042,26 @@ function OwnerTreeRow(props: {
                 : ` · ${props.row.snapshot.activeProcessName}`}
             </div>
           </div>
-          <MetricPair
-            cpuPercent={props.row.snapshot.cpuPercent}
-            rssBytes={props.row.snapshot.rssBytes}
+          <ProcessMetricPair
+            cpuPercent={visibleCpuPercent}
+            rssBytes={visibleRssBytes}
+            selfCpuPercent={processRows.selfCpuPercent}
+            selfRssBytes={processRows.selfRssBytes}
+            treeCpuPercent={processRows.treeCpuPercent}
+            treeRssBytes={processRows.treeRssBytes}
+            hasDescendants={processRows.canExpand}
             className="text-ui-sm text-foreground/90"
           />
         </button>
       </div>
-      {props.collapsed
+      {!props.expanded
         ? null
-        : processRows.map((processRow) => (
+        : processRows.rows.map((processRow) => (
             <ProcessTreeRow
               key={processRowKey(processRow.process)}
               processRow={processRow}
+              stickyTop={props.stickyTop}
+              labelMode="full"
               onToggleExpand={props.onToggleProcess}
             />
           ))}
@@ -909,39 +1087,53 @@ function ProcessRowMarker(props: {
 
 function ProcessTreeRow(props: {
   readonly processRow: ProcessDisplayRow;
+  readonly stickyTop: number;
+  readonly labelMode: "full" | "compact-root";
   readonly onToggleExpand: (key: string) => void;
 }) {
-  const { process, depth, canExpand, expanded, hiddenCount } = props.processRow;
+  const {
+    process,
+    depth,
+    canExpand,
+    expanded,
+    hiddenCount,
+    treeCpuPercent,
+    treeRssBytes,
+  } = props.processRow;
   const rowClassName =
     "flex w-full items-center justify-between gap-3 px-3.5 py-1 text-left text-muted-foreground transition-colors hover:bg-muted/40";
   const rowStyle = { paddingLeft: `calc(1.25rem + ${depth} * 1rem)` };
+  const collapsedLabel =
+    props.labelMode === "compact-root"
+      ? processCompactLeafLabel(process, hiddenCount)
+      : processLeafLabel(process, hiddenCount);
   const inner = (
     <>
       <div className="flex min-w-0 items-center gap-1.5">
         <ProcessRowMarker canExpand={canExpand} expanded={expanded} />
         <span className="min-w-0 truncate text-ui-xs">
-          {expanded
-            ? processLabel(process)
-            : processLeafLabel(process, hiddenCount)}
+          {expanded ? processLabel(process) : collapsedLabel}
         </span>
       </div>
-      <MetricPair
-        cpuPercent={process.cpuPercent}
-        rssBytes={process.rssBytes}
+      <ProcessMetricPair
+        cpuPercent={expanded ? process.cpuPercent : treeCpuPercent}
+        rssBytes={expanded ? process.rssBytes : treeRssBytes}
+        selfCpuPercent={process.cpuPercent}
+        selfRssBytes={process.rssBytes}
+        treeCpuPercent={treeCpuPercent}
+        treeRssBytes={treeRssBytes}
+        hasDescendants={canExpand}
         className="text-ui-xs text-muted-foreground/80"
       />
     </>
   );
   // Leaf and non-boundary rows are static; only an expand boundary is an
   // interactive, keyboard-reachable toggle that reveals its sub-tree inline.
-  if (!canExpand) {
-    return (
-      <div className={rowClassName} style={rowStyle}>
-        {inner}
-      </div>
-    );
-  }
-  return (
+  const row = !canExpand ? (
+    <div className={rowClassName} style={rowStyle}>
+      {inner}
+    </div>
+  ) : (
     <button
       type="button"
       aria-expanded={expanded}
@@ -955,6 +1147,68 @@ function ProcessTreeRow(props: {
     >
       {inner}
     </button>
+  );
+  return (
+    <div>
+      <div
+        className={cn(expanded && "sticky z-10 bg-popover")}
+        style={expanded ? { top: props.stickyTop } : undefined}
+      >
+        {row}
+      </div>
+      {!expanded
+        ? null
+        : props.processRow.children.map((child) => (
+            <ProcessTreeRow
+              key={processRowKey(child.process)}
+              processRow={child}
+              stickyTop={props.stickyTop}
+              labelMode="full"
+              onToggleExpand={props.onToggleExpand}
+            />
+          ))}
+    </div>
+  );
+}
+
+function ProcessMetricPair(props: {
+  readonly cpuPercent: number;
+  readonly rssBytes: number;
+  readonly selfCpuPercent: number;
+  readonly selfRssBytes: number;
+  readonly treeCpuPercent: number;
+  readonly treeRssBytes: number;
+  readonly hasDescendants: boolean;
+  readonly className: string;
+}) {
+  const metrics = (
+    <MetricPair
+      cpuPercent={props.cpuPercent}
+      rssBytes={props.rssBytes}
+      className={props.className}
+    />
+  );
+  if (!props.hasDescendants) return metrics;
+  return (
+    <TooltipWrapper
+      label={
+        <div className="space-y-1 text-ui-xs">
+          <div>
+            Self: {formatCpuPercent(props.selfCpuPercent)} CPU ·{" "}
+            {formatMemoryBytes(props.selfRssBytes)} memory
+          </div>
+          <div>
+            Tree: {formatCpuPercent(props.treeCpuPercent)} CPU ·{" "}
+            {formatMemoryBytes(props.treeRssBytes)} memory
+          </div>
+        </div>
+      }
+      side="left"
+      sideOffset={6}
+      align="center"
+    >
+      <div className="shrink-0">{metrics}</div>
+    </TooltipWrapper>
   );
 }
 
@@ -981,40 +1235,42 @@ function buildTaskRows(input: {
 }): TaskDisplayRow[] {
   const rows = input.entries.flatMap((entry): TaskDisplayRow[] => {
     if (entry.owners.length === 0) return [];
-    const owners = entry.owners
-      .filter(shouldShowOwnerRow)
-      .map((snapshot): OwnerDisplayRow => {
-        const key = ownerKey(
-          snapshot.owner.epicId,
-          snapshot.owner.kind,
-          snapshot.owner.ownerId,
-        );
-        const location = input.canvasIndex.locationByOwner.get(key) ?? null;
-        const record = input.recordByOwner.get(key) ?? null;
-        return {
-          snapshot,
-          label: ownerLabel(snapshot, location, record),
-          canOpen: canOpenOwner(snapshot, location, record),
-          tabOrder:
-            input.canvasIndex.tabOrderByOwner.get(key) ??
-            Number.MAX_SAFE_INTEGER,
-          location,
-        };
-      });
+    const owners = entry.owners.map((snapshot): OwnerDisplayRow => {
+      const key = ownerKey(
+        snapshot.owner.epicId,
+        snapshot.owner.kind,
+        snapshot.owner.ownerId,
+      );
+      const location = input.canvasIndex.locationByOwner.get(key) ?? null;
+      const record = input.recordByOwner.get(key) ?? null;
+      const processRows = buildProcessRows(
+        snapshot.processes,
+        NO_EXPANDED_PROCESSES,
+        snapshot,
+      );
+      return {
+        snapshot,
+        label: ownerLabel(snapshot, location, record, null),
+        canOpen: canOpenOwner(snapshot, location, record),
+        tabOrder:
+          input.canvasIndex.tabOrderByOwner.get(key) ?? Number.MAX_SAFE_INTEGER,
+        location,
+        record,
+        treeCpuPercent: processRows.treeCpuPercent,
+        treeRssBytes: processRows.treeRssBytes,
+      };
+    });
     if (owners.length === 0) return [];
     return [
       {
         entry,
         label: taskLabel(entry.epicId, input.canvas, input.epicTitleById),
         tabOrder: taskTabOrder(entry.epicId, input.canvas),
-        cpuPercent: entry.owners.reduce(
-          (sum, snapshot) => sum + snapshot.cpuPercent,
+        cpuPercent: owners.reduce(
+          (sum, owner) => sum + owner.treeCpuPercent,
           0,
         ),
-        rssBytes: entry.owners.reduce(
-          (sum, snapshot) => sum + snapshot.rssBytes,
-          0,
-        ),
+        rssBytes: owners.reduce((sum, owner) => sum + owner.treeRssBytes, 0),
         owners: sortOwnerRows(owners, input.sortOption),
       },
     ];
@@ -1114,10 +1370,10 @@ function sortOwnerRows(
   const sorted = [...rows];
   switch (sortOption) {
     case "memory":
-      sorted.sort((a, b) => b.snapshot.rssBytes - a.snapshot.rssBytes);
+      sorted.sort((a, b) => b.treeRssBytes - a.treeRssBytes);
       break;
     case "cpu":
-      sorted.sort((a, b) => b.snapshot.cpuPercent - a.snapshot.cpuPercent);
+      sorted.sort((a, b) => b.treeCpuPercent - a.treeCpuPercent);
       break;
     case "name":
       sorted.sort((a, b) => a.label.localeCompare(b.label));
@@ -1299,15 +1555,6 @@ function ownerKey(
   return `${epicId}\x1f${kind}\x1f${ownerId}`;
 }
 
-function shouldShowOwnerRow(snapshot: OwnerResourceSnapshotWire): boolean {
-  if (snapshot.owner.kind !== "terminal") return true;
-  // A terminal always carries its own shell, so "has a process" is always true
-  // and never filters anything. Show a terminal only once it has a sub-process
-  // worth rendering - an idle shell adds no signal over the aggregate metrics.
-  // Visibility depends only on the always-visible rows, not on expansion state.
-  return buildProcessRows(snapshot.processes, NO_EXPANDED_PROCESSES).length > 0;
-}
-
 function resourceOwnerKindForNodeType(
   type: string,
 ): ResourceOwnerKindWire | null {
@@ -1347,12 +1594,29 @@ function ownerLabel(
   snapshot: OwnerResourceSnapshotWire,
   location: OpenOwnerLocation | null,
   record: EpicNodeRecord | null,
+  liveArtifactTitle: string | null,
 ): string {
+  if (snapshot.owner.kind === "terminal") {
+    if (
+      location?.ref.type === "terminal" &&
+      location.ref.titleSource === "manual"
+    ) {
+      return location.ref.name;
+    }
+    return terminalSessionTitle({
+      title: null,
+      activeProcessName: snapshot.activeProcessName,
+    });
+  }
+  if (snapshot.owner.kind === "chat") {
+    return chatDisplayTitle({
+      title: liveArtifactTitle ?? location?.ref.name ?? record?.name ?? "",
+      firstUserMessage: null,
+    });
+  }
+  if (liveArtifactTitle !== null) return liveArtifactTitle;
   if (location !== null) return location.ref.name;
   if (record !== null) return record.name;
-  if (snapshot.owner.kind === "terminal") {
-    return snapshot.activeProcessName ?? "Terminal";
-  }
   return ownerKindLabel(snapshot.owner.kind);
 }
 
@@ -1383,7 +1647,30 @@ function processLeafLabel(
   process: ResourceProcessSnapshotWire,
   hiddenCount: number,
 ): string {
-  const label = processLabel(process);
+  return leafLabelFrom(processLabel(process), hiddenCount);
+}
+
+/**
+ * Compact label for an unattributed (Other) root: the executable basename
+ * rather than the full command path, which for provider binaries is a long
+ * install path that adds no signal at the collapsed level. The full command
+ * remains visible on the expanded row.
+ */
+function processCompactLeafLabel(
+  process: ResourceProcessSnapshotWire,
+  hiddenCount: number,
+): string {
+  return leafLabelFrom(processBasename(process), hiddenCount);
+}
+
+function processBasename(process: ResourceProcessSnapshotWire): string {
+  const source = process.name.length > 0 ? process.name : processLabel(process);
+  const segments = source.split("/");
+  const base = segments[segments.length - 1];
+  return base.length > 0 ? base : source;
+}
+
+function leafLabelFrom(label: string, hiddenCount: number): string {
   if (hiddenCount === 0) return label;
   return `${label} (${countLabel(hiddenCount, "sub-process", "sub-processes")})`;
 }
@@ -1395,65 +1682,96 @@ function processRowKey(process: ResourceProcessSnapshotWire): string {
 function buildProcessRows(
   processes: readonly ResourceProcessSnapshotWire[],
   expandedKeys: ReadonlySet<string>,
-): ProcessDisplayRow[] {
-  // A lone process - a terminal shell with nothing running under it, or an owner
-  // whose whole tree is a single process - is fully described by its owner row,
-  // so it adds no signal as a child row.
-  if (processes.length <= 1) return [];
+  fallback: { readonly cpuPercent: number; readonly rssBytes: number },
+): OwnerProcessRows {
+  if (processes.length === 0) {
+    return {
+      rows: [],
+      rootRows: [],
+      canExpand: false,
+      selfCpuPercent: fallback.cpuPercent,
+      selfRssBytes: fallback.rssBytes,
+      treeCpuPercent: fallback.cpuPercent,
+      treeRssBytes: fallback.rssBytes,
+    };
+  }
 
+  const processByPid = new Map(
+    processes.map((process) => [process.pid, process]),
+  );
   const childrenByParent = new Map<number, ResourceProcessSnapshotWire[]>();
   for (const process of processes) {
-    if (process.parentPid === null || process.pid === process.rootPid) continue;
+    if (process.parentPid === null || !processByPid.has(process.parentPid))
+      continue;
     const siblings = childrenByParent.get(process.parentPid) ?? [];
     siblings.push(process);
     childrenByParent.set(process.parentPid, siblings);
   }
 
-  const countDescendants = (pid: number, seen: Set<number>): number => {
-    let total = 0;
-    for (const child of childrenByParent.get(pid) ?? []) {
-      if (seen.has(child.pid)) continue;
-      seen.add(child.pid);
-      total += 1 + countDescendants(child.pid, seen);
-    }
-    return total;
-  };
+  const roots = processes.filter(
+    (process) =>
+      process.parentPid === null ||
+      process.pid === process.rootPid ||
+      !processByPid.has(process.parentPid),
+  );
+  const completeRoots = roots.length === 0 ? processes : roots;
 
-  const rows: ProcessDisplayRow[] = [];
-  const walk = (
+  const buildRow = (
     process: ResourceProcessSnapshotWire,
     depth: number,
-    revealed: boolean,
-    seen: Set<number>,
-  ): void => {
-    const children = childrenByParent.get(process.pid) ?? [];
-    // Only the deepest always-visible level acts as an expand boundary; once it
-    // is expanded (or an ancestor boundary is), the sub-tree renders to leaves.
-    const atBoundary =
-      depth === MAX_VISIBLE_PROCESS_DEPTH && children.length > 0;
-    const expanded = atBoundary && expandedKeys.has(processRowKey(process));
-    rows.push({
+    ancestors: ReadonlySet<number>,
+  ): ProcessDisplayRow => {
+    const childProcesses = (childrenByParent.get(process.pid) ?? []).filter(
+      (child) => !ancestors.has(child.pid),
+    );
+    const nextAncestors = new Set(ancestors);
+    nextAncestors.add(process.pid);
+    const children = childProcesses.map((child) =>
+      buildRow(child, depth + 1, nextAncestors),
+    );
+    const treeCpuPercent = children.reduce(
+      (sum, child) => sum + child.treeCpuPercent,
+      process.cpuPercent,
+    );
+    const treeRssBytes = children.reduce(
+      (sum, child) => sum + child.treeRssBytes,
+      process.rssBytes,
+    );
+    return {
       process,
       depth,
-      canExpand: atBoundary,
-      expanded,
-      hiddenCount: atBoundary
-        ? countDescendants(process.pid, new Set([process.pid]))
-        : 0,
-    });
-    if (depth >= MAX_VISIBLE_PROCESS_DEPTH && !expanded && !revealed) return;
-    for (const child of children) {
-      if (seen.has(child.pid)) continue;
-      seen.add(child.pid);
-      walk(child, depth + 1, expanded || revealed, seen);
-    }
+      canExpand: children.length > 0,
+      expanded: children.length > 0 && expandedKeys.has(processRowKey(process)),
+      hiddenCount: children.reduce(
+        (sum, child) => sum + 1 + child.hiddenCount,
+        0,
+      ),
+      treeCpuPercent,
+      treeRssBytes,
+      children,
+    };
   };
 
-  for (const root of processes) {
-    if (root.pid !== root.rootPid) continue;
-    walk(root, 1, false, new Set([root.pid]));
-  }
-  return rows;
+  const rootRows = completeRoots.map((root) => buildRow(root, 0, new Set()));
+  const rows = rootRows.flatMap((root) => root.children);
+  return {
+    rows,
+    rootRows,
+    canExpand: rows.length > 0,
+    selfCpuPercent: rootRows.reduce(
+      (sum, root) => sum + root.process.cpuPercent,
+      0,
+    ),
+    selfRssBytes: rootRows.reduce(
+      (sum, root) => sum + root.process.rssBytes,
+      0,
+    ),
+    treeCpuPercent: rootRows.reduce(
+      (sum, root) => sum + root.treeCpuPercent,
+      0,
+    ),
+    treeRssBytes: rootRows.reduce((sum, root) => sum + root.treeRssBytes, 0),
+  };
 }
 
 function countLabel(count: number, singular: string, plural: string): string {

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -1703,11 +1703,14 @@ function buildProcessRows(
     return byParent;
   }, new Map<number, ResourceProcessSnapshotWire[]>());
 
+  // Rootness is purely structural: parentless, or parent outside this list.
+  // `pid === rootPid` must NOT qualify — an owner can carry a second tracked
+  // root that is an OS descendant of its first (e.g. a harness child under the
+  // owner's PTY), and counting it as a root while `childrenByParent` also
+  // attaches it under its in-list parent would double-count its subtree.
   const roots = processes.filter(
     (process) =>
-      process.parentPid === null ||
-      process.pid === process.rootPid ||
-      !processByPid.has(process.parentPid),
+      process.parentPid === null || !processByPid.has(process.parentPid),
   );
   const completeRoots = roots.length === 0 ? processes : roots;
 

--- a/clients/gui-app/src/lib/epic-selectors.ts
+++ b/clients/gui-app/src/lib/epic-selectors.ts
@@ -510,6 +510,50 @@ export function useEpicLiveArtifactTitle(
 }
 
 /**
+ * Live artifact title for an epic session that may be mounted elsewhere in
+ * the app. Global surfaces (for example, the resource monitor) live outside
+ * an `EpicSessionProvider`, but must use the same Y.Doc-backed title that a
+ * canvas tab uses instead of its persisted opening-name snapshot.
+ */
+export function useRegisteredEpicLiveArtifactTitle(
+  epicId: string,
+  artifactId: string | null,
+): string | null {
+  const registry = getOpenEpicRegistry();
+  const handle = useSyncExternalStore(
+    (listener) => registry.subscribe(listener),
+    () => registry.peek(epicId),
+    () => null,
+  );
+  return useSyncExternalStore(
+    (listener) => handle?.store.subscribe(listener) ?? noopSubscribe,
+    () => liveArtifactTitleFromHandle(handle, artifactId),
+    () => null,
+  );
+}
+
+function liveArtifactTitleFromHandle(
+  handle: OpenEpicStoreHandle | null,
+  artifactId: string | null,
+): string | null {
+  if (handle === null || artifactId === null) return null;
+  const state = handle.store.getState();
+  if (Object.hasOwn(state.artifacts.byId, artifactId)) {
+    const title = state.artifacts.byId[artifactId].title;
+    return title.length > 0 ? title : null;
+  }
+  if (Object.hasOwn(state.chats.byId, artifactId)) {
+    const title = state.chats.byId[artifactId].title;
+    return title.length > 0 ? title : null;
+  }
+  if (Object.hasOwn(state.tuiAgents.byId, artifactId)) {
+    const title = state.tuiAgents.byId[artifactId].title;
+    return title.length > 0 ? title : null;
+  }
+  return null;
+}
+
+/**
  * Canonical display title for a canvas tile / node. The Y.Doc live title is
  * the single source of truth; the tile's persisted `name` snapshot is only a
  * fallback for tiles that have no live title (workspace files, git diff,

--- a/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
+++ b/clients/gui-app/src/stores/resources/__tests__/resources-store.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import type {
   AppResourceSnapshotWire,
   EpicResourceSnapshotWire,
+  HostTreeResourceSnapshotWire,
+  OtherResourceSnapshotWire,
   OwnerResourceSnapshotWire,
   ResourceProcessSnapshotWire,
   ResourceOwnerKindWire,
@@ -86,6 +88,32 @@ function makeApp(
   };
 }
 
+function makeHostTree(
+  over: Partial<HostTreeResourceSnapshotWire>,
+): HostTreeResourceSnapshotWire {
+  return {
+    sampledAt: 1_000,
+    processCount: 4,
+    cpuPercent: 25,
+    rssBytes: 2_500,
+    ...over,
+  };
+}
+
+function makeOther(
+  over: Partial<OtherResourceSnapshotWire>,
+): OtherResourceSnapshotWire {
+  return {
+    sampledAt: 1_000,
+    rootPids: [20],
+    processCount: 1,
+    cpuPercent: 5,
+    rssBytes: 400,
+    processes: [makeProcess({ pid: 20, rootPid: 20 })],
+    ...over,
+  };
+}
+
 function projection(
   over: Partial<ResourcesProjectionPayload>,
 ): ResourcesProjectionPayload {
@@ -96,6 +124,8 @@ function projection(
     owners: [],
     epic: null,
     epics: [],
+    hostTree: undefined,
+    other: undefined,
     ...over,
   };
 }
@@ -274,6 +304,41 @@ describe("createResourcesStore", () => {
       );
 
     expect(handle.store.getState().epic?.cpuPercent).toBe(80);
+    handle.dispose();
+  });
+
+  it("merges 1.2 host-tree and Other snapshots without churning unchanged identities", () => {
+    const fake = makeFakeClient();
+    const handle = createResourcesStore({
+      scope: { kind: "global" },
+      streamClientFactory: fake.factory,
+    });
+    const hostTree = makeHostTree({});
+    const other = makeOther({});
+
+    fake.callbacks().onSnapshot(projection({ hostTree, other }));
+    expect(handle.store.getState().hostTree).toBe(hostTree);
+    expect(handle.store.getState().other).toBe(other);
+
+    fake.callbacks().onUpdate(
+      projection({
+        sampledAt: 2_000,
+        hostTree: makeHostTree({ sampledAt: 2_000 }),
+        other: makeOther({ sampledAt: 2_000 }),
+      }),
+    );
+    expect(handle.store.getState().hostTree).toBe(hostTree);
+    expect(handle.store.getState().other).toBe(other);
+
+    fake.callbacks().onUpdate(
+      projection({
+        sampledAt: 3_000,
+        hostTree: makeHostTree({ sampledAt: 3_000, cpuPercent: 30 }),
+        other: makeOther({ sampledAt: 3_000, rssBytes: 500 }),
+      }),
+    );
+    expect(handle.store.getState().hostTree?.cpuPercent).toBe(30);
+    expect(handle.store.getState().other?.rssBytes).toBe(500);
     handle.dispose();
   });
 

--- a/clients/gui-app/src/stores/resources/resources-registry.ts
+++ b/clients/gui-app/src/stores/resources/resources-registry.ts
@@ -6,6 +6,8 @@ import {
   resourceOwnerKey,
   type AppResourceUsage,
   type EpicResourceUsage,
+  type HostTreeResourceUsage,
+  type OtherResourceUsage,
   type OwnerResourceUsage,
   type ResourcesState,
   type ResourcesStoreHandle,
@@ -36,6 +38,8 @@ export interface GlobalResourceEpicEntry {
   readonly epicId: string;
   readonly sampledAt: number | null;
   readonly app: AppResourceUsage | null;
+  readonly hostTree: HostTreeResourceUsage | null;
+  readonly other: OtherResourceUsage | null;
   readonly owners: readonly OwnerResourceUsage[];
   readonly epic: EpicResourceUsage | null;
   readonly taskSummary: TaskResourceSummary | null;
@@ -44,6 +48,8 @@ export interface GlobalResourceEpicEntry {
 export interface GlobalResourceProjection {
   readonly sampledAt: number | null;
   readonly app: AppResourceUsage | null;
+  readonly hostTree: HostTreeResourceUsage | null;
+  readonly other: OtherResourceUsage | null;
   readonly owners: readonly OwnerResourceUsage[];
   readonly entries: readonly GlobalResourceEpicEntry[];
   readonly summary: TaskResourceSummary | null;
@@ -110,6 +116,8 @@ class ResourcesRegistry {
         epicId,
         sampledAt: state.sampledAt,
         app: state.app,
+        hostTree: state.hostTree,
+        other: state.other,
         owners: [...state.owners.values()],
         epic: state.epic,
         taskSummary: state.taskSummary,
@@ -117,6 +125,8 @@ class ResourcesRegistry {
     });
     const owners = entries.flatMap((entry) => entry.owners);
     const app = latestAppSnapshot(entries);
+    const hostTree = latestHostTreeSnapshot(entries);
+    const other = latestOtherSnapshot(entries);
     const sampledAt = Math.max(
       app?.sampledAt ?? 0,
       ...entries.map((entry) => entry.sampledAt ?? 0),
@@ -124,6 +134,8 @@ class ResourcesRegistry {
     const projection = {
       sampledAt: sampledAt > 0 ? sampledAt : null,
       app,
+      hostTree,
+      other,
       owners,
       entries,
       summary: deriveTaskResourceSummary(app, owners),
@@ -160,6 +172,8 @@ class ResourcesRegistry {
         epicId,
         sampledAt: sampledAt > 0 ? sampledAt : null,
         app: state.app,
+        hostTree: state.hostTree,
+        other: state.other,
         owners: scopedOwners,
         epic,
         taskSummary: deriveTaskResourceSummary(null, scopedOwners),
@@ -168,6 +182,8 @@ class ResourcesRegistry {
     return {
       sampledAt: state.sampledAt,
       app: state.app,
+      hostTree: state.hostTree,
+      other: state.other,
       owners,
       entries,
       summary: deriveTaskResourceSummary(state.app, owners),
@@ -310,6 +326,32 @@ function latestAppSnapshot(
   return latest;
 }
 
+function latestHostTreeSnapshot(
+  entries: readonly GlobalResourceEpicEntry[],
+): HostTreeResourceUsage | null {
+  let latest: HostTreeResourceUsage | null = null;
+  for (const entry of entries) {
+    if (entry.hostTree === null) continue;
+    if (latest === null || entry.hostTree.sampledAt > latest.sampledAt) {
+      latest = entry.hostTree;
+    }
+  }
+  return latest;
+}
+
+function latestOtherSnapshot(
+  entries: readonly GlobalResourceEpicEntry[],
+): OtherResourceUsage | null {
+  let latest: OtherResourceUsage | null = null;
+  for (const entry of entries) {
+    if (entry.other === null) continue;
+    if (latest === null || entry.other.sampledAt > latest.sampledAt) {
+      latest = entry.other;
+    }
+  }
+  return latest;
+}
+
 export const resourcesRegistry = new ResourcesRegistry();
 
 // Stable fallback for `useStore` when no entry exists for an epic yet: every
@@ -320,6 +362,8 @@ const emptyResourcesStore = create<ResourcesState>()(() => ({
   sampledAt: null,
   owners: new Map(),
   app: null,
+  hostTree: null,
+  other: null,
   epic: null,
   epics: new Map(),
   taskSummary: null,

--- a/clients/gui-app/src/stores/resources/resources-registry.ts
+++ b/clients/gui-app/src/stores/resources/resources-registry.ts
@@ -326,30 +326,38 @@ function latestAppSnapshot(
   return latest;
 }
 
+// Both selectors compare the ENTRY-level `sampledAt`, not the nested
+// snapshot's: identity-stable merges intentionally keep the previous nested
+// object (with its old timestamp) when display values are unchanged, so the
+// nested `sampledAt` can lag the frame that actually delivered it.
 function latestHostTreeSnapshot(
   entries: readonly GlobalResourceEpicEntry[],
 ): HostTreeResourceUsage | null {
-  let latest: HostTreeResourceUsage | null = null;
-  for (const entry of entries) {
-    if (entry.hostTree === null) continue;
-    if (latest === null || entry.hostTree.sampledAt > latest.sampledAt) {
-      latest = entry.hostTree;
-    }
-  }
-  return latest;
+  const latest = entries
+    .filter((entry) => entry.hostTree !== null)
+    .reduce(
+      (best: GlobalResourceEpicEntry | null, entry) =>
+        best === null || (entry.sampledAt ?? 0) > (best.sampledAt ?? 0)
+          ? entry
+          : best,
+      null,
+    );
+  return latest?.hostTree ?? null;
 }
 
 function latestOtherSnapshot(
   entries: readonly GlobalResourceEpicEntry[],
 ): OtherResourceUsage | null {
-  let latest: OtherResourceUsage | null = null;
-  for (const entry of entries) {
-    if (entry.other === null) continue;
-    if (latest === null || entry.other.sampledAt > latest.sampledAt) {
-      latest = entry.other;
-    }
-  }
-  return latest;
+  const latest = entries
+    .filter((entry) => entry.other !== null)
+    .reduce(
+      (best: GlobalResourceEpicEntry | null, entry) =>
+        best === null || (entry.sampledAt ?? 0) > (best.sampledAt ?? 0)
+          ? entry
+          : best,
+      null,
+    );
+  return latest?.other ?? null;
 }
 
 export const resourcesRegistry = new ResourcesRegistry();

--- a/clients/gui-app/src/stores/resources/resources-store.ts
+++ b/clients/gui-app/src/stores/resources/resources-store.ts
@@ -12,6 +12,8 @@ import type {
 import type {
   AppResourceSnapshotWire,
   EpicResourceSnapshotWire,
+  HostTreeResourceSnapshotWire,
+  OtherResourceSnapshotWire,
   OwnerResourceSnapshotWire,
   ResourceProcessSnapshotWire,
   ResourceOwnerKindWire,
@@ -39,6 +41,8 @@ export type ResourcesStreamClientFactory = (
 export type OwnerResourceUsage = OwnerResourceSnapshotWire;
 export type EpicResourceUsage = EpicResourceSnapshotWire;
 export type AppResourceUsage = AppResourceSnapshotWire;
+export type HostTreeResourceUsage = HostTreeResourceSnapshotWire;
+export type OtherResourceUsage = OtherResourceSnapshotWire;
 
 export interface TaskResourceSummary {
   readonly cpuPercent: number;
@@ -78,6 +82,10 @@ export interface ResourcesState {
   readonly owners: ReadonlyMap<string, OwnerResourceSnapshotWire>;
   /** Host-app usage sampled alongside the owner projection. */
   readonly app: AppResourceSnapshotWire | null;
+  /** Whole host-process-tree aggregate, available from resources.subscribe@1.2. */
+  readonly hostTree: HostTreeResourceSnapshotWire | null;
+  /** Unattributed host-tree process roots, available from resources.subscribe@1.2. */
+  readonly other: OtherResourceSnapshotWire | null;
   /** `null` when the epic has no tracked owner roots (a valid quiet state). */
   readonly epic: EpicResourceSnapshotWire | null;
   readonly epics: ReadonlyMap<string, EpicResourceSnapshotWire>;
@@ -187,6 +195,29 @@ function appUsageEqual(
   return processEqual(a.process, b.process);
 }
 
+function hostTreeUsageEqual(
+  a: HostTreeResourceSnapshotWire,
+  b: HostTreeResourceSnapshotWire,
+): boolean {
+  return (
+    a.processCount === b.processCount &&
+    a.cpuPercent === b.cpuPercent &&
+    a.rssBytes === b.rssBytes
+  );
+}
+
+function otherUsageEqual(
+  a: OtherResourceSnapshotWire,
+  b: OtherResourceSnapshotWire,
+): boolean {
+  return (
+    a.processCount === b.processCount &&
+    a.cpuPercent === b.cpuPercent &&
+    a.rssBytes === b.rssBytes &&
+    processesEqual(a.processes, b.processes)
+  );
+}
+
 function mergeOwners(
   previous: ReadonlyMap<string, OwnerResourceSnapshotWire>,
   payload: ResourcesProjectionPayload,
@@ -294,6 +325,24 @@ function mergeApp(
   return next;
 }
 
+function mergeHostTree(
+  previous: HostTreeResourceSnapshotWire | null,
+  next: HostTreeResourceSnapshotWire | null | undefined,
+): HostTreeResourceSnapshotWire | null {
+  if (next === null || next === undefined) return null;
+  if (previous !== null && hostTreeUsageEqual(previous, next)) return previous;
+  return next;
+}
+
+function mergeOther(
+  previous: OtherResourceSnapshotWire | null,
+  next: OtherResourceSnapshotWire | null | undefined,
+): OtherResourceSnapshotWire | null {
+  if (next === null || next === undefined) return null;
+  if (previous !== null && otherUsageEqual(previous, next)) return previous;
+  return next;
+}
+
 function mergeTaskSummary(
   previous: TaskResourceSummary | null,
   payload: ResourcesProjectionPayload,
@@ -319,6 +368,8 @@ export function createResourcesStore(
         sampledAt: payload.sampledAt,
         owners: mergeOwners(state.owners, payload, options.scope),
         app: mergeApp(state.app, payload.app),
+        hostTree: mergeHostTree(state.hostTree, payload.hostTree),
+        other: mergeOther(state.other, payload.other),
         epic: mergeEpic(state.epic, payload.epic),
         epics: mergeEpics(state.epics, payload),
         taskSummary: mergeTaskSummary(state.taskSummary, payload),
@@ -345,6 +396,8 @@ export function createResourcesStore(
       sampledAt: null,
       owners: EMPTY_OWNERS,
       app: null,
+      hostTree: null,
+      other: null,
       epic: null,
       epics: EMPTY_EPICS,
       taskSummary: null,

--- a/clients/shared/host-transport/__tests__/resources-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/resources-stream-client.test.ts
@@ -170,6 +170,32 @@ const APP = {
   rssBytes: 2_000,
 };
 
+const HOST_TREE = {
+  sampledAt: 1_000,
+  processCount: 3,
+  cpuPercent: 15,
+  rssBytes: 3_000,
+};
+
+const OTHER = {
+  sampledAt: 1_000,
+  rootPids: [20],
+  processCount: 1,
+  cpuPercent: 4,
+  rssBytes: 500,
+  processes: [
+    {
+      pid: 20,
+      parentPid: null,
+      rootPid: 20,
+      name: "worker",
+      command: "worker",
+      cpuPercent: 4,
+      rssBytes: 500,
+    },
+  ],
+};
+
 describe("ResourcesStreamClient", () => {
   it("subscribes to resources.subscribe with the epicId and dispatches typed frames", () => {
     const { factory, sockets } = makeFactory();
@@ -191,7 +217,7 @@ describe("ResourcesStreamClient", () => {
     expect(parseText(sockets[0].textSent[1])).toEqual({
       kind: "subscribe",
       method: "resources.subscribe",
-      schemaVersion: { major: 1, minor: 1 },
+      schemaVersion: { major: 1, minor: 2 },
       params: {
         epicId: "epic-1",
         scope: { kind: "epic", epicId: "epic-1" },
@@ -206,6 +232,8 @@ describe("ResourcesStreamClient", () => {
       app: APP,
       owners: [OWNER],
       epic: EPIC,
+      hostTree: HOST_TREE,
+      other: OTHER,
     });
     sockets[0].fireText({
       kind: "update",
@@ -215,6 +243,8 @@ describe("ResourcesStreamClient", () => {
       app: { ...APP, sampledAt: 2_000, cpuPercent: 2 },
       owners: [{ ...OWNER, cpuPercent: 55, sampledAt: 2_000 }],
       epic: { ...EPIC, cpuPercent: 55, sampledAt: 2_000 },
+      hostTree: { ...HOST_TREE, sampledAt: 2_000, cpuPercent: 60 },
+      other: { ...OTHER, sampledAt: 2_000, cpuPercent: 5 },
     });
 
     expect(snapshots).toHaveLength(1);
@@ -223,9 +253,12 @@ describe("ResourcesStreamClient", () => {
     expect(snapshots[0].owners[0].processes[0].command).toBe("/bin/bash");
     expect(snapshots[0].epic?.epicId).toBe("epic-1");
     expect(snapshots[0].epics).toEqual([]);
+    expect(snapshots[0].hostTree?.cpuPercent).toBe(15);
+    expect(snapshots[0].other?.processes[0].name).toBe("worker");
     expect(updates).toHaveLength(1);
     expect(updates[0].owners[0].cpuPercent).toBe(55);
     expect(updates[0].sampledAt).toBe(2_000);
+    expect(updates[0].hostTree?.cpuPercent).toBe(60);
 
     client.close();
   });

--- a/clients/shared/host-transport/resources-stream-client.ts
+++ b/clients/shared/host-transport/resources-stream-client.ts
@@ -2,9 +2,13 @@ import {
   resourcesSubscribeServerFrameSchema,
   type AppResourceSnapshotWire,
   type EpicResourceSnapshotWire,
+  type HostTreeResourceSnapshotWire,
+  type OtherResourceSnapshotWire,
   type OwnerResourceSnapshotWire,
   type ResourcesSubscribeOpenRequestV11,
   type ResourcesSubscribeServerFrame,
+  type ResourcesSubscribeServerFrameV12,
+  resourcesSubscribeServerFrameSchemaV12,
 } from "@traycer/protocol/host/resources/subscribe";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type {
@@ -28,6 +32,10 @@ export interface ResourcesProjectionPayload {
   readonly owners: readonly OwnerResourceSnapshotWire[];
   readonly epic: EpicResourceSnapshotWire | null;
   readonly epics: readonly EpicResourceSnapshotWire[];
+  /** Absent when the connected host negotiated resources.subscribe <= 1.1. */
+  readonly hostTree: HostTreeResourceSnapshotWire | null | undefined;
+  /** Absent when the connected host negotiated resources.subscribe <= 1.1. */
+  readonly other: OtherResourceSnapshotWire | null | undefined;
 }
 
 export type ResourcesStreamScope =
@@ -128,11 +136,17 @@ export class ResourcesStreamClient {
     envelope: StreamFrameEnvelope,
     _binaryPayload: Uint8Array | null,
   ): void {
-    const parsed = resourcesSubscribeServerFrameSchema.safeParse(envelope);
+    const v12Parsed =
+      resourcesSubscribeServerFrameSchemaV12.safeParse(envelope);
+    const parsed = v12Parsed.success
+      ? v12Parsed
+      : resourcesSubscribeServerFrameSchema.safeParse(envelope);
     if (!parsed.success) {
       return;
     }
-    const frame: ResourcesSubscribeServerFrame = parsed.data;
+    const frame:
+      ResourcesSubscribeServerFrame | ResourcesSubscribeServerFrameV12 =
+      parsed.data;
     switch (frame.kind) {
       case "snapshot": {
         this.callbacks.onSnapshot(toPayload(frame));
@@ -152,7 +166,7 @@ export class ResourcesStreamClient {
 
 function toPayload(
   frame: Extract<
-    ResourcesSubscribeServerFrame,
+    ResourcesSubscribeServerFrame | ResourcesSubscribeServerFrameV12,
     { kind: "snapshot" | "update" }
   >,
 ): ResourcesProjectionPayload {
@@ -163,5 +177,7 @@ function toPayload(
     owners: frame.owners,
     epic: frame.epic,
     epics: frame.epics ?? [],
+    hostTree: "hostTree" in frame ? frame.hostTree : undefined,
+    other: "other" in frame ? frame.other : undefined,
   };
 }

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -138,6 +138,7 @@ import { notificationsSubscribeV10 } from "@traycer/protocol/host/notifications/
 import {
   resourcesSubscribeV10,
   resourcesSubscribeV11,
+  resourcesSubscribeV12,
 } from "@traycer/protocol/host/resources/subscribe";
 import {
   speechEnsureModelV10,
@@ -564,7 +565,9 @@ function downgradeProviderStateListForV10(
 // provider.* mutation whose v2.0 contract reuses `providerCliStateSchema`
 // directly (all except `providers.list`, which freezes its own v2.0 shape
 // and upgrades via `upgradeProviderCliStateV10ToV20` inline below instead).
-function upgradeProviderStateFromV10(state: ProviderCliStateV10): ProviderCliState {
+function upgradeProviderStateFromV10(
+  state: ProviderCliStateV10,
+): ProviderCliState {
   return upgradeProviderCliStateV10ToLatest(state);
 }
 
@@ -2890,7 +2893,8 @@ export const hostRpcRegistry = defineVersionedRpcRegistry({
         },
         1: {
           contract: worktreeListBindingsForEpicV11,
-          upgradeFromPreviousVersion: worktreeListBindingsForEpicUpgradeV10ToV11,
+          upgradeFromPreviousVersion:
+            worktreeListBindingsForEpicUpgradeV10ToV11,
         },
       },
       downgradePathsFromLatest: {},
@@ -3023,13 +3027,16 @@ export const hostStreamRpcRegistry = defineVersionedStreamRpcRegistry({
   },
   "resources.subscribe": {
     1: {
-      latestMinor: 1,
+      latestMinor: 2,
       versions: {
         0: {
           contract: resourcesSubscribeV10,
         },
         1: {
           contract: resourcesSubscribeV11,
+        },
+        2: {
+          contract: resourcesSubscribeV12,
         },
       },
     },

--- a/protocol/src/host/resources/__tests__/resources-subscribe.test.ts
+++ b/protocol/src/host/resources/__tests__/resources-subscribe.test.ts
@@ -4,8 +4,10 @@ import {
   resourcesSubscribeClientFrameSchema,
   resourcesSubscribeOpenRequestV11Schema,
   resourcesSubscribeServerFrameSchema,
+  resourcesSubscribeServerFrameSchemaV12,
   resourcesSubscribeV10,
   resourcesSubscribeV11,
+  resourcesSubscribeV12,
 } from "@traycer/protocol/host/resources/subscribe";
 
 /**
@@ -59,6 +61,29 @@ const APP_FIXTURE = {
   processCount: 1,
   cpuPercent: 1.5,
   rssBytes: 256 * 1024 * 1024,
+};
+
+const HOST_TREE_FIXTURE = {
+  sampledAt: 1_000,
+  processCount: 5,
+  cpuPercent: 21.5,
+  rssBytes: 512 * 1024 * 1024,
+};
+
+const OTHER_FIXTURE = {
+  sampledAt: 1_000,
+  rootPids: [99],
+  processCount: 2,
+  cpuPercent: 8.5,
+  rssBytes: 128 * 1024 * 1024,
+  processes: [
+    {
+      ...PROCESS_FIXTURE,
+      pid: 99,
+      rootPid: 99,
+      name: "shared-provider",
+    },
+  ],
 };
 
 describe("resources.subscribe@1.0 open request", () => {
@@ -231,6 +256,36 @@ describe("resources.subscribe@1.0 server frames", () => {
   });
 });
 
+describe("resources.subscribe@1.2 server frames", () => {
+  it("carries the host-tree aggregate and Other process self snapshots", () => {
+    const parsed = resourcesSubscribeServerFrameSchemaV12.parse({
+      kind: "snapshot",
+      epicId: "__global__",
+      sampledAt: 1_000,
+      app: APP_FIXTURE,
+      owners: [OWNER_FIXTURE],
+      epic: null,
+      epics: [EPIC_FIXTURE],
+      hostTree: HOST_TREE_FIXTURE,
+      other: OTHER_FIXTURE,
+      hasBinaryPayload: false,
+    });
+
+    if (parsed.kind !== "snapshot") throw new Error("expected snapshot");
+    expect(parsed.hostTree).toEqual(HOST_TREE_FIXTURE);
+    expect(parsed.other?.rootPids).toEqual([99]);
+    expect(parsed.other?.processes[0]).toMatchObject({
+      pid: 99,
+      parentPid: 1,
+      rootPid: 99,
+      name: "shared-provider",
+      command: "/bin/bash",
+      cpuPercent: 12.5,
+      rssBytes: 4_096,
+    });
+  });
+});
+
 describe("resources.subscribe@1.0 client frames", () => {
   it("parses a text-only ping frame", () => {
     const parsed = resourcesSubscribeClientFrameSchema.parse({
@@ -245,10 +300,12 @@ describe("resources.subscribe@1.0 registry membership", () => {
   it("is registered on the stream registry at major 1 / minor 0", () => {
     const entry = hostStreamRpcRegistry["resources.subscribe"];
     expect(entry).toBeDefined();
-    expect(entry[1].latestMinor).toBe(1);
+    expect(entry[1].latestMinor).toBe(2);
     expect(entry[1].versions[0].contract).toBe(resourcesSubscribeV10);
     expect(entry[1].versions[1].contract).toBe(resourcesSubscribeV11);
+    expect(entry[1].versions[2].contract).toBe(resourcesSubscribeV12);
     expect(resourcesSubscribeV10.schemaVersion).toEqual({ major: 1, minor: 0 });
     expect(resourcesSubscribeV11.schemaVersion).toEqual({ major: 1, minor: 1 });
+    expect(resourcesSubscribeV12.schemaVersion).toEqual({ major: 1, minor: 2 });
   });
 });

--- a/protocol/src/host/resources/subscribe.ts
+++ b/protocol/src/host/resources/subscribe.ts
@@ -1,5 +1,5 @@
 /**
- * `resources.subscribe@1.0` / `@1.1` - versioned streaming-RPC contract for
+ * `resources.subscribe@1.0` / `@1.1` / `@1.2` - versioned streaming-RPC contract for
  * live process-resource snapshots.
  *
  * Subscribing opens a per-epic view over the host's `ResourceTracker`: the
@@ -143,7 +143,35 @@ export const appResourceSnapshotSchema = z.object({
 });
 export type AppResourceSnapshotWire = z.infer<typeof appResourceSnapshotSchema>;
 
-const resourcesProjectionFields = {
+/** Aggregate resource use for the host process and all of its descendants. */
+export const hostTreeResourceSnapshotSchema = z.object({
+  sampledAt: z.number(),
+  processCount: z.number().int().nonnegative(),
+  cpuPercent: z.number(),
+  rssBytes: z.number().int().nonnegative(),
+});
+export type HostTreeResourceSnapshotWire = z.infer<
+  typeof hostTreeResourceSnapshotSchema
+>;
+
+/**
+ * Host-tree processes that are not charged to an owner. Process readings are
+ * self values only; consumers derive inclusive subtree totals from the process
+ * parent/root relationships.
+ */
+export const otherResourceSnapshotSchema = z.object({
+  sampledAt: z.number(),
+  rootPids: z.array(z.number().int().nonnegative()),
+  processCount: z.number().int().nonnegative(),
+  cpuPercent: z.number(),
+  rssBytes: z.number().int().nonnegative(),
+  processes: z.array(resourceProcessSnapshotSchema),
+});
+export type OtherResourceSnapshotWire = z.infer<
+  typeof otherResourceSnapshotSchema
+>;
+
+const resourcesProjectionFieldsV11 = {
   epicId: z.string(),
   sampledAt: z.number(),
   app: appResourceSnapshotSchema.nullable(),
@@ -155,16 +183,18 @@ const resourcesProjectionFields = {
   hasBinaryPayload: z.literal(false),
 } as const;
 
+// Frozen `resources.subscribe@1.0` / `@1.1` frame shape. Do not add fields
+// here: a resolver serving either minor must emit precisely this projection.
 export const resourcesSubscribeServerFrameSchema = z.discriminatedUnion(
   "kind",
   [
     z.object({
       kind: z.literal("snapshot"),
-      ...resourcesProjectionFields,
+      ...resourcesProjectionFieldsV11,
     }),
     z.object({
       kind: z.literal("update"),
-      ...resourcesProjectionFields,
+      ...resourcesProjectionFieldsV11,
     }),
     z.object({
       kind: z.literal("pong"),
@@ -174,6 +204,33 @@ export const resourcesSubscribeServerFrameSchema = z.discriminatedUnion(
 );
 export type ResourcesSubscribeServerFrame = z.infer<
   typeof resourcesSubscribeServerFrameSchema
+>;
+
+const resourcesProjectionFieldsV12 = {
+  ...resourcesProjectionFieldsV11,
+  hostTree: hostTreeResourceSnapshotSchema.nullable(),
+  other: otherResourceSnapshotSchema.nullable(),
+} as const;
+
+export const resourcesSubscribeServerFrameSchemaV12 = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({
+      kind: z.literal("snapshot"),
+      ...resourcesProjectionFieldsV12,
+    }),
+    z.object({
+      kind: z.literal("update"),
+      ...resourcesProjectionFieldsV12,
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      hasBinaryPayload: z.literal(false),
+    }),
+  ],
+);
+export type ResourcesSubscribeServerFrameV12 = z.infer<
+  typeof resourcesSubscribeServerFrameSchemaV12
 >;
 
 export const resourcesSubscribeClientFrameSchema = z.discriminatedUnion(
@@ -202,5 +259,13 @@ export const resourcesSubscribeV11 = defineStreamRpcContract({
   schemaVersion: { major: 1, minor: 1 } as const,
   openRequestSchema: resourcesSubscribeOpenRequestV11Schema,
   serverFrameSchema: resourcesSubscribeServerFrameSchema,
+  clientFrameSchema: resourcesSubscribeClientFrameSchema,
+});
+
+export const resourcesSubscribeV12 = defineStreamRpcContract({
+  method: "resources.subscribe",
+  schemaVersion: { major: 1, minor: 2 } as const,
+  openRequestSchema: resourcesSubscribeOpenRequestV11Schema,
+  serverFrameSchema: resourcesSubscribeServerFrameSchemaV12,
   clientFrameSchema: resourcesSubscribeClientFrameSchema,
 });


### PR DESCRIPTION
## What

Resource Monitor utilization now covers **all processes running under the Traycer Host** (default host in v1), not just sessions open in the app, plus a presentation rework of the popover.

### Protocol
- `resources.subscribe@1.2`: additive required-nullable frame fields — `hostTree` (aggregate over host PID + all descendants) and `other` (unattributed host-tree process roots with self-value process snapshots). The 1.0/1.1 frame shape is frozen and byte-identical for older clients.

### Resource monitor (gui-app)
- Headline CPU / Memory / RAM-share computes from the host-tree aggregate + desktop usage (legacy summation fallback on ≤1.1 hosts).
- Owner process trees **collapsed by default**; a row shows its inclusive subtree total while children are hidden and its self cost once expanded, with a self/tree tooltip. Invariant: visible rows in a section always sum to the section header.
- **Sticky-on-expand**: the expanded row pins below its section header while its children scroll (one pinned level).
- Idle terminals are no longer hidden.
- **Other** section (collapsed by default, basename root labels) lists unattributed processes — provider servers, MCP servers, probes — with expandable trees; non-navigable.
- Title fixes: chat rows resolve the live Y.Doc title (no more "Untitled chat"); terminal rows follow the live active-process name instead of the tile-open snapshot.

### Transport/store
- `ResourcesStreamClient` parses 1.2 frames alongside frozen legacy frames; the resources store retains `hostTree`/`other` with identity-stable merges.

Host-side tracker + resolver changes land in the internal repo (gitlink re-pin follows this merge).

## Testing
- gui-app resources suites 41/41, shared 330/330, protocol 693/693; workspace compiles clean.
- Manually verified in the dev desktop app (headline totals, Other bucket, sticky-on-expand, tree/self swap, live titles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)