### PR TITLE
fix(protocol): bridge legacy-host resolvedAt as resolved, not pending

### DIFF
--- a/protocol/src/host/__tests__/worktree-schemas.test.ts
+++ b/protocol/src/host/__tests__/worktree-schemas.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@traycer/protocol/framework/index";
 import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import {
+  LEGACY_HOST_RESOLVED_AT,
   worktreeBindingEntrySchema,
   worktreeBranchStatusSchema,
   worktreeHostEntrySchema,
@@ -707,7 +708,7 @@ describe("worktree.listAllForHost v1.0 <-> v1.2 negotiation", () => {
     );
   });
 
-  it("upgrades v1.3 to v1.4 with an unresolved timestamp", () => {
+  it("upgrades v1.3 to v1.4 stamping the legacy-host resolved sentinel (not null)", () => {
     const request = {
       includeActivity: false,
       activityPaths: null,
@@ -742,10 +743,14 @@ describe("worktree.listAllForHost v1.0 <-> v1.2 negotiation", () => {
       V14,
       response,
     );
-    expect(upgraded.worktrees[0].resolvedAt).toBeNull();
+    // NEW CLIENT + OLD HOST: a v1.3 host has no `resolvedAt` and never sends
+    // one, so bridging to `null` would strand its rows perpetually "checking".
+    // The resolved sentinel keeps them authoritative.
+    expect(upgraded.worktrees[0].resolvedAt).toBe(LEGACY_HOST_RESOLVED_AT);
     expect(worktreeListAllForHostResponseSchemaV14.parse(upgraded)).toEqual(
       upgraded,
     );
+    // OLD CLIENT + NEW HOST: a v1.3 caller strips the field it never knew.
     expect(
       worktreeListAllForHostResponseSchemaV13.parse(upgraded).worktrees[0],
     ).not.toHaveProperty("resolvedAt");
@@ -811,7 +816,7 @@ describe("worktree.listByWorkspacePaths v1.1 <-> v1.2 negotiation", () => {
     ).toThrow();
   });
 
-  it("upgrades v1.2 to v1.3 with unresolved timestamps and strips them for v1.2", () => {
+  it("upgrades v1.2 to v1.3 stamping the legacy-host resolved sentinel and strips it for v1.2", () => {
     const request = {
       workspacePaths: ["/Users/dev/acme/web"],
       scriptRefs: [],
@@ -843,10 +848,14 @@ describe("worktree.listByWorkspacePaths v1.1 <-> v1.2 negotiation", () => {
       V13,
       response,
     );
-    expect(upgraded.workspaces[0].resolvedAt).toBeNull();
+    // NEW CLIENT + OLD HOST: a v1.2 host never sends `resolvedAt`; the resolved
+    // sentinel (not `null`) keeps its summaries authoritative so the home
+    // workspace selector does not strand every folder as perpetually pending.
+    expect(upgraded.workspaces[0].resolvedAt).toBe(LEGACY_HOST_RESOLVED_AT);
     expect(
       worktreeListByWorkspacePathsResponseSchemaV13.parse(upgraded),
     ).toEqual(upgraded);
+    // OLD CLIENT + NEW HOST: a v1.2 caller strips the field it never knew.
     expect(
       worktreeListByWorkspacePathsResponseSchemaV12.parse(upgraded)
         .workspaces[0],

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -255,6 +255,7 @@ import {
   worktreeSetRepoScriptsResponseSchema,
   worktreeGetBindingRequestSchema,
   worktreeGetBindingResponseSchema,
+  LEGACY_HOST_RESOLVED_AT,
 } from "@traycer/protocol/host/worktree-schemas";
 import {
   snapshotsClearLocalSnapshotsRequestSchema,
@@ -475,6 +476,11 @@ export const worktreeListByWorkspacePathsV13 = defineRpcContract({
   responseSchema: worktreeListByWorkspacePathsResponseSchemaV13,
 });
 
+// A v1.2 host predates `resolvedAt` and never emits one, so its rows bridge to
+// the resolved sentinel (NOT `null`): its summaries are authoritative, and
+// stamping `null` would strand every folder as perpetually pending in the home
+// workspace selector (non-selectable, no git eligibility). See
+// LEGACY_HOST_RESOLVED_AT.
 export const worktreeListByWorkspacePathsUpgradeV12ToV13 = defineUpgradePath<
   typeof worktreeListByWorkspacePathsV12,
   typeof worktreeListByWorkspacePathsV13
@@ -486,7 +492,7 @@ export const worktreeListByWorkspacePathsUpgradeV12ToV13 = defineUpgradePath<
     ...response,
     workspaces: response.workspaces.map((workspace) => ({
       ...workspace,
-      resolvedAt: null,
+      resolvedAt: LEGACY_HOST_RESOLVED_AT,
     })),
   }),
 });
@@ -685,6 +691,12 @@ export const worktreeListAllForHostV14 = defineRpcContract({
   responseSchema: worktreeListAllForHostResponseSchemaV14,
 });
 
+// A v1.3 host predates `resolvedAt` and never emits one, so its rows bridge to
+// the resolved sentinel (NOT `null`): stamping `null` would strand every
+// worktree in the settings panel as perpetually "checking" - non-selectable,
+// non-deletable, no enrichment ever accepted by the staleness merge. Every row
+// from the legacy host shares the same sentinel, so that merge's timestamp
+// comparison degrades to a no-op accept. See LEGACY_HOST_RESOLVED_AT.
 export const worktreeListAllForHostUpgradeV13ToV14 = defineUpgradePath<
   typeof worktreeListAllForHostV13,
   typeof worktreeListAllForHostV14
@@ -696,7 +708,7 @@ export const worktreeListAllForHostUpgradeV13ToV14 = defineUpgradePath<
     ...response,
     worktrees: response.worktrees.map((worktree) => ({
       ...worktree,
-      resolvedAt: null,
+      resolvedAt: LEGACY_HOST_RESOLVED_AT,
     })),
   }),
 });

--- a/protocol/src/host/worktree-schemas.ts
+++ b/protocol/src/host/worktree-schemas.ts
@@ -368,9 +368,35 @@ export type WorktreeListByWorkspacePathsRequestV13 =
   WorktreeListByWorkspacePathsRequestV12;
 
 /**
+ * The `resolvedAt` a version-bridge stamps for a row coming from a host that
+ * predates `resolvedAt` entirely (a v1.2 `listByWorkspacePaths` / v1.3
+ * `listAllForHost` peer). Such a host has already returned its authoritative
+ * answer and will NEVER emit a real timestamp to clear a `null`, so bridging
+ * these rows to `null` (the "not yet derived" sentinel) strands them as
+ * perpetually pending - non-selectable folders, no git eligibility, endless
+ * "checking". Stamping this resolved sentinel instead lets clients treat the
+ * legacy host's facts as authoritative.
+ *
+ * The value is a small POSITIVE number, deliberately, for two reasons:
+ *  - The only timestamp math over `resolvedAt` compares two rows FROM THE SAME
+ *    METHOD AND HOST (the settings staleness merge,
+ *    `enriched.resolvedAt >= base.resolvedAt`); a legacy host bridges every one
+ *    of its rows to this same constant, so the comparison degrades to a no-op
+ *    accept - exactly the pre-`resolvedAt` behavior. A real host's timestamps
+ *    (`Date.now()`, ~1e12) never collide with it, and no consumer computes an
+ *    age from `resolvedAt`.
+ *  - It is truthy, so it reads as "resolved" under a `!resolvedAt` check too,
+ *    not just the `=== null` checks consumers use today - `0` would regress the
+ *    moment any consumer switched to a falsy check.
+ */
+export const LEGACY_HOST_RESOLVED_AT = 1;
+
+/**
  * `worktree.listByWorkspacePaths` v1.3 summary. `null` means the host has not
  * derived this row yet; clients must not treat schema-safe fallback facts as
- * authoritative until a non-null timestamp arrives.
+ * authoritative until a non-null timestamp arrives. A row bridged up from a
+ * pre-`resolvedAt` host instead carries {@link LEGACY_HOST_RESOLVED_AT} - that
+ * host's answer is authoritative, not pending.
  */
 export const worktreeWorkspaceSummarySchemaV13 =
   worktreeWorkspaceSummarySchema.extend({


### PR DESCRIPTION
## Problem

A host that predates `resolvedAt` — `worktree.listByWorkspacePaths` at **v1.2** or `worktree.listAllForHost` at **v1.3** — never emits the field. The v1.2→v1.3 and v1.3→v1.4 upgrade paths bridged every such row to `resolvedAt: null`, i.e. the *"not yet derived / pending"* sentinel. But an old host will **never** send a real timestamp to clear it, so those rows are pending **forever**, with no convergence path (the query re-bridges to `null` even on a forced refetch).

Both consuming surfaces deliberately address **arbitrary (remote / older) directory hosts**, so this version skew is reachable:

- **Home workspace selector** (`listByWorkspacePaths@1.3`): every folder is permanently non-git, its mode/branch controls disabled ("Waiting for the host to verify this folder…"), and `emitForFolder` early-returns on `resolvedAt === null` — so **folders can't be selected at all**.
- **Settings worktrees panel + delete-candidates** (`listAllForHost@1.4`): every worktree is stuck **"Checking…"**, non-selectable and non-deletable, and the enrichment staleness merge never accepts.

This is the same class as the `worktree.listBindingsForEpic` pending-row bug, on the two sibling `resolvedAt` surfaces.

## Fix

Add `LEGACY_HOST_RESOLVED_AT` and stamp it (instead of `null`) in both upgrade paths, so an old host's rows read as **resolved / authoritative** rather than perpetually pending.

The value is a **small positive number**, deliberately:

- The only timestamp math over `resolvedAt` is the settings staleness merge `enriched.resolvedAt >= base.resolvedAt`, which compares two rows from the **same method + host**. A legacy host bridges every one of its rows to the same constant, so the comparison degrades to a no-op accept — exactly the pre-`resolvedAt` behavior. (A `Date.now()` fabrication would instead order by arrival time; a fixed constant does not.)
- Being **truthy**, it also reads as resolved under a `!resolvedAt` check, not just the `=== null` checks consumers use today — `0` would silently regress the moment any consumer switched to a falsy check.

Client-side only: the upgrade path only changes what a *new* client synthesizes from an *old-host* response. No wire-schema change, no released-surface impact.

## Verification

- `bun run compile` (protocol + gui-app) clean.
- Protocol suite green (**958 tests**), including updated both-direction negotiation tests (bridge stamps the sentinel; the field is stripped for an older caller).
- gui-app consumer suites green (**534 tests** across home workspace selector, settings panels, epic hooks) — no regression.
- Audited all ~24 `resolvedAt` consumers: every one uses an explicit `=== null` / `!== null` / `>=` check.