### PR TITLE
Align Traycer usage accounts with provider profile cards

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -62,6 +62,7 @@ type MockState = {
   }>;
   results: Record<string, QueryResult>;
   draining: boolean;
+  traycerUsageFetching: boolean;
   openSettings: Mock<(...args: unknown[]) => void>;
   enqueue: Mock<(...args: unknown[]) => Promise<void>>;
   authUser: MockAuthUser;
@@ -94,6 +95,7 @@ const mocks = vi.hoisted<MockState>(() => ({
   configured: [],
   results: {},
   draining: false,
+  traycerUsageFetching: false,
   openSettings: vi.fn(),
   enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
   lastUseHostQueriesOptions: null,
@@ -166,7 +168,12 @@ function mockUseHostQueriesImpl(args: {
     );
   }
   return args.requests.map((request) => {
-    if (!("providerId" in request.params)) return readyResult(null);
+    if (!("providerId" in request.params)) {
+      return {
+        ...readyResult(null),
+        isFetching: mocks.traycerUsageFetching,
+      };
+    }
     return (
       mocks.results[
         resultKey(request.params.providerId, request.params.profileId)
@@ -479,6 +486,7 @@ beforeEach(() => {
   mocks.configured = [];
   mocks.results = {};
   mocks.draining = false;
+  mocks.traycerUsageFetching = false;
   mocks.openSettings = vi.fn();
   mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
   mocks.lastUseHostQueriesOptions = null;
@@ -1316,6 +1324,23 @@ describe("<RateLimitPopover /> Refresh all", () => {
     expect(screen.getByTestId("usage-limit-refreshing-dots")).toBeTruthy();
     const refreshAll = screen.getByRole("button", { name: "Refresh all" });
     expect(refreshAll.getAttribute("disabled")).not.toBeNull();
+  });
+
+  it("keeps the Traycer card refreshing while account usage refetches", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO", withTeam: false }),
+    );
+    mocks.traycerUsageFetching = true;
+
+    renderPopover();
+
+    expect(screen.getByText("Refreshing")).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: "Refresh all" })
+        .getAttribute("disabled"),
+    ).not.toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -63,6 +63,7 @@ type MockState = {
   results: Record<string, QueryResult>;
   draining: boolean;
   traycerUsageFetching: boolean;
+  traycerUsageUpdatedAt: number;
   openSettings: Mock<(...args: unknown[]) => void>;
   enqueue: Mock<(...args: unknown[]) => Promise<void>>;
   authUser: MockAuthUser;
@@ -96,6 +97,7 @@ const mocks = vi.hoisted<MockState>(() => ({
   results: {},
   draining: false,
   traycerUsageFetching: false,
+  traycerUsageUpdatedAt: 0,
   openSettings: vi.fn(),
   enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
   lastUseHostQueriesOptions: null,
@@ -172,6 +174,7 @@ function mockUseHostQueriesImpl(args: {
       return {
         ...readyResult(null),
         isFetching: mocks.traycerUsageFetching,
+        dataUpdatedAt: mocks.traycerUsageUpdatedAt,
       };
     }
     return (
@@ -487,6 +490,7 @@ beforeEach(() => {
   mocks.results = {};
   mocks.draining = false;
   mocks.traycerUsageFetching = false;
+  mocks.traycerUsageUpdatedAt = 0;
   mocks.openSettings = vi.fn();
   mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
   mocks.lastUseHostQueriesOptions = null;
@@ -1341,6 +1345,18 @@ describe("<RateLimitPopover /> Refresh all", () => {
         .getByRole("button", { name: "Refresh all" })
         .getAttribute("disabled"),
     ).not.toBeNull();
+  });
+
+  it("uses account usage freshness for a rate-limit-based Traycer card", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO", withTeam: false }),
+    );
+    mocks.traycerUsageUpdatedAt = NOW - 1_000;
+
+    renderPopover();
+
+    expect(screen.getByText("Just now")).toBeTruthy();
   });
 });
 

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -1581,37 +1581,56 @@ describe("<RateLimitPopover /> Traycer tab", () => {
     ]);
   });
 
-  it("shows the subscription detail with an account picker on the Traycer tab", () => {
+  it("shows one subscription card per Traycer account and marks the active one", () => {
     mocks.configured = [];
     mocks.authUser = readyAuthUser(
       authUserFixture({ status: "PRO_V3", withTeam: true }),
     );
     renderPopover();
     fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
-    // Shared subscription view: plan credit breakdown (30 of 100).
+    // Shared subscription view: personal plan credit breakdown (30 of 100).
     expect(screen.getByText("$30.00 / $100.00")).toBeTruthy();
-    // Detail tab surfaces the same Personal/Team picker as the Settings card.
-    expect(screen.getByRole("combobox", { name: "Account" })).toBeTruthy();
-    // Plan/tier chip next to the name - the trailing "_V3" pricing-generation
-    // tag is stripped (matching Cloud UI's own Settings pages), so "PRO_V3"
-    // reads as "Pro", not "Pro V3".
+    expect(
+      screen.getByRole("button", { name: "Use Personal account" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Use acme account" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("combobox", { name: "Account" })).toBeNull();
+    const activeCards = document.querySelectorAll('[aria-current="true"]');
+    expect(activeCards).toHaveLength(1);
+    expect(activeCards[0].textContent).toContain("Personal");
+    expect(screen.getByText("Active")).toBeTruthy();
+    // Plan chips live on their matching cards. The trailing "_V3"
+    // pricing-generation tag remains hidden.
     expect(screen.getByText("Pro")).toBeTruthy();
+    expect(screen.getByText("Ultra")).toBeTruthy();
   });
 
-  it("renders a condensed Traycer block with no picker or plan chip on Overview", () => {
+  it("renders Traycer account cards with active state on Overview", () => {
     mocks.configured = [];
     mocks.authUser = readyAuthUser(
       authUserFixture({ status: "PRO_V3", withTeam: true }),
     );
     renderPopover();
-    // Overview reflects the selected account's numbers, but exposes no controls.
+    // Overview now uses the same account-card structure as the Traycer detail tab.
     expect(screen.getByText("$30.00 / $100.00")).toBeTruthy();
     expect(screen.queryByRole("combobox", { name: "Account" })).toBeNull();
-    // Overview is condensed, same as the host-RPC providers' plan chip.
-    expect(screen.queryByText("Pro")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Use Personal account" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Use acme account" }),
+    ).toBeTruthy();
+    expect(screen.getByText("Pro")).toBeTruthy();
+    expect(screen.getByText("Ultra")).toBeTruthy();
+    expect(screen.getByText("Active")).toBeTruthy();
+    const activeCards = document.querySelectorAll('[aria-current="true"]');
+    expect(activeCards).toHaveLength(1);
+    expect(activeCards[0].textContent).toContain("Personal");
   });
 
-  it("reflects the selected account's own plan in the chip, not the personal account's", () => {
+  it("marks the selected team card active while retaining every account's plan", () => {
     mocks.configured = [];
     mocks.authUser = readyAuthUser(
       authUserFixture({ status: "PRO_V3", withTeam: true }),
@@ -1623,11 +1642,30 @@ describe("<RateLimitPopover /> Traycer tab", () => {
     });
     renderPopover();
     fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
-    // "ULTRA_1X_V3" reads as the bare "Ultra" tier name (matching
-    // `subscriptionPlanLabel`'s own tier-name mapping), not the personal
-    // account's "Pro".
+    const activeCards = document.querySelectorAll('[aria-current="true"]');
+    expect(activeCards).toHaveLength(1);
+    expect(activeCards[0].textContent).toContain("acme");
     expect(screen.getByText("Ultra")).toBeTruthy();
-    expect(screen.queryByText("Pro")).toBeNull();
+    expect(screen.getByText("Pro")).toBeTruthy();
+  });
+
+  it("switches the active Traycer account from its profile card", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "PRO_V3", withTeam: true }),
+    );
+    renderPopover();
+    fireEvent.click(screen.getByRole("tab", { name: "Traycer Inference" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Use acme account" }));
+
+    expect(useAccountContextStore.getState().accountContext).toEqual({
+      type: "TEAM",
+      teamId: "team-1",
+    });
+    const activeCards = document.querySelectorAll('[aria-current="true"]');
+    expect(activeCards).toHaveLength(1);
+    expect(activeCards[0].textContent).toContain("acme");
   });
 
   it("refetches the subscription from the Traycer tab's refresh button", () => {

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -16,7 +16,10 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import {
+  DEFAULT_ACCOUNT_CONTEXT,
+  type AccountContext,
+} from "@traycer/protocol/common/schemas";
 import type { ProviderRateLimits } from "@traycer/protocol/host";
 import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
@@ -140,20 +143,36 @@ vi.mock("@/hooks/host/use-host-provider-rate-limits-query", () => ({
 // production passes is irrelevant to this fixture-backed double.
 function mockUseHostQueriesImpl(args: {
   requests: ReadonlyArray<{
-    params: { providerId: string; profileId: string | null };
+    params:
+      | { providerId: string; profileId: string | null }
+      | { accountContext: AccountContext; profileId: null };
   }>;
-  options: { retry: boolean | undefined } | null;
+  options: { retry: boolean | undefined } | { enabled: boolean } | null;
 }) {
-  mocks.lastUseHostQueriesOptions = args.options;
-  mocks.lastUseHostQueriesProviderIds = args.requests.map(
-    (request) => request.params.providerId,
+  const providerRequests = args.requests.filter(
+    (
+      request,
+    ): request is {
+      params: { providerId: string; profileId: string | null };
+    } => "providerId" in request.params,
   );
-  return args.requests.map(
-    (request) =>
+  if (providerRequests.length > 0) {
+    mocks.lastUseHostQueriesOptions =
+      args.options !== null && "retry" in args.options
+        ? { retry: args.options.retry }
+        : null;
+    mocks.lastUseHostQueriesProviderIds = providerRequests.map(
+      (request) => request.params.providerId,
+    );
+  }
+  return args.requests.map((request) => {
+    if (!("providerId" in request.params)) return readyResult(null);
+    return (
       mocks.results[
         resultKey(request.params.providerId, request.params.profileId)
-      ] ?? readyResult(null),
-  );
+      ] ?? readyResult(null)
+    );
+  });
 }
 vi.mock("@/hooks/host/use-host-queries", () => ({
   useHostQueries: mockUseHostQueriesImpl,
@@ -432,8 +451,8 @@ function readyAuthUser(data: AuthenticatedUser): MockAuthUser {
   };
 }
 
-function traycerUsageQueryKey() {
-  return queryKeys.hostTraycerRateLimitUsage("host-1", DEFAULT_ACCOUNT_CONTEXT);
+function traycerUsageQueryKey(accountContext: AccountContext) {
+  return queryKeys.hostTraycerRateLimitUsage("host-1", accountContext);
 }
 
 let onClose: () => void;
@@ -1255,7 +1274,30 @@ describe("<RateLimitPopover /> Refresh all", () => {
 
     expect(authUser.refetch).toHaveBeenCalledTimes(1);
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: traycerUsageQueryKey(),
+      queryKey: traycerUsageQueryKey(DEFAULT_ACCOUNT_CONTEXT),
+      exact: true,
+    });
+  });
+
+  it("refreshes every rendered rate-limit-based Traycer account", () => {
+    mocks.configured = [];
+    const fixture = authUserFixture({ status: "PRO", withTeam: true });
+    const team = fixture.teamSubscriptions[0];
+    mocks.authUser = readyAuthUser({
+      ...fixture,
+      teamSubscriptions: [{ ...team, subscriptionStatus: "PRO" }],
+    });
+    const { client } = renderPopover();
+    const invalidateSpy = vi.spyOn(client, "invalidateQueries");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh all" }));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: traycerUsageQueryKey(DEFAULT_ACCOUNT_CONTEXT),
+      exact: true,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: traycerUsageQueryKey({ type: "TEAM", teamId: "team-1" }),
       exact: true,
     });
   });
@@ -1552,6 +1594,22 @@ describe("<RateLimitPopover /> Traycer tab", () => {
       "Overview",
       "Codex",
     ]);
+  });
+
+  it("keeps paid team accounts selectable when Personal is ineligible", () => {
+    mocks.configured = [];
+    mocks.authUser = readyAuthUser(
+      authUserFixture({ status: "FREE", withTeam: true }),
+    );
+
+    renderPopover();
+
+    expect(screen.getByRole("tab", { name: "Traycer Inference" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Use acme account" }));
+    expect(useAccountContextStore.getState().accountContext).toEqual({
+      type: "TEAM",
+      teamId: "team-1",
+    });
   });
 
   it("orders the Traycer tab per PROVIDER_ID_ORDER (after Codex, before Kilo Code)", () => {

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -34,6 +34,7 @@ import type {
   AvailableProviderRateLimits,
   ProviderRateLimitEnvelope,
 } from "@/lib/rate-limits/rate-limit-envelope";
+import { accountContextValue } from "@/lib/auth/traycer-subscription-content";
 import { queryKeys } from "@/lib/query-keys";
 
 type QueryResult = {
@@ -63,7 +64,7 @@ type MockState = {
   results: Record<string, QueryResult>;
   draining: boolean;
   traycerUsageFetching: boolean;
-  traycerUsageUpdatedAt: number;
+  traycerUsageUpdatedAt: Readonly<Record<string, number>>;
   openSettings: Mock<(...args: unknown[]) => void>;
   enqueue: Mock<(...args: unknown[]) => Promise<void>>;
   authUser: MockAuthUser;
@@ -97,7 +98,7 @@ const mocks = vi.hoisted<MockState>(() => ({
   results: {},
   draining: false,
   traycerUsageFetching: false,
-  traycerUsageUpdatedAt: 0,
+  traycerUsageUpdatedAt: {},
   openSettings: vi.fn(),
   enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
   lastUseHostQueriesOptions: null,
@@ -174,7 +175,10 @@ function mockUseHostQueriesImpl(args: {
       return {
         ...readyResult(null),
         isFetching: mocks.traycerUsageFetching,
-        dataUpdatedAt: mocks.traycerUsageUpdatedAt,
+        dataUpdatedAt:
+          mocks.traycerUsageUpdatedAt[
+            accountContextValue(request.params.accountContext)
+          ] ?? 0,
       };
     }
     return (
@@ -490,7 +494,7 @@ beforeEach(() => {
   mocks.results = {};
   mocks.draining = false;
   mocks.traycerUsageFetching = false;
-  mocks.traycerUsageUpdatedAt = 0;
+  mocks.traycerUsageUpdatedAt = {};
   mocks.openSettings = vi.fn();
   mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
   mocks.lastUseHostQueriesOptions = null;
@@ -1347,16 +1351,27 @@ describe("<RateLimitPopover /> Refresh all", () => {
     ).not.toBeNull();
   });
 
-  it("uses account usage freshness for a rate-limit-based Traycer card", () => {
+  it("keeps rate-limit usage freshness scoped to its Traycer account", () => {
     mocks.configured = [];
-    mocks.authUser = readyAuthUser(
-      authUserFixture({ status: "PRO", withTeam: false }),
-    );
-    mocks.traycerUsageUpdatedAt = NOW - 1_000;
+    const fixture = authUserFixture({ status: "PRO", withTeam: true });
+    const team = fixture.teamSubscriptions[0];
+    mocks.authUser = readyAuthUser({
+      ...fixture,
+      teamSubscriptions: [{ ...team, subscriptionStatus: "PRO" }],
+    });
+    mocks.traycerUsageUpdatedAt = {
+      [accountContextValue(DEFAULT_ACCOUNT_CONTEXT)]: NOW - 1_000,
+      [accountContextValue({ type: "TEAM", teamId: "team-1" })]: 0,
+    };
 
     renderPopover();
 
-    expect(screen.getByText("Just now")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Use Personal account" }).textContent,
+    ).toContain("Just now");
+    expect(
+      screen.getByRole("button", { name: "Use acme account" }).textContent,
+    ).toContain("stale");
   });
 });
 

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -582,9 +582,12 @@ interface TraycerRefreshTarget {
   readonly refetch: () => Promise<unknown>;
 }
 
-function useTraycerRateLimitUsageFetching(
+function useTraycerRateLimitUsageState(
   accountContexts: ReadonlyArray<AccountContext>,
-): boolean {
+): {
+  readonly isFetching: boolean;
+  readonly updatedAtByAccount: ReadonlyMap<string, number>;
+} {
   const client = useHostClient();
   const queries = useHostQueries<HostRpcRegistry, "host.getRateLimitUsage">({
     client,
@@ -596,7 +599,15 @@ function useTraycerRateLimitUsageFetching(
     // each rendered RateLimitView remains the enabled owner of its account pull.
     options: { enabled: false },
   });
-  return queries.some((query) => query.isFetching);
+  return {
+    isFetching: queries.some((query) => query.isFetching),
+    updatedAtByAccount: new Map(
+      accountContexts.map((accountContext, index) => [
+        accountContextValue(accountContext),
+        queries[index]?.dataUpdatedAt ?? 0,
+      ]),
+    ),
+  };
 }
 
 /**
@@ -628,7 +639,7 @@ function RateLimitRefreshAllButton({
   const queryClient = useQueryClient();
   const hostId = useReactiveActiveHostId();
   const client = useHostClient();
-  const traycerRateLimitUsageFetching = useTraycerRateLimitUsageFetching(
+  const traycerRateLimitUsageState = useTraycerRateLimitUsageState(
     traycerRefreshTarget.rateLimitAccountContexts,
   );
   const httpFetchProviders = providers.filter(
@@ -673,7 +684,7 @@ function RateLimitRefreshAllButton({
   });
   const traycerRefreshing =
     traycerRefreshTarget.enabled &&
-    (traycerRefreshTarget.isFetching || traycerRateLimitUsageFetching);
+    (traycerRefreshTarget.isFetching || traycerRateLimitUsageState.isFetching);
   const refreshing =
     draining ||
     httpFetchQueries.some((query) => query.isFetching) ||
@@ -1297,11 +1308,11 @@ function TraycerRateLimitBlock({
   }, [state.kind, onReady]);
 
   const overview = variant === "popover-overview";
-  const rateLimitUsageFetching = useTraycerRateLimitUsageFetching(
+  const rateLimitUsageState = useTraycerRateLimitUsageState(
     traycerSubscription.rateLimitAccountContexts,
   );
   const isRefreshing =
-    traycerSubscription.query.isFetching || rateLimitUsageFetching;
+    traycerSubscription.query.isFetching || rateLimitUsageState.isFetching;
   // Refetch the subscription and every rendered rate-limit account. Exact
   // invalidation targets only aperture `{ accountContext }` keys, never provider
   // `{ accountContext, providerId }` pulls.
@@ -1344,6 +1355,7 @@ function TraycerRateLimitBlock({
         personalSubscription={traycerSubscription.personalSubscription}
         activeAccountContext={traycerSubscription.resolvedAccountContext}
         updatedAt={traycerSubscription.query.dataUpdatedAt}
+        rateLimitUpdatedAtByAccount={rateLimitUsageState.updatedAtByAccount}
         refreshing={isRefreshing}
         onSelect={setAccountContext}
       />
@@ -1357,6 +1369,7 @@ function TraycerAccountCards({
   personalSubscription,
   activeAccountContext,
   updatedAt,
+  rateLimitUpdatedAtByAccount,
   refreshing,
   onSelect,
 }: {
@@ -1365,6 +1378,7 @@ function TraycerAccountCards({
   readonly personalSubscription: TraycerSubscription | null;
   readonly activeAccountContext: AccountContext;
   readonly updatedAt: number;
+  readonly rateLimitUpdatedAtByAccount: ReadonlyMap<string, number>;
   readonly refreshing: boolean;
   readonly onSelect: (accountContext: AccountContext) => void;
 }): ReactNode {
@@ -1434,7 +1448,9 @@ function TraycerAccountCards({
                 ) : null}
               </div>
               <ProfileUsageUpdatedLabel
-                updatedAt={updatedAt}
+                updatedAt={
+                  rateLimitUpdatedAtByAccount.get(account.key) ?? updatedAt
+                }
                 refreshing={refreshing}
               />
             </div>

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -1344,7 +1344,7 @@ function TraycerRateLimitBlock({
         personalSubscription={traycerSubscription.personalSubscription}
         activeAccountContext={traycerSubscription.resolvedAccountContext}
         updatedAt={traycerSubscription.query.dataUpdatedAt}
-        refreshing={traycerSubscription.query.isFetching}
+        refreshing={isRefreshing}
         onSelect={setAccountContext}
       />
     </div>

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { Gauge, Settings } from "lucide-react";
 import {
   DEFAULT_ACCOUNT_CONTEXT,
@@ -26,7 +26,10 @@ import {
 } from "@/components/settings/panels/provider-rate-limit-views";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
-import { useHostQueriesWithResponseMap } from "@/hooks/host/use-host-queries";
+import {
+  useHostQueries,
+  useHostQueriesWithResponseMap,
+} from "@/hooks/host/use-host-queries";
 import { providerRateLimitQueryOptions } from "@/hooks/host/provider-rate-limit-query-options";
 import {
   mapResponseToProviderRateLimitEnvelope,
@@ -118,20 +121,37 @@ function useTraycerSubscription() {
     storedAccountContext,
     teamIds,
   );
+  const personalSubscription = user?.userSubscription ?? null;
   const subscription = selectSubscription(user, resolvedAccountContext, teams);
-  const eligible = subscription !== null && isTraycerEligible(subscription);
-  const rateLimitBased =
-    subscription !== null &&
-    !isCreditBasedPricing(subscription.subscriptionStatus);
+  const accountSubscriptions = [
+    {
+      accountContext: PERSONAL_ACCOUNT_CONTEXT,
+      subscription: personalSubscription,
+    },
+    ...teams.map((team) => ({
+      accountContext: { type: "TEAM" as const, teamId: team.team.id },
+      subscription: team,
+    })),
+  ];
+  const eligible = accountSubscriptions.some(
+    (account) =>
+      account.subscription !== null && isTraycerEligible(account.subscription),
+  );
+  const rateLimitAccountContexts = accountSubscriptions
+    .filter(
+      (account) =>
+        account.subscription !== null &&
+        !isCreditBasedPricing(account.subscription.subscriptionStatus),
+    )
+    .map((account) => account.accountContext);
   return {
     query,
-    storedAccountContext,
     resolvedAccountContext,
     teams,
-    personalSubscription: user?.userSubscription ?? null,
+    personalSubscription,
     subscription,
     eligible,
-    rateLimitBased,
+    rateLimitAccountContexts,
   };
 }
 
@@ -283,8 +303,8 @@ function RateLimitPopoverBody({
         providers={providers}
         traycerRefreshTarget={{
           enabled: traycerSubscription.eligible,
-          accountContext: traycerSubscription.storedAccountContext,
-          rateLimitBased: traycerSubscription.rateLimitBased,
+          rateLimitAccountContexts:
+            traycerSubscription.rateLimitAccountContexts,
           isFetching: traycerSubscription.query.isFetching,
           refetch: traycerSubscription.query.refetch,
         }}
@@ -557,10 +577,26 @@ function RateLimitOverviewLoading(): ReactNode {
 
 interface TraycerRefreshTarget {
   readonly enabled: boolean;
-  readonly accountContext: AccountContext;
-  readonly rateLimitBased: boolean;
+  readonly rateLimitAccountContexts: ReadonlyArray<AccountContext>;
   readonly isFetching: boolean;
   readonly refetch: () => Promise<unknown>;
+}
+
+function useTraycerRateLimitUsageFetching(
+  accountContexts: ReadonlyArray<AccountContext>,
+): boolean {
+  const client = useHostClient();
+  const queries = useHostQueries<HostRpcRegistry, "host.getRateLimitUsage">({
+    client,
+    requests: accountContexts.map((accountContext) => ({
+      method: "host.getRateLimitUsage",
+      params: { accountContext, profileId: null },
+    })),
+    // Observe the exact shared query states without initiating a second fetch;
+    // each rendered RateLimitView remains the enabled owner of its account pull.
+    options: { enabled: false },
+  });
+  return queries.some((query) => query.isFetching);
 }
 
 /**
@@ -592,14 +628,9 @@ function RateLimitRefreshAllButton({
   const queryClient = useQueryClient();
   const hostId = useReactiveActiveHostId();
   const client = useHostClient();
-  const traycerRateLimitUsageFetching =
-    useIsFetching({
-      queryKey: queryKeys.hostTraycerRateLimitUsage(
-        hostId,
-        traycerRefreshTarget.accountContext,
-      ),
-      exact: true,
-    }) > 0;
+  const traycerRateLimitUsageFetching = useTraycerRateLimitUsageFetching(
+    traycerRefreshTarget.rateLimitAccountContexts,
+  );
   const httpFetchProviders = providers.filter(
     (provider) => provider.lane === "httpFetch",
   );
@@ -642,8 +673,7 @@ function RateLimitRefreshAllButton({
   });
   const traycerRefreshing =
     traycerRefreshTarget.enabled &&
-    (traycerRefreshTarget.isFetching ||
-      (traycerRefreshTarget.rateLimitBased && traycerRateLimitUsageFetching));
+    (traycerRefreshTarget.isFetching || traycerRateLimitUsageFetching);
   const refreshing =
     draining ||
     httpFetchQueries.some((query) => query.isFetching) ||
@@ -681,15 +711,17 @@ function RateLimitRefreshAllButton({
       });
     if (traycerRefreshTarget.enabled) {
       void traycerRefreshTarget.refetch();
-      if (traycerRefreshTarget.rateLimitBased) {
-        void queryClient.invalidateQueries({
-          queryKey: queryKeys.hostTraycerRateLimitUsage(
-            hostId,
-            traycerRefreshTarget.accountContext,
-          ),
-          exact: true,
-        });
-      }
+      traycerRefreshTarget.rateLimitAccountContexts.forEach(
+        (accountContext) => {
+          void queryClient.invalidateQueries({
+            queryKey: queryKeys.hostTraycerRateLimitUsage(
+              hostId,
+              accountContext,
+            ),
+            exact: true,
+          });
+        },
+      );
     }
     return Promise.resolve();
   };
@@ -1265,33 +1297,22 @@ function TraycerRateLimitBlock({
   }, [state.kind, onReady]);
 
   const overview = variant === "popover-overview";
-  const rateLimitUsageFetching =
-    useIsFetching({
-      queryKey: queryKeys.hostTraycerRateLimitUsage(
-        hostId,
-        traycerSubscription.storedAccountContext,
-      ),
-      exact: true,
-    }) > 0;
+  const rateLimitUsageFetching = useTraycerRateLimitUsageFetching(
+    traycerSubscription.rateLimitAccountContexts,
+  );
   const isRefreshing =
-    traycerSubscription.query.isFetching ||
-    (traycerSubscription.rateLimitBased && rateLimitUsageFetching);
-  // Refetch the subscription, and - only for rate-limit-based plans, whose
-  // aperture bar is live host data - invalidate that exact query so the mounted
-  // `RateLimitView` refetches it too. `exact: true` targets only the aperture
-  // `{ accountContext }` key, never the providers' `{ accountContext, providerId }`
-  // pulls (which a Traycer refresh can't have changed).
+    traycerSubscription.query.isFetching || rateLimitUsageFetching;
+  // Refetch the subscription and every rendered rate-limit account. Exact
+  // invalidation targets only aperture `{ accountContext }` keys, never provider
+  // `{ accountContext, providerId }` pulls.
   const refresh = async (): Promise<void> => {
     await traycerSubscription.query.refetch();
-    if (traycerSubscription.rateLimitBased) {
+    traycerSubscription.rateLimitAccountContexts.forEach((accountContext) => {
       void queryClient.invalidateQueries({
-        queryKey: queryKeys.hostTraycerRateLimitUsage(
-          hostId,
-          traycerSubscription.storedAccountContext,
-        ),
+        queryKey: queryKeys.hostTraycerRateLimitUsage(hostId, accountContext),
         exact: true,
       });
-    }
+    });
   };
 
   return (

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/rate-limits/rate-limit-envelope";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import type { RateLimitUnavailableReason } from "@traycer/protocol/host";
+import type { TraycerTeamSubscription } from "@traycer/protocol/auth";
 import type {
   ProviderId,
   ProviderProfile,
@@ -78,16 +79,13 @@ import {
   accountContextValue,
   isCreditBasedPricing,
   isTraycerEligible,
-  parseAccountContextValue,
   resolveTraycerSubscriptionState,
   selectSubscription,
   subscriptionPlanLabel,
+  type TraycerSubscription,
   type TraycerSubscriptionState,
 } from "@/lib/auth/traycer-subscription-content";
-import {
-  TraycerAccountSelect,
-  TraycerSubscriptionView,
-} from "@/components/settings/panels/traycer-subscription-views";
+import { TraycerSubscriptionView } from "@/components/settings/panels/traycer-subscription-views";
 import {
   useRateLimitPopoverStore,
   type RateLimitPopoverTab,
@@ -103,6 +101,8 @@ import { cn } from "@/lib/utils";
 type RailTabDescriptor =
   | { readonly kind: "provider"; readonly providerId: RateLimitProviderId }
   | { readonly kind: "traycer" };
+
+const PERSONAL_ACCOUNT_CONTEXT: AccountContext = { type: "PERSONAL" };
 
 function railTabProviderId(tab: RailTabDescriptor): ProviderId {
   return tab.kind === "traycer" ? "traycer" : tab.providerId;
@@ -128,6 +128,7 @@ function useTraycerSubscription() {
     storedAccountContext,
     resolvedAccountContext,
     teams,
+    personalSubscription: user?.userSubscription ?? null,
     subscription,
     eligible,
     rateLimitBased,
@@ -1235,12 +1236,11 @@ function RateLimitProviderBody({
  * NOT a `host.getRateLimitUsage` provider pull. Header mirrors the provider
  * blocks (name + plan/tier chip + "Updated Xm ago" + refresh) - the chip
  * (`subscriptionPlanLabel`) reflects whichever account is currently selected
- * and is single-provider-tab only, same scoping
- * `RateLimitProviderBlock` applies to its own plan chip; the detail variant
- * adds the same Personal/Team picker the Settings card uses, so switching
- * accounts here updates the global selection (and therefore Overview, the
- * Settings card, and what a Traycer run bills). Both variants render through
- * the shared `TraycerSubscriptionView`. `onReady` mirrors
+ * and is shown on each account card in the single-provider tab. The detail
+ * variant and Overview both render Personal/Team cards like the Codex and
+ * Claude profile cards; selecting a card updates the global account selection
+ * (and therefore Overview, the Settings card, and what a Traycer run bills).
+ * Both variants render through the shared `TraycerSubscriptionView`. `onReady` mirrors
  * `RateLimitProviderBlock`'s own - fires once `state.kind` moves past `cold`,
  * `null` on the single-provider detail tab.
  */
@@ -1276,17 +1276,6 @@ function TraycerRateLimitBlock({
   const isRefreshing =
     traycerSubscription.query.isFetching ||
     (traycerSubscription.rateLimitBased && rateLimitUsageFetching);
-  // Chip next to the name, single-provider tab only - same scoping
-  // `resolveProviderPlanLabel` uses for the host-RPC providers' plan chip.
-  // Reflects whichever account (personal/team) is currently selected, since
-  // `subscription` is already resolved against that selection.
-  const planLabel =
-    !overview && traycerSubscription.subscription !== null
-      ? subscriptionPlanLabel(
-          traycerSubscription.subscription.subscriptionStatus,
-        )
-      : null;
-
   // Refetch the subscription, and - only for rate-limit-based plans, whose
   // aperture bar is live host data - invalidate that exact query so the mounted
   // `RateLimitView` refetches it too. `exact: true` targets only the aperture
@@ -1315,22 +1304,8 @@ function TraycerRateLimitBlock({
           <span className="text-ui-sm font-medium text-foreground">
             {providerDisplayName("traycer")}
           </span>
-          {planLabel !== null ? (
-            <Badge variant="secondary" className="font-normal">
-              {planLabel}
-            </Badge>
-          ) : null}
         </div>
         <div className="flex items-center gap-1.5">
-          <UsageLimitUpdatedLabel
-            ready={state.kind === "ready"}
-            updatedAt={traycerSubscription.query.dataUpdatedAt}
-            refreshing={isRefreshing}
-            degraded={state.kind === "ready" && state.degraded}
-            // The Traycer aperture block's state (`resolveTraycerSubscriptionState`)
-            // has no transient-reason concept of its own - always the generic note.
-            degradedReason={null}
-          />
           {/* Overview has its own "Refresh all" on the rail (item 2 feedback);
               only the single-provider detail tab keeps this one. */}
           {!overview ? (
@@ -1342,29 +1317,123 @@ function TraycerRateLimitBlock({
           ) : null}
         </div>
       </div>
-      {/* Detail tab only: the account picker, matching the Settings card. Renders
-          nothing when the user has no teams. Overview just reflects the global
-          selection with no controls, like every other Overview block. */}
-      {!overview ? (
-        <TraycerAccountSelect
-          teams={traycerSubscription.teams}
-          value={accountContextValue(
-            traycerSubscription.resolvedAccountContext,
-          )}
-          onValueChange={(value) =>
-            setAccountContext(parseAccountContextValue(value))
-          }
-        />
-      ) : null}
-      <TraycerRateLimitBody state={state} />
+      <TraycerAccountCards
+        state={state}
+        teams={traycerSubscription.teams}
+        personalSubscription={traycerSubscription.personalSubscription}
+        activeAccountContext={traycerSubscription.resolvedAccountContext}
+        updatedAt={traycerSubscription.query.dataUpdatedAt}
+        refreshing={traycerSubscription.query.isFetching}
+        onSelect={setAccountContext}
+      />
+    </div>
+  );
+}
+
+function TraycerAccountCards({
+  state,
+  teams,
+  personalSubscription,
+  activeAccountContext,
+  updatedAt,
+  refreshing,
+  onSelect,
+}: {
+  readonly state: TraycerSubscriptionState;
+  readonly teams: readonly TraycerTeamSubscription[];
+  readonly personalSubscription: TraycerSubscription | null;
+  readonly activeAccountContext: AccountContext;
+  readonly updatedAt: number;
+  readonly refreshing: boolean;
+  readonly onSelect: (accountContext: AccountContext) => void;
+}): ReactNode {
+  if (state.kind !== "ready") {
+    return (
+      <TraycerRateLimitBody
+        state={state}
+        accountContext={activeAccountContext}
+      />
+    );
+  }
+
+  const accounts = [
+    {
+      key: accountContextValue(PERSONAL_ACCOUNT_CONTEXT),
+      label: "Personal",
+      accountContext: PERSONAL_ACCOUNT_CONTEXT,
+      subscription: personalSubscription,
+    },
+    ...teams.map((team) => ({
+      key: accountContextValue({ type: "TEAM", teamId: team.team.id }),
+      label: team.team.slug,
+      accountContext: { type: "TEAM" as const, teamId: team.team.id },
+      subscription: team,
+    })),
+  ];
+  return (
+    <div className="flex flex-col gap-2">
+      {accounts.map((account) => {
+        if (account.subscription === null) return null;
+        const active =
+          accountContextValue(activeAccountContext) === account.key;
+        return (
+          <button
+            key={account.key}
+            type="button"
+            onClick={() => onSelect(account.accountContext)}
+            aria-current={active ? "true" : undefined}
+            aria-label={`Use ${account.label} account`}
+            className={cn(
+              "flex w-full flex-col gap-2 rounded-lg border border-border/60 bg-background/40 p-2 text-left transition-colors hover:border-border hover:bg-accent/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60",
+              active && "border-primary/60 bg-primary/5",
+            )}
+          >
+            <div className="min-w-0">
+              <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                <AccentDot
+                  profileId={account.key}
+                  accentColor={null}
+                  label={null}
+                  variant="inline"
+                  size="default"
+                  className={undefined}
+                />
+                <span className="min-w-0 truncate text-ui-sm font-medium text-foreground">
+                  {account.label}
+                </span>
+                <Badge variant="secondary" className="font-normal">
+                  {subscriptionPlanLabel(
+                    account.subscription.subscriptionStatus,
+                  )}
+                </Badge>
+                {active ? (
+                  <Badge variant="outline" className="font-normal">
+                    Active
+                  </Badge>
+                ) : null}
+              </div>
+              <ProfileUsageUpdatedLabel
+                updatedAt={updatedAt}
+                refreshing={refreshing}
+              />
+            </div>
+            <TraycerSubscriptionView
+              subscription={account.subscription}
+              accountContext={account.accountContext}
+            />
+          </button>
+        );
+      })}
     </div>
   );
 }
 
 function TraycerRateLimitBody({
   state,
+  accountContext,
 }: {
   readonly state: TraycerSubscriptionState;
+  readonly accountContext: AccountContext;
 }): ReactNode {
   switch (state.kind) {
     case "cold":
@@ -1382,7 +1451,10 @@ function TraycerRateLimitBody({
     case "ready":
       return (
         <div className={cn(state.degraded && "opacity-60")}>
-          <TraycerSubscriptionView subscription={state.subscription} />
+          <TraycerSubscriptionView
+            subscription={state.subscription}
+            accountContext={accountContext}
+          />
         </div>
       );
   }

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
@@ -13,6 +13,7 @@
 import { ExternalLink } from "lucide-react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { AuthenticatedUser } from "@traycer/protocol/auth";
+import type { AccountContext } from "@traycer/protocol/common/schemas";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import {
@@ -86,7 +87,11 @@ export function TraycerSubscriptionSection() {
         }
       />
 
-      <SubscriptionBody query={query} subscription={subscription} />
+      <SubscriptionBody
+        query={query}
+        subscription={subscription}
+        accountContext={resolved}
+      />
     </div>
   );
 }
@@ -94,9 +99,11 @@ export function TraycerSubscriptionSection() {
 function SubscriptionBody({
   query,
   subscription,
+  accountContext,
 }: {
   readonly query: UseQueryResult<AuthenticatedUser | null>;
   readonly subscription: TraycerSubscription | null;
+  readonly accountContext: AccountContext;
 }) {
   if (query.isPending) {
     return (
@@ -119,5 +126,10 @@ function SubscriptionBody({
       </div>
     );
   }
-  return <TraycerSubscriptionView subscription={subscription} />;
+  return (
+    <TraycerSubscriptionView
+      subscription={subscription}
+      accountContext={accountContext}
+    />
+  );
 }

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-views.tsx
@@ -11,7 +11,7 @@
  * and credits"). Unlike `ProviderRateLimitDetail`, it is NOT
  * variant-parameterized: the Traycer body has no per-model / extra-window rows
  * to drop, so the Overview-vs-detail difference is purely the surrounding
- * chrome (the account picker, the "Manage subscription" link), which each
+ * chrome (account cards or picker, the "Manage subscription" link), which each
  * caller composes around this body. Each bucket (Plan/Bonus/Bundle/Artifacts)
  * renders through `CreditMeterRow`, the same shared `MeterRow` shell the
  * Codex/Claude windows use, so Traycer's own bars read identically
@@ -25,6 +25,7 @@
  */
 import type { ReactNode } from "react";
 import type { TraycerTeamSubscription } from "@traycer/protocol/auth";
+import type { AccountContext } from "@traycer/protocol/common/schemas";
 import {
   Select,
   SelectContent,
@@ -95,14 +96,19 @@ export function TraycerAccountSelect({
  */
 export function TraycerSubscriptionView({
   subscription,
+  accountContext,
 }: {
   readonly subscription: TraycerSubscription;
+  readonly accountContext: AccountContext;
 }): ReactNode {
   const status = subscription.subscriptionStatus;
   return isCreditBasedPricing(status) ? (
     <CreditBreakdownView breakdown={creditBreakdown(subscription)} />
   ) : (
-    <RateLimitView subscription={subscription} />
+    <RateLimitView
+      subscription={subscription}
+      accountContext={accountContext}
+    />
   );
 }
 
@@ -115,13 +121,15 @@ export function TraycerSubscriptionView({
 // its `useHostRateLimitUsageQuery` mount is the implicit tier-gate.
 function RateLimitView({
   subscription,
+  accountContext,
 }: {
   readonly subscription: TraycerSubscription;
+  readonly accountContext: AccountContext;
 }) {
-  const usageQuery = useHostRateLimitUsageQuery(null);
+  const usageQuery = useHostRateLimitUsageQuery(accountContext, null);
   // Keep the bar live: a Traycer turn finishing while this is on screen
   // re-fetches usage. Only mounted here, so it costs nothing elsewhere.
-  useRefreshRateLimitUsageOnTraycerTurn();
+  useRefreshRateLimitUsageOnTraycerTurn(accountContext);
 
   const recharge = formatRechargeRate(subscription.rechargeRateSeconds);
   const usage = usageQuery.data ?? null;

--- a/clients/gui-app/src/hooks/host/use-host-rate-limit-usage-query.ts
+++ b/clients/gui-app/src/hooks/host/use-host-rate-limit-usage-query.ts
@@ -1,17 +1,20 @@
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
-import { useAccountContextStore } from "@/stores/auth/account-context-store";
+import type { AccountContext } from "@traycer/protocol/common/schemas";
 
 /**
  * Live artifact rate-limit usage for the default host. Default-host scoped, like
  * runtime capabilities. The value moves every Traycer turn, so there is no
  * `staleTime` - `useRefreshRateLimitUsageOnTraycerTurn` invalidates it on turn
- * completion. Mounted only inside `RateLimitView`, which is the implicit
- * tier-gate (rate-limit tiers only).
+ * completion. The caller supplies the account context so the Traycer popover
+ * can render Personal and Team cards concurrently. Mounted only inside
+ * `RateLimitView`, which is the implicit tier-gate (rate-limit tiers only).
  */
-export function useHostRateLimitUsageQuery(profileId: string | null) {
+export function useHostRateLimitUsageQuery(
+  accountContext: AccountContext,
+  profileId: string | null,
+) {
   const client = useHostClient();
-  const accountContext = useAccountContextStore((s) => s.accountContext);
   return useHostQuery<HostRpcRegistry, "host.getRateLimitUsage">({
     cacheKeyIdentity: undefined,
     client,

--- a/clients/gui-app/src/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn.ts
+++ b/clients/gui-app/src/hooks/host/use-refresh-rate-limit-usage-on-traycer-turn.ts
@@ -1,9 +1,9 @@
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
+import type { AccountContext } from "@traycer/protocol/common/schemas";
 import { subscribeChatTurnCompletions } from "@/lib/notifications/chat-turn-completion";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
-import { useAccountContextStore } from "@/stores/auth/account-context-store";
 import { queryKeys } from "@/lib/query-keys";
 
 /**
@@ -20,13 +20,14 @@ import { queryKeys } from "@/lib/query-keys";
  * Traycer turn even though a Traycer turn can't have changed a Codex/Claude
  * account's rate limits.
  *
- * Mounted by `RateLimitView` (rate-limit tiers only), mirroring
- * `useRefreshCreditsOnTraycerTurn`.
+ * Mounted by each `RateLimitView` (rate-limit tiers only) with its explicit
+ * account context, mirroring `useRefreshCreditsOnTraycerTurn`.
  */
-export function useRefreshRateLimitUsageOnTraycerTurn(): void {
+export function useRefreshRateLimitUsageOnTraycerTurn(
+  accountContext: AccountContext,
+): void {
   const queryClient = useQueryClient();
   const hostId = useReactiveActiveHostId();
-  const accountContext = useAccountContextStore((s) => s.accountContext);
 
   useEffect(() => {
     return subscribeChatTurnCompletions((completion) => {


### PR DESCRIPTION
Replaces the Traycer account dropdown in the usage-limit popover with consistent Personal and team account cards in both the dedicated Traycer tab and all-providers Overview. Cards show plan, freshness, usage, and active state while preserving account switching. Explicit account contexts keep legacy rate-limit usage correct when multiple account cards are rendered. Validation: pre-commit run --all-files; 48 focused tests; TypeScript compile; ESLint; Prettier; React Doctor.