### PR TITLE
fix(gui-app): surface worktree provision failures + add clients/shared compile gate

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-message-setup-card.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-setup-card.test.tsx
@@ -59,6 +59,8 @@ const SETUP_MODEL: SetupCardViewModel = {
       terminalSessionId: "term-1",
       worktreePath: "/worktrees/repo/feature",
       branch: "feature",
+      errorMessage: null,
+      retryFolderIntent: null,
     },
   ],
   createdAt: 1500,

--- a/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
@@ -377,7 +377,7 @@ describe("<SetupCardSegment /> single-repo dropdown (two steps)", () => {
       ]),
     );
 
-    expect(screen.getByTestId("setup-card-error-message").textContent).toBe(
+    expect(screen.getByRole("alert").textContent).toBe(
       "fatal: a branch named 'traycer/x' already exists",
     );
   });

--- a/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
@@ -18,6 +18,7 @@ import {
 
 const focusTerminal = vi.hoisted(() => vi.fn());
 const retryMutate = vi.hoisted(() => vi.fn());
+const createMutate = vi.hoisted(() => vi.fn());
 // `value === undefined` models the "liveness not yet known" window (the query
 // has not settled); an array models a settled `terminal.list` response.
 const terminalSessions = vi.hoisted<{
@@ -58,6 +59,13 @@ vi.mock("@/hooks/worktree/use-worktree-retry-setup-mutation", () => ({
   },
 }));
 
+vi.mock("@/hooks/worktree/use-worktree-create-mutation", () => ({
+  useWorktreeCreateForClient: () => ({
+    mutate: createMutate,
+    isPending: false,
+  }),
+}));
+
 // Contract guard: the state union is exactly these five. If it drifts,
 // `Exclude<...>` stops resolving to `never` and `bun run compile` fails.
 type UnexpectedStates = Exclude<
@@ -81,6 +89,8 @@ function workspace(
     terminalSessionId: "term-1",
     worktreePath: "/worktrees/repo/feature",
     branch: "feature",
+    errorMessage: null,
+    retryFolderIntent: null,
     ...overrides,
   };
 }
