### PR TITLE
fix(gui): resize agent selection guide editor

### DIFF
--- a/clients/gui-app/src/components/agent-selection-guide-editor-surface.tsx
+++ b/clients/gui-app/src/components/agent-selection-guide-editor-surface.tsx
@@ -16,6 +16,8 @@ type AgentSelectionGuideEditorSurfaceProps = {
   readonly placeholder: string | undefined;
   readonly ariaLabel: string;
   readonly testId: string;
+  readonly setTextareaElement:
+    ((element: HTMLTextAreaElement | null) => void) | null;
   readonly textareaClassName: string;
   readonly className: string;
   readonly revertDisabled: boolean;
@@ -24,19 +26,30 @@ type AgentSelectionGuideEditorSurfaceProps = {
   readonly status: ReactNode;
 };
 
-export function AgentSelectionGuideEditorSurface(
-  props: AgentSelectionGuideEditorSurfaceProps,
-) {
+export function AgentSelectionGuideEditorSurface({
+  titleId,
+  value,
+  onValueChange,
+  onBlur,
+  disabled,
+  placeholder,
+  ariaLabel,
+  testId,
+  setTextareaElement,
+  textareaClassName,
+  className,
+  revertDisabled,
+  onRevert,
+  revertTestId,
+  status,
+}: AgentSelectionGuideEditorSurfaceProps) {
   return (
     <section
-      aria-labelledby={props.titleId}
-      className={cn("flex min-h-0 flex-col gap-3", props.className)}
+      aria-labelledby={titleId}
+      className={cn("flex min-h-0 flex-col gap-3", className)}
     >
       <div className="min-w-0">
-        <h2
-          id={props.titleId}
-          className="text-ui-md font-semibold text-foreground"
-        >
+        <h2 id={titleId} className="text-ui-md font-semibold text-foreground">
           {AGENT_SELECTION_GUIDE_TITLE}
         </h2>
         <p className="mt-1 text-ui-xs text-muted-foreground">
@@ -45,17 +58,18 @@ export function AgentSelectionGuideEditorSurface(
       </div>
 
       <Textarea
-        value={props.value}
-        onChange={(event) => props.onValueChange(event.target.value)}
-        onBlur={props.onBlur ?? undefined}
+        ref={setTextareaElement}
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        onBlur={onBlur ?? undefined}
         spellCheck={false}
-        disabled={props.disabled}
-        aria-label={props.ariaLabel}
-        data-testid={props.testId}
-        placeholder={props.placeholder}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        data-testid={testId}
+        placeholder={placeholder}
         className={cn(
           "min-h-0 overflow-y-auto font-mono text-code-xs leading-relaxed",
-          props.textareaClassName,
+          textareaClassName,
         )}
       />
 
@@ -72,14 +86,14 @@ export function AgentSelectionGuideEditorSurface(
             type="button"
             variant="ghost"
             size="sm"
-            disabled={props.revertDisabled}
-            onClick={props.onRevert}
-            data-testid={props.revertTestId}
+            disabled={revertDisabled}
+            onClick={onRevert}
+            data-testid={revertTestId}
             className="h-7 px-2"
           >
             Revert to default
           </Button>
-          {props.status}
+          {status}
         </div>
       </div>
     </section>

--- a/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
@@ -1524,6 +1524,7 @@ function AgentGuidePane(props: {
       placeholder={agentGuide.loading ? "Loading…" : undefined}
       ariaLabel="Onboarding agent selection instructions"
       testId="onboarding-agent-guide-input"
+      setTextareaElement={null}
       textareaClassName="flex-1 resize-none"
       className="size-full overflow-hidden rounded-lg border border-border bg-card p-4 shadow-2xl"
       revertDisabled={agentGuide.loading || agentGuide.saving || isAtDefault}

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -257,7 +257,9 @@ codeFontSize` in muted styling while `null`; any tick/type pins an
   to decide which child agents to spawn (harness / model / reasoning effort) for
   a task. A monospace `Textarea` debounce-auto-saves (and flushes on blur) via
   `agent.selectionGuide.setGlobal`; a quiet "Saving… / Saved" status sits in the
-  footer, no Save button. A **Revert to default** button (disabled while the
+  footer, no Save button. The textarea opens at a stable, viewport-aware height
+  and can be resized vertically until the panel reaches the settings viewport's
+  bottom spacing. A **Revert to default** button (disabled while the
   content already equals the provider-based default) calls
   `agent.selectionGuide.resetGlobalToDefault` behind a `ConfirmDestructiveDialog`.
   Default-host scope: the editor remounts (keyed on the active host id) so a host

--- a/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
@@ -116,6 +116,19 @@ describe("AgentSelectionGuideSection", () => {
     expect(guideMocks.resetGlobalMutateAsync).not.toHaveBeenCalled();
   });
 
+  it("keeps the opening height stable and allows vertical resizing", () => {
+    renderPanel();
+    const editor = screen.getByTestId<HTMLTextAreaElement>(
+      "agents-selection-guide-input",
+    );
+
+    expect(editor.className).toContain("field-sizing-fixed");
+    expect(editor.className).not.toContain("field-sizing-content");
+    expect(editor.className).toContain("h-[min(32vh,16rem)]");
+    expect(editor.className).toContain("resize-y");
+    expect(editor.className).not.toContain("max-h-[min(32vh,16rem)]");
+  });
+
   it("reverts through the host reset API instead of sending generated content back", async () => {
     guideMocks.queryData = {
       content: "claude guide",

--- a/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
@@ -51,6 +51,7 @@ vi.mock(
 );
 
 import { AgentSelectionGuideSection } from "@/components/settings/panels/agent-selection-guide-section";
+import { AgentsSettingsPanel } from "@/components/settings/panels/agents-settings-panel";
 
 function renderPanel() {
   return render(
@@ -88,6 +89,8 @@ describe("AgentSelectionGuideSection", () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("updates generated defaults without clobbering the active editor draft", async () => {
@@ -127,6 +130,78 @@ describe("AgentSelectionGuideSection", () => {
     expect(editor.className).toContain("h-[min(32vh,16rem)]");
     expect(editor.className).toContain("resize-y");
     expect(editor.className).not.toContain("max-h-[min(32vh,16rem)]");
+  });
+
+  it("caps resizing at the settings viewport without shrinking below the opening height", () => {
+    let scrollBottom = 800;
+    const bodyBottom = 500;
+    const openingHeight = 256;
+    let resizeCallback: ResizeObserverCallback | null = null;
+    const resizeObserver: ResizeObserver = {
+      observe(): void {},
+      unobserve(): void {},
+      disconnect(): void {},
+    };
+
+    class BoundaryResizeObserver implements ResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback;
+      }
+
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+
+    vi.stubGlobal("ResizeObserver", BoundaryResizeObserver);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.getAttribute("data-testid") === "settings-scroll-viewport") {
+          return new DOMRect(0, 0, 100, scrollBottom);
+        }
+        if (this.hasAttribute("data-settings-panel-body")) {
+          return new DOMRect(0, 0, 100, bodyBottom);
+        }
+        if (this instanceof HTMLTextAreaElement) {
+          return new DOMRect(0, 0, 100, openingHeight);
+        }
+        return new DOMRect();
+      },
+    );
+
+    render(
+      <StrictMode>
+        <div
+          data-testid="settings-scroll-viewport"
+          style={{ overflowY: "auto" }}
+        >
+          <AgentsSettingsPanel />
+        </div>
+      </StrictMode>,
+    );
+
+    const editor = screen.getByTestId<HTMLTextAreaElement>(
+      "agents-selection-guide-input",
+    );
+    const panelShell = editor.closest("[data-settings-panel-shell]");
+    if (!(panelShell instanceof HTMLElement)) {
+      throw new Error("Expected the editor to render inside a settings shell");
+    }
+    panelShell.style.paddingBottom = "40px";
+
+    const emitResize = (): void => {
+      if (resizeCallback === null) {
+        throw new Error("Expected the resize observer to be active");
+      }
+      resizeCallback([], resizeObserver);
+    };
+
+    act(emitResize);
+    expect(editor.style.maxHeight).toBe("516px");
+
+    scrollBottom = 300;
+    act(emitResize);
+    expect(editor.style.maxHeight).toBe("256px");
   });
 
   it("reverts through the host reset API instead of sending generated content back", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
@@ -180,9 +180,9 @@ describe("AgentSelectionGuideSection", () => {
       </StrictMode>,
     );
 
-    const editor = screen.getByTestId<HTMLTextAreaElement>(
-      "agents-selection-guide-input",
-    );
+    const editor = screen.getByRole<HTMLTextAreaElement>("textbox", {
+      name: "Global agent selection instructions",
+    });
     const panelShell = editor.closest("[data-settings-panel-shell]");
     if (!(panelShell instanceof HTMLElement)) {
       throw new Error("Expected the editor to render inside a settings shell");

--- a/clients/gui-app/src/components/settings/panels/agent-selection-guide-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/agent-selection-guide-section.tsx
@@ -3,7 +3,13 @@
  * Update that file whenever this settings surface changes.
  */
 import type { ReactNode } from "react";
-import { useEffect, useReducer, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+} from "react";
 import { Check, TriangleAlert } from "lucide-react";
 import {
   AGENT_SELECTION_GUIDE_DESCRIPTION,
@@ -20,6 +26,70 @@ import { useAgentSelectionGuideSetGlobalMutation } from "@/hooks/agent/use-agent
 import { useAgentSelectionGuideResetGlobalMutation } from "@/hooks/agent/use-agent-selection-guide-reset-global-mutation";
 
 const SAVE_DEBOUNCE_MS = 600;
+
+function findVerticalScrollContainer(element: HTMLElement): HTMLElement | null {
+  let current = element.parentElement;
+  while (current !== null) {
+    const overflowY = window.getComputedStyle(current).overflowY;
+    if (overflowY === "auto" || overflowY === "scroll") return current;
+    current = current.parentElement;
+  }
+  return null;
+}
+
+function useTextareaResizeBoundary() {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const setTextareaElement = useCallback(
+    (element: HTMLTextAreaElement | null): void => {
+      textareaRef.current = element;
+    },
+    [],
+  );
+
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea === null) return;
+
+    const panelBody = textarea.closest("[data-settings-panel-body]");
+    const panelShell = textarea.closest("[data-settings-panel-shell]");
+    if (!(panelBody instanceof HTMLElement)) return;
+    if (!(panelShell instanceof HTMLElement)) return;
+
+    const scrollContainer = findVerticalScrollContainer(panelShell);
+    if (scrollContainer === null) return;
+
+    const defaultHeight = textarea.getBoundingClientRect().height;
+    if (defaultHeight <= 0) return;
+
+    const updateMaxHeight = (): void => {
+      const scrollRect = scrollContainer.getBoundingClientRect();
+      const bodyRect = panelBody.getBoundingClientRect();
+      const textareaHeight = textarea.getBoundingClientRect().height;
+      const shellBottomPadding = Number.parseFloat(
+        window.getComputedStyle(panelShell).paddingBottom,
+      );
+      // The card grows one-for-one with the textarea. Add only the free space
+      // below the current card so the shell's normal bottom padding remains.
+      const availableGrowth =
+        scrollRect.bottom -
+        bodyRect.bottom -
+        (Number.isFinite(shellBottomPadding) ? shellBottomPadding : 0);
+      const maxHeight = Math.max(
+        defaultHeight,
+        textareaHeight + availableGrowth,
+      );
+      textarea.style.maxHeight = `${Math.floor(maxHeight)}px`;
+    };
+
+    updateMaxHeight();
+    const observer = new ResizeObserver(updateMaxHeight);
+    observer.observe(scrollContainer);
+    observer.observe(panelBody);
+    return () => observer.disconnect();
+  }, []);
+
+  return setTextareaElement;
+}
 
 type AgentsGuideEditorState = {
   readonly value: string;
@@ -181,6 +251,7 @@ function AgentsGuideEditor(props: {
   const queuedSaveRef = useRef<string | null>(null);
   const queuedResetRef = useRef(false);
   const mountedRef = useRef(true);
+  const setTextareaElement = useTextareaResizeBoundary();
 
   // Drop a pending debounced save when unmounting (blur already flushes the
   // common close paths) so the timer can't fire into an unmounted component.
@@ -312,7 +383,8 @@ function AgentsGuideEditor(props: {
         placeholder={undefined}
         ariaLabel="Global agent selection instructions"
         testId="agents-selection-guide-input"
-        textareaClassName="max-h-[min(32vh,16rem)] min-h-[min(20vh,10rem)]"
+        setTextareaElement={setTextareaElement}
+        textareaClassName="field-sizing-fixed h-[min(32vh,16rem)] min-h-[min(20vh,10rem)] resize-y"
         className=""
         revertDisabled={
           isAtDefault || state.saveInFlight || state.resetInFlight

--- a/clients/gui-app/src/components/settings/settings-panel-shell.tsx
+++ b/clients/gui-app/src/components/settings/settings-panel-shell.tsx
@@ -29,6 +29,7 @@ export function SettingsPanelShell(props: SettingsPanelShellProps) {
   } = props;
   return (
     <section
+      data-settings-panel-shell
       className={cn(
         "mx-auto w-full max-w-5xl px-8 py-10",
         fillHeight && "flex h-full flex-col",
@@ -50,6 +51,7 @@ export function SettingsPanelShell(props: SettingsPanelShellProps) {
         )}
       </header>
       <div
+        data-settings-panel-body
         className={cn(
           "overflow-hidden rounded-xl border border-border/60 bg-card/40",
           fillHeight && "min-h-0 flex-1",


### PR DESCRIPTION
## Summary

- preserve the agent selection guide editor's existing opening height while allowing vertical resizing
- cap growth at the active settings viewport while retaining the shell's bottom spacing in tab and modal layouts
- document the behavior and add regression coverage for the resize classes

## Related issue

None.

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)