### PR TITLE
fix(gui-app): anchor selection toolbar to tile scroll container

### DIFF
--- a/clients/gui-app/__tests__/editor-core/artifact-toolbar.test.tsx
+++ b/clients/gui-app/__tests__/editor-core/artifact-toolbar.test.tsx
@@ -1,7 +1,14 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { Editor } from "@tiptap/core";
-import { EditorContent, EditorContext } from "@tiptap/react";
+import { EditorContent, EditorContext, useEditor } from "@tiptap/react";
+import { useCallback, useState } from "react";
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";
 import {
@@ -10,22 +17,58 @@ import {
   deriveCollabUser,
 } from "@/editor-core";
 
-function mountToolbarEditor(): Editor {
+function buildToolbarExtensions() {
   const doc = new Y.Doc();
   const fragment = doc.getXmlFragment("default");
   const awareness = new Awareness(doc);
   const user = deriveCollabUser({ userName: "T", email: "t@x.io" });
-  return new Editor({
-    extensions: buildArtifactExtensions({
-      doc,
-      fragment,
-      awareness,
-      user,
-      onCommentShortcut: null,
-      placeholderText: "Start writing…",
-      titlePlaceholderText: "Untitled",
-    }),
+  return buildArtifactExtensions({
+    doc,
+    fragment,
+    awareness,
+    user,
+    onCommentShortcut: null,
+    placeholderText: "Start writing…",
+    titlePlaceholderText: "Untitled",
   });
+}
+
+function mountToolbarEditor(): Editor {
+  return new Editor({ extensions: buildToolbarExtensions() });
+}
+
+function RefOwnedToolbarHarness({
+  onScrollTarget,
+}: {
+  readonly onScrollTarget: (element: HTMLDivElement) => void;
+}) {
+  const [extensions] = useState(buildToolbarExtensions);
+  const editor = useEditor({ extensions, immediatelyRender: false });
+  const [scrollTarget, setScrollTarget] = useState<HTMLDivElement | null>(null);
+  const setScrollContainerRef = useCallback(
+    (element: HTMLDivElement | null): void => {
+      if (element !== null) onScrollTarget(element);
+      setScrollTarget(element);
+    },
+    [onScrollTarget],
+  );
+
+  return (
+    <div ref={setScrollContainerRef} className="overflow-y-auto">
+      {editor !== null ? (
+        <>
+          <EditorContent editor={editor} />
+          <ArtifactToolbar
+            editor={editor}
+            className={undefined}
+            scrollTarget={scrollTarget}
+            commentAction={null}
+            suppressBubbleMenu={false}
+          />
+        </>
+      ) : null}
+    </div>
+  );
 }
 
 /**
@@ -50,6 +93,7 @@ async function revealBubbleMenu(editor: Editor): Promise<void> {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("ArtifactToolbar", () => {
@@ -61,6 +105,7 @@ describe("ArtifactToolbar", () => {
         <ArtifactToolbar
           editor={editor}
           className={undefined}
+          scrollTarget={null}
           commentAction={null}
           suppressBubbleMenu={false}
         />
@@ -85,6 +130,7 @@ describe("ArtifactToolbar", () => {
         <ArtifactToolbar
           editor={editor}
           className={undefined}
+          scrollTarget={null}
           commentAction={null}
           suppressBubbleMenu={false}
         />
@@ -108,6 +154,7 @@ describe("ArtifactToolbar", () => {
         <ArtifactToolbar
           editor={editor}
           className={undefined}
+          scrollTarget={null}
           commentAction={{ onStart: () => {} }}
           suppressBubbleMenu
         />
@@ -118,5 +165,195 @@ describe("ArtifactToolbar", () => {
       screen.queryByRole("toolbar", { name: /editor formatting/i }),
     ).toBeNull();
     editor.destroy();
+  });
+
+  it("repositions from scroll events on the tile scroll container", async () => {
+    const editor = mountToolbarEditor();
+    const scrollContainer = document.createElement("div");
+    scrollContainer.className = "overflow-y-auto";
+    document.body.append(scrollContainer);
+    const containerAddEventListener = vi.spyOn(
+      scrollContainer,
+      "addEventListener",
+    );
+    const windowAddEventListener = vi.spyOn(window, "addEventListener");
+    const coordsAtPos = vi.spyOn(editor.view, "coordsAtPos");
+
+    render(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorContent editor={editor} />
+        <ArtifactToolbar
+          editor={editor}
+          className={undefined}
+          scrollTarget={scrollContainer}
+          commentAction={null}
+          suppressBubbleMenu={false}
+        />
+      </EditorContext.Provider>,
+      { container: scrollContainer },
+    );
+    await revealBubbleMenu(editor);
+
+    expect(containerAddEventListener).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+    expect(windowAddEventListener).not.toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+
+    coordsAtPos.mockClear();
+    fireEvent.scroll(scrollContainer);
+    await waitFor(() => expect(coordsAtPos).toHaveBeenCalled(), {
+      timeout: 500,
+    });
+
+    editor.destroy();
+    scrollContainer.remove();
+  });
+
+  it("attaches to the ref-owned target when the editor arrives after mount", async () => {
+    const scrollTargetListenerAssertions: Array<() => void> = [];
+    const windowAddEventListener = vi.spyOn(window, "addEventListener");
+
+    render(
+      <RefOwnedToolbarHarness
+        onScrollTarget={(element) => {
+          const addEventListener = vi.spyOn(element, "addEventListener");
+          scrollTargetListenerAssertions.push(() => {
+            expect(addEventListener).toHaveBeenCalledWith(
+              "scroll",
+              expect.any(Function),
+            );
+          });
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(scrollTargetListenerAssertions).toHaveLength(1);
+      scrollTargetListenerAssertions[0]();
+    });
+    expect(windowAddEventListener).not.toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+  });
+
+  it("moves the listener across target identities and removes it on unmount", async () => {
+    const editor = mountToolbarEditor();
+    const scrollContainer = document.createElement("div");
+    scrollContainer.className = "overflow-y-auto";
+    document.body.append(scrollContainer);
+    const replacementScrollContainer = document.createElement("div");
+    replacementScrollContainer.className = "overflow-y-auto";
+    document.body.append(replacementScrollContainer);
+    const containerAddEventListener = vi.spyOn(
+      scrollContainer,
+      "addEventListener",
+    );
+    const containerRemoveEventListener = vi.spyOn(
+      scrollContainer,
+      "removeEventListener",
+    );
+    const replacementAddEventListener = vi.spyOn(
+      replacementScrollContainer,
+      "addEventListener",
+    );
+    const replacementRemoveEventListener = vi.spyOn(
+      replacementScrollContainer,
+      "removeEventListener",
+    );
+    const windowAddEventListener = vi.spyOn(window, "addEventListener");
+    const windowRemoveEventListener = vi.spyOn(window, "removeEventListener");
+    const coordsAtPos = vi.spyOn(editor.view, "coordsAtPos");
+
+    const view = render(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorContent editor={editor} />
+        <ArtifactToolbar
+          editor={editor}
+          className={undefined}
+          scrollTarget={null}
+          commentAction={null}
+          suppressBubbleMenu={false}
+        />
+      </EditorContext.Provider>,
+      { container: scrollContainer },
+    );
+    await revealBubbleMenu(editor);
+    expect(windowAddEventListener).toHaveBeenCalledWith(
+      "scroll",
+      expect.any(Function),
+    );
+
+    view.rerender(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorContent editor={editor} />
+        <ArtifactToolbar
+          editor={editor}
+          className={undefined}
+          scrollTarget={scrollContainer}
+          commentAction={null}
+          suppressBubbleMenu={false}
+        />
+      </EditorContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(windowRemoveEventListener).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+      );
+      expect(containerAddEventListener).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+      );
+    });
+
+    view.rerender(
+      <EditorContext.Provider value={{ editor }}>
+        <EditorContent editor={editor} />
+        <ArtifactToolbar
+          editor={editor}
+          className={undefined}
+          scrollTarget={replacementScrollContainer}
+          commentAction={null}
+          suppressBubbleMenu={false}
+        />
+      </EditorContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(containerRemoveEventListener).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+      );
+      expect(replacementAddEventListener).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+      );
+    });
+
+    coordsAtPos.mockClear();
+    fireEvent.scroll(replacementScrollContainer);
+    await waitFor(() => expect(coordsAtPos).toHaveBeenCalled(), {
+      timeout: 500,
+    });
+
+    const activeScrollHandler = replacementAddEventListener.mock.calls.find(
+      ([eventName]) => eventName === "scroll",
+    )?.[1];
+    expect(activeScrollHandler).toEqual(expect.any(Function));
+    view.unmount();
+    expect(replacementRemoveEventListener).toHaveBeenCalledWith(
+      "scroll",
+      activeScrollHandler,
+    );
+
+    editor.destroy();
+    scrollContainer.remove();
+    replacementScrollContainer.remove();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/collab-tile-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/collab-tile-body.tsx
@@ -47,7 +47,7 @@ import { useLeftPanelStore } from "@/stores/epics/left-panel-store";
 import type { EpicArtifactRoomAvailability } from "@/stores/epics/open-epic/types";
 import type { Editor } from "@tiptap/core";
 import { EditorContent } from "@tiptap/react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
 import { ArtifactChildIndex } from "./artifact-child-index";
@@ -159,6 +159,7 @@ function CollabTileBodyEditor(props: CollabTileBodyEditorProps) {
   const profile = useAuthStore((s) => s.profile);
   const editable = role === "owner" || role === "editor";
   const editorRootRef = useRef<HTMLDivElement>(null);
+  const [scrollTarget, setScrollTarget] = useState<HTMLDivElement | null>(null);
   const epicId = useOpenEpicId();
   const commentArtifactKind =
     node.type === WORKSPACE_FILE_TAB_KIND
@@ -421,6 +422,7 @@ function CollabTileBodyEditor(props: CollabTileBodyEditorProps) {
   const setScrollContainerRef = useCallback(
     (element: HTMLDivElement | null): void => {
       editorRootRef.current = element;
+      setScrollTarget(element);
       scrollRestorationRef(element);
     },
     [scrollRestorationRef],
@@ -446,6 +448,7 @@ function CollabTileBodyEditor(props: CollabTileBodyEditorProps) {
             <ArtifactToolbar
               editor={editor}
               className={undefined}
+              scrollTarget={scrollTarget}
               commentAction={commentAction}
               suppressBubbleMenu={ownedDraftRange !== null}
             />

--- a/clients/gui-app/src/editor-core/toolbar/artifact-toolbar.tsx
+++ b/clients/gui-app/src/editor-core/toolbar/artifact-toolbar.tsx
@@ -16,6 +16,7 @@ import {
   Quote,
   Strikethrough,
 } from "lucide-react";
+import { useCallback, useMemo } from "react";
 import { ToolbarButton } from "./toolbar-button";
 
 export interface ArtifactCommentAction {
@@ -27,6 +28,11 @@ export interface ArtifactCommentAction {
 export interface ArtifactToolbarProps {
   readonly editor: Editor;
   readonly className: string | undefined;
+  /**
+   * Tile-owned scroll container. The bubble-menu plugin listens to this
+   * element so the toolbar stays anchored while the tile body scrolls.
+   */
+  readonly scrollTarget: HTMLElement | null;
   /**
    * Pass `null` for tiles whose artifact type doesn't support comments
    * (chat). When non-null, the bubble bar shows the 💬 button on every
@@ -92,7 +98,8 @@ function selectToolbarState({ editor }: { editor: Editor }): ToolbarState {
  * keyboard (⌘Z / ⌘⇧Z); it is intentionally not exposed in the bubble bar.
  */
 export function ArtifactToolbar(props: ArtifactToolbarProps) {
-  const { editor, className, commentAction, suppressBubbleMenu } = props;
+  const { editor, className, scrollTarget, commentAction, suppressBubbleMenu } =
+    props;
 
   const state = useEditorState<ToolbarState>({
     editor,
@@ -100,6 +107,37 @@ export function ArtifactToolbar(props: ArtifactToolbarProps) {
   });
 
   const editable = editor.isEditable;
+  const bubbleMenuOptions = useMemo(
+    () => ({ scrollTarget: scrollTarget ?? undefined }),
+    [scrollTarget],
+  );
+  const shouldShow = useCallback(
+    ({
+      editor: currentEditor,
+      from,
+      to,
+    }: {
+      readonly editor: Editor;
+      readonly from: number;
+      readonly to: number;
+    }): boolean => {
+      // Viewers (non-editable) still see the bar when commenting is
+      // available - the bar will only render the 💬 button via the
+      // `commentAction !== null` branch below; formatting buttons stay
+      // disabled regardless.
+      if (!currentEditor.isEditable && commentAction === null) return false;
+      // Hide inside code blocks - inline formatting would be rejected
+      // by the schema and the bar would flash against an empty selection.
+      if (currentEditor.isActive("codeBlock")) return false;
+      // Hide over atom blocks (mermaid diagrams / wireframes) - each
+      // ships its own floating toolbar and the global formatting bar
+      // would fight with it visually and semantically.
+      if (currentEditor.isActive("mermaidBlock")) return false;
+      if (currentEditor.isActive("uiPreviewBlock")) return false;
+      return from !== to;
+    },
+    [commentAction],
+  );
 
   if (suppressBubbleMenu) return null;
 
@@ -117,22 +155,8 @@ export function ArtifactToolbar(props: ArtifactToolbarProps) {
   return (
     <BubbleMenu
       editor={editor}
-      shouldShow={({ editor: ed, from, to }) => {
-        // Viewers (non-editable) still see the bar when commenting is
-        // available - the bar will only render the 💬 button via the
-        // `commentAction !== null` branch below; formatting buttons stay
-        // disabled regardless.
-        if (!ed.isEditable && commentAction === null) return false;
-        // Hide inside code blocks - inline formatting would be rejected
-        // by the schema and the bar would flash against an empty selection.
-        if (ed.isActive("codeBlock")) return false;
-        // Hide over atom blocks (mermaid diagrams / wireframes) - each
-        // ships its own floating toolbar and the global formatting bar
-        // would fight with it visually and semantically.
-        if (ed.isActive("mermaidBlock")) return false;
-        if (ed.isActive("uiPreviewBlock")) return false;
-        return from !== to;
-      }}
+      options={bubbleMenuOptions}
+      shouldShow={shouldShow}
     >
       <div
         role="toolbar"


### PR DESCRIPTION
## Summary

- thread the collab tile's live scroll-container element into `ArtifactToolbar`
- pass that element through memoized TipTap `BubbleMenu` options so the plugin rebinds its scroll listener when the ref arrives or changes
- stabilize `shouldShow` with `useCallback` to avoid metadata-only option updates on unrelated renders
- cover container-scroll repositioning, window → target A → target B listener migration, late editor mount, and unmount cleanup

## Root cause

TipTap's BubbleMenu plugin listens for scroll on `options.scrollTarget ?? window`. The tile's actual scroller is an inner `overflow-y-auto` element, and its scroll events do not bubble to `window`, so the toolbar never recomputed its position. In Chromium 149, a 300 px tile scroll moved the selection by -300 px while the menu moved 0 px.

The fix passes the tile-owned element directly to the plugin. TipTap's options-update path removes the prior listener and binds the new target, including the callback-ref/late-editor mount order.

## Verification

- `bun run compile`
- `bun run test` — 645 files passed, 1 skipped; 5,324 tests passed, 1 skipped
- `bun run lint`
- `bun run react-doctor` — no issues detected; internal lint analysis timed out after 300s, with standalone ESLint passing
- `pre-commit run --files <three changed files>` — passed, including affected build/compile/lint/format
- Chromium 149 E2E: exact 1:1 tracking in both directions; late-arrival rebind; zero positioning work while hidden; one debounced reposition per scroll burst
