### PR TITLE
fix(gui): apply hover-preview review nits

### DIFF
--- a/clients/gui-app/src/components/ui/__tests__/hover-preview-surface.test.tsx
+++ b/clients/gui-app/src/components/ui/__tests__/hover-preview-surface.test.tsx
@@ -36,9 +36,9 @@ describe("hover-preview surface", () => {
     // The workspace and chat/owner hover previews must read as the same card
     // as the composer's @mention preview panel - one shared surface, so the
     // hover-card styles cannot drift apart from it again.
-    for (const expected of HOVER_PREVIEW_SURFACE_CLASS.split(/\s+/)) {
+    HOVER_PREVIEW_SURFACE_CLASS.split(/\s+/).forEach((expected) => {
       expect(tokens).toContain(expected);
-    }
+    });
     expect(tokens).not.toContain("bg-foreground");
     expect(tokens).not.toContain("text-background");
     expect(screen.getByTestId("hover-body")).toBeTruthy();

--- a/clients/gui-app/src/components/ui/hover-preview-card.tsx
+++ b/clients/gui-app/src/components/ui/hover-preview-card.tsx
@@ -11,8 +11,8 @@ interface HoverPreviewCardProps {
   readonly side: "top" | "right" | "bottom" | "left";
   readonly sideOffset: number | undefined;
   readonly align: "start" | "center" | "end" | undefined;
-  readonly open?: boolean;
-  readonly onOpenChange?: (open: boolean) => void;
+  readonly open: boolean | undefined;
+  readonly onOpenChange: ((open: boolean) => void) | undefined;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #347 (auto-merged), applying the still-valid inline review comments on the hover-preview consolidation.

## Applied

- **`hover-preview-surface.test.tsx`** — iterate the surface tokens with `forEach` instead of a `for...of` loop, matching the repo style guide's preference for functional array methods.
- **`HoverPreviewCard` (`hover-preview-card.tsx`)** — type `open` / `onOpenChange` as explicit `| undefined` unions instead of optional (`?:`) props. This matches the sibling `sideOffset` / `align` props in the same interface and the repo's "no optional params, use explicit unions" rule. All three callers (`worktree-owner-metadata`, `workspace-summary-trigger`, `workspace-folder-summary-control`) already pass both props explicitly, so **behavior is unchanged**.

## Skipped (with reason)

- **`hover-card.tsx` — make `openDelay` / `closeDelay` / `align` / `sideOffset` required, remove defaults.** `HoverCard` / `HoverCardContent` are shadcn primitives, and every sibling in `components/ui/` (`tooltip.tsx` `sideOffset = 0`, `popover.tsx` `align = "center"` / `sideOffset = 4`, `dropdown-menu.tsx` `align = "start"` / `sideOffset = 4`) uses the same destructuring-default idiom. Applying the rule here alone would make `hover-card` the lone inconsistent primitive, push timing/positioning boilerplate onto every caller, and break the primitive's encapsulation of its hover-timing constants. `gui-app/AGENTS.md` treats `components/ui/` as shadcn-managed primitives to compose, not rewrite.

## Validation

- `bun run compile` (gui-app) — clean
- `bun x vitest run` on the affected suites — 69 passed
- ESLint on changed files — clean
- `react-doctor` (changed vs `main`) — no issues
