### PR TITLE
fix(dev-desktop): wait for host teardown

### DIFF
--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -1,12 +1,39 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { readFile, rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  SHUTDOWN_FORCE_EXIT_MS,
+  STOP_EXIT_GRACE_MARGIN_MS,
+} from "@traycer/protocol/host/lifecycle-constants";
 
 import { createMacosController, type ProcessRunner } from "../macos";
 import { ProcessRunError, type RunResult } from "../../process-runner";
 import { serviceLabelFor } from "../../label";
 import { CLI_ERROR_CODES } from "../../../runner/errors";
+
+const mocks = vi.hoisted(() => ({
+  readHostPidMetadata: vi.fn(),
+  isProcessAlive: vi.fn(),
+}));
+
+const HOST_PID_METADATA = {
+  pid: 4242,
+  hostId: "test-host",
+  version: "1.2.3",
+  websocketUrl: "ws://127.0.0.1:1234/rpc",
+  startedAt: "2026-07-12T00:00:00.000Z",
+};
+
+vi.mock("../../../host/pid-metadata", () => ({
+  readHostPidMetadata: mocks.readHostPidMetadata,
+}));
+
+vi.mock("../../../store/cli-lock", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../store/cli-lock")>();
+  return { ...actual, isProcessAlive: mocks.isProcessAlive };
+});
 
 // Test isolation: `serviceManifestPath` normally resolves to the REAL
 // `~/Library/LaunchAgents/<label>.plist` (via `os.homedir()`, which ignores
@@ -57,16 +84,21 @@ function buildLaunchctlError(args: {
   );
 }
 
