### PR TITLE
perf(gui): manual-refresh worktree settings and batch enrichment RPCs

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-enrichment.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-enrichment.test.tsx
@@ -897,6 +897,112 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
     });
   });
 
+  describe("sentinel guard (cold-host clobber regression)", () => {
+    // A cold host answers reads it cannot derive with the `unresolvedRow`
+    // SENTINEL - `resolvedAt: null`, unknown branch, `gitRemovable: false` -
+    // which the panel renders as "detached HEAD" / "Waiting for host
+    // verification…". Caching those over good rows (and then persisting them)
+    // turned one cold read into a fleet of permanently-unknown rows.
+    function sentinelEntry(worktreePath: string): WorktreeHostEntryV14 {
+      return {
+        ...enrichedEntry(worktreePath, "feat-a"),
+        branch: null,
+        gitRemovable: false,
+        branchStatus: null,
+        resolvedAt: null,
+      };
+    }
+
+    it("keeps a resolved cached row when a later read answers with the sentinel", async () => {
+      const resolved: WorktreeHostEntryV14 = {
+        ...enrichedEntry("/wt/a", "feat-a"),
+        prState: "none",
+      };
+      const entriesByPath = new Map<string, WorktreeHostEntryV14>([
+        ["/wt/a", resolved],
+      ]);
+      const fixture = createFixture(
+        entriesByPath,
+        null,
+        null,
+        createAppQueryClient(),
+      );
+      const { result } = renderHook(
+        () =>
+          useWorktreeActivityEnrichment(fixture.client, true, HOST_ID, [
+            "/wt/a",
+          ]),
+        { wrapper: fixture.Wrapper },
+      );
+      await waitFor(() => {
+        expect(result.current.enrichedByPath.get("/wt/a")?.branch).toBe(
+          "feat-a",
+        );
+      });
+
+      // The host goes cold (restart) and now answers the sentinel. A refetch
+      // must NOT downgrade the resolved row we already hold.
+      entriesByPath.set("/wt/a", sentinelEntry("/wt/a"));
+      await act(async () => {
+        await fixture.queryClient.invalidateQueries({
+          queryKey: METHOD_SCOPE,
+          refetchType: "active",
+        });
+      });
+
+      expect(result.current.enrichedByPath.get("/wt/a")?.branch).toBe("feat-a");
+      expect(
+        result.current.enrichedByPath.get("/wt/a")?.resolvedAt,
+      ).not.toBeNull();
+    });
+
+    it("still accepts a resolved row that replaces another resolved row", async () => {
+      const first: WorktreeHostEntryV14 = {
+        ...enrichedEntry("/wt/a", "feat-a"),
+        prState: "none",
+      };
+      const renamed: WorktreeHostEntryV14 = {
+        ...enrichedEntry("/wt/a", "feat-renamed"),
+        prState: "none",
+      };
+      const entriesByPath = new Map<string, WorktreeHostEntryV14>([
+        ["/wt/a", first],
+      ]);
+      const fixture = createFixture(
+        entriesByPath,
+        null,
+        null,
+        createAppQueryClient(),
+      );
+      const { result } = renderHook(
+        () =>
+          useWorktreeActivityEnrichment(fixture.client, true, HOST_ID, [
+            "/wt/a",
+          ]),
+        { wrapper: fixture.Wrapper },
+      );
+      await waitFor(() => {
+        expect(result.current.enrichedByPath.get("/wt/a")?.branch).toBe(
+          "feat-a",
+        );
+      });
+
+      // Guard must not freeze the cache: resolved data still wins.
+      entriesByPath.set("/wt/a", renamed);
+      await act(async () => {
+        await fixture.queryClient.invalidateQueries({
+          queryKey: METHOD_SCOPE,
+          refetchType: "active",
+        });
+      });
+      await waitFor(() => {
+        expect(result.current.enrichedByPath.get("/wt/a")?.branch).toBe(
+          "feat-renamed",
+        );
+      });
+    });
+  });
+
   describe("overlay identity stability (render-churn regression)", () => {
     // Every distinct overlay identity fans out through the panel: merged rows,
     // task rollups, filters, and finally a re-render of EVERY worktree row

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-enrichment.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-enrichment.test.tsx
@@ -921,9 +921,14 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
       const entriesByPath = new Map<string, WorktreeHostEntryV14>([
         ["/wt/a", resolved],
       ]);
+      // Count host reads so we can prove the sentinel refetch actually landed.
+      // The guard's whole job is to leave the cached data UNCHANGED, so a
+      // `waitFor` on the data cannot tell "guard preserved the row" apart from
+      // "the refetch never happened" - only the request count can.
+      const requests: string[] = [];
       const fixture = createFixture(
         entriesByPath,
-        null,
+        (path) => requests.push(path),
         null,
         createAppQueryClient(),
       );
@@ -939,9 +944,10 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
           "feat-a",
         );
       });
+      const requestsBeforeSentinel = requests.length;
 
-      // The host goes cold (restart) and now answers the sentinel. A refetch
-      // must NOT downgrade the resolved row we already hold.
+      // The host goes cold (restart) and now answers the sentinel. Invalidation
+      // re-arms the sweep, which re-probes the row through the batcher.
       entriesByPath.set("/wt/a", sentinelEntry("/wt/a"));
       await act(async () => {
         await fixture.queryClient.invalidateQueries({
@@ -949,7 +955,13 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
           refetchType: "active",
         });
       });
+      // The sentinel response must actually land before the assertion, or the
+      // test would pass trivially on stale cache without exercising the guard.
+      await waitFor(() => {
+        expect(requests.length).toBeGreaterThan(requestsBeforeSentinel);
+      });
 
+      // Guard kept the resolved row despite the sentinel refetch landing.
       expect(result.current.enrichedByPath.get("/wt/a")?.branch).toBe("feat-a");
       expect(
         result.current.enrichedByPath.get("/wt/a")?.resolvedAt,

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-enrichment.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-enrichment.test.tsx
@@ -34,6 +34,11 @@ afterEach(() => {
 const HOST_ID = mockLocalHostEntry.hostId;
 // Slightly over the hook's internal 80ms report debounce.
 const WORKTREE_DEBOUNCE_SETTLE_MS = 120;
+// Under fake timers the batcher's coalescing window arms only once the query
+// actually mounts - i.e. during the act() flush AFTER an advance - so a fetch
+// needs one more act-sized advance to hit the wire. Comfortably above the
+// batcher's 25ms window.
+const WORKTREE_BATCH_FLUSH_MS = 50;
 // Passed as `worktreePaths` where a test exercises only the viewport
 // machinery - an empty denominator keeps the background sweep inert.
 const NO_SWEEP_PATHS: readonly string[] = [];
@@ -239,11 +244,15 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
     entriesByPath: ReadonlyMap<string, WorktreeHostEntryV14>,
     onPathRequest: ((path: string) => void) | null,
     // Awaited per requested path before the response resolves - lets a test
-    // hold probes in flight to observe concurrency/dedupe. `null` = respond
-    // immediately (no extra microtask boundary for the sync-handler tests).
+    // hold probes in flight to observe dedupe. `null` = respond immediately
+    // (no extra microtask boundary for the sync-handler tests).
     requestGate: ((path: string) => Promise<void>) | null,
     queryClient: QueryClient,
   ) {
+    // One entry per WIRE call, carrying the batched `activityPaths` it asked
+    // for - the chunking assertions read this (per-path counts stay on
+    // `onPathRequest`).
+    const wireRequests: Array<readonly string[]> = [];
     const client = new HostClient<HostRpcRegistry>({
       registry: hostRpcRegistry,
       invalidator: createHostQueryInvalidator(queryClient),
@@ -252,12 +261,14 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         requestId: () => "req-1",
         handlers: {
           "worktree.listAllForHost": async (params) => {
-            // Per-path enrichment: return the enriched entry for each requested
-            // path (the panel always requests exactly one path per query).
+            // Batched enrichment: the panel coalesces per-path queries into
+            // chunked `activityPaths` calls; return the enriched entry for
+            // each requested path.
             const paths =
               "activityPaths" in params && params.activityPaths !== null
                 ? params.activityPaths
                 : [];
+            wireRequests.push([...paths]);
             const worktrees: WorktreeHostEntryV14[] = [];
             for (const path of paths) {
               // Snapshot the entry BEFORE the callbacks, so a callback that
@@ -282,7 +293,7 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         {props.children}
       </QueryClientProvider>
     );
-    return { client, Wrapper, queryClient };
+    return { client, Wrapper, queryClient, wireRequests };
   }
 
   it("enriches a reported window, then keeps it enriched after the window shrinks", async () => {
@@ -410,6 +421,9 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
       result.current.reportVisiblePaths(["/wt/a"]);
       await vi.advanceTimersByTimeAsync(WORKTREE_DEBOUNCE_SETTLE_MS);
     });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
+    });
     expect(requests).toHaveLength(1);
 
     await act(async () => {
@@ -489,6 +503,9 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
       result.current.reportVisiblePaths(["/wt/a"]);
       await vi.advanceTimersByTimeAsync(WORKTREE_DEBOUNCE_SETTLE_MS);
     });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
+    });
     expect(requests).toHaveLength(1);
 
     await act(async () => {
@@ -536,6 +553,9 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
       result.current.reportVisiblePaths(["/wt/a"]);
       await vi.advanceTimersByTimeAsync(WORKTREE_DEBOUNCE_SETTLE_MS);
     });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
+    });
     expect(requests).toHaveLength(1);
 
     // Exponential backoff (750ms, 1.5s, 3s, 6s, 12s, then 20s flat), budgeted
