### PR TITLE
Add Pi harness protocol ids and GUI wiring

### DIFF
--- a/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
+++ b/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
@@ -30,6 +30,7 @@ export function providerIdForHarness(
   if (harnessId === "kilocode") return "kilocode";
   if (harnessId === "amp") return "amp";
   if (harnessId === "devin") return "devin";
+  if (harnessId === "pi") return "pi";
   return TUI_HARNESS_ID_TO_PROVIDER_ID[harnessId];
 }
 

--- a/clients/gui-app/src/components/home/data/harness-icon-map.ts
+++ b/clients/gui-app/src/components/home/data/harness-icon-map.ts
@@ -12,6 +12,7 @@ import {
   KimiIcon,
   OpenCodeIcon,
   OpenRouterIcon,
+  PiIcon,
   QwenIcon,
   TraycerIcon,
   type HarnessIcon,
@@ -39,4 +40,5 @@ export const PROVIDER_ICON_CONFIG: Record<ProviderId, HarnessIconConfig> = {
   kilocode: { Icon: KiloCodeIcon, className: "text-foreground" },
   amp: { Icon: AmpIcon, className: "text-foreground" },
   devin: { Icon: DevinIcon, className: "text-foreground" },
+  pi: { Icon: PiIcon, className: "text-foreground" },
 };

--- a/clients/gui-app/src/components/home/pickers/harness-icons.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-icons.tsx
@@ -66,6 +66,21 @@ export const AmpIcon: HarnessIcon = (props) => (
 // Devin (Cognition) — lobehub monochrome brand mark (`currentColor` theming).
 export const DevinIcon: HarnessIcon = (props) => <DevinMono {...props} />;
 
+// Pi (pi.dev) has no lobehub entry — official badge mark from pi.dev/favicon.svg
+// (press kit). Brand dark plate + white glyph so it keeps identity in both themes
+// (same idea as Amp brand red / Claude colored sunburst).
+export const PiIcon: HarnessIcon = (props) => (
+  <svg {...props} viewBox="0 0 800 800" fill="none">
+    <rect width="800" height="800" rx="120" fill="#09090b" />
+    <path
+      fill="#fff"
+      fillRule="evenodd"
+      d="M165.29 165.29H517.36V400H400V517.36H282.65V634.72H165.29ZM282.65 282.65V400H400V282.65Z"
+    />
+    <path fill="#fff" d="M517.36 400H634.72V634.72H517.36Z" />
+  </svg>
+);
+
 // Traycer does not have a lobehub entry — hand-rolled from the brand mark.
 export const TraycerIcon: HarnessIcon = (props) => (
   <svg {...props} viewBox="0 0 211 218" fill="currentColor">

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-detected-agents.test.tsx
@@ -40,6 +40,7 @@ describe("OnboardingDetectedAgents", () => {
       "Qwen Code",
       "Amp",
       "Devin",
+      "Pi",
     ];
     const textOrEmpty = (text: string | null): string => text ?? "";
 

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-diorama.test.tsx
@@ -42,6 +42,7 @@ describe("OnboardingDiorama", () => {
       "Qwen Code",
       "Amp",
       "Devin",
+      "Pi",
     ];
     const textOrEmpty = (text: string | null): string => text ?? "";
 

--- a/clients/gui-app/src/components/settings/panels/provider-env-name-placeholder.ts
+++ b/clients/gui-app/src/components/settings/panels/provider-env-name-placeholder.ts
@@ -5,6 +5,8 @@ type ProviderId = ProviderCliState["providerId"];
 // Example variable name shown as the add-row placeholder, per provider, so the
 // hint matches the harness being configured (illustrative only). Also read by
 // `ProviderApiKeySection` for its "using X from your shell" copy.
+// PI is BYOK; final auth UX is host-side — `ANTHROPIC_API_KEY` is a temporary
+// placeholder only.
 const ENV_NAME_PLACEHOLDER: Record<ProviderId, string> = {
   "claude-code": "ANTHROPIC_API_KEY",
   codex: "OPENAI_API_KEY",
@@ -21,6 +23,7 @@ const ENV_NAME_PLACEHOLDER: Record<ProviderId, string> = {
   kilocode: "KILO_API_KEY",
   amp: "AMP_API_KEY",
   devin: "WINDSURF_API_KEY",
+  pi: "ANTHROPIC_API_KEY",
 };
 
 export function envNamePlaceholder(providerId: ProviderId): string {

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -94,6 +94,7 @@ const PROVIDER_DESCRIPTIONS: Record<ProviderId, string> = {
   amp: "Amp agent - Ampcode's coding CLI via your Amp account or API key.",
   devin:
     "Devin agent - Cognition's coding CLI via Windsurf/Devin login or API key.",
+  pi: "Pi agent - pi.dev coding agent via your configured model API key (BYOK).",
 };
 
 function hasPendingProviderProbe(

--- a/clients/gui-app/src/components/settings/panels/terminal-agent-args-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/terminal-agent-args-section.tsx
@@ -27,6 +27,7 @@ const TERMINAL_AGENT_ARGS_PLACEHOLDER: Record<ProviderId, string> = {
   kilocode: "CLI arguments (optional)",
   amp: "CLI arguments (optional)",
   devin: "CLI arguments (optional)",
+  pi: "CLI arguments (optional)",
 };
 
 function terminalAgentArgsPlaceholder(providerId: ProviderId): string {

--- a/clients/gui-app/src/lib/chat/sender-display.ts
+++ b/clients/gui-app/src/lib/chat/sender-display.ts
@@ -150,6 +150,7 @@ const AGENT_PROVIDER_LABEL: Record<GuiHarnessId, string> = {
   kilocode: "Kilo Code",
   amp: "Amp",
   devin: "Devin",
+  pi: "Pi",
 };
 
 function agentProviderLabel(provider: GuiHarnessId): string {

--- a/clients/gui-app/src/lib/provider-ordering.ts
+++ b/clients/gui-app/src/lib/provider-ordering.ts
@@ -25,6 +25,7 @@ const PROVIDER_ID_ORDER = [
   "qwen",
   "amp",
   "devin",
+  "pi",
 ] as const satisfies ReadonlyArray<ProviderId>;
 
 type MissingProviderIdFromOrder = Exclude<
@@ -55,6 +56,7 @@ const GUI_HARNESS_BY_PROVIDER_ID = {
   qwen: "qwen",
   amp: "amp",
   devin: "devin",
+  pi: "pi",
 } satisfies Readonly<Record<ProviderId, GuiHarnessId>>;
 
 export const ORDERED_PROVIDERS: ExhaustiveOrderedProviders =

--- a/protocol/src/common/_internal/schemas.ts
+++ b/protocol/src/common/_internal/schemas.ts
@@ -64,4 +64,5 @@ export const harnessIdSchema = z.enum([
   "openrouter",
   "amp",
   "devin",
+  "pi",
 ]);

--- a/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/grok-versioning.test.ts
@@ -391,14 +391,15 @@ describe("post-v2.0 Amp non-breaking v3→v2 / v3→v1 downgrade bridges", () =>
   });
 });
 
-describe("post-v3.0 Devin non-breaking v4→v3 / v4→v2 / v4→v1 downgrade bridges", () => {
-  it("drops Devin from agent.gui.listHarnesses for v3.0, v2.0, and v1.0 callers", () => {
+describe("post-v3.0 Devin/Pi non-breaking v4→v3 / v4→v2 / v4→v1 downgrade bridges", () => {
+  it("drops Devin/Pi from agent.gui.listHarnesses for v3.0, v2.0, and v1.0 callers", () => {
     const v4Response = listGuiHarnessesResponseSchema.parse({
       harnesses: [
         harnessOption("claude"),
         harnessOption("cursor"),
         harnessOption("amp"),
         harnessOption("devin"),
+        harnessOption("pi"),
       ],
     });
 
@@ -437,7 +438,7 @@ describe("post-v3.0 Devin non-breaking v4→v3 / v4→v2 / v4→v1 downgrade bri
     ).not.toThrow();
   });
 
-  it("drops Devin agents from agent.list for v3.0, v2.0, and v1.0 callers", () => {
+  it("drops Devin/Pi agents from agent.list for v3.0, v2.0, and v1.0 callers", () => {
     const v4Response = listAgentsResponseSchema.parse({
       caller: { agentId: "self", canSendMessages: true },
       scope: "all",
@@ -445,6 +446,7 @@ describe("post-v3.0 Devin non-breaking v4→v3 / v4→v2 / v4→v1 downgrade bri
         agentSummary("a-claude", "claude"),
         agentSummary("a-amp", "amp"),
         agentSummary("a-devin", "devin"),
+        agentSummary("a-pi", "pi"),
         agentSummary("a-null", null),
       ],
     });
@@ -478,12 +480,13 @@ describe("post-v3.0 Devin non-breaking v4→v3 / v4→v2 / v4→v1 downgrade bri
     expect(() => listAgentsResponseSchemaV10.parse(toV1.value)).not.toThrow();
   });
 
-  it("drops Devin from providers.list for v3.0, v2.0, and v1.0 callers", () => {
+  it("drops Devin/Pi from providers.list for v3.0, v2.0, and v1.0 callers", () => {
     const v4Response = providersListResponseSchema.parse({
       providers: [
         providerState("cursor", "unknown"),
         providerState("amp", "unknown"),
         providerState("devin", "unknown"),
+        providerState("pi", "unknown"),
       ],
     });
 

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -876,13 +876,20 @@ export const ampUserMessageAnchorResolvedSchema = z.object({
   ampSessionId: z.string().nullable(),
 });
 
-
 export const devinUserMessageAnchorResolvedSchema = z.object({
   harnessId: z.literal("devin"),
   sessionId: z.string(),
   // The ACP session id the `devin acp` process assigned for this turn.
   // Null until `session/new` resolves; used to resume the same ACP session.
   devinSessionId: z.string().nullable(),
+});
+
+export const piUserMessageAnchorResolvedSchema = z.object({
+  harnessId: z.literal("pi"),
+  sessionId: z.string(),
+  // The Pi session id assigned for this turn. Null until the session is
+  // resolved; used to resume the same Pi session on a later turn.
+  piSessionId: z.string().nullable(),
 });
 
 export const userMessageAnchorResolvedEventSchema = z.object({
@@ -905,6 +912,7 @@ export const userMessageAnchorResolvedEventSchema = z.object({
     kilocodeUserMessageAnchorResolvedSchema,
     ampUserMessageAnchorResolvedSchema,
     devinUserMessageAnchorResolvedSchema,
+    piUserMessageAnchorResolvedSchema,
   ]),
 });
 export type UserMessageAnchorResolvedEvent = z.infer<

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -60,6 +60,7 @@ export const guiHarnessIdSchema = harnessIdSchema.extract([
   "openrouter",
   "amp",
   "devin",
+  "pi",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 
@@ -191,6 +192,7 @@ export const AGENT_FACING_HARNESS_IDS = [
   "openrouter",
   "amp",
   "devin",
+  "pi",
 ] as const;
 
 export const AGENT_FACING_HARNESS_ID_LIST = AGENT_FACING_HARNESS_IDS.join(", ");

--- a/protocol/src/host/provider-schemas.ts
+++ b/protocol/src/host/provider-schemas.ts
@@ -28,6 +28,7 @@ export const providerIdSchema = z.enum([
   "openrouter",
   "amp",
   "devin",
+  "pi",
 ]);
 export type ProviderId = z.infer<typeof providerIdSchema>;
 
@@ -111,6 +112,7 @@ export const PROVIDER_DISPLAY_NAMES: Record<ProviderId, string> = {
   openrouter: "OpenRouter",
   amp: "Amp",
   devin: "Devin",
+  pi: "Pi",
 };
 
 /**

--- a/protocol/src/persistence/epic/__tests__/__fixtures__/chat-schema-surface.ts
+++ b/protocol/src/persistence/epic/__tests__/__fixtures__/chat-schema-surface.ts
@@ -59,7 +59,8 @@ export const chatSchemaSurfaceBaseline = {
                   "kilocode",
                   "openrouter",
                   "amp",
-                  "devin"
+                  "devin",
+                  "pi"
                 ]
               },
               "model": {
@@ -150,7 +151,8 @@ export const chatSchemaSurfaceBaseline = {
                   "kilocode",
                   "openrouter",
                   "amp",
-                  "devin"
+                  "devin",
+                  "pi"
                 ]
               },
               "sessionId": {
@@ -300,7 +302,8 @@ export const chatSchemaSurfaceBaseline = {
                             "kilocode",
                             "openrouter",
                             "amp",
-                            "devin"
+                            "devin",
+                            "pi"
                           ]
                         },
                         "agentId": {
@@ -2049,6 +2052,109 @@ export const chatSchemaSurfaceBaseline = {
                             "sessionWorkspaceSnapshot",
                             "createdAt"
                           ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "harnessId": {
+                              "type": "string",
+                              "const": "pi"
+                            },
+                            "hostId": {
+                              "type": "string"
+                            },
+                            "sessionId": {
+                              "type": "string"
+                            },
+                            "sessionWorkspaceSnapshot": {
+                              "type": "object",
+                              "properties": {
+                                "workspaceKind": {
+                                  "type": "string",
+                                  "const": "session-snapshot"
+                                },
+                                "primaryWorkspace": {
+                                  "type": "string"
+                                },
+                                "secondaryWorkspaces": {
+                                  "default": [],
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "workspaceKind",
+                                "primaryWorkspace"
+                              ]
+                            },
+                            "createdAt": {
+                              "type": "number"
+                            },
+                            "coveredUntilMessageId": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "profileId": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "labelSnapshot": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "accountUuid": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "accentColor": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "harnessId",
+                            "hostId",
+                            "sessionId",
+                            "sessionWorkspaceSnapshot",
+                            "createdAt"
+                          ]
                         }
                       ]
                     },
@@ -2102,7 +2208,8 @@ export const chatSchemaSurfaceBaseline = {
                         "kilocode",
                         "openrouter",
                         "amp",
-                        "devin"
+                        "devin",
+                        "pi"
                       ]
                     },
                     "agentId": {
@@ -2222,7 +2329,8 @@ export const chatSchemaSurfaceBaseline = {
                                       "kilocode",
                                       "openrouter",
                                       "amp",
-                                      "devin"
+                                      "devin",
+                                      "pi"
                                     ]
                                   },
                                   "noticeKind": {
@@ -3491,7 +3599,8 @@ export const chatSchemaSurfaceBaseline = {
                               "kilocode",
                               "openrouter",
                               "amp",
-                              "devin"
+                              "devin",
+                              "pi"
                             ]
                           },
                           "source": {
@@ -3514,7 +3623,8 @@ export const chatSchemaSurfaceBaseline = {
                                   "kilocode",
                                   "openrouter",
                                   "amp",
-                                  "devin"
+                                  "devin",
+                                  "pi"
                                 ]
                               },
                               "sessionId": {
@@ -4658,7 +4768,8 @@ export const chatSchemaSurfaceBaseline = {
                             "kilocode",
                             "openrouter",
                             "amp",
-                            "devin"
+                            "devin",
+                            "pi"
                           ]
                         },
                         "agentId": {
@@ -4942,7 +5053,8 @@ export const chatSchemaSurfaceBaseline = {
                   "kilocode",
                   "openrouter",
                   "amp",
-                  "devin"
+                  "devin",
+                  "pi"
                 ]
               },
               "model": {
@@ -5036,7 +5148,8 @@ export const chatSchemaSurfaceBaseline = {
                   "kilocode",
                   "openrouter",
                   "amp",
-                  "devin"
+                  "devin",
+                  "pi"
                 ]
               },
               "sessionId": {
@@ -5193,7 +5306,8 @@ export const chatSchemaSurfaceBaseline = {
                             "kilocode",
                             "openrouter",
                             "amp",
-                            "devin"
+                            "devin",
+                            "pi"
                           ]
                         },
                         "agentId": {
@@ -7070,6 +7184,117 @@ export const chatSchemaSurfaceBaseline = {
                             "accentColor"
                           ],
                           "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "harnessId": {
+                              "type": "string",
+                              "const": "pi"
+                            },
+                            "hostId": {
+                              "type": "string"
+                            },
+                            "sessionId": {
+                              "type": "string"
+                            },
+                            "sessionWorkspaceSnapshot": {
+                              "type": "object",
+                              "properties": {
+                                "workspaceKind": {
+                                  "type": "string",
+                                  "const": "session-snapshot"
+                                },
+                                "primaryWorkspace": {
+                                  "type": "string"
+                                },
+                                "secondaryWorkspaces": {
+                                  "default": [],
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "required": [
+                                "workspaceKind",
+                                "primaryWorkspace",
+                                "secondaryWorkspaces"
+                              ],
+                              "additionalProperties": false
+                            },
+                            "createdAt": {
+                              "type": "number"
+                            },
+                            "coveredUntilMessageId": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "profileId": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "labelSnapshot": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "accountUuid": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "accentColor": {
+                              "default": null,
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "required": [
+                            "harnessId",
+                            "hostId",
+                            "sessionId",
+                            "sessionWorkspaceSnapshot",
+                            "createdAt",
+                            "coveredUntilMessageId",
+                            "profileId",
+                            "labelSnapshot",
+                            "accountUuid",
+                            "accentColor"
+                          ],
+                          "additionalProperties": false
                         }
                       ]
                     },
@@ -7124,7 +7349,8 @@ export const chatSchemaSurfaceBaseline = {
                         "kilocode",
                         "openrouter",
                         "amp",
-                        "devin"
+                        "devin",
+                        "pi"
                       ]
                     },
                     "agentId": {
@@ -7248,7 +7474,8 @@ export const chatSchemaSurfaceBaseline = {
                                       "kilocode",
                                       "openrouter",
                                       "amp",
-                                      "devin"
+                                      "devin",
+                                      "pi"
                                     ]
                                   },
                                   "noticeKind": {
@@ -8566,7 +8793,8 @@ export const chatSchemaSurfaceBaseline = {
                               "kilocode",
                               "openrouter",
                               "amp",
-                              "devin"
+                              "devin",
+                              "pi"
                             ]
                           },
                           "source": {
@@ -8589,7 +8817,8 @@ export const chatSchemaSurfaceBaseline = {
                                   "kilocode",
                                   "openrouter",
                                   "amp",
-                                  "devin"
+                                  "devin",
+                                  "pi"
                                 ]
                               },
                               "sessionId": {
@@ -9719,7 +9948,8 @@ export const chatSchemaSurfaceBaseline = {
                             "kilocode",
                             "openrouter",
                             "amp",
-                            "devin"
+                            "devin",
+                            "pi"
                           ]
                         },
                         "agentId": {

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -72,6 +72,7 @@ export const guiHarnessIdSchema = z.enum([
   "openrouter",
   "amp",
   "devin",
+  "pi",
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 

--- a/protocol/src/persistence/epic/senders.ts
+++ b/protocol/src/persistence/epic/senders.ts
@@ -302,7 +302,6 @@ export const ampChatSessionAnchorSchema = z.object({
 });
 export type AmpChatSessionAnchor = z.infer<typeof ampChatSessionAnchorSchema>;
 
-
 // Devin (ACP) resumes at session granularity only — `session/load` reloads the
 // whole ACP session, with no per-message truncation/fork point — so the anchor
 // carries just the ACP session id. `sessionId` is that ACP session id.
@@ -318,6 +317,20 @@ export const devinChatSessionAnchorSchema = z.object({
 export type DevinChatSessionAnchor = z.infer<
   typeof devinChatSessionAnchorSchema
 >;
+
+// Pi resumes at session granularity only — no per-message truncation/fork
+// point — so the anchor carries just the session id. `sessionId` is the Pi
+// session id.
+export const piChatSessionAnchorSchema = z.object({
+  harnessId: z.literal("pi"),
+  hostId: z.string(),
+  sessionId: z.string(),
+  sessionWorkspaceSnapshot: sessionWorkspaceSnapshotSchema,
+  createdAt: z.number(),
+  coveredUntilMessageId: z.string().nullable().default(null),
+  ...profileSnapshotFields,
+});
+export type PiChatSessionAnchor = z.infer<typeof piChatSessionAnchorSchema>;
 
 export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   claudeChatSessionAnchorSchema,
@@ -335,5 +348,6 @@ export const chatSessionAnchorSchema = z.discriminatedUnion("harnessId", [
   kilocodeChatSessionAnchorSchema,
   ampChatSessionAnchorSchema,
   devinChatSessionAnchorSchema,
+  piChatSessionAnchorSchema,
 ]);
 export type ChatSessionAnchor = z.infer<typeof chatSessionAnchorSchema>;


### PR DESCRIPTION
## Summary

- Registers the `pi` harness/provider ids (PI.dev — `@earendil-works/pi-coding-agent`) across protocol + GUI, mirroring the Devin id addition this PR is stacked on: schemas/enums, `piChatSessionAnchorSchema` session anchor, runtime anchor, display name "Pi", official pi.dev brand icon (press kit), ordering/sender/reauth/env-placeholder wiring.
- **Stacked on #285** (base: `traycer/new-provider-devin-acp`) — merge that first; this PR then lands only the pi commit.
- `pi` joins the **still-unreleased v4.0 line #285 opens**: canonical v4.0 carries it and every downgrade bridge (v4→v3/v2/v1) drops it for released peers. Frozen v1.0–v3.0 sets untouched; no new RPC method names.

## Companion

Host-side adapter PR: traycerai/traycer-internal#4338 (drives `pi --mode rpc`; its gitlink pins this branch head).

## Tests

protocol 696/696 · gui-app 4818 pass / 1 skip · compile green — verified at this tip and standalone at the base commit.
