### PR TITLE
fix(gui-app): stabilize rate limit popover interactions

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -515,6 +515,188 @@ function renderPopover() {
   return { ...rendered, client };
 }
 
+function pointerEvent(
+  type:
+    | "pointerdown"
+    | "pointermove"
+    | "pointerup"
+    | "pointercancel"
+    | "lostpointercapture",
+  options: {
+    readonly pointerId: number;
+    readonly clientX: number;
+    readonly clientY: number;
+    readonly button: number;
+  },
+): MouseEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: options.clientX,
+    clientY: options.clientY,
+    button: options.button,
+  });
+  Object.defineProperty(event, "pointerId", { value: options.pointerId });
+  return event;
+}
+
+function parseTranslate(transform: string): {
+  readonly xPx: number;
+  readonly yPx: number;
+} {
+  const matches = Array.from(
+    transform.matchAll(/translate\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px\s*\)/g),
+  );
+  return {
+    xPx: matches.reduce(
+      (total, match) => total + Number.parseFloat(match[1]),
+      0,
+    ),
+    yPx: matches.reduce(
+      (total, match) => total + Number.parseFloat(match[2]),
+      0,
+    ),
+  };
+}
+
+function mockRadixResizeGeometry(
+  surface: HTMLElement,
+  initialWidth: number,
+  initialHeight: number,
+) {
+  const positionWrapper = surface.closest<HTMLElement>(
+    "[data-radix-popper-content-wrapper]",
+  );
+  if (positionWrapper === null) {
+    throw new Error("Expected the Radix popover positioning elements");
+  }
+  const startLeftPx = 100;
+  const startTopPx = 100;
+  const initialTransform = `translate(${startLeftPx}px, ${startTopPx}px)`;
+  positionWrapper.style.transform = initialTransform;
+  const rectSpy = vi
+    .spyOn(surface, "getBoundingClientRect")
+    .mockImplementation(() => {
+      const width = Number.parseFloat(surface.style.width) || initialWidth;
+      const height = Number.parseFloat(surface.style.height) || initialHeight;
+      const translate = parseTranslate(positionWrapper.style.transform);
+      return new DOMRect(translate.xPx, translate.yPx, width, height);
+    });
+  return {
+    initialTransform,
+    positionWrapper,
+    rectSpy,
+    overwriteRadixPosition: (xPx: number, yPx: number) => {
+      positionWrapper.style.transform = `translate(${xPx}px, ${yPx}px)`;
+    },
+  };
+}
+
+const RESIZE_GEOMETRY_CASES = [
+  {
+    direction: "n",
+    deltaX: 0,
+    deltaY: -40,
+    expected: { left: 100, top: 60, right: 580, bottom: 460 },
+  },
+  {
+    direction: "ne",
+    deltaX: 40,
+    deltaY: -40,
+    expected: { left: 100, top: 60, right: 620, bottom: 460 },
+  },
+  {
+    direction: "e",
+    deltaX: 40,
+    deltaY: 0,
+    expected: { left: 100, top: 100, right: 620, bottom: 460 },
+  },
+  {
+    direction: "se",
+    deltaX: 40,
+    deltaY: 40,
+    expected: { left: 100, top: 100, right: 620, bottom: 500 },
+  },
+  {
+    direction: "s",
+    deltaX: 0,
+    deltaY: 40,
+    expected: { left: 100, top: 100, right: 580, bottom: 500 },
+  },
+  {
+    direction: "sw",
+    deltaX: -40,
+    deltaY: 40,
+    expected: { left: 60, top: 100, right: 580, bottom: 500 },
+  },
+  {
+    direction: "w",
+    deltaX: -40,
+    deltaY: 0,
+    expected: { left: 60, top: 100, right: 580, bottom: 460 },
+  },
+  {
+    direction: "nw",
+    deltaX: -40,
+    deltaY: -40,
+    expected: { left: 60, top: 60, right: 580, bottom: 460 },
+  },
+] as const;
+
+function dragResize(
+  surface: HTMLElement,
+  direction: (typeof RESIZE_GEOMETRY_CASES)[number]["direction"],
+  pointerId: number,
+  delta: { readonly x: number; readonly y: number },
+): void {
+  const startClientX = 580;
+  const startClientY = 460;
+  fireEvent(
+    screen.getByTestId(`rate-limit-popover-resize-${direction}`),
+    pointerEvent("pointerdown", {
+      pointerId,
+      clientX: startClientX,
+      clientY: startClientY,
+      button: 0,
+    }),
+  );
+  fireEvent(
+    surface,
+    pointerEvent("pointermove", {
+      pointerId,
+      clientX: startClientX + delta.x,
+      clientY: startClientY + delta.y,
+      button: 0,
+    }),
+  );
+}
+
+function endResize(
+  surface: HTMLElement,
+  type: "pointerup" | "pointercancel" | "lostpointercapture",
+  pointerId: number,
+  delta: { readonly x: number; readonly y: number },
+): void {
+  fireEvent(
+    surface,
+    pointerEvent(type, {
+      pointerId,
+      clientX: 580 + delta.x,
+      clientY: 460 + delta.y,
+      button: 0,
+    }),
+  );
+}
+
+function renderCodexPopover(): HTMLElement {
+  mocks.configured = [
+    { providerId: "codex", lane: "ephemeralProcess", profiles: undefined },
+  ];
+  mocks.results = { codex: readyResult(codexReady()) };
+  renderPopover();
+  return screen.getByTestId("rate-limit-popover-resize-surface");
+}
+
 beforeEach(() => {
   mocks.configured = [];
   mocks.results = {};
@@ -573,7 +755,14 @@ describe("<RateLimitPopover /> zero-provider state", () => {
     expect(surface.className).toContain(
       "min-h-[min(20vh,8rem,var(--radix-popover-content-available-height))]",
     );
-    expect(surface.className).toContain("resize");
+    expect(
+      Array.from(surface.querySelectorAll("[data-resize-direction]")).map(
+        (handle) => handle.getAttribute("data-resize-direction"),
+      ),
+    ).toEqual(["n", "ne", "e", "se", "s", "sw", "w", "nw"]);
+    expect(
+      screen.getByTestId("rate-limit-popover-resize-sw").className,
+    ).toContain("cursor-sw-resize");
   });
 
   it("opens provider settings and closes the popover from the CTA", () => {
@@ -591,63 +780,187 @@ describe("<RateLimitPopover /> zero-provider state", () => {
 });
 
 describe("<RateLimitPopover /> rail", () => {
-  it("applies observed drag dimensions without persisting before pointer-up", () => {
-    mocks.configured = [
-      { providerId: "codex", lane: "ephemeralProcess", profiles: undefined },
-    ];
-    mocks.results = { codex: readyResult(codexReady()) };
-    const OriginalResizeObserver = globalThis.ResizeObserver;
-    class TestResizeObserver implements ResizeObserver {
-      static triggerSurface: (() => void) | null = null;
+  it.each(RESIZE_GEOMETRY_CASES)(
+    "keeps the opposite edges fixed while resizing $direction",
+    ({ direction, deltaX, deltaY, expected }) => {
+      const surface = renderCodexPopover();
+      mockRadixResizeGeometry(surface, 480, 360);
 
-      constructor(private readonly callback: ResizeObserverCallback) {}
+      dragResize(surface, direction, 7, { x: deltaX, y: deltaY });
 
-      observe(target: Element): void {
-        if (
-          target.getAttribute("data-testid") ===
-          "rate-limit-popover-resize-surface"
-        ) {
-          TestResizeObserver.triggerSurface = () => this.callback([], this);
-        }
-      }
+      const rect = surface.getBoundingClientRect();
+      expect(rect.left).toBe(expected.left);
+      expect(rect.top).toBe(expected.top);
+      expect(rect.right).toBe(expected.right);
+      expect(rect.bottom).toBe(expected.bottom);
+      expect(useRateLimitPopoverStore.getState().size).toBeNull();
 
-      unobserve(): void {}
+      endResize(surface, "pointerup", 7, { x: deltaX, y: deltaY });
+      expect(useRateLimitPopoverStore.getState().size).toEqual({
+        widthPx: expected.right - expected.left,
+        heightPx: expected.bottom - expected.top,
+      });
+    },
+  );
 
-      disconnect(): void {}
-    }
-    globalThis.ResizeObserver = TestResizeObserver;
-    vi.useFakeTimers();
+  it("keeps the wrapper locked when Radix rewrites its transform mid-drag", async () => {
+    const surface = renderCodexPopover();
+    const geometry = mockRadixResizeGeometry(surface, 480, 360);
+    dragResize(surface, "e", 8, { x: 40, y: 0 });
 
-    try {
-      const view = renderPopover();
-      const surface = screen.getByTestId("rate-limit-popover-resize-surface");
-      vi.spyOn(surface, "getBoundingClientRect").mockReturnValue(
-        new DOMRect(0, 0, 540, 460),
+    await act(async () => {
+      geometry.overwriteRadixPosition(-80, 120);
+      await Promise.resolve();
+    });
+
+    const rect = surface.getBoundingClientRect();
+    expect(rect.left).toBe(100);
+    expect(rect.top).toBe(100);
+    expect(rect.right).toBe(620);
+    expect(rect.bottom).toBe(460);
+    endResize(surface, "pointerup", 8, { x: 40, y: 0 });
+  });
+
+  it("does not accumulate position across repeated horizontal Radix rewrites", async () => {
+    const surface = renderCodexPopover();
+    const geometry = mockRadixResizeGeometry(surface, 480, 360);
+    fireEvent(
+      screen.getByTestId("rate-limit-popover-resize-e"),
+      pointerEvent("pointerdown", {
+        pointerId: 14,
+        clientX: 580,
+        clientY: 460,
+        button: 0,
+      }),
+    );
+    const assertHorizontalDragStep = async (deltaX: number): Promise<void> => {
+      fireEvent(
+        surface,
+        pointerEvent("pointermove", {
+          pointerId: 14,
+          clientX: 580 + deltaX,
+          clientY: 460,
+          button: 0,
+        }),
       );
-      const triggerSurface = TestResizeObserver.triggerSurface;
-      if (triggerSurface === null)
-        throw new Error("expected surface ResizeObserver");
-
-      act(triggerSurface);
-      act(triggerSurface);
-      act(() => {
-        vi.advanceTimersByTime(99);
+      await act(async () => {
+        // Simulate bottom-end Radix re-anchoring after each content-size update.
+        geometry.overwriteRadixPosition(100 - deltaX, 100);
+        await Promise.resolve();
       });
-      expect(surface.style.width).toBe("");
-      expect(useRateLimitPopoverStore.getState().size).toBeNull();
+      const rect = surface.getBoundingClientRect();
+      expect(rect.left).toBe(100);
+      expect(rect.right).toBe(580 + deltaX);
+    };
 
-      act(() => {
-        vi.advanceTimersByTime(1);
+    await assertHorizontalDragStep(20);
+    await assertHorizontalDragStep(40);
+    await assertHorizontalDragStep(80);
+    await assertHorizontalDragStep(120);
+    endResize(surface, "pointerup", 14, { x: 120, y: 0 });
+  });
+
+  it("caps outward resizing at the popover collision boundary", () => {
+    const widthSpy = vi
+      .spyOn(document.documentElement, "clientWidth", "get")
+      .mockReturnValue(700);
+    const heightSpy = vi
+      .spyOn(document.documentElement, "clientHeight", "get")
+      .mockReturnValue(600);
+    try {
+      const surface = renderCodexPopover();
+      mockRadixResizeGeometry(surface, 480, 360);
+      dragResize(surface, "ne", 9, { x: 1_000, y: -1_000 });
+
+      const rect = surface.getBoundingClientRect();
+      expect(rect.left).toBe(100);
+      expect(rect.top).toBe(12);
+      expect(rect.right).toBe(688);
+      expect(rect.bottom).toBe(460);
+      endResize(surface, "pointerup", 9, { x: 1_000, y: -1_000 });
+      expect(useRateLimitPopoverStore.getState().size).toEqual({
+        widthPx: 588,
+        heightPx: 448,
       });
-      expect(surface.style.width).toBe("540px");
-      expect(surface.style.height).toBe("460px");
-      expect(useRateLimitPopoverStore.getState().size).toBeNull();
-      view.unmount();
-      expect(useRateLimitPopoverStore.getState().size).toBeNull();
     } finally {
-      vi.useRealTimers();
-      globalThis.ResizeObserver = OriginalResizeObserver;
+      widthSpy.mockRestore();
+      heightSpy.mockRestore();
     }
+  });
+
+  it.each(["pointercancel", "lostpointercapture"] as const)(
+    "rolls back an interrupted drag on %s",
+    (eventType) => {
+      const surface = renderCodexPopover();
+      const geometry = mockRadixResizeGeometry(surface, 480, 360);
+      dragResize(surface, "ne", 10, { x: 40, y: -40 });
+      expect(geometry.positionWrapper.style.transform).not.toBe(
+        geometry.initialTransform,
+      );
+
+      endResize(surface, eventType, 10, { x: 40, y: -40 });
+
+      expect(surface.style.width).toBe("");
+      expect(surface.style.height).toBe("");
+      expect(geometry.positionWrapper.style.transform).toBe(
+        geometry.initialTransform,
+      );
+      expect(useRateLimitPopoverStore.getState().size).toBeNull();
+    },
+  );
+
+  it("ignores events from a different pointer id", () => {
+    const surface = renderCodexPopover();
+    mockRadixResizeGeometry(surface, 480, 360);
+    fireEvent(
+      screen.getByTestId("rate-limit-popover-resize-e"),
+      pointerEvent("pointerdown", {
+        pointerId: 11,
+        clientX: 580,
+        clientY: 460,
+        button: 0,
+      }),
+    );
+    fireEvent(
+      surface,
+      pointerEvent("pointermove", {
+        pointerId: 99,
+        clientX: 620,
+        clientY: 460,
+        button: 0,
+      }),
+    );
+    expect(surface.style.width).toBe("480px");
+    fireEvent(
+      surface,
+      pointerEvent("pointermove", {
+        pointerId: 11,
+        clientX: 620,
+        clientY: 460,
+        button: 0,
+      }),
+    );
+
+    endResize(surface, "pointerup", 99, { x: 40, y: 0 });
+    expect(surface.style.width).toBe("520px");
+    expect(useRateLimitPopoverStore.getState().size).toBeNull();
+
+    endResize(surface, "pointercancel", 11, { x: 40, y: 0 });
+    expect(surface.style.width).toBe("");
+  });
+
+  it("does not roll back a committed resize when capture is lost after pointer-up", () => {
+    const surface = renderCodexPopover();
+    mockRadixResizeGeometry(surface, 480, 360);
+    dragResize(surface, "ne", 12, { x: 40, y: -40 });
+    endResize(surface, "pointerup", 12, { x: 40, y: -40 });
+    const committedSize = useRateLimitPopoverStore.getState().size;
+
+    endResize(surface, "lostpointercapture", 12, { x: 40, y: -40 });
+
+    expect(useRateLimitPopoverStore.getState().size).toEqual(committedSize);
+    expect(surface.style.width).toBe("520px");
+    expect(surface.style.height).toBe("400px");
   });
 
   it("remembers the last drag size across popover reopens", () => {
@@ -658,13 +971,9 @@ describe("<RateLimitPopover /> rail", () => {
     const first = renderPopover();
 
     const surface = screen.getByTestId("rate-limit-popover-resize-surface");
-    const rectSpy = vi
-      .spyOn(surface, "getBoundingClientRect")
-      .mockReturnValue(new DOMRect(0, 0, 540, 460));
-    // CSS `resize` owns live drag frames and writes these inline dimensions.
-    surface.style.width = "540px";
-    surface.style.height = "460px";
-    fireEvent.pointerUp(surface);
+    const geometry = mockRadixResizeGeometry(surface, 480, 360);
+    dragResize(surface, "se", 13, { x: 60, y: 100 });
+    endResize(surface, "pointerup", 13, { x: 60, y: 100 });
 
     expect(useRateLimitPopoverStore.getState().size).toEqual({
       widthPx: 540,
@@ -678,7 +987,7 @@ describe("<RateLimitPopover /> rail", () => {
     );
     expect(surface.className).toContain("overflow-hidden");
 
-    rectSpy.mockRestore();
+    geometry.rectSpy.mockRestore();
     first.unmount();
     renderPopover();
 
@@ -1751,7 +2060,7 @@ describe("<RateLimitPopover /> per-provider refresh", () => {
     expect(mocks.enqueue).not.toHaveBeenCalled();
   });
 
-  it("refreshes every profile from one provider-heading control", () => {
+  it("refreshes every profile in parallel from one provider-heading control", () => {
     mocks.configured = [
       {
         providerId: "codex",
@@ -1787,16 +2096,22 @@ describe("<RateLimitPopover /> per-provider refresh", () => {
     expect(screen.queryByRole("button", { name: "Refresh Work" })).toBeNull();
     fireEvent.click(refreshProvider);
 
-    expect(mocks.enqueue).toHaveBeenCalledWith(
-      "codex",
-      { type: "PERSONAL" },
-      { force: true, profileId: null },
+    expect(mocks.enqueueBatch).toHaveBeenCalledWith(
+      [
+        {
+          providerId: "codex",
+          accountContext: { type: "PERSONAL" },
+          profileId: null,
+        },
+        {
+          providerId: "codex",
+          accountContext: { type: "PERSONAL" },
+          profileId: "work-profile",
+        },
+      ],
+      { force: true },
     );
-    expect(mocks.enqueue).toHaveBeenCalledWith(
-      "codex",
-      { type: "PERSONAL" },
-      { force: true, profileId: "work-profile" },
-    );
+    expect(mocks.enqueue).not.toHaveBeenCalled();
   });
 
   it("keeps profile cards out of a shared loading state while the provider refresh queue drains", () => {
@@ -1840,11 +2155,12 @@ describe("<RateLimitPopover /> per-provider refresh", () => {
 
   // The queue's `draining` flag is lane-global, not per-provider, so a refresh
   // on ANY ephemeralProcess provider disables every provider's control in that
-  // lane - not just the one whose fetch is in flight. Deliberate: the lane runs
-  // providers one at a time, so this matches a "refresh round is in progress"
-  // mental model rather than "my own fetch is in flight". See the spinner-state
-  // note in `use-provider-rate-limit-refresh.ts`. Pinned here so the shared
-  // disable isn't mistaken for cross-provider leakage and "fixed" away.
+  // lane - not just the one whose fetch is in flight. Deliberate: queue items run
+  // one at a time (each provider click is one parallel profile batch), so this
+  // matches a "refresh round is in progress" mental model rather than "my own
+  // fetch is in flight". See the spinner-state note in
+  // `use-provider-rate-limit-refresh.ts`. Pinned here so the shared disable isn't
+  // mistaken for cross-provider leakage and "fixed" away.
   it("disables both ephemeralProcess providers' refresh controls while the shared queue drains", () => {
     mocks.configured = [
       {

--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -888,6 +888,34 @@ describe("<RateLimitPopover /> rail", () => {
     }
   });
 
+  it("does not commit a drag clamped to the starting dimensions", () => {
+    const widthSpy = vi
+      .spyOn(document.documentElement, "clientWidth", "get")
+      .mockReturnValue(592);
+    const heightSpy = vi
+      .spyOn(document.documentElement, "clientHeight", "get")
+      .mockReturnValue(600);
+    try {
+      const surface = renderCodexPopover();
+      const geometry = mockRadixResizeGeometry(surface, 480, 360);
+
+      dragResize(surface, "e", 15, { x: 100, y: 0 });
+      expect(surface.getBoundingClientRect().width).toBe(480);
+
+      endResize(surface, "pointerup", 15, { x: 100, y: 0 });
+
+      expect(surface.style.width).toBe("");
+      expect(surface.style.height).toBe("");
+      expect(geometry.positionWrapper.style.transform).toBe(
+        geometry.initialTransform,
+      );
+      expect(useRateLimitPopoverStore.getState().size).toBeNull();
+    } finally {
+      widthSpy.mockRestore();
+      heightSpy.mockRestore();
+    }
+  });
+
   it.each(["pointercancel", "lostpointercapture"] as const)(
     "rolls back an interrupted drag on %s",
     (eventType) => {

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -60,10 +60,7 @@ import {
   resolveRateLimitProfileId,
   type RateLimitProfileSelection,
 } from "@/hooks/rate-limits/use-rate-limit-profile-selection";
-import {
-  enqueueRateLimitFetch,
-  enqueueRateLimitFetchBatch,
-} from "@/lib/rate-limits/ephemeral-fetch-queue";
+import { enqueueRateLimitFetchBatch } from "@/lib/rate-limits/ephemeral-fetch-queue";
 import {
   formatUnavailableReason,
   resolvePopoverProviderRateLimitState,
@@ -120,7 +117,162 @@ type RailTabDescriptor =
 const PERSONAL_ACCOUNT_CONTEXT: AccountContext = { type: "PERSONAL" };
 
 const POPOVER_SURFACE_CLASS_NAME =
-  "w-[min(92vw,30rem)] min-w-[min(92vw,20rem,var(--radix-popover-content-available-width))] max-w-[var(--radix-popover-content-available-width)] max-h-[var(--radix-popover-content-available-height)] resize overflow-hidden";
+  "relative w-[min(92vw,30rem)] min-w-[min(92vw,20rem,var(--radix-popover-content-available-width))] max-w-[var(--radix-popover-content-available-width)] max-h-[var(--radix-popover-content-available-height)] overflow-hidden";
+
+type RateLimitPopoverResizeDirection =
+  "n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "nw";
+
+interface RateLimitPopoverPositionLock {
+  readonly wrapperElement: HTMLElement;
+  offsetXPx: number;
+  offsetYPx: number;
+  readonly setOffset: (xPx: number, yPx: number) => void;
+  readonly restore: () => void;
+}
+
+interface RateLimitPopoverViewportBounds {
+  readonly rightPx: number;
+  readonly bottomPx: number;
+}
+
+interface RateLimitPopoverResizeDrag {
+  readonly pointerId: number;
+  readonly direction: RateLimitPopoverResizeDirection;
+  readonly startClientX: number;
+  readonly startClientY: number;
+  readonly startLeftPx: number;
+  readonly startTopPx: number;
+  readonly startRightPx: number;
+  readonly startBottomPx: number;
+  readonly startWidthPx: number;
+  readonly startHeightPx: number;
+  readonly viewportRightPx: number;
+  readonly viewportBottomPx: number;
+  readonly positionLock: RateLimitPopoverPositionLock;
+  readonly restorePositionOnCancel: boolean;
+  readonly startPositionOffsetXPx: number;
+  readonly startPositionOffsetYPx: number;
+  readonly previousInlineWidth: string;
+  readonly previousInlineHeight: string;
+  latestWidthPx: number;
+  latestHeightPx: number;
+  moved: boolean;
+}
+
+const RATE_LIMIT_POPOVER_RESIZE_DIRECTIONS = [
+  "n",
+  "ne",
+  "e",
+  "se",
+  "s",
+  "sw",
+  "w",
+  "nw",
+] as const;
+
+function isRateLimitPopoverResizeDirection(
+  value: string | undefined,
+): value is RateLimitPopoverResizeDirection {
+  return RATE_LIMIT_POPOVER_RESIZE_DIRECTIONS.some(
+    (direction) => direction === value,
+  );
+}
+
+const RATE_LIMIT_POPOVER_RESIZE_HANDLE_CLASS_NAMES = {
+  n: "absolute inset-x-3 top-0 z-20 h-2 cursor-n-resize touch-none",
+  ne: "absolute top-0 right-0 z-30 size-3 cursor-ne-resize touch-none",
+  e: "absolute inset-y-3 right-0 z-20 w-2 cursor-e-resize touch-none",
+  se: "absolute right-0 bottom-0 z-30 size-3 cursor-se-resize touch-none",
+  s: "absolute inset-x-3 bottom-0 z-20 h-2 cursor-s-resize touch-none",
+  sw: "absolute bottom-0 left-0 z-30 size-3 cursor-sw-resize touch-none",
+  w: "absolute inset-y-3 left-0 z-20 w-2 cursor-w-resize touch-none",
+  nw: "absolute top-0 left-0 z-30 size-3 cursor-nw-resize touch-none",
+} satisfies Record<RateLimitPopoverResizeDirection, string>;
+
+const RATE_LIMIT_POPOVER_COLLISION_PADDING_PX = 12;
+
+// Radix owns the floating wrapper's transform and rewrites it whenever content
+// size changes. Lock that transform for the rest of this popover opening so a
+// resize can move the exact active edge without Radix re-anchoring underneath
+// the pointer. The observer only restores one expected transform; it never
+// derives another offset from the moved element, avoiding a feedback loop.
+function createRateLimitPopoverPositionLock(
+  wrapperElement: HTMLElement,
+): RateLimitPopoverPositionLock {
+  const originalTransform = wrapperElement.style.transform;
+  const originalTransformPriority =
+    wrapperElement.style.getPropertyPriority("transform");
+  let expectedTransform = originalTransform;
+  let restored = false;
+  const applyExpectedTransform = (): void => {
+    if (restored) return;
+    if (
+      wrapperElement.style.transform === expectedTransform &&
+      wrapperElement.style.getPropertyPriority("transform") === "important"
+    ) {
+      return;
+    }
+    wrapperElement.style.setProperty(
+      "transform",
+      expectedTransform,
+      "important",
+    );
+  };
+  const observer = new MutationObserver(applyExpectedTransform);
+  const positionLock: RateLimitPopoverPositionLock = {
+    wrapperElement,
+    offsetXPx: 0,
+    offsetYPx: 0,
+    setOffset: (xPx, yPx) => {
+      positionLock.offsetXPx = xPx;
+      positionLock.offsetYPx = yPx;
+      const offsetTransform = `translate(${xPx}px, ${yPx}px)`;
+      expectedTransform =
+        originalTransform === "" || originalTransform === "none"
+          ? offsetTransform
+          : `${originalTransform} ${offsetTransform}`;
+      applyExpectedTransform();
+    },
+    restore: () => {
+      if (restored) return;
+      restored = true;
+      observer.disconnect();
+      if (originalTransform === "") {
+        wrapperElement.style.removeProperty("transform");
+        return;
+      }
+      wrapperElement.style.setProperty(
+        "transform",
+        originalTransform,
+        originalTransformPriority,
+      );
+    },
+  };
+  observer.observe(wrapperElement, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+  applyExpectedTransform();
+  return positionLock;
+}
+
+function rateLimitPopoverViewportBounds(
+  surface: HTMLDivElement,
+  rect: DOMRect,
+): RateLimitPopoverViewportBounds {
+  const ownerDocument = surface.ownerDocument;
+  const win = ownerDocument.defaultView;
+  const viewportWidth =
+    ownerDocument.documentElement.clientWidth || win?.innerWidth || rect.right;
+  const viewportHeight =
+    ownerDocument.documentElement.clientHeight ||
+    win?.innerHeight ||
+    rect.bottom;
+  return {
+    rightPx: viewportWidth - RATE_LIMIT_POPOVER_COLLISION_PADDING_PX,
+    bottomPx: viewportHeight - RATE_LIMIT_POPOVER_COLLISION_PADDING_PX,
+  };
+}
 
 type RateLimitPopoverSurfaceVariant = "content" | "empty";
 
@@ -239,7 +391,7 @@ export function RateLimitPopover({
       side="bottom"
       align="end"
       sideOffset={8}
-      collisionPadding={12}
+      collisionPadding={RATE_LIMIT_POPOVER_COLLISION_PADDING_PX}
       role="dialog"
       aria-label="Usage limits"
       className="w-fit max-w-[var(--radix-popover-content-available-width)] max-h-[var(--radix-popover-content-available-height)] gap-0 overflow-hidden rounded-xl p-0"
@@ -272,9 +424,9 @@ export function RateLimitPopover({
 }
 
 /**
- * Viewport-bounded, two-axis CSS resize surface. The browser owns live drag
- * frames and writes the resulting inline dimensions; pointer release commits
- * that measured size once so subsequent opens restore it.
+ * Viewport-bounded resize surface with OS-style hit areas on every edge and
+ * corner. Drag frames mutate inline dimensions directly, while pointer release
+ * commits the final measured size once so subsequent opens restore it.
  */
 function RateLimitPopoverResizeSurface({
   variant,
@@ -285,49 +437,170 @@ function RateLimitPopoverResizeSurface({
 }): ReactNode {
   const size = useRateLimitPopoverStore((state) => state.size);
   const setSize = useRateLimitPopoverStore((state) => state.setSize);
-  const surfaceRef = useRef<HTMLDivElement | null>(null);
-  const commitResizedDimensions = (
-    event: ReactPointerEvent<HTMLDivElement>,
-  ): void => {
-    if (event.target !== event.currentTarget) return;
-    const { width, height } = event.currentTarget.getBoundingClientRect();
-    if (width <= 0 || height <= 0) return;
-    setSize({ widthPx: width, heightPx: height });
-  };
-  useEffect(() => {
-    const surface = surfaceRef.current;
-    if (surface === null) return;
-    const win = surface.ownerDocument.defaultView;
-    if (win === null) return;
+  const dragRef = useRef<RateLimitPopoverResizeDrag | null>(null);
+  const positionLockRef = useRef<RateLimitPopoverPositionLock | null>(null);
+  useEffect(
+    () => () => {
+      positionLockRef.current?.restore();
+    },
+    [],
+  );
 
-    let initialized = false;
-    let applyTimer: number | null = null;
-    const applyMeasuredSize = (): void => {
-      const { width, height } = surface.getBoundingClientRect();
-      if (width <= 0 || height <= 0) return;
-      surface.style.width = `${width}px`;
-      surface.style.height = `${height}px`;
+  const startResize = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    if (event.button !== 0 || dragRef.current !== null) return;
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    const direction = target.dataset.resizeDirection;
+    if (!isRateLimitPopoverResizeDirection(direction)) return;
+
+    const surface = event.currentTarget;
+    const positionWrapper = surface.closest<HTMLElement>(
+      "[data-radix-popper-content-wrapper]",
+    );
+    if (positionWrapper === null) return;
+    const rect = surface.getBoundingClientRect();
+    const { width, height } = rect;
+    if (width <= 0 || height <= 0) return;
+    const viewportBounds = rateLimitPopoverViewportBounds(surface, rect);
+    event.preventDefault();
+    event.stopPropagation();
+    surface.setPointerCapture(event.pointerId);
+    const existingPositionLock = positionLockRef.current;
+    const restorePositionOnCancel =
+      existingPositionLock === null ||
+      existingPositionLock.wrapperElement !== positionWrapper;
+    if (
+      existingPositionLock !== null &&
+      existingPositionLock.wrapperElement !== positionWrapper
+    ) {
+      existingPositionLock.restore();
+    }
+    const positionLock = restorePositionOnCancel
+      ? createRateLimitPopoverPositionLock(positionWrapper)
+      : existingPositionLock;
+    positionLockRef.current = positionLock;
+    const drag: RateLimitPopoverResizeDrag = {
+      pointerId: event.pointerId,
+      direction,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startLeftPx: rect.left,
+      startTopPx: rect.top,
+      startRightPx: rect.right,
+      startBottomPx: rect.bottom,
+      startWidthPx: width,
+      startHeightPx: height,
+      viewportRightPx: viewportBounds.rightPx,
+      viewportBottomPx: viewportBounds.bottomPx,
+      positionLock,
+      restorePositionOnCancel,
+      startPositionOffsetXPx: positionLock.offsetXPx,
+      startPositionOffsetYPx: positionLock.offsetYPx,
+      previousInlineWidth: surface.style.width,
+      previousInlineHeight: surface.style.height,
+      latestWidthPx: width,
+      latestHeightPx: height,
+      moved: false,
     };
-    const observer = new ResizeObserver(() => {
-      if (!initialized) {
-        initialized = true;
-        return;
+    dragRef.current = drag;
+    // Freeze both axes at their computed dimensions before the first drag frame;
+    // otherwise a content reflow can change the untouched axis mid-drag.
+    surface.style.width = `${width}px`;
+    surface.style.height = `${height}px`;
+  };
+
+  const resizeDuringDrag = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    const drag = dragRef.current;
+    if (drag === null || drag.pointerId !== event.pointerId) return;
+    event.preventDefault();
+    const deltaX = event.clientX - drag.startClientX;
+    const deltaY = event.clientY - drag.startClientY;
+    const resizeFromLeft = drag.direction.includes("w");
+    const resizeFromRight = drag.direction.includes("e");
+    const resizeFromTop = drag.direction.includes("n");
+    const resizeFromBottom = drag.direction.includes("s");
+    let widthDelta = 0;
+    if (resizeFromLeft) widthDelta = -deltaX;
+    else if (resizeFromRight) widthDelta = deltaX;
+    let heightDelta = 0;
+    if (resizeFromTop) heightDelta = -deltaY;
+    else if (resizeFromBottom) heightDelta = deltaY;
+    let maxWidthPx = drag.startWidthPx;
+    if (resizeFromLeft) {
+      maxWidthPx = drag.startRightPx - RATE_LIMIT_POPOVER_COLLISION_PADDING_PX;
+    } else if (resizeFromRight) {
+      maxWidthPx = drag.viewportRightPx - drag.startLeftPx;
+    }
+    let maxHeightPx = drag.startHeightPx;
+    if (resizeFromTop) {
+      maxHeightPx =
+        drag.startBottomPx - RATE_LIMIT_POPOVER_COLLISION_PADDING_PX;
+    } else if (resizeFromBottom) {
+      maxHeightPx = drag.viewportBottomPx - drag.startTopPx;
+    }
+    drag.latestWidthPx = Math.min(
+      Math.max(1, maxWidthPx),
+      Math.max(1, drag.startWidthPx + widthDelta),
+    );
+    drag.latestHeightPx = Math.min(
+      Math.max(1, maxHeightPx),
+      Math.max(1, drag.startHeightPx + heightDelta),
+    );
+    drag.moved = widthDelta !== 0 || heightDelta !== 0;
+    event.currentTarget.style.width = `${drag.latestWidthPx}px`;
+    event.currentTarget.style.height = `${drag.latestHeightPx}px`;
+    const measured = event.currentTarget.getBoundingClientRect();
+    const offsetDeltaXPx = resizeFromLeft
+      ? drag.startWidthPx - measured.width
+      : 0;
+    const offsetDeltaYPx = resizeFromTop
+      ? drag.startHeightPx - measured.height
+      : 0;
+    drag.positionLock.setOffset(
+      drag.startPositionOffsetXPx + offsetDeltaXPx,
+      drag.startPositionOffsetYPx + offsetDeltaYPx,
+    );
+  };
+
+  const finishResize = (
+    event: ReactPointerEvent<HTMLDivElement>,
+    commit: boolean,
+  ): void => {
+    const drag = dragRef.current;
+    if (drag === null || drag.pointerId !== event.pointerId) return;
+    dragRef.current = null;
+    const surface = event.currentTarget;
+    if (surface.hasPointerCapture(event.pointerId)) {
+      surface.releasePointerCapture(event.pointerId);
+    }
+    if (!commit || !drag.moved) {
+      surface.style.width = drag.previousInlineWidth;
+      surface.style.height = drag.previousInlineHeight;
+      if (drag.restorePositionOnCancel) {
+        drag.positionLock.restore();
+        if (positionLockRef.current === drag.positionLock) {
+          positionLockRef.current = null;
+        }
+      } else {
+        drag.positionLock.setOffset(
+          drag.startPositionOffsetXPx,
+          drag.startPositionOffsetYPx,
+        );
       }
-      if (applyTimer !== null) win.clearTimeout(applyTimer);
-      applyTimer = win.setTimeout(applyMeasuredSize, 100);
-    });
-    observer.observe(surface);
-    return () => {
-      observer.disconnect();
-      if (applyTimer === null) return;
-      win.clearTimeout(applyTimer);
-      applyMeasuredSize();
-    };
-  }, []);
+      return;
+    }
+
+    const measured = surface.getBoundingClientRect();
+    const widthPx = measured.width > 0 ? measured.width : drag.latestWidthPx;
+    const heightPx =
+      measured.height > 0 ? measured.height : drag.latestHeightPx;
+    surface.style.width = `${widthPx}px`;
+    surface.style.height = `${heightPx}px`;
+    setSize({ widthPx, heightPx });
+  };
 
   return (
     <div
-      ref={surfaceRef}
       data-testid="rate-limit-popover-resize-surface"
       className={cn(
         POPOVER_SURFACE_CLASS_NAME,
@@ -340,9 +613,22 @@ function RateLimitPopoverResizeSurface({
           ? undefined
           : { width: size.widthPx, height: size.heightPx }
       }
-      onPointerUp={commitResizedDimensions}
+      onPointerDown={startResize}
+      onPointerMove={resizeDuringDrag}
+      onPointerUp={(event) => finishResize(event, true)}
+      onPointerCancel={(event) => finishResize(event, false)}
+      onLostPointerCapture={(event) => finishResize(event, false)}
     >
       {children}
+      {RATE_LIMIT_POPOVER_RESIZE_DIRECTIONS.map((direction) => (
+        <div
+          key={direction}
+          aria-hidden="true"
+          data-resize-direction={direction}
+          data-testid={`rate-limit-popover-resize-${direction}`}
+          className={RATE_LIMIT_POPOVER_RESIZE_HANDLE_CLASS_NAMES[direction]}
+        />
+      ))}
     </div>
   );
 }
@@ -1059,12 +1345,14 @@ function ProfileRateLimitProviderBlock({
 
   const refresh = (): Promise<void> => {
     if (lane === "ephemeralProcess") {
-      targets.forEach((target) => {
-        void enqueueRateLimitFetch(providerId, DEFAULT_ACCOUNT_CONTEXT, {
-          force: true,
+      void enqueueRateLimitFetchBatch(
+        targets.map((target) => ({
+          providerId,
+          accountContext: DEFAULT_ACCOUNT_CONTEXT,
           profileId: target.profileId,
-        });
-      });
+        })),
+        { force: true },
+      );
       return Promise.resolve();
     }
     targets.forEach((target) => {

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -546,10 +546,12 @@ function RateLimitPopoverResizeSurface({
       Math.max(1, maxHeightPx),
       Math.max(1, drag.startHeightPx + heightDelta),
     );
-    drag.moved = widthDelta !== 0 || heightDelta !== 0;
     event.currentTarget.style.width = `${drag.latestWidthPx}px`;
     event.currentTarget.style.height = `${drag.latestHeightPx}px`;
     const measured = event.currentTarget.getBoundingClientRect();
+    drag.moved =
+      measured.width !== drag.startWidthPx ||
+      measured.height !== drag.startHeightPx;
     const offsetDeltaXPx = resizeFromLeft
       ? drag.startWidthPx - measured.width
       : 0;


### PR DESCRIPTION
## Summary

- batch every configured profile for a provider into one rate-limit fetch queue item so provider-header refreshes start profile requests concurrently while preserving lane-wide pending state and failure isolation
- add OS-style resize handles on all four edges and corners, persist committed dimensions across popover reopenings, and roll back abnormal pointer cancellation/lost-capture paths
- lock the Radix positioning wrapper during a resize and apply stable absolute offsets with viewport collision limits, preventing horizontal drags from recursively moving or losing the popover
- add regression coverage for all eight resize directions, Radix transform rewrites, viewport bounds, commit/cancel semantics, pointer identity, persistence, and provider refresh concurrency

## Related issue

N/A

## Validation

- focused rate-limit popover/store/queue suites — 97 tests passed
- `bun run build`
- `bun run compile`
- `bun run lint`
- changed-file Prettier and diff checks
- React Doctor changed-files scan — no issues
- commit-time pre-commit hygiene plus affected build/compile/lint/format checks
- full-workspace tests were attempted concurrently; unrelated CLI/desktop/protocol tests hit 5-second timeouts under resource contention, while no changed-path test failed

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
