### PR TITLE
fix(gui): unify chat loading during sidebar switches

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile.test.tsx
@@ -12,10 +12,26 @@ import {
 } from "@testing-library/react";
 import { VirtuosoMessageListTestingContext } from "@virtuoso.dev/message-list";
 
+const loadingSurfaceTestState = vi.hoisted(() => ({
+  unresolvedWorkspaceRenderCount: 0,
+}));
+
 vi.mock(
   "@/components/home/host-workspace-selector/host-workspace-selector",
   () => ({
-    HostWorkspaceSelector: () => null,
+    HostWorkspaceSelector: (props: {
+      readonly surface: { readonly bindingResolved: boolean };
+    }) => {
+      if (!props.surface.bindingResolved) {
+        loadingSurfaceTestState.unresolvedWorkspaceRenderCount += 1;
+      }
+      return (
+        <div
+          data-testid="host-workspace-selector"
+          data-binding-resolved={String(props.surface.bindingResolved)}
+        />
+      );
+    },
     ActiveHostWorkspaceControls: () => null,
   }),
 );
@@ -220,6 +236,8 @@ interface ChatHarness {
     queueItems: ReadonlyArray<ChatQueuedItem>,
     settings: ChatRunSettings | null,
   ): void;
+  installDeferred(): void;
+  streamCreations(): number;
   callbacks(): ChatStreamCallbacks;
   teardown(): void;
 }
