### PR TITLE
fix(agent): reserve Cursor TUI schema without exposing it

### DIFF
--- a/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
+++ b/clients/gui-app/src/components/chat/composer/use-provider-reauth-gate.ts
@@ -13,14 +13,15 @@ import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
 // The harness id set is a superset of the provider-CLI id set (it also carries
 // `traycer`, which has no provider-CLI login). Only CLI harnesses gate. Grok,
-// Qwen, Kiro, Kimi, Droid, Copilot, and Kilo Code are GUI-only (not in the TUI map)
-// but DO gate through their CLI login providers, mirroring the host's
+// Cursor, Grok, Qwen, Kiro, Kimi, Droid, Copilot, and Kilo Code are GUI-only
+// (not in the TUI map) but DO gate through their providers, mirroring the host's
 // `harnessIdToProviderId`. Exported so other harness->provider derivations
 // (e.g. the chat provider rate-limit selector) share this single mapping.
 export function providerIdForHarness(
   harnessId: GuiHarnessId,
 ): ProviderId | null {
   if (harnessId === "traycer") return null;
+  if (harnessId === "cursor") return "cursor";
   if (harnessId === "openrouter") return "openrouter";
   if (harnessId === "grok") return "grok";
   if (harnessId === "qwen") return "qwen";

--- a/clients/gui-app/src/components/home/composer/__tests__/terminal-launch-panel.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/terminal-launch-panel.test.tsx
@@ -48,9 +48,8 @@ function makeToolbarStore() {
     tuiOnly: true,
   });
   // The Start gate reads the selected harness's runtime `modes` from the
