### PR TITLE
fix(worktree): classify landed submodule work

### DIFF
--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -391,10 +391,12 @@ codeFontSize` in muted styling while `null`; any tick/type pins an
     `classify-worktree.ts`) naming a PROVEN fact, never a generic "Safe"
     label. **Merged**, **At base commit**, and **Unreferenced** are the three
     green tiers - each requires positive, host-validated proof (a merged PR at
-    the live HEAD or local ancestry into the default branch; never advanced
-    from the worktree's birth commit; or clean, fully pushed, and unreferenced
-    by any Task) - and are deliberately kept distinct rather than collapsed
-    into one badge. **Review** is the amber catch-all for anything unproven or
+    the live HEAD, local ancestry into the default branch, or authored owned-
+    submodule work proven landed from an otherwise at-base superproject; never
+    advanced from the worktree's birth commit with no landed authored submodule
+    work; or clean, fully pushed, and unreferenced by any Task) - and are
+    deliberately kept distinct rather than collapsed into one badge. **Review**
+    is the amber catch-all for anything unproven or
     with would-be-lost state (dirty, unpushed/local-only commits, a detached
     HEAD, an unmerged owned-submodule branch, or unverified branch status).
     **Orphaned** means git can't remove the worktree normally (missing/broken

--- a/clients/shared/worktree/__tests__/classify-worktree.test.ts
+++ b/clients/shared/worktree/__tests__/classify-worktree.test.ts
@@ -328,12 +328,36 @@ describe("classifyWorktreeTier - precedence truth table (first match wins)", () 
       tier: "merged",
     },
     {
-      name: "submodule proven via local ancestry does not block → at-base-commit",
+      name: "at-base + authored submodule proven via merged PR → merged",
+      entry: entry({
+        atBaseCommit: true,
+        submodules: [
+          subFact({ prState: "merged", mergedHeadShaMatches: true }),
+        ],
+      }),
+      tier: "merged",
+    },
+    {
+      name: "at-base + authored submodule proven via local ancestry → merged",
       entry: entry({
         atBaseCommit: true,
         submodules: [subFact({ mergedIntoDefault: true })],
       }),
-      tier: "at-base-commit",
+      tier: "merged",
+    },
+    {
+      name: "at-base + any authored landed submodule → merged when siblings are at-pin",
+      entry: entry({
+        atBaseCommit: true,
+        submodules: [
+          subFact({ mergedIntoDefault: true }),
+          subFact({
+            repoIdentifier: { owner: "acme", repo: "unchanged" },
+            atPinnedCommit: true,
+          }),
+        ],
+      }),
+      tier: "merged",
     },
     {
       name: "submodule proven at its pinned gitlink does not block → at-base-commit",
@@ -342,6 +366,42 @@ describe("classifyWorktreeTier - precedence truth table (first match wins)", () 
         submodules: [subFact({ atPinnedCommit: true })],
       }),
       tier: "at-base-commit",
+    },
+    {
+      name: "at-pin overrides merged proof for authored-work promotion → at-base-commit",
+      entry: entry({
+        atBaseCommit: true,
+        submodules: [
+          subFact({
+            prState: "merged",
+            mergedHeadShaMatches: true,
+            atPinnedCommit: true,
+          }),
+        ],
+      }),
+      tier: "at-base-commit",
+    },
+    {
+      name: "dirty gate blocks authored-submodule promotion → review",
+      entry: entry({
+        uncommittedCount: 1,
+        atBaseCommit: true,
+        submodules: [
+          subFact({ prState: "merged", mergedHeadShaMatches: true }),
+        ],
+      }),
+      tier: "review",
+    },
+    {
+      name: "one unproven sibling blocks authored-submodule promotion → review",
+      entry: entry({
+        atBaseCommit: true,
+        submodules: [
+          subFact({ prState: "merged", mergedHeadShaMatches: true }),
+          subFact({ repoIdentifier: { owner: "acme", repo: "unmerged" } }),
+        ],
+      }),
+      tier: "review",
     },
     {
       name: "submodule atPinnedCommit false proves nothing by itself → review",
@@ -459,6 +519,19 @@ describe("classifyWorktreeTier - precedence truth table (first match wins)", () 
     expect(atBase.tier).toBe("at-base-commit");
     expect(atBase.label).toBe("At base commit");
     expect(atBase.facts).toContain("clean");
+
+    const submoduleLanded = classifyWorktree(
+      entry({
+        atBaseCommit: true,
+        submodules: [
+          subFact({ prState: "merged", mergedHeadShaMatches: true }),
+        ],
+      }),
+    );
+    expect(submoduleLanded.tier).toBe("merged");
+    expect(submoduleLanded.label).toBe("Landed");
+    expect(submoduleLanded.prFacts).toContain("submodule acme/lib landed");
+    expect(submoduleLanded.nonPrFacts).toContain("clean");
 
     const dirty = classifyWorktree(entry({ uncommittedCount: 3 }));
     expect(dirty.tier).toBe("review");

--- a/clients/shared/worktree/classify-worktree.ts
+++ b/clients/shared/worktree/classify-worktree.ts
@@ -7,13 +7,15 @@ import type {
 /**
  * Evidence tier for a host worktree. Names a PROVEN fact about the worktree, not
  * a safety verdict. Three green tiers each require positive, host-validated proof:
- * `merged` (a PR merged with the live HEAD at the merged SHA, OR local ancestry
- * proof the work landed in the default branch); `at-base-commit` (the worktree
- * never advanced from its birth commit, so deleting loses nothing committed); and
- * `unreferenced` (a proven upstream-tip branch nothing points at). `review` is the
- * amber catch-all for anything unproven or with would-be-lost state; `orphaned`
- * and `in-use` are neutral. The same names are shared verbatim with the
- * Task-delete dialog and the `traycer-housekeeping` skill.
+ * `merged` (a PR merged with the live HEAD at the merged SHA, local ancestry
+ * proof the work landed in the default branch, OR an at-base superproject with
+ * authored owned-submodule work proven landed); `at-base-commit` (the worktree
+ * never advanced from its birth commit and no authored submodule work landed, so
+ * deleting loses nothing committed); and `unreferenced` (a proven upstream-tip
+ * branch nothing points at). `review` is the amber catch-all for anything
+ * unproven or with would-be-lost state; `orphaned` and `in-use` are neutral. The
+ * same names are shared verbatim with the Task-delete dialog and the
+ * `traycer-housekeeping` skill.
  */
 export type WorktreeTier =
   | "in-use"
@@ -69,7 +71,7 @@ export const WORKTREE_TIER_TOOLTIP: Record<WorktreeTier, string> = {
   orphaned:
     "Git can't remove this worktree normally - its directory or metadata is missing or broken. Deleting it uses a forced cleanup.",
   merged:
-    "The work is proven to have landed: a merged PR matching this worktree's current commit, or the branch's commits are contained in the default branch.",
+    "The work is proven to have landed: a merged PR matches this worktree's current commit, the branch's commits are contained in the default branch, or authored submodule work from an otherwise at-base worktree is proven landed.",
   "at-base-commit":
     "The worktree never advanced from the commit it was created on and has no uncommitted changes - deleting it loses no committed work.",
   unreferenced:
@@ -125,7 +127,13 @@ export function worktreeTierRank(tier: WorktreeTier): number {
  *     The host already validated the live HEAD is the merged SHA, so the pure
  *     client never needs the SHA. A merged PR state WITHOUT the live-HEAD match
  *     does NOT green - it falls through.
- *  7. `atBaseCommit === true` → **at-base-commit** (green). Host-computed
+ *  7. `atBaseCommit === true` + any owned submodule with authored work proven
+ *     landed → **merged** (green). A submodule has authored work when it differs
+ *     from the pinned gitlink (`!atPinnedCommit`); landing proof is the same
+ *     HEAD-validated merged PR or local default-branch ancestry used by the
+ *     submodule safety gate. The gate above still requires EVERY owned submodule
+ *     to be proven safe, so one unproven sibling keeps the row in Review.
+ *  8. `atBaseCommit === true` → **at-base-commit** (green). Host-computed
  *     retroactively from signals every worktree carries: `clean && contained in
  *     default (mergedIntoDefault) && no authored-commit reflog entry` ⇒ untouched.
  *     Checked BEFORE local ancestry ON PURPOSE: an untouched worktree is contained
@@ -135,13 +143,13 @@ export function worktreeTierRank(tier: WorktreeTier): number {
  *     splitting the two labels - both share the `mergedIntoDefault` safety
  *     floor. Applies
  *     regardless of owners or an open PR; deleting loses nothing committed.
- *  8. `branchStatus.mergedIntoDefault === true` → **merged** (green, local
+ *  9. `branchStatus.mergedIntoDefault === true` → **merged** (green, local
  *     ancestry). Now correctly rare: only a branch that actually ADVANCED from its
  *     base and is now contained in the default lands here (a genuine merge). Proof
  *     stands regardless of owners and of any upstream.
- *  9. clean + non-null status + `ahead === 0` + no owners → **unreferenced**
+ *  10. clean + non-null status + `ahead === 0` + no owners → **unreferenced**
  *     (quiet-green; a PROVEN upstream-tip branch nothing references).
- *  10. else → **review** (null status, `ahead === null`/`> 0` unmerged,
+ *  11. else → **review** (null status, `ahead === null`/`> 0` unmerged,
  *     referenced-unmerged).
  *
  * Green requires positive, host-validated proof; unknown/stale is never green.
@@ -166,6 +174,12 @@ export function classifyWorktreeTier(
   // default, making `mergedIntoDefault` also true) reads the honest "At base
   // commit", not "Landed". A validated merged PR still wins over both.
   if (entry.prState === "merged" && entry.mergedHeadShaMatches) return "merged";
+  if (
+    entry.atBaseCommit &&
+    entry.submodules.some(submoduleAuthoredWorkLanded)
+  ) {
+    return "merged";
+  }
   if (entry.atBaseCommit) return "at-base-commit";
   const status = entry.branchStatus;
   if (status !== null && status.mergedIntoDefault) return "merged";
@@ -240,6 +254,19 @@ export function describeReviewReasons(
 function submoduleMergeProven(fact: WorktreeSubmoduleMergeFactV12): boolean {
   if (fact.prState === "merged" && fact.mergedHeadShaMatches) return true;
   return fact.mergedIntoDefault || fact.atPinnedCommit;
+}
+
+/**
+ * Positive proof that an owned submodule both carried work beyond the
+ * superproject's pinned gitlink and landed that work. `atPinnedCommit` is kept as
+ * a hard exclusion even if another proof bit is also true: the pinned checkout
+ * is safe, but it contains no authored submodule work that should promote an
+ * otherwise at-base superproject to Landed.
+ */
+function submoduleAuthoredWorkLanded(
+  fact: WorktreeSubmoduleMergeFactV12,
+): boolean {
+  return !fact.atPinnedCommit && submoduleMergeProven(fact);
 }
 
 function describeUnprovenSubmodule(
@@ -325,10 +352,11 @@ function worktreeFacts(
 
 /**
  * The row-fact hint that distinguishes HOW a `merged` worktree was proven merged:
- * `PR #123` when the green came from a validated merged PR, or `in default` when
- * it came from local ancestry. Only emitted on the `merged` tier - the provenance
- * is the reassuring detail there. `PR #123` takes precedence because the
- * classifier evaluates the PR row first.
+ * `PR #123` when the green came from a validated superproject PR, `submodule
+ * owner/repo landed` when an otherwise at-base superproject carried landed
+ * authored submodule work, or `in default` when it came from superproject local
+ * ancestry. Only emitted on the `merged` tier - the provenance is the reassuring
+ * detail there. The order mirrors the classifier's evidence ladder.
  */
 function mergedProvenanceFacts(
   entry: WorktreeHostEntryV12,
@@ -344,6 +372,12 @@ function mergedProvenanceFacts(
   }
   if (entry.prState === "merged" && entry.mergedHeadShaMatches) {
     return ["merged PR"];
+  }
+  if (entry.atBaseCommit) {
+    return entry.submodules.filter(submoduleAuthoredWorkLanded).map((fact) => {
+      const name = `${fact.repoIdentifier.owner}/${fact.repoIdentifier.repo}`;
+      return `submodule ${name} landed`;
+    });
   }
   return ["in default"];
 }

