### PR TITLE
fix(gui): make HostRpcError query/mutation error generics true by construction

### DIFF
--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-kill-mutation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-kill-mutation.ts
@@ -3,6 +3,8 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
 import type {
   HostRpcError,
   ResponseOfMethod,
@@ -38,31 +40,37 @@ export function useLandingTerminalKill(): UseMutationResult<
   const defaultClient = useHostClient();
   const directory = useHostDirectory();
 
-  return useMutation({
-    mutationKey: terminalMutationKeys.kill(),
-    mutationFn: (variables) => {
-      const client = clientForLandingTerminal(
-        defaultClient,
-        directory.findById(variables.hostId),
-      );
-      if (client === null) {
-        return Promise.reject(hostClientUnavailableError("terminal.kill"));
-      }
-      return client.request("terminal.kill", {
-        sessionId: variables.sessionId,
-      });
-    },
-    onSuccess: (_response, variables) => {
-      // An acknowledgement is the durable boundary: only now can a tombstone
-      // be cleared without reopening adoption to a still-running PTY.
-      useLandingTerminalStore
-        .getState()
-        .clearPendingKill(variables.hostId, variables.sessionId);
-      void queryClient.invalidateQueries({
-        queryKey: hostQueryKeys.methodScope(variables.hostId, "terminal.list"),
-      });
-    },
-  });
+  return useMutation(
+    withHostMutationLifecycleBoundary("terminal.kill", {
+      mutationKey: terminalMutationKeys.kill(),
+      mutationFn: (variables) =>
+        withHostRpcErrorBoundary("terminal.kill", () => {
+          const client = clientForLandingTerminal(
+            defaultClient,
+            directory.findById(variables.hostId),
+          );
+          if (client === null) {
+            return Promise.reject(hostClientUnavailableError("terminal.kill"));
+          }
+          return client.request("terminal.kill", {
+            sessionId: variables.sessionId,
+          });
+        }),
+      onSuccess: (_response, variables) => {
+        // An acknowledgement is the durable boundary: only now can a tombstone
+        // be cleared without reopening adoption to a still-running PTY.
+        useLandingTerminalStore
+          .getState()
+          .clearPendingKill(variables.hostId, variables.sessionId);
+        void queryClient.invalidateQueries({
+          queryKey: hostQueryKeys.methodScope(
+            variables.hostId,
+            "terminal.list",
+          ),
+        });
+      },
+    }),
+  );
 }
 
 function clientForLandingTerminal(

--- a/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
+++ b/clients/gui-app/src/components/home/terminal-panel/use-landing-terminal-reconciliation.ts
@@ -2,6 +2,7 @@ import { queryOptions, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { toHostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcRegistry } from "@/lib/host";
 import { hostQueryKeys } from "@/lib/query-keys";
 import {
@@ -41,11 +42,11 @@ function abortableRequest<Value>(
       },
       (error: unknown) => {
         signal.removeEventListener("abort", onAbort);
-        reject(
-          error instanceof Error
-            ? error
-            : new Error("Landing terminal list request failed"),
-        );
+        // Normalized, not passed through raw: this queryFn writes the same
+        // `terminal.list` cache slot that `useTerminalListFor` types as
+        // `HostRpcError`. The abort path above stays a DOMException so
+        // TanStack's cancellation handling is untouched.
+        reject(toHostRpcError(error, "terminal.list"));
       },
     );
   });

--- a/clients/gui-app/src/components/settings/panels/worktrees-enrichment.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-enrichment.ts
@@ -14,6 +14,7 @@ import {
   type QueryKey,
 } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { WorktreeHostEntryV14 } from "@traycer/protocol/host/index";
 import type { WorktreeListAllForHostResponseV14 } from "@traycer/protocol/host/worktree-schemas";
 import { type HostRpcRegistry } from "@/lib/host";
@@ -155,8 +156,13 @@ function sweepEnrichmentFetchOptions(
   client: HostClient<HostRpcRegistry>,
   path: string,
 ) {
+  // Boundary-wrapped: the sweep and the `useHostQueries` observer leg share
+  // this key, so a sweep failure must store the same `HostRpcError` shape the
+  // observer's error generic declares.
   const fetcher = () =>
-    client.request("worktree.listAllForHost", perPathEnrichmentParams(path));
+    withHostRpcErrorBoundary("worktree.listAllForHost", () =>
+      client.request("worktree.listAllForHost", perPathEnrichmentParams(path)),
+    );
   return queryOptions({
     queryKey: perPathEnrichmentQueryKey(hostId, path),
     queryFn: fetcher,

--- a/clients/gui-app/src/components/settings/panels/worktrees-listing-query.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-listing-query.ts
@@ -6,7 +6,9 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
 import type { WorktreeHostEntryV14 } from "@traycer/protocol/host/index";
 import type { WorktreeListAllForHostResponseV14 } from "@traycer/protocol/host/worktree-schemas";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -155,20 +157,21 @@ export function useWorktreeListing(
       restoredCount: snapshot.entries.length,
     });
   }, [queryClient, readiness.hostId]);
-  const fetchWorktreeListPage = async ({
+  const fetchWorktreeListPage = ({
     pageParam,
   }: {
     readonly pageParam: string | null;
-  }): Promise<WorktreeListAllForHostResponseV14> => {
-    if (client === null) {
-      throw hostClientUnavailableError("worktree.listAllForHost");
-    }
-    return client.request("worktree.listAllForHost", {
-      ...SETTINGS_WORKTREE_LIST_BASE_PARAMS,
-      cursor: pageParam,
-      forceRefresh: false,
+  }): Promise<WorktreeListAllForHostResponseV14> =>
+    withHostRpcErrorBoundary("worktree.listAllForHost", async () => {
+      if (client === null) {
+        throw hostClientUnavailableError("worktree.listAllForHost");
+      }
+      return client.request("worktree.listAllForHost", {
+        ...SETTINGS_WORKTREE_LIST_BASE_PARAMS,
+        cursor: pageParam,
+        forceRefresh: false,
+      });
     });
-  };
   const {
     data,
     error,
@@ -196,49 +199,51 @@ export function useWorktreeListing(
       enabled,
     }),
   );
-  // `HostRpcError` error generic: the mutationFn only rejects via
-  // `client.request`, whose failures are always host RPC errors.
   const refreshMutation = useMutation<
     WorktreeListAllForHostResponseV14,
     HostRpcError,
     { readonly client: HostClient<HostRpcRegistry>; readonly hostId: string }
-  >({
-    mutationKey: worktreeMutationKeys.refreshListing(),
-    // The Refresh button's only failure signal was the spinner stopping - the
-    // rejected promise is swallowed by useRefreshSpinner.
-    onError: (error) =>
-      toastFromHostError(error, "Couldn't refresh worktrees."),
-    mutationFn: (input) =>
-      input.client.request("worktree.listAllForHost", {
-        includeActivity: false,
-        activityPaths: null,
-        cursor: null,
-        limit: null,
-        forceRefresh: true,
-      }),
-    onSuccess: (response, input) => {
-      queryClient.setQueryData<
-        InfiniteData<WorktreeListAllForHostResponseV14, string | null>
-      >(listingQueryKeyFor(input.hostId), {
-        pages: [response],
-        pageParams: [null],
-      });
-      // The forced listing re-resolves the BASE rows, so every cached overlay
-      // is now older than its base row and `acceptedEnrichedByPath` rejects it
-      // - the rows read "Checking..." until something re-probes them. Nothing
-      // would: the overlays keep their keys, so they are neither invalidated
-      // nor sweep candidates. Without this the Refresh button strands every
-      // on-screen row, permanently on a host that lacks `worktree.changed`.
-      void queryClient.invalidateQueries({
-        queryKey: hostQueryKeys.methodScope(
-          input.hostId,
-          "worktree.listAllForHost",
+  >(
+    withHostMutationLifecycleBoundary("worktree.listAllForHost", {
+      mutationKey: worktreeMutationKeys.refreshListing(),
+      // The Refresh button's only failure signal was the spinner stopping - the
+      // rejected promise is swallowed by useRefreshSpinner.
+      onError: (error) =>
+        toastFromHostError(error, "Couldn't refresh worktrees."),
+      mutationFn: (input) =>
+        withHostRpcErrorBoundary("worktree.listAllForHost", () =>
+          input.client.request("worktree.listAllForHost", {
+            includeActivity: false,
+            activityPaths: null,
+            cursor: null,
+            limit: null,
+            forceRefresh: true,
+          }),
         ),
-        refetchType: "active",
-        predicate: (query) => isPerPathEnrichmentQueryKey(query.queryKey),
-      });
-    },
-  });
+      onSuccess: (response, input) => {
+        queryClient.setQueryData<
+          InfiniteData<WorktreeListAllForHostResponseV14, string | null>
+        >(listingQueryKeyFor(input.hostId), {
+          pages: [response],
+          pageParams: [null],
+        });
+        // The forced listing re-resolves the BASE rows, so every cached overlay
+        // is now older than its base row and `acceptedEnrichedByPath` rejects it
+        // - the rows read "Checking..." until something re-probes them. Nothing
+        // would: the overlays keep their keys, so they are neither invalidated
+        // nor sweep candidates. Without this the Refresh button strands every
+        // on-screen row, permanently on a host that lacks `worktree.changed`.
+        void queryClient.invalidateQueries({
+          queryKey: hostQueryKeys.methodScope(
+            input.hostId,
+            "worktree.listAllForHost",
+          ),
+          refetchType: "active",
+          predicate: (query) => isPerPathEnrichmentQueryKey(query.queryKey),
+        });
+      },
+    }),
+  );
   useEffect(() => {
     if (!enabled) return;
     if (!hasNextPage) return;

--- a/clients/gui-app/src/hooks/agent/use-prepare-tui-launch-mutation.ts
+++ b/clients/gui-app/src/hooks/agent/use-prepare-tui-launch-mutation.ts
@@ -1,7 +1,11 @@
 import { useMutation, type UseMutationResult } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import { HostRpcError as HostRpcErrorCtor } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  HostRpcError as HostRpcErrorCtor,
+  withHostRpcErrorBoundary,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
 import type {
   RequestOfMethod,
   ResponseOfMethod,
@@ -33,28 +37,31 @@ export function useAgentStartTerminalSession(
     HostRpcError,
     RequestOfMethod<HostRpcRegistry, "agent.tui.prepareLaunch">,
     StartTerminalSessionMutationContext
-  >({
-    mutationKey: agentMutationKeys.startTerminalSession(),
-    mutationFn: (variables) => {
-      if (client === null) {
-        return Promise.reject(
-          new HostRpcErrorCtor({
-            code: "RPC_ERROR",
-            message: "Cannot prepare terminal agent without a host client.",
-            requestId: "client-preflight",
-            method: "agent.tui.prepareLaunch",
-            fatalDetails: null,
-          }),
+  >(
+    withHostMutationLifecycleBoundary("agent.tui.prepareLaunch", {
+      mutationKey: agentMutationKeys.startTerminalSession(),
+      mutationFn: (variables) =>
+        withHostRpcErrorBoundary("agent.tui.prepareLaunch", () => {
+          if (client === null) {
+            return Promise.reject(
+              new HostRpcErrorCtor({
+                code: "RPC_ERROR",
+                message: "Cannot prepare terminal agent without a host client.",
+                requestId: "client-preflight",
+                method: "agent.tui.prepareLaunch",
+                fatalDetails: null,
+              }),
+            );
+          }
+          return client.request("agent.tui.prepareLaunch", variables);
+        }),
+      onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
+      onError: (error) => {
+        toastFromHostErrorWithDetail(
+          error,
+          "Couldn't start terminal agent session.",
         );
-      }
-      return client.request("agent.tui.prepareLaunch", variables);
-    },
-    onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
-    onError: (error) => {
-      toastFromHostErrorWithDetail(
-        error,
-        "Couldn't start terminal agent session.",
-      );
-    },
-  });
+      },
+    }),
+  );
 }

--- a/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
@@ -14,8 +14,14 @@ import type {
   UpdateChatRunSettingsResponse,
 } from "@traycer/protocol/host/epic/unary-schemas";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
-import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import { useHostMutation } from "@/hooks/host/use-host-query";
+import {
+  HostRpcError,
+  withHostRpcErrorBoundary,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  useHostMutation,
+  withHostMutationLifecycleBoundary,
+} from "@/hooks/host/use-host-query";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
@@ -46,10 +52,10 @@ export type DeleteChatMutationOptions = Omit<
  *
  * Owns the per-tab host binding rule (`chatSchema.hostId` is required)
  * by stamping `hostId` from `useReactiveActiveHostId()` in the request
- * mapper. If no host is active at mutate time, the mutation
- * rejects synchronously with a `HostRpcError` so the failure surfaces
- * through `onError` (and `toastFromHostError`) instead of silently
- * dropping the action at the call site.
+ * mapper. If no host is active at mutate time, the mutation rejects
+ * through the mutation error channel with a `HostRpcError` so the failure
+ * surfaces through `onError` (and `toastFromHostError`) instead of
+ * silently dropping the action at the call site.
  *
  * Uses `useHostMutation` with a request mapper so the host RPC path stays
  * centralized while callers still pass host-agnostic chat inputs.
@@ -113,9 +119,10 @@ export function useEpicCreateChatForHost(): UseMutationResult<
  * an explicit `HostClient` (e.g. via `useHostClientFor` for a sidebar
  * row's OWN host) and the hook stamps that client's host id onto the new
  * chat, rather than the app-wide active host. `null` client (offline /
- * directory unresolved) rejects synchronously so the caller can disable the
- * affordance. `useEpicCreateChatForHost` is the tab-scoped wrapper over
- * this; row child-create passes the row's host client.
+ * directory unresolved) rejects through the mutation error channel so the
+ * caller can disable the affordance. `useEpicCreateChatForHost` is the
+ * tab-scoped wrapper over this; row child-create passes the row's host
+ * client.
  */
 export function useEpicCreateChatForHostClient(
   client: HostClient<HostRpcRegistry> | null,
@@ -131,43 +138,50 @@ export function useEpicCreateChatForHostClient(
     HostRpcError,
     CreateChatMutationInput,
     CreateChatMutationContext
-  >({
-    mutationKey: epicMutationKeys.createChat(),
-    mutationFn: (params) => {
-      if (client === null) {
-        return Promise.reject<CreateChatResponse>(
-          new HostRpcError({
-            code: "RPC_ERROR",
-            message:
-              "Host client unavailable - directory not resolved or signed out.",
-            requestId: "client-pre-flight",
-            method: "epic.createChat",
-            fatalDetails: null,
-          }),
-        );
-      }
-      const hostId = client.getActiveHostId();
-      if (hostId === null) {
-        return Promise.reject<CreateChatResponse>(
-          new HostRpcError({
-            code: "RPC_ERROR",
-            message: "Tab host identity unavailable - cannot stamp hostId.",
-            requestId: "client-pre-flight",
-            method: "epic.createChat",
-            fatalDetails: null,
-          }),
-        );
-      }
-      return client.request("epic.createChat", { ...params, hostId });
-    },
-    onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
-    onSuccess: (_data, _params, ctx) => {
-      invalidateBindingsForEpic(queryClient, ctx.hostId);
-    },
-    onError: (error) => {
-      toastFromHostError(error, "Couldn't create chat.");
-    },
-  });
+  >(
+    withHostMutationLifecycleBoundary<
+      CreateChatResponse,
+      CreateChatMutationInput,
+      CreateChatMutationContext
+    >("epic.createChat", {
+      mutationKey: epicMutationKeys.createChat(),
+      mutationFn: (params) =>
+        withHostRpcErrorBoundary("epic.createChat", () => {
+          if (client === null) {
+            return Promise.reject<CreateChatResponse>(
+              new HostRpcError({
+                code: "RPC_ERROR",
+                message:
+                  "Host client unavailable - directory not resolved or signed out.",
+                requestId: "client-pre-flight",
+                method: "epic.createChat",
+                fatalDetails: null,
+              }),
+            );
+          }
+          const hostId = client.getActiveHostId();
+          if (hostId === null) {
+            return Promise.reject<CreateChatResponse>(
+              new HostRpcError({
+                code: "RPC_ERROR",
+                message: "Tab host identity unavailable - cannot stamp hostId.",
+                requestId: "client-pre-flight",
+                method: "epic.createChat",
+                fatalDetails: null,
+              }),
+            );
+          }
+          return client.request("epic.createChat", { ...params, hostId });
+        }),
+      onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
+      onSuccess: (_data, _params, ctx) => {
+        invalidateBindingsForEpic(queryClient, ctx.hostId);
+      },
+      onError: (error) => {
+        toastFromHostError(error, "Couldn't create chat.");
+      },
+    }),
+  );
 }
 
 function invalidateBindingsForEpic(
@@ -205,21 +219,22 @@ export function useEpicUpdateChatRunSettings(): UseMutationResult<
     UpdateChatRunSettingsRequest
   >({
     mutationKey: epicMutationKeys.updateChatRunSettings(),
-    mutationFn: (params) => {
-      if (client === null) {
-        return Promise.reject<UpdateChatRunSettingsResponse>(
-          new HostRpcError({
-            code: "RPC_ERROR",
-            message:
-              "Host client unavailable - directory not resolved or signed out.",
-            requestId: "client-pre-flight",
-            method: "epic.updateChatRunSettings",
-            fatalDetails: null,
-          }),
-        );
-      }
-      return client.request("epic.updateChatRunSettings", params);
-    },
+    mutationFn: (params) =>
+      withHostRpcErrorBoundary("epic.updateChatRunSettings", () => {
+        if (client === null) {
+          return Promise.reject<UpdateChatRunSettingsResponse>(
+            new HostRpcError({
+              code: "RPC_ERROR",
+              message:
+                "Host client unavailable - directory not resolved or signed out.",
+              requestId: "client-pre-flight",
+              method: "epic.updateChatRunSettings",
+              fatalDetails: null,
+            }),
+          );
+        }
+        return client.request("epic.updateChatRunSettings", params);
+      }),
   });
 }
 

--- a/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
@@ -1,6 +1,5 @@
 import {
   QueryClient,
-  useMutation,
   useQueryClient,
   type UseMutationOptions,
   type UseMutationResult,
@@ -14,14 +13,8 @@ import type {
   UpdateChatRunSettingsResponse,
 } from "@traycer/protocol/host/epic/unary-schemas";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
-import {
-  HostRpcError,
-  withHostRpcErrorBoundary,
-} from "@traycer-clients/shared/host-transport/host-messenger";
-import {
-  useHostMutation,
-  withHostMutationLifecycleBoundary,
-} from "@/hooks/host/use-host-query";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { useHostMutation } from "@/hooks/host/use-host-query";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
 import type { HostRpcRegistry } from "@traycer/protocol/host/index";
@@ -120,9 +113,12 @@ export function useEpicCreateChatForHost(): UseMutationResult<
  * row's OWN host) and the hook stamps that client's host id onto the new
  * chat, rather than the app-wide active host. `null` client (offline /
  * directory unresolved) rejects through the mutation error channel so the
- * caller can disable the affordance. `useEpicCreateChatForHost` is the
- * tab-scoped wrapper over this; row child-create passes the row's host
- * client.
+ * caller can disable the affordance - `useHostMutation`'s own `client ===
+ * null` guard covers that case; only the second-stage "client resolved but
+ * host identity unset" check lives in `mapVariables` here (also normalized
+ * to `HostRpcError` by `useHostMutation`'s boundary). `useEpicCreateChatForHost`
+ * is the tab-scoped wrapper over this; row child-create passes the row's
+ * host client.
  */
 export function useEpicCreateChatForHostClient(
   client: HostClient<HostRpcRegistry> | null,
@@ -133,46 +129,29 @@ export function useEpicCreateChatForHostClient(
   CreateChatMutationContext
 > {
   const queryClient = useQueryClient();
-  return useMutation<
-    CreateChatResponse,
-    HostRpcError,
-    CreateChatMutationInput,
-    CreateChatMutationContext
-  >(
-    withHostMutationLifecycleBoundary<
-      CreateChatResponse,
-      CreateChatMutationInput,
-      CreateChatMutationContext
-    >("epic.createChat", {
+  return useHostMutation<
+    HostRpcRegistry,
+    "epic.createChat",
+    CreateChatMutationContext,
+    CreateChatMutationInput
+  >({
+    client,
+    method: "epic.createChat",
+    mapVariables: (params) => {
+      const hostId = client?.getActiveHostId() ?? null;
+      if (hostId === null) {
+        throw new HostRpcError({
+          code: "RPC_ERROR",
+          message: "Tab host identity unavailable - cannot stamp hostId.",
+          requestId: "client-pre-flight",
+          method: "epic.createChat",
+          fatalDetails: null,
+        });
+      }
+      return { ...params, hostId };
+    },
+    options: {
       mutationKey: epicMutationKeys.createChat(),
-      mutationFn: (params) =>
-        withHostRpcErrorBoundary("epic.createChat", () => {
-          if (client === null) {
-            return Promise.reject<CreateChatResponse>(
-              new HostRpcError({
-                code: "RPC_ERROR",
-                message:
-                  "Host client unavailable - directory not resolved or signed out.",
-                requestId: "client-pre-flight",
-                method: "epic.createChat",
-                fatalDetails: null,
-              }),
-            );
-          }
-          const hostId = client.getActiveHostId();
-          if (hostId === null) {
-            return Promise.reject<CreateChatResponse>(
-              new HostRpcError({
-                code: "RPC_ERROR",
-                message: "Tab host identity unavailable - cannot stamp hostId.",
-                requestId: "client-pre-flight",
-                method: "epic.createChat",
-                fatalDetails: null,
-              }),
-            );
-          }
-          return client.request("epic.createChat", { ...params, hostId });
-        }),
       onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
       onSuccess: (_data, _params, ctx) => {
         invalidateBindingsForEpic(queryClient, ctx.hostId);
@@ -180,8 +159,8 @@ export function useEpicCreateChatForHostClient(
       onError: (error) => {
         toastFromHostError(error, "Couldn't create chat.");
       },
-    }),
-  );
+    },
+  });
 }
 
 function invalidateBindingsForEpic(
@@ -213,28 +192,18 @@ export function useEpicUpdateChatRunSettings(): UseMutationResult<
   UpdateChatRunSettingsRequest
 > {
   const client = useTabHostClient();
-  return useMutation<
-    UpdateChatRunSettingsResponse,
-    HostRpcError,
+  return useHostMutation<
+    HostRpcRegistry,
+    "epic.updateChatRunSettings",
+    unknown,
     UpdateChatRunSettingsRequest
   >({
-    mutationKey: epicMutationKeys.updateChatRunSettings(),
-    mutationFn: (params) =>
-      withHostRpcErrorBoundary("epic.updateChatRunSettings", () => {
-        if (client === null) {
-          return Promise.reject<UpdateChatRunSettingsResponse>(
-            new HostRpcError({
-              code: "RPC_ERROR",
-              message:
-                "Host client unavailable - directory not resolved or signed out.",
-              requestId: "client-pre-flight",
-              method: "epic.updateChatRunSettings",
-              fatalDetails: null,
-            }),
-          );
-        }
-        return client.request("epic.updateChatRunSettings", params);
-      }),
+    client,
+    method: "epic.updateChatRunSettings",
+    mapVariables: (variables) => variables,
+    options: {
+      mutationKey: epicMutationKeys.updateChatRunSettings(),
+    },
   });
 }
 

--- a/clients/gui-app/src/hooks/epic/use-task-delete-worktree-candidates-query.ts
+++ b/clients/gui-app/src/hooks/epic/use-task-delete-worktree-candidates-query.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { queryOptions, useQuery } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type {
   WorktreeBranchStatus,
@@ -108,13 +109,19 @@ export function useTaskDeleteWorktreeCandidates(
         "worktree.listAllForHost exceeded the maximum pagination page count",
       );
     };
+  // Boundary-wrapped: the pagination guards above throw bare `Error`s, which
+  // must not leak through the declared `HostRpcError` generic. Stays a NAMED
+  // queryFn so the closure is not mistaken for missing cache identity.
+  const fetchWorktreePagesNormalized =
+    (): Promise<WorktreeListAllForHostResponseV14> =>
+      withHostRpcErrorBoundary("worktree.listAllForHost", fetchWorktreePages);
   const { data, isError } = useQuery(
     queryOptions<WorktreeListAllForHostResponseV14, HostRpcError>({
       queryKey: hostQueryKeys.method<
         HostRpcRegistry,
         "worktree.listAllForHost"
       >(readiness.hostId, "worktree.listAllForHost", queryParams),
-      queryFn: fetchWorktreePages,
+      queryFn: fetchWorktreePagesNormalized,
       enabled: deletedEpicIds !== null && readiness.isReady,
       retry: false,
     }),

--- a/clients/gui-app/src/hooks/git/use-git-get-file-diff-query.ts
+++ b/clients/gui-app/src/hooks/git/use-git-get-file-diff-query.ts
@@ -3,6 +3,7 @@ import {
   useQuery,
   type UseQueryResult,
 } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type {
   GitGetFileDiffRequest,
@@ -52,27 +53,28 @@ export function useGitGetFileDiffQuery(args: {
           args.byteBudget,
         ),
       ],
-      queryFn: async () => {
-        // client is captured from closure. enabled: readiness.isReady ensures it's available.
-        // The enabled flag prevents this queryFn from running when client is unavailable,
-        // but a defensive runtime guard is retained against future refactors.
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        if (!client) {
-          // A `HostRpcError` (not a bare Error): this query publicly declares
-          // that error type and UI surfaces read `.code`.
-          throw hostClientUnavailableError("git.getFileDiff");
-        }
-        const request: GitGetFileDiffRequest = {
-          hostId: args.hostId ?? "",
-          runningDir: args.runningDir,
-          filePath: args.filePath,
-          previousPath: args.previousPath,
-          stage: args.stage,
-          ignoreWhitespace: args.ignoreWhitespace,
-          byteBudget: args.byteBudget,
-        };
-        return client.request("git.getFileDiff", request);
-      },
+      queryFn: () =>
+        withHostRpcErrorBoundary("git.getFileDiff", async () => {
+          // client is captured from closure. enabled: readiness.isReady ensures it's available.
+          // The enabled flag prevents this queryFn from running when client is unavailable,
+          // but a defensive runtime guard is retained against future refactors.
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+          if (!client) {
+            // A `HostRpcError` (not a bare Error): this query publicly declares
+            // that error type and UI surfaces read `.code`.
+            throw hostClientUnavailableError("git.getFileDiff");
+          }
+          const request: GitGetFileDiffRequest = {
+            hostId: args.hostId ?? "",
+            runningDir: args.runningDir,
+            filePath: args.filePath,
+            previousPath: args.previousPath,
+            stage: args.stage,
+            ignoreWhitespace: args.ignoreWhitespace,
+            byteBudget: args.byteBudget,
+          };
+          return client.request("git.getFileDiff", request);
+        }),
       staleTime: Infinity,
       gcTime: 30 * 60 * 1000,
     }),

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-with-submodules.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-with-submodules.ts
@@ -5,6 +5,7 @@ import {
   useQueryClient,
   type QueryClient,
 } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { GitListChangedFilesResponseV11 } from "@traycer/protocol/host";
 import { hostClientUnavailableError } from "@/hooks/host/use-host-query";
@@ -312,7 +313,7 @@ export function useGitListChangedFilesWithSubmodules(args: {
   // the cache key: it is transport identity, not data identity. Wrapped in
   // the generation-aware rich-slot request: a response that raced a newer
   // stream write (ownership flipping mid-flight) is dropped, not written.
-  const request = createRichSlotRequest({
+  const richSlotRequest = createRichSlotRequest({
     queryClient,
     hostId,
     runningDir: runningDir ?? "",
@@ -333,6 +334,16 @@ export function useGitListChangedFilesWithSubmodules(args: {
       });
     },
   });
+  // Boundary-wrapped: the rich-slot wrapper's own throws are already
+  // `HostRpcError`s, but the declared error generic must also survive bugs in
+  // the request/arbitration path itself. Stays a NAMED queryFn so `client`
+  // (transport identity, not data identity) remains out of the cache key.
+  const request = (context: {
+    readonly signal: AbortSignal;
+  }): Promise<GitListChangedFilesResponseV11> =>
+    withHostRpcErrorBoundary("git.listChangedFiles", () =>
+      richSlotRequest(context),
+    );
 
   const query = useQuery(
     queryOptions<

--- a/clients/gui-app/src/hooks/git/use-git-refresh-worktree-status.ts
+++ b/clients/gui-app/src/hooks/git/use-git-refresh-worktree-status.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { UseMutationResult } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
 import type {
   HostRpcError,
   ResponseOfMethod,
@@ -68,35 +70,40 @@ export function useGitRefreshWorktreeStatus(): UseMutationResult<
     HostRpcError,
     GitRefreshWorktreeStatusVariables,
     GitRefreshWorktreeStatusContext
-  >({
-    mutationKey: gitMutationKeys.refreshWorktreeStatus(),
-    mutationFn: (variables) => {
-      const entry = directory.findById(variables.hostId);
-      const client =
-        entry === null ? null : buildTransientHostClient(globalClient, entry);
-      if (client === null) {
-        return Promise.reject<GitListChangedFilesResponse>(
-          hostClientUnavailableError("git.listChangedFiles"),
-        );
-      }
-      // Parent-only: this refresh feeds the v1.0 change-list slot; the nested
-      // snapshot has its own invalidation path.
-      return client.request("git.listChangedFiles", {
+  >(
+    withHostMutationLifecycleBoundary("git.listChangedFiles", {
+      mutationKey: gitMutationKeys.refreshWorktreeStatus(),
+      mutationFn: (variables) =>
+        withHostRpcErrorBoundary("git.listChangedFiles", () => {
+          const entry = directory.findById(variables.hostId);
+          const client =
+            entry === null
+              ? null
+              : buildTransientHostClient(globalClient, entry);
+          if (client === null) {
+            return Promise.reject<GitListChangedFilesResponse>(
+              hostClientUnavailableError("git.listChangedFiles"),
+            );
+          }
+          // Parent-only: this refresh feeds the v1.0 change-list slot; the nested
+          // snapshot has its own invalidation path.
+          return client.request("git.listChangedFiles", {
+            hostId: variables.hostId,
+            runningDir: variables.runningDir,
+            ignoreWhitespace: variables.ignoreWhitespace,
+            includeSubmodules: false,
+          });
+        }),
+      onMutate: (variables) => ({
         hostId: variables.hostId,
         runningDir: variables.runningDir,
         ignoreWhitespace: variables.ignoreWhitespace,
-        includeSubmodules: false,
-      });
-    },
-    onMutate: (variables) => ({
-      hostId: variables.hostId,
-      runningDir: variables.runningDir,
-      ignoreWhitespace: variables.ignoreWhitespace,
+      }),
+      onSuccess: (data, _variables, context) => {
+        writeGitListChangedFilesResponse(queryClient, context, data);
+      },
+      onError: (error) =>
+        toastFromHostError(error, "Couldn't refresh git status."),
     }),
-    onSuccess: (data, _variables, context) => {
-      writeGitListChangedFilesResponse(queryClient, context, data);
-    },
-    onError: (error) =>
-      toastFromHostError(error, "Couldn't refresh git status."),
-  });
+  );
 }

--- a/clients/gui-app/src/hooks/git/use-git-submodule-snapshot-refresh.ts
+++ b/clients/gui-app/src/hooks/git/use-git-submodule-snapshot-refresh.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { queryOptions, useQueryClient } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { GitListChangedFilesResponseV11 } from "@traycer/protocol/host";
 import { useHostClientFor } from "@/hooks/host/use-host-client-for";
 import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
@@ -45,7 +46,7 @@ export function useGitSubmoduleSnapshotRefresh(args: {
       rootRunningDir,
       ignoreWhitespace,
     );
-    const request = createRichSlotRequest({
+    const richSlotRequest = createRichSlotRequest({
       queryClient,
       hostId,
       runningDir: rootRunningDir,
@@ -58,6 +59,15 @@ export function useGitSubmoduleSnapshotRefresh(args: {
           includeSubmodules: true,
         }),
     });
+    // Boundary-wrapped: a rejection here lands in the SAME query slot the
+    // passive hook publicly types as `HostRpcError`, so it must never carry a
+    // foreign error shape to the panel's `.code`-reading error states.
+    const request = (context: {
+      readonly signal: AbortSignal;
+    }): Promise<GitListChangedFilesResponseV11> =>
+      withHostRpcErrorBoundary("git.listChangedFiles", () =>
+        richSlotRequest(context),
+      );
     // Cancel any fetch already in flight for this key first: `fetchQuery`
     // otherwise JOINS an existing in-flight promise instead of starting a
     // fresh request, so a click while an earlier fetch is hung would silently

--- a/clients/gui-app/src/hooks/host/__tests__/use-host-query.test.tsx
+++ b/clients/gui-app/src/hooks/host/__tests__/use-host-query.test.tsx
@@ -9,7 +9,11 @@ import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messen
 import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
 import { hostRpcRegistry, type HostRpcRegistry } from "@/lib/host";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
-import { useHostMutation, useHostQuery } from "@/hooks/host/use-host-query";
+import {
+  useHostMutation,
+  useHostQuery,
+  useHostQueryWithResponseMap,
+} from "@/hooks/host/use-host-query";
 
 describe("useHostQuery auth readiness", () => {
   afterEach(() => {
@@ -156,6 +160,179 @@ describe("useHostQuery auth readiness", () => {
       message: "Host client unavailable",
       fatalDetails: null,
     });
+  });
+});
+
+// The `HostRpcError` error generic on these hooks is an unchecked assertion:
+// TypeScript cannot type a promise's rejection channel, so a bare throw
+// anywhere inside the queryFn/mutationFn would reach `.code`-reading
+// consumers as a foreign shape (the git diff white-screen). These tests pin
+// the boundary that makes the declared type true by construction.
+describe("host query/mutation HostRpcError boundary", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("normalizes a bare throw from mapResponse into a HostRpcError", async () => {
+    const fixture = createHostQueryFixture();
+    fixture.client.bind(mockLocalHostEntry);
+    fixture.client.setRequestContext(
+      createRequestContextFixture({
+        origin: "renderer",
+        bearerToken: "tok-1",
+      }),
+    );
+
+    const rendered = renderHook(
+      () =>
+        useHostQueryWithResponseMap({
+          cacheKeyIdentity: undefined,
+          client: fixture.client,
+          method: "host.status",
+          params: {},
+          options: null,
+          mapResponse: () => {
+            throw new TypeError("mapResponse exploded");
+          },
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(rendered.result.current.error).not.toBeNull();
+    });
+    expect(rendered.result.current.error).toBeInstanceOf(HostRpcError);
+    expect(rendered.result.current.error).toMatchObject({
+      code: "RPC_ERROR",
+      method: "host.status",
+      message: "mapResponse exploded",
+      fatalDetails: null,
+    });
+  });
+
+  it("normalizes a bare throw from mapVariables into a HostRpcError", async () => {
+    const fixture = createHostQueryFixture();
+    fixture.client.bind(mockLocalHostEntry);
+    fixture.client.setRequestContext(
+      createRequestContextFixture({
+        origin: "renderer",
+        bearerToken: "tok-1",
+      }),
+    );
+
+    const rendered = renderHook(
+      () =>
+        useHostMutation({
+          client: fixture.client,
+          method: "host.status",
+          options: null,
+          mapVariables: () => {
+            throw new Error("mapVariables exploded");
+          },
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await rendered.result.current.mutateAsync({});
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(HostRpcError);
+    expect(caught).toMatchObject({
+      code: "RPC_ERROR",
+      method: "host.status",
+      message: "mapVariables exploded",
+      fatalDetails: null,
+    });
+  });
+
+  it("normalizes a bare throw from a caller-supplied select into a HostRpcError", async () => {
+    const fixture = createHostQueryFixture();
+    fixture.client.bind(mockLocalHostEntry);
+    fixture.client.setRequestContext(
+      createRequestContextFixture({
+        origin: "renderer",
+        bearerToken: "tok-1",
+      }),
+    );
+
+    const rendered = renderHook(
+      () =>
+        useHostQuery({
+          cacheKeyIdentity: undefined,
+          client: fixture.client,
+          method: "host.status",
+          params: {},
+          options: {
+            select: () => {
+              throw new TypeError("select exploded");
+            },
+          },
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+
+    await waitFor(() => {
+      expect(rendered.result.current.error).not.toBeNull();
+    });
+    expect(rendered.result.current.error).toBeInstanceOf(HostRpcError);
+    expect(rendered.result.current.error).toMatchObject({
+      code: "RPC_ERROR",
+      method: "host.status",
+      message: "select exploded",
+    });
+  });
+
+  it("normalizes a bare throw from onMutate into a HostRpcError", async () => {
+    const fixture = createHostQueryFixture();
+    fixture.client.bind(mockLocalHostEntry);
+    fixture.client.setRequestContext(
+      createRequestContextFixture({
+        origin: "renderer",
+        bearerToken: "tok-1",
+      }),
+    );
+
+    let onErrorReceived: unknown;
+    const rendered = renderHook(
+      () =>
+        useHostMutation({
+          client: fixture.client,
+          method: "host.status",
+          options: {
+            onMutate: () => {
+              throw new TypeError("onMutate exploded");
+            },
+            onError: (error) => {
+              onErrorReceived = error;
+            },
+          },
+          mapVariables: () => ({}),
+        }),
+      { wrapper: fixture.Wrapper },
+    );
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await rendered.result.current.mutateAsync({});
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(HostRpcError);
+    expect(caught).toMatchObject({
+      code: "RPC_ERROR",
+      method: "host.status",
+      message: "onMutate exploded",
+    });
+    expect(onErrorReceived).toBeInstanceOf(HostRpcError);
   });
 });
 

--- a/clients/gui-app/src/hooks/host/use-host-queries.ts
+++ b/clients/gui-app/src/hooks/host/use-host-queries.ts
@@ -8,8 +8,9 @@ import {
   type UseQueryResult,
 } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
-import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
 import type {
+  HostRpcError,
   RequestOfMethod,
   ResponseOfMethod,
 } from "@traycer-clients/shared/host-transport/host-messenger";
@@ -171,15 +172,19 @@ export function useHostQueriesWithResponseMap<
       ),
       ...(args.cacheKeyIdentity === undefined ? [] : [args.cacheKeyIdentity]),
     ];
-    const fetcher = async (): Promise<TData> => {
-      if (client === null) {
-        return Promise.reject<TData>(
-          hostClientUnavailableError(request.method),
-        );
-      }
-      const response = await client.request(request.method, request.params);
-      return mapResponse({ response, queryClient, queryKey });
-    };
+    // Boundary-wrapped like `useHostQueryWithResponseMap`'s request: the
+    // declared `HostRpcError` generic must hold even when the caller's
+    // `mapResponse` throws.
+    const fetcher = (): Promise<TData> =>
+      withHostRpcErrorBoundary(request.method, async () => {
+        if (client === null) {
+          return Promise.reject<TData>(
+            hostClientUnavailableError(request.method),
+          );
+        }
+        const response = await client.request(request.method, request.params);
+        return mapResponse({ response, queryClient, queryKey });
+      });
     return queryOptions<TData, HostRpcError, TData>({
       ...(options ?? {}),
       queryKey,

--- a/clients/gui-app/src/hooks/host/use-host-query.ts
+++ b/clients/gui-app/src/hooks/host/use-host-query.ts
@@ -13,6 +13,8 @@ import {
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import {
   HostRpcError,
+  toHostRpcError,
+  withHostRpcErrorBoundary,
   type RequestOfMethod,
   type ResponseOfMethod,
 } from "@traycer-clients/shared/host-transport/host-messenger";
@@ -127,17 +129,35 @@ export function useHostQueryWithResponseMap<
     ...(args.cacheKeyIdentity ?? []),
   ];
 
-  const request = async (): Promise<TData> => {
-    if (client === null) {
-      return Promise.reject<TData>(hostClientUnavailableError(method));
-    }
-    const response = await client.request(method, params);
-    return mapResponse({ response, queryClient, queryKey });
-  };
+  // The boundary makes the declared `HostRpcError` generic true by
+  // construction: it also normalizes throws from the caller-supplied
+  // `mapResponse`, which the transport's own error discipline can't cover.
+  const request = (): Promise<TData> =>
+    withHostRpcErrorBoundary(method, async () => {
+      if (client === null) {
+        return Promise.reject<TData>(hostClientUnavailableError(method));
+      }
+      const response = await client.request(method, params);
+      return mapResponse({ response, queryClient, queryKey });
+    });
 
+  const select = baseOptions.select;
   return useQuery<TData, HostRpcError, TData>(
     queryOptions<TData, HostRpcError, TData>({
       ...baseOptions,
+      // A throw inside a caller-supplied `select` is stored by the observer
+      // as `result.error` - the same `HostRpcError`-typed channel the queryFn
+      // boundary protects - so it must be normalized too.
+      select:
+        select === undefined
+          ? undefined
+          : (data) => {
+              try {
+                return select(data);
+              } catch (error) {
+                throw toHostRpcError(error, method);
+              }
+            },
       queryKey,
       queryFn: request,
       // A function-form `enabled` must still be evaluated per-query - not
@@ -200,15 +220,18 @@ export function useHostMutation<
     TVariables,
     TContext
   >({
-    ...baseOptions,
-    mutationFn: (variables) => {
-      if (args.client === null) {
-        return Promise.reject<ResponseOfMethod<Registry, Method>>(
-          hostClientUnavailableError(args.method),
-        );
-      }
-      return args.client.request(args.method, args.mapVariables(variables));
-    },
+    ...withHostMutationLifecycleBoundary(args.method, baseOptions),
+    // Boundary-wrapped so a throw inside the caller-supplied `mapVariables`
+    // (pre-flight validation) surfaces as the declared `HostRpcError`.
+    mutationFn: (variables) =>
+      withHostRpcErrorBoundary(args.method, () => {
+        if (args.client === null) {
+          return Promise.reject<ResponseOfMethod<Registry, Method>>(
+            hostClientUnavailableError(args.method),
+          );
+        }
+        return args.client.request(args.method, args.mapVariables(variables));
+      }),
   });
 }
 
@@ -242,19 +265,20 @@ export function useHostMutationWithResponseTimeout<
     TVariables,
     TContext
   >({
-    ...baseOptions,
-    mutationFn: (variables) => {
-      if (args.client === null) {
-        return Promise.reject<ResponseOfMethod<Registry, Method>>(
-          hostClientUnavailableError(args.method),
+    ...withHostMutationLifecycleBoundary(args.method, baseOptions),
+    mutationFn: (variables) =>
+      withHostRpcErrorBoundary(args.method, () => {
+        if (args.client === null) {
+          return Promise.reject<ResponseOfMethod<Registry, Method>>(
+            hostClientUnavailableError(args.method),
+          );
+        }
+        return args.client.requestWithResponseTimeout(
+          args.method,
+          args.mapVariables(variables),
+          args.responseTimeoutMs,
         );
-      }
-      return args.client.requestWithResponseTimeout(
-        args.method,
-        args.mapVariables(variables),
-        args.responseTimeoutMs,
-      );
-    },
+      }),
   });
 }
 
@@ -266,4 +290,54 @@ export function hostClientUnavailableError(method: string): HostRpcError {
     message: "Host client unavailable",
     fatalDetails: null,
   });
+}
+
+/**
+ * Wraps a mutation's lifecycle callbacks (`onMutate` / `onSuccess` /
+ * `onSettled`) so a throw inside them is normalized to `HostRpcError`.
+ * TanStack stores a lifecycle throw in `mutation.state.error`, hands it to
+ * `onError`, and rejects `mutateAsync` with it - all surfaces the declared
+ * `HostRpcError` generic covers but the mutationFn boundary cannot reach.
+ * TanStack awaits every mutation lifecycle callback, so the async wrappers
+ * do not change observable ordering. Used by `useHostMutation` and by the
+ * bespoke `useMutation` producers that declare a `HostRpcError` generic.
+ */
+export function withHostMutationLifecycleBoundary<TData, TVariables, TContext>(
+  method: string,
+  options: UseMutationOptions<TData, HostRpcError, TVariables, TContext>,
+): UseMutationOptions<TData, HostRpcError, TVariables, TContext> {
+  const { onMutate, onSuccess, onSettled } = options;
+  return {
+    ...options,
+    onMutate:
+      onMutate === undefined
+        ? undefined
+        : async (...args) => {
+            try {
+              return await onMutate(...args);
+            } catch (error) {
+              throw toHostRpcError(error, method);
+            }
+          },
+    onSuccess:
+      onSuccess === undefined
+        ? undefined
+        : async (...args) => {
+            try {
+              return await onSuccess(...args);
+            } catch (error) {
+              throw toHostRpcError(error, method);
+            }
+          },
+    onSettled:
+      onSettled === undefined
+        ? undefined
+        : async (...args) => {
+            try {
+              return await onSettled(...args);
+            } catch (error) {
+              throw toHostRpcError(error, method);
+            }
+          },
+  };
 }

--- a/clients/gui-app/src/hooks/terminal/use-terminal-create-mutation.ts
+++ b/clients/gui-app/src/hooks/terminal/use-terminal-create-mutation.ts
@@ -5,7 +5,11 @@ import {
 } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
-import { HostRpcError as HostRpcErrorCtor } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  HostRpcError as HostRpcErrorCtor,
+  withHostRpcErrorBoundary,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
 import type {
   RequestOfMethod,
   ResponseOfMethod,
@@ -32,33 +36,37 @@ export function useTerminalCreate(
     HostRpcError,
     RequestOfMethod<HostRpcRegistry, "terminal.create">,
     CreateTerminalMutationContext
-  >({
-    mutationKey: terminalMutationKeys.create(),
-    mutationFn: (variables) => {
-      if (client === null) {
-        return Promise.reject(
-          new HostRpcErrorCtor({
-            code: "RPC_ERROR",
-            message: "Cannot create terminal without a host client.",
-            requestId: "client-preflight",
-            method: "terminal.create",
-            fatalDetails: null,
-          }),
-        );
-      }
-      return client.request("terminal.create", variables);
-    },
-    onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
-    onSuccess: (_data, _variables, ctx) => {
-      if (ctx.hostId === null) return;
-      // Refresh only the terminal-session list (drives `hostHasSession`).
-      // Invalidating the whole host scope would also force-refetch the
-      // manual-refresh-only cloud-tasks history, dropping a just-created
-      // local-first epic that the cloud `listTasks` does not contain yet.
-      void queryClient.invalidateQueries({
-        queryKey: hostQueryKeys.methodScope(ctx.hostId, "terminal.list"),
-      });
-    },
-    onError: (error) => toastFromHostError(error, "Could not create terminal"),
-  });
+  >(
+    withHostMutationLifecycleBoundary("terminal.create", {
+      mutationKey: terminalMutationKeys.create(),
+      mutationFn: (variables) =>
+        withHostRpcErrorBoundary("terminal.create", () => {
+          if (client === null) {
+            return Promise.reject(
+              new HostRpcErrorCtor({
+                code: "RPC_ERROR",
+                message: "Cannot create terminal without a host client.",
+                requestId: "client-preflight",
+                method: "terminal.create",
+                fatalDetails: null,
+              }),
+            );
+          }
+          return client.request("terminal.create", variables);
+        }),
+      onMutate: () => ({ hostId: client?.getActiveHostId() ?? null }),
+      onSuccess: (_data, _variables, ctx) => {
+        if (ctx.hostId === null) return;
+        // Refresh only the terminal-session list (drives `hostHasSession`).
+        // Invalidating the whole host scope would also force-refetch the
+        // manual-refresh-only cloud-tasks history, dropping a just-created
+        // local-first epic that the cloud `listTasks` does not contain yet.
+        void queryClient.invalidateQueries({
+          queryKey: hostQueryKeys.methodScope(ctx.hostId, "terminal.list"),
+        });
+      },
+      onError: (error) =>
+        toastFromHostError(error, "Could not create terminal"),
+    }),
+  );
 }

--- a/clients/gui-app/src/hooks/terminal/use-terminal-kill-for-mutation.ts
+++ b/clients/gui-app/src/hooks/terminal/use-terminal-kill-for-mutation.ts
@@ -3,6 +3,8 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
 import type {
   HostRpcError,
   RequestOfMethod,
@@ -10,6 +12,7 @@ import type {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@/lib/host";
+import { hostClientUnavailableError } from "@/hooks/host/use-host-query";
 import { hostQueryKeys, terminalMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
@@ -47,33 +50,36 @@ export function useTerminalKillFor(
     HostRpcError,
     RequestOfMethod<HostRpcRegistry, "terminal.kill">,
     KillTerminalMutationContext
-  >({
-    mutationKey: terminalMutationKeys.kill(),
-    mutationFn: (variables) => {
-      if (client === null) {
-        return Promise.reject<
-          ResponseOfMethod<HostRpcRegistry, "terminal.kill">
-        >(new Error("Host client unavailable"));
-      }
-      return client.request("terminal.kill", variables);
-    },
-    onMutate: () => ({
-      hostId: client === null ? null : client.getActiveHostId(),
-    }),
-    onSuccess: (_data, _variables, ctx) => {
-      if (trackUserIntent) {
-        Analytics.getInstance().track(AnalyticsEvent.TerminalKilled, {
-          kind: "shell",
+  >(
+    withHostMutationLifecycleBoundary("terminal.kill", {
+      mutationKey: terminalMutationKeys.kill(),
+      mutationFn: (variables) =>
+        withHostRpcErrorBoundary("terminal.kill", () => {
+          if (client === null) {
+            return Promise.reject<
+              ResponseOfMethod<HostRpcRegistry, "terminal.kill">
+            >(hostClientUnavailableError("terminal.kill"));
+          }
+          return client.request("terminal.kill", variables);
+        }),
+      onMutate: () => ({
+        hostId: client === null ? null : client.getActiveHostId(),
+      }),
+      onSuccess: (_data, _variables, ctx) => {
+        if (trackUserIntent) {
+          Analytics.getInstance().track(AnalyticsEvent.TerminalKilled, {
+            kind: "shell",
+          });
+        }
+        if (ctx.hostId === null) return;
+        // Only the terminal-session list changed; invalidating the whole host
+        // scope would also force-refetch the manual-refresh-only cloud-tasks
+        // history.
+        void queryClient.invalidateQueries({
+          queryKey: hostQueryKeys.methodScope(ctx.hostId, "terminal.list"),
         });
-      }
-      if (ctx.hostId === null) return;
-      // Only the terminal-session list changed; invalidating the whole host
-      // scope would also force-refetch the manual-refresh-only cloud-tasks
-      // history.
-      void queryClient.invalidateQueries({
-        queryKey: hostQueryKeys.methodScope(ctx.hostId, "terminal.list"),
-      });
-    },
-    onError: (error) => toastFromHostError(error, errorMessage),
-  });
+      },
+      onError: (error) => toastFromHostError(error, errorMessage),
+    }),
+  );
 }

--- a/clients/gui-app/src/hooks/worktree/use-worktree-retry-setup-mutation.ts
+++ b/clients/gui-app/src/hooks/worktree/use-worktree-retry-setup-mutation.ts
@@ -3,6 +3,8 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
 import type {
   HostRpcError,
   RequestOfMethod,
@@ -10,6 +12,7 @@ import type {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@/lib/host";
+import { hostClientUnavailableError } from "@/hooks/host/use-host-query";
 import { hostQueryKeys, worktreeMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { WORKTREE_BINDING_INVALIDATIONS } from "@/hooks/worktree/invalidations";
@@ -48,30 +51,33 @@ export function useWorktreeRetrySetupFor(
     HostRpcError,
     RequestOfMethod<HostRpcRegistry, "worktree.retrySetup">,
     RetrySetupMutationContext
-  >({
-    mutationKey: worktreeMutationKeys.retrySetup(),
-    mutationFn: (variables) => {
-      if (client === null) {
-        return Promise.reject<
-          ResponseOfMethod<HostRpcRegistry, "worktree.retrySetup">
-        >(new Error("Host client unavailable"));
-      }
-      return client.request("worktree.retrySetup", variables);
-    },
-    onMutate: () => {
-      Analytics.getInstance().track(AnalyticsEvent.SetupScriptsRetryStarted, {
-        source: "direct_ui",
-      });
-      return { hostId: client === null ? null : client.getActiveHostId() };
-    },
-    onSuccess: (_data, _variables, ctx) => {
-      if (ctx.hostId === null) return;
-      for (const method of WORKTREE_BINDING_INVALIDATIONS) {
-        void queryClient.invalidateQueries({
-          queryKey: hostQueryKeys.methodScope(ctx.hostId, method),
+  >(
+    withHostMutationLifecycleBoundary("worktree.retrySetup", {
+      mutationKey: worktreeMutationKeys.retrySetup(),
+      mutationFn: (variables) =>
+        withHostRpcErrorBoundary("worktree.retrySetup", () => {
+          if (client === null) {
+            return Promise.reject<
+              ResponseOfMethod<HostRpcRegistry, "worktree.retrySetup">
+            >(hostClientUnavailableError("worktree.retrySetup"));
+          }
+          return client.request("worktree.retrySetup", variables);
+        }),
+      onMutate: () => {
+        Analytics.getInstance().track(AnalyticsEvent.SetupScriptsRetryStarted, {
+          source: "direct_ui",
         });
-      }
-    },
-    onError: (error) => toastFromHostError(error, "Couldn't retry setup."),
-  });
+        return { hostId: client === null ? null : client.getActiveHostId() };
+      },
+      onSuccess: (_data, _variables, ctx) => {
+        if (ctx.hostId === null) return;
+        for (const method of WORKTREE_BINDING_INVALIDATIONS) {
+          void queryClient.invalidateQueries({
+            queryKey: hostQueryKeys.methodScope(ctx.hostId, method),
+          });
+        }
+      },
+      onError: (error) => toastFromHostError(error, "Couldn't retry setup."),
+    }),
+  );
 }

--- a/clients/gui-app/src/hooks/worktree/use-worktree-set-repo-scripts-mutation.ts
+++ b/clients/gui-app/src/hooks/worktree/use-worktree-set-repo-scripts-mutation.ts
@@ -3,6 +3,8 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
+import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
 import type {
   HostRpcError,
   RequestOfMethod,
@@ -10,6 +12,7 @@ import type {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@/lib/host";
+import { hostClientUnavailableError } from "@/hooks/host/use-host-query";
 import { hostQueryKeys, worktreeMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
@@ -51,34 +54,39 @@ export function useWorktreeSetRepoScriptsFor(
     HostRpcError,
     RequestOfMethod<HostRpcRegistry, "worktree.setRepoScripts">,
     SetRepoScriptsMutationContext
-  >({
-    mutationKey: worktreeMutationKeys.setRepoScripts(),
-    mutationFn: (variables) => {
-      if (client === null) {
-        return Promise.reject<
-          ResponseOfMethod<HostRpcRegistry, "worktree.setRepoScripts">
-        >(new Error("Host client unavailable"));
-      }
-      return client.request("worktree.setRepoScripts", variables);
-    },
-    onMutate: () => ({
-      hostId: client === null ? null : client.getActiveHostId(),
-    }),
-    onSuccess: (_data, _variables, mutationContext) => {
-      Analytics.getInstance().track(AnalyticsEvent.SetupScriptsSaved, {
-        script_count: [_variables.setup, _variables.teardown].filter((script) =>
-          Object.values(script).some(
-            (command) => command !== null && command.trim().length > 0,
-          ),
-        ).length,
-      });
-      if (mutationContext.hostId === null) return;
-      for (const method of SET_REPO_SCRIPTS_INVALIDATIONS) {
-        void queryClient.invalidateQueries({
-          queryKey: hostQueryKeys.methodScope(mutationContext.hostId, method),
+  >(
+    withHostMutationLifecycleBoundary("worktree.setRepoScripts", {
+      mutationKey: worktreeMutationKeys.setRepoScripts(),
+      mutationFn: (variables) =>
+        withHostRpcErrorBoundary("worktree.setRepoScripts", () => {
+          if (client === null) {
+            return Promise.reject<
+              ResponseOfMethod<HostRpcRegistry, "worktree.setRepoScripts">
+            >(hostClientUnavailableError("worktree.setRepoScripts"));
+          }
+          return client.request("worktree.setRepoScripts", variables);
+        }),
+      onMutate: () => ({
+        hostId: client === null ? null : client.getActiveHostId(),
+      }),
+      onSuccess: (_data, _variables, mutationContext) => {
+        Analytics.getInstance().track(AnalyticsEvent.SetupScriptsSaved, {
+          script_count: [_variables.setup, _variables.teardown].filter(
+            (script) =>
+              Object.values(script).some(
+                (command) => command !== null && command.trim().length > 0,
+              ),
+          ).length,
         });
-      }
-    },
-    onError: (error) => toastFromHostError(error, "Couldn't save environment."),
-  });
+        if (mutationContext.hostId === null) return;
+        for (const method of SET_REPO_SCRIPTS_INVALIDATIONS) {
+          void queryClient.invalidateQueries({
+            queryKey: hostQueryKeys.methodScope(mutationContext.hostId, method),
+          });
+        }
+      },
+      onError: (error) =>
+        toastFromHostError(error, "Couldn't save environment."),
+    }),
+  );
 }

--- a/clients/gui-app/src/hooks/worktree/use-worktree-set-repo-scripts-mutation.ts
+++ b/clients/gui-app/src/hooks/worktree/use-worktree-set-repo-scripts-mutation.ts
@@ -1,10 +1,4 @@
-import {
-  useMutation,
-  useQueryClient,
-  type UseMutationResult,
-} from "@tanstack/react-query";
-import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
-import { withHostMutationLifecycleBoundary } from "@/hooks/host/use-host-query";
+import { useQueryClient, type UseMutationResult } from "@tanstack/react-query";
 import type {
   HostRpcError,
   RequestOfMethod,
@@ -12,7 +6,7 @@ import type {
 } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@/lib/host";
-import { hostClientUnavailableError } from "@/hooks/host/use-host-query";
+import { useHostMutation } from "@/hooks/host/use-host-query";
 import { hostQueryKeys, worktreeMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
@@ -38,7 +32,8 @@ const SET_REPO_SCRIPTS_INVALIDATIONS: ReadonlyArray<
  * page and in an epic.
  *
  * A `null` client makes the mutation a rejecting no-op, matching the other
- * `*For` worktree hooks.
+ * `*For` worktree hooks - `useHostMutation`'s own `client === null` guard
+ * covers it.
  */
 export function useWorktreeSetRepoScriptsFor(
   client: HostClient<HostRpcRegistry> | null,
@@ -49,23 +44,16 @@ export function useWorktreeSetRepoScriptsFor(
   SetRepoScriptsMutationContext
 > {
   const queryClient = useQueryClient();
-  return useMutation<
-    ResponseOfMethod<HostRpcRegistry, "worktree.setRepoScripts">,
-    HostRpcError,
-    RequestOfMethod<HostRpcRegistry, "worktree.setRepoScripts">,
+  return useHostMutation<
+    HostRpcRegistry,
+    "worktree.setRepoScripts",
     SetRepoScriptsMutationContext
-  >(
-    withHostMutationLifecycleBoundary("worktree.setRepoScripts", {
+  >({
+    client,
+    method: "worktree.setRepoScripts",
+    mapVariables: (variables) => variables,
+    options: {
       mutationKey: worktreeMutationKeys.setRepoScripts(),
-      mutationFn: (variables) =>
-        withHostRpcErrorBoundary("worktree.setRepoScripts", () => {
-          if (client === null) {
-            return Promise.reject<
-              ResponseOfMethod<HostRpcRegistry, "worktree.setRepoScripts">
-            >(hostClientUnavailableError("worktree.setRepoScripts"));
-          }
-          return client.request("worktree.setRepoScripts", variables);
-        }),
       onMutate: () => ({
         hostId: client === null ? null : client.getActiveHostId(),
       }),
@@ -87,6 +75,6 @@ export function useWorktreeSetRepoScriptsFor(
       },
       onError: (error) =>
         toastFromHostError(error, "Couldn't save environment."),
-    }),
-  );
+    },
+  });
 }

--- a/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/ephemeral-fetch-queue.test.ts
@@ -1,5 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import type { ProviderId } from "@traycer/protocol/host/provider-schemas";
 import type {
@@ -391,6 +392,29 @@ describe("ephemeral-fetch-queue", () => {
     settlers[1].ok();
     await flush();
     expect(isRateLimitQueueDraining()).toBe(false);
+  });
+
+  it("stores a normalized HostRpcError in the shared cache slot when the request rejects a foreign error", async () => {
+    const queryClient = newQueryClient();
+    // A raw TypeError - the shape that previously leaked into the provider
+    // rate-limit slot that `HostRpcError`-typed observers read.
+    const request: RateLimitQueueRequestFn = () =>
+      Promise.reject(new TypeError("boom from transport"));
+    configureRateLimitQueue({ hostId: HOST_ID, queryClient, request });
+
+    void enqueueRateLimitFetch("claude-code", DEFAULT_ACCOUNT_CONTEXT, {
+      force: true,
+      profileId: null,
+    });
+    await flush();
+
+    const cachedError = queryClient.getQueryState(keyFor("claude-code"))?.error;
+    expect(cachedError).toBeInstanceOf(HostRpcError);
+    expect(cachedError).toMatchObject({
+      code: "RPC_ERROR",
+      method: "host.getRateLimitUsage",
+      message: "boom from transport",
+    });
   });
 
   it("a failed first read does not make a provider look fresh; an automatic enqueue retries and recovers", async () => {

--- a/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
+++ b/clients/gui-app/src/lib/rate-limits/ephemeral-fetch-queue.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { AccountContext } from "@traycer/protocol/common/schemas";
+import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { RequestOfMethod } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { HostRpcRegistry } from "@/lib/host";
 import { queryKeys } from "@/lib/query-keys";
@@ -313,25 +314,29 @@ function enqueueRateLimitFetchBatchForScope(
       // Named request fn (not an inline closure in `queryFn`) so the host-scoped
       // key stays the sole cache identity - `request` is stable module state, not
       // a key input, and inlining it would trip the query plugin's exhaustive-deps
-      // check (mirrors `resolve-artifact-by-path.ts`).
-      async function queryFn(): Promise<ProviderRateLimitEnvelope> {
-        const response = await request(
-          hostId,
-          "host.getRateLimitUsage",
-          params,
-        );
-        const envelope = mapResponseToProviderRateLimitEnvelope({
-          response,
-          queryClient,
-          queryKey,
+      // check (mirrors `resolve-artifact-by-path.ts`). Boundary-wrapped: this
+      // writes the same cache slot the `HostRpcError`-typed provider observers
+      // read, so mapper/cool-down throws must not leak a foreign error shape.
+      function queryFn(): Promise<ProviderRateLimitEnvelope> {
+        return withHostRpcErrorBoundary("host.getRateLimitUsage", async () => {
+          const response = await request(
+            hostId,
+            "host.getRateLimitUsage",
+            params,
+          );
+          const envelope = mapResponseToProviderRateLimitEnvelope({
+            response,
+            queryClient,
+            queryKey,
+          });
+          applyCooldownPolicy(
+            hostId,
+            target.providerId,
+            target.profileId,
+            envelope,
+          );
+          return envelope;
         });
-        applyCooldownPolicy(
-          hostId,
-          target.providerId,
-          target.profileId,
-          envelope,
-        );
-        return envelope;
       }
 
       function runFetch(): Promise<ProviderRateLimitEnvelope | undefined> {

--- a/clients/shared/host-transport/__tests__/host-rpc-error-boundary.test.ts
+++ b/clients/shared/host-transport/__tests__/host-rpc-error-boundary.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  HostRpcError,
+  RetryableTransportError,
+  toHostRpcError,
+  withHostRpcErrorBoundary,
+} from "../host-messenger";
+
+describe("toHostRpcError", () => {
+  it("returns a HostRpcError unchanged, preserving the subclass", () => {
+    const rpcError = new HostRpcError({
+      code: "FORBIDDEN",
+      message: "nope",
+      requestId: "req-1",
+      method: "host.echo",
+      fatalDetails: null,
+    });
+    expect(toHostRpcError(rpcError, "host.echo")).toBe(rpcError);
+
+    const transportError = new RetryableTransportError({
+      code: "RPC_ERROR",
+      message: "dial timeout",
+      requestId: "req-2",
+      method: "host.echo",
+      fatalDetails: null,
+    });
+    expect(toHostRpcError(transportError, "host.echo")).toBe(transportError);
+  });
+
+  it("wraps a bare Error, preserving its message and stamping the method", () => {
+    const wrapped = toHostRpcError(
+      new TypeError("Cannot read properties of undefined (reading 'replace')"),
+      "git.listChangedFiles",
+    );
+    expect(wrapped).toBeInstanceOf(HostRpcError);
+    expect(wrapped.code).toBe("RPC_ERROR");
+    expect(wrapped.method).toBe("git.listChangedFiles");
+    expect(wrapped.requestId).toBe("client-normalized");
+    expect(wrapped.fatalDetails).toBeNull();
+    expect(wrapped.message).toBe(
+      "Cannot read properties of undefined (reading 'replace')",
+    );
+  });
+
+  it("wraps a non-Error rejection value with a generic message", () => {
+    const wrapped = toHostRpcError("string throw", "host.echo");
+    expect(wrapped).toBeInstanceOf(HostRpcError);
+    expect(wrapped.code).toBe("RPC_ERROR");
+    expect(wrapped.message).toBe("Unknown host request failure");
+  });
+});
+
+describe("withHostRpcErrorBoundary", () => {
+  it("passes a resolved value through untouched", async () => {
+    await expect(
+      withHostRpcErrorBoundary("host.echo", () => Promise.resolve(42)),
+    ).resolves.toBe(42);
+  });
+
+  it("normalizes a bare rejection into a HostRpcError", async () => {
+    const rejection = withHostRpcErrorBoundary("host.echo", () =>
+      Promise.reject(new Error("bare failure")),
+    );
+    await expect(rejection).rejects.toBeInstanceOf(HostRpcError);
+    await expect(rejection).rejects.toMatchObject({
+      code: "RPC_ERROR",
+      method: "host.echo",
+      message: "bare failure",
+    });
+  });
+
+  it("normalizes a synchronous throw from the thunk", async () => {
+    const rejection = withHostRpcErrorBoundary("host.echo", () => {
+      throw new Error("sync failure");
+    });
+    await expect(rejection).rejects.toBeInstanceOf(HostRpcError);
+  });
+
+  it("re-throws an existing HostRpcError by identity", async () => {
+    const rpcError = new HostRpcError({
+      code: "UNAUTHORIZED",
+      message: "expired",
+      requestId: "req-3",
+      method: "host.echo",
+      fatalDetails: null,
+    });
+    await expect(
+      withHostRpcErrorBoundary("host.echo", () => Promise.reject(rpcError)),
+    ).rejects.toBe(rpcError);
+  });
+});

--- a/clients/shared/host-transport/host-messenger.ts
+++ b/clients/shared/host-transport/host-messenger.ts
@@ -135,6 +135,44 @@ export function classifyHostRequestFailure(error: unknown): HostRequestFailure {
 }
 
 /**
+ * Totalizes an arbitrary rejection into a `HostRpcError`. TypeScript cannot
+ * type a promise's rejection channel, so every `HostRpcError`-declared error
+ * generic (TanStack queries/mutations, hook result interfaces) is an
+ * unchecked assertion - a bare `Error` slipping through it crashes `.code` /
+ * `.fatalDetails` consumers at runtime. Passing a rejection through this
+ * function is what makes those declarations true by construction.
+ */
+export function toHostRpcError(error: unknown, method: string): HostRpcError {
+  if (error instanceof HostRpcError) return error;
+  return new HostRpcError({
+    code: "RPC_ERROR",
+    message:
+      error instanceof Error ? error.message : "Unknown host request failure",
+    requestId: "client-normalized",
+    method,
+    fatalDetails: null,
+  });
+}
+
+/**
+ * Runs `run` and re-throws any rejection normalized via `toHostRpcError`.
+ * Wrap the entire body of a queryFn/mutationFn whose error type is declared
+ * as `HostRpcError`, so bugs and bare throws anywhere inside (response
+ * mapping, pagination guards, transient-client resolution) can never leak a
+ * foreign error shape to `.code`-reading consumers.
+ */
+export async function withHostRpcErrorBoundary<T>(
+  method: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    throw toHostRpcError(error, method);
+  }
+}
+
+/**
  * A `HostRpcError` whose cause is the transport itself - no host bound, a
  * dropped or unopenable WebSocket, a dial or frame timeout - rather than the
  * host rejecting the operation. The host either never saw the request or


### PR DESCRIPTION
## Summary

TanStack's `TError` generic on a queryFn/mutationFn is an unchecked assertion — promise rejection channels are untyped, so a bare `Error` thrown anywhere in the chain reaches `.code`/`.fatalDetails`-reading consumers as a foreign shape at runtime despite the declared `HostRpcError` type. This crashed the git diff view (`undefined.replace` in the report-issue context — fixed separately in e6c6313) and the same class of bug was latent in several other host-RPC hooks.

This closes every producer of a `HostRpcError`-typed TanStack error, not just the one that crashed:

- **New normalization primitives**: `toHostRpcError` / `withHostRpcErrorBoundary` in `clients/shared/host-transport/host-messenger.ts`, and `withHostMutationLifecycleBoundary` in `clients/gui-app/src/hooks/host/use-host-query.ts`.
- **Shared wrappers**: `useHostQuery`/`useHostQueryWithResponseMap`, `useHostMutation`/`useHostMutationWithResponseTimeout`, and `useHostQueries` now normalize their `queryFn`/`mutationFn`, caller-supplied `select`, and mutation lifecycle callbacks (`onMutate`/`onSuccess`/`onSettled` — all typed-error surfaces TanStack exposes, not just the request function).
- **Bespoke hooks with live bare-`Error` bugs**: `useTerminalKillFor`, `useWorktreeRetrySetupFor`, `useWorktreeSetRepoScriptsFor` rejected `new Error(...)` under a declared `HostRpcError` generic — these fed straight into `toastFromHostError`, which dereferences `.fatalDetails`.
- **Every remaining hand-rolled producer**: both git diff hooks, git refresh/submodule-snapshot-refresh, worktrees listing (infinite query + refresh), epic chat create/update-run-settings, terminal create, TUI prepare-launch, landing-terminal kill, task-delete worktree candidates.
- **Imperative `fetchQuery` writers sharing a cache key with a typed observer**: the rate-limit fetch queue, the worktrees-enrichment sweep, and the landing-terminal reconciliation queryFn — these write into the same slot a `HostRpcError`-typed hook reads, so an unwrapped rejection poisons what the observer sees even though its own generic looked correct.

This changeset went through an independent adversarial review (fresh agent, no context from the implementation) which found two additional real gaps — TanStack's `select`/mutation-lifecycle callbacks, and the three imperative writers above — both since fixed and covered by regression tests.

## Test plan

- [x] `bun run compile` clean
- [x] Full affected suite: 93 test files / 784 tests pass (host hooks, rate-limit queue, git/epic/terminal/worktree/agent hooks, settings panels, terminal-panel, git-diff components)
- [x] New regression tests: `clients/shared/host-transport/__tests__/host-rpc-error-boundary.test.ts` (7 tests), `use-host-query.test.tsx` (throwing `mapResponse`, `mapVariables`, `select`, `onMutate`), `ephemeral-fetch-queue.test.ts` (cache-sharing: a raw `TypeError` rejection stores a `HostRpcError` at the shared provider rate-limit key)
- [x] eslint `--max-warnings 0` and prettier clean on touched files
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)