### PR TITLE
feat(gui): add report issue actions to error states

### DIFF
--- a/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-assistant-body.tsx
@@ -13,7 +13,6 @@ import type {
 } from "@/stores/composer/chat-store";
 import { Check, Copy, GitBranch, Sparkles } from "lucide-react";
 import { use, useCallback, useMemo } from "react";
-import { toast } from "sonner";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 import { useElapsedSeconds } from "@/hooks/use-elapsed-seconds";
 import { formatClockDuration } from "@/lib/format-duration";
@@ -37,11 +36,17 @@ import { SubagentSegment } from "./segments/subagent-segment";
 import { TextSegment } from "./segments/text-segment";
 import { TodoSegment } from "./segments/todo-segment";
 import { ToolSegment } from "./segments/tool-segment";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const COPIED_RESET_MS = 1600;
 
 const handleCopyError = (): void => {
-  toast.error("Couldn't copy to clipboard.");
+  reportableErrorToast("Couldn't copy to clipboard.", undefined, {
+    title: "Could not copy to clipboard",
+    message: null,
+    code: null,
+    source: "Clipboard",
+  });
 };
 
 /**

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -9,7 +9,6 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { toast } from "sonner";
 import { v4 as uuidv4 } from "uuid";
 import {
   useCallback,
@@ -77,6 +76,7 @@ import { useTombstonedProfileLabel } from "./use-tombstoned-profile-label";
 import { AccentDot } from "@/components/providers/accent-dot";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import type { ProviderId } from "@/components/home/data/landing-options";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const NOOP: () => void = () => undefined;
 const NOOP_CLIPBOARD: ClipboardEventHandler<HTMLElement> = () => undefined;
@@ -89,7 +89,12 @@ const DISPLAY_MAX_HEIGHT_PX = 120;
 const COPIED_RESET_MS = 1600;
 
 const handleCopyError = (): void => {
-  toast.error("Couldn't copy to clipboard.");
+  reportableErrorToast("Couldn't copy to clipboard.", undefined, {
+    title: "Could not copy to clipboard",
+    message: null,
+    code: null,
+    source: "Clipboard",
+  });
 };
 
 interface UserBodyProps {

--- a/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
+++ b/clients/gui-app/src/components/chat/composer/provider-reauth-banner.tsx
@@ -35,6 +35,8 @@ import { useTabRefreshProviders } from "@/hooks/providers/use-tab-refresh-provid
 import { HostRuntimeContext, useHostBinding } from "@/lib/host/runtime";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 // Static destructive icon shared by every banner state. Hoisted to module scope
 // so it isn't rebuilt on each render.
@@ -133,7 +135,19 @@ function ReauthBannerShell({
         <div className="flex items-start gap-2">
           {icon}
           <div className="flex min-w-0 flex-1 flex-col gap-2">{children}</div>
-          {action}
+          <div className="flex shrink-0 items-center gap-1">
+            {action}
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Provider needs to be reconnected",
+                message: null,
+                code: null,
+                source: "Provider sign-in",
+              })}
+              presentation="icon"
+              className="-my-1 -mr-1 text-destructive"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
+++ b/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
@@ -9,6 +9,7 @@ import {
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { useTabProvidersList } from "@/hooks/providers/use-tab-providers-list-query";
 import type { ComposerSeedSourceKind } from "@/lib/composer/composer-seed-source";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 // The harness id set is a superset of the provider-CLI id set (it also carries
 // `traycer`, which has no provider-CLI login). Only CLI harnesses gate. Grok,
@@ -218,7 +219,16 @@ export function useProviderReauthGate(
     if (providerUnauthenticated && providerId !== null) {
       if (signedOutProviderRef.current !== providerId) {
         signedOutProviderRef.current = providerId;
-        toast.error(`${PROVIDER_DISPLAY_NAMES[providerId]} is signed out`);
+        reportableErrorToast(
+          `${PROVIDER_DISPLAY_NAMES[providerId]} is signed out`,
+          undefined,
+          {
+            title: "Provider signed out",
+            message: null,
+            code: null,
+            source: "Chat",
+          },
+        );
       }
     } else if (
       authStatus === "authenticated" &&

--- a/clients/gui-app/src/components/chat/segments/__tests__/error-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/error-segment.test.tsx
@@ -1,12 +1,15 @@
 import "../../../../../__tests__/test-browser-apis";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { ErrorSegment } from "../error-segment";
 
 describe("<ErrorSegment />", () => {
   afterEach(() => {
     cleanup();
+    useDesktopDialogStore.getState().close();
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
   });
 
   // Auth errors never reach this component - they're suppressed at the
@@ -34,5 +37,29 @@ describe("<ErrorSegment />", () => {
 
     expect(screen.getByText("Error")).toBeDefined();
     expect(screen.getByText("Something failed")).toBeDefined();
+  });
+
+  it("does not copy a hostile transcript code into public report context", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    const hostileCode = "/Users/alice/private.txt?token=sk-secret";
+
+    render(
+      <TooltipProvider>
+        <ErrorSegment
+          message="Something failed"
+          code={hostileCode}
+          findUnitId={null}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText(hostileCode)).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Chat error",
+      message: null,
+      code: null,
+      source: "Chat",
+    });
   });
 });

--- a/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
@@ -133,6 +133,7 @@ afterEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 

--- a/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -7,6 +8,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import {
   SetupCardSegment,
   type SetupCardViewModel,
@@ -127,6 +129,11 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
 });
 
 describe("<SetupCardSegment /> worktree location", () => {
@@ -321,6 +328,39 @@ describe("<SetupCardSegment /> single-repo dropdown (two steps)", () => {
     expect(retryMutate).toHaveBeenCalledWith(
       expect.objectContaining({ workspacePath: "/repo" }),
     );
+  });
+
+  it("gates the failed-setup report action on capability and reports only fixed generic context", () => {
+    renderCard(
+      viewModel("failed", [workspace({ state: "failed", setupExitCode: 1 })]),
+    );
+
+    // Capability-gated off by default.
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Worktree setup failed",
+        message: null,
+        code: null,
+        source: "Setup",
+      },
+    });
+  });
+
+  it("omits the report action for a cancelled (non-failed) setup", () => {
+    renderCard(viewModel("cancelled", [workspace({ state: "cancelled" })]));
+    expand();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/chat/segments/error-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/error-segment.tsx
@@ -1,4 +1,6 @@
 import { AlertTriangle } from "lucide-react";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 interface ErrorSegmentProps {
   message: string;
@@ -35,6 +37,16 @@ export function ErrorSegment({ code, findUnitId, message }: ErrorSegmentProps) {
             {message}
           </span>
         </div>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Chat error",
+            message: null,
+            code: null,
+            source: "Chat",
+          })}
+          presentation="icon"
+          className="-mt-1 -mr-1 shrink-0"
+        />
       </div>
     </div>
   );

--- a/clients/gui-app/src/components/chat/segments/next-steps-action-group.tsx
+++ b/clients/gui-app/src/components/chat/segments/next-steps-action-group.tsx
@@ -1,10 +1,10 @@
 import { ArrowRight, Check, Copy } from "lucide-react";
 import { useCallback } from "react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 import type { TraycerNextStepOption } from "@/markdown/traycer-next-steps";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 export interface NextStepActionHandler {
   readonly canSend: boolean;
@@ -23,7 +23,12 @@ interface NextStepsActionGroupProps {
 const COPIED_RESET_MS = 1600;
 
 const handleCopyError = (): void => {
-  toast.error("Couldn't copy to clipboard.");
+  reportableErrorToast("Couldn't copy to clipboard.", undefined, {
+    title: "Could not copy to clipboard",
+    message: null,
+    code: null,
+    source: "Clipboard",
+  });
 };
 
 export function NextStepsActionGroup(props: NextStepsActionGroupProps) {

--- a/clients/gui-app/src/components/chat/segments/plan-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/plan-segment.tsx
@@ -50,7 +50,7 @@ import {
   planHeadline,
 } from "./plan-display";
 import { cn } from "@/lib/utils";
-import { toast } from "sonner";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 interface PlanSegmentProps {
   readonly segment: PlanSegmentModel;
@@ -69,7 +69,12 @@ const STATUS_ICONS: Record<PlanSegmentModel["planStatus"], LucideIcon> = {
 };
 
 const handleCopyError = (): void => {
-  toast.error("Couldn't copy to clipboard.");
+  reportableErrorToast("Couldn't copy to clipboard.", undefined, {
+    title: "Could not copy to clipboard",
+    message: null,
+    code: null,
+    source: "Clipboard",
+  });
 };
 
 export function PlanSegment(props: PlanSegmentProps) {

--- a/clients/gui-app/src/components/chat/segments/segment-copy-button.tsx
+++ b/clients/gui-app/src/components/chat/segments/segment-copy-button.tsx
@@ -1,8 +1,8 @@
 import { Check, Copy } from "lucide-react";
 import { useCallback } from "react";
-import { toast } from "sonner";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 import { cn } from "@/lib/utils";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 interface SegmentCopyButtonProps {
   value: string;
@@ -13,7 +13,12 @@ interface SegmentCopyButtonProps {
 const COPIED_RESET_MS = 1600;
 
 const handleCopyError = (): void => {
-  toast.error("Couldn't copy to clipboard.");
+  reportableErrorToast("Couldn't copy to clipboard.", undefined, {
+    title: "Could not copy to clipboard",
+    message: null,
+    code: null,
+    source: "Clipboard",
+  });
 };
 
 /**

--- a/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
@@ -21,6 +21,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { FilePathTooltip } from "@/components/file-path-tooltip";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import { useFocusEpicTerminalSession } from "@/components/epic-canvas/renderers/chat-tile-focus-terminal";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
@@ -348,6 +350,19 @@ function WorkspaceSetupDetail(
         onRetry={() => onRetry(entry.workspacePath)}
       />
     ) : null;
+  const reportIssue =
+    entry.state === "failed" ? (
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Worktree setup failed",
+          message: null,
+          code: null,
+          source: "Setup",
+        })}
+        presentation="icon"
+        className={undefined}
+      />
+    ) : null;
   return (
     <div
       data-testid={`setup-card-workspace-${entry.workspacePath}`}
@@ -395,6 +410,7 @@ function WorkspaceSetupDetail(
             }
           />
           {retry}
+          {reportIssue}
         </li>
       </ol>
     </div>

--- a/clients/gui-app/src/components/copy-text-button.tsx
+++ b/clients/gui-app/src/components/copy-text-button.tsx
@@ -1,8 +1,8 @@
 import { Check, Copy } from "lucide-react";
 import { useCallback } from "react";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const COPIED_RESET_MS = 1600;
 
@@ -26,7 +26,13 @@ export function CopyTextButton(props: CopyTextButtonProps) {
   const { copied, copy } = useClipboardCopy({
     resetMs: COPIED_RESET_MS,
     onSuccess: null,
-    onError: () => toast.error("Couldn't copy to clipboard."),
+    onError: () =>
+      reportableErrorToast("Couldn't copy to clipboard.", undefined, {
+        title: "Could not copy to clipboard",
+        message: null,
+        code: null,
+        source: "Clipboard",
+      }),
   });
   const handleCopy = useCallback(() => copy(value), [copy, value]);
   const Icon = copied ? Check : Copy;

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-toasts.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-toasts.test.tsx
@@ -181,7 +181,7 @@ describe("<EpicConnectionToasts />", () => {
     await waitFor(() => {
       expect(sonner.info).toHaveBeenCalledWith(
         "Your role on this Epic is now Editor.",
-        { id: "epic-role:epic-role-toast" },
+        { id: "epic-role:epic-role-toast", cancel: null },
       );
     });
     expect(sonner.warning).not.toHaveBeenCalled();
@@ -213,7 +213,7 @@ describe("<EpicConnectionToasts />", () => {
     await waitFor(() => {
       expect(sonner.warning).toHaveBeenCalledWith(
         "Your role on this Epic is now Viewer. Pending edits were discarded.",
-        { id: "epic-role:epic-role-toast" },
+        { id: "epic-role:epic-role-toast", cancel: null },
       );
     });
     expect(handle.store.getState().unsyncedQueueSize).toBe(0);

--- a/clients/gui-app/src/components/epic-canvas/dialogs/epic-migration-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/dialogs/epic-migration-modal.tsx
@@ -5,6 +5,8 @@ import { Check } from "lucide-react";
 import type { EpicMigrationPhase } from "@traycer/protocol/host/epic/subscribe";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { cn } from "@/lib/utils";
 import {
   useEpicMigrationState,
@@ -221,10 +223,20 @@ function ErrorBody(props: ErrorBodyProps): ReactNode {
         {TITLE_ERROR}
       </DialogPrimitive.Title>
       <p className="text-sm text-muted-foreground">{BODY_ERROR}</p>
-      <div className="flex justify-end gap-2">
+      <div className="flex flex-wrap justify-end gap-2">
         <Button type="button" variant="ghost" onClick={props.onClose}>
           Close
         </Button>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: TITLE_ERROR,
+            message: BODY_ERROR,
+            code: null,
+            source: "Epic migration",
+          })}
+          presentation="text"
+          className={undefined}
+        />
         <Button
           type="button"
           onClick={props.onRetry}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/git-roots-unavailable.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/git-roots-unavailable.tsx
@@ -1,7 +1,9 @@
 import { useCallback, type ReactNode } from "react";
 import { TriangleAlert, RotateCcw } from "lucide-react";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { Button } from "@/components/ui/button";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { cn } from "@/lib/utils";
 
 const GIT_ROOTS_REFRESH_TIMEOUT_MS = 10_000;
@@ -46,24 +48,35 @@ export function GitRootsUnavailable(props: {
           </p>
         </div>
       </div>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={refresh.trigger}
-        disabled={refresh.refreshing}
-        className="mt-2"
-        data-testid="git-roots-unavailable-retry"
-      >
-        <RotateCcw
-          className={cn(
-            "mr-1.5 size-3.5",
-            refresh.refreshing && "animate-spin",
-          )}
-          aria-hidden
+      <div className="mt-2 flex flex-wrap justify-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={refresh.trigger}
+          disabled={refresh.refreshing}
+          data-testid="git-roots-unavailable-retry"
+        >
+          <RotateCcw
+            className={cn(
+              "mr-1.5 size-3.5",
+              refresh.refreshing && "animate-spin",
+            )}
+            aria-hidden
+          />
+          Retry
+        </Button>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Git workspaces unavailable",
+            message: "The Git workspaces in this chat could not be read.",
+            code: null,
+            source: "Git changes",
+          })}
+          presentation="text"
+          className={undefined}
         />
-        Retry
-      </Button>
+      </div>
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/host-unsupported.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/host-unsupported.tsx
@@ -1,5 +1,7 @@
 import { AlertCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 export function HostUnsupported(props: { readonly reason: string }) {
   return (
@@ -15,9 +17,21 @@ export function HostUnsupported(props: { readonly reason: string }) {
             <p className="mt-2 text-sm">{props.reason}</p>
           </div>
         </div>
-        <Button variant="outline" size="sm" className="w-fit" asChild>
-          <a href="#update-host">Update Traycer Host</a>
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" className="w-fit" asChild>
+            <a href="#update-host">Update Traycer Host</a>
+          </Button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Git panel unavailable",
+              message: "The Git panel is not supported by the current host.",
+              code: null,
+              source: "Git changes",
+            })}
+            presentation="text"
+            className={undefined}
+          />
+        </div>
       </div>
     </div>
   );

--- a/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/submodule-unavailable.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/submodule-unavailable.tsx
@@ -1,7 +1,9 @@
 import { useCallback, type ReactNode } from "react";
 import { TriangleAlert, RotateCcw } from "lucide-react";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { Button } from "@/components/ui/button";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { cn } from "@/lib/utils";
 
 const GIT_SUBMODULE_REFRESH_TIMEOUT_MS = 10_000;
@@ -42,24 +44,35 @@ export function SubmoduleUnavailable(props: {
           </p>
         </div>
       </div>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={refresh.trigger}
-        disabled={refresh.refreshing}
-        className="mt-2"
-        data-testid="git-submodule-unavailable-refresh"
-      >
-        <RotateCcw
-          className={cn(
-            "mr-1.5 size-3.5",
-            refresh.refreshing && "animate-spin",
-          )}
-          aria-hidden
+      <div className="mt-2 flex flex-wrap justify-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={refresh.trigger}
+          disabled={refresh.refreshing}
+          data-testid="git-submodule-unavailable-refresh"
+        >
+          <RotateCcw
+            className={cn(
+              "mr-1.5 size-3.5",
+              refresh.refreshing && "animate-spin",
+            )}
+            aria-hidden
+          />
+          Refresh
+        </Button>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Submodule details unavailable",
+            message: "The host could not inspect the Git submodule.",
+            code: null,
+            source: "Git changes",
+          })}
+          presentation="text"
+          className={undefined}
         />
-        Refresh
-      </Button>
+      </div>
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/subscription-error-state.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/empty-states/subscription-error-state.tsx
@@ -1,5 +1,7 @@
 import type { GitSubscribeStatusEvent } from "@traycer/protocol/host/git-schemas";
 import { AlertCircle } from "lucide-react";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 export interface SubscriptionErrorStateProps {
   readonly event: GitSubscribeStatusEvent;
@@ -16,6 +18,16 @@ export function SubscriptionErrorState(props: SubscriptionErrorStateProps) {
         <p className="text-sm font-medium text-foreground">Error</p>
         <p className="text-xs text-muted-foreground max-w-sm">{message}</p>
       </div>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Git subscription error",
+          message: "The Git changes subscription failed.",
+          code: null,
+          source: "Git changes",
+        })}
+        presentation="text"
+        className={undefined}
+      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-error-block.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-error-block.tsx
@@ -1,5 +1,7 @@
 import { AlertTriangleIcon } from "lucide-react";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 interface GitErrorBlockProps {
   readonly error: HostRpcError;
@@ -13,6 +15,16 @@ export function GitErrorBlock(props: GitErrorBlockProps) {
       <p className="text-sm text-muted-foreground">
         {props.error.message || "An error occurred while loading the diff"}
       </p>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Diff loading error",
+          message: "The Git diff could not be loaded.",
+          code: props.error.code,
+          source: "Git changes",
+        })}
+        presentation="text"
+        className={undefined}
+      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/selected-repo-changes.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/selected-repo-changes.tsx
@@ -40,7 +40,9 @@ import {
   InputGroupInput,
 } from "@/components/ui/input-group";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { cn } from "@/lib/utils";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import { FileList } from "./file-list";
 import { RepoStateBanner } from "./repo-state-banner";
@@ -760,6 +762,16 @@ function GitSnapshotErrorBanner(props: { readonly error: HostRpcError }) {
       <span className="min-w-0 truncate">
         {props.error.message || "Could not refresh git changes"}
       </span>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Could not refresh git changes",
+          message: "The Git changes snapshot could not be refreshed.",
+          code: props.error.code,
+          source: "Git changes",
+        })}
+        presentation="icon"
+        className="-my-1 shrink-0 text-warning-foreground"
+      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/__tests__/access-lists-report-issue.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/__tests__/access-lists-report-issue.test.tsx
@@ -1,0 +1,116 @@
+import "../../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { PeopleWithAccess, TeamsAccess } from "../access-lists";
+
+function renderPeopleError(): void {
+  render(
+    <TooltipProvider>
+      <PeopleWithAccess
+        loadState="error"
+        collaborators={[]}
+        accessPermission="owner"
+        directOwnerCount={1}
+        batchUpdateRolesPending={false}
+        pendingRoleUserId={null}
+        pendingRevokeUserId={null}
+        onRoleChange={() => undefined}
+        onRevokeRequest={() => undefined}
+      />
+    </TooltipProvider>,
+  );
+}
+
+function renderTeamsError(): void {
+  render(
+    <TooltipProvider>
+      <TeamsAccess
+        loadState="error"
+        rows={[]}
+        accessPermission="owner"
+        pending={{
+          anyMutation: false,
+          shareTeamId: null,
+          roleTeamId: null,
+          revokeTeamId: null,
+        }}
+        teamRolesById={{}}
+        onPendingTeamRoleChange={() => undefined}
+        onShareTeam={() => undefined}
+        onRoleChange={() => undefined}
+        onRevokeRequest={() => undefined}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("epic-sharing access lists report action", () => {
+  afterEach(() => {
+    cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
+  });
+
+  it("hides the report action on the collaborators error state when capability is unavailable", () => {
+    renderPeopleError();
+
+    screen.getByText("Couldn't load collaborators.");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+
+  it("reports only fixed generic context for a collaborators load failure", () => {
+    renderPeopleError();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load collaborators",
+        message: "Epic collaborators could not be loaded.",
+        code: null,
+        source: "Epic sharing",
+      },
+    });
+  });
+
+  it("hides the report action on the teams error state when capability is unavailable", () => {
+    renderTeamsError();
+
+    screen.getByText("Couldn't load teams.");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+
+  it("reports only fixed generic context for a teams load failure", () => {
+    renderTeamsError();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load teams",
+        message: "Epic teams could not be loaded.",
+        code: null,
+        source: "Epic sharing",
+      },
+    });
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/access-lists.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/access-lists.tsx
@@ -3,6 +3,11 @@ import type { ReactNode } from "react";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import {
+  createReportIssueContext,
+  type ReportIssueContext,
+} from "@/lib/report-issue-context";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   ROLE_PILL_CLASS,
@@ -54,10 +59,29 @@ export interface TeamsAccessProps {
   readonly onRevokeRequest: (team: TeamRow) => void;
 }
 
+const COLLABORATORS_LOAD_ERROR_CONTEXT = createReportIssueContext({
+  title: "Couldn't load collaborators",
+  message: "Epic collaborators could not be loaded.",
+  code: null,
+  source: "Epic sharing",
+});
+
+const TEAMS_LOAD_ERROR_CONTEXT = createReportIssueContext({
+  title: "Couldn't load teams",
+  message: "Epic teams could not be loaded.",
+  code: null,
+  source: "Epic sharing",
+});
+
 export function PeopleWithAccess(props: PeopleWithAccessProps) {
   if (props.loadState === "loading") return <SharingLoadingRows />;
   if (props.loadState === "error") {
-    return <SharingError label="Couldn't load collaborators." />;
+    return (
+      <SharingError
+        label="Couldn't load collaborators."
+        reportContext={COLLABORATORS_LOAD_ERROR_CONTEXT}
+      />
+    );
   }
   if (props.collaborators.length === 0) {
     return (
@@ -98,7 +122,12 @@ export function PeopleWithAccess(props: PeopleWithAccessProps) {
 export function TeamsAccess(props: TeamsAccessProps) {
   if (props.loadState === "loading") return <SharingLoadingRows />;
   if (props.loadState === "error") {
-    return <SharingError label="Couldn't load teams." />;
+    return (
+      <SharingError
+        label="Couldn't load teams."
+        reportContext={TEAMS_LOAD_ERROR_CONTEXT}
+      />
+    );
   }
   if (props.rows.length === 0) {
     return (
@@ -162,14 +191,22 @@ function SharingLoadingRows() {
   );
 }
 
-function SharingError(props: { label: string }) {
+function SharingError(props: {
+  readonly label: string;
+  readonly reportContext: ReportIssueContext;
+}) {
   return (
-    <p
-      className="rounded-md border border-dashed border-destructive/40 px-3 py-2 text-ui-xs text-destructive"
+    <div
+      className="flex items-center justify-between gap-2 rounded-md border border-dashed border-destructive/40 px-3 py-2 text-ui-xs text-destructive"
       data-testid="epic-sharing-error"
     >
-      {props.label}
-    </p>
+      <span>{props.label}</span>
+      <ReportIssueAction
+        context={props.reportContext}
+        presentation="icon"
+        className={undefined}
+      />
+    </div>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/use-controller.ts
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/use-controller.ts
@@ -38,6 +38,7 @@ import {
   type QueuedInvite,
 } from "@/lib/epic-invites";
 import { toast } from "sonner";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const EMPTY_DIRECT_USERS: ReadonlyArray<EpicCollaboratorView> = [];
 const EMPTY_TEAMS: ReadonlyArray<EpicTeamCollaboratorView> = [];
@@ -201,8 +202,15 @@ export function useEpicSharingPanelController(
     });
 
     if (result.failedInvites.length > 0) {
-      toast.error(
+      reportableErrorToast(
         `Couldn't invite ${result.failedInvites.map(formatInviteLabel).join(", ")}`,
+        undefined,
+        {
+          title: "Could not invite collaborators",
+          message: null,
+          code: null,
+          source: "Epic sharing",
+        },
       );
     }
   };

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -49,6 +49,7 @@ beforeEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 
@@ -57,6 +58,7 @@ afterEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { ExternalToast } from "sonner";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
   ChatActiveTurn,
@@ -6,11 +8,57 @@ import type {
   ChatRunSettings,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { ChatMessage } from "@/stores/composer/chat-store";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+const toastSuccess = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "success-toast",
+  ),
+);
+const toastWarning = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "warning-toast",
+  ),
+);
+const toastInfo = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "info-toast",
+  ),
+);
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccess,
+    warning: toastWarning,
+    info: toastInfo,
+  },
+}));
+
 import {
   chatMessageEditingForInlineEdit,
   resolvedTurnStatus,
+  showRestoreResultToast,
   type InlineEditState,
 } from "../chat-tile-session-state";
+
+beforeEach(() => {
+  toastSuccess.mockClear();
+  toastWarning.mockClear();
+  toastInfo.mockClear();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
+
+afterEach(() => {
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
 
 const CONTENT: JsonContent = {
   type: "doc",
@@ -89,6 +137,107 @@ describe("chatMessageEditingForInlineEdit", () => {
     expect(renderInlineEdit(true).canSubmit).toBe(true);
   });
 });
+
+describe("showRestoreResultToast", () => {
+  const FAILED_RESULT = {
+    filePath: "/Users/alice/private-project/secrets.txt",
+    status: "failed" as const,
+    operation: "edit" as const,
+    reason: "Restore rejected for token sk-secret-123",
+  };
+
+  it("keeps Show details primary and adds a privacy-safe secondary report action", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+
+    showRestoreResultToast([FAILED_RESULT]);
+
+    const options = readWarningOptions();
+    expect(toastWarning.mock.lastCall?.[0]).toBe(
+      "0 restored, 0 skipped, 1 failed",
+    );
+    expectToastAction(options.action, "Show details");
+    expectToastAction(options.cancel, "Report issue");
+    clickToastAction(options.action, "Show details");
+    expect(toastInfo).toHaveBeenCalledWith("Restore details", {
+      description:
+        "failed: /Users/alice/private-project/secrets.txt (Restore rejected for token sk-secret-123)",
+    });
+
+    clickToastAction(options.cancel, "Report issue");
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "File restore incomplete",
+      message: null,
+      code: null,
+      source: "File restore",
+    });
+    expect(
+      JSON.stringify(useDesktopDialogStore.getState().reportIssueContext),
+    ).not.toMatch(/alice|private-project|secrets\.txt|sk-secret-123/);
+  });
+
+  it("keeps Show details but omits reporting when capability is unavailable", () => {
+    showRestoreResultToast([FAILED_RESULT]);
+
+    const options = readWarningOptions();
+    expect(toastWarning.mock.lastCall?.[0]).toBe(
+      "0 restored, 0 skipped, 1 failed",
+    );
+    expectToastAction(options.action, "Show details");
+    expect(options.cancel).toBeUndefined();
+  });
+
+  it("leaves skipped-only restore notifications on the success path", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+
+    showRestoreResultToast([
+      {
+        filePath: "/Users/alice/private-project/unchanged.txt",
+        status: "skipped",
+        operation: "edit",
+        reason: "Already matches",
+      },
+    ]);
+
+    expect(toastWarning).not.toHaveBeenCalled();
+    expect(toastSuccess.mock.lastCall?.[0]).toBe(
+      "0 restored, 1 skipped, 0 failed",
+    );
+    const options = toastSuccess.mock.lastCall?.[1];
+    if (options === undefined) {
+      throw new Error("Expected success toast options.");
+    }
+    expectToastAction(options.action, "Show details");
+    expect(options).not.toHaveProperty("cancel");
+  });
+});
+
+function readWarningOptions(): ExternalToast {
+  const options = toastWarning.mock.lastCall?.[1];
+  if (options === undefined) {
+    throw new Error("Expected warning toast options.");
+  }
+  return options;
+}
+
+function clickToastAction(
+  action: ExternalToast["action"],
+  label: string,
+): void {
+  if (typeof action !== "object" || action === null || !("onClick" in action)) {
+    throw new Error(`Expected ${label} action.`);
+  }
+  action.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+}
+
+function expectToastAction(
+  action: ExternalToast["action"],
+  label: string,
+): void {
+  if (typeof action !== "object" || action === null || !("label" in action)) {
+    throw new Error(`Expected ${label} action.`);
+  }
+  expect(action.label).toBe(label);
+}
 
 const ACTIVE_TURN: ChatActiveTurn = {
   turnId: "turn-1",

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
@@ -1,6 +1,8 @@
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { ExternalToast } from "sonner";
 
 vi.mock(
   "@/components/home/host-workspace-selector/host-workspace-selector",
@@ -37,7 +39,11 @@ vi.mock("@/stores/epics/canvas/store", () => ({
   findOpenArtifactInTab: () => null,
 }));
 
-const sonnerToastWarning = vi.hoisted(() => vi.fn());
+const sonnerToastWarning = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "warning-toast",
+  ),
+);
 const sonnerToastError = vi.hoisted(() => vi.fn());
 const sonnerToast = vi.hoisted(() => vi.fn());
 
@@ -61,6 +67,7 @@ import {
 } from "@/stores/chats/chat-session-store";
 import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
 import { useComposerDraftStore } from "@/stores/composer/composer-draft-store";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { ChatControlStrip } from "../chat-tile-control-strip";
 import { ChatTileErrorNoticeToasts } from "../chat-tile-error-notice-toasts";
 import { useChatSetupFailureRestoreDriver } from "@/hooks/chats/use-chat-setup-failure-restore-driver";
@@ -182,12 +189,23 @@ beforeEach(() => {
   setActiveTilePane.mockReset();
   sonnerToast.mockReset();
   sonnerToastWarning.mockReset();
+  sonnerToastWarning.mockReturnValue("warning-toast");
   sonnerToastError.mockReset();
   useComposerDraftStore.setState({ drafts: {} });
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
 });
 
 afterEach(() => {
   cleanup();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
 });
 
 describe("useChatSetupFailureRestoreDriver", () => {
@@ -812,7 +830,48 @@ describe("useChatSetupFailureRestoreDriver", () => {
 });
 
 describe("<ChatTileErrorNoticeToasts />", () => {
-  it("shows new chat error notices as toasts", () => {
+  it("keeps warning severity and reports with fixed chat context", () => {
+    const harness = createHarness();
+    emitSnapshot(harness.callbacks(), [], []);
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+
+    render(<ChatTileErrorNoticeToasts handle={harness.handle} />);
+
+    const unsafeMessage =
+      "The request for alice@example.com in /Users/alice/private failed.";
+    act(() => {
+      harness.callbacks().onErrorNotice({
+        kind: "errorNotice",
+        hasBinaryPayload: false,
+        epicId: EPIC_ID,
+        chatId: CHAT_ID,
+        notice: {
+          code: "SECRET_/Users/alice/private",
+          message: unsafeMessage,
+          severity: "warning",
+          clientActionId: "interview-1",
+        },
+      });
+    });
+
+    expect(sonnerToastWarning.mock.lastCall?.[0]).toBe(unsafeMessage);
+    expect(readWarningOptions().cancel).toMatchObject({
+      label: "Report issue",
+    });
+    clickWarningReportAction();
+
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Chat action failed",
+      message: null,
+      code: null,
+      source: "Chat",
+    });
+    expect(
+      JSON.stringify(useDesktopDialogStore.getState().reportIssueContext),
+    ).not.toMatch(/alice@example\.com|\/Users\/alice|SECRET_/);
+  });
+
+  it("keeps warning notices non-reportable when capability is unavailable", () => {
     const harness = createHarness();
     emitSnapshot(harness.callbacks(), [], []);
 
@@ -862,6 +921,22 @@ describe("<ChatTileErrorNoticeToasts />", () => {
     expect(sonnerToastWarning).not.toHaveBeenCalled();
   });
 });
+
+function clickWarningReportAction(): void {
+  const cancel = readWarningOptions().cancel;
+  if (typeof cancel !== "object" || cancel === null || !("onClick" in cancel)) {
+    throw new Error("Expected a warning report action.");
+  }
+  cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+}
+
+function readWarningOptions(): ExternalToast {
+  const options = sonnerToastWarning.mock.lastCall?.[1];
+  if (options === undefined) {
+    throw new Error("Expected warning toast options.");
+  }
+  return options;
+}
 
 describe("<ChatControlStrip />", () => {
   it("does not reserve persistent space for chat error notices", () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-setup.test.tsx
@@ -1,7 +1,7 @@
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render } from "@testing-library/react";
-import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import type { ReactNode } from "react";
 import type { ExternalToast } from "sonner";
 
 vi.mock(
@@ -196,6 +196,7 @@ beforeEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 
@@ -205,6 +206,7 @@ afterEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 
@@ -927,7 +929,15 @@ function clickWarningReportAction(): void {
   if (typeof cancel !== "object" || cancel === null || !("onClick" in cancel)) {
     throw new Error("Expected a warning report action.");
   }
-  cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+  const action = render(
+    <button type="button" onClick={cancel.onClick}>
+      Trigger warning report
+    </button>,
+  );
+  fireEvent.click(
+    action.getByRole("button", { name: "Trigger warning report" }),
+  );
+  action.unmount();
 }
 
 function readWarningOptions(): ExternalToast {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-tile-setup-banner.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-agent-tile-setup-banner.test.tsx
@@ -1,9 +1,16 @@
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
 vi.mock(
   "@/components/home/host-workspace-selector/host-workspace-selector",
@@ -165,6 +172,11 @@ describe("<TuiAgentTile /> setup error rendering", () => {
 
   afterEach(() => {
     cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
   });
 
   it("renders no persistent failure banner when prepareLaunch fails with WORKTREE_SETUP_FAILED", () => {
@@ -198,6 +210,13 @@ describe("<TuiAgentTile /> setup error rendering", () => {
     expect(screen.queryByText(/Failed to start terminal/)).toBeNull();
     expect(screen.queryByRole("button", { name: /Retry/i })).toBeNull();
     expect(screen.getByText(/Waiting for worktree setup/)).toBeTruthy();
+    // The worktree-setup waiting state must never surface a report
+    // affordance, even once the support capability is available - recovery
+    // for this state is the setup terminal tab, not a report action.
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
   });
 
   it("classifies typed WORKTREE_SETUP_FAILED code without the code in the message", () => {
@@ -303,6 +322,53 @@ describe("<TuiAgentTile /> setup error rendering", () => {
     expect(screen.getByRole("button", { name: /Retry/i })).toBeTruthy();
   });
 
+  it("gates the generic failure banner's report action on capability and reports only fixed context", () => {
+    mockPrepare = {
+      isError: true,
+      isPending: false,
+      isIdle: false,
+      error: new Error("secret-token-should-never-render /Users/hostile/path"),
+      reset: () => undefined,
+      mutateAsync: () => Promise.reject(new Error("boom")),
+    };
+    render(
+      withQueryClient(
+        <TuiAgentTile
+          viewTabId="tab-test"
+          node={{
+            id: "agent-1",
+            instanceId: "inst-agent-1",
+            type: "terminal-agent",
+            name: "claude",
+            hostId: "test-host",
+          }}
+          tileId="tile-1"
+          isActive
+        />,
+      ),
+    );
+
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Failed to start terminal agent",
+        message: "The terminal agent session could not be started.",
+        code: null,
+        source: "Terminal agent",
+      },
+    });
+    const context = useDesktopDialogStore.getState().reportIssueContext;
+    expect(JSON.stringify(context)).not.toContain("secret-token");
+    expect(JSON.stringify(context)).not.toContain("/Users/hostile/path");
+  });
+
   it("renders a distinct missing-worktree body (not the generic banner) for WORKTREE_MISSING", () => {
     // The host refuses to launch into a missing cwd (no silent demote-to-Local)
     // and rejects with the typed WORKTREE_MISSING envelope. The tile surfaces an
@@ -346,5 +412,57 @@ describe("<TuiAgentTile /> setup error rendering", () => {
       screen.getByText(/Restore the missing folder or worktree/),
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: /Retry/i })).toBeTruthy();
+  });
+
+  it("gates the missing-worktree body's report action on capability and reports only fixed context", () => {
+    const error = Object.assign(
+      new Error(
+        "Cannot launch this terminal agent: bound folder(s) missing on disk: /repo-wt-secret.",
+      ),
+      { code: "WORKTREE_MISSING" as const },
+    );
+    mockPrepare = {
+      isError: true,
+      isPending: false,
+      isIdle: false,
+      error,
+      reset: () => undefined,
+      mutateAsync: () => Promise.reject(error),
+    };
+    render(
+      withQueryClient(
+        <TuiAgentTile
+          viewTabId="tab-test"
+          node={{
+            id: "agent-1",
+            instanceId: "inst-agent-1",
+            type: "terminal-agent",
+            name: "claude",
+            hostId: "test-host",
+          }}
+          tileId="tile-1"
+          isActive
+        />,
+      ),
+    );
+
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Terminal agent folder is missing",
+        message: "A bound folder for a terminal agent was missing on disk.",
+        code: null,
+        source: "Terminal agent",
+      },
+    });
+    const context = useDesktopDialogStore.getState().reportIssueContext;
+    expect(JSON.stringify(context)).not.toContain("/repo-wt-secret");
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-connection-overlay.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-connection-overlay.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { TerminalConnectionOverlay } from "../terminal-connection-overlay";
+
+afterEach(() => {
+  cleanup();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
+
+describe("<TerminalConnectionOverlay />", () => {
+  it("keeps reconnect primary and reports only fixed terminal context", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    render(
+      <TerminalConnectionOverlay
+        state="lost"
+        onReconnect={() => undefined}
+        testId="terminal-connection-overlay"
+      />,
+    );
+
+    const reconnect = screen.getByRole("button", { name: "Reconnect" });
+    const report = screen.getByRole("button", { name: "Report issue" });
+    expect(reconnect.getAttribute("data-variant")).toBe("outline");
+    expect(report.getAttribute("data-variant")).toBe("ghost");
+
+    fireEvent.click(report);
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Terminal session could not reconnect",
+      message: "The terminal session could not be restarted.",
+      code: null,
+      source: "Terminal",
+    });
+  });
+
+  it("hides reporting when the support capability is unavailable", () => {
+    render(
+      <TerminalConnectionOverlay
+        state="lost"
+        onReconnect={() => undefined}
+        testId="terminal-connection-overlay"
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-report-issue.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-report-issue.test.tsx
@@ -1,0 +1,159 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { TabHostProvider } from "@/components/epic-canvas/tab-host-provider";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { collectPanes } from "@/stores/epics/canvas/tile-tree";
+import type { EpicTerminalRef } from "@/stores/epics/canvas/types";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+interface TestBootstrapState {
+  reachability: { status: string; hostLabel: string };
+  createIsError: boolean;
+  createError: { readonly message: string } | null;
+}
+
+const testState = vi.hoisted<TestBootstrapState>(() => ({
+  reachability: {
+    status: "reachable",
+    hostLabel: "Host A",
+  },
+  createIsError: true,
+  createError: {
+    message: "secret-token-should-never-render /Users/hostile/path",
+  },
+}));
+
+vi.mock("@/hooks/agent/use-host-reachability", () => ({
+  useHostReachability: () => testState.reachability,
+}));
+
+vi.mock("@/hooks/terminal/use-terminal-session-recovery", () => ({
+  useTerminalSessionRecovery: () => ({
+    recoverNonce: 0,
+    recoveryExhausted: false,
+    onManualReconnect: () => undefined,
+    onSessionHealthy: () => undefined,
+    onSessionLost: () => undefined,
+  }),
+}));
+
+vi.mock("@/hooks/agent/use-terminal-tile-bootstrap", () => ({
+  TerminalXtermHost: () => null,
+  useTerminalTileBootstrap: () => ({
+    handle: null,
+    createIsError: testState.createIsError,
+    createError: testState.createError,
+    retry: () => undefined,
+    hostHasSession: false,
+  }),
+}));
+
+vi.mock("@/lib/perf/terminal-load-perf", () => ({
+  beginTerminalLoad: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  AnalyticsEvent: { TerminalOpened: "TerminalOpened" },
+  Analytics: {
+    getInstance: () => ({ track: vi.fn() }),
+  },
+}));
+
+import { TerminalTile } from "../terminal-tile";
+
+const EPIC_ID = "epic-1";
+const HOST_ID = "host-1";
+
+function withTabHost(node: ReactNode): ReactNode {
+  return <TabHostProvider hostId={HOST_ID}>{node}</TabHostProvider>;
+}
+
+function terminalNode(id: string, instanceId: string): EpicTerminalRef {
+  return {
+    id,
+    instanceId,
+    type: "terminal",
+    name: "shell",
+    titleSource: "manual",
+    hostId: HOST_ID,
+    cwd: "/work/repo",
+  };
+}
+
+function renderErroredTile(): void {
+  const store = useEpicCanvasStore.getState();
+  const viewTabId = store.openEpicTab(EPIC_ID, "Epic");
+  const node = terminalNode("terminal-1", "inst-terminal-1");
+  store.openTileInTab(viewTabId, node);
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[viewTabId];
+  if (canvas === undefined) throw new Error("expected view tab canvas");
+  const paneId = collectPanes(canvas.root)[0].id;
+  render(
+    withTabHost(
+      <TerminalTile
+        viewTabId={viewTabId}
+        node={node}
+        tileId={paneId}
+        isActive
+      />,
+    ),
+  );
+}
+
+describe("<TerminalTile /> bootstrap error report action", () => {
+  beforeEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    testState.reachability = { status: "reachable", hostLabel: "Host A" };
+    testState.createIsError = true;
+    testState.createError = {
+      message: "secret-token-should-never-render /Users/hostile/path",
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
+  });
+
+  it("hides the report action when the support capability is unavailable", () => {
+    renderErroredTile();
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+
+  it("reports only fixed generic context, never the raw bootstrap error", () => {
+    renderErroredTile();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Failed to start terminal",
+        message: "The terminal session could not be started.",
+        code: null,
+        source: "Terminal",
+      },
+    });
+    const context = useDesktopDialogStore.getState().reportIssueContext;
+    expect(JSON.stringify(context)).not.toContain("secret-token");
+    expect(JSON.stringify(context)).not.toContain("/Users/hostile/path");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-host-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/workspace-file-tile-host-gate.test.tsx
@@ -2,6 +2,7 @@ import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { WorkspaceFileRef } from "@/stores/epics/canvas/types";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
 interface GateTestState {
   activeHostId: string | null;
@@ -105,8 +106,20 @@ describe("<WorkspaceFileTile /> host-binding gate", () => {
       isError: false,
       error: null,
     };
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
   });
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
+  });
 
   it("shows the offline banner when the bound host is unreachable", () => {
     state.reachability = { status: "unreachable", hostLabel: "Host A" };
@@ -135,6 +148,33 @@ describe("<WorkspaceFileTile /> host-binding gate", () => {
     expect(screen.queryByText(/Switch your active host/)).toBeNull();
     expect(screen.queryByText(/currently unreachable/)).toBeNull();
     expect(screen.getByText("src/index.ts")).toBeTruthy();
+  });
+
+  it("reports a file-read failure without copying its raw path or error", () => {
+    state.readFile = {
+      data: {
+        content: "",
+        error: "Could not read /Users/me/private/api-key.txt",
+        truncated: false,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    };
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    renderTile("host-A", NODE);
+
+    expect(
+      screen.getByText("Could not read /Users/me/private/api-key.txt"),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Workspace file could not be read",
+      message: "The workspace file preview could not be loaded.",
+      code: null,
+      source: "Workspace file",
+    });
   });
 
   it("shows markdown source and preview modes for markdown files", () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-error-notice-toasts.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-error-notice-toasts.tsx
@@ -8,6 +8,18 @@ import {
   type ChatSessionStoreHandle,
   type DeliveredNoticeTracker,
 } from "@/stores/chats/chat-session-store";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import {
+  reportableErrorToast,
+  reportableWarningToast,
+} from "@/lib/reportable-error-toast";
+
+const CHAT_ACTION_REPORT_CONTEXT = createReportIssueContext({
+  title: "Chat action failed",
+  message: null,
+  code: null,
+  source: "Chat",
+});
 
 interface ChatTileErrorNoticeToastsProps {
   readonly handle: ChatSessionStoreHandle;
@@ -62,11 +74,11 @@ function rememberErrorNotice(
 function showErrorNoticeToast(notice: ChatErrorNotice): void {
   const message = notice.message.length > 0 ? notice.message : "Action failed.";
   if (notice.severity === "error") {
-    toast.error(message);
+    reportableErrorToast(message, undefined, CHAT_ACTION_REPORT_CONTEXT);
     return;
   }
   if (notice.severity === "warning") {
-    toast.warning(message);
+    reportableWarningToast(message, undefined, CHAT_ACTION_REPORT_CONTEXT);
     return;
   }
   toast(message);

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-runtime-gate.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-runtime-gate.tsx
@@ -2,6 +2,8 @@ import { type ReactNode } from "react";
 import { AlertTriangle } from "lucide-react";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 // Display-only components for the chat tile's pre-snapshot states (loading and
 // fatal-close error). Kept separate from chat-tile.tsx so Fast Refresh stays
@@ -42,14 +44,26 @@ export function ChatTileError(props: {
           <span>This chat could not be opened.</span>
         </div>
         <p className="text-ui-sm text-muted-foreground">{detail}</p>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={props.onRetry}
-        >
-          Retry
-        </Button>
+        <div className="flex flex-wrap justify-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={props.onRetry}
+          >
+            Retry
+          </Button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "This chat could not be opened",
+              message: "The chat could not be opened.",
+              code: null,
+              source: "Chat",
+            })}
+            presentation="text"
+            className={undefined}
+          />
+        </div>
       </div>
     </div>
   );

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -16,6 +16,7 @@ import type {
 import { isTransientLiveAssistantMessageId } from "@/lib/chat/transient-live-assistant-message-id";
 import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-json-content";
 import { containsImageAtoms } from "@/lib/composer/image-atoms";
+import { reportableWarningToast } from "@/lib/reportable-error-toast";
 import type { PendingInterviewView } from "./chat-tile-types";
 
 /**
@@ -317,7 +318,12 @@ export function showRestoreResultToast(
     },
   };
   if (counts.failed > 0) {
-    toast.warning(title, options);
+    reportableWarningToast(title, options, {
+      title: "File restore incomplete",
+      message: null,
+      code: null,
+      source: "File restore",
+    });
     return;
   }
   toast.success(title, options);

--- a/clients/gui-app/src/components/epic-canvas/renderers/dead-tile-banner.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/dead-tile-banner.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { cn } from "@/lib/utils";
 
 /**
@@ -38,9 +40,26 @@ export function TerminalDeadTileBanner(
         Host &quot;{props.hostLabel}&quot; is unreachable. This terminal is
         permanently closed.
       </p>
-      <Button type="button" variant="outline" size="sm" onClick={props.onClose}>
-        Close tab
-      </Button>
+      <div className="flex flex-wrap justify-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={props.onClose}
+        >
+          Close tab
+        </Button>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Terminal host is unreachable",
+            message: "The terminal's bound host is unreachable.",
+            code: null,
+            source: "Terminal",
+          })}
+          presentation="text"
+          className={undefined}
+        />
+      </div>
     </div>
   );
 }
@@ -69,6 +88,16 @@ export function WorkspaceFileDeadTileBanner(
           ? `This file is on host "${props.hostLabel}", which is currently unreachable. The preview will load once that host is back.`
           : `This file is on host "${props.hostLabel}". Switch your active host to "${props.hostLabel}" to view it.`}
       </p>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Workspace file is unavailable",
+          message: "The workspace file's bound host is unavailable.",
+          code: null,
+          source: "Workspace file",
+        })}
+        presentation="text"
+        className={undefined}
+      />
     </div>
   );
 }
@@ -92,6 +121,16 @@ export function GitDiffDeadTileBanner(
           ? `This diff is on host "${props.hostLabel}", which is currently unreachable. The diff will load once that host is back.`
           : `This diff is on host "${props.hostLabel}". Switch your active host to "${props.hostLabel}" to view it.`}
       </p>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Git diff is unavailable",
+          message: "The Git diff's bound host is unavailable.",
+          code: null,
+          source: "Git changes",
+        })}
+        presentation="text"
+        className={undefined}
+      />
     </div>
   );
 }
@@ -120,6 +159,16 @@ export function SnapshotDiffSourceUnavailableBanner(
         This change is no longer available. The chat edit it came from was
         reverted, removed, or is no longer loaded.
       </p>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Change is no longer available",
+          message: "The source chat edit could not be resolved.",
+          code: null,
+          source: "Snapshot diff",
+        })}
+        presentation="text"
+        className={undefined}
+      />
     </div>
   );
 }
@@ -154,6 +203,16 @@ export function ChatDeadTileBanner(props: ChatDeadTileBannerProps): ReactNode {
       >
         Clone chat
       </Button>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Chat host is offline",
+          message: "The chat's bound host is offline.",
+          code: null,
+          source: "Chat",
+        })}
+        presentation="icon"
+        className="shrink-0 text-warning-foreground"
+      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-connection-overlay.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-connection-overlay.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { Button } from "@/components/ui/button";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import type { TerminalConnectionOverlayState } from "./terminal-connection-overlay-state";
 
 /**
@@ -46,14 +48,26 @@ export function TerminalConnectionOverlay(
             This session disconnected and could not be restarted. It may have
             ended while the app was asleep.
           </p>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={props.onReconnect}
-          >
-            Reconnect
-          </Button>
+          <div className="flex flex-wrap justify-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={props.onReconnect}
+            >
+              Reconnect
+            </Button>
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Terminal session could not reconnect",
+                message: "The terminal session could not be restarted.",
+                code: null,
+                source: "Terminal",
+              })}
+              presentation="text"
+              className={undefined}
+            />
+          </div>
         </>
       ) : (
         <div className="flex items-center gap-2">

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
@@ -23,6 +23,8 @@ import { TerminalDeadTileBanner } from "./dead-tile-banner";
 import { TerminalConnectionOverlay } from "./terminal-connection-overlay";
 import { resolveTerminalOverlayState } from "./terminal-connection-overlay-state";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { useCloseCanvasTileWithNestedFocus } from "./use-close-canvas-tile-with-nested-focus";
 
 export interface TerminalTileProps {
@@ -114,22 +116,33 @@ function TerminalTileLive(
   if (bootstrap.createIsError) {
     return (
       <div
-        className="flex h-full w-full items-center justify-center bg-canvas text-ui-sm text-destructive"
+        className="flex h-full w-full flex-col items-center justify-center gap-2 bg-canvas p-4 text-center text-ui-sm text-destructive"
         data-testid={`terminal-tile-${props.tileId}`}
       >
         <span>
           Failed to start terminal:{" "}
           {bootstrap.createError?.message ?? "Unknown error"}
         </span>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="ml-3"
-          onClick={bootstrap.retry}
-        >
-          Retry
-        </Button>
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={bootstrap.retry}
+          >
+            Retry
+          </Button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Failed to start terminal",
+              message: "The terminal session could not be started.",
+              code: null,
+              source: "Terminal",
+            })}
+            presentation="text"
+            className={undefined}
+          />
+        </div>
       </div>
     );
   }

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -8,7 +8,6 @@ import {
   useState,
 } from "react";
 import { ChevronDown, GitFork, Users } from "lucide-react";
-import { toast } from "sonner";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
 import {
@@ -74,6 +73,9 @@ import {
 } from "@/stores/worktree/worktree-intent-staging-store";
 import { TerminalAgentForkDialog } from "./terminal-agent-fork-dialog";
 import { useCloseCanvasTileWithNestedFocus } from "./use-close-canvas-tile-with-nested-focus";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const WORKTREE_SETUP_ERROR_CODES: ReadonlyArray<string> = [
   "WORKTREE_SETUP_FAILED",
@@ -571,6 +573,35 @@ function TerminalAgentBody(props: TerminalAgentBodyProps): React.ReactNode {
             Restore the missing folder or worktree at its bound path, then retry
             — or close this terminal agent.
           </span>
+          <div className="flex flex-wrap justify-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={props.onRetry}
+            >
+              Retry
+            </Button>
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Terminal agent folder is missing",
+                message:
+                  "A bound folder for a terminal agent was missing on disk.",
+                code: null,
+                source: "Terminal agent",
+              })}
+              presentation="text"
+              className={undefined}
+            />
+          </div>
+        </div>
+      );
+    }
+    const message = error?.message ?? "Unknown error";
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-6 text-center text-ui-sm text-destructive">
+        <span>Failed to start terminal: {message}</span>
+        <div className="flex flex-wrap items-center justify-center gap-2">
           <Button
             type="button"
             variant="outline"
@@ -579,22 +610,17 @@ function TerminalAgentBody(props: TerminalAgentBodyProps): React.ReactNode {
           >
             Retry
           </Button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Failed to start terminal agent",
+              message: "The terminal agent session could not be started.",
+              code: null,
+              source: "Terminal agent",
+            })}
+            presentation="text"
+            className={undefined}
+          />
         </div>
-      );
-    }
-    const message = error?.message ?? "Unknown error";
-    return (
-      <div className="flex h-full w-full items-center justify-center text-ui-sm text-destructive">
-        <span>Failed to start terminal: {message}</span>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="ml-3"
-          onClick={props.onRetry}
-        >
-          Retry
-        </Button>
       </div>
     );
   }
@@ -979,11 +1005,20 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
     if (exitReason === "reaped") return;
     if (!exitToastShownRef.current && exitCode !== null && exitCode !== 0) {
       exitToastShownRef.current = true;
-      toast.error("Terminal agent exited with an error.", {
-        description:
-          lastOutputPreview ??
-          "The agent stopped before reporting a readable error. Try restarting it.",
-      });
+      reportableErrorToast(
+        "Terminal agent exited with an error.",
+        {
+          description:
+            lastOutputPreview ??
+            "The agent stopped before reporting a readable error. Try restarting it.",
+        },
+        createReportIssueContext({
+          title: "Terminal agent exited with an error",
+          message: null,
+          code: String(exitCode),
+          source: "Terminal agent",
+        }),
+      );
     }
   }, [
     status,

--- a/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
@@ -1,7 +1,9 @@
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import { useWorkspaceReadFile } from "@/hooks/workspace/use-read-file-query";
 import { languageFromFilePath } from "@/lib/file-change-diff-hunks";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { cn } from "@/lib/utils";
 import { TraycerMarkdown } from "@/markdown";
 import { useShikiHighlighter } from "@/markdown/shiki-highlighter";
@@ -356,8 +358,18 @@ function WorkspaceFilePreviewContent(props: {
 
   if (props.displayError !== null) {
     return (
-      <div className="flex h-full items-center justify-center px-6 text-center text-ui-sm text-muted-foreground">
-        {props.displayError}
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center text-ui-sm text-muted-foreground">
+        <p>{props.displayError}</p>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Workspace file could not be read",
+            message: "The workspace file preview could not be loaded.",
+            code: null,
+            source: "Workspace file",
+          })}
+          presentation="text"
+          className={undefined}
+        />
       </div>
     );
   }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-report-issue.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-report-issue.test.tsx
@@ -1,0 +1,388 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+// Minimal harness for reaching the "file-tree" left panel's load-error state.
+// Mirrors the mocking approach in epic-sidebar-selection-mode.test.tsx (dnd
+// context, sidebar UI primitives, add-node-dropdown, git-diff, terminal
+// sidebar, comments icon are all irrelevant noise for this panel and are
+// stubbed the same way), plus the file-tree-specific hooks that test file
+// does not need.
+
+vi.mock("@/components/epic-canvas/dnd/epic-canvas-dnd-context-value", () => ({
+  useEpicCanvasDnd: () => ({
+    activeSource: null,
+    dropPreview: null,
+    interactionLocked: false,
+    clearDropPreview: () => undefined,
+  }),
+}));
+
+vi.mock("@/components/epic-canvas/snapshots/snapshot-loading-context", () => ({
+  SnapshotGate: (props: { readonly children: ReactNode }) => props.children,
+}));
+
+vi.mock("@/components/epic-canvas/add-node-dropdown", () => ({
+  AddNodeDropdown: (props: { readonly children: ReactNode }) => props.children,
+}));
+
+vi.mock("@/components/epic-canvas/add-node-options", () => ({
+  CHAT_PANEL_EXCLUDED_TYPES: [],
+  ARTIFACT_PANEL_EXCLUDED_TYPES: [],
+}));
+
+vi.mock("@/components/epic-canvas/sidebar/epic-sidebar-filter-menu", () => ({
+  ChatFilterMenu: () => null,
+  ArtifactFilterMenu: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/sidebar/epic-terminal-sidebar", () => ({
+  TerminalsPanelActions: () => null,
+  TerminalsPanelBody: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/git-diff/git-diff-panel-body-live", () => ({
+  GitDiffPanelBodyLive: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/git-diff/git-diff-panel-actions", () => ({
+  GitDiffPanelActions: () => null,
+}));
+
+vi.mock("@/components/chat/chat-progress-icon", () => ({
+  ChatProgressIcon: () => null,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: (props: { readonly children: ReactNode }) => props.children,
+  DropdownMenuTrigger: (props: { readonly children: ReactNode }) =>
+    props.children,
+  DropdownMenuContent: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  DropdownMenuItem: (props: { readonly children: ReactNode }) => (
+    <button type="button">{props.children}</button>
+  ),
+  DropdownMenuSeparator: () => null,
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  Sidebar: (props: {
+    readonly children: ReactNode;
+    readonly "data-testid": string;
+    readonly "data-left-panel-id": string;
+  }) => (
+    <aside
+      data-testid={props["data-testid"]}
+      data-left-panel-id={props["data-left-panel-id"]}
+    >
+      {props.children}
+    </aside>
+  ),
+  SidebarContent: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  SidebarGroup: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  SidebarGroupContent: (props: { readonly children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-1",
+}));
+
+vi.mock("@/hooks/worktree/use-latest-conversation-workspace-seed", () => ({
+  useLatestConversationWorkspaceSeed: () => null,
+}));
+
+vi.mock("@/hooks/worktree/use-worktree-get-binding-query", () => ({
+  useWorktreeGetBinding: () => ({
+    data: { binding: null, missingWorktreePaths: [] },
+    isError: false,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
+  useEpicCreateChat: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicCreateChatForHostClient: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicDeleteChat: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useEpicRenameChat: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/agent/use-create-tui-agent", () => ({
+  useCreateTuiAgentForClient: () => ({
+    create: vi.fn(() => Promise.resolve(null)),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/host/runtime", () => ({
+  useHostClient: () => ({ getActiveHostId: () => "host-1" }),
+}));
+
+vi.mock("@/hooks/host/use-host-client-for", () => ({
+  useHostClientFor: () => ({ getActiveHostId: () => "host-1" }),
+}));
+
+vi.mock("@/hooks/host/use-host-directory-entry", () => ({
+  useHostDirectoryEntry: () => ({ hostId: "host-1" }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-node-mutations", () => ({
+  useEpicCreateArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicDeleteArtifact: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useEpicRenameArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/epic/use-epic-tui-agent-mutations", () => ({
+  useEpicDeleteTuiAgent: () => ({
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+  useEpicRenameTuiAgent: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/providers/use-open-epic-handle", () => ({
+  useOpenEpicHandle: () => ({
+    epicId: "epic-1",
+    store: {
+      getState: () => ({ deleteArtifact: vi.fn(), renameArtifact: vi.fn() }),
+      subscribe: () => () => undefined,
+    },
+  }),
+}));
+
+vi.mock("@/stores/epics/canvas/store", () => ({
+  findOpenArtifactInTab: () => null,
+  useActiveEpicArtifactId: () => null,
+  useEpicCanvasStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      closeCanvasTab: vi.fn(),
+      markArtifactSelfDeleted: vi.fn(),
+      openTileInTab: vi.fn(),
+      openTilePreviewInTab: vi.fn(),
+      pendingRootCreatesByEpic: {},
+      preAckRootCreatesByEpic: {},
+      promotePreviewInTab: vi.fn(),
+      renameArtifactInTab: vi.fn(),
+      unmarkArtifactSelfDeleted: vi.fn(),
+      prepareOpenTilePreviewInTabFocusTarget: () => () => null,
+      prepareOpenTileInTabFocusTarget: () => () => null,
+    }),
+  useIsActiveEpicArtifact: () => false,
+}));
+
+vi.mock("@/stores/epics/epic-sidebar-expansion-store", () => ({
+  useEpicSidebarEffectiveExpanded: () => new Set<string>(),
+  useEpicSidebarExpansionStore: (selector: (state: unknown) => unknown) =>
+    selector({ collapse: vi.fn(), collapseAll: vi.fn(), expand: vi.fn() }),
+}));
+
+vi.mock("@/stores/epics/left-panel-store", () => ({
+  DEFAULT_LEFT_PANEL_ID: "chats",
+  isArtifactFilterActive: () => false,
+  isChatFilterActive: () => false,
+  useAcknowledgedRootCreatePending: () => null,
+  useActiveLeftPanelId: () => "file-tree",
+  useArtifactFilter: () => ({ statuses: [], kinds: [], read: "all" }),
+  useArtifactSort: () => ({ field: "updated", direction: "desc" }),
+  useChatFilter: () => ({ origin: "all" }),
+  useChatSort: () => ({ field: "updated", direction: "desc" }),
+  useCommentsPanelRevealed: () => false,
+  useEpicLeftPanelStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      clearAcknowledgedRootCreatePending: vi.fn(),
+      clearLocalRootCreatePending: vi.fn(),
+      panelSectionCollapsedByPanelId: {},
+      setAcknowledgedRootCreatePending: vi.fn(),
+      setActivePanelId: vi.fn(),
+      setLocalRootCreatePending: vi.fn(),
+      setPanelSectionWeights: vi.fn(),
+      togglePanelSectionCollapsed: vi.fn(),
+    }),
+  useLeftPanelGroups: () => [{ panelIds: ["file-tree"] }],
+  useLeftPanelSectionCollapsed: () => false,
+  useLocalRootCreatePending: () => null,
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useAncestorIds: () => new Set<string>(),
+  useChildIds: () => [],
+  useEpicActiveAgentIds: () => new Set<string>(),
+  useEpicArtifact: () => null,
+  useEpicArtifactRecords: () => [],
+  useEpicArtifactStatus: () => null,
+  useEpicConnectionStatus: () => "open",
+  useEpicNodeHostId: () => "host-1",
+  useEpicNodeOwnerKind: () => "chat",
+  useEpicNodeWorkspaceFolders: () => [],
+  useEpicPermissionRole: () => "owner",
+  useEpicTreeIndex: () => ({ rootIds: [], childrenByParent: {}, nodeById: {} }),
+  useEpicTreeNode: () => null,
+  useMaybeEpicTuiAgentHarnessId: () => null,
+  useRootIds: () => [],
+}));
+
+vi.mock("@/hooks/use-epic-store", () => ({
+  useEpicStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      snapshotLoaded: true,
+      artifacts: { allIds: [], byId: {} },
+    }),
+}));
+
+vi.mock("@/stores/epics/artifact-read-state-store", () => ({
+  isArtifactUnread: () => false,
+  useArtifactReadStateStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        lastSeenByArtifact: {},
+        markRead: vi.fn(),
+        seedAtByEpic: {},
+        seedEpicArtifacts: vi.fn(),
+      }),
+    {
+      getState: () => ({
+        lastSeenByArtifact: {},
+        markRead: vi.fn(),
+        seedAtByEpic: {},
+        seedEpicArtifacts: vi.fn(),
+      }),
+    },
+  ),
+}));
+
+vi.mock("@/stores/settings/settings-store", () => ({
+  useSettingsStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      artifactIconColorMode: "none",
+      artifactIconColors: {
+        chat: undefined,
+        review: undefined,
+        spec: undefined,
+        story: undefined,
+        ticket: undefined,
+        "terminal-agent": undefined,
+      },
+    }),
+}));
+
+// File-tree-panel-specific dependencies.
+vi.mock("@/hooks/worktree/use-worktree-list-bindings-for-epic-query", () => ({
+  useWorktreeListBindingsForEpic: () => ({
+    data: {
+      rows: [
+        {
+          runningDir: "/work/repo",
+          disabledReason: null,
+        },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@/hooks/workspace/use-list-file-tree-query", () => ({
+  useWorkspaceListFileTree: () => ({
+    data: undefined,
+    error: new Error("secret-token-should-never-render /Users/hostile/path"),
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@pierre/trees/react", () => ({
+  FileTree: () => <div data-testid="pierre-file-tree-stub" />,
+  useFileTree: () => ({
+    model: {
+      setSearch: () => undefined,
+      setGitStatus: () => undefined,
+      resetPaths: () => undefined,
+    },
+  }),
+}));
+
+vi.mock("@/components/worktree/workspace-picker-with-opener", () => ({
+  WorkspacePickerWithOpener: () => null,
+}));
+
+vi.mock("@/components/epic-canvas/sidebar/file-tree-workspace-picker", () => ({
+  FileTreeWorkspacePicker: () => null,
+}));
+
+import { EpicLeftPanelHost } from "@/components/epic-canvas/sidebar/epic-sidebar";
+
+const TAB_ID = "tab-1";
+const EPIC_ID = "epic-1";
+
+describe("epic sidebar file-tree load failure report action", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
+  });
+
+  it("hides the report action when the support capability is unavailable", () => {
+    render(
+      <TooltipProvider>
+        <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />
+      </TooltipProvider>,
+    );
+
+    screen.getByText("Unable to load files.");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+
+  it("reports only fixed generic context, never the raw file-tree host error", () => {
+    render(
+      <TooltipProvider>
+        <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />
+      </TooltipProvider>,
+    );
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Unable to load files",
+        message: "The workspace file tree could not be loaded.",
+        code: null,
+        source: "File tree",
+      },
+    });
+    const context = useDesktopDialogStore.getState().reportIssueContext;
+    expect(JSON.stringify(context)).not.toContain("secret-token");
+    expect(JSON.stringify(context)).not.toContain("/Users/hostile/path");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker.test.tsx
@@ -1,10 +1,18 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import type {
   WorktreeBindingSelectorDisabledReason,
   WorktreeBindingSelectorRow,
 } from "@traycer/protocol/host";
 import { NewTerminalPicker } from "../new-terminal-picker";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { paneTabRefs } from "@/stores/epics/canvas/actions";
 import { collectPanes } from "@/stores/epics/canvas/tile-tree";
@@ -97,7 +105,11 @@ function resetCanvas(): void {
 
 function openPicker(): string {
   const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic");
-  render(<NewTerminalPicker epicId="epic-1" tabId={tabId} />);
+  render(
+    <TooltipProvider>
+      <NewTerminalPicker epicId="epic-1" tabId={tabId} />
+    </TooltipProvider>,
+  );
   fireEvent.click(screen.getByTestId("epic-terminals-panel-add"));
   return tabId;
 }
@@ -114,6 +126,14 @@ describe("<NewTerminalPicker />", () => {
     resetCanvas();
     selectById.mockClear();
     stubLoadedBindings();
+  });
+
+  afterEach(() => {
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
   });
 
   it("opens a popover with the host section and workspace rows", () => {
@@ -313,6 +333,24 @@ describe("<NewTerminalPicker />", () => {
       (tile) => tile.type === "terminal",
     );
     expect(terminals).toHaveLength(0);
+
+    // Capability-gated off by default.
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't resolve terminal directory",
+        message: "The terminal working directory could not be resolved.",
+        code: null,
+        source: "New terminal",
+      },
+    });
   });
 
   it("selects a workspace without creating a terminal on a single click", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -164,6 +164,8 @@ import { GitDiffPanelBodyLive } from "@/components/epic-canvas/git-diff/git-diff
 import { GitDiffPanelActions } from "@/components/epic-canvas/git-diff/git-diff-panel-actions";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import {
   InputGroup,
@@ -1282,9 +1284,19 @@ function FileTreePanelBodyForWorkspace(props: {
           </output>
         ) : null}
         {query.error !== null && files.length === 0 ? (
-          <p className="p-1 text-ui-xs text-destructive">
-            Unable to load files.
-          </p>
+          <div className="flex items-center justify-between gap-2 p-1 text-ui-xs text-destructive">
+            <span>Unable to load files.</span>
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Unable to load files",
+                message: "The workspace file tree could not be loaded.",
+                code: null,
+                source: "File tree",
+              })}
+              presentation="icon"
+              className={undefined}
+            />
+          </div>
         ) : null}
       </div>
       {query.data?.truncated === true ? (

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -27,6 +27,8 @@ import {
 } from "lucide-react";
 import type { TerminalSessionInfo } from "@traycer/protocol/host/terminal/unary-schemas";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -200,10 +202,22 @@ function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
   if (props.isError) {
     return (
       <div
-        className="px-2 py-1.5 text-ui-sm text-destructive"
+        className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-destructive"
         data-testid="epic-terminal-sidebar-error"
       >
-        {props.errorMessage ?? "Failed to load terminals."}
+        <span className="min-w-0 flex-1">
+          {props.errorMessage ?? "Failed to load terminals."}
+        </span>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Failed to load terminals",
+            message: "The terminal list could not be loaded.",
+            code: null,
+            source: "Terminals",
+          })}
+          presentation="icon"
+          className="text-current"
+        />
       </div>
     );
   }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -10,7 +10,6 @@ import {
 import { useStore } from "zustand";
 import { useShallow } from "zustand/react/shallow";
 import { v4 as uuidv4 } from "uuid";
-import { toast } from "sonner";
 import { ArrowLeftRight, Plus, XIcon } from "lucide-react";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
@@ -113,6 +112,7 @@ import {
   worktreeStagingKeyString,
 } from "@/stores/worktree/worktree-intent-staging-store";
 import { useWorktreeIntentMemoryStore } from "@/stores/worktree/worktree-intent-memory-store";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 /**
  * Isolated subscriber for the live draft content. The editor rewrites content
@@ -634,9 +634,18 @@ function NewConversationModalBody(props: {
     // open with no feedback - mirror the landing flow's host-first toast.
     const activeHostId = hostClient.getActiveHostId();
     if (activeHostId === null) {
-      toast.error("Couldn't start the chat.", {
-        description: "No active device. Reconnect and try again.",
-      });
+      reportableErrorToast(
+        "Couldn't start the chat.",
+        {
+          description: "No active device. Reconnect and try again.",
+        },
+        {
+          title: "Could not start chat",
+          message: "No active device was available.",
+          code: null,
+          source: "Chat",
+        },
+      );
       return;
     }
     const content = buildSubmittedChatJSONContent(editor.getJSON());

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
@@ -15,6 +15,8 @@ import { v4 as uuidv4 } from "uuid";
 import { Plus } from "lucide-react";
 import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import {
   Popover,
   PopoverContent,
@@ -131,10 +133,20 @@ export function NewTerminalPicker(props: NewTerminalPickerProps) {
   if (folderlessCwdFailed) {
     folderlessCwdStatus = (
       <span
-        className="text-destructive"
+        className="flex items-center gap-1.5 text-destructive"
         data-testid="new-terminal-folderless-cwd-error"
       >
         Couldn't resolve terminal directory.
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Couldn't resolve terminal directory",
+            message: "The terminal working directory could not be resolved.",
+            code: null,
+            source: "New terminal",
+          })}
+          presentation="icon"
+          className={undefined}
+        />
       </span>
     );
   }

--- a/clients/gui-app/src/components/epic-canvas/snapshots/snapshot-error-banner.tsx
+++ b/clients/gui-app/src/components/epic-canvas/snapshots/snapshot-error-banner.tsx
@@ -1,7 +1,9 @@
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { useEpicRequestFreshSnapshot } from "@/lib/epic-selectors";
 import { cn } from "@/lib/utils";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import type { SnapshotFetchError } from "@/stores/epics/open-epic/store";
 
 interface SnapshotErrorBannerProps {
@@ -29,15 +31,27 @@ export function SnapshotErrorBanner(props: SnapshotErrorBannerProps) {
         <p className="text-ui-xs text-muted-foreground">
           {props.error.message}
         </p>
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          data-testid="snapshot-error-retry"
-          onClick={() => requestFreshSnapshot()}
-        >
-          Retry
-        </Button>
+        <div className="flex flex-wrap justify-center gap-2">
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            data-testid="snapshot-error-retry"
+            onClick={() => requestFreshSnapshot()}
+          >
+            Retry
+          </Button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Failed to load epic",
+              message: "The Epic snapshot could not be loaded.",
+              code: props.error.code,
+              source: "Epic snapshot",
+            })}
+            presentation="text"
+            className={undefined}
+          />
+        </div>
       </div>
     </div>
   );

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/epics/use-history-open-in-new-window";
 import { UnsyncedEpicMoveDialog } from "@/components/layout/dialogs/unsynced-epic-move-dialog";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { DeleteTasksDialog } from "@/components/epics/delete-tasks-dialog";
 import {
@@ -48,6 +49,7 @@ import { useEpicUpdateTitle } from "@/hooks/epic/use-epic-title-mutation";
 import { useInlineRename } from "@/hooks/ui/use-inline-rename";
 import { withMemberToggled } from "@/lib/immutable-set";
 import { cn } from "@/lib/utils";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import {
   InputGroup,
   InputGroupAddon,
@@ -1386,7 +1388,7 @@ function EpicsListError(props: EpicsListErrorProps) {
       role="alert"
     >
       <p className="font-medium text-destructive">{errorHeadline(error)}</p>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Button
           type="button"
           size="sm"
@@ -1408,6 +1410,16 @@ function EpicsListError(props: EpicsListErrorProps) {
         >
           {showDetails ? "Hide details" : "Show details"}
         </Button>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Failed to load Epics",
+            message: "The Epic list could not be loaded.",
+            code: error instanceof HostRpcError ? error.code : null,
+            source: "Epic list",
+          })}
+          presentation="text"
+          className={undefined}
+        />
       </div>
       {showDetails ? (
         <pre

--- a/clients/gui-app/src/components/errors/__tests__/root-error-boundary.test.tsx
+++ b/clients/gui-app/src/components/errors/__tests__/root-error-boundary.test.tsx
@@ -1,8 +1,14 @@
 import "../../../../__tests__/test-browser-apis";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import { RootErrorBoundary } from "@/components/errors/root-error-boundary";
+import { ReportIssueDialogHost } from "@/components/layout/dialogs/report-issue-dialog-host";
+import { Toaster } from "@/components/ui/sonner";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { router } from "@/router";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
 function Boom(): never {
   throw new Error("boom from a provider");
@@ -11,6 +17,8 @@ function Boom(): never {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  useDesktopDialogStore.getState().close();
+  useDesktopDialogStore.setState({ reportIssueAvailable: false });
 });
 
 describe("<RootErrorBoundary />", () => {
@@ -56,5 +64,58 @@ describe("<RootErrorBoundary />", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /return to home/i }));
     expect(navigateSpy).toHaveBeenCalledWith({ to: "/" });
+  });
+
+  it("shows report submission failures while the root crash screen is active", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const runnerHost = Object.assign(
+      new MockRunnerHost({
+        signInUrl: "https://example.invalid/signin",
+        authnBaseUrl: "https://example.invalid",
+        localHost: null,
+        hosts: [],
+        workspaceFolderPickerPaths: undefined,
+        hasLocalHost: undefined,
+        traycerCli: undefined,
+      }),
+      {
+        support: {
+          getSnapshot: () => Promise.reject(new Error("snapshot unavailable")),
+          revealLog: () => Promise.reject(new Error("log unavailable")),
+          submitReport: () => Promise.reject(new Error("submit unavailable")),
+          tailLog: () => Promise.reject(new Error("log unavailable")),
+        },
+      },
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+
+    render(
+      <RunnerHostProvider runnerHost={runnerHost}>
+        <QueryClientProvider client={queryClient}>
+          <ReportIssueDialogHost />
+          <Toaster />
+          <RootErrorBoundary router={router}>
+            <Boom />
+          </RootErrorBoundary>
+        </QueryClientProvider>
+      </RunnerHostProvider>,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Report issue" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Submit Report" }),
+    );
+
+    expect(
+      await screen.findByText("Failed to submit report. Please try again."),
+    ).not.toBeNull();
+    expect(screen.getByTestId("app-error-screen")).not.toBeNull();
+    expect(
+      screen.getByRole("heading", { name: "Report an Issue" }),
+    ).not.toBeNull();
   });
 });

--- a/clients/gui-app/src/components/errors/app-error-screen.tsx
+++ b/clients/gui-app/src/components/errors/app-error-screen.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 import { AlertTriangle, House, RotateCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 export interface AppErrorScreenProps {
   /** The thrown value, surfaced as a short technical detail for support. */
