### PR TITLE
fix(gui-app): keep plain terminal streams warm across tab switches

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
@@ -137,13 +137,18 @@ export interface TerminalXtermHostProps {
    */
   readonly shouldFocusOnActivePane: boolean;
   /**
-   * Whether the underlying terminal session is still live (a running
-   * terminal-agent). The host keeps the persistent xterm engine cached across
-   * unmount when true, so splitting a pane / switching tabs / reopening does not
-   * dispose the `Terminal` and lose its scrollback. Plain terminals (and exited
-   * agents) pass false: their session handle is torn down on unmount too, so the
-   * next open rebuilds both and replays a fresh host snapshot. Mirrors the
-   * keep-lease-free rule in `TerminalSessionRegistry`.
+   * Whether the underlying terminal session is still live. The host keeps the
+   * persistent xterm engine cached across unmount when true, so splitting a
+   * pane / switching tabs / reopening does not dispose the `Terminal` and lose
+   * its scrollback. Mirrors the lease-free retention rules in
+   * `TerminalSessionRegistry`: a running terminal-agent's handle is kept warm
+   * indefinitely and a running plain terminal's lingers for the release-linger
+   * window, and in both cases the session store's writer keeps pointing at
+   * this engine - so the engine must outlive the unmount with it, or the
+   * reattach would render blank (the host snapshot was already consumed).
+   * Exited sessions pass false: their handle is torn down with the tile, and
+   * the registry follower disposes any cached engine once the handle leaves
+   * the session registry.
    */
   readonly keepAlive: boolean;
   /**

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
@@ -377,10 +377,15 @@ function TerminalLive(props: TerminalLiveProps) {
                 ? `terminal:${props.viewTabId}:${props.tileId}:${handle.sessionId}`
                 : null
             }
-            // Plain terminals have no scrollback to preserve beyond the host
-            // snapshot: their session handle is disposed on unmount and the next
-            // open replays a fresh snapshot, so the xterm engine is rebuilt too.
-            keepAlive={false}
+            // Mirrors the registry's linger rule: a running plain terminal's
+            // handle now outlives this unmount (its stream stays subscribed for
+            // the linger window so tab switches reattach instantly), and the
+            // store's writer keeps pointing at this engine - dispose the engine
+            // and the reattach would be blank, since the host snapshot was
+            // already consumed. The registry follower disposes the engine when
+            // the lingering handle is finally evicted; only an exited session
+            // tears down eagerly.
+            keepAlive={status !== "exited"}
           />
         </Suspense>
         {overlayState !== null ? (

--- a/clients/gui-app/src/components/epic-canvas/renderers/xterm-host-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/xterm-host-registry.ts
@@ -98,13 +98,14 @@ let followerInstalled = false;
 
 /**
  * Evict any kept-alive engine whose tab instance has left the
- * `TerminalSessionRegistry`. Plain terminals release their engine eagerly
- * (`releaseXtermHost(..., false)`), so by the time the session-membership
- * change fires there is nothing to evict here. The follower's job is the
- * terminal-agent case: an agent kept lease-free (tab closed, agent still
- * running) keeps its engine alive for instant reopen, and this drops that
- * engine once the agent exits and the session registry evicts the handle. The
- * registry keys handles by `instanceId` too, so the membership sets line up.
+ * `TerminalSessionRegistry`. Live sessions keep their engine cached across
+ * unmount (`releaseXtermHost(..., true)`) - terminal-agents for as long as the
+ * agent runs, plain terminals for the registry's release-linger window - so
+ * the engine's true owner is the session handle, and this follower is what
+ * finally disposes the engine when the registry evicts that handle (agent
+ * exit, linger expiry, or a forced release). Only exited sessions release
+ * their engine eagerly. The registry keys handles by `instanceId` too, so the
+ * membership sets line up.
  */
 function installFollowerOnce(): void {
   if (followerInstalled) return;
@@ -145,11 +146,12 @@ export function acquireXtermHost(
 
 /**
  * Drop a host's reference to the engine. `keepAlive` is the caller's "this
- * session is still live" signal (a running terminal-agent): true keeps the
- * engine cached for the next host so scrollback and cursor state survive a
- * split / tab-switch / reopen; false (plain terminals, exited agents) disposes
- * it now - the matching session handle is being torn down too, so the next open
- * rebuilds both and replays a fresh host snapshot.
+ * session is still live" signal (a running terminal-agent or plain terminal):
+ * true keeps the engine cached for the next host so scrollback and cursor
+ * state survive a split / tab-switch / reopen, with the follower disposing it
+ * once the session registry evicts the matching handle; false (exited
+ * sessions) disposes it now - the matching session handle is being torn down
+ * too, so the next open rebuilds both and replays a fresh host snapshot.
  */
 export function releaseXtermHost(instanceId: string, keepAlive: boolean): void {
   if (keepAlive) return;

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
@@ -177,7 +177,14 @@ function LandingTerminalTileLive(props: {
             onWriterReady={handleWriter}
             shouldFocusOnActivePane={active}
             findTargetId={null}
-            keepAlive={false}
+            // Mirrors the registry's linger rule: while the session is live its
+            // handle outlives this unmount (tab switch away from the landing
+            // page), and the store's writer keeps pointing at this engine - so
+            // the engine must survive too, or a return within the linger
+            // window would reattach a blank terminal (the host snapshot was
+            // already consumed). The registry follower disposes the engine
+            // when the lingering handle is finally evicted.
+            keepAlive={status !== "exited"}
           />
         </Suspense>
       </div>

--- a/clients/gui-app/src/lib/registries/terminal-session-registry.ts
+++ b/clients/gui-app/src/lib/registries/terminal-session-registry.ts
@@ -75,8 +75,9 @@ export function useTerminalSessionHandle(
   const hostEntry = useHostDirectoryEntry(args.hostId);
   const globalClient = useHostClient();
   // Terminal is a DURABLE per-tab stream: its `WsStreamClient` is OWNED by the
-  // session store for the session's warm lifetime (terminal-agent sessions are
-  // kept warm across tile unmount), NOT by this tile - so closing then reopening
+  // session store for the session's warm lifetime (live sessions are kept warm
+  // across tile unmount - agents indefinitely, plain terminals for the
+  // release-linger window), NOT by this tile - so closing then reopening
   // the tab no longer hands the revived warm session a socket the unmounting
   // tile already closed. The opener wires the shared "durable stream = auth +
   // wake" recovery; the returned handle's `close()` tears it down on dispose.

--- a/clients/gui-app/src/stores/terminals/__tests__/terminal-session-registry.test.ts
+++ b/clients/gui-app/src/stores/terminals/__tests__/terminal-session-registry.test.ts
@@ -180,10 +180,11 @@ describe("TerminalSessionRegistry", () => {
     owned.forEach((entry, index) => {
       registry.acquire(`terminal-${index}`, () => entry.handle);
     });
+    // All releases happen in the same synchronous batch (same tick), so
+    // ordering relies entirely on the monotonic release sequence, not on
+    // `Date.now()` ticking between them.
     owned.forEach((_entry, index) => {
       registry.release(`terminal-${index}`);
-      // Distinct release stamps so oldest-first ordering is deterministic.
-      vi.advanceTimersByTime(1);
     });
 
     expect(owned[0].closeCount()).toBe(1);
@@ -206,7 +207,6 @@ describe("TerminalSessionRegistry", () => {
     owned.forEach((entry, index) => {
       registry.acquire(`terminal-${index}`, () => entry.handle);
       registry.release(`terminal-${index}`);
-      vi.advanceTimersByTime(1);
     });
 
     // The warm agent neither counts toward the cap (all plains retained) nor

--- a/clients/gui-app/src/stores/terminals/__tests__/terminal-session-registry.test.ts
+++ b/clients/gui-app/src/stores/terminals/__tests__/terminal-session-registry.test.ts
@@ -1,11 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { TerminalStreamCallbacks } from "@traycer-clients/shared/host-transport/terminal-stream-client";
 import type { TerminalSessionKind } from "@traycer/protocol/host/terminal/unary-schemas";
 import {
   createTerminalSessionStore,
   type TerminalSessionStoreHandle,
 } from "@/stores/terminals/terminal-session-store";
-import { TerminalSessionRegistry } from "@/stores/terminals/terminal-session-registry";
+import {
+  MAX_LINGERING_PLAIN_TERMINALS,
+  PLAIN_TERMINAL_RELEASE_LINGER_MS,
+  TerminalSessionRegistry,
+} from "@/stores/terminals/terminal-session-registry";
 
 function createHandle(kind: TerminalSessionKind): {
   readonly handle: TerminalSessionStoreHandle;
@@ -42,15 +46,191 @@ function createHandle(kind: TerminalSessionKind): {
 }
 
 describe("TerminalSessionRegistry", () => {
-  it("disposes a plain terminal when its last lease is released", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("lingers a released running plain terminal, then disposes at window expiry", () => {
     const registry = new TerminalSessionRegistry();
     const owned = createHandle("terminal");
 
     registry.acquire("terminal-1", () => owned.handle);
     registry.release("terminal-1");
 
+    // Still a live registry member for the linger window: the stream stays
+    // open and the xterm follower keeps its engine.
+    expect(owned.closeCount()).toBe(0);
+    expect(registry.get("terminal-1")).toBe(owned.handle);
+
+    vi.advanceTimersByTime(PLAIN_TERMINAL_RELEASE_LINGER_MS - 1);
+    expect(owned.closeCount()).toBe(0);
+
+    vi.advanceTimersByTime(1);
     expect(owned.closeCount()).toBe(1);
     expect(registry.get("terminal-1")).toBeNull();
+  });
+
+  it("reacquiring within the linger window reuses the handle and cancels eviction", () => {
+    const registry = new TerminalSessionRegistry();
+    const owned = createHandle("terminal");
+
+    registry.acquire("terminal-1", () => owned.handle);
+    registry.release("terminal-1");
+
+    const reacquired = registry.acquire("terminal-1", () => {
+      throw new Error("must reuse the lingering handle");
+    });
+    expect(reacquired).toBe(owned.handle);
+
+    vi.advanceTimersByTime(PLAIN_TERMINAL_RELEASE_LINGER_MS * 2);
+    expect(owned.closeCount()).toBe(0);
+    expect(registry.get("terminal-1")).toBe(owned.handle);
+  });
+
+  it("disposes a lingering plain terminal immediately when the session exits", () => {
+    const registry = new TerminalSessionRegistry();
+    const owned = createHandle("terminal");
+
+    registry.acquire("terminal-1", () => owned.handle);
+    registry.release("terminal-1");
+
+    owned.callbacks().onExit({
+      kind: "exit",
+      hasBinaryPayload: false,
+      sessionId: "terminal-1",
+      exitCode: 0,
+    });
+
+    expect(owned.closeCount()).toBe(1);
+    expect(registry.get("terminal-1")).toBeNull();
+
+    // The cancelled linger timer must not double-dispose or resurrect.
+    vi.advanceTimersByTime(PLAIN_TERMINAL_RELEASE_LINGER_MS);
+    expect(owned.closeCount()).toBe(1);
+  });
+
+  it("disposes an exited plain terminal without lingering when its last lease is released", () => {
+    const registry = new TerminalSessionRegistry();
+    const owned = createHandle("terminal");
+
+    registry.acquire("terminal-1", () => owned.handle);
+    // Two leases: the exit eviction only fires on lease-free entries, so the
+    // release below is what must observe the exited state.
+    registry.acquire("terminal-1", () => {
+      throw new Error("must reuse the live handle");
+    });
+    registry.release("terminal-1");
+    owned.callbacks().onExit({
+      kind: "exit",
+      hasBinaryPayload: false,
+      sessionId: "terminal-1",
+      exitCode: 0,
+    });
+    registry.release("terminal-1");
+
+    expect(owned.closeCount()).toBe(1);
+    expect(registry.get("terminal-1")).toBeNull();
+  });
+
+  it("disposes a lost plain terminal on release instead of lingering it", () => {
+    const registry = new TerminalSessionRegistry();
+    const owned = createHandle("terminal");
+
+    registry.acquire("terminal-1", () => owned.handle);
+    owned.callbacks().onConnectionStatus("closed", { kind: "caller" });
+    expect(owned.handle.store.getState().status).toBe("lost");
+    registry.release("terminal-1");
+
+    // A closed stream never redials, so a lingering lost handle could only be
+    // revived as a permanently dead terminal.
+    expect(owned.closeCount()).toBe(1);
+    expect(registry.get("terminal-1")).toBeNull();
+  });
+
+  it("evicts a lingering plain terminal whose stream is lost, so reacquire builds fresh", () => {
+    const registry = new TerminalSessionRegistry();
+    const owned = createHandle("terminal");
+
+    registry.acquire("terminal-1", () => owned.handle);
+    registry.release("terminal-1");
+    expect(registry.get("terminal-1")).toBe(owned.handle);
+
+    owned.callbacks().onConnectionStatus("closed", { kind: "caller" });
+
+    expect(owned.closeCount()).toBe(1);
+    expect(registry.get("terminal-1")).toBeNull();
+
+    const fresh = createHandle("terminal");
+    const reacquired = registry.acquire("terminal-1", () => fresh.handle);
+    expect(reacquired).toBe(fresh.handle);
+    expect(fresh.closeCount()).toBe(0);
+  });
+
+  it("caps the linger pool, evicting the oldest-released plain terminal first", () => {
+    const registry = new TerminalSessionRegistry();
+    const owned = Array.from(
+      { length: MAX_LINGERING_PLAIN_TERMINALS + 1 },
+      () => createHandle("terminal"),
+    );
+
+    owned.forEach((entry, index) => {
+      registry.acquire(`terminal-${index}`, () => entry.handle);
+    });
+    owned.forEach((_entry, index) => {
+      registry.release(`terminal-${index}`);
+      // Distinct release stamps so oldest-first ordering is deterministic.
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(owned[0].closeCount()).toBe(1);
+    expect(registry.get("terminal-0")).toBeNull();
+    owned.slice(1).forEach((entry, index) => {
+      expect(entry.closeCount()).toBe(0);
+      expect(registry.get(`terminal-${index + 1}`)).toBe(entry.handle);
+    });
+  });
+
+  it("excludes warm terminal-agents from the linger pool count and candidacy", () => {
+    const registry = new TerminalSessionRegistry();
+    const agent = createHandle("terminal-agent");
+    registry.acquire("agent-1", () => agent.handle);
+    registry.release("agent-1");
+
+    const owned = Array.from({ length: MAX_LINGERING_PLAIN_TERMINALS }, () =>
+      createHandle("terminal"),
+    );
+    owned.forEach((entry, index) => {
+      registry.acquire(`terminal-${index}`, () => entry.handle);
+      registry.release(`terminal-${index}`);
+      vi.advanceTimersByTime(1);
+    });
+
+    // The warm agent neither counts toward the cap (all plains retained) nor
+    // gets evicted by it.
+    expect(agent.closeCount()).toBe(0);
+    expect(registry.get("agent-1")).toBe(agent.handle);
+    owned.forEach((entry) => {
+      expect(entry.closeCount()).toBe(0);
+    });
+  });
+
+  it("forceRelease during the linger window disposes once and cancels the timer", () => {
+    const registry = new TerminalSessionRegistry();
+    const owned = createHandle("terminal");
+
+    registry.acquire("terminal-1", () => owned.handle);
+    registry.release("terminal-1");
+    registry.forceRelease("terminal-1");
+
+    expect(owned.closeCount()).toBe(1);
+    expect(registry.get("terminal-1")).toBeNull();
+
+    vi.advanceTimersByTime(PLAIN_TERMINAL_RELEASE_LINGER_MS);
+    expect(owned.closeCount()).toBe(1);
   });
 
   it("keeps a lease-free terminal-agent warm until the host session exits", () => {

--- a/clients/gui-app/src/stores/terminals/terminal-session-registry.ts
+++ b/clients/gui-app/src/stores/terminals/terminal-session-registry.ts
@@ -1,10 +1,42 @@
 import type { TerminalSessionStoreHandle } from "@/stores/terminals/terminal-session-store";
 
+/**
+ * How long a released, still-running plain terminal keeps its handle (and
+ * therefore its live `terminal.subscribe` stream + warm xterm engine) before
+ * the registry evicts it. Navigating away from the surface that mounted the
+ * tile (landing page -> epic tab, epic -> epic) releases every lease; without
+ * this window the stream is torn down immediately and coming back pays the
+ * full reconnect cost - transport dial, re-subscribe, snapshot replay - as
+ * seconds of blank terminal. Within the window a remount reacquires the same
+ * handle and reattaches the same engine instantly. The host-side PTY runs
+ * regardless; this only bounds how long the renderer keeps an attachment
+ * nobody is looking at. Matches `DEFAULT_CHAT_IDLE_TTL_MS` so a tab switch
+ * treats the chats and the terminals it hides identically.
+ */
+export const PLAIN_TERMINAL_RELEASE_LINGER_MS = 10 * 60 * 1000;
+
+/**
+ * Upper bound on lease-free lingering plain terminals held at once. The
+ * linger window bounds retention in time; this bounds it in count, so cycling
+ * through many terminal-bearing tabs inside one window cannot pin an unbounded
+ * set of open streams and warm xterm engines. Oldest-released first. The
+ * count-bounded pool is the lingering plain terminals only: lease-free
+ * running terminal-agents live under their own indefinite keep-warm rule and
+ * neither count toward nor get evicted by this cap (counting them would let N
+ * running agents flush every lingering shell immediately). Mirrors
+ * `DEFAULT_MAX_WARM_CHAT_SESSIONS`.
+ */
+export const MAX_LINGERING_PLAIN_TERMINALS = 6;
+
 interface RegistryEntry {
   readonly instanceId: string;
   readonly handle: TerminalSessionStoreHandle;
   readonly unsubscribeStatus: () => void;
   leases: number;
+  /** Pending timed eviction for a lease-free, still-running plain terminal. */
+  lingerTimer: number | null;
+  /** When the last lease released; orders warm-cap eviction (oldest first). */
+  lastReleasedAt: number;
 }
 
 /**
@@ -19,6 +51,15 @@ interface RegistryEntry {
  * their own `TerminalStreamClient` subscribing to the shared session. The
  * host already fans `terminal.subscribe` out to many subscribers and replays
  * scrollback to each, so a second live view costs nothing host-side.
+ *
+ * Lease-free retention: a running terminal-agent is kept warm indefinitely
+ * (its tab may reopen any time while the agent works); a running plain
+ * terminal lingers for {@link PLAIN_TERMINAL_RELEASE_LINGER_MS} so a tab
+ * switch away and back reattaches instantly, count-bounded by
+ * {@link MAX_LINGERING_PLAIN_TERMINALS} (oldest-released evicted first);
+ * exited sessions are disposed as soon as the last lease releases. This is
+ * the terminal twin of `ChatSessionRegistry`'s warm pool, so hiding a tab
+ * treats its chats and terminals identically.
  */
 export class TerminalSessionRegistry {
   private readonly entries = new Map<string, RegistryEntry>();
@@ -74,6 +115,7 @@ export class TerminalSessionRegistry {
   ): TerminalSessionStoreHandle {
     const existing = this.entries.get(instanceId);
     if (existing !== undefined) {
+      this.cancelLinger(existing);
       existing.leases += 1;
       return existing.handle;
     }
@@ -82,10 +124,24 @@ export class TerminalSessionRegistry {
       instanceId,
       handle,
       unsubscribeStatus: handle.store.subscribe((state) => {
-        if (state.status !== "exited") return;
-        this.evictExitedLeaseFreeEntry(instanceId);
+        const defunct =
+          state.status === "exited" ||
+          // "Lost" (the store's mapping of a `closed` stream) is a dead end
+          // for a plain terminal: the stream client never redials after
+          // `closed` (transient drops surface as "reconnecting", not
+          // "closed"), so a lingering lost handle would only ever be revived
+          // as a permanently dead store - and it would shadow the fresh
+          // create-then-acquire bootstrap after the host recreates the
+          // session. Lost terminal-AGENTS stay warm: their reopen path runs
+          // `useTerminalSessionRecovery`, which force-releases the dead
+          // handle and re-bootstraps.
+          (state.status === "lost" && state.kind === "terminal");
+        if (!defunct) return;
+        this.evictDefunctLeaseFreeEntry(instanceId);
       }),
       leases: 1,
+      lingerTimer: null,
+      lastReleasedAt: 0,
     };
     this.entries.set(instanceId, entry);
     this.notify();
@@ -99,6 +155,25 @@ export class TerminalSessionRegistry {
     entry.leases -= 1;
     if (entry.leases > 0) return;
     if (shouldKeepLeaseFree(entry.handle)) return;
+    if (shouldLingerLeaseFree(entry.handle)) {
+      // Still-running plain terminal: keep the handle (live stream + warm
+      // engine) for the linger window so navigating back reattaches instantly
+      // instead of paying a full reconnect. The entry stays a registry member
+      // so the xterm follower keeps its engine; eviction happens on the timer,
+      // on session exit or stream loss (the status subscription above), on
+      // warm-cap overflow, or via forceRelease.
+      entry.lastReleasedAt = Date.now();
+      entry.lingerTimer = window.setTimeout(() => {
+        entry.lingerTimer = null;
+        if (entry.leases > 0) return;
+        if (this.entries.get(instanceId) !== entry) return;
+        this.entries.delete(instanceId);
+        this.disposeEntry(entry);
+        this.notify();
+      }, PLAIN_TERMINAL_RELEASE_LINGER_MS);
+      this.evictLingerOverflow();
+      return;
+    }
     this.entries.delete(instanceId);
     this.disposeEntry(entry);
     this.notify();
@@ -121,7 +196,13 @@ export class TerminalSessionRegistry {
     this.notify();
   }
 
-  private evictExitedLeaseFreeEntry(instanceId: string): void {
+  /**
+   * Drops a lease-free entry whose session became unreattachable (exited, or
+   * a plain terminal whose stream closed for good). Leased entries are left
+   * alone: the mounted tile observes the same status and owns the response
+   * (close the tab, run recovery).
+   */
+  private evictDefunctLeaseFreeEntry(instanceId: string): void {
     const entry = this.entries.get(instanceId);
     if (entry === undefined) return;
     if (entry.leases > 0) return;
@@ -130,13 +211,57 @@ export class TerminalSessionRegistry {
     this.notify();
   }
 
+  /**
+   * Enforces the linger cap after a release parks an entry in the linger pool.
+   * A live `lingerTimer` is the pool-membership marker, so lease-free warm
+   * terminal-agents (timer-less) are neither counted nor candidates.
+   */
+  private evictLingerOverflow(): void {
+    const lingering = Array.from(this.entries.values()).filter(
+      (entry) => entry.lingerTimer !== null,
+    );
+    const overflow = lingering.length - MAX_LINGERING_PLAIN_TERMINALS;
+    if (overflow <= 0) return;
+    lingering.sort((a, b) => a.lastReleasedAt - b.lastReleasedAt);
+    for (const entry of lingering.slice(0, overflow)) {
+      this.entries.delete(entry.instanceId);
+      this.disposeEntry(entry);
+    }
+    this.notify();
+  }
+
   private disposeEntry(entry: RegistryEntry): void {
+    this.cancelLinger(entry);
     entry.unsubscribeStatus();
     entry.handle.dispose();
+  }
+
+  private cancelLinger(entry: RegistryEntry): void {
+    if (entry.lingerTimer === null) return;
+    window.clearTimeout(entry.lingerTimer);
+    entry.lingerTimer = null;
   }
 }
 
 function shouldKeepLeaseFree(handle: TerminalSessionStoreHandle): boolean {
   const state = handle.store.getState();
   return state.kind === "terminal-agent" && state.status !== "exited";
+}
+
+/**
+ * A released plain terminal lingers for
+ * {@link PLAIN_TERMINAL_RELEASE_LINGER_MS} only while its stream can still
+ * serve a reattach (creating/running). "Lost" is excluded: the stream client
+ * never redials after `closed` (transient drops surface as "reconnecting"),
+ * so a lost handle would be revived as a permanently dead terminal - the
+ * landing tile has no recovery hook - and would shadow the fresh
+ * create-then-acquire bootstrap after the host recreates the session.
+ */
+function shouldLingerLeaseFree(handle: TerminalSessionStoreHandle): boolean {
+  const state = handle.store.getState();
+  return (
+    state.kind === "terminal" &&
+    state.status !== "exited" &&
+    state.status !== "lost"
+  );
 }

--- a/clients/gui-app/src/stores/terminals/terminal-session-registry.ts
+++ b/clients/gui-app/src/stores/terminals/terminal-session-registry.ts
@@ -35,8 +35,14 @@ interface RegistryEntry {
   leases: number;
   /** Pending timed eviction for a lease-free, still-running plain terminal. */
   lingerTimer: number | null;
-  /** When the last lease released; orders warm-cap eviction (oldest first). */
-  lastReleasedAt: number;
+  /**
+   * Monotonic release ordinal, orders warm-cap eviction (oldest first).
+   * `Date.now()` is not fine-grained enough - two releases in the same
+   * synchronous batch (e.g. `closeAllTabs`) can land on the same millisecond,
+   * making the sort order ambiguous - so a per-registry counter is used
+   * instead.
+   */
+  releaseSequence: number;
 }
 
 /**
@@ -64,6 +70,7 @@ interface RegistryEntry {
 export class TerminalSessionRegistry {
   private readonly entries = new Map<string, RegistryEntry>();
   private readonly listeners = new Set<() => void>();
+  private nextReleaseSequence = 0;
 
   size(): number {
     return this.entries.size;
@@ -141,7 +148,7 @@ export class TerminalSessionRegistry {
       }),
       leases: 1,
       lingerTimer: null,
-      lastReleasedAt: 0,
+      releaseSequence: 0,
     };
     this.entries.set(instanceId, entry);
     this.notify();
@@ -162,7 +169,7 @@ export class TerminalSessionRegistry {
       // so the xterm follower keeps its engine; eviction happens on the timer,
       // on session exit or stream loss (the status subscription above), on
       // warm-cap overflow, or via forceRelease.
-      entry.lastReleasedAt = Date.now();
+      entry.releaseSequence = this.nextReleaseSequence++;
       entry.lingerTimer = window.setTimeout(() => {
         entry.lingerTimer = null;
         if (entry.leases > 0) return;
@@ -222,11 +229,11 @@ export class TerminalSessionRegistry {
     );
     const overflow = lingering.length - MAX_LINGERING_PLAIN_TERMINALS;
     if (overflow <= 0) return;
-    lingering.sort((a, b) => a.lastReleasedAt - b.lastReleasedAt);
-    for (const entry of lingering.slice(0, overflow)) {
+    lingering.sort((a, b) => a.releaseSequence - b.releaseSequence);
+    lingering.slice(0, overflow).forEach((entry) => {
       this.entries.delete(entry.instanceId);
       this.disposeEntry(entry);
-    }
+    });
     this.notify();
   }
 


### PR DESCRIPTION
## Summary
- Switching away from a landing or epic terminal tab released the terminal's last lease and disposed its `terminal.subscribe` stream (and xterm engine) immediately, so switching back paid a full reconnect - as several seconds of blank screen. Chats already avoid this via `ChatSessionRegistry`'s warm idle pool; this gives plain terminals the same treatment.
- A released, still-running plain terminal now lingers for 10 minutes (matching the chat idle TTL), count-bounded to 6 lingering terminals (matching the chat warm cap). The xterm engine is kept alive alongside the lingering handle so a reattach within the window is instant, since the store's writer still points at that engine and the host snapshot is one-shot.
- A `lost` stream (closed for good - the transport never redials past `closed`) is excluded from lingering and evicted immediately, rather than revived as a permanently dead handle on a later reacquire.
- Lease-free running terminal-agents keep their pre-existing indefinite keep-warm rule and are excluded from both the linger predicate and the new warm-count cap.

## Test plan
- [x] `bun run test src/stores/terminals/__tests__/terminal-session-registry.test.ts` - 11 tests covering linger/expiry, reacquire-cancels-eviction, exit-during-linger, warm-cap eviction ordering, terminal-agent exclusion, lost-at-release, and lost-while-lingering
- [x] Full gui-app suite: 5665 passed
- [x] `bun run compile` (tsc -b) clean
- [x] `eslint` clean on touched files
- [x] `react-doctor --scope changed --base main` clean