### PR TITLE
fix(gui-app): make PR number searchable in worktree settings

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel-states.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel-states.test.tsx
@@ -372,7 +372,7 @@ describe("WorktreesSettingsPanel host-scoped states", () => {
       screen.getByText("feat-clean");
     });
     screen.getByTestId("worktrees-host-select");
-    screen.getByPlaceholderText("Search repo, branch, path, or Task");
+    screen.getByPlaceholderText("Search repo, branch, path, PR, or Task");
     screen.getByTestId("worktrees-filter-trigger");
     screen.getByTestId("worktrees-sort-trigger");
     screen.getByRole("button", { name: "Refresh worktrees" });

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -3693,4 +3693,44 @@ describe("WorktreesList PR-number search", () => {
     screen.getByText("No worktrees match your search.");
     expect(screen.queryByText(/still checking/)).toBeNull();
   });
+
+  it("suppresses the 'still checking' notice while a tier filter is active", () => {
+    // A pending row bypasses the tier stage only WHILE it's pending (see
+    // `filteredWorktrees`) - once it resolves it might land in a tier the
+    // active filter excludes, and the search would never surface it despite
+    // the notice having promised to. `/wt/atbase` is enriched purely so
+    // "At base commit" is an available filter option to select; the two rows
+    // that matter, `/wt/super-pr` and `/wt/other-pending`, are left pending
+    // and irrelevant to the "4360" query either way.
+    const atBase = entry({
+      worktreePath: "/wt/atbase",
+      branch: "feat-atbase",
+      atBaseCommit: true,
+    });
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: [
+        entry({ worktreePath: "/wt/super-pr", branch: "feat-super-pr" }),
+        entry({
+          worktreePath: "/wt/other-pending",
+          branch: "feat-other-pending",
+        }),
+        atBase,
+      ],
+      enrichedByPath: new Map([[atBase.worktreePath, atBase]]),
+      erroredPaths: undefined,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    fireEvent.click(screen.getByTestId("worktrees-filter-at-base-commit"));
+    search("4360");
+
+    expect(
+      screen.queryByRole("button", { name: "Delete worktree feat-super-pr" }),
+    ).toBeNull();
+    screen.getByText("No worktrees match your search.");
+    expect(screen.queryByText(/still checking/)).toBeNull();
+  });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -3532,3 +3532,165 @@ describe("WorktreesList status-aware delete safety", () => {
     expect(streamMock.paths).toEqual(["/wt/errored-dirty"]);
   });
 });
