### PR TITLE
fix(gui-app): open bundle diff files in source viewer

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-bundle-file-section.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-bundle-file-section.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { GitChangedFile } from "@traycer/protocol/host";
+import { nestedFocusBoundaryMock } from "@/__tests__/nested-focus-boundary-mock";
+import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
+import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
+import { makeGitBundleDiffTile } from "@/lib/git/git-diff-tile";
+import {
+  createOpenEpicStore,
+  type EpicStreamClientFactory,
+  type OpenEpicStoreHandle,
+} from "@/stores/epics/open-epic/store";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { BundleFileSection } from "../git-bundle-file-section";
+import type { GitBundleDiffTileRef } from "../git-diff-tile-shared";
+
+const FILE: GitChangedFile = {
+  path: "src/app.ts",
+  previousPath: null,
+  status: "modified",
+  stage: "unstaged",
+  insertions: 1_001,
+  deletions: 0,
+  isBinary: false,
+  sizeBytes: 1_024,
+  stagedOid: null,
+  worktreeOid: "worktree-1",
+};
+
+function bundleNode(): GitBundleDiffTileRef {
+  const node = makeGitBundleDiffTile({
+    hostId: "host-1",
+    runningDir: "/repo",
+    bundleGroup: "changes",
+    repositoryContext: null,
+  });
+  if (node.diff.kind !== "bundle") throw new Error("expected bundle node");
+  return { ...node, diff: node.diff };
+}
+
+const NODE = bundleNode();
+
+const fakeStreamClientFactory: EpicStreamClientFactory = () => ({
+  applyUpdate: () => undefined,
+  awareness: () => undefined,
+  applyArtifactRoomUpdate: () => undefined,
+  artifactRoomAwareness: () => undefined,
+  retryMigration: () => undefined,
+  close: () => undefined,
+});
+
+let epicSessionHandle: OpenEpicStoreHandle;
+
+describe("<BundleFileSection />", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+    nestedFocusBoundaryMock.navigateNested.mockClear();
+    epicSessionHandle = createOpenEpicStore({
+      epicId: "epic-1",
+      userId: null,
+      streamClientFactory: fakeStreamClientFactory,
+      onAuthError: null,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    epicSessionHandle.dispose();
+  });
+
+  it("opens the source file rather than another diff tile", () => {
+    const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic 1");
+
+    render(
+      <EpicSessionContext.Provider value={epicSessionHandle}>
+        <BundleFileSection
+          node={NODE}
+          viewTabId={tabId}
+          file={FILE}
+          headSha="head-1"
+          diffViewerPreferences={DEFAULT_DIFF_VIEWER_PREFERENCES}
+        />
+      </EpicSessionContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "File" }));
+
+    expect(nestedFocusBoundaryMock.navigateNested).toHaveBeenCalledWith(
+      "epic-1",
+      tabId,
+      expect.any(Function),
+    );
+    const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId];
+    if (canvas?.root?.kind !== "pane") throw new Error("expected pane");
+    const activeTileId = canvas.root.activeTabId;
+    if (activeTileId === null) throw new Error("expected active tile");
+    const tile = canvas.tilesByInstanceId[activeTileId];
+    expect(tile).toEqual(
+      expect.objectContaining({
+        type: "workspace-file",
+        name: "app.ts",
+        hostId: "host-1",
+        workspacePath: "/repo",
+        filePath: "src/app.ts",
+      }),
+    );
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-bundle-file-section.tsx
@@ -17,7 +17,8 @@ import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import type { DiffViewerPreferences } from "@/lib/diff/diff-viewer-preferences";
 import { useOpenEpicId } from "@/lib/epic-selectors";
-import { makeGitFileDiffTileForFile } from "@/lib/git/git-diff-tile";
+import { getBasename } from "@/lib/path/cross-platform-path";
+import { workspaceFileRefFromTreePath } from "@/components/epic-canvas/workspace-file/workspace-file-ref";
 import { BUNDLE_INLINE_LINE_THRESHOLD } from "@/lib/git/bundle-thresholds";
 import { NO_HIGHLIGHT } from "@/lib/git/path-highlight";
 import { useBundleDiffFindRegistrationContext } from "@/components/diff/bundle-diff-find-registration-hooks";
@@ -64,12 +65,13 @@ export function BundleFileSection(props: BundleFileSectionProps): ReactNode {
   const isLarge = totalChangedLines > BUNDLE_INLINE_LINE_THRESHOLD;
 
   const handleOpenFileTile = useCallback(() => {
-    const tile = makeGitFileDiffTileForFile({
-      hostId: props.node.hostId,
-      runningDir: props.node.diff.runningDir,
-      file: props.file,
-      repositoryContext: props.node.repositoryContext,
-    });
+    const tile = workspaceFileRefFromTreePath(
+      props.node.hostId,
+      props.node.diff.runningDir,
+      props.file.path,
+      getBasename(props.file.path),
+    );
+    if (tile === null) return;
     navigateNested(epicId, props.viewTabId, () =>
       prepareOpenTileInTabFocusTarget(props.viewTabId, tile),
     );
@@ -77,10 +79,9 @@ export function BundleFileSection(props: BundleFileSectionProps): ReactNode {
     epicId,
     navigateNested,
     prepareOpenTileInTabFocusTarget,
-    props.file,
+    props.file.path,
     props.node.hostId,
     props.node.diff.runningDir,
-    props.node.repositoryContext,
     props.viewTabId,
   ]);
 


### PR DESCRIPTION
## Summary
- Open changed files from a bundle diff in the workspace file viewer instead of creating a nested file diff.
- Preserve the bundle’s host and repository-root context when opening the file.
- Cover the File action with a canvas tile regression test.

## Validation
- bun run test src/components/epic-canvas/git-diff/__tests__/git-bundle-file-section.test.tsx src/components/epic-canvas/renderers/__tests__/git-bundle-diff-tile-find.test.tsx src/components/epic-canvas/renderers/__tests__/snapshot-bundle-diff-file-navigation.test.tsx
- bun run compile (clients/gui-app)
- bun x eslint <changed files> --max-warnings 0
- react-doctor changed scope
- pre-commit hooks (affected lint, format, compile, build)