### PR TITLE
Fix notification toast navigation

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-node-tab-icon.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-node-tab-icon.test.tsx
@@ -30,8 +30,14 @@ describe("<EpicNodeTabIcon /> terminal indicator", () => {
     useAppLocalNotificationsStore.getState().activateIdentity("user-1");
     emitTerminalCrashedNotification({
       instanceId: TERMINAL_NODE.instanceId,
-      epicId: "epic-1",
-      chatId: TERMINAL_NODE.id,
+      target: {
+        kind: "terminal",
+        epicId: "epic-1",
+        terminalId: TERMINAL_NODE.id,
+        tabId: "view-tab-1",
+        paneId: "pane-1",
+        tileInstanceId: TERMINAL_NODE.instanceId,
+      },
       cause: "exit",
     });
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
@@ -60,11 +60,23 @@ export function TerminalTile(props: TerminalTileProps) {
     crashReportedRef.current = true;
     emitTerminalCrashedNotification({
       instanceId: props.node.instanceId,
-      epicId,
-      chatId: props.node.id,
+      target: {
+        kind: "terminal",
+        epicId,
+        terminalId: props.node.id,
+        tabId: props.viewTabId,
+        paneId: props.tileId,
+        tileInstanceId: props.node.instanceId,
+      },
       cause: "exit",
     });
-  }, [epicId, props.node.id, props.node.instanceId]);
+  }, [
+    epicId,
+    props.node.id,
+    props.node.instanceId,
+    props.tileId,
+    props.viewTabId,
+  ]);
   const reportRecoveryExhausted = useCallback(() => {
     // Whichever path observes this terminal death first owns its notification.
     if (crashReportedRef.current) return;
@@ -72,11 +84,23 @@ export function TerminalTile(props: TerminalTileProps) {
     crashReportedRef.current = true;
     emitTerminalCrashedNotification({
       instanceId: props.node.instanceId,
-      epicId,
-      chatId: props.node.id,
+      target: {
+        kind: "terminal",
+        epicId,
+        terminalId: props.node.id,
+        tabId: props.viewTabId,
+        paneId: props.tileId,
+        tileInstanceId: props.node.instanceId,
+      },
       cause: "recovery-exhausted",
     });
-  }, [epicId, props.node.id, props.node.instanceId]);
+  }, [
+    epicId,
+    props.node.id,
+    props.node.instanceId,
+    props.tileId,
+    props.viewTabId,
+  ]);
   const closeCanvasTile = useCloseCanvasTileWithNestedFocus(
     props.viewTabId,
     props.tileId,
@@ -104,8 +128,14 @@ export function TerminalTile(props: TerminalTileProps) {
     emitTerminalClosedNotification({
       instanceId: props.node.instanceId,
       hostLabel: reachability.hostLabel,
-      epicId,
-      chatId: props.node.id,
+      target: {
+        kind: "terminal",
+        epicId,
+        terminalId: props.node.id,
+        tabId: props.viewTabId,
+        paneId: props.tileId,
+        tileInstanceId: props.node.instanceId,
+      },
     });
   }, [
     reachability.status,
@@ -113,6 +143,8 @@ export function TerminalTile(props: TerminalTileProps) {
     epicId,
     props.node.id,
     props.node.instanceId,
+    props.tileId,
+    props.viewTabId,
   ]);
   if (reachability.status === "unreachable") {
     return (

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -147,22 +147,46 @@ export function TuiAgentTile(props: TuiAgentTileProps) {
     crashReportedRef.current = true;
     emitTerminalCrashedNotification({
       instanceId: props.node.instanceId,
-      epicId,
-      chatId: props.node.id,
+      target: {
+        kind: "terminal",
+        epicId,
+        terminalId: props.node.id,
+        tabId: props.viewTabId,
+        paneId: props.tileId,
+        tileInstanceId: props.node.instanceId,
+      },
       cause: "exit",
     });
-  }, [epicId, props.node.id, props.node.instanceId]);
+  }, [
+    epicId,
+    props.node.id,
+    props.node.instanceId,
+    props.tileId,
+    props.viewTabId,
+  ]);
   const reportRecoveryExhausted = useCallback(() => {
     // Whichever path observes this terminal death first owns its notification.
     if (crashReportedRef.current) return;
     crashReportedRef.current = true;
     emitTerminalCrashedNotification({
       instanceId: props.node.instanceId,
-      epicId,
-      chatId: props.node.id,
+      target: {
+        kind: "terminal",
+        epicId,
+        terminalId: props.node.id,
+        tabId: props.viewTabId,
+        paneId: props.tileId,
+        tileInstanceId: props.node.instanceId,
+      },
       cause: "recovery-exhausted",
     });
-  }, [epicId, props.node.id, props.node.instanceId]);
+  }, [
+    epicId,
+    props.node.id,
+    props.node.instanceId,
+    props.tileId,
+    props.viewTabId,
+  ]);
   const closeCanvasTile = useCloseCanvasTileWithNestedFocus(
     props.viewTabId,
     props.tileId,
@@ -189,8 +213,14 @@ export function TuiAgentTile(props: TuiAgentTileProps) {
     emitTerminalClosedNotification({
       instanceId: props.node.instanceId,
       hostLabel: reachability.hostLabel,
-      epicId,
-      chatId: props.node.id,
+      target: {
+        kind: "terminal",
+        epicId,
+        terminalId: props.node.id,
+        tabId: props.viewTabId,
+        paneId: props.tileId,
+        tileInstanceId: props.node.instanceId,
+      },
     });
   }, [
     reachability.status,
@@ -198,6 +228,8 @@ export function TuiAgentTile(props: TuiAgentTileProps) {
     epicId,
     props.node.id,
     props.node.instanceId,
+    props.tileId,
+    props.viewTabId,
   ]);
   if (reachability.status === "unreachable") {
     return (

--- a/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.test.tsx
@@ -125,6 +125,81 @@ describe("NotificationFocusBridge", () => {
     });
   });
 
+  it("routes in-app Chat toast clicks without opening the popover", () => {
+    const tabId = useEpicCanvasStore
+      .getState()
+      .openEpicTab("epic-in-app", "In-app epic");
+    renderBridge();
+
+    act(() => {
+      useNotificationEventsStore.getState().recordInAppClick(
+        {
+          kind: "chat",
+          epicId: "epic-in-app",
+          chatId: "chat-in-app",
+        },
+        1_777_768_800_123,
+      );
+    });
+
+    expect(useNotificationsPopoverStore.getState().open).toBe(false);
+    expect(navigateSpy).toHaveBeenCalledWith({
+      to: "/epics/$epicId/$tabId",
+      params: { epicId: "epic-in-app", tabId },
+      search: {
+        focusedAt: 1_777_768_800_123,
+        focusArtifactId: "chat-in-app",
+        focusThreadId: undefined,
+        migrationSource: undefined,
+      },
+    });
+  });
+
+  it("parses and routes terminal payloads to their exact canvas tile", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-terminal", "Terminal epic");
+    store.openTileInTab(tabId, {
+      id: "terminal-1",
+      instanceId: "terminal-instance-1",
+      type: "terminal",
+      name: "Terminal",
+      titleSource: "manual",
+      hostId: "host-1",
+      cwd: "/repo",
+    });
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+    if (canvas === undefined || canvas.activePaneId === null) {
+      throw new Error("expected terminal canvas");
+    }
+    const paneId = canvas.activePaneId;
+    renderBridge();
+
+    act(() => {
+      useNotificationEventsStore.getState().recordClick({
+        kind: "terminal",
+        epicId: "epic-terminal",
+        terminalId: "terminal-1",
+        tabId,
+        paneId,
+        tileInstanceId: "terminal-instance-1",
+      });
+    });
+
+    expect(useNotificationsPopoverStore.getState().open).toBe(true);
+    expect(navigateSpy).toHaveBeenCalledWith({
+      to: "/epics/$epicId/$tabId",
+      params: { epicId: "epic-terminal", tabId },
+      search: {
+        focusedAt: 1_777_768_800_000,
+        focusArtifactId: undefined,
+        focusThreadId: undefined,
+        migrationSource: undefined,
+        focusPaneId: paneId,
+        focusTileInstanceId: "terminal-instance-1",
+      },
+    });
+  });
+
   it.each([
     ["session", { kind: "session", sessionId: "session-1" }],
     [

--- a/clients/gui-app/src/components/layout/bridges/notification-emission-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/notification-emission-controller.tsx
@@ -12,11 +12,11 @@ export function NotificationEmissionController(): null {
   const showNotification = useNotificationShow();
   const { activate } = useNotificationActivation();
   const onToastClick = useCallback(
-    (row: MergedNotificationRow): void => {
+    (row: MergedNotificationRow, activatedAt: number): void => {
       if (row.payload === null) return;
       activate({
         payload: row.payload,
-        receivedAt: row.createdAt,
+        receivedAt: activatedAt,
         onActivated: null,
       });
     },

--- a/clients/gui-app/src/components/layout/bridges/notification-focus-bridge.tsx
+++ b/clients/gui-app/src/components/layout/bridges/notification-focus-bridge.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { parseNotificationPayload } from "@/lib/notifications";
 import { useNotificationActivation } from "@/hooks/notifications/use-notification-activation";
 import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
@@ -20,6 +19,7 @@ import { useNotificationsPopoverStore } from "@/stores/notifications/notificatio
  *                 (and `focusThreadId` when present) when `payload.epicId`
  *                 is known
  *   - `chat` / `approval` / `interview` → then navigate to the owning chat
+ *   - `terminal` → then navigate to the exact task tab and terminal tile
  *   - `session` / artifact-without-epic → open only
  *
  * `receivedAt` is forwarded as `focusedAt` so repeat clicks of the same
@@ -29,7 +29,6 @@ export function NotificationFocusBridge(): null {
   const notificationEvent = useNotificationEventsStore(
     (state) => state.notificationEvent,
   );
-  const navigate = useNavigate();
   const { activate } = useNotificationActivation();
 
   useEffect(() => {
@@ -39,7 +38,9 @@ export function NotificationFocusBridge(): null {
 
     const parsed = parseNotificationPayload(notificationEvent.payload);
 
-    useNotificationsPopoverStore.getState().setOpen(true);
+    if (notificationEvent.openPopover) {
+      useNotificationsPopoverStore.getState().setOpen(true);
+    }
 
     if (parsed === null) {
       return;
@@ -48,6 +49,7 @@ export function NotificationFocusBridge(): null {
     if (
       parsed.kind === "epic" ||
       parsed.kind === "chat" ||
+      parsed.kind === "terminal" ||
       parsed.kind === "approval" ||
       parsed.kind === "interview"
     ) {
@@ -66,7 +68,7 @@ export function NotificationFocusBridge(): null {
         onActivated: null,
       });
     }
-  }, [notificationEvent, navigate, activate]);
+  }, [notificationEvent, activate]);
 
   return null;
 }

--- a/clients/gui-app/src/components/ui/sonner.tsx
+++ b/clients/gui-app/src/components/ui/sonner.tsx
@@ -25,13 +25,19 @@ const TOAST_CANCEL_BUTTON_CLASS_NAME = cn(
   "border border-border bg-background text-foreground",
   "hover:bg-muted",
 );
+const INTERACTIVE_ELEMENT_SELECTOR =
+  "button, a, input, textarea, select, [role='button']";
+const NOTIFICATION_TOAST_ACTION_SELECTOR = "[data-notification-toast-action]";
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme();
   const toasterTheme = normalizeToasterTheme(theme);
 
   return (
-    <DismissableLayer.Branch data-slot="toaster-branch">
+    <DismissableLayer.Branch
+      data-slot="toaster-branch"
+      onClick={activateNotificationToastSurface}
+    >
       <Sonner
         theme={toasterTheme}
         className="toaster group"
@@ -63,6 +69,23 @@ const Toaster = ({ ...props }: ToasterProps) => {
     </DismissableLayer.Branch>
   );
 };
+
+function activateNotificationToastSurface(
+  event: React.MouseEvent<HTMLDivElement>,
+): void {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+
+  const interactiveTarget = target.closest(INTERACTIVE_ELEMENT_SELECTOR);
+  const toastSurface = target.closest("[data-sonner-toast]");
+  const action = toastSurface?.querySelector<HTMLButtonElement>(
+    NOTIFICATION_TOAST_ACTION_SELECTOR,
+  );
+  if (interactiveTarget !== null) return;
+
+  if (action === undefined || action === null) return;
+  action.click();
+}
 
 function normalizeToasterTheme(
   theme: string | undefined,

--- a/clients/gui-app/src/hooks/notifications/__tests__/use-notification-activation.test.tsx
+++ b/clients/gui-app/src/hooks/notifications/__tests__/use-notification-activation.test.tsx
@@ -11,6 +11,8 @@ type CapturedNavigate = {
     readonly focusArtifactId: string | undefined;
     readonly focusThreadId: string | undefined;
     readonly migrationSource: string | undefined;
+    readonly focusPaneId: string | undefined;
+    readonly focusTileInstanceId: string | undefined;
   };
 };
 
@@ -111,6 +113,8 @@ describe("useNotificationActivation", () => {
       focusArtifactId: undefined,
       focusThreadId: undefined,
       migrationSource: undefined,
+      focusPaneId: undefined,
+      focusTileInstanceId: undefined,
     });
     expect(onActivated).not.toHaveBeenCalled();
 
@@ -159,6 +163,8 @@ describe("useNotificationActivation", () => {
       focusArtifactId: "artifact-1",
       focusThreadId: "thread-1",
       migrationSource: undefined,
+      focusPaneId: undefined,
+      focusTileInstanceId: undefined,
     });
   });
 
@@ -190,12 +196,114 @@ describe("useNotificationActivation", () => {
       focusArtifactId: "chat-approval",
       focusThreadId: undefined,
       migrationSource: undefined,
+      focusPaneId: undefined,
+      focusTileInstanceId: undefined,
     });
 
     await waitFor(() => {
       expect(requestMock).toHaveBeenCalledWith("epic.listCollaborators", {
         epicId: "epic-approval",
       });
+    });
+  });
+
+  it("routes terminal notifications to the exact canvas tile", async () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-terminal", "Terminal epic");
+    store.openTileInTab(tabId, {
+      id: "setup:chat-1:repo:branch",
+      instanceId: "terminal-instance",
+      type: "terminal",
+      name: "Setup terminal",
+      titleSource: "manual",
+      hostId: "host-1",
+      cwd: "/repo",
+    });
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+    if (canvas === undefined || canvas.activePaneId === null) {
+      throw new Error("expected terminal canvas");
+    }
+    const paneId = canvas.activePaneId;
+    const hook = renderHook(() => useNotificationActivation(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      hook.result.current.activate({
+        payload: {
+          kind: "terminal",
+          epicId: "epic-terminal",
+          terminalId: "setup:chat-1:repo:branch",
+          tabId,
+          paneId,
+          tileInstanceId: "terminal-instance",
+        },
+        receivedAt: 901,
+        onActivated: null,
+      });
+    });
+
+    expect(navigateSpy.mock.calls[0][0]).toEqual({
+      to: "/epics/$epicId/$tabId",
+      params: { epicId: "epic-terminal", tabId },
+      search: {
+        focusedAt: 901,
+        focusArtifactId: undefined,
+        focusThreadId: undefined,
+        migrationSource: undefined,
+        focusPaneId: paneId,
+        focusTileInstanceId: "terminal-instance",
+      },
+    });
+
+    await waitFor(() => {
+      expect(requestMock).toHaveBeenCalledWith("epic.listCollaborators", {
+        epicId: "epic-terminal",
+      });
+    });
+  });
+
+  it("routes persisted legacy terminal rows to their open canvas tile", () => {
+    const store = useEpicCanvasStore.getState();
+    const tabId = store.openEpicTab("epic-legacy", "Legacy terminal epic");
+    const terminalId = "setup:chat-legacy:repo:branch";
+    store.openTileInTab(tabId, {
+      id: terminalId,
+      instanceId: "legacy-terminal-instance",
+      type: "terminal",
+      name: "Setup terminal",
+      titleSource: "manual",
+      hostId: "host-1",
+      cwd: "/repo",
+    });
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+    if (canvas === undefined || canvas.activePaneId === null) {
+      throw new Error("expected legacy terminal canvas");
+    }
+    const hook = renderHook(() => useNotificationActivation(), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => {
+      hook.result.current.activate({
+        payload: {
+          kind: "chat",
+          epicId: "epic-legacy",
+          chatId: terminalId,
+        },
+        receivedAt: 902,
+        onActivated: null,
+      });
+    });
+
+    expect(navigateSpy.mock.calls[0][0]).toMatchObject({
+      params: { epicId: "epic-legacy", tabId },
+      search: {
+        focusedAt: 902,
+        focusArtifactId: undefined,
+        focusPaneId: canvas.activePaneId,
+        focusTileInstanceId: "legacy-terminal-instance",
+      },
     });
   });
 });

