### PR TITLE
test(protocol): enforce additive-only host-notification payload evolution

### DIFF
--- a/protocol/src/host/notifications/__tests__/payload-additivity-baseline.ts
+++ b/protocol/src/host/notifications/__tests__/payload-additivity-baseline.ts
@@ -1,0 +1,166 @@
+import type { JsonSchemaFingerprint } from "@traycer/protocol/framework/json-schema-fingerprint";
+import type { HostNotificationKnownPayloadKind } from "@traycer/protocol/host/notifications/payloads";
+
+/**
+ * Committed structural baseline for the Lane-B payload evolution rule in
+ * `payloads.ts` ("additive-only: never rename or retype an existing field;
+ * a new shape is a NEW payload kind"). `payload-additivity.test.ts` diffs
+ * the live schemas against this file with the framework's fingerprint
+ * engine, turning the doc-comment convention into a machine-enforced check.
+ *
+ * When the test fails:
+ *  - a `removed` finding means a field/enum-value was dropped or renamed —
+ *    that is forbidden; fix the schema, never this file;
+ *  - a `schema-changed` finding on a field you extended additively (e.g. a
+ *    new optional key inside a nested object) is the one legitimate reason
+ *    to refresh that entry — paste the current fingerprint printed in the
+ *    failure output, and let review see the diff;
+ *  - a new payload kind must add its fingerprint here (the coverage test
+ *    prints it).
+ */
+export const PAYLOAD_FINGERPRINT_BASELINE = {
+  chat: {
+    type: "object",
+    properties: {
+      kind: { type: "string", const: "chat" },
+      epicId: { type: "string", minLength: 1 },
+      chatId: {
+        anyOf: [{ type: "string", minLength: 1 }, { type: "null" }],
+      },
+      agentName: { type: "string" },
+      taskTitle: { type: "string" },
+      outcome: { type: "string", enum: ["completed", "stopped", "errored"] },
+      code: { type: "string" },
+      message: { type: "string" },
+      reason: { type: "string" },
+      providerId: { type: "string" },
+    },
+    required: ["kind", "epicId", "chatId", "agentName", "taskTitle", "outcome"],
+  },
+  epic: {
+    type: "object",
+    properties: {
+      kind: { type: "string", const: "epic" },
+      epicId: { type: "string", minLength: 1 },
+      tuiAgentId: { type: "string", minLength: 1 },
+      agentName: { type: "string" },
+      taskTitle: { type: "string" },
+      outcome: { type: "string", enum: ["completed", "stopped", "errored"] },
+      code: { type: "string" },
+      message: { type: "string" },
+      reason: { type: "string" },
+      providerId: { type: "string" },
+    },
+    required: [
+      "kind",
+      "epicId",
+      "tuiAgentId",
+      "agentName",
+      "taskTitle",
+      "outcome",
+    ],
+  },
+  agent_stalled: {
+    type: "object",
+    properties: {
+      kind: { type: "string", const: "agent_stalled" },
+      epicId: { type: "string", minLength: 1 },
+      chatId: { type: "string", minLength: 1 },
+      agentId: { type: "string", minLength: 1 },
+      agentName: { type: "string" },
+      taskTitle: { type: "string" },
+      reason: { type: "string" },
+      title: { type: "string" },
+      message: { type: "string" },
+      outcome: { type: "string", enum: ["completed", "stopped", "errored"] },
+    },
+    required: [
+      "kind",
+      "epicId",
+      "chatId",
+      "agentId",
+      "agentName",
+      "taskTitle",
+      "reason",
+      "title",
+      "outcome",
+    ],
+  },
+  workspace_operation_failed: {
+    type: "object",
+    properties: {
+      kind: { type: "string", const: "workspace_operation_failed" },
+      epicId: { type: "string", minLength: 1 },
+      chatId: { type: "string", minLength: 1 },
+      chatTitle: { type: "string" },
+      taskTitle: { type: "string" },
+      operation: { type: "string", minLength: 1 },
+      title: { type: "string" },
+      message: { type: "string" },
+      workspacePath: { type: "string" },
+      worktreePath: { type: "string" },
+      branch: { type: "string" },
+      setupExitCode: {
+        anyOf: [
+          {
+            type: "integer",
+            minimum: -9007199254740991,
+            maximum: 9007199254740991,
+          },
+          { type: "null" },
+        ],
+      },
+      terminalSessionId: { type: "string" },
+      outcome: { type: "string", const: "errored" },
+    },
+    required: [
+      "kind",
+      "epicId",
+      "chatId",
+      "chatTitle",
+      "taskTitle",
+      "operation",
+      "title",
+      "message",
+      "outcome",
+    ],
+  },
+  approval: {
+    type: "object",
+    properties: {
+      kind: { type: "string", const: "approval" },
+      epicId: { type: "string", minLength: 1 },
+      chatId: { type: "string", minLength: 1 },
+      chatTitle: { type: "string" },
+      taskTitle: { type: "string" },
+      approvalId: { type: "string", minLength: 1 },
+    },
+    required: [
+      "kind",
+      "epicId",
+      "chatId",
+      "chatTitle",
+      "taskTitle",
+      "approvalId",
+    ],
+  },
+  interview: {
+    type: "object",
+    properties: {
+      kind: { type: "string", const: "interview" },
+      epicId: { type: "string", minLength: 1 },
+      chatId: { type: "string", minLength: 1 },
+      chatTitle: { type: "string" },
+      taskTitle: { type: "string" },
+      interviewBlockId: { type: "string", minLength: 1 },
+    },
+    required: [
+      "kind",
+      "epicId",
+      "chatId",
+      "chatTitle",
+      "taskTitle",
+      "interviewBlockId",
+    ],
+  },
+} satisfies Record<HostNotificationKnownPayloadKind, JsonSchemaFingerprint>;

