### PR TITLE
test(gui-app): lock in focus-authority for chat scroll keys

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -503,6 +503,34 @@ describe("ChatMessages Virtuoso renderer", () => {
     sibling.remove();
   });
 
+  it("keeps scrolling from a focused descendant when the tile is inactive", () => {
+    const messages = makeMessages(100);
+    renderChatMessages(
+      messages,
+      makeDefaultOpts({ minimapItems: minimapItemsFor(messages) }),
+    );
+    const scroller = screen.getByTestId("virtuoso-scroller");
+    Object.defineProperties(scroller, {
+      clientHeight: { configurable: true, value: 500 },
+      scrollHeight: { configurable: true, value: 2_000 },
+    });
+
+    // A split pane that isn't the active pane still renders its selected chat
+    // visibly and focusably (unselected tabs are display:none, which blurs).
+    // Focus is the authority for a key rooted INSIDE the tile: no other tile
+    // would claim it, so gating this branch on `data-active` would drop the
+    // key entirely rather than route it elsewhere.
+    const tile = screen.getByTestId("chat-keyboard-scroll-scope");
+    tile.setAttribute("data-active", "false");
+    const composer = document.createElement("textarea");
+    tile.appendChild(composer);
+    composer.focus();
+
+    scroller.scrollTop = 1_000;
+    fireEvent.keyDown(composer, { key: "PageUp" });
+    expect(scroller.scrollTop).toBe(500);
+  });
+
   it("scrolls the transcript with plain Home/End on macOS, including from editable targets", () => {
     platformMock.isMac = true;
     const messages = makeMessages(100);


### PR DESCRIPTION
Follow-up to #387. The regression test CodeRabbit asked for in [this thread](https://github.com/traycerai/traycer/pull/387#discussion_r3598162825) — auto-merge fired on #387 while this commit was still running its pre-commit hook, so it missed the merge.

## Why the branch it covers is intentionally ungated

CodeRabbit flagged that `targetInsideTile` bypasses `data-active`, and proposed gating both containment branches on active state. I applied that exact diff locally and ran the case: **the key stops working entirely**. The inactive tile returns early on `data-active`, and every other tile returns because the target is neither inside it nor an ancestor of it — so nothing handles the event and `scrollTop` never moves. That's strictly worse than scrolling the tile the user is focused in.

The asymmetry is the design:

- **`targetInsideTile`** — unambiguous. Exactly one tile contains the target, so focus decides the owner. No tiebreak needed.
- **ancestor branch** — ambiguous. Several tiles could claim the same `body`-rooted event, so `data-active` picks the winner.

The scenario as described also can't arise: an unselected chat tab renders `display:none` (`tab-group-view.tsx:392`), and the browser blurs any focused descendant of a `display:none` subtree, so a hidden keep-alive tile can't hold focus. Its keys arrive rooted at `body` — the ancestor branch, which *is* gated.

The one case where a chat tile is inactive yet focusable is a split pane that isn't the active pane (`isActive = role !== null && selected && globallyActive`). It's visible and focusable, and scrolling it is correct — the caret is in that transcript's composer.

## The test

Covers exactly that case: tile marked inactive, focused descendant, PageUp scrolls. It fails under CodeRabbit's suggested diff and passes as written.

Correcting the record from the #387 thread: my reply there cited `4b7ba99` for this test, which was a hash I wrote before the commit existed. The real commit is `4da7e32`, here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)