### PR TITLE
feat(protocol,gui-app): narrow in-flight profile switch; forbid subset-field settings writes

### DIFF
--- a/clients/gui-app/src/components/chat/composer/use-task-profile-rate-limit-switch.ts
+++ b/clients/gui-app/src/components/chat/composer/use-task-profile-rate-limit-switch.ts
@@ -3,8 +3,7 @@ import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type { ModelOption } from "@/components/home/data/landing-options";
 import { useTabHostId } from "@/components/epic-canvas/hooks/use-tab-host-id";
-import { useEpicUpdateChatRunSettings } from "@/hooks/epic/use-epic-chat-mutations";
-import { enqueuePersistChatRunSettings } from "@/lib/chats/chat-run-settings-write-queue";
+import { useEpicUpdateChatProfile } from "@/hooks/epic/use-epic-chat-mutations";
 import { getChatSessionRegistry } from "@/lib/registries/chat-session-registry";
 import { useMaybeOpenEpicHandle } from "@/providers/use-open-epic-handle";
 import type { ChatsSlice } from "@/stores/epics/open-epic/types";
@@ -24,13 +23,15 @@ export interface TaskProfileRateLimitSwitch {
    */
   readonly affectedChatCount: number;
   /**
-   * Switches every OTHER affected chat to `nextProfileId`: persists each
-   * chat's settings durably via `epic.updateChatRunSettings` (best-effort -
-   * an old host rejects the optional method and those chats keep legacy
-   * persist-on-next-send behavior), live-updates any warm session so an open
-   * composer re-seeds immediately, and restamps its already-queued prompts so
-   * they don't keep running on the old profile. The caller's own composer
-   * commit (`onSwitchProfile`) covers this chat.
+   * Switches every OTHER affected chat to `nextProfileId` via the narrow
+   * `epic.updateChatProfile` RPC (best-effort - an old host rejects the
+   * optional method and those chats keep legacy persist-on-next-send
+   * behavior). The host patches its own authoritative persisted tuple and,
+   * for a warm session, moves already-queued prompts and a not-yet-spawned
+   * parked turn onto the new profile with it. Warm sessions additionally get
+   * a local composer re-seed so open sibling tiles reflect the switch
+   * immediately. The caller's own composer commit (`onSwitchProfile`) covers
+   * this chat.
    */
   readonly switchOtherTaskChats: (nextProfileId: string | null) => void;
 }
