### PR TITLE
fix(gui-app): stop chat find counting a phantom unit per user message

### DIFF
--- a/clients/gui-app/AGENTS.md
+++ b/clients/gui-app/AGENTS.md
@@ -256,6 +256,17 @@ adding fields, actions, or selectors.
 - Start in `src/components/command-palette/` for the dialog shell, chips, pin
   toggle, and sub-page rendering.
 
+## Testing Philosophy
+
+- Prefer end-to-end tests that run as much of the real machinery as possible
+  (real filesystem, real watchers, real docs/stores) over isolated unit tests.
+  Most bugs live in the seams between layers, and an end-to-end test also fails
+  when an underlying unit is wrong — its capture group is strictly larger.
+- Fake only true external boundaries (network, cloud services) or sources of
+  nondeterminism.
+- Unit tests are acceptable for isolated logic, but treat them as a supplement,
+  never as the reason to skip exercising the integrated path.
+
 ## Testing Notes
 
 - Tests use Testing Library role queries, so semantic markup and accessible

--- a/clients/gui-app/src/components/chat/__tests__/chat-find-projection.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-find-projection.test.ts
@@ -3,6 +3,7 @@ import "../../../../__tests__/test-browser-apis";
 import { describe, expect, it } from "vitest";
 import {
   buildChatFindRows,
+  chatFindMessageContentUnitId,
   chatFindSegmentUnitId,
   chatFindSubagentBodyUnitId,
   chatFindSubagentHeaderUnitId,
@@ -12,6 +13,7 @@ import {
 import { derivePromotedSubagentRenderId } from "@/components/chat/chat-collapsible-key";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
+  ApprovalSegment,
   ChatMessage as ChatMessageModel,
   MessageSegment,
 } from "@/stores/composer/chat-store";
@@ -421,47 +423,46 @@ describe("chat find projection", () => {
     expect(rowSearchText(row)).not.toContain("Hidden heading");
   });
 
-  it("indexes the approval header label only (verdict + toolName), never the body-only description, at both projection sites", () => {
+  it("indexes a resolved approval's header label only (verdict + toolName), never the body-only description", () => {
     const toolName = "run_command";
     const descriptionOnly = "delete the production database";
-    const approval = (id: string): MessageSegment => ({
+    const approval = (
+      id: string,
+      decision: ApprovalSegment["decision"],
+    ): MessageSegment => ({
       id,
       kind: "approval",
       toolName,
       description: descriptionOnly,
       inputSummary: null,
       inputDetail: null,
-      decision: { approved: false, reason: null },
+      decision,
     });
-    // Top-level approval projection (segmentSearchText): a non-assistant message
-    // routes its segments straight through segmentSearchUnits.
-    const topLevel: ChatMessageModel = {
-      ...makeMessage(20, "user"),
-      content: "",
-      segments: [approval("approval-top")],
-    };
-    // Activity-group-child approval projection
-    // (activityGroupChildHeaderSearchText): a resolved approval on an assistant
-    // turn folds into an activity group.
+    // A resolved approval on an assistant turn folds into an activity group and
+    // renders one child-header row (activityGroupChildHeaderSearchText). A
+    // pending approval is suppressed from the transcript entirely, so this header
+    // is the only place an approval's text is findable.
     const grouped: ChatMessageModel = {
       ...makeMessage(21, "assistant"),
-      segments: [approval("approval-grouped")],
+      segments: [
+        approval("approval-grouped", { approved: false, reason: null }),
+      ],
     };
 
-    const joined = buildChatFindRows([topLevel, grouped], TILE_INSTANCE_ID)
+    const joined = buildChatFindRows([grouped], TILE_INSTANCE_ID)
       .map((row) => rowSearchText(row))
       .join("\n");
 
-    // Both rendered headers index the toolName label, so it stays findable at
-    // both sites (one match per header, no group-summary noise).
-    expect(countOccurrences(joined, toolName)).toBe(2);
+    // The rendered header indexes the toolName label exactly once - the activity
+    // group summary must not also index it (that would double-count).
+    expect(countOccurrences(joined, toolName)).toBe(1);
 
     // The verdict is part of the rendered header too, so it remains findable.
-    expect(countOccurrences(joined, "Denied")).toBeGreaterThanOrEqual(2);
+    expect(joined).toContain("Denied");
 
     // The description lives only in the unanchored approval body
-    // (bodyFindUnitId=null). Before the fix both projection sites indexed it,
-    // counting a phantom match that can never paint; it must now find nothing.
+    // (bodyFindUnitId=null), so indexing it would count a phantom match that can
+    // never paint; it must find nothing.
     expect(joined).not.toContain(descriptionOnly);
   });
 
@@ -554,6 +555,115 @@ describe("chat find projection", () => {
     // body - expanding the card reveals the notice alongside it.
     expect(noticeUnit?.owningChain).toEqual(bodyUnit?.owningChain);
     expect(noticeUnit?.owningChain).toHaveLength(1);
+  });
+
+  // A regular user message renders its whole body as ONE anchor
+  // (message:{id}:content) via UserMessageBody - it never renders per-segment
+  // anchors. Real user messages also carry a `text` segment mirroring their
+  // content, so also projecting that segment double-counts every match with a
+  // phantom that can never paint (the Cmd+F "N matches shows N+1" bug).
+  it("projects a plain-content user message with a mirrored text segment as a single content unit", () => {
+    const user: ChatMessageModel = {
+      ...makeMessage(30, "user"),
+      content: "confirm the app is working",
+      segments: [
+        {
+          id: "user-text-0",
+          kind: "text",
+          markdown: "confirm the app is working",
+          isStreaming: false,
+        },
+      ],
+    };
+
+    const row = buildChatFindRows([user], TILE_INSTANCE_ID)[0];
+
+    expect(row.units.map((unit) => unit.unitId)).toEqual([
+      chatFindMessageContentUnitId(user.id),
+    ]);
+    // "app" renders once, so the projection must count it exactly once.
+    expect(countOccurrences(rowSearchText(row), "app")).toBe(1);
+  });
+
+  it("projects a structured-content user message as a single content unit despite mirroring text segments", () => {
+    const user: ChatMessageModel = {
+      ...makeMessage(31, "user"),
+      content: "",
+      structuredContent: {
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "align the search bar" }],
+          },
+        ],
+      },
+      segments: [
+        {
+          id: "user-text-1",
+          kind: "text",
+          markdown: "align the search bar",
+          isStreaming: false,
+        },
+      ],
+    };
+
+    const row = buildChatFindRows([user], TILE_INSTANCE_ID)[0];
+
+    expect(row.units.map((unit) => unit.unitId)).toEqual([
+      chatFindMessageContentUnitId(user.id),
+    ]);
+    expect(countOccurrences(rowSearchText(row), "search")).toBe(1);
+  });
+
+  // Guard the fix's scope: assistant turns render per-segment anchors, so their
+  // segments must still each project a unit (both "app" occurrences count).
+  it("still projects assistant text segments per-segment (fix is scoped to non-assistant messages)", () => {
+    const assistant: ChatMessageModel = {
+      ...makeMessage(32, "assistant"),
+      segments: [
+        {
+          id: "assistant-text-0",
+          kind: "text",
+          markdown: "the app renders the app",
+          isStreaming: false,
+        },
+      ],
+    };
+
+    const row = buildChatFindRows([assistant], TILE_INSTANCE_ID)[0];
+
+    expect(row.units.map((unit) => unit.unitId)).toEqual([
+      chatFindSegmentUnitId("assistant-text-0"),
+    ]);
+    expect(countOccurrences(rowSearchText(row), "app")).toBe(2);
+  });
+
+  // Guard the fix's exception: a synthesized single-special-segment row
+  // (setup-card / forked-chat-link) renders that segment's OWN anchor and no
+  // content block, so the projection must keep emitting the segment unit.
+  it("still projects a synthesized single forked-chat-link segment as its own unit", () => {
+    const synthesized: ChatMessageModel = {
+      ...makeMessage(33, "system"),
+      content: "",
+      segments: [
+        {
+          id: "forked-1",
+          kind: "forked-chat-link",
+          viewTabId: "view-tab-1",
+          sourceChatId: "source-chat-1",
+          sourceChatTitle: "Legacy Thread",
+          sourceHostId: "host-1",
+        },
+      ],
+    };
+
+    const row = buildChatFindRows([synthesized], TILE_INSTANCE_ID)[0];
+
+    expect(row.units.map((unit) => unit.unitId)).toEqual([
+      chatFindSegmentUnitId("forked-1"),
+    ]);
+    expect(rowSearchText(row)).toContain("Forked from Legacy Thread");
   });
 });
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -35,6 +35,7 @@ import {
 import {
   chatFindA2AReceivedBodyUnitId,
   chatFindActivityGroupChildHeaderUnitId,
+  chatFindMessageContentUnitId,
   chatFindSegmentUnitId,
   chatFindSubagentBodyUnitId,
   chatFindSubagentHeaderUnitId,
@@ -460,6 +461,45 @@ describe("ChatMessages Virtuoso renderer", () => {
     const activeRow =
       activeRange?.startContainer.parentElement?.closest(MESSAGE_ROW_SELECTOR);
     expect(activeRow?.getAttribute("data-message-id")).toBe("message-0");
+  });
+
+  it("counts a user message with a mirrored text segment once, matching its single rendered anchor", async () => {
+    const registry = installMockHighlights();
+    // Real user messages carry a `text` segment mirroring their content, but the
+    // user body renders the whole content as ONE anchor (message:{id}:content)
+    // with no per-segment anchors. The end-to-end find pipeline must therefore
+    // report exactly one match and paint it - not a phantom N+1 from the
+    // never-rendered text-segment unit.
+    const message: ChatMessageModel = {
+      ...makeMessage(0, "user"),
+      content: "confirm the needle is working",
+      segments: [
+        {
+          id: "user-text-0",
+          kind: "text",
+          markdown: "confirm the needle is working",
+          isStreaming: false,
+        },
+      ],
+    };
+    renderChatMessagesWithTileFind(
+      [message],
+      makeDefaultOpts({ minimapItems: minimapItemsFor([message]) }),
+    );
+
+    await waitForChatFindAdapter();
+    searchChat("needle");
+
+    await waitFor(() => {
+      expect(lastChatFindSnapshot()?.exactHighlight).toBe("painted");
+    });
+
+    expect(lastChatFindSnapshot()?.total).toBe(1);
+    expect(lastChatFindSnapshot()?.activeUnitId).toBe(
+      chatFindMessageContentUnitId(message.id),
+    );
+    // Count matches paint: the single rendered occurrence is the only highlight.
+    expect(totalPaintedRanges(registry)).toBe(1);
   });
 
   it("paints activity-group header matches inside content-bearing trigger buttons", async () => {

--- a/clients/gui-app/src/components/chat/chat-find-projection.ts
+++ b/clients/gui-app/src/components/chat/chat-find-projection.ts
@@ -158,6 +158,19 @@ function chatFindUnitsForMessage(
     ]);
   }
 
+  // A synthesized row whose single segment is a setup-card / forked-chat-link
+  // renders that segment's own find anchor and no content block (mirrors
+  // renderSingleSpecialSegment in chat-message.tsx), so index the segment.
+  const specialSegment = singleSpecialSegment(message.segments);
+  if (specialSegment !== null) {
+    return segmentSearchUnits(specialSegment, tileInstanceId);
+  }
+
+  // Every other user/system message renders its whole body as ONE anchor
+  // (message:{id}:content) via UserMessageBody - never per-segment anchors. Its
+  // `text` segments mirror that content, so also projecting them would
+  // double-count every match with a phantom unit that has no anchor to paint.
+  // Project the content unit alone so the count matches what actually renders.
   const contentText =
     message.structuredContent === null
       ? message.content
@@ -168,10 +181,21 @@ function chatFindUnitsForMessage(
       text: contentText,
       owningChain: [],
     }),
-    ...message.segments.flatMap((segment) =>
-      segmentSearchUnits(segment, tileInstanceId),
-    ),
   ]);
