### PR TITLE
fix(gui-app): make notification expansion overflow-aware

### DIFF
--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -563,6 +563,7 @@ describe("NotificationsPopover click routing", () => {
       expect(notificationTitle.className).toContain("line-clamp-2");
       expect(notificationTitle.className).toContain("font-semibold");
       expect(notificationBody.className).toContain("line-clamp-2");
+      expect(notificationBody.className).toContain("break-words");
       expect(notificationBody.className).not.toContain("truncate");
 
       const expand = within(completed).getByRole("button", {

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -275,6 +275,46 @@ function notificationIds(rows: ReadonlyArray<HTMLElement>) {
   return rows.map((row) => row.dataset.notificationId);
 }
 
+const ELEMENT_DIMENSIONS = [
+  "scrollHeight",
+  "clientHeight",
+  "scrollWidth",
+  "clientWidth",
+] as const;
+
+type ElementDimension = (typeof ELEMENT_DIMENSIONS)[number];
+
+function mockElementDimensions(
+  getValue: (element: HTMLElement, dimension: ElementDimension) => number,
+) {
+  const descriptors = new Map(
+    ELEMENT_DIMENSIONS.map((dimension) => [
+      dimension,
+      Object.getOwnPropertyDescriptor(HTMLElement.prototype, dimension),
+    ]),
+  );
+
+  ELEMENT_DIMENSIONS.forEach((dimension) => {
+    Object.defineProperty(HTMLElement.prototype, dimension, {
+      configurable: true,
+      get(this: HTMLElement) {
+        return getValue(this, dimension);
+      },
+    });
+  });
+
+  return (): void => {
+    ELEMENT_DIMENSIONS.forEach((dimension) => {
+      const descriptor = descriptors.get(dimension);
+      if (descriptor === undefined) {
+        Reflect.deleteProperty(HTMLElement.prototype, dimension);
+      } else {
+        Object.defineProperty(HTMLElement.prototype, dimension, descriptor);
+      }
+    });
+  };
+}
+
 async function selectTab(testId: string) {
   const trigger = screen.getByTestId(testId);
   await act(async () => {
@@ -468,10 +508,226 @@ describe("NotificationsPopover click routing", () => {
     if (completed === undefined) throw new Error("missing completed row");
     const notificationTitle =
       within(completed).getByTestId("notification-title");
-    expect(notificationTitle.className).toContain("truncate");
+    const notificationBody = within(completed).getByTestId("notification-body");
+    expect(notificationTitle.className).toContain("line-clamp-2");
     expect(notificationTitle.className).toContain("font-semibold");
-    fireEvent.pointerMove(notificationTitle, { pointerType: "mouse" });
-    expect((await screen.findByRole("tooltip")).textContent).toBe(TASK_TITLE);
+    expect(notificationBody.className).toContain("line-clamp-2");
+  });
+
+  it("expands overflowing notification text inline", async () => {
+    const scrollHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollHeight",
+    );
+    const clientHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight",
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get: () => 48,
+    });
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get: () => 24,
+    });
+
+    try {
+      useHostNotificationsStore.getState().replaceFromSnapshot(
+        [
+          hostAgentEntry({
+            id: "completed",
+            kind: "agent.stopped",
+            severity: "done",
+            outcome: "completed",
+          }),
+        ],
+        50,
+      );
+
+      const captured: TargetCapture = {
+        epicId: null,
+        tabId: null,
+        focusArtifactId: null,
+        focusThreadId: null,
+      };
+      const onNavigate = vi.fn();
+      const { router } = buildRouterWithCapture(captured, onNavigate);
+      renderRouter(router);
+
+      const completed = await screen.findByTestId("notification-entry");
+      const notificationTitle =
+        within(completed).getByTestId("notification-title");
+      const notificationBody =
+        within(completed).getByTestId("notification-body");
+      expect(notificationTitle.className).toContain("line-clamp-2");
+      expect(notificationTitle.className).toContain("font-semibold");
+      expect(notificationBody.className).toContain("line-clamp-2");
+      expect(notificationBody.className).not.toContain("truncate");
+
+      const expand = within(completed).getByRole("button", {
+        name: "Show more",
+      });
+      expect(expand.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(expand);
+      expect(onNavigate).not.toHaveBeenCalled();
+
+      expect(notificationTitle.className).not.toContain("line-clamp-2");
+      expect(notificationBody.className).not.toContain("line-clamp-2");
+      const collapse = within(completed).getByRole("button", {
+        name: "Show less",
+      });
+      expect(collapse.getAttribute("aria-expanded")).toBe("true");
+
+      fireEvent.click(collapse);
+      expect(notificationTitle.className).toContain("line-clamp-2");
+      expect(notificationBody.className).toContain("line-clamp-2");
+    } finally {
+      if (scrollHeight === undefined) {
+        Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
+      } else {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollHeight",
+          scrollHeight,
+        );
+      }
+      if (clientHeight === undefined) {
+        Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
+      } else {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "clientHeight",
+          clientHeight,
+        );
+      }
+    }
+  });
+
+  it("omits the expansion control when notification text fits", async () => {
+    useHostNotificationsStore.getState().replaceFromSnapshot(
+      [
+        hostAgentEntry({
+          id: "completed",
+          kind: "agent.stopped",
+          severity: "done",
+          outcome: "completed",
+        }),
+      ],
+      50,
+    );
+
+    const captured: TargetCapture = {
+      epicId: null,
+      tabId: null,
+      focusArtifactId: null,
+      focusThreadId: null,
+    };
+    const { router } = buildRouterWithCapture(captured, () => undefined);
+    renderRouter(router);
+
+    await screen.findByTestId("notification-entry");
+    expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+  });
+
+  it("omits disclosure when the title and body fit within two lines", async () => {
+    const restoreDimensions = mockElementDimensions((element, dimension) => {
+      const isTitle = element.dataset.testid === "notification-title";
+      const isWidth =
+        dimension === "scrollWidth" || dimension === "clientWidth";
+      if (isWidth) {
+        return isTitle &&
+          dimension === "scrollWidth" &&
+          element.className.includes("truncate")
+          ? 240
+          : 200;
+      }
+      return isTitle ? 40 : 20;
+    });
+
+    try {
+      useHostNotificationsStore.getState().replaceFromSnapshot(
+        [
+          hostAgentEntry({
+            id: "completed",
+            kind: "agent.stopped",
+            severity: "done",
+            outcome: "completed",
+          }),
+        ],
+        50,
+      );
+
+      const captured: TargetCapture = {
+        epicId: null,
+        tabId: null,
+        focusArtifactId: null,
+        focusThreadId: null,
+      };
+      const { router } = buildRouterWithCapture(captured, () => undefined);
+      renderRouter(router);
+
+      await screen.findByTestId("notification-entry");
+      expect(screen.queryByRole("button", { name: "Show more" })).toBeNull();
+    } finally {
+      restoreDimensions();
+    }
+  });
+
+  it("shows disclosure consistently for overflowing read and unread rows", async () => {
+    const restoreDimensions = mockElementDimensions((element, dimension) => {
+      if (dimension === "scrollWidth" || dimension === "clientWidth")
+        return 200;
+      const isBody = element.dataset.testid === "notification-body";
+      if (isBody && dimension === "scrollHeight") return 60;
+      return isBody ? 40 : 20;
+    });
+
+    try {
+      const readEntry = {
+        ...hostAgentEntry({
+          id: "read",
+          kind: "agent.stopped",
+          severity: "done",
+          outcome: "completed",
+        }),
+        readAt: 10,
+      };
+      useHostNotificationsStore.getState().replaceFromSnapshot(
+        [
+          hostAgentEntry({
+            id: "unread",
+            kind: "agent.stopped",
+            severity: "done",
+            outcome: "completed",
+          }),
+          readEntry,
+        ],
+        50,
+      );
+
+      const captured: TargetCapture = {
+        epicId: null,
+        tabId: null,
+        focusArtifactId: null,
+        focusThreadId: null,
+      };
+      const { router } = buildRouterWithCapture(captured, () => undefined);
+      renderRouter(router);
+      await screen.findByTestId("notifications-tab-all");
+      await selectTab("notifications-tab-all");
+
+      const allContent = await screen.findByTestId(
+        "notifications-tab-content-all",
+      );
+      await waitFor(() => {
+        expect(
+          within(allContent).getAllByRole("button", { name: "Show more" }),
+        ).toHaveLength(2);
+      });
+    } finally {
+      restoreDimensions();
+    }
   });
 
   it("keeps the Unread tab visible when every notification is read", async () => {

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -515,22 +515,9 @@ describe("NotificationsPopover click routing", () => {
   });
 
   it("expands overflowing notification text inline", async () => {
-    const scrollHeight = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      "scrollHeight",
+    const restoreDimensions = mockElementDimensions((_element, dimension) =>
+      dimension === "scrollHeight" ? 48 : 24,
     );
-    const clientHeight = Object.getOwnPropertyDescriptor(
-      HTMLElement.prototype,
-      "clientHeight",
-    );
-    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
-      configurable: true,
-      get: () => 48,
-    });
-    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
-      configurable: true,
-      get: () => 24,
-    });
 
     try {
       useHostNotificationsStore.getState().replaceFromSnapshot(
@@ -584,24 +571,7 @@ describe("NotificationsPopover click routing", () => {
       expect(notificationTitle.className).toContain("line-clamp-2");
       expect(notificationBody.className).toContain("line-clamp-2");
     } finally {
-      if (scrollHeight === undefined) {
-        Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
-      } else {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          "scrollHeight",
-          scrollHeight,
-        );
-      }
-      if (clientHeight === undefined) {
-        Reflect.deleteProperty(HTMLElement.prototype, "clientHeight");
-      } else {
-        Object.defineProperty(
-          HTMLElement.prototype,
-          "clientHeight",
-          clientHeight,
-        );
-      }
+      restoreDimensions();
     }
   });
 

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -351,6 +351,7 @@ function useNotificationTextOverflow(
   const [isOverflowing, setIsOverflowing] = useState(false);
   const title = row === null ? null : row.title;
   const body = row === null ? null : row.body;
+  const readAt = row === null ? null : row.readAt;
 
   useLayoutEffect(() => {
     if (isExpanded) return;
@@ -371,7 +372,7 @@ function useNotificationTextOverflow(
     observer.observe(bodyElement);
     check();
     return () => observer.disconnect();
-  }, [body, isExpanded, title]);
+  }, [body, isExpanded, readAt, title]);
 
   return { bodyRef, isOverflowing, titleRef };
 }
