### PR TITLE
fix(gui-app): quote final paragraphs cleanly

### DIFF
--- a/clients/gui-app/src/components/chat/quote/__tests__/append-quote-to-draft.test.ts
+++ b/clients/gui-app/src/components/chat/quote/__tests__/append-quote-to-draft.test.ts
@@ -71,6 +71,50 @@ describe("buildQuoteBlockquote", () => {
     });
   });
 
+  it("drops a single trailing empty line (the browser's block-boundary blank after a triple-click)", () => {
+    const node = buildQuoteBlockquote({
+      text: "Third paragraph, the last one.\n",
+      fenceLanguage: null,
+    });
+    expect(node).toEqual({
+      type: "blockquote",
+      content: [paragraph("Third paragraph, the last one.")],
+    });
+  });
+
+  it("drops two trailing empty lines", () => {
+    const node = buildQuoteBlockquote({
+      text: "Third paragraph, the last one.\n\n",
+      fenceLanguage: null,
+    });
+    expect(node).toEqual({
+      type: "blockquote",
+      content: [paragraph("Third paragraph, the last one.")],
+    });
+  });
+
+  it("drops three trailing empty lines", () => {
+    const node = buildQuoteBlockquote({
+      text: "Third paragraph, the last one.\n\n\n",
+      fenceLanguage: null,
+    });
+    expect(node).toEqual({
+      type: "blockquote",
+      content: [paragraph("Third paragraph, the last one.")],
+    });
+  });
+
+  it("drops trailing empty lines after a multi-paragraph selection while keeping the internal blank line", () => {
+    const node = buildQuoteBlockquote({
+      text: "First.\n\nSecond.\n\n",
+      fenceLanguage: null,
+    });
+    expect(node).toEqual({
+      type: "blockquote",
+      content: [paragraph("First."), emptyParagraph(), paragraph("Second.")],
+    });
+  });
+
   it("wraps a fence selection in a codeBlock with the language attr, preserving raw lines", () => {
     const node = buildQuoteBlockquote({
       text: "const x = 1;  \nconst y = 2;",

--- a/clients/gui-app/src/components/chat/quote/__tests__/use-quote-selection.test.ts
+++ b/clients/gui-app/src/components/chat/quote/__tests__/use-quote-selection.test.ts
@@ -124,6 +124,350 @@ describe("resolveQuoteSelection - endpoint resolution", () => {
       resolveQuoteSelection(range, "Third.\nIntervening prose"),
     ).toBeNull();
   });
+
+  it("clamps past an assistant elapsed-footer even when its provider icon has an SVG title (invisible title text doesn't count as real tail content)", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    // Sibling AFTER the quotable root, shaped like the real elapsed footer:
+    // a provider icon (SVG with an accessibility-only <title>) plus an
+    // elapsed-time label. Triple-click extends the end into the label span.
+    const footer = document.createElement("button");
+    footer.setAttribute("data-testid", "assistant-elapsed-footer");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const title = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "title",
+    );
+    title.textContent = "Claude";
+    svg.appendChild(title);
+    const footerSpan = document.createElement("span");
+    footerSpan.textContent = "Mulled for 4s";
+    footer.append(svg, footerSpan);
+    segment.appendChild(footer);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(footerSpan, 0);
+
+    // jsdom's `Range`/`Selection.toString()` both include the SVG title's
+    // text (plain DOM concatenation) - real Chromium's `Selection.toString()`
+    // does NOT, since `<title>` produces no layout box. Don't trust this
+    // jsdom value as the production `selectionText` contract; a hand-authored,
+    // browser-shaped string is passed below instead. This assertion just
+    // documents the divergence so a future edit doesn't "simplify" this test
+    // back to `range.toString()`.
+    expect(range.toString()).toBe("Third.Claude");
+
+    // Browser-shaped: no leaked "Claude" (real Chromium excludes it), with
+    // the trailing block-boundary blank line the browser synthesizes at the
+    // selection's end for a last-paragraph triple-click.
+    const selectionText = "Third.\n\n";
+    const snapshot = resolveQuoteSelection(range, selectionText);
+    expect(snapshot).not.toBeNull();
+    // Nothing to strip - passes through unchanged. Dropping the trailing
+    // blank line is `buildQuoteBlockquote`'s job, not this hook's.
+    expect(snapshot?.text).toBe("Third.\n\n");
+    // End clamped to the root's end, so the range never reaches the footer.
+    expect(snapshot?.range.endContainer).toBe(root);
+    expect(snapshot?.range.endOffset).toBe(root.childNodes.length);
+  });
+
+  it("preserves multi-paragraph block boundaries in the emitted text for an accepted clamp", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const first = document.createElement("p");
+    first.textContent = "First.";
+    const second = document.createElement("p");
+    second.textContent = "Second.";
+    root.append(first, second);
+    segment.appendChild(root);
+    const footer = document.createElement("button");
+    footer.setAttribute("data-testid", "assistant-elapsed-footer");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const title = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "title",
+    );
+    title.textContent = "Claude";
+    svg.appendChild(title);
+    const footerSpan = document.createElement("span");
+    footerSpan.textContent = "Mulled for 4s";
+    footer.append(svg, footerSpan);
+    segment.appendChild(footer);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(first), 0);
+    range.setEnd(footerSpan, 0);
+
+    // Browser-shaped: real Chromium's `Selection.toString()` keeps the
+    // paragraph-boundary blank line BETWEEN blocks. A derived
+    // `Range.toString()` would flatten this to "First.Second." instead -
+    // the regression an earlier fix attempt introduced.
+    const selectionText = "First.\n\nSecond.\n\n";
+    const snapshot = resolveQuoteSelection(range, selectionText);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.text).toBe("First.\n\nSecond.\n\n");
+    expect(snapshot?.range.endContainer).toBe(root);
+    expect(snapshot?.range.endOffset).toBe(root.childNodes.length);
+  });
+
+  it("clamps past an out-of-root data-quote-exclude sibling and excludes its text from the emitted quote", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    // Chrome AFTER the quotable root: an excluded label (real text, but
+    // data-quote-exclude) followed by a trailing span the triple-click
+    // extends into - mirrors the elapsed-footer shape without an SVG title,
+    // so the excluded label fully precedes the end boundary in document
+    // order and actually lands in the clamped-away/raw-selection text.
+    const chrome = document.createElement("div");
+    const excludedLabel = document.createElement("span");
+    excludedLabel.setAttribute("data-quote-exclude", "");
+    excludedLabel.textContent = "Next steps";
+    const trailingSpan = document.createElement("span");
+    trailingSpan.textContent = "tail";
+    chrome.append(excludedLabel, trailingSpan);
+    segment.appendChild(chrome);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(trailingSpan, 0);
+
+    // Browser-shaped: unlike an SVG title, real Chromium's
+    // `Selection.toString()` DOES include this visible (merely
+    // quote-excluded) label text - it's ordinary rendered HTML. A
+    // block-boundary blank line separates the root's paragraph from the
+    // chrome div.
+    const selectionText = "Third.\n\nNext steps";
+    const snapshot = resolveQuoteSelection(range, selectionText);
+    expect(snapshot).not.toBeNull();
+    // The excluded tail is stripped from the emitted quote text, not just
+    // absent from the popover's clamped range.
+    expect(snapshot?.text).toBe("Third.");
+    expect(snapshot?.range.endContainer).toBe(root);
+    expect(snapshot?.range.endOffset).toBe(root.childNodes.length);
+  });
+
+  it("strips ALL rendered option labels from a NextStepsActionGroup-shaped excluded container, not just the first", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    // Mirrors the real NextStepsActionGroup: ONE data-quote-exclude flex
+    // container wrapping MULTIPLE separately rendered option buttons, each
+    // its own text node - not one merged string. Chromium inserts a layout
+    // separator between them even though they share an excluded ancestor.
+    const nextSteps = document.createElement("div");
+    nextSteps.setAttribute("data-quote-exclude", "");
+    const option1 = document.createElement("button");
+    const option1Label = document.createElement("span");
+    option1Label.textContent = "Create the plan (1)";
+    option1.appendChild(option1Label);
+    const option2 = document.createElement("button");
+    const option2Label = document.createElement("span");
+    option2Label.textContent = "Review + ship?";
+    option2.appendChild(option2Label);
+    nextSteps.append(option1, option2);
+    segment.appendChild(nextSteps);
+    const trailingSibling = document.createElement("span");
+    trailingSibling.textContent = "tail";
+    segment.appendChild(trailingSibling);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(trailingSibling, 0);
+
+    // Browser-shaped, matching a real Chrome 148 capture: a block-boundary
+    // blank line between EACH separately rendered option, not just before
+    // the excluded container as a whole.
+    const selectionText = "Third.\n\nCreate the plan (1)\n\nReview + ship?\n\n";
+    const snapshot = resolveQuoteSelection(range, selectionText);
+    expect(snapshot).not.toBeNull();
+    // Both option labels must be gone, not just the first (a naive
+    // parts.join("") regex would only match a single unbroken run and miss
+    // this).
+    expect(snapshot?.text).toBe("Third.");
+  });
+
+  it("does not strip an earlier, unrelated occurrence of similar wording in the quoted body", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    // The quoted body legitimately contains wording that also appears (as an
+    // excluded option label) in the trailing chrome - only the trailing,
+    // excluded occurrence must be stripped.
+    paragraph.textContent = "Third: Review + ship? is the plan.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    const nextSteps = document.createElement("div");
+    nextSteps.setAttribute("data-quote-exclude", "");
+    const option = document.createElement("button");
+    const optionLabel = document.createElement("span");
+    optionLabel.textContent = "Review + ship?";
+    option.appendChild(optionLabel);
+    nextSteps.appendChild(option);
+    segment.appendChild(nextSteps);
+    const trailingSibling = document.createElement("span");
+    trailingSibling.textContent = "tail";
+    segment.appendChild(trailingSibling);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(trailingSibling, 0);
+
+    const selectionText =
+      "Third: Review + ship? is the plan.\n\nReview + ship?\n\n";
+    const snapshot = resolveQuoteSelection(range, selectionText);
+    expect(snapshot).not.toBeNull();
+    // Only the trailing occurrence is stripped (end-anchored match); the
+    // legitimate earlier occurrence in the quoted body survives.
+    expect(snapshot?.text).toBe("Third: Review + ship? is the plan.");
+  });
+
+  it("treats an HTML-namespace element merely NAMED 'desc' as visible text (namespace-scoped, not tag-name-only)", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    const chrome = document.createElement("div");
+    // An HTML (non-SVG) element merely NAMED "desc" - not the SVG
+    // accessibility element - so its real text must still count as visible.
+    const htmlDesc = document.createElement("desc");
+    htmlDesc.textContent = "Visible description";
+    const trailingSpan = document.createElement("span");
+    trailingSpan.textContent = "tail";
+    chrome.append(htmlDesc, trailingSpan);
+    segment.appendChild(chrome);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(trailingSpan, 0);
+
+    expect(range.toString()).toBe("Third.Visible description");
+    expect(resolveQuoteSelection(range, range.toString())).toBeNull();
+  });
+
+  it("clamps past an SVG <defs> subtree (non-rendered definitions, not just <title>/<desc>)", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    const chrome = document.createElement("div");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+    // Text under <defs> is never painted directly (only reachable via
+    // <use>), so it must not block the clamp.
+    defs.textContent = "reusable-icon-label";
+    svg.appendChild(defs);
+    const trailingSpan = document.createElement("span");
+    trailingSpan.textContent = "tail";
+    chrome.append(svg, trailingSpan);
+    segment.appendChild(chrome);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(trailingSpan, 0);
+
+    // Real Chromium excludes <defs> content from Selection.toString() the
+    // same way it excludes <title>/<desc> (no layout box) - nothing to strip.
+    const selectionText = "Third.";
+    const snapshot = resolveQuoteSelection(range, selectionText);
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.text).toBe("Third.");
+  });
+
+  it("still rejects a clamp when a rendered SVG <text> element holds real content", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    const chrome = document.createElement("div");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const svgText = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "text",
+    );
+    // SVG <text> IS painted, so it counts as real content even inside an SVG.
+    svgText.textContent = "rendered label";
+    svg.appendChild(svgText);
+    const trailingSpan = document.createElement("span");
+    trailingSpan.textContent = "tail";
+    chrome.append(svg, trailingSpan);
+    segment.appendChild(chrome);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(trailingSpan, 0);
+
+    expect(range.toString()).toBe("Third.rendered label");
+    expect(resolveQuoteSelection(range, range.toString())).toBeNull();
+  });
+
+  it("still rejects a clamp when the footer region also holds real visible text alongside the SVG title", () => {
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    // A real, visible label BETWEEN the root and the footer - not wrapped in
+    // <title>/<desc>/[data-quote-exclude] - so the guard must still see it.
+    const label = document.createElement("span");
+    label.textContent = "Provider label";
+    segment.appendChild(label);
+    const footer = document.createElement("button");
+    footer.setAttribute("data-testid", "assistant-elapsed-footer");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const title = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "title",
+    );
+    title.textContent = "Claude";
+    svg.appendChild(title);
+    const footerSpan = document.createElement("span");
+    footerSpan.textContent = "Mulled for 4s";
+    footer.append(svg, footerSpan);
+    segment.appendChild(footer);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(footerSpan, 0);
+
+    expect(resolveQuoteSelection(range, "Third.\nProvider label")).toBeNull();
+  });
 });
 
 describe("resolveQuoteSelection - validity rules", () => {

--- a/clients/gui-app/src/components/chat/quote/append-quote-to-draft.ts
+++ b/clients/gui-app/src/components/chat/quote/append-quote-to-draft.ts
@@ -79,8 +79,23 @@ function quoteCodeBlockNode(text: string, language: string): JsonContent {
   };
 }
 
+// A triple-click's captured `Selection.toString()` carries trailing
+// block-boundary blank lines the browser synthesizes at the selection's end
+// (one exact-last-paragraph triple-click observed 2 trailing LFs in real
+// Chromium). Left alone, each becomes a real empty paragraph inside the
+// blockquote - visible blank rows the user never selected. Internal blank
+// lines (between two real lines) stay: they're deliberate paragraph spacing.
 function normalizedQuoteLines(text: string): string[] {
-  return text.split(LINE_BREAK_REGEX).map((line) => line.replace(/\s+$/, ""));
+  const lines = text
+    .split(LINE_BREAK_REGEX)
+    .map((line) => line.replace(/\s+$/, ""));
+  return withoutTrailingEmptyLines(lines);
+}
+
+function withoutTrailingEmptyLines(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 1 && lines[end - 1].length === 0) end -= 1;
+  return lines.slice(0, end);
 }
 
 function quoteParagraphNode(line: string): JsonContent {

--- a/clients/gui-app/src/components/chat/quote/use-quote-selection.ts
+++ b/clients/gui-app/src/components/chat/quote/use-quote-selection.ts
@@ -6,8 +6,17 @@ import { useCallback, useEffect, useState, type RefObject } from "react";
  * re-reads the live `Selection` (Chromium/Electron can collapse or retarget the
  * selection before the click dispatches across the portal).
  *
- * `text` is the raw `Selection.toString()` value - normalization (per-line
- * trailing trim, blockquote/codeBlock shaping) is `buildQuoteBlockquote`'s job.
+ * `text` is the raw `Selection.toString()` value - this preserves the
+ * browser's own block-boundary blank lines (`\n\n` between paragraphs),
+ * which a derived `Range.toString()` would flatten away. EXCEPTION: when the
+ * end was clamped back into the quotable root (the triple-click tail) and
+ * the clamped-away region held visible `[data-quote-exclude]` text, that
+ * text is stripped from the tail - real `Selection.toString()` DOES include
+ * it (it's ordinary rendered HTML, just excluded from quoting), unlike an
+ * SVG `<title>`/`<desc>`/`<metadata>`/`<defs>`, which produces no layout box
+ * and so the browser's own stringifier already omits. Further normalization
+ * (per-line trailing trim, dropping trailing blank lines, blockquote/
+ * codeBlock shaping) is `buildQuoteBlockquote`'s job.
  * `range` is a detached clone of the live range; the popover reads its live
  * `getBoundingClientRect()` for anchoring and guards against its nodes being
  * disconnected.
@@ -213,22 +222,30 @@ export function resolveQuoteSelection(
   // Clone so the snapshot is immutable against later selection mutations; the
   // clone still references the live nodes, so its rect tracks their position.
   const range = liveRange.cloneRange();
+  // Text found under a [data-quote-exclude] ancestor in the clamped-away
+  // region, one entry per rendered descendant - real `Selection.toString()`
+  // includes it (unlike non-rendered SVG chrome), so it's stripped from the
+  // tail of `selectionText` below.
+  let excludedTailParts: ReadonlyArray<string> = [];
   if (end.clampToRootEnd) {
     // The clamp exists for the triple-click tail, where the clamped-away
-    // region holds no text. A drag that genuinely selected content past the
-    // root would keep that out-of-root text in `selectionText` below (the
-    // range is clamped but the emitted text is not), so any non-whitespace
-    // in the clamped-away region rejects the gesture instead.
+    // region holds no USER-VISIBLE, non-excluded text (only whitespace,
+    // non-rendered SVG chrome like <title>/<desc>, or a [data-quote-exclude]
+    // sibling). A drag that genuinely selected visible content past the root
+    // rejects instead of clamping.
     const clampedAway = liveRange.cloneRange();
     clampedAway.setStart(startRoot, startRoot.childNodes.length);
-    if (clampedAway.toString().trim().length > 0) return null;
+    if (rangeHasVisibleText(clampedAway)) return null;
+    excludedTailParts = excludedVisibleTailParts(clampedAway);
     range.setEnd(startRoot, startRoot.childNodes.length);
   }
 
   if (rangeIntersectsExcluded(range, startRoot)) return null;
 
   return {
-    text: selectionText,
+    text: end.clampToRootEnd
+      ? stripExcludedTail(selectionText, excludedTailParts)
+      : selectionText,
     fenceLanguage: detectFenceLanguage(range, startRoot),
     range,
     root: startRoot,
@@ -313,6 +330,128 @@ function fenceBoundaryNode(
       ? childAt(container, offset)
       : childAt(container, offset - 1);
   return child ?? container;
+}
+
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+
+// SVG element names whose subtree is never painted even though it appears in
+// `Range.toString()` - a provider icon's `<title>Claude</title>`, `<desc>`,
+// and definition containers (`<metadata>`, `<defs>`) that only exist to be
+// referenced via `<use>`. Scoped to the SVG namespace below so an
+// HTML-authored element that happens to be named e.g. `desc` isn't mistaken
+// for one. SVG `<text>` IS painted and is deliberately excluded from this set.
+const NON_VISIBLE_SVG_TAGS = new Set(["title", "desc", "metadata", "defs"]);
+
+/** Whether `range` covers any user-visible, non-whitespace text - i.e. text
+ *  outside SVG `<title>`/`<desc>` and `[data-quote-exclude]` subtrees. Walks a
+ *  `cloneContents()` snapshot (which already slices partial boundary text
+ *  nodes to just their in-range portion) instead of `Range.toString()`, so
+ *  invisible accessibility text doesn't get counted as real tail content by
+ *  the clamped-away guard above. */
+function rangeHasVisibleText(range: Range): boolean {
+  const fragment = range.cloneContents();
+  const walker = document.createTreeWalker(fragment, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  while (node !== null) {
+    if (
+      node.textContent !== null &&
+      node.textContent.trim().length > 0 &&
+      !hasNonVisibleTextAncestor(node)
+    ) {
+      return true;
+    }
+    node = walker.nextNode();
+  }
+  return false;
+}
+
+function hasNonVisibleTextAncestor(node: Node): boolean {
+  return (
+    isUnderNonVisibleSvgAncestor(node) || isUnderQuoteExcludeAncestor(node)
+  );
+}
+
+function isUnderNonVisibleSvgAncestor(node: Node): boolean {
+  let ancestor = node.parentElement;
+  while (ancestor !== null) {
+    if (
+      ancestor.namespaceURI === SVG_NAMESPACE &&
+      NON_VISIBLE_SVG_TAGS.has(ancestor.tagName.toLowerCase())
+    ) {
+      return true;
+    }
+    ancestor = ancestor.parentElement;
+  }
+  return false;
+}
+
+function isUnderQuoteExcludeAncestor(node: Node): boolean {
+  let ancestor = node.parentElement;
+  while (ancestor !== null) {
+    if (ancestor.hasAttribute("data-quote-exclude")) return true;
+    ancestor = ancestor.parentElement;
+  }
+  return false;
+}
+
+/** Collects the text found under a `[data-quote-exclude]` ancestor within
+ *  `range`'s content, ONE ENTRY PER TEXT NODE (document order) rather than a
+ *  single joined string - real `[data-quote-exclude]` chrome (e.g.
+ *  `NextStepsActionGroup`) commonly renders several SEPARATE descendants
+ *  (one button per option) under one excluded container, and Chromium
+ *  synthesizes a layout separator between them in `Selection.toString()`
+ *  even though they share an ancestor. Joining the parts directly would lose
+ *  that boundary and make the tail unmatchable. Non-rendered SVG chrome
+ *  (which the browser's own stringifier already omits) is excluded. */
+function excludedVisibleTailParts(range: Range): ReadonlyArray<string> {
+  const fragment = range.cloneContents();
+  const walker = document.createTreeWalker(fragment, NodeFilter.SHOW_TEXT);
+  const parts: string[] = [];
+  let node = walker.nextNode();
+  while (node !== null) {
+    if (
+      isUnderQuoteExcludeAncestor(node) &&
+      !isUnderNonVisibleSvgAncestor(node)
+    ) {
+      const text = node.textContent ?? "";
+      if (text.trim().length > 0) parts.push(text);
+    }
+    node = walker.nextNode();
+  }
+  return parts;
+}
+
+/** Removes a whitespace-tolerant trailing occurrence of `excludedParts` from
+ *  the end of `selectionText`. Each part matches with internal `\s+`
+ *  tolerance (a single rendered node's own whitespace/line-break layout),
+ *  and CONSECUTIVE parts are joined with `\s*` (an optional Chromium-inserted
+ *  layout separator between separately rendered descendants of one excluded
+ *  container) - see {@link excludedVisibleTailParts}. A miss (the parts
+ *  don't actually form a trailing suffix) safely no-ops rather than
+ *  mangling `selectionText`. */
+function stripExcludedTail(
+  selectionText: string,
+  excludedParts: ReadonlyArray<string>,
+): string {
+  const partPatterns = excludedParts
+    .map(wordsToPattern)
+    .filter((pattern): pattern is string => pattern !== null);
+  if (partPatterns.length === 0) return selectionText;
+  const pattern = partPatterns.join("\\s*");
+  return selectionText.replace(new RegExp(`\\s*${pattern}\\s*$`), "");
+}
+
+function wordsToPattern(text: string): string | null {
+  const words = text
+    .trim()
+    .split(/\s+/)
+    .filter((word) => word.length > 0);
+  if (words.length === 0) return null;
+  return words.map(escapeRegExpLiteral).join("\\s+");
+}
+
+function escapeRegExpLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function rangeIntersectsExcluded(range: Range, root: Element): boolean {


### PR DESCRIPTION
## Summary

- allow last-paragraph triple-click quotes when Chromium extends the selection into elapsed-footer chrome with non-rendered SVG metadata
- strip visible data-quote-exclude tail text without flattening Chromium paragraph boundaries, including multi-option next-step groups
- drop terminal browser-synthesized blank lines before building blockquote paragraphs while preserving internal blanks and fenced code

## Root cause

Chromium can extend a last-paragraph triple-click range beyond the quotable root. The clamp guard treated invisible SVG title text as selected content and rejected the quote. Accepted clamps also need to preserve Selection.toString paragraph separators while removing rendered excluded chrome. Separately, trailing block-boundary newlines were being converted into empty paragraphs inside the blockquote.

## Verification

- pre-commit run --all-files
- bun run compile from clients/gui-app
- bun run test -- src/components/chat/quote/ — 69 tests passed
- ESLint with zero warnings on all four changed files
- Prettier check on all four changed files
- React Doctor changed-file scan — no issues
- DCO sign-off hook passed

## Related issue

N/A

## Checklist

- [x] Affected build, compile, lint, and format checks pass
- [x] Quote tests pass
- [x] Tests added and updated for the browser-specific regressions
- [x] Commits are signed off with DCO