### PR TITLE
fix(chat): carry sender provenance on steered messages; log retention

### DIFF
--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -344,6 +344,7 @@ function assistantSteerMessage(
         messageId,
         content: CONTENT,
         mode: "safe_point",
+        sender: null,
       },
     ],
     startedAt: 4,

--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
@@ -5,6 +5,7 @@ import type {
   AgentSender,
   ChatEvent,
   Message,
+  UserMessageSender,
 } from "@traycer/protocol/persistence/epic/schemas";
 import type { TurnCheckpointManifest } from "@traycer/protocol/persistence/epic/checkpoint-manifests";
 import type {
@@ -922,6 +923,7 @@ describe("useRenderedMessages", () => {
           queueItemId: "queue-1",
           messageId: "message-queue-1",
           mode: "safe_point",
+          sender: null,
           content: {
             type: "doc",
             content: [
@@ -989,6 +991,7 @@ describe("useRenderedMessages", () => {
           queueItemId: "queue-1",
           messageId: "message-queue-1",
           mode: "safe_point",
+          sender: null,
           content,
         },
         {
@@ -1087,6 +1090,7 @@ describe("useRenderedMessages", () => {
           queueItemId: "queue-1",
           messageId: "message-queue-1",
           mode: "safe_point",
+          sender: null,
           content,
         },
         {
@@ -4533,6 +4537,7 @@ describe("useRenderedMessages head/tail partition", () => {
     blockId: string,
     messageId: string,
     timestamp: number,
+    sender: UserMessageSender | null,
   ): Extract<Message, { role: "assistant" }>["blocks"][number] {
     return {
       blockId,
@@ -4544,6 +4549,7 @@ describe("useRenderedMessages head/tail partition", () => {
       messageId,
       content: CONTENT,
       mode: "safe_point",
+      sender,
     };
   }
 
@@ -4649,7 +4655,7 @@ describe("useRenderedMessages head/tail partition", () => {
     const messages = [userMessage("u1"), steered, activeRecord];
     const live = liveTurn(
       "turn-2",
-      [turnSteerBlock("steer-1", "steered-user-1", 4100)],
+      [turnSteerBlock("steer-1", "steered-user-1", 4100, null)],
       4000,
     );
 
@@ -4665,6 +4671,82 @@ describe("useRenderedMessages head/tail partition", () => {
     // standalone user row at its own send timestamp.
     expect(steeredRows[0]?.createdAt).toBe(4000);
     expect(steeredRows[0]?.steerBadge).not.toBeNull();
+  });
+
+  // An ORPHANED steer block - one whose steered user row is absent from
+  // `messages` - falls back to rendering the block's own content. These three
+  // pin the provenance of that fallback: it is the only thing standing between
+  // an agent-to-agent message and a bubble that looks like the user typed it.
+  const AGENT_STEER_SENDER: UserMessageSender = {
+    type: "agent",
+    harnessId: "claude",
+    agentId: "agent-7",
+    displayName: "Reviewer",
+    reply: { expectsReply: true, responseId: "resp-1" },
+  };
+
+  // `turnKey` must be unique per case: rendered rows are memoized by turn/block
+  // id, so reusing one would hand back the previous case's row.
+  function orphanedSteerRow(turnKey: string, sender: UserMessageSender | null) {
+    // Deliberately NOT including the steered user row in `messages` - this is a
+    // chat whose mid-turn reload dropped it.
+    const activeRecord = {
+      ...assistantMessage(turnKey, 4000),
+      blocks: [turnTextBlock(`block:${turnKey}`, 4000, "before steer")],
+    };
+    const live = liveTurn(
+      turnKey,
+      [
+        turnSteerBlock(
+          `steer:${turnKey}`,
+          `steered-user:${turnKey}`,
+          4100,
+          sender,
+        ),
+      ],
+      4000,
+    );
+    const { result } = renderHook(() =>
+      useRenderedMessages(
+        partitionInput([userMessage("u1"), activeRecord], live),
+        displayContext,
+      ),
+    );
+    return result.current.find((row) => row.steerBadge?.status === "steered");
+  }
+
+  it("renders an orphaned AGENT steer as an agent card, never as a user-authored row", () => {
+    const row = orphanedSteerRow("turn-orphan-agent", AGENT_STEER_SENDER);
+
+    expect(row).toBeDefined();
+    // The regression: with no sender on the block this rendered as a plain
+    // "YOU" bubble - an A2A message impersonating the user.
+    expect(row?.agentSenderInfo).toEqual({
+      agentId: "agent-7",
+      senderTitle: "Reviewer",
+      expectReply: true,
+      responseId: "resp-1",
+    });
+  });
+
+  it("keeps an orphaned HUMAN steer a user row", () => {
+    const row = orphanedSteerRow("turn-orphan-human", {
+      type: "user",
+      userId: "owner-1",
+    });
+
+    expect(row).toBeDefined();
+    expect(row?.agentSenderInfo).toBeNull();
+  });
+
+  it("renders an orphaned steer block persisted before the sender field as a user row", () => {
+    // Legacy blocks parse with `sender: null` (the schema default), which must
+    // keep the pre-fix behavior rather than inventing provenance.
+    const row = orphanedSteerRow("turn-orphan-legacy", null);
+
+    expect(row).toBeDefined();
+    expect(row?.agentSenderInfo).toBeNull();
+    expect(row?.senderLabel).toBeNull();
   });
 
   it("re-interleaves settled and active-turn rows in transcript order", () => {

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -1836,6 +1836,19 @@ function assistantTurnTimelineEntries(
   }));
 }
 
+/**
+ * Renders a `steer` block's message row. The steered USER row (`block.messageId`)
+ * is the preferred source - it carries the full message, its sender, and its
+ * session anchor.
+ *
+ * The fallback below runs when that row is absent: the block and the row have
+ * asymmetric durability (the block is rewritten on every checkpoint, the row is
+ * written once), so a mid-turn reload can leave the block orphaned. It renders
+ * from the block alone, and `block.sender` is what keeps provenance intact - an
+ * orphaned agent-to-agent steer must still render as an agent card, never as a
+ * plain user-authored bubble. Blocks persisted before that field carry `null`
+ * and render as a "you" row exactly as before.
+ */
 function renderSteerBlockUserMessage(
   block: Extract<ContentBlock, { type: "steer" }>,
   ctx: RenderedMessagesDisplayContext,
@@ -1849,8 +1862,9 @@ function renderSteerBlockUserMessage(
     content: block.content,
     timestamp: block.timestamp,
     persistentMessageId: null,
-    sender: null,
-    senderLabel: null,
+    sender: block.sender,
+    senderLabel:
+      block.sender === null ? null : ctx.resolveUserSenderLabel(block.sender),
     settings: null,
     steerBadge: {
       status: "steered",

--- a/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
@@ -153,6 +153,12 @@ interface Recorded {
   readonly errors: string[];
   exited: number | null;
   readonly exitWaiters: Array<() => void>;
+  // Log rotations attempted, in order. Stubbed (not left to the real helper) so
+  // a test run can never rotate the developer's actual ~/.traycer host log.
+  readonly rotations: string[];
+  // Ordered trace of the start lifecycle: rotate -> marker -> open fd -> spawn.
+  // The ORDER is the invariant (see the ordering test), not just the calls.
+  readonly sequence: string[];
   readonly spawnCalls: Array<{
     command: string;
     args: readonly string[];
@@ -180,6 +186,8 @@ function makeRunStubs(
     exited: null,
     exitWaiters: [],
     spawnCalls: [],
+    rotations: [],
+    sequence: [],
   };
   // The stub implements only the surface `runHostStart` touches; route it
   // to `ChildProcess` through an explicit `unknown` intermediate rather than a
@@ -193,6 +201,7 @@ function makeRunStubs(
         p,
       ),
     spawn: (command, args, options) => {
+      recorded.sequence.push("spawn");
       recorded.spawnCalls.push({
         command,
         args,
@@ -203,12 +212,21 @@ function makeRunStubs(
       });
       return childAsProcess;
     },
-    openLogFd: async () => 42,
+    openLogFd: async () => {
+      recorded.sequence.push("open-fd");
+      return 42;
+    },
+    rotateLog: async (environment) => {
+      recorded.rotations.push(environment);
+      recorded.sequence.push("rotate");
+      return "skipped";
+    },
     readEnvOverrides: async () => ({
       EXTRA_FROM_OVERRIDE: "1",
       TRAYCER_TEST_UNSET: null,
     }),
     writeMarker: async (environment, phase, fields) => {
+      recorded.sequence.push(`marker:${phase}`);
       recorded.markers.push({
         environment,
         phase,
@@ -309,6 +327,30 @@ describe("runHostStart - installed-record launch path", () => {
       hostHomeDir("dev"),
     ]);
     expect(recorded.spawnCalls[0]?.env.TRAYCER_CHANNEL).toBeUndefined();
+  });
+
+  it("rotates the log for this environment before anything appends to the run", async () => {
+    const exec = "/opt/traycer/host/dev/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    const invoke = () => runHostStart({ environment: "dev", cwd: null }, deps);
+    setTimeout(() => child.emit("exit", 0, null));
+    await runUntilExit(invoke, recorded);
+
+    expect(recorded.rotations).toEqual(["dev"]);
+    // Ordering is load-bearing, not incidental, so assert the actual SEQUENCE
+    // rather than just that each step ran. The `starting` marker must land in
+    // the POST-rotation file, and the stdio fd opened after it lives for the
+    // child's whole lifetime - an fd follows the inode across a rename, so
+    // rotating any later would divert the host's own stdout into the
+    // rotated-away file and split one session across two inodes.
+    // Prefix, not the whole trace: the child's own exit appends `marker:exited`
+    // afterwards, which is not part of the start sequence under test.
+    expect(recorded.sequence.slice(0, 4)).toEqual([
+      "rotate",
+      "marker:starting",
+      "open-fd",
+      "spawn",
+    ]);
   });
 
   it("passes the dev-desktop run host root to the host when a slot is set", async () => {

--- a/clients/traycer-cli/src/commands/__tests__/host-uninstall.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-uninstall.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { noopLogger } from "../../logger";
+import { serviceLabelFor } from "../../service";
+import { stopServiceBeforeRuntimePurge } from "../host-uninstall";
+
+describe("stopServiceBeforeRuntimePurge", () => {
+  it("allows runtime purge after stop confirms the host exited", async () => {
+    const label = serviceLabelFor("dev");
+
+    await expect(
+      stopServiceBeforeRuntimePurge({
+        controller: {
+          stop: async (receivedLabel) => {
+            expect(receivedLabel).toBe(label);
+          },
+        },
+        environment: "dev",
+        label,
+        logger: noopLogger,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("preserves runtime when stop cannot confirm the host exited", async () => {
+    const label = serviceLabelFor("production");
+
+    await expect(
+      stopServiceBeforeRuntimePurge({
+        controller: {
+          stop: async () => {
+            throw new Error("host still running");
+          },
+        },
+        environment: "production",
+        label,
+        logger: noopLogger,
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/host-uninstall.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-uninstall.test.ts
@@ -1,7 +1,38 @@
 import { describe, expect, it } from "vitest";
 import { noopLogger } from "../../logger";
 import { serviceLabelFor } from "../../service";
-import { stopServiceBeforeRuntimePurge } from "../host-uninstall";
+import type { UninstallHostOptions } from "../../installer";
+import {
+  runHostUninstall,
+  stopServiceBeforeRuntimePurge,
+  type RunHostUninstallDeps,
+} from "../host-uninstall";
+
+function commandDeps(args: {
+  readonly stop: () => Promise<void>;
+  readonly receivedOptions: UninstallHostOptions[];
+}): RunHostUninstallDeps {
+  return {
+    createServiceController: () => ({
+      uninstall: async () => undefined,
+      stop: args.stop,
+    }),
+    uninstallHost: async (options) => {
+      args.receivedOptions.push(options);
+      return {
+        removedRecord: null,
+        removedInstallDir: true,
+        purgedRuntime: options.purgeChannelRuntime,
+      };
+    },
+  };
+}
+
+const COMMAND_CONTEXT = {
+  environment: "dev" as const,
+  logger: noopLogger,
+  progress: () => undefined,
+};
 
 describe("stopServiceBeforeRuntimePurge", () => {
   it("allows runtime purge after stop confirms the host exited", async () => {
@@ -36,5 +67,45 @@ describe("stopServiceBeforeRuntimePurge", () => {
         logger: noopLogger,
       }),
     ).resolves.toBe(false);
+  });
+});
+
+describe("runHostUninstall", () => {
+  it("forwards runtime purge permission after a confirmed stop", async () => {
+    const receivedOptions: UninstallHostOptions[] = [];
+
+    const result = await runHostUninstall(
+      { all: true },
+      COMMAND_CONTEXT,
+      commandDeps({
+        stop: async () => undefined,
+        receivedOptions,
+      }),
+    );
+
+    expect(receivedOptions).toEqual([
+      { environment: "dev", purgeChannelRuntime: true },
+    ]);
+    expect(result.data).toMatchObject({ purgedRuntime: true });
+  });
+
+  it("forwards runtime preservation after a failed stop", async () => {
+    const receivedOptions: UninstallHostOptions[] = [];
+
+    const result = await runHostUninstall(
+      { all: true },
+      COMMAND_CONTEXT,
+      commandDeps({
+        stop: async () => {
+          throw new Error("host still running");
+        },
+        receivedOptions,
+      }),
+    );
+
+    expect(receivedOptions).toEqual([
+      { environment: "dev", purgeChannelRuntime: false },
+    ]);
+    expect(result.data).toMatchObject({ purgedRuntime: false });
   });
 });

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -9,6 +9,7 @@ import {
   openBootstrapLogFd,
   writeBootstrapMarker,
 } from "../host/bootstrap-log";
+import { rotateHostLogIfOversized } from "../host/host-log-rotation";
 import {
   readHostInstallRecord,
   type HostInstallRecord,
@@ -144,6 +145,9 @@ export type SpawnImpl = (
 export interface RunHostStartDeps extends ResolveHostStartTargetDeps {
   readonly spawn: SpawnImpl;
   readonly openLogFd: (environment: Environment) => Promise<number>;
+  readonly rotateLog: (
+    environment: Environment,
+  ) => Promise<"rotated" | "skipped">;
   readonly readEnvOverrides: () => Promise<Record<string, EnvOverrideValue>>;
   readonly writeMarker: typeof writeBootstrapMarker;
   // `process.exit` itself returns `never`, but the dependency is typed
@@ -159,6 +163,7 @@ const defaultRunDeps: RunHostStartDeps = {
   ...defaultDeps,
   spawn: (cmd, args, options) => nodeSpawn(cmd, args.slice(), options),
   openLogFd: openBootstrapLogFd,
+  rotateLog: rotateHostLogIfOversized,
   readEnvOverrides: async () => ({ ...(await listEnvOverrides()) }),
   writeMarker: writeBootstrapMarker,
   exit: (code) => {
@@ -251,6 +256,13 @@ export async function runHostStart(
   // computes its own CLI bin dir (`~/.traycer/cli[/<slot>]/bin`, where the
   // bundled `traycer` is symlinked) and puts it on PATH, so no `traycer` path
   // needs to be handed down here.
+
+  // Bound the log before anything appends to this run. Nothing truncates
+  // `host.log` - every writer appends - so a start is the only safe moment to
+  // roll it: the fd opened below lives for the child's whole lifetime and would
+  // follow the file across a rename, splitting one session across two files.
+  // Under the cap this is a no-op, so consecutive starts still share one log.
+  await deps.rotateLog(opts.environment);
 
   await deps.writeMarker(opts.environment, "starting", {
     shell: undefined,

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -262,7 +262,11 @@ export async function runHostStart(
   // roll it: the fd opened below lives for the child's whole lifetime and would
   // follow the file across a rename, splitting one session across two files.
   // Under the cap this is a no-op, so consecutive starts still share one log.
-  await deps.rotateLog(opts.environment);
+  const rotation = await deps.rotateLog(opts.environment);
+  logger.debug("Host supervisor checked log rotation", {
+    environment: opts.environment,
+    rotation,
+  });
 
   await deps.writeMarker(opts.environment, "starting", {
     shell: undefined,

--- a/clients/traycer-cli/src/commands/host-uninstall.ts
+++ b/clients/traycer-cli/src/commands/host-uninstall.ts
@@ -1,11 +1,17 @@
-import { uninstallHost } from "../installer";
+import {
+  uninstallHost,
+  type UninstallHostOptions,
+  type UninstallHostResult,
+} from "../installer";
 import type { ILogger } from "../logger";
 import type { CommandFn, CommandResult } from "../runner/runner";
 import type { Environment } from "../runner/environment";
+import type { ProgressInfo } from "../runner/output";
 import {
   createServiceController,
   serviceLabelFor,
   type ServiceLabel,
+  type UninstallServiceOptions,
 } from "../service";
 import { withCliLock } from "../store/cli-lock";
 
@@ -20,6 +26,21 @@ export interface HostUninstallArgs {
 
 export interface RuntimePurgeStopController {
   stop(label: ServiceLabel): Promise<void>;
+}
+
+export interface HostUninstallServiceController extends RuntimePurgeStopController {
+  uninstall(options: UninstallServiceOptions): Promise<void>;
+}
+
+export interface RunHostUninstallDeps {
+  createServiceController(): HostUninstallServiceController;
+  uninstallHost(options: UninstallHostOptions): Promise<UninstallHostResult>;
+}
+
+export interface RunHostUninstallContext {
+  readonly environment: Environment;
+  readonly logger: ILogger;
+  progress(info: ProgressInfo): void;
 }
 
 interface StopServiceBeforeRuntimePurgeArgs {
@@ -62,83 +83,101 @@ export function buildHostUninstallCommand(args: HostUninstallArgs): CommandFn {
         waitMs: 30_000,
         pollIntervalMs: 100,
       },
-      async () => {
-        let serviceUninstalled = false;
-        let purgeChannelRuntime = false;
-        if (args.all) {
-          ctx.runtime.logger.warn(
-            "Host uninstall command will deregister service and purge runtime",
-            {
-              environment: ctx.runtime.environment,
-            },
-          );
-          ctx.progress({
-            stage: "service-stop",
-            message: `stopping service for ${ctx.runtime.environment} environment`,
-            percent: null,
-            bytes: null,
-            totalBytes: null,
-          });
-          const controller = createServiceController();
-          const label = serviceLabelFor(ctx.runtime.environment);
-          // Deregister BEFORE waiting for the process to exit. On macOS the
-          // running job stays under launchd's `KeepAlive` supervision until
-          // its registration is torn down (`uninstall` -> `launchctl
-          // bootout`); stopping first and deregistering after leaves a
-          // window where a non-clean SIGTERM exit gets treated as a
-          // failed/crashed exit and launchd respawns the host before we
-          // ever reach `uninstall`. Deregistering first removes that
-          // supervision so no exit outcome can trigger a respawn.
-          await controller.uninstall({ label });
-          serviceUninstalled = true;
-          ctx.runtime.logger.info("Host uninstall service deregistered", {
+      () =>
+        runHostUninstall(
+          args,
+          {
             environment: ctx.runtime.environment,
-            label: label.id,
-          });
-          // Install removal stays best-effort, but runtime files are preserved
-          // unless stop confirms the process is gone. A failed stop can leave
-          // the host actively writing its pid metadata and log.
-          purgeChannelRuntime = await stopServiceBeforeRuntimePurge({
-            controller,
-            environment: ctx.runtime.environment,
-            label,
             logger: ctx.runtime.logger,
-          });
-        }
-        ctx.progress({
-          stage: "uninstall",
-          message: "removing installed host",
-          percent: null,
-          bytes: null,
-          totalBytes: null,
-        });
-        const result = await uninstallHost({
-          environment: ctx.runtime.environment,
-          purgeChannelRuntime,
-        });
-        ctx.runtime.logger.info("Host uninstall command completed", {
-          environment: ctx.runtime.environment,
-          serviceUninstalled,
-          removedInstallDir: result.removedInstallDir,
-          purgedRuntime: result.purgedRuntime,
-          hadInstallRecord: result.removedRecord !== null,
-        });
-        return {
-          data: {
-            removedRecord: result.removedRecord,
-            removedInstallDir: result.removedInstallDir,
-            serviceUninstalled,
-            purgedRuntime: result.purgedRuntime,
+            progress: ctx.progress,
           },
-          human: humanSummary({
-            removedVersion: result.removedRecord?.version ?? null,
-            serviceUninstalled,
-            purgedRuntime: result.purgedRuntime,
-          }),
-          exitCode: 0,
-        };
+          {
+            createServiceController,
+            uninstallHost,
+          },
+        ),
+    );
+  };
+}
+
+export async function runHostUninstall(
+  args: HostUninstallArgs,
+  ctx: RunHostUninstallContext,
+  deps: RunHostUninstallDeps,
+): Promise<CommandResult> {
+  let serviceUninstalled = false;
+  let purgeChannelRuntime = false;
+  if (args.all) {
+    ctx.logger.warn(
+      "Host uninstall command will deregister service and purge runtime",
+      {
+        environment: ctx.environment,
       },
     );
+    ctx.progress({
+      stage: "service-stop",
+      message: `stopping service for ${ctx.environment} environment`,
+      percent: null,
+      bytes: null,
+      totalBytes: null,
+    });
+    const controller = deps.createServiceController();
+    const label = serviceLabelFor(ctx.environment);
+    // Deregister BEFORE waiting for the process to exit. On macOS the
+    // running job stays under launchd's `KeepAlive` supervision until
+    // its registration is torn down (`uninstall` -> `launchctl
+    // bootout`); stopping first and deregistering after leaves a
+    // window where a non-clean SIGTERM exit gets treated as a
+    // failed/crashed exit and launchd respawns the host before we
+    // ever reach `uninstall`. Deregistering first removes that
+    // supervision so no exit outcome can trigger a respawn.
+    await controller.uninstall({ label });
+    serviceUninstalled = true;
+    ctx.logger.info("Host uninstall service deregistered", {
+      environment: ctx.environment,
+      label: label.id,
+    });
+    // Install removal stays best-effort, but runtime files are preserved
+    // unless stop confirms the process is gone. A failed stop can leave
+    // the host actively writing its pid metadata and log.
+    purgeChannelRuntime = await stopServiceBeforeRuntimePurge({
+      controller,
+      environment: ctx.environment,
+      label,
+      logger: ctx.logger,
+    });
+  }
+  ctx.progress({
+    stage: "uninstall",
+    message: "removing installed host",
+    percent: null,
+    bytes: null,
+    totalBytes: null,
+  });
+  const result = await deps.uninstallHost({
+    environment: ctx.environment,
+    purgeChannelRuntime,
+  });
+  ctx.logger.info("Host uninstall command completed", {
+    environment: ctx.environment,
+    serviceUninstalled,
+    removedInstallDir: result.removedInstallDir,
+    purgedRuntime: result.purgedRuntime,
+    hadInstallRecord: result.removedRecord !== null,
+  });
+  return {
+    data: {
+      removedRecord: result.removedRecord,
+      removedInstallDir: result.removedInstallDir,
+      serviceUninstalled,
+      purgedRuntime: result.purgedRuntime,
+    },
+    human: humanSummary({
+      removedVersion: result.removedRecord?.version ?? null,
+      serviceUninstalled,
+      purgedRuntime: result.purgedRuntime,
+    }),
+    exitCode: 0,
   };
 }
 

--- a/clients/traycer-cli/src/commands/host-uninstall.ts
+++ b/clients/traycer-cli/src/commands/host-uninstall.ts
@@ -1,6 +1,12 @@
 import { uninstallHost } from "../installer";
+import type { ILogger } from "../logger";
 import type { CommandFn, CommandResult } from "../runner/runner";
-import { createServiceController, serviceLabelFor } from "../service";
+import type { Environment } from "../runner/environment";
+import {
+  createServiceController,
+  serviceLabelFor,
+  type ServiceLabel,
+} from "../service";
 import { withCliLock } from "../store/cli-lock";
 
 // `traycer host uninstall [--all]`:
@@ -10,6 +16,37 @@ import { withCliLock } from "../store/cli-lock";
 // is never removed - there is no destructive "purge" path.
 export interface HostUninstallArgs {
   readonly all: boolean;
+}
+
+export interface RuntimePurgeStopController {
+  stop(label: ServiceLabel): Promise<void>;
+}
+
+interface StopServiceBeforeRuntimePurgeArgs {
+  readonly controller: RuntimePurgeStopController;
+  readonly environment: Environment;
+  readonly label: ServiceLabel;
+  readonly logger: ILogger;
+}
+
+// Runtime state belongs to the live host process, so deleting pid metadata or
+// rotating its active log is only safe after the service controller confirms
+// the process exited. Service deregistration/install removal remain
+// best-effort even when this confirmation fails.
+export async function stopServiceBeforeRuntimePurge(
+  args: StopServiceBeforeRuntimePurgeArgs,
+): Promise<boolean> {
+  try {
+    await args.controller.stop(args.label);
+    return true;
+  } catch (err) {
+    args.logger.warn("Host uninstall service stop failed; preserving runtime", {
+      environment: args.environment,
+      errorName: err instanceof Error ? err.name : "Error",
+      errorMessage: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
 }
 
 export function buildHostUninstallCommand(args: HostUninstallArgs): CommandFn {
@@ -27,6 +64,7 @@ export function buildHostUninstallCommand(args: HostUninstallArgs): CommandFn {
       },
       async () => {
         let serviceUninstalled = false;
+        let purgeChannelRuntime = false;
         if (args.all) {
           ctx.runtime.logger.warn(
             "Host uninstall command will deregister service and purge runtime",
@@ -57,23 +95,15 @@ export function buildHostUninstallCommand(args: HostUninstallArgs): CommandFn {
             environment: ctx.runtime.environment,
             label: label.id,
           });
-          // Best-effort: confirm the process actually exited so any held
-          // file handles release before the install dir is removed below.
-          // Tolerate failures - the uninstall path forces removal
-          // regardless.
-          try {
-            await controller.stop(label);
-          } catch (err) {
-            ctx.runtime.logger.warn(
-              "Host uninstall service stop failed; continuing",
-              {
-                environment: ctx.runtime.environment,
-                errorName: err instanceof Error ? err.name : "Error",
-                errorMessage: err instanceof Error ? err.message : String(err),
-              },
-            );
-            // Service may not be running; proceed.
-          }
+          // Install removal stays best-effort, but runtime files are preserved
+          // unless stop confirms the process is gone. A failed stop can leave
+          // the host actively writing its pid metadata and log.
+          purgeChannelRuntime = await stopServiceBeforeRuntimePurge({
+            controller,
+            environment: ctx.runtime.environment,
+            label,
+            logger: ctx.runtime.logger,
+          });
         }
         ctx.progress({
           stage: "uninstall",
@@ -84,9 +114,7 @@ export function buildHostUninstallCommand(args: HostUninstallArgs): CommandFn {
         });
         const result = await uninstallHost({
           environment: ctx.runtime.environment,
-          // --all also clears environment runtime state (pid metadata,
-          // log) - the host is gone, those are just stale files.
-          purgeChannelRuntime: args.all,
+          purgeChannelRuntime,
         });
         ctx.runtime.logger.info("Host uninstall command completed", {
           environment: ctx.runtime.environment,

--- a/clients/traycer-cli/src/host/__tests__/host-log-rotation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/host-log-rotation.test.ts
@@ -1,0 +1,198 @@
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// `hostLogPath` resolves under the real `homedir()`, so redirect both paths into
+// a temp dir and let the rotation run against a real filesystem - the `rename` /
+// `rm` sequencing is the whole behavior under test and a mocked fs would prove
+// nothing about it.
+let logDir = "";
+
+vi.mock("../../store/paths", () => ({
+  hostLogPath: () => join(logDir, "host.log"),
+  hostLogBackupPath: () => join(logDir, "host.log.1"),
+}));
+
+// The start path skips rotation while a host is live (it holds an open append fd
+// on the file). Default to "no host running"; the guard test overrides it.
+let livePid: number | null = null;
+
+vi.mock("../pid-metadata", () => ({
+  readHostPidMetadata: async () =>
+    livePid === null
+      ? null
+      : {
+          pid: livePid,
+          hostId: "host-1",
+          version: "1.0.0",
+          websocketUrl: "ws://127.0.0.1:7100/rpc",
+          startedAt: new Date(0).toISOString(),
+        },
+}));
+
+const { MAX_HOST_LOG_BYTES, rotateHostLogForPurge, rotateHostLogIfOversized } =
+  await import("../host-log-rotation");
+
+const LOG = () => join(logDir, "host.log");
+const BACKUP = () => join(logDir, "host.log.1");
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+beforeEach(async () => {
+  logDir = await mkdtemp(join(tmpdir(), "traycer-host-log-"));
+  await mkdir(logDir, { recursive: true });
+  livePid = null;
+});
+
+afterEach(async () => {
+  await rm(logDir, { recursive: true, force: true });
+});
+
+describe("rotateHostLogIfOversized (host start)", () => {
+  it("leaves a log under the cap alone, so consecutive starts share one file", async () => {
+    await writeFile(LOG(), "session one\n");
+
+    expect(await rotateHostLogIfOversized("dev")).toBe("skipped");
+
+    // Unchanged and un-rotated: this is what keeps a restart's markers readable
+    // in the context of the run that preceded them.
+    expect(await readFile(LOG(), "utf8")).toBe("session one\n");
+    expect(await exists(BACKUP())).toBe(false);
+  });
+
+  it("rotates a log past the cap into host.log.1 and starts the live file fresh", async () => {
+    await writeFile(LOG(), "x".repeat(MAX_HOST_LOG_BYTES + 1));
+
+    expect(await rotateHostLogIfOversized("dev")).toBe("rotated");
+
+    // The live log is gone (the next append recreates it); the previous
+    // generation is intact.
+    expect(await exists(LOG())).toBe(false);
+    expect((await stat(BACKUP())).size).toBe(MAX_HOST_LOG_BYTES + 1);
+  });
+
+  it("keeps exactly one generation - a second rotation overwrites the older backup", async () => {
+    await writeFile(BACKUP(), "ancient");
+    await writeFile(LOG(), "y".repeat(MAX_HOST_LOG_BYTES + 1));
+
+    expect(await rotateHostLogIfOversized("dev")).toBe("rotated");
+
+    const backup = await readFile(BACKUP(), "utf8");
+    expect(backup).not.toContain("ancient");
+    expect(backup.startsWith("y")).toBe(true);
+  });
+
+  it("is a no-op when no log exists yet (first start on a machine)", async () => {
+    expect(await rotateHostLogIfOversized("dev")).toBe("skipped");
+    expect(await exists(BACKUP())).toBe(false);
+  });
+
+  it("refuses to rotate under a LIVE host, however big the log has grown", async () => {
+    // The live host holds the append fd the supervisor handed it. An fd follows
+    // the inode across a rename, so rotating here would send that host's stdout
+    // into host.log.1 while fresh markers went to host.log - one session torn
+    // across two files. Growing past the cap is the lesser evil.
+    livePid = process.pid;
+    await writeFile(LOG(), "z".repeat(MAX_HOST_LOG_BYTES + 1));
+
+    expect(await rotateHostLogIfOversized("dev")).toBe("skipped");
+
+    expect((await stat(LOG())).size).toBe(MAX_HOST_LOG_BYTES + 1);
+    expect(await exists(BACKUP())).toBe(false);
+  });
+
+  it("rotates when the recorded pid is stale (host died without cleaning up)", async () => {
+    // A pid that cannot exist: the guard must fall through rather than wedge
+    // rotation forever behind a leftover pid file.
+    livePid = 2147483646;
+    await writeFile(LOG(), "w".repeat(MAX_HOST_LOG_BYTES + 1));
+
+    expect(await rotateHostLogIfOversized("dev")).toBe("rotated");
+
+    expect(await exists(LOG())).toBe(false);
+    expect((await stat(BACKUP())).size).toBe(MAX_HOST_LOG_BYTES + 1);
+  });
+
+  it("keeps the previous generation when the rotation itself cannot happen", async () => {
+    // Rename-before-remove: a rotation that fails must not have already
+    // destroyed the evidence it was supposed to preserve. Point the backup at a
+    // DIRECTORY so `rename` onto it fails on every platform.
+    await mkdir(BACKUP(), { recursive: true });
+    await writeFile(join(BACKUP(), "prior-evidence.txt"), "keep me");
+    await writeFile(LOG(), "v".repeat(MAX_HOST_LOG_BYTES + 1));
+
+    expect(await rotateHostLogIfOversized("dev")).toBe("skipped");
+
+    // The live log is untouched and the prior generation still exists.
+    expect((await stat(LOG())).size).toBe(MAX_HOST_LOG_BYTES + 1);
+    expect(await readFile(join(BACKUP(), "prior-evidence.txt"), "utf8")).toBe(
+      "keep me",
+    );
+  });
+});
+
+describe("rotateHostLogForPurge (host uninstall --all / dev teardown)", () => {
+  it("preserves the session in host.log.1 instead of deleting it", async () => {
+    // The regression this closes: `make dev-desktop` runs `host uninstall --all`
+    // on every Ctrl-C, which used to `rm` this file - so the session you wanted
+    // to investigate was routinely gone before you could read it.
+    await writeFile(LOG(), "the session worth investigating\n");
+
+    expect(await rotateHostLogForPurge("dev")).toBe("rotated");
+
+    // The purge still clears the live log...
+    expect(await exists(LOG())).toBe(false);
+    // ...but the evidence survives.
+    expect(await readFile(BACKUP(), "utf8")).toBe(
+      "the session worth investigating\n",
+    );
+  });
+
+  it("rotates regardless of size - a purge is not size-gated", async () => {
+    await writeFile(LOG(), "tiny");
+
+    expect(await rotateHostLogForPurge("dev")).toBe("rotated");
+
+    expect(await readFile(BACKUP(), "utf8")).toBe("tiny");
+  });
+
+  it("cannot accumulate generations across repeated teardowns", async () => {
+    await writeFile(LOG(), "run one\n");
+    await rotateHostLogForPurge("dev");
+    await writeFile(LOG(), "run two\n");
+    await rotateHostLogForPurge("dev");
+
+    // Still exactly one backup, holding the most recent run.
+    expect(await readFile(BACKUP(), "utf8")).toBe("run two\n");
+    expect(await exists(join(logDir, "host.log.2"))).toBe(false);
+  });
+
+  it("leaves no stragglers when the log is empty", async () => {
+    await writeFile(LOG(), "");
+
+    expect(await rotateHostLogForPurge("dev")).toBe("skipped");
+
+    expect(await exists(LOG())).toBe(false);
+    expect(await exists(BACKUP())).toBe(false);
+  });
+
+  it("is a no-op when there is no log to purge", async () => {
+    expect(await rotateHostLogForPurge("dev")).toBe("skipped");
+    expect(await exists(BACKUP())).toBe(false);
+  });
+});

--- a/clients/traycer-cli/src/host/__tests__/host-log-rotation.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/host-log-rotation.test.ts
@@ -2,13 +2,36 @@ import {
   mkdtemp,
   mkdir,
   readFile,
+  readdir,
   rm,
   stat,
   writeFile,
 } from "node:fs/promises";
+import type { PathLike } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const renameFaults = vi.hoisted(() => {
+  const codes: Array<string | null> = [];
+  return { codes };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    rename: async (oldPath: PathLike, newPath: PathLike): Promise<void> => {
+      const code = renameFaults.codes.shift();
+      if (code !== undefined && code !== null) {
+        throw Object.assign(new Error(`injected rename failure: ${code}`), {
+          code,
+        });
+      }
+      await actual.rename(oldPath, newPath);
+    },
+  };
+});
 
 // `hostLogPath` resolves under the real `homedir()`, so redirect both paths into
 // a temp dir and let the rotation run against a real filesystem - the `rename` /
@@ -54,6 +77,7 @@ async function exists(path: string): Promise<boolean> {
 }
 
 beforeEach(async () => {
+  renameFaults.codes.length = 0;
   logDir = await mkdtemp(join(tmpdir(), "traycer-host-log-"));
   await mkdir(logDir, { recursive: true });
   livePid = null;
@@ -143,6 +167,22 @@ describe("rotateHostLogIfOversized (host start)", () => {
     expect(await readFile(join(BACKUP(), "prior-evidence.txt"), "utf8")).toBe(
       "keep me",
     );
+  });
+
+  it("restores the previous generation when Windows replacement fails after displacement", async () => {
+    await writeFile(BACKUP(), "prior evidence");
+    await writeFile(LOG(), "n".repeat(MAX_HOST_LOG_BYTES + 1));
+
+    // Simulate Windows refusing the initial replace because host.log.1 exists,
+    // then an unrelated failure promoting host.log after the prior backup has
+    // been moved aside. The fourth rename is the rollback.
+    renameFaults.codes.push("EPERM", null, "EACCES", null);
+
+    expect(await rotateHostLogIfOversized("dev")).toBe("skipped");
+
+    expect(await readFile(BACKUP(), "utf8")).toBe("prior evidence");
+    expect((await stat(LOG())).size).toBe(MAX_HOST_LOG_BYTES + 1);
+    expect((await readdir(logDir)).sort()).toEqual(["host.log", "host.log.1"]);
   });
 });
 

--- a/clients/traycer-cli/src/host/host-log-rotation.ts
+++ b/clients/traycer-cli/src/host/host-log-rotation.ts
@@ -1,0 +1,172 @@
+import { rename, rm, stat } from "node:fs/promises";
+import type { Environment } from "../runner/environment";
+import { hostLogBackupPath, hostLogPath } from "../store/paths";
+import { readHostPidMetadata } from "./pid-metadata";
+
+/**
+ * Single-generation rotation for `host.log`.
+ *
+ * `host.log` is append-only from every writer - the supervisor's bootstrap
+ * markers, the host's stdio fd handed to `spawn`, and the host's own file
+ * logger - so nothing ever truncates it. That leaves two problems, and this
+ * module is the one answer to both:
+ *
+ *   - **Unbounded growth.** Nothing caps the file. A long-lived host retrying a
+ *     failing provider can grow it without limit (`harness-runtime.ts` says as
+ *     much in its own comment).
+ *   - **Forensics destroyed on purge.** `traycer host uninstall --all` deletes
+ *     the log outright, and `make dev-desktop` runs exactly that on every Ctrl-C
+ *     teardown - so the session you actually want to investigate is routinely
+ *     gone by the time you look.
+ *
+ * Rotating to a single `host.log.1` sibling addresses both without either
+ * failure mode of the alternatives: it bounds the file (unlike pure appending)
+ * and it preserves one previous generation (unlike deleting/truncating). One
+ * generation is the whole design - this is a forensic trail across ONE restart,
+ * not an archive.
+ *
+ * ## The cap is checked AT START, not continuously - and that is a real limit
+ *
+ * Be precise about what {@link MAX_HOST_LOG_BYTES} buys: it bounds the log
+ * **across restarts**, not *within* a single host's lifetime. A host that runs
+ * for weeks can still grow `host.log` past the cap, and nothing here stops it.
+ *
+ * This is not laziness about the cost of a `stat` on the append path - it is a
+ * correctness constraint. The supervisor hands the running host a long-lived
+ * append **fd** for its stdout/stderr (`spawn(stdio:[ignore, fd, fd])`), while
+ * the host's own logger writes to the same file BY PATH (`appendFileSync`). An
+ * fd follows the inode across a `rename`; a path does not. So an in-process
+ * rotation while the host is live would send the logger's lines to the new
+ * `host.log` while the very same process's stdout kept flowing into
+ * `host.log.1` - one session torn across two files, which is strictly worse for
+ * forensics than a large file. Rotating before that fd is ever opened has no
+ * such hazard.
+ *
+ * Making the cap a true within-lifetime bound therefore requires the supervisor
+ * to stop sharing one file between the child's stdio fd and the path-writers
+ * (give the host's stdio its own sink, or have the host reopen stdio after it
+ * rotates). That is a larger change than this module, and deliberately out of
+ * its scope.
+ *
+ * Best-effort by contract: rotation is a diagnostics nicety and must never block
+ * a host start or an uninstall, so every entry point swallows its errors.
+ */
+
+// Matches the desktop perf log's cap (`perf-telemetry-writer.ts`), the one other
+// rotating file Traycer writes.
+export const MAX_HOST_LOG_BYTES = 5 * 1024 * 1024;
+
+async function fileSize(filePath: string): Promise<number> {
+  try {
+    const info = await stat(filePath);
+    return info.size;
+  } catch {
+    // Missing (first start, or already purged) reads as empty - nothing to
+    // rotate, and every caller treats that the same way.
+    return 0;
+  }
+}
+
+async function removeQuietly(filePath: string): Promise<void> {
+  try {
+    await rm(filePath, { force: true });
+  } catch {
+    // Best-effort contract: a purge must never throw into the caller.
+  }
+}
+
+/**
+ * Move `logPath` onto `backupPath`, keeping exactly one generation.
+ *
+ * Ordering matters: the rename is attempted FIRST, so a rotation that cannot
+ * happen never destroys the evidence it was supposed to preserve. On POSIX that
+ * single call atomically replaces the destination, so the old backup is dropped
+ * only once the new one is safely in place. Windows `rename` refuses an existing
+ * destination, so that (and only that) case falls back to removing the previous
+ * backup and retrying - by which point we already know the destination exists
+ * and the source is intact.
+ */
+async function rotate(
+  logPath: string,
+  backupPath: string,
+): Promise<"rotated" | "skipped"> {
+  try {
+    await rename(logPath, backupPath);
+    return "rotated";
+  } catch {
+    // Fall through to the replace-existing-destination retry below.
+  }
+  try {
+    await rm(backupPath, { force: true });
+    await rename(logPath, backupPath);
+    return "rotated";
+  } catch {
+    return "skipped";
+  }
+}
+
+/**
+ * True when a host process is already recorded as live for this environment.
+ *
+ * Guards against an overlapping start rotating the log out from under a host
+ * that is still running and still holds the append fd for it - the same
+ * fd-follows-the-inode hazard described above, which would split the live
+ * host's session across two inodes.
+ */
+async function hostIsLive(environment: Environment): Promise<boolean> {
+  const metadata = await readHostPidMetadata(environment);
+  if (metadata === null) return false;
+  try {
+    // Signal 0 performs the permission/existence check without delivering a
+    // signal: it throws ESRCH when no such process exists.
+    process.kill(metadata.pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Rotate `host.log` to `host.log.1` when it has grown past
+ * {@link MAX_HOST_LOG_BYTES}. Called on the host-start path BEFORE the append fd
+ * is opened, so growth is bounded across restarts and a start under the cap
+ * keeps appending to the same file - two consecutive starts still land in one
+ * log, which is what makes a restart's markers readable in context.
+ *
+ * Skipped entirely when a host is already live for this environment: that host
+ * holds an open fd on the file, and rotating under it would tear its session in
+ * half.
+ */
+export async function rotateHostLogIfOversized(
+  environment: Environment,
+): Promise<"rotated" | "skipped"> {
+  const logPath = hostLogPath(environment);
+  if ((await fileSize(logPath)) < MAX_HOST_LOG_BYTES) return "skipped";
+  if (await hostIsLive(environment)) return "skipped";
+  return await rotate(logPath, hostLogBackupPath(environment));
+}
+
+/**
+ * Rotate `host.log` to `host.log.1` unconditionally, for the runtime-purge path
+ * (`host uninstall --all`). Purging must still clear the live log - an orphan
+ * log left behind by an uninstall is its own surprise - but the session it
+ * records is precisely the one worth keeping, and a dev teardown hits this path
+ * many times a day. Rotating satisfies both: the runtime is purged, one
+ * generation survives, and it cannot accumulate.
+ *
+ * Not pid-guarded, unlike the start path: uninstall runs after the host has been
+ * stopped, and a purge that silently left the log behind because a stale pid
+ * file said "live" would defeat the point.
+ */
+export async function rotateHostLogForPurge(
+  environment: Environment,
+): Promise<"rotated" | "skipped"> {
+  const logPath = hostLogPath(environment);
+  if ((await fileSize(logPath)) === 0) {
+    // Nothing worth keeping (absent, empty, or unreadable). Still drop a
+    // zero-length file so the purge leaves no stragglers.
+    await removeQuietly(logPath);
+    return "skipped";
+  }
+  return await rotate(logPath, hostLogBackupPath(environment));
+}

--- a/clients/traycer-cli/src/host/host-log-rotation.ts
+++ b/clients/traycer-cli/src/host/host-log-rotation.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from "node:crypto";
 import { rename, rm, stat } from "node:fs/promises";
 import type { Environment } from "../runner/environment";
+import { isErrnoException } from "../runner/errors";
 import { hostLogBackupPath, hostLogPath } from "../store/paths";
 import { readHostPidMetadata } from "./pid-metadata";
 
@@ -75,6 +77,16 @@ async function removeQuietly(filePath: string): Promise<void> {
   }
 }
 
+const REPLACE_EXISTING_CODES = new Set(["EACCES", "EEXIST", "EPERM"]);
+
+async function isRegularFile(filePath: string): Promise<boolean> {
+  try {
+    return (await stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Move `logPath` onto `backupPath`, keeping exactly one generation.
  *
@@ -82,9 +94,11 @@ async function removeQuietly(filePath: string): Promise<void> {
  * happen never destroys the evidence it was supposed to preserve. On POSIX that
  * single call atomically replaces the destination, so the old backup is dropped
  * only once the new one is safely in place. Windows `rename` refuses an existing
- * destination, so that (and only that) case falls back to removing the previous
- * backup and retrying - by which point we already know the destination exists
- * and the source is intact.
+ * destination, so that (and only that) case falls back to moving the previous
+ * backup aside and retrying - by which point we already know the destination
+ * exists and the source is intact. The displaced backup is restored if the
+ * retry fails, so an unrelated source/permission failure cannot destroy the
+ * previous generation.
  */
 async function rotate(
   logPath: string,
@@ -93,16 +107,40 @@ async function rotate(
   try {
     await rename(logPath, backupPath);
     return "rotated";
-  } catch {
-    // Fall through to the replace-existing-destination retry below.
+  } catch (cause) {
+    const code = isErrnoException(cause) ? cause.code : null;
+    if (
+      typeof code !== "string" ||
+      !REPLACE_EXISTING_CODES.has(code) ||
+      !(await isRegularFile(backupPath))
+    ) {
+      return "skipped";
+    }
   }
+
+  const displacedBackupPath = `${backupPath}.replace-${randomUUID()}`;
   try {
-    await rm(backupPath, { force: true });
-    await rename(logPath, backupPath);
-    return "rotated";
+    await rename(backupPath, displacedBackupPath);
   } catch {
     return "skipped";
   }
+
+  try {
+    await rename(logPath, backupPath);
+  } catch {
+    // If rollback itself is blocked, the prior evidence still survives at the
+    // displaced path rather than being deleted. A successful rollback removes
+    // that exceptional extra file and restores the normal single generation.
+    try {
+      await rename(displacedBackupPath, backupPath);
+    } catch {
+      // Best-effort contract: never block host start or uninstall.
+    }
+    return "skipped";
+  }
+
+  await removeQuietly(displacedBackupPath);
+  return "rotated";
 }
 
 /**

--- a/clients/traycer-cli/src/installer/__tests__/uninstall.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/uninstall.test.ts
@@ -8,10 +8,15 @@ describe("removeHostPidMetadataForPurge", () => {
     const receivedPaths: string[] = [];
 
     await expect(
-      removeHostPidMetadataForPurge("dev", noopLogger, async (path) => {
-        receivedPaths.push(path);
-        throw Object.assign(new Error("file is locked"), { code: "EBUSY" });
-      }),
+      removeHostPidMetadataForPurge(
+        "dev",
+        noopLogger,
+        async (path, options) => {
+          receivedPaths.push(path);
+          expect(options).toEqual({ force: true });
+          throw Object.assign(new Error("file is locked"), { code: "EBUSY" });
+        },
+      ),
     ).resolves.toBeUndefined();
 
     expect(receivedPaths).toEqual([hostPidMetadataPath("dev")]);

--- a/clients/traycer-cli/src/installer/__tests__/uninstall.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/uninstall.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { noopLogger } from "../../logger";
+import { hostPidMetadataPath } from "../../store/paths";
+import { removeHostPidMetadataForPurge } from "../uninstall";
+
+describe("removeHostPidMetadataForPurge", () => {
+  it("continues when locked pid metadata cannot be removed", async () => {
+    const receivedPaths: string[] = [];
+
+    await expect(
+      removeHostPidMetadataForPurge("dev", noopLogger, async (path) => {
+        receivedPaths.push(path);
+        throw Object.assign(new Error("file is locked"), { code: "EBUSY" });
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(receivedPaths).toEqual([hostPidMetadataPath("dev")]);
+  });
+});

--- a/clients/traycer-cli/src/installer/uninstall.ts
+++ b/clients/traycer-cli/src/installer/uninstall.ts
@@ -6,11 +6,8 @@ import {
 } from "../manifest/host-install";
 import type { Environment } from "../runner/environment";
 import { createCliLogger, errorFromUnknown } from "../logger";
-import {
-  hostInstallDir,
-  hostLogPath,
-  hostPidMetadataPath,
-} from "../store/paths";
+import { rotateHostLogForPurge } from "../host/host-log-rotation";
+import { hostInstallDir, hostPidMetadataPath } from "../store/paths";
 import { sweepOldTrash } from "./install";
 
 // Uninstall the installed host directory for a single environment. Always
@@ -70,14 +67,22 @@ export async function uninstallHost(
 
   let purgedRuntime = false;
   if (opts.purgeChannelRuntime) {
-    // Remove pid metadata + log + any other environment-scoped runtime
+    // Clear pid metadata + log + any other environment-scoped runtime
     // state. We don't blow away ~/.traycer/host/ wholesale because
     // the dev environment's install lives under it.
+    //
+    // The log is ROTATED, not deleted. `make dev-desktop` runs
+    // `host uninstall --all` on every Ctrl-C teardown, so deleting here meant
+    // the session you most wanted to investigate was routinely gone before you
+    // could read it. Rotating still clears the live log (a purge that leaves an
+    // orphan behind is its own surprise) while keeping one generation, and it
+    // cannot accumulate.
     await rm(hostPidMetadataPath(opts.environment), { force: true });
-    await rm(hostLogPath(opts.environment), { force: true });
+    const rotated = await rotateHostLogForPurge(opts.environment);
     purgedRuntime = true;
     logger.warn("Host uninstall purged runtime files", {
       environment: opts.environment,
+      rotatedLog: rotated === "rotated",
     });
   }
 

--- a/clients/traycer-cli/src/installer/uninstall.ts
+++ b/clients/traycer-cli/src/installer/uninstall.ts
@@ -5,7 +5,7 @@ import {
   type HostInstallRecord,
 } from "../manifest/host-install";
 import type { Environment } from "../runner/environment";
-import { createCliLogger, errorFromUnknown } from "../logger";
+import { createCliLogger, errorFromUnknown, type ILogger } from "../logger";
 import { rotateHostLogForPurge } from "../host/host-log-rotation";
 import { hostInstallDir, hostPidMetadataPath } from "../store/paths";
 import { sweepOldTrash } from "./install";
@@ -26,6 +26,22 @@ export interface UninstallHostResult {
   readonly removedRecord: HostInstallRecord | null;
   readonly removedInstallDir: boolean;
   readonly purgedRuntime: boolean;
+}
+
+export async function removeHostPidMetadataForPurge(
+  environment: Environment,
+  logger: ILogger,
+  remove: (path: string, options: { readonly force: true }) => Promise<void>,
+): Promise<void> {
+  try {
+    await remove(hostPidMetadataPath(environment), { force: true });
+  } catch (err) {
+    logger.warn("Host uninstall failed to remove pid metadata", {
+      environment,
+      errorName: errorFromUnknown(err).name,
+      errorMessage: errorFromUnknown(err).message,
+    });
+  }
 }
 
 export async function uninstallHost(
@@ -77,7 +93,7 @@ export async function uninstallHost(
     // could read it. Rotating still clears the live log (a purge that leaves an
     // orphan behind is its own surprise) while keeping one generation, and it
     // cannot accumulate.
-    await rm(hostPidMetadataPath(opts.environment), { force: true });
+    await removeHostPidMetadataForPurge(opts.environment, logger, rm);
     const rotated = await rotateHostLogForPurge(opts.environment);
     purgedRuntime = true;
     logger.warn("Host uninstall purged runtime files", {

--- a/clients/traycer-cli/src/store/paths.ts
+++ b/clients/traycer-cli/src/store/paths.ts
@@ -40,6 +40,10 @@ const HOST_STAGING_SUBDIR = "install-staging";
 const HOST_INSTALL_RECORD_FILENAME = "install.json";
 const CLI_LOG_FILENAME = "cli.log";
 const HOST_LOG_FILENAME = "host.log";
+// Single retained generation of the host log. One is enough: it exists so the
+// PREVIOUS session's trail survives a restart or a runtime purge, not to build
+// an archive (see `host-log-rotation.ts`).
+const HOST_LOG_BACKUP_FILENAME = "host.log.1";
 const HOST_PID_FILENAME = "pid.json";
 
 function environmentSubdir(base: string, environment: Environment): string {
@@ -127,6 +131,11 @@ export function hostPidMetadataPath(
 }
 export function hostLogPath(environment: Environment | undefined): string {
   return join(hostHomeDir(environment), HOST_LOG_FILENAME);
+}
+export function hostLogBackupPath(
+  environment: Environment | undefined,
+): string {
+  return join(hostHomeDir(environment), HOST_LOG_BACKUP_FILENAME);
 }
 export function bootstrapLogPath(environment: Environment | undefined): string {
   return hostLogPath(environment);

--- a/protocol/scripts/compat/compat-exceptions.json
+++ b/protocol/scripts/compat/compat-exceptions.json
@@ -230,6 +230,22 @@
       "method": "chat.subscribe",
       "version": "*",
       "payload": "serverFrame",
+      "path": "**.blocks.items.anyOf[*].properties.sender",
+      "reason": "Steer-block provenance, nullable/.default(null). The steered USER row remains the primary record of who sent a steered message and is unchanged; this only mirrors its sender onto the block so the renderer's ORPHAN fallback (block present, user row missing) can tell an agent-to-agent steer from a human one instead of rendering it as user-authored text. null is exactly what a pre-field host produces, and the fallback then renders the plain user row it always did - so an old host's frames degrade to the shipped behavior, and an old client strips the key and is unaffected. Scoped by field path."
+    },
+    {
+      "family": "stream",
+      "method": "chat.subscribe",
+      "version": "*",
+      "payload": "serverFrame",
+      "path": "**.event.anyOf[*].properties.sender",
+      "reason": "The steer.submitted counterpart of the **.blocks.items.anyOf[*].properties.sender entry (nullable/.default(null)): the shared accumulator copies it onto the steer block it builds, so host and client derive an identical block. Absent from a pre-field host's events, which yields the same null the block schema defaults to."
+    },
+    {
+      "family": "stream",
+      "method": "chat.subscribe",
+      "version": "*",
+      "payload": "serverFrame",
       "path": "**.backgroundTask",
       "reason": "Parsed-stream background-task marker (block: nullable/.default(false); events: .optional() with `?? null` in the shared accumulator): falsy means no background-card promotion, so old-host tool calls collapse into the generic activity group exactly as before #127."
     },

--- a/protocol/src/host/agent/gui/__tests__/agent-runtime-accumulator.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/agent-runtime-accumulator.test.ts
@@ -5,6 +5,7 @@ import {
   createTurnContentState,
 } from "../agent-runtime-accumulator";
 import {
+  steerSubmittedEventSchema,
   toolCallCompletedEventSchema,
   toolCallErroredEventSchema,
   toolCallStartedEventSchema,
@@ -27,6 +28,7 @@ type PlanBlock = Extract<ContentBlock, { type: "plan" }>;
 type ErrorBlock = Extract<ContentBlock, { type: "error" }>;
 type CompactionBlock = Extract<ContentBlock, { type: "compaction" }>;
 type InterviewBlock = Extract<ContentBlock, { type: "interview" }>;
+type SteerBlock = Extract<ContentBlock, { type: "steer" }>;
 
 function expectPlanBlock(block: ContentBlock | undefined): PlanBlock {
   if (block?.type !== "plan") {
@@ -2957,5 +2959,78 @@ describe("accumulateEvent - provider_notice.upsert", () => {
     expect(block.status).toBe("completed");
     expect(block.timestamp).toBe(5);
     expect(block.providerNotice).not.toBeNull();
+  });
+
+  // ── steer provenance ────────────────────────────────────────
+  //
+  // The steered USER row is the primary record of who sent a steered message,
+  // but it and this block are not equally durable (the block is rewritten on
+  // every checkpoint; the row is written once). So the block carries the sender
+  // too, and a renderer holding only the block can still tell an agent-to-agent
+  // steer from a human one instead of rendering it as user-authored text.
+  it("carries an agent sender from the steer.submitted event onto the steer block", () => {
+    const blocks = accumulateEvent(makeBlocks(), {
+      type: "steer.submitted",
+      blockId: "steer:q1",
+      timestamp: 7,
+      queueItemId: "q1",
+      messageId: "m1",
+      content: { type: "doc", content: [] },
+      mode: "safe_point",
+      sender: {
+        type: "agent",
+        harnessId: "claude",
+        agentId: "agent-7",
+        displayName: "Reviewer",
+        reply: { expectsReply: true, responseId: "resp-1" },
+      },
+    });
+
+    const block = blocks[0] as SteerBlock;
+    expect(block.type).toBe("steer");
+    expect(block.sender).toEqual({
+      type: "agent",
+      harnessId: "claude",
+      agentId: "agent-7",
+      displayName: "Reviewer",
+      reply: { expectsReply: true, responseId: "resp-1" },
+    });
+  });
+
+  it("carries a human sender through unchanged", () => {
+    const blocks = accumulateEvent(makeBlocks(), {
+      type: "steer.submitted",
+      blockId: "steer:q2",
+      timestamp: 7,
+      queueItemId: "q2",
+      messageId: "m2",
+      content: { type: "doc", content: [] },
+      mode: "safe_point",
+      sender: { type: "user", userId: "owner-1" },
+    });
+
+    expect((blocks[0] as SteerBlock).sender).toEqual({
+      type: "user",
+      userId: "owner-1",
+    });
+  });
+
+  it("leaves the block sender null for an event from a host that predates the field", () => {
+    // `steerSubmittedEventSchema.sender` is nullable/.default(null), so an old
+    // host's event parses to null - and the renderer's orphan fallback then
+    // renders the plain user row it always did.
+    const parsed = steerSubmittedEventSchema.parse({
+      type: "steer.submitted",
+      blockId: "steer:q3",
+      timestamp: 7,
+      queueItemId: "q3",
+      messageId: "m3",
+      content: { type: "doc", content: [] },
+    });
+
+    const blocks = accumulateEvent(makeBlocks(), parsed);
+
+    expect(parsed.sender).toBeNull();
+    expect((blocks[0] as SteerBlock).sender).toBeNull();
   });
 });

--- a/protocol/src/host/agent/gui/agent-runtime-accumulator.ts
+++ b/protocol/src/host/agent/gui/agent-runtime-accumulator.ts
@@ -581,6 +581,10 @@ export function accumulateEvent(
           messageId: event.messageId,
           content: event.content,
           mode: event.mode,
+          // Provenance, so the block can stand in for the steered user row if
+          // that row is ever missing (the two are not equally durable). `null`
+          // from a pre-field host keeps the old "render as a user row" fallback.
+          sender: event.sender,
         },
       ];
 

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -6,6 +6,7 @@ import {
 } from "@traycer/protocol/common/schemas";
 import { guiHarnessIdSchema } from "@traycer/protocol/host/agent/shared";
 import { getRecordSchema } from "@traycer/protocol/framework/index";
+import { userMessageSenderSchema } from "@traycer/protocol/persistence/epic/senders";
 import {
   interviewAnswerSchema,
   interviewQuestionOptionSchema,
@@ -526,6 +527,14 @@ export const steerSubmittedEventSchema = z.object({
   messageId: z.string(),
   content: jsonContentSchema,
   mode: chatQueueSteerModeSchema.default("safe_point"),
+  // Who authored the steered message, carried onto the `steer` content block by
+  // the shared accumulator. The steered USER row (`messageId`) is the primary
+  // record, but it and the block have asymmetric durability - so a renderer that
+  // sees only the block must still be able to tell an agent-to-agent message
+  // from a human one. Additive + nullable: a host that predates this field sends
+  // no sender, the block's stays `null`, and the fallback renders a plain user
+  // row exactly as before.
+  sender: userMessageSenderSchema.nullable().default(null),
 });
 export type SteerSubmittedEvent = z.infer<typeof steerSubmittedEventSchema>;
 

--- a/protocol/src/persistence/epic/__tests__/__fixtures__/chat-schema-surface.ts
+++ b/protocol/src/persistence/epic/__tests__/__fixtures__/chat-schema-surface.ts
@@ -4214,6 +4214,118 @@ export const chatSchemaSurfaceBaseline = {
                               "safe_point",
                               "interrupt_restart"
                             ]
+                          },
+                          "sender": {
+                            "default": null,
+                            "anyOf": [
+                              {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "const": "user"
+                                      },
+                                      "userId": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "userId"
+                                    ]
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "const": "agent"
+                                      },
+                                      "harnessId": {
+                                        "type": "string",
+                                        "enum": [
+                                          "claude",
+                                          "codex",
+                                          "opencode",
+                                          "traycer",
+                                          "cursor",
+                                          "grok",
+                                          "qwen",
+                                          "kiro",
+                                          "droid",
+                                          "kimi",
+                                          "copilot",
+                                          "kilocode",
+                                          "openrouter",
+                                          "amp",
+                                          "devin",
+                                          "pi"
+                                        ]
+                                      },
+                                      "agentId": {
+                                        "type": "string"
+                                      },
+                                      "displayName": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "reply": {
+                                        "default": {
+                                          "expectsReply": false
+                                        },
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "expectsReply": {
+                                                "type": "boolean",
+                                                "const": true
+                                              },
+                                              "responseId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "expectsReply",
+                                              "responseId"
+                                            ]
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "expectsReply": {
+                                                "type": "boolean",
+                                                "const": false
+                                              }
+                                            },
+                                            "required": [
+                                              "expectsReply"
+                                            ]
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "harnessId",
+                                      "agentId",
+                                      "displayName"
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           }
                         },
                         "required": [
@@ -9378,6 +9490,123 @@ export const chatSchemaSurfaceBaseline = {
                               "safe_point",
                               "interrupt_restart"
                             ]
+                          },
+                          "sender": {
+                            "default": null,
+                            "anyOf": [
+                              {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "const": "user"
+                                      },
+                                      "userId": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "userId"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "const": "agent"
+                                      },
+                                      "harnessId": {
+                                        "type": "string",
+                                        "enum": [
+                                          "claude",
+                                          "codex",
+                                          "opencode",
+                                          "traycer",
+                                          "cursor",
+                                          "grok",
+                                          "qwen",
+                                          "kiro",
+                                          "droid",
+                                          "kimi",
+                                          "copilot",
+                                          "kilocode",
+                                          "openrouter",
+                                          "amp",
+                                          "devin",
+                                          "pi"
+                                        ]
+                                      },
+                                      "agentId": {
+                                        "type": "string"
+                                      },
+                                      "displayName": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "reply": {
+                                        "default": {
+                                          "expectsReply": false
+                                        },
+                                        "oneOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "expectsReply": {
+                                                "type": "boolean",
+                                                "const": true
+                                              },
+                                              "responseId": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "expectsReply",
+                                              "responseId"
+                                            ],
+                                            "additionalProperties": false
+                                          },
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "expectsReply": {
+                                                "type": "boolean",
+                                                "const": false
+                                              }
+                                            },
+                                            "required": [
+                                              "expectsReply"
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "harnessId",
+                                      "agentId",
+                                      "displayName",
+                                      "reply"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
                           }
                         },
                         "required": [
@@ -9388,7 +9617,8 @@ export const chatSchemaSurfaceBaseline = {
                           "queueItemId",
                           "messageId",
                           "content",
-                          "mode"
+                          "mode",
+                          "sender"
                         ],
                         "additionalProperties": false
                       },

--- a/protocol/src/persistence/epic/content-blocks.ts
+++ b/protocol/src/persistence/epic/content-blocks.ts
@@ -1,5 +1,6 @@
 import { commonRecordRegistry } from "@traycer/protocol/common/registry";
 import { getRecordSchema } from "@traycer/protocol/framework/index";
+import { userMessageSenderSchema } from "@traycer/protocol/persistence/epic/senders";
 import { z } from "zod";
 
 /**
@@ -702,6 +703,17 @@ export const steerBlockSchema = z.object({
   messageId: z.string(),
   content: jsonContentSchema,
   mode: z.enum(["safe_point", "interrupt_restart"]).default("safe_point"),
+  // Who authored the steered message. Duplicated from the steered USER row
+  // (`messageId`) on purpose: the two records have asymmetric durability - this
+  // block is execution-owned and rewritten on every persistence checkpoint,
+  // while the user row is written once into `chat.messages`. When a renderer
+  // sees the block but not the row, it falls back to rendering the block's own
+  // content, and without this field an agent-to-agent message would render as a
+  // plain user-authored bubble - an agent impersonating the user. Carrying the
+  // sender here means the fallback can never lose provenance.
+  // Additive + nullable: blocks persisted before this field parse to `null`,
+  // which the renderer treats exactly as it did before (a "you" row).
+  sender: userMessageSenderSchema.nullable().default(null),
 });
 export type SteerBlock = z.infer<typeof steerBlockSchema>;
 


### PR DESCRIPTION
An A2A message steered into a live turn could render as a plain "YOU"
user bubble instead of an agent card. The renderer joins a `steer` block
to its user row by messageId; when the window lacks that row, the orphan
fallback rendered the block's content with `sender: null` - and the block
carried no provenance to render an agent card from.

Fixes:

1. Sender provenance (the fix). `sender` is added to the `steer` content
   block AND the `steer.submitted` wire event, so the host's persisted
   block and the GUI's live-accumulated block agree - both run the shared
   `agent-runtime-accumulator`, and it was the live window that showed the
   bug. Required-but-nullable, so every producer must state provenance.
   The renderer's orphan fallback now renders an agent card for an agent
   steer, and keeps a human steer a user row.

2. Reload-durable steered rows (defense-in-depth). `reassertSteeredUserRows`
   re-asserts missing steered rows at the persist choke point. NOTE: no
   mid-turn reload seam exists today (`readChat()` runs only from
   `initialize()`; `subscribe()` reads non-mutating snapshots; the session
   serializer is a strict FIFO mutex) - this guards that invariant, which
   is one refactor from breaking. Includes a real ordering fix: multi-steer
   turns repaired out of transcript order when a back-to-back steer
   collapsed an intermediate assistant row.

3. Log retention. `host.log` was never truncated (it appends) - the dev
   Ctrl-C teardown DELETED it via `host uninstall --all`, which is what
   destroyed the forensic trail for this incident. Now: size-capped
   rotation to one `host.log.1` generation, teardown rotates instead of
   removing, rename-before-remove so a failed rotation cannot destroy the
   evidence, and a live-pid guard so a start cannot rotate under a running
   host's open fd. Known limitation, documented in-module: rotation is
   start-time only, so the cap bounds the log across restarts, not within
   one host's lifetime (an in-process rotation would tear a session across
   two inodes, since the supervisor holds an append fd while the host's
   logger writes by path).

REQUIRES THE `protocol-compat-override` LABEL ON THIS PR.
`protocol/scripts/compat/compat-exceptions.json` gains two entries: the new
`sender` fields sit on `chat.subscribe`'s serverFrame, a host->client slot at
a released version, which `surface-compat` grades as breaking. The exception
asserts the additive-nullable case (null == the pre-feature semantic; old
clients ignore unknown keys), following the existing `**.workflowMeta` /
`**.providerNotice` / `**.stopped` precedent. That file is guarded by
`guarded-files-tripwire`, so the label - and a protocol-owner review of the
two entries - is required before this can merge.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Signed-off-by: Tanveer Gill <tanveer@traycer.ai>
