### PR TITLE
fix(gui-app): guard mention menu scroll effect against empty items

### DIFF
--- a/clients/gui-app/src/components/comments/__tests__/collaborator-mention-suggestion.test.tsx
+++ b/clients/gui-app/src/components/comments/__tests__/collaborator-mention-suggestion.test.tsx
@@ -1,0 +1,36 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MentionSuggestionList } from "../collaborator-mention-suggestion";
+
+afterEach(() => {
+  cleanup();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+describe("MentionSuggestionList", () => {
+  it("renders the empty state instead of crashing when items is empty", async () => {
+    // Regression: the scroll-into-view effect indexed itemRefs with a
+    // `=== null` guard, but an empty `items` array never populates any
+    // itemRefs slot, so the ref there is `undefined` - `undefined` !==
+    // `null`, so the guard didn't catch it and `undefined.scrollIntoView`
+    // threw during commit, crashing before the empty state could render.
+    render(
+      <MentionSuggestionList
+        items={[]}
+        command={vi.fn()}
+        getReferenceClientRect={null}
+      />,
+    );
+    await flush();
+
+    expect(screen.getByText("No matching collaborators")).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/comments/collaborator-mention-suggestion.tsx
+++ b/clients/gui-app/src/components/comments/collaborator-mention-suggestion.tsx
@@ -130,10 +130,11 @@ function MentionSuggestionListContent({
   }, [getReferenceClientRect, items.length]);
 
   useLayoutEffect(() => {
-    const node = itemRefs.current[selectedIndex];
+    if (items.length === 0) return;
+    const node = itemRefs.current[selectedIndex] ?? null;
     if (node === null) return;
     node.scrollIntoView({ block: "nearest" });
-  }, [selectedIndex]);
+  }, [items.length, selectedIndex]);
 
   if (typeof document === "undefined") return null;
 


### PR DESCRIPTION
## Crash

Typing `@` in the collab-editor comment composer could crash the entire app to the error boundary whenever the mention suggestion list had zero items - most commonly while the collaborators query is still loading, or when the typed query matches nobody.

## Root cause

`MentionSuggestionListContent` (`clients/gui-app/src/components/comments/collaborator-mention-suggestion.tsx`) renders a "No matching collaborators" empty state when `items` is empty. But its scroll-into-view layout effect read the selected item's ref like this:

```ts
useLayoutEffect(() => {
  const node = itemRefs.current[selectedIndex];
  if (node === null) return;
  node.scrollIntoView({ block: "nearest" });
}, [selectedIndex]);
```

`itemRefs` is `useRef<Array<HTMLButtonElement | null>>([])`. When `items` is empty, no `<button>` rows render, so no ref callback ever runs and `itemRefs.current[selectedIndex]` is `undefined` - not `null`. The `=== null` guard doesn't catch `undefined`, so `undefined.scrollIntoView` throws during commit.

Because the list remounts fresh on every items-derived `key` change (including the empty case), this made the empty-items render path always crash - the "No matching collaborators" UI was effectively unreachable.

## Fix

Early-return from the effect when `items.length === 0`, and normalize any missing ref slot to `null` instead of relying on strict `=== null`:

```ts
useLayoutEffect(() => {
  if (items.length === 0) return;
  const node = itemRefs.current[selectedIndex] ?? null;
  if (node === null) return;
  node.scrollIntoView({ block: "nearest" });
}, [items.length, selectedIndex]);
```

## Test

Added `clients/gui-app/src/components/comments/__tests__/collaborator-mention-suggestion.test.tsx`, which mounts `MentionSuggestionList` with `items={[]}` and asserts the "No matching collaborators" empty state renders without throwing. Verified the test fails against the pre-fix code (`TypeError: Cannot read properties of undefined (reading 'scrollIntoView')`) and passes against the fix.

`bun run compile`, `bun run test` (full suite, 6083 tests), `bun run lint`, and `react-doctor` on the changed files are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)