### PR TITLE
fix(gui-app): prevent landing terminal loading text overlap

### DIFF
--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -276,9 +276,9 @@ describe("<LandingTerminalPanel />", () => {
 
     render(panelUi());
 
-    expect(
-      screen.getAllByText("Connecting to the selected host…"),
-    ).toHaveLength(1);
+    expect(screen.getByRole("status").textContent).toBe(
+      "Connecting to the selected host…",
+    );
     expect(screen.queryByText("Starting terminal…")).toBeNull();
   });
 

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -103,7 +103,9 @@ vi.mock(
   }),
 );
 vi.mock("@/components/home/terminal-panel/landing-terminal-tile", () => ({
-  LandingTerminalTile: () => <div data-testid="landing-terminal-tile" />,
+  LandingTerminalTile: () => (
+    <div data-testid="landing-terminal-tile">Starting terminal…</div>
+  ),
 }));
 
 import { LandingTerminalPanel } from "@/components/home/terminal-panel/landing-terminal-panel";
@@ -257,6 +259,27 @@ describe("<LandingTerminalPanel />", () => {
 
     fireEvent.click(pick);
     expect(mocks.pickAndAddFolders).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows only the host connection state while an existing terminal waits for the probe", () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    useLandingTerminalStore.getState().addTab({
+      instanceId: "tab-1",
+      sessionId: "session-1",
+      hostId: "host-a",
+      cwd: "/workspace/project",
+      name: "project",
+      titleSource: "default",
+    });
+    useLandingTerminalStore.getState().setPanelOpen(true);
+
+    render(panelUi());
+
+    expect(
+      screen.getAllByText("Connecting to the selected host…"),
+    ).toHaveLength(1);
+    expect(screen.queryByText("Starting terminal…")).toBeNull();
   });
 
   it("opens a terminal when the empty tab-strip space is double-clicked", async () => {

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
@@ -605,7 +605,10 @@ function LandingTerminalPanelBody(props: {
 }): ReactNode {
   if (props.availability === "unknown") {
     return (
-      <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-ui-sm text-muted-foreground">
+      <div
+        role="status"
+        className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-ui-sm text-muted-foreground"
+      >
         Connecting to the selected host…
       </div>
     );

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
@@ -603,11 +603,18 @@ function LandingTerminalPanelBody(props: {
   readonly folderPickPending: boolean;
   readonly onPickFolder: () => void;
 }): ReactNode {
+  if (props.availability === "unknown") {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center text-ui-sm text-muted-foreground">
+        Connecting to the selected host…
+      </div>
+    );
+  }
+
   return (
     <div className="relative min-h-0 flex-1">
       {props.tabs.length === 0 ? (
         <LandingTerminalEmptyState
-          availability={props.availability}
           primaryWorkspacePath={props.primaryWorkspacePath}
           folderPickPending={props.folderPickPending}
           onPickFolder={props.onPickFolder}
@@ -634,28 +641,15 @@ function LandingTerminalPanelBody(props: {
           </div>
         ))
       )}
-      {props.availability === "unknown" ? (
-        <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-canvas/85 p-6 text-center text-ui-sm text-muted-foreground">
-          Connecting to the selected host…
-        </div>
-      ) : null}
     </div>
   );
 }
 
 function LandingTerminalEmptyState(props: {
-  readonly availability: LandingTerminalAvailability;
   readonly primaryWorkspacePath: string | null;
   readonly folderPickPending: boolean;
   readonly onPickFolder: () => void;
 }): ReactNode {
-  if (props.availability === "unknown") {
-    return (
-      <div className="flex h-full min-h-0 items-center justify-center p-6 text-center text-ui-sm text-muted-foreground">
-        Connecting to the selected host…
-      </div>
-    );
-  }
   // No folder means no cwd to spawn in. Offer the picker here rather than
   // telling the user to go find it: it writes through the same workspace
   // source as the composer's picker, so the folder they choose becomes the


### PR DESCRIPTION
## Summary

- render the landing terminal host-connection message as an exclusive state
- prevent the terminal startup fallback from showing through behind it
- add regression coverage for an existing terminal tab while the host probe is unresolved

## Related issue

None.

## Test plan

- `bun run test src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx` (18 passed)
- `bun run compile`
- scoped ESLint and Prettier checks
- React Doctor changed-file scan
- commit-hook affected build, compile, lint, and format checks

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass (focused and affected checks passed; full suite delegated to CI)
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO