### PR TITLE
docs: add Cursor Cloud setup instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,3 +152,32 @@ Router/Query, Zustand) — see its `AGENTS.md`.
 
 - Always run `bun run compile` for the workspaces containing your changes, never
   `tsc` directly.
+
+## Cursor Cloud specific instructions
+
+Toolchain (Bun 1.3.12, Node 24) and workspace deps are already provisioned by the
+startup update script (`bun install`); `bun` and `node` are on `PATH` via
+`~/.bashrc`. Standard commands live in the "Common Commands" section above
+(`bun run build|compile|lint|test|format`) — all four gates pass from a clean
+checkout. Non-obvious caveats:
+
+- **Node 24 must outrank `/exec-daemon/node` (v22).** `~/.bashrc` prepends the
+  nvm Node 24 bin so `node --version` is v24; the repo's `engines` require it.
+- **`bun run lint` runs ESLint with `--fix`.** It can rewrite source in place, so
+  re-check `git status` after linting.
+- **Running the app:** `make dev-desktop` (from repo root) is the E2E entrypoint.
+  It downloads + minisign-verifies the signed host from GitHub Releases, stages a
+  dev CLI wrapper, starts the host, and runs the Vite-HMR Electron shell against
+  the **production** cloud (`authn.traycer.ai` / `platform.traycer.ai`). The
+  renderer port is hash-derived per worktree (not 5173). Ctrl-C deregisters the
+  dev host but preserves `~/.traycer` user data.
+- **Headless Electron noise is benign.** `dbus`/`Gtk`/GPU `ERROR` lines and the
+  `systemctl --user daemon-reload ... No medium found` service-install warning do
+  not stop the run — the host still starts and the launch probe reports
+  `reachable: true`. There is no systemd user session in the VM.
+- **Auto-open-browser fails in the VM** ("Failed to execute default Web Browser —
+  Input/output error"). Sign-in uses an OAuth **device-code** flow: the app shows
+  a code + approval URL (`platform.traycer.ai/device`); open that URL manually in
+  Chrome (`DISPLAY=:1`) to approve. Full sign-in (and any epic/chat/terminal
+  action) needs a **real Traycer account** (GitHub/Google/email) — there are no
+  test credentials in this environment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,19 +165,43 @@ checkout. Non-obvious caveats:
   nvm Node 24 bin so `node --version` is v24; the repo's `engines` require it.
 - **`bun run lint` runs ESLint with `--fix`.** It can rewrite source in place, so
   re-check `git status` after linting.
-- **Running the app:** `make dev-desktop` (from repo root) is the E2E entrypoint.
-  It downloads + minisign-verifies the signed host from GitHub Releases, stages a
-  dev CLI wrapper, starts the host, and runs the Vite-HMR Electron shell against
-  the **production** cloud (`authn.traycer.ai` / `platform.traycer.ai`). The
-  renderer port is hash-derived per worktree (not 5173). Ctrl-C deregisters the
-  dev host but preserves `~/.traycer` user data.
-- **Headless Electron noise is benign.** `dbus`/`Gtk`/GPU `ERROR` lines and the
-  `systemctl --user daemon-reload ... No medium found` service-install warning do
-  not stop the run — the host still starts and the launch probe reports
-  `reachable: true`. There is no systemd user session in the VM.
-- **Auto-open-browser fails in the VM** ("Failed to execute default Web Browser —
-  Input/output error"). Sign-in uses an OAuth **device-code** flow: the app shows
-  a code + approval URL (`platform.traycer.ai/device`); open that URL manually in
-  Chrome (`DISPLAY=:1`) to approve. Full sign-in (and any epic/chat/terminal
-  action) needs a **real Traycer account** (GitHub/Google/email) — there are no
-  test credentials in this environment.
+- **Running the app:** `make dev-desktop` (repo root) is the documented E2E
+  entrypoint: it downloads + minisign-verifies the signed host from GitHub
+  Releases, stages a per-slot dev CLI wrapper
+  (`~/.traycer/cli/dev-runs/<slot>/bin/traycer`), and runs the Vite-HMR Electron
+  shell against the **production** cloud (`authn.traycer.ai` /
+  `platform.traycer.ai`). Renderer port is hash-derived per worktree (not 5173).
+- **No systemd in this VM (PID 1 is `tini`).** `systemctl --user` cannot work
+  (`systemd --user` refuses: "system has not been booted with systemd"). So the
+  desktop's Linux host convergence (`traycer host ensure` → `systemctl --user
+  start`) fails with a blocking modal, and `make dev-desktop`'s host auto-start
+  can't run the service. Workaround that avoids systemd entirely:
+  1. Start the host in the foreground (writes `pid.json`, no systemctl):
+     `~/.traycer/cli/dev-runs/<slot>/bin/traycer host start` (run under tmux).
+     The Linux `statusService` reports "running" from the unit file's presence +
+     a live `pid.json`, so once the host runs the desktop's `host ensure` is a
+     satisfied no-op (no `systemctl` call).
+  2. Run the desktop shell directly instead of `make dev-desktop`:
+     `DEV_DESKTOP_SLOT=<slot> PORT=<free> bun run --cwd clients/desktop dev`.
+- **Dev-desktop credential-path mismatch.** The downloaded host is a
+  **production** build and reads credentials from `~/.traycer/cli/credentials`,
+  but the **dev** desktop signs in to `~/.traycer/cli/dev/credentials`. A host
+  started against the dev slot then rejects RPCs with `UNAUTHORIZED: Host is not
+  provisioned - sign in on this machine to authorize it`. Since `make
+  dev-desktop` points the dev config at the production authn, the dev token is a
+  real production token — seed the prod path from it to provision the host:
+  `cp ~/.traycer/cli/dev/credentials ~/.traycer/cli/credentials` (and the
+  matching `.meta.json`), then restart `host start`.
+- **Auth is device-code.** Auto-open-browser fails in the VM ("Failed to execute
+  default Web Browser"); the app shows a code + `platform.traycer.ai/device` —
+  open it manually in Chrome (`DISPLAY=:1`) to approve. Needs a **real Traycer
+  account** (no test creds here). Tokens live in `~/.traycer`, so a fresh
+  Electron profile keeps you signed in.
+- **Headless rendering is fragile.** The Start Page renders, but editor-heavy
+  epic/task tabs often render **black**, and reloading the renderer (Ctrl+R)
+  crashes Electron (SIGTRAP). A corrupted GPU state (e.g. after forcing software
+  GL) can black out the whole renderer persistently — recover by resetting the
+  slot's Electron profile dir (`~/.config/Traycer Dev-<slot>/`). Do NOT force
+  `LIBGL_ALWAYS_SOFTWARE`/llvmpipe; it makes rendering worse. Verify backend
+  flows via `~/.traycer/host/dev-runs/<slot>/host.log` when a tab view won't
+  paint. Benign log noise: `dbus`/`Gtk`/GPU `ERROR` lines.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Traycer development environment for Cursor Cloud agents, and documents durable, non-obvious startup/run caveats under `## Cursor Cloud specific instructions` in `AGENTS.md`. The only code change is documentation.

Environment provisioning: startup update script `bun install` plus a one-time `~/.bashrc` edit (nvm Node 24 prepended ahead of `/exec-daemon/node` v22; Bun 1.3.12 on `PATH`).

### Verified working

- `bun install` — 3431 packages
- `bun run build` — 3 publishable projects built
- `bun run compile` — type-check passes (5 projects)
- `bun run lint` — ESLint passes (runs with `--fix`)
- `bun run test` — all Vitest suites pass (protocol 1114, shared 402, gui-app 6741 + 1 skipped, plus cli/desktop)

### Desktop app end-to-end (hello world)

- Downloads + minisign-verifies host `1.1.7` from GitHub Releases; host runs and is authorized.
- OAuth **device-code** sign-in completed against the production cloud.
- App loads the signed-in user's **real epics** from the cloud.
- Core action: **bound the `/workspace` folder** to the host — the host detected the git repo and current branch.

### Key findings captured in AGENTS.md

- This VM's init is `tini`, not systemd, so `systemctl --user` can't work. The desktop's Linux host-convergence uses systemd; workaround is to start the host in the foreground (`traycer host start`) and run the desktop shell directly (`bun run --cwd clients/desktop dev`).
- Dev/prod credential-path mismatch: the production host reads `~/.traycer/cli/credentials` while the dev desktop signs in to `~/.traycer/cli/dev/credentials`; seed the prod path to provision the host.
- Headless rendering is fragile: editor-heavy epic/task tabs can render black and reload crashes Electron; reset the slot's Electron profile dir to recover. Do not force software GL.

## Related issue

<!-- N/A -->

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

## Demo

Launch + OAuth device-code sign-in:
[traycer_desktop_launch_and_signin.mp4](https://cursor.com/agents/bc-4e5619b3-f558-4ca2-85c9-36d654691602/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftraycer_desktop_launch_and_signin.mp4)

Core action — binding the `/workspace` folder (host detects the git repo/branch):
[traycer_bind_workspace_folder.mp4](https://cursor.com/agents/bc-4e5619b3-f558-4ca2-85c9-36d654691602/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftraycer_bind_workspace_folder.mp4)

Signed-in workspace with the user's real epics loaded from the cloud:
[Connected workspace with real epics](https://cursor.com/agents/bc-4e5619b3-f558-4ca2-85c9-36d654691602/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftraycer_workspace_connected.webp)

[Workspace folder bound](https://cursor.com/agents/bc-4e5619b3-f558-4ca2-85c9-36d654691602/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftraycer_workspace_folder_bound.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e5619b3-f558-4ca2-85c9-36d654691602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e5619b3-f558-4ca2-85c9-36d654691602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

