### PR TITLE
fix(protocol): tell A2A receivers a responseId names the thread, not one message

### DIFF
--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -1320,7 +1320,7 @@ function registerAgentCommands(program: Command): void {
       )
       .option(
         "--response-id <id>",
-        "Close an open thread - this send is the final reply",
+        "Close an open thread - one reply answers every message received on it",
       ),
     (opts) =>
       buildAgentSendCommand({

--- a/protocol/src/agent/__tests__/a2a-message-format.test.ts
+++ b/protocol/src/agent/__tests__/a2a-message-format.test.ts
@@ -18,6 +18,7 @@ describe("formatAgentMessage", () => {
       [
         "[traycer:agent-message] from Review Agent (agent agent-1) [codex]",
         '[traycer:agent-message] A reply is expected. Use the traycer_send_message tool to reply with responseId="response-1".',
+        "[traycer:agent-message] The responseId names this sender's thread, not this single message: follow-up messages may arrive with the same responseId, and one reply with it answers everything on the thread. Only a reply carrying the responseId completes the request — a fresh message does not.",
         "",
         "Please review this.",
       ].join("\n"),
@@ -40,6 +41,7 @@ describe("formatAgentMessage", () => {
       [
         "[traycer:agent-message] from agent agent-1",
         '[traycer:agent-message] A reply is expected. Use the traycer_send_message tool to reply with responseId="response-1".',
+        "[traycer:agent-message] The responseId names this sender's thread, not this single message: follow-up messages may arrive with the same responseId, and one reply with it answers everything on the thread. Only a reply carrying the responseId completes the request — a fresh message does not.",
         "",
         "Please review this.",
       ].join("\n"),
@@ -87,6 +89,7 @@ describe("formatAgentMessage", () => {
         "",
         "[traycer inbox] message from agent agent-1 — responseId response-1",
         '[traycer inbox] a reply is expected — reply with: traycer agent send --to agent-1 --response-id response-1 --message "<your reply>"',
+        "[traycer inbox] the response id names this sender's thread, not this single message — follow-ups may arrive with the same id and one reply with it answers them all; only a reply sent with --response-id completes the request",
         "",
         "Please review this.",
         "[traycer inbox] ─── end of message ───",

--- a/protocol/src/agent/a2a-message-format.ts
+++ b/protocol/src/agent/a2a-message-format.ts
@@ -37,7 +37,8 @@ export function formatAgentMessage(input: FormatAgentMessageInput): string {
 
 function formatGuiAgentMessage(input: FormatAgentMessageInput): string {
   const replyLine = input.reply.expectsReply
-    ? `[traycer:agent-message] A reply is expected. Use the traycer_send_message tool to reply with responseId="${input.reply.responseId}".`
+    ? `[traycer:agent-message] A reply is expected. Use the traycer_send_message tool to reply with responseId="${input.reply.responseId}".
+[traycer:agent-message] The responseId names this sender's thread, not this single message: follow-up messages may arrive with the same responseId, and one reply with it answers everything on the thread. Only a reply carrying the responseId completes the request — a fresh message does not.`
     : "[traycer:agent-message] No reply is required.";
 
   return `[traycer:agent-message] from ${formatAgentMessageSenderLabel(input.sender)}
@@ -56,6 +57,7 @@ function formatCliAgentMessage(input: FormatAgentMessageInput): string {
     return `
 ${header}
 [traycer inbox] a reply is expected — reply with: traycer agent send --to ${input.sender.agentId} --response-id ${input.reply.responseId} --message "<your reply>"
+[traycer inbox] the response id names this sender's thread, not this single message — follow-ups may arrive with the same id and one reply with it answers them all; only a reply sent with --response-id completes the request
 
 ${input.body}
 [traycer inbox] ─── end of message ───


### PR DESCRIPTION
## Problem

An `expectReply` A2A send reuses **one `responseId` per (sender, receiver) pair** — the id is a stable thread handle, not a per-message id. Follow-up sends to an agent that still owes a reply therefore pile onto the same thread and arrive with the same `responseId`.

A receiver that saw a repeated id had no framing telling it that:
- one reply on that id answers **everything** delivered on the thread, and
- **only** a reply carrying the id closes the request.

In a field incident a receiver facing an ambiguous id switched to fresh report messages instead. A fresh message delivers content but never consumes the pending slot, so the content channel and the broker's bookkeeping diverged: one unclosed thread then re-fired a "finished turn without replying" notice on every later turn-end for the rest of the session.

## Fix

- `a2a-message-format.ts`: add one line to both the **GUI** and **CLI** delivery framing making the thread semantics explicit (repeated id → one reply answers the cumulative thread; a fresh message does not complete the request).
- `index.ts`: sharpen the `--response-id` CLI help from "this send is the final reply" to "one reply answers every message received on it".

The framing is emitted by the shared `formatAgentMessage`, so the same wording reaches live deliveries, the TUI `monitor` output, and the host's system-prompt examples.

## Tests

`protocol/src/agent/__tests__/a2a-message-format.test.ts` pins updated for the new lines. `bun run compile` clean; formatter suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)