-  // catalog (so a schema-TUI harness that advertises only `gui` is blocked in
-  // lockstep with the store's reroute), so seed a loaded catalog where `claude`
-  // is TUI-capable - otherwise Start stays disabled.
+  // catalog, so seed a loaded catalog where `claude` is TUI-capable - otherwise
+  // Start stays disabled.
   store.getState().setCatalog({
     harnesses: [
       {
@@ -82,7 +81,7 @@ function makeGuiOnlyToolbarStore() {
     seedKey: "test",
     values: {
       permission: "supervised",
-      selection: { harnessId: "cursor", modelSlug: "", profileId: null },
+      selection: { harnessId: "traycer", modelSlug: "", profileId: null },
       reasoning: "",
       serviceTier: "",
       agentMode: "regular",
@@ -90,14 +89,13 @@ function makeGuiOnlyToolbarStore() {
     onSettingsChange: null,
     tuiOnly: true,
   });
-  // `cursor` is a schema-TUI harness (`isTuiHarnessId("cursor")` is true) whose
-  // adapter advertises only `gui`, so it can't back a terminal agent. The Start
-  // gate must follow the runtime `modes`, not the schema id.
+  // A GUI-only harness cannot back a terminal agent. The Start gate follows
+  // the runtime `modes` advertised by the host.
   store.getState().setCatalog({
     harnesses: [
       {
-        id: "cursor",
-        label: "Cursor",
+        id: "traycer",
+        label: "Traycer",
         enabled: true,
         available: true,
         error: null,
@@ -107,7 +105,7 @@ function makeGuiOnlyToolbarStore() {
         availabilityPending: false,
       },
     ],
-    modelsHarnessId: "cursor",
+    modelsHarnessId: "traycer",
     models: [],
     modelsLoaded: true,
     tuiOnly: true,
@@ -194,7 +192,7 @@ describe("<TerminalLaunchPanel /> terminal-agent args handoff", () => {
     );
   });
 
-  it("blocks Start for a schema-TUI harness that advertises only gui (cursor)", () => {
+  it("blocks Start for a GUI-only harness", () => {
     const onStart = vi.fn();
     render(
       <TooltipProvider>

--- a/clients/gui-app/src/components/home/composer/terminal-launch-panel.tsx
+++ b/clients/gui-app/src/components/home/composer/terminal-launch-panel.tsx
@@ -50,11 +50,10 @@ function TerminalLaunchPanelImpl(props: TerminalLaunchPanelProps) {
   const setAgentMode = useStore(store, (s) => s.setAgentMode);
   // Launch capability is the runtime `modes` the host advertises for the
   // selected harness - the same signal the store uses to reroute off non-TUI
-  // harnesses - NOT the schema id (`isTuiHarnessId`). They diverge for a
-  // schema-TUI harness whose adapter currently exposes only `gui` (e.g.
-  // `cursor`): gating on `modes` keeps Start in lockstep with the store's
-  // reroute and stays disabled until the catalog confirms capability, instead
-  // of briefly enabling a pre-reroute selection that can't back a terminal agent.
+  // harnesses, not the schema id (`isTuiHarnessId`). Gating on `modes` keeps
+  // Start in lockstep with the store's reroute and stays disabled until the
+  // catalog confirms capability, instead of briefly enabling a pre-reroute
+  // selection that can't back a terminal agent.
   const selectionIsTuiCapable = useStore(
     store,
     (s) =>
@@ -99,9 +98,8 @@ function TerminalLaunchPanelImpl(props: TerminalLaunchPanelProps) {
   const argsTouched = needsReseed ? false : argsState.touched;
 
   // The harness/model picker lists every GUI harness, including ones that can't
-  // back a terminal agent (the GUI-only `traycer`, or a schema-TUI harness whose
-  // adapter advertises only `gui`). Block Start (rather than silently no-op)
-  // unless the shared selection is runtime-TUI-capable.
+  // back a terminal agent. Block Start (rather than silently no-op) unless the
+  // shared selection is runtime-TUI-capable.
   const launchHint =
     disabledHint ??
     (selectionIsTuiCapable

--- a/clients/gui-app/src/components/home/hooks/__tests__/use-composer-toolbar-store.test.tsx
+++ b/clients/gui-app/src/components/home/hooks/__tests__/use-composer-toolbar-store.test.tsx
@@ -232,27 +232,6 @@ describe("useComposerToolbarStore selection reconciliation", () => {
     );
   });
 
-  it("reroutes a schema-TUI harness that advertises only gui (cursor)", async () => {
-    // Cursor is in `tuiHarnessIdSchema`, but its adapter currently advertises
-    // only `gui`. Capability is the runtime `modes`, not the schema id, so the
-    // terminal surface reroutes off it like any other non-TUI harness.
-    seedDefault("cursor");
-    harnessesData.value = {
-      harnesses: [
-        { id: "cursor", available: true, modes: ["gui"] },
-        { id: "codex", available: true, modes: ["gui", "tui"] },
-      ],
-    };
-
-    const { result } = renderHook(() =>
-      useComposerToolbarStore(null, { kind: "none" }, null, true),
-    );
-
-    await waitFor(() =>
-      expect(result.current.getState().selection.harnessId).toBe("codex"),
-    );
-  });
-
   it("keeps a TUI-capable selection on the terminal surface", async () => {
     seedDefault("claude");
     harnessesData.value = {

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker.tsx
@@ -923,11 +923,8 @@ function modelPickerSelectionSummary(
   return `${label} · Thinking ${reasoningLabel}`;
 }
 
-// Restrict to harnesses whose adapter advertises a TUI surface. This is the
-// runtime capability (`modes`), not the schema id: Cursor is a TUI harness at
-// the schema level but its adapter currently advertises only `gui`, so it stays
-// hidden from the terminal launcher until the CLI ships - and reappears on its
-// own once the host starts advertising `tui`, with no code change here.
+// Restrict to harnesses whose adapter advertises a TUI surface. Runtime
+// capability (`modes`) is the source of truth for the terminal launcher.
 function isTuiCapable(harness: HarnessOption): boolean {
   return harness.modes.includes("tui");
 }

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -179,8 +179,8 @@ codeFontSize` in muted styling while `null`; any tick/type pins an
     value if it changes underneath (refetch / another window) and stays editable
     while a save is in flight (writes are serialized host-side). Shown only for
     terminal-agent-capable providers - it checks `useGuiHarnessesQuery` for the
-    mapped harness (`HARNESS_ICON_ID`) advertising the `tui` `mode`, so it's
-    hidden for Cursor. Persisted as `terminalAgentArgs` in
+    mapped harness (`HARNESS_ICON_ID`) advertising the `tui` `mode`, so GUI-only
+    providers do not show it. Persisted as `terminalAgentArgs` in
     `provider-overrides.json` via `providers.setTerminalAgentArgs`
     (`useProvidersSetTerminalAgentArgs`, invalidates only `providers.list`). In
     `agent.tui.prepareLaunch` the host tokenizes the string and each harness
@@ -202,11 +202,9 @@ codeFontSize` in muted styling while `null`; any tick/type pins an
     `cursor-agent about` for provider auth because GUI chats use `@cursor/sdk`,
     not the CLI login session. Backed by `providers.setApiKey` /
     `providers.clearApiKey` (`useProvidersSetApiKey` /
-    `useProvidersClearApiKey`). Cursor is GUI-only in the UI for now - its
-    `cursor-agent` TUI surface is hidden until the CLI reaches feature parity
-    (the adapter advertises only the `gui` mode via `listGuiHarnesses`'s
-    `modes`) - so the Cursor row hides the CLI candidates table and shows only
-    the API-key section; the key drives the `@cursor/sdk` GUI chat surface.
+    `useProvidersClearApiKey`). Cursor is GUI-only, so its row hides the CLI
+    candidates table and shows only the API-key section; the key drives the
+    `@cursor/sdk` GUI chat surface.
   - **Traycer subscription + credits.** The Traycer provider detail leads with a
     `TraycerSubscriptionSection` card (always visible, not gated by the
     enable/disable toggle since it is account- not binary-level) showing the

--- a/clients/gui-app/src/lib/__tests__/display-title.test.ts
+++ b/clients/gui-app/src/lib/__tests__/display-title.test.ts
@@ -80,9 +80,6 @@ describe("tuiAgentDisplayTitle", () => {
     expect(tuiAgentDisplayTitle({ title: "", harnessId: "opencode" })).toBe(
       "OpenCode",
     );
-    expect(tuiAgentDisplayTitle({ title: "", harnessId: "cursor" })).toBe(
-      "Cursor",
-    );
   });
 });
 

--- a/clients/gui-app/src/lib/artifacts/node-display.ts
+++ b/clients/gui-app/src/lib/artifacts/node-display.ts
@@ -170,6 +170,8 @@ export const TUI_AGENT_HARNESS_LABELS: Readonly<Record<TuiHarnessId, string>> =
     claude: "Claude Code",
     codex: "Codex",
     opencode: "OpenCode",
+    // Reserved schema value; current runtime catalogs and epic projection hide
+    // Cursor terminal agents until the TUI surface is supported.
     cursor: "Cursor",
   };
 

--- a/clients/gui-app/src/stores/composer/composer-toolbar-store.ts
+++ b/clients/gui-app/src/stores/composer/composer-toolbar-store.ts
@@ -75,12 +75,11 @@ export interface ComposerToolbarCatalog {
   readonly modelsLoaded: boolean;
   /**
    * True when the consuming surface is the terminal launcher. A selection
-   * carried over from a chat surface that isn't TUI-capable - GUI-only
-   * `traycer`, or a schema-TUI harness like `cursor` whose adapter currently
-   * advertises only `gui` - is then rerouted to the first available TUI-capable
-   * harness, the same single clamp site that reroutes off an unavailable
-   * harness. Chat surfaces push `false` and the selection is never narrowed by
-   * surface, so flipping back to chat re-presents the raw sticky harness.
+   * carried over from a chat surface that isn't TUI-capable is rerouted to the
+   * first available TUI-capable harness, the same single clamp site that
+   * reroutes off an unavailable harness. Chat surfaces push `false` and the
+   * selection is never narrowed by surface, so flipping back to chat
+   * re-presents the raw sticky harness.
    */
   readonly tuiOnly: boolean;
 }
@@ -540,8 +539,7 @@ function effectiveSelectionFromHarnesses(
     // GUI-only selection carried over from chat is rerouted off it - mirroring
     // the availability reroute. Capability is the runtime `modes` advertised by
     // `listGuiHarnesses` (the same signal the terminal picker filters its rail
-    // by), NOT the schema id, so a schema-TUI harness whose adapter currently
-    // exposes only `gui` (cursor) is rerouted too.
+    // by), not the schema id.
     if (tuiOnly && !harness.modes.includes("tui")) continue;
     firstEligible ??= harness;
     if (harness.id === selection.harnessId) return selection;

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/selectors.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/selectors.test.ts
@@ -110,13 +110,14 @@ function makeMeta(): SnapshotMetaEpic {
 function makeTerminalAgentProjectionDoc(
   terminalAgentArgs: unknown,
   shouldSetTerminalAgentArgs: boolean,
+  harnessId: string,
 ): Y.Doc {
   const doc = new Y.Doc();
   const epic = doc.getMap("epic");
   const tuiAgents = new Y.Map<unknown>();
   const terminalAgent = new Y.Map<unknown>();
   terminalAgent.set("id", "terminal-1");
-  terminalAgent.set("harnessId", "codex");
+  terminalAgent.set("harnessId", harnessId);
   terminalAgent.set("title", "Codex");
   terminalAgent.set("parentId", null);
   terminalAgent.set("createdAt", 0);
@@ -227,6 +228,14 @@ describe("open-epic-store doc projection", () => {
     expect(projected.byId["terminal-1"]).toBeUndefined();
   });
 
+  it("rejects Cursor records from the terminal-agent projection", () => {
+    const doc = makeTerminalAgentProjectionDoc(null, false, "cursor");
+
+    const projected = projectTerminalAgents(doc, null);
+
+    expect(projected.byId["terminal-1"]).toBeUndefined();
+  });
+
   it("projects durable terminal-agent args with fallback and override semantics", () => {
     const cases: ReadonlyArray<{
       readonly label: string;
@@ -262,7 +271,7 @@ describe("open-epic-store doc projection", () => {
 
     cases.forEach(({ label, rawValue, shouldSetRawValue, expected }) => {
       const projected = projectTerminalAgents(
-        makeTerminalAgentProjectionDoc(rawValue, shouldSetRawValue),
+        makeTerminalAgentProjectionDoc(rawValue, shouldSetRawValue, "codex"),
         null,
       );
 

--- a/clients/gui-app/src/stores/epics/open-epic/projection-helpers.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/projection-helpers.ts
@@ -155,12 +155,7 @@ export function readArtifactKind(map: Y.Map<unknown>): EpicArtifactKind | null {
 
 function readHarnessType(map: Y.Map<unknown>): TuiHarnessId | null {
   const value = map.get("harnessId");
-  if (
-    value === "claude" ||
-    value === "codex" ||
-    value === "opencode" ||
-    value === "cursor"
-  ) {
+  if (value === "claude" || value === "codex" || value === "opencode") {
     return value;
   }
   return null;
@@ -295,14 +290,8 @@ export function projectTerminalAgent(
   if (typeof hostId !== "string") return null;
   const harnessSessionId = entry.get("harnessSessionId");
   // Claude/OpenCode require a non-null harness session id (allocated
-  // synchronously). Codex tolerates null until `thread/started` back-fills;
-  // Cursor tolerates null when `create-chat` minting failed (re-mints on the
-  // next launch) rather than persisting a bogus id.
-  if (
-    typeof harnessSessionId !== "string" &&
-    harnessId !== "codex" &&
-    harnessId !== "cursor"
-  ) {
+  // synchronously). Codex tolerates null until `thread/started` back-fills.
+  if (typeof harnessSessionId !== "string" && harnessId !== "codex") {
     return null;
   }
   const model = entry.get("model");

--- a/clients/traycer-cli/src/commands/agent-title-from-hook.ts
+++ b/clients/traycer-cli/src/commands/agent-title-from-hook.ts
@@ -157,18 +157,16 @@ function extractPrompt(
     if (!parsed.success) return null;
     return parsed.data.prompt.trim().length === 0 ? null : parsed.data.prompt;
   }
-  if (harness === "opencode") {
-    const parsed = opencodeHookSchema.safeParse(payload);
-    if (!parsed.success) return null;
-    const text = parsed.data.output.parts
-      .flatMap((part) => {
-        const r = opencodeTextPartSchema.safeParse(part);
-        return r.success ? [r.data.text] : [];
-      })
-      .join("");
-    return text.trim().length === 0 ? null : text;
-  }
-  // Cursor TUI exists in the schema but ships no hook payload contract
-  // yet; treat as a quiet no-op rather than failing the hook.
-  return null;
+  // Cursor remains in the released TUI schema for compatibility but has no
+  // supported hook payload contract until its TUI surface ships.
+  if (harness === "cursor") return null;
+  const parsed = opencodeHookSchema.safeParse(payload);
+  if (!parsed.success) return null;
+  const text = parsed.data.output.parts
+    .flatMap((part) => {
+      const r = opencodeTextPartSchema.safeParse(part);
+      return r.success ? [r.data.text] : [];
+    })
+    .join("");
+  return text.trim().length === 0 ? null : text;
 }

--- a/protocol/src/host/agent/__tests__/agent-schemas.test.ts
+++ b/protocol/src/host/agent/__tests__/agent-schemas.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import { downgradeRequestAcrossMajors } from "@traycer/protocol/framework/index";
 import { agentListHarnessModelsDowngradeV2ToV1 } from "@traycer/protocol/host/agent/contracts";
 import {
+  guiHarnessIdSchema,
+  tuiHarnessIdSchema,
+} from "@traycer/protocol/host/agent/shared";
+import {
   agentSelectionGuideResponseSchema,
   createAgentRequestSchema,
   hostRpcRegistry,
@@ -16,6 +20,17 @@ import {
 } from "@traycer/protocol/host/index";
 
 describe("agent host schemas", () => {
+  it("retains Cursor in the TUI wire schema as a compatibility value", () => {
+    expect(guiHarnessIdSchema.safeParse("cursor").success).toBe(true);
+    expect(tuiHarnessIdSchema.safeParse("cursor").success).toBe(true);
+    expect(tuiHarnessIdSchema.options).toEqual([
+      "claude",
+      "codex",
+      "opencode",
+      "cursor",
+    ]);
+  });
+
   it("accepts the agent.gui.listCommands request and response shapes", () => {
     expect(
       listGuiAgentCommandsRequestSchema.parse({

--- a/protocol/src/host/agent/gui/unary-schemas.ts
+++ b/protocol/src/host/agent/gui/unary-schemas.ts
@@ -23,8 +23,7 @@ import {
 // The surfaces a harness can run on. `"gui"` is the host-driven chat tab;
 // `"tui"` is the PTY terminal-agent tab. Each adapter declares the surfaces it
 // implements, and `listGuiHarnesses` reports them so the renderer can show the
-// terminal-agent launcher only for harnesses that actually support it (Cursor,
-// for instance, is GUI-only until its CLI reaches TUI parity).
+// terminal-agent launcher only for harnesses that actually support it.
 export const harnessSurfaceSchema = z.enum(["gui", "tui"]);
 export type HarnessSurface = z.infer<typeof harnessSurfaceSchema>;
 

--- a/protocol/src/host/agent/shared.ts
+++ b/protocol/src/host/agent/shared.ts
@@ -31,12 +31,11 @@ export { DEFAULT_AGENT_MODE, agentModeSchema, type AgentMode };
 // `TuiHarnessId extends HarnessId` are both true at the type level, so a
 // surface-narrow value passes everywhere a `HarnessId` is expected.
 //
-// Cursor supports BOTH surfaces at the schema level: the GUI chat tab drives
-// the `@cursor/sdk` agent runtime in local mode, and the TUI tab can launch the
-// `cursor-agent` CLI in a PTY. It is therefore listed in `harnessIdSchema` and
-// in BOTH `guiHarnessIdSchema` and `tuiHarnessIdSchema`. The TUI surface is
-// hidden in the renderer for now (the adapter advertises only the GUI mode via
-// `listGuiHarnesses`'s `modes` field) until the CLI reaches feature parity.
+// Cursor is retained in the TUI subset because it shipped in the v1 wire
+// contract and persisted TUI union. It is a reserved compatibility value until
+// the Cursor CLI reaches the minimum feature set required for product support;
+// runtime adapter surfaces and catalogs, not this schema, decide what users can
+// currently create or launch.
 export const harnessIdSchema = getRecordSchema(
   commonRecordRegistry,
   "harness-id",
@@ -520,8 +519,8 @@ export type ListHarnessModelsResponse = z.infer<
  * uuid-keyed map) so the wire shape lines up with `listEpicCollaborators`
  * and the rest of the `list*` family in this registry.
  *
- * `surface` lets a caller route to the right per-agent UI (e.g. fetch a
- * GUI chat transcript vs a TUI scrollback) without a second round-trip.
+ * `surface` lets a caller route to the right per-agent UI (e.g. a GUI chat
+ * interface vs a TUI terminal interface) without a second round-trip.
  * `isLocal` is the host's authoritative answer to "did I mint this
  * session?" - `hostId` equals the responding host's id. Cross-host
  * entries are returned for read-only enumeration; mutating RPCs
@@ -689,10 +688,11 @@ export type SendAgentMessageResponse = z.infer<
  * XML-tagged string so a sibling agent can read it without re-implementing
  * the discriminated `messageSchema` shape. For GUI agents the host
  * serializes the persisted `messageSchema` array (`<user>` / `<assistant>`
- * blocks); for TUI agents the host best-effort returns whatever
- * scrollback its PTY buffer holds. TUI scrollback is not persisted, so the
- * resolver errors when the target TUI session is not local and currently
- * present in this host's PTY manager.
+ * blocks); for supported TUI agents the host reads structured conversation
+ * history through the harness provider SDK. Provider history survives the PTY
+ * closing; there is deliberately no raw scrollback fallback. TUI transcript
+ * reads remain local to the agent's bound host because its provider session
+ * store and credentials are host-local.
  */
 export const getAgentTranscriptRequestSchema = z.object({
   epicId: z.string(),

--- a/protocol/src/persistence/_internal/epic-schemas.ts
+++ b/protocol/src/persistence/_internal/epic-schemas.ts
@@ -36,7 +36,8 @@ export const epicSchema = z.object({
   deletedArtifacts: z.record(z.string(), deletedEpicArtifactSchema),
   // TUI agent sessions live alongside chats in their own map. Records carry
   // resume metadata (harnessId + harnessSessionId + hostId +
-  // workspaceFolders); transcript bytes stay in the host-owned PTY.
+  // workspaceFolders); supported transcripts come from host-local provider
+  // session history and are not persisted in the epic record.
   // Default `{}` so existing epics without the field still parse.
   tuiAgents: z.record(z.string(), tuiAgentSchema).default({}),
 });

--- a/protocol/src/persistence/epic/__tests__/tui-agent-schema-compat.test.ts
+++ b/protocol/src/persistence/epic/__tests__/tui-agent-schema-compat.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { tuiHarnessIdSchema } from "@traycer/protocol/persistence/epic/foundation";
+import { tuiAgentSchema } from "@traycer/protocol/persistence/epic/tui-agents";
+
+describe("persisted TUI agent schema compatibility", () => {
+  it("retains the released Cursor discriminator and record variant", () => {
+    expect(tuiHarnessIdSchema.safeParse("cursor").success).toBe(true);
+    expect(
+      tuiAgentSchema.safeParse({
+        id: "cursor-agent-1",
+        parentId: null,
+        title: "",
+        isTitleEditedByUser: false,
+        createdAt: 1,
+        updatedAt: 1,
+        hostId: "host-1",
+        userId: "user-1",
+        workspaceFolders: ["/repo"],
+        model: null,
+        reasoningEffort: null,
+        agentMode: "epic",
+        terminalAgentArgs: null,
+        terminalShellCommand: null,
+        terminalShellArgs: null,
+        profileId: null,
+        harnessId: "cursor",
+        harnessSessionId: null,
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -76,6 +76,8 @@ export const guiHarnessIdSchema = z.enum([
 ]);
 export type GuiHarnessId = z.infer<typeof guiHarnessIdSchema>;
 
+// Cursor remains a reserved compatibility value: it shipped in this persisted
+// enum before the unfinished runtime surface was withdrawn from the product.
 export const tuiHarnessIdSchema = z.enum([
   "claude",
   "codex",

--- a/protocol/src/persistence/epic/tui-agents.ts
+++ b/protocol/src/persistence/epic/tui-agents.ts
@@ -37,8 +37,9 @@ import { worktreeBindingWorkspaceModeSchema } from "../../host/worktree-schemas"
  * non-empty title is itself the "already titled" marker and is never
  * overwritten.
  *
- * No transcript fields: TUI scrollback lives in the host's PTY buffer and
- * is not part of the cloud-synced epic record.
+ * No transcript fields: supported TUI transcripts are read from host-local
+ * provider session history and are not part of the cloud-synced epic record.
+ * Live terminal scrollback is a separate, ephemeral PTY concern.
  */
 
 const baseTuiAgentFields = {
@@ -94,13 +95,12 @@ export const opencodeTuiAgentSchema = z.object({
 });
 export type OpencodeTuiAgent = z.infer<typeof opencodeTuiAgentSchema>;
 
+// Reserved for backward compatibility with the previously released persisted
+// union and for planned Cursor TUI support. Current runtime catalogs do not
+// advertise this surface, so normal product flows do not create these records.
 export const cursorTuiAgentSchema = z.object({
   harnessId: z.literal("cursor"),
   ...baseTuiAgentFields,
-  // The chat id minted by `cursor-agent create-chat` and resumed with
-  // `cursor-agent --resume <id>`. Minting is synchronous but can fail
-  // (offline/unauthenticated); null then means "no chat yet - re-mint on the
-  // next launch" rather than persisting a bogus, non-resumable id.
   harnessSessionId: z.string().nullable().catch(null),
 });
 export type CursorTuiAgent = z.infer<typeof cursorTuiAgentSchema>;


### PR DESCRIPTION
## Summary
- retain Cursor in released TUI schemas and persisted records as a reserved compatibility value
- remove Cursor from runtime launch, creation, transcript, and UI exposure paths
- add persistence compatibility coverage and correct durable transcript documentation

## Verification
- targeted protocol, host, CLI, and GUI compiles and tests
- trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
check that executables have shebangs.....................................Passed
check that scripts with shebangs are executable..........................Passed
detect private key.......................................................Passed
mixed line ending........................................................Passed
check yaml...............................................................Passed
check json...............................................................Passed
check for merge conflicts................................................Passed
Shellcheck Bash Linter...................................................Passed
Check hooks apply to the repository......................................Passed
build · compile · lint · format (nx affected)............................Passed
- React Doctor completed with no detected issues; its lint analysis timed out after 300s, so that check is incomplete