@@ -580,18 +600,13 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         paths.map((path, i) => [path, warmEntry(path, `feat-${i}`)]),
       );
       const requests: string[] = [];
-      let inFlight = 0;
-      let maxInFlight = 0;
       const fixture = createFixture(
         entriesByPath,
         (path) => {
           requests.push(path);
         },
         async () => {
-          inFlight += 1;
-          maxInFlight = Math.max(maxInFlight, inFlight);
           await new Promise((resolve) => setTimeout(resolve, 5));
-          inFlight -= 1;
         },
         createAppQueryClient(),
       );
@@ -607,10 +622,14 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
       });
       // Every path probed exactly once…
       expect([...requests].sort()).toEqual([...paths].sort());
-      // …never more than one chunk's worth of probes in flight at a time, and
-      // genuinely chunked (concurrent within a chunk, not serialized).
-      expect(maxInFlight).toBeLessThanOrEqual(8);
-      expect(maxInFlight).toBeGreaterThan(1);
+      // …and the wire is genuinely batched: each sweep chunk rides ONE
+      // `activityPaths` call bounded at the chunk size - 20 paths is exactly
+      // ceil(20/8) = 3 calls, never a per-path fan-out or a whole-list call.
+      expect(fixture.wireRequests).toHaveLength(3);
+      for (const call of fixture.wireRequests) {
+        expect(call.length).toBeLessThanOrEqual(8);
+      }
+      expect(fixture.wireRequests.some((call) => call.length > 1)).toBe(true);
     });
 
     it("probes a path exactly once when the sweep and the viewport race for it", async () => {
@@ -675,16 +694,20 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         { wrapper: fixture.Wrapper },
       );
 
-      // The mount-time sweep chunk fires without any visible-paths report.
+      // The mount-time sweep chunk fires without any visible-paths report
+      // (one advance to let the batcher's coalescing window flush).
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
       });
       expect(requests).toHaveLength(1);
 
       // Cold → the sweep's exponential backoff re-probes it (first retry
-      // after 750ms).
+      // after 750ms; the re-probe's batch window flushes on its own advance).
       await act(async () => {
         await vi.advanceTimersByTimeAsync(1_000);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
       });
       expect(requests).toHaveLength(2);
       expect(result.current.enrichedByPath.get("/wt/a")?.prState).toBe("none");
@@ -718,7 +741,7 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
       );
 
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
       });
       expect(requests).toHaveLength(1);
 
@@ -735,6 +758,10 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         await act(async () => {
           await vi.advanceTimersByTimeAsync(step.advanceMs);
         });
+        // Each re-probe's batch window flushes on its own advance.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
+        });
         expect(requests).toHaveLength(step.expectedCount);
       }
 
@@ -747,6 +774,9 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
           await vi.advanceTimersByTimeAsync(15_000);
         });
       }
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
+      });
       expect(requests).toHaveLength(10);
       await act(async () => {
         await vi.advanceTimersByTimeAsync(60_000);
@@ -760,18 +790,13 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         paths.map((path, i) => [path, warmEntry(path, `feat-${i}`)]),
       );
       const requests: string[] = [];
-      let inFlight = 0;
-      let maxInFlight = 0;
       const fixture = createFixture(
         entriesByPath,
         (path) => {
           requests.push(path);
         },
         async () => {
-          inFlight += 1;
-          maxInFlight = Math.max(maxInFlight, inFlight);
           await new Promise((resolve) => setTimeout(resolve, 5));
-          inFlight -= 1;
         },
         createAppQueryClient(),
       );
@@ -784,15 +809,14 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         expect(result.current.enrichedByPath.size).toBe(12);
       });
       expect(requests).toHaveLength(12);
-      maxInFlight = 0;
+      const wireCallsBeforeRefresh = fixture.wireRequests.length;
 
       // A refresh invalidates the method scope with `refetchType: "active"`
       // (mirroring `WorktreesBody.onRefresh`). The swept entries have no
       // observers, so nothing refetches directly - only the sweep can pick
       // them back up, woken by the invalidation cache event. The re-sweep must
       // be the same bounded chunk walk, never a whole-list fan-out: every path