@@ -67,6 +69,16 @@ export function AppErrorScreen(props: AppErrorScreenProps): ReactNode {
               <House aria-hidden />
               Return to Home
             </Button>
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Something went wrong",
+                message: "The app hit an unexpected error.",
+                code: null,
+                source: "Traycer app",
+              })}
+              presentation="text"
+              className="w-full"
+            />
           </div>
         </CardContent>
       </Card>

--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -2,7 +2,6 @@ import { useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
 import { v4 as uuidv4 } from "uuid";
-import { toast } from "sonner";
 import type {
   CreateEpicChatSeed,
   CreateEpicResponse,
@@ -75,6 +74,7 @@ import type {
   ServiceTier,
 } from "@/components/home/data/landing-options";
 import { deriveWorkspaceMode } from "@/lib/worktree/workspace-mode";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 export interface LandingComposerSubmitArgs {
   readonly editor: ComposerPromptEditorHandle | null;
@@ -255,9 +255,18 @@ export function useLandingComposerActions(): LandingComposerActions {
       // The folded chat is bound to a device for life, so a host must be
       // active to mint its binding (workspaces already imply one).
       if (activeHostId === null) {
-        toast.error("Couldn't create epic.", {
-          description: "No active device. Reconnect and try again.",
-        });
+        reportableErrorToast(
+          "Couldn't create epic.",
+          {
+            description: "No active device. Reconnect and try again.",
+          },
+          {
+            title: "Could not create Epic",
+            message: "No active device was available.",
+            code: null,
+            source: "Epic creation",
+          },
+        );
         return;
       }
       const userId = profile?.userId ?? null;
@@ -434,9 +443,18 @@ export function useLandingComposerActions(): LandingComposerActions {
         .then((bytesByHash) => {
           const missing = hashes.filter((hash) => !bytesByHash.has(hash));
           if (missing.length > 0) {
-            toast.error("Couldn't attach an image.", {
-              description: "Re-add the image and try sending again.",
-            });
+            reportableErrorToast(
+              "Couldn't attach an image.",
+              {
+                description: "Re-add the image and try sending again.",
+              },
+              {
+                title: "Could not attach image",
+                message: null,
+                code: null,
+                source: "Chat composer",
+              },
+            );
             return;
           }
           finalizeSubmission(
@@ -447,9 +465,18 @@ export function useLandingComposerActions(): LandingComposerActions {
           );
         })
         .catch(() => {
-          toast.error("Couldn't attach an image.", {
-            description: "Image storage is unavailable. Please try again.",
-          });
+          reportableErrorToast(
+            "Couldn't attach an image.",
+            {
+              description: "Image storage is unavailable. Please try again.",
+            },
+            {
+              title: "Could not attach image",
+              message: "Image storage was unavailable.",
+              code: null,
+              source: "Chat composer",
+            },
+          );
         })
         .finally(() => {
           submissionInFlightRef.current = false;

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-report-issue.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-report-issue.test.tsx
@@ -50,6 +50,7 @@ describe("<ModelRowsState /> catalog and model failure report actions", () => {
       activeDialog: null,
       reportIssueAvailable: false,
       reportIssueContext: null,
+      reportIssueDraftId: 0,
     });
   });
 
@@ -62,7 +63,7 @@ describe("<ModelRowsState /> catalog and model failure report actions", () => {
       rowsCount: 0,
     });
 
-    screen.getByText("Couldn't load providers");
+    screen.getByRole("option", { name: "Couldn't load providers" });
     expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
   });
 
@@ -112,7 +113,9 @@ describe("<ModelRowsState /> catalog and model failure report actions", () => {
     expect(reportButton.closest('[aria-disabled="true"]')).toBeNull();
     expect(reportButton.hasAttribute("disabled")).toBe(false);
     // The option row itself is still present, describing the same failure.
-    expect(screen.getByRole("option")).toBeTruthy();
+    expect(
+      screen.getByRole("option", { name: "Couldn't load providers" }),
+    ).toBeTruthy();
   });
 
   it("reports only fixed generic context for a selected-provider model load failure, never the raw host message", () => {
@@ -135,7 +138,9 @@ describe("<ModelRowsState /> catalog and model failure report actions", () => {
 
     // The raw host reason is still shown to the user inline (existing UX) -
     // only the report context must stay generic.
-    screen.getByText("secret-token-should-never-render /Users/hostile/path");
+    screen.getByRole("option", {
+      name: "secret-token-should-never-render /Users/hostile/path",
+    });
     expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
 
     act(() => {
@@ -165,7 +170,7 @@ describe("<ModelRowsState /> catalog and model failure report actions", () => {
       activeProvider: null,
       rowsCount: 0,
     });
-    screen.getByText("No models available");
+    screen.getByRole("option", { name: "No models available" });
     expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
 
     cleanup();
@@ -179,7 +184,7 @@ describe("<ModelRowsState /> catalog and model failure report actions", () => {
       activeProvider: null,
       rowsCount: 0,
     });
-    screen.getByText("Loading models");
+    screen.getByRole("option", { name: "Loading models" });
     expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
   });
 
@@ -199,7 +204,7 @@ describe("<ModelRowsState /> catalog and model failure report actions", () => {
       rowsCount: 0,
     });
 
-    screen.getByText("Add API key");
+    screen.getByRole("button", { name: "Add API key" });
     expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-report-issue.test.tsx
+++ b/clients/gui-app/src/components/home/pickers/__tests__/harness-model-picker-empty-report-issue.test.tsx
@@ -1,0 +1,205 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
+import { ModelRowsState } from "../harness-model-picker-empty";
+
+function harnessEntry(
+  overrides: Partial<GuiHarnessCatalogEntry>,
+): GuiHarnessCatalogEntry {
+  return {
+    id: "claude",
+    label: "Claude",
+    enabled: true,
+    available: true,
+    error: null,
+    modes: ["gui"],
+    requiresApiKey: false,
+    supportedPermissionModes: ["full_access"],
+    availabilityPending: false,
+    models: [],
+    modelsLoading: false,
+    modelsError: null,
+    ...overrides,
+  };
+}
+
+function renderRowsState(
+  props: Omit<Parameters<typeof ModelRowsState>[0], "onOpenProviderSettings">,
+): void {
+  render(
+    <TooltipProvider>
+      {ModelRowsState({ ...props, onOpenProviderSettings: () => undefined })}
+    </TooltipProvider>,
+  );
+}
+
+describe("<ModelRowsState /> catalog and model failure report actions", () => {
+  afterEach(() => {
+    cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
+  });
+
+  it("hides the report action on catalog error when capability is unavailable", () => {
+    renderRowsState({
+      catalogLoading: false,
+      catalogError: true,
+      hasQuery: false,
+      activeProvider: null,
+      rowsCount: 0,
+    });
+
+    screen.getByText("Couldn't load providers");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+
+  it("reports only fixed generic context for a catalog load failure", () => {
+    renderRowsState({
+      catalogLoading: false,
+      catalogError: true,
+      hasQuery: false,
+      activeProvider: null,
+      rowsCount: 0,
+    });
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load providers",
+        message: "The harness/provider catalog could not be loaded.",
+        code: null,
+        source: "Model picker",
+      },
+    });
+  });
+
+  it("keeps the report button outside the disabled option row so it stays independently accessible", () => {
+    renderRowsState({
+      catalogLoading: false,
+      catalogError: true,
+      hasQuery: false,
+      activeProvider: null,
+      rowsCount: 0,
+    });
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    const reportButton = screen.getByRole("button", { name: "Report issue" });
+
+    // A `role="option"` element's descendants are flattened/disabled by
+    // assistive tech, so the action must not be nested inside the
+    // `aria-disabled="true"` option row - only a sibling of it.
+    expect(reportButton.closest('[role="option"]')).toBeNull();
+    expect(reportButton.closest('[aria-disabled="true"]')).toBeNull();
+    expect(reportButton.hasAttribute("disabled")).toBe(false);
+    // The option row itself is still present, describing the same failure.
+    expect(screen.getByRole("option")).toBeTruthy();
+  });
+
+  it("reports only fixed generic context for a selected-provider model load failure, never the raw host message", () => {
+    const provider = harnessEntry({
+      modelsError: new HostRpcError({
+        code: "RPC_ERROR",
+        message: "secret-token-should-never-render /Users/hostile/path",
+        requestId: "req-1",
+        method: "agent.gui.listModels",
+        fatalDetails: null,
+      }),
+    });
+    renderRowsState({
+      catalogLoading: false,
+      catalogError: false,
+      hasQuery: false,
+      activeProvider: provider,
+      rowsCount: 0,
+    });
+
+    // The raw host reason is still shown to the user inline (existing UX) -
+    // only the report context must stay generic.
+    screen.getByText("secret-token-should-never-render /Users/hostile/path");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load models",
+        message: "Models for the selected provider could not be loaded.",
+        code: null,
+        source: "Model picker",
+      },
+    });
+    const context = useDesktopDialogStore.getState().reportIssueContext;
+    expect(JSON.stringify(context)).not.toContain("secret-token");
+    expect(JSON.stringify(context)).not.toContain("/Users/hostile/path");
+  });
+
+  it("does not surface a report action for benign empty/no-model states", () => {
+    renderRowsState({
+      catalogLoading: false,
+      catalogError: false,
+      hasQuery: false,
+      activeProvider: null,
+      rowsCount: 0,
+    });
+    screen.getByText("No models available");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    cleanup();
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    renderRowsState({
+      catalogLoading: true,
+      catalogError: false,
+      hasQuery: false,
+      activeProvider: null,
+      rowsCount: 0,
+    });
+    screen.getByText("Loading models");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+
+  it("does not surface a report action for the missing-API-key CTA", () => {
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    const provider = harnessEntry({
+      available: false,
+      requiresApiKey: true,
+    });
+    renderRowsState({
+      catalogLoading: false,
+      catalogError: false,
+      hasQuery: false,
+      activeProvider: provider,
+      rowsCount: 0,
+    });
+
+    screen.getByText("Add API key");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-empty.tsx
@@ -1,5 +1,7 @@
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
 import { useProvidersFocusStore } from "@/stores/settings/providers-focus-store";
 import { KeyRound } from "lucide-react";
@@ -8,18 +10,28 @@ import type { ReactNode } from "react";
 interface PickerStateRowProps {
   readonly label: string;
   readonly icon: ReactNode | undefined;
+  readonly action: ReactNode | undefined;
 }
 function PickerStateRow(props: PickerStateRowProps) {
-  const { label, icon } = props;
+  const { label, icon, action } = props;
   return (
-    <div
-      role="option"
-      aria-selected="false"
-      aria-disabled="true"
-      className="flex items-center gap-2 rounded-lg p-2 text-ui-sm text-muted-foreground"
-    >
-      {icon}
-      {label}
+    <div className="flex items-center justify-between gap-2 rounded-lg p-2 text-ui-sm text-muted-foreground">
+      {/* The action (when present) must stay OUTSIDE the option element: an
+          `option` role's descendants are flattened/treated as disabled by
+          assistive tech, which would make a nested Report issue button
+          unreachable. Keeping the row's flex layout on the outer div and the
+          option semantics on this inner span preserves the visual row while
+          leaving the action independently focusable/announced. */}
+      <span
+        role="option"
+        aria-selected="false"
+        aria-disabled="true"
+        className="flex min-w-0 items-center gap-2"
+      >
+        {icon}
+        {label}
+      </span>
+      {action}
     </div>
   );
 }
@@ -45,12 +57,33 @@ export function ModelRowsState(props: ModelRowsStateProps): ReactNode | null {
 
   if (catalogLoading && rowsCount === 0) {
     return (
-      <PickerStateRow icon={<MutedAgentSpinner />} label="Loading models" />
+      <PickerStateRow
+        icon={<MutedAgentSpinner />}
+        label="Loading models"
+        action={undefined}
+      />
     );
   }
 
   if (catalogError) {
-    return <PickerStateRow label="Couldn't load providers" icon={undefined} />;
+    return (
+      <PickerStateRow
+        label="Couldn't load providers"
+        icon={undefined}
+        action={
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Couldn't load providers",
+              message: "The harness/provider catalog could not be loaded.",
+              code: null,
+              source: "Model picker",
+            })}
+            presentation="icon"
+            className={undefined}
+          />
+        }
+      />
+    );
   }
 
   // A provider that can't list models (unavailable / missing API key / load
@@ -62,7 +95,11 @@ export function ModelRowsState(props: ModelRowsStateProps): ReactNode | null {
 
   if (activeProvider?.modelsLoading === true) {
     return (
-      <PickerStateRow icon={<MutedAgentSpinner />} label="Loading models" />
+      <PickerStateRow
+        icon={<MutedAgentSpinner />}
+        label="Loading models"
+        action={undefined}
+      />
     );
   }
 
@@ -75,6 +112,18 @@ export function ModelRowsState(props: ModelRowsStateProps): ReactNode | null {
       <PickerStateRow
         label={reason.length > 0 ? reason : "Couldn't load models"}
         icon={undefined}
+        action={
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Couldn't load models",
+              message: "Models for the selected provider could not be loaded.",
+              code: null,
+              source: "Model picker",
+            })}
+            presentation="icon"
+            className={undefined}
+          />
+        }
       />
     );
   }
@@ -84,6 +133,7 @@ export function ModelRowsState(props: ModelRowsStateProps): ReactNode | null {
       <PickerStateRow
         label={noModelsLabel(hasQuery, activeProvider)}
         icon={undefined}
+        action={undefined}
       />
     );
   }
@@ -120,7 +170,11 @@ function unavailableProviderState(
     );
   }
   return (
-    <PickerStateRow label={`${provider.label} unavailable`} icon={undefined} />
+    <PickerStateRow
+      label={`${provider.label} unavailable`}
+      icon={undefined}
+      action={undefined}
+    />
   );
 }
 

--- a/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-update-ui.test.tsx
@@ -35,7 +35,7 @@ type ToastOptions = {
   description?: ReactNode;
   duration?: number;
   action?: ToastAction;
-  cancel?: ToastAction;
+  cancel?: ToastAction | null;
 };
 
 type ToastCall = (
@@ -243,6 +243,7 @@ describe("desktop app update UI", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useDesktopDialogStore.getState().close();
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
   });
 
   afterEach(() => {
@@ -478,7 +479,12 @@ describe("desktop app update UI", () => {
     await waitFor(() => {
       expect(toastMock.info).toHaveBeenCalledWith(
         "Checking for Traycer updates...",
-        { id: "traycer-app-update", description: null, duration: 4000 },
+        {
+          id: "traycer-app-update",
+          description: null,
+          duration: 4000,
+          cancel: null,
+        },
       );
     });
 
@@ -515,7 +521,7 @@ describe("desktop app update UI", () => {
       throw new Error("Expected update available toast content");
     }
     expect(options.action).toBeUndefined();
-    expect(options.cancel).toBeUndefined();
+    expect(options.cancel).toBeNull();
     render(<>{message}</>);
     screen.getByText("Update available");
     screen.getByText("Version 1.2.3 is ready to download.");
@@ -639,7 +645,7 @@ describe("desktop app update UI", () => {
       throw new Error("Expected update ready toast content");
     }
     expect(options.action).toBeUndefined();
-    expect(options.cancel).toBeUndefined();
+    expect(options.cancel).toBeNull();
     render(<>{message}</>);
     screen.getByText("Update ready to install");
     screen.getByText("Restart Traycer to finish updating.");
@@ -687,6 +693,7 @@ describe("desktop app update UI", () => {
   });
 
   it("offers a Report an issue action that opens the report dialog on error", async () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
     const bridge = new FakeAppUpdatesBridge(IDLE_SNAPSHOT);
     renderWithHost(<AppUpdateToastController />, bridge);
     await waitFor(() => {
@@ -711,7 +718,7 @@ describe("desktop app update UI", () => {
       throw new Error("Expected update error toast options");
     }
     expect(options.action).toBeUndefined();
-    expect(options.cancel).toBeUndefined();
+    expect(options.cancel).toBeNull();
     render(<>{options.description}</>);
     screen.getByText(
       "Traycer couldn't reach the update service right now. Please try again in a little while.",
@@ -722,9 +729,16 @@ describe("desktop app update UI", () => {
     expect(useDesktopDialogStore.getState().activeDialog).toBeNull();
     fireEvent.click(reportButton);
     expect(useDesktopDialogStore.getState().activeDialog).toBe("report-issue");
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Could not update Traycer",
+      message: null,
+      code: null,
+      source: "App update",
+    });
   });
 
   it("offers View instructions alongside Report an issue when a live install failure has guidance", async () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
     const bridge = new FakeAppUpdatesBridge(IDLE_SNAPSHOT);
     renderWithHost(<AppUpdateToastController />, bridge);
     await waitFor(() => {
@@ -749,12 +763,75 @@ describe("desktop app update UI", () => {
     const viewInstructions = screen.getByRole("button", {
       name: "View instructions",
     });
-    screen.getByRole("button", { name: "Report an issue" });
+    const reportIssue = screen.getByRole("button", {
+      name: "Report an issue",
+    });
+    expect(viewInstructions.getAttribute("data-variant")).toBe("default");
+    expect(reportIssue.getAttribute("data-variant")).toBe("secondary");
     expect(useDesktopDialogStore.getState().activeDialog).toBeNull();
     fireEvent.click(viewInstructions);
     expect(useDesktopDialogStore.getState().activeDialog).toBe(
       "install-guidance",
     );
+  });
+
+  it("does not offer reporting when the support capability is unavailable", async () => {
+    const bridge = new FakeAppUpdatesBridge(IDLE_SNAPSHOT);
+    renderWithHost(<AppUpdateToastController />, bridge);
+    await waitFor(() => {
+      expect(bridge.subscriptionCount()).toBe(1);
+    });
+
+    act(() => {
+      bridge.emit(errorSnapshot(1));
+    });
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalled();
+    });
+
+    const [, options] = toastMock.error.mock.lastCall ?? [];
+    if (options === undefined) {
+      throw new Error("Expected update error toast options");
+    }
+    render(<>{options.description}</>);
+
+    screen.getByText(
+      "Traycer couldn't reach the update service right now. Please try again in a little while.",
+    );
+    expect(
+      screen.queryByRole("button", { name: "Report an issue" }),
+    ).toBeNull();
+  });
+
+  it("updates the current error toast when reporting becomes available", async () => {
+    const bridge = new FakeAppUpdatesBridge(IDLE_SNAPSHOT);
+    renderWithHost(<AppUpdateToastController />, bridge);
+    await waitFor(() => {
+      expect(bridge.subscriptionCount()).toBe(1);
+    });
+
+    act(() => {
+      bridge.emit(errorSnapshot(1));
+    });
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledTimes(2);
+    });
+
+    const [, options] = toastMock.error.mock.lastCall ?? [];
+    if (options === undefined) {
+      throw new Error("Expected update error toast options");
+    }
+    render(<>{options.description}</>);
+    expect(
+      screen.getByRole("button", { name: "Report an issue" }),
+    ).not.toBeNull();
   });
 
   it("does not replay stale manual-check results in a newly opened window", async () => {

--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -480,7 +480,10 @@ async function flushDialogEffects(): Promise<void> {
 function resetStores(): void {
   cloudEpicTasks.data = [];
   useDesktopDialogStore.getState().close();
-  useDesktopDialogStore.setState({ reportIssueAvailable: false });
+  useDesktopDialogStore.setState({
+    reportIssueAvailable: false,
+    reportIssueDraftId: 0,
+  });
   useEpicCanvasStore.setState({
     tabsById: {},
     openTabOrder: [],
@@ -566,10 +569,14 @@ describe("<DesktopDialogHost />", () => {
     renderDesktopDialogHost(createRunnerHost([], [], []), "/");
     await flushDialogEffects();
 
-    expect(screen.getByDisplayValue("Failed to load epic")).not.toBeNull();
-    const whatHappened = screen.getByPlaceholderText(
-      "A clear description of the bug. Include any error messages you saw.",
-    );
+    const title = screen.getByRole("textbox", { name: "Title" });
+    if (!(title instanceof HTMLInputElement)) {
+      throw new Error("Expected the report title field.");
+    }
+    expect(title.value).toBe("Failed to load epic");
+    const whatHappened = screen.getByRole("textbox", {
+      name: "What happened?",
+    });
     if (!(whatHappened instanceof HTMLTextAreaElement)) {
       throw new Error("Expected the report description field.");
     }

--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -24,6 +24,8 @@ import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import type {
+  DesktopReportIssueForm,
+  DesktopSubmitReportResult,
   DesktopWindowsBridge,
   DesktopSupportLogTarget,
   DesktopSupportSnapshot,
@@ -39,6 +41,7 @@ import type {
   OpenEpicStoreHandle,
 } from "@/stores/epics/open-epic/store";
 import { EMPTY_PROJECTED_SLICES } from "@/stores/epics/open-epic/types";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 const cloudEpicTasks = vi.hoisted((): { data: TaskLight[] } => ({ data: [] }));
 
@@ -60,6 +63,7 @@ vi.mock("@/hooks/epics/use-cloud-epic-tasks-query", () => ({
 }));
 
 import { DesktopDialogHost } from "@/components/layout/dialogs/desktop-dialog-host";
+import { ReportIssueDialogHost } from "@/components/layout/dialogs/report-issue-dialog-host";
 
 const snapshot: DesktopSupportSnapshot = {
   appName: "Traycer",
@@ -122,6 +126,22 @@ const snapshot: DesktopSupportSnapshot = {
 
 const EPIC_A = { id: "e-a", name: "A", draft: false };
 
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T) => void;
+  readonly reject: (error: Error) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolveValue: (value: T) => void = () => undefined;
+  let rejectValue: (error: Error) => void = () => undefined;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveValue = resolve;
+    rejectValue = reject;
+  });
+  return { promise, resolve: resolveValue, reject: rejectValue };
+}
+
 function createRunnerHost(
   revealed: DesktopSupportLogTarget[],
   openedLinks: string[],
@@ -154,6 +174,32 @@ function createRunnerHost(
               ?.path ?? "",
           lines: logLines.slice(-input.tailLines),
           truncated: logLines.length > input.tailLines,
+        }),
+    },
+  });
+}
+
+function createRunnerHostWithSubmit(
+  openedLinks: string[],
+  submitReport: (
+    form: DesktopReportIssueForm,
+  ) => Promise<DesktopSubmitReportResult>,
+): IRunnerHost {
+  return Object.assign(createRunnerHost([], openedLinks, []), {
+    support: {
+      getSnapshot: () => Promise.resolve(snapshot),
+      revealLog: (target: DesktopSupportLogTarget) =>
+        Promise.resolve({ target, path: "" }),
+      submitReport,
+      tailLog: (input: {
+        readonly target: DesktopSupportLogTarget;
+        readonly tailLines: number;
+      }) =>
+        Promise.resolve({
+          target: input.target,
+          path: "",
+          lines: [],
+          truncated: false,
         }),
     },
   });
@@ -377,6 +423,7 @@ function buildRouter(runnerHost: IRunnerHost, initialPath: string) {
     component: () => (
       <RunnerHostProvider runnerHost={runnerHost}>
         <DesktopDialogHost />
+        <ReportIssueDialogHost />
       </RunnerHostProvider>
     ),
   });
@@ -433,6 +480,7 @@ async function flushDialogEffects(): Promise<void> {
 function resetStores(): void {
   cloudEpicTasks.data = [];
   useDesktopDialogStore.getState().close();
+  useDesktopDialogStore.setState({ reportIssueAvailable: false });
   useEpicCanvasStore.setState({
     tabsById: {},
     openTabOrder: [],
@@ -502,6 +550,233 @@ describe("<DesktopDialogHost />", () => {
 
     await waitFor(() => {
       expect(revealed).toEqual(["host"]);
+    });
+  });
+
+  it("prefills a contextual report and clears it when the dialog closes", async () => {
+    useDesktopDialogStore.getState().openReportIssueWithContext(
+      createReportIssueContext({
+        title: "Failed to load epic",
+        message: "The host returned an unexpected response.",
+        code: "RPC_ERROR",
+        source: "Epic snapshot",
+      }),
+    );
+
+    renderDesktopDialogHost(createRunnerHost([], [], []), "/");
+    await flushDialogEffects();
+
+    expect(screen.getByDisplayValue("Failed to load epic")).not.toBeNull();
+    const whatHappened = screen.getByPlaceholderText(
+      "A clear description of the bug. Include any error messages you saw.",
+    );
+    if (!(whatHappened instanceof HTMLTextAreaElement)) {
+      throw new Error("Expected the report description field.");
+    }
+    expect(whatHappened.value).toBe(
+      "Area: Epic snapshot\n\nError code: RPC_ERROR\n\nThe host returned an unexpected response.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: null,
+      reportIssueContext: null,
+    });
+  });
+
+  it("replaces an edited draft when a later report context is selected", async () => {
+    useDesktopDialogStore.getState().openReportIssueWithContext(
+      createReportIssueContext({
+        title: "Earlier error",
+        message: null,
+        code: null,
+        source: "Earlier area",
+      }),
+    );
+    renderDesktopDialogHost(createRunnerHost([], [], []), "/");
+    await flushDialogEffects();
+
+    const titleInput = screen.getByPlaceholderText(
+      "Short summary of the issue",
+    );
+    if (!(titleInput instanceof HTMLInputElement)) {
+      throw new Error("Expected the report title input.");
+    }
+    fireEvent.change(titleInput, { target: { value: "My edited draft" } });
+    expect(titleInput.value).toBe("My edited draft");
+
+    act(() => {
+      useDesktopDialogStore.getState().openReportIssueWithContext(
+        createReportIssueContext({
+          title: "Most recent error",
+          message: "A fixed safe message.",
+          code: "RPC_ERROR",
+          source: "Latest area",
+        }),
+      );
+    });
+
+    expect(await screen.findByDisplayValue("Most recent error")).not.toBeNull();
+    expect(screen.queryByDisplayValue("My edited draft")).toBeNull();
+  });
+
+  it("refuses and closes report state when desktop support is unavailable", async () => {
+    useDesktopDialogStore.setState({
+      activeDialog: "report-issue",
+      reportIssueContext: createReportIssueContext({
+        title: "Unsupported report",
+        message: null,
+        code: null,
+        source: "Test",
+      }),
+      reportIssueDraftId: 1,
+    });
+
+    renderDesktopDialogHost(createBaseRunnerHost(), "/");
+
+    expect(
+      screen.queryByRole("heading", { name: "Report an Issue" }),
+    ).toBeNull();
+    await waitFor(() => {
+      expect(useDesktopDialogStore.getState()).toMatchObject({
+        activeDialog: null,
+        reportIssueAvailable: false,
+        reportIssueContext: null,
+      });
+    });
+  });
+
+  it("keeps a failed submission inline, focused, and preserves the form", async () => {
+    useDesktopDialogStore.getState().openReportIssueWithContext(
+      createReportIssueContext({
+        title: "Original title",
+        message: "Original details",
+        code: null,
+        source: "Test",
+      }),
+    );
+    renderDesktopDialogHost(
+      createRunnerHostWithSubmit([], () =>
+        Promise.reject(new Error("submit unavailable")),
+      ),
+      "/",
+    );
+    await flushDialogEffects();
+
+    const title = screen.getByPlaceholderText("Short summary of the issue");
+    const whatHappened = screen.getByPlaceholderText(
+      "A clear description of the bug. Include any error messages you saw.",
+    );
+    fireEvent.change(title, { target: { value: "Edited title" } });
+    fireEvent.change(whatHappened, {
+      target: { value: "Edited private-safe details" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Submit Report" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toBe(
+      "Failed to submit report. Please try again.",
+    );
+    await waitFor(() => {
+      expect(document.activeElement).toBe(alert);
+    });
+    expect(screen.getByDisplayValue("Edited title")).not.toBeNull();
+    expect(
+      screen.getByDisplayValue("Edited private-safe details"),
+    ).not.toBeNull();
+    expect(useDesktopDialogStore.getState().activeDialog).toBe("report-issue");
+  });
+
+  it("opens an older successful submission without closing a newer draft", async () => {
+    const deferred = createDeferred<DesktopSubmitReportResult>();
+    const openedLinks: string[] = [];
+    useDesktopDialogStore.getState().openReportIssueWithContext(
+      createReportIssueContext({
+        title: "Draft A",
+        message: null,
+        code: null,
+        source: "Test A",
+      }),
+    );
+    renderDesktopDialogHost(
+      createRunnerHostWithSubmit(openedLinks, () => deferred.promise),
+      "/",
+    );
+    await flushDialogEffects();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Report" }));
+
+    const draftBContext = createReportIssueContext({
+      title: "Draft B",
+      message: "Newer details",
+      code: null,
+      source: "Test B",
+    });
+    act(() => {
+      useDesktopDialogStore
+        .getState()
+        .openReportIssueWithContext(draftBContext);
+    });
+    const draftBTitle = await screen.findByDisplayValue("Draft B");
+    fireEvent.change(draftBTitle, { target: { value: "Edited Draft B" } });
+
+    await act(async () => {
+      deferred.resolve({ reportId: "rpt_a" });
+      await deferred.promise;
+    });
+    await waitFor(() => {
+      expect(openedLinks).toHaveLength(1);
+    });
+
+    expect(
+      new URL(openedLinks[0], "https://github.com").searchParams.get("title"),
+    ).toBe("Draft A");
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: draftBContext,
+    });
+    expect(screen.getByDisplayValue("Edited Draft B")).not.toBeNull();
+  });
+
+  it("does not surface an older failed submission in a newer draft", async () => {
+    const deferred = createDeferred<DesktopSubmitReportResult>();
+    useDesktopDialogStore.getState().openReportIssueWithContext(
+      createReportIssueContext({
+        title: "Draft A",
+        message: null,
+        code: null,
+        source: "Test A",
+      }),
+    );
+    renderDesktopDialogHost(
+      createRunnerHostWithSubmit([], () => deferred.promise),
+      "/",
+    );
+    await flushDialogEffects();
+    fireEvent.click(screen.getByRole("button", { name: "Submit Report" }));
+
+    const draftBContext = createReportIssueContext({
+      title: "Draft B",
+      message: "Newer details",
+      code: null,
+      source: "Test B",
+    });
+    act(() => {
+      useDesktopDialogStore
+        .getState()
+        .openReportIssueWithContext(draftBContext);
+    });
+    await screen.findByDisplayValue("Draft B");
+
+    await act(async () => {
+      deferred.reject(new Error("Draft A failed"));
+      await deferred.promise.catch(() => undefined);
+    });
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByDisplayValue("Draft B")).not.toBeNull();
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: draftBContext,
     });
   });
 

--- a/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
@@ -336,12 +336,14 @@ describe("<MenuCommandListener />", () => {
     routerState.pathname = "/";
     resetStores();
     useDesktopDialogStore.getState().close();
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
   });
 
   afterEach(() => {
     cleanup();
     resetStores();
     useDesktopDialogStore.getState().close();
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
   });
 
   it("dispatches native menu commands to renderer-owned actions", () => {
@@ -372,6 +374,22 @@ describe("<MenuCommandListener />", () => {
     );
     expect(runnerHost.windows.requestNew).toHaveBeenCalledWith(null);
     expect(runnerHost.hostPickerRequestOpen).not.toHaveBeenCalled();
+  });
+
+  it("gates the native report command on current support capability", () => {
+    const menu = createMenu();
+    renderMenuCommandListener(menu);
+
+    act(() => {
+      menu.emit("app.reportIssue");
+    });
+    expect(useDesktopDialogStore.getState().activeDialog).toBeNull();
+
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    act(() => {
+      menu.emit("app.reportIssue");
+    });
+    expect(useDesktopDialogStore.getState().activeDialog).toBe("report-issue");
   });
 
   it("requests close for the sender window from the native close-window command", () => {

--- a/clients/gui-app/src/components/layout/__tests__/migration-blocking-modal-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/migration-blocking-modal-host.test.tsx
@@ -1,17 +1,28 @@
 import "../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MigrationBlockingModalHost } from "@/components/layout/dialogs/migration-blocking-modal-host";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { useMigrationRunStore } from "@/stores/migration/migration-run-store";
 
 describe("<MigrationBlockingModalHost />", () => {
   beforeEach(() => {
     useMigrationRunStore.getState().reset();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
   });
 
   afterEach(() => {
     cleanup();
     useMigrationRunStore.getState().reset();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
   });
 
   it("renders the settings retry migration layer as a portaled full-screen blocker", () => {
@@ -31,5 +42,23 @@ describe("<MigrationBlockingModalHost />", () => {
     expect(overlay.className).toContain("fixed");
     expect(overlay.className).not.toContain("absolute");
     expect(modal.className).toContain("fixed");
+  });
+
+  it("offers a capability-gated report action with fixed migration context", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    useMigrationRunStore.getState().applyError();
+
+    render(<MigrationBlockingModalHost />);
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Migration interrupted",
+        message: "The migration did not finish.",
+        code: null,
+        source: "Data migration",
+      },
+    });
   });
 });

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -35,6 +35,7 @@ import type { AuthService } from "@/lib/auth/auth-service";
 import { AuthSessionExpiredToastBridge } from "@/providers/auth-session-expired-toast-bridge";
 import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import { useAuthStore } from "@/stores/auth/auth-store";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
 function buildHost(): MockRunnerHost {
   return new MockRunnerHost({
@@ -259,6 +260,11 @@ describe("<SignInButton />", () => {
 
   beforeEach(() => {
     useAuthStore.getState().setSignedOut();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
     vi.clearAllMocks();
     // Default profile fetch is unused by these tests; install a benign 401
     // so any stray call does not accidentally sign the user in.
@@ -270,6 +276,11 @@ describe("<SignInButton />", () => {
   afterEach(() => {
     cleanup();
     useAuthStore.getState().setSignedOut();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
     restoreFetch();
   });
 
@@ -300,6 +311,21 @@ describe("<SignInButton />", () => {
     });
     const detail = screen.getByTestId("signin-error-detail");
     expect(detail.textContent).toBe("sign-in-failed");
+
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Sign in failed",
+        message: null,
+        code: null,
+        source: "Sign in",
+      },
+    });
     result.cleanupClient();
   });
 
@@ -359,7 +385,7 @@ describe("<SignInButton />", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
         "Session expired - sign in again.",
-        { id: "auth-session:expired" },
+        { id: "auth-session:expired", cancel: null },
       );
     });
     expect(screen.queryByTestId("signin-error")).toBeNull();
@@ -379,7 +405,7 @@ describe("<SignInButton />", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
         "Session expired - sign in again.",
-        { id: "auth-session:expired" },
+        { id: "auth-session:expired", cancel: null },
       );
     });
     expect(await host.tokenStore.get()).toBeNull();
@@ -420,7 +446,7 @@ describe("<SignInButton />", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
         "Session expired - sign in again.",
-        { id: "auth-session:expired" },
+        { id: "auth-session:expired", cancel: null },
       );
     });
     expect(useAuthStore.getState().status).toBe("signed-out");

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -264,6 +264,7 @@ describe("<SignInButton />", () => {
       activeDialog: null,
       reportIssueAvailable: false,
       reportIssueContext: null,
+      reportIssueDraftId: 0,
     });
     vi.clearAllMocks();
     // Default profile fetch is unused by these tests; install a benign 401
@@ -280,6 +281,7 @@ describe("<SignInButton />", () => {
       activeDialog: null,
       reportIssueAvailable: false,
       reportIssueContext: null,
+      reportIssueDraftId: 0,
     });
     restoreFetch();
   });

--- a/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
@@ -7,22 +7,34 @@ import type {
   DesktopAppUpdateSnapshot,
   DesktopAppUpdatesBridge,
 } from "@/lib/windows/types";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const APP_UPDATE_TOAST_ID = "traycer-app-update";
 const APP_UPDATE_TRANSIENT_TOAST_DURATION_MS = 4000;
+const APP_UPDATE_REPORT_CONTEXT = createReportIssueContext({
+  title: "Could not update Traycer",
+  message: null,
+  code: null,
+  source: "App update",
+});
 
 export function AppUpdateToastController(): null {
   const { bridge, snapshot } = useDesktopAppUpdates();
-  const openReportIssue = useDesktopDialogStore(
-    (state) => state.openReportIssue,
-  );
   const openConfirmRestartUpdate = useDesktopDialogStore(
     (state) => state.openConfirmRestartUpdate,
   );
   const openInstallGuidance = useDesktopDialogStore(
     (state) => state.openInstallGuidance,
   );
+  const openReportIssueWithContext = useDesktopDialogStore(
+    (state) => state.openReportIssueWithContext,
+  );
+  const reportIssueAvailable = useDesktopDialogStore(
+    (state) => state.reportIssueAvailable,
+  );
   const handledSequenceRef = useRef(0);
+  const handledReportCapabilityRef = useRef<boolean | null>(null);
   const bridgeRef = useRef<DesktopAppUpdatesBridge | null | undefined>(
     undefined,
   );
@@ -34,14 +46,26 @@ export function AppUpdateToastController(): null {
       const isInitialBridge = bridgeRef.current === undefined;
       bridgeRef.current = bridge;
       handledSequenceRef.current = 0;
+      handledReportCapabilityRef.current = null;
       if (!isInitialBridge) {
         mountedAtMsRef.current = Date.now();
       }
     }
     if (bridge === null) return;
     if (snapshot.sequence === 0) return;
-    if (handledSequenceRef.current >= snapshot.sequence) return;
+    const capabilityChangedForCurrentError =
+      snapshot.status === "error" &&
+      handledSequenceRef.current === snapshot.sequence &&
+      handledReportCapabilityRef.current !== reportIssueAvailable;
+    if (
+      handledSequenceRef.current > snapshot.sequence ||
+      (handledSequenceRef.current === snapshot.sequence &&
+        !capabilityChangedForCurrentError)
+    ) {
+      return;
+    }
     handledSequenceRef.current = snapshot.sequence;
+    handledReportCapabilityRef.current = reportIssueAvailable;
     const mountedAtMs = mountedAtMsRef.current;
     if (isManualReplayFromBeforeMount(snapshot, mountedAtMs)) {
       return;
@@ -52,15 +76,18 @@ export function AppUpdateToastController(): null {
         void bridge.downloadUpdate();
       },
       onRestart: openConfirmRestartUpdate,
-      onReportIssue: openReportIssue,
       onViewInstructions: openInstallGuidance,
+      onReportIssue: reportIssueAvailable
+        ? () => openReportIssueWithContext(APP_UPDATE_REPORT_CONTEXT)
+        : null,
     });
   }, [
     bridge,
     snapshot,
-    openReportIssue,
     openConfirmRestartUpdate,
     openInstallGuidance,
+    openReportIssueWithContext,
+    reportIssueAvailable,
   ]);
 
   return null;
@@ -69,8 +96,8 @@ export function AppUpdateToastController(): null {
 interface AppUpdateToastActions {
   readonly onDownload: () => void;
   readonly onRestart: () => void;
-  readonly onReportIssue: () => void;
   readonly onViewInstructions: () => void;
+  readonly onReportIssue: (() => void) | null;
 }
 
 function showAppUpdateToast(
@@ -84,6 +111,7 @@ function showAppUpdateToast(
           id: APP_UPDATE_TOAST_ID,
           description: null,
           duration: APP_UPDATE_TRANSIENT_TOAST_DURATION_MS,
+          cancel: null,
         });
       }
       return;
@@ -97,6 +125,7 @@ function showAppUpdateToast(
           id: APP_UPDATE_TOAST_ID,
           description: snapshot.installBlockedReason,
           duration: APP_UPDATE_TRANSIENT_TOAST_DURATION_MS,
+          cancel: null,
         });
         return;
       }
@@ -113,6 +142,7 @@ function showAppUpdateToast(
           id: APP_UPDATE_TOAST_ID,
           description: null,
           duration: Infinity,
+          cancel: null,
         },
       );
       return;
@@ -124,6 +154,7 @@ function showAppUpdateToast(
             ? "Starting download…"
             : `${snapshot.downloadProgress}% complete`,
         duration: Infinity,
+        cancel: null,
       });
       return;
     case "ready":
@@ -150,26 +181,33 @@ function showAppUpdateToast(
           id: APP_UPDATE_TOAST_ID,
           description: null,
           duration: Infinity,
+          cancel: null,
         },
       );
       return;
-    case "error":
-      toast.error("Couldn't update Traycer", {
-        id: APP_UPDATE_TOAST_ID,
-        description: (
-          <AppUpdateErrorToastDescription
-            message={snapshot.errorMessage}
-            onReportIssue={actions.onReportIssue}
-            onViewInstructions={
-              snapshot.installGuidance === null
-                ? null
-                : actions.onViewInstructions
-            }
-          />
-        ),
-        duration: Infinity,
-      });
+    case "error": {
+      reportableErrorToast(
+        "Couldn't update Traycer",
+        {
+          id: APP_UPDATE_TOAST_ID,
+          cancel: null,
+          description: (
+            <AppUpdateErrorToastDescription
+              message={snapshot.errorMessage}
+              onReportIssue={actions.onReportIssue}
+              onViewInstructions={
+                snapshot.installGuidance === null
+                  ? null
+                  : actions.onViewInstructions
+              }
+            />
+          ),
+          duration: Infinity,
+        },
+        APP_UPDATE_REPORT_CONTEXT,
+      );
       return;
+    }
     case "up-to-date":
       toast.success("Traycer is up to date", {
         id: APP_UPDATE_TOAST_ID,
@@ -178,6 +216,7 @@ function showAppUpdateToast(
             ? null
             : `Current version: v${snapshot.currentVersion}`,
         duration: APP_UPDATE_TRANSIENT_TOAST_DURATION_MS,
+        cancel: null,
       });
       return;
     case "unavailable":
@@ -185,6 +224,7 @@ function showAppUpdateToast(
         id: APP_UPDATE_TOAST_ID,
         description: null,
         duration: APP_UPDATE_TRANSIENT_TOAST_DURATION_MS,
+        cancel: null,
       });
       return;
     case "idle":
@@ -277,26 +317,33 @@ function AppUpdateActionToastContent(props: {
 
 function AppUpdateErrorToastDescription(props: {
   readonly message: string | null;
-  readonly onReportIssue: () => void;
+  readonly onReportIssue: (() => void) | null;
   readonly onViewInstructions: (() => void) | null;
 }) {
   return (
     <div className="flex flex-col items-start gap-3">
       {props.message === null ? null : <span>{props.message}</span>}
-      <div className="flex gap-2">
+      <div className="flex flex-wrap gap-2">
         {props.onViewInstructions === null ? null : (
           <Button
             type="button"
             size="sm"
-            variant="secondary"
+            variant="default"
             onClick={props.onViewInstructions}
           >
             View instructions
           </Button>
         )}
-        <Button type="button" size="sm" onClick={props.onReportIssue}>
-          Report an issue
-        </Button>
+        {props.onReportIssue === null ? null : (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            onClick={props.onReportIssue}
+          >
+            Report an issue
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
@@ -80,9 +80,6 @@ export function MenuCommandListener() {
   const openEpicInNewWindow = useDesktopDialogStore(
     (state) => state.openEpicInNewWindow,
   );
-  const openReportIssue = useDesktopDialogStore(
-    (state) => state.openReportIssue,
-  );
   const management = runnerHost.hostManagement;
   const service = runnerHost.service;
   const traycerCli = runnerHost.traycerCli;
@@ -174,7 +171,11 @@ export function MenuCommandListener() {
         requestHostRestart: () => {
           setPendingHostRestart(true);
         },
-        reportIssue: openReportIssue,
+        reportIssue: () => {
+          const state = useDesktopDialogStore.getState();
+          if (!state.reportIssueAvailable) return;
+          state.openReportIssue();
+        },
       });
     });
     return () => {
@@ -189,7 +190,6 @@ export function MenuCommandListener() {
     openLogs,
     runnerHost,
     mutateInstallUpdate,
-    openReportIssue,
   ]);
 
   return (

--- a/clients/gui-app/src/components/layout/bridges/worktree-delete-progress-toast-bridge.tsx
+++ b/clients/gui-app/src/components/layout/bridges/worktree-delete-progress-toast-bridge.tsx
@@ -5,8 +5,16 @@ import {
   worktreeDeleteProgressDetail,
   type WorktreeDeleteProgressSummary,
 } from "@/components/settings/panels/use-worktree-delete-run";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 const WORKTREE_DELETE_PROGRESS_TOAST_ID = "worktree-delete-progress";
+const WORKTREE_DELETE_REPORT_CONTEXT = createReportIssueContext({
+  title: "Could not delete worktree",
+  message: null,
+  code: null,
+  source: "Worktrees",
+});
 
 export function WorktreeDeleteProgressToastBridge(): null {
   const summary = useWorktreeDeleteProgressSummary();
@@ -47,6 +55,7 @@ function showWorktreeDeleteProgressToast(
       id: WORKTREE_DELETE_PROGRESS_TOAST_ID,
       description,
       duration: Infinity,
+      cancel: null,
     });
     return;
   }
@@ -54,18 +63,23 @@ function showWorktreeDeleteProgressToast(
     toast.success(`Deleted ${worktreeCountLabel(summary.deleted)}`, {
       id: WORKTREE_DELETE_PROGRESS_TOAST_ID,
       description,
+      cancel: null,
     });
     return;
   }
   // A failure toast persists (no auto-expiry) and is directly dismissable, so a
   // user who never reopens the Worktrees panel to dismiss the strip can still
   // clear it.
-  toast.error(worktreeDeleteFailureTitle(summary), {
-    id: WORKTREE_DELETE_PROGRESS_TOAST_ID,
-    description,
-    duration: Infinity,
-    closeButton: true,
-  });
+  reportableErrorToast(
+    worktreeDeleteFailureTitle(summary),
+    {
+      id: WORKTREE_DELETE_PROGRESS_TOAST_ID,
+      description,
+      duration: Infinity,
+      closeButton: true,
+    },
+    WORKTREE_DELETE_REPORT_CONTEXT,
+  );
 }
 
 function worktreeDeleteToastKey(

--- a/clients/gui-app/src/components/layout/dialogs/desktop-dialog-host.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop-dialog-host.tsx
@@ -10,7 +10,6 @@ import { InstallGuidanceDialog } from "@/components/layout/dialogs/install-guida
 import { AboutDetailsDialog } from "./desktop/about-details-dialog";
 import { LogsChooserDialog } from "./desktop/logs-chooser-dialog";
 import { OpenEpicInNewWindowDialog } from "./desktop/open-epic-in-new-window-dialog";
-import { ReportIssueDialog } from "./desktop/report-issue-dialog";
 
 export function DesktopDialogHost(): ReactNode {
   const runnerHost = useRunnerHost();
@@ -74,15 +73,6 @@ export function DesktopDialogHost(): ReactNode {
           }}
           close={close}
           flow={openEpicInNewWindowFlow}
-        />
-      ) : null}
-      {activeDialog === "report-issue" ? (
-        <ReportIssueDialog
-          open
-          onOpenChange={(open) => {
-            if (!open) close();
-          }}
-          support={support}
         />
       ) : null}
       {activeDialog === "confirm-restart-update" &&

--- a/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/about-details-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/about-details-dialog.test.tsx
@@ -1,0 +1,90 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopSupportBridge } from "@/lib/windows/types";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { AboutDetailsDialog } from "@/components/layout/dialogs/desktop/about-details-dialog";
+
+afterEach(() => {
+  cleanup();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
+
+function unavailableSupport(): DesktopSupportBridge {
+  return {
+    getSnapshot: () =>
+      Promise.reject(new Error("secret-token-should-never-render")),
+    revealLog: vi.fn(),
+    submitReport: vi.fn(),
+    tailLog: vi.fn(),
+  };
+}
+
+describe("<AboutDetailsDialog />", () => {
+  it("gates the failed-snapshot report action on capability and never forwards the raw error", async () => {
+    render(
+      <AboutDetailsDialog
+        open
+        onOpenChange={() => {}}
+        support={unavailableSupport()}
+        openExternalLink={() => Promise.resolve()}
+      />,
+    );
+
+    await waitFor(() => {
+      screen.getByText("Could not load desktop details.");
+    });
+    expect(screen.queryByText(/secret-token-should-never-render/)).toBeNull();
+    // Capability-gated off by default.
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load desktop details",
+        message: null,
+        code: null,
+        source: "About Traycer",
+      },
+    });
+  });
+
+  it("gates the missing-support-bridge report action on capability", () => {
+    render(
+      <AboutDetailsDialog
+        open
+        onOpenChange={() => {}}
+        support={null}
+        openExternalLink={() => Promise.resolve()}
+      />,
+    );
+
+    screen.getByText("Desktop support bridge unavailable.");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState().reportIssueContext).toMatchObject({
+      title: "Couldn't load desktop details",
+      message: null,
+      code: null,
+      source: "About Traycer",
+    });
+  });
+});

--- a/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/about-details-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/about-details-dialog.test.tsx
@@ -17,6 +17,7 @@ afterEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 

--- a/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/logs-chooser-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/logs-chooser-dialog.test.tsx
@@ -22,6 +22,7 @@ afterEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 

--- a/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/logs-chooser-dialog.test.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/__tests__/logs-chooser-dialog.test.tsx
@@ -1,0 +1,132 @@
+import type { ReactNode } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type {
+  DesktopSupportBridge,
+  DesktopSupportSnapshot,
+} from "@/lib/windows/types";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { LogsChooserDialog } from "@/components/layout/dialogs/desktop/logs-chooser-dialog";
+
+afterEach(() => {
+  cleanup();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
+
+function readySnapshot(): DesktopSupportSnapshot {
+  return {
+    appName: "Traycer",
+    appVersion: "1.0.0",
+    platform: "darwin",
+    arch: "arm64",
+    user: { status: "signed-out", userName: null, email: null },
+    versions: { electron: "1", chrome: "1", node: "1" },
+    host: { status: "ready", version: "1", pid: 1, hostId: "host-1" },
+    logs: [{ target: "desktop", label: "Desktop", path: "/tmp/desktop.log" }],
+    links: [],
+    supportEmail: "support@traycer.ai",
+  };
+}
+
+function unavailableSupport(): DesktopSupportBridge {
+  return {
+    getSnapshot: () =>
+      Promise.reject(new Error("secret-token-should-never-render")),
+    revealLog: vi.fn(),
+    submitReport: vi.fn(),
+    tailLog: vi.fn(),
+  };
+}
+
+function supportWithFailingTail(): DesktopSupportBridge {
+  return {
+    getSnapshot: () => Promise.resolve(readySnapshot()),
+    revealLog: vi.fn(),
+    submitReport: vi.fn(),
+    tailLog: () =>
+      Promise.reject(new Error("secret-log-path-should-never-render")),
+  };
+}
+
+function renderDialog(support: DesktopSupportBridge | null): void {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={client}>{props.children}</QueryClientProvider>
+  );
+  render(
+    <Wrapper>
+      <LogsChooserDialog open onOpenChange={() => {}} support={support} />
+    </Wrapper>,
+  );
+}
+
+describe("<LogsChooserDialog />", () => {
+  it("gates the failed-snapshot report action on capability and never forwards the raw error", async () => {
+    renderDialog(unavailableSupport());
+
+    await waitFor(() => {
+      screen.getByText("Could not load desktop details.");
+    });
+    expect(screen.queryByText(/secret-token-should-never-render/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load desktop details",
+        message: null,
+        code: null,
+        source: "Logs",
+      },
+    });
+  });
+
+  it("gates the failed-log-tail report action on capability and never forwards the raw tail error", async () => {
+    renderDialog(supportWithFailingTail());
+
+    await waitFor(() => {
+      screen.getByText("Desktop");
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Desktop/ }));
+
+    await waitFor(() => {
+      screen.getByText("Could not load log output.");
+    });
+    expect(
+      screen.queryByText(/secret-log-path-should-never-render/),
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load log output",
+        message: null,
+        code: null,
+        source: "Logs",
+      },
+    });
+  });
+});

