### PR TITLE
fix(gui-app): expand mermaid diagrams on click

### DIFF
--- a/clients/gui-app/__tests__/editor-core/mermaid-node-view.test.tsx
+++ b/clients/gui-app/__tests__/editor-core/mermaid-node-view.test.tsx
@@ -12,6 +12,7 @@ import { EditorContent, EditorContext } from "@tiptap/react";
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";
 import { buildArtifactExtensions, deriveCollabUser } from "@/editor-core";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { saveBlobToDisk } from "@/lib/files/save-blob-to-disk";
 
 // The download path lives in a shared lib module; mock it on its own.
@@ -37,6 +38,7 @@ vi.mock("@/editor-core/nodes/mermaid/mermaid-service", () => {
       .mockResolvedValue(new Blob(["mock-png"], { type: "image/png" })),
     subscribeMermaidTheme: vi.fn().mockReturnValue(() => undefined),
     getMermaidThemeVersion: vi.fn().mockReturnValue(0),
+    getSvgIntrinsicSize: vi.fn().mockReturnValue({ width: 10, height: 10 }),
     deriveMermaidAriaLabel: (code: string): string => {
       const firstLine = code
         .split("\n")
@@ -108,11 +110,13 @@ function makeQueryClient() {
 function renderMermaidEditor(editor: Editor) {
   const queryClient = makeQueryClient();
   render(
-    <QueryClientProvider client={queryClient}>
-      <EditorContext.Provider value={{ editor }}>
-        <EditorContent editor={editor} />
-      </EditorContext.Provider>
-    </QueryClientProvider>,
+    <TooltipProvider>
+      <QueryClientProvider client={queryClient}>
+        <EditorContext.Provider value={{ editor }}>
+          <EditorContent editor={editor} />
+        </EditorContext.Provider>
+      </QueryClientProvider>
+    </TooltipProvider>,
   );
   return queryClient;
 }
@@ -139,10 +143,28 @@ describe("MermaidNodeView", () => {
       editable: true,
     });
     renderMermaidEditor(editor);
-    const region = await screen.findByRole("img", { name: /graph TD/ });
-    await waitFor(() => {
-      expect(region.querySelector("svg")).not.toBeNull();
+    const diagram = await screen.findByRole("button", {
+      name: /expand diagram: graph TD/i,
     });
+    await waitFor(() => {
+      expect(diagram.querySelector("svg")).not.toBeNull();
+    });
+    editor.destroy();
+  });
+
+  it("opens the fullscreen preview by clicking the rendered diagram", async () => {
+    const editor = mountMermaidEditor({
+      code: "graph TD\n  A --> B",
+      editable: true,
+    });
+    renderMermaidEditor(editor);
+
+    const diagram = await screen.findByRole("button", {
+      name: /expand diagram: graph TD/i,
+    });
+    fireEvent.click(diagram);
+
+    expect(await screen.findByRole("dialog")).toBeTruthy();
     editor.destroy();
   });
 
@@ -161,6 +183,7 @@ describe("MermaidNodeView", () => {
     expect(
       await screen.findByRole("button", { name: /edit source/i }),
     ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /fullscreen/i })).toBeNull();
     editor.destroy();
   });
 
@@ -212,9 +235,11 @@ describe("MermaidNodeView", () => {
     const download = await screen.findByRole("button", {
       name: /download png/i,
     });
-    const region = await screen.findByRole("img", { name: /graph TD/ });
+    const diagram = await screen.findByRole("button", {
+      name: /expand diagram: graph TD/i,
+    });
     await waitFor(() => {
-      expect(region.querySelector("svg")).not.toBeNull();
+      expect(diagram.querySelector("svg")).not.toBeNull();
       expect((download as HTMLButtonElement).disabled).toBe(false);
     });
 

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-block-toolbar.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-block-toolbar.tsx
@@ -1,4 +1,4 @@
-import { Copy, Download, Maximize2, Pencil, X } from "lucide-react";
+import { Copy, Download, Pencil, X } from "lucide-react";
 import { ToolbarButton } from "../../toolbar/toolbar-button";
 import { BlockFloatingToolbar } from "../shared/block-floating-toolbar";
 
@@ -8,9 +8,7 @@ export interface MermaidBlockToolbarProps {
   readonly onToggleEdit: () => void;
   readonly onCopyCode: () => void;
   readonly onDownloadPng: () => void;
-  readonly onOpenFullscreen: () => void;
   readonly downloadDisabled: boolean;
-  readonly fullscreenDisabled: boolean;
 }
 
 /**
@@ -26,9 +24,7 @@ export function MermaidBlockToolbar(props: MermaidBlockToolbarProps) {
     onToggleEdit,
     onCopyCode,
     onDownloadPng,
-    onOpenFullscreen,
     downloadDisabled,
-    fullscreenDisabled,
   } = props;
 
   return (
@@ -48,14 +44,6 @@ export function MermaidBlockToolbar(props: MermaidBlockToolbarProps) {
           className="tc-editor-toolbar-button"
         />
       ) : null}
-      <ToolbarButton
-        icon={<Maximize2 className="size-4" aria-hidden="true" />}
-        label="Fullscreen"
-        active={false}
-        disabled={fullscreenDisabled}
-        onClick={onOpenFullscreen}
-        className="tc-editor-toolbar-button"
-      />
       <ToolbarButton
         icon={<Copy className="size-4" aria-hidden="true" />}
         label="Copy code"

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-expand-button.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-expand-button.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+interface MermaidExpandButtonProps {
+  readonly ariaLabel: string;
+  readonly children: ReactNode;
+  readonly onExpand: () => void;
+}
+
+/** Makes the rendered diagram itself the fullscreen affordance. */
+export function MermaidExpandButton(props: MermaidExpandButtonProps) {
+  return (
+    <button
+      type="button"
+      className="tc-node-mermaid__expand"
+      aria-label={`Expand diagram: ${props.ariaLabel}`}
+      onClick={props.onExpand}
+    >
+      <span className="tc-node-mermaid__svg">{props.children}</span>
+    </button>
+  );
+}

--- a/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-node-view.tsx
+++ b/clients/gui-app/src/editor-core/nodes/mermaid/mermaid-node-view.tsx
@@ -16,6 +16,7 @@ import { createReportIssueContext } from "@/lib/report-issue-context";
 import { trustedMarkupToReactNodes } from "@/lib/trusted-markup";
 import { BlockErrorBoundary } from "../shared/block-error-boundary";
 import { MermaidBlockToolbar } from "./mermaid-block-toolbar";
+import { MermaidExpandButton } from "./mermaid-expand-button";
 import { MermaidFullscreenDialog } from "./mermaid-fullscreen-dialog";
 import {
   deriveMermaidAriaLabel,
@@ -210,15 +211,13 @@ export function MermaidNodeView(props: NodeViewProps) {
           onToggleEdit={handleToggleEdit}
           onCopyCode={handleCopy}
           onDownloadPng={downloadMermaidPng}
-          onOpenFullscreen={() => setFullscreenOpen(true)}
           downloadDisabled={render.status !== "ready" || isDownloading}
-          fullscreenDisabled={render.status !== "ready"}
         />
 
         <figure
           className="tc-node-mermaid__preview m-0"
-          role="img"
-          aria-label={ariaLabel}
+          role={render.status === "pending" ? "img" : undefined}
+          aria-label={render.status === "pending" ? ariaLabel : undefined}
         >
           {render.status === "pending" && (
             <div className="tc-node-block__skeleton" aria-hidden="true">
@@ -230,7 +229,12 @@ export function MermaidNodeView(props: NodeViewProps) {
             </div>
           )}
           {render.status === "ready" && (
-            <div className="tc-node-mermaid__svg">{renderedSvg}</div>
+            <MermaidExpandButton
+              ariaLabel={ariaLabel}
+              onExpand={() => setFullscreenOpen(true)}
+            >
+              {renderedSvg}
+            </MermaidExpandButton>
           )}
           {render.status === "error" && (
             <div className="tc-node-block__error" role="alert">

--- a/clients/gui-app/src/editor-core/styles/editor.css
+++ b/clients/gui-app/src/editor-core/styles/editor.css
@@ -293,6 +293,21 @@
   align-items: flex-start;
 }
 
+.tc-node-mermaid__expand {
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.tc-node-mermaid__expand:focus-visible {
+  outline: 2px solid var(--color-ring, hsl(222 47% 40%));
+  outline-offset: 2px;
+}
+
 .tc-node-mermaid__svg svg {
   max-width: none;
 }

--- a/clients/gui-app/src/markdown/components/mermaid-block.tsx
+++ b/clients/gui-app/src/markdown/components/mermaid-block.tsx
@@ -1,6 +1,7 @@
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { MermaidBlockToolbar } from "@/editor-core/nodes/mermaid/mermaid-block-toolbar";
+import { MermaidExpandButton } from "@/editor-core/nodes/mermaid/mermaid-expand-button";
 import { MermaidFullscreenDialog } from "@/editor-core/nodes/mermaid/mermaid-fullscreen-dialog";
 import {
   deriveMermaidAriaLabel,
@@ -143,7 +144,6 @@ function MermaidRenderSession(props: {
   });
 
   const downloadDisabled = render.status !== "ready" || isDownloading;
-  const fullscreenDisabled = render.status !== "ready";
   const renderedSvg = useMemo(
     () =>
       render.status === "ready"
@@ -163,15 +163,13 @@ function MermaidRenderSession(props: {
         onToggleEdit={noop}
         onCopyCode={handleCopy}
         onDownloadPng={downloadMermaidPng}
-        onOpenFullscreen={() => onFullscreenOpenChange(true)}
         downloadDisabled={downloadDisabled}
-        fullscreenDisabled={fullscreenDisabled}
       />
 
       <figure
         className="tc-node-mermaid__preview m-0"
-        role={render.status === "error" ? undefined : "img"}
-        aria-label={ariaLabel}
+        role={render.status === "pending" ? "img" : undefined}
+        aria-label={render.status === "pending" ? ariaLabel : undefined}
       >
         {render.status === "pending" ? (
           <div className="tc-node-block__skeleton" aria-hidden="true">
@@ -183,7 +181,12 @@ function MermaidRenderSession(props: {
           </div>
         ) : null}
         {render.status === "ready" ? (
-          <div className="tc-node-mermaid__svg">{renderedSvg}</div>
+          <MermaidExpandButton
+            ariaLabel={ariaLabel}
+            onExpand={() => onFullscreenOpenChange(true)}
+          >
+            {renderedSvg}
+          </MermaidExpandButton>
         ) : null}
         {render.status === "error" ? (
           <div className="tc-node-block__error" role="alert">


### PR DESCRIPTION
## Summary
- make rendered Mermaid diagrams the fullscreen interaction target
- remove the explicit fullscreen toolbar action
- preserve keyboard activation and add regression coverage

## Verification
- `bun run test __tests__/editor-core/mermaid-node-view.test.tsx`
- `bun run compile`
- targeted ESLint and Prettier checks
- `bun run react-doctor`