### PR TITLE
fix(gui-app): guard undefined userName at the auth store boundary

### DIFF
--- a/clients/gui-app/src/stores/auth/auth-store.ts
+++ b/clients/gui-app/src/stores/auth/auth-store.ts
@@ -89,6 +89,20 @@ export interface AuthState {
   setSignedOut(): void;
 }
 
+/**
+ * Coalesce a profile's display name to a guaranteed string. `userName` and
+ * `email` are typed `string` on `AuthProfile`, but a persisted or
+ * cross-window-projected snapshot can violate that at runtime; declaring the
+ * params nullable makes the fallback a genuine guard (and preserves an
+ * explicitly empty `userName` rather than overwriting it with the email).
+ */
+function coalesceUserName(
+  userName: string | undefined,
+  email: string | undefined,
+): string {
+  return userName ?? email ?? "";
+}
+
 export const useAuthStore = create<AuthState>()((set) => ({
   status: "signed-out",
   profile: null,
@@ -103,11 +117,29 @@ export const useAuthStore = create<AuthState>()((set) => ({
     contextMetadata: AuthContextMetadata,
     shareableTeams: ReadonlyArray<EpicShareableTeam>,
   ) => {
-    set({ status: "signed-in", profile, contextMetadata, shareableTeams });
+    // Store chokepoint: every signed-in profile lands here, including the
+    // projected/persisted-snapshot override paths (AuthService.ingestProjected
+    // SessionSnapshot / applyExternalSession) that bypass `profileFromUser`.
+    // `AuthProfile.userName` is typed `string`, but a stale or partial snapshot
+    // can deliver it absent at runtime - the type is a serialization-boundary
+    // guarantee the wire can violate. Coerce here so it is never absent
+    // downstream; otherwise startup consumers throw on it:
+    // `readFirstName(userName).replace(...)` in HomeHero and
+    // `computeInitials(userName).trim()` in the header avatar.
+    const safeProfile = {
+      ...profile,
+      userName: coalesceUserName(profile.userName, profile.email),
+    };
+    set({
+      status: "signed-in",
+      profile: safeProfile,
+      contextMetadata,
+      shareableTeams,
+    });
     // Email is the one person property sent (deliberate product decision so
     // PostHog dashboards can look users up); the final sanitizer drops
     // everything else the SDK stages on $identify.
-    Analytics.getInstance().identify(contextMetadata.userId, profile.email);
+    Analytics.getInstance().identify(contextMetadata.userId, safeProfile.email);
   },
   setSubscriptionStatus: (status: SubscriptionStatus | null) => {
     set({ subscriptionStatus: status });


### PR DESCRIPTION
## Problem

The desktop app white-screens on startup with the top-level error boundary showing:

> Cannot read properties of undefined (reading 'replace')

A signed-in profile can reach the auth store with `userName === undefined` via the projected/persisted-snapshot override paths — `AuthService.ingestProjectedSessionSnapshot` and `applyExternalSession` — which feed a persisted `AuthProfile` straight into the store and **bypass `profileFromUser`** (whose input is parse-gated, so it can't itself produce the undefined).

Two startup consumers then throw on that undefined during the initial `/` render:

- `readFirstName(profile.userName).replace(/[._-]+/g, " ")` in `HomeHero` → `reading 'replace'`
- `computeInitials(profile.userName).trim()` in the header avatar → would throw `reading 'trim'`

Guarding only `HomeHero` would just move the crash to the avatar, and hardening `profileFromUser` doesn't sit on the failing (override) path.

## Fix

Normalize `userName` at the `setSignedIn` reducer — the single chokepoint every signed-in profile flows through — falling back to `email ?? ""`. This covers **both** entry paths and **all** consumers in one place. `readFirstName` and `computeInitials` already degrade cleanly on an empty string (greeting drops the name; initials fall back to email → `?`).

## Verification

- `react-doctor` (scoped to the changed file): no issues.
- Type-check: clean w.r.t. this change (an unrelated pre-existing codemirror dep-dedup error in a settings test is not touched).
- Runtime: not exercised end-to-end (reproducing requires staging a partial session snapshot with a missing `userName`); the change is a boundary-level string coercion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)