### PR TITLE
fix(gui-app): tame host-error notification noise

### DIFF
--- a/clients/gui-app/src/hooks/notifications/use-notification-mark-entity-read-mutation.ts
+++ b/clients/gui-app/src/hooks/notifications/use-notification-mark-entity-read-mutation.ts
@@ -4,7 +4,7 @@ import type { HostNotificationsEntityRef } from "@traycer/protocol/host/notifica
 import type { ResponseOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import { useHostMutation } from "@/hooks/host/use-host-query";
-import { toastFromHostError } from "@/lib/host-error-toast";
+import { toastFromBackgroundHostError } from "@/lib/host-error-toast";
 import { invalidateNotificationIndicatorsForEntities } from "@/lib/notifications/notification-indicator-cache";
 import { notificationsMutationKeys } from "@/lib/query-keys";
 
@@ -42,8 +42,7 @@ export function useNotificationMarkEntityRead(): UseMutationResult<
         );
       },
       onError: (error) => {
-        if (error.code === "E_HOST_UNSUPPORTED") return;
-        toastFromHostError(
+        toastFromBackgroundHostError(
           error,
           "Couldn't mark viewed notifications as read.",
         );

--- a/clients/gui-app/src/lib/__tests__/host-error-toast.test.ts
+++ b/clients/gui-app/src/lib/__tests__/host-error-toast.test.ts
@@ -16,7 +16,10 @@ import {
   __resetAppLocalNotificationsStoreForTests,
   useAppLocalNotificationsStore,
 } from "@/stores/notifications/app-local-notifications-store";
-import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  HostRpcError,
+  HostTransportFailureError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
 
 function makeError(code: HostRpcError["code"], message: string): HostRpcError {
   return new HostRpcError({
@@ -28,8 +31,30 @@ function makeError(code: HostRpcError["code"], message: string): HostRpcError {
   });
 }
 
+function unauthorizedFatal(
+  requestId: string,
+  method: string,
+  reason: string,
+  retryable: boolean,
+): HostRpcError {
+  return new HostRpcError({
+    code: "UNAUTHORIZED",
+    message: reason,
+    requestId,
+    method,
+    fatalDetails: {
+      code: "UNAUTHORIZED",
+      reason,
+      incompatibleMethods: null,
+      upgradeGuidance: null,
+      ...(retryable ? { retryable: true } : {}),
+    },
+  });
+}
+
 describe("toastFromHostError", () => {
   afterEach(() => {
+    vi.mocked(toast.error).mockClear();
     __resetAppLocalNotificationsStoreForTests();
   });
 
@@ -65,35 +90,126 @@ describe("toastFromHostError", () => {
     expect(toast.error).toHaveBeenCalledWith("Please sign in again.");
   });
 
-  it("uses operation copy for retryable UNAUTHORIZED host failures", () => {
-    __resetAppLocalNotificationsStoreForTests();
+  it("uses verify-session copy for retryable UNAUTHORIZED host failures", () => {
     useAppLocalNotificationsStore.getState().activateIdentity("user-1");
     const reason = "Signing key unavailable: request timed out";
-    const error = new HostRpcError({
-      code: "UNAUTHORIZED",
-      message: reason,
-      requestId: "req-retryable-auth",
-      method: "providers.list",
-      fatalDetails: {
-        code: "UNAUTHORIZED",
-        reason,
-        incompatibleMethods: null,
-        upgradeGuidance: null,
-        retryable: true,
-      },
-    });
 
-    toastFromHostError(error, "Couldn't refresh providers.");
+    toastFromHostError(
+      unauthorizedFatal("req-retryable-auth", "providers.list", reason, true),
+      "Couldn't refresh providers.",
+    );
 
-    expect(toast.error).toHaveBeenCalledWith("Couldn't refresh providers.");
+    expect(toast.error).toHaveBeenCalledWith(
+      "The host couldn't verify your session. Try again in a moment.",
+      { id: "host-error:UNAUTHORIZED:UNAUTHORIZED", cancel: null },
+    );
     expect(
       useAppLocalNotificationsStore.getState().byId[
-        "host.error:providers.list:req-retryable-auth"
+        "host.error:UNAUTHORIZED:UNAUTHORIZED"
       ],
     ).toMatchObject({
-      message: "Couldn't refresh providers.",
+      message: "The host couldn't verify your session. Try again in a moment.",
       detail: reason,
     });
+  });
+
+  it("collapses repeated same-cause fatal failures into one resurfacing feed entry", () => {
+    useAppLocalNotificationsStore.getState().activateIdentity("user-1");
+
+    toastFromHostError(
+      unauthorizedFatal(
+        "req-1",
+        "providers.list",
+        "Expected 200 OK from the JSON Web Key Set endpoint",
+        false,
+      ),
+      "Couldn't load providers.",
+    );
+    useAppLocalNotificationsStore
+      .getState()
+      .markAsRead("host.error:UNAUTHORIZED:UNAUTHORIZED", 10);
+    toastFromHostError(
+      unauthorizedFatal(
+        "req-2",
+        "epic.list",
+        "Host is not provisioned - sign in on this machine to authorize it",
+        false,
+      ),
+      "Couldn't load epics.",
+    );
+
+    const state = useAppLocalNotificationsStore.getState();
+    expect(state.orderedIds).toEqual(["host.error:UNAUTHORIZED:UNAUTHORIZED"]);
+    expect(state.byId["host.error:UNAUTHORIZED:UNAUTHORIZED"]).toMatchObject({
+      message: "Please sign in again.",
+      detail:
+        "Host is not provisioned - sign in on this machine to authorize it",
+      readAt: null,
+    });
+    expect(toast.error).toHaveBeenCalledTimes(2);
+    expect(toast.error).toHaveBeenLastCalledWith("Please sign in again.", {
+      id: "host-error:UNAUTHORIZED:UNAUTHORIZED",
+      cancel: null,
+    });
+  });
+
+  it("does not re-flip a recently acknowledged entry back to unread", () => {
+    useAppLocalNotificationsStore.getState().activateIdentity("user-1");
+
+    toastFromHostError(
+      unauthorizedFatal(
+        "req-1",
+        "providers.list",
+        "Expected 200 OK from the JSON Web Key Set endpoint",
+        false,
+      ),
+      "Couldn't load providers.",
+    );
+    const readAt = Date.now();
+    useAppLocalNotificationsStore
+      .getState()
+      .markAsRead("host.error:UNAUTHORIZED:UNAUTHORIZED", readAt);
+    toastFromHostError(
+      unauthorizedFatal(
+        "req-2",
+        "epic.list",
+        "Host is not provisioned - sign in on this machine to authorize it",
+        false,
+      ),
+      "Couldn't load epics.",
+    );
+
+    const state = useAppLocalNotificationsStore.getState();
+    expect(state.orderedIds).toEqual(["host.error:UNAUTHORIZED:UNAUTHORIZED"]);
+    // A recurrence seconds after the user read the entry keeps it read but
+    // still refreshes it with the latest cause detail.
+    expect(state.byId["host.error:UNAUTHORIZED:UNAUTHORIZED"]).toMatchObject({
+      readAt,
+      detail:
+        "Host is not provisioned - sign in on this machine to authorize it",
+    });
+    expect(state.unreadCount).toBe(0);
+  });
+
+  it("dedupes transport-failure toasts under one id without a feed entry", () => {
+    useAppLocalNotificationsStore.getState().activateIdentity("user-1");
+
+    toastFromHostError(
+      new HostTransportFailureError({
+        code: "RPC_ERROR",
+        message: "WebSocket closed before next frame",
+        requestId: "req-transport",
+        method: "epic.list",
+        fatalDetails: null,
+      }),
+      "Couldn't load epics.",
+    );
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Can't reach the Traycer host. It may be restarting — try again in a moment.",
+      { id: "host-error:transport", cancel: null },
+    );
+    expect(useAppLocalNotificationsStore.getState().orderedIds).toHaveLength(0);
   });
 
   it("shows rebind-blocked copy for WORKTREE_REBIND_BLOCKED", () => {

--- a/clients/gui-app/src/lib/host-error-toast.ts
+++ b/clients/gui-app/src/lib/host-error-toast.ts
@@ -1,4 +1,8 @@
-import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  HostTransportFailureError,
+  isTransientHostRpcFailure,
+  type HostRpcError,
+} from "@traycer-clients/shared/host-transport/host-messenger";
 import { emitHostErrorNotification } from "@/stores/notifications/app-local-notifications-store";
 import { createReportIssueContext } from "@/lib/report-issue-context";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
@@ -16,9 +20,10 @@ export function toastFromHostError(
 ): void {
   const message = hostErrorToastMessage(error, fallback);
   emitHostFatalErrorNotification(error, message);
+  const dedupeKey = hostErrorDedupeKey(error);
   reportableErrorToast(
     message,
-    undefined,
+    dedupeKey === null ? undefined : { id: `host-error:${dedupeKey}` },
     createReportIssueContext({
       title: "Host operation failed",
       message: null,
@@ -28,15 +33,35 @@ export function toastFromHostError(
   );
 }
 
+/**
+ * Error policy for background best-effort host mutations - calls fired by
+ * presence changes or stream frames rather than a user gesture (e.g. marking
+ * the viewed entity's notifications read). These self-heal on reconnect, so a
+ * restarting or unreachable host must not stack operation-named toasts for
+ * work the user never initiated: transient failures (transport-level, or a
+ * fatal frame the host marked retryable) and capability gaps stay silent.
+ * Only a host that was reached and genuinely rejected the operation toasts,
+ * through the same copy mapping as gesture-driven mutations.
+ */
+export function toastFromBackgroundHostError(
+  error: HostRpcError,
+  fallback: string,
+): void {
+  if (error.code === "E_HOST_UNSUPPORTED") return;
+  if (isTransientHostRpcFailure(error)) return;
+  toastFromHostError(error, fallback);
+}
+
 export function toastFromHostErrorWithDetail(
   error: HostRpcError,
   fallback: string,
 ): void {
   const message = hostErrorToastMessageWithDetail(error, fallback);
   emitHostFatalErrorNotification(error, message);
+  const dedupeKey = hostErrorDedupeKey(error);
   reportableErrorToast(
     message,
-    undefined,
+    dedupeKey === null ? undefined : { id: `host-error:${dedupeKey}` },
     createReportIssueContext({
       title: "Host operation failed",
       message: null,
@@ -47,6 +72,11 @@ export function toastFromHostErrorWithDetail(
 }
 
 function hostErrorToastMessage(error: HostRpcError, fallback: string) {
+  // Connection-level failures name the underlying cause, not whichever
+  // operation happened to be in flight when the host went away.
+  if (error instanceof HostTransportFailureError) {
+    return "Can't reach the Traycer host. It may be restarting — try again in a moment.";
+  }
   if (isLastOwnerRevokeError(error.message)) {
     return "Can't revoke the only Owner. Transfer ownership first.";
   }
@@ -54,7 +84,9 @@ function hostErrorToastMessage(error: HostRpcError, fallback: string) {
     return "You don't have permission to do that.";
   }
   if (error.code === "UNAUTHORIZED") {
-    if (error.fatalDetails?.retryable === true) return fallback;
+    if (error.fatalDetails?.retryable === true) {
+      return "The host couldn't verify your session. Try again in a moment.";
+    }
     return "Please sign in again.";
   }
   if (error.code === "WORKTREE_BUSY") {
@@ -104,13 +136,33 @@ function isLastOwnerRevokeError(message: string): boolean {
   );
 }
 
+/**
+ * One connection-level cause produces one dedupe key, regardless of which
+ * request tripped over it. Keying by `method:requestId` minted a fresh feed
+ * entry and toast per failed call, so an auth outage (e.g. a JWKS fetch
+ * failing) stacked identical "Please sign in again." rows as fast as
+ * background calls hit it. With a cause key, the store's upsert and sonner's
+ * id-replacement collapse repeats into one entry that resurfaces (unread,
+ * fresh timestamp, latest detail) each time the cause fires again.
+ */
+function hostErrorDedupeKey(error: HostRpcError): string | null {
+  if (error.fatalDetails !== null) {
+    return `${error.code}:${error.fatalDetails.code}`;
+  }
+  if (error instanceof HostTransportFailureError) {
+    return "transport";
+  }
+  return null;
+}
+
 function emitHostFatalErrorNotification(
   error: HostRpcError,
   message: string,
 ): void {
   if (error.fatalDetails === null) return;
+  const dedupeKey = hostErrorDedupeKey(error);
   emitHostErrorNotification({
-    id: `${error.method}:${error.requestId}`,
+    id: dedupeKey ?? `${error.method}:${error.requestId}`,
     message,
     detail: error.fatalDetails.reason,
     payload: null,

--- a/clients/gui-app/src/lib/notifications/__tests__/notification-display.test.ts
+++ b/clients/gui-app/src/lib/notifications/__tests__/notification-display.test.ts
@@ -1,11 +1,16 @@
+import "../../../../__tests__/test-browser-apis";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HostNotificationEntry } from "@traycer/protocol/host/notifications/contracts";
 import {
+  displayHostChannelEmission,
   displayNotificationRows,
   notificationReplaceKey,
 } from "@/lib/notifications/notification-display";
 import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { makeOpenableNodeRef } from "@/stores/epics/canvas/types";
 
 interface CapturedToast {
   readonly title: string;
@@ -250,5 +255,119 @@ describe("notification display", () => {
 
     expect(onToastClick).not.toHaveBeenCalled();
     expect(dismiss).toHaveBeenCalledWith("host:chat:chat-1");
+  });
+});
+
+function hostEntry(id: string, chatId: string | null): HostNotificationEntry {
+  return {
+    id,
+    updatedAt: 10,
+    readAt: null,
+    kind: "agent.stopped",
+    sourceRef: id,
+    severity: "done",
+    outcome: "completed",
+    epicId: "epic-1",
+    chatId,
+    payload:
+      chatId === null
+        ? {
+            kind: "epic",
+            epicId: "epic-1",
+            tuiAgentId: "tui-1",
+            agentName: "Agent",
+            taskTitle: "Task",
+            outcome: "completed",
+          }
+        : {
+            kind: "chat",
+            epicId: "epic-1",
+            chatId,
+            agentName: "Agent",
+            taskTitle: "Task",
+            outcome: "completed",
+          },
+  };
+}
+
+describe("host channel emission focus gate", () => {
+  beforeEach(() => {
+    toastCalls.length = 0;
+    customToastCalls.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    useEpicCanvasStore.setState({
+      tabsById: {},
+      canvasByTabId: {},
+      openTabOrder: [],
+      activeTabId: null,
+      mostRecentTabIdByEpicId: {},
+    });
+    cleanup();
+  });
+
+  function focusChatTile(chatId: string): void {
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+    useEpicCanvasStore.getState().openTileInTab(
+      tabId,
+      makeOpenableNodeRef({
+        id: chatId,
+        instanceId: `${chatId}-instance`,
+        type: "chat",
+        name: "Chat",
+        hostId: "host-1",
+      }),
+    );
+  }
+
+  function displayTarget() {
+    return {
+      showNotification: vi.fn(() => Promise.resolve()),
+      playChime: vi.fn(),
+      onToastClick: vi.fn(),
+    };
+  }
+
+  it("suppresses rows addressed to the focused chat, including epic rollups", () => {
+    focusChatTile("chat-1");
+    const target = displayTarget();
+
+    displayHostChannelEmission(
+      [hostEntry("n-1", "chat-1"), hostEntry("n-2", null)],
+      target,
+    );
+
+    expect(target.showNotification).not.toHaveBeenCalled();
+    expect(target.playChime).not.toHaveBeenCalled();
+    expect(toastCalls).toHaveLength(0);
+    expect(customToastCalls).toHaveLength(0);
+  });
+
+  it("still displays rows for a sibling chat in the same epic", () => {
+    focusChatTile("chat-1");
+    const target = displayTarget();
+
+    displayHostChannelEmission(
+      [hostEntry("n-1", "chat-1"), hostEntry("n-2", "chat-2")],
+      target,
+    );
+
+    expect(target.showNotification).toHaveBeenCalledOnce();
+    expect(target.playChime).toHaveBeenCalledOnce();
+    expect(customToastCalls).toHaveLength(1);
+  });
+
+  it("displays rows for the active entity when the window is blurred", () => {
+    focusChatTile("chat-1");
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    const target = displayTarget();
+
+    displayHostChannelEmission([hostEntry("n-1", "chat-1")], target);
+
+    expect(target.showNotification).toHaveBeenCalledOnce();
+    expect(target.playChime).toHaveBeenCalledOnce();
   });
 });

--- a/clients/gui-app/src/lib/notifications/index.ts
+++ b/clients/gui-app/src/lib/notifications/index.ts
@@ -14,6 +14,7 @@ export {
   notificationEntitiesMatch,
   notificationEntityFromHostEntry,
   notificationEntityFromPayload,
+  notificationEntityMatchesPresence,
   notificationPayloadBelongsToEpic,
   notificationPayloadBelongsToEntity,
 } from "./notification-entity";

--- a/clients/gui-app/src/lib/notifications/notification-display.ts
+++ b/clients/gui-app/src/lib/notifications/notification-display.ts
@@ -8,6 +8,11 @@ import {
 } from "@/stores/notifications/merged-notifications";
 import type { AppLocalNotificationEntry } from "@/stores/notifications/app-local-notifications-store";
 import type { HostNotificationEntry } from "@traycer/protocol/host/notifications/contracts";
+import {
+  notificationEntityFromHostEntry,
+  notificationEntityMatchesPresence,
+} from "@/lib/notifications/notification-entity";
+import { readFocusedHostNotificationPresenceEntity } from "@/lib/notifications/notification-presence";
 
 export interface NotificationDisplayTarget {
   readonly showNotification: NotificationShow;
@@ -86,11 +91,30 @@ export function displayNotificationRows(
   target.playChime();
 }
 
+/**
+ * Host-side presence suppression is authoritative (fresh presence marks the
+ * row read at birth and skips the renderer channel entirely), but it runs on
+ * TTL'd presence snapshots — an emission can already be in flight when focus
+ * lands on the entity, or presence can go stale mid-hold. This gate re-checks
+ * live focus at display time so the tab you are looking at never toasts about
+ * its own activity; rows for other entities still display.
+ */
 export function displayHostChannelEmission(
   entries: ReadonlyArray<HostNotificationEntry>,
   target: NotificationDisplayTarget,
 ): void {
-  displayNotificationRows(entries.map(rowFromHostEntry), target);
+  const focusedEntity = readFocusedHostNotificationPresenceEntity();
+  const visibleEntries =
+    focusedEntity === null
+      ? entries
+      : entries.filter((entry) => {
+          const entity = notificationEntityFromHostEntry(entry);
+          return (
+            entity === null ||
+            !notificationEntityMatchesPresence(entity, focusedEntity)
+          );
+        });
+  displayNotificationRows(visibleEntries.map(rowFromHostEntry), target);
 }
 
 export function displayAppLocalNotification(

--- a/clients/gui-app/src/lib/notifications/notification-entity.ts
+++ b/clients/gui-app/src/lib/notifications/notification-entity.ts
@@ -1,6 +1,7 @@
 import type {
   HostNotificationEntry,
   HostNotificationsEntityRef,
+  HostNotificationsPresenceEntity,
 } from "@traycer/protocol/host/notifications/contracts";
 
 /**
@@ -37,6 +38,21 @@ export function notificationEntitiesMatch(
   right: HostNotificationsEntityRef,
 ): boolean {
   return left.epicId === right.epicId && left.chatId === right.chatId;
+}
+
+/**
+ * Whether a notification's entity is covered by a focused presence entity,
+ * mirroring the host emission service's suppression semantics: the epic must
+ * match, and a chat-addressed notification additionally needs the same chat
+ * in focus. An epic-level notification is covered by any focused tile inside
+ * that epic; a chat-level one is not covered by a sibling chat.
+ */
+export function notificationEntityMatchesPresence(
+  entity: HostNotificationsEntityRef,
+  presence: HostNotificationsPresenceEntity,
+): boolean {
+  if (presence.epicId !== entity.epicId) return false;
+  return entity.chatId === undefined || presence.chatId === entity.chatId;
 }
 
 export function notificationPayloadBelongsToEntity(

--- a/clients/gui-app/src/lib/notifications/notification-presence.ts
+++ b/clients/gui-app/src/lib/notifications/notification-presence.ts
@@ -60,6 +60,17 @@ export function subscribeHostNotificationPresence(
   };
 }
 
+/**
+ * The entity this window is actively looking at, or `null` when the window is
+ * blurred or no epic/chat tile is active. Read live (canvas store + document
+ * focus) so display-time gates see the current state rather than the last
+ * presence frame that happened to be sent.
+ */
+export function readFocusedHostNotificationPresenceEntity(): HostNotificationsPresenceEntity | null {
+  if (!isDocumentFocused()) return null;
+  return readActiveHostNotificationPresenceEntity();
+}
+
 function isDocumentFocused(): boolean {
   return typeof document !== "undefined" && document.hasFocus();
 }

--- a/clients/gui-app/src/stores/notifications/__tests__/host-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/host-notifications-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   hostStreamRpcRegistry,
   type HostStreamRpcRegistry,
@@ -20,6 +20,7 @@ import {
 } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import {
   __resetHostNotificationsStoreForTests,
+  HOST_NOTIFICATIONS_PRESENCE_HEARTBEAT_MS,
   openHostNotificationsStream,
   useHostNotificationsStore,
 } from "@/stores/notifications/host-notifications-store";
@@ -545,5 +546,41 @@ describe("host notifications store", () => {
     });
 
     close();
+  });
+
+  it("re-sends unchanged presence on the heartbeat cadence and stops on close", () => {
+    vi.useFakeTimers();
+    try {
+      const client = new MockWsStreamClient();
+
+      const close = openHostNotificationsStream(client, null, {
+        windowId: "window-1",
+        now: () => 456,
+        displayChannelEmission: () => undefined,
+        onFeedFrame: () => undefined,
+        onPresenceChanged: () => undefined,
+        onStreamOpened: () => undefined,
+      });
+
+      expect(client.session.clientFrames).toHaveLength(1);
+
+      // Nothing changed locally — the heartbeat must still refresh the
+      // host's TTL'd presence record, bypassing the content dedupe.
+      vi.advanceTimersByTime(HOST_NOTIFICATIONS_PRESENCE_HEARTBEAT_MS);
+      expect(client.session.clientFrames).toHaveLength(2);
+      expect(client.session.clientFrames[1]).toMatchObject({
+        kind: "presence",
+        windowId: "window-1",
+      });
+
+      vi.advanceTimersByTime(HOST_NOTIFICATIONS_PRESENCE_HEARTBEAT_MS);
+      expect(client.session.clientFrames).toHaveLength(3);
+
+      close();
+      vi.advanceTimersByTime(3 * HOST_NOTIFICATIONS_PRESENCE_HEARTBEAT_MS);
+      expect(client.session.clientFrames).toHaveLength(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/clients/gui-app/src/stores/notifications/app-local-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/app-local-notifications-store.ts
@@ -10,6 +10,14 @@ import type { HostNotificationsEntityRef } from "@traycer/protocol/host/notifica
 
 export const APP_LOCAL_NOTIFICATIONS_ROW_CAP = 200;
 
+/**
+ * How long a read cause-keyed entry stays acknowledged before a recurrence
+ * of the same cause flips it back to unread. Caps badge churn from a
+ * high-frequency failure at one unread-flip per window while still
+ * re-surfacing a problem the user acknowledged but that keeps happening.
+ */
+export const APP_LOCAL_RESURFACE_COOLDOWN_MS = 5 * 60_000;
+
 export type AppLocalNotificationKind =
   | "terminal.closed"
   | "terminal.crashed"
@@ -42,6 +50,7 @@ export interface AppLocalNotificationsState {
   activateIdentity: (userId: string) => void;
   deactivateIdentity: () => void;
   upsert: (entry: AppLocalNotificationEntry) => void;
+  upsertReplacing: (entry: AppLocalNotificationEntry) => void;
   markAsRead: (id: string, readAt: number) => void;
   markEntityAsRead: (
     entity: HostNotificationsEntityRef,
@@ -117,6 +126,41 @@ export function createAppLocalNotificationsStore(initialName: string) {
             const byId = cappedAppLocalEntries({
               ...state.byId,
               [entry.id]: entry,
+            });
+            const projection = projectAppLocalNotifications(byId);
+            return {
+              byId,
+              orderedIds: projection.orderedIds,
+              unreadCount: projection.unreadCount,
+            };
+          });
+        },
+
+        // For cause-keyed entries (recurring host errors): replaces the
+        // existing row so the single entry carries the latest occurrence -
+        // fresh timestamp, latest detail - instead of either stacking
+        // duplicates or (like `upsert`) silently dropping every recurrence
+        // after the first, which a persisted store would otherwise do
+        // forever. A recurrence flips the row back to unread only when the
+        // user's read-acknowledgement is older than the resurface cooldown;
+        // a cause firing every few seconds must not re-light the badge as
+        // fast as it fires.
+        upsertReplacing: (entry) => {
+          if (get().activeUserId === null) return;
+          set((state) => {
+            const existing = Object.hasOwn(state.byId, entry.id)
+              ? state.byId[entry.id]
+              : null;
+            const acknowledged =
+              existing !== null &&
+              existing.readAt !== null &&
+              entry.updatedAt - existing.readAt <
+                APP_LOCAL_RESURFACE_COOLDOWN_MS;
+            const byId = cappedAppLocalEntries({
+              ...state.byId,
+              [entry.id]: acknowledged
+                ? { ...entry, readAt: existing.readAt }
+                : entry,
             });
             const projection = projectAppLocalNotifications(byId);
             return {
@@ -317,7 +361,7 @@ export function emitHostErrorNotification(input: {
   readonly detail: string | null;
   readonly payload: NotificationPayload | null;
 }): void {
-  useAppLocalNotificationsStore.getState().upsert({
+  useAppLocalNotificationsStore.getState().upsertReplacing({
     id: `host.error:${input.id}`,
     updatedAt: Date.now(),
     readAt: null,

--- a/clients/gui-app/src/stores/notifications/host-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/host-notifications-store.ts
@@ -21,6 +21,15 @@ import {
 
 export const HOST_NOTIFICATIONS_INITIAL_LIMIT = 50;
 
+/**
+ * The host expires presence records after a short TTL (15s at the time of
+ * writing) so a dead window can't suppress deliveries forever. A change-driven
+ * presence send alone therefore goes stale whenever the user simply stays on
+ * one tab — exactly the case suppression exists for — so the stream re-sends
+ * the current presence on this cadence, comfortably inside that TTL.
+ */
+export const HOST_NOTIFICATIONS_PRESENCE_HEARTBEAT_MS = 5_000;
+
 export type HostNotificationFeedEntry = HostNotificationEntry;
 
 export type HostNotificationsFeedFrame = Extract<
@@ -298,7 +307,9 @@ export function openHostNotificationsStream(
     initialLimit: HOST_NOTIFICATIONS_INITIAL_LIMIT,
   });
   let lastPresenceKey: string | null = null;
-  const sendPresence = (): void => {
+  // `force` refreshes the host's TTL'd presence record even when nothing
+  // changed locally; change-driven sends stay deduplicated by content.
+  const sendPresence = (force: boolean): void => {
     const frame = readHostNotificationPresenceFrame({
       windowId: options.windowId,
       now: options.now,
@@ -311,13 +322,18 @@ export function openHostNotificationsStream(
       focused: presence.focused,
       entity: presence.entity,
     });
-    if (presenceKey === lastPresenceKey) return;
+    if (!force && presenceKey === lastPresenceKey) return;
     lastPresenceKey = presenceKey;
     session.sendClientFrame(presence, null);
     options.onPresenceChanged(presence);
   };
-  const unsubscribePresence = subscribeHostNotificationPresence(sendPresence);
-  sendPresence();
+  const unsubscribePresence = subscribeHostNotificationPresence(() => {
+    sendPresence(false);
+  });
+  const presenceHeartbeat = globalThis.setInterval(() => {
+    sendPresence(true);
+  }, HOST_NOTIFICATIONS_PRESENCE_HEARTBEAT_MS);
+  sendPresence(true);
   session.onServerFrame((envelope, binaryPayload) => {
     if (binaryPayload !== null) return;
     const parsed =
@@ -378,11 +394,12 @@ export function openHostNotificationsStream(
     if (status === "open") {
       lastPresenceKey = null;
       options.onStreamOpened();
-      sendPresence();
+      sendPresence(true);
     }
     handleHostNotificationsCloseReason(reason, onAuthError);
   });
   return () => {
+    globalThis.clearInterval(presenceHeartbeat);
     unsubscribePresence();
     session.close();
   };

--- a/clients/shared/host-transport/__tests__/host-messenger-transient-classifier.test.ts
+++ b/clients/shared/host-transport/__tests__/host-messenger-transient-classifier.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  HostRpcError,
+  HostTransportFailureError,
+  RetryableTransportError,
+  isTransientHostRpcFailure,
+} from "../host-messenger";
+
+const base = {
+  code: "RPC_ERROR" as const,
+  message: "boom",
+  requestId: "req-1",
+  method: "host.echo",
+  fatalDetails: null,
+};
+
+describe("isTransientHostRpcFailure", () => {
+  it("classifies transport-level failures as transient", () => {
+    expect(isTransientHostRpcFailure(new HostTransportFailureError(base))).toBe(
+      true,
+    );
+    expect(isTransientHostRpcFailure(new RetryableTransportError(base))).toBe(
+      true,
+    );
+  });
+
+  it("classifies a retryable fatal frame as transient", () => {
+    expect(
+      isTransientHostRpcFailure(
+        new HostRpcError({
+          ...base,
+          code: "UNAUTHORIZED",
+          fatalDetails: {
+            code: "UNAUTHORIZED",
+            reason: "signing key unavailable",
+            retryable: true,
+            incompatibleMethods: null,
+            upgradeGuidance: null,
+          },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps host-originated rejections non-transient", () => {
+    expect(isTransientHostRpcFailure(new HostRpcError(base))).toBe(false);
+    expect(
+      isTransientHostRpcFailure(
+        new HostRpcError({
+          ...base,
+          code: "UNAUTHORIZED",
+          fatalDetails: {
+            code: "UNAUTHORIZED",
+            reason: "token rejected",
+            incompatibleMethods: null,
+            upgradeGuidance: null,
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/clients/shared/host-transport/__tests__/ws-rpc-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-rpc-client.test.ts
@@ -9,7 +9,11 @@ import {
   defineVersionedRpcRegistry,
   type VersionedRpcRegistry,
 } from "@traycer/protocol/framework/index";
-import { HostRpcError, RetryableTransportError } from "../host-messenger";
+import {
+  HostRpcError,
+  HostTransportFailureError,
+  RetryableTransportError,
+} from "../host-messenger";
 import {
   createRequestContext,
   identityFromAuthenticatedUser,
@@ -685,7 +689,7 @@ describe("WsRpcClient", () => {
 
     await expect(pending).rejects.toSatisfy(
       (error: unknown) =>
-        error instanceof HostRpcError &&
+        error instanceof HostTransportFailureError &&
         !(error instanceof RetryableTransportError) &&
         error.message.includes("frame timed out"),
     );
@@ -809,7 +813,7 @@ describe("WsRpcClient", () => {
     await expect(pending).rejects.toSatisfy(
       (error: unknown) =>
         error instanceof HostRpcError &&
-        !(error instanceof RetryableTransportError) &&
+        !(error instanceof HostTransportFailureError) &&
         error.message.includes("Malformed host frame:"),
     );
   });

--- a/clients/shared/host-transport/host-messenger.ts
+++ b/clients/shared/host-transport/host-messenger.ts
@@ -135,23 +135,44 @@ export function classifyHostRequestFailure(error: unknown): HostRequestFailure {
 }
 
 /**
- * A `HostRpcError` raised by a transient transport failure that occurred
- * *before* the request frame was put on the wire - a dial timeout, an
- * `onerror`/`onclose` during the dial-or-handshake phase, or a handshake
- * (`openAck`) frame timeout.
+ * A `HostRpcError` whose cause is the transport itself - no host bound, a
+ * dropped or unopenable WebSocket, a dial or frame timeout - rather than the
+ * host rejecting the operation. The host either never saw the request or
+ * never answered it, so the failure says nothing about the method that
+ * happened to be in flight.
+ *
+ * It is a `HostRpcError` (`code` stays `"RPC_ERROR"`) so existing
+ * `instanceof HostRpcError` / `code`-based handling - the auth-aware wrapper,
+ * error toasts - keeps treating it exactly as it did before, while UI layers
+ * can branch on the class to describe the connection ("host unreachable")
+ * instead of the operation.
+ */
+export class HostTransportFailureError extends HostRpcError {
+  constructor(details: {
+    code: RpcErrorCode;
+    message: string;
+    requestId: string;
+    method: string;
+    fatalDetails: FatalErrorDetails | null;
+  }) {
+    super(details);
+    this.name = "HostTransportFailureError";
+  }
+}
+
+/**
+ * A `HostTransportFailureError` that occurred *before* the request frame was
+ * put on the wire - a dial timeout, an `onerror`/`onclose` during the
+ * dial-or-handshake phase, or a handshake (`openAck`) frame timeout.
  *
  * The "before the request was sent" guarantee is what makes it safe to retry
  * even non-idempotent methods: the host never observed the call, so a fresh
  * dial cannot double-apply a side effect. `createRetryingMessenger` keys its
- * bounded retry off this subclass; every other failure (a post-send drop, a
- * malformed frame, or any host-originated error) stays a plain `HostRpcError`
- * and propagates on the first attempt.
- *
- * It is a `HostRpcError` (`code` stays `"RPC_ERROR"`) so existing
- * `instanceof HostRpcError` / `code`-based handling - the auth-aware wrapper,
- * error toasts - keeps treating it exactly as it did before.
+ * bounded retry off this subclass; a post-send drop stays a
+ * `HostTransportFailureError`, and a malformed frame or any host-originated
+ * error stays a plain `HostRpcError` - both propagate on the first attempt.
  */
-export class RetryableTransportError extends HostRpcError {
+export class RetryableTransportError extends HostTransportFailureError {
   constructor(details: {
     code: RpcErrorCode;
     message: string;
@@ -162,4 +183,19 @@ export class RetryableTransportError extends HostRpcError {
     super(details);
     this.name = "RetryableTransportError";
   }
+}
+
+/**
+ * True when the failure is expected to clear on its own: the transport never
+ * got an answer from the host (restart, dropped socket, dial/frame timeout),
+ * or the host answered with a fatal frame it explicitly marked `retryable`
+ * (e.g. a transient credential-verification outage). Background best-effort
+ * callers use this to fail silently; user-gesture surfaces can still toast,
+ * describing the connection rather than the operation.
+ */
+export function isTransientHostRpcFailure(error: HostRpcError): boolean {
+  return (
+    error instanceof HostTransportFailureError ||
+    error.fatalDetails?.retryable === true
+  );
 }

--- a/clients/shared/host-transport/ws-rpc-client.ts
+++ b/clients/shared/host-transport/ws-rpc-client.ts
@@ -20,6 +20,7 @@ import type {
 } from "@traycer-clients/shared/auth/bearer-source";
 import {
   HostRpcError,
+  HostTransportFailureError,
   RetryableTransportError,
   type IHostMessenger,
   type RequestOfMethod,
@@ -114,7 +115,8 @@ export interface WsRpcClientOptions<Registry extends VersionedRpcRegistry> {
  *
  * Failure mapping (Refactoring Approach D-N2):
  *   - dial timeout / transport unreachable / transport aborted / frame timeout
- *     → `HostRpcError(code: "RPC_ERROR")`
+ *     → `HostTransportFailureError(code: "RPC_ERROR")` (the pre-send subset is
+ *     a `RetryableTransportError`)
  *   - missing / released bearer before dial → `HostRpcError(code: "RPC_ERROR")`
  *   - host `fatalError { code }` (`INCOMPATIBLE`, `UNAUTHORIZED`, or a
  *     domain-specific code) → known RPC codes are preserved on
@@ -173,7 +175,7 @@ export class WsRpcClient<
     const selected = this.endpoint();
 
     if (selected === null) {
-      throw new HostRpcError({
+      throw new HostTransportFailureError({
         code: "RPC_ERROR",
         message: "No host is currently bound to the client",
         requestId,
@@ -810,8 +812,8 @@ function openSession(options: SessionOptions): Session {
   // Flipped the instant the `request` frame is handed to `send`. Before this
   // point every transient failure is provably pre-send (the host never saw the
   // call), so it surfaces as a `RetryableTransportError`; after it, the same
-  // failure shapes stay a plain `HostRpcError` because a retry could
-  // re-execute a non-idempotent method.
+  // failure shapes stay a non-retryable `HostTransportFailureError` because a
+  // retry could re-execute a non-idempotent method.
   let requestSent = false;
   let failure: HostRpcError | null = null;
 
@@ -823,7 +825,7 @@ function openSession(options: SessionOptions): Session {
    */
   const transientFailure = (message: string): HostRpcError =>
     requestSent
-      ? new HostRpcError({
+      ? new HostTransportFailureError({
           code: "RPC_ERROR",
           message,
           requestId,


### PR DESCRIPTION
## Problem

When the host is unreachable, restarting, or hitting a transient auth-verification outage (e.g. a JWKS fetch failing), the notification feed and toasts **spam** — a fresh "Please sign in again." / operation-named entry per failed request, stacking as fast as background calls hit the failure.

## Fixes

**1. Transport-vs-rejection errors**
- New `HostTransportFailureError` (no host bound, dropped/unopenable socket, dial/frame timeout); `RetryableTransportError` is now its pre-send subset. Adds `isTransientHostRpcFailure()`.
- Connection-level failures toast **cause-centric** copy ("Can't reach the Traycer host…") instead of naming whichever operation was in flight.
- Background best-effort mutations (presence-driven mark-entity-read) go **silent** on transient failures via `toastFromBackgroundHostError` — they self-heal on reconnect.

**2. Focused-tab suppression**
- Don't display an in-app notification for the entity the window is actively looking at. A 5s presence heartbeat keeps the host's TTL'd presence record fresh; `displayHostChannelEmission` re-checks **live focus at display time** as a race guard. Sibling chats in the same epic still display.

**3. Error dedupe + resurface cooldown**
- Feed entries and toasts are keyed by **cause** (`code:fatalDetails.code`, or `transport`) so repeats collapse into one resurfacing entry / one replaced toast instead of stacking per request.
- New `upsertReplacing` store action refreshes the row with the latest detail; a recurrence only re-flips it to **unread** when the user's read-ack is older than a 5min cooldown — capping badge churn from a high-frequency failure.

## Testing

- Full gui-app suite green (5443 passed); shared 347 passed.
- New/updated: transport classifier, focused-tab gate + presence heartbeat, cause-collapse, resurface cooldown, transport-toast dedupe.
- `compile` clean, `lint` clean, react-doctor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)