### PR TITLE
fix(gui-app): refresh provider profiles in parallel

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -72,6 +72,7 @@ type MockState = {
   traycerUsageUpdatedAt: Readonly<Record<string, number>>;
   openSettings: Mock<(...args: unknown[]) => void>;
   enqueue: Mock<(...args: unknown[]) => Promise<void>>;
+  enqueueBatch: Mock<(...args: unknown[]) => Promise<void>>;
   consumeReset: Mock<
     (
       request: ProvidersConsumeRateLimitResetCreditRequest,
@@ -112,6 +113,7 @@ const mocks = vi.hoisted<MockState>(() => ({
   traycerUsageUpdatedAt: {},
   openSettings: vi.fn(),
   enqueue: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  enqueueBatch: vi.fn((..._args: unknown[]) => Promise.resolve()),
   consumeReset: vi.fn(),
   lastUseHostQueriesOptions: null,
   lastUseHostQueriesProviderIds: null,
@@ -227,6 +229,8 @@ vi.mock("@/lib/rate-limits/ephemeral-fetch-queue", () => ({
   // Wrapper (not `mocks.enqueue` directly) so `beforeEach` can swap the spy -
   // an object-literal binding would freeze the original fn at module load.
   enqueueRateLimitFetch: (...args: unknown[]) => mocks.enqueue(...args),
+  enqueueRateLimitFetchBatch: (...args: unknown[]) =>
+    mocks.enqueueBatch(...args),
   enqueueRateLimitFetchForScope: (...args: unknown[]) =>
     mocks.enqueue(...args.slice(1)),
 }));
@@ -518,6 +522,7 @@ beforeEach(() => {
   mocks.traycerUsageUpdatedAt = {};
   mocks.openSettings = vi.fn();
   mocks.enqueue = vi.fn((..._args: unknown[]) => Promise.resolve());
+  mocks.enqueueBatch = vi.fn((..._args: unknown[]) => Promise.resolve());
   mocks.consumeReset = vi.fn();
   mocks.lastUseHostQueriesOptions = null;
   mocks.lastUseHostQueriesProviderIds = null;
@@ -1377,9 +1382,28 @@ describe("<RateLimitPopover /> Refresh all", () => {
     expect((refreshCodex as HTMLButtonElement).disabled).toBe(true);
   });
 
-  it("enqueues each ephemeralProcess provider with force:true", () => {
+  it("enqueues every ephemeralProcess profile in one parallel refresh batch", () => {
     mocks.configured = [
-      { providerId: "codex", lane: "ephemeralProcess", profiles: undefined },
+      {
+        providerId: "codex",
+        lane: "ephemeralProcess",
+        profiles: [
+          providerProfile({
+            profileId: "ambient",
+            kind: "ambient",
+            label: "Terminal",
+            tier: "Pro",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+          providerProfile({
+            profileId: "work-profile",
+            kind: "managed",
+            label: "Work",
+            tier: "Pro 5x",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+        ],
+      },
       {
         providerId: "claude-code",
         lane: "ephemeralProcess",
@@ -1391,17 +1415,67 @@ describe("<RateLimitPopover /> Refresh all", () => {
       "claude-code": readyResult(claudeReady()),
     };
     renderPopover();
+    mocks.enqueue.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Refresh all" }));
-    expect(mocks.enqueue).toHaveBeenCalledWith(
-      "codex",
-      { type: "PERSONAL" },
-      { force: true, profileId: null },
+    expect(mocks.enqueueBatch).toHaveBeenCalledWith(
+      [
+        {
+          providerId: "codex",
+          accountContext: { type: "PERSONAL" },
+          profileId: null,
+        },
+        {
+          providerId: "codex",
+          accountContext: { type: "PERSONAL" },
+          profileId: "work-profile",
+        },
+        {
+          providerId: "claude-code",
+          accountContext: { type: "PERSONAL" },
+          profileId: null,
+        },
+      ],
+      { force: true },
     );
-    expect(mocks.enqueue).toHaveBeenCalledWith(
-      "claude-code",
-      { type: "PERSONAL" },
-      { force: true, profileId: null },
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("targets the managed profile id, not null, when refreshing a provider with exactly one managed profile", () => {
+    // Regression: refreshTargetsForProvider used to short-circuit to [null]
+    // whenever profiles.length <= 1, so a lone managed profile's card
+    // (keyed by work-profile) never received the Refresh-all invalidation.
+    mocks.configured = [
+      {
+        providerId: "codex",
+        lane: "ephemeralProcess",
+        profiles: [
+          providerProfile({
+            profileId: "work-profile",
+            kind: "managed",
+            label: "Work",
+            tier: "Pro 5x",
+            usageUpdatedAt: NOW - 10_000,
+          }),
+        ],
+      },
+    ];
+    mocks.results = {
+      [resultKey("codex", "work-profile")]: readyResult(codexReady()),
+    };
+    renderPopover();
+    mocks.enqueue.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh all" }));
+    expect(mocks.enqueueBatch).toHaveBeenCalledWith(
+      [
+        {
+          providerId: "codex",
+          accountContext: { type: "PERSONAL" },
+          profileId: "work-profile",
+        },
+      ],
+      { force: true },
     );
+    expect(mocks.enqueue).not.toHaveBeenCalled();
   });
 
   it("refetches Traycer when the synthetic Traycer entry is eligible", () => {

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -58,7 +58,10 @@ import {
   resolveRateLimitProfileId,
   type RateLimitProfileSelection,
 } from "@/hooks/rate-limits/use-rate-limit-profile-selection";
-import { enqueueRateLimitFetch } from "@/lib/rate-limits/ephemeral-fetch-queue";
+import {
+  enqueueRateLimitFetch,
+  enqueueRateLimitFetchBatch,
+} from "@/lib/rate-limits/ephemeral-fetch-queue";
 import {
   formatUnavailableReason,
   resolvePopoverProviderRateLimitState,
@@ -191,7 +194,7 @@ function configuredProviderProfiles(
 function refreshTargetsForProvider(
   provider: ConfiguredRateLimitProvider,
 ): ReadonlyArray<string | null> {
-  if (provider.profiles.length <= 1) return [null];
+  if (provider.profiles.length === 0) return [null];
   return provider.profiles
     .filter(profileLoggedInForUsage)
     .map(rateLimitProfileId);
@@ -630,16 +633,17 @@ function useTraycerRateLimitUsageState(
 
 /**
  * The rail's icon-only "Refresh all" (Core Flows): ephemeralProcess providers
- * refresh one at a time through the shared serial queue (`force: true`), while
- * httpFetch providers refresh concurrently alongside via a direct query
- * invalidation - a plain GET has no subprocess cost to serialize. The synthetic
- * Traycer entry refreshes here too: it refetches the AuthService subscription
- * query, and rate-limit based plans additionally invalidate the unscoped
- * aperture `host.getRateLimitUsage` query that backs the live artifact bar.
+ * refresh as one queued batch whose profile pulls run concurrently
+ * (`force: true`), while httpFetch providers refresh concurrently alongside via
+ * a direct query invalidation - a plain GET has no subprocess cost to serialize.
+ * The synthetic Traycer entry refreshes here too: it refetches the AuthService
+ * subscription query, and rate-limit based plans additionally invalidate the
+ * unscoped aperture `host.getRateLimitUsage` query that backs the live artifact
+ * bar.
  * `refreshing` combines all lanes' real query state - the queue's draining flag
- * for ephemeralProcess (which stays true a beat longer than any single
- * provider's `isFetching`, covering the "still waiting behind an earlier
- * provider in the queue" gap), each configured httpFetch provider's own
+ * for ephemeralProcess (which stays true until every profile in the batch has
+ * settled, even after one provider's own `isFetching` clears), each configured
+ * httpFetch provider's own
  * `isFetching` (read via `useHostQueries` against the exact same query keys the
  * invalidation below targets), plus Traycer's auth/aperture fetch state - so
  * the icon spins for the whole round regardless of which lane(s) are actually
@@ -669,6 +673,15 @@ function RateLimitRefreshAllButton({
       profileId,
     })),
   );
+  const ephemeralProcessRequests = providers
+    .filter((provider) => provider.lane === "ephemeralProcess")
+    .flatMap((provider) =>
+      refreshTargetsForProvider(provider).map((profileId) => ({
+        providerId: provider.providerId,
+        accountContext: DEFAULT_ACCOUNT_CONTEXT,
+        profileId,
+      })),
+    );
   // Every httpFetch provider resolves to the exact same lane options (the
   // `isHttpFetch` branch in `providerRateLimitQueryOptions` doesn't vary by
   // provider id) - reusing the first one's is safe without the "verify every
@@ -710,8 +723,8 @@ function RateLimitRefreshAllButton({
     traycerRefreshing;
 
   // Fire-and-forget, not awaited: httpFetch providers refresh concurrently via a
-  // direct invalidation, ephemeralProcess providers queue through the shared
-  // serial lane, and Traycer refetches its subscription/usage queries. Returns
+  // direct invalidation, ephemeralProcess profiles fan out inside one queued
+  // batch, and Traycer refetches its subscription/usage queries. Returns
   // an already-resolved promise so `RefreshIconButton` gets its
   // `() => Promise<void>` contract without gating the spinner on the fetches
   // themselves - `refreshing` (above) owns that.
@@ -728,17 +741,7 @@ function RateLimitRefreshAllButton({
         }),
       });
     });
-    providers
-      .filter((provider) => provider.lane === "ephemeralProcess")
-      .forEach((provider) => {
-        refreshTargetsForProvider(provider).forEach((profileId) => {
-          void enqueueRateLimitFetch(
-            provider.providerId,
-            DEFAULT_ACCOUNT_CONTEXT,
-            { force: true, profileId },
-          );
-        });
-      });
+    void enqueueRateLimitFetchBatch(ephemeralProcessRequests, { force: true });
     if (traycerRefreshTarget.enabled) {
       void traycerRefreshTarget.refetch();
       traycerRefreshTarget.rateLimitAccountContexts.forEach(
@@ -907,7 +910,7 @@ function SingleProfileRateLimitProviderBlock({
               // `isRefreshing` (from useProviderRateLimitRefresh) already folds
               // in the ephemeralProcess `draining` flag, so this button stays
               // disabled for a "Refresh all" round's full duration, not just
-              // this provider's own slice of it.
+              // this provider's own fetch.
               refreshing={isRefreshing}
             />
           ) : null}

--- a/clients/gui-app/src/hooks/rate-limits/use-is-rate-limit-queue-draining.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-is-rate-limit-queue-draining.ts
@@ -5,11 +5,13 @@ import {
 } from "@/lib/rate-limits/ephemeral-fetch-queue";
 
 /**
- * Reactively projects whether the `ephemeralProcess` serial queue currently has
- * a subprocess fetch in flight. Backs the popover's "disable Refresh-all while
- * draining" state. Both the subscribe and snapshot functions are stable module
- * references returning a primitive boolean, so `useSyncExternalStore` never
- * re-subscribes or tears on identity.
+ * Reactively projects whether the `ephemeralProcess` queue currently has work
+ * queued or in flight. A queue item is usually one subprocess fetch, while
+ * "Refresh all" may run several profile fetches concurrently inside one item.
+ * Backs the popover's "disable Refresh-all while draining" state. Both the
+ * subscribe and snapshot functions are stable module references returning a
+ * primitive boolean, so `useSyncExternalStore` never re-subscribes or tears on
+ * identity.
  */
 export function useIsRateLimitQueueDraining(): boolean {
   return useSyncExternalStore(

--- a/clients/gui-app/src/hooks/rate-limits/use-provider-rate-limit-refresh.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-provider-rate-limit-refresh.ts
@@ -26,13 +26,13 @@ import {
  * - **Spinner state (`isRefreshing`)**: `query.isFetching` covers a fetch on
  *   THIS provider's own query key (whoever triggered it - the queue's
  *   `fetchQuery`, a direct refetch, an invalidation). For `ephemeralProcess`
- *   providers it is OR-ed with the queue's `draining` flag, because the queue
- *   runs providers one at a time: this provider's own `isFetching` can settle
- *   the instant its turn finishes while "Refresh all" is still working through a
- *   later provider queued behind it. Gating on `draining` (the whole round)
- *   rather than only this provider's own fetch keeps the button disabled for as
- *   long as any refresh in the shared lane is in flight - matching the user's
- *   "Refresh all is in progress" mental model, not "my own fetch is in flight".
+ *   providers it is OR-ed with the queue's `draining` flag: this provider's own
+ *   `isFetching` can settle while another profile in the same "Refresh all"
+ *   batch is still running, or while another queue item is pending. Gating on
+ *   `draining` (the whole round) rather than only this provider's own fetch keeps
+ *   the button disabled for as long as any refresh in the shared lane is in
+ *   flight - matching the user's "Refresh all is in progress" mental model, not
+ *   "my own fetch is in flight".
  *   `httpFetch` providers refresh concurrently (no shared queue), so their own
  *   `isFetching` is already the complete signal.
  *

--- a/clients/gui-app/src/lib/rate-limit-providers.ts
+++ b/clients/gui-app/src/lib/rate-limit-providers.ts
@@ -28,8 +28,9 @@ export type RateLimitProviderId = RateLimitCapableProviderId;
  *   serial queue.
  * - `"ephemeralProcess"`: the host spawns a real CLI subprocess to read usage
  *   (codex, claude-code). Expensive; these are funnelled through a shared
- *   serial queue so an interval tick, a manual refresh, and a turn completion
- *   can never spawn overlapping subprocesses.
+ *   queue so background and single-profile triggers cannot overlap. The
+ *   deliberate exception is the popover's "Refresh all" queue item, which fans
+ *   out its configured profiles together before the next item begins.
  */
 export type RateLimitFetchLane = "httpFetch" | "ephemeralProcess";
 

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
@@ -15,6 +15,7 @@ import {
   __resetRateLimitQueueForTests,
   configureRateLimitQueue,
   enqueueRateLimitFetch,
+  enqueueRateLimitFetchBatch,
   enqueueRateLimitFetchForScope,
   isRateLimitQueueDraining,
   subscribeRateLimitQueueDraining,
@@ -123,6 +124,57 @@ describe("ephemeral-fetch-queue", () => {
 
     settlers[1].ok();
     await flush();
+  });
+
+  it("starts every profile in one refresh batch concurrently, then waits before running the next queue item", async () => {
+    const queryClient = newQueryClient();
+    const profileStarts: Array<string | null> = [];
+    const settlers: Array<() => void> = [];
+    const request = vi.fn<RateLimitQueueRequestFn>(
+      (_hostId, _method, params) => {
+        profileStarts.push(params.profileId);
+        return new Promise((resolve) => {
+          settlers.push(() => resolve(response()));
+        });
+      },
+    );
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    void enqueueRateLimitFetchBatch(
+      [
+        {
+          providerId: "codex",
+          accountContext: DEFAULT_ACCOUNT_CONTEXT,
+          profileId: null,
+        },
+        {
+          providerId: "codex",
+          accountContext: DEFAULT_ACCOUNT_CONTEXT,
+          profileId: "work-profile",
+        },
+      ],
+      { force: true },
+    );
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+      profileId: null,
+    });
+
+    await flush();
+    expect(profileStarts).toEqual([null, "work-profile"]);
+    expect(request).toHaveBeenCalledTimes(2);
+
+    settlers[0]();
+    await flush();
+    expect(request).toHaveBeenCalledTimes(2);
+
+    settlers[1]();
+    await flush();
+    expect(profileStarts).toEqual([null, "work-profile", null]);
+
+    settlers[2]();
+    await flush();
+    expect(isRateLimitQueueDraining()).toBe(false);
   });
 
   it("targets an explicit selected host instead of the configured default host and writes only its cache key", async () => {

--- a/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
+++ b/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
@@ -15,12 +15,12 @@ import {
 import { EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS } from "@/lib/rate-limits/rate-limit-timing";
 
 /**
- * Shared serial fetch lane for the `ephemeralProcess` rate-limit providers
- * (codex, claude-code) - the only providers this queue serves. Each of their
- * pulls spawns a real CLI subprocess on the host, so every trigger that can
- * cause one (the interval timer, a turn completion, a manual "Refresh all")
- * routes through here to guarantee **at most one subprocess-spawning fetch is
- * in flight at a time**, no matter how many providers or how fast the clicks.
+ * Shared fetch queue for the `ephemeralProcess` rate-limit providers (codex,
+ * claude-code) - the only providers this queue serves. Each pull spawns a real
+ * CLI subprocess on the host, so interval timers, turn completions, and manual
+ * refreshes all route through here. Queue items run serially, but a deliberate
+ * batch (the popover's "Refresh all") may fan out its distinct profile pulls in
+ * parallel before the next queue item begins.
  *
  * `httpFetch` providers (openrouter, kilocode) NEVER touch this queue - they
  * poll directly via their query's own `refetchInterval`.
@@ -28,10 +28,10 @@ import { EPHEMERAL_RATE_LIMIT_POLL_INTERVAL_MS } from "@/lib/rate-limits/rate-li
  * The queue is a plain module holding process-wide state. The long-lived app
  * shell binds its default host via `configureRateLimitQueue`, while surfaces
  * that can inspect another host pass an explicit, render-time scope through
- * `enqueueRateLimitFetchForScope`. Both entry points append to the same promise
- * chain, so subprocess work remains serialized across every host scope. Each
- * enqueue snapshots its scope, so it cannot be reassigned by a later host swap
- * and always writes to the query key for the host that receives the RPC.
+ * `enqueueRateLimitFetchForScope`. Every entry point appends to the same promise
+ * chain, so queue items remain ordered across every host scope. Each enqueue
+ * snapshots its scope, so it cannot be reassigned by a later host swap and
+ * always writes to the query key for the host that receives the RPC.
  */
 
 type RateLimitUsageParams = RequestOfMethod<
@@ -51,9 +51,18 @@ export interface RateLimitQueueConfig {
   readonly request: RateLimitQueueRequestFn;
 }
 
+export interface RateLimitQueueBatchTarget {
+  readonly providerId: RateLimitProviderId;
+  readonly accountContext: AccountContext;
+  readonly profileId: string | null;
+}
+
+type RateLimitQueueFetch = () => Promise<ProviderRateLimitEnvelope | undefined>;
+
 let deps: RateLimitQueueConfig | null = null;
-// The serial lane itself: every enqueued fetch appends to the tail of this
-// promise chain, so fetch N+1's `fetchQuery` cannot start until fetch N settles.
+// The serial lane itself: every queue item appends to the tail of this promise
+// chain. An item normally contains one fetch, while an explicit batch may
+// contain several profile fetches that run concurrently inside that item.
 let chain: Promise<unknown> = Promise.resolve();
 let inFlightCount = 0;
 const drainingListeners = new Set<() => void>();
@@ -132,7 +141,7 @@ function notifyDraining(): void {
  * Bind (or, with `null`, unbind) the app-shell default scope. Called from an
  * effect that re-runs on default-host/client changes. Explicit host scopes do
  * not replace this binding; they only snapshot their own dependencies for one
- * enqueue onto the same serialized lane.
+ * enqueue onto the same ordered lane.
  */
 export function configureRateLimitQueue(
   next: RateLimitQueueConfig | null,
@@ -141,10 +150,10 @@ export function configureRateLimitQueue(
 }
 
 /**
- * `useSyncExternalStore`-compatible pair for the "a subprocess fetch is
- * running" signal - a bare promise chain isn't React-observable on its own.
- * The popover consumes this (via `useIsRateLimitQueueDraining`) to disable
- * "Refresh all" while the lane is draining.
+ * `useSyncExternalStore`-compatible pair for the "subprocess work is queued or
+ * running" signal - a bare promise chain isn't React-observable on its own. The
+ * popover consumes this (via `useIsRateLimitQueueDraining`) to disable "Refresh
+ * all" while the lane is draining.
  */
 export function subscribeRateLimitQueueDraining(
   listener: () => void,
@@ -212,9 +221,9 @@ function isInCooldown(
 }
 
 /**
- * Append a rate-limit pull for one `ephemeralProcess` provider to the serial
- * lane. Returns the tail of the chain so a caller ("Refresh all") can await the
- * lane draining.
+ * Append one `ephemeralProcess` provider/profile pull to the serial lane.
+ * Returns the tail of the chain so the caller can await this item and everything
+ * queued before it.
  *
  * - `force: false` (interval timer, turn completion): no-ops if the query's
  *   cached data is younger than `PROVIDER_RATE_LIMITS_STALE_TIME_MS`, so
@@ -238,6 +247,19 @@ export function enqueueRateLimitFetch(
 }
 
 /**
+ * Append one queue item whose distinct provider/profile pulls start together
+ * when that item reaches the front of the lane. Used by the popover's "Refresh
+ * all" action so profiles do not wait top-to-bottom, while later timers, turn
+ * completions, and clicks still wait for the whole refresh round to settle.
+ */
+export function enqueueRateLimitFetchBatch(
+  targets: ReadonlyArray<RateLimitQueueBatchTarget>,
+  opts: { readonly force: boolean },
+): Promise<unknown> {
+  return enqueueRateLimitFetchBatchForScope(deps, targets, opts);
+}
+
+/**
  * Append a provider pull for an explicit host/client/cache scope. The scope is
  * captured at call time and never mutates the app-shell default binding. A
  * `null` scope is the same readiness no-op as an unconfigured default queue.
@@ -248,67 +270,94 @@ export function enqueueRateLimitFetchForScope(
   accountContext: AccountContext,
   opts: { readonly force: boolean; readonly profileId: string | null },
 ): Promise<unknown> {
+  return enqueueRateLimitFetchBatchForScope(
+    scope,
+    [{ providerId, accountContext, profileId: opts.profileId }],
+    { force: opts.force },
+  );
+}
+
+function enqueueRateLimitFetchBatchForScope(
+  scope: RateLimitQueueConfig | null,
+  targets: ReadonlyArray<RateLimitQueueBatchTarget>,
+  opts: { readonly force: boolean },
+): Promise<unknown> {
   if (scope === null) return chain;
   const { hostId, queryClient, request } = scope;
-  const params: RateLimitUsageParams = {
-    accountContext,
-    providerId,
-    profileId: opts.profileId,
-  };
-  const queryKey = queryKeys.hostMethod<
-    HostRpcRegistry,
-    "host.getRateLimitUsage"
-  >(hostId, "host.getRateLimitUsage", params);
+  const fetches = targets
+    .map((target): RateLimitQueueFetch | null => {
+      const params: RateLimitUsageParams = {
+        accountContext: target.accountContext,
+        providerId: target.providerId,
+        profileId: target.profileId,
+      };
+      const queryKey = queryKeys.hostMethod<
+        HostRpcRegistry,
+        "host.getRateLimitUsage"
+      >(hostId, "host.getRateLimitUsage", params);
 
-  const isFresh = (): boolean => {
-    const updatedAt = queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0;
-    return Date.now() - updatedAt < PROVIDER_RATE_LIMITS_STALE_TIME_MS;
-  };
-  const shouldSkipAutomatic = (): boolean =>
-    !opts.force &&
-    (isFresh() || isInCooldown(hostId, providerId, opts.profileId));
-  if (shouldSkipAutomatic()) return chain;
+      function isFresh(): boolean {
+        const updatedAt =
+          queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0;
+        return Date.now() - updatedAt < PROVIDER_RATE_LIMITS_STALE_TIME_MS;
+      }
+      function shouldSkipAutomatic(): boolean {
+        return (
+          !opts.force &&
+          (isFresh() ||
+            isInCooldown(hostId, target.providerId, target.profileId))
+        );
+      }
+      if (shouldSkipAutomatic()) return null;
 
-  // Named request fn (not an inline closure in `queryFn`) so the host-scoped
-  // key stays the sole cache identity - `request` is stable module state, not a
-  // key input, and inlining it would trip the query plugin's exhaustive-deps
-  // check (mirrors `resolve-artifact-by-path.ts`).
-  const queryFn = async (): Promise<ProviderRateLimitEnvelope> => {
-    const response = await request(hostId, "host.getRateLimitUsage", params);
-    const envelope = mapResponseToProviderRateLimitEnvelope({
-      response,
-      queryClient,
-      queryKey,
-    });
-    applyCooldownPolicy(hostId, providerId, opts.profileId, envelope);
-    return envelope;
-  };
+      // Named request fn (not an inline closure in `queryFn`) so the host-scoped
+      // key stays the sole cache identity - `request` is stable module state, not
+      // a key input, and inlining it would trip the query plugin's exhaustive-deps
+      // check (mirrors `resolve-artifact-by-path.ts`).
+      async function queryFn(): Promise<ProviderRateLimitEnvelope> {
+        const response = await request(
+          hostId,
+          "host.getRateLimitUsage",
+          params,
+        );
+        const envelope = mapResponseToProviderRateLimitEnvelope({
+          response,
+          queryClient,
+          queryKey,
+        });
+        applyCooldownPolicy(
+          hostId,
+          target.providerId,
+          target.profileId,
+          envelope,
+        );
+        return envelope;
+      }
+
+      function runFetch(): Promise<ProviderRateLimitEnvelope | undefined> {
+        // Re-checked when this batch reaches the front of the lane: an earlier
+        // item may have refreshed this exact profile (or entered it into
+        // cool-down) while this item waited.
+        if (shouldSkipAutomatic()) return Promise.resolve(undefined);
+        // `staleTime: 0` is load-bearing: `fetchQuery` inherits the app
+        // QueryClient's GLOBAL `staleTime` default (60s in `query-client.ts`)
+        // and otherwise serves still-fresh cache without fetching at all.
+        return queryClient.fetchQuery({ queryKey, queryFn, staleTime: 0 });
+      }
+
+      return runFetch;
+    })
+    .filter((fetch): fetch is RateLimitQueueFetch => fetch !== null);
+  if (fetches.length === 0) return chain;
 
   inFlightCount += 1;
   notifyDraining();
   chain = chain
-    .then(() => {
-      // Re-checked at this fetch's turn in the lane (not just at enqueue time):
-      // an earlier fetch in the same round may have just refreshed this exact
-      // provider (or just entered it into cool-down), and an automatic trigger
-      // must not re-spawn a subprocess for data that became fresh - or a
-      // provider that entered cool-down - while it waited in the queue.
-      if (shouldSkipAutomatic()) return undefined;
-      // `staleTime: 0` is load-bearing: `fetchQuery` inherits the app
-      // QueryClient's GLOBAL `staleTime` default (60s in `query-client.ts`)
-      // and serves still-fresh cache without fetching at all. The popover's
-      // open-time refresh keeps this data younger than 60s, so without the
-      // override a user's `force: true` refresh silently no-oped - resolving
-      // from cache in a microtask, spawning no subprocess, flipping
-      // `draining` for under a frame - while the httpFetch lane's
-      // `invalidateQueries` (which always refetches) visibly spun. Freshness
-      // policy for automatic triggers lives in the explicit `isFresh` checks
-      // above, never in `fetchQuery`'s own staleness short-circuit.
-      return queryClient.fetchQuery({ queryKey, queryFn, staleTime: 0 });
-    })
-    // One provider's failure must not block the next provider's turn in the
-    // lane, and must not reject the shared chain (which every future enqueue
-    // builds on).
+    .then(() =>
+      Promise.all(fetches.map((fetch) => fetch().catch(() => undefined))),
+    )
+    // One profile's failure must not block a later queue item or reject the
+    // shared chain (which every future enqueue builds on).
     .catch(() => undefined)
     .finally(() => {
       inFlightCount -= 1;


### PR DESCRIPTION
## Summary

- batch ephemeral-process usage refreshes so every configured provider profile starts concurrently
- keep the batch behind the shared queue so later polling, turn-completion refreshes, and clicks remain serialized
- preserve exact host/provider/profile TanStack Query cache identity, including a lone managed profile
- add queue timing and popover target-selection regressions

## Validation

- pre-commit run --all-files
- full gui-app suite: 5,474 passed, 1 skipped
- focused rate-limit suites: 71 passed
- isolated rerun of broad-suite CLI, desktop, and protocol failures: 107 passed
- GUI compile, focused ESLint, formatting, and React Doctor passed

## Notes

The broad multi-workspace test run encountered unrelated concurrent CLI/desktop timeouts and the known protocol fuzz instability; every affected test passed immediately in isolated reruns.

No internal repository gitlink update is included; that remains deferred until this submodule PR merges.