### PR TITLE
feat(protocol): publish an agent's turn/background tier over epic awareness

### DIFF
--- a/clients/gui-app/src/hooks/epic/use-epic-activity-status.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-activity-status.ts
@@ -51,12 +51,20 @@ export function useEpicActivityStatus(
  * live agents for {@link useEpicActivityStatus}, or a node's descendant ids
  * for {@link useSubtreeChatActivityTier}.
  *
- * An open chat session is authoritative for its own tier (it has the full
- * snapshot). Everything else - a chat that was never opened, or one whose warm
- * session was evicted - is resolved from `activityTiers`, which reports
- * `"turn"` for any host that does not classify its agents. That keeps the
- * pre-existing conservative reading intact against an older host while letting
- * a newer one report background-only work accurately.
+ * An open chat session is authoritative for its own tier ONLY when it reads
+ * some activity - a local `"turn"`/`"background"` is never overridden by
+ * awareness, so the two tiers can't be re-conflated. A session reading idle is
+ * deliberately NOT treated as resolved: it still defers to awareness, which
+ * backfills the brief subscription-gap window where a genuinely running chat's
+ * store has not received its first snapshot yet (same rule as the per-chat icon
+ * in `chat-progress-icon.tsx`). Stale awareness is handled by `candidateIds`
+ * liveness, not by local idle.
+ *
+ * Everything else - a chat that was never opened, or one whose warm session was
+ * evicted - is resolved from `activityTiers`, which reports `"turn"` for any
+ * host that does not classify its agents. That keeps the pre-existing
+ * conservative reading intact against an older host while letting a newer one
+ * report background-only work accurately.
  */
 function getChatSessionActivity(
   epicId: string | null,

--- a/clients/gui-app/src/hooks/epic/use-epic-activity-status.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-activity-status.ts
@@ -1,7 +1,8 @@
 import { useCallback, useSyncExternalStore } from "react";
 import {
-  useRegisteredEpicActiveAgentIds,
+  useRegisteredEpicAgentActivityTiers,
   useRegisteredEpicLiveAgentIds,
+  type AgentActivityTier,
 } from "@/lib/epic-selectors";
 import { getChatSessionRegistry } from "@/lib/registries/chat-session-registry";
 import { reconcileStoreSubscriptions } from "@/lib/registries/reconcile-store-subscriptions";
@@ -25,16 +26,16 @@ export type EpicActivityStatus = "idle" | "turn" | "background";
 export function useEpicActivityStatus(
   epicId: string | null,
 ): EpicActivityStatus {
-  const activeAgentIds = useRegisteredEpicActiveAgentIds(epicId);
+  const activityTiers = useRegisteredEpicAgentActivityTiers(epicId);
   const liveAgentIds = useRegisteredEpicLiveAgentIds(epicId);
   const subscribeLocalChatActivity = useCallback(
     (onChange: () => void) =>
-      subscribeEpicChatSessionActivity(epicId, liveAgentIds, onChange),
+      subscribeChatSessionActivity(epicId, liveAgentIds, onChange),
     [epicId, liveAgentIds],
   );
   const getLocalChatActivity = useCallback(
-    () => getEpicChatSessionActivity(epicId, activeAgentIds, liveAgentIds),
-    [activeAgentIds, epicId, liveAgentIds],
+    () => getChatSessionActivity(epicId, activityTiers, liveAgentIds),
+    [activityTiers, epicId, liveAgentIds],
   );
   return useSyncExternalStore(
     subscribeLocalChatActivity,
@@ -44,20 +45,30 @@ export function useEpicActivityStatus(
 }
 
 /**
- * Reads session activity first, then conservatively treats an unresolved
- * awareness signal as a turn while its chat subscription catches up.
+ * Reads session activity across a candidate set of chat ids, falling back to
+ * the host-published awareness tier for agents whose session state did not
+ * resolve locally. `candidateIds` scopes the aggregation: the whole epic's
+ * live agents for {@link useEpicActivityStatus}, or a node's descendant ids
+ * for {@link useSubtreeChatActivityTier}.
+ *
+ * An open chat session is authoritative for its own tier (it has the full
+ * snapshot). Everything else - a chat that was never opened, or one whose warm
+ * session was evicted - is resolved from `activityTiers`, which reports
+ * `"turn"` for any host that does not classify its agents. That keeps the
+ * pre-existing conservative reading intact against an older host while letting
+ * a newer one report background-only work accurately.
  */
-function getEpicChatSessionActivity(
+function getChatSessionActivity(
   epicId: string | null,
-  activeAgentIds: ReadonlySet<string>,
-  liveAgentIds: ReadonlySet<string>,
+  activityTiers: ReadonlyMap<string, AgentActivityTier>,
+  candidateIds: ReadonlySet<string>,
 ): EpicActivityStatus {
   if (epicId === null) return "idle";
   let hasBackgroundActivity = false;
   const locallyResolvedAgentIds = new Set<string>();
   for (const handle of CHAT_REGISTRY.listHandles()) {
     if (handle.epicId !== epicId) continue;
-    if (!liveAgentIds.has(handle.chatId)) continue;
+    if (!candidateIds.has(handle.chatId)) continue;
     const activity = chatSessionActivity(handle.store.getState());
     if (activity === "turn") return "turn";
     if (activity === "background") {
@@ -65,26 +76,28 @@ function getEpicChatSessionActivity(
       locallyResolvedAgentIds.add(handle.chatId);
     }
   }
-  const hasUnresolvedActiveAgent = [...activeAgentIds].some(
-    (id) => liveAgentIds.has(id) && !locallyResolvedAgentIds.has(id),
-  );
-  if (hasUnresolvedActiveAgent) return "turn";
+  for (const [agentId, tier] of activityTiers) {
+    if (!candidateIds.has(agentId)) continue;
+    if (locallyResolvedAgentIds.has(agentId)) continue;
+    if (tier === "turn") return "turn";
+    hasBackgroundActivity = true;
+  }
   return hasBackgroundActivity ? "background" : "idle";
 }
 
-/** Subscribes only to live chats belonging to this epic. */
-function subscribeEpicChatSessionActivity(
+/** Subscribes only to live chats in `candidateIds` belonging to this epic. */
+function subscribeChatSessionActivity(
   epicId: string | null,
-  liveAgentIds: ReadonlySet<string>,
+  candidateIds: ReadonlySet<string>,
   onChange: () => void,
 ): () => void {
-  if (epicId === null) return noopUnsubscribe;
+  if (epicId === null || candidateIds.size === 0) return noopUnsubscribe;
   const handleSubs = new Map<ChatSessionStoreHandle, () => void>();
 
   const resync = (): void => {
     reconcileStoreSubscriptions(
       CHAT_REGISTRY.listHandles().filter(
-        (handle) => handle.epicId === epicId && liveAgentIds.has(handle.chatId),
+        (handle) => handle.epicId === epicId && candidateIds.has(handle.chatId),
       ),
       handleSubs,
       (handle) => {
@@ -110,7 +123,7 @@ function subscribeEpicChatSessionActivity(
   };
 }
 
-/** Projects the chat session's indicator tier for task-level aggregation. */
+/** Projects the chat session's indicator tier for aggregation. */
 function chatSessionActivity(state: ChatSessionState): ChatActivityIndicator {
   return chatActivityIndicator(state);
 }

--- a/clients/gui-app/src/lib/__tests__/agent-activity-tiers-awareness.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/agent-activity-tiers-awareness.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  AGENT_WORKING_AWARENESS_FIELD,
+  AGENT_WORKING_TURN_AWARENESS_FIELD,
+} from "@traycer/protocol/host/epic/subscribe";
+import { useRegisteredEpicAgentActivityTiers } from "@/lib/epic-selectors";
+import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
+import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+
+const EPIC_ID = "epic-awareness";
+
+/**
+ * One awareness entry per host, exactly as the cloud merges them. Each entry
+ * independently decides whether it carries the turn field, which is the whole
+ * point of these tests: mixed shapes are the steady state, not a rollout
+ * window.
+ */
+type HostEntry = {
+  readonly working: unknown;
+  readonly turn: unknown;
+};
+
+function buildEpicHandle(entries: readonly HostEntry[]): OpenEpicStoreHandle {
+  const state = { bindingVersion: 0 };
+  const storeCallable = (_selector: unknown): unknown => state;
+  const storeBase: unknown = Object.assign(storeCallable, {
+    getState: () => state as never,
+    subscribe: () => () => undefined,
+  });
+  const awareness = {
+    getStates: () =>
+      new Map<number, Record<string, unknown>>(
+        entries.map((entry, index) => [
+          index,
+          entry.turn === undefined
+            ? { [AGENT_WORKING_AWARENESS_FIELD]: entry.working }
+            : {
+                [AGENT_WORKING_AWARENESS_FIELD]: entry.working,
+                [AGENT_WORKING_TURN_AWARENESS_FIELD]: entry.turn,
+              },
+        ]),
+      ),
+    on: () => undefined,
+    off: () => undefined,
+  };
+  return {
+    epicId: EPIC_ID,
+    userId: null,
+    doc: {} as never,
+    awareness: awareness as never,
+    store: storeBase as OpenEpicStoreHandle["store"],
+    dispose: () => undefined,
+    requestFreshSnapshot: () => undefined,
+    isClean: () => true,
+  };
+}
+
+function renderTiers(entries: readonly HostEntry[]) {
+  __getOpenEpicRegistryForTests().acquire(EPIC_ID, () =>
+    buildEpicHandle(entries),
+  );
+  return renderHook(() => useRegisteredEpicAgentActivityTiers(EPIC_ID));
+}
+
+afterEach(() => {
+  __getOpenEpicRegistryForTests().disposeAll();
+});
+
+describe("agent activity tiers from awareness", () => {
+  it("resolves every working id to 'turn' for a host that omits the turn field", () => {
+    // An older host: no `agentWorkingTurn` at all. Its agents are unclassified,
+    // so they must keep the pre-existing conservative reading.
+    const { result } = renderTiers([{ working: ["a", "b"], turn: undefined }]);
+    expect(result.current.get("a")).toBe("turn");
+    expect(result.current.get("b")).toBe("turn");
+  });
+
+  it("splits turn from background for a host that publishes the turn field", () => {
+    const { result } = renderTiers([{ working: ["a", "b"], turn: ["a"] }]);
+    expect(result.current.get("a")).toBe("turn");
+    // Working but absent from the turn list => genuinely background-only.
+    expect(result.current.get("b")).toBe("background");
+  });
+
+  it("treats an empty turn list as 'all background', not as absent", () => {
+    const { result } = renderTiers([{ working: ["a"], turn: [] }]);
+    expect(result.current.get("a")).toBe("background");
+  });
+
+  it("applies the absence rule per host, not globally", () => {
+    // Old host and new host visible at the same time. The old host's agent
+    // must NOT be downgraded to background just because another host
+    // publishes the field.
+    const { result } = renderTiers([
+      { working: ["old"], turn: undefined },
+      { working: ["new-turn", "new-bg"], turn: ["new-turn"] },
+    ]);
+    expect(result.current.get("old")).toBe("turn");
+    expect(result.current.get("new-turn")).toBe("turn");
+    expect(result.current.get("new-bg")).toBe("background");
+  });
+
+  it("lets 'turn' win when the same agent appears under two hosts", () => {
+    const { result } = renderTiers([
+      { working: ["shared"], turn: [] },
+      { working: ["shared"], turn: ["shared"] },
+    ]);
+    expect(result.current.get("shared")).toBe("turn");
+  });
+
+  it("ignores entries whose agentWorking is not an array", () => {
+    const { result } = renderTiers([
+      { working: { not: "an array" }, turn: ["x"] },
+      { working: ["real"], turn: undefined },
+    ]);
+    expect(result.current.has("x")).toBe(false);
+    expect(result.current.get("real")).toBe("turn");
+  });
+
+  it("ignores a malformed turn field by falling back to 'turn'", () => {
+    // Not an array => unreadable => treat as absent (conservative), rather
+    // than dropping the agent or calling it background.
+    const { result } = renderTiers([{ working: ["a"], turn: "nonsense" }]);
+    expect(result.current.get("a")).toBe("turn");
+  });
+
+  it("filters non-string ids on both fields", () => {
+    const { result } = renderTiers([
+      { working: ["a", 7, null], turn: ["a", 9] },
+    ]);
+    expect(result.current.size).toBe(1);
+    expect(result.current.get("a")).toBe("turn");
+  });
+});

--- a/clients/gui-app/src/lib/__tests__/agent-activity-tiers-awareness.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/agent-activity-tiers-awareness.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import {
   AGENT_WORKING_AWARENESS_FIELD,
   AGENT_WORKING_TURN_AWARENESS_FIELD,
@@ -21,29 +21,60 @@ type HostEntry = {
   readonly turn: unknown;
 };
 
-function buildEpicHandle(entries: readonly HostEntry[]): OpenEpicStoreHandle {
+function awarenessStates(
+  entries: readonly HostEntry[],
+): Map<number, Record<string, unknown>> {
+  return new Map<number, Record<string, unknown>>(
+    entries.map((entry, index) => [
+      index,
+      entry.turn === undefined
+        ? { [AGENT_WORKING_AWARENESS_FIELD]: entry.working }
+        : {
+            [AGENT_WORKING_AWARENESS_FIELD]: entry.working,
+            [AGENT_WORKING_TURN_AWARENESS_FIELD]: entry.turn,
+          },
+    ]),
+  );
+}
+
+/**
+ * A real emitter, not a no-op stub: `on`/`off` register listeners and
+ * `publish` fires them, so a test can mutate awareness and assert the hook
+ * re-subscribes, recomputes, and re-renders - covering the subscription wiring
+ * and not just the first snapshot.
+ */
+function buildAwarenessEmitter(initial: readonly HostEntry[]) {
+  const listeners = new Set<() => void>();
+  let states = awarenessStates(initial);
+  let onCalls = 0;
+  let offCalls = 0;
+  return {
+    awareness: {
+      getStates: () => states,
+      on: (_event: string, listener: () => void) => {
+        onCalls += 1;
+        listeners.add(listener);
+      },
+      off: (_event: string, listener: () => void) => {
+        offCalls += 1;
+        listeners.delete(listener);
+      },
+    },
+    publish: (next: readonly HostEntry[]) => {
+      states = awarenessStates(next);
+      for (const listener of listeners) listener();
+    },
+    subscribeBalance: () => ({ onCalls, offCalls }),
+  };
+}
+
+function buildEpicHandle(awareness: unknown): OpenEpicStoreHandle {
   const state = { bindingVersion: 0 };
   const storeCallable = (_selector: unknown): unknown => state;
   const storeBase: unknown = Object.assign(storeCallable, {
     getState: () => state as never,
     subscribe: () => () => undefined,
   });
-  const awareness = {
-    getStates: () =>
-      new Map<number, Record<string, unknown>>(
-        entries.map((entry, index) => [
-          index,
-          entry.turn === undefined
-            ? { [AGENT_WORKING_AWARENESS_FIELD]: entry.working }
-            : {
-                [AGENT_WORKING_AWARENESS_FIELD]: entry.working,
-                [AGENT_WORKING_TURN_AWARENESS_FIELD]: entry.turn,
-              },
-        ]),
-      ),
-    on: () => undefined,
-    off: () => undefined,
-  };
   return {
     epicId: EPIC_ID,
     userId: null,
@@ -57,10 +88,14 @@ function buildEpicHandle(entries: readonly HostEntry[]): OpenEpicStoreHandle {
 }
 
 function renderTiers(entries: readonly HostEntry[]) {
+  const emitter = buildAwarenessEmitter(entries);
   __getOpenEpicRegistryForTests().acquire(EPIC_ID, () =>
-    buildEpicHandle(entries),
+    buildEpicHandle(emitter.awareness),
   );
-  return renderHook(() => useRegisteredEpicAgentActivityTiers(EPIC_ID));
+  return {
+    ...renderHook(() => useRegisteredEpicAgentActivityTiers(EPIC_ID)),
+    emitter,
+  };
 }
 
 afterEach(() => {
@@ -131,5 +166,40 @@ describe("agent activity tiers from awareness", () => {
     ]);
     expect(result.current.size).toBe(1);
     expect(result.current.get("a")).toBe("turn");
+  });
+
+  it("re-renders with the new tier when awareness changes", () => {
+    // Drives the real subscription path: the hook must re-read the snapshot on
+    // an awareness "change" event, not just on first render.
+    const { result, emitter } = renderTiers([{ working: ["a"], turn: ["a"] }]);
+    expect(result.current.get("a")).toBe("turn");
+
+    // The turn ends but a background task keeps the agent working.
+    act(() => {
+      emitter.publish([{ working: ["a"], turn: [] }]);
+    });
+    expect(result.current.get("a")).toBe("background");
+
+    // The agent goes fully idle.
+    act(() => {
+      emitter.publish([{ working: [], turn: [] }]);
+    });
+    expect(result.current.has("a")).toBe(false);
+  });
+
+  it("keeps the same Map ref when a change leaves tiers untouched", () => {
+    // Ref stability is what lets useSyncExternalStore bail the re-render; an
+    // unrelated awareness event must not churn every consumer.
+    const { result, emitter } = renderTiers([{ working: ["a"], turn: ["a"] }]);
+    const first = result.current;
+    act(() => {
+      emitter.publish([{ working: ["a"], turn: ["a"] }]);
+    });
+    expect(result.current).toBe(first);
+  });
+
+  it("subscribes to awareness while mounted", () => {
+    const { emitter } = renderTiers([{ working: ["a"], turn: ["a"] }]);
+    expect(emitter.subscribeBalance().onCalls).toBeGreaterThan(0);
   });
 });

--- a/clients/gui-app/src/lib/epic-selectors.ts
+++ b/clients/gui-app/src/lib/epic-selectors.ts
@@ -32,7 +32,10 @@ import type { PermissionRole } from "@traycer/protocol/host/epic/unary-schemas";
 import type { TuiHarnessId } from "@traycer/protocol/persistence/epic/schemas";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
 import type { SnapshotMetaEpic } from "@traycer/protocol/host/epic/snapshot-meta";
-import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
+import {
+  AGENT_WORKING_AWARENESS_FIELD,
+  AGENT_WORKING_TURN_AWARENESS_FIELD,
+} from "@traycer/protocol/host/epic/subscribe";
 import type { StreamConnectionStatus } from "@traycer-clients/shared/host-transport/i-stream-session";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@/lib/host";
@@ -701,6 +704,24 @@ const activeAgentIdsCache = new WeakMap<
   Awareness,
   { readonly ids: ReadonlySet<string>; readonly key: string }
 >();
+
+/**
+ * Live-activity tier of a working agent, as published by its host. See
+ * {@link AGENT_WORKING_TURN_AWARENESS_FIELD}: hosts that do not publish the
+ * turn field leave their agents' tier unknown, which reads as `"turn"`.
+ */
+export type AgentActivityTier = "turn" | "background";
+
+const EMPTY_AGENT_ACTIVITY_TIERS: ReadonlyMap<string, AgentActivityTier> =
+  new Map<string, AgentActivityTier>();
+
+const agentActivityTiersCache = new WeakMap<
+  Awareness,
+  {
+    readonly tiers: ReadonlyMap<string, AgentActivityTier>;
+    readonly key: string;
+  }
+>();
 const registeredLiveAgentIdsCache = new WeakMap<
   OpenEpicStoreHandle,
   { readonly ids: ReadonlySet<string>; readonly key: string }
@@ -726,6 +747,54 @@ function activeAgentIdsSnapshot(awareness: Awareness): ReadonlySet<string> {
   const entry = { ids, key };
   activeAgentIdsCache.set(awareness, entry);
   return entry.ids;
+}
+
+/**
+ * Same union as {@link activeAgentIdsSnapshot}, but resolving each working
+ * agent to its {@link AgentActivityTier}.
+ *
+ * The turn field is read PER AWARENESS ENTRY (one entry per host) because its
+ * presence is per-host, and mixed shapes are the steady state rather than a
+ * rollout window - see `AGENT_WORKING_TURN_AWARENESS_FIELD`. A host that omits
+ * it has not classified its agents, so they stay `"turn"` (the conservative
+ * pre-existing reading); a host that publishes it is authoritative, so its
+ * working ids absent from that list are genuinely background-only.
+ *
+ * `"turn"` wins when the same agent appears under two hosts. Returns the prior
+ * Map ref while membership AND tiers are unchanged so `useSyncExternalStore`
+ * sees a referentially-stable snapshot.
+ */
+function agentActivityTiersSnapshot(
+  awareness: Awareness,
+): ReadonlyMap<string, AgentActivityTier> {
+  const tiers = new Map<string, AgentActivityTier>();
+  for (const state of awareness.getStates().values()) {
+    const working: unknown = state[AGENT_WORKING_AWARENESS_FIELD];
+    if (!Array.isArray(working)) continue;
+    const turnField: unknown = state[AGENT_WORKING_TURN_AWARENESS_FIELD];
+    const turnIds = Array.isArray(turnField)
+      ? new Set(
+          (turnField as readonly unknown[]).filter(
+            (id): id is string => typeof id === "string",
+          ),
+        )
+      : null;
+    for (const id of working as readonly unknown[]) {
+      if (typeof id !== "string") continue;
+      const tier: AgentActivityTier =
+        turnIds === null || turnIds.has(id) ? "turn" : "background";
+      if (tier === "turn" || !tiers.has(id)) tiers.set(id, tier);
+    }
+  }
+  const key = [...tiers.entries()]
+    .map(([id, tier]) => `${id}:${tier}`)
+    .sort()
+    .join(" ");
+  const cached = agentActivityTiersCache.get(awareness);
+  if (cached !== undefined && cached.key === key) return cached.tiers;
+  const entry = { tiers, key };
+  agentActivityTiersCache.set(awareness, entry);
+  return entry.tiers;
 }
 
 /**
@@ -755,6 +824,38 @@ export function useEpicActiveAgentIds(): ReadonlySet<string> {
     subscribe,
     getSnapshot,
     () => EMPTY_ACTIVE_AGENT_IDS,
+  );
+}
+
+/**
+ * {@link useEpicActiveAgentIds} with each working agent resolved to its
+ * {@link AgentActivityTier}. Prefer this when the caller distinguishes an
+ * active turn from background-only work; the id set alone cannot.
+ */
+export function useEpicAgentActivityTiers(): ReadonlyMap<
+  string,
+  AgentActivityTier
+> {
+  const handle = useOpenEpicHandle();
+  useStore(handle.store, (s) => s.bindingVersion); // re-resolve on replica swap
+  const awareness = handle.awareness;
+  const subscribe = useMemo(
+    () => (onChange: () => void) => {
+      awareness.on("change", onChange);
+      return () => {
+        awareness.off("change", onChange);
+      };
+    },
+    [awareness],
+  );
+  const getSnapshot = useMemo(
+    () => () => agentActivityTiersSnapshot(awareness),
+    [awareness],
+  );
+  return useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    () => EMPTY_AGENT_ACTIVITY_TIERS,
   );
 }
 
@@ -798,6 +899,54 @@ export function useRegisteredEpicActiveAgentIds(
     subscribe,
     getSnapshot,
     () => EMPTY_ACTIVE_AGENT_IDS,
+  );
+}
+
+/**
+ * {@link useRegisteredEpicActiveAgentIds} with each working agent resolved to
+ * its {@link AgentActivityTier}, for surfaces that run outside the open-epic
+ * provider (epic tabs, the epic list).
+ */
+export function useRegisteredEpicAgentActivityTiers(
+  epicId: string | null,
+): ReadonlyMap<string, AgentActivityTier> {
+  const registry = getOpenEpicRegistry();
+  const handle = useSyncExternalStore(
+    (listener) => registry.subscribe(listener),
+    () => (epicId === null ? null : registry.peek(epicId)),
+    () => null,
+  );
+  useSyncExternalStore(
+    (listener) =>
+      handle?.store.subscribe((state, prev) => {
+        if (state.bindingVersion === prev.bindingVersion) return;
+        listener();
+      }) ?? noopSubscribe,
+    () => handle?.store.getState().bindingVersion ?? 0,
+    () => 0,
+  );
+  const awareness = handle?.awareness ?? null;
+  const subscribe = useMemo(
+    () => (onChange: () => void) => {
+      if (awareness === null) return noopUnsubscribe;
+      awareness.on("change", onChange);
+      return () => {
+        awareness.off("change", onChange);
+      };
+    },
+    [awareness],
+  );
+  const getSnapshot = useMemo(
+    () => () =>
+      awareness === null
+        ? EMPTY_AGENT_ACTIVITY_TIERS
+        : agentActivityTiersSnapshot(awareness),
+    [awareness],
+  );
+  return useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    () => EMPTY_AGENT_ACTIVITY_TIERS,
   );
 }
 

--- a/protocol/src/host/epic/subscribe.ts
+++ b/protocol/src/host/epic/subscribe.ts
@@ -64,6 +64,39 @@ import {
  * here so writer and reader cannot drift.
  */
 export const AGENT_WORKING_AWARENESS_FIELD = "agentWorking";
+
+/**
+ * Awareness state field under which each host publishes the subset of its
+ * {@link AGENT_WORKING_AWARENESS_FIELD} ids whose work is an actual agent
+ * **turn** (running or activating), as opposed to background-only work
+ * (`run_in_background` / a subagent / Monitor / a scheduled wakeup) that keeps
+ * a session non-idle while the agent itself is not executing.
+ *
+ * Additive and OPTIONAL by design. Awareness rides an opaque binary payload
+ * (the `awareness` frame is `hasBinaryPayload: true`), so this value is NOT
+ * schema-validated and is NOT covered by the stream contract's
+ * `major`/`minor` negotiation - a reader cannot learn from the handshake
+ * whether its peer publishes this field. Two rules follow, and both are
+ * load-bearing:
+ *
+ * 1. NEVER change the shape of `agentWorking` itself. Existing readers do
+ *    `Array.isArray(...)` on it and skip the whole entry otherwise, so
+ *    repurposing it makes agents silently vanish from the working set on older
+ *    clients.
+ * 2. Absence is per-HOST, and must be read that way. Cloud-merged awareness
+ *    carries one entry per host, so a single client can see an old host (field
+ *    absent) and a new host (field present) simultaneously - indefinitely, not
+ *    just during a rollout. Readers must therefore decide per entry:
+ *      - field absent  -> tier unknown for that host; treat its working ids
+ *                         conservatively as turns (the pre-existing behaviour).
+ *      - field present -> ids listed here are turns; working ids NOT listed
+ *                         here are genuinely background-only.
+ *
+ * Because "turn" is the conservative default, a publisher only needs to list
+ * ids it can positively classify; agents with no turn/background distinction
+ * (terminal agents, CLI/TUI runs) simply stay in the turn set.
+ */
+export const AGENT_WORKING_TURN_AWARENESS_FIELD = "agentWorkingTurn";
 import { getRecordSchema } from "@traycer/protocol/framework/index";
 import { commonRecordRegistry } from "@traycer/protocol/common/registry";
 


### PR DESCRIPTION
## Problem

Epic awareness carries **one bit per agent**. `agentWorking` is fed by the host's `hasInProgressWork()`, which unions an active turn, a runnable queue, **and** background-only work (`run_in_background` / a subagent / Monitor / a scheduled wakeup). So a reader cannot tell *"the agent is executing"* from *"a background task is ticking over while the agent sits idle"*.

That distinction does exist per chat — but only inside `chat.subscribe` snapshot state (`turnInProgress` / `backgroundItems`), which needs an open (or still-warm, ≤6, ≤10min) chat session. It is therefore unavailable for exactly the chats a rollup cares about: the ones nobody has opened.

Concretely, the descendant status rollup added in #420 correctly avoids loading chats and reads awareness instead — which is the right call, but it means its `running` tier is that single bit and can never split turn from background. No client-side change can fix that; the data isn't on the wire.

## Change

Add `agentWorkingTurn`: the subset of `agentWorking` whose work is a real turn.

**This field is not schema-validated and is not covered by major/minor.** The `awareness` frame is `hasBinaryPayload: z.literal(true)`, so the payload is an opaque Y.js blob the protocol machinery never inspects — I verified this by dumping the protocol surface (`dump-protocol-surface.ts`): neither `agentWorking` nor `agentWorkingTurn` appears anywhere in it. A reader therefore cannot learn from the handshake whether its peer publishes the field, so the field is additive/optional and **the reader carries the entire compatibility burden**:

- **`agentWorking` keeps its exact shape.** Existing readers `Array.isArray` it and skip the whole entry otherwise, so repurposing it would make agents *silently vanish* from the working set on older clients.
- **Absence is resolved per awareness entry, i.e. per host.** Cloud-merged awareness carries one entry per host, so a client can see an old host (field absent) and a new host (field present) **at the same time, indefinitely** — not just while a rollout drains. A global "does anyone publish this?" check would wrongly downgrade an unclassified host's agents to background.
- **"turn" is the conservative default.** A host that doesn't classify an agent omits the field, and its working ids keep reading as turns — exactly today's behaviour.

Client side, `agentActivityTiersSnapshot` resolves the union to `Map<agentId, "turn" | "background">` under those rules (turn wins if the same agent appears under two hosts), exposed as `useEpicAgentActivityTiers` / `useRegisteredEpicAgentActivityTiers` with the same ref-stability caching as the existing id-set snapshot.

`useEpicActivityStatus` now resolves agents with no locally-open session from that tier instead of assuming a turn — so the **epic tab** and the **task list** stop reporting background-only work as an active turn.

## Coordination

The host-side publisher is implemented in the internal repo (tracker `turnWorkingAgentIds` + `setBackgroundOnly`, published alongside `agentWorking` with identical `(epicId, userId)` scoping). It imports `AGENT_WORKING_TURN_AWARENESS_FIELD` from here, so **this PR is its blocking dependency** and must land first — which is also the correct rollout order: tolerant reader before publisher, never the reverse.

Follow-up (not in this PR): feed the tier into #420's `useChatDescendantStatus` so its `running` tier splits into turn vs background. That touches @hdkshingala's just-merged rollup design (new status kind, ranks, tones, tooltip), so it deserves its own PR.

## Test plan

- [x] `bun run compile` (gui-app + protocol) — clean
- [x] `bun run lint` — clean
- [x] pre-commit `build · compile · lint · format (nx affected)` — passed
- [x] 106 tests green across the awareness reader, tab-strip, epics-list, and sidebar selection-mode suites
- [x] New `agent-activity-tiers-awareness.test.tsx` pins the compat contract: old host (absent → turn), new host (split), **mixed hosts simultaneously**, turn-wins-across-hosts, empty list ≠ absent, plus three malformed-input cases