### PR TITLE
fix(gui-app): hide closed app-wide stream client during rebuild

### DIFF
--- a/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
@@ -642,7 +642,7 @@ describe("useGitListChangedFilesSubscription", () => {
     expect(session.closed).toBe(true);
   });
 
-  it("a closed stream client surfaces an error via the inert session", async () => {
+  it("waits for a replacement client and recovers without surfacing CLIENT_CLOSED", async () => {
     const closedClient = new WsStreamClient<HostStreamRpcRegistry>({
       registry: hostStreamRpcRegistry,
       endpoint: () => null,
@@ -665,15 +665,16 @@ describe("useGitListChangedFilesSubscription", () => {
     const warnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
+    let streamClient: WsStreamClient<HostStreamRpcRegistry> = closedClient;
     const closedWrapper = ({ children }: { children: ReactNode }) => (
       <QueryClientProvider client={queryClient}>
-        <StreamRuntimeContext.Provider value={{ wsStreamClient: closedClient }}>
+        <StreamRuntimeContext.Provider value={{ wsStreamClient: streamClient }}>
           {children}
         </StreamRuntimeContext.Provider>
       </QueryClientProvider>
     );
 
-    const { result } = renderHook(
+    const { result, rerender } = renderHook(
       () =>
         useGitListChangedFilesSubscription({
           hostId: "host1",
@@ -684,18 +685,154 @@ describe("useGitListChangedFilesSubscription", () => {
       { wrapper: closedWrapper },
     );
 
+    expect(result.current.error).toBeNull();
+    expect(result.current.isPending).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    const replacementClient = new MockWsStreamClient();
+    streamClient = replacementClient;
+    rerender();
+
     await waitFor(() => {
-      expect(result.current.error).not.toBeNull();
+      expect(replacementClient.subscribeCallCount).toBe(1);
     });
-    const error = result.current.error;
-    if (error === null || error.type !== "error") {
-      throw new Error("Expected an error event");
+    const replacementSession = replacementClient.getSession(
+      "git.subscribeStatus",
+      {
+        hostId: "host1",
+        runningDir: "/repo",
+        ignoreWhitespace: false,
+      },
+    );
+    if (replacementSession === undefined) {
+      throw new Error("Replacement session should exist");
     }
-    expect(error.isFatal).toBe(true);
-    expect(error.message).toContain("CLIENT_CLOSED");
+    replacementSession.emitFrame(
+      {
+        type: "snapshot",
+        runningDir: "/repo",
+        headSha: "replacement-head",
+        branch: "main",
+        files: [],
+        fingerprint: "replacement-fingerprint",
+        repoMode: "normal",
+        repoState: { kind: "clean" },
+        pollStartedAtMs: 1_000,
+      },
+      null,
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.headSha).toBe("replacement-head");
+    });
+    expect(result.current.error).toBeNull();
     expect(result.current.isPending).toBe(false);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
     warnSpy.mockRestore();
+  });
+
+  it("detaches when the live client closes underneath and rebinds to a replacement", async () => {
+    const liveClient = new MockWsStreamClient();
+    let streamClient: WsStreamClient<HostStreamRpcRegistry> = liveClient;
+    const swappableWrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <StreamRuntimeContext.Provider value={{ wsStreamClient: streamClient }}>
+          {children}
+        </StreamRuntimeContext.Provider>
+      </QueryClientProvider>
+    );
+
+    const { result, rerender } = renderHook(
+      () =>
+        useGitListChangedFilesSubscription({
+          hostId: "host1",
+          runningDir: "/repo",
+          ignoreWhitespace: false,
+          enabled: true,
+        }),
+      { wrapper: swappableWrapper },
+    );
+
+    await waitFor(() => {
+      expect(liveClient.subscribeCallCount).toBe(1);
+    });
+    const liveSession = liveClient.getSession("git.subscribeStatus", {
+      hostId: "host1",
+      runningDir: "/repo",
+      ignoreWhitespace: false,
+    });
+    if (liveSession === undefined) {
+      throw new Error("Live session should exist");
+    }
+
+    liveSession.emitFrame(
+      {
+        type: "snapshot",
+        runningDir: "/repo",
+        headSha: "initial-head",
+        branch: "main",
+        files: [],
+        fingerprint: "initial-fingerprint",
+        repoMode: "normal",
+        repoState: { kind: "clean" },
+        pollStartedAtMs: 1_000,
+      },
+      null,
+    );
+    await waitFor(() => {
+      expect(result.current.data?.headSha).toBe("initial-head");
+    });
+
+    // Close the LIVE client underneath the consumer with NO parent rerender.
+    // The `onClosed` subscription in `useWsStreamClient` must notify on its own,
+    // flip the served snapshot to null, and drive the consumer to detach - its
+    // effect cleanup closes the session - WITHOUT surfacing CLIENT_CLOSED. If
+    // the subscribe branch were dropped, nothing would re-read the snapshot on
+    // this close and the consumer would cling to the dead client's session.
+    act(() => {
+      liveClient.close("closed-underneath");
+    });
+
+    expect(liveSession.closed).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    // A replacement client reaches context (the provider's liveness rebuild).
+    const replacementClient = new MockWsStreamClient();
+    streamClient = replacementClient;
+    rerender();
+
+    await waitFor(() => {
+      expect(replacementClient.subscribeCallCount).toBe(1);
+    });
+    const replacementSession = replacementClient.getSession(
+      "git.subscribeStatus",
+      {
+        hostId: "host1",
+        runningDir: "/repo",
+        ignoreWhitespace: false,
+      },
+    );
+    if (replacementSession === undefined) {
+      throw new Error("Replacement session should exist");
+    }
+    replacementSession.emitFrame(
+      {
+        type: "snapshot",
+        runningDir: "/repo",
+        headSha: "replacement-head",
+        branch: "main",
+        files: [],
+        fingerprint: "replacement-fingerprint",
+        repoMode: "normal",
+        repoState: { kind: "clean" },
+        pollStartedAtMs: 2_000,
+      },
+      null,
+    );
+
+    await waitFor(() => {
+      expect(result.current.data?.headSha).toBe("replacement-head");
+    });
+    expect(result.current.error).toBeNull();
   });
 
   it("a rebuilt stream client gets a fresh subscription (per-client keying)", async () => {

--- a/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
+++ b/clients/gui-app/src/hooks/git/__tests__/use-git-list-changed-files-subscription.test.tsx
@@ -31,6 +31,7 @@ import { __resetRichSlotOrderingForTesting } from "@/lib/git/git-rich-slot-order
 import {
   useGitListChangedFilesSubscription,
   __resetSubscriptionsForTesting,
+  type GitListChangedFilesSubscriptionResult,
 } from "../use-git-list-changed-files-subscription";
 
 // Mock stream session for testing.
@@ -147,6 +148,72 @@ class MockWsStreamClient extends WsStreamClient<HostStreamRpcRegistry> {
   notifySupportChanged(): void {
     this.supportListeners.forEach((listener) => listener());
   }
+}
+
+function makeSwappableStreamWrapper(
+  queryClient: QueryClient,
+  initialStreamClient: WsStreamClient<HostStreamRpcRegistry>,
+) {
+  const holder: { current: WsStreamClient<HostStreamRpcRegistry> } = {
+    current: initialStreamClient,
+  };
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <StreamRuntimeContext.Provider value={{ wsStreamClient: holder.current }}>
+        {children}
+      </StreamRuntimeContext.Provider>
+    </QueryClientProvider>
+  );
+  return { wrapper, holder };
+}
+
+// Shared "swap the context to a fresh replacement client, then prove it takes
+// over the subscription and delivers a snapshot without surfacing an error"
+// flow used by the replacement-recovery tests below.
+async function swapToReplacementClientAndAssertHeadSha(
+  holder: { current: WsStreamClient<HostStreamRpcRegistry> },
+  rerender: () => void,
+  result: { readonly current: GitListChangedFilesSubscriptionResult },
+  headSha: string,
+) {
+  const replacementClient = new MockWsStreamClient();
+  holder.current = replacementClient;
+  rerender();
+
+  await waitFor(() => {
+    expect(replacementClient.subscribeCallCount).toBe(1);
+  });
+  const replacementSession = replacementClient.getSession(
+    "git.subscribeStatus",
+    {
+      hostId: "host1",
+      runningDir: "/repo",
+      ignoreWhitespace: false,
+    },
+  );
+  if (replacementSession === undefined) {
+    throw new Error("Replacement session should exist");
+  }
+  replacementSession.emitFrame(
+    {
+      type: "snapshot",
+      runningDir: "/repo",
+      headSha,
+      branch: "main",
+      files: [],
+      fingerprint: `${headSha}-fingerprint`,
+      repoMode: "normal",
+      repoState: { kind: "clean" },
+      pollStartedAtMs: 1_000,
+    },
+    null,
+  );
+
+  await waitFor(() => {
+    expect(result.current.data?.headSha).toBe(headSha);
+  });
+  expect(result.current.error).toBeNull();
+  expect(result.current.isPending).toBe(false);
 }
 
 describe("useGitListChangedFilesSubscription", () => {
@@ -665,13 +732,9 @@ describe("useGitListChangedFilesSubscription", () => {
     const warnSpy = vi
       .spyOn(console, "warn")
       .mockImplementation(() => undefined);
-    let streamClient: WsStreamClient<HostStreamRpcRegistry> = closedClient;
-    const closedWrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>
-        <StreamRuntimeContext.Provider value={{ wsStreamClient: streamClient }}>
-          {children}
-        </StreamRuntimeContext.Provider>
-      </QueryClientProvider>
+    const { wrapper, holder } = makeSwappableStreamWrapper(
+      queryClient,
+      closedClient,
     );
 
     const { result, rerender } = renderHook(
@@ -682,63 +745,27 @@ describe("useGitListChangedFilesSubscription", () => {
           ignoreWhitespace: false,
           enabled: true,
         }),
-      { wrapper: closedWrapper },
+      { wrapper },
     );
 
     expect(result.current.error).toBeNull();
     expect(result.current.isPending).toBe(true);
     expect(warnSpy).not.toHaveBeenCalled();
 
-    const replacementClient = new MockWsStreamClient();
-    streamClient = replacementClient;
-    rerender();
-
-    await waitFor(() => {
-      expect(replacementClient.subscribeCallCount).toBe(1);
-    });
-    const replacementSession = replacementClient.getSession(
-      "git.subscribeStatus",
-      {
-        hostId: "host1",
-        runningDir: "/repo",
-        ignoreWhitespace: false,
-      },
+    await swapToReplacementClientAndAssertHeadSha(
+      holder,
+      rerender,
+      result,
+      "replacement-head",
     );
-    if (replacementSession === undefined) {
-      throw new Error("Replacement session should exist");
-    }
-    replacementSession.emitFrame(
-      {
-        type: "snapshot",
-        runningDir: "/repo",
-        headSha: "replacement-head",
-        branch: "main",
-        files: [],
-        fingerprint: "replacement-fingerprint",
-        repoMode: "normal",
-        repoState: { kind: "clean" },
-        pollStartedAtMs: 1_000,
-      },
-      null,
-    );
-
-    await waitFor(() => {
-      expect(result.current.data?.headSha).toBe("replacement-head");
-    });
-    expect(result.current.error).toBeNull();
-    expect(result.current.isPending).toBe(false);
     warnSpy.mockRestore();
   });
 
   it("detaches when the live client closes underneath and rebinds to a replacement", async () => {
     const liveClient = new MockWsStreamClient();
-    let streamClient: WsStreamClient<HostStreamRpcRegistry> = liveClient;
-    const swappableWrapper = ({ children }: { children: ReactNode }) => (
-      <QueryClientProvider client={queryClient}>
-        <StreamRuntimeContext.Provider value={{ wsStreamClient: streamClient }}>
-          {children}
-        </StreamRuntimeContext.Provider>
-      </QueryClientProvider>
+    const { wrapper, holder } = makeSwappableStreamWrapper(
+      queryClient,
+      liveClient,
     );
 
     const { result, rerender } = renderHook(
@@ -749,7 +776,7 @@ describe("useGitListChangedFilesSubscription", () => {
           ignoreWhitespace: false,
           enabled: true,
         }),
-      { wrapper: swappableWrapper },
+      { wrapper },
     );
 
     await waitFor(() => {
@@ -796,43 +823,12 @@ describe("useGitListChangedFilesSubscription", () => {
     expect(result.current.error).toBeNull();
 
     // A replacement client reaches context (the provider's liveness rebuild).
-    const replacementClient = new MockWsStreamClient();
-    streamClient = replacementClient;
-    rerender();
-
-    await waitFor(() => {
-      expect(replacementClient.subscribeCallCount).toBe(1);
-    });
-    const replacementSession = replacementClient.getSession(
-      "git.subscribeStatus",
-      {
-        hostId: "host1",
-        runningDir: "/repo",
-        ignoreWhitespace: false,
-      },
+    await swapToReplacementClientAndAssertHeadSha(
+      holder,
+      rerender,
+      result,
+      "replacement-head",
     );
-    if (replacementSession === undefined) {
-      throw new Error("Replacement session should exist");
-    }
-    replacementSession.emitFrame(
-      {
-        type: "snapshot",
-        runningDir: "/repo",
-        headSha: "replacement-head",
-        branch: "main",
-        files: [],
-        fingerprint: "replacement-fingerprint",
-        repoMode: "normal",
-        repoState: { kind: "clean" },
-        pollStartedAtMs: 2_000,
-      },
-      null,
-    );
-
-    await waitFor(() => {
-      expect(result.current.data?.headSha).toBe("replacement-head");
-    });
-    expect(result.current.error).toBeNull();
   });
 
   it("a rebuilt stream client gets a fresh subscription (per-client keying)", async () => {

--- a/clients/gui-app/src/lib/host/stream-runtime-context.ts
+++ b/clients/gui-app/src/lib/host/stream-runtime-context.ts
@@ -21,9 +21,30 @@ export const StreamRuntimeContext = createContext<StreamRuntimeBinding | null>(
   null,
 );
 
+/**
+ * Returns only a live app-wide stream client. A closed client is hidden
+ * immediately while `HostStreamProvider` rebuilds it, so consumers detach from
+ * dead sessions and rebind when the replacement reaches context.
+ */
 export function useWsStreamClient(): WsStreamClient<HostStreamRpcRegistry> | null {
   const value = use(StreamRuntimeContext);
-  return value === null ? null : value.wsStreamClient;
+  const client = value?.wsStreamClient ?? null;
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      if (client === null) {
+        return () => undefined;
+      }
+      return client.onClosed(callback);
+    },
+    [client],
+  );
+  const getSnapshot = useCallback(() => {
+    if (client === null || client.isClosed()) {
+      return null;
+    }
+    return client;
+  }, [client]);
+  return useSyncExternalStore(subscribe, getSnapshot, () => null);
 }
 
 // Both method-support readers ride the same `subscribeMethodSupport` store and
@@ -37,8 +58,7 @@ function useStreamMethodValue<T>(
     method: keyof HostStreamRpcRegistry & string,
   ) => T,
 ): T | null {
-  const value = use(StreamRuntimeContext);
-  const client = value?.wsStreamClient ?? null;
+  const client = useWsStreamClient();
   const subscribe = useCallback(
     (callback: () => void) => {
       if (client === null) {

--- a/clients/gui-app/src/lib/host/stream-runtime.tsx
+++ b/clients/gui-app/src/lib/host/stream-runtime.tsx
@@ -88,15 +88,14 @@ export function HostStreamProvider(props: HostStreamProviderProps): ReactNode {
         binding !== null && binding.hostClient.getActiveHost() !== null,
     });
   }, [binding, readiness.hostId, value]);
-  // Liveness guard: the context must never keep serving a CLOSED client -
-  // every subscribe on one degrades to an inert session and its consumer
-  // hangs in a pending state until the window reloads (the stuck git-diff
-  // skeleton incident). Legitimate closes (replace / unmount) are always
+  // Liveness guard: a CLOSED client must be replaced, not left unavailable
+  // until the window reloads. Legitimate closes (replace / unmount) are always
   // paired with a value change or teardown, so this effect's subscription is
   // gone before they fire; anything else closing the served client - e.g. the
   // deferred unmount-close in `useCloseWsStreamClientOnReplace` firing across
   // an effects-disconnect where React preserves the memoized value - lands
-  // here and forces a rebuild. The `isClosed()` re-check covers closes that
+  // here and forces a rebuild. `useWsStreamClient` hides the dead instance
+  // during that handoff, and the `isClosed()` re-check covers closes that
   // happened while this effect itself was disconnected.
   useEffect(() => {
     if (value === null) return;


### PR DESCRIPTION
## Problem

The git-diff panel could get stuck on a permanent `CLIENT_CLOSED` skeleton instead of recovering like every other streaming RPC. The app-wide `WsStreamClient` is owned by React via `HostStreamProvider`. A replace-on-unmount race (`useCloseWsStreamClientOnReplace`'s deferred close firing across an effects-disconnect where React preserved the memoized value) could leave a **closed** client sitting in context. Every consumer of that client — git-diff, notifications, resources, worktree-changed, voice, migration — would then subscribe on the dead instance, receive an inert session, and surface a terminal `CLIENT_CLOSED` error with no path back to a live stream until a full window reload.

## Fix

Two-sided defense so a closed client is both hidden immediately and rebuilt reactively:

- **Consumer side** — `useWsStreamClient()` is now a `useSyncExternalStore` over the client's `onClosed` event whose snapshot returns `null` when `client.isClosed()`. A closed client is hidden the moment it closes (no rerender required), so consumers detach from the dead session and rebind once a replacement reaches context. The method-support readers (`useStreamMethodSupport` / `useStreamMethodSchemaVersion`) route through the same live-only hook.
- **Owner side** — `HostStreamProvider`'s existing liveness guard mints a fresh client via the rebuild nonce when one closes underneath it. The two halves compose cleanly: close → `null`, provider bumps the nonce once, the new open client changes context; `close()` is idempotent and the old guard subscription is cleaned up, so there is no rebuild loop.

Legitimate closes (host swap, sign-out, unmount) always coincide with a value change or teardown, so the guard's subscription is already gone before they fire; only the illegitimate replace-on-unmount race lands in it.

## Test

Adds a focused regression that exercises the exact `onClosed` subscribe branch the fix introduces:

1. Mounts with a **live** client and delivers a snapshot.
2. Closes the live client inside `act()` with **no parent rerender** — asserts the consumer detaches (its session closes) and **no `CLIENT_CLOSED`** surfaces. This only passes because `onClosed` notifies `useSyncExternalStore` on its own.
3. Swaps in a replacement client and asserts a **fresh git snapshot**.

Verified non-vacuous: temporarily neutering the `onClosed` subscription makes the new test fail precisely at the detach assertion.

## Verification

- Focused suite: 16/16 pass
- `bun run compile`: clean
- pre-commit (nx-affected build/compile/lint/format + DCO sign-off): pass

## Notes

Branch is based on the currently-pinned submodule commit (`424899d1`); it merges cleanly onto `main` (main did not touch these files). A follow-up worth considering: move the app-wide client out of React ownership into a module-owned holder keyed on `(hostId, userId)` to match the session-store model and delete the liveness guard / rebuild nonce / close-on-replace scaffolding outright.