### PR TITLE
fix(gui-app): use waiting chat for background activity

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
@@ -159,7 +159,7 @@ describe("<ChatProgressIcon />", () => {
     ).toBeDefined();
     expect(
       screen.getByTestId(BACKGROUND_TEST_ID).getAttribute("class"),
-    ).toContain("lucide-calendar-clock");
+    ).toContain("lucide-message-square-clock");
     expect(
       screen.queryByRole("status", { name: TURN_RUNNING_LABEL }),
     ).toBeNull();

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -1380,7 +1380,7 @@ describe("chat descendant status rollup", () => {
     expect(backgroundIcon).toBeTruthy();
     expect(backgroundIcon.getAttribute("class")).toContain("opacity-60");
     expect(
-      backgroundIcon.querySelector(".lucide-calendar-clock"),
+      backgroundIcon.querySelector(".lucide-message-square-clock"),
     ).not.toBeNull();
     expect(
       screen.queryByTestId("chat-descendant-status-running-chat-root"),

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -607,7 +607,7 @@ describe("<EpicsListPanel />", () => {
       "epics-list-row-background-activity-epic-from-history",
     );
     expect(backgroundIcon.getAttribute("class")).toContain(
-      "lucide-calendar-clock",
+      "lucide-message-square-clock",
     );
     expect(
       screen.queryByTitle("Background activity — agent idle"),

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -534,7 +534,7 @@ describe("<TabStrip />", () => {
       `header-tab-background-activity-${EPIC_A.id}`,
     );
     expect(backgroundIcon.getAttribute("class")).toContain(
-      "lucide-calendar-clock",
+      "lucide-message-square-clock",
     );
     expect(screen.queryByTestId(`header-tab-activity-${EPIC_A.id}`)).toBeNull();
     expect(

--- a/clients/gui-app/src/components/notifications/__tests__/notification-indicator-icon.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notification-indicator-icon.test.tsx
@@ -130,7 +130,7 @@ describe("<NotificationIndicatorIcon />", () => {
     expect(screen.getByTestId("default-icon")).toBeDefined();
   });
 
-  it("renders the background tier muted and titled distinctly from the turn spinner", () => {
+  it("renders the background tier as a muted waiting chat distinct from the turn spinner", () => {
     renderIcon(DEFAULT_STATE, "background");
 
     expect(
@@ -143,7 +143,12 @@ describe("<NotificationIndicatorIcon />", () => {
     ).toBeNull();
     const glyph = screen.getByTestId("indicator-background-activity-subject-1");
     expect(glyph.tagName).toBe("svg");
-    expect(glyph.getAttribute("class")).toContain("lucide-calendar-clock");
+    expect(glyph.getAttribute("class")).toContain(
+      "lucide-message-square-clock",
+    );
+    expect(
+      glyph.querySelector('circle[cx="16"][cy="16"][r="6"]'),
+    ).not.toBeNull();
     expect(glyph.getAttribute("class")).toContain("size-3.5");
     expect(glyph.getAttribute("class")).toContain("text-muted-foreground");
   });

--- a/clients/gui-app/src/components/notifications/background-activity-glyph.tsx
+++ b/clients/gui-app/src/components/notifications/background-activity-glyph.tsx
@@ -1,4 +1,4 @@
-import { CalendarClock } from "lucide-react";
+import { MessageSquareClock } from "@/components/notifications/message-square-clock";
 
 interface BackgroundActivityGlyphProps {
   readonly testId: string | undefined;
@@ -7,7 +7,7 @@ interface BackgroundActivityGlyphProps {
 /** Shared visual for confirmed background-only activity. */
 export function BackgroundActivityGlyph(props: BackgroundActivityGlyphProps) {
   return (
-    <CalendarClock
+    <MessageSquareClock
       aria-hidden
       className="size-3.5 text-muted-foreground"
       data-testid={props.testId}

--- a/clients/gui-app/src/components/notifications/message-square-clock.ts
+++ b/clients/gui-app/src/components/notifications/message-square-clock.ts
@@ -1,0 +1,18 @@
+import { createLucideIcon } from "lucide-react";
+
+/**
+ * Lucide-style message-square glyph with a clock badge. The bubble follows the
+ * app's canonical chat icon and opens at the lower-right so the clock remains
+ * legible at the compact indicator size.
+ */
+export const MessageSquareClock = createLucideIcon("message-square-clock", [
+  [
+    "path",
+    {
+      d: "M22 8.5V5a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v16.286a.71.71 0 0 0 1.212.502l2.202-2.202A2 2 0 0 1 6.828 19H8.5",
+      key: "1yt8rh",
+    },
+  ],
+  ["path", { d: "M16 14v2.2l1.6 1", key: "fo4ql5" }],
+  ["circle", { cx: "16", cy: "16", r: "6", key: "qoo3c4" }],
+]);


### PR DESCRIPTION
## Summary

- replace the standalone calendar-clock background indicator with a chat bubble carrying a lower-right clock badge
- reuse the app canonical `MessageSquare` geometry through a compact Lucide-style `MessageSquareClock` icon
- preserve the existing muted styling, accessibility label, status precedence, rollup opacity, and stable test IDs

Follow-up to #443.

## Related issue

N/A

## Validation

- focused indicator suites: 5 files, 115 tests passed
- `bun run compile`
- changed-file ESLint and Prettier checks
- React Doctor changed-files scan — no issues
- `pre-commit run --all-files`
- visual comparison against the canonical chat icon

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO