### PR TITLE
fix(gui-app): guard undefined error.code in report-issue context

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-error-block.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-error-block.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import {
+  QueryClient,
+  QueryClientProvider,
+  queryOptions,
+  useQuery,
+} from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { GitErrorBlock } from "../git-error-block";
+
+/**
+ * Reproduces the production seam that crashed the git diff view: the git
+ * snapshot queries declare `HostRpcError` as their error type while their
+ * queryFn could reject with a bare `Error`, so `error.code` was `undefined`
+ * at runtime despite the declared type. No assertion is needed to model the
+ * lie - the TanStack error generic launders it exactly as production did.
+ */
+function BareErrorQueryHarness(): ReactNode {
+  const query = useQuery(
+    queryOptions<never, HostRpcError>({
+      queryKey: ["git-error-block-bare-error"],
+      queryFn: () => Promise.reject(new Error("Host client unavailable")),
+      retry: false,
+    }),
+  );
+  if (query.error === null) return null;
+  return <GitErrorBlock error={query.error} />;
+}
+
+describe("GitErrorBlock", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the error state for a bare Error without a code", async () => {
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <BareErrorQueryHarness />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Diff Loading Error")).toBeDefined();
+    expect(screen.getByText("Host client unavailable")).toBeDefined();
+  });
+});

--- a/clients/gui-app/src/hooks/git/use-git-get-file-diff-query.ts
+++ b/clients/gui-app/src/hooks/git/use-git-get-file-diff-query.ts
@@ -9,6 +9,7 @@ import type {
   GitGetFileDiffResponse,
   GitStage,
 } from "@traycer/protocol/host";
+import { hostClientUnavailableError } from "@/hooks/host/use-host-query";
 import { useHostClient } from "@/lib/host";
 import { gitQueryKeys } from "@/lib/query-keys/git-query-keys";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
@@ -57,7 +58,9 @@ export function useGitGetFileDiffQuery(args: {
         // but a defensive runtime guard is retained against future refactors.
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (!client) {
-          throw new Error("Host client unavailable");
+          // A `HostRpcError` (not a bare Error): this query publicly declares
+          // that error type and UI surfaces read `.code`.
+          throw hostClientUnavailableError("git.getFileDiff");
         }
         const request: GitGetFileDiffRequest = {
           hostId: args.hostId ?? "",

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-with-submodules.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-with-submodules.ts
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-query";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { GitListChangedFilesResponseV11 } from "@traycer/protocol/host";
+import { hostClientUnavailableError } from "@/hooks/host/use-host-query";
 import { useHostClientFor } from "@/hooks/host/use-host-client-for";
 import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
@@ -318,7 +319,11 @@ export function useGitListChangedFilesWithSubmodules(args: {
     ignoreWhitespace,
     request: async (): Promise<GitListChangedFilesResponseV11> => {
       if (client === null || hostId === null || runningDir === null) {
-        return Promise.reject(new Error("Host client unavailable"));
+        // A `HostRpcError` (not a bare Error): consuming hooks publicly
+        // declare that error type and UI surfaces read `.code`.
+        return Promise.reject(
+          hostClientUnavailableError("git.listChangedFiles"),
+        );
       }
       return client.request("git.listChangedFiles", {
         hostId,

--- a/clients/gui-app/src/lib/__tests__/report-issue-context.test.ts
+++ b/clients/gui-app/src/lib/__tests__/report-issue-context.test.ts
@@ -32,4 +32,23 @@ describe("createReportIssueContext", () => {
     expect(context.code).toBeNull();
     expect(context.source).toBeNull();
   });
+
+  it("treats undefined values as absent instead of crashing", () => {
+    // Regression: `.code` read off an error whose declared type lied (a bare
+    // `Error` surfaced through a TanStack generic) is `undefined`, not `null`.
+    // The old null-only guard crashed the git diff view on `.replace`.
+    expect(
+      createReportIssueContext({
+        title: "Diff loading error",
+        message: undefined,
+        code: undefined,
+        source: undefined,
+      }),
+    ).toEqual({
+      title: "Diff loading error",
+      message: null,
+      code: null,
+      source: null,
+    });
+  });
 });

--- a/clients/gui-app/src/lib/report-issue-context.ts
+++ b/clients/gui-app/src/lib/report-issue-context.ts
@@ -14,9 +14,9 @@ export interface ReportIssueContext {
  */
 export function createReportIssueContext(input: {
   readonly title: string;
-  readonly message: string | null;
-  readonly code: string | null;
-  readonly source: string | null;
+  readonly message: string | null | undefined;
+  readonly code: string | null | undefined;
+  readonly source: string | null | undefined;
 }): ReportIssueContext {
   return {
     title: normalizeReportContextValue(input.title) ?? "Traycer error",
@@ -26,8 +26,14 @@ export function createReportIssueContext(input: {
   };
 }
 
-function normalizeReportContextValue(value: string | null): string | null {
-  if (value === null) return null;
+// Total over `undefined` as well as `null`: callers routinely feed `.code`
+// off error objects whose declared type (e.g. `HostRpcError`) is a TanStack
+// generic promise, not a runtime guarantee - a bare `Error` leaking through
+// that seam made this helper crash the whole view.
+function normalizeReportContextValue(
+  value: string | null | undefined,
+): string | null {
+  if (value === null || value === undefined) return null;
   const normalized = value.replace(/\s+/g, " ").trim();
   if (normalized.length === 0) return null;
   if (normalized.length <= MAX_REPORT_CONTEXT_LENGTH) return normalized;


### PR DESCRIPTION
## Summary

Opening the git diff view could crash the whole app with `Cannot read properties of undefined (reading 'replace')`.

- The `git.listChangedFiles` (submodule-aware) query declares `HostRpcError` as its TanStack error generic, but its queryFn could reject with a bare `Error("Host client unavailable")` — so `error.code` was `undefined` at runtime despite the declared type.
- `GitErrorBlock` passes `error.code` into `createReportIssueContext`, whose `normalizeReportContextValue` only guarded `null`, so `undefined.replace(...)` threw during render and hit the root error boundary.

Fix:
- Widen `normalizeReportContextValue` (and `createReportIssueContext`'s inputs) to treat `undefined` the same as `null`.
- Make both git queryFns (`git.listChangedFiles`, `git.getFileDiff`) reject with a real `HostRpcError` via the existing `hostClientUnavailableError` helper instead of a bare `Error`, so `.code` stays truthful to the declared type.

## Test plan

- [x] `bun run compile` clean
- [x] `bunx vitest run` — git-diff components + git hooks + report-issue-context suites (26 files / 173 tests) pass
- [x] New regression test (`git-error-block.test.tsx`) reproduces the exact production seam via a `queryOptions<never, HostRpcError>` query whose queryFn rejects a bare `Error` — verified to fail with the original TypeError when the guard fix is reverted
- [x] eslint + prettier clean on touched files