### PR TITLE
feat(gui-app): mobile-responsive Settings, Landing, and History

### DIFF
--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -660,13 +660,19 @@ function PanelChromeBar(props: PanelChromeBarProps): ReactNode {
   });
 
   return (
-    <div className="flex items-center justify-between gap-2 px-2 pb-2">
+    // Wraps instead of clipping when the bar is narrower than its controls
+    // (sub-340px phones, or the Clear button appearing beside the cluster).
+    // The button cluster `grow`s so it renders identically while everything
+    // fits on one line (buttons flush right, as justify-between alone would
+    // place them) and spans the full row - still right-aligned - when it
+    // wraps below the Clear button.
+    <div className="flex flex-wrap items-center justify-between gap-2 px-2 pb-2">
       <div className="min-w-0">
         {props.filters.active ? (
           <ClearFiltersButton onClick={props.filters.onClear} />
         ) : null}
       </div>
-      <div className="flex shrink-0 items-center gap-1">
+      <div className="flex min-w-0 grow flex-wrap items-center justify-end gap-1">
         {props.selection.kind === "active" ? (
           <>
             <Button
@@ -714,40 +720,47 @@ function PanelChromeBar(props: PanelChromeBarProps): ReactNode {
             </Button>
           </>
         ) : (
+          // Paired sub-groups so a wrap breaks between pairs instead of
+          // orphaning a lone icon on its own line. Intra- and inter-group
+          // gaps are both gap-1, so the one-line rendering is unchanged.
           <>
-            <EpicsSortMenu value={props.sort} onChange={props.onSortChange} />
-            <EpicsFilterPopover
-              availableRepos={props.availableRepos}
-              availableWorkspaces={props.availableWorkspaces}
-              search={props.search}
-              onSearchChange={props.onSearchChange}
-              facets={props.facets}
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-label="Select history items"
-              disabled={!props.selection.canSelect}
-              className="gap-1.5 overflow-visible text-ui-sm text-muted-foreground hover:text-foreground"
-              onClick={props.selection.onStart}
-            >
-              <ListChecks className="size-4" />
-              Select
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label="Refresh tasks"
-              data-testid="epics-list-refresh"
-              disabled={refresh.refreshing || hostId === null}
-              onClick={refresh.trigger}
-            >
-              <RefreshCwIcon
-                className={cn("size-4", refresh.refreshing && "animate-spin")}
+            <div className="flex shrink-0 items-center gap-1">
+              <EpicsSortMenu value={props.sort} onChange={props.onSortChange} />
+              <EpicsFilterPopover
+                availableRepos={props.availableRepos}
+                availableWorkspaces={props.availableWorkspaces}
+                search={props.search}
+                onSearchChange={props.onSearchChange}
+                facets={props.facets}
               />
-            </Button>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label="Select history items"
+                disabled={!props.selection.canSelect}
+                className="gap-1.5 overflow-visible text-ui-sm text-muted-foreground hover:text-foreground"
+                onClick={props.selection.onStart}
+              >
+                <ListChecks className="size-4" />
+                Select
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Refresh tasks"
+                data-testid="epics-list-refresh"
+                disabled={refresh.refreshing || hostId === null}
+                onClick={refresh.trigger}
+              >
+                <RefreshCwIcon
+                  className={cn("size-4", refresh.refreshing && "animate-spin")}
+                />
+              </Button>
+            </div>
           </>
         )}
       </div>
@@ -1287,7 +1300,9 @@ function HistoryPinControl(props: {
             "pointer-events-auto flex size-5 shrink-0 items-center justify-center rounded-sm outline-none transition-[color,opacity] hover:bg-muted focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-wait",
             props.item.isPinned
               ? "text-primary opacity-100"
-              : "text-muted-foreground opacity-0 group-hover/list-row:opacity-100 group-focus-within/list-row:opacity-100",
+              : // Touch has no hover to reveal the control, and tapping the row
+                // navigates - so on coarse pointers it stays visible.
+                "text-muted-foreground opacity-0 group-hover/list-row:opacity-100 group-focus-within/list-row:opacity-100 pointer-coarse:opacity-100",
           )}
           onClick={() => {
             props.onSetPinned(props.item.epicId, !props.item.isPinned);
@@ -1391,7 +1406,7 @@ function HistoryTitleEditControl(props: {
         aria-label={`Edit title for ${historyItemDisplayTitle(props.item)}`}
         data-testid="epics-list-row-edit-title"
         disabled={props.isRenamePending}
-        className="pointer-events-auto size-5 opacity-0 transition-opacity hover:bg-muted focus-visible:opacity-100 group-hover:opacity-100"
+        className="pointer-events-auto size-5 opacity-0 transition-opacity hover:bg-muted focus-visible:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100"
         onClick={props.onStartRename}
       >
         <Pencil className="size-3.5" />
@@ -1486,7 +1501,7 @@ function HistoryRowDeleteControl(props: {
         aria-label={`Delete ${historyItemDisplayTitle(props.item)}`}
         aria-haspopup="dialog"
         data-testid="epics-list-row-delete"
-        className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
+        className="absolute right-2 top-1/2 -translate-y-1/2 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100"
         onClick={() => {
           props.onRequestDelete([props.item.epicId]);
         }}

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -435,7 +435,9 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
       <section
         className={cn(
           "flex min-h-0 w-full flex-col",
-          variant === "page" ? "mx-auto max-w-3xl flex-1 px-6 pt-6" : "mt-8",
+          variant === "page"
+            ? "mx-auto max-w-3xl flex-1 px-4 pt-4 md:px-6 md:pt-6"
+            : "mt-8",
         )}
       >
         {showChrome ? (
@@ -952,13 +954,18 @@ function HistoryRowTrailingMetadata(props: {
 }): ReactNode {
   const hasPrPills =
     !props.selectionMode && worktreePrReferences(props.worktrees).length > 0;
+  // Desktop (md+): label and pills share one grid cell and swap on
+  // hover/focus. Below md there is no hover, so the cell flattens into a
+  // flex line - label and pills sit side by side, pills persistently
+  // visible and tappable - on the row's wrapped second line (`pl-6` aligns
+  // it under the title, past the leading icon).
   return (
-    <span className="grid shrink-0 items-center justify-items-end text-ui-xs">
+    <span className="grid shrink-0 items-center justify-items-end text-ui-xs max-md:flex max-md:min-w-0 max-md:gap-2 max-md:pl-6">
       <span
         className={cn(
           "col-start-1 row-start-1 text-muted-foreground",
           hasPrPills &&
-            "transition-opacity group-hover/list-row:opacity-0 group-focus-within/list-row:opacity-0",
+            "transition-opacity md:group-hover/list-row:opacity-0 md:group-focus-within/list-row:opacity-0",
         )}
       >
         updated {props.updatedLabel}
@@ -968,7 +975,7 @@ function HistoryRowTrailingMetadata(props: {
           worktrees={props.worktrees}
           detailOnHover
           maximumVisible={2}
-          className="pointer-events-none col-start-1 row-start-1 max-w-[min(36vw,22rem)] overflow-hidden opacity-0 transition-opacity group-hover/list-row:pointer-events-auto group-hover/list-row:opacity-100 group-focus-within/list-row:pointer-events-auto group-focus-within/list-row:opacity-100 has-data-[state=open]:pointer-events-auto has-data-[state=open]:opacity-100"
+          className="pointer-events-none col-start-1 row-start-1 max-w-[min(36vw,22rem)] overflow-hidden opacity-0 transition-opacity group-hover/list-row:pointer-events-auto group-hover/list-row:opacity-100 group-focus-within/list-row:pointer-events-auto group-focus-within/list-row:opacity-100 has-data-[state=open]:pointer-events-auto has-data-[state=open]:opacity-100 max-md:pointer-events-auto max-md:max-w-full max-md:opacity-100"
           testId={`task-history-prs-${props.epicId}`}
         />
       ) : null}
@@ -1194,8 +1201,12 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
       })}
     >
       {rowInteractionLayer}
-      <div className="pointer-events-none relative z-10 flex items-center justify-between gap-3 p-3 pr-12 text-ui-sm">
-        <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+      {/* Below md the row wraps to two lines - title spans the full first
+          line (`basis-full` beats flex-1's 0% basis inside the media query)
+          and the metadata drops underneath - otherwise the shrink-0
+          "updated ..." label squeezes the title to nothing at phone width. */}
+      <div className="pointer-events-none relative z-10 flex items-center justify-between gap-3 p-3 pr-12 text-ui-sm max-md:flex-wrap max-md:gap-y-1">
+        <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden max-md:basis-full">
           <HistoryRowLeadingIcon item={item} />
           {isRenaming ? (
             <input

--- a/clients/gui-app/src/components/epics/history-modal-content.tsx
+++ b/clients/gui-app/src/components/epics/history-modal-content.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { EpicsListPanel } from "@/components/epics/epics-list-panel";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
 
 export interface HistoryModalContentProps {
   /**
@@ -14,17 +15,25 @@ export interface HistoryModalContentProps {
 export function HistoryModalContent(
   props: HistoryModalContentProps,
 ): ReactNode {
+  // No autofocus on phones: focusing the search input raises the on-screen
+  // keyboard over half the just-opened sheet.
+  const isMobile = useIsMobile();
   // `variant="page"` keeps the chrome (header + search + filters)
   // identical to the `/epics` strip-tab view so the modal and tab
   // forms read as the same surface, just framed differently.
+  //
+  // `min-w-0`: this div is a flex item of the frame's row-direction body,
+  // so without it `min-width: auto` sizes it to the list's content
+  // min-width - wider than the frame once titles outgrow the viewport,
+  // clipping the toolbar and row metadata past the right edge.
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       <EpicsListPanel
         variant="page"
         onSelectEpic={props.onSelectEpic}
         routeSearch={null}
         historyNowMs={null}
-        autoFocusSearch
+        autoFocusSearch={!isMobile}
       />
     </div>
   );

--- a/clients/gui-app/src/components/home/home-page.tsx
+++ b/clients/gui-app/src/components/home/home-page.tsx
@@ -9,6 +9,7 @@ import { HostWorkspaceSelector } from "@/components/home/host-workspace-selector
 import { EpicsListPanel } from "@/components/epics/epics-list-panel";
 import { LandingTerminalPanel } from "@/components/home/terminal-panel/landing-terminal-panel";
 import { parseSystemTabOverlayView } from "@/lib/system-tab-overlay-search";
+import "./home-touch-targets.css";
 
 export function HomePage() {
   // Subscribe to the render-stable shell, NOT the full draft: the active
@@ -40,8 +41,17 @@ export function HomePage() {
   );
 
   return (
-    <div className="relative flex min-h-0 flex-1 overflow-hidden bg-background text-foreground">
-      <div className="grid min-h-0 min-w-0 flex-1 grid-rows-[auto_minmax(0,1fr)_minmax(0,1fr)] overflow-hidden">
+    <div
+      data-home-touch-scope
+      className="relative flex min-h-0 flex-1 overflow-hidden bg-background text-foreground"
+    >
+      {/* The column track must be minmax(0,1fr), not the implicit `auto`: an
+          auto track's minimum is its items' min-content, so the composer
+          toolbar's intrinsic width would lock the whole column wider than a
+          narrow viewport (or the space left beside the terminal panel) and
+          the outer overflow-hidden would clip the right edge instead of
+          letting content reflow. */}
+      <div className="grid min-h-0 min-w-0 flex-1 grid-cols-[minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_minmax(0,1fr)] overflow-hidden">
         <div className="mx-auto w-full max-w-3xl px-6 pt-3">
           <HostUpdateBanner className={undefined} />
         </div>

--- a/clients/gui-app/src/components/home/home-touch-targets.css
+++ b/clients/gui-app/src/components/home/home-touch-targets.css
@@ -7,8 +7,9 @@
  * and terminal panel header; SelectTrigger 28-32px) sit below the 44px
  * touch-target guideline. These rules extend each control's *hit area* to
  * >=44px via an invisible pseudo-element - visual size and layout are
- * unchanged on every device, and the scope attribute (set by HomePage)
- * keeps the rest of the app untouched.
+ * unchanged on every device, and the scope attribute (set by HomePage and
+ * by the system-tab modal host, whose portal renders the same epics-list
+ * chrome outside HomePage's subtree) keeps the rest of the app untouched.
  *
  * Vertical-only slop: flush horizontal neighbours exist (the composer
  * toolbar's icon row, the epics-list chrome bar), and horizontal slop would

--- a/clients/gui-app/src/components/home/home-touch-targets.css
+++ b/clients/gui-app/src/components/home/home-touch-targets.css
@@ -1,0 +1,38 @@
+/*
+ * Home-scoped touch-target enlargement, mirroring the settings pattern in
+ * settings-touch-targets.css.
+ *
+ * On coarse-pointer devices, the shadcn primitives used across the landing
+ * page (Button sm/icon 28-32px in the composer toolbar, epics-list chrome,
+ * and terminal panel header; SelectTrigger 28-32px) sit below the 44px
+ * touch-target guideline. These rules extend each control's *hit area* to
+ * >=44px via an invisible pseudo-element - visual size and layout are
+ * unchanged on every device, and the scope attribute (set by HomePage)
+ * keeps the rest of the app untouched.
+ *
+ * Vertical-only slop: flush horizontal neighbours exist (the composer
+ * toolbar's icon row, the epics-list chrome bar), and horizontal slop would
+ * let them capture each other's taps.
+ *
+ * The `position: relative` fallback must skip `.absolute` controls (the
+ * epics-row delete button, the terminal panel's reveal toggle): this file is
+ * unlayered CSS, so it would beat Tailwind's layered `absolute` utility
+ * regardless of specificity and yank those controls back into flow. An
+ * absolutely positioned control already anchors its ::after itself.
+ */
+@media (pointer: coarse) {
+  [data-home-touch-scope]
+    :is([data-slot="button"], [data-slot="select-trigger"]):not(.absolute) {
+    position: relative;
+  }
+
+  [data-home-touch-scope]
+    :is([data-slot="button"], [data-slot="select-trigger"])::after {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    top: 50%;
+    height: max(100%, 44px);
+    transform: translateY(-50%);
+  }
+}

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-panel.tsx
@@ -33,6 +33,7 @@ import {
   usePointerDragCommit,
 } from "@/components/epic-canvas/canvas/use-pointer-drag-commit";
 import { useHomeWorkspaceSource } from "@/components/home/host-workspace-selector/use-home-workspace-source";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
 import { usePickAndAddWorkspaceFolders } from "@/components/home/host-workspace-selector/use-pick-and-add-folders";
 import type { WorktreeStagingKey } from "@/stores/worktree/worktree-intent-staging-store";
 import { workspaceMutationKeys } from "@/lib/query-keys";
@@ -351,6 +352,15 @@ function LandingTerminalPanelContents(
     panelWidthFraction: props.panelWidthFraction,
     setPanelWidthFraction: props.onSetPanelWidthFraction,
   });
+  // Below the mobile breakpoint a side-by-side split leaves both halves
+  // unusably narrow and the drag handle has no pointer to serve, so an open
+  // panel always renders through the maximized full-overlay path instead.
+  // The overlay geometry applies only while actually open: a closed panel
+  // physically collapses to the 0%-width in-flow strip on every device
+  // rather than lingering as an invisible full-viewport layer.
+  const isMobile = useIsMobile();
+  const fullOverlay = props.maximized || isMobile;
+  const overlayActive = fullOverlay && props.panelOpen;
   const createDisabledReason = landingTerminalCreateDisabledReason(
     props.availability,
     props.primaryWorkspacePath,
@@ -371,7 +381,7 @@ function LandingTerminalPanelContents(
     onCloseTab: props.onCloseTab,
     onCloseAllTabs: props.onCloseAllTabs,
   });
-  const panelStyle = props.maximized
+  const panelStyle = overlayActive
     ? undefined
     : { width: props.panelOpen ? `${props.panelWidthFraction * 100}%` : "0%" };
 
@@ -396,8 +406,7 @@ function LandingTerminalPanelContents(
         className={cn(
           "relative z-10 shrink-0 bg-background ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden",
           pointerDragHandleAxisClassName("horizontal"),
-          (!props.panelOpen || props.maximized) &&
-            "invisible pointer-events-none",
+          (!props.panelOpen || fullOverlay) && "invisible pointer-events-none",
         )}
       />
       <aside
@@ -412,12 +421,13 @@ function LandingTerminalPanelContents(
           // the panel rubber-bands behind the pointer.
           "[.traycer-panel-resizing_&]:transition-none",
           !props.panelOpen && "invisible pointer-events-none",
-          props.maximized && "absolute inset-0 z-20 w-full",
+          overlayActive && "absolute inset-0 z-20 w-full",
         )}
         style={panelStyle}
       >
         <LandingTerminalPanelHeader
           maximized={props.maximized}
+          showMaximize={!isMobile}
           onToggleMaximized={props.onToggleMaximized}
           onTogglePanel={props.onTogglePanel}
         />
@@ -656,6 +666,12 @@ function LandingTerminalPanelToggle(props: {
 
 function LandingTerminalPanelHeader(props: {
   readonly maximized: boolean;
+  /**
+   * Mobile renders the open panel as a full overlay regardless of the
+   * maximized bit, so the Maximize/Restore toggle would be a no-op there
+   * and is hidden.
+   */
+  readonly showMaximize: boolean;
   readonly onToggleMaximized: () => void;
   readonly onTogglePanel: () => void;
 }): ReactNode {
@@ -666,23 +682,25 @@ function LandingTerminalPanelHeader(props: {
         <span className="truncate">Terminal</span>
       </div>
       <div className="flex shrink-0 items-center">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label={
-            props.maximized
-              ? "Restore terminal panel"
-              : "Maximize terminal panel"
-          }
-          onClick={props.onToggleMaximized}
-        >
-          {props.maximized ? (
-            <Minimize2 className="size-4" />
-          ) : (
-            <Maximize2 className="size-4" />
-          )}
-        </Button>
+        {props.showMaximize ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={
+              props.maximized
+                ? "Restore terminal panel"
+                : "Maximize terminal panel"
+            }
+            onClick={props.onToggleMaximized}
+          >
+            {props.maximized ? (
+              <Minimize2 className="size-4" />
+            ) : (
+              <Maximize2 className="size-4" />
+            )}
+          </Button>
+        ) : null}
         <Button
           type="button"
           variant="ghost"

--- a/clients/gui-app/src/components/layout/dialogs/promotable-modal-frame.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/promotable-modal-frame.tsx
@@ -95,10 +95,13 @@ export function PromotableModalFrame(
             {props.title}
           </DialogPrimitive.Title>
           <div className="ml-auto flex items-center gap-1">
+            {/* No promote on phones: the strip-tab surface it opens isn't
+                mobile-ready, and below md the modal is already full-screen. */}
             <Button
               type="button"
               variant="ghost"
               size="icon-sm"
+              className="max-md:hidden"
               aria-label={props.promoteAriaLabel}
               data-testid={props.promoteTestId}
               onClick={props.onPromote}

--- a/clients/gui-app/src/components/layout/dialogs/system-tab-modal-host.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/system-tab-modal-host.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, type ReactNode } from "react";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { PromotableModalFrame } from "@/components/layout/dialogs/promotable-modal-frame";
+import "@/components/home/home-touch-targets.css";
 import {
   useSystemTabModalController,
   useSystemTabModalRefreshGuard,
@@ -72,8 +73,18 @@ function SystemTabModalSurface(props: SystemTabModalSurfaceProps): ReactNode {
     <PromotableModalFrame
       icon={<Icon className="size-4 text-muted-foreground" />}
       title={meta.label}
-      contentClassName="h-[80vh] w-[80vw] max-w-[min(95vw,80rem)]"
-      dataAttributes={{ "data-leader-scope": LEADER_SCOPE_SETTINGS }}
+      // Full-screen sheet below md: the centered 80% box leaves the History
+      // list unusably narrow on phones. Pure CSS (not a JS viewport check) so
+      // an open modal reflows correctly when the window crosses 768px.
+      contentClassName="h-[80vh] w-[80vw] max-w-[min(95vw,80rem)] max-md:h-dvh max-md:w-screen max-md:max-w-none max-md:rounded-none"
+      // The touch-target scope re-applies the coarse-pointer hit-slop rules
+      // (home-touch-targets.css) inside this portal - the modal body renders
+      // the same list chrome as the home page but portals outside the
+      // `[data-home-touch-scope]` subtree HomePage sets.
+      dataAttributes={{
+        "data-leader-scope": LEADER_SCOPE_SETTINGS,
+        "data-home-touch-scope": "",
+      }}
       promoteAriaLabel={`Open ${meta.label} as a tab`}
       promoteTestId={`system-tab-modal-promote-${active.kind}`}
       closeTestId={`system-tab-modal-close-${active.kind}`}

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -38,11 +38,45 @@ which maps each `SettingsSectionId` to its panel in a `switch`. A new section
 must be added in BOTH places - the route file under `src/routes/` AND the modal
 `switch` - or the modal renders a blank pane for that section.
 
+## Responsive Behavior (mobile)
+
+The **route** presentation collapses to a drill-down below the 768px
+`useIsMobile()` breakpoint: `/settings` renders the section list full-screen
+(`SettingsSidebar` with `variant="mobile-list"` - the index no longer
+redirects on phones), tapping a section navigates to its existing route
+full-screen, and `settings-layout.tsx` shows a back-to-list header instead of
+the rail. Desktop keeps the exact two-pane shell; the **modal** presentation
+is deliberately unchanged internally (it always renders the rail variant) and
+simply never opens on phones: `openSettings` in
+`src/stores/tabs/use-system-tab-modal.ts` - the single funnel for every modal
+entry point (user menu, deep-links, the palette/keybinding bridge) - gates on
+`isMobileViewport()` and navigates to the full-page route instead
+(`/settings/<section>` when a section is requested, else `/settings`).
+History keeps its modal on every viewport.
+
+Supporting pieces, all viewport-agnostic where possible:
+
+- `settings-row.tsx` uses `flex-wrap` + a label `basis` so small controls
+  (switches) stay inline while wide controls wrap below the label on narrow
+  containers.
+- `settings-panel-shell.tsx` (and the inline shells in the Keybindings and
+  Shell panels) step padding down below `sm`; the shell header wraps.
+- The Providers rail collapses below `md` into a full-width provider `Select`
+  above the detail pane. `EnvOverrideEditor` rows restack onto two lines below
+  `sm` and hide the column header.
+- `settings-touch-targets.css` (imported by `settings-layout.tsx`, scoped
+  under `[data-settings-touch-scope]`) enlarges the *hit areas* of
+  switch/button/select-trigger primitives to >=44px on coarse-pointer devices
+  without changing any visual size - settings-only, the shared primitives in
+  `src/components/ui/` are untouched.
+
 ## Key Files
 
 - `settings-layout.tsx` Owns the two-column shell for the settings route.
 - `settings-sidebar.tsx` Renders navigation from `settings-sections.ts`.
 - `settings-panel-shell.tsx` Shared width, card shell, and panel spacing.
+- `settings-touch-targets.css` Coarse-pointer hit-area rules for the route
+  shell (see below).
 - `panels/*.tsx` Route-mounted settings sections.
 - `controls/settings-select.tsx` Shared select wrapper used by settings rows.
 - `src/stores/settings-store.ts` Persisted local settings state.

--- a/clients/gui-app/src/components/settings/__tests__/settings-sidebar.test.tsx
+++ b/clients/gui-app/src/components/settings/__tests__/settings-sidebar.test.tsx
@@ -22,7 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function buildRouter(initialPath: string) {
   const rootRoute = createRootRoute({
-    component: () => <SettingsSidebar mode={{ kind: "route" }} />,
+    component: () => <SettingsSidebar mode={{ kind: "route" }} variant="rail" />,
   });
   const settingsRoute = createRoute({
     getParentRoute: () => rootRoute,

--- a/clients/gui-app/src/components/settings/panels/env-override-editor.tsx
+++ b/clients/gui-app/src/components/settings/panels/env-override-editor.tsx
@@ -24,9 +24,15 @@ const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 // Single grid shared by the header, every row, and the add row so the column
 // edges line up exactly (the previous header/rows used different padding). The
 // last track is fixed so the row delete button and the add button never shift
-// the Name/Value boundaries.
+// the Name/Value boundaries. Below `sm` the three columns can't fit, so rows
+// restack onto two lines - name + actions, then the value field full-width
+// (see VALUE_FIELD_PLACEMENT / ROW_ACTIONS_PLACEMENT) - and the header hides.
 const GRID =
-  "grid grid-cols-[minmax(0,1fr)_minmax(0,1.7fr)_4.75rem] items-center gap-2";
+  "grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1.7fr)_4.75rem]";
+const VALUE_FIELD_PLACEMENT =
+  "col-span-2 row-start-2 sm:col-span-1 sm:row-start-auto";
+const ROW_ACTIONS_PLACEMENT =
+  "col-start-2 row-start-1 justify-self-end sm:col-start-auto sm:row-start-auto sm:justify-self-center";
 
 type EnvMode = "set" | "unset";
 
@@ -86,7 +92,7 @@ export function EnvOverrideEditor(props: {
       <div
         className={cn(
           GRID,
-          "border-b border-border/40 bg-muted/30 px-3 py-2 text-ui-xs font-medium text-muted-foreground",
+          "hidden border-b border-border/40 bg-muted/30 px-3 py-2 text-ui-xs font-medium text-muted-foreground sm:grid",
         )}
       >
         <span>Name</span>
@@ -201,6 +207,7 @@ function EnvOverrideRow(props: {
           mode={draft.mode}
           disabled={disabled}
           ariaLabel={`Value for ${entry.key}`}
+          className={VALUE_FIELD_PLACEMENT}
           onModeChange={(mode) => setDraft((current) => ({ ...current, mode }))}
           onValueChange={(value) =>
             setDraft((current) => ({ ...current, value }))
@@ -212,7 +219,10 @@ function EnvOverrideRow(props: {
           disabled={disabled}
           onClick={() => onDelete(entry.key)}
           aria-label={`Remove ${entry.key}`}
-          className="flex size-8 items-center justify-center justify-self-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-destructive disabled:opacity-50"
+          className={cn(
+            ROW_ACTIONS_PLACEMENT,
+            "flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-destructive disabled:opacity-50",
+          )}
         >
           <Trash2 className="size-4" />
         </button>
@@ -268,13 +278,14 @@ function EnvOverrideAddRow(props: {
           mode={draft.mode}
           disabled={disabled}
           ariaLabel="New environment variable value"
+          className={VALUE_FIELD_PLACEMENT}
           onModeChange={(mode) => setDraft((current) => ({ ...current, mode }))}
           onValueChange={(value) =>
             setDraft((current) => ({ ...current, value }))
           }
           onBlur={() => undefined}
         />
-        <div className="flex justify-self-center">
+        <div className={cn(ROW_ACTIONS_PLACEMENT, "flex")}>
           <Button
             type="button"
             size="icon-sm"
@@ -309,6 +320,7 @@ function EnvValueField(props: {
   readonly mode: EnvMode;
   readonly disabled: boolean;
   readonly ariaLabel: string;
+  readonly className: string;
   readonly onModeChange: (mode: EnvMode) => void;
   readonly onValueChange: (value: string) => void;
   readonly onBlur: () => void;
@@ -318,12 +330,13 @@ function EnvValueField(props: {
     mode,
     disabled,
     ariaLabel,
+    className,
     onModeChange,
     onValueChange,
     onBlur,
   } = props;
   return (
-    <div className="flex min-w-0 items-center gap-2">
+    <div className={cn("flex min-w-0 items-center gap-2", className)}>
       <Select
         value={mode}
         disabled={disabled}

--- a/clients/gui-app/src/components/settings/panels/keybindings-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/keybindings-settings-panel.tsx
@@ -27,8 +27,8 @@ export function KeybindingsSettingsPanel() {
   );
 
   return (
-    <section className="mx-auto w-full max-w-5xl px-8 py-10">
-      <header className="sticky top-0 z-10 -mx-8 mb-8 bg-background/95 px-8 py-2 backdrop-blur">
+    <section className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-8 sm:py-10">
+      <header className="sticky top-0 z-10 -mx-4 mb-8 bg-background/95 px-4 py-2 backdrop-blur sm:-mx-8 sm:px-8">
         <h1 className="text-title-lg font-semibold text-foreground">
           Keybindings
         </h1>

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -371,6 +371,14 @@ function ProvidersRailLayout({
   const active =
     orderedProviders.find((p) => p.providerId === activeId) ??
     orderedProviders[0];
+  const selectProvider = (providerId: ProviderId): void => {
+    setInitialFocus({
+      harnessId: null,
+      profileId: null,
+      startSignIn: false,
+    });
+    setActiveId(providerId);
+  };
 
   return (
     // Fill the panel body (the shell stretches it to the settings scroll
@@ -378,10 +386,19 @@ function ProvidersRailLayout({
     // providers never resizes the box and the detail pane - not the outer
     // overlay - owns the scroll. Height follows the viewport: on shorter
     // screens it shrinks to fit the modal instead of overflowing it.
-    <div className="flex h-full">
+    // Below md the rail column collapses into a full-width provider select
+    // stacked above the detail pane.
+    <div className="flex h-full flex-col md:flex-row">
+      <div className="shrink-0 border-b border-border/60 p-2 md:hidden">
+        <ProvidersMobileSelect
+          providers={orderedProviders}
+          activeId={active.providerId}
+          onSelect={selectProvider}
+        />
+      </div>
       <nav
         aria-label="Providers"
-        className="flex w-[clamp(10rem,22vw,14rem)] shrink-0 flex-col gap-1 overflow-y-auto border-r border-border/60 p-2"
+        className="hidden w-[clamp(10rem,22vw,14rem)] shrink-0 flex-col gap-1 overflow-y-auto border-r border-border/60 p-2 md:flex"
       >
         <ProviderList
           ariaLabel="Providers"
@@ -395,14 +412,7 @@ function ProvidersRailLayout({
             badge: null,
             description: null,
             trailing: null,
-            onSelect: (providerId) => {
-              setInitialFocus({
-                harnessId: null,
-                profileId: null,
-                startSignIn: false,
-              });
-              setActiveId(providerId);
-            },
+            onSelect: selectProvider,
           }))}
         />
       </nav>
@@ -418,6 +428,35 @@ function ProvidersRailLayout({
         />
       </div>
     </div>
+  );
+}
+
+function ProvidersMobileSelect(props: {
+  readonly providers: readonly ProviderCliState[];
+  readonly activeId: ProviderId;
+  readonly onSelect: (providerId: ProviderId) => void;
+}): ReactNode {
+  return (
+    <Select
+      value={props.activeId}
+      onValueChange={(value) => {
+        // Resolve through the provider list instead of asserting the select's
+        // string value back into the ProviderId union.
+        const match = props.providers.find((p) => p.providerId === value);
+        if (match !== undefined) props.onSelect(match.providerId);
+      }}
+    >
+      <SelectTrigger aria-label="Provider" className="w-full">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {props.providers.map((provider) => (
+          <SelectItem key={provider.providerId} value={provider.providerId}>
+            {PROVIDER_DISPLAY_NAMES[provider.providerId]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }
 

--- a/clients/gui-app/src/components/settings/panels/shell-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/shell-settings-panel.tsx
@@ -152,7 +152,7 @@ function ShellSettingsPanelInner() {
   };
 
   return (
-    <section className="mx-auto w-full max-w-5xl px-8 py-10">
+    <section className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-8 sm:py-10">
       <header className="mb-8 space-y-2">
         <h1 className="text-title-lg font-semibold text-foreground">Shell</h1>
         <p className="max-w-2xl text-ui-sm text-muted-foreground">

--- a/clients/gui-app/src/components/settings/settings-layout.tsx
+++ b/clients/gui-app/src/components/settings/settings-layout.tsx
@@ -1,13 +1,56 @@
-import { Outlet } from "@tanstack/react-router";
+import { Link, Outlet, useRouterState } from "@tanstack/react-router";
+import { ChevronLeft } from "lucide-react";
 import { SettingsSidebar } from "@/components/settings/settings-sidebar";
+import { SETTINGS_SECTIONS } from "@/lib/settings-sections";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
+import { cn } from "@/lib/utils";
+import "./settings-touch-targets.css";
 
 export function SettingsLayout() {
+  const isMobile = useIsMobile();
   return (
-    <div className="flex min-h-0 flex-1 bg-background text-foreground">
-      <SettingsSidebar mode={{ kind: "route" }} />
+    <div
+      data-settings-touch-scope
+      className={cn(
+        "flex min-h-0 flex-1 bg-background text-foreground",
+        isMobile && "flex-col",
+      )}
+    >
+      {isMobile ? (
+        <MobileSectionHeader />
+      ) : (
+        <SettingsSidebar mode={{ kind: "route" }} variant="rail" />
+      )}
       <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
         <Outlet />
       </div>
+    </div>
+  );
+}
+
+/**
+ * Mobile drill-down header: on a section route, a back link to the
+ * full-screen section list at `/settings`. On the index (the list itself)
+ * there is nothing to go back to, so nothing renders.
+ */
+function MobileSectionHeader() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const section = SETTINGS_SECTIONS.find((s) =>
+    pathname.startsWith(`/settings/${s.id}`),
+  );
+  if (section === undefined) return null;
+  return (
+    <div className="flex shrink-0 items-center gap-1 border-b border-border/60 px-2 py-1.5">
+      <Link
+        to="/settings"
+        className="inline-flex min-h-10 items-center gap-1 rounded-md px-2 text-ui-sm text-muted-foreground transition-colors hover:bg-accent/60 hover:text-accent-foreground"
+      >
+        <ChevronLeft className="size-4" />
+        Settings
+      </Link>
+      <span className="min-w-0 truncate text-ui-sm font-medium text-foreground">
+        {section.label}
+      </span>
     </div>
   );
 }

--- a/clients/gui-app/src/components/settings/settings-modal-content.tsx
+++ b/clients/gui-app/src/components/settings/settings-modal-content.tsx
@@ -35,6 +35,7 @@ export function SettingsModalContent(
           activeSection: section,
           onSelect: setSection,
         }}
+        variant="rail"
       />
       <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
         <SettingsPanelForSection section={section} />

--- a/clients/gui-app/src/components/settings/settings-panel-shell.tsx
+++ b/clients/gui-app/src/components/settings/settings-panel-shell.tsx
@@ -31,11 +31,11 @@ export function SettingsPanelShell(props: SettingsPanelShellProps) {
     <section
       data-settings-panel-shell
       className={cn(
-        "mx-auto w-full max-w-5xl px-8 py-10",
+        "mx-auto w-full max-w-5xl px-4 py-6 sm:px-8 sm:py-10",
         fillHeight && "flex h-full flex-col",
       )}
     >
-      <header className="mb-8 flex items-start justify-between gap-4">
+      <header className="mb-8 flex flex-wrap items-start justify-between gap-4">
         <div className="min-w-0 space-y-2">
           <h1 className="text-title-lg font-semibold text-foreground">
             {title}

--- a/clients/gui-app/src/components/settings/settings-row.tsx
+++ b/clients/gui-app/src/components/settings/settings-row.tsx
@@ -9,14 +9,17 @@ interface SettingsRowProps {
 export function SettingsRow(props: SettingsRowProps) {
   const { label, description, control } = props;
   return (
-    <div className="flex items-start justify-between gap-6 border-b border-border/40 px-5 py-4 last:border-b-0">
-      <div className="min-w-0 space-y-1">
+    // flex-wrap + the label's basis keep small controls (switches) inline
+    // beside the label while wide controls (pickers, selects) wrap below it
+    // once the row gets narrow - no breakpoint, so it holds in any container.
+    <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3 border-b border-border/40 px-5 py-4 last:border-b-0">
+      <div className="min-w-0 grow basis-48 space-y-1">
         <div className="font-medium text-foreground">{label}</div>
         {description ? (
           <p className="text-ui-sm text-muted-foreground">{description}</p>
         ) : null}
       </div>
-      <div className="shrink-0">{control}</div>
+      <div className="max-w-full shrink-0">{control}</div>
     </div>
   );
 }

--- a/clients/gui-app/src/components/settings/settings-sidebar.tsx
+++ b/clients/gui-app/src/components/settings/settings-sidebar.tsx
@@ -1,4 +1,5 @@
 import { Link, useRouterState } from "@tanstack/react-router";
+import { ChevronRight } from "lucide-react";
 import { AnimatePresence } from "motion/react";
 import { cn } from "@/lib/utils";
 import {
@@ -22,13 +23,28 @@ export type SettingsSidebarMode =
       readonly onSelect: (section: SettingsSectionId) => void;
     };
 
+/**
+ * "rail" is the desktop two-pane nav column; "mobile-list" is the same
+ * sections rendered as a full-width drill-down list (the `/settings` index on
+ * phones).
+ */
+export type SettingsSidebarVariant = "rail" | "mobile-list";
+
 export interface SettingsSidebarProps {
   readonly mode: SettingsSidebarMode;
+  readonly variant: SettingsSidebarVariant;
 }
 
 export function SettingsSidebar(props: SettingsSidebarProps) {
   return (
-    <aside className="flex w-64 shrink-0 flex-col gap-1 border-r border-border/60 bg-background p-4">
+    <aside
+      className={cn(
+        "flex shrink-0 flex-col gap-1 bg-background p-4",
+        props.variant === "rail"
+          ? "w-64 border-r border-border/60"
+          : "w-full overflow-y-auto",
+      )}
+    >
       <div className="flex flex-col gap-1">
         {SETTINGS_SECTIONS.map((section, index) => (
           <SettingsSidebarItem
@@ -36,6 +52,7 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
             section={section}
             index={index}
             mode={props.mode}
+            variant={props.variant}
           />
         ))}
       </div>
@@ -47,15 +64,18 @@ interface SettingsSidebarItemProps {
   section: SettingsSection;
   index: number;
   mode: SettingsSidebarMode;
+  variant: SettingsSidebarVariant;
 }
 
 function SettingsSidebarItem(props: SettingsSidebarItemProps) {
-  const { section, index, mode } = props;
+  const { section, index, mode, variant } = props;
   const badgeModifier = useSettingsLeaderModifierForIndex(index);
   const Icon = section.icon;
   const digit = singleDigitLeaderDigitFor(index);
-  const baseClass =
-    "inline-flex items-center gap-3 rounded-md px-3 py-2 text-ui-sm transition-colors";
+  const baseClass = cn(
+    "inline-flex items-center gap-3 rounded-md px-3 text-ui-sm transition-colors",
+    variant === "mobile-list" ? "py-3" : "py-2",
+  );
   const badge = (
     <span className="flex min-w-5 justify-end">
       <AnimatePresence initial={false}>
@@ -99,14 +119,23 @@ function SettingsSidebarItem(props: SettingsSidebarItemProps) {
       </button>
     );
   }
-  return <SettingsSidebarRouteItem section={section} badge={badge} />;
+  return (
+    <SettingsSidebarRouteItem
+      section={section}
+      badge={badge}
+      baseClass={baseClass}
+      variant={variant}
+    />
+  );
 }
 
 function SettingsSidebarRouteItem(props: {
   readonly section: SettingsSection;
   readonly badge: React.ReactNode;
+  readonly baseClass: string;
+  readonly variant: SettingsSidebarVariant;
 }) {
-  const { section, badge } = props;
+  const { section, badge, baseClass, variant } = props;
   const Icon = section.icon;
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const active = pathname.startsWith(`/settings/${section.id}`);
@@ -121,7 +150,7 @@ function SettingsSidebarRouteItem(props: {
         });
       }}
       className={cn(
-        "inline-flex items-center gap-3 rounded-md px-3 py-2 text-ui-sm transition-colors",
+        baseClass,
         active
           ? "bg-accent text-accent-foreground"
           : "text-foreground/70 hover:bg-accent/60 hover:text-accent-foreground",
@@ -130,6 +159,9 @@ function SettingsSidebarRouteItem(props: {
       <Icon className="size-4" />
       <span className="flex-1">{section.label}</span>
       {badge}
+      {variant === "mobile-list" ? (
+        <ChevronRight className="size-4 shrink-0 text-muted-foreground/60" />
+      ) : null}
     </Link>
   );
 }

--- a/clients/gui-app/src/components/settings/settings-touch-targets.css
+++ b/clients/gui-app/src/components/settings/settings-touch-targets.css
@@ -1,0 +1,45 @@
+/*
+ * Settings-scoped touch-target enlargement (see SETTINGS.md).
+ *
+ * On coarse-pointer devices, the shadcn primitives used across settings
+ * (Switch ~18px, Button sm/icon 28-32px, SelectTrigger 28-32px) sit below the
+ * 44px touch-target guideline. These rules extend each control's *hit area*
+ * to >=44px via an invisible pseudo-element - visual size and layout are
+ * unchanged on every device, and the scope attribute (set by SettingsLayout)
+ * keeps the rest of the app untouched.
+ *
+ * Buttons and select triggers get vertical-only slop: flush horizontal
+ * neighbours exist (e.g. the env editor's apply/discard pair), and horizontal
+ * slop would let them capture each other's taps. The switch is never flush
+ * against another control, so it grows on both axes.
+ */
+@media (pointer: coarse) {
+  [data-settings-touch-scope]
+    :is(
+      [data-slot="switch"],
+      [data-slot="button"],
+      [data-slot="select-trigger"]
+    ) {
+    position: relative;
+  }
+
+  [data-settings-touch-scope]
+    :is([data-slot="button"], [data-slot="select-trigger"])::after {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    top: 50%;
+    height: max(100%, 44px);
+    transform: translateY(-50%);
+  }
+
+  [data-settings-touch-scope] [data-slot="switch"]::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: max(100%, 44px);
+    height: max(100%, 44px);
+    transform: translate(-50%, -50%);
+  }
+}

--- a/clients/gui-app/src/hooks/ui/use-mobile.ts
+++ b/clients/gui-app/src/hooks/ui/use-mobile.ts
@@ -24,3 +24,12 @@ export function useIsMobile(): boolean {
     readIsMobileServerSnapshot,
   );
 }
+
+/**
+ * Imperative read of the same breakpoint for command-time call sites (event
+ * handlers, non-subscribing actions) that must not re-render on viewport
+ * changes.
+ */
+export function isMobileViewport(): boolean {
+  return readIsMobileSnapshot();
+}

--- a/clients/gui-app/src/routes/settings-index-route-components.tsx
+++ b/clients/gui-app/src/routes/settings-index-route-components.tsx
@@ -1,5 +1,16 @@
 import { Navigate } from "@tanstack/react-router";
+import { SettingsSidebar } from "@/components/settings/settings-sidebar";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
 
+/**
+ * On phones, `/settings` is the drill-down entry: a full-screen list of
+ * sections (SettingsLayout renders no rail there). On wider screens the rail
+ * already shows every section, so the index redirects to General as before.
+ */
 export function SettingsIndexRedirect() {
+  const isMobile = useIsMobile();
+  if (isMobile) {
+    return <SettingsSidebar mode={{ kind: "route" }} variant="mobile-list" />;
+  }
   return <Navigate to="/settings/general" replace />;
 }

--- a/clients/gui-app/src/stores/tabs/kinds/settings.tsx
+++ b/clients/gui-app/src/stores/tabs/kinds/settings.tsx
@@ -13,7 +13,7 @@ const SETTINGS_PATH_PREFIX = "/settings";
 const SETTINGS_DEFAULT_PATH = "/settings/general";
 const LEGACY_SERVICE_PATH = "/settings/service";
 
-function settingsRouteOptions(section: SettingsSectionId) {
+export function settingsRouteOptions(section: SettingsSectionId) {
   switch (section) {
     case "general":
       return { to: "/settings/general" } as const;

--- a/clients/gui-app/src/stores/tabs/use-system-tab-modal.ts
+++ b/clients/gui-app/src/stores/tabs/use-system-tab-modal.ts
@@ -12,6 +12,8 @@ import {
   ensureHistoryTab,
   ensureSettingsTab,
 } from "@/lib/commands/actions/open-system-tab";
+import { isMobileViewport } from "@/hooks/ui/use-mobile";
+import { settingsRouteOptions } from "@/stores/tabs/kinds/settings";
 import { type TabNavigationIntent } from "@/lib/tab-navigation";
 import { tabActivate, tabRouteOptions } from "@/stores/tabs/registry";
 import {
@@ -69,6 +71,21 @@ export function useSystemTabModalActions(): SystemTabModalActions {
 
   const openSettings = useCallback(
     (opts: OpenSettingsModalOpts) => {
+      // On phones the two-pane modal never opens: settings is only the
+      // full-page drill-down. Every modal entry point (user menu, deep-links,
+      // the bridge for palette/keybindings) funnels through here, so this one
+      // gate routes them all to `/settings` (the section list) or straight to
+      // the requested section. History keeps its modal on every viewport.
+      if (isMobileViewport()) {
+        // No `search` reducer: leaving the current route drops the overlay
+        // params on its own, and the settings routes carry no search schema.
+        if (opts.section !== null) {
+          void router.navigate(settingsRouteOptions(opts.section));
+          return;
+        }
+        void router.navigate({ to: "/settings" });
+        return;
+      }
       const settingsTab = useTabsStore.getState().systemTabs.settings;
       if (settingsTab !== null) {
         navigateToTabClearingOverlay(


### PR DESCRIPTION
## What

Makes three GUI surfaces responsive + touch-friendly on phones, stacked on top of the `mobile-app` Capacitor client. Desktop (≥768px) behavior is unchanged throughout — every change is gated at `max-md:`/`useIsMobile()` or is desktop-neutral by construction.

## Commits

- **Settings** — mobile drill-down for the full-page `/settings` (section list → panel → back), settings-scoped coarse-pointer touch targets, fluid row wrapping, Providers rail → `Select` on narrow, env-editor stacking, and a mobile redirect of the settings-modal entry points to the full page.
- **Landing / Home** — fixes the main grid column clipping the page below its content min-width (`grid-cols-[minmax(0,1fr)]`) so hero/composer/recents reflow and the composer's narrow mode engages; landing terminal panel becomes a full-screen overlay below 768px; recents-list row actions become tap-reachable on coarse pointers; scoped touch-target hit-slop; and the epics toolbar wraps cleanly at narrow width.
- **History** — the shared system-tab modal becomes a full-screen sheet below 768px; fixes a horizontal-overflow bug (`min-w-0`); gates search autofocus off on mobile; two-line epics rows with tappable PR pills; hides the promote/"Open as tab" button on phones; and applies coarse-pointer touch-target slop inside the modal.

## Verification

Each page was implemented, verified live at phone widths (320/375px), and independently cold-reviewed:
- Desktop ≥768px measured unchanged (pixel-identical for the Landing grid fix and the History modal box).
- `lint` clean; targeted `home` / `epics` / `settings` / `promotable-modal-frame` test suites pass.

## Notes / out of scope

- Pre-existing `compile`/`test` failures from a duplicated `prosemirror-model` in the bun store (editor-core/artifacts) are unrelated to this change.
- Separate pre-existing issues surfaced during testing but intentionally **not** addressed here: the app shell's `h-screen` (vs `h-dvh`) bottom-cutoff on mobile browsers; a shared History/Home search-state leak; History backdrop-click not closing on desktop.