### PR TITLE
fix(gui-app): landing terminal focus fixes + chat descendant status rollup

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
@@ -48,6 +48,7 @@ import {
   useVisiblePaneValue,
 } from "@/components/epic-tabs/pane-visibility-context";
 import { markTerminalLoad } from "@/lib/perf/terminal-load-perf";
+import { registerTerminalFocus } from "@/lib/terminals/terminal-focus-registry";
 import {
   acquireXtermHost,
   releaseXtermHost,
@@ -397,6 +398,17 @@ export function TerminalXtermHost(props: TerminalXtermHostProps) {
     theme,
   });
   useActiveTerminalFocus(termRef, props.shouldFocusOnActivePane);
+  // Imperative focus bridge. Surfaces whose reveal is not a pane-visibility
+  // flip (the landing panel expanding around an always-mounted tile, or a tab
+  // created before its engine exists) focus through the registry instead of
+  // `shouldFocusOnActivePane`.
+  useEffect(
+    () =>
+      registerTerminalFocus(props.instanceId, () => {
+        termRef.current?.focus();
+      }),
+    [props.instanceId],
+  );
 
   const pastePaths = useCallback((paths: readonly string[]): void => {
     const input = terminalPathInput(uniquePaths(paths));

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -1168,6 +1168,7 @@ describe("chat descendant status rollup", () => {
     testState.records = [];
     testState.indicatorChats = {};
     testState.activeAgentIds = new Set<string>();
+    testState.chatFilterOrigin = "all";
   });
 
   function seedNestedChatTree(): void {
@@ -1366,6 +1367,55 @@ describe("chat descendant status rollup", () => {
     expect(
       screen.queryByTestId("chat-descendant-status-done-chat-root"),
     ).toBeNull();
+  });
+
+  it("ranks interview above approval, both outranked by failure", () => {
+    seedNestedChatTree();
+    testState.indicatorChats = {
+      "chat-child": indicator({ pendingApproval: true }),
+      "chat-grandchild": indicator({ pendingInterview: true }),
+    };
+
+    const view = render(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.getByTestId("chat-descendant-status-interview-chat-root"),
+    ).toBeTruthy();
+
+    testState.indicatorChats = {
+      ...testState.indicatorChats,
+      "chat-child": indicator({ unreadFailure: true }),
+    };
+    view.rerender(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.queryByTestId("chat-descendant-status-interview-chat-root"),
+    ).toBeNull();
+    expect(
+      screen.getByTestId("chat-descendant-status-failure-chat-root"),
+    ).toBeTruthy();
+  });
+
+  it("excludes a filter-hidden subtree from the rollup while keeping a visible descendant's status", () => {
+    seedNestedChatTree();
+    // GUI-only origin filter hides the terminal-agent descendant entirely -
+    // its active-run state must not leak into the rollup as "running" - while
+    // the chat subtree (still reachable under the filter) keeps surfacing.
+    testState.chatFilterOrigin = "gui";
+    testState.activeAgentIds = new Set(["agent-child"]);
+    testState.indicatorChats = {
+      "chat-grandchild": indicator({ unreadFailure: true }),
+    };
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+    expect(
+      screen.queryByTestId("chat-descendant-status-running-chat-root"),
+    ).toBeNull();
+    expect(
+      screen.getByTestId("chat-descendant-status-failure-chat-root"),
+    ).toBeTruthy();
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -30,6 +30,13 @@ interface TestRecord {
   readonly hostId: string;
 }
 
+interface TestIndicatorState {
+  readonly unreadFailure: boolean;
+  readonly pendingApproval: boolean;
+  readonly pendingInterview: boolean;
+  readonly unreadDone: boolean;
+}
+
 interface TestState {
   readonly createChatMutate: Mock;
   readonly createArtifactMutate: Mock;
@@ -56,6 +63,8 @@ interface TestState {
     readonly nodeById: Readonly<Record<string, TestTreeNode | undefined>>;
   };
   records: readonly TestRecord[];
+  indicatorChats: Readonly<Record<string, TestIndicatorState>>;
+  activeAgentIds: ReadonlySet<string>;
   permissionRole: "owner" | "editor" | "viewer" | null;
   rowHostId: string | null;
   rowHostEntry: unknown;
@@ -93,6 +102,8 @@ const testState = vi.hoisted<TestState>(() => ({
     nodeById: {},
   },
   records: [],
+  indicatorChats: {},
+  activeAgentIds: new Set<string>(),
   permissionRole: "owner",
   rowHostId: "host-1",
   rowHostEntry: { hostId: "host-1" },
@@ -169,7 +180,7 @@ vi.mock("@/components/worktree/worktree-owner-metadata", () => ({
 
 vi.mock("@/hooks/notifications/use-host-notification-indicators-query", () => ({
   useHostNotificationIndicators: () => ({
-    data: { epics: {}, chats: {} },
+    data: { epics: {}, chats: testState.indicatorChats },
     isPending: false,
     isFetching: false,
     error: null,
@@ -399,7 +410,7 @@ vi.mock("@/lib/epic-selectors", () => ({
   useAncestorIds: () => new Set<string>(),
   useChildIds: (parentId: string) =>
     testState.tree.childrenByParent[parentId] ?? [],
-  useEpicActiveAgentIds: () => new Set<string>(),
+  useEpicActiveAgentIds: () => testState.activeAgentIds,
   useEpicArtifact: (artifactId: string | null) => {
     if (artifactId === null) return null;
     const node = testState.tree.nodeById[artifactId];
@@ -535,6 +546,8 @@ describe("epic sidebar selection mode", () => {
       nodeById: {},
     };
     testState.records = [];
+    testState.indicatorChats = {};
+    testState.activeAgentIds = new Set<string>();
     testState.permissionRole = "owner";
     testState.rowHostId = "host-1";
     testState.rowHostEntry = { hostId: "host-1" };
@@ -1138,6 +1151,221 @@ describe("epic sidebar selection mode", () => {
     render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
 
     expect(markRead).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat descendant status rollup", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    testState.activePanelId = "chats";
+    testState.expandedIds = new Set<string>();
+    testState.tree = {
+      rootIds: [],
+      childrenByParent: {},
+      nodeById: {},
+    };
+    testState.records = [];
+    testState.indicatorChats = {};
+    testState.activeAgentIds = new Set<string>();
+  });
+
+  function seedNestedChatTree(): void {
+    const chatRoot = treeNode("chat-root", null, "Root chat", "chat");
+    const chatChild = treeNode("chat-child", "chat-root", "Child chat", "chat");
+    const chatGrandchild = treeNode(
+      "chat-grandchild",
+      "chat-child",
+      "Grandchild chat",
+      "chat",
+    );
+    const agentChild = treeNode(
+      "agent-child",
+      "chat-root",
+      "Terminal agent",
+      "terminal-agent",
+    );
+    testState.activePanelId = "chats";
+    testState.expandedIds = new Set<string>();
+    testState.tree = {
+      rootIds: ["chat-root"],
+      childrenByParent: {
+        "chat-root": ["chat-child", "agent-child"],
+        "chat-child": ["chat-grandchild"],
+      },
+      nodeById: {
+        "chat-root": chatRoot,
+        "chat-child": chatChild,
+        "chat-grandchild": chatGrandchild,
+        "agent-child": agentChild,
+      },
+    };
+    testState.records = [chatRoot, chatChild, chatGrandchild, agentChild].map(
+      recordFromNode,
+    );
+  }
+
+  function indicator(
+    overrides: Partial<TestIndicatorState>,
+  ): TestIndicatorState {
+    return {
+      unreadFailure: false,
+      pendingApproval: false,
+      pendingInterview: false,
+      unreadDone: false,
+      ...overrides,
+    };
+  }
+
+  it("bubbles a hidden grandchild's needs-attention status onto the collapsed root", () => {
+    seedNestedChatTree();
+    testState.indicatorChats = {
+      "chat-grandchild": indicator({ unreadFailure: true }),
+    };
+
+    const view = render(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+
+    // The grandchild's row is not even mounted, yet its status reaches the
+    // collapsed root as the rollup badge.
+    expect(
+      screen.queryByTestId("epic-sidebar-item-chat-grandchild"),
+    ).toBeNull();
+    expect(
+      screen.getByTestId("chat-descendant-status-failure-chat-root"),
+    ).toBeTruthy();
+
+    // Expanding the root moves the rollup down to the still-collapsed child.
+    testState.expandedIds = new Set(["chat-root"]);
+    view.rerender(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.queryByTestId("chat-descendant-status-failure-chat-root"),
+    ).toBeNull();
+    expect(
+      screen.getByTestId("chat-descendant-status-failure-chat-child"),
+    ).toBeTruthy();
+
+    // Fully expanded: the grandchild presents its own status, no rollups left.
+    testState.expandedIds = new Set(["chat-root", "chat-child"]);
+    view.rerender(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.queryByTestId("chat-descendant-status-failure-chat-child"),
+    ).toBeNull();
+    expect(
+      screen.getByTestId("epic-sidebar-item-chat-grandchild"),
+    ).toBeTruthy();
+  });
+
+  it("rolls an active terminal-agent descendant up as running, outranked by failure", () => {
+    seedNestedChatTree();
+    testState.activeAgentIds = new Set(["agent-child"]);
+    testState.indicatorChats = {
+      "chat-grandchild": indicator({ unreadDone: true }),
+    };
+
+    const view = render(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+
+    // Running outranks unread completion...
+    expect(
+      screen.getByTestId("chat-descendant-status-running-chat-root"),
+    ).toBeTruthy();
+
+    // ...and a failure anywhere below outranks running.
+    testState.indicatorChats = {
+      "chat-grandchild": indicator({ unreadDone: true }),
+      "chat-child": indicator({ unreadFailure: true }),
+    };
+    view.rerender(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.queryByTestId("chat-descendant-status-running-chat-root"),
+    ).toBeNull();
+    expect(
+      screen.getByTestId("chat-descendant-status-failure-chat-root"),
+    ).toBeTruthy();
+  });
+
+  it("lets a hidden failure take the slot from a merely-running parent, with a breakdown tooltip", () => {
+    seedNestedChatTree();
+    testState.activeAgentIds = new Set(["chat-root", "agent-child"]);
+    testState.indicatorChats = {
+      "chat-grandchild": indicator({ unreadFailure: true }),
+      "chat-child": indicator({ unreadDone: true }),
+    };
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    // The parent is running (rank below failure), so the nested failure owns
+    // the icon slot - rendered as the muted variant in place of the parent's
+    // own icon, with the tooltip carrying the full nested breakdown.
+    const nested = screen.getByTestId(
+      "chat-descendant-status-failure-chat-root",
+    );
+    expect(nested.getAttribute("title")).toBe(
+      "Nested: 1 needs attention · 1 running · 1 completed",
+    );
+    expect(screen.queryByTestId("chat-sidebar-spinner")).toBeNull();
+  });
+
+  it("keeps the slot with the parent when its own status is at least as urgent", () => {
+    seedNestedChatTree();
+    // Parent's own failure vs a nested running agent: parent outranks.
+    testState.activeAgentIds = new Set(["agent-child"]);
+    testState.indicatorChats = {
+      "chat-root": indicator({ unreadFailure: true }),
+    };
+
+    const view = render(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.queryByTestId("chat-descendant-status-running-chat-root"),
+    ).toBeNull();
+    expect(screen.getByTestId("chat-sidebar-spinner")).toBeTruthy();
+
+    // Equal tiers: the tie goes to the parent's own (solid) presentation.
+    testState.activeAgentIds = new Set<string>();
+    testState.indicatorChats = {
+      "chat-root": indicator({ pendingApproval: true }),
+      "chat-grandchild": indicator({ pendingApproval: true }),
+    };
+    view.rerender(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.queryByTestId("chat-descendant-status-approval-chat-root"),
+    ).toBeNull();
+    expect(screen.getByTestId("chat-sidebar-spinner")).toBeTruthy();
+  });
+
+  it("shows an unread-done rollup and nothing when descendants are idle", () => {
+    seedNestedChatTree();
+    testState.indicatorChats = {
+      "chat-child": indicator({ unreadDone: true }),
+    };
+
+    const view = render(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.getByTestId("chat-descendant-status-done-chat-root"),
+    ).toBeTruthy();
+
+    testState.indicatorChats = {};
+    view.rerender(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.queryByTestId("chat-descendant-status-done-chat-root"),
+    ).toBeNull();
   });
 });
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -28,6 +28,24 @@ import { OwnerResourceChip } from "@/components/resources/resource-usage-chip";
 import type { ResourceOwnerKindWire } from "@traycer/protocol/host/resources/subscribe";
 import { ChatProgressIcon } from "@/components/chat/chat-progress-icon";
 import { NotificationIndicatorsProvider } from "@/components/notifications/notification-indicators-provider";
+import {
+  NotificationIndicatorsContext,
+  useSurfaceNotificationIndicatorState,
+} from "@/components/notifications/notification-indicator-context";
+import {
+  APPROVAL_TONE,
+  attentionTone,
+  DONE_TONE,
+  FAILURE_TONE,
+  INTERVIEW_TONE,
+  type IndicatorTone,
+} from "@/components/notifications/notification-indicator-tones";
+import {
+  selectNotificationIndicatorState,
+  type NotificationIndicatorState,
+} from "@/stores/notifications/notification-indicator-state";
+import { useAppLocalNotificationsStore } from "@/stores/notifications/app-local-notifications-store";
+import type { TreeSlice } from "@/stores/epics/open-epic/types";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
@@ -97,6 +115,7 @@ import {
 import {
   memo,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -104,6 +123,7 @@ import {
   type KeyboardEvent,
   type ReactNode,
 } from "react";
+import { useShallow } from "zustand/react/shallow";
 import {
   BASE_PAD_LEFT,
   EMPTY_PENDING_LIST,
@@ -122,6 +142,7 @@ import {
   SidebarFilterVisibilityContext,
   SidebarSortContext,
   useFilteredPanelChildIds,
+  useSidebarVisibleIds,
 } from "./epic-sidebar-filter";
 import {
   collectVisibleSidebarTreeIds,
@@ -156,6 +177,159 @@ const CHATS_TREE_FILTER: TreeFilterFn = (type) =>
 const EMPTY_SELECTED_IDS: ReadonlySet<string> = new Set<string>();
 const noopToggleSelection = (_id: string): void => undefined;
 const noopRowAction = (): void => undefined;
+
+type ChatDescendantStatusKind =
+  "failure" | "interview" | "approval" | "running" | "done";
+
+/**
+ * One shared urgency ladder for a collapsed parent's icon slot: the parent's
+ * own status tier and the hidden descendants' highest tier are ranked on it,
+ * and the higher one owns the slot (ties go to the parent, so solid always
+ * beats muted). Mirrors the order `NotificationIndicatorIcon` resolves a
+ * single chat's simultaneous states.
+ */
+const CHAT_STATUS_RANKS: Record<ChatDescendantStatusKind, number> = {
+  failure: 5,
+  interview: 4,
+  approval: 3,
+  running: 2,
+  done: 1,
+};
+
+/**
+ * Rollup over a collapsed parent's hidden chat descendants: the
+ * highest-priority kind plus per-tier counts (each descendant is counted once,
+ * under its own highest tier) so the icon's tooltip can break the aggregate
+ * down instead of hiding it behind one glyph.
+ */
+interface ChatDescendantStatusRollup {
+  readonly kind: ChatDescendantStatusKind;
+  readonly failureCount: number;
+  readonly interviewCount: number;
+  readonly approvalCount: number;
+  readonly runningCount: number;
+  readonly doneCount: number;
+}
+
+interface ChatDescendantIds {
+  readonly chatIds: ReadonlyArray<string>;
+  readonly agentIds: ReadonlyArray<string>;
+}
+
+const EMPTY_CHAT_DESCENDANT_IDS: ChatDescendantIds = {
+  chatIds: [],
+  agentIds: [],
+};
+
+/**
+ * Collects the chat / terminal-agent descendants of `nodeId` so a collapsed
+ * parent can roll their statuses up without mounting the child rows. Mirrors
+ * the artifact tree's `collectDescendantArtifactEntries`: filter-hidden
+ * subtrees are skipped along with their children (the rollup must never point
+ * at a row the user cannot reach by expanding) and the walk is cycle-guarded
+ * via `visited`.
+ */
+function collectDescendantChatIds(
+  nodeId: string,
+  tree: TreeSlice,
+  visibleIds: ReadonlySet<string> | null,
+): ChatDescendantIds {
+  const rootChildren = Object.hasOwn(tree.childrenByParent, nodeId)
+    ? tree.childrenByParent[nodeId]
+    : null;
+  if (rootChildren === null || rootChildren.length === 0) {
+    return EMPTY_CHAT_DESCENDANT_IDS;
+  }
+  const chatIds: string[] = [];
+  const agentIds: string[] = [];
+  const visited = new Set<string>([nodeId]);
+  const stack = [...rootChildren];
+  while (stack.length > 0) {
+    const id = stack.pop();
+    if (id === undefined || visited.has(id)) continue;
+    visited.add(id);
+    if (visibleIds !== null && !visibleIds.has(id)) continue;
+    if (!Object.hasOwn(tree.nodeById, id)) continue;
+    const node = tree.nodeById[id];
+    if (node.type === "chat") chatIds.push(id);
+    if (node.type === "terminal-agent") agentIds.push(id);
+    if (Object.hasOwn(tree.childrenByParent, id)) {
+      for (const childId of tree.childrenByParent[id]) stack.push(childId);
+    }
+  }
+  if (chatIds.length === 0 && agentIds.length === 0) {
+    return EMPTY_CHAT_DESCENDANT_IDS;
+  }
+  return { chatIds, agentIds };
+}
+
+/**
+ * Rollup over a collapsed parent's hidden chat descendants, or `null` when
+ * there are none or none has a notable status. Each descendant chat is
+ * classified once, under its own highest tier - the per-chat attention
+ * precedence goes through the shared `attentionTone`, so failure > interview >
+ * approval lives in exactly one place. Terminal-agent descendants contribute
+ * only running-ness - epic-wide activity is their sole status authority. Only
+ * mounted inside `ChatSidebarNodeIconWithNestedStatus` (rendered solely for
+ * collapsed parents), so leaves and expanded rows carry none of these
+ * subscriptions; the shallow-compared flat result lets Zustand bail re-renders
+ * whose rollup did not change.
+ */
+function useChatDescendantStatus(args: {
+  readonly epicId: string;
+  readonly nodeId: string;
+}): ChatDescendantStatusRollup | null {
+  const { epicId, nodeId } = args;
+  const tree = useEpicTreeIndex();
+  const visibleIds = useSidebarVisibleIds();
+  const descendants = useMemo(
+    () => collectDescendantChatIds(nodeId, tree, visibleIds),
+    [nodeId, tree, visibleIds],
+  );
+  const activeAgentIds = useEpicActiveAgentIds();
+  const indicators = useContext(NotificationIndicatorsContext);
+  return useAppLocalNotificationsStore(
+    useShallow((state): ChatDescendantStatusRollup | null => {
+      if (descendants === EMPTY_CHAT_DESCENDANT_IDS) return null;
+      let failureCount = 0;
+      let interviewCount = 0;
+      let approvalCount = 0;
+      let runningCount = 0;
+      let doneCount = 0;
+      for (const chatId of descendants.chatIds) {
+        const indicatorState = selectNotificationIndicatorState(
+          state,
+          { epicId, chatId },
+          indicators,
+        );
+        const tone = attentionTone(indicatorState);
+        if (tone === FAILURE_TONE) failureCount += 1;
+        else if (tone === INTERVIEW_TONE) interviewCount += 1;
+        else if (tone === APPROVAL_TONE) approvalCount += 1;
+        else if (activeAgentIds.has(chatId)) runningCount += 1;
+        else if (indicatorState.unreadDone) doneCount += 1;
+      }
+      for (const agentId of descendants.agentIds) {
+        if (activeAgentIds.has(agentId)) runningCount += 1;
+      }
+      let kind: ChatDescendantStatusKind | null = null;
+      if (failureCount > 0) kind = "failure";
+      else if (interviewCount > 0) kind = "interview";
+      else if (approvalCount > 0) kind = "approval";
+      else if (runningCount > 0) kind = "running";
+      else if (doneCount > 0) kind = "done";
+      if (kind === null) return null;
+      return {
+        kind,
+        failureCount,
+        interviewCount,
+        approvalCount,
+        runningCount,
+        doneCount,
+      };
+    }),
+  );
+}
 
 interface ExpansionController {
   expandedIds: ReadonlySet<string>;
@@ -296,9 +470,21 @@ export function ChatTreePanelBody(props: ChatTreePanelBodyProps) {
       }),
     [rootIds, expandedIds, tree, visibleIds, comparator],
   );
+  // Indicator state must cover every chat in the (filter-visible) tree, not
+  // just rows currently revealed by expansion: a collapsed parent rolls its
+  // hidden descendants' statuses up into a badge, so their indicators have to
+  // be observed even while their rows are unmounted. Sorted for a stable
+  // query identity across expand/collapse churn.
   const indicatorChatIds = useMemo(
-    () => selectableIds.filter((id) => tree.nodeById[id].type === "chat"),
-    [selectableIds, tree],
+    () =>
+      Object.keys(tree.nodeById)
+        .filter(
+          (id) =>
+            tree.nodeById[id].type === "chat" &&
+            (visibleIds === null || visibleIds.has(id)),
+        )
+        .sort(),
+    [tree, visibleIds],
   );
   const notificationIndicators = useHostNotificationIndicators({
     epicIds: [],
@@ -1255,6 +1441,28 @@ function ChatRowButton(props: ChatRowButtonProps) {
       : "text-foreground/75 hover:bg-accent/70 hover:text-accent-foreground",
   );
   const selectionInputId = `epic-sidebar-select-input-${nodeId}`;
+  // Collapsed parents merge their hidden descendants' status into the icon
+  // slot; every other row renders its own status only.
+  const nodeIcon =
+    hasChildren && !expanded ? (
+      <ChatSidebarNodeIconWithNestedStatus
+        epicId={epicId}
+        nodeId={nodeId}
+        artifactType={artifactType}
+        Icon={Icon}
+        artifactIconColorMode={artifactIconColorMode}
+        iconStyle={iconStyle}
+      />
+    ) : (
+      <ChatSidebarNodeIcon
+        epicId={epicId}
+        nodeId={nodeId}
+        artifactType={artifactType}
+        Icon={Icon}
+        artifactIconColorMode={artifactIconColorMode}
+        iconStyle={iconStyle}
+      />
+    );
 
   if (selectionMode) {
     return (
@@ -1281,14 +1489,7 @@ function ChatRowButton(props: ChatRowButtonProps) {
           onToggleSelection={onToggleSelection}
         />
         <span className="flex min-w-0 flex-1 items-center gap-1.5">
-          <ChatSidebarNodeIcon
-            epicId={epicId}
-            nodeId={nodeId}
-            artifactType={artifactType}
-            Icon={Icon}
-            artifactIconColorMode={artifactIconColorMode}
-            iconStyle={iconStyle}
-          />
+          {nodeIcon}
           <span className="min-w-0 flex-1 truncate">{nodeName}</span>
         </span>
       </label>
@@ -1316,14 +1517,7 @@ function ChatRowButton(props: ChatRowButtonProps) {
         onToggle={onToggle}
       />
       <span className="flex min-w-0 flex-1 items-center gap-1.5">
-        <ChatSidebarNodeIcon
-          epicId={epicId}
-          nodeId={nodeId}
-          artifactType={artifactType}
-          Icon={Icon}
-          artifactIconColorMode={artifactIconColorMode}
-          iconStyle={iconStyle}
-        />
+        {nodeIcon}
         <span className="min-w-0 flex-1 truncate">{nodeName}</span>
         {resourceOwnerKind === null || !showNavigatorResourceStats ? null : (
           <OwnerResourceChip
@@ -1346,6 +1540,137 @@ function ChatRowButton(props: ChatRowButtonProps) {
       ownerKind={ownerKind}
     />
   );
+}
+
+// Glyph and color come from the shared notification tones so the nested
+// variant cannot drift from the per-row icon; "running" stays local because
+// it is an activity tier, not a notification state.
+const CHAT_DESCENDANT_STATUS_TONES: Record<
+  Exclude<ChatDescendantStatusKind, "running">,
+  IndicatorTone
+> = {
+  failure: FAILURE_TONE,
+  interview: INTERVIEW_TONE,
+  approval: APPROVAL_TONE,
+  done: DONE_TONE,
+};
+
+/**
+ * The parent's own tier on the shared ladder. `selfActive` is the epic-wide
+ * activity bit - the same authority the per-row icon falls back to for an
+ * unopened chat; the handle-refined turn/background split does not matter here
+ * because both tiers rank as "running".
+ */
+function chatSelfStatusRank(
+  state: NotificationIndicatorState,
+  selfActive: boolean,
+): number {
+  const tone = attentionTone(state);
+  if (tone === FAILURE_TONE) return CHAT_STATUS_RANKS.failure;
+  if (tone === INTERVIEW_TONE) return CHAT_STATUS_RANKS.interview;
+  if (tone === APPROVAL_TONE) return CHAT_STATUS_RANKS.approval;
+  if (selfActive) return CHAT_STATUS_RANKS.running;
+  if (state.unreadDone) return CHAT_STATUS_RANKS.done;
+  return 0;
+}
+
+/** "Nested: 1 needs attention · 2 running" - non-zero tiers, priority order. */
+function nestedChatStatusSummary(rollup: ChatDescendantStatusRollup): string {
+  const parts: string[] = [];
+  if (rollup.failureCount > 0) {
+    parts.push(
+      `${rollup.failureCount} ${rollup.failureCount === 1 ? "needs" : "need"} attention`,
+    );
+  }
+  if (rollup.interviewCount > 0) {
+    parts.push(`${rollup.interviewCount} waiting for interview`);
+  }
+  if (rollup.approvalCount > 0) {
+    parts.push(`${rollup.approvalCount} waiting for approval`);
+  }
+  if (rollup.runningCount > 0) parts.push(`${rollup.runningCount} running`);
+  if (rollup.doneCount > 0) parts.push(`${rollup.doneCount} completed`);
+  return `Nested: ${parts.join(" · ")}`;
+}
+
+/**
+ * Icon slot for a collapsed parent. Merges the parent's own status tier with
+ * the hidden descendants' rollup on the shared ladder: the more urgent one
+ * owns the slot, ties go to the parent - so a nested state renders exactly
+ * where users already read status, as a muted variant of the same icon, and a
+ * hidden failure can never sit invisible behind a parent that is merely
+ * running. Mounted only for collapsed parents, so rows without a rollup carry
+ * none of these subscriptions.
+ */
+const ChatSidebarNodeIconWithNestedStatus = memo(
+  function ChatSidebarNodeIconWithNestedStatus(
+    props: ChatSidebarNodeIconProps,
+  ) {
+    const rollup = useChatDescendantStatus({
+      epicId: props.epicId,
+      nodeId: props.nodeId,
+    });
+    const activeAgentIds = useEpicActiveAgentIds();
+    const selfIndicator = useSurfaceNotificationIndicatorState({
+      epicId: props.epicId,
+      chatId: props.nodeId,
+    });
+    if (rollup !== null) {
+      const selfActive = activeAgentIds.has(props.nodeId);
+      // Terminal-agent parents have no notification states of their own -
+      // activity is their only tier (their indicator entry is always empty).
+      const agentSelfRank = selfActive ? CHAT_STATUS_RANKS.running : 0;
+      const selfRank =
+        props.artifactType === "chat"
+          ? chatSelfStatusRank(selfIndicator, selfActive)
+          : agentSelfRank;
+      if (CHAT_STATUS_RANKS[rollup.kind] > selfRank) {
+        return <NestedChatStatusIcon nodeId={props.nodeId} rollup={rollup} />;
+      }
+    }
+    return <ChatSidebarNodeIcon {...props} />;
+  },
+);
+
+/**
+ * The muted variant of the status icon: same glyph, same slot, reduced
+ * opacity - the artifact tree's solid-vs-translucent "self vs descendant"
+ * convention applied to chat status. The tooltip carries the full nested
+ * breakdown, since one glyph can stand for several children.
+ */
+function NestedChatStatusIcon(props: {
+  readonly nodeId: string;
+  readonly rollup: ChatDescendantStatusRollup;
+}): ReactNode {
+  const title = nestedChatStatusSummary(props.rollup);
+  return (
+    <span
+      role="status"
+      aria-label={title}
+      title={title}
+      data-testid={`chat-descendant-status-${props.rollup.kind}-${props.nodeId}`}
+      className="inline-flex size-3.5 shrink-0 items-center justify-center opacity-60"
+    >
+      <NestedChatStatusGlyph kind={props.rollup.kind} />
+    </span>
+  );
+}
+
+function NestedChatStatusGlyph(props: {
+  readonly kind: ChatDescendantStatusKind;
+}): ReactNode {
+  if (props.kind === "running") {
+    return (
+      <AgentSpinningDots
+        className="text-current"
+        testId={undefined}
+        variant={undefined}
+      />
+    );
+  }
+  const tone = CHAT_DESCENDANT_STATUS_TONES[props.kind];
+  const Icon = tone.Icon;
+  return <Icon aria-hidden className={cn("size-3.5", tone.className)} />;
 }
 
 interface ChatSidebarNodeIconProps {

--- a/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/__tests__/landing-terminal-panel.test.tsx
@@ -10,6 +10,11 @@ import {
 } from "@testing-library/react";
 import type { CanonicalTerminalSessionInfo } from "@traycer/protocol/host/terminal/unary-schemas";
 import { useLandingTerminalStore } from "@/stores/home/landing-terminal-store";
+import { registerComposerFocus } from "@/lib/composer/composer-focus-registry";
+import {
+  registerTerminalFocus,
+  resetTerminalFocusRegistryForTests,
+} from "@/lib/terminals/terminal-focus-registry";
 import {
   dispatchAction,
   matchDigitAction,
@@ -175,8 +180,31 @@ function leaderDigitEvent(code: string): KeyboardEvent {
   return new KeyboardEvent("keydown", { code, metaKey: true });
 }
 
+/**
+ * Resolves every deferred `fetchQuery` a reconciliation generation issues,
+ * repeatedly: a generation only calls `fetchQuery` after an internal await, so
+ * a single splice would race it and leave the live generation hanging. Each
+ * pass yields a macrotask so continuations (including newly started
+ * generations) run before the next drain.
+ */
+async function drainDeferredListFetches(
+  resolvers: Array<(value: unknown) => void>,
+): Promise<void> {
+  await act(async () => {
+    for (let pass = 0; pass < 10; pass += 1) {
+      resolvers.splice(0).forEach((resolve) => {
+        resolve({ sessions: [] });
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  });
+}
+
 describe("<LandingTerminalPanel />", () => {
+  const focusCleanups: Array<() => void> = [];
+
   beforeEach(() => {
+    resetTerminalFocusRegistryForTests();
     mocks.activeHostId = null;
     mocks.probeData = undefined;
     mocks.freshProbeData = undefined;
@@ -197,6 +225,9 @@ describe("<LandingTerminalPanel />", () => {
 
   afterEach(() => {
     cleanup();
+    focusCleanups.forEach((unregister) => unregister());
+    focusCleanups.length = 0;
+    resetTerminalFocusRegistryForTests();
     useLandingTerminalStore.getState().resetForTests();
     setSystemTabModalApi(null);
   });
@@ -690,5 +721,323 @@ describe("<LandingTerminalPanel />", () => {
     expect(matchDigitAction(leaderDigitEvent("Digit1"))).toBeNull();
     expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
     expect(mocks.kill).not.toHaveBeenCalled();
+  });
+
+  it("moves focus into the active terminal on expand and back to the composer on collapse", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = { sessions: [] };
+    mocks.freshProbeData = mocks.probeData;
+    useLandingTerminalStore.getState().setPanelOpen(true);
+    render(panelUi());
+    const router = fakeKeybindingRouter();
+
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    });
+    const tab = useLandingTerminalStore.getState().tabs[0];
+    const terminalFocus = vi.fn();
+    const composerFocus = vi.fn();
+    focusCleanups.push(registerTerminalFocus(tab.instanceId, terminalFocus));
+    focusCleanups.push(registerComposerFocus(composerFocus, true));
+
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    expect(useLandingTerminalStore.getState().panelOpen).toBe(false);
+    await waitFor(() => {
+      expect(composerFocus).toHaveBeenCalled();
+    });
+    expect(terminalFocus).not.toHaveBeenCalled();
+
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    await waitFor(() => {
+      expect(terminalFocus).toHaveBeenCalled();
+    });
+  });
+
+  it("does not steal focus from the composer when mounting with the panel already open", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = { sessions: [] };
+    mocks.freshProbeData = mocks.probeData;
+    useLandingTerminalStore.getState().addTab({
+      instanceId: "tab-1",
+      sessionId: "session-1",
+      hostId: "host-a",
+      cwd: "/workspace/project",
+      name: "project",
+      titleSource: "default",
+    });
+    useLandingTerminalStore.getState().setPanelOpen(true);
+    const terminalFocus = vi.fn();
+    focusCleanups.push(registerTerminalFocus("tab-1", terminalFocus));
+
+    render(panelUi());
+
+    // Let the mount-time reconciliation generation settle fully, including
+    // any deferred focus fulfilment the registry might have scheduled.
+    await waitFor(() => {
+      expect(mocks.queryClient.fetchQuery).toHaveBeenCalledTimes(1);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(terminalFocus).not.toHaveBeenCalled();
+  });
+
+  it("parks the focus request for a terminal spawned by expanding an empty panel", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = { sessions: [] };
+    mocks.freshProbeData = mocks.probeData;
+    render(panelUi());
+    const router = fakeKeybindingRouter();
+
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    });
+    const created = useLandingTerminalStore.getState().tabs[0];
+
+    // The auto-spawned tile's engine registers after the create - the parked
+    // request must fire exactly then, not get lost.
+    const terminalFocus = vi.fn();
+    focusCleanups.push(
+      registerTerminalFocus(created.instanceId, terminalFocus),
+    );
+    await waitFor(() => {
+      expect(terminalFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("fulfils tab-activation focus only after the commit, never synchronously", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = { sessions: [] };
+    mocks.freshProbeData = mocks.probeData;
+    useLandingTerminalStore.getState().setPanelOpen(true);
+    render(panelUi());
+
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    });
+    fireEvent.click(screen.getByTestId("landing-terminal-new-tab"));
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(2);
+    });
+    const [first] = useLandingTerminalStore.getState().tabs;
+    const firstFocus = vi.fn();
+    focusCleanups.push(registerTerminalFocus(first.instanceId, firstFocus));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    firstFocus.mockClear();
+
+    // At click time the target tile's wrapper is still `invisible` (React has
+    // not committed the active flip), and a browser rejects focus on hidden
+    // elements without retrying - so the registry must defer fulfilment past
+    // the commit instead of invoking the callback inside the click handler.
+    fireEvent.click(
+      screen.getByTestId(`landing-terminal-tab-${first.instanceId}`),
+    );
+    expect(firstFocus).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(firstFocus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("an unfulfilled open intent lands on the folder pinned at settle time", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = { sessions: [] };
+    useLandingTerminalStore.getState().addTab({
+      instanceId: "tab-1",
+      sessionId: "session-1",
+      hostId: "host-a",
+      cwd: "/workspace/project",
+      name: "project",
+      titleSource: "default",
+    });
+    const resolvers: Array<(value: unknown) => void> = [];
+    mocks.queryClient.fetchQuery.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    const view = render(panelUi());
+    const router = fakeKeybindingRouter();
+
+    // Expand while the list fetch is still in flight, then repoint the pinned
+    // folder before anything settles. The open gesture was never fulfilled,
+    // so the surviving generation honors it against the folder pinned NOW -
+    // nothing had landed yet, so nothing is disrupted.
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    mocks.primaryWorkspacePath = "/workspace/other";
+    view.rerender(panelUi());
+    await drainDeferredListFetches(resolvers);
+
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(2);
+    });
+    const spawned = useLandingTerminalStore
+      .getState()
+      .tabs.find((tab) => tab.instanceId !== "tab-1");
+    expect(spawned?.cwd).toBe("/workspace/other");
+    expect(useLandingTerminalStore.getState().activeInstanceId).toBe(
+      spawned?.instanceId,
+    );
+  });
+
+  it("cancels the open intent once the user interacts with the panel", async () => {
+    mocks.activeHostId = "host-a";
+    // Pinned folder has no matching terminal, so an uncancelled intent would
+    // spawn there on settle.
+    mocks.primaryWorkspacePath = "/workspace/other";
+    mocks.probeData = { sessions: [] };
+    useLandingTerminalStore.getState().addTab({
+      instanceId: "tab-1",
+      sessionId: "session-1",
+      hostId: "host-a",
+      cwd: "/workspace/project",
+      name: "project",
+      titleSource: "default",
+    });
+    const resolvers: Array<(value: unknown) => void> = [];
+    mocks.queryClient.fetchQuery.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+    render(panelUi());
+    const router = fakeKeybindingRouter();
+
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    // The user picks a tab themselves while the list fetch is still pending -
+    // a late-settling pass must not yank them off that choice or spawn.
+    fireEvent.click(screen.getByTestId("landing-terminal-tab-tab-1"));
+    await drainDeferredListFetches(resolvers);
+
+    expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    expect(useLandingTerminalStore.getState().activeInstanceId).toBe("tab-1");
+  });
+
+  it("hands focus to the composer when closing the last tab collapses the panel", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = { sessions: [] };
+    mocks.freshProbeData = mocks.probeData;
+    useLandingTerminalStore.getState().setPanelOpen(true);
+    render(panelUi());
+    const router = fakeKeybindingRouter();
+
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    });
+    const composerFocus = vi.fn();
+    focusCleanups.push(registerComposerFocus(composerFocus, true));
+
+    act(() => {
+      dispatchAction("tab.close", router);
+    });
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().panelOpen).toBe(false);
+      expect(composerFocus).toHaveBeenCalled();
+    });
+  });
+
+  it("reopens onto the pinned folder: spawns there when no terminal matches, reuses one that does", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = { sessions: [] };
+    mocks.freshProbeData = mocks.probeData;
+    useLandingTerminalStore.getState().setPanelOpen(true);
+    const view = render(panelUi());
+    const router = fakeKeybindingRouter();
+
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    });
+    const first = useLandingTerminalStore.getState().tabs[0];
+    expect(first.cwd).toBe("/workspace/project");
+
+    // Collapse, repoint the composer's pinned folder, re-expand: the panel
+    // must land on a terminal running in the new folder - here by spawning
+    // one, since none matches - while the old terminal stays as a tab.
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    mocks.primaryWorkspacePath = "/workspace/other";
+    view.rerender(panelUi());
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(2);
+    });
+    const second = useLandingTerminalStore
+      .getState()
+      .tabs.find((tab) => tab.instanceId !== first.instanceId);
+    expect(second?.cwd).toBe("/workspace/other");
+    expect(useLandingTerminalStore.getState().activeInstanceId).toBe(
+      second?.instanceId,
+    );
+
+    // Collapse, repoint back to the original folder, re-expand: the still-
+    // running matching terminal is reused instead of spawning a third.
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    mocks.primaryWorkspacePath = "/workspace/project";
+    view.rerender(panelUi());
+    act(() => {
+      dispatchAction("app.terminal.toggle", router);
+    });
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().activeInstanceId).toBe(
+        first.instanceId,
+      );
+    });
+    expect(useLandingTerminalStore.getState().tabs).toHaveLength(2);
+  });
+
+  it("leaves the open panel alone when the pinned folder changes without a reopen", async () => {
+    mocks.activeHostId = "host-a";
+    mocks.primaryWorkspacePath = "/workspace/project";
+    mocks.probeData = { sessions: [] };
+    mocks.freshProbeData = mocks.probeData;
+    useLandingTerminalStore.getState().setPanelOpen(true);
+    const view = render(panelUi());
+
+    await waitFor(() => {
+      expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    });
+    const first = useLandingTerminalStore.getState().tabs[0];
+
+    mocks.primaryWorkspacePath = "/workspace/other";
+    view.rerender(panelUi());
+
+    // The folder change re-runs reconciliation; it must not spawn or switch
+    // while the panel stays open - only a reopen re-targets the pinned folder.
+    await waitFor(() => {
+      expect(mocks.queryClient.fetchQuery).toHaveBeenCalledTimes(2);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useLandingTerminalStore.getState().tabs).toHaveLength(1);
+    expect(useLandingTerminalStore.getState().activeInstanceId).toBe(
+      first.instanceId,
+    );
   });
 });

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
@@ -37,6 +37,11 @@ import { usePickAndAddWorkspaceFolders } from "@/components/home/host-workspace-
 import type { WorktreeStagingKey } from "@/stores/worktree/worktree-intent-staging-store";
 import { workspaceMutationKeys } from "@/lib/query-keys";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
+import { focusActiveComposer } from "@/lib/composer/composer-focus-registry";
+import {
+  clearPendingTerminalFocus,
+  focusTerminalInstance,
+} from "@/lib/terminals/terminal-focus-registry";
 import { cn } from "@/lib/utils";
 import {
   DEFAULT_LANDING_TERMINAL_PANEL_WIDTH_FRACTION,
@@ -116,18 +121,111 @@ export function LandingTerminalPanel(
   const [maximized, setMaximized] = useState(false);
   const [reconciledHostId, setReconciledHostId] = useState<string | null>(null);
 
-  const createTerminalTab = useCallback(() => {
-    if (activeHostId === null || primaryWorkspacePath === null) return;
-    if (availability !== "supported") return;
+  // "This open gesture has not landed on the pinned folder yet." Armed on the
+  // closed->open transition, fulfilled by the first reconciliation pass that
+  // settles while open (against the folder pinned at THAT moment), and
+  // cancelled by collapse or by any manual panel interaction - once the user
+  // activates, creates, or closes a tab themselves, a late-settling pass (for
+  // example after the host recovers) must not yank them off their choice.
+  const panelOpenIntentRef = useRef(false);
+
+  const createTerminalTab = useCallback((): string | null => {
+    if (activeHostId === null || primaryWorkspacePath === null) return null;
+    if (availability !== "supported") return null;
+    const instanceId = `landing-terminal-${uuidv4()}`;
     addTab({
-      instanceId: `landing-terminal-${uuidv4()}`,
+      instanceId,
       sessionId: `landing-term-${uuidv4()}`,
       hostId: activeHostId,
       cwd: primaryWorkspacePath,
       name: workspaceFolderName(primaryWorkspacePath),
       titleSource: "default",
     });
+    return instanceId;
   }, [activeHostId, addTab, availability, primaryWorkspacePath]);
+
+  // A user-gesture create keeps the keyboard with the panel: the focus request
+  // parks in the registry until the new tile's xterm engine mounts.
+  const createTerminalTabFocused = useCallback(() => {
+    panelOpenIntentRef.current = false;
+    const instanceId = createTerminalTab();
+    if (instanceId !== null) focusTerminalInstance(instanceId);
+  }, [createTerminalTab]);
+
+  const activateTerminalTab = useCallback(
+    (instanceId: string) => {
+      panelOpenIntentRef.current = false;
+      activateTab(instanceId);
+      focusTerminalInstance(instanceId);
+    },
+    [activateTab],
+  );
+
+  // Focus follows the open/collapse *transition*, never the mount: a landing
+  // page that mounts with the panel already open (new tab, tab switch back)
+  // must leave focus with the composer. Opening also arms the pinned-folder
+  // intent that reconciliation consumes once the host's session list settles.
+  const prevPanelOpenRef = useRef(panelOpen);
+  useEffect(() => {
+    const wasOpen = prevPanelOpenRef.current;
+    prevPanelOpenRef.current = panelOpen;
+    if (wasOpen === panelOpen) return;
+    if (panelOpen) {
+      panelOpenIntentRef.current = true;
+      const activeInstanceId =
+        useLandingTerminalStore.getState().activeInstanceId;
+      if (activeInstanceId !== null) focusTerminalInstance(activeInstanceId);
+      return;
+    }
+    // Every collapse path converges on this store transition: the chord, the
+    // header button, closing the last tab, close-all, and a shell exiting.
+    // All of them should hand the keyboard back to the composer.
+    panelOpenIntentRef.current = false;
+    clearPendingTerminalFocus();
+    focusActiveComposer();
+  }, [panelOpen]);
+  useEffect(
+    () => () => {
+      clearPendingTerminalFocus();
+    },
+    [],
+  );
+
+  // Runs after every settled reconciliation pass (the reconciliation key
+  // includes the open/closed bit, so every panel-open transition lands here).
+  // Empty panels auto-spawn in the pinned folder; a gesture-opened panel
+  // additionally re-targets the pinned folder: reuse a terminal already
+  // running there, otherwise spawn a fresh one, and focus it either way.
+  const handleReconciliationSettled = useCallback(() => {
+    const state = useLandingTerminalStore.getState();
+    const openIntent = panelOpenIntentRef.current;
+    panelOpenIntentRef.current = false;
+    if (!state.panelOpen || primaryWorkspacePath === null) return;
+    if (state.tabs.length === 0) {
+      const created = createTerminalTab();
+      if (openIntent && created !== null) focusTerminalInstance(created);
+      return;
+    }
+    if (!openIntent || activeHostId === null) return;
+    const matchesPinnedFolder = (tab: LandingTerminalTabRef): boolean =>
+      tab.hostId === activeHostId && tab.cwd === primaryWorkspacePath;
+    const activeTab = state.tabs.find(
+      (tab) => tab.instanceId === state.activeInstanceId,
+    );
+    const target =
+      activeTab !== undefined && matchesPinnedFolder(activeTab)
+        ? activeTab
+        : state.tabs.find(matchesPinnedFolder);
+    if (target === undefined) {
+      const created = createTerminalTab();
+      if (created !== null) focusTerminalInstance(created);
+      return;
+    }
+    if (target.instanceId !== state.activeInstanceId) {
+      state.activateTab(target.instanceId);
+    }
+    focusTerminalInstance(target.instanceId);
+  }, [activeHostId, createTerminalTab, primaryWorkspacePath]);
 
   useLandingTerminalReconciliation({
     activeHostId,
@@ -135,18 +233,26 @@ export function LandingTerminalPanel(
     panelOpen,
     primaryWorkspacePath,
     client: defaultClient,
-    createTerminalTab,
     killTerminal: killTerminalAsync,
     onReconciled: setReconciledHostId,
+    onSettled: handleReconciliationSettled,
   });
 
   const closeTerminalTab = useCallback(
     (tab: LandingTerminalTabRef) => {
+      panelOpenIntentRef.current = false;
       // `closeTab` is the atomic tombstone-first durable write. Dispatch the
       // host mutation only after that state transition has completed.
       const closed = closeTab(tab.instanceId);
       if (closed === null) return;
       killTerminal({ hostId: closed.hostId, sessionId: closed.sessionId });
+      // Closing a non-last tab promotes a surviving neighbor - keep the
+      // keyboard with the panel. The last-tab case collapses the panel, and
+      // the open-transition effect hands focus back to the composer instead.
+      const state = useLandingTerminalStore.getState();
+      if (state.panelOpen && state.activeInstanceId !== null) {
+        focusTerminalInstance(state.activeInstanceId);
+      }
     },
     [closeTab, killTerminal],
   );
@@ -205,8 +311,8 @@ export function LandingTerminalPanel(
       onOpenPanel={openPanel}
       onToggleMaximized={() => setMaximized((value) => !value)}
       onSetPanelWidthFraction={setPanelWidthFraction}
-      onCreateTerminal={createTerminalTab}
-      onActivateTab={activateTab}
+      onCreateTerminal={createTerminalTabFocused}
+      onActivateTab={activateTerminalTab}
       onCloseTab={closeTerminalTab}
       onCloseAllTabs={closeAllTerminalTabs}
       onRenameTab={renameTab}

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
@@ -120,7 +120,6 @@ function LandingTerminalTileBootstrap(
     <LandingTerminalTileLive
       handle={bootstrap.handle}
       tab={props.tab}
-      active={props.active}
       onExited={removeExitedTab}
     />
   );
@@ -129,10 +128,9 @@ function LandingTerminalTileBootstrap(
 function LandingTerminalTileLive(props: {
   readonly handle: TerminalSessionStoreHandle;
   readonly tab: LandingTerminalTabRef;
-  readonly active: boolean;
   readonly onExited: (instanceId: string) => void;
 }): ReactNode {
-  const { handle, tab, active, onExited } = props;
+  const { handle, tab, onExited } = props;
   const status = useStore(handle.store, (state) => state.status);
   const effectiveCols = useStore(handle.store, (state) => state.effectiveCols);
   const effectiveRows = useStore(handle.store, (state) => state.effectiveRows);
@@ -175,7 +173,12 @@ function LandingTerminalTileLive(props: {
             onUserInput={handleInput}
             onContainerResize={handleResize}
             onWriterReady={handleWriter}
-            shouldFocusOnActivePane={active}
+            // Landing tiles stay mounted while the panel is collapsed, so a
+            // visibility-driven focus grab would fire on every landing-page
+            // mount (new tab, tab switch back) and steal the composer's focus.
+            // Focus moves here only through explicit gestures, routed via the
+            // terminal-focus registry by the panel.
+            shouldFocusOnActivePane={false}
             findTargetId={null}
             // Mirrors the registry's linger rule: while the session is live its
             // handle outlives this unmount (tab switch away from the landing

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -57,11 +57,17 @@ interface LandingTerminalReconciliationArgs {
   readonly panelOpen: boolean;
   readonly primaryWorkspacePath: string | null;
   readonly client: HostClient<HostRpcRegistry>;
-  readonly createTerminalTab: () => void;
   readonly killTerminal: (
     variables: LandingTerminalKillVariables,
   ) => Promise<unknown>;
   readonly onReconciled: (hostId: string) => void;
+  /**
+   * Runs after a reconciliation generation has fully applied (store updated,
+   * host id published). The panel owns what happens next - auto-spawning into
+   * an empty panel and honoring a pending open-gesture's pinned-folder intent -
+   * so those decisions always act on reconciled truth, never a stale cache.
+   */
+  readonly onSettled: () => void;
 }
 
 function landingTerminalListQueryOptions(client: HostClient<HostRpcRegistry>) {
@@ -100,9 +106,9 @@ export function useLandingTerminalReconciliation(
     panelOpen,
     primaryWorkspacePath,
     client,
-    createTerminalTab,
     killTerminal,
     onReconciled,
+    onSettled,
   } = args;
   const queryClient = useQueryClient();
   const [connectionEpoch, setConnectionEpoch] = useState(0);
@@ -216,15 +222,7 @@ export function useLandingTerminalReconciliation(
         reconciliation.collapseWhenEmpty,
       );
       onReconciled(activeHostId);
-
-      const reconciledState = useLandingTerminalStore.getState();
-      if (
-        reconciledState.panelOpen &&
-        reconciledState.tabs.length === 0 &&
-        primaryWorkspacePath !== null
-      ) {
-        createTerminalTab();
-      }
+      onSettled();
     })();
 
     return () => {
@@ -240,9 +238,9 @@ export function useLandingTerminalReconciliation(
     availability,
     client,
     connectionEpoch,
-    createTerminalTab,
     killTerminal,
     onReconciled,
+    onSettled,
     panelOpen,
     primaryWorkspacePath,
     queryClient,

--- a/clients/gui-app/src/components/notifications/message-square-question-mark.ts
+++ b/clients/gui-app/src/components/notifications/message-square-question-mark.ts
@@ -1,0 +1,21 @@
+import { createLucideIcon } from "lucide-react";
+
+/**
+ * Lucide's message-square-question-mark glyph, assembled locally: the installed
+ * lucide-react version does not ship it yet. Shared by the notification
+ * indicator icon and the chat tree's descendant-status rollup badge.
+ */
+export const MessageSquareQuestionMark = createLucideIcon(
+  "message-square-question-mark",
+  [
+    [
+      "path",
+      {
+        d: "M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z",
+        key: "18887p",
+      },
+    ],
+    ["path", { d: "M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3", key: "1u773s" }],
+    ["path", { d: "M12 17h.01", key: "p32p05" }],
+  ],
+);

--- a/clients/gui-app/src/components/notifications/notification-indicator-icon.tsx
+++ b/clients/gui-app/src/components/notifications/notification-indicator-icon.tsx
@@ -1,13 +1,11 @@
 import { type CSSProperties, type ReactNode } from "react";
-import {
-  createLucideIcon,
-  MessageSquareCheck,
-  MessageSquareWarning,
-  MessageSquareX,
-  type LucideIcon,
-} from "lucide-react";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import type { AgentSpinnerVariant } from "@/components/ui/agent-spinner-variant";
+import {
+  attentionTone,
+  DONE_TONE,
+  type IndicatorTone,
+} from "@/components/notifications/notification-indicator-tones";
 import type { NotificationIndicatorState } from "@/stores/notifications/notification-indicator-state";
 import { cn } from "@/lib/utils";
 
@@ -85,67 +83,6 @@ export function NotificationIndicatorIcon(
     );
   }
   return props.defaultIcon;
-}
-
-interface IndicatorTone {
-  readonly testId: "failure" | "interview" | "approval" | "done";
-  readonly title: string;
-  readonly className: string;
-  readonly Icon: LucideIcon;
-}
-
-const MessageSquareQuestionMark = createLucideIcon(
-  "message-square-question-mark",
-  [
-    [
-      "path",
-      {
-        d: "M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z",
-        key: "18887p",
-      },
-    ],
-    ["path", { d: "M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3", key: "1u773s" }],
-    ["path", { d: "M12 17h.01", key: "p32p05" }],
-  ],
-);
-
-const DONE_TONE: IndicatorTone = {
-  testId: "done",
-  title: "Task completed",
-  // `--success-foreground` (unlike `--success`) is verified >=3:1 against
-  // every preset's `--background`/`--canvas` - see index.css.
-  className: "text-success-foreground",
-  Icon: MessageSquareCheck,
-};
-
-const FAILURE_TONE: IndicatorTone = {
-  testId: "failure",
-  title: "Task needs attention",
-  className: "text-destructive",
-  Icon: MessageSquareX,
-};
-
-const INTERVIEW_TONE: IndicatorTone = {
-  testId: "interview",
-  title: "Task waiting for your interview response",
-  className: "text-warning-foreground",
-  Icon: MessageSquareQuestionMark,
-};
-
-const APPROVAL_TONE: IndicatorTone = {
-  testId: "approval",
-  title: "Task waiting for your approval",
-  className: "text-warning-foreground",
-  Icon: MessageSquareWarning,
-};
-
-function attentionTone(
-  state: NotificationIndicatorState,
-): IndicatorTone | null {
-  if (state.unreadFailure) return FAILURE_TONE;
-  if (state.pendingInterview) return INTERVIEW_TONE;
-  if (state.pendingApproval) return APPROVAL_TONE;
-  return null;
 }
 
 function IndicatorTonePresentation(props: {

--- a/clients/gui-app/src/components/notifications/notification-indicator-tones.ts
+++ b/clients/gui-app/src/components/notifications/notification-indicator-tones.ts
@@ -1,0 +1,62 @@
+import {
+  MessageSquareCheck,
+  MessageSquareWarning,
+  MessageSquareX,
+  type LucideIcon,
+} from "lucide-react";
+import { MessageSquareQuestionMark } from "@/components/notifications/message-square-question-mark";
+import type { NotificationIndicatorState } from "@/stores/notifications/notification-indicator-state";
+
+/**
+ * Shared presentation metadata for the notification status tiers. Both the
+ * per-row `NotificationIndicatorIcon` and the chat tree's descendant-status
+ * rollup badge derive their glyph and color from these, so the two surfaces
+ * cannot drift apart. `attentionTone` also encodes the attention-tier
+ * precedence (failure > interview > approval); the running and unread-done
+ * tiers slot in below it at each consumer per its activity signal.
+ */
+export interface IndicatorTone {
+  readonly testId: "failure" | "interview" | "approval" | "done";
+  readonly title: string;
+  readonly className: string;
+  readonly Icon: LucideIcon;
+}
+
+export const DONE_TONE: IndicatorTone = {
+  testId: "done",
+  title: "Task completed",
+  // `--success-foreground` (unlike `--success`) is verified >=3:1 against
+  // every preset's `--background`/`--canvas` - see index.css.
+  className: "text-success-foreground",
+  Icon: MessageSquareCheck,
+};
+
+export const FAILURE_TONE: IndicatorTone = {
+  testId: "failure",
+  title: "Task needs attention",
+  className: "text-destructive",
+  Icon: MessageSquareX,
+};
+
+export const INTERVIEW_TONE: IndicatorTone = {
+  testId: "interview",
+  title: "Task waiting for your interview response",
+  className: "text-warning-foreground",
+  Icon: MessageSquareQuestionMark,
+};
+
+export const APPROVAL_TONE: IndicatorTone = {
+  testId: "approval",
+  title: "Task waiting for your approval",
+  className: "text-warning-foreground",
+  Icon: MessageSquareWarning,
+};
+
+export function attentionTone(
+  state: NotificationIndicatorState,
+): IndicatorTone | null {
+  if (state.unreadFailure) return FAILURE_TONE;
+  if (state.pendingInterview) return INTERVIEW_TONE;
+  if (state.pendingApproval) return APPROVAL_TONE;
+  return null;
+}

--- a/clients/gui-app/src/lib/terminals/__tests__/terminal-focus-registry.test.ts
+++ b/clients/gui-app/src/lib/terminals/__tests__/terminal-focus-registry.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  focusTerminalInstance,
+  registerTerminalFocus,
+  resetTerminalFocusRegistryForTests,
+} from "../terminal-focus-registry";
+
+describe("terminal-focus-registry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    resetTerminalFocusRegistryForTests();
+    vi.useRealTimers();
+  });
+
+  it("fulfils a request for a mounted instance only after a macrotask, not synchronously", () => {
+    const focus = vi.fn();
+    registerTerminalFocus("a", focus);
+    focusTerminalInstance("a");
+    expect(focus).not.toHaveBeenCalled();
+    vi.runAllTimers();
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a still-scheduled fulfilment when a newer, not-yet-mounted instance is requested", () => {
+    const focusA = vi.fn();
+    registerTerminalFocus("a", focusA);
+    focusTerminalInstance("a");
+
+    // "b" has not mounted yet - this park must not let "a"'s already-scheduled
+    // timer fire later and steal focus back from the newer request.
+    focusTerminalInstance("b");
+    vi.runAllTimers();
+    expect(focusA).not.toHaveBeenCalled();
+
+    const focusB = vi.fn();
+    registerTerminalFocus("b", focusB);
+    vi.runAllTimers();
+    expect(focusB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/lib/terminals/terminal-focus-registry.ts
+++ b/clients/gui-app/src/lib/terminals/terminal-focus-registry.ts
@@ -1,0 +1,83 @@
+type TerminalFocusCallback = () => void;
+
+const focusCallbacks = new Map<string, TerminalFocusCallback>();
+let pendingInstanceId: string | null = null;
+let scheduledInstanceId: string | null = null;
+let scheduledTimer: number | null = null;
+
+/**
+ * Fulfilment is deferred one macrotask and last-wins. Requests typically
+ * arrive from event handlers that just flipped the active tab in the store -
+ * at that instant React has not committed the target wrapper's flip away from
+ * `invisible`, and browsers silently reject focus on a hidden element without
+ * retrying once it becomes visible. Deferring lands the focus after the
+ * commit; collapsing the panel cancels the deferred work via
+ * {@link clearPendingTerminalFocus} so a hidden terminal can never grab the
+ * keyboard back.
+ */
+function scheduleFocus(instanceId: string): void {
+  if (scheduledTimer !== null) window.clearTimeout(scheduledTimer);
+  scheduledInstanceId = instanceId;
+  scheduledTimer = window.setTimeout(() => {
+    scheduledTimer = null;
+    const target = scheduledInstanceId;
+    scheduledInstanceId = null;
+    if (target === null) return;
+    // The tile may have unmounted since the request (tab closed mid-flight);
+    // a vanished target simply drops the request rather than re-parking it.
+    focusCallbacks.get(target)?.();
+  }, 0);
+}
+
+/**
+ * Imperative focus bridge for mounted xterm hosts, keyed by tile instance id.
+ * Mirrors `composer-focus-registry`: surfaces that need to move keyboard focus
+ * into a terminal (the landing panel on expand, tab activation from the strip)
+ * request it here instead of threading refs through the tile tree. A request
+ * for an instance whose xterm engine has not mounted yet is parked and fires
+ * once on registration, so "create a tab, then focus it" works while the
+ * tile bootstrap is still in flight.
+ */
+export function registerTerminalFocus(
+  instanceId: string,
+  focus: TerminalFocusCallback,
+): () => void {
+  focusCallbacks.set(instanceId, focus);
+  if (pendingInstanceId === instanceId) {
+    pendingInstanceId = null;
+    scheduleFocus(instanceId);
+  }
+  return () => {
+    if (focusCallbacks.get(instanceId) === focus) {
+      focusCallbacks.delete(instanceId);
+    }
+  };
+}
+
+export function focusTerminalInstance(instanceId: string): void {
+  if (!focusCallbacks.has(instanceId)) {
+    pendingInstanceId = instanceId;
+    return;
+  }
+  pendingInstanceId = null;
+  scheduleFocus(instanceId);
+}
+
+/**
+ * Drops a parked focus request and cancels any deferred fulfilment, so a
+ * terminal that mounts later - or one revealed after the panel already
+ * collapsed - cannot steal focus from wherever the user moved it since.
+ */
+export function clearPendingTerminalFocus(): void {
+  pendingInstanceId = null;
+  scheduledInstanceId = null;
+  if (scheduledTimer !== null) {
+    window.clearTimeout(scheduledTimer);
+    scheduledTimer = null;
+  }
+}
+
+export function resetTerminalFocusRegistryForTests(): void {
+  focusCallbacks.clear();
+  clearPendingTerminalFocus();
+}

--- a/clients/gui-app/src/lib/terminals/terminal-focus-registry.ts
+++ b/clients/gui-app/src/lib/terminals/terminal-focus-registry.ts
@@ -56,6 +56,14 @@ export function registerTerminalFocus(
 
 export function focusTerminalInstance(instanceId: string): void {
   if (!focusCallbacks.has(instanceId)) {
+    // A still-scheduled fulfilment for an earlier request must not fire once
+    // a newer, not-yet-mounted instance has been requested - last-wins covers
+    // parked requests too.
+    scheduledInstanceId = null;
+    if (scheduledTimer !== null) {
+      window.clearTimeout(scheduledTimer);
+      scheduledTimer = null;
+    }
     pendingInstanceId = instanceId;
     return;
   }


### PR DESCRIPTION
## Summary

Two related fixes to the landing page terminal panel and chat sidebar:

**Landing terminal focus / folder fixes**
- Expanding the terminal (cmd+J or the toggle button) now moves keyboard focus into the terminal instead of leaving it in the composer.
- Closing the terminal or opening a new tab now returns focus to the composer.
- Reopening the terminal after changing the composer's pinned folder now reuses a terminal already running in that folder if one exists, else spawns a new one there.

Root cause for the focus issues: focusing synchronously from event handlers races the browser's rejection of `.focus()` on elements still hidden by the pre-commit visibility flip, with no retry. `terminal-focus-registry.ts` defers fulfilment one macrotask past the triggering event so the DOM has committed first.

**Chat descendant status rollup**
- A collapsed chat/agent tree node now surfaces a hidden descendant's notable status (needs attention, running, unread-done), mirroring the existing unread-artifact bubble-up.
- The parent's own icon slot merges its own status against the descendant rollup on one shared urgency ladder (failure > interview > approval > running > done); the more urgent side wins the slot, ties go to the parent, and a rollup that wins renders as the *same* status icon at reduced opacity rather than a new visual idiom — with a tooltip breakdown of per-tier descendant counts.

## Test plan

- [x] `bun run compile` — clean
- [x] `bun run lint` — clean
- [x] `bunx prettier --check` on touched files — clean
- [x] `npx react-doctor@latest . --verbose --scope changed --base HEAD --offline --no-score` — no issues
- [x] Full gui-app suite: 5,869 passed | 1 skipped
- [x] New/updated tests cover: focus-on-expand/collapse ordering (deferred, never synchronous), pinned-folder reopen (reuse vs. spawn), open-intent cancellation on manual interaction, descendant status rollup merge/urgency/tie-break semantics with tooltip breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)