### PR TITLE
fix(gui-app): prevent tab tooltip hover flicker

### DIFF
--- a/clients/gui-app/src/components/ui/tooltip.tsx
+++ b/clients/gui-app/src/components/ui/tooltip.tsx
@@ -43,7 +43,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-ui-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          // Tooltip content is label-only (see hover-preview-card.tsx for the
+          // interactive-content surface); `pointer-events-none` stops the
+          // portalled content from ever winning hit-testing away from its
+          // trigger, which otherwise can drive a hover/reposition loop when
+          // the trigger sits directly under the content (e.g. a top-pinned
+          // strip flipping the tooltip to `side="bottom"`).
+          "pointer-events-none z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-ui-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}

--- a/clients/gui-app/src/index.css
+++ b/clients/gui-app/src/index.css
@@ -1168,7 +1168,7 @@
 
   /* Reveal on hover, or keyboard focus - NOT :focus-within. A mouse-drag reorder
      focuses the tab div, and dnd-kit swallows the trailing click so the tab is
-     never activated; with :focus-within the reveal (slot width + close button)
+     never activated; with :focus-within the reveal (opacity + close button)
      would stay stuck lit on that inactive tab until focus moved away.
      Keyboard focus is expressed as :focus-visible (mouse focus doesn't match it,
      so a drag doesn't stick) across two selectors:
@@ -1178,12 +1178,26 @@
          :focus-visible, so without this the slot would collapse and hide the
          very button the user just focused.
      Keep in sync with the accent chrome's `group-focus-visible/tab` +
-     `group-has-[:focus-visible]/tab` gates in tab-strip-item.tsx. */
+     `group-has-[:focus-visible]/tab` gates in tab-strip-item.tsx.
+
+     The width is reserved unconditionally once the tab is wide enough to
+     spare the room - hover/focus only toggle opacity now. The title span
+     (the tooltip anchor, tab-strip-item.tsx) sits in the same flex row and
+     used to shrink every time the slot animated 0 -> 1.25rem on hover;
+     Floating UI's autoUpdate would reposition the tooltip against that
+     resize, the content would land under the cursor, hit-testing would
+     drop off the tab, and the slot would collapse - an infinite loop. A
+     stable width breaks that at the source. Below 7rem the button never
+     reveals at all, so the slot stays width 0 (the base rule above) rather
+     than permanently eating title space on narrow tabs. */
   @container (min-width: 7rem) {
+    .header-tab-trailing-slot {
+      width: 1.25rem;
+    }
+
     .group\/tab:hover .header-tab-trailing-slot,
     .group\/tab:focus-visible .header-tab-trailing-slot,
     .group\/tab:has(:focus-visible) .header-tab-trailing-slot {
-      width: 1.25rem;
       opacity: 1;
     }
 


### PR DESCRIPTION
## Summary

- reserve the tab trailing-slot width at supported container sizes so hover only changes opacity
- make label-only tooltip content ignore pointer hit-testing
- prevent active epic tab hover from repeatedly changing title truncation, close-button visibility, and tooltip placement

## Root cause

The close-button slot changed width from 0 to 1.25rem on tab hover. That resized the title span used as the tooltip anchor, causing Floating UI to reposition the tooltip content beneath the cursor. Because the content accepted pointer events, it could steal hit-testing from the tab, drop hover, collapse the slot, and restart the cycle.

## Validation

- bun run compile (clients/gui-app)
- targeted ESLint and Prettier checks for the changed files
- React Doctor changed-files scan: no issues
- repository pre-commit gate: hygiene plus Nx affected build, compile, lint, and format
- Chromium live-Vite regression harness: trailing slot remained 20px over 2.5s of bottom-edge hover sampling, tooltip position converged, and tooltip content computed pointer-events: none