@@ -483,8 +484,8 @@ function NotificationRow(props: NotificationRowProps) {
             ref={bodyRef}
             data-testid="notification-body"
             className={cn(
-              "text-ui-sm leading-snug",
-              isExpanded ? "whitespace-pre-wrap break-words" : "line-clamp-2",
+              "break-words text-ui-sm leading-snug",
+              isExpanded ? "whitespace-pre-wrap" : "line-clamp-2",
               isRead ? "text-muted-foreground/80" : "text-foreground/80",
             )}
           >

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -1,10 +1,12 @@
-import { useCallback, useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import {
   Bell,
   BellOff,
   Check,
   CheckCheck,
   CheckCircle2,
+  ChevronDown,
+  ChevronUp,
   CircleAlert,
   MessageCircle,
   MessageSquarePlus,
@@ -48,8 +50,8 @@ type NotificationsTab = "unread" | "all";
  * Notifications list surface. Rendered inside the bell's popover.
  *
  * Layout: header with unread count, unread/all tabs, and bulk actions. Every
- * row is a single button (navigation), with a sibling hover-revealed
- * "mark as read" affordance - no nested buttons.
+ * row has a primary navigation button, with sibling disclosure and
+ * hover-revealed "mark as read" affordances - no nested buttons.
  *
  * Click-to-navigate: clicking a notification activates it through the same
  * preflight path that `NotificationFocusBridge` uses for OS-toast clicks.
@@ -340,9 +342,81 @@ interface NotificationRowProps {
   readonly onMarkRead: (id: string) => void;
 }
 
+function useNotificationTextOverflow(
+  row: MergedNotificationRow | null,
+  isExpanded: boolean,
+) {
+  const titleRef = useRef<HTMLSpanElement | null>(null);
+  const bodyRef = useRef<HTMLSpanElement | null>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const title = row === null ? null : row.title;
+  const body = row === null ? null : row.body;
+
+  useLayoutEffect(() => {
+    if (isExpanded) return;
+    const titleElement = titleRef.current;
+    const bodyElement = bodyRef.current;
+    if (titleElement === null || bodyElement === null) return;
+
+    const check = (): void => {
+      const titleIsOverflowing =
+        titleElement.scrollHeight - titleElement.clientHeight > 1;
+      const bodyIsOverflowing =
+        bodyElement.scrollHeight - bodyElement.clientHeight > 1;
+      const next = titleIsOverflowing || bodyIsOverflowing;
+      setIsOverflowing((current) => (current === next ? current : next));
+    };
+    const observer = new ResizeObserver(check);
+    observer.observe(titleElement);
+    observer.observe(bodyElement);
+    check();
+    return () => observer.disconnect();
+  }, [body, isExpanded, title]);
+
+  return { bodyRef, isOverflowing, titleRef };
+}
+
+interface NotificationExpansionControlProps {
+  readonly isExpanded: boolean;
+  readonly onToggle: () => void;
+}
+
+function NotificationExpansionControl(
+  props: NotificationExpansionControlProps,
+) {
+  return (
+    <div className="flex justify-end px-3 pb-2">
+      <Button
+        type="button"
+        variant="ghost"
+        size="xs"
+        aria-expanded={props.isExpanded}
+        onClick={(event) => {
+          event.stopPropagation();
+          props.onToggle();
+        }}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        {props.isExpanded ? (
+          <ChevronUp className="size-3" aria-hidden />
+        ) : (
+          <ChevronDown className="size-3" aria-hidden />
+        )}
+        {props.isExpanded ? "Show less" : "Show more"}
+      </Button>
+    </div>
+  );
+}
+
 function NotificationRow(props: NotificationRowProps) {
   const { feedId, filter, onActivate, onMarkRead } = props;
   const row = useMergedNotificationRow(feedId);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { bodyRef, isOverflowing, titleRef } = useNotificationTextOverflow(
+    row,
+    isExpanded,
+  );
+
   if (row === null) return null;
   const isRead = row.readAt !== null;
   if (filter === "unread" && isRead) return null;
@@ -376,6 +450,7 @@ function NotificationRow(props: NotificationRowProps) {
         className={cn(
           "flex w-full items-start gap-3 rounded-2xl px-3 py-3 text-left transition-colors",
           "hover:bg-accent/70 focus-visible:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+          isOverflowing && "pb-1",
         )}
       >
         <span
@@ -389,28 +464,27 @@ function NotificationRow(props: NotificationRowProps) {
         </span>
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
           <div className="flex min-w-0 items-baseline gap-2">
-            <TooltipWrapper
-              label={row.title}
-              side="bottom"
-              sideOffset={6}
-              align="start"
+            <span
+              ref={titleRef}
+              data-testid="notification-title"
+              className={cn(
+                "min-w-0 flex-1 text-ui-sm font-semibold leading-snug",
+                isExpanded
+                  ? "whitespace-pre-wrap break-words"
+                  : "line-clamp-2 break-words",
+                isRead ? "text-muted-foreground" : "text-foreground",
+              )}
             >
-              <span
-                data-testid="notification-title"
-                className={cn(
-                  "min-w-0 flex-1 truncate text-ui-sm font-semibold leading-snug",
-                  isRead ? "text-muted-foreground" : "text-foreground",
-                )}
-              >
-                {row.title}
-              </span>
-            </TooltipWrapper>
+              {row.title}
+            </span>
             <NotificationTimestamp createdAt={row.createdAt} />
           </div>
           <span
+            ref={bodyRef}
             data-testid="notification-body"
             className={cn(
-              "truncate text-ui-sm leading-snug",
+              "text-ui-sm leading-snug",
+              isExpanded ? "whitespace-pre-wrap break-words" : "line-clamp-2",
               isRead ? "text-muted-foreground/80" : "text-foreground/80",
             )}
           >
@@ -418,6 +492,12 @@ function NotificationRow(props: NotificationRowProps) {
           </span>
         </div>
       </button>
+      {isOverflowing ? (
+        <NotificationExpansionControl
+          isExpanded={isExpanded}
+          onToggle={() => setIsExpanded((current) => !current)}
+        />
+      ) : null}
       {!isRead && (
         <TooltipWrapper
           label="Mark as read"


### PR DESCRIPTION
## Summary
- show notification titles and bodies in a two-line preview
- add inline Show more / Show less only when either preview is vertically clamped
- apply the same behavior to read and unread rows

## Validation
- bun run test -- src/components/notifications
- bun run compile
- eslint and Prettier on changed files