### PR TITLE
feat(desktop): expose Chromium CDP port in dev by default

### DIFF
--- a/clients/desktop/scripts/dev/dev-main.cjs
+++ b/clients/desktop/scripts/dev/dev-main.cjs
@@ -42,7 +42,34 @@ const childEnv = {
 
 delete childEnv.ELECTRON_RUN_AS_NODE;
 
-const child = spawn(electronBin, [workspaceRoot], {
+// Expose a Chromium remote-debugging (CDP) endpoint on loopback so browser
+// automation (the Playwright MCP) can attach to the live app window. This is
+// the dev-only runner and the port stays bound to 127.0.0.1, so the open
+// endpoint is a local affordance. On by default so `make dev-desktop` is
+// drivable without remembering a flag; set the port to "off" (or "0") to
+// disable it, or to another value to avoid a clash when two desktop slots run
+// at once. Kept at a fixed default because the Playwright MCP's static
+// `--cdp-endpoint` can't chase a per-slot port.
+const remoteDebuggingSetting =
+  process.env.TRAYCER_DESKTOP_REMOTE_DEBUGGING_PORT ?? "9222";
+const remoteDebuggingPort =
+  remoteDebuggingSetting === "off" || remoteDebuggingSetting === "0"
+    ? null
+    : remoteDebuggingSetting;
+
+const electronArgs = [];
+if (remoteDebuggingPort !== null) {
+  electronArgs.push(`--remote-debugging-port=${remoteDebuggingPort}`);
+  // Chromium rejects DevTools WebSocket upgrades whose Origin header isn't
+  // allowlisted; Playwright's connectOverCDP sends one, so permit any origin.
+  electronArgs.push("--remote-allow-origins=*");
+  console.log(
+    `[dev-main] CDP endpoint at http://127.0.0.1:${remoteDebuggingPort} - Playwright can attach`,
+  );
+}
+electronArgs.push(workspaceRoot);
+
+const child = spawn(electronBin, electronArgs, {
   cwd: workspaceRoot,
   env: childEnv,
   stdio: "inherit",


### PR DESCRIPTION
## What

The dev runner (`scripts/dev/dev-main.cjs`) spawns Electron with no remote-debugging port. That leaves browser automation — e.g. the Playwright MCP — with no way to drive the running app: a plain browser can't render the app at all because the Electron preload bridge (`window.runnerHost`) is absent, and there's no CDP endpoint to attach to the real window.

This defaults a Chromium remote-debugging (CDP) endpoint **on** in the dev runner, bound to loopback, so `make dev-desktop` is drivable out of the box.

## Details

- Adds `--remote-debugging-port` (+ `--remote-allow-origins=*`, required for Playwright's `connectOverCDP` origin check) to the dev-only Electron spawn.
- Port comes from `TRAYCER_DESKTOP_REMOTE_DEBUGGING_PORT`, defaulting to `9222`. Set it to another port to avoid a clash when running two desktop slots at once, or to `off`/`0` to disable.
- Fixed default (rather than a per-slot port) because a static CDP client can't chase a dynamically-allocated port.
- Dev-only and loopback-bound, so the open endpoint is a local affordance — consistent with the existing opt-in host `--inspect`.

## Test plan

- `make dev-desktop` → `curl http://127.0.0.1:9222/json/list` shows the `Traycer` app window as a CDP target; a Playwright client attaches to the real window (preload present) and can send a chat message end-to-end.
- `TRAYCER_DESKTOP_REMOTE_DEBUGGING_PORT=off make dev-desktop` → no port opened.