-describe("macOS service install failure handling (ticket a849b064)", () => {
+describe("macOS service lifecycle", () => {
   const label = serviceLabelFor("production");
   const tempPlistDir = TEST_LAUNCH_AGENTS_DIR;
   let createdPlistPath: string | null = null;
 
   beforeEach(() => {
     createdPlistPath = null;
+    mocks.readHostPidMetadata.mockReset();
+    mocks.readHostPidMetadata.mockResolvedValue(null);
+    mocks.isProcessAlive.mockReset();
+    mocks.isProcessAlive.mockReturnValue(false);
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     // installService writes a plist to ~/Library/LaunchAgents/<label>.plist
     // - clean it up so a failed run doesn't leak between tests. We only
     // touch the specific test label to avoid clobbering a real install
@@ -320,5 +352,130 @@ describe("macOS service install failure handling (ticket a849b064)", () => {
       "bootstrap",
       "kickstart",
     ]);
+  });
+
+  it("uses a bounded launchd completion barrier when pid metadata is missing", async () => {
+    const calls: Array<{
+      readonly args: readonly string[];
+      readonly timeoutMs: number;
+      readonly tolerateNonZeroExit: boolean;
+    }> = [];
+    const runner: ProcessRunner = async (_command, args, options) => {
+      calls.push({
+        args,
+        timeoutMs: options.timeoutMs,
+        tolerateNonZeroExit: options.tolerateNonZeroExit,
+      });
+      return buildSuccessResult();
+    };
+    const controller = createMacosController(runner);
+
+    await controller.uninstall({ label });
+
+    expect(calls).toEqual([
+      {
+        args: [
+          "bootout",
+          "--wait",
+          `gui/${process.getuid?.() ?? 0}/${label.id}`,
+        ],
+        timeoutMs: SHUTDOWN_FORCE_EXIT_MS + STOP_EXIT_GRACE_MARGIN_MS,
+        tolerateNonZeroExit: false,
+      },
+    ]);
+    expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
+    expect(mocks.isProcessAlive).not.toHaveBeenCalled();
+  });
+
+  it("treats an already-removed launchd service as a successful uninstall", async () => {
+    const runner: ProcessRunner = async (command, args) => {
+      throw buildLaunchctlError({
+        command,
+        cmdArgs: args,
+        stderr: "Boot-out failed: 3: No such process\n",
+        stdout: "",
+        exitCode: 3,
+      });
+    };
+    const controller = createMacosController(runner);
+
+    await expect(controller.uninstall({ label })).resolves.toBeUndefined();
+  });
+
+  it("surfaces a real bootout failure and preserves the service manifest", async () => {
+    createdPlistPath = join(tempPlistDir, `${label.id}.plist`);
+    await writeFile(createdPlistPath, "test manifest", "utf8");
+    const runner: ProcessRunner = async (command, args) => {
+      throw buildLaunchctlError({
+        command,
+        cmdArgs: args,
+        stderr: "Boot-out failed: 1: Operation not permitted\n",
+        stdout: "",
+        exitCode: 1,
+      });
+    };
+    const controller = createMacosController(runner);
+
+    await expect(controller.uninstall({ label })).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      message: expect.stringContaining("Operation not permitted"),
+    });
+    await expect(readFile(createdPlistPath, "utf8")).resolves.toBe(
+      "test manifest",
+    );
+  });
+
+  it("surfaces a bootout timeout instead of treating it as already removed", async () => {
+    const runner: ProcessRunner = async (command, args) => {
+      throw new ProcessRunError(
+        `${command} ${args.join(" ")} timed out`,
+        command,
+        args,
+        -1,
+        "",
+        "",
+      );
+    };
+    const controller = createMacosController(runner);
+
+    await expect(controller.uninstall({ label })).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      message: expect.stringContaining("timed out"),
+    });
+  });
+
+  it("waits through delayed host exit when stopping", async () => {
+    vi.useFakeTimers();
+    mocks.readHostPidMetadata.mockResolvedValue(HOST_PID_METADATA);
+    mocks.isProcessAlive
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+    const runner: ProcessRunner = async () => buildSuccessResult();
+    const controller = createMacosController(runner);
+
+    const stopping = controller.stop(label);
+    await vi.advanceTimersByTimeAsync(300);
+
+    await expect(stopping).resolves.toBeUndefined();
+    expect(mocks.isProcessAlive).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects when a stopped host remains alive through the shutdown timeout", async () => {
+    vi.useFakeTimers();
+    mocks.readHostPidMetadata.mockResolvedValue(HOST_PID_METADATA);
+    mocks.isProcessAlive.mockReturnValue(true);
+    const runner: ProcessRunner = async () => buildSuccessResult();
+    const controller = createMacosController(runner);
+
+    const stopping = controller.stop(label);
+    const result = expect(stopping).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+      message: expect.stringContaining("stop did not take effect"),
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.runAllTimersAsync();
+
+    await result;
   });
 });

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -1,4 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { mkdtempSync } from "node:fs";
 import { readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -12,7 +21,7 @@ import { ProcessRunError, type RunResult } from "../../process-runner";
 import { serviceLabelFor } from "../../label";
 import { CLI_ERROR_CODES } from "../../../runner/errors";
 
-const mocks = vi.hoisted(() => ({
+const MOCKS = vi.hoisted(() => ({
   readHostPidMetadata: vi.fn(),
   isProcessAlive: vi.fn(),
 }));
@@ -26,22 +35,25 @@ const HOST_PID_METADATA = {
 };
 
 vi.mock("../../../host/pid-metadata", () => ({
-  readHostPidMetadata: mocks.readHostPidMetadata,
+  readHostPidMetadata: MOCKS.readHostPidMetadata,
 }));
 
 vi.mock("../../../store/cli-lock", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../../../store/cli-lock")>();
-  return { ...actual, isProcessAlive: mocks.isProcessAlive };
+  return { ...actual, isProcessAlive: MOCKS.isProcessAlive };
 });
 
 // Test isolation: `serviceManifestPath` normally resolves to the REAL
 // `~/Library/LaunchAgents/<label>.plist` (via `os.homedir()`, which ignores
 // `$HOME`), so running this suite would write - and `afterEach`-remove - the
 // developer's actual host LaunchAgent, deregistering a running host.
-// Redirect the manifest path to a temp dir so the suite never touches real
-// macOS service registration.
-const TEST_LAUNCH_AGENTS_DIR = join(tmpdir(), "traycer-macos-service-test");
+// Redirect the manifest path to a private, uniquely-created temp dir so the
+// suite never touches real macOS service registration or follows a predictable
+// path another local user could pre-create.
+const TEST_LAUNCH_AGENTS_DIR = mkdtempSync(
+  join(tmpdir(), "traycer-macos-service-test-"),
+);
 vi.mock("../../label", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../label")>();
   return {
@@ -91,10 +103,10 @@ describe("macOS service lifecycle", () => {
 
   beforeEach(() => {
     createdPlistPath = null;
-    mocks.readHostPidMetadata.mockReset();
-    mocks.readHostPidMetadata.mockResolvedValue(null);
-    mocks.isProcessAlive.mockReset();
-    mocks.isProcessAlive.mockReturnValue(false);
+    MOCKS.readHostPidMetadata.mockReset();
+    MOCKS.readHostPidMetadata.mockResolvedValue(null);
+    MOCKS.isProcessAlive.mockReset();
+    MOCKS.isProcessAlive.mockReturnValue(false);
   });
 
   afterEach(async () => {
@@ -106,6 +118,10 @@ describe("macOS service lifecycle", () => {
     if (createdPlistPath !== null) {
       await rm(createdPlistPath, { force: true });
     }
+  });
+
+  afterAll(async () => {
+    await rm(tempPlistDir, { recursive: true, force: true });
   });
 
   it("on an existing registration runs print → bootout → bootstrap → kickstart and returns cleanly", async () => {
@@ -383,8 +399,8 @@ describe("macOS service lifecycle", () => {
         tolerateNonZeroExit: false,
       },
     ]);
-    expect(mocks.readHostPidMetadata).not.toHaveBeenCalled();
-    expect(mocks.isProcessAlive).not.toHaveBeenCalled();
+    expect(MOCKS.readHostPidMetadata).not.toHaveBeenCalled();
+    expect(MOCKS.isProcessAlive).not.toHaveBeenCalled();
   });
 
   it("treats an already-removed launchd service as a successful uninstall", async () => {
@@ -446,8 +462,8 @@ describe("macOS service lifecycle", () => {
 
   it("waits through delayed host exit when stopping", async () => {
     vi.useFakeTimers();
-    mocks.readHostPidMetadata.mockResolvedValue(HOST_PID_METADATA);
-    mocks.isProcessAlive
+    MOCKS.readHostPidMetadata.mockResolvedValue(HOST_PID_METADATA);
+    MOCKS.isProcessAlive
       .mockReturnValueOnce(true)
       .mockReturnValueOnce(true)
       .mockReturnValue(false);
@@ -458,13 +474,13 @@ describe("macOS service lifecycle", () => {
     await vi.advanceTimersByTimeAsync(300);
 
     await expect(stopping).resolves.toBeUndefined();
-    expect(mocks.isProcessAlive).toHaveBeenCalledTimes(3);
+    expect(MOCKS.isProcessAlive).toHaveBeenCalledTimes(3);
   });
 
   it("rejects when a stopped host remains alive through the shutdown timeout", async () => {
     vi.useFakeTimers();
-    mocks.readHostPidMetadata.mockResolvedValue(HOST_PID_METADATA);
-    mocks.isProcessAlive.mockReturnValue(true);
+    MOCKS.readHostPidMetadata.mockResolvedValue(HOST_PID_METADATA);
+    MOCKS.isProcessAlive.mockReturnValue(true);
     const runner: ProcessRunner = async () => buildSuccessResult();
     const controller = createMacosController(runner);
 

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -231,15 +231,37 @@ async function uninstallService(
   options: UninstallServiceOptions,
   run: ProcessRunner,
 ): Promise<void> {
-  // `bootout` non-zero exit on uninstall is a legitimate "already gone"
-  // signal - keep this tolerant so repeat uninstalls stay idempotent.
-  await run("launchctl", ["bootout", `${guiDomain()}/${options.label.id}`], {
-    env: undefined,
-    cwd: undefined,
-    timeoutMs: 10_000,
-    tolerateNonZeroExit: true,
-  });
+  const serviceTarget = `${guiDomain()}/${options.label.id}`;
+  try {
+    await run("launchctl", ["bootout", "--wait", serviceTarget], {
+      env: undefined,
+      cwd: undefined,
+      // `--wait` is launchd's authoritative completion barrier but may block
+      // indefinitely. Keep the subprocess bound above the host's own forced
+      // shutdown watchdog so normal graceful shutdown has time to finish.
+      timeoutMs: STOP_EXIT_TIMEOUT_MS,
+      tolerateNonZeroExit: false,
+    });
+  } catch (cause) {
+    if (!isBenignBootoutFailure(cause)) {
+      throw cliError({
+        code: CLI_ERROR_CODES.SERVICE_CONTROL_FAILED,
+        message: `launchctl bootout failed for ${options.label.id}: ${describeCause(cause)}`,
+        details: { label: options.label.id, cause: describeCause(cause) },
+        exitCode: 1,
+      });
+    }
+  }
   await rm(serviceManifestPath(options.label), { force: true });
+}
+
+function isBenignBootoutFailure(cause: unknown): boolean {
+  if (!(cause instanceof ProcessRunError)) return false;
+  const haystack = `${cause.stderr}\n${cause.stdout}`.toLowerCase();
+  return (
+    haystack.includes("no such process") ||
+    haystack.includes("could not find specified service")
+  );
 }
 
 async function statusService(label: ServiceLabel): Promise<ServiceStatus> {

--- a/scripts/__tests__/dev-desktop.test.mjs
+++ b/scripts/__tests__/dev-desktop.test.mjs
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -134,6 +134,29 @@ describe("dev-desktop concurrent stack entries", () => {
     expect(hostEntry?.command).toContain(
       "/tmp/traycer/example-slot/host.log",
     );
+  });
+
+  it("makes concurrent shutdown triggers await the same teardown", async () => {
+    let finishTeardown;
+    const onTeardown = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          finishTeardown = resolve;
+        }),
+    );
+    const teardown = devDesktop.createTeardown(onTeardown);
+
+    const first = teardown();
+    const second = teardown();
+
+    expect(onTeardown).toHaveBeenCalledOnce();
+    expect(second).toBe(first);
+
+    finishTeardown();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 });
 

--- a/scripts/dev-desktop.js
+++ b/scripts/dev-desktop.js
@@ -546,6 +546,28 @@ function buildDevDesktopEntries(hostLogPath, slot, port) {
   ];
 }
 
+// Collapse every shutdown trigger (terminal signal, child exit, spawn error)
+// onto one promise. A boolean-only guard lets later triggers return while the
+// first async teardown is still running; their process.exit() can then cut the
+// host uninstall short and leave the slot's host alive for the next launch.
+function createTeardown(onTeardown) {
+  let teardownPromise = null;
+  return function teardown() {
+    if (teardownPromise !== null) return teardownPromise;
+    teardownPromise = (async () => {
+      if (typeof onTeardown !== "function") return;
+      try {
+        await onTeardown();
+      } catch (err) {
+        console.warn(
+          `[dev-desktop] teardown error: ${err && err.message ? err.message : err}`,
+        );
+      }
+    })();
+    return teardownPromise;
+  };
+}
+
 // Spawn `concurrently` with the supplied stream entries, install signal
 // forwarders, and exit when either the user hits Ctrl-C or a child dies. Calls
 // `onTeardown` exactly once (signal path or exit/error path) before exiting.
@@ -573,19 +595,7 @@ function runConcurrentStack(options) {
     { stdio: "inherit", cwd, env: process.env },
   );
 
-  let tornDown = false;
-  async function teardown() {
-    if (tornDown) return;
-    tornDown = true;
-    if (typeof onTeardown !== "function") return;
-    try {
-      await onTeardown();
-    } catch (err) {
-      console.warn(
-        `[dev-desktop] teardown error: ${err && err.message ? err.message : err}`,
-      );
-    }
-  }
+  const teardown = createTeardown(onTeardown);
 
   const forwardSignal = (signal) => async () => {
     await teardown();
@@ -720,6 +730,7 @@ module.exports = {
   buildHostUninstallArgs,
   buildDevDesktopEntries,
   buildDevDesktopSlotEnv,
+  createTeardown,
   parseReleaseArg,
   parseSlotArg,
   resolveDevDesktopSlot,


### PR DESCRIPTION
## Summary

- make concurrent shutdown signals and child-exit paths await the same teardown promise before the orchestrator exits
- use a bounded `launchctl bootout --wait` barrier on macOS instead of relying on nullable PID metadata
- preserve idempotent uninstall for recognized not-found errors while surfacing permission failures and timeouts without deleting the service manifest
- add regression coverage for shared teardown, missing metadata, benign and real bootout failures, delayed host exit, and shutdown timeout

## Related issue

None.

## Validation

- `pre-commit run --all-files`
- `bun run compile`
- `bunx nx run @traycer-clients/traycer-cli:lint --tui=false`
- focused Vitest: 2 files, 31 tests passed
- `git diff --check`

Full repository tests were not run locally; pre-commit ran the affected build, compile, lint, and format targets.

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass (full suite not run locally)
- [x] Code is formatted (`bun run format` via affected pre-commit checks)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