--- a/clients/gui-app/src/components/layout/dialogs/desktop/about-details-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/about-details-dialog.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { ExternalLink, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import {
   Dialog,
   DialogContent,
@@ -44,6 +46,36 @@ function AboutDetailsDialogContent(
     });
   };
 
+  let snapshotContent: ReactNode;
+  if (snapshot.status === "ready") {
+    snapshotContent = (
+      <>
+        <DetailsGrid snapshot={snapshot.snapshot} />
+        <SupportLinks snapshot={snapshot.snapshot} openLink={openLink} />
+      </>
+    );
+  } else if (snapshot.status === "unavailable") {
+    snapshotContent = (
+      <div className="flex items-center gap-2 text-ui-sm text-muted-foreground">
+        <span>{snapshot.message}</span>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Couldn't load desktop details",
+            message: null,
+            code: null,
+            source: "About Traycer",
+          })}
+          presentation="link"
+          className="h-auto p-0 text-current"
+        />
+      </div>
+    );
+  } else {
+    snapshotContent = (
+      <p className="text-ui-sm text-muted-foreground">{snapshot.message}</p>
+    );
+  }
+
   return (
     <DialogContent className="sm:max-w-xl">
       <DialogHeader>
@@ -55,20 +87,24 @@ function AboutDetailsDialogContent(
           Desktop runtime and diagnostics details.
         </DialogDescription>
       </DialogHeader>
-      <div className="grid gap-3">
-        {snapshot.status === "ready" ? (
-          <>
-            <DetailsGrid snapshot={snapshot.snapshot} />
-            <SupportLinks snapshot={snapshot.snapshot} openLink={openLink} />
-          </>
-        ) : (
-          <p className="text-ui-sm text-muted-foreground">{snapshot.message}</p>
-        )}
-      </div>
+      <div className="grid gap-3">{snapshotContent}</div>
       {linkError === null ? null : (
-        <p className="text-ui-sm text-destructive" role="alert">
-          {linkError}
-        </p>
+        <div
+          className="flex items-center gap-2 text-ui-sm text-destructive"
+          role="alert"
+        >
+          <span>{linkError}</span>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Couldn't open the link",
+              message: null,
+              code: null,
+              source: "About Traycer",
+            })}
+            presentation="link"
+            className="h-auto p-0 text-current"
+          />
+        </div>
       )}
       <DialogFooter showCloseButton />
     </DialogContent>

