### PR TITLE
fix(gui-app): preserve default worktree launch intent

### DIFF
--- a/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
+++ b/clients/gui-app/src/components/home/hooks/use-landing-composer-actions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { v4 as uuidv4 } from "uuid";
 import type {
   CreateEpicChatSeed,
@@ -12,6 +12,7 @@ import type {
   WorktreeBindingSelectorRowV12,
   WorktreeBindingWorkspaceMode,
   WorktreeIntent,
+  WorktreeWorkspaceSummaryV13,
 } from "@traycer/protocol/host/worktree-schemas";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { TuiHarnessId } from "@traycer/protocol/persistence/epic/schemas";
@@ -64,7 +65,10 @@ import {
 import { scheduleLandingImageReconcile } from "@/lib/composer/landing-image-gc";
 import { buildChatRunSettings } from "@/lib/composer/chat-run-settings";
 import { useAccountContextStore } from "@/stores/auth/account-context-store";
-import { orderFoldersPrimaryFirst } from "@/lib/worktree/resolve-primary-path";
+import {
+  orderFoldersPrimaryFirst,
+  resolvePrimaryPath,
+} from "@/lib/worktree/resolve-primary-path";
 import {
   clearEpicCreateSeedPending,
   markEpicCreateSeedPending,
@@ -80,6 +84,8 @@ import type {
 } from "@/components/home/data/landing-options";
 import { deriveWorkspaceMode } from "@/lib/worktree/workspace-mode";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
+import { buildDefaultBranchByPath } from "@/lib/worktree/default-branch-name";
+import { defaultFolderIntent } from "@/lib/worktree/worktree-intent-seeding";
 
 export interface LandingComposerSubmitArgs {
   readonly editor: ComposerPromptEditorHandle | null;
@@ -598,22 +604,28 @@ export function useLandingComposerActions(): LandingComposerActions {
 
   const submit = useCallback(
     (args: LandingComposerSubmitArgs) => {
-      const workspaceContext = readLandingWorkspaceContext();
+      const workspaceContext = readLandingWorkspaceContext(
+        queryClient,
+        client.getActiveHostId(),
+      );
       if (workspaceContext.worktreeIntentSuspended) return;
       dispatchSubmission(args, workspaceContext);
       clearConsumedLandingWorktreeIntent(workspaceContext);
     },
-    [dispatchSubmission],
+    [client, dispatchSubmission, queryClient],
   );
 
   const selectTerminalAgent = useCallback(
     (launch: TerminalAgentLaunch) => {
-      const workspaceContext = readLandingWorkspaceContext();
+      const workspaceContext = readLandingWorkspaceContext(
+        queryClient,
+        client.getActiveHostId(),
+      );
       if (workspaceContext.worktreeIntentSuspended) return;
       dispatchTerminalAgent(launch, workspaceContext);
       clearConsumedLandingWorktreeIntent(workspaceContext);
     },
-    [dispatchTerminalAgent],
+    [client, dispatchTerminalAgent, queryClient],
   );
 
   return useMemo(
@@ -636,7 +648,10 @@ interface LandingWorkspaceContext {
   readonly activeDraftId: string | null;
 }
 
-function readLandingWorkspaceContext(): LandingWorkspaceContext {
+function readLandingWorkspaceContext(
+  queryClient: QueryClient,
+  hostId: string | null,
+): LandingWorkspaceContext {
   const draftState = useLandingDraftStore.getState();
   const activeDraft =
     draftState.activeDraftId === null
@@ -655,21 +670,31 @@ function readLandingWorkspaceContext(): LandingWorkspaceContext {
   });
   if (activeDraft !== null) {
     return {
-      ...canonicalLaunchWorkspace(activeDraft.workspace, stagedWorktreeIntent),
+      ...canonicalLaunchWorkspace(
+        activeDraft.workspace,
+        stagedWorktreeIntent,
+        readCachedDefaultWorktreeIntent(
+          queryClient,
+          hostId,
+          activeDraft.workspace,
+        ),
+      ),
       workspaceFolderInfoByPath: activeDraft.workspace.folderInfoByPath,
       worktreeIntentSuspended,
       activeDraftId,
     };
   }
   const globalState = useWorkspaceFoldersStore.getState();
+  const globalWorkspace = {
+    folders: globalState.folders,
+    folderInfoByPath: globalState.folderInfoByPath,
+    primaryPath: globalState.primaryPath,
+  };
   return {
     ...canonicalLaunchWorkspace(
-      {
-        folders: globalState.folders,
-        folderInfoByPath: globalState.folderInfoByPath,
-        primaryPath: globalState.primaryPath,
-      },
+      globalWorkspace,
       stagedWorktreeIntent,
+      readCachedDefaultWorktreeIntent(queryClient, hostId, globalWorkspace),
     ),
     workspaceFolderInfoByPath: globalState.folderInfoByPath,
     worktreeIntentSuspended,
@@ -689,24 +714,26 @@ function readLandingWorkspaceContext(): LandingWorkspaceContext {
 // only staged (git) entry to `isPrimary: false` with nothing taking its
 // place, sending a zero-primary intent.
 //
-// A nothing-staged launch stays `null`: the primary-first folder list already
-// carries the binding, and synthesizing an all-`local` intent here would be
-// remembered as the epic's intent and suppress the per-folder worktree
-// defaults the next time the epic opens.
+// A nothing-staged launch only stays `null` when the cached workspace summaries
+// do not identify a resolved git folder. When the picker is visibly showing its
+// derived "New worktree" default but branch-dependent memory is still being
+// validated, `cachedDefaultWorktreeIntent` closes that transient gap at the
+// submit boundary without trusting the unvalidated remembered branch.
 function canonicalLaunchWorkspace(
   workspace: LandingDraftWorkspaceSnapshot,
   stagedWorktreeIntent: WorktreeIntent | null,
+  cachedDefaultWorktreeIntent: WorktreeIntent | null,
 ): {
   readonly workspaceFolders: ReadonlyArray<string>;
   readonly worktreeIntent: WorktreeIntent | null;
   readonly workspaceMode: WorktreeBindingWorkspaceMode;
 } {
   const worktreeIntent =
-    stagedWorktreeIntent === null
+    stagedWorktreeIntent === null && cachedDefaultWorktreeIntent === null
       ? null
       : effectiveWorktreeIntent({
           workspace,
-          seedIntent: null,
+          seedIntent: cachedDefaultWorktreeIntent,
           stagedIntent: stagedWorktreeIntent,
         });
   return {
@@ -720,6 +747,71 @@ function canonicalLaunchWorkspace(
       worktreeIntent,
     ),
   };
+}
+
+function readCachedDefaultWorktreeIntent(
+  queryClient: QueryClient,
+  hostId: string | null,
+  workspace: LandingDraftWorkspaceSnapshot,
+): WorktreeIntent | null {
+  const response = queryClient.getQueryData<{
+    readonly workspaces: ReadonlyArray<WorktreeWorkspaceSummaryV13>;
+  }>(
+    hostQueryKeys.method<HostRpcRegistry, "worktree.listByWorkspacePaths">(
+      hostId,
+      "worktree.listByWorkspacePaths",
+      {
+        workspacePaths: [...workspace.folders],
+        scriptRefs: [],
+        forceRefresh: false,
+      },
+    ),
+  );
+  const summariesByPath = new Map(
+    response?.workspaces.map((summary) => [summary.workspacePath, summary]) ??
+      [],
+  );
+  const worktreeDefaults = workspace.folders.flatMap((workspacePath) => {
+    const summary = summariesByPath.get(workspacePath);
+    if (
+      summary === undefined ||
+      summary.resolvedAt === null ||
+      !summary.isGitRepo
+    ) {
+      return [];
+    }
+    const currentBranch = branchForCachedSummary(summary);
+    return currentBranch === null ? [] : [{ summary, currentBranch }];
+  });
+  if (worktreeDefaults.length === 0) return null;
+
+  const defaultBranchByPath = buildDefaultBranchByPath(
+    worktreeDefaults.map((entry) => entry.summary),
+    worktreeDefaults.length > 1,
+  );
+  const primaryPath = resolvePrimaryPath(
+    workspace.folders,
+    workspace.primaryPath,
+  );
+  return {
+    entries: worktreeDefaults.map(({ summary, currentBranch }) =>
+      defaultFolderIntent({
+        workspacePath: summary.workspacePath,
+        repoIdentifier: summary.repoIdentifier,
+        isPrimary: summary.workspacePath === primaryPath,
+        isGitRepo: true,
+        currentBranch,
+        defaultNewBranchName: defaultBranchByPath[summary.workspacePath] ?? "",
+      }),
+    ),
+  };
+}
+
+function branchForCachedSummary(
+  summary: WorktreeWorkspaceSummaryV13,
+): string | null {
+  const mainEntry = summary.worktrees.find((worktree) => worktree.isMain);
+  return mainEntry?.branch ?? summary.mainBranch ?? null;
 }
 
 function rememberLandingWorktreeIntent(

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -693,6 +693,7 @@ function editorHandleForPrompt(prompt: string): ComposerPromptEditorHandle {
     clear: () => undefined,
     setContent: () => undefined,
     insertImageAttachments: () => undefined,
+    beginPathInsertion: () => null,
     removeImageAttachmentById: () => undefined,
     insertDictatedText: () => undefined,
     dismissActiveSuggestion: () => false,

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -299,7 +299,6 @@ function DelayedBranchValidationHarness() {
       />
       <button
         type="button"
-        data-testid="submit-task"
         onClick={() => {
           actions.submit({
             editor: editorHandleForPrompt("Investigate the worktree race"),
@@ -615,7 +614,7 @@ describe("landing workspace summary empty state", () => {
       readStagedWorktreeIntent({ surface: "landing", draftId: null }),
     ).toBeNull();
 
-    fireEvent.click(screen.getByTestId("submit-task"));
+    fireEvent.click(screen.getByRole("button", { name: "Create task" }));
 
     await waitFor(() => {
       expect(

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/home-summary-empty.test.tsx
@@ -1,12 +1,34 @@
 import "../../../../../__tests__/test-browser-apis";
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ActiveHostWorkspaceControls } from "../host-workspace-selector";
 import type { WorktreeWorkspaceSummaryV13 } from "@traycer/protocol/host/worktree-schemas";
+import type { JsonContent } from "@traycer/protocol/common/registry";
 import type { ResolvedFolder } from "@/lib/workspace/resolved-folder";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import type { ComposerPromptEditorHandle } from "@/components/chat/composer/composer-prompt-editor";
+import { useLandingComposerActions } from "@/components/home/hooks/use-landing-composer-actions";
+import { useLandingComposerStore } from "@/stores/composer/landing-composer-store";
+import { useComposerRunSettingsStore } from "@/stores/composer/composer-run-settings-store";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useInitialChatHandoffStore } from "@/stores/epics/initial-chat-handoff-store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
+import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
+import { useWorktreeIntentMemoryStore } from "@/stores/worktree/worktree-intent-memory-store";
+import { hostQueryKeys } from "@/lib/query-keys";
+import type { HostRpcRegistry } from "@/lib/host";
+import {
+  readStagedWorktreeIntent,
+  useWorktreeIntentStagingStore,
+} from "@/stores/worktree/worktree-intent-staging-store";
 
 interface MockSummariesQuery {
   readonly data:
@@ -30,11 +52,13 @@ interface MockHostClient {
   };
   getActiveHostId(): string;
   getRequestContextUserId(): string;
-  request(): Promise<never>;
+  request(method: string, payload: unknown): Promise<unknown>;
   onChange(): () => void;
 }
 
-function createMockHostClient(): MockHostClient {
+function createMockHostClient(
+  request: (method: string, payload: unknown) => Promise<unknown>,
+): MockHostClient {
   return {
     getActiveHost: () => ({
       hostId: "host-home",
@@ -46,14 +70,16 @@ function createMockHostClient(): MockHostClient {
     }),
     getActiveHostId: () => "host-home",
     getRequestContextUserId: () => "user-home",
-    request: () => Promise.reject(new Error("unexpected request")),
+    request,
     onChange: () => () => undefined,
   };
 }
 
 const mocks = vi.hoisted(() => {
+  const request =
+    vi.fn<(method: string, payload: unknown) => Promise<unknown>>();
   const hostClient: { current: MockHostClient | null } = {
-    current: createMockHostClient(),
+    current: createMockHostClient(request),
   };
   const resolvedWorkspace: {
     current: { readonly folders: readonly ResolvedFolder[] };
@@ -72,16 +98,21 @@ const mocks = vi.hoisted(() => {
     pickAndPrepareFolders: vi.fn(() => Promise.resolve(null)),
     selectHost: vi.fn(),
     listByWorkspacePathsForClient: vi.fn(),
+    hostQueries: vi.fn(),
+    navigate: vi.fn(),
+    request,
     hostClient,
     resolvedWorkspace,
     summariesQuery,
   };
 });
 
+const GIT_REPO_IDENTIFIER = { owner: "acme", repo: "app" };
+
 const GIT_SUMMARY: WorktreeWorkspaceSummaryV13 = {
   workspacePath: "/workspace/app",
   isGitRepo: true,
-  repoIdentifier: { owner: "acme", repo: "app" },
+  repoIdentifier: GIT_REPO_IDENTIFIER,
   mainBranch: "development",
   worktrees: [
     {
@@ -146,6 +177,28 @@ vi.mock("@/lib/host", () => ({
   useHostClient: () => mocks.hostClient.current,
 }));
 
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@/hooks/agent/use-create-tui-agent", () => ({
+  useCreateTuiAgent: () => ({
+    create: () => Promise.resolve(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/composer/landing-image-store", () => ({
+  sessionImageBytes: () => null,
+  getImageBytes: () => Promise.resolve(undefined),
+  imageHashKeys: () => Promise.resolve([]),
+}));
+
+vi.mock("@/lib/composer/landing-image-gc", () => ({
+  markLandingDraftsReady: () => undefined,
+  scheduleLandingImageReconcile: () => undefined,
+}));
+
 vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
   useReactiveActiveHostId: () => "host-home",
 }));
@@ -187,7 +240,10 @@ vi.mock("@/hooks/worktree/use-worktree-list-by-workspace-paths-query", () => ({
 }));
 
 vi.mock("@/hooks/host/use-host-queries", () => ({
-  useHostQueries: () => [],
+  useHostQueries: (args: unknown) => {
+    mocks.hostQueries(args);
+    return [];
+  },
 }));
 
 vi.mock("@/hooks/workspace/use-workspace-folder-actions", () => ({
@@ -229,12 +285,81 @@ function renderControl(layout: "inline" | "stacked") {
   return queryClient;
 }
 
+function DelayedBranchValidationHarness() {
+  const actions = useLandingComposerActions();
+  return (
+    <>
+      <ActiveHostWorkspaceControls
+        stagingKey={{ surface: "landing", draftId: null }}
+        workspaceSeed={null}
+        seedIntent={null}
+        seedIntentOverride={null}
+        layout="stacked"
+        hostScope={{ kind: "active" }}
+      />
+      <button
+        type="button"
+        data-testid="submit-task"
+        onClick={() => {
+          actions.submit({
+            editor: editorHandleForPrompt("Investigate the worktree race"),
+            toolbar: {
+              selection: {
+                harnessId: "codex",
+                modelSlug: "gpt-5-codex",
+                profileId: null,
+              },
+              reasoning: "high",
+              serviceTier: "",
+              permission: "supervised",
+              agentMode: "regular",
+            },
+          });
+        }}
+      >
+        Create task
+      </button>
+    </>
+  );
+}
+
+function renderDelayedBranchValidationHarness(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  queryClient.setQueryData(
+    hostQueryKeys.method<HostRpcRegistry, "worktree.listByWorkspacePaths">(
+      "host-home",
+      "worktree.listByWorkspacePaths",
+      {
+        workspacePaths: [GIT_SUMMARY.workspacePath],
+        scriptRefs: [],
+        forceRefresh: false,
+      },
+    ),
+    { workspaces: [GIT_SUMMARY], scriptsAtRefs: [] },
+  );
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <DelayedBranchValidationHarness />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+  return queryClient;
+}
+
 describe("landing workspace summary empty state", () => {
   beforeEach(() => {
+    window.localStorage.clear();
     mocks.pickAndPrepareFolders.mockClear();
     mocks.selectHost.mockClear();
     mocks.listByWorkspacePathsForClient.mockClear();
-    mocks.hostClient.current = createMockHostClient();
+    mocks.hostQueries.mockClear();
+    mocks.navigate.mockClear();
+    mocks.request.mockReset();
+    mocks.request.mockResolvedValue({ roomInfo: null });
+    mocks.hostClient.current = createMockHostClient(mocks.request);
     mocks.resolvedWorkspace.current = { folders: [] };
     mocks.summariesQuery.current = {
       data: { workspaces: [] },
@@ -242,10 +367,45 @@ describe("landing workspace summary empty state", () => {
       isPending: false,
       isLoading: false,
     };
+    useInitialChatHandoffStore.getState().resetForTests();
+    useComposerRunSettingsStore.getState().resetForTests();
+    useLandingComposerStore.getState().reset();
+    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useEpicCanvasStore.setState({
+      tabsById: {},
+      openTabOrder: [],
+      activeTabId: null,
+      mostRecentTabIdByEpicId: {},
+    });
+    useWorkspaceFoldersStore.setState({
+      folders: [],
+      folderInfoByPath: {},
+      primaryPath: null,
+    });
+    useWorktreeIntentMemoryStore.getState().resetForTests();
+    useWorktreeIntentStagingStore.getState().resetForTests();
   });
 
   afterEach(() => {
     cleanup();
+    useInitialChatHandoffStore.getState().resetForTests();
+    useComposerRunSettingsStore.getState().resetForTests();
+    useLandingComposerStore.getState().reset();
+    useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
+    useEpicCanvasStore.setState({
+      tabsById: {},
+      openTabOrder: [],
+      activeTabId: null,
+      mostRecentTabIdByEpicId: {},
+    });
+    useWorkspaceFoldersStore.setState({
+      folders: [],
+      folderInfoByPath: {},
+      primaryPath: null,
+    });
+    useWorktreeIntentMemoryStore.getState().resetForTests();
+    useWorktreeIntentStagingStore.getState().resetForTests();
+    window.localStorage.clear();
   });
 
   it("shows Add folder directly instead of a no-folder summary trigger", () => {
@@ -388,6 +548,102 @@ describe("landing workspace summary empty state", () => {
     queryClient.clear();
   });
 
+  it("submits the displayed New worktree intent while remembered-branch validation is delayed", async () => {
+    mocks.resolvedWorkspace.current = {
+      folders: [
+        {
+          kind: "resolved",
+          path: GIT_SUMMARY.workspacePath,
+          name: "app",
+          repoIdentifier: GIT_REPO_IDENTIFIER,
+        },
+      ],
+    };
+    mocks.summariesQuery.current = {
+      data: { workspaces: [GIT_SUMMARY] },
+      isFetching: false,
+      isPending: false,
+      isLoading: false,
+    };
+    useWorkspaceFoldersStore.setState({
+      folders: [GIT_SUMMARY.workspacePath],
+      folderInfoByPath: {
+        [GIT_SUMMARY.workspacePath]: {
+          path: GIT_SUMMARY.workspacePath,
+          name: "app",
+          repoIdentifier: GIT_SUMMARY.repoIdentifier,
+        },
+      },
+      primaryPath: GIT_SUMMARY.workspacePath,
+    });
+    useWorktreeIntentMemoryStore.getState().setFolderIntent(
+      {
+        kind: "worktree",
+        scripts: null,
+        workspacePath: GIT_SUMMARY.workspacePath,
+        repoIdentifier: GIT_SUMMARY.repoIdentifier,
+        isPrimary: true,
+        branch: {
+          type: "new",
+          name: "investigate-worktree-race",
+          source: "main",
+          carryUncommittedChanges: false,
+        },
+      },
+      1,
+    );
+
+    const queryClient = renderDelayedBranchValidationHarness();
+
+    expect(screen.getByTestId("folder-location-trigger").textContent).toContain(
+      "New worktree",
+    );
+    expect(mocks.hostQueries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requests: [
+          {
+            method: "worktree.listBranches",
+            params: {
+              workspacePath: GIT_SUMMARY.workspacePath,
+              includeRemote: true,
+            },
+          },
+        ],
+      }),
+    );
+    expect(
+      readStagedWorktreeIntent({ surface: "landing", draftId: null }),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByTestId("submit-task"));
+
+    await waitFor(() => {
+      expect(
+        mocks.request.mock.calls.some(([method]) => method === "epic.create"),
+      ).toBe(true);
+    });
+    const createEpicCall = mocks.request.mock.calls.find(
+      ([method]) => method === "epic.create",
+    );
+    const createEpicPayload = createEpicCall?.[1];
+    expect(createEpicPayload).toBeDefined();
+    if (
+      typeof createEpicPayload !== "object" ||
+      createEpicPayload === null ||
+      !("chat" in createEpicPayload) ||
+      typeof createEpicPayload.chat !== "object" ||
+      createEpicPayload.chat === null ||
+      !("worktreeIntent" in createEpicPayload.chat)
+    ) {
+      throw new Error(
+        "epic.create payload did not include chat.worktreeIntent",
+      );
+    }
+    expect(createEpicPayload.chat.worktreeIntent).not.toBeNull();
+
+    queryClient.clear();
+  });
+
   it("shows unavailable, not loading, when unresolved metadata query is disabled by a missing host client", () => {
     mocks.hostClient.current = null;
     mocks.resolvedWorkspace.current = {
@@ -418,3 +674,28 @@ describe("landing workspace summary empty state", () => {
     queryClient.clear();
   });
 });
+
+function editorHandleForPrompt(prompt: string): ComposerPromptEditorHandle {
+  const content: JsonContent = {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: prompt }],
+      },
+    ],
+  };
+  return {
+    isReady: () => true,
+    focus: () => undefined,
+    focusAtEnd: () => undefined,
+    getJSON: () => content,
+    isEmpty: () => prompt.length === 0,
+    clear: () => undefined,
+    setContent: () => undefined,
+    insertImageAttachments: () => undefined,
+    removeImageAttachmentById: () => undefined,
+    insertDictatedText: () => undefined,
+    dismissActiveSuggestion: () => false,
+  };
+}


### PR DESCRIPTION
## Summary

- preserve the derived New worktree default at landing-chat and terminal-agent submit time when intent staging is delayed by branch validation
- add a regression that holds `worktree.listBranches` pending while a remembered source branch requires validation
- keep unresolved, non-Git, and detached-HEAD workspaces local rather than synthesizing an invalid binding

## Related issue

N/A

## Checklist

- [x] Focused GUI regression tests pass (25 tests)
- [ ] Full CI pending
- [x] Tests added/updated
- [x] Commits signed off per DCO