+
+describe("WorktreesList PR-number search", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // The BASE listing exactly as the host serves it: `prNumber` pinned to null on
+  // every row (see `worktree-setup-orchestrator`'s base shape). PR facts do not
+  // exist here - they only arrive on the enrichment overlay below. Building the
+  // fixture this way is what makes the un-enriched cases honest.
+  const PR_BASE: readonly WorktreeHostEntryV12[] = [
+    entry({ worktreePath: "/wt/super-pr", branch: "feat-super-pr" }),
+    entry({ worktreePath: "/wt/sub-pr", branch: "feat-sub-pr" }),
+    entry({ worktreePath: "/wt/no-pr", branch: "feat-no-pr" }),
+  ];
+
+  // What those rows resolve to once probed: a superproject PR, a submodule-only
+  // PR, and a row that genuinely has none.
+  const PR_ENRICHED: readonly WorktreeHostEntryV12[] = [
+    entry({
+      worktreePath: "/wt/super-pr",
+      branch: "feat-super-pr",
+      prState: "merged",
+      prNumber: 4360,
+      prUrl: "https://github.com/acme/app/pull/4360",
+    }),
+    entry({
+      worktreePath: "/wt/sub-pr",
+      branch: "feat-sub-pr",
+      submodules: [
+        {
+          repoIdentifier: { owner: "acme", repo: "sub" },
+          branch: "feat-sub-pr",
+          prState: "open",
+          prNumber: 256,
+          prUrl: "https://github.com/acme/sub/pull/256",
+          mergedHeadShaMatches: false,
+          mergedIntoDefault: false,
+          atPinnedCommit: false,
+        },
+      ],
+    }),
+    entry({ worktreePath: "/wt/no-pr", branch: "feat-no-pr" }),
+  ];
+
+  // The overlay with the named paths held back - i.e. still awaiting their probe.
+  function enrichedExcept(
+    unprobedPaths: readonly string[],
+  ): ReadonlyMap<string, WorktreeHostEntryV12> {
+    return new Map(
+      PR_ENRICHED.filter(
+        (worktree) => !unprobedPaths.includes(worktree.worktreePath),
+      ).map((worktree) => [worktree.worktreePath, worktree]),
+    );
+  }
+
+  function search(value: string): void {
+    fireEvent.change(
+      screen.getByRole("searchbox", { name: "Search worktrees" }),
+      { target: { value } },
+    );
+  }
+
+  function renderPrList(args: {
+    readonly enrichedByPath: ReadonlyMap<string, WorktreeHostEntryV12>;
+    readonly erroredPaths: ReadonlySet<string> | undefined;
+  }): void {
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: PR_BASE,
+      enrichedByPath: args.enrichedByPath,
+      erroredPaths: args.erroredPaths,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+  }
+
+  function visibleBranches(): readonly string[] {
+    return PR_BASE.map((worktree) => worktree.branch).filter(
+      (branch): branch is string =>
+        branch !== null &&
+        screen.queryByRole("button", { name: `Delete worktree ${branch}` }) !==
+          null,
+    );
+  }
+
+  it.each([
+    ["4360", "feat-super-pr"],
+    ["#4360", "feat-super-pr"],
+    // The submodule leg is indexed too - the row wears a `#256` pill, so the
+    // number on that pill has to find it.
+    ["256", "feat-sub-pr"],
+    ["#256", "feat-sub-pr"],
+  ])("narrows to the row owning PR %s", (query, expectedBranch) => {
+    renderPrList({
+      enrichedByPath: enrichedExcept([]),
+      erroredPaths: undefined,
+    });
+    search(query);
+    expect(visibleBranches()).toEqual([expectedBranch]);
+  });
+
+  it("still matches repo, branch, path, and Task after the PR leg is added", () => {
+    renderPrList({
+      enrichedByPath: enrichedExcept([]),
+      erroredPaths: undefined,
+    });
+    // The PR index is a UNION with the text haystack, never a replacement: a
+    // non-PR query must keep behaving exactly as it did before.
+    search("feat-no-pr");
+    expect(visibleBranches()).toEqual(["feat-no-pr"]);
+    search("acme/app");
+    expect(visibleBranches()).toEqual([
+      "feat-super-pr",
+      "feat-sub-pr",
+      "feat-no-pr",
+    ]);
+  });
+
+  it("reads 'still checking' - not 'no matches' - while the PR row is un-enriched", () => {
+    // `/wt/super-pr` is held back from the overlay, so its base row still carries
+    // `prNumber: null`. It genuinely cannot match `4360` yet - but claiming "no
+    // matches" would be a lie, because the worktree being looked for is right
+    // there, one probe away.
+    renderPrList({
+      enrichedByPath: enrichedExcept(["/wt/super-pr"]),
+      erroredPaths: undefined,
+    });
+    search("4360");
+
+    expect(visibleBranches()).toEqual([]);
+    screen.getByText("No matches yet - still checking 1 worktree.");
+    expect(screen.queryByText("No worktrees match your search.")).toBeNull();
+  });
+
+  it("settles to 'no matches' once every probe has landed", () => {
+    renderPrList({
+      enrichedByPath: enrichedExcept([]),
+      erroredPaths: undefined,
+    });
+    search("9999");
+
+    expect(visibleBranches()).toEqual([]);
+    screen.getByText("No worktrees match your search.");
+  });
+
+  it("does not hold the 'still checking' notice open for an errored row", () => {
+    // An errored row is un-enriched too, but its probe SETTLED - it will never
+    // learn its PR number. Counting it would pin the spinner on forever, so the
+    // empty state has to fall through to the plain no-match copy.
+    renderPrList({
+      enrichedByPath: enrichedExcept(["/wt/super-pr"]),
+      erroredPaths: new Set(["/wt/super-pr"]),
+    });
+    search("4360");
+
+    expect(visibleBranches()).toEqual([]);
+    screen.getByText("No worktrees match your search.");
+    expect(screen.queryByText(/still checking/)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -900,18 +900,6 @@ export function WorktreesList(props: {
     () => buildWorktreePrHaystackByPath(mergedWorktrees),
     [mergedWorktrees],
   );
-  // Rows still waiting on their probe. A PR-number query CANNOT match them yet
-  // (their `prNumber` is null), so an empty result set only honestly reads "no
-  // matches" once this hits zero - until then the empty state says "still
-  // checking". Errored rows are excluded deliberately: they settle to "Unknown"
-  // and will never enrich, so counting them would hold the notice open forever.
-  const stillCheckingCount = useMemo(
-    () =>
-      mergedWorktrees.filter(
-        (entry) => enrichmentStateFor(entry.worktreePath) === "pending",
-      ).length,
-    [mergedWorktrees, enrichmentStateFor],
-  );
   // Only offer filter options for tiers actually present in this host's list.
   // Un-enriched rows have no known tier, so they cannot contribute an option -
   // the menu fills in as rows enrich (on-screen rows first, then the
@@ -924,6 +912,34 @@ export function WorktreesList(props: {
     }
     return WORKTREE_TIER_ORDER.filter((tier) => present.has(tier));
   }, [mergedWorktrees, isPending]);
+  // Intersects the raw selection with the tiers actually present (mirroring
+  // `worktreeTierFilterLabel`): a stale selection for a now-absent tier is
+  // ignored, so the effective filter is empty and every row shows, matching
+  // the "All" the toolbar reads. Hoisted so the tier-filter stage below and the
+  // "still checking" notice agree on whether a filter is ACTUALLY narrowing
+  // the list.
+  const effectiveTierFilters = useMemo(
+    () => new Set(availableTiers.filter((tier) => tierFilters.has(tier))),
+    [availableTiers, tierFilters],
+  );
+  // Rows still waiting on their probe. A PR-number query CANNOT match them yet
+  // (their `prNumber` is null), so an empty result set only honestly reads "no
+  // matches" once this hits zero - until then the empty state says "still
+  // checking". Errored rows are excluded deliberately: they settle to "Unknown"
+  // and will never enrich, so counting them would hold the notice open forever.
+  //
+  // Suppressed entirely while a tier filter is active: a pending row bypasses
+  // the tier stage only WHILE it's pending (see `filteredWorktrees` below) - if
+  // it resolves into an excluded tier, it drops out right where a plain PR
+  // match would otherwise have shown it. Promising "still checking" in that
+  // case overclaims; the tier-filtered empty state falls back to the honest
+  // plain "no matches" copy instead.
+  const stillCheckingCount = useMemo(() => {
+    if (effectiveTierFilters.size > 0) return 0;
+    return mergedWorktrees.filter(
+      (entry) => enrichmentStateFor(entry.worktreePath) === "pending",
+    ).length;
+  }, [mergedWorktrees, enrichmentStateFor, effectiveTierFilters]);
   // The status filter composes with the search box (both apply) before repo
   // grouping. The repo / branch / path / Task legs of search run on cheap base
   // fields, so they work before enrichment; only the PR-number leg waits on a
@@ -946,22 +962,18 @@ export function WorktreesList(props: {
       searchHaystackByPath,
       prHaystackByPath,
     );
-    const effectiveTiers = new Set(
-      availableTiers.filter((tier) => tierFilters.has(tier)),
-    );
-    if (effectiveTiers.size === 0) return searched;
+    if (effectiveTierFilters.size === 0) return searched;
     return searched.filter(
       (entry) =>
         isPending(entry.worktreePath) ||
-        effectiveTiers.has(classifyWorktreeTier(entry)),
+        effectiveTierFilters.has(classifyWorktreeTier(entry)),
     );
   }, [
     mergedWorktrees,
     deferredSearchText,
     searchHaystackByPath,
     prHaystackByPath,
-    tierFilters,
-    availableTiers,
+    effectiveTierFilters,
     isPending,
   ]);
   const toggleTierFilter = useCallback((tier: WorktreeTier) => {

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -339,7 +339,7 @@ function WorktreesFilterControls(props: {
           type="search"
           value={props.searchText}
           onChange={(event) => props.onSearchChange(event.target.value)}
-          placeholder="Search repo, branch, path, or Task"
+          placeholder="Search repo, branch, path, PR, or Task"
           aria-label="Search worktrees"
           className="pl-8"
         />
@@ -894,6 +894,24 @@ export function WorktreesList(props: {
     () => buildWorktreeSearchHaystackByPath(worktrees, taskTitlesByEpicId),
     [worktrees, taskTitlesByEpicId],
   );
+  // Keyed on the ENRICHED list, unlike the text haystack above: a PR number only
+  // exists once a path's activity probe has landed.
+  const prHaystackByPath = useMemo(
+    () => buildWorktreePrHaystackByPath(mergedWorktrees),
+    [mergedWorktrees],
+  );
+  // Rows still waiting on their probe. A PR-number query CANNOT match them yet
+  // (their `prNumber` is null), so an empty result set only honestly reads "no
+  // matches" once this hits zero - until then the empty state says "still
+  // checking". Errored rows are excluded deliberately: they settle to "Unknown"
+  // and will never enrich, so counting them would hold the notice open forever.
+  const stillCheckingCount = useMemo(
+    () =>
+      mergedWorktrees.filter(
+        (entry) => enrichmentStateFor(entry.worktreePath) === "pending",
+      ).length,
+    [mergedWorktrees, enrichmentStateFor],
+  );
   // Only offer filter options for tiers actually present in this host's list.
   // Un-enriched rows have no known tier, so they cannot contribute an option -
   // the menu fills in as rows enrich (on-screen rows first, then the
@@ -907,7 +925,9 @@ export function WorktreesList(props: {
     return WORKTREE_TIER_ORDER.filter((tier) => present.has(tier));
   }, [mergedWorktrees, isPending]);
   // The status filter composes with the search box (both apply) before repo
-  // grouping. Search runs on cheap base fields, so it works before enrichment.
+  // grouping. The repo / branch / path / Task legs of search run on cheap base
+  // fields, so they work before enrichment; only the PR-number leg waits on a
+  // probe, and the empty state owns that gap.
   // Tier comes from the shared classifier, so the filter options exactly match the
   // row pills. Intersect the selection with the tiers actually present (mirroring
   // `worktreeTierFilterLabel`): a stale selection for a now-absent tier is ignored,
@@ -924,6 +944,7 @@ export function WorktreesList(props: {
       mergedWorktrees,
       deferredSearchText,
       searchHaystackByPath,
+      prHaystackByPath,
     );
     const effectiveTiers = new Set(
       availableTiers.filter((tier) => tierFilters.has(tier)),
@@ -938,6 +959,7 @@ export function WorktreesList(props: {
     mergedWorktrees,
     deferredSearchText,
     searchHaystackByPath,
+    prHaystackByPath,
     tierFilters,
     availableTiers,
     isPending,
@@ -1472,8 +1494,20 @@ export function WorktreesList(props: {
             }
           >
             {groups.length === 0 ? (
-              <WorktreesStateMessage tone="muted" spinner={false}>
-                No worktrees match your search.
+              /**
+               * Empty because the search excluded everything - a tier filter
+               * alone can't land here, since un-enriched rows always pass it.
+               * So while probes are outstanding, "no matches" would be a lie for
+               * a PR-number query: the row exists, it just doesn't know its PR
+               * yet. Say what's actually true and keep the spinner honest.
+               */
+              <WorktreesStateMessage
+                tone="muted"
+                spinner={stillCheckingCount > 0}
+              >
+                {stillCheckingCount > 0
+                  ? worktreeSearchCheckingNoticeText(stillCheckingCount)
+                  : "No worktrees match your search."}
               </WorktreesStateMessage>
             ) : (
               <div
@@ -1782,6 +1816,11 @@ function WorktreeSelectionActionBar(props: {
 function worktreeCheckingNoticeText(checkingCount: number): string {
   const plural = checkingCount === 1 ? "worktree is" : "worktrees are";
   return `${checkingCount} selected ${plural} still checking status`;
+}
+
+function worktreeSearchCheckingNoticeText(checkingCount: number): string {
+  const plural = checkingCount === 1 ? "worktree" : "worktrees";
+  return `No matches yet - still checking ${checkingCount} ${plural}.`;
 }
 
 /**
@@ -2948,20 +2987,27 @@ function compareByCreatedAt(
 }
 
 /**
- * Client-side text filter over the four fields the tab searches: repo label,
- * branch, worktree path, and each owning Task's resolved title. Whitespace-only
- * queries pass everything through. Pure renderer work - the full list is already
- * in memory.
+ * Client-side text filter over the fields the tab searches: repo label, branch,
+ * worktree path, each owning Task's resolved title, and the row's PR numbers.
+ * Whitespace-only queries pass everything through. Pure renderer work - the full
+ * list is already in memory.
+ *
+ * Two haystacks, because they resolve on different clocks (see
+ * {@link buildWorktreePrHaystackByPath}). A hit in either matches, so a query is
+ * never made narrower by the PR leg being cold.
  */
 function filterWorktrees(
   worktrees: readonly WorktreeHostEntryV12[],
   searchText: string,
   searchHaystackByPath: ReadonlyMap<string, string>,
+  prHaystackByPath: ReadonlyMap<string, string>,
 ): readonly WorktreeHostEntryV12[] {
   const needle = searchText.trim().toLowerCase();
   if (needle.length === 0) return worktrees;
-  return worktrees.filter((entry) =>
-    (searchHaystackByPath.get(entry.worktreePath) ?? "").includes(needle),
+  return worktrees.filter(
+    (entry) =>
+      (searchHaystackByPath.get(entry.worktreePath) ?? "").includes(needle) ||
+      (prHaystackByPath.get(entry.worktreePath) ?? "").includes(needle),
   );
 }
 
@@ -2988,6 +3034,39 @@ function worktreeSearchHaystack(
   return [entry.repoLabel, entry.branch ?? "", entry.worktreePath, ...titles]
     .join("\n")
     .toLowerCase();
+}
+
+/**
+ * PR numbers get their OWN index because they live on a different clock to the
+ * base fields: the host pins `prNumber: null` on every base row and only the
+ * per-path activity probe fills it in. Folding them into the text haystack would
+ * rekey that memo on the enriched list, rebuilding every row's joined string on
+ * each enrichment chunk; kept apart, repo / branch / path / Task search stays
+ * churn-free and instant, and only this cheap `#N` map rebuilds as probes land.
+ *
+ * The cost of that split is honest and visible: a PR-number query is eventually
+ * consistent - a row joins the result set when its probe lands, which is why an
+ * empty result set with probes outstanding reads "still checking" rather than
+ * "no matches" (see `WorktreesList`).
+ *
+ * Both the superproject PR and each owned submodule's PR are indexed, matching
+ * the two kinds of `#N` pill the row renders. The `#` is kept in the token so
+ * that `4360` and `#4360` both hit under the same plain substring rule the other
+ * fields use.
+ */
+function buildWorktreePrHaystackByPath(
+  worktrees: readonly WorktreeHostEntryV12[],
+): ReadonlyMap<string, string> {
+  return new Map(
+    worktrees.map((entry) => [entry.worktreePath, worktreePrHaystack(entry)]),
+  );
+}
+
+function worktreePrHaystack(entry: WorktreeHostEntryV12): string {
+  return [entry.prNumber, ...entry.submodules.map((sub) => sub.prNumber)]
+    .filter((prNumber): prNumber is number => prNumber !== null)
+    .map((prNumber) => `#${prNumber}`)
+    .join("\n");
 }
 
 function deleteDialogCopy(entry: WorktreeHostEntryV12): {


### PR DESCRIPTION
## Summary
- Worktree search now indexes PR numbers (superproject + submodule legs), sourced from the per-path enrichment overlay since the base listing always serves `prNumber: null`.
- The empty state distinguishes "still checking N worktrees" (probes outstanding) from a settled "no worktrees match your search" — a PR-number query is otherwise eventually consistent and a flat no-match would be misleading while rows are un-enriched.
- Search placeholder updated to mention PR.

## Validation
- `bun run compile`
- `bun run lint`
- 119 focused worktree-panel tests (7 new, covering match-by-number with/without `#`, submodule PRs, union with existing text search, and both empty-state branches)
- Rebased on latest `main`; re-ran compile/lint/tests post-rebase

## Checklist
- [x] Build, compile, lint, and format checks pass
- [x] Tests added/updated
- [x] Pre-commit hooks pass
- [x] Commit is DCO signed

🤖 Generated with [Claude Code](https://claude.com/claude-code)