@@ -142,39 +143,37 @@ export function useTaskProfileRateLimitSwitch(input: {
     ? affected.length
     : affected.length + 1;
 
-  const updateChatRunSettings = useEpicUpdateChatRunSettings();
-  const updateChatRunSettingsMutateAsync = updateChatRunSettings.mutateAsync;
+  const updateChatProfile = useEpicUpdateChatProfile();
+  const updateChatProfileMutate = updateChatProfile.mutate;
   const switchOtherTaskChats = useCallback(
     (nextProfileId: string | null): void => {
       if (epicId === null) return;
       for (const chat of affected) {
         if (chat.chatId === chatId) continue;
-        const settings: ChatRunSettings = {
-          ...chat.settings,
-          profileId: nextProfileId,
-        };
-        // Routed through the same module-scoped queue the sibling's own
-        // composer writes use (chat-tile.tsx), so this task-wide switch can't
-        // race an in-flight write from that chat's own composer and leave it
-        // pinned to stale settings.
-        enqueuePersistChatRunSettings(updateChatRunSettingsMutateAsync, {
+        // Narrow profile-only update: the host patches its own authoritative
+        // persisted tuple (and, for a warm session, moves queued prompts and
+        // a not-yet-spawned parked turn with it). Deliberately NOT a
+        // client-side `{ ...chat.settings, profileId }` rebuild - the store
+        // projection can lag the sibling's real settings, and re-persisting
+        // a stale full tuple just to move the profile is exactly the
+        // subset-field misuse `epic.updateChatRunSettings` v1.1 forbids.
+        updateChatProfileMutate({
           epicId,
           chatId: chat.chatId,
-          settings,
+          profileId: nextProfileId,
         });
-        const warmSession = getChatSessionRegistry().peek(epicId, chat.chatId);
         // Warm sessions re-seed their composer toolbar from
         // `currentComposerSettings`, so an open sibling tile reflects the
-        // switch immediately instead of stomping it on its next send.
-        warmSession?.store.getState().setCurrentComposerSettings(settings);
-        // Also restamp its already-queued (not-yet-sent) prompts - otherwise
-        // they keep running on the old profile until another composer change
-        // happens to touch them. No queue item is "open for editing" from
-        // this task-wide switch's perspective, so nothing is excluded.
-        warmSession?.store.getState().restampQueuedItemSettings(settings, null);
+        // switch immediately instead of stomping it on its next send. This is
+        // local display state, not a wire persist.
+        const warmSession = getChatSessionRegistry().peek(epicId, chat.chatId);
+        warmSession?.store.getState().setCurrentComposerSettings({
+          ...chat.settings,
+          profileId: nextProfileId,
+        });
       }
     },
-    [affected, chatId, epicId, updateChatRunSettingsMutateAsync],
+    [affected, chatId, epicId, updateChatProfileMutate],
   );
 
   return { affectedChatCount, switchOtherTaskChats };

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
@@ -4,7 +4,10 @@ import type {
   ChatRunSettings,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { JsonContent } from "@traycer/protocol/common/registry";
-import type { ChatSessionStoreHandle } from "@/stores/chats/chat-session-store";
+import {
+  isChatRunInProgress,
+  type ChatSessionStoreHandle,
+} from "@/stores/chats/chat-session-store";
 import {
   decideSteerSettings,
   type SteerSettingsDecision,
@@ -241,6 +244,9 @@ export function useChatQueueActions(
     (settings: ChatRunSettings): void => {
       const permissionModeChanged =
         settings.permissionMode !== currentComposerSettings.permissionMode;
+      const profileChanged =
+        settings.profileId !== currentComposerSettings.profileId &&
+        settings.harnessId === currentComposerSettings.harnessId;
       setEpicRunSettings(currentEpicId, settings, Date.now());
       handle.store.getState().setCurrentComposerSettings(settings);
       // Durable sync: the host's per-chat settings must not lag the composer,
@@ -248,10 +254,7 @@ export function useChatQueueActions(
       persistChatRunSettings(settings);
       // Live-mirror: pending queued prompts always resolve the latest toolbar
       // settings. Exclude the item open for editing (it commits on submit); the
-      // store also skips no-op updates. With an empty queue it still forwards a
-      // profile switch while a run is in progress - the host stamps a pre-spawn
-      // override from the frame so a turn still parked on worktree setup adopts
-      // the new profile instead of spawning on the switched-away one.
+      // store also skips no-op updates and when there are no pending items.
       chatActions.restampQueuedItemSettings(settings, activeEditingQueueItemId);
       // Read the live turn at call time (see steerQueuedItemNow): closing over the
       // per-snapshot `state.activeTurn` object would re-create this callback every
@@ -262,11 +265,28 @@ export function useChatQueueActions(
       ) {
         chatActions.updateActivePermissionMode(settings.permissionMode);
       }
+      // Narrow in-flight profile switch (same shape as the permission-mode
+      // update above): a same-harness profile change while a run is in
+      // progress is forwarded so a turn still parked on worktree setup
+      // adopts the switched profile before it spawns, instead of erroring
+      // on the rate-limited profile the user just moved off. Gated on
+      // `runStatus` (not `activeTurn`): the parked pre-spawn window this
+      // targets begins at accept, before an activeTurn is broadcast. A
+      // cross-harness change is NOT a profile switch (profile ids are
+      // harness-scoped) - the full tuple on the next send covers it.
+      if (
+        profileChanged &&
+        isChatRunInProgress(handle.store.getState().runStatus)
+      ) {
+        chatActions.updateActiveProfile(settings.harnessId, settings.profileId);
+      }
     },
     [
       activeEditingQueueItemId,
       chatActions,
       currentComposerSettings.permissionMode,
+      currentComposerSettings.profileId,
+      currentComposerSettings.harnessId,
       currentEpicId,
       handle.store,
       persistChatRunSettings,

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
@@ -248,10 +248,10 @@ export function useChatQueueActions(
       persistChatRunSettings(settings);
       // Live-mirror: pending queued prompts always resolve the latest toolbar
       // settings. Exclude the item open for editing (it commits on submit); the
-      // store also skips no-op updates and only sends with an empty queue while
-      // a run is in progress - the host then stamps a pre-spawn profile
-      // override from the frame so a turn still parked on worktree setup
-      // adopts a profile switch instead of spawning on the switched-away one.
+      // store also skips no-op updates. With an empty queue it still forwards a
+      // profile switch while a run is in progress - the host stamps a pre-spawn
+      // override from the frame so a turn still parked on worktree setup adopts
+      // the new profile instead of spawning on the switched-away one.
       chatActions.restampQueuedItemSettings(settings, activeEditingQueueItemId);
       // Read the live turn at call time (see steerQueuedItemNow): closing over the
       // per-snapshot `state.activeTurn` object would re-create this callback every

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
@@ -256,12 +256,16 @@ export function useChatQueueActions(
       // settings. Exclude the item open for editing (it commits on submit); the
       // store also skips no-op updates and when there are no pending items.
       chatActions.restampQueuedItemSettings(settings, activeEditingQueueItemId);
-      // Read the live turn at call time (see steerQueuedItemNow): closing over the
-      // per-snapshot `state.activeTurn` object would re-create this callback every
-      // streamed token → lowerComposer → composerModel churn → composer re-render.
+      // Both live-turn forwards below read store state at call time (see
+      // steerQueuedItemNow): closing over per-snapshot objects would
+      // re-create this callback every streamed token → lowerComposer →
+      // composerModel churn → composer re-render. Both gate on `runStatus`
+      // rather than `activeTurn`: the pre-spawn window they target begins at
+      // accept, before an activeTurn is broadcast, and the host honors both
+      // updates through that whole window (`turnActivating` onward).
       if (
-        handle.store.getState().activeTurn !== null &&
-        permissionModeChanged
+        permissionModeChanged &&
+        isChatRunInProgress(handle.store.getState().runStatus)
       ) {
         chatActions.updateActivePermissionMode(settings.permissionMode);
       }
@@ -269,9 +273,7 @@ export function useChatQueueActions(
       // update above): a same-harness profile change while a run is in
       // progress is forwarded so a turn still parked on worktree setup
       // adopts the switched profile before it spawns, instead of erroring
-      // on the rate-limited profile the user just moved off. Gated on
-      // `runStatus` (not `activeTurn`): the parked pre-spawn window this
-      // targets begins at accept, before an activeTurn is broadcast. A
+      // on the rate-limited profile the user just moved off. A
       // cross-harness change is NOT a profile switch (profile ids are
       // harness-scoped) - the full tuple on the next send covers it.
       if (

--- a/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/use-chat-queue-actions.ts
@@ -248,7 +248,10 @@ export function useChatQueueActions(
       persistChatRunSettings(settings);
       // Live-mirror: pending queued prompts always resolve the latest toolbar
       // settings. Exclude the item open for editing (it commits on submit); the
-      // store also skips no-op updates and when there are no pending items.
+      // store also skips no-op updates and only sends with an empty queue while
+      // a run is in progress - the host then stamps a pre-spawn profile
+      // override from the frame so a turn still parked on worktree setup
+      // adopts a profile switch instead of spawning on the switched-away one.
       chatActions.restampQueuedItemSettings(settings, activeEditingQueueItemId);
       // Read the live turn at call time (see steerQueuedItemNow): closing over the
       // per-snapshot `state.activeTurn` object would re-create this callback every

--- a/clients/gui-app/src/hooks/chats/use-chat-actions.ts
+++ b/clients/gui-app/src/hooks/chats/use-chat-actions.ts
@@ -3,6 +3,7 @@ import type {
   ChatRunSettings,
   ChatActiveTurn,
 } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type { PermissionMode } from "@traycer/protocol/persistence/epic/foundation";
 import type {
   InterviewAnswer,
@@ -64,6 +65,10 @@ export interface ChatActions {
   ) => void;
   readonly updateActivePermissionMode: (
     permissionMode: PermissionMode,
+  ) => string | null;
+  readonly updateActiveProfile: (
+    harnessId: GuiHarnessId,
+    profileId: string | null,
   ) => string | null;
   readonly queueCancel: (queueItemId: string) => string | null;
   readonly queueReorder: (
@@ -195,6 +200,8 @@ export function useChatActions(handle: ChatSessionStoreHandle): ChatActions {
           .restampQueuedItemSettings(settings, excludeQueueItemId),
       updateActivePermissionMode: (permissionMode) =>
         handle.store.getState().updateActivePermissionMode(permissionMode),
+      updateActiveProfile: (harnessId, profileId) =>
+        handle.store.getState().updateActiveProfile(harnessId, profileId),
       queueCancel: (queueItemId) =>
         tracked(handle.store.getState().queueCancel(queueItemId), () => {
           Analytics.getInstance().track(

--- a/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-chat-mutations.ts
@@ -9,6 +9,8 @@ import type {
   CreateChatResponse,
   DeleteChatRequest,
   DeleteChatResponse,
+  UpdateChatProfileRequest,
+  UpdateChatProfileResponse,
   UpdateChatRunSettingsRequest,
   UpdateChatRunSettingsResponse,
 } from "@traycer/protocol/host/epic/unary-schemas";
@@ -203,6 +205,38 @@ export function useEpicUpdateChatRunSettings(): UseMutationResult<
     mapVariables: (variables) => variables,
     options: {
       mutationKey: epicMutationKeys.updateChatRunSettings(),
+    },
+  });
+}
+
+/**
+ * Mutation hook for `epic.updateChatProfile` (optional host capability).
+ *
+ * Narrow profile-only settings update: moves a chat onto another logged-in
+ * profile of its current harness WITHOUT rebuilding the full tuple
+ * client-side - the host patches its own authoritative persisted record, so
+ * a possibly-stale projection can never be re-persisted just to move the
+ * profile. Tab-host scoped, like `useEpicUpdateChatRunSettings` above, and
+ * likewise fire-and-forget: against an old host the call fails with
+ * `E_HOST_UNSUPPORTED` and callers degrade to persist-on-next-send.
+ */
+export function useEpicUpdateChatProfile(): UseMutationResult<
+  UpdateChatProfileResponse,
+  HostRpcError,
+  UpdateChatProfileRequest
+> {
+  const client = useTabHostClient();
+  return useHostMutation<
+    HostRpcRegistry,
+    "epic.updateChatProfile",
+    unknown,
+    UpdateChatProfileRequest
+  >({
+    client,
+    method: "epic.updateChatProfile",
+    mapVariables: (variables) => variables,
+    options: {
+      mutationKey: epicMutationKeys.updateChatProfile(),
     },
   });
 }

--- a/clients/gui-app/src/lib/query-keys/epic-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/epic-mutation-keys.ts
@@ -6,4 +6,5 @@ export const epicMutationKeys = {
   createChat: () => ["epic.createChat"] as const,
   exportArtifacts: () => ["epic.exportArtifacts"] as const,
   updateChatRunSettings: () => ["epic.updateChatRunSettings"] as const,
+  updateChatProfile: () => ["epic.updateChatProfile"] as const,
 };

--- a/clients/gui-app/src/stores/chats/__tests__/profile-durability-d1-queue-restamp.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/profile-durability-d1-queue-restamp.test.ts
@@ -3,6 +3,7 @@ import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
   ChatQueuedItem,
   ChatRunSettings,
+  ChatRunStatus,
   ChatSubscribeClientFrame,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { ChatStreamCallbacks } from "@traycer-clients/shared/host-transport/chat-stream-client";
@@ -90,7 +91,7 @@ function createHarness(): Harness {
   };
 }
 
-function emitSnapshot(harness: Harness): void {
+function emitSnapshot(harness: Harness, runStatus: ChatRunStatus): void {
   harness.callbacks().onConnectionStatus("open", null);
   harness.callbacks().onSnapshot({
     kind: "snapshot",
@@ -115,7 +116,7 @@ function emitSnapshot(harness: Harness): void {
       },
       access: { role: "owner", ownerUserId: OWNER_ID, canAct: true },
       queue: { status: "idle", items: [] },
-      runStatus: "idle",
+      runStatus,
       activeTurn: null,
       pendingApprovals: [],
       pendingInterviews: [],
@@ -151,7 +152,7 @@ function queuedItem(
 describe("D1: queued messages + profile switch (restamp path)", () => {
   it("a same-harness/same-model profile-only switch restamps an already-queued message to the new profile", () => {
     const harness = createHarness();
-    emitSnapshot(harness);
+    emitSnapshot(harness, "idle");
 
     // One message is already queued on profile A.
     harness.callbacks().onQueueChanged({
@@ -183,7 +184,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("a no-op re-commit of the SAME profile still sends nothing (chatRunSettingsEqual correctly reports equal)", () => {
     const harness = createHarness();
-    emitSnapshot(harness);
+    emitSnapshot(harness, "idle");
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -205,7 +206,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("control: a harness/model change on top of the same profile DOES restamp (chatRunSettingsEqual still catches non-profile fields)", () => {
     const harness = createHarness();
-    emitSnapshot(harness);
+    emitSnapshot(harness, "idle");
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -236,7 +237,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("documents the mixed-queue contract: the GUI has no per-item scoping, only excludeQueueItemId - a profile-only item now trips the gate on its own, and a sibling with an unrelated field change rides along in the SAME frame", () => {
     const harness = createHarness();
-    emitSnapshot(harness);
+    emitSnapshot(harness, "idle");
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -275,5 +276,33 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
     }
     expect(frame.settings).toEqual(PROFILE_B_SETTINGS);
     expect(frame.excludeQueueItemId).toBeNull();
+  });
+
+  it("with an EMPTY queue, a profile switch during an in-progress run still sends the frame - the host stamps a pre-spawn profile override from it, so a turn parked on worktree setup adopts the switch", () => {
+    const harness = createHarness();
+    emitSnapshot(harness, "running");
+
+    harness.handle.store
+      .getState()
+      .restampQueuedItemSettings(PROFILE_B_SETTINGS, null);
+
+    expect(harness.sent).toHaveLength(1);
+    const frame = harness.sent[0];
+    if (frame.kind !== "queueSettingsRestamp") {
+      throw new Error("Expected queueSettingsRestamp frame");
+    }
+    expect(frame.settings.profileId).toBe("profile-b");
+    expect(frame.excludeQueueItemId).toBeNull();
+  });
+
+  it("with an empty queue and no run in progress, a profile switch sends nothing - there is neither a queued item nor a pre-spawn turn the frame could move", () => {
+    const harness = createHarness();
+    emitSnapshot(harness, "idle");
+
+    harness.handle.store
+      .getState()
+      .restampQueuedItemSettings(PROFILE_B_SETTINGS, null);
+
+    expect(harness.sent).toHaveLength(0);
   });
 });

--- a/clients/gui-app/src/stores/chats/__tests__/profile-durability-d1-queue-restamp.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/profile-durability-d1-queue-restamp.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
+  ChatActiveTurn,
   ChatQueuedItem,
   ChatRunSettings,
   ChatRunStatus,
@@ -91,7 +92,30 @@ function createHarness(): Harness {
   };
 }
 
-function emitSnapshot(harness: Harness, runStatus: ChatRunStatus): void {
+// A minimal running/stopping turn bound to `profileId` - the pre-spawn
+// override the empty-queue restamp forwards is keyed off the difference
+// between this and the incoming settings' profile.
+function activeTurnOnProfile(profileId: string | null): ChatActiveTurn {
+  return {
+    turnId: "turn-active",
+    status: "running",
+    harnessId: "claude",
+    model: "sonnet-4.5",
+    agentMode: "regular",
+    profileId,
+    userMessageId: "m-1",
+    startedAt: 1,
+    updatedAt: 1,
+    reasoningEffort: "high",
+    serviceTier: null,
+  };
+}
+
+function emitSnapshot(
+  harness: Harness,
+  runStatus: ChatRunStatus,
+  activeTurn: ChatActiveTurn | null,
+): void {
   harness.callbacks().onConnectionStatus("open", null);
   harness.callbacks().onSnapshot({
     kind: "snapshot",
@@ -117,7 +141,7 @@ function emitSnapshot(harness: Harness, runStatus: ChatRunStatus): void {
       access: { role: "owner", ownerUserId: OWNER_ID, canAct: true },
       queue: { status: "idle", items: [] },
       runStatus,
-      activeTurn: null,
+      activeTurn,
       pendingApprovals: [],
       pendingInterviews: [],
       worktreeBinding: null,
@@ -152,7 +176,7 @@ function queuedItem(
 describe("D1: queued messages + profile switch (restamp path)", () => {
   it("a same-harness/same-model profile-only switch restamps an already-queued message to the new profile", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle");
+    emitSnapshot(harness, "idle", null);
 
     // One message is already queued on profile A.
     harness.callbacks().onQueueChanged({
@@ -184,7 +208,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("a no-op re-commit of the SAME profile still sends nothing (chatRunSettingsEqual correctly reports equal)", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle");
+    emitSnapshot(harness, "idle", null);
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -206,7 +230,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("control: a harness/model change on top of the same profile DOES restamp (chatRunSettingsEqual still catches non-profile fields)", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle");
+    emitSnapshot(harness, "idle", null);
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -237,7 +261,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("documents the mixed-queue contract: the GUI has no per-item scoping, only excludeQueueItemId - a profile-only item now trips the gate on its own, and a sibling with an unrelated field change rides along in the SAME frame", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle");
+    emitSnapshot(harness, "idle", null);
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -278,26 +302,45 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
     expect(frame.excludeQueueItemId).toBeNull();
   });
 
-  it("with an EMPTY queue, a profile switch during an in-progress run still sends the frame - the host stamps a pre-spawn profile override from it, so a turn parked on worktree setup adopts the switch", () => {
+  // `isChatRunInProgress` accepts both "running" and "stopping", so the
+  // empty-queue forward must hold for either accepted state.
+  for (const runStatus of ["running", "stopping"] as const) {
+    it(`with an EMPTY queue, a profile switch away from the active turn's profile during a ${runStatus} run still sends the frame - the host stamps a pre-spawn override from it, so a turn parked on worktree setup adopts the switch`, () => {
+      const harness = createHarness();
+      emitSnapshot(harness, runStatus, activeTurnOnProfile("profile-a"));
+
+      harness.handle.store
+        .getState()
+        .restampQueuedItemSettings(PROFILE_B_SETTINGS, null);
+
+      expect(harness.sent).toHaveLength(1);
+      const frame = harness.sent[0];
+      if (frame.kind !== "queueSettingsRestamp") {
+        throw new Error("Expected queueSettingsRestamp frame");
+      }
+      expect(frame.settings.profileId).toBe("profile-b");
+      expect(frame.excludeQueueItemId).toBeNull();
+    });
+  }
+
+  it("with an empty queue during a run, a NON-profile change (same profile as the active turn) sends nothing - there is no parked turn to redirect, only a permission/model edit", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "running");
+    emitSnapshot(harness, "running", activeTurnOnProfile("profile-a"));
 
-    harness.handle.store
-      .getState()
-      .restampQueuedItemSettings(PROFILE_B_SETTINGS, null);
+    // Same profile as the active turn, only a non-profile field differs. This
+    // is the "changed permission/model mid-turn" case the chat-tile suite
+    // guards - it must not emit a queueSettingsRestamp.
+    harness.handle.store.getState().restampQueuedItemSettings(
+      { ...PROFILE_A_SETTINGS, permissionMode: "full_access" },
+      null,
+    );
 
-    expect(harness.sent).toHaveLength(1);
-    const frame = harness.sent[0];
-    if (frame.kind !== "queueSettingsRestamp") {
-      throw new Error("Expected queueSettingsRestamp frame");
-    }
-    expect(frame.settings.profileId).toBe("profile-b");
-    expect(frame.excludeQueueItemId).toBeNull();
+    expect(harness.sent).toHaveLength(0);
   });
 
   it("with an empty queue and no run in progress, a profile switch sends nothing - there is neither a queued item nor a pre-spawn turn the frame could move", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle");
+    emitSnapshot(harness, "idle", null);
 
     harness.handle.store
       .getState()

--- a/clients/gui-app/src/stores/chats/__tests__/profile-durability-d1-queue-restamp.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/profile-durability-d1-queue-restamp.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type {
-  ChatActiveTurn,
   ChatQueuedItem,
   ChatRunSettings,
-  ChatRunStatus,
   ChatSubscribeClientFrame,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { ChatStreamCallbacks } from "@traycer-clients/shared/host-transport/chat-stream-client";
@@ -92,30 +90,7 @@ function createHarness(): Harness {
   };
 }
 
-// A minimal running/stopping turn bound to `profileId` - the pre-spawn
-// override the empty-queue restamp forwards is keyed off the difference
-// between this and the incoming settings' profile.
-function activeTurnOnProfile(profileId: string | null): ChatActiveTurn {
-  return {
-    turnId: "turn-active",
-    status: "running",
-    harnessId: "claude",
-    model: "sonnet-4.5",
-    agentMode: "regular",
-    profileId,
-    userMessageId: "m-1",
-    startedAt: 1,
-    updatedAt: 1,
-    reasoningEffort: "high",
-    serviceTier: null,
-  };
-}
-
-function emitSnapshot(
-  harness: Harness,
-  runStatus: ChatRunStatus,
-  activeTurn: ChatActiveTurn | null,
-): void {
+function emitSnapshot(harness: Harness): void {
   harness.callbacks().onConnectionStatus("open", null);
   harness.callbacks().onSnapshot({
     kind: "snapshot",
@@ -140,8 +115,8 @@ function emitSnapshot(
       },
       access: { role: "owner", ownerUserId: OWNER_ID, canAct: true },
       queue: { status: "idle", items: [] },
-      runStatus,
-      activeTurn,
+      runStatus: "idle",
+      activeTurn: null,
       pendingApprovals: [],
       pendingInterviews: [],
       worktreeBinding: null,
@@ -176,7 +151,7 @@ function queuedItem(
 describe("D1: queued messages + profile switch (restamp path)", () => {
   it("a same-harness/same-model profile-only switch restamps an already-queued message to the new profile", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle", null);
+    emitSnapshot(harness);
 
     // One message is already queued on profile A.
     harness.callbacks().onQueueChanged({
@@ -208,7 +183,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("a no-op re-commit of the SAME profile still sends nothing (chatRunSettingsEqual correctly reports equal)", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle", null);
+    emitSnapshot(harness);
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -230,7 +205,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("control: a harness/model change on top of the same profile DOES restamp (chatRunSettingsEqual still catches non-profile fields)", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle", null);
+    emitSnapshot(harness);
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -261,7 +236,7 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
 
   it("documents the mixed-queue contract: the GUI has no per-item scoping, only excludeQueueItemId - a profile-only item now trips the gate on its own, and a sibling with an unrelated field change rides along in the SAME frame", () => {
     const harness = createHarness();
-    emitSnapshot(harness, "idle", null);
+    emitSnapshot(harness);
 
     harness.callbacks().onQueueChanged({
       kind: "queueChanged",
@@ -300,52 +275,5 @@ describe("D1: queued messages + profile switch (restamp path)", () => {
     }
     expect(frame.settings).toEqual(PROFILE_B_SETTINGS);
     expect(frame.excludeQueueItemId).toBeNull();
-  });
-
-  // `isChatRunInProgress` accepts both "running" and "stopping", so the
-  // empty-queue forward must hold for either accepted state.
-  for (const runStatus of ["running", "stopping"] as const) {
-    it(`with an EMPTY queue, a profile switch away from the active turn's profile during a ${runStatus} run still sends the frame - the host stamps a pre-spawn override from it, so a turn parked on worktree setup adopts the switch`, () => {
-      const harness = createHarness();
-      emitSnapshot(harness, runStatus, activeTurnOnProfile("profile-a"));
-
-      harness.handle.store
-        .getState()
-        .restampQueuedItemSettings(PROFILE_B_SETTINGS, null);
-
-      expect(harness.sent).toHaveLength(1);
-      const frame = harness.sent[0];
-      if (frame.kind !== "queueSettingsRestamp") {
-        throw new Error("Expected queueSettingsRestamp frame");
-      }
-      expect(frame.settings.profileId).toBe("profile-b");
-      expect(frame.excludeQueueItemId).toBeNull();
-    });
-  }
-
-  it("with an empty queue during a run, a NON-profile change (same profile as the active turn) sends nothing - there is no parked turn to redirect, only a permission/model edit", () => {
-    const harness = createHarness();
-    emitSnapshot(harness, "running", activeTurnOnProfile("profile-a"));
-
-    // Same profile as the active turn, only a non-profile field differs. This
-    // is the "changed permission/model mid-turn" case the chat-tile suite
-    // guards - it must not emit a queueSettingsRestamp.
-    harness.handle.store.getState().restampQueuedItemSettings(
-      { ...PROFILE_A_SETTINGS, permissionMode: "full_access" },
-      null,
-    );
-
-    expect(harness.sent).toHaveLength(0);
-  });
-
-  it("with an empty queue and no run in progress, a profile switch sends nothing - there is neither a queued item nor a pre-spawn turn the frame could move", () => {
-    const harness = createHarness();
-    emitSnapshot(harness, "idle", null);
-
-    harness.handle.store
-      .getState()
-      .restampQueuedItemSettings(PROFILE_B_SETTINGS, null);
-
-    expect(harness.sent).toHaveLength(0);
   });
 });

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -2095,7 +2095,17 @@ export function createChatSessionStore(
             item.queueItemId !== excludeQueueItemId &&
             !chatRunSettingsEqual(item.settings, settings),
         );
-        if (pendingItems.length === 0) return;
+        // With nothing queued the frame still matters while a run is in
+        // progress: the host stamps a pre-spawn profile override from it at
+        // frame intake, so a turn still parked on worktree setup adopts a
+        // profile switch instead of spawning on the profile the user just
+        // moved off. Idle with an empty queue there is nothing to restamp.
+        if (
+          pendingItems.length === 0 &&
+          !isChatRunInProgress(get().runStatus)
+        ) {
+          return;
+        }
         const clientActionId = uuidv4();
         const frame: ChatOwnerActionFrame = {
           kind: "queueSettingsRestamp",

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -68,6 +68,7 @@ import type {
   WorktreeIntent,
 } from "@traycer/protocol/host/worktree-schemas";
 import type { FatalErrorDetails } from "@traycer/protocol/framework/ws-protocol";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import type { RestoreResultEntry } from "@traycer/protocol/persistence/epic/checkpoint-manifests";
 import type {
   PermissionMode,
@@ -461,6 +462,19 @@ export interface ChatSessionState {
     settings: ChatRunSettings,
   ) => string | null;
   updateActivePermissionMode: (permissionMode: PermissionMode) => string | null;
+  /**
+   * Narrow in-flight profile switch, parallel to
+   * `updateActivePermissionMode`: tells the host the chat's CURRENT work
+   * should run on `profileId` (of `harnessId` - profile ids are
+   * harness-scoped). The host stamps a pre-spawn override from the frame at
+   * intake, so a turn still parked on worktree setup adopts the switch
+   * before it spawns. Deliberately not a whole-settings frame: model/harness
+   * never late-bind into an accepted turn.
+   */
+  updateActiveProfile: (
+    harnessId: GuiHarnessId,
+    profileId: string | null,
+  ) => string | null;
   // Live-mirror: atomically re-stamp every non-transient pending queued item
   // with the current toolbar settings so the host's stored copy stays current
   // for auto-send. Transient items (steer_requested/steering/injected) keep the
@@ -2095,22 +2109,7 @@ export function createChatSessionStore(
             item.queueItemId !== excludeQueueItemId &&
             !chatRunSettingsEqual(item.settings, settings),
         );
-        // With nothing queued the frame still matters while a run is in
-        // progress AND the new profile differs from the one the active turn is
-        // bound to: the host stamps a pre-spawn profile override from it at
-        // frame intake, so a turn still parked on worktree setup adopts the
-        // switch instead of spawning on the profile the user just moved off. A
-        // permission/model-only change (or a same-profile re-commit) has no
-        // parked turn to redirect here, and an idle empty queue has nothing to
-        // restamp, so neither sends.
-        if (pendingItems.length === 0) {
-          const activeTurn = get().activeTurn;
-          const forwardsProfileToActiveTurn =
-            activeTurn !== null &&
-            isChatRunInProgress(get().runStatus) &&
-            activeTurn.profileId !== settings.profileId;
-          if (!forwardsProfileToActiveTurn) return;
-        }
+        if (pendingItems.length === 0) return;
         const clientActionId = uuidv4();
         const frame: ChatOwnerActionFrame = {
           kind: "queueSettingsRestamp",
@@ -2167,6 +2166,25 @@ export function createChatSessionStore(
           get,
           frame,
           pending: basicPending(clientActionId, "activePermissionModeUpdate"),
+          pendingUserMessage: null,
+        });
+      },
+      updateActiveProfile: (harnessId, profileId) => {
+        const clientActionId = uuidv4();
+        const frame: ChatOwnerActionFrame = {
+          kind: "activeProfileUpdate",
+          hasBinaryPayload: false,
+          epicId: options.epicId,
+          chatId: options.chatId,
+          clientActionId,
+          harnessId,
+          profileId,
+        };
+        return sendAction({
+          set,
+          get,
+          frame,
+          pending: basicPending(clientActionId, "activeProfileUpdate"),
           pendingUserMessage: null,
         });
       },

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -2096,15 +2096,20 @@ export function createChatSessionStore(
             !chatRunSettingsEqual(item.settings, settings),
         );
         // With nothing queued the frame still matters while a run is in
-        // progress: the host stamps a pre-spawn profile override from it at
-        // frame intake, so a turn still parked on worktree setup adopts a
-        // profile switch instead of spawning on the profile the user just
-        // moved off. Idle with an empty queue there is nothing to restamp.
-        if (
-          pendingItems.length === 0 &&
-          !isChatRunInProgress(get().runStatus)
-        ) {
-          return;
+        // progress AND the new profile differs from the one the active turn is
+        // bound to: the host stamps a pre-spawn profile override from it at
+        // frame intake, so a turn still parked on worktree setup adopts the
+        // switch instead of spawning on the profile the user just moved off. A
+        // permission/model-only change (or a same-profile re-commit) has no
+        // parked turn to redirect here, and an idle empty queue has nothing to
+        // restamp, so neither sends.
+        if (pendingItems.length === 0) {
+          const activeTurn = get().activeTurn;
+          const forwardsProfileToActiveTurn =
+            activeTurn !== null &&
+            isChatRunInProgress(get().runStatus) &&
+            activeTurn.profileId !== settings.profileId;
+          if (!forwardsProfileToActiveTurn) return;
         }
         const clientActionId = uuidv4();
         const frame: ChatOwnerActionFrame = {

--- a/protocol/src/host/agent/gui/subscribe.ts
+++ b/protocol/src/host/agent/gui/subscribe.ts
@@ -111,6 +111,7 @@ export const chatActionSchema = z.enum([
   "queueSettingsUpdate",
   "queueSettingsRestamp",
   "activePermissionModeUpdate",
+  "activeProfileUpdate",
   "approvalDecision",
   "fileEditApprovalDecision",
   "interviewAnswer",
@@ -742,6 +743,24 @@ const pauseQueueClientFrameSchema = z.object({
   ...ownerActionFrameFields,
 });
 
+// Narrow live-turn field update, parallel to `activePermissionModeUpdate`:
+// move the chat's IN-FLIGHT work onto another logged-in profile of the same
+// harness. Sent by the composer on a profile switch while a run is in
+// progress; the host stamps a pre-spawn profile override from it at frame
+// intake, so a turn still parked on worktree setup adopts the switch before
+// it spawns instead of erroring on the rate-limited profile the user just
+// moved off. `harnessId` scopes application: profile ids are harness-scoped,
+// so the switch only applies to a turn on the same harness. Deliberately NOT
+// a whole-settings frame - model/harness never late-bind into an accepted
+// turn (a model change invalidates the reasoning/thinking selection and is
+// only expressible as a full tuple on a new send).
+const activeProfileUpdateClientFrameSchema = z.object({
+  kind: z.literal("activeProfileUpdate"),
+  ...ownerActionFrameFields,
+  harnessId: guiHarnessIdSchema,
+  profileId: z.string().nullable(),
+});
+
 const chatSubscribeClientFrameSchemaBeforeV13Options = [
   z.object({
     kind: z.literal("send"),
@@ -931,9 +950,22 @@ export const chatSubscribeClientFrameSchemaBeforeV13 = z.discriminatedUnion(
   chatSubscribeClientFrameSchemaBeforeV13Options,
 );
 
-const chatSubscribeClientFrameSchemaOptions = [
+const chatSubscribeClientFrameSchemaBeforeV14Options = [
   ...chatSubscribeClientFrameSchemaBeforeV13Options,
   pauseQueueClientFrameSchema,
+] as const;
+
+// Frozen client frame of the RELEASED `1.3` line (pauseQueue, but no
+// `activeProfileUpdate`). Kept as its own union so the shipped 1.3 shape
+// stays verbatim while the live schema below grows the minor-4 delta.
+export const chatSubscribeClientFrameSchemaBeforeV14 = z.discriminatedUnion(
+  "kind",
+  chatSubscribeClientFrameSchemaBeforeV14Options,
+);
+
+const chatSubscribeClientFrameSchemaOptions = [
+  ...chatSubscribeClientFrameSchemaBeforeV14Options,
+  activeProfileUpdateClientFrameSchema,
 ] as const;
 
 export const chatSubscribeClientFrameSchema = z.discriminatedUnion(
@@ -1451,7 +1483,7 @@ export const chatSubscribeV13 = defineStreamRpcContract({
   schemaVersion: { major: 1, minor: 3 } as const,
   openRequestSchema: chatSubscribeOpenRequestSchema,
   serverFrameSchema: chatSubscribeServerFrameSchemaV13,
-  clientFrameSchema: chatSubscribeClientFrameSchema,
+  clientFrameSchema: chatSubscribeClientFrameSchemaBeforeV14,
 });
 
 // ─── Live `chat.subscribe@1.4` contract (`inReplyTo` + `mcp` items) ─────────
@@ -1460,8 +1492,11 @@ export const chatSubscribeV13 = defineStreamRpcContract({
 // assistant, queue item, event `actor`, steer) and the `mcp` background-item
 // kind (CLI auto-backgrounded MCP tool calls). Older peers negotiate ≤1.3 and
 // receive the frozen frames above, which strip the key and never carry `mcp`
-// items (the host degrades them to `command`). The client frame is identical
-// to `1.3` (`inReplyTo` is host→client only).
+// items (the host degrades them to `command`). The client frame adds
+// `activeProfileUpdate` (the narrow in-flight profile switch); a ≤1.3 host
+// never receives it - the host drops unknown kinds with a MALFORMED_FRAME
+// ack, and the switch still lands durably via `epic.updateChatProfile` /
+// the next send's full tuple.
 
 export const chatSubscribeV14 = defineStreamRpcContract({
   method: "chat.subscribe",

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -71,7 +71,10 @@ import {
   setEpicPinnedResponseSchema,
   updateArtifactStatusRequestSchema,
   updateArtifactStatusResponseSchema,
+  updateChatProfileRequestSchema,
+  updateChatProfileResponseSchema,
   updateChatRunSettingsRequestSchema,
+  updateChatRunSettingsRequestSchemaV11,
   updateChatRunSettingsResponseSchema,
   updateEpicRequestSchema,
   updateEpicResponseSchema,
@@ -265,6 +268,41 @@ export const epicUpdateChatRunSettingsV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: updateChatRunSettingsRequestSchema,
   responseSchema: updateChatRunSettingsResponseSchema,
+});
+
+// v1.1 tightens `settings` to the wire-strict tuple (no zod-default
+// backstops): a subset-field patch is a validation error at the canonical
+// minor instead of a silent null-clobber. Shipped as a minor so the loose
+// v1.0 shape stays an explicitly bridged legacy line rather than the live
+// contract. See `updateChatRunSettingsRequestSchemaV11`.
+export const epicUpdateChatRunSettingsV11 = defineRpcContract({
+  method: "epic.updateChatRunSettings",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  requestSchema: updateChatRunSettingsRequestSchemaV11,
+  responseSchema: updateChatRunSettingsResponseSchema,
+});
+
+// A parsed v1.0 request has already materialized the loose schema's defaults
+// (serviceTier/profileId -> null), so it satisfies the strict tuple as-is;
+// the request upgrade is the identity. The response is unchanged.
+export const epicUpdateChatRunSettingsUpgradeV10ToV11 = defineUpgradePath<
+  typeof epicUpdateChatRunSettingsV10,
+  typeof epicUpdateChatRunSettingsV11
+>({
+  from: epicUpdateChatRunSettingsV10.schemaVersion,
+  to: epicUpdateChatRunSettingsV11.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+// Optional (non-floor) capability: narrow profile-only settings update - the
+// host patches its own authoritative persisted tuple. See the schema doc in
+// `unary-schemas.ts` for why no sibling model/harness update exists.
+export const epicUpdateChatProfileV10 = defineRpcContract({
+  method: "epic.updateChatProfile",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: updateChatProfileRequestSchema,
+  responseSchema: updateChatProfileResponseSchema,
 });
 
 export const epicDeleteChatV10 = defineRpcContract({

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -29,6 +29,7 @@ import {
 } from "@traycer/protocol/host/worktree-schemas";
 import {
   chatRunSettingsSchema,
+  chatRunSettingsStrictSchema,
   userMessageSenderSchema,
 } from "@traycer/protocol/persistence/epic/schemas";
 import { z } from "zod";
@@ -979,6 +980,49 @@ export const updateChatRunSettingsResponseSchema = z.object({
 });
 export type UpdateChatRunSettingsResponse = z.infer<
   typeof updateChatRunSettingsResponseSchema
+>;
+
+// v1.1 tightens `settings` to the wire-strict tuple (every field required, no
+// zod defaults): this method is a whole-tuple WYSIWYG replace, and the strict
+// schema makes a subset-field "patch" a validation error instead of a silent
+// null-clobber of omitted fields. See `chatRunSettingsStrictSchema`.
+// Profile-only changes belong on `epic.updateChatProfile` below.
+export const updateChatRunSettingsRequestSchemaV11 = z.object({
+  epicId: z.string(),
+  chatId: z.string(),
+  settings: chatRunSettingsStrictSchema,
+});
+export type UpdateChatRunSettingsRequestV11 = z.infer<
+  typeof updateChatRunSettingsRequestSchemaV11
+>;
+
+// Narrow, safe-by-construction field update: move a chat onto another
+// logged-in profile (subscription) of its CURRENT harness without touching
+// the rest of the tuple. The host patches its own authoritative persisted
+// record, so callers never rebuild (and possibly stale-patch) the full
+// tuple client-side. `null` = the ambient/host login. There is deliberately
+// no sibling `epic.updateChatModel`: a model change invalidates the
+// reasoning/thinking/tier selection and is only expressible as a full
+// reconfigure (`agent.configure` / `epic.updateChatRunSettings`).
+// Optional (non-floor) capability: old hosts fail only this call with
+// E_HOST_UNSUPPORTED and the renderer degrades to persist-on-next-send.
+export const updateChatProfileRequestSchema = z.object({
+  epicId: z.string(),
+  chatId: z.string(),
+  profileId: z.string().nullable(),
+});
+export type UpdateChatProfileRequest = z.infer<
+  typeof updateChatProfileRequestSchema
+>;
+
+// `updated` is false when the chat has no persisted run settings yet (a
+// never-configured chat has no tuple to patch; its first send will stamp
+// the composer's full tuple, profile included).
+export const updateChatProfileResponseSchema = z.object({
+  updated: z.boolean(),
+});
+export type UpdateChatProfileResponse = z.infer<
+  typeof updateChatProfileResponseSchema
 >;
 
 export const deleteChatRequestSchema = z.object({

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -127,7 +127,10 @@ import {
   epicRemoveRepoV10,
   epicRenameArtifactV10,
   epicRenameChatV10,
+  epicUpdateChatProfileV10,
+  epicUpdateChatRunSettingsUpgradeV10ToV11,
   epicUpdateChatRunSettingsV10,
+  epicUpdateChatRunSettingsV11,
   epicRenameTuiAgentV10,
   epicReparentArtifactV10,
   epicReparentChatV10,
@@ -3012,10 +3015,36 @@ const HOST_RPC_REGISTRY_DEFINITION = {
   // persist-on-next-send behavior.
   "epic.updateChatRunSettings": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: epicUpdateChatRunSettingsV10,
+          upgradeFromPreviousVersion: null,
+        },
+        // v1.1: wire-strict settings tuple - a subset-field patch fails
+        // validation at the canonical minor instead of silently null-
+        // clobbering omitted fields. Profile-only changes belong on
+        // `epic.updateChatProfile`.
+        1: {
+          contract: epicUpdateChatRunSettingsV11,
+          upgradeFromPreviousVersion: epicUpdateChatRunSettingsUpgradeV10ToV11,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+    degrade: { kind: "unsupported" },
+  },
+  // Optional (non-floor) capability: narrow profile-only update of a chat's
+  // persisted run settings - the host patches its own authoritative tuple, so
+  // clients never rebuild (and stale-patch) the full tuple to move a chat's
+  // profile. Old peers lack it; callers get E_HOST_UNSUPPORTED for this call
+  // only and degrade to persist-on-next-send.
+  "epic.updateChatProfile": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: epicUpdateChatProfileV10,
           upgradeFromPreviousVersion: null,
         },
       },

--- a/protocol/src/persistence/epic/foundation.ts
+++ b/protocol/src/persistence/epic/foundation.ts
@@ -122,3 +122,25 @@ export const chatRunSettingsSchema = z.object({
   profileId: z.string().nullable().default(null),
 });
 export type ChatRunSettings = z.infer<typeof chatRunSettingsSchema>;
+
+// The wire-strict variant of `chatRunSettingsSchema`: identical output type,
+// but every field is REQUIRED - no `.default(...)` backstops. The defaults
+// above exist for PERSISTED records written before a field was introduced;
+// on a write path they are a misuse foothold: a caller sending a partial
+// tuple would have the omitted fields silently defaulted, turning a
+// subset-field "patch" into a null-clobber of settings it never looked at.
+// A settings write is a whole-tuple WYSIWYG replace - the caller must state
+// every field of the tuple it resolved, so a partial object is a validation
+// error instead. Field-level updates get their own narrow methods (e.g.
+// `epic.updateChatProfile`); there is deliberately no narrow model/harness
+// update - changing the model invalidates the reasoning/thinking/tier
+// selection, so it is only expressible as a full tuple.
+export const chatRunSettingsStrictSchema = z.object({
+  harnessId: guiHarnessIdSchema,
+  model: z.string().min(1),
+  permissionMode: permissionModeSchema,
+  reasoningEffort: z.string().nullable(),
+  serviceTier: z.string().nullable(),
+  agentMode: agentModeSchema,
+  profileId: z.string().nullable(),
+});


### PR DESCRIPTION
## Problem

Two related API-design flaws around chat run settings:

1. **The rate-limit "switch account" click never reached in-flight work.** It only rewrote the local composer selection (consumed on the *next* send), so a turn parked on the worktree-setup gate spawned on the very rate-limited profile the user had just moved off.
2. **Incremental whole-settings updates promote an anti-pattern.** The task-wide switch patched `{ ...chat.settings, profileId }` over a possibly-stale store projection and re-persisted the whole tuple — a subset-field update that can silently resurrect a lagging model/reasoning tuple, violating WYSIWYG semantics. The loose `chatRunSettingsSchema` (zod defaults on `serviceTier`/`profileId`) made this worse: a partial object null-clobbers omitted fields.

## Change

Deprecates the incremental-whole-settings pattern in favor of **narrow, safe-by-construction field updates** — and encodes at the RPC layer which fields can never be updated alone. There is deliberately **no** `updateChatModel`/`updateChatHarness`: a model change invalidates the reasoning/thinking/tier selection, so it is only expressible as a full tuple (`agent.configure` / a new send).

### Protocol
- **`activeProfileUpdate`** chat.subscribe client frame — the minor-4 client-frame delta (released `1.3` keeps its frozen shape via `chatSubscribeClientFrameSchemaBeforeV14`). Narrow in-flight profile switch, parallel to `activePermissionModeUpdate`, carrying only `harnessId` + `profileId`. All chat.subscribe surfaces ≥ 1.4 are unreleased (baseline pins 1.3), so no released line changes shape.
- **`epic.updateChatProfile@1.0`** unary RPC (optional, degrade `unsupported`) — profile-only update where the **host patches its own authoritative persisted tuple**; clients never rebuild it.
- **`epic.updateChatRunSettings@1.1`** (minor bump) — `settings` tightens to the new `chatRunSettingsStrictSchema`: every field required, no zod-default backstops. A subset-field patch is now a **validation error** at the canonical minor instead of a silent null-clobber. The loose v1.0 shape survives only as an explicitly bridged legacy line (identity upgrade; both minors are unreleased — stable baseline has neither).

### gui-app
- `updateActiveProfile` store action; the composer settings-change path forwards a same-harness profile change while a run is in progress (mirrors the live permission-mode update), so a turn parked on worktree setup adopts the switch pre-spawn.
- The task-wide rate-limit switch moves sibling chats via `epic.updateChatProfile` — the one subset-field misuse of `epic.updateChatRunSettings` in the tree is gone.
- The earlier empty-queue `queueSettingsRestamp` special-case from this PR's first commits is reverted; the narrow frame replaces it.

## Host side

The paired host PR (traycerai/traycer-internal#4528) stamps the pre-spawn override from the new frame at intake, implements `ChatSession.applyProfileUpdate` + the `epic.updateChatProfile` resolver, and parses the released 1.3 line against its frozen client shape.

## Verification

- protocol: `bun run compile` + full suite (964 tests, incl. released-baseline compat + registry validation) — green.
- gui-app: `bun run compile`, eslint, react-doctor (changed scope) — clean; targeted suites (d1 restamp, chat-session-store, chat-tile, composer directory) — 381 tests green.
- Full workspace `bun run compile` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)