### PR TITLE
fix(gui-app): clamp double-click tail on a turn's last paragraph

### DIFF
--- a/clients/gui-app/src/components/chat/quote/__tests__/use-quote-selection.test.ts
+++ b/clients/gui-app/src/components/chat/quote/__tests__/use-quote-selection.test.ts
@@ -98,6 +98,64 @@ describe("resolveQuoteSelection - endpoint resolution", () => {
     expect(snapshot?.range.endOffset).toBe(root.childNodes.length);
   });
 
+  it("clamps a double-click on the LAST block whose word-selection tail lands at offset 0 of an out-of-root TEXT node", () => {
+    // A real double-click's word selection absorbs the block's trailing
+    // whitespace and finalizes the end at offset 0 of the NEXT text node - for
+    // a turn's last paragraph that node is the elapsed footer's label text,
+    // OUTSIDE the quotable root. This is the text-node analogue of the
+    // triple-click element@0 tail above; the element@0 clamp did not cover it,
+    // so the final paragraph was unquotable by double-click on every turn.
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    const footer = document.createElement("button");
+    footer.setAttribute("data-testid", "assistant-elapsed-footer");
+    footer.textContent = "Mulled for 4s";
+    segment.appendChild(footer);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    // End at offset 0 of the footer's TEXT node (not the element) - the
+    // double-click finalization shape the element@0 branch never reaches.
+    range.setEnd(firstText(footer), 0);
+
+    // Browser-shaped: the word plus the absorbed trailing block-boundary
+    // blank line the double-click synthesizes at the selection's end.
+    const snapshot = resolveQuoteSelection(range, "Third.\n\n");
+    expect(snapshot).not.toBeNull();
+    // End clamped to the root's end, so the range never reaches the footer.
+    expect(snapshot?.range.endContainer).toBe(root);
+    expect(snapshot?.range.endOffset).toBe(root.childNodes.length);
+  });
+
+  it("rejects a double-click tail that genuinely selected out-of-root TEXT (offset > 0)", () => {
+    // Offset > 0 in an out-of-root text node means the browser actually
+    // captured characters past the root (a real cross-root selection), not the
+    // empty offset-0 tail landing. The clamp must not fire and swallow it.
+    const segment = document.createElement("div");
+    const root = document.createElement("div");
+    root.setAttribute("data-quotable", "true");
+    const paragraph = document.createElement("p");
+    paragraph.textContent = "Third.";
+    root.appendChild(paragraph);
+    segment.appendChild(root);
+    const footer = document.createElement("div");
+    footer.textContent = "Mulled for 4s";
+    segment.appendChild(footer);
+    document.body.appendChild(segment);
+
+    const range = document.createRange();
+    range.setStart(firstText(paragraph), 0);
+    range.setEnd(firstText(footer), "Mulled".length);
+
+    expect(resolveQuoteSelection(range, "Third.\n\nMulled")).toBeNull();
+  });
+
   it("rejects a clamp whose clamped-away region holds real text (no cross-root text leak)", () => {
     const segment = document.createElement("div");
     const root = document.createElement("div");

--- a/clients/gui-app/src/components/chat/quote/use-quote-selection.ts
+++ b/clients/gui-app/src/components/chat/quote/use-quote-selection.ts
@@ -275,10 +275,18 @@ function quotableRootForEnd(
   startRoot: Element,
 ): EndResolution {
   if (isTextNode(container)) {
-    return {
-      root: closestQuotable(container.parentElement),
-      clampToRootEnd: false,
-    };
+    const here = closestQuotable(container.parentElement);
+    // A double-click's word selection can absorb the block's trailing
+    // whitespace and finalize at offset 0 of the NEXT text node - on a turn's
+    // LAST block that node sits outside the quotable root. offset 0 means no
+    // character of this text node is selected, so it's the same tail landing
+    // as the triple-click element@0 case below: clamp back into the root
+    // rather than rejecting, and let the caller's clamped-away guard reject a
+    // drag that genuinely selected content past the root.
+    if (here !== startRoot && offset === 0) {
+      return { root: startRoot, clampToRootEnd: true };
+    }
+    return { root: here, clampToRootEnd: false };
   }
   const element = asElement(container);
   if (element === null) return { root: null, clampToRootEnd: false };


### PR DESCRIPTION
## Summary

Double-clicking a word in the **last paragraph of a completed turn** never surfaced the Quote button — on every turn, without fail. Drag-select and triple-click on the same text worked. This extends the last-paragraph clamp to the double-click end shape so the Quote affordance appears there too.

Builds directly on #479, which hardened the same clamp for the triple-click tail (SVG-`<title>` guard, excluded-tail stripping, trailing-blank trim) but only for the `element@0` end shape. This PR is the small remaining slice #479 did not cover.

## Root cause

Gesture finalization — not the visible highlight — decides the selection's end boundary:

- A **triple-click** ends at offset 0 of the *element* after the paragraph. #479 clamps that back into the quotable root.
- A **double-click**'s word selection absorbs the block's trailing whitespace and finalizes the end at **offset 0 of the next *text node***. On a turn's last paragraph that text node is the elapsed-footer label, **outside** the quotable root.

`resolveQuoteSelection` routed the text-node shape through its `isTextNode` branch, returned the footer's root, and — since it differed from the start root — rejected the selection silently. So the final paragraph was unquotable by double-click on every turn. Drag places exact boundaries (no absorption) and triple-click hits the already-handled `element@0` branch, which is why only double-click broke.

The fix treats the text-node analogue identically: an end at **offset 0** of a text node outside the start root is the same empty tail landing as `element@0`, so clamp it back into the root. `offset 0` means no character of that node is selected; a genuine cross-root selection lands at `offset > 0` (or carries visible clamped-away text) and still rejects via the existing `rangeHasVisibleText` guard.

## Verification

- `bun run compile` from `clients/gui-app` — clean
- `bunx vitest run src/components/chat/quote` — 71 passed (69 + 2 new), covering the double-click clamp shape and the `offset > 0` cross-root rejection
- `react-doctor --scope changed` — no issues
- Pre-commit `build · compile · lint · format` workspace checks — pass
- Confirmed live in the running desktop app: double-click on a last paragraph now surfaces Quote

## Related issue

N/A

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)