### PR TITLE
feat(notifications): surface actionable provider failures

### DIFF
--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -461,7 +461,9 @@ describe("NotificationsPopover click routing", () => {
     expect(completed?.textContent).toContain("Agent • Done");
     expect(stalled?.dataset.notificationSeverity).toBe("failure");
     expect(stalled?.textContent).toContain(TASK_TITLE);
-    expect(stalled?.textContent).toContain("Agent • Stalled");
+    expect(stalled?.textContent).toContain(
+      "Agent • Provider is taking longer than expected",
+    );
 
     if (completed === undefined) throw new Error("missing completed row");
     const notificationTitle =

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
@@ -202,8 +202,7 @@ describe("merged notifications feed", () => {
     });
     expect(rowFromHostEntry(stalled)).toMatchObject({
       title: "Checkout notifications",
-      body:
-        "Deploy checkout fix • Provider is taking longer than expected",
+      body: "Deploy checkout fix • Provider is taking longer than expected",
     });
     expect(rowFromHostEntry(interview)).toMatchObject({
       title: "Checkout notifications",

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
@@ -225,7 +225,7 @@ describe("merged notifications feed", () => {
     const entry = (
       reason: string | undefined,
       code: string,
-      providerId: "claude-code" | undefined,
+      providerId: string | undefined,
     ): HostNotificationEntry => ({
       ...base,
       payload: {
@@ -262,6 +262,11 @@ describe("merged notifications feed", () => {
         body: "Debug notifications • Provider is signed out. Reconnect to continue.",
       },
     );
+    expect(
+      rowFromHostEntry(entry("auth", "auth", "future-provider")),
+    ).toMatchObject({
+      body: "Debug notifications • Provider is signed out. Reconnect to continue.",
+    });
     expect(
       rowFromHostEntry(entry(undefined, "MISSING_API_KEY", "claude-code")),
     ).toMatchObject({

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
@@ -202,11 +202,71 @@ describe("merged notifications feed", () => {
     });
     expect(rowFromHostEntry(stalled)).toMatchObject({
       title: "Checkout notifications",
-      body: "Deploy checkout fix • Stalled",
+      body:
+        "Deploy checkout fix • Provider is taking longer than expected",
     });
     expect(rowFromHostEntry(interview)).toMatchObject({
       title: "Checkout notifications",
       body: "Deploy checkout fix • Question waiting",
+    });
+  });
+
+  it("renders safe semantic failure copy without exposing raw messages", () => {
+    const base = {
+      id: "notification-semantic",
+      updatedAt: 10,
+      readAt: null,
+      sourceRef: "agent-1",
+      epicId: "epic-1",
+      chatId: "chat-1",
+      kind: "agent.stopped",
+      severity: "failure",
+      outcome: "errored",
+    } as const;
+    const entry = (
+      reason: string | undefined,
+      code: string,
+      providerId: "claude-code" | undefined,
+    ): HostNotificationEntry => ({
+      ...base,
+      payload: {
+        kind: "chat",
+        epicId: "epic-1",
+        chatId: "chat-1",
+        agentName: "Debug notifications",
+        taskTitle: "Notification errors",
+        outcome: "errored",
+        code,
+        message: "raw /Users/alice/private-path and provider output",
+        reason,
+        providerId,
+      },
+    });
+
+    expect(
+      rowFromHostEntry(entry("auth", "auth", "claude-code")),
+    ).toMatchObject({
+      body: "Debug notifications • Claude Code is signed out. Reconnect to continue.",
+    });
+    expect(
+      rowFromHostEntry(entry("rate_limit", "future-code", "claude-code")),
+    ).toMatchObject({
+      body: "Debug notifications • Claude Code rate limit reached",
+    });
+    expect(
+      rowFromHostEntry(entry("future-reason", "future-code", undefined)),
+    ).toMatchObject({
+      body: "Debug notifications • Failed",
+    });
+    expect(rowFromHostEntry(entry(undefined, "auth", undefined))).toMatchObject(
+      {
+        body: "Debug notifications • Provider is signed out. Reconnect to continue.",
+      },
+    );
+    expect(
+      rowFromHostEntry(entry(undefined, "MISSING_API_KEY", "claude-code")),
+    ).toMatchObject({
+      body: "Debug notifications • Failed",
     });
   });
 

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -30,11 +30,18 @@ import {
   useNotificationsStore,
 } from "@/stores/notifications/notifications-store";
 import {
+  deriveHostNotificationStoppedReason,
   parseKnownHostNotificationPayloadForKind,
   type HostNotificationKnownPayload,
   type HostNotificationOutcome,
   type HostNotificationSeverity,
 } from "@traycer/protocol/host/notifications/contracts";
+import {
+  PROVIDER_DISPLAY_NAMES,
+  providerIdSchema,
+  type ProviderId,
+} from "@traycer/protocol/host/provider-schemas";
+import { providerSignedOutMessage } from "@traycer/protocol/host/provider-display";
 import type { NotificationEntry } from "@traycer/protocol/notifications/notification-entry";
 import { formatNotification } from "@traycer/protocol/notifications/notification-formatter";
 
@@ -563,16 +570,17 @@ function hostNotificationPresentation(
   switch (entry.kind) {
     case "agent.stopped": {
       const context = notificationContext(agentName, title, isTerminalAgent);
-      const code = known === null ? null : knownStoppedCode(known);
+      const reason = known === null ? null : knownStoppedReason(known);
+      const providerId = known === null ? null : knownProviderId(known);
       return {
         title,
-        body: `${context} • ${agentStoppedStatus(entry.outcome, code)}`,
+        body: `${context} • ${agentStoppedStatus(entry.outcome, reason, providerId)}`,
       };
     }
     case "agent.stalled":
       return {
         title,
-        body: `${notificationContext(agentName, title, isTerminalAgent)} • Stalled`,
+        body: `${notificationContext(agentName, title, isTerminalAgent)} • ${agentStalledStatus(known)}`,
       };
     case "approval.requested":
       return { title, body: `${chatContext} • Approval requested` };
@@ -605,13 +613,32 @@ function knownChatTitle(payload: HostNotificationKnownPayload): string | null {
   }
 }
 
-function knownStoppedCode(
+function knownStoppedReason(
   payload: HostNotificationKnownPayload,
 ): string | null {
   switch (payload.kind) {
     case "chat":
     case "epic":
-      return payload.code ?? null;
+      return (
+        payload.reason ??
+        deriveHostNotificationStoppedReason(payload.code ?? null)
+      );
+    case "agent_stalled":
+    case "approval":
+    case "interview":
+      return null;
+  }
+}
+
+function knownProviderId(
+  payload: HostNotificationKnownPayload,
+): ProviderId | null {
+  switch (payload.kind) {
+    case "chat":
+    case "epic": {
+      const parsed = providerIdSchema.safeParse(payload.providerId);
+      return parsed.success ? parsed.data : null;
+    }
     case "agent_stalled":
     case "approval":
     case "interview":
@@ -621,12 +648,69 @@ function knownStoppedCode(
 
 function agentStoppedStatus(
   outcome: HostNotificationOutcome,
-  code: string | null,
+  reason: string | null,
+  providerId: ProviderId | null,
 ): string {
-  if (code === "RATE_LIMIT") return "Rate limit reached";
-  if (outcome === "errored") return "Failed";
+  if (outcome === "errored") {
+    return agentStoppedFailureStatus(reason, providerId);
+  }
   if (outcome === "stopped") return "Stopped";
   return "Done";
+}
+
+function agentStoppedFailureStatus(
+  reason: string | null,
+  providerId: ProviderId | null,
+): string {
+  const providerName =
+    providerId === null ? null : PROVIDER_DISPLAY_NAMES[providerId];
+  switch (reason) {
+    case "auth":
+      return providerId === null
+        ? "Provider is signed out. Reconnect to continue."
+        : providerSignedOutMessage(providerId);
+    case "rate_limit":
+      return providerName === null
+        ? "Rate limit reached"
+        : `${providerName} rate limit reached`;
+    case "billing":
+      return providerName === null
+        ? "Provider billing issue"
+        : `${providerName} billing issue`;
+    case "model_unavailable":
+      return "Model unavailable";
+    case "provider_unavailable":
+      return providerName === null
+        ? "Provider is temporarily unavailable"
+        : `${providerName} is temporarily unavailable`;
+    case "provider_connection_failed":
+      return providerName === null
+        ? "Provider connection failed"
+        : `Connection to ${providerName} failed`;
+    case "turn_start_timeout":
+      return "Provider did not start in time";
+    case "missing_terminal_event":
+      return "Provider stopped responding";
+    case "background_work_failed":
+      return "Background work stopped";
+    case null:
+    default:
+      return "Failed";
+  }
+}
+
+function agentStalledStatus(
+  payload: HostNotificationKnownPayload | null,
+): string {
+  if (payload?.kind !== "agent_stalled") return "Stalled";
+  switch (payload.reason) {
+    case "provider_buffering":
+      return "Provider is taking longer than expected";
+    case "provider_reroute":
+      return "Provider is rerouting";
+    default:
+      return "Stalled";
+  }
 }
 
 function notificationContext(

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -662,31 +662,37 @@ function agentStoppedFailureStatus(
   reason: string | null,
   providerId: ProviderId | null,
 ): string {
-  const providerName =
-    providerId === null ? null : PROVIDER_DISPLAY_NAMES[providerId];
   switch (reason) {
     case "auth":
       return providerId === null
         ? "Provider is signed out. Reconnect to continue."
         : providerSignedOutMessage(providerId);
     case "rate_limit":
-      return providerName === null
-        ? "Rate limit reached"
-        : `${providerName} rate limit reached`;
+      return providerSpecificFailureStatus(
+        providerId,
+        "Rate limit reached",
+        (providerName) => `${providerName} rate limit reached`,
+      );
     case "billing":
-      return providerName === null
-        ? "Provider billing issue"
-        : `${providerName} billing issue`;
+      return providerSpecificFailureStatus(
+        providerId,
+        "Provider billing issue",
+        (providerName) => `${providerName} billing issue`,
+      );
     case "model_unavailable":
       return "Model unavailable";
     case "provider_unavailable":
-      return providerName === null
-        ? "Provider is temporarily unavailable"
-        : `${providerName} is temporarily unavailable`;
+      return providerSpecificFailureStatus(
+        providerId,
+        "Provider is temporarily unavailable",
+        (providerName) => `${providerName} is temporarily unavailable`,
+      );
     case "provider_connection_failed":
-      return providerName === null
-        ? "Provider connection failed"
-        : `Connection to ${providerName} failed`;
+      return providerSpecificFailureStatus(
+        providerId,
+        "Provider connection failed",
+        (providerName) => `Connection to ${providerName} failed`,
+      );
     case "turn_start_timeout":
       return "Provider did not start in time";
     case "missing_terminal_event":
@@ -697,6 +703,16 @@ function agentStoppedFailureStatus(
     default:
       return "Failed";
   }
+}
+
+function providerSpecificFailureStatus(
+  providerId: ProviderId | null,
+  genericStatus: string,
+  providerStatus: (providerName: string) => string,
+): string {
+  return providerId === null
+    ? genericStatus
+    : providerStatus(PROVIDER_DISPLAY_NAMES[providerId]);
 }
 
 function agentStalledStatus(

--- a/protocol/src/host/notifications/__tests__/payloads.test.ts
+++ b/protocol/src/host/notifications/__tests__/payloads.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  deriveHostNotificationStoppedReason,
   hostNotificationPayloadWithChatTitle,
   parseKnownHostNotificationPayload,
   parseKnownHostNotificationPayloadForKind,
@@ -88,6 +89,35 @@ describe("parseKnownHostNotificationPayload", () => {
     });
   });
 
+  it("accepts additive stopped reason and provider attribution fields", () => {
+    expect(
+      parseKnownHostNotificationPayload({
+        ...CHAT_STOPPED,
+        outcome: "errored",
+        code: "auth",
+        reason: "auth",
+        providerId: "claude-code",
+      }),
+    ).toMatchObject({
+      kind: "chat",
+      code: "auth",
+      reason: "auth",
+      providerId: "claude-code",
+    });
+  });
+
+  it("keeps a future provider id without invalidating the known payload", () => {
+    expect(
+      parseKnownHostNotificationPayload({
+        ...CHAT_STOPPED,
+        providerId: "future-provider",
+      }),
+    ).toMatchObject({
+      kind: "chat",
+      providerId: "future-provider",
+    });
+  });
+
   // A malformed row with empty identifiers must degrade rather than mint an
   // unusable deep-link.
   it("rejects empty identifier fields", () => {
@@ -121,6 +151,38 @@ describe("parseKnownHostNotificationPayload", () => {
     expect(parseKnownHostNotificationPayload(null)).toBeNull();
     expect(parseKnownHostNotificationPayload(undefined)).toBeNull();
     expect(parseKnownHostNotificationPayload([CHAT_STOPPED])).toBeNull();
+  });
+});
+
+describe("deriveHostNotificationStoppedReason", () => {
+  it.each([
+    ["auth", "auth"],
+    ["rate_limit", "rate_limit"],
+    ["RATE_LIMIT", "rate_limit"],
+    ["usage_limit_exceeded", "rate_limit"],
+    ["session_budget_exceeded", "rate_limit"],
+    ["billing_error", "billing"],
+    ["model_not_found", "model_unavailable"],
+    ["overloaded", "provider_unavailable"],
+    ["server_error", "provider_unavailable"],
+    ["CLAUDE_CODE_TRANSPORT", "provider_connection_failed"],
+    ["TURN_START_TIMEOUT", "turn_start_timeout"],
+    ["MISSING_TERMINAL_EVENT", "missing_terminal_event"],
+    ["background_work_died", "background_work_failed"],
+  ])("normalizes %s to %s", (code, reason) => {
+    expect(deriveHostNotificationStoppedReason(code)).toBe(reason);
+  });
+
+  it.each([
+    null,
+    "MISSING_API_KEY",
+    "invalid_request",
+    "refusal",
+    "RUNTIME_THROWN",
+    "TURN_FINALIZATION_FAILED",
+    "future_error",
+  ])("keeps unsafe or unknown code %s generic", (code) => {
+    expect(deriveHostNotificationStoppedReason(code)).toBeNull();
   });
 });
 

--- a/protocol/src/host/notifications/payloads.ts
+++ b/protocol/src/host/notifications/payloads.ts
@@ -29,6 +29,62 @@ import {
  * letting it through would mint an unusable deep-link instead of degrading. */
 const idSchema = z.string().min(1);
 
+export const HOST_NOTIFICATION_STOPPED_REASONS = [
+  "auth",
+  "rate_limit",
+  "billing",
+  "model_unavailable",
+  "provider_unavailable",
+  "provider_connection_failed",
+  "turn_start_timeout",
+  "missing_terminal_event",
+  "background_work_failed",
+] as const;
+export type HostNotificationStoppedReason =
+  (typeof HOST_NOTIFICATION_STOPPED_REASONS)[number];
+
+/**
+ * Central normalization for the stable runtime codes that are safe to explain
+ * in a durable notification. Unknown, ambiguous, configuration, and
+ * provider-controlled errors deliberately return `null`: consumers must use
+ * generic failure copy rather than infer semantics from raw text.
+ *
+ * New rows persist the result at the host notification boundary. Consumers may
+ * also call this only as a compatibility fallback for rows minted before the
+ * additive `reason` field existed.
+ */
+export function deriveHostNotificationStoppedReason(
+  code: string | null,
+): HostNotificationStoppedReason | null {
+  const normalized = code?.trim().toLowerCase() ?? null;
+  switch (normalized) {
+    case "auth":
+      return "auth";
+    case "rate_limit":
+    case "usage_limit_exceeded":
+    case "session_budget_exceeded":
+      return "rate_limit";
+    case "billing_error":
+      return "billing";
+    case "model_not_found":
+      return "model_unavailable";
+    case "overloaded":
+    case "server_error":
+      return "provider_unavailable";
+    case "claude_code_transport":
+      return "provider_connection_failed";
+    case "turn_start_timeout":
+      return "turn_start_timeout";
+    case "missing_terminal_event":
+      return "missing_terminal_event";
+    case "background_work_died":
+      return "background_work_failed";
+    case null:
+    default:
+      return null;
+  }
+}
+
 /**
  * GUI `agent.stopped` payload: the "chat" shape. `agentName` carries the
  * chat title (the GUI agent IS the chat).
@@ -43,6 +99,8 @@ export const hostNotificationChatStoppedPayloadSchema = z
     outcome: hostNotificationOutcomeSchema,
     code: z.string().optional(),
     message: z.string().optional(),
+    reason: z.string().optional(),
+    providerId: z.string().optional(),
   })
   .catchall(z.unknown());
 export type HostNotificationChatStoppedPayload = z.infer<
@@ -63,6 +121,8 @@ export const hostNotificationEpicStoppedPayloadSchema = z
     outcome: hostNotificationOutcomeSchema,
     code: z.string().optional(),
     message: z.string().optional(),
+    reason: z.string().optional(),
+    providerId: z.string().optional(),
   })
   .catchall(z.unknown());
 export type HostNotificationEpicStoppedPayload = z.infer<
@@ -122,16 +182,13 @@ export type HostNotificationInterviewPayload = z.infer<
   typeof hostNotificationInterviewPayloadSchema
 >;
 
-export const hostNotificationKnownPayloadSchema = z.discriminatedUnion(
-  "kind",
-  [
-    hostNotificationChatStoppedPayloadSchema,
-    hostNotificationEpicStoppedPayloadSchema,
-    hostNotificationAgentStalledPayloadSchema,
-    hostNotificationApprovalPayloadSchema,
-    hostNotificationInterviewPayloadSchema,
-  ],
-);
+export const hostNotificationKnownPayloadSchema = z.discriminatedUnion("kind", [
+  hostNotificationChatStoppedPayloadSchema,
+  hostNotificationEpicStoppedPayloadSchema,
+  hostNotificationAgentStalledPayloadSchema,
+  hostNotificationApprovalPayloadSchema,
+  hostNotificationInterviewPayloadSchema,
+]);
 export type HostNotificationKnownPayload = z.infer<
   typeof hostNotificationKnownPayloadSchema
 >;


### PR DESCRIPTION
## Summary
- persist normalized, provider-aware stop reasons in notification payloads
- present safe actionable failure copy without exposing raw provider messages
- cover legacy rows, future provider IDs, and stalled states

## Verification
- bun test protocol/src/host/notifications/__tests__/payloads.test.ts
- bun run test -- src/stores/notifications/__tests__/merged-notifications.test.ts src/components/notifications/__tests__/notifications-popover.test.tsx
- bun run compile
- React Doctor changed-file scan