--- a/protocol/src/host/notifications/__tests__/payload-additivity.test.ts
+++ b/protocol/src/host/notifications/__tests__/payload-additivity.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  findBreakingChange,
+  toJsonSchemaFingerprint,
+} from "@traycer/protocol/framework/json-schema-fingerprint";
+import {
+  hostNotificationAgentStalledPayloadSchema,
+  hostNotificationApprovalPayloadSchema,
+  hostNotificationChatStoppedPayloadSchema,
+  hostNotificationEpicStoppedPayloadSchema,
+  hostNotificationInterviewPayloadSchema,
+  hostNotificationKnownPayloadSchema,
+  hostNotificationWorkspaceOperationFailedPayloadSchema,
+  type HostNotificationKnownPayloadKind,
+} from "@traycer/protocol/host/notifications/payloads";
+import { PAYLOAD_FINGERPRINT_BASELINE } from "./payload-additivity-baseline";
+
+/**
+ * Machine-enforces the payload EVOLUTION RULE documented in `payloads.ts`:
+ * additive-only, never rename or retype an existing field, new shapes are
+ * new kinds. Reuses the versioned-record framework's fingerprint diff
+ * engine against the committed baseline, so the convention fails a build
+ * instead of a downgrade. See the baseline module for the refresh policy.
+ */
+const LIVE_PAYLOAD_SCHEMAS: Record<HostNotificationKnownPayloadKind, z.ZodType> =
+  {
+    chat: hostNotificationChatStoppedPayloadSchema,
+    epic: hostNotificationEpicStoppedPayloadSchema,
+    agent_stalled: hostNotificationAgentStalledPayloadSchema,
+    workspace_operation_failed:
+      hostNotificationWorkspaceOperationFailedPayloadSchema,
+    approval: hostNotificationApprovalPayloadSchema,
+    interview: hostNotificationInterviewPayloadSchema,
+  };
+
+const KINDS = [
+  "chat",
+  "epic",
+  "agent_stalled",
+  "workspace_operation_failed",
+  "approval",
+  "interview",
+] as const satisfies readonly HostNotificationKnownPayloadKind[];
+
+describe("host notification payload additivity", () => {
+  it("baselines every payload kind (a new kind must add its fingerprint to the baseline)", () => {
+    const unionKinds = hostNotificationKnownPayloadSchema.options
+      .map((option) => option.shape.kind.value)
+      .sort();
+    expect([...KINDS].sort()).toEqual(unionKinds);
+    expect(Object.keys(PAYLOAD_FINGERPRINT_BASELINE).sort()).toEqual(
+      unionKinds,
+    );
+  });
+
+  it.each(KINDS)(
+    "payload kind '%s' only evolves additively over the committed baseline",
+    (kind) => {
+      const current = toJsonSchemaFingerprint(
+        LIVE_PAYLOAD_SCHEMAS[kind],
+        `host notification payload kind '${kind}'`,
+      );
+      const breaking = findBreakingChange(
+        PAYLOAD_FINGERPRINT_BASELINE[kind],
+        current,
+      );
+      const failure =
+        breaking === null
+          ? null
+          : [
+              breaking.reason === "removed"
+                ? `FORBIDDEN: ${breaking.kind} '${breaking.detail}' was removed or renamed. ` +
+                  `The payload evolution rule is additive-only — restore the field ` +
+                  `(a new shape must be a NEW payload kind); never refresh the baseline to silence this.`
+                : `${breaking.kind} '${breaking.detail}' changed shape. Renames/retypes are ` +
+                  `forbidden; if this is an additive nested change (new optional key, new enum ` +
+                  `value), refresh this kind's baseline entry with the fingerprint below so ` +
+                  `review sees the diff.`,
+              `Current fingerprint for '${kind}':`,
+              JSON.stringify(current, null, 2),
+            ].join("\n");
+      expect(failure).toBeNull();
+    },
+  );
+});


### PR DESCRIPTION
## What

Adds a build-enforced check that the host-notification **payload** schemas in `protocol/src/host/notifications/payloads.ts` only ever evolve additively.

## Why

`payloads.ts` documents an evolution rule in a comment — *additive-only; never rename or retype an existing field; a new shape is a new payload `kind`.* Nothing enforced it. These payloads are a second-stage parse over rows that **outlive code in both directions** (an upgraded host reads old rows; a downgraded host reads future rows), so a breaking reshape doesn't error — it silently degrades a row to generic rendering. That's the failure mode a test should catch before merge, not a user's downgraded host after.

## How

- `payload-additivity-baseline.ts` — a committed `JsonSchemaFingerprint` per payload kind, typed `satisfies Record<HostNotificationKnownPayloadKind, JsonSchemaFingerprint>` so the compiler also enforces kind coverage.
- `payload-additivity.test.ts` — diffs each live schema against the baseline with the versioned-record framework's `findBreakingChange` (reused, not reinvented):
  - a **removed/renamed** field fails as forbidden (restore it; a new shape must be a new kind);
  - a **retype** fails with guidance to refresh the baseline only if the change is a legitimate additive nested one;
  - a **new kind** must add its baseline entry (coverage test, cross-checked against the discriminated union).

Deliberately reuses the fingerprint engine rather than routing payloads through the versioned-record **registry** — the registry throws on unknown versions, which would invert the kind-discriminated *degrade-on-unknown* posture these payloads require.

## Verification

- `bunx vitest run` on the new test: green (7 cases).
- Proven able to fail: injecting a simulated field removal produced the FORBIDDEN failure, and a simulated retype produced the schema-changed failure; restored to green.
- `bun run compile` (protocol) and pre-commit `nx affected` (compile/lint/format): pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)