--- a/clients/gui-app/src/components/layout/dialogs/desktop/logs-chooser-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/logs-chooser-dialog.tsx
@@ -2,6 +2,8 @@ import { useEffect, useReducer, useState, type ReactNode } from "react";
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { ChevronDown, ChevronUp, FolderOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { CopyTextButton } from "@/components/copy-text-button";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import {
@@ -94,6 +96,44 @@ function LogsChooserDialogContent(
     );
   };
 
+  let snapshotContent: ReactNode;
+  if (snapshot.status === "ready") {
+    snapshotContent = (
+      <div className="grid gap-2">
+        {snapshot.snapshot.logs.map((entry) => (
+          <LogEntryPanel
+            key={entry.target}
+            entry={entry}
+            support={props.support}
+            revealDisabled={revealState.pendingTarget !== null}
+            revealPending={revealState.pendingTarget === entry.target}
+            onReveal={() => revealLog(entry.target)}
+          />
+        ))}
+      </div>
+    );
+  } else if (snapshot.status === "unavailable") {
+    snapshotContent = (
+      <div className="flex items-center gap-2 text-ui-sm text-muted-foreground">
+        <span>{snapshot.message}</span>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Couldn't load desktop details",
+            message: null,
+            code: null,
+            source: "Logs",
+          })}
+          presentation="link"
+          className="h-auto p-0 text-current"
+        />
+      </div>
+    );
+  } else {
+    snapshotContent = (
+      <p className="text-ui-sm text-muted-foreground">{snapshot.message}</p>
+    );
+  }
+
   return (
     <DialogContent className="sm:max-w-lg">
       <DialogHeader>
@@ -105,26 +145,24 @@ function LogsChooserDialogContent(
           Desktop and host diagnostics.
         </DialogDescription>
       </DialogHeader>
-      {snapshot.status === "ready" ? (
-        <div className="grid gap-2">
-          {snapshot.snapshot.logs.map((entry) => (
-            <LogEntryPanel
-              key={entry.target}
-              entry={entry}
-              support={props.support}
-              revealDisabled={revealState.pendingTarget !== null}
-              revealPending={revealState.pendingTarget === entry.target}
-              onReveal={() => revealLog(entry.target)}
-            />
-          ))}
-        </div>
-      ) : (
-        <p className="text-ui-sm text-muted-foreground">{snapshot.message}</p>
-      )}
+      {snapshotContent}
       {revealState.error === null ? null : (
-        <p className="text-ui-sm text-destructive" role="alert">
-          {revealState.error}
-        </p>
+        <div
+          className="flex items-center gap-2 text-ui-sm text-destructive"
+          role="alert"
+        >
+          <span>{revealState.error}</span>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Couldn't reveal the log file",
+              message: null,
+              code: null,
+              source: "Logs",
+            })}
+            presentation="link"
+            className="h-auto p-0 text-current"
+          />
+        </div>
       )}
       <DialogFooter showCloseButton />
     </DialogContent>
@@ -316,6 +354,24 @@ function LogTailView(props: { readonly state: LogTailState }): ReactNode {
         <pre className="max-h-72 w-full overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-left font-mono text-code-xs text-muted-foreground">
           {content}
         </pre>
+      </div>
+    );
+  }
+
+  if (props.state.status === "error") {
+    return (
+      <div className="flex items-center justify-center gap-2 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-center text-ui-xs text-muted-foreground">
+        <span>{props.state.message}</span>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Couldn't load log output",
+            message: null,
+            code: null,
+            source: "Logs",
+          })}
+          presentation="link"
+          className="h-auto p-0 text-current"
+        />
       </div>
     );
   }

--- a/clients/gui-app/src/components/layout/dialogs/desktop/open-epic-in-new-window-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/open-epic-in-new-window-dialog.tsx
@@ -2,6 +2,8 @@ import { useCallback, type ReactNode } from "react";
 import { ExternalLink, RefreshCw } from "lucide-react";
 import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import {
   Dialog,
   DialogContent,
@@ -143,15 +145,26 @@ function OpenEpicPickerBody(props: OpenEpicPickerBodyProps): ReactNode {
     return (
       <div className="grid gap-2 rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-ui-sm">
         <p className="font-medium text-destructive">Couldn't load Epics.</p>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={props.onRetry}
-          className="justify-self-start"
-        >
-          Retry
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={props.onRetry}
+          >
+            Retry
+          </Button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Couldn't load Epics",
+              message: null,
+              code: null,
+              source: "Open Epic in new window",
+            })}
+            presentation="text"
+            className={undefined}
+          />
+        </div>
       </div>
     );
   }

