### PR TITLE
fix(gui): avoid sign-in prompt for retryable auth failures

### DIFF
--- a/clients/gui-app/src/lib/__tests__/host-error-toast.test.ts
+++ b/clients/gui-app/src/lib/__tests__/host-error-toast.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -12,6 +12,10 @@ import {
   toastFromHostError,
   toastFromHostErrorWithDetail,
 } from "@/lib/host-error-toast";
+import {
+  __resetAppLocalNotificationsStoreForTests,
+  useAppLocalNotificationsStore,
+} from "@/stores/notifications/app-local-notifications-store";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 
 function makeError(code: HostRpcError["code"], message: string): HostRpcError {
@@ -25,6 +29,10 @@ function makeError(code: HostRpcError["code"], message: string): HostRpcError {
 }
 
 describe("toastFromHostError", () => {
+  afterEach(() => {
+    __resetAppLocalNotificationsStoreForTests();
+  });
+
   it("shows permission copy for FORBIDDEN", () => {
     toastFromHostError(makeError("FORBIDDEN", "test error"), "fallback");
     expect(toast.error).toHaveBeenCalledWith(
@@ -55,6 +63,37 @@ describe("toastFromHostError", () => {
   it("shows sign-in copy for UNAUTHORIZED", () => {
     toastFromHostError(makeError("UNAUTHORIZED", "test error"), "fallback");
     expect(toast.error).toHaveBeenCalledWith("Please sign in again.");
+  });
+
+  it("uses operation copy for retryable UNAUTHORIZED host failures", () => {
+    __resetAppLocalNotificationsStoreForTests();
+    useAppLocalNotificationsStore.getState().activateIdentity("user-1");
+    const reason = "Signing key unavailable: request timed out";
+    const error = new HostRpcError({
+      code: "UNAUTHORIZED",
+      message: reason,
+      requestId: "req-retryable-auth",
+      method: "providers.list",
+      fatalDetails: {
+        code: "UNAUTHORIZED",
+        reason,
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+        retryable: true,
+      },
+    });
+
+    toastFromHostError(error, "Couldn't refresh providers.");
+
+    expect(toast.error).toHaveBeenCalledWith("Couldn't refresh providers.");
+    expect(
+      useAppLocalNotificationsStore.getState().byId[
+        "host.error:providers.list:req-retryable-auth"
+      ],
+    ).toMatchObject({
+      message: "Couldn't refresh providers.",
+      detail: reason,
+    });
   });
 
   it("shows rebind-blocked copy for WORKTREE_REBIND_BLOCKED", () => {

--- a/clients/gui-app/src/lib/host-error-toast.ts
+++ b/clients/gui-app/src/lib/host-error-toast.ts
@@ -54,6 +54,7 @@ function hostErrorToastMessage(error: HostRpcError, fallback: string) {
     return "You don't have permission to do that.";
   }
   if (error.code === "UNAUTHORIZED") {
+    if (error.fatalDetails?.retryable === true) return fallback;
     return "Please sign in again.";
   }
   if (error.code === "WORKTREE_BUSY") {


### PR DESCRIPTION
## Summary\n- retain operation-specific retryable messaging when a JWKS lookup times out\n- keep the sign-in prompt reserved for non-retryable authentication failures\n- cover the durable notification path with a regression test\n\n## Verification\n- 
 NX   Running target test for 5 projects:

- @traycer-clients/traycer-cli
- @traycer-clients/desktop
- traycer-clients-gui-app
- @traycer-clients/shared
- @traycer/protocol

With additional flags:
  src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts



> nx run @traycer-clients/shared:test src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts

(node:54011) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mvitest run src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts[0m
(node:54114) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)

 RUN  v4.1.9 /Users/tgill/.traycer/worktrees/traycerai__traycer-internal/traycer-quick-penguin/traycer/clients/shared

No test files found, exiting with code 1

filter: src/stores/notifications/__tests__/app-local-notifications-store.test.ts, src/lib/__tests__/host-error-toast.test.ts
include: **/__tests__/**/*.test.ts
exclude:  **/node_modules/**, **/.git/**

[0m[31merror[0m[2m:[0m script [1m"test"[0m exited with code 1[0m

> nx run @traycer-clients/desktop:test src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts

(node:54014) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mvitest run src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts[0m
(node:54113) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)

 RUN  v4.1.9 /Users/tgill/.traycer/worktrees/traycerai__traycer-internal/traycer-quick-penguin/traycer/clients/desktop

No test files found, exiting with code 1

filter: src/stores/notifications/__tests__/app-local-notifications-store.test.ts, src/lib/__tests__/host-error-toast.test.ts
include: **/__tests__/**/*.test.ts
exclude:  **/node_modules/**, **/.git/**

[0m[31merror[0m[2m:[0m script [1m"test"[0m exited with code 1[0m

> nx run @traycer/protocol:test src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts

(node:54012) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mvitest run src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts[0m
(node:54116) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)

 RUN  v4.1.9 /Users/tgill/.traycer/worktrees/traycerai__traycer-internal/traycer-quick-penguin/traycer/protocol

No test files found, exiting with code 1

filter: src/stores/notifications/__tests__/app-local-notifications-store.test.ts, src/lib/__tests__/host-error-toast.test.ts
include: **/__tests__/**/*.test.ts
exclude:  **/node_modules/**, **/.git/**

[0m[31merror[0m[2m:[0m script [1m"test"[0m exited with code 1[0m

> nx run @traycer-clients/traycer-cli:test src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts

(node:54013) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mvitest run --config vitest.config.ts src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts[0m
(node:54117) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)

 RUN  v4.1.9 /Users/tgill/.traycer/worktrees/traycerai__traycer-internal/traycer-quick-penguin/traycer/clients/traycer-cli

No test files found, exiting with code 1

filter: src/stores/notifications/__tests__/app-local-notifications-store.test.ts, src/lib/__tests__/host-error-toast.test.ts
include: src/**/__tests__/**/*.test.ts
exclude:  **/node_modules/**, **/.git/**

[0m[31merror[0m[2m:[0m script [1m"test"[0m exited with code 1[0m

> nx run traycer-clients-gui-app:test src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts

(node:54015) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mvitest run --config vitest.config.ts src/stores/notifications/__tests__/app-local-notifications-store.test.ts src/lib/__tests__/host-error-toast.test.ts[0m
(node:54115) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)

 RUN  v4.1.9 /Users/tgill/.traycer/worktrees/traycerai__traycer-internal/traycer-quick-penguin/traycer/clients/gui-app

(node:54137) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:54136) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)

 Test Files  2 passed (2)
      Tests  18 passed (18)
   Start at  23:45:24
   Duration  1.86s (transform 1.04s, setup 352ms, import 1.63s, tests 30ms, environment 1.47s)\n- 
 NX   Running target compile for 4 projects:

- @traycer-clients/traycer-cli
- @traycer-clients/desktop
- traycer-clients-gui-app
- @traycer/protocol



> nx run @traycer/protocol:compile

(node:54278) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mtsc --noEmit[0m

> nx run @traycer-clients/traycer-cli:compile

(node:54901) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mtsc --noEmit[0m

> nx run @traycer-clients/desktop:compile

(node:54279) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mtsc --noEmit -p tsconfig.json[0m

> nx run traycer-clients-gui-app:compile

(node:54280) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
(Use `node --trace-warnings ...` to show where the warning was created)
[0m[2m[35m$[0m [2m[1mtsc -b[0m



 NX   Successfully ran target compile for 4 projects\n- \n- Checking formatting...
All matched files use Prettier code style!\n