### PR TITLE
fix(gui-app): prevent diff loading error flicker

### DIFF
--- a/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-with-submodules.test.tsx
+++ b/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-with-submodules.test.tsx
@@ -8,7 +8,11 @@ import {
   type Mock,
 } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  CancelledError,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import type { SchemaVersion } from "@traycer/protocol/framework/versioned-stream-rpc";
 import React from "react";
@@ -379,6 +383,52 @@ describe("useGitListChangedFilesWithSubmodules", () => {
     await waitFor(() =>
       expect(result.current.data?.fingerprint).toBe("fallback-value"),
     );
+  });
+
+  it("keeps an initial fallback cancellation in the loading state until the stream fills the slot", async () => {
+    const request = clientForHost("h").request;
+    request.mockImplementationOnce(() => new Promise(() => undefined));
+    const streamClient = streamState.client;
+    if (streamClient === null) throw new Error("Stream client missing");
+    const richKey = gitQueryKeys.listChangedFilesWithSubmodules(
+      "h",
+      "/repo",
+      false,
+    );
+
+    const { result } = renderHook(
+      () =>
+        useGitListChangedFilesWithSubmodules({
+          hostId: "h",
+          runningDir: "/repo",
+          ignoreWhitespace: false,
+          enabled: true,
+          changeToken: null,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    streamClient.version = { major: 1, minor: 1 };
+    streamClient.notifySupportChanged();
+
+    await waitFor(() =>
+      expect(queryClient.getQueryState(richKey)?.error).toBeInstanceOf(
+        CancelledError,
+      ),
+    );
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.isPending).toBe(true);
+
+    queryClient.setQueryData(richKey, snapshot("stream-value"));
+
+    await waitFor(() =>
+      expect(result.current.data?.fingerprint).toBe("stream-value"),
+    );
+    expect(result.current.error).toBeNull();
+    expect(result.current.isPending).toBe(false);
   });
 
   it("forces a unary refetch when fallback mounts over a stream-owned rich cache", async () => {

--- a/clients/gui-app/src/hooks/git/use-git-list-changed-files-with-submodules.ts
+++ b/clients/gui-app/src/hooks/git/use-git-list-changed-files-with-submodules.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import {
+  CancelledError,
   queryOptions,
   useQuery,
   useQueryClient,
@@ -386,6 +387,14 @@ export function useGitListChangedFilesWithSubmodules(args: {
     lastTokenRef,
   });
 
+  // TanStack's non-reverting cancellation publishes its internal
+  // `CancelledError` into the query state. That cancellation is expected
+  // control flow during the fallback -> stream ownership handoff, not a host
+  // failure: the first rich stream frame will fill this same slot. Keep the
+  // public result inside its `HostRpcError | null` contract and let consumers
+  // render their loading state while that frame is still in flight.
+  const error = query.error instanceof CancelledError ? null : query.error;
+
   // Refetch when the parent subscription reports a change (FALLBACK state
   // only - `enabled` is false under stream ownership). The ref stores the
   // full source identity alongside the token so a host/worktree/whitespace
@@ -439,9 +448,9 @@ export function useGitListChangedFilesWithSubmodules(args: {
       hostId,
       runningDir,
       hasData: query.data !== undefined,
-      hasError: query.error !== null,
+      hasError: error !== null,
     }),
-    error: query.error ?? null,
+    error,
   };
 }
 


### PR DESCRIPTION
## Summary

- treat TanStack Query cancellation during the unary-to-stream Git snapshot handoff as pending control flow
- keep genuine host failures in the Git diff error channel
- add regression coverage for the refresh-time cancellation sequence

## Related issue

None.

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
- [x] React Doctor reports no issues