--- a/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
@@ -120,8 +120,9 @@ export function ReportIssueDialog(
           <div className="grid gap-4 py-1 pr-1">
             {snapshot !== null && <EnvBadge snapshot={snapshot} />}
 
-            <Field label="Title" required>
+            <Field htmlFor="report-issue-title" label="Title" required>
               <Input
+                id="report-issue-title"
                 placeholder="Short summary of the issue"
                 value={form.title}
                 onChange={update("title")}
@@ -129,8 +130,9 @@ export function ReportIssueDialog(
               />
             </Field>
 
-            <Field label="What happened?">
+            <Field htmlFor="report-issue-what-happened" label="What happened?">
               <Textarea
+                id="report-issue-what-happened"
                 placeholder="A clear description of the bug. Include any error messages you saw."
                 value={form.whatHappened}
                 onChange={update("whatHappened")}
@@ -139,8 +141,12 @@ export function ReportIssueDialog(
               />
             </Field>
 
-            <Field label="Steps to reproduce">
+            <Field
+              htmlFor="report-issue-steps-to-reproduce"
+              label="Steps to reproduce"
+            >
               <Textarea
+                id="report-issue-steps-to-reproduce"
                 placeholder={"1.\n2.\n3."}
                 value={form.stepsToReproduce}
                 onChange={update("stepsToReproduce")}
@@ -150,8 +156,12 @@ export function ReportIssueDialog(
             </Field>
 
             <div className="grid grid-cols-2 gap-4">
-              <Field label="Expected behavior">
+              <Field
+                htmlFor="report-issue-expected-behavior"
+                label="Expected behavior"
+              >
                 <Textarea
+                  id="report-issue-expected-behavior"
                   placeholder="What did you expect to happen?"
                   value={form.expectedBehavior}
                   onChange={update("expectedBehavior")}
@@ -159,8 +169,12 @@ export function ReportIssueDialog(
                   className="min-h-20 resize-none"
                 />
               </Field>
-              <Field label="Actual behavior">
+              <Field
+                htmlFor="report-issue-actual-behavior"
+                label="Actual behavior"
+              >
                 <Textarea
+                  id="report-issue-actual-behavior"
                   placeholder="What actually happened instead?"
                   value={form.actualBehavior}
                   onChange={update("actualBehavior")}
@@ -273,10 +287,12 @@ function supportHostIssueFields(snapshot: DesktopSupportSnapshot | null) {
 }
 
 function Field({
+  htmlFor,
   label,
   required,
   children,
 }: {
+  htmlFor: string;
   label: string;
   required?: boolean;
   children: ReactNode;
@@ -284,6 +300,7 @@ function Field({
   return (
     <div className="grid gap-1.5">
       <Label
+        htmlFor={htmlFor}
         className={cn(
           "text-ui-sm",
           required && "after:ml-0.5 after:text-destructive after:content-['*']",

--- a/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Bug } from "lucide-react";
 import { useMutation } from "@tanstack/react-query";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -18,8 +17,10 @@ import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { cn } from "@/lib/utils";
 import { buildGitHubIssueUrl } from "@traycer-clients/shared/support/issue-reporter";
 import { runnerMutationKeys } from "@/lib/query-keys";
+import type { ReportIssueContext } from "@/lib/report-issue-context";
 import type { DesktopSupportSnapshot } from "@/lib/windows/types";
 import { useRunnerHost } from "@/providers/use-runner-host";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import type { DesktopSupportDialogProps } from "./types";
 
 interface ReportIssueForm {
@@ -30,6 +31,12 @@ interface ReportIssueForm {
   actualBehavior: string;
 }
 
+interface ReportIssueSubmission {
+  readonly draftId: number;
+  readonly form: ReportIssueForm;
+  readonly snapshot: DesktopSupportSnapshot | null;
+}
+
 const EMPTY_FORM: ReportIssueForm = {
   title: "",
   whatHappened: "",
@@ -38,11 +45,20 @@ const EMPTY_FORM: ReportIssueForm = {
   actualBehavior: "",
 };
 
-export function ReportIssueDialog(props: DesktopSupportDialogProps): ReactNode {
-  const { onOpenChange, open, support } = props;
+export function ReportIssueDialog(
+  props: DesktopSupportDialogProps & { readonly draftId: number },
+): ReactNode {
+  const { draftId, onOpenChange, open, support } = props;
   const runnerHost = useRunnerHost();
-  const [form, setForm] = useState<ReportIssueForm>(EMPTY_FORM);
+  const context = useDesktopDialogStore((state) => state.reportIssueContext);
+  const closeReportIssueDraft = useDesktopDialogStore(
+    (state) => state.closeReportIssueDraft,
+  );
+  const [form, setForm] = useState<ReportIssueForm>(() =>
+    reportIssueFormFromContext(context),
+  );
   const [snapshot, setSnapshot] = useState<DesktopSupportSnapshot | null>(null);
+  const submitErrorRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open || support === null) return;
@@ -51,24 +67,26 @@ export function ReportIssueDialog(props: DesktopSupportDialogProps): ReactNode {
 
   const submitMutation = useMutation({
     mutationKey: runnerMutationKeys.supportSubmitReport(),
-    mutationFn: async () => {
+    mutationFn: async (submission: ReportIssueSubmission) => {
       if (support === null) throw new Error("Support bridge unavailable");
-      const result = await support.submitReport(form);
+      const result = await support.submitReport(submission.form);
       return result.reportId;
     },
-    onSuccess: (reportId) => {
-      const url = buildSupportIssueUrl(snapshot, form, reportId);
+    onSuccess: (reportId, submission) => {
+      const url = buildSupportIssueUrl(
+        submission.snapshot,
+        submission.form,
+        reportId,
+      );
       void runnerHost.openExternalLink(url);
-      // Close directly: handleOpenChange short-circuits while the mutation
-      // is still in its onSuccess callback (isPending hasn't flipped yet).
-      setForm(EMPTY_FORM);
-      setSnapshot(null);
-      onOpenChange(false);
-    },
-    onError: () => {
-      toast.error("Failed to submit report. Please try again.");
+      closeReportIssueDraft(submission.draftId);
     },
   });
+
+  useEffect(() => {
+    if (!submitMutation.isError) return;
+    submitErrorRef.current?.focus();
+  }, [submitMutation.isError]);
 
   const handleOpenChange = (open: boolean) => {
     if (!open && submitMutation.isPending) return;
@@ -156,6 +174,17 @@ export function ReportIssueDialog(props: DesktopSupportDialogProps): ReactNode {
           </div>
         </div>
 
+        {submitMutation.isError ? (
+          <div
+            ref={submitErrorRef}
+            role="alert"
+            tabIndex={-1}
+            className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-ui-sm text-destructive outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Failed to submit report. Please try again.
+          </div>
+        ) : null}
+
         <DialogFooter>
           <Button
             variant="outline"
@@ -165,7 +194,7 @@ export function ReportIssueDialog(props: DesktopSupportDialogProps): ReactNode {
             Cancel
           </Button>
           <Button
-            onClick={() => submitMutation.mutate()}
+            onClick={() => submitMutation.mutate({ draftId, form, snapshot })}
             disabled={
               submitMutation.isPending || form.title.trim().length === 0
             }
@@ -183,6 +212,22 @@ export function ReportIssueDialog(props: DesktopSupportDialogProps): ReactNode {
       </DialogContent>
     </Dialog>
   );
+}
+
+function reportIssueFormFromContext(
+  context: ReportIssueContext | null,
+): ReportIssueForm {
+  if (context === null) return EMPTY_FORM;
+  const contextLines = [
+    context.source === null ? null : `Area: ${context.source}`,
+    context.code === null ? null : `Error code: ${context.code}`,
+    context.message,
+  ].filter((line): line is string => line !== null);
+  return {
+    ...EMPTY_FORM,
+    title: context.title,
+    whatHappened: contextLines.join("\n\n"),
+  };
 }
 
 function buildSupportIssueUrl(

--- a/clients/gui-app/src/components/layout/dialogs/migration-blocking-modal-host.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/migration-blocking-modal-host.tsx
@@ -1,7 +1,9 @@
 import { type ReactNode } from "react";
 import { Dialog as DialogPrimitive } from "radix-ui";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import {
   epicsSeen,
   taskChainsSeen,
@@ -125,7 +127,17 @@ function ErrorBody(props: ErrorBodyProps): ReactNode {
         Migration interrupted
       </DialogPrimitive.Title>
       <p className="text-sm text-muted-foreground">{message}</p>
-      <div className="flex justify-end">
+      <div className="flex flex-wrap justify-end gap-2">
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Migration interrupted",
+            message: "The migration did not finish.",
+            code: null,
+            source: "Data migration",
+          })}
+          presentation="text"
+          className={undefined}
+        />
         <Button type="button" onClick={onAcknowledge}>
           Dismiss
         </Button>

--- a/clients/gui-app/src/components/layout/dialogs/report-issue-dialog-host.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/report-issue-dialog-host.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useMemo, type ReactNode } from "react";
+import { resolveDesktopSupportBridge } from "@/lib/windows/desktop-capabilities";
+import { useRunnerHost } from "@/providers/use-runner-host";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { ReportIssueDialog } from "./desktop/report-issue-dialog";
+
+export function ReportIssueDialogHost(): ReactNode {
+  const runnerHost = useRunnerHost();
+  const support = useMemo(
+    () => resolveDesktopSupportBridge(runnerHost),
+    [runnerHost],
+  );
+  const activeDialog = useDesktopDialogStore((state) => state.activeDialog);
+  const reportIssueDraftId = useDesktopDialogStore(
+    (state) => state.reportIssueDraftId,
+  );
+  const close = useDesktopDialogStore((state) => state.close);
+  const setReportIssueAvailable = useDesktopDialogStore(
+    (state) => state.setReportIssueAvailable,
+  );
+
+  useEffect(() => {
+    setReportIssueAvailable(support !== null);
+    if (support === null && activeDialog === "report-issue") {
+      close();
+    }
+    return () => {
+      setReportIssueAvailable(false);
+    };
+  }, [activeDialog, close, setReportIssueAvailable, support]);
+
+  if (activeDialog !== "report-issue" || support === null) return null;
+  return (
+    <ReportIssueDialog
+      key={reportIssueDraftId}
+      draftId={reportIssueDraftId}
+      open
+      onOpenChange={(open) => {
+        if (!open) close();
+      }}
+      support={support}
+    />
+  );
+}

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -9,6 +9,7 @@ import {
   type Mock,
 } from "vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -30,6 +31,7 @@ import type {
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Popover, PopoverTrigger } from "@/components/ui/popover";
 import { useAccountContextStore } from "@/stores/auth/account-context-store";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import type {
   AvailableProviderRateLimits,
   ProviderRateLimitEnvelope,
@@ -512,6 +514,11 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
 });
 
 describe("<RateLimitPopover /> zero-provider state", () => {
@@ -1140,6 +1147,68 @@ describe("<RateLimitPopover /> per-provider states", () => {
     expect(
       screen.getByText("Usage limits unavailable - the CLI isn't installed"),
     ).toBeTruthy();
+  });
+
+  it("gates the hard-failure report action on capability and reports only fixed generic context", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess", profiles: undefined },
+    ];
+    mocks.results = {
+      codex: {
+        data: undefined,
+        isPending: false,
+        isFetching: false,
+        isError: true,
+        dataUpdatedAt: 0,
+        refetch: vi.fn(() => Promise.resolve({})),
+      },
+    };
+    renderPopover();
+
+    // Capability-gated off by default.
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load usage limits",
+        message: null,
+        code: null,
+        source: "Usage limits",
+      },
+    });
+  });
+
+  it("gates the unavailable-reason report action on capability without leaking the reason into the report context beyond its fixed label", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess", profiles: undefined },
+    ];
+    mocks.results = {
+      codex: readyResult({
+        provider: "codex",
+        available: false,
+        reason: "cli_not_found",
+      }),
+    };
+    renderPopover();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Usage limits unavailable",
+        message: null,
+        code: null,
+        source: "Usage limits",
+      },
+    });
   });
 });
 

--- a/clients/gui-app/src/components/layout/header/host-picker.tsx
+++ b/clients/gui-app/src/components/layout/header/host-picker.tsx
@@ -15,6 +15,8 @@ import {
   useHostPickerList,
 } from "@/hooks/host/use-host-picker-list";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { useRunnerHost } from "@/providers/use-runner-host";
 
 /**
@@ -146,12 +148,22 @@ function HostPickerList(props: HostPickerListProps) {
 
   if (query.isError) {
     return (
-      <p
-        className="text-ui-sm text-destructive"
+      <div
+        className="flex items-center gap-2 text-ui-sm text-destructive"
         data-testid="host-picker-error"
       >
-        Failed to load hosts.
-      </p>
+        <span>Failed to load hosts.</span>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Failed to load hosts",
+            message: null,
+            code: null,
+            source: "Host picker",
+          })}
+          presentation="icon"
+          className="text-current"
+        />
+      </div>
     );
   }
 

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -17,6 +17,11 @@ import { PopoverContent } from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import {
+  createReportIssueContext,
+  type ReportIssueContext,
+} from "@/lib/report-issue-context";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { AccentDot } from "@/components/providers/accent-dot";
 import { profileDisplayLabel } from "@/components/providers/provider-profile-model";
@@ -988,7 +993,10 @@ function ProfileRateLimitProviderBlock({
           refresh={refresh}
           isRefreshing={isRefreshing}
         />
-        <RateLimitErrorMessage message="No logged-in profiles." />
+        <RateLimitErrorMessage
+          message="No logged-in profiles."
+          reportContext={null}
+        />
       </div>
     );
   }
@@ -1253,12 +1261,26 @@ function RateLimitProviderBody({
       return <RateLimitDetailSkeleton />;
     case "error":
       return (
-        <RateLimitErrorMessage message="Couldn't load usage limits right now." />
+        <RateLimitErrorMessage
+          message="Couldn't load usage limits right now."
+          reportContext={createReportIssueContext({
+            title: "Couldn't load usage limits",
+            message: null,
+            code: null,
+            source: "Usage limits",
+          })}
+        />
       );
     case "unavailable":
       return (
         <RateLimitErrorMessage
           message={`Usage limits unavailable - ${formatUnavailableReason(state.reason)}`}
+          reportContext={createReportIssueContext({
+            title: "Usage limits unavailable",
+            message: null,
+            code: null,
+            source: "Usage limits",
+          })}
         />
       );
     case "ready":
@@ -1477,7 +1499,15 @@ function TraycerRateLimitBody({
       return <RateLimitDetailSkeleton />;
     case "error":
       return (
-        <RateLimitErrorMessage message="Couldn't load your Traycer subscription right now." />
+        <RateLimitErrorMessage
+          message="Couldn't load your Traycer subscription right now."
+          reportContext={createReportIssueContext({
+            title: "Couldn't load your Traycer subscription",
+            message: null,
+            code: null,
+            source: "Subscription",
+          })}
+        />
       );
     case "empty":
       return (
@@ -1503,10 +1533,24 @@ function TraycerRateLimitBody({
 // for the same action.
 function RateLimitErrorMessage({
   message,
+  reportContext,
 }: {
   readonly message: string;
+  readonly reportContext: ReportIssueContext | null;
 }): ReactNode {
-  return <p className="text-ui-xs text-muted-foreground">{message}</p>;
+  if (reportContext === null) {
+    return <p className="text-ui-xs text-muted-foreground">{message}</p>;
+  }
+  return (
+    <div className="flex items-center gap-2 text-ui-xs text-muted-foreground">
+      <span>{message}</span>
+      <ReportIssueAction
+        context={reportContext}
+        presentation="link"
+        className="h-auto p-0 text-current"
+      />
+    </div>
+  );
 }
 
 /**

--- a/clients/gui-app/src/components/layout/header/sign-in/copyable-approval-field.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/copyable-approval-field.tsx
@@ -1,11 +1,16 @@
 import { Check, Copy } from "lucide-react";
-import { toast } from "sonner";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 import { cn } from "@/lib/utils";
 import { COPY_CONFIRMATION_RESET_MS } from "./styles";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const handleCopyError = (): void => {
-  toast.error("Couldn't copy to clipboard.");
+  reportableErrorToast("Couldn't copy to clipboard.", undefined, {
+    title: "Could not copy to clipboard",
+    message: null,
+    code: null,
+    source: "Sign in",
+  });
 };
 
 export function CopyableApprovalField(props: {

--- a/clients/gui-app/src/components/layout/header/sign-in/sign-in-error-message.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/sign-in-error-message.tsx
@@ -6,6 +6,8 @@ import {
   AUTH_ERROR_SIGN_IN_FAILED,
 } from "@/lib/auth/auth-service";
 import { cn } from "@/lib/utils";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { type AuthStatus } from "@/stores/auth/auth-store";
 
 export function SignInErrorMessage(props: {
@@ -21,16 +23,17 @@ export function SignInErrorMessage(props: {
     return null;
   }
 
+  const message = messageForError(props.lastError);
   return (
-    <span
+    <div
       className={cn(
-        "text-destructive",
+        "flex flex-wrap items-center gap-x-1 text-destructive",
         props.isHero ? "text-ui-sm leading-6" : "text-ui-xs",
       )}
       data-testid="signin-error"
       role="alert"
     >
-      {messageForError(props.lastError)}
+      <span>{message}</span>
       <span
         className="sr-only"
         data-testid="signin-error-detail"
@@ -38,7 +41,17 @@ export function SignInErrorMessage(props: {
       >
         {props.lastError}
       </span>
-    </span>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Sign in failed",
+          message: null,
+          code: null,
+          source: "Sign in",
+        })}
+        presentation="link"
+        className="h-auto p-0 text-current"
+      />
+    </div>
   );
 }
 

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -45,7 +45,6 @@ import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import { getHostBindingSnapshot } from "@/lib/host/runtime";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { toastFromHostError } from "@/lib/host-error-toast";
-import { toast } from "sonner";
 import { useInlineRename } from "@/hooks/ui/use-inline-rename";
 import { updateEpicTitleInCloudTaskCaches } from "@/lib/cloud-epic-tasks-query/cache";
 import { useTabLeaderModifierForIndex } from "@/providers/keybinding-context";
@@ -65,6 +64,7 @@ import {
   useEpicActivityStatus,
   type EpicActivityStatus,
 } from "@/hooks/epic/use-epic-activity-status";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 const TAB_CLASS_BASE =
   "group/tab relative flex h-10 w-full min-w-0 items-center gap-1.5 px-[clamp(0.75rem,10%,1.5rem)] text-ui-sm transition-[color,transform] duration-300 ease-spring";
@@ -177,7 +177,16 @@ export const TabItem = memo(function TabItem(props: TabItemProps) {
       const binding = getHostBindingSnapshot();
       if (binding === null) {
         rollback();
-        toast.error("Couldn't reach the host to rename the epic.");
+        reportableErrorToast(
+          "Couldn't reach the host to rename the epic.",
+          undefined,
+          {
+            title: "Could not rename Epic",
+            message: "The host was unavailable.",
+            code: null,
+            source: "Epic tabs",
+          },
+        );
         return;
       }
       const hostId = binding.hostClient.getActiveHostId();
@@ -201,7 +210,12 @@ export const TabItem = memo(function TabItem(props: TabItemProps) {
             if (error instanceof HostRpcError) {
               toastFromHostError(error, "Couldn't rename epic.");
             } else {
-              toast.error("Couldn't rename epic.");
+              reportableErrorToast("Couldn't rename epic.", undefined, {
+                title: "Could not rename Epic",
+                message: null,
+                code: null,
+                source: "Epic tabs",
+              });
             }
           },
         );

--- a/clients/gui-app/src/components/local-host-gate.tsx
+++ b/clients/gui-app/src/components/local-host-gate.tsx
@@ -18,6 +18,7 @@ import type {
   LocalHostSnapshot,
 } from "@traycer-clients/shared/platform/runner-host";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { Card, CardContent } from "@/components/ui/card";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { AppHeader } from "@/components/layout/header/app-header";
@@ -34,6 +35,7 @@ import {
 import { requestAppQuit } from "@/lib/desktop-app-lifecycle";
 import { runnerQueryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 /**
  * URL prefix that bypasses the host-readiness gate. Settings work without
@@ -635,6 +637,16 @@ function GateIncompatibleHost(props: GateIncompatibleBusyProps) {
                   {isBusyKeep ? "Force update host" : "Update host"}
                 </Button>
               ) : null}
+              <ReportIssueAction
+                context={createReportIssueContext({
+                  title: "Host update required",
+                  message: "Traycer Host requires an update.",
+                  code: null,
+                  source: "Host startup",
+                })}
+                presentation="text"
+                className="w-full"
+              />
             </div>
           </CardContent>
         </Card>
@@ -658,7 +670,7 @@ function GateProvisioningError(props: GateProvisioningErrorProps) {
       <Card className="w-full max-w-md">
         <CardContent className="flex flex-col gap-4 py-6 text-ui-sm">
           <p className="text-center">{props.message}</p>
-          <div className="flex justify-center">
+          <div className="flex flex-wrap justify-center gap-2">
             <Button
               type="button"
               size="sm"
@@ -678,6 +690,16 @@ function GateProvisioningError(props: GateProvisioningErrorProps) {
                 ) : null}
               </span>
             </Button>
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Could not start Traycer Host",
+                message: "Traycer Host could not start.",
+                code: null,
+                source: "Host startup",
+              })}
+              presentation="text"
+              className={undefined}
+            />
           </div>
         </CardContent>
       </Card>
@@ -908,7 +930,7 @@ export function LocalHostUnavailable(props: LocalHostUnavailableProps) {
               bootstrapLogPath={status.data?.bootstrapLogPath ?? null}
             />
           ) : null}
-          <div className="flex justify-center">
+          <div className="flex flex-wrap justify-center gap-2">
             <Button
               type="button"
               size="sm"
@@ -930,6 +952,16 @@ export function LocalHostUnavailable(props: LocalHostUnavailableProps) {
                 ) : null}
               </span>
             </Button>
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Traycer Host is unavailable",
+                message: "Traycer Host was unavailable.",
+                code: null,
+                source: "Host startup",
+              })}
+              presentation="text"
+              className={undefined}
+            />
           </div>
         </CardContent>
       </Card>

--- a/clients/gui-app/src/components/migration/__tests__/migration-run-controller.test.tsx
+++ b/clients/gui-app/src/components/migration/__tests__/migration-run-controller.test.tsx
@@ -95,6 +95,7 @@ beforeEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 
@@ -106,6 +107,7 @@ afterEach(() => {
     activeDialog: null,
     reportIssueAvailable: false,
     reportIssueContext: null,
+    reportIssueDraftId: 0,
   });
 });
 

--- a/clients/gui-app/src/components/migration/__tests__/migration-run-controller.test.tsx
+++ b/clients/gui-app/src/components/migration/__tests__/migration-run-controller.test.tsx
@@ -1,0 +1,200 @@
+import "../../../../__tests__/test-browser-apis";
+import { act, cleanup, render } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { ExternalToast } from "sonner";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import type {
+  MigrationStreamCallbacks,
+  MigrationStreamClientOptions,
+} from "@traycer-clients/shared/host-transport/migration-stream-client";
+
+interface MigrationClientHarness {
+  callbacks: MigrationStreamCallbacks | null;
+  readonly close: Mock<() => void>;
+}
+
+const migrationClient = vi.hoisted((): MigrationClientHarness => ({
+  callbacks: null,
+  close: vi.fn(),
+}));
+const invalidateQueries = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const toastSuccess = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "success-toast",
+  ),
+);
+const toastWarning = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "warning-toast",
+  ),
+);
+
+vi.mock(
+  "@traycer-clients/shared/host-transport/migration-stream-client",
+  () => ({
+    MigrationStreamClient: class {
+      constructor(options: MigrationStreamClientOptions) {
+        migrationClient.callbacks = options.callbacks;
+      }
+
+      close(): void {
+        migrationClient.close();
+      }
+    },
+  }),
+);
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: toastSuccess,
+    warning: toastWarning,
+  },
+}));
+
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => ({ getActiveHostId: () => "host-test" }),
+}));
+
+vi.mock("@/lib/host/stream-runtime-context", () => ({
+  useWsStreamClient: () => ({ stream: "test" }),
+}));
+
+vi.mock("@/providers/use-runner-host", () => ({
+  useRunnerHost: () => ({ migration: null }),
+}));
+
+import {
+  getMigrationStartHandle,
+  setMigrationStartHandle,
+} from "@/components/migration/migration-run-handle";
+import { MigrationRunController } from "@/components/migration/migration-run-controller";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { useMigrationRunStore } from "@/stores/migration/migration-run-store";
+
+beforeEach(() => {
+  migrationClient.callbacks = null;
+  migrationClient.close.mockClear();
+  invalidateQueries.mockClear();
+  toastSuccess.mockClear();
+  toastWarning.mockClear();
+  setMigrationStartHandle(null);
+  useMigrationRunStore.getState().reset();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  setMigrationStartHandle(null);
+  useMigrationRunStore.getState().reset();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
+
+describe("<MigrationRunController />", () => {
+  it("keeps incomplete migration results as privacy-safe reportable warnings", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    render(<MigrationRunController />);
+
+    completeMigration(false);
+
+    expect(toastWarning.mock.lastCall?.[0]).toBe(
+      "Migration re-attempt incomplete. Some local data still needs migration.",
+    );
+    expect(readWarningOptions().cancel).toMatchObject({
+      label: "Report issue",
+    });
+    clickWarningReportAction();
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Migration incomplete",
+      message: null,
+      code: null,
+      source: "Data migration",
+    });
+    expect(
+      JSON.stringify(useDesktopDialogStore.getState().reportIssueContext),
+    ).not.toMatch(/taskChains|epicsFailed|replaysIncomplete|host-test/);
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("omits the report action when reporting is unavailable", () => {
+    render(<MigrationRunController />);
+
+    completeMigration(false);
+
+    expect(toastWarning).toHaveBeenCalledWith(
+      "Migration re-attempt incomplete. Some local data still needs migration.",
+    );
+  });
+
+  it("leaves successful migration notifications unchanged", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    render(<MigrationRunController />);
+
+    completeMigration(true);
+
+    expect(toastSuccess).toHaveBeenCalledWith("Migration re-attempt complete.");
+    expect(toastWarning).not.toHaveBeenCalled();
+  });
+});
+
+function completeMigration(success: boolean): void {
+  const startHandle = getMigrationStartHandle();
+  if (startHandle === null) {
+    throw new Error("Expected a migration start handle.");
+  }
+  act(() => {
+    startHandle.start();
+  });
+  const callbacks = migrationClient.callbacks;
+  if (callbacks === null) {
+    throw new Error("Expected migration callbacks.");
+  }
+  act(() => {
+    callbacks.onComplete({
+      success,
+      counts: {
+        taskChainsComplete: 1,
+        taskChainsSkipped: 2,
+        taskChainsFailed: 3,
+        epicsComplete: 4,
+        epicsFailed: 5,
+        replaysIncomplete: 6,
+      },
+    });
+  });
+}
+
+function clickWarningReportAction(): void {
+  const cancel = readWarningOptions().cancel;
+  if (typeof cancel !== "object" || cancel === null || !("onClick" in cancel)) {
+    throw new Error("Expected a warning report action.");
+  }
+  cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+}
+
+function readWarningOptions(): ExternalToast {
+  const options = toastWarning.mock.lastCall?.[1];
+  if (options === undefined) {
+    throw new Error("Expected warning toast options.");
+  }
+  return options;
+}

--- a/clients/gui-app/src/components/migration/migration-run-controller.tsx
+++ b/clients/gui-app/src/components/migration/migration-run-controller.tsx
@@ -13,6 +13,7 @@ import {
 import { useHostClient } from "@/lib/host";
 import { useWsStreamClient } from "@/lib/host/stream-runtime-context";
 import { hostQueryKeys } from "@/lib/query-keys";
+import { reportableWarningToast } from "@/lib/reportable-error-toast";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useMigrationRunStore } from "@/stores/migration/migration-run-store";
 import {
@@ -82,8 +83,15 @@ export function MigrationRunController(): null {
           if (payload.success) {
             toast.success("Migration re-attempt complete.");
           } else {
-            toast.warning(
+            reportableWarningToast(
               "Migration re-attempt incomplete. Some local data still needs migration.",
+              undefined,
+              {
+                title: "Migration incomplete",
+                message: null,
+                code: null,
+                source: "Data migration",
+              },
             );
           }
           closeClient();

--- a/clients/gui-app/src/components/report-issue/report-issue-action.tsx
+++ b/clients/gui-app/src/components/report-issue/report-issue-action.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react";
+import { Bug } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ReportIssueContext } from "@/lib/report-issue-context";
+import { cn } from "@/lib/utils";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+interface ReportIssueActionProps {
+  readonly context: ReportIssueContext;
+  readonly presentation: "text" | "icon" | "link";
+  readonly className: string | undefined;
+}
+
+export function ReportIssueAction(props: ReportIssueActionProps): ReactNode {
+  const reportIssueAvailable = useDesktopDialogStore(
+    (state) => state.reportIssueAvailable,
+  );
+  const openReportIssueWithContext = useDesktopDialogStore(
+    (state) => state.openReportIssueWithContext,
+  );
+  if (!reportIssueAvailable) return null;
+
+  const handleClick = () => {
+    openReportIssueWithContext(props.context);
+  };
+
+  if (props.presentation === "text") {
+    return (
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className={cn("text-muted-foreground", props.className)}
+        onClick={handleClick}
+      >
+        <Bug aria-hidden />
+        Report issue
+      </Button>
+    );
+  }
+
+  if (props.presentation === "link") {
+    return (
+      <Button
+        type="button"
+        size="xs"
+        variant="link"
+        className={props.className}
+        onClick={handleClick}
+      >
+        Report issue
+      </Button>
+    );
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          className={cn("text-muted-foreground", props.className)}
+          aria-label="Report issue"
+          onClick={handleClick}
+        >
+          <Bug aria-hidden />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>Report issue</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-settings-available-versions-list.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-settings-available-versions-list.test.tsx
@@ -1,0 +1,69 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { AvailableVersionsList } from "../host-settings-available-versions-list";
+
+function renderErrorState(errorMessage: string): void {
+  render(
+    <AvailableVersionsList
+      availableSnapshot={undefined}
+      visibleVersions={[]}
+      installedVersion={null}
+      isPending={false}
+      errorMessage={errorMessage}
+      fetching={false}
+      anyPending={false}
+      showAllVersions={false}
+      onToggleShowAll={() => undefined}
+      onInstallVersion={() => undefined}
+      onRetry={() => undefined}
+    />,
+  );
+}
+
+describe("<AvailableVersionsList /> registry failure report action", () => {
+  afterEach(() => {
+    cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
+  });
+
+  it("hides the report action when the support capability is unavailable", () => {
+    renderErrorState("secret-token-should-never-render");
+
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+
+  it("reports only fixed generic context, never the raw registry error", () => {
+    renderErrorState("secret-token-should-never-render /Users/hostile/path");
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load host versions",
+        message: "The host version registry could not be loaded.",
+        code: null,
+        source: "Host versions",
+      },
+    });
+    const context = useDesktopDialogStore.getState().reportIssueContext;
+    expect(JSON.stringify(context)).not.toContain("secret-token");
+    expect(JSON.stringify(context)).not.toContain("/Users/hostile/path");
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-profile-scoped-section-report-issue.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-profile-scoped-section-report-issue.test.tsx
@@ -1,0 +1,184 @@
+import "../../../../../__tests__/test-browser-apis";
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+// `ProviderProfileScopedSection` always mounts `ProfileEditDialog`, whose
+// mutation hooks call `useHostClient()` unconditionally regardless of the
+// dialog's `open` state. Mock the mutation/host hooks it and its refresh
+// button pull in so this test only needs a QueryClient, not a bound host.
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return { ...actual, useHostClient: () => null };
+});
+vi.mock("@/hooks/providers/use-remove-provider-profile-mutation", () => ({
+  useRemoveProviderProfile: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+vi.mock("@/hooks/providers/use-rename-provider-profile-mutation", () => ({
+  useRenameProviderProfile: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+vi.mock("@/hooks/providers/use-recolor-provider-profile-mutation", () => ({
+  useRecolorProviderProfile: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+vi.mock("@/hooks/providers/use-refresh-providers", () => ({
+  useRefreshProviders: () => () => Promise.resolve(),
+}));
+
+import { ProviderProfileScopedSection } from "@/components/settings/panels/provider-profile-scoped-section";
+
+function ambientProfile(): ProviderCliState["profiles"][number] {
+  return {
+    profileId: "ambient",
+    kind: "ambient",
+    authType: "oauth",
+    label: "Terminal account",
+    auth: {
+      status: "authenticated",
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    identity: null,
+    usageUpdatedAt: null,
+    rateLimitStatus: "unknown",
+    duplicateOfProfileId: null,
+    accentColor: null,
+    ambientDriftNotice: null,
+  };
+}
+
+// `opencode` is not in the rate-limit-capable provider set, so the embedded
+// usage card and refresh button take their no-query branch - no additional
+// host-query mocking needed for this section-level test.
+function opencodeState(): ProviderCliState {
+  return {
+    providerId: "opencode",
+    enabled: true,
+    disabledBy: null,
+    selected: { kind: "bundled" },
+    candidates: [],
+    auth: {
+      status: "authenticated",
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    authPending: false,
+    checkedAt: null,
+    apiKey: { supported: false, configured: false, source: null },
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
+    availabilityPending: false,
+    profiles: [ambientProfile()],
+  };
+}
+
+function renderSection(
+  overrides: Partial<Parameters<typeof ProviderProfileScopedSection>[0]>,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ProviderProfileScopedSection
+          state={opencodeState()}
+          hostId="host-1"
+          isSelectedHostLocal
+          canAddProfile
+          failedAttempt={null}
+          onAddProfile={() => undefined}
+          onDismissFailedAttempt={() => undefined}
+          selectedProfileId={null}
+          onSelectedProfileIdChange={() => undefined}
+          {...overrides}
+        />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("<ProviderProfileScopedSection /> sign-in failure report action", () => {
+  afterEach(() => {
+    cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
+  });
+
+  it("hides the report action when the support capability is unavailable", () => {
+    renderSection({
+      failedAttempt: {
+        providerId: "opencode",
+        message: "secret-token-should-never-render",
+      },
+    });
+
+    screen.getByText(/Sign-in did not finish for/);
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+
+  it("reports only fixed generic context, never the provider identity or raw failure message", () => {
+    renderSection({
+      failedAttempt: {
+        providerId: "opencode",
+        message: "secret-token-should-never-render",
+      },
+    });
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Provider sign-in failed",
+        message: "Sign-in did not finish for a provider profile.",
+        code: null,
+        source: "Provider sign-in",
+      },
+    });
+    const context = useDesktopDialogStore.getState().reportIssueContext;
+    expect(JSON.stringify(context)).not.toContain("secret-token");
+    expect(JSON.stringify(context)).not.toContain("opencode");
+  });
+
+  it("renders no failure banner (and no report action) when there is no failed attempt", () => {
+    renderSection({ failedAttempt: null });
+
+    expect(screen.queryByText(/Sign-in did not finish for/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -92,6 +92,7 @@ const providerMocks = vi.hoisted(() => ({
     isPending: false,
     isError: false,
     isFetching: false,
+    error: undefined as { message: string; code: string } | undefined,
   },
   setSelectionMutate: vi.fn(),
   addCustomPathMutate: vi.fn(),
@@ -417,6 +418,7 @@ import { ProvidersSettingsPanel } from "@/components/settings/panels/providers-s
 import { ProviderProfileScopedSection } from "@/components/settings/panels/provider-profile-scoped-section";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { redactEmail } from "@/lib/providers/redact-email";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
 const OPENCODE_CANDIDATES: readonly ProviderCliCandidate[] = [
   {
@@ -593,6 +595,8 @@ describe("<ProvidersSettingsPanel />", () => {
         }),
       ],
     };
+    providerMocks.listResult.isError = false;
+    providerMocks.listResult.error = undefined;
     providerMocks.setSelectionMutate.mockClear();
     providerMocks.setEnabledMutate.mockClear();
     providerMocks.setEnvOverrideMutate.mockClear();
@@ -609,6 +613,43 @@ describe("<ProvidersSettingsPanel />", () => {
 
   afterEach(() => {
     cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
+  });
+
+  it("gates the provider-list-error report action on capability and never forwards the raw host error", () => {
+    providerMocks.listResult.isError = true;
+    providerMocks.listResult.error = {
+      message: "secret-token-should-never-render",
+      code: "RPC_ERROR",
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    expect(screen.queryByText(/secret-token-should-never-render/)).toBeNull();
+    // Capability-gated off by default.
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load provider state",
+        message: null,
+        code: "RPC_ERROR",
+        source: "Providers",
+      },
+    });
   });
 
   it("lists OpenCode CLI candidates for Traycer and mutates Traycer selection", () => {
@@ -1541,6 +1582,65 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(typeof awaitOptions.onSuccess).toBe("function");
   });
 
+  it("gates the add-profile failure report action on capability and reports only fixed generic context", () => {
+    providerMocks.listResult.data = {
+      providers: [
+        {
+          ...providerState({
+            providerId: "codex",
+            selected: { kind: "bundled" },
+            candidates: [],
+            envOverrides: [],
+            profiles: [
+              profile({
+                profileId: "ambient",
+                kind: "ambient",
+                label: "Terminal account",
+                email: "ambient@example.test",
+                tier: null,
+                authStatus: "authenticated",
+                duplicateOfProfileId: null,
+                ambientDriftNotice: null,
+              }),
+            ],
+          }),
+          loginCapability: { oauthArgs: ["auth", "login"], token: null },
+        },
+      ],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Link account" }));
+
+    const [, startOptions] = firstStartLoginCall();
+    act(() => startOptions.onError());
+
+    screen.getByText(
+      "Sign-in did not start. You can retry when the provider is available.",
+    );
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Provider sign-in failed",
+        message: null,
+        code: null,
+        source: "Add profile",
+      },
+    });
+  });
+
   it("keeps a cancelled profile creation mounted until its minted id is cleaned up", () => {
     providerMocks.listResult.data = {
       providers: [
@@ -1727,6 +1827,76 @@ describe("<ProvidersSettingsPanel />", () => {
 
     expect(providerMocks.cancelLoginMutate).toHaveBeenCalledTimes(1);
     expect(providerMocks.awaitLoginMutate).not.toHaveBeenCalled();
+  });
+
+  it("gates the reauth-failure report action on capability and reports only fixed generic context", async () => {
+    providerMocks.listResult.data = {
+      providers: [
+        {
+          ...providerState({
+            providerId: "codex",
+            selected: { kind: "bundled" },
+            candidates: [],
+            envOverrides: [],
+            profiles: [
+              profile({
+                profileId: "ambient",
+                kind: "ambient",
+                label: "Terminal account",
+                email: "ambient@example.test",
+                tier: null,
+                authStatus: "authenticated",
+                duplicateOfProfileId: null,
+                ambientDriftNotice: null,
+              }),
+              profile({
+                profileId: "managed-1",
+                kind: "managed",
+                label: "Work",
+                email: "work@example.test",
+                tier: "Pro",
+                authStatus: "authenticated",
+                duplicateOfProfileId: null,
+                ambientDriftNotice: null,
+              }),
+            ],
+          }),
+          loginCapability: { oauthArgs: ["auth", "login"], token: null },
+        },
+      ],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Work" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
+    await waitFor(() => {
+      expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
+    });
+    const [, startOptions] = firstStartLoginCall();
+    act(() => startOptions.onError());
+
+    screen.getByText("Sign-in did not start. Try again when ready.");
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Provider reauthentication failed",
+        message: null,
+        code: null,
+        source: "Provider reauth",
+      },
+    });
   });
 
   it("cancels the known re-auth profile while a retry start is pending", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
@@ -4,12 +4,20 @@ import type {
   TraycerTeamSubscription,
   TraycerUserSubscription,
 } from "@traycer/protocol/auth";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAccountContextStore } from "@/stores/auth/account-context-store";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
 const mocks = vi.hoisted(() => ({
   data: null as AuthenticatedUser | null,
+  isError: false,
   refetch: vi.fn(() => Promise.resolve({})),
   openExternalLink: vi.fn(),
 }));
@@ -18,8 +26,11 @@ vi.mock("@/hooks/auth/use-auth-user-query", () => ({
   useAuthUser: () => ({
     data: mocks.data,
     isPending: false,
-    isError: false,
+    isError: mocks.isError,
     isFetching: false,
+    error: mocks.isError
+      ? { message: "secret-token-should-never-render" }
+      : null,
     refetch: mocks.refetch,
   }),
 }));
@@ -134,11 +145,17 @@ const user: AuthenticatedUser = {
 describe("TraycerSubscriptionSection", () => {
   beforeEach(() => {
     mocks.data = user;
+    mocks.isError = false;
     useAccountContextStore.setState({ accountContext: { type: "PERSONAL" } });
   });
 
   afterEach(() => {
     cleanup();
+    useDesktopDialogStore.setState({
+      activeDialog: null,
+      reportIssueAvailable: false,
+      reportIssueContext: null,
+    });
   });
 
   it("renders the personal subscription by default", () => {
@@ -180,5 +197,29 @@ describe("TraycerSubscriptionSection", () => {
     expect(
       screen.getByText("Live artifact usage is unavailable."),
     ).toBeDefined();
+  });
+
+  it("gates the subscription-error report action on capability and never forwards the raw query error", () => {
+    mocks.isError = true;
+
+    render(<TraycerSubscriptionSection />);
+
+    expect(screen.queryByText(/secret-token-should-never-render/)).toBeNull();
+    // Capability-gated off by default.
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Couldn't load your subscription",
+        message: null,
+        code: null,
+        source: "Subscription",
+      },
+    });
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/traycer-subscription-section.test.tsx
@@ -155,6 +155,7 @@ describe("TraycerSubscriptionSection", () => {
       activeDialog: null,
       reportIssueAvailable: false,
       reportIssueContext: null,
+      reportIssueDraftId: 0,
     });
   });
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel-states.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel-states.test.tsx
@@ -1,5 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -14,6 +21,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/index";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
 // `WorktreesSettingsPanel` sits above `WorktreesList` (covered exhaustively by
 // `worktrees-settings-panel.test.tsx`) and owns the host-scoped states from
@@ -152,6 +160,11 @@ afterEach(() => {
     restoreOffsetHeight();
   }
   restoreOffsetHeight = null;
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
 });
 
 describe("WorktreesSettingsPanel host-scoped states", () => {
@@ -230,6 +243,75 @@ describe("WorktreesSettingsPanel host-scoped states", () => {
     });
     const refresh = screen.getByRole("button", { name: "Refresh worktrees" });
     expect(refresh.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("gates the partial-listing report action on capability and reports only fixed generic context", async () => {
+    state.hosts = [host({ hostId: "host-a" })];
+    state.activeHostId = "host-a";
+    const cleanWorktree = {
+      repoLabel: "acme/app",
+      repoIdentifier: { owner: "acme", repo: "app" },
+      worktreePath: "/wt/clean",
+      branch: "feat-clean",
+      inUse: false,
+      uncommittedCount: 0,
+      gitRemovable: true,
+      scripts: null,
+      owners: [],
+      lastActivityAt: null,
+      branchStatus: null,
+      createdAt: null,
+      prState: null,
+      prNumber: null,
+      prUrl: null,
+      mergedHeadShaMatches: false,
+      submodules: [],
+      atBaseCommit: false,
+    } satisfies WorktreeHostEntryV12;
+    let call = 0;
+    state.client = clientWithHandler(() => {
+      call += 1;
+      if (call === 1) {
+        return { worktrees: [cleanWorktree], nextCursor: "cursor-2" };
+      }
+      throw new HostRpcError({
+        code: "RPC_ERROR",
+        message: "secret-token-should-never-render",
+        requestId: "req-partial",
+        method: "worktree.listAllForHost",
+        fatalDetails: null,
+      });
+    });
+    state.enrichment = {
+      enrichedByPath: new Map([["/wt/clean", cleanWorktree]]),
+      erroredPaths: new Set(),
+      reportVisiblePaths: vi.fn(),
+      enriching: false,
+    };
+
+    renderPanel();
+
+    await waitFor(() => {
+      screen.getByRole("status");
+    });
+    // Capability-gated off by default.
+    expect(screen.queryByRole("button", { name: "Report issue" })).toBeNull();
+
+    act(() => {
+      useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Report issue" }));
+    // The report draft carries only fixed generic context - never the raw
+    // host error message threaded through the banner's own visible copy.
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: {
+        title: "Some worktrees could not be loaded",
+        message: null,
+        code: null,
+        source: "Worktrees",
+      },
+    });
   });
 
   it("says nothing was created when the host's list is empty", async () => {

--- a/clients/gui-app/src/components/settings/panels/add-provider-profile-dialog.tsx
+++ b/clients/gui-app/src/components/settings/panels/add-provider-profile-dialog.tsx
@@ -18,6 +18,8 @@ import {
 } from "@traycer/protocol/host/provider-schemas";
 import type { HostRpcRegistry } from "@/lib/host";
 import { ProviderProfileCard } from "@/components/providers/provider-profile-card";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -559,6 +561,16 @@ function AddProfileFailureStep({
         <Button type="button" size="sm" variant="secondary" onClick={onRetry}>
           Retry
         </Button>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Provider sign-in failed",
+            message: null,
+            code: null,
+            source: "Add profile",
+          })}
+          presentation="link"
+          className="h-auto p-0 text-current"
+        />
       </div>
     </div>
   );

--- a/clients/gui-app/src/components/settings/panels/agent-selection-guide-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/agent-selection-guide-section.tsx
@@ -11,6 +11,8 @@ import {
   AgentSelectionGuideEditorSurface,
 } from "@/components/agent-selection-guide-editor-surface";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { useAgentSelectionGuideGlobalQuery } from "@/hooks/agent/use-agent-selection-guide-global-query";
@@ -106,6 +108,16 @@ export function AgentSelectionGuideSection() {
       <AgentSelectionGuideMessage>
         <div className="text-ui-sm text-muted-foreground">
           Couldn't load agent instructions for this host.
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Couldn't load agent instructions",
+              message: null,
+              code: null,
+              source: "Agent instructions",
+            })}
+            presentation="link"
+            className="ml-1 h-auto p-0"
+          />
         </div>
       </AgentSelectionGuideMessage>
     );

--- a/clients/gui-app/src/components/settings/panels/diagnostics-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/diagnostics-settings-panel.tsx
@@ -4,6 +4,8 @@ import { ChevronDown, ChevronUp, FolderOpen } from "lucide-react";
 import { SettingsPanelShell } from "@/components/settings/settings-panel-shell";
 import { LogLevelRow } from "@/components/settings/panels/log-level-row";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { CopyTextButton } from "@/components/copy-text-button";
 import { useRunnerHost } from "@/providers/use-runner-host";
@@ -214,12 +216,26 @@ function DiagnosticsLogEntry(props: {
         </div>
       </div>
       {open ? (
-        <pre
-          className="mt-3 max-h-52 w-full overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-code-xs text-muted-foreground"
-          data-testid={`diagnostics-log-output-${entry.target}`}
-        >
-          {tailText}
-        </pre>
+        <div className="mt-3 flex items-start gap-2">
+          <pre
+            className="max-h-52 min-w-0 flex-1 overflow-auto rounded-md border border-border/60 bg-muted/30 px-3 py-2 font-mono text-code-xs text-muted-foreground"
+            data-testid={`diagnostics-log-output-${entry.target}`}
+          >
+            {tailText}
+          </pre>
+          {tailQuery.isError ? (
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Couldn't load log output",
+                message: null,
+                code: null,
+                source: "Diagnostics",
+              })}
+              presentation="icon"
+              className={undefined}
+            />
+          ) : null}
+        </div>
       ) : null}
     </div>
   );

--- a/clients/gui-app/src/components/settings/panels/host-doctor-actions.ts
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-actions.ts
@@ -4,6 +4,7 @@ import type {
   FreePortAndRestartInput,
   IHostManagement,
 } from "@traycer-clients/shared/platform/runner-host";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 export function copyTerminalCommand(command: string): void {
   void navigator.clipboard.writeText(command).then(
@@ -11,7 +12,12 @@ export function copyTerminalCommand(command: string): void {
       toast.success("Command copied to clipboard");
     },
     () => {
-      toast.error("Could not copy command");
+      reportableErrorToast("Could not copy command", undefined, {
+        title: "Could not copy command",
+        message: null,
+        code: null,
+        source: "Host Doctor",
+      });
     },
   );
 }

--- a/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
@@ -32,6 +32,7 @@ import type {
   FreePortAndRestartInput,
   IHostManagement,
 } from "@traycer-clients/shared/platform/runner-host";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 export interface HostDoctorCardProps {
   readonly recurrenceState?: RecurrenceState;
@@ -140,8 +141,15 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
   const handleFix = useCallback(
     (issue: HostDoctorIssue) => {
       if (recurrenceModel.recurrence.locked) {
-        toast.error(
+        reportableErrorToast(
           "Doctor paused after 3 failed fixes. Click Re-run Doctor to retry.",
+          undefined,
+          {
+            title: "Host Doctor paused",
+            message: "Host Doctor paused after repeated failed fixes.",
+            code: null,
+            source: "Host Doctor",
+          },
         );
         return;
       }

--- a/clients/gui-app/src/components/settings/panels/host-settings-available-versions-list.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-available-versions-list.tsx
@@ -1,5 +1,7 @@
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import {
   formatInstallDate,
   VERSION_LIST_PREVIEW,
@@ -52,7 +54,7 @@ export function AvailableVersionsList(props: AvailableVersionsListProps) {
         <div className="break-words font-mono text-code-xs text-muted-foreground">
           {errorMessage}
         </div>
-        <div>
+        <div className="flex flex-wrap items-center gap-2">
           <Button
             variant="secondary"
             size="sm"
@@ -68,6 +70,16 @@ export function AvailableVersionsList(props: AvailableVersionsListProps) {
             ) : null}
             Retry
           </Button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Couldn't load host versions",
+              message: "The host version registry could not be loaded.",
+              code: null,
+              source: "Host versions",
+            })}
+            presentation="text"
+            className={undefined}
+          />
         </div>
       </div>
     );

--- a/clients/gui-app/src/components/settings/panels/provider-profile-reauth-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-profile-reauth-panel.tsx
@@ -12,6 +12,8 @@ import type {
 } from "@traycer/protocol/host/provider-schemas";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { useProvidersStartLogin } from "@/hooks/providers/use-providers-start-login-mutation";
 import { useHostScopedProvidersAwaitLogin } from "@/hooks/providers/use-providers-await-login-mutation";
 import { useProvidersCancelLogin } from "@/hooks/providers/use-providers-cancel-login-mutation";
@@ -188,6 +190,16 @@ function ProviderProfileReauthState({
         <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-ui-sm text-destructive">
           <AlertTriangle className="mt-0.5 size-4 shrink-0" />
           <span>{flow.state.message}</span>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Provider reauthentication failed",
+              message: null,
+              code: null,
+              source: "Provider reauth",
+            })}
+            presentation="link"
+            className="h-auto p-0 text-current"
+          />
         </div>
       ) : null}
 

--- a/clients/gui-app/src/components/settings/panels/provider-profile-scoped-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-profile-scoped-section.tsx
@@ -19,6 +19,8 @@ import {
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import {
   Dialog,
@@ -235,6 +237,16 @@ export function ProviderProfileScopedSection(
               >
                 Dismiss
               </Button>
+              <ReportIssueAction
+                context={createReportIssueContext({
+                  title: "Provider sign-in failed",
+                  message: "Sign-in did not finish for a provider profile.",
+                  code: null,
+                  source: "Provider sign-in",
+                })}
+                presentation="icon"
+                className={undefined}
+              />
             </div>
           </div>
         ) : null}

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -12,6 +12,8 @@ import type {
 import type { ProviderRateLimitEnvelope } from "@/lib/rate-limits/rate-limit-envelope";
 import { Badge } from "@/components/ui/badge";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { MeterRow } from "@/components/settings/panels/traycer-subscription-views";
 import { contextUsageTone } from "@/components/chat/context-usage";
 import {
@@ -762,6 +764,16 @@ export function ProviderRateLimitBody(
     return (
       <div className="text-ui-sm text-destructive">
         Couldn't load usage limits. Try refreshing.
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Couldn't load usage limits",
+            message: null,
+            code: null,
+            source: "Provider usage limits",
+          })}
+          presentation="link"
+          className="ml-1 h-auto p-0 text-current"
+        />
       </div>
     );
   }

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -12,6 +12,8 @@ import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/hos
 import { SettingsPanelShell } from "@/components/settings/settings-panel-shell";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import {
   Select,
   SelectContent,
@@ -297,6 +299,16 @@ function ProvidersPanelBody({
     return (
       <div className="px-6 py-8 text-ui-sm text-destructive">
         Couldn't load provider state. The host may need to be updated.
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Couldn't load provider state",
+            message: null,
+            code: query.error.code,
+            source: "Providers",
+          })}
+          presentation="link"
+          className="ml-1 h-auto p-0 text-current"
+        />
       </div>
     );
   }

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
@@ -15,6 +15,8 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import type { AuthenticatedUser } from "@traycer/protocol/auth";
 import type { AccountContext } from "@traycer/protocol/common/schemas";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import {
   TraycerAccountSelect,
@@ -116,6 +118,16 @@ function SubscriptionBody({
     return (
       <div className="text-ui-sm text-destructive">
         Couldn't load your subscription. Try refreshing.
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Couldn't load your subscription",
+            message: null,
+            code: null,
+            source: "Subscription",
+          })}
+          presentation="link"
+          className="ml-1 h-auto p-0 text-current"
+        />
       </div>
     );
   }

--- a/clients/gui-app/src/components/settings/panels/worktree-delete-progress-modal.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktree-delete-progress-modal.tsx
@@ -4,6 +4,8 @@ import type { WorktreeDeletePhase } from "@traycer/protocol/host/worktree-delete
 import type { WorktreeHostEntry } from "@traycer/protocol/host/index";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { cn } from "@/lib/utils";
 import type {
   LogSegment,
@@ -37,6 +39,7 @@ export function WorktreeDeleteProgressModal(
   const { target, run, onClose } = props;
   const inProgress = run.status === "queued" || run.status === "running";
   const branch = target.branch ?? "detached HEAD";
+  const errorMessage = errorMessageFor(run);
 
   const steps: StepDefinition[] = run.hasTeardown
     ? [
@@ -83,13 +86,23 @@ export function WorktreeDeleteProgressModal(
         ))}
       </ol>
 
-      {errorMessageFor(run) !== null ? (
-        <p
+      {errorMessage !== null ? (
+        <div
           data-testid="worktree-delete-error"
-          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-ui-sm wrap-anywhere text-destructive"
+          className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-ui-sm wrap-anywhere text-destructive"
         >
-          {errorMessageFor(run)}
-        </p>
+          <span className="min-w-0 flex-1">{errorMessage}</span>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Could not delete worktree",
+              message: null,
+              code: null,
+              source: "Worktrees",
+            })}
+            presentation="icon"
+            className="-my-1 shrink-0 text-current"
+          />
+        </div>
       ) : null}
     </output>
   );

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -133,6 +133,9 @@ import {
 } from "@/lib/tab-navigation";
 import { RunnerHostContext } from "@/providers/runner-host-context";
 import { useRunnerOpenExternalLink } from "@/hooks/runner/use-open-external-link-mutation";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 type WorktreeRowDeleteStatus = "deleting";
 // Per-row activity-enrichment state, driving ONLY the tier pill's presentation:
@@ -690,6 +693,16 @@ function WorktreesPartialListingBanner(props: {
       >
         Retry
       </Button>
+      <ReportIssueAction
+        context={createReportIssueContext({
+          title: "Some worktrees could not be loaded",
+          message: null,
+          code: null,
+          source: "Worktrees",
+        })}
+        presentation="link"
+        className="h-auto shrink-0 p-0 text-current"
+      />
     </div>
   );
 }
@@ -2000,7 +2013,13 @@ const WorktreeRow = memo(function WorktreeRow(props: {
   const { copy: copyToClipboard } = useClipboardCopy({
     resetMs: 2000,
     onSuccess: () => toast.success("Copied worktree path"),
-    onError: () => toast.error("Couldn't copy path to clipboard."),
+    onError: () =>
+      reportableErrorToast("Couldn't copy path to clipboard.", undefined, {
+        title: "Could not copy worktree path",
+        message: null,
+        code: null,
+        source: "Worktrees",
+      }),
   });
   const copyPath = useCallback(() => {
     copyToClipboard(entry.worktreePath);
@@ -2828,6 +2847,18 @@ function WorktreesStateMessage(props: {
         />
       ) : null}
       <span className="max-w-md wrap-anywhere">{props.children}</span>
+      {props.tone === "error" ? (
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Could not load worktrees",
+            message: null,
+            code: null,
+            source: "Worktrees",
+          })}
+          presentation="icon"
+          className="text-current"
+        />
+      ) : null}
     </div>
   );
 }

--- a/clients/gui-app/src/components/ui/sonner.tsx
+++ b/clients/gui-app/src/components/ui/sonner.tsx
@@ -21,6 +21,10 @@ const TOAST_CLOSE_BUTTON_CLASS_NAME = cn(
   "focus-visible:pointer-events-auto",
   "focus-visible:opacity-100",
 );
+const TOAST_CANCEL_BUTTON_CLASS_NAME = cn(
+  "border border-border bg-background text-foreground",
+  "hover:bg-muted",
+);
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();
@@ -56,6 +60,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           classNames: {
             toast: TOAST_CLASS_NAME,
             closeButton: TOAST_CLOSE_BUTTON_CLASS_NAME,
+            cancelButton: TOAST_CANCEL_BUTTON_CLASS_NAME,
           },
         }}
         {...props}

--- a/clients/gui-app/src/components/workspaces/scripts-review-dialog.tsx
+++ b/clients/gui-app/src/components/workspaces/scripts-review-dialog.tsx
@@ -18,6 +18,8 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { RepoScriptsFields } from "@/components/workspaces/repo-scripts-fields";
 import {
   repoScriptsRequestPayload,
@@ -146,13 +148,23 @@ export function ScriptsReviewDialog(props: {
             </code>
           </div>
           {props.errorNote !== null ? (
-            <p
+            <div
               className="text-ui-xs text-destructive"
               role="alert"
               data-testid={`${props.testId}-error-note`}
             >
-              {props.errorNote}
-            </p>
+              <span>{props.errorNote}</span>
+              <ReportIssueAction
+                context={createReportIssueContext({
+                  title: "Could not load workspace scripts",
+                  message: null,
+                  code: null,
+                  source: "Workspace scripts",
+                })}
+                presentation="link"
+                className="ml-1 h-auto p-0 text-current"
+              />
+            </div>
           ) : null}
           {props.seedPending ? (
             <div

--- a/clients/gui-app/src/components/worktree/open-in-editor-button.tsx
+++ b/clients/gui-app/src/components/worktree/open-in-editor-button.tsx
@@ -26,6 +26,7 @@ import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-i
 import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useSettingsStore } from "@/stores/settings/settings-store";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 type EditorIconComponent = ComponentType<EditorIconProps>;
 
@@ -87,7 +88,12 @@ export function OpenInEditorButton(props: OpenInEditorButtonProps) {
       toast.success("Copied workspace path");
     },
     onError: () => {
-      toast.error("Couldn't copy path to clipboard.");
+      reportableErrorToast("Couldn't copy path to clipboard.", undefined, {
+        title: "Could not copy workspace path",
+        message: null,
+        code: null,
+        source: "Workspace",
+      });
     },
   });
 

--- a/clients/gui-app/src/components/worktree/worktree-folder-list-body.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-folder-list-body.tsx
@@ -1,6 +1,8 @@
 import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
 import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { WorktreeFolderList } from "@/components/worktree/worktree-folder-list";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { formatWorktreeFolderDisabledReason } from "@/lib/worktree/worktree-folder-disabled-reason";
 
 /**
@@ -30,8 +32,18 @@ export function WorktreeFolderListBody(props: WorktreeFolderListBodyProps) {
   }
   if (props.isError) {
     return (
-      <div className="p-2.5 text-ui-sm text-destructive">
-        Failed to load workspaces.
+      <div className="flex items-center gap-2 p-2.5 text-ui-sm text-destructive">
+        <span className="min-w-0 flex-1">Failed to load workspaces.</span>
+        <ReportIssueAction
+          context={createReportIssueContext({
+            title: "Failed to load workspaces",
+            message: null,
+            code: null,
+            source: "Workspaces",
+          })}
+          presentation="icon"
+          className="text-current"
+        />
       </div>
     );
   }

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-node-view.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-node-view.tsx
@@ -11,6 +11,8 @@ import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { trustedMarkupToReactNodes } from "@/lib/trusted-markup";
 import { BlockErrorBoundary } from "../shared/block-error-boundary";
 import { MermaidBlockToolbar } from "./mermaid-block-toolbar";
@@ -236,6 +238,16 @@ export function MermaidNodeView(props: NodeViewProps) {
                 Mermaid parse error
               </div>
               <div className="tc-node-block__error-detail">{render.error}</div>
+              <ReportIssueAction
+                context={createReportIssueContext({
+                  title: "Mermaid parse error",
+                  message: null,
+                  code: null,
+                  source: "Artifact editor",
+                })}
+                presentation="icon"
+                className={undefined}
+              />
             </div>
           )}
           {render.status === "idle" && rawCode.trim().length === 0 && (

--- a/clients/gui-app/src/editor-core/nodes/mermaid/use-mermaid-png-download.ts
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/use-mermaid-png-download.ts
@@ -6,6 +6,7 @@ import { readMermaidPalette } from "@/editor-core/nodes/mermaid/mermaid-theme";
 import { saveBlobToDisk } from "@/lib/files/save-blob-to-disk";
 import { appLogger } from "@/lib/logger";
 import { runnerMutationKeys } from "@/lib/query-keys";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 export interface UseMermaidPngDownloadParams {
   readonly svg: string;
@@ -46,7 +47,12 @@ export function useMermaidPngDownload(
     },
     onError: (err) => {
       appLogger.errorSummary("[mermaid] download failed", {}, err);
-      toast.error("Failed to download diagram");
+      reportableErrorToast("Failed to download diagram", undefined, {
+        title: "Could not download diagram",
+        message: null,
+        code: null,
+        source: "Mermaid diagram",
+      });
     },
   });
 

--- a/clients/gui-app/src/editor-core/nodes/shared/block-error-boundary.tsx
+++ b/clients/gui-app/src/editor-core/nodes/shared/block-error-boundary.tsx
@@ -1,5 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
 import { appLogger } from "@/lib/logger";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 
 interface BlockErrorBoundaryProps {
   /** Headline shown in the fallback panel. */
@@ -78,6 +80,16 @@ export class BlockErrorBoundary extends Component<
           >
             Retry
           </button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: this.props.title,
+              message: null,
+              code: null,
+              source: "Artifact editor",
+            })}
+            presentation="icon"
+            className={undefined}
+          />
         </div>
       </div>
     );

--- a/clients/gui-app/src/hooks/chats/use-chat-setup-failure-restore-driver.ts
+++ b/clients/gui-app/src/hooks/chats/use-chat-setup-failure-restore-driver.ts
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
 import { useStore } from "zustand";
 import { selectRestorableSetupInterruption } from "@/stores/chats/chat-session-selectors";
 import type { ChatSessionStoreHandle } from "@/stores/chats/chat-session-store";
 import { useComposerDraftStore } from "@/stores/composer/composer-draft-store";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 /**
  * Drives the "restore-to-composer" half of Flow 8 for chats.
@@ -96,7 +96,16 @@ export function useChatSetupFailureRestoreDriver(
       (interruption.workspacePath === null ||
         interruption.workspacePath.length === 0)
     ) {
-      toast.error("Setup failed before the first message could run.");
+      reportableErrorToast(
+        "Setup failed before the first message could run.",
+        undefined,
+        {
+          title: "Workspace setup failed",
+          message: "Setup failed before the first message could run.",
+          code: null,
+          source: "Chat setup",
+        },
+      );
     }
   }, [dedupe, interruption, handle.store, nodeId, replaceDraft]);
 }

--- a/clients/gui-app/src/hooks/composer/use-composer-dictation.ts
+++ b/clients/gui-app/src/hooks/composer/use-composer-dictation.ts
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, type RefObject } from "react";
-import { toast } from "sonner";
 
 import type { ComposerDictationControl } from "@/components/home/toolbar/composer-mic-button";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
@@ -11,6 +10,7 @@ import { useDictationHotkey } from "@/hooks/composer/use-dictation-hotkey";
 import { useVoiceDictation } from "@/hooks/composer/use-voice-dictation";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useSettingsStore } from "@/stores/settings/settings-store";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 interface UseComposerDictationArgs {
   readonly editorRef: RefObject<ComposerPromptEditorHandle | null>;
@@ -49,7 +49,7 @@ export function useComposerDictation(
   const runnerHost = useRunnerHost();
   useEffect(() => {
     if (dictationError === null) return;
-    toast.error(
+    reportableErrorToast(
       dictationError,
       dictationPermissionDenied
         ? {
@@ -63,6 +63,14 @@ export function useComposerDictation(
             },
           }
         : undefined,
+      {
+        title: "Dictation failed",
+        message: dictationPermissionDenied
+          ? "Microphone permission was unavailable."
+          : null,
+        code: null,
+        source: "Dictation",
+      },
     );
   }, [dictationError, dictationPermissionDenied, runnerHost]);
 

--- a/clients/gui-app/src/hooks/composer/use-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-composer-paste.ts
@@ -4,11 +4,11 @@ import {
   type ClipboardEvent,
   type DragEvent,
 } from "react";
-import { toast } from "sonner";
 import type { Editor } from "@tiptap/core";
 import { v4 as uuidv4 } from "uuid";
 
 import type { ImageAttachmentAttrs } from "@/components/chat/composer/editor/extensions/image-attachment-extension";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 export const IMAGE_MIME_PREFIX = "image/";
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
@@ -36,9 +36,18 @@ export function collectImages(files: ReadonlyArray<File>): File[] {
   for (const file of files) {
     if (!file.type.startsWith(IMAGE_MIME_PREFIX)) continue;
     if (file.size > MAX_IMAGE_BYTES) {
-      toast.error("Image too large", {
-        description: `${file.name || "Image"} exceeds the 5MB limit.`,
-      });
+      reportableErrorToast(
+        "Image too large",
+        {
+          description: `${file.name || "Image"} exceeds the 5MB limit.`,
+        },
+        {
+          title: "Image exceeded the size limit",
+          message: null,
+          code: null,
+          source: "Chat composer",
+        },
+      );
       continue;
     }
     accepted.push(file);

--- a/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
@@ -1,5 +1,4 @@
 import { useCallback } from "react";
-import { toast } from "sonner";
 import { v4 as uuidv4 } from "uuid";
 
 import type { ImageAttachmentAttrs } from "@/components/chat/composer/editor/extensions/image-attachment-extension";
@@ -14,6 +13,7 @@ import {
   reserveLandingImageBudget,
   scheduleLandingImageReconcile,
 } from "@/lib/composer/landing-image-gc";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 /**
  * Landing-composer paste/drop ingest. Unlike the shared base64 adapter
@@ -72,9 +72,18 @@ export function useLandingComposerPaste(editorRef: {
           // or store) inserts nothing, but earlier images may already be stored —
           // now orphaned. Surface the failure and schedule a reconcile to reclaim
           // them (their session entries keep the bytes safe until it runs).
-          toast.error("Couldn't attach the image.", {
-            description: "Please try adding it again.",
-          });
+          reportableErrorToast(
+            "Couldn't attach the image.",
+            {
+              description: "Please try adding it again.",
+            },
+            {
+              title: "Could not attach image",
+              message: null,
+              code: null,
+              source: "Chat composer",
+            },
+          );
           scheduleLandingImageReconcile();
         });
     },

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-batch-delete-mutation.test.ts
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-batch-delete-mutation.test.ts
@@ -1,9 +1,45 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { ExternalToast } from "sonner";
+
+const toastWarning = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "warning-toast",
+  ),
+);
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    warning: toastWarning,
+    error: vi.fn(),
+  },
+}));
+
 import {
   deletedEpicSuccessToastMessage,
+  emitEpicDeleteToast,
   pickNeighborAfterDeletingEpics,
 } from "@/hooks/epic/use-epic-batch-delete-mutation";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import type { HeaderTab } from "@/stores/tabs/types";
+
+beforeEach(() => {
+  toastWarning.mockClear();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
+
+afterEach(() => {
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
 
 function epicTab(id: string, epicId: string): HeaderTab {
   return {
@@ -149,3 +185,48 @@ describe("deletedEpicSuccessToastMessage", () => {
     ).toBe("2 epics deleted");
   });
 });
+
+describe("emitEpicDeleteToast", () => {
+  it("keeps partial deletions as warnings with fixed report context", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+
+    emitEpicDeleteToast("warning", "Deleted 1 of 2; 1 failed.");
+
+    expect(toastWarning.mock.lastCall?.[0]).toBe("Deleted 1 of 2; 1 failed.");
+    expect(readWarningOptions().cancel).toMatchObject({
+      label: "Report issue",
+    });
+    clickWarningReportAction();
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Epic deletion incomplete",
+      message: null,
+      code: null,
+      source: "Epic deletion",
+    });
+    expect(
+      JSON.stringify(useDesktopDialogStore.getState().reportIssueContext),
+    ).not.toMatch(/epic-[a-z0-9]+|Customer onboarding|Deleted 1 of 2/);
+  });
+
+  it("does not expose reporting when the capability is unavailable", () => {
+    emitEpicDeleteToast("warning", "Deleted 1 of 2; 1 failed.");
+
+    expect(toastWarning).toHaveBeenCalledWith("Deleted 1 of 2; 1 failed.");
+  });
+});
+
+function clickWarningReportAction(): void {
+  const cancel = readWarningOptions().cancel;
+  if (typeof cancel !== "object" || cancel === null || !("onClick" in cancel)) {
+    throw new Error("Expected a warning report action.");
+  }
+  cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+}
+
+function readWarningOptions(): ExternalToast {
+  const options = toastWarning.mock.lastCall?.[1];
+  if (options === undefined) {
+    throw new Error("Expected warning toast options.");
+  }
+  return options;
+}

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-batch-delete-mutation.test.ts
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-batch-delete-mutation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import type { ExternalToast } from "sonner";
 
 const toastWarning = vi.hoisted(() =>
@@ -220,7 +221,17 @@ function clickWarningReportAction(): void {
   if (typeof cancel !== "object" || cancel === null || !("onClick" in cancel)) {
     throw new Error("Expected a warning report action.");
   }
-  cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+  const action = render(
+    createElement(
+      "button",
+      { type: "button", onClick: cancel.onClick },
+      "Trigger warning report",
+    ),
+  );
+  fireEvent.click(
+    action.getByRole("button", { name: "Trigger warning report" }),
+  );
+  action.unmount();
 }
 
 function readWarningOptions(): ExternalToast {

--- a/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
@@ -33,6 +33,10 @@ import { pickNeighborAfterRemovingTabs } from "@/stores/tabs/neighbor";
 import { tabResolveIntent } from "@/stores/tabs/registry";
 import type { HeaderTab } from "@/stores/tabs/types";
 import { getHeaderTabs } from "@/stores/tabs/use-header-tabs";
+import {
+  reportableErrorToast,
+  reportableWarningToast,
+} from "@/lib/reportable-error-toast";
 
 interface BatchDeleteEpicMutationContext {
   readonly hostId: string | null;
@@ -143,7 +147,7 @@ export function useEpicBatchDelete(): UseMutationResult<
           successes,
         );
         if (ctx.hostId === null || eligibleWorktreePaths.length === 0) {
-          emitToast(epicToast.level, epicToast.message);
+          emitEpicDeleteToast(epicToast.level, epicToast.message);
         } else {
           // The Task(s) are already deleted; stream the approved worktree
           // removals and report a single combined summary once they settle.
@@ -290,16 +294,29 @@ function epicDeleteToastParts(args: {
   };
 }
 
-function emitToast(level: EpicDeleteToastLevel, message: string): void {
+export function emitEpicDeleteToast(
+  level: EpicDeleteToastLevel,
+  message: string,
+): void {
   if (level === "success") {
     toast.success(message);
     return;
   }
   if (level === "warning") {
-    toast.warning(message);
+    reportableWarningToast(message, undefined, {
+      title: "Epic deletion incomplete",
+      message: null,
+      code: null,
+      source: "Epic deletion",
+    });
     return;
   }
-  toast.error(message);
+  reportableErrorToast(message, undefined, {
+    title: "Could not delete Epics",
+    message: null,
+    code: null,
+    source: "Epic deletion",
+  });
 }
 
 // A worktree is safe to remove only when EVERY owning Task actually succeeded -
@@ -346,13 +363,13 @@ function emitTaskDeleteSummaryToast(
     outcome.failed.length,
   );
   if (summary === null) {
-    emitToast(epicToast.level, epicToast.message);
+    emitEpicDeleteToast(epicToast.level, epicToast.message);
     return;
   }
   // A worktree that couldn't be removed downgrades the combined toast to a
   // warning even when every Task deleted cleanly.
   const level = outcome.failed.length > 0 ? "warning" : epicToast.level;
-  emitToast(level, `${epicToast.message} · ${summary}`);
+  emitEpicDeleteToast(level, `${epicToast.message} · ${summary}`);
 }
 
 // Refresh the host-wide worktree list plus the shared binding-backed caches

--- a/clients/gui-app/src/hooks/terminal/use-terminal-create-mutation.ts
+++ b/clients/gui-app/src/hooks/terminal/use-terminal-create-mutation.ts
@@ -11,8 +11,8 @@ import type {
   ResponseOfMethod,
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcRegistry } from "@/lib/host";
+import { toastFromHostError } from "@/lib/host-error-toast";
 import { hostQueryKeys, terminalMutationKeys } from "@/lib/query-keys";
-import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 interface CreateTerminalMutationContext {
   readonly hostId: string | null;
@@ -59,12 +59,6 @@ export function useTerminalCreate(
         queryKey: hostQueryKeys.methodScope(ctx.hostId, "terminal.list"),
       });
     },
-    onError: (error) =>
-      reportableErrorToast(error.message, undefined, {
-        title: "Could not create terminal",
-        message: null,
-        code: null,
-        source: "Terminal",
-      }),
+    onError: (error) => toastFromHostError(error, "Could not create terminal"),
   });
 }

--- a/clients/gui-app/src/hooks/terminal/use-terminal-create-mutation.ts
+++ b/clients/gui-app/src/hooks/terminal/use-terminal-create-mutation.ts
@@ -3,7 +3,6 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
-import { toast } from "sonner";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { HostRpcError as HostRpcErrorCtor } from "@traycer-clients/shared/host-transport/host-messenger";
@@ -13,6 +12,7 @@ import type {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcRegistry } from "@/lib/host";
 import { hostQueryKeys, terminalMutationKeys } from "@/lib/query-keys";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 interface CreateTerminalMutationContext {
   readonly hostId: string | null;
@@ -59,6 +59,12 @@ export function useTerminalCreate(
         queryKey: hostQueryKeys.methodScope(ctx.hostId, "terminal.list"),
       });
     },
-    onError: (error) => toast.error(error.message),
+    onError: (error) =>
+      reportableErrorToast(error.message, undefined, {
+        title: "Could not create terminal",
+        message: null,
+        code: null,
+        source: "Terminal",
+      }),
   });
 }

--- a/clients/gui-app/src/hooks/workspace/use-workspace-folder-actions.ts
+++ b/clients/gui-app/src/hooks/workspace/use-workspace-folder-actions.ts
@@ -4,7 +4,6 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
-import { toast } from "sonner";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
@@ -25,6 +24,7 @@ import {
 } from "@/lib/query-keys";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import type { WorkspaceFolderInfo } from "@/stores/workspace/workspace-folders-store";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 interface MutationContext {
   readonly hostId: string | null;
@@ -72,9 +72,18 @@ export function useWorkspaceFolderActionsForClient(
       onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
       // No success toast: added folders appear immediately in the picker rows.
       onError: (error) => {
-        toast.error("Couldn't add folders", {
-          description: readWorkspaceActionErrorMessage(error),
-        });
+        reportableErrorToast(
+          "Couldn't add folders",
+          {
+            description: readWorkspaceActionErrorMessage(error),
+          },
+          {
+            title: "Could not add workspace folders",
+            message: null,
+            code: null,
+            source: "Workspace folders",
+          },
+        );
       },
     },
   });
@@ -97,9 +106,18 @@ export function useWorkspaceFolderActionsForClient(
         });
       },
       onError: (error) => {
-        toast.error("Couldn't remove repository from epic", {
-          description: readWorkspaceActionErrorMessage(error),
-        });
+        reportableErrorToast(
+          "Couldn't remove repository from epic",
+          {
+            description: readWorkspaceActionErrorMessage(error),
+          },
+          {
+            title: "Could not remove repository from Epic",
+            message: null,
+            code: null,
+            source: "Workspace folders",
+          },
+        );
       },
     },
   });
@@ -114,7 +132,12 @@ export function useWorkspaceFolderActionsForClient(
   const pickAndPrepareFolders = useCallback(async () => {
     const activeHost = client?.getActiveHost() ?? null;
     if (!canAssociateLocalWorkspaces(activeHost)) {
-      toast.error("Select the local host to add folders.");
+      reportableErrorToast("Select the local host to add folders.", undefined, {
+        title: "Could not add workspace folders",
+        message: "The local host was not selected.",
+        code: null,
+        source: "Workspace folders",
+      });
       return null;
     }
 

--- a/clients/gui-app/src/lib/__tests__/report-issue-context.test.ts
+++ b/clients/gui-app/src/lib/__tests__/report-issue-context.test.ts
@@ -28,7 +28,7 @@ describe("createReportIssueContext", () => {
 
     expect(context.title).toBe("Traycer error");
     expect(context.message?.endsWith("…")).toBe(true);
-    expect(context.message?.length).toBe(301);
+    expect(context.message?.length).toBe(300);
     expect(context.code).toBeNull();
     expect(context.source).toBeNull();
   });

--- a/clients/gui-app/src/lib/__tests__/report-issue-context.test.ts
+++ b/clients/gui-app/src/lib/__tests__/report-issue-context.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+
+describe("createReportIssueContext", () => {
+  it("normalizes intentionally privacy-safe error context", () => {
+    expect(
+      createReportIssueContext({
+        title: "  Failed to load\nEpic  ",
+        message: "Host returned\n\nan error",
+        code: " RPC_ERROR ",
+        source: " Epic snapshot ",
+      }),
+    ).toEqual({
+      title: "Failed to load Epic",
+      message: "Host returned an error",
+      code: "RPC_ERROR",
+      source: "Epic snapshot",
+    });
+  });
+
+  it("drops empty values and caps long context", () => {
+    const context = createReportIssueContext({
+      title: " ",
+      message: "x".repeat(500),
+      code: "",
+      source: null,
+    });
+
+    expect(context.title).toBe("Traycer error");
+    expect(context.message?.endsWith("…")).toBe(true);
+    expect(context.message?.length).toBe(301);
+    expect(context.code).toBeNull();
+    expect(context.source).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/__tests__/reportable-error-toast.test.ts
+++ b/clients/gui-app/src/lib/__tests__/reportable-error-toast.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import { fireEvent, render } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
 import type { ExternalToast } from "sonner";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 
@@ -122,6 +123,21 @@ describe("reportableErrorToast", () => {
     expect(readToastOptions().cancel).toBeNull();
   });
 
+  it("preserves a caller-supplied cancel action for a stable toast when reporting is unavailable", () => {
+    const cancel = { label: "Dismiss", onClick: vi.fn() };
+
+    reportableErrorToast(
+      "Couldn't update",
+      { id: "stable-error", cancel },
+      SAFE_CONTEXT,
+    );
+
+    expect(errorToast).toHaveBeenCalledWith("Couldn't update", {
+      id: "stable-error",
+      cancel,
+    });
+  });
+
   it("keeps warning severity and a primary action while adding reporting", () => {
     useDesktopDialogStore.setState({ reportIssueAvailable: true });
     const retry = vi.fn();
@@ -231,7 +247,15 @@ function clickReportAction(cancel: ExternalToast["cancel"]): void {
   if (typeof cancel !== "object" || cancel === null || !("onClick" in cancel)) {
     throw new Error("Expected a report issue action.");
   }
-  cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+  const action = render(
+    createElement(
+      "button",
+      { type: "button", onClick: cancel.onClick },
+      "Trigger report issue",
+    ),
+  );
+  fireEvent.click(action.getByRole("button", { name: "Trigger report issue" }));
+  action.unmount();
 }
 
 function readToastOptions(): ExternalToast {

--- a/clients/gui-app/src/lib/__tests__/reportable-error-toast.test.ts
+++ b/clients/gui-app/src/lib/__tests__/reportable-error-toast.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { ExternalToast } from "sonner";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+
+const errorToast = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "toast-id",
+  ),
+);
+const warningToast = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "toast-id",
+  ),
+);
+
+vi.mock("sonner", () => ({
+  toast: { error: errorToast, warning: warningToast },
+}));
+
+import { toastFromAuthError } from "@/lib/auth-error-toast";
+import { toastFromHostErrorWithDetail } from "@/lib/host-error-toast";
+import {
+  reportableErrorToast,
+  reportableWarningToast,
+} from "@/lib/reportable-error-toast";
+import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+const SAFE_CONTEXT = {
+  title: "Could not load Epic",
+  message: "The Epic could not be loaded.",
+  code: null,
+  source: "Epic list",
+};
+
+afterEach(() => {
+  errorToast.mockClear();
+  warningToast.mockClear();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+    reportIssueDraftId: 0,
+  });
+});
+
+describe("reportableErrorToast", () => {
+  it("preserves an ordinary error toast when desktop reporting is unavailable", () => {
+    reportableErrorToast("Couldn't load", undefined, SAFE_CONTEXT);
+
+    expect(errorToast).toHaveBeenCalledWith("Couldn't load");
+  });
+
+  it("uses only the explicitly supplied privacy-safe context", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    const unsafeVisibleCopy =
+      "alice@example.com could not open /Users/alice/secret-project/private.png";
+
+    reportableErrorToast(
+      unsafeVisibleCopy,
+      {
+        description: "hidden raw error: --value sk-secret-123",
+      },
+      SAFE_CONTEXT,
+    );
+    clickErrorReportAction();
+
+    expect(errorToast).toHaveBeenCalledWith(
+      unsafeVisibleCopy,
+      expect.objectContaining({
+        description: "hidden raw error: --value sk-secret-123",
+      }),
+    );
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual(
+      SAFE_CONTEXT,
+    );
+    expect(
+      JSON.stringify(useDesktopDialogStore.getState().reportIssueContext),
+    ).not.toMatch(
+      /alice@example\.com|private\.png|\/Users\/alice|sk-secret-123|hidden raw error/,
+    );
+  });
+
+  it("replaces an already-open ordinary draft with the most recently selected context", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    useDesktopDialogStore.getState().openReportIssueWithContext({
+      title: "Earlier error",
+      message: null,
+      code: null,
+      source: "Earlier area",
+    });
+    const previousDraftId = useDesktopDialogStore.getState().reportIssueDraftId;
+
+    reportableErrorToast("Couldn't load", undefined, SAFE_CONTEXT);
+    clickErrorReportAction();
+
+    expect(useDesktopDialogStore.getState()).toMatchObject({
+      activeDialog: "report-issue",
+      reportIssueContext: SAFE_CONTEXT,
+      reportIssueDraftId: previousDraftId + 1,
+    });
+  });
+
+  it("rechecks capability before a visible report action opens a draft", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    reportableErrorToast("Couldn't load", undefined, SAFE_CONTEXT);
+    const action = readToastOptions().cancel;
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
+
+    clickReportAction(action);
+
+    expect(useDesktopDialogStore.getState().activeDialog).toBeNull();
+    expect(useDesktopDialogStore.getState().reportIssueContext).toBeNull();
+  });
+
+  it("preserves an explicitly composed cancel slot", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+
+    reportableErrorToast("Couldn't update", { cancel: null }, SAFE_CONTEXT);
+
+    expect(readToastOptions().cancel).toBeNull();
+  });
+
+  it("keeps warning severity and a primary action while adding reporting", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    const retry = vi.fn();
+    const action = { label: "Retry", onClick: retry };
+
+    reportableWarningToast("Partially completed", { action }, SAFE_CONTEXT);
+
+    expect(warningToast).toHaveBeenCalledWith(
+      "Partially completed",
+      expect.objectContaining({ action }),
+    );
+    clickReportAction(readWarningOptions().cancel);
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual(
+      SAFE_CONTEXT,
+    );
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("explicitly clears warning report actions when capability is unavailable", () => {
+    reportableWarningToast(
+      "Partially completed",
+      { id: "stable-warning" },
+      SAFE_CONTEXT,
+    );
+
+    expect(warningToast).toHaveBeenCalledWith("Partially completed", {
+      id: "stable-warning",
+      cancel: null,
+    });
+  });
+
+  it("rechecks capability before a warning report action opens a draft", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    reportableWarningToast("Partially completed", undefined, SAFE_CONTEXT);
+    const action = readWarningOptions().cancel;
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
+
+    clickReportAction(action);
+
+    expect(useDesktopDialogStore.getState().activeDialog).toBeNull();
+    expect(useDesktopDialogStore.getState().reportIssueContext).toBeNull();
+  });
+});
+
+describe("shared error helpers", () => {
+  it("keeps runner details visible without putting env secrets in the draft", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    const rawError =
+      "Command failed: traycer env set API_KEY --value sk-secret-123";
+
+    toastFromRunnerError(new Error(rawError), "Failed to save env override");
+    expect(readToastOptions().description).toBe(rawError);
+    clickErrorReportAction();
+
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Desktop operation failed",
+      message: null,
+      code: null,
+      source: "Desktop",
+    });
+  });
+
+  it("keeps user identifiers out of authentication report context", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+
+    toastFromAuthError(
+      new Error("Authentication failed for alice@example.com"),
+      "Couldn't sign in",
+    );
+    clickErrorReportAction();
+
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Authentication failed",
+      message: null,
+      code: null,
+      source: "Authentication",
+    });
+  });
+
+  it("keeps hidden host paths and filenames out while retaining a stable code", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    const error = new HostRpcError({
+      code: "RPC_ERROR",
+      message: "Could not read /Users/alice/project/private.txt",
+      requestId: "request-1",
+      method: "workspace.readFile",
+      fatalDetails: null,
+    });
+
+    toastFromHostErrorWithDetail(error, "Couldn't read workspace file.");
+    clickErrorReportAction();
+
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Host operation failed",
+      message: null,
+      code: "RPC_ERROR",
+      source: "Host",
+    });
+  });
+});
+
+function clickErrorReportAction(): void {
+  clickReportAction(readToastOptions().cancel);
+}
+
+function clickReportAction(cancel: ExternalToast["cancel"]): void {
+  if (typeof cancel !== "object" || cancel === null || !("onClick" in cancel)) {
+    throw new Error("Expected a report issue action.");
+  }
+  cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+}
+
+function readToastOptions(): ExternalToast {
+  const call = errorToast.mock.lastCall;
+  if (call === undefined || call[1] === undefined) {
+    throw new Error("Expected toast options.");
+  }
+  return call[1];
+}
+
+function readWarningOptions(): ExternalToast {
+  const call = warningToast.mock.lastCall;
+  if (call === undefined || call[1] === undefined) {
+    throw new Error("Expected warning toast options.");
+  }
+  return call[1];
+}

--- a/clients/gui-app/src/lib/__tests__/stable-toast-report-action.test.ts
+++ b/clients/gui-app/src/lib/__tests__/stable-toast-report-action.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { toast, type ToastT } from "sonner";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
+import { scopedToastChannel } from "@/lib/toast/toast-channel";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+const LOADING_TOAST_ID = "report-action-error-to-loading";
+const SUCCESS_TOAST_PREFIX = "report-action-error-to-success";
+const REPORT_CONTEXT = {
+  title: "Traycer operation failed",
+  message: null,
+  code: null,
+  source: "Traycer app",
+};
+
+afterEach(() => {
+  toast.dismiss(LOADING_TOAST_ID);
+  toast.dismiss(`${SUCCESS_TOAST_PREFIX}:scope`);
+  useDesktopDialogStore.getState().close();
+  useDesktopDialogStore.setState({ reportIssueAvailable: false });
+});
+
+describe("stable-id toast report actions", () => {
+  it("clears the report action when an error is replaced by loading", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    reportableErrorToast(
+      "Operation failed",
+      { id: LOADING_TOAST_ID },
+      REPORT_CONTEXT,
+    );
+    expect(readToast(LOADING_TOAST_ID).cancel).not.toBeNull();
+
+    toast.loading("Trying again", {
+      id: LOADING_TOAST_ID,
+      cancel: null,
+    });
+
+    expect(readToast(LOADING_TOAST_ID)).toMatchObject({
+      type: "loading",
+      cancel: null,
+    });
+  });
+
+  it("clears the report action when a shared channel error becomes success", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    const channel = scopedToastChannel(SUCCESS_TOAST_PREFIX)("scope");
+    channel.error("Operation failed");
+    expect(readToast(channel.id).cancel).not.toBeNull();
+
+    channel.success("Operation completed");
+
+    expect(readToast(channel.id)).toMatchObject({
+      type: "success",
+      cancel: null,
+    });
+  });
+
+  it("clears a same-ID report action when support capability is lost", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    reportableErrorToast(
+      "Operation failed",
+      { id: LOADING_TOAST_ID },
+      REPORT_CONTEXT,
+    );
+    expect(readToast(LOADING_TOAST_ID).cancel).not.toBeNull();
+
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
+    reportableErrorToast(
+      "Operation still failed",
+      { id: LOADING_TOAST_ID },
+      REPORT_CONTEXT,
+    );
+
+    expect(readToast(LOADING_TOAST_ID)).toMatchObject({
+      type: "error",
+      cancel: null,
+    });
+  });
+});
+
+function readToast(id: string): ToastT {
+  const entry = toast
+    .getToasts()
+    .find((candidate) => candidate.id === id && "title" in candidate);
+  if (entry === undefined || !("title" in entry)) {
+    throw new Error(`Expected active toast ${id}`);
+  }
+  return entry;
+}

--- a/clients/gui-app/src/lib/auth-error-toast.ts
+++ b/clients/gui-app/src/lib/auth-error-toast.ts
@@ -1,11 +1,17 @@
-import { toast } from "sonner";
 import { readErrorMessage } from "@/lib/read-error-message";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 export function toastFromAuthError(error: unknown, fallback: string): void {
   const message = readErrorMessage(error);
-  if (message !== null) {
-    toast.error(fallback, { description: message });
-    return;
-  }
-  toast.error(fallback);
+  reportableErrorToast(
+    fallback,
+    message === null ? undefined : { description: message },
+    createReportIssueContext({
+      title: "Authentication failed",
+      message: null,
+      code: null,
+      source: "Authentication",
+    }),
+  );
 }

--- a/clients/gui-app/src/lib/commands/__tests__/help.source.test.tsx
+++ b/clients/gui-app/src/lib/commands/__tests__/help.source.test.tsx
@@ -1,0 +1,76 @@
+import "../../../../__tests__/test-browser-apis";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { helpSource } from "@/lib/commands/sources/help.source";
+import type { CommandContext, CommandItem } from "@/lib/commands/types";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+function context(): CommandContext {
+  return {
+    pathname: "/",
+    router: {
+      getPathname: () => "/",
+      navigateHome: () => undefined,
+      navigateSettings: () => undefined,
+      navigateToEpic: () => undefined,
+      navigateToEpicTab: () => undefined,
+      navigateToEpicList: () => undefined,
+      navigateSettingsSection: () => undefined,
+      navigateToTabIntent: () => undefined,
+      goBack: () => undefined,
+      goForward: () => undefined,
+      isHistoryNavAvailable: () => false,
+      canGoBack: () => false,
+      canGoForward: () => false,
+    },
+    activeTabId: null,
+    activeEpicId: null,
+    focusedComposerKind: null,
+    targetGroupId: null,
+  };
+}
+
+function captureItems(): ReadonlyArray<CommandItem> {
+  let captured: ReadonlyArray<CommandItem> = [];
+  function Probe() {
+    captured = helpSource.useItems(context());
+    return null;
+  }
+  render(<Probe />);
+  return captured;
+}
+
+afterEach(() => {
+  cleanup();
+  useDesktopDialogStore.getState().close();
+  useDesktopDialogStore.setState({ reportIssueAvailable: false });
+});
+
+describe("helpSource", () => {
+  it("omits report issue when desktop support is unavailable", () => {
+    expect(captureItems().map((item) => item.id)).toEqual(["help:keybindings"]);
+  });
+
+  it("offers report issue when desktop support is available", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    const items = captureItems();
+    const reportIssue = items.find((item) => item.id === "help:report-issue");
+
+    expect(reportIssue).toBeDefined();
+    void reportIssue?.run(context());
+    expect(useDesktopDialogStore.getState().activeDialog).toBe("report-issue");
+  });
+
+  it("rechecks support before running a previously visible command", () => {
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    const reportIssue = captureItems().find(
+      (item) => item.id === "help:report-issue",
+    );
+    cleanup();
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
+
+    void reportIssue?.run(context());
+
+    expect(useDesktopDialogStore.getState().activeDialog).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/help.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/help.source.ts
@@ -8,21 +8,25 @@ import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 export const helpSource: ReactCommandSource = {
   id: "help",
   useItems: (): ReadonlyArray<CommandItem> => {
-    const openReportIssue = useDesktopDialogStore((s) => s.openReportIssue);
+    const reportIssueAvailable = useDesktopDialogStore(
+      (s) => s.reportIssueAvailable,
+    );
+    const keybindings: CommandItem = {
+      id: "help:keybindings",
+      label: "Open keybindings reference",
+      description:
+        "Jump to the keybindings settings panel to see and edit every shortcut.",
+      keywords: ["help", "keybindings", "shortcuts", "hotkeys"],
+      group: "help",
+      scope: "help",
+      shortcut: null,
+      actionId: null,
+      run: (ctx) => ctx.router.navigateSettingsSection("keybindings"),
+      subpage: null,
+    };
+    if (!reportIssueAvailable) return [keybindings];
     return [
-      {
-        id: "help:keybindings",
-        label: "Open keybindings reference",
-        description:
-          "Jump to the keybindings settings panel to see and edit every shortcut.",
-        keywords: ["help", "keybindings", "shortcuts", "hotkeys"],
-        group: "help",
-        scope: "help",
-        shortcut: null,
-        actionId: null,
-        run: (ctx) => ctx.router.navigateSettingsSection("keybindings"),
-        subpage: null,
-      },
+      keybindings,
       {
         id: "help:report-issue",
         label: "Report issue",
@@ -34,7 +38,9 @@ export const helpSource: ReactCommandSource = {
         shortcut: null,
         actionId: null,
         run: () => {
-          openReportIssue();
+          const state = useDesktopDialogStore.getState();
+          if (!state.reportIssueAvailable) return;
+          state.openReportIssue();
         },
         subpage: null,
       },

--- a/clients/gui-app/src/lib/composer/landing-image-gc.ts
+++ b/clients/gui-app/src/lib/composer/landing-image-gc.ts
@@ -40,6 +40,7 @@ import {
 } from "@/stores/home/landing-draft-store";
 import { landingComposerLiveImageHashes } from "@/stores/composer/landing-composer-store";
 import { appLogger, describeLogError } from "@/lib/logger";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 /**
  * Per-partition byte budget for stored landing images. Flagged TUNABLE — shipped
@@ -212,9 +213,18 @@ export function reserveLandingImageBudget(incomingBytes: number): boolean {
   // would destroy unrelated in-progress drafts to make room for it. Block the
   // paste instead — we never evict user drafts for an unattributed paste.
   if (activeDraftId === null) {
-    toast.error("Couldn't add the image.", {
-      description: "It would exceed this window's image storage budget.",
-    });
+    reportableErrorToast(
+      "Couldn't add the image.",
+      {
+        description: "It would exceed this window's image storage budget.",
+      },
+      {
+        title: "Could not add image",
+        message: "The image storage budget was exceeded.",
+        code: null,
+        source: "Chat composer",
+      },
+    );
     return false;
   }
 
@@ -231,9 +241,18 @@ export function reserveLandingImageBudget(incomingBytes: number): boolean {
 
   if (referenced + incomingBytes <= LANDING_IMAGE_BUDGET_BYTES) return true;
 
-  toast.error("Couldn't add the image.", {
-    description: "It would exceed this window's image storage budget.",
-  });
+  reportableErrorToast(
+    "Couldn't add the image.",
+    {
+      description: "It would exceed this window's image storage budget.",
+    },
+    {
+      title: "Could not add image",
+      message: "The image storage budget was exceeded.",
+      code: null,
+      source: "Chat composer",
+    },
+  );
   return false;
 }
 

--- a/clients/gui-app/src/lib/host-error-toast.ts
+++ b/clients/gui-app/src/lib/host-error-toast.ts
@@ -1,5 +1,6 @@
-import { toast } from "sonner";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 /**
  * Maps a HostRpcError to the appropriate toast copy mandated by the
@@ -12,14 +13,34 @@ export function toastFromHostError(
   error: HostRpcError,
   fallback: string,
 ): void {
-  toast.error(hostErrorToastMessage(error, fallback));
+  const message = hostErrorToastMessage(error, fallback);
+  reportableErrorToast(
+    message,
+    undefined,
+    createReportIssueContext({
+      title: "Host operation failed",
+      message: null,
+      code: error.code,
+      source: "Host",
+    }),
+  );
 }
 
 export function toastFromHostErrorWithDetail(
   error: HostRpcError,
   fallback: string,
 ): void {
-  toast.error(hostErrorToastMessageWithDetail(error, fallback));
+  const message = hostErrorToastMessageWithDetail(error, fallback);
+  reportableErrorToast(
+    message,
+    undefined,
+    createReportIssueContext({
+      title: "Host operation failed",
+      message: null,
+      code: error.code,
+      source: "Host",
+    }),
+  );
 }
 
 function hostErrorToastMessage(error: HostRpcError, fallback: string) {

--- a/clients/gui-app/src/lib/report-issue-context.ts
+++ b/clients/gui-app/src/lib/report-issue-context.ts
@@ -31,5 +31,5 @@ function normalizeReportContextValue(value: string | null): string | null {
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length === 0) return null;
   if (normalized.length <= MAX_REPORT_CONTEXT_LENGTH) return normalized;
-  return `${normalized.slice(0, MAX_REPORT_CONTEXT_LENGTH)}…`;
+  return `${normalized.slice(0, MAX_REPORT_CONTEXT_LENGTH - 1)}…`;
 }

--- a/clients/gui-app/src/lib/report-issue-context.ts
+++ b/clients/gui-app/src/lib/report-issue-context.ts
@@ -1,0 +1,35 @@
+const MAX_REPORT_CONTEXT_LENGTH = 300;
+
+export interface ReportIssueContext {
+  readonly title: string;
+  readonly message: string | null;
+  readonly code: string | null;
+  readonly source: string | null;
+}
+
+/**
+ * Normalizes context that the caller has already classified as safe for a
+ * public issue. This function deliberately does not redact or inspect values:
+ * callers must pass fixed product copy, stable codes, and broad source names.
+ */
+export function createReportIssueContext(input: {
+  readonly title: string;
+  readonly message: string | null;
+  readonly code: string | null;
+  readonly source: string | null;
+}): ReportIssueContext {
+  return {
+    title: normalizeReportContextValue(input.title) ?? "Traycer error",
+    message: normalizeReportContextValue(input.message),
+    code: normalizeReportContextValue(input.code),
+    source: normalizeReportContextValue(input.source),
+  };
+}
+
+function normalizeReportContextValue(value: string | null): string | null {
+  if (value === null) return null;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length === 0) return null;
+  if (normalized.length <= MAX_REPORT_CONTEXT_LENGTH) return normalized;
+  return `${normalized.slice(0, MAX_REPORT_CONTEXT_LENGTH)}…`;
+}

--- a/clients/gui-app/src/lib/reportable-error-toast.ts
+++ b/clients/gui-app/src/lib/reportable-error-toast.ts
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { toast, type ExternalToast } from "sonner";
+import type { ReportIssueContext } from "@/lib/report-issue-context";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+export function reportableErrorToast(
+  message: ReactNode,
+  options: ExternalToast | undefined,
+  privacySafeContext: ReportIssueContext,
+): string | number {
+  return showReportableToast(message, options, privacySafeContext, toast.error);
+}
+
+export function reportableWarningToast(
+  message: ReactNode,
+  options: ExternalToast | undefined,
+  privacySafeContext: ReportIssueContext,
+): string | number {
+  return showReportableToast(
+    message,
+    options,
+    privacySafeContext,
+    toast.warning,
+  );
+}
+
+function showReportableToast(
+  message: ReactNode,
+  options: ExternalToast | undefined,
+  privacySafeContext: ReportIssueContext,
+  showToast: typeof toast.error,
+): string | number {
+  const state = useDesktopDialogStore.getState();
+  if (!state.reportIssueAvailable) {
+    if (options === undefined) return showToast(message);
+    if (options.id === undefined) return showToast(message, options);
+    return showToast(message, { ...options, cancel: null });
+  }
+  const cancel =
+    options !== undefined && "cancel" in options
+      ? options.cancel
+      : createReportAction(privacySafeContext);
+  return showToast(message, {
+    ...options,
+    cancel,
+  });
+}
+
+function createReportAction(
+  context: ReportIssueContext,
+): NonNullable<ExternalToast["cancel"]> {
+  return {
+    label: "Report issue",
+    onClick: () => {
+      const current = useDesktopDialogStore.getState();
+      if (!current.reportIssueAvailable) return;
+      current.openReportIssueWithContext(context);
+    },
+  };
+}

--- a/clients/gui-app/src/lib/reportable-error-toast.ts
+++ b/clients/gui-app/src/lib/reportable-error-toast.ts
@@ -34,7 +34,10 @@ function showReportableToast(
   if (!state.reportIssueAvailable) {
     if (options === undefined) return showToast(message);
     if (options.id === undefined) return showToast(message, options);
-    return showToast(message, { ...options, cancel: null });
+    return showToast(
+      message,
+      options.cancel === undefined ? { ...options, cancel: null } : options,
+    );
   }
   const cancel =
     options !== undefined && "cancel" in options

--- a/clients/gui-app/src/lib/runner-error-toast.ts
+++ b/clients/gui-app/src/lib/runner-error-toast.ts
@@ -1,11 +1,17 @@
-import { toast } from "sonner";
 import { readErrorMessage } from "@/lib/read-error-message";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 export function toastFromRunnerError(error: unknown, fallback: string): void {
   const message = readErrorMessage(error);
-  if (message !== null) {
-    toast.error(fallback, { description: message });
-    return;
-  }
-  toast.error(fallback);
+  reportableErrorToast(
+    fallback,
+    message === null ? undefined : { description: message },
+    createReportIssueContext({
+      title: "Desktop operation failed",
+      message: null,
+      code: null,
+      source: "Desktop",
+    }),
+  );
 }

--- a/clients/gui-app/src/lib/toast/toast-channel.ts
+++ b/clients/gui-app/src/lib/toast/toast-channel.ts
@@ -1,4 +1,13 @@
 import { toast } from "sonner";
+import { createReportIssueContext } from "@/lib/report-issue-context";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
+
+const TOAST_CHANNEL_REPORT_CONTEXT = createReportIssueContext({
+  title: "Traycer operation failed",
+  message: null,
+  code: null,
+  source: "Traycer app",
+});
 
 /**
  * A toast "channel" is a single, stable sonner id together with the variant
@@ -31,11 +40,12 @@ export interface ToastChannel {
 function createToastChannel(id: string): ToastChannel {
   return {
     id,
-    message: (message) => toast(message, { id }),
-    success: (message) => toast.success(message, { id }),
-    info: (message) => toast.info(message, { id }),
-    warning: (message) => toast.warning(message, { id }),
-    error: (message) => toast.error(message, { id }),
+    message: (message) => toast(message, { id, cancel: null }),
+    success: (message) => toast.success(message, { id, cancel: null }),
+    info: (message) => toast.info(message, { id, cancel: null }),
+    warning: (message) => toast.warning(message, { id, cancel: null }),
+    error: (message) =>
+      reportableErrorToast(message, { id }, TOAST_CHANNEL_REPORT_CONTEXT),
     dismiss: () => {
       toast.dismiss(id);
     },

--- a/clients/gui-app/src/markdown/__tests__/markdown-anchor.test.tsx
+++ b/clients/gui-app/src/markdown/__tests__/markdown-anchor.test.tsx
@@ -1,6 +1,6 @@
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { ReactNode } from "react";
 import type { ExternalToast } from "sonner";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RunnerHostContext } from "@/providers/runner-host-context";
@@ -153,7 +153,23 @@ describe("MarkdownAnchor", () => {
     ) {
       throw new Error("Expected a report issue action.");
     }
-    cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+    const action = render(
+      <button type="button" onClick={cancel.onClick}>
+        Trigger report issue
+      </button>,
+    );
+
+    useDesktopDialogStore.setState({ reportIssueAvailable: false });
+    fireEvent.click(
+      action.getByRole("button", { name: "Trigger report issue" }),
+    );
+    expect(useDesktopDialogStore.getState().reportIssueContext).toBeNull();
+
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    fireEvent.click(
+      action.getByRole("button", { name: "Trigger report issue" }),
+    );
+    action.unmount();
 
     expect(neutralToast).toHaveBeenCalledTimes(1);
     expect(neutralToast.mock.lastCall?.[0]).toBe("Couldn't open link");

--- a/clients/gui-app/src/markdown/__tests__/markdown-anchor.test.tsx
+++ b/clients/gui-app/src/markdown/__tests__/markdown-anchor.test.tsx
@@ -1,13 +1,32 @@
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import type { ExternalToast } from "sonner";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { RunnerHostContext } from "@/providers/runner-host-context";
 import { TraycerMarkdown } from "@/markdown";
 import { classifyHref } from "@/markdown/links/classify-href";
 import { markdownUrlTransform } from "@/markdown/links/markdown-url-transform";
 import { MarkdownLinkContext } from "@/markdown/links/markdown-link-context";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 
-afterEach(cleanup);
+const neutralToast = vi.hoisted(() =>
+  vi.fn<(message: ReactNode, options: ExternalToast | undefined) => string>(
+    () => "toast-id",
+  ),
+);
+
+vi.mock("sonner", () => ({ toast: neutralToast }));
+
+afterEach(() => {
+  cleanup();
+  neutralToast.mockClear();
+  useDesktopDialogStore.setState({
+    activeDialog: null,
+    reportIssueAvailable: false,
+    reportIssueContext: null,
+  });
+});
 
 function createRunnerHost(): MockRunnerHost {
   return new MockRunnerHost({
@@ -99,6 +118,55 @@ describe("MarkdownAnchor", () => {
       isDirectory: false,
     });
     expect(host.openedExternalLinks).toEqual([]);
+  });
+
+  it("keeps an unresolved-link toast neutral and reports only fixed context", () => {
+    const host = createRunnerHost();
+    const openFileLink = vi.fn(() => false);
+    useDesktopDialogStore.setState({ reportIssueAvailable: true });
+    render(
+      <RunnerHostContext.Provider value={host}>
+        <MarkdownLinkContext.Provider value={{ openFileLink }}>
+          <TraycerMarkdown
+            className={null}
+            proseSize="normal"
+            components={null}
+            remarkPlugins={null}
+            rehypePlugins={null}
+            quotable={false}
+            isStreaming={false}
+          >
+            {"[Private file](/Users/me/private/api-key.txt)"}
+          </TraycerMarkdown>
+        </MarkdownLinkContext.Provider>
+      </RunnerHostContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Private file" }));
+
+    const options = readNeutralToastOptions();
+    const cancel = options.cancel;
+    if (
+      typeof cancel !== "object" ||
+      cancel === null ||
+      !("onClick" in cancel)
+    ) {
+      throw new Error("Expected a report issue action.");
+    }
+    cancel.onClick({} as ReactMouseEvent<HTMLButtonElement>);
+
+    expect(neutralToast).toHaveBeenCalledTimes(1);
+    expect(neutralToast.mock.lastCall?.[0]).toBe("Couldn't open link");
+    expect(cancel.label).toBe("Report issue");
+    expect(useDesktopDialogStore.getState().reportIssueContext).toEqual({
+      title: "Markdown link could not be opened",
+      message: "The requested markdown link could not be opened.",
+      code: null,
+      source: "Markdown link",
+    });
+    expect(JSON.stringify(neutralToast.mock.lastCall)).not.toContain(
+      "/Users/me/private/api-key.txt",
+    );
   });
 
   it("decodes file URLs before routing them through the surface policy", () => {
@@ -205,6 +273,14 @@ describe("MarkdownAnchor", () => {
     expect(host.openedExternalLinks).toEqual([]);
   });
 });
+
+function readNeutralToastOptions(): ExternalToast {
+  const call = neutralToast.mock.lastCall;
+  if (call === undefined || call[1] === undefined) {
+    throw new Error("Expected neutral toast options.");
+  }
+  return call[1];
+}
 
 // The real render order: react-markdown runs `markdownUrlTransform` on the
 // href first, then the anchor classifies the result. Driving the drive-letter

--- a/clients/gui-app/src/markdown/components/markdown-anchor.tsx
+++ b/clients/gui-app/src/markdown/components/markdown-anchor.tsx
@@ -1,8 +1,17 @@
 import { use, useCallback, type MouseEvent, type ReactNode } from "react";
 import { toast } from "sonner";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { RunnerHostContext } from "@/providers/runner-host-context";
 import { classifyHref } from "@/markdown/links/classify-href";
 import { MarkdownLinkContext } from "@/markdown/links/markdown-link-context";
+import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+
+const MARKDOWN_LINK_REPORT_CONTEXT = createReportIssueContext({
+  title: "Markdown link could not be opened",
+  message: "The requested markdown link could not be opened.",
+  code: null,
+  source: "Markdown link",
+});
 
 interface MarkdownAnchorProps {
   href?: string;
@@ -32,6 +41,12 @@ export function MarkdownAnchor({
 }: MarkdownAnchorProps) {
   const runnerHost = use(RunnerHostContext);
   const linkPolicy = use(MarkdownLinkContext);
+  const reportIssueAvailable = useDesktopDialogStore(
+    (state) => state.reportIssueAvailable,
+  );
+  const openReportIssueWithContext = useDesktopDialogStore(
+    (state) => state.openReportIssueWithContext,
+  );
 
   const routeLinkClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>): void => {
@@ -59,13 +74,32 @@ export function MarkdownAnchor({
           col: classified.col,
           isDirectory: false,
         });
-        if (opened === false) toast("Couldn't open link");
+        if (opened === false) {
+          toast(
+            "Couldn't open link",
+            reportIssueAvailable
+              ? {
+                  cancel: {
+                    label: "Report issue",
+                    onClick: () =>
+                      openReportIssueWithContext(MARKDOWN_LINK_REPORT_CONTEXT),
+                  },
+                }
+              : undefined,
+          );
+        }
         return;
       }
 
       if (runnerHost !== null) void runnerHost.openExternalLink(classified.url);
     },
-    [href, linkPolicy, runnerHost],
+    [
+      href,
+      linkPolicy,
+      openReportIssueWithContext,
+      reportIssueAvailable,
+      runnerHost,
+    ],
   );
 
   return (

--- a/clients/gui-app/src/markdown/components/markdown-anchor.tsx
+++ b/clients/gui-app/src/markdown/components/markdown-anchor.tsx
@@ -44,10 +44,6 @@ export function MarkdownAnchor({
   const reportIssueAvailable = useDesktopDialogStore(
     (state) => state.reportIssueAvailable,
   );
-  const openReportIssueWithContext = useDesktopDialogStore(
-    (state) => state.openReportIssueWithContext,
-  );
-
   const routeLinkClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>): void => {
       // Same-document anchors should keep native browser hash scrolling.
@@ -81,8 +77,13 @@ export function MarkdownAnchor({
               ? {
                   cancel: {
                     label: "Report issue",
-                    onClick: () =>
-                      openReportIssueWithContext(MARKDOWN_LINK_REPORT_CONTEXT),
+                    onClick: () => {
+                      const current = useDesktopDialogStore.getState();
+                      if (!current.reportIssueAvailable) return;
+                      current.openReportIssueWithContext(
+                        MARKDOWN_LINK_REPORT_CONTEXT,
+                      );
+                    },
                   },
                 }
               : undefined,
@@ -93,13 +94,7 @@ export function MarkdownAnchor({
 
       if (runnerHost !== null) void runnerHost.openExternalLink(classified.url);
     },
-    [
-      href,
-      linkPolicy,
-      openReportIssueWithContext,
-      reportIssueAvailable,
-      runnerHost,
-    ],
+    [href, linkPolicy, reportIssueAvailable, runnerHost],
   );
 
   return (

--- a/clients/gui-app/src/markdown/components/mermaid-block.tsx
+++ b/clients/gui-app/src/markdown/components/mermaid-block.tsx
@@ -170,7 +170,7 @@ function MermaidRenderSession(props: {
 
       <figure
         className="tc-node-mermaid__preview m-0"
-        role="img"
+        role={render.status === "error" ? undefined : "img"}
         aria-label={ariaLabel}
       >
         {render.status === "pending" ? (

--- a/clients/gui-app/src/markdown/components/mermaid-block.tsx
+++ b/clients/gui-app/src/markdown/components/mermaid-block.tsx
@@ -1,4 +1,5 @@
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { MermaidBlockToolbar } from "@/editor-core/nodes/mermaid/mermaid-block-toolbar";
 import { MermaidFullscreenDialog } from "@/editor-core/nodes/mermaid/mermaid-fullscreen-dialog";
 import {
@@ -12,6 +13,7 @@ import { useMermaidPngDownload } from "@/editor-core/nodes/mermaid/use-mermaid-p
 import { useMermaidThemeKey } from "@/editor-core/nodes/mermaid/use-mermaid-theme-key";
 import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
 import { trustedMarkupToReactNodes } from "@/lib/trusted-markup";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
@@ -189,6 +191,16 @@ function MermaidRenderSession(props: {
               Mermaid parse error
             </div>
             <div className="tc-node-block__error-detail">{render.error}</div>
+            <ReportIssueAction
+              context={createReportIssueContext({
+                title: "Mermaid parse error",
+                message: null,
+                code: null,
+                source: "Chat diagram",
+              })}
+              presentation="icon"
+              className={undefined}
+            />
           </div>
         ) : null}
       </figure>

--- a/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-access-coordinator.test.tsx
@@ -187,7 +187,7 @@ describe("EpicAccessCoordinator", () => {
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
     expect(toastInfo).toHaveBeenCalledWith(
       'Epic "Epic One" was deleted by Alice',
-      { id: "epic-access:epic-1" },
+      { id: "epic-access:epic-1", cancel: null },
     );
   });
 
@@ -214,7 +214,7 @@ describe("EpicAccessCoordinator", () => {
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
     expect(toastInfo).toHaveBeenCalledWith(
       expect.stringContaining("no longer have access"),
-      { id: "epic-access:epic-1" },
+      { id: "epic-access:epic-1", cancel: null },
     );
   });
 
@@ -252,6 +252,7 @@ describe("EpicAccessCoordinator", () => {
     );
     expect(toastInfo).toHaveBeenCalledWith('Epic "Background" was deleted', {
       id: "epic-access:epic-bg",
+      cancel: null,
     });
   });
 
@@ -282,7 +283,7 @@ describe("EpicAccessCoordinator", () => {
     await waitFor(() => expect(router.state.location.pathname).toBe("/"));
     expect(toastInfo).toHaveBeenCalledWith(
       expect.stringContaining("no longer available"),
-      { id: "epic-access:epic-1" },
+      { id: "epic-access:epic-1", cancel: null },
     );
   });
 
@@ -372,7 +373,7 @@ describe("EpicAccessCoordinator", () => {
     ]);
     expect(toastInfo).toHaveBeenCalledWith(
       'Epic "Broadcast Title" was deleted',
-      { id: "epic-access:epic-1" },
+      { id: "epic-access:epic-1", cancel: null },
     );
   });
 });

--- a/clients/gui-app/src/routes/epic-tab-route-components.tsx
+++ b/clients/gui-app/src/routes/epic-tab-route-components.tsx
@@ -3,11 +3,13 @@ import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
 import { EpicShell } from "@/components/epic-canvas/epic-shell";
 import { EpicRouteSessionBody } from "@/components/epic-canvas/epic-route-session-body";
+import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { useCloudEpicTasksQuery } from "@/hooks/epics/use-cloud-epic-tasks-query";
 import { usePhaseMigrateToEpic } from "@/hooks/migration/use-phase-migrate-to-epic-mutation";
 import { EpicSessionProvider } from "@/providers/epic-session-provider";
+import { createReportIssueContext } from "@/lib/report-issue-context";
 import {
   navigateToTabIntent,
   openOrFocusEpicIntent,
@@ -219,19 +221,31 @@ function PhaseToEpicMigrationGateInner(props: {
               </p>
             ) : null}
             {migration.isError ? (
-              <Button
-                onClick={() =>
-                  migration.mutate(
-                    { phaseId: props.phaseId },
-                    { onSuccess: (data) => openMigratedEpic(data.epicId) },
-                  )
-                }
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                Re-attempt migration
-              </Button>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  onClick={() =>
+                    migration.mutate(
+                      { phaseId: props.phaseId },
+                      { onSuccess: (data) => openMigratedEpic(data.epicId) },
+                    )
+                  }
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  Re-attempt migration
+                </Button>
+                <ReportIssueAction
+                  context={createReportIssueContext({
+                    title: "Phase migration did not finish",
+                    message: "The legacy Phase migration did not complete.",
+                    code: null,
+                    source: "Phase migration",
+                  })}
+                  presentation="text"
+                  className={undefined}
+                />
+              </div>
             ) : null}
           </div>
         </div>

--- a/clients/gui-app/src/routes/root-route-components.tsx
+++ b/clients/gui-app/src/routes/root-route-components.tsx
@@ -37,8 +37,8 @@ export function RootComponent() {
           HostReadyGate so they keep working while the page is gated on host
           readiness (the "Setting up Traycer Host…" screen). The menu command
           listener routes native menu items; the dialog host renders
-          About/Logs/Report (which read the desktop support bridge, not host
-          RPC). Both only depend on the runner host + auth + local stores, all
+          host-independent About/Logs dialogs. Both only depend on the runner
+          host + auth + local stores, all
           available without a ready host. */}
       <MenuCommandListener />
       <DesktopDialogHost />

--- a/clients/gui-app/src/stores/dialogs/desktop-dialog-store.ts
+++ b/clients/gui-app/src/stores/dialogs/desktop-dialog-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { ReportIssueContext } from "@/lib/report-issue-context";
 
 export type DesktopDialogKind =
   | "about-details"
@@ -10,10 +11,16 @@ export type DesktopDialogKind =
 
 export interface DesktopDialogState {
   readonly activeDialog: DesktopDialogKind | null;
+  readonly reportIssueAvailable: boolean;
+  readonly reportIssueContext: ReportIssueContext | null;
+  readonly reportIssueDraftId: number;
   readonly openAboutDetails: () => void;
   readonly openLogs: () => void;
   readonly openEpicInNewWindow: () => void;
   readonly openReportIssue: () => void;
+  readonly openReportIssueWithContext: (context: ReportIssueContext) => void;
+  readonly closeReportIssueDraft: (draftId: number) => void;
+  readonly setReportIssueAvailable: (available: boolean) => void;
   readonly openConfirmRestartUpdate: () => void;
   readonly openInstallGuidance: () => void;
   readonly close: () => void;
@@ -21,6 +28,9 @@ export interface DesktopDialogState {
 
 export const useDesktopDialogStore = create<DesktopDialogState>((set) => ({
   activeDialog: null,
+  reportIssueAvailable: false,
+  reportIssueContext: null,
+  reportIssueDraftId: 0,
   openAboutDetails: () => {
     set({ activeDialog: "about-details" });
   },
@@ -31,7 +41,29 @@ export const useDesktopDialogStore = create<DesktopDialogState>((set) => ({
     set({ activeDialog: "open-epic-in-new-window" });
   },
   openReportIssue: () => {
-    set({ activeDialog: "report-issue" });
+    set((state) => ({
+      activeDialog: "report-issue",
+      reportIssueContext: null,
+      reportIssueDraftId: state.reportIssueDraftId + 1,
+    }));
+  },
+  openReportIssueWithContext: (context) => {
+    set((state) => ({
+      activeDialog: "report-issue",
+      reportIssueContext: context,
+      reportIssueDraftId: state.reportIssueDraftId + 1,
+    }));
+  },
+  closeReportIssueDraft: (draftId) => {
+    set((state) =>
+      state.activeDialog === "report-issue" &&
+      state.reportIssueDraftId === draftId
+        ? { activeDialog: null, reportIssueContext: null }
+        : state,
+    );
+  },
+  setReportIssueAvailable: (available) => {
+    set({ reportIssueAvailable: available });
   },
   openConfirmRestartUpdate: () => {
     set({ activeDialog: "confirm-restart-update" });
@@ -40,6 +72,6 @@ export const useDesktopDialogStore = create<DesktopDialogState>((set) => ({
     set({ activeDialog: "install-guidance" });
   },
   close: () => {
-    set({ activeDialog: null });
+    set({ activeDialog: null, reportIssueContext: null });
   },
 }));

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -5,6 +5,7 @@ import { HostOperationStatusListener } from "@/components/layout/bridges/host-op
 import { HostRegistryUpdateListener } from "@/components/layout/bridges/host-registry-update-listener";
 import { RunnerHostBridges } from "@/components/layout/bridges/runner-host-bridges";
 import { WorktreeDeleteProgressToastBridge } from "@/components/layout/bridges/worktree-delete-progress-toast-bridge";
+import { ReportIssueDialogHost } from "@/components/layout/dialogs/report-issue-dialog-host";
 import { CenteredCard } from "@/components/centered-card";
 import { RootErrorBoundary } from "@/components/errors/root-error-boundary";
 import { Toaster } from "@/components/ui/sonner";
@@ -122,6 +123,8 @@ export function TraycerApp(props: TraycerAppProps): ReactNode {
               <TooltipProvider>
                 <KeybindingProvider router={router}>
                   <DesktopZoomController />
+                  <ReportIssueDialogHost />
+                  <Toaster />
                   <HostRuntimeProvider
                     registry={props.registry}
                     messengerFactory={props.messengerFactory ?? null}
@@ -212,7 +215,6 @@ function TraycerAppRuntimeSurface(props: TraycerAppRuntimeSurfaceProps) {
       <HistoryPruneProvider router={props.router} />
       <RouterProvider router={props.router} />
       <HostPicker />
-      <Toaster />
     </>
   );
 }

--- a/protocol/src/comments/__tests__/comments-xml-formatting.test.ts
+++ b/protocol/src/comments/__tests__/comments-xml-formatting.test.ts
@@ -103,9 +103,9 @@ body &amp; &lt;tag&gt;
 </comment>
 </thread>
 
-<thread id="thread-resolved" created_at="2026-06-17T10:20:00.000Z" status="resolved">
+<thread id="thread-resolved" user_id="user-2" created_at="2026-06-17T10:20:00.000Z" status="resolved">
 <quoted_section anchor="unavailable" reason="failed to parse anchor position">old wording</quoted_section>
-<comment id="comment-2" n="1" created_at="2026-06-17T10:21:00.000Z" edited_at="2026-06-17T10:22:00.000Z">
+<comment id="comment-2" n="1" user_id="user-2" created_at="2026-06-17T10:21:00.000Z" edited_at="2026-06-17T10:22:00.000Z">
 fixed
 </comment>
 </thread>

--- a/protocol/src/comments/comments-xml-formatting.ts
+++ b/protocol/src/comments/comments-xml-formatting.ts
@@ -93,7 +93,10 @@ function serializeThread(
   platform: "POSIX" | "WINDOWS",
 ): string {
   const { thread } = input;
-  const author = authorName(thread.data.createdByHandle ?? null);
+  const author = authorAttribute(
+    thread.data.createdByHandle ?? null,
+    thread.data.createdByUserId,
+  );
   const attrs = [
     attribute("id", thread.threadId),
     author,
@@ -118,7 +121,10 @@ function serializeThread(
   }
 
   thread.comments.forEach((comment, index) => {
-    const commentAuthor = authorName(comment.author.fallbackHandle);
+    const commentAuthor = authorAttribute(
+      comment.author.fallbackHandle,
+      comment.author.userId,
+    );
     const commentAttrs = [
       attribute("id", comment.commentId),
       attribute("n", String(index + 1)),
@@ -144,9 +150,22 @@ function serializeThread(
   return lines.join("\n");
 }
 
-function authorName(providerHandle: string | null): string | null {
+// Legacy comments were persisted before author handles were guaranteed at
+// write time; fall back to the stable user id (as `user_id=`, mirroring what
+// the GUI shows) so the model always gets an attribution signal instead of an
+// anonymous comment.
+function authorAttribute(
+  providerHandle: string | null,
+  userId: string,
+): string | null {
   const trimmedHandle = providerHandle?.trim() ?? "";
-  return trimmedHandle.length > 0 ? attribute("author", trimmedHandle) : null;
+  if (trimmedHandle.length > 0) {
+    return attribute("author", trimmedHandle);
+  }
+  const trimmedUserId = userId.trim();
+  return trimmedUserId.length > 0
+    ? attribute("user_id", trimmedUserId)
+    : null;
 }
 
 function attribute(name: string, value: string): string {


### PR DESCRIPTION
## Summary

- add capability-gated Report issue actions across desktop error toasts, banners, warning failures, and blocking recovery states
- keep report drafts privacy-safe by requiring fixed product context and excluding raw errors, paths, identifiers, credentials, and unconstrained harness codes
- harden dialog submission races, support-capability changes, stable-ID toast replacement, and top-level crash reporting
- preserve recovery hierarchy, compact responsive layouts, modal accessibility, and existing toast severity/actions

## Verification

- GUI lint passed
- GUI and desktop TypeScript compilation passed
- full GUI suite: 5,017 passed, 1 skipped
- repository pre-commit lint, format, compile, build, and DCO checks passed
- git diff --check passed