### PR TITLE
fix(gui-app): clarify worktree select-all state

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -1002,6 +1002,15 @@ describe("WorktreesList delete flow", () => {
     expect(scrollRegion.style.paddingBottom).toBe("128px");
   });
 
+  it("renders an actionable select-all control with enabled foreground contrast", () => {
+    renderDefault();
+
+    const selectAll = screen.getByTestId("worktrees-select-all");
+    expect(selectAll.hasAttribute("disabled")).toBe(false);
+    expect(selectAll.classList.contains("text-foreground")).toBe(true);
+    expect(selectAll.classList.contains("text-muted-foreground")).toBe(false);
+  });
+
   it("excludes an in-use row and a backgrounded-deleting row from selection and select-all", () => {
     renderDefault();
     confirmDelete("feat-dirty");

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -1754,7 +1754,7 @@ function WorktreeSelectAllToggle(props: {
         "flex h-7 shrink-0 items-center gap-1.5 rounded-sm border px-2 text-ui-xs font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
         allSelected || indeterminate
           ? "border-border bg-muted text-foreground"
-          : "border-border bg-background text-muted-foreground hover:border-foreground hover:bg-muted hover:text-foreground",
+          : "border-border bg-background text-foreground hover:border-foreground hover:bg-muted",
       )}
     >
       <span


### PR DESCRIPTION
## Summary

Makes the enabled Worktrees **Select all** control use normal foreground contrast so it no longer reads as disabled. The true disabled state when no rows are selectable remains unchanged.

## Related issue

N/A

## Verification

- `bun run test src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx`
- `bun run compile`
- focused ESLint for the changed component and test
- `react-doctor@latest . --verbose --scope changed --base origin/main --offline --no-score`
- affected workspace lint, format, compile, and build via the pre-commit check sequence with the Nx daemon disabled

## Checklist

- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO