### PR TITLE
feat(protocol,gui): add the mcp background-item kind on chat.subscribe@1.4

### DIFF
--- a/clients/gui-app/src/components/chat/chat-background-items-panel.tsx
+++ b/clients/gui-app/src/components/chat/chat-background-items-panel.tsx
@@ -4,6 +4,7 @@ import {
   Bot,
   ChevronDown,
   Monitor,
+  Plug,
   Square,
   TerminalSquare,
   Workflow,
@@ -60,6 +61,8 @@ function backgroundKindLabel(kind: BackgroundItem["kind"]): string {
       return "Wake";
     case "workflow":
       return "Workflow";
+    case "mcp":
+      return "MCP tool";
   }
   const unreachableKind: never = kind;
   return unreachableKind;
@@ -93,6 +96,8 @@ function BackgroundKindIcon(props: { readonly kind: BackgroundItem["kind"] }) {
       return (
         <Workflow aria-hidden className="size-3.5 shrink-0 text-primary/80" />
       );
+    case "mcp":
+      return <Plug aria-hidden className="size-3.5 shrink-0 text-primary/80" />;
   }
   const unreachableKind: never = props.kind;
   return unreachableKind;
@@ -158,6 +163,11 @@ function backgroundItemDisplayTitle(item: BackgroundItem): string {
   if (item.kind === "workflow") {
     const summary = workflowRowSummary(item);
     return summary === null ? item.title : `${item.title} — ${summary}`;
+  }
+  if (item.kind === "mcp") {
+    // The structured MCP identity beats the freeform title (which mirrors the
+    // CLI's "server/tool" description and degrades with old hosts).
+    return `${item.serverName} · ${item.toolName}`;
   }
   return item.title;
 }

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -232,15 +232,44 @@ const workflowBackgroundItemSchema = z.object({
   agentsFinished: z.number().nullable().default(null),
 });
 
-export const backgroundItemKindSchema = z.enum([
+// ─── Frozen `chat.subscribe@1.3` background-item shapes (pre-`mcp`) ────────
+//
+// `1.4` adds the `mcp` kind below. A released ≤1.3 peer must never observe
+// it - the host degrades `mcp` items to `command` for those lines - and these
+// frozen schemas keep the `1.3` frames parsing only shapes a real 1.3 peer
+// could produce. Do not add `1.4`-only kinds here.
+export const backgroundItemKindSchemaV13 = z.enum([
   ...backgroundItemKindSchemaV12.options,
   "workflow",
+]);
+export const backgroundItemSchemaV13 = z.discriminatedUnion("kind", [
+  ...backgroundItemSchemaV12.def.options,
+  workflowBackgroundItemSchema,
+]);
+
+// One currently-running MCP background item (`chat.subscribe@1.4`) - an MCP
+// tool call the CLI moved to the background after it outlived the
+// auto-background threshold (CLI 2.1.212+, `task_started` with task_type
+// "mcp_task"). Unlike a `command` row there is no shell command line to echo:
+// `serverName`/`toolName` carry the MCP identity (split from
+// `mcp__<server>__<tool>`) so the renderer can title the row and give MCP
+// work its own presentation instead of a pseudo-command one.
+const mcpBackgroundItemSchema = z.object({
+  ...backgroundItemBaseFields,
+  kind: z.literal("mcp"),
+  serverName: z.string(),
+  toolName: z.string(),
+});
+
+export const backgroundItemKindSchema = z.enum([
+  ...backgroundItemKindSchemaV13.options,
+  "mcp",
 ]);
 export type BackgroundItemKind = z.infer<typeof backgroundItemKindSchema>;
 
 export const backgroundItemSchema = z.discriminatedUnion("kind", [
-  ...backgroundItemSchemaV12.def.options,
-  workflowBackgroundItemSchema,
+  ...backgroundItemSchemaV13.def.options,
+  mcpBackgroundItemSchema,
 ]);
 export type BackgroundItem = z.infer<typeof backgroundItemSchema>;
 
@@ -1378,7 +1407,7 @@ const chatSnapshotSchemaV13 = z.object({
   missingWorktreePaths: z.array(z.string()),
   pendingFileEditApprovals: z.array(chatFileEditApprovalStateSchema),
   accumulatedFileChanges: z.array(chatAccumulatedFileChangeSchema),
-  backgroundItems: z.array(backgroundItemSchema).optional(),
+  backgroundItems: z.array(backgroundItemSchemaV13).optional(),
   turnInProgress: z.boolean().optional(),
 });
 
@@ -1389,9 +1418,23 @@ const chatSubscribeSnapshotServerFrameSchemaV13 = z.object({
   snapshot: chatSnapshotSchemaV13,
 });
 
+// `turnStateChanged` carries no sender, so `1.3` originally reused the live
+// frame - until `1.4` added the `mcp` background-item kind, which rides this
+// broadcast too. Pinned with the pre-`mcp` item union so the released `1.3`
+// line cannot observe the new kind.
+const chatSubscribeTurnStateChangedServerFrameSchemaV13 = z.object({
+  kind: z.literal("turnStateChanged"),
+  ...textFrameFields,
+  ...chatReferenceFields,
+  runStatus: chatRunStatusSchema,
+  activeTurn: chatActiveTurnSchema.nullable(),
+  backgroundItems: z.array(backgroundItemSchemaV13).optional(),
+  turnInProgress: z.boolean().optional(),
+});
+
 const chatSubscribeServerFrameSchemaV13 = z.discriminatedUnion("kind", [
   chatSubscribeSnapshotServerFrameSchemaV13,
-  chatSubscribeTurnStateChangedServerFrameSchema,
+  chatSubscribeTurnStateChangedServerFrameSchemaV13,
   ...chatSubscribeSharedServerFrameSchemasPreInReplyTo,
 ]);
 
@@ -1403,12 +1446,14 @@ export const chatSubscribeV13 = defineStreamRpcContract({
   clientFrameSchema: chatSubscribeClientFrameSchema,
 });
 
-// ─── Live `chat.subscribe@1.4` contract (adds `inReplyTo` to senders) ───────
+// ─── Live `chat.subscribe@1.4` contract (`inReplyTo` + `mcp` items) ─────────
 //
 // The live serverFrame carries `inReplyTo` on every agent sender (user-message,
-// assistant, queue item, event `actor`, steer). Older peers negotiate ≤1.3 and
-// receive the frozen frames above, which strip the key. The client frame is
-// identical to `1.3` (`inReplyTo` is host→client only).
+// assistant, queue item, event `actor`, steer) and the `mcp` background-item
+// kind (CLI auto-backgrounded MCP tool calls). Older peers negotiate ≤1.3 and
+// receive the frozen frames above, which strip the key and never carry `mcp`
+// items (the host degrades them to `command`). The client frame is identical
+// to `1.3` (`inReplyTo` is host→client only).
 
 export const chatSubscribeV14 = defineStreamRpcContract({
   method: "chat.subscribe",


### PR DESCRIPTION
## Summary

Claude CLI 2.1.212 auto-backgrounds MCP tool calls that outlive a threshold (`CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS`, default 120s). The promoted task is a different animal from a shell-command row — it carries an MCP server/tool identity and no command line — so it gets its **own background-item kind** instead of masquerading as `command`.

### Protocol
- Freezes the pre-`mcp` background-item shapes as `backgroundItemKindSchemaV13`/`backgroundItemSchemaV13` and rebinds the **released** `chat.subscribe@1.3` line's snapshot **and** `turnStateChanged` frames to them. `turnStateChanged` previously reused the live frame — exactly where the new kind would have leaked to released peers.
- The live `1.4` union gains `mcpBackgroundItemSchema` (`kind: "mcp"`, `serverName`, `toolName`). `chat.subscribe@1.4` is unreleased (verified: no release tag contains the 1.4 registration), so the kind rides additively on it — no new minor.
- Hosts degrade `mcp` items to `command` for ≤1.3 subscribers (host-side projection, landing in traycer-internal alongside the adapter work that produces these items).

### GUI
- The background-items panel renders `mcp` rows with a plug icon, an "MCP tool" label, and the structured `serverName · toolName` identity instead of the freeform title.

Wire truth behind the design: probed against the vendored 2.1.212 binary (2 enabled trials + control) — promotion emits `task_started` with `task_type: "mcp_task"` and the call's real `tool_use_id`; the settle grammar is identical to Bash background tasks.

## Verification
- `bun run compile` — all workspaces pass
- `bun run test` — all 5 projects pass (a @traycer-clients/desktop parallel-run flake passed standalone and on rerun)
- Host-side degrade + adapter tests live in the companion traycer-internal PR (frozen-1.3-rejects-mcp pin, degrade-to-command pins, MCP promotion visibility pin)