@@ -254,17 +272,28 @@ function seedDocWithChat(doc: Y.Doc): void {
 function createChatHarness(): ChatHarness {
   const sent: ChatSubscribeClientFrame[] = [];
   let callbacks: ChatStreamCallbacks | null = null;
-  const installWithSettings = (
-    access: "owner" | "viewer",
-    queueItems: ReadonlyArray<ChatQueuedItem>,
-    settings: ChatRunSettings | null,
+  let streamCreations = 0;
+  const installStream = (
+    snapshot: {
+      readonly access: "owner" | "viewer";
+      readonly queueItems: ReadonlyArray<ChatQueuedItem>;
+      readonly settings: ChatRunSettings | null;
+    } | null,
   ): void => {
     __setChatStreamClientFactoryForTests((_epicId, _chatId, nextCallbacks) => {
       callbacks = nextCallbacks;
-      setTimeout(() => {
-        nextCallbacks.onConnectionStatus("open", null);
-        emitChatSnapshot(nextCallbacks, access, queueItems, settings);
-      }, 0);
+      streamCreations += 1;
+      if (snapshot !== null) {
+        setTimeout(() => {
+          nextCallbacks.onConnectionStatus("open", null);
+          emitChatSnapshot(
+            nextCallbacks,
+            snapshot.access,
+            snapshot.queueItems,
+            snapshot.settings,
+          );
+        }, 0);
+      }
       const client: Pick<ChatStreamClient, "sendAction" | "close"> = {
         sendAction: (frame) => {
           sent.push(frame);
@@ -274,12 +303,25 @@ function createChatHarness(): ChatHarness {
       return client;
     });
   };
+  const installWithSettings = (
+    access: "owner" | "viewer",
+    queueItems: ReadonlyArray<ChatQueuedItem>,
+    settings: ChatRunSettings | null,
+  ): void => {
+    installStream({
+      access,
+      queueItems,
+      settings,
+    });
+  };
   return {
     sent,
     install: (access, queueItems) => {
       installWithSettings(access, queueItems, null);
     },
     installWithSettings,
+    installDeferred: () => installStream(null),
+    streamCreations: () => streamCreations,
     callbacks: () => {
       if (callbacks === null) throw new Error("expected chat callbacks");
       return callbacks;
@@ -289,6 +331,7 @@ function createChatHarness(): ChatHarness {
       __getChatSessionRegistryForTests().disposeAll();
       sent.length = 0;
       callbacks = null;
+      streamCreations = 0;
     },
   };
 }
@@ -534,7 +577,24 @@ function renderChatTile() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
-  return render(
+  return render(chatTileTestTree(queryClient, true));
+}
+
+function renderSwitchableChatTile() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const rendered = render(chatTileTestTree(queryClient, true));
+  return {
+    ...rendered,
+    setChatVisible: (visible: boolean) => {
+      rendered.rerender(chatTileTestTree(queryClient, visible));
+    },
+  };
+}
+
+function chatTileTestTree(queryClient: QueryClient, chatVisible: boolean) {
+  return (
     <TestRouterProvider>
       <VirtuosoMessageListTestingContext.Provider
         value={{ itemHeight: 120, viewportHeight: 900 }}
@@ -556,18 +616,20 @@ function renderChatTile() {
             <TooltipProvider>
               <TestEpicSessionWrapper epicId={EPIC_ID}>
                 <TabHostProvider hostId={CHAT_ARTIFACT.hostId}>
-                  <ChatTile
-                    node={CHAT_ARTIFACT}
-                    viewTabId="tab-test"
-                    isActive
-                  />
+                  {chatVisible ? (
+                    <ChatTile
+                      node={CHAT_ARTIFACT}
+                      viewTabId="tab-test"
+                      isActive
+                    />
+                  ) : null}
                 </TabHostProvider>
               </TestEpicSessionWrapper>
             </TooltipProvider>
           </RunnerHostProvider>
         </QueryClientProvider>
       </VirtuosoMessageListTestingContext.Provider>
-    </TestRouterProvider>,
+    </TestRouterProvider>
   );
 }
 
@@ -650,6 +712,7 @@ describe("<ChatTile />", () => {
     });
     useComposerRunSettingsStore.getState().resetForTests();
     useComposerHarnessMemoryStore.getState().resetForTests();
+    loadingSurfaceTestState.unresolvedWorkspaceRenderCount = 0;
     // The composer gates Send on a resolved (non-empty) model slug. Without a
     // host binding the catalog never resolves the empty default, so seed a
     // concrete default model so the composer reaches a sendable state.
@@ -705,6 +768,53 @@ describe("<ChatTile />", () => {
 
     expect(chatStreamSpy).not.toHaveBeenCalled();
     expect(screen.queryByTestId("chat-tile-loading")).not.toBeNull();
+  });
+
+  it("keeps a cold sidebar-opened chat in one loading state until its first snapshot", async () => {
+    chatHarness.teardown();
+    chatHarness.installDeferred();
+
+    renderChatTile();
+
+    await waitFor(() => {
+      expect(chatHarness.streamCreations()).toBe(1);
+    });
+    expect(screen.getByRole("status", { name: "Loading chat" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
+    expect(screen.queryByTestId("host-workspace-selector")).toBeNull();
+    expect(loadingSurfaceTestState.unresolvedWorkspaceRenderCount).toBe(0);
+
+    act(() => {
+      emitChatSnapshot(chatHarness.callbacks(), "owner", [], SESSION_SETTINGS);
+    });
+
+    await waitForChatTileLoaded();
+    expect(screen.getByRole("button", { name: "Send" })).not.toBeNull();
+    expect(
+      screen
+        .getByTestId("host-workspace-selector")
+        .getAttribute("data-binding-resolved"),
+    ).toBe("true");
+  });
+
+  it("does not mount unresolved controls when switching back to a warm chat", async () => {
+    const rendered = renderSwitchableChatTile();
+    await waitForChatTileLoaded();
+    expect(chatHarness.streamCreations()).toBe(1);
+
+    rendered.setChatVisible(false);
+    loadingSurfaceTestState.unresolvedWorkspaceRenderCount = 0;
+    rendered.setChatVisible(true);
+
+    await waitForChatTileLoaded();
+    expect(chatHarness.streamCreations()).toBe(1);
+    expect(loadingSurfaceTestState.unresolvedWorkspaceRenderCount).toBe(0);
+    expect(screen.queryByRole("status", { name: "Loading chat" })).toBeNull();
+    expect(
+      screen
+        .getByTestId("host-workspace-selector")
+        .getAttribute("data-binding-resolved"),
+    ).toBe("true");
   });
 
   it("renders host chat content and sends through chat.subscribe", async () => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
@@ -30,10 +30,7 @@ import { ComposerSlotApprovalQueue } from "@/components/chat/segments/composer-s
 import { ComposerSlotFileEditApprovalQueue } from "@/components/chat/segments/composer-slot-file-edit-approval-queue";
 import { ComposerReadonlyWorkspaceModeRow } from "@/components/home/composer/composer-workspace-mode-row";
 import { lowerScrollRegionMaxHeightClass } from "@/lib/chat/chat-lower-scroll-budget";
-import {
-  WORKSPACE_COMPOSER_READY,
-  type WorkspaceComposerAvailability,
-} from "@/lib/composer/workspace-composer-availability";
+import type { WorkspaceComposerAvailability } from "@/lib/composer/workspace-composer-availability";
 import type { ChatSessionState } from "@/stores/chats/chat-session-store";
 import { cn } from "@/lib/utils";
 import type { PendingInterviewView } from "./chat-tile-types";
@@ -388,19 +385,7 @@ function ComposerSurface(props: {
 }): ReactNode {
   const { model, layout } = props;
   if (!model.runtime.snapshotLoaded) {
-    return (
-      <InertChatComposer
-        taskId={model.composer.nodeId}
-        isActive={model.composer.isActive}
-        mentionRoots={model.composer.mentionRoots}
-        fallbackToGlobalMentionRoots={
-          model.composer.fallbackToGlobalMentionRoots
-        }
-        currentEpicId={model.composer.currentEpicId}
-        workspaceControls={model.composer.workspaceControls}
-        topSpacing={layout.topSpacing}
-      />
-    );
+    return null;
   }
   if (model.access.isViewer) {
     return (
@@ -497,41 +482,6 @@ function PendingApprovalQueues(props: {
         onDecision={props.onApprovalDecision}
       />
     </div>
-  );
-}
-
-export function InertChatComposer(props: {
-  readonly taskId: string;
-  readonly isActive: boolean;
-  readonly mentionRoots: ReadonlyArray<string>;
-  readonly fallbackToGlobalMentionRoots: boolean;
-  readonly currentEpicId: string;
-  readonly workspaceControls: ReactNode;
-  readonly topSpacing: ChatLowerSurfaceTopSpacing;
-}) {
-  return (
-    <ChatComposer
-      taskId={props.taskId}
-      isActive={props.isActive}
-      sendDisabled
-      mentionRoots={props.mentionRoots}
-      fallbackToGlobalMentionRoots={props.fallbackToGlobalMentionRoots}
-      currentEpicId={props.currentEpicId}
-      settingsSeed={null}
-      fallbackSettingsSeed={null}
-      onSubmitMessage={() => false}
-      onSettingsChange={null}
-      activeTurnStatus={null}
-      editingQueueItemId={null}
-      onCancelQueueEdit={null}
-      hasPendingApprovals={false}
-      stopDisabled
-      onStopTurn={null}
-      workspaceControls={props.workspaceControls}
-      workspaceAvailability={WORKSPACE_COMPOSER_READY}
-      topSpacing={props.topSpacing}
-      topSlot={null}
-    />
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-runtime-gate.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-runtime-gate.tsx
@@ -13,9 +13,13 @@ export function ChatTileLoading(): ReactNode {
   return (
     <div
       data-testid="chat-tile-loading"
+      role="status"
+      aria-label="Loading chat"
+      aria-live="polite"
       className="flex w-full flex-1 items-center justify-center px-6 py-8"
     >
       <MutedAgentSpinner />
+      <span className="sr-only">Loading chat</span>
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -165,10 +165,7 @@ import { ChatTileErrorNoticeToasts } from "./chat-tile-error-notice-toasts";
 import { HostWorkspaceSelector } from "@/components/home/host-workspace-selector/host-workspace-selector";
 import type { FatalErrorDetails } from "@traycer/protocol/framework/ws-protocol";
 import type { TraycerNextStepOption } from "@/markdown/traycer-next-steps";
-import {
-  ChatLowerInteractionSurfaces,
-  InertChatComposer,
-} from "./chat-tile-lower-surfaces";
+import { ChatLowerInteractionSurfaces } from "./chat-tile-lower-surfaces";
 import { composerHasBlockingApprovals } from "./chat-approval-visibility";
 import {
   chatTileUiReducer,
@@ -187,7 +184,6 @@ import {
 import { ChatTileLoading, ChatTileError } from "./chat-tile-runtime-gate";
 import { SurfaceActivityProvider } from "@/components/home/composer/surface-activity-context";
 
-const EMPTY_MENTION_ROOTS: ReadonlyArray<string> = [];
 const EMPTY_WORKSPACE_PATH_SET: ReadonlySet<string> = new Set();
 const EMPTY_BACKGROUND_STOP_TASK_IDS: ReadonlySet<string> = new Set();
 
@@ -290,12 +286,6 @@ export function ChatTile(props: ChatTileProps) {
       >
         {deadTileBanner}
         <ChatTileLoading />
-        <ChatTileFallbackComposer
-          node={node}
-          viewTabId={viewTabId}
-          isActive={isActive}
-          currentEpicId={epicId}
-        />
       </div>
     );
   }
@@ -315,48 +305,6 @@ export function ChatTile(props: ChatTileProps) {
         />
       </TombstonedProfileProvider>
     </div>
-  );
-}
-
-function ChatTileFallbackComposer(props: {
-  readonly node: EpicNodeRef;
-  readonly viewTabId: string;
-  readonly isActive: boolean;
-  readonly currentEpicId: string;
-}): ReactNode {
-  const hostId = useTabHostId();
-  const workspaceControls = useMemo(
-    () => (
-      <HostWorkspaceSelector
-        surface={{
-          kind: "chat",
-          hostId,
-          epicId: props.currentEpicId,
-          tabId: props.viewTabId,
-          ownerId: props.node.id,
-          binding: null,
-          isOwnerActive: false,
-          hasActiveTurn: false,
-          // Pre-subscribe setup state: no binding resolved yet, so the chip shows
-          // its loading affordance (never a "no folders" terminal state).
-          missingWorktreePaths: [],
-          bindingResolved: false,
-          onBindingCommitted: null,
-        }}
-      />
-    ),
-    [hostId, props.currentEpicId, props.node.id, props.viewTabId],
-  );
-  return (
-    <InertChatComposer
-      taskId={props.node.id}
-      isActive={props.isActive}
-      mentionRoots={EMPTY_MENTION_ROOTS}
-      fallbackToGlobalMentionRoots
-      currentEpicId={props.currentEpicId}
-      workspaceControls={workspaceControls}
-      topSpacing="normal"
-    />
   );
 }
 
@@ -719,27 +667,29 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
            * return. Providers compose by narrowing only — the context can never
            * widen past the parent.
            */}
-          <SurfaceActivityProvider active={view.surfaceVisible}>
-            <ChatLowerInteractionSurfaces
-              epicId={view.currentEpicId}
-              chatId={view.node.id}
-              runtime={view.lower.runtime}
-              access={view.lower.access}
-              turn={view.lower.turn}
-              interview={view.lower.interview}
-              approvals={view.lower.approvals}
-              queue={view.lower.queue}
-              composer={view.lower.composer}
-              todo={view.todo}
-              restoreContext={view.restoreContext}
-              backgroundItems={view.lower.backgroundItems}
-              backgroundStopPendingTaskIds={
-                view.lower.backgroundStopPendingTaskIds
-              }
-              backgroundStopAllPending={view.lower.backgroundStopAllPending}
-              onBackgroundItemClick={scrollToBackgroundItem}
-            />
-          </SurfaceActivityProvider>
+          {view.snapshotLoaded ? (
+            <SurfaceActivityProvider active={view.surfaceVisible}>
+              <ChatLowerInteractionSurfaces
+                epicId={view.currentEpicId}
+                chatId={view.node.id}
+                runtime={view.lower.runtime}
+                access={view.lower.access}
+                turn={view.lower.turn}
+                interview={view.lower.interview}
+                approvals={view.lower.approvals}
+                queue={view.lower.queue}
+                composer={view.lower.composer}
+                todo={view.todo}
+                restoreContext={view.restoreContext}
+                backgroundItems={view.lower.backgroundItems}
+                backgroundStopPendingTaskIds={
+                  view.lower.backgroundStopPendingTaskIds
+                }
+                backgroundStopAllPending={view.lower.backgroundStopAllPending}
+                onBackgroundItemClick={scrollToBackgroundItem}
+              />
+            </SurfaceActivityProvider>
+          ) : null}
           <RevertOnEditDialog
             open={view.revertOnEdit.open}
             onOpenChange={view.revertOnEdit.onOpenChange}


### PR DESCRIPTION
## Summary

- keep the transcript, composer toolbar, and workspace controls behind the selected chat first authoritative snapshot
- remove the inert fallback composer that exposed unrelated default model, permission, and mode values while loading
- add an accessible loading status plus cold- and warm-switch regression coverage

## Testing

- [x] `pre-commit run --all-files`
- [x] GUI `bun run compile`
- [x] 46 focused chat-tile tests
- [x] focused ESLint and Prettier
- [x] changed-scope React Doctor
- [x] Tests added for cold and warm sidebar switching
- [x] Commit signed off for DCO

Repository-wide React Doctor still reports 88 pre-existing findings outside the changed hunks; changed-scope analysis reports no issues.