### PR TITLE
feat(gui): PostHog user-journey analytics with a strict privacy boundary

### DIFF
--- a/clients/gui-app/eslint.config.mjs
+++ b/clients/gui-app/eslint.config.mjs
@@ -194,6 +194,30 @@ export default tseslint.config(
 
   // ── Per-directory overrides ─────────────────────────────────────────────────
   {
+    // PostHog is reachable only through the typed adapter so every event and
+    // property passes its allowlist sanitizer before leaving the app. The
+    // adapter's own test is the one other legitimate consumer: it drives the
+    // real SDK through the sanitizer to prove the payload boundary.
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["src/lib/analytics.ts", "src/lib/__tests__/analytics.test.ts"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          ...traycerClientsImportBoundaryRestrictions,
+          patterns: [
+            ...(traycerClientsImportBoundaryRestrictions.patterns ?? []),
+            {
+              group: ["posthog-js", "posthog-js/*"],
+              message:
+                "Import PostHog only through the typed adapter in @/lib/analytics.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     // shadcn/ui generated primitives follow library conventions that
     // intentionally diverge from app-code rules.
     files: ["src/components/ui/**/*.tsx"],

--- a/clients/gui-app/src/components/auth/user-menu.tsx
+++ b/clients/gui-app/src/components/auth/user-menu.tsx
@@ -16,6 +16,7 @@ import { useTitleBarDragSuppression } from "@/stores/layout/title-bar-drag-store
 import { getSystemTabModalApi } from "@/stores/tabs/system-tab-modal-bridge";
 import { ExternalLink, LogOut, Settings } from "lucide-react";
 import { useState } from "react";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface UserMenuProps {
   readonly userName: string;
@@ -90,6 +91,10 @@ export function UserMenu(props: UserMenuProps) {
             data-testid="user-menu-app-settings"
             onSelect={() => {
               setOpen(false);
+              Analytics.getInstance().track(AnalyticsEvent.SettingsOpened, {
+                source: "direct_ui",
+                section: "general",
+              });
               getSystemTabModalApi()?.openSettings({
                 section: null,
                 resetToGeneral: true,
@@ -104,7 +109,12 @@ export function UserMenu(props: UserMenuProps) {
           data-testid="user-menu-manage-subscription"
           onSelect={() => {
             setOpen(false);
-            void runnerHost.openExternalLink(manageSubscriptionUrl);
+            void runnerHost.openExternalLink(manageSubscriptionUrl).then(() => {
+              Analytics.getInstance().track(
+                AnalyticsEvent.SubscriptionManagementOpened,
+                { source: "direct_ui" },
+              );
+            });
           }}
         >
           <ExternalLink className="size-3.5" />
@@ -116,6 +126,9 @@ export function UserMenu(props: UserMenuProps) {
           variant="destructive"
           onSelect={() => {
             setOpen(false);
+            Analytics.getInstance().track(AnalyticsEvent.SignOutRequested, {
+              source: "direct_ui",
+            });
             void auth.signOut();
           }}
         >

--- a/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
+++ b/clients/gui-app/src/components/chat/chat-fork-dialog.tsx
@@ -44,6 +44,7 @@ import type { SeedIntentOverride } from "@/lib/worktree/worktree-intent-seeding"
 import { readSeededLaunchWorkspace } from "@/lib/worktree/seeded-launch-worktree-intent";
 import { useSeededWorkspaceSnapshotStore } from "@/stores/worktree/seeded-workspace-snapshot-store";
 import { deriveWorkspaceMode } from "@/lib/worktree/workspace-mode";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 const activeChatForkWorkspaceOwnerByKey = new Map<string, symbol>();
 
@@ -265,6 +266,10 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
       },
       {
         onSuccess: (result) => {
+          Analytics.getInstance().track(AnalyticsEvent.ChatForked, {
+            source: "direct_ui",
+            include_history: true,
+          });
           clearChatForkWorkspace(stagingKey);
           const cancel = openCreatedChatWhenProjectedWithNavigation({
             intent: {
@@ -273,6 +278,7 @@ function ChatForkDialogBody(props: ChatForkDialogProps) {
               tabId,
               chatId: result.chatId,
               hostId,
+              source: "direct_ui",
             },
             navigateNestedFocus,
           });

--- a/clients/gui-app/src/components/chat/composer/chat-composer.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer.tsx
@@ -62,6 +62,7 @@ import {
 import { useComposerPickerItems } from "./picker/use-composer-picker-items";
 import { commitSelection } from "@/stores/composer/commit-selection";
 import { useTaskProfileRateLimitSwitch } from "./use-task-profile-rate-limit-switch";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface ChatComposerProps {
   readonly taskId: string;
@@ -313,6 +314,10 @@ function ChatComposerImpl(props: ChatComposerProps) {
   } = useComposerPaste(editorRef);
 
   const removeImage = useCallback((id: string) => {
+    Analytics.getInstance().track(AnalyticsEvent.AttachmentRemoved, {
+      kind: "image",
+      surface: "chat",
+    });
     editorRef.current?.removeImageAttachmentById(id);
   }, []);
 

--- a/clients/gui-app/src/components/command-palette/palette-cmdk-controller.ts
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk-controller.ts
@@ -20,6 +20,11 @@ import type {
   CommandItem as CommandItemShape,
   CommandSubpage,
 } from "@/lib/commands/types";
+import {
+  Analytics,
+  AnalyticsEvent,
+  type AnalyticsCommand,
+} from "@/lib/analytics";
 
 export function buildCmdkValue(item: CommandItemShape): string {
   return `${item.id} ${item.label}`;
@@ -167,6 +172,13 @@ export function usePaletteController(
         resetQuery();
         return;
       }
+      const analyticsCommand = analyticsCommandForItem(item);
+      if (analyticsCommand !== null) {
+        Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
+          command: analyticsCommand,
+          source: "command_palette",
+        });
+      }
       void runCommandItem(item, ctx, { recordUse, close });
     },
     [ctx, recordUse, close, resetQuery],
@@ -180,4 +192,23 @@ export function usePaletteController(
   const resetStack = useCallback(() => setSubpageStack([]), []);
 
   return { activeSubpage, runItem, popSubpage, resetStack };
+}
+
+function analyticsCommandForItem(
+  item: CommandItemShape,
+): AnalyticsCommand | null {
+  if (item.id.startsWith("open:files:")) return "open_file";
+  if (item.id.startsWith("open:diff:")) return "open_diff";
+  if (item.id.startsWith("open:chats:")) return "open_chat";
+  if (item.id.startsWith("open:artifacts:")) return "open_artifact";
+  if (item.id.startsWith("open:terminals:")) return "open_terminal";
+  if (item.id.startsWith("open:tui:")) return "open_terminal";
+  if (item.id.startsWith("epic:")) return "open_task";
+  if (item.id === "help:report-issue") return "report_issue";
+  if (item.actionId === "epic.new") return "create_task";
+  if (item.actionId === "epic.duplicate-tab") return "duplicate_tab";
+  if (item.actionId === "app.settings.open") return "open_settings";
+  if (item.actionId === "app.history.open") return "open_task";
+  if (item.actionId === "app.terminal.new") return "open_terminal";
+  return null;
 }

--- a/clients/gui-app/src/components/epic-canvas/canvas/use-rename-canvas-tab.ts
+++ b/clients/gui-app/src/components/epic-canvas/canvas/use-rename-canvas-tab.ts
@@ -32,11 +32,15 @@ export function useRenameCanvasTab(
   const renameArtifactInTab = useEpicCanvasStore((s) => s.renameArtifactInTab);
   const renameChat = useEpicRenameChat();
   const renameTerminalAgent = useEpicRenameTuiAgent();
-  const renameArtifact = useEpicRenameArtifact();
+  const renameArtifact = useEpicRenameArtifact(true);
 
   return useCallback(
     (tab, rawTitle) => {
       const trimmed = rawTitle.trim();
+      // No same-title suppression: the optimistic local update can already be
+      // ahead of a failed RPC, and resubmitting the visible title is the
+      // user's retry path. A duplicate rename RPC is harmless (HEAD behavior);
+      // the event only fires on authoritative mutation success.
       if (trimmed.length === 0) return;
       if (tab.type === "terminal") return;
       const id = tab.id;

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-close-navigation.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-tile-close-navigation.test.tsx
@@ -94,10 +94,14 @@ vi.mock("@/lib/perf/terminal-load-perf", () => ({
 }));
 
 vi.mock("@/lib/analytics", () => ({
-  AnalyticsEvent: { TerminalOpened: "TerminalOpened" },
+  AnalyticsEvent: {
+    TerminalOpened: "TerminalOpened",
+    TabClosed: "TabClosed",
+  },
   Analytics: {
     getInstance: () => ({ track: vi.fn() }),
   },
+  analyticsTargetForCanvasTileType: () => null,
 }));
 
 import { TerminalTile } from "../terminal-tile";

--- a/clients/gui-app/src/components/epic-canvas/renderers/git-diff-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/git-diff-tile.tsx
@@ -210,7 +210,7 @@ function GitDiffTileToolbar(props: GitDiffTileToolbarProps): ReactNode {
   const patchDiffViewerPreferences = useSettingsStore(
     (s) => s.patchDiffViewerPreferences,
   );
-  const editorOpen = useEditorOpen();
+  const editorOpen = useEditorOpen("file");
   const { mutateAsync: refreshWorktreeStatus } = useGitRefreshWorktreeStatus();
   const updateView = useEpicCanvasStore((s) => s.updateGitDiffTileViewInTab);
   const { active: openFileFeedbackActive, trigger: triggerOpenFileFeedback } =
@@ -408,7 +408,7 @@ interface GitFileDiffPanelProps {
 
 function GitFileDiffPanel(props: GitFileDiffPanelProps): ReactNode {
   const defaultEditor = useSettingsStore((s) => s.defaultEditor);
-  const editorOpen = useEditorOpen();
+  const editorOpen = useEditorOpen("file");
   const {
     active: openExternallyFeedbackActive,
     trigger: triggerOpenExternallyFeedback,

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-agent-fork-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-agent-fork-dialog.tsx
@@ -36,6 +36,7 @@ import {
   type WorktreeStagingKey,
 } from "@/stores/worktree/worktree-intent-staging-store";
 import { useWorktreeIntentMemoryStore } from "@/stores/worktree/worktree-intent-memory-store";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 // `pendingForkTerminalAgentStagingKey` is per-EPIC, so every terminal-agent
 // tile in an epic shares one staging slot. Two dialog bodies can therefore be
@@ -247,6 +248,10 @@ function TerminalAgentForkDialogBody(props: TerminalAgentForkDialogProps) {
       })
       .then((createdAgentId) => {
         if (createdAgentId !== null) {
+          Analytics.getInstance().track(AnalyticsEvent.TerminalAgentForked, {
+            source: "direct_ui",
+            harness: target.sourceAgent.harnessId,
+          });
           clearTerminalForkWorkspace(stagingKey);
           onOpenChange(false);
         }

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
@@ -3,7 +3,6 @@ import { Suspense, useCallback, useEffect, useMemo, useRef } from "react";
 import type { EpicTerminalRef } from "@/stores/epics/canvas/types";
 import { useOpenEpicId } from "@/lib/epic-selectors";
 import { beginTerminalLoad } from "@/lib/perf/terminal-load-perf";
-import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import {
   TerminalXtermHost,
   useTerminalTileBootstrap,
@@ -98,9 +97,6 @@ export function TerminalTile(props: TerminalTileProps) {
   const sessionId = props.node.id;
   useEffect(() => {
     beginTerminalLoad(sessionId, "terminal");
-    Analytics.getInstance().track(AnalyticsEvent.TerminalOpened, {
-      kind: "shell",
-    });
   }, [sessionId]);
   useEffect(() => {
     if (reachability.status !== "unreachable") return;

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -33,7 +33,6 @@ import {
 } from "@/hooks/terminal/use-terminal-crash-notification";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
 import { beginTerminalLoad } from "@/lib/perf/terminal-load-perf";
-import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { useAgentStartTerminalSession } from "@/hooks/agent/use-prepare-tui-launch-mutation";
 import { useHostClientFor } from "@/hooks/host/use-host-client-for";
 import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
@@ -184,9 +183,6 @@ export function TuiAgentTile(props: TuiAgentTileProps) {
   const sessionId = props.node.id;
   useEffect(() => {
     beginTerminalLoad(sessionId, "terminal-agent");
-    Analytics.getInstance().track(AnalyticsEvent.TerminalOpened, {
-      kind: "agent",
-    });
   }, [sessionId]);
   useEffect(() => {
     if (reachability.status !== "unreachable") return;
@@ -268,6 +264,7 @@ function TuiAgentTileLive(
   const killTerminal = useTerminalKillFor(
     hostClient,
     "Couldn't restart terminal after updating folders.",
+    false,
   );
 
   // Every harness - Claude included - goes through `agent.startTerminalSession`

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-artifact-doc-title-follow.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-artifact-doc-title-follow.ts
@@ -119,7 +119,7 @@ export function useArtifactDocTitleFollow(params: {
   const nodeType = node.type;
   const handle = useOpenEpicHandle();
   const renameArtifactInTab = useEpicCanvasStore((s) => s.renameArtifactInTab);
-  const renameArtifact = useEpicRenameArtifact();
+  const renameArtifact = useEpicRenameArtifact(false);
   // TanStack Query keeps `mutate` referentially stable, so depending on it
   // does not re-subscribe the editor listener on every mutation state change.
   const persistRename = renameArtifact.mutate;

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -674,13 +674,13 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
   const childIds = useFilteredPanelChildIds(nodeId, treeFilter);
   const navigateNested = useEpicNestedFocusNavigation();
   const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
-    (s) => s.prepareOpenTileInTabFocusTarget,
+    (s) => s.prepareOpenTileInTabFocusTargetFromSource,
   );
   const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
     (s) => s.prepareCloseCanvasTabFocusTarget,
   );
   const prepareOpenTilePreviewInTabFocusTarget = useEpicCanvasStore(
-    (s) => s.prepareOpenTilePreviewInTabFocusTarget,
+    (s) => s.prepareOpenTilePreviewInTabFocusTargetFromSource,
   );
   const promotePreviewInTab = useEpicCanvasStore((s) => s.promotePreviewInTab);
   const markArtifactSelfDeleted = useEpicCanvasStore(
@@ -693,7 +693,7 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
 
   const createArtifact = useEpicCreateArtifact();
   const deleteArtifact = useEpicDeleteArtifact();
-  const renameArtifact = useEpicRenameArtifact();
+  const renameArtifact = useEpicRenameArtifact(true);
   const renameArtifactInTab = useEpicCanvasStore((s) => s.renameArtifactInTab);
 
   const [pendingChildName, setPendingChildName] = useState<string | null>(null);
@@ -778,7 +778,11 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
           fallbackHostId: activeHostId,
           openTileInTab: (targetTabId, nodeRef) => {
             navigateNested(epicId, targetTabId, () =>
-              prepareOpenTileInTabFocusTarget(targetTabId, nodeRef),
+              prepareOpenTileInTabFocusTarget(
+                targetTabId,
+                nodeRef,
+                "direct_ui",
+              ),
             );
           },
           onBeforeOpen,
@@ -819,13 +823,17 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
     if (isRenaming) return;
     if (openableType === null) return;
     navigateNested(epicId, tabId, () =>
-      prepareOpenTilePreviewInTabFocusTarget(tabId, {
-        id: nodeId,
-        instanceId: uuidv4(),
-        type: openableType,
-        name: nodeName,
-        hostId: activeHostId,
-      }),
+      prepareOpenTilePreviewInTabFocusTarget(
+        tabId,
+        {
+          id: nodeId,
+          instanceId: uuidv4(),
+          type: openableType,
+          name: nodeName,
+          hostId: activeHostId,
+        },
+        "direct_ui",
+      ),
     );
   }, [
     activeHostId,
@@ -853,13 +861,17 @@ const ArtifactNode = memo(function ArtifactNode(props: ArtifactNodeProps) {
       });
     } else {
       navigateNested(epicId, tabId, () =>
-        prepareOpenTileInTabFocusTarget(tabId, {
-          id: nodeId,
-          instanceId: uuidv4(),
-          type: openableType,
-          name: nodeName,
-          hostId: activeHostId,
-        }),
+        prepareOpenTileInTabFocusTarget(
+          tabId,
+          {
+            id: nodeId,
+            instanceId: uuidv4(),
+            type: openableType,
+            name: nodeName,
+            hostId: activeHostId,
+          },
+          "direct_ui",
+        ),
       );
     }
   }, [

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -1052,7 +1052,10 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     // Passing the row's title threads it through tab creation so the
     // cold-open canvas skeleton can render the real epic title at +0ms,
     // not "Untitled epic" until the snapshot arrives.
-    openEpicFromCommand(navigate, item.epicId, pathname, item.title);
+    openEpicFromCommand(navigate, item.epicId, pathname, {
+      title: item.title,
+      source: "direct_ui",
+    });
   }, [isPhase, item.epicId, item.title, navigate, onSelectEpic, pathname]);
   const toggleEpicSelection = () => {
     if (!canDeleteItem) return;

--- a/clients/gui-app/src/components/home/composer/landing-composer.tsx
+++ b/clients/gui-app/src/components/home/composer/landing-composer.tsx
@@ -48,6 +48,7 @@ import { contentIsSubmittable } from "@/lib/composer/composer-content";
 import { nextComposerMode } from "@/components/home/data/landing-options";
 import { ArrowLeftRight } from "lucide-react";
 import { useHostBinding, useHostClient } from "@/lib/host";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface LandingComposerProps {
   readonly draftId: string | null;
@@ -222,6 +223,10 @@ export function LandingComposer(props: LandingComposerProps) {
   );
 
   const handleRemoveImage = useCallback((id: string) => {
+    Analytics.getInstance().track(AnalyticsEvent.AttachmentRemoved, {
+      kind: "image",
+      surface: "draft",
+    });
     editorRef.current?.removeImageAttachmentById(id);
   }, []);
 

--- a/clients/gui-app/src/components/home/host-update-banner.tsx
+++ b/clients/gui-app/src/components/home/host-update-banner.tsx
@@ -30,7 +30,7 @@ import {
 import {
   Analytics,
   AnalyticsEvent,
-  analyticsBlockerFromError,
+  hostUpdateAnalyticsCallbacks,
 } from "@/lib/analytics";
 
 interface HostUpdateBannerProps {
@@ -112,6 +112,7 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
       ? operationStatus.percent
       : null;
 
+  const hostUpdateAnalytics = hostUpdateAnalyticsCallbacks("direct_ui");
   const updateMutation = useMutation<HostInstallResult>({
     mutationKey: runnerMutationKeys.hostUpdate(),
     // Progress is read from the shared `operationStatus` query above (it
@@ -119,12 +120,10 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
     // this mutation doesn't need its own progress callback.
     mutationFn: () => management.updateHost({ onProgress: null }),
     onMutate: () => {
-      Analytics.getInstance().track(AnalyticsEvent.HostUpdateStarted, {
-        source: "direct_ui",
-      });
+      hostUpdateAnalytics.onStarted();
     },
     onSuccess: (data) => {
-      Analytics.getInstance().track(AnalyticsEvent.HostUpdateSucceeded, null);
+      hostUpdateAnalytics.onSucceeded();
       toast.success(`Updated host to v${data.version}`);
       // Drop any snooze entry recorded against the version the user just
       // installed. We pull `clearSnooze` from the store via `getState()`
@@ -140,9 +139,7 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
       });
     },
     onError: (err) => {
-      Analytics.getInstance().track(AnalyticsEvent.HostUpdateFailed, {
-        blocker: analyticsBlockerFromError(err),
-      });
+      hostUpdateAnalytics.onFailed(err);
       toastFromRunnerError(err, "Couldn't update host");
     },
   });

--- a/clients/gui-app/src/components/home/host-update-banner.tsx
+++ b/clients/gui-app/src/components/home/host-update-banner.tsx
@@ -27,6 +27,11 @@ import {
   isHostUpdateBannerSnoozed,
   useHostUpdateBannerStore,
 } from "@/stores/settings/host-update-banner-store";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 
 interface HostUpdateBannerProps {
   readonly className: string | undefined;
@@ -113,7 +118,13 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
     // reflects the operation regardless of which surface started it), so
     // this mutation doesn't need its own progress callback.
     mutationFn: () => management.updateHost({ onProgress: null }),
+    onMutate: () => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateStarted, {
+        source: "direct_ui",
+      });
+    },
     onSuccess: (data) => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateSucceeded, null);
       toast.success(`Updated host to v${data.version}`);
       // Drop any snooze entry recorded against the version the user just
       // installed. We pull `clearSnooze` from the store via `getState()`
@@ -128,7 +139,12 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
         queryKey: runnerQueryKeys.hostInstalledRecord(management),
       });
     },
-    onError: (err) => toastFromRunnerError(err, "Couldn't update host"),
+    onError: (err) => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateFailed, {
+        blocker: analyticsBlockerFromError(err),
+      });
+      toastFromRunnerError(err, "Couldn't update host");
+    },
   });
 
   const nowMs = useHostUpdateNowMs();
@@ -216,6 +232,9 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
         className="text-current hover:bg-sky-500/15 hover:text-current"
         onClick={() => {
           snooze(latestVersion, getHostUpdateSnoozeUntilMs());
+          Analytics.getInstance().track(AnalyticsEvent.HostUpdateSnoozed, {
+            source: "direct_ui",
+          });
         }}
       >
         <X className="size-3" aria-hidden />

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -103,6 +103,8 @@ import {
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 import { useChatById } from "@/lib/epic-selectors";
 import { toast } from "sonner";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import { trackUserInitiatedWorktreeWrite } from "@/lib/worktree/user-worktree-analytics";
 
 /**
  *
@@ -704,6 +706,9 @@ function HomeWorkspaceRows(props: {
   const handleEditEnvironment = useCallback((path: string): void => {
     // Keep the picker open: the scripts modal stacks on top of it, so closing
     // the modal returns to the still-open picker.
+    Analytics.getInstance().track(AnalyticsEvent.SetupScriptsOpened, {
+      source: "direct_ui",
+    });
     setScriptsTargetPath(path);
   }, []);
   const scriptsTarget = useMemo<WorktreeScriptsTarget | null>(() => {
@@ -1491,7 +1496,14 @@ function InEpicSurface(props: InEpicSurfaceProps) {
         ownerKind,
         entries: [...stagedEntries],
       },
-      { onSuccess: finishAndResume },
+      {
+        onSuccess: (result) => {
+          finishAndResume();
+          // Telemetry runs strictly after the product work; it is an
+          // observer and never part of the mutation chain.
+          trackUserInitiatedWorktreeWrite(stagedEntries, result);
+        },
+      },
     );
   }, [
     editor.dirtyPathsSinceResume,
@@ -1666,6 +1678,11 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   const emitForFolder = useCallback(
     (ws: WorktreeWorkspaceSummary) =>
       (intent: WorktreeFolderIntent): void => {
+        if (intent.kind !== "local") {
+          Analytics.getInstance().track(AnalyticsEvent.WorktreeSelected, {
+            source: "direct_ui",
+          });
+        }
         // Persist the per-folder choice immediately (not at send) so it survives
         // a reload and seeds future adds of this folder.
         setFolderIntent(intent, Date.now());
@@ -1717,7 +1734,12 @@ function InEpicSurface(props: InEpicSurfaceProps) {
                 },
               ],
             },
-            { onSuccess: () => handleBindingCommitted([ws.workspacePath]) },
+            {
+              onSuccess: (result) => {
+                handleBindingCommitted([ws.workspacePath]);
+                trackUserInitiatedWorktreeWrite([intent], result);
+              },
+            },
           );
           return;
         }
@@ -1884,6 +1906,9 @@ function InEpicSurface(props: InEpicSurfaceProps) {
   );
   const handleEditEnvironment = useCallback((path: string): void => {
     // Keep the picker open: the scripts modal stacks on top of it.
+    Analytics.getInstance().track(AnalyticsEvent.SetupScriptsOpened, {
+      source: "direct_ui",
+    });
     setScriptsTargetPath(path);
   }, []);
   const scriptsTarget = useMemo<WorktreeScriptsTarget | null>(() => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/use-home-workspace-source.ts
@@ -24,6 +24,7 @@ import { useSeededWorkspaceSnapshotStore } from "@/stores/worktree/seeded-worksp
 import { resolvePrimaryPath } from "@/lib/worktree/resolve-primary-path";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
 import { restampWorktreeIntentPrimary } from "./worktree-intent-merge";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface PrimaryRemovalTransition {
   // Whether removing the folder demoted-and-reassigned primary to a
@@ -277,6 +278,15 @@ export function useHomeWorkspaceSource(
         };
       },
       setPrimaryFolder: (folderPath) => {
+        // Suppress only the duplicate EVENT on a same-primary re-selection;
+        // the state writes below must still run so a staged worktree intent's
+        // stale isPrimary bit is restamped before launch consumers read it.
+        if (folderPath !== primaryPath) {
+          Analytics.getInstance().track(
+            AnalyticsEvent.WorkspacePrimaryChanged,
+            { source: "direct_ui" },
+          );
+        }
         if (modalEpicId !== null) {
           setModalPrimaryFolder(modalEpicId, modalSeedWorkspace, folderPath);
         } else {

--- a/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/app-update-toast-controller.tsx
@@ -10,6 +10,11 @@ import type {
 import { createReportIssueContext } from "@/lib/report-issue-context";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 import { progressToast } from "@/lib/toast/progress-toast";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import {
+  settleUpdateDownloadOutcome,
+  trackUpdateDownloadStarted,
+} from "@/lib/app-update-analytics";
 
 const APP_UPDATE_TOAST_ID = "traycer-app-update";
 const APP_UPDATE_TRANSIENT_TOAST_DURATION_MS = 4000;
@@ -67,6 +72,11 @@ export function AppUpdateToastController(): null {
     }
     handledSequenceRef.current = snapshot.sequence;
     handledReportCapabilityRef.current = reportIssueAvailable;
+    // Terminal download outcomes settle the window-local flow armed by a
+    // download gesture; replayed snapshots in other windows are no-ops there.
+    if (snapshot.status === "ready" || snapshot.status === "error") {
+      settleUpdateDownloadOutcome(snapshot.status, snapshot.errorMessage);
+    }
     const mountedAtMs = mountedAtMsRef.current;
     if (isManualReplayFromBeforeMount(snapshot, mountedAtMs)) {
       return;
@@ -74,10 +84,17 @@ export function AppUpdateToastController(): null {
 
     showAppUpdateToast(snapshot, {
       onDownload: () => {
+        trackUpdateDownloadStarted("direct_ui");
         void bridge.downloadUpdate();
       },
       onRestart: openConfirmRestartUpdate,
-      onViewInstructions: openInstallGuidance,
+      onViewInstructions: () => {
+        Analytics.getInstance().track(
+          AnalyticsEvent.UpdateInstallGuidanceOpened,
+          { source: "direct_ui" },
+        );
+        openInstallGuidance();
+      },
       onReportIssue: reportIssueAvailable
         ? () => openReportIssueWithContext(APP_UPDATE_REPORT_CONTEXT)
         : null,

--- a/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
@@ -12,6 +12,11 @@ import { runnerMutationKeys, runnerQueryKeys } from "@/lib/query-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import { RestartHostConfirmDialog } from "@/components/host/restart-host-confirm-dialog";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 
 /**
  * NP-6: listens for host-scoped tray commands forwarded from the
@@ -93,7 +98,13 @@ export function HostTrayCommandListener() {
       }
       return management.installHost({ version, onProgress: null });
     },
+    onMutate: () => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateStarted, {
+        source: "system_tray",
+      });
+    },
     onSuccess: (data) => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateSucceeded, null);
       toast.success(`Installed host v${data.version}`);
       setPendingInstallVersion(null);
       if (management !== null) {
@@ -104,6 +115,9 @@ export function HostTrayCommandListener() {
       invalidate();
     },
     onError: (err) => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateFailed, {
+        blocker: analyticsBlockerFromError(err),
+      });
       setPendingInstallVersion(null);
       toastFromRunnerError(err, "Couldn't install host update");
     },
@@ -117,14 +131,26 @@ export function HostTrayCommandListener() {
     const subscription = tray.onCommand((command: HostTrayCommand) => {
       switch (command.kind) {
         case "openSettingsHost":
+          Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
+            source: "system_tray",
+            command: "open_settings",
+          });
           void navigate({ to: "/settings/host" });
           return;
         case "restartHost":
+          Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
+            source: "system_tray",
+            command: "restart_host",
+          });
           // Destructive: restart kills PTYs and in-flight RPC sessions.
           // Surface the confirmation modal before executing.
           setPendingRestart(true);
           return;
         case "openLogs":
+          Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
+            source: "system_tray",
+            command: "open_logs",
+          });
           // Logs surface lives inside Settings → Host; navigate there and
           // also open the legacy logs dialog so the user gets the fastest
           // path to the tail regardless of which surface they prefer.
@@ -132,6 +158,10 @@ export function HostTrayCommandListener() {
           openLogs();
           return;
         case "installUpdate":
+          Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
+            source: "system_tray",
+            command: "install_host_update",
+          });
           // Destructive: installing an update restarts the host and kills
           // PTYs / in-flight RPC sessions. Preview the version that will be
           // installed before executing.

--- a/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
@@ -15,7 +15,7 @@ import { RestartHostConfirmDialog } from "@/components/host/restart-host-confirm
 import {
   Analytics,
   AnalyticsEvent,
-  analyticsBlockerFromError,
+  hostUpdateAnalyticsCallbacks,
 } from "@/lib/analytics";
 
 /**
@@ -47,6 +47,7 @@ export function HostTrayCommandListener() {
   const [pendingInstallVersion, setPendingInstallVersion] = useState<
     string | null
   >(null);
+  const hostUpdateAnalytics = hostUpdateAnalyticsCallbacks("system_tray");
 
   const invalidate = (): void => {
     if (management === null) return;
@@ -99,12 +100,10 @@ export function HostTrayCommandListener() {
       return management.installHost({ version, onProgress: null });
     },
     onMutate: () => {
-      Analytics.getInstance().track(AnalyticsEvent.HostUpdateStarted, {
-        source: "system_tray",
-      });
+      hostUpdateAnalytics.onStarted();
     },
     onSuccess: (data) => {
-      Analytics.getInstance().track(AnalyticsEvent.HostUpdateSucceeded, null);
+      hostUpdateAnalytics.onSucceeded();
       toast.success(`Installed host v${data.version}`);
       setPendingInstallVersion(null);
       if (management !== null) {
@@ -115,9 +114,7 @@ export function HostTrayCommandListener() {
       invalidate();
     },
     onError: (err) => {
-      Analytics.getInstance().track(AnalyticsEvent.HostUpdateFailed, {
-        blocker: analyticsBlockerFromError(err),
-      });
+      hostUpdateAnalytics.onFailed(err);
       setPendingInstallVersion(null);
       toastFromRunnerError(err, "Couldn't install host update");
     },

--- a/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
@@ -26,6 +26,11 @@ import {
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { RestartHostConfirmDialog } from "@/components/host/restart-host-confirm-dialog";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 
 interface HostWithRequestClose extends IRunnerHost {
   readonly windows: {
@@ -111,7 +116,13 @@ export function MenuCommandListener() {
       }
       return management.updateHost({ onProgress: null });
     },
+    onMutate: () => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateStarted, {
+        source: "native_menu",
+      });
+    },
     onSuccess: (data) => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateSucceeded, null);
       toast.success(`Updated host to v${data.version}`);
       if (management !== null) {
         if (service !== null) {
@@ -130,7 +141,12 @@ export function MenuCommandListener() {
         });
       }
     },
-    onError: (err) => toastFromRunnerError(err, "Couldn't install host update"),
+    onError: (err) => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateFailed, {
+        blocker: analyticsBlockerFromError(err),
+      });
+      toastFromRunnerError(err, "Couldn't install host update");
+    },
   });
 
   const { mutate: mutateInstallUpdate } = installUpdateMutation;
@@ -234,18 +250,32 @@ function handleMenuCommand(
   handlers: MenuCommandHandlers,
 ): void {
   if (payload.command === "app.openSettings") {
+    Analytics.getInstance().track(AnalyticsEvent.SettingsOpened, {
+      source: "native_menu",
+      section: "general",
+    });
     handlers.navigateSettings();
     return;
   }
   if (payload.command === "app.signIn") {
+    Analytics.getInstance().track(AnalyticsEvent.SignInStarted, {
+      source: "native_menu",
+    });
     void handlers.authService.signIn();
     return;
   }
   if (payload.command === "app.signOut") {
+    Analytics.getInstance().track(AnalyticsEvent.SignOutRequested, {
+      source: "native_menu",
+    });
     void handlers.authService.signOut();
     return;
   }
   if (payload.command === "app.openLogs") {
+    Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
+      source: "native_menu",
+      command: "open_logs",
+    });
     handlers.openLogs();
     return;
   }
@@ -262,14 +292,25 @@ function handleMenuCommand(
     return;
   }
   if (payload.command === "app.reportIssue") {
+    Analytics.getInstance().track(AnalyticsEvent.ReportIssueOpened, {
+      source: "native_menu",
+    });
     handlers.reportIssue();
     return;
   }
   if (payload.command === "host.installUpdate") {
+    Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
+      source: "native_menu",
+      command: "install_host_update",
+    });
     handlers.installHostUpdate();
     return;
   }
   if (payload.command === "host.restart") {
+    Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
+      source: "native_menu",
+      command: "restart_host",
+    });
     handlers.requestHostRestart();
     return;
   }

--- a/clients/gui-app/src/components/layout/bridges/tray-open-epic-bridge.tsx
+++ b/clients/gui-app/src/components/layout/bridges/tray-open-epic-bridge.tsx
@@ -33,7 +33,7 @@ export function TrayOpenEpicBridge(): null {
       navigate,
       openRequest.epicId,
       router.state.location.pathname,
-      epic?.title,
+      { title: epic?.title, source: "system_tray" },
     );
   }, [openRequest, navigate, router]);
 

--- a/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
@@ -22,6 +22,11 @@ import type { DesktopSupportSnapshot } from "@/lib/windows/types";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import type { DesktopSupportDialogProps } from "./types";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 
 interface ReportIssueForm {
   title: string;
@@ -73,6 +78,10 @@ export function ReportIssueDialog(
       return result.reportId;
     },
     onSuccess: (reportId, submission) => {
+      Analytics.getInstance().track(AnalyticsEvent.ReportIssueHandedOff, {
+        outcome: "succeeded",
+        blocker: null,
+      });
       const url = buildSupportIssueUrl(
         submission.snapshot,
         submission.form,
@@ -80,6 +89,12 @@ export function ReportIssueDialog(
       );
       void runnerHost.openExternalLink(url);
       closeReportIssueDraft(submission.draftId);
+    },
+    onError: (error) => {
+      Analytics.getInstance().track(AnalyticsEvent.ReportIssueHandedOff, {
+        outcome: "failed",
+        blocker: analyticsBlockerFromError(error),
+      });
     },
   });
 

--- a/clients/gui-app/src/components/layout/dialogs/restart-update-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/restart-update-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface RestartUpdateDialogProps {
   readonly open: boolean;
@@ -41,6 +42,9 @@ export function RestartUpdateDialog(props: RestartUpdateDialogProps) {
   function handleConfirm(): void {
     if (actionHandled) return;
     setActionState({ open, actionHandled: true });
+    Analytics.getInstance().track(AnalyticsEvent.UpdateRestartRequested, {
+      source: "direct_ui",
+    });
     onConfirm();
   }
 

--- a/clients/gui-app/src/components/layout/dialogs/use-close-tab-flow.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/use-close-tab-flow.tsx
@@ -12,6 +12,7 @@ import type { HeaderTab } from "@/stores/tabs/types";
 import { useTabCloseCommand } from "@/components/layout/tabs/use-tab-close-command";
 import { useNeighborTabPicker } from "@/components/layout/tabs/use-neighbor-tab-picker";
 import { useUnsyncedCloseDialog } from "@/components/layout/dialogs/use-unsynced-close-dialog";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface CloseTabFlow {
   readonly requestCloseTab: (tab: HeaderTab) => void;
@@ -34,6 +35,11 @@ export function useCloseTabFlow(): CloseTabFlow {
       const captured = picker.capture(tab);
       const finalize = () => {
         closeTab(tab);
+        if (tab.kind === "epic") {
+          Analytics.getInstance().track(AnalyticsEvent.TabClosed, {
+            target: "task",
+          });
+        }
         picker.navigateToCaptured(captured);
       };
       if (dialog.promptOrConfirm(tab, finalize)) return;
@@ -52,6 +58,11 @@ export function useCloseTabFlow(): CloseTabFlow {
           continue;
         }
         closeTab(other);
+        if (other.kind === "epic") {
+          Analytics.getInstance().track(AnalyticsEvent.TabClosed, {
+            target: "task",
+          });
+        }
       }
       if (skipped.length > 0) {
         const detail =

--- a/clients/gui-app/src/components/layout/dialogs/use-unsynced-close-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/use-unsynced-close-dialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { tabRequiresCloseConfirm, tabEpicId } from "@/stores/tabs/registry";
 import { UnsyncedCloseDialog } from "@/components/layout/dialogs/unsynced-close-dialog";
 import type { HeaderTab } from "@/stores/tabs/types";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface PendingClose {
   readonly tab: HeaderTab;
@@ -35,12 +36,20 @@ export function useUnsyncedCloseDialog(): UnsyncedCloseDialogController {
     const p = pending;
     setPending(null);
     if (p === null) return;
+    Analytics.getInstance().track(AnalyticsEvent.TabCloseBlocked, {
+      decision: "discard",
+    });
     p.onConfirm();
   }, [pending]);
 
   const handleWait = useCallback(() => {
+    if (pending !== null) {
+      Analytics.getInstance().track(AnalyticsEvent.TabCloseBlocked, {
+        decision: "cancel",
+      });
+    }
     setPending(null);
-  }, []);
+  }, [pending]);
 
   const dialog = useMemo<ReactNode>(
     () => (

--- a/clients/gui-app/src/components/layout/header/app-update-button.tsx
+++ b/clients/gui-app/src/components/layout/header/app-update-button.tsx
@@ -5,6 +5,8 @@ import { useDesktopAppUpdates } from "@/hooks/runner/use-desktop-app-updates";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { cn } from "@/lib/utils";
 import type { DesktopAppUpdateGuidance } from "@/lib/windows/types";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import { trackUpdateDownloadStarted } from "@/lib/app-update-analytics";
 
 /**
  * Compact circular update control in the header's right-side cluster. It cycles
@@ -48,6 +50,7 @@ export function AppUpdateHeaderButton() {
               blockedReason !== null && "disabled:opacity-60",
             )}
             onClick={() => {
+              trackUpdateDownloadStarted("direct_ui");
               void bridge.downloadUpdate();
             }}
           >
@@ -147,9 +150,19 @@ function AppUpdateReadyButton(props: {
               : "bg-emerald-500 hover:bg-emerald-600 hover:text-white",
             installBlockedReason !== null && "disabled:opacity-60",
           )}
-          onClick={
-            needsManualInstall ? openInstallGuidance : openConfirmRestartUpdate
-          }
+          onClick={() => {
+            if (needsManualInstall) {
+              // Same gesture as the toast's "View instructions" - both
+              // guidance affordances report through the one event.
+              Analytics.getInstance().track(
+                AnalyticsEvent.UpdateInstallGuidanceOpened,
+                { source: "direct_ui" },
+              );
+              openInstallGuidance();
+              return;
+            }
+            openConfirmRestartUpdate();
+          }}
         >
           {needsManualInstall ? (
             <Terminal className="size-4" aria-hidden />

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -72,6 +72,7 @@ import {
   sortProviderStatesByProviderOrder,
 } from "@/lib/provider-ordering";
 import { queryKeys } from "@/lib/query-keys";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import {
   PROVIDER_RATE_LIMITS_STALE_TIME_MS,
   rateLimitFetchLane,
@@ -1368,13 +1369,20 @@ function TraycerRateLimitBlock({
   // invalidation targets only aperture `{ accountContext }` keys, never provider
   // `{ accountContext, providerId }` pulls.
   const refresh = async (): Promise<void> => {
-    await traycerSubscription.query.refetch();
+    const result = await traycerSubscription.query.refetch();
     traycerSubscription.rateLimitAccountContexts.forEach((accountContext) => {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.hostTraycerRateLimitUsage(hostId, accountContext),
         exact: true,
       });
     });
+    // Observational only: the UI awaits exactly what it always did (the
+    // primary refetch; invalidations stay fire-and-forget background work).
+    if (result.status === "success") {
+      Analytics.getInstance().track(AnalyticsEvent.SubscriptionRefreshed, {
+        source: "direct_ui",
+      });
+    }
   };
 
   return (

--- a/clients/gui-app/src/components/local-host-gate.tsx
+++ b/clients/gui-app/src/components/local-host-gate.tsx
@@ -36,6 +36,42 @@ import { requestAppQuit } from "@/lib/desktop-app-lifecycle";
 import { runnerQueryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
 import { createReportIssueContext } from "@/lib/report-issue-context";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
+
+type HostSetupReason = "launch" | "recovery" | "reinstall" | "update";
+
+// Best-effort setup telemetry around the `ensureHost` mutation. Emitted from
+// mutation events, never renders. `host-busy`/`removed` results are neither
+// success nor failure - the user resolves them through their own surfaces.
+function hostSetupAnalyticsCallbacks(
+  reason: HostSetupReason,
+  onSuccess: (result: HostEnsureResult) => void,
+): {
+  readonly onSuccess: (result: HostEnsureResult) => void;
+  readonly onError: (error: unknown) => void;
+} {
+  Analytics.getInstance().track(AnalyticsEvent.HostSetupStarted, { reason });
+  return {
+    onSuccess: (result) => {
+      onSuccess(result);
+      if (result.action !== "host-busy" && result.action !== "removed") {
+        Analytics.getInstance().track(AnalyticsEvent.HostSetupSucceeded, {
+          reason,
+        });
+      }
+    },
+    onError: (error) => {
+      Analytics.getInstance().track(AnalyticsEvent.HostSetupFailed, {
+        source: "direct_ui",
+        blocker: analyticsBlockerFromError(error),
+      });
+    },
+  };
+}
 
 /**
  * URL prefix that bypasses the host-readiness gate. Settings work without
@@ -412,12 +448,12 @@ function useHostProvisioning(args: {
   // Retry/forced update: clear any prior error/progress, then re-run ensure. Only
   // `onSuccess` transitions the busy-keep latch; an error leaves it untouched
   // (see markBusyKeep).
-  const run = (force: boolean): void => {
+  const run = (force: boolean, reason: HostSetupReason): void => {
     reset();
     setProgress(null);
     mutate(
       { force, onProgress: (event) => setProgress(event) },
-      { onSuccess: markBusyKeep },
+      hostSetupAnalyticsCallbacks(reason, markBusyKeep),
     );
   };
 
@@ -437,7 +473,7 @@ function useHostProvisioning(args: {
       removedByUser: false,
     });
     void management.clearRemoval().then(
-      () => run(false),
+      () => run(false, "reinstall"),
       () => {
         // The sentinel couldn't be cleared, so ensure would just short-circuit
         // back to `removed`. Restore the removed surface instead of flashing a
@@ -457,7 +493,7 @@ function useHostProvisioning(args: {
     attemptedRef.current = true;
     mutate(
       { force: false, onProgress: (event) => setProgress(event) },
-      { onSuccess: markBusyKeep },
+      hostSetupAnalyticsCallbacks("launch", markBusyKeep),
     );
   }, [canProvision, args.isReady, mutate, markBusyKeep]);
 
@@ -490,8 +526,8 @@ function useHostProvisioning(args: {
     hostBusy: hasManagement && inBusyKeepFlow,
     removed: hasManagement && isRemoved,
     canManageHost: hasManagement,
-    retry: () => run(false),
-    force: () => run(true),
+    retry: () => run(false, "recovery"),
+    force: () => run(true, "update"),
     reinstall,
   };
 }

--- a/clients/gui-app/src/components/notifications/notifications-bell.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-bell.tsx
@@ -12,6 +12,7 @@ import { useMergedNotificationUnreadCount } from "@/stores/notifications/merged-
 import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
 import { useTitleBarDragSuppression } from "@/stores/layout/title-bar-drag-store";
 import { cn } from "@/lib/utils";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /**
  * Top-level notifications trigger in the app header. Shows an unread-count
@@ -32,7 +33,18 @@ export function NotificationsBell() {
   const ariaLabel =
     unread > 0 ? `Notifications, ${unread} unread` : "Notifications";
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) {
+          Analytics.getInstance().track(
+            AnalyticsEvent.NotificationCenterOpened,
+            null,
+          );
+        }
+        setOpen(nextOpen);
+      }}
+    >
       <TooltipWrapper
         label={open ? null : "Notifications"}
         side="top"

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -36,6 +36,7 @@ import {
   type NotificationEvent,
   NOTIFICATION_EVENT_TYPES,
 } from "@traycer/protocol/notifications/notification-entry";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface NotificationsPopoverProps {
   readonly onNavigate: () => void;
@@ -65,6 +66,13 @@ export function NotificationsPopover(props: NotificationsPopoverProps) {
   const handleClick = useCallback(
     (row: MergedNotificationRow) => {
       if (row.payload === null) {
+        // Payload-less rows have no preflight: the click IS the activation.
+        Analytics.getInstance().track(AnalyticsEvent.NotificationActivated, {
+          category: row.source,
+        });
+        Analytics.getInstance().track(AnalyticsEvent.NotificationMarkedRead, {
+          category: row.source,
+        });
         actions.markAsRead(row.feedId);
         return;
       }
@@ -72,7 +80,16 @@ export function NotificationsPopover(props: NotificationsPopoverProps) {
       activate({
         payload: row.payload,
         receivedAt: Date.now(),
+        // Fires only after activation preflight succeeds, so a failed
+        // preflight is not counted as an activation - and the auto-read that
+        // accompanies it is recorded too.
         onActivated: () => {
+          Analytics.getInstance().track(AnalyticsEvent.NotificationActivated, {
+            category: row.source,
+          });
+          Analytics.getInstance().track(AnalyticsEvent.NotificationMarkedRead, {
+            category: row.source,
+          });
           actions.markAsRead(row.feedId);
         },
       });
@@ -148,7 +165,13 @@ export function NotificationsPopover(props: NotificationsPopoverProps) {
                   type="button"
                   variant="ghost"
                   size="icon-sm"
-                  onClick={() => actions.markAllAsRead()}
+                  onClick={() => {
+                    Analytics.getInstance().track(
+                      AnalyticsEvent.NotificationsMarkedAllRead,
+                      null,
+                    );
+                    actions.markAllAsRead();
+                  }}
                   disabled={unreadCount === 0}
                   data-testid="notifications-mark-all-read"
                   aria-label="Mark all notifications as read"
@@ -167,7 +190,13 @@ export function NotificationsPopover(props: NotificationsPopoverProps) {
                   type="button"
                   variant="ghost"
                   size="icon-sm"
-                  onClick={() => actions.clearAll()}
+                  onClick={() => {
+                    Analytics.getInstance().track(
+                      AnalyticsEvent.NotificationsCleared,
+                      { scope: "all" },
+                    );
+                    actions.clearAll();
+                  }}
                   disabled={isEmpty}
                   data-testid="notifications-clear-all"
                   aria-label="Clear all notifications"
@@ -400,6 +429,10 @@ function NotificationRow(props: NotificationRowProps) {
             type="button"
             onClick={(event) => {
               event.stopPropagation();
+              Analytics.getInstance().track(
+                AnalyticsEvent.NotificationMarkedRead,
+                { category: row.source },
+              );
               onMarkRead(row.feedId);
             }}
             aria-label="Mark as read"

--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -35,6 +35,7 @@ import {
   useOnboardingStore,
 } from "@/stores/onboarding/onboarding-store";
 import { cn } from "@/lib/utils";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 const ACT_EASE = [0.32, 0.72, 0, 1] as const;
 const ONBOARDING_FOOTER_LINKS = [
@@ -448,6 +449,12 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
   }, [restart]);
 
   useEffect(() => {
+    Analytics.getInstance().track(AnalyticsEvent.OnboardingStarted, {
+      mode: replay ? "replay" : "first_run",
+    });
+  }, [replay]);
+
+  useEffect(() => {
     const data = agentGuideQuery.data;
     if (data === undefined) return;
     const nextDefault = data.generatedDefaultContent;
@@ -520,6 +527,9 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
     const content = agentGuideDraft ?? agentGuideDefault;
     return setAgentGuideGlobal({ content }).then(
       (result) => {
+        Analytics.getInstance().track(AnalyticsEvent.AgentGuideSaved, {
+          customized: result.content !== result.generatedDefaultContent,
+        });
         agentGuideDraftRef.current = result.content;
         setAgentGuide({
           draft: result.content,
@@ -558,32 +568,57 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
   // no real back target, so we open a fresh draft tab. Either way the user
   // lands on a real tab. The /onboarding + / route guards bounce a completed
   // user onward as needed.
-  const finish = useCallback((): void => {
-    void saveAgentGuideDraft().then((saved) => {
-      if (!saved) return;
-      complete();
-      if (replay) {
-        router.history.back();
-        return;
-      }
-      void navigate({ to: "/draft/new", replace: true });
+  const finish = useCallback(
+    (outcome: "completed" | "skipped"): void => {
+      void saveAgentGuideDraft().then((saved) => {
+        if (!saved) return;
+        Analytics.getInstance().track(
+          outcome === "completed"
+            ? AnalyticsEvent.OnboardingCompleted
+            : AnalyticsEvent.OnboardingSkipped,
+          { last_step: act.id },
+        );
+        complete();
+        if (replay) {
+          router.history.back();
+          return;
+        }
+        void navigate({ to: "/draft/new", replace: true });
+      });
+    },
+    [act.id, complete, navigate, replay, router, saveAgentGuideDraft],
+  );
+
+  const retreatWithAnalytics = useCallback((): void => {
+    const destination = ONBOARDING_ACTS[Math.max(0, step - 1)] ?? act;
+    retreat();
+    Analytics.getInstance().track(AnalyticsEvent.OnboardingNavigated, {
+      direction: "back",
+      step: destination.id,
     });
-  }, [complete, navigate, replay, router, saveAgentGuideDraft]);
+  }, [act, retreat, step]);
 
   const advance = useCallback((): void => {
     if (advanceDisabled) return;
     const advancePastCurrent = (): void => {
       if (isLastAct) {
-        finish();
+        finish("completed");
         return;
       }
+      const destination = ONBOARDING_ACTS[step + 1] ?? act;
       advanceStep();
+      Analytics.getInstance().track(AnalyticsEvent.OnboardingNavigated, {
+        direction: "continue",
+        step: destination.id,
+      });
     };
     advancePastCurrent();
-  }, [advanceDisabled, advanceStep, finish, isLastAct]);
+  }, [act, advanceDisabled, advanceStep, finish, isLastAct, step]);
   const handleKeyboardAdvance = useEffectEvent((): void => advance());
-  const handleKeyboardRetreat = useEffectEvent((): void => retreat());
-  const handleKeyboardFinish = useEffectEvent((): void => finish());
+  const handleKeyboardRetreat = useEffectEvent((): void =>
+    retreatWithAnalytics(),
+  );
+  const handleKeyboardFinish = useEffectEvent((): void => finish("skipped"));
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent): void => {
@@ -630,7 +665,7 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
             <button
               type="button"
               data-testid="onboarding-skip"
-              onClick={finish}
+              onClick={() => finish("skipped")}
               disabled={agentGuideSaving}
               className="absolute right-10 flex h-9 items-center justify-center gap-2 rounded px-2 font-heading text-[0.875rem] leading-[1.125rem] font-normal tracking-normal text-white transition-colors hover:bg-white/10 disabled:pointer-events-none disabled:opacity-55 [@media(min-height:920px)]:h-10 [@media(min-height:920px)]:text-[0.9375rem] max-sm:right-5"
             >
@@ -712,7 +747,7 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
               {step > 0 ? (
                 <button
                   type="button"
-                  onClick={retreat}
+                  onClick={retreatWithAnalytics}
                   className="flex h-9 items-center justify-center gap-2 rounded px-3 font-heading text-[0.875rem] leading-[1.125rem] font-medium text-white transition-colors hover:bg-white/10 [@media(min-height:920px)]:h-10 [@media(min-height:920px)]:px-4 [@media(min-height:920px)]:text-[0.9375rem]"
                 >
                   <Kbd tone="light">←</Kbd>

--- a/clients/gui-app/src/components/onboarding/onboarding-theme-picker.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-theme-picker.tsx
@@ -39,6 +39,7 @@ export function OnboardingThemePicker() {
             type="button"
             aria-pressed={theme === mode.id}
             onClick={() => {
+              if (mode.id === theme) return;
               Analytics.getInstance().track(
                 AnalyticsEvent.OnboardingThemeChanged,
                 { theme: `mode:${mode.id}` },
@@ -70,6 +71,7 @@ export function OnboardingThemePicker() {
             aria-label={preset.label}
             title={preset.label}
             onClick={() => {
+              if (preset.id === themePreset) return;
               Analytics.getInstance().track(
                 AnalyticsEvent.OnboardingThemeChanged,
                 { theme: `preset:${preset.id}` },

--- a/clients/gui-app/src/components/onboarding/onboarding-theme-picker.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-theme-picker.tsx
@@ -4,6 +4,7 @@ import {
   useSettingsStore,
   type ThemeMode,
 } from "@/stores/settings/settings-store";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 const MODES: ReadonlyArray<{ id: ThemeMode; label: string }> = [
   { id: "light", label: "Light" },
@@ -37,7 +38,13 @@ export function OnboardingThemePicker() {
             key={mode.id}
             type="button"
             aria-pressed={theme === mode.id}
-            onClick={() => setTheme(mode.id)}
+            onClick={() => {
+              Analytics.getInstance().track(
+                AnalyticsEvent.OnboardingThemeChanged,
+                { theme: `mode:${mode.id}` },
+              );
+              setTheme(mode.id);
+            }}
             className={cn(
               "px-3 py-1.5 font-mono text-overline uppercase tracking-wider transition-colors duration-200",
               theme === mode.id
@@ -62,7 +69,13 @@ export function OnboardingThemePicker() {
             aria-pressed={themePreset === preset.id}
             aria-label={preset.label}
             title={preset.label}
-            onClick={() => setThemePreset(preset.id)}
+            onClick={() => {
+              Analytics.getInstance().track(
+                AnalyticsEvent.OnboardingThemeChanged,
+                { theme: `preset:${preset.id}` },
+              );
+              setThemePreset(preset.id);
+            }}
             className={cn(
               "relative size-7 shrink-0 overflow-hidden rounded-full border transition-transform duration-200",
               themePreset === preset.id

--- a/clients/gui-app/src/components/report-issue/report-issue-action.tsx
+++ b/clients/gui-app/src/components/report-issue/report-issue-action.tsx
@@ -9,6 +9,7 @@ import {
 import type { ReportIssueContext } from "@/lib/report-issue-context";
 import { cn } from "@/lib/utils";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface ReportIssueActionProps {
   readonly context: ReportIssueContext;
@@ -26,6 +27,9 @@ export function ReportIssueAction(props: ReportIssueActionProps): ReactNode {
   if (!reportIssueAvailable) return null;
 
   const handleClick = () => {
+    Analytics.getInstance().track(AnalyticsEvent.ReportIssueOpened, {
+      source: "direct_ui",
+    });
     openReportIssueWithContext(props.context);
   };
 

--- a/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
@@ -35,8 +35,8 @@ import {
 import { cn } from "@/lib/utils";
 import { useRunnerInstalledFontsQuery } from "@/hooks/runner/use-runner-installed-fonts-query";
 import {
-  Analytics,
-  AnalyticsEvent,
+  trackedSettingSetter,
+  trackSettingChanged,
   type AnalyticsSetting,
 } from "@/lib/analytics";
 
@@ -44,22 +44,11 @@ function trackedAppearanceSetter<Value>(
   setting: AnalyticsSetting,
   setter: (value: Value) => void,
 ): (value: Value) => void {
-  return (value) => {
-    Analytics.getInstance().track(AnalyticsEvent.SettingChanged, {
-      source: "direct_ui",
-      section: "appearance",
-      setting,
-    });
-    setter(value);
-  };
+  return trackedSettingSetter("appearance", setting, setter);
 }
 
 function trackAppearanceSetting(setting: AnalyticsSetting): void {
-  Analytics.getInstance().track(AnalyticsEvent.SettingChanged, {
-    source: "direct_ui",
-    section: "appearance",
-    setting,
-  });
+  trackSettingChanged("appearance", setting);
 }
 
 export function AppearanceSettingsPanel() {

--- a/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/appearance-settings-panel.tsx
@@ -34,6 +34,33 @@ import {
 } from "@/stores/settings/settings-store";
 import { cn } from "@/lib/utils";
 import { useRunnerInstalledFontsQuery } from "@/hooks/runner/use-runner-installed-fonts-query";
+import {
+  Analytics,
+  AnalyticsEvent,
+  type AnalyticsSetting,
+} from "@/lib/analytics";
+
+function trackedAppearanceSetter<Value>(
+  setting: AnalyticsSetting,
+  setter: (value: Value) => void,
+): (value: Value) => void {
+  return (value) => {
+    Analytics.getInstance().track(AnalyticsEvent.SettingChanged, {
+      source: "direct_ui",
+      section: "appearance",
+      setting,
+    });
+    setter(value);
+  };
+}
+
+function trackAppearanceSetting(setting: AnalyticsSetting): void {
+  Analytics.getInstance().track(AnalyticsEvent.SettingChanged, {
+    source: "direct_ui",
+    section: "appearance",
+    setting,
+  });
+}
 
 export function AppearanceSettingsPanel() {
   const theme = useSettingsStore((state) => state.theme);
@@ -102,13 +129,21 @@ export function AppearanceSettingsPanel() {
       <SettingsRow
         label="Theme"
         description="Use light, dark, or match your system."
-        control={<ThemeModeToggle value={theme} onChange={setTheme} />}
+        control={
+          <ThemeModeToggle
+            value={theme}
+            onChange={trackedAppearanceSetter("theme", setTheme)}
+          />
+        }
       />
       <SettingsRow
         label="Preset"
         description="Pick a named palette. Full-palette presets override the base surface."
         control={
-          <ThemePresetPicker value={themePreset} onChange={setThemePreset} />
+          <ThemePresetPicker
+            value={themePreset}
+            onChange={trackedAppearanceSetter("themePreset", setThemePreset)}
+          />
         }
       />
       <SettingsRow
@@ -122,7 +157,10 @@ export function AppearanceSettingsPanel() {
         control={
           <Switch
             checked={pointerCursors}
-            onCheckedChange={setPointerCursors}
+            onCheckedChange={trackedAppearanceSetter(
+              "pointerCursors",
+              setPointerCursors,
+            )}
             aria-label="Use pointer cursors"
           />
         }
@@ -134,11 +172,18 @@ export function AppearanceSettingsPanel() {
           <EpicNodeIconColorPicker
             enabled={artifactIconColorMode === "byType"}
             onEnabledChange={(enabled) => {
+              trackAppearanceSetting("artifactIconColorMode");
               setArtifactIconColorMode(enabled ? "byType" : "none");
             }}
             colors={artifactIconColors}
-            onChange={setArtifactIconColor}
-            onReset={resetArtifactIconColors}
+            onChange={(type, color) => {
+              trackAppearanceSetting("artifactIconColors");
+              setArtifactIconColor(type, color);
+            }}
+            onReset={() => {
+              trackAppearanceSetting("artifactIconColors");
+              resetArtifactIconColors();
+            }}
           />
         }
       />
@@ -150,7 +195,10 @@ export function AppearanceSettingsPanel() {
           <div className="flex flex-col items-end gap-2">
             <FontPicker
               value={uiFontFamily}
-              onChange={setUiFontFamily}
+              onChange={trackedAppearanceSetter(
+                "uiFontFamily",
+                setUiFontFamily,
+              )}
               options={installedFonts}
               defaultLabel="Figtree (Default)"
               resetTooltip="Reset to default"
@@ -158,7 +206,7 @@ export function AppearanceSettingsPanel() {
             />
             <SettingsNumberInput
               value={uiFontSize}
-              onChange={setUiFontSize}
+              onChange={trackedAppearanceSetter("uiFontSize", setUiFontSize)}
               min={10}
               max={20}
               unit="px"
@@ -176,7 +224,10 @@ export function AppearanceSettingsPanel() {
           <div className="flex flex-col items-end gap-2">
             <FontPicker
               value={codeFontFamily}
-              onChange={setCodeFontFamily}
+              onChange={trackedAppearanceSetter(
+                "codeFontFamily",
+                setCodeFontFamily,
+              )}
               options={installedFonts}
               defaultLabel="System Default"
               resetTooltip="Reset to default"
@@ -184,7 +235,10 @@ export function AppearanceSettingsPanel() {
             />
             <SettingsNumberInput
               value={codeFontSize}
-              onChange={setCodeFontSize}
+              onChange={trackedAppearanceSetter(
+                "codeFontSize",
+                setCodeFontSize,
+              )}
               min={10}
               max={24}
               unit="px"
@@ -202,7 +256,10 @@ export function AppearanceSettingsPanel() {
           <div className="flex flex-col items-end gap-2">
             <FontPicker
               value={terminalFontFamily}
-              onChange={setTerminalFontFamily}
+              onChange={trackedAppearanceSetter(
+                "terminalFontFamily",
+                setTerminalFontFamily,
+              )}
               options={installedFonts}
               defaultLabel="Same as code font"
               resetTooltip="Use code font"
@@ -211,7 +268,10 @@ export function AppearanceSettingsPanel() {
             <NullableFontSizeInput
               value={terminalFontSize}
               followValue={codeFontSize}
-              onChange={setTerminalFontSize}
+              onChange={trackedAppearanceSetter(
+                "terminalFontSize",
+                setTerminalFontSize,
+              )}
               min={10}
               max={24}
               ariaLabel="Terminal font size"
@@ -226,7 +286,10 @@ export function AppearanceSettingsPanel() {
         control={
           <TerminalCursorStylePicker
             value={terminalCursorStyle}
-            onChange={setTerminalCursorStyle}
+            onChange={trackedAppearanceSetter<TerminalCursorStyle>(
+              "terminalCursorStyle",
+              setTerminalCursorStyle,
+            )}
           />
         }
       />
@@ -236,7 +299,10 @@ export function AppearanceSettingsPanel() {
         control={
           <Switch
             checked={terminalCursorBlink}
-            onCheckedChange={setTerminalCursorBlink}
+            onCheckedChange={trackedAppearanceSetter(
+              "terminalCursorBlink",
+              setTerminalCursorBlink,
+            )}
             aria-label="Blink terminal cursor"
           />
         }

--- a/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
@@ -39,6 +39,11 @@ import { useSettingsStore } from "@/stores/settings/settings-store";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useLocalSnapshotClearStore } from "@/stores/settings/local-snapshot-clear-store";
 import { useOnboardingStore } from "@/stores/onboarding/onboarding-store";
+import {
+  Analytics,
+  AnalyticsEvent,
+  type AnalyticsSetting,
+} from "@/lib/analytics";
 
 const MIGRATION_PROGRESS_LABEL = "Migrating tasks";
 const SNAPSHOTS_LOCAL_STORAGE_PARAMS = {};
@@ -55,6 +60,14 @@ function formatMigrationProgress(state: MigrationRunState): string | null {
   const tasks = `${taskChainsSeen(state.counts)}/${totalTaskChains}`;
   const epics = `${epicsSeen(state.counts)}/${totalLocalEpics}`;
   return `${MIGRATION_PROGRESS_LABEL} - tasks ${tasks}, epics ${epics}`;
+}
+
+function trackGeneralSetting(setting: AnalyticsSetting): void {
+  Analytics.getInstance().track(AnalyticsEvent.SettingChanged, {
+    source: "direct_ui",
+    section: "general",
+    setting,
+  });
 }
 
 export function GeneralSettingsPanel() {
@@ -107,7 +120,10 @@ export function GeneralSettingsPanel() {
         control={
           <Switch
             checked={preventSleepWhileRunning}
-            onCheckedChange={setPreventSleepWhileRunning}
+            onCheckedChange={(value) => {
+              trackGeneralSetting("preventSleepWhileRunning");
+              setPreventSleepWhileRunning(value);
+            }}
             aria-label="Prevent sleep while running"
           />
         }
@@ -118,7 +134,10 @@ export function GeneralSettingsPanel() {
         control={
           <Switch
             checked={showGlobalResourceMonitor}
-            onCheckedChange={setShowGlobalResourceMonitor}
+            onCheckedChange={(value) => {
+              trackGeneralSetting("showGlobalResourceMonitor");
+              setShowGlobalResourceMonitor(value);
+            }}
             aria-label="Show global resources button"
           />
         }
@@ -129,7 +148,10 @@ export function GeneralSettingsPanel() {
         control={
           <Switch
             checked={showNavigatorResourceStats}
-            onCheckedChange={setShowNavigatorResourceStats}
+            onCheckedChange={(value) => {
+              trackGeneralSetting("showNavigatorResourceStats");
+              setShowNavigatorResourceStats(value);
+            }}
             aria-label="Show navigator resource stats"
           />
         }
@@ -140,7 +162,10 @@ export function GeneralSettingsPanel() {
         control={
           <Switch
             checked={pinContextUsageBreakdown}
-            onCheckedChange={setPinContextUsageBreakdown}
+            onCheckedChange={(value) => {
+              trackGeneralSetting("pinContextUsageBreakdown");
+              setPinContextUsageBreakdown(value);
+            }}
             aria-label="Pin context usage breakdown"
           />
         }
@@ -151,7 +176,10 @@ export function GeneralSettingsPanel() {
         control={
           <Switch
             checked={quoteReplyEnabled}
-            onCheckedChange={setQuoteReplyEnabled}
+            onCheckedChange={(value) => {
+              trackGeneralSetting("quoteReplyEnabled");
+              setQuoteReplyEnabled(value);
+            }}
             aria-label="Quote reply on text selection"
           />
         }

--- a/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
@@ -39,11 +39,7 @@ import { useSettingsStore } from "@/stores/settings/settings-store";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useLocalSnapshotClearStore } from "@/stores/settings/local-snapshot-clear-store";
 import { useOnboardingStore } from "@/stores/onboarding/onboarding-store";
-import {
-  Analytics,
-  AnalyticsEvent,
-  type AnalyticsSetting,
-} from "@/lib/analytics";
+import { trackSettingChanged, type AnalyticsSetting } from "@/lib/analytics";
 
 const MIGRATION_PROGRESS_LABEL = "Migrating tasks";
 const SNAPSHOTS_LOCAL_STORAGE_PARAMS = {};
@@ -63,11 +59,7 @@ function formatMigrationProgress(state: MigrationRunState): string | null {
 }
 
 function trackGeneralSetting(setting: AnalyticsSetting): void {
-  Analytics.getInstance().track(AnalyticsEvent.SettingChanged, {
-    source: "direct_ui",
-    section: "general",
-    setting,
-  });
+  trackSettingChanged("general", setting);
 }
 
 export function GeneralSettingsPanel() {

--- a/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/traycer-subscription-section.tsx
@@ -23,6 +23,7 @@ import {
   TraycerSubscriptionView,
 } from "@/components/settings/panels/traycer-subscription-views";
 import { resolveManageSubscriptionUrl } from "@/lib/auth/manage-subscription-url";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import {
   accountContextValue,
   parseAccountContextValue,
@@ -65,6 +66,10 @@ export function TraycerSubscriptionSection() {
             type="button"
             onClick={() => {
               void runnerHost.openExternalLink(manageUrl);
+              Analytics.getInstance().track(
+                AnalyticsEvent.SubscriptionManagementOpened,
+                { source: "direct_ui" },
+              );
             }}
             className="inline-flex w-fit items-center gap-1.5 rounded px-1 text-ui-xs font-medium text-primary transition-colors hover:text-primary/80 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
           >
@@ -73,7 +78,13 @@ export function TraycerSubscriptionSection() {
           </button>
           <RefreshIconButton
             onRefresh={async () => {
-              await query.refetch();
+              const result = await query.refetch();
+              if (result.status === "success") {
+                Analytics.getInstance().track(
+                  AnalyticsEvent.SubscriptionRefreshed,
+                  { source: "direct_ui" },
+                );
+              }
             }}
             label="Refresh subscription"
             refreshing={query.isFetching}

--- a/clients/gui-app/src/components/settings/panels/use-provider-profile-login-flow.ts
+++ b/clients/gui-app/src/components/settings/panels/use-provider-profile-login-flow.ts
@@ -11,6 +11,12 @@ import type {
   ProviderLoginCapability,
   ProviderProfile,
 } from "@traycer/protocol/host/provider-schemas";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+  type AnalyticsBlocker,
+} from "@/lib/analytics";
 
 type LoginMutationContext = { readonly hostId: string | null };
 
@@ -308,17 +314,30 @@ export function useProviderProfileLoginFlow(
       // means the host never minted a profile-scoped child, so there is
       // nothing to cancel.
       if (mode === "reauth" || profileId !== null) cancelProfile(profileId);
+      Analytics.getInstance().track(
+        AnalyticsEvent.ProviderProfileLinkCancelled,
+        { provider: providerId, mode },
+      );
       setState({ kind: "cancelled" });
     },
-    [cancelProfile, mode],
+    [cancelProfile, mode, providerId],
   );
 
+  // The blocker is classified from the REAL error at each call site (or an
+  // explicit bounded value for error-less outcomes), never from the display
+  // message - UI copy like "Sign-in did not…" would misclassify everything
+  // as `authentication`.
   const fail = useCallback(
-    (message: string): void => {
+    (message: string, blocker: AnalyticsBlocker): void => {
+      Analytics.getInstance().track(AnalyticsEvent.ProviderProfileLinkFailed, {
+        provider: providerId,
+        mode,
+        blocker,
+      });
       setState({ kind: "failed", message });
       onFailed(message);
     },
-    [onFailed],
+    [mode, onFailed, providerId],
   );
 
   /**
@@ -334,7 +353,7 @@ export function useProviderProfileLoginFlow(
         return;
       }
       if (restartCountRef.current >= CODE_PASTE_RESTART_CAP) {
-        fail(CODE_PASTE_RESTART_LIMIT_MESSAGES[cause]);
+        fail(CODE_PASTE_RESTART_LIMIT_MESSAGES[cause], "timeout");
         return;
       }
       restartCountRef.current += 1;
@@ -378,6 +397,10 @@ export function useProviderProfileLoginFlow(
       if (awaitOutcome === null) return;
       const ambient = mode === "reauth" && existingProfileId === null;
       if (awaitOutcome === "authenticated") {
+        Analytics.getInstance().track(
+          AnalyticsEvent.ProviderProfileLinkSucceeded,
+          { provider: providerId, mode },
+        );
         if (ambient) {
           setState({ kind: "start" });
           return;
@@ -403,9 +426,9 @@ export function useProviderProfileLoginFlow(
         setState({ kind: "start" });
         return;
       }
-      fail(failureMessages.notFinished);
+      fail(failureMessages.notFinished, "authentication");
     },
-    [existingProfileId, fail, failureMessages, mode, restart],
+    [existingProfileId, fail, failureMessages, mode, providerId, restart],
   );
 
   const beginLogin = useCallback(
@@ -465,7 +488,9 @@ export function useProviderProfileLoginFlow(
               !data.started ||
               (mode === "create" && nextProfileId === null)
             ) {
-              fail(failureMessages.notStarted);
+              // The RPC succeeded but the host declined to start the login:
+              // the provider tooling is the limiting factor, not auth.
+              fail(failureMessages.notStarted, "provider_unavailable");
               return;
             }
             setState({
@@ -540,12 +565,12 @@ export function useProviderProfileLoginFlow(
               },
             );
           },
-          onError: () => {
+          onError: (error) => {
             if (cancelRequestedRef.current) {
               finishCancellation(null);
               return;
             }
-            fail(failureMessages.notStarted);
+            fail(failureMessages.notStarted, analyticsBlockerFromError(error));
           },
         },
       );
@@ -588,9 +613,21 @@ export function useProviderProfileLoginFlow(
       cancelRequestedRef.current = false;
       cancelledRef.current = false;
       restartCountRef.current = 0;
+      Analytics.getInstance().track(AnalyticsEvent.ProviderProfileLinkStarted, {
+        source: "direct_ui",
+        provider: providerId,
+        mode,
+      });
       beginLogin(options, null);
     },
-    [awaitLogin.isPending, beginLogin, startLogin.isPending, state.kind],
+    [
+      awaitLogin.isPending,
+      beginLogin,
+      mode,
+      providerId,
+      startLogin.isPending,
+      state.kind,
+    ],
   );
 
   const commitPending =

--- a/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
+++ b/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
@@ -12,6 +12,11 @@ import type { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-s
 import { WorktreeDeleteStreamClient } from "@traycer-clients/shared/host-transport/worktree-delete-stream-client";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
 import { openOwnedDurableStreamClient } from "@/lib/host/owned-durable-stream-client";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 
 export interface LogSegment {
   /** Monotonic per-run id (append-only), so React keys are stable. */
@@ -116,7 +121,15 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
         record.key === key ? { ...record, run: updater(record.run) } : record,
       ),
     })),
-  completeRun: (key, deleted) =>
+  completeRun: (key, deleted) => {
+    // Emission rides the natural non-terminal -> terminal transition (state
+    // read before the synchronous update); a replayed/duplicate settle can't
+    // double-count and no reporting ledger is needed.
+    const existing = useWorktreeDeleteRunStore
+      .getState()
+      .runs.find((candidate) => candidate.key === key);
+    const wasTerminal =
+      existing === undefined || worktreeRunIsTerminal(existing.run);
     set((state) => {
       const record = state.runs.find((candidate) => candidate.key === key);
       if (record === undefined) return state;
@@ -142,8 +155,20 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
             ? key
             : state.foregroundKey,
       };
-    }),
-  failRun: (key, error) =>
+    });
+    if (!wasTerminal) {
+      reportTerminalDeleteOutcome(
+        key,
+        useWorktreeDeleteRunStore.getState().runs,
+      );
+    }
+  },
+  failRun: (key, error) => {
+    const existing = useWorktreeDeleteRunStore
+      .getState()
+      .runs.find((candidate) => candidate.key === key);
+    const wasTerminal =
+      existing === undefined || worktreeRunIsTerminal(existing.run);
     set((state) => {
       const record = state.runs.find((candidate) => candidate.key === key);
       if (record === undefined) return state;
@@ -171,7 +196,14 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
             ? key
             : state.foregroundKey,
       };
-    }),
+    });
+    if (!wasTerminal) {
+      reportTerminalDeleteOutcome(
+        key,
+        useWorktreeDeleteRunStore.getState().runs,
+      );
+    }
+  },
   setBackgrounded: (key, backgrounded) =>
     set((state) => ({
       runs: state.runs.map((record) =>
@@ -467,6 +499,45 @@ export function __resetWorktreeDeleteRunForTests(): void {
   pendingSettledCallbacks.clear();
   batchSequence = 0;
   useWorktreeDeleteRunStore.getState().clearAll();
+}
+
+/**
+ * Called exactly once per run's non-terminal -> terminal transition (the
+ * store actions observe the transition inside their state update). A batch
+ * emits when the member that just settled was its last non-terminal one.
+ */
+function reportTerminalDeleteOutcome(
+  key: string,
+  runs: readonly WorktreeDeleteRunRecord[],
+): void {
+  const record = runs.find((candidate) => candidate.key === key);
+  if (record === undefined || !worktreeRunIsTerminal(record.run)) return;
+  if (record.batchKey === null) {
+    Analytics.getInstance().track(
+      AnalyticsEvent.WorktreeDeleted,
+      record.run.deleted
+        ? { outcome: "succeeded", blocker: null }
+        : {
+            outcome: "failed",
+            blocker: analyticsBlockerFromError(record.run.error),
+          },
+    );
+    return;
+  }
+  const batch = runs.filter(
+    (candidate) => candidate.batchKey === record.batchKey,
+  );
+  if (batch.some((candidate) => !worktreeRunIsTerminal(candidate.run))) {
+    return;
+  }
+  const succeededCount = batch.filter(
+    (candidate) => candidate.run.deleted,
+  ).length;
+  Analytics.getInstance().track(AnalyticsEvent.WorktreesBulkDeleted, {
+    requested_count: batch.length,
+    succeeded_count: succeededCount,
+    failed_count: batch.length - succeededCount,
+  });
 }
 
 export function useWorktreeDeleteProgressSummary(): WorktreeDeleteProgressSummary {

--- a/clients/gui-app/src/components/settings/settings-sidebar.tsx
+++ b/clients/gui-app/src/components/settings/settings-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/providers/keybinding-context";
 import { LeaderDigitBadge } from "@/components/ui/leader-digit-badge";
 import { leaderHint } from "@/components/ui/leader-digit-shortcuts";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export type SettingsSidebarMode =
   | { readonly kind: "route" }
@@ -77,7 +78,13 @@ function SettingsSidebarItem(props: SettingsSidebarItemProps) {
       <button
         type="button"
         data-testid={`settings-sidebar-item-${section.id}`}
-        onClick={() => mode.onSelect(section.id)}
+        onClick={() => {
+          Analytics.getInstance().track(AnalyticsEvent.SettingsOpened, {
+            source: "direct_ui",
+            section: section.id,
+          });
+          mode.onSelect(section.id);
+        }}
         className={cn(
           baseClass,
           "text-left",
@@ -107,6 +114,12 @@ function SettingsSidebarRouteItem(props: {
     <Link
       to={`/settings/${section.id}`}
       replace
+      onClick={() => {
+        Analytics.getInstance().track(AnalyticsEvent.SettingsOpened, {
+          source: "direct_ui",
+          section: section.id,
+        });
+      }}
       className={cn(
         "inline-flex items-center gap-3 rounded-md px-3 py-2 text-ui-sm transition-colors",
         active

--- a/clients/gui-app/src/components/settings/voice-settings-section.tsx
+++ b/clients/gui-app/src/components/settings/voice-settings-section.tsx
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import { SettingsRow } from "@/components/settings/settings-row";
 import { Switch } from "@/components/ui/switch";
 import { useSettingsStore } from "@/stores/settings/settings-store";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export function VoiceSettingsSection(): ReactNode {
   const { voiceInputEnabled, setVoiceInputEnabled } = useSettingsStore(
@@ -19,7 +20,15 @@ export function VoiceSettingsSection(): ReactNode {
       control={
         <Switch
           checked={voiceInputEnabled}
-          onCheckedChange={setVoiceInputEnabled}
+          onCheckedChange={(enabled) => {
+            Analytics.getInstance().track(
+              enabled
+                ? AnalyticsEvent.VoiceEnabled
+                : AnalyticsEvent.VoiceDisabled,
+              { source: "direct_ui" },
+            );
+            setVoiceInputEnabled(enabled);
+          }}
           aria-label="Voice input"
         />
       }

--- a/clients/gui-app/src/components/worktree/open-in-editor-button.tsx
+++ b/clients/gui-app/src/components/worktree/open-in-editor-button.tsx
@@ -78,7 +78,7 @@ export function OpenInEditorButton(props: OpenInEditorButtonProps) {
   const activeHostEntry = useHostDirectoryEntry(activeHostId ?? "");
   const defaultEditor = useSettingsStore((s) => s.defaultEditor);
   const setDefaultEditor = useSettingsStore((s) => s.setDefaultEditor);
-  const mutation = useEditorOpen();
+  const mutation = useEditorOpen("workspace");
   const { active: openFeedbackActive, trigger: triggerOpenFeedback } =
     useEditorOpenFeedback();
   const availability = useEditorAvailability();

--- a/clients/gui-app/src/hooks/auth/use-auth-open-verification-page-mutation.ts
+++ b/clients/gui-app/src/hooks/auth/use-auth-open-verification-page-mutation.ts
@@ -1,11 +1,17 @@
 import { useMutation } from "@tanstack/react-query";
 import { useAuthService } from "@/lib/host";
 import { authMutationKeys } from "@/lib/query-keys";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export function useAuthOpenVerificationPageMutation() {
   const auth = useAuthService();
   return useMutation({
     mutationKey: authMutationKeys.openVerificationPage(),
+    onMutate: () => {
+      Analytics.getInstance().track(AnalyticsEvent.SignInApprovalOpened, {
+        source: "direct_ui",
+      });
+    },
     mutationFn: () => {
       auth.openVerificationPage();
       return Promise.resolve();

--- a/clients/gui-app/src/hooks/auth/use-auth-sign-in-mutation.ts
+++ b/clients/gui-app/src/hooks/auth/use-auth-sign-in-mutation.ts
@@ -2,12 +2,24 @@ import { useMutation } from "@tanstack/react-query";
 import { toastFromAuthError } from "@/lib/auth-error-toast";
 import { useAuthService } from "@/lib/host";
 import { authMutationKeys } from "@/lib/query-keys";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export function useAuthSignInMutation() {
   const auth = useAuthService();
   return useMutation({
     mutationKey: authMutationKeys.signIn(),
     mutationFn: () => auth.signIn(),
-    onError: (error) => toastFromAuthError(error, "Couldn't start sign-in."),
+    // Only `sign_in_started` belongs to the gesture. `signIn()` resolves once
+    // the device flow is LAUNCHED (and swallows launch failures), so the
+    // terminal succeeded/failed events are emitted by AuthService when the
+    // OAuth result actually lands.
+    onMutate: () => {
+      Analytics.getInstance().track(AnalyticsEvent.SignInStarted, {
+        source: "direct_ui",
+      });
+    },
+    onError: (error) => {
+      toastFromAuthError(error, "Couldn't start sign-in.");
+    },
   });
 }

--- a/clients/gui-app/src/hooks/chats/use-chat-actions.ts
+++ b/clients/gui-app/src/hooks/chats/use-chat-actions.ts
@@ -99,34 +99,94 @@ export interface ChatActions {
   ) => JsonContent | null;
 }
 
+/**
+ * Emits the semantic event only when the store accepted the dispatch (a
+ * `null` result means the action was rejected locally and never left the
+ * renderer). Analytics is best-effort by design: a dispatch the host later
+ * rejects still counts as the user taking the action.
+ */
+function tracked<Result>(
+  result: Result | null,
+  emit: () => void,
+): Result | null {
+  if (result !== null) emit();
+  return result;
+}
+
 export function useChatActions(handle: ChatSessionStoreHandle): ChatActions {
   return useMemo<ChatActions>(
     () => ({
-      sendMessage: (content, sender, settings) => {
-        Analytics.getInstance().track(AnalyticsEvent.ChatMessageSent, {
-          harness: settings.harnessId,
-          model: settings.model,
-          mode: settings.agentMode,
-        });
-        return handle.store.getState().sendMessage(content, sender, settings);
-      },
+      sendMessage: (content, sender, settings) =>
+        tracked(
+          handle.store.getState().sendMessage(content, sender, settings),
+          () => {
+            Analytics.getInstance().track(AnalyticsEvent.ChatMessageSent, {
+              harness: settings.harnessId,
+              mode: settings.agentMode,
+            });
+          },
+        ),
       deleteMessageSuffix: (fromMessageId) =>
-        handle.store.getState().deleteMessageSuffix(fromMessageId),
+        tracked(
+          handle.store.getState().deleteMessageSuffix(fromMessageId),
+          () => {
+            Analytics.getInstance().track(
+              AnalyticsEvent.ChatMessageSuffixDeleted,
+              null,
+            );
+          },
+        ),
       editUserMessage: (input) =>
-        handle.store.getState().editUserMessage(input),
+        tracked(handle.store.getState().editUserMessage(input), () => {
+          Analytics.getInstance().track(AnalyticsEvent.ChatMessageEdited, null);
+        }),
       revertFileChanges: (fromMessageId, filePaths, revertArtifacts) =>
-        handle.store
-          .getState()
-          .revertFileChanges(fromMessageId, filePaths, revertArtifacts),
-      stopTurn: () => handle.store.getState().stopTurn(),
+        tracked(
+          handle.store
+            .getState()
+            .revertFileChanges(fromMessageId, filePaths, revertArtifacts),
+          () => {
+            Analytics.getInstance().track(AnalyticsEvent.FileChangesReverted, {
+              file_count: filePaths === null ? 0 : filePaths.length,
+              revert_artifacts: revertArtifacts,
+            });
+          },
+        ),
+      stopTurn: () =>
+        tracked(handle.store.getState().stopTurn(), () => {
+          Analytics.getInstance().track(AnalyticsEvent.ChatStopped, {
+            scope: "current",
+          });
+        }),
       stopBackgroundItem: (taskId) =>
-        handle.store.getState().stopBackgroundItem(taskId),
+        tracked(handle.store.getState().stopBackgroundItem(taskId), () => {
+          Analytics.getInstance().track(
+            AnalyticsEvent.ChatBackgroundItemStopped,
+            { scope: "one" },
+          );
+        }),
       stopAllBackgroundItems: () =>
-        handle.store.getState().stopAllBackgroundItems(),
-      pauseQueue: () => handle.store.getState().pauseQueue(),
-      resumeQueue: () => handle.store.getState().resumeQueue(),
+        tracked(handle.store.getState().stopAllBackgroundItems(), () => {
+          Analytics.getInstance().track(
+            AnalyticsEvent.ChatBackgroundItemStopped,
+            { scope: "all" },
+          );
+        }),
+      pauseQueue: () =>
+        tracked(handle.store.getState().pauseQueue(), () => {
+          Analytics.getInstance().track(AnalyticsEvent.ChatQueuePaused, null);
+        }),
+      resumeQueue: () =>
+        tracked(handle.store.getState().resumeQueue(), () => {
+          Analytics.getInstance().track(AnalyticsEvent.ChatQueueResumed, null);
+        }),
       queueEdit: (queueItemId, content) =>
-        handle.store.getState().queueEdit(queueItemId, content),
+        tracked(handle.store.getState().queueEdit(queueItemId, content), () => {
+          Analytics.getInstance().track(
+            AnalyticsEvent.ChatQueueItemEdited,
+            null,
+          );
+        }),
       queueSettingsUpdate: (queueItemId, settings) =>
         handle.store.getState().queueSettingsUpdate(queueItemId, settings),
       restampQueuedItemSettings: (settings, excludeQueueItemId) =>
@@ -136,23 +196,74 @@ export function useChatActions(handle: ChatSessionStoreHandle): ChatActions {
       updateActivePermissionMode: (permissionMode) =>
         handle.store.getState().updateActivePermissionMode(permissionMode),
       queueCancel: (queueItemId) =>
-        handle.store.getState().queueCancel(queueItemId),
+        tracked(handle.store.getState().queueCancel(queueItemId), () => {
+          Analytics.getInstance().track(
+            AnalyticsEvent.ChatQueueItemCancelled,
+            null,
+          );
+        }),
       queueReorder: (queueItemId, beforeQueueItemId) =>
-        handle.store.getState().queueReorder(queueItemId, beforeQueueItemId),
+        tracked(
+          handle.store.getState().queueReorder(queueItemId, beforeQueueItemId),
+          () => {
+            Analytics.getInstance().track(
+              AnalyticsEvent.ChatQueueItemReordered,
+              null,
+            );
+          },
+        ),
       queueSteerNow: (queueItemId, newSettings) =>
-        handle.store.getState().queueSteerNow(queueItemId, newSettings),
+        tracked(
+          handle.store.getState().queueSteerNow(queueItemId, newSettings),
+          () => {
+            Analytics.getInstance().track(AnalyticsEvent.ChatQueueItemSteered, {
+              settings_changed: newSettings !== null,
+            });
+          },
+        ),
       queueAbortSteer: (queueItemId) =>
         handle.store.getState().queueAbortSteer(queueItemId),
       approvalDecision: (approvalId, decision) =>
-        handle.store.getState().approvalDecision(approvalId, decision),
+        tracked(
+          handle.store.getState().approvalDecision(approvalId, decision),
+          () => {
+            Analytics.getInstance().track(AnalyticsEvent.ApprovalDecided, {
+              decision: decision.approved ? "approved" : "denied",
+            });
+          },
+        ),
       fileEditApprovalDecision: (approvalId, decision) =>
-        handle.store.getState().fileEditApprovalDecision(approvalId, decision),
+        tracked(
+          handle.store
+            .getState()
+            .fileEditApprovalDecision(approvalId, decision),
+          () => {
+            Analytics.getInstance().track(
+              AnalyticsEvent.FileEditApprovalDecided,
+              { decision: decision.approved ? "approved" : "denied" },
+            );
+          },
+        ),
       restoreCheckpoint: (checkpointId, revertArtifacts) =>
-        handle.store
-          .getState()
-          .restoreCheckpoint(checkpointId, revertArtifacts),
+        tracked(
+          handle.store
+            .getState()
+            .restoreCheckpoint(checkpointId, revertArtifacts),
+          () => {
+            Analytics.getInstance().track(AnalyticsEvent.CheckpointRestored, {
+              revert_artifacts: revertArtifacts,
+            });
+          },
+        ),
       interviewAnswer: (blockId, answers) =>
-        handle.store.getState().interviewAnswer(blockId, answers),
+        tracked(
+          handle.store.getState().interviewAnswer(blockId, answers),
+          () => {
+            Analytics.getInstance().track(AnalyticsEvent.InterviewAnswered, {
+              answer_count: answers.length,
+            });
+          },
+        ),
       interviewError: (blockId, reason) =>
         handle.store.getState().interviewError(blockId, reason),
       ackFailedSendRestoration: (clientActionId) =>

--- a/clients/gui-app/src/hooks/comments/use-comment-thread-mutations.ts
+++ b/clients/gui-app/src/hooks/comments/use-comment-thread-mutations.ts
@@ -3,10 +3,12 @@ import type {
   CreateCommentThreadRequest,
   ListCommentThreadsResponse,
 } from "@traycer/protocol/host/epic/unary-schemas";
+import { extractUserMentionIds } from "@traycer/protocol/notifications/comment-notification-utils";
 import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient } from "@/lib/host/runtime";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { commentThreadsQueryKey } from "./use-epic-comment-threads";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /**
  * Mutation hooks for the host comment-thread RPC surface.
@@ -59,6 +61,9 @@ export function useCreateCommentThread() {
     options: {
       onMutate: () => ({ hostId: client.getActiveHostId() }),
       onSuccess: (_data, variables: CreateCommentThreadRequest, ctx) => {
+        Analytics.getInstance().track(AnalyticsEvent.CommentCreated, {
+          has_mention: extractUserMentionIds(variables.content).length > 0,
+        });
         invalidate(
           (ctx as MutationContext).hostId,
           variables.epicId,
@@ -83,6 +88,9 @@ export function useReplyToCommentThread() {
     options: {
       onMutate: () => ({ hostId: client.getActiveHostId() }),
       onSuccess: (_data, variables, ctx) => {
+        Analytics.getInstance().track(AnalyticsEvent.CommentReplied, {
+          has_mention: extractUserMentionIds(variables.content).length > 0,
+        });
         invalidate(
           (ctx as MutationContext).hostId,
           variables.epicId,
@@ -107,6 +115,7 @@ export function useEditComment() {
     options: {
       onMutate: () => ({ hostId: client.getActiveHostId() }),
       onSuccess: (_data, variables, ctx) => {
+        Analytics.getInstance().track(AnalyticsEvent.CommentEdited, null);
         invalidate(
           (ctx as MutationContext).hostId,
           variables.epicId,
@@ -131,6 +140,7 @@ export function useDeleteComment() {
     options: {
       onMutate: () => ({ hostId: client.getActiveHostId() }),
       onSuccess: (_data, variables, ctx) => {
+        Analytics.getInstance().track(AnalyticsEvent.CommentDeleted, null);
         invalidate(
           (ctx as MutationContext).hostId,
           variables.epicId,
@@ -155,6 +165,12 @@ export function useSetCommentThreadResolved() {
     options: {
       onMutate: () => ({ hostId: client.getActiveHostId() }),
       onSuccess: (_data, variables, ctx) => {
+        Analytics.getInstance().track(
+          variables.resolved
+            ? AnalyticsEvent.CommentResolved
+            : AnalyticsEvent.CommentReopened,
+          null,
+        );
         invalidate(
           (ctx as MutationContext).hostId,
           variables.epicId,
@@ -180,6 +196,7 @@ export function useDeleteCommentThread() {
     options: {
       onMutate: () => ({ hostId: client.getActiveHostId() }),
       onSuccess: (_data, variables, ctx) => {
+        Analytics.getInstance().track(AnalyticsEvent.CommentDeleted, null);
         const { hostId } = ctx as MutationContext;
         if (hostId !== null) {
           // Clear the deleted thread from the cached list eagerly so the

--- a/clients/gui-app/src/hooks/composer/__tests__/use-composer-paste.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-composer-paste.test.tsx
@@ -11,10 +11,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { toast } from "sonner";
 
 import {
+  useComposerPaste,
   useComposerPasteAdapter,
   type UseComposerPasteResult,
 } from "@/hooks/composer/use-composer-paste";
 import type { ImageAttachmentAttrs } from "@/components/chat/composer/editor/extensions/image-attachment-extension";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -33,6 +35,7 @@ describe("useComposerPasteAdapter - attachImageFiles", () => {
     const { result } = renderHook(() =>
       useComposerPasteAdapter((attrs) => {
         inserted.push([...attrs]);
+        return attrs.length;
       }),
     );
     const imageFile = new File(["hello"], "sample.png", {
@@ -61,6 +64,7 @@ describe("useComposerPasteAdapter - attachImageFiles", () => {
     const { result } = renderHook(() =>
       useComposerPasteAdapter((attrs) => {
         inserted.push([...attrs]);
+        return attrs.length;
       }),
     );
     const png = new File(["png-bytes"], "shot.png", { type: "image/png" });
@@ -82,6 +86,7 @@ describe("useComposerPasteAdapter - attachImageFiles", () => {
     const { result } = renderHook(() =>
       useComposerPasteAdapter((attrs) => {
         inserted.push([...attrs]);
+        return attrs.length;
       }),
     );
     const oversized = makeOversizedImage("big.png");
@@ -109,6 +114,7 @@ describe("useComposerPasteAdapter - attachImageFiles", () => {
     const { result } = renderHook(() =>
       useComposerPasteAdapter((attrs) => {
         inserted.push([...attrs]);
+        return attrs.length;
       }),
     );
 
@@ -119,14 +125,88 @@ describe("useComposerPasteAdapter - attachImageFiles", () => {
   });
 
   it("returns a stable attachImageFiles reference across renders", () => {
-    const onInsert = (_attrs: ReadonlyArray<ImageAttachmentAttrs>): void =>
-      undefined;
+    const onInsert = (_attrs: ReadonlyArray<ImageAttachmentAttrs>): number => 0;
     const { result, rerender } = renderHook(() =>
       useComposerPasteAdapter(onInsert),
     );
     const first = result.current.attachImageFiles;
     rerender();
     expect(result.current.attachImageFiles).toBe(first);
+  });
+
+  it("does not report an attachment when the live editor rejects insertion", async () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    const insert = vi.fn(
+      (_attrs: ReadonlyArray<ImageAttachmentAttrs>): number => 0,
+    );
+    const { result } = renderHook(() => useComposerPasteAdapter(insert));
+    const imageFile = new File(["hello"], "sample.png", {
+      type: "image/png",
+    });
+
+    attachImageFiles(result.current, [imageFile]);
+
+    await waitFor(() => expect(insert).toHaveBeenCalledOnce());
+    expect(track).not.toHaveBeenCalledWith(
+      AnalyticsEvent.AttachmentAdded,
+      expect.anything(),
+    );
+  });
+
+  it("does not report an attachment when the editor ref disappears during conversion", async () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    const insertImageAttachments = vi.fn();
+    const editorRef: {
+      current: {
+        insertImageAttachments: typeof insertImageAttachments;
+        isReady: () => boolean;
+        focus: () => void;
+      } | null;
+    } = {
+      current: { insertImageAttachments, isReady: () => true, focus: vi.fn() },
+    };
+    const { result } = renderHook(() => useComposerPaste(editorRef));
+    const imageFile = new File(["hello"], "sample.png", {
+      type: "image/png",
+    });
+
+    attachImageFiles(result.current, [imageFile]);
+    editorRef.current = null;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(insertImageAttachments).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalledWith(
+      AnalyticsEvent.AttachmentAdded,
+      expect.anything(),
+    );
+  });
+
+  it("does not report an attachment when a non-null editor is not ready", async () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    const insertImageAttachments = vi.fn();
+    const editorRef = {
+      current: {
+        insertImageAttachments,
+        isReady: () => false,
+        focus: vi.fn(),
+      },
+    };
+    const { result } = renderHook(() => useComposerPaste(editorRef));
+
+    attachImageFiles(result.current, [
+      new File(["hello"], "sample.png", { type: "image/png" }),
+    ]);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(insertImageAttachments).not.toHaveBeenCalled();
+    expect(track).not.toHaveBeenCalledWith(
+      AnalyticsEvent.AttachmentAdded,
+      expect.anything(),
+    );
   });
 });
 
@@ -248,6 +328,7 @@ function renderHarness(inserted: ImageAttachmentAttrs[][]) {
 function PasteHarness(props: { readonly inserted: ImageAttachmentAttrs[][] }) {
   const handlers = useComposerPasteAdapter((attrs) => {
     props.inserted.push([...attrs]);
+    return attrs.length;
   });
   return (
     <div

--- a/clients/gui-app/src/hooks/composer/__tests__/use-landing-composer-paste.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-landing-composer-paste.test.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import type { ImageAttachmentAttrs } from "@/components/chat/composer/editor/extensions/image-attachment-extension";
 import type { ComposerPasteEditorHandle } from "@/hooks/composer/use-composer-paste";
 import { useLandingComposerPaste } from "@/hooks/composer/use-landing-composer-paste";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import {
   deleteImage,
   getImageBytes,
@@ -61,6 +62,7 @@ function makeHandle(inserted: ImageAttachmentAttrs[][]): {
 } {
   const focusCalls = { count: 0 };
   const handle: ComposerPasteEditorHandle = {
+    isReady: () => true,
     insertImageAttachments: (attrs) => inserted.push([...attrs]),
     focus: () => {
       focusCalls.count += 1;
@@ -70,6 +72,35 @@ function makeHandle(inserted: ImageAttachmentAttrs[][]): {
 }
 
 describe("useLandingComposerPaste", () => {
+  it("does not report an attachment when a non-null editor is not ready", async () => {
+    const inserted: ImageAttachmentAttrs[][] = [];
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    const editorRef = {
+      current: {
+        isReady: () => false,
+        insertImageAttachments: (attrs: ReadonlyArray<ImageAttachmentAttrs>) =>
+          inserted.push([...attrs]),
+        focus: () => undefined,
+      },
+    };
+    const { result } = renderHook(() => useLandingComposerPaste(editorRef));
+
+    act(() => {
+      result.current.attachImageFiles([
+        new File(["hello"], "not-ready.png", { type: "image/png" }),
+      ]);
+    });
+    await waitFor(async () => {
+      expect(await imageHashKeys()).toHaveLength(1);
+    });
+
+    expect(inserted).toEqual([]);
+    expect(track).not.toHaveBeenCalledWith(
+      AnalyticsEvent.AttachmentAdded,
+      expect.anything(),
+    );
+  });
+
   it("ingests an image as a hash-only node with bytes + a session object-URL", async () => {
     const inserted: ImageAttachmentAttrs[][] = [];
     const { handle, focusCalls } = makeHandle(inserted);

--- a/clients/gui-app/src/hooks/composer/use-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-composer-paste.ts
@@ -9,6 +9,11 @@ import { v4 as uuidv4 } from "uuid";
 
 import type { ImageAttachmentAttrs } from "@/components/chat/composer/editor/extensions/image-attachment-extension";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 
 export const IMAGE_MIME_PREFIX = "image/";
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
@@ -31,7 +36,15 @@ function readFileAsDataUrl(file: File): Promise<string> {
   });
 }
 
-export function collectImages(files: ReadonlyArray<File>): File[] {
+/**
+ * `onOversized` lets each surface observe the 5MB rejection (which is
+ * user-visible via the toast here) without the shared filter knowing surface
+ * names; it receives no file details so nothing sensitive can leak into it.
+ */
+export function collectImages(
+  files: ReadonlyArray<File>,
+  onOversized: () => void,
+): File[] {
   const accepted: File[] = [];
   for (const file of files) {
     if (!file.type.startsWith(IMAGE_MIME_PREFIX)) continue;
@@ -48,6 +61,7 @@ export function collectImages(files: ReadonlyArray<File>): File[] {
           source: "Chat composer",
         },
       );
+      onOversized();
       continue;
     }
     accepted.push(file);
@@ -58,7 +72,14 @@ export function collectImages(files: ReadonlyArray<File>): File[] {
 async function filesToImageAttrs(
   files: ReadonlyArray<File>,
 ): Promise<ImageAttachmentAttrs[]> {
-  const accepted = collectImages(files);
+  // This base64 ingest serves only chat / new-conversation surfaces.
+  const accepted = collectImages(files, () => {
+    Analytics.getInstance().track(AnalyticsEvent.AttachmentRejected, {
+      kind: "image",
+      surface: "chat",
+      blocker: "invalid_input",
+    });
+  });
   if (accepted.length === 0) return [];
   const results = await Promise.all(
     accepted.map(async (file) => {
@@ -180,13 +201,34 @@ export function useComposerPasteEvents(
  * is the behavior every non-landing surface relies on — do NOT change it.
  */
 export function useComposerPasteAdapter(
-  insertAttrs: (attrs: ReadonlyArray<ImageAttachmentAttrs>) => void,
+  insertAttrs: (attrs: ReadonlyArray<ImageAttachmentAttrs>) => number,
 ): UseComposerPasteResult {
   const onFiles = useCallback(
     (files: ReadonlyArray<File>) => {
-      void filesToImageAttrs(files).then((attrs) => {
-        if (attrs.length > 0) insertAttrs(attrs);
-      });
+      void filesToImageAttrs(files)
+        .then((attrs) => {
+          if (attrs.length > 0) {
+            const acceptedCount = Math.min(
+              attrs.length,
+              Math.max(0, insertAttrs(attrs)),
+            );
+            attrs.slice(0, acceptedCount).forEach(() => {
+              Analytics.getInstance().track(AnalyticsEvent.AttachmentAdded, {
+                kind: "image",
+                surface: "chat",
+              });
+            });
+          }
+        })
+        .catch((error: unknown) => {
+          // A FileReader failure previously surfaced only as an unhandled
+          // rejection; record it so chat rejections exist in the funnel.
+          Analytics.getInstance().track(AnalyticsEvent.AttachmentRejected, {
+            kind: "image",
+            surface: "chat",
+            blocker: analyticsBlockerFromError(error),
+          });
+        });
     },
     [insertAttrs],
   );
@@ -194,6 +236,7 @@ export function useComposerPasteAdapter(
 }
 
 export interface ComposerPasteEditorHandle {
+  readonly isReady: () => boolean;
   readonly insertImageAttachments: (
     attrs: ReadonlyArray<ImageAttachmentAttrs>,
   ) => void;
@@ -204,11 +247,12 @@ export function useComposerPaste(editorRef: {
   readonly current: ComposerPasteEditorHandle | null;
 }): UseComposerPasteResult {
   const insertAttrs = useCallback(
-    (attrs: ReadonlyArray<ImageAttachmentAttrs>) => {
+    (attrs: ReadonlyArray<ImageAttachmentAttrs>): number => {
       const handle = editorRef.current;
-      if (handle === null) return;
+      if (handle === null || !handle.isReady()) return 0;
       handle.insertImageAttachments(attrs);
       handle.focus();
+      return attrs.length;
     },
     [editorRef],
   );

--- a/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
@@ -14,6 +14,11 @@ import {
   scheduleLandingImageReconcile,
 } from "@/lib/composer/landing-image-gc";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 
 /**
  * Landing-composer paste/drop ingest. Unlike the shared base64 adapter
@@ -30,7 +35,13 @@ import { reportableErrorToast } from "@/lib/reportable-error-toast";
 async function landingImageAttrsFromFiles(
   files: ReadonlyArray<File>,
 ): Promise<ImageAttachmentAttrs[]> {
-  const accepted = collectImages(files);
+  const accepted = collectImages(files, () => {
+    Analytics.getInstance().track(AnalyticsEvent.AttachmentRejected, {
+      kind: "image",
+      surface: "draft",
+      blocker: "invalid_input",
+    });
+  });
   if (accepted.length === 0) return [];
   // Make room (evict oldest inactive drafts) before storing bytes; a paste that
   // can't fit even after eviction is blocked here (toast shown by the budget).
@@ -38,7 +49,14 @@ async function landingImageAttrsFromFiles(
     (sum, file) => sum + (file.size > 0 ? file.size : 0),
     0,
   );
-  if (!reserveLandingImageBudget(incomingBytes)) return [];
+  if (!reserveLandingImageBudget(incomingBytes)) {
+    Analytics.getInstance().track(AnalyticsEvent.AttachmentRejected, {
+      kind: "image",
+      surface: "draft",
+      blocker: "rate_limit",
+    });
+    return [];
+  }
   return Promise.all(
     accepted.map(async (file) => {
       const bytes = new Uint8Array(await file.arrayBuffer());
@@ -63,11 +81,22 @@ export function useLandingComposerPaste(editorRef: {
         .then((attrs) => {
           if (attrs.length === 0) return;
           const handle = editorRef.current;
-          if (handle === null) return;
+          if (handle === null || !handle.isReady()) return;
           handle.insertImageAttachments(attrs);
           handle.focus();
+          attrs.forEach(() => {
+            Analytics.getInstance().track(AnalyticsEvent.AttachmentAdded, {
+              kind: "image",
+              surface: "draft",
+            });
+          });
         })
-        .catch(() => {
+        .catch((error: unknown) => {
+          Analytics.getInstance().track(AnalyticsEvent.AttachmentRejected, {
+            kind: "image",
+            surface: "draft",
+            blocker: analyticsBlockerFromError(error),
+          });
           // A failed ingest (e.g. one image of a multi-image paste failed to hash
           // or store) inserts nothing, but earlier images may already be stored —
           // now orphaned. Surface the failure and schedule a reconcile to reclaim

--- a/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
@@ -81,7 +81,13 @@ export function useLandingComposerPaste(editorRef: {
         .then((attrs) => {
           if (attrs.length === 0) return;
           const handle = editorRef.current;
-          if (handle === null || !handle.isReady()) return;
+          if (handle === null || !handle.isReady()) {
+            // Stored bytes for these images are now orphaned - the same
+            // situation as a failed ingest below - so reclaim them the same
+            // way (their session entries keep the bytes safe until it runs).
+            scheduleLandingImageReconcile();
+            return;
+          }
           handle.insertImageAttachments(attrs);
           handle.focus();
           attrs.forEach(() => {

--- a/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
+++ b/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
@@ -145,15 +145,15 @@ export function useVoiceDictation(
   }, [teardownAudio]);
 
   const fail = useCallback(
-    (message: string) => {
+    (message: string, error: unknown) => {
       if (stateRef.current === "transcribing") {
         Analytics.getInstance().track(AnalyticsEvent.VoiceTranscriptionFailed, {
-          blocker: analyticsBlockerFromError(message),
+          blocker: analyticsBlockerFromError(error),
         });
       } else {
         Analytics.getInstance().track(AnalyticsEvent.VoiceCaptureFailed, {
           source: "direct_ui",
-          blocker: analyticsBlockerFromError(message),
+          blocker: analyticsBlockerFromError(error),
         });
       }
       markClosing();
@@ -187,7 +187,10 @@ export function useVoiceDictation(
         Analytics.getInstance().track(AnalyticsEvent.VoicePermissionResolved, {
           permission: "unavailable",
         });
-        fail("Microphone capture is not available in this environment.");
+        fail(
+          "Microphone capture is not available in this environment.",
+          "Microphone capture is not available in this environment.",
+        );
         return null;
       }
       // Trigger the native OS permission prompt (macOS) before opening the
@@ -200,7 +203,10 @@ export function useVoiceDictation(
           permission: "denied",
         });
         setPermissionDenied(true);
-        fail("Microphone access is blocked for Traycer.");
+        fail(
+          "Microphone access is blocked for Traycer.",
+          "Microphone access is blocked for Traycer.",
+        );
         return null;
       }
       Analytics.getInstance().track(AnalyticsEvent.VoicePermissionResolved, {
@@ -251,6 +257,7 @@ export function useVoiceDictation(
             : `Could not access the microphone: ${
                 error instanceof Error ? error.message : String(error)
               }`,
+          error,
         );
         return null;
       }
@@ -282,6 +289,7 @@ export function useVoiceDictation(
       }
       if (ctx.state !== "running") {
         fail(
+          "Could not start audio capture (the audio context did not start).",
           "Could not start audio capture (the audio context did not start).",
         );
         return;
@@ -317,7 +325,10 @@ export function useVoiceDictation(
   const start = useCallback(() => {
     if (state === "recording" || state === "requesting") return;
     if (wsStreamClient === null) {
-      fail("Not connected to the local host.");
+      fail(
+        "Not connected to the local host.",
+        "Not connected to the local host.",
+      );
       return;
     }
     // Cancel any fallback timer left armed by a previous stop() so it can't
@@ -360,6 +371,7 @@ export function useVoiceDictation(
           `Could not start audio capture: ${
             error instanceof Error ? error.message : String(error)
           }`,
+          error,
         );
         return;
       }
@@ -411,7 +423,7 @@ export function useVoiceDictation(
           finalize();
         },
         onError: (frame) => {
-          fail(frame.message);
+          fail(frame.message, frame);
         },
         onConnectionStatus: (status) => {
           if (status !== "closed") return;
@@ -424,7 +436,10 @@ export function useVoiceDictation(
           // Unexpected drop mid-recording: surface it and stop capturing,
           // otherwise the audio graph keeps buffering with nowhere to send.
           markClosing();
-          fail("Lost connection to the local host.");
+          fail(
+            "Lost connection to the local host.",
+            "Lost connection to the local host.",
+          );
         },
       },
     });

--- a/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
+++ b/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
@@ -209,9 +209,6 @@ export function useVoiceDictation(
         );
         return null;
       }
-      Analytics.getInstance().track(AnalyticsEvent.VoicePermissionResolved, {
-        permission: "granted",
-      });
       try {
         const stream = await navigator.mediaDevices.getUserMedia({
           // Use the browser's built-in audio processing (noise suppression /
@@ -231,6 +228,9 @@ export function useVoiceDictation(
           for (const track of stream.getTracks()) track.stop();
           return null;
         }
+        Analytics.getInstance().track(AnalyticsEvent.VoicePermissionResolved, {
+          permission: "granted",
+        });
         return stream;
       } catch (error) {
         const denied =
@@ -408,6 +408,11 @@ export function useVoiceDictation(
           }
         },
         onFlushed: () => {
+          // A later attempt (auto-restart, or a stop/start racing this flush)
+          // already superseded this session - ignore its stale resolution,
+          // matching onTranscript's guard. Otherwise this would finalize()
+          // the ACTIVE session out from under it.
+          if (speechClientRef.current !== client) return;
           // Same gate as the stopped event: a flush of a session that never
           // reached "recording" transcribed nothing worth counting.
           if (recordingStartedAtRef.current !== null) {

--- a/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
+++ b/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
@@ -8,6 +8,11 @@ import { SpeechStreamClient } from "@traycer-clients/shared/host-transport/speec
 import { useWsStreamClient } from "@/lib/host/stream-runtime-context";
 import { appLogger, describeLogError } from "@/lib/logger";
 import { useRunnerHost } from "@/providers/use-runner-host";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 
 export type VoiceDictationState =
   "idle" | "requesting" | "recording" | "transcribing" | "error";
@@ -46,6 +51,15 @@ const PROCESSOR_BUFFER_SIZE = 2048;
 // arrives (e.g., an unusually long decode) so the UI never hangs in
 // "transcribing".
 const FINALIZE_FALLBACK_MS = 15000;
+
+function dictationDurationBucket(
+  startedAtMs: number | null,
+): "under_10s" | "10_to_30s" | "over_30s" {
+  const elapsed = startedAtMs === null ? 0 : Date.now() - startedAtMs;
+  if (elapsed < 10_000) return "under_10s";
+  if (elapsed <= 30_000) return "10_to_30s";
+  return "over_30s";
+}
 
 /**
  * Drives on-device dictation: captures the mic as PCM16 mono, streams it to the
@@ -90,6 +104,8 @@ export function useVoiceDictation(
   // value at launch and bails if it changed, so a stop/cancel during the
   // permission prompt can't re-arm a now-abandoned session.
   const startGenerationRef = useRef(0);
+  // When the live recording actually began (onReady), for duration buckets.
+  const recordingStartedAtRef = useRef<number | null>(null);
 
   const markClosing = useCallback(() => {
     closingRef.current = true;
@@ -130,6 +146,16 @@ export function useVoiceDictation(
 
   const fail = useCallback(
     (message: string) => {
+      if (stateRef.current === "transcribing") {
+        Analytics.getInstance().track(AnalyticsEvent.VoiceTranscriptionFailed, {
+          blocker: analyticsBlockerFromError(message),
+        });
+      } else {
+        Analytics.getInstance().track(AnalyticsEvent.VoiceCaptureFailed, {
+          source: "direct_ui",
+          blocker: analyticsBlockerFromError(message),
+        });
+      }
       markClosing();
       teardownAll();
       setState("error");
@@ -158,6 +184,9 @@ export function useVoiceDictation(
     async (generation: number): Promise<MediaStream | null> => {
       if (generation !== startGenerationRef.current) return null;
       if (typeof navigator === "undefined") {
+        Analytics.getInstance().track(AnalyticsEvent.VoicePermissionResolved, {
+          permission: "unavailable",
+        });
         fail("Microphone capture is not available in this environment.");
         return null;
       }
@@ -167,10 +196,16 @@ export function useVoiceDictation(
       const access = await runnerHost.requestMicrophoneAccess();
       if (generation !== startGenerationRef.current) return null;
       if (access === "denied") {
+        Analytics.getInstance().track(AnalyticsEvent.VoicePermissionResolved, {
+          permission: "denied",
+        });
         setPermissionDenied(true);
         fail("Microphone access is blocked for Traycer.");
         return null;
       }
+      Analytics.getInstance().track(AnalyticsEvent.VoicePermissionResolved, {
+        permission: "granted",
+      });
       try {
         const stream = await navigator.mediaDevices.getUserMedia({
           // Use the browser's built-in audio processing (noise suppression /
@@ -201,7 +236,15 @@ export function useVoiceDictation(
             error: describeLogError(error),
           },
         );
-        if (denied) setPermissionDenied(true);
+        if (denied) {
+          // The OS said yes but the browser-level prompt was refused - still a
+          // user-visible permission denial for the funnel.
+          Analytics.getInstance().track(
+            AnalyticsEvent.VoicePermissionResolved,
+            { permission: "denied" },
+          );
+          setPermissionDenied(true);
+        }
         fail(
           denied
             ? "Microphone access is blocked for Traycer."
@@ -287,6 +330,9 @@ export function useVoiceDictation(
     setPermissionDenied(false);
     setState("requesting");
     readyRef.current = false;
+    // Cleared at start so a stop during "requesting" can't report a stopped
+    // event stamped with the PREVIOUS recording's start time.
+    recordingStartedAtRef.current = null;
     pendingChunksRef.current = [];
     closingRef.current = false;
     const generation = startGenerationRef.current + 1;
@@ -331,6 +377,10 @@ export function useVoiceDictation(
           // UI back to "recording" with no live capture.
           if (closingRef.current || speechClientRef.current !== client) return;
           readyRef.current = true;
+          recordingStartedAtRef.current = Date.now();
+          Analytics.getInstance().track(AnalyticsEvent.VoiceDictationStarted, {
+            source: "direct_ui",
+          });
           setState("recording");
           const pending = pendingChunksRef.current;
           pendingChunksRef.current = [];
@@ -346,6 +396,18 @@ export function useVoiceDictation(
           }
         },
         onFlushed: () => {
+          // Same gate as the stopped event: a flush of a session that never
+          // reached "recording" transcribed nothing worth counting.
+          if (recordingStartedAtRef.current !== null) {
+            Analytics.getInstance().track(
+              AnalyticsEvent.VoiceTranscriptionSucceeded,
+              {
+                duration_bucket: dictationDurationBucket(
+                  recordingStartedAtRef.current,
+                ),
+              },
+            );
+          }
           finalize();
         },
         onError: (frame) => {
@@ -379,6 +441,13 @@ export function useVoiceDictation(
     // Invalidate any startAudioGraph still waiting on the permission prompt so
     // it can't re-arm capture into this now-flushing session.
     startGenerationRef.current += 1;
+    // Only a session that actually reached "recording" reports a stop - a
+    // stop while still requesting has no matching started event.
+    if (recordingStartedAtRef.current !== null) {
+      Analytics.getInstance().track(AnalyticsEvent.VoiceDictationStopped, {
+        duration_bucket: dictationDurationBucket(recordingStartedAtRef.current),
+      });
+    }
     markClosing();
     // Stop capturing immediately and ask the host to transcribe the buffered
     // utterance. Stay connected until it replies `flushed` (→ `finalize`); the
@@ -409,6 +478,12 @@ export function useVoiceDictation(
   // Abort: tear down without flushing so the in-progress utterance is dropped.
   const cancel = useCallback(() => {
     startGenerationRef.current += 1;
+    if (stateRef.current === "recording" || stateRef.current === "requesting") {
+      Analytics.getInstance().track(
+        AnalyticsEvent.VoiceDictationCancelled,
+        null,
+      );
+    }
     markClosing();
     teardownAll();
     setState("idle");

--- a/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
+++ b/clients/gui-app/src/hooks/composer/use-voice-dictation.ts
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SPEECH_INPUT_SAMPLE_RATE } from "@traycer/protocol/host/speech/schemas";
 import { SpeechStreamClient } from "@traycer-clients/shared/host-transport/speech-stream-client";
+import type { MicrophoneAccessStatus } from "@traycer-clients/shared/platform/runner-host";
 import { useWsStreamClient } from "@/lib/host/stream-runtime-context";
 import { appLogger, describeLogError } from "@/lib/logger";
 import { useRunnerHost } from "@/providers/use-runner-host";
@@ -196,7 +197,19 @@ export function useVoiceDictation(
       // Trigger the native OS permission prompt (macOS) before opening the
       // stream. Returns the existing decision when already set; a denied app is
       // never re-prompted, so route those to the "Open Settings" affordance.
-      const access = await runnerHost.requestMicrophoneAccess();
+      let access: MicrophoneAccessStatus;
+      try {
+        access = await runnerHost.requestMicrophoneAccess();
+      } catch (error) {
+        if (generation !== startGenerationRef.current) return null;
+        fail(
+          `Could not request microphone access: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          error,
+        );
+        return null;
+      }
       if (generation !== startGenerationRef.current) return null;
       if (access === "denied") {
         Analytics.getInstance().track(AnalyticsEvent.VoicePermissionResolved, {
@@ -233,6 +246,10 @@ export function useVoiceDictation(
         });
         return stream;
       } catch (error) {
+        // The session may have been stopped/cancelled while getUserMedia was
+        // pending - a late rejection must not resurrect it into "error" or
+        // emit analytics for an attempt the user already abandoned.
+        if (generation !== startGenerationRef.current) return null;
         const denied =
           error instanceof Error && error.name === "NotAllowedError";
         appLogger.warn(
@@ -428,9 +445,11 @@ export function useVoiceDictation(
           finalize();
         },
         onError: (frame) => {
+          if (speechClientRef.current !== client) return;
           fail(frame.message, frame);
         },
         onConnectionStatus: (status) => {
+          if (speechClientRef.current !== client) return;
           if (status !== "closed") return;
           if (closingRef.current) {
             // Expected close (we flushed / tore down). Settle the UI if it's

--- a/clients/gui-app/src/hooks/editor/__tests__/use-editor-open-mutation.test.ts
+++ b/clients/gui-app/src/hooks/editor/__tests__/use-editor-open-mutation.test.ts
@@ -18,6 +18,7 @@ let capturedArgs: {
   options: {
     mutationKey?: ReadonlyArray<unknown>;
     onError?: (e: unknown) => void;
+    onSuccess?: (response: unknown, variables: { editorId: string }) => void;
   };
 } | null = null;
 vi.mock("@/hooks/host/use-host-query", () => ({
@@ -33,6 +34,7 @@ import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messen
 import type { RpcErrorCode } from "@traycer/protocol/framework/index";
 import { useEditorOpen } from "@/hooks/editor/use-editor-open-mutation";
 import { editorMutationKeys } from "@/lib/query-keys";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 function makeError(code: RpcErrorCode, message: string): HostRpcError {
   return new HostRpcError({
@@ -46,7 +48,7 @@ function makeError(code: RpcErrorCode, message: string): HostRpcError {
 
 describe("useEditorOpen", () => {
   it("targets editor.openPaths with the host client and the editor mutation key", () => {
-    renderHook(() => useEditorOpen());
+    renderHook(() => useEditorOpen("workspace"));
     expect(capturedArgs).not.toBeNull();
     expect(capturedArgs?.method).toBe("editor.openPaths");
     expect(capturedArgs?.client).toBe(fakeClient);
@@ -56,7 +58,7 @@ describe("useEditorOpen", () => {
   });
 
   it("passes the host error message through as the toast for generic RPC errors", () => {
-    renderHook(() => useEditorOpen());
+    renderHook(() => useEditorOpen("workspace"));
     capturedArgs?.options.onError?.(
       makeError("RPC_ERROR", "Windsurf isn't installed on this machine."),
     );
@@ -66,10 +68,28 @@ describe("useEditorOpen", () => {
   });
 
   it("uses the FORBIDDEN copy for permission errors", () => {
-    renderHook(() => useEditorOpen());
+    renderHook(() => useEditorOpen("workspace"));
     capturedArgs?.options.onError?.(makeError("FORBIDDEN", "denied"));
     expect(toast.error).toHaveBeenCalledWith(
       "You don't have permission to do that.",
     );
+  });
+
+  it("emits workspace_opened_in_editor only for the workspace intent", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    try {
+      renderHook(() => useEditorOpen("file"));
+      capturedArgs?.options.onSuccess?.({}, { editorId: "vscode" });
+      expect(track).not.toHaveBeenCalled();
+
+      renderHook(() => useEditorOpen("workspace"));
+      capturedArgs?.options.onSuccess?.({}, { editorId: "vscode" });
+      expect(track).toHaveBeenCalledWith(
+        AnalyticsEvent.WorkspaceOpenedInEditor,
+        { source: "direct_ui", editor: "vscode" },
+      );
+    } finally {
+      track.mockRestore();
+    }
   });
 });

--- a/clients/gui-app/src/hooks/editor/use-editor-open-mutation.ts
+++ b/clients/gui-app/src/hooks/editor/use-editor-open-mutation.ts
@@ -8,8 +8,17 @@ import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { editorMutationKeys } from "@/lib/query-keys";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
-export function useEditorOpen(): UseMutationResult<
+/**
+ * `intent` is the caller's declared gesture: only opening a workspace ROOT
+ * counts toward `workspace_opened_in_editor` - single-file opens (e.g. a
+ * changed file from a diff tile) would overstate editor workspace adoption
+ * and deliberately emit nothing here.
+ */
+export function useEditorOpen(
+  intent: "file" | "workspace",
+): UseMutationResult<
   ResponseOfMethod<HostRpcRegistry, "editor.openPaths">,
   HostRpcError,
   RequestOfMethod<HostRpcRegistry, "editor.openPaths">
@@ -21,6 +30,13 @@ export function useEditorOpen(): UseMutationResult<
     mapVariables: (variables) => variables,
     options: {
       mutationKey: editorMutationKeys.openPaths(),
+      onSuccess: (_response, variables) => {
+        if (intent !== "workspace") return;
+        Analytics.getInstance().track(AnalyticsEvent.WorkspaceOpenedInEditor, {
+          source: "direct_ui",
+          editor: variables.editorId,
+        });
+      },
       onError: (error) => {
         toastFromHostError(error, error.message);
       },

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx
@@ -12,6 +12,7 @@ import {
   type ListCloudTasksRequest,
 } from "@/lib/cloud-epic-tasks-query";
 import { useEpicCreate } from "@/hooks/epic/use-epic-create-mutation";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface TaskWorkspaceInput {
   readonly hostId: string;
@@ -33,10 +34,16 @@ interface CreateEpicMutationContext {
 }
 
 interface CapturedCreateOptions {
-  readonly onMutate: () => CreateEpicMutationContext;
+  readonly onMutate: (variables: {
+    readonly chat: null;
+    readonly workspaces: readonly unknown[];
+  }) => CreateEpicMutationContext;
   readonly onSuccess: (
     response: { readonly task: TaskLight | null | undefined },
-    variables: Record<string, never>,
+    variables: {
+      readonly chat: null;
+      readonly workspaces: readonly unknown[];
+    },
     ctx: CreateEpicMutationContext,
   ) => void;
 }
@@ -190,7 +197,26 @@ describe("useEpicCreate", () => {
     const options = testState.capturedOptions;
     if (options === null) throw new Error("expected mutation options");
 
-    options.onSuccess({ task: createdTask }, {}, options.onMutate());
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    track.mockClear();
+    const stagedVariables = { chat: null, workspaces: [] };
+    options.onSuccess(
+      { task: createdTask },
+      stagedVariables,
+      options.onMutate(stagedVariables),
+    );
+
+    // The started/created pair must agree on the mode derived from the SAME
+    // variables - a mismatch would corrupt the task-creation funnel.
+    expect(track).toHaveBeenCalledWith(AnalyticsEvent.TaskCreationStarted, {
+      source: "direct_ui",
+      mode: "terminal_agent",
+      workspace_count: 0,
+    });
+    expect(track).toHaveBeenCalledWith(AnalyticsEvent.TaskCreated, {
+      mode: "terminal_agent",
+    });
+    track.mockRestore();
 
     expect(
       taskIds(
@@ -322,7 +348,12 @@ describe("useEpicCreate", () => {
     const options = testState.capturedOptions;
     if (options === null) throw new Error("expected mutation options");
 
-    options.onSuccess({ task: createdTask }, {}, options.onMutate());
+    const stagedVariables = { chat: null, workspaces: [] };
+    options.onSuccess(
+      { task: createdTask },
+      stagedVariables,
+      options.onMutate(stagedVariables),
+    );
 
     const defaultResponse = queryClient.getQueryData<ListTasksResponse>(
       cloudEpicTasksQueryKey("host-1", "user-1", defaultRequest),
@@ -395,10 +426,11 @@ describe("useEpicCreate", () => {
     const options = testState.capturedOptions;
     if (options === null) throw new Error("expected mutation options");
 
+    const stagedVariables = { chat: null, workspaces: [] };
     options.onSuccess(
       { task: staleCreateResponseTask },
-      {},
-      options.onMutate(),
+      stagedVariables,
+      options.onMutate(stagedVariables),
     );
 
     expect(

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-create-mutation.test.tsx
@@ -282,7 +282,12 @@ describe("useEpicCreate", () => {
     const options = testState.capturedOptions;
     if (options === null) throw new Error("expected mutation options");
 
-    options.onSuccess({ task: createdTask }, {}, options.onMutate());
+    const stagedVariables = { chat: null, workspaces: [] };
+    options.onSuccess(
+      { task: createdTask },
+      stagedVariables,
+      options.onMutate(stagedVariables),
+    );
 
     expect(taskIds(queryClient.getQueryData(queryKey))).toEqual([
       "pinned",

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-node-mutations.test.ts
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-node-mutations.test.ts
@@ -26,6 +26,7 @@ import {
 } from "@/hooks/epic/use-epic-node-mutations";
 import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { RpcErrorCode } from "@traycer/protocol/framework/index";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 function makeError(code: RpcErrorCode): HostRpcError {
   return new HostRpcError({
@@ -89,5 +90,27 @@ describe("useEpicRenameArtifact", () => {
     };
     opts.onError(makeError("RPC_ERROR"));
     expect(toast.error).toHaveBeenCalledWith("Couldn't rename artifact.");
+  });
+
+  it("tracks ArtifactRenamed on success when trackUserIntent is true", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    track.mockClear();
+    renderHook(() => useEpicRenameArtifact(true));
+    const opts = capturedOptions["epic.renameArtifact"] as {
+      onSuccess: () => void;
+    };
+    opts.onSuccess();
+    expect(track).toHaveBeenCalledWith(AnalyticsEvent.ArtifactRenamed, null);
+  });
+
+  it("does not track on success when trackUserIntent is false", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    track.mockClear();
+    renderHook(() => useEpicRenameArtifact(false));
+    const opts = capturedOptions["epic.renameArtifact"] as {
+      onSuccess: () => void;
+    };
+    opts.onSuccess();
+    expect(track).not.toHaveBeenCalled();
   });
 });

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-node-mutations.test.ts
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-node-mutations.test.ts
@@ -83,7 +83,7 @@ describe("useEpicUpdateArtifactStatus", () => {
 
 describe("useEpicRenameArtifact", () => {
   it("shows fallback on error", () => {
-    renderHook(() => useEpicRenameArtifact());
+    renderHook(() => useEpicRenameArtifact(true));
     const opts = capturedOptions["epic.renameArtifact"] as {
       onError: (e: HostRpcError) => void;
     };

--- a/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
@@ -37,6 +37,7 @@ import {
   reportableErrorToast,
   reportableWarningToast,
 } from "@/lib/reportable-error-toast";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface BatchDeleteEpicMutationContext {
   readonly hostId: string | null;
@@ -113,6 +114,13 @@ export function useEpicBatchDelete(): UseMutationResult<
           result.success ? [result.taskId] : [],
         );
         const successes = data.results.length - failures.length;
+        if (variables.ids.length === 1 && successes === 1) {
+          Analytics.getInstance().track(AnalyticsEvent.TaskDeleted, {
+            source: "direct_ui",
+            cleanup_worktrees:
+              (variables.worktreeCleanup?.candidates.length ?? 0) > 0,
+          });
+        }
         const navigationTarget = pickNeighborAfterDeletingEpics(
           getHeaderTabs(),
           activePathname,

--- a/clients/gui-app/src/hooks/epic/use-epic-collaborator-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-collaborator-mutations.ts
@@ -4,6 +4,8 @@ import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient } from "@/lib/host/runtime";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { queryKeys } from "@/lib/query-keys";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import { projectCollaborators } from "@/hooks/epics/use-epic-collaborators-query";
 
 /**
  * Mutation hook for `epic.grantAccess`.
@@ -21,6 +23,19 @@ export function useEpicGrantAccess() {
     mapVariables: (variables) => variables,
     options: {
       onSuccess: (data, variables) => {
+        const collaborators = projectCollaborators(data.collaborators);
+        if (variables.input.kind === "team") {
+          const input = variables.input;
+          const wasGranted = collaborators.teams.some(
+            (team) => team.teamId === input.teamId && team.role === input.role,
+          );
+          if (wasGranted) {
+            Analytics.getInstance().track(AnalyticsEvent.ShareInviteSent, {
+              target: "team",
+              role: input.role,
+            });
+          }
+        }
         const hostId = client.getActiveHostId();
         if (hostId === null) return;
         queryClient.setQueryData(
@@ -54,6 +69,28 @@ export function useEpicBatchUpdateRoles() {
     mapVariables: (variables) => variables,
     options: {
       onSuccess: (data, variables) => {
+        if (variables.input.intent !== "invite") {
+          const collaborators = projectCollaborators(data.collaborators);
+          variables.input.changes.forEach((change) => {
+            const wasChanged =
+              change.teamId !== undefined
+                ? collaborators.teams.some(
+                    (team) =>
+                      team.teamId === change.teamId &&
+                      team.role === change.newRole,
+                  )
+                : collaborators.directUsers.some(
+                    (user) =>
+                      user.userId === change.userId &&
+                      user.role === change.newRole,
+                  );
+            if (!wasChanged) return;
+            Analytics.getInstance().track(AnalyticsEvent.ShareRoleChanged, {
+              target: change.teamId === undefined ? "person" : "team",
+              role: change.newRole,
+            });
+          });
+        }
         const hostId = client.getActiveHostId();
         if (hostId === null) return;
         queryClient.setQueryData(
@@ -87,6 +124,19 @@ export function useEpicRevokeCollaborator() {
     mapVariables: (variables) => variables,
     options: {
       onSuccess: (data, variables) => {
+        const collaborators = projectCollaborators(data.collaborators);
+        const input = variables.input;
+        const wasRevoked =
+          input.kind === "team"
+            ? !collaborators.teams.some((team) => team.teamId === input.teamId)
+            : !collaborators.directUsers.some(
+                (user) => user.userId === input.userId,
+              );
+        if (wasRevoked) {
+          Analytics.getInstance().track(AnalyticsEvent.ShareAccessRevoked, {
+            target: input.kind === "team" ? "team" : "person",
+          });
+        }
         const hostId = client.getActiveHostId();
         if (hostId === null) return;
         queryClient.setQueryData(

--- a/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
@@ -39,6 +39,12 @@ interface CreateEpicMutationContext {
   readonly userId: string | null;
 }
 
+function taskCreationMode(
+  chat: RequestOfMethod<HostRpcRegistry, "epic.create">["chat"],
+): "chat" | "terminal_agent" {
+  return chat === null ? "terminal_agent" : "chat";
+}
+
 export function useEpicCreate(): UseMutationResult<
   ResponseOfMethod<HostRpcRegistry, "epic.create">,
   HostRpcError,
@@ -57,10 +63,9 @@ export function useEpicCreate(): UseMutationResult<
     mapVariables: (variables) => variables,
     options: {
       onMutate: (variables) => {
-        const mode = variables.chat === null ? "terminal_agent" : "chat";
         Analytics.getInstance().track(AnalyticsEvent.TaskCreationStarted, {
           source: "direct_ui",
-          mode,
+          mode: taskCreationMode(variables.chat),
           workspace_count: variables.workspaces.length,
         });
         return {
@@ -70,7 +75,7 @@ export function useEpicCreate(): UseMutationResult<
       },
       onSuccess: (response, variables, ctx) => {
         Analytics.getInstance().track(AnalyticsEvent.TaskCreated, {
-          mode: variables.chat === null ? "terminal_agent" : "chat",
+          mode: taskCreationMode(variables.chat),
         });
         if (ctx.hostId === null) return;
         // The new epic's workspace folders are seeded into the host's
@@ -97,7 +102,7 @@ export function useEpicCreate(): UseMutationResult<
       onError: (error, variables) => {
         Analytics.getInstance().track(AnalyticsEvent.TaskCreationFailed, {
           source: "direct_ui",
-          mode: variables.chat === null ? "terminal_agent" : "chat",
+          mode: taskCreationMode(variables.chat),
           blocker: analyticsBlockerFromError(error),
         });
         toastFromHostError(error, "Couldn't create epic.");

--- a/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-create-mutation.ts
@@ -27,7 +27,11 @@ import { hostQueryKeys } from "@/lib/query-keys";
 import { cloudEpicTasksQueryKeyMatchesScope } from "@/lib/cloud-epic-tasks-query/cache";
 import type { ListCloudTasksRequest } from "@/lib/cloud-epic-tasks-query";
 import { toastFromHostError } from "@/lib/host-error-toast";
-import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+} from "@/lib/analytics";
 import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 
 interface CreateEpicMutationContext {
@@ -52,13 +56,21 @@ export function useEpicCreate(): UseMutationResult<
     method: "epic.create",
     mapVariables: (variables) => variables,
     options: {
-      onMutate: () => ({
-        hostId: client.getActiveHostId(),
-        userId: client.getRequestContextUserId(),
-      }),
+      onMutate: (variables) => {
+        const mode = variables.chat === null ? "terminal_agent" : "chat";
+        Analytics.getInstance().track(AnalyticsEvent.TaskCreationStarted, {
+          source: "direct_ui",
+          mode,
+          workspace_count: variables.workspaces.length,
+        });
+        return {
+          hostId: client.getActiveHostId(),
+          userId: client.getRequestContextUserId(),
+        };
+      },
       onSuccess: (response, variables, ctx) => {
         Analytics.getInstance().track(AnalyticsEvent.TaskCreated, {
-          mode: variables.chat?.initialMessage?.settings.agentMode ?? "regular",
+          mode: variables.chat === null ? "terminal_agent" : "chat",
         });
         if (ctx.hostId === null) return;
         // The new epic's workspace folders are seeded into the host's
@@ -82,7 +94,14 @@ export function useEpicCreate(): UseMutationResult<
         if (task === null || task === undefined) return;
         patchCreatedTaskIntoCloudTaskCaches(queryClient, ctx, task);
       },
-      onError: (error) => toastFromHostError(error, "Couldn't create epic."),
+      onError: (error, variables) => {
+        Analytics.getInstance().track(AnalyticsEvent.TaskCreationFailed, {
+          source: "direct_ui",
+          mode: variables.chat === null ? "terminal_agent" : "chat",
+          blocker: analyticsBlockerFromError(error),
+        });
+        toastFromHostError(error, "Couldn't create epic.");
+      },
     },
   });
 }

--- a/clients/gui-app/src/hooks/epic/use-epic-export-artifacts-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-export-artifacts-mutation.ts
@@ -9,6 +9,7 @@ import { appLogger } from "@/lib/logger";
 import { epicMutationKeys } from "@/lib/query-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface ArtifactExportSelection {
   readonly id: string;
@@ -48,8 +49,14 @@ export function useEpicExportArtifacts() {
       });
       return saveBlobToDisk(output.blob, output.suggestedName);
     },
-    onSuccess: (saved) => {
-      if (saved !== null) toast.success(`Saved ${saved}`);
+    onSuccess: (saved, input) => {
+      if (saved !== null) {
+        Analytics.getInstance().track(AnalyticsEvent.ArtifactExported, {
+          format: input.format,
+          artifact_count: input.artifacts.length,
+        });
+        toast.success(`Saved ${saved}`);
+      }
     },
     onError: (error, input) => {
       appLogger.errorSummary(

--- a/clients/gui-app/src/hooks/epic/use-epic-node-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-node-mutations.ts
@@ -64,7 +64,7 @@ export function useEpicUpdateArtifactStatus() {
       onSuccess: (_data, variables) => {
         Analytics.getInstance().track(AnalyticsEvent.ArtifactStatusChanged, {
           kind: variables.artifactType,
-          status: variables.status,
+          status: analyticsTicketStatus(variables.status),
         });
       },
       onError: (error) => {
@@ -72,6 +72,12 @@ export function useEpicUpdateArtifactStatus() {
       },
     },
   });
+}
+
+function analyticsTicketStatus(status: number): 0 | 1 | 2 {
+  if (status === 1) return 1;
+  if (status === 2) return 2;
+  return 0;
 }
 
 /**

--- a/clients/gui-app/src/hooks/epic/use-epic-node-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-node-mutations.ts
@@ -1,6 +1,7 @@
 import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient } from "@/lib/host/runtime";
 import { toastFromHostError } from "@/lib/host-error-toast";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /**
  * Mutation hook for epic.createArtifact.
@@ -14,6 +15,11 @@ export function useEpicCreateArtifact() {
     method: "epic.createArtifact",
     mapVariables: (variables) => variables,
     options: {
+      onSuccess: (_data, variables) => {
+        Analytics.getInstance().track(AnalyticsEvent.ArtifactCreated, {
+          kind: variables.artifactType,
+        });
+      },
       onError: (error) => {
         toastFromHostError(error, "Couldn't create artifact.");
       },
@@ -33,6 +39,9 @@ export function useEpicDeleteArtifact() {
     method: "epic.deleteArtifact",
     mapVariables: (variables) => variables,
     options: {
+      onSuccess: () => {
+        Analytics.getInstance().track(AnalyticsEvent.ArtifactDeleted, null);
+      },
       onError: (error) => {
         toastFromHostError(error, "Couldn't delete artifact.");
       },
@@ -52,6 +61,12 @@ export function useEpicUpdateArtifactStatus() {
     method: "epic.updateArtifactStatus",
     mapVariables: (variables) => variables,
     options: {
+      onSuccess: (_data, variables) => {
+        Analytics.getInstance().track(AnalyticsEvent.ArtifactStatusChanged, {
+          kind: variables.artifactType,
+          status: variables.status,
+        });
+      },
       onError: (error) => {
         toastFromHostError(error, "Couldn't update status.");
       },
@@ -63,13 +78,18 @@ export function useEpicUpdateArtifactStatus() {
  * Mutation hook for epic.renameArtifact.
  * Input/title enters pending (read-only) state; success is silent.
  */
-export function useEpicRenameArtifact() {
+export function useEpicRenameArtifact(trackUserIntent: boolean) {
   const client = useHostClient();
   return useHostMutation({
     client,
     method: "epic.renameArtifact",
     mapVariables: (variables) => variables,
     options: {
+      onSuccess: () => {
+        if (trackUserIntent) {
+          Analytics.getInstance().track(AnalyticsEvent.ArtifactRenamed, null);
+        }
+      },
       onError: (error) => {
         toastFromHostError(error, "Couldn't rename artifact.");
       },

--- a/clients/gui-app/src/hooks/epic/use-epic-send-queued-invites-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-send-queued-invites-mutation.ts
@@ -16,6 +16,7 @@ import {
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import { appLogger } from "@/lib/logger";
 import { hostQueryKeys, epicMutationKeys } from "@/lib/query-keys";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface SendQueuedInvitesArgs {
   readonly epicId: string;
@@ -171,7 +172,19 @@ export function useEpicSendQueuedInvites(): UseMutationResult<
         failedInvites,
       };
     },
-    onSuccess: (_result, _variables, ctx) => {
+    onSuccess: (result, _variables, ctx) => {
+      result.succeededNewInvites.forEach((invite) => {
+        Analytics.getInstance().track(AnalyticsEvent.ShareInviteSent, {
+          target: "person",
+          role: invite.role,
+        });
+      });
+      result.succeededReInvites.forEach((invite) => {
+        Analytics.getInstance().track(AnalyticsEvent.ShareRoleChanged, {
+          target: "person",
+          role: invite.role,
+        });
+      });
       if (ctx.hostId === null) return;
       void queryClient.invalidateQueries({
         queryKey: hostQueryKeys.methodScope<keyof HostRpcRegistry & string>(

--- a/clients/gui-app/src/hooks/epic/use-epic-title-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-title-mutation.ts
@@ -4,6 +4,7 @@ import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient } from "@/lib/host";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { updateEpicTitleInCloudTaskCaches } from "@/lib/cloud-epic-tasks-query/cache";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface UpdateTitleMutationContext {
   readonly hostId: string | null;
@@ -28,6 +29,9 @@ export function useEpicUpdateTitle() {
         userId: client.getRequestContextUserId(),
       }),
       onSuccess: (_response, variables, ctx: UpdateTitleMutationContext) => {
+        Analytics.getInstance().track(AnalyticsEvent.TaskRenamed, {
+          source: "direct_ui",
+        });
         const delta = variables.epicDelta;
         if (
           ctx.userId !== null &&

--- a/clients/gui-app/src/hooks/epic/use-epic-tui-agent-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-tui-agent-mutations.ts
@@ -3,6 +3,7 @@ import type { HostRpcRegistry } from "@/lib/host";
 import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient } from "@/lib/host/runtime";
 import { toastFromHostError } from "@/lib/host-error-toast";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /**
  * Mutation hook for `epic.createTerminalAgent`.
@@ -33,6 +34,12 @@ export function useEpicCreateTuiAgentForClient(
     method: "epic.createTuiAgent",
     mapVariables: (variables) => variables,
     options: {
+      onSuccess: (_data, variables) => {
+        Analytics.getInstance().track(AnalyticsEvent.TerminalAgentLaunched, {
+          source: "direct_ui",
+          harness: variables.harnessId,
+        });
+      },
       onError: (error) => {
         toastFromHostError(error, "Couldn't create terminal agent.");
       },
@@ -55,6 +62,11 @@ export function useEpicDeleteTuiAgent() {
     method: "epic.deleteTuiAgent",
     mapVariables: (variables) => variables,
     options: {
+      onSuccess: () => {
+        Analytics.getInstance().track(AnalyticsEvent.TerminalAgentStopped, {
+          source: "direct_ui",
+        });
+      },
       onError: (error) => {
         toastFromHostError(error, "Couldn't delete terminal agent.");
       },
@@ -73,6 +85,11 @@ export function useEpicRenameTuiAgent() {
     method: "epic.renameTuiAgent",
     mapVariables: (variables) => variables,
     options: {
+      onSuccess: () => {
+        Analytics.getInstance().track(AnalyticsEvent.TerminalRenamed, {
+          kind: "agent",
+        });
+      },
       onError: (error) => {
         toastFromHostError(error, "Couldn't rename terminal agent.");
       },

--- a/clients/gui-app/src/hooks/host/use-host-scoped-mutation.ts
+++ b/clients/gui-app/src/hooks/host/use-host-scoped-mutation.ts
@@ -9,6 +9,11 @@ import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import { useHostMutation } from "@/hooks/host/use-host-query";
 import { hostQueryKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
+import {
+  Analytics,
+  AnalyticsEvent,
+  type AnalyticsProviderOperation,
+} from "@/lib/analytics";
 
 interface HostScopedMutationContext {
   readonly hostId: string | null;
@@ -67,7 +72,8 @@ export function useHostScopedMutationForClient<
     options: {
       mutationKey: args.mutationKey,
       onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
-      onSuccess: (_data, _variables, ctx) => {
+      onSuccess: (_data, variables, ctx) => {
+        trackScopedMutationSuccess(args.mutationKey, variables);
         if (ctx.hostId === null) return;
         for (const method of args.invalidateMethods) {
           void queryClient.invalidateQueries({
@@ -75,7 +81,67 @@ export function useHostScopedMutationForClient<
           });
         }
       },
-      onError: (error) => toastFromHostError(error, args.errorMessage),
+      onError: (error) => {
+        toastFromHostError(error, args.errorMessage);
+      },
     },
   });
+}
+
+const PROVIDER_MUTATION_OPERATIONS: Readonly<
+  Record<string, AnalyticsProviderOperation | undefined>
+> = {
+  "providers.setSelection": "selection",
+  "providers.addCustomPath": "custom_path",
+  "providers.removeCustomPath": "custom_path",
+  "providers.setEnabled": "enabled",
+  "providers.setApiKey": "api_key",
+  "providers.clearApiKey": "api_key",
+  "providers.setTerminalAgentArgs": "terminal_args",
+  "providers.setEnvOverride": "env_override",
+  "providers.deleteEnvOverride": "env_override",
+  "providers.renameProfile": "profile",
+  "providers.recolorProfile": "profile",
+  "providers.removeProfile": "profile",
+  "providers.acknowledgeAmbientDrift": "ambient_drift",
+};
+
+function trackScopedMutationSuccess(
+  mutationKey: ReadonlyArray<unknown>,
+  variables: unknown,
+): void {
+  const action = mutationKey[0];
+  if (typeof action !== "string") return;
+  const providerOperation = PROVIDER_MUTATION_OPERATIONS[action];
+  if (providerOperation !== undefined) {
+    Analytics.getInstance().track(AnalyticsEvent.ProviderConfigurationChanged, {
+      operation: providerOperation,
+    });
+    return;
+  }
+  if (action === "workspaceBinding.addFolder") {
+    Analytics.getInstance().track(AnalyticsEvent.WorkspaceFolderAdded, {
+      source: "direct_ui",
+      workspace_kind: "local",
+    });
+    return;
+  }
+  if (action === "workspaceBinding.removeEntry") {
+    Analytics.getInstance().track(AnalyticsEvent.WorkspaceFolderRemoved, {
+      source: "direct_ui",
+      workspace_kind: "unknown",
+    });
+    return;
+  }
+  if (action === "agent.stop") {
+    const cascade =
+      variables !== null &&
+      typeof variables === "object" &&
+      "cascade" in variables &&
+      variables.cascade === true;
+    Analytics.getInstance().track(AnalyticsEvent.AgentStopped, {
+      source: "direct_ui",
+      cascade,
+    });
+  }
 }

--- a/clients/gui-app/src/hooks/host/use-host-scoped-mutation.ts
+++ b/clients/gui-app/src/hooks/host/use-host-scoped-mutation.ts
@@ -7,7 +7,12 @@ import type {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import { useHostMutation } from "@/hooks/host/use-host-query";
-import { hostQueryKeys } from "@/lib/query-keys";
+import {
+  agentMutationKeys,
+  hostQueryKeys,
+  providersMutationKeys,
+  workspaceMutationKeys,
+} from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import {
   Analytics,
@@ -91,19 +96,19 @@ export function useHostScopedMutationForClient<
 const PROVIDER_MUTATION_OPERATIONS: Readonly<
   Record<string, AnalyticsProviderOperation | undefined>
 > = {
-  "providers.setSelection": "selection",
-  "providers.addCustomPath": "custom_path",
-  "providers.removeCustomPath": "custom_path",
-  "providers.setEnabled": "enabled",
-  "providers.setApiKey": "api_key",
-  "providers.clearApiKey": "api_key",
-  "providers.setTerminalAgentArgs": "terminal_args",
-  "providers.setEnvOverride": "env_override",
-  "providers.deleteEnvOverride": "env_override",
-  "providers.renameProfile": "profile",
-  "providers.recolorProfile": "profile",
-  "providers.removeProfile": "profile",
-  "providers.acknowledgeAmbientDrift": "ambient_drift",
+  [providersMutationKeys.setSelection()[0]]: "selection",
+  [providersMutationKeys.addCustomPath()[0]]: "custom_path",
+  [providersMutationKeys.removeCustomPath()[0]]: "custom_path",
+  [providersMutationKeys.setEnabled()[0]]: "enabled",
+  [providersMutationKeys.setApiKey()[0]]: "api_key",
+  [providersMutationKeys.clearApiKey()[0]]: "api_key",
+  [providersMutationKeys.setTerminalAgentArgs()[0]]: "terminal_args",
+  [providersMutationKeys.setEnvOverride()[0]]: "env_override",
+  [providersMutationKeys.deleteEnvOverride()[0]]: "env_override",
+  [providersMutationKeys.renameProfile()[0]]: "profile",
+  [providersMutationKeys.recolorProfile()[0]]: "profile",
+  [providersMutationKeys.removeProfile()[0]]: "profile",
+  [providersMutationKeys.acknowledgeAmbientDrift()[0]]: "ambient_drift",
 };
 
 function trackScopedMutationSuccess(
@@ -119,21 +124,21 @@ function trackScopedMutationSuccess(
     });
     return;
   }
-  if (action === "workspaceBinding.addFolder") {
+  if (action === workspaceMutationKeys.addBindingFolder()[0]) {
     Analytics.getInstance().track(AnalyticsEvent.WorkspaceFolderAdded, {
       source: "direct_ui",
       workspace_kind: "local",
     });
     return;
   }
-  if (action === "workspaceBinding.removeEntry") {
+  if (action === workspaceMutationKeys.removeBindingEntry()[0]) {
     Analytics.getInstance().track(AnalyticsEvent.WorkspaceFolderRemoved, {
       source: "direct_ui",
       workspace_kind: "unknown",
     });
     return;
   }
-  if (action === "agent.stop") {
+  if (action === agentMutationKeys.stop()[0]) {
     const cascade =
       variables !== null &&
       typeof variables === "object" &&

--- a/clients/gui-app/src/hooks/terminal/use-terminal-kill-for-mutation.ts
+++ b/clients/gui-app/src/hooks/terminal/use-terminal-kill-for-mutation.ts
@@ -12,6 +12,7 @@ import type { HostClient } from "@traycer-clients/shared/host-client/host-client
 import type { HostRpcRegistry } from "@/lib/host";
 import { hostQueryKeys, terminalMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface KillTerminalMutationContext {
   readonly hostId: string | null;
@@ -33,6 +34,7 @@ export interface KillTerminalMutationContext {
 export function useTerminalKillFor(
   client: HostClient<HostRpcRegistry> | null,
   errorMessage: string,
+  trackUserIntent: boolean,
 ): UseMutationResult<
   ResponseOfMethod<HostRpcRegistry, "terminal.kill">,
   HostRpcError,
@@ -59,6 +61,11 @@ export function useTerminalKillFor(
       hostId: client === null ? null : client.getActiveHostId(),
     }),
     onSuccess: (_data, _variables, ctx) => {
+      if (trackUserIntent) {
+        Analytics.getInstance().track(AnalyticsEvent.TerminalKilled, {
+          kind: "shell",
+        });
+      }
       if (ctx.hostId === null) return;
       // Only the terminal-session list changed; invalidating the whole host
       // scope would also force-refetch the manual-refresh-only cloud-tasks

--- a/clients/gui-app/src/hooks/terminal/use-terminal-kill-mutation.ts
+++ b/clients/gui-app/src/hooks/terminal/use-terminal-kill-mutation.ts
@@ -21,5 +21,9 @@ export function useTerminalKill(): UseMutationResult<
   RequestOfMethod<HostRpcRegistry, "terminal.kill">,
   KillTerminalMutationContext
 > {
-  return useTerminalKillFor(useHostClient(), "Couldn't close the terminal.");
+  return useTerminalKillFor(
+    useHostClient(),
+    "Couldn't close the terminal.",
+    true,
+  );
 }

--- a/clients/gui-app/src/hooks/terminal/use-terminal-rename-for-mutation.ts
+++ b/clients/gui-app/src/hooks/terminal/use-terminal-rename-for-mutation.ts
@@ -15,6 +15,7 @@ import { useHostMutation } from "@/hooks/host/use-host-query";
 import { hostQueryKeys, terminalMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface RenameTerminalMutationContext {
   readonly hostId: string | null;
@@ -111,6 +112,9 @@ export function useTerminalRenameFor(
             return row !== undefined && row.title !== variables.title;
           });
         if (superseded) return;
+        Analytics.getInstance().track(AnalyticsEvent.TerminalRenamed, {
+          kind: "shell",
+        });
         useEpicCanvasStore
           .getState()
           .updateTerminalNameSnapshots(

--- a/clients/gui-app/src/hooks/worktree/use-worktree-retry-setup-mutation.ts
+++ b/clients/gui-app/src/hooks/worktree/use-worktree-retry-setup-mutation.ts
@@ -13,6 +13,7 @@ import type { HostRpcRegistry } from "@/lib/host";
 import { hostQueryKeys, worktreeMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { WORKTREE_BINDING_INVALIDATIONS } from "@/hooks/worktree/invalidations";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface RetrySetupMutationContext {
   readonly hostId: string | null;
@@ -57,9 +58,12 @@ export function useWorktreeRetrySetupFor(
       }
       return client.request("worktree.retrySetup", variables);
     },
-    onMutate: () => ({
-      hostId: client === null ? null : client.getActiveHostId(),
-    }),
+    onMutate: () => {
+      Analytics.getInstance().track(AnalyticsEvent.SetupScriptsRetryStarted, {
+        source: "direct_ui",
+      });
+      return { hostId: client === null ? null : client.getActiveHostId() };
+    },
     onSuccess: (_data, _variables, ctx) => {
       if (ctx.hostId === null) return;
       for (const method of WORKTREE_BINDING_INVALIDATIONS) {

--- a/clients/gui-app/src/hooks/worktree/use-worktree-set-repo-scripts-mutation.ts
+++ b/clients/gui-app/src/hooks/worktree/use-worktree-set-repo-scripts-mutation.ts
@@ -12,6 +12,7 @@ import type { HostClient } from "@traycer-clients/shared/host-client/host-client
 import type { HostRpcRegistry } from "@/lib/host";
 import { hostQueryKeys, worktreeMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface SetRepoScriptsMutationContext {
   readonly hostId: string | null;
@@ -64,6 +65,13 @@ export function useWorktreeSetRepoScriptsFor(
       hostId: client === null ? null : client.getActiveHostId(),
     }),
     onSuccess: (_data, _variables, mutationContext) => {
+      Analytics.getInstance().track(AnalyticsEvent.SetupScriptsSaved, {
+        script_count: [_variables.setup, _variables.teardown].filter((script) =>
+          Object.values(script).some(
+            (command) => command !== null && command.trim().length > 0,
+          ),
+        ).length,
+      });
       if (mutationContext.hostId === null) return;
       for (const method of SET_REPO_SCRIPTS_INVALIDATIONS) {
         void queryClient.invalidateQueries({

--- a/clients/gui-app/src/lib/__tests__/analytics.test.ts
+++ b/clients/gui-app/src/lib/__tests__/analytics.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { PostHog, type CaptureResult } from "posthog-js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  window.history.replaceState({}, "", "/");
+});
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // MODE === "test" in vitest, so analytics is disabled and posthog never boots.
 describe("analytics", () => {
@@ -11,11 +19,507 @@ describe("analytics", () => {
     const { Analytics, AnalyticsEvent } = await import("@/lib/analytics");
     const analytics = Analytics.getInstance();
 
-    analytics.identify("user-1", null);
-    analytics.track(AnalyticsEvent.TaskCreated, null);
+    analytics.identify("7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1", null);
+    analytics.track(AnalyticsEvent.TaskCreated, { mode: "chat" });
 
     expect(initSpy).not.toHaveBeenCalled();
     expect(identifySpy).not.toHaveBeenCalled();
     expect(captureSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps every automatic PostHog capture surface disabled", async () => {
+    const { POSTHOG_CONFIG } = await import("@/lib/analytics");
+
+    expect(POSTHOG_CONFIG).toMatchObject({
+      autocapture: false,
+      rageclick: false,
+      capture_pageview: false,
+      capture_pageleave: false,
+      capture_heatmaps: false,
+      capture_dead_clicks: false,
+      capture_exceptions: false,
+      capture_performance: false,
+      disable_session_recording: true,
+      disable_surveys: true,
+      disable_surveys_automatic_display: true,
+      disable_product_tours: true,
+      disable_web_experiments: true,
+      advanced_disable_decide: true,
+      advanced_disable_feature_flags: true,
+      save_campaign_params: false,
+      save_referrer: false,
+    });
+    expect(POSTHOG_CONFIG.property_denylist).toEqual(
+      expect.arrayContaining([
+        "$current_url",
+        "$pathname",
+        "$referrer",
+        "$initial_current_url",
+        "$session_entry_url",
+      ]),
+    );
+  });
+
+  it("refuses to identify with a non-UUID user id", async () => {
+    const { Analytics } = await import("@/lib/analytics");
+    const analytics = Analytics.getInstance();
+
+    expect(analytics.identify("alice@example.com", null)).toBe(false);
+    expect(analytics.identify("/Users/alice/secret-repo", null)).toBe(false);
+    expect(
+      analytics.identify("7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1", null),
+    ).toBe(true);
+    analytics.reset();
+  });
+
+  it("strips identifiers, paths, content, queries, and raw errors at runtime", async () => {
+    const { AnalyticsEvent, sanitizeAnalyticsProperties } =
+      await import("@/lib/analytics");
+
+    expect(
+      sanitizeAnalyticsProperties(AnalyticsEvent.ChatMessageSent, {
+        source: "direct_ui",
+        harness: "codex",
+        mode: "regular",
+        path: "/private/repository",
+        query: "customer secret",
+        prompt: "user content",
+        error: "raw server response",
+        userId: "user-1",
+      }),
+    ).toEqual({ harness: "codex", mode: "regular" });
+  });
+
+  it("rejects an allowed key with a value outside its event taxonomy", async () => {
+    const { AnalyticsEvent, sanitizeAnalyticsProperties } =
+      await import("@/lib/analytics");
+
+    expect(
+      sanitizeAnalyticsProperties(AnalyticsEvent.ChatMessageSent, {
+        harness: "customer-secret",
+        mode: "regular",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects values that belong to another event sharing the same key", async () => {
+    const { AnalyticsEvent, sanitizeAnalyticsProperties } =
+      await import("@/lib/analytics");
+
+    expect(
+      sanitizeAnalyticsProperties(AnalyticsEvent.OnboardingStarted, {
+        mode: "chat",
+      }),
+    ).toBeNull();
+    expect(
+      sanitizeAnalyticsProperties(AnalyticsEvent.ApprovalDecided, {
+        decision: "discard",
+      }),
+    ).toBeNull();
+    expect(
+      sanitizeAnalyticsProperties(AnalyticsEvent.ArtifactCreated, {
+        kind: "shell",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects contradictory outcome/blocker pairs and partial-count arithmetic", async () => {
+    const { AnalyticsEvent, sanitizeAnalyticsProperties } =
+      await import("@/lib/analytics");
+
+    expect(
+      sanitizeAnalyticsProperties(AnalyticsEvent.WorktreeDeleted, {
+        outcome: "succeeded",
+        blocker: "conflict",
+      }),
+    ).toBeNull();
+    expect(
+      sanitizeAnalyticsProperties(AnalyticsEvent.WorktreeDeleted, {
+        outcome: "failed",
+        blocker: null,
+      }),
+    ).toBeNull();
+    expect(
+      sanitizeAnalyticsProperties(AnalyticsEvent.WorktreesBulkDeleted, {
+        requested_count: 3,
+        succeeded_count: 1,
+        failed_count: 1,
+      }),
+    ).toBeNull();
+  });
+
+  it("has a runtime schema for every declared event", async () => {
+    const { analyticsEventContractIsComplete } =
+      await import("@/lib/analytics");
+
+    expect(analyticsEventContractIsComplete()).toBe(true);
+  });
+
+  it("maps typed host RPC codes and error text to bounded blockers", async () => {
+    const { analyticsBlockerFromError } = await import("@/lib/analytics");
+
+    expect(
+      analyticsBlockerFromError({ code: "WORKTREE_BUSY", message: "opaque" }),
+    ).toBe("conflict");
+    expect(
+      analyticsBlockerFromError({ code: "UNAUTHORIZED", message: "opaque" }),
+    ).toBe("authentication");
+    expect(analyticsBlockerFromError(new Error("Request timed out"))).toBe(
+      "timeout",
+    );
+    expect(analyticsBlockerFromError("something inscrutable")).toBe("unknown");
+  });
+
+  it("filters real SDK custom and identify CaptureResults after enrichment", async () => {
+    const { POSTHOG_CONFIG, sanitizePostHogCaptureResult } =
+      await import("@/lib/analytics");
+    const captured: CaptureResult[] = [];
+    window.history.replaceState(
+      {},
+      "",
+      "/epics/epic-secret/tab-secret?focusArtifactId=artifact-secret&focusThreadId=thread-secret",
+    );
+    const sdk = new PostHog();
+    sdk.init("phc_test_project_key", {
+      ...POSTHOG_CONFIG,
+      before_send: (result) => {
+        const sanitized = sanitizePostHogCaptureResult(result);
+        if (sanitized !== null) captured.push(sanitized);
+        return null;
+      },
+      persistence: "memory",
+      request_batching: false,
+    });
+    sdk.register({
+      app: "gui-app",
+      app_version: "1.2.3",
+      platform: "macos",
+      release_channel: "production",
+    });
+
+    sdk.capture("chat_message_sent", {
+      harness: "codex",
+      mode: "regular",
+    });
+    sdk.identify("7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1", {
+      email: "alice@example.com",
+      name: "Alice Smith",
+      favorite_repo: "/Users/alice/secret-repo",
+    });
+
+    const custom = captured.find(({ event }) => event === "chat_message_sent");
+    const identify = captured.find(({ event }) => event === "$identify");
+    expect(typeof custom?.properties.distinct_id).toBe("string");
+    expect(custom?.properties).toMatchObject({
+      token: "phc_test_project_key",
+      app: "gui-app",
+      app_version: "1.2.3",
+      platform: "macos",
+      release_channel: "production",
+      harness: "codex",
+      mode: "regular",
+    });
+    // $session_id / $window_id are the ONLY SDK enrichment allowed through:
+    // opaque SDK-generated UUIDs that keep session analyses working.
+    const allowedKeys = new Set([
+      "app",
+      "app_version",
+      "distinct_id",
+      "harness",
+      "mode",
+      "platform",
+      "release_channel",
+      "token",
+      "$session_id",
+      "$window_id",
+    ]);
+    for (const key of Object.keys(custom?.properties ?? {})) {
+      expect(allowedKeys.has(key)).toBe(true);
+    }
+    // Unconditional: session-based analyses (paths, session funnels) depend
+    // on this passthrough, so its silent disappearance must fail the suite.
+    expect(custom?.properties.$session_id).toMatch(UUID_PATTERN);
+    expect(typeof identify?.properties.$anon_distinct_id).toBe("string");
+    expect(identify?.properties).toMatchObject({
+      token: "phc_test_project_key",
+      distinct_id: "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+    });
+    expect(Object.keys(identify?.properties ?? {}).sort()).toEqual(
+      ["$anon_distinct_id", "distinct_id", "token"].sort(),
+    );
+    // Email is the ONLY person property allowed through; everything else the
+    // SDK staged on $set/$set_once (name, custom props, referrer/campaign
+    // enrichment) is dropped.
+    expect(identify?.$set).toEqual({ email: "alice@example.com" });
+    expect(identify?.$set_once).toBeUndefined();
+    expect(identify?.$unset).toBeUndefined();
+    expect(JSON.stringify(captured)).not.toMatch(
+      /epic-secret|artifact-secret|thread-secret|pathname|referrer|user_agent|Alice Smith|secret-repo/,
+    );
+  });
+
+  it("rejects content-shaped identities from real SDK CaptureResults", async () => {
+    const { POSTHOG_CONFIG, sanitizePostHogCaptureResult } =
+      await import("@/lib/analytics");
+    const unsafeIdentities = [
+      "/Users/alice/secret-repo",
+      "alice@example.com",
+      "https://example.com/private/task",
+      "Alice Smith",
+      "secret-team-slug",
+    ];
+
+    for (const unsafeIdentity of unsafeIdentities) {
+      const captured: CaptureResult[] = [];
+      const sdk = new PostHog();
+      sdk.init("phc_test_project_key", {
+        ...POSTHOG_CONFIG,
+        before_send: (result) => {
+          const sanitized = sanitizePostHogCaptureResult(result);
+          if (sanitized !== null) captured.push(sanitized);
+          return null;
+        },
+        persistence: "memory",
+        request_batching: false,
+      });
+      sdk.register({
+        app: "gui-app",
+        app_version: "1.2.3",
+        platform: "macos",
+        release_channel: "production",
+      });
+      sdk.identify(unsafeIdentity);
+      sdk.capture("command_palette_opened");
+
+      expect(JSON.stringify(captured)).not.toContain(unsafeIdentity);
+    }
+  });
+
+  it("keeps the email when a repeat identify surfaces as a $set event", async () => {
+    const { POSTHOG_CONFIG, sanitizePostHogCaptureResult } =
+      await import("@/lib/analytics");
+    const captured: CaptureResult[] = [];
+    const sdk = new PostHog();
+    // Unique token: posthog-js shares instances (and identified state) by
+    // token, and this test needs a genuinely fresh anonymous -> identified
+    // -> repeat-identify sequence.
+    sdk.init("phc_test_project_key_repeat_identify", {
+      ...POSTHOG_CONFIG,
+      before_send: (result) => {
+        const sanitized = sanitizePostHogCaptureResult(result);
+        if (sanitized !== null) captured.push(sanitized);
+        return null;
+      },
+      persistence: "memory",
+      request_batching: false,
+    });
+    sdk.register({
+      app: "gui-app",
+      app_version: "1.2.3",
+      platform: "macos",
+      release_channel: "production",
+    });
+
+    // Second identify for an ALREADY-identified distinct id: the real SDK
+    // emits `$set` instead of `$identify` (this is the renderer-restart /
+    // changed-email shape). The sanitizer must pass the email through.
+    sdk.identify("7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1", {
+      email: "alice@example.com",
+      name: "Alice Smith",
+    });
+    sdk.identify("7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1", {
+      email: "alice.renamed@example.com",
+      name: "Alice Renamed",
+    });
+
+    const setEvent = captured.filter(({ event }) => event === "$set").at(-1);
+    expect(setEvent).toBeDefined();
+    expect(setEvent?.$set).toEqual({ email: "alice.renamed@example.com" });
+    expect(setEvent?.properties).toMatchObject({
+      token: "phc_test_project_key_repeat_identify",
+      distinct_id: "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+    });
+    expect(Object.keys(setEvent?.properties ?? {}).sort()).toEqual(
+      ["distinct_id", "token"].sort(),
+    );
+    expect(JSON.stringify(captured)).not.toMatch(/Alice/);
+  });
+
+  it("contains SDK exceptions: a throwing init permanently disables analytics", async () => {
+    vi.resetModules();
+    vi.stubEnv("MODE", "development");
+    vi.stubEnv("VITE_POSTHOG_KEY", "phc_test_project_key");
+    try {
+      const posthog = (await import("posthog-js")).default;
+      const initSpy = vi.spyOn(posthog, "init").mockImplementation(() => {
+        throw new Error("storage denied");
+      });
+      const captureSpy = vi.spyOn(posthog, "capture");
+      const { Analytics, AnalyticsEvent } = await import("@/lib/analytics");
+
+      const analytics = Analytics.getInstance();
+      expect(initSpy).toHaveBeenCalledTimes(1);
+      // Valid payloads still report local acceptance; the SDK is never
+      // touched again, and nothing escapes into the caller.
+      expect(
+        analytics.track(AnalyticsEvent.TaskCreated, { mode: "chat" }),
+      ).toBe(true);
+      expect(
+        analytics.identify("7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1", null),
+      ).toBe(true);
+      expect(() => {
+        analytics.reset();
+      }).not.toThrow();
+      expect(captureSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+      vi.resetModules();
+    }
+  });
+
+  it("contains SDK exceptions thrown by capture/identify/reset mid-session", async () => {
+    vi.resetModules();
+    vi.stubEnv("MODE", "development");
+    vi.stubEnv("VITE_POSTHOG_KEY", "phc_test_project_key");
+    try {
+      const posthog = (await import("posthog-js")).default;
+      vi.spyOn(posthog, "init").mockImplementation(() => posthog);
+      vi.spyOn(posthog, "register").mockImplementation(() => undefined);
+      vi.spyOn(posthog, "capture").mockImplementation(() => {
+        throw new Error("before_send exploded");
+      });
+      vi.spyOn(posthog, "identify").mockImplementation(() => {
+        throw new Error("identify exploded");
+      });
+      vi.spyOn(posthog, "reset").mockImplementation(() => {
+        throw new Error("reset exploded");
+      });
+      vi.spyOn(posthog, "get_distinct_id").mockImplementation(() => {
+        throw new Error("persistence exploded");
+      });
+      const { Analytics, AnalyticsEvent } = await import("@/lib/analytics");
+
+      const analytics = Analytics.getInstance();
+      expect(
+        analytics.track(AnalyticsEvent.TaskCreated, { mode: "chat" }),
+      ).toBe(true);
+      expect(
+        analytics.identify(
+          "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+          "alice@example.com",
+        ),
+      ).toBe(true);
+      expect(() => {
+        analytics.reset();
+      }).not.toThrow();
+    } finally {
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+      vi.resetModules();
+    }
+  });
+
+  it("resets persisted cross-account identity before identifying the new user", async () => {
+    vi.resetModules();
+    vi.stubEnv("MODE", "development");
+    vi.stubEnv("VITE_POSTHOG_KEY", "phc_test_project_key");
+    try {
+      const posthog = (await import("posthog-js")).default;
+      const calls: string[] = [];
+      // Simulate a cold start on ANOTHER account's persisted SDK state:
+      // distinct_id differs from $device_id (= identified) and from the
+      // signing-in user.
+      vi.spyOn(posthog, "init").mockImplementation(() => posthog);
+      vi.spyOn(posthog, "register").mockImplementation(() => undefined);
+      vi.spyOn(posthog, "get_distinct_id").mockImplementation(
+        () => "0f0e23f5-8a3d-4d2b-923c-8d02b8ef8000",
+      );
+      vi.spyOn(posthog, "get_property").mockImplementation(
+        () => "9a9e23f5-8a3d-4d2b-923c-8d02b8ef8999",
+      );
+      vi.spyOn(posthog, "reset").mockImplementation(() => {
+        calls.push("reset");
+      });
+      vi.spyOn(posthog, "identify").mockImplementation(() => {
+        calls.push("identify");
+      });
+      const { Analytics } = await import("@/lib/analytics");
+
+      Analytics.getInstance().identify(
+        "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+        "alice@example.com",
+      );
+      // The stale account's identity/session is dropped BEFORE the new
+      // identify so the two accounts' streams cannot blend.
+      expect(calls).toEqual(["reset", "identify"]);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+      vi.resetModules();
+    }
+  });
+
+  it("does not reset when the persisted identity already belongs to the signing-in user", async () => {
+    vi.resetModules();
+    vi.stubEnv("MODE", "development");
+    vi.stubEnv("VITE_POSTHOG_KEY", "phc_test_project_key");
+    try {
+      const posthog = (await import("posthog-js")).default;
+      const calls: string[] = [];
+      vi.spyOn(posthog, "init").mockImplementation(() => posthog);
+      vi.spyOn(posthog, "register").mockImplementation(() => undefined);
+      // Renderer restart: the SDK still holds THIS user's identity.
+      vi.spyOn(posthog, "get_distinct_id").mockImplementation(
+        () => "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+      );
+      vi.spyOn(posthog, "get_property").mockImplementation(
+        () => "9a9e23f5-8a3d-4d2b-923c-8d02b8ef8999",
+      );
+      vi.spyOn(posthog, "reset").mockImplementation(() => {
+        calls.push("reset");
+      });
+      vi.spyOn(posthog, "identify").mockImplementation(() => {
+        calls.push("identify");
+      });
+      const { Analytics } = await import("@/lib/analytics");
+
+      Analytics.getInstance().identify(
+        "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+        "alice@example.com",
+      );
+      // No reset: the repeat identify keeps the session and lets the SDK
+      // surface the email refresh as a $set event.
+      expect(calls).toEqual(["identify"]);
+    } finally {
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+      vi.resetModules();
+    }
+  });
+
+  it("drops events that are not part of the declared contract", async () => {
+    const { sanitizePostHogCaptureResult } = await import("@/lib/analytics");
+
+    expect(
+      sanitizePostHogCaptureResult({
+        event: "$pageview",
+        properties: {
+          token: "phc_test_project_key",
+          distinct_id: "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+        },
+        uuid: "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+      }),
+    ).toBeNull();
+    expect(
+      sanitizePostHogCaptureResult({
+        event: "made_up_event",
+        properties: {
+          token: "phc_test_project_key",
+          distinct_id: "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+        },
+        uuid: "7b6e23f5-8a3d-4d2b-923c-8d02b8ef80d1",
+      }),
+    ).toBeNull();
   });
 });

--- a/clients/gui-app/src/lib/__tests__/app-update-analytics.test.ts
+++ b/clients/gui-app/src/lib/__tests__/app-update-analytics.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import {
+  __resetAppUpdateAnalyticsForTests,
+  settleUpdateDownloadOutcome,
+  trackUpdateDownloadStarted,
+} from "@/lib/app-update-analytics";
+
+describe("app-update-analytics", () => {
+  beforeEach(() => {
+    __resetAppUpdateAnalyticsForTests();
+  });
+
+  it("tracks a start followed by a ready settle as succeeded", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    track.mockClear();
+
+    trackUpdateDownloadStarted("direct_ui");
+    settleUpdateDownloadOutcome("ready", null);
+
+    expect(track).toHaveBeenNthCalledWith(
+      1,
+      AnalyticsEvent.UpdateDownloadStarted,
+      { source: "direct_ui" },
+    );
+    expect(track).toHaveBeenNthCalledWith(
+      2,
+      AnalyticsEvent.UpdateDownloadSucceeded,
+      null,
+    );
+  });
+
+  it("tracks a start followed by an error settle as failed", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    track.mockClear();
+
+    trackUpdateDownloadStarted("system_tray");
+    settleUpdateDownloadOutcome("error", "network timeout");
+
+    expect(track).toHaveBeenNthCalledWith(
+      1,
+      AnalyticsEvent.UpdateDownloadStarted,
+      { source: "system_tray" },
+    );
+    expect(track).toHaveBeenNthCalledWith(2, AnalyticsEvent.UpdateFailed, {
+      blocker: "timeout",
+    });
+  });
+
+  it("is a no-op when settling without a matching start", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    track.mockClear();
+
+    settleUpdateDownloadOutcome("ready", null);
+
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("only tracks the first terminal outcome on a double settle", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    track.mockClear();
+
+    trackUpdateDownloadStarted("direct_ui");
+    settleUpdateDownloadOutcome("ready", null);
+    settleUpdateDownloadOutcome("error", "should be ignored");
+
+    expect(track).toHaveBeenCalledTimes(2);
+    expect(track).toHaveBeenNthCalledWith(
+      2,
+      AnalyticsEvent.UpdateDownloadSucceeded,
+      null,
+    );
+  });
+});

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -561,7 +561,7 @@ export interface AnalyticsEventProperties {
   readonly [AnalyticsEvent.ArtifactRenamed]: null;
   readonly [AnalyticsEvent.ArtifactStatusChanged]: {
     readonly kind: AnalyticsArtifactKind;
-    readonly status: number;
+    readonly status: 0 | 1 | 2;
   };
   readonly [AnalyticsEvent.ArtifactDeleted]: null;
   readonly [AnalyticsEvent.ArtifactExported]: {
@@ -1691,6 +1691,62 @@ export function analyticsBlockerFromError(error: unknown): AnalyticsBlocker {
     ANALYTICS_BLOCKER_PATTERNS.find(({ pattern }) => pattern.test(text))
       ?.blocker ?? "unknown"
   );
+}
+
+/**
+ * Host-update analytics trio shared by every install/update surface
+ * (the in-app banner and the system-tray listener): `host_update_started`
+ * on mutate, `host_update_succeeded` on success, `host_update_failed` on
+ * error - differing only by `source`.
+ */
+export function hostUpdateAnalyticsCallbacks(source: AnalyticsSource): {
+  readonly onStarted: () => void;
+  readonly onSucceeded: () => void;
+  readonly onFailed: (error: unknown) => void;
+} {
+  return {
+    onStarted: () => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateStarted, {
+        source,
+      });
+    },
+    onSucceeded: () => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateSucceeded, null);
+    },
+    onFailed: (error) => {
+      Analytics.getInstance().track(AnalyticsEvent.HostUpdateFailed, {
+        blocker: analyticsBlockerFromError(error),
+      });
+    },
+  };
+}
+
+/** Fires `setting_changed` for the given Settings section/setting pair. */
+export function trackSettingChanged(
+  section: AnalyticsSettingsSection,
+  setting: AnalyticsSetting,
+): void {
+  Analytics.getInstance().track(AnalyticsEvent.SettingChanged, {
+    source: "direct_ui",
+    section,
+    setting,
+  });
+}
+
+/**
+ * Wraps a settings-store setter so every call tracks `setting_changed` for
+ * the given section before writing through. Shared by the Appearance and
+ * General settings panels so both stay on one tracking contract.
+ */
+export function trackedSettingSetter<Value>(
+  section: AnalyticsSettingsSection,
+  setting: AnalyticsSetting,
+  setter: (value: Value) => void,
+): (value: Value) => void {
+  return (value) => {
+    trackSettingChanged(section, setting);
+    setter(value);
+  };
 }
 
 function analyticsPlatform(): "linux" | "macos" | "other" | "windows" {

--- a/clients/gui-app/src/lib/analytics.ts
+++ b/clients/gui-app/src/lib/analytics.ts
@@ -1,23 +1,1717 @@
-import posthog from "posthog-js";
+import posthog, { type CaptureResult, type PostHogConfig } from "posthog-js";
 
-type EventProperties = Record<string, unknown> | null;
+export type AnalyticsSource =
+  | "direct_ui"
+  | "command_palette"
+  | "keyboard_shortcut"
+  | "native_menu"
+  | "native_menu_accelerator"
+  | "system_tray"
+  | "os_jump_list_or_dock"
+  | "window_chrome"
+  | "notification"
+  | "history"
+  | "deep_link"
+  | "restored_session";
+
+export type AnalyticsBlocker =
+  | "authentication"
+  | "authorization"
+  | "cancelled"
+  | "conflict"
+  | "host_incompatible"
+  | "host_unavailable"
+  | "invalid_input"
+  | "migration"
+  | "network"
+  | "not_found"
+  | "permission"
+  | "provider_unavailable"
+  | "rate_limit"
+  | "setup"
+  | "timeout"
+  | "unsupported"
+  | "unknown";
+
+export type AnalyticsCommand =
+  | "create_task"
+  | "create_chat"
+  | "duplicate_tab"
+  | "history_back"
+  | "history_forward"
+  | "open_artifact"
+  | "open_chat"
+  | "open_diff"
+  | "open_file"
+  | "open_logs"
+  | "open_settings"
+  | "open_task"
+  | "open_terminal"
+  | "install_host_update"
+  | "report_issue"
+  | "restart_host"
+  | "switch_task";
+
+export type AnalyticsSettingsSection =
+  | "agents"
+  | "appearance"
+  | "diagnostics"
+  | "general"
+  | "host"
+  | "keybindings"
+  | "notifications"
+  | "providers"
+  | "shell"
+  | "worktrees";
+
+export type AnalyticsArtifactKind = "review" | "spec" | "story" | "ticket";
+
+export type AnalyticsEditor = "cursor" | "vscode" | "windsurf" | "zed";
+
+export type AnalyticsHarness =
+  | "amp"
+  | "claude"
+  | "codex"
+  | "copilot"
+  | "cursor"
+  | "devin"
+  | "droid"
+  | "grok"
+  | "kilocode"
+  | "kimi"
+  | "kiro"
+  | "opencode"
+  | "openrouter"
+  | "pi"
+  | "qwen"
+  | "traycer";
+
+export type AnalyticsNotificationCategory = "app-local" | "global" | "host";
+
+export type AnalyticsOnboardingStep =
+  | "agent-guide"
+  | "command-theme"
+  | "navigation"
+  | "providers"
+  | "task-context"
+  | "task-tabs";
+
+export type AnalyticsProviderOperation =
+  | "ambient_drift"
+  | "api_key"
+  | "custom_path"
+  | "enabled"
+  | "env_override"
+  | "profile"
+  | "selection"
+  | "terminal_args";
+
+export type AnalyticsProvider =
+  | "amp"
+  | "claude-code"
+  | "codex"
+  | "copilot"
+  | "cursor"
+  | "devin"
+  | "droid"
+  | "grok"
+  | "kilocode"
+  | "kimi"
+  | "kiro"
+  | "opencode"
+  | "openrouter"
+  | "pi"
+  | "qwen"
+  | "traycer";
+
+export type AnalyticsRole = "editor" | "owner" | "viewer";
+
+export type AnalyticsSetting =
+  | "artifactIconColorMode"
+  | "artifactIconColors"
+  | "codeFontFamily"
+  | "codeFontSize"
+  | "composerMode"
+  | "defaultAgentMode"
+  | "defaultEditor"
+  | "defaultPermission"
+  | "defaultReasoning"
+  | "defaultSelection"
+  | "defaultServiceTier"
+  | "diffViewerPreferences"
+  | "pinContextUsageBreakdown"
+  | "pointerCursors"
+  | "preventSleepWhileRunning"
+  | "quoteReplyEnabled"
+  | "showGlobalResourceMonitor"
+  | "showNavigatorResourceStats"
+  | "terminalCursorBlink"
+  | "terminalCursorStyle"
+  | "terminalFontFamily"
+  | "terminalFontSize"
+  | "theme"
+  | "themePreset"
+  | "uiFontFamily"
+  | "uiFontSize"
+  | "voiceInputEnabled"
+  | "voiceLanguage";
+
+export type AnalyticsTheme =
+  | "mode:dark"
+  | "mode:light"
+  | "mode:system"
+  | "preset:amoled"
+  | "preset:ayu"
+  | "preset:blue"
+  | "preset:catppuccin"
+  | "preset:dracula"
+  | "preset:everforest"
+  | "preset:github"
+  | "preset:green"
+  | "preset:gruvbox"
+  | "preset:neutral"
+  | "preset:nord"
+  | "preset:orange"
+  | "preset:pink"
+  | "preset:rose"
+  | "preset:tokyo-night"
+  | "preset:traycer-green"
+  | "preset:violet";
 
 export enum AnalyticsEvent {
+  AppOpened = "app_opened",
+  SignInStarted = "sign_in_started",
+  SignInApprovalOpened = "sign_in_approval_opened",
+  SignInSucceeded = "sign_in_succeeded",
+  SignInFailed = "sign_in_failed",
+  SignOutRequested = "sign_out_requested",
+  HostSetupStarted = "host_setup_started",
+  HostSetupSucceeded = "host_setup_succeeded",
+  HostSetupFailed = "host_setup_failed",
+  HostSelected = "host_selected",
+  HostUpdateStarted = "host_update_started",
+  HostUpdateSucceeded = "host_update_succeeded",
+  HostUpdateFailed = "host_update_failed",
+  HostUpdateSnoozed = "host_update_snoozed",
+  OnboardingStarted = "onboarding_started",
+  OnboardingNavigated = "onboarding_navigated",
+  OnboardingCompleted = "onboarding_completed",
+  OnboardingSkipped = "onboarding_skipped",
+  OnboardingThemeChanged = "onboarding_theme_changed",
+  AgentGuideSaved = "agent_guide_saved",
+  ProviderProfileLinkStarted = "provider_profile_link_started",
+  ProviderProfileLinkSucceeded = "provider_profile_link_succeeded",
+  ProviderProfileLinkFailed = "provider_profile_link_failed",
+  ProviderProfileLinkCancelled = "provider_profile_link_cancelled",
+  ProviderConfigurationChanged = "provider_configuration_changed",
+  AccountContextChanged = "account_context_changed",
+  SubscriptionRefreshed = "subscription_refreshed",
+  SubscriptionManagementOpened = "subscription_management_opened",
+  TaskCreationStarted = "task_creation_started",
   TaskCreated = "task_created",
+  TaskCreationFailed = "task_creation_failed",
   TaskOpened = "task_opened",
+  TaskRenamed = "task_renamed",
+  TaskDeleted = "task_deleted",
   TaskShared = "task_shared",
+  AttachmentAdded = "attachment_added",
+  AttachmentRemoved = "attachment_removed",
+  AttachmentRejected = "attachment_rejected",
+  WorkspaceFolderAdded = "workspace_folder_added",
+  WorkspaceFolderRemoved = "workspace_folder_removed",
+  WorkspacePrimaryChanged = "workspace_primary_changed",
+  WorkspaceFileOpened = "workspace_file_opened",
+  WorkspaceOpenedInEditor = "workspace_opened_in_editor",
+  WorktreeCreated = "worktree_created",
+  WorktreeImported = "worktree_imported",
+  WorktreeSelected = "worktree_selected",
+  WorktreeDeleted = "worktree_deleted",
+  WorktreesBulkDeleted = "worktrees_bulk_deleted",
+  SetupScriptsOpened = "setup_scripts_opened",
+  SetupScriptsSaved = "setup_scripts_saved",
+  SetupScriptsRetryStarted = "setup_scripts_retry_started",
+  ChatOpened = "chat_opened",
   ChatMessageSent = "chat_message_sent",
-  CommandPaletteOpened = "command_palette_opened",
-  TerminalOpened = "terminal_opened",
+  ChatMessageEdited = "chat_message_edited",
+  ChatMessageSuffixDeleted = "chat_message_suffix_deleted",
+  ChatForked = "chat_forked",
+  ChatStopped = "chat_stopped",
+  ChatBackgroundItemStopped = "chat_background_item_stopped",
+  ChatQueuePaused = "chat_queue_paused",
+  ChatQueueResumed = "chat_queue_resumed",
+  ChatQueueItemEdited = "chat_queue_item_edited",
+  ChatQueueItemReordered = "chat_queue_item_reordered",
+  ChatQueueItemCancelled = "chat_queue_item_cancelled",
+  ChatQueueItemSteered = "chat_queue_item_steered",
+  ApprovalDecided = "approval_decided",
+  FileEditApprovalDecided = "file_edit_approval_decided",
+  CheckpointRestored = "checkpoint_restored",
+  InterviewAnswered = "interview_answered",
+  FileChangesReverted = "file_changes_reverted",
+  DiffOpened = "diff_opened",
   HarnessChanged = "harness_changed",
+  CommandPaletteOpened = "command_palette_opened",
+  CommandExecuted = "command_executed",
   HistoryNavigationUsed = "history_navigation_used",
+  TabCreated = "tab_created",
+  TabDuplicated = "tab_duplicated",
+  TabSplit = "tab_split",
+  TabMoved = "tab_moved",
+  TabClosed = "tab_closed",
+  ArtifactCreated = "artifact_created",
+  ArtifactOpened = "artifact_opened",
+  ArtifactRenamed = "artifact_renamed",
+  ArtifactStatusChanged = "artifact_status_changed",
+  ArtifactDeleted = "artifact_deleted",
+  ArtifactExported = "artifact_exported",
+  CommentCreated = "comment_created",
+  CommentReplied = "comment_replied",
+  CommentEdited = "comment_edited",
+  CommentResolved = "comment_resolved",
+  CommentReopened = "comment_reopened",
+  CommentDeleted = "comment_deleted",
+  ShareInviteSent = "share_invite_sent",
+  ShareRoleChanged = "share_role_changed",
+  ShareAccessRevoked = "share_access_revoked",
+  NotificationCenterOpened = "notification_center_opened",
+  NotificationActivated = "notification_activated",
+  NotificationMarkedRead = "notification_marked_read",
+  NotificationsMarkedAllRead = "notifications_marked_all_read",
+  NotificationsCleared = "notifications_cleared",
+  TerminalOpened = "terminal_opened",
+  TerminalRenamed = "terminal_renamed",
+  TerminalKilled = "terminal_killed",
+  TerminalAgentLaunched = "terminal_agent_launched",
+  TerminalAgentForked = "terminal_agent_forked",
+  TerminalAgentStopped = "terminal_agent_stopped",
+  AgentStopped = "agent_stopped",
+  VoiceEnabled = "voice_enabled",
+  VoiceDisabled = "voice_disabled",
+  VoiceDictationStarted = "voice_dictation_started",
+  VoiceDictationStopped = "voice_dictation_stopped",
+  VoiceDictationCancelled = "voice_dictation_cancelled",
+  VoicePermissionResolved = "voice_permission_resolved",
+  VoiceCaptureFailed = "voice_capture_failed",
+  VoiceTranscriptionSucceeded = "voice_transcription_succeeded",
+  VoiceTranscriptionFailed = "voice_transcription_failed",
+  SettingsOpened = "settings_opened",
+  SettingChanged = "setting_changed",
+  UpdateDownloadStarted = "update_download_started",
+  UpdateDownloadSucceeded = "update_download_succeeded",
+  UpdateRestartRequested = "update_restart_requested",
+  UpdateInstallGuidanceOpened = "update_install_guidance_opened",
+  UpdateFailed = "update_failed",
+  ReportIssueOpened = "report_issue_opened",
+  ReportIssueHandedOff = "report_issue_handed_off",
+  AppQuitRequested = "app_quit_requested",
+  TabCloseBlocked = "tab_close_blocked",
+}
+
+type SourceProperties = { readonly source: AnalyticsSource };
+type BlockedProperties = SourceProperties & {
+  readonly blocker: AnalyticsBlocker;
+};
+type WorkspaceKind = "local" | "unknown" | "worktree";
+export type AnalyticsTargetKind =
+  | "artifact"
+  | "chat"
+  | "diff"
+  | "file"
+  | "task"
+  | "terminal"
+  | "terminal_agent";
+
+export function analyticsTargetForCanvasTileType(
+  tileType: string,
+): AnalyticsTargetKind | null {
+  switch (tileType) {
+    case "chat":
+      return "chat";
+    case "terminal":
+      return "terminal";
+    case "terminal-agent":
+      return "terminal_agent";
+    case "workspace-file":
+      return "file";
+    case "git-diff":
+    case "snapshot-diff":
+      return "diff";
+    case "spec":
+    case "ticket":
+    case "story":
+    case "review":
+      return "artifact";
+    default:
+      return null;
+  }
+}
+
+export function analyticsArtifactKindForCanvasTileType(
+  tileType: string,
+): AnalyticsArtifactKind | null {
+  switch (tileType) {
+    case "review":
+    case "spec":
+    case "story":
+    case "ticket":
+      return tileType;
+    default:
+      return null;
+  }
+}
+
+export interface AnalyticsEventProperties {
+  readonly [AnalyticsEvent.AppOpened]: SourceProperties & {
+    readonly launch_reason: "normal" | "update_restart";
+    readonly restored_tabs: boolean;
+  };
+  readonly [AnalyticsEvent.SignInStarted]: SourceProperties;
+  readonly [AnalyticsEvent.SignInApprovalOpened]: SourceProperties;
+  readonly [AnalyticsEvent.SignInSucceeded]: null;
+  // Deliberately source-less: success/failure are emitted from the terminal
+  // auth transition inside AuthService, where the originating UI gesture is
+  // unknown; funnels take `source` from `sign_in_started`.
+  readonly [AnalyticsEvent.SignInFailed]: {
+    readonly blocker: AnalyticsBlocker;
+  };
+  readonly [AnalyticsEvent.SignOutRequested]: SourceProperties;
+  readonly [AnalyticsEvent.HostSetupStarted]: {
+    readonly reason: "launch" | "recovery" | "reinstall" | "update";
+  };
+  readonly [AnalyticsEvent.HostSetupSucceeded]: {
+    readonly reason: "launch" | "recovery" | "reinstall" | "update";
+  };
+  readonly [AnalyticsEvent.HostSetupFailed]: BlockedProperties;
+  readonly [AnalyticsEvent.HostSelected]: SourceProperties & {
+    readonly host_kind: "local" | "remote";
+  };
+  readonly [AnalyticsEvent.HostUpdateStarted]: SourceProperties;
+  readonly [AnalyticsEvent.HostUpdateSucceeded]: null;
+  readonly [AnalyticsEvent.HostUpdateFailed]: {
+    readonly blocker: AnalyticsBlocker;
+  };
+  readonly [AnalyticsEvent.HostUpdateSnoozed]: SourceProperties;
+  readonly [AnalyticsEvent.OnboardingStarted]: {
+    readonly mode: "first_run" | "replay";
+  };
+  readonly [AnalyticsEvent.OnboardingNavigated]: {
+    readonly direction: "back" | "continue";
+    readonly step: AnalyticsOnboardingStep;
+  };
+  readonly [AnalyticsEvent.OnboardingCompleted]: {
+    readonly last_step: AnalyticsOnboardingStep;
+  };
+  readonly [AnalyticsEvent.OnboardingSkipped]: {
+    readonly last_step: AnalyticsOnboardingStep;
+  };
+  readonly [AnalyticsEvent.OnboardingThemeChanged]: {
+    readonly theme: AnalyticsTheme;
+  };
+  readonly [AnalyticsEvent.AgentGuideSaved]: { readonly customized: boolean };
+  readonly [AnalyticsEvent.ProviderProfileLinkStarted]: SourceProperties & {
+    readonly provider: AnalyticsProvider;
+    readonly mode: "create" | "reauth";
+  };
+  readonly [AnalyticsEvent.ProviderProfileLinkSucceeded]: {
+    readonly provider: AnalyticsProvider;
+    readonly mode: "create" | "reauth";
+  };
+  readonly [AnalyticsEvent.ProviderProfileLinkFailed]: {
+    readonly provider: AnalyticsProvider;
+    readonly mode: "create" | "reauth";
+    readonly blocker: AnalyticsBlocker;
+  };
+  readonly [AnalyticsEvent.ProviderProfileLinkCancelled]: {
+    readonly provider: AnalyticsProvider;
+    readonly mode: "create" | "reauth";
+  };
+  readonly [AnalyticsEvent.ProviderConfigurationChanged]: {
+    readonly operation: AnalyticsProviderOperation;
+  };
+  readonly [AnalyticsEvent.AccountContextChanged]: {
+    readonly context: "personal" | "team";
+  };
+  readonly [AnalyticsEvent.SubscriptionRefreshed]: SourceProperties;
+  readonly [AnalyticsEvent.SubscriptionManagementOpened]: SourceProperties;
+  readonly [AnalyticsEvent.TaskCreationStarted]: SourceProperties & {
+    readonly mode: "chat" | "terminal_agent";
+    readonly workspace_count: number;
+  };
+  readonly [AnalyticsEvent.TaskCreated]: {
+    readonly mode: "chat" | "terminal_agent";
+  };
+  readonly [AnalyticsEvent.TaskCreationFailed]: BlockedProperties & {
+    readonly mode: "chat" | "terminal_agent";
+  };
+  readonly [AnalyticsEvent.TaskOpened]: SourceProperties;
+  readonly [AnalyticsEvent.TaskRenamed]: SourceProperties;
+  readonly [AnalyticsEvent.TaskDeleted]: SourceProperties & {
+    readonly cleanup_worktrees: boolean;
+  };
+  readonly [AnalyticsEvent.TaskShared]: null;
+  readonly [AnalyticsEvent.AttachmentAdded]: {
+    readonly kind: "image";
+    readonly surface: "draft" | "chat";
+  };
+  readonly [AnalyticsEvent.AttachmentRemoved]: {
+    readonly kind: "image";
+    readonly surface: "draft" | "chat";
+  };
+  readonly [AnalyticsEvent.AttachmentRejected]: {
+    readonly kind: "image";
+    readonly surface: "draft" | "chat";
+    readonly blocker: AnalyticsBlocker;
+  };
+  readonly [AnalyticsEvent.WorkspaceFolderAdded]: SourceProperties & {
+    readonly workspace_kind: WorkspaceKind;
+  };
+  readonly [AnalyticsEvent.WorkspaceFolderRemoved]: SourceProperties & {
+    readonly workspace_kind: WorkspaceKind;
+  };
+  readonly [AnalyticsEvent.WorkspacePrimaryChanged]: SourceProperties;
+  readonly [AnalyticsEvent.WorkspaceFileOpened]: SourceProperties;
+  readonly [AnalyticsEvent.WorkspaceOpenedInEditor]: SourceProperties & {
+    readonly editor: AnalyticsEditor;
+  };
+  readonly [AnalyticsEvent.WorktreeCreated]: SourceProperties;
+  readonly [AnalyticsEvent.WorktreeImported]: SourceProperties;
+  readonly [AnalyticsEvent.WorktreeSelected]: SourceProperties;
+  readonly [AnalyticsEvent.WorktreeDeleted]:
+    | { readonly outcome: "failed"; readonly blocker: AnalyticsBlocker }
+    | { readonly outcome: "succeeded"; readonly blocker: null };
+  readonly [AnalyticsEvent.WorktreesBulkDeleted]: {
+    readonly requested_count: number;
+    readonly succeeded_count: number;
+    readonly failed_count: number;
+  };
+  readonly [AnalyticsEvent.SetupScriptsOpened]: SourceProperties;
+  readonly [AnalyticsEvent.SetupScriptsSaved]: {
+    readonly script_count: number;
+  };
+  readonly [AnalyticsEvent.SetupScriptsRetryStarted]: SourceProperties;
+  readonly [AnalyticsEvent.ChatOpened]: SourceProperties;
+  readonly [AnalyticsEvent.ChatMessageSent]: {
+    readonly harness: AnalyticsHarness;
+    readonly mode: "epic" | "regular";
+  };
+  readonly [AnalyticsEvent.ChatMessageEdited]: null;
+  readonly [AnalyticsEvent.ChatMessageSuffixDeleted]: null;
+  readonly [AnalyticsEvent.ChatForked]: SourceProperties & {
+    readonly include_history: boolean;
+  };
+  readonly [AnalyticsEvent.ChatStopped]: {
+    readonly scope: "current" | "with_children";
+  };
+  readonly [AnalyticsEvent.ChatBackgroundItemStopped]: {
+    readonly scope: "one" | "all";
+  };
+  readonly [AnalyticsEvent.ChatQueuePaused]: null;
+  readonly [AnalyticsEvent.ChatQueueResumed]: null;
+  readonly [AnalyticsEvent.ChatQueueItemEdited]: null;
+  readonly [AnalyticsEvent.ChatQueueItemReordered]: null;
+  readonly [AnalyticsEvent.ChatQueueItemCancelled]: null;
+  readonly [AnalyticsEvent.ChatQueueItemSteered]: {
+    readonly settings_changed: boolean;
+  };
+  readonly [AnalyticsEvent.ApprovalDecided]: {
+    readonly decision: "approved" | "denied";
+  };
+  readonly [AnalyticsEvent.FileEditApprovalDecided]: {
+    readonly decision: "approved" | "denied";
+  };
+  readonly [AnalyticsEvent.CheckpointRestored]: {
+    readonly revert_artifacts: boolean;
+  };
+  readonly [AnalyticsEvent.InterviewAnswered]: {
+    readonly answer_count: number;
+  };
+  readonly [AnalyticsEvent.FileChangesReverted]: {
+    readonly file_count: number;
+    readonly revert_artifacts: boolean;
+  };
+  readonly [AnalyticsEvent.DiffOpened]: SourceProperties & {
+    readonly scope: "all" | "file";
+  };
+  readonly [AnalyticsEvent.HarnessChanged]: {
+    readonly from: AnalyticsHarness;
+    readonly to: AnalyticsHarness;
+  };
+  readonly [AnalyticsEvent.CommandPaletteOpened]: null;
+  readonly [AnalyticsEvent.CommandExecuted]: SourceProperties & {
+    readonly command: AnalyticsCommand;
+  };
+  readonly [AnalyticsEvent.HistoryNavigationUsed]: {
+    readonly direction: "back" | "forward";
+  };
+  readonly [AnalyticsEvent.TabCreated]: {
+    readonly target: AnalyticsTargetKind;
+  };
+  readonly [AnalyticsEvent.TabDuplicated]: {
+    readonly target: AnalyticsTargetKind;
+  };
+  readonly [AnalyticsEvent.TabSplit]: { readonly target: AnalyticsTargetKind };
+  readonly [AnalyticsEvent.TabMoved]: { readonly target: AnalyticsTargetKind };
+  readonly [AnalyticsEvent.TabClosed]: { readonly target: AnalyticsTargetKind };
+  readonly [AnalyticsEvent.ArtifactCreated]: {
+    readonly kind: AnalyticsArtifactKind;
+  };
+  readonly [AnalyticsEvent.ArtifactOpened]: SourceProperties & {
+    readonly kind: AnalyticsArtifactKind;
+  };
+  readonly [AnalyticsEvent.ArtifactRenamed]: null;
+  readonly [AnalyticsEvent.ArtifactStatusChanged]: {
+    readonly kind: AnalyticsArtifactKind;
+    readonly status: number;
+  };
+  readonly [AnalyticsEvent.ArtifactDeleted]: null;
+  readonly [AnalyticsEvent.ArtifactExported]: {
+    readonly format: "markdown" | "pdf";
+    readonly artifact_count: number;
+  };
+  readonly [AnalyticsEvent.CommentCreated]: { readonly has_mention: boolean };
+  readonly [AnalyticsEvent.CommentReplied]: { readonly has_mention: boolean };
+  readonly [AnalyticsEvent.CommentEdited]: null;
+  readonly [AnalyticsEvent.CommentResolved]: null;
+  readonly [AnalyticsEvent.CommentReopened]: null;
+  readonly [AnalyticsEvent.CommentDeleted]: null;
+  readonly [AnalyticsEvent.ShareInviteSent]: {
+    readonly target: "person" | "team";
+    readonly role: AnalyticsRole;
+  };
+  readonly [AnalyticsEvent.ShareRoleChanged]: {
+    readonly target: "person" | "team";
+    readonly role: AnalyticsRole;
+  };
+  readonly [AnalyticsEvent.ShareAccessRevoked]: {
+    readonly target: "person" | "team";
+  };
+  readonly [AnalyticsEvent.NotificationCenterOpened]: null;
+  readonly [AnalyticsEvent.NotificationActivated]: {
+    readonly category: AnalyticsNotificationCategory;
+  };
+  readonly [AnalyticsEvent.NotificationMarkedRead]: {
+    readonly category: AnalyticsNotificationCategory;
+  };
+  readonly [AnalyticsEvent.NotificationsMarkedAllRead]: null;
+  readonly [AnalyticsEvent.NotificationsCleared]: {
+    readonly scope: "all" | "read";
+  };
+  readonly [AnalyticsEvent.TerminalOpened]: SourceProperties & {
+    readonly kind: "agent" | "shell";
+  };
+  readonly [AnalyticsEvent.TerminalRenamed]: {
+    readonly kind: "agent" | "shell";
+  };
+  readonly [AnalyticsEvent.TerminalKilled]: {
+    readonly kind: "agent" | "shell";
+  };
+  readonly [AnalyticsEvent.TerminalAgentLaunched]: SourceProperties & {
+    readonly harness: AnalyticsHarness;
+  };
+  readonly [AnalyticsEvent.TerminalAgentForked]: SourceProperties & {
+    readonly harness: AnalyticsHarness;
+  };
+  readonly [AnalyticsEvent.TerminalAgentStopped]: SourceProperties;
+  readonly [AnalyticsEvent.AgentStopped]: SourceProperties & {
+    readonly cascade: boolean;
+  };
+  readonly [AnalyticsEvent.VoiceEnabled]: SourceProperties;
+  readonly [AnalyticsEvent.VoiceDisabled]: SourceProperties;
+  readonly [AnalyticsEvent.VoiceDictationStarted]: SourceProperties;
+  readonly [AnalyticsEvent.VoiceDictationStopped]: {
+    readonly duration_bucket: "under_10s" | "10_to_30s" | "over_30s";
+  };
+  readonly [AnalyticsEvent.VoiceDictationCancelled]: null;
+  readonly [AnalyticsEvent.VoicePermissionResolved]: {
+    readonly permission: "granted" | "denied" | "unavailable";
+  };
+  readonly [AnalyticsEvent.VoiceCaptureFailed]: BlockedProperties;
+  readonly [AnalyticsEvent.VoiceTranscriptionSucceeded]: {
+    readonly duration_bucket: "under_10s" | "10_to_30s" | "over_30s";
+  };
+  readonly [AnalyticsEvent.VoiceTranscriptionFailed]: {
+    readonly blocker: AnalyticsBlocker;
+  };
+  readonly [AnalyticsEvent.SettingsOpened]: SourceProperties & {
+    readonly section: AnalyticsSettingsSection;
+  };
+  readonly [AnalyticsEvent.SettingChanged]: SourceProperties & {
+    readonly section: AnalyticsSettingsSection;
+    readonly setting: AnalyticsSetting;
+  };
+  readonly [AnalyticsEvent.UpdateDownloadStarted]: SourceProperties;
+  readonly [AnalyticsEvent.UpdateDownloadSucceeded]: null;
+  readonly [AnalyticsEvent.UpdateRestartRequested]: SourceProperties;
+  readonly [AnalyticsEvent.UpdateInstallGuidanceOpened]: SourceProperties;
+  readonly [AnalyticsEvent.UpdateFailed]: {
+    readonly blocker: AnalyticsBlocker;
+  };
+  readonly [AnalyticsEvent.ReportIssueOpened]: SourceProperties;
+  readonly [AnalyticsEvent.ReportIssueHandedOff]:
+    | { readonly outcome: "failed"; readonly blocker: AnalyticsBlocker }
+    | { readonly outcome: "succeeded"; readonly blocker: null };
+  readonly [AnalyticsEvent.AppQuitRequested]: SourceProperties;
+  readonly [AnalyticsEvent.TabCloseBlocked]: {
+    readonly decision: "cancel" | "discard";
+  };
+}
+
+export const POSTHOG_CONFIG = {
+  api_host: "https://us.i.posthog.com",
+  autocapture: false,
+  rageclick: false,
+  capture_pageview: false,
+  capture_pageleave: false,
+  capture_heatmaps: false,
+  capture_dead_clicks: false,
+  capture_exceptions: false,
+  capture_performance: false,
+  disable_session_recording: true,
+  disable_surveys: true,
+  disable_surveys_automatic_display: true,
+  disable_product_tours: true,
+  disable_web_experiments: true,
+  advanced_disable_decide: true,
+  advanced_disable_feature_flags: true,
+  person_profiles: "identified_only",
+  save_campaign_params: false,
+  save_referrer: false,
+  before_send: sanitizePostHogCaptureResult,
+  property_denylist: [
+    "$current_url",
+    "$host",
+    "$pathname",
+    "$referrer",
+    "$referring_domain",
+    "$initial_current_url",
+    "$initial_referrer",
+    "$initial_referring_domain",
+    "$session_entry_url",
+  ],
+} satisfies Partial<PostHogConfig>;
+
+type AnalyticsPropertyValue = boolean | number | string | null;
+
+const ANALYTICS_SOURCES = new Set<string>([
+  "command_palette",
+  "deep_link",
+  "direct_ui",
+  "history",
+  "keyboard_shortcut",
+  "native_menu",
+  "native_menu_accelerator",
+  "notification",
+  "os_jump_list_or_dock",
+  "restored_session",
+  "system_tray",
+  "window_chrome",
+]);
+
+const ANALYTICS_BLOCKERS = new Set<string>([
+  "authentication",
+  "authorization",
+  "cancelled",
+  "conflict",
+  "host_incompatible",
+  "host_unavailable",
+  "invalid_input",
+  "migration",
+  "network",
+  "not_found",
+  "permission",
+  "provider_unavailable",
+  "rate_limit",
+  "setup",
+  "timeout",
+  "unknown",
+  "unsupported",
+]);
+
+const ANALYTICS_COMMANDS = new Set<string>([
+  "create_chat",
+  "create_task",
+  "duplicate_tab",
+  "history_back",
+  "history_forward",
+  "install_host_update",
+  "open_artifact",
+  "open_chat",
+  "open_diff",
+  "open_file",
+  "open_logs",
+  "open_settings",
+  "open_task",
+  "open_terminal",
+  "report_issue",
+  "restart_host",
+  "switch_task",
+]);
+
+const ANALYTICS_HARNESSES = new Set<string>([
+  "amp",
+  "claude",
+  "codex",
+  "copilot",
+  "cursor",
+  "devin",
+  "droid",
+  "grok",
+  "kilocode",
+  "kimi",
+  "kiro",
+  "opencode",
+  "openrouter",
+  "pi",
+  "qwen",
+  "traycer",
+]);
+
+const ANALYTICS_PROVIDERS = new Set<string>([
+  "amp",
+  "claude-code",
+  "codex",
+  "copilot",
+  "cursor",
+  "devin",
+  "droid",
+  "grok",
+  "kilocode",
+  "kimi",
+  "kiro",
+  "opencode",
+  "openrouter",
+  "pi",
+  "qwen",
+  "traycer",
+]);
+
+const ANALYTICS_SETTINGS_SECTIONS = new Set<string>([
+  "agents",
+  "appearance",
+  "diagnostics",
+  "general",
+  "host",
+  "keybindings",
+  "notifications",
+  "providers",
+  "shell",
+  "worktrees",
+]);
+
+const ANALYTICS_SETTINGS = new Set<string>([
+  "artifactIconColorMode",
+  "artifactIconColors",
+  "codeFontFamily",
+  "codeFontSize",
+  "composerMode",
+  "defaultAgentMode",
+  "defaultEditor",
+  "defaultPermission",
+  "defaultReasoning",
+  "defaultSelection",
+  "defaultServiceTier",
+  "diffViewerPreferences",
+  "pinContextUsageBreakdown",
+  "pointerCursors",
+  "preventSleepWhileRunning",
+  "quoteReplyEnabled",
+  "showGlobalResourceMonitor",
+  "showNavigatorResourceStats",
+  "terminalCursorBlink",
+  "terminalCursorStyle",
+  "terminalFontFamily",
+  "terminalFontSize",
+  "theme",
+  "themePreset",
+  "uiFontFamily",
+  "uiFontSize",
+  "voiceInputEnabled",
+  "voiceLanguage",
+]);
+
+const ANALYTICS_THEMES = new Set<string>([
+  "mode:dark",
+  "mode:light",
+  "mode:system",
+  "preset:amoled",
+  "preset:ayu",
+  "preset:blue",
+  "preset:catppuccin",
+  "preset:dracula",
+  "preset:everforest",
+  "preset:github",
+  "preset:green",
+  "preset:gruvbox",
+  "preset:neutral",
+  "preset:nord",
+  "preset:orange",
+  "preset:pink",
+  "preset:rose",
+  "preset:tokyo-night",
+  "preset:traycer-green",
+  "preset:violet",
+]);
+
+const ANALYTICS_ONBOARDING_STEPS = new Set<string>([
+  "agent-guide",
+  "command-theme",
+  "navigation",
+  "providers",
+  "task-context",
+  "task-tabs",
+]);
+
+const ANALYTICS_TARGETS = new Set<string>([
+  "artifact",
+  "chat",
+  "diff",
+  "file",
+  "task",
+  "terminal",
+  "terminal_agent",
+]);
+
+const ANALYTICS_EVENTS = new Set<string>(Object.values(AnalyticsEvent));
+
+function isAnalyticsEvent(event: string): event is AnalyticsEvent {
+  return ANALYTICS_EVENTS.has(event);
+}
+
+function eventKeyEntries(
+  events: ReadonlyArray<AnalyticsEvent>,
+  keys: ReadonlyArray<string>,
+): ReadonlyArray<readonly [AnalyticsEvent, ReadonlyArray<string>]> {
+  return events.map((event) => [event, keys]);
+}
+
+const EVENT_PROPERTY_KEYS = new Map<AnalyticsEvent, ReadonlyArray<string>>([
+  ...eventKeyEntries(
+    [AnalyticsEvent.AppOpened],
+    ["source", "launch_reason", "restored_tabs"],
+  ),
+  ...eventKeyEntries(
+    [
+      AnalyticsEvent.SignInStarted,
+      AnalyticsEvent.SignInApprovalOpened,
+      AnalyticsEvent.SignOutRequested,
+      AnalyticsEvent.HostUpdateStarted,
+      AnalyticsEvent.HostUpdateSnoozed,
+      AnalyticsEvent.SubscriptionRefreshed,
+      AnalyticsEvent.SubscriptionManagementOpened,
+      AnalyticsEvent.TaskOpened,
+      AnalyticsEvent.TaskRenamed,
+      AnalyticsEvent.WorkspacePrimaryChanged,
+      AnalyticsEvent.WorkspaceFileOpened,
+      AnalyticsEvent.WorktreeCreated,
+      AnalyticsEvent.WorktreeImported,
+      AnalyticsEvent.WorktreeSelected,
+      AnalyticsEvent.SetupScriptsOpened,
+      AnalyticsEvent.SetupScriptsRetryStarted,
+      AnalyticsEvent.ChatOpened,
+      AnalyticsEvent.TerminalAgentStopped,
+      AnalyticsEvent.VoiceEnabled,
+      AnalyticsEvent.VoiceDisabled,
+      AnalyticsEvent.VoiceDictationStarted,
+      AnalyticsEvent.UpdateDownloadStarted,
+      AnalyticsEvent.UpdateRestartRequested,
+      AnalyticsEvent.UpdateInstallGuidanceOpened,
+      AnalyticsEvent.ReportIssueOpened,
+      AnalyticsEvent.AppQuitRequested,
+    ],
+    ["source"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.HostSetupFailed, AnalyticsEvent.VoiceCaptureFailed],
+    ["source", "blocker"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.TaskCreationFailed],
+    ["source", "blocker", "mode"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.HostSetupStarted, AnalyticsEvent.HostSetupSucceeded],
+    ["reason"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.HostSelected], ["source", "host_kind"]),
+  ...eventKeyEntries(
+    [
+      AnalyticsEvent.SignInFailed,
+      AnalyticsEvent.HostUpdateFailed,
+      AnalyticsEvent.VoiceTranscriptionFailed,
+      AnalyticsEvent.UpdateFailed,
+    ],
+    ["blocker"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.OnboardingStarted, AnalyticsEvent.TaskCreated],
+    ["mode"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.OnboardingNavigated],
+    ["direction", "step"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.OnboardingCompleted, AnalyticsEvent.OnboardingSkipped],
+    ["last_step"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.OnboardingThemeChanged], ["theme"]),
+  ...eventKeyEntries([AnalyticsEvent.AgentGuideSaved], ["customized"]),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ProviderProfileLinkStarted],
+    ["source", "provider", "mode"],
+  ),
+  ...eventKeyEntries(
+    [
+      AnalyticsEvent.ProviderProfileLinkSucceeded,
+      AnalyticsEvent.ProviderProfileLinkCancelled,
+    ],
+    ["provider", "mode"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ProviderProfileLinkFailed],
+    ["provider", "mode", "blocker"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ProviderConfigurationChanged],
+    ["operation"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.AccountContextChanged], ["context"]),
+  ...eventKeyEntries(
+    [AnalyticsEvent.TaskCreationStarted],
+    ["source", "mode", "workspace_count"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.TaskDeleted],
+    ["source", "cleanup_worktrees"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.AttachmentAdded, AnalyticsEvent.AttachmentRemoved],
+    ["kind", "surface"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.AttachmentRejected],
+    ["kind", "surface", "blocker"],
+  ),
+  ...eventKeyEntries(
+    [
+      AnalyticsEvent.WorkspaceFolderAdded,
+      AnalyticsEvent.WorkspaceFolderRemoved,
+    ],
+    ["source", "workspace_kind"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.WorkspaceOpenedInEditor],
+    ["source", "editor"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.WorktreeDeleted], ["outcome", "blocker"]),
+  ...eventKeyEntries(
+    [AnalyticsEvent.WorktreesBulkDeleted],
+    ["requested_count", "succeeded_count", "failed_count"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.SetupScriptsSaved], ["script_count"]),
+  ...eventKeyEntries([AnalyticsEvent.ChatMessageSent], ["harness", "mode"]),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ChatForked],
+    ["source", "include_history"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ChatStopped, AnalyticsEvent.ChatBackgroundItemStopped],
+    ["scope"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ChatQueueItemSteered],
+    ["settings_changed"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ApprovalDecided, AnalyticsEvent.FileEditApprovalDecided],
+    ["decision"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.CheckpointRestored], ["revert_artifacts"]),
+  ...eventKeyEntries([AnalyticsEvent.InterviewAnswered], ["answer_count"]),
+  ...eventKeyEntries(
+    [AnalyticsEvent.FileChangesReverted],
+    ["file_count", "revert_artifacts"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.DiffOpened], ["source", "scope"]),
+  ...eventKeyEntries([AnalyticsEvent.HarnessChanged], ["from", "to"]),
+  ...eventKeyEntries([AnalyticsEvent.CommandExecuted], ["source", "command"]),
+  ...eventKeyEntries([AnalyticsEvent.HistoryNavigationUsed], ["direction"]),
+  ...eventKeyEntries(
+    [
+      AnalyticsEvent.TabCreated,
+      AnalyticsEvent.TabDuplicated,
+      AnalyticsEvent.TabSplit,
+      AnalyticsEvent.TabMoved,
+      AnalyticsEvent.TabClosed,
+      AnalyticsEvent.ShareAccessRevoked,
+    ],
+    ["target"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.ArtifactCreated], ["kind"]),
+  ...eventKeyEntries([AnalyticsEvent.ArtifactOpened], ["source", "kind"]),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ArtifactStatusChanged],
+    ["kind", "status"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ArtifactExported],
+    ["format", "artifact_count"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.CommentCreated, AnalyticsEvent.CommentReplied],
+    ["has_mention"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ShareInviteSent, AnalyticsEvent.ShareRoleChanged],
+    ["target", "role"],
+  ),
+  ...eventKeyEntries(
+    [
+      AnalyticsEvent.NotificationActivated,
+      AnalyticsEvent.NotificationMarkedRead,
+    ],
+    ["category"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.NotificationsCleared], ["scope"]),
+  ...eventKeyEntries([AnalyticsEvent.TerminalOpened], ["source", "kind"]),
+  ...eventKeyEntries(
+    [AnalyticsEvent.TerminalRenamed, AnalyticsEvent.TerminalKilled],
+    ["kind"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.TerminalAgentLaunched, AnalyticsEvent.TerminalAgentForked],
+    ["source", "harness"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.AgentStopped], ["source", "cascade"]),
+  ...eventKeyEntries(
+    [
+      AnalyticsEvent.VoiceDictationStopped,
+      AnalyticsEvent.VoiceTranscriptionSucceeded,
+    ],
+    ["duration_bucket"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.VoicePermissionResolved], ["permission"]),
+  ...eventKeyEntries([AnalyticsEvent.SettingsOpened], ["source", "section"]),
+  ...eventKeyEntries(
+    [AnalyticsEvent.SettingChanged],
+    ["source", "section", "setting"],
+  ),
+  ...eventKeyEntries(
+    [AnalyticsEvent.ReportIssueHandedOff],
+    ["outcome", "blocker"],
+  ),
+  ...eventKeyEntries([AnalyticsEvent.TabCloseBlocked], ["decision"]),
+]);
+
+const EVENTS_WITHOUT_PROPERTIES = new Set<AnalyticsEvent>([
+  AnalyticsEvent.SignInSucceeded,
+  AnalyticsEvent.HostUpdateSucceeded,
+  AnalyticsEvent.TaskShared,
+  AnalyticsEvent.ChatMessageEdited,
+  AnalyticsEvent.ChatMessageSuffixDeleted,
+  AnalyticsEvent.ChatQueuePaused,
+  AnalyticsEvent.ChatQueueResumed,
+  AnalyticsEvent.ChatQueueItemEdited,
+  AnalyticsEvent.ChatQueueItemReordered,
+  AnalyticsEvent.ChatQueueItemCancelled,
+  AnalyticsEvent.CommandPaletteOpened,
+  AnalyticsEvent.ArtifactRenamed,
+  AnalyticsEvent.ArtifactDeleted,
+  AnalyticsEvent.CommentEdited,
+  AnalyticsEvent.CommentResolved,
+  AnalyticsEvent.CommentReopened,
+  AnalyticsEvent.CommentDeleted,
+  AnalyticsEvent.NotificationCenterOpened,
+  AnalyticsEvent.NotificationsMarkedAllRead,
+  AnalyticsEvent.VoiceDictationCancelled,
+  AnalyticsEvent.UpdateDownloadSucceeded,
+]);
+
+function eventPropertyKeys(
+  event: AnalyticsEvent,
+): ReadonlyArray<string> | null {
+  const keys = EVENT_PROPERTY_KEYS.get(event);
+  if (keys !== undefined) return keys;
+  return EVENTS_WITHOUT_PROPERTIES.has(event) ? [] : null;
+}
+
+export function analyticsEventContractIsComplete(): boolean {
+  return Object.values(AnalyticsEvent).every((event) => {
+    const hasProperties = EVENT_PROPERTY_KEYS.has(event);
+    const hasNoProperties = EVENTS_WITHOUT_PROPERTIES.has(event);
+    const keys = eventPropertyKeys(event);
+    return (
+      hasProperties !== hasNoProperties &&
+      keys !== null &&
+      keys.every((key) => analyticsPropertyHasValidator(event, key))
+    );
+  });
+}
+
+const EXACT_PROPERTY_VALUES: {
+  readonly [key: string]: ReadonlySet<string> | undefined;
+} = {
+  category: new Set(["app-local", "global", "host"]),
+  command: ANALYTICS_COMMANDS,
+  context: new Set(["personal", "team"]),
+  operation: new Set([
+    "ambient_drift",
+    "api_key",
+    "custom_path",
+    "enabled",
+    "env_override",
+    "profile",
+    "selection",
+    "terminal_args",
+  ]),
+  duration_bucket: new Set(["10_to_30s", "over_30s", "under_10s"]),
+  editor: new Set(["cursor", "vscode", "windsurf", "zed"]),
+  format: new Set(["markdown", "pdf"]),
+  from: ANALYTICS_HARNESSES,
+  harness: ANALYTICS_HARNESSES,
+  host_kind: new Set(["local", "remote"]),
+  launch_reason: new Set(["normal", "update_restart"]),
+  last_step: ANALYTICS_ONBOARDING_STEPS,
+  permission: new Set(["denied", "granted", "unavailable"]),
+  provider: ANALYTICS_PROVIDERS,
+  role: new Set(["editor", "owner", "viewer"]),
+  section: ANALYTICS_SETTINGS_SECTIONS,
+  setting: ANALYTICS_SETTINGS,
+  source: ANALYTICS_SOURCES,
+  step: ANALYTICS_ONBOARDING_STEPS,
+  surface: new Set(["chat", "draft"]),
+  theme: ANALYTICS_THEMES,
+  to: ANALYTICS_HARNESSES,
+  workspace_kind: new Set(["local", "unknown", "worktree"]),
+};
+
+function eventValueEntries(
+  events: ReadonlyArray<AnalyticsEvent>,
+  key: string,
+  values: ReadonlySet<string>,
+): ReadonlyArray<readonly [string, ReadonlySet<string>]> {
+  return events.map((event) => [`${event}:${key}`, values]);
+}
+
+const EVENT_EXACT_PROPERTY_VALUES = new Map<string, ReadonlySet<string>>([
+  ...eventValueEntries(
+    [AnalyticsEvent.OnboardingStarted],
+    "mode",
+    new Set(["first_run", "replay"]),
+  ),
+  ...eventValueEntries(
+    [
+      AnalyticsEvent.ProviderProfileLinkStarted,
+      AnalyticsEvent.ProviderProfileLinkSucceeded,
+      AnalyticsEvent.ProviderProfileLinkFailed,
+      AnalyticsEvent.ProviderProfileLinkCancelled,
+    ],
+    "mode",
+    new Set(["create", "reauth"]),
+  ),
+  ...eventValueEntries(
+    [
+      AnalyticsEvent.TaskCreationStarted,
+      AnalyticsEvent.TaskCreated,
+      AnalyticsEvent.TaskCreationFailed,
+    ],
+    "mode",
+    new Set(["chat", "terminal_agent"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.ChatMessageSent],
+    "mode",
+    new Set(["epic", "regular"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.HostSetupStarted, AnalyticsEvent.HostSetupSucceeded],
+    "reason",
+    new Set(["launch", "recovery", "reinstall", "update"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.ApprovalDecided, AnalyticsEvent.FileEditApprovalDecided],
+    "decision",
+    new Set(["approved", "denied"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.TabCloseBlocked],
+    "decision",
+    new Set(["cancel", "discard"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.OnboardingNavigated],
+    "direction",
+    new Set(["back", "continue"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.HistoryNavigationUsed],
+    "direction",
+    new Set(["back", "forward"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.ChatStopped],
+    "scope",
+    new Set(["current", "with_children"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.ChatBackgroundItemStopped],
+    "scope",
+    new Set(["all", "one"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.DiffOpened],
+    "scope",
+    new Set(["all", "file"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.NotificationsCleared],
+    "scope",
+    new Set(["all", "read"]),
+  ),
+  ...eventValueEntries(
+    [
+      AnalyticsEvent.AttachmentAdded,
+      AnalyticsEvent.AttachmentRemoved,
+      AnalyticsEvent.AttachmentRejected,
+    ],
+    "kind",
+    new Set(["image"]),
+  ),
+  ...eventValueEntries(
+    [
+      AnalyticsEvent.ArtifactCreated,
+      AnalyticsEvent.ArtifactOpened,
+      AnalyticsEvent.ArtifactStatusChanged,
+    ],
+    "kind",
+    new Set(["review", "spec", "story", "ticket"]),
+  ),
+  ...eventValueEntries(
+    [
+      AnalyticsEvent.TerminalOpened,
+      AnalyticsEvent.TerminalRenamed,
+      AnalyticsEvent.TerminalKilled,
+    ],
+    "kind",
+    new Set(["agent", "shell"]),
+  ),
+  ...eventValueEntries(
+    [
+      AnalyticsEvent.TabCreated,
+      AnalyticsEvent.TabDuplicated,
+      AnalyticsEvent.TabSplit,
+      AnalyticsEvent.TabMoved,
+      AnalyticsEvent.TabClosed,
+    ],
+    "target",
+    ANALYTICS_TARGETS,
+  ),
+  ...eventValueEntries(
+    [
+      AnalyticsEvent.ShareInviteSent,
+      AnalyticsEvent.ShareRoleChanged,
+      AnalyticsEvent.ShareAccessRevoked,
+    ],
+    "target",
+    new Set(["person", "team"]),
+  ),
+  ...eventValueEntries(
+    [AnalyticsEvent.WorktreeDeleted, AnalyticsEvent.ReportIssueHandedOff],
+    "outcome",
+    new Set(["failed", "succeeded"]),
+  ),
+]);
+
+const BOOLEAN_PROPERTY_KEYS = new Set<string>([
+  "cascade",
+  "cleanup_worktrees",
+  "customized",
+  "has_mention",
+  "include_history",
+  "restored_tabs",
+  "revert_artifacts",
+  "settings_changed",
+]);
+
+const COUNT_PROPERTY_KEYS = new Set<string>([
+  "answer_count",
+  "artifact_count",
+  "failed_count",
+  "file_count",
+  "requested_count",
+  "script_count",
+  "succeeded_count",
+  "workspace_count",
+]);
+
+function analyticsPropertyHasValidator(
+  event: AnalyticsEvent,
+  key: string,
+): boolean {
+  return (
+    key === "blocker" ||
+    key === "status" ||
+    BOOLEAN_PROPERTY_KEYS.has(key) ||
+    COUNT_PROPERTY_KEYS.has(key) ||
+    EVENT_EXACT_PROPERTY_VALUES.has(`${event}:${key}`) ||
+    EXACT_PROPERTY_VALUES[key] !== undefined
+  );
+}
+
+function isAnalyticsStatus(value: unknown): boolean {
+  return value === 0 || value === 1 || value === 2;
+}
+
+function isAnalyticsCount(value: unknown): boolean {
+  if (!Number.isInteger(value)) return false;
+  const count = Number(value);
+  return count >= 0 && count <= 10_000;
+}
+
+function isAnalyticsPropertyValue(
+  event: AnalyticsEvent,
+  key: string,
+  value: unknown,
+): value is AnalyticsPropertyValue {
+  if (key === "blocker") {
+    if (value === null) {
+      return (
+        event === AnalyticsEvent.WorktreeDeleted ||
+        event === AnalyticsEvent.ReportIssueHandedOff
+      );
+    }
+    return typeof value === "string" && ANALYTICS_BLOCKERS.has(value);
+  }
+  if (key === "status") return isAnalyticsStatus(value);
+  if (BOOLEAN_PROPERTY_KEYS.has(key)) return typeof value === "boolean";
+  if (COUNT_PROPERTY_KEYS.has(key)) return isAnalyticsCount(value);
+  const allowed =
+    EVENT_EXACT_PROPERTY_VALUES.get(`${event}:${key}`) ??
+    EXACT_PROPERTY_VALUES[key];
+  return (
+    typeof value === "string" && allowed !== undefined && allowed.has(value)
+  );
+}
+
+function analyticsPropertiesAreRelationallyValid(
+  event: AnalyticsEvent,
+  properties: Record<string, unknown>,
+): boolean {
+  if (
+    event === AnalyticsEvent.WorktreeDeleted ||
+    event === AnalyticsEvent.ReportIssueHandedOff
+  ) {
+    return (
+      (properties.outcome === "succeeded" && properties.blocker === null) ||
+      (properties.outcome === "failed" &&
+        typeof properties.blocker === "string" &&
+        ANALYTICS_BLOCKERS.has(properties.blocker))
+    );
+  }
+  if (event === AnalyticsEvent.WorktreesBulkDeleted) {
+    return (
+      Number(properties.requested_count) ===
+      Number(properties.succeeded_count) + Number(properties.failed_count)
+    );
+  }
+  return true;
+}
+
+export function sanitizeAnalyticsProperties(
+  event: AnalyticsEvent,
+  properties: object | null,
+): Record<string, AnalyticsPropertyValue> | null {
+  const record: Record<string, unknown> = { ...properties };
+  const expectedKeys = eventPropertyKeys(event);
+  if (expectedKeys === null) return null;
+  if (
+    expectedKeys.some(
+      (key) =>
+        !(key in record) || !isAnalyticsPropertyValue(event, key, record[key]),
+    )
+  ) {
+    return null;
+  }
+  if (!analyticsPropertiesAreRelationallyValid(event, record)) return null;
+  return expectedKeys.reduce<Record<string, AnalyticsPropertyValue>>(
+    (sanitized, key) => {
+      const value = record[key];
+      return isAnalyticsPropertyValue(event, key, value)
+        ? { ...sanitized, [key]: value }
+        : sanitized;
+    },
+    {},
+  );
+}
+
+function isSafeIngestionToken(value: unknown): value is string {
+  return typeof value === "string" && /^phc_[a-zA-Z0-9_-]{1,252}$/.test(value);
+}
+
+function isSafeOpaqueIdentity(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    )
+  );
+}
+
+function safeIngestionProperties(
+  properties: Record<string, unknown>,
+  includeAnonymousId: boolean,
+): Record<string, string> | null {
+  if (
+    !isSafeIngestionToken(properties.token) ||
+    !isSafeOpaqueIdentity(properties.distinct_id)
+  ) {
+    return null;
+  }
+  if (includeAnonymousId) {
+    if (!isSafeOpaqueIdentity(properties.$anon_distinct_id)) return null;
+    return {
+      token: properties.token,
+      distinct_id: properties.distinct_id,
+      $anon_distinct_id: properties.$anon_distinct_id,
+    };
+  }
+  return { token: properties.token, distinct_id: properties.distinct_id };
+}
+
+function safeAppGlobals(
+  properties: Record<string, unknown>,
+): Record<string, AnalyticsPropertyValue> | null {
+  const appVersion = properties.app_version;
+  if (
+    properties.app !== "gui-app" ||
+    (appVersion !== null &&
+      (typeof appVersion !== "string" ||
+        !/^[a-zA-Z0-9][a-zA-Z0-9.+_-]{0,63}$/.test(appVersion))) ||
+    typeof properties.platform !== "string" ||
+    !new Set(["linux", "macos", "other", "windows"]).has(properties.platform) ||
+    typeof properties.release_channel !== "string" ||
+    !new Set(["development", "other", "production"]).has(
+      properties.release_channel,
+    )
+  ) {
+    return null;
+  }
+  return {
+    app: "gui-app",
+    app_version: appVersion,
+    platform: String(properties.platform),
+    release_channel: String(properties.release_channel),
+  };
+}
+
+/**
+ * PostHog session/window ids are SDK-generated opaque UUIDs. Passing them
+ * through keeps session-based analyses (paths, session funnels, duration)
+ * working without exposing any user content.
+ */
+function safeSessionProperties(
+  properties: Record<string, unknown>,
+): Record<string, string> {
+  const sessionId = properties.$session_id;
+  const windowId = properties.$window_id;
+  return {
+    ...(isSafeOpaqueIdentity(sessionId) ? { $session_id: sessionId } : {}),
+    ...(isSafeOpaqueIdentity(windowId) ? { $window_id: windowId } : {}),
+  };
+}
+
+function captureResult(
+  event: string,
+  properties: Record<string, AnalyticsPropertyValue>,
+  timestamp: CaptureResult["timestamp"],
+): CaptureResult {
+  const uuid: string = crypto.randomUUID();
+  if (timestamp === undefined) return { uuid, event, properties };
+  return { uuid, event, properties, timestamp };
+}
+
+/**
+ * Person properties are limited to the user's email, deliberately sent so
+ * PostHog dashboards can look a user up. Everything else the SDK stages in
+ * `$set`/`$set_once` (referrer, campaign, URL data) is dropped.
+ */
+function safePersonProperties(
+  setProperties: Record<string, unknown> | undefined,
+): Record<string, string> | null {
+  const email = setProperties === undefined ? undefined : setProperties.email;
+  return typeof email === "string" && /^[^\s@]{1,64}@[^\s@]{1,254}$/.test(email)
+    ? { email }
+    : null;
+}
+
+/**
+ * A repeat `identify()` for an already-identified distinct id makes the SDK
+ * emit a `$set` event instead of `$identify`; the staged person properties
+ * then live in the event's `properties.$set` rather than the result's
+ * top-level `$set`. Read both so email refreshes survive either shape.
+ */
+function stagedPersonProperties(
+  result: CaptureResult,
+  rawProperties: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (result.$set !== undefined) return result.$set;
+  const inProperties = rawProperties.$set;
+  return inProperties !== null && typeof inProperties === "object"
+    ? Object.fromEntries(Object.entries(inProperties))
+    : undefined;
+}
+
+export function sanitizePostHogCaptureResult(
+  result: CaptureResult | null,
+): CaptureResult | null {
+  if (result === null) return null;
+  const rawProperties: Record<string, unknown> = { ...result.properties };
+  if (result.event === "$identify") {
+    const identity = safeIngestionProperties(rawProperties, true);
+    if (identity === null) return null;
+    const sanitized = captureResult("$identify", identity, result.timestamp);
+    const personProperties = safePersonProperties(
+      stagedPersonProperties(result, rawProperties),
+    );
+    return personProperties === null
+      ? sanitized
+      : { ...sanitized, $set: personProperties };
+  }
+  if (result.event === "$set") {
+    const identity = safeIngestionProperties(rawProperties, false);
+    const personProperties = safePersonProperties(
+      stagedPersonProperties(result, rawProperties),
+    );
+    if (identity === null || personProperties === null) return null;
+    return {
+      ...captureResult("$set", identity, result.timestamp),
+      $set: personProperties,
+    };
+  }
+  if (!isAnalyticsEvent(result.event)) return null;
+  const identity = safeIngestionProperties(rawProperties, false);
+  const globals = safeAppGlobals(rawProperties);
+  const session = safeSessionProperties(rawProperties);
+  const eventProperties = sanitizeAnalyticsProperties(
+    result.event,
+    rawProperties,
+  );
+  if (identity === null || globals === null || eventProperties === null) {
+    return null;
+  }
+  return captureResult(
+    result.event,
+    { ...identity, ...globals, ...session, ...eventProperties },
+    result.timestamp,
+  );
+}
+
+function analyticsErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name} ${error.message}`.toLowerCase();
+  }
+  if (typeof error === "string") return error.toLowerCase();
+  if (error === null || typeof error !== "object") return "";
+  const record: Record<string, unknown> = { ...error };
+  return [record.name, record.code, record.message]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+}
+
+const ANALYTICS_BLOCKER_PATTERNS: ReadonlyArray<{
+  readonly blocker: AnalyticsBlocker;
+  readonly pattern: RegExp;
+}> = [
+  { blocker: "cancelled", pattern: /cancel|abort/ },
+  { blocker: "rate_limit", pattern: /rate.?limit|too many requests|quota/ },
+  { blocker: "authentication", pattern: /unauth|sign.?in|login|token|401/ },
+  {
+    blocker: "authorization",
+    pattern: /forbidden|not allowed|access denied|403/,
+  },
+  {
+    blocker: "permission",
+    pattern: /permission|microphone access|eacces|eperm/,
+  },
+  { blocker: "timeout", pattern: /timeout|timed out/ },
+  {
+    blocker: "host_unavailable",
+    pattern: /host.*unavailable|host.*unreachable/,
+  },
+  {
+    blocker: "network",
+    pattern:
+      /offline|network|not connected|econn|socket|fetch failed|connection/,
+  },
+  {
+    blocker: "provider_unavailable",
+    pattern: /provider.*unavailable|provider.*missing/,
+  },
+  { blocker: "not_found", pattern: /not found|enoent|404/ },
+  { blocker: "conflict", pattern: /conflict|already exists|409/ },
+  { blocker: "invalid_input", pattern: /invalid|validation|bad request|400/ },
+  { blocker: "migration", pattern: /migration|upgrade required/ },
+  { blocker: "setup", pattern: /setup|bootstrap/ },
+  { blocker: "unsupported", pattern: /unsupported|not supported/ },
+];
+
+const RPC_ERROR_BLOCKERS: Readonly<Record<string, AnalyticsBlocker>> = {
+  DOWNGRADE_UNSUPPORTED: "host_incompatible",
+  E_HOST_UNSUPPORTED: "unsupported",
+  FORBIDDEN: "authorization",
+  INCOMPATIBLE: "host_incompatible",
+  PROVIDER_DISABLED: "provider_unavailable",
+  RPC_ERROR: "host_unavailable",
+  SENDER_TUI_UNSUPPORTED: "unsupported",
+  TERMINAL_ID_TAKEN: "conflict",
+  UNAUTHORIZED: "authentication",
+  WORKSPACE_BINDING_REQUIRED: "invalid_input",
+  WORKTREE_BUSY: "conflict",
+  WORKTREE_MISSING: "not_found",
+  WORKTREE_REBIND_BLOCKED: "conflict",
+  WORKTREE_REMOVE_LAST_ENTRY: "conflict",
+  WORKTREE_SETUP_CANCELLED: "cancelled",
+  WORKTREE_SETUP_FAILED: "setup",
+};
+
+function typedAnalyticsBlocker(error: unknown): AnalyticsBlocker | null {
+  if (error === null || typeof error !== "object" || !("code" in error)) {
+    return null;
+  }
+  const code = error.code;
+  return typeof code === "string" ? (RPC_ERROR_BLOCKERS[code] ?? null) : null;
+}
+
+export function analyticsBlockerFromError(error: unknown): AnalyticsBlocker {
+  const typedBlocker = typedAnalyticsBlocker(error);
+  if (typedBlocker !== null) return typedBlocker;
+  const text = analyticsErrorText(error);
+  return (
+    ANALYTICS_BLOCKER_PATTERNS.find(({ pattern }) => pattern.test(text))
+      ?.blocker ?? "unknown"
+  );
+}
+
+function analyticsPlatform(): "linux" | "macos" | "other" | "windows" {
+  const platform = navigator.platform.toLowerCase();
+  if (platform.includes("mac")) return "macos";
+  if (platform.includes("win")) return "windows";
+  if (platform.includes("linux")) return "linux";
+  return "other";
+}
+
+function analyticsReleaseChannel(): "development" | "other" | "production" {
+  if (import.meta.env.MODE === "development") return "development";
+  if (import.meta.env.MODE === "production") return "production";
+  return "other";
 }
 
 export class Analytics {
   private static instance: Analytics | null = null;
-  private readonly enabled: boolean;
+  private enabled: boolean;
   private readonly key: string | undefined;
-  private readonly apiHost: string = "https://us.i.posthog.com";
+  private identifiedUserId: string | null = null;
 
   private constructor() {
     this.key = import.meta.env.VITE_POSTHOG_KEY;
@@ -25,11 +1719,38 @@ export class Analytics {
 
     if (!this.enabled || this.key === undefined) return;
 
-    posthog.init(this.key, { api_host: this.apiHost });
-    posthog.register({
-      app: "gui-app",
-      app_version: import.meta.env.VITE_APP_VERSION ?? null,
-    });
+    const key = this.key;
+    if (this.guarded(() => posthog.init(key, POSTHOG_CONFIG)) === null) {
+      // A storage/security failure at init permanently disables analytics for
+      // this process; the app must never pay for telemetry.
+      this.enabled = false;
+      return;
+    }
+    this.registerGlobals();
+  }
+
+  /**
+   * Telemetry is best-effort and many call sites run product-critical work
+   * after a capture, so no SDK exception may escape this adapter.
+   */
+  private guarded<Result>(operation: () => Result): Result | null {
+    if (!this.enabled) return null;
+    try {
+      return operation();
+    } catch {
+      return null;
+    }
+  }
+
+  private registerGlobals(): void {
+    this.guarded(() =>
+      posthog.register({
+        app: "gui-app",
+        app_version: import.meta.env.VITE_APP_VERSION ?? null,
+        platform: analyticsPlatform(),
+        release_channel: analyticsReleaseChannel(),
+      }),
+    );
   }
 
   static getInstance(): Analytics {
@@ -37,18 +1758,57 @@ export class Analytics {
     return Analytics.instance;
   }
 
-  identify(userId: string, properties: EventProperties): void {
-    if (!this.enabled) return;
-    posthog.identify(userId, properties ?? undefined);
+  /**
+   * The SDK persists identity across renderer restarts, so the in-memory id
+   * alone cannot see a cross-account transition on a cold start. Anonymous
+   * state is `distinct_id === $device_id` (the SDK's own proxy for it).
+   */
+  private persistedIdentifiedUserId(): string | null {
+    const distinctId = this.guarded(() => posthog.get_distinct_id());
+    if (typeof distinctId !== "string") return null;
+    const deviceId = this.guarded((): string | null => {
+      const value: unknown = posthog.get_property("$device_id");
+      return typeof value === "string" ? value : null;
+    });
+    return distinctId === deviceId ? null : distinctId;
+  }
+
+  identify(userId: string, email: string | null): boolean {
+    if (!isSafeOpaqueIdentity(userId)) {
+      this.identifiedUserId = null;
+      this.guarded(() => posthog.reset());
+      this.registerGlobals();
+      return false;
+    }
+    const knownUserId =
+      this.identifiedUserId ?? this.persistedIdentifiedUserId();
+    if (knownUserId !== null && knownUserId !== userId) {
+      // Cross-account transition (including a cold start on another account's
+      // persisted state): drop the previous identity and session before the
+      // new identify so the two accounts' streams cannot blend.
+      this.guarded(() => posthog.reset());
+      this.registerGlobals();
+    }
+    this.guarded(() =>
+      posthog.identify(userId, email === null ? undefined : { email }),
+    );
+    this.identifiedUserId = userId;
+    return true;
   }
 
   reset(): void {
-    if (!this.enabled) return;
-    posthog.reset();
+    this.identifiedUserId = null;
+    this.guarded(() => posthog.reset());
+    this.registerGlobals();
   }
 
-  track(event: AnalyticsEvent, properties: EventProperties): void {
-    if (!this.enabled) return;
-    posthog.capture(event, properties ?? undefined);
+  track<Event extends AnalyticsEvent>(
+    event: Event,
+    properties: AnalyticsEventProperties[Event],
+  ): boolean {
+    const safeProperties = sanitizeAnalyticsProperties(event, properties);
+    if (safeProperties === null) return false;
+    this.guarded(() => posthog.capture(event, safeProperties));
+    return true;
   }
 }

--- a/clients/gui-app/src/lib/app-update-analytics.ts
+++ b/clients/gui-app/src/lib/app-update-analytics.ts
@@ -39,3 +39,8 @@ export function settleUpdateDownloadOutcome(
     blocker: analyticsBlockerFromError(errorMessage),
   });
 }
+
+/** Test-only: resets the window-local in-flight flag between tests. */
+export function __resetAppUpdateAnalyticsForTests(): void {
+  userDownloadInFlight = false;
+}

--- a/clients/gui-app/src/lib/app-update-analytics.ts
+++ b/clients/gui-app/src/lib/app-update-analytics.ts
@@ -1,0 +1,41 @@
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsBlockerFromError,
+  type AnalyticsSource,
+} from "@/lib/analytics";
+
+/**
+ * Binds update download outcomes to THIS window's user-initiated download.
+ *
+ * Update snapshots are broadcast to every window and replayed to late
+ * subscribers, so emitting `update_download_succeeded` / `update_failed` from
+ * snapshot processing double-counts (a second window replays the same
+ * `ready`). Instead, the download gestures arm a single window-local flow
+ * flag, and the first terminal snapshot after it settles the flow exactly
+ * once. A download that outlives this renderer loses its outcome event -
+ * accepted best-effort.
+ */
+let userDownloadInFlight = false;
+
+export function trackUpdateDownloadStarted(source: AnalyticsSource): void {
+  userDownloadInFlight = true;
+  Analytics.getInstance().track(AnalyticsEvent.UpdateDownloadStarted, {
+    source,
+  });
+}
+
+export function settleUpdateDownloadOutcome(
+  status: "error" | "ready",
+  errorMessage: string | null,
+): void {
+  if (!userDownloadInFlight) return;
+  userDownloadInFlight = false;
+  if (status === "ready") {
+    Analytics.getInstance().track(AnalyticsEvent.UpdateDownloadSucceeded, null);
+    return;
+  }
+  Analytics.getInstance().track(AnalyticsEvent.UpdateFailed, {
+    blocker: analyticsBlockerFromError(errorMessage),
+  });
+}

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -29,6 +29,11 @@ import {
   type AuthStatus,
 } from "@/stores/auth/auth-store";
 import { normalizeAvatarUrl } from "@/lib/avatar-url";
+import {
+  Analytics,
+  AnalyticsEvent,
+  type AnalyticsBlocker,
+} from "@/lib/analytics";
 import { projectShareableTeams } from "@/hooks/epic/use-epic-shareable-teams";
 import { onWakeReconnect } from "@/lib/host/wake-reconnect";
 import { appLogger, describeLogError } from "@/lib/logger";
@@ -1138,6 +1143,10 @@ export class AuthService {
 
       this.setLastError(null);
       this.applySignedIn(accepted.token, outcome.user, undefined);
+      // Terminal success of an interactive device-flow attempt (this method's
+      // only caller is `finalizeDeviceResult`). Passive token restores use a
+      // different path and deliberately never count as sign-ins.
+      Analytics.getInstance().track(AnalyticsEvent.SignInSucceeded, null);
       return true;
     }
     // Validation `rejected` OR `network-error`: do not persist. Surface
@@ -1592,6 +1601,12 @@ export class AuthService {
     appLogger.warn("[auth] applying auth failure", {
       errorCode: classifyAuthFailureForLog(error),
     });
+    // Every caller of this method is a terminal failure of an interactive
+    // sign-in attempt (launch failure, device denial/expiry, token rejection),
+    // so this is the one seam where `sign_in_failed` is emitted.
+    Analytics.getInstance().track(AnalyticsEvent.SignInFailed, {
+      blocker: SIGN_IN_FAILURE_BLOCKERS[error] ?? "unknown",
+    });
     this.setLastError(error);
     this.applySignedOut();
     await this.clearStoredAuth();
@@ -1716,3 +1731,10 @@ function deviceFailureError(
       return AUTH_ERROR_SIGN_IN_FAILED;
   }
 }
+
+const SIGN_IN_FAILURE_BLOCKERS: Readonly<Record<string, AnalyticsBlocker>> = {
+  [AUTH_ERROR_LAUNCH_FAILED]: "network",
+  [AUTH_ERROR_DEVICE_DENIED]: "authorization",
+  [AUTH_ERROR_DEVICE_EXPIRED]: "timeout",
+  [AUTH_ERROR_SIGN_IN_FAILED]: "authentication",
+};

--- a/clients/gui-app/src/lib/commands/actions/__tests__/new-chat.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/new-chat.test.ts
@@ -8,6 +8,7 @@ import {
   expect,
   it,
   vi,
+  type MockInstance,
 } from "vitest";
 import type { CreateChatMutationInput } from "@/hooks/epic/use-epic-chat-mutations";
 import {
@@ -182,14 +183,18 @@ function nestedFocusRecorder(): {
 }
 
 describe("new chat command actions", () => {
+  let track: MockInstance<Analytics["track"]>;
+
   beforeEach(() => {
     resetCanvasStore();
     registryMock.reset();
+    track = vi.spyOn(Analytics.getInstance(), "track");
   });
 
   afterEach(() => {
     resetCanvasStore();
     registryMock.reset();
+    vi.restoreAllMocks();
   });
 
   it("creates active-tile chats through epic.createChat and queues the host chat id", () => {
@@ -428,7 +433,6 @@ describe("new chat command actions", () => {
   });
 
   it("opens the host-created chat into the explicit target group (opener path)", () => {
-    const track = vi.spyOn(Analytics.getInstance(), "track");
     const sourceGroupId = seedActiveGroup();
     const targetGroupId = useEpicCanvasStore
       .getState()
@@ -460,10 +464,6 @@ describe("new chat command actions", () => {
   });
 
   it("abandons the open (and emits nothing) when the projected target disappears", () => {
-    // vi.spyOn returns the SAME accumulated spy across tests in this file, so
-    // clear it - the absence assertion below must only see THIS test's calls.
-    const track = vi.spyOn(Analytics.getInstance(), "track");
-    track.mockClear();
     const sourceGroupId = seedActiveGroup();
     const targetGroupId = useEpicCanvasStore
       .getState()

--- a/clients/gui-app/src/lib/commands/actions/__tests__/new-chat.test.ts
+++ b/clients/gui-app/src/lib/commands/actions/__tests__/new-chat.test.ts
@@ -28,6 +28,7 @@ import type {
   EpicCanvasState,
   EpicCanvasTileRef,
 } from "@/stores/epics/canvas/types";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /** Every open tab's payload across all panes, resolved through the canvas. */
 function allTabRefs(
@@ -199,6 +200,7 @@ describe("new chat command actions", () => {
       epicId: EPIC_ID,
       tabId: TAB_ID,
       hostId: "test-host",
+      source: "direct_ui",
       worktreeIntent: null,
       settings: null,
       createChat: createChat.createChat,
@@ -224,6 +226,7 @@ describe("new chat command actions", () => {
         tabId: TAB_ID,
         chatId: "host-chat",
         hostId: "test-host",
+        source: "direct_ui",
       },
     ]);
   });
@@ -236,6 +239,7 @@ describe("new chat command actions", () => {
       epicId: EPIC_ID,
       tabId: TAB_ID,
       hostId: "test-host",
+      source: "direct_ui",
       worktreeIntent: SEEDED_WORKTREE_INTENT,
       settings: null,
       createChat: createChat.createChat,
@@ -256,6 +260,7 @@ describe("new chat command actions", () => {
       tabId: TAB_ID,
       chatId: "host-chat",
       hostId: "test-host",
+      source: "direct_ui",
     });
 
     expect(
@@ -293,6 +298,7 @@ describe("new chat command actions", () => {
         tabId: TAB_ID,
         chatId: "host-chat",
         hostId: "test-host",
+        source: "direct_ui",
       },
       navigateNestedFocus: navigation.navigateNestedFocus,
     });
@@ -341,6 +347,7 @@ describe("new chat command actions", () => {
         tabId: TAB_ID,
         chatId: "host-chat",
         hostId: "test-host",
+        source: "direct_ui",
       });
 
       expect(registryMock.listenerCount()).toBe(1);
@@ -368,6 +375,7 @@ describe("new chat command actions", () => {
         tabId: TAB_ID,
         chatId: "host-chat",
         hostId: "test-host",
+        source: "direct_ui",
       });
 
       expect(registryMock.listenerCount()).toBe(1);
@@ -383,6 +391,7 @@ describe("new chat command actions", () => {
         epicId: EPIC_ID,
         tabId: TAB_ID,
         hostId: "test-host",
+        source: "direct_ui",
         worktreeIntent: null,
         settings: null,
         createChat: createChat.createChat,
@@ -404,6 +413,7 @@ describe("new chat command actions", () => {
         epicId: EPIC_ID,
         tabId: TAB_ID,
         hostId: "test-host",
+        source: "direct_ui",
         worktreeIntent: null,
         settings: null,
         createChat: createChat.createChat,
@@ -418,6 +428,7 @@ describe("new chat command actions", () => {
   });
 
   it("opens the host-created chat into the explicit target group (opener path)", () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
     const sourceGroupId = seedActiveGroup();
     const targetGroupId = useEpicCanvasStore
       .getState()
@@ -431,6 +442,7 @@ describe("new chat command actions", () => {
       chatId: "host-chat",
       groupId: targetGroupId,
       hostId: "test-host",
+      source: "command_palette",
     });
     registryMock.projectChat({ id: "host-chat", title: "Host chat" });
 
@@ -442,6 +454,47 @@ describe("new chat command actions", () => {
     expect(paneTabRefs(canvas, target).map((tab) => tab.id)).toEqual([
       "host-chat",
     ]);
+    expect(track).toHaveBeenCalledWith(AnalyticsEvent.ChatOpened, {
+      source: "command_palette",
+    });
+  });
+
+  it("abandons the open (and emits nothing) when the projected target disappears", () => {
+    // vi.spyOn returns the SAME accumulated spy across tests in this file, so
+    // clear it - the absence assertion below must only see THIS test's calls.
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    track.mockClear();
+    const sourceGroupId = seedActiveGroup();
+    const targetGroupId = useEpicCanvasStore
+      .getState()
+      .splitPaneEmptyRightInTab(TAB_ID, sourceGroupId);
+    if (targetGroupId === null) throw new Error("expected a target group");
+    openCreatedChatWhenProjected({
+      kind: "target-group",
+      epicId: EPIC_ID,
+      tabId: TAB_ID,
+      chatId: "host-chat",
+      groupId: targetGroupId,
+      hostId: "test-host",
+      source: "command_palette",
+    });
+
+    useEpicCanvasStore.getState().closeCanvasPane(TAB_ID, targetGroupId);
+    registryMock.projectChat({ id: "host-chat", title: "Host chat" });
+
+    // Pre-analytics product behavior: the open is attempted exactly once and
+    // abandoned when its pane is gone - no fallback pane, no chat_opened.
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
+    const source = findPaneById(canvas?.root ?? null, sourceGroupId);
+    if (canvas === undefined || source === null) {
+      throw new Error("expected the original pane to survive");
+    }
+    expect(paneTabRefs(canvas, source).map((tab) => tab.id)).not.toContain(
+      "host-chat",
+    );
+    expect(track).not.toHaveBeenCalledWith(AnalyticsEvent.ChatOpened, {
+      source: "command_palette",
+    });
   });
 
   it("splits with the host-created chat id after projection", () => {
@@ -455,6 +508,7 @@ describe("new chat command actions", () => {
       targetGroupId: activeGroupId,
       position: "bottom",
       hostId: "test-host",
+      source: "direct_ui",
     });
     registryMock.projectChat({ id: "host-chat", title: "" });
 

--- a/clients/gui-app/src/lib/commands/actions/clone-chat-on-host-switch.ts
+++ b/clients/gui-app/src/lib/commands/actions/clone-chat-on-host-switch.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/commands/actions/new-chat";
 import { resolveClonedChatSettings } from "@/lib/commands/actions/resolve-cloned-chat-settings";
 import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /**
  * Clone-not-migrate flow for switching a chat tab's bound host: chat tabs
@@ -58,14 +59,20 @@ export function cloneChatOnHostSwitch(
       hostId: args.targetHostId,
       worktreeIntent: null,
       settings,
+      source: "direct_ui",
       createChat: args.createChat,
-      openWhenProjected: (intent) =>
-        args.navigateNestedFocus === null
+      openWhenProjected: (intent) => {
+        Analytics.getInstance().track(AnalyticsEvent.ChatForked, {
+          source: "direct_ui",
+          include_history: true,
+        });
+        return args.navigateNestedFocus === null
           ? openCreatedChatWhenProjected(intent)
           : openCreatedChatWhenProjectedWithNavigation({
               intent,
               navigateNestedFocus: args.navigateNestedFocus,
-            }),
+            });
+      },
     });
   });
 

--- a/clients/gui-app/src/lib/commands/actions/duplicate-tab.ts
+++ b/clients/gui-app/src/lib/commands/actions/duplicate-tab.ts
@@ -1,10 +1,14 @@
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { EpicViewTab } from "@/stores/epics/canvas/types";
 import { copyEpicSidebarTabState } from "@/lib/epics/copy-epic-sidebar-tab-state";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export function duplicateEpicTab(tabId: string): EpicViewTab | null {
   const newTabId = useEpicCanvasStore.getState().duplicateTab(tabId);
   if (newTabId === null) return null;
+  Analytics.getInstance().track(AnalyticsEvent.TabDuplicated, {
+    target: "task",
+  });
   copyEpicSidebarTabState(tabId, newTabId);
   return useEpicCanvasStore.getState().tabsById[newTabId] ?? null;
 }

--- a/clients/gui-app/src/lib/commands/actions/new-chat.ts
+++ b/clients/gui-app/src/lib/commands/actions/new-chat.ts
@@ -26,6 +26,12 @@ import { getOpenEpicRegistry } from "@/lib/registries/epic-session-registry";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { deriveWorkspaceMode } from "@/lib/worktree/workspace-mode";
 import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
+import type { NestedFocusTarget } from "@/lib/epic-nested-focus-route";
+import {
+  Analytics,
+  AnalyticsEvent,
+  type AnalyticsSource,
+} from "@/lib/analytics";
 
 const CHAT_PROJECTION_WAIT_MS = 30_000;
 
@@ -49,6 +55,7 @@ export type CreatedChatOpenIntent =
       readonly tabId: string;
       readonly chatId: string;
       readonly hostId: string;
+      readonly source: AnalyticsSource;
     }
   | {
       readonly kind: "split";
@@ -58,6 +65,7 @@ export type CreatedChatOpenIntent =
       readonly targetGroupId: string;
       readonly position: NewChatSplitPosition;
       readonly hostId: string;
+      readonly source: AnalyticsSource;
     }
   | {
       // Opener path: drop a fresh instance into an explicit target group
@@ -69,6 +77,7 @@ export type CreatedChatOpenIntent =
       readonly chatId: string;
       readonly groupId: string;
       readonly hostId: string;
+      readonly source: AnalyticsSource;
     };
 
 /**
@@ -95,6 +104,7 @@ export interface OpenNewChatInActiveTileArgs {
    *  with host defaults (today's behavior for every caller but the clone
    *  flow, which carries the source chat's own settings forward). */
   readonly settings: ChatRunSettings | null;
+  readonly source: AnalyticsSource;
   readonly createChat: CreateChatCommand;
   readonly openWhenProjected: OpenWhenProjected;
 }
@@ -117,6 +127,7 @@ export function openNewChatInActiveTile(
           tabId: args.tabId,
           chatId: result.chatId,
           hostId: args.hostId,
+          source: args.source,
         });
       },
     },
@@ -157,7 +168,12 @@ function openCreatedChatWhenProjectedInternal(
   intent: CreatedChatOpenIntent,
   navigateNestedFocus: NavigateNestedFocus,
 ): CancelFn {
-  if (openProjectedChat(intent, navigateNestedFocus)) return noop;
+  // Any attempted open (successful or with a vanished target) is terminal;
+  // only "chat not yet projected" keeps the wait alive - matching the
+  // pre-analytics behavior of attempting the open exactly once.
+  if (openProjectedChat(intent, navigateNestedFocus) !== "not_projected") {
+    return noop;
+  }
   const handle = getOpenEpicRegistry().get(intent.epicId);
   if (handle === null) return noop;
 
@@ -174,7 +190,9 @@ function openCreatedChatWhenProjectedInternal(
   };
   const unsubscribe = handle.store.subscribe(() => {
     if (cancelled) return;
-    if (!openProjectedChat(intent, navigateNestedFocus)) return;
+    if (openProjectedChat(intent, navigateNestedFocus) === "not_projected") {
+      return;
+    }
     cleanup();
   });
   timeoutId = window.setTimeout(cleanup, CHAT_PROJECTION_WAIT_MS);
@@ -204,14 +222,19 @@ function buildCreateChatRequest(
   };
 }
 
+type ProjectedChatOpenResult =
+  "not_projected" | "opened" | "target_unavailable";
+
 function openProjectedChat(
   intent: CreatedChatOpenIntent,
   navigateNestedFocus: NavigateNestedFocus,
-): boolean {
+): ProjectedChatOpenResult {
   const handle = getOpenEpicRegistry().get(intent.epicId);
-  if (handle === null) return false;
+  if (handle === null) return "not_projected";
   const state = handle.store.getState();
-  if (!Object.hasOwn(state.chats.byId, intent.chatId)) return false;
+  if (!Object.hasOwn(state.chats.byId, intent.chatId)) {
+    return "not_projected";
+  }
   const chat = state.chats.byId[intent.chatId];
   const node = {
     id: chat.id,
@@ -223,29 +246,35 @@ function openProjectedChat(
     hostId: intent.hostId,
   };
   const canvas = useEpicCanvasStore.getState();
+  let opened: NestedFocusTarget | null = null;
   if (intent.kind === "active-tile") {
-    navigateNestedFocus(intent.epicId, intent.tabId, () =>
+    opened = navigateNestedFocus(intent.epicId, intent.tabId, () =>
       canvas.prepareOpenTileInTabFocusTarget(intent.tabId, node),
     );
-    return true;
-  }
-  if (intent.kind === "target-group") {
-    navigateNestedFocus(intent.epicId, intent.tabId, () =>
+  } else if (intent.kind === "target-group") {
+    opened = navigateNestedFocus(intent.epicId, intent.tabId, () =>
       canvas.prepareOpenTileInPaneFocusTarget(
         intent.tabId,
         intent.groupId,
         node,
       ),
     );
-    return true;
+  } else {
+    opened = navigateNestedFocus(intent.epicId, intent.tabId, () =>
+      canvas.prepareSplitPaneWithNodeFocusTarget(
+        intent.tabId,
+        intent.targetGroupId,
+        intent.position,
+        node,
+      ),
+    );
   }
-  navigateNestedFocus(intent.epicId, intent.tabId, () =>
-    canvas.prepareSplitPaneWithNodeFocusTarget(
-      intent.tabId,
-      intent.targetGroupId,
-      intent.position,
-      node,
-    ),
-  );
-  return true;
+  // A pane can disappear while host creation is in flight. The open is then
+  // abandoned exactly as it was before analytics existed - no fallback pane,
+  // no retry - and the only difference is that no `chat_opened` is emitted.
+  if (opened === null) return "target_unavailable";
+  Analytics.getInstance().track(AnalyticsEvent.ChatOpened, {
+    source: intent.source,
+  });
+  return "opened";
 }

--- a/clients/gui-app/src/lib/commands/actions/open-epic-from-list.ts
+++ b/clients/gui-app/src/lib/commands/actions/open-epic-from-list.ts
@@ -7,7 +7,11 @@ import { extractPlainTextFromComposerJSONContent } from "@/lib/composer/tiptap-j
 import { containsImageAtoms } from "@/lib/composer/image-atoms";
 import { useTabsStore } from "@/stores/tabs/store";
 import type { TabRef } from "@/stores/tabs/types";
-import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import {
+  Analytics,
+  AnalyticsEvent,
+  type AnalyticsSource,
+} from "@/lib/analytics";
 
 type NavigateFn = UseNavigateResult<string>;
 
@@ -28,13 +32,18 @@ export function openEpicFromList(
   navigate: NavigateFn,
   epicId: string,
   currentPathname: string,
-  title: string | undefined,
+  options: {
+    readonly title: string | undefined;
+    readonly source: AnalyticsSource;
+  },
 ): void {
-  Analytics.getInstance().track(AnalyticsEvent.TaskOpened, null);
+  Analytics.getInstance().track(AnalyticsEvent.TaskOpened, {
+    source: options.source,
+  });
   const replacedDraft = replaceEmptyDraftWithEpicInStrip(
     epicId,
     currentPathname,
-    title,
+    options.title,
   );
   navigateToTabIntent(
     navigate,

--- a/clients/gui-app/src/lib/commands/actions/open-epic-in-background.ts
+++ b/clients/gui-app/src/lib/commands/actions/open-epic-in-background.ts
@@ -14,6 +14,8 @@ export function openEpicInBackground(
   epicId: string,
   title: string | undefined,
 ): void {
-  Analytics.getInstance().track(AnalyticsEvent.TaskOpened, null);
+  Analytics.getInstance().track(AnalyticsEvent.TaskOpened, {
+    source: "direct_ui",
+  });
   useEpicCanvasStore.getState().openEpicTabInBackground(epicId, title);
 }

--- a/clients/gui-app/src/lib/commands/actions/open-epic-in-new-window.ts
+++ b/clients/gui-app/src/lib/commands/actions/open-epic-in-new-window.ts
@@ -42,7 +42,9 @@ export async function openEpicInNewWindow(
   bridge: DesktopWindowsBridge,
   input: OpenEpicInNewWindowInput,
 ): Promise<void> {
-  Analytics.getInstance().track(AnalyticsEvent.TaskOpened, null);
+  Analytics.getInstance().track(AnalyticsEvent.TaskOpened, {
+    source: "history",
+  });
   const owned = await bridge.ownership.snapshot();
   const existing = owned.find(
     (entry) =>

--- a/clients/gui-app/src/lib/desktop-app-lifecycle.ts
+++ b/clients/gui-app/src/lib/desktop-app-lifecycle.ts
@@ -1,3 +1,5 @@
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+
 /**
  * Feature-detected access to the desktop-only `appLifecycle` namespace the
  * Electron preload installs on `window.runnerHost`. gui-app must stay
@@ -25,6 +27,9 @@ function readAppLifecycleQuit(): (() => Promise<void>) | null {
  * current window outside the desktop shell.
  */
 export function requestAppQuit(): void {
+  Analytics.getInstance().track(AnalyticsEvent.AppQuitRequested, {
+    source: "direct_ui",
+  });
   const quit = readAppLifecycleQuit();
   if (quit !== null) {
     void quit();

--- a/clients/gui-app/src/lib/host/host-directory-service.ts
+++ b/clients/gui-app/src/lib/host/host-directory-service.ts
@@ -10,6 +10,7 @@ import type {
 } from "@traycer-clients/shared/platform/runner-host";
 import type { Disposable } from "@traycer-clients/shared/platform/uri-callback";
 import { appLogger } from "@/lib/logger";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 export interface HostDirectoryServiceOptions {
   readonly runnerHost: IRunnerHost;
@@ -149,6 +150,12 @@ export class HostDirectoryService implements IHostDirectoryService {
       return;
     }
     const entry = this.findById(hostId);
+    if (entry !== null) {
+      Analytics.getInstance().track(AnalyticsEvent.HostSelected, {
+        source: "direct_ui",
+        host_kind: entry.kind === "remote" ? "remote" : "local",
+      });
+    }
     this.setSelected(entry);
   }
 

--- a/clients/gui-app/src/lib/worktree/user-worktree-analytics.ts
+++ b/clients/gui-app/src/lib/worktree/user-worktree-analytics.ts
@@ -1,0 +1,76 @@
+import type {
+  WorktreeBinding,
+  WorktreeCreateResponse,
+  WorktreeImportResponse,
+  WorktreeIntent,
+} from "@traycer/protocol/host/worktree-schemas";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+
+type WorktreeIntentEntry = WorktreeIntent["entries"][number];
+type UserWorktreeWriteResult = WorktreeCreateResponse | WorktreeImportResponse;
+
+function entrySucceededInBinding(
+  entry: WorktreeIntentEntry,
+  binding: WorktreeBinding | null,
+): boolean {
+  const bound = binding?.entries.find(
+    (candidate) => candidate.workspacePath === entry.workspacePath,
+  );
+  if (bound === undefined || bound.mode !== "worktree") return false;
+  if (entry.kind === "worktree") {
+    return bound.worktreePath !== null && !bound.isImported;
+  }
+  if (entry.kind === "import") {
+    return bound.worktreePath === entry.worktreePath && bound.isImported;
+  }
+  return false;
+}
+
+function entriesSucceeded(
+  entries: ReadonlyArray<WorktreeIntentEntry>,
+  result: UserWorktreeWriteResult,
+): boolean {
+  if (entries.length === 0) return false;
+  if (!("perEntry" in result)) {
+    return entries.every((entry) =>
+      entrySucceededInBinding(entry, result.binding),
+    );
+  }
+  return entries.every((entry) =>
+    result.perEntry.some(
+      (entryResult) =>
+        entryResult.workspacePath === entry.workspacePath && entryResult.ok,
+    ),
+  );
+}
+
+/**
+ * Observes a deliberate worktree picker commit, not the underlying union RPC.
+ * Local-only entries intentionally produce no worktree-created/imported
+ * event, and an entry that the host reports as failed does not count as
+ * created/imported. Purely an observer: callers invoke it from their success
+ * callback AFTER product work, never wrapping the mutation promise, so
+ * telemetry can neither delay nor fail a successful write.
+ */
+export function trackUserInitiatedWorktreeWrite(
+  entries: ReadonlyArray<WorktreeIntentEntry>,
+  result: UserWorktreeWriteResult,
+): void {
+  const analytics = Analytics.getInstance();
+  if (
+    entriesSucceeded(
+      entries.filter((entry) => entry.kind === "worktree"),
+      result,
+    )
+  ) {
+    analytics.track(AnalyticsEvent.WorktreeCreated, { source: "direct_ui" });
+  }
+  if (
+    entriesSucceeded(
+      entries.filter((entry) => entry.kind === "import"),
+      result,
+    )
+  ) {
+    analytics.track(AnalyticsEvent.WorktreeImported, { source: "direct_ui" });
+  }
+}

--- a/clients/gui-app/src/providers/windows-bridge-provider.tsx
+++ b/clients/gui-app/src/providers/windows-bridge-provider.tsx
@@ -28,6 +28,24 @@ import type {
   DesktopPerWindowSnapshot,
   DesktopWindowsBridge,
 } from "@/lib/windows/types";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+
+// One `app_opened` per renderer process, emitted when hydration settles (the
+// earliest point this window knows whether it restored content). Secondary
+// windows are separate renderer processes and count too; the `restored_tabs`
+// flag plus PostHog sessions keep launch analyses honest enough without any
+// cross-window coordination.
+let appOpenedTracked = false;
+
+function trackAppOpenedOnce(restoredTabs: boolean): void {
+  if (appOpenedTracked) return;
+  appOpenedTracked = true;
+  Analytics.getInstance().track(AnalyticsEvent.AppOpened, {
+    source: restoredTabs ? "restored_session" : "direct_ui",
+    launch_reason: "normal",
+    restored_tabs: restoredTabs,
+  });
+}
 
 interface WindowsBridgeProviderProps {
   readonly children: ReactNode;
@@ -133,6 +151,7 @@ export function WindowsBridgeProvider(
 function installMissingDesktopWindowsBridge(): () => void {
   clearDesktopWindowsBridge();
   queueMicrotask(() => {
+    trackAppOpenedOnce(false);
     markHydrated();
   });
   return clearDesktopWindowsBridge;
@@ -183,6 +202,9 @@ function installDesktopWindowsBridge(
       const snapshot = await bridge.perWindowState.get();
       if (isCancelled()) return;
       applyPerWindowSnapshot(snapshot);
+      trackAppOpenedOnce(
+        snapshot.epicTabs.length > 0 || snapshot.landingDrafts.length > 0,
+      );
     } catch (error) {
       if (isCancelled()) return;
       // Fall back to not applying a snapshot (empty/absent snapshot

--- a/clients/gui-app/src/stores/auth/account-context-store.ts
+++ b/clients/gui-app/src/stores/auth/account-context-store.ts
@@ -1,6 +1,7 @@
 import type { AccountContext } from "@traycer/protocol/common/schemas";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 /**
  * Global, persisted "whose subscription am I looking at" selector. Mirrors the
@@ -27,6 +28,9 @@ export const useAccountContextStore = create<AccountContextStoreState>()(
     (set) => ({
       accountContext: { type: "PERSONAL" },
       setAccountContext: (accountContext) => {
+        Analytics.getInstance().track(AnalyticsEvent.AccountContextChanged, {
+          context: accountContext.type === "TEAM" ? "team" : "personal",
+        });
         set({ accountContext });
       },
     }),

--- a/clients/gui-app/src/stores/auth/account-context-store.ts
+++ b/clients/gui-app/src/stores/auth/account-context-store.ts
@@ -23,11 +23,17 @@ interface AccountContextStoreState {
   readonly setAccountContext: (context: AccountContext) => void;
 }
 
+function accountContextsEqual(a: AccountContext, b: AccountContext): boolean {
+  if (a.type !== b.type) return false;
+  return a.type === "TEAM" && b.type === "TEAM" ? a.teamId === b.teamId : true;
+}
+
 export const useAccountContextStore = create<AccountContextStoreState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       accountContext: { type: "PERSONAL" },
       setAccountContext: (accountContext) => {
+        if (accountContextsEqual(get().accountContext, accountContext)) return;
         Analytics.getInstance().track(AnalyticsEvent.AccountContextChanged, {
           context: accountContext.type === "TEAM" ? "team" : "personal",
         });

--- a/clients/gui-app/src/stores/auth/auth-store.ts
+++ b/clients/gui-app/src/stores/auth/auth-store.ts
@@ -104,10 +104,10 @@ export const useAuthStore = create<AuthState>()((set) => ({
     shareableTeams: ReadonlyArray<EpicShareableTeam>,
   ) => {
     set({ status: "signed-in", profile, contextMetadata, shareableTeams });
-    Analytics.getInstance().identify(contextMetadata.userId, {
-      name: profile.userName,
-      email: profile.email,
-    });
+    // Email is the one person property sent (deliberate product decision so
+    // PostHog dashboards can look users up); the final sanitizer drops
+    // everything else the SDK stages on $identify.
+    Analytics.getInstance().identify(contextMetadata.userId, profile.email);
   },
   setSubscriptionStatus: (status: SubscriptionStatus | null) => {
     set({ subscriptionStatus: status });

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -27,6 +27,13 @@ import {
 } from "@/lib/epic-nested-focus-route";
 import { UNTITLED_EPIC_TITLE } from "@/lib/display-title";
 import { createEpicName } from "@/lib/epic-name";
+import {
+  Analytics,
+  AnalyticsEvent,
+  analyticsArtifactKindForCanvasTileType,
+  analyticsTargetForCanvasTileType,
+  type AnalyticsSource,
+} from "@/lib/analytics";
 import type {
   DesktopJsonValue,
   DesktopPerWindowSnapshot,
@@ -95,6 +102,69 @@ import {
   type PendingTitleEntry,
 } from "@/stores/epics/canvas/canvas-title-timers";
 export { parseEpicNodeRef as parseArtifactRef } from "@/stores/epics/canvas/tile-schema/artifact-tile";
+
+function trackOpenedCanvasTile(
+  node: EpicCanvasTileRef,
+  source: AnalyticsSource,
+): void {
+  if (node.type === "chat") {
+    Analytics.getInstance().track(AnalyticsEvent.ChatOpened, {
+      source,
+    });
+    return;
+  }
+  if (node.type === "terminal" || node.type === "terminal-agent") {
+    Analytics.getInstance().track(AnalyticsEvent.TerminalOpened, {
+      source,
+      kind: node.type === "terminal" ? "shell" : "agent",
+    });
+    return;
+  }
+  if (node.type === "workspace-file") {
+    Analytics.getInstance().track(AnalyticsEvent.WorkspaceFileOpened, {
+      source,
+    });
+    return;
+  }
+  if (node.type === "git-diff" || node.type === "snapshot-diff") {
+    const bundle =
+      node.diff.kind === "bundle" ||
+      node.diff.kind === "snapshot-cumulative-bundle";
+    Analytics.getInstance().track(AnalyticsEvent.DiffOpened, {
+      source,
+      scope: bundle ? "all" : "file",
+    });
+    return;
+  }
+  const artifactKind = analyticsArtifactKindForCanvasTileType(node.type);
+  if (artifactKind !== null) {
+    Analytics.getInstance().track(AnalyticsEvent.ArtifactOpened, {
+      source,
+      kind: artifactKind,
+    });
+  }
+}
+
+/**
+ * Emits `tab_closed` for every tile a close GESTURE actually removed, by
+ * diffing the tab canvas' tile registry around the update (every close path
+ * prunes `tilesByInstanceId`, including last-tab pane collapse). Only the
+ * user-facing close actions call this, so programmatic tile removal - e.g. a
+ * cross-tab move, which routes through different actions - never counts.
+ */
+function trackClosedCanvasTiles(
+  before: EpicCanvasState | undefined,
+  after: EpicCanvasState | undefined,
+): void {
+  if (before === undefined) return;
+  Object.entries(before.tilesByInstanceId).forEach(([instanceId, tile]) => {
+    if (tile === undefined) return;
+    if (after !== undefined && instanceId in after.tilesByInstanceId) return;
+    const target = analyticsTargetForCanvasTileType(tile.type);
+    if (target === null) return;
+    Analytics.getInstance().track(AnalyticsEvent.TabClosed, { target });
+  });
+}
 
 export interface TabMoveArgs {
   readonly sourcePaneId: string;
@@ -234,6 +304,11 @@ export interface EpicCanvasStore {
     tabId: string,
     node: EpicCanvasTileRef,
   ) => NestedFocusTarget | null;
+  prepareOpenTileInTabFocusTargetFromSource: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+    source: AnalyticsSource,
+  ) => NestedFocusTarget | null;
   /**
    * Open a tile in preview mode (italic tab), replacing the destination
    * pane's existing preview. Same dedup as `openTileInTab`.
@@ -242,6 +317,11 @@ export interface EpicCanvasStore {
   prepareOpenTilePreviewInTabFocusTarget: (
     tabId: string,
     node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
+  prepareOpenTilePreviewInTabFocusTargetFromSource: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+    source: AnalyticsSource,
   ) => NestedFocusTarget | null;
   /**
    * Add `node` as a tab in the active pane without changing the active
@@ -252,6 +332,11 @@ export interface EpicCanvasStore {
   prepareOpenTileInBackgroundTabFocusTarget: (
     tabId: string,
     node: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
+  prepareOpenTileInBackgroundTabFocusTargetFromSource: (
+    tabId: string,
+    node: EpicCanvasTileRef,
+    source: AnalyticsSource,
   ) => NestedFocusTarget | null;
   /**
    * Opener-only path: open `ref` into the explicit `paneId` as a fresh tab
@@ -267,6 +352,12 @@ export interface EpicCanvasStore {
     tabId: string,
     paneId: string,
     ref: EpicCanvasTileRef,
+  ) => NestedFocusTarget | null;
+  prepareOpenTileInPaneFocusTargetFromSource: (
+    tabId: string,
+    paneId: string,
+    ref: EpicCanvasTileRef,
+    source: AnalyticsSource,
   ) => NestedFocusTarget | null;
   /**
    * Open a blank "New tab" in `paneId`, made active. Reuse-if-active-is-blank:
@@ -1037,6 +1128,12 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             },
           };
         });
+        const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
+        if (analyticsTarget !== null) {
+          Analytics.getInstance().track(AnalyticsEvent.TabCreated, {
+            target: analyticsTarget,
+          });
+        }
         return tabId;
       },
 
@@ -1094,6 +1191,12 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             },
           };
         });
+        const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
+        if (analyticsTarget !== null) {
+          Analytics.getInstance().track(AnalyticsEvent.TabMoved, {
+            target: analyticsTarget,
+          });
+        }
         return newId;
       },
 
@@ -1191,6 +1294,14 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         return after;
       },
 
+      prepareOpenTileInTabFocusTargetFromSource: (tabId, node, source) => {
+        const before = canvasForExistingTab(get(), tabId);
+        get().openTileInTab(tabId, node);
+        const canvas = canvasForExistingTab(get(), tabId);
+        if (before !== canvas) trackOpenedCanvasTile(node, source);
+        return currentNestedFocusTargetForTab(get(), tabId);
+      },
+
       openTilePreviewInTab: (tabId, node) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
@@ -1205,6 +1316,18 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         return after;
       },
 
+      prepareOpenTilePreviewInTabFocusTargetFromSource: (
+        tabId,
+        node,
+        source,
+      ) => {
+        const before = canvasForExistingTab(get(), tabId);
+        get().openTilePreviewInTab(tabId, node);
+        const canvas = canvasForExistingTab(get(), tabId);
+        if (before !== canvas) trackOpenedCanvasTile(node, source);
+        return currentNestedFocusTargetForTab(get(), tabId);
+      },
+
       openTileInBackgroundTab: (tabId, node) => {
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
@@ -1215,6 +1338,18 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
 
       prepareOpenTileInBackgroundTabFocusTarget: (tabId, node) => {
         get().openTileInBackgroundTab(tabId, node);
+        return null;
+      },
+
+      prepareOpenTileInBackgroundTabFocusTargetFromSource: (
+        tabId,
+        node,
+        source,
+      ) => {
+        const before = canvasForExistingTab(get(), tabId);
+        get().openTileInBackgroundTab(tabId, node);
+        const after = canvasForExistingTab(get(), tabId);
+        if (before !== after) trackOpenedCanvasTile(node, source);
         return null;
       },
 
@@ -1231,6 +1366,23 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         const targetPane =
           before === null ? null : findPaneById(before.root, paneId);
         get().openTileInPane(tabId, paneId, ref);
+        const after = currentNestedFocusTargetForTab(get(), tabId);
+        const target = targetPane === null ? null : after;
+        return target;
+      },
+
+      prepareOpenTileInPaneFocusTargetFromSource: (
+        tabId,
+        paneId,
+        ref,
+        source,
+      ) => {
+        const before = canvasForExistingTab(get(), tabId);
+        const targetPane =
+          before === null ? null : findPaneById(before.root, paneId);
+        get().openTileInPane(tabId, paneId, ref);
+        const canvas = canvasForExistingTab(get(), tabId);
+        if (before !== canvas) trackOpenedCanvasTile(ref, source);
         const after = currentNestedFocusTargetForTab(get(), tabId);
         const target = targetPane === null ? null : after;
         return target;
@@ -1369,6 +1521,8 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       },
 
       moveTabOnTabStrip: (tabId, args) => {
+        const before = canvasForExistingTab(get(), tabId);
+        const node = before?.tilesByInstanceId[args.tabId];
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) => {
             const sourcePane = findPaneById(canvas.root, args.sourcePaneId);
@@ -1387,6 +1541,16 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             );
           }),
         );
+        const after = canvasForExistingTab(get(), tabId);
+        const analyticsTarget =
+          node === undefined
+            ? null
+            : analyticsTargetForCanvasTileType(node.type);
+        if (before !== after && analyticsTarget !== null) {
+          Analytics.getInstance().track(AnalyticsEvent.TabMoved, {
+            target: analyticsTarget,
+          });
+        }
       },
 
       prepareMoveActiveTabOnTabStripFocusTarget: (tabId, args) => {
@@ -1406,6 +1570,7 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       },
 
       splitPaneWithNode: (tabId, targetPaneId, position, node) => {
+        const before = canvasForExistingTab(get(), tabId);
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             splitPaneAtEdge(canvas, targetPaneId, position, {
@@ -1414,6 +1579,13 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             }),
           ),
         );
+        const after = canvasForExistingTab(get(), tabId);
+        const analyticsTarget = analyticsTargetForCanvasTileType(node.type);
+        if (before !== after && analyticsTarget !== null) {
+          Analytics.getInstance().track(AnalyticsEvent.TabSplit, {
+            target: analyticsTarget,
+          });
+        }
       },
 
       prepareSplitPaneWithNodeFocusTarget: (
@@ -1430,6 +1602,8 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       },
 
       splitPaneWithTab: (tabId, args) => {
+        const before = canvasForExistingTab(get(), tabId);
+        const node = before?.tilesByInstanceId[args.tabId];
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) => {
             const sourcePane = findPaneById(canvas.root, args.sourcePaneId);
@@ -1443,6 +1617,16 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             });
           }),
         );
+        const after = canvasForExistingTab(get(), tabId);
+        const analyticsTarget =
+          node === undefined
+            ? null
+            : analyticsTargetForCanvasTileType(node.type);
+        if (before !== after && analyticsTarget !== null) {
+          Analytics.getInstance().track(AnalyticsEvent.TabSplit, {
+            target: analyticsTarget,
+          });
+        }
       },
 
       prepareSplitPaneWithTabFocusTarget: (tabId, args) => {
@@ -1487,6 +1671,7 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
         get().splitPaneEmptyInTab(tabId, targetPaneId, "horizontal"),
 
       closeCanvasTab: (tabId, paneId, tileTabId) => {
+        const beforeCanvas = get().canvasByTabId[tabId];
         // `tileTabId` is a tab instanceId; pendingCreate tracking is keyed by
         // content id, so resolve the closed tab's content id before clearing.
         set((state) => {
@@ -1507,6 +1692,7 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
             ? updated
             : { ...updated, pendingCreateArtifactIds: pendingNext };
         });
+        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
       },
 
       prepareCloseCanvasTabFocusTarget: (tabId, paneId, tileTabId) => {
@@ -1526,19 +1712,23 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       },
 
       closeOtherCanvasTabs: (tabId, paneId, tileTabId) => {
+        const beforeCanvas = get().canvasByTabId[tabId];
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             closeOtherTileTabs(canvas, paneId, tileTabId),
           ),
         );
+        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
       },
 
       closeRightCanvasTabs: (tabId, paneId, tileTabId) => {
+        const beforeCanvas = get().canvasByTabId[tabId];
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             closeRightTabs(canvas, paneId, tileTabId),
           ),
         );
+        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
       },
 
       prepareCloseRightCanvasTabsFocusTarget: (tabId, paneId, tileTabId) => {
@@ -1550,11 +1740,13 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       },
 
       closeAllCanvasTabs: (tabId, paneId) => {
+        const beforeCanvas = get().canvasByTabId[tabId];
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) =>
             closeAllTabs(canvas, paneId),
           ),
         );
+        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
       },
 
       prepareCloseAllCanvasTabsFocusTarget: (tabId, paneId) => {

--- a/clients/gui-app/src/stores/epics/canvas/store.ts
+++ b/clients/gui-app/src/stores/epics/canvas/store.ts
@@ -1758,9 +1758,11 @@ export const useEpicCanvasStore = create<EpicCanvasStore>()(
       },
 
       closeCanvasPane: (tabId, paneId) => {
+        const beforeCanvas = get().canvasByTabId[tabId];
         set((state) =>
           updateTabCanvas(state, tabId, (canvas) => closePane(canvas, paneId)),
         );
+        trackClosedCanvasTiles(beforeCanvas, get().canvasByTabId[tabId]);
       },
 
       prepareCloseCanvasPaneFocusTarget: (tabId, paneId) => {

--- a/protocol/src/notifications/comment-notification-utils.ts
+++ b/protocol/src/notifications/comment-notification-utils.ts
@@ -1,4 +1,4 @@
-import { JsonContent } from "../common/registry";
+import type { JsonContent } from "../common/registry";
 
 /**
  * Extracts unique user IDs from mention nodes in Tiptap JSONContent.


### PR DESCRIPTION
## What

Instruments the GUI renderer with a typed, best-effort PostHog analytics layer mapping the user journey — launch, sign-in, onboarding, host/provider setup, task creation, chat actions, workspaces/worktrees, terminals, tabs, artifacts, settings, voice dictation, app updates, and quit — as **126 semantic events**. Renderer-only: the Electron main process, preload, IPC contracts, `clients/shared`, and the protocol are untouched (one `import type` hygiene fix aside).

## Design

- **Typed contract.** One `AnalyticsEvent` enum with a compile-time per-event property map. Every property value is a bounded union (`source`, `blocker`, `harness`, `mode`, counts) — no free-form strings, no runtime IDs, no user content. A completeness test pins a runtime schema for every declared event.
- **Fire-and-forget, non-throwing.** `track()` sanitizes and calls `posthog.capture` inside an exception boundary; no SDK failure can escape into product control flow, and an init failure disables analytics for the process. No product path waits on, is gated by, or is restructured for telemetry. Flush/batching/retry is the stock posthog-js queue (3s batches, sendBeacon on pagehide, bounded retries).
- **Privacy boundary.** All PostHog automatic capture surfaces are disabled (autocapture, pageview/pageleave, replay, heatmaps, exceptions, surveys, experiments, feature flags). A final `before_send` **rebuilds** every payload from allowlists after SDK enrichment: ingestion identity, app globals, `$session_id`/`$window_id` passthrough (opaque SDK UUIDs, keeps session analyses working), then the event's allowlisted properties. Unknown events are dropped.
- **Identity.** `identify()` sends **email as the sole person property**, forwards the repeat-identify `$set` email-only, validates user ids as UUIDs, and reconciles against the SDK's persisted distinct id so a cold start on another account's state resets identity + session first.
- **Gesture-driven volume.** Events fire on user gestures or their direct mutation outcomes; renders, polling, reconnects, and restored sessions emit nothing. A representative session (launch → sign-in → create task → 3 messages → terminal → quit) emits ~15 events. Sign-in success/failure comes from the terminal auth transition inside `AuthService` (device-flow result application), so passive token restores never count as sign-ins.
- **Import boundary.** `posthog-js` is importable only by `src/lib/analytics.ts`, enforced with a stock `no-restricted-imports` override.

## Testing

- Full gui-app suite: **5,291 passed, 1 skipped** (includes real-SDK sanitizer tests: enrichment stripping, content-shaped identity rejection, repeat-identify `$set` passthrough, SDK exception containment, cross-account reset ordering).
- Compile, lint (zero warnings, boundary rule verified), and the production renderer build are green; desktop (540) and protocol (896) suites remain at their untouched baselines.