### PR TITLE
feat(gui): add Markdown source editor for agent guide

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,7 @@
       "name": "@traycer-clients/gui-app",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/lang-markdown": "catalog:",
         "@codemirror/language": "catalog:",
         "@codemirror/state": "catalog:",
         "@dnd-kit/core": "catalog:",
@@ -265,6 +266,7 @@
     "yaml": "^2.9.0",
   },
   "catalog": {
+    "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.0",
     "@dnd-kit/core": "^6.3.1",
@@ -497,6 +499,14 @@
     "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
 
     "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
 
     "@codemirror/language": ["@codemirror/language@6.12.4", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A=="],
 
@@ -732,9 +742,17 @@
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 
+    "@lezer/css": ["@lezer/css@1.3.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q=="],
+
     "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
 
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
     "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.7.1", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-MEBZeFSBxgteUjEC3Wxg2Dwld5/JxRKG267L3bMFdibm8KjqSdiJYBeFw1Nt1CM8+zKMpSIEHblY8FD9z38sJQ=="],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.6.0", "", {}, "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ=="],
 

--- a/clients/gui-app/package.json
+++ b/clients/gui-app/package.json
@@ -18,6 +18,7 @@
     "test:watch": "vitest --config vitest.config.ts"
   },
   "dependencies": {
+    "@codemirror/lang-markdown": "catalog:",
     "@codemirror/language": "catalog:",
     "@codemirror/state": "catalog:",
     "@dnd-kit/core": "catalog:",

--- a/clients/gui-app/src/components/agent-selection-guide-editor-surface.tsx
+++ b/clients/gui-app/src/components/agent-selection-guide-editor-surface.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { markdown } from "@codemirror/lang-markdown";
 import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { Button } from "@/components/ui/button";
@@ -65,20 +65,6 @@ export function AgentSelectionGuideEditorSurface({
   status,
 }: AgentSelectionGuideEditorSurfaceProps) {
   const theme = useCodeMirrorTheme();
-  const onValueChangeRef = useRef(onValueChange);
-  const onBlurRef = useRef(onBlur);
-  useEffect(() => {
-    onValueChangeRef.current = onValueChange;
-    onBlurRef.current = onBlur;
-  }, [onBlur, onValueChange]);
-
-  const handleValueChange = useCallback((nextValue: string): void => {
-    onValueChangeRef.current(nextValue);
-  }, []);
-  const handleBlur = useCallback((): void => {
-    onBlurRef.current?.();
-  }, []);
-
   const extensions = useMemo(
     () => [
       ...MARKDOWN_EDITOR_EXTENSIONS,
@@ -118,8 +104,8 @@ export function AgentSelectionGuideEditorSurface({
       >
         <CodeMirror
           value={value}
-          onChange={handleValueChange}
-          onBlur={handleBlur}
+          onChange={onValueChange}
+          onBlur={onBlur ?? undefined}
           editable={!disabled}
           readOnly={disabled}
           height="100%"

--- a/clients/gui-app/src/components/agent-selection-guide-editor-surface.tsx
+++ b/clients/gui-app/src/components/agent-selection-guide-editor-surface.tsx
@@ -1,11 +1,35 @@
-import type { ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
+import { markdown } from "@codemirror/lang-markdown";
+import CodeMirror, { EditorView } from "@uiw/react-codemirror";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+import { useCodeMirrorTheme } from "@/editor-core/use-code-mirror-theme";
 import { cn } from "@/lib/utils";
 
 export const AGENT_SELECTION_GUIDE_TITLE = "Agent selection guide";
 export const AGENT_SELECTION_GUIDE_DESCRIPTION =
   "Instructions for how Traycer agents choose child-agent harnesses, models, and reasoning effort.";
+
+const MARKDOWN_EDITOR_EXTENSIONS = [
+  markdown(),
+  EditorView.lineWrapping,
+  EditorView.theme({
+    "&": { height: "100%" },
+    ".cm-scroller": {
+      height: "100%",
+      fontFamily: "var(--font-mono)",
+      fontSize: "var(--code-font-size, 0.8rem)",
+    },
+    ".cm-content": { minHeight: "100%" },
+  }),
+];
+
+const MARKDOWN_EDITOR_BASIC_SETUP = {
+  lineNumbers: true,
+  foldGutter: false,
+  highlightActiveLine: true,
+  highlightActiveLineGutter: true,
+  autocompletion: false,
+};
 
 type AgentSelectionGuideEditorSurfaceProps = {
   readonly titleId: string;
@@ -16,9 +40,7 @@ type AgentSelectionGuideEditorSurfaceProps = {
   readonly placeholder: string | undefined;
   readonly ariaLabel: string;
   readonly testId: string;
-  readonly setTextareaElement:
-    ((element: HTMLTextAreaElement | null) => void) | null;
-  readonly textareaClassName: string;
+  readonly editorClassName: string;
   readonly className: string;
   readonly revertDisabled: boolean;
   readonly onRevert: () => void;
@@ -35,14 +57,41 @@ export function AgentSelectionGuideEditorSurface({
   placeholder,
   ariaLabel,
   testId,
-  setTextareaElement,
-  textareaClassName,
+  editorClassName,
   className,
   revertDisabled,
   onRevert,
   revertTestId,
   status,
 }: AgentSelectionGuideEditorSurfaceProps) {
+  const theme = useCodeMirrorTheme();
+  const onValueChangeRef = useRef(onValueChange);
+  const onBlurRef = useRef(onBlur);
+  useEffect(() => {
+    onValueChangeRef.current = onValueChange;
+    onBlurRef.current = onBlur;
+  }, [onBlur, onValueChange]);
+
+  const handleValueChange = useCallback((nextValue: string): void => {
+    onValueChangeRef.current(nextValue);
+  }, []);
+  const handleBlur = useCallback((): void => {
+    onBlurRef.current?.();
+  }, []);
+
+  const extensions = useMemo(
+    () => [
+      ...MARKDOWN_EDITOR_EXTENSIONS,
+      EditorView.contentAttributes.of({
+        "aria-label": ariaLabel,
+        "aria-multiline": "true",
+        role: "textbox",
+        spellcheck: "false",
+      }),
+    ],
+    [ariaLabel],
+  );
+
   return (
     <section
       aria-labelledby={titleId}
@@ -57,21 +106,31 @@ export function AgentSelectionGuideEditorSurface({
         </p>
       </div>
 
-      <Textarea
-        ref={setTextareaElement}
-        value={value}
-        onChange={(event) => onValueChange(event.target.value)}
-        onBlur={onBlur ?? undefined}
-        spellCheck={false}
-        disabled={disabled}
-        aria-label={ariaLabel}
-        data-testid={testId}
-        placeholder={placeholder}
+      <div
+        data-agent-selection-guide-editor-shell=""
+        aria-disabled={disabled}
         className={cn(
-          "min-h-0 overflow-y-auto font-mono text-code-xs leading-relaxed",
-          textareaClassName,
+          "relative min-h-0 overflow-hidden rounded-md border border-input bg-background shadow-xs transition-[color,box-shadow]",
+          "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
+          disabled && "cursor-not-allowed opacity-50",
+          editorClassName,
         )}
-      />
+      >
+        <CodeMirror
+          value={value}
+          onChange={handleValueChange}
+          onBlur={handleBlur}
+          editable={!disabled}
+          readOnly={disabled}
+          height="100%"
+          theme={theme}
+          placeholder={placeholder}
+          basicSetup={MARKDOWN_EDITOR_BASIC_SETUP}
+          extensions={extensions}
+          data-testid={testId}
+          className="h-full"
+        />
+      </div>
 
       <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
         <p className="min-w-[min(100%,18rem)] flex-1 text-ui-xs text-muted-foreground">

--- a/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-diorama.tsx
@@ -1524,8 +1524,7 @@ function AgentGuidePane(props: {
       placeholder={agentGuide.loading ? "Loading…" : undefined}
       ariaLabel="Onboarding agent selection instructions"
       testId="onboarding-agent-guide-input"
-      setTextareaElement={null}
-      textareaClassName="flex-1 resize-none"
+      editorClassName="flex-1"
       className="size-full overflow-hidden rounded-lg border border-border bg-card p-4 shadow-2xl"
       revertDisabled={agentGuide.loading || agentGuide.saving || isAtDefault}
       onRevert={agentGuide.onRevertToDefault}

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -255,11 +255,11 @@ codeFontSize` in muted styling while `null`; any tick/type pins an
 - `Agents` Editor for the **global** agent selection guide
   (`~/.traycer/agent-selection-guide.md`) - the instructions Traycer agents read
   to decide which child agents to spawn (harness / model / reasoning effort) for
-  a task. A monospace `Textarea` debounce-auto-saves (and flushes on blur) via
+  a task. A full-height CodeMirror Markdown source editor provides syntax
+  highlighting and line numbers, including for Mermaid and wireframe fences.
+  It debounce-auto-saves (and flushes on blur) via
   `agent.selectionGuide.setGlobal`; a quiet "Saving… / Saved" status sits in the
-  footer, no Save button. The textarea opens at a stable, viewport-aware height
-  and can be resized vertically until the panel reaches the settings viewport's
-  bottom spacing. A **Revert to default** button (disabled while the
+  footer, no Save button. A **Revert to default** button (disabled while the
   content already equals the provider-based default) calls
   `agent.selectionGuide.resetGlobalToDefault` behind a `ConfirmDestructiveDialog`.
   Default-host scope: the editor remounts (keyed on the active host id) so a host

--- a/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
@@ -7,6 +7,8 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { StrictMode, act } from "react";
+import { syntaxTree } from "@codemirror/language";
+import { EditorView } from "@uiw/react-codemirror";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type Deferred<T> = {
@@ -69,6 +71,25 @@ function strictPanel() {
   );
 }
 
+function getCodeMirrorView(element: HTMLElement): EditorView {
+  const view = EditorView.findFromDOM(element);
+  if (view === null) throw new Error("Expected a CodeMirror editor element");
+  return view;
+}
+
+function readMarkdown(element: HTMLElement): string {
+  return getCodeMirrorView(element).state.doc.toString();
+}
+
+function replaceMarkdown(element: HTMLElement, markdown: string): void {
+  act(() => {
+    const view = getCodeMirrorView(element);
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: markdown },
+    });
+  });
+}
+
 describe("AgentSelectionGuideSection", () => {
   beforeEach(() => {
     guideMocks.queryData = {
@@ -95,14 +116,12 @@ describe("AgentSelectionGuideSection", () => {
 
   it("updates generated defaults without clobbering the active editor draft", async () => {
     const { rerender } = renderPanel();
-    const editor = screen.getByTestId<HTMLTextAreaElement>(
-      "agents-selection-guide-input",
-    );
+    const editor = screen.getByTestId("agents-selection-guide-input");
     const revert = screen.getByTestId<HTMLButtonElement>(
       "agents-selection-guide-revert",
     );
 
-    expect(editor.value).toBe("claude guide");
+    expect(readMarkdown(editor)).toBe("claude guide");
     expect(revert.disabled).toBe(true);
 
     guideMocks.queryData = {
@@ -112,96 +131,59 @@ describe("AgentSelectionGuideSection", () => {
     rerender(strictPanel());
 
     await waitFor(() => {
-      expect(editor.value).toBe("claude guide");
+      expect(readMarkdown(editor)).toBe("claude guide");
       expect(revert.disabled).toBe(false);
     });
     expect(guideMocks.setGlobalMutateAsync).not.toHaveBeenCalled();
     expect(guideMocks.resetGlobalMutateAsync).not.toHaveBeenCalled();
   });
 
-  it("keeps the opening height stable and allows vertical resizing", () => {
-    renderPanel();
-    const editor = screen.getByTestId<HTMLTextAreaElement>(
-      "agents-selection-guide-input",
-    );
-
-    expect(editor.className).toContain("field-sizing-fixed");
-    expect(editor.className).not.toContain("field-sizing-content");
-    expect(editor.className).toContain("h-[min(32vh,16rem)]");
-    expect(editor.className).toContain("resize-y");
-    expect(editor.className).not.toContain("max-h-[min(32vh,16rem)]");
-  });
-
-  it("caps resizing at the settings viewport without shrinking below the opening height", () => {
-    let scrollBottom = 800;
-    const bodyBottom = 500;
-    const openingHeight = 256;
-    let resizeCallback: ResizeObserverCallback | null = null;
-    const resizeObserver: ResizeObserver = {
-      observe(): void {},
-      unobserve(): void {},
-      disconnect(): void {},
+  it("renders Markdown source with line numbers at full height", () => {
+    guideMocks.queryData = {
+      content: "# Choose an agent\n\n- Match the task",
+      generatedDefaultContent: "# Choose an agent\n\n- Match the task",
     };
-
-    class BoundaryResizeObserver implements ResizeObserver {
-      constructor(callback: ResizeObserverCallback) {
-        resizeCallback = callback;
-      }
-
-      observe(): void {}
-      unobserve(): void {}
-      disconnect(): void {}
-    }
-
-    vi.stubGlobal("ResizeObserver", BoundaryResizeObserver);
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
-      function (this: HTMLElement) {
-        if (this.getAttribute("data-testid") === "settings-scroll-viewport") {
-          return new DOMRect(0, 0, 100, scrollBottom);
-        }
-        if (this.hasAttribute("data-settings-panel-body")) {
-          return new DOMRect(0, 0, 100, bodyBottom);
-        }
-        if (this instanceof HTMLTextAreaElement) {
-          return new DOMRect(0, 0, 100, openingHeight);
-        }
-        return new DOMRect();
-      },
-    );
-
     render(
       <StrictMode>
-        <div
-          data-testid="settings-scroll-viewport"
-          style={{ overflowY: "auto" }}
-        >
-          <AgentsSettingsPanel />
-        </div>
+        <AgentsSettingsPanel />
       </StrictMode>,
     );
-
-    const editor = screen.getByRole<HTMLTextAreaElement>("textbox", {
-      name: "Global agent selection instructions",
-    });
-    const panelShell = editor.closest("[data-settings-panel-shell]");
-    if (!(panelShell instanceof HTMLElement)) {
-      throw new Error("Expected the editor to render inside a settings shell");
+    const editor = screen.getByTestId("agents-selection-guide-input");
+    const editorShell = editor.closest(
+      "[data-agent-selection-guide-editor-shell]",
+    );
+    if (!(editorShell instanceof HTMLElement)) {
+      throw new Error("Expected the editor shell to render");
     }
-    panelShell.style.paddingBottom = "40px";
+    const panelShell = editor.closest("[data-settings-panel-shell]");
+    const panelBody = editor.closest("[data-settings-panel-body]");
+    if (!(panelShell instanceof HTMLElement)) {
+      throw new Error("Expected the settings panel shell to render");
+    }
+    if (!(panelBody instanceof HTMLElement)) {
+      throw new Error("Expected the settings panel body to render");
+    }
 
-    const emitResize = (): void => {
-      if (resizeCallback === null) {
-        throw new Error("Expected the resize observer to be active");
-      }
-      resizeCallback([], resizeObserver);
-    };
-
-    act(emitResize);
-    expect(editor.style.maxHeight).toBe("516px");
-
-    scrollBottom = 300;
-    act(emitResize);
-    expect(editor.style.maxHeight).toBe("256px");
+    const editorView = getCodeMirrorView(editor);
+    expect(editorView.state.doc.toString()).toBe(
+      "# Choose an agent\n\n- Match the task",
+    );
+    expect(
+      syntaxTree(editorView.state).topNode.getChild("ATXHeading1"),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("textbox", {
+        name: "Global agent selection instructions",
+      }),
+    ).toBeTruthy();
+    expect(editor.querySelector(".cm-lineNumbers")).not.toBeNull();
+    expect(editor.className).toContain("h-full");
+    expect(editorShell.className).toContain("flex-1");
+    expect(panelShell.className).toContain("h-full");
+    expect(panelBody.className).toContain("flex-1");
+    expect(
+      screen.queryByRole("heading", { name: "Choose an agent" }),
+    ).toBeNull();
   });
 
   it("reverts through the host reset API instead of sending generated content back", async () => {
@@ -216,8 +198,7 @@ describe("AgentSelectionGuideSection", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByTestId<HTMLTextAreaElement>("agents-selection-guide-input")
-          .value,
+        readMarkdown(screen.getByTestId("agents-selection-guide-input")),
       ).toBe("codex guide");
     });
     expect(guideMocks.resetGlobalMutateAsync).toHaveBeenCalledWith({});
@@ -237,11 +218,9 @@ describe("AgentSelectionGuideSection", () => {
       .mockReturnValueOnce(first.promise)
       .mockReturnValueOnce(second.promise);
     renderPanel();
-    const editor = screen.getByTestId<HTMLTextAreaElement>(
-      "agents-selection-guide-input",
-    );
+    const editor = screen.getByTestId("agents-selection-guide-input");
 
-    fireEvent.change(editor, { target: { value: "first edit" } });
+    replaceMarkdown(editor, "first edit");
     fireEvent.blur(editor);
 
     expect(guideMocks.setGlobalMutateAsync).toHaveBeenCalledTimes(1);
@@ -249,7 +228,7 @@ describe("AgentSelectionGuideSection", () => {
       content: "first edit",
     });
 
-    fireEvent.change(editor, { target: { value: "second edit" } });
+    replaceMarkdown(editor, "second edit");
     fireEvent.blur(editor);
 
     expect(guideMocks.setGlobalMutateAsync).toHaveBeenCalledTimes(1);

--- a/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/agent-selection-guide-section.test.tsx
@@ -90,6 +90,14 @@ function replaceMarkdown(element: HTMLElement, markdown: string): void {
   });
 }
 
+function blurCodeMirror(element: HTMLElement): void {
+  const content = element.querySelector(".cm-content");
+  if (!(content instanceof HTMLElement)) {
+    throw new Error("Expected CodeMirror content to render");
+  }
+  fireEvent.blur(content);
+}
+
 describe("AgentSelectionGuideSection", () => {
   beforeEach(() => {
     guideMocks.queryData = {
@@ -221,7 +229,7 @@ describe("AgentSelectionGuideSection", () => {
     const editor = screen.getByTestId("agents-selection-guide-input");
 
     replaceMarkdown(editor, "first edit");
-    fireEvent.blur(editor);
+    blurCodeMirror(editor);
 
     expect(guideMocks.setGlobalMutateAsync).toHaveBeenCalledTimes(1);
     expect(guideMocks.setGlobalMutateAsync).toHaveBeenLastCalledWith({
@@ -229,7 +237,7 @@ describe("AgentSelectionGuideSection", () => {
     });
 
     replaceMarkdown(editor, "second edit");
-    fireEvent.blur(editor);
+    blurCodeMirror(editor);
 
     expect(guideMocks.setGlobalMutateAsync).toHaveBeenCalledTimes(1);
 

--- a/clients/gui-app/src/components/settings/panels/agent-selection-guide-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/agent-selection-guide-section.tsx
@@ -3,13 +3,7 @@
  * Update that file whenever this settings surface changes.
  */
 import type { ReactNode } from "react";
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useReducer,
-  useRef,
-} from "react";
+import { useEffect, useReducer, useRef } from "react";
 import { Check, TriangleAlert } from "lucide-react";
 import {
   AGENT_SELECTION_GUIDE_DESCRIPTION,
@@ -26,70 +20,6 @@ import { useAgentSelectionGuideSetGlobalMutation } from "@/hooks/agent/use-agent
 import { useAgentSelectionGuideResetGlobalMutation } from "@/hooks/agent/use-agent-selection-guide-reset-global-mutation";
 
 const SAVE_DEBOUNCE_MS = 600;
-
-function findVerticalScrollContainer(element: HTMLElement): HTMLElement | null {
-  let current = element.parentElement;
-  while (current !== null) {
-    const overflowY = window.getComputedStyle(current).overflowY;
-    if (overflowY === "auto" || overflowY === "scroll") return current;
-    current = current.parentElement;
-  }
-  return null;
-}
-
-function useTextareaResizeBoundary() {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const setTextareaElement = useCallback(
-    (element: HTMLTextAreaElement | null): void => {
-      textareaRef.current = element;
-    },
-    [],
-  );
-
-  useLayoutEffect(() => {
-    const textarea = textareaRef.current;
-    if (textarea === null) return;
-
-    const panelBody = textarea.closest("[data-settings-panel-body]");
-    const panelShell = textarea.closest("[data-settings-panel-shell]");
-    if (!(panelBody instanceof HTMLElement)) return;
-    if (!(panelShell instanceof HTMLElement)) return;
-
-    const scrollContainer = findVerticalScrollContainer(panelShell);
-    if (scrollContainer === null) return;
-
-    const defaultHeight = textarea.getBoundingClientRect().height;
-    if (defaultHeight <= 0) return;
-
-    const updateMaxHeight = (): void => {
-      const scrollRect = scrollContainer.getBoundingClientRect();
-      const bodyRect = panelBody.getBoundingClientRect();
-      const textareaHeight = textarea.getBoundingClientRect().height;
-      const shellBottomPadding = Number.parseFloat(
-        window.getComputedStyle(panelShell).paddingBottom,
-      );
-      // The card grows one-for-one with the textarea. Add only the free space
-      // below the current card so the shell's normal bottom padding remains.
-      const availableGrowth =
-        scrollRect.bottom -
-        bodyRect.bottom -
-        (Number.isFinite(shellBottomPadding) ? shellBottomPadding : 0);
-      const maxHeight = Math.max(
-        defaultHeight,
-        textareaHeight + availableGrowth,
-      );
-      textarea.style.maxHeight = `${Math.floor(maxHeight)}px`;
-    };
-
-    updateMaxHeight();
-    const observer = new ResizeObserver(updateMaxHeight);
-    observer.observe(scrollContainer);
-    observer.observe(panelBody);
-    return () => observer.disconnect();
-  }, []);
-
-  return setTextareaElement;
-}
 
 type AgentsGuideEditorState = {
   readonly value: string;
@@ -207,14 +137,14 @@ export function AgentSelectionGuideSection() {
     );
   }
 
-  return <div className="shrink-0 px-5 py-5">{panelContent}</div>;
+  return <div className="h-full min-h-0 p-5">{panelContent}</div>;
 }
 
 function AgentSelectionGuideMessage(props: { readonly children: ReactNode }) {
   return (
     <section
       aria-labelledby="agent-selection-guide-heading"
-      className="flex flex-col gap-3"
+      className="flex h-full min-h-0 flex-col gap-3"
     >
       <div className="min-w-0">
         <h2
@@ -251,7 +181,6 @@ function AgentsGuideEditor(props: {
   const queuedSaveRef = useRef<string | null>(null);
   const queuedResetRef = useRef(false);
   const mountedRef = useRef(true);
-  const setTextareaElement = useTextareaResizeBoundary();
 
   // Drop a pending debounced save when unmounting (blur already flushes the
   // common close paths) so the timer can't fire into an unmounted component.
@@ -383,9 +312,8 @@ function AgentsGuideEditor(props: {
         placeholder={undefined}
         ariaLabel="Global agent selection instructions"
         testId="agents-selection-guide-input"
-        setTextareaElement={setTextareaElement}
-        textareaClassName="field-sizing-fixed h-[min(32vh,16rem)] min-h-[min(20vh,10rem)] resize-y"
-        className=""
+        editorClassName="flex-1"
+        className="h-full"
         revertDisabled={
           isAtDefault || state.saveInFlight || state.resetInFlight
         }
@@ -443,8 +371,8 @@ function SaveStatus(props: {
 
 function EditorSkeleton() {
   return (
-    <div className="space-y-3">
-      <div className="h-[min(22vh,11rem)] animate-pulse rounded-md bg-muted/40" />
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      <div className="min-h-[min(22vh,11rem)] flex-1 animate-pulse rounded-md bg-muted/40" />
       <div className="h-4 w-2/3 animate-pulse rounded bg-muted/30" />
     </div>
   );

--- a/clients/gui-app/src/components/settings/panels/agents-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/agents-settings-panel.tsx
@@ -5,12 +5,11 @@
 import { SettingsPanelShell } from "@/components/settings/settings-panel-shell";
 import { AgentSelectionGuideSection } from "./agent-selection-guide-section";
 
-// The global agent selection guide lives in its own settings section. The
-// editor itself is shared with no other surface, so the panel is just the
-// section wrapped in the standard settings shell.
+// The global agent selection guide lives in its own full-height settings
+// section so the Markdown source editor can use all remaining panel space.
 export function AgentsSettingsPanel() {
   return (
-    <SettingsPanelShell title="Agents">
+    <SettingsPanelShell title="Agents" fillHeight>
       <AgentSelectionGuideSection />
     </SettingsPanelShell>
   );

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-code-editor.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-code-editor.tsx
@@ -1,16 +1,11 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useSyncExternalStore,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import CodeMirror, {
   type ReactCodeMirrorRef,
   EditorView,
   keymap,
 } from "@uiw/react-codemirror";
 import { Prec } from "@codemirror/state";
+import { useCodeMirrorTheme } from "@/editor-core/use-code-mirror-theme";
 import { mermaidStreamLanguage } from "./mermaid-simple-mode";
 
 export interface MermaidCodeEditorProps {
@@ -58,11 +53,7 @@ export function MermaidCodeEditor(props: MermaidCodeEditorProps) {
     latestValueRef.current = value;
   }, [value]);
 
-  const cmTheme = useSyncExternalStore(
-    subscribeToDocumentTheme,
-    readDocumentTheme,
-    readServerDocumentTheme,
-  );
+  const cmTheme = useCodeMirrorTheme();
 
   // Imperative focus on mount. Tied to a `ref` - the CodeMirror view is
   // attached in the first render pass but `.view` is only populated after
@@ -140,23 +131,4 @@ export function MermaidCodeEditor(props: MermaidCodeEditorProps) {
       />
     </div>
   );
-}
-
-function readDocumentTheme(): "light" | "dark" {
-  if (typeof document === "undefined") return "light";
-  return document.documentElement.classList.contains("dark") ? "dark" : "light";
-}
-
-function readServerDocumentTheme(): "light" | "dark" {
-  return "light";
-}
-
-function subscribeToDocumentTheme(onStoreChange: () => void): () => void {
-  if (typeof document === "undefined") return () => undefined;
-  const observer = new MutationObserver(onStoreChange);
-  observer.observe(document.documentElement, {
-    attributes: true,
-    attributeFilter: ["class"],
-  });
-  return () => observer.disconnect();
 }

--- a/clients/gui-app/src/editor-core/use-code-mirror-theme.ts
+++ b/clients/gui-app/src/editor-core/use-code-mirror-theme.ts
@@ -1,0 +1,28 @@
+import { useSyncExternalStore } from "react";
+
+function readDocumentTheme(): "light" | "dark" {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+function subscribeToDocumentTheme(onStoreChange: () => void): () => void {
+  if (typeof document === "undefined") return () => undefined;
+  const observer = new MutationObserver(onStoreChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+  return () => observer.disconnect();
+}
+
+function readServerDocumentTheme(): "light" {
+  return "light";
+}
+
+export function useCodeMirrorTheme(): "light" | "dark" {
+  return useSyncExternalStore(
+    subscribeToDocumentTheme,
+    readDocumentTheme,
+    readServerDocumentTheme,
+  );
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clients/*"
   ],
   "catalog": {
+    "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.0",
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary

- replace the Agent selection guide textarea with a full-height CodeMirror Markdown source editor
- add Markdown syntax highlighting, line numbers, wrapping, and shared light/dark CodeMirror theming
- preserve onboarding/settings autosave, blur flush, reset, and host-scoped behavior

## Related issue

N/A

## Testing

- `bun run test` in `clients/gui-app` (5,253 passed, 1 skipped)
- `bun run compile` in `clients/gui-app`
- `bun run lint` in `clients/gui-app`
- `bunx nx run traycer-clients-gui-app:build --tui=false`
- React Doctor changed-file scan
- `pre-commit run --all-files`

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass for the affected GUI workspace
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
