### PR TITLE
feat(gui-app): improve notification presentation

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/notification-emission-controller.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/notification-emission-controller.test.tsx
@@ -166,6 +166,6 @@ describe("NotificationEmissionController", () => {
     });
 
     expect(runnerHost.notificationsSent).toHaveLength(1);
-    expect(runnerHost.notificationsSent[0]?.body).toBe("Host error Details");
+    expect(runnerHost.notificationsSent[0]?.body).toBe("Details");
   });
 });

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -44,6 +44,8 @@ import {
 } from "@traycer/protocol/notifications/notification-room";
 import type { HostNotificationEntry } from "@traycer/protocol/host/notifications/contracts";
 
+const TASK_TITLE = "Checkout notification title and hover behavior";
+
 function seedEntries(
   callbacks: NotificationsStreamCallbacks,
   entries: ReadonlyArray<NotificationEntry>,
@@ -151,6 +153,7 @@ function hostAgentEntry(input: {
         epicId: "epic-1",
         chatId: "chat-1",
         agentName: "Agent",
+        taskTitle: TASK_TITLE,
         outcome: input.outcome ?? "completed",
       },
     };
@@ -167,6 +170,7 @@ function hostAgentEntry(input: {
       epicId: "epic-1",
       chatId: "chat-1",
       agentName: "Agent",
+      taskTitle: TASK_TITLE,
     },
   };
 }
