### PR TITLE
fix(gui-app): coalesce worktree.changed invalidations into per-burst flushes

### DIFF
--- a/clients/gui-app/src/lib/worktree/__tests__/worktree-changed-invalidation-scheduler.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/worktree-changed-invalidation-scheduler.test.ts
@@ -58,10 +58,10 @@ describe("createWorktreeChangedInvalidationScheduler", () => {
 
     // Events every 100ms - each resets the 300ms trailing edge, so only the
     // 1s maxWait bound produces the flush.
-    for (let i = 0; i < 12; i += 1) {
+    Array.from({ length: 12 }).forEach((_, i) => {
       scheduler.push({ kind: "worktreePath", worktreePath: `/wt/${i}` });
       vi.advanceTimersByTime(100);
-    }
+    });
     expect(flushes).toHaveLength(1);
     expect(flushes[0].worktreePaths.size).toBeGreaterThanOrEqual(10);
 

--- a/clients/gui-app/src/lib/worktree/__tests__/worktree-changed-invalidation-scheduler.test.ts
+++ b/clients/gui-app/src/lib/worktree/__tests__/worktree-changed-invalidation-scheduler.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createWorktreeChangedInvalidationScheduler,
+  type WorktreeChangedAccumulatedScopes,
+  type WorktreeChangedInvalidationScheduler,
+} from "@/lib/worktree/worktree-changed-invalidation-scheduler";
+
+describe("createWorktreeChangedInvalidationScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function tracked(): {
+    readonly flushes: WorktreeChangedAccumulatedScopes[];
+    readonly scheduler: WorktreeChangedInvalidationScheduler;
+  } {
+    const flushes: WorktreeChangedAccumulatedScopes[] = [];
+    const scheduler = createWorktreeChangedInvalidationScheduler({
+      onFlush: (scopes) => flushes.push(scopes),
+      debounceMs: 300,
+      maxWaitMs: 1_000,
+    });
+    return { flushes, scheduler };
+  }
+
+  it("collapses a burst of path events into one flush with the path union", () => {
+    const { flushes, scheduler } = tracked();
+
+    scheduler.push({ kind: "worktreePath", worktreePath: "/wt/a" });
+    vi.advanceTimersByTime(100);
+    scheduler.push({ kind: "worktreePath", worktreePath: "/wt/b" });
+    vi.advanceTimersByTime(100);
+    scheduler.push({ kind: "worktreePath", worktreePath: "/wt/a" });
+    expect(flushes).toHaveLength(0);
+
+    vi.advanceTimersByTime(300);
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0].root).toBe(false);
+    expect([...flushes[0].worktreePaths].sort()).toEqual(["/wt/a", "/wt/b"]);
+  });
+
+  it("absorbs path precision into root when any root event is in the window", () => {
+    const { flushes, scheduler } = tracked();
+
+    scheduler.push({ kind: "worktreePath", worktreePath: "/wt/a" });
+    scheduler.push({ kind: "root", root: "worktrees" });
+    vi.advanceTimersByTime(300);
+
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0].root).toBe(true);
+  });
+
+  it("bounds a continuous drizzle with maxWait instead of sliding forever", () => {
+    const { flushes, scheduler } = tracked();
+
+    // Events every 100ms - each resets the 300ms trailing edge, so only the
+    // 1s maxWait bound produces the flush.
+    for (let i = 0; i < 12; i += 1) {
+      scheduler.push({ kind: "worktreePath", worktreePath: `/wt/${i}` });
+      vi.advanceTimersByTime(100);
+    }
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0].worktreePaths.size).toBeGreaterThanOrEqual(10);
+
+    // The tail after the forced flush drains via the trailing edge.
+    vi.advanceTimersByTime(300);
+    expect(flushes).toHaveLength(2);
+  });
+
+  it("starts a fresh accumulation after each flush", () => {
+    const { flushes, scheduler } = tracked();
+
+    scheduler.push({ kind: "worktreePath", worktreePath: "/wt/a" });
+    vi.advanceTimersByTime(300);
+    scheduler.push({ kind: "worktreePath", worktreePath: "/wt/b" });
+    vi.advanceTimersByTime(300);
+
+    expect(flushes).toHaveLength(2);
+    expect([...flushes[0].worktreePaths]).toEqual(["/wt/a"]);
+    expect([...flushes[1].worktreePaths]).toEqual(["/wt/b"]);
+  });
+
+  it("flushes pending scopes on dispose and ignores later pushes", () => {
+    const { flushes, scheduler } = tracked();
+
+    scheduler.push({ kind: "worktreePath", worktreePath: "/wt/a" });
+    scheduler.dispose();
+    expect(flushes).toHaveLength(1);
+
+    scheduler.push({ kind: "worktreePath", worktreePath: "/wt/b" });
+    vi.advanceTimersByTime(2_000);
+    expect(flushes).toHaveLength(1);
+  });
+
+  it("does not flush at all when no events arrived", () => {
+    const { flushes, scheduler } = tracked();
+    scheduler.dispose();
+    vi.advanceTimersByTime(2_000);
+    expect(flushes).toHaveLength(0);
+  });
+});

