### PR TITLE
fix(gui-app): keep onboarding escapable while guide loads

### DIFF
--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
@@ -380,7 +380,7 @@ describe("OnboardingPage", () => {
     });
   });
 
-  it("waits for provider authorization to settle before editing a missing onboarding guide", async () => {
+  it("keeps onboarding navigation available while provider discovery settles", async () => {
     guideQueryState = {
       data: {
         content: null,
@@ -399,7 +399,49 @@ describe("OnboardingPage", () => {
     expect(input.disabled).toBe(true);
     expect(
       screen.getByTestId<HTMLButtonElement>("onboarding-advance").disabled,
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      screen.getByTestId<HTMLButtonElement>("onboarding-skip").disabled,
+    ).toBe(false);
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => {
+      expect(useOnboardingStore.getState().completedAt).not.toBeNull();
+    });
+    expect(setGlobalGuideMock).not.toHaveBeenCalled();
+  });
+
+  it("persists an edited existing guide even while provider discovery is still settling", async () => {
+    guideQueryState = {
+      data: {
+        content: "saved guide",
+        generatedDefaultContent: "claude guide",
+        providersSettled: false,
+      },
+      isError: false,
+    };
+    renderPage({ replay: false });
+
+    await advanceToStage(4);
+
+    const input = screen.getByTestId<HTMLTextAreaElement>(
+      "mock-agent-guide-input",
+    );
+    expect(input.disabled).toBe(false);
+
+    fireEvent.change(input, {
+      target: { value: "edited while providers settle" },
+    });
+    fireEvent.click(screen.getByTestId("onboarding-skip"));
+
+    await waitFor(() => {
+      expect(setGlobalGuideMock).toHaveBeenCalledWith({
+        content: "edited while providers settle",
+      });
+    });
+    await waitFor(() => {
+      expect(useOnboardingStore.getState().completedAt).not.toBeNull();
+    });
   });
 
   it("never traps the user when the onboarding guide fails to load", async () => {

--- a/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
+++ b/clients/gui-app/src/components/onboarding/__tests__/onboarding-page.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@/components/onboarding/onboarding-diorama", () => ({
         <>
           <textarea
             data-testid="mock-agent-guide-input"
+            aria-label="Agent selection guide"
             value={props.agentGuide.value}
             disabled={props.agentGuide.loading || props.agentGuide.saving}
             onChange={(event) =>
@@ -393,15 +394,17 @@ describe("OnboardingPage", () => {
 
     await advanceToStage(4);
 
-    const input = screen.getByTestId<HTMLTextAreaElement>(
-      "mock-agent-guide-input",
-    );
+    const input = screen.getByRole<HTMLTextAreaElement>("textbox", {
+      name: "Agent selection guide",
+    });
     expect(input.disabled).toBe(true);
     expect(
-      screen.getByTestId<HTMLButtonElement>("onboarding-advance").disabled,
+      screen.getByRole<HTMLButtonElement>("button", { name: /continue/i })
+        .disabled,
     ).toBe(false);
     expect(
-      screen.getByTestId<HTMLButtonElement>("onboarding-skip").disabled,
+      screen.getByRole<HTMLButtonElement>("button", { name: /skip intro/i })
+        .disabled,
     ).toBe(false);
 
     fireEvent.keyDown(window, { key: "Escape" });
@@ -424,15 +427,15 @@ describe("OnboardingPage", () => {
 
     await advanceToStage(4);
 
-    const input = screen.getByTestId<HTMLTextAreaElement>(
-      "mock-agent-guide-input",
-    );
+    const input = screen.getByRole<HTMLTextAreaElement>("textbox", {
+      name: "Agent selection guide",
+    });
     expect(input.disabled).toBe(false);
 
     fireEvent.change(input, {
       target: { value: "edited while providers settle" },
     });
-    fireEvent.click(screen.getByTestId("onboarding-skip"));
+    fireEvent.click(screen.getByRole("button", { name: /skip intro/i }));
 
     await waitFor(() => {
       expect(setGlobalGuideMock).toHaveBeenCalledWith({

--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -442,12 +442,6 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
     !agentGuideQueryData.providersSettled;
   const agentGuideLoading =
     agentGuideQueryData === undefined || agentGuideWaitingForProviderSettlement;
-  // The guide editor keeps spinning while the read is pending or has failed (it
-  // never resolves to a usable guide on error). Navigation, however, must never
-  // be trapped by the optional guide: a failed read leaves Skip/Advance enabled
-  // so the user can always leave onboarding. Only an in-flight, non-errored read
-  // blocks progression.
-  const agentGuideBlocking = agentGuideLoading && !agentGuideQuery.isError;
 
   useLayoutEffect(() => {
     restart();
@@ -510,11 +504,19 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
   }, [agentGuideDefault, resetAgentGuideSetMutation]);
 
   const saveAgentGuideDraft = useCallback(async (): Promise<boolean> => {
-    if (agentGuideBlocking || agentGuideSaving) return false;
-    // The guide is optional. When it never loaded (read error) there is nothing
-    // to persist, so report success and let onboarding complete rather than
-    // trapping the user behind a failed read.
-    if (agentGuideQueryData === undefined) return true;
+    if (agentGuideSaving) return false;
+    // The guide is optional. When it has not loaded, or still reflects an
+    // in-flight generated default with no saved content yet, there is no
+    // stable draft to persist. Report success so Skip/Escape and the final
+    // action can always leave onboarding; the host can seed the fully
+    // resolved default later. An existing saved guide the user edited must
+    // still persist even while providers are still settling.
+    if (
+      agentGuideQueryData === undefined ||
+      agentGuideWaitingForProviderSettlement
+    ) {
+      return true;
+    }
     const content = agentGuideDraft ?? agentGuideDefault;
     return setAgentGuideGlobal({ content }).then(
       (result) => {
@@ -530,11 +532,11 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
       () => false,
     );
   }, [
-    agentGuideBlocking,
     agentGuideDefault,
     agentGuideDraft,
     agentGuideQueryData,
     agentGuideSaving,
+    agentGuideWaitingForProviderSettlement,
     setAgentGuideGlobal,
   ]);
 
@@ -547,8 +549,7 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
     onValueChange: updateAgentGuideDraft,
     onRevertToDefault: revertAgentGuideDraft,
   };
-  const advanceDisabled =
-    (isAgentGuideAct || isLastAct) && (agentGuideBlocking || agentGuideSaving);
+  const advanceDisabled = (isAgentGuideAct || isLastAct) && agentGuideSaving;
 
   // Finishing the tour must never leave the app on the tabless landing.
   // Replay-from-settings sets `?replay=true` (and pushed /onboarding onto the
@@ -630,7 +631,7 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
               type="button"
               data-testid="onboarding-skip"
               onClick={finish}
-              disabled={agentGuideBlocking || agentGuideSaving}
+              disabled={agentGuideSaving}
               className="absolute right-10 flex h-9 items-center justify-center gap-2 rounded px-2 font-heading text-[0.875rem] leading-[1.125rem] font-normal tracking-normal text-white transition-colors hover:bg-white/10 disabled:pointer-events-none disabled:opacity-55 [@media(min-height:920px)]:h-10 [@media(min-height:920px)]:text-[0.9375rem] max-sm:right-5"
             >
               <span>Skip intro</span>


### PR DESCRIPTION
## Summary
- keep Continue and Skip/Escape available while the optional agent-selection guide is loading
- avoid saving provisional generated defaults while still preserving edits to an existing saved guide
- add regression coverage for unsettled provider discovery, Escape completion, and existing-guide persistence

## Validation
- pre-commit run --all-files
- gui-app compile
- 17 focused onboarding tests
- changed-files React Doctor: no issues

## Checklist
- [x] Build, compile, lint, and format checks pass
- [x] Tests added/updated
- [x] Pre-commit hooks pass
- [x] Commit is DCO signed

Companion host change will be linked from the internal PR.