--- a/protocol/src/host/worktree-schemas.ts
+++ b/protocol/src/host/worktree-schemas.ts
@@ -838,7 +838,9 @@ export const worktreeHostEntrySchemaV11 = worktreeHostEntrySchema.extend({
   // `mergedIntoDefault` is the REQUIRED safety floor (HEAD contained in default
   // ⇒ deleting loses nothing); the reflog-no-`commit` guard only splits the
   // LABEL (an untouched worktree reads "At base commit" instead of "Merged").
-  // The pure client classifier greens "At base commit" on this boolean alone.
+  // The pure client normally labels this "At base commit"; it promotes the row
+  // to "Landed" when an owned submodule differs from its pinned gitlink and is
+  // proven merged. An unproven owned submodule still forces Review.
   // FAILS CLOSED: an unknown reflog (`null`) is NOT at-base. `false` whenever
   // unproven: dirty, HEAD not contained in default, an authored-commit reflog
   // entry, or `includeActivity` false (the probes are gated).


### PR DESCRIPTION
## Summary
- show Landed for an at-base superproject when authored submodule work is beyond the pinned gitlink and proven merged
- preserve Review precedence for dirty, detached, and unproven-submodule work
- include exact precedence and provenance regression coverage

## Verification
- bun test clients/shared/worktree/__tests__/classify-worktree.test.ts
- bun run --filter @traycer-clients/shared lint
- bun run --filter @traycer-clients/shared compile
- bun run --filter @traycer-clients/shared test