--- a/clients/gui-app/src/lib/worktree/invalidate-worktree-changed-caches.ts
+++ b/clients/gui-app/src/lib/worktree/invalidate-worktree-changed-caches.ts
@@ -1,24 +1,28 @@
 import type { QueryClient } from "@tanstack/react-query";
-import type { WorktreeChangedScope } from "@traycer/protocol/host/worktree-changed-stream";
 import { hostQueryKeys } from "@/lib/query-keys";
 import { perPathEnrichmentQueryPath } from "@/lib/query-keys/worktree-enrichment-keys";
+import type { WorktreeChangedAccumulatedScopes } from "@/lib/worktree/worktree-changed-invalidation-scheduler";
 
 /**
- * Drops the host's worktree listing caches after a `worktree.changed` push.
+ * Drops the host's worktree listing caches for one accumulated burst of
+ * `worktree.changed` pushes (see `worktree-changed-invalidation-scheduler`).
  * Invalidation only - the refetch reads the host's own cache, so this never
  * forces a git resolve.
  *
- * Scope-aware on purpose. A `worktreePath` event says exactly one row moved, so
- * only that row's enrichment overlay is re-probed; invalidating them all would
- * turn one commit into one refetch PER ON-SCREEN ROW. The base listing and the
- * workspace-path queries always go, at any scope: a change can add or remove
- * rows, which no per-path overlay can express, and a worktree path does not map
- * back to the workspace folders that list it.
+ * Scope-aware on purpose. A `worktreePath` event says exactly one row moved,
+ * so only that row's enrichment overlay is re-probed; invalidating them all
+ * would turn one commit into one refetch PER ON-SCREEN ROW. The base listing
+ * and the workspace-path queries always go, at any scope: a change can add or
+ * remove rows, which no per-path overlay can express, and a worktree path
+ * does not map back to the workspace folders that list it. Called once per
+ * BURST rather than per event: the host's sweep emits one event per
+ * re-derived row, and refetching the full base list per row is pure
+ * amplification - one trailing refetch renews demand and freshness the same.
  */
 export function invalidateWorktreeChangedCaches(
   queryClient: QueryClient,
   hostId: string,
-  scope: WorktreeChangedScope,
+  scopes: WorktreeChangedAccumulatedScopes,
 ): void {
   const listAllScope = hostQueryKeys.methodScope(
     hostId,
@@ -32,8 +36,8 @@ export function invalidateWorktreeChangedCaches(
       // Not an enrichment overlay (the base list, task-delete whole-list): row
       // membership may have changed, so it always refetches.
       if (path === null) return true;
-      if (scope.kind === "root") return true;
-      return path === scope.worktreePath;
+      if (scopes.root) return true;
+      return scopes.worktreePaths.has(path);
     },
   });
   void queryClient.invalidateQueries({

--- a/clients/gui-app/src/lib/worktree/worktree-changed-invalidation-scheduler.ts
+++ b/clients/gui-app/src/lib/worktree/worktree-changed-invalidation-scheduler.ts
@@ -1,0 +1,87 @@
+import type { WorktreeChangedScope } from "@traycer/protocol/host/worktree-changed-stream";
+
+/**
+ * Trailing-edge debounce for the burst shape the host's freshness sweep
+ * produces: one push event PER re-derived row, ~20+ events/second during a
+ * wave (providers-list storm RCA, live CDP audit). Collapsing a wave into one
+ * flush turns N base-list + workspace-paths refetch pairs into one pair.
+ */
+export const WORKTREE_CHANGED_INVALIDATION_DEBOUNCE_MS = 300;
+
+/**
+ * Upper bound on how long a continuous drizzle of events (gaps under the
+ * debounce) can postpone the flush - the sweep's demand-renewal contract and
+ * on-screen freshness only need a refetch per wave, but they do need one.
+ */
+export const WORKTREE_CHANGED_INVALIDATION_MAX_WAIT_MS = 1_000;
+
+/**
+ * The union of every scope pushed since the last flush. `root: true` absorbs
+ * path precision on purpose: a root event means "row membership may have
+ * changed anywhere", which no path set can narrow back down.
+ */
+export interface WorktreeChangedAccumulatedScopes {
+  readonly root: boolean;
+  readonly worktreePaths: ReadonlySet<string>;
+}
+
+export interface WorktreeChangedInvalidationScheduler {
+  readonly push: (scope: WorktreeChangedScope) => void;
+  readonly dispose: () => void;
+}
+
+/**
+ * Accumulates `worktree.changed` scopes and delivers them as ONE `onFlush`
+ * per burst: trailing-edge `debounceMs` after the last event, bounded by
+ * `maxWaitMs` from the first unflushed event. `dispose` flushes anything
+ * pending (an invalidation must never be dropped on unmount/host switch)
+ * and ignores later pushes.
+ */
+export function createWorktreeChangedInvalidationScheduler(args: {
+  readonly onFlush: (scopes: WorktreeChangedAccumulatedScopes) => void;
+  readonly debounceMs: number;
+  readonly maxWaitMs: number;
+}): WorktreeChangedInvalidationScheduler {
+  let root = false;
+  let worktreePaths = new Set<string>();
+  let trailingTimer: number | null = null;
+  let maxWaitTimer: number | null = null;
+  let disposed = false;
+
+  const clearTimers = (): void => {
+    if (trailingTimer !== null) window.clearTimeout(trailingTimer);
+    if (maxWaitTimer !== null) window.clearTimeout(maxWaitTimer);
+    trailingTimer = null;
+    maxWaitTimer = null;
+  };
+
+  const flush = (): void => {
+    clearTimers();
+    if (!root && worktreePaths.size === 0) return;
+    const scopes: WorktreeChangedAccumulatedScopes = { root, worktreePaths };
+    root = false;
+    worktreePaths = new Set<string>();
+    args.onFlush(scopes);
+  };
+
+  return {
+    push: (scope: WorktreeChangedScope): void => {
+      if (disposed) return;
+      if (scope.kind === "root") {
+        root = true;
+      } else {
+        worktreePaths.add(scope.worktreePath);
+      }
+      if (trailingTimer !== null) window.clearTimeout(trailingTimer);
+      trailingTimer = window.setTimeout(flush, args.debounceMs);
+      if (maxWaitTimer === null) {
+        maxWaitTimer = window.setTimeout(flush, args.maxWaitMs);
+      }
+    },
+    dispose: (): void => {
+      if (disposed) return;
+      disposed = true;
+      flush();
+    },
+  };
+}

--- a/clients/gui-app/src/providers/__tests__/worktree-changed-stream-mount.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/worktree-changed-stream-mount.test.tsx
@@ -88,8 +88,8 @@ it("refetches a changed worktree event into the active canonical cache entry wit
 
   act(() => {
     invalidateWorktreeChangedCaches(queryClient, mockLocalHostEntry.hostId, {
-      kind: "worktreePath",
-      worktreePath: "/wt/app",
+      root: false,
+      worktreePaths: new Set(["/wt/app"]),
     });
   });
 
@@ -130,8 +130,8 @@ it("invalidates only the named path's enrichment overlay on a worktreePath event
   const other = seedOverlay(queryClient, "/wt/other");
 
   invalidateWorktreeChangedCaches(queryClient, mockLocalHostEntry.hostId, {
-    kind: "worktreePath",
-    worktreePath: "/wt/app",
+    root: false,
+    worktreePaths: new Set(["/wt/app"]),
   });
 
   expect(queryClient.getQueryState(named)?.isInvalidated).toBe(true);
@@ -146,8 +146,8 @@ it("invalidates every enrichment overlay on a root event", () => {
   const other = seedOverlay(queryClient, "/wt/other");
 
   invalidateWorktreeChangedCaches(queryClient, mockLocalHostEntry.hostId, {
-    kind: "root",
-    root: "/repo",
+    root: true,
+    worktreePaths: new Set(),
   });
 
   expect(queryClient.getQueryState(named)?.isInvalidated).toBe(true);

--- a/clients/gui-app/src/providers/worktree-changed-stream-mount.tsx
+++ b/clients/gui-app/src/providers/worktree-changed-stream-mount.tsx
@@ -7,6 +7,11 @@ import {
 } from "@/lib/host/stream-runtime-context";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { invalidateWorktreeChangedCaches } from "@/lib/worktree/invalidate-worktree-changed-caches";
+import {
+  createWorktreeChangedInvalidationScheduler,
+  WORKTREE_CHANGED_INVALIDATION_DEBOUNCE_MS,
+  WORKTREE_CHANGED_INVALIDATION_MAX_WAIT_MS,
+} from "@/lib/worktree/worktree-changed-invalidation-scheduler";
 
 export function WorktreeChangedStreamMount(): ReactNode {
   const wsStreamClient = useWsStreamClient();
@@ -22,15 +27,27 @@ export function WorktreeChangedStreamMount(): ReactNode {
     ) {
       return;
     }
+    // The host's freshness sweep pushes one event per re-derived row; the
+    // scheduler collapses each wave into a single invalidation flush so the
+    // base-list/workspace-paths refetch pair runs once per burst, not once
+    // per row (providers-list storm RCA, live CDP audit).
+    const scheduler = createWorktreeChangedInvalidationScheduler({
+      onFlush: (scopes) =>
+        invalidateWorktreeChangedCaches(queryClient, hostId, scopes),
+      debounceMs: WORKTREE_CHANGED_INVALIDATION_DEBOUNCE_MS,
+      maxWaitMs: WORKTREE_CHANGED_INVALIDATION_MAX_WAIT_MS,
+    });
     const stream = new WorktreeChangedStreamClient({
       wsStreamClient,
       callbacks: {
-        onChanged: (scope) =>
-          invalidateWorktreeChangedCaches(queryClient, hostId, scope),
+        onChanged: (scope) => scheduler.push(scope),
         onConnectionStatus: () => undefined,
       },
     });
-    return () => stream.close();
+    return () => {
+      stream.close();
+      scheduler.dispose();
+    };
   }, [hostId, queryClient, support, wsStreamClient]);
 
   return null;


### PR DESCRIPTION
## Problem

The host's worktree freshness sweep pushes one `worktree.changed` event per re-derived row, and the stream mount invalidated + actively refetched BOTH `worktree.listAllForHost` (full base list) and `worktree.listByWorkspacePaths` on every single event.

Measured via a live CDP network audit of an idle desktop app: **83 + 83 calls inside one ~10s window, bursts of 21–23/s**, recurring every row-cache TTL (5 min) and scaling with worktree count. Each refetch pair returns the full list, so an N-row sweep cost 2N full-list RPCs where one pair carries the same information.

## Fix

A trailing-edge debounce (300 ms, 1 s max-wait) accumulates scopes and flushes ONE batched invalidation per burst:

- any root event absorbs path precision (row membership may have changed anywhere);
- otherwise the union of worktree paths keeps per-path enrichment overlays selective — overlay invalidation still only touches the changed rows;
- `dispose` flushes pending scopes so unmounts/host switches never drop an invalidation.

The sweep's demand-renewal contract is preserved: each wave still produces the base-list refetch that renews demand — exactly once.

## Verification

Live CDP capture, same method as the audit:

| Scenario | Before | After |
|---|---|---|
| Boot/reconnect wave | 83 + 83 calls, bursts 21–23/s | **2 + 1 calls** |
| 5-min TTL sweep wave | same shape | **6 + 3 calls**, then silence |

Unit tests cover burst collapse, root absorption, max-wait bounding, post-flush re-accumulation, dispose semantics, and overlay selectivity. Pairs with a host-side same-scope emit dedupe in the internal repo (same branch name).