### PR TITLE
fix(desktop): make host restarts resilient and non-blocking

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/host-respawn.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/host-respawn.test.ts
@@ -118,6 +118,63 @@ describe("respawnHost - non-host-owned-login-item path", () => {
     expect(registerHostLoginItem).not.toHaveBeenCalled();
     expect(waitForHostReady).not.toHaveBeenCalled();
   });
+
+  // The dialog-hang RCA's "swallowed respawn failure" defect: `respawn()`
+  // used to resolve even when the underlying CLI restart failed, so the
+  // renderer toasted success for a dead host. Pin that a rejecting
+  // `host.respawn()` propagates all the way through `respawnHost()`.
+  it("propagates a rejecting host.respawn(), and clears `inFlight` afterward so a subsequent call re-runs rather than replaying the stale result", async () => {
+    const host = new FakeHost();
+    hostManagesHostLoginItem.mockResolvedValue(false);
+    let shouldFail = true;
+    host.respawn = vi.fn(async () => {
+      host.respawnCalls += 1;
+      if (shouldFail) {
+        throw new Error("traycer host restart failed");
+      }
+    });
+
+    await expect(respawnHost(host)).rejects.toThrow(
+      "traycer host restart failed",
+    );
+    expect(host.respawnCalls).toBe(1);
+
+    // A retry after the rejection must actually re-run `host.respawn()` -
+    // if `inFlight` were left set (or cleared only on the success path),
+    // this second call would hang forever or short-circuit without ever
+    // calling `respawn()` again.
+    shouldFail = false;
+    await expect(respawnHost(host)).resolves.toBeUndefined();
+    expect(host.respawnCalls).toBe(2);
+  });
+
+  // Two callers racing the same in-flight (and ultimately failing) respawn
+  // must both observe the rejection - not one rejecting while the other
+  // hangs or silently resolves - and the dedup must still only run the
+  // underlying respawn once.
+  it("dedups two concurrent callers against the same failing in-flight respawn - both observe the rejection, only one respawn() call happens", async () => {
+    const host = new FakeHost();
+    hostManagesHostLoginItem.mockResolvedValue(false);
+    host.respawn = vi.fn(async () => {
+      host.respawnCalls += 1;
+      throw new Error("host stayed down");
+    });
+
+    const first = respawnHost(host);
+    const second = respawnHost(host);
+
+    await expect(first).rejects.toThrow("host stayed down");
+    await expect(second).rejects.toThrow("host stayed down");
+    expect(host.respawnCalls).toBe(1);
+
+    // `inFlight` cleared after the shared rejection - a subsequent call
+    // re-runs rather than being wedged behind a stale in-flight guard.
+    host.respawn = vi.fn(async () => {
+      host.respawnCalls += 1;
+    });
+    await expect(respawnHost(host)).resolves.toBeUndefined();
+    expect(host.respawnCalls).toBe(2);
+  });
 });
 
 describe("respawnHost - host-owned login item path", () => {

--- a/clients/desktop/src/electron-main/host/__tests__/host-lifecycle.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-lifecycle.test.ts
@@ -54,6 +54,7 @@ import {
 } from "../host-lifecycle";
 import { DEV_LABEL } from "../host-paths";
 import { config } from "../../../config";
+import { streamTraycerCliJson } from "../../cli/traycer-cli";
 
 describe("isCurrentHostWebsocketUrl", () => {
   it("accepts the canonical ws URL shape", () => {
@@ -712,14 +713,15 @@ describe("HostLifecycle.respawn (CLI subprocess)", () => {
   it("shells out to `traycer host restart`", async () => {
     cliStreamCalls.length = 0;
     const { lifecycle, cleanup } = makeChannelLifecycleForChannel("production");
-    // `respawn()` ends with a `waitForReady` against a deliberately
-    // missing pid.json so the lifecycle emits a `HOST_NOT_READY`
-    // error after the CLI step. Subscribe a no-op listener so
-    // EventEmitter does not throw the unhandled `error` event - the
-    // assertion here is purely about which CLI args were issued.
+    // `respawn()` ends with a `waitForReady` against a deliberately missing
+    // pid.json, so the lifecycle both emits AND rejects with a
+    // `HOST_NOT_READY` error after the CLI step - it must not swallow that
+    // failure into a false success (the dialog-hang RCA's respawn-swallow
+    // bug). Subscribe a no-op listener so EventEmitter does not additionally
+    // throw the unhandled `error` event.
     lifecycle.on("error", () => undefined);
     try {
-      await lifecycle.respawn();
+      await expect(lifecycle.respawn()).rejects.toThrow();
       expect(cliStreamCalls).toHaveLength(1);
       // No --environment - the CLI resolves its slot from config.environment.
       expect(cliStreamCalls[0]?.args).toEqual(["host", "restart"]);
@@ -732,14 +734,36 @@ describe("HostLifecycle.respawn (CLI subprocess)", () => {
   it("shells out to `traycer host restart` for the dev label", async () => {
     cliStreamCalls.length = 0;
     const { lifecycle, cleanup } = makeChannelLifecycleForChannel("dev");
-    // See sibling test - pid.json is intentionally absent, so the
-    // post-CLI `waitForReady` emits a `HOST_NOT_READY` error.
+    // See sibling test - pid.json is intentionally absent, so the post-CLI
+    // `waitForReady` rejects with a `HOST_NOT_READY` error instead of
+    // resolving.
     lifecycle.on("error", () => undefined);
     try {
-      await lifecycle.respawn();
+      await expect(lifecycle.respawn()).rejects.toThrow();
       expect(cliStreamCalls).toHaveLength(1);
       // No --environment - the CLI resolves its slot from config.environment.
       expect(cliStreamCalls[0]?.args).toEqual(["host", "restart"]);
+    } finally {
+      lifecycle.dispose();
+      await cleanup();
+    }
+  });
+
+  // The dialog-hang RCA's "swallowed respawn failure" defect was the CLI
+  // subprocess step itself throwing (not just the readiness poll timing
+  // out afterward) - `respawn()`'s catch block used to log + emit + resolve
+  // regardless of which step failed. Pin that the CLI-step failure alone
+  // (readiness never even reached) still rejects the returned promise.
+  it("rejects respawn() when the CLI restart subprocess itself throws, before the readiness poll ever runs", async () => {
+    const { lifecycle, cleanup } = makeChannelLifecycleForChannel("production");
+    lifecycle.on("error", () => undefined);
+    vi.mocked(streamTraycerCliJson).mockRejectedValueOnce(
+      new Error("traycer CLI exited with code 1"),
+    );
+    try {
+      await expect(lifecycle.respawn()).rejects.toThrow(
+        /traycer host restart failed/,
+      );
     } finally {
       lifecycle.dispose();
       await cleanup();

--- a/clients/desktop/src/electron-main/host/host-lifecycle.ts
+++ b/clients/desktop/src/electron-main/host/host-lifecycle.ts
@@ -15,6 +15,7 @@ import {
 } from "./host-display-name";
 import type { DesktopLocalHostSnapshot } from "../../ipc-contracts/host-types";
 import { streamTraycerCliJson } from "../cli/traycer-cli";
+import { HOST_RESTART_SUBPROCESS_TIMEOUT_MS } from "@traycer/protocol/host/lifecycle-constants";
 
 /**
  * Snapshot of the OS-supervised host's runtime state, as projected by
@@ -50,7 +51,6 @@ const WS_RPC_HOST = "127.0.0.1";
 const HOST_READY_TIMEOUT_MS = 60_000;
 const HOST_POLL_INTERVAL_MS = 250;
 const HOST_ENDPOINT_CHECK_TIMEOUT_MS = 750;
-const CLI_RESTART_TIMEOUT_MS = 2 * 60_000;
 const CLI_START_STOP_TIMEOUT_MS = 60_000;
 /**
  * Backoff ladder for re-probing a pid.json that is present but whose
@@ -245,6 +245,11 @@ export class HostLifecycle extends EventEmitter {
    * build) instead of poking the platform service-manager APIs directly. The
    * PID-file watcher fires `change` once the new host publishes fresh
    * metadata.
+   *
+   * Rethrows after logging/emitting so the renderer-driven caller (IPC
+   * `requestHostRespawn` via `respawnHost`) sees a rejected promise instead of
+   * a false success - a swallowed failure here used to resolve while the host
+   * stayed dead.
    */
   async respawn(): Promise<void> {
     if (this.disposed) {
@@ -269,6 +274,7 @@ export class HostLifecycle extends EventEmitter {
       const startupError = await this.buildStartupError(cause);
       log.error("[host] respawn failed", startupError);
       this.emit("error", startupError);
+      throw cause;
     }
   }
 
@@ -574,7 +580,7 @@ export class HostLifecycle extends EventEmitter {
     await streamTraycerCliJson<unknown>({
       args: ["host", "restart"],
       env: null,
-      timeoutMs: CLI_RESTART_TIMEOUT_MS,
+      timeoutMs: HOST_RESTART_SUBPROCESS_TIMEOUT_MS,
       onEvent: () => {
         // No progress sink - restart payload is small and any partial
         // progress lines are advisory. The PID-metadata watcher fires

--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-channel.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-channel.test.ts
@@ -100,6 +100,7 @@ function writeInstallRecord(
 interface RecordedCall {
   readonly kind: "run" | "stream";
   readonly args: readonly string[];
+  readonly timeoutMs: number | undefined;
 }
 
 interface FakeCli {
@@ -115,12 +116,18 @@ function installFakeCli(opts: {
   const calls: RecordedCall[] = [];
   vi.doMock("../../cli/traycer-cli", () => ({
     runTraycerCliJson: vi.fn((args: readonly string[]) => {
-      calls.push({ kind: "run", args: [...args] });
+      calls.push({ kind: "run", args: [...args], timeoutMs: undefined });
       return Promise.resolve(opts.runResult);
     }),
     streamTraycerCliJson: vi.fn(
-      ({ args }: { readonly args: readonly string[] }) => {
-        calls.push({ kind: "stream", args: [...args] });
+      ({
+        args,
+        timeoutMs,
+      }: {
+        readonly args: readonly string[];
+        readonly timeoutMs: number;
+      }) => {
+        calls.push({ kind: "stream", args: [...args], timeoutMs });
         return Promise.resolve({ data: opts.streamResult });
       },
     ),
@@ -681,7 +688,7 @@ function installFakeCliRejectingWithVerifyFailed(): {
   }
   vi.doMock("../../cli/traycer-cli", () => ({
     runTraycerCliJson: vi.fn((args: readonly string[]) => {
-      calls.push({ kind: "run", args: [...args] });
+      calls.push({ kind: "run", args: [...args], timeoutMs: undefined });
       return Promise.reject(
         new FakeTraycerCliError(
           "E_HOST_VERIFY_FAILED",
@@ -690,8 +697,14 @@ function installFakeCliRejectingWithVerifyFailed(): {
       );
     }),
     streamTraycerCliJson: vi.fn(
-      ({ args }: { readonly args: readonly string[] }) => {
-        calls.push({ kind: "stream", args: [...args] });
+      ({
+        args,
+        timeoutMs,
+      }: {
+        readonly args: readonly string[];
+        readonly timeoutMs: number;
+      }) => {
+        calls.push({ kind: "stream", args: [...args], timeoutMs });
         return Promise.resolve({ data: {} });
       },
     ),
@@ -789,18 +802,20 @@ function installFakeCliWithDeferredStream(): {
   let rejectStream: (err: unknown) => void = () => undefined;
   vi.doMock("../../cli/traycer-cli", () => ({
     runTraycerCliJson: vi.fn((args: readonly string[]) => {
-      calls.push({ kind: "run", args: [...args] });
+      calls.push({ kind: "run", args: [...args], timeoutMs: undefined });
       return Promise.resolve({});
     }),
     streamTraycerCliJson: vi.fn(
       ({
         args,
         onEvent,
+        timeoutMs,
       }: {
         readonly args: readonly string[];
         readonly onEvent: (event: unknown) => void;
+        readonly timeoutMs: number;
       }) => {
-        calls.push({ kind: "stream", args: [...args] });
+        calls.push({ kind: "stream", args: [...args], timeoutMs });
         return new Promise((resolve, reject) => {
           resolveStream = (data: unknown) => {
             onEvent({
@@ -1032,5 +1047,230 @@ describe("host-management IPC - single-flight guard on concurrent host mutations
     });
     await updatePromise;
     expect(await statusHandler(null, null)).toBeNull();
+  });
+});
+
+// Dialog-hang RCA finding 2: `traycerHostRestart` used to call
+// `runTraycerCliJson`, whose hardcoded 10s default is shorter than the CLI's
+// stop-grace (32s) - a slow-draining host got SIGKILLed between `stop` and
+// `start`, leaving it down. The fix routes this handler through
+// `streamTraycerCliJson` with the shared `HOST_RESTART_SUBPROCESS_TIMEOUT_MS`
+// budget instead.
+describe("host-management IPC - restart timeout budget", () => {
+  it("traycerHostRestart streams the CLI restart with the shared HOST_RESTART_SUBPROCESS_TIMEOUT_MS budget, not the 10s runTraycerCliJson default", async () => {
+    const fake = installFakeCli({ runResult: {}, streamResult: {} });
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const { HOST_RESTART_SUBPROCESS_TIMEOUT_MS } =
+      await import("@traycer/protocol/host/lifecycle-constants");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+
+    await bridge.handlers.get(RunnerHostInvoke.traycerHostRestart)!(null, null);
+
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.kind).toBe("stream");
+    expect(fake.calls[0]?.args).toEqual(["host", "restart"]);
+    expect(fake.calls[0]?.timeoutMs).toBe(HOST_RESTART_SUBPROCESS_TIMEOUT_MS);
+  });
+
+  it("keeps the restart budget comfortably above the macOS CLI's stop-grace so a slow drain can't regress into a mid-restart SIGKILL", async () => {
+    const {
+      HOST_RESTART_SUBPROCESS_TIMEOUT_MS,
+      SHUTDOWN_FORCE_EXIT_MS,
+      STOP_EXIT_GRACE_MARGIN_MS,
+    } = await import("@traycer/protocol/host/lifecycle-constants");
+    const stopGrace = SHUTDOWN_FORCE_EXIT_MS + STOP_EXIT_GRACE_MARGIN_MS;
+    // A budget merely equal to the stop-grace regresses to the original
+    // bug (SIGKILL lands the instant `stop` finishes, before `start` runs).
+    // Require real headroom above it, not just `>`.
+    expect(HOST_RESTART_SUBPROCESS_TIMEOUT_MS).toBeGreaterThanOrEqual(
+      stopGrace + 30_000,
+    );
+  });
+
+  // Review finding 1: a budget sized only for macOS's stop-grace can still
+  // SIGKILL a legitimate, slow-but-successful Windows restart mid-sequence -
+  // `schtasks /End` + the PowerShell process scan + `taskkill` + `schtasks
+  // /Run` can cumulatively take longer than the macOS-only 92s budget did.
+  it("keeps the restart budget comfortably above the Windows restart sequence's own worst case", async () => {
+    const {
+      HOST_RESTART_SUBPROCESS_TIMEOUT_MS,
+      WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS,
+    } = await import("@traycer/protocol/host/lifecycle-constants");
+    // A budget merely equal to the Windows sequence's own worst case
+    // regresses to the same class of bug - SIGKILL lands the instant the
+    // sequence would have finished. Require real headroom above it.
+    expect(HOST_RESTART_SUBPROCESS_TIMEOUT_MS).toBeGreaterThanOrEqual(
+      WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS + 15_000,
+    );
+  });
+
+  // Review finding 3: Doctor's "Free Port + Restart" also SIGTERMs a
+  // confirmed foreign process and then awaits a platform service restart
+  // with the same 10-100s deadlines, so it needs the same restart-safe
+  // budget as `traycerHostRestart` instead of the 10s `runTraycerCliJson`
+  // default it used to carry.
+  it("traycerFreePortAndRestart streams the CLI restart with the shared HOST_RESTART_SUBPROCESS_TIMEOUT_MS budget, not the 10s runTraycerCliJson default", async () => {
+    const fake = installFakeCli({ runResult: {}, streamResult: {} });
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const { HOST_RESTART_SUBPROCESS_TIMEOUT_MS } =
+      await import("@traycer/protocol/host/lifecycle-constants");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+
+    await bridge.handlers.get(RunnerHostInvoke.traycerFreePortAndRestart)!(
+      null,
+      { port: 7000, pid: 1234, processName: "rogue" },
+    );
+
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.kind).toBe("stream");
+    expect(fake.calls[0]?.args.slice(0, 2)).toEqual([
+      "host",
+      "free-port-and-restart",
+    ]);
+    expect(fake.calls[0]?.timeoutMs).toBe(HOST_RESTART_SUBPROCESS_TIMEOUT_MS);
+  });
+});
+
+// Review finding 4: `traycerHostRestart` used to call `streamTraycerCliJson`
+// directly with a no-op event sink, so `HostOperationStatus` stayed null
+// during a restart - a second Settings window showed no banner and could
+// launch a competing restart that lost on `cli-lock` with a spurious error.
+// The fix routes restart through the same `trackHostOperation` seam
+// install/update/register-service already use.
+describe("host-management IPC - restart routes through the canonical operation-status/single-flight guard", () => {
+  it("reports HostOperationStatus.kind === 'restart' while a restart is running and clears it back to null on settle", async () => {
+    const fake = installFakeCliWithDeferredStream();
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke, RunnerHostEvent } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+
+    const statusHandler = bridge.handlers.get(
+      RunnerHostInvoke.traycerHostOperationStatusGet,
+    )!;
+    expect(await statusHandler(null, null)).toBeNull();
+
+    const restartPromise = bridge.handlers.get(
+      RunnerHostInvoke.traycerHostRestart,
+    )!(null, null);
+    await waitForStreamCallCount(fake, 1);
+
+    expect(await statusHandler(null, null)).toMatchObject({ kind: "restart" });
+    const statusCalls = () =>
+      bridge.fanOut.mock.calls.filter(
+        ([channel]) => channel === RunnerHostEvent.hostOperationStatusChange,
+      );
+    expect(statusCalls()[0]?.[1]).toMatchObject({
+      kind: "restart",
+      percent: null,
+    });
+
+    fake.resolveStream({});
+    await restartPromise;
+
+    expect(mgmt.getHostOperationStatus()).toBeNull();
+    expect(await statusHandler(null, null)).toBeNull();
+  });
+
+  it("rejects a second concurrent host operation while a restart is in flight, without spawning a second CLI subprocess", async () => {
+    const fake = installFakeCliWithDeferredStream();
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+
+    const restartPromise = bridge.handlers.get(
+      RunnerHostInvoke.traycerHostRestart,
+    )!(null, null);
+    await waitForStreamCallCount(fake, 1);
+
+    await expect(
+      bridge.handlers.get(RunnerHostInvoke.traycerHostUpdate)!(null, {
+        operationId: "op-update",
+      }),
+    ).rejects.toThrow(
+      /Another host operation \(restart\) is already in progress/i,
+    );
+
+    // Only ONE CLI subprocess was ever spawned - the second call never
+    // reached the CLI lock at all.
+    expect(fake.calls.filter((c) => c.kind === "stream")).toHaveLength(1);
+
+    fake.resolveStream({});
+    await restartPromise;
+  });
+
+  // Review follow-up finding: neither `host restart` nor the hidden
+  // `host free-port-and-restart` CLI command takes the CLI's own file lock
+  // (`withCliLock`), so `trackHostOperation` is the ONLY same-process
+  // protection against the two interleaving their stop/kill/start
+  // sequences. Both directions must be covered - either one racing the
+  // other must lose without spawning a second CLI subprocess.
+  it("rejects a concurrent traycerFreePortAndRestart while a tracked restart is in flight, without spawning a second CLI subprocess", async () => {
+    const fake = installFakeCliWithDeferredStream();
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+
+    const restartPromise = bridge.handlers.get(
+      RunnerHostInvoke.traycerHostRestart,
+    )!(null, null);
+    await waitForStreamCallCount(fake, 1);
+
+    await expect(
+      bridge.handlers.get(RunnerHostInvoke.traycerFreePortAndRestart)!(null, {
+        port: 7000,
+        pid: 1234,
+        processName: "rogue",
+      }),
+    ).rejects.toThrow(
+      /Another host operation \(restart\) is already in progress/i,
+    );
+
+    expect(fake.calls.filter((c) => c.kind === "stream")).toHaveLength(1);
+
+    fake.resolveStream({});
+    await restartPromise;
+  });
+
+  it("rejects a concurrent traycerHostRestart while a tracked free-port-and-restart is in flight, without spawning a second CLI subprocess", async () => {
+    const fake = installFakeCliWithDeferredStream();
+    const mgmt = await import("../host-management-ipc");
+    mgmt.setActiveEnvironment("production");
+    const { RunnerHostInvoke } =
+      await import("../../../ipc-contracts/ipc-channels");
+    const bridge = makeBridge();
+    mgmt.registerHostManagementIpc(bridge as never);
+
+    const freePortPromise = bridge.handlers.get(
+      RunnerHostInvoke.traycerFreePortAndRestart,
+    )!(null, { port: 7000, pid: 1234, processName: "rogue" });
+    await waitForStreamCallCount(fake, 1);
+
+    await expect(
+      bridge.handlers.get(RunnerHostInvoke.traycerHostRestart)!(null, null),
+    ).rejects.toThrow(
+      /Another host operation \(free-port-and-restart\) is already in progress/i,
+    );
+
+    expect(fake.calls.filter((c) => c.kind === "stream")).toHaveLength(1);
+
+    fake.resolveStream({});
+    await freePortPromise;
   });
 });

--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -2466,6 +2466,60 @@ describe("RunnerIpcBridge", () => {
     bridge.dispose();
   });
 
+  it("tracks requestHostRespawn in the shared host-operation single-flight guard", async () => {
+    const mod = await import("../register-runner-ipc");
+    const host = new FakeHost();
+    const respawnStarted = Promise.withResolvers<void>();
+    const releaseRespawn = Promise.withResolvers<void>();
+    host.respawn = vi.fn(() => {
+      host.respawnCalls += 1;
+      respawnStarted.resolve();
+      return releaseRespawn.promise;
+    });
+    const bridge = new mod.RunnerIpcBridge({
+      host,
+      authnBaseUrl: "http://localhost:5005",
+      authRedirectUri: null,
+      tray: null,
+      zoomController: undefined,
+      window: buildWindow(),
+    });
+    bridge.install();
+
+    const respawnHandler = ipcMainState.handlers.get(
+      RunnerHostInvoke.requestHostRespawn,
+    );
+    const statusHandler = ipcMainState.handlers.get(
+      RunnerHostInvoke.traycerHostOperationStatusGet,
+    );
+    const restartHandler = ipcMainState.handlers.get(
+      RunnerHostInvoke.traycerHostRestart,
+    );
+    if (
+      respawnHandler === undefined ||
+      statusHandler === undefined ||
+      restartHandler === undefined
+    ) {
+      throw new Error("host restart handlers missing");
+    }
+
+    const respawn = respawnHandler(bareEvent());
+    await respawnStarted.promise;
+
+    await expect(statusHandler(bareEvent())).resolves.toMatchObject({
+      kind: "restart",
+    });
+    await expect(restartHandler(bareEvent())).rejects.toThrow(
+      /Another host operation \(restart\) is already in progress/i,
+    );
+    expect(host.respawnCalls).toBe(1);
+
+    releaseRespawn.resolve();
+    await respawn;
+    await expect(statusHandler(bareEvent())).resolves.toBeNull();
+    bridge.dispose();
+  });
+
   it("serves authnBaseUrl synchronously via ipcMain.on", async () => {
     const mod = await import("../register-runner-ipc");
     const bridge = new mod.RunnerIpcBridge({

--- a/clients/desktop/src/electron-main/ipc/host-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-ipc.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from "node:crypto";
 import { respawnHost } from "../app/host-respawn";
 import {
   RunnerHostEvent,
   RunnerHostInvoke,
 } from "../../ipc-contracts/ipc-channels";
 import type { DesktopLocalHostSnapshot } from "../../ipc-contracts/host-types";
+import { runTrackedHostOperation } from "./host-management-ipc";
 import type { RunnerIpcBridge } from "./runner-ipc-bridge";
 
 export function registerHostIpc(bridge: RunnerIpcBridge): void {
@@ -12,12 +14,16 @@ export function registerHostIpc(bridge: RunnerIpcBridge): void {
   // `respawnHost` (in `app/host-respawn.ts`) is the single shared
   // entrypoint used by every respawn surface - this IPC handler, the
   // tray's "Restart Host", and any menu-bar host command. It owns
-  // both the in-flight dedupe (so concurrent Retry clicks can't
-  // interleave SMAppService unregister/register cycles) and the routing
-  // between the SMAppService cycle (macOS host-owned login item) and the
-  // CLI restart path.
+  // both the in-flight dedupe (so concurrent Retry clicks can't interleave
+  // SMAppService unregister/register cycles) and the routing between the
+  // SMAppService cycle (macOS host-owned login item) and the CLI restart path.
+  // The outer process-wide tracker coordinates this entrypoint with Settings,
+  // tray, and Doctor restart-class operations and publishes the same status to
+  // every renderer window.
   bridge.handleInvoke(RunnerHostInvoke.requestHostRespawn, async () => {
-    await respawnHost(bridge.options.host);
+    await runTrackedHostOperation(bridge, "restart", randomUUID(), async () =>
+      respawnHost(bridge.options.host),
+    );
   });
 
   const onHostChange = (snapshot: DesktopLocalHostSnapshot | null): void => {

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -11,6 +11,7 @@ import {
   TraycerCliError,
   type NdjsonEvent,
 } from "../cli/traycer-cli";
+import { HOST_RESTART_SUBPROCESS_TIMEOUT_MS } from "@traycer/protocol/host/lifecycle-constants";
 import {
   RunnerHostEvent,
   RunnerHostInvoke,
@@ -1102,7 +1103,23 @@ export function registerHostManagementIpc(bridge: RunnerIpcBridge): void {
   });
 
   bridge.handleInvoke(RunnerHostInvoke.traycerHostRestart, async () => {
-    await runTraycerCliJson<unknown>(["host", "restart", "--json"]);
+    // `runTraycerCliJson`'s 10s default is shorter than the CLI's stop-grace
+    // (32s) - a slow-draining host would get SIGKILLed between `stop` and
+    // `start`, leaving it down. Route through `trackHostOperation` (like
+    // install/update/register-service) instead of calling
+    // `streamTraycerCliJson` directly with a no-op event sink: a bare
+    // no-op sink left `HostOperationStatus` null during a restart, so a
+    // second Settings window showed no banner and could launch a competing
+    // restart that lost on `cli-lock` with a spurious error. Routing through
+    // the canonical seam gets the shared restart budget, the cross-window
+    // single-flight guard, and the progress banner for free.
+    await streamCliWithProgress(
+      ["host", "restart"],
+      randomUUID(),
+      "restart",
+      HOST_RESTART_SUBPROCESS_TIMEOUT_MS,
+      bridge,
+    );
   });
 
   bridge.handleInvoke(
@@ -1220,7 +1237,28 @@ export function registerHostManagementIpc(bridge: RunnerIpcBridge): void {
       const args = ["host", "free-port-and-restart"];
       if (pid !== null) args.push("--pid", String(pid));
       if (port !== null) args.push("--port", String(port));
-      const data = await runTraycerCliJson<unknown>(args);
+      // Same class of bug as `traycerHostRestart` (review finding 3): this
+      // command SIGTERMs the confirmed foreign process and then awaits a
+      // platform service restart with the same 10-100s deadlines - the 10s
+      // `runTraycerCliJson` default can kill the CLI after the foreign
+      // process is gone but before the host restart finishes, leaving a
+      // dead process, a failed Doctor action, and possibly no host.
+      //
+      // Routed through `trackHostOperation` too (review follow-up finding):
+      // neither `host restart` nor the hidden `host free-port-and-restart`
+      // CLI command takes the CLI's own file lock (`withCliLock`), so
+      // `trackHostOperation`'s single-flight guard is the ONLY same-process
+      // protection against two restart-class subprocesses interleaving
+      // their stop/kill/start sequences - a tracked restart racing an
+      // untracked free-port-and-restart could kill the other's freshly
+      // started host, worst on Windows.
+      const data = await streamCliWithProgress(
+        args,
+        randomUUID(),
+        "free-port-and-restart",
+        HOST_RESTART_SUBPROCESS_TIMEOUT_MS,
+        bridge,
+      );
       return projectFreePortAndRestartResult(data, {
         port: port ?? 0,
         pid,

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -353,6 +353,21 @@ async function trackHostOperation<T>(
   }
 }
 
+/**
+ * Runs a host lifecycle action through the same process-wide single-flight
+ * guard and status publisher used by streaming CLI operations. Callers whose
+ * underlying operation owns its own progress/readiness flow (for example the
+ * native-menu respawn path) do not need to manufacture NDJSON progress events.
+ */
+export function runTrackedHostOperation<T>(
+  bridge: RunnerIpcBridge,
+  kind: HostOperationKind,
+  operationId: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  return trackHostOperation(bridge, kind, operationId, () => run());
+}
+
 export function streamCliWithProgress(
   args: readonly string[],
   operationId: string,

--- a/clients/desktop/src/electron-preload/__tests__/host-management-bridge.test.ts
+++ b/clients/desktop/src/electron-preload/__tests__/host-management-bridge.test.ts
@@ -133,22 +133,25 @@ describe("host-management-bridge onOperationStatus", () => {
     subscription.dispose();
   });
 
-  it("rejects a malformed payload with an unrecognized kind", async () => {
-    vi.resetModules();
-    const { buildHostManagementBridge } =
-      await import("../host-management-bridge");
-    const bridge = buildHostManagementBridge();
-    const observed: (HostOperationStatus | null)[] = [];
-    const subscription = bridge.onOperationStatus((status) => {
-      observed.push(status);
-    });
+  it.each(["not-a-real-kind", "toString", "constructor"])(
+    "rejects a malformed payload with kind %s",
+    async (kind) => {
+      vi.resetModules();
+      const { buildHostManagementBridge } =
+        await import("../host-management-bridge");
+      const bridge = buildHostManagementBridge();
+      const observed: (HostOperationStatus | null)[] = [];
+      const subscription = bridge.onOperationStatus((status) => {
+        observed.push(status);
+      });
 
-    fakeElectron.emit(RunnerHostEvent.hostOperationStatusChange, {
-      ...makeStatus("install"),
-      kind: "not-a-real-kind",
-    });
+      fakeElectron.emit(RunnerHostEvent.hostOperationStatusChange, {
+        ...makeStatus("install"),
+        kind,
+      });
 
-    expect(observed).toEqual([]);
-    subscription.dispose();
-  });
+      expect(observed).toEqual([]);
+      subscription.dispose();
+    },
+  );
 });

--- a/clients/desktop/src/electron-preload/__tests__/host-management-bridge.test.ts
+++ b/clients/desktop/src/electron-preload/__tests__/host-management-bridge.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RunnerHostEvent } from "../../ipc-contracts/ipc-channels";
+import type {
+  HostOperationKind,
+  HostOperationStatus,
+} from "../../ipc-contracts/host-management-types";
+
+/**
+ * Review follow-up (dialog-hang RCA): `onOperationStatus`'s runtime type
+ * guard hand-maintains an allowlist of `HostOperationKind` values. When
+ * `restart` and `free-port-and-restart` were added to the shared type, this
+ * preload's guard was not updated - it silently dropped main's broadcasts
+ * for those kinds before they ever reached `HostOperationStatusListener`, so
+ * an already-mounted Doctor/Settings window never saw the live status
+ * transition (mount-time `getOperationStatus` reads worked fine, since that
+ * path is a direct cast with no guard). These tests pin every current
+ * `HostOperationKind` passing through, and the exhaustiveness guard inside
+ * `host-management-bridge.ts` (a `Record<HostOperationKind, true>` map, which
+ * fails to compile if a member is ever added there without a matching key
+ * here) is what keeps this from silently regressing again.
+ */
+
+type IpcHandler = (event: unknown, payload: unknown) => void;
+
+interface FakeElectron {
+  channels: Map<string, Set<IpcHandler>>;
+  emit(channel: string, payload: unknown): void;
+  reset(): void;
+}
+
+const fakeElectron: FakeElectron = {
+  channels: new Map(),
+  emit(channel, payload) {
+    const handlers = fakeElectron.channels.get(channel);
+    if (handlers === undefined) return;
+    for (const handler of handlers) {
+      handler({}, payload);
+    }
+  },
+  reset() {
+    fakeElectron.channels.clear();
+  },
+};
+
+vi.mock("electron", () => ({
+  ipcRenderer: {
+    on: (channel: string, handler: IpcHandler): void => {
+      let set = fakeElectron.channels.get(channel);
+      if (set === undefined) {
+        set = new Set();
+        fakeElectron.channels.set(channel, set);
+      }
+      set.add(handler);
+    },
+    removeListener: (channel: string, handler: IpcHandler): void => {
+      fakeElectron.channels.get(channel)?.delete(handler);
+    },
+    invoke: (): Promise<unknown> => Promise.resolve(undefined),
+  },
+}));
+
+function makeStatus(kind: HostOperationKind): HostOperationStatus {
+  return {
+    operationId: `op-${kind}`,
+    kind,
+    stage: null,
+    percent: null,
+    bytes: null,
+    totalBytes: null,
+    message: null,
+    startedAt: "2026-05-15T00:00:00Z",
+  };
+}
+
+// Every member of `HostOperationKind` as of this writing. If the union
+// gains a member, `host-management-bridge.ts`'s `HOST_OPERATION_KINDS` map
+// fails to compile until it's added there too - update this list to match
+// when that happens, so the boundary stays covered.
+const ALL_HOST_OPERATION_KINDS: readonly HostOperationKind[] = [
+  "install",
+  "update",
+  "register-service",
+  "ensure",
+  "restart",
+  "free-port-and-restart",
+];
+
+describe("host-management-bridge onOperationStatus", () => {
+  beforeEach(() => {
+    fakeElectron.reset();
+  });
+
+  afterEach(() => {
+    fakeElectron.reset();
+    vi.resetModules();
+  });
+
+  it.each(ALL_HOST_OPERATION_KINDS)(
+    "passes a %s operation-status broadcast through to the listener",
+    async (kind) => {
+      vi.resetModules();
+      const { buildHostManagementBridge } =
+        await import("../host-management-bridge");
+      const bridge = buildHostManagementBridge();
+      const observed: (HostOperationStatus | null)[] = [];
+      const subscription = bridge.onOperationStatus((status) => {
+        observed.push(status);
+      });
+
+      fakeElectron.emit(
+        RunnerHostEvent.hostOperationStatusChange,
+        makeStatus(kind),
+      );
+
+      expect(observed).toEqual([makeStatus(kind)]);
+      subscription.dispose();
+    },
+  );
+
+  it("passes a null operation-status broadcast through (operation cleared)", async () => {
+    vi.resetModules();
+    const { buildHostManagementBridge } =
+      await import("../host-management-bridge");
+    const bridge = buildHostManagementBridge();
+    const observed: (HostOperationStatus | null)[] = [];
+    const subscription = bridge.onOperationStatus((status) => {
+      observed.push(status);
+    });
+
+    fakeElectron.emit(RunnerHostEvent.hostOperationStatusChange, null);
+
+    expect(observed).toEqual([null]);
+    subscription.dispose();
+  });
+
+  it("rejects a malformed payload with an unrecognized kind", async () => {
+    vi.resetModules();
+    const { buildHostManagementBridge } =
+      await import("../host-management-bridge");
+    const bridge = buildHostManagementBridge();
+    const observed: (HostOperationStatus | null)[] = [];
+    const subscription = bridge.onOperationStatus((status) => {
+      observed.push(status);
+    });
+
+    fakeElectron.emit(RunnerHostEvent.hostOperationStatusChange, {
+      ...makeStatus("install"),
+      kind: "not-a-real-kind",
+    });
+
+    expect(observed).toEqual([]);
+    subscription.dispose();
+  });
+});

--- a/clients/desktop/src/electron-preload/host-management-bridge.ts
+++ b/clients/desktop/src/electron-preload/host-management-bridge.ts
@@ -13,6 +13,7 @@ import type {
   HostInstalledRecord,
   HostLogsTailResult,
   HostNameSettings,
+  HostOperationKind,
   HostOperationStatus,
   HostProgressEvent,
   HostRegistryUpdateState,
@@ -262,6 +263,26 @@ function isHostRegistryUpdateState(
   );
 }
 
+// `Record<HostOperationKind, true>` requires a key for every member of the
+// union - if `HostOperationKind` ever gains a member without a matching key
+// added here, this object literal fails to compile instead of silently
+// dropping that kind's broadcasts at runtime (the exact bug: `restart` and
+// `free-port-and-restart` were added to the shared type without updating
+// this preload's validation, so `onOperationStatus` rejected main's
+// broadcasts for them before they ever reached the query cache).
+const HOST_OPERATION_KINDS: Record<HostOperationKind, true> = {
+  install: true,
+  update: true,
+  "register-service": true,
+  ensure: true,
+  restart: true,
+  "free-port-and-restart": true,
+};
+
+function isHostOperationKind(value: unknown): value is HostOperationKind {
+  return typeof value === "string" && value in HOST_OPERATION_KINDS;
+}
+
 function isHostOperationStatusOrNull(
   value: unknown,
 ): value is HostOperationStatus | null {
@@ -275,10 +296,7 @@ function isHostOperationStatusOrNull(
   const message = candidate.message;
   return (
     typeof candidate.operationId === "string" &&
-    (candidate.kind === "install" ||
-      candidate.kind === "update" ||
-      candidate.kind === "register-service" ||
-      candidate.kind === "ensure") &&
+    isHostOperationKind(candidate.kind) &&
     (typeof stage === "string" || stage === null) &&
     (typeof percent === "number" || percent === null) &&
     (typeof bytes === "number" || bytes === null) &&

--- a/clients/desktop/src/electron-preload/host-management-bridge.ts
+++ b/clients/desktop/src/electron-preload/host-management-bridge.ts
@@ -280,7 +280,9 @@ const HOST_OPERATION_KINDS: Record<HostOperationKind, true> = {
 };
 
 function isHostOperationKind(value: unknown): value is HostOperationKind {
-  return typeof value === "string" && value in HOST_OPERATION_KINDS;
+  return (
+    typeof value === "string" && Object.hasOwn(HOST_OPERATION_KINDS, value)
+  );
 }
 
 function isHostOperationStatusOrNull(

--- a/clients/gui-app/src/components/home/host-update-banner.tsx
+++ b/clients/gui-app/src/components/home/host-update-banner.tsx
@@ -14,11 +14,11 @@ import {
   runnerQueryKeys,
 } from "@/lib/query-keys/runner-mutation-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import { useRunnerHostOperationStatusQuery } from "@/hooks/runner/use-runner-host-operation-status-query";
 import { cn } from "@/lib/utils";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import type {
   HostInstallResult,
-  HostOperationStatus,
   HostRegistryUpdateState,
   IHostManagement,
 } from "@traycer-clients/shared/platform/runner-host";
@@ -96,15 +96,8 @@ function HostUpdateBannerInner(props: HostUpdateBannerInnerProps) {
   // open window via the same query key, so the button here disables and
   // shows progress whether THIS banner, Settings, or the background
   // auto-update reconciler is the one actually driving the update.
-  // `staleTime: Infinity` because this is entirely event-sourced (pushed by
-  // `HostOperationStatusListener`), never polling-appropriate.
-  const { data: operationStatus } = useQuery(
-    queryOptions<HostOperationStatus | null>({
-      queryKey: runnerQueryKeys.hostOperationStatus(management),
-      queryFn: () => management.getOperationStatus(),
-      staleTime: Infinity,
-    }),
-  );
+  const { data: operationStatus } =
+    useRunnerHostOperationStatusQuery(management);
   const sharedOperationActive =
     operationStatus !== undefined && operationStatus !== null;
   const sharedPercent =

--- a/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
@@ -9,6 +9,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { toast } from "sonner";
 import type {
   HostInstallResult,
   HostTrayCommand,
@@ -225,6 +226,8 @@ function renderListener(host: IRunnerHost): QueryClient {
 describe("<HostTrayCommandListener /> - mounted in __root", () => {
   beforeEach(() => {
     navigateMock.mockClear();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
   });
   afterEach(() => {
     cleanup();
@@ -256,6 +259,133 @@ describe("<HostTrayCommandListener /> - mounted in __root", () => {
     expect(management.restartHost).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId("confirm-action"));
+    await waitFor(() => {
+      expect(management.restartHost).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("closes the restart dialog optimistically on confirm while the mutation is still pending, and surfaces a later rejection via toast", async () => {
+    const tray = createTray();
+    let rejectRestart: (error: Error) => void = () => undefined;
+    const management: IHostManagement = {
+      ...makeManagement(),
+      restartHost: vi.fn(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectRestart = reject;
+          }),
+      ),
+    };
+    renderListener(makeHost(tray.bridge, management));
+
+    act(() => {
+      tray.emit({ kind: "restartHost" });
+    });
+
+    await screen.findByTestId("confirm-destructive-dialog");
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    // Closes synchronously at confirm time - this listener also lives
+    // inside HostReadyGate and can unmount mid-restart, so the dialog must
+    // not depend on the mutation's onSuccess/onError to close.
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    await waitFor(() => {
+      expect(management.restartHost).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      rejectRestart(new Error("traycer host restart failed"));
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't restart host",
+        expect.objectContaining({
+          description: "traycer host restart failed",
+        }),
+      );
+    });
+  });
+
+  it("does not reopen the restart dialog while a restart is still pending, but does once it has settled", async () => {
+    const tray = createTray();
+    let resolveRestart: () => void = () => undefined;
+    const management: IHostManagement = {
+      ...makeManagement(),
+      restartHost: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRestart = resolve;
+          }),
+      ),
+    };
+    renderListener(makeHost(tray.bridge, management));
+
+    act(() => {
+      tray.emit({ kind: "restartHost" });
+    });
+    await screen.findByTestId("confirm-destructive-dialog");
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    await waitFor(() => {
+      expect(management.restartHost).toHaveBeenCalledTimes(1);
+    });
+
+    // The mutation is still pending here - a repeated command must not
+    // reopen the dialog, since it would mount with isPending=true and lock
+    // Cancel/Esc for the rest of the mutation's lifetime.
+    act(() => {
+      tray.emit({ kind: "restartHost" });
+    });
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    expect(management.restartHost).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      resolveRestart();
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Host restart requested");
+    });
+
+    // Once settled, the guard is scoped to "pending", not permanent - the
+    // command must be able to reopen the dialog again.
+    act(() => {
+      tray.emit({ kind: "restartHost" });
+    });
+    await screen.findByTestId("confirm-destructive-dialog");
+    expect(management.restartHost).toHaveBeenCalledTimes(1);
+  });
+
+  // Review P2: the reopen guard must close the race BEFORE any render/effect
+  // runs - a native command queued in the same turn as confirm (no `await`
+  // between them) must still be blocked. Reading `queryClient.isMutating`
+  // (which reflects `mutate()` synchronously) rather than a ref synced from
+  // an effect is what closes this specific window.
+  it("does not reopen the restart dialog for a duplicate command delivered in the same turn as confirm", async () => {
+    const tray = createTray();
+    const management: IHostManagement = {
+      ...makeManagement(),
+      restartHost: vi.fn(() => new Promise<void>(() => {})),
+    };
+    renderListener(makeHost(tray.bridge, management));
+
+    act(() => {
+      tray.emit({ kind: "restartHost" });
+    });
+    await screen.findByTestId("confirm-destructive-dialog");
+
+    act(() => {
+      // No `await`/`waitFor` between the confirm click and the duplicate
+      // command - both happen inside the same `act()` batch, before React
+      // has re-rendered or run any effect.
+      fireEvent.click(screen.getByTestId("confirm-action"));
+      tray.emit({ kind: "restartHost" });
+    });
+
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    // `mutate()` invokes the mutation function on a later microtask, so
+    // assert the eventual call count rather than immediately after the
+    // synchronous act() block above.
     await waitFor(() => {
       expect(management.restartHost).toHaveBeenCalledTimes(1);
     });

--- a/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
@@ -18,6 +18,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { toast } from "sonner";
 import type {
   HostInstallResult,
   IHostManagement,
@@ -76,6 +77,14 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("@/lib/host", () => ({
   useHostBinding: () => null,
   useAuthService: () => authMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
 }));
 
 interface FakeDesktopMenu {
@@ -333,6 +342,8 @@ describe("<MenuCommandListener />", () => {
     navigateMock.mockClear();
     authMock.signIn.mockClear();
     authMock.signOut.mockClear();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
     routerState.pathname = "/";
     resetStores();
     useDesktopDialogStore.getState().close();
@@ -649,6 +660,153 @@ describe("<MenuCommandListener />", () => {
 
     fireEvent.click(screen.getByTestId("confirm-action"));
 
+    await waitFor(() => {
+      expect(requestHostRespawn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("closes the restart dialog optimistically on confirm - before the up-to-~180s respawn settles - and surfaces a later rejection via toast", async () => {
+    const menu = createMenu();
+    let rejectRespawn: (error: Error) => void = () => undefined;
+    const requestHostRespawn = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRespawn = reject;
+        }),
+    );
+    const runnerHost = Object.assign(createRunnerHost(menu), {
+      requestHostRespawn,
+    });
+
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <RunnerHostProvider runnerHost={runnerHost}>
+          <MenuCommandListener />
+        </RunnerHostProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      menu.emit("host.restart");
+    });
+
+    await screen.findByTestId("confirm-destructive-dialog");
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    // Closes synchronously at confirm time - this surface's mutation can
+    // legitimately run up to ~180s, so the dialog must not wait for it.
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    await waitFor(() => {
+      expect(requestHostRespawn).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      rejectRespawn(new Error("host did not become reachable after restart"));
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't restart host",
+        expect.objectContaining({
+          description: "host did not become reachable after restart",
+        }),
+      );
+    });
+  });
+
+  it("does not reopen the restart dialog while a restart is still pending, but does once it has settled", async () => {
+    const menu = createMenu();
+    let resolveRespawn: () => void = () => undefined;
+    const requestHostRespawn = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRespawn = resolve;
+        }),
+    );
+    const runnerHost = Object.assign(createRunnerHost(menu), {
+      requestHostRespawn,
+    });
+
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <RunnerHostProvider runnerHost={runnerHost}>
+          <MenuCommandListener />
+        </RunnerHostProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      menu.emit("host.restart");
+    });
+    await screen.findByTestId("confirm-destructive-dialog");
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    await waitFor(() => {
+      expect(requestHostRespawn).toHaveBeenCalledTimes(1);
+    });
+
+    // The mutation is still pending here - a repeated command must not
+    // reopen the dialog, since it would mount with isPending=true and lock
+    // Cancel/Esc for the rest of the mutation's lifetime.
+    act(() => {
+      menu.emit("host.restart");
+    });
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    expect(requestHostRespawn).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      resolveRespawn();
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Host restart requested");
+    });
+
+    // Once settled, the guard is scoped to "pending", not permanent - the
+    // command must be able to reopen the dialog again.
+    act(() => {
+      menu.emit("host.restart");
+    });
+    await screen.findByTestId("confirm-destructive-dialog");
+    expect(requestHostRespawn).toHaveBeenCalledTimes(1);
+  });
+
+  // Review P2: the reopen guard must close the race BEFORE any render/effect
+  // runs - a native command queued in the same turn as confirm (no `await`
+  // between them) must still be blocked. Reading `queryClient.isMutating`
+  // (which reflects `mutate()` synchronously) rather than a ref synced from
+  // an effect is what closes this specific window.
+  it("does not reopen the restart dialog for a duplicate command delivered in the same turn as confirm", async () => {
+    const menu = createMenu();
+    const requestHostRespawn = vi.fn(() => new Promise<void>(() => {}));
+    const runnerHost = Object.assign(createRunnerHost(menu), {
+      requestHostRespawn,
+    });
+
+    render(
+      <QueryClientProvider client={makeQueryClient()}>
+        <RunnerHostProvider runnerHost={runnerHost}>
+          <MenuCommandListener />
+        </RunnerHostProvider>
+      </QueryClientProvider>,
+    );
+
+    act(() => {
+      menu.emit("host.restart");
+    });
+    await screen.findByTestId("confirm-destructive-dialog");
+
+    act(() => {
+      // No `await`/`waitFor` between the confirm click and the duplicate
+      // command - both happen inside the same `act()` batch, before React
+      // has re-rendered or run any effect.
+      fireEvent.click(screen.getByTestId("confirm-action"));
+      menu.emit("host.restart");
+    });
+
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    // `mutate()` invokes the mutation function on a later microtask, so
+    // assert the eventual call count rather than immediately after the
+    // synchronous act() block above.
     await waitFor(() => {
       expect(requestHostRespawn).toHaveBeenCalledTimes(1);
     });

--- a/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
@@ -77,6 +77,9 @@ export function HostTrayCommandListener() {
     },
     onSuccess: () => {
       toast.success("Host restart requested");
+      // Belt-and-braces: the dialog already closed optimistically at
+      // confirm time, but this guarantees the open flag can never survive
+      // settlement even if something else set it in between.
       setPendingRestart(false);
       if (management !== null) {
         void queryClient.invalidateQueries({
@@ -135,6 +138,21 @@ export function HostTrayCommandListener() {
           void navigate({ to: "/settings/host" });
           return;
         case "restartHost":
+          // A restart already in flight (from this or an earlier confirm)
+          // must not reopen the dialog - it would mount with
+          // `isPending=true`, which locks Cancel/Esc for the rest of that
+          // mutation's lifetime (the exact lockout this fix removed).
+          // Read the mutation cache directly (not a ref synced from
+          // `restartMutation.isPending`) - `isMutating` reflects `mutate()`
+          // the instant it's called, synchronously, with no render/effect
+          // delay for a queued native command to slip through.
+          if (
+            queryClient.isMutating({
+              mutationKey: runnerMutationKeys.hostRestart(),
+            }) > 0
+          ) {
+            return;
+          }
           Analytics.getInstance().track(AnalyticsEvent.CommandExecuted, {
             source: "system_tray",
             command: "restart_host",
@@ -169,7 +187,7 @@ export function HostTrayCommandListener() {
     return () => {
       subscription.dispose();
     };
-  }, [navigate, openLogs, runnerHost]);
+  }, [navigate, openLogs, runnerHost, queryClient]);
 
   return (
     <>
@@ -179,7 +197,16 @@ export function HostTrayCommandListener() {
           if (!open) setPendingRestart(false);
         }}
         isPending={restartMutation.isPending}
-        onConfirm={() => restartMutation.mutate()}
+        onConfirm={() => {
+          // Close optimistically - see host-settings-panel.tsx for why. This
+          // listener also lives inside HostReadyGate and can unmount
+          // mid-restart (the gate swaps to "Setting up Traycer Host…" once
+          // the snapshot goes null), which would otherwise discard this
+          // mutation's onSuccess/onError toasts - closing eagerly means the
+          // dialog never depends on those callbacks firing.
+          setPendingRestart(false);
+          restartMutation.mutate();
+        }}
       />
       <ConfirmDestructiveDialog
         open={pendingInstallVersion !== null}

--- a/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
@@ -95,6 +95,9 @@ export function MenuCommandListener() {
     mutationFn: () => runnerHost.requestHostRespawn(),
     onSuccess: () => {
       toast.success("Host restart requested");
+      // Belt-and-braces: the dialog already closed optimistically at
+      // confirm time, but this guarantees the open flag can never survive
+      // settlement even if something else set it in between.
       setPendingHostRestart(false);
       if (traycerCli !== null) {
         void queryClient.invalidateQueries({
@@ -185,6 +188,21 @@ export function MenuCommandListener() {
           mutateInstallUpdate();
         },
         requestHostRestart: () => {
+          // A restart already in flight (from this or an earlier confirm)
+          // must not reopen the dialog - it would mount with
+          // `isPending=true`, which locks Cancel/Esc for the rest of that
+          // mutation's lifetime (the exact lockout this fix removed). Read
+          // the mutation cache directly (not a ref synced from
+          // `restartHostMutation.isPending`) - `isMutating` reflects
+          // `mutate()` the instant it's called, synchronously, with no
+          // render/effect delay for a queued native command to slip through.
+          if (
+            queryClient.isMutating({
+              mutationKey: runnerMutationKeys.requestHostRespawn(),
+            }) > 0
+          ) {
+            return;
+          }
           setPendingHostRestart(true);
         },
         reportIssue: () => {
@@ -206,6 +224,7 @@ export function MenuCommandListener() {
     openLogs,
     runnerHost,
     mutateInstallUpdate,
+    queryClient,
   ]);
 
   return (
@@ -217,7 +236,14 @@ export function MenuCommandListener() {
           if (!open) setPendingHostRestart(false);
         }}
         isPending={restartHostMutation.isPending}
-        onConfirm={() => restartHostMutation.mutate()}
+        onConfirm={() => {
+          // Close optimistically - see host-settings-panel.tsx for why. This
+          // surface's mutation can legitimately run up to ~180s with zero
+          // progress feedback, which is what made the un-dismissable dialog
+          // read as "stuck forever" in the field.
+          setPendingHostRestart(false);
+          restartHostMutation.mutate();
+        }}
       />
     </>
   );

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
@@ -403,4 +403,29 @@ describe("HostDoctorCard pending CLI upgrade", () => {
     fireEvent.click(button);
     expect(restartHost).not.toHaveBeenCalled();
   });
+
+  it("keeps fix buttons disabled until operation status resolves idle", async () => {
+    const operationStatus = Promise.withResolvers<HostOperationStatus | null>();
+    const restartHost = vi.fn(() => Promise.resolve());
+    const management = makeManagement({
+      runDoctor: () =>
+        Promise.resolve<HostDoctorReport>({
+          issues: [pendingUpgradeIssue()],
+          ranAt: "2026-05-15T00:00:00Z",
+        }),
+      restartHost,
+      getOperationStatus: () => operationStatus.promise,
+    });
+    renderCard(makeHostWithManagement(management));
+
+    const button = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /Restart host/i,
+    });
+    expect(button.disabled).toBe(true);
+
+    operationStatus.resolve(null);
+    await waitFor(() => {
+      expect(button.disabled).toBe(false);
+    });
+  });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
@@ -184,7 +184,7 @@ describe("HostDoctorCard pending CLI upgrade", () => {
     });
     renderCard(makeHostWithManagement(management));
 
-    const fixButton = await screen.findByRole("button", {
+    const fixButton = await screen.findByRole<HTMLButtonElement>("button", {
       name: /Free port \+ restart/i,
     });
     fireEvent.click(fixButton);
@@ -218,6 +218,10 @@ describe("HostDoctorCard pending CLI upgrade", () => {
     // fix, `isPending` kept this dialog open with Cancel/Esc disabled for the
     // entire restart budget.
     expect(screen.queryByRole("dialog")).toBeNull();
+    expect(fixButton.disabled).toBe(true);
+    fireEvent.click(fixButton);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(freePortAndRestart).toHaveBeenCalledTimes(1);
   });
 
   it("allows Free Port + Restart when PID and process name are unknown", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
@@ -13,6 +13,7 @@ import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import type {
   HostDoctorIssue,
   HostDoctorReport,
+  HostOperationStatus,
   FreePortAndRestartInput,
   IHostManagement,
   IRunnerHost,
@@ -33,6 +34,7 @@ interface ManagementOverrides {
   readonly freePortAndRestart?: (
     input: FreePortAndRestartInput,
   ) => Promise<FreePortAndRestartInput>;
+  readonly getOperationStatus?: () => Promise<HostOperationStatus | null>;
 }
 
 function makeManagement(overrides: ManagementOverrides): IHostManagement {
@@ -56,7 +58,8 @@ function makeManagement(overrides: ManagementOverrides): IHostManagement {
     ensureHost: vi.fn(notImplemented("ensureHost")),
     deregisterService: vi.fn(notImplemented("deregisterService")),
     registryCheck: vi.fn(notImplemented("registryCheck")),
-    getOperationStatus: vi.fn(() => Promise.resolve(null)),
+    getOperationStatus:
+      overrides.getOperationStatus ?? vi.fn(() => Promise.resolve(null)),
     freePortAndRestart:
       overrides.freePortAndRestart ?? vi.fn((input) => Promise.resolve(input)),
     cliManifest: vi.fn(() => Promise.resolve(null)),
@@ -358,5 +361,43 @@ describe("HostDoctorCard pending CLI upgrade", () => {
     await waitFor(() => {
       expect(restartHost).toHaveBeenCalledTimes(1);
     });
+  });
+
+  // Review follow-up finding: Doctor's fix actions (including Free Port +
+  // Restart) must respect the same cross-surface operation-status signal
+  // Settings → Host reads, since a Doctor fix racing a tracked
+  // restart/install/update elsewhere interleaves two independent
+  // stop/kill/start sequences.
+  it("disables fix buttons while a tracked host operation is active elsewhere", async () => {
+    const restartHost = vi.fn(() => Promise.resolve());
+    const activeStatus: HostOperationStatus = {
+      operationId: "op-elsewhere",
+      kind: "install",
+      stage: null,
+      percent: null,
+      bytes: null,
+      totalBytes: null,
+      message: null,
+      startedAt: "2026-05-15T00:00:00Z",
+    };
+    const management = makeManagement({
+      runDoctor: () =>
+        Promise.resolve<HostDoctorReport>({
+          issues: [pendingUpgradeIssue()],
+          ranAt: "2026-05-15T00:00:00Z",
+        }),
+      restartHost,
+      getOperationStatus: () => Promise.resolve(activeStatus),
+    });
+    renderCard(makeHostWithManagement(management));
+
+    const button = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /Restart host/i,
+    });
+    await waitFor(() => {
+      expect(button.disabled).toBe(true);
+    });
+    fireEvent.click(button);
+    expect(restartHost).not.toHaveBeenCalled();
   });
 });

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
@@ -154,10 +154,9 @@ describe("HostDoctorCard pending CLI upgrade", () => {
     expect(screen.getByRole("button", { name: /Restart host/i })).toBeTruthy();
   });
 
-  it("opens the Free Port + Restart confirmation when PORT_CONFLICT carries process identity", async () => {
-    const freePortAndRestart = vi.fn((input: FreePortAndRestartInput) =>
-      Promise.resolve(input),
-    );
+  it("closes the Free Port + Restart confirmation while its restart is still pending", async () => {
+    const pendingRestart = Promise.withResolvers<FreePortAndRestartInput>();
+    const freePortAndRestart = vi.fn(() => pendingRestart.promise);
     const issue: HostDoctorIssue = {
       code: "PORT_CONFLICT",
       severity: "error",
@@ -215,6 +214,10 @@ describe("HostDoctorCard pending CLI upgrade", () => {
       pid: 4321,
       processName: "node",
     });
+    // The subprocess promise is intentionally unresolved here. Before the
+    // fix, `isPending` kept this dialog open with Cancel/Esc disabled for the
+    // entire restart budget.
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   it("allows Free Port + Restart when PID and process name are unknown", async () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
@@ -62,6 +62,46 @@ describe("<HostSettingsPanel /> - mutation flows", () => {
     expect(toast.success).toHaveBeenCalledWith("Host restart requested");
   });
 
+  it("closes the restart dialog optimistically on confirm - before the mutation settles - and still surfaces a later rejection via toast", async () => {
+    let rejectRestart: (error: Error) => void = () => undefined;
+    const restartHost = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectRestart = reject;
+        }),
+    );
+    const { management } = makeManagement({ restartHost });
+
+    renderPanel(makeHost(management, makeLocalHostSnapshot()));
+
+    const restartButton = await waitForButton("Restart");
+    fireEvent.click(restartButton);
+
+    await screen.findByTestId("confirm-destructive-dialog");
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    // Closes synchronously at confirm time - the mutation below is still
+    // pending (never resolved/rejected yet), so this proves the dialog
+    // doesn't wait on onSuccess/onError to close.
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+    await waitFor(() => {
+      expect(restartHost).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      rejectRestart(new Error("host restart failed"));
+    });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Couldn't restart host",
+        expect.objectContaining({ description: "host restart failed" }),
+      );
+    });
+    // The failure must not resurrect the dialog.
+    expect(screen.queryByTestId("confirm-destructive-dialog")).toBeNull();
+  });
+
   it("saves a custom host name from the Host settings page", async () => {
     const setHostName = vi.fn((input: { readonly customName: string | null }) =>
       Promise.resolve({

--- a/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
@@ -236,7 +236,14 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
       }}
       onConfirmFreePort={() => {
         if (freePortPrompt !== null) {
-          freePortMutation.mutate(freePortPrompt);
+          // Capture the destructive target, then close optimistically before
+          // starting the restart. This operation shares the platform-wide
+          // restart budget and can legitimately run for minutes; keeping the
+          // dialog tied to `isPending` would lock every dismissal path for
+          // that entire window.
+          const input = freePortPrompt;
+          setFreePortPrompt(null);
+          freePortMutation.mutate(input);
         }
       }}
     />

--- a/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
@@ -222,7 +222,9 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
       recurrence={recurrenceModel.recurrence}
       reportFetching={reportFetching}
       fixPendingCode={fixMutation.isPending ? fixMutation.variables.code : null}
-      externalOperationActive={sharedOperationActive}
+      externalOperationActive={
+        sharedOperationActive || freePortMutation.isPending
+      }
       freePortPrompt={freePortPrompt}
       freePortPending={freePortMutation.isPending}
       onFix={handleFix}

--- a/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
@@ -26,11 +26,11 @@ import {
 } from "@/lib/query-keys/runner-mutation-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { useRunnerHost } from "@/providers/use-runner-host";
+import { useRunnerHostOperationStatusQuery } from "@/hooks/runner/use-runner-host-operation-status-query";
 import type {
   HostDoctorIssue,
   HostDoctorReport,
   FreePortAndRestartInput,
-  HostOperationStatus,
   IHostManagement,
 } from "@traycer-clients/shared/platform/runner-host";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
@@ -81,13 +81,8 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
   // fix racing a tracked restart-class operation interleaves two independent
   // stop/kill/start sequences (worst on Windows, where one can kill the
   // other's freshly started host).
-  const { data: operationStatus } = useQuery(
-    queryOptions<HostOperationStatus | null>({
-      queryKey: runnerQueryKeys.hostOperationStatus(management),
-      queryFn: () => management.getOperationStatus(),
-      staleTime: Infinity,
-    }),
-  );
+  const { data: operationStatus } =
+    useRunnerHostOperationStatusQuery(management);
   const sharedOperationActive =
     operationStatus !== undefined && operationStatus !== null;
 

--- a/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
@@ -83,8 +83,10 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
   // other's freshly started host).
   const { data: operationStatus } =
     useRunnerHostOperationStatusQuery(management);
-  const sharedOperationActive =
-    operationStatus !== undefined && operationStatus !== null;
+  // Fail closed while the initial status read is unresolved: `null` is the
+  // only authoritative idle state. Otherwise Doctor could briefly enable a
+  // destructive fix while another surface's operation is still being read.
+  const sharedOperationActive = operationStatus !== null;
 
   const {
     data: report,

--- a/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
@@ -30,6 +30,7 @@ import type {
   HostDoctorIssue,
   HostDoctorReport,
   FreePortAndRestartInput,
+  HostOperationStatus,
   IHostManagement,
 } from "@traycer-clients/shared/platform/runner-host";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
@@ -73,6 +74,22 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
   );
   const [freePortPrompt, setFreePortPrompt] =
     useState<FreePortAndRestartInput | null>(null);
+
+  // Same cross-surface single-flight signal Settings → Host reads (Ticket:
+  // host-update-race-conditions) - a tracked restart/install/update started
+  // from ANOTHER surface must gate Doctor's fix actions too, since a Doctor
+  // fix racing a tracked restart-class operation interleaves two independent
+  // stop/kill/start sequences (worst on Windows, where one can kill the
+  // other's freshly started host).
+  const { data: operationStatus } = useQuery(
+    queryOptions<HostOperationStatus | null>({
+      queryKey: runnerQueryKeys.hostOperationStatus(management),
+      queryFn: () => management.getOperationStatus(),
+      staleTime: Infinity,
+    }),
+  );
+  const sharedOperationActive =
+    operationStatus !== undefined && operationStatus !== null;
 
   const {
     data: report,
@@ -208,6 +225,7 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
       recurrence={recurrenceModel.recurrence}
       reportFetching={reportFetching}
       fixPendingCode={fixMutation.isPending ? fixMutation.variables.code : null}
+      externalOperationActive={sharedOperationActive}
       freePortPrompt={freePortPrompt}
       freePortPending={freePortMutation.isPending}
       onFix={handleFix}

--- a/clients/gui-app/src/components/settings/panels/host-doctor-issue-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-issue-card.tsx
@@ -15,13 +15,21 @@ interface HostDoctorIssueCardProps {
   readonly expanded: boolean;
   readonly recurrenceLocked: boolean;
   readonly fixPendingCode: string | null;
+  readonly externalOperationActive: boolean;
   readonly onFix: (issue: HostDoctorIssue) => void;
   readonly onToggle: (code: string) => void;
 }
 
 export function HostDoctorIssueCard(props: HostDoctorIssueCardProps) {
-  const { issue, expanded, recurrenceLocked, fixPendingCode, onFix, onToggle } =
-    props;
+  const {
+    issue,
+    expanded,
+    recurrenceLocked,
+    fixPendingCode,
+    externalOperationActive,
+    onFix,
+    onToggle,
+  } = props;
   const issueFixPending = fixPendingCode === issue.code;
   return (
     <div
@@ -49,7 +57,11 @@ export function HostDoctorIssueCard(props: HostDoctorIssueCardProps) {
               <Button
                 variant="default"
                 size="sm"
-                disabled={recurrenceLocked || fixPendingCode !== null}
+                disabled={
+                  recurrenceLocked ||
+                  fixPendingCode !== null ||
+                  externalOperationActive
+                }
                 onClick={() => onFix(issue)}
               >
                 {issueFixPending ? (

--- a/clients/gui-app/src/components/settings/panels/host-doctor-report-content.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-report-content.tsx
@@ -16,6 +16,7 @@ interface HostDoctorReportContentProps {
   readonly recurrence: RecurrenceState;
   readonly reportFetching: boolean;
   readonly fixPendingCode: string | null;
+  readonly externalOperationActive: boolean;
   readonly freePortPrompt: FreePortAndRestartInput | null;
   readonly freePortPending: boolean;
   readonly onFix: (issue: HostDoctorIssue) => void;
@@ -32,6 +33,7 @@ export function HostDoctorReportContent(props: HostDoctorReportContentProps) {
     recurrence,
     reportFetching,
     fixPendingCode,
+    externalOperationActive,
     freePortPrompt,
     freePortPending,
     onFix,
@@ -53,6 +55,7 @@ export function HostDoctorReportContent(props: HostDoctorReportContentProps) {
           expanded={expandedCodes.has(issue.code)}
           recurrenceLocked={recurrence.locked}
           fixPendingCode={fixPendingCode}
+          externalOperationActive={externalOperationActive}
           onFix={onFix}
           onToggle={onToggleIssue}
         />

--- a/clients/gui-app/src/components/settings/panels/host-settings-panel-model.ts
+++ b/clients/gui-app/src/components/settings/panels/host-settings-panel-model.ts
@@ -210,6 +210,10 @@ export function formatProgressKind(kind: HostOperationKind): string {
       return "Registering service";
     case "ensure":
       return "Setting up host";
+    case "restart":
+      return "Restarting host";
+    case "free-port-and-restart":
+      return "Freeing port and restarting host";
   }
 }
 

--- a/clients/gui-app/src/components/settings/panels/host-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-panel.tsx
@@ -305,7 +305,6 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
     mutationKey: runnerMutationKeys.hostRestart(),
     mutationFn: () => management.restartHost(),
     onSuccess: () => {
-      setRestartConfirmOpen(false);
       toast.success("Host restart requested");
       void queryClient.invalidateQueries({
         queryKey: runnerQueryKeys.hostInstalledRecord(management),
@@ -313,7 +312,6 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
       invalidate();
     },
     onError: (err) => {
-      setRestartConfirmOpen(false);
       toastFromRunnerError(err, "Couldn't restart host");
     },
   });
@@ -400,6 +398,11 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
     (operationStatus !== undefined &&
       operationStatus !== null &&
       operationStatus.kind === "register-service");
+  const restartPending =
+    restartMutation.isPending ||
+    (operationStatus !== undefined &&
+      operationStatus !== null &&
+      operationStatus.kind === "restart");
 
   const status = deriveStatus(localHost, installedRecord);
   const statusPending = status === undefined;
@@ -444,7 +447,7 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
         pending={statusPending}
         anyPending={anyPending}
         installPending={installPending}
-        restartPending={restartMutation.isPending}
+        restartPending={restartPending}
         onInstall={() => installMutation.mutate(null)}
         onRestart={() => setRestartConfirmOpen(true)}
         onOpenDoctor={() => setDoctorOpen(true)}
@@ -455,7 +458,14 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
           if (!open) setRestartConfirmOpen(false);
         }}
         isPending={restartMutation.isPending}
-        onConfirm={() => restartMutation.mutate()}
+        onConfirm={() => {
+          // Close optimistically instead of waiting for onSuccess/onError -
+          // the mutation can legitimately run tens of seconds, and holding
+          // the dialog open+locked for that whole window is what made it
+          // read as "stuck". Progress/failure still surface via toast.
+          setRestartConfirmOpen(false);
+          restartMutation.mutate();
+        }}
       />
       {status?.state === "not-installed" ? null : (
         <UpdatesRow

--- a/clients/gui-app/src/components/settings/panels/host-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-panel.tsx
@@ -36,13 +36,13 @@ import {
 } from "@/lib/query-keys/runner-mutation-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
 import { useRunnerHost } from "@/providers/use-runner-host";
+import { useRunnerHostOperationStatusQuery } from "@/hooks/runner/use-runner-host-operation-status-query";
 import { useHostUpdateBannerStore } from "@/stores/settings/host-update-banner-store";
 import type {
   CliInstallManifestSnapshot,
   HostAvailableSnapshot,
   HostInstalledRecord,
   HostNameSettings,
-  HostOperationStatus,
   HostRegistryUpdateState,
   IHostManagement,
   IRunnerHost,
@@ -178,13 +178,8 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
   // auto-update reconciler) actually started the operation - so this panel no
   // longer needs its own per-mutation `onProgress` callback or local
   // `progress` state.
-  const { data: operationStatus } = useQuery(
-    queryOptions<HostOperationStatus | null>({
-      queryKey: runnerQueryKeys.hostOperationStatus(management),
-      queryFn: () => management.getOperationStatus(),
-      staleTime: Infinity,
-    }),
-  );
+  const { data: operationStatus } =
+    useRunnerHostOperationStatusQuery(management);
   const sharedOperationActive =
     operationStatus !== undefined && operationStatus !== null;
   const progress: HostProgressState | null =

--- a/clients/gui-app/src/hooks/runner/use-runner-host-operation-status-query.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-host-operation-status-query.ts
@@ -1,0 +1,27 @@
+import {
+  queryOptions,
+  useQuery,
+  type UseQueryResult,
+} from "@tanstack/react-query";
+import type {
+  HostOperationStatus,
+  IHostManagement,
+} from "@traycer-clients/shared/platform/runner-host";
+import { runnerQueryKeys } from "@/lib/query-keys";
+
+/**
+ * Reads the canonical cross-surface host-operation snapshot. The status is
+ * event-sourced by HostOperationStatusListener, so every consumer must share
+ * this exact key and treat cached data as authoritative between push events.
+ */
+export function useRunnerHostOperationStatusQuery(
+  management: IHostManagement,
+): UseQueryResult<HostOperationStatus | null> {
+  return useQuery(
+    queryOptions<HostOperationStatus | null>({
+      queryKey: runnerQueryKeys.hostOperationStatus(management),
+      queryFn: () => management.getOperationStatus(),
+      staleTime: Infinity,
+    }),
+  );
+}

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -766,7 +766,12 @@ export interface HostProgressEvent {
 }
 
 export type HostOperationKind =
-  "install" | "update" | "register-service" | "ensure";
+  | "install"
+  | "update"
+  | "register-service"
+  | "ensure"
+  | "restart"
+  | "free-port-and-restart";
 
 /**
  * Canonical cross-surface snapshot of the single host mutation currently

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -5,6 +5,12 @@ import {
   readHostPidMetadata,
   removeHostPidMetadata,
 } from "../../host/pid-metadata";
+import {
+  WINDOWS_PROCESS_SCAN_TIMEOUT_MS,
+  WINDOWS_SCHTASKS_END_TIMEOUT_MS,
+  WINDOWS_SCHTASKS_RUN_TIMEOUT_MS,
+  WINDOWS_TASKKILL_TIMEOUT_MS,
+} from "@traycer/protocol/host/lifecycle-constants";
 import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
 import { isProcessAlive } from "../../store/cli-lock";
 import type { CliInvocation } from "../cli-binary";
@@ -156,7 +162,7 @@ async function stopService(
   await run("schtasks", ["/End", "/TN", windowsTaskName(label)], {
     env: undefined,
     cwd: undefined,
-    timeoutMs: 30_000,
+    timeoutMs: WINDOWS_SCHTASKS_END_TIMEOUT_MS,
     tolerateNonZeroExit: true,
   });
   await killHostProcessTree(label, run);
@@ -191,7 +197,7 @@ async function killHostProcessTree(
       run("taskkill", ["/T", "/F", "/PID", String(pid)], {
         env: undefined,
         cwd: undefined,
-        timeoutMs: 30_000,
+        timeoutMs: WINDOWS_TASKKILL_TIMEOUT_MS,
         tolerateNonZeroExit: true,
       }).catch(() => undefined),
     ),
@@ -203,7 +209,7 @@ async function startService(label: ServiceLabel): Promise<void> {
     await runCommand("schtasks", ["/Run", "/TN", windowsTaskName(label)], {
       env: undefined,
       cwd: undefined,
-      timeoutMs: 30_000,
+      timeoutMs: WINDOWS_SCHTASKS_RUN_TIMEOUT_MS,
       tolerateNonZeroExit: false,
     });
   } catch (cause) {
@@ -224,7 +230,7 @@ async function restartService(
   await run("schtasks", ["/End", "/TN", taskName], {
     env: undefined,
     cwd: undefined,
-    timeoutMs: 30_000,
+    timeoutMs: WINDOWS_SCHTASKS_END_TIMEOUT_MS,
     tolerateNonZeroExit: true,
   });
   // Reap the orphaned host tree before re-running, otherwise the old node keeps
@@ -234,7 +240,7 @@ async function restartService(
     await run("schtasks", ["/Run", "/TN", taskName], {
       env: undefined,
       cwd: undefined,
-      timeoutMs: 30_000,
+      timeoutMs: WINDOWS_SCHTASKS_RUN_TIMEOUT_MS,
       tolerateNonZeroExit: false,
     });
   } catch (cause) {
@@ -280,7 +286,7 @@ async function findSlotProcessIds(
       {
         env: undefined,
         cwd: undefined,
-        timeoutMs: 10_000,
+        timeoutMs: WINDOWS_PROCESS_SCAN_TIMEOUT_MS,
         tolerateNonZeroExit: true,
       },
     );

--- a/protocol/src/host/lifecycle-constants.ts
+++ b/protocol/src/host/lifecycle-constants.ts
@@ -18,3 +18,52 @@ export const SHUTDOWN_FORCE_EXIT_MS = 30_000;
  * that is in fact guaranteed to exit moments later.
  */
 export const STOP_EXIT_GRACE_MARGIN_MS = 2_000;
+
+/**
+ * Per-step timeouts for the Windows Scheduled-Task restart sequence
+ * (`traycer-cli/src/service/platforms/windows.ts`: `stopService` /
+ * `killHostProcessTree` / `startService` / `restartService`). Windows has no
+ * single graceful-stop signal like launchd SIGTERM - `restart` runs four
+ * independently-capped steps in sequence: `schtasks /End`, a PowerShell
+ * process-tree scan, `taskkill` on any surviving pids, then `schtasks /Run`.
+ * Exported here (not left as local literals in `windows.ts`) so the outer
+ * budget below can be derived from the platform's actual worst case instead
+ * of duplicating these numbers as a second, driftable magic number.
+ */
+export const WINDOWS_SCHTASKS_END_TIMEOUT_MS = 30_000;
+export const WINDOWS_PROCESS_SCAN_TIMEOUT_MS = 10_000;
+export const WINDOWS_TASKKILL_TIMEOUT_MS = 30_000;
+export const WINDOWS_SCHTASKS_RUN_TIMEOUT_MS = 30_000;
+
+/**
+ * Worst-case cumulative duration of a legitimate (non-failing) Windows
+ * restart: every step in the sequence runs right up against its own
+ * timeout and still succeeds. Not a typical duration - a bound.
+ */
+export const WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS =
+  WINDOWS_SCHTASKS_END_TIMEOUT_MS +
+  WINDOWS_PROCESS_SCAN_TIMEOUT_MS +
+  WINDOWS_TASKKILL_TIMEOUT_MS +
+  WINDOWS_SCHTASKS_RUN_TIMEOUT_MS;
+
+/**
+ * Budget for a full `traycer host restart` subprocess as invoked by Desktop
+ * (Settings, tray, and the native-menu respawn path all route through this
+ * one constant). `host restart` runs stop-then-start, and a caller-side
+ * timeout shorter than the platform's own worst-case sequence SIGKILLs the
+ * CLI mid-restart - after stop succeeds but before start runs - leaving the
+ * host down. That is exactly what a desktop-side 10s cap against macOS's 32s
+ * stop-grace used to do.
+ *
+ * Derived as the max of every platform's worst case plus margin, not just
+ * macOS's: on macOS the stop phase alone waits up to `SHUTDOWN_FORCE_EXIT_MS
+ * + STOP_EXIT_GRACE_MARGIN_MS`; on Windows the four-step sequence above can
+ * legitimately take `WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS`, which is larger.
+ * A budget sized only for macOS would SIGKILL a slow-but-successful Windows
+ * restart during its final `schtasks /Run` step - the same class of bug this
+ * constant exists to prevent, just on the other platform.
+ */
+export const HOST_RESTART_SUBPROCESS_TIMEOUT_MS = Math.max(
+  SHUTDOWN_FORCE_EXIT_MS + STOP_EXIT_GRACE_MARGIN_MS + 60_000,
+  WINDOWS_RESTART_SEQUENCE_TIMEOUT_MS + 30_000,
+);


### PR DESCRIPTION
## Summary

- close long-running restart confirmations immediately on Settings, system tray, native menu, and Doctor's free-port-and-restart surface; report completion through toasts and synchronously ignore attempts to reopen matching restart dialogs while their mutation is pending
- propagate `HostLifecycle.respawn()` failures so callers no longer show false success when the host remains down
- replace the desktop caller's 10-second restart cap with a shared 130-second budget derived from the platform worst case, and use it for Settings/tray restarts, native-menu respawn, and Doctor's free-port-and-restart action
- route both restart-class operations through the existing `trackHostOperation` single-flight guard, expose their operation kinds for cross-window status banners/gating, disable Doctor fix actions while another host operation is active, and make the preload operation-kind allowlist exhaustively type-checked

## Why

The confirmation dialog disabled every dismissal path for the full mutation lifetime. A native-menu restart can legitimately take 60–180 seconds, so the UI appeared permanently stuck. The shorter CLI path had a second failure mode: its 10-second subprocess cap was shorter than the host's graceful-stop budget, which could terminate the CLI after stop but before start and leave the host down. The native-menu lifecycle path also swallowed restart failures and resolved successfully.

## Validation

- [x] `bun run compile` in `protocol`, `clients/shared`, `clients/traycer-cli`, `clients/desktop`, and `clients/gui-app`
- [x] focused desktop regressions: 4 files, 72 tests
- [x] focused GUI regressions: 4 files, 36 tests
- [x] focused Windows CLI regressions: 1 file, 9 tests
- [x] React Doctor changed-scope scan: no issues
- [x] pre-commit affected-workspace lint, format, build, compile, hygiene, and DCO checks
- [x] three-round fresh-agent review; the final preload allowlist finding is fixed and covered by a dedicated preload test
