### PR TITLE
fix(gui-app): don't fail a terminal-account switch while its auth probe is pending

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -476,6 +476,10 @@ vi.mock("@/components/ui/dropdown-menu", () => {
 
 import { ProvidersSettingsPanel } from "@/components/settings/panels/providers-settings-panel";
 import { ProviderProfileScopedSection } from "@/components/settings/panels/provider-profile-scoped-section";
+import {
+  AMBIENT_AUTH_PENDING_REPOLL_CAP,
+  AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS,
+} from "@/components/settings/panels/use-provider-profile-login-flow";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { redactEmail } from "@/lib/providers/redact-email";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
@@ -651,6 +655,41 @@ function codePasteReauthProviderState(): ProviderCliState {
   };
 }
 
+/**
+ * An `awaitLogin` response for the ambient row taken while the host's auth
+ * probe is still in flight: the login runner evicts the ambient auth-cache
+ * entry when the login child closes, so the row can read non-definitive with
+ * `authPending` set even though the sign-in landed. The flow must treat this
+ * as unsettled, never as a failed sign-in.
+ */
+function pendingAmbientAwaitResponse(): unknown {
+  return {
+    codeRejected: false,
+    existingProfileId: null,
+    state: {
+      authPending: true,
+      auth: {
+        status: "unknown",
+        badgeText: null,
+        label: null,
+        detail: null,
+      },
+      profiles: [
+        profile({
+          profileId: "ambient",
+          kind: "ambient",
+          label: "Terminal account",
+          email: null,
+          tier: null,
+          authStatus: "unknown",
+          duplicateOfProfileId: null,
+          ambientDriftNotice: null,
+        }),
+      ],
+    },
+  };
+}
+
 function codePasteCreateProviderState(): ProviderCliState {
   return {
     ...providerState({
@@ -769,6 +808,10 @@ describe("<ProvidersSettingsPanel />", () => {
   });
 
   afterEach(() => {
+    // Unconditional and before `cleanup()`: the ambient re-poll tests opt into
+    // fake timers mid-test, and a leaked fake clock would strand every later
+    // test's timers (and Testing Library's own unmount work).
+    vi.useRealTimers();
     cleanup();
     useDesktopDialogStore.setState({
       activeDialog: null,
@@ -2374,6 +2417,9 @@ describe("<ProvidersSettingsPanel />", () => {
       profileId: "ambient",
       createProfile: null,
     });
+    // From here on the re-poll's timer is the only thing being waited on -
+    // drive it deterministically instead of sleeping out the real delay.
+    vi.useFakeTimers();
     act(() => {
       startOptions.onSuccess({
         url: "https://login.example.test",
@@ -2392,43 +2438,17 @@ describe("<ProvidersSettingsPanel />", () => {
       profileId: "ambient",
     });
     act(() => {
-      awaitOptions.onSuccess({
-        codeRejected: false,
-        existingProfileId: null,
-        state: {
-          authPending: true,
-          auth: {
-            status: "unknown",
-            badgeText: null,
-            label: null,
-            detail: null,
-          },
-          profiles: [
-            profile({
-              profileId: "ambient",
-              kind: "ambient",
-              label: "Terminal account",
-              email: null,
-              tier: null,
-              authStatus: "unknown",
-              duplicateOfProfileId: null,
-              ambientDriftNotice: null,
-            }),
-          ],
-        },
-      });
+      awaitOptions.onSuccess(pendingAmbientAwaitResponse());
     });
 
     expect(screen.queryByText("Sign-in did not finish. Try again.")).toBeNull();
 
     // The bounded re-poll fires after its short delay; its re-probed state
     // is authoritative and resolves the switch to the identity step.
-    await waitFor(
-      () => {
-        expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(2);
-      },
-      { timeout: 4_000 },
-    );
+    act(() => {
+      vi.advanceTimersByTime(AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS);
+    });
+    expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(2);
     const repollCall = providerMocks.awaitLoginMutate.mock.calls.at(1);
     if (repollCall === undefined) {
       throw new Error("Expected re-poll await login call.");
@@ -2465,6 +2485,72 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
   }, 10_000);
 
+  it("ignores an in-flight ambient re-poll that resolves after the sign-in was cancelled", async () => {
+    providerMocks.listResult.data = {
+      providers: [codePasteReauthProviderState()],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Terminal account" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
+    await waitFor(() => {
+      expect(providerMocks.startLoginMutate).toHaveBeenCalled();
+    });
+    const [, startOptions] = firstStartLoginCall();
+    vi.useFakeTimers();
+    act(() => {
+      startOptions.onSuccess({
+        url: "https://login.example.test",
+        started: true,
+        profileId: "ambient",
+      });
+    });
+
+    const [, awaitOptions] = firstAwaitLoginCall();
+    act(() => {
+      awaitOptions.onSuccess(pendingAmbientAwaitResponse());
+    });
+
+    // The re-poll is dispatched...
+    act(() => {
+      vi.advanceTimersByTime(AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS);
+    });
+    expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(2);
+    const repollCall = providerMocks.awaitLoginMutate.mock.calls.at(1);
+    if (repollCall === undefined) {
+      throw new Error("Expected re-poll await login call.");
+    }
+
+    // ...and the user cancels while it is still in flight. Clearing the timer
+    // cannot recall an already-dispatched RPC, and cancelling leaves the
+    // attempt id untouched, so the late resolution must be ignored outright -
+    // otherwise it settles a cancelled attempt, and a still-pending verdict
+    // would arm yet another re-poll for a sign-in the user already abandoned.
+    fireEvent.click(screen.getByRole("button", { name: "Cancel sign-in" }));
+    expect(providerMocks.cancelLoginMutate).toHaveBeenCalledWith({
+      providerId: "codex",
+      profileId: "ambient",
+    });
+
+    act(() => {
+      repollCall[1].onSuccess(pendingAmbientAwaitResponse());
+    });
+
+    // No third await: the cancelled attempt must not keep re-polling. Advanced
+    // well past the delay so any scheduled tick would have fired.
+    act(() => {
+      vi.advanceTimersByTime(AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS * 3);
+    });
+    expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(2);
+    expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
+  });
+
   it("fails after the ambient authPending re-poll budget is exhausted without a definitive verdict", async () => {
     providerMocks.listResult.data = {
       providers: [codePasteReauthProviderState()],
@@ -2483,6 +2569,7 @@ describe("<ProvidersSettingsPanel />", () => {
       expect(providerMocks.startLoginMutate).toHaveBeenCalled();
     });
     const [, startOptions] = firstStartLoginCall();
+    vi.useFakeTimers();
     act(() => {
       startOptions.onSuccess({
         url: "https://login.example.test",
@@ -2491,59 +2578,35 @@ describe("<ProvidersSettingsPanel />", () => {
       });
     });
 
-    const pendingAmbientResponse = {
-      codeRejected: false,
-      existingProfileId: null,
-      state: {
-        authPending: true,
-        auth: {
-          status: "unknown",
-          badgeText: null,
-          label: null,
-          detail: null,
-        },
-        profiles: [
-          profile({
-            profileId: "ambient",
-            kind: "ambient",
-            label: "Terminal account",
-            email: null,
-            tier: null,
-            authStatus: "unknown",
-            duplicateOfProfileId: null,
-            ambientDriftNotice: null,
-          }),
-        ],
-      },
-    };
-
     // The initial await plus every budgeted re-poll keeps reporting the
     // probe as still pending - after the budget is spent the flow must land
     // on the ordinary not-finished failure instead of re-polling forever.
-    for (let attempt = 0; attempt < 4; attempt += 1) {
-      await waitFor(
-        () => {
-          expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(
-            attempt + 1,
-          );
-        },
-        { timeout: 4_000 },
-      );
+    for (
+      let attempt = 0;
+      attempt < AMBIENT_AUTH_PENDING_REPOLL_CAP + 1;
+      attempt += 1
+    ) {
+      expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(attempt + 1);
       const awaitCall = providerMocks.awaitLoginMutate.mock.calls.at(attempt);
       if (awaitCall === undefined) {
         throw new Error("Expected await login call.");
       }
       act(() => {
-        awaitCall[1].onSuccess(pendingAmbientResponse);
+        awaitCall[1].onSuccess(pendingAmbientAwaitResponse());
+      });
+      act(() => {
+        vi.advanceTimersByTime(AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS);
       });
     }
 
     expect(
       screen.getByText("Sign-in did not finish. Try again."),
     ).toBeDefined();
-    expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(4);
+    expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(
+      AMBIENT_AUTH_PENDING_REPOLL_CAP + 1,
+    );
     expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
-  }, 15_000);
+  });
 
   it("restarts with a session-expired notice when awaitLogin also fails after a noActiveLogin submit response (fixup review finding 1, genuine restart)", async () => {
     providerMocks.listResult.data = {

--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -2351,6 +2351,200 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
   });
 
+  it("re-polls awaitLogin instead of failing when the ambient row is still authPending after the login completes (terminal-account switch)", async () => {
+    providerMocks.listResult.data = {
+      providers: [codePasteReauthProviderState()],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Terminal account" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
+    await waitFor(() => {
+      expect(providerMocks.startLoginMutate).toHaveBeenCalled();
+    });
+    const [startVariables, startOptions] = firstStartLoginCall();
+    expect(startVariables).toEqual({
+      providerId: "codex",
+      profileId: "ambient",
+      createProfile: null,
+    });
+    act(() => {
+      startOptions.onSuccess({
+        url: "https://login.example.test",
+        started: true,
+        profileId: "ambient",
+      });
+    });
+
+    // The sign-in landed, but the host assembled the response right after
+    // the login runner evicted the ambient auth-cache entry: the ambient row
+    // reads non-definitive with the probe still in flight (`authPending`).
+    // That must resolve as "not settled yet" - never as a failed sign-in.
+    const [awaitVariables, awaitOptions] = firstAwaitLoginCall();
+    expect(awaitVariables).toEqual({
+      providerId: "codex",
+      profileId: "ambient",
+    });
+    act(() => {
+      awaitOptions.onSuccess({
+        codeRejected: false,
+        existingProfileId: null,
+        state: {
+          authPending: true,
+          auth: {
+            status: "unknown",
+            badgeText: null,
+            label: null,
+            detail: null,
+          },
+          profiles: [
+            profile({
+              profileId: "ambient",
+              kind: "ambient",
+              label: "Terminal account",
+              email: null,
+              tier: null,
+              authStatus: "unknown",
+              duplicateOfProfileId: null,
+              ambientDriftNotice: null,
+            }),
+          ],
+        },
+      });
+    });
+
+    expect(screen.queryByText("Sign-in did not finish. Try again.")).toBeNull();
+
+    // The bounded re-poll fires after its short delay; its re-probed state
+    // is authoritative and resolves the switch to the identity step.
+    await waitFor(
+      () => {
+        expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 4_000 },
+    );
+    const repollCall = providerMocks.awaitLoginMutate.mock.calls.at(1);
+    if (repollCall === undefined) {
+      throw new Error("Expected re-poll await login call.");
+    }
+    expect(repollCall[0]).toEqual({
+      providerId: "codex",
+      profileId: "ambient",
+    });
+    act(() => {
+      repollCall[1].onSuccess({
+        codeRejected: false,
+        existingProfileId: null,
+        state: {
+          authPending: false,
+          profiles: [
+            profile({
+              profileId: "ambient",
+              kind: "ambient",
+              label: "Terminal account",
+              email: "personal@example.test",
+              tier: null,
+              authStatus: "authenticated",
+              duplicateOfProfileId: null,
+              ambientDriftNotice: null,
+            }),
+          ],
+        },
+      });
+    });
+
+    expect(screen.getByText("Signed in as")).toBeDefined();
+    // Exactly one login child for the whole switch - re-polling never
+    // restarts the OAuth flow.
+    expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
+  }, 10_000);
+
+  it("fails after the ambient authPending re-poll budget is exhausted without a definitive verdict", async () => {
+    providerMocks.listResult.data = {
+      providers: [codePasteReauthProviderState()],
+    };
+
+    render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Terminal account" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
+    await waitFor(() => {
+      expect(providerMocks.startLoginMutate).toHaveBeenCalled();
+    });
+    const [, startOptions] = firstStartLoginCall();
+    act(() => {
+      startOptions.onSuccess({
+        url: "https://login.example.test",
+        started: true,
+        profileId: "ambient",
+      });
+    });
+
+    const pendingAmbientResponse = {
+      codeRejected: false,
+      existingProfileId: null,
+      state: {
+        authPending: true,
+        auth: {
+          status: "unknown",
+          badgeText: null,
+          label: null,
+          detail: null,
+        },
+        profiles: [
+          profile({
+            profileId: "ambient",
+            kind: "ambient",
+            label: "Terminal account",
+            email: null,
+            tier: null,
+            authStatus: "unknown",
+            duplicateOfProfileId: null,
+            ambientDriftNotice: null,
+          }),
+        ],
+      },
+    };
+
+    // The initial await plus every budgeted re-poll keeps reporting the
+    // probe as still pending - after the budget is spent the flow must land
+    // on the ordinary not-finished failure instead of re-polling forever.
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      await waitFor(
+        () => {
+          expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(
+            attempt + 1,
+          );
+        },
+        { timeout: 4_000 },
+      );
+      const awaitCall = providerMocks.awaitLoginMutate.mock.calls.at(attempt);
+      if (awaitCall === undefined) {
+        throw new Error("Expected await login call.");
+      }
+      act(() => {
+        awaitCall[1].onSuccess(pendingAmbientResponse);
+      });
+    }
+
+    expect(
+      screen.getByText("Sign-in did not finish. Try again."),
+    ).toBeDefined();
+    expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(4);
+    expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
+  }, 15_000);
+
   it("restarts with a session-expired notice when awaitLogin also fails after a noActiveLogin submit response (fixup review finding 1, genuine restart)", async () => {
     providerMocks.listResult.data = {
       providers: [codePasteReauthProviderState()],

--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -2551,6 +2551,64 @@ describe("<ProvidersSettingsPanel />", () => {
     expect(providerMocks.startLoginMutate).toHaveBeenCalledTimes(1);
   });
 
+  it("stops re-polling when an in-flight ambient re-poll resolves after the flow unmounted", async () => {
+    providerMocks.listResult.data = {
+      providers: [codePasteReauthProviderState()],
+    };
+
+    const view = render(
+      <TooltipProvider>
+        <ProvidersSettingsPanel />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Terminal account" }));
+    fireEvent.click(screen.getByRole("button", { name: "Manage profile" }));
+    fireEvent.click(screen.getByRole("button", { name: "Switch account" }));
+    await waitFor(() => {
+      expect(providerMocks.startLoginMutate).toHaveBeenCalled();
+    });
+    const [, startOptions] = firstStartLoginCall();
+    vi.useFakeTimers();
+    act(() => {
+      startOptions.onSuccess({
+        url: "https://login.example.test",
+        started: true,
+        profileId: "ambient",
+      });
+    });
+
+    const [, awaitOptions] = firstAwaitLoginCall();
+    act(() => {
+      awaitOptions.onSuccess(pendingAmbientAwaitResponse());
+    });
+    act(() => {
+      vi.advanceTimersByTime(AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS);
+    });
+    expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(2);
+    const repollCall = providerMocks.awaitLoginMutate.mock.calls.at(1);
+    if (repollCall === undefined) {
+      throw new Error("Expected re-poll await login call.");
+    }
+
+    // The flow goes away with its re-poll still in flight - no cancel involved
+    // (the in-chat banner unmounts on its own the moment its reauth gate
+    // clears). Clearing the scheduled timer is not enough: the dispatched RPC
+    // still resolves, and a still-pending verdict must not arm a fresh timer on
+    // a dead hook.
+    act(() => {
+      view.unmount();
+    });
+    act(() => {
+      repollCall[1].onSuccess(pendingAmbientAwaitResponse());
+    });
+    act(() => {
+      vi.advanceTimersByTime(AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS * 3);
+    });
+
+    expect(providerMocks.awaitLoginMutate).toHaveBeenCalledTimes(2);
+  });
+
   it("fails after the ambient authPending re-poll budget is exhausted without a definitive verdict", async () => {
     providerMocks.listResult.data = {
       providers: [codePasteReauthProviderState()],

--- a/clients/gui-app/src/components/settings/panels/use-provider-profile-login-flow.ts
+++ b/clients/gui-app/src/components/settings/panels/use-provider-profile-login-flow.ts
@@ -108,8 +108,11 @@ const CODE_PASTE_KEEPALIVE_INTERVAL_MS = 60_000;
  * instead of misreporting a successful switch as a failure. Definitive
  * verdicts (`authenticated`/`unauthenticated`) are never re-polled.
  */
-const AMBIENT_AUTH_PENDING_REPOLL_CAP = 3;
-const AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS = 2_000;
+export const AMBIENT_AUTH_PENDING_REPOLL_CAP = 3;
+// Exported so tests can drive the re-poll deterministically with fake timers
+// instead of hardcoding a duplicate magic number that could silently drift
+// from this value.
+export const AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS = 2_000;
 
 function isDefinitiveAuthStatus(
   status: ProviderProfile["auth"]["status"],
@@ -634,6 +637,18 @@ export function useProviderProfileLoginFlow(
             // the constant's doc comment). Scoped to this attempt's closure -
             // an auto-restart mints a fresh attempt with a fresh budget.
             let authPendingRepolls = 0;
+            // A resolution this attempt must no longer act on: either a later
+            // attempt (auto-restart, or the child finishing while a restart
+            // was already triggered) superseded this long-poll, or the flow
+            // was cancelled. Clearing the re-poll timer cannot cancel an
+            // already-dispatched RPC, and cancelling leaves `attemptIdRef`
+            // untouched - so without the cancellation half, a re-poll landing
+            // after `finishCancellation` would settle the attempt and
+            // overwrite the terminal `cancelled` state with a failure.
+            const attemptAbandoned = (): boolean =>
+              attemptIdRef.current !== thisAttemptId ||
+              cancelRequestedRef.current ||
+              cancelledRef.current;
             const scheduleAuthPendingRepoll = (): boolean => {
               if (authPendingRepolls >= AMBIENT_AUTH_PENDING_REPOLL_CAP) {
                 return false;
@@ -645,17 +660,13 @@ export function useProviderProfileLoginFlow(
               );
               repollTimerRef.current = window.setTimeout(() => {
                 repollTimerRef.current = null;
-                if (attemptIdRef.current !== thisAttemptId) return;
-                if (cancelRequestedRef.current || cancelledRef.current) return;
+                if (attemptAbandoned()) return;
                 awaitOnce();
               }, AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS);
               return true;
             };
             const handleAwaitSuccess = (result: AwaitLoginResult): void => {
-              // A later attempt (auto-restart, or the child finished
-              // while another restart was already triggered) already
-              // superseded this long-poll - ignore its stale resolution.
-              if (attemptIdRef.current !== thisAttemptId) return;
+              if (attemptAbandoned()) return;
               const resolution =
                 mode === "reauth" && existingProfileId === null
                   ? classifyAmbientAwaitResult(result)
@@ -680,7 +691,7 @@ export function useProviderProfileLoginFlow(
               settleAttempt(thisAttemptId);
             };
             const handleAwaitError = (): void => {
-              if (attemptIdRef.current !== thisAttemptId) return;
+              if (attemptAbandoned()) return;
               awaitOutcomeRef.current = "notAuthenticated";
               settleAttempt(thisAttemptId);
             };

--- a/clients/gui-app/src/components/settings/panels/use-provider-profile-login-flow.ts
+++ b/clients/gui-app/src/components/settings/panels/use-provider-profile-login-flow.ts
@@ -17,6 +17,7 @@ import {
   analyticsBlockerFromError,
   type AnalyticsBlocker,
 } from "@/lib/analytics";
+import { appLogger } from "@/lib/logger";
 
 type LoginMutationContext = { readonly hostId: string | null };
 
@@ -94,6 +95,109 @@ const CODE_PASTE_RESTART_LIMIT_MESSAGES: Record<CodePasteRestartCause, string> =
  *  typing (code-paste decision log's "Timeouts" row). */
 const CODE_PASTE_TOUCH_THROTTLE_MS = 45_000;
 const CODE_PASTE_KEEPALIVE_INTERVAL_MS = 60_000;
+
+/**
+ * Bounded re-poll for the ambient row's `authPending` window: the host's
+ * `providers.awaitLogin` response can carry a non-definitive ambient auth
+ * reading (the login runner evicts the ambient auth cache when the login
+ * child closes, and older hosts assemble the response from a non-blocking
+ * probe), so a not-yet-authenticated ambient verdict with `authPending` set
+ * means "the probe is still running", not "sign-in failed". Re-awaiting is
+ * cheap - with no login job in flight the host resolves immediately with a
+ * re-probed state - so a few short re-polls let the background probe land
+ * instead of misreporting a successful switch as a failure. Definitive
+ * verdicts (`authenticated`/`unauthenticated`) are never re-polled.
+ */
+const AMBIENT_AUTH_PENDING_REPOLL_CAP = 3;
+const AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS = 2_000;
+
+function isDefinitiveAuthStatus(
+  status: ProviderProfile["auth"]["status"],
+): boolean {
+  return status === "authenticated" || status === "unauthenticated";
+}
+
+type AwaitLoginResult = ResponseOfMethod<
+  HostRpcRegistry,
+  "providers.awaitLogin"
+>;
+
+/** What a settled `providers.awaitLogin` response means for the current
+ *  attempt - computed by the pure classifiers below, acted on by
+ *  `beginLogin`'s success handler. */
+type AwaitLoginResolution =
+  | {
+      readonly kind: "authenticated";
+      readonly payload: {
+        readonly profile: ProviderProfile;
+        readonly profiles: readonly ProviderProfile[];
+        readonly existingProfileId: string | null;
+      } | null;
+    }
+  | { readonly kind: "codeRejected" }
+  | { readonly kind: "authPending" }
+  | { readonly kind: "notAuthenticated" };
+
+/**
+ * Ambient reauth (no profile picker - the in-chat banner's OAuth reconnect)
+ * has no profile row to check: the re-probed top-level auth status is the
+ * only success signal, since `providers.list` keeps a profile row present
+ * even when it is signed out (fixup review finding 2 - presence alone is
+ * not success). A non-definitive top-level status with the probe still in
+ * flight is "not settled yet" (see `AMBIENT_AUTH_PENDING_REPOLL_CAP`).
+ */
+function classifyAmbientAwaitResult(
+  result: AwaitLoginResult,
+): AwaitLoginResolution {
+  if (result.state?.auth.status === "authenticated") {
+    return { kind: "authenticated", payload: null };
+  }
+  if (result.codeRejected) return { kind: "codeRejected" };
+  if (
+    result.state !== null &&
+    result.state.authPending &&
+    !isDefinitiveAuthStatus(result.state.auth.status)
+  ) {
+    return { kind: "authPending" };
+  }
+  return { kind: "notAuthenticated" };
+}
+
+/**
+ * Same presence-is-not-success caveat as the ambient classifier: a resolved
+ * row must also be authenticated, not merely present. The ambient row
+ * mirrors the state's top-level auth, whose force-refresh read is
+ * non-blocking host-side - a non-definitive ambient verdict with the probe
+ * still in flight is "not settled yet", never a failure. Managed rows get an
+ * awaited per-profile probe host-side, so that window is ambient-only.
+ */
+function classifyProfileAwaitResult(
+  result: AwaitLoginResult,
+  awaitedProfileId: string | null,
+): AwaitLoginResolution {
+  const profiles = result.state?.profiles ?? [];
+  const existingProfileId = result.existingProfileId ?? null;
+  const resolvedProfileId = existingProfileId ?? awaitedProfileId;
+  const profile =
+    profiles.find((candidate) => candidate.profileId === resolvedProfileId) ??
+    null;
+  if (profile !== null && profile.auth.status === "authenticated") {
+    return {
+      kind: "authenticated",
+      payload: { profile, profiles, existingProfileId },
+    };
+  }
+  if (result.codeRejected) return { kind: "codeRejected" };
+  if (
+    profile !== null &&
+    profile.kind === "ambient" &&
+    !isDefinitiveAuthStatus(profile.auth.status) &&
+    (result.state?.authPending ?? false)
+  ) {
+    return { kind: "authPending" };
+  }
+  return { kind: "notAuthenticated" };
+}
 
 /**
  * The paste field's real-world phases, derived from the mutation lifecycle:
@@ -280,6 +384,11 @@ export function useProviderProfileLoginFlow(
     readonly existingProfileId: string | null;
   } | null>(null);
   const lastTouchAtRef = useRef(0);
+  // Pending timer for the bounded ambient `authPending` re-poll (see
+  // `scheduleAuthPendingRepoll` inside `beginLogin`). Cleared on every fresh
+  // attempt, on cancellation, and on unmount so a late tick can never
+  // re-await a superseded or abandoned attempt.
+  const repollTimerRef = useRef<number | null>(null);
   const lastStartOptionsRef = useRef<{
     readonly label: string | null;
     readonly shareSkillsAndPlugins: boolean;
@@ -297,6 +406,17 @@ export function useProviderProfileLoginFlow(
     ) => void
   >(() => {});
 
+  const clearRepollTimer = useCallback((): void => {
+    if (repollTimerRef.current !== null) {
+      window.clearTimeout(repollTimerRef.current);
+      repollTimerRef.current = null;
+    }
+  }, []);
+
+  // Unmount-only cleanup: callers conditionally unmount to discard the flow,
+  // and a re-poll tick surviving that would re-await a discarded attempt.
+  useEffect(() => clearRepollTimer, [clearRepollTimer]);
+
   const cancelProfile = useCallback(
     (profileId: string | null): void => {
       if (cancelledRef.current) return;
@@ -308,6 +428,7 @@ export function useProviderProfileLoginFlow(
 
   const finishCancellation = useCallback(
     (profileId: string | null): void => {
+      clearRepollTimer();
       // Reauth always targets a real login child - a specific profile, or
       // the ambient/no-profile-picker identity when `existingProfileId` is
       // null (the in-chat banner's OAuth reconnect). Create mode's `null`
@@ -320,7 +441,7 @@ export function useProviderProfileLoginFlow(
       );
       setState({ kind: "cancelled" });
     },
-    [cancelProfile, mode, providerId],
+    [cancelProfile, clearRepollTimer, mode, providerId],
   );
 
   // The blocker is classified from the REAL error at each call site (or an
@@ -329,6 +450,15 @@ export function useProviderProfileLoginFlow(
   // as `authentication`.
   const fail = useCallback(
     (message: string, blocker: AnalyticsBlocker): void => {
+      // Flow-level failures otherwise surface only as inline dialog copy -
+      // log them so a failed sign-in/switch is diagnosable from the desktop
+      // log after the fact.
+      appLogger.warn("[provider-login] flow failed", {
+        provider: providerId,
+        mode,
+        blocker,
+        message,
+      });
       Analytics.getInstance().track(AnalyticsEvent.ProviderProfileLinkFailed, {
         provider: providerId,
         mode,
@@ -440,6 +570,8 @@ export function useProviderProfileLoginFlow(
       notice: string | null,
     ): void => {
       lastStartOptionsRef.current = options;
+      // A fresh attempt supersedes any pending ambient re-poll tick.
+      clearRepollTimer();
       attemptIdRef.current += 1;
       const thisAttemptId = attemptIdRef.current;
       awaitOutcomeRef.current = null;
@@ -498,72 +630,67 @@ export function useProviderProfileLoginFlow(
               profileId: nextProfileId,
               url: data.url,
             });
-            awaitLogin.mutate(
-              { providerId, profileId: nextProfileId },
-              {
-                onSuccess: (result) => {
-                  // A later attempt (auto-restart, or the child finished
-                  // while another restart was already triggered) already
-                  // superseded this long-poll - ignore its stale resolution.
-                  if (attemptIdRef.current !== thisAttemptId) return;
-                  // Ambient reauth (no profile picker - the in-chat banner's
-                  // OAuth reconnect) has no profile row to check: the
-                  // re-probed top-level auth status is the only success
-                  // signal, since `providers.list` keeps a profile row
-                  // present even when it is signed out (fixup review
-                  // finding 2 - presence alone is not success).
-                  if (mode === "reauth" && existingProfileId === null) {
-                    if (result.state?.auth.status === "authenticated") {
-                      awaitOutcomeRef.current = "authenticated";
-                      settleAttempt(thisAttemptId);
-                      return;
-                    }
-                    if (result.codeRejected) {
-                      restart("codeRejected");
-                      return;
-                    }
-                    awaitOutcomeRef.current = "notAuthenticated";
-                    settleAttempt(thisAttemptId);
-                    return;
-                  }
-                  const profiles = result.state?.profiles ?? [];
-                  const resolvedExistingProfileId =
-                    result.existingProfileId ?? null;
-                  const resolvedProfileId =
-                    resolvedExistingProfileId ?? nextProfileId;
-                  const profile =
-                    profiles.find(
-                      (candidate) => candidate.profileId === resolvedProfileId,
-                    ) ?? null;
-                  // Same presence-is-not-success caveat: a resolved row must
-                  // also be authenticated, not merely present.
-                  if (
-                    profile !== null &&
-                    profile.auth.status === "authenticated"
-                  ) {
-                    awaitOutcomeRef.current = "authenticated";
-                    successPayloadRef.current = {
-                      profile,
-                      profiles,
-                      existingProfileId: resolvedExistingProfileId,
-                    };
-                    settleAttempt(thisAttemptId);
-                    return;
-                  }
-                  if (result.codeRejected) {
-                    restart("codeRejected");
-                    return;
-                  }
-                  awaitOutcomeRef.current = "notAuthenticated";
-                  settleAttempt(thisAttemptId);
-                },
-                onError: () => {
-                  if (attemptIdRef.current !== thisAttemptId) return;
-                  awaitOutcomeRef.current = "notAuthenticated";
-                  settleAttempt(thisAttemptId);
-                },
-              },
-            );
+            // Per-attempt budget for the ambient `authPending` re-poll (see
+            // the constant's doc comment). Scoped to this attempt's closure -
+            // an auto-restart mints a fresh attempt with a fresh budget.
+            let authPendingRepolls = 0;
+            const scheduleAuthPendingRepoll = (): boolean => {
+              if (authPendingRepolls >= AMBIENT_AUTH_PENDING_REPOLL_CAP) {
+                return false;
+              }
+              authPendingRepolls += 1;
+              appLogger.info(
+                "[provider-login] ambient auth still pending after login completion; re-polling",
+                { provider: providerId, repoll: authPendingRepolls },
+              );
+              repollTimerRef.current = window.setTimeout(() => {
+                repollTimerRef.current = null;
+                if (attemptIdRef.current !== thisAttemptId) return;
+                if (cancelRequestedRef.current || cancelledRef.current) return;
+                awaitOnce();
+              }, AMBIENT_AUTH_PENDING_REPOLL_DELAY_MS);
+              return true;
+            };
+            const handleAwaitSuccess = (result: AwaitLoginResult): void => {
+              // A later attempt (auto-restart, or the child finished
+              // while another restart was already triggered) already
+              // superseded this long-poll - ignore its stale resolution.
+              if (attemptIdRef.current !== thisAttemptId) return;
+              const resolution =
+                mode === "reauth" && existingProfileId === null
+                  ? classifyAmbientAwaitResult(result)
+                  : classifyProfileAwaitResult(result, nextProfileId);
+              if (resolution.kind === "authenticated") {
+                awaitOutcomeRef.current = "authenticated";
+                successPayloadRef.current = resolution.payload;
+                settleAttempt(thisAttemptId);
+                return;
+              }
+              if (resolution.kind === "codeRejected") {
+                restart("codeRejected");
+                return;
+              }
+              if (
+                resolution.kind === "authPending" &&
+                scheduleAuthPendingRepoll()
+              ) {
+                return;
+              }
+              awaitOutcomeRef.current = "notAuthenticated";
+              settleAttempt(thisAttemptId);
+            };
+            const handleAwaitError = (): void => {
+              if (attemptIdRef.current !== thisAttemptId) return;
+              awaitOutcomeRef.current = "notAuthenticated";
+              settleAttempt(thisAttemptId);
+            };
+            const awaitOnce = (): void => {
+              awaitLogin.mutate(
+                { providerId, profileId: nextProfileId },
+                { onSuccess: handleAwaitSuccess, onError: handleAwaitError },
+              );
+            };
+            awaitOnce();
           },
           onError: (error) => {
             if (cancelRequestedRef.current) {
@@ -577,6 +704,7 @@ export function useProviderProfileLoginFlow(
     },
     [
       awaitLogin,
+      clearRepollTimer,
       existingProfileId,
       fail,
       failureMessages,

--- a/clients/gui-app/src/components/settings/panels/use-provider-profile-login-flow.ts
+++ b/clients/gui-app/src/components/settings/panels/use-provider-profile-login-flow.ts
@@ -392,6 +392,9 @@ export function useProviderProfileLoginFlow(
   // attempt, on cancellation, and on unmount so a late tick can never
   // re-await a superseded or abandoned attempt.
   const repollTimerRef = useRef<number | null>(null);
+  // Latched by the unmount cleanup below so a re-poll already in flight at
+  // unmount cannot schedule its successor.
+  const unmountedRef = useRef(false);
   const lastStartOptionsRef = useRef<{
     readonly label: string | null;
     readonly shareSkillsAndPlugins: boolean;
@@ -416,9 +419,22 @@ export function useProviderProfileLoginFlow(
     }
   }, []);
 
-  // Unmount-only cleanup: callers conditionally unmount to discard the flow,
-  // and a re-poll tick surviving that would re-await a discarded attempt.
-  useEffect(() => clearRepollTimer, [clearRepollTimer]);
+  // Unmount-only cleanup: callers conditionally unmount to discard the flow
+  // (the Settings panel's reauth section, and the in-chat banner the moment
+  // its reauth gate clears), and a re-poll surviving that would keep
+  // re-awaiting a discarded attempt. Clearing the timer alone is not enough:
+  // an already-dispatched `awaitOnce` resolves after unmount, and a
+  // still-pending verdict would arm a fresh timer on a dead hook - so the
+  // unmount is latched into `attemptAbandoned` too. Reset on every effect run
+  // rather than only at declaration: StrictMode's dev double-invoke unmounts
+  // and remounts, which would otherwise leave this latched on for good.
+  useEffect(() => {
+    unmountedRef.current = false;
+    return () => {
+      unmountedRef.current = true;
+      clearRepollTimer();
+    };
+  }, [clearRepollTimer]);
 
   const cancelProfile = useCallback(
     (profileId: string | null): void => {
@@ -637,27 +653,25 @@ export function useProviderProfileLoginFlow(
             // the constant's doc comment). Scoped to this attempt's closure -
             // an auto-restart mints a fresh attempt with a fresh budget.
             let authPendingRepolls = 0;
-            // A resolution this attempt must no longer act on: either a later
-            // attempt (auto-restart, or the child finishing while a restart
-            // was already triggered) superseded this long-poll, or the flow
-            // was cancelled. Clearing the re-poll timer cannot cancel an
-            // already-dispatched RPC, and cancelling leaves `attemptIdRef`
-            // untouched - so without the cancellation half, a re-poll landing
-            // after `finishCancellation` would settle the attempt and
-            // overwrite the terminal `cancelled` state with a failure.
+            // A resolution this attempt must no longer act on: a later attempt
+            // (auto-restart, or the child finishing while a restart was
+            // already triggered) superseded this long-poll, the flow was
+            // cancelled, or the hook unmounted. Clearing the re-poll timer
+            // cannot recall an already-dispatched RPC, and neither cancelling
+            // nor unmounting touches `attemptIdRef` - so without the other two
+            // halves a re-poll landing afterward would settle the attempt
+            // (overwriting the terminal `cancelled` state with a failure) or
+            // arm a fresh timer on a dead hook.
             const attemptAbandoned = (): boolean =>
               attemptIdRef.current !== thisAttemptId ||
               cancelRequestedRef.current ||
-              cancelledRef.current;
+              cancelledRef.current ||
+              unmountedRef.current;
             const scheduleAuthPendingRepoll = (): boolean => {
               if (authPendingRepolls >= AMBIENT_AUTH_PENDING_REPOLL_CAP) {
                 return false;
               }
               authPendingRepolls += 1;
-              appLogger.info(
-                "[provider-login] ambient auth still pending after login completion; re-polling",
-                { provider: providerId, repoll: authPendingRepolls },
-              );
               repollTimerRef.current = window.setTimeout(() => {
                 repollTimerRef.current = null;
                 if (attemptAbandoned()) return;


### PR DESCRIPTION
## Summary

Switching the ambient (**Terminal account**) profile to a different account showed **"Sign-in did not finish. Try again."** on every attempt — even when the OAuth exchange had actually landed and the credentials were written. The switch looked permanently broken; the account had in fact changed.

The ambient profile row mirrors the provider state's top-level `auth`, and the host's `providers.awaitLogin` reads that **non-blocking**: the login runner evicts the ambient auth-cache entry the moment the login child closes, so the response can carry a non-definitive reading with `authPending` set while the real probe is still in flight. The flow treated "not authenticated" as terminal and failed the attempt. Managed profiles never hit this — their wire rows get an awaited per-profile probe host-side.

This PR fixes the client half:

- **Treat a non-definitive ambient verdict with `authPending` set as unsettled, not failed** — re-await up to 3 times, 2s apart, before falling back to the ordinary not-finished path. Re-awaiting is cheap (with no login job in flight the host resolves immediately with a re-probed state). Definitive verdicts are never re-polled, the budget is per-attempt, and the timer is cleared on restart, cancel, and unmount.
- **Log flow-level login failures** through `appLogger` — they previously surfaced only as inline dialog copy, so a failed sign-in left nothing in the desktop log to diagnose after the fact. This is why the original report had to be reconstructed from keychain timestamps.
- The await-result verdict logic moves into two pure classifiers so the success handler stays within the complexity budget.

The host-side counterpart (making `awaitLogin`'s ambient verdict authoritative) ships separately. The re-poll is deliberately kept regardless: it closes the window against hosts that predate that fix, and the `authPending` contract is real either way.

### Tests

Two regression tests in `providers-settings-panel.test.tsx`:
- a terminal-account switch returning `authPending`/unknown does **not** show "Sign-in did not finish", re-polls once, and resolves to the identity step — with a single OAuth child (re-polling never restarts the flow)
- the budget-exhaustion path still lands on the ordinary failure after the re-polls are spent

## Related issue

<!-- none -->

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)