--- a/clients/gui-app/src/hooks/notifications/use-notification-activation.ts
+++ b/clients/gui-app/src/hooks/notifications/use-notification-activation.ts
@@ -89,6 +89,8 @@ function getNotificationPreflightEpicId(
       return payload.epicId;
     case "chat":
       return payload.epicId;
+    case "terminal":
+      return payload.epicId;
     case "session":
       return null;
   }

--- a/clients/gui-app/src/lib/notifications/__tests__/notification-display.test.ts
+++ b/clients/gui-app/src/lib/notifications/__tests__/notification-display.test.ts
@@ -166,7 +166,7 @@ describe("notification display", () => {
       screen.getByRole("button", { name: "Traycer 2 new notifications" }),
     );
 
-    expect(onToastClick).toHaveBeenCalledWith(first);
+    expect(onToastClick).toHaveBeenCalledWith(first, expect.any(Number));
   });
 
   it("still plays the chime when native notification setup throws", () => {
@@ -203,7 +203,7 @@ describe("notification display", () => {
       }),
     );
 
-    expect(onToastClick).toHaveBeenCalledWith(notification);
+    expect(onToastClick).toHaveBeenCalledWith(notification, expect.any(Number));
   });
 
   it("does not make notifications without a destination clickable", () => {

--- a/clients/gui-app/src/lib/notifications/__tests__/notification-toast-interactions.test.tsx
+++ b/clients/gui-app/src/lib/notifications/__tests__/notification-toast-interactions.test.tsx
@@ -18,7 +18,7 @@ vi.mock("next-themes", () => ({
   useTheme: () => ({ theme: "dark" }),
 }));
 
-const notification: MergedNotificationRow = {
+const NOTIFICATION: MergedNotificationRow = {
   feedId: "host:n-1",
   source: "host",
   sourceId: "n-1",
@@ -51,7 +51,7 @@ describe("notification toast interactions", () => {
     render(<Toaster />);
 
     act(() => {
-      displayNotificationRows([notification], {
+      displayNotificationRows([NOTIFICATION], {
         showNotification: vi.fn(() => Promise.resolve()),
         playChime: vi.fn(),
         onToastClick,
@@ -68,10 +68,10 @@ describe("notification toast interactions", () => {
     fireEvent.click(toastSurface);
 
     expect(onToastClick).toHaveBeenCalledOnce();
-    expect(onToastClick).toHaveBeenCalledWith(notification, expect.any(Number));
+    expect(onToastClick).toHaveBeenCalledWith(NOTIFICATION, expect.any(Number));
     const activatedAt = onToastClick.mock.calls[0]?.[1];
     expect(activatedAt).toBeGreaterThanOrEqual(beforeClick);
-    expect(activatedAt).not.toBe(notification.createdAt);
+    expect(activatedAt).not.toBe(NOTIFICATION.createdAt);
   });
 
   it("does not activate when the close control is clicked", async () => {
@@ -79,7 +79,7 @@ describe("notification toast interactions", () => {
     render(<Toaster />);
 
     act(() => {
-      displayNotificationRows([notification], {
+      displayNotificationRows([NOTIFICATION], {
         showNotification: vi.fn(() => Promise.resolve()),
         playChime: vi.fn(),
         onToastClick,

--- a/clients/gui-app/src/lib/notifications/__tests__/notification-toast-interactions.test.tsx
+++ b/clients/gui-app/src/lib/notifications/__tests__/notification-toast-interactions.test.tsx
@@ -1,0 +1,96 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
+import {
+  displayNotificationRows,
+  type NotificationDisplayTarget,
+} from "@/lib/notifications/notification-display";
+import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "dark" }),
+}));
+
+const notification: MergedNotificationRow = {
+  feedId: "host:n-1",
+  source: "host",
+  sourceId: "n-1",
+  createdAt: 10,
+  readAt: null,
+  title: "Checkout notifications",
+  body: "New chat • Done",
+  payload: { kind: "chat", epicId: "epic-1", chatId: "chat-1" },
+  hostKind: "agent.stopped",
+  appLocalKind: null,
+  globalEntry: null,
+  severity: "done",
+  outcome: "completed",
+};
+
+describe("notification toast interactions", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(1_000);
+  });
+
+  afterEach(() => {
+    toast.dismiss();
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("activates when the rendered toast surface is clicked", async () => {
+    const onToastClick = vi.fn<NotificationDisplayTarget["onToastClick"]>();
+    render(<Toaster />);
+
+    act(() => {
+      displayNotificationRows([notification], {
+        showNotification: vi.fn(() => Promise.resolve()),
+        playChime: vi.fn(),
+        onToastClick,
+      });
+    });
+
+    const title = await screen.findByText("Checkout notifications");
+    const toastSurface = title.closest("[data-sonner-toast]");
+
+    expect(toastSurface).not.toBeNull();
+    if (toastSurface === null) return;
+
+    const beforeClick = Date.now();
+    fireEvent.click(toastSurface);
+
+    expect(onToastClick).toHaveBeenCalledOnce();
+    expect(onToastClick).toHaveBeenCalledWith(notification, expect.any(Number));
+    const activatedAt = onToastClick.mock.calls[0]?.[1];
+    expect(activatedAt).toBeGreaterThanOrEqual(beforeClick);
+    expect(activatedAt).not.toBe(notification.createdAt);
+  });
+
+  it("does not activate when the close control is clicked", async () => {
+    const onToastClick = vi.fn<NotificationDisplayTarget["onToastClick"]>();
+    render(<Toaster />);
+
+    act(() => {
+      displayNotificationRows([notification], {
+        showNotification: vi.fn(() => Promise.resolve()),
+        playChime: vi.fn(),
+        onToastClick,
+      });
+    });
+
+    const closeToastButton = await screen.findByRole("button", {
+      name: "Close toast",
+    });
+    fireEvent.click(closeToastButton);
+
+    expect(onToastClick).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/lib/notifications/notification-display.ts
+++ b/clients/gui-app/src/lib/notifications/notification-display.ts
@@ -17,7 +17,10 @@ import { readFocusedHostNotificationPresenceEntity } from "@/lib/notifications/n
 export interface NotificationDisplayTarget {
   readonly showNotification: NotificationShow;
   readonly playChime: () => void;
-  readonly onToastClick: (row: MergedNotificationRow) => void;
+  readonly onToastClick: (
+    row: MergedNotificationRow,
+    activatedAt: number,
+  ) => void;
 }
 
 export function displayNotificationRows(
@@ -47,8 +50,11 @@ export function displayNotificationRows(
         {
           type: "button",
           "aria-label": `${content.title} ${content.body}`,
+          "data-notification-toast-action": "",
           className: "min-w-0 text-left",
-          onClick: () => target.onToastClick(content.row),
+          onClick: () => {
+            target.onToastClick(content.row, Date.now());
+          },
         },
         createElement(
           "span",
@@ -175,6 +181,7 @@ function hostEntityReplaceKey(
       return `host:chat:${payload.chatId}`;
     case "artifact":
     case "epic":
+    case "terminal":
       return epicReplaceKey(payload.epicId);
     case "session":
       return null;

--- a/clients/gui-app/src/lib/notifications/notification-entity.ts
+++ b/clients/gui-app/src/lib/notifications/notification-entity.ts
@@ -29,7 +29,10 @@ export function notificationEntityFromPayload(
   const record = payload;
   const epicId = readNonEmptyString(record.epicId);
   if (epicId === null) return null;
-  const chatId = readNonEmptyString(record.chatId);
+  const chatId =
+    record.kind === "terminal"
+      ? readNonEmptyString(record.terminalId)
+      : readNonEmptyString(record.chatId);
   return chatId === null ? { epicId } : { epicId, chatId };
 }
 

--- a/clients/gui-app/src/lib/notifications/payload.ts
+++ b/clients/gui-app/src/lib/notifications/payload.ts
@@ -11,12 +11,23 @@ import {
   type NotificationEvent,
 } from "@traycer/protocol/notifications/notification-entry";
 import {
+  existingEpicTabIntentWithNestedFocus,
   navigateToTabIntent,
   openOrFocusEpicIntent,
 } from "@/lib/tab-navigation";
+import {
+  findOpenArtifactInTab,
+  useEpicCanvasStore,
+} from "@/stores/epics/canvas/store";
 
 export type NotificationPayloadKind =
-  "session" | "artifact" | "epic" | "approval" | "interview" | "chat";
+  | "session"
+  | "artifact"
+  | "epic"
+  | "approval"
+  | "interview"
+  | "chat"
+  | "terminal";
 
 export interface SessionNotificationPayload {
   readonly kind: "session";
@@ -57,13 +68,23 @@ export interface ChatNotificationPayload {
   readonly chatId: string | undefined;
 }
 
+export interface TerminalNotificationPayload {
+  readonly kind: "terminal";
+  readonly epicId: string;
+  readonly terminalId: string;
+  readonly tabId: string;
+  readonly paneId: string;
+  readonly tileInstanceId: string;
+}
+
 export type NotificationPayload =
   | SessionNotificationPayload
   | ArtifactNotificationPayload
   | EpicNotificationPayload
   | ApprovalNotificationPayload
   | InterviewNotificationPayload
-  | ChatNotificationPayload;
+  | ChatNotificationPayload
+  | TerminalNotificationPayload;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
@@ -125,6 +146,33 @@ function parseChatPayload(
   };
 }
 
+function parseTerminalPayload(
+  value: Record<string, unknown>,
+): TerminalNotificationPayload | null {
+  const epicId = readString(value.epicId);
+  const terminalId = readString(value.terminalId);
+  const tabId = readString(value.tabId);
+  const paneId = readString(value.paneId);
+  const tileInstanceId = readString(value.tileInstanceId);
+  if (
+    epicId === null ||
+    terminalId === null ||
+    tabId === null ||
+    paneId === null ||
+    tileInstanceId === null
+  ) {
+    return null;
+  }
+  return {
+    kind: "terminal",
+    epicId,
+    terminalId,
+    tabId,
+    paneId,
+    tileInstanceId,
+  };
+}
+
 function parseApprovalPayload(
   value: Record<string, unknown>,
 ): ApprovalNotificationPayload | null {
@@ -179,6 +227,8 @@ export function parseNotificationPayload(
       return parseEpicPayload(value);
     case "chat":
       return parseChatPayload(value);
+    case "terminal":
+      return parseTerminalPayload(value);
     case "approval":
       return parseApprovalPayload(value);
     case "interview":
@@ -244,6 +294,9 @@ export function routeNotification(
     case "chat":
       routeEpicChatNotification(navigate, payload, receivedAt);
       return;
+    case "terminal":
+      routeTerminalNotification(navigate, payload, receivedAt);
+      return;
     case "approval":
       if (payload.epicId === undefined || payload.chatId === undefined) {
         return;
@@ -292,11 +345,56 @@ export function routeNotification(
   }
 }
 
+function routeTerminalNotification(
+  navigate: NavigateFn,
+  payload: TerminalNotificationPayload,
+  receivedAt: number,
+): void {
+  const store = useEpicCanvasStore.getState();
+  const tab = store.tabsById[payload.tabId];
+  if (tab?.epicId !== payload.epicId) {
+    navigateToTabIntent(
+      navigate,
+      openOrFocusEpicIntent({
+        epicId: payload.epicId,
+        focus: {
+          focusedAt: receivedAt,
+          focusArtifactId: undefined,
+          focusThreadId: undefined,
+          migrationSource: undefined,
+        },
+      }),
+    );
+    return;
+  }
+
+  const nestedFocus = store.prepareSetActiveTileTabFocusTarget(
+    payload.tabId,
+    payload.paneId,
+    payload.tileInstanceId,
+  );
+  navigateToTabIntent(
+    navigate,
+    existingEpicTabIntentWithNestedFocus({
+      epicId: payload.epicId,
+      tabId: payload.tabId,
+      focus: {
+        focusedAt: receivedAt,
+        focusArtifactId: undefined,
+        focusThreadId: undefined,
+        migrationSource: undefined,
+      },
+      nestedFocus,
+    }),
+  );
+}
+
 function routeEpicChatNotification(
   navigate: NavigateFn,
   payload: ChatNotificationPayload,
   receivedAt: number,
 ): void {
+  if (routeLegacyTerminalNotification(navigate, payload, receivedAt)) return;
   navigateToTabIntent(
     navigate,
     openOrFocusEpicIntent({
@@ -309,4 +407,39 @@ function routeEpicChatNotification(
       },
     }),
   );
+}
+
+function routeLegacyTerminalNotification(
+  navigate: NavigateFn,
+  payload: ChatNotificationPayload,
+  receivedAt: number,
+): boolean {
+  if (payload.chatId === undefined) return false;
+  const terminalId = payload.chatId;
+  const state = useEpicCanvasStore.getState();
+  const match = Object.values(state.tabsById)
+    .flatMap((tab) => {
+      if (tab === undefined || tab.epicId !== payload.epicId) return [];
+      const found = findOpenArtifactInTab(tab.tabId, terminalId);
+      if (found === null) return [];
+      const tile =
+        state.canvasByTabId[tab.tabId]?.tilesByInstanceId[found.instanceId];
+      return tile?.type === "terminal" ? [{ tab, found }] : [];
+    })
+    .at(0);
+  if (match === undefined) return false;
+
+  routeTerminalNotification(
+    navigate,
+    {
+      kind: "terminal",
+      epicId: payload.epicId,
+      terminalId,
+      tabId: match.tab.tabId,
+      paneId: match.found.paneId,
+      tileInstanceId: match.found.instanceId,
+    },
+    receivedAt,
+  );
+  return true;
 }

--- a/clients/gui-app/src/providers/__tests__/notifications-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/notifications-session-provider.test.tsx
@@ -1,7 +1,14 @@
 import "../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
 import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
@@ -73,6 +80,7 @@ vi.mock("@/hooks/notifications/use-notifications", () => ({
 }));
 
 import { NotificationsSessionProvider } from "@/providers/notifications-session-provider";
+import { Toaster } from "@/components/ui/sonner";
 import { __setNotificationsStreamFactoryForTests } from "@/providers/notifications-stream-factory-override";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import {
@@ -92,6 +100,7 @@ import { makeOpenableNodeRef } from "@/stores/epics/canvas/types";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
 import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
 import { selectNotificationIndicatorState } from "@/stores/notifications/notification-indicator-state";
+import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
 
 interface ControlledStream {
   closeCount: number;
@@ -237,8 +246,11 @@ function hostEntry(input: {
     epicId: input.epicId,
     chatId: input.chatId,
     payload: {
+      kind: "chat",
       epicId: input.epicId,
       chatId: input.chatId,
+      agentName: "Chat",
+      taskTitle: "Task",
       outcome: "completed",
     },
   };
@@ -371,6 +383,7 @@ describe("<NotificationsSessionProvider />", () => {
     __resetNotificationsStoreForTests();
     __resetHostNotificationsStoreForTests();
     useAppLocalNotificationsStore.getState().resetForTests();
+    useNotificationEventsStore.getState().clear();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     __setNotificationsStreamFactoryForTests(null);
     resetAuth("signed-out", null);
@@ -381,10 +394,59 @@ describe("<NotificationsSessionProvider />", () => {
     __resetNotificationsStoreForTests();
     __resetHostNotificationsStoreForTests();
     useAppLocalNotificationsStore.getState().resetForTests();
+    useNotificationEventsStore.getState().clear();
+    toast.dismiss();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     __setNotificationsStreamFactoryForTests(null);
     resetAuth("signed-out", null);
     vi.restoreAllMocks();
+  });
+
+  it("hands host toast clicks to the router-bound notification bridge", async () => {
+    const { streamClient } = await renderHostNotificationsProvider();
+    render(<Toaster />);
+
+    act(() => {
+      streamClient.session.emitServerFrame({
+        kind: "channelEmission",
+        hasBinaryPayload: false,
+        emissionId: "emission-chat-click",
+        channelId: "renderer",
+        severity: "done",
+        rows: [
+          hostEntry({
+            id: "done-chat-click",
+            epicId: "epic-chat-click",
+            chatId: "chat-click",
+            severity: "done",
+          }),
+        ],
+        reason: "new",
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector("[data-notification-toast-action]"),
+      ).not.toBeNull();
+    });
+    const action = document.querySelector<HTMLElement>(
+      "[data-notification-toast-action]",
+    );
+    if (action === null) throw new Error("expected actionable host toast");
+
+    const beforeClick = Date.now();
+    fireEvent.click(action);
+
+    const notificationEvent =
+      useNotificationEventsStore.getState().notificationEvent;
+    expect(notificationEvent?.payload).toEqual({
+      kind: "chat",
+      epicId: "epic-chat-click",
+      chatId: "chat-click",
+    });
+    expect(notificationEvent?.openPopover).toBe(false);
+    expect(notificationEvent?.receivedAt).toBeGreaterThanOrEqual(beforeClick);
   });
 
   it("reopens the stream and resets the local replica on signed-in user switches", async () => {
@@ -803,8 +865,14 @@ describe("<NotificationsSessionProvider />", () => {
     act(() => {
       emitTerminalCrashedNotification({
         instanceId: "terminal-a-instance",
-        epicId: "epic-a",
-        chatId: "terminal-a",
+        target: {
+          kind: "terminal",
+          epicId: "epic-a",
+          terminalId: "terminal-a",
+          tabId: "view-tab-a",
+          paneId: "pane-a",
+          tileInstanceId: "terminal-a-instance",
+        },
         cause: "exit",
       });
     });
@@ -835,8 +903,14 @@ describe("<NotificationsSessionProvider />", () => {
     act(() => {
       emitTerminalCrashedNotification({
         instanceId: "terminal-b-instance",
-        epicId: "epic-a",
-        chatId: "terminal-b",
+        target: {
+          kind: "terminal",
+          epicId: "epic-a",
+          terminalId: "terminal-b",
+          tabId: "view-tab-a",
+          paneId: "pane-a",
+          tileInstanceId: "terminal-b-instance",
+        },
         cause: "exit",
       });
     });

--- a/clients/gui-app/src/providers/notifications-session-provider.tsx
+++ b/clients/gui-app/src/providers/notifications-session-provider.tsx
@@ -25,7 +25,6 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useAuthService } from "@/lib/host";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { useNotificationShow } from "@/hooks/notifications/use-notifications";
-import { useNotificationActivation } from "@/hooks/notifications/use-notification-activation";
 import { useNotificationMarkEntityRead } from "@/hooks/notifications/use-notification-mark-entity-read-mutation";
 import { useWindowsBridge } from "@/providers/windows-bridge-context";
 import {
@@ -49,6 +48,7 @@ import {
 import { useAppLocalNotificationsStore } from "@/stores/notifications/app-local-notifications-store";
 import type { HostNotificationsEntityRef } from "@traycer/protocol/host/notifications/contracts";
 import type { MergedNotificationRow } from "@/stores/notifications/merged-notifications";
+import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
 
 export interface NotificationsSessionProviderProps {
   readonly children: ReactNode;
@@ -69,7 +69,9 @@ export function NotificationsSessionProvider(
   const activeHostId = useReactiveActiveHostId();
   const authService = useAuthService();
   const showNotification = useNotificationShow();
-  const { activate } = useNotificationActivation();
+  const recordInAppClick = useNotificationEventsStore(
+    (state) => state.recordInAppClick,
+  );
   const windowsBridge = useWindowsBridge();
   const status = useAuthStore((state) => state.status);
   const email = useAuthStore((state) => state.profile?.email ?? null);
@@ -89,15 +91,11 @@ export function NotificationsSessionProvider(
   const markEntityRead = markEntityReadMutation.mutate;
   const activeEntityRef = useRef<HostNotificationsEntityRef | null>(null);
   const onToastClick = useCallback(
-    (row: MergedNotificationRow): void => {
+    (row: MergedNotificationRow, activatedAt: number): void => {
       if (row.payload === null) return;
-      activate({
-        payload: row.payload,
-        receivedAt: row.createdAt,
-        onActivated: null,
-      });
+      recordInAppClick(row.payload, activatedAt);
     },
-    [activate],
+    [recordInAppClick],
   );
   const onToastClickRef = useRef(onToastClick);
   useEffect(() => {
@@ -253,7 +251,8 @@ export function NotificationsSessionProvider(
             displayHostChannelEmission(entries, {
               showNotification,
               playChime: playNotificationChime,
-              onToastClick: (row) => onToastClickRef.current(row),
+              onToastClick: (row, activatedAt) =>
+                onToastClickRef.current(row, activatedAt),
             });
           },
           onFeedFrame: (frame) => onFeedFrame(frame, streamHostId),

--- a/clients/gui-app/src/stores/notifications/__tests__/app-local-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/app-local-notifications-store.test.ts
@@ -178,6 +178,52 @@ describe("app-local notifications store", () => {
     });
   });
 
+  it("refreshes a terminal-closed entry's target after the terminal moves", () => {
+    useAppLocalNotificationsStore.getState().activateIdentity("user-a");
+
+    emitTerminalClosedNotification({
+      instanceId: "terminal-instance",
+      hostLabel: "MacBook",
+      target: {
+        kind: "terminal",
+        epicId: "epic-1",
+        terminalId: "terminal-tile-1",
+        tabId: "view-tab-1",
+        paneId: "pane-1",
+        tileInstanceId: "terminal-instance",
+      },
+    });
+    useAppLocalNotificationsStore
+      .getState()
+      .markAsRead("terminal.closed:terminal-instance", 123);
+
+    emitTerminalClosedNotification({
+      instanceId: "terminal-instance",
+      hostLabel: "MacBook",
+      target: {
+        kind: "terminal",
+        epicId: "epic-1",
+        terminalId: "terminal-tile-1",
+        tabId: "view-tab-2",
+        paneId: "pane-2",
+        tileInstanceId: "terminal-instance",
+      },
+    });
+
+    expect(
+      useAppLocalNotificationsStore.getState().byId[
+        "terminal.closed:terminal-instance"
+      ],
+    ).toMatchObject({
+      readAt: 123,
+      payload: {
+        kind: "terminal",
+        tabId: "view-tab-2",
+        paneId: "pane-2",
+      },
+    });
+  });
+
   it("keeps successive terminal deaths as distinct entity-addressable rows", () => {
     useAppLocalNotificationsStore.getState().activateIdentity("user-a");
 

--- a/clients/gui-app/src/stores/notifications/__tests__/app-local-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/app-local-notifications-store.test.ts
@@ -148,21 +148,34 @@ describe("app-local notifications store", () => {
     expect(store.getState().unreadCount).toBe(1);
   });
 
-  it("enriches terminal closed entries with their epic and tile entity", () => {
+  it("addresses terminal closed entries to their exact canvas tile", () => {
     useAppLocalNotificationsStore.getState().activateIdentity("user-a");
 
     emitTerminalClosedNotification({
       instanceId: "terminal-instance",
       hostLabel: "MacBook",
-      epicId: "epic-1",
-      chatId: "terminal-tile-1",
+      target: {
+        kind: "terminal",
+        epicId: "epic-1",
+        terminalId: "terminal-tile-1",
+        tabId: "view-tab-1",
+        paneId: "pane-1",
+        tileInstanceId: "terminal-instance",
+      },
     });
 
     expect(
       useAppLocalNotificationsStore.getState().byId[
         "terminal.closed:terminal-instance"
       ].payload,
-    ).toEqual({ kind: "chat", epicId: "epic-1", chatId: "terminal-tile-1" });
+    ).toEqual({
+      kind: "terminal",
+      epicId: "epic-1",
+      terminalId: "terminal-tile-1",
+      tabId: "view-tab-1",
+      paneId: "pane-1",
+      tileInstanceId: "terminal-instance",
+    });
   });
 
   it("keeps successive terminal deaths as distinct entity-addressable rows", () => {
@@ -170,14 +183,26 @@ describe("app-local notifications store", () => {
 
     emitTerminalCrashedNotification({
       instanceId: "terminal-instance",
-      epicId: "epic-1",
-      chatId: "terminal-tile-1",
+      target: {
+        kind: "terminal",
+        epicId: "epic-1",
+        terminalId: "terminal-tile-1",
+        tabId: "view-tab-1",
+        paneId: "pane-1",
+        tileInstanceId: "terminal-instance",
+      },
       cause: "exit",
     });
     emitTerminalCrashedNotification({
       instanceId: "terminal-instance",
-      epicId: "epic-1",
-      chatId: "terminal-tile-1",
+      target: {
+        kind: "terminal",
+        epicId: "epic-1",
+        terminalId: "terminal-tile-1",
+        tabId: "view-tab-1",
+        paneId: "pane-1",
+        tileInstanceId: "terminal-instance",
+      },
       cause: "recovery-exhausted",
     });
 
@@ -190,8 +215,22 @@ describe("app-local notifications store", () => {
       "terminal.crashed",
     ]);
     expect(entries.map((entry) => entry.payload)).toEqual([
-      { kind: "chat", epicId: "epic-1", chatId: "terminal-tile-1" },
-      { kind: "chat", epicId: "epic-1", chatId: "terminal-tile-1" },
+      {
+        kind: "terminal",
+        epicId: "epic-1",
+        terminalId: "terminal-tile-1",
+        tabId: "view-tab-1",
+        paneId: "pane-1",
+        tileInstanceId: "terminal-instance",
+      },
+      {
+        kind: "terminal",
+        epicId: "epic-1",
+        terminalId: "terminal-tile-1",
+        tabId: "view-tab-1",
+        paneId: "pane-1",
+        tileInstanceId: "terminal-instance",
+      },
     ]);
   });
 });

--- a/clients/gui-app/src/stores/notifications/app-local-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/app-local-notifications-store.ts
@@ -8,6 +8,11 @@ import { notificationPayloadBelongsToEntity } from "@/lib/notifications";
 import { appLocalNotificationsKey, basePersistOptions } from "@/lib/persist";
 import type { HostNotificationsEntityRef } from "@traycer/protocol/host/notifications/contracts";
 
+type TerminalNotificationTarget = Extract<
+  NotificationPayload,
+  { readonly kind: "terminal" }
+>;
+
 export const APP_LOCAL_NOTIFICATIONS_ROW_CAP = 200;
 
 /**
@@ -262,8 +267,7 @@ export const useAppLocalNotificationsStore = createAppLocalNotificationsStore(
 export function emitTerminalClosedNotification(input: {
   readonly instanceId: string;
   readonly hostLabel: string;
-  readonly epicId: string;
-  readonly chatId: string;
+  readonly target: TerminalNotificationTarget;
 }): void {
   const message = `Terminal closed: host "${input.hostLabel}" is unreachable.`;
   useAppLocalNotificationsStore.getState().upsert({
@@ -272,11 +276,7 @@ export function emitTerminalClosedNotification(input: {
     readAt: null,
     kind: "terminal.closed",
     sourceRef: input.instanceId,
-    payload: {
-      kind: "chat",
-      epicId: input.epicId,
-      chatId: input.chatId,
-    },
+    payload: input.target,
     message,
     detail: "The terminal is bound to that host and cannot migrate.",
   });
@@ -284,8 +284,7 @@ export function emitTerminalClosedNotification(input: {
 
 export function emitTerminalCrashedNotification(input: {
   readonly instanceId: string;
-  readonly epicId: string;
-  readonly chatId: string;
+  readonly target: TerminalNotificationTarget;
   readonly cause: "exit" | "recovery-exhausted";
 }): void {
   const isRecoveryExhausted = input.cause === "recovery-exhausted";
@@ -299,11 +298,7 @@ export function emitTerminalCrashedNotification(input: {
     readAt: null,
     kind: "terminal.crashed",
     sourceRef: input.instanceId,
-    payload: {
-      kind: "chat",
-      epicId: input.epicId,
-      chatId: input.chatId,
-    },
+    payload: input.target,
     message: isRecoveryExhausted
       ? "Terminal connection could not be recovered."
       : "Terminal exited unexpectedly.",

--- a/clients/gui-app/src/stores/notifications/app-local-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/app-local-notifications-store.ts
@@ -56,6 +56,9 @@ export interface AppLocalNotificationsState {
   deactivateIdentity: () => void;
   upsert: (entry: AppLocalNotificationEntry) => void;
   upsertReplacing: (entry: AppLocalNotificationEntry) => void;
+  upsertReplacingPreservingReadState: (
+    entry: AppLocalNotificationEntry,
+  ) => void;
   markAsRead: (id: string, readAt: number) => void;
   markEntityAsRead: (
     entity: HostNotificationsEntityRef,
@@ -176,6 +179,28 @@ export function createAppLocalNotificationsStore(initialName: string) {
           });
         },
 
+        upsertReplacingPreservingReadState: (entry) => {
+          if (get().activeUserId === null) return;
+          set((state) => {
+            const existing = Object.hasOwn(state.byId, entry.id)
+              ? state.byId[entry.id]
+              : null;
+            const byId = cappedAppLocalEntries({
+              ...state.byId,
+              [entry.id]:
+                existing === null
+                  ? entry
+                  : { ...entry, readAt: existing.readAt },
+            });
+            const projection = projectAppLocalNotifications(byId);
+            return {
+              byId,
+              orderedIds: projection.orderedIds,
+              unreadCount: projection.unreadCount,
+            };
+          });
+        },
+
         markAsRead: (id, readAt) => {
           if (get().activeUserId === null) return;
           set((state) => {
@@ -270,7 +295,7 @@ export function emitTerminalClosedNotification(input: {
   readonly target: TerminalNotificationTarget;
 }): void {
   const message = `Terminal closed: host "${input.hostLabel}" is unreachable.`;
-  useAppLocalNotificationsStore.getState().upsert({
+  useAppLocalNotificationsStore.getState().upsertReplacingPreservingReadState({
     id: `terminal.closed:${input.instanceId}`,
     updatedAt: Date.now(),
     readAt: null,

--- a/clients/gui-app/src/stores/notifications/notification-events-store.ts
+++ b/clients/gui-app/src/stores/notifications/notification-events-store.ts
@@ -3,11 +3,13 @@ import { create } from "zustand";
 export interface NotificationClickEvent {
   readonly payload: unknown;
   readonly receivedAt: number;
+  readonly openPopover: boolean;
 }
 
 interface NotificationEventsState {
   readonly notificationEvent: NotificationClickEvent | null;
   readonly recordClick: (payload: unknown) => void;
+  readonly recordInAppClick: (payload: unknown, receivedAt: number) => void;
   readonly clear: () => void;
 }
 
@@ -25,7 +27,18 @@ export const useNotificationEventsStore = create<NotificationEventsState>(
   (set) => ({
     notificationEvent: null,
     recordClick: (payload) => {
-      set({ notificationEvent: { payload, receivedAt: Date.now() } });
+      set({
+        notificationEvent: {
+          payload,
+          receivedAt: Date.now(),
+          openPopover: true,
+        },
+      });
+    },
+    recordInAppClick: (payload, receivedAt) => {
+      set({
+        notificationEvent: { payload, receivedAt, openPopover: false },
+      });
     },
     clear: () => {
       set({ notificationEvent: null });


### PR DESCRIPTION
## Summary
- make the full actionable in-app notification toast surface activate while preserving control isolation
- route host-originated toast clicks through the RouterProvider-bound focus bridge
- target terminal crash notifications at their exact terminal tile, including a narrow compatibility path for legacy persisted payloads

## Verification
- focused notification test suite: 51 tests passed
- GUI TypeScript compilation passed
- changed-file ESLint passed
- affected lint, format, compile, and build passed via the repository pre-commit workspace gate