### PR TITLE
fix(gui-app): validate pasted image hashes and add unavailable-image state, edit-composer attach support

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
@@ -1,5 +1,6 @@
 import "../../../../__tests__/test-browser-apis";
 import {
+  act,
   cleanup,
   fireEvent,
   render as rtlRender,
@@ -8,13 +9,17 @@ import {
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import { ChatExpansionTestProviders } from "@/components/chat/__tests__/chat-expansion-test-providers";
 import { deriveA2AReceivedCollapsibleKey } from "@/components/chat/chat-collapsible-key";
 import { UserMessageBody } from "@/components/chat/chat-message-user-body";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { parseComposerClipboardHtml } from "@/lib/composer/composer-clipboard";
+import {
+  buildComposerClipboardHtml,
+  composerClipboardPlainText,
+  parseComposerClipboardHtml,
+} from "@/lib/composer/composer-clipboard";
 import type { ChatMessage as ChatMessageModel } from "@/stores/composer/chat-store";
 import type { ChatMessageUserActions } from "@/components/chat/chat-message";
 import { useSetA2AReceivedOpen } from "@/stores/chats/a2a-open-store-context";
@@ -22,6 +27,14 @@ import {
   useChatCollapsibleTileInstanceId,
   useSetChatFindForcedOpen,
 } from "@/stores/chats/chat-find-force-store-context";
+import { collectImageAtoms } from "@/lib/composer/image-atoms";
+
+const attachmentMocks = vi.hoisted(() => ({
+  fetcher: vi.fn((_hash: string, _signal: AbortSignal) =>
+    Promise.resolve(new Uint8Array([1, 2, 3])),
+  ),
+  hasBytes: vi.fn(() => true),
+}));
 
 function render(ui: ReactNode) {
   return rtlRender(
@@ -51,6 +64,18 @@ vi.mock("@/hooks/host/use-tab-host-client", () => ({
 vi.mock("@/components/chat/composer/picker/use-composer-picker-items", () => ({
   useComposerPickerItems: () => undefined,
 }));
+
+vi.mock(
+  import("@/lib/attachments/use-attachment-blob-src"),
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      ...actual,
+      useEpicImageFetcher: () => attachmentMocks.fetcher,
+      useEpicAttachmentBytesPresence: () => attachmentMocks.hasBytes,
+    };
+  },
+);
 
 interface OpenReceivedA2AButtonProps {
   readonly label: string;
@@ -156,6 +181,13 @@ const STRUCTURED_IMAGE_USER_CONTENT: JsonContent = {
 describe("<UserMessageBody /> agent messages", () => {
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
+    attachmentMocks.fetcher.mockReset();
+    attachmentMocks.fetcher.mockImplementation((_hash, _signal) =>
+      Promise.resolve(new Uint8Array([1, 2, 3])),
+    );
+    attachmentMocks.hasBytes.mockReset();
+    attachmentMocks.hasBytes.mockReturnValue(true);
   });
 
   it("reveals the action chip for keyboard focus", () => {
@@ -312,6 +344,186 @@ describe("<UserMessageBody /> agent messages", () => {
     ).not.toBeNull();
     expect(screen.getByLabelText("Open Image#1: first.png")).not.toBeNull();
     expect(screen.getByLabelText("Open Image#2: second.png")).not.toBeNull();
+  });
+
+  it("adds multiple pasted images to the edit strip and submits base64 nodes", async () => {
+    const onSubmit = vi.fn<(content: JsonContent) => void>();
+    render(<InlineEditAttachmentHarness onSubmit={onSubmit} />);
+    const editor = await screen.findByRole("textbox", { name: "Edit message" });
+    const first = imageFile("first-paste.png", [1, 2, 3]);
+    const second = imageFile("second-paste.png", [4, 5, 6]);
+
+    fireEvent.paste(editor, {
+      clipboardData: clipboardWithFiles([first, second]),
+    });
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Open Image#1: first-paste.png",
+      }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "Open Image#2: second-paste.png",
+      }),
+    ).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Remove Image#2: second-paste.png",
+      }),
+    );
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", {
+          name: "Open Image#2: second-paste.png",
+        }),
+      ).toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Send edit" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0];
+    const images = collectImageAtoms(submitted);
+    expect(images.map((image) => image.fileName)).toEqual(["first-paste.png"]);
+    expect(images.every((image) => image.b64content !== null)).toBe(true);
+    expect(images.every((image) => image.hash === null)).toBe(true);
+  });
+
+  it("blocks edit submission until a pasted image finishes reading", async () => {
+    const delayedReader = installDelayedFileReader();
+    const onSubmit = vi.fn<(content: JsonContent) => void>();
+    render(<InlineEditAttachmentHarness onSubmit={onSubmit} />);
+    const editor = await screen.findByRole("textbox", { name: "Edit message" });
+
+    fireEvent.paste(editor, {
+      clipboardData: clipboardWithFiles([
+        imageFile("delayed.png", [16, 17, 18]),
+      ]),
+    });
+
+    const send = screen.getByRole("button", {
+      name: "Preparing attachments",
+    });
+    expect(send.getAttribute("disabled")).not.toBeNull();
+    fireEvent.click(send);
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    delayedReader.resolveNext("data:image/png;base64,EBES");
+    await screen.findByRole("button", {
+      name: "Open Image#1: delayed.png",
+    });
+    const readySend = screen.getByRole("button", { name: "Send edit" });
+    expect(readySend.getAttribute("disabled")).toBeNull();
+    fireEvent.click(readySend);
+
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(collectImageAtoms(submitted)).toEqual([
+      expect.objectContaining({
+        fileName: "delayed.png",
+        b64content: "EBES",
+        hash: null,
+      }),
+    ]);
+  });
+
+  it("submits a synchronously validated rich paste immediately", async () => {
+    const onSubmit = vi.fn<(content: JsonContent) => void>();
+    render(<InlineEditAttachmentHarness onSubmit={onSubmit} />);
+    const editor = await screen.findByRole("textbox", { name: "Edit message" });
+    const content = hashOnlyInlineEditContent();
+    const html = buildComposerClipboardHtml(
+      content,
+      composerClipboardPlainText(content),
+    );
+
+    fireEvent.paste(editor, {
+      clipboardData: {
+        files: [],
+        items: [],
+        types: ["text/html"],
+        getData: (type: string) => (type === "text/html" ? html : ""),
+      },
+    });
+
+    expect(attachmentMocks.hasBytes).toHaveBeenCalledWith("same-epic-hash");
+    const readySend = screen.getByRole("button", { name: "Send edit" });
+    expect(readySend.getAttribute("disabled")).toBeNull();
+    fireEvent.click(readySend);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(collectImageAtoms(onSubmit.mock.calls[0][0])).toEqual([
+      expect.objectContaining({
+        id: "rich-paste",
+        hash: "same-epic-hash",
+        b64content: null,
+      }),
+    ]);
+  });
+
+  it("adds a dropped image to the inline edit attachment strip", async () => {
+    render(<InlineEditAttachmentHarness onSubmit={() => undefined} />);
+    const editor = await screen.findByRole("textbox", { name: "Edit message" });
+    const dropped = imageFile("dropped.png", [7, 8, 9]);
+
+    fireEvent.drop(editor, {
+      dataTransfer: dataTransferWithFiles([dropped]),
+    });
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Open Image#1: dropped.png",
+      }),
+    ).not.toBeNull();
+  });
+
+  it("opens the image picker and attaches its selected file", async () => {
+    const inputClick = vi
+      .spyOn(HTMLInputElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const view = render(
+      <InlineEditAttachmentHarness onSubmit={() => undefined} />,
+    );
+    await screen.findByRole("textbox", { name: "Edit message" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Attach image" }));
+    expect(inputClick).toHaveBeenCalledTimes(1);
+
+    const input =
+      view.container.querySelector<HTMLInputElement>('input[type="file"]');
+    if (input === null) throw new Error("expected inline edit image input");
+    fireEvent.change(input, {
+      target: { files: [imageFile("picked.png", [10, 11, 12])] },
+    });
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Open Image#1: picked.png",
+      }),
+    ).not.toBeNull();
+  });
+
+  it("discards an image read that resolves after edit cancellation", async () => {
+    const delayedReader = installDelayedFileReader();
+    render(<InlineEditAttachmentHarness onSubmit={() => undefined} />);
+    const editor = await screen.findByRole("textbox", { name: "Edit message" });
+
+    fireEvent.paste(editor, {
+      clipboardData: clipboardWithFiles([
+        imageFile("discarded.png", [13, 14, 15]),
+      ]),
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reopen edit" }));
+    await screen.findByRole("textbox", { name: "Edit message" });
+
+    delayedReader.resolveNext("data:image/png;base64,DQ4P");
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    expect(screen.queryByRole("button", { name: /Open Image#/ })).toBeNull();
   });
 
   it("renders received agent messages as an expandable A2A card", () => {
@@ -516,6 +728,141 @@ function editingUserActions(content: JsonContent): ChatMessageUserActions {
     onDeleteRequest: () => undefined,
     onDeleteConfirm: () => undefined,
     onDeleteCancel: () => undefined,
+  };
+}
+
+const INLINE_EDIT_INITIAL_CONTENT: JsonContent = {
+  type: "doc",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Edit this message" }],
+    },
+  ],
+};
+
+function hashOnlyInlineEditContent(): JsonContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "imageAttachment",
+            attrs: {
+              id: "rich-paste",
+              fileName: "rich-paste.png",
+              b64content: null,
+              hash: "same-epic-hash",
+              mimeType: "image/png",
+              size: 3,
+            },
+          },
+          { type: "text", text: " pasted" },
+        ],
+      },
+    ],
+  };
+}
+
+function InlineEditAttachmentHarness(props: {
+  readonly onSubmit: (content: JsonContent) => void;
+}): ReactNode {
+  const [editing, setEditing] = useState(true);
+  const [content, setContent] = useState(INLINE_EDIT_INITIAL_CONTENT);
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setContent(INLINE_EDIT_INITIAL_CONTENT);
+          setEditing(true);
+        }}
+      >
+        Reopen edit
+      </button>
+    );
+  }
+  const actions = editingUserActions(INLINE_EDIT_INITIAL_CONTENT);
+  const baseEditing = actions.editing;
+  if (baseEditing === null) throw new Error("expected editing actions");
+  return (
+    <TooltipProvider>
+      <UserMessageBody
+        message={{
+          ...plainUserMessage("Edit this message"),
+          structuredContent: INLINE_EDIT_INITIAL_CONTENT,
+        }}
+        actions={{
+          ...actions,
+          editing: {
+            ...baseEditing,
+            initialContent: INLINE_EDIT_INITIAL_CONTENT,
+            currentContent: content,
+            canSubmit: true,
+            onSnapshot: (nextContent) => setContent(nextContent),
+            onSubmit: () => props.onSubmit(content),
+            onCancel: () => {
+              setContent(INLINE_EDIT_INITIAL_CONTENT);
+              setEditing(false);
+            },
+          },
+        }}
+      />
+    </TooltipProvider>
+  );
+}
+
+function imageFile(name: string, bytes: ReadonlyArray<number>): File {
+  return new File([new Uint8Array(bytes)], name, { type: "image/png" });
+}
+
+function clipboardWithFiles(files: ReadonlyArray<File>) {
+  return {
+    files,
+    items: files.map((file) => ({
+      kind: "file",
+      type: file.type,
+      getAsFile: () => file,
+    })),
+    types: ["Files"],
+    getData: () => "",
+  };
+}
+
+function dataTransferWithFiles(files: ReadonlyArray<File>) {
+  return {
+    files,
+    items: [],
+    types: ["Files"],
+    dropEffect: "none",
+    getData: () => "",
+  };
+}
+
+interface DelayedFileReaderControl {
+  readonly resolveNext: (dataUrl: string) => void;
+}
+
+function installDelayedFileReader(): DelayedFileReaderControl {
+  const pending: FileReader[] = [];
+  vi.spyOn(FileReader.prototype, "readAsDataURL").mockImplementation(function (
+    this: FileReader,
+    _blob: Blob,
+  ) {
+    pending.push(this);
+  });
+  return {
+    resolveNext: (dataUrl) => {
+      const reader = pending.shift();
+      if (reader === undefined) throw new Error("expected pending file read");
+      Object.defineProperty(reader, "result", {
+        configurable: true,
+        value: dataUrl,
+      });
+      reader.dispatchEvent(new ProgressEvent("load"));
+    },
   };
 }
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-message-user-body.test.tsx
@@ -403,9 +403,7 @@ describe("<UserMessageBody /> agent messages", () => {
       ]),
     });
 
-    const send = screen.getByRole("button", {
-      name: "Preparing attachments",
-    });
+    const send = screen.getByRole("button", { name: "Send edit" });
     expect(send.getAttribute("disabled")).not.toBeNull();
     fireEvent.click(send);
     expect(onSubmit).not.toHaveBeenCalled();

