### PR TITLE
fix(gui-app): distinguish background work from agent processing in chat indicators

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
@@ -14,6 +14,16 @@ const EPIC_ID = "epic-1";
 const CHAT_ID = "chat-1";
 const TEST_ID = "chat-progress";
 const RUNNING_TEST_ID = `${TEST_ID}-activity-${CHAT_ID}`;
+const BACKGROUND_RUNNING_TEST_ID = `${TEST_ID}-background-activity-${CHAT_ID}`;
+
+const MONITOR_ITEM = {
+  taskId: "task-1",
+  kind: "monitor" as const,
+  title: "Monitor",
+  blockId: "block-1",
+  parentTaskId: null,
+  scheduledFor: null,
+};
 
 const mockSessionState = vi.hoisted<{
   readonly activeAgentIds: Set<string>;
@@ -126,6 +136,44 @@ describe("<ChatProgressIcon />", () => {
 
     expect(screen.queryByTestId(RUNNING_TEST_ID)).not.toBeNull();
     expect(screen.queryByTitle("Chat in progress")).not.toBeNull();
+  });
+
+  it("shows the muted background indicator instead of the turn spinner when only background work runs", () => {
+    const handle = createHandle();
+    handle.store.setState({
+      runStatus: "running",
+      turnInProgress: false,
+      backgroundItems: [MONITOR_ITEM],
+    });
+    // Epic-level activity also reads active during background-only phases;
+    // the session's own tri-state must still win.
+    mockSessionState.activeAgentIds.add(CHAT_ID);
+    mockSessionState.existingHandle = handle;
+
+    renderIcon();
+
+    expect(screen.queryByTestId(BACKGROUND_RUNNING_TEST_ID)).not.toBeNull();
+    expect(
+      screen.queryByTitle("Background tasks running — chat idle"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId(RUNNING_TEST_ID)).toBeNull();
+    expect(screen.queryByTitle("Chat in progress")).toBeNull();
+  });
+
+  it("prioritizes the turn spinner when a turn and background work run simultaneously", () => {
+    const handle = createHandle();
+    handle.store.setState({
+      runStatus: "running",
+      turnInProgress: true,
+      backgroundItems: [MONITOR_ITEM],
+    });
+    mockSessionState.existingHandle = handle;
+
+    renderIcon();
+
+    expect(screen.queryByTestId(RUNNING_TEST_ID)).not.toBeNull();
+    expect(screen.queryByTitle("Chat in progress")).not.toBeNull();
+    expect(screen.queryByTestId(BACKGROUND_RUNNING_TEST_ID)).toBeNull();
   });
 
   it("keeps the running spinner for an active opened chat that needs approval", () => {

--- a/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
@@ -14,7 +14,8 @@ const EPIC_ID = "epic-1";
 const CHAT_ID = "chat-1";
 const TEST_ID = "chat-progress";
 const RUNNING_TEST_ID = `${TEST_ID}-activity-${CHAT_ID}`;
-const BACKGROUND_RUNNING_TEST_ID = `${TEST_ID}-background-activity-${CHAT_ID}`;
+const TURN_RUNNING_LABEL = "Chat in progress";
+const BACKGROUND_RUNNING_LABEL = "Background tasks running — chat idle";
 
 const MONITOR_ITEM = {
   taskId: "task-1",
@@ -152,12 +153,12 @@ describe("<ChatProgressIcon />", () => {
 
     renderIcon();
 
-    expect(screen.queryByTestId(BACKGROUND_RUNNING_TEST_ID)).not.toBeNull();
     expect(
-      screen.queryByTitle("Background tasks running — chat idle"),
-    ).not.toBeNull();
-    expect(screen.queryByTestId(RUNNING_TEST_ID)).toBeNull();
-    expect(screen.queryByTitle("Chat in progress")).toBeNull();
+      screen.getByRole("status", { name: BACKGROUND_RUNNING_LABEL }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("status", { name: TURN_RUNNING_LABEL }),
+    ).toBeNull();
   });
 
   it("prioritizes the turn spinner when a turn and background work run simultaneously", () => {
@@ -171,9 +172,12 @@ describe("<ChatProgressIcon />", () => {
 
     renderIcon();
 
-    expect(screen.queryByTestId(RUNNING_TEST_ID)).not.toBeNull();
-    expect(screen.queryByTitle("Chat in progress")).not.toBeNull();
-    expect(screen.queryByTestId(BACKGROUND_RUNNING_TEST_ID)).toBeNull();
+    expect(
+      screen.getByRole("status", { name: TURN_RUNNING_LABEL }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("status", { name: BACKGROUND_RUNNING_LABEL }),
+    ).toBeNull();
   });
 
   it("keeps the running spinner for an active opened chat that needs approval", () => {

--- a/clients/gui-app/src/components/chat/chat-progress-icon.tsx
+++ b/clients/gui-app/src/components/chat/chat-progress-icon.tsx
@@ -8,10 +8,9 @@ import {
   useEpicPermissionRole,
 } from "@/lib/epic-selectors";
 import { useExistingChatSessionHandle } from "@/lib/registries/chat-session-registry";
-import {
-  isChatRunInProgress,
-  type ChatSessionStoreHandle,
-} from "@/stores/chats/chat-session-store";
+import { chatActivityIndicator } from "@/components/epic-canvas/renderers/chat-tile-session-state";
+import type { IndicatorRunningKind } from "@/components/notifications/notification-indicator-icon";
+import type { ChatSessionStoreHandle } from "@/stores/chats/chat-session-store";
 import type { NotificationIndicatorState } from "@/stores/notifications/notification-indicator-state";
 import { EPIC_NODE_ICONS } from "@/lib/artifacts/node-display";
 import { cn } from "@/lib/utils";
@@ -46,7 +45,11 @@ export function ChatProgressIcon(props: ChatProgressIconProps) {
     return (
       <ChatProgressPresentation
         indicatorState={indicatorState}
-        isRunning={isActive}
+        // Without a session subscription the epic-activity signal is binary
+        // (it bridges the host's whole non-idle range, background included),
+        // so an unopened chat can't tell the two tiers apart. Presenting the
+        // turn spinner is the conservative read; opening the chat refines it.
+        running={isActive ? "turn" : false}
         isReadOnly={fallbackReadOnly}
         subjectId={props.chatId}
         className={props.className}
@@ -83,12 +86,23 @@ function ChatProgressIconWithHandle(props: {
   // `useStore(api, selector)` instead of `props.handle.store(...)`: the
   // bound-store call form isn't recognizable as a hook to the React Compiler,
   // which memoizes it away and corrupts the hook order.
-  const runStatus = useStore(props.handle.store, (state) => state.runStatus);
+  //
+  // The selector collapses the session state to the tri-state activity kind
+  // (a primitive), so array-identity churn on queue/backgroundItems can't
+  // re-render this icon.
+  const activity = useStore(props.handle.store, (state) =>
+    chatActivityIndicator(state),
+  );
   const access = useStore(props.handle.store, (state) => state.access);
   return (
     <ChatProgressPresentation
       indicatorState={props.indicatorState}
-      isRunning={props.isActive || isChatRunInProgress(runStatus)}
+      // The session's own tri-state is authoritative when it reads any
+      // activity: the epic-activity bit also covers background-only phases,
+      // so letting it force the turn spinner would re-conflate the tiers.
+      // It only backfills the brief subscription-gap window where the store
+      // still reads idle.
+      running={activity ?? (props.isActive ? "turn" : false)}
       // A session's access snapshot is authoritative. Keep the icon neutral
       // while it is unknown so an owner never sees the unopened-chat fallback
       // lock flash before the snapshot arrives.
@@ -104,7 +118,7 @@ function ChatProgressIconWithHandle(props: {
 
 function ChatProgressPresentation(props: {
   readonly indicatorState: NotificationIndicatorState;
-  readonly isRunning: boolean;
+  readonly running: IndicatorRunningKind;
   readonly isReadOnly: boolean;
   readonly subjectId: string;
   readonly className: string | undefined;
@@ -136,12 +150,13 @@ function ChatProgressPresentation(props: {
   return (
     <NotificationIndicatorIcon
       state={props.indicatorState}
-      running={props.isRunning}
+      running={props.running}
       subjectId={props.subjectId}
       testIdPrefix={props.testId}
       className={icon.className}
       style={icon.style}
       runningTitle="Chat in progress"
+      backgroundRunningTitle="Background tasks running — chat idle"
       defaultIcon={idleIcon}
       statusPresentation="message"
     />

--- a/clients/gui-app/src/components/epic-canvas/epic-node-tab-icon.tsx
+++ b/clients/gui-app/src/components/epic-canvas/epic-node-tab-icon.tsx
@@ -117,6 +117,7 @@ function TerminalNodeTabIcon(props: {
       className={undefined}
       style={undefined}
       runningTitle=""
+      backgroundRunningTitle={undefined}
       defaultIcon={props.defaultIcon}
       statusPresentation="spinner"
     />

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -35,6 +35,7 @@ vi.mock("sonner", () => ({
 }));
 
 import {
+  chatActivityIndicator,
   chatMessageEditingForInlineEdit,
   resolvedTurnStatus,
   showRestoreResultToast,
@@ -482,5 +483,109 @@ describe("resolvedTurnStatus - turnInProgress present (host-sent, exact)", () =>
         null,
       ),
     ).toBeNull();
+  });
+});
+
+describe("chatActivityIndicator", () => {
+  const MONITOR_ITEM = {
+    taskId: "t1",
+    kind: "monitor" as const,
+    title: "Monitor",
+    blockId: "t1",
+    parentTaskId: null,
+    scheduledFor: null,
+  };
+
+  it("reads null for an idle chat", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "idle",
+        activeTurn: null,
+        queue: EMPTY_QUEUE,
+        backgroundItems: [],
+        turnInProgress: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("reads turn while the host reports a genuine turn in progress", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "running",
+        activeTurn: ACTIVE_TURN,
+        queue: EMPTY_QUEUE,
+        backgroundItems: [],
+        turnInProgress: true,
+      }),
+    ).toBe("turn");
+  });
+
+  it("reads background when only a Monitor/background task keeps the chat non-idle", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "running",
+        activeTurn: null,
+        queue: EMPTY_QUEUE,
+        backgroundItems: [MONITOR_ITEM],
+        turnInProgress: false,
+      }),
+    ).toBe("background");
+  });
+
+  it("prioritizes the turn when a turn and background work run simultaneously", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "running",
+        activeTurn: ACTIVE_TURN,
+        queue: EMPTY_QUEUE,
+        backgroundItems: [MONITOR_ITEM],
+        turnInProgress: true,
+      }),
+    ).toBe("turn");
+  });
+
+  it("reads turn (not background) while a runnable queue drains between turns", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "running",
+        activeTurn: null,
+        queue: runnableQueue(1),
+        backgroundItems: [],
+        turnInProgress: false,
+      }),
+    ).toBe("turn");
+  });
+
+  it("keeps the stopping phase on the turn tier", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "stopping",
+        activeTurn: ACTIVE_TURN,
+        queue: EMPTY_QUEUE,
+        backgroundItems: [],
+        turnInProgress: true,
+      }),
+    ).toBe("turn");
+  });
+
+  it("falls back to the older-host heuristic when turnInProgress is absent", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "running",
+        activeTurn: null,
+        queue: EMPTY_QUEUE,
+        backgroundItems: [MONITOR_ITEM],
+        turnInProgress: undefined,
+      }),
+    ).toBe("background");
+    expect(
+      chatActivityIndicator({
+        runStatus: "running",
+        activeTurn: null,
+        queue: EMPTY_QUEUE,
+        backgroundItems: undefined,
+        turnInProgress: undefined,
+      }),
+    ).toBe("turn");
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -227,6 +227,36 @@ export function resolvedTurnStatus(
   return isQueueRunnable || hasVisibleBackgroundWork ? null : turnStatus;
 }
 
+/**
+ * Tri-state activity for the chat's progress indicators (sidebar tree, tab
+ * icons): is the agent actually processing, or is only background work
+ * (Bash `run_in_background` / a subagent / Monitor / a scheduled wakeup)
+ * keeping the chat non-idle? `runStatus` alone can't tell the two apart, and
+ * showing the same spinner for both left users unable to see whether the
+ * agent was really running.
+ *
+ * `"turn"` wins whenever a genuine turn is active or activating (the host's
+ * `turnInProgress`, via {@link resolvedTurnStatus}) — background work running
+ * alongside a turn is subsumed by it. A runnable queue also reads `"turn"`:
+ * the next prompt is imminent, and the momentary turn-boundary gaps while a
+ * queue drains must not flicker the indicator through the background style.
+ */
+export type ChatActivityIndicator = "turn" | "background" | null;
+
+export function chatActivityIndicator(
+  state: Pick<
+    ChatSessionState,
+    "runStatus" | "activeTurn" | "queue" | "backgroundItems" | "turnInProgress"
+  >,
+): ChatActivityIndicator {
+  const turnStatus = composerTurnStatus(state.runStatus);
+  if (turnStatus === null) return null;
+  if (resolvedTurnStatus(state, turnStatus) !== null) return "turn";
+  const isQueueRunnable =
+    state.queue.status !== "paused" && state.queue.items.length > 0;
+  return isQueueRunnable ? "turn" : "background";
+}
+
 export function normalizeInlineEditForSession(
   inlineEdit: InlineEditState | null,
   state: Pick<

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -1315,12 +1315,15 @@ function HistoryRowLeadingIcon(props: { readonly item: HistoryItem }) {
   return (
     <NotificationIndicatorIcon
       state={indicatorState}
-      running={activityStatus === "running"}
+      // Epic-level activity is binary (any agent busy, background included);
+      // the per-chat turn/background split lives on the chat icons.
+      running={activityStatus === "running" ? "turn" : false}
       subjectId={props.item.epicId}
       testIdPrefix="epics-list-row"
       className="text-muted-foreground group-hover/list-row:text-foreground"
       style={undefined}
       runningTitle="Task activity in progress"
+      backgroundRunningTitle={undefined}
       defaultIcon={
         <Layers className="size-4 shrink-0 text-muted-foreground group-hover/list-row:text-foreground" />
       }

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -468,12 +468,15 @@ function TabLeadingIcon(props: {
   return (
     <NotificationIndicatorIcon
       state={indicatorState}
-      running={props.activityStatus === "running"}
+      // Epic-level activity is binary (any agent busy, background included);
+      // the per-chat turn/background split lives on the chat icons.
+      running={props.activityStatus === "running" ? "turn" : false}
       subjectId={props.tabId}
       testIdPrefix="header-tab"
       className="text-muted-foreground"
       style={undefined}
       runningTitle="Task activity in progress"
+      backgroundRunningTitle={undefined}
       defaultIcon={defaultIcon}
       statusPresentation="message"
     />

--- a/clients/gui-app/src/components/notifications/__tests__/notification-indicator-icon.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notification-indicator-icon.test.tsx
@@ -134,21 +134,29 @@ describe("<NotificationIndicatorIcon />", () => {
   it("renders the background tier muted and titled distinctly from the turn spinner", () => {
     renderIcon(DEFAULT_STATE, "background");
 
-    const indicator = screen.getByTestId(
-      "indicator-background-activity-subject-1",
-    );
-    expect(indicator.getAttribute("class")).toContain("text-muted-foreground");
-    expect(screen.getByTitle("Background tasks running")).toBeDefined();
-    expect(screen.queryByTestId("indicator-activity-subject-1")).toBeNull();
-    expect(screen.queryByTitle("Task activity in progress")).toBeNull();
+    expect(
+      screen.getByRole("status", { name: "Background tasks running" }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("status", { name: "Task activity in progress" }),
+    ).toBeNull();
+    // Class assertion needs the inner spinner node, which carries the tier's
+    // muted styling; the role query above owns the presence contract.
+    expect(
+      screen
+        .getByTestId("indicator-background-activity-subject-1")
+        .getAttribute("class"),
+    ).toContain("text-muted-foreground");
   });
 
   it("renders status icons ahead of the background tier", () => {
     renderIcon({ ...DEFAULT_STATE, pendingApproval: true }, "background");
 
-    expect(screen.getByTestId("indicator-approval-subject-1")).toBeDefined();
     expect(
-      screen.queryByTestId("indicator-background-activity-subject-1"),
+      screen.getByRole("status", { name: "Task waiting for your approval" }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("status", { name: "Background tasks running" }),
     ).toBeNull();
   });
 

--- a/clients/gui-app/src/components/notifications/__tests__/notification-indicator-icon.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notification-indicator-icon.test.tsx
@@ -1,7 +1,10 @@
 import "../../../../__tests__/test-browser-apis";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { NotificationIndicatorIcon } from "@/components/notifications/notification-indicator-icon";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  NotificationIndicatorIcon,
+  type IndicatorRunningKind,
+} from "@/components/notifications/notification-indicator-icon";
 import {
   contrastRatio,
   DARK_THEME_SURFACES,
@@ -17,14 +20,19 @@ const DEFAULT_STATE = {
   unreadDone: false,
 };
 
+afterEach(cleanup);
+
 describe("<NotificationIndicatorIcon />", () => {
   it("renders status icons ahead of running, then running ahead of completion", () => {
-    const { rerender } = renderIcon({
-      unreadFailure: true,
-      pendingApproval: true,
-      pendingInterview: true,
-      unreadDone: true,
-    });
+    const { rerender } = renderIcon(
+      {
+        unreadFailure: true,
+        pendingApproval: true,
+        pendingInterview: true,
+        unreadDone: true,
+      },
+      "turn",
+    );
 
     expect(
       screen.getByTestId("indicator-failure-subject-1").getAttribute("class"),
@@ -43,7 +51,7 @@ describe("<NotificationIndicatorIcon />", () => {
           pendingInterview: true,
           unreadDone: true,
         },
-        true,
+        "turn",
       ),
     );
     expect(
@@ -61,7 +69,7 @@ describe("<NotificationIndicatorIcon />", () => {
           pendingInterview: false,
           unreadDone: true,
         },
-        true,
+        "turn",
       ),
     );
     expect(
@@ -79,7 +87,7 @@ describe("<NotificationIndicatorIcon />", () => {
           pendingInterview: false,
           unreadDone: true,
         },
-        true,
+        "turn",
       ),
     );
     expect(screen.getByTestId("indicator-activity-subject-1")).toBeDefined();
@@ -103,7 +111,7 @@ describe("<NotificationIndicatorIcon />", () => {
       screen.getByTestId("indicator-done-subject-1").getAttribute("class"),
     ).toContain("lucide-message-square-check");
 
-    rerender(renderIconContent(DEFAULT_STATE, true));
+    rerender(renderIconContent(DEFAULT_STATE, "turn"));
     expect(screen.getByTestId("indicator-activity-subject-1")).toBeDefined();
 
     rerender(
@@ -115,11 +123,33 @@ describe("<NotificationIndicatorIcon />", () => {
         className={undefined}
         style={undefined}
         runningTitle="Task activity in progress"
+        backgroundRunningTitle={undefined}
         defaultIcon={<span data-testid="default-icon" />}
         statusPresentation="message"
       />,
     );
     expect(screen.getByTestId("default-icon")).toBeDefined();
+  });
+
+  it("renders the background tier muted and titled distinctly from the turn spinner", () => {
+    renderIcon(DEFAULT_STATE, "background");
+
+    const indicator = screen.getByTestId(
+      "indicator-background-activity-subject-1",
+    );
+    expect(indicator.getAttribute("class")).toContain("text-muted-foreground");
+    expect(screen.getByTitle("Background tasks running")).toBeDefined();
+    expect(screen.queryByTestId("indicator-activity-subject-1")).toBeNull();
+    expect(screen.queryByTitle("Task activity in progress")).toBeNull();
+  });
+
+  it("renders status icons ahead of the background tier", () => {
+    renderIcon({ ...DEFAULT_STATE, pendingApproval: true }, "background");
+
+    expect(screen.getByTestId("indicator-approval-subject-1")).toBeDefined();
+    expect(
+      screen.queryByTestId("indicator-background-activity-subject-1"),
+    ).toBeNull();
   });
 
   it("keeps the failure and completion status colors at >=3:1 against every theme preset's background and canvas", () => {
@@ -154,13 +184,16 @@ describe("<NotificationIndicatorIcon />", () => {
   });
 });
 
-function renderIcon(state: {
-  readonly unreadFailure: boolean;
-  readonly pendingApproval: boolean;
-  readonly pendingInterview: boolean;
-  readonly unreadDone: boolean;
-}) {
-  return render(renderIconContent(state, true));
+function renderIcon(
+  state: {
+    readonly unreadFailure: boolean;
+    readonly pendingApproval: boolean;
+    readonly pendingInterview: boolean;
+    readonly unreadDone: boolean;
+  },
+  running: IndicatorRunningKind,
+) {
+  return render(renderIconContent(state, running));
 }
 
 function renderIconContent(
@@ -170,7 +203,7 @@ function renderIconContent(
     readonly pendingInterview: boolean;
     readonly unreadDone: boolean;
   },
-  running: boolean,
+  running: IndicatorRunningKind,
 ) {
   return (
     <NotificationIndicatorIcon
@@ -181,6 +214,7 @@ function renderIconContent(
       className={undefined}
       style={undefined}
       runningTitle="Task activity in progress"
+      backgroundRunningTitle="Background tasks running"
       defaultIcon={<span data-testid="default-icon" />}
       statusPresentation="message"
     />

--- a/clients/gui-app/src/components/notifications/notification-indicator-icon.tsx
+++ b/clients/gui-app/src/components/notifications/notification-indicator-icon.tsx
@@ -7,17 +7,36 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import type { AgentSpinnerVariant } from "@/components/ui/agent-spinner-variant";
 import type { NotificationIndicatorState } from "@/stores/notifications/notification-indicator-state";
 import { cn } from "@/lib/utils";
 
+/**
+ * Live-activity tier for the running slot. `"turn"` is the agent actually
+ * processing (an active or activating turn — the busy spinner); `"background"`
+ * is background-only work (Monitor / `run_in_background` / a scheduled
+ * wakeup) keeping the chat non-idle while the agent itself is NOT running —
+ * rendered calmer and muted so the two are distinguishable at a glance.
+ * Callers resolve the tier (turn wins when both are happening); this
+ * component only presents it.
+ */
+export type IndicatorRunningKind = "turn" | "background" | false;
+
 interface NotificationIndicatorIconProps {
   readonly state: NotificationIndicatorState;
-  readonly running: boolean;
+  readonly running: IndicatorRunningKind;
   readonly subjectId: string;
   readonly testIdPrefix: string;
   readonly className: string | undefined;
   readonly style: CSSProperties | undefined;
   readonly runningTitle: string;
+  /**
+   * Tooltip/label for the `"background"` running tier. `undefined` is valid
+   * for consumers whose activity signal is binary and never passes
+   * `"background"`; if the tier does render without one, the turn title is
+   * reused rather than showing an untitled indicator.
+   */
+  readonly backgroundRunningTitle: string | undefined;
   readonly defaultIcon: ReactNode;
   readonly statusPresentation: "message" | "spinner";
 }
@@ -25,7 +44,8 @@ interface NotificationIndicatorIconProps {
 /**
  * The single renderer for notification status icons. Notification state wins
  * over live activity: errors first, then unresolved prompts, followed by the
- * session-backed running spinner and unread completion.
+ * session-backed running indicator (turn spinner, or the muted background
+ * variant) and unread completion.
  */
 export function NotificationIndicatorIcon(
   props: NotificationIndicatorIconProps,
@@ -34,13 +54,28 @@ export function NotificationIndicatorIcon(
   if (tone !== null) {
     return <IndicatorTonePresentation tone={tone} indicatorProps={props} />;
   }
-  if (props.running) {
+  if (props.running === "turn") {
     return (
       <IndicatorSpan
         indicatorProps={props}
         title={props.runningTitle}
         dotsClassName="text-current"
+        variant={undefined}
         testId={`${props.testIdPrefix}-activity-${props.subjectId}`}
+      />
+    );
+  }
+  if (props.running === "background") {
+    return (
+      <IndicatorSpan
+        indicatorProps={props}
+        title={props.backgroundRunningTitle ?? props.runningTitle}
+        dotsClassName="text-muted-foreground"
+        // A slow single-dot bounce, deliberately distinct from the busy
+        // multi-dot turn spin: "something is ticking over" rather than
+        // "the agent is working".
+        variant="bounce"
+        testId={`${props.testIdPrefix}-background-activity-${props.subjectId}`}
       />
     );
   }
@@ -176,6 +211,7 @@ function IndicatorSpan(props: {
   readonly indicatorProps: NotificationIndicatorIconProps;
   readonly title: string;
   readonly dotsClassName: string;
+  readonly variant: AgentSpinnerVariant | undefined;
   readonly testId: string;
 }): ReactNode {
   return (
@@ -192,7 +228,7 @@ function IndicatorSpan(props: {
       <AgentSpinningDots
         className={cn(props.dotsClassName)}
         testId={props.testId}
-        variant={undefined}
+        variant={props.variant}
       />
     </span>
   );


### PR DESCRIPTION
## Problem

Monitors and background processes (`run_in_background`, subagents, scheduled wakeups) showed the **same busy spinner** as an actually-processing turn, so users could not tell whether the agent was really running. `runStatus` alone reads `running` for both, and the chat progress icons rendered it as one binary bit.

## Fix

Derive a tri-state from signals the wire already carries — **no protocol change**:

- **`chatActivityIndicator`** (new, in `chat-tile-session-state.ts`) returns `"turn" | "background" | null`. **Agent processing has priority**: `"turn"` wins whenever a genuine turn is active or activating (the host's own `turnInProgress`, via the existing `resolvedTurnStatus`), so background work running alongside a turn is subsumed by it. A runnable queue also reads `"turn"` so the momentary turn-boundary gaps while a queue drains don't flicker the indicator through the background style. Only remaining activity reads `"background"`.
- **`NotificationIndicatorIcon.running`** becomes `"turn" | "background" | false`. `"turn"` keeps the busy multi-dot spinner ("Chat in progress"); `"background"` renders a slow single-dot `bounce` in `text-muted-foreground`, titled "Background tasks running — chat idle". Notification tones (failure / interview / approval) still win over both tiers.
- **`ChatProgressIcon`** selects the tri-state straight from the session store, and lets it override the epic-level activity bit — that bit also covers background-only phases, so honouring it would re-conflate the tiers. It only backfills the brief subscription-gap window.

## Scope

- **Epic-level surfaces** (header tabs, epics list) keep their binary activity signal: distinguishing there needs the epic-activity stream to carry the tier, i.e. a protocol minor. They pass `"turn"` explicitly.
- **An unopened chat** has no session subscription and so can't tell the tiers apart; it conservatively shows the turn spinner until opened.
- **In-transcript surfaces** (composer Stop, "Working…" rows) already narrowed via `resolvedTurnStatus` and are untouched.

## Verification

- New tests: 7 unit cases for `chatActivityIndicator` (incl. turn-priority when both run simultaneously, queue-drain gaps, older-host fallback), 2 component cases for the background presentation + tone precedence, and 2 `ChatProgressIcon` cases (background-only shows the muted indicator even when epic activity reads active; turn + background shows the turn spinner).
- Full gui-app suite green (5516 passed); `bun run compile` clean; `react-doctor` on the changed files reports no issues.
- Merged with latest `main` (`bc82464`); re-verified after the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
