### PR TITLE
feat(gui-app): split the descendant rollup's running tier into turn vs background

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -65,6 +65,7 @@ interface TestState {
   records: readonly TestRecord[];
   indicatorChats: Readonly<Record<string, TestIndicatorState>>;
   activeAgentIds: ReadonlySet<string>;
+  activityTierById: Map<string, "turn" | "background">;
   permissionRole: "owner" | "editor" | "viewer" | null;
   rowHostId: string | null;
   rowHostEntry: unknown;
@@ -104,6 +105,7 @@ const testState = vi.hoisted<TestState>(() => ({
   records: [],
   indicatorChats: {},
   activeAgentIds: new Set<string>(),
+  activityTierById: new Map<string, "turn" | "background">(),
   permissionRole: "owner",
   rowHostId: "host-1",
   rowHostEntry: { hostId: "host-1" },
@@ -411,6 +413,16 @@ vi.mock("@/lib/epic-selectors", () => ({
   useChildIds: (parentId: string) =>
     testState.tree.childrenByParent[parentId] ?? [],
   useEpicActiveAgentIds: () => testState.activeAgentIds,
+  // Awareness reports a tier per working agent. An agent whose host did not
+  // classify it reads as "turn", so tests that only set `activeAgentIds` keep
+  // their pre-tier behaviour.
+  useEpicAgentActivityTiers: () =>
+    new Map(
+      [...testState.activeAgentIds].map((id) => [
+        id,
+        testState.activityTierById.get(id) ?? "turn",
+      ]),
+    ),
   useEpicArtifact: (artifactId: string | null) => {
     if (artifactId === null) return null;
     const node = testState.tree.nodeById[artifactId];
@@ -548,6 +560,7 @@ describe("epic sidebar selection mode", () => {
     testState.records = [];
     testState.indicatorChats = {};
     testState.activeAgentIds = new Set<string>();
+    testState.activityTierById = new Map();
     testState.permissionRole = "owner";
     testState.rowHostId = "host-1";
     testState.rowHostEntry = { hostId: "host-1" };
@@ -1168,6 +1181,7 @@ describe("chat descendant status rollup", () => {
     testState.records = [];
     testState.indicatorChats = {};
     testState.activeAgentIds = new Set<string>();
+    testState.activityTierById = new Map();
     testState.chatFilterOrigin = "all";
   });
 
@@ -1334,6 +1348,7 @@ describe("chat descendant status rollup", () => {
 
     // Equal tiers: the tie goes to the parent's own (solid) presentation.
     testState.activeAgentIds = new Set<string>();
+    testState.activityTierById = new Map();
     testState.indicatorChats = {
       "chat-root": indicator({ pendingApproval: true }),
       "chat-grandchild": indicator({ pendingApproval: true }),
@@ -1345,6 +1360,71 @@ describe("chat descendant status rollup", () => {
       screen.queryByTestId("chat-descendant-status-approval-chat-root"),
     ).toBeNull();
     expect(screen.getByTestId("chat-sidebar-spinner")).toBeTruthy();
+  });
+
+  it("distinguishes a background-only descendant from one mid-turn", () => {
+    seedNestedChatTree();
+    // The grandchild is non-idle, but only because a background task
+    // (run_in_background / Monitor / a scheduled wakeup) is keeping it alive -
+    // the agent itself is not executing. Before the awareness tier existed
+    // this was indistinguishable from a live turn.
+    testState.activeAgentIds = new Set(["chat-grandchild"]);
+    testState.activityTierById = new Map([["chat-grandchild", "background"]]);
+
+    const view = render(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.getByTestId("chat-descendant-status-background-chat-root"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByTestId("chat-descendant-status-running-chat-root"),
+    ).toBeNull();
+
+    // Same descendant, now genuinely mid-turn: the busier tier takes the slot.
+    testState.activityTierById = new Map([["chat-grandchild", "turn"]]);
+    view.rerender(
+      <EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />,
+    );
+    expect(
+      screen.getByTestId("chat-descendant-status-running-chat-root"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByTestId("chat-descendant-status-background-chat-root"),
+    ).toBeNull();
+  });
+
+  it("ranks a descendant's turn above a descendant's background work", () => {
+    seedNestedChatTree();
+    testState.activeAgentIds = new Set(["chat-child", "chat-grandchild"]);
+    testState.activityTierById = new Map([
+      ["chat-child", "background"],
+      ["chat-grandchild", "turn"],
+    ]);
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+    const icon = screen.getByTestId("chat-descendant-status-running-chat-root");
+    expect(icon).toBeTruthy();
+    // The tooltip breaks the aggregate down across both tiers.
+    expect(icon.getAttribute("title")).toContain("1 running");
+    expect(icon.getAttribute("title")).toContain("1 in background");
+  });
+
+  it("lets a descendant's turn outrank the parent's own background work", () => {
+    seedNestedChatTree();
+    // Parent is non-idle but only in background; a hidden descendant is
+    // actually mid-turn, so the busier nested tier must win the slot rather
+    // than being masked by the parent's own (lower) tier.
+    testState.activeAgentIds = new Set(["chat-root", "chat-grandchild"]);
+    testState.activityTierById = new Map([
+      ["chat-root", "background"],
+      ["chat-grandchild", "turn"],
+    ]);
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+    expect(
+      screen.getByTestId("chat-descendant-status-running-chat-root"),
+    ).toBeTruthy();
   });
 
   it("shows an unread-done rollup and nothing when descendants are idle", () => {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -93,6 +93,8 @@ import {
 import {
   useAncestorIds,
   useEpicActiveAgentIds,
+  useEpicAgentActivityTiers,
+  type AgentActivityTier,
   useEpicArtifactRecords,
   useEpicConnectionStatus,
   useEpicNodeHostId,
@@ -179,7 +181,7 @@ const noopToggleSelection = (_id: string): void => undefined;
 const noopRowAction = (): void => undefined;
 
 type ChatDescendantStatusKind =
-  "failure" | "interview" | "approval" | "running" | "done";
+  "failure" | "interview" | "approval" | "running" | "background" | "done";
 
 /**
  * One shared urgency ladder for a collapsed parent's icon slot: the parent's
@@ -187,14 +189,54 @@ type ChatDescendantStatusKind =
  * and the higher one owns the slot (ties go to the parent, so solid always
  * beats muted). Mirrors the order `NotificationIndicatorIcon` resolves a
  * single chat's simultaneous states.
+ *
+ * `running` (an agent turn) outranks `background` (a `run_in_background` task
+ * / subagent / Monitor / scheduled wakeup keeping a session non-idle while the
+ * agent itself is idle), matching the turn-over-background precedence the
+ * per-chat indicator already uses. Both still outrank `done`, so any live work
+ * beats a finished-but-unread one.
  */
 const CHAT_STATUS_RANKS: Record<ChatDescendantStatusKind, number> = {
-  failure: 5,
-  interview: 4,
-  approval: 3,
-  running: 2,
+  failure: 6,
+  interview: 5,
+  approval: 4,
+  running: 3,
+  background: 2,
   done: 1,
 };
+
+/** {@link CHAT_STATUS_RANKS} most-urgent first, for picking a rollup's kind. */
+const CHAT_STATUS_ORDER: ReadonlyArray<ChatDescendantStatusKind> = [
+  "failure",
+  "interview",
+  "approval",
+  "running",
+  "background",
+  "done",
+];
+
+/** The ladder kind an activity tier occupies. */
+function activityTierKind(tier: AgentActivityTier): ChatDescendantStatusKind {
+  return tier === "turn" ? "running" : "background";
+}
+
+/**
+ * The single tier a descendant chat is counted under - its own highest. The
+ * attention precedence goes through the shared `attentionTone`, so
+ * failure > interview > approval lives in exactly one place.
+ */
+function chatDescendantKind(
+  indicatorState: NotificationIndicatorState,
+  tier: AgentActivityTier | undefined,
+): ChatDescendantStatusKind | null {
+  const tone = attentionTone(indicatorState);
+  if (tone === FAILURE_TONE) return "failure";
+  if (tone === INTERVIEW_TONE) return "interview";
+  if (tone === APPROVAL_TONE) return "approval";
+  if (tier !== undefined) return activityTierKind(tier);
+  if (indicatorState.unreadDone) return "done";
+  return null;
+}
 
 /**
  * Rollup over a collapsed parent's hidden chat descendants: the
@@ -208,6 +250,7 @@ interface ChatDescendantStatusRollup {
   readonly interviewCount: number;
   readonly approvalCount: number;
   readonly runningCount: number;
+  readonly backgroundCount: number;
   readonly doneCount: number;
 }
 
@@ -286,46 +329,48 @@ function useChatDescendantStatus(args: {
     () => collectDescendantChatIds(nodeId, tree, visibleIds),
     [nodeId, tree, visibleIds],
   );
-  const activeAgentIds = useEpicActiveAgentIds();
+  const activityTiers = useEpicAgentActivityTiers();
   const indicators = useContext(NotificationIndicatorsContext);
   return useAppLocalNotificationsStore(
     useShallow((state): ChatDescendantStatusRollup | null => {
       if (descendants === EMPTY_CHAT_DESCENDANT_IDS) return null;
-      let failureCount = 0;
-      let interviewCount = 0;
-      let approvalCount = 0;
-      let runningCount = 0;
-      let doneCount = 0;
+      const counts: Record<ChatDescendantStatusKind, number> = {
+        failure: 0,
+        interview: 0,
+        approval: 0,
+        running: 0,
+        background: 0,
+        done: 0,
+      };
       for (const chatId of descendants.chatIds) {
         const indicatorState = selectNotificationIndicatorState(
           state,
           { epicId, chatId },
           indicators,
         );
-        const tone = attentionTone(indicatorState);
-        if (tone === FAILURE_TONE) failureCount += 1;
-        else if (tone === INTERVIEW_TONE) interviewCount += 1;
-        else if (tone === APPROVAL_TONE) approvalCount += 1;
-        else if (activeAgentIds.has(chatId)) runningCount += 1;
-        else if (indicatorState.unreadDone) doneCount += 1;
+        const kind = chatDescendantKind(
+          indicatorState,
+          activityTiers.get(chatId),
+        );
+        if (kind !== null) counts[kind] += 1;
       }
       for (const agentId of descendants.agentIds) {
-        if (activeAgentIds.has(agentId)) runningCount += 1;
+        // Terminal-agent descendants contribute only activity - epic-wide
+        // awareness is their sole status authority.
+        const tier = activityTiers.get(agentId);
+        if (tier !== undefined) counts[activityTierKind(tier)] += 1;
       }
-      let kind: ChatDescendantStatusKind | null = null;
-      if (failureCount > 0) kind = "failure";
-      else if (interviewCount > 0) kind = "interview";
-      else if (approvalCount > 0) kind = "approval";
-      else if (runningCount > 0) kind = "running";
-      else if (doneCount > 0) kind = "done";
+      const kind =
+        CHAT_STATUS_ORDER.find((candidate) => counts[candidate] > 0) ?? null;
       if (kind === null) return null;
       return {
         kind,
-        failureCount,
-        interviewCount,
-        approvalCount,
-        runningCount,
-        doneCount,
+        failureCount: counts.failure,
+        interviewCount: counts.interview,
+        approvalCount: counts.approval,
+        runningCount: counts.running,
+        backgroundCount: counts.background,
+        doneCount: counts.done,
       };
     }),
   );
@@ -1546,7 +1591,7 @@ function ChatRowButton(props: ChatRowButtonProps) {
 // variant cannot drift from the per-row icon; "running" stays local because
 // it is an activity tier, not a notification state.
 const CHAT_DESCENDANT_STATUS_TONES: Record<
-  Exclude<ChatDescendantStatusKind, "running">,
+  Exclude<ChatDescendantStatusKind, "running" | "background">,
   IndicatorTone
 > = {
   failure: FAILURE_TONE,
@@ -1556,20 +1601,22 @@ const CHAT_DESCENDANT_STATUS_TONES: Record<
 };
 
 /**
- * The parent's own tier on the shared ladder. `selfActive` is the epic-wide
- * activity bit - the same authority the per-row icon falls back to for an
- * unopened chat; the handle-refined turn/background split does not matter here
- * because both tiers rank as "running".
+ * The parent's own tier on the shared ladder. `selfTier` is the host-published
+ * activity tier from epic awareness - the same authority the per-row icon
+ * falls back to for an unopened chat, now carrying the turn/background split
+ * so a parent doing only background work cannot outrank a descendant that is
+ * genuinely mid-turn.
  */
 function chatSelfStatusRank(
   state: NotificationIndicatorState,
-  selfActive: boolean,
+  selfTier: AgentActivityTier | undefined,
 ): number {
   const tone = attentionTone(state);
   if (tone === FAILURE_TONE) return CHAT_STATUS_RANKS.failure;
   if (tone === INTERVIEW_TONE) return CHAT_STATUS_RANKS.interview;
   if (tone === APPROVAL_TONE) return CHAT_STATUS_RANKS.approval;
-  if (selfActive) return CHAT_STATUS_RANKS.running;
+  if (selfTier === "turn") return CHAT_STATUS_RANKS.running;
+  if (selfTier === "background") return CHAT_STATUS_RANKS.background;
   if (state.unreadDone) return CHAT_STATUS_RANKS.done;
   return 0;
 }
@@ -1589,6 +1636,9 @@ function nestedChatStatusSummary(rollup: ChatDescendantStatusRollup): string {
     parts.push(`${rollup.approvalCount} waiting for approval`);
   }
   if (rollup.runningCount > 0) parts.push(`${rollup.runningCount} running`);
+  if (rollup.backgroundCount > 0) {
+    parts.push(`${rollup.backgroundCount} in background`);
+  }
   if (rollup.doneCount > 0) parts.push(`${rollup.doneCount} completed`);
   return `Nested: ${parts.join(" · ")}`;
 }
@@ -1610,19 +1660,22 @@ const ChatSidebarNodeIconWithNestedStatus = memo(
       epicId: props.epicId,
       nodeId: props.nodeId,
     });
-    const activeAgentIds = useEpicActiveAgentIds();
+    const activityTiers = useEpicAgentActivityTiers();
     const selfIndicator = useSurfaceNotificationIndicatorState({
       epicId: props.epicId,
       chatId: props.nodeId,
     });
     if (rollup !== null) {
-      const selfActive = activeAgentIds.has(props.nodeId);
+      const selfTier = activityTiers.get(props.nodeId);
       // Terminal-agent parents have no notification states of their own -
       // activity is their only tier (their indicator entry is always empty).
-      const agentSelfRank = selfActive ? CHAT_STATUS_RANKS.running : 0;
+      const agentSelfRank =
+        selfTier === undefined
+          ? 0
+          : CHAT_STATUS_RANKS[activityTierKind(selfTier)];
       const selfRank =
         props.artifactType === "chat"
-          ? chatSelfStatusRank(selfIndicator, selfActive)
+          ? chatSelfStatusRank(selfIndicator, selfTier)
           : agentSelfRank;
       if (CHAT_STATUS_RANKS[rollup.kind] > selfRank) {
         return <NestedChatStatusIcon nodeId={props.nodeId} rollup={rollup} />;
@@ -1659,12 +1712,16 @@ function NestedChatStatusIcon(props: {
 function NestedChatStatusGlyph(props: {
   readonly kind: ChatDescendantStatusKind;
 }): ReactNode {
-  if (props.kind === "running") {
+  if (props.kind === "running" || props.kind === "background") {
+    // Same busy-vs-bounce split the per-chat indicator uses for the two
+    // activity tiers, so a nested spinner reads identically to a direct one.
     return (
       <AgentSpinningDots
-        className="text-current"
+        className={
+          props.kind === "running" ? "text-current" : "text-muted-foreground"
+        }
         testId={undefined}
-        variant={undefined}
+        variant={props.kind === "running" ? undefined : "bounce"}
       />
     );
   }


### PR DESCRIPTION
Follow-up to #420, built on #421. cc @hdkshingala — this extends your rollup's status ladder, so I'd value your eyes on the ranking call.

## Why

#420's rollup reads epic awareness rather than chat sessions — deliberately, and correctly: it never has to load a chat to know a hidden descendant is busy, so it works for descendants nobody has opened. The cost was resolution. `agentWorking` is a single bit, so `running` covered both an active agent turn *and* background-only work (`run_in_background` / a subagent / Monitor / a scheduled wakeup) that keeps a session non-idle while the agent itself is idle. The code said as much:

> the handle-refined turn/background split does not matter here because both tiers rank as "running"

#421 put that tier on the same always-on channel (`agentWorkingTurn`), so the split now costs nothing in loading — it's a swap from `useEpicActiveAgentIds` to `useEpicAgentActivityTiers`.

## What changed

- **`background` joins the shared ladder**, between `running` and `done`: a turn outranks background work, and both outrank a finished-but-unread chat. The consequence worth noting is that a parent doing only background work can no longer mask a descendant that is genuinely mid-turn — covered by a test.
- **The nested glyph reuses the per-chat indicator's own split** — busy spinner for a turn, muted bounce for background — so a nested spinner reads identically to a direct one, still at the reduced opacity your self/descendant convention uses.
- **Tooltip** gains an `N in background` part.
- **Older hosts are unaffected**: a host that doesn't classify an agent leaves it reading as a turn, so the rollup behaves exactly as it does today.

## Ranking call worth a second opinion

I put `background` above `done` on the theory that live work beats a finished-but-unread chat, which follows your existing `running > done`. The alternative is `done > background`. Easy to flip if you'd rather.

## Refactor note

The rollup selector moves from the if/else chain to a counts record plus a `chatDescendantKind` classifier. Not gratuitous — the sixth tier pushed the inline version to complexity 17 against the ceiling of 16. The shared `attentionTone` precedence still lives in exactly one place, and all 36 of your existing tests pass unchanged.

## Test plan

- [x] `bun run compile` — clean
- [x] `bun run lint` — clean (0 warnings)
- [x] pre-commit `build · compile · lint · format (nx affected)` + DCO — passed
- [x] 78 tests green across the rollup, awareness-tier, and tab-strip suites
- [x] #420's 36 selection-mode tests pass **unchanged** — the test mock derives the tier map from `activeAgentIds`, defaulting to `turn`, mirroring the unclassified-host case
- [x] 3 new cases: background-only descendant renders the background kind (and flips to running mid-turn); turn ranked above background with both counts in the tooltip; a descendant's turn outranking the parent's own background work