### PR TITLE
feat(rate-limits): use Codex manual reset credits

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -22,6 +22,7 @@ import {
   type AccountContext,
 } from "@traycer/protocol/common/schemas";
 import type { ProviderRateLimits } from "@traycer/protocol/host";
+import type { ProvidersConsumeRateLimitResetCreditRequest } from "@traycer/protocol/host/rate-limit";
 import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
 import type {
@@ -69,6 +70,12 @@ type MockState = {
   traycerUsageUpdatedAt: Readonly<Record<string, number>>;
   openSettings: Mock<(...args: unknown[]) => void>;
   enqueue: Mock<(...args: unknown[]) => Promise<void>>;
+  consumeReset: Mock<
+    (
+      request: ProvidersConsumeRateLimitResetCreditRequest,
+      options: { readonly onSuccess: () => void },
+    ) => void
+  >;
   authUser: MockAuthUser;
   // Last `options` object `RateLimitRefreshAllButton` passed to
   // `useHostQueries`, so a test can assert it reused the real lane options
@@ -103,6 +110,7 @@ const mocks = vi.hoisted<MockState>(() => ({
   traycerUsageUpdatedAt: {},
   openSettings: vi.fn(),
   enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  consumeReset: vi.fn(),
   lastUseHostQueriesOptions: null,
   lastUseHostQueriesProviderIds: null,
   profileSelection: {
@@ -204,6 +212,15 @@ vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
 vi.mock("@/hooks/rate-limits/use-rate-limit-queue-scope", () => ({
   useRateLimitQueueScope: () => queueScope,
 }));
+vi.mock(
+  "@/hooks/providers/use-consume-rate-limit-reset-credit-mutation",
+  () => ({
+    useConsumeRateLimitResetCreditMutation: () => ({
+      isPending: false,
+      mutate: mocks.consumeReset,
+    }),
+  }),
+);
 vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
   // Wrapper (not `mocks.enqueue` directly) so `beforeEach` can swap the spy -
   // an object-literal binding would freeze the original fn at module load.
@@ -312,10 +329,10 @@ function claudeReady(): AvailableProviderRateLimits {
   };
 }
 
-function codexReady(): AvailableProviderRateLimits {
+function codexReady() {
   return {
-    provider: "codex",
-    available: true,
+    provider: "codex" as const,
+    available: true as const,
     planType: "pro_5x",
     limitId: null,
     limitName: null,
@@ -499,6 +516,7 @@ beforeEach(() => {
   mocks.traycerUsageUpdatedAt = {};
   mocks.openSettings = vi.fn();
   mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
+  mocks.consumeReset = vi.fn();
   mocks.lastUseHostQueriesOptions = null;
   mocks.lastUseHostQueriesProviderIds = null;
   mocks.profileSelection = {
@@ -980,6 +998,31 @@ describe("<RateLimitPopover /> Overview progressive reveal", () => {
 });
 
 describe("<RateLimitPopover /> per-provider states", () => {
+  it("offers a confirmed Codex reset on the detail panel but keeps Overview read-only", () => {
+    mocks.configured = [
+      { providerId: "codex", lane: "ephemeralProcess", profiles: undefined },
+    ];
+    mocks.results = {
+      codex: readyResult({
+        ...codexReady(),
+        resetCredits: { availableCount: 2 },
+      }),
+    };
+
+    renderPopover();
+    expect(screen.queryByRole("button", { name: "Use reset" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Codex" }));
+    fireEvent.click(screen.getByRole("button", { name: "Use reset" }));
+    expect(screen.getByText("Use a Codex manual reset?")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(mocks.consumeReset).toHaveBeenCalledOnce();
+    const request = mocks.consumeReset.mock.calls[0]?.[0];
+    expect(request).toMatchObject({ providerId: "codex", profileId: null });
+    expect(typeof request.idempotencyKey).toBe("string");
+  });
+
   it("shows skeleton bars (not a spinner) on cold load", () => {
     mocks.configured = [
       { providerId: "codex", lane: "ephemeralProcess", profiles: undefined },

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -29,6 +29,7 @@ import {
   ProviderRateLimitDetail,
   type ProviderRateLimitQueryState,
 } from "@/components/settings/panels/provider-rate-limit-views";
+import { CodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-action";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import {
@@ -239,6 +240,15 @@ export function RateLimitPopover({
       // focusable is its search input, so it wants and keeps the auto-focus), so
       // opting out of the initial focus is harmless and stops the stuck tooltip.
       onOpenAutoFocus={(event) => event.preventDefault()}
+      onInteractOutside={(event) => {
+        const target = event.target;
+        if (
+          target instanceof Element &&
+          target.closest('[data-testid="confirm-destructive-dialog"]') !== null
+        ) {
+          event.preventDefault();
+        }
+      }}
     >
       <RateLimitPopoverBody
         onClose={onClose}
@@ -901,7 +911,7 @@ function SingleProfileRateLimitProviderBlock({
           ) : null}
         </div>
       </div>
-      <RateLimitProviderBody state={state} variant={variant} />
+      <RateLimitProviderBody state={state} variant={variant} profileId={null} />
     </div>
   );
 }
@@ -1145,7 +1155,11 @@ function RateLimitProviderProfileRow({
           />
         </div>
       </div>
-      <RateLimitProviderBody state={state} variant={variant} />
+      <RateLimitProviderBody
+        state={state}
+        variant={variant}
+        profileId={profileId}
+      />
     </div>
   );
 }
@@ -1255,9 +1269,11 @@ function UpdatedAgoText({
 function RateLimitProviderBody({
   state,
   variant,
+  profileId,
 }: {
   readonly state: PopoverProviderRateLimitState;
   readonly variant: PopoverBlockVariant;
+  readonly profileId: string | null;
 }): ReactNode {
   switch (state.kind) {
     case "cold":
@@ -1291,7 +1307,16 @@ function RateLimitProviderBody({
       // than replacing it with an error (Core Flows).
       return (
         <div className={cn(state.degraded && "opacity-60")}>
-          <ProviderRateLimitDetail data={state.data} variant={variant} />
+          <ProviderRateLimitDetail
+            data={state.data}
+            variant={variant}
+            codexResetAction={
+              variant === "popover-detail" &&
+              state.data.provider === "codex" ? (
+                <CodexResetCreditAction profileId={profileId} />
+              ) : null
+            }
+          />
         </div>
       );
   }

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -30,6 +30,7 @@ import {
   type ProviderRateLimitQueryState,
 } from "@/components/settings/panels/provider-rate-limit-views";
 import { CodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-action";
+import { canUseCodexResetCredit } from "@/components/settings/panels/codex-reset-credit-availability";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import {
@@ -244,7 +245,9 @@ export function RateLimitPopover({
         const target = event.target;
         if (
           target instanceof Element &&
-          target.closest('[data-testid="confirm-destructive-dialog"]') !== null
+          (target.closest('[data-testid="confirm-destructive-dialog"]') !==
+            null ||
+            target.closest('[data-slot="dialog-overlay"]') !== null)
         ) {
           event.preventDefault();
         }
@@ -1311,8 +1314,10 @@ function RateLimitProviderBody({
             data={state.data}
             variant={variant}
             codexResetAction={
-              variant === "popover-detail" &&
-              state.data.provider === "codex" ? (
+              canUseCodexResetCredit(
+                state.data.provider,
+                variant === "popover-detail",
+              ) ? (
                 <CodexResetCreditAction profileId={profileId} />
               ) : null
             }

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -29,8 +29,7 @@ import {
   ProviderRateLimitDetail,
   type ProviderRateLimitQueryState,
 } from "@/components/settings/panels/provider-rate-limit-views";
-import { CodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-action";
-import { canUseCodexResetCredit } from "@/components/settings/panels/codex-reset-credit-availability";
+import { resolveCodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-availability";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import {
@@ -1313,14 +1312,11 @@ function RateLimitProviderBody({
           <ProviderRateLimitDetail
             data={state.data}
             variant={variant}
-            codexResetAction={
-              canUseCodexResetCredit(
-                state.data.provider,
-                variant === "popover-detail",
-              ) ? (
-                <CodexResetCreditAction profileId={profileId} />
-              ) : null
-            }
+            codexResetAction={resolveCodexResetCreditAction(
+              state.data.provider,
+              profileId,
+              variant === "popover-detail",
+            )}
           />
         </div>
       );

--- a/clients/gui-app/src/components/settings/panels/__tests__/codex-reset-credit-action.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/codex-reset-credit-action.test.tsx
@@ -48,5 +48,9 @@ describe("CodexResetCreditAction", () => {
       profileId: "personal",
     });
     expect(typeof request.idempotencyKey).toBe("string");
+
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    const retry = mocks.mutate.mock.calls[1]?.[0];
+    expect(retry.idempotencyKey).toBe(request.idempotencyKey);
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/codex-reset-credit-action.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/codex-reset-credit-action.test.tsx
@@ -1,0 +1,52 @@
+import "../../../../../__tests__/test-browser-apis";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ProvidersConsumeRateLimitResetCreditRequest } from "@traycer/protocol/host/rate-limit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isPending: false,
+  mutate:
+    vi.fn<
+      (
+        request: ProvidersConsumeRateLimitResetCreditRequest,
+        options: { readonly onSuccess: () => void },
+      ) => void
+    >(),
+}));
+
+vi.mock(
+  "@/hooks/providers/use-consume-rate-limit-reset-credit-mutation",
+  () => ({
+    useConsumeRateLimitResetCreditMutation: () => ({
+      isPending: mocks.isPending,
+      mutate: mocks.mutate,
+    }),
+  }),
+);
+
+import { CodexResetCreditAction } from "../codex-reset-credit-action";
+
+afterEach(() => {
+  cleanup();
+  mocks.isPending = false;
+  mocks.mutate.mockReset();
+});
+
+describe("CodexResetCreditAction", () => {
+  it("requires confirmation and sends a profile-scoped idempotent request", () => {
+    render(<CodexResetCreditAction profileId="personal" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Use reset" }));
+    expect(screen.getByText("Use a Codex manual reset?")).toBeTruthy();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(mocks.mutate).toHaveBeenCalledOnce();
+    const request = mocks.mutate.mock.calls[0]?.[0];
+    expect(request).toMatchObject({
+      providerId: "codex",
+      profileId: "personal",
+    });
+    expect(typeof request.idempotencyKey).toBe("string");
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -446,6 +446,7 @@ describe("ProviderRateLimitDetail dispatch", () => {
           balance: 12,
         }}
         variant="settings"
+        codexResetAction={null}
       />,
     );
     expect(screen.getByText("Balance")).toBeTruthy();
@@ -462,6 +463,7 @@ describe("ProviderRateLimitDetail dispatch", () => {
           passState: null,
         }}
         variant="settings"
+        codexResetAction={null}
       />,
     );
     expect(screen.getByText("Credit balance")).toBeTruthy();
@@ -486,6 +488,7 @@ describe("ProviderRateLimitBody (unavailable state)", () => {
           lastGoodAt: null,
           lastFailureAt: NOW,
         }}
+        codexResetAction={null}
       />,
     );
     expect(
@@ -493,5 +496,40 @@ describe("ProviderRateLimitBody (unavailable state)", () => {
         "Usage limits unavailable - not available for this account",
       ),
     ).toBeTruthy();
+  });
+});
+
+describe("ProviderRateLimitBody (Codex reset action)", () => {
+  it("places the supplied action beside a positive manual-reset count", () => {
+    render(
+      <ProviderRateLimitBody
+        isPending={false}
+        isFetching={false}
+        isError={false}
+        envelope={{
+          latest: {
+            provider: "codex",
+            available: true,
+            planType: "pro_5x",
+            limitId: "codex",
+            limitName: "Codex",
+            primary: null,
+            secondary: null,
+            extraWindows: [],
+            credits: null,
+            individualLimit: null,
+            resetCredits: { availableCount: 3 },
+            rateLimitReachedType: null,
+          },
+          lastGood: null,
+          lastGoodAt: null,
+          lastFailureAt: null,
+        }}
+        codexResetAction={<button type="button">Use reset</button>}
+      />,
+    );
+
+    expect(screen.getByText("3 available")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Use reset" })).toBeTruthy();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/codex-reset-credit-action.tsx
+++ b/clients/gui-app/src/components/settings/panels/codex-reset-credit-action.tsx
@@ -1,0 +1,52 @@
+import { useState, type ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
+import { useConsumeRateLimitResetCreditMutation } from "@/hooks/providers/use-consume-rate-limit-reset-credit-mutation";
+
+export function CodexResetCreditAction({
+  profileId,
+}: {
+  readonly profileId: string | null;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+  const mutation = useConsumeRateLimitResetCreditMutation();
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        disabled={mutation.isPending}
+        onClick={() => {
+          setOpen(true);
+        }}
+      >
+        Use reset
+      </Button>
+      <ConfirmDestructiveDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="Use a Codex manual reset?"
+        description="This uses one manual reset on the currently reached Codex usage limit. The reset can't be returned or undone."
+        cascadeSummary={null}
+        actionLabel="Use reset"
+        isPending={mutation.isPending}
+        onConfirm={() => {
+          mutation.mutate(
+            {
+              providerId: "codex",
+              profileId,
+              idempotencyKey: crypto.randomUUID(),
+            },
+            {
+              onSuccess: () => {
+                setOpen(false);
+              },
+            },
+          );
+        }}
+      />
+    </>
+  );
+}

--- a/clients/gui-app/src/components/settings/panels/codex-reset-credit-action.tsx
+++ b/clients/gui-app/src/components/settings/panels/codex-reset-credit-action.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import { useConsumeRateLimitResetCreditMutation } from "@/hooks/providers/use-consume-rate-limit-reset-credit-mutation";
@@ -22,6 +23,13 @@ export function CodexResetCreditAction({
           setOpen(true);
         }}
       >
+        {mutation.isPending ? (
+          <AgentSpinningDots
+            className={undefined}
+            testId={undefined}
+            variant={undefined}
+          />
+        ) : null}
         Use reset
       </Button>
       <ConfirmDestructiveDialog

--- a/clients/gui-app/src/components/settings/panels/codex-reset-credit-action.tsx
+++ b/clients/gui-app/src/components/settings/panels/codex-reset-credit-action.tsx
@@ -10,6 +10,7 @@ export function CodexResetCreditAction({
   readonly profileId: string | null;
 }): ReactNode {
   const [open, setOpen] = useState(false);
+  const [idempotencyKey, setIdempotencyKey] = useState<string | null>(null);
   const mutation = useConsumeRateLimitResetCreditMutation();
 
   return (
@@ -20,6 +21,7 @@ export function CodexResetCreditAction({
         size="xs"
         disabled={mutation.isPending}
         onClick={() => {
+          setIdempotencyKey(crypto.randomUUID());
           setOpen(true);
         }}
       >
@@ -34,21 +36,26 @@ export function CodexResetCreditAction({
       </Button>
       <ConfirmDestructiveDialog
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          if (!nextOpen) setIdempotencyKey(null);
+        }}
         title="Use a Codex manual reset?"
         description="This uses one manual reset on the currently reached Codex usage limit. The reset can't be returned or undone."
         cascadeSummary={null}
         actionLabel="Use reset"
         isPending={mutation.isPending}
         onConfirm={() => {
+          if (idempotencyKey === null) return;
           mutation.mutate(
             {
               providerId: "codex",
               profileId,
-              idempotencyKey: crypto.randomUUID(),
+              idempotencyKey,
             },
             {
               onSuccess: () => {
+                setIdempotencyKey(null);
                 setOpen(false);
               },
             },

--- a/clients/gui-app/src/components/settings/panels/codex-reset-credit-availability.ts
+++ b/clients/gui-app/src/components/settings/panels/codex-reset-credit-availability.ts
@@ -1,8 +1,12 @@
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+import { createElement, type ReactNode } from "react";
+import { CodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-action";
 
-export function canUseCodexResetCredit(
+export function resolveCodexResetCreditAction(
   providerId: ProviderId,
+  profileId: string | null,
   enabled: boolean,
-): boolean {
-  return enabled && providerId === "codex";
+): ReactNode {
+  if (!enabled || providerId !== "codex") return null;
+  return createElement(CodexResetCreditAction, { profileId });
 }

--- a/clients/gui-app/src/components/settings/panels/codex-reset-credit-availability.ts
+++ b/clients/gui-app/src/components/settings/panels/codex-reset-credit-availability.ts
@@ -1,0 +1,8 @@
+import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
+
+export function canUseCodexResetCredit(
+  providerId: ProviderId,
+  enabled: boolean,
+): boolean {
+  return enabled && providerId === "codex";
+}

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
@@ -2,6 +2,7 @@ import { useCallback, type ReactNode } from "react";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { ProviderRateLimitBody } from "@/components/settings/panels/provider-rate-limit-views";
+import { CodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-action";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
@@ -136,6 +137,11 @@ function EmbeddedProviderRateLimitSettingsCard({
         isFetching={query.isFetching}
         isError={query.isError}
         envelope={query.data}
+        codexResetAction={
+          providerId === "codex" ? (
+            <CodexResetCreditAction profileId={profileId} />
+          ) : null
+        }
       />
     </div>
   );
@@ -177,6 +183,11 @@ function ProviderRateLimitSettingsCard({
         isFetching={query.isFetching || isRefreshing}
         isError={query.isError}
         envelope={query.data}
+        codexResetAction={
+          providerId === "codex" ? (
+            <CodexResetCreditAction profileId={profileId} />
+          ) : null
+        }
       />
     </div>
   );

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
@@ -3,6 +3,7 @@ import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { ProviderRateLimitBody } from "@/components/settings/panels/provider-rate-limit-views";
 import { CodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-action";
+import { canUseCodexResetCredit } from "@/components/settings/panels/codex-reset-credit-availability";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
@@ -138,7 +139,7 @@ function EmbeddedProviderRateLimitSettingsCard({
         isError={query.isError}
         envelope={query.data}
         codexResetAction={
-          providerId === "codex" ? (
+          canUseCodexResetCredit(providerId, true) ? (
             <CodexResetCreditAction profileId={profileId} />
           ) : null
         }
@@ -184,7 +185,7 @@ function ProviderRateLimitSettingsCard({
         isError={query.isError}
         envelope={query.data}
         codexResetAction={
-          providerId === "codex" ? (
+          canUseCodexResetCredit(providerId, true) ? (
             <CodexResetCreditAction profileId={profileId} />
           ) : null
         }

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-section.tsx
@@ -2,8 +2,7 @@ import { useCallback, type ReactNode } from "react";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 import { RefreshIconButton } from "@/components/refresh-icon-button";
 import { ProviderRateLimitBody } from "@/components/settings/panels/provider-rate-limit-views";
-import { CodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-action";
-import { canUseCodexResetCredit } from "@/components/settings/panels/codex-reset-credit-availability";
+import { resolveCodexResetCreditAction } from "@/components/settings/panels/codex-reset-credit-availability";
 import { useHostProviderRateLimitsQuery } from "@/hooks/host/use-host-provider-rate-limits-query";
 import { useRefreshProviderRateLimitsOnMount } from "@/hooks/host/use-refresh-provider-rate-limits-on-mount";
 import { useRefreshProviderRateLimitsOnTurn } from "@/hooks/host/use-refresh-provider-rate-limits-on-turn";
@@ -138,11 +137,11 @@ function EmbeddedProviderRateLimitSettingsCard({
         isFetching={query.isFetching}
         isError={query.isError}
         envelope={query.data}
-        codexResetAction={
-          canUseCodexResetCredit(providerId, true) ? (
-            <CodexResetCreditAction profileId={profileId} />
-          ) : null
-        }
+        codexResetAction={resolveCodexResetCreditAction(
+          providerId,
+          profileId,
+          true,
+        )}
       />
     </div>
   );
@@ -184,11 +183,11 @@ function ProviderRateLimitSettingsCard({
         isFetching={query.isFetching || isRefreshing}
         isError={query.isError}
         envelope={query.data}
-        codexResetAction={
-          canUseCodexResetCredit(providerId, true) ? (
-            <CodexResetCreditAction profileId={profileId} />
-          ) : null
-        }
+        codexResetAction={resolveCodexResetCreditAction(
+          providerId,
+          profileId,
+          true,
+        )}
       />
     </div>
   );

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -367,6 +367,24 @@ export function CodexRateLimitView({
   readonly data: CodexRateLimits;
   readonly variant: RateLimitViewVariant;
 }): ReactNode {
+  return (
+    <CodexRateLimitViewContent
+      data={data}
+      variant={variant}
+      resetAction={null}
+    />
+  );
+}
+
+function CodexRateLimitViewContent({
+  data,
+  variant,
+  resetAction,
+}: {
+  readonly data: CodexRateLimits;
+  readonly variant: RateLimitViewVariant;
+  readonly resetAction: ReactNode;
+}): ReactNode {
   // Overview keeps only the primary/secondary (5h/Weekly) windows; the badge,
   // credits, per-model extraWindows, spend control, and reset credits are
   // single-provider-tab detail (`!isOverviewVariant`). The plan/tier label
@@ -425,7 +443,10 @@ export function CodexRateLimitView({
 
   const manualResets: ReactNode =
     !overview && data.resetCredits !== null ? (
-      <CodexResetCreditsRow resetCredits={data.resetCredits} />
+      <CodexResetCreditsRow
+        resetCredits={data.resetCredits}
+        resetAction={resetAction}
+      />
     ) : null;
 
   // Overview never gets here with more than `globalLimits`; the divider
@@ -459,14 +480,19 @@ export function CodexRateLimitView({
  */
 function CodexResetCreditsRow({
   resetCredits,
+  resetAction,
 }: {
   readonly resetCredits: NonNullable<CodexRateLimits["resetCredits"]>;
+  readonly resetAction: ReactNode;
 }): ReactNode {
   return (
-    <div className="flex items-center justify-between text-ui-sm">
+    <div className="flex flex-wrap items-center justify-between gap-2 text-ui-sm">
       <span className="text-muted-foreground">Manual resets</span>
-      <span className="font-mono text-ui-xs text-foreground">
-        {resetCredits.availableCount} available
+      <span className="flex items-center gap-2">
+        <span className="font-mono text-ui-xs text-foreground">
+          {resetCredits.availableCount} available
+        </span>
+        {resetCredits.availableCount > 0 ? resetAction : null}
       </span>
     </div>
   );
@@ -745,7 +771,7 @@ export function KiloCodeRateLimitView({
 }
 
 export function ProviderRateLimitBody(
-  props: ProviderRateLimitQueryState,
+  props: ProviderRateLimitQueryState & { readonly codexResetAction: ReactNode },
 ): ReactNode {
   const state = resolveProviderRateLimitViewState(props);
   // `isPending` alone stays `true` forever for a disabled query (e.g. a chat
@@ -786,7 +812,13 @@ export function ProviderRateLimitBody(
       </p>
     );
   }
-  return <ProviderRateLimitDetail data={data} variant="settings" />;
+  return (
+    <ProviderRateLimitDetail
+      data={data}
+      variant="settings"
+      codexResetAction={props.codexResetAction}
+    />
+  );
 }
 
 /**
@@ -800,13 +832,21 @@ export function ProviderRateLimitBody(
 export function ProviderRateLimitDetail({
   data,
   variant,
+  codexResetAction,
 }: {
   readonly data: AvailableProviderRateLimits;
   readonly variant: RateLimitViewVariant;
+  readonly codexResetAction: ReactNode;
 }): ReactNode {
   switch (data.provider) {
     case "codex":
-      return <CodexRateLimitView data={data} variant={variant} />;
+      return (
+        <CodexRateLimitViewContent
+          data={data}
+          variant={variant}
+          resetAction={codexResetAction}
+        />
+      );
     case "claude-code":
       return <ClaudeRateLimitView data={data} variant={variant} />;
     // OpenRouter/Kilo Code report no usage *windows* (only credit/spend bars and

--- a/clients/gui-app/src/hooks/providers/use-consume-rate-limit-reset-credit-mutation.ts
+++ b/clients/gui-app/src/hooks/providers/use-consume-rate-limit-reset-credit-mutation.ts
@@ -1,0 +1,91 @@
+import { useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
+import type {
+  ProvidersConsumeRateLimitResetCreditRequest,
+  ProvidersConsumeRateLimitResetCreditResponse,
+} from "@traycer/protocol/host/rate-limit";
+import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { toast } from "sonner";
+import { useHostMutation } from "@/hooks/host/use-host-query";
+import { useRateLimitQueueScope } from "@/hooks/rate-limits/use-rate-limit-queue-scope";
+import { useHostClient, type HostRpcRegistry } from "@/lib/host";
+import { toastFromHostError } from "@/lib/host-error-toast";
+import { hostQueryKeys, providersMutationKeys } from "@/lib/query-keys";
+import {
+  enqueueRateLimitFetchForScope,
+  type RateLimitQueueConfig,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
+
+interface ConsumeResetCreditContext {
+  readonly hostId: string | null;
+  readonly queueScope: RateLimitQueueConfig | null;
+}
+
+function toastResetOutcome(
+  response: ProvidersConsumeRateLimitResetCreditResponse,
+): void {
+  switch (response.outcome) {
+    case "reset":
+      toast.success("Codex usage limit reset");
+      return;
+    case "nothingToReset":
+      toast.info("Codex has no active usage limit to reset.");
+      return;
+    case "noCredit":
+      toast.info("No Codex manual resets are available.");
+      return;
+    case "alreadyRedeemed":
+      toast.info("That Codex manual reset was already used.");
+  }
+}
+
+export function useConsumeRateLimitResetCreditMutation(): UseMutationResult<
+  ProvidersConsumeRateLimitResetCreditResponse,
+  HostRpcError,
+  ProvidersConsumeRateLimitResetCreditRequest,
+  ConsumeResetCreditContext
+> {
+  const client = useHostClient();
+  const queryClient = useQueryClient();
+  const queueScope = useRateLimitQueueScope();
+
+  return useHostMutation<
+    HostRpcRegistry,
+    "providers.consumeRateLimitResetCredit",
+    ConsumeResetCreditContext
+  >({
+    client,
+    method: "providers.consumeRateLimitResetCredit",
+    mapVariables: (variables) => variables,
+    options: {
+      mutationKey: providersMutationKeys.consumeRateLimitResetCredit(),
+      onMutate: () => ({
+        hostId: client.getActiveHostId() ?? null,
+        queueScope,
+      }),
+      onSuccess: (data, variables, context) => {
+        toastResetOutcome(data);
+        if (context.hostId === null) return;
+        void queryClient.invalidateQueries({
+          queryKey: hostQueryKeys.method<
+            HostRpcRegistry,
+            "host.getRateLimitUsage"
+          >(context.hostId, "host.getRateLimitUsage", {
+            accountContext: DEFAULT_ACCOUNT_CONTEXT,
+            providerId: "codex",
+            profileId: variables.profileId,
+          }),
+        });
+        if (context.queueScope?.hostId !== context.hostId) return;
+        void enqueueRateLimitFetchForScope(
+          context.queueScope,
+          "codex",
+          DEFAULT_ACCOUNT_CONTEXT,
+          { force: true, profileId: variables.profileId },
+        );
+      },
+      onError: (error) =>
+        toastFromHostError(error, "Couldn't use the Codex manual reset."),
+    },
+  });
+}

--- a/clients/gui-app/src/hooks/providers/use-consume-rate-limit-reset-credit-mutation.ts
+++ b/clients/gui-app/src/hooks/providers/use-consume-rate-limit-reset-credit-mutation.ts
@@ -63,10 +63,10 @@ export function useConsumeRateLimitResetCreditMutation(): UseMutationResult<
         hostId: client.getActiveHostId() ?? null,
         queueScope,
       }),
-      onSuccess: (data, variables, context) => {
+      onSuccess: async (data, variables, context) => {
         toastResetOutcome(data);
         if (context.hostId === null) return;
-        void queryClient.invalidateQueries({
+        const rateLimitQueryFilters = {
           queryKey: hostQueryKeys.method<
             HostRpcRegistry,
             "host.getRateLimitUsage"
@@ -75,7 +75,10 @@ export function useConsumeRateLimitResetCreditMutation(): UseMutationResult<
             providerId: "codex",
             profileId: variables.profileId,
           }),
-        });
+          exact: true,
+        };
+        await queryClient.cancelQueries(rateLimitQueryFilters);
+        await queryClient.invalidateQueries(rateLimitQueryFilters);
         if (context.queueScope?.hostId !== context.hostId) return;
         void enqueueRateLimitFetchForScope(
           context.queueScope,

--- a/clients/gui-app/src/lib/query-keys/providers-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/providers-mutation-keys.ts
@@ -16,4 +16,6 @@ export const providersMutationKeys = {
   removeProfile: () => ["providers.removeProfile"] as const,
   refresh: () => ["providers.refresh"] as const,
   acknowledgeAmbientDrift: () => ["providers.acknowledgeAmbientDrift"] as const,
+  consumeRateLimitResetCredit: () =>
+    ["providers.consumeRateLimitResetCredit"] as const,
 };

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -28,6 +28,18 @@ describe("providers.consumeRateLimitResetCredit schemas", () => {
       idempotencyKey: "reset-attempt-1",
     });
 
+    expect(
+      providersConsumeRateLimitResetCreditRequestSchema.parse({
+        providerId: "codex",
+        profileId: null,
+        idempotencyKey: "reset-attempt-ambient",
+      }),
+    ).toEqual({
+      providerId: "codex",
+      profileId: null,
+      idempotencyKey: "reset-attempt-ambient",
+    });
+
     ["reset", "nothingToReset", "noCredit", "alreadyRedeemed"].forEach(
       (outcome) => {
         expect(
@@ -71,13 +83,21 @@ describe("providerRateLimitsSchema", () => {
       planType: "plus",
       limitId: "plus-primary",
       limitName: "Plus",
-      primary: { usedPercent: 42, resetsAt: 1735689600000, durationMinutes: 300 },
+      primary: {
+        usedPercent: 42,
+        resetsAt: 1735689600000,
+        durationMinutes: 300,
+      },
       secondary: null,
       extraWindows: [
         {
           limitId: "plus-secondary",
           limitName: "Plus (weekly)",
-          primary: { usedPercent: 12, resetsAt: 1735776000000, durationMinutes: 10080 },
+          primary: {
+            usedPercent: 12,
+            resetsAt: 1735776000000,
+            durationMinutes: 10080,
+          },
           secondary: null,
         },
       ],
@@ -101,7 +121,12 @@ describe("providerRateLimitsSchema", () => {
       sevenDayOpus: null,
       sevenDaySonnet: null,
       modelScoped: [
-        { displayName: "Opus", usedPercent: 5, resetsAt: null, durationMinutes: null },
+        {
+          displayName: "Opus",
+          usedPercent: 5,
+          resetsAt: null,
+          durationMinutes: null,
+        },
       ],
       extraUsage: null,
     };

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -5,12 +5,55 @@ import { hostGetRateLimitUsageDowngradeV2ToV1 } from "@traycer/protocol/host/rat
 import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import {
   providerRateLimitsSchema,
+  providersConsumeRateLimitResetCreditRequestSchema,
+  providersConsumeRateLimitResetCreditResponseSchema,
   rateLimitUnavailableReasonSchemaV1,
   rateLimitUnavailableReasonSchemaV2,
   rateLimitUsageRequestSchemaV12,
   rateLimitUsageResponseSchemaV12,
   rateLimitUsageResponseSchemaV20,
 } from "@traycer/protocol/host/rate-limit/schemas";
+
+describe("providers.consumeRateLimitResetCredit schemas", () => {
+  it("accepts a profile-scoped idempotent Codex reset request and every upstream outcome", () => {
+    expect(
+      providersConsumeRateLimitResetCreditRequestSchema.parse({
+        providerId: "codex",
+        profileId: "personal",
+        idempotencyKey: "reset-attempt-1",
+      }),
+    ).toEqual({
+      providerId: "codex",
+      profileId: "personal",
+      idempotencyKey: "reset-attempt-1",
+    });
+
+    ["reset", "nothingToReset", "noCredit", "alreadyRedeemed"].forEach(
+      (outcome) => {
+        expect(
+          providersConsumeRateLimitResetCreditResponseSchema.parse({ outcome }),
+        ).toEqual({ outcome });
+      },
+    );
+  });
+
+  it("rejects another provider and an empty idempotency key", () => {
+    expect(
+      providersConsumeRateLimitResetCreditRequestSchema.safeParse({
+        providerId: "claude-code",
+        profileId: null,
+        idempotencyKey: "attempt",
+      }).success,
+    ).toBe(false);
+    expect(
+      providersConsumeRateLimitResetCreditRequestSchema.safeParse({
+        providerId: "codex",
+        profileId: null,
+        idempotencyKey: "",
+      }).success,
+    ).toBe(false);
+  });
+});
 
 // `providerRateLimitsSchema` is a plain `z.union`, not a `z.discriminatedUnion`,
 // because its "unavailable" arm's `provider` field ranges over the full

--- a/protocol/src/host/rate-limit/contracts.ts
+++ b/protocol/src/host/rate-limit/contracts.ts
@@ -5,6 +5,8 @@ import {
 } from "@traycer/protocol/framework/index";
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import {
+  providersConsumeRateLimitResetCreditRequestSchema,
+  providersConsumeRateLimitResetCreditResponseSchema,
   rateLimitUsageRequestSchemaV10,
   rateLimitUsageRequestSchemaV11,
   rateLimitUsageRequestSchemaV12,
@@ -12,6 +14,13 @@ import {
   rateLimitUsageResponseSchemaV12,
   rateLimitUsageResponseSchemaV20,
 } from "@traycer/protocol/host/rate-limit/schemas";
+
+export const providersConsumeRateLimitResetCreditV10 = defineRpcContract({
+  method: "providers.consumeRateLimitResetCredit",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: providersConsumeRateLimitResetCreditRequestSchema,
+  responseSchema: providersConsumeRateLimitResetCreditResponseSchema,
+});
 
 export const hostGetRateLimitUsageV10 = defineRpcContract({
   method: "host.getRateLimitUsage",

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -314,3 +314,34 @@ export const rateLimitUsageResponseSchemaV20 =
 export type RateLimitUsageResponseV20 = z.infer<
   typeof rateLimitUsageResponseSchemaV20
 >;
+
+/**
+ * Uses one of Codex's account-level manual rate-limit reset credits for the
+ * selected profile. The idempotency key is generated once by the GUI for a
+ * confirmation attempt and reused by the transport if that request is retried.
+ */
+export const providersConsumeRateLimitResetCreditRequestSchema = z.object({
+  providerId: z.literal("codex"),
+  profileId: z.string().nullable(),
+  idempotencyKey: z.string().min(1),
+});
+export type ProvidersConsumeRateLimitResetCreditRequest = z.infer<
+  typeof providersConsumeRateLimitResetCreditRequestSchema
+>;
+
+export const codexRateLimitResetOutcomeSchema = z.enum([
+  "reset",
+  "nothingToReset",
+  "noCredit",
+  "alreadyRedeemed",
+]);
+export type CodexRateLimitResetOutcome = z.infer<
+  typeof codexRateLimitResetOutcomeSchema
+>;
+
+export const providersConsumeRateLimitResetCreditResponseSchema = z.object({
+  outcome: codexRateLimitResetOutcomeSchema,
+});
+export type ProvidersConsumeRateLimitResetCreditResponse = z.infer<
+  typeof providersConsumeRateLimitResetCreditResponseSchema
+>;

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -93,6 +93,7 @@ import {
   hostGetRateLimitUsageUpgradeV11ToV12,
   hostGetRateLimitUsageUpgradeV12ToV20,
   hostGetRateLimitUsageDowngradeV2ToV1,
+  providersConsumeRateLimitResetCreditV10,
 } from "@traycer/protocol/host/rate-limit/contracts";
 import {
   epicBatchDeleteV10,
@@ -1764,6 +1765,19 @@ const hostRpcRegistryDefinition = {
         },
       },
       downgradePathsFromLatest: { 1: hostGetRateLimitUsageDowngradeV2ToV1 },
+    },
+  },
+  "providers.consumeRateLimitResetCredit": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: providersConsumeRateLimitResetCreditV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
     },
   },
   "host.notifications.list": {

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -1712,7 +1712,7 @@ export const worktreeListBindingsForEpicUpgradeV10ToV11 = defineUpgradePath<
 // Note: git contract definitions are imported from git-contracts.ts above
 // and registered inline in hostRpcRegistry and hostStreamRpcRegistry below.
 
-const hostRpcRegistryDefinition = {
+const HOST_RPC_REGISTRY_DEFINITION = {
   "host.status": {
     1: {
       latestMinor: 0,
@@ -3576,7 +3576,7 @@ const hostRpcRegistryDefinition = {
 
 export const hostRpcRegistry = defineFloorAwareVersionedRpcRegistry(
   RELEASED_FLOOR_METHOD_NAMES,
-  hostRpcRegistryDefinition,
+  HOST_RPC_REGISTRY_DEFINITION,
 );
 
 export type HostRpcRegistry = typeof hostRpcRegistry;


### PR DESCRIPTION
## Summary\n- expose Codex manual reset credits through a backward-compatible host RPC\n- add confirmed reset actions in Settings and the header rate-limit detail panel\n- refresh the profile-scoped Codex limit snapshot after a reset\n\n## Verification\n- protocol, host, and GUI compilation\n- focused protocol, host, and GUI tests\n- targeted ESLint and repository pre-commit checks