### PR TITLE
Improve provider profile and rate-limit UX

### DIFF
--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-panel.tsx
@@ -223,7 +223,6 @@ export function HarnessModelPickerPanel(props: HarnessModelPickerPanelProps) {
                       onProfileChange(resolvedActiveProviderId, profileId),
                   );
                 }}
-                onEditProfile={null}
                 createProfileDisabled={createProfileDisabled}
                 createProfileDisabledReason={createProfileDisabledReason}
                 shortcutHintForIndex={pickerProfileShortcutHintForIndex}

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-icon.test.tsx
@@ -43,7 +43,7 @@ function renderIcon() {
 // variant classes always carry `disabled:opacity-50`, which would otherwise
 // false-positive a substring check for the bare `opacity-50` utility.
 function hasClass(element: Element, className: string): boolean {
-  return element.className.split(/\s+/).includes(className);
+  return (element.getAttribute("class") ?? "").split(/\s+/).includes(className);
 }
 
 afterEach(() => {
@@ -57,6 +57,8 @@ describe("<RateLimitIconButton />", () => {
     renderIcon();
     const button = screen.getByRole("button", { name: "Usage limits" });
     expect(button).toBeTruthy();
+    expect(button.getAttribute("data-variant")).toBe("outline");
+    expect(screen.getByTestId("rate-limit-gauge-icon")).toBeTruthy();
   });
 
   it("suppresses title-bar dragging only while the popover is open", () => {
@@ -75,20 +77,47 @@ describe("<RateLimitIconButton />", () => {
     expect(isSuppressed()).toBe(false);
   });
 
-  it("renders zero providers configured as a muted, pre-filled placeholder glyph", () => {
+  it("renders zero providers as visible empty tracks without fabricated usage", () => {
     bars = [];
     renderIcon();
     const button = screen.getByTestId("rate-limit-header-button");
-    expect(hasClass(button, "opacity-50")).toBe(true);
-    expect(hasClass(button, "opacity-[0.55]")).toBe(false);
     const tracks = within(button).getAllByTestId("rate-limit-bar-track");
     expect(tracks).toHaveLength(2);
+    expect(within(button).queryAllByTestId("rate-limit-bar-fill")).toHaveLength(
+      0,
+    );
+    for (const track of tracks) {
+      expect(track.className).toContain("bg-muted-foreground/35");
+    }
+  });
+
+  it("keeps valid 0% readings empty while preserving visible tracks", () => {
+    bars = [
+      {
+        providerId: "codex",
+        windowLabel: "5h",
+        usedPercent: 0,
+        severity: "blue",
+        degraded: false,
+      },
+      {
+        providerId: "codex",
+        windowLabel: "Weekly",
+        usedPercent: 0,
+        severity: "blue",
+        degraded: false,
+      },
+    ];
+    renderIcon();
+    const button = screen.getByTestId("rate-limit-header-button");
+    const tracks = within(button).getAllByTestId("rate-limit-bar-track");
     const fills = within(button).getAllByTestId("rate-limit-bar-fill");
+    expect(tracks).toHaveLength(2);
     expect(fills).toHaveLength(2);
-    expect(fills[0].style.width).toBe("75%");
-    expect(fills[1].style.width).toBe("60%");
-    for (const fill of fills) {
-      expect(hasClass(fill, "bg-muted-foreground")).toBe(true);
+    expect(fills[0].style.width).toBe("0%");
+    expect(fills[1].style.width).toBe("0%");
+    for (const track of tracks) {
+      expect(track.className).toContain("bg-muted-foreground/35");
     }
   });
 
@@ -111,8 +140,6 @@ describe("<RateLimitIconButton />", () => {
     ];
     renderIcon();
     const button = screen.getByTestId("rate-limit-header-button");
-    expect(hasClass(button, "opacity-50")).toBe(false);
-    expect(hasClass(button, "opacity-[0.55]")).toBe(false);
     const fills = within(button).getAllByTestId("rate-limit-bar-fill");
     expect(fills).toHaveLength(2);
     expect(fills[0].className).toContain("blue-500");
@@ -150,7 +177,7 @@ describe("<RateLimitIconButton />", () => {
     expect(fills[1].style.width).toBe("20%");
   });
 
-  it("dims the whole glyph when a contributing bar's last poll failed (degraded)", () => {
+  it("marks the gauge without dimming the whole button when data is degraded", () => {
     bars = [
       {
         providerId: "claude-code",
@@ -169,10 +196,12 @@ describe("<RateLimitIconButton />", () => {
     ];
     renderIcon();
     const button = screen.getByTestId("rate-limit-header-button");
-    expect(hasClass(button, "opacity-[0.55]")).toBe(true);
-    expect(hasClass(button, "opacity-50")).toBe(false);
-    // Degraded dims the whole icon container, not the individual bar - both
-    // bars keep their own severity fill.
+    expect(hasClass(button, "opacity-[0.55]")).toBe(false);
+    expect(
+      hasClass(screen.getByTestId("rate-limit-gauge-icon"), "text-amber-600"),
+    ).toBe(true);
+    // Both bars keep their own severity fill while the gauge carries the
+    // degraded-state treatment.
     const fills = within(button).getAllByTestId("rate-limit-bar-fill");
     expect(fills).toHaveLength(2);
   });

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -640,7 +640,7 @@ describe("<RateLimitPopover /> rail", () => {
     expect(screen.getByText("Pro 5x")).toBeTruthy();
   });
 
-  it("keeps the old single-provider layout when profiles has only one entry", () => {
+  it("renders the profile-card layout when a provider has only one profile", () => {
     mocks.configured = [
       {
         providerId: "codex",
@@ -656,12 +656,15 @@ describe("<RateLimitPopover /> rail", () => {
         ],
       },
     ];
-    mocks.results = { codex: readyResult(codexReady()) };
+    mocks.results = {
+      [resultKey("codex", "work-profile")]: readyResult(codexReady()),
+    };
     renderPopover();
 
     expect(screen.getByText("Codex")).toBeTruthy();
     expect(screen.getByText("Current session")).toBeTruthy();
-    expect(screen.queryByText("Work")).toBeNull();
+    expect(screen.getByText("Work")).toBeTruthy();
+    expect(screen.getByText("Pro 5x")).toBeTruthy();
   });
 
   it("enqueues open-time refresh only for stale multi-profile rows", async () => {
@@ -1314,6 +1317,93 @@ describe("<RateLimitPopover /> per-provider refresh", () => {
     fireEvent.click(screen.getByRole("button", { name: "Refresh Kilo Code" }));
     expect(refetch).toHaveBeenCalledTimes(1);
     expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("refreshes every profile from one provider-heading control", () => {
+    mocks.configured = [
+      {
+        providerId: "codex",
+        lane: "ephemeralProcess",
+        profiles: [
+          providerProfile({
+            profileId: "ambient",
+            kind: "ambient",
+            label: "Terminal",
+            tier: "Pro",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+          providerProfile({
+            profileId: "work-profile",
+            kind: "managed",
+            label: "Work",
+            tier: "Pro 5x",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+        ],
+      },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      [resultKey("codex", "work-profile")]: readyResult(codexReady()),
+    };
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+
+    const refreshProvider = screen.getByRole("button", {
+      name: "Refresh Codex",
+    });
+    expect(screen.queryByRole("button", { name: "Refresh Work" })).toBeNull();
+    fireEvent.click(refreshProvider);
+
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "codex",
+      { type: "PERSONAL" },
+      { force: true, profileId: null },
+    );
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "codex",
+      { type: "PERSONAL" },
+      { force: true, profileId: "work-profile" },
+    );
+  });
+
+  it("keeps profile cards out of a shared loading state while the provider refresh queue drains", () => {
+    mocks.configured = [
+      {
+        providerId: "codex",
+        lane: "ephemeralProcess",
+        profiles: [
+          providerProfile({
+            profileId: "ambient",
+            kind: "ambient",
+            label: "Terminal",
+            tier: "Pro",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+          providerProfile({
+            profileId: "work-profile",
+            kind: "managed",
+            label: "Work",
+            tier: "Pro 5x",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+        ],
+      },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      [resultKey("codex", "work-profile")]: readyResult(codexReady()),
+    };
+    mocks.draining = true;
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+
+    expect(
+      screen
+        .getByRole("button", { name: "Refresh Codex" })
+        .getAttribute("disabled"),
+    ).not.toBeNull();
+    expect(screen.queryByText("Refreshing")).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -1405,6 +1405,80 @@ describe("<RateLimitPopover /> per-provider refresh", () => {
     ).not.toBeNull();
     expect(screen.queryByText("Refreshing")).toBeNull();
   });
+
+  // The queue's `draining` flag is lane-global, not per-provider, so a refresh
+  // on ANY ephemeralProcess provider disables every provider's control in that
+  // lane - not just the one whose fetch is in flight. Deliberate: the lane runs
+  // providers one at a time, so this matches a "refresh round is in progress"
+  // mental model rather than "my own fetch is in flight". See the spinner-state
+  // note in `use-provider-rate-limit-refresh.ts`. Pinned here so the shared
+  // disable isn't mistaken for cross-provider leakage and "fixed" away.
+  it("disables both ephemeralProcess providers' refresh controls while the shared queue drains", () => {
+    mocks.configured = [
+      {
+        providerId: "codex",
+        lane: "ephemeralProcess",
+        profiles: [
+          providerProfile({
+            profileId: "ambient",
+            kind: "ambient",
+            label: "Terminal",
+            tier: "Pro",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+          providerProfile({
+            profileId: "work-profile",
+            kind: "managed",
+            label: "Work",
+            tier: "Pro 5x",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+        ],
+      },
+      {
+        providerId: "claude-code",
+        lane: "ephemeralProcess",
+        profiles: [
+          providerProfile({
+            profileId: "ambient",
+            kind: "ambient",
+            label: "Personal",
+            tier: "Max",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+          providerProfile({
+            profileId: "team-profile",
+            kind: "managed",
+            label: "Team",
+            tier: "Max 20x",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+        ],
+      },
+    ];
+    mocks.results = {
+      codex: readyResult(codexReady()),
+      [resultKey("codex", "work-profile")]: readyResult(codexReady()),
+      "claude-code": readyResult(claudeReady()),
+      [resultKey("claude-code", "team-profile")]: readyResult(claudeReady()),
+    };
+    mocks.draining = true;
+    renderPopover();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    const refreshCodex = screen.getByRole("button", { name: "Refresh Codex" });
+    expect((refreshCodex as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Claude Code" }));
+    const refreshClaude = screen.getByRole("button", {
+      name: "Refresh Claude Code",
+    });
+    expect((refreshClaude as HTMLButtonElement).disabled).toBe(true);
+
+    // The shared lane gates the control, but it must not bleed into the profile
+    // cards' own loading state.
+    expect(screen.queryByText("Refreshing")).toBeNull();
+  });
 });
 
 // Guards that a stacked Overview keeps each provider's block scoped, and that

--- a/clients/gui-app/src/components/layout/header/rate-limit-icon.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-icon.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { Gauge } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverTrigger } from "@/components/ui/popover";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
@@ -12,25 +13,19 @@ import {
 } from "@/lib/rate-limits/window-severity";
 import { cn } from "@/lib/utils";
 
-/**
- * Fixed placeholder fill percentages for the neutral/no-data glyph (Core
- * Flows wireframe, CodexBar-style generic pre-filled look) - shown both when
- * zero providers are configured and while every provider's first fetch is
- * still pending. Not real usage data.
- */
-const PLACEHOLDER_BAR_PERCENTAGES: ReadonlyArray<number> = [75, 60];
+const EMPTY_BAR_KEYS = ["primary", "secondary"] as const;
 
 /**
- * Header trigger for the provider rate-limit popover. Same `TooltipWrapper` +
- * `Button variant="ghost" size="icon-sm"` structural pattern as
- * `HistoryButton`, always visible per Core Flows' "Entry point & visibility"
- * (position consistency + feature discovery beat hiding an empty state).
- * Clicking opens the popover in any glyph state, including empty (which lands on
- * the zero-provider CTA).
+ * Header trigger for the provider rate-limit popover. Its compact outlined
+ * surface combines a recognizable gauge icon with the two live usage bars, so
+ * the control still reads as an intentional button when both fills are 0%.
+ * Clicking opens the popover in any glyph state, including empty (which lands
+ * on the zero-provider CTA).
  *
  * Never gates on data loading: `useHeaderRateLimitBars` returns `[]` both
  * before any provider has data and when zero providers are configured, and
- * both render the same neutral glyph - there is no separate loading state.
+ * both render the same neutral empty tracks - there is no separate loading
+ * state and no fabricated placeholder usage.
  */
 export function RateLimitIconButton(): ReactNode {
   const [open, setOpen] = useState(false);
@@ -55,39 +50,37 @@ export function RateLimitIconButton(): ReactNode {
         <PopoverTrigger asChild>
           <Button
             type="button"
-            variant="ghost"
-            size="icon-sm"
+            variant="outline"
+            size="sm"
             aria-label="Usage limits"
             data-testid="rate-limit-header-button"
-            className={cn(
-              "text-muted-foreground hover:text-foreground",
-              isEmpty && "opacity-50",
-              isDegraded && "opacity-[0.55]",
-            )}
+            className="gap-1.5 bg-muted/30 px-2 text-muted-foreground shadow-xs hover:text-foreground"
           >
+            <Gauge
+              data-testid="rate-limit-gauge-icon"
+              className={cn(
+                "size-3.5",
+                isDegraded && "text-amber-600 dark:text-amber-400",
+              )}
+              aria-hidden
+            />
             <span
               aria-hidden
               className="inline-flex flex-col items-start gap-[2.5px]"
             >
               {isEmpty
-                ? PLACEHOLDER_BAR_PERCENTAGES.map((percent) => (
+                ? EMPTY_BAR_KEYS.map((key) => (
                     <span
-                      key={percent}
+                      key={key}
                       data-testid="rate-limit-bar-track"
-                      className="relative h-1 w-4 overflow-hidden rounded-[2px] bg-muted"
-                    >
-                      <span
-                        data-testid="rate-limit-bar-fill"
-                        className="absolute inset-y-0 left-0 rounded-[2px] bg-muted-foreground"
-                        style={{ width: `${percent}%` }}
-                      />
-                    </span>
+                      className="relative h-1 w-4 overflow-hidden rounded-[2px] bg-muted-foreground/35 dark:bg-muted-foreground/40"
+                    />
                   ))
                 : bars.map((bar) => (
                     <span
                       key={`${bar.providerId}-${bar.windowLabel}`}
                       data-testid="rate-limit-bar-track"
-                      className="relative h-1 w-4 overflow-hidden rounded-[2px] bg-muted"
+                      className="relative h-1 w-4 overflow-hidden rounded-[2px] bg-muted-foreground/35 dark:bg-muted-foreground/40"
                     >
                       <span
                         data-testid="rate-limit-bar-fill"

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -25,6 +25,7 @@ import {
   type ProviderRateLimitQueryState,
 } from "@/components/settings/panels/provider-rate-limit-views";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
+import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useHostQueriesWithResponseMap } from "@/hooks/host/use-host-queries";
 import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
 import {
@@ -63,6 +64,7 @@ import {
 import { queryKeys } from "@/lib/query-keys";
 import {
   PROVIDER_RATE_LIMITS_STALE_TIME_MS,
+  rateLimitFetchLane,
   type RateLimitProviderId,
 } from "@/lib/rate-limit-providers";
 import { useRelativeTimestamp, useSampledNow } from "@/lib/relative-time";
@@ -709,8 +711,9 @@ function RateLimitRefreshAllButton({
 type PopoverBlockVariant = "popover-detail" | "popover-overview";
 
 /**
- * One provider's block - a header (name + plan/tier chip + "Updated Xm ago" +
- * per-provider refresh) over its state-driven body. Shared by the
+ * One provider's block. Providers with profile metadata always render the
+ * same profile-card layout, whether they have one profile or many; older hosts
+ * that do not report profiles fall back to the provider-wide reading. Shared by the
  * single-provider tab (`variant="popover-detail"`, full detail) and each
  * Overview entry (`variant="popover-overview"`, condensed). The plan/tier
  * chip (`resolveProviderPlanLabel`) is single-provider-tab only, same scoping
@@ -736,9 +739,9 @@ function RateLimitProviderBlock({
   readonly onReady: (() => void) | null;
   readonly profileSelection: RateLimitProfileSelection;
 }): ReactNode {
-  if (profiles.length > 1) {
+  if (profiles.length > 0) {
     return (
-      <MultiProfileRateLimitProviderBlock
+      <ProfileRateLimitProviderBlock
         providerId={providerId}
         profiles={profiles}
         variant={variant}
@@ -852,7 +855,7 @@ function SingleProfileRateLimitProviderBlock({
   );
 }
 
-function MultiProfileRateLimitProviderBlock({
+function ProfileRateLimitProviderBlock({
   providerId,
   profiles,
   variant,
@@ -865,12 +868,68 @@ function MultiProfileRateLimitProviderBlock({
   readonly onReady: (() => void) | null;
   readonly profileSelection: RateLimitProfileSelection;
 }): ReactNode {
+  const draining = useIsRateLimitQueueDraining();
+  const queryClient = useQueryClient();
+  const hostId = useReactiveActiveHostId();
+  const client = useHostClient();
   const activeProfileId = resolveRateLimitProfileId(
     profileSelection,
     providerId,
     profiles,
   );
   const rows = profiles.filter(profileLoggedInForUsage);
+  const targets = rows.map((profile) => ({
+    profile,
+    profileId: rateLimitProfileId(profile),
+  }));
+  const queryOptions = providerRateLimitQueryOptions(providerId, null).options;
+  const queries = useHostQueriesWithResponseMap<
+    HostRpcRegistry,
+    "host.getRateLimitUsage",
+    ProviderRateLimitEnvelope
+  >({
+    client,
+    requests: targets.map((target) => {
+      const { method, params } = providerRateLimitQueryOptions(
+        providerId,
+        target.profileId,
+      );
+      return { method, params };
+    }),
+    options: queryOptions,
+    mapResponse: mapResponseToProviderRateLimitEnvelope,
+  });
+  const lane = rateLimitFetchLane(providerId);
+  const isRefreshing =
+    lane === "ephemeralProcess"
+      ? draining
+      : queries.some((query) => query.isFetching);
+
+  const refresh = (): Promise<void> => {
+    if (lane === "ephemeralProcess") {
+      targets.forEach((target) => {
+        void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
+          force: true,
+          profileId: target.profileId,
+        });
+      });
+      return Promise.resolve();
+    }
+    targets.forEach((target) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.hostMethod<
+          HostRpcRegistry,
+          "host.getRateLimitUsage"
+        >(hostId, "host.getRateLimitUsage", {
+          accountContext: DEFAULT_ACCOUNT_CONTEXT,
+          providerId,
+          profileId: target.profileId,
+        }),
+        exact: true,
+      });
+    });
+    return Promise.resolve();
+  };
 
   useEffect(() => {
     if (onReady !== null) onReady();
@@ -879,7 +938,12 @@ function MultiProfileRateLimitProviderBlock({
   if (rows.length === 0) {
     return (
       <div className="flex flex-col gap-2">
-        <ProviderGroupHeader providerId={providerId} variant={variant} />
+        <ProviderGroupHeader
+          providerId={providerId}
+          variant={variant}
+          refresh={refresh}
+          isRefreshing={isRefreshing}
+        />
         <RateLimitErrorMessage message="No logged-in profiles." />
       </div>
     );
@@ -887,18 +951,23 @@ function MultiProfileRateLimitProviderBlock({
 
   return (
     <div className="flex flex-col gap-2">
-      <ProviderGroupHeader providerId={providerId} variant={variant} />
+      <ProviderGroupHeader
+        providerId={providerId}
+        variant={variant}
+        refresh={refresh}
+        isRefreshing={isRefreshing}
+      />
       <div className="flex flex-col gap-2">
-        {rows.map((profile) => {
-          const rowProfileId = rateLimitProfileId(profile);
+        {targets.map((target, index) => {
           return (
             <RateLimitProviderProfileRow
-              key={profile.profileId}
+              key={target.profile.profileId}
               providerId={providerId}
-              profile={profile}
-              profileId={rowProfileId}
-              active={activeProfileId === rowProfileId}
+              profile={target.profile}
+              profileId={target.profileId}
+              active={activeProfileId === target.profileId}
               variant={variant}
+              query={queries[index]}
             />
           );
         })}
@@ -910,18 +979,31 @@ function MultiProfileRateLimitProviderBlock({
 function ProviderGroupHeader({
   providerId,
   variant,
+  refresh,
+  isRefreshing,
 }: {
   readonly providerId: RateLimitProviderId;
   readonly variant: PopoverBlockVariant;
+  readonly refresh: () => Promise<void>;
+  readonly isRefreshing: boolean;
 }): ReactNode {
   return (
-    <div className="flex min-w-0 items-center gap-1.5">
-      {variant === "popover-overview" ? (
-        <HarnessIcon harnessId={providerIdToGuiHarnessId(providerId)} />
+    <div className="flex min-w-0 items-center justify-between gap-2">
+      <div className="flex min-w-0 items-center gap-1.5">
+        {variant === "popover-overview" ? (
+          <HarnessIcon harnessId={providerIdToGuiHarnessId(providerId)} />
+        ) : null}
+        <span className="text-ui-sm font-medium text-foreground">
+          {providerDisplayName(providerId)}
+        </span>
+      </div>
+      {variant === "popover-detail" ? (
+        <RefreshIconButton
+          onRefresh={refresh}
+          label={`Refresh ${providerDisplayName(providerId)}`}
+          refreshing={isRefreshing}
+        />
       ) : null}
-      <span className="text-ui-sm font-medium text-foreground">
-        {providerDisplayName(providerId)}
-      </span>
     </div>
   );
 }
@@ -932,24 +1014,28 @@ function RateLimitProviderProfileRow({
   profileId,
   active,
   variant,
+  query,
 }: {
   readonly providerId: RateLimitProviderId;
   readonly profile: ProviderProfile;
   readonly profileId: string | null;
   readonly active: boolean;
   readonly variant: PopoverBlockVariant;
+  readonly query: {
+    readonly isPending: boolean;
+    readonly isFetching: boolean;
+    readonly isError: boolean;
+    readonly data: ProviderRateLimitEnvelope | undefined;
+  };
 }): ReactNode {
-  const query = useHostProviderRateLimitsQuery(providerId, profileId);
-  const { refresh, isRefreshing } = useProviderRateLimitRefresh({
+  useRefreshProviderRateLimitsOnMount(
     providerId,
     profileId,
-    usageUpdatedAt: profile.usageUpdatedAt,
-    isFetching: query.isFetching,
-    refetch: query.refetch,
-  });
+    profile.usageUpdatedAt,
+  );
   const queryState: ProviderRateLimitQueryState = {
     isPending: query.isPending,
-    isFetching: isRefreshing,
+    isFetching: query.isFetching,
     isError: query.isError,
     envelope: query.data,
   };
@@ -1000,16 +1086,9 @@ function RateLimitProviderProfileRow({
           </div>
           <ProfileUsageUpdatedLabel
             updatedAt={profile.usageUpdatedAt}
-            refreshing={isRefreshing}
+            refreshing={query.isFetching}
           />
         </div>
-        {variant === "popover-detail" ? (
-          <RefreshIconButton
-            onRefresh={refresh}
-            label={`Refresh ${profileDisplayLabel(profile)}`}
-            refreshing={isRefreshing}
-          />
-        ) : null}
       </div>
       <RateLimitProviderBody state={state} variant={variant} />
     </div>

--- a/clients/gui-app/src/components/providers/__tests__/profile-dropdown.test.tsx
+++ b/clients/gui-app/src/components/providers/__tests__/profile-dropdown.test.tsx
@@ -133,7 +133,6 @@ function renderDropdown(input: RenderDropdownInput) {
       activeProfileId={input.activeProfileId}
       onSelectProfile={input.onSelectProfile}
       onCreateProfile={input.onCreateProfile}
-      onEditProfile={null}
       createProfileDisabled={input.createProfileDisabled}
       createProfileDisabledReason={input.createProfileDisabledReason}
       shortcutHintForIndex={input.shortcutHintForIndex}
@@ -162,34 +161,6 @@ describe("<ProfileDropdown />", () => {
       name: "Codex profile: Work",
     });
     expect(trigger.textContent).toContain("Work");
-  });
-
-  it("places the settings edit action directly after the profile name", () => {
-    const onEditProfile = vi.fn();
-    render(
-      <ProfileDropdown
-        providerLabel="Codex"
-        profiles={[AMBIENT, WORK]}
-        activeProfileId="work-profile"
-        onSelectProfile={vi.fn()}
-        onCreateProfile={vi.fn()}
-        onEditProfile={onEditProfile}
-        createProfileDisabled={false}
-        createProfileDisabledReason={undefined}
-        shortcutHintForIndex={noShortcutHint}
-        contentContainer={null}
-        onCloseAutoFocus={null}
-      />,
-    );
-
-    const edit = screen.getByRole("button", { name: "Edit Work profile" });
-    expect(edit.previousElementSibling?.textContent).toBe("Work");
-    expect(edit.previousElementSibling?.getAttribute("aria-hidden")).toBe(
-      "true",
-    );
-    expect(edit.closest('[aria-hidden="true"]')).toBeNull();
-    fireEvent.click(edit);
-    expect(onEditProfile).toHaveBeenCalledTimes(1);
   });
 
   it("renders non-modal so nested picker clicks can dismiss only the profile menu", () => {

--- a/clients/gui-app/src/components/providers/__tests__/profile-dropdown.test.tsx
+++ b/clients/gui-app/src/components/providers/__tests__/profile-dropdown.test.tsx
@@ -270,7 +270,7 @@ describe("<ProfileDropdown />", () => {
   // This file only verifies the contract: render whatever the caller's
   // `shortcutHintForIndex` returns, per row, and nothing when it returns
   // `null` - `ProfileDropdown` itself owns no keybinding-formatting logic.
-  it("renders the injected shortcut hint's digit and label verbatim, per row", () => {
+  it("renders each injected shortcut hint in the native Kbd component", () => {
     renderDropdown({
       profiles: [AMBIENT, WORK],
       activeProfileId: "work-profile",
@@ -282,12 +282,12 @@ describe("<ProfileDropdown />", () => {
       onCloseAutoFocus: null,
     });
 
-    expect(screen.getByTestId("model-profile-digit-1").textContent).toBe(
-      "Hint 1",
-    );
-    expect(screen.getByTestId("model-profile-digit-2").textContent).toBe(
-      "Hint 2",
-    );
+    const firstHint = screen.getByTestId("model-profile-digit-1");
+    const secondHint = screen.getByTestId("model-profile-digit-2");
+    expect(firstHint.textContent).toBe("Hint 1");
+    expect(secondHint.textContent).toBe("Hint 2");
+    expect(firstHint.querySelector('[data-slot="kbd"]')).not.toBeNull();
+    expect(secondHint.querySelector('[data-slot="kbd"]')).not.toBeNull();
   });
 
   it("hides shortcut hints when the caller (Settings) disables them", () => {

--- a/clients/gui-app/src/components/providers/profile-dropdown.tsx
+++ b/clients/gui-app/src/components/providers/profile-dropdown.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, ChevronDown, Pencil, Plus } from "lucide-react";
+import { CheckIcon, ChevronDown, Plus } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,10 +33,6 @@ interface ProfileDropdownProps {
   readonly activeProfileId: string | null;
   readonly onSelectProfile: (profileId: string | null) => void;
   readonly onCreateProfile: () => void;
-  /** Settings-only edit action. When present, it is visually inset into the
-   *  trigger immediately before the caret without nesting one button inside
-   *  another. Picker surfaces pass null. */
-  readonly onEditProfile: (() => void) | null;
   readonly createProfileDisabled: boolean;
   readonly createProfileDisabledReason: string | undefined;
   /** Per-row shortcut hint, or a function that always returns `null` to opt
@@ -72,7 +68,6 @@ export function ProfileDropdown(props: ProfileDropdownProps) {
     activeProfileId,
     onSelectProfile,
     onCreateProfile,
-    onEditProfile,
     createProfileDisabled,
     createProfileDisabledReason,
     shortcutHintForIndex,
@@ -85,71 +80,26 @@ export function ProfileDropdown(props: ProfileDropdownProps) {
 
   return (
     <DropdownMenu modal={false}>
-      {onEditProfile === null ? (
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label={`${providerLabel} profile: ${profileDisplayLabel(activeProfile)}`}
-            className="flex h-8 w-full min-w-0 items-center justify-between gap-2 rounded-md border border-input bg-transparent px-2.5 text-ui-sm text-foreground outline-none transition-colors hover:bg-input/30 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 data-open:bg-input/30 dark:bg-input/30 dark:hover:bg-input/50"
-          >
-            <AccentDot
-              profileId={activeProfile.profileId}
-              accentColor={activeProfile.accentColor}
-              label={null}
-              variant="inline"
-              size="default"
-              className={undefined}
-            />
-            <span className="min-w-0 flex-1 truncate text-left font-medium">
-              {profileDisplayLabel(activeProfile)}
-            </span>
-            <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
-          </button>
-        </DropdownMenuTrigger>
-      ) : (
-        <div className="relative h-8 min-w-0">
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              aria-label={`${providerLabel} profile: ${profileDisplayLabel(activeProfile)}`}
-              className="absolute inset-0 rounded-md border border-input bg-transparent text-foreground outline-none transition-colors hover:bg-input/30 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 data-open:bg-input/30 dark:bg-input/30 dark:hover:bg-input/50"
-            >
-              <span className="sr-only">
-                Select {profileDisplayLabel(activeProfile)} profile
-              </span>
-            </button>
-          </DropdownMenuTrigger>
-          <div className="pointer-events-none relative flex h-full min-w-0 items-center gap-2 px-2.5 text-ui-sm text-foreground">
-            <AccentDot
-              profileId={activeProfile.profileId}
-              accentColor={activeProfile.accentColor}
-              label={null}
-              variant="inline"
-              size="default"
-              className={undefined}
-            />
-            <span
-              aria-hidden="true"
-              className="min-w-0 truncate text-left font-medium"
-            >
-              {profileDisplayLabel(activeProfile)}
-            </span>
-            <button
-              type="button"
-              aria-label={`Edit ${profileDisplayLabel(activeProfile)} profile`}
-              className="pointer-events-auto flex size-6 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
-              onClick={onEditProfile}
-            >
-              <Pencil className="size-3.5" />
-            </button>
-            <span className="min-w-0 flex-1" />
-            <ChevronDown
-              aria-hidden="true"
-              className="size-4 shrink-0 text-muted-foreground"
-            />
-          </div>
-        </div>
-      )}
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${providerLabel} profile: ${profileDisplayLabel(activeProfile)}`}
+          className="flex h-8 w-full min-w-0 items-center justify-between gap-2 rounded-md border border-input bg-transparent px-2.5 text-ui-sm text-foreground outline-none transition-colors hover:bg-input/30 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 data-open:bg-input/30 dark:bg-input/30 dark:hover:bg-input/50"
+        >
+          <AccentDot
+            profileId={activeProfile.profileId}
+            accentColor={activeProfile.accentColor}
+            label={null}
+            variant="inline"
+            size="default"
+            className={undefined}
+          />
+          <span className="min-w-0 flex-1 truncate text-left font-medium">
+            {profileDisplayLabel(activeProfile)}
+          </span>
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
         sideOffset={4}

--- a/clients/gui-app/src/components/providers/profile-dropdown.tsx
+++ b/clients/gui-app/src/components/providers/profile-dropdown.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Kbd } from "@/components/ui/kbd";
 import { AccentDot } from "@/components/providers/accent-dot";
 import {
   profileCommitId,
@@ -144,7 +145,9 @@ export function ProfileDropdown(props: ProfileDropdownProps) {
                 <DropdownMenuShortcut
                   data-testid={`model-profile-digit-${shortcutHint.digit}`}
                 >
-                  {shortcutHint.label}
+                  <Kbd className="font-mono tabular-nums">
+                    {shortcutHint.label}
+                  </Kbd>
                 </DropdownMenuShortcut>
               ) : null}
               <span className="pointer-events-none flex size-4 shrink-0 items-center justify-center">

--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -996,18 +996,30 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(
       screen.getByRole("menuitem", { name: "Create new profile" }),
     ).toBeDefined();
-    expect(screen.getByRole("button", { name: "Add profile" })).toBeDefined();
+    const addProfileButton = screen.getByRole("button", {
+      name: "Add profile",
+    });
+    expect(addProfileButton.getAttribute("data-variant")).toBe("outline");
+    expect(addProfileButton.getAttribute("data-size")).toBe("xs");
     expect(screen.getByText("Profiles")).toBeDefined();
-    expect(
-      screen.getByRole("button", { name: "Edit Terminal account profile" }),
-    ).toBeDefined();
+    const manageProfileButton = screen.getByRole("button", {
+      name: "Manage profile",
+    });
+    expect(manageProfileButton.getAttribute("data-variant")).toBe("outline");
+    expect(manageProfileButton.getAttribute("data-size")).toBe("xs");
+    const profileSummaryActions = manageProfileButton.closest(".flex-wrap");
+    if (!(profileSummaryActions instanceof HTMLElement)) {
+      throw new Error("Expected profile summary and actions row");
+    }
+    expect(within(profileSummaryActions).getByText("No plan")).toBeDefined();
+    fireEvent.focus(manageProfileButton);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Change the profile name and accent color, sign in again, or remove this profile.",
+    );
     expect(
       screen.queryByRole("button", { name: "Refresh usage limits" }),
     ).toBeNull();
 
-    const addProfileButton = screen.getByRole("button", {
-      name: "Add profile",
-    });
     const refreshButton = screen.getByRole("button", {
       name: "Refresh profile statuses and usage limits",
     });
@@ -1052,9 +1064,7 @@ describe("<ProvidersSettingsPanel />", () => {
       </TooltipProvider>,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Edit Terminal account profile" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.change(screen.getByLabelText("Profile name"), {
       target: { value: "Default" },
     });
@@ -1084,9 +1094,7 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(providerMocks.recolorProfileMutate).toHaveBeenCalledTimes(2);
     act(() => recolorOptions.onSuccess());
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Edit Terminal account profile" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
     await waitFor(() => {
       expect(providerMocks.startLoginMutate).toHaveBeenCalled();
@@ -1150,9 +1158,7 @@ describe("<ProvidersSettingsPanel />", () => {
       </TooltipProvider>,
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Edit Terminal account profile" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.change(screen.getByLabelText("Profile name"), {
       target: { value: "Unsaved name" },
     });
@@ -1161,9 +1167,7 @@ describe("<ProvidersSettingsPanel />", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Edit Terminal account profile" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     const reopenedNameInput = screen.getByLabelText("Profile name");
     if (!(reopenedNameInput instanceof HTMLInputElement)) {
       throw new Error("Expected profile name input");
@@ -1182,7 +1186,7 @@ describe("<ProvidersSettingsPanel />", () => {
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Work" }));
-    fireEvent.click(screen.getByRole("button", { name: "Edit Work profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
 
     const nameInput = screen.getByLabelText("Profile name");
     if (!(nameInput instanceof HTMLInputElement)) {
@@ -1244,9 +1248,7 @@ describe("<ProvidersSettingsPanel />", () => {
     );
     const { rerender } = render(renderSection("host-b"));
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Edit Terminal account profile" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.change(screen.getByLabelText("Profile name"), {
       target: { value: "Host B draft" },
     });
@@ -1699,7 +1701,7 @@ describe("<ProvidersSettingsPanel />", () => {
     );
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Work" }));
-    fireEvent.click(screen.getByRole("button", { name: "Edit Work profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
     await waitFor(() => {
       expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
@@ -1771,7 +1773,7 @@ describe("<ProvidersSettingsPanel />", () => {
     );
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Work, Signed out" }));
-    fireEvent.click(screen.getByRole("button", { name: "Edit Work profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
     await waitFor(() => {
       expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
@@ -1847,7 +1849,7 @@ describe("<ProvidersSettingsPanel />", () => {
 
     // Defaults to the ambient profile - select "Work" (signed out) first.
     fireEvent.click(screen.getByRole("menuitem", { name: "Work, Signed out" }));
-    fireEvent.click(screen.getByRole("button", { name: "Edit Work profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
 
     await waitFor(() => {
@@ -1991,7 +1993,7 @@ describe("<ProvidersSettingsPanel />", () => {
     );
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Work" }));
-    fireEvent.click(screen.getByRole("button", { name: "Edit Work profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
 
     await waitFor(() => {
@@ -2398,7 +2400,7 @@ describe("<ProvidersSettingsPanel />", () => {
     // Defaults to the ambient profile - select "Work" to bring its editable
     // details dialog (name field, actions) into view.
     fireEvent.click(screen.getByRole("menuitem", { name: "Work" }));
-    fireEvent.click(screen.getByRole("button", { name: "Edit Work profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.change(screen.getByLabelText("Profile name"), {
       target: { value: "Personal" },
     });
@@ -2413,7 +2415,7 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(typeof renameOptions.onSuccess).toBe("function");
     act(() => renameOptions.onSuccess());
 
-    fireEvent.click(screen.getByRole("button", { name: "Edit Work profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
     fireEvent.click(screen.getByRole("button", { name: "Remove profile" }));
     expect(
       screen.getByText(

--- a/clients/gui-app/src/components/settings/panels/provider-profile-scoped-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-profile-scoped-section.tsx
@@ -6,6 +6,7 @@ import {
   EyeOff,
   Plus,
   RefreshCw,
+  Settings2,
   Trash2,
   X,
 } from "lucide-react";
@@ -41,6 +42,7 @@ import {
   ProviderProfilesRefreshButton,
 } from "./provider-rate-limit-section";
 import { ProviderProfileReauthPanel } from "./provider-profile-reauth-panel";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import type { FailedProviderProfileAttempt } from "./add-provider-profile-dialog";
 import {
   duplicateProfileLabel,
@@ -152,9 +154,9 @@ export function ProviderProfileScopedSection(
           <div className="flex items-center gap-1">
             <Button
               type="button"
-              size="sm"
-              variant="ghost"
-              className="h-7 shrink-0 px-2 text-ui-xs"
+              size="xs"
+              variant="outline"
+              className="shrink-0"
               disabled={addProfileDisabled}
               title={addProfileDisabledReason}
               onClick={onAddProfile}
@@ -175,7 +177,6 @@ export function ProviderProfileScopedSection(
           activeProfileId={selectedProfileId}
           onSelectProfile={onSelectedProfileIdChange}
           onCreateProfile={onAddProfile}
-          onEditProfile={openProfileEditor}
           createProfileDisabled={addProfileDisabled}
           createProfileDisabledReason={addProfileDisabledReason}
           // ⌘⇧-digit isn't wired to Settings - no picker leader scope here.
@@ -183,10 +184,28 @@ export function ProviderProfileScopedSection(
           contentContainer={null}
           onCloseAutoFocus={null}
         />
-        <ProfileSummary
-          key={selectedProfile.profileId}
-          profile={selectedProfile}
-        />
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          <ProfileSummary
+            key={selectedProfile.profileId}
+            profile={selectedProfile}
+          />
+          <TooltipWrapper
+            label="Change the profile name and accent color, sign in again, or remove this profile."
+            side="bottom"
+            sideOffset={6}
+            align="end"
+          >
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              onClick={openProfileEditor}
+            >
+              <Settings2 data-icon="inline-start" />
+              Manage profile
+            </Button>
+          </TooltipWrapper>
+        </div>
 
         {addProfileDisabled ? (
           <p className="text-ui-xs text-muted-foreground">
@@ -273,7 +292,7 @@ function ProfileSummary({
     tier === null || tier === undefined || tier.length === 0 ? "No plan" : tier;
 
   return (
-    <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 text-ui-xs text-muted-foreground">
+    <div className="grid min-w-[75%] flex-1 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-2 text-ui-xs text-muted-foreground">
       <div className="flex min-w-0 items-center gap-1">
         <span className="min-w-0 truncate" title={email ?? undefined}>
           {emailText}


### PR DESCRIPTION
## Summary
- replace the profile-selector pencil action with compact outlined Add profile and Manage profile controls
- keep profile metadata and management on one responsive row, with a capability tooltip
- use the profile-card rate-limit layout for both single- and multi-profile providers
- move refresh to one provider-level action and keep per-profile loading independent
- add an outlined gauge-and-bars header trigger that stays visible at true 0% usage

## Verification
- focused provider settings and rate-limit component tests passed
- React Doctor reported no issues
- pre-commit passed Nx affected lint, format, compile, and build checks
- DCO sign-off hook passed