--- a/clients/gui-app/src/components/chat/__tests__/user-message-attachment-gallery.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/user-message-attachment-gallery.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UserMessageAttachmentGallery } from "@/components/chat/user-message-attachment-gallery";
+import { useAttachmentBlobSrc } from "@/lib/attachments/use-attachment-blob-src";
+
+vi.mock("@/lib/attachments/use-attachment-blob-src", () => ({
+  useAttachmentBlobSrc: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("UserMessageAttachmentGallery", () => {
+  it("surfaces an unavailable image in both the thumbnail and dialog", async () => {
+    vi.mocked(useAttachmentBlobSrc).mockReturnValue({
+      status: "unavailable",
+      src: null,
+    });
+
+    const { container } = render(
+      <UserMessageAttachmentGallery
+        align="end"
+        attachments={[
+          {
+            kind: "image",
+            hash: "missing-hash",
+            mediaType: "image/png",
+            dataUrl: null,
+            name: "missing.png",
+            size: 128,
+          },
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Open Image#1: missing.png (image unavailable)",
+    });
+    expect(
+      trigger.querySelector("[data-user-message-image-unavailable]"),
+    ).not.toBeNull();
+    expect(container.querySelector(".animate-pulse")).toBeNull();
+
+    fireEvent.click(trigger);
+
+    expect(await screen.findByText("Image unavailable")).not.toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -780,7 +780,7 @@ function InlineUserMessageEditor({
           Cancel
         </MessageActionButton>
         <MessageActionButton
-          label={attachmentPending ? "Preparing attachments" : "Send edit"}
+          label="Send edit"
           variant="default"
           size="default"
           tooltip

--- a/clients/gui-app/src/components/chat/chat-message-user-body.tsx
+++ b/clients/gui-app/src/components/chat/chat-message-user-body.tsx
@@ -3,6 +3,7 @@ import {
   ChevronDown,
   ChevronUp,
   Copy,
+  ImagePlus,
   Inbox,
   Pencil,
   SendHorizontal,
@@ -16,13 +17,10 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
   type ReactNode,
 } from "react";
-import type {
-  ClipboardEventHandler,
-  DragEventHandler,
-  KeyboardEvent,
-} from "react";
+import type { KeyboardEvent } from "react";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import {
   ComposerPromptEditor,
@@ -69,6 +67,7 @@ import { ChatUserMessageContent } from "./chat-user-message-content";
 import { UserMessageAttachmentGallery } from "./user-message-attachment-gallery";
 import { ComposerArea } from "@/components/home/composer/composer-shell";
 import { LivePulse } from "@/components/ui/live-pulse";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { AgentReferenceMarkdown } from "./segments/agent-reference-markdown";
 import { SegmentCard } from "./segments/segment-card";
 import { SegmentPanel } from "./segments/segment-panel";
@@ -77,10 +76,10 @@ import { AccentDot } from "@/components/providers/accent-dot";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
 import type { ProviderId } from "@/components/home/data/landing-options";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
+import { useComposerPaste } from "@/hooks/composer/use-composer-paste";
+import { useEpicAttachmentBytesPresence } from "@/lib/attachments/use-attachment-blob-src";
 
 const NOOP: () => void = () => undefined;
-const NOOP_CLIPBOARD: ClipboardEventHandler<HTMLElement> = () => undefined;
-const NOOP_DRAG: DragEventHandler<HTMLElement> = () => undefined;
 
 // Keep long prompts compact: ~3-4 lines (leading-7 ≈ 28px/line) stay visible
 // before the bubble clamps and fades, with "Show more" revealing the rest.
@@ -592,9 +591,14 @@ function InlineUserMessageEditor({
   const [pickerStore] = useState(() => createComposerPickerStore());
   const hostClient = useTabHostClient();
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null);
+  const hasPastedImageBytes = useEpicAttachmentBytesPresence();
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const focusFrameRef = useRef<number | null>(null);
   const visibilityFrameRef = useRef<number | null>(null);
+  const { onPaste, onDrop, onDragOver, attachImageFiles, isIngestingImages } =
+    useComposerPaste(editorRef);
+  const attachmentPending = isIngestingImages;
 
   // Without this, the picker opens empty - nothing writes items into the store.
   useComposerPickerItems({
@@ -608,9 +612,11 @@ function InlineUserMessageEditor({
   });
 
   const submit = useCallback(() => {
-    if (!editing.canSubmit || editing.pending) return;
+    if (!editing.canSubmit || editing.pending || attachmentPending) {
+      return;
+    }
     editing.onSubmit();
-  }, [editing]);
+  }, [attachmentPending, editing]);
 
   const cancel = useCallback(() => {
     if (editing.pending) return;
@@ -620,6 +626,22 @@ function InlineUserMessageEditor({
   const removeImageAttachment = useCallback((id: string) => {
     editorRef.current?.removeImageAttachmentById(id);
   }, []);
+
+  const openImagePicker = useCallback(() => {
+    const input = imageInputRef.current;
+    if (input === null) return;
+    input.value = "";
+    input.click();
+  }, []);
+
+  const handleImageChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.currentTarget.files ?? []);
+      event.currentTarget.value = "";
+      attachImageFiles(files);
+    },
+    [attachImageFiles],
+  );
 
   const onSnapshot = useCallback(
     (content: JsonContent, selection: { from: number; to: number }) => {
@@ -679,6 +701,7 @@ function InlineUserMessageEditor({
         initialContent={editing.initialContent}
         initialSelection={null}
         slashProviderId={editing.slashProviderId}
+        hasPastedImageBytes={hasPastedImageBytes}
         isActive
         disabled={editing.pending}
         placeholder="Edit message"
@@ -686,16 +709,26 @@ function InlineUserMessageEditor({
         stabilizeImageAttachmentCaret={false}
         onSnapshot={onSnapshot}
         onSubmit={submit}
-        onPaste={NOOP_CLIPBOARD}
-        onDragOver={NOOP_DRAG}
-        onDrop={NOOP_DRAG}
+        onPaste={onPaste}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
         onKeyDown={handleEditorKeyDown}
         onFocus={NOOP}
         onBlur={NOOP}
         onEditorReady={null}
       />
     ),
-    [editing, handleEditorKeyDown, onSnapshot, pickerStore, submit],
+    [
+      editing,
+      handleEditorKeyDown,
+      onDragOver,
+      onDrop,
+      onPaste,
+      onSnapshot,
+      pickerStore,
+      hasPastedImageBytes,
+      submit,
+    ],
   );
   const editorSlot = useMemo(
     () => (
@@ -713,7 +746,28 @@ function InlineUserMessageEditor({
   );
   const toolbar = useMemo(
     () => (
-      <div className="flex justify-end gap-1 px-4 pb-3 pt-2">
+      <div className="flex items-center gap-1 px-4 pb-3 pt-2">
+        <input
+          ref={imageInputRef}
+          type="file"
+          accept="image/*"
+          multiple
+          tabIndex={-1}
+          aria-hidden="true"
+          className="hidden"
+          onChange={handleImageChange}
+        />
+        <MessageActionButton
+          label="Attach image"
+          variant="ghost"
+          size="icon-sm"
+          tooltip
+          disabled={editing.pending}
+          className="mr-auto text-muted-foreground hover:text-foreground"
+          onClick={openImagePicker}
+        >
+          <ImagePlus className="size-4" aria-hidden />
+        </MessageActionButton>
         <MessageActionButton
           label="Cancel edit"
           variant="secondary"
@@ -726,19 +780,34 @@ function InlineUserMessageEditor({
           Cancel
         </MessageActionButton>
         <MessageActionButton
-          label="Send edit"
+          label={attachmentPending ? "Preparing attachments" : "Send edit"}
           variant="default"
           size="default"
           tooltip
-          disabled={!editing.canSubmit || editing.pending}
+          disabled={!editing.canSubmit || editing.pending || attachmentPending}
           className={undefined}
           onClick={submit}
         >
+          {attachmentPending ? (
+            <AgentSpinningDots
+              className="text-current"
+              testId="edit-attachment-pending"
+              variant={undefined}
+            />
+          ) : null}
           Send
         </MessageActionButton>
       </div>
     ),
-    [cancel, editing.canSubmit, editing.pending, submit],
+    [
+      cancel,
+      editing.canSubmit,
+      editing.pending,
+      handleImageChange,
+      openImagePicker,
+      attachmentPending,
+      submit,
+    ],
   );
 
   return (

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-image-attachment-flow.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-image-attachment-flow.test.tsx
@@ -194,6 +194,7 @@ function makeEditor(): Editor {
       placeholder: "test",
       onSubmit: { current: () => undefined },
       slashProviderId: "claude",
+      getHasPastedImageBytes: () => null,
     }),
     content: { type: "doc", content: [{ type: "paragraph" }] },
   });

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-list-input.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-list-input.test.tsx
@@ -28,6 +28,7 @@ function makeFixture(): {
         },
       },
       slashProviderId: "claude",
+      getHasPastedImageBytes: () => null,
     }),
     content: { type: "doc", content: [{ type: "paragraph" }] },
   });

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-mention-flow.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-mention-flow.test.tsx
@@ -36,6 +36,7 @@ function makeFixture(): {
       placeholder: "test",
       onSubmit: submitHolder,
       slashProviderId: "claude",
+      getHasPastedImageBytes: () => null,
     }),
     content: { type: "doc", content: [{ type: "paragraph" }] },
   });

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-paste-normalize.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-paste-normalize.test.tsx
@@ -28,6 +28,7 @@ function makeEditor(): Editor {
       placeholder: "t",
       onSubmit: { current: () => {} },
       slashProviderId: "claude",
+      getHasPastedImageBytes: () => null,
     }),
     content: { type: "doc", content: [{ type: "paragraph" }] },
   });

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-paste-presence-bridge.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-paste-presence-bridge.test.tsx
@@ -1,0 +1,166 @@
+import "../../../../../__tests__/test-browser-apis";
+import { createRef, useState, type RefObject } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+
+import {
+  buildComposerClipboardHtml,
+  composerClipboardPlainText,
+} from "@/lib/composer/composer-clipboard";
+import {
+  ComposerPromptEditor,
+  type ComposerPromptEditorHandle,
+} from "@/components/chat/composer/composer-prompt-editor";
+import { createComposerPickerStore } from "@/components/chat/composer/picker/composer-picker-store";
+
+const mocks = vi.hoisted(() => ({
+  reportableErrorToast: vi.fn(),
+}));
+
+vi.mock("@/lib/reportable-error-toast", () => ({
+  reportableErrorToast: mocks.reportableErrorToast,
+}));
+
+afterEach(() => {
+  cleanup();
+  mocks.reportableErrorToast.mockClear();
+});
+
+describe("ComposerPromptEditor pasted-image presence bridge", () => {
+  it("uses the latest nullable presence predicate without rebuilding the editor", async () => {
+    const handleRef = createRef<ComposerPromptEditorHandle>();
+    const checker = (hash: string): boolean => hash.startsWith("present-");
+    const view = render(
+      <BridgeHarness handleRef={handleRef} hasPastedImageBytes={null} />,
+    );
+    const editor = await screen.findByRole("textbox", { name: "test" });
+
+    pasteHashImage(editor, "early-image", "early-hash");
+    expect(imageIds(handleRef)).toEqual(["early-image"]);
+    expect(mocks.reportableErrorToast).not.toHaveBeenCalled();
+
+    view.rerender(
+      <BridgeHarness handleRef={handleRef} hasPastedImageBytes={checker} />,
+    );
+    pasteHashImage(editor, "missing-image", "missing-hash");
+    pasteHashImage(editor, "present-image", "present-hash");
+    expect(imageIds(handleRef)).toEqual(["early-image", "present-image"]);
+    expect(mocks.reportableErrorToast).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <BridgeHarness handleRef={handleRef} hasPastedImageBytes={null} />,
+    );
+    pasteHashImage(editor, "reset-image", "reset-hash");
+    expect(imageIds(handleRef)).toEqual([
+      "early-image",
+      "present-image",
+      "reset-image",
+    ]);
+    expect(mocks.reportableErrorToast).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <BridgeHarness handleRef={handleRef} hasPastedImageBytes={checker} />,
+    );
+    pasteHashImage(editor, "missing-image-2", "missing-hash-2");
+    pasteHashImage(editor, "present-image-2", "present-hash-2");
+    expect(imageIds(handleRef)).toEqual([
+      "early-image",
+      "present-image",
+      "reset-image",
+      "present-image-2",
+    ]);
+    expect(mocks.reportableErrorToast).toHaveBeenCalledTimes(2);
+  });
+});
+
+function BridgeHarness({
+  handleRef,
+  hasPastedImageBytes,
+}: {
+  readonly handleRef: RefObject<ComposerPromptEditorHandle | null>;
+  readonly hasPastedImageBytes: ((hash: string) => boolean) | null;
+}) {
+  const [pickerStore] = useState(() => createComposerPickerStore());
+  const setHandle = (handle: ComposerPromptEditorHandle | null): void => {
+    handleRef.current = handle;
+  };
+  return (
+    <ComposerPromptEditor
+      ref={setHandle}
+      initialContent={{ type: "doc", content: [{ type: "paragraph" }] }}
+      initialSelection={null}
+      pickerStore={pickerStore}
+      placeholder="test"
+      editorClassName={undefined}
+      isActive={false}
+      disabled={false}
+      slashProviderId="claude"
+      hasPastedImageBytes={hasPastedImageBytes}
+      stabilizeImageAttachmentCaret={false}
+      onSnapshot={() => undefined}
+      onSubmit={() => undefined}
+      onPaste={() => undefined}
+      onDragOver={() => undefined}
+      onDrop={() => undefined}
+      onKeyDown={undefined}
+      onFocus={() => undefined}
+      onBlur={() => undefined}
+      onEditorReady={null}
+    />
+  );
+}
+
+function pasteHashImage(element: HTMLElement, id: string, hash: string): void {
+  const content = hashImageContent(id, hash);
+  const html = buildComposerClipboardHtml(
+    content,
+    composerClipboardPlainText(content),
+  );
+  fireEvent.paste(element, {
+    clipboardData: {
+      files: [],
+      items: [],
+      types: ["text/html"],
+      getData: (type: string) => (type === "text/html" ? html : ""),
+    },
+  });
+}
+
+function hashImageContent(id: string, hash: string): JsonContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "imageAttachment",
+            attrs: {
+              id,
+              fileName: `${id}.png`,
+              b64content: null,
+              hash,
+              mimeType: "image/png",
+              size: 3,
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function imageIds(
+  handleRef: RefObject<ComposerPromptEditorHandle | null>,
+): string[] {
+  const ids: string[] = [];
+  handleRef.current?.getJSON().content?.forEach((block) => {
+    block.content?.forEach((node) => {
+      if (node.type !== "imageAttachment") return;
+      const id = node.attrs?.id;
+      if (typeof id === "string") ids.push(id);
+    });
+  });
+  return ids;
+}

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-quote-keymap.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-quote-keymap.test.tsx
@@ -28,6 +28,7 @@ function makeFixture(content: JsonContent): {
         },
       },
       slashProviderId: "claude",
+      getHasPastedImageBytes: () => null,
     }),
     content,
   });

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-render-isolation.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-render-isolation.test.tsx
@@ -54,6 +54,7 @@ function Harness({
         isActive={false}
         disabled={false}
         slashProviderId="claude"
+        hasPastedImageBytes={null}
         stabilizeImageAttachmentCaret={stabilizeImageAttachmentCaret}
         onSnapshot={() => undefined}
         onSubmit={() => undefined}

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
@@ -1,7 +1,8 @@
 import "../../../../../__tests__/test-browser-apis";
 import { fireEvent } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Editor } from "@tiptap/core";
+import { DOMSerializer } from "@tiptap/pm/model";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import {
@@ -12,6 +13,14 @@ import { insertImageAttachmentsCommand } from "@/hooks/composer/use-composer-pas
 
 import { buildComposerExtensions } from "../editor/editor-config";
 import { createComposerPickerStore } from "../picker/composer-picker-store";
+
+const mocks = vi.hoisted(() => ({
+  reportableErrorToast: vi.fn(),
+}));
+
+vi.mock("@/lib/reportable-error-toast", () => ({
+  reportableErrorToast: mocks.reportableErrorToast,
+}));
 
 const editors: Editor[] = [];
 
@@ -62,6 +71,8 @@ const STRUCTURED_CONTENT: JsonContent = {
 
 afterEach(() => {
   editors.splice(0).forEach((editor) => editor.destroy());
+  mocks.reportableErrorToast.mockClear();
+  vi.useRealTimers();
 });
 
 describe("composer rich clipboard paste", () => {
@@ -172,6 +183,149 @@ describe("composer rich clipboard paste", () => {
         },
       ],
     });
+  });
+
+  it("preserves a hash-only image when the destination has its bytes", () => {
+    const hasBytes = vi.fn((hash: string) => hash === "same-epic-hash");
+    const editor = makeEditorWithPastedImagePresence(
+      KNOWN_SLASH_NAMES,
+      hasBytes,
+      () => undefined,
+    );
+
+    pasteComposerContent(editor, hashOnlyImageContent("same-epic-hash"));
+
+    expect(hasBytes).toHaveBeenCalledWith("same-epic-hash");
+    expect(collectImageIds(editor)).toEqual(["pasted-image"]);
+    expect(editor.state.doc.textContent).toBe("describe it");
+    expect(mocks.reportableErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("strips an unresolved cross-context image synchronously", () => {
+    const hasBytes = vi.fn(() => false);
+    const editor = makeEditorWithPastedImagePresence(
+      KNOWN_SLASH_NAMES,
+      hasBytes,
+      () => undefined,
+    );
+
+    pasteComposerContent(editor, hashOnlyImageContent("other-epic-hash"));
+
+    expect(hasBytes).toHaveBeenCalledWith("other-epic-hash");
+    expect(collectImageIds(editor)).toEqual([]);
+    expect(editor.state.doc.textContent).toBe("describe it");
+    expect(mocks.reportableErrorToast).toHaveBeenCalledWith(
+      "Pasted image unavailable",
+      {
+        description:
+          "1 image could not be found in this composer and was removed.",
+      },
+      {
+        title: "Pasted image unavailable",
+        message: null,
+        code: null,
+        source: "Chat composer",
+      },
+    );
+  });
+
+  it("filters hash-only images copied directly as editor HTML", () => {
+    const source = makeEditor(KNOWN_SLASH_NAMES);
+    source.commands.setContent(hashOnlyImageContent("other-epic-hash"));
+    const wrapper = document.createElement("div");
+    wrapper.appendChild(
+      DOMSerializer.fromSchema(source.schema).serializeFragment(
+        source.state.doc.content,
+      ),
+    );
+    const hasBytes = vi.fn(() => false);
+    const destination = makeEditorWithPastedImagePresence(
+      KNOWN_SLASH_NAMES,
+      hasBytes,
+      () => undefined,
+    );
+
+    fireEvent.paste(destination.view.dom, {
+      clipboardData: {
+        files: [],
+        items: [],
+        types: ["text/html"],
+        getData: (type: string) =>
+          type === "text/html" ? wrapper.innerHTML : "",
+      },
+    });
+    expect(hasBytes).toHaveBeenCalledWith("other-epic-hash");
+    expect(collectImageIds(destination)).toEqual([]);
+    expect(destination.state.doc.textContent).toBe("describe it");
+    expect(mocks.reportableErrorToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves landing-composer rich pastes unvalidated", () => {
+    const editor = makeEditor(KNOWN_SLASH_NAMES);
+
+    pasteComposerContent(editor, hashOnlyImageContent("landing-hash"));
+
+    expect(collectImageIds(editor)).toEqual(["pasted-image"]);
+    expect(mocks.reportableErrorToast).not.toHaveBeenCalled();
+  });
+
+  it("keeps cold-open pastes unvalidated, then validates after snapshot readiness", () => {
+    let hasPastedImageBytes: ((hash: string) => boolean) | null = null;
+    const editor = makeEditorWithPastedImagePresenceGetter(
+      KNOWN_SLASH_NAMES,
+      () => hasPastedImageBytes,
+      () => undefined,
+    );
+
+    pasteComposerContent(
+      editor,
+      hashOnlyImageContentWithIdAndText(
+        "early-hash",
+        "early-image",
+        "early paste",
+      ),
+    );
+
+    expect(collectImageIds(editor)).toEqual(["early-image"]);
+    expect(mocks.reportableErrorToast).not.toHaveBeenCalled();
+
+    hasPastedImageBytes = (hash) => hash === "valid-hash";
+    pasteComposerContent(
+      editor,
+      hashOnlyImageContentWithIdAndText(
+        "missing-hash",
+        "missing-image",
+        "missing paste",
+      ),
+    );
+    pasteComposerContent(
+      editor,
+      hashOnlyImageContentWithIdAndText(
+        "valid-hash",
+        "valid-image",
+        "valid paste",
+      ),
+    );
+
+    expect(collectImageIds(editor)).toEqual(["early-image", "valid-image"]);
+    expect(mocks.reportableErrorToast).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits validated pasted content on immediate Enter", () => {
+    let submitted: JsonContent | null = null;
+    const editor = makeEditorWithPastedImagePresence(
+      KNOWN_SLASH_NAMES,
+      () => true,
+      () => {
+        submitted = editor.getJSON();
+      },
+    );
+
+    pasteComposerContent(editor, hashOnlyImageContent("same-epic-hash"));
+    fireEvent.keyDown(editor.view.dom, { key: "Enter" });
+
+    expect(submitted).toEqual(editor.getJSON());
+    expect(collectImageIds(editor)).toEqual(["pasted-image"]);
   });
 
   it("pastes plain text Markdown as structured editor content", () => {
@@ -502,6 +656,26 @@ function imageAttrs(id: string) {
 }
 
 function makeEditor(slashNames: ReadonlyArray<string> | null): Editor {
+  return makeEditorWithPastedImagePresence(slashNames, null, () => undefined);
+}
+
+function makeEditorWithPastedImagePresence(
+  slashNames: ReadonlyArray<string> | null,
+  hasPastedImageBytes: ((hash: string) => boolean) | null,
+  onSubmit: () => void,
+): Editor {
+  return makeEditorWithPastedImagePresenceGetter(
+    slashNames,
+    () => hasPastedImageBytes,
+    onSubmit,
+  );
+}
+
+function makeEditorWithPastedImagePresenceGetter(
+  slashNames: ReadonlyArray<string> | null,
+  getHasPastedImageBytes: () => ((hash: string) => boolean) | null,
+  onSubmit: () => void,
+): Editor {
   const element = document.createElement("div");
   document.body.appendChild(element);
   const pickerStore = createComposerPickerStore();
@@ -517,11 +691,64 @@ function makeEditor(slashNames: ReadonlyArray<string> | null): Editor {
     extensions: buildComposerExtensions({
       pickerStore,
       placeholder: "test",
-      onSubmit: { current: () => undefined },
+      onSubmit: { current: onSubmit },
       slashProviderId: "claude",
+      getHasPastedImageBytes,
     }),
     content: { type: "doc", content: [{ type: "paragraph" }] },
   });
   editors.push(editor);
   return editor;
+}
+
+function pasteComposerContent(editor: Editor, content: JsonContent): void {
+  const html = buildComposerClipboardHtml(
+    content,
+    composerClipboardPlainText(content),
+  );
+  fireEvent.paste(editor.view.dom, {
+    clipboardData: {
+      files: [],
+      items: [],
+      types: ["text/html"],
+      getData: (type: string) => (type === "text/html" ? html : ""),
+    },
+  });
+}
+
+function hashOnlyImageContent(hash: string): JsonContent {
+  return hashOnlyImageContentWithText(hash, "describe it");
+}
+
+function hashOnlyImageContentWithText(hash: string, text: string): JsonContent {
+  return hashOnlyImageContentWithIdAndText(hash, "pasted-image", text);
+}
+
+function hashOnlyImageContentWithIdAndText(
+  hash: string,
+  id: string,
+  text: string,
+): JsonContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [
+          {
+            type: "imageAttachment",
+            attrs: {
+              id,
+              fileName: "pasted.png",
+              b64content: null,
+              hash,
+              mimeType: "image/png",
+              size: 3,
+            },
+          },
+          { type: "text", text },
+        ],
+      },
+    ],
+  };
 }

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
@@ -260,6 +260,56 @@ describe("composer rich clipboard paste", () => {
     expect(mocks.reportableErrorToast).toHaveBeenCalledTimes(1);
   });
 
+  it("merges an available hash-only image pasted as inline editor HTML into the surrounding paragraph instead of splitting it", () => {
+    const source = makeEditor(KNOWN_SLASH_NAMES);
+    source.commands.setContent(
+      hashOnlyImageContentWithText("same-epic-hash", "suffix"),
+    );
+    // Serialize just the paragraph's own (inline) content - not the doc-level
+    // fragment - so the wrapper carries no block wrapper, mirroring a real
+    // mid-paragraph copy rather than a whole-paragraph one.
+    const wrapper = document.createElement("div");
+    wrapper.appendChild(
+      DOMSerializer.fromSchema(source.schema).serializeFragment(
+        source.state.doc.firstChild?.content ?? source.state.doc.content,
+      ),
+    );
+    const hasBytes = vi.fn((hash: string) => hash === "same-epic-hash");
+    const destination = makeEditorWithPastedImagePresence(
+      KNOWN_SLASH_NAMES,
+      hasBytes,
+      () => undefined,
+    );
+    destination.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "prefix " }] },
+      ],
+    });
+    destination.commands.setTextSelection(
+      destination.state.doc.content.size - 1,
+    );
+
+    fireEvent.paste(destination.view.dom, {
+      clipboardData: {
+        files: [],
+        items: [],
+        types: ["text/html"],
+        getData: (type: string) =>
+          type === "text/html" ? wrapper.innerHTML : "",
+      },
+    });
+
+    expect(hasBytes).toHaveBeenCalledWith("same-epic-hash");
+    // Nothing needed stripping, so the original (open) slice is dispatched
+    // unchanged - merging into the SAME paragraph as "prefix" rather than the
+    // JSON round-trip's closed 0/0 slice splitting it into a new block.
+    expect(destination.state.doc.childCount).toBe(1);
+    expect(collectImageIds(destination)).toEqual(["pasted-image"]);
+    expect(destination.state.doc.textContent).toBe("prefix suffix");
+    expect(mocks.reportableErrorToast).not.toHaveBeenCalled();
+  });
+
   it("leaves landing-composer rich pastes unvalidated", () => {
     const editor = makeEditor(KNOWN_SLASH_NAMES);
 

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-rich-paste.test.tsx
@@ -310,6 +310,56 @@ describe("composer rich clipboard paste", () => {
     expect(mocks.reportableErrorToast).not.toHaveBeenCalled();
   });
 
+  it("keeps a stripped unavailable image's surviving text merged into the surrounding paragraph instead of splitting it", () => {
+    const source = makeEditor(KNOWN_SLASH_NAMES);
+    source.commands.setContent(
+      hashOnlyImageContentWithText("other-epic-hash", "suffix"),
+    );
+    // Same inline-only serialization as the merge case above - no block
+    // wrapper, mirroring a real mid-paragraph copy.
+    const wrapper = document.createElement("div");
+    wrapper.appendChild(
+      DOMSerializer.fromSchema(source.schema).serializeFragment(
+        source.state.doc.firstChild?.content ?? source.state.doc.content,
+      ),
+    );
+    const hasBytes = vi.fn(() => false);
+    const destination = makeEditorWithPastedImagePresence(
+      KNOWN_SLASH_NAMES,
+      hasBytes,
+      () => undefined,
+    );
+    destination.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "paragraph", content: [{ type: "text", text: "prefix " }] },
+      ],
+    });
+    destination.commands.setTextSelection(
+      destination.state.doc.content.size - 1,
+    );
+
+    fireEvent.paste(destination.view.dom, {
+      clipboardData: {
+        files: [],
+        items: [],
+        types: ["text/html"],
+        getData: (type: string) =>
+          type === "text/html" ? wrapper.innerHTML : "",
+      },
+    });
+
+    expect(hasBytes).toHaveBeenCalledWith("other-epic-hash");
+    expect(collectImageIds(destination)).toEqual([]);
+    // The image was stripped, but the surviving text must still merge into
+    // the SAME paragraph as "prefix" - a JSON round-trip through
+    // `pasteComposerContent`'s closed 0/0 slice would instead split it into
+    // a second paragraph.
+    expect(destination.state.doc.childCount).toBe(1);
+    expect(destination.state.doc.textContent).toBe("prefix suffix");
+    expect(mocks.reportableErrorToast).toHaveBeenCalledTimes(1);
+  });
+
   it("leaves landing-composer rich pastes unvalidated", () => {
     const editor = makeEditor(KNOWN_SLASH_NAMES);
 

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-slash-flow.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-slash-flow.test.tsx
@@ -30,6 +30,7 @@ function makeFixture(): {
       placeholder: "test",
       onSubmit: submitHolder,
       slashProviderId: "claude",
+      getHasPastedImageBytes: () => null,
     }),
     content: { type: "doc", content: [{ type: "paragraph" }] },
   });

