### PR TITLE
feat(gui): pin epic history items

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -23,6 +23,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -110,6 +111,11 @@ interface RenameEpicTitleVariables {
   };
 }
 
+interface SetEpicPinnedVariables {
+  readonly epicId: string;
+  readonly pinned: boolean;
+}
+
 interface WorktreeCleanupCandidateStub {
   readonly worktreePath: string;
   readonly repoLabel: string;
@@ -162,6 +168,8 @@ const testState = vi.hoisted(() => ({
       ) => void
     >(),
   renameMutate: vi.fn<(variables: RenameEpicTitleVariables) => void>(),
+  setPinnedMutate: vi.fn<(variables: SetEpicPinnedVariables) => void>(),
+  pendingSetPinnedEpicIds: new Set<string>(),
   refetch: vi.fn(),
   fetchNextPage: vi.fn(),
 }));
@@ -208,6 +216,13 @@ vi.mock("@/hooks/epic/use-epic-title-mutation", () => ({
   }),
 }));
 
+vi.mock("@/hooks/epic/use-epic-set-pinned-mutation", () => ({
+  useEpicSetPinned: () => ({
+    mutate: testState.setPinnedMutate,
+  }),
+  usePendingSetPinnedEpicIds: () => testState.pendingSetPinnedEpicIds,
+}));
+
 vi.mock("@/hooks/epic/use-epic-activity-status", () => ({
   useEpicActivityStatus: (epicId: string | null) =>
     epicId === null
@@ -230,6 +245,7 @@ function historyItem(overrides: Partial<HistoryItem>): HistoryItem {
     pullRequestNumbers: [],
     ownership: "mine",
     permissionRole: "owner",
+    isPinned: false,
     ...overrides,
   };
 }
@@ -335,6 +351,8 @@ describe("<EpicsListPanel />", () => {
     setDesktopEpicOwnershipBridge(null);
     testState.mutate.mockReset();
     testState.renameMutate.mockReset();
+    testState.setPinnedMutate.mockReset();
+    testState.pendingSetPinnedEpicIds = new Set();
     testState.refetch.mockReset();
     testState.fetchNextPage.mockReset();
     testState.activityByEpicId.clear();
@@ -367,6 +385,123 @@ describe("<EpicsListPanel />", () => {
       );
     });
     expect(screen.queryByTestId("old-epic-route")).toBeNull();
+  });
+
+  it("unpins a pinned app history epic from the row control", async () => {
+    testState.items = [historyItem({ isPinned: true })];
+    renderPanel("embedded", "/");
+
+    const unpin = await screen.findByRole("button", {
+      name: "Unpin Open from landing from top",
+    });
+    expect(unpin.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByTestId("epics-list-row").dataset.pinned).toBe("true");
+    fireEvent.click(unpin);
+    expect(testState.setPinnedMutate).toHaveBeenCalledWith({
+      epicId: "epic-from-history",
+      pinned: false,
+    });
+  });
+
+  it("pins an unpinned app history epic", async () => {
+    renderPanel("embedded", "/");
+
+    const pin = await screen.findByRole("button", {
+      name: "Pin Open from landing to top",
+    });
+    expect(pin.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(pin);
+    expect(testState.setPinnedMutate).toHaveBeenCalledWith({
+      epicId: "epic-from-history",
+      pinned: true,
+    });
+  });
+
+  it("clicks the pin control without triggering the row navigation layer", async () => {
+    const router = renderPanel("embedded", "/");
+
+    const pin = await screen.findByRole("button", {
+      name: "Pin Open from landing to top",
+    });
+    fireEvent.click(pin);
+
+    expect(testState.setPinnedMutate).toHaveBeenCalledWith({
+      epicId: "epic-from-history",
+      pinned: true,
+    });
+    // The pin control sits alongside - not inside - the row's absolute <Link>
+    // overlay. A regression that nested it inside the link, or dropped the
+    // sibling stacking, would fire navigation on the same click.
+    expect(router.state.location.pathname).toBe("/");
+    expect(screen.queryByTestId("epic-tab-route")).toBeNull();
+  });
+
+  it("keeps two independently pending pin rows disabled and spinning at the same time", async () => {
+    testState.items = [
+      historyItem({}),
+      historyItem({
+        id: "history-epic-2",
+        epicId: "epic-two",
+        title: "Second history item",
+      }),
+      historyItem({
+        id: "history-epic-3",
+        epicId: "epic-three",
+        title: "Third history item",
+      }),
+    ];
+    // Simulates two rows having each fired their own `epic.setPinned` call
+    // concurrently: both must read as pending off the shared mutation
+    // cache, independent of which one was clicked most recently.
+    testState.pendingSetPinnedEpicIds = new Set([
+      "epic-from-history",
+      "epic-two",
+    ]);
+    renderPanel("embedded", "/");
+
+    const pendingPinOne = await screen.findByRole("button", {
+      name: "Pin Open from landing to top",
+    });
+    const pendingPinTwo = screen.getByRole("button", {
+      name: "Pin Second history item to top",
+    });
+    const idlePin = screen.getByRole("button", {
+      name: "Pin Third history item to top",
+    });
+
+    expect(pendingPinOne.hasAttribute("disabled")).toBe(true);
+    expect(pendingPinTwo.hasAttribute("disabled")).toBe(true);
+    expect(idlePin.hasAttribute("disabled")).toBe(false);
+
+    expect(
+      within(pendingPinOne).queryByTestId("epics-list-row-pin-spinner"),
+    ).not.toBeNull();
+    expect(
+      within(pendingPinTwo).queryByTestId("epics-list-row-pin-spinner"),
+    ).not.toBeNull();
+    expect(
+      within(idlePin).queryByTestId("epics-list-row-pin-spinner"),
+    ).toBeNull();
+  });
+
+  it("shows no pin control for a phase row even when the raw task carries isPinned true", async () => {
+    testState.items = [
+      historyItem({
+        id: "history-phase-pinned",
+        epicId: "phase-pinned",
+        taskType: "phase",
+        title: "Phase somehow pinned",
+        // A phase can never legitimately be pinned - the data layer always
+        // projects `isPinned: false` for phases - but the row control must
+        // stay defensive even if a stale/bad projection carried `true`
+        // through.
+        isPinned: true,
+      }),
+    ];
+    renderPanel("embedded", "/");
+
+    expect(await screen.findByText("Phase somehow pinned")).not.toBeNull();
+    expect(screen.queryByTestId("epics-list-row-pin")).toBeNull();
   });
 
   it("shows task PR pills without replacing the row navigation layer", async () => {
@@ -426,6 +561,8 @@ describe("<EpicsListPanel />", () => {
       }),
     ];
     renderPanel("embedded", "/");
+
+    expect(screen.queryByTestId("epics-list-row-pin")).toBeNull();
 
     fireEvent.contextMenu(await screen.findByTestId("epics-list-row-card"));
 

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -23,7 +23,6 @@ import {
   render,
   screen,
   waitFor,
-  within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -436,7 +435,7 @@ describe("<EpicsListPanel />", () => {
     expect(screen.queryByTestId("epic-tab-route")).toBeNull();
   });
 
-  it("keeps two independently pending pin rows disabled and spinning at the same time", async () => {
+  it("keeps two independently pending pin rows disabled, without swapping their icons for a spinner", async () => {
     testState.items = [
       historyItem({}),
       historyItem({
@@ -452,7 +451,9 @@ describe("<EpicsListPanel />", () => {
     ];
     // Simulates two rows having each fired their own `epic.setPinned` call
     // concurrently: both must read as pending off the shared mutation
-    // cache, independent of which one was clicked most recently.
+    // cache, independent of which one was clicked most recently. The pin
+    // state itself is optimistic, so the icon keeps showing each row's
+    // current state - pending only disables re-toggling, with no spinner.
     testState.pendingSetPinnedEpicIds = new Set([
       "epic-from-history",
       "epic-two",
@@ -473,15 +474,9 @@ describe("<EpicsListPanel />", () => {
     expect(pendingPinTwo.hasAttribute("disabled")).toBe(true);
     expect(idlePin.hasAttribute("disabled")).toBe(false);
 
-    expect(
-      within(pendingPinOne).queryByTestId("epics-list-row-pin-spinner"),
-    ).not.toBeNull();
-    expect(
-      within(pendingPinTwo).queryByTestId("epics-list-row-pin-spinner"),
-    ).not.toBeNull();
-    expect(
-      within(idlePin).queryByTestId("epics-list-row-pin-spinner"),
-    ).toBeNull();
+    expect(pendingPinOne.querySelector("svg")).not.toBeNull();
+    expect(pendingPinTwo.querySelector("svg")).not.toBeNull();
+    expect(screen.queryByTestId("epics-list-row-pin-spinner")).toBeNull();
   });
 
   it("shows no pin control for a phase row even when the raw task carries isPinned true", async () => {

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -1289,17 +1289,12 @@ function HistoryPinControl(props: {
             props.onSetPinned(props.item.epicId, !props.item.isPinned);
           }}
         >
-          {props.isPending ? (
-            <AgentSpinningDots
-              variant="orbit"
-              className="text-current"
-              testId="epics-list-row-pin-spinner"
-            />
-          ) : (
-            <Pin
-              className={cn("size-3.5", props.item.isPinned && "fill-current")}
-            />
-          )}
+          {/* The pin state is optimistic - it flips at click time - so the
+              icon always shows the row's current state; the brief disabled
+              window only serializes rapid re-toggles, with no spinner. */}
+          <Pin
+            className={cn("size-3.5", props.item.isPinned && "fill-current")}
+          />
         </button>
       </TooltipTrigger>
       <TooltipContent>{label}</TooltipContent>

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -15,6 +15,7 @@ import {
   Layers,
   ListChecks,
   Pencil,
+  Pin,
   RefreshCwIcon,
   Search,
   Trash2,
@@ -46,6 +47,10 @@ import {
 import { useEpicBatchDelete } from "@/hooks/epic/use-epic-batch-delete-mutation";
 import { useTaskDeleteWorktreeCandidates } from "@/hooks/epic/use-task-delete-worktree-candidates-query";
 import { useEpicUpdateTitle } from "@/hooks/epic/use-epic-title-mutation";
+import {
+  useEpicSetPinned,
+  usePendingSetPinnedEpicIds,
+} from "@/hooks/epic/use-epic-set-pinned-mutation";
 import { useInlineRename } from "@/hooks/ui/use-inline-rename";
 import { withMemberToggled } from "@/lib/immutable-set";
 import { cn } from "@/lib/utils";
@@ -283,6 +288,15 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
     ReadonlyMap<string, boolean>
   >(() => new Map());
   const deleteMutation = useEpicBatchDelete();
+  const setPinnedMutation = useEpicSetPinned();
+  const setPinned = setPinnedMutation.mutate;
+  const pendingSetPinnedEpicIds = usePendingSetPinnedEpicIds();
+  const handleSetPinned = useCallback(
+    (epicId: string, pinned: boolean) => {
+      setPinned({ epicId, pinned });
+    },
+    [setPinned],
+  );
 
   const { candidates: worktreeCandidates } =
     useTaskDeleteWorktreeCandidates(pendingDeleteIds);
@@ -485,6 +499,8 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
               selectedIds={selectedIds}
               onToggleSelection={toggleSelection}
               onRequestDelete={requestDelete}
+              onSetPinned={handleSetPinned}
+              pendingSetPinnedEpicIds={pendingSetPinnedEpicIds}
               hasNextPage={hasNextPage}
               isFetchingNextPage={isFetchingNextPage}
               onLoadMore={fetchNextPage}
@@ -771,6 +787,8 @@ interface EpicsListBodyProps {
   readonly selectedIds: ReadonlySet<string>;
   readonly onToggleSelection: (id: string) => void;
   readonly onRequestDelete: (ids: ReadonlyArray<string>) => void;
+  readonly onSetPinned: (epicId: string, pinned: boolean) => void;
+  readonly pendingSetPinnedEpicIds: ReadonlySet<string>;
   readonly hasNextPage: boolean;
   readonly isFetchingNextPage: boolean;
   readonly onLoadMore: () => void;
@@ -795,6 +813,8 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     selectedIds,
     onToggleSelection,
     onRequestDelete,
+    onSetPinned,
+    pendingSetPinnedEpicIds,
     hasNextPage,
     isFetchingNextPage,
     onLoadMore,
@@ -835,6 +855,8 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
               isSelected={selectedIds.has(item.epicId)}
               onToggleSelection={onToggleSelection}
               onRequestDelete={onRequestDelete}
+              onSetPinned={onSetPinned}
+              isPinPending={pendingSetPinnedEpicIds.has(item.epicId)}
               onSelectEpic={onSelectEpic}
               onOpenInNewWindow={onOpenInNewWindow}
               openInNewWindowAvailable={openInNewWindowAvailable}
@@ -901,6 +923,8 @@ interface EpicsListRowProps {
   readonly isSelected: boolean;
   readonly onToggleSelection: (id: string) => void;
   readonly onRequestDelete: (ids: ReadonlyArray<string>) => void;
+  readonly onSetPinned: (epicId: string, pinned: boolean) => void;
+  readonly isPinPending: boolean;
   readonly onSelectEpic: ((epicId: string) => void) | null;
   readonly onOpenInNewWindow: HistoryNewWindowFlow["requestOpen"];
   readonly openInNewWindowAvailable: boolean;
@@ -945,6 +969,8 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     isSelected,
     onToggleSelection,
     onRequestDelete,
+    onSetPinned,
+    isPinPending,
     onSelectEpic,
     onOpenInNewWindow,
     openInNewWindowAvailable,
@@ -1095,6 +1121,14 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
       <TooltipContent>{deleteDisabledTooltip}</TooltipContent>
     </Tooltip>
   );
+  const pinControl = (
+    <HistoryPinControl
+      item={item}
+      isPending={isPinPending}
+      selectionMode={selectionMode}
+      onSetPinned={onSetPinned}
+    />
+  );
   const rowInteractionLayer = selectionMode ? (
     <HistorySelectionOverlay
       item={item}
@@ -1159,6 +1193,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
               <span className="truncate font-medium text-foreground">
                 {displayTitle}
               </span>
+              {pinControl}
               {titleEditControl}
             </span>
           )}
@@ -1198,6 +1233,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
   return (
     <li
       data-testid="epics-list-row"
+      data-pinned={item.isPinned}
       className="group/list-row flex items-stretch gap-1.5"
     >
       <div className="flex w-5 shrink-0 items-center justify-center">
@@ -1222,6 +1258,54 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     </li>
   );
 });
+
+function HistoryPinControl(props: {
+  readonly item: HistoryItem;
+  readonly isPending: boolean;
+  readonly selectionMode: boolean;
+  readonly onSetPinned: (epicId: string, pinned: boolean) => void;
+}): ReactNode {
+  if (props.selectionMode || props.item.taskType === "phase") return null;
+  const displayTitle = historyItemDisplayTitle(props.item);
+  const label = props.item.isPinned
+    ? `Unpin ${displayTitle} from top`
+    : `Pin ${displayTitle} to top`;
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={label}
+          aria-pressed={props.item.isPinned}
+          data-testid="epics-list-row-pin"
+          disabled={props.isPending}
+          className={cn(
+            "pointer-events-auto flex size-5 shrink-0 items-center justify-center rounded-sm outline-none transition-[color,opacity] hover:bg-muted focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-wait",
+            props.item.isPinned
+              ? "text-primary opacity-100"
+              : "text-muted-foreground opacity-0 group-hover/list-row:opacity-100 group-focus-within/list-row:opacity-100",
+          )}
+          onClick={() => {
+            props.onSetPinned(props.item.epicId, !props.item.isPinned);
+          }}
+        >
+          {props.isPending ? (
+            <AgentSpinningDots
+              variant="orbit"
+              className="text-current"
+              testId="epics-list-row-pin-spinner"
+            />
+          ) : (
+            <Pin
+              className={cn("size-3.5", props.item.isPinned && "fill-current")}
+            />
+          )}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 function HistoryRowLeadingIcon(props: { readonly item: HistoryItem }) {
   const activityStatus = useEpicActivityStatus(

--- a/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
+++ b/clients/gui-app/src/components/home/__tests__/home-page.data.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { TaskLight } from "@traycer/protocol/host/epic/unary-schemas";
+import type { ListTaskLight } from "@traycer/protocol/host/epic/unary-schemas";
 import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import {
   buildHistoryItemsFromTasks,
   collectHistoryRepos,
   filterHistoryItems,
   groupHistoryItems,
+  prioritizePinnedHistoryItems,
+  sortHistoryItems,
   withHistoryItemPullRequestNumbers,
   type HistoryItem,
 } from "@/components/home/data/home-page.data";
@@ -27,6 +29,7 @@ function makeItem(
     pullRequestNumbers: overrides.pullRequestNumbers ?? [],
     ownership: overrides.ownership ?? "mine",
     permissionRole: overrides.permissionRole ?? "owner",
+    isPinned: overrides.isPinned ?? false,
   };
 }
 
@@ -76,6 +79,35 @@ describe("home-page history helpers", () => {
     expect(groups.map((g) => g.bucket)).toEqual(["today", "earlier"]);
   });
 
+  it("keeps pinned items first while preserving the active sort within each block", () => {
+    const items = [
+      makeItem({ id: "a", title: "Alpha", isPinned: false }),
+      makeItem({ id: "z", title: "Zulu", isPinned: true }),
+      makeItem({ id: "b", title: "Bravo", isPinned: true }),
+      makeItem({ id: "c", title: "Charlie", isPinned: false }),
+    ];
+
+    expect(sortHistoryItems(items, "title-asc").map((item) => item.id)).toEqual(
+      ["b", "z", "a", "c"],
+    );
+  });
+
+  it("stably promotes pinned items in relevance-ranked results", () => {
+    const items = [
+      makeItem({ id: "best", title: "Best match", isPinned: false }),
+      makeItem({ id: "pinned-1", title: "Pinned one", isPinned: true }),
+      makeItem({ id: "next", title: "Next match", isPinned: false }),
+      makeItem({ id: "pinned-2", title: "Pinned two", isPinned: true }),
+    ];
+
+    expect(prioritizePinnedHistoryItems(items).map((item) => item.id)).toEqual([
+      "pinned-1",
+      "pinned-2",
+      "best",
+      "next",
+    ]);
+  });
+
   it("projects distinct superproject and submodule PR numbers for a task", () => {
     const items = [makeItem({ id: "history-1", title: "History task" })];
     const worktreesByEpicId = new Map([
@@ -101,7 +133,7 @@ describe("home-page history helpers", () => {
   });
 
   it("builds history items from cloud task lights and extracts real repo identifiers", () => {
-    const tasks: ReadonlyArray<TaskLight> = [
+    const tasks: ReadonlyArray<ListTaskLight> = [
       {
         epic: {
           light: {
@@ -137,6 +169,7 @@ describe("home-page history helpers", () => {
           roomInfo: null,
         },
         phase: null,
+        pinned: true,
       },
       {
         epic: null,
@@ -164,6 +197,10 @@ describe("home-page history helpers", () => {
           workspaces: [],
           roomInfo: null,
         },
+        // A phase can never legitimately be pinned - the raw task carries
+        // `pinned: true` here to prove the projection ignores it rather
+        // than merely happening to see `false`.
+        pinned: true,
       },
     ];
 
@@ -185,6 +222,7 @@ describe("home-page history helpers", () => {
       linkedRepos: ["traycerai/gui-app", "traycerai/host"],
       ownership: "mine",
       permissionRole: "owner",
+      isPinned: true,
     });
     expect(items[1]).toMatchObject({
       id: "phase-phase-real",
@@ -195,6 +233,7 @@ describe("home-page history helpers", () => {
       initialUserPrompt: "",
       updatedBucket: "today",
       linkedRepos: ["traycerai/gui-app"],
+      isPinned: false,
     });
   });
 });

--- a/clients/gui-app/src/components/home/data/home-page.data.ts
+++ b/clients/gui-app/src/components/home/data/home-page.data.ts
@@ -1,6 +1,6 @@
 import type {
   PermissionRole,
-  TaskLight,
+  ListTaskLight,
   TaskOwnershipScope,
   TaskWorkspaceIdentifier,
 } from "@traycer/protocol/host/epic/unary-schemas";
@@ -41,6 +41,7 @@ export interface HistoryItem {
   pullRequestNumbers: ReadonlyArray<string>;
   ownership: HistoryOwnershipScope;
   permissionRole: PermissionRole | null;
+  isPinned: boolean;
 }
 
 export interface HistoryFilters {
@@ -64,7 +65,7 @@ const HISTORY_GROUP_LABELS: Record<HistoryRecencyBucket, string> = {
 };
 
 export function buildHistoryItemsFromTasks(
-  tasks: ReadonlyArray<TaskLight>,
+  tasks: ReadonlyArray<ListTaskLight>,
   nowMs: number,
   userId: string | null,
 ): ReadonlyArray<HistoryItem> {
@@ -81,6 +82,7 @@ export function buildHistoryItemsFromTasks(
           userId,
           nowMs,
           role: task.epic?.permission?.role ?? null,
+          isPinned: task.pinned ?? false,
         }),
       ];
     }
@@ -101,6 +103,7 @@ export function buildHistoryItemsFromTasks(
         userId,
         nowMs,
         role: task.phase?.permission?.role ?? null,
+        isPinned: false,
       }),
     ];
   });
@@ -110,11 +113,12 @@ function buildHistoryItem(args: {
   light: { id: string; title: string; updatedAt: number; createdBy: string };
   taskType: "epic" | "phase";
   initialUserPrompt: string;
-  task: TaskLight;
+  task: ListTaskLight;
   index: number;
   userId: string | null;
   nowMs: number;
   role: PermissionRole | null;
+  isPinned: boolean;
 }): HistoryItem {
   const {
     light,
@@ -125,6 +129,7 @@ function buildHistoryItem(args: {
     userId,
     nowMs,
     role,
+    isPinned,
   } = args;
   const ownership = light.createdBy === userId ? "mine" : "shared";
   return {
@@ -147,6 +152,7 @@ function buildHistoryItem(args: {
     pullRequestNumbers: [],
     ownership,
     permissionRole: historyPermissionRole(ownership, role),
+    isPinned,
   };
 }
 
@@ -280,6 +286,7 @@ export function sortHistoryItems(
         .slice()
         .sort(
           (left, right) =>
+            comparePinnedHistoryItems(left, right) ||
             right.updatedAtMs - left.updatedAtMs ||
             BUCKET_ORDER[left.updatedBucket] -
               BUCKET_ORDER[right.updatedBucket],
@@ -289,6 +296,7 @@ export function sortHistoryItems(
         .slice()
         .sort(
           (left, right) =>
+            comparePinnedHistoryItems(left, right) ||
             left.updatedAtMs - right.updatedAtMs ||
             BUCKET_ORDER[right.updatedBucket] -
               BUCKET_ORDER[left.updatedBucket],
@@ -296,14 +304,39 @@ export function sortHistoryItems(
     case "title-asc":
       return items
         .slice()
-        .sort((left, right) => left.title.localeCompare(right.title));
+        .sort(
+          (left, right) =>
+            comparePinnedHistoryItems(left, right) ||
+            left.title.localeCompare(right.title),
+        );
     case "title-desc":
       return items
         .slice()
-        .sort((left, right) => right.title.localeCompare(left.title));
+        .sort(
+          (left, right) =>
+            comparePinnedHistoryItems(left, right) ||
+            right.title.localeCompare(left.title),
+        );
     case "relevance":
       return sortHistoryItems(items, "recent");
   }
+}
+
+/** Stable pinned-first partition for relevance-ranked search results. */
+export function prioritizePinnedHistoryItems(
+  items: ReadonlyArray<HistoryItem>,
+): ReadonlyArray<HistoryItem> {
+  return items
+    .slice()
+    .sort((left, right) => comparePinnedHistoryItems(left, right));
+}
+
+function comparePinnedHistoryItems(
+  left: HistoryItem,
+  right: HistoryItem,
+): number {
+  if (left.isPinned === right.isPinned) return 0;
+  return left.isPinned ? -1 : 1;
 }
 
 export function groupHistoryItems(
@@ -348,7 +381,7 @@ function toStartOfDay(timestamp: number): number {
   return date.getTime();
 }
 
-function readTaskRepos(task: TaskLight): ReadonlyArray<string> {
+function readTaskRepos(task: ListTaskLight): ReadonlyArray<string> {
   const repos = task.epic?.repos ?? task.phase?.repos ?? [];
   return Array.from(
     new Set(
@@ -367,7 +400,7 @@ function readTaskRepos(task: TaskLight): ReadonlyArray<string> {
 }
 
 function readTaskWorkspaces(
-  task: TaskLight,
+  task: ListTaskLight,
 ): ReadonlyArray<HistoryWorkspaceRef> {
   const workspaces = task.epic?.workspaces ?? task.phase?.workspaces ?? [];
   const unique = new Map<string, HistoryWorkspaceRef>();

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx
@@ -222,6 +222,48 @@ describe("useEpicCreate", () => {
     ).toEqual(["old"]);
   });
 
+  it("keeps pinned cached tasks ahead of a newly created task", () => {
+    const queryClient = new QueryClient();
+    const pinnedTask = {
+      ...makeTask({
+        id: "pinned",
+        title: "Pinned epic",
+        createdBy: "user-1",
+        updatedAt: 1,
+        repos: [],
+        workspaces: [],
+      }),
+      pinned: true,
+    };
+    const createdTask = makeTask({
+      id: "new",
+      title: "New epic",
+      createdBy: "user-1",
+      updatedAt: 2,
+      repos: [],
+      workspaces: [],
+    });
+    const queryKey = cloudEpicTasksQueryKey(
+      "host-1",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    queryClient.setQueryData<ListTasksResponse>(queryKey, {
+      tasks: [pinnedTask],
+      hasMore: false,
+    });
+    renderHook(() => useEpicCreate(), { wrapper: makeWrapper(queryClient) });
+    const options = testState.capturedOptions;
+    if (options === null) throw new Error("expected mutation options");
+
+    options.onSuccess({ task: createdTask }, {}, options.onMutate());
+
+    expect(taskIds(queryClient.getQueryData(queryKey))).toEqual([
+      "pinned",
+      "new",
+    ]);
+  });
+
   it("patches cached facets only when the created task matches the cache request", () => {
     const queryClient = new QueryClient({
       defaultOptions: {

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-set-pinned-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-set-pinned-mutation.test.tsx
@@ -49,7 +49,11 @@ let capturedOptions: {
     epicId: string;
     pinned: boolean;
   }) => MutationContext;
-  onSuccess?: unknown;
+  onSuccess?: (
+    response: { pinned: boolean },
+    variables: { epicId: string; pinned: boolean },
+    context: MutationContext,
+  ) => Promise<void>;
   onError?: (
     error: unknown,
     variables: { epicId: string; pinned: boolean },
@@ -190,7 +194,8 @@ describe("useEpicSetPinned", () => {
     const pages = useCloudEpicTasksPagesStore.getState().pagesByIdentity;
     expect(pinnedById(pages[scopedIdentity][0])).toEqual({ "epic-1": true });
     expect(pinnedById(pages[otherIdentity][0])).toEqual({ "epic-1": false });
-    // No reset: the tails stay retained and their generations untouched.
+    // Mutate time only patches - the tails stay retained (and generations
+    // untouched) until the success handler resets the scope's pagination.
     expect(useCloudEpicTasksPagesStore.getState().generationByIdentity).toEqual(
       {},
     );
@@ -246,12 +251,14 @@ describe("useEpicSetPinned", () => {
     expect(toast.error).toHaveBeenCalledWith("Couldn't update pinned task.");
   });
 
-  it("leaves every cache untouched when the mutation scope is null", () => {
+  it("leaves every cache untouched when the mutation scope is null", async () => {
     // A signed-out or host-swapping window can leave onMutate's captured
-    // scope null; the optimistic patch and the error revert must both no-op
-    // rather than touch an unrelated scope.
+    // scope null; the optimistic patch, the success reconciliation, and the
+    // error revert must all no-op rather than touch an unrelated scope.
     testState.activeHostId = null;
     const queryClient = new QueryClient();
+    const removeQueries = vi.spyOn(queryClient, "removeQueries");
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
     const scopedQueryKey = cloudEpicTasksQueryKey(
       "host-1",
       "user-1",
@@ -274,6 +281,14 @@ describe("useEpicSetPinned", () => {
       "epic-1": false,
     });
 
+    await capturedOptions.onSuccess?.(
+      { pinned: true },
+      { epicId: "epic-1", pinned: true },
+      { hostId: null, userId: null },
+    );
+    expect(removeQueries).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
+
     capturedOptions.onError?.(
       { code: "RPC_ERROR", message: "test", fatalDetails: null },
       { epicId: "epic-1", pinned: true },
@@ -285,14 +300,67 @@ describe("useEpicSetPinned", () => {
     expect(toast.error).toHaveBeenCalledWith("Couldn't update pinned task.");
   });
 
-  it("registers no success handler - the optimistic patch is the final state", () => {
+  it("resets the scope's pagination and refreshes the first page on success", async () => {
+    // The committed reorder crosses server page boundaries, so retained
+    // cursors are stale: success must drop the scope's tails (advancing
+    // their generations so in-flight ones are rejected), remove the scope's
+    // inactive first pages, and refetch the active ones - all without
+    // disturbing other scopes or the already-correct optimistic display.
+    const queryClient = new QueryClient();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    const scopedQueryKey = cloudEpicTasksQueryKey(
+      "host-1",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    const otherQueryKey = cloudEpicTasksQueryKey(
+      "host-2",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    queryClient.setQueryData(
+      scopedQueryKey,
+      pageWith([epicTask("epic-1", true)]),
+    );
+    queryClient.setQueryData(
+      otherQueryKey,
+      pageWith([epicTask("epic-1", false)]),
+    );
+    const scopedIdentity = "host-1|user-1|recent";
+    const otherIdentity = "host-2|user-1|recent";
+    const pagesStore = useCloudEpicTasksPagesStore.getState();
+    pagesStore.appendPage(
+      scopedIdentity,
+      cloudEpicTasksPageGeneration(scopedIdentity),
+      pageWith([epicTask("epic-1", true)]),
+    );
+    pagesStore.appendPage(
+      otherIdentity,
+      cloudEpicTasksPageGeneration(otherIdentity),
+      pageWith([epicTask("epic-1", false)]),
+    );
     renderHook(() => useEpicSetPinned(), {
-      wrapper: makeWrapper(new QueryClient()),
+      wrapper: makeWrapper(queryClient),
     });
 
-    // The response carries exactly the bit the request wrote, so success
-    // needs no invalidation, refetch, or pagination reset.
-    expect(capturedOptions.onSuccess).toBeUndefined();
+    await capturedOptions.onSuccess?.(
+      { pinned: true },
+      { epicId: "epic-1", pinned: true },
+      { hostId: "host-1", userId: "user-1" },
+    );
+
+    const state = useCloudEpicTasksPagesStore.getState();
+    expect(state.pagesByIdentity[scopedIdentity]).toBeUndefined();
+    expect(cloudEpicTasksPageGeneration(scopedIdentity)).toBe(1);
+    expect(state.pagesByIdentity[otherIdentity]).toBeDefined();
+    expect(cloudEpicTasksPageGeneration(otherIdentity)).toBe(0);
+    // These seeded queries have no observers, so they are inactive - the
+    // scoped one is removed outright while the other scope is retained.
+    expect(queryClient.getQueryData(scopedQueryKey)).toBeUndefined();
+    expect(queryClient.getQueryData(otherQueryKey)).toBeDefined();
+    expect(invalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "active" }),
+    );
   });
 
   it("shows the host error fallback", () => {

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-set-pinned-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-set-pinned-mutation.test.tsx
@@ -7,7 +7,10 @@ import {
 } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
-import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
+import type {
+  ListTaskLight,
+  ListTasksResponse,
+} from "@traycer/protocol/host/epic/unary-schemas";
 import {
   LIST_CLOUD_TASKS_REQUEST,
   cloudEpicTasksQueryKey,
@@ -21,10 +24,13 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
-const testState = vi.hoisted(() => ({
-  activeHostId: "host-1",
-  userId: "user-1",
-}));
+const testState = vi.hoisted(() => {
+  const state: { activeHostId: string | null; userId: string | null } = {
+    activeHostId: "host-1",
+    userId: "user-1",
+  };
+  return state;
+});
 
 vi.mock("@/lib/host/runtime", () => ({
   useHostClient: () => ({
@@ -39,13 +45,16 @@ interface MutationContext {
 }
 
 let capturedOptions: {
-  onMutate?: () => MutationContext;
-  onSuccess?: (
-    response: { pinned: boolean },
+  onMutate?: (variables: {
+    epicId: string;
+    pinned: boolean;
+  }) => MutationContext;
+  onSuccess?: unknown;
+  onError?: (
+    error: unknown,
     variables: { epicId: string; pinned: boolean },
-    context: MutationContext,
-  ) => Promise<void>;
-  onError?: (error: unknown) => void;
+    context: MutationContext | undefined,
+  ) => void;
 } = {};
 
 vi.mock("@/hooks/host/use-host-query", () => ({
@@ -61,7 +70,48 @@ import {
 } from "@/hooks/epic/use-epic-set-pinned-mutation";
 import { epicMutationKeys } from "@/lib/query-keys";
 
-const PAGE: ListTasksResponse = { tasks: [], hasMore: false };
+function epicTask(epicId: string, pinned: boolean): ListTaskLight {
+  return {
+    epic: {
+      light: {
+        id: epicId,
+        title: `Epic ${epicId}`,
+        initialUserPrompt: "",
+        ticketCount: 0,
+        specCount: 0,
+        storyCount: 0,
+        reviewCount: 0,
+        status: "in_progress",
+        createdAt: 0,
+        updatedAt: 0,
+        createdBy: "user-1",
+        version: "1",
+      },
+      permission: null,
+      repos: [],
+      workspaces: [],
+      roomInfo: null,
+    },
+    phase: null,
+    pinned,
+  };
+}
+
+function pageWith(tasks: readonly ListTaskLight[]): ListTasksResponse {
+  return { tasks: [...tasks], hasMore: false };
+}
+
+function pinnedById(
+  response: ListTasksResponse | undefined,
+): Record<string, boolean | undefined> {
+  return Object.fromEntries(
+    (response?.tasks ?? []).flatMap((task) =>
+      task.epic?.light?.id === undefined
+        ? []
+        : [[task.epic.light.id, task.pinned]],
+    ),
+  );
+}
 
 interface SetPinnedVariables {
   readonly epicId: string;
@@ -79,13 +129,15 @@ describe("useEpicSetPinned", () => {
   beforeEach(() => {
     capturedOptions = {};
     vi.clearAllMocks();
+    testState.activeHostId = "host-1";
+    testState.userId = "user-1";
     useCloudEpicTasksPagesStore.setState({
       pagesByIdentity: {},
       generationByIdentity: {},
     });
   });
 
-  it("drops stale scoped pages and inactive history queries after success", async () => {
+  it("optimistically flips the row in the scoped first page and tails on mutate, leaving other scopes alone", () => {
     const queryClient = new QueryClient();
     const scopedQueryKey = cloudEpicTasksQueryKey(
       "host-1",
@@ -97,59 +149,150 @@ describe("useEpicSetPinned", () => {
       "user-1",
       LIST_CLOUD_TASKS_REQUEST,
     );
-    queryClient.setQueryData(scopedQueryKey, PAGE);
-    queryClient.setQueryData(otherQueryKey, PAGE);
+    queryClient.setQueryData(
+      scopedQueryKey,
+      pageWith([epicTask("epic-1", false), epicTask("epic-other", true)]),
+    );
+    queryClient.setQueryData(
+      otherQueryKey,
+      pageWith([epicTask("epic-1", false)]),
+    );
     const scopedIdentity = "host-1|user-1|recent";
     const otherIdentity = "host-2|user-1|recent";
     const pagesStore = useCloudEpicTasksPagesStore.getState();
     pagesStore.appendPage(
       scopedIdentity,
       cloudEpicTasksPageGeneration(scopedIdentity),
-      PAGE,
+      pageWith([epicTask("epic-1", false)]),
     );
     pagesStore.appendPage(
       otherIdentity,
       cloudEpicTasksPageGeneration(otherIdentity),
-      PAGE,
+      pageWith([epicTask("epic-1", false)]),
     );
     renderHook(() => useEpicSetPinned(), {
       wrapper: makeWrapper(queryClient),
     });
 
-    await capturedOptions.onSuccess?.(
-      { pinned: true },
-      { epicId: "epic-1", pinned: true },
-      capturedOptions.onMutate?.() ?? { hostId: null, userId: null },
-    );
+    const context = capturedOptions.onMutate?.({
+      epicId: "epic-1",
+      pinned: true,
+    });
 
-    expect(queryClient.getQueryData(scopedQueryKey)).toBeUndefined();
-    expect(queryClient.getQueryData(otherQueryKey)).toEqual(PAGE);
-    expect(
-      useCloudEpicTasksPagesStore.getState().pagesByIdentity[scopedIdentity],
-    ).toBeUndefined();
-    expect(
-      useCloudEpicTasksPagesStore.getState().pagesByIdentity[otherIdentity],
-    ).toEqual([PAGE]);
+    expect(context).toEqual({ hostId: "host-1", userId: "user-1" });
+    expect(pinnedById(queryClient.getQueryData(scopedQueryKey))).toEqual({
+      "epic-1": true,
+      "epic-other": true,
+    });
+    expect(pinnedById(queryClient.getQueryData(otherQueryKey))).toEqual({
+      "epic-1": false,
+    });
+    const pages = useCloudEpicTasksPagesStore.getState().pagesByIdentity;
+    expect(pinnedById(pages[scopedIdentity][0])).toEqual({ "epic-1": true });
+    expect(pinnedById(pages[otherIdentity][0])).toEqual({ "epic-1": false });
+    // No reset: the tails stay retained and their generations untouched.
+    expect(useCloudEpicTasksPagesStore.getState().generationByIdentity).toEqual(
+      {},
+    );
   });
 
-  it("leaves the cache untouched when the mutation resolves with a null scope", async () => {
+  it("reverts the optimistic patch and toasts when the RPC fails", () => {
     const queryClient = new QueryClient();
-    const removeQueries = vi.spyOn(queryClient, "removeQueries");
-    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    const scopedQueryKey = cloudEpicTasksQueryKey(
+      "host-1",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    queryClient.setQueryData(
+      scopedQueryKey,
+      pageWith([epicTask("epic-1", false)]),
+    );
+    const scopedIdentity = "host-1|user-1|recent";
+    useCloudEpicTasksPagesStore
+      .getState()
+      .appendPage(
+        scopedIdentity,
+        cloudEpicTasksPageGeneration(scopedIdentity),
+        pageWith([epicTask("epic-1", false)]),
+      );
     renderHook(() => useEpicSetPinned(), {
       wrapper: makeWrapper(queryClient),
     });
 
-    // A host swap can leave `onMutate`'s captured scope null; the success
-    // handler must then no-op rather than reset/invalidate an unrelated scope.
-    await capturedOptions.onSuccess?.(
-      { pinned: true },
+    const context = capturedOptions.onMutate?.({
+      epicId: "epic-1",
+      pinned: true,
+    });
+    expect(pinnedById(queryClient.getQueryData(scopedQueryKey))).toEqual({
+      "epic-1": true,
+    });
+
+    capturedOptions.onError?.(
+      { code: "RPC_ERROR", message: "test", fatalDetails: null },
       { epicId: "epic-1", pinned: true },
-      { hostId: null, userId: null },
+      context,
     );
 
-    expect(removeQueries).not.toHaveBeenCalled();
-    expect(invalidateQueries).not.toHaveBeenCalled();
+    expect(pinnedById(queryClient.getQueryData(scopedQueryKey))).toEqual({
+      "epic-1": false,
+    });
+    expect(
+      pinnedById(
+        useCloudEpicTasksPagesStore.getState().pagesByIdentity[
+          scopedIdentity
+        ][0],
+      ),
+    ).toEqual({ "epic-1": false });
+    expect(toast.error).toHaveBeenCalledWith("Couldn't update pinned task.");
+  });
+
+  it("leaves every cache untouched when the mutation scope is null", () => {
+    // A signed-out or host-swapping window can leave onMutate's captured
+    // scope null; the optimistic patch and the error revert must both no-op
+    // rather than touch an unrelated scope.
+    testState.activeHostId = null;
+    const queryClient = new QueryClient();
+    const scopedQueryKey = cloudEpicTasksQueryKey(
+      "host-1",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    queryClient.setQueryData(
+      scopedQueryKey,
+      pageWith([epicTask("epic-1", false)]),
+    );
+    renderHook(() => useEpicSetPinned(), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    const context = capturedOptions.onMutate?.({
+      epicId: "epic-1",
+      pinned: true,
+    });
+    expect(context).toEqual({ hostId: null, userId: "user-1" });
+    expect(pinnedById(queryClient.getQueryData(scopedQueryKey))).toEqual({
+      "epic-1": false,
+    });
+
+    capturedOptions.onError?.(
+      { code: "RPC_ERROR", message: "test", fatalDetails: null },
+      { epicId: "epic-1", pinned: true },
+      context,
+    );
+    expect(pinnedById(queryClient.getQueryData(scopedQueryKey))).toEqual({
+      "epic-1": false,
+    });
+    expect(toast.error).toHaveBeenCalledWith("Couldn't update pinned task.");
+  });
+
+  it("registers no success handler - the optimistic patch is the final state", () => {
+    renderHook(() => useEpicSetPinned(), {
+      wrapper: makeWrapper(new QueryClient()),
+    });
+
+    // The response carries exactly the bit the request wrote, so success
+    // needs no invalidation, refetch, or pagination reset.
+    expect(capturedOptions.onSuccess).toBeUndefined();
   });
 
   it("shows the host error fallback", () => {
@@ -157,11 +300,11 @@ describe("useEpicSetPinned", () => {
       wrapper: makeWrapper(new QueryClient()),
     });
 
-    capturedOptions.onError?.({
-      code: "RPC_ERROR",
-      message: "test",
-      fatalDetails: null,
-    });
+    capturedOptions.onError?.(
+      { code: "RPC_ERROR", message: "test", fatalDetails: null },
+      { epicId: "epic-1", pinned: true },
+      undefined,
+    );
 
     expect(toast.error).toHaveBeenCalledWith("Couldn't update pinned task.");
   });

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-set-pinned-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-set-pinned-mutation.test.tsx
@@ -132,6 +132,26 @@ describe("useEpicSetPinned", () => {
     ).toEqual([PAGE]);
   });
 
+  it("leaves the cache untouched when the mutation resolves with a null scope", async () => {
+    const queryClient = new QueryClient();
+    const removeQueries = vi.spyOn(queryClient, "removeQueries");
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    renderHook(() => useEpicSetPinned(), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    // A host swap can leave `onMutate`'s captured scope null; the success
+    // handler must then no-op rather than reset/invalidate an unrelated scope.
+    await capturedOptions.onSuccess?.(
+      { pinned: true },
+      { epicId: "epic-1", pinned: true },
+      { hostId: null, userId: null },
+    );
+
+    expect(removeQueries).not.toHaveBeenCalled();
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+
   it("shows the host error fallback", () => {
     renderHook(() => useEpicSetPinned(), {
       wrapper: makeWrapper(new QueryClient()),

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-set-pinned-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-set-pinned-mutation.test.tsx
@@ -1,0 +1,205 @@
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+} from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
+import {
+  LIST_CLOUD_TASKS_REQUEST,
+  cloudEpicTasksQueryKey,
+} from "@/lib/cloud-epic-tasks-query";
+import {
+  cloudEpicTasksPageGeneration,
+  useCloudEpicTasksPagesStore,
+} from "@/stores/epics/cloud-epic-tasks-pages-store";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const testState = vi.hoisted(() => ({
+  activeHostId: "host-1",
+  userId: "user-1",
+}));
+
+vi.mock("@/lib/host/runtime", () => ({
+  useHostClient: () => ({
+    getActiveHostId: () => testState.activeHostId,
+    getRequestContextUserId: () => testState.userId,
+  }),
+}));
+
+interface MutationContext {
+  readonly hostId: string | null;
+  readonly userId: string | null;
+}
+
+let capturedOptions: {
+  onMutate?: () => MutationContext;
+  onSuccess?: (
+    response: { pinned: boolean },
+    variables: { epicId: string; pinned: boolean },
+    context: MutationContext,
+  ) => Promise<void>;
+  onError?: (error: unknown) => void;
+} = {};
+
+vi.mock("@/hooks/host/use-host-query", () => ({
+  useHostMutation: (args: { options: typeof capturedOptions }) => {
+    capturedOptions = args.options;
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
+
+import {
+  useEpicSetPinned,
+  usePendingSetPinnedEpicIds,
+} from "@/hooks/epic/use-epic-set-pinned-mutation";
+import { epicMutationKeys } from "@/lib/query-keys";
+
+const PAGE: ListTasksResponse = { tasks: [], hasMore: false };
+
+interface SetPinnedVariables {
+  readonly epicId: string;
+  readonly pinned: boolean;
+}
+
+function makeWrapper(
+  queryClient: QueryClient,
+): ({ children }: { readonly children: ReactNode }) => ReactNode {
+  return ({ children }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe("useEpicSetPinned", () => {
+  beforeEach(() => {
+    capturedOptions = {};
+    vi.clearAllMocks();
+    useCloudEpicTasksPagesStore.setState({
+      pagesByIdentity: {},
+      generationByIdentity: {},
+    });
+  });
+
+  it("drops stale scoped pages and inactive history queries after success", async () => {
+    const queryClient = new QueryClient();
+    const scopedQueryKey = cloudEpicTasksQueryKey(
+      "host-1",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    const otherQueryKey = cloudEpicTasksQueryKey(
+      "host-2",
+      "user-1",
+      LIST_CLOUD_TASKS_REQUEST,
+    );
+    queryClient.setQueryData(scopedQueryKey, PAGE);
+    queryClient.setQueryData(otherQueryKey, PAGE);
+    const scopedIdentity = "host-1|user-1|recent";
+    const otherIdentity = "host-2|user-1|recent";
+    const pagesStore = useCloudEpicTasksPagesStore.getState();
+    pagesStore.appendPage(
+      scopedIdentity,
+      cloudEpicTasksPageGeneration(scopedIdentity),
+      PAGE,
+    );
+    pagesStore.appendPage(
+      otherIdentity,
+      cloudEpicTasksPageGeneration(otherIdentity),
+      PAGE,
+    );
+    renderHook(() => useEpicSetPinned(), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await capturedOptions.onSuccess?.(
+      { pinned: true },
+      { epicId: "epic-1", pinned: true },
+      capturedOptions.onMutate?.() ?? { hostId: null, userId: null },
+    );
+
+    expect(queryClient.getQueryData(scopedQueryKey)).toBeUndefined();
+    expect(queryClient.getQueryData(otherQueryKey)).toEqual(PAGE);
+    expect(
+      useCloudEpicTasksPagesStore.getState().pagesByIdentity[scopedIdentity],
+    ).toBeUndefined();
+    expect(
+      useCloudEpicTasksPagesStore.getState().pagesByIdentity[otherIdentity],
+    ).toEqual([PAGE]);
+  });
+
+  it("shows the host error fallback", () => {
+    renderHook(() => useEpicSetPinned(), {
+      wrapper: makeWrapper(new QueryClient()),
+    });
+
+    capturedOptions.onError?.({
+      code: "RPC_ERROR",
+      message: "test",
+      fatalDetails: null,
+    });
+
+    expect(toast.error).toHaveBeenCalledWith("Couldn't update pinned task.");
+  });
+});
+
+describe("usePendingSetPinnedEpicIds", () => {
+  it("tracks two concurrently pending epics independently and drops each as its own mutation settles", async () => {
+    // A real `useMutation` sharing `epicMutationKeys.setPinned()` stands in
+    // for two rows calling the same shared `useEpicSetPinned()` instance -
+    // the mutation cache (not this local observer) is what the hook under
+    // test reads from.
+    const resolvers = new Map<string, (value: { pinned: boolean }) => void>();
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    });
+
+    const { result } = renderHook(
+      () => {
+        const mutation = useMutation({
+          mutationKey: epicMutationKeys.setPinned(),
+          mutationFn: (variables: SetPinnedVariables) =>
+            new Promise<{ pinned: boolean }>((resolve) => {
+              resolvers.set(variables.epicId, resolve);
+            }),
+        });
+        return {
+          mutate: mutation.mutate,
+          pending: usePendingSetPinnedEpicIds(),
+        };
+      },
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    act(() => {
+      result.current.mutate({ epicId: "epic-a", pinned: true });
+      result.current.mutate({ epicId: "epic-b", pinned: false });
+    });
+
+    await waitFor(() => {
+      expect(result.current.pending).toEqual(new Set(["epic-a", "epic-b"]));
+    });
+
+    await act(async () => {
+      resolvers.get("epic-a")?.({ pinned: true });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.pending).toEqual(new Set(["epic-b"]));
+    });
+
+    await act(async () => {
+      resolvers.get("epic-b")?.({ pinned: false });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.pending.size).toBe(0);
+    });
+  });
+});

--- a/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
@@ -11,6 +11,7 @@ import type {
 import type {
   ListTasksFacets,
   ListTasksResponse,
+  ListTaskLight,
   ListTasksSort,
   TaskLight,
   TaskRepoIdentifier,
@@ -134,14 +135,18 @@ function mergeTaskIntoCloudTasksResponse(
     (existing) => taskProjection(existing)?.id === incomingProjection.id,
   );
   const taskToMerge = taskWithPreferredEpicTitle(task, existingTask);
-  const projection = taskProjection(taskToMerge);
+  const listTaskToMerge: ListTaskLight = {
+    ...taskToMerge,
+    pinned: existingTask?.pinned ?? false,
+  };
+  const projection = taskProjection(listTaskToMerge);
   if (projection === null) return response;
   if (!taskProjectionMatchesRequest(projection, request, userId)) {
     return response;
   }
   const tasks = response.tasks
     .filter((existing) => taskProjection(existing)?.id !== projection.id)
-    .concat(taskToMerge)
+    .concat(listTaskToMerge)
     .sort((left, right) =>
       compareTaskLights(
         left,
@@ -492,11 +497,14 @@ function taskWorkspaces(task: TaskLight): readonly TaskWorkspaceIdentifier[] {
 }
 
 function compareTaskLights(
-  left: TaskLight,
-  right: TaskLight,
+  left: ListTaskLight,
+  right: ListTaskLight,
   sort: ListTasksSort,
   query: string | null,
 ): number {
+  const leftPinned = left.pinned ?? false;
+  const rightPinned = right.pinned ?? false;
+  if (leftPinned !== rightPinned) return leftPinned ? -1 : 1;
   const leftProjection = taskProjection(left);
   const rightProjection = taskProjection(right);
   if (leftProjection === null || rightProjection === null) return 0;

--- a/clients/gui-app/src/hooks/epic/use-epic-set-pinned-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-set-pinned-mutation.ts
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+import { useMutationState, useQueryClient } from "@tanstack/react-query";
+import { useHostMutation } from "@/hooks/host/use-host-query";
+import { useHostClient } from "@/lib/host";
+import { toastFromHostError } from "@/lib/host-error-toast";
+import { cloudEpicTasksQueryKeyMatchesScope } from "@/lib/cloud-epic-tasks-query/cache";
+import { epicMutationKeys } from "@/lib/query-keys";
+import { resetCloudEpicTasksPagesForScope } from "@/stores/epics/cloud-epic-tasks-pages-store";
+
+interface SetEpicPinnedMutationContext {
+  readonly hostId: string | null;
+  readonly userId: string | null;
+}
+
+interface SetEpicPinnedVariables {
+  readonly epicId: string;
+  readonly pinned: boolean;
+}
+
+/** Personal, default-host-scoped history pin mutation. */
+export function useEpicSetPinned() {
+  const client = useHostClient();
+  const queryClient = useQueryClient();
+  return useHostMutation({
+    client,
+    method: "epic.setPinned",
+    mapVariables: (variables) => variables,
+    options: {
+      mutationKey: epicMutationKeys.setPinned(),
+      onMutate: () => ({
+        hostId: client.getActiveHostId(),
+        userId: client.getRequestContextUserId(),
+      }),
+      onSuccess: async (
+        _response,
+        _variables,
+        ctx: SetEpicPinnedMutationContext,
+      ) => {
+        if (ctx.hostId === null || ctx.userId === null) return;
+        const scope = { hostId: ctx.hostId, userId: ctx.userId };
+        resetCloudEpicTasksPagesForScope(ctx.hostId, ctx.userId);
+        queryClient.removeQueries({
+          type: "inactive",
+          predicate: (query) =>
+            cloudEpicTasksQueryKeyMatchesScope(query.queryKey, scope),
+        });
+        await queryClient.invalidateQueries({
+          type: "active",
+          predicate: (query) =>
+            cloudEpicTasksQueryKeyMatchesScope(query.queryKey, scope),
+        });
+      },
+      onError: (error) => {
+        toastFromHostError(error, "Couldn't update pinned task.");
+      },
+    },
+  });
+}
+
+/**
+ * epicIds with an in-flight `epic.setPinned` mutation. `useEpicSetPinned()`
+ * is a single mutation instance shared across every history row, so reading
+ * `.isPending`/`.variables` off it only ever reflects the most-recently
+ * fired call - a second row's click would make an earlier still-pending row
+ * read as idle. Reading every pending mutation with this shared key from the
+ * mutation cache instead lets each row track its own request independently.
+ */
+export function usePendingSetPinnedEpicIds(): ReadonlySet<string> {
+  const pendingVariables = useMutationState({
+    filters: {
+      mutationKey: epicMutationKeys.setPinned(),
+      status: "pending",
+    },
+    select: (mutation) => mutation.state.variables,
+  });
+
+  return useMemo(
+    () =>
+      new Set(
+        pendingVariables.flatMap((variables) =>
+          isSetEpicPinnedVariables(variables) ? [variables.epicId] : [],
+        ),
+      ),
+    [pendingVariables],
+  );
+}
+
+function isSetEpicPinnedVariables(
+  value: unknown,
+): value is SetEpicPinnedVariables {
+  if (value === null || typeof value !== "object") return false;
+  return (
+    "epicId" in value &&
+    typeof value.epicId === "string" &&
+    "pinned" in value &&
+    typeof value.pinned === "boolean"
+  );
+}

--- a/clients/gui-app/src/hooks/epic/use-epic-set-pinned-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-set-pinned-mutation.ts
@@ -1,11 +1,15 @@
 import { useMemo } from "react";
-import { useMutationState, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutationState,
+  useQueryClient,
+  type QueryClient,
+} from "@tanstack/react-query";
 import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient } from "@/lib/host";
 import { toastFromHostError } from "@/lib/host-error-toast";
-import { cloudEpicTasksQueryKeyMatchesScope } from "@/lib/cloud-epic-tasks-query/cache";
+import { setEpicPinnedInCloudTaskCaches } from "@/lib/cloud-epic-tasks-query/cache";
 import { epicMutationKeys } from "@/lib/query-keys";
-import { resetCloudEpicTasksPagesForScope } from "@/stores/epics/cloud-epic-tasks-pages-store";
+import { setCloudEpicTasksPagePinned } from "@/stores/epics/cloud-epic-tasks-pages-store";
 
 interface SetEpicPinnedMutationContext {
   readonly hostId: string | null;
@@ -17,7 +21,18 @@ interface SetEpicPinnedVariables {
   readonly pinned: boolean;
 }
 
-/** Personal, default-host-scoped history pin mutation. */
+/**
+ * Personal, default-host-scoped history pin mutation.
+ *
+ * Optimistic by design (the justified response-equals-state case: the RPC's
+ * `{ pinned }` response is exactly the bit the request wrote, so a patched
+ * cache already equals the server outcome on success): `onMutate` flips the
+ * row in the scoped first-page query cache and in every retained "Show more"
+ * tail, the RPC settles in the background with no success-path invalidation
+ * or refetch, and `onError` restores the previous state with the inverse
+ * patch (each row's control is disabled while its own mutation is pending,
+ * so the pre-mutate state is exactly the opposite bit) plus the error toast.
+ */
 export function useEpicSetPinned() {
   const client = useHostClient();
   const queryClient = useQueryClient();
@@ -27,34 +42,48 @@ export function useEpicSetPinned() {
     mapVariables: (variables) => variables,
     options: {
       mutationKey: epicMutationKeys.setPinned(),
-      onMutate: () => ({
-        hostId: client.getActiveHostId(),
-        userId: client.getRequestContextUserId(),
-      }),
-      onSuccess: async (
-        _response,
-        _variables,
-        ctx: SetEpicPinnedMutationContext,
-      ) => {
-        if (ctx.hostId === null || ctx.userId === null) return;
-        const scope = { hostId: ctx.hostId, userId: ctx.userId };
-        resetCloudEpicTasksPagesForScope(ctx.hostId, ctx.userId);
-        queryClient.removeQueries({
-          type: "inactive",
-          predicate: (query) =>
-            cloudEpicTasksQueryKeyMatchesScope(query.queryKey, scope),
-        });
-        await queryClient.invalidateQueries({
-          type: "active",
-          predicate: (query) =>
-            cloudEpicTasksQueryKeyMatchesScope(query.queryKey, scope),
-        });
+      onMutate: (
+        variables: SetEpicPinnedVariables,
+      ): SetEpicPinnedMutationContext => {
+        const hostId = client.getActiveHostId();
+        const userId = client.getRequestContextUserId();
+        if (hostId !== null && userId !== null) {
+          applyPinnedPatch(
+            queryClient,
+            { hostId, userId },
+            variables.epicId,
+            variables.pinned,
+          );
+        }
+        return { hostId, userId };
       },
-      onError: (error) => {
+      onError: (
+        error,
+        variables: SetEpicPinnedVariables,
+        ctx: SetEpicPinnedMutationContext | undefined,
+      ) => {
+        if (ctx !== undefined && ctx.hostId !== null && ctx.userId !== null) {
+          applyPinnedPatch(
+            queryClient,
+            { hostId: ctx.hostId, userId: ctx.userId },
+            variables.epicId,
+            !variables.pinned,
+          );
+        }
         toastFromHostError(error, "Couldn't update pinned task.");
       },
     },
   });
+}
+
+function applyPinnedPatch(
+  queryClient: QueryClient,
+  scope: { readonly hostId: string; readonly userId: string },
+  epicId: string,
+  pinned: boolean,
+): void {
+  setEpicPinnedInCloudTaskCaches(queryClient, scope, epicId, pinned);
+  setCloudEpicTasksPagePinned(scope.hostId, scope.userId, epicId, pinned);
 }
 
 /**

--- a/clients/gui-app/src/hooks/epic/use-epic-set-pinned-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-set-pinned-mutation.ts
@@ -7,9 +7,15 @@ import {
 import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient } from "@/lib/host";
 import { toastFromHostError } from "@/lib/host-error-toast";
-import { setEpicPinnedInCloudTaskCaches } from "@/lib/cloud-epic-tasks-query/cache";
+import {
+  cloudEpicTasksQueryKeyMatchesScope,
+  setEpicPinnedInCloudTaskCaches,
+} from "@/lib/cloud-epic-tasks-query/cache";
 import { epicMutationKeys } from "@/lib/query-keys";
-import { setCloudEpicTasksPagePinned } from "@/stores/epics/cloud-epic-tasks-pages-store";
+import {
+  resetCloudEpicTasksPagesForScope,
+  setCloudEpicTasksPagePinned,
+} from "@/stores/epics/cloud-epic-tasks-pages-store";
 
 interface SetEpicPinnedMutationContext {
   readonly hostId: string | null;
@@ -25,13 +31,19 @@ interface SetEpicPinnedVariables {
  * Personal, default-host-scoped history pin mutation.
  *
  * Optimistic by design (the justified response-equals-state case: the RPC's
- * `{ pinned }` response is exactly the bit the request wrote, so a patched
- * cache already equals the server outcome on success): `onMutate` flips the
- * row in the scoped first-page query cache and in every retained "Show more"
- * tail, the RPC settles in the background with no success-path invalidation
- * or refetch, and `onError` restores the previous state with the inverse
- * patch (each row's control is disabled while its own mutation is pending,
- * so the pre-mutate state is exactly the opposite bit) plus the error toast.
+ * `{ pinned }` response is exactly the bit the request wrote): `onMutate`
+ * flips the row in the scoped first-page query cache and in every retained
+ * "Show more" tail so the toggle renders instantly, and `onError` restores
+ * the previous state with the inverse patch (each row's control is disabled
+ * while its own mutation is pending, so the pre-mutate state is exactly the
+ * opposite bit) plus the error toast.
+ *
+ * `onSuccess` then reconciles in the background: a pin reorders rows across
+ * server page boundaries, which makes every retained pagination cursor
+ * stale (a later "Show more" against an old cursor could silently skip
+ * rows), so the scope's tails are reset - rejecting in-flight ones via the
+ * generation guard - and the active first page refetches with no pending UI
+ * while the optimistic state keeps rendering.
  */
 export function useEpicSetPinned() {
   const client = useHostClient();
@@ -56,6 +68,25 @@ export function useEpicSetPinned() {
           );
         }
         return { hostId, userId };
+      },
+      onSuccess: async (
+        _response,
+        _variables,
+        ctx: SetEpicPinnedMutationContext,
+      ) => {
+        if (ctx.hostId === null || ctx.userId === null) return;
+        const scope = { hostId: ctx.hostId, userId: ctx.userId };
+        resetCloudEpicTasksPagesForScope(ctx.hostId, ctx.userId);
+        queryClient.removeQueries({
+          type: "inactive",
+          predicate: (query) =>
+            cloudEpicTasksQueryKeyMatchesScope(query.queryKey, scope),
+        });
+        await queryClient.invalidateQueries({
+          type: "active",
+          predicate: (query) =>
+            cloudEpicTasksQueryKeyMatchesScope(query.queryKey, scope),
+        });
       },
       onError: (
         error,

--- a/clients/gui-app/src/hooks/epics/__tests__/use-cloud-epic-tasks-query.test.tsx
+++ b/clients/gui-app/src/hooks/epics/__tests__/use-cloud-epic-tasks-query.test.tsx
@@ -89,7 +89,7 @@ describe("useCloudEpicTasksQuery", () => {
     });
   });
 
-  it("rejects a stale first-tail response that resolves after a pin/unpin scope reset lands mid-flight", async () => {
+  it("rejects a stale first-tail response that resolves after a scope reset lands mid-flight", async () => {
     const firstPage: ListTasksResponse = {
       tasks: [taskLight("epic-first", "First page task")],
       hasMore: true,
@@ -133,9 +133,8 @@ describe("useCloudEpicTasksQuery", () => {
       expect(result.current.isFetchingNextPage).toBe(true);
     });
 
-    // A pin/unpin mutation succeeds and resets the host/user scope while
-    // that tail request is still unresolved - mirrors `useEpicSetPinned`'s
-    // `onSuccess` calling `resetCloudEpicTasksPagesForScope`.
+    // A scope-level reset lands while that tail request is still
+    // unresolved.
     act(() => {
       resetCloudEpicTasksPagesForScope(HOST_ID, USER_ID);
     });
@@ -156,5 +155,57 @@ describe("useCloudEpicTasksQuery", () => {
 
     // The stale tail must not be appended to - or rendered in - the task list.
     expect(taskLightIds(result.current.tasks)).toEqual(["epic-first"]);
+  });
+
+  it("dedupes a row that appears in both the first page and a loaded tail, first page winning", async () => {
+    // An optimistic pin moves a row across server page boundaries: after the
+    // pin, a refetched first page carries the pinned row at the top while a
+    // previously loaded tail still carries it at its old position. The
+    // assembled list must render it once, from the first page.
+    const firstPage: ListTasksResponse = {
+      tasks: [taskLight("epic-first", "First page task")],
+      hasMore: true,
+      nextCursor: "cursor-a",
+    };
+    const tailPage: ListTasksResponse = {
+      tasks: [
+        taskLight("epic-first", "Duplicate of the first-page task"),
+        taskLight("epic-second", "Tail-only task"),
+      ],
+      hasMore: false,
+    };
+    mockHostClient.request.mockImplementation(
+      (_method: string, params: { readonly cursor: string | undefined }) =>
+        Promise.resolve(params.cursor === undefined ? firstPage : tailPage),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const { result } = renderHook(
+      () => useCloudEpicTasksQuery(LIST_CLOUD_TASKS_REQUEST, { enabled: true }),
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(taskLightIds(result.current.tasks)).toEqual(["epic-first"]);
+    });
+    act(() => {
+      result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(taskLightIds(result.current.tasks)).toEqual([
+        "epic-first",
+        "epic-second",
+      ]);
+    });
+    expect(
+      result.current.tasks.find((task) => task.epic?.light?.id === "epic-first")
+        ?.epic?.light?.title,
+    ).toBe("First page task");
   });
 });

--- a/clients/gui-app/src/hooks/epics/__tests__/use-cloud-epic-tasks-query.test.tsx
+++ b/clients/gui-app/src/hooks/epics/__tests__/use-cloud-epic-tasks-query.test.tsx
@@ -1,0 +1,160 @@
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type {
+  ListTaskLight,
+  ListTasksResponse,
+} from "@traycer/protocol/host/epic/unary-schemas";
+import { useCloudEpicTasksQuery } from "@/hooks/epics/use-cloud-epic-tasks-query";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import {
+  resetCloudEpicTasksPagesForScope,
+  useCloudEpicTasksPagesStore,
+} from "@/stores/epics/cloud-epic-tasks-pages-store";
+import { LIST_CLOUD_TASKS_REQUEST } from "@/lib/cloud-epic-tasks-query";
+
+const HOST_ID = "host-test";
+const USER_ID = "user-test";
+
+const mockHostClient = {
+  getActiveHostId: () => HOST_ID,
+  getRequestContextUserId: () => USER_ID,
+  onChange: () => () => undefined,
+  request: vi.fn(),
+};
+
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => mockHostClient,
+}));
+
+function makeWrapper(
+  queryClient: QueryClient,
+): ({ children }: { readonly children: ReactNode }) => ReactNode {
+  return ({ children }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+function taskLight(id: string, title: string): ListTaskLight {
+  return {
+    epic: {
+      light: {
+        id,
+        title,
+        initialUserPrompt: "",
+        ticketCount: 0,
+        specCount: 0,
+        storyCount: 0,
+        reviewCount: 0,
+        status: "draft",
+        createdAt: 0,
+        updatedAt: 0,
+        createdBy: USER_ID,
+        version: "1.0.0",
+      },
+      permission: null,
+      repos: [],
+      workspaces: [],
+      roomInfo: null,
+    },
+    phase: null,
+    pinned: false,
+  };
+}
+
+function taskLightIds(tasks: readonly ListTaskLight[]): ReadonlyArray<string> {
+  return tasks.flatMap((task) => {
+    const id = task.epic?.light?.id;
+    return id !== undefined ? [id] : [];
+  });
+}
+
+describe("useCloudEpicTasksQuery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCloudEpicTasksPagesStore.setState({
+      pagesByIdentity: {},
+      generationByIdentity: {},
+    });
+    useAuthStore.setState({
+      status: "signed-in",
+      profile: {
+        userId: USER_ID,
+        userName: "Test User",
+        email: "test@example.com",
+      },
+      contextMetadata: { userId: USER_ID, username: "test-user" },
+      shareableTeams: [],
+      subscriptionStatus: null,
+    });
+  });
+
+  it("rejects a stale first-tail response that resolves after a pin/unpin scope reset lands mid-flight", async () => {
+    const firstPage: ListTasksResponse = {
+      tasks: [taskLight("epic-first", "First page task")],
+      hasMore: true,
+      nextCursor: "cursor-a",
+    };
+    let resolveStaleTail: ((value: ListTasksResponse) => void) | undefined;
+    mockHostClient.request.mockImplementation(
+      (_method: string, params: { readonly cursor: string | undefined }) => {
+        if (params.cursor !== undefined) {
+          return new Promise<ListTasksResponse>((resolve) => {
+            resolveStaleTail = resolve;
+          });
+        }
+        return Promise.resolve(firstPage);
+      },
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const { result } = renderHook(
+      () => useCloudEpicTasksQuery(LIST_CLOUD_TASKS_REQUEST, { enabled: true }),
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(taskLightIds(result.current.tasks)).toEqual(["epic-first"]);
+    });
+    expect(result.current.hasNextPage).toBe(true);
+
+    // Start the FIRST "Show more" tail request for this identity through the
+    // production `fetchNextPage` - the exact call path review finding 2
+    // reproduced (`traycer/clients/gui-app/src/hooks/epics/use-cloud-epic-tasks-query.ts`).
+    act(() => {
+      result.current.fetchNextPage();
+    });
+    await waitFor(() => {
+      expect(result.current.isFetchingNextPage).toBe(true);
+    });
+
+    // A pin/unpin mutation succeeds and resets the host/user scope while
+    // that tail request is still unresolved - mirrors `useEpicSetPinned`'s
+    // `onSuccess` calling `resetCloudEpicTasksPagesForScope`.
+    act(() => {
+      resetCloudEpicTasksPagesForScope(HOST_ID, USER_ID);
+    });
+
+    // The stale tail finally resolves after the refreshed first page would
+    // have landed.
+    await act(async () => {
+      resolveStaleTail?.({
+        tasks: [taskLight("epic-stale", "Stale tail task")],
+        hasMore: false,
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isFetchingNextPage).toBe(false);
+    });
+
+    // The stale tail must not be appended to - or rendered in - the task list.
+    expect(taskLightIds(result.current.tasks)).toEqual(["epic-first"]);
+  });
+});

--- a/clients/gui-app/src/hooks/epics/use-cloud-epic-tasks-query.ts
+++ b/clients/gui-app/src/hooks/epics/use-cloud-epic-tasks-query.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from "react";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 import type {
   ListTasksResponse,
-  TaskLight,
+  ListTaskLight,
 } from "@traycer/protocol/host/epic/unary-schemas";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import { useAuthStore, type AuthStatus } from "@/stores/auth/auth-store";
@@ -12,6 +12,7 @@ import { toastFromHostError } from "@/lib/host-error-toast";
 import {
   useCloudEpicTasksPagesStore,
   cloudEpicTasksPageGeneration,
+  registerCloudEpicTasksPageIdentity,
 } from "@/stores/epics/cloud-epic-tasks-pages-store";
 import {
   LIST_CLOUD_TASKS_REQUEST,
@@ -34,14 +35,14 @@ interface NextPageVariables {
   readonly cursor: string;
 }
 
-const EMPTY_TASKS: readonly TaskLight[] = [];
+const EMPTY_TASKS: readonly ListTaskLight[] = [];
 const EMPTY_PAGES: readonly ListTasksResponse[] = [];
 const EMPTY_FIRST_PAGE: ListTasksResponse = { tasks: [], hasMore: false };
 
 export interface CloudEpicTasksQueryResult {
   readonly hostId: string | null;
   readonly currentUserId: string | null;
-  readonly tasks: readonly TaskLight[];
+  readonly tasks: readonly ListTaskLight[];
   readonly query: CloudEpicTasksFirstPageQuery;
   readonly fetchNextPage: () => void;
   readonly hasNextPage: boolean;
@@ -145,9 +146,9 @@ export function useCloudEpicTasksQuery(
     nextPageMutation.variables.identity === identity;
   const mutateNextPage = nextPageMutation.mutate;
 
-  const tasks = useMemo<readonly TaskLight[]>(() => {
+  const tasks = useMemo<readonly ListTaskLight[]>(() => {
     if (queryData === undefined) return EMPTY_TASKS;
-    const acc: TaskLight[] = [...queryData.tasks];
+    const acc: ListTaskLight[] = [...queryData.tasks];
     for (const page of extraPages) {
       acc.push(...page.tasks);
     }
@@ -167,6 +168,11 @@ export function useCloudEpicTasksQuery(
 
   const fetchNextPage = useCallback(() => {
     if (lastNextCursor === null || isFetchingNextPage) return;
+    // Register the identity before capturing its generation: a pin/unpin
+    // scope reset landing while this very first tail request for the
+    // identity is still in flight must have an entry to advance, or the
+    // stale response's captured generation would still match on arrival.
+    registerCloudEpicTasksPageIdentity(identity);
     mutateNextPage({
       identity,
       generation: cloudEpicTasksPageGeneration(identity),

--- a/clients/gui-app/src/hooks/epics/use-cloud-epic-tasks-query.ts
+++ b/clients/gui-app/src/hooks/epics/use-cloud-epic-tasks-query.ts
@@ -148,9 +148,21 @@ export function useCloudEpicTasksQuery(
 
   const tasks = useMemo<readonly ListTaskLight[]>(() => {
     if (queryData === undefined) return EMPTY_TASKS;
-    const acc: ListTaskLight[] = [...queryData.tasks];
-    for (const page of extraPages) {
-      acc.push(...page.tasks);
+    // Dedupe by task id, first occurrence wins (the first page outranks the
+    // tails): a personal pin moves a row across server page boundaries, so
+    // after a pin lands, a refetched first page or a still-in-flight tail
+    // can both carry a row the other already has.
+    const seenTaskIds = new Set<string>();
+    const acc: ListTaskLight[] = [];
+    for (const page of [queryData, ...extraPages]) {
+      for (const task of page.tasks) {
+        const taskId = task.epic?.light?.id ?? task.phase?.light?.id;
+        if (taskId !== undefined) {
+          if (seenTaskIds.has(taskId)) continue;
+          seenTaskIds.add(taskId);
+        }
+        acc.push(task);
+      }
     }
     return acc;
   }, [queryData, extraPages]);
@@ -168,10 +180,10 @@ export function useCloudEpicTasksQuery(
 
   const fetchNextPage = useCallback(() => {
     if (lastNextCursor === null || isFetchingNextPage) return;
-    // Register the identity before capturing its generation: a pin/unpin
-    // scope reset landing while this very first tail request for the
-    // identity is still in flight must have an entry to advance, or the
-    // stale response's captured generation would still match on arrival.
+    // Register the identity before capturing its generation: a scope reset
+    // landing while this very first tail request for the identity is still
+    // in flight must have an entry to advance, or the stale response's
+    // captured generation would still match on arrival.
     registerCloudEpicTasksPageIdentity(identity);
     mutateNextPage({
       identity,

--- a/clients/gui-app/src/hooks/epics/use-cloud-epic-tasks-query.ts
+++ b/clients/gui-app/src/hooks/epics/use-cloud-epic-tasks-query.ts
@@ -151,20 +151,18 @@ export function useCloudEpicTasksQuery(
     // Dedupe by task id, first occurrence wins (the first page outranks the
     // tails): a personal pin moves a row across server page boundaries, so
     // after a pin lands, a refetched first page or a still-in-flight tail
-    // can both carry a row the other already has.
+    // can both carry a row the other already has. A task with no id (neither
+    // epic nor phase) is always retained.
     const seenTaskIds = new Set<string>();
-    const acc: ListTaskLight[] = [];
-    for (const page of [queryData, ...extraPages]) {
-      for (const task of page.tasks) {
+    return [queryData, ...extraPages]
+      .flatMap((page) => page.tasks)
+      .filter((task) => {
         const taskId = task.epic?.light?.id ?? task.phase?.light?.id;
-        if (taskId !== undefined) {
-          if (seenTaskIds.has(taskId)) continue;
-          seenTaskIds.add(taskId);
-        }
-        acc.push(task);
-      }
-    }
-    return acc;
+        if (taskId === undefined) return true;
+        if (seenTaskIds.has(taskId)) return false;
+        seenTaskIds.add(taskId);
+        return true;
+      });
   }, [queryData, extraPages]);
 
   const lastPage: ListTasksResponse | undefined =

--- a/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
+++ b/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
@@ -185,6 +185,27 @@ describe("useHistoryQuery", () => {
     expect(screen.getByTestId("has-next-page").textContent).toBe("true");
   });
 
+  it("lifts an optimistically pinned row above unpinned rows in the settled server order", () => {
+    // An optimistic pin patch flips the cached row's bit in place, so the
+    // settled (non-projecting) path must partition pinned-first itself
+    // instead of trusting the raw cached order, which still reflects the
+    // pre-pin state.
+    testState.tasks = [
+      taskLight("epic-alpha", "Alpha workbench", "traycer/gui-app"),
+      {
+        ...taskLight("epic-beta", "Beta search flow", "traycer/server"),
+        pinned: true,
+      },
+    ];
+    testState.response = { tasks: testState.tasks, hasMore: false };
+
+    render(<HistoryQueryHarness search={DEFAULT_HISTORY_SEARCH} />);
+
+    expect(screen.getByTestId("titles").textContent).toBe(
+      "Beta search flow|Alpha workbench",
+    );
+  });
+
   it("floats pinned rows above a higher-relevance unpinned match under relevance sort", () => {
     // Relevance sort + a non-empty query is the only path that routes through
     // prioritizePinnedHistoryItems (use-history-query.ts). That local

--- a/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
+++ b/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ListTasksResponse,
-  TaskLight,
+  ListTaskLight,
 } from "@traycer/protocol/host/epic/unary-schemas";
 import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import {
@@ -14,7 +14,7 @@ import type { HistorySearchState } from "@/lib/history-search";
 import { useHistoryQuery } from "@/hooks/home/use-history-query";
 
 const testState = vi.hoisted(() => {
-  const tasks: TaskLight[] = [];
+  const tasks: ListTaskLight[] = [];
   const response: ListTasksResponse = {
     tasks,
     hasMore: false,
@@ -237,7 +237,7 @@ function HistoryQueryHarness(props: {
   );
 }
 
-function taskLight(id: string, title: string, repo: string): TaskLight {
+function taskLight(id: string, title: string, repo: string): ListTaskLight {
   const [owner, repoName] = repo.split("/");
   return {
     epic: {
@@ -270,6 +270,7 @@ function taskLight(id: string, title: string, repo: string): TaskLight {
       workspaces: [],
       roomInfo: null,
     },
+    pinned: false,
   };
 }
 

--- a/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
+++ b/clients/gui-app/src/hooks/home/__tests__/use-history-query.test.tsx
@@ -185,6 +185,36 @@ describe("useHistoryQuery", () => {
     expect(screen.getByTestId("has-next-page").textContent).toBe("true");
   });
 
+  it("floats pinned rows above a higher-relevance unpinned match under relevance sort", () => {
+    // Relevance sort + a non-empty query is the only path that routes through
+    // prioritizePinnedHistoryItems (use-history-query.ts). That local
+    // projection only runs while the cloud query is unsettled, so mark it
+    // fetching. The unpinned row is the exact-title match, so Fuse ranks it
+    // first; the pin must still lift its (weaker-matching) row above it.
+    testState.isFetching = true;
+    testState.tasks = [
+      taskLight("epic-exact", "search", "traycer/gui-app"),
+      {
+        ...taskLight("epic-pinned", "Beta search flow", "traycer/server"),
+        pinned: true,
+      },
+    ];
+    testState.response = { tasks: testState.tasks, hasMore: false };
+
+    render(
+      <HistoryQueryHarness
+        search={patchHistorySearch(DEFAULT_HISTORY_SEARCH, {
+          query: "search",
+          sort: "relevance",
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("titles").textContent).toBe(
+      "Beta search flow|search",
+    );
+  });
+
   it("surfaces a worktree metadata failure for a PR-number search", () => {
     testState.worktreeMetadataError = new Error("Worktree metadata failed");
 

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -9,6 +9,7 @@ import {
   collectHistoryRepos,
   dedupSortWorkspaces,
   filterHistoryItems,
+  prioritizePinnedHistoryItems,
   sortHistoryItems,
   withHistoryItemPullRequestNumbers,
 } from "@/components/home/data/home-page.data";
@@ -261,7 +262,9 @@ function sortProjectedHistoryItems(
   sort: HistorySortOption,
   query: string,
 ): ReadonlyArray<HistoryItem> {
-  if (sort === "relevance" && query.length > 0) return items;
+  if (sort === "relevance" && query.length > 0) {
+    return prioritizePinnedHistoryItems(items);
+  }
   return sortHistoryItems(items, sort);
 }
 

--- a/clients/gui-app/src/hooks/home/use-history-query.ts
+++ b/clients/gui-app/src/hooks/home/use-history-query.ts
@@ -112,9 +112,13 @@ export function useHistoryQuery(
     if (tasksQuery.data === undefined) {
       return undefined;
     }
+    // The settled server order is pinned-first, but an optimistic pin patch
+    // flips a cached row's bit without moving it - the stable pinned-first
+    // partition lifts it into (or drops it out of) the pinned block
+    // instantly, and is an order-preserving no-op on untouched server data.
     const items = shouldProjectLocally
       ? projectHistoryItems(serverItems, params.search)
-      : serverItems;
+      : prioritizePinnedHistoryItems(serverItems);
     const canUseServerFacets =
       !isQueryDebouncing && !tasksQuery.isPlaceholderData;
     const facets = canUseServerFacets

--- a/clients/gui-app/src/lib/cloud-epic-tasks-query/cache.ts
+++ b/clients/gui-app/src/lib/cloud-epic-tasks-query/cache.ts
@@ -91,6 +91,46 @@ export function updateEpicTitleInCloudTaskCaches(
   }
 }
 
+export function setEpicPinnedInCloudTaskCaches(
+  queryClient: QueryClient,
+  scope: CloudEpicTasksCacheScope,
+  epicId: string,
+  pinned: boolean,
+): void {
+  for (const [
+    queryKey,
+    response,
+  ] of queryClient.getQueriesData<ListTasksResponse>({
+    predicate: (query) =>
+      cloudEpicTasksQueryKeyMatchesScope(query.queryKey, scope),
+  })) {
+    if (response === undefined) continue;
+    const next = setEpicPinnedInCloudTasksResponse(response, epicId, pinned);
+    if (next === response) continue;
+    queryClient.setQueryData<ListTasksResponse>(queryKey, next);
+  }
+}
+
+/**
+ * Identity-preserving per-row pin patch: returns the same response reference
+ * when the epic is absent or already carries the requested pin state. Shared
+ * with the pages store so the cached first page and the accumulated "Show
+ * more" tails patch identically.
+ */
+export function setEpicPinnedInCloudTasksResponse(
+  response: ListTasksResponse,
+  epicId: string,
+  pinned: boolean,
+): ListTasksResponse {
+  const tasks = response.tasks.map((task) => {
+    if (task.epic?.light?.id !== epicId) return task;
+    if ((task.pinned ?? false) === pinned) return task;
+    return { ...task, pinned };
+  });
+  const changed = tasks.some((task, index) => task !== response.tasks[index]);
+  return changed ? { ...response, tasks } : response;
+}
+
 export function cloudEpicTasksQueryKeyMatchesScope(
   queryKey: readonly unknown[],
   scope: CloudEpicTasksCacheScope,

--- a/clients/gui-app/src/lib/query-keys/epic-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/epic-mutation-keys.ts
@@ -1,6 +1,7 @@
 export const epicMutationKeys = {
   create: () => ["epic.create"] as const,
   batchDelete: () => ["epic.batchDelete"] as const,
+  setPinned: () => ["epic.setPinned"] as const,
   sendQueuedInvites: () => ["epic.sendQueuedInvites"] as const,
   createChat: () => ["epic.createChat"] as const,
   exportArtifacts: () => ["epic.exportArtifacts"] as const,

--- a/clients/gui-app/src/stores/epics/__tests__/cloud-epic-tasks-pages-store.test.ts
+++ b/clients/gui-app/src/stores/epics/__tests__/cloud-epic-tasks-pages-store.test.ts
@@ -1,16 +1,47 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
+import type {
+  ListTaskLight,
+  ListTasksResponse,
+} from "@traycer/protocol/host/epic/unary-schemas";
 import {
   useCloudEpicTasksPagesStore,
   cloudEpicTasksPageGeneration,
   registerCloudEpicTasksPageIdentity,
   resetCloudEpicTasksPagesForScope,
+  setCloudEpicTasksPagePinned,
 } from "@/stores/epics/cloud-epic-tasks-pages-store";
 
 const IDENTITY = "host-a|user-a|{}";
 
 function page(marker: string): ListTasksResponse {
   return { tasks: [], hasMore: true, nextCursor: marker };
+}
+
+function epicTask(epicId: string, pinned: boolean): ListTaskLight {
+  return {
+    epic: {
+      light: {
+        id: epicId,
+        title: `Epic ${epicId}`,
+        initialUserPrompt: "",
+        ticketCount: 0,
+        specCount: 0,
+        storyCount: 0,
+        reviewCount: 0,
+        status: "in_progress",
+        createdAt: 0,
+        updatedAt: 0,
+        createdBy: "user-a",
+        version: "1",
+      },
+      permission: null,
+      repos: [],
+      workspaces: [],
+      roomInfo: null,
+    },
+    phase: null,
+    pinned,
+  };
 }
 
 function pagesFor(identity: string): readonly ListTasksResponse[] | undefined {
@@ -75,7 +106,7 @@ describe("useCloudEpicTasksPagesStore", () => {
     );
   });
 
-  it("rejects a stale first-tail response when a pin/unpin reset lands while it is still in flight", () => {
+  it("rejects a stale first-tail response when a scope reset lands while it is still in flight", () => {
     const hostId = "host-a";
     const userId = "user-a";
     const identity = `${hostId}|${userId}|recent`;
@@ -90,8 +121,8 @@ describe("useCloudEpicTasksPagesStore", () => {
     const capturedGeneration = cloudEpicTasksPageGeneration(identity);
     expect(capturedGeneration).toBe(0);
 
-    // A pin/unpin mutation succeeds and resets the host/user scope while
-    // that first tail request is still in flight.
+    // A scope-level reset lands while that first tail request is still in
+    // flight.
     resetCloudEpicTasksPagesForScope(hostId, userId);
     expect(cloudEpicTasksPageGeneration(identity)).toBe(1);
 
@@ -125,5 +156,46 @@ describe("useCloudEpicTasksPagesStore", () => {
     expect(cloudEpicTasksPageGeneration(matchingFirst)).toBe(1);
     expect(cloudEpicTasksPageGeneration(matchingSecond)).toBe(1);
     expect(cloudEpicTasksPageGeneration(otherUser)).toBe(0);
+  });
+
+  it("patches one epic's pin bit across a scope's tails without resetting them", () => {
+    const scopedIdentity = "host-a|user-a|recent";
+    const otherUserIdentity = "host-a|user-b|recent";
+    const state = useCloudEpicTasksPagesStore.getState();
+    state.appendPage(scopedIdentity, 0, {
+      tasks: [epicTask("epic-1", false), epicTask("epic-2", true)],
+      hasMore: true,
+      nextCursor: "next",
+    });
+    state.appendPage(otherUserIdentity, 0, {
+      tasks: [epicTask("epic-1", false)],
+      hasMore: false,
+    });
+    const untouchedBefore = pagesFor(otherUserIdentity);
+
+    setCloudEpicTasksPagePinned("host-a", "user-a", "epic-1", true);
+
+    const scopedPage = pagesFor(scopedIdentity)?.[0];
+    expect(scopedPage?.tasks.map((task) => task.pinned)).toEqual([true, true]);
+    // The page's non-task fields and the untouched scope keep their
+    // identities - and, crucially, no generation advanced: the tails stay
+    // retained rather than being dropped by a reset.
+    expect(scopedPage?.nextCursor).toBe("next");
+    expect(pagesFor(otherUserIdentity)).toBe(untouchedBefore);
+    expect(cloudEpicTasksPageGeneration(scopedIdentity)).toBe(0);
+  });
+
+  it("is an identity-preserving no-op when the epic is absent or already in the requested state", () => {
+    const scopedIdentity = "host-a|user-a|recent";
+    useCloudEpicTasksPagesStore.getState().appendPage(scopedIdentity, 0, {
+      tasks: [epicTask("epic-1", true)],
+      hasMore: false,
+    });
+    const before = pagesFor(scopedIdentity);
+
+    setCloudEpicTasksPagePinned("host-a", "user-a", "epic-1", true);
+    setCloudEpicTasksPagePinned("host-a", "user-a", "epic-missing", true);
+
+    expect(pagesFor(scopedIdentity)).toBe(before);
   });
 });

--- a/clients/gui-app/src/stores/epics/__tests__/cloud-epic-tasks-pages-store.test.ts
+++ b/clients/gui-app/src/stores/epics/__tests__/cloud-epic-tasks-pages-store.test.ts
@@ -178,8 +178,10 @@ describe("useCloudEpicTasksPagesStore", () => {
     const scopedPage = pagesFor(scopedIdentity)?.[0];
     expect(scopedPage?.tasks.map((task) => task.pinned)).toEqual([true, true]);
     // The page's non-task fields and the untouched scope keep their
-    // identities - and, crucially, no generation advanced: the tails stay
-    // retained rather than being dropped by a reset.
+    // identities, and the patch action itself is generation-neutral -
+    // discarding the scope's tails after the pin commits is the mutation's
+    // success handler's job (via resetCloudEpicTasksPagesForScope), not
+    // this action's.
     expect(scopedPage?.nextCursor).toBe("next");
     expect(pagesFor(otherUserIdentity)).toBe(untouchedBefore);
     expect(cloudEpicTasksPageGeneration(scopedIdentity)).toBe(0);

--- a/clients/gui-app/src/stores/epics/__tests__/cloud-epic-tasks-pages-store.test.ts
+++ b/clients/gui-app/src/stores/epics/__tests__/cloud-epic-tasks-pages-store.test.ts
@@ -3,6 +3,8 @@ import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schema
 import {
   useCloudEpicTasksPagesStore,
   cloudEpicTasksPageGeneration,
+  registerCloudEpicTasksPageIdentity,
+  resetCloudEpicTasksPagesForScope,
 } from "@/stores/epics/cloud-epic-tasks-pages-store";
 
 const IDENTITY = "host-a|user-a|{}";
@@ -71,5 +73,57 @@ describe("useCloudEpicTasksPagesStore", () => {
     expect(cloudEpicTasksPageGeneration("other-identity")).toBe(
       otherGeneration,
     );
+  });
+
+  it("rejects a stale first-tail response when a pin/unpin reset lands while it is still in flight", () => {
+    const hostId = "host-a";
+    const userId = "user-a";
+    const identity = `${hostId}|${userId}|recent`;
+
+    // `fetchNextPage` starting the FIRST "Show more" request for an identity
+    // that has never appended a page or been reset before: it must register
+    // the identity before capturing the generation it hands to the request,
+    // or a reset landing during this exact window has nothing to advance.
+    // This is the precise gap the review reproduced as
+    // `{"captured":0,"afterReset":0,"accepted":1}`.
+    registerCloudEpicTasksPageIdentity(identity);
+    const capturedGeneration = cloudEpicTasksPageGeneration(identity);
+    expect(capturedGeneration).toBe(0);
+
+    // A pin/unpin mutation succeeds and resets the host/user scope while
+    // that first tail request is still in flight.
+    resetCloudEpicTasksPagesForScope(hostId, userId);
+    expect(cloudEpicTasksPageGeneration(identity)).toBe(1);
+
+    // The stale tail finally resolves after the refreshed first page has
+    // already landed.
+    useCloudEpicTasksPagesStore
+      .getState()
+      .appendPage(identity, capturedGeneration, page("stale-tail"));
+
+    expect(pagesFor(identity)).toBeUndefined();
+  });
+
+  it("resets every pagination identity for one host and user", () => {
+    const matchingFirst = "host-a|user-a|recent";
+    const matchingSecond = "host-a|user-a|title";
+    const otherUser = "host-a|user-b|recent";
+    const state = useCloudEpicTasksPagesStore.getState();
+    [matchingFirst, matchingSecond, otherUser].forEach((identity) => {
+      state.appendPage(
+        identity,
+        cloudEpicTasksPageGeneration(identity),
+        page(identity),
+      );
+    });
+
+    resetCloudEpicTasksPagesForScope("host-a", "user-a");
+
+    expect(pagesFor(matchingFirst)).toBeUndefined();
+    expect(pagesFor(matchingSecond)).toBeUndefined();
+    expect(pagesFor(otherUser)).toHaveLength(1);
+    expect(cloudEpicTasksPageGeneration(matchingFirst)).toBe(1);
+    expect(cloudEpicTasksPageGeneration(matchingSecond)).toBe(1);
+    expect(cloudEpicTasksPageGeneration(otherUser)).toBe(0);
   });
 });

--- a/clients/gui-app/src/stores/epics/cloud-epic-tasks-pages-store.ts
+++ b/clients/gui-app/src/stores/epics/cloud-epic-tasks-pages-store.ts
@@ -104,9 +104,10 @@ export const useCloudEpicTasksPagesStore =
         // In-place optimistic pin patch across every retained tail in the
         // scope. Identity-preserving on both levels (page and identity
         // bucket) so untouched scopes never re-render, and deliberately
-        // generation-neutral: patched tails stay valid, and any tail still
-        // in flight reconciles through the assembly-time dedupe instead of
-        // being dropped.
+        // generation-neutral: the patch only updates what is displayed. The
+        // pin mutation's success handler resets the scope's pagination
+        // afterwards - a pin reorders rows across server page boundaries,
+        // so every retained cursor goes stale on commit.
         const entries = Object.entries(state.pagesByIdentity).map(
           ([identity, pages]): [string, readonly ListTasksResponse[]] => {
             if (!identity.startsWith(identityPrefix)) {
@@ -159,10 +160,11 @@ export function registerCloudEpicTasksPageIdentity(identity: string): void {
 
 /**
  * Drops every accumulated pagination tail for one host/user and advances
- * their generations so in-flight tails are rejected on arrival. Scope-level
- * invalidation for flows that must discard a host/user's tails wholesale -
- * the optimistic pin path patches rows in place via
- * `setCloudEpicTasksPagePinned` instead of resetting.
+ * their generations so in-flight tails are rejected on arrival. The pin
+ * mutation patches rows in place at mutate time (`setCloudEpicTasksPagePinned`)
+ * and calls this on success: the committed reorder crosses server page
+ * boundaries, so every retained cursor is stale and a later "Show more"
+ * against one could silently skip rows.
  */
 export function resetCloudEpicTasksPagesForScope(
   hostId: string,

--- a/clients/gui-app/src/stores/epics/cloud-epic-tasks-pages-store.ts
+++ b/clients/gui-app/src/stores/epics/cloud-epic-tasks-pages-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
+import { setEpicPinnedInCloudTasksResponse } from "@/lib/cloud-epic-tasks-query/cache";
 
 /**
  * Accumulated "Show more" pages for the cloud epic-tasks list, keyed by the
@@ -30,7 +31,7 @@ import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schema
  * though no page or reset has touched the identity yet. Without an explicit
  * `generationByIdentity` entry, `resetCloudEpicTasksPagesForScope` only
  * iterates identities already present in `pagesByIdentity` /
- * `generationByIdentity` - a pin/unpin reset that lands while the *first*
+ * `generationByIdentity` - a scope reset that lands while the *first*
  * "Show more" request for an identity is still in flight would find no entry
  * to bump, so the stale response's captured generation `0` would still equal
  * the (never-advanced) current generation `0` and get accepted.
@@ -47,6 +48,11 @@ interface CloudEpicTasksPagesStoreState {
     page: ListTasksResponse,
   ) => void;
   readonly resetIdentity: (identity: string) => void;
+  readonly setTaskPinned: (
+    identityPrefix: string,
+    epicId: string,
+    pinned: boolean,
+  ) => void;
 }
 
 export const useCloudEpicTasksPagesStore =
@@ -93,6 +99,36 @@ export const useCloudEpicTasksPagesStore =
         return { pagesByIdentity, generationByIdentity };
       });
     },
+    setTaskPinned: (identityPrefix, epicId, pinned) => {
+      set((state) => {
+        // In-place optimistic pin patch across every retained tail in the
+        // scope. Identity-preserving on both levels (page and identity
+        // bucket) so untouched scopes never re-render, and deliberately
+        // generation-neutral: patched tails stay valid, and any tail still
+        // in flight reconciles through the assembly-time dedupe instead of
+        // being dropped.
+        const entries = Object.entries(state.pagesByIdentity).map(
+          ([identity, pages]): [string, readonly ListTasksResponse[]] => {
+            if (!identity.startsWith(identityPrefix)) {
+              return [identity, pages];
+            }
+            const nextPages = pages.map((page) =>
+              setEpicPinnedInCloudTasksResponse(page, epicId, pinned),
+            );
+            const identityChanged = nextPages.some(
+              (page, index) => page !== pages[index],
+            );
+            return [identity, identityChanged ? nextPages : pages];
+          },
+        );
+        const scopeChanged = entries.some(
+          ([identity, pages]) => pages !== state.pagesByIdentity[identity],
+        );
+        return scopeChanged
+          ? { pagesByIdentity: Object.fromEntries(entries) }
+          : state;
+      });
+    },
   }));
 
 function currentGeneration(
@@ -122,9 +158,11 @@ export function registerCloudEpicTasksPageIdentity(identity: string): void {
 }
 
 /**
- * Drops every accumulated pagination tail for one host/user. A personal pin can
- * move an item across page boundaries, so retaining any old tail risks a
- * duplicate row after the first page refetches in pinned-first order.
+ * Drops every accumulated pagination tail for one host/user and advances
+ * their generations so in-flight tails are rejected on arrival. Scope-level
+ * invalidation for flows that must discard a host/user's tails wholesale -
+ * the optimistic pin path patches rows in place via
+ * `setCloudEpicTasksPagePinned` instead of resetting.
  */
 export function resetCloudEpicTasksPagesForScope(
   hostId: string,
@@ -139,4 +177,21 @@ export function resetCloudEpicTasksPagesForScope(
   identities.forEach((identity) => {
     if (identity.startsWith(prefix)) state.resetIdentity(identity);
   });
+}
+
+/**
+ * Flips one epic's `pinned` bit inside every retained "Show more" tail for
+ * one host/user - the pages-store half of the optimistic pin patch (the
+ * cached first page lives in TanStack Query and is patched by
+ * `setEpicPinnedInCloudTaskCaches`).
+ */
+export function setCloudEpicTasksPagePinned(
+  hostId: string,
+  userId: string,
+  epicId: string,
+  pinned: boolean,
+): void {
+  useCloudEpicTasksPagesStore
+    .getState()
+    .setTaskPinned(`${hostId}|${userId}|`, epicId, pinned);
 }

--- a/clients/gui-app/src/stores/epics/cloud-epic-tasks-pages-store.ts
+++ b/clients/gui-app/src/stores/epics/cloud-epic-tasks-pages-store.ts
@@ -25,12 +25,22 @@ import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schema
  * re-create `pagesByIdentity[identity]` with stale rows on top of the refreshed
  * first page. The next-page fetch (a TanStack `useHostMutation`) captures the
  * generation when it starts and hands it back here on success.
+ *
+ * `registerIdentity` must run before that first fetch is dispatched, even
+ * though no page or reset has touched the identity yet. Without an explicit
+ * `generationByIdentity` entry, `resetCloudEpicTasksPagesForScope` only
+ * iterates identities already present in `pagesByIdentity` /
+ * `generationByIdentity` - a pin/unpin reset that lands while the *first*
+ * "Show more" request for an identity is still in flight would find no entry
+ * to bump, so the stale response's captured generation `0` would still equal
+ * the (never-advanced) current generation `0` and get accepted.
  */
 interface CloudEpicTasksPagesStoreState {
   readonly pagesByIdentity: Readonly<
     Record<string, readonly ListTasksResponse[]>
   >;
   readonly generationByIdentity: Readonly<Record<string, number>>;
+  readonly registerIdentity: (identity: string) => void;
   readonly appendPage: (
     identity: string,
     generation: number,
@@ -43,6 +53,17 @@ export const useCloudEpicTasksPagesStore =
   create<CloudEpicTasksPagesStoreState>()((set) => ({
     pagesByIdentity: {},
     generationByIdentity: {},
+    registerIdentity: (identity) => {
+      set((state) => {
+        if (identity in state.generationByIdentity) return state;
+        return {
+          generationByIdentity: {
+            ...state.generationByIdentity,
+            [identity]: 0,
+          },
+        };
+      });
+    },
     appendPage: (identity, generation, page) => {
       set((state) => {
         // A response tagged with a superseded generation belongs to a list
@@ -88,4 +109,34 @@ function currentGeneration(
  */
 export function cloudEpicTasksPageGeneration(identity: string): number {
   return currentGeneration(useCloudEpicTasksPagesStore.getState(), identity);
+}
+
+/**
+ * Registers an identity's generation entry imperatively, before the fetch
+ * that will read it via `cloudEpicTasksPageGeneration` is dispatched. Must be
+ * called first so a scope reset landing during that very first in-flight
+ * request has an entry to advance - see the store-level doc comment.
+ */
+export function registerCloudEpicTasksPageIdentity(identity: string): void {
+  useCloudEpicTasksPagesStore.getState().registerIdentity(identity);
+}
+
+/**
+ * Drops every accumulated pagination tail for one host/user. A personal pin can
+ * move an item across page boundaries, so retaining any old tail risks a
+ * duplicate row after the first page refetches in pinned-first order.
+ */
+export function resetCloudEpicTasksPagesForScope(
+  hostId: string,
+  userId: string,
+): void {
+  const state = useCloudEpicTasksPagesStore.getState();
+  const prefix = `${hostId}|${userId}|`;
+  const identities = new Set([
+    ...Object.keys(state.pagesByIdentity),
+    ...Object.keys(state.generationByIdentity),
+  ]);
+  identities.forEach((identity) => {
+    if (identity.startsWith(prefix)) state.resetIdentity(identity);
+  });
 }

--- a/protocol/src/host/epic/__tests__/epic-list-tasks-instance-identity.test.ts
+++ b/protocol/src/host/epic/__tests__/epic-list-tasks-instance-identity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { hostRpcRegistry } from "@traycer/protocol/host/registry";
+import { epicListTasksUpgradeV10ToV11 } from "@traycer/protocol/host/epic/contracts";
 import {
   listTasksRequestSchema,
   listTasksResponseSchema,
@@ -8,7 +9,7 @@ import {
 /**
  * Hard invariant for the partial CloudData → protocol migration:
  *
- *   hostRpcRegistry["epic.listTasks"]
+ *   latest hostRpcRegistry["epic.listTasks"] contract
  *
  * must wire the canonical `listTasks*` schema instances exported from
  * `unary-schemas` - not merely equal shapes. Referential equality
@@ -24,7 +25,7 @@ import {
  */
 describe("epic.listTasks instance identity", () => {
   const hostContract =
-    hostRpcRegistry["epic.listTasks"][1].versions[0].contract;
+    hostRpcRegistry["epic.listTasks"][1].versions[1].contract;
 
   it("host request schema is the canonical listTasksRequestSchema instance", () => {
     expect(hostContract.requestSchema).toBe(listTasksRequestSchema);
@@ -96,6 +97,32 @@ describe("epic.listTasks instance identity", () => {
         ],
         ownershipScopes: [{ value: "mine", count: 1 }],
       },
+    });
+  });
+
+  it("carries personal pin state on canonical list rows", () => {
+    const parsed = listTasksResponseSchema.parse({
+      tasks: [
+        {
+          epic: null,
+          phase: null,
+          pinned: true,
+        },
+      ],
+      hasMore: false,
+    });
+    expect(parsed.tasks[0]?.pinned).toBe(true);
+  });
+
+  it("defaults rows from a v1.0 host to unpinned", () => {
+    expect(
+      epicListTasksUpgradeV10ToV11.upgradeResponse({
+        tasks: [{ epic: null, phase: null }],
+        hasMore: false,
+      }),
+    ).toEqual({
+      tasks: [{ epic: null, phase: null, pinned: false }],
+      hasMore: false,
     });
   });
 });

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -1,4 +1,7 @@
-import { defineRpcContract } from "@traycer/protocol/framework/index";
+import {
+  defineRpcContract,
+  defineUpgradePath,
+} from "@traycer/protocol/framework/index";
 import {
   batchDeleteRequestSchema,
   batchDeleteResponseSchema,
@@ -41,6 +44,7 @@ import {
   listEpicCollaboratorsResponseSchema,
   listTasksRequestSchema,
   listTasksResponseSchema,
+  listTasksResponseSchemaV10,
   removeEpicRepoRequestSchema,
   removeEpicRepoResponseSchema,
   resolveArtifactByPathRequestSchema,
@@ -61,6 +65,8 @@ import {
   revokeEpicCollaboratorResponseSchema,
   setCommentThreadResolvedRequestSchema,
   setCommentThreadResolvedResponseSchema,
+  setEpicPinnedRequestSchema,
+  setEpicPinnedResponseSchema,
   updateArtifactStatusRequestSchema,
   updateArtifactStatusResponseSchema,
   updateChatRunSettingsRequestSchema,
@@ -70,15 +76,47 @@ import {
 } from "@traycer/protocol/host/epic/unary-schemas";
 import { epicSubscribeV10 } from "@traycer/protocol/host/epic/subscribe";
 
-// `epic.listTasks@1.0` - host-side entry point for the CloudData
-// task-list query. Schemas are imported from `./unary-schemas` and are
-// the same zod instances CloudDataClient's `task.list` contract resolves
-// (enforced by epic-list-tasks-instance-identity.test.ts).
+// `epic.listTasks@1.0` - frozen pre-pinning host entry point for the CloudData
+// task-list query. The request remains shared with the latest contract while
+// the response preserves the released row shape.
 export const epicListTasksV10 = defineRpcContract({
   method: "epic.listTasks",
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: listTasksRequestSchema,
+  responseSchema: listTasksResponseSchemaV10,
+});
+
+// `epic.listTasks@1.1` adds the signed-in user's personal `pinned` bit to each
+// row and reuses CloudData's canonical current list response schema. The
+// request is unchanged; an older host's rows upgrade as unpinned.
+export const epicListTasksV11 = defineRpcContract({
+  method: "epic.listTasks",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: listTasksRequestSchema,
   responseSchema: listTasksResponseSchema,
+});
+
+export const epicListTasksUpgradeV10ToV11 = defineUpgradePath<
+  typeof epicListTasksV10,
+  typeof epicListTasksV11
+>({
+  from: epicListTasksV10.schemaVersion,
+  to: epicListTasksV11.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => ({
+    ...response,
+    tasks: response.tasks.map((task) => ({ ...task, pinned: false })),
+  }),
+});
+
+// Personal cloud preference. Optional/non-floor so clients retain the released
+// unary handshake against older hosts and receive E_HOST_UNSUPPORTED only when
+// they try to change a pin.
+export const epicSetPinnedV10 = defineRpcContract({
+  method: "epic.setPinned",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: setEpicPinnedRequestSchema,
+  responseSchema: setEpicPinnedResponseSchema,
 });
 
 // `epic.create@1.0` - host-side entry point for the CloudData epic create

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -472,13 +472,24 @@ export type ListEpicCollaboratorsResponse = z.infer<
   typeof listEpicCollaboratorsResponseSchema
 >;
 
-// ─── Task list (epic.listTasks@1.0 wire shape) ───────────────────────────────
+// ─── Task list (versioned epic.listTasks wire shapes) ───────────────────────
 
 export const taskLightSchema = z.object({
   epic: epicLightWithPermissionSchema.nullable().optional(),
   phase: phaseLightWithPermissionSchema.nullable().optional(),
 });
 export type TaskLight = z.infer<typeof taskLightSchema>;
+
+// The task list carries viewer-specific presentation state in addition to the
+// reusable TaskLight core. Keep the v1.0 row frozen so a v1.1 client can bridge
+// an older host by defaulting every row to unpinned.
+export const listTaskLightSchemaV10 = taskLightSchema;
+export type ListTaskLightV10 = z.infer<typeof listTaskLightSchemaV10>;
+
+export const listTaskLightSchema = taskLightSchema.extend({
+  pinned: z.boolean().optional(),
+});
+export type ListTaskLight = z.infer<typeof listTaskLightSchema>;
 
 export const listTasksRequestSchema = z.object({
   limit: z.number(),
@@ -512,13 +523,34 @@ export const listTasksFacetsSchema = z.object({
 });
 export type ListTasksFacets = z.infer<typeof listTasksFacetsSchema>;
 
+export const listTasksResponseSchemaV10 = z.object({
+  tasks: z.array(listTaskLightSchemaV10),
+  nextCursor: z.string().optional(),
+  hasMore: z.boolean(),
+  facets: listTasksFacetsSchema.optional(),
+});
+export type ListTasksResponseV10 = z.infer<typeof listTasksResponseSchemaV10>;
+
 export const listTasksResponseSchema = z.object({
-  tasks: z.array(taskLightSchema),
+  tasks: z.array(listTaskLightSchema),
   nextCursor: z.string().optional(),
   hasMore: z.boolean(),
   facets: listTasksFacetsSchema.optional(),
 });
 export type ListTasksResponse = z.infer<typeof listTasksResponseSchema>;
+
+// ─── Personal history pinning (epic.setPinned@1.0) ──────────────────────────
+
+export const setEpicPinnedRequestSchema = z.object({
+  epicId: z.string(),
+  pinned: z.boolean(),
+});
+export type SetEpicPinnedRequest = z.infer<typeof setEpicPinnedRequestSchema>;
+
+export const setEpicPinnedResponseSchema = z.object({
+  pinned: z.boolean(),
+});
+export type SetEpicPinnedResponse = z.infer<typeof setEpicPinnedResponseSchema>;
 
 // ─── Epic/entity mentions ────────────────────────────────────────────────────
 

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -115,6 +115,8 @@ import {
   epicListCollaboratorsV10,
   epicListCommentThreadsV10,
   epicListTasksV10,
+  epicListTasksV11,
+  epicListTasksUpgradeV10ToV11,
   epicMentionEpicsV10,
   epicMentionReviewsV10,
   epicMentionSpecsV10,
@@ -131,6 +133,7 @@ import {
   epicResolveArtifactByPathV10,
   epicRevokeCollaboratorV10,
   epicSetCommentThreadResolvedV10,
+  epicSetPinnedV10,
   epicSubscribeV10,
   epicUpdateArtifactStatusV10,
   epicUpdateTitleV10,
@@ -2314,15 +2317,32 @@ const HOST_RPC_REGISTRY_DEFINITION = {
   },
   "epic.listTasks": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: epicListTasksV10,
           upgradeFromPreviousVersion: null,
         },
+        1: {
+          contract: epicListTasksV11,
+          upgradeFromPreviousVersion: epicListTasksUpgradeV10ToV11,
+        },
       },
       downgradePathsFromLatest: {},
     },
+  },
+  "epic.setPinned": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: epicSetPinnedV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+    degrade: { kind: "unsupported" },
   },
   "epic.create": {
     1: {


### PR DESCRIPTION
## Summary

- extend the Epic host protocol with personal pin state and the `epic.setPinned` RPC
- render an accessible pin/unpin control for Epic rows on the History landing page
- keep pinned Epics above unpinned results while preserving the selected sort within each block
- track concurrent pin mutations independently per Epic
- reset cached pagination after pin changes and reject stale first-tail responses that resolve after the reset
- keep Phase rows explicitly unpinnable, including malformed input carrying `pinned: true`

## Compatibility

- the released `epic.listTasks@1.0` surface remains frozen
- the upgraded list row defaults older responses to `pinned: false`
- old-host downgrade behavior strips the newer field and treats `epic.setPinned` as unsupported
- request/query state remains scoped by host, authenticated user, sort, and filter identity

## Verification

- focused GUI publication-gate suite: 43 tests
- focused protocol suite: 5 tests
- full GUI suite: 5,268 tests passed with one pre-existing skip
- full four-project submodule compile passed
- changed-file ESLint, React Doctor, Prettier, and `git diff --check` passed
- a load-bearing deferred hook test proves the first stale pagination tail is rejected after a pin reset

## Companion change

Internal persistence, authorization, server routing, schema rollout, and the updated gitlink are in [traycer-internal PR #4398](https://github.com/traycerai/traycer-internal/pull/4398).