+}
+
+// Mirror renderSingleSpecialSegment (chat-message.tsx): a row whose single
+// segment is a setup-card or forked-chat-link renders that segment directly with
+// its own find anchor, bypassing the user/system content block.
+function singleSpecialSegment(
+  segments: ReadonlyArray<MessageSegment>,
+): MessageSegment | null {
+  if (segments.length !== 1) return null;
+  const segment = segments[0];
+  if (segment.kind === "setup-card" || segment.kind === "forked-chat-link") {
+    return segment;
+  }
+  return null;
 }
 
 function timelineItemSearchUnits(

--- a/clients/gui-app/src/components/chat/chat-find-projection.ts
+++ b/clients/gui-app/src/components/chat/chat-find-projection.ts
@@ -15,6 +15,7 @@ import {
   adjacentDedupedProgressItems,
   cleanSubagentNotificationText,
 } from "@/components/chat/segments/subagent-display";
+import { singleSpecialSegment } from "@/components/chat/chat-special-segment";
 import { parseTraycerNextStepsMarkdown } from "@/markdown/traycer-next-steps";
 import { composerClipboardPlainText } from "@/lib/composer/composer-clipboard";
 import { artifactOperationVerb } from "@/lib/chat/artifact-operation-verb";
@@ -159,8 +160,9 @@ function chatFindUnitsForMessage(
   }
 
   // A synthesized row whose single segment is a setup-card / forked-chat-link
-  // renders that segment's own find anchor and no content block (mirrors
-  // renderSingleSpecialSegment in chat-message.tsx), so index the segment.
+  // renders that segment's own find anchor and no content block (the render side
+  // is renderSingleSpecialSegment in chat-message.tsx; both key off the shared
+  // singleSpecialSegment predicate), so index the segment.
   const specialSegment = singleSpecialSegment(message.segments);
   if (specialSegment !== null) {
     return segmentSearchUnits(specialSegment, tileInstanceId);
@@ -182,20 +184,6 @@ function chatFindUnitsForMessage(
       owningChain: [],
     }),
   ]);
