### PR TITLE
fix(gui-app): size git diff tree rows correctly

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
@@ -32,6 +32,10 @@ vi.mock("@pierre/trees/react", () => ({
       Git file tree
     </button>
   ),
+  useFileTreeSelector: (
+    model: object,
+    selector: (currentModel: object) => number,
+  ) => selector(model),
 }));
 
 vi.mock("../git-diff-section", () => ({
@@ -52,8 +56,11 @@ vi.mock("../use-git-pierre-file-tree-model", () => ({
     model: {
       getSelectedPaths: () => [],
       getItem: () => null,
+      getItemHeight: () => 24,
       scrollToPath: () => undefined,
     },
+    paths: files.map((file) => file.path),
+    rowDirectoryPaths: ["src"],
   }),
 }));
 

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-actions.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-panel-actions.test.tsx
@@ -7,6 +7,7 @@ import { useGitPanelStore } from "@/stores/epics/git-panel-store";
 import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import { gitQueryKeys } from "@/lib/query-keys/git-query-keys";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 function setup() {
   const queryClient = new QueryClient({
@@ -14,7 +15,9 @@ function setup() {
   });
   const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
   const wrapper = ({ children }: { readonly children: ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
+    </QueryClientProvider>
   );
   return { invalidateSpy, wrapper };
 }
@@ -49,6 +52,31 @@ describe("<GitDiffPanelActions />", () => {
 
     expect(useGitPanelStore.getState().stateByEpicId["epic-1"].listLayout).toBe(
       "tree",
+    );
+  });
+
+  it("explains the layout switch action in a keyboard-accessible tooltip", async () => {
+    const { wrapper } = setup();
+    render(<GitDiffPanelActions epicId="epic-1" tabId="tab-1" />, { wrapper });
+
+    const toggle = screen.getByRole("button", {
+      name: "Switch to tree view",
+    });
+    fireEvent.focus(toggle);
+
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Switch to tree view",
+    );
+
+    fireEvent.blur(toggle);
+    fireEvent.click(toggle);
+
+    const nextToggle = screen.getByRole("button", {
+      name: "Switch to list view",
+    });
+    fireEvent.focus(nextToggle);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "Switch to list view",
     );
   });
 

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/selected-repo-changes-section-state.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/selected-repo-changes-section-state.test.tsx
@@ -1,7 +1,14 @@
 import { act, type ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import type {
   GitChangedFileV11,
   GitListChangedFilesResponseV11,
@@ -276,6 +283,106 @@ describe("<SelectedRepoChanges /> module section state", () => {
 
     expect(screen.queryByText("src/root-working.ts")).toBeNull();
     expect(screen.getByTestId("git-no-matching-files")).toBeDefined();
+  });
+
+  it("gives the live non-virtualized tree enough height to show its rows", async () => {
+    useGitPanelStore.getState().setListLayout("epic-1", "tree");
+    renderSelectedChanges(
+      response({
+        files: [file("src/root-working.ts")],
+      }),
+    );
+
+    expect(screen.getByTestId("git-single-repo-changes")).toBeDefined();
+    const tree = screen.getByTestId("git-pierre-file-tree");
+    expect(tree.style.height).toBe("48px");
+    await waitFor(() => {
+      expect(tree.shadowRoot?.querySelectorAll("[data-item-path]").length).toBe(
+        2,
+      );
+    });
+
+    const directoryRow = tree.shadowRoot?.querySelector(
+      'button[data-item-type="folder"]',
+    );
+    if (!(directoryRow instanceof HTMLButtonElement)) {
+      throw new Error("Expected a Pierre directory row");
+    }
+    fireEvent.click(directoryRow);
+
+    await waitFor(() => expect(tree.style.height).toBe("24px"));
+  });
+
+  it("does not reserve extra height for flattened directory segments", async () => {
+    useGitPanelStore.getState().setListLayout("epic-1", "tree");
+    renderSelectedChanges(
+      response({
+        files: [
+          stagedFile("Profile/components/PlatformRatings.jsx"),
+          stagedFile("Trace-20260603T220311.json.gz"),
+          stagedFile("Trace-20260604T133730.json.gz"),
+          file("backend/controller.js"),
+        ],
+      }),
+    );
+
+    const [stagedTree] = screen.getAllByTestId("git-pierre-file-tree");
+    await waitFor(() => {
+      expect(
+        stagedTree.shadowRoot?.querySelectorAll("[data-item-path]").length,
+      ).toBe(4);
+    });
+
+    expect(stagedTree.style.height).toBe("96px");
+  });
+
+  it("keeps live tree stage headers in the module sticky hierarchy", () => {
+    useGitPanelStore.getState().setListLayout("epic-1", "tree");
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue(DOMRect.fromRect({ width: 320, height: 36 }));
+
+    renderSelectedChanges(
+      response({
+        files: [
+          stagedFile("src/root-staged.ts"),
+          file("src/root-working.ts"),
+          gitlink("traycer"),
+        ],
+        submodules: [changeset({ files: [file("src/submodule-working.ts")] })],
+      }),
+    );
+
+    const rootModule = screen.getByTestId("git-module-group-root");
+    const moduleHeader = within(rootModule).getByTestId(
+      "git-module-header-root",
+    );
+    const treeSections = within(rootModule).getByTestId(
+      "git-file-tree-sections",
+    );
+    const stagedButton = within(rootModule).getByRole("button", {
+      name: "Staged section, 1 file",
+    });
+    const stagedHeader = stagedButton.closest(".sticky");
+    const moduleBody = rootModule.querySelector<HTMLElement>(
+      '[style*="--git-section-sticky-top"]',
+    );
+
+    expect(moduleHeader.className).toContain("sticky");
+    expect(moduleHeader.className).toContain("top-0");
+    expect(moduleHeader.className).toContain("z-40");
+    expect(moduleBody?.style.getPropertyValue("--git-section-sticky-top")).toBe(
+      "36px",
+    );
+    expect(stagedHeader?.className).toContain("sticky");
+    expect(stagedHeader?.className).toContain(
+      "top-[var(--git-section-sticky-top,0px)]",
+    );
+    expect(stagedHeader?.className).toContain("z-30");
+    expect(treeSections.className).toContain("overflow-visible");
+    expect(treeSections.className).not.toContain("overflow-hidden");
+
+    rectSpy.mockRestore();
   });
 
   it("expands a collapsed module while search reveals a matching file", () => {

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-sections.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-sections.tsx
@@ -1,16 +1,10 @@
-import { useMemo, type ReactNode } from "react";
+import { useCallback, type ReactNode } from "react";
 import type { GitChangedFile } from "@traycer/protocol/host";
-import { buildGitPanelFileSections } from "@/lib/git/panel-file-rendering";
 import type { HighlightRanges } from "@/lib/git/path-highlight";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
-import { GitDiffSection } from "./git-diff-section";
 import { GitFlatFileList } from "./git-flat-file-list";
-import {
-  gitPanelActiveFilePathForGroup,
-  useGitPanelActiveFile,
-  useGitPanelRevealSection,
-} from "./use-git-panel-active-file";
+import { GitFileSectionStack } from "./git-file-section-stack";
+import type { GitFileSectionBodyRenderProps } from "./git-file-section-stack";
 import type { GitDiffSectionCollapseController } from "./git-diff-section";
 
 // Deliberate hover dwell for the per-row path tooltips: long enough that
@@ -33,16 +27,28 @@ export interface FileSectionsProps {
 }
 
 export function FileSections(props: FileSectionsProps): ReactNode {
-  const activeFile = useGitPanelActiveFile({
-    viewTabId: props.viewTabId,
-    hostId: props.hostId,
-    runningDir: props.runningDir,
-  });
-  useGitPanelRevealSection({ epicId: props.epicId, activeFile });
-
-  const sections = useMemo(
-    () => buildGitPanelFileSections(props.allFiles, props.visibleFiles),
-    [props.allFiles, props.visibleFiles],
+  const renderBody = useCallback(
+    (section: GitFileSectionBodyRenderProps) => (
+      <GitFlatFileList
+        epicId={props.epicId}
+        viewTabId={props.viewTabId}
+        hostId={props.hostId}
+        runningDir={props.runningDir}
+        files={section.visibleFiles}
+        pathRangesByPath={props.pathRangesByPath}
+        activeFilePath={section.activeFilePath}
+        virtualized={props.virtualized}
+        nestedRows={!props.virtualized}
+      />
+    ),
+    [
+      props.epicId,
+      props.hostId,
+      props.pathRangesByPath,
+      props.runningDir,
+      props.viewTabId,
+      props.virtualized,
+    ],
   );
 
   return (
@@ -50,54 +56,20 @@ export function FileSections(props: FileSectionsProps): ReactNode {
       delayDuration={FILE_ROW_TOOLTIP_DELAY_MS}
       skipDelayDuration={0}
     >
-      <div
-        className={cn(
-          props.virtualized
-            ? "flex min-h-0 flex-1 flex-col overflow-hidden"
-            : "flex flex-col overflow-visible",
-        )}
-        data-testid="git-file-sections"
-      >
-        {sections.map(({ group, visibleFiles, bundleFileCount }) =>
-          // While filtering, hide any empty section so only matches show;
-          // otherwise keep the existing "hide the merge section when empty"
-          // behavior and let staged/changes render their empty state.
-          visibleFiles.length === 0 &&
-          (props.forceExpanded ||
-            props.hideEmptySections ||
-            group === "merge") ? null : (
-            <GitDiffSection
-              key={group}
-              epicId={props.epicId}
-              viewTabId={props.viewTabId}
-              hostId={props.hostId}
-              runningDir={props.runningDir}
-              group={group}
-              visibleFiles={visibleFiles}
-              bundleFileCount={bundleFileCount}
-              forceExpanded={props.forceExpanded}
-              collapseController={props.sectionCollapseController}
-              fillAvailable={props.virtualized}
-              compactChrome={!props.virtualized}
-            >
-              <GitFlatFileList
-                epicId={props.epicId}
-                viewTabId={props.viewTabId}
-                hostId={props.hostId}
-                runningDir={props.runningDir}
-                files={visibleFiles}
-                pathRangesByPath={props.pathRangesByPath}
-                activeFilePath={gitPanelActiveFilePathForGroup(
-                  activeFile,
-                  group,
-                )}
-                virtualized={props.virtualized}
-                nestedRows={!props.virtualized}
-              />
-            </GitDiffSection>
-          ),
-        )}
-      </div>
+      <GitFileSectionStack
+        epicId={props.epicId}
+        viewTabId={props.viewTabId}
+        hostId={props.hostId}
+        runningDir={props.runningDir}
+        allFiles={props.allFiles}
+        visibleFiles={props.visibleFiles}
+        forceExpanded={props.forceExpanded}
+        hideEmptySections={props.hideEmptySections}
+        sectionCollapseController={props.sectionCollapseController}
+        virtualized={props.virtualized}
+        testId="git-file-sections"
+        renderBody={renderBody}
+      />
     </TooltipProvider>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
@@ -1,15 +1,15 @@
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useMemo, type MouseEvent } from "react";
-import { FileTree as PierreFileTree } from "@pierre/trees/react";
+import { useCallback, useEffect, type MouseEvent } from "react";
+import {
+  FileTree as PierreFileTree,
+  useFileTreeSelector,
+} from "@pierre/trees/react";
 import type {
   FileTreeDirectoryHandle,
   FileTreeItemHandle,
 } from "@pierre/trees";
 import type { GitChangedFile } from "@traycer/protocol/host";
-import {
-  buildGitTreeDirectoryPaths,
-  buildGitPanelFileSections,
-} from "@/lib/git/panel-file-rendering";
+import { buildGitTreeDirectoryPaths } from "@/lib/git/panel-file-rendering";
 import { GIT_PANEL_PIERRE_FILE_TREE_THEME_STYLE } from "@/components/epic-canvas/pierre-tree-theme";
 import { extractPierreItemPathFromEvent } from "@/components/epic-canvas/pierre-tree-adapter";
 import { usePierreCanvasDragBridge } from "@/components/epic-canvas/dnd/use-pierre-canvas-drag-bridge";
@@ -26,14 +26,10 @@ import type {
   GitDiffTileRef,
 } from "@/stores/epics/canvas/types";
 import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
-import { GitDiffSection } from "./git-diff-section";
 import type { GitDiffSectionCollapseController } from "./git-diff-section";
+import { GitFileSectionStack } from "./git-file-section-stack";
+import type { GitFileSectionBodyRenderProps } from "./git-file-section-stack";
 import { useGitPierreFileTreeModel } from "./use-git-pierre-file-tree-model";
-import {
-  gitPanelActiveFilePathForGroup,
-  useGitPanelActiveFile,
-  useGitPanelRevealSection,
-} from "./use-git-panel-active-file";
 
 export interface FileTreeProps {
   readonly epicId: string;
@@ -56,58 +52,94 @@ interface GitTreeSectionBodyProps {
   readonly group: GitDiffBundleGroup;
   readonly files: ReadonlyArray<GitChangedFile>;
   readonly activeFilePath: string | null;
+  readonly virtualized: boolean;
 }
 
-export function FileTree(props: FileTreeProps): ReactNode {
-  const activeFile = useGitPanelActiveFile({
-    viewTabId: props.viewTabId,
-    hostId: props.hostId,
-    runningDir: props.runningDir,
-  });
-  useGitPanelRevealSection({ epicId: props.epicId, activeFile });
+type GitTreeVisibilityModel = {
+  getItem(path: string): FileTreeItemHandle | null;
+};
 
-  const sections = useMemo(
-    () => buildGitPanelFileSections(props.allFiles, props.visibleFiles),
-    [props.allFiles, props.visibleFiles],
+export function FileTree(props: FileTreeProps): ReactNode {
+  const renderBody = useCallback(
+    (section: GitFileSectionBodyRenderProps) => (
+      <GitTreeSectionBody
+        epicId={props.epicId}
+        viewTabId={props.viewTabId}
+        hostId={props.hostId}
+        runningDir={props.runningDir}
+        group={section.group}
+        files={section.visibleFiles}
+        activeFilePath={section.activeFilePath}
+        virtualized={props.virtualized}
+      />
+    ),
+    [
+      props.epicId,
+      props.hostId,
+      props.runningDir,
+      props.viewTabId,
+      props.virtualized,
+    ],
   );
 
   return (
-    <div
-      className="flex min-h-0 flex-1 flex-col overflow-hidden"
-      data-testid="git-file-tree-sections"
-    >
-      {sections.map(({ group, visibleFiles, bundleFileCount }) =>
-        visibleFiles.length === 0 &&
-        (props.forceExpanded ||
-          props.hideEmptySections ||
-          group === "merge") ? null : (
-          <GitDiffSection
-            key={group}
-            epicId={props.epicId}
-            viewTabId={props.viewTabId}
-            hostId={props.hostId}
-            runningDir={props.runningDir}
-            group={group}
-            visibleFiles={visibleFiles}
-            bundleFileCount={bundleFileCount}
-            forceExpanded={props.forceExpanded}
-            collapseController={props.sectionCollapseController}
-            fillAvailable={props.virtualized}
-            compactChrome={!props.virtualized}
-          >
-            <GitTreeSectionBody
-              epicId={props.epicId}
-              viewTabId={props.viewTabId}
-              hostId={props.hostId}
-              runningDir={props.runningDir}
-              group={group}
-              files={visibleFiles}
-              activeFilePath={gitPanelActiveFilePathForGroup(activeFile, group)}
-            />
-          </GitDiffSection>
-        ),
-      )}
-    </div>
+    <GitFileSectionStack
+      epicId={props.epicId}
+      viewTabId={props.viewTabId}
+      hostId={props.hostId}
+      runningDir={props.runningDir}
+      allFiles={props.allFiles}
+      visibleFiles={props.visibleFiles}
+      forceExpanded={props.forceExpanded}
+      hideEmptySections={props.hideEmptySections}
+      sectionCollapseController={props.sectionCollapseController}
+      virtualized={props.virtualized}
+      testId="git-file-tree-sections"
+      renderBody={renderBody}
+    />
+  );
+}
+
+/**
+ * Pierre's renderer is always virtualized and therefore needs a definite host
+ * height. Module-group bodies deliberately use the outer panel as their scroll
+ * owner, so size that mode to its currently visible rows instead of inheriting
+ * `height: 100%` from an auto-height section body (which resolves to zero).
+ */
+function gitTreeStyle(
+  itemHeight: number,
+  visibleRowCount: number,
+  virtualized: boolean,
+) {
+  if (virtualized) return GIT_PANEL_PIERRE_FILE_TREE_THEME_STYLE;
+  return {
+    ...GIT_PANEL_PIERRE_FILE_TREE_THEME_STYLE,
+    height: visibleRowCount * itemHeight,
+  };
+}
+
+function gitTreePathIsVisible(
+  model: GitTreeVisibilityModel,
+  treePath: string,
+): boolean {
+  return buildGitTreeDirectoryPaths([treePath]).every((directoryPath) => {
+    const directory = model.getItem(directoryPath);
+    return (
+      directory !== null &&
+      isDirectoryHandle(directory) &&
+      directory.isExpanded()
+    );
+  });
+}
+
+function countVisibleGitTreeRows(
+  model: GitTreeVisibilityModel,
+  paths: ReadonlyArray<string>,
+  rowDirectoryPaths: ReadonlyArray<string>,
+): number {
+  return (
+    rowDirectoryPaths.filter((path) => gitTreePathIsVisible(model, path))
+      .length + paths.filter((path) => gitTreePathIsVisible(model, path)).length
   );
 }
 
@@ -125,7 +157,16 @@ function GitTreeSectionBody(props: GitTreeSectionBodyProps): ReactNode {
   const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
     (s) => s.prepareOpenTileInTabFocusTarget,
   );
-  const { model, fileByPath } = useGitPierreFileTreeModel(props.files);
+  const { model, fileByPath, paths, rowDirectoryPaths } =
+    useGitPierreFileTreeModel(props.files);
+  const selectVisibleRowCount = useCallback(
+    (currentModel: GitTreeVisibilityModel) =>
+      props.virtualized
+        ? 0
+        : countVisibleGitTreeRows(currentModel, paths, rowDirectoryPaths),
+    [paths, props.virtualized, rowDirectoryPaths],
+  );
+  const visibleRowCount = useFileTreeSelector(model, selectVisibleRowCount);
 
   // Mirror the canvas's focused diff tile into Pierre's selection, expanding
   // ancestor folders and scrolling the row into view. Runs on focus changes
@@ -226,7 +267,11 @@ function GitTreeSectionBody(props: GitTreeSectionBodyProps): ReactNode {
         model={model}
         onClick={previewFileFromTreeRow}
         onDoubleClick={pinFileFromTreeRow}
-        style={GIT_PANEL_PIERRE_FILE_TREE_THEME_STYLE}
+        style={gitTreeStyle(
+          model.getItemHeight(),
+          visibleRowCount,
+          props.virtualized,
+        )}
         data-testid="git-pierre-file-tree"
       />
     </div>

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-panel-actions.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { FolderTree, List, RotateCcw } from "lucide-react";
 import type { LeftPanelSlotProps } from "@/components/epic-canvas/sidebar/left-panel-registry";
 import { Button } from "@/components/ui/button";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { cn } from "@/lib/utils";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
 import {
@@ -26,6 +27,8 @@ export function GitDiffPanelActions(props: LeftPanelSlotProps) {
   const ignoreWhitespace = useSettingsStore(
     (s) => s.diffViewerPreferences.ignoreWhitespace,
   );
+  const layoutToggleLabel =
+    listLayout === "sections" ? "Switch to tree view" : "Switch to list view";
 
   const handleToggleLayout = useCallback(() => {
     const nextLayout = listLayout === "sections" ? "tree" : "sections";
@@ -53,25 +56,28 @@ export function GitDiffPanelActions(props: LeftPanelSlotProps) {
 
   return (
     <div className="flex items-center gap-0.5">
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        onClick={handleToggleLayout}
-        aria-label={
-          listLayout === "sections"
-            ? "Switch to tree layout"
-            : "Switch to list layout"
-        }
-        data-testid="git-diff-panel-layout-toggle"
-        className="text-muted-foreground hover:text-foreground"
+      <TooltipWrapper
+        label={layoutToggleLabel}
+        side="bottom"
+        sideOffset={4}
+        align="end"
       >
-        {listLayout === "sections" ? (
-          <FolderTree className="size-4" />
-        ) : (
-          <List className="size-4" />
-        )}
-      </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={handleToggleLayout}
+          aria-label={layoutToggleLabel}
+          data-testid="git-diff-panel-layout-toggle"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          {listLayout === "sections" ? (
+            <FolderTree className="size-4" />
+          ) : (
+            <List className="size-4" />
+          )}
+        </Button>
+      </TooltipWrapper>
 
       <Button
         type="button"

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-file-section-stack.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-file-section-stack.tsx
@@ -1,0 +1,93 @@
+import { useMemo, type ReactNode } from "react";
+import type { GitChangedFile } from "@traycer/protocol/host";
+import type { GitDiffBundleGroup } from "@/stores/epics/canvas/types";
+import { buildGitPanelFileSections } from "@/lib/git/panel-file-rendering";
+import { cn } from "@/lib/utils";
+import { GitDiffSection } from "./git-diff-section";
+import type { GitDiffSectionCollapseController } from "./git-diff-section";
+import {
+  gitPanelActiveFilePathForGroup,
+  useGitPanelActiveFile,
+  useGitPanelRevealSection,
+} from "./use-git-panel-active-file";
+
+export interface GitFileSectionBodyRenderProps {
+  readonly group: GitDiffBundleGroup;
+  readonly visibleFiles: ReadonlyArray<GitChangedFile>;
+  readonly activeFilePath: string | null;
+}
+
+export interface GitFileSectionStackProps {
+  readonly epicId: string;
+  readonly viewTabId: string;
+  readonly hostId: string;
+  readonly runningDir: string;
+  readonly allFiles: ReadonlyArray<GitChangedFile>;
+  readonly visibleFiles: ReadonlyArray<GitChangedFile>;
+  readonly forceExpanded: boolean;
+  readonly hideEmptySections: boolean;
+  readonly sectionCollapseController: GitDiffSectionCollapseController | null;
+  readonly virtualized: boolean;
+  readonly testId: string;
+  readonly renderBody: (props: GitFileSectionBodyRenderProps) => ReactNode;
+}
+
+/**
+ * Shared stage-section hierarchy for the flat and tree layouts. In the live
+ * module composition, the outer module list owns scrolling so both the module
+ * header and its nested stage headers participate in the same sticky context.
+ */
+export function GitFileSectionStack(
+  props: GitFileSectionStackProps,
+): ReactNode {
+  const activeFile = useGitPanelActiveFile({
+    viewTabId: props.viewTabId,
+    hostId: props.hostId,
+    runningDir: props.runningDir,
+  });
+  useGitPanelRevealSection({ epicId: props.epicId, activeFile });
+
+  const sections = useMemo(
+    () => buildGitPanelFileSections(props.allFiles, props.visibleFiles),
+    [props.allFiles, props.visibleFiles],
+  );
+
+  return (
+    <div
+      className={cn(
+        props.virtualized
+          ? "flex min-h-0 flex-1 flex-col overflow-hidden"
+          : "flex flex-col overflow-visible",
+      )}
+      data-testid={props.testId}
+    >
+      {sections.map(({ group, visibleFiles, bundleFileCount }) =>
+        visibleFiles.length === 0 &&
+        (props.forceExpanded ||
+          props.hideEmptySections ||
+          group === "merge") ? null : (
+          <GitDiffSection
+            key={group}
+            epicId={props.epicId}
+            viewTabId={props.viewTabId}
+            hostId={props.hostId}
+            runningDir={props.runningDir}
+            group={group}
+            visibleFiles={visibleFiles}
+            bundleFileCount={bundleFileCount}
+            forceExpanded={props.forceExpanded}
+            collapseController={props.sectionCollapseController}
+            fillAvailable={props.virtualized}
+            compactChrome={!props.virtualized}
+          >
+            {props.renderBody({
+              group,
+              visibleFiles,
+              activeFilePath: gitPanelActiveFilePathForGroup(activeFile, group),
+            })}
+          </GitDiffSection>
+        ),
+      )}
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/use-git-pierre-file-tree-model.ts
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/use-git-pierre-file-tree-model.ts
@@ -11,6 +11,7 @@ import type { GitChangedFile } from "@traycer/protocol/host";
 import {
   buildGitFileRowMetadata,
   buildGitTreeDirectoryPaths,
+  buildGitTreeRowDirectoryPaths,
   gitChangedFileToPierreStatusEntry,
   mergeGitTreeExpandedDirectoryPaths,
 } from "@/lib/git/panel-file-rendering";
@@ -19,6 +20,8 @@ import { GIT_PANEL_PIERRE_FILE_TREE_UNSAFE_CSS } from "@/components/epic-canvas/
 interface GitPierreFileTreeModel {
   readonly model: PierreFileTreeModel;
   readonly fileByPath: ReadonlyMap<string, GitChangedFile>;
+  readonly paths: ReadonlyArray<string>;
+  readonly rowDirectoryPaths: ReadonlyArray<string>;
 }
 
 export function useGitPierreFileTreeModel(
@@ -27,6 +30,10 @@ export function useGitPierreFileTreeModel(
   const paths = useMemo(() => files.map((file) => file.path), [files]);
   const directoryPaths = useMemo(
     () => buildGitTreeDirectoryPaths(paths),
+    [paths],
+  );
+  const rowDirectoryPaths = useMemo(
+    () => buildGitTreeRowDirectoryPaths(paths),
     [paths],
   );
   const fileByPath = useMemo(
@@ -56,6 +63,7 @@ export function useGitPierreFileTreeModel(
 
   const { model } = useFileTree({
     paths,
+    flattenEmptyDirectories: true,
     initialExpansion: "closed",
     initialExpandedPaths: directoryPaths,
     density: "compact",
@@ -85,7 +93,7 @@ export function useGitPierreFileTreeModel(
     model.setGitStatus(gitStatus);
   }, [model, gitStatus]);
 
-  return { model, fileByPath };
+  return { model, fileByPath, paths, rowDirectoryPaths };
 }
 
 function collectExpandedDirectoryPaths(

--- a/clients/gui-app/src/lib/git/__tests__/panel-file-rendering.test.ts
+++ b/clients/gui-app/src/lib/git/__tests__/panel-file-rendering.test.ts
@@ -13,6 +13,7 @@ import {
   buildGitFileRowMetadata,
   buildGitPanelFileSections,
   buildGitTreeDirectoryPaths,
+  buildGitTreeRowDirectoryPaths,
   gitChangedFileTooltipContent,
   gitChangedFileToPierreStatus,
   gitChangedFileToPierreStatusEntry,
@@ -278,6 +279,27 @@ describe("git panel file rendering helpers", () => {
       "test",
       "test/unit",
     ]);
+  });
+
+  it("counts Pierre-flattened directory chains as single rendered rows", () => {
+    expect(
+      buildGitTreeRowDirectoryPaths([
+        "Profile/components/PlatformRatings.jsx",
+        "Trace-20260603T220311.json.gz",
+        "Trace-20260604T133730.json.gz",
+      ]),
+    ).toEqual(["Profile"]);
+
+    expect(
+      buildGitTreeRowDirectoryPaths(["clients/gui/src/components/button.tsx"]),
+    ).toEqual(["clients"]);
+
+    expect(
+      buildGitTreeRowDirectoryPaths([
+        "src/components/button.tsx",
+        "src/lib/git.ts",
+      ]),
+    ).toEqual(["src", "src/components", "src/lib"]);
   });
 
   it("expands Pierre's compacted Git tree rows to the deepest changed file", () => {

--- a/clients/gui-app/src/lib/git/panel-file-rendering.ts
+++ b/clients/gui-app/src/lib/git/panel-file-rendering.ts
@@ -36,6 +36,31 @@ function directoryPathsForPath(filePath: string): ReadonlyArray<string> {
   );
 }
 
+function parentDirectoryPath(path: string): string | null {
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  if (segments.length <= 1) return null;
+  return segments.slice(0, -1).join("/");
+}
+
+interface GitTreeDirectoryChildSummary {
+  readonly count: number;
+  readonly onlyDirectoryPath: string | null;
+}
+
+function addGitTreeDirectoryChild(
+  summaryByDirectory: Map<string, GitTreeDirectoryChildSummary>,
+  parentPath: string | null,
+  directoryPath: string | null,
+): void {
+  if (parentPath === null) return;
+  const current = summaryByDirectory.get(parentPath);
+  if (current === undefined) return;
+  summaryByDirectory.set(parentPath, {
+    count: current.count + 1,
+    onlyDirectoryPath: current.count === 0 ? directoryPath : null,
+  });
+}
+
 export function gitChangedFileToPierreStatus(
   file: GitChangedFile,
 ): GitStatusEntry["status"] {
@@ -139,6 +164,46 @@ export function buildGitTreeDirectoryPaths(
   return Array.from(
     new Set(paths.flatMap((path) => directoryPathsForPath(path))),
   );
+}
+
+/**
+ * Pierre flattens a directory into its sole directory child by default, so a
+ * chain such as `Profile/components` occupies one rendered row rather than
+ * one row per directory segment. Return only the directory paths that start a
+ * rendered row while preserving the full directory list for expansion state.
+ */
+export function buildGitTreeRowDirectoryPaths(
+  paths: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const directoryPaths = buildGitTreeDirectoryPaths(paths);
+  const summaryByDirectory = new Map<string, GitTreeDirectoryChildSummary>(
+    directoryPaths.map((path) => [path, { count: 0, onlyDirectoryPath: null }]),
+  );
+
+  for (const directoryPath of directoryPaths) {
+    addGitTreeDirectoryChild(
+      summaryByDirectory,
+      parentDirectoryPath(directoryPath),
+      directoryPath,
+    );
+  }
+  for (const path of paths) {
+    addGitTreeDirectoryChild(
+      summaryByDirectory,
+      parentDirectoryPath(path),
+      null,
+    );
+  }
+
+  return directoryPaths.filter((directoryPath) => {
+    const parentPath = parentDirectoryPath(directoryPath);
+    if (parentPath === null) return true;
+    const parentSummary = summaryByDirectory.get(parentPath);
+    return !(
+      parentSummary?.count === 1 &&
+      parentSummary.onlyDirectoryPath === directoryPath
+    );
+  });
 }
 
 export function mergeGitTreeExpandedDirectoryPaths(


### PR DESCRIPTION
## Summary

- size live non-virtualized Pierre trees from visible rendered rows so the tree view no longer renders blank or reserves oversized gaps
- mirror flattened directory rows and share stage-section composition so tree and list layouts preserve the same sticky module/stage hierarchy
- add an accessible tooltip to the list/tree layout toggle

## Related issue

None.

## Validation

- `pre-commit run --all-files`
- GUI suite: 580 test files passed, 1 skipped; 4,830 tests passed, 1 skipped
- React Doctor changed-scope scan: no issues
- cold code review: no actionable findings

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO