### PR TITLE
refactor(gui): remove renderer-local artifact/chat create action

### DIFF
--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/epic-projector.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/epic-projector.test.ts
@@ -6,6 +6,7 @@
 import "../../../../../__tests__/test-browser-apis";
 import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
+import { createArtifactInDocForTests } from "./projection-helpers-test-shims";
 import {
   createOpenEpicStore,
   type EpicStreamClientFactory,
@@ -149,9 +150,9 @@ describe("epic-projector", () => {
     handle.dispose();
   });
 
-  it("createArtifact populates artifacts.byId, allIds and the tree", () => {
+  it("a seeded artifact populates artifacts.byId, allIds and the tree", () => {
     const { handle } = newSession();
-    const id = handle.store.getState().createArtifact("spec", null);
+    const id = createArtifactInDocForTests(handle.doc, "spec", null);
     const state = handle.store.getState();
     expect(state.artifacts.allIds).toContain(id);
     expect(state.artifacts.byId[id].kind).toBe("spec");
@@ -164,7 +165,7 @@ describe("epic-projector", () => {
 
   it("projects artifactRoomId metadata without changing tree display fields", () => {
     const { handle } = newSession();
-    const id = handle.store.getState().createArtifact("spec", null);
+    const id = createArtifactInDocForTests(handle.doc, "spec", null);
     const artifactBefore = handle.store.getState().artifacts.byId[id];
     const treeBefore = handle.store.getState().tree;
 
@@ -189,8 +190,8 @@ describe("epic-projector", () => {
 
   it("rename only re-allocates the renamed slot; siblings keep ===", () => {
     const { handle } = newSession();
-    const a = handle.store.getState().createArtifact("spec", null);
-    const b = handle.store.getState().createArtifact("ticket", null);
+    const a = createArtifactInDocForTests(handle.doc, "spec", null);
+    const b = createArtifactInDocForTests(handle.doc, "ticket", null);
     const beforeA = handle.store.getState().artifacts.byId[a];
     const beforeB = handle.store.getState().artifacts.byId[b];
 
@@ -206,7 +207,7 @@ describe("epic-projector", () => {
 
   it("title edit does not invalidate tree rootIds when set is unchanged", () => {
     const { handle } = newSession();
-    const a = handle.store.getState().createArtifact("spec", null);
+    const a = createArtifactInDocForTests(handle.doc, "spec", null);
     const treeBefore = handle.store.getState().tree;
 
     handle.store.getState().renameArtifact(a, "Renamed");
@@ -219,8 +220,8 @@ describe("epic-projector", () => {
 
   it("structural change (parent move) updates childrenByParent buckets", () => {
     const { handle } = newSession();
-    const parent = handle.store.getState().createArtifact("spec", null);
-    const child = handle.store.getState().createArtifact("ticket", null);
+    const parent = createArtifactInDocForTests(handle.doc, "spec", null);
+    const child = createArtifactInDocForTests(handle.doc, "ticket", null);
 
     handle.store.getState().reparentArtifact(child, parent);
 
@@ -233,10 +234,10 @@ describe("epic-projector", () => {
 
   it("delete preserves artifact child parent links for host cascade", () => {
     const { handle } = newSession();
-    const root = handle.store.getState().createArtifact("spec", null);
-    const mid = handle.store.getState().createArtifact("spec", root);
-    const leaf = handle.store.getState().createArtifact("ticket", mid);
-    const chat = handle.store.getState().createArtifact("chat", mid);
+    const root = createArtifactInDocForTests(handle.doc, "spec", null);
+    const mid = createArtifactInDocForTests(handle.doc, "spec", root);
+    const leaf = createArtifactInDocForTests(handle.doc, "ticket", mid);
+    const chat = createArtifactInDocForTests(handle.doc, "chat", mid);
 
     handle.store.getState().deleteArtifact(mid);
 
@@ -251,7 +252,7 @@ describe("epic-projector", () => {
 
   it("chat creation populates chats slice and tree as a chat node", () => {
     const { handle } = newSession();
-    const id = handle.store.getState().createArtifact("chat", null);
+    const id = createArtifactInDocForTests(handle.doc, "chat", null);
     const state = handle.store.getState();
     expect(state.chats.allIds).toContain(id);
     expect(state.chats.byId[id].title).toBe("New chat");
@@ -275,9 +276,9 @@ describe("epic-projector", () => {
 
   it("projected slices match a fresh full projection of the live Y.Doc", () => {
     const { handle } = newSession();
-    const a = handle.store.getState().createArtifact("spec", null);
-    const b = handle.store.getState().createArtifact("ticket", a);
-    const c = handle.store.getState().createArtifact("chat", null);
+    const a = createArtifactInDocForTests(handle.doc, "spec", null);
+    const b = createArtifactInDocForTests(handle.doc, "ticket", a);
+    const c = createArtifactInDocForTests(handle.doc, "chat", null);
     handle.store.getState().setEpicTitle("Parity Check");
     handle.store.getState().renameArtifact(b, "Ticket B");
     void a;
@@ -635,7 +636,7 @@ describe("epic-projector", () => {
 
   it("a tombstone-only change does not rebuild the live artifact tree or byId", () => {
     const { handle } = newSession();
-    const live = handle.store.getState().createArtifact("spec", null);
+    const live = createArtifactInDocForTests(handle.doc, "spec", null);
 
     const treeBefore = handle.store.getState().tree;
     const artifactsBefore = handle.store.getState().artifacts;
@@ -671,8 +672,8 @@ describe("epic-projector", () => {
 
   it("preserves live artifact rename identity semantics when tombstones exist", () => {
     const { handle } = newSession();
-    const a = handle.store.getState().createArtifact("spec", null);
-    const b = handle.store.getState().createArtifact("ticket", null);
+    const a = createArtifactInDocForTests(handle.doc, "spec", null);
+    const b = createArtifactInDocForTests(handle.doc, "ticket", null);
 
     handle.doc.transact(() => {
       const tombstones = new Y.Map<unknown>();

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/epic-render-counts.test.tsx
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/epic-render-counts.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { Profiler, type ProfilerOnRenderCallback } from "react";
 import { act, cleanup, render } from "@testing-library/react";
 import * as Y from "yjs";
+import { createArtifactInDocForTests } from "./projection-helpers-test-shims";
 import {
   createOpenEpicStore,
   type EpicStreamClientFactory,
@@ -97,8 +98,8 @@ afterEach(() => {
 describe("epic projector render-count regressions", () => {
   it("editing artifact A does NOT re-render a component subscribed to artifact B", () => {
     const handle = newSession();
-    const idA = handle.store.getState().createArtifact("spec", null);
-    const idB = handle.store.getState().createArtifact("spec", null);
+    const idA = createArtifactInDocForTests(handle.doc, "spec", null);
+    const idB = createArtifactInDocForTests(handle.doc, "spec", null);
 
     const spy = makeSpy();
 
@@ -130,7 +131,7 @@ describe("epic projector render-count regressions", () => {
 
   it("editing artifact title does NOT re-render the connection-status subscriber", () => {
     const handle = newSession();
-    const idA = handle.store.getState().createArtifact("spec", null);
+    const idA = createArtifactInDocForTests(handle.doc, "spec", null);
 
     const spy = makeSpy();
 
@@ -158,7 +159,7 @@ describe("epic projector render-count regressions", () => {
 
   it("tree slice stays referentially stable when only a title changes", () => {
     const handle = newSession();
-    const id = handle.store.getState().createArtifact("spec", null);
+    const id = createArtifactInDocForTests(handle.doc, "spec", null);
 
     const spy = makeSpy();
 
@@ -201,7 +202,7 @@ describe("epic projector render-count regressions", () => {
     const initial = spy.counts.get("root") ?? 0;
 
     act(() => {
-      handle.store.getState().createArtifact("spec", null);
+      createArtifactInDocForTests(handle.doc, "spec", null);
     });
 
     // Adding a root invalidates rootIds → at least one extra render.

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/inline-body-characterization.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/inline-body-characterization.test.ts
@@ -7,11 +7,12 @@
  * a per-artifact-room Y.Doc replica seeded by `onArtifactRoomSnapshot`. These tests pin the
  * post-cutover invariants:
  *
- *   - `createArtifact` creates metadata-only local placeholders with no
- *     root `content` fragment and no `artifactRoomId`.
+ *   - Freshly created artifacts are metadata-only placeholders with no
+ *     root `content` fragment and no `artifactRoomId` (seeded here via
+ *     `createArtifactInDocForTests`, standing in for the host-side create).
  *   - `getArtifactFragment` returns null when no artifactRoom has been seeded for
  *     the artifact's `artifactRoomId` (the expected state after a fresh
- *     `createArtifact`).
+ *     create).
  *   - Chat / unknown artifacts still return null.
  *   - The projector no longer bumps `contentRevByArtifactId` on edits to
  *     the legacy root `content` fragment because body edits now live on
@@ -20,6 +21,7 @@
 import "../../../../../__tests__/test-browser-apis";
 import { describe, expect, it } from "vitest";
 import * as Y from "yjs";
+import { createArtifactInDocForTests } from "./projection-helpers-test-shims";
 import {
   createOpenEpicStore,
   type EpicStreamClientFactory,
@@ -103,9 +105,9 @@ function readContentField(
 }
 
 describe("open-epic store artifact-room binding (post-B6)", () => {
-  it("createArtifact writes a metadata-only root entry with no local body fragment", () => {
+  it("a freshly seeded artifact is a metadata-only root entry with no local body fragment", () => {
     const { handle } = newSession();
-    const id = handle.store.getState().createArtifact("spec", null);
+    const id = createArtifactInDocForTests(handle.doc, "spec", null);
     const fragment = readContentField(handle.doc, id);
     expect(fragment).toBeNull();
     expect(
@@ -116,7 +118,7 @@ describe("open-epic store artifact-room binding (post-B6)", () => {
 
   it("does not bump contentRevByArtifactId for legacy root content edits", () => {
     const { handle } = newSession();
-    const id = handle.store.getState().createArtifact("spec", null);
+    const id = createArtifactInDocForTests(handle.doc, "spec", null);
     const before = handle.store.getState().contentRevByArtifactId[id];
 
     const epic = handle.doc.getMap<unknown>("epic");
@@ -143,7 +145,7 @@ describe("open-epic store artifact-room binding (post-B6)", () => {
     // then the editor must render a placeholder rather than bind a stale
     // root-doc fragment.
     const { handle } = newSession();
-    const id = handle.store.getState().createArtifact("spec", null);
+    const id = createArtifactInDocForTests(handle.doc, "spec", null);
     expect(handle.store.getState().getArtifactFragment(id)).toBeNull();
     expect(handle.store.getState().getArtifactBodyAvailability(id)).toBe(
       "unavailable",
@@ -153,7 +155,7 @@ describe("open-epic store artifact-room binding (post-B6)", () => {
 
   it("getArtifactFragment returns null for chat artifacts (no body fragment)", () => {
     const { handle } = newSession();
-    const id = handle.store.getState().createArtifact("chat", null);
+    const id = createArtifactInDocForTests(handle.doc, "chat", null);
     expect(handle.store.getState().getArtifactFragment(id)).toBeNull();
     handle.dispose();
   });

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/projection-helpers-test-shims.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/projection-helpers-test-shims.ts
@@ -4,16 +4,22 @@
  * the live `projectFullState` (which projects every slice at once).
  */
 import * as Y from "yjs";
+import { v4 as uuidv4 } from "uuid";
 import {
+  ensureMap,
   getArtifactsMap,
   getChatsMap,
+  getEpicMap,
   getTerminalAgentsMap,
   isChatVisibleToUser,
   isTerminalAgentVisibleToUser,
+  NEW_ARTIFACT_TITLES,
   projectArtifact,
   projectChat,
   projectTerminalAgent,
+  type AddableArtifactType,
 } from "@/stores/epics/open-epic/projection-helpers";
+import { LOCAL_ORIGIN } from "@/stores/epics/open-epic/store";
 import type {
   ArtifactProjection,
   ArtifactsSlice,
@@ -55,6 +61,49 @@ export function projectChatsSliceForTests(
     allIds.push(id);
   }
   return { byId, allIds: allIds.length === 0 ? EMPTY_ARRAY : allIds };
+}
+
+/**
+ * Seeds a metadata-only artifact or chat entry directly into the doc,
+ * standing in for the host-side `epic.createArtifact` / `epic.createChat`
+ * writes. The renderer no longer exposes a local create action (creation is
+ * host-RPC-only), so tests seed the doc here. Transacts with the store's
+ * LOCAL_ORIGIN so `handleDocUpdate` routes the update exactly like the
+ * removed local mutation did, keeping projector and render-count semantics.
+ */
+export function createArtifactInDocForTests(
+  doc: Y.Doc,
+  type: AddableArtifactType,
+  parentId: string | null,
+): string {
+  const id = uuidv4();
+  const now = Date.now();
+  const title = NEW_ARTIFACT_TITLES[type];
+  doc.transact(() => {
+    const epic = getEpicMap(doc);
+    if (type === "chat") {
+      const chats = ensureMap(epic, "chats");
+      const entry = new Y.Map<unknown>();
+      entry.set("id", id);
+      entry.set("title", title);
+      entry.set("parentId", parentId);
+      entry.set("createdAt", now);
+      entry.set("updatedAt", now);
+      entry.set("messages", new Y.Array());
+      chats.set(id, entry);
+      return;
+    }
+    const artifacts = ensureMap(epic, "artifacts");
+    const entry = new Y.Map<unknown>();
+    entry.set("id", id);
+    entry.set("kind", type);
+    entry.set("title", title);
+    entry.set("parentId", parentId);
+    entry.set("createdAt", now);
+    entry.set("updatedAt", now);
+    artifacts.set(id, entry);
+  }, LOCAL_ORIGIN);
+  return id;
 }
 
 export function projectTerminalAgentsSliceForTests(

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -40,7 +40,6 @@ import type {
 } from "./types";
 import { EMPTY_ARTIFACT_ROOMS_SLICE, EMPTY_PROJECTED_SLICES } from "./types";
 import {
-  ensureMap,
   getArtifactEntry,
   getArtifactsMap,
   getChatEntry,
@@ -49,12 +48,9 @@ import {
   getEpicMap,
   getTerminalAgentEntry,
   getTerminalAgentsMap,
-  NEW_ARTIFACT_TITLES,
   readArtifactKind,
   readMaybeString,
-  type AddableArtifactType,
 } from "./projection-helpers";
-import { v4 as uuidv4 } from "uuid";
 import { createEpicProjector, type EpicProjector } from "./epic-projector";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { appLogger } from "@/lib/logger";
@@ -341,11 +337,10 @@ export interface OpenEpicState {
   dispose: () => void;
 
   // ── Actions: artifact + chat mutations (own `doc.transact`) ──────────
-  /** Returns the new artifact id; no-op (returns generated id) if viewer/null. */
-  createArtifact: (
-    type: AddableArtifactType,
-    parentId: string | null,
-  ) => string;
+  // Creation is deliberately NOT a local doc write: `epic.createArtifact` /
+  // `epic.createChat` host RPCs own it, because creation needs host-side
+  // setup the renderer cannot fake. The actions below are the optimistic
+  // fast path layered under those same host RPCs.
   /** Returns true when the title actually changed in the Y.Doc. */
   renameArtifact: (artifactId: string, nextTitle: string) => boolean;
   /** Returns true when a delete actually happened. Reparents children. */
@@ -424,7 +419,12 @@ export interface OpenEpicStoreHandle {
 }
 
 const STREAM_ORIGIN = "stream";
-const LOCAL_ORIGIN = "local";
+/**
+ * Origin tag for renderer-local Y.Doc mutations. Exported for test seeding
+ * helpers that must route through `handleDocUpdate` exactly like a local
+ * user mutation.
+ */
+export const LOCAL_ORIGIN = "local";
 const EMPTY_Y_UPDATE_BYTES = 2;
 
 function encodeBase64(bytes: Uint8Array): string {
@@ -1519,43 +1519,6 @@ export function createOpenEpicStore(
         //    fires once per logical mutation and `handleDocUpdate` routes
         //    the resulting update bytes through `applyLocalUpdate`.
 
-        const createArtifactAction = (
-          type: AddableArtifactType,
-          parentId: string | null,
-        ): string => {
-          const id = uuidv4();
-          if (disposed) return id;
-          const role = currentRole ?? get().permissionRole;
-          if (role === "viewer" || role === null) return id;
-          const now = Date.now();
-          const title = NEW_ARTIFACT_TITLES[type];
-          doc.transact(() => {
-            const epic = getEpicMap(doc);
-            if (type === "chat") {
-              const chats = ensureMap(epic, "chats");
-              const entry = new Y.Map<unknown>();
-              entry.set("id", id);
-              entry.set("title", title);
-              entry.set("parentId", parentId);
-              entry.set("createdAt", now);
-              entry.set("updatedAt", now);
-              entry.set("messages", new Y.Array());
-              chats.set(id, entry);
-              return;
-            }
-            const artifacts = ensureMap(epic, "artifacts");
-            const entry = new Y.Map<unknown>();
-            entry.set("id", id);
-            entry.set("kind", type);
-            entry.set("title", title);
-            entry.set("parentId", parentId);
-            entry.set("createdAt", now);
-            entry.set("updatedAt", now);
-            artifacts.set(id, entry);
-          }, LOCAL_ORIGIN);
-          return id;
-        };
-
         const renameArtifactAction = (
           artifactId: string,
           nextTitle: string,
@@ -1894,7 +1857,6 @@ export function createOpenEpicStore(
             destroyAllArtifactRoomReplicas();
           },
 
-          createArtifact: createArtifactAction,
           renameArtifact: renameArtifactAction,
           deleteArtifact: deleteArtifactAction,
           reparentArtifact: reparentArtifactAction,


### PR DESCRIPTION
## Summary

The open-epic store exposed a `createArtifact` action that wrote artifact and **chat** entries directly into the epic Y.Doc from the renderer. Production creation is host-RPC-only (`epic.createArtifact` / `epic.createChat` via `useEpicCreateArtifact`) — the sidebar never wired the local action, and a chat row minted renderer-side would bypass all host-side setup. Its only callers were three test suites using it as a doc-seeding utility.

- Remove `createArtifact` from the production store surface (interface, implementation, wiring, now-unused imports).
- Move the seeding into `createArtifactInDocForTests` in the test shims; it transacts with the store's now-exported `LOCAL_ORIGIN` so `handleDocUpdate` routing — and therefore the projector and render-count invariants — behave exactly as before.
- The optimistic `renameArtifact`/`deleteArtifact`/`reparentArtifact` actions are deliberately untouched: they're the production fast path layered under their host RPCs.

Groundwork for the direction that all chat mutations flow through host RPCs only (ahead of moving chat storage out of YJS).

## Testing

- `gui-app`: compile clean; all 6 open-epic suites pass (105 tests), including `epic-render-counts` (the render-count invariant guard for this area); eslint + react-doctor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)