### PR TITLE
gui-app: self-explanatory Review warnings — unmerged-commit chips + per-reason tooltips

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-enrichment.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-enrichment.test.tsx
@@ -382,6 +382,8 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
       mergedHeadShaMatches: false,
       mergedIntoDefault: false,
       atPinnedCommit: false,
+      unmergedCommitCount: null,
+      unmergedCommitSubjects: null,
     };
     const coldEntry: WorktreeHostEntryV12 = {
       ...enrichedEntry("/wt/a", "feat-a"),

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -19,7 +19,10 @@ import { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream
 import type { WorktreeDeleteStreamCallbacks } from "@traycer-clients/shared/host-transport/worktree-delete-stream-client";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/index";
-import type { WorktreeEntryScripts } from "@traycer/protocol/host/worktree-schemas";
+import type {
+  WorktreeEntryScripts,
+  WorktreeSubmoduleMergeFactV12,
+} from "@traycer/protocol/host/worktree-schemas";
 import {
   hostStreamRpcRegistry,
   type HostStreamRpcRegistry,
@@ -207,12 +210,25 @@ function stubOpenStreamTransport() {
   };
 }
 
+type WorktreeSubmoduleMergeFactInput = Omit<
+  WorktreeSubmoduleMergeFactV12,
+  "unmergedCommitCount" | "unmergedCommitSubjects"
+> &
+  Partial<
+    Pick<
+      WorktreeSubmoduleMergeFactV12,
+      "unmergedCommitCount" | "unmergedCommitSubjects"
+    >
+  >;
+
 function entry(
-  over: Partial<WorktreeHostEntryV12> & {
+  over: Partial<Omit<WorktreeHostEntryV12, "submodules">> & {
     worktreePath: string;
     branch: string;
+    submodules?: readonly WorktreeSubmoduleMergeFactInput[];
   },
 ): WorktreeHostEntryV12 {
+  const { submodules, ...rest } = over;
   return {
     repoLabel: "acme/app",
     repoIdentifier: { owner: "acme", repo: "app" },
@@ -230,9 +246,14 @@ function entry(
     prNumber: null,
     prUrl: null,
     mergedHeadShaMatches: false,
-    submodules: [],
+    submodules:
+      submodules?.map((submodule) => ({
+        ...submodule,
+        unmergedCommitCount: submodule.unmergedCommitCount ?? null,
+        unmergedCommitSubjects: submodule.unmergedCommitSubjects ?? null,
+      })) ?? [],
     atBaseCommit: false,
-    ...over,
+    ...rest,
   };
 }
 
@@ -402,9 +423,15 @@ describe("useWorktreeListing", () => {
           "worktree.listAllForHost": (params) => {
             requests.push(params);
             if (params.cursor === null) {
-              return { worktrees: [first], nextCursor: first.worktreePath };
+              return {
+                worktrees: [first],
+                nextCursor: first.worktreePath,
+              };
             }
-            return { worktrees: [second], nextCursor: null };
+            return {
+              worktrees: [second],
+              nextCursor: null,
+            };
           },
         },
       }),
@@ -459,7 +486,10 @@ describe("useWorktreeListing", () => {
           "worktree.listAllForHost": (params) => {
             if (params.cursor === null) {
               firstPageCalls += 1;
-              return { worktrees: [first], nextCursor: first.worktreePath };
+              return {
+                worktrees: [first],
+                nextCursor: first.worktreePath,
+              };
             }
             secondPageCalls += 1;
             throw new Error("host unreachable");
@@ -2161,7 +2191,126 @@ describe("WorktreesList v1.2 signals", () => {
     expect(
       screen.queryByRole("link", { name: "Open cold-sub PR #15" }),
     ).toBeNull();
-    screen.getByText("none-sub · unmerged");
+    screen.getByText("none-sub · unmerged commits");
+  });
+
+  it("explains unmerged submodule commits with a count and newest subjects", async () => {
+    const submodule: WorktreeSubmoduleMergeFactV12 = {
+      repoIdentifier: { owner: "acme", repo: "traycer" },
+      branch: "traycer/feature",
+      prState: "none",
+      prNumber: null,
+      prUrl: null,
+      mergedHeadShaMatches: false,
+      mergedIntoDefault: false,
+      atPinnedCommit: false,
+      unmergedCommitCount: 7,
+      unmergedCommitSubjects: [
+        "Newest change",
+        "Fourth change",
+        "Third change",
+        "Second change",
+        "First change",
+      ],
+    };
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [
+        entry({
+          worktreePath: "/wt/unmerged",
+          branch: "feat-unmerged",
+          submodules: [submodule],
+        }),
+      ],
+      taskTitlesByEpicId: undefined,
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      onVisiblePathsChange: undefined,
+    });
+
+    const chip = screen.getByTestId("worktree-pr-chip");
+    screen.getByText("traycer · 7 unmerged commits");
+    fireEvent.pointerMove(chip);
+    expect(
+      (
+        await screen.findAllByText(
+          "This submodule branch has commits that never landed on traycer's main branch. Deleting the worktree deletes the branch and these commits with it:",
+        )
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Newest change").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("First change").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("…and 2 more").length).toBeGreaterThan(0);
+  });
+
+  it("lists every Review reason once activity enrichment is available", async () => {
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [
+        entry({
+          worktreePath: "/wt/review-reasons",
+          branch: "feat-review",
+          uncommittedCount: 2,
+          branchStatus: { ahead: 2, behind: 0, mergedIntoDefault: false },
+          submodules: [
+            {
+              repoIdentifier: { owner: "acme", repo: "lib" },
+              branch: "traycer/lib",
+              prState: "none",
+              prNumber: null,
+              prUrl: null,
+              mergedHeadShaMatches: false,
+              mergedIntoDefault: false,
+              atPinnedCommit: false,
+              unmergedCommitCount: 3,
+              unmergedCommitSubjects: ["Newest"],
+            },
+          ],
+        }),
+      ],
+      taskTitlesByEpicId: undefined,
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      onVisiblePathsChange: undefined,
+    });
+
+    fireEvent.pointerMove(screen.getByTestId("worktree-tier-pill"));
+    expect(
+      (await screen.findAllByText("2 uncommitted changes")).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("acme/lib (traycer/lib): 3 unmerged commits").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("keeps the generic Review tooltip before activity enrichment", async () => {
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [
+        entry({
+          worktreePath: "/wt/review-fallback",
+          branch: "feat-review",
+          uncommittedCount: 1,
+          branchStatus: null,
+        }),
+      ],
+      taskTitlesByEpicId: undefined,
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      onVisiblePathsChange: undefined,
+    });
+
+    fireEvent.pointerMove(screen.getByTestId("worktree-tier-pill"));
+    expect(
+      (
+        await screen.findAllByText(
+          "Not proven safe to remove: it has uncommitted changes, unmerged or unpushed commits, an unmerged submodule branch, a detached HEAD, or unknown branch status. Review before deleting.",
+        )
+      ).length,
+    ).toBeGreaterThan(0);
   });
 
   it("hides PR facts from the row facts line now that chips carry the links", () => {

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -50,6 +50,7 @@ import {
   WORKTREE_TIER_TOOLTIP,
   classifyWorktree,
   classifyWorktreeTier,
+  describeReviewReasons,
   type WorktreeTier,
 } from "@traycer-clients/shared/worktree/classify-worktree";
 import {
@@ -2005,7 +2006,11 @@ const WorktreeRow = memo(function WorktreeRow(props: {
       </div>
       <div className="min-w-0 flex-1 space-y-1 pr-10">
         <div className="flex flex-wrap items-center gap-2">
-          <WorktreeTierPill tier={classification.tier} state={enrichment} />
+          <WorktreeTierPill
+            entry={entry}
+            tier={classification.tier}
+            state={enrichment}
+          />
           <WorktreePrChips entry={entry} />
           <span className="truncate text-ui-sm font-medium text-foreground">
             {branchLabel(entry)}
@@ -2056,6 +2061,7 @@ const WorktreeRow = memo(function WorktreeRow(props: {
  * amber; `orphaned` and `in-use` stay neutral.
  */
 function WorktreeTierPill(props: {
+  readonly entry: WorktreeHostEntryV12;
   readonly tier: WorktreeTier;
   readonly state: WorktreeEnrichmentState;
 }): ReactNode {
@@ -2115,9 +2121,23 @@ function WorktreeTierPill(props: {
     );
   }
   const style = WORKTREE_TIER_PILL_STYLE[props.tier];
+  const reviewReasons =
+    props.tier === "review" && props.entry.branchStatus !== null
+      ? describeReviewReasons(props.entry)
+      : [];
+  const tooltip =
+    reviewReasons.length === 0 ? (
+      WORKTREE_TIER_TOOLTIP[props.tier]
+    ) : (
+      <div className="max-w-[min(90vw,24rem)] space-y-1">
+        {reviewReasons.map((reason) => (
+          <p key={reason}>{reason}</p>
+        ))}
+      </div>
+    );
   return (
     <TooltipWrapper
-      label={WORKTREE_TIER_TOOLTIP[props.tier]}
+      label={tooltip}
       side="top"
       sideOffset={undefined}
       align="center"
@@ -2210,6 +2230,7 @@ interface WorktreePrChipModel {
 interface WorktreeMutedPrChipModel {
   readonly key: string;
   readonly label: string;
+  readonly tooltip: ReactNode;
 }
 
 function WorktreePrChips(props: {
@@ -2289,10 +2310,37 @@ function submoduleUnmergedChip(
   ) {
     return [];
   }
+  const count = submodule.unmergedCommitCount ?? null;
+  const subjects = submodule.unmergedCommitSubjects ?? null;
   return [
     {
       key: `submodule-unmerged:${submodule.repoIdentifier.owner}/${submodule.repoIdentifier.repo}:${submodule.branch}`,
-      label: `${submodule.repoIdentifier.repo} · unmerged`,
+      label:
+        count !== null && count >= 1
+          ? `${submodule.repoIdentifier.repo} · ${count} unmerged commit${count === 1 ? "" : "s"}`
+          : `${submodule.repoIdentifier.repo} · unmerged commits`,
+      tooltip: (
+        <div className="max-w-[min(90vw,24rem)] space-y-1.5">
+          <p>
+            This submodule branch has commits that never landed on{" "}
+            {submodule.repoIdentifier.repo}'s main branch. Deleting the worktree
+            deletes the branch and these commits with it
+            {subjects === null ? "." : ":"}
+          </p>
+          {subjects === null ? null : (
+            <>
+              <ul className="list-inside list-disc">
+                {subjects.map((subject) => (
+                  <li key={subject}>{subject}</li>
+                ))}
+              </ul>
+              {count !== null && count > subjects.length ? (
+                <p>…and {count - subjects.length} more</p>
+              ) : null}
+            </>
+          )}
+        </div>
+      ),
     },
   ];
 }
@@ -2360,16 +2408,23 @@ function WorktreeMutedPrChip(props: {
   readonly chip: WorktreeMutedPrChipModel;
 }): ReactNode {
   return (
-    <Badge
-      variant="outline"
-      className="gap-1 border-border/40 bg-muted/30 font-medium text-muted-foreground"
-      data-testid="worktree-pr-chip"
-      data-pr-state="unmerged"
+    <TooltipWrapper
+      label={props.chip.tooltip}
+      side="top"
+      sideOffset={undefined}
+      align="center"
     >
-      <span className="max-w-[min(60vw,16rem)] truncate">
-        {props.chip.label}
-      </span>
-    </Badge>
+      <Badge
+        variant="outline"
+        className="gap-1 border-border/40 bg-muted/30 font-medium text-muted-foreground"
+        data-testid="worktree-pr-chip"
+        data-pr-state="unmerged"
+      >
+        <span className="max-w-[min(60vw,16rem)] truncate">
+          {props.chip.label}
+        </span>
+      </Badge>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -2312,6 +2312,15 @@ function submoduleUnmergedChip(
   }
   const count = submodule.unmergedCommitCount ?? null;
   const subjects = submodule.unmergedCommitSubjects ?? null;
+  // Subjects are display-only and NOT unique ("wip", "Merge branch …" repeat),
+  // so key each by its occurrence ordinal - unique without leaning on the
+  // array index (react/no-array-index-key).
+  const occurrences = new Map<string, number>();
+  const subjectItems = (subjects ?? []).map((subject) => {
+    const ordinal = (occurrences.get(subject) ?? 0) + 1;
+    occurrences.set(subject, ordinal);
+    return { key: `${subject}#${ordinal}`, subject };
+  });
   return [
     {
       key: `submodule-unmerged:${submodule.repoIdentifier.owner}/${submodule.repoIdentifier.repo}:${submodule.branch}`,
@@ -2330,8 +2339,8 @@ function submoduleUnmergedChip(
           {subjects === null ? null : (
             <>
               <ul className="list-inside list-disc">
-                {subjects.map((subject) => (
-                  <li key={subject}>{subject}</li>
+                {subjectItems.map((item) => (
+                  <li key={item.key}>{item.subject}</li>
                 ))}
               </ul>
               {count !== null && count > subjects.length ? (

--- a/clients/gui-app/src/lib/worktree/__tests__/task-merge-rollup.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/task-merge-rollup.test.ts
@@ -34,6 +34,8 @@ function submodule(
     mergedHeadShaMatches: false,
     mergedIntoDefault: false,
     atPinnedCommit: false,
+    unmergedCommitCount: null,
+    unmergedCommitSubjects: null,
     ...over,
   };
 }

--- a/clients/shared/worktree/__tests__/classify-worktree.test.ts
+++ b/clients/shared/worktree/__tests__/classify-worktree.test.ts
@@ -662,6 +662,17 @@ describe("provenRemovable - single green / bulk-eligible predicate", () => {
 });
 
 describe("describeReviewReasons", () => {
+  it("names a closed superproject PR instead of the generic fallback", () => {
+    expect(
+      describeReviewReasons(
+        entry({
+          prState: "closed",
+          branchStatus: status({ ahead: 2, mergedIntoDefault: false }),
+        }),
+      ),
+    ).toEqual(["Superproject PR was closed without merging"]);
+  });
+
   it("names the never-pushed shape: no PR, no upstream, not contained", () => {
     // The gui-agent-cli-env fleet shape: clean tree, local-only commits, no PR
     // ever, branch never pushed (`ahead: null`). Falling back to the generic

--- a/clients/shared/worktree/__tests__/classify-worktree.test.ts
+++ b/clients/shared/worktree/__tests__/classify-worktree.test.ts
@@ -8,6 +8,7 @@ import {
   WORKTREE_TIER_ORDER,
   classifyWorktree,
   classifyWorktreeTier,
+  describeReviewReasons,
   provenRemovable,
   worktreeTierRank,
   type WorktreeTier,
@@ -38,6 +39,8 @@ function subFact(
     mergedHeadShaMatches: false,
     mergedIntoDefault: false,
     atPinnedCommit: false,
+    unmergedCommitCount: null,
+    unmergedCommitSubjects: null,
     ...over,
   };
 }
@@ -655,5 +658,78 @@ describe("provenRemovable - single green / bulk-eligible predicate", () => {
         greens.has(classifyWorktreeTier(sample)),
       );
     }
+  });
+});
+
+describe("describeReviewReasons", () => {
+  it("names the never-pushed shape: no PR, no upstream, not contained", () => {
+    // The gui-agent-cli-env fleet shape: clean tree, local-only commits, no PR
+    // ever, branch never pushed (`ahead: null`). Falling back to the generic
+    // tier help here hid the highest-stakes warning - these commits exist
+    // nowhere else.
+    expect(
+      describeReviewReasons(
+        entry({
+          prState: "none",
+          branchStatus: status({ ahead: null, mergedIntoDefault: false }),
+        }),
+      ),
+    ).toEqual([
+      "Commits with no PR that were never pushed - they exist only in this worktree",
+    ]);
+  });
+
+  it("returns every applicable dirty, submodule, and superproject reason", () => {
+    expect(
+      describeReviewReasons(
+        entry({
+          uncommittedCount: 2,
+          prState: "open",
+          branchStatus: status({ ahead: 3 }),
+          submodules: [
+            subFact({
+              branch: "traycer/lib",
+              prState: "none",
+              unmergedCommitCount: 4,
+              unmergedCommitSubjects: ["Newest"],
+            }),
+          ],
+        }),
+      ),
+    ).toEqual([
+      "2 uncommitted changes",
+      "acme/lib (traycer/lib): 4 unmerged commits",
+      "Superproject PR is open",
+    ]);
+  });
+
+  it("describes each submodule state and the remaining superproject blockers", () => {
+    expect(
+      describeReviewReasons(
+        entry({
+          prState: "merged",
+          mergedHeadShaMatches: false,
+          owners: [owner("epic-1")],
+          branchStatus: status({ ahead: 0 }),
+          submodules: [
+            subFact({ branch: "open", prState: "open" }),
+            subFact({ branch: "cold", prState: null }),
+          ],
+        }),
+      ),
+    ).toEqual([
+      "acme/lib (open): PR is open",
+      "acme/lib (cold): still checking merge status",
+      "Merged PR does not cover the current HEAD",
+      "Referenced by a Task at the upstream tip",
+    ]);
+  });
+
+  it("is empty for every non-review tier", () => {
+    expect(
+      describeReviewReasons(
+        entry({ prState: "merged", mergedHeadShaMatches: true }),
+      ),
+    ).toEqual([]);
   });
 });

--- a/clients/shared/worktree/classify-worktree.ts
+++ b/clients/shared/worktree/classify-worktree.ts
@@ -176,6 +176,57 @@ export function classifyWorktreeTier(
 }
 
 /**
+ * Specific, non-exclusive blockers for a Review row. Kept separate from the
+ * tier classifier: the ladder still picks one tier, while this reports every
+ * contributing risk the user should inspect.
+ */
+export function describeReviewReasons(
+  entry: WorktreeHostEntryV12,
+): readonly string[] {
+  if (classifyWorktreeTier(entry) !== "review") return [];
+  const status = entry.branchStatus;
+  return [
+    ...(entry.uncommittedCount > 0
+      ? [
+          `${entry.uncommittedCount} uncommitted change${entry.uncommittedCount === 1 ? "" : "s"}`,
+        ]
+      : []),
+    ...(entry.branch === null ? ["Detached HEAD"] : []),
+    ...entry.submodules
+      .filter((fact) => !submoduleMergeProven(fact))
+      .map(describeUnprovenSubmodule),
+    ...(entry.prState === "merged" && !entry.mergedHeadShaMatches
+      ? ["Merged PR does not cover the current HEAD"]
+      : []),
+    ...(entry.prState === "open" ? ["Superproject PR is open"] : []),
+    ...(entry.prState === "none" &&
+    status !== null &&
+    status.ahead !== null &&
+    status.ahead > 0
+      ? [
+          `No PR for ${status.ahead} unmerged commit${status.ahead === 1 ? "" : "s"}`,
+        ]
+      : []),
+    // `ahead === null` = no upstream to diff against: the branch was never
+    // pushed (or its remote ref is gone), so its unmerged commits are not
+    // recoverable from anywhere else - the highest-stakes Review shape, and it
+    // must say so rather than fall back to the generic tier help.
+    ...(entry.prState === "none" &&
+    status !== null &&
+    status.ahead === null &&
+    !status.mergedIntoDefault
+      ? [
+          "Commits with no PR that were never pushed - they exist only in this worktree",
+        ]
+      : []),
+    ...(entry.prState === null ? ["Checking merge status…"] : []),
+    ...(status !== null && status.ahead === 0 && entry.owners.length > 0
+      ? ["Referenced by a Task at the upstream tip"]
+      : []),
+  ];
+}
+
+/**
  * A single owned-submodule branch is proven merged the same two ways the
  * superproject greens, plus the submodule-specific at-pin proof: a
  * HEAD-validated merged PR (`prState === "merged"` with the host's live-HEAD
@@ -186,6 +237,23 @@ export function classifyWorktreeTier(
 function submoduleMergeProven(fact: WorktreeSubmoduleMergeFactV12): boolean {
   if (fact.prState === "merged" && fact.mergedHeadShaMatches) return true;
   return fact.mergedIntoDefault || fact.atPinnedCommit;
+}
+
+function describeUnprovenSubmodule(
+  fact: WorktreeSubmoduleMergeFactV12,
+): string {
+  const name = `${fact.repoIdentifier.owner}/${fact.repoIdentifier.repo} (${fact.branch})`;
+  if (fact.unmergedCommitCount !== null && fact.unmergedCommitCount >= 1) {
+    return `${name}: ${fact.unmergedCommitCount} unmerged commit${fact.unmergedCommitCount === 1 ? "" : "s"}`;
+  }
+  if (fact.prState === "open" || fact.prState === "closed") {
+    return `${name}: PR is ${fact.prState}`;
+  }
+  if (fact.prState === null) return `${name}: still checking merge status`;
+  if (fact.prState === "merged") {
+    return `${name}: merged PR does not cover the current HEAD`;
+  }
+  return `${name}: unmerged commits`;
 }
 
 /**

--- a/clients/shared/worktree/classify-worktree.ts
+++ b/clients/shared/worktree/classify-worktree.ts
@@ -199,6 +199,9 @@ export function describeReviewReasons(
       ? ["Merged PR does not cover the current HEAD"]
       : []),
     ...(entry.prState === "open" ? ["Superproject PR is open"] : []),
+    ...(entry.prState === "closed"
+      ? ["Superproject PR was closed without merging"]
+      : []),
     ...(entry.prState === "none" &&
     status !== null &&
     status.ahead !== null &&

--- a/protocol/src/host/__tests__/worktree-schemas.test.ts
+++ b/protocol/src/host/__tests__/worktree-schemas.test.ts
@@ -356,6 +356,8 @@ describe("worktreeListAllForHostResponseSchemaV12", () => {
               mergedHeadShaMatches: false,
               mergedIntoDefault: false,
               atPinnedCommit: true,
+              unmergedCommitCount: null,
+              unmergedCommitSubjects: null,
             },
           ],
         },
@@ -381,6 +383,8 @@ describe("worktreeListAllForHostResponseSchemaV12", () => {
                 prUrl: null,
                 mergedHeadShaMatches: false,
                 mergedIntoDefault: false,
+                unmergedCommitCount: null,
+                unmergedCommitSubjects: null,
               },
             ],
           },
@@ -410,6 +414,8 @@ describe("worktreeListAllForHostResponseSchemaV12", () => {
                 mergedHeadShaMatches: false,
                 mergedIntoDefault: false,
                 atPinnedCommit: true,
+                unmergedCommitCount: 7,
+                unmergedCommitSubjects: ["Newest", "Older"],
               },
             ],
           },
@@ -439,6 +445,96 @@ describe("worktreeListAllForHostResponseSchemaV12", () => {
         },
       ],
       nextCursor: null,
+    });
+  });
+});
+
+describe("worktreeListAllForHostResponseSchemaV12 unmerged commit details", () => {
+  it("requires nullable unmerged-commit display fields on submodule facts", () => {
+    const response = {
+      worktrees: [
+        {
+          ...v10Entry,
+          lastActivityAt: null,
+          owners: [],
+          branchStatus: null,
+          createdAt: null,
+          ...mergeProvenanceAbsent,
+          submodules: [
+            {
+              repoIdentifier: { owner: "acme", repo: "protocol" },
+              branch: "feature-x",
+              prState: "none" as const,
+              prNumber: null,
+              prUrl: null,
+              mergedHeadShaMatches: false,
+              mergedIntoDefault: false,
+              atPinnedCommit: false,
+              unmergedCommitCount: null,
+              unmergedCommitSubjects: null,
+            },
+          ],
+        },
+      ],
+      nextCursor: null,
+    };
+    expect(worktreeListAllForHostResponseSchemaV12.parse(response)).toEqual(
+      response,
+    );
+    expect(() =>
+      worktreeListAllForHostResponseSchemaV12.parse({
+        ...response,
+        worktrees: [
+          {
+            ...response.worktrees[0],
+            submodules: [
+              {
+                ...response.worktrees[0].submodules[0],
+                unmergedCommitCount: undefined,
+              },
+            ],
+          },
+        ],
+      }),
+    ).toThrow();
+  });
+
+  it("strips unmerged-commit display fields when parsed as a v1.1 peer", () => {
+    const parsed = worktreeListAllForHostResponseSchemaV11.parse({
+      worktrees: [
+        {
+          ...v10Entry,
+          lastActivityAt: null,
+          owners: [],
+          branchStatus: null,
+          createdAt: null,
+          ...mergeProvenanceAbsent,
+          submodules: [
+            {
+              repoIdentifier: { owner: "acme", repo: "protocol" },
+              branch: "feature-x",
+              prState: "none" as const,
+              prNumber: null,
+              prUrl: null,
+              mergedHeadShaMatches: false,
+              mergedIntoDefault: false,
+              atPinnedCommit: false,
+              unmergedCommitCount: 7,
+              unmergedCommitSubjects: ["Newest", "Older"],
+            },
+          ],
+        },
+      ],
+      nextCursor: null,
+    });
+    expect(parsed.worktrees[0]?.submodules[0]).toEqual({
+      repoIdentifier: { owner: "acme", repo: "protocol" },
+      branch: "feature-x",
+      prState: "none",
+      prNumber: null,
+      prUrl: null,
+      mergedHeadShaMatches: false,
+      mergedIntoDefault: false,
     });
   });
 });
@@ -542,7 +638,11 @@ describe("worktree.listAllForHost v1.0 <-> v1.2 negotiation", () => {
       V12,
       response,
     );
-    expect(upgraded.worktrees[0].submodules[0].atPinnedCommit).toBe(false);
+    expect(upgraded.worktrees[0].submodules[0]).toMatchObject({
+      atPinnedCommit: false,
+      unmergedCommitCount: null,
+      unmergedCommitSubjects: null,
+    });
     expect(worktreeListAllForHostResponseSchemaV12.parse(upgraded)).toEqual(
       upgraded,
     );
@@ -704,6 +804,8 @@ describe("worktreeSubmoduleMergeFactSchemaV12", () => {
       mergedHeadShaMatches: false,
       mergedIntoDefault: false,
       atPinnedCommit: true,
+      unmergedCommitCount: 2,
+      unmergedCommitSubjects: ["Newest", "Older"],
     };
     expect(worktreeSubmoduleMergeFactSchemaV12.parse(fact)).toEqual(fact);
     expect(() =>
@@ -715,6 +817,8 @@ describe("worktreeSubmoduleMergeFactSchemaV12", () => {
         prUrl: null,
         mergedHeadShaMatches: false,
         mergedIntoDefault: false,
+        unmergedCommitCount: null,
+        unmergedCommitSubjects: null,
       }),
     ).toThrow();
   });

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -508,6 +508,8 @@ export const worktreeListAllForHostUpgradeV11ToV12 = defineUpgradePath<
       submodules: entry.submodules.map((fact) => ({
         ...fact,
         atPinnedCommit: false,
+        unmergedCommitCount: null,
+        unmergedCommitSubjects: null,
       })),
     })),
     nextCursor: response.nextCursor,

--- a/protocol/src/host/worktree-schemas.ts
+++ b/protocol/src/host/worktree-schemas.ts
@@ -693,8 +693,8 @@ export type WorktreeSubmoduleMergeFact = z.infer<
 export const worktreeSubmoduleMergeFactSchemaV12 =
   worktreeSubmoduleMergeFactSchema.extend({
     atPinnedCommit: z.boolean(),
-    unmergedCommitCount: z.number().int().nullable(),
-    unmergedCommitSubjects: z.array(z.string()).nullable(),
+    unmergedCommitCount: z.number().int().nonnegative().nullable(),
+    unmergedCommitSubjects: z.array(z.string()).max(5).nullable(),
   });
 export type WorktreeSubmoduleMergeFactV12 = z.infer<
   typeof worktreeSubmoduleMergeFactSchemaV12

--- a/protocol/src/host/worktree-schemas.ts
+++ b/protocol/src/host/worktree-schemas.ts
@@ -686,14 +686,20 @@ export type WorktreeSubmoduleMergeFact = z.infer<
  * v1.2 adds the submodule equivalent of `atBaseCommit`: the owned branch's live
  * checkout or resolved tip is exactly the superproject's pinned gitlink, so it
  * carries no committed work beyond what the superproject already references.
+ * It also carries a bounded, newest-first display summary of commits on an
+ * unproven branch that are absent from its default branch; `null` means the
+ * host did not compute that display detail.
  */
 export const worktreeSubmoduleMergeFactSchemaV12 =
   worktreeSubmoduleMergeFactSchema.extend({
     atPinnedCommit: z.boolean(),
+    unmergedCommitCount: z.number().int().nullable(),
+    unmergedCommitSubjects: z.array(z.string()).nullable(),
   });
 export type WorktreeSubmoduleMergeFactV12 = z.infer<
   typeof worktreeSubmoduleMergeFactSchemaV12
 >;
+
 
 /**
  * `worktree.listAllForHost` v1.1 entry. Adds the staleness signals the
@@ -768,6 +774,7 @@ export const worktreeHostEntrySchemaV12 = worktreeHostEntrySchemaV11.extend({
   submodules: z.array(worktreeSubmoduleMergeFactSchemaV12),
 });
 export type WorktreeHostEntryV12 = z.infer<typeof worktreeHostEntrySchemaV12>;
+
 
 /**
  * `worktree.listAllForHost` v1.1 request. Adds `includeActivity`: the git
@@ -851,6 +858,7 @@ export const worktreeListAllForHostRequestSchemaV12 =
 export type WorktreeListAllForHostRequestV12 =
   WorktreeListAllForHostRequestV11;
 
+
 /**
  * `worktree.listAllForHost` v1.1 response. Same `worktrees` field, enriched
  * entry shape ({@link worktreeHostEntrySchemaV11}), plus `nextCursor` for the
@@ -875,6 +883,7 @@ export const worktreeListAllForHostResponseSchemaV12 = z.object({
 export type WorktreeListAllForHostResponseV12 = z.infer<
   typeof worktreeListAllForHostResponseSchemaV12
 >;
+
 
 /**
  * Returns `null` when no row exists yet so a fresh terminal-agent


### PR DESCRIPTION
## Problem

Two opaque warnings in Settings ▸ Worktrees. The muted `<repo> · unmerged` chip tells the user nothing about WHAT is unmerged or what deleting would lose, and the Review tier pill's tooltip is a generic catch-all ("uncommitted changes, unmerged or unpushed commits, an unmerged submodule branch, a detached HEAD, or unknown branch status") that never says which of those actually applies to the row.

## Change

- **Wire (v1.2 amended in place — verified unreleased; latest release host-v1.1.6 predates it; released v1.0/v1.1 shapes untouched)**: the submodule merge fact gains nullable `unmergedCommitCount` and `unmergedCommitSubjects` (newest-first, capped at 5). The v1.1→v1.2 upgrade path defaults both to null; v1.1 peers strip them (pinned by tests). The host computes them only for unproven facts — exactly the rows that render the chip.
- **Unmerged chip**: copy becomes `<repo> · N unmerged commits` (plain fallback `<repo> · unmerged commits` against older hosts), with a tooltip that explains the stake — "This submodule branch has commits that never landed on <repo>'s main branch. Deleting the worktree deletes the branch and these commits with it:" — followed by the commit subjects and "…and N more".
- **Review pill reasons**: new `describeReviewReasons(entry)` in the shared classifier mirrors the evidence ladder and lists every contributing blocker (uncommitted count, detached HEAD, each unproven submodule with why, merged-PR-not-covering-HEAD, open PR, no-PR-with-N-unmerged-commits, the never-pushed shape — "Commits with no PR that were never pushed - they exist only in this worktree" — checking-in-progress, referenced-at-tip). The Review pill tooltip renders these, falling back to the generic tier help until enrichment lands.

## Tests

Protocol: v1.2 fields nullable + upgrade-path null defaults + v1.1 peer strip. Classifier: per-scenario reason coverage incl. multi-reason rows and the never-pushed shape. Panel: chip copy/tooltip with count+subjects, fallback copy when null, no chip for proven facts; Review tooltip reasons + generic fallback. All targeted suites, compile, lint, format, changed-scope react-doctor green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)