### PR TITLE
fix(gui-app): search task history by PR number

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -174,6 +174,7 @@ vi.mock("@/hooks/home/use-history-query", () => ({
       availableWorkspaces: testState.availableWorkspaces,
       totalCount: testState.items.length,
       facets: testState.facets,
+      worktreesByEpicId: testState.worktreesByEpicId,
     },
     isPending: false,
     isFetching: testState.isFetching,
@@ -198,10 +199,6 @@ vi.mock("@/hooks/epic/use-task-delete-worktree-candidates-query", () => ({
     candidates: testState.worktreeCandidates,
     isError: false,
   }),
-}));
-
-vi.mock("@/hooks/worktree/use-task-worktree-metadata-query", () => ({
-  useTaskWorktreeMetadata: () => testState.worktreesByEpicId,
 }));
 
 vi.mock("@/hooks/epic/use-epic-title-mutation", () => ({
@@ -230,6 +227,7 @@ function historyItem(overrides: Partial<HistoryItem>): HistoryItem {
     updatedBucket: "today",
     linkedRepos: [],
     linkedWorkspaces: [],
+    pullRequestNumbers: [],
     ownership: "mine",
     permissionRole: "owner",
     ...overrides,

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -96,12 +96,15 @@ import type {
 import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import { WorktreePrPills } from "@/components/worktree/worktree-pr-metadata";
 import { worktreePrReferences } from "@/components/worktree/worktree-pr-metadata-model";
-import { useTaskWorktreeMetadata } from "@/hooks/worktree/use-task-worktree-metadata-query";
 
 const EMPTY_REPOS: ReadonlyArray<string> = [];
 const EMPTY_WORKSPACES: ReadonlyArray<HistoryWorkspaceRef> = [];
 const EMPTY_ITEMS: ReadonlyArray<HistoryItem> = [];
 const EMPTY_WORKTREES: readonly WorktreeHostEntryV12[] = [];
+const EMPTY_WORKTREES_BY_EPIC: ReadonlyMap<
+  string,
+  readonly WorktreeHostEntryV12[]
+> = new Map();
 const VIEWER_DELETE_TOOLTIP = "Viewers cannot select task for deletion.";
 const NO_DELETE_PERMISSION_TOOLTIP =
   "You don't have permission to delete this task.";
@@ -251,11 +254,11 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
   });
 
   const items = data?.items ?? EMPTY_ITEMS;
+  const worktreesByEpicId = data?.worktreesByEpicId ?? EMPTY_WORKTREES_BY_EPIC;
   const indicatorEpicIds = useMemo(
     () => items.map((item) => item.epicId),
     [items],
   );
-  const worktreesByEpicId = useTaskWorktreeMetadata(indicatorEpicIds);
   const notificationIndicators = useHostNotificationIndicators({
     epicIds: indicatorEpicIds,
     chatIds: [],
@@ -566,7 +569,7 @@ function PanelSearchInput(props: PanelSearchInputProps): ReactNode {
           onChange={(event) => {
             props.onChange(event.target.value);
           }}
-          placeholder="Search by title or repo"
+          placeholder="Search by title, repo, or PR"
           aria-label="Search tasks"
         />
         {props.value.length > 0 ? (

--- a/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
@@ -22,6 +22,7 @@ function makeItem(
     updatedBucket: overrides.updatedBucket ?? "today",
     linkedRepos: overrides.linkedRepos ?? [],
     linkedWorkspaces: overrides.linkedWorkspaces ?? [],
+    pullRequestNumbers: overrides.pullRequestNumbers ?? [],
     ownership: overrides.ownership ?? "mine",
     permissionRole: overrides.permissionRole ?? "owner",
   };

--- a/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
+import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import {
   buildHistoryItemsFromTasks,
   collectHistoryRepos,
   filterHistoryItems,
   groupHistoryItems,
+  withHistoryItemPullRequestNumbers,
   type HistoryItem,
 } from "@/components/home/data/home-page.data";
 
@@ -72,6 +74,30 @@ describe("home-page history helpers", () => {
     ];
     const groups = groupHistoryItems(items);
     expect(groups.map((g) => g.bucket)).toEqual(["today", "earlier"]);
+  });
+
+  it("projects distinct superproject and submodule PR numbers for a task", () => {
+    const items = [makeItem({ id: "history-1", title: "History task" })];
+    const worktreesByEpicId = new Map([
+      [
+        "history-1",
+        [
+          worktreeWithPullRequests({
+            prNumber: 84,
+            submodulePrNumbers: [85, null],
+          }),
+          worktreeWithPullRequests({
+            prNumber: 84,
+            submodulePrNumbers: [85],
+          }),
+        ],
+      ],
+    ]);
+
+    expect(
+      withHistoryItemPullRequestNumbers(items, worktreesByEpicId)[0]
+        .pullRequestNumbers,
+    ).toEqual(["84", "#84", "PR #84", "85", "#85", "PR #85"]);
   });
 
   it("builds history items from cloud task lights and extracts real repo identifiers", () => {
@@ -172,3 +198,46 @@ describe("home-page history helpers", () => {
     });
   });
 });
+
+function worktreeWithPullRequests(args: {
+  readonly prNumber: number | null;
+  readonly submodulePrNumbers: ReadonlyArray<number | null>;
+}): WorktreeHostEntryV12 {
+  return {
+    worktreePath: `/worktrees/${args.prNumber ?? "none"}`,
+    repoLabel: "traycer/gui-app",
+    repoIdentifier: { owner: "traycer", repo: "gui-app" },
+    branch: "task-history",
+    inUse: false,
+    uncommittedCount: 0,
+    gitRemovable: true,
+    scripts: null,
+    lastActivityAt: null,
+    owners: [],
+    branchStatus: null,
+    createdAt: null,
+    prState: args.prNumber === null ? "none" : "open",
+    prNumber: args.prNumber,
+    prUrl:
+      args.prNumber === null
+        ? null
+        : `https://github.com/traycer/gui-app/pull/${args.prNumber}`,
+    mergedHeadShaMatches: false,
+    submodules: args.submodulePrNumbers.map((prNumber, index) => ({
+      repoIdentifier: { owner: "traycer", repo: `submodule-${index}` },
+      branch: `submodule-${index}`,
+      prState: prNumber === null ? "none" : "open",
+      prNumber,
+      prUrl:
+        prNumber === null
+          ? null
+          : `https://github.com/traycer/submodule-${index}/pull/${prNumber}`,
+      mergedHeadShaMatches: false,
+      mergedIntoDefault: false,
+      atPinnedCommit: false,
+      unmergedCommitCount: null,
+      unmergedCommitSubjects: null,
+    })),
+    atBaseCommit: false,
+  };
+}

--- a/clients/gui-app/src/components/home/data/home-page.data.ts
+++ b/clients/gui-app/src/components/home/data/home-page.data.ts
@@ -4,6 +4,7 @@ import type {
   TaskOwnershipScope,
   TaskWorkspaceIdentifier,
 } from "@traycer/protocol/host/epic/unary-schemas";
+import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import { formatDistanceToNow } from "date-fns";
 import { displayTitle } from "@/lib/display-title";
 import { isEditableRole } from "@/lib/epic-permissions";
@@ -37,6 +38,7 @@ export interface HistoryItem {
   updatedBucket: HistoryRecencyBucket;
   linkedRepos: ReadonlyArray<string>;
   linkedWorkspaces: ReadonlyArray<HistoryWorkspaceRef>;
+  pullRequestNumbers: ReadonlyArray<string>;
   ownership: HistoryOwnershipScope;
   permissionRole: PermissionRole | null;
 }
@@ -142,9 +144,47 @@ function buildHistoryItem(args: {
     updatedBucket: toHistoryRecencyBucket(light.updatedAt, nowMs),
     linkedRepos: readTaskRepos(task),
     linkedWorkspaces: readTaskWorkspaces(task),
+    pullRequestNumbers: [],
     ownership,
     permissionRole: historyPermissionRole(ownership, role),
   };
+}
+
+/**
+ * Adds the PR numbers discovered from the task's local worktrees to history
+ * items. Worktree activity is deliberately fetched separately from cloud task
+ * history, so this stays a pure projection that can update as probes finish.
+ */
+export function withHistoryItemPullRequestNumbers(
+  items: ReadonlyArray<HistoryItem>,
+  worktreesByEpicId: ReadonlyMap<string, readonly WorktreeHostEntryV12[]>,
+): ReadonlyArray<HistoryItem> {
+  return items.map((item) => ({
+    ...item,
+    pullRequestNumbers: historyPullRequestNumbers(
+      worktreesByEpicId.get(item.epicId) ?? [],
+    ),
+  }));
+}
+
+function historyPullRequestNumbers(
+  worktrees: readonly WorktreeHostEntryV12[],
+): ReadonlyArray<string> {
+  return Array.from(
+    new Set(
+      worktrees
+        .flatMap((worktree) => [
+          worktree.prNumber,
+          ...worktree.submodules.map((submodule) => submodule.prNumber),
+        ])
+        .filter((prNumber): prNumber is number => prNumber !== null)
+        .flatMap((prNumber) => [
+          String(prNumber),
+          `#${prNumber}`,
+          `PR #${prNumber}`,
+        ]),
+    ),
+  );
 }
 
 export function canEditHistoryItemTitle(item: HistoryItem): boolean {

--- a/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
+++ b/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
@@ -26,6 +26,7 @@ const testState = vi.hoisted(() => {
     isPlaceholderData: false,
     hasNextPage: false,
     worktreesByEpicId: new Map<string, readonly WorktreeHostEntryV12[]>(),
+    worktreeMetadataError: null as Error | null,
     refetch: vi.fn(),
     fetchNextPage: vi.fn(),
   };
@@ -54,6 +55,7 @@ vi.mock("@/hooks/worktree/use-task-worktree-metadata-query", () => ({
   useTaskWorktreeMetadata: () => ({
     worktreesByEpicId: testState.worktreesByEpicId,
     isFetching: false,
+    error: testState.worktreeMetadataError,
   }),
 }));
 
@@ -71,6 +73,7 @@ describe("useHistoryQuery", () => {
     testState.isPlaceholderData = false;
     testState.hasNextPage = false;
     testState.worktreesByEpicId = new Map();
+    testState.worktreeMetadataError = null;
     testState.refetch.mockReset();
     testState.fetchNextPage.mockReset();
   });
@@ -181,6 +184,22 @@ describe("useHistoryQuery", () => {
 
     expect(screen.getByTestId("has-next-page").textContent).toBe("true");
   });
+
+  it("surfaces a worktree metadata failure for a PR-number search", () => {
+    testState.worktreeMetadataError = new Error("Worktree metadata failed");
+
+    render(
+      <HistoryQueryHarness
+        search={patchHistorySearch(DEFAULT_HISTORY_SEARCH, {
+          query: "#84",
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("error").textContent).toBe(
+      "Worktree metadata failed",
+    );
+  });
 });
 
 function HistoryQueryHarness(props: {
@@ -191,6 +210,7 @@ function HistoryQueryHarness(props: {
     <div>
       <div data-testid="pending">{String(result.isPending)}</div>
       <div data-testid="fetching">{String(result.isFetching)}</div>
+      <div data-testid="error">{result.error?.message ?? ""}</div>
       <div data-testid="has-next-page">{String(result.hasNextPage)}</div>
       <div data-testid="titles">
         {result.data?.items.map((item) => item.title).join("|") ?? ""}

--- a/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
+++ b/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
@@ -5,6 +5,7 @@ import type {
   ListTasksResponse,
   TaskLight,
 } from "@traycer/protocol/host/epic/unary-schemas";
+import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import {
   DEFAULT_HISTORY_SEARCH,
   patchHistorySearch,
@@ -23,6 +24,8 @@ const testState = vi.hoisted(() => {
     response,
     isFetching: false,
     isPlaceholderData: false,
+    hasNextPage: false,
+    worktreesByEpicId: new Map<string, readonly WorktreeHostEntryV12[]>(),
     refetch: vi.fn(),
     fetchNextPage: vi.fn(),
   };
@@ -42,8 +45,15 @@ vi.mock("@/hooks/epics/use-cloud-epic-tasks-query", () => ({
       refetch: testState.refetch,
     },
     fetchNextPage: testState.fetchNextPage,
-    hasNextPage: false,
+    hasNextPage: testState.hasNextPage,
     isFetchingNextPage: false,
+  }),
+}));
+
+vi.mock("@/hooks/worktree/use-task-worktree-metadata-query", () => ({
+  useTaskWorktreeMetadata: () => ({
+    worktreesByEpicId: testState.worktreesByEpicId,
+    isFetching: false,
   }),
 }));
 
@@ -59,6 +69,8 @@ describe("useHistoryQuery", () => {
     testState.response = { tasks: testState.tasks, hasMore: false };
     testState.isFetching = false;
     testState.isPlaceholderData = false;
+    testState.hasNextPage = false;
+    testState.worktreesByEpicId = new Map();
     testState.refetch.mockReset();
     testState.fetchNextPage.mockReset();
   });
@@ -133,6 +145,42 @@ describe("useHistoryQuery", () => {
     expect(screen.getByTestId("workspace-facets").textContent).toBe("");
     expect(screen.getByTestId("ownership-facets").textContent).toBe("");
   });
+
+  it.each(["84", "#84", "PR #84"])(
+    "locally matches a task by enriched PR query %s",
+    (query) => {
+      testState.worktreesByEpicId = new Map([
+        ["epic-beta", [worktreeWithPullRequest(84)]],
+      ]);
+
+      render(
+        <HistoryQueryHarness
+          search={patchHistorySearch(DEFAULT_HISTORY_SEARCH, {
+            query,
+          })}
+        />,
+      );
+
+      expect(screen.getByTestId("titles").textContent).toBe("Beta search flow");
+    },
+  );
+
+  it("keeps pagination available for a settled PR query", () => {
+    testState.hasNextPage = true;
+    testState.worktreesByEpicId = new Map([
+      ["epic-beta", [worktreeWithPullRequest(84)]],
+    ]);
+
+    render(
+      <HistoryQueryHarness
+        search={patchHistorySearch(DEFAULT_HISTORY_SEARCH, {
+          query: "#84",
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("has-next-page").textContent).toBe("true");
+  });
 });
 
 function HistoryQueryHarness(props: {
@@ -143,6 +191,7 @@ function HistoryQueryHarness(props: {
     <div>
       <div data-testid="pending">{String(result.isPending)}</div>
       <div data-testid="fetching">{String(result.isFetching)}</div>
+      <div data-testid="has-next-page">{String(result.hasNextPage)}</div>
       <div data-testid="titles">
         {result.data?.items.map((item) => item.title).join("|") ?? ""}
       </div>
@@ -201,5 +250,35 @@ function taskLight(id: string, title: string, repo: string): TaskLight {
       workspaces: [],
       roomInfo: null,
     },
+  };
+}
+
+function worktreeWithPullRequest(prNumber: number): WorktreeHostEntryV12 {
+  return {
+    worktreePath: "/worktrees/task-history",
+    repoLabel: "traycer/gui-app",
+    repoIdentifier: { owner: "traycer", repo: "gui-app" },
+    branch: "task-history",
+    inUse: false,
+    uncommittedCount: 0,
+    gitRemovable: true,
+    scripts: null,
+    lastActivityAt: null,
+    owners: [
+      {
+        epicId: "epic-beta",
+        ownerKind: "chat",
+        ownerId: "chat-1",
+        updatedAt: 1,
+      },
+    ],
+    branchStatus: null,
+    createdAt: null,
+    prState: "open",
+    prNumber,
+    prUrl: `https://github.com/traycer/gui-app/pull/${prNumber}`,
+    mergedHeadShaMatches: false,
+    submodules: [],
+    atBaseCommit: false,
   };
 }

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -153,7 +153,9 @@ export function useHistoryQuery(
       tasksQuery.isFetching ||
       isQueryDebouncing ||
       (isPullRequestNumberQuery && worktreeMetadata.isFetching),
-    error: tasksQuery.error instanceof Error ? tasksQuery.error : null,
+    error:
+      (tasksQuery.error instanceof Error ? tasksQuery.error : null) ??
+      (isPullRequestNumberQuery ? worktreeMetadata.error : null),
     hostId,
     refetch,
     fetchNextPage,

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -10,14 +10,17 @@ import {
   dedupSortWorkspaces,
   filterHistoryItems,
   sortHistoryItems,
+  withHistoryItemPullRequestNumbers,
 } from "@/components/home/data/home-page.data";
 import { useCloudEpicTasksQuery } from "@/hooks/epics/use-cloud-epic-tasks-query";
 import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
+import { useTaskWorktreeMetadata } from "@/hooks/worktree/use-task-worktree-metadata-query";
 import {
   listCloudTasksRequestForHistorySearch,
   type ListCloudTasksRequest,
 } from "@/lib/cloud-epic-tasks-query";
 import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
+import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import type { HistorySearchState } from "@/lib/history-search";
 import { patchHistorySearch } from "@/lib/history-search";
 import Fuse, { type IFuseOptions } from "fuse.js";
@@ -32,6 +35,7 @@ const LOCAL_FUSE_OPTIONS: IFuseOptions<HistoryItem> = {
   keys: [
     { name: "title", weight: 0.8 },
     { name: "linkedRepos", weight: 0.2 },
+    { name: "pullRequestNumbers", weight: 0.8 },
   ],
 };
 
@@ -60,8 +64,13 @@ export function useHistoryQuery(
   const [fallbackNowMs] = useState(() => Date.now());
   const nowMs = params.nowMs ?? fallbackNowMs;
   const request = useMemo<ListCloudTasksRequest>(() => {
+    const isPullRequestNumberQuery =
+      isHistoryPullRequestNumberQuery(debouncedQuery);
     const search = patchHistorySearch(params.search, {
-      query: debouncedQuery,
+      // PR numbers are discovered from local worktree activity, not the cloud
+      // task index. Keep the cloud query broad so it cannot remove the task
+      // before the local PR projection gets to match it.
+      query: isPullRequestNumberQuery ? "" : debouncedQuery,
     });
     return listCloudTasksRequestForHistorySearch(search);
   }, [debouncedQuery, params.search]);
@@ -76,14 +85,32 @@ export function useHistoryQuery(
   } = useCloudEpicTasksQuery(request, { enabled: true });
   const tasksQueryRefetch = tasksQuery.refetch;
   const isQueryDebouncing = debouncedQuery !== trimmedQuery;
+  const isPullRequestNumberQuery =
+    isHistoryPullRequestNumberQuery(debouncedQuery);
   const shouldProjectLocally =
-    isQueryDebouncing || tasksQuery.isFetching || tasksQuery.isPlaceholderData;
+    isQueryDebouncing ||
+    isPullRequestNumberQuery ||
+    tasksQuery.isFetching ||
+    tasksQuery.isPlaceholderData;
+  const baseItems = useMemo(
+    () => buildHistoryItemsFromTasks(tasks, nowMs, currentUserId),
+    [currentUserId, nowMs, tasks],
+  );
+  const historyEpicIds = useMemo(
+    () => baseItems.map((item) => item.epicId),
+    [baseItems],
+  );
+  const worktreeMetadata = useTaskWorktreeMetadata(historyEpicIds);
+  const worktreesByEpicId = worktreeMetadata.worktreesByEpicId;
+  const serverItems = useMemo(
+    () => withHistoryItemPullRequestNumbers(baseItems, worktreesByEpicId),
+    [baseItems, worktreesByEpicId],
+  );
 
   const data = useMemo<HistoryFetchResult | undefined>(() => {
     if (tasksQuery.data === undefined) {
       return undefined;
     }
-    const serverItems = buildHistoryItemsFromTasks(tasks, nowMs, currentUserId);
     const items = shouldProjectLocally
       ? projectHistoryItems(serverItems, params.search)
       : serverItems;
@@ -105,16 +132,16 @@ export function useHistoryQuery(
       availableWorkspaces,
       totalCount: items.length,
       facets,
+      worktreesByEpicId,
     };
   }, [
-    currentUserId,
     isQueryDebouncing,
-    nowMs,
     params.search,
+    serverItems,
     shouldProjectLocally,
-    tasks,
     tasksQuery.data,
     tasksQuery.isPlaceholderData,
+    worktreesByEpicId,
   ]);
 
   const refetch = useCallback(() => tasksQueryRefetch(), [tasksQueryRefetch]);
@@ -122,12 +149,20 @@ export function useHistoryQuery(
   return {
     data,
     isPending: tasksQuery.isPending,
-    isFetching: tasksQuery.isFetching || isQueryDebouncing,
+    isFetching:
+      tasksQuery.isFetching ||
+      isQueryDebouncing ||
+      (isPullRequestNumberQuery && worktreeMetadata.isFetching),
     error: tasksQuery.error instanceof Error ? tasksQuery.error : null,
     hostId,
     refetch,
     fetchNextPage,
-    hasNextPage: hasNextPage && !shouldProjectLocally,
+    // A settled PR query intentionally projects the broad cloud page locally,
+    // but it must retain pagination so matching tasks beyond the first page
+    // remain reachable. During ordinary debouncing / placeholder handoff, keep
+    // the existing guard so "Show more" cannot fetch against a stale request.
+    hasNextPage:
+      hasNextPage && !isQueryDebouncing && !tasksQuery.isPlaceholderData,
     isFetchingNextPage,
   };
 }
@@ -138,6 +173,7 @@ export interface HistoryFetchResult {
   availableWorkspaces: ReadonlyArray<HistoryWorkspaceRef>;
   totalCount: number;
   facets: HistoryFacets;
+  worktreesByEpicId: ReadonlyMap<string, readonly WorktreeHostEntryV12[]>;
 }
 
 export interface HistoryFacets {
@@ -225,4 +261,8 @@ function sortProjectedHistoryItems(
 ): ReadonlyArray<HistoryItem> {
   if (sort === "relevance" && query.length > 0) return items;
   return sortHistoryItems(items, sort);
+}
+
+function isHistoryPullRequestNumberQuery(query: string): boolean {
+  return /^(?:pr\s*)?#?\d+$/i.test(query.trim());
 }

--- a/clients/gui-app/src/hooks/worktree/use-task-worktree-metadata-query.ts
+++ b/clients/gui-app/src/hooks/worktree/use-task-worktree-metadata-query.ts
@@ -13,6 +13,7 @@ export interface TaskWorktreeMetadata {
     readonly WorktreeHostEntryV12[]
   >;
   readonly isFetching: boolean;
+  readonly error: Error | null;
 }
 
 /**
@@ -79,5 +80,8 @@ export function useTaskWorktreeMetadata(
   return {
     worktreesByEpicId,
     isFetching: baseQuery.isFetching || enrichedQuery.isFetching,
+    error:
+      (baseQuery.error instanceof Error ? baseQuery.error : null) ??
+      (enrichedQuery.error instanceof Error ? enrichedQuery.error : null),
   };
 }

--- a/clients/gui-app/src/hooks/worktree/use-task-worktree-metadata-query.ts
+++ b/clients/gui-app/src/hooks/worktree/use-task-worktree-metadata-query.ts
@@ -7,6 +7,14 @@ const EMPTY_WORKTREES: readonly WorktreeHostEntryV12[] = [];
 const EMPTY_BY_EPIC: ReadonlyMap<string, readonly WorktreeHostEntryV12[]> =
   new Map();
 
+export interface TaskWorktreeMetadata {
+  readonly worktreesByEpicId: ReadonlyMap<
+    string,
+    readonly WorktreeHostEntryV12[]
+  >;
+  readonly isFetching: boolean;
+}
+
 /**
  * Batches task-history worktree metadata into two host calls: one cheap
  * owner/path index, then one bounded enrichment request for only paths owned by
@@ -14,7 +22,7 @@ const EMPTY_BY_EPIC: ReadonlyMap<string, readonly WorktreeHostEntryV12[]> =
  */
 export function useTaskWorktreeMetadata(
   epicIds: readonly string[],
-): ReadonlyMap<string, readonly WorktreeHostEntryV12[]> {
+): TaskWorktreeMetadata {
   const client = useHostClient();
   const baseQuery = useHostQuery<HostRpcRegistry, "worktree.listAllForHost">({
     cacheKeyIdentity: undefined,
@@ -54,7 +62,7 @@ export function useTaskWorktreeMetadata(
     options: { enabled: ownedPaths.length > 0 },
   });
 
-  return useMemo(() => {
+  const worktreesByEpicId = useMemo(() => {
     const worktrees = enrichedQuery.data?.worktrees;
     if (worktrees === undefined || worktrees.length === 0) return EMPTY_BY_EPIC;
     const byEpic = new Map<string, WorktreeHostEntryV12[]>();
@@ -68,4 +76,8 @@ export function useTaskWorktreeMetadata(
     }
     return byEpic;
   }, [enrichedQuery.data, visibleEpicIds]);
+  return {
+    worktreesByEpicId,
+    isFetching: baseQuery.isFetching || enrichedQuery.isFetching,
+  };
 }


### PR DESCRIPTION
## Summary
- index task-history worktree PR metadata so PR numbers can be searched as `84`, `#84`, or `PR #84`
- retain history pagination for settled PR searches
- surface PR context through the shared history data model

## Validation
- `bun run --cwd clients/gui-app test src/hooks/home/__tests__/use-history-query.test.tsx src/components/home/__tests__/home-page.data.test.ts src/components/epics/__tests__/epics-list-panel.test.tsx`
- `bun run --cwd clients/gui-app lint -- …`
- React Doctor changed-files scan (0 issues)

`bun run --cwd clients/gui-app compile` is blocked by unrelated pre-existing dirty-file type errors outside this PR scope.