### PR TITLE
fix(gui-app): pin spinner font-weight so braille glyphs don't switch faces

### DIFF
--- a/clients/gui-app/src/components/ui/agent-spinning-dots.tsx
+++ b/clients/gui-app/src/components/ui/agent-spinning-dots.tsx
@@ -641,7 +641,11 @@ export function AgentSpinningDots(props: AgentSpinningDotsProps) {
       data-testid={props.testId}
       aria-hidden="true"
       className={cn(
-        "inline-flex h-3.5 min-w-3.5 shrink-0 items-center justify-center whitespace-pre font-mono text-code leading-none tabular-nums",
+        // `font-normal` is load-bearing on macOS: the mono stack has no braille
+        // coverage, and an inherited 500 (active tab / Button `font-medium`)
+        // makes Chromium's fallback pick the hollow-grid "Apple Braille
+        // Outline" faces instead of the filled-dot regular face.
+        "inline-flex h-3.5 min-w-3.5 shrink-0 items-center justify-center whitespace-pre font-mono text-code font-normal leading-none tabular-nums",
         props.className,
       )}
       style={{ width: `${preset.widthCh}ch` }}


### PR DESCRIPTION
## Summary

The activity/loading spinner (`AgentSpinningDots`) rendered its braille glyphs with a different font face depending on the surrounding font-weight. On a **selected** header tab — and inside any shadcn `Button` (both apply `font-medium`) — the familiar single moving-dot bounce turned into a **three-dot hollow grid with the bottom dot blinking**.

## Root cause

The spinner span sets `font-mono text-code` but pins **no** font-weight, so it inherits the parent's. The mono stack (`SF Mono`, …) has no braille coverage, so the glyphs come from macOS font fallback — and the fallback **face depends on weight**:

- weight **400** → regular **"Apple Braille"** face → draws only the lit dots (the single moving dot).
- weight **500** (inherited from `font-medium`) → **"Apple Braille Outline 6/8 Dot"** faces → draw *every* dot position, unset ones as hollow circles.

All five Apple Braille faces report an identical `0.0` weight trait, so Chromium's fallback has no weight signal to keep it on the regular face for a 500 request and lands on the outline faces instead.

## Fix

Pin `font-normal` on the spinner span so the glyph face never depends on inherited weight. One line; fixes the active-tab indicator and every inline-in-`Button` spinner at once.

## Validation

- Reproduced and confirmed the fix in headless Chromium using the app's exact mono stack under a `font-weight: 500` parent — hollow grid before, single filled dot after.
- `bun run compile` (gui-app) — clean.
- `bun run test -- --run src/components/layout/__tests__/tab-strip.test.tsx` — 28/28 passed.