-      // re-probed exactly once, and never more than one chunk's worth of
-      // probes in flight.
+      // re-probed exactly once, riding chunk-sized batched wire calls.
       await act(async () => {
         await fixture.queryClient.invalidateQueries({
           queryKey: METHOD_SCOPE,
@@ -803,8 +827,12 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         expect(requests).toHaveLength(24);
       });
       expect([...requests.slice(12)].sort()).toEqual([...paths].sort());
-      expect(maxInFlight).toBeLessThanOrEqual(8);
-      expect(maxInFlight).toBeGreaterThan(1);
+      const resweepCalls = fixture.wireRequests.slice(wireCallsBeforeRefresh);
+      expect(resweepCalls).toHaveLength(2); // ceil(12/8)
+      for (const call of resweepCalls) {
+        expect(call.length).toBeLessThanOrEqual(8);
+      }
+      expect(resweepCalls.some((call) => call.length > 1)).toBe(true);
     });
 
     it("keeps a permanently rejecting refresh bounded (regression: isInvalidated persists across failed refetches)", async () => {
@@ -831,7 +859,7 @@ describe("useWorktreeActivityEnrichment (live fetch → cache → overlay)", () 
         { wrapper: fixture.Wrapper },
       );
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(WORKTREE_BATCH_FLUSH_MS);
       });
       expect(requests).toHaveLength(1);
 

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-listing-query.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-listing-query.test.tsx
@@ -283,7 +283,7 @@ describe("useWorktreeListing (warm-open listing snapshot)", () => {
     // only understands numeric offsets).
     await waitFor(() => {
       expect(result.current.worktrees).toHaveLength(PAGE_LIMIT + 8);
-      expect(result.current.refreshing).toBe(false);
+      expect(result.current.isRefreshPending).toBe(false);
     });
     expect(result.current.worktrees[PAGE_LIMIT + 7].worktreePath).toBe(
       `/wt/old-${String(PAGE_LIMIT + 7)}`,
@@ -387,6 +387,67 @@ describe("useWorktreeListing (warm-open listing snapshot)", () => {
   // it - the row reads "Checking...". The overlays keep their keys, so nothing
   // else re-probes them: without this invalidation the Refresh button strands
   // every on-screen row, permanently against a host with no `worktree.changed`.
+  it("isRefreshPending tracks the manual refresh mutation only, not background fetches", async () => {
+    // Regression: the toolbar keyed its Refresh button's disabled state off a
+    // signal that also went true during background/enrichment fetching, so a
+    // cold fleet still converging locked the button (and the "Updated" label)
+    // out for the whole convergence.
+    const live = [listedEntry("/wt/a", "main")];
+    // Two gates: one holds the mount-time background page, one holds the
+    // forced-refresh request, so each can be observed in flight.
+    let backgroundGate: { promise: Promise<void>; resolve: () => void } | null =
+      deferred();
+    let refreshGate: { promise: Promise<void>; resolve: () => void } | null =
+      null;
+    const fixture = createFixture(
+      () => live,
+      null,
+      async (cursor) => {
+        void cursor;
+        if (backgroundGate !== null) {
+          await backgroundGate.promise;
+          return;
+        }
+        if (refreshGate !== null) await refreshGate.promise;
+      },
+    );
+    const { result } = renderHook(
+      () => useWorktreeListing(fixture.client, true),
+      { wrapper: fixture.Wrapper },
+    );
+
+    // The initial page is still fetching in the background, but no manual
+    // refresh has been triggered - the button must stay live.
+    expect(result.current.isRefreshPending).toBe(false);
+    act(() => {
+      backgroundGate?.resolve();
+      backgroundGate = null;
+    });
+    await waitFor(() => {
+      expect(result.current.worktrees).toHaveLength(1);
+    });
+    expect(result.current.isRefreshPending).toBe(false);
+
+    // Only the explicit Refresh mutation flips it; held in flight so `true`
+    // is observable, then cleared on settle.
+    refreshGate = deferred();
+    let refreshDone: Promise<unknown> = Promise.resolve();
+    act(() => {
+      refreshDone = result.current.refresh();
+    });
+    await waitFor(() => {
+      expect(result.current.isRefreshPending).toBe(true);
+    });
+    await act(async () => {
+      refreshGate?.resolve();
+      refreshGate = null;
+      await refreshDone;
+    });
+    await waitFor(() => {
+      expect(result.current.isRefreshPending).toBe(false);
+    });
+  });
+
   it("invalidates the per-path enrichment overlays after a forced refresh", async () => {
     const live = [listedEntry("/wt/a", "main")];
     const fixture = createFixture(() => live, null, null);

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-listing-query.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-listing-query.test.tsx
@@ -124,6 +124,83 @@ function createFixture(
   return { client, Wrapper, queryClient };
 }
 
+describe("listing snapshot sentinel guard (cold-host clobber regression)", () => {
+  // The base listing is deliberately non-spawning, so against a cold host it
+  // answers entirely in `unresolvedRow` sentinels (`resolvedAt: null`, unknown
+  // branch). Persisting those replaced a good snapshot with a fleet of
+  // "detached HEAD" rows, which then restored on the next launch - the failure
+  // seen live, where all 54 rows went unknown and stayed that way.
+  function sentinelEntry(worktreePath: string): WorktreeHostEntryV14 {
+    return {
+      ...listedEntry(worktreePath, "feat"),
+      branch: null,
+      gitRemovable: false,
+      resolvedAt: null,
+    };
+  }
+
+  it("never lets unresolved rows overwrite resolved ones, but still drops de-listed rows", () => {
+    persistWorktreeListingSnapshot({
+      hostId: HOST_ID,
+      entries: [
+        listedEntry("/wt/a", "feat-a"),
+        listedEntry("/wt/b", "feat-b"),
+        listedEntry("/wt/gone", "feat-gone"),
+      ],
+      now: Date.now(),
+    });
+
+    // A cold-host listing: /wt/gone is genuinely absent, the rest are sentinels.
+    persistWorktreeListingSnapshot({
+      hostId: HOST_ID,
+      entries: [sentinelEntry("/wt/a"), sentinelEntry("/wt/b")],
+      now: Date.now(),
+    });
+
+    const snapshot = readWorktreeListingSnapshot(HOST_ID, Date.now());
+    // Membership follows the incoming listing - absence is the one proof of
+    // deletion - but the surviving rows keep their resolved facts.
+    expect(snapshot?.entries.map((entry) => entry.worktreePath)).toEqual([
+      "/wt/a",
+      "/wt/b",
+    ]);
+    expect(snapshot?.entries.map((entry) => entry.branch)).toEqual([
+      "feat-a",
+      "feat-b",
+    ]);
+  });
+
+  it("still lets resolved rows replace resolved rows", () => {
+    persistWorktreeListingSnapshot({
+      hostId: HOST_ID,
+      entries: [listedEntry("/wt/a", "feat-a")],
+      now: Date.now(),
+    });
+    persistWorktreeListingSnapshot({
+      hostId: HOST_ID,
+      entries: [listedEntry("/wt/a", "feat-renamed")],
+      now: Date.now(),
+    });
+
+    const snapshot = readWorktreeListingSnapshot(HOST_ID, Date.now());
+    expect(snapshot?.entries.map((entry) => entry.branch)).toEqual([
+      "feat-renamed",
+    ]);
+  });
+
+  it("seeds a first snapshot even when the host is cold", () => {
+    persistWorktreeListingSnapshot({
+      hostId: HOST_ID,
+      entries: [sentinelEntry("/wt/a")],
+      now: Date.now(),
+    });
+
+    const snapshot = readWorktreeListingSnapshot(HOST_ID, Date.now());
+    expect(snapshot?.entries).toHaveLength(1);
+    expect(snapshot?.entries[0]?.resolvedAt).toBeNull();
+  });
+});
+
 describe("useWorktreeListing (warm-open listing snapshot)", () => {
   it("paints the last run's rows before the first page lands, then reconciles to live truth", async () => {
     const restored = [

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-row-overflow.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-row-overflow.test.tsx
@@ -86,6 +86,7 @@ function renderSingleRow(
           onRefresh: () => Promise.resolve(),
           refreshing: false,
           canRefresh: true,
+          lastUpdatedAt: null,
         }}
       />
     </Wrapper>,

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -10,6 +10,7 @@ import {
   within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
@@ -346,6 +347,32 @@ function renderList(args: {
   );
 }
 
+// Renders the toolbar with explicit props (the `renderList` helper always
+// passes the null-timestamp default) so tests can exercise the freshness label.
+function renderListWithToolbar(toolbarProps: ToolbarTestProps): void {
+  const queryClient = new QueryClient();
+  const Wrapper = (props: { readonly children: ReactNode }): ReactNode => (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{props.children}</TooltipProvider>
+    </QueryClientProvider>
+  );
+  render(
+    <Wrapper>
+      <WorktreesList
+        openStreamTransport={() => stubOpenStreamTransport()}
+        hostId="host-a"
+        worktrees={WORKTREES}
+        enrichedByPath={fullyEnriched(WORKTREES)}
+        erroredPaths={new Set()}
+        seededPaths={new Set()}
+        onVisiblePathsChange={vi.fn()}
+        taskTitlesByEpicId={new Map()}
+        toolbarProps={toolbarProps}
+      />
+    </Wrapper>,
+  );
+}
+
 function renderDefault(): void {
   renderList({
     hostId: "host-a",
@@ -383,7 +410,17 @@ function callbacksFor(path: string): WorktreeDeleteStreamCallbacks {
   return callbacks;
 }
 
-function testToolbarProps() {
+type ToolbarTestProps = {
+  hosts: readonly HostDirectoryEntry[];
+  value: string | null;
+  onChange: (hostId: string) => void;
+  onRefresh: () => Promise<unknown>;
+  refreshing: boolean;
+  canRefresh: boolean;
+  lastUpdatedAt: number | null;
+};
+
+function testToolbarProps(): ToolbarTestProps {
   return {
     hosts: [],
     value: null,
@@ -838,6 +875,29 @@ describe("WorktreesList delete flow", () => {
     expect(
       within(actionBar).getByTestId("worktrees-list-delete-selected").className,
     ).toContain("whitespace-nowrap");
+  });
+
+  it("shows the freshness label for a real timestamp and suppresses it while refreshing", () => {
+    // A non-null lastUpdatedAt renders the "Updated …" label; the null-timestamp
+    // fixtures elsewhere only cover its absence.
+    renderListWithToolbar({
+      ...testToolbarProps(),
+      lastUpdatedAt: Date.now() - 60_000,
+      refreshing: false,
+    });
+    const label = screen.getByTestId("worktrees-updated-ago");
+    expect(label.textContent).toMatch(/^Updated /);
+
+    cleanup();
+
+    // While a manual refresh is in flight the timestamp is suppressed (the
+    // spinning Refresh button stands in for it).
+    renderListWithToolbar({
+      ...testToolbarProps(),
+      lastUpdatedAt: Date.now() - 60_000,
+      refreshing: true,
+    });
+    expect(screen.queryByTestId("worktrees-updated-ago")).toBeNull();
   });
 
   it("selecting the first row does not insert a new top bar that shifts the list", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -391,6 +391,7 @@ function testToolbarProps() {
     onRefresh: vi.fn(),
     refreshing: false,
     canRefresh: true,
+    lastUpdatedAt: null,
   };
 }
 

--- a/clients/gui-app/src/components/settings/panels/worktrees-enrichment-batcher.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-enrichment-batcher.ts
@@ -1,5 +1,6 @@
 import {
   queryOptions,
+  replaceEqualDeep,
   useQueries,
   type QueryKey,
   type UseQueryResult,
@@ -52,6 +53,72 @@ export function perPathEnrichmentQueryKey(
   );
 }
 
+// The minimal shape this guard reasons about. Rows are passed through BY
+// REFERENCE, so every other field survives untouched - narrowing here only
+// keeps the guard honest about what it actually inspects.
+type ResolvableRow = {
+  readonly worktreePath: string;
+  readonly resolvedAt: number | null;
+};
+
+function isResolvableResponse(
+  value: unknown,
+): value is { readonly worktrees: readonly ResolvableRow[] } {
+  if (value === null || typeof value !== "object") return false;
+  if (!("worktrees" in value)) return false;
+  const { worktrees } = value;
+  return (
+    Array.isArray(worktrees) &&
+    worktrees.every(
+      (row: unknown) =>
+        row !== null &&
+        typeof row === "object" &&
+        "worktreePath" in row &&
+        typeof row.worktreePath === "string" &&
+        "resolvedAt" in row &&
+        (row.resolvedAt === null || typeof row.resolvedAt === "number"),
+    )
+  );
+}
+
+/**
+ * Cache-write guard shared by both enrichment legs: a row the host answered
+ * UNRESOLVED (`resolvedAt === null` - the cold-host `unresolvedRow` sentinel,
+ * rendered as "detached HEAD" / "Waiting for host verification…") never
+ * replaces a resolved row already in cache.
+ *
+ * Resolved data is only ever replaced by resolved data; a row disappears only
+ * by leaving the base listing, which is the one thing that proves it is gone.
+ * Wired through TanStack's `structuralSharing` so it covers every write to
+ * these keys - the observer leg, the sweep's `fetchQuery`, and refetches -
+ * without each call site remembering to merge.
+ *
+ * Delegates to `replaceEqualDeep` (what TanStack's DEFAULT structural sharing
+ * does) rather than returning a fresh object: the enrichment fold keeps its Map
+ * identity only while equal refetches preserve row references, and losing that
+ * re-renders every row in the list on each probe.
+ */
+export function keepResolvedEnrichmentRows(
+  previous: unknown,
+  next: unknown,
+): unknown {
+  if (!isResolvableResponse(previous) || !isResolvableResponse(next)) {
+    return replaceEqualDeep(previous, next);
+  }
+  const previousByPath = new Map(
+    previous.worktrees.map((row) => [row.worktreePath, row]),
+  );
+  const worktrees = next.worktrees.map((row) => {
+    if (row.resolvedAt !== null) return row;
+    const prior = previousByPath.get(row.worktreePath);
+    return prior !== undefined && prior.resolvedAt !== null ? prior : row;
+  });
+  // Unconditionally rebuilt, then handed to `replaceEqualDeep`: when nothing
+  // was actually held back the result deep-equals `previous` and the previous
+  // reference comes straight back, so row identity survives an equal refetch.
+  return replaceEqualDeep(previous, { ...next, worktrees });
+}
+
 /**
  * Observer-leg fetch driver over the batched transport. Split out here (not
  * `useHostQueries`, the usual wrapper) because that wrapper hard-wires one
@@ -86,6 +153,7 @@ export function useBatchedEnrichmentQueries(args: {
         // cold-PR retry ledgers are the only re-probe paths.
         staleTime: Infinity,
         gcTime: WORKTREE_ENRICHMENT_GC_MS,
+        structuralSharing: keepResolvedEnrichmentRows,
       });
     }),
   });

--- a/clients/gui-app/src/components/settings/panels/worktrees-enrichment-batcher.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-enrichment-batcher.ts
@@ -1,0 +1,189 @@
+import {
+  queryOptions,
+  useQueries,
+  type QueryKey,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
+import type {
+  WorktreeHostEntryV14,
+  WorktreeListAllForHostResponseV14,
+} from "@traycer/protocol/host/worktree-schemas";
+import { type HostRpcRegistry } from "@/lib/host";
+import { hostQueryKeys } from "@/lib/query-keys";
+import { hostClientUnavailableError } from "@/hooks/host/use-host-query";
+
+/**
+ * Paths per batched `worktree.listAllForHost` RPC. Matches the sweep's chunk
+ * size, so one sweep pass is exactly one wire call.
+ */
+export const WORKTREE_ENRICH_BATCH_LIMIT = 8;
+// Both enrichment legs pin the same generous gcTime, well past TanStack's
+// 5-minute default: swept entries have no observers, so under the default they
+// would be garbage-collected while the panel sits open - each GC visibly
+// regresses its row to "Checking…" and the sweep would re-probe it, a slow,
+// pointless churn loop. Refresh (method-scope invalidation) remains the way
+// entries are re-probed deliberately.
+export const WORKTREE_ENRICHMENT_GC_MS = 30 * 60_000;
+
+// The per-path enrichment params, shared by the viewport observers and the
+// background sweep so both produce identical query keys - the cache fold and
+// TanStack's request dedupe both hinge on that identity. `forceRefresh` is
+// pinned to its canonical `false`: it is a fetch directive, so every automatic
+// enrichment/refetch lands in the same entry and remains a cache-only host read.
+export function perPathEnrichmentParams(path: string) {
+  return {
+    includeActivity: true,
+    activityPaths: [path],
+    cursor: null,
+    limit: null,
+    forceRefresh: false,
+  };
+}
+
+export function perPathEnrichmentQueryKey(
+  hostId: string | null,
+  path: string,
+): QueryKey {
+  return hostQueryKeys.method<HostRpcRegistry, "worktree.listAllForHost">(
+    hostId,
+    "worktree.listAllForHost",
+    perPathEnrichmentParams(path),
+  );
+}
+
+/**
+ * Observer-leg fetch driver over the batched transport. Split out here (not
+ * `useHostQueries`, the usual wrapper) because that wrapper hard-wires one
+ * `client.request` per request spec - the whole point of this module is the
+ * coalesced transport. Key shape, enabled gating, and error typing mirror the
+ * wrapper exactly; consumers treat the returned results as the same opaque
+ * array.
+ */
+export function useBatchedEnrichmentQueries(args: {
+  readonly hostId: string | null;
+  readonly paths: readonly string[];
+  readonly batcher: WorktreeEnrichmentBatcher | null;
+  readonly enabled: boolean;
+}): Array<UseQueryResult<WorktreeListAllForHostResponseV14, HostRpcError>> {
+  const { hostId, paths, batcher, enabled } = args;
+  return useQueries({
+    queries: paths.map((path) => {
+      // The batcher is transport, not cache identity - it stays out of the
+      // query key, exactly as the client did under `useHostQueries`.
+      const fetcher = (): Promise<WorktreeListAllForHostResponseV14> =>
+        batcher === null
+          ? Promise.reject(
+              hostClientUnavailableError("worktree.listAllForHost"),
+            )
+          : batcher.fetchPath(path);
+      return queryOptions<WorktreeListAllForHostResponseV14, HostRpcError>({
+        queryKey: perPathEnrichmentQueryKey(hostId, path),
+        queryFn: fetcher,
+        enabled,
+        // Probe-once for real (manual-refresh model): an enriched row never
+        // refetches on remount or scroll-back. Refresh invalidation and the
+        // cold-PR retry ledgers are the only re-probe paths.
+        staleTime: Infinity,
+        gcTime: WORKTREE_ENRICHMENT_GC_MS,
+      });
+    }),
+  });
+}
+// Coalescing window: how long the first enqueued path waits for company
+// before its batch flushes. Sized to catch callers that enqueue across a few
+// microtask/effect boundaries (a viewport settle window's observers, the
+// staggered timers of one cold-retry round) while staying imperceptible
+// against the RPC's own latency.
+const WORKTREE_ENRICH_BATCH_WINDOW_MS = 25;
+
+interface PendingEnrichmentPath {
+  readonly path: string;
+  readonly resolve: (response: WorktreeListAllForHostResponseV14) => void;
+  readonly reject: (error: unknown) => void;
+}
+
+export interface WorktreeEnrichmentBatcher {
+  readonly fetchPath: (
+    path: string,
+  ) => Promise<WorktreeListAllForHostResponseV14>;
+}
+
+/**
+ * Coalesces per-path enrichment fetches into chunked `activityPaths` RPCs.
+ *
+ * The per-path shape is a CACHE choice, not a wire necessity: TanStack keys
+ * each worktree's enrichment under its own path (probe once, scroll-back is a
+ * cache hit, per-path error isolation), but issuing one WebSocket dial per
+ * path made opening or refreshing an N-row fleet cost N dials. This layer
+ * keeps the per-path cache entries exactly as they are - each `fetchPath`
+ * resolves with a response shaped like the old single-path RPC - while the
+ * wire carries up to {@link WORKTREE_ENRICH_BATCH_LIMIT} paths per call.
+ *
+ * Row fan-out matches by EXACT `worktreePath` string equality, the same
+ * contract the host's per-path change emits rely on (raw paths, never
+ * normalized). A requested path with no row in the batch response resolves to
+ * an empty listing - identical to what its single-path RPC would have
+ * returned for a path absent from the disk walk. A failed batch rejects every
+ * waiter in the chunk with the same error; retry bookkeeping stays per-path
+ * in the callers, so one poisoned path never spends its neighbours' budgets.
+ *
+ * No dedupe on purpose: TanStack already single-flights per query key, and
+ * the sweep skips paths that are fetching or viewport-owned, so a path never
+ * has two concurrent waiters.
+ */
+export function createWorktreeEnrichmentBatcher(
+  requestBatch: (
+    paths: readonly string[],
+  ) => Promise<WorktreeListAllForHostResponseV14>,
+): WorktreeEnrichmentBatcher {
+  let pending: PendingEnrichmentPath[] = [];
+  let windowTimer: number | null = null;
+
+  const flush = (): void => {
+    if (windowTimer !== null) {
+      window.clearTimeout(windowTimer);
+      windowTimer = null;
+    }
+    while (pending.length > 0) {
+      const chunk = pending.slice(0, WORKTREE_ENRICH_BATCH_LIMIT);
+      pending = pending.slice(WORKTREE_ENRICH_BATCH_LIMIT);
+      void requestBatch(chunk.map((entry) => entry.path)).then(
+        (response) => {
+          const rowsByPath = new Map<string, WorktreeHostEntryV14[]>();
+          for (const row of response.worktrees) {
+            const rows = rowsByPath.get(row.worktreePath) ?? [];
+            rows.push(row);
+            rowsByPath.set(row.worktreePath, rows);
+          }
+          for (const entry of chunk) {
+            entry.resolve({
+              worktrees: rowsByPath.get(entry.path) ?? [],
+              nextCursor: null,
+            });
+          }
+        },
+        (error: unknown) => {
+          for (const entry of chunk) entry.reject(error);
+        },
+      );
+    }
+  };
+
+  return {
+    fetchPath: (path) =>
+      new Promise((resolve, reject) => {
+        pending.push({ path, resolve, reject });
+        if (pending.length >= WORKTREE_ENRICH_BATCH_LIMIT) {
+          flush();
+          return;
+        }
+        if (windowTimer === null) {
+          windowTimer = window.setTimeout(() => {
+            windowTimer = null;
+            flush();
+          }, WORKTREE_ENRICH_BATCH_WINDOW_MS);
+        }
+      }),
+  };
+}

--- a/clients/gui-app/src/components/settings/panels/worktrees-enrichment-persistence.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-enrichment-persistence.ts
@@ -71,6 +71,19 @@ function worktreeEntryIsWarm(entry: WorktreeHostEntryV14): boolean {
   );
 }
 
+/**
+ * Whether the host has actually derived this row's git facts.
+ * `resolvedAt === null` is the `unresolvedRow` SENTINEL a cold host answers
+ * with - unknown branch, `gitRemovable: false`, no owners - which the panel
+ * renders as "detached HEAD" / "Waiting for host verification…".
+ *
+ * Distinct from {@link worktreeEntryIsWarm}, which is about the (later) `gh`
+ * PR probe: a row can be fully resolved with its PR fact still warming.
+ */
+function worktreeEntryIsResolved(entry: WorktreeHostEntryV14): boolean {
+  return entry.resolvedAt !== null;
+}
+
 function parseSnapshot(raw: string): WorktreeActivitySnapshot | null {
   // Boundary catch: corrupt disk state must read as "no snapshot", never
   // throw into the panel's render path.
@@ -179,16 +192,38 @@ export function readWorktreeListingSnapshot(
 }
 
 /**
- * Writes the base-listing snapshot for `hostId`: every listed row (warm or
- * not), in listing order. The caller only persists COMPLETE listings (all
- * pages landed), so a restored row list is never a silently-truncated prefix.
+ * Writes the base-listing snapshot for `hostId`, in listing order. The caller
+ * only persists COMPLETE listings (all pages landed), so a restored row list is
+ * never a silently-truncated prefix.
+ *
+ * Membership comes from the incoming listing - a row absent there is proven
+ * gone and drops - but an UNRESOLVED incoming row never overwrites a resolved
+ * one already on disk. The base listing is deliberately non-spawning, so
+ * against a cold host it answers entirely in `unresolvedRow` sentinels; writing
+ * those through replaced a good snapshot with a fleet of "detached HEAD" rows
+ * that then restored on the next launch. Resolved data is only ever replaced by
+ * resolved data.
  */
 export function persistWorktreeListingSnapshot(args: {
   readonly hostId: string;
   readonly entries: readonly WorktreeHostEntryV14[];
   readonly now: number;
 }): void {
-  writeSnapshotAt(worktreeListingCacheKey(args.hostId), args.entries, args.now);
+  const key = worktreeListingCacheKey(args.hostId);
+  const previousByPath = new Map(
+    (readSnapshotAt(key, args.now)?.entries ?? []).map((entry) => [
+      entry.worktreePath,
+      entry,
+    ]),
+  );
+  const entries = args.entries.map((entry) => {
+    if (worktreeEntryIsResolved(entry)) return entry;
+    const previous = previousByPath.get(entry.worktreePath);
+    return previous !== undefined && worktreeEntryIsResolved(previous)
+      ? previous
+      : entry;
+  });
+  writeSnapshotAt(key, entries, args.now);
 }
 
 /**

--- a/clients/gui-app/src/components/settings/panels/worktrees-enrichment.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-enrichment.ts
@@ -26,6 +26,7 @@ import { logPerfEvent } from "@/lib/perf/perf-telemetry";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
 import {
   createWorktreeEnrichmentBatcher,
+  keepResolvedEnrichmentRows,
   perPathEnrichmentQueryKey,
   useBatchedEnrichmentQueries,
   WORKTREE_ENRICHMENT_GC_MS,
@@ -143,6 +144,7 @@ function sweepEnrichmentFetchOptions(
     // the same cold row a nonzero staleTime would consider fresh.
     staleTime: 0,
     gcTime: WORKTREE_ENRICHMENT_GC_MS,
+    structuralSharing: keepResolvedEnrichmentRows,
   });
 }
 

--- a/clients/gui-app/src/components/settings/panels/worktrees-enrichment.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-enrichment.ts
@@ -11,7 +11,6 @@ import {
   queryOptions,
   useQueryClient,
   type QueryClient,
-  type QueryKey,
 } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { withHostRpcErrorBoundary } from "@traycer-clients/shared/host-transport/host-messenger";
@@ -24,8 +23,14 @@ import {
   perPathEnrichmentQueryPath,
 } from "@/lib/query-keys/worktree-enrichment-keys";
 import { logPerfEvent } from "@/lib/perf/perf-telemetry";
-import { useHostQueries } from "@/hooks/host/use-host-queries";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
+import {
+  createWorktreeEnrichmentBatcher,
+  perPathEnrichmentQueryKey,
+  useBatchedEnrichmentQueries,
+  WORKTREE_ENRICHMENT_GC_MS,
+  type WorktreeEnrichmentBatcher,
+} from "@/components/settings/panels/worktrees-enrichment-batcher";
 import { useWorktreeEnrichSettlePerf } from "@/components/settings/panels/worktrees-settings-perf";
 import {
   persistWorktreeActivitySnapshot,
@@ -80,13 +85,6 @@ function coldRetryDelayMs(attempts: number): number {
 // viewport batch, so the host never sees more concurrent per-path probes than
 // a normal scroll would produce.
 const WORKTREE_SWEEP_CHUNK_SIZE = 8;
-// Both enrichment legs pin the same generous gcTime, well past TanStack's
-// 5-minute default: swept entries have no observers, so under the default they
-// would be garbage-collected while the panel sits open - each GC visibly
-// regresses its row to "Checking…" and the sweep would re-probe it, a slow,
-// pointless churn loop. Refresh (method-scope invalidation) remains the way
-// entries are re-probed deliberately.
-const WORKTREE_ENRICHMENT_GC_MS = 30 * 60_000;
 // Debounce for the warm-open snapshot writes: the cache fold's identity
 // changes on every relevant cache event (each settled probe), so writes wait
 // for a quiet window instead of serializing the fleet once per chunk while
@@ -108,21 +106,6 @@ interface SweepRetryState {
   readonly sawInvalidated: boolean;
 }
 
-// The per-path enrichment params, shared by the viewport observers and the
-// background sweep so both produce identical query keys - the cache fold and
-// TanStack's request dedupe both hinge on that identity. `forceRefresh` is
-// pinned to its canonical `false`: it is a fetch directive, so every automatic
-// enrichment/refetch lands in the same entry and remains a cache-only host read.
-function perPathEnrichmentParams(path: string) {
-  return {
-    includeActivity: true,
-    activityPaths: [path],
-    cursor: null,
-    limit: null,
-    forceRefresh: false,
-  };
-}
-
 // `prState === null` = "not yet probed" (distinct from `"none"` = probed, no
 // PR): the host served a stale/cold row and scheduled a background `gh` probe
 // whose result never re-emits; only a refetch picks the warmed fact up. A
@@ -139,36 +122,25 @@ function responseHasColdPrState(
   );
 }
 
-function perPathEnrichmentQueryKey(hostId: string, path: string): QueryKey {
-  return hostQueryKeys.method<HostRpcRegistry, "worktree.listAllForHost">(
-    hostId,
-    "worktree.listAllForHost",
-    perPathEnrichmentParams(path),
-  );
-}
-
 // The sweep's imperative fetch, mirroring the observer leg exactly (same key,
-// same request) so the two legs dedupe onto one in-flight query. As in
-// `useHostQueriesWithResponseMap`, the client stays OUT of the query key -
-// `hostId` already carries the cache identity; the client is transport.
+// same batched transport) so the two legs dedupe onto one in-flight query.
+// The client stays OUT of the query key - `hostId` already carries the cache
+// identity; the batcher is transport.
 function sweepEnrichmentFetchOptions(
   hostId: string,
-  client: HostClient<HostRpcRegistry>,
+  batcher: WorktreeEnrichmentBatcher,
   path: string,
 ) {
-  // Boundary-wrapped: the sweep and the `useHostQueries` observer leg share
-  // this key, so a sweep failure must store the same `HostRpcError` shape the
-  // observer's error generic declares.
-  const fetcher = () =>
-    withHostRpcErrorBoundary("worktree.listAllForHost", () =>
-      client.request("worktree.listAllForHost", perPathEnrichmentParams(path)),
-    );
+  // Rejections carry the `HostRpcError` shape the observer leg declares: the
+  // batcher wraps its wire call in the host-rpc error boundary. The batcher
+  // stays out of the query key (it is transport, like the client before it).
+  const fetcher = () => batcher.fetchPath(path);
   return queryOptions({
     queryKey: perPathEnrichmentQueryKey(hostId, path),
     queryFn: fetcher,
     // Sweep candidates are exactly the missing / invalidated / still-cold
-    // entries, so this must always hit the network - never be handed back the
-    // same cold row the app's 60s default staleTime considers fresh.
+    // entries, so this must always hit the network - never be handed back
+    // the same cold row a nonzero staleTime would consider fresh.
     staleTime: 0,
     gcTime: WORKTREE_ENRICHMENT_GC_MS,
   });
@@ -409,10 +381,12 @@ export function useCachedWorktreeEnrichment(
  * Per-viewport lazy enrichment. The base list paints instantly with cheap fields;
  * the expensive activity probes (git ahead/behind/merged, gh PR state, submodule
  * merge facts) are fetched ONLY for the worktree paths currently on screen. Each
- * on-screen path gets its OWN selection-mode `worktree.listAllForHost`
- * (`includeActivity: true`, `activityPaths: [path]`, `cursor: null`,
- * `limit: null`) query, so TanStack Query caches enrichment PER PATH: a path is
- * probed once, and scrolling back to it is a cache hit, never a refetch.
+ * on-screen path gets its OWN selection-mode `worktree.listAllForHost` query
+ * (keyed on `activityPaths: [path]`), so TanStack Query caches enrichment PER
+ * PATH: a path is probed once, and scrolling back to it is a cache hit, never a
+ * refetch. The WIRE is batched underneath: per-path fetches coalesce through
+ * {@link createWorktreeEnrichmentBatcher} into chunked `activityPaths` RPCs, so
+ * cache granularity stays per-path while dial count is ~paths/8.
  *
  * The reported on-screen set is debounced into `requestedPaths` (trailing edge),
  * so a fast scroll spins up one batch of per-path queries per settle window, not
@@ -503,22 +477,36 @@ export function useWorktreeActivityEnrichment(
     [],
   );
 
-  // One enrichment query per on-screen path - the cache identity is the path
-  // itself, so each worktree is probed exactly once and cached independently. This
-  // only DRIVES fetching; the overlay is read from the cache below.
-  const requests = useMemo(
+  // The shared wire transport for BOTH enrichment legs: per-path fetches
+  // coalesce into chunked `activityPaths` RPCs (see the batcher's doc), so an
+  // N-row open or refresh costs ~N/8 dials instead of N. Keyed on the bound
+  // client alone - host identity lives in the query keys.
+  const readiness = useReactiveHostReadiness(client);
+  const batcher = useMemo(
     () =>
-      requestedPaths.map((path) => ({
-        method: "worktree.listAllForHost" as const,
-        params: perPathEnrichmentParams(path),
-      })),
-    [requestedPaths],
+      client === null
+        ? null
+        : createWorktreeEnrichmentBatcher((paths) =>
+            withHostRpcErrorBoundary("worktree.listAllForHost", () =>
+              client.request("worktree.listAllForHost", {
+                includeActivity: true,
+                activityPaths: [...paths],
+                cursor: null,
+                limit: null,
+                forceRefresh: false,
+              }),
+            ),
+          ),
+    [client],
   );
-  const results = useHostQueries({
-    client,
-    cacheKeyIdentity: undefined,
-    requests,
-    options: { enabled: reachable, gcTime: WORKTREE_ENRICHMENT_GC_MS },
+  // One enrichment query per on-screen path - the cache identity is the path
+  // itself, so each worktree is probed exactly once and cached independently.
+  // This only DRIVES fetching; the overlay is read from the cache below.
+  const results = useBatchedEnrichmentQueries({
+    hostId: readiness.hostId,
+    paths: requestedPaths,
+    batcher,
+    enabled: reachable && client !== null && readiness.isReady,
   });
   const coldPrRefetchStateRef = useRef<Map<string, ColdPrRefetchState>>(
     new Map(),
@@ -684,12 +672,10 @@ export function useWorktreeActivityEnrichment(
   // The viewport drives the rows on screen; the sweep drives everything else.
   // Each pass fetches ONE chunk of paths that still need a probe (no cached
   // data, invalidated by a refresh, or landed cold) through
-  // `queryClient.fetchQuery` under the exact per-path keys the observers use,
-  // then bumps `sweepTick` on settle to schedule the next chunk. Keys are
-  // built from the client's OWN readiness (`readiness.hostId`), mirroring
-  // `useHostQueries`, so swept entries land in precisely the scope the fold
-  // and the observers read.
-  const readiness = useReactiveHostReadiness(client);
+  // `queryClient.fetchQuery` under the exact per-path keys the observers use
+  // - and through the same batcher, so a whole chunk is one wire call. Keys
+  // are built from the client's OWN readiness (`readiness.hostId`), so swept
+  // entries land in precisely the scope the fold and the observers read.
   const [sweepTick, bumpSweepTick] = useReducer((tick: number) => tick + 1, 0);
   const [seedTick, bumpSeedTick] = useReducer((tick: number) => tick + 1, 0);
   const seedsOutstandingRef = useRef(false);
@@ -749,7 +735,8 @@ export function useWorktreeActivityEnrichment(
     // gives the fold a fresh identity.
     void sweepTick;
     void enrichedByPath;
-    if (!reachable || client === null || !readiness.isReady) return;
+    if (!reachable || client === null || batcher === null) return;
+    if (!readiness.isReady) return;
     const sweepHostId = readiness.hostId;
     if (sweepHostId === null) return;
     // One chunk in flight at a time; its settle handler bumps `sweepTick`.
@@ -757,7 +744,7 @@ export function useWorktreeActivityEnrichment(
     // Visible rows first: while the viewport batch is fetching, hold the sweep
     // so the on-screen rows always win the host's attention.
     if (results.some((result) => result.isFetching)) return;
-    const boundClient = client;
+    const boundBatcher = batcher;
     const ledger = sweepLedgerRef.current;
     const now = Date.now();
     const { candidates, nextWakeAt } = selectSweepChunk({
@@ -800,7 +787,7 @@ export function useWorktreeActivityEnrichment(
     void Promise.allSettled(
       candidates.map((path) =>
         queryClient.fetchQuery(
-          sweepEnrichmentFetchOptions(sweepHostId, boundClient, path),
+          sweepEnrichmentFetchOptions(sweepHostId, boundBatcher, path),
         ),
       ),
     ).then((outcomes) => {
@@ -847,6 +834,7 @@ export function useWorktreeActivityEnrichment(
     results,
     enrichedByPath,
     client,
+    batcher,
     reachable,
     readiness.isReady,
     readiness.hostId,

--- a/clients/gui-app/src/components/settings/panels/worktrees-listing-query.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-listing-query.ts
@@ -118,7 +118,13 @@ export function useWorktreeListing(
    * every already-landed page too.
    */
   readonly retryPartial: () => Promise<unknown>;
-  readonly refreshing: boolean;
+  /**
+   * True only while the user's explicit Refresh (the forced-listing mutation)
+   * is in flight - NOT during background page fetches or enrichment. The
+   * toolbar keys the Refresh button's disabled/spinner state off this, so it
+   * stays clickable while a cold fleet is still converging its rows.
+   */
+  readonly isRefreshPending: boolean;
   /**
    * When the listing data was last written: a live fetch's wall-clock stamp,
    * or the snapshot's own save time while the warm-open seed is still what's
@@ -192,7 +198,6 @@ export function useWorktreeListing(
     fetchStatus,
     hasNextPage,
     isError,
-    isFetching,
     isFetchingNextPage,
     isPending,
     isSuccess,
@@ -359,7 +364,7 @@ export function useWorktreeListing(
       });
     },
     retryPartial: () => fetchNextPage(),
-    refreshing: isFetching || refreshMutation.isPending,
+    isRefreshPending: refreshMutation.isPending,
     lastUpdatedAt: dataUpdatedAt === 0 ? null : dataUpdatedAt,
   };
 }

--- a/clients/gui-app/src/components/settings/panels/worktrees-listing-query.ts
+++ b/clients/gui-app/src/components/settings/panels/worktrees-listing-query.ts
@@ -119,6 +119,13 @@ export function useWorktreeListing(
    */
   readonly retryPartial: () => Promise<unknown>;
   readonly refreshing: boolean;
+  /**
+   * When the listing data was last written: a live fetch's wall-clock stamp,
+   * or the snapshot's own save time while the warm-open seed is still what's
+   * showing. `null` until any data exists. Drives the toolbar's
+   * "Updated Xm ago" label under the manual-refresh model.
+   */
+  readonly lastUpdatedAt: number | null;
 } {
   const readiness = useReactiveHostReadiness(client);
   const enabled = reachable && client !== null && readiness.isReady;
@@ -153,6 +160,11 @@ export function useWorktreeListing(
     >(key, seededListingData(snapshot.entries), {
       updatedAt: snapshot.savedAt,
     });
+    // Under `staleTime: Infinity` a seed would otherwise read as fresh
+    // forever. The snapshot is ANOTHER session's truth, so mark it
+    // invalidated: the observer reconciles it against the host exactly once
+    // (on enable), and only live data earned this session sticks.
+    void queryClient.invalidateQueries({ queryKey: key });
     logPerfEvent("worktree.listing_restore", {
       restoredCount: snapshot.entries.length,
     });
@@ -174,6 +186,7 @@ export function useWorktreeListing(
     });
   const {
     data,
+    dataUpdatedAt,
     error,
     fetchNextPage,
     fetchStatus,
@@ -197,6 +210,12 @@ export function useWorktreeListing(
       initialPageParam: null,
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       enabled,
+      // Manual-refresh model: the listing never expires on its own. The host
+      // pushes `worktree.changed` only on real mutations now (no periodic
+      // sweep), so freshness is owned by the Refresh button + invalidation;
+      // the toolbar surfaces `lastUpdatedAt` so staleness is visible instead
+      // of silently refetched.
+      staleTime: Infinity,
     }),
   );
   const refreshMutation = useMutation<
@@ -341,5 +360,6 @@ export function useWorktreeListing(
     },
     retryPartial: () => fetchNextPage(),
     refreshing: isFetching || refreshMutation.isPending,
+    lastUpdatedAt: dataUpdatedAt === 0 ? null : dataUpdatedAt,
   };
 }

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -588,7 +588,11 @@ function WorktreesBody(props: {
     value,
     onChange,
     onRefresh,
-    refreshing: listing.refreshing || enrichment.enriching,
+    // Only the explicit Refresh mutation locks the button - NOT enrichment.
+    // A cold fleet enriches for tens of seconds; gating on that stranded the
+    // manual escape hatch (and the "Updated Xm ago" label) for the whole
+    // convergence, which is exactly when the user most wants to re-pull.
+    refreshing: listing.isRefreshPending,
     canRefresh,
     lastUpdatedAt: listing.lastUpdatedAt,
   };

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -268,6 +268,7 @@ function WorktreesToolbar(props: {
   readonly onRefresh: () => Promise<unknown>;
   readonly refreshing: boolean;
   readonly canRefresh: boolean;
+  readonly lastUpdatedAt: number | null;
   readonly selectionControls: ReactNode | null;
   readonly filterControls: ReactNode | null;
 }): ReactNode {
@@ -275,6 +276,7 @@ function WorktreesToolbar(props: {
     canRefresh,
     filterControls,
     hosts,
+    lastUpdatedAt,
     onChange,
     onRefresh,
     refreshing,
@@ -295,10 +297,13 @@ function WorktreesToolbar(props: {
       <div className="flex items-center justify-between gap-2">
         <HostSelect hosts={hosts} value={value} onChange={onChange} />
         <div
-          className="flex shrink-0 items-center gap-1"
+          className="flex shrink-0 items-center gap-2"
           data-testid="worktrees-toolbar-actions"
         >
           {selectionControls}
+          {refresh.refreshing ? null : (
+            <WorktreesUpdatedAgoLabel updatedAt={lastUpdatedAt} />
+          )}
           <Button
             type="button"
             variant="outline"
@@ -316,6 +321,35 @@ function WorktreesToolbar(props: {
       </div>
       {filterControls}
     </div>
+  );
+}
+
+/**
+ * "Updated Xm ago" beside the Refresh button. Under the manual-refresh model
+ * (listing `staleTime: Infinity`, no host freshness sweep) this is the only
+ * signal of how old the list is - a warm-open seed shows its snapshot-era
+ * save time, so a relaunch honestly reads as hours old until refreshed.
+ * Split into an outer null-gate and an inner hook caller so the shared 60s
+ * relative-time clock only re-renders this leaf, never the toolbar.
+ */
+function WorktreesUpdatedAgoLabel(props: {
+  readonly updatedAt: number | null;
+}): ReactNode {
+  if (props.updatedAt === null) return null;
+  return <WorktreesUpdatedAgoText updatedAt={props.updatedAt} />;
+}
+
+function WorktreesUpdatedAgoText(props: {
+  readonly updatedAt: number;
+}): ReactNode {
+  const ago = useRelativeTimestamp(props.updatedAt);
+  return (
+    <span
+      className="text-ui-xs whitespace-nowrap text-muted-foreground"
+      data-testid="worktrees-updated-ago"
+    >
+      Updated {ago}
+    </span>
   );
 }
 
@@ -556,6 +590,7 @@ function WorktreesBody(props: {
     onRefresh,
     refreshing: listing.refreshing || enrichment.enriching,
     canRefresh,
+    lastUpdatedAt: listing.lastUpdatedAt,
   };
 
   let content: ReactNode;
@@ -807,6 +842,7 @@ export function WorktreesList(props: {
     readonly onRefresh: () => Promise<unknown>;
     readonly refreshing: boolean;
     readonly canRefresh: boolean;
+    readonly lastUpdatedAt: number | null;
   };
 }): ReactNode {
   const {


### PR DESCRIPTION
## Summary

The Settings ▸ Worktrees page was the noisy-RPC surface behind a live CDP audit: it refetched its listing on the host's 15s `worktree.changed` push cadence, and issued **one WebSocket dial per worktree row** for activity enrichment. On an N-row fleet that was ~N dials (each with a full JWT handshake) on open and again on every Refresh, plus a steady 15s background trio at idle.

This moves the page to a **manual-refresh** model and **batches** the enrichment wire.

## Changes

- **`staleTime: Infinity`** on the base listing and per-path enrichment queries. Freshness is now owned by the Refresh button + real host pushes (create/delete/setup-completion), not a timer. Warm-open snapshot seeds are invalidated on restore, so a relaunch reconciles against the host exactly once instead of trusting another session's snapshot forever.
- **"Updated Xm ago"** label beside Refresh (from the query's `dataUpdatedAt`, on the shared 60s relative-time clock) so staleness is visible instead of silently refetched. A warm-open seed honestly shows its snapshot-era time.
- **Chunked-batch enrichment** (`worktrees-enrichment-batcher.ts`): per-path fetches coalesce into `activityPaths` RPCs of up to 8 paths, and the response is fanned back into the existing per-path cache entries. Cache identity, scroll-back hits, per-path error isolation, and warm-open seeding are unchanged — only the dial count drops, to ~N/8. Both the viewport observer leg and the background sweep ride the same batcher.

## Pairs with

The traycer-host PR that retires the periodic worktree freshness sweep (keeping mutation-driven `worktree.changed` pushes and adding a direct push for late cold-resolve convergence). Both are needed for the idle traffic to actually stop.

## Testing

- `bun run compile` clean; 343 gui-app panel tests pass (sweep tests rewritten to assert wire-batch composition — e.g. 20 paths → exactly 3 batched calls — rather than the retired per-path concurrency).
- ESLint + react-doctor clean on changed files.
- Not yet exercised in a running app; a dev-desktop CDP re-check (no 15s trio at idle, one batched call per chunk on open) is planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)