### PR TITLE
fix(gui-app): preserve model settings on profile switch

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/profile-rate-limit-task-wide-switch.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/profile-rate-limit-task-wide-switch.test.tsx
@@ -1,7 +1,10 @@
 import "../../../../../__tests__/test-browser-apis";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProfileRateLimitSwitchBanner } from "../profile-rate-limit-switch-banner";
+import { createComposerToolbarStore } from "@/stores/composer/composer-toolbar-store";
+import { commitProfileSelection } from "@/stores/composer/commit-selection";
+import { useComposerHarnessMemoryStore } from "@/stores/composer/composer-harness-memory-store";
 
 /**
  * Task-wide rate-limit switch: when the limited profile pins more than one
@@ -44,7 +47,14 @@ function renderBanner(input: {
 }
 
 describe("rate-limit banner task-wide switch", () => {
-  afterEach(() => cleanup());
+  beforeEach(() => {
+    useComposerHarnessMemoryStore.getState().resetForTests();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useComposerHarnessMemoryStore.getState().resetForTests();
+  });
 
   it("hides the task-wide option when only this chat is affected", () => {
     renderBanner({
@@ -81,6 +91,52 @@ describe("rate-limit banner task-wide switch", () => {
     );
     expect(onSwitchProfile).toHaveBeenCalledWith(ALTERNATIVE.profileId);
     expect(onSwitchProfileForTask).not.toHaveBeenCalled();
+  });
+
+  it("preserves the session's configured model and reasoning when switching profiles", () => {
+    useComposerHarnessMemoryStore.getState().record({
+      harnessId: "claude",
+      model: "opus-4",
+      permissionMode: "supervised",
+      reasoningEffort: "low",
+      serviceTier: null,
+      agentMode: "regular",
+      profileId: ALTERNATIVE.profileId,
+    });
+    const store = createComposerToolbarStore({
+      seedKey: "rate-limit-banner",
+      values: {
+        permission: "supervised",
+        selection: {
+          harnessId: "claude",
+          modelSlug: "sonnet-4.5",
+          profileId: CURRENT.profileId,
+        },
+        reasoning: "high",
+        serviceTier: "",
+        agentMode: "regular",
+      },
+      onSettingsChange: null,
+      tuiOnly: false,
+    });
+    renderBanner({
+      affectedChatCount: 1,
+      onSwitchProfile: (profileId) => commitProfileSelection(store, profileId),
+      onSwitchProfileForTask: () => undefined,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Continue this session on ${ALTERNATIVE.label}`,
+      }),
+    );
+
+    expect(store.getState().selection).toEqual({
+      harnessId: "claude",
+      modelSlug: "sonnet-4.5",
+      profileId: ALTERNATIVE.profileId,
+    });
+    expect(store.getState().reasoning).toBe("high");
   });
 
   it("switches the whole task (this chat included) from the task-wide option", () => {

--- a/clients/gui-app/src/components/chat/composer/chat-composer.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer.tsx
@@ -60,7 +60,7 @@ import {
   type AmbientDriftSendNotice,
 } from "./use-ambient-drift-gate";
 import { useComposerPickerItems } from "./picker/use-composer-picker-items";
-import { commitSelection } from "@/stores/composer/commit-selection";
+import { commitProfileSelection } from "@/stores/composer/commit-selection";
 import { useTaskProfileRateLimitSwitch } from "./use-task-profile-rate-limit-switch";
 
 interface ChatComposerProps {
@@ -215,7 +215,6 @@ function ChatComposerImpl(props: ChatComposerProps) {
   );
   const harnessId = useStore(toolbarStore, (s) => s.selection.harnessId);
   const profileId = useStore(toolbarStore, (s) => s.selection.profileId);
-  const modelSlug = useStore(toolbarStore, (s) => s.selection.modelSlug);
   // Connection-level auth gate for the selected provider, scoped to the tab's
   // host. When the provider CLI is signed out it blocks send and mounts the
   // re-auth banner above the composer; a doomed turn can't start.
@@ -240,9 +239,9 @@ function ChatComposerImpl(props: ChatComposerProps) {
   useRefreshProvidersListOnTurn(harnessId, tabHostId);
   const onSwitchProfile = useCallback(
     (nextProfileId: string | null) => {
-      commitSelection(toolbarStore, harnessId, modelSlug, nextProfileId);
+      commitProfileSelection(toolbarStore, nextProfileId);
     },
-    [toolbarStore, harnessId, modelSlug],
+    [toolbarStore],
   );
   // Task-wide extension of the rate-limit switch: sibling chats of this task
   // pinned to the same limited profile, and the action moving them together.

--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -1574,6 +1574,69 @@ describe("<HarnessModelPicker />", () => {
     expect(selections.at(-1)?.profileId).toBeNull();
   });
 
+  it("keeps a degraded provider's profile paired with that provider when profile selection commits the browse", async () => {
+    const codex = codexModels();
+    const signedOutClaude: HarnessOption = {
+      ...CLAUDE_HARNESS,
+      available: false,
+      error: "Claude is signed out",
+    };
+    queryMock.harnesses = [CODEX_HARNESS, signedOutClaude];
+    queryMock.catalogHarnesses = [
+      catalogHarness(CODEX_HARNESS, codex),
+      catalogHarness(signedOutClaude, []),
+    ];
+    queryMock.selectedModelsByHarness = new Map([
+      ["codex", codex],
+      ["claude", []],
+    ]);
+    const degradedClaude = providerCliStateWithProfiles({
+      providerId: "claude-code",
+      profiles: claudeProfilesForDropdown(),
+    });
+    queryMock.providerStates = [
+      {
+        ...degradedClaude,
+        auth: { ...degradedClaude.auth, status: "unauthenticated" },
+      },
+    ];
+    useComposerHarnessMemoryStore.getState().record({
+      harnessId: "claude",
+      model: "claude-opus-4-7",
+      permissionMode: "supervised",
+      reasoningEffort: "high",
+      serviceTier: null,
+      agentMode: "regular",
+      profileId: "work-profile",
+    });
+    const { store, selections } = renderPicker(undefined);
+
+    await openPicker();
+    const claudeTab = screen.getByRole("tab", { name: "Claude" });
+    expect(claudeTab.getAttribute("data-degraded")).toBe("true");
+    fireEvent.click(claudeTab);
+
+    // A degraded rail entry is browse-only, so Codex remains selected until
+    // the user explicitly picks one of Claude's profiles.
+    expect(store.getState().selection.harnessId).toBe("codex");
+    expect(selections).toEqual([]);
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Work" }));
+
+    expect(store.getState().selection).toEqual({
+      harnessId: "claude",
+      modelSlug: "claude-opus-4-7",
+      profileId: "work-profile",
+    });
+    expect(store.getState().reasoning).toBe("high");
+    expect(
+      useComposerHarnessMemoryStore.getState().resolveLastProfile("claude"),
+    ).toBe("work-profile");
+    expect(
+      useComposerHarnessMemoryStore.getState().lastProfileByHarness.codex,
+    ).not.toBe("work-profile");
+  });
+
   it("reflects provider profile rename and recolor in the trigger and dropdown", async () => {
     const initialColor = PROVIDER_PROFILE_ACCENT_COLORS[0];
     const nextColor = PROVIDER_PROFILE_ACCENT_COLORS[4];
@@ -1718,6 +1781,65 @@ describe("<HarnessModelPicker />", () => {
     await waitFor(() => {
       expect(screen.queryByRole("textbox", { name: /^Search/ })).toBeNull();
     });
+  });
+
+  it("keeps a delayed created profile paired with its provider after the current selection changes", async () => {
+    queryMock.providerStates = [
+      providerCliStateWithProfiles({
+        providerId: "claude-code",
+        profiles: claudeProfilesForDropdown(),
+      }),
+    ];
+    useComposerHarnessMemoryStore.getState().record({
+      harnessId: "claude",
+      model: "claude-opus-4-7",
+      permissionMode: "supervised",
+      reasoningEffort: "high",
+      serviceTier: null,
+      agentMode: "regular",
+      profileId: "new-profile",
+    });
+    const { store } = renderPicker(undefined);
+
+    await openPicker();
+    fireEvent.click(screen.getByRole("tab", { name: "Claude" }));
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Create new profile" }),
+    );
+
+    const onProfileCreated =
+      useProviderProfileAddFlowStore.getState().onProfileCreated;
+    if (onProfileCreated === null) {
+      throw new Error("Expected the add-profile flow to retain its callback.");
+    }
+
+    // The flow is global and can resolve after another picker/control changes
+    // this composer's provider. The retained callback must still target Claude.
+    act(() => {
+      store.getState().setSelection({
+        harnessId: "codex",
+        modelSlug: "gpt-5.5",
+        profileId: null,
+      });
+    });
+    expect(store.getState().selection.harnessId).toBe("codex");
+
+    act(() => {
+      onProfileCreated("new-profile");
+    });
+
+    expect(store.getState().selection).toEqual({
+      harnessId: "claude",
+      modelSlug: "claude-opus-4-7",
+      profileId: "new-profile",
+    });
+    expect(store.getState().reasoning).toBe("high");
+    expect(
+      useComposerHarnessMemoryStore.getState().resolveLastProfile("claude"),
+    ).toBe("new-profile");
+    expect(
+      useComposerHarnessMemoryStore.getState().lastProfileByHarness.codex,
+    ).not.toBe("new-profile");
   });
 
   it("targets the tab's host scope, not the default, when creating a profile from a tab-scoped picker (S8)", async () => {
@@ -2207,7 +2329,7 @@ describe("<HarnessModelPicker />", () => {
     );
   });
 
-  it("restores the remembered (harness, profile, model) record on a dropdown commit", async () => {
+  it("preserves the configured model and reasoning on a profile dropdown commit", async () => {
     queryMock.providerStates = [
       providerCliStateWithProfiles({
         providerId: "claude-code",
@@ -2251,9 +2373,9 @@ describe("<HarnessModelPicker />", () => {
         ],
       }),
     ];
-    // Seed memory for the SPECIFIC (harness, profile) pair the dropdown
-    // commits, to prove `commitSelection`'s funnel is keyed by profile - not
-    // just harness.
+    // The destination profile remembers a different model and effort. A
+    // profile-only switch must ignore that memory and preserve the current
+    // composer configuration.
     useComposerHarnessMemoryStore.getState().record({
       harnessId: "claude",
       model: "claude-opus-4-7",
@@ -2263,18 +2385,25 @@ describe("<HarnessModelPicker />", () => {
       agentMode: "regular",
       profileId: "work-profile",
     });
-    const { selections, reasoningChanges } = renderPicker(undefined);
+    const { store, selections, reasoningChanges } = renderPicker({
+      selection: {
+        harnessId: "claude",
+        modelSlug: "claude-sonnet-4-6",
+        profileId: null,
+      },
+      reasoning: "low",
+    });
 
-    await openPicker();
-    fireEvent.click(screen.getByRole("tab", { name: "Claude" }));
+    await openPickerByTriggerName(/^Claude Sonnet 4\.6/);
     fireEvent.click(screen.getByRole("menuitem", { name: "Work" }));
 
     expect(selections.at(-1)).toEqual({
       harnessId: "claude",
-      modelSlug: "claude-opus-4-7",
+      modelSlug: "claude-sonnet-4-6",
       profileId: "work-profile",
     });
-    expect(reasoningChanges.at(-1)).toBe("high");
+    expect(store.getState().reasoning).toBe("low");
+    expect(reasoningChanges).toEqual([]);
   });
 
   it("commits a profile switch via the ⌘⇧ leader digit", async () => {

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -13,7 +13,10 @@ import {
 } from "@/components/home/data/landing-options";
 import { useSurfaceActivity } from "@/components/home/composer/surface-activity-hooks";
 import type { ComposerToolbarStore } from "@/stores/composer/composer-toolbar-store";
-import { commitSelection } from "@/stores/composer/commit-selection";
+import {
+  commitProfileSelection,
+  commitSelection,
+} from "@/stores/composer/commit-selection";
 import {
   harnessCatalogEntryNeedsRefresh,
   useDefaultHostClient,
@@ -644,7 +647,19 @@ function HarnessModelPickerImpl(props: HarnessModelPickerProps) {
       // Mirrors `handleRailEntryChange`'s lock rule: while a fork lock is
       // active the strip stays interactive for the locked provider only.
       if (lockedHarnessId !== null && providerId !== lockedHarnessId) return;
-      commitSelection(store, providerId, null, profileId);
+      // Same-provider profile changes only replace the credential, preserving
+      // the user's configured model, reasoning effort, and tier. The provider
+      // can differ after browsing a degraded rail entry without committing it,
+      // or when this globally retained create-profile callback resolves after
+      // another control changed the selection. In that case preserve the old
+      // provider-switch behavior and restore the target provider/profile's
+      // remembered settings instead of pairing its profile with the current
+      // provider.
+      if (store.getState().selection.harnessId === providerId) {
+        commitProfileSelection(store, profileId);
+      } else {
+        commitSelection(store, providerId, null, profileId);
+      }
       setActiveRailEntry(providerId, profileId);
     },
     [lockedHarnessId, setActiveRailEntry, store],

--- a/clients/gui-app/src/stores/composer/__tests__/commit-selection.test.ts
+++ b/clients/gui-app/src/stores/composer/__tests__/commit-selection.test.ts
@@ -1,7 +1,10 @@
 import "../../../../__tests__/test-browser-apis";
 import { beforeEach, describe, expect, it } from "vitest";
 import { createComposerToolbarStore } from "@/stores/composer/composer-toolbar-store";
-import { commitSelection } from "@/stores/composer/commit-selection";
+import {
+  commitProfileSelection,
+  commitSelection,
+} from "@/stores/composer/commit-selection";
 import { useComposerHarnessMemoryStore } from "@/stores/composer/composer-harness-memory-store";
 import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
 import { composerHarnessMemoryKey } from "@/lib/persist";
@@ -15,15 +18,26 @@ function resetMemory(): void {
   useComposerRunSettingsStore.getState().resetForTests();
 }
 
-// Mid-chat profile switching rides `commitSelection`, the same funnel a
-// harness switch uses - this is the "turn-boundary switch" commit half of the
-// multi-profile feature (the other half, forcing a fresh upstream session, is
-// host-side in `prepareHarnessSessionForSend`).
-describe("commitSelection - profile switch", () => {
+describe("commitProfileSelection", () => {
   beforeEach(resetMemory);
 
-  it("commits a different profile for the same harness/model without touching either", () => {
-    const emitted: Array<{ harnessId: string; profileId: string | null }> = [];
+  it("changes only the profile even when the destination remembers different model settings", () => {
+    useComposerHarnessMemoryStore.getState().record({
+      harnessId: "claude",
+      model: "opus-4",
+      permissionMode: "supervised",
+      reasoningEffort: "low",
+      serviceTier: "standard",
+      agentMode: "regular",
+      profileId: "profile-b",
+    });
+
+    const emitted: Array<{
+      model: string;
+      profileId: string | null;
+      reasoningEffort: string | null;
+      serviceTier: string | null;
+    }> = [];
     const store = createComposerToolbarStore({
       seedKey: "seed-1",
       values: {
@@ -34,44 +48,44 @@ describe("commitSelection - profile switch", () => {
           profileId: "profile-a",
         },
         reasoning: "high",
-        serviceTier: "",
+        serviceTier: "fast",
         agentMode: "regular",
       },
       onSettingsChange: (settings) =>
         emitted.push({
-          harnessId: settings.harnessId,
+          model: settings.model,
           profileId: settings.profileId,
+          reasoningEffort: settings.reasoningEffort,
+          serviceTier: settings.serviceTier,
         }),
       tuiOnly: false,
     });
 
-    commitSelection(store, "claude", "sonnet-4.5", "profile-b");
+    commitProfileSelection(store, "profile-b");
 
     expect(store.getState().selection).toEqual({
       harnessId: "claude",
       modelSlug: "sonnet-4.5",
       profileId: "profile-b",
     });
+    expect(store.getState().reasoning).toBe("high");
+    expect(store.getState().serviceTier).toBe("fast");
     expect(emitted.at(-1)).toEqual({
-      harnessId: "claude",
+      model: "sonnet-4.5",
       profileId: "profile-b",
+      reasoningEffort: "high",
+      serviceTier: "fast",
     });
     expect(
       useComposerHarnessMemoryStore.getState().resolveLastProfile("claude"),
     ).toBe("profile-b");
   });
+});
 
-  it("restores the profile's own remembered model on a rail-entry profile switch", () => {
-    // Seed memory: profile-a last ran sonnet-4.5, profile-b last ran opus-4.
-    useComposerHarnessMemoryStore.getState().record({
-      harnessId: "claude",
-      model: "sonnet-4.5",
-      permissionMode: "supervised",
-      reasoningEffort: "high",
-      serviceTier: null,
-      agentMode: "regular",
-      profileId: "profile-a",
-    });
+describe("commitSelection - provider switch", () => {
+  beforeEach(resetMemory);
+
+  it("restores the selected profile's remembered model when changing providers", () => {
     useComposerHarnessMemoryStore.getState().record({
       harnessId: "claude",
       model: "opus-4",
@@ -88,9 +102,9 @@ describe("commitSelection - profile switch", () => {
       values: {
         permission: "supervised",
         selection: {
-          harnessId: "claude",
-          modelSlug: "sonnet-4.5",
-          profileId: "profile-a",
+          harnessId: "codex",
+          modelSlug: "gpt-5.5",
+          profileId: null,
         },
         reasoning: "high",
         serviceTier: "",
@@ -104,8 +118,8 @@ describe("commitSelection - profile switch", () => {
       tuiOnly: false,
     });
 
-    // Rail-entry click: modelSlug is null, so the harness-switch resolver
-    // restores profile-b's own last model, not profile-a's.
+    // Provider-rail click: modelSlug is null, so the harness-switch resolver
+    // restores the destination provider/profile's own last model.
     commitSelection(store, "claude", null, "profile-b");
 
     expect(store.getState().selection).toEqual({

--- a/clients/gui-app/src/stores/composer/commit-selection.ts
+++ b/clients/gui-app/src/stores/composer/commit-selection.ts
@@ -43,3 +43,24 @@ export function commitSelection(
     serviceTier: resolved.serviceTier ?? "",
   });
 }
+
+/**
+ * Commits a profile-only change for the currently selected harness. Unlike
+ * `commitSelection`, this path deliberately does not consult the destination
+ * profile's model/effort memory: switching credentials must not discard model,
+ * reasoning, or service-tier choices the user already configured.
+ *
+ * Shared by the model picker's profile dropdown and the chat rate-limit
+ * banner, so both profile-switch surfaces preserve the same composer state.
+ */
+export function commitProfileSelection(
+  store: ComposerToolbarStore,
+  profileId: string | null,
+): void {
+  const state = store.getState();
+  const selection = { ...state.selection, profileId };
+  useComposerHarnessMemoryStore
+    .getState()
+    .recordProfileSelection(selection.harnessId, profileId);
+  state.setSelection(selection);
+}


### PR DESCRIPTION
## Summary

- preserve the selected model, reasoning effort, and service tier when switching profiles within the current provider
- keep profile callbacks provider-aware so degraded-provider browsing and delayed profile creation cannot produce invalid provider/profile pairs
- add regression coverage for the model picker and rate-limit banner paths

## Related issue

N/A

## Testing

- `pre-commit run --all-files`
- `bun run compile` in `clients/gui-app`
- 66 focused Vitest tests across the picker, profile commit, and rate-limit switching suites
- focused ESLint for all changed files
- React Doctor changed-files scan against `main`

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO