### PR TITLE
fix(gui-app): explain why the composer send button is disabled

### DIFF
--- a/clients/gui-app/src/components/chat/composer/chat-composer.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer.tsx
@@ -81,6 +81,13 @@ interface ChatComposerProps {
    */
   readonly isActive: boolean;
   readonly sendDisabled: boolean | undefined;
+  /**
+   * Why `sendDisabled` is true, shown as the send button's hover/focus
+   * tooltip (e.g. "Reconnecting to the host…"). Without it a blocked send
+   * button is silently grey and reads as broken. `null`/absent when
+   * `sendDisabled` is false or the caller has no reason to give.
+   */
+  readonly sendDisabledHint: string | null | undefined;
   readonly mentionRoots: ReadonlyArray<string> | null;
   readonly fallbackToGlobalMentionRoots: boolean;
   readonly currentEpicId: string | null;
@@ -126,6 +133,7 @@ function ChatComposerImpl(props: ChatComposerProps) {
     taskId,
     isActive,
     sendDisabled,
+    sendDisabledHint,
     mentionRoots,
     fallbackToGlobalMentionRoots,
     currentEpicId,
@@ -233,6 +241,12 @@ function ChatComposerImpl(props: ChatComposerProps) {
     seedSource.kind,
   );
   const sendBlocked = sendDisabled === true || reauthGate.signedOut;
+  const sendBlockedHint = resolveSendBlockedHint({
+    workspaceDisabledHint: workspaceAvailability.disabledHint,
+    signedOut: reauthGate.signedOut,
+    sendDisabled,
+    sendDisabledHint,
+  });
   const selectedModel = useStore(toolbarStore, (s) => s.selectedModel);
   // Rate-limit switch prompt: purely informational + user-confirmed, so it
   // never blocks send the way the reauth gate does. Scoped to the selected
@@ -461,7 +475,7 @@ function ChatComposerImpl(props: ChatComposerProps) {
                   hasPendingApprovals={hasPendingApprovals}
                   stopDisabled={stopDisabled}
                   onStopTurn={onStopTurn}
-                  composerDisabledHint={workspaceAvailability.disabledHint}
+                  composerDisabledHint={sendBlockedHint}
                   dictation={dictationControl}
                   dictationPreparing={dictationPreparing}
                   settingsLocked={false}
@@ -571,6 +585,27 @@ interface CanSubmitDraftArgs {
   readonly attachmentPreparationPending: boolean;
   readonly draftHasText: boolean;
   readonly draftHasImages: boolean;
+}
+
+/**
+ * Every blocked-send reason gets a hover/focus hint on the send button — a
+ * silently grey button reads as broken. Priority mirrors severity: the
+ * workspace gate (can't run anywhere), then the signed-out gate (the reauth
+ * banner has the full story), then the caller's reason (connection loss /
+ * view-only access).
+ */
+function resolveSendBlockedHint(args: {
+  readonly workspaceDisabledHint: string | null;
+  readonly signedOut: boolean;
+  readonly sendDisabled: boolean | undefined;
+  readonly sendDisabledHint: string | null | undefined;
+}): string | null {
+  if (args.workspaceDisabledHint !== null) return args.workspaceDisabledHint;
+  if (args.signedOut) {
+    return "Signed out of the provider — sign in to send messages";
+  }
+  if (args.sendDisabled === true) return args.sendDisabledHint ?? null;
+  return null;
 }
 
 function canSubmitDraft(args: CanSubmitDraftArgs): boolean {

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
@@ -68,6 +68,18 @@ export interface ChatLowerAccessState {
   readonly canAct: boolean;
 }
 
+/**
+ * Why the composer's send is blocked, for the send button's tooltip. `canAct`
+ * folds role and connection: a viewer can never act; a non-viewer with
+ * `canAct === false` means the chat stream is not open (host reconnecting
+ * after a drop / renderer resume).
+ */
+function chatSendDisabledHint(access: ChatLowerAccessState): string | null {
+  if (access.canAct) return null;
+  if (access.isViewer) return "You have view-only access to this chat";
+  return "Reconnecting to the host — sending is paused";
+}
+
 export interface ChatLowerTurnState {
   readonly activeTurnStatus: ChatActiveTurn["status"] | null;
   readonly stopDisabled: boolean;
@@ -445,6 +457,7 @@ function LiveChatComposer(props: {
       taskId={model.composer.nodeId}
       isActive={model.composer.isActive}
       sendDisabled={!model.access.canAct}
+      sendDisabledHint={chatSendDisabledHint(model.access)}
       mentionRoots={model.composer.mentionRoots}
       fallbackToGlobalMentionRoots={model.composer.fallbackToGlobalMentionRoots}
       currentEpicId={model.composer.currentEpicId}


### PR DESCRIPTION
## Problem

A blocked send button rendered as a plain `disabled` control with no tooltip — native `title`s don't show on disabled buttons — so it read as broken. Most visible during a post-suspension reconnect, where the chat stream is briefly not open and send is paused with no explanation.

## Change

Give every blocked-send reason a hover/focus hint via the existing `aria-disabled` + styled-tooltip idiom (the button stays focusable/hoverable), priority-ordered:

| Reason | Tooltip |
|---|---|
| No workspace | existing workspace hint |
| Provider signed out | "Signed out of the provider — sign in to send messages" |
| Stream not open (post-nap reconnect) | "Reconnecting to the host — sending is paused" |
| View-only access | "You have view-only access to this chat" |

`ChatComposer` takes a `sendDisabledHint`, merges it with the workspace + reauth gates (`resolveSendBlockedHint`) into the toolbar's existing `composerDisabledHint` path; the chat tile derives the reason from `access` (`chatSendDisabledHint`).

The visible half of the renderer-suspension wake fix (traycer#508 client resilience + internal host protocol-ping #4547).

## Verification

gui-app compiles + lints clean; 314 composer tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)