### PR TITLE
fix(gui): improve epic canvas context menus and Git diff labels

### DIFF
--- a/clients/gui-app/src/__tests__/nested-focus-interaction-fixtures.test.tsx
+++ b/clients/gui-app/src/__tests__/nested-focus-interaction-fixtures.test.tsx
@@ -147,6 +147,7 @@ const ROWS: ReadonlyArray<OpenerFixtureRow> = [
           viewTabId={tabId}
           hostId="host-1"
           runningDir="/repo"
+          repositoryContext={null}
           file={changedFile("src/app.ts")}
           active={false}
           pathRanges={[]}

--- a/clients/gui-app/src/components/diff/__tests__/bundle-diff-find-registration.test.tsx
+++ b/clients/gui-app/src/components/diff/__tests__/bundle-diff-find-registration.test.tsx
@@ -39,6 +39,7 @@ const NODE: EpicCanvasTileRef = {
   instanceId: "bundle-instance",
   name: "Bundle",
   hostId: "host-1",
+  repositoryContext: null,
   type: "git-diff",
   diff: {
     kind: "bundle",

--- a/clients/gui-app/src/components/epic-canvas/__tests__/root-dnd-commits.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/root-dnd-commits.test.ts
@@ -163,6 +163,7 @@ const GIT_DIFF_TILE = makeGitFileDiffTile({
   runningDir: "/repo",
   filePath: "src/app.ts",
   stage: "unstaged",
+  repositoryContext: null,
 });
 const TERMINAL_TILE = {
   id: "term-1",

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip-title.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip-title.test.tsx
@@ -109,7 +109,7 @@ function renderTabStrip(tab: typeof TAB, canRenameTabs: boolean): void {
   const onSelectTab = vi.fn<(groupId: string, tabId: string) => void>();
   const onCloseTab = vi.fn<(groupId: string, tabId: string) => void>();
   const onPromotePreview = vi.fn<(groupId: string) => void>();
-  const onSplitRight = vi.fn<(groupId: string) => void>();
+  const onSplit = vi.fn<(groupId: string, direction: SplitDirection) => void>();
   const onCloseGroup = vi.fn<(groupId: string) => void>();
   const onOpenBlankTab = vi.fn<(groupId: string) => void>();
   const onMenuTab = vi.fn<(groupId: string, tabId: string) => void>();
@@ -137,7 +137,7 @@ function renderTabStrip(tab: typeof TAB, canRenameTabs: boolean): void {
           onSelectTab={onSelectTab}
           onCloseTab={onCloseTab}
           onPromotePreview={onPromotePreview}
-          onSplitRight={onSplitRight}
+          onSplit={onSplit}
           onCloseGroup={onCloseGroup}
           onOpenBlankTab={onOpenBlankTab}
           canRenameTabs={canRenameTabs}

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip.test.tsx
@@ -9,13 +9,23 @@ vi.mock("@/hooks/notifications/use-host-notification-indicators-query", () => ({
     refetch: () => Promise.resolve(),
   }),
 }));
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TabStrip } from "@/components/epic-canvas/canvas/tab-strip";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
-import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+import type {
+  EpicCanvasTileRef,
+  EpicNodeRef,
+} from "@/stores/epics/canvas/types";
+import { makeGitBundleDiffTile } from "@/lib/git/git-diff-tile";
 
 interface CapturedDraggableInput {
   readonly id: string;
@@ -80,7 +90,7 @@ function createQueryClient(): QueryClient {
 // TabItem reads its active/preview/globally-active state from the canvas store
 // (via `useTabActivation`), not from props, so seed a tab whose lone group has
 // `TAB` as the active + preview tab.
-function seedActivePreviewTab(): void {
+function seedActivePreviewTab(tab: EpicCanvasTileRef): void {
   useEpicCanvasStore.setState({
     tabsById: {
       [VIEW_TAB_ID]: {
@@ -95,12 +105,12 @@ function seedActivePreviewTab(): void {
         root: {
           kind: "pane",
           id: "group-1",
-          tabInstanceIds: [TAB.instanceId],
-          activeTabId: TAB.instanceId,
-          previewTabId: TAB.instanceId,
-          activationHistory: [TAB.instanceId],
+          tabInstanceIds: [tab.instanceId],
+          activeTabId: tab.instanceId,
+          previewTabId: tab.instanceId,
+          activationHistory: [tab.instanceId],
         },
-        tilesByInstanceId: { [TAB.instanceId]: TAB },
+        tilesByInstanceId: { [tab.instanceId]: tab },
         sizesByGroupId: {},
       },
     },
@@ -111,22 +121,41 @@ function renderTabStrip(input: {
   readonly onClose: (groupId: string, tabId: string) => void;
   readonly onPromotePreview: (groupId: string) => void;
   readonly onOpenBlankTab: (groupId: string) => void;
+  readonly onSplit?: (
+    groupId: string,
+    direction: "horizontal" | "vertical",
+  ) => void;
 }) {
-  seedActivePreviewTab();
+  renderTabStripForTab(TAB, input);
+}
+
+function renderTabStripForTab(
+  tab: EpicCanvasTileRef,
+  input: {
+    readonly onClose: (groupId: string, tabId: string) => void;
+    readonly onPromotePreview: (groupId: string) => void;
+    readonly onOpenBlankTab: (groupId: string) => void;
+    readonly onSplit?: (
+      groupId: string,
+      direction: "horizontal" | "vertical",
+    ) => void;
+  },
+) {
+  seedActivePreviewTab(tab);
   const queryClient = createQueryClient();
   render(
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
+      <TooltipProvider delayDuration={0}>
         <TabStrip
           epicId="epic-1"
           tabId={VIEW_TAB_ID}
           groupId="group-1"
-          tabs={[TAB]}
-          activeTabId={TAB.instanceId}
+          tabs={[tab]}
+          activeTabId={tab.instanceId}
           onSelectTab={() => undefined}
           onCloseTab={input.onClose}
           onPromotePreview={input.onPromotePreview}
-          onSplitRight={() => undefined}
+          onSplit={input.onSplit ?? (() => undefined)}
           onCloseGroup={() => undefined}
           onOpenBlankTab={input.onOpenBlankTab}
           canRenameTabs
@@ -232,5 +261,86 @@ describe("<TabStrip />", () => {
     fireEvent.doubleClick(screen.getByRole("tab", { name: /a\.md/ }));
 
     expect(onOpenBlankTab).not.toHaveBeenCalled();
+  });
+
+  it("splits right by default and down when Shift is held for the click", () => {
+    const onSplit = vi.fn();
+    renderTabStrip({
+      onClose: () => undefined,
+      onPromotePreview: () => undefined,
+      onOpenBlankTab: () => undefined,
+      onSplit,
+    });
+
+    const splitButton = screen.getByTestId("tab-strip-split-right");
+    fireEvent.click(splitButton);
+    fireEvent.click(splitButton, { shiftKey: true });
+
+    expect(onSplit).toHaveBeenNthCalledWith(1, "group-1", "horizontal");
+    expect(onSplit).toHaveBeenNthCalledWith(2, "group-1", "vertical");
+  });
+
+  it("updates the split affordance and tooltip while Shift is held", async () => {
+    renderTabStrip({
+      onClose: () => undefined,
+      onPromotePreview: () => undefined,
+      onOpenBlankTab: () => undefined,
+    });
+
+    const splitButton = screen.getByTestId("tab-strip-split-right");
+    fireEvent.focus(splitButton);
+
+    expect(splitButton.getAttribute("aria-label")).toBe("Split group right");
+    expect(splitButton.getAttribute("data-split-direction")).toBe("horizontal");
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toContain("Shift+click to split down");
+    expect(tooltip.querySelector('[data-slot="kbd"]')).not.toBeNull();
+
+    fireEvent.keyDown(window, { key: "Shift", shiftKey: true });
+
+    expect(splitButton.getAttribute("aria-label")).toBe("Split group down");
+    expect(splitButton.getAttribute("data-split-direction")).toBe("vertical");
+    expect(screen.getByRole("tooltip").textContent).toContain(
+      "Release Shift to split right",
+    );
+  });
+
+  it("shows repository hierarchy in Git bundle titles and structured tooltips", async () => {
+    const gitTab = makeGitBundleDiffTile({
+      hostId: "host-A",
+      runningDir: "/worktrees/right-click-context-menu/traycer",
+      bundleGroup: "changes",
+      repositoryContext: {
+        workspaceLabel: "traycer-internal",
+        repositoryLabel: "traycer",
+      },
+    });
+    renderTabStripForTab(gitTab, {
+      onClose: () => undefined,
+      onPromotePreview: () => undefined,
+      onOpenBlankTab: () => undefined,
+    });
+
+    const title = screen.getByTestId(`tab-title-${gitTab.instanceId}`);
+    expect(title.textContent).toBe("traycer-internal › traycer · Changes");
+
+    fireEvent.focus(title);
+
+    const tooltips = await screen.findAllByTestId(
+      `git-diff-tab-tooltip-${gitTab.instanceId}`,
+    );
+    const tooltip = within(tooltips[0]);
+    expect(tooltip.getByTestId("git-diff-tooltip-workspace").textContent).toBe(
+      "Workspacetraycer-internal",
+    );
+    expect(tooltip.getByTestId("git-diff-tooltip-repository").textContent).toBe(
+      "Repositorytraycer",
+    );
+    expect(tooltip.getByTestId("git-diff-tooltip-scope").textContent).toBe(
+      "DiffChanges",
+    );
+    expect(tooltip.getByTestId("git-diff-tooltip-path").textContent).toBe(
+      "Path/worktrees/right-click-context-menu/traycer",
+    );
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip.test.tsx
@@ -24,6 +24,7 @@ import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type {
   EpicCanvasTileRef,
   EpicNodeRef,
+  SplitDirection,
 } from "@/stores/epics/canvas/types";
 import { makeGitBundleDiffTile } from "@/lib/git/git-diff-tile";
 
@@ -121,10 +122,8 @@ function renderTabStrip(input: {
   readonly onClose: (groupId: string, tabId: string) => void;
   readonly onPromotePreview: (groupId: string) => void;
   readonly onOpenBlankTab: (groupId: string) => void;
-  readonly onSplit?: (
-    groupId: string,
-    direction: "horizontal" | "vertical",
-  ) => void;
+  readonly onSplit:
+    ((groupId: string, direction: SplitDirection) => void) | undefined;
 }) {
   renderTabStripForTab(TAB, input);
 }
@@ -135,14 +134,13 @@ function renderTabStripForTab(
     readonly onClose: (groupId: string, tabId: string) => void;
     readonly onPromotePreview: (groupId: string) => void;
     readonly onOpenBlankTab: (groupId: string) => void;
-    readonly onSplit?: (
-      groupId: string,
-      direction: "horizontal" | "vertical",
-    ) => void;
+    readonly onSplit:
+      ((groupId: string, direction: SplitDirection) => void) | undefined;
   },
 ) {
   seedActivePreviewTab(tab);
   const queryClient = createQueryClient();
+  const onSplit = input.onSplit === undefined ? () => undefined : input.onSplit;
   render(
     <QueryClientProvider client={queryClient}>
       <TooltipProvider delayDuration={0}>
@@ -155,7 +153,7 @@ function renderTabStripForTab(
           onSelectTab={() => undefined}
           onCloseTab={input.onClose}
           onPromotePreview={input.onPromotePreview}
-          onSplit={input.onSplit ?? (() => undefined)}
+          onSplit={onSplit}
           onCloseGroup={() => undefined}
           onOpenBlankTab={input.onOpenBlankTab}
           canRenameTabs
@@ -188,6 +186,7 @@ describe("<TabStrip />", () => {
       onClose,
       onPromotePreview: () => undefined,
       onOpenBlankTab: () => undefined,
+      onSplit: undefined,
     });
 
     const tab = screen.getByRole("tab", { name: /a\.md/ });
@@ -209,6 +208,7 @@ describe("<TabStrip />", () => {
       onClose: () => undefined,
       onPromotePreview,
       onOpenBlankTab: () => undefined,
+      onSplit: undefined,
     });
 
     fireEvent.doubleClick(screen.getByRole("tab", { name: /a\.md/ }));
@@ -222,6 +222,7 @@ describe("<TabStrip />", () => {
       onClose: () => undefined,
       onPromotePreview: () => undefined,
       onOpenBlankTab,
+      onSplit: undefined,
     });
 
     // Double-clicking the strip-end container itself (not a tab) opens a blank.
@@ -235,6 +236,7 @@ describe("<TabStrip />", () => {
       onClose: () => undefined,
       onPromotePreview: () => undefined,
       onOpenBlankTab: () => undefined,
+      onSplit: undefined,
     });
 
     const scroller = screen.getByTestId("tab-strip-end");
@@ -254,6 +256,7 @@ describe("<TabStrip />", () => {
       onClose: () => undefined,
       onPromotePreview: () => undefined,
       onOpenBlankTab,
+      onSplit: undefined,
     });
 
     // The guard (target === currentTarget) keeps tab double-clicks from
@@ -272,7 +275,9 @@ describe("<TabStrip />", () => {
       onSplit,
     });
 
-    const splitButton = screen.getByTestId("tab-strip-split-right");
+    const splitButton = screen.getByRole("button", {
+      name: "Split group right",
+    });
     fireEvent.click(splitButton);
     fireEvent.click(splitButton, { shiftKey: true });
 
@@ -280,14 +285,51 @@ describe("<TabStrip />", () => {
     expect(onSplit).toHaveBeenNthCalledWith(2, "group-1", "vertical");
   });
 
+  it("shows the down-split affordance when focus arrives with Shift held", () => {
+    renderTabStrip({
+      onClose: () => undefined,
+      onPromotePreview: () => undefined,
+      onOpenBlankTab: () => undefined,
+      onSplit: undefined,
+    });
+
+    fireEvent.keyDown(window, { key: "Shift", shiftKey: true });
+    const splitButton = screen.getByRole("button", {
+      name: "Split group right",
+    });
+    fireEvent.focus(splitButton);
+
+    expect(splitButton.getAttribute("aria-label")).toBe("Split group down");
+    expect(splitButton.getAttribute("data-split-direction")).toBe("vertical");
+  });
+
+  it("keeps the default affordance while neither hovered nor focused", () => {
+    renderTabStrip({
+      onClose: () => undefined,
+      onPromotePreview: () => undefined,
+      onOpenBlankTab: () => undefined,
+      onSplit: undefined,
+    });
+
+    fireEvent.keyDown(window, { key: "Shift", shiftKey: true });
+
+    const splitButton = screen.getByRole("button", {
+      name: "Split group right",
+    });
+    expect(splitButton.getAttribute("data-split-direction")).toBe("horizontal");
+  });
+
   it("updates the split affordance and tooltip while Shift is held", async () => {
     renderTabStrip({
       onClose: () => undefined,
       onPromotePreview: () => undefined,
       onOpenBlankTab: () => undefined,
+      onSplit: undefined,
     });
 
-    const splitButton = screen.getByTestId("tab-strip-split-right");
+    const splitButton = screen.getByRole("button", {
+      name: "Split group right",
+    });
     fireEvent.focus(splitButton);
 
     expect(splitButton.getAttribute("aria-label")).toBe("Split group right");
@@ -319,6 +361,7 @@ describe("<TabStrip />", () => {
       onClose: () => undefined,
       onPromotePreview: () => undefined,
       onOpenBlankTab: () => undefined,
+      onSplit: undefined,
     });
 
     const title = screen.getByTestId(`tab-title-${gitTab.instanceId}`);

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-epic-route-synchronization.test.tsx
@@ -626,6 +626,7 @@ describe("useEpicRouteSynchronization", () => {
       type: "git-diff",
       name: "file.ts · Working",
       hostId: "host-1",
+      repositoryContext: null,
       diff: {
         kind: "file",
         runningDir: "/repo",

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -170,12 +170,12 @@ export const TabGroupView = memo(function TabGroupView(
     [promotePreviewInTab, tabId],
   );
 
-  const handleSplitRight = useCallback(
-    (groupId: string) => {
+  const handleSplit = useCallback(
+    (groupId: string, direction: SplitDirection) => {
       // The new empty pane self-renders the inline opener (PaneOpener); no
       // explicit trigger needed.
       navigateNested(epicId, tabId, () =>
-        prepareSplitPaneEmptyFocusTarget(tabId, groupId, "horizontal"),
+        prepareSplitPaneEmptyFocusTarget(tabId, groupId, direction),
       );
     },
     [epicId, navigateNested, prepareSplitPaneEmptyFocusTarget, tabId],
@@ -335,7 +335,7 @@ export const TabGroupView = memo(function TabGroupView(
             onSelectTab={handleSelectTab}
             onCloseTab={handleCloseTab}
             onPromotePreview={handlePromotePreview}
-            onSplitRight={handleSplitRight}
+            onSplit={handleSplit}
             onCloseGroup={handleCloseGroup}
             onOpenBlankTab={handleOpenBlankTab}
             canRenameTabs={canRenameTabs}

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-strip.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-strip.tsx
@@ -80,6 +80,10 @@ import {
 import { getBasename } from "@/lib/path/cross-platform-path";
 import { formatChordForDisplay } from "@/lib/keybindings/chord";
 import { useBindingForAction } from "@/stores/settings/keybinding-store";
+import {
+  reportShiftKeyHeld,
+  useShiftKeyHeld,
+} from "@/hooks/use-shift-key-held";
 
 const EPIC_TAB_LAYOUT_TRANSITION = {
   type: "spring",
@@ -305,30 +309,13 @@ interface SplitGroupButtonProps {
 function SplitGroupButton(props: SplitGroupButtonProps) {
   const [hovered, setHovered] = useState(false);
   const [focused, setFocused] = useState(false);
-  const [shiftHeld, setShiftHeld] = useState(false);
-  const splitRightBinding = useBindingForAction("group.split-right");
-  const splitDownBinding = useBindingForAction("group.split.vertical");
-  const direction = shiftHeld ? "vertical" : "horizontal";
-  const actionLabel = shiftHeld ? "Split group down" : "Split group right";
-  const shortcut = shiftHeld ? splitDownBinding : splitRightBinding;
-
-  useEffect(() => {
-    if (!hovered && !focused) return;
-
-    const handleModifierChange = (event: globalThis.KeyboardEvent) => {
-      setShiftHeld(event.shiftKey);
-    };
-    const handleWindowBlur = () => setShiftHeld(false);
-
-    window.addEventListener("keydown", handleModifierChange);
-    window.addEventListener("keyup", handleModifierChange);
-    window.addEventListener("blur", handleWindowBlur);
-    return () => {
-      window.removeEventListener("keydown", handleModifierChange);
-      window.removeEventListener("keyup", handleModifierChange);
-      window.removeEventListener("blur", handleWindowBlur);
-    };
-  }, [focused, hovered]);
+  const shiftHeld = useShiftKeyHeld();
+  const splitHorizontalBinding = useBindingForAction("group.split.horizontal");
+  const splitVerticalBinding = useBindingForAction("group.split.vertical");
+  const splitsDown = shiftHeld && (hovered || focused);
+  const direction = splitsDown ? "vertical" : "horizontal";
+  const actionLabel = splitsDown ? "Split group down" : "Split group right";
+  const shortcut = splitsDown ? splitVerticalBinding : splitHorizontalBinding;
 
   return (
     <Tooltip>
@@ -339,17 +326,11 @@ function SplitGroupButton(props: SplitGroupButtonProps) {
           size="icon-sm"
           onPointerEnter={(event) => {
             setHovered(true);
-            setShiftHeld(event.shiftKey);
+            reportShiftKeyHeld(event.shiftKey);
           }}
-          onPointerLeave={() => {
-            setHovered(false);
-            if (!focused) setShiftHeld(false);
-          }}
+          onPointerLeave={() => setHovered(false)}
           onFocus={() => setFocused(true)}
-          onBlur={() => {
-            setFocused(false);
-            if (!hovered) setShiftHeld(false);
-          }}
+          onBlur={() => setFocused(false)}
           onClick={(event) =>
             props.onSplit(
               props.groupId,
@@ -357,10 +338,10 @@ function SplitGroupButton(props: SplitGroupButtonProps) {
             )
           }
           aria-label={actionLabel}
-          data-testid="tab-strip-split-right"
+          data-testid="tab-strip-split"
           data-split-direction={direction}
         >
-          {shiftHeld ? (
+          {splitsDown ? (
             <SplitSquareVertical className="size-4" />
           ) : (
             <SplitSquareHorizontal className="size-4" />
@@ -379,7 +360,7 @@ function SplitGroupButton(props: SplitGroupButtonProps) {
           )}
         </span>
         <span className="text-background/70">
-          {shiftHeld
+          {splitsDown
             ? "Release Shift to split right"
             : "Shift+click to split down"}
         </span>

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-strip.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-strip.tsx
@@ -3,12 +3,19 @@ import {
   useEffect,
   useMemo,
   useRef,
+  useState,
   type KeyboardEvent,
   type MouseEvent,
   type ReactNode,
 } from "react";
 import { useDraggable, useDroppable } from "@dnd-kit/core";
-import { FileDiff, FilePlus, SplitSquareHorizontal, X } from "lucide-react";
+import {
+  FileDiff,
+  FilePlus,
+  SplitSquareHorizontal,
+  SplitSquareVertical,
+  X,
+} from "lucide-react";
 import { AnimatePresence, LayoutGroup } from "motion/react";
 import * as m from "motion/react-m";
 import { mergeRefs } from "@/lib/merge-refs";
@@ -17,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { DropLine } from "@/components/ui/drop-line";
+import { Kbd } from "@/components/ui/kbd";
 import {
   Tooltip,
   TooltipContent,
@@ -39,10 +47,14 @@ import {
   type EpicCanvasDropTargetData,
 } from "@/components/epic-canvas/dnd/dnd";
 import { useTabStripDropIndex } from "@/components/epic-canvas/dnd/dnd-store";
-import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+import type {
+  EpicCanvasTileRef,
+  SplitDirection,
+} from "@/stores/epics/canvas/types";
 import {
   isBlankTileRef,
   isDiffTileRef,
+  isGitDiffTileRef,
   isOpenableEpicNodeKind,
 } from "@/stores/epics/canvas/types";
 import { useIsActivePane, useTabActivation } from "@/stores/epics/canvas/store";
@@ -60,6 +72,14 @@ import {
   leaderDigitFor,
   leaderHint,
 } from "@/components/ui/leader-digit-shortcuts";
+import {
+  gitBundleGroupLabel,
+  gitDiffRepositoryContextLabel,
+  gitStageLabel,
+} from "@/lib/git/git-diff-tile";
+import { getBasename } from "@/lib/path/cross-platform-path";
+import { formatChordForDisplay } from "@/lib/keybindings/chord";
+import { useBindingForAction } from "@/stores/settings/keybinding-store";
 
 const EPIC_TAB_LAYOUT_TRANSITION = {
   type: "spring",
@@ -85,7 +105,7 @@ export interface TabStripProps {
   readonly onSelectTab: (groupId: string, tabId: string) => void;
   readonly onCloseTab: (groupId: string, tabId: string) => void;
   readonly onPromotePreview: (groupId: string) => void;
-  readonly onSplitRight: (groupId: string) => void;
+  readonly onSplit: (groupId: string, direction: SplitDirection) => void;
   readonly onCloseGroup: (groupId: string) => void;
   readonly onOpenBlankTab: (groupId: string) => void;
   readonly canRenameTabs: boolean;
@@ -146,7 +166,7 @@ export function TabStrip(props: TabStripProps) {
     onSelectTab,
     onCloseTab,
     onPromotePreview,
-    onSplitRight,
+    onSplit,
     onCloseGroup,
     onOpenBlankTab,
     canRenameTabs,
@@ -260,16 +280,7 @@ export function TabStrip(props: TabStripProps) {
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-0.5 border-l border-canvas-border/70 bg-canvas px-1">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={() => onSplitRight(groupId)}
-            aria-label="Split group right"
-            data-testid="tab-strip-split-right"
-          >
-            <SplitSquareHorizontal className="size-4" />
-          </Button>
+          <SplitGroupButton groupId={groupId} onSplit={onSplit} />
           <Button
             type="button"
             variant="ghost"
@@ -283,6 +294,97 @@ export function TabStrip(props: TabStripProps) {
         </div>
       </div>
     </NotificationIndicatorsProvider>
+  );
+}
+
+interface SplitGroupButtonProps {
+  readonly groupId: string;
+  readonly onSplit: (groupId: string, direction: SplitDirection) => void;
+}
+
+function SplitGroupButton(props: SplitGroupButtonProps) {
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [shiftHeld, setShiftHeld] = useState(false);
+  const splitRightBinding = useBindingForAction("group.split-right");
+  const splitDownBinding = useBindingForAction("group.split.vertical");
+  const direction = shiftHeld ? "vertical" : "horizontal";
+  const actionLabel = shiftHeld ? "Split group down" : "Split group right";
+  const shortcut = shiftHeld ? splitDownBinding : splitRightBinding;
+
+  useEffect(() => {
+    if (!hovered && !focused) return;
+
+    const handleModifierChange = (event: globalThis.KeyboardEvent) => {
+      setShiftHeld(event.shiftKey);
+    };
+    const handleWindowBlur = () => setShiftHeld(false);
+
+    window.addEventListener("keydown", handleModifierChange);
+    window.addEventListener("keyup", handleModifierChange);
+    window.addEventListener("blur", handleWindowBlur);
+    return () => {
+      window.removeEventListener("keydown", handleModifierChange);
+      window.removeEventListener("keyup", handleModifierChange);
+      window.removeEventListener("blur", handleWindowBlur);
+    };
+  }, [focused, hovered]);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onPointerEnter={(event) => {
+            setHovered(true);
+            setShiftHeld(event.shiftKey);
+          }}
+          onPointerLeave={() => {
+            setHovered(false);
+            if (!focused) setShiftHeld(false);
+          }}
+          onFocus={() => setFocused(true)}
+          onBlur={() => {
+            setFocused(false);
+            if (!hovered) setShiftHeld(false);
+          }}
+          onClick={(event) =>
+            props.onSplit(
+              props.groupId,
+              event.shiftKey ? "vertical" : "horizontal",
+            )
+          }
+          aria-label={actionLabel}
+          data-testid="tab-strip-split-right"
+          data-split-direction={direction}
+        >
+          {shiftHeld ? (
+            <SplitSquareVertical className="size-4" />
+          ) : (
+            <SplitSquareHorizontal className="size-4" />
+          )}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        sideOffset={4}
+        className="flex-col items-start gap-1"
+      >
+        <span className="flex items-center gap-2">
+          <span>{actionLabel}</span>
+          {shortcut === null ? null : (
+            <Kbd>{formatChordForDisplay(shortcut)}</Kbd>
+          )}
+        </span>
+        <span className="text-background/70">
+          {shiftHeld
+            ? "Release Shift to split right"
+            : "Shift+click to split down"}
+        </span>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -445,6 +547,7 @@ function TabItem(props: TabItemProps) {
           modifier: leaderModifier,
           hint: leaderHint(leaderDigitFor(index), "to switch to", displayTitle),
         };
+  const tooltipContent = tabTooltipContent(tab, displayTitle);
 
   return (
     <ContextMenu>
@@ -491,6 +594,7 @@ function TabItem(props: TabItemProps) {
             />
             <TabItemLabelSlot
               displayTitle={displayTitle}
+              tooltipContent={tooltipContent}
               inputProps={rename.inputProps}
               isActive={isActive}
               isEditing={rename.isEditing}
@@ -519,6 +623,7 @@ interface CanvasLeaderBadge {
 
 interface TabItemLabelSlotProps {
   readonly displayTitle: string;
+  readonly tooltipContent: ReactNode;
   readonly inputProps: InlineRenameInputProps;
   readonly isActive: boolean;
   readonly isEditing: boolean;
@@ -532,6 +637,7 @@ interface TabItemLabelSlotProps {
 function TabItemLabelSlot(props: TabItemLabelSlotProps) {
   const {
     displayTitle,
+    tooltipContent,
     inputProps,
     isActive,
     isEditing,
@@ -569,7 +675,7 @@ function TabItemLabelSlot(props: TabItemLabelSlotProps) {
               {displayTitle}
             </span>
           </TooltipTrigger>
-          <TooltipContent>{displayTitle}</TooltipContent>
+          <TooltipContent>{tooltipContent}</TooltipContent>
         </Tooltip>
         <span
           aria-hidden="true"
@@ -611,6 +717,90 @@ function TabItemLabelSlot(props: TabItemLabelSlotProps) {
         </button>
       ) : null}
     </>
+  );
+}
+
+function tabTooltipContent(
+  tab: EpicCanvasTileRef,
+  displayTitle: string,
+): ReactNode {
+  if (!isGitDiffTileRef(tab)) return displayTitle;
+  const context = tab.repositoryContext;
+  const repositoryLabel =
+    context?.repositoryLabel ?? getBasename(tab.diff.runningDir);
+  const scopeLabel =
+    tab.diff.kind === "bundle"
+      ? gitBundleGroupLabel(tab.diff.bundleGroup)
+      : gitStageLabel(tab.diff.stage);
+  const heading =
+    context === null ? repositoryLabel : gitDiffRepositoryContextLabel(context);
+  return (
+    <div
+      className="flex w-[min(80vw,24rem)] min-w-0 flex-col gap-1 text-left"
+      data-testid={`git-diff-tab-tooltip-${tab.instanceId}`}
+    >
+      <div className="truncate font-medium">{heading}</div>
+      {context === null ? null : (
+        <GitDiffTooltipSummaryRow
+          label="Workspace"
+          value={context.workspaceLabel}
+          testId="git-diff-tooltip-workspace"
+          wrap={false}
+        />
+      )}
+      <GitDiffTooltipSummaryRow
+        label="Repository"
+        value={repositoryLabel}
+        testId="git-diff-tooltip-repository"
+        wrap={false}
+      />
+      <GitDiffTooltipSummaryRow
+        label="Diff"
+        value={scopeLabel}
+        testId="git-diff-tooltip-scope"
+        wrap={false}
+      />
+      {tab.diff.kind === "file" ? (
+        <GitDiffTooltipSummaryRow
+          label="File"
+          value={tab.diff.filePath}
+          testId="git-diff-tooltip-file"
+          wrap
+        />
+      ) : null}
+      <div className="mt-0.5 border-t border-background/15 pt-1">
+        <GitDiffTooltipSummaryRow
+          label="Path"
+          value={tab.diff.runningDir}
+          testId="git-diff-tooltip-path"
+          wrap
+        />
+      </div>
+    </div>
+  );
+}
+
+function GitDiffTooltipSummaryRow(props: {
+  readonly label: string;
+  readonly value: string;
+  readonly testId: string;
+  readonly wrap: boolean;
+}): ReactNode {
+  return (
+    <div
+      className="flex min-w-0 items-start justify-between gap-3"
+      data-testid={props.testId}
+    >
+      <span className="shrink-0 text-background/70">{props.label}</span>
+      <span
+        className={cn(
+          "min-w-0 text-right font-medium",
+          props.wrap ? "break-all" : "truncate",
+        )}
+      >
+        {props.value}
+      </span>
+    </div>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/dnd/__tests__/drag-overlay-chip.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/dnd/__tests__/drag-overlay-chip.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EpicRootDragOverlayContent } from "@/components/epic-canvas/dnd/drag-overlay-chip";
+import type { EpicCanvasGitDiffTileDragData } from "@/components/epic-canvas/dnd/dnd";
+import { GIT_DIFF_TILE_DND_TYPE } from "@/components/epic-canvas/dnd/dnd";
+import { useEpicDndStore } from "@/components/epic-canvas/dnd/dnd-store";
+import { makeGitBundleDiffTile } from "@/lib/git/git-diff-tile";
+
+describe("<EpicRootDragOverlayContent />", () => {
+  beforeEach(() => {
+    useEpicDndStore.getState().dragEnded();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useEpicDndStore.getState().dragEnded();
+  });
+
+  it("renders a Git bundle drag as an intrinsically sized semantic chip", () => {
+    const tile = makeGitBundleDiffTile({
+      hostId: "host-1",
+      runningDir: "/worktrees/right-click-context-menu/traycer",
+      bundleGroup: "changes",
+      repositoryContext: {
+        workspaceLabel: "traycer-internal",
+        repositoryLabel: "traycer",
+      },
+    });
+    const source: EpicCanvasGitDiffTileDragData = {
+      kind: GIT_DIFF_TILE_DND_TYPE,
+      epicId: "epic-1",
+      viewTabId: "view-tab-1",
+      tile,
+    };
+    useEpicDndStore.getState().canvasDragStarted(source, tile);
+
+    render(<EpicRootDragOverlayContent />);
+
+    const chip = screen.getByTestId("git-diff-drag-overlay");
+    expect(chip.className).toContain("w-max");
+    expect(chip.getAttribute("aria-label")).toBe(
+      "Changes: traycer-internal › traycer",
+    );
+    expect(screen.getByTestId("git-diff-drag-overlay-scope").textContent).toBe(
+      "Changes",
+    );
+    expect(
+      screen.getByTestId("git-diff-drag-overlay-subject").textContent,
+    ).toBe("traycer-internal › traycer");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/dnd/drag-overlay-chip.tsx
+++ b/clients/gui-app/src/components/epic-canvas/dnd/drag-overlay-chip.tsx
@@ -22,6 +22,7 @@ import type { HeaderTabDragData } from "@/components/layout/tabs/header-tab-dnd"
 import {
   isBlankTileRef,
   isDiffTileRef,
+  isGitDiffTileRef,
   type BlankTileRef,
   type EpicCanvasTileRef,
   type EpicNodeRef,
@@ -29,9 +30,15 @@ import {
   type SnapshotDiffTileRef,
 } from "@/stores/epics/canvas/types";
 import { cn } from "@/lib/utils";
+import {
+  gitBundleGroupLabel,
+  gitDiffRepositoryContextLabel,
+  gitStageLabel,
+} from "@/lib/git/git-diff-tile";
+import { getBasename } from "@/lib/path/cross-platform-path";
 
 const CHIP_CLASS =
-  "pointer-events-none flex h-9 max-w-56 cursor-grabbing select-none items-center gap-1.5 rounded-md border border-canvas-border/80 bg-canvas px-3 text-ui-sm text-canvas-foreground shadow-lg";
+  "pointer-events-none flex h-9 w-max max-w-[min(80vw,24rem)] cursor-grabbing select-none items-center gap-1.5 rounded-md border border-canvas-border/80 bg-canvas px-3 text-ui-sm text-canvas-foreground shadow-lg";
 
 const CHIP_MOTION = {
   initial: { opacity: 0, scale: 0.96, y: 2 },
@@ -159,10 +166,52 @@ function ArtifactNodeDragOverlay(props: {
 function DiffTileDragOverlay(props: {
   readonly node: GitDiffTileRef | SnapshotDiffTileRef;
 }) {
+  if (isGitDiffTileRef(props.node)) {
+    return <GitDiffTileDragOverlay node={props.node} />;
+  }
   return (
     <m.div {...CHIP_MOTION} className={cn(CHIP_CLASS)}>
       <FileDiff className="size-3.5 shrink-0 text-muted-foreground" />
       <span className="min-w-0 truncate font-medium">{props.node.name}</span>
+    </m.div>
+  );
+}
+
+function GitDiffTileDragOverlay(props: { readonly node: GitDiffTileRef }) {
+  const scopeLabel =
+    props.node.diff.kind === "bundle"
+      ? gitBundleGroupLabel(props.node.diff.bundleGroup)
+      : gitStageLabel(props.node.diff.stage);
+  let subjectLabel = getBasename(props.node.diff.runningDir);
+  if (props.node.diff.kind === "file") {
+    subjectLabel = getBasename(props.node.diff.filePath);
+  } else if (props.node.repositoryContext !== null) {
+    subjectLabel = gitDiffRepositoryContextLabel(props.node.repositoryContext);
+  }
+
+  return (
+    <m.div
+      {...CHIP_MOTION}
+      aria-label={`${scopeLabel}: ${subjectLabel}`}
+      className={cn(CHIP_CLASS)}
+      data-testid="git-diff-drag-overlay"
+    >
+      <FileDiff className="size-3.5 shrink-0 text-primary" />
+      <span
+        className="shrink-0 font-medium"
+        data-testid="git-diff-drag-overlay-scope"
+      >
+        {scopeLabel}
+      </span>
+      <span aria-hidden="true" className="text-muted-foreground/70">
+        ·
+      </span>
+      <span
+        className="min-w-0 truncate text-muted-foreground"
+        data-testid="git-diff-drag-overlay-subject"
+      >
+        {subjectLabel}
+      </span>
     </m.div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/bundle-open-button.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/bundle-open-button.test.tsx
@@ -35,6 +35,10 @@ describe("<BundleOpenButton />", () => {
         hostId="host-1"
         runningDir="/repo"
         group="changes"
+        repositoryContext={{
+          workspaceLabel: "traycer-internal",
+          repositoryLabel: "traycer",
+        }}
         disabled={false}
       />,
     );
@@ -59,6 +63,11 @@ describe("<BundleOpenButton />", () => {
       bundleGroup: "changes",
     });
     expect(tile.hostId).toBe("host-1");
+    expect(tile.name).toBe("traycer-internal › traycer · Changes");
+    expect(tile.repositoryContext).toEqual({
+      workspaceLabel: "traycer-internal",
+      repositoryLabel: "traycer",
+    });
   });
 
   it("opens a pinned merge bundle diff tile", () => {
@@ -71,6 +80,7 @@ describe("<BundleOpenButton />", () => {
         hostId="host-1"
         runningDir="/repo"
         group="merge"
+        repositoryContext={null}
         disabled={false}
       />,
     );
@@ -100,6 +110,7 @@ describe("<BundleOpenButton />", () => {
         hostId="host-1"
         runningDir="/repo"
         group="staged"
+        repositoryContext={null}
         disabled
       />,
     );

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-row-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-row-navigation.test.tsx
@@ -44,6 +44,7 @@ function renderRow(tabId: string): void {
         viewTabId={tabId}
         hostId="host-1"
         runningDir="/repo"
+        repositoryContext={null}
         file={changedFile("src/app.ts")}
         active={false}
         pathRanges={[]}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/file-tree-navigation.test.tsx
@@ -105,6 +105,7 @@ function renderTree(tabId: string): void {
       viewTabId={tabId}
       hostId="host-1"
       runningDir="/repo"
+      repositoryContext={null}
       allFiles={[file]}
       visibleFiles={[file]}
       forceExpanded={false}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/use-git-panel-active-file.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/use-git-panel-active-file.test.tsx
@@ -55,6 +55,7 @@ describe("useGitPanelActiveFile", () => {
       runningDir: RUNNING_DIR,
       filePath: "src/a.ts",
       stage: "staged",
+      repositoryContext: null,
     });
     seedViewTab(openTile(createEmptyCanvas(), tile, false));
 
@@ -79,6 +80,7 @@ describe("useGitPanelActiveFile", () => {
       runningDir: "/other-worktree",
       filePath: "src/a.ts",
       stage: "unstaged",
+      repositoryContext: null,
     });
     seedViewTab(openTile(createEmptyCanvas(), tile, false));
 

--- a/clients/gui-app/src/components/epic-canvas/git-diff/bundle-open-button.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/bundle-open-button.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/lib/git/git-diff-tile";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
-import type { GitDiffBundleGroup } from "@/stores/epics/canvas/types";
+import type {
+  GitDiffBundleGroup,
+  GitDiffRepositoryContext,
+} from "@/stores/epics/canvas/types";
 import { useDraggable } from "@dnd-kit/core";
 import { FileDiff } from "lucide-react";
 import type { ReactNode } from "react";
@@ -22,6 +25,7 @@ export interface BundleOpenButtonProps {
   readonly hostId: string;
   readonly runningDir: string;
   readonly group: GitDiffBundleGroup;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly disabled: boolean;
 }
 
@@ -36,8 +40,9 @@ export function BundleOpenButton(props: BundleOpenButtonProps): ReactNode {
         hostId: props.hostId,
         runningDir: props.runningDir,
         bundleGroup: props.group,
+        repositoryContext: props.repositoryContext,
       }),
-    [props.hostId, props.group, props.runningDir],
+    [props.hostId, props.group, props.repositoryContext, props.runningDir],
   );
   const dragData = useMemo<EpicCanvasGitDiffTileDragData>(
     () => ({

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-list.tsx
@@ -13,12 +13,14 @@ import { FileSections } from "./file-sections";
 import { FileTree } from "./file-tree";
 import { NoMatchingFiles } from "./empty-states/no-matching-files";
 import type { GitDiffSectionCollapseController } from "./git-diff-section";
+import type { GitDiffRepositoryContext } from "@/stores/epics/canvas/types";
 
 export interface FileListProps {
   readonly epicId: string;
   readonly viewTabId: string;
   readonly hostId: string;
   readonly runningDir: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly files: ReadonlyArray<GitChangedFile>;
   readonly query: string;
   readonly onClearQuery: () => void;
@@ -71,6 +73,7 @@ export function FileList(props: FileListProps): ReactNode {
         viewTabId={props.viewTabId}
         hostId={props.hostId}
         runningDir={props.runningDir}
+        repositoryContext={props.repositoryContext}
         allFiles={props.files}
         visibleFiles={visibleFiles}
         forceExpanded={queryActive}
@@ -87,6 +90,7 @@ export function FileList(props: FileListProps): ReactNode {
       viewTabId={props.viewTabId}
       hostId={props.hostId}
       runningDir={props.runningDir}
+      repositoryContext={props.repositoryContext}
       allFiles={props.files}
       visibleFiles={visibleFiles}
       pathRangesByPath={pathRangesByPath}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-row.tsx
@@ -5,6 +5,7 @@ import type { GitChangedFile } from "@traycer/protocol/host";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { makeGitFileDiffTileForFile } from "@/lib/git/git-diff-tile";
+import type { GitDiffRepositoryContext } from "@/stores/epics/canvas/types";
 import { gitChangedFileTooltipContent } from "@/lib/git/panel-file-rendering";
 import type { HighlightRanges } from "@/lib/git/path-highlight";
 import { FilePathTooltip } from "@/components/file-path-tooltip";
@@ -20,6 +21,7 @@ export interface FileRowProps {
   readonly viewTabId: string;
   readonly hostId: string;
   readonly runningDir: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly file: GitChangedFile;
   readonly active: boolean;
   /** Filter match ranges into `file.path`; empty when no filter is active. */
@@ -41,8 +43,9 @@ export function FileRow(props: FileRowProps): ReactNode {
         hostId: props.hostId,
         runningDir: props.runningDir,
         file: props.file,
+        repositoryContext: props.repositoryContext,
       }),
-    [props.hostId, props.file, props.runningDir],
+    [props.hostId, props.file, props.repositoryContext, props.runningDir],
   );
 
   const onClick = useCallback(() => {

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-sections.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-sections.tsx
@@ -36,6 +36,7 @@ export function FileSections(props: FileSectionsProps): ReactNode {
         viewTabId={props.viewTabId}
         hostId={props.hostId}
         runningDir={props.runningDir}
+        repositoryContext={props.repositoryContext}
         files={section.visibleFiles}
         pathRangesByPath={props.pathRangesByPath}
         activeFilePath={section.activeFilePath}
@@ -47,6 +48,7 @@ export function FileSections(props: FileSectionsProps): ReactNode {
       props.epicId,
       props.hostId,
       props.pathRangesByPath,
+      props.repositoryContext,
       props.runningDir,
       props.viewTabId,
       props.virtualized,

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-sections.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-sections.tsx
@@ -6,6 +6,7 @@ import { GitFlatFileList } from "./git-flat-file-list";
 import { GitFileSectionStack } from "./git-file-section-stack";
 import type { GitFileSectionBodyRenderProps } from "./git-file-section-stack";
 import type { GitDiffSectionCollapseController } from "./git-diff-section";
+import type { GitDiffRepositoryContext } from "@/stores/epics/canvas/types";
 
 // Deliberate hover dwell for the per-row path tooltips: long enough that
 // sweeping the cursor across the list never pops them, and skipDelay 0 so
@@ -17,6 +18,7 @@ export interface FileSectionsProps {
   readonly viewTabId: string;
   readonly hostId: string;
   readonly runningDir: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly allFiles: ReadonlyArray<GitChangedFile>;
   readonly visibleFiles: ReadonlyArray<GitChangedFile>;
   readonly pathRangesByPath: ReadonlyMap<string, HighlightRanges>;
@@ -61,6 +63,7 @@ export function FileSections(props: FileSectionsProps): ReactNode {
         viewTabId={props.viewTabId}
         hostId={props.hostId}
         runningDir={props.runningDir}
+        repositoryContext={props.repositoryContext}
         allFiles={props.allFiles}
         visibleFiles={props.visibleFiles}
         forceExpanded={props.forceExpanded}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
@@ -23,6 +23,7 @@ import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { makeGitFileDiffTileForFile } from "@/lib/git/git-diff-tile";
 import type {
   GitDiffBundleGroup,
+  GitDiffRepositoryContext,
   GitDiffTileRef,
 } from "@/stores/epics/canvas/types";
 import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
@@ -36,6 +37,7 @@ export interface FileTreeProps {
   readonly viewTabId: string;
   readonly hostId: string;
   readonly runningDir: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly allFiles: ReadonlyArray<GitChangedFile>;
   readonly visibleFiles: ReadonlyArray<GitChangedFile>;
   readonly forceExpanded: boolean;
@@ -88,6 +90,7 @@ export function FileTree(props: FileTreeProps): ReactNode {
       viewTabId={props.viewTabId}
       hostId={props.hostId}
       runningDir={props.runningDir}
+      repositoryContext={props.repositoryContext}
       allFiles={props.allFiles}
       visibleFiles={props.visibleFiles}
       forceExpanded={props.forceExpanded}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/file-tree.tsx
@@ -51,6 +51,7 @@ interface GitTreeSectionBodyProps {
   readonly viewTabId: string;
   readonly hostId: string;
   readonly runningDir: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly group: GitDiffBundleGroup;
   readonly files: ReadonlyArray<GitChangedFile>;
   readonly activeFilePath: string | null;
@@ -69,6 +70,7 @@ export function FileTree(props: FileTreeProps): ReactNode {
         viewTabId={props.viewTabId}
         hostId={props.hostId}
         runningDir={props.runningDir}
+        repositoryContext={props.repositoryContext}
         group={section.group}
         files={section.visibleFiles}
         activeFilePath={section.activeFilePath}
@@ -78,6 +80,7 @@ export function FileTree(props: FileTreeProps): ReactNode {
     [
       props.epicId,
       props.hostId,
+      props.repositoryContext,
       props.runningDir,
       props.viewTabId,
       props.virtualized,
@@ -205,9 +208,10 @@ function GitTreeSectionBody(props: GitTreeSectionBodyProps): ReactNode {
         hostId: props.hostId,
         runningDir: props.runningDir,
         file,
+        repositoryContext: props.repositoryContext,
       });
     },
-    [fileByPath, props.hostId, props.runningDir],
+    [fileByPath, props.hostId, props.repositoryContext, props.runningDir],
   );
 
   const openFile = useCallback(

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
@@ -68,6 +68,7 @@ export function BundleFileSection(props: BundleFileSectionProps): ReactNode {
       hostId: props.node.hostId,
       runningDir: props.node.diff.runningDir,
       file: props.file,
+      repositoryContext: props.node.repositoryContext,
     });
     navigateNested(epicId, props.viewTabId, () =>
       prepareOpenTileInTabFocusTarget(props.viewTabId, tile),
@@ -79,6 +80,7 @@ export function BundleFileSection(props: BundleFileSectionProps): ReactNode {
     props.file,
     props.node.hostId,
     props.node.diff.runningDir,
+    props.node.repositoryContext,
     props.viewTabId,
   ]);
 

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-changed-files-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-changed-files-view.tsx
@@ -107,6 +107,7 @@ export function GitChangedFilesView(
         viewTabId={props.viewTabId}
         hostId={props.hostId}
         runningDir={props.runningDir}
+        repositoryContext={null}
         files={props.files}
         query={appliedQuery}
         onClearQuery={handleClear}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-section.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-section.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useMemo, type ReactNode } from "react";
 import type { GitChangedFile } from "@traycer/protocol/host";
-import type { GitDiffBundleGroup } from "@/stores/epics/canvas/types";
+import type {
+  GitDiffBundleGroup,
+  GitDiffRepositoryContext,
+} from "@/stores/epics/canvas/types";
 import { gitBundleGroupLabel } from "@/lib/git/git-diff-tile";
 import { sumGitFileStats } from "@/lib/git/file-stats";
 import {
@@ -22,6 +25,7 @@ export interface GitDiffSectionProps {
   readonly hostId: string;
   readonly runningDir: string;
   readonly group: GitDiffBundleGroup;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly visibleFiles: ReadonlyArray<GitChangedFile>;
   readonly bundleFileCount: number;
   /**
@@ -88,6 +92,7 @@ export function GitDiffSection(props: GitDiffSectionProps): ReactNode {
           hostId={props.hostId}
           runningDir={props.runningDir}
           group={props.group}
+          repositoryContext={props.repositoryContext}
           disabled={props.bundleFileCount === 0}
         />
       }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-file-section-stack.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-file-section-stack.tsx
@@ -1,6 +1,9 @@
 import { useMemo, type ReactNode } from "react";
 import type { GitChangedFile } from "@traycer/protocol/host";
-import type { GitDiffBundleGroup } from "@/stores/epics/canvas/types";
+import type {
+  GitDiffBundleGroup,
+  GitDiffRepositoryContext,
+} from "@/stores/epics/canvas/types";
 import { buildGitPanelFileSections } from "@/lib/git/panel-file-rendering";
 import { cn } from "@/lib/utils";
 import { GitDiffSection } from "./git-diff-section";
@@ -22,6 +25,7 @@ export interface GitFileSectionStackProps {
   readonly viewTabId: string;
   readonly hostId: string;
   readonly runningDir: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly allFiles: ReadonlyArray<GitChangedFile>;
   readonly visibleFiles: ReadonlyArray<GitChangedFile>;
   readonly forceExpanded: boolean;
@@ -73,6 +77,7 @@ export function GitFileSectionStack(
             hostId={props.hostId}
             runningDir={props.runningDir}
             group={group}
+            repositoryContext={props.repositoryContext}
             visibleFiles={visibleFiles}
             bundleFileCount={bundleFileCount}
             forceExpanded={props.forceExpanded}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-flat-file-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-flat-file-list.tsx
@@ -3,6 +3,7 @@ import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import type { GitChangedFile } from "@traycer/protocol/host";
 import { sortGitPanelFlatFiles } from "@/lib/git/panel-file-rendering";
 import { NO_HIGHLIGHT, type HighlightRanges } from "@/lib/git/path-highlight";
+import type { GitDiffRepositoryContext } from "@/stores/epics/canvas/types";
 import { FileRow } from "./file-row";
 
 export interface GitFlatFileListProps {
@@ -10,6 +11,7 @@ export interface GitFlatFileListProps {
   readonly viewTabId: string;
   readonly hostId: string;
   readonly runningDir: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly files: ReadonlyArray<GitChangedFile>;
   /** Filter match ranges keyed by file path; empty map when no filter active. */
   readonly pathRangesByPath: ReadonlyMap<string, HighlightRanges>;
@@ -24,6 +26,7 @@ interface GitFlatFileListItemProps {
   readonly viewTabId: string;
   readonly hostId: string;
   readonly runningDir: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly file: GitChangedFile;
   readonly activeFilePath: string | null;
   readonly pathRangesByPath: ReadonlyMap<string, HighlightRanges>;
@@ -37,6 +40,7 @@ function GitFlatFileListItem(props: GitFlatFileListItemProps): ReactNode {
       viewTabId={props.viewTabId}
       hostId={props.hostId}
       runningDir={props.runningDir}
+      repositoryContext={props.repositoryContext}
       file={props.file}
       active={props.file.path === props.activeFilePath}
       pathRanges={props.pathRangesByPath.get(props.file.path) ?? NO_HIGHLIGHT}
@@ -52,6 +56,7 @@ export function GitFlatFileList(props: GitFlatFileListProps): ReactNode {
     epicId,
     files: unsortedFiles,
     pathRangesByPath,
+    repositoryContext,
     runningDir,
     viewTabId,
   } = props;
@@ -91,6 +96,7 @@ export function GitFlatFileList(props: GitFlatFileListProps): ReactNode {
         viewTabId={viewTabId}
         hostId={hostId}
         runningDir={runningDir}
+        repositoryContext={repositoryContext}
         file={file}
         activeFilePath={activeFilePath}
         pathRangesByPath={pathRangesByPath}
@@ -102,6 +108,7 @@ export function GitFlatFileList(props: GitFlatFileListProps): ReactNode {
       hostId,
       epicId,
       pathRangesByPath,
+      repositoryContext,
       props.nestedRows,
       runningDir,
       viewTabId,
@@ -123,6 +130,7 @@ export function GitFlatFileList(props: GitFlatFileListProps): ReactNode {
             viewTabId={viewTabId}
             hostId={hostId}
             runningDir={runningDir}
+            repositoryContext={repositoryContext}
             file={file}
             activeFilePath={activeFilePath}
             pathRangesByPath={pathRangesByPath}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/selected-repo-changes.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/selected-repo-changes.tsx
@@ -433,6 +433,7 @@ export function SelectedRepoChanges(
       epicId={props.epicId}
       viewTabId={props.viewTabId}
       hostId={props.selected.hostId}
+      workspaceLabel={props.rootLabel}
       modules={moduleModel.modules}
       hiddenCleanModuleCount={moduleModel.hiddenCleanModuleCount}
       lastUpdatedAtMs={source.lastUpdatedAtMs}
@@ -447,6 +448,7 @@ function GitModuleGroupsView(props: {
   readonly epicId: string;
   readonly viewTabId: string;
   readonly hostId: string;
+  readonly workspaceLabel: string;
   readonly modules: ReadonlyArray<GitModuleGroup>;
   readonly hiddenCleanModuleCount: number;
   readonly lastUpdatedAtMs: number | null;
@@ -679,6 +681,7 @@ function GitModuleGroupsView(props: {
           epicId={props.epicId}
           viewTabId={props.viewTabId}
           hostId={props.hostId}
+          workspaceLabel={props.workspaceLabel}
           module={singleRepo}
           query={appliedQuery}
           lastUpdatedAtMs={props.lastUpdatedAtMs}
@@ -708,6 +711,7 @@ function GitModuleGroupsView(props: {
                 epicId={props.epicId}
                 viewTabId={props.viewTabId}
                 hostId={props.hostId}
+                workspaceLabel={props.workspaceLabel}
                 module={module}
                 expanded={expanded}
                 query={moduleMatchesHeader ? "" : appliedQuery}
@@ -819,6 +823,7 @@ function SingleRepoChangesView(props: {
   readonly epicId: string;
   readonly viewTabId: string;
   readonly hostId: string;
+  readonly workspaceLabel: string;
   readonly module: GitModuleGroup;
   readonly query: string;
   readonly lastUpdatedAtMs: number | null;
@@ -840,6 +845,7 @@ function SingleRepoChangesView(props: {
         epicId={props.epicId}
         viewTabId={props.viewTabId}
         hostId={props.hostId}
+        workspaceLabel={props.workspaceLabel}
         module={props.module}
         query={props.query}
         lastUpdatedAtMs={props.lastUpdatedAtMs}
@@ -857,6 +863,7 @@ function GitModuleGroupView(props: {
   readonly epicId: string;
   readonly viewTabId: string;
   readonly hostId: string;
+  readonly workspaceLabel: string;
   readonly module: GitModuleGroup;
   readonly expanded: boolean;
   readonly query: string;
@@ -939,6 +946,7 @@ function GitModuleGroupView(props: {
             epicId={props.epicId}
             viewTabId={props.viewTabId}
             hostId={props.hostId}
+            workspaceLabel={props.workspaceLabel}
             module={module}
             query={props.query}
             lastUpdatedAtMs={props.lastUpdatedAtMs}
@@ -1083,6 +1091,7 @@ function GitModuleBody(props: {
   readonly epicId: string;
   readonly viewTabId: string;
   readonly hostId: string;
+  readonly workspaceLabel: string;
   readonly module: GitModuleGroup;
   readonly query: string;
   readonly lastUpdatedAtMs: number | null;
@@ -1147,6 +1156,10 @@ function GitModuleBody(props: {
         viewTabId={props.viewTabId}
         hostId={props.hostId}
         runningDir={module.repoRoot}
+        repositoryContext={{
+          workspaceLabel: props.workspaceLabel,
+          repositoryLabel: module.label,
+        }}
         files={module.files}
         query={props.query}
         onClearQuery={props.onClearQuery}

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-bundle-diff-tile-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-bundle-diff-tile-find.test.tsx
@@ -158,6 +158,7 @@ const NODE = makeGitBundleDiffTile({
   hostId: "host-1",
   runningDir: "/repo",
   bundleGroup: "changes",
+  repositoryContext: null,
 });
 
 const EPIC_ID = "epic-1";

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-host-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/git-diff-tile-host-gate.test.tsx
@@ -86,6 +86,7 @@ const NODE = makeGitBundleDiffTile({
   hostId: "host-A",
   runningDir: "/work/repo",
   bundleGroup: "changes",
+  repositoryContext: null,
 });
 
 function changedFile(path: string): GitChangedFile {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/tile-render-find-scope.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/tile-render-find-scope.test.tsx
@@ -87,6 +87,7 @@ const NODES: ReadonlyArray<EpicCanvasTileRef> = [
     id: "git-1",
     instanceId: "git-inst",
     type: "git-diff",
+    repositoryContext: null,
     diff: {
       kind: "file",
       runningDir: "/repo",

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -720,11 +720,9 @@ describe("epic sidebar selection mode", () => {
     fireEvent.contextMenu(chatRow);
 
     expect(
-      await screen.findByTestId("epic-sidebar-context-rename-chat-root"),
+      await screen.findByRole("menuitem", { name: "Rename" }),
     ).not.toBeNull();
-    expect(
-      screen.getByTestId("epic-sidebar-context-delete-chat-root"),
-    ).not.toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Delete" })).not.toBeNull();
   });
 
   it("keeps artifact add inline and exposes ellipsis actions on right-click", async () => {
@@ -737,16 +735,10 @@ describe("epic sidebar selection mode", () => {
     fireEvent.contextMenu(screen.getByTestId("epic-sidebar-item-spec-root"));
 
     expect(
-      await screen.findByTestId(
-        "epic-sidebar-context-export-markdown-spec-root",
-      ),
+      await screen.findByRole("menuitem", { name: "Export as Markdown" }),
     ).not.toBeNull();
-    expect(
-      screen.getByTestId("epic-sidebar-context-rename-spec-root"),
-    ).not.toBeNull();
-    expect(
-      screen.getByTestId("epic-sidebar-context-delete-spec-root"),
-    ).not.toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Rename" })).not.toBeNull();
+    expect(screen.getByRole("menuitem", { name: "Delete" })).not.toBeNull();
   });
 
   it("enters chat selection mode from cmd-click on a row", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -706,6 +706,49 @@ describe("epic sidebar selection mode", () => {
     expect(screen.getByTestId("epic-sidebar-more-chat-root")).not.toBeNull();
   });
 
+  it("keeps chat add inline and exposes ellipsis actions on right-click", async () => {
+    seedChatTree();
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    const chatRow = screen.getByTestId("epic-sidebar-item-chat-root");
+    expect(
+      chatRow.parentElement?.querySelector(
+        '[aria-label="Add child chat or agent"]',
+      ),
+    ).not.toBeNull();
+    fireEvent.contextMenu(chatRow);
+
+    expect(
+      await screen.findByTestId("epic-sidebar-context-rename-chat-root"),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("epic-sidebar-context-delete-chat-root"),
+    ).not.toBeNull();
+  });
+
+  it("keeps artifact add inline and exposes ellipsis actions on right-click", async () => {
+    seedArtifactTree();
+    testState.activePanelId = "artifacts";
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    expect(screen.getByTestId("epic-sidebar-add-spec-root")).not.toBeNull();
+    fireEvent.contextMenu(screen.getByTestId("epic-sidebar-item-spec-root"));
+
+    expect(
+      await screen.findByTestId(
+        "epic-sidebar-context-export-markdown-spec-root",
+      ),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("epic-sidebar-context-rename-spec-root"),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("epic-sidebar-context-delete-spec-root"),
+    ).not.toBeNull();
+  });
+
   it("enters chat selection mode from cmd-click on a row", () => {
     seedChatTree();
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -143,6 +143,12 @@ describe("terminal sidebar Close", () => {
     expect(
       getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`).textContent,
     ).toBe("New Terminal");
+    expect(
+      getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`).className,
+    ).toContain("h-7");
+    expect(
+      getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`).className,
+    ).not.toContain("h-9");
     expect(queryByText("/tmp/work")).toBeNull();
     expect(
       getByTestId(`epic-terminal-sidebar-more-${SESSION_ID}`),
@@ -161,6 +167,26 @@ describe("terminal sidebar Close", () => {
     // The open tab is closed...
     expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).toBeNull();
     // ...and the PTY is terminated.
+    expect(killMutate).toHaveBeenCalledWith({ sessionId: SESSION_ID });
+  });
+
+  it("offers the ellipsis actions from the row context menu", async () => {
+    const { getByTestId, findByTestId } = render(
+      wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
+    );
+
+    fireEvent.contextMenu(
+      getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`),
+    );
+
+    expect(
+      await findByTestId(`epic-terminal-sidebar-context-rename-${SESSION_ID}`),
+    ).not.toBeNull();
+    fireEvent.click(
+      await findByTestId(`epic-terminal-sidebar-context-kill-${SESSION_ID}`),
+    );
+
+    expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).toBeNull();
     expect(killMutate).toHaveBeenCalledWith({ sessionId: SESSION_ID });
   });
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-close-tab.test.tsx
@@ -1,6 +1,11 @@
 import "../../../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render } from "@testing-library/react";
+import {
+  cleanup,
+  createEvent,
+  fireEvent,
+  render,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { CanonicalTerminalSessionInfo } from "@traycer/protocol/host/terminal/unary-schemas";
@@ -171,7 +176,7 @@ describe("terminal sidebar Close", () => {
   });
 
   it("offers the ellipsis actions from the row context menu", async () => {
-    const { getByTestId, findByTestId } = render(
+    const { getByTestId, findByRole } = render(
       wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
     );
 
@@ -179,15 +184,29 @@ describe("terminal sidebar Close", () => {
       getByTestId(`epic-terminal-sidebar-item-${SESSION_ID}`),
     );
 
-    expect(
-      await findByTestId(`epic-terminal-sidebar-context-rename-${SESSION_ID}`),
-    ).not.toBeNull();
-    fireEvent.click(
-      await findByTestId(`epic-terminal-sidebar-context-kill-${SESSION_ID}`),
-    );
+    expect(await findByRole("menuitem", { name: "Rename" })).not.toBeNull();
+    fireEvent.click(await findByRole("menuitem", { name: "Close" }));
 
     expect(findOpenArtifactInTab(TAB_ID, SESSION_ID)).toBeNull();
     expect(killMutate).toHaveBeenCalledWith({ sessionId: SESSION_ID });
+  });
+
+  it("does not suppress the native context menu while renaming", async () => {
+    const { getByTestId, findByTestId, queryByRole } = render(
+      wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
+    );
+
+    fireEvent.click(getByTestId(`epic-terminal-sidebar-rename-${SESSION_ID}`));
+
+    const renameInput = await findByTestId(
+      `epic-terminal-sidebar-rename-input-${SESSION_ID}`,
+    );
+    const contextMenuEvent = createEvent.contextMenu(renameInput);
+    fireEvent(renameInput, contextMenuEvent);
+
+    expect(contextMenuEvent.defaultPrevented).toBe(false);
+    expect(queryByRole("menuitem", { name: "Rename" })).toBeNull();
+    expect(queryByRole("menuitem", { name: "Close" })).toBeNull();
   });
 
   it("uses the active process name for an unnamed terminal", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -38,10 +38,9 @@ import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-di
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ContextMenuContent } from "@/components/ui/context-menu";
 import {
   SidebarContent,
   SidebarGroup,
@@ -155,6 +154,11 @@ import {
 import { SidebarReparentRowDropWrapper } from "@/components/epic-canvas/sidebar/sidebar-reparent-row-drop-wrapper";
 import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
 import type { ArtifactsSlice, TreeSlice } from "@/stores/epics/open-epic/types";
+import {
+  SidebarContextMenuItems,
+  SidebarDropdownMenuItems,
+  type SidebarRowMenuEntry,
+} from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
 
 interface ArtifactTreePanelBodyProps {
   readonly epicId: string;
@@ -1187,6 +1191,13 @@ function ArtifactNodeShell(props: ArtifactNodeShellProps) {
     selectedIds,
     onToggleSelection,
   } = props;
+  const rowMenuEntries = useArtifactRowMenuEntries({
+    nodeId,
+    nodeName,
+    canMutate,
+    onStartRename,
+    onPerformDelete,
+  });
 
   return (
     <li
@@ -1199,6 +1210,13 @@ function ArtifactNodeShell(props: ArtifactNodeShellProps) {
         viewTabId={tabId}
         nodeId={nodeId}
         panelId="artifacts"
+        contextMenu={
+          !isRenaming && !selectionMode ? (
+            <ContextMenuContent>
+              <SidebarContextMenuItems entries={rowMenuEntries} />
+            </ContextMenuContent>
+          ) : null
+        }
       >
         {isRenaming ? (
           <ArtifactRenameRow
@@ -1262,9 +1280,7 @@ function ArtifactNodeShell(props: ArtifactNodeShellProps) {
           <ArtifactMoreMenu
             nodeId={nodeId}
             nodeName={nodeName}
-            canMutate={canMutate}
-            onStartRename={onStartRename}
-            onPerformDelete={onPerformDelete}
+            entries={rowMenuEntries}
           />
         ) : null}
       </SidebarReparentRowDropWrapper>
@@ -1819,7 +1835,7 @@ function ArtifactAddChildButton(props: ArtifactAddChildButtonProps) {
   );
 }
 
-interface ArtifactMoreMenuProps {
+interface ArtifactRowMenuEntriesProps {
   readonly nodeId: string;
   readonly nodeName: string;
   readonly canMutate: boolean;
@@ -1827,17 +1843,91 @@ interface ArtifactMoreMenuProps {
   readonly onPerformDelete: () => void;
 }
 
-function ArtifactMoreMenu(props: ArtifactMoreMenuProps) {
-  const { nodeId, nodeName, canMutate, onStartRename, onPerformDelete } = props;
+function useArtifactRowMenuEntries(
+  props: ArtifactRowMenuEntriesProps,
+): ReadonlyArray<SidebarRowMenuEntry> {
   const exportArtifacts = useEpicExportArtifacts();
   const exportOne = (format: "markdown" | "pdf"): void => {
     exportArtifacts.mutate({
-      artifacts: [{ id: nodeId, title: nodeName }],
+      artifacts: [{ id: props.nodeId, title: props.nodeName }],
       format,
       archive: false,
       archiveTitle: null,
     });
   };
+  const exportIcon = exportArtifacts.isPending ? (
+    <AgentSpinningDots
+      className={undefined}
+      testId={undefined}
+      variant={undefined}
+    />
+  ) : (
+    <FileDown className="size-3.5" />
+  );
+  return [
+    {
+      kind: "item",
+      id: "export-markdown",
+      label: "Export as Markdown",
+      icon: exportIcon,
+      disabled: exportArtifacts.isPending,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-sidebar-export-markdown-${props.nodeId}`,
+        context: `epic-sidebar-context-export-markdown-${props.nodeId}`,
+      },
+      onSelect: () => exportOne("markdown"),
+    },
+    {
+      kind: "item",
+      id: "export-pdf",
+      label: "Export as PDF",
+      icon: exportIcon,
+      disabled: exportArtifacts.isPending,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-sidebar-export-pdf-${props.nodeId}`,
+        context: `epic-sidebar-context-export-pdf-${props.nodeId}`,
+      },
+      onSelect: () => exportOne("pdf"),
+    },
+    { kind: "separator", id: "after-export" },
+    {
+      kind: "item",
+      id: "rename",
+      label: "Rename",
+      icon: <Pencil className="size-3.5" />,
+      disabled: !props.canMutate,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-sidebar-rename-${props.nodeId}`,
+        context: `epic-sidebar-context-rename-${props.nodeId}`,
+      },
+      onSelect: props.onStartRename,
+    },
+    { kind: "separator", id: "before-delete" },
+    {
+      kind: "item",
+      id: "delete",
+      label: "Delete",
+      icon: <Trash2 className="size-3.5" />,
+      disabled: !props.canMutate,
+      variant: "destructive",
+      testIds: {
+        dropdown: `epic-sidebar-delete-${props.nodeId}`,
+        context: `epic-sidebar-context-delete-${props.nodeId}`,
+      },
+      onSelect: props.onPerformDelete,
+    },
+  ];
+}
+
+function ArtifactMoreMenu(props: {
+  readonly nodeId: string;
+  readonly nodeName: string;
+  readonly entries: ReadonlyArray<SidebarRowMenuEntry>;
+}) {
+  const { nodeId, nodeName, entries } = props;
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -1856,65 +1946,7 @@ function ArtifactMoreMenu(props: ArtifactMoreMenuProps) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          data-testid={`epic-sidebar-export-markdown-${nodeId}`}
-          disabled={exportArtifacts.isPending}
-          onSelect={() => {
-            exportOne("markdown");
-          }}
-        >
-          {exportArtifacts.isPending ? (
-            <AgentSpinningDots
-              className={undefined}
-              testId={undefined}
-              variant={undefined}
-            />
-          ) : (
-            <FileDown className="size-3.5" />
-          )}
-          Export as Markdown
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          data-testid={`epic-sidebar-export-pdf-${nodeId}`}
-          disabled={exportArtifacts.isPending}
-          onSelect={() => {
-            exportOne("pdf");
-          }}
-        >
-          {exportArtifacts.isPending ? (
-            <AgentSpinningDots
-              className={undefined}
-              testId={undefined}
-              variant={undefined}
-            />
-          ) : (
-            <FileDown className="size-3.5" />
-          )}
-          Export as PDF
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          data-testid={`epic-sidebar-rename-${nodeId}`}
-          disabled={!canMutate}
-          onSelect={() => {
-            onStartRename();
-          }}
-        >
-          <Pencil className="size-3.5" />
-          Rename
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          data-testid={`epic-sidebar-delete-${nodeId}`}
-          disabled={!canMutate}
-          onSelect={() => {
-            onPerformDelete();
-          }}
-          variant="destructive"
-        >
-          <Trash2 className="size-3.5" />
-          Delete
-        </DropdownMenuItem>
+        <SidebarDropdownMenuItems entries={entries} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -35,10 +35,9 @@ import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-di
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ContextMenuContent } from "@/components/ui/context-menu";
 import {
   SidebarContent,
   SidebarGroup,
@@ -138,6 +137,11 @@ import { NewConversationModalAction } from "@/components/epic-canvas/sidebar/new
 import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
 import { useHostNotificationIndicators } from "@/hooks/notifications/use-host-notification-indicators-query";
 import { WorktreeOwnerMetadataHoverCard } from "@/components/worktree/worktree-owner-metadata";
+import {
+  SidebarContextMenuItems,
+  SidebarDropdownMenuItems,
+  type SidebarRowMenuEntry,
+} from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
 
 interface ChatTreePanelBodyProps {
   readonly epicId: string;
@@ -855,6 +859,12 @@ function ChatNodeShell(props: ChatNodeShellProps) {
   // The row `+` (child-create trigger) reserves right padding and is offered
   // whenever the epic is editable and we are not bulk-selecting.
   const showAddChild = canEdit && !selectionMode;
+  const rowMenuEntries = chatRowMenuEntries({
+    nodeId,
+    canMutate,
+    onStartRename,
+    onPerformDelete,
+  });
 
   return (
     <li
@@ -867,6 +877,13 @@ function ChatNodeShell(props: ChatNodeShellProps) {
         viewTabId={tabId}
         nodeId={nodeId}
         panelId="chats"
+        contextMenu={
+          canEdit && !isRenaming && !selectionMode ? (
+            <ContextMenuContent>
+              <SidebarContextMenuItems entries={rowMenuEntries} />
+            </ContextMenuContent>
+          ) : null
+        }
       >
         {isRenaming ? (
           <ChatRenameRow
@@ -936,9 +953,7 @@ function ChatNodeShell(props: ChatNodeShellProps) {
           <ChatMoreMenu
             nodeId={nodeId}
             nodeName={nodeName}
-            canMutate={canMutate}
-            onStartRename={onStartRename}
-            onPerformDelete={onPerformDelete}
+            entries={rowMenuEntries}
           />
         ) : null}
       </SidebarReparentRowDropWrapper>
@@ -1441,16 +1456,53 @@ function StaticSidebarNodeIcon(props: {
   );
 }
 
-interface SidebarNodeActionsProps {
+interface ChatRowMenuEntriesProps {
   readonly nodeId: string;
-  readonly nodeName: string;
   readonly canMutate: boolean;
   readonly onStartRename: () => void;
   readonly onPerformDelete: () => void;
 }
 
-function ChatMoreMenu(props: SidebarNodeActionsProps) {
-  const { nodeId, nodeName, canMutate, onStartRename, onPerformDelete } = props;
+function chatRowMenuEntries(
+  props: ChatRowMenuEntriesProps,
+): ReadonlyArray<SidebarRowMenuEntry> {
+  return [
+    {
+      kind: "item",
+      id: "rename",
+      label: "Rename",
+      icon: <Pencil className="size-3.5" />,
+      disabled: !props.canMutate,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-sidebar-rename-${props.nodeId}`,
+        context: `epic-sidebar-context-rename-${props.nodeId}`,
+      },
+      onSelect: props.onStartRename,
+    },
+    { kind: "separator", id: "before-delete" },
+    {
+      kind: "item",
+      id: "delete",
+      label: "Delete",
+      icon: <Trash2 className="size-3.5" />,
+      disabled: !props.canMutate,
+      variant: "destructive",
+      testIds: {
+        dropdown: `epic-sidebar-delete-${props.nodeId}`,
+        context: `epic-sidebar-context-delete-${props.nodeId}`,
+      },
+      onSelect: props.onPerformDelete,
+    },
+  ];
+}
+
+function ChatMoreMenu(props: {
+  readonly nodeId: string;
+  readonly nodeName: string;
+  readonly entries: ReadonlyArray<SidebarRowMenuEntry>;
+}) {
+  const { nodeId, nodeName, entries } = props;
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -1469,28 +1521,7 @@ function ChatMoreMenu(props: SidebarNodeActionsProps) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          data-testid={`epic-sidebar-rename-${nodeId}`}
-          disabled={!canMutate}
-          onSelect={() => {
-            onStartRename();
-          }}
-        >
-          <Pencil className="size-3.5" />
-          Rename
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          data-testid={`epic-sidebar-delete-${nodeId}`}
-          disabled={!canMutate}
-          onSelect={() => {
-            onPerformDelete();
-          }}
-          variant="destructive"
-        >
-          <Trash2 className="size-3.5" />
-          Delete
-        </DropdownMenuItem>
+        <SidebarDropdownMenuItems entries={entries} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -399,7 +399,7 @@ function TerminalRow(props: TerminalRowProps) {
   return (
     <li>
       <ContextMenu>
-        <ContextMenuTrigger asChild>
+        <ContextMenuTrigger asChild disabled={isRenaming}>
           <div className="group/term-row relative">
             {isRenaming ? (
               <div

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -33,10 +33,13 @@ import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { Input } from "@/components/ui/input";
 import {
   SidebarContent,
@@ -74,6 +77,11 @@ import {
 } from "@/stores/epics/canvas/store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import type { EpicTerminalRef } from "@/stores/epics/canvas/types";
+import {
+  SidebarContextMenuItems,
+  SidebarDropdownMenuItems,
+  type SidebarRowMenuEntry,
+} from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
 
 const TERMINALS_PANEL_SKELETON = <TerminalsPanelSkeleton />;
 
@@ -146,7 +154,7 @@ function TerminalsPanelBodyLive(props: {
 
   return (
     <SidebarContent className="min-h-0">
-      <SidebarGroup className="min-h-0 flex-1 px-2 py-3">
+      <SidebarGroup className="min-h-0 flex-1 px-2 py-1">
         <SidebarGroupContent className="flex min-h-0 flex-1 flex-col">
           <TerminalSidebarBody
             isLoading={list.isPending}
@@ -381,102 +389,142 @@ function TerminalRow(props: TerminalRowProps) {
     if (isRenaming) return;
     startRename();
   }, [isRenaming, startRename]);
+  const rowMenuEntries = terminalRowMenuEntries({
+    sessionId: session.sessionId,
+    closePending: kill.isPending,
+    onStartRename: startRename,
+    onRequestClose: requestClose,
+  });
 
   return (
     <li>
-      <div className="group/term-row relative">
-        {isRenaming ? (
-          <div
-            className={cn(
-              "flex h-9 w-full items-center gap-1.5 rounded-md pl-2 pr-2 text-ui-sm",
-              "bg-accent text-accent-foreground",
-            )}
-          >
-            <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
-            <Input
-              ref={renameInputRef}
-              data-testid={`epic-terminal-sidebar-rename-input-${session.sessionId}`}
-              value={renameValue}
-              disabled={rename.isPending}
-              onChange={(event) => setRenameValue(event.target.value)}
-              onBlur={commitRename}
-              onKeyDown={handleRenameKeyDown}
-              className="h-7 flex-1 min-w-0 px-1 text-ui-sm"
-            />
-          </div>
-        ) : (
-          <>
-            <button
-              ref={dragRef}
-              {...attributes}
-              {...listeners}
-              type="button"
-              data-testid={`epic-terminal-sidebar-item-${session.sessionId}`}
-              data-terminal-status={session.status}
-              className={cn(
-                "flex h-9 w-full items-center gap-1.5 rounded-md pl-2 pr-8 text-left text-ui-sm transition-colors",
-                "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
-                isDragging && "cursor-grabbing opacity-60",
-                isActive
-                  ? "bg-accent font-medium text-accent-foreground"
-                  : "text-foreground/75 hover:bg-accent/70 hover:text-accent-foreground",
-              )}
-              onClick={() => onOpen(session)}
-              onDoubleClick={handleDoubleClick}
-            >
-              <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
-              <div className="flex min-w-0 flex-1 flex-col">
-                <span className="truncate">{label}</span>
-              </div>
-              {showNavigatorResourceStats ? (
-                <OwnerResourceChip
-                  epicId={epicId}
-                  kind="terminal"
-                  ownerId={session.sessionId}
-                  className={undefined}
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div className="group/term-row relative">
+            {isRenaming ? (
+              <div
+                className={cn(
+                  "flex h-7 w-full items-center gap-1.5 rounded-md pl-2 pr-2 text-ui-sm",
+                  "bg-accent text-accent-foreground",
+                )}
+              >
+                <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+                <Input
+                  ref={renameInputRef}
+                  data-testid={`epic-terminal-sidebar-rename-input-${session.sessionId}`}
+                  value={renameValue}
+                  disabled={rename.isPending}
+                  onChange={(event) => setRenameValue(event.target.value)}
+                  onBlur={commitRename}
+                  onKeyDown={handleRenameKeyDown}
+                  className="h-7 flex-1 min-w-0 px-1 text-ui-sm"
                 />
-              ) : null}
-            </button>
-            <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/term-row:opacity-100">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label={`Terminal actions for ${label}`}
-                    data-testid={`epic-terminal-sidebar-more-${session.sessionId}`}
-                    onClick={(event) => event.stopPropagation()}
-                  >
-                    <MoreHorizontal className="size-3" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    data-testid={`epic-terminal-sidebar-rename-${session.sessionId}`}
-                    onSelect={() => startRename()}
-                  >
-                    <Pencil className="size-3.5" />
-                    Rename
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    data-testid={`epic-terminal-sidebar-kill-menu-${session.sessionId}`}
-                    disabled={kill.isPending}
-                    onSelect={() => requestClose()}
-                    variant="destructive"
-                  >
-                    <Trash2 className="size-3.5" />
-                    Close
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </>
+              </div>
+            ) : (
+              <>
+                <button
+                  ref={dragRef}
+                  {...attributes}
+                  {...listeners}
+                  type="button"
+                  data-testid={`epic-terminal-sidebar-item-${session.sessionId}`}
+                  data-terminal-status={session.status}
+                  className={cn(
+                    "flex h-7 w-full items-center gap-1.5 rounded-md pl-2 pr-8 text-left text-ui-sm transition-colors",
+                    "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2",
+                    isDragging && "cursor-grabbing opacity-60",
+                    isActive
+                      ? "bg-accent font-medium text-accent-foreground"
+                      : "text-foreground/75 hover:bg-accent/70 hover:text-accent-foreground",
+                  )}
+                  onClick={() => onOpen(session)}
+                  onDoubleClick={handleDoubleClick}
+                >
+                  <TerminalIcon className="size-3.5 shrink-0 text-muted-foreground/70" />
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate">{label}</span>
+                  </div>
+                  {showNavigatorResourceStats ? (
+                    <OwnerResourceChip
+                      epicId={epicId}
+                      kind="terminal"
+                      ownerId={session.sessionId}
+                      className={undefined}
+                    />
+                  ) : null}
+                </button>
+                <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity focus-within:opacity-100 group-hover/term-row:opacity-100">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-xs"
+                        aria-label={`Terminal actions for ${label}`}
+                        data-testid={`epic-terminal-sidebar-more-${session.sessionId}`}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <MoreHorizontal className="size-3" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <SidebarDropdownMenuItems entries={rowMenuEntries} />
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </>
+            )}
+          </div>
+        </ContextMenuTrigger>
+        {isRenaming ? null : (
+          <ContextMenuContent>
+            <SidebarContextMenuItems entries={rowMenuEntries} />
+          </ContextMenuContent>
         )}
-      </div>
+      </ContextMenu>
     </li>
   );
+}
+
+interface TerminalRowMenuEntriesProps {
+  readonly sessionId: string;
+  readonly closePending: boolean;
+  readonly onStartRename: () => void;
+  readonly onRequestClose: () => void;
+}
+
+function terminalRowMenuEntries(
+  props: TerminalRowMenuEntriesProps,
+): ReadonlyArray<SidebarRowMenuEntry> {
+  return [
+    {
+      kind: "item",
+      id: "rename",
+      label: "Rename",
+      icon: <Pencil className="size-3.5" />,
+      disabled: false,
+      variant: "default",
+      testIds: {
+        dropdown: `epic-terminal-sidebar-rename-${props.sessionId}`,
+        context: `epic-terminal-sidebar-context-rename-${props.sessionId}`,
+      },
+      onSelect: props.onStartRename,
+    },
+    { kind: "separator", id: "before-close" },
+    {
+      kind: "item",
+      id: "close",
+      label: "Close",
+      icon: <Trash2 className="size-3.5" />,
+      disabled: props.closePending,
+      variant: "destructive",
+      testIds: {
+        dropdown: `epic-terminal-sidebar-kill-menu-${props.sessionId}`,
+        context: `epic-terminal-sidebar-context-kill-${props.sessionId}`,
+      },
+      onSelect: props.onRequestClose,
+    },
+  ];
 }
 
 function deriveTerminalLabel(session: CanonicalTerminalSessionInfo): string {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/sidebar-reparent-row-drop-wrapper.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/sidebar-reparent-row-drop-wrapper.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/epic-canvas/dnd/dnd";
 import { useSidebarReparentTargetActive } from "@/components/epic-canvas/dnd/dnd-store";
 import type { RootCreatePanelId } from "@/stores/epics/left-panel-store";
+import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
 
 /**
  * Row container shared by the chat and artifact trees: registers the
@@ -20,8 +21,9 @@ export function SidebarReparentRowDropWrapper(props: {
   readonly nodeId: string;
   readonly panelId: RootCreatePanelId;
   readonly children: ReactNode;
+  readonly contextMenu: ReactNode | null;
 }) {
-  const { epicId, viewTabId, nodeId, panelId, children } = props;
+  const { epicId, viewTabId, nodeId, panelId, children, contextMenu } = props;
   const dropData = useMemo<EpicCanvasDropTargetData>(
     () => ({
       kind: "sidebar-reparent-row",
@@ -37,7 +39,7 @@ export function SidebarReparentRowDropWrapper(props: {
     data: dropData,
   });
   const isReparentTarget = useSidebarReparentTargetActive(nodeId);
-  return (
+  const row = (
     <div
       ref={setNodeRef}
       className={cn(
@@ -47,5 +49,12 @@ export function SidebarReparentRowDropWrapper(props: {
     >
       {children}
     </div>
+  );
+  if (contextMenu === null) return row;
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      {contextMenu}
+    </ContextMenu>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/sidebar/sidebar-reparent-row-drop-wrapper.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/sidebar-reparent-row-drop-wrapper.tsx
@@ -50,10 +50,11 @@ export function SidebarReparentRowDropWrapper(props: {
       {children}
     </div>
   );
-  if (contextMenu === null) return row;
   return (
     <ContextMenu>
-      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      <ContextMenuTrigger asChild disabled={contextMenu === null}>
+        {row}
+      </ContextMenuTrigger>
       {contextMenu}
     </ContextMenu>
   );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/sidebar-row-menu-items.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/sidebar-row-menu-items.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import {
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from "@/components/ui/context-menu";
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+
+interface SidebarRowMenuTestIds {
+  readonly dropdown: string;
+  readonly context: string;
+}
+
+interface SidebarRowMenuItemEntry {
+  readonly kind: "item";
+  readonly id: string;
+  readonly label: string;
+  readonly icon: ReactNode;
+  readonly disabled: boolean;
+  readonly variant: "default" | "destructive";
+  readonly testIds: SidebarRowMenuTestIds;
+  readonly onSelect: () => void;
+}
+
+interface SidebarRowMenuSeparatorEntry {
+  readonly kind: "separator";
+  readonly id: string;
+}
+
+export type SidebarRowMenuEntry =
+  SidebarRowMenuItemEntry | SidebarRowMenuSeparatorEntry;
+
+export function SidebarDropdownMenuItems(props: {
+  readonly entries: ReadonlyArray<SidebarRowMenuEntry>;
+}) {
+  return props.entries.map((entry) => {
+    if (entry.kind === "separator") {
+      return <DropdownMenuSeparator key={entry.id} />;
+    }
+    return (
+      <DropdownMenuItem
+        key={entry.id}
+        disabled={entry.disabled}
+        variant={entry.variant}
+        data-testid={entry.testIds.dropdown}
+        onSelect={entry.onSelect}
+      >
+        {entry.icon}
+        {entry.label}
+      </DropdownMenuItem>
+    );
+  });
+}
+
+export function SidebarContextMenuItems(props: {
+  readonly entries: ReadonlyArray<SidebarRowMenuEntry>;
+}) {
+  return props.entries.map((entry) => {
+    if (entry.kind === "separator") {
+      return <ContextMenuSeparator key={entry.id} />;
+    }
+    return (
+      <ContextMenuItem
+        key={entry.id}
+        disabled={entry.disabled}
+        variant={entry.variant}
+        data-testid={entry.testIds.context}
+        onSelect={entry.onSelect}
+      >
+        {entry.icon}
+        {entry.label}
+      </ContextMenuItem>
+    );
+  });
+}

--- a/clients/gui-app/src/hooks/use-shift-key-held.ts
+++ b/clients/gui-app/src/hooks/use-shift-key-held.ts
@@ -1,0 +1,47 @@
+import { useSyncExternalStore } from "react";
+
+let shiftHeld = false;
+const listeners = new Set<() => void>();
+
+function setShiftKeyHeld(next: boolean): void {
+  if (next === shiftHeld) return;
+  shiftHeld = next;
+  for (const listener of listeners) listener();
+}
+
+function handleModifierChange(event: globalThis.KeyboardEvent): void {
+  setShiftKeyHeld(event.shiftKey);
+}
+
+function handleWindowBlur(): void {
+  setShiftKeyHeld(false);
+}
+
+function subscribe(listener: () => void): () => void {
+  if (listeners.size === 0) {
+    window.addEventListener("keydown", handleModifierChange);
+    window.addEventListener("keyup", handleModifierChange);
+    window.addEventListener("blur", handleWindowBlur);
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size > 0) return;
+    window.removeEventListener("keydown", handleModifierChange);
+    window.removeEventListener("keyup", handleModifierChange);
+    window.removeEventListener("blur", handleWindowBlur);
+    shiftHeld = false;
+  };
+}
+
+function getSnapshot(): boolean {
+  return shiftHeld;
+}
+
+export function reportShiftKeyHeld(held: boolean): void {
+  setShiftKeyHeld(held);
+}
+
+export function useShiftKeyHeld(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/diff-subpage.ts
@@ -64,6 +64,7 @@ function changedFileLeaves(
             hostId,
             runningDir: workspacePath,
             file,
+            repositoryContext: null,
           }),
           navigateNestedFocus: ctx.router.navigateNestedFocus,
         }),

--- a/clients/gui-app/src/lib/git/git-diff-tile.ts
+++ b/clients/gui-app/src/lib/git/git-diff-tile.ts
@@ -4,6 +4,7 @@ import { getBasename } from "@/lib/path/cross-platform-path";
 import { TILE_KIND_GIT_DIFF } from "@/stores/epics/canvas/tile-kinds";
 import type {
   GitDiffBundleGroup,
+  GitDiffRepositoryContext,
   GitDiffTilePayload,
   GitDiffTileRef,
 } from "@/stores/epics/canvas/types";
@@ -43,6 +44,15 @@ export function gitBundleGroupLabel(group: GitDiffBundleGroup): string {
   return "Changes";
 }
 
+export function gitDiffRepositoryContextLabel(
+  context: GitDiffRepositoryContext,
+): string {
+  if (context.workspaceLabel === context.repositoryLabel) {
+    return context.workspaceLabel;
+  }
+  return `${context.workspaceLabel} › ${context.repositoryLabel}`;
+}
+
 export function makeGitFileDiffTile(args: {
   readonly hostId: string;
   readonly runningDir: string;
@@ -61,6 +71,7 @@ export function makeGitFileDiffTile(args: {
     type: TILE_KIND_GIT_DIFF,
     name: `${getBasename(args.filePath)} · ${gitStageLabel(args.stage)}`,
     hostId: args.hostId,
+    repositoryContext: null,
     diff,
     view: createDiffTileViewState(),
   };
@@ -83,6 +94,7 @@ export function makeGitBundleDiffTile(args: {
   readonly hostId: string;
   readonly runningDir: string;
   readonly bundleGroup: GitDiffBundleGroup;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
 }): GitDiffTileRef {
   const diff: GitDiffTilePayload = {
     kind: "bundle",
@@ -93,8 +105,12 @@ export function makeGitBundleDiffTile(args: {
     id: gitDiffTileId(args.hostId, diff),
     instanceId: uuidv4(),
     type: TILE_KIND_GIT_DIFF,
-    name: gitBundleGroupLabel(args.bundleGroup),
+    name:
+      args.repositoryContext === null
+        ? `${getBasename(args.runningDir)} · ${gitBundleGroupLabel(args.bundleGroup)}`
+        : `${gitDiffRepositoryContextLabel(args.repositoryContext)} · ${gitBundleGroupLabel(args.bundleGroup)}`,
     hostId: args.hostId,
+    repositoryContext: args.repositoryContext,
     diff,
     view: createDiffTileViewState(),
   };

--- a/clients/gui-app/src/lib/git/git-diff-tile.ts
+++ b/clients/gui-app/src/lib/git/git-diff-tile.ts
@@ -58,6 +58,7 @@ export function makeGitFileDiffTile(args: {
   readonly runningDir: string;
   readonly filePath: string;
   readonly stage: GitStage;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
 }): GitDiffTileRef {
   const diff: GitDiffTilePayload = {
     kind: "file",
@@ -71,7 +72,7 @@ export function makeGitFileDiffTile(args: {
     type: TILE_KIND_GIT_DIFF,
     name: `${getBasename(args.filePath)} · ${gitStageLabel(args.stage)}`,
     hostId: args.hostId,
-    repositoryContext: null,
+    repositoryContext: args.repositoryContext,
     diff,
     view: createDiffTileViewState(),
   };
@@ -81,12 +82,14 @@ export function makeGitFileDiffTileForFile(args: {
   readonly hostId: string;
   readonly runningDir: string;
   readonly file: GitChangedFile;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
 }): GitDiffTileRef {
   return makeGitFileDiffTile({
     hostId: args.hostId,
     runningDir: args.runningDir,
     filePath: args.file.path,
     stage: args.file.stage,
+    repositoryContext: args.repositoryContext,
   });
 }
 

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/canvas-test-fixtures.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/canvas-test-fixtures.ts
@@ -90,6 +90,7 @@ export const GIT_BUNDLE_CHANGES: GitDiffTileRef = makeGitBundleDiffTile({
   hostId: TEST_HOST_ID,
   runningDir: "/repo",
   bundleGroup: "changes",
+  repositoryContext: null,
 });
 export const SNAPSHOT_BUNDLE_CHANGES: SnapshotDiffTileRef =
   makeSnapshotCumulativeBundleDiffTile({

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/canvas-test-fixtures.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/canvas-test-fixtures.ts
@@ -73,6 +73,7 @@ export const GIT_FILE_A: GitDiffTileRef = makeGitFileDiffTile({
   runningDir: "/repo",
   filePath: "src/a.ts",
   stage: "unstaged",
+  repositoryContext: null,
 });
 // Same diff as GIT_FILE_A - same deterministic id - but distinct
 // tile-local view state, exercising "dedupe focuses the existing tab".
@@ -85,6 +86,7 @@ export const GIT_FILE_B: GitDiffTileRef = makeGitFileDiffTile({
   runningDir: "/repo",
   filePath: "src/b.ts",
   stage: "unstaged",
+  repositoryContext: null,
 });
 export const GIT_BUNDLE_CHANGES: GitDiffTileRef = makeGitBundleDiffTile({
   hostId: TEST_HOST_ID,

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-schema.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-schema.test.ts
@@ -156,6 +156,10 @@ describe("parseTileRef / serializeTileRef", () => {
       runningDir: "/repo",
       filePath: "src/a.ts",
       stage: "unstaged",
+      repositoryContext: {
+        workspaceLabel: "workspace",
+        repositoryLabel: "packages/traycer",
+      },
     });
     const bundle = makeGitBundleDiffTile({
       hostId: HOST,
@@ -176,6 +180,7 @@ describe("parseTileRef / serializeTileRef", () => {
       runningDir: "/repo",
       filePath: "src/a.ts",
       stage: "unstaged",
+      repositoryContext: null,
     });
     const parsed = parseTileRef({
       id: "legacy-random-uuid",
@@ -245,6 +250,7 @@ describe("isTileRefRecordBacked", () => {
       runningDir: "/repo",
       filePath: "src/a.ts",
       stage: "unstaged",
+      repositoryContext: null,
     });
     expect(isTileRefRecordBacked(chat)).toBe(true);
     expect(isTileRefRecordBacked(terminal)).toBe(false);

--- a/clients/gui-app/src/stores/epics/canvas/__tests__/tile-schema.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/tile-schema.test.ts
@@ -161,6 +161,10 @@ describe("parseTileRef / serializeTileRef", () => {
       hostId: HOST,
       runningDir: "/repo",
       bundleGroup: "changes",
+      repositoryContext: {
+        workspaceLabel: "workspace",
+        repositoryLabel: "packages/traycer",
+      },
     });
     expect(parseTileRef(serializeTileRef(file))).toEqual(file);
     expect(parseTileRef(serializeTileRef(bundle))).toEqual(bundle);
@@ -190,6 +194,26 @@ describe("parseTileRef / serializeTileRef", () => {
     });
     expect(parsed).not.toBeNull();
     expect(parsed?.id).toBe(tile.id);
+  });
+
+  it("upgrades legacy Git bundle titles with the repository directory", () => {
+    const parsed = parseTileRef({
+      id: "legacy-random-uuid",
+      type: "git-diff",
+      name: "Changes",
+      hostId: HOST,
+      diff: {
+        kind: "bundle",
+        runningDir: "/worktrees/right-click-context-menu/traycer",
+        bundleGroup: "changes",
+      },
+      view: {
+        collapsedFilePaths: [],
+      },
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.name).toBe("traycer · Changes");
   });
 
   it("rejects unknown tile kinds", () => {

--- a/clients/gui-app/src/stores/epics/canvas/tile-schema/git-diff-tile.ts
+++ b/clients/gui-app/src/stores/epics/canvas/tile-schema/git-diff-tile.ts
@@ -6,10 +6,12 @@
  */
 import type { GitStage } from "@traycer/protocol/host";
 import type { DesktopJsonValue } from "@/lib/windows/types";
-import { gitDiffTileId } from "@/lib/git/git-diff-tile";
+import { gitBundleGroupLabel, gitDiffTileId } from "@/lib/git/git-diff-tile";
+import { getBasename } from "@/lib/path/cross-platform-path";
 import { TILE_KIND_GIT_DIFF } from "../tile-kinds";
 import type {
   GitDiffBundleGroup,
+  GitDiffRepositoryContext,
   GitDiffTilePayload,
   GitDiffTileRef,
 } from "../types";
@@ -35,6 +37,22 @@ function isGitStage(value: unknown): value is GitStage {
 
 function isGitDiffBundleGroup(value: unknown): value is GitDiffBundleGroup {
   return value === "merge" || value === "staged" || value === "changes";
+}
+
+function parseGitDiffRepositoryContext(
+  value: unknown,
+): GitDiffRepositoryContext | null {
+  if (!isRecord(value)) return null;
+  if (
+    typeof value.workspaceLabel !== "string" ||
+    typeof value.repositoryLabel !== "string"
+  ) {
+    return null;
+  }
+  return {
+    workspaceLabel: value.workspaceLabel,
+    repositoryLabel: value.repositoryLabel,
+  };
 }
 
 function parseGitDiffPayload(value: unknown): GitDiffTilePayload | null {
@@ -82,12 +100,20 @@ function parseGitDiffTileRef(value: unknown): GitDiffTileRef | null {
   const diff = parseGitDiffPayload(value.diff);
   const view = parseDiffTileViewState(value.view);
   if (diff === null || view === null) return null;
+  const repositoryContext = parseGitDiffRepositoryContext(
+    value.repositoryContext,
+  );
+  const name =
+    diff.kind === "bundle" && repositoryContext === null
+      ? `${getBasename(diff.runningDir)} · ${gitBundleGroupLabel(diff.bundleGroup)}`
+      : value.name;
   return {
     id: gitDiffTileId(value.hostId, diff),
     instanceId: readTileInstanceId(value.instanceId),
     type: TILE_KIND_GIT_DIFF,
-    name: value.name,
+    name,
     hostId: value.hostId,
+    repositoryContext,
     diff,
     view,
   };
@@ -121,6 +147,13 @@ function serializeGitDiffTileRef(ref: GitDiffTileRef): DesktopJsonValue {
     type: ref.type,
     name: ref.name,
     hostId: ref.hostId,
+    repositoryContext:
+      ref.repositoryContext === null
+        ? null
+        : {
+            workspaceLabel: ref.repositoryContext.workspaceLabel,
+            repositoryLabel: ref.repositoryContext.repositoryLabel,
+          },
     diff,
     view: serializeDiffTileViewState(ref.view),
   };

--- a/clients/gui-app/src/stores/epics/canvas/types.ts
+++ b/clients/gui-app/src/stores/epics/canvas/types.ts
@@ -166,6 +166,11 @@ export interface GitDiffBundleTilePayload {
   readonly bundleGroup: GitDiffBundleGroup;
 }
 
+export interface GitDiffRepositoryContext {
+  readonly workspaceLabel: string;
+  readonly repositoryLabel: string;
+}
+
 /**
  * Snapshot diff payloads address a chat file-edit by reference (not by copying
  * content): the renderer re-reads the agent's `beforeContent`/`afterContent`
@@ -228,6 +233,7 @@ export interface GitDiffTileRef {
   readonly type: typeof TILE_KIND_GIT_DIFF;
   readonly name: string;
   readonly hostId: string;
+  readonly repositoryContext: GitDiffRepositoryContext | null;
   readonly diff: GitDiffTilePayload;
   readonly view: GitDiffTileViewState;
 }


### PR DESCRIPTION
## Summary
- add shared sidebar row menus and right-click entry points
- improve Git diff labels, tooltips, and drag previews
- add Shift-aware split-group control

## Validation
- `bun run compile`
- `npx vitest run src/components/epic-canvas src/components/diff`
- `bun run lint`
- changed-file React Doctor

Auto-merge is intentionally disabled.