### PR TITLE
fix(gui-app): show the busy spinner for detached native agent work

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/chat-tile-session-state.test.ts
@@ -537,6 +537,52 @@ describe("chatActivityIndicator", () => {
     ).toBe("background");
   });
 
+  it("reads turn (not background) while a detached subagent is still running", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "running",
+        activeTurn: null,
+        queue: EMPTY_QUEUE,
+        backgroundItems: [
+          {
+            taskId: "t2",
+            kind: "subagent" as const,
+            title: "Explore the codebase",
+            blockId: "t2",
+            parentTaskId: null,
+            scheduledFor: null,
+          },
+        ],
+        turnInProgress: false,
+      }),
+    ).toBe("turn");
+  });
+
+  it("reads turn (not background) while a detached workflow fleet is still running", () => {
+    expect(
+      chatActivityIndicator({
+        runStatus: "running",
+        activeTurn: null,
+        queue: EMPTY_QUEUE,
+        backgroundItems: [
+          MONITOR_ITEM,
+          {
+            taskId: "t3",
+            kind: "workflow" as const,
+            title: "review-changes",
+            blockId: "t3",
+            parentTaskId: null,
+            phase: null,
+            activeLabel: null,
+            agentsStarted: null,
+            agentsFinished: null,
+          },
+        ],
+        turnInProgress: false,
+      }),
+    ).toBe("turn");
+  });
+
   it("prioritizes the turn when a turn and background work run simultaneously", () => {
     expect(
       chatActivityIndicator({

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-session-state.ts
@@ -230,16 +230,24 @@ export function resolvedTurnStatus(
 /**
  * Tri-state activity for the chat's progress indicators (sidebar tree, tab
  * icons): is the agent actually processing, or is only background work
- * (Bash `run_in_background` / a subagent / Monitor / a scheduled wakeup)
- * keeping the chat non-idle? `runStatus` alone can't tell the two apart, and
- * showing the same spinner for both left users unable to see whether the
- * agent was really running.
+ * (Bash `run_in_background` / Monitor / a scheduled wakeup) keeping the chat
+ * non-idle? `runStatus` alone can't tell the two apart, and showing the same
+ * spinner for both left users unable to see whether the agent was really
+ * running.
  *
  * `"turn"` wins whenever a genuine turn is active or activating (the host's
  * `turnInProgress`, via {@link resolvedTurnStatus}) — background work running
  * alongside a turn is subsumed by it. A runnable queue also reads `"turn"`:
  * the next prompt is imminent, and the momentary turn-boundary gaps while a
  * queue drains must not flicker the indicator through the background style.
+ *
+ * Native agent work — a spawned subagent or a workflow fleet still running
+ * after the turn ended — also reads `"turn"`: it IS the agent working, just
+ * detached from the turn, so it gets the busy spinner rather than the muted
+ * background-process glyph. Only process-like kinds (command / monitor /
+ * wakeup / mcp) read `"background"`. This deliberately diverges from
+ * {@link resolvedTurnStatus}, which keeps reporting no active turn for the
+ * same state: a detached subagent must not surface a Stop-turn affordance.
  */
 export type ChatActivityIndicator = "turn" | "background" | null;
 
@@ -254,7 +262,12 @@ export function chatActivityIndicator(
   if (resolvedTurnStatus(state, turnStatus) !== null) return "turn";
   const isQueueRunnable =
     state.queue.status !== "paused" && state.queue.items.length > 0;
-  return isQueueRunnable ? "turn" : "background";
+  if (isQueueRunnable) return "turn";
+  const hasNativeAgentWork =
+    state.backgroundItems?.some(
+      (item) => item.kind === "subagent" || item.kind === "workflow",
+    ) ?? false;
+  return hasNativeAgentWork ? "turn" : "background";
 }
 
 export function normalizeInlineEditForSession(


### PR DESCRIPTION
## What

Native agent work — a spawned subagent or a workflow fleet still running after the turn ends — now drives the **agent-busy spinner** on chat/tab/sidebar indicators instead of the muted background-process glyph (the one shared with Bash `run_in_background`, Monitor, and scheduled wakeups).

## Why

The `kind` discriminator (`subagent` / `workflow` vs `command` / `monitor` / `wakeup` / `mcp`) was already carried end-to-end on `backgroundItems`, but `chatActivityIndicator` never consulted it: any turn-less background work collapsed to the `"background"` tier, so a chat whose only live work was a detached subagent looked idle-ish rather than busy.

## Change

`chatActivityIndicator` now reads the live `backgroundItems` kinds: a `subagent` or `workflow` item reads `"turn"` (busy spinner); process-like kinds stay `"background"`.

This deliberately diverges from `resolvedTurnStatus`, which still reports *no active turn* for the same state — a detached subagent must **not** surface a Stop-turn affordance (its stop lives in the Background dock). The host-side presence tier gets the matching change in the internal repo so unopened-chat surfaces stay consistent.

## Tests

Added coverage in `chat-tile-session-state.test.ts` for both a detached `subagent` and a detached `workflow` reading `"turn"`, alongside the existing Monitor→`"background"` case. `bun run compile` + targeted vitest + react-doctor all green.