-}
-
-// Mirror renderSingleSpecialSegment (chat-message.tsx): a row whose single
-// segment is a setup-card or forked-chat-link renders that segment directly with
-// its own find anchor, bypassing the user/system content block.
-function singleSpecialSegment(
-  segments: ReadonlyArray<MessageSegment>,
-): MessageSegment | null {
-  if (segments.length !== 1) return null;
-  const segment = segments[0];
-  if (segment.kind === "setup-card" || segment.kind === "forked-chat-link") {
-    return segment;
-  }
-  return null;
 }
 
 function timelineItemSearchUnits(

--- a/clients/gui-app/src/components/chat/chat-message.tsx
+++ b/clients/gui-app/src/components/chat/chat-message.tsx
@@ -5,6 +5,7 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { AssistantMessageBody } from "./chat-message-assistant-body";
 import { chatFindSegmentUnitId } from "./chat-find";
+import { singleSpecialSegment } from "./chat-special-segment";
 import { UserMessageBody } from "./chat-message-user-body";
 import { ForkedChatLinkSegment } from "./segments/forked-chat-link-segment";
 import { SetupCardSegment } from "./segments/setup-card-segment";
@@ -99,8 +100,8 @@ function messageAlignmentClass(message: ChatMessageModel): string {
 function renderSingleSpecialSegment(
   message: ChatMessageModel,
 ): ReactElement | null {
-  if (message.segments.length !== 1) return null;
-  const segment = message.segments[0];
+  const segment = singleSpecialSegment(message.segments);
+  if (segment === null) return null;
   if (segment.kind === "setup-card") {
     return (
       <div

--- a/clients/gui-app/src/components/chat/chat-special-segment.ts
+++ b/clients/gui-app/src/components/chat/chat-special-segment.ts
@@ -1,0 +1,18 @@
+import type { MessageSegment } from "@/stores/composer/chat-store";
+
+// A synthesized row whose single segment is a setup-card / forked-chat-link
+// renders that segment directly - its own card and its own find anchor -
+// instead of a normal message body. Both the renderer
+// (renderSingleSpecialSegment in chat-message.tsx) and the find projection
+// (chatFindUnitsForMessage in chat-find-projection.ts) key off this shape, so it
+// lives in one place to keep them from drifting.
+export function singleSpecialSegment(
+  segments: ReadonlyArray<MessageSegment>,
+): MessageSegment | null {
+  if (segments.length !== 1) return null;
+  const segment = segments[0];
+  if (segment.kind === "setup-card" || segment.kind === "forked-chat-link") {
+    return segment;
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Chat Cmd+F search counted a **phantom match for every occurrence inside a user message**: the find bar showed `N+1` for `N` visible matches, and the cyclical Next/Prev navigation had a dead stop that highlighted nothing. Only GUI chats were affected.

## Why

Find runs two independent scanners: the **count** comes from a projected list of "units" (built from the message model), and the **paint** walks the real DOM anchors (`data-chat-find-unit`). They only stay consistent if each projected unit maps 1:1 to a rendered anchor.

A regular user message renders its whole body as a **single** `message:{id}:content` anchor (`UserMessageBody`) — never per-segment anchors. But `chatFindUnitsForMessage` emitted the content unit **plus** a unit per `text` segment, and a user message's `text` segment mirrors its content. So every match inside a user message was counted twice: once on the content unit (paintable) and once on the never-rendered segment unit (a phantom). Assistant turns were unaffected because they project per-timeline-item units that each have a real anchor.

## The fix

Project non-assistant (user/system) messages as the **content unit alone**, mirroring what `UserMessageBody` renders. Synthesized single-segment rows (setup-card / forked-chat-link) still project their own segment anchor — mirroring `renderSingleSpecialSegment`.

## Tests

- **Projection cases** (`chat-find-projection.test.ts`): plain-content and structured-content user messages with a mirrored text segment now project a single content unit; assistant per-segment projection and the synthesized forked-chat-link row are guarded so the fix stays scoped.
- **End-to-end** (`chat-messages.test.tsx`): renders the real `ChatMessages` list wrapped in `TileFindContext`, drives search through the real store → controller → adapter → projection → paint, and asserts the reported `total` equals the paintable DOM occurrences (fails `2 → 1` before the fix).
- **Approval projection test** rewritten: it had used a *user-message* approval (a phantom that never renders) as a vehicle to reach `segmentSearchText`; it now exercises the approval's real render site (a resolved approval folded into an activity group), keeping the guarantee that the approval body/description is never indexed.
- Also records the end-to-end-first testing philosophy in `clients/gui-app/AGENTS.md`.

## Verified live

In `make dev-desktop`, searching `app` in a chat now reports `total: 2` matching 2 paintable DOM occurrences (was 3), and the cycle steps `1 → 2 → wraps to 1` with every stop on a real highlight.

## Test plan

- `bun run --cwd clients/gui-app test` (find + chat-messages suites green)
- `bun run --cwd clients/gui-app compile`
- Manual: open a GUI chat, Cmd+F a word that appears once in your message — expect `1 of 1`, no empty stop when cycling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
