### PR TITLE
fix(notifications): keep toast content in sync with feed

### DIFF
--- a/clients/gui-app/src/stores/notifications/__tests__/host-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/host-notifications-store.test.ts
@@ -427,6 +427,54 @@ describe("host notifications store", () => {
     close();
   });
 
+  it("uses the latest feed copy for renderer channel emissions", () => {
+    const client = new MockWsStreamClient();
+    const displayed: Array<ReadonlyArray<HostNotificationEntry>> = [];
+    const staleEmissionEntry = entry("live", 200, null);
+    if (staleEmissionEntry.kind !== "agent.stopped") {
+      throw new Error("Expected an agent-stopped notification fixture");
+    }
+    const richFeedEntry: HostNotificationEntry = {
+      ...staleEmissionEntry,
+      updatedAt: 201,
+      payload: {
+        ...staleEmissionEntry.payload,
+        agentName: "Investigate Harness Selection Issue",
+        taskTitle: "Fix Chat Error Notification",
+      },
+    };
+
+    const close = openHostNotificationsStream(client, null, {
+      windowId: "window-1",
+      now: () => 123,
+      displayChannelEmission: (entries) => {
+        displayed.push(entries);
+      },
+      onFeedFrame: () => undefined,
+      onPresenceChanged: () => undefined,
+      onStreamOpened: () => undefined,
+    });
+
+    client.session.emitServerFrame({
+      kind: "upserted",
+      hasBinaryPayload: false,
+      entry: richFeedEntry,
+    });
+    client.session.emitServerFrame({
+      kind: "channelEmission",
+      hasBinaryPayload: false,
+      emissionId: "emission-1",
+      channelId: "renderer",
+      severity: "done",
+      rows: [staleEmissionEntry],
+      reason: "new",
+    });
+
+    expect(displayed).toEqual([[richFeedEntry]]);
+
+    close();
+  });
+
   it("ignores non-renderer channelEmission frames for in-app display", () => {
     const client = new MockWsStreamClient();
     const displayed: Array<ReadonlyArray<HostNotificationEntry>> = [];

--- a/clients/gui-app/src/stores/notifications/host-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/host-notifications-store.ts
@@ -357,7 +357,16 @@ export function openHostNotificationsStream(
         return;
       case "channelEmission":
         if (frame.channelId === "renderer") {
-          options.displayChannelEmission(frame.rows);
+          const currentById = useHostNotificationsStore.getState().byId;
+          options.displayChannelEmission(
+            frame.rows.map((entry) => {
+              const current = currentById[entry.id];
+              return Object.hasOwn(currentById, entry.id) &&
+                current.updatedAt >= entry.updatedAt
+                ? current
+                : entry;
+            }),
+          );
         }
         return;
       case "pong":


### PR DESCRIPTION
## Summary
- render renderer-channel toasts from the latest feed row for the notification ID
- keep native and in-app toast titles and context aligned with the bell feed
- add regression coverage for a stale emission frame

## Verification
- bun run test src/stores/notifications/__tests__/host-notifications-store.test.ts src/lib/notifications/__tests__/notification-display.test.ts src/stores/notifications/__tests__/merged-notifications.test.ts
- bun run compile
- React Doctor
- ESLint and Prettier checks