### PR TITLE
fix(gui-app): collapse excess history PR pills

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -518,6 +518,60 @@ describe("<EpicsListPanel />", () => {
     ).not.toBeNull();
   });
 
+  it("collapses excess History PR pills into an overflow control", async () => {
+    testState.worktreesByEpicId = new Map([
+      [
+        "epic-from-history",
+        [
+          {
+            ...historyWorktree(),
+            submodules: [
+              {
+                repoIdentifier: { owner: "acme", repo: "shared" },
+                branch: "feature/shared-history",
+                prState: "merged",
+                prNumber: 85,
+                prUrl: "https://github.com/acme/shared/pull/85",
+                mergedHeadShaMatches: true,
+                mergedIntoDefault: true,
+                atPinnedCommit: true,
+                unmergedCommitCount: null,
+                unmergedCommitSubjects: null,
+              },
+              {
+                repoIdentifier: { owner: "acme", repo: "docs" },
+                branch: "feature/docs-history",
+                prState: "open",
+                prNumber: 86,
+                prUrl: "https://github.com/acme/docs/pull/86",
+                mergedHeadShaMatches: false,
+                mergedIntoDefault: false,
+                atPinnedCommit: false,
+                unmergedCommitCount: null,
+                unmergedCommitSubjects: null,
+              },
+            ],
+          },
+        ],
+      ],
+    ]);
+    renderPanel("embedded", "/");
+
+    const overflow = await screen.findByRole("button", {
+      name: "Show 1 more pull request",
+    });
+    expect(overflow.textContent).toBe("+1");
+    expect(
+      screen.queryByRole("link", { name: "Open docs PR #86 Open" }),
+    ).toBeNull();
+
+    fireEvent.click(overflow);
+
+    expect(
+      await screen.findByRole("link", { name: "Open docs PR #86 Open" }),
+    ).not.toBeNull();
+  });
+
   it("keeps the updated timestamp visible when a task has no PR pills", async () => {
     renderPanel("embedded", "/");
 

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -954,7 +954,8 @@ function HistoryRowTrailingMetadata(props: {
         <WorktreePrPills
           worktrees={props.worktrees}
           detailOnHover
-          className="pointer-events-none col-start-1 row-start-1 max-w-[min(36vw,22rem)] opacity-0 transition-opacity group-hover/list-row:pointer-events-auto group-hover/list-row:opacity-100 group-focus-within/list-row:pointer-events-auto group-focus-within/list-row:opacity-100"
+          maximumVisible={2}
+          className="pointer-events-none col-start-1 row-start-1 max-w-[min(36vw,22rem)] overflow-hidden opacity-0 transition-opacity group-hover/list-row:pointer-events-auto group-hover/list-row:opacity-100 group-focus-within/list-row:pointer-events-auto group-focus-within/list-row:opacity-100 has-data-[state=open]:pointer-events-auto has-data-[state=open]:opacity-100"
           testId={`task-history-prs-${props.epicId}`}
         />
       ) : null}

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-pr-metadata.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-pr-metadata.test.tsx
@@ -225,6 +225,9 @@ describe("worktree PR metadata", () => {
     fireEvent.click(overflow);
 
     const content = screen.getByTestId("worktree-pr-overflow-content");
+    expect(screen.getByRole("dialog", { name: "More pull requests" })).toBe(
+      content,
+    );
     expect(
       within(content).getByRole("link", {
         name: "Open design-system PR #9 Open",

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-pr-metadata.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-pr-metadata.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import type {
   WorktreeBinding,
   WorktreeHostEntryV12,
@@ -143,6 +149,7 @@ describe("worktree PR metadata", () => {
         <WorktreePrPills
           worktrees={[entry]}
           detailOnHover
+          maximumVisible={null}
           className={undefined}
           testId="history-prs"
         />
@@ -168,6 +175,61 @@ describe("worktree PR metadata", () => {
     }
     expect(screen.getByText("feature/login")).toBeDefined();
     expect(screen.getByText("/worktrees/app/feature-login")).toBeDefined();
+  });
+
+  it("collapses excess PR pills behind an accessible overflow control", () => {
+    const entry = worktree({
+      submodules: [
+        {
+          repoIdentifier: { owner: "acme", repo: "shared" },
+          branch: "feature/shared-login",
+          prState: "merged",
+          prNumber: 7,
+          prUrl: "https://github.com/acme/shared/pull/7",
+          mergedHeadShaMatches: true,
+          mergedIntoDefault: true,
+          atPinnedCommit: true,
+          unmergedCommitCount: null,
+          unmergedCommitSubjects: null,
+        },
+        {
+          repoIdentifier: { owner: "acme", repo: "design-system" },
+          branch: "feature/design-login",
+          prState: "open",
+          prNumber: 9,
+          prUrl: "https://github.com/acme/design-system/pull/9",
+          mergedHeadShaMatches: false,
+          mergedIntoDefault: false,
+          atPinnedCommit: false,
+          unmergedCommitCount: null,
+          unmergedCommitSubjects: null,
+        },
+      ],
+    });
+    renderWithProviders(
+      <WorktreePrPills
+        worktrees={[entry]}
+        detailOnHover
+        maximumVisible={2}
+        className={undefined}
+        testId="history-prs"
+      />,
+    );
+
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+    const overflow = screen.getByRole("button", {
+      name: "Show 1 more pull request",
+    });
+    expect(overflow.textContent).toBe("+1");
+
+    fireEvent.click(overflow);
+
+    const content = screen.getByTestId("worktree-pr-overflow-content");
+    expect(
+      within(content).getByRole("link", {
+        name: "Open design-system PR #9 Open",
+      }),
+    ).toBeDefined();
   });
 
   it("renders the owner hover's embedded PR pill as a real link", () => {

--- a/clients/gui-app/src/components/worktree/worktree-pr-metadata.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-pr-metadata.tsx
@@ -133,6 +133,7 @@ function WorktreePrOverflow(props: {
         </PopoverTrigger>
       </Badge>
       <PopoverContent
+        aria-label="More pull requests"
         align="end"
         sideOffset={6}
         className="w-[min(90vw,24rem)]"

--- a/clients/gui-app/src/components/worktree/worktree-pr-metadata.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-pr-metadata.tsx
@@ -7,6 +7,11 @@ import { ExternalLink, FolderGit2, GitBranch } from "lucide-react";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Badge } from "@/components/ui/badge";
 import { HOVER_PREVIEW_SCROLL_CLASS } from "@/components/ui/hover-preview-surface";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useRunnerOpenExternalLink } from "@/hooks/runner/use-open-external-link-mutation";
 import { cn } from "@/lib/utils";
@@ -40,26 +45,34 @@ const PR_PILL_CLASS: Record<WorktreeDisplayedPrState, string> = {
 export function WorktreePrPills(props: {
   readonly worktrees: readonly WorktreeHostEntryV12[];
   readonly detailOnHover: boolean;
+  readonly maximumVisible: number | null;
   readonly className: string | undefined;
   readonly testId: string;
 }): ReactNode {
   const references = worktreePrReferences(props.worktrees);
   if (references.length === 0) return null;
+  const visibleReferences =
+    props.maximumVisible === null
+      ? references
+      : references.slice(0, props.maximumVisible);
+  const overflowReferences =
+    props.maximumVisible === null ? [] : references.slice(props.maximumVisible);
   return (
     <span
-      className={cn(
-        "flex min-w-0 items-center gap-1 overflow-hidden",
-        props.className,
-      )}
+      className={cn("flex min-w-0 items-center gap-1", props.className)}
       data-testid={props.testId}
     >
-      {references.map((reference) => (
+      {visibleReferences.map((reference) => (
         <WorktreePrPill
           key={reference.key}
           reference={reference}
           detailOnHover={props.detailOnHover}
+          flexible={props.maximumVisible !== null}
         />
       ))}
+      {overflowReferences.length === 0 ? null : (
+        <WorktreePrOverflow references={overflowReferences} />
+      )}
     </span>
   );
 }
@@ -67,6 +80,7 @@ export function WorktreePrPills(props: {
 function WorktreePrPill(props: {
   readonly reference: WorktreePrReference;
   readonly detailOnHover: boolean;
+  readonly flexible: boolean;
 }): ReactNode {
   // The pill is a real PR link everywhere it renders - the Epic history list
   // and the chat/owner hover preview (now an interactive HoverCard, so a
@@ -75,11 +89,15 @@ function WorktreePrPill(props: {
     <Badge
       asChild
       variant="outline"
-      className={cn("gap-1 font-medium", PR_PILL_CLASS[props.reference.state])}
+      className={cn(
+        "gap-1 font-medium",
+        props.flexible && "min-w-0 shrink",
+        PR_PILL_CLASS[props.reference.state],
+      )}
     >
       <WorktreePrAnchor
         reference={props.reference}
-        className="max-w-[min(60vw,16rem)]"
+        className={cn("max-w-[min(60vw,16rem)]", props.flexible && "min-w-0")}
       />
     </Badge>
   );
@@ -93,6 +111,48 @@ function WorktreePrPill(props: {
     >
       {pill}
     </TooltipWrapper>
+  );
+}
+
+function WorktreePrOverflow(props: {
+  readonly references: readonly WorktreePrReference[];
+}): ReactNode {
+  const count = props.references.length;
+  return (
+    <Popover>
+      <Badge
+        asChild
+        variant="outline"
+        className="cursor-pointer border-border bg-background font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <PopoverTrigger
+          aria-label={`Show ${count} more pull request${count === 1 ? "" : "s"}`}
+          data-testid="worktree-pr-overflow-trigger"
+        >
+          +{count}
+        </PopoverTrigger>
+      </Badge>
+      <PopoverContent
+        align="end"
+        sideOffset={6}
+        className="w-[min(90vw,24rem)]"
+        data-testid="worktree-pr-overflow-content"
+      >
+        <span className="text-ui-xs font-medium text-muted-foreground">
+          More pull requests
+        </span>
+        <span className="flex flex-wrap gap-1.5">
+          {props.references.map((reference) => (
+            <WorktreePrPill
+              key={reference.key}
+              reference={reference}
+              detailOnHover={false}
+              flexible={false}
+            />
+          ))}
+        </span>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -221,6 +281,7 @@ export function OwnerWorkspaceMetadataContent(props: {
             <WorktreePrPills
               worktrees={[item.worktree]}
               detailOnHover={false}
+              maximumVisible={null}
               className="mt-0.5 flex-wrap overflow-visible"
               testId={`owner-workspace-prs-${item.key}`}
             />


### PR DESCRIPTION
## Summary
- cap History rows at two visible PR pills and expose the rest through an accessible +N popover
- keep PR links usable in the overflow popover and preserve the owner metadata’s wrapping behavior
- cover shared metadata and History rendering with focused tests

## Verification
- bun run test src/components/worktree/__tests__/worktree-pr-metadata.test.tsx src/components/epics/__tests__/epics-list-panel.test.tsx
- bun run compile
- bunx eslint src/components/epics/epics-list-panel.tsx src/components/epics/__tests__/epics-list-panel.test.tsx src/components/worktree/worktree-pr-metadata.tsx src/components/worktree/__tests__/worktree-pr-metadata.test.tsx --max-warnings 0
- pre-commit run --all-files
- npx -y react-doctor@latest . --verbose --scope changed --base origin/main --offline --no-score