--- a/clients/gui-app/src/components/chat/composer/__tests__/use-chat-composer-draft.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/use-chat-composer-draft.test.tsx
@@ -201,6 +201,7 @@ function QuoteFocusHarness(props: QuoteFocusHarnessProps) {
       isActive={false}
       disabled={false}
       slashProviderId="claude"
+      hasPastedImageBytes={null}
       stabilizeImageAttachmentCaret={false}
       onSnapshot={(_content, selection) => {
         selectionRef.current = selection;

--- a/clients/gui-app/src/components/chat/composer/chat-composer-editor-slot.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer-editor-slot.tsx
@@ -21,6 +21,7 @@ interface ChatComposerEditorSlotProps {
   readonly initialContent: JsonContent;
   readonly initialSelection: { from: number; to: number } | null;
   readonly slashProviderId: GuiHarnessId;
+  readonly hasPastedImageBytes: ((hash: string) => boolean) | null;
   readonly isActive: boolean;
   readonly onSnapshot: (
     content: JsonContent,
@@ -45,6 +46,7 @@ export function ChatComposerEditorSlot(props: ChatComposerEditorSlotProps) {
     initialContent,
     initialSelection,
     slashProviderId,
+    hasPastedImageBytes,
     isActive,
     onSnapshot,
     onSubmit,
@@ -61,6 +63,7 @@ export function ChatComposerEditorSlot(props: ChatComposerEditorSlotProps) {
       initialContent={initialContent}
       initialSelection={initialSelection}
       slashProviderId={slashProviderId}
+      hasPastedImageBytes={hasPastedImageBytes}
       isActive={isActive}
       disabled={false}
       placeholder={isNarrow ? NARROW_PLACEHOLDER : PLACEHOLDER}

--- a/clients/gui-app/src/components/chat/composer/chat-composer-toolbar-slot.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer-toolbar-slot.tsx
@@ -15,6 +15,7 @@ interface ChatComposerToolbarSlotProps {
   readonly store: ComposerToolbarStore;
   readonly onAttachImages: (files: ReadonlyArray<File>) => void;
   readonly canSubmit: boolean;
+  readonly attachmentPending: boolean;
   readonly onSubmit: () => void;
   readonly activeTurnStatus: ChatActiveTurn["status"] | null;
   readonly hasPendingApprovals: boolean;
@@ -74,6 +75,7 @@ function ChatComposerToolbarSlotView(props: ChatComposerToolbarSlotViewProps) {
       showNextTurnPermissionNote={props.showNextTurnPermissionNote}
       showAgentModeTooltip={false}
       canSubmit={props.canSubmit}
+      attachmentPending={props.attachmentPending}
       onSubmit={props.onSubmit}
       activeTurnStatus={props.activeTurnStatus}
       stopDisabled={props.stopDisabled}

--- a/clients/gui-app/src/components/chat/composer/chat-composer.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer.tsx
@@ -63,6 +63,7 @@ import { useComposerPickerItems } from "./picker/use-composer-picker-items";
 import { commitProfileSelection } from "@/stores/composer/commit-selection";
 import { useTaskProfileRateLimitSwitch } from "./use-task-profile-rate-limit-switch";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import { useEpicAttachmentBytesPresence } from "@/lib/attachments/use-attachment-blob-src";
 
 interface ChatComposerProps {
   readonly taskId: string;
@@ -148,6 +149,7 @@ function ChatComposerImpl(props: ChatComposerProps) {
   const workspaceBlocked = !workspaceComposerCanStart(workspaceAvailability);
 
   const editorRef = useRef<ComposerPromptEditorHandle | null>(null);
+  const hasPastedImageBytes = useEpicAttachmentBytesPresence();
   // Counts editor-ready transitions (a counter, not a boolean, so a torn-down
   // and re-created editor re-fires). The draft-reset bridge keys its
   // handle-ready catch-up on this - a ref flip alone never re-renders us.
@@ -274,6 +276,18 @@ function ChatComposerImpl(props: ChatComposerProps) {
     isActive,
   });
 
+  const {
+    onPaste,
+    onDrop,
+    onDragOver,
+    onDragEnter,
+    onDragLeave,
+    attachImageFiles,
+    isDraggingFiles,
+    isIngestingImages,
+  } = useComposerPaste(editorRef);
+  const attachmentPending = isIngestingImages;
+
   const submitDraft = useChatComposerSubmit({
     taskId,
     editorRef,
@@ -284,6 +298,7 @@ function ChatComposerImpl(props: ChatComposerProps) {
     sendDisabled: sendBlocked,
     workspaceBlocked,
     imagesUnsupported,
+    attachmentPreparationPending: attachmentPending,
     onSubmitMessage,
   });
   const ambientDrift = useAmbientDriftGate(
@@ -308,16 +323,6 @@ function ChatComposerImpl(props: ChatComposerProps) {
     });
   };
 
-  const {
-    onPaste,
-    onDrop,
-    onDragOver,
-    onDragEnter,
-    onDragLeave,
-    attachImageFiles,
-    isDraggingFiles,
-  } = useComposerPaste(editorRef);
-
   const removeImage = useCallback((id: string) => {
     Analytics.getInstance().track(AnalyticsEvent.AttachmentRemoved, {
       kind: "image",
@@ -336,6 +341,7 @@ function ChatComposerImpl(props: ChatComposerProps) {
     sendDisabled: sendBlocked,
     workspaceBlocked,
     imagesUnsupported,
+    attachmentPreparationPending: attachmentPending,
     draftHasText,
     draftHasImages,
   });
@@ -422,6 +428,7 @@ function ChatComposerImpl(props: ChatComposerProps) {
                   initialContent={initialContent}
                   initialSelection={initialSelection}
                   slashProviderId={harnessId}
+                  hasPastedImageBytes={hasPastedImageBytes}
                   isActive={isActive}
                   onSnapshot={handleSnapshot}
                   onSubmit={handleSubmitDraft}
@@ -436,6 +443,7 @@ function ChatComposerImpl(props: ChatComposerProps) {
                   store={toolbarStore}
                   onAttachImages={attachImageFiles}
                   canSubmit={canSubmit}
+                  attachmentPending={attachmentPending}
                   onSubmit={handleSubmitDraft}
                   activeTurnStatus={activeTurnStatus}
                   hasPendingApprovals={hasPendingApprovals}
@@ -548,6 +556,7 @@ interface CanSubmitDraftArgs {
   readonly sendDisabled: boolean | undefined;
   readonly workspaceBlocked: boolean;
   readonly imagesUnsupported: boolean;
+  readonly attachmentPreparationPending: boolean;
   readonly draftHasText: boolean;
   readonly draftHasImages: boolean;
 }
@@ -559,6 +568,7 @@ function canSubmitDraft(args: CanSubmitDraftArgs): boolean {
     !args.sendDisabled &&
     !args.workspaceBlocked &&
     !args.imagesUnsupported &&
+    !args.attachmentPreparationPending &&
     (args.draftHasText || args.draftHasImages)
   );
 }

--- a/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
+++ b/clients/gui-app/src/components/chat/composer/composer-prompt-editor.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -80,6 +81,7 @@ export interface ComposerPromptEditorProps {
   readonly isActive: boolean;
   readonly disabled: boolean;
   readonly slashProviderId: GuiHarnessId;
+  readonly hasPastedImageBytes: ((hash: string) => boolean) | null;
   readonly onSnapshot: (
     content: JsonContent,
     selection: { from: number; to: number },
@@ -101,6 +103,16 @@ export interface ComposerPromptEditorProps {
   readonly ref?: Ref<ComposerPromptEditorHandle>;
 }
 
+function usePastedImageBytesPresenceGetter(
+  hasPastedImageBytes: ((hash: string) => boolean) | null,
+): () => ((hash: string) => boolean) | null {
+  const latest = useRef(hasPastedImageBytes);
+  useLayoutEffect(() => {
+    latest.current = hasPastedImageBytes;
+  }, [hasPastedImageBytes]);
+  return useCallback(() => latest.current, []);
+}
+
 function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
   const {
     initialContent,
@@ -112,6 +124,7 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
     isActive,
     disabled,
     slashProviderId,
+    hasPastedImageBytes,
     onSnapshot,
     onSubmit,
     onPaste,
@@ -153,7 +166,8 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
       },
     }),
   );
-
+  const getHasPastedImageBytes =
+    usePastedImageBytesPresenceGetter(hasPastedImageBytes);
   const extensions = useMemo(
     () =>
       buildComposerExtensions({
@@ -161,8 +175,15 @@ function ComposerPromptEditorImpl(props: ComposerPromptEditorProps) {
         placeholder,
         onSubmit: stableSubmitHolder,
         slashProviderId,
+        getHasPastedImageBytes,
       }),
-    [pickerStore, placeholder, slashProviderId, stableSubmitHolder],
+    [
+      getHasPastedImageBytes,
+      pickerStore,
+      placeholder,
+      slashProviderId,
+      stableSubmitHolder,
+    ],
   );
 
   const editorAttributesObject = useMemo(

--- a/clients/gui-app/src/components/chat/composer/editor/editor-config.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/editor-config.ts
@@ -24,6 +24,7 @@ export interface BuildComposerExtensionsArgs {
   readonly placeholder: string;
   readonly onSubmit: { readonly current: () => void };
   readonly slashProviderId: GuiHarnessId;
+  readonly getHasPastedImageBytes: () => ((hash: string) => boolean) | null;
 }
 
 // Blockquote is button-only (T5): the composer schema stays blockquote-valid
@@ -74,7 +75,10 @@ export function buildComposerExtensions(
       onSubmit: args.onSubmit,
       pickerStore: args.pickerStore,
     }),
-    createChatPasteHandler({ pickerStore: args.pickerStore }),
+    createChatPasteHandler({
+      pickerStore: args.pickerStore,
+      getHasPastedImageBytes: args.getHasPastedImageBytes,
+    }),
     // Cmd+C / Cmd+X -> structured plain text (list markers, mentions, slash
     // commands) instead of ProseMirror's default blank-line-joined textContent.
     ChatCopySerializer,

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
@@ -40,18 +40,27 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
 
     addProseMirrorPlugins() {
       const { editor } = this;
+      // `dispatchUnchanged` inserts the caller's original, structurally-open
+      // paste content when nothing needs to be stripped - only an actual
+      // strip forces the JSON round-trip through `pasteComposerContent`
+      // (always a closed 0/0 slice), which would otherwise needlessly flatten
+      // an inline HTML paste's open slice into a new block.
       const pasteWithValidatedImages = (
         view: EditorView,
         content: JsonContent,
+        dispatchUnchanged: () => boolean,
       ): boolean => {
         const hashes = hashOnlyImageHashes(content);
         const hasPastedImageBytes = deps.getHasPastedImageBytes();
         if (hashes.length === 0 || hasPastedImageBytes === null) {
-          return pasteComposerContent(view, content);
+          return dispatchUnchanged();
         }
         const availableHashes = new Set(
           hashes.filter((hash) => hasPastedImageBytes(hash)),
         );
+        if (availableHashes.size === hashes.length) {
+          return dispatchUnchanged();
+        }
         const filtered = filterUnavailablePastedImages(
           content,
           availableHashes,
@@ -74,7 +83,9 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
               const composerContent =
                 readComposerContentFromClipboardData(clipboardData);
               if (composerContent !== null) {
-                return pasteWithValidatedImages(view, composerContent);
+                return pasteWithValidatedImages(view, composerContent, () =>
+                  pasteComposerContent(view, composerContent),
+                );
               }
 
               const html = clipboardData.getData("text/html");
@@ -91,16 +102,23 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
                   }),
                   view.state.schema,
                 );
+                const dispatchOriginalSlice = (): boolean => {
+                  const tr = view.state.tr.replaceSelection(slice);
+                  view.dispatch(tr.scrollIntoView());
+                  return true;
+                };
                 const htmlContent = sliceToDocJson(slice);
                 if (
                   htmlContent !== null &&
                   hashOnlyImageHashes(htmlContent).length > 0
                 ) {
-                  return pasteWithValidatedImages(view, htmlContent);
+                  return pasteWithValidatedImages(
+                    view,
+                    htmlContent,
+                    dispatchOriginalSlice,
+                  );
                 }
-                const tr = view.state.tr.replaceSelection(slice);
-                view.dispatch(tr.scrollIntoView());
-                return true;
+                return dispatchOriginalSlice();
               }
 
               const text = clipboardData.getData("text/plain");

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
@@ -5,6 +5,7 @@ import {
   DOMParser as ProseMirrorDOMParser,
   Fragment,
   Slice,
+  type Node as ProseMirrorNode,
   type Schema,
 } from "@tiptap/pm/model";
 import type { JsonContent } from "@traycer/protocol/common/registry";
@@ -18,7 +19,6 @@ import {
   slashCommandParagraph,
   stringValue,
 } from "@/lib/composer/tiptap-json-content";
-import { sliceToDocJson } from "@/lib/editor/prosemirror-json";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 import {
@@ -40,32 +40,63 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
 
     addProseMirrorPlugins() {
       const { editor } = this;
-      // `dispatchUnchanged` inserts the caller's original, structurally-open
-      // paste content when nothing needs to be stripped - only an actual
-      // strip forces the JSON round-trip through `pasteComposerContent`
-      // (always a closed 0/0 slice), which would otherwise needlessly flatten
-      // an inline HTML paste's open slice into a new block.
+      // The composer-content (JSON) clipboard flavor is a whole standalone
+      // copied-message doc, so both the no-strip and strip cases rebuild
+      // through `pasteComposerContent`'s closed 0/0 slice - there's no open
+      // slice to preserve for this flavor. The HTML clipboard flavor uses
+      // `pasteSliceWithValidatedImages` below instead, which strips directly
+      // against the parsed `Slice`'s `Fragment` so an inline paste's open
+      // boundaries survive a strip.
       const pasteWithValidatedImages = (
         view: EditorView,
         content: JsonContent,
-        dispatchUnchanged: () => boolean,
       ): boolean => {
         const hashes = hashOnlyImageHashes(content);
         const hasPastedImageBytes = deps.getHasPastedImageBytes();
         if (hashes.length === 0 || hasPastedImageBytes === null) {
-          return dispatchUnchanged();
+          return pasteComposerContent(view, content);
         }
         const availableHashes = new Set(
           hashes.filter((hash) => hasPastedImageBytes(hash)),
         );
         if (availableHashes.size === hashes.length) {
-          return dispatchUnchanged();
+          return pasteComposerContent(view, content);
         }
         const filtered = filterUnavailablePastedImages(
           content,
           availableHashes,
         );
         const pasted = pasteComposerContent(view, filtered.content);
+        if (filtered.removedCount > 0) {
+          showUnavailablePastedImageToast(filtered.removedCount);
+        }
+        return pasted;
+      };
+      const pasteSliceWithValidatedImages = (
+        view: EditorView,
+        slice: Slice,
+      ): boolean => {
+        const dispatchSlice = (sliceToDispatch: Slice): boolean => {
+          const tr = view.state.tr.replaceSelection(sliceToDispatch);
+          view.dispatch(tr.scrollIntoView());
+          return true;
+        };
+        const hashes = hashOnlyImageFragmentHashes(slice.content);
+        const hasPastedImageBytes = deps.getHasPastedImageBytes();
+        if (hashes.length === 0 || hasPastedImageBytes === null) {
+          return dispatchSlice(slice);
+        }
+        const availableHashes = new Set(
+          hashes.filter((hash) => hasPastedImageBytes(hash)),
+        );
+        if (availableHashes.size === hashes.length) {
+          return dispatchSlice(slice);
+        }
+        const filtered = filterUnavailablePastedImageSlice(
+          slice,
+          availableHashes,
+        );
+        const pasted = dispatchSlice(filtered.slice);
         if (filtered.removedCount > 0) {
           showUnavailablePastedImageToast(filtered.removedCount);
         }
@@ -83,9 +114,7 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
               const composerContent =
                 readComposerContentFromClipboardData(clipboardData);
               if (composerContent !== null) {
-                return pasteWithValidatedImages(view, composerContent, () =>
-                  pasteComposerContent(view, composerContent),
-                );
+                return pasteWithValidatedImages(view, composerContent);
               }
 
               const html = clipboardData.getData("text/html");
@@ -102,23 +131,7 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
                   }),
                   view.state.schema,
                 );
-                const dispatchOriginalSlice = (): boolean => {
-                  const tr = view.state.tr.replaceSelection(slice);
-                  view.dispatch(tr.scrollIntoView());
-                  return true;
-                };
-                const htmlContent = sliceToDocJson(slice);
-                if (
-                  htmlContent !== null &&
-                  hashOnlyImageHashes(htmlContent).length > 0
-                ) {
-                  return pasteWithValidatedImages(
-                    view,
-                    htmlContent,
-                    dispatchOriginalSlice,
-                  );
-                }
-                return dispatchOriginalSlice();
+                return pasteSliceWithValidatedImages(view, slice);
               }
 
               const text = clipboardData.getData("text/plain");
@@ -249,6 +262,94 @@ function filterUnavailablePastedImageNode(
     return { node: null, removedCount };
   }
   return { node: { ...node, content: children }, removedCount };
+}
+
+function hashOnlyImageFragmentHashes(fragment: Fragment): string[] {
+  const hashes = new Set<string>();
+  collectHashOnlyImageFragmentHashes(fragment, hashes);
+  return Array.from(hashes);
+}
+
+function collectHashOnlyImageFragmentHashes(
+  fragment: Fragment,
+  hashes: Set<string>,
+): void {
+  fragment.forEach((node) => {
+    if (node.type.name === "imageAttachment") {
+      const hash = stringValue(node.attrs.hash);
+      const b64content = stringValue(node.attrs.b64content);
+      if (hash !== null && b64content === null) hashes.add(hash);
+      return;
+    }
+    if (node.isLeaf) return;
+    collectHashOnlyImageFragmentHashes(node.content, hashes);
+  });
+}
+
+interface FilteredPastedImageSlice {
+  readonly slice: Slice;
+  readonly removedCount: number;
+}
+
+interface FilteredPastedImageFragment {
+  readonly fragment: Fragment;
+  readonly removedCount: number;
+}
+
+// Mirrors `filterUnavailablePastedImages`, but works on the ProseMirror
+// `Slice`/`Fragment` directly instead of round-tripping through JSON, so the
+// original slice's `openStart`/`openEnd` survive a strip. An inline atomic
+// `imageAttachment` node's removal never changes block-nesting depth, so
+// reusing the original open boundaries on the filtered fragment stays valid.
+function filterUnavailablePastedImageSlice(
+  slice: Slice,
+  availableHashes: ReadonlySet<string>,
+): FilteredPastedImageSlice {
+  const filtered = filterUnavailablePastedImageFragment(
+    slice.content,
+    availableHashes,
+  );
+  return {
+    slice: new Slice(filtered.fragment, slice.openStart, slice.openEnd),
+    removedCount: filtered.removedCount,
+  };
+}
+
+function filterUnavailablePastedImageFragment(
+  fragment: Fragment,
+  availableHashes: ReadonlySet<string>,
+): FilteredPastedImageFragment {
+  const children: ProseMirrorNode[] = [];
+  let removedCount = 0;
+  fragment.forEach((node) => {
+    if (node.type.name === "imageAttachment") {
+      const hash = stringValue(node.attrs.hash);
+      const b64content = stringValue(node.attrs.b64content);
+      if (hash !== null && b64content === null && !availableHashes.has(hash)) {
+        removedCount += 1;
+        return;
+      }
+      children.push(node);
+      return;
+    }
+    if (node.isLeaf) {
+      children.push(node);
+      return;
+    }
+    const filteredChild = filterUnavailablePastedImageFragment(
+      node.content,
+      availableHashes,
+    );
+    removedCount += filteredChild.removedCount;
+    if (
+      node.type.name === "attachmentGroup" &&
+      filteredChild.fragment.childCount === 0
+    ) {
+      return;
+    }
+    children.push(node.copy(filteredChild.fragment));
+  });
+  return { fragment: Fragment.fromArray(children), removedCount };
 }
 
 function showUnavailablePastedImageToast(removedCount: number): void {

--- a/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
+++ b/clients/gui-app/src/components/chat/composer/editor/extensions/chat-paste-handler.ts
@@ -1,5 +1,6 @@
 import { Extension } from "@tiptap/core";
-import { Plugin, PluginKey, type EditorState } from "@tiptap/pm/state";
+import { Plugin, type EditorState } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 import {
   DOMParser as ProseMirrorDOMParser,
   Fragment,
@@ -15,7 +16,10 @@ import { normalizeSliceSoftBreaks } from "@/lib/composer/normalize-soft-breaks";
 import {
   parseLeadingSlashCommand,
   slashCommandParagraph,
+  stringValue,
 } from "@/lib/composer/tiptap-json-content";
+import { sliceToDocJson } from "@/lib/editor/prosemirror-json";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 import {
   isLeadingRange,
@@ -23,11 +27,11 @@ import {
 } from "./slash-command-extension";
 import type { ComposerPickerStore } from "../../picker/composer-picker-store";
 
-const chatPasteHandlerKey = new PluginKey("composer-chat-paste-handler");
 const BOLD_MARK = { type: "bold" };
 
 export interface ChatPasteHandlerDeps {
   readonly pickerStore: ComposerPickerStore;
+  readonly getHasPastedImageBytes: () => ((hash: string) => boolean) | null;
 }
 
 export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
@@ -36,9 +40,30 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
 
     addProseMirrorPlugins() {
       const { editor } = this;
+      const pasteWithValidatedImages = (
+        view: EditorView,
+        content: JsonContent,
+      ): boolean => {
+        const hashes = hashOnlyImageHashes(content);
+        const hasPastedImageBytes = deps.getHasPastedImageBytes();
+        if (hashes.length === 0 || hasPastedImageBytes === null) {
+          return pasteComposerContent(view, content);
+        }
+        const availableHashes = new Set(
+          hashes.filter((hash) => hasPastedImageBytes(hash)),
+        );
+        const filtered = filterUnavailablePastedImages(
+          content,
+          availableHashes,
+        );
+        const pasted = pasteComposerContent(view, filtered.content);
+        if (filtered.removedCount > 0) {
+          showUnavailablePastedImageToast(filtered.removedCount);
+        }
+        return pasted;
+      };
       return [
         new Plugin({
-          key: chatPasteHandlerKey,
           props: {
             handlePaste(view, event) {
               const clipboardData = event.clipboardData;
@@ -49,16 +74,7 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
               const composerContent =
                 readComposerContentFromClipboardData(clipboardData);
               if (composerContent !== null) {
-                const slice = composerContentSlice(
-                  view.state.schema,
-                  composerContent,
-                );
-                if (slice === null) return false;
-                const tr = view.state.tr.replaceSelection(
-                  normalizeSliceSoftBreaks(slice, view.state.schema),
-                );
-                view.dispatch(tr.scrollIntoView());
-                return true;
+                return pasteWithValidatedImages(view, composerContent);
               }
 
               const html = clipboardData.getData("text/html");
@@ -69,12 +85,20 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
                 const parser = ProseMirrorDOMParser.fromSchema(
                   view.state.schema,
                 );
-                const slice = parser.parseSlice(sanitized, {
-                  preserveWhitespace: false,
-                });
-                const tr = view.state.tr.replaceSelection(
-                  normalizeSliceSoftBreaks(slice, view.state.schema),
+                const slice = normalizeSliceSoftBreaks(
+                  parser.parseSlice(sanitized, {
+                    preserveWhitespace: false,
+                  }),
+                  view.state.schema,
                 );
+                const htmlContent = sliceToDocJson(slice);
+                if (
+                  htmlContent !== null &&
+                  hashOnlyImageHashes(htmlContent).length > 0
+                ) {
+                  return pasteWithValidatedImages(view, htmlContent);
+                }
+                const tr = view.state.tr.replaceSelection(slice);
                 view.dispatch(tr.scrollIntoView());
                 return true;
               }
@@ -128,6 +152,104 @@ export function createChatPasteHandler(deps: ChatPasteHandlerDeps) {
       ];
     },
   });
+}
+
+function pasteComposerContent(view: EditorView, content: JsonContent): boolean {
+  const slice = composerContentSlice(view.state.schema, content);
+  if (slice === null) return false;
+  const tr = view.state.tr.replaceSelection(
+    normalizeSliceSoftBreaks(slice, view.state.schema),
+  );
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}
+
+function hashOnlyImageHashes(content: JsonContent): string[] {
+  const hashes = new Set<string>();
+  collectHashOnlyImageHashes(content, hashes);
+  return Array.from(hashes);
+}
+
+function collectHashOnlyImageHashes(
+  node: JsonContent,
+  hashes: Set<string>,
+): void {
+  if (node.type === "imageAttachment") {
+    const hash = stringValue(node.attrs?.hash);
+    const b64content = stringValue(node.attrs?.b64content);
+    if (hash !== null && b64content === null) hashes.add(hash);
+    return;
+  }
+  node.content?.forEach((child) => collectHashOnlyImageHashes(child, hashes));
+}
+
+interface FilteredPastedImageContent {
+  readonly content: JsonContent;
+  readonly removedCount: number;
+}
+
+interface FilteredPastedImageNode {
+  readonly node: JsonContent | null;
+  readonly removedCount: number;
+}
+
+function filterUnavailablePastedImages(
+  content: JsonContent,
+  availableHashes: ReadonlySet<string>,
+): FilteredPastedImageContent {
+  const filtered = filterUnavailablePastedImageNode(content, availableHashes);
+  return {
+    content: filtered.node ?? { type: "doc", content: [] },
+    removedCount: filtered.removedCount,
+  };
+}
+
+function filterUnavailablePastedImageNode(
+  node: JsonContent,
+  availableHashes: ReadonlySet<string>,
+): FilteredPastedImageNode {
+  if (node.type === "imageAttachment") {
+    const hash = stringValue(node.attrs?.hash);
+    const b64content = stringValue(node.attrs?.b64content);
+    if (hash !== null && b64content === null && !availableHashes.has(hash)) {
+      return { node: null, removedCount: 1 };
+    }
+    return { node, removedCount: 0 };
+  }
+  if (node.content === undefined) return { node, removedCount: 0 };
+  const filteredChildren = node.content.map((child) =>
+    filterUnavailablePastedImageNode(child, availableHashes),
+  );
+  const children = filteredChildren.flatMap((child) =>
+    child.node === null ? [] : [child.node],
+  );
+  const removedCount = filteredChildren.reduce(
+    (count, child) => count + child.removedCount,
+    0,
+  );
+  if (node.type === "attachmentGroup" && children.length === 0) {
+    return { node: null, removedCount };
+  }
+  return { node: { ...node, content: children }, removedCount };
+}
+
+function showUnavailablePastedImageToast(removedCount: number): void {
+  const plural = removedCount === 1 ? "image" : "images";
+  const verb = removedCount === 1 ? "was" : "were";
+  reportableErrorToast(
+    removedCount === 1
+      ? "Pasted image unavailable"
+      : "Some pasted images are unavailable",
+    {
+      description: `${removedCount} ${plural} could not be found in this composer and ${verb} removed.`,
+    },
+    {
+      title: "Pasted image unavailable",
+      message: null,
+      code: null,
+      source: "Chat composer",
+    },
+  );
 }
 
 function composerMarkdownContentSlice(

--- a/clients/gui-app/src/components/chat/composer/use-chat-composer-submit.ts
+++ b/clients/gui-app/src/components/chat/composer/use-chat-composer-submit.ts
@@ -46,6 +46,7 @@ interface UseChatComposerSubmitArgs {
    */
   readonly workspaceBlocked: boolean;
   readonly imagesUnsupported: boolean;
+  readonly attachmentPreparationPending: boolean;
   readonly onSubmitMessage:
     ((input: ChatComposerSubmitInput) => boolean) | null;
 }
@@ -68,6 +69,7 @@ export function useChatComposerSubmit(args: UseChatComposerSubmitArgs) {
     sendDisabled,
     workspaceBlocked,
     imagesUnsupported,
+    attachmentPreparationPending,
     onSubmitMessage,
   } = args;
   const appendMessage = useChatStore((state) => state.appendMessage);
@@ -79,7 +81,8 @@ export function useChatComposerSubmit(args: UseChatComposerSubmitArgs) {
       hasPendingApprovals ||
       sendDisabled ||
       workspaceBlocked ||
-      imagesUnsupported
+      imagesUnsupported ||
+      attachmentPreparationPending
     ) {
       return;
     }
@@ -139,6 +142,7 @@ export function useChatComposerSubmit(args: UseChatComposerSubmitArgs) {
     editorRef,
     hasPendingApprovals,
     imagesUnsupported,
+    attachmentPreparationPending,
     onSubmitMessage,
     pickerStore,
     sendDisabled,

--- a/clients/gui-app/src/components/chat/user-message-attachment-gallery.tsx
+++ b/clients/gui-app/src/components/chat/user-message-attachment-gallery.tsx
@@ -1,4 +1,5 @@
 import { useMemo, type ReactNode } from "react";
+import { ImageOff } from "lucide-react";
 
 import {
   Dialog,
@@ -6,7 +7,10 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { useAttachmentBlobSrc } from "@/lib/attachments/use-attachment-blob-src";
+import {
+  type AttachmentBlobSrcState,
+  useAttachmentBlobSrc,
+} from "@/lib/attachments/use-attachment-blob-src";
 import {
   buildImageAttachmentDisplayLabels,
   fallbackImageAttachmentDisplayLabel,
@@ -76,10 +80,13 @@ function imageAttachmentRenderKey(attachment: ImageAttachment): string {
 /**
  * Resolves the image source: persisted images (`hash`) stream their bytes from
  * the epic doc's attachments map into a shared blob URL via the content-addressed
- * cache; draft/optimistic images render their inline `dataUrl` directly. Returns
- * null while a persisted image's blob is still loading.
+ * cache; draft/optimistic images render their inline `dataUrl` directly. A
+ * persisted hash transitions from loading to unavailable after its sync grace
+ * period while remaining able to recover when bytes arrive later.
  */
-function useImageAttachmentSrc(attachment: ImageAttachment): string | null {
+function useImageAttachmentSrc(
+  attachment: ImageAttachment,
+): AttachmentBlobSrcState {
   return useAttachmentBlobSrc(
     attachment.hash,
     attachment.mediaType,
@@ -98,13 +105,72 @@ function ImageAttachmentThumb({
   const label =
     displayLabel ??
     fallbackImageAttachmentDisplayLabel({ id: "fallback", fileName: alt });
-  const src = useImageAttachmentSrc(attachment);
+  const image = useImageAttachmentSrc(attachment);
+  const triggerAriaLabel =
+    image.status === "unavailable"
+      ? `Open ${label.ariaLabel} (image unavailable)`
+      : `Open ${label.ariaLabel}`;
+  let thumbnail: ReactNode;
+  if (image.status === "loading") {
+    thumbnail = (
+      <div className="size-full animate-pulse bg-muted/60" aria-hidden />
+    );
+  } else if (image.status === "unavailable") {
+    thumbnail = (
+      <div
+        className="flex size-full items-center justify-center bg-muted/60 text-muted-foreground"
+        data-user-message-image-unavailable
+        aria-hidden
+      >
+        <ImageOff className="size-4" />
+      </div>
+    );
+  } else {
+    thumbnail = (
+      <img
+        src={image.src}
+        alt={alt}
+        className="size-full object-cover transition-transform group-hover:scale-[1.02]"
+        draggable={false}
+      />
+    );
+  }
+
+  let dialogBody: ReactNode;
+  if (image.status === "loading") {
+    dialogBody = (
+      <div
+        className="aspect-video w-full animate-pulse rounded-lg bg-muted/60"
+        aria-hidden
+      />
+    );
+  } else if (image.status === "unavailable") {
+    dialogBody = (
+      <div
+        className="flex aspect-video w-full flex-col items-center justify-center gap-2 rounded-lg bg-muted/40 px-4 py-8 text-center text-muted-foreground"
+        role="status"
+      >
+        <ImageOff className="size-8" aria-hidden />
+        <p className="text-ui-sm">Image unavailable</p>
+      </div>
+    );
+  } else {
+    dialogBody = (
+      <img
+        src={image.src}
+        alt={alt}
+        className="block max-h-[min(90vh,52rem)] w-full rounded-lg object-contain"
+        draggable={false}
+      />
+    );
+  }
+
   return (
     <Dialog>
       <DialogTrigger asChild>
         <button
           type="button"
-          aria-label={`Open ${label.ariaLabel}`}
+          aria-label={triggerAriaLabel}
           title={label.title}
           className="group relative size-12 overflow-hidden rounded-md border border-border/70 bg-muted/40 outline-none transition-colors hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring"
         >
@@ -114,16 +180,7 @@ function ImageAttachmentThumb({
           >
             {label.badgeLabel}
           </span>
-          {src === null ? (
-            <div className="size-full animate-pulse bg-muted/60" aria-hidden />
-          ) : (
-            <img
-              src={src}
-              alt={alt}
-              className="size-full object-cover transition-transform group-hover:scale-[1.02]"
-              draggable={false}
-            />
-          )}
+          {thumbnail}
         </button>
       </DialogTrigger>
       <DialogContent
@@ -131,19 +188,7 @@ function ImageAttachmentThumb({
         showCloseButton
       >
         <DialogTitle className="sr-only">{alt}</DialogTitle>
-        {src === null ? (
-          <div
-            className="aspect-video w-full animate-pulse rounded-lg bg-muted/60"
-            aria-hidden
-          />
-        ) : (
-          <img
-            src={src}
-            alt={alt}
-            className="block max-h-[min(90vh,52rem)] w-full rounded-lg object-contain"
-            draggable={false}
-          />
-        )}
+        {dialogBody}
       </DialogContent>
     </Dialog>
   );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-submit-gate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-conversation-submit-gate.test.tsx
@@ -1,0 +1,263 @@
+import "../../../../../__tests__/test-browser-apis";
+import { createRef } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStore } from "zustand/vanilla";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+
+import type { ComposerBodyProps } from "@/components/home/composer/composer-body";
+import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
+import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
+import { NewConversationModalBody } from "../new-conversation-modal";
+
+const DIRTY_CONTENT: JsonContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "dirty" }] }],
+};
+
+const testState = vi.hoisted(() => ({
+  createChat: vi.fn(),
+  bodySubmit: null as (() => void) | null,
+  installEditor: null as (() => void) | null,
+  ingesting: false,
+  attachmentPresence: null as ((hash: string) => boolean) | null,
+  bodyAttachmentPresence: null as ((hash: string) => boolean) | null,
+}));
+
+vi.mock("@/components/home/composer/composer-body", async () => {
+  const React = await import("react");
+  return {
+    ComposerBody: (props: ComposerBodyProps) => {
+      testState.bodySubmit = props.onSubmit;
+      testState.bodyAttachmentPresence = props.hasPastedImageBytes;
+      testState.installEditor = () => {
+        props.editorRef.current = editorHandle();
+      };
+      return React.createElement(
+        "button",
+        { type: "button", onClick: props.onSubmit },
+        "Submit new conversation",
+      );
+    },
+  };
+});
+
+vi.mock("@/components/home/hooks/use-composer-toolbar-store", () => {
+  const toolbarStore = createStore(() => ({
+    selection: {
+      harnessId: "claude",
+      modelSlug: "claude-sonnet",
+      profileId: null,
+    },
+    permission: "supervised",
+    reasoning: "medium",
+    serviceTier: "",
+    agentMode: "regular",
+  }));
+  return { useComposerToolbarStore: () => toolbarStore };
+});
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicPermissionRole: () => "owner",
+  useEpicConnectionStatus: () => "open",
+  useEpicNodeOwnerKind: () => "chat",
+  useEpicNodeWorkspaceFolders: () => [],
+}));
+
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => ({ getActiveHostId: () => "host-1" }),
+}));
+
+vi.mock("@/hooks/worktree/use-latest-conversation-workspace-seed", () => ({
+  useLatestConversationWorkspaceSeed: () => null,
+  latestCreatedConversationOwner: () => null,
+}));
+
+vi.mock("@/hooks/worktree/use-owner-workspace-inheritance-seed", () => ({
+  useOwnerWorkspaceInheritanceSeed: () => ({ seed: null }),
+}));
+
+vi.mock("@/hooks/use-epic-store", () => ({
+  useEpicStore: () => ({
+    chats: { byId: {}, allIds: [] },
+    tuiAgents: { byId: {}, allIds: [] },
+  }),
+}));
+
+vi.mock("@/hooks/composer/use-composer-paste", () => ({
+  useComposerPaste: () => ({
+    onPaste: vi.fn(),
+    onDrop: vi.fn(),
+    onDragOver: vi.fn(),
+    onDragEnter: vi.fn(),
+    onDragLeave: vi.fn(),
+    attachImageFiles: vi.fn(),
+    isDraggingFiles: false,
+    isIngestingImages: testState.ingesting,
+  }),
+}));
+
+vi.mock("@/hooks/workspace/use-resolved-workspace-folders-query", () => ({
+  useResolvedWorkspaceFolders: () => ({ folders: [], isLoading: false }),
+}));
+
+vi.mock("@/lib/composer/workspace-composer-availability", () => ({
+  deriveFolderlessAllowedWorkspaceAvailability: () => ({
+    disabledHint: null,
+  }),
+  workspaceComposerCanStart: () => true,
+}));
+
+vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
+  useEpicCreateChat: () => ({
+    isPending: false,
+    mutate: testState.createChat,
+  }),
+}));
+
+vi.mock("@/hooks/agent/use-create-tui-agent", () => ({
+  useCreateTuiAgent: () => ({ isPending: false, mutate: vi.fn() }),
+}));
+
+vi.mock("@/components/chat/composer/picker/use-composer-picker-items", () => ({
+  useComposerPickerItems: () => undefined,
+}));
+vi.mock("@/hooks/composer/use-composer-dictation", () => ({
+  useComposerDictation: () => ({
+    dictationControl: null,
+    dictationPreparing: null,
+  }),
+}));
+vi.mock("@/hooks/composer/use-workspace-mention-roots", () => ({
+  mentionRootsFromWorktreeIntent: () => [],
+  useWorkspaceMentionRoots: () => [],
+}));
+vi.mock(
+  "@/components/home/host-workspace-selector/host-workspace-selector",
+  () => ({ ActiveHostWorkspaceControls: () => null }),
+);
+vi.mock("@/lib/attachments/use-attachment-blob-src", () => ({
+  useEpicImageFetcher: () => vi.fn(),
+  useEpicAttachmentBytesPresence: () => testState.attachmentPresence,
+}));
+vi.mock("@/stores/epics/canvas/store", () => ({
+  useEpicCanvasStore: {
+    getState: () => ({
+      markChatTitlePending: vi.fn(),
+      clearChatTitlePending: vi.fn(),
+    }),
+  },
+}));
+vi.mock("@/stores/epics/initial-chat-handoff-store", () => ({
+  useInitialChatHandoffStore: {
+    getState: () => ({
+      register: vi.fn(),
+      markInitialTurnStarted: vi.fn(),
+      markFailed: vi.fn(),
+    }),
+  },
+}));
+
+beforeEach(() => {
+  useNewConversationModalStore.getState().resetForTests();
+  useNewConversationModalStore.getState().setContent("epic-1", DIRTY_CONTENT);
+  useNewConversationModalStore.getState().setComposerMode("epic-1", "chat");
+});
+
+afterEach(() => {
+  cleanup();
+  testState.createChat.mockClear();
+  testState.bodySubmit = null;
+  testState.installEditor = null;
+  testState.ingesting = false;
+  testState.attachmentPresence = null;
+  testState.bodyAttachmentPresence = null;
+  useNewConversationModalStore.getState().resetForTests();
+});
+
+describe("NewConversationModalBody direct submit gate", () => {
+  it("passes no paste predicate before snapshot readiness and the predicate afterward", () => {
+    const view = render(
+      <NewConversationModalBody
+        epicId="epic-1"
+        tabId="tab-1"
+        placement={ACTIVE_TILE_PLACEMENT}
+        parentId={null}
+        dismissPickerRef={createRef<(() => boolean) | null>()}
+        onSubmitted={() => undefined}
+      />,
+    );
+
+    expect(testState.bodyAttachmentPresence).toBeNull();
+
+    testState.attachmentPresence = (hash) => hash === "present-hash";
+    view.rerender(
+      <NewConversationModalBody
+        epicId="epic-1"
+        tabId="tab-1"
+        placement={ACTIVE_TILE_PLACEMENT}
+        parentId={null}
+        dismissPickerRef={createRef<(() => boolean) | null>()}
+        onSubmitted={() => undefined}
+      />,
+    );
+
+    expect(testState.bodyAttachmentPresence?.("present-hash")).toBe(true);
+    expect(testState.bodyAttachmentPresence?.("missing-hash")).toBe(false);
+  });
+
+  it("blocks the actual new-conversation submit path while image ingestion is pending", () => {
+    testState.ingesting = true;
+    const view = render(
+      <NewConversationModalBody
+        epicId="epic-1"
+        tabId="tab-1"
+        placement={ACTIVE_TILE_PLACEMENT}
+        parentId={null}
+        dismissPickerRef={createRef<(() => boolean) | null>()}
+        onSubmitted={() => undefined}
+      />,
+    );
+    const installEditor = testState.installEditor;
+    if (installEditor === null) throw new Error("expected ComposerBody seam");
+    installEditor();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit new conversation" }),
+    );
+    expect(testState.createChat).not.toHaveBeenCalled();
+
+    testState.ingesting = false;
+    view.rerender(
+      <NewConversationModalBody
+        epicId="epic-1"
+        tabId="tab-1"
+        placement={ACTIVE_TILE_PLACEMENT}
+        parentId={null}
+        dismissPickerRef={createRef<(() => boolean) | null>()}
+        onSubmitted={() => undefined}
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Submit new conversation" }),
+    );
+    expect(testState.createChat).toHaveBeenCalledTimes(1);
+  });
+});
+
+function editorHandle(): ComposerPromptEditorHandle {
+  return {
+    isReady: () => true,
+    focus: () => undefined,
+    focusAtEnd: () => undefined,
+    getJSON: () => DIRTY_CONTENT,
+    isEmpty: () => false,
+    clear: () => undefined,
+    setContent: () => undefined,
+    insertImageAttachments: () => undefined,
+    removeImageAttachmentById: () => undefined,
+    insertDictatedText: () => undefined,
+    dismissActiveSuggestion: () => false,
+  };
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-conversation-modal.tsx
@@ -19,7 +19,10 @@ import {
   AttachmentStrip,
   NO_SESSION_OBJECT_URL,
 } from "@/components/chat/composer/attachments/attachment-strip";
-import { useEpicImageFetcher } from "@/lib/attachments/use-attachment-blob-src";
+import {
+  useEpicAttachmentBytesPresence,
+  useEpicImageFetcher,
+} from "@/lib/attachments/use-attachment-blob-src";
 import { DialogOverlayBoundaryContext } from "@/providers/dialog-overlay-boundary-context";
 import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
 import { createComposerPickerStore } from "@/components/chat/composer/picker/composer-picker-store";
@@ -398,7 +401,7 @@ function NewConversationModalHeader(props: {
   );
 }
 
-function NewConversationModalBody(props: {
+export function NewConversationModalBody(props: {
   readonly epicId: string;
   readonly tabId: string;
   readonly placement: ConversationTilePlacement;
@@ -556,12 +559,18 @@ function NewConversationModalBody(props: {
   );
   const workspaceCanStart = workspaceComposerCanStart(workspaceAvailability);
   const draftWorkspaceFolderCount = draftWorkspace.folders.length;
+  const paste = useComposerPaste(editorRef);
+  const attachmentPending = paste.isIngestingImages;
   const canSubmit =
-    canMutate && !isSubmitting && workspaceCanStart && hasSubmittableContent;
+    canMutate &&
+    !isSubmitting &&
+    !attachmentPending &&
+    workspaceCanStart &&
+    hasSubmittableContent;
   const composerDisabledHint =
     mutationDisabledHint(permissionRole, isDisconnected, "make changes") ??
     workspaceAvailability.disabledHint;
-  const paste = useComposerPaste(editorRef);
+  const hasPastedImageBytes = useEpicAttachmentBytesPresence();
   const { dictationControl, dictationPreparing } = useComposerDictation({
     editorRef,
     isActive: chatComposerActive,
@@ -816,6 +825,7 @@ function NewConversationModalBody(props: {
       initialSelection={null}
       canSubmit={canSubmit}
       isSubmitting={isSubmitting}
+      attachmentPending={attachmentPending}
       workspaceDisabledHint={composerDisabledHint}
       header={header}
       attachmentsStrip={
@@ -829,6 +839,7 @@ function NewConversationModalBody(props: {
       dictationControl={dictationControl}
       dictationPreparing={dictationPreparing}
       paste={paste}
+      hasPastedImageBytes={hasPastedImageBytes}
       onSubmit={handleSubmit}
       onStartTerminal={handleStartTerminal}
       onSnapshot={handleSnapshot}

--- a/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ComposerSendButton } from "../composer-send-button";
+
+afterEach(() => cleanup());
+
+describe("ComposerSendButton attachment preparation", () => {
+  it("shows visible pending feedback while attachment work gates submit", () => {
+    render(
+      <ComposerSendButton
+        canSubmit={false}
+        attachmentPending
+        onSubmit={() => undefined}
+        activeTurnStatus={null}
+        stopDisabled
+        onStopTurn={null}
+        disabledHint={null}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Preparing attachments" })
+        .getAttribute("disabled"),
+    ).not.toBeNull();
+    expect(screen.getByTestId("composer-attachment-pending")).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/composer-send-button.test.tsx
@@ -20,9 +20,7 @@ describe("ComposerSendButton attachment preparation", () => {
     );
 
     expect(
-      screen
-        .getByRole("button", { name: "Preparing attachments" })
-        .getAttribute("disabled"),
+      screen.getByRole("button", { name: "Send" }).getAttribute("disabled"),
     ).not.toBeNull();
     expect(screen.getByTestId("composer-attachment-pending")).toBeTruthy();
   });

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-submit-gate.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-submit-gate.test.tsx
@@ -1,0 +1,220 @@
+import "../../../../../__tests__/test-browser-apis";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createStore } from "zustand/vanilla";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+
+import type { ComposerBodyProps } from "@/components/home/composer/composer-body";
+import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { LandingComposer } from "../landing-composer";
+
+const DIRTY_CONTENT: JsonContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "dirty" }] }],
+};
+
+const testState = vi.hoisted(() => ({
+  submit: vi.fn(),
+  bodySubmit: null as (() => void) | null,
+  installEditor: null as (() => void) | null,
+  ingesting: false,
+}));
+
+vi.mock("@/components/home/composer/composer-body", async () => {
+  const React = await import("react");
+  return {
+    ComposerBody: (props: ComposerBodyProps) => {
+      testState.bodySubmit = props.onSubmit;
+      testState.installEditor = () => {
+        props.editorRef.current = editorHandle();
+      };
+      return React.createElement(
+        "button",
+        { type: "button", onClick: props.onSubmit },
+        "Submit landing",
+      );
+    },
+  };
+});
+
+vi.mock("@/stores/composer/landing-composer-store", () => {
+  const dirtyContent = {
+    type: "doc",
+    content: [
+      { type: "paragraph", content: [{ type: "text", text: "dirty" }] },
+    ],
+  };
+  const state = {
+    currentContent: dirtyContent,
+    setSnapshot: vi.fn(),
+    openDraft: () => dirtyContent,
+  };
+  const useLandingComposerStore = Object.assign(
+    (selector: (value: typeof state) => unknown) => selector(state),
+    { getState: () => state },
+  );
+  return {
+    useLandingComposerStore,
+    flushPendingLandingDraftContent: vi.fn(),
+  };
+});
+
+vi.mock("@/stores/settings/settings-store", () => {
+  const state = { composerMode: "chat", setComposerMode: vi.fn() };
+  return {
+    useSettingsStore: (selector: (value: typeof state) => unknown) =>
+      selector(state),
+  };
+});
+
+vi.mock("@/stores/home/landing-draft-store", () => {
+  const state = {
+    drafts: [],
+    setDraftComposerMode: vi.fn(),
+    setDraftSettings: vi.fn(),
+  };
+  return {
+    useLandingDraftStore: (selector: (value: typeof state) => unknown) =>
+      selector(state),
+  };
+});
+
+vi.mock("@/stores/composer/composer-run-settings-store", () => {
+  const state = {
+    globalLastRunSettings: null,
+    setGlobalRunSettings: vi.fn(),
+  };
+  return {
+    useComposerRunSettingsStore: (selector: (value: typeof state) => unknown) =>
+      selector(state),
+  };
+});
+
+vi.mock("@/components/home/hooks/use-composer-toolbar-store", () => {
+  const toolbarStore = createStore(() => ({
+    selection: {
+      harnessId: "claude",
+      modelSlug: "claude-sonnet",
+      profileId: null,
+    },
+    permission: "supervised",
+    reasoning: "medium",
+    serviceTier: "",
+    agentMode: "regular",
+  }));
+  return { useComposerToolbarStore: () => toolbarStore };
+});
+
+vi.mock("@/components/home/hooks/use-landing-composer-actions", () => ({
+  useLandingComposerActions: () => ({
+    submit: testState.submit,
+    selectTerminalAgent: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/composer/use-landing-composer-paste", () => ({
+  useLandingComposerPaste: () => ({
+    onPaste: vi.fn(),
+    onDrop: vi.fn(),
+    onDragOver: vi.fn(),
+    onDragEnter: vi.fn(),
+    onDragLeave: vi.fn(),
+    attachImageFiles: vi.fn(),
+    isDraggingFiles: false,
+    isIngestingImages: testState.ingesting,
+  }),
+}));
+
+vi.mock("@/hooks/workspace/use-resolved-workspace-folders-query", () => ({
+  useResolvedWorkspaceFolders: () => ({ folders: [], isLoading: false }),
+}));
+
+vi.mock("@/lib/composer/workspace-composer-availability", () => ({
+  deriveFolderlessAllowedWorkspaceAvailability: () => ({
+    disabledHint: null,
+  }),
+  workspaceComposerCanStart: () => true,
+}));
+
+vi.mock("@/components/home/composer/surface-activity-hooks", () => ({
+  useSurfaceActivity: () => true,
+}));
+vi.mock("@/components/chat/composer/picker/use-composer-picker-items", () => ({
+  useComposerPickerItems: () => undefined,
+}));
+vi.mock("@/hooks/composer/use-workspace-mention-roots", () => ({
+  useLandingComposerMentionRoots: () => [],
+}));
+vi.mock("@/hooks/composer/use-composer-dictation", () => ({
+  useComposerDictation: () => ({
+    dictationControl: null,
+    dictationPreparing: null,
+  }),
+}));
+vi.mock("@/hooks/composer/use-landing-image-fetcher", () => ({
+  useLandingImageFetcher: () => vi.fn(),
+}));
+vi.mock("@/hooks/epic/use-epic-create-mutation", () => ({
+  useEpicCreate: () => ({ isPending: false }),
+}));
+vi.mock("@/hooks/agent/use-create-tui-agent", () => ({
+  useCreateTuiAgent: () => ({ isPending: false }),
+}));
+vi.mock("@/lib/host", () => ({
+  useHostBinding: () => null,
+  useHostClient: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+  testState.submit.mockClear();
+  testState.bodySubmit = null;
+  testState.installEditor = null;
+  testState.ingesting = false;
+});
+
+describe("LandingComposer direct submit gate", () => {
+  it("blocks the actual landing submit path while image ingestion is pending", () => {
+    testState.ingesting = true;
+    const view = render(
+      <LandingComposer
+        draftId={null}
+        initialSettings={null}
+        workspaceControls={null}
+      />,
+    );
+    const installEditor = testState.installEditor;
+    if (installEditor === null) throw new Error("expected ComposerBody seam");
+    installEditor();
+
+    fireEvent.click(screen.getByRole("button", { name: "Submit landing" }));
+    expect(testState.submit).not.toHaveBeenCalled();
+
+    testState.ingesting = false;
+    view.rerender(
+      <LandingComposer
+        draftId={null}
+        initialSettings={null}
+        workspaceControls={null}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Submit landing" }));
+    expect(testState.submit).toHaveBeenCalledTimes(1);
+  });
+});
+
+function editorHandle(): ComposerPromptEditorHandle {
+  return {
+    isReady: () => true,
+    focus: () => undefined,
+    focusAtEnd: () => undefined,
+    getJSON: () => DIRTY_CONTENT,
+    isEmpty: () => false,
+    clear: () => undefined,
+    setContent: () => undefined,
+    insertImageAttachments: () => undefined,
+    removeImageAttachmentById: () => undefined,
+    insertDictatedText: () => undefined,
+    dismissActiveSuggestion: () => false,
+  };
+}

--- a/clients/gui-app/src/components/home/composer/composer-body.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-body.tsx
@@ -36,6 +36,7 @@ export interface ComposerBodyProps {
   } | null;
   readonly canSubmit: boolean;
   readonly isSubmitting: boolean;
+  readonly attachmentPending: boolean;
   readonly workspaceDisabledHint: string | null;
   readonly header: ReactNode;
   readonly attachmentsStrip: ReactNode;
@@ -43,6 +44,7 @@ export interface ComposerBodyProps {
   readonly dictationControl: ComposerDictationControl | null;
   readonly dictationPreparing: DictationPreparingStatus | null;
   readonly paste: UseComposerPasteResult;
+  readonly hasPastedImageBytes: ((hash: string) => boolean) | null;
   readonly onSubmit: () => void;
   readonly onStartTerminal: (launch: TerminalAgentLaunch) => void;
   readonly onSnapshot: (
@@ -62,6 +64,7 @@ export function ComposerBody({
   initialSelection,
   canSubmit,
   isSubmitting,
+  attachmentPending,
   workspaceDisabledHint,
   header,
   attachmentsStrip,
@@ -69,6 +72,7 @@ export function ComposerBody({
   dictationControl,
   dictationPreparing,
   paste,
+  hasPastedImageBytes,
   onSubmit,
   onStartTerminal,
   onSnapshot,
@@ -98,6 +102,7 @@ export function ComposerBody({
                 initialContent={initialContent}
                 initialSelection={initialSelection}
                 slashProviderId={harnessId}
+                hasPastedImageBytes={hasPastedImageBytes}
                 isActive={chatEditorIsActive}
                 disabled={false}
                 placeholder={COMPOSER_PLACEHOLDER}
@@ -135,6 +140,7 @@ export function ComposerBody({
                 showNextTurnPermissionNote={false}
                 showAgentModeTooltip={showLandingAgentModeTooltip}
                 canSubmit={canSubmit}
+                attachmentPending={attachmentPending}
                 onSubmit={onSubmit}
                 activeTurnStatus={null}
                 stopDisabled

--- a/clients/gui-app/src/components/home/composer/composer-send-button.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-send-button.tsx
@@ -35,10 +35,7 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
   const disabled = stopMode
     ? stopDisabled || onStopTurn === null
     : !canSubmit || disabledHint !== null;
-  const label =
-    attachmentPending && !stopMode
-      ? "Preparing attachments"
-      : composerSendButtonLabel(activeTurnStatus);
+  const label = composerSendButtonLabel(activeTurnStatus);
   // Hint mode (e.g. no workspace) marks the button `aria-disabled` rather than
   // using the `disabled` attribute, so it stays focusable and the styled
   // TooltipWrapper's hint is reachable by hover and keyboard focus (a native

--- a/clients/gui-app/src/components/home/composer/composer-send-button.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-send-button.tsx
@@ -1,12 +1,14 @@
 import { ArrowUp, Square } from "lucide-react";
-import { memo, useCallback } from "react";
+import { memo, useCallback, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import type { ChatActiveTurn } from "@traycer/protocol/host/agent/gui/subscribe";
 import { cn } from "@/lib/utils";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 
 interface ComposerSendButtonProps {
   canSubmit: boolean;
+  attachmentPending: boolean;
   onSubmit: () => void;
   activeTurnStatus: ChatActiveTurn["status"] | null;
   stopDisabled: boolean;
@@ -22,6 +24,7 @@ interface ComposerSendButtonProps {
 function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
   const {
     canSubmit,
+    attachmentPending,
     onSubmit,
     activeTurnStatus,
     stopDisabled,
@@ -32,7 +35,10 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
   const disabled = stopMode
     ? stopDisabled || onStopTurn === null
     : !canSubmit || disabledHint !== null;
-  const label = composerSendButtonLabel(activeTurnStatus);
+  const label =
+    attachmentPending && !stopMode
+      ? "Preparing attachments"
+      : composerSendButtonLabel(activeTurnStatus);
   // Hint mode (e.g. no workspace) marks the button `aria-disabled` rather than
   // using the `disabled` attribute, so it stays focusable and the styled
   // TooltipWrapper's hint is reachable by hover and keyboard focus (a native
@@ -68,11 +74,7 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
       data-testid={stopMode ? "chat-stop-button" : undefined}
       className={buttonClassName}
     >
-      {stopMode ? (
-        <Square className="size-3.5 fill-current" />
-      ) : (
-        <ArrowUp className="size-4" />
-      )}
+      {composerSendButtonIcon(attachmentPending, stopMode)}
     </Button>
   );
 
@@ -91,6 +93,23 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
 }
 
 export const ComposerSendButton = memo(ComposerSendButtonImpl);
+
+function composerSendButtonIcon(
+  attachmentPending: boolean,
+  stopMode: boolean,
+): ReactNode {
+  if (attachmentPending && !stopMode) {
+    return (
+      <AgentSpinningDots
+        className="text-current"
+        testId="composer-attachment-pending"
+        variant={undefined}
+      />
+    );
+  }
+  if (stopMode) return <Square className="size-3.5 fill-current" />;
+  return <ArrowUp className="size-4" />;
+}
 
 function composerSendButtonLabel(
   activeTurnStatus: ChatActiveTurn["status"] | null,

--- a/clients/gui-app/src/components/home/composer/landing-composer.tsx
+++ b/clients/gui-app/src/components/home/composer/landing-composer.tsx
@@ -187,10 +187,15 @@ export function LandingComposer(props: LandingComposerProps) {
     ],
   );
   const workspaceCanStart = workspaceComposerCanStart(workspaceAvailability);
-  const canSubmit = !isSubmitting && workspaceCanStart && hasSubmittableContent;
+  const paste = useLandingComposerPaste(editorRef);
+  const attachmentPending = paste.isIngestingImages;
+  const canSubmit =
+    !isSubmitting &&
+    !attachmentPending &&
+    workspaceCanStart &&
+    hasSubmittableContent;
 
   const actions = useLandingComposerActions();
-  const paste = useLandingComposerPaste(editorRef);
   const { dictationControl, dictationPreparing } = useComposerDictation({
     editorRef,
     isActive: chatComposerActive,
@@ -269,6 +274,7 @@ export function LandingComposer(props: LandingComposerProps) {
       initialSelection={initialSelection}
       canSubmit={canSubmit}
       isSubmitting={isSubmitting}
+      attachmentPending={attachmentPending}
       workspaceDisabledHint={workspaceAvailability.disabledHint}
       header={<div className="flex justify-end">{switcher}</div>}
       attachmentsStrip={
@@ -278,6 +284,7 @@ export function LandingComposer(props: LandingComposerProps) {
       dictationControl={dictationControl}
       dictationPreparing={dictationPreparing}
       paste={paste}
+      hasPastedImageBytes={null}
       onSubmit={handleSubmit}
       onStartTerminal={handleStartTerminal}
       onSnapshot={handleSnapshot}

--- a/clients/gui-app/src/components/home/toolbar/composer-toolbar-right.tsx
+++ b/clients/gui-app/src/components/home/toolbar/composer-toolbar-right.tsx
@@ -15,6 +15,7 @@ import type { ComposerToolbarStore } from "@/stores/composer/composer-toolbar-st
 interface ComposerToolbarRightProps {
   store: ComposerToolbarStore;
   canSubmit: boolean;
+  attachmentPending: boolean;
   onSubmit: () => void;
   activeTurnStatus: ChatActiveTurn["status"] | null;
   stopDisabled: boolean;
@@ -35,6 +36,7 @@ function ComposerToolbarRightImpl(props: ComposerToolbarRightProps) {
   const {
     store,
     canSubmit,
+    attachmentPending,
     onSubmit,
     activeTurnStatus,
     stopDisabled,
@@ -75,6 +77,7 @@ function ComposerToolbarRightImpl(props: ComposerToolbarRightProps) {
       ) : null}
       <ComposerSendButton
         canSubmit={canSubmitResolved}
+        attachmentPending={attachmentPending}
         onSubmit={onSubmit}
         activeTurnStatus={activeTurnStatus}
         stopDisabled={stopDisabled}

--- a/clients/gui-app/src/components/home/toolbar/composer-toolbar.tsx
+++ b/clients/gui-app/src/components/home/toolbar/composer-toolbar.tsx
@@ -17,6 +17,7 @@ interface ComposerToolbarProps {
   showNextTurnPermissionNote: boolean;
   showAgentModeTooltip: boolean;
   canSubmit: boolean;
+  attachmentPending: boolean;
   onSubmit: () => void;
   activeTurnStatus: ChatActiveTurn["status"] | null;
   stopDisabled: boolean;
@@ -49,6 +50,7 @@ function ComposerToolbarImpl(props: ComposerToolbarProps) {
     showNextTurnPermissionNote,
     showAgentModeTooltip,
     canSubmit,
+    attachmentPending,
     onSubmit,
     activeTurnStatus,
     stopDisabled,
@@ -111,6 +113,7 @@ function ComposerToolbarImpl(props: ComposerToolbarProps) {
           <ComposerToolbarRight
             store={store}
             canSubmit={canSubmit}
+            attachmentPending={attachmentPending}
             onSubmit={onSubmit}
             activeTurnStatus={activeTurnStatus}
             stopDisabled={stopDisabled}

--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -372,6 +372,7 @@ function createDirtyEpicHandle(
     reparentArtifact: () => false,
     setEpicTitle: () => false,
     readAttachmentBytes: () => Promise.resolve(null),
+    hasAttachmentBytes: () => false,
     getArtifactFragment: () => null,
     getArtifactBodyAwareness: () => null,
     getArtifactBodyAvailability: () => "unavailable",

--- a/clients/gui-app/src/hooks/composer/__tests__/use-composer-paste.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-composer-paste.test.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 import {
   useComposerPaste,
   useComposerPasteAdapter,
+  IMAGE_READ_TIMEOUT_MS,
   type UseComposerPasteResult,
 } from "@/hooks/composer/use-composer-paste";
 import type { ImageAttachmentAttrs } from "@/components/chat/composer/editor/extensions/image-attachment-extension";
@@ -27,9 +28,103 @@ vi.mock("sonner", () => ({
 afterEach(() => {
   cleanup();
   vi.mocked(toast.error).mockClear();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe("useComposerPasteAdapter - attachImageFiles", () => {
+  it("exposes ingestion as pending until the FileReader settles", async () => {
+    const delayedReader = installDelayedFileReader();
+    const insert = vi.fn(
+      (_attrs: ReadonlyArray<ImageAttachmentAttrs>): number => 1,
+    );
+    const { result } = renderHook(() => useComposerPasteAdapter(insert));
+
+    attachImageFiles(result.current, [
+      new File(["pending"], "pending.png", { type: "image/png" }),
+    ]);
+
+    expect(result.current.isIngestingImages).toBe(true);
+    expect(insert).not.toHaveBeenCalled();
+    delayedReader.resolveNext("data:image/png;base64,cGVuZGluZw==");
+    await waitFor(() => {
+      expect(result.current.isIngestingImages).toBe(false);
+    });
+    expect(insert).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the gate and reports a FileReader rejection", async () => {
+    const delayedReader = installDelayedFileReader();
+    const insert = vi.fn(
+      (_attrs: ReadonlyArray<ImageAttachmentAttrs>): number => 1,
+    );
+    const { result } = renderHook(() => useComposerPasteAdapter(insert));
+
+    attachImageFiles(result.current, [
+      new File(["broken"], "broken.png", { type: "image/png" }),
+    ]);
+    delayedReader.rejectNext();
+
+    await waitFor(() => {
+      expect(result.current.isIngestingImages).toBe(false);
+    });
+    expect(insert).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't attach the image.",
+      expect.objectContaining({ description: "Please try adding it again." }),
+    );
+  });
+
+  it("times out a non-settling FileReader and releases the gate", async () => {
+    vi.useFakeTimers();
+    installDelayedFileReader();
+    const insert = vi.fn(
+      (_attrs: ReadonlyArray<ImageAttachmentAttrs>): number => 1,
+    );
+    const { result } = renderHook(() => useComposerPasteAdapter(insert));
+
+    attachImageFiles(result.current, [
+      new File(["stuck"], "stuck.png", { type: "image/png" }),
+    ]);
+    expect(result.current.isIngestingImages).toBe(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(IMAGE_READ_TIMEOUT_MS);
+    });
+
+    expect(result.current.isIngestingImages).toBe(false);
+    expect(insert).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't attach the image.",
+      expect.objectContaining({ description: "Please try adding it again." }),
+    );
+  });
+
+  it("aborts an in-flight FileReader on unmount without showing a toast", async () => {
+    installDelayedFileReader();
+    const abort = vi
+      .spyOn(FileReader.prototype, "abort")
+      .mockImplementation(() => undefined);
+    const insert = vi.fn(
+      (_attrs: ReadonlyArray<ImageAttachmentAttrs>): number => 1,
+    );
+    const { result, unmount } = renderHook(() =>
+      useComposerPasteAdapter(insert),
+    );
+
+    attachImageFiles(result.current, [
+      new File(["pending"], "pending.png", { type: "image/png" }),
+    ]);
+    expect(result.current.isIngestingImages).toBe(true);
+    unmount();
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(insert).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   it("converts picker-selected image files into image attachment attrs", async () => {
     const inserted: ImageAttachmentAttrs[][] = [];
     const { result } = renderHook(() =>
@@ -319,6 +414,37 @@ function attachImageFiles(
   act(() => {
     result.attachImageFiles(files);
   });
+}
+
+interface DelayedFileReaderControl {
+  readonly resolveNext: (dataUrl: string) => void;
+  readonly rejectNext: () => void;
+}
+
+function installDelayedFileReader(): DelayedFileReaderControl {
+  const pending: FileReader[] = [];
+  vi.spyOn(FileReader.prototype, "readAsDataURL").mockImplementation(function (
+    this: FileReader,
+    _blob: Blob,
+  ) {
+    pending.push(this);
+  });
+  return {
+    resolveNext: (dataUrl) => {
+      const reader = pending.shift();
+      if (reader === undefined) throw new Error("expected pending file read");
+      Object.defineProperty(reader, "result", {
+        configurable: true,
+        value: dataUrl,
+      });
+      reader.dispatchEvent(new ProgressEvent("load"));
+    },
+    rejectNext: () => {
+      const reader = pending.shift();
+      if (reader === undefined) throw new Error("expected pending file read");
+      reader.dispatchEvent(new ProgressEvent("error"));
+    },
+  };
 }
 
 function renderHarness(inserted: ImageAttachmentAttrs[][]) {

--- a/clients/gui-app/src/hooks/composer/__tests__/use-landing-composer-paste.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-landing-composer-paste.test.tsx
@@ -20,7 +20,11 @@ vi.mock("@/lib/composer/landing-image-gc", async (importActual) => {
     await importActual<typeof import("@/lib/composer/landing-image-gc")>();
   return {
     ...actual,
-    scheduleLandingImageReconcile: vi.fn(actual.scheduleLandingImageReconcile),
+    // A no-op stub, not a call-through: the real scheduler starts a 250ms
+    // timer that later calls the real `reconcile()`, which would otherwise
+    // escape this test's boundary and run against a later test's IDB mock
+    // state. Only call presence is asserted here.
+    scheduleLandingImageReconcile: vi.fn(() => undefined),
   };
 });
 

--- a/clients/gui-app/src/hooks/composer/__tests__/use-landing-composer-paste.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-landing-composer-paste.test.tsx
@@ -13,6 +13,16 @@ import {
   releaseSession,
   sessionObjectUrl,
 } from "@/lib/composer/landing-image-store";
+import { scheduleLandingImageReconcile } from "@/lib/composer/landing-image-gc";
+
+vi.mock("@/lib/composer/landing-image-gc", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@/lib/composer/landing-image-gc")>();
+  return {
+    ...actual,
+    scheduleLandingImageReconcile: vi.fn(actual.scheduleLandingImageReconcile),
+  };
+});
 
 // In-memory stand-in for idb-keyval so `putImage` can persist + read back bytes
 // without a real IndexedDB. Mirrors the landing-image-store unit test.
@@ -50,6 +60,7 @@ beforeEach(async () => {
     releaseSession(hash);
   }
   vi.mocked(toast.error).mockClear();
+  vi.mocked(scheduleLandingImageReconcile).mockClear();
 });
 
 afterEach(() => {
@@ -201,6 +212,46 @@ describe("useLandingComposerPaste", () => {
       });
     });
     expect(inserted).toHaveLength(0);
+
+    digestSpy.mockRestore();
+  });
+
+  it("schedules a reconcile but suppresses the toast when the composer unmounts mid-ingest", async () => {
+    const inserted: ImageAttachmentAttrs[][] = [];
+    const { handle } = makeHandle(inserted);
+    const editorRef = { current: handle };
+
+    // Hold `putImage`'s hash step open so bytes can be aborted-away between
+    // the (already-persisted) hash write and the node insertion - mirrors
+    // unmounting/navigating away while a paste is still in flight.
+    let resolveDigest: (() => void) | null = null;
+    const digestSpy = vi.spyOn(crypto.subtle, "digest").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveDigest = () => resolve(new ArrayBuffer(32));
+        }),
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useLandingComposerPaste(editorRef),
+    );
+    const file = new File(["hello"], "shot.png", { type: "image/png" });
+    act(() => {
+      result.current.attachImageFiles([file]);
+    });
+
+    await waitFor(() => expect(resolveDigest).not.toBeNull());
+    unmount();
+
+    await act(async () => {
+      resolveDigest?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(inserted).toHaveLength(0);
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(scheduleLandingImageReconcile).toHaveBeenCalled();
 
     digestSpy.mockRestore();
   });

--- a/clients/gui-app/src/hooks/composer/use-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-composer-paste.ts
@@ -1,5 +1,7 @@
 import {
   useCallback,
+  useEffect,
+  useRef,
   useState,
   type ClipboardEvent,
   type DragEvent,
@@ -17,21 +19,55 @@ import {
 
 export const IMAGE_MIME_PREFIX = "image/";
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+export const IMAGE_READ_TIMEOUT_MS = 15_000;
 
-function readFileAsDataUrl(file: File): Promise<string> {
+function readFileAsDataUrl(file: File, signal: AbortSignal): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
+    let settled = false;
+    const cleanup = (): void => {
+      window.clearTimeout(timeout);
+      signal.removeEventListener("abort", abort);
+      reader.onerror = null;
+      reader.onload = null;
+      reader.onabort = null;
+    };
+    const fail = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    };
+    const abort = (): void => {
+      reader.abort();
+      fail(new Error("Image read was cancelled"));
+    };
+    const timeout = window.setTimeout(() => {
+      reader.abort();
+      fail(new Error("Timed out while reading image"));
+    }, IMAGE_READ_TIMEOUT_MS);
     reader.onerror = () => {
-      reject(reader.error ?? new Error("Failed to read image"));
+      fail(reader.error ?? new Error("Failed to read image"));
+    };
+    reader.onabort = () => {
+      fail(new Error("Image read was cancelled"));
     };
     reader.onload = () => {
       const result = reader.result;
       if (typeof result !== "string") {
-        reject(new Error("Image reader returned non-string result"));
+        fail(new Error("Image reader returned non-string result"));
         return;
       }
+      if (settled) return;
+      settled = true;
+      cleanup();
       resolve(result);
     };
+    if (signal.aborted) {
+      abort();
+      return;
+    }
+    signal.addEventListener("abort", abort, { once: true });
     reader.readAsDataURL(file);
   });
 }
@@ -71,6 +107,7 @@ export function collectImages(
 
 async function filesToImageAttrs(
   files: ReadonlyArray<File>,
+  signal: AbortSignal,
 ): Promise<ImageAttachmentAttrs[]> {
   // This base64 ingest serves only chat / new-conversation surfaces.
   const accepted = collectImages(files, () => {
@@ -83,7 +120,7 @@ async function filesToImageAttrs(
   if (accepted.length === 0) return [];
   const results = await Promise.all(
     accepted.map(async (file) => {
-      const dataUrl = await readFileAsDataUrl(file);
+      const dataUrl = await readFileAsDataUrl(file, signal);
       return {
         id: uuidv4(),
         fileName: file.name || "image",
@@ -109,6 +146,7 @@ export interface UseComposerPasteResult {
   onDragLeave: (event: DragEvent<HTMLElement>) => void;
   attachImageFiles: (files: ReadonlyArray<File>) => void;
   isDraggingFiles: boolean;
+  isIngestingImages: boolean;
 }
 
 function dataTransferHasFiles(event: DragEvent<HTMLElement>): boolean {
@@ -123,14 +161,34 @@ function dataTransferHasFiles(event: DragEvent<HTMLElement>): boolean {
  * for chat / new-conversation, `useLandingComposerPaste` (hash-only) for landing.
  */
 export function useComposerPasteEvents(
-  onFiles: (files: ReadonlyArray<File>) => void,
+  onFiles: (files: ReadonlyArray<File>, signal: AbortSignal) => Promise<void>,
 ): UseComposerPasteResult {
   const [dragDepth, setDragDepth] = useState(0);
+  const [pendingImageCount, setPendingImageCount] = useState(0);
+  const activeRef = useRef(true);
+  const controllersRef = useRef(new Set<AbortController>());
+
+  useEffect(() => {
+    activeRef.current = true;
+    const controllers = controllersRef.current;
+    return () => {
+      activeRef.current = false;
+      controllers.forEach((controller) => controller.abort());
+      controllers.clear();
+    };
+  }, []);
 
   const attachImageFiles = useCallback(
     (files: ReadonlyArray<File>) => {
       if (files.length === 0) return;
-      onFiles(files);
+      const controller = new AbortController();
+      controllersRef.current.add(controller);
+      setPendingImageCount((count) => count + 1);
+      void onFiles(files, controller.signal).finally(() => {
+        controllersRef.current.delete(controller);
+        if (!activeRef.current) return;
+        setPendingImageCount((count) => Math.max(0, count - 1));
+      });
     },
     [onFiles],
   );
@@ -192,6 +250,7 @@ export function useComposerPasteEvents(
     onDragLeave,
     attachImageFiles,
     isDraggingFiles: dragDepth > 0,
+    isIngestingImages: pendingImageCount > 0,
   };
 }
 
@@ -204,8 +263,8 @@ export function useComposerPasteAdapter(
   insertAttrs: (attrs: ReadonlyArray<ImageAttachmentAttrs>) => number,
 ): UseComposerPasteResult {
   const onFiles = useCallback(
-    (files: ReadonlyArray<File>) => {
-      void filesToImageAttrs(files)
+    (files: ReadonlyArray<File>, signal: AbortSignal) =>
+      filesToImageAttrs(files, signal)
         .then((attrs) => {
           if (attrs.length > 0) {
             const acceptedCount = Math.min(
@@ -221,15 +280,25 @@ export function useComposerPasteAdapter(
           }
         })
         .catch((error: unknown) => {
-          // A FileReader failure previously surfaced only as an unhandled
-          // rejection; record it so chat rejections exist in the funnel.
           Analytics.getInstance().track(AnalyticsEvent.AttachmentRejected, {
             kind: "image",
             surface: "chat",
             blocker: analyticsBlockerFromError(error),
           });
-        });
-    },
+          if (signal.aborted) return;
+          reportableErrorToast(
+            "Couldn't attach the image.",
+            {
+              description: "Please try adding it again.",
+            },
+            {
+              title: "Could not attach image",
+              message: null,
+              code: null,
+              source: "Chat composer",
+            },
+          );
+        }),
     [insertAttrs],
   );
   return useComposerPasteEvents(onFiles);

--- a/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
@@ -34,6 +34,7 @@ import {
  */
 async function landingImageAttrsFromFiles(
   files: ReadonlyArray<File>,
+  signal: AbortSignal,
 ): Promise<ImageAttachmentAttrs[]> {
   const accepted = collectImages(files, () => {
     Analytics.getInstance().track(AnalyticsEvent.AttachmentRejected, {
@@ -59,8 +60,11 @@ async function landingImageAttrsFromFiles(
   }
   return Promise.all(
     accepted.map(async (file) => {
+      signal.throwIfAborted();
       const bytes = new Uint8Array(await file.arrayBuffer());
+      signal.throwIfAborted();
       const hash = await putImage(bytes);
+      signal.throwIfAborted();
       return {
         id: uuidv4(),
         fileName: file.name || "image",
@@ -76,8 +80,8 @@ export function useLandingComposerPaste(editorRef: {
   readonly current: ComposerPasteEditorHandle | null;
 }): UseComposerPasteResult {
   const onFiles = useCallback(
-    (files: ReadonlyArray<File>) => {
-      void landingImageAttrsFromFiles(files)
+    (files: ReadonlyArray<File>, signal: AbortSignal) =>
+      landingImageAttrsFromFiles(files, signal)
         .then((attrs) => {
           if (attrs.length === 0) return;
           const handle = editorRef.current;
@@ -103,6 +107,7 @@ export function useLandingComposerPaste(editorRef: {
             surface: "draft",
             blocker: analyticsBlockerFromError(error),
           });
+          if (signal.aborted) return;
           // A failed ingest (e.g. one image of a multi-image paste failed to hash
           // or store) inserts nothing, but earlier images may already be stored —
           // now orphaned. Surface the failure and schedule a reconcile to reclaim
@@ -120,8 +125,7 @@ export function useLandingComposerPaste(editorRef: {
             },
           );
           scheduleLandingImageReconcile();
-        });
-    },
+        }),
     [editorRef],
   );
   return useComposerPasteEvents(onFiles);

--- a/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
+++ b/clients/gui-app/src/hooks/composer/use-landing-composer-paste.ts
@@ -107,23 +107,26 @@ export function useLandingComposerPaste(editorRef: {
             surface: "draft",
             blocker: analyticsBlockerFromError(error),
           });
-          if (signal.aborted) return;
-          // A failed ingest (e.g. one image of a multi-image paste failed to hash
-          // or store) inserts nothing, but earlier images may already be stored —
-          // now orphaned. Surface the failure and schedule a reconcile to reclaim
-          // them (their session entries keep the bytes safe until it runs).
-          reportableErrorToast(
-            "Couldn't attach the image.",
-            {
-              description: "Please try adding it again.",
-            },
-            {
-              title: "Could not attach image",
-              message: null,
-              code: null,
-              source: "Chat composer",
-            },
-          );
+          // A failed or aborted ingest (e.g. one image of a multi-image paste
+          // failed to hash/store, or the composer unmounted mid-flight)
+          // inserts nothing, but earlier images may already be stored - now
+          // orphaned. Schedule a reconcile to reclaim them (their session
+          // entries keep the bytes safe until it runs) regardless of cause;
+          // only the user-facing failure toast is abort-specific.
+          if (!signal.aborted) {
+            reportableErrorToast(
+              "Couldn't attach the image.",
+              {
+                description: "Please try adding it again.",
+              },
+              {
+                title: "Could not attach image",
+                message: null,
+                code: null,
+                source: "Chat composer",
+              },
+            );
+          }
           scheduleLandingImageReconcile();
         }),
     [editorRef],

--- a/clients/gui-app/src/lib/attachments/__tests__/use-attachment-blob-src.test.tsx
+++ b/clients/gui-app/src/lib/attachments/__tests__/use-attachment-blob-src.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useEpicAttachmentBytesPresence } from "@/lib/attachments/use-attachment-blob-src";
+
+const mocks = vi.hoisted(() => ({
+  snapshotLoaded: false,
+  hasAttachmentBytes: vi.fn((hash: string) => hash === "present-hash"),
+}));
+
+vi.mock("@/providers/use-open-epic-handle", () => ({
+  useMaybeOpenEpicHandle: () => null,
+  useOpenEpicHandle: () => ({
+    store: {
+      getState: () => ({
+        hasAttachmentBytes: mocks.hasAttachmentBytes,
+      }),
+    },
+  }),
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicSnapshotLoaded: () => mocks.snapshotLoaded,
+}));
+
+afterEach(() => {
+  mocks.snapshotLoaded = false;
+  mocks.hasAttachmentBytes.mockClear();
+});
+
+describe("useEpicAttachmentBytesPresence", () => {
+  it("returns no predicate until the root snapshot is loaded", () => {
+    const { result, rerender } = renderHook(() =>
+      useEpicAttachmentBytesPresence(),
+    );
+
+    expect(result.current).toBeNull();
+
+    mocks.snapshotLoaded = true;
+    rerender();
+
+    const hasAttachmentBytes = result.current;
+    if (hasAttachmentBytes === null) {
+      throw new Error("expected attachment presence after snapshot readiness");
+    }
+    expect(hasAttachmentBytes("present-hash")).toBe(true);
+    expect(hasAttachmentBytes("missing-hash")).toBe(false);
+  });
+});

--- a/clients/gui-app/src/lib/attachments/__tests__/use-image-blob-url.test.tsx
+++ b/clients/gui-app/src/lib/attachments/__tests__/use-image-blob-url.test.tsx
@@ -1,0 +1,200 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { imageBlobCache } from "@/lib/attachments/image-blob-cache";
+import {
+  IMAGE_FETCH_MAX_ATTEMPTS,
+  IMAGE_FETCH_RETRY_BASE_MS,
+  IMAGE_FETCH_RETRY_MAX_MS,
+  IMAGE_UNAVAILABLE_GRACE_MS,
+  useImageBlobUrlState,
+} from "@/lib/attachments/use-image-blob-url";
+
+describe("useImageBlobUrlState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("becomes unavailable after the grace period and recovers from late bytes", async () => {
+    let resolveFetch: ((url: string) => void) | null = null;
+    const pendingUrl = new Promise<string>((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.spyOn(imageBlobCache, "acquire").mockReturnValue(pendingUrl);
+    const release = vi
+      .spyOn(imageBlobCache, "release")
+      .mockImplementation(() => {});
+    const fetcher = vi.fn(() => Promise.resolve(new Uint8Array([1])));
+
+    const { result, unmount } = renderHook(() =>
+      useImageBlobUrlState(
+        "late-hash",
+        "image/png",
+        fetcher,
+        IMAGE_UNAVAILABLE_GRACE_MS,
+      ),
+    );
+
+    expect(result.current).toEqual({ status: "loading", url: null });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(IMAGE_UNAVAILABLE_GRACE_MS);
+    });
+    expect(result.current).toEqual({ status: "unavailable", url: null });
+
+    await act(async () => {
+      resolveFetch?.("blob:late-image");
+      await Promise.resolve();
+    });
+    expect(result.current).toEqual({
+      status: "ready",
+      url: "blob:late-image",
+    });
+
+    unmount();
+    expect(release).toHaveBeenCalledWith("late-hash");
+  });
+
+  it("re-acquires after a rejected fetch without requiring a remount", async () => {
+    const acquire = vi
+      .spyOn(imageBlobCache, "acquire")
+      .mockRejectedValueOnce(new Error("store disposed"))
+      .mockResolvedValueOnce("blob:retried-image");
+    vi.spyOn(imageBlobCache, "release").mockImplementation(() => {});
+    const fetcher = vi.fn(() => Promise.resolve(new Uint8Array([1])));
+
+    const { result } = renderHook(() =>
+      useImageBlobUrlState(
+        "retry-hash",
+        "image/png",
+        fetcher,
+        IMAGE_UNAVAILABLE_GRACE_MS,
+      ),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(acquire).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(IMAGE_FETCH_RETRY_BASE_MS);
+    });
+
+    expect(acquire).toHaveBeenCalledTimes(2);
+    expect(result.current).toEqual({
+      status: "ready",
+      url: "blob:retried-image",
+    });
+  });
+
+  it("stops scheduling acquisitions after the retry budget is exhausted", async () => {
+    const acquire = vi
+      .spyOn(imageBlobCache, "acquire")
+      .mockRejectedValue(new Error("store disposed"));
+    vi.spyOn(imageBlobCache, "release").mockImplementation(() => {});
+    const fetcher = vi.fn(() => Promise.resolve(new Uint8Array([1])));
+
+    const { result } = renderHook(() =>
+      useImageBlobUrlState(
+        "exhausted-hash",
+        "image/png",
+        fetcher,
+        IMAGE_UNAVAILABLE_GRACE_MS,
+      ),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(IMAGE_UNAVAILABLE_GRACE_MS);
+    });
+
+    expect(acquire).toHaveBeenCalledTimes(IMAGE_FETCH_MAX_ATTEMPTS);
+    expect(result.current).toEqual({ status: "unavailable", url: null });
+    expect(vi.getTimerCount()).toBe(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(IMAGE_FETCH_RETRY_MAX_MS * 3);
+    });
+
+    expect(acquire).toHaveBeenCalledTimes(IMAGE_FETCH_MAX_ATTEMPTS);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("cancels a scheduled retry when unmounted", async () => {
+    const acquire = vi
+      .spyOn(imageBlobCache, "acquire")
+      .mockRejectedValue(new Error("store disposed"));
+    vi.spyOn(imageBlobCache, "release").mockImplementation(() => {});
+    const fetcher = vi.fn(() => Promise.resolve(new Uint8Array([1])));
+
+    const { unmount } = renderHook(() =>
+      useImageBlobUrlState(
+        "unmounted-hash",
+        "image/png",
+        fetcher,
+        IMAGE_UNAVAILABLE_GRACE_MS,
+      ),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(acquire).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(IMAGE_UNAVAILABLE_GRACE_MS);
+    });
+    expect(acquire).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms the retry budget when the fetcher dependency changes", async () => {
+    const rejectedFetcher = vi.fn(() => Promise.resolve(new Uint8Array([1])));
+    const recoveredFetcher = vi.fn(() => Promise.resolve(new Uint8Array([2])));
+    const acquire = vi
+      .spyOn(imageBlobCache, "acquire")
+      .mockImplementation((_hash, _mediaType, fetcher) =>
+        fetcher === recoveredFetcher
+          ? Promise.resolve("blob:rearmed-image")
+          : Promise.reject(new Error("store disposed")),
+      );
+    vi.spyOn(imageBlobCache, "release").mockImplementation(() => {});
+
+    const { result, rerender } = renderHook(
+      ({ fetcher }) =>
+        useImageBlobUrlState(
+          "rearmed-hash",
+          "image/png",
+          fetcher,
+          IMAGE_UNAVAILABLE_GRACE_MS,
+        ),
+      { initialProps: { fetcher: rejectedFetcher } },
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(IMAGE_UNAVAILABLE_GRACE_MS);
+    });
+    expect(acquire).toHaveBeenCalledTimes(IMAGE_FETCH_MAX_ATTEMPTS);
+    expect(result.current).toEqual({ status: "unavailable", url: null });
+
+    rerender({ fetcher: recoveredFetcher });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(acquire).toHaveBeenCalledTimes(IMAGE_FETCH_MAX_ATTEMPTS + 1);
+    expect(result.current).toEqual({
+      status: "ready",
+      url: "blob:rearmed-image",
+    });
+  });
+});

--- a/clients/gui-app/src/lib/attachments/use-attachment-blob-src.ts
+++ b/clients/gui-app/src/lib/attachments/use-attachment-blob-src.ts
@@ -1,8 +1,20 @@
 import { useCallback } from "react";
 
-import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import {
+  useMaybeOpenEpicHandle,
+  useOpenEpicHandle,
+} from "@/providers/use-open-epic-handle";
+import { useEpicSnapshotLoaded } from "@/lib/epic-selectors";
 import { type ImageBytesFetcher } from "@/lib/attachments/image-blob-cache";
-import { useImageBlobUrl } from "@/lib/attachments/use-image-blob-url";
+import {
+  IMAGE_UNAVAILABLE_GRACE_MS,
+  useImageBlobUrlState,
+} from "@/lib/attachments/use-image-blob-url";
+
+export type AttachmentBlobSrcState =
+  | { readonly status: "loading"; readonly src: null }
+  | { readonly status: "unavailable"; readonly src: null }
+  | { readonly status: "ready"; readonly src: string };
 
 /**
  * The epic-doc byte source for image attachments: streams a hash's bytes from
@@ -28,20 +40,45 @@ export function useEpicImageFetcher(): ImageBytesFetcher {
   );
 }
 
+/** Synchronously checks the currently-open epic's local attachment replica. */
+export function useEpicAttachmentBytesPresence():
+  ((hash: string) => boolean) | null {
+  const handle = useOpenEpicHandle();
+  const snapshotLoaded = useEpicSnapshotLoaded();
+  const hasAttachmentBytes = useCallback(
+    (hash: string) => handle.store.getState().hasAttachmentBytes(hash),
+    [handle],
+  );
+  return snapshotLoaded ? hasAttachmentBytes : null;
+}
+
 /**
  * Resolves an image attachment's `src`: persisted images (`hash`) stream their
  * bytes from the epic doc's attachments map into a shared blob URL via the
  * content-addressed cache; draft/optimistic images use their inline `dataUrl`.
- * Returns null while a persisted image's blob is still loading. Used by the
- * sent-message renderer (the composer chip resolves images via the strip's
+ * Persisted images become unavailable after the sync grace window, but the
+ * underlying acquisition remains recoverable when bytes arrive later. Used by
+ * the sent-message renderer (the composer chip resolves images via the strip's
  * injected fetcher instead).
  */
 export function useAttachmentBlobSrc(
   hash: string | null,
   mediaType: string,
   dataUrl: string | null,
-): string | null {
+): AttachmentBlobSrcState {
   const fetcher = useEpicImageFetcher();
-  const blobUrl = useImageBlobUrl(hash, mediaType, fetcher);
-  return hash !== null ? blobUrl : dataUrl;
+  const blob = useImageBlobUrlState(
+    hash,
+    mediaType,
+    fetcher,
+    IMAGE_UNAVAILABLE_GRACE_MS,
+  );
+  if (hash !== null) {
+    return blob.status === "ready"
+      ? { status: "ready", src: blob.url }
+      : { status: blob.status, src: null };
+  }
+  return dataUrl === null
+    ? { status: "unavailable", src: null }
+    : { status: "ready", src: dataUrl };
 }

--- a/clients/gui-app/src/lib/attachments/use-image-blob-url.ts
+++ b/clients/gui-app/src/lib/attachments/use-image-blob-url.ts
@@ -5,6 +5,16 @@ import {
   imageBlobCache,
 } from "@/lib/attachments/image-blob-cache";
 
+export type ImageBlobUrlState =
+  | { readonly status: "loading"; readonly url: null }
+  | { readonly status: "unavailable"; readonly url: null }
+  | { readonly status: "ready"; readonly url: string };
+
+export const IMAGE_UNAVAILABLE_GRACE_MS = 12_000;
+export const IMAGE_FETCH_RETRY_BASE_MS = 250;
+export const IMAGE_FETCH_RETRY_MAX_MS = 2_000;
+export const IMAGE_FETCH_MAX_ATTEMPTS = 4;
+
 /**
  * Resolve a chat image's content hash to a shared `blob:` URL, fetching its
  * bytes once via `fetcher` (the tab-scoped host's `attachments.read`). Every
@@ -19,29 +29,95 @@ export function useImageBlobUrl(
   mediaType: string,
   fetcher: ImageBytesFetcher,
 ): string | null {
+  return useImageBlobUrlState(hash, mediaType, fetcher, null).url;
+}
+
+/**
+ * Resolves the same shared blob URL while preserving the difference between a
+ * hash that is still within its sync grace window and one that has remained
+ * absent long enough to be called unavailable.
+ *
+ * A pending fetch stays alive after the unavailable transition, so a late Yjs
+ * attachment-map update can still resolve it. Rejected acquisitions (for
+ * example, an open-epic store being disposed during mount) receive a finite
+ * retry budget, then rest in unavailable until a dependency change or remount
+ * starts a fresh acquisition.
+ */
+export function useImageBlobUrlState(
+  hash: string | null,
+  mediaType: string,
+  fetcher: ImageBytesFetcher,
+  unavailableAfterMs: number | null,
+): ImageBlobUrlState {
   const [resolved, setResolved] = useState<{
     hash: string;
-    url: string;
+    state: ImageBlobUrlState;
   } | null>(null);
 
   useEffect(() => {
     if (hash === null) return;
     let active = true;
-    imageBlobCache
-      .acquire(hash, mediaType, fetcher)
-      .then((url) => {
-        if (active) setResolved({ hash, url });
-      })
-      .catch(() => {
-        if (active) setResolved(null);
-      });
+    let attemptCount = 0;
+    let cancelRetry: (() => void) | null = null;
+    let cancelUnavailable: (() => void) | null = null;
+
+    if (unavailableAfterMs !== null) {
+      const unavailableTimer = window.setTimeout(() => {
+        if (active) {
+          setResolved({
+            hash,
+            state: { status: "unavailable", url: null },
+          });
+        }
+      }, unavailableAfterMs);
+      cancelUnavailable = () => window.clearTimeout(unavailableTimer);
+    }
+
+    const acquire = (): void => {
+      attemptCount += 1;
+      imageBlobCache
+        .acquire(hash, mediaType, fetcher)
+        .then((url) => {
+          if (!active) return;
+          cancelUnavailable?.();
+          cancelUnavailable = null;
+          setResolved({ hash, state: { status: "ready", url } });
+        })
+        .catch(() => {
+          if (!active) return;
+          if (attemptCount >= IMAGE_FETCH_MAX_ATTEMPTS) {
+            cancelUnavailable?.();
+            cancelUnavailable = null;
+            setResolved({
+              hash,
+              state: { status: "unavailable", url: null },
+            });
+            return;
+          }
+          const delay = Math.min(
+            IMAGE_FETCH_RETRY_BASE_MS * 2 ** (attemptCount - 1),
+            IMAGE_FETCH_RETRY_MAX_MS,
+          );
+          const retryTimer = window.setTimeout(() => {
+            cancelRetry = null;
+            acquire();
+          }, delay);
+          cancelRetry = () => window.clearTimeout(retryTimer);
+        });
+    };
+
+    acquire();
     return () => {
       active = false;
+      cancelRetry?.();
+      cancelUnavailable?.();
       imageBlobCache.release(hash);
     };
-  }, [hash, mediaType, fetcher]);
+  }, [hash, mediaType, fetcher, unavailableAfterMs]);
 
-  // Only surface a URL that belongs to the current hash, so a hash change shows
-  // nothing (not the previous image) until the new blob resolves.
-  return resolved !== null && resolved.hash === hash ? resolved.url : null;
+  // Only surface state that belongs to the current hash, so a hash change shows
+  // loading (not the previous image) until the new blob resolves.
+  return resolved !== null && resolved.hash === hash
+    ? resolved.state
+    : { status: "loading", url: null };
 }

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/store.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/store.test.ts
@@ -2314,4 +2314,33 @@ describe("createOpenEpicStore", () => {
     expect(settled).toBe(true);
     expect(await pending).toBeNull();
   });
+
+  it("synchronously reports attachment bytes in the local root replica", () => {
+    const hostDoc = new Y.Doc();
+    hostDoc
+      .getMap("attachments")
+      .set("present-hash", new Uint8Array([1, 2, 3]));
+    const { factory, handle } = fakeFactory();
+    const opened = createOpenEpicStore({
+      epicId: "epic-a",
+      streamClientFactory: factory,
+      userId: null,
+      onAuthError: null,
+    });
+
+    handle().callbacks.onSnapshot(
+      buildMeta("editor", hostDoc),
+      Y.encodeStateAsUpdate(hostDoc),
+    );
+
+    expect(opened.store.getState().hasAttachmentBytes("present-hash")).toBe(
+      true,
+    );
+    expect(opened.store.getState().hasAttachmentBytes("missing-hash")).toBe(
+      false,
+    );
+
+    opened.dispose();
+    hostDoc.destroy();
+  });
 });

--- a/clients/gui-app/src/stores/epics/open-epic/store.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/store.ts
@@ -379,6 +379,8 @@ export interface OpenEpicState {
     hash: string,
     signal: AbortSignal,
   ) => Promise<Uint8Array | null>;
+  /** Synchronously reports whether the root attachment map has this hash. */
+  hasAttachmentBytes: (hash: string) => boolean;
   /**
    * Returns the artifact-room-scoped Awareness instance hosting `artifactId`'s body
    * presence channel, or `null` when the artifactRoom is not currently `ready`.
@@ -1893,6 +1895,9 @@ export function createOpenEpicStore(
               bindAttachmentWaiter(waiter);
             });
           },
+
+          hasAttachmentBytes: (hash) =>
+            doc.getMap("attachments").get(hash) instanceof Uint8Array,
 
           getArtifactFragment: (artifactId) => {
             // Resolve the artifact's artifactRoom via root metadata, then look up


### PR DESCRIPTION
## Summary

Companion PR to [traycerai/traycer-internal#4512](https://github.com/traycerai/traycer-internal/pull/4512), which fixes the root-cause data-loss bug (edit-triggered orphan sweep deleting attachment bytes). This PR closes the renderer-side gaps around the same bug class.

**Root cause recap**: editing a user message re-swept the checkpoint before re-appending the hash-only replacement, so the sweep deleted attachment bytes still referenced by the replacement (and any other chat sharing that hash). Copying a sent message also carries hash-only image nodes on the clipboard with no bytes, so pasting into a different epic persisted a permanently dangling reference with no safety net.

## Changes

- **Synchronous paste validation**: `handlePaste` checks hash-only image nodes against the destination epic's local attachment replica (`hasAttachmentBytes`) and strips unavailable ones with a toast. The presence check stays `null` until the epic snapshot loads, so cold-open pastes insert unvalidated rather than being falsely stripped (the host-side ingest guard, in the companion PR, is the backstop).
- **Honest "image unavailable" state**: thumbnails and the message dialog showed an infinite grey pulse for any missing hash, indistinguishable from "still loading". They now show an `ImageOff` state after a 12s grace period, recover automatically if bytes arrive late, and retry fetch failures up to 4 times instead of blanking permanently on first failure.
- **Edit-composer image support**: the inline edit composer's paste/drop/attach handlers were wired as no-ops (a "blinking cursor" with no feedback). They're now wired through the same ingest path as the main composer, with FileReader timeouts, abort-on-unmount, and submit gating while attachments are being prepared.

## Test plan

- [x] Full GUI test suite passes
- [x] Compile and lint clean
- [x] Correctness review (5 rounds, all findings fixed) and simplicity review, both ship-approved
- [ ] Manual: paste a copied image cross-epic -> stripped with toast; edit a message and paste/drop/attach an image -> works