### PR TITLE
fix(gui-app): share rate-limit switch-prompt dismissals across composers

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/profile-durability-d2-d3-rate-limit-switch.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/profile-durability-d2-d3-rate-limit-switch.test.tsx
@@ -64,6 +64,7 @@ import { useProviderReauthGate } from "../use-provider-reauth-gate";
 import { useProfileRateLimitSwitchPrompt } from "../use-profile-rate-limit-switch-prompt";
 import { ProfileRateLimitSwitchBanner } from "../profile-rate-limit-switch-banner";
 import { resolveComposerTopBannerKind } from "../chat-composer-top-banner";
+import { useRateLimitSwitchPromptDismissalsStore } from "@/stores/rate-limits/rate-limit-switch-prompt-dismissals-store";
 
 function profile(
   profileId: string,
@@ -278,6 +279,9 @@ describe("D2: rate-limit switch prompt race (stale click vs. live re-validation)
     mocks.refresh.mockClear();
     mocks.toastSuccess.mockClear();
     mocks.toastError.mockClear();
+    useRateLimitSwitchPromptDismissalsStore.setState({
+      dismissedKeys: new Set<string>(),
+    });
   });
 
   it("shows ambient drift before rate-limit and moves to rate-limit after acknowledging drift without submitting", () => {
@@ -469,6 +473,9 @@ describe("D2: rate-limit switch prompt race (stale click vs. live re-validation)
 describe("D3: every profile of the provider is hard-limited", () => {
   beforeEach(() => {
     mocks.providers = [];
+    useRateLimitSwitchPromptDismissalsStore.setState({
+      dismissedKeys: new Set<string>(),
+    });
   });
   afterEach(() => {
     cleanup();

--- a/clients/gui-app/src/components/chat/composer/__tests__/use-profile-rate-limit-switch-prompt.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/use-profile-rate-limit-switch-prompt.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ProviderCliState,
@@ -19,6 +19,7 @@ vi.mock("@/hooks/providers/use-tab-providers-list-query", () => ({
 }));
 
 import { useProfileRateLimitSwitchPrompt } from "../use-profile-rate-limit-switch-prompt";
+import { useRateLimitSwitchPromptDismissalsStore } from "@/stores/rate-limits/rate-limit-switch-prompt-dismissals-store";
 
 function profile(
   profileId: string,
@@ -74,6 +75,9 @@ function claudeState(profiles: ProviderProfile[]): ProviderCliState {
 describe("useProfileRateLimitSwitchPrompt", () => {
   beforeEach(() => {
     mocks.providers = [];
+    useRateLimitSwitchPromptDismissalsStore.setState({
+      dismissedKeys: new Set<string>(),
+    });
   });
 
   it("stays inert with fewer than 2 profiles even if somehow marked limited", () => {
@@ -167,6 +171,32 @@ describe("useProfileRateLimitSwitchPrompt", () => {
       useProfileRateLimitSwitchPrompt("claude", null, true),
     );
     expect(result.current.hardLimited).toBe(true);
+  });
+
+  it("shares a dismissal across every hook instance (dismiss in one composer hides it everywhere)", () => {
+    mocks.providers = [
+      claudeState([
+        profile("ambient", "ambient", "Terminal account", "near_limit"),
+        profile("work-uuid", "managed", "Work", "ok"),
+      ]),
+    ];
+    const first = renderHook(() =>
+      useProfileRateLimitSwitchPrompt("claude", null, true),
+    );
+    const second = renderHook(() =>
+      useProfileRateLimitSwitchPrompt("claude", null, true),
+    );
+    expect(first.result.current.limited).toBe(true);
+    expect(second.result.current.limited).toBe(true);
+
+    act(() => {
+      first.result.current.dismiss();
+    });
+    first.rerender();
+    second.rerender();
+
+    expect(first.result.current.limited).toBe(false);
+    expect(second.result.current.limited).toBe(false);
   });
 
   it("stays inert when the composer is inactive", () => {

--- a/clients/gui-app/src/components/chat/composer/__tests__/use-profile-rate-limit-switch-prompt.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/use-profile-rate-limit-switch-prompt.test.tsx
@@ -192,8 +192,6 @@ describe("useProfileRateLimitSwitchPrompt", () => {
     act(() => {
       first.result.current.dismiss();
     });
-    first.rerender();
-    second.rerender();
 
     expect(first.result.current.limited).toBe(false);
     expect(second.result.current.limited).toBe(false);

--- a/clients/gui-app/src/components/chat/composer/use-profile-rate-limit-switch-prompt.ts
+++ b/clients/gui-app/src/components/chat/composer/use-profile-rate-limit-switch-prompt.ts
@@ -1,7 +1,8 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import { useTabProvidersList } from "@/hooks/providers/use-tab-providers-list-query";
+import { useRateLimitSwitchPromptDismissalsStore } from "@/stores/rate-limits/rate-limit-switch-prompt-dismissals-store";
 import {
   profileCommitId,
   profileDisplayLabel,
@@ -38,7 +39,8 @@ export interface ProfileRateLimitSwitchPrompt {
    *  after dismissal while the underlying rate-limit condition still holds. */
   readonly current: ProfileRateLimitProfileChip | null;
   readonly alternatives: ReadonlyArray<ProfileRateLimitAlternative>;
-  /** Hides this exact warning for the lifetime of the composer. A change in
+  /** Hides this exact warning in EVERY composer for the rest of the app
+   *  session (shared dismissal store, not per-composer state). A change in
    *  source profile, severity, or viable alternatives creates a new warning. */
   readonly dismiss: () => void;
 }
@@ -62,8 +64,8 @@ export function useProfileRateLimitSwitchPrompt(
   profileId: string | null,
   active: boolean,
 ): ProfileRateLimitSwitchPrompt {
-  const [dismissedPromptKey, setDismissedPromptKey] = useState<string | null>(
-    null,
+  const dismissPromptKey = useRateLimitSwitchPromptDismissalsStore(
+    (state) => state.dismiss,
   );
   const providerId = providerIdForHarness(harnessId);
   const enabled = active && providerId !== null;
@@ -111,9 +113,14 @@ export function useProfileRateLimitSwitchPrompt(
           hardLimited,
           alternatives.map((alternative) => alternative.accentDotId).sort(),
         ]);
+  // Subscribes to this exact key's dismissed bit (a boolean, so a dismissal
+  // of an unrelated prompt key never re-renders this composer).
+  const dismissed = useRateLimitSwitchPromptDismissalsStore(
+    (state) => promptKey !== null && state.dismissedKeys.has(promptKey),
+  );
   const dismiss = useCallback((): void => {
-    if (promptKey !== null) setDismissedPromptKey(promptKey);
-  }, [promptKey]);
+    if (promptKey !== null) dismissPromptKey(promptKey);
+  }, [dismissPromptKey, promptKey]);
 
   if (currentChip === null || promptKey === null) {
     return {
@@ -126,7 +133,7 @@ export function useProfileRateLimitSwitchPrompt(
   }
 
   return {
-    limited: alternatives.length > 0 && dismissedPromptKey !== promptKey,
+    limited: alternatives.length > 0 && !dismissed,
     hardLimited,
     current: currentChip,
     alternatives,

--- a/clients/gui-app/src/stores/rate-limits/rate-limit-switch-prompt-dismissals-store.ts
+++ b/clients/gui-app/src/stores/rate-limits/rate-limit-switch-prompt-dismissals-store.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+
+/**
+ * App-wide registry of dismissed rate-limit switch prompts, keyed by the
+ * prompt key `useProfileRateLimitSwitchPrompt` derives (harness + limited
+ * profile + severity + viable alternatives). The same limited profile is
+ * typically selected in several composers at once (multiple chat tabs, the
+ * home composer), and each used to hold its own dismissed flag - dismissing
+ * the banner in one tab left it standing everywhere else. One shared set
+ * makes a dismissal stick across every composer.
+ *
+ * Deliberately in-memory (not persisted): a dismissal should outlive tab
+ * switches, not app restarts - rate-limit state moves constantly, and any
+ * material change (severity, alternatives) already re-arms the prompt via a
+ * new key.
+ */
+interface RateLimitSwitchPromptDismissalsState {
+  readonly dismissedKeys: ReadonlySet<string>;
+  readonly dismiss: (promptKey: string) => void;
+}
+
+export const useRateLimitSwitchPromptDismissalsStore =
+  create<RateLimitSwitchPromptDismissalsState>()((set, get) => ({
+    dismissedKeys: new Set<string>(),
+    dismiss: (promptKey) => {
+      const { dismissedKeys } = get();
+      if (dismissedKeys.has(promptKey)) return;
+      set({ dismissedKeys: new Set([...dismissedKeys, promptKey]) });
+    },
+  }));


### PR DESCRIPTION
## Summary
- Dismissing the "is close to its rate limit" banner in one chat tab left it showing in every other tab and the home composer — each composer held its own dismissed-flag in local `useState`.
- Move the dismissed-key set into a shared Zustand store (`rate-limit-switch-prompt-dismissals-store.ts`) so a dismissal for a given `(harness, profile, severity, alternatives)` key sticks everywhere until something material changes (new severity, different alternatives, different profile).

## Test plan
- [x] `bun run compile` (gui-app)
- [x] `bun run test` — `use-profile-rate-limit-switch-prompt.test.tsx`, `profile-durability-d2-d3-rate-limit-switch.test.tsx`, `profile-durability-d6-pre-feature-chat.test.tsx` (17 passed), including a new test asserting dismissal in one hook instance hides the banner in a second instance
- [x] `react-doctor --diff main` clean on changed files
- [x] eslint clean

Companion fix (banner firing too early on long-window usage) is in the internal `traycer-host` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)