### PR TITLE
fix(desktop): suppress WSL kernel core dumps and cap crashpad minidump backlog

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/core-dump-guard.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/core-dump-guard.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+type GuardModule = typeof import("../core-dump-guard");
+
+type WriteFailure = "none" | "enoent" | "eacces";
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(
+  process,
+  "platform",
+);
+const originalWslDistroName = process.env["WSL_DISTRO_NAME"];
+const originalWslInterop = process.env["WSL_INTEROP"];
+const originalKeepDumps = process.env["TRAYCER_KEEP_KERNEL_CORE_DUMPS"];
+
+afterEach(() => {
+  if (originalPlatformDescriptor === undefined) {
+    Reflect.deleteProperty(process, "platform");
+  } else {
+    Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  }
+  restoreEnvValue("WSL_DISTRO_NAME", originalWslDistroName);
+  restoreEnvValue("WSL_INTEROP", originalWslInterop);
+  restoreEnvValue("TRAYCER_KEEP_KERNEL_CORE_DUMPS", originalKeepDumps);
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.doUnmock("node:fs");
+  vi.doUnmock("../logger");
+});
+
+function restoreEnvValue(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(process.env, key);
+  } else {
+    process.env[key] = value;
+  }
+}
+
+describe("suppressWslKernelCoreDumps", () => {
+  it("does nothing on non-Linux platforms", async () => {
+    const { guard, writeFileSyncMock } = await loadGuard({
+      platform: "darwin",
+      wslDistroName: "Ubuntu",
+      procVersion: null,
+      keepDumps: undefined,
+      writeFailure: "none",
+      filterReadback: "00000000",
+    });
+
+    guard.suppressWslKernelCoreDumps();
+
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("clears coredump_filter under WSL, detected via WSL_DISTRO_NAME", async () => {
+    const { guard, writeFileSyncMock, infoMock, errorMock } = await loadGuard({
+      platform: "linux",
+      wslDistroName: "Ubuntu",
+      procVersion: null,
+      keepDumps: undefined,
+      writeFailure: "none",
+      filterReadback: "00000000",
+    });
+
+    guard.suppressWslKernelCoreDumps();
+
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      "/proc/self/coredump_filter",
+      "0",
+    );
+    expect(infoMock).toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+
+  it("clears coredump_filter under WSL, detected via /proc/version", async () => {
+    const { guard, writeFileSyncMock } = await loadGuard({
+      platform: "linux",
+      wslDistroName: undefined,
+      procVersion: "Linux version 5.15.90.1-microsoft-standard-WSL2",
+      keepDumps: undefined,
+      writeFailure: "none",
+      filterReadback: "00000000",
+    });
+
+    guard.suppressWslKernelCoreDumps();
+
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      "/proc/self/coredump_filter",
+      "0",
+    );
+  });
+
+  it("is a no-op on non-WSL Linux", async () => {
+    const { guard, writeFileSyncMock } = await loadGuard({
+      platform: "linux",
+      wslDistroName: undefined,
+      procVersion: "Linux version 6.5.0-generic",
+      keepDumps: undefined,
+      writeFailure: "none",
+      filterReadback: "00000000",
+    });
+
+    guard.suppressWslKernelCoreDumps();
+
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps kernel core dumps when the env override is set", async () => {
+    const { guard, writeFileSyncMock, infoMock } = await loadGuard({
+      platform: "linux",
+      wslDistroName: "Ubuntu",
+      procVersion: null,
+      keepDumps: "1",
+      writeFailure: "none",
+      filterReadback: "00000000",
+    });
+
+    guard.suppressWslKernelCoreDumps();
+
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+    expect(infoMock).toHaveBeenCalled();
+  });
+
+  it("treats an absent coredump_filter (ENOENT) as safe, not an error", async () => {
+    const { guard, infoMock, errorMock } = await loadGuard({
+      platform: "linux",
+      wslDistroName: "Ubuntu",
+      procVersion: null,
+      keepDumps: undefined,
+      writeFailure: "enoent",
+      filterReadback: "00000000",
+    });
+
+    expect(() => guard.suppressWslKernelCoreDumps()).not.toThrow();
+    expect(infoMock).toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+
+  it("escalates any other write failure to log.error and survives", async () => {
+    const { guard, errorMock } = await loadGuard({
+      platform: "linux",
+      wslDistroName: "Ubuntu",
+      procVersion: null,
+      keepDumps: undefined,
+      writeFailure: "eacces",
+      filterReadback: "00000000",
+    });
+
+    expect(() => guard.suppressWslKernelCoreDumps()).not.toThrow();
+    expect(errorMock).toHaveBeenCalled();
+  });
+
+  it("escalates a readback mismatch to log.error", async () => {
+    const { guard, errorMock, infoMock } = await loadGuard({
+      platform: "linux",
+      wslDistroName: "Ubuntu",
+      procVersion: null,
+      keepDumps: undefined,
+      writeFailure: "none",
+      filterReadback: "00000033",
+    });
+
+    guard.suppressWslKernelCoreDumps();
+
+    expect(errorMock).toHaveBeenCalled();
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+});
+
+async function loadGuard(opts: {
+  readonly platform: NodeJS.Platform;
+  readonly wslDistroName: string | undefined;
+  readonly procVersion: string | null;
+  readonly keepDumps: string | undefined;
+  readonly writeFailure: WriteFailure;
+  readonly filterReadback: string;
+}): Promise<{
+  readonly guard: GuardModule;
+  readonly writeFileSyncMock: Mock;
+  readonly infoMock: Mock;
+  readonly warnMock: Mock;
+  readonly errorMock: Mock;
+}> {
+  vi.resetModules();
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: opts.platform,
+  });
+  restoreEnvValue("WSL_DISTRO_NAME", opts.wslDistroName);
+  Reflect.deleteProperty(process.env, "WSL_INTEROP");
+  restoreEnvValue("TRAYCER_KEEP_KERNEL_CORE_DUMPS", opts.keepDumps);
+
+  const writeFileSyncMock: Mock = vi.fn(() => {
+    if (opts.writeFailure === "enoent") {
+      throw Object.assign(
+        new Error(
+          "ENOENT: no such file or directory, open '/proc/self/coredump_filter'",
+        ),
+        { code: "ENOENT" },
+      );
+    }
+    if (opts.writeFailure === "eacces") {
+      throw Object.assign(new Error("EACCES: permission denied"), {
+        code: "EACCES",
+      });
+    }
+  });
+  const fs = {
+    existsSync: vi.fn(
+      (path: string) => path === "/proc/version" && opts.procVersion !== null,
+    ),
+    readFileSync: vi.fn((path: string) => {
+      if (path === "/proc/version") {
+        return opts.procVersion ?? "";
+      }
+      if (path === "/proc/self/coredump_filter") {
+        return `${opts.filterReadback}\n`;
+      }
+      return "";
+    }),
+    writeFileSync: writeFileSyncMock,
+  };
+  vi.doMock("node:fs", () => ({ ...fs, default: fs }));
+
+  const infoMock: Mock = vi.fn();
+  const warnMock: Mock = vi.fn();
+  const errorMock: Mock = vi.fn();
+  vi.doMock("../logger", () => ({
+    log: { debug: vi.fn(), info: infoMock, warn: warnMock, error: errorMock },
+  }));
+
+  return {
+    guard: await import("../core-dump-guard"),
+    writeFileSyncMock,
+    infoMock,
+    warnMock,
+    errorMock,
+  };
+}

--- a/clients/desktop/src/electron-main/app/__tests__/crash-dump-prune.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/crash-dump-prune.test.ts
@@ -1,0 +1,171 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+type PruneModule = typeof import("../crash-dump-prune");
+
+const CRASH_DUMPS_ROOT = "/tmp/traycer-test-crash-dumps";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.doUnmock("node:fs/promises");
+  vi.doUnmock("electron");
+  vi.doUnmock("../logger");
+});
+
+describe("selectCrashDumpsToPrune", () => {
+  it("returns nothing when at or under the retention cap", async () => {
+    const { prune } = await loadPrune({ files: [], readdirFails: false });
+    const files = [
+      { path: "/dumps/a.dmp", mtimeMs: 3 },
+      { path: "/dumps/b.dmp", mtimeMs: 2 },
+      { path: "/dumps/c.dmp", mtimeMs: 1 },
+    ];
+
+    expect(prune.selectCrashDumpsToPrune(files, 3)).toEqual([]);
+    expect(prune.selectCrashDumpsToPrune([], 3)).toEqual([]);
+  });
+
+  it("keeps the newest maxRetained files and returns the older remainder", async () => {
+    const { prune } = await loadPrune({ files: [], readdirFails: false });
+    const files = [
+      { path: "/dumps/oldest.dmp", mtimeMs: 1 },
+      { path: "/dumps/newest.dmp", mtimeMs: 4 },
+      { path: "/dumps/older.dmp", mtimeMs: 2 },
+      { path: "/dumps/newer.dmp", mtimeMs: 3 },
+    ];
+
+    expect(prune.selectCrashDumpsToPrune(files, 2)).toEqual([
+      "/dumps/older.dmp",
+      "/dumps/oldest.dmp",
+    ]);
+  });
+
+  it("does not mutate the input ordering", async () => {
+    const { prune } = await loadPrune({ files: [], readdirFails: false });
+    const files = [
+      { path: "/dumps/a.dmp", mtimeMs: 1 },
+      { path: "/dumps/b.dmp", mtimeMs: 2 },
+    ];
+
+    prune.selectCrashDumpsToPrune(files, 1);
+
+    expect(files.map((file) => file.path)).toEqual([
+      "/dumps/a.dmp",
+      "/dumps/b.dmp",
+    ]);
+  });
+});
+
+describe("pruneStaleCrashDumps", () => {
+  it("unlinks only the oldest dumps beyond the cap, ignoring non-dump files", async () => {
+    const dumpFiles = Array.from({ length: 12 }, (_, index) => ({
+      name: `report-${index}.dmp`,
+      dir: join(CRASH_DUMPS_ROOT, "completed"),
+      // index 0 is the oldest, index 11 the newest.
+      mtimeMs: 1_000 + index,
+      isFile: true,
+    }));
+    const { prune, unlinkMock } = await loadPrune({
+      files: [
+        ...dumpFiles,
+        {
+          name: "settings.dat",
+          dir: CRASH_DUMPS_ROOT,
+          mtimeMs: 1,
+          isFile: true,
+        },
+        { name: "completed", dir: CRASH_DUMPS_ROOT, mtimeMs: 1, isFile: false },
+      ],
+      readdirFails: false,
+    });
+
+    await prune.pruneStaleCrashDumps();
+
+    expect(unlinkMock.mock.calls.map((call) => call[0]).sort()).toEqual([
+      join(CRASH_DUMPS_ROOT, "completed", "report-0.dmp"),
+      join(CRASH_DUMPS_ROOT, "completed", "report-1.dmp"),
+    ]);
+  });
+
+  it("does nothing when the dump count is within the cap", async () => {
+    const { prune, unlinkMock } = await loadPrune({
+      files: Array.from({ length: 10 }, (_, index) => ({
+        name: `report-${index}.dmp`,
+        dir: CRASH_DUMPS_ROOT,
+        mtimeMs: 1_000 + index,
+        isFile: true,
+      })),
+      readdirFails: false,
+    });
+
+    await prune.pruneStaleCrashDumps();
+
+    expect(unlinkMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves quietly when the crash-dumps directory does not exist yet", async () => {
+    const { prune, unlinkMock } = await loadPrune({
+      files: [],
+      readdirFails: true,
+    });
+
+    await expect(prune.pruneStaleCrashDumps()).resolves.toBeUndefined();
+    expect(unlinkMock).not.toHaveBeenCalled();
+  });
+});
+
+interface FakeDumpEntry {
+  readonly name: string;
+  readonly dir: string;
+  readonly mtimeMs: number;
+  readonly isFile: boolean;
+}
+
+async function loadPrune(opts: {
+  readonly files: readonly FakeDumpEntry[];
+  readonly readdirFails: boolean;
+}): Promise<{
+  readonly prune: PruneModule;
+  readonly unlinkMock: Mock;
+}> {
+  vi.resetModules();
+
+  const unlinkMock: Mock = vi.fn(() => Promise.resolve());
+  const fsPromises = {
+    readdir: vi.fn(() =>
+      opts.readdirFails
+        ? Promise.reject(new Error("ENOENT: no such file or directory"))
+        : Promise.resolve(
+            opts.files.map((file) => ({
+              name: file.name,
+              parentPath: file.dir,
+              isFile: () => file.isFile,
+            })),
+          ),
+    ),
+    stat: vi.fn((path: string) => {
+      const match = opts.files.find(
+        (file) => join(file.dir, file.name) === path,
+      );
+      return match === undefined
+        ? Promise.reject(new Error(`unexpected stat: ${path}`))
+        : Promise.resolve({ mtimeMs: match.mtimeMs });
+    }),
+    unlink: unlinkMock,
+  };
+  vi.doMock("node:fs/promises", () => ({ ...fsPromises, default: fsPromises }));
+
+  vi.doMock("electron", () => ({
+    app: { getPath: vi.fn(() => CRASH_DUMPS_ROOT) },
+  }));
+  vi.doMock("../logger", () => ({
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  }));
+
+  return {
+    prune: await import("../crash-dump-prune"),
+    unlinkMock,
+  };
+}

--- a/clients/desktop/src/electron-main/app/core-dump-guard.ts
+++ b/clients/desktop/src/electron-main/app/core-dump-guard.ts
@@ -1,0 +1,97 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { isWsl } from "./wsl";
+import { log } from "./logger";
+
+// Support-driven opt-out: set to "1" to keep WSL's kernel core dumps, e.g.
+// to capture a full native core for a crash that only reproduces on one
+// user's machine. Deliberately an env var, not a setting: re-enabling after
+// the fact is otherwise a pre-crash, per-process `/proc/<pid>/coredump_filter`
+// write across every Electron child - not something support can walk a user
+// through. Whoever sets this accepts the giant-dump risk knowingly (WSL's
+// `.wslconfig` `crashDumpFolder` can at least point it at a large drive).
+const KEEP_KERNEL_CORE_DUMPS_ENV = "TRAYCER_KEEP_KERNEL_CORE_DUMPS";
+
+const COREDUMP_FILTER_PATH = "/proc/self/coredump_filter";
+
+/**
+ * Suppresses kernel core dumps under WSL by clearing
+ * `/proc/self/coredump_filter` - the kernel bitmask of which memory-mapping
+ * kinds get serialized into a core (0 = none; the resulting core is headers
+ * only, a few KB).
+ *
+ * Why: WSL sets `kernel.core_pattern` to pipe every core dump into its
+ * `wsl-capture-crash` handler, which relays the stream to
+ * `%TEMP%\wsl-crashes` on the Windows drive with a file-count cap but NO
+ * size cap. A piped core cannot seek, so the kernel materializes every
+ * untouched page as literal zero bytes - and an Electron process reserves
+ * hundreds of GB of virtual address space (V8 sandbox + guard regions) that
+ * is never backed by real memory. Observed in the field: one SIGTRAP after
+ * an overnight sleep produced a 450 GB dump that filled the user's Windows
+ * drive. `RLIMIT_CORE` is NOT enforced for piped cores, so `ulimit` is no
+ * defense; `coredump_filter` IS honored, and is inherited across
+ * `fork`/`execve`, so setting it here - before Chromium spawns any child -
+ * covers every renderer/GPU/utility process too.
+ *
+ * Crash diagnostics are unaffected: crashpad (see `initCrashReporter`)
+ * snapshots crashes via ptrace into its own minidumps and never reads
+ * kernel cores. Outside WSL this is deliberately a no-op - desktop distros
+ * cap core size in their own handlers (systemd-coredump/apport), and those
+ * cores stay useful for local debugging.
+ *
+ * Must run pre-`whenReady` (see `runPreReady`) so children inherit the
+ * filter; /proc is memory-backed, so the sync write cannot block on storage.
+ *
+ * Fail-open by design (settled in review): a failure here never blocks
+ * launch. The only realistic failure is the /proc file being absent
+ * (ENOENT), which means the kernel was built without ELF coredump support
+ * and cannot produce the dumps we're defending against - refusing to launch
+ * there would trade zero risk for a certain outage. Any other failure is
+ * escalated to `log.error` after a read-back verifies whether the mask
+ * actually stuck.
+ */
+export function suppressWslKernelCoreDumps(): void {
+  if (process.platform !== "linux") {
+    return;
+  }
+  if (process.env[KEEP_KERNEL_CORE_DUMPS_ENV] === "1") {
+    log.info("[core-dump-guard] kernel core dumps kept by env override", {
+      env: KEEP_KERNEL_CORE_DUMPS_ENV,
+    });
+    return;
+  }
+  if (!isWsl()) {
+    return;
+  }
+  try {
+    writeFileSync(COREDUMP_FILTER_PATH, "0");
+    // /proc writes can misreport partial application; trust the file, not
+    // the write. The kernel renders the mask as hex (e.g. "00000000").
+    const applied = parseInt(
+      readFileSync(COREDUMP_FILTER_PATH, "utf-8").trim(),
+      16,
+    );
+    if (applied === 0) {
+      log.info("[core-dump-guard] kernel core dumps suppressed under WSL");
+    } else {
+      log.error(
+        "[core-dump-guard] coredump_filter readback mismatch - giant WSL crash dumps remain possible",
+        { applied },
+      );
+    }
+  } catch (err) {
+    if (isEnoent(err)) {
+      log.info(
+        "[core-dump-guard] coredump_filter absent - kernel cannot produce core dumps, nothing to suppress",
+      );
+    } else {
+      log.error(
+        "[core-dump-guard] failed to clear coredump_filter - giant WSL crash dumps remain possible",
+        { err },
+      );
+    }
+  }
+}
+
+function isEnoent(err: unknown): boolean {
+  return err instanceof Error && "code" in err && err.code === "ENOENT";
+}

--- a/clients/desktop/src/electron-main/app/crash-dump-prune.ts
+++ b/clients/desktop/src/electron-main/app/crash-dump-prune.ts
@@ -1,0 +1,85 @@
+import { readdir, stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { app } from "electron";
+import { log } from "./logger";
+
+// Mirrors WSL's own crash-collection file-count cap. Crashpad prunes its
+// database too, but only at a loose ceiling (128 MB / age based); this keeps
+// a repeatedly-crashing environment (e.g. one crash per overnight sleep
+// under WSL) bounded to a handful of recent minidumps regardless of how many
+// sessions it takes to notice. Deliberately platform-neutral (settled in
+// review): dump-count growth is not WSL-specific, and the newest ten are all
+// diagnostics ever needs - Sentry uploads recent dumps when enabled.
+export const MAX_RETAINED_CRASH_DUMP_FILES = 10;
+
+export interface CrashDumpFile {
+  readonly path: string;
+  readonly mtimeMs: number;
+}
+
+/**
+ * Newest-first retention: keeps the `maxRetained` most recent dumps (the
+ * ones Sentry may still be uploading, and the ones worth attaching to a
+ * fresh bug report) and returns the older remainder for deletion.
+ */
+export function selectCrashDumpsToPrune(
+  files: readonly CrashDumpFile[],
+  maxRetained: number,
+): string[] {
+  return [...files]
+    .sort((a, b) => b.mtimeMs - a.mtimeMs)
+    .slice(maxRetained)
+    .map((file) => file.path);
+}
+
+/**
+ * Bounds the on-disk crashpad minidump backlog under
+ * `app.getPath("crashDumps")`. With uploads disabled or unreachable, crash
+ * reports otherwise accumulate until crashpad's own loose prune threshold.
+ * Touches only `*.dmp` report files - crashpad's database metadata recovers
+ * gracefully from a missing report. Best-effort by design: it runs inside a
+ * `timed` boot step whose boundary already logs a failure without aborting
+ * startup, and per-file errors just leave that file for the next launch.
+ */
+export async function pruneStaleCrashDumps(): Promise<void> {
+  const root = app.getPath("crashDumps");
+  // Absent until the first crash ever recorded - nothing to prune.
+  const entries = await readdir(root, {
+    withFileTypes: true,
+    recursive: true,
+  }).catch(() => null);
+  if (entries === null) {
+    return;
+  }
+  const dumpPaths = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".dmp"))
+    .map((entry) => join(entry.parentPath, entry.name));
+  if (dumpPaths.length <= MAX_RETAINED_CRASH_DUMP_FILES) {
+    return;
+  }
+  const files = await Promise.all(
+    dumpPaths.map((path) =>
+      stat(path).then(
+        (stats): CrashDumpFile => ({ path, mtimeMs: stats.mtimeMs }),
+        (): null => null,
+      ),
+    ),
+  );
+  const toPrune = selectCrashDumpsToPrune(
+    files.filter((file): file is CrashDumpFile => file !== null),
+    MAX_RETAINED_CRASH_DUMP_FILES,
+  );
+  const results = await Promise.all(
+    toPrune.map((path) =>
+      unlink(path).then(
+        () => true,
+        () => false,
+      ),
+    ),
+  );
+  log.info("[crash-dump-prune] pruned stale crash dumps", {
+    found: dumpPaths.length,
+    pruned: results.filter(Boolean).length,
+    maxRetained: MAX_RETAINED_CRASH_DUMP_FILES,
+  });
+}

--- a/clients/desktop/src/electron-main/app/linux-update-guidance.ts
+++ b/clients/desktop/src/electron-main/app/linux-update-guidance.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { isWsl } from "./wsl";
 import type { DesktopAppUpdateGuidance } from "../../ipc-contracts/app-update-types";
 
 const execFileAsync = promisify(execFile);
@@ -36,27 +37,6 @@ export function readLinuxPackageType(): LinuxPackageType | null {
 }
 
 /**
- * WSLg sessions typically have no session polkit authentication agent and no
- * TTY for a GUI-launched `sudo`, so `dpkg -i`/`rpm -U` via
- * `LinuxUpdater.runCommandWithSudoIfNeeded` reliably fails there. A plain
- * `/proc/version` read (no subprocess) is the authoritative signal; the env
- * vars are a cheap supplementary fast path, not fully guaranteed to propagate
- * through every WSLg GUI-launch path.
- */
-function isWsl(): boolean {
-  if (
-    process.env["WSL_DISTRO_NAME"] !== undefined ||
-    process.env["WSL_INTEROP"] !== undefined
-  ) {
-    return true;
-  }
-  if (!existsSync("/proc/version")) {
-    return false;
-  }
-  return /microsoft/i.test(readFileSync("/proc/version", "utf-8"));
-}
-
-/**
  * Resolves whether the package manager that owns `packageType` actually
  * tracks the binary we're running from - i.e. whether an in-place
  * `dpkg -i`/`rpm -U` upgrade would replace this exact process. A manually
@@ -86,10 +66,14 @@ async function isRegisteredAtRunningLocation(
  * UX gate, not a safety net: `updater.ts` unconditionally disables
  * `autoInstallOnAppQuit` for any deb/rpm build regardless of this result, so
  * a wrong answer here only costs the user a manual step, never a silent
- * failure. Deliberately does not probe for a live polkit agent (fragile
- * across desktop environments, and would risk spawning a spurious auth
- * prompt on every launch) - WSL exclusion plus the registration check cover
- * the realistic split between "normal desktop Linux" and "can't self-update".
+ * failure. WSLg sessions typically have no session polkit authentication
+ * agent and no TTY for a GUI-launched `sudo`, so `dpkg -i`/`rpm -U` via
+ * `LinuxUpdater.runCommandWithSudoIfNeeded` reliably fails there - hence the
+ * `isWsl` exclusion. Deliberately does not probe for a live polkit agent
+ * (fragile across desktop environments, and would risk spawning a spurious
+ * auth prompt on every launch) - WSL exclusion plus the registration check
+ * cover the realistic split between "normal desktop Linux" and "can't
+ * self-update".
  */
 export async function resolveLinuxSilentInstallSupported(
   packageType: LinuxPackageType,

--- a/clients/desktop/src/electron-main/app/wsl.ts
+++ b/clients/desktop/src/electron-main/app/wsl.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync } from "node:fs";
+
+/**
+ * WSL detection shared by update guidance (WSLg sessions can't run a GUI
+ * `sudo` - see `resolveLinuxSilentInstallSupported`) and the core-dump guard
+ * (WSL's crash capture has no size cap). A plain `/proc/version` read (no
+ * subprocess) is the authoritative signal; the env vars are a cheap
+ * supplementary fast path, not fully guaranteed to propagate through every
+ * WSLg GUI-launch path.
+ */
+export function isWsl(): boolean {
+  if (
+    process.env["WSL_DISTRO_NAME"] !== undefined ||
+    process.env["WSL_INTEROP"] !== undefined
+  ) {
+    return true;
+  }
+  if (!existsSync("/proc/version")) {
+    return false;
+  }
+  return /microsoft/i.test(readFileSync("/proc/version", "utf-8"));
+}

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -81,6 +81,8 @@ import {
   installProcessGoneListeners,
   logGpuInfo,
 } from "../app/crash-reporter";
+import { suppressWslKernelCoreDumps } from "../app/core-dump-guard";
+import { pruneStaleCrashDumps } from "../app/crash-dump-prune";
 import { startRendererMemorySampler } from "../app/diagnostics";
 import {
   configureAppUserModelId,
@@ -231,13 +233,15 @@ async function timed(
 // Pre-ready: command-line switches, scheme registration, hardware
 // acceleration toggle, V8 heap, and crash collection all run before
 // Chromium initializes. These are synchronous in-process Electron calls
-// (the one sync filesystem read - the GPU preference - is documented as the
-// required pre-`whenReady` exception in app/gpu-acceleration.ts).
+// (two documented sync-filesystem exceptions: the GPU preference read in
+// app/gpu-acceleration.ts and the memory-backed /proc write in
+// app/core-dump-guard.ts, which must land before Chromium spawns children).
 function runPreReady(state: BootState): void {
   trimUnusedChromiumFeatures();
   configureV8HeapSize();
   applyHardwareAccelerationPreference();
   registerAppScheme();
+  suppressWslKernelCoreDumps();
   initCrashReporter();
   installGlobalErrorHandlers();
   installProcessGoneListeners();
@@ -273,6 +277,7 @@ async function runOnReady(state: BootState): Promise<void> {
     timed("on-ready", "download-observer", () => installDownloadObserver()),
     timed("on-ready", "preconnect", () => preconnectTraycerHosts()),
     timed("on-ready", "gpu-info", () => logGpuInfo()),
+    timed("on-ready", "crash-dump-prune", () => pruneStaleCrashDumps()),
   ]);
 }
 


### PR DESCRIPTION
## Summary

- Under WSL, kernel core dumps are piped to `wsl-capture-crash`, which relays them to `%TEMP%\wsl-crashes` on the Windows drive with a file-count cap but **no size cap**. A piped core can't seek, so every untouched page of the process's reserved-but-never-touched virtual address space (Electron/V8's sandbox + guard regions run into the hundreds of GB) gets serialized as literal zero bytes. One user's overnight-sleep crash produced a **450 GB** dump that filled their Windows drive. `RLIMIT_CORE` is not enforced for piped cores, so `ulimit` offers no defense.
- `core-dump-guard.ts`: on Linux under WSL, clears `/proc/self/coredump_filter` pre-`whenReady` (inherited by every Chromium child via fork/exec) so the kernel serializes no memory mappings into a core. Fails open — a write failure never blocks launch; ENOENT is treated as confirmed-safe (no coredump support to abuse), a write is verified by read-back, and any other failure is escalated to `log.error`. `TRAYCER_KEEP_KERNEL_CORE_DUMPS=1` opts back in for support-driven debugging. Non-WSL Linux is unaffected — desktop distros already cap core size in their own handlers. Crashpad/Sentry minidumps (ptrace-based, not kernel cores) are unaffected either way.
- `crash-dump-prune.ts`: bounds the local crashpad minidump backlog to the 10 newest `.dmp` files on boot, platform-neutral, so a repeatedly-crashing environment can't accumulate dumps without bound regardless of platform.
- `wsl.ts`: extracts the existing `isWsl()` detection (previously private to `linux-update-guidance.ts`) for reuse.

## Test plan

- [x] `bun run compile` — clean
- [x] `bun run test` — 611/611 desktop tests pass (66 files), including new coverage for WSL detection paths, the env override, ENOENT/write-failure/read-back-mismatch handling, and prune selection/IO
- [x] `prettier --check` / `eslint --max-warnings 0` on all touched files — clean
- [x] Reviewed by a fresh agent (Traycer `traycer-review`); both findings addressed (fail-open hardened with read-back verification; prune scope confirmed intentional as platform-neutral)
- [ ] Not verified end-to-end on a real WSL machine (no WSL environment available here) — relies on documented kernel/WSL semantics (`coredump_filter` inheritance across fork/exec, piped-core `RLIMIT_CORE` non-enforcement)