@@ -122,6 +132,7 @@ function expand() {
 beforeEach(() => {
   focusTerminal.mockReset();
   retryMutate.mockReset();
+  createMutate.mockReset();
   terminalSessions.value = undefined;
   tabClient.value = {};
   retryClientArg.value = "unset";
@@ -318,6 +329,57 @@ describe("<SetupCardSegment /> single-repo dropdown (two steps)", () => {
       ownerKind: "chat",
       workspacePath: "/repo",
     });
+  });
+
+  it("re-provisions a provision failure via worktree.create, not retrySetup", () => {
+    const folderIntent = {
+      kind: "worktree" as const,
+      workspacePath: "/repo",
+      repoIdentifier: null,
+      isPrimary: true,
+      branch: {
+        type: "new" as const,
+        name: "traycer/fresh-fox",
+        source: "main",
+        carryUncommittedChanges: false,
+      },
+      scripts: null,
+    };
+    renderCard(
+      viewModel("failed", [
+        workspace({
+          state: "failed",
+          worktreePath: null,
+          errorMessage: "fatal: could not create work tree dir",
+          retryFolderIntent: folderIntent,
+        }),
+      ]),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry setup" }));
+    expect(createMutate).toHaveBeenCalledWith({
+      epicId: EPIC_ID,
+      ownerId: OWNER_ID,
+      ownerKind: "chat",
+      entries: [folderIntent],
+    });
+    expect(retryMutate).not.toHaveBeenCalled();
+  });
+
+  it("renders the provision failure reason on the failed card", () => {
+    renderCard(
+      viewModel("failed", [
+        workspace({
+          state: "failed",
+          worktreePath: null,
+          errorMessage: "fatal: a branch named 'traycer/x' already exists",
+        }),
+      ]),
+    );
+
+    expect(screen.getByTestId("setup-card-error-message").textContent).toBe(
+      "fatal: a branch named 'traycer/x' already exists",
+    );
   });
 
   it("offers Retry on a cancelled setup after expand", () => {

--- a/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
@@ -446,8 +446,10 @@ function WorkspaceSetupDetail(
         </li>
       </ol>
       {entry.state === "failed" && entry.errorMessage !== null ? (
+        // `role="alert"` announces the provisioning failure to assistive tech
+        // when it appears, and gives the message an accessible query handle.
         <p
-          data-testid="setup-card-error-message"
+          role="alert"
           className="m-0 whitespace-pre-wrap break-words pl-6 text-ui-sm text-destructive"
         >
           {entry.errorMessage}

--- a/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
@@ -7,7 +7,10 @@ import {
   X,
 } from "lucide-react";
 import { useMemo, useState } from "react";
-import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
+import type {
+  WorktreeBindingOwnerKind,
+  WorktreeFolderIntent,
+} from "@traycer/protocol/host/worktree-schemas";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,6 +31,7 @@ import { useFocusEpicTerminalSession } from "@/components/epic-canvas/renderers/
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import { useTerminalListFor } from "@/hooks/terminal/use-terminal-list-for-query";
 import { useWorktreeRetrySetupFor } from "@/hooks/worktree/use-worktree-retry-setup-mutation";
+import { useWorktreeCreateForClient } from "@/hooks/worktree/use-worktree-create-mutation";
 import { isVisibleRawTerminalSession } from "@/lib/terminals/terminal-session-filters";
 import { cn } from "@/lib/utils";
 import { LiveElapsed } from "./segment-elapsed";
@@ -68,6 +72,19 @@ export interface SetupCardWorkspace {
    */
   readonly worktreePath: string | null;
   readonly branch: string | null;
+  /**
+   * Failure reason from the failing `setup.*` event (a provision failure's
+   * git error). `null` for non-failed states and for script failures, which
+   * surface the exit code + terminal output instead.
+   */
+  readonly errorMessage: string | null;
+  /**
+   * Non-null only for a provision failure (`git worktree add` never ran or
+   * failed): the exact folder intent the failed create attempted. Retry
+   * re-provisions from it via `worktree.create` - `worktree.retrySetup` only
+   * re-runs setup scripts and rejects an entry with no worktree.
+   */
+  readonly retryFolderIntent: WorktreeFolderIntent | null;
 }
 
 /**
@@ -138,6 +155,7 @@ export function SetupCardSegment(props: {
   const focusTerminal = useFocusEpicTerminalSession(viewTabId);
   const tabClient = useTabHostClient();
   const retrySetup = useWorktreeRetrySetupFor(tabClient);
+  const worktreeCreate = useWorktreeCreateForClient(tabClient);
   const terminalList = useTerminalListFor(tabClient, {
     kind: "epic",
     epicId: aggregate.epicId,
@@ -164,12 +182,26 @@ export function SetupCardSegment(props: {
     return livenessKnown ? "ended" : "live";
   };
 
-  const handleRetry = (workspacePath: string): void => {
+  const handleRetry = (workspace: SetupCardWorkspace): void => {
+    // A provision failure has no worktree to re-run setup inside -
+    // `worktree.retrySetup` would reject it ("entry has no worktree"). Retry
+    // it by re-provisioning from the exact intent the failing event carried.
+    // Script failures keep the in-place `retrySetup` path: the worktree
+    // exists and only its setup script needs to re-run.
+    if (workspace.retryFolderIntent !== null) {
+      worktreeCreate.mutate({
+        epicId: aggregate.epicId,
+        ownerId: aggregate.ownerId,
+        ownerKind: aggregate.ownerKind,
+        entries: [workspace.retryFolderIntent],
+      });
+      return;
+    }
     retrySetup.mutate({
       epicId: aggregate.epicId,
       ownerId: aggregate.ownerId,
       ownerKind: aggregate.ownerKind,
-      workspacePath,
+      workspacePath: workspace.workspacePath,
     });
   };
 
@@ -205,7 +237,7 @@ export function SetupCardSegment(props: {
     focusTerminal,
     livenessFor,
     onRetry: handleRetry,
-    retryPending: retrySetup.isPending,
+    retryPending: retrySetup.isPending || worktreeCreate.isPending,
     tabReady,
     active: isActive,
   };
@@ -319,7 +351,7 @@ interface SharedHandlers {
     cwd: string,
   ) => void;
   readonly livenessFor: (sessionId: string | null) => TerminalLiveness;
-  readonly onRetry: (workspacePath: string) => void;
+  readonly onRetry: (workspace: SetupCardWorkspace) => void;
   readonly retryPending: boolean;
   /** Tab host client resolved - gates the `tabClient`-routed Retry. */
   readonly tabReady: boolean;
@@ -348,17 +380,14 @@ function WorkspaceSetupDetail(
   const liveness = livenessFor(entry.terminalSessionId);
   const retry =
     (entry.state === "failed" || entry.state === "cancelled") && tabReady ? (
-      <RetryButton
-        pending={retryPending}
-        onRetry={() => onRetry(entry.workspacePath)}
-      />
+      <RetryButton pending={retryPending} onRetry={() => onRetry(entry)} />
     ) : null;
   const reportIssue =
     entry.state === "failed" ? (
       <ReportIssueAction
         context={createReportIssueContext({
           title: "Worktree setup failed",
-          message: null,
+          message: entry.errorMessage,
           code: null,
           source: "Setup",
         })}
@@ -416,6 +445,14 @@ function WorkspaceSetupDetail(
           {reportIssue}
         </li>
       </ol>
+      {entry.state === "failed" && entry.errorMessage !== null ? (
+        <p
+          data-testid="setup-card-error-message"
+          className="m-0 whitespace-pre-wrap break-words pl-6 text-ui-sm text-destructive"
+        >
+          {entry.errorMessage}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/clients/gui-app/src/lib/chat/event-metadata.ts
+++ b/clients/gui-app/src/lib/chat/event-metadata.ts
@@ -19,3 +19,14 @@ export function readMetadataNumber(
   const value = metadata[key];
   return typeof value === "number" ? value : null;
 }
+
+/**
+ * Raw metadata value for structured payloads (objects the caller validates
+ * with a schema - e.g. the `folderIntent` a `setup.failed` event carries).
+ * Returns `undefined` when the event has no metadata or the key is absent.
+ */
+export function readMetadataValue(event: ChatEvent, key: string): unknown {
+  const metadata = event.metadata;
+  if (metadata === null) return undefined;
+  return metadata[key];
+}

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
   ChatEvent,
@@ -375,6 +375,13 @@ function persistedUserMessage(
 }
 
 describe("createChatSessionStore", () => {
+  // The worktree intent staging store is a module-global Zustand store; a test
+  // that leaves a staged (or restored-on-reject) intent behind would make later
+  // tests order-dependent. Reset it after every test so each starts clean.
+  afterEach(() => {
+    useWorktreeIntentStagingStore.getState().resetForTests();
+  });
+
   it("clears a running chat when the stream closes", () => {
     const harness = createHarness();
 
@@ -789,6 +796,77 @@ describe("createChatSessionStore", () => {
 
     // The rejected edit puts the selection back, so the chip reflects the
     // worktree the user chose rather than silently reverting to the binding.
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        worktreeStagingKeyString(key)
+      ],
+    ).toEqual(intent);
+  });
+
+  it("restores a staged worktree intent when a pending edit is swept after reconnect", () => {
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages: [persistedUserMessage("msg-original")],
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+    });
+    const key: WorktreeStagingKey = {
+      surface: "owner",
+      epicId: EPIC_ID,
+      ownerKind: "chat",
+      ownerId: CHAT_ID,
+    };
+    const intent: WorktreeIntent = {
+      entries: [
+        {
+          kind: "worktree",
+          scripts: null,
+          workspacePath: "/repo",
+          repoIdentifier: null,
+          isPrimary: true,
+          branch: {
+            type: "new",
+            name: "feat",
+            source: "main",
+            carryUncommittedChanges: false,
+          },
+        },
+      ],
+    };
+    useWorktreeIntentStagingStore.getState().stageIntent(key, intent);
+
+    const result = harness.handle.store.getState().editUserMessage({
+      targetMessageId: "msg-original",
+      content: CONTENT,
+      sender: { type: "user", userId: OWNER_ID },
+      settings: SETTINGS,
+      revertFileChanges: false,
+      revertArtifacts: false,
+    });
+    expect(result).not.toBeNull();
+    // Dispatch consumed the slot.
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        worktreeStagingKeyString(key)
+      ],
+    ).toBeUndefined();
+
+    // Connection drops before the ack (epoch bumps), then a fresh snapshot
+    // arrives with the edit still un-acked: the stale pending is swept, and the
+    // sweep restores its staged intent instead of leaving the slot cleared for
+    // the next resend to run against the prior binding.
+    callbacks.onConnectionStatus("reconnecting", null);
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages: [persistedUserMessage("msg-original")],
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+    });
+
     expect(
       useWorktreeIntentStagingStore.getState().intentByKey[
         worktreeStagingKeyString(key)

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -714,6 +714,88 @@ describe("createChatSessionStore", () => {
     ).toEqual(intent);
   });
 
+  it("restores a staged worktree intent when an edit-and-resend is rejected", () => {
+    useWorktreeIntentStagingStore.setState({ intentByKey: {} });
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    // Seed the message the edit targets so `editUserMessage` has something to
+    // rewrite. A stopped first message is the real-world trigger for this path.
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages: [persistedUserMessage("msg-original")],
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+    });
+    const key: WorktreeStagingKey = {
+      surface: "owner",
+      epicId: EPIC_ID,
+      ownerKind: "chat",
+      ownerId: CHAT_ID,
+    };
+    const intent: WorktreeIntent = {
+      entries: [
+        {
+          kind: "worktree",
+          scripts: null,
+          workspacePath: "/repo",
+          repoIdentifier: null,
+          isPrimary: true,
+          branch: {
+            type: "new",
+            name: "feat",
+            source: "main",
+            carryUncommittedChanges: false,
+          },
+        },
+      ],
+    };
+    useWorktreeIntentStagingStore.getState().stageIntent(key, intent);
+
+    const result = harness.handle.store.getState().editUserMessage({
+      targetMessageId: "msg-original",
+      content: CONTENT,
+      sender: { type: "user", userId: OWNER_ID },
+      settings: SETTINGS,
+      revertFileChanges: false,
+      revertArtifacts: false,
+    });
+    expect(result).not.toBeNull();
+
+    const frame = harness.sent.at(-1);
+    if (frame === undefined || frame.kind !== "editUserMessage") {
+      throw new Error("Expected editUserMessage frame");
+    }
+    expect(frame.worktreeIntent).toEqual(intent);
+    // The dispatch consumes the slot up front (mirrors send).
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        worktreeStagingKeyString(key)
+      ],
+    ).toBeUndefined();
+
+    callbacks.onActionAck({
+      kind: "actionAck",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      clientActionId: frame.clientActionId,
+      action: "editUserMessage",
+      status: "rejected",
+      reason: "feat already exists; choose a new branch name.",
+      code: "WORKTREE_CREATE_FAILED",
+      backgroundStopTaskIds: [],
+    });
+
+    // The rejected edit puts the selection back, so the chip reflects the
+    // worktree the user chose rather than silently reverting to the binding.
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        worktreeStagingKeyString(key)
+      ],
+    ).toEqual(intent);
+  });
+
   it("does not restore a rejected worktree intent after a newer explicit clear", () => {
     useWorktreeIntentStagingStore.getState().resetForTests();
     const harness = createHarness();
@@ -1616,6 +1698,84 @@ describe("createChatSessionStore", () => {
     expect(
       useWorktreeIntentMemoryStore.getState().getEpicIntent(EPIC_ID),
     ).toEqual(intent);
+  });
+
+  it("does not restore a rejected edit intent over a newer selection", () => {
+    useWorktreeIntentStagingStore.getState().resetForTests();
+    const harness = createHarness();
+    const callbacks = harness.callbacks();
+    emitSnapshot(callbacks, "owner");
+    const key: WorktreeStagingKey = {
+      surface: "owner",
+      epicId: EPIC_ID,
+      ownerKind: "chat",
+      ownerId: CHAT_ID,
+    };
+    const staleIntent: WorktreeIntent = {
+      entries: [
+        {
+          kind: "worktree",
+          scripts: null,
+          workspacePath: "/repo",
+          repoIdentifier: null,
+          isPrimary: true,
+          branch: {
+            type: "new",
+            name: "edited-stale",
+            source: "main",
+            carryUncommittedChanges: false,
+          },
+        },
+      ],
+    };
+    useWorktreeIntentStagingStore.getState().stageIntent(key, staleIntent);
+
+    harness.handle.store.getState().editUserMessage({
+      targetMessageId: "message-1",
+      content: CONTENT,
+      sender: { type: "user", userId: OWNER_ID },
+      settings: SETTINGS,
+      revertFileChanges: false,
+      revertArtifacts: true,
+    });
+    const frame = harness.sent.at(-1);
+    if (frame === undefined || frame.kind !== "editUserMessage") {
+      throw new Error("Expected editUserMessage frame");
+    }
+
+    // While the edit is in flight the user re-picks. The rejection of the
+    // OLD edit must not clobber this newer choice.
+    const newerIntent: WorktreeIntent = {
+      entries: [
+        {
+          kind: "local",
+          workspacePath: "/repo",
+          repoIdentifier: null,
+          isPrimary: true,
+        },
+      ],
+    };
+    useWorktreeIntentStagingStore.getState().stageIntent(key, newerIntent);
+
+    callbacks.onActionAck({
+      kind: "actionAck",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      clientActionId: frame.clientActionId,
+      action: "editUserMessage",
+      status: "rejected",
+      reason: "feat already exists; choose a new branch name.",
+      code: "WORKTREE_CREATE_FAILED",
+      backgroundStopTaskIds: [],
+    });
+
+    expect(
+      useWorktreeIntentStagingStore.getState().intentByKey[
+        worktreeStagingKeyString(key)
+      ],
+    ).toEqual(newerIntent);
+    useWorktreeIntentStagingStore.getState().resetForTests();
   });
 
   it("refuses edit and resend while staged worktree metadata is unresolved", () => {

--- a/clients/gui-app/src/stores/chats/__tests__/setup-card-rows.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/setup-card-rows.test.ts
@@ -218,6 +218,9 @@ describe("buildSetupCardRows", () => {
       // These events carry no worktreePath/branch metadata, so both are null.
       worktreePath: null,
       branch: null,
+      // Non-failed states never surface a failure reason or retry intent.
+      errorMessage: null,
+      retryFolderIntent: null,
     });
   });
 
@@ -250,6 +253,66 @@ describe("buildSetupCardRows", () => {
       state: "failed",
       setupExitCode: 17,
       terminalSessionId: "term-1",
+    });
+  });
+
+  it("surfaces a provision failure's reason and schema-valid retry intent", () => {
+    const folderIntent = {
+      kind: "worktree",
+      workspacePath: "/repo",
+      repoIdentifier: { owner: "acme", repo: "app" },
+      isPrimary: true,
+      branch: {
+        type: "new",
+        name: "traycer/fresh-fox",
+        source: "main",
+        carryUncommittedChanges: false,
+      },
+      scripts: null,
+    };
+    const row = onlyRow([
+      setupEvent(
+        "setup.creating",
+        { workspacePath: "/repo", branch: "traycer/fresh-fox" },
+        null,
+      ),
+      setupEvent(
+        "setup.failed",
+        {
+          workspacePath: "/repo",
+          branch: "traycer/fresh-fox",
+          operation: "provision",
+          setupExitCode: null,
+          errorMessage: "fatal: could not create work tree dir",
+          folderIntent,
+        },
+        null,
+      ),
+    ]);
+    expect(row.model.workspaces[0]).toMatchObject({
+      state: "failed",
+      errorMessage: "fatal: could not create work tree dir",
+      retryFolderIntent: folderIntent,
+    });
+  });
+
+  it("drops a malformed folderIntent instead of offering a broken retry", () => {
+    const row = onlyRow([
+      setupEvent(
+        "setup.failed",
+        {
+          workspacePath: "/repo",
+          operation: "provision",
+          errorMessage: "fatal: boom",
+          folderIntent: { kind: "worktree", workspacePath: "/repo" },
+        },
+        null,
+      ),
+    ]);
+    expect(row.model.workspaces[0]).toMatchObject({
+      state: "failed",
+      errorMessage: "fatal: boom",
+      retryFolderIntent: null,
     });
   });
 

--- a/clients/gui-app/src/stores/chats/__tests__/tui-agent-setup-card-model.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/tui-agent-setup-card-model.test.ts
@@ -85,6 +85,8 @@ describe("buildTuiAgentSetupCardModel", () => {
       terminalSessionId: "setup-term-1",
       worktreePath: "/home/me/repo-wt",
       branch: "feat/x",
+      errorMessage: null,
+      retryFolderIntent: null,
     });
   });
 

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -818,12 +818,12 @@ export function createChatSessionStore(
           // Every swept id came from this same `pendingActions` snapshot, so
           // the lookup is always present.
           const sweptPendings = get().pendingActions;
-          for (const sweptId of sweep.sweptActionIds) {
+          sweep.sweptActionIds.forEach((sweptId) => {
             restoreStagedWorktreeIntentForPending(
               sweptPendings[sweptId],
               stagingKey,
             );
-          }
+          });
         }
         set((state) => {
           const previousTurnId = snapshotPreviousTurnId(

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -640,6 +640,36 @@ function appendErrorNotice(
   ];
 }
 
+/**
+ * Re-stage the worktree intent a `send`/`editUserMessage` pending captured,
+ * unless the user has staged a newer selection since (revision guard). Shared
+ * by the rejection ack and the reconnect sweep: an edit dropped before its ack
+ * (connection lost mid-flight) never runs the rejection path, so without this
+ * its staged selection would stay cleared and the next resend would silently
+ * run against the prior binding - the exact silent-local-run the restore exists
+ * to prevent.
+ */
+function restoreStagedWorktreeIntentForPending(
+  pending: PendingChatAction,
+  stagingKey: WorktreeStagingKey,
+): void {
+  if (
+    pending.restoreWorktreeIntent === null ||
+    pending.restoreWorktreeStagingRevision === null
+  ) {
+    return;
+  }
+  if (
+    stagedWorktreeIntentRevision(stagingKey) !==
+    pending.restoreWorktreeStagingRevision
+  ) {
+    return;
+  }
+  useWorktreeIntentStagingStore
+    .getState()
+    .setIntent(stagingKey, pending.restoreWorktreeIntent);
+}
+
 export function createChatSessionStore(
   options: ChatSessionStoreOptions,
 ): ChatSessionStoreHandle {
@@ -767,6 +797,34 @@ export function createChatSessionStore(
           return;
         }
         flushBlockDeltas();
+        // Pendings dispatched on an earlier connection never see their ack, so
+        // the snapshot drops them (below). Computed here, before the set, so a
+        // swept `editUserMessage` gets its staged worktree intent restored the
+        // same way a rejected one does - the drop otherwise leaves the slot
+        // cleared and the next resend runs against the prior binding. Reads
+        // `get()` (no pendingActions mutation happens before the set), so it
+        // sees the same state the updater will.
+        const sweep = sweepStalePendingActions(
+          get().pendingActions,
+          connectionEpoch,
+        );
+        if (sweep.sweptActionIds.size > 0) {
+          const stagingKey: WorktreeStagingKey = {
+            surface: "owner",
+            epicId: options.epicId,
+            ownerKind: "chat",
+            ownerId: options.chatId,
+          };
+          // Every swept id came from this same `pendingActions` snapshot, so
+          // the lookup is always present.
+          const sweptPendings = get().pendingActions;
+          for (const sweptId of sweep.sweptActionIds) {
+            restoreStagedWorktreeIntentForPending(
+              sweptPendings[sweptId],
+              stagingKey,
+            );
+          }
+        }
         set((state) => {
           const previousTurnId = snapshotPreviousTurnId(
             state.activeTurn,
@@ -783,14 +841,11 @@ export function createChatSessionStore(
           const now = Date.now();
           // This snapshot is the authority for everything a lost connection
           // left in limbo: pendings dispatched on an earlier connection will
-          // never see their ack, so drop them here (controls re-enable; the
-          // user can re-issue against the state the snapshot shows). Message
-          // sends stay - `reconcileSnapshotChange` settles those by messageId
-          // with composer restoration.
-          const sweep = sweepStalePendingActions(
-            state.pendingActions,
-            connectionEpoch,
-          );
+          // never see their ack, so drop them (via `sweep`, computed above so
+          // swept edits restore their staged worktree intent). Controls
+          // re-enable; the user can re-issue against the state the snapshot
+          // shows. Message sends stay - `reconcileSnapshotChange` settles those
+          // by messageId with composer restoration.
           const pending = reconcileSnapshotChange({
             pendingActions: sweep.pendingActions,
             pendingUserMessages: state.pendingUserMessages,
@@ -905,27 +960,13 @@ export function createChatSessionStore(
           frame.status === "rejected"
             ? pendingActionForId(get().pendingActions, frame.clientActionId)
             : null;
-        if (
-          rejectedPending !== null &&
-          rejectedPending.restoreWorktreeIntent !== null &&
-          rejectedPending.restoreWorktreeStagingRevision !== null
-        ) {
-          const stagingKey: WorktreeStagingKey = {
+        if (rejectedPending !== null) {
+          restoreStagedWorktreeIntentForPending(rejectedPending, {
             surface: "owner",
             epicId: options.epicId,
             ownerKind: "chat",
             ownerId: options.chatId,
-          };
-          const stagingStore = useWorktreeIntentStagingStore.getState();
-          if (
-            stagedWorktreeIntentRevision(stagingKey) ===
-            rejectedPending.restoreWorktreeStagingRevision
-          ) {
-            stagingStore.setIntent(
-              stagingKey,
-              rejectedPending.restoreWorktreeIntent,
-            );
-          }
+          });
         }
         set((state) => {
           const pending = pendingActionForId(

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -1695,6 +1695,20 @@ export function createChatSessionStore(
           revertFileChanges: input.revertFileChanges,
           revertArtifacts: input.revertArtifacts,
         };
+        // Consume before dispatch, exactly like `sendMessage`: the pending
+        // action captures the staging revision it may later restore, so a
+        // rejected edit (e.g. the staged worktree failed to materialize) puts
+        // the selection back unless the user re-picked meanwhile. Without
+        // this, the folder chip silently reverts to the prior binding and the
+        // next resend runs there - the silent-local-run the reject exists to
+        // prevent.
+        const stagingStore = useWorktreeIntentStagingStore.getState();
+        let restoreWorktreeStagingRevision: number | null = null;
+        if (worktreeIntent !== null) {
+          stagingStore.clear(stagedKey);
+          restoreWorktreeStagingRevision =
+            stagedWorktreeIntentRevision(stagedKey);
+        }
         const sentClientActionId = sendAction({
           set,
           get,
@@ -1706,18 +1720,22 @@ export function createChatSessionStore(
             restoreContent: null,
             sender: null,
             settings: null,
-            restoreWorktreeIntent: null,
-            restoreWorktreeStagingRevision: null,
+            restoreWorktreeIntent: worktreeIntent,
+            restoreWorktreeStagingRevision,
             createdAt: Date.now(),
           },
           pendingUserMessage: null,
         });
-        if (sentClientActionId === null) return null;
+        if (sentClientActionId === null) {
+          if (worktreeIntent !== null) {
+            stagingStore.setIntent(stagedKey, worktreeIntent);
+          }
+          return null;
+        }
         if (worktreeIntent !== null) {
           useWorktreeIntentMemoryStore
             .getState()
             .setEpicIntent(options.epicId, worktreeIntent, Date.now());
-          useWorktreeIntentStagingStore.getState().clear(stagedKey);
           get().refreshMissingWorktreePaths([]);
         }
         return { clientActionId: sentClientActionId, messageId };

--- a/clients/gui-app/src/stores/chats/setup-card-rows.ts
+++ b/clients/gui-app/src/stores/chats/setup-card-rows.ts
@@ -1,8 +1,13 @@
 import type { ChatEvent } from "@traycer/protocol/persistence/epic/schemas";
-import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
+import {
+  worktreeFolderIntentSchema,
+  type WorktreeBindingOwnerKind,
+  type WorktreeFolderIntent,
+} from "@traycer/protocol/host/worktree-schemas";
 import {
   readMetadataNumber,
   readMetadataString,
+  readMetadataValue,
 } from "@/lib/chat/event-metadata";
 import { SETUP_EVENT_TYPES } from "@/lib/chat/setup-tone";
 import { workspaceFolderName } from "@/lib/worktree/workspace-folder-name";
@@ -300,6 +305,17 @@ function deriveWorkspace(
     // Only a `failed` state surfaces an exit code; the failing event carries it.
     setupExitCode:
       state === "failed" ? readMetadataNumber(latest, "setupExitCode") : null,
+    // The failure reason the host stamped on the failing event (a provision
+    // failure's git error, or null for a script failure - those surface the
+    // exit code + terminal instead).
+    errorMessage:
+      state === "failed" ? readMetadataString(latest, "errorMessage") : null,
+    // A provision failure carries the exact folder intent it attempted, so
+    // Retry can re-provision via `worktree.create`. Schema-validated: an
+    // older event without it (or a malformed value) resolves to null and
+    // Retry falls back to `worktree.retrySetup`.
+    retryFolderIntent:
+      state === "failed" ? readRetryFolderIntent(latest) : null,
     terminalSessionId: latestMetadataString(groupEvents, "terminalSessionId"),
     // Where + what was created, for the expanded view. Carried on every setup.*
     // event now, but read newest-first non-empty so a workspace inherits it even
@@ -307,6 +323,20 @@ function deriveWorkspace(
     worktreePath: latestMetadataString(groupEvents, "worktreePath"),
     branch: latestMetadataString(groupEvents, "branch"),
   };
+}
+
+/**
+ * Parse the `folderIntent` a provision-failure `setup.failed` event carries.
+ * Only a `worktree`-kind intent is retryable through `worktree.create`; a
+ * missing/malformed value (older hosts) yields null and the caller falls back
+ * to the script-retry path.
+ */
+function readRetryFolderIntent(event: ChatEvent): WorktreeFolderIntent | null {
+  const parsed = worktreeFolderIntentSchema.safeParse(
+    readMetadataValue(event, "folderIntent"),
+  );
+  if (!parsed.success) return null;
+  return parsed.data.kind === "worktree" ? parsed.data : null;
 }
 
 /**

--- a/clients/gui-app/src/stores/chats/tui-agent-setup-card-model.ts
+++ b/clients/gui-app/src/stores/chats/tui-agent-setup-card-model.ts
@@ -85,6 +85,11 @@ function toSetupCardWorkspace(entry: WorktreeBindingEntry): SetupCardWorkspace {
     terminalSessionId: entry.setupTerminalSessionId,
     worktreePath: entry.worktreePath,
     branch: entry.branch,
+    // Binding entries carry no failure reason or attempted intent - those live
+    // on the chat's `setup.failed` events, which this binding-derived model
+    // never sees. Script failures here surface the exit code + terminal.
+    errorMessage: null,
+    retryFolderIntent: null,
   };
 }
 

--- a/clients/shared/auth/__tests__/token-refresh-scheduler.test.ts
+++ b/clients/shared/auth/__tests__/token-refresh-scheduler.test.ts
@@ -158,13 +158,13 @@ describe("createProactiveRefreshScheduler", () => {
   it("does not re-arm when stopped while a refresh is in flight", async () => {
     const clock = makeFakeClock();
     const token: string = tokenExpiringAtMs(4 * HOUR_MS);
-    let resolveRefresh: (() => void) | null = null;
-    const revalidate = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveRefresh = resolve;
-        }),
-    );
+    // Held open so the refresh can be suspended mid-flight, then settled after
+    // `stop()`. A `let resolve … = null` captured inside the executor is not
+    // narrowed by control-flow analysis (the assignment happens in a callback),
+    // so calling it later reads as `never`; `withResolvers` keeps the resolver
+    // plainly typed and callable.
+    const refresh = Promise.withResolvers<void>();
+    const revalidate = vi.fn(() => refresh.promise);
 
     const scheduler = createProactiveRefreshScheduler<number>({
       getToken: () => token,
@@ -186,7 +186,7 @@ describe("createProactiveRefreshScheduler", () => {
     // Stop mid-flight, then let the refresh settle: the post-await `stopped`
     // guard must suppress the re-arm so no timer is left scheduled.
     scheduler.stop();
-    resolveRefresh?.();
+    refresh.resolve();
     for (let i = 0; i < 8; i++) {
       await Promise.resolve();
     }

--- a/clients/shared/host-transport/__tests__/auth-aware-messenger.test.ts
+++ b/clients/shared/host-transport/__tests__/auth-aware-messenger.test.ts
@@ -57,8 +57,14 @@ describe("createAuthAwareMessenger", () => {
   it("passes results through without revalidating on success", async () => {
     const revalidate = vi.fn();
     const auth: AuthRevalidator = { revalidateCurrentContext: revalidate };
+    // `IHostMessenger` requires `requestWithResponseTimeout` alongside
+    // `request`. These tests drive only the unary path (the wrapper routes the
+    // two independently), so the long-poll variant is a bare stub - if a future
+    // change starts routing `request` through it, these tests fail loudly on
+    // the unmet `inner.request` expectations rather than passing silently.
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockResolvedValue(undefined),
+      requestWithResponseTimeout: vi.fn(),
     };
 
     const wrapped = createAuthAwareMessenger(inner, auth, null);
@@ -72,6 +78,7 @@ describe("createAuthAwareMessenger", () => {
     const auth: AuthRevalidator = { revalidateCurrentContext: revalidate };
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(unauthorizedError()),
+      requestWithResponseTimeout: vi.fn(),
     };
 
     const wrapped = createAuthAwareMessenger(inner, auth, null);
@@ -88,6 +95,7 @@ describe("createAuthAwareMessenger", () => {
     const original = retryableUnauthorizedError();
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(original),
+      requestWithResponseTimeout: vi.fn(),
     };
 
     const wrapped = createAuthAwareMessenger(inner, auth, null);
@@ -104,6 +112,7 @@ describe("createAuthAwareMessenger", () => {
     const original = unauthorizedError();
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(original),
+      requestWithResponseTimeout: vi.fn(),
     };
     const auth: AuthRevalidator = {
       revalidateCurrentContext: vi
@@ -127,6 +136,7 @@ describe("createAuthAwareMessenger", () => {
     const auth: AuthRevalidator = { revalidateCurrentContext: revalidate };
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(rpcError()),
+      requestWithResponseTimeout: vi.fn(),
     };
 
     const wrapped = createAuthAwareMessenger(inner, auth, null);
@@ -141,7 +151,10 @@ describe("createAuthAwareMessenger", () => {
     const request = vi.fn();
     request.mockRejectedValueOnce(unauthorizedError());
     request.mockResolvedValueOnce(undefined);
-    const inner: IHostMessenger<Registry> = { request };
+    const inner: IHostMessenger<Registry> = {
+      request,
+      requestWithResponseTimeout: vi.fn(),
+    };
     const revalidate = vi.fn().mockImplementation(() => {
       lease.rotate("fresh");
       return Promise.resolve();
@@ -160,6 +173,7 @@ describe("createAuthAwareMessenger", () => {
     const lease = new MutableBearerLease("stale", "u1");
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(unauthorizedError()),
+      requestWithResponseTimeout: vi.fn(),
     };
     // refresh failed → lease unchanged, so no retry.
     const revalidate = vi.fn().mockResolvedValue(undefined);

--- a/clients/shared/host-transport/__tests__/auth-aware-messenger.test.ts
+++ b/clients/shared/host-transport/__tests__/auth-aware-messenger.test.ts
@@ -53,18 +53,26 @@ function retryableUnauthorizedError(): HostRpcError {
   });
 }
 
+// These tests drive only the unary `request` path; the wrapper routes the two
+// methods independently. Stub the long-poll variant with a throwing mock rather
+// than a bare `vi.fn()` (which resolves `undefined`) so an accidental route of
+// `request` through it fails loudly instead of silently passing on an invalid
+// result.
+function uncalledLongPoll() {
+  return vi.fn(() => {
+    throw new Error(
+      "requestWithResponseTimeout must not be called by these unary-path tests",
+    );
+  });
+}
+
 describe("createAuthAwareMessenger", () => {
   it("passes results through without revalidating on success", async () => {
     const revalidate = vi.fn();
     const auth: AuthRevalidator = { revalidateCurrentContext: revalidate };
-    // `IHostMessenger` requires `requestWithResponseTimeout` alongside
-    // `request`. These tests drive only the unary path (the wrapper routes the
-    // two independently), so the long-poll variant is a bare stub - if a future
-    // change starts routing `request` through it, these tests fail loudly on
-    // the unmet `inner.request` expectations rather than passing silently.
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockResolvedValue(undefined),
-      requestWithResponseTimeout: vi.fn(),
+      requestWithResponseTimeout: uncalledLongPoll(),
     };
 
     const wrapped = createAuthAwareMessenger(inner, auth, null);
@@ -78,7 +86,7 @@ describe("createAuthAwareMessenger", () => {
     const auth: AuthRevalidator = { revalidateCurrentContext: revalidate };
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(unauthorizedError()),
-      requestWithResponseTimeout: vi.fn(),
+      requestWithResponseTimeout: uncalledLongPoll(),
     };
 
     const wrapped = createAuthAwareMessenger(inner, auth, null);
@@ -95,7 +103,7 @@ describe("createAuthAwareMessenger", () => {
     const original = retryableUnauthorizedError();
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(original),
-      requestWithResponseTimeout: vi.fn(),
+      requestWithResponseTimeout: uncalledLongPoll(),
     };
 
     const wrapped = createAuthAwareMessenger(inner, auth, null);
@@ -112,7 +120,7 @@ describe("createAuthAwareMessenger", () => {
     const original = unauthorizedError();
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(original),
-      requestWithResponseTimeout: vi.fn(),
+      requestWithResponseTimeout: uncalledLongPoll(),
     };
     const auth: AuthRevalidator = {
       revalidateCurrentContext: vi
@@ -136,7 +144,7 @@ describe("createAuthAwareMessenger", () => {
     const auth: AuthRevalidator = { revalidateCurrentContext: revalidate };
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(rpcError()),
-      requestWithResponseTimeout: vi.fn(),
+      requestWithResponseTimeout: uncalledLongPoll(),
     };
 
     const wrapped = createAuthAwareMessenger(inner, auth, null);
@@ -153,7 +161,7 @@ describe("createAuthAwareMessenger", () => {
     request.mockResolvedValueOnce(undefined);
     const inner: IHostMessenger<Registry> = {
       request,
-      requestWithResponseTimeout: vi.fn(),
+      requestWithResponseTimeout: uncalledLongPoll(),
     };
     const revalidate = vi.fn().mockImplementation(() => {
       lease.rotate("fresh");
@@ -173,7 +181,7 @@ describe("createAuthAwareMessenger", () => {
     const lease = new MutableBearerLease("stale", "u1");
     const inner: IHostMessenger<Registry> = {
       request: vi.fn().mockRejectedValue(unauthorizedError()),
-      requestWithResponseTimeout: vi.fn(),
+      requestWithResponseTimeout: uncalledLongPoll(),
     };
     // refresh failed → lease unchanged, so no retry.
     const revalidate = vi.fn().mockResolvedValue(undefined);

--- a/clients/shared/host-transport/__tests__/retrying-messenger.test.ts
+++ b/clients/shared/host-transport/__tests__/retrying-messenger.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import {
   defineRpcContract,
@@ -62,8 +62,14 @@ function fakeInner(outcomes: ReadonlyArray<HostRpcError>): {
   calls: () => number;
 } {
   let call = 0;
-  const messenger: IHostMessenger<typeof testRegistry> = {
-    request(method, params) {
+  // Written as a `vi.fn()` rather than a hand-rolled `request<Method>(…)`
+  // method: the interface promises `ResponseOfMethod<Registry, Method>` for an
+  // unresolved `Method`, which a concrete `{ echoed }` literal cannot satisfy
+  // (the real wrapper only type-checks because it *delegates*, preserving the
+  // type parameter). The mock stays loosely typed and assignable.
+  const request = vi
+    .fn()
+    .mockImplementation((method: string, params: { message: string }) => {
       const index = call;
       call += 1;
       const outcome = outcomes[index];
@@ -72,7 +78,12 @@ function fakeInner(outcomes: ReadonlyArray<HostRpcError>): {
       }
       void method;
       return Promise.resolve({ echoed: params.message.toUpperCase() });
-    },
+    });
+  const messenger: IHostMessenger<typeof testRegistry> = {
+    request,
+    // The retry wrapper drives both paths through the same `runWithRetries`,
+    // so the long-poll variant shares this mock (and its call counter).
+    requestWithResponseTimeout: request,
   };
   return { messenger, calls: () => call };
 }

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -1749,7 +1749,13 @@ describe("WsStreamClient UNAUTHORIZED auth recovery", () => {
     const session = client.subscribe("epic.subscribe", { epicId: "e1" });
     session.onStatusChange((status) => statuses.push(status));
 
-    const driveFatal = async (frame: typeof UNAUTHORIZED_FATAL) => {
+    // Both fixtures are `as const`, so their `details.reason` (and the
+    // retryable variant's extra `retryable` flag) are literal types: this
+    // helper drives BOTH, and typing it as only the UNAUTHORIZED shape rejects
+    // the transient interlude the test is specifically about.
+    const driveFatal = async (
+      frame: typeof UNAUTHORIZED_FATAL | typeof RETRYABLE_FATAL,
+    ) => {
       const socket = sockets[sockets.length - 1].socket;
       socket.fireOpen();
       socket.fireText(frame);

--- a/clients/shared/package.json
+++ b/clients/shared/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
+    "compile": "tsc --noEmit",
     "lint": "eslint . --cache --fix --max-warnings 0",
     "format": "bun x prettier --write .",
     "test": "vitest run"

--- a/clients/shared/tsconfig.json
+++ b/clients/shared/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "paths": {
-      "@traycer-clients/shared/*": ["."],
+      "@traycer-clients/shared/*": ["./*"],
       "@traycer/protocol/utils/*": ["../../protocol/utils/*"],
       "@traycer/protocol/*": ["../../protocol/src/*"]
     }


### PR DESCRIPTION
## Summary

Two changes:

**1. Fix the silent-failure class around a mid-chat worktree selection that fails to provision** (`git worktree add` never runs or errors). Before this, three things went wrong and none of them told the user anything:

- the setup card showed **no failure reason** (the `setup.failed` event carried an `errorMessage`, but the card and the Report-issue action hardcoded `null`);
- **Retry** on the failed card called `worktree.retrySetup`, which only re-runs a *setup script* inside an existing worktree — for a provision failure there is no worktree, so it always rejected with "entry has no worktree";
- **editing and resending** a stopped message with a freshly-staged worktree, when the create failed, silently ran the replacement turn against the *prior* binding, and the folder chip reverted with no signal.

**2. Add a `compile` gate to `clients/shared` and fix the drift it surfaced** (see "clients/shared" below).

## Changes — worktree provision failures (gui-app)

- **Render the provision error** — `setup-card-rows` extracts `errorMessage` from the failing event; the segment renders it under the steps and feeds it to the Report-issue context.
- **Retry re-provisions** — the failing `setup.failed` event now carries the exact `folderIntent` it attempted (host side, companion internal PR). The card's Retry re-provisions through `worktree.create` from that intent for a provision failure; a *script* failure keeps the in-place `worktree.retrySetup` path. An older event without the intent falls back to the script path, so nothing regresses against an older host.
- **Restore the staged intent on a rejected edit-and-resend** — `editUserMessage` now captures `restoreWorktreeIntent` + the staging revision on its pending action, mirroring `sendMessage`, so a rejected resend puts the worktree selection back (unless the user re-picked meanwhile) instead of silently reverting to the prior binding.

## Changes — clients/shared compile gate

`clients/shared` had **no `compile` script**, so `tsc` never ran over it directly — it was only type-checked transitively by consumers, which exclude test dirs. Its `@traycer-clients/shared/*` path mapped to `["."]` (no `*` placeholder), so shared's own subpath self-imports never resolved; every other consumer maps it `../shared/*`, shared was the lone anomaly.

- fix the mapping to `["./*"]`; add a `compile` target — **repo-wide compile now covers this workspace (5 projects, was 4)**;
- repair the test-only type errors the working mapping then exposed (mocks predating `requestWithResponseTimeout` on `IHostMessenger`, a generic-return violation, a closure-narrowing `never`, an over-narrow `as const` param).

> **Reviewer note:** this widens what CI type-checks. `clients/shared` test files were previously unchecked.

## Verification

- `bun run --filter @traycer-clients/gui-app compile`; `nx run @traycer-clients/shared:compile`.
- Vitest — gui-app: `chat-session-store`, `setup-card-rows`, `tui-agent-setup-card-model`, `setup-card-segment`, `chat-message-setup-card` (new coverage for the provision-error render, the `worktree.create`-vs-`retrySetup` Retry branch, and the edit-and-resend restore). shared: 347 passed.
- Live-verified end to end in the dev desktop (picker resolves, provision failure surfaces its git error, Retry re-provisions and creates the worktree, staged intent restored on a rejected resend).

## Companion

Host-side changes (the `resolvedAt` fix that unblocks the picker, warn-level logging, the edit-resend reject, and the `folderIntent` event metadata this card reads) ship in the internal repo's companion PR; the gitlink is re-pinned to this PR's squash commit after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
