### PR TITLE
fix(comments): fall back to user_id when a comment lacks an author handle

### DIFF
--- a/protocol/src/comments/__tests__/comments-xml-formatting.test.ts
+++ b/protocol/src/comments/__tests__/comments-xml-formatting.test.ts
@@ -103,9 +103,9 @@ body &amp; &lt;tag&gt;
 </comment>
 </thread>
 
-<thread id="thread-resolved" created_at="2026-06-17T10:20:00.000Z" status="resolved">
+<thread id="thread-resolved" user_id="user-2" created_at="2026-06-17T10:20:00.000Z" status="resolved">
 <quoted_section anchor="unavailable" reason="failed to parse anchor position">old wording</quoted_section>
-<comment id="comment-2" n="1" created_at="2026-06-17T10:21:00.000Z" edited_at="2026-06-17T10:22:00.000Z">
+<comment id="comment-2" n="1" user_id="user-2" created_at="2026-06-17T10:21:00.000Z" edited_at="2026-06-17T10:22:00.000Z">
 fixed
 </comment>
 </thread>

--- a/protocol/src/comments/comments-xml-formatting.ts
+++ b/protocol/src/comments/comments-xml-formatting.ts
@@ -93,7 +93,10 @@ function serializeThread(
   platform: "POSIX" | "WINDOWS",
 ): string {
   const { thread } = input;
-  const author = authorName(thread.data.createdByHandle ?? null);
+  const author = authorAttribute(
+    thread.data.createdByHandle ?? null,
+    thread.data.createdByUserId,
+  );
   const attrs = [
     attribute("id", thread.threadId),
     author,
@@ -118,7 +121,10 @@ function serializeThread(
   }
 
   thread.comments.forEach((comment, index) => {
-    const commentAuthor = authorName(comment.author.fallbackHandle);
+    const commentAuthor = authorAttribute(
+      comment.author.fallbackHandle,
+      comment.author.userId,
+    );
     const commentAttrs = [
       attribute("id", comment.commentId),
       attribute("n", String(index + 1)),
@@ -144,9 +150,22 @@ function serializeThread(
   return lines.join("\n");
 }
 
-function authorName(providerHandle: string | null): string | null {
+// Legacy comments were persisted before author handles were guaranteed at
+// write time; fall back to the stable user id (as `user_id=`, mirroring what
+// the GUI shows) so the model always gets an attribution signal instead of an
+// anonymous comment.
+function authorAttribute(
+  providerHandle: string | null,
+  userId: string,
+): string | null {
   const trimmedHandle = providerHandle?.trim() ?? "";
-  return trimmedHandle.length > 0 ? attribute("author", trimmedHandle) : null;
+  if (trimmedHandle.length > 0) {
+    return attribute("author", trimmedHandle);
+  }
+  const trimmedUserId = userId.trim();
+  return trimmedUserId.length > 0
+    ? attribute("user_id", trimmedUserId)
+    : null;
 }
 
 function attribute(name: string, value: string): string {


### PR DESCRIPTION
## Summary

Legacy comments were persisted before author handles were guaranteed at write time, so they serialized with no author attribution at all. This falls back to the stable `user_id` (rendered as a `user_id=` attribute, mirroring what the GUI shows) whenever a handle is absent, so the model always receives an attribution signal instead of an anonymous comment.

The internal-repo side of this change (guaranteeing the handle is non-null at write time, and consuming `createdByUserId` in the serializer) pins this commit.

## Changes

- `authorName` → `authorAttribute`: emits `author=` when a trimmed handle is present, else `user_id=` from the stable user id, else nothing.
- Applied to both thread and comment serialization.
- Updated the XML-formatting test to cover the `user_id` fallback path.

## Testing

- `bun run --filter @traycer/protocol compile` — clean.