### PR TITLE
fix(gui-app): recover notification indicators after fetch errors

### DIFF
--- a/clients/gui-app/src/hooks/notifications/__tests__/use-host-notification-indicators-query.test.ts
+++ b/clients/gui-app/src/hooks/notifications/__tests__/use-host-notification-indicators-query.test.ts
@@ -161,14 +161,27 @@ describe("useHostNotificationIndicators recovery", () => {
     expect(result.current.error).not.toBeNull();
     expect(result.current.data.epics["epic-a"].unreadDone).toBe(true);
 
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+      await flushQueryNotifications();
+    });
+    expect(requestCount.value).toBe(3);
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.data.epics["epic-a"].unreadDone).toBe(true);
+
     responseMode.value = "clear";
     await act(async () => {
       await vi.advanceTimersByTimeAsync(30_000);
       await flushQueryNotifications();
     });
-
-    expect(requestCount.value).toBe(3);
+    expect(requestCount.value).toBe(4);
     expect(result.current.error).toBeNull();
     expect(result.current.data.epics).toEqual({});
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+      await flushQueryNotifications();
+    });
+    expect(requestCount.value).toBe(4);
   });
 });

--- a/clients/gui-app/src/hooks/notifications/__tests__/use-host-notification-indicators-query.test.ts
+++ b/clients/gui-app/src/hooks/notifications/__tests__/use-host-notification-indicators-query.test.ts
@@ -1,6 +1,47 @@
-import { describe, expect, it } from "vitest";
+import { createElement, type ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { RetryableTransportError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
+import type { HostNotificationsIndicatorStateResponse } from "@traycer/protocol/host/notifications/contracts";
 import { HOST_NOTIFICATIONS_INDICATOR_BATCH_CAP } from "@traycer/protocol/host/notifications/contracts";
-import { indicatorRequests } from "@/hooks/notifications/use-host-notification-indicators-query";
+import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
+import {
+  indicatorRequests,
+  useHostNotificationIndicators,
+} from "@/hooks/notifications/use-host-notification-indicators-query";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { createAppQueryClient } from "@/lib/query-client";
+import { useAuthStore } from "@/stores/auth/auth-store";
+
+let hostClient: HostClient<HostRpcRegistry>;
+
+const flushQueryNotifications = async (): Promise<void> => {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+};
+
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return {
+    ...actual,
+    useHostClient: () => hostClient,
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  useAuthStore.setState(useAuthStore.getInitialState(), true);
+});
 
 describe("indicatorRequests", () => {
   it("deduplicates, sorts, and chunks visible surface ids at the host cap", () => {
@@ -22,5 +63,112 @@ describe("indicatorRequests", () => {
     ]);
     expect(requests[0].chatIds).toEqual(["chat-a", "chat-b"]);
     expect(requests[1].chatIds).toEqual([]);
+  });
+});
+
+describe("useHostNotificationIndicators recovery", () => {
+  it("self-heals stale indicator data after a transport-exhausted refetch", async () => {
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+    const queryClient = createAppQueryClient();
+    queryClient.setDefaultOptions({
+      queries: {
+        ...queryClient.getDefaultOptions().queries,
+        retry: false,
+      },
+    });
+    const requestCount = { value: 0 };
+    const responseMode: { value: "done" | "error" | "clear" } = {
+      value: "done",
+    };
+    const doneResponse: HostNotificationsIndicatorStateResponse = {
+      epics: {
+        "epic-a": {
+          unreadFailure: false,
+          pendingApproval: false,
+          pendingInterview: false,
+          unreadDone: true,
+        },
+      },
+      chats: {},
+    };
+    const clearResponse: HostNotificationsIndicatorStateResponse = {
+      epics: {},
+      chats: {},
+    };
+    hostClient = new HostClient<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      invalidator: createHostQueryInvalidator(queryClient),
+      messenger: new MockHostMessenger<HostRpcRegistry>({
+        registry: hostRpcRegistry,
+        requestId: () => `request-${requestCount.value}`,
+        handlers: {
+          "host.notifications.indicatorState": () => {
+            requestCount.value += 1;
+            if (responseMode.value === "error") {
+              return Promise.reject(
+                new RetryableTransportError({
+                  code: "RPC_ERROR",
+                  message: "WebSocket dial timed out after 10000ms",
+                  requestId: `request-${requestCount.value}`,
+                  method: "host.notifications.indicatorState",
+                  fatalDetails: null,
+                }),
+              );
+            }
+            return responseMode.value === "done" ? doneResponse : clearResponse;
+          },
+        },
+      }),
+    });
+    hostClient.bind(mockLocalHostEntry);
+    hostClient.setRequestContext(
+      createRequestContextFixture({
+        origin: "renderer",
+        bearerToken: "token",
+      }),
+    );
+    useAuthStore.setState({
+      contextMetadata: { userId: "user-a", username: "user-a" },
+    });
+    const wrapper = (props: { readonly children: ReactNode }): ReactNode =>
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        props.children,
+      );
+
+    const { result } = renderHook(
+      () =>
+        useHostNotificationIndicators({
+          epicIds: ["epic-a"],
+          chatIds: [],
+          enabled: true,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await flushQueryNotifications();
+    });
+    expect(requestCount.value).toBe(1);
+    expect(result.current.data.epics["epic-a"].unreadDone).toBe(true);
+
+    responseMode.value = "error";
+    await act(async () => {
+      await result.current.refetch();
+    });
+    expect(requestCount.value).toBe(2);
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.data.epics["epic-a"].unreadDone).toBe(true);
+
+    responseMode.value = "clear";
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+      await flushQueryNotifications();
+    });
+
+    expect(requestCount.value).toBe(3);
+    expect(result.current.error).toBeNull();
+    expect(result.current.data.epics).toEqual({});
   });
 });

--- a/clients/gui-app/src/hooks/notifications/use-host-notification-indicators-query.ts
+++ b/clients/gui-app/src/hooks/notifications/use-host-notification-indicators-query.ts
@@ -15,6 +15,7 @@ const EMPTY_INDICATOR_STATE: HostNotificationsIndicatorStateResponse = {
   epics: {},
   chats: {},
 };
+const INDICATOR_ERROR_REFETCH_INTERVAL_MS = 30_000;
 
 export interface UseHostNotificationIndicatorsArgs {
   readonly epicIds: ReadonlyArray<string>;
@@ -58,7 +59,13 @@ export function useHostNotificationIndicators(
       userId === null
         ? undefined
         : notificationsQueryKeys.indicatorIdentity(userId),
-    options: { enabled: args.enabled && userId !== null },
+    options: {
+      enabled: args.enabled && userId !== null,
+      refetchInterval: (query) =>
+        query.state.status === "error"
+          ? INDICATOR_ERROR_REFETCH_INTERVAL_MS
+          : false,
+    },
     combine: (results) => ({
       data: mergeIndicatorResponses(results),
       isPending: results.some((result) => result.isPending),


### PR DESCRIPTION
## Summary

- retry notification indicator queries every 30 seconds only while they remain in an error state
- stop polling immediately after a successful recovery
- cover stale cached indicator data recovering without another notification feed event

## Root cause

The affected indicator refetch exhausted its per-request WebSocket dial budget before sending the RPC frame. TanStack Query retained the previous successful data while the query entered an error state, and no later invalidation was guaranteed to heal that surface.

## Verification

- bun run test src/hooks/notifications/__tests__/use-host-notification-indicators-query.test.ts src/lib/notifications/__tests__/notification-indicator-cache.test.ts src/providers/__tests__/notifications-session-provider.test.tsx
- bun run compile
- focused ESLint on the changed hook and test