### PR TITLE
fix(gui-app): stop React Compiler from memoizing bound-store hook calls (terminal tile crash loop)

### DIFF
--- a/clients/gui-app/src/components/chat/chat-progress-icon.tsx
+++ b/clients/gui-app/src/components/chat/chat-progress-icon.tsx
@@ -1,3 +1,4 @@
+import { useStore } from "zustand";
 import type { LucideIcon } from "lucide-react";
 import { NotificationIndicatorIcon } from "@/components/notifications/notification-indicator-icon";
 import { useSurfaceNotificationIndicatorState } from "@/components/notifications/notification-indicator-context";
@@ -64,7 +65,10 @@ function ChatProgressIconWithHandle(props: {
   readonly testId: string;
   readonly subjectId: string;
 }) {
-  const runStatus = props.handle.store((state) => state.runStatus);
+  // `useStore(api, selector)` instead of `props.handle.store(...)`: the
+  // bound-store call form isn't recognizable as a hook to the React Compiler,
+  // which memoizes it away and corrupts the hook order.
+  const runStatus = useStore(props.handle.store, (state) => state.runStatus);
   return (
     <ChatProgressPresentation
       indicatorState={props.indicatorState}

--- a/clients/gui-app/src/hooks/terminal/use-terminal-crash-notification.ts
+++ b/clients/gui-app/src/hooks/terminal/use-terminal-crash-notification.ts
@@ -1,3 +1,4 @@
+import { useStore } from "zustand";
 import { useEffect, useRef } from "react";
 import type { TerminalSessionExitReason } from "@traycer/protocol/host/terminal/unary-schemas";
 import type {
@@ -35,9 +36,12 @@ export function useTerminalCrashNotification(input: {
   readonly onCrashExit: () => void;
 }): void {
   const { handle, isExitSuppressed, onCrashExit } = input;
-  const status = handle.store((state) => state.status);
-  const exitCode = handle.store((state) => state.exitCode);
-  const exitReason = handle.store((state) => state.exitReason);
+  // Read via `useStore(api, selector)` rather than calling `handle.store(...)`
+  // directly: the bound-store call form isn't recognizable as a hook to the
+  // React Compiler, which memoizes it away and corrupts the hook order.
+  const status = useStore(handle.store, (state) => state.status);
+  const exitCode = useStore(handle.store, (state) => state.exitCode);
+  const exitReason = useStore(handle.store, (state) => state.exitReason);
   const crashReportedRef = useRef(false);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixes the desktop renderer crash loop (`TypeError: Cannot read properties of undefined (reading 'length')`) that lands terminal/setup tiles on the route error screen after every status transition, introduced by #306.
- Converts all four `handle.store(selector)` bound-store reads to `useStore(handle.store, selector)` so the React Compiler recognizes them as hooks.

## Root cause
`handle.store(selector)` is a zustand bound-store **hook call**, but the property-call form doesn't match the `use*` naming convention, so the React Compiler treats it as a plain function call and wraps it in a memo-cache guard:

```js
// compiled useTerminalCrashNotification (S5) in epic-session-provider chunk
t[0]===n ? a=t[1] : (a=n.store(Jve), t[0]=n, t[1]=a);
```

On the first re-render with an unchanged `handle`, the cache hits and the call — along with zustand's internal `useSyncExternalStore` + `useCallback` pair — is skipped. The component's hook order shifts, and production React 19 throws inside `areHookInputsEqual` (reading `.deps` off a slot that now holds a non-effect hook). The TanStack Router `defaultErrorComponent` catches it, the tile remounts, the next re-render crashes again — a loop that also leaks `runnerHost:event:systemResumed` subscriptions (`MaxListenersExceededWarning`).

Confirmed empirically via CDP against the packaged app: a conditional breakpoint in `areHookInputsEqual` showed the committed fiber with `TerminalLive`'s full 45 hook slots while the re-render laid down only ~30, the gap exactly matching the three skipped `handle.store(...)` reads.

`ChatProgressIconWithHandle` has used the same pattern since before the OSS cut but never crashed: the compiler currently **bails out** of that component and emits the call unconditionally. Converted it anyway so a future refactor can't arm it.

## Verification
- `tsc -b` clean; `vitest` suites for `chat-progress-icon` and `terminal-crash` pass (2 files, 5 tests).
- Ran both files through `babel-plugin-react-compiler@1.0.0` (repo lockfile version): all four reads now compile to unconditional `useStore(...)` calls with hoisted selectors — no cache guards.
- Repo-wide sweep: no other `.store(selector)` / `.store()` render-path call sites remain in `gui-app`/`shared`.

Follow-up worth considering (not in this PR): a lint guard against compiler-invisible hook calls (e.g. `eslint-plugin-react-hooks` compiler rules) so new bound-store property calls can't reintroduce this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)