@@ -323,7 +327,7 @@ describe("NotificationsPopover click routing", () => {
       "notification-unread-marker",
     );
     expect(unreadMarker.className).toContain("absolute");
-    expect(unreadMarker.className).toContain("inset-y-0");
+    expect(unreadMarker.className).toContain("inset-y-2");
     expect(unreadMarker.className).toContain("left-0");
     expect(unreadMarker.className).toContain("rounded-r-full");
 
@@ -393,11 +397,22 @@ describe("NotificationsPopover click routing", () => {
 
     expect(failed?.dataset.notificationSeverity).toBe("failure");
     expect(failed?.dataset.notificationOutcome).toBe("errored");
-    expect(failed?.textContent).toContain("Agent failed");
+    expect(failed?.textContent).toContain(TASK_TITLE);
+    expect(failed?.textContent).toContain("Agent • Failed");
     expect(completed?.dataset.notificationSeverity).toBe("done");
-    expect(completed?.textContent).toContain("Agent finished");
+    expect(completed?.textContent).toContain(TASK_TITLE);
+    expect(completed?.textContent).toContain("Agent • Done");
     expect(stalled?.dataset.notificationSeverity).toBe("failure");
-    expect(stalled?.textContent).toContain("Agent stalled");
+    expect(stalled?.textContent).toContain(TASK_TITLE);
+    expect(stalled?.textContent).toContain("Agent • Stalled");
+
+    if (completed === undefined) throw new Error("missing completed row");
+    const notificationTitle =
+      within(completed).getByTestId("notification-title");
+    expect(notificationTitle.className).toContain("truncate");
+    expect(notificationTitle.className).toContain("font-semibold");
+    fireEvent.pointerMove(notificationTitle, { pointerType: "mouse" });
+    expect((await screen.findByRole("tooltip")).textContent).toBe(TASK_TITLE);
   });
 
   it("keeps the Unread tab visible when every notification is read", async () => {

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -238,7 +238,7 @@ interface NotificationListProps {
 
 function NotificationList(props: NotificationListProps) {
   return (
-    <ul className="flex flex-col py-1">
+    <ul className="flex flex-col gap-2 p-2">
       {props.ids.map((id) => (
         <NotificationRow
           key={id}
@@ -296,7 +296,10 @@ function NotificationRow(props: NotificationRowProps) {
 
   return (
     <li
-      className="group/row relative"
+      className={cn(
+        "group/row relative overflow-hidden rounded-2xl border border-border/60 bg-muted/35 shadow-sm",
+        !isRead && "bg-accent/55",
+      )}
       data-testid="notification-entry"
       data-notification-id={row.feedId}
       data-notification-source={row.source}
@@ -308,38 +311,56 @@ function NotificationRow(props: NotificationRowProps) {
         <span
           aria-hidden
           data-testid="notification-unread-marker"
-          className="pointer-events-none absolute inset-y-0 left-0 z-10 w-1 rounded-r-full bg-blue-500 dark:bg-blue-400"
+          className="pointer-events-none absolute inset-y-2 left-0 z-10 w-1 rounded-r-full bg-blue-500 dark:bg-blue-400"
         />
       )}
       <button
         type="button"
         onClick={() => onActivate(row)}
+        aria-label={`${row.title}. ${row.body}`}
         className={cn(
-          "flex w-full items-start gap-3 px-4 py-2.5 text-left transition-colors",
-          "hover:bg-accent focus-visible:bg-accent focus-visible:outline-none",
-          !isRead && "bg-accent/30",
+          "flex w-full items-start gap-3 rounded-2xl px-3 py-3 text-left transition-colors",
+          "hover:bg-accent/70 focus-visible:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
         )}
       >
-        <span aria-hidden className="mt-1.5 h-4 w-0.5 shrink-0" />
         <span
           aria-hidden
           className={cn(
-            "relative mt-0.5 grid size-7 shrink-0 place-items-center rounded-full",
+            "relative grid size-10 shrink-0 place-items-center rounded-xl",
             meta.tone,
           )}
         >
-          <Icon className="size-3.5" />
+          <Icon className="size-5" />
         </span>
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5 pr-7">
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex min-w-0 items-baseline gap-2">
+            <TooltipWrapper
+              label={row.title}
+              side="bottom"
+              sideOffset={6}
+              align="start"
+            >
+              <span
+                data-testid="notification-title"
+                className={cn(
+                  "min-w-0 flex-1 truncate text-ui-sm font-semibold leading-snug",
+                  isRead ? "text-muted-foreground" : "text-foreground",
+                )}
+              >
+                {row.title}
+              </span>
+            </TooltipWrapper>
+            <NotificationTimestamp createdAt={row.createdAt} />
+          </div>
           <span
+            data-testid="notification-body"
             className={cn(
-              "line-clamp-2 text-ui-sm leading-snug",
-              isRead ? "text-muted-foreground" : "text-foreground",
+              "truncate text-ui-sm leading-snug",
+              isRead ? "text-muted-foreground/80" : "text-foreground/80",
             )}
           >
-            {row.text}
+            {row.body}
           </span>
-          <NotificationTimestamp createdAt={row.createdAt} />
         </div>
       </button>
       {!isRead && (
@@ -358,8 +379,8 @@ function NotificationRow(props: NotificationRowProps) {
             aria-label="Mark as read"
             data-testid="notification-mark-read"
             className={cn(
-              "absolute right-2 top-2 inline-flex size-6 items-center justify-center rounded-md",
-              "text-muted-foreground opacity-0 transition-opacity",
+              "absolute right-2.5 top-2.5 inline-flex size-6 items-center justify-center rounded-md",
+              "bg-background/90 text-muted-foreground opacity-0 shadow-sm transition-opacity",
               "hover:bg-background hover:text-foreground",
               "focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
               "group-hover/row:opacity-100",

--- a/clients/gui-app/src/lib/notifications/__tests__/notification-display.test.ts
+++ b/clients/gui-app/src/lib/notifications/__tests__/notification-display.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import {
   displayNotificationRows,
   notificationReplaceKey,
 } from "@/lib/notifications/notification-display";
 import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
 
-function row(text: string): MergedNotificationRow {
+vi.mock("sonner", () => ({
+  toast: vi.fn(),
+}));
+
+function row(title: string): MergedNotificationRow {
   return {
     feedId: "host:n-1",
     source: "host",
     sourceId: "n-1",
     createdAt: 10,
     readAt: null,
-    text,
+    title,
+    body: "New chat • Done",
     payload: { kind: "chat", epicId: "epic-1", chatId: "chat-1" },
     hostKind: "agent.stopped",
     appLocalKind: null,
@@ -27,15 +33,15 @@ describe("notification display", () => {
     const showNotification = vi.fn(() => Promise.resolve());
     const playChime = vi.fn();
 
-    displayNotificationRows([row("Agent finished")], {
+    displayNotificationRows([row("Checkout notifications")], {
       showNotification,
       playChime,
     });
 
     expect(showNotification).toHaveBeenCalledOnce();
     expect(showNotification).toHaveBeenCalledWith(
-      "Traycer",
-      "Agent finished",
+      "Checkout notifications",
+      "New chat • Done",
       {
         kind: "chat",
         epicId: "epic-1",
@@ -43,6 +49,10 @@ describe("notification display", () => {
       },
       "host:chat:chat-1",
     );
+    expect(toast).toHaveBeenCalledWith("Checkout notifications", {
+      description: "New chat • Done",
+      id: "host:chat:chat-1",
+    });
     expect(playChime).toHaveBeenCalledOnce();
   });
 
@@ -129,7 +139,7 @@ describe("notification display", () => {
     const playChime = vi.fn();
 
     expect(() => {
-      displayNotificationRows([row("Agent finished")], {
+      displayNotificationRows([row("Checkout notifications")], {
         showNotification,
         playChime,
       });

--- a/clients/gui-app/src/lib/notifications/notification-display.ts
+++ b/clients/gui-app/src/lib/notifications/notification-display.ts
@@ -1,4 +1,5 @@
 import type { NotificationShow } from "@/hooks/notifications/use-notifications";
+import { toast } from "sonner";
 import {
   rowFromAppLocalEntry,
   rowFromHostEntry,
@@ -32,6 +33,10 @@ export function displayNotificationRows(
   } catch {
     // The feed remains authoritative; a failed native toast is non-critical.
   }
+  toast(content.title, {
+    description: content.body,
+    id: content.replaceKey,
+  });
   target.playChime();
 }
 
@@ -84,8 +89,8 @@ function buildNotificationToastContent(
   const first = rows[0];
   if (rows.length === 1) {
     return {
-      title: "Traycer",
-      body: first.text,
+      title: first.title,
+      body: first.body,
       payload: first.payload,
       replaceKey: notificationReplaceKey(first),
     };

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
@@ -11,6 +11,7 @@ import {
   mergeNotificationFeedIds,
   mergedUnreadCount,
   rowFromAppLocalEntry,
+  rowFromGlobalEntry,
   rowFromHostEntry,
 } from "@/stores/notifications/merged-notifications";
 import type { AppLocalNotificationEntry } from "@/stores/notifications/app-local-notifications-store";
@@ -105,6 +106,13 @@ describe("merged notifications feed", () => {
       approvalId: "approval-1",
       sessionId: undefined,
       artifactId: undefined,
+    });
+  });
+
+  it("splits global notification titles from their collaboration context", () => {
+    expect(rowFromGlobalEntry(globalEntry("global", 10, null))).toMatchObject({
+      title: "Alice invited you to an epic",
+      body: "Collaboration",
     });
   });
 

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
@@ -108,6 +108,107 @@ describe("merged notifications feed", () => {
     });
   });
 
+  it("uses the task title in host notification copy", () => {
+    const base = {
+      id: "notification-1",
+      updatedAt: 10,
+      readAt: null,
+      sourceRef: "agent-1",
+    } as const;
+    const stopped: HostNotificationEntry = {
+      ...base,
+      kind: "agent.stopped",
+      severity: "done",
+      outcome: "completed",
+      payload: {
+        epicId: "epic-1",
+        chatId: "chat-1",
+        agentName: "Deploy checkout fix",
+        taskTitle: "Checkout notifications",
+        outcome: "completed",
+      },
+    };
+    const rateLimited: HostNotificationEntry = {
+      ...base,
+      kind: "agent.stopped",
+      severity: "failure",
+      outcome: "errored",
+      payload: {
+        epicId: "epic-1",
+        chatId: "chat-1",
+        agentName: "Deploy checkout fix",
+        taskTitle: "Checkout notifications",
+        outcome: "errored",
+        code: "RATE_LIMIT",
+      },
+    };
+    const stalled: HostNotificationEntry = {
+      ...base,
+      kind: "agent.stalled",
+      severity: "failure",
+      outcome: "errored",
+      payload: {
+        epicId: "epic-1",
+        chatId: "chat-1",
+        agentName: "Deploy checkout fix",
+        taskTitle: "Checkout notifications",
+      },
+    };
+    const interview: HostNotificationEntry = {
+      ...base,
+      kind: "interview.requested",
+      severity: "needs_action",
+      outcome: null,
+      resolvedAt: null,
+      payload: {
+        epicId: "epic-1",
+        chatId: "chat-1",
+        chatTitle: "Deploy checkout fix",
+        taskTitle: "Checkout notifications",
+      },
+    };
+
+    expect(rowFromHostEntry(stopped)).toMatchObject({
+      title: "Checkout notifications",
+      body: "Deploy checkout fix • Done",
+    });
+    expect(rowFromHostEntry(rateLimited)).toMatchObject({
+      title: "Checkout notifications",
+      body: "Deploy checkout fix • Rate limit reached",
+    });
+    expect(rowFromHostEntry(stalled)).toMatchObject({
+      title: "Checkout notifications",
+      body: "Deploy checkout fix • Stalled",
+    });
+    expect(rowFromHostEntry(interview)).toMatchObject({
+      title: "Checkout notifications",
+      body: "Deploy checkout fix • Question waiting",
+    });
+  });
+
+  it("does not display UUID placeholders from legacy host payloads", () => {
+    const interview: HostNotificationEntry = {
+      id: "legacy-interview",
+      updatedAt: 10,
+      readAt: null,
+      sourceRef: "interview-1",
+      kind: "interview.requested",
+      severity: "needs_action",
+      outcome: null,
+      resolvedAt: null,
+      payload: {
+        epicId: "epic-1",
+        chatId: "40694091-7647-44a6-856a-54d3fd620412",
+        chatTitle: "Chat 40694091-7647-44a6-856a-54d3fd620412",
+      },
+    };
+
+    expect(rowFromHostEntry(interview)).toMatchObject({
+      title: "Task",
+      body: "Chat • Question waiting",
+    });
+  });
+
   it("formats app-local rows with their own payload and kind", () => {
     expect(rowFromAppLocalEntry(appLocalEntry("setup", 10, null))).toEqual({
       feedId: appLocalFeedId("setup"),
@@ -115,7 +216,8 @@ describe("merged notifications feed", () => {
       sourceId: "setup",
       createdAt: 10,
       readAt: null,
-      text: "Worktree setup failed",
+      title: "Worktree setup failed",
+      body: "Traycer notification",
       payload: { kind: "chat", epicId: "epic-1", chatId: "chat-1" },
       hostKind: null,
       appLocalKind: "worktree.setup.failed",

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -45,7 +45,8 @@ export interface MergedNotificationRow {
   readonly sourceId: string;
   readonly createdAt: number;
   readonly readAt: number | null;
-  readonly text: string;
+  readonly title: string;
+  readonly body: string;
   readonly payload: NotificationPayload | null;
   readonly hostKind: HostNotificationFeedEntry["kind"] | null;
   readonly appLocalKind: AppLocalNotificationEntry["kind"] | null;
@@ -355,13 +356,15 @@ export function useMergedNotificationsActions(): MergedNotificationsActions {
 export function rowFromHostEntry(
   entry: HostNotificationFeedEntry,
 ): MergedNotificationRow {
+  const presentation = hostNotificationPresentation(entry);
   return {
     feedId: hostFeedId(entry.id),
     source: "host",
     sourceId: entry.id,
     createdAt: entry.updatedAt,
     readAt: entry.readAt,
-    text: formatHostNotification(entry),
+    title: presentation.title,
+    body: presentation.body,
     payload: payloadFromHostEntry(entry),
     hostKind: entry.kind,
     appLocalKind: null,
@@ -380,10 +383,8 @@ export function rowFromAppLocalEntry(
     sourceId: entry.id,
     createdAt: entry.updatedAt,
     readAt: entry.readAt,
-    text:
-      entry.detail === null
-        ? entry.message
-        : `${entry.message} ${entry.detail}`,
+    title: entry.message,
+    body: entry.detail ?? "Traycer notification",
     payload: entry.payload,
     hostKind: null,
     appLocalKind: entry.kind,
@@ -402,7 +403,8 @@ export function rowFromGlobalEntry(
     sourceId: entry.id,
     createdAt: entry.createdAt,
     readAt: entry.readAt,
-    text: formatNotification(entry.event, undefined),
+    title: formatNotification(entry.event, undefined),
+    body: "Collaboration",
     payload: buildPayloadFromEvent(entry.event),
     hostKind: null,
     appLocalKind: null,
@@ -476,33 +478,57 @@ function payloadFromHostEntry(
   return { kind: "chat", epicId, chatId };
 }
 
-function formatHostNotification(entry: HostNotificationFeedEntry): string {
-  const agentName = readPayloadString(entry.payload, "agentName");
-  const chatTitle = readPayloadString(entry.payload, "chatTitle");
+interface NotificationPresentation {
+  readonly title: string;
+  readonly body: string;
+}
+
+function hostNotificationPresentation(
+  entry: HostNotificationFeedEntry,
+): NotificationPresentation {
+  const agentName = readNotificationTitle(entry.payload, "agentName");
+  const chatTitle = readNotificationTitle(entry.payload, "chatTitle");
+  const taskTitle = readNotificationTitle(entry.payload, "taskTitle");
+  const title = taskTitle ?? chatTitle ?? agentName ?? "Task";
   switch (entry.kind) {
-    case "agent.stopped":
-      return formatAgentStoppedNotification(agentName, entry.outcome);
+    case "agent.stopped": {
+      const context = notificationContext(agentName, title, entry.payload);
+      return {
+        title,
+        body: `${context} • ${agentStoppedStatus(entry.outcome, readPayloadString(entry.payload, "code"))}`,
+      };
+    }
     case "agent.stalled":
-      return agentName === null ? "Agent stalled" : `${agentName} stalled`;
+      return {
+        title,
+        body: `${notificationContext(agentName, title, entry.payload)} • Stalled`,
+      };
     case "approval.requested":
-      return chatTitle === null
-        ? "Approval requested"
-        : `Approval requested in ${chatTitle}`;
+      return { title, body: `${chatTitle ?? "Chat"} • Approval requested` };
     case "interview.requested":
-      return chatTitle === null
-        ? "Question waiting"
-        : `Question waiting in ${chatTitle}`;
+      return { title, body: `${chatTitle ?? "Chat"} • Question waiting` };
   }
 }
 
-function formatAgentStoppedNotification(
-  agentName: string | null,
+function agentStoppedStatus(
   outcome: HostNotificationOutcome,
+  code: string | null,
 ): string {
-  const name = agentName ?? "Agent";
-  if (outcome === "errored") return `${name} failed`;
-  if (outcome === "stopped") return `${name} stopped`;
-  return `${name} finished`;
+  if (code === "RATE_LIMIT") return "Rate limit reached";
+  if (outcome === "errored") return "Failed";
+  if (outcome === "stopped") return "Stopped";
+  return "Done";
+}
+
+function notificationContext(
+  agentName: string | null,
+  title: string,
+  payload: HostNotificationFeedEntry["payload"],
+): string {
+  if (agentName !== null && agentName !== title) return agentName;
+  return readPayloadString(payload, "kind") === "epic"
+    ? "Terminal agent"
+    : "Chat";
 }
 
 function readPayloadString(
@@ -513,4 +539,16 @@ function readPayloadString(
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function readNotificationTitle(
+  payload: HostNotificationFeedEntry["payload"],
+  key: string,
+): string | null {
+  const value = readPayloadString(payload, key);
+  return value !== null && !LEGACY_ENTITY_UUID_PATTERN.test(value)
+    ? value
+    : null;
+}
+
 const HOST_PAGE_LIMIT = 50;
+const LEGACY_ENTITY_UUID_PATTERN =
+  /^(?:Chat|Task) [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -490,6 +490,8 @@ function hostNotificationPresentation(
   const chatTitle = readNotificationTitle(entry.payload, "chatTitle");
   const taskTitle = readNotificationTitle(entry.payload, "taskTitle");
   const title = taskTitle ?? chatTitle ?? agentName ?? "Task";
+  const chatContext =
+    chatTitle !== null && chatTitle !== title ? chatTitle : "Chat";
   switch (entry.kind) {
     case "agent.stopped": {
       const context = notificationContext(agentName, title, entry.payload);
@@ -504,9 +506,9 @@ function hostNotificationPresentation(
         body: `${notificationContext(agentName, title, entry.payload)} • Stalled`,
       };
     case "approval.requested":
-      return { title, body: `${chatTitle ?? "Chat"} • Approval requested` };
+      return { title, body: `${chatContext} • Approval requested` };
     case "interview.requested":
-      return { title, body: `${chatTitle ?? "Chat"} • Question waiting` };
+      return { title, body: `${chatContext} • Question waiting` };
   }
 }
 


### PR DESCRIPTION
Summary: OS-style notification cards now show the task title first, with chat or agent context and status below. Native and in-app toasts use the same title/body content. Legacy UUID placeholders are suppressed and truncated titles expose their full value on hover. Verification: targeted GUI tests, GUI compile, and diff check passed.