### PR TITLE
fix(gui-app): surface provider auth failures durably

### DIFF
--- a/clients/gui-app/src/components/chat/segments/__tests__/error-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/error-segment.test.tsx
@@ -12,10 +12,9 @@ describe("<ErrorSegment />", () => {
     useDesktopDialogStore.setState({ reportIssueAvailable: false });
   });
 
-  // Auth errors never reach this component - they're suppressed at the
-  // projection layer (`suppressAuthErrors`). This is the static chrome for every
-  // other (non-auth) error: the "Error" overline, the code badge, and the
-  // message.
+  // Every error - auth included - renders through this component as the
+  // failure's durable transcript record. This is the static chrome shared by
+  // all codes: the "Error" overline, the code badge, and the message.
   it("renders the error chrome with the code badge and message", () => {
     render(
       <ErrorSegment

--- a/clients/gui-app/src/components/chat/segments/error-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/error-segment.tsx
@@ -8,9 +8,9 @@ interface ErrorSegmentProps {
   findUnitId: string | null;
 }
 
-// Static error row. Auth errors never reach here - they are suppressed at the
-// projection layer (`suppressAuthErrors` in `rendered-messages.ts`) and surfaced
-// live as the composer's re-auth banner instead.
+// Static error row. Auth errors (`code: "auth"`) render here like any other
+// error - the durable transcript row is what keeps a headless (A2A-triggered)
+// auth failure visible after the composer's re-auth banner clears.
 export function ErrorSegment({ code, findUnitId, message }: ErrorSegmentProps) {
   return (
     <div

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -4970,4 +4970,84 @@ describe("createChatSessionStore - persisted auth-error provider nudge", () => {
     ]);
     expect(harness.nudgeCount()).toBe(0);
   });
+
+  it("does not double-nudge when a live auth event's turn is later re-delivered by a snapshot", () => {
+    const harness = createNudgeHarness();
+    const callbacks = harness.callbacks();
+
+    // The live turn fails on auth mid-session: onBlockDelta fires the nudge
+    // directly (no persisted row exists yet to read from).
+    callbacks.onTurnStateChanged({
+      kind: "turnStateChanged",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      runStatus: "running",
+      activeTurn: {
+        turnId: "turn-live-auth-1",
+        status: "running",
+        harnessId: "codex",
+        model: "gpt-5-codex",
+        agentMode: "regular",
+        profileId: null,
+        userMessageId: "message-live-1",
+        startedAt: 3,
+        updatedAt: 3,
+        reasoningEffort: null,
+        serviceTier: null,
+      },
+    });
+    callbacks.onBlockDelta({
+      kind: "blockDelta",
+      hasBinaryPayload: false,
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      event: {
+        type: "error",
+        blockId: "auth-live-1",
+        timestamp: 4,
+        message: "Codex is signed out on this machine.",
+        recoverable: true,
+        code: "auth",
+      },
+    });
+    expect(harness.nudgeCount()).toBe(1);
+
+    // The turn's own persisted row (same turnId) then arrives via snapshot -
+    // a reconnect, or the same connection catching up. It must NOT re-nudge:
+    // it is the SAME failure the live path already reported.
+    emitMessagesSnapshot(callbacks, [
+      {
+        role: "assistant",
+        messageId: "assistant-live-auth-1",
+        sender: {
+          type: "agent",
+          harnessId: "codex",
+          agentId: "codex",
+          displayName: "Codex",
+          reply: { expectsReply: false },
+          inReplyTo: null,
+        },
+        blocks: [
+          {
+            type: "error",
+            blockId: "auth-live-1",
+            status: "completed",
+            timestamp: 4,
+            parentBlockId: null,
+            message: "Codex is signed out on this machine.",
+            recoverable: true,
+            code: "auth",
+          },
+        ],
+        startedAt: 3,
+        timestamp: 4,
+        turnId: "turn-live-auth-1",
+        usage: null,
+        reasoningEffort: null,
+        serviceTier: null,
+      },
+    ]);
+    expect(harness.nudgeCount()).toBe(1);
+  });
 });

--- a/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
+++ b/clients/gui-app/src/stores/chats/__tests__/chat-session-store.test.ts
@@ -4826,3 +4826,148 @@ describe("non-message pendings across a missed-ack reconnect", () => {
     expect(harness.handle.store.getState().restore).toBeNull();
   });
 });
+
+describe("createChatSessionStore - persisted auth-error provider nudge", () => {
+  function authErroredAssistantMessage(
+    messageId: string,
+    code: string | null,
+  ): Extract<Message, { role: "assistant" }> {
+    return {
+      role: "assistant",
+      messageId,
+      sender: {
+        type: "agent",
+        harnessId: "codex",
+        agentId: "codex",
+        displayName: "Codex",
+        reply: { expectsReply: false },
+        inReplyTo: null,
+      },
+      blocks:
+        code === null
+          ? []
+          : [
+              {
+                type: "error",
+                blockId: `error-${messageId}`,
+                status: "completed",
+                timestamp: 4,
+                parentBlockId: null,
+                message: "Codex is signed out on this machine.",
+                recoverable: true,
+                code,
+              },
+            ],
+      startedAt: 4,
+      timestamp: 4,
+      turnId: `turn-${messageId}`,
+      usage: null,
+      reasoningEffort: null,
+      serviceTier: null,
+    };
+  }
+
+  interface NudgeHarness {
+    readonly handle: ChatSessionStoreHandle;
+    callbacks(): ChatStreamCallbacks;
+    nudgeCount(): number;
+  }
+
+  function createNudgeHarness(): NudgeHarness {
+    let nudges = 0;
+    let callbacks: ChatStreamCallbacks | null = null;
+    const handle = createChatSessionStore({
+      epicId: EPIC_ID,
+      chatId: CHAT_ID,
+      userId: OWNER_ID,
+      onAuthError: null,
+      onProviderAuthError: () => {
+        nudges += 1;
+      },
+      streamFlushCoordinator: IMMEDIATE_STREAM_FLUSH_COORDINATOR,
+      streamClientFactory: (_epicId, _chatId, nextCallbacks) => {
+        callbacks = nextCallbacks;
+        return {
+          sendAction: () => undefined,
+          close: () => undefined,
+        };
+      },
+    });
+    return {
+      handle,
+      callbacks: () => {
+        if (callbacks === null) throw new Error("Expected callbacks");
+        return callbacks;
+      },
+      nudgeCount: () => nudges,
+    };
+  }
+
+  function emitMessagesSnapshot(
+    callbacks: ChatStreamCallbacks,
+    messages: ReadonlyArray<Message>,
+  ): void {
+    emitSnapshotFrame({
+      callbacks,
+      access: "owner",
+      messages,
+      queue: { status: "idle", items: [] },
+      pendingFileEditApprovals: [],
+    });
+  }
+
+  it("nudges once per persisted auth-error row, even across reconnect re-delivery", () => {
+    const harness = createNudgeHarness();
+    const authRow = authErroredAssistantMessage("assistant-auth-1", "auth");
+    emitMessagesSnapshot(harness.callbacks(), [authRow]);
+    expect(harness.nudgeCount()).toBe(1);
+
+    // Reconnect re-delivers the SAME row: no duplicate nudge.
+    harness.callbacks().onConnectionStatus("reconnecting", null);
+    emitMessagesSnapshot(harness.callbacks(), [authRow]);
+    expect(harness.nudgeCount()).toBe(1);
+  });
+
+  it("nudges again for a NEW auth failure after the first one recovered", () => {
+    const harness = createNudgeHarness();
+    emitMessagesSnapshot(harness.callbacks(), [
+      authErroredAssistantMessage("assistant-auth-1", "auth"),
+    ]);
+    expect(harness.nudgeCount()).toBe(1);
+
+    // Recovered: latest assistant row carries no auth error.
+    emitMessagesSnapshot(harness.callbacks(), [
+      authErroredAssistantMessage("assistant-auth-1", "auth"),
+      authErroredAssistantMessage("assistant-ok", null),
+    ]);
+    expect(harness.nudgeCount()).toBe(1);
+
+    // A second headless failure lands during a disconnect; the reconnect
+    // snapshot is its only signal, so the store must nudge again - a
+    // store-lifetime latch would leave the provider gate stale here.
+    harness.callbacks().onConnectionStatus("reconnecting", null);
+    emitMessagesSnapshot(harness.callbacks(), [
+      authErroredAssistantMessage("assistant-auth-1", "auth"),
+      authErroredAssistantMessage("assistant-ok", null),
+      authErroredAssistantMessage("assistant-auth-2", "auth"),
+    ]);
+    expect(harness.nudgeCount()).toBe(2);
+  });
+
+  it("finds the latest assistant row behind a trailing user row", () => {
+    const harness = createNudgeHarness();
+    emitMessagesSnapshot(harness.callbacks(), [
+      authErroredAssistantMessage("assistant-auth-1", "auth"),
+      persistedUserMessage("user-after-failure"),
+    ]);
+    expect(harness.nudgeCount()).toBe(1);
+  });
+
+  it("does not nudge for a non-auth error on the latest assistant row", () => {
+    const harness = createNudgeHarness();
+    emitMessagesSnapshot(harness.callbacks(), [
+      authErroredAssistantMessage("assistant-runtime-err", "RUNTIME_THROWN"),
+    ]);
+    expect(harness.nudgeCount()).toBe(0);
+  });
+});

--- a/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
+++ b/clients/gui-app/src/stores/chats/__tests__/rendered-messages.test.tsx
@@ -4887,7 +4887,7 @@ describe("useRenderedMessages head/tail partition", () => {
     ]);
   });
 
-  it("suppresses code:auth error segments while keeping surrounding content", () => {
+  it("renders code:auth error segments alongside other errors (no suppression)", () => {
     const assistant = {
       ...assistantMessage("turn-1", 2000),
       blocks: [
@@ -4906,14 +4906,17 @@ describe("useRenderedMessages head/tail partition", () => {
 
     const row = result.current.find((r) => r.id === "assistant:turn-1");
     expect(row?.segments.some((s) => s.kind === "text")).toBe(true);
-    // The auth error is gone; the non-auth error survives.
+    // Auth errors render like any other error: suppressing them made headless
+    // (A2A-triggered) auth failures invisible once the transient re-auth
+    // banner cleared.
     const errorSegments = row?.segments.filter((s) => s.kind === "error") ?? [];
-    expect(errorSegments).toHaveLength(1);
-    const onlyError = errorSegments[0];
-    expect(onlyError.code).toBe("RUNTIME_THROWN");
+    expect(errorSegments.map((segment) => segment.code)).toEqual([
+      "auth",
+      "RUNTIME_THROWN",
+    ]);
   });
 
-  it("collapses an auth-only turn to zero segments", () => {
+  it("keeps an auth-only turn's error segment as its durable record", () => {
     const assistant = {
       ...assistantMessage("turn-1", 2000),
       blocks: [turnErrorBlock("block-1", 2000, "auth")],
@@ -4927,7 +4930,9 @@ describe("useRenderedMessages head/tail partition", () => {
     );
 
     const row = result.current.find((r) => r.id === "assistant:turn-1");
-    expect(row?.segments ?? []).toHaveLength(0);
+    const segments = row?.segments ?? [];
+    expect(segments).toHaveLength(1);
+    expect(segments[0]?.kind).toBe("error");
   });
 });
 

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -75,6 +75,7 @@ import type {
   TokenUsage,
 } from "@traycer/protocol/persistence/epic/foundation";
 import type {
+  AssistantMessage,
   Chat,
   ChatEvent,
   ContentBlock,
@@ -773,6 +774,38 @@ export function createChatSessionStore(
     // flushes the buffer first, so observable ordering matches arrival order.
     let bufferedDeltas: RuntimeEvent[] = [];
 
+    // `providers.list` nudge driven by the DURABLE auth-failure signal: an
+    // error block tagged `code: "auth"` persisted on the latest assistant row
+    // (a trailing user row - e.g. a message accepted after the failure - does
+    // not hide it). Live failures already nudge via the `onBlockDelta` error
+    // frame below; this covers failures that happened headlessly (an
+    // A2A-triggered turn with no live subscriber) and only surface on
+    // subscribe/rehydrate - reload, host restart, reconnect, or opening the
+    // tab after the fact. Deduped by the failed row's `messageId`, NOT once
+    // per store lifetime: a reconnect can surface a NEW headless failure
+    // after the user already re-authed the first one, and that later snapshot
+    // must still invalidate the (long-staleTime) provider query. Re-delivery
+    // of the SAME row across reconnects stays a single nudge; a stale nudge
+    // is a harmless refetch either way (the gate is a pure predicate).
+    let nudgedAuthErrorMessageId: string | null = null;
+
+    const nudgeProviderAuthFromPersistedError = (
+      messages: ReadonlyArray<Message>,
+    ): void => {
+      if (options.onProviderAuthError === null) return;
+      const lastAssistant = messages.findLast(
+        (message): message is AssistantMessage => message.role === "assistant",
+      );
+      if (lastAssistant === undefined) return;
+      if (nudgedAuthErrorMessageId === lastAssistant.messageId) return;
+      const hasAuthError = lastAssistant.blocks.some(
+        (block) => block.type === "error" && block.code === AUTH_ERROR_CODE,
+      );
+      if (!hasAuthError) return;
+      nudgedAuthErrorMessageId = lastAssistant.messageId;
+      options.onProviderAuthError();
+    };
+
     const applyBufferedDeltas = (): void => {
       if (bufferedDeltas.length === 0) return;
       const batch = bufferedDeltas;
@@ -820,6 +853,7 @@ export function createChatSessionStore(
         if (disposed || !matchesChat(options, frame.epicId, frame.chatId)) {
           return;
         }
+        nudgeProviderAuthFromPersistedError(frame.snapshot.chat.messages);
         flushBlockDeltas();
         // Pendings dispatched on an earlier connection never see their ack, so
         // the snapshot drops them (below). Computed here, before the set, so a
@@ -1192,9 +1226,10 @@ export function createChatSessionStore(
         bufferedDeltas.push(frame.event);
         lease.requestFlush();
         // The `code: "auth"` error frame is the one live push that flips the
-        // re-auth banner on mid-session. The failed turn's error block is itself
-        // suppressed from the transcript by `suppressAuthErrors`, so it never
-        // surfaces a transcript error row.
+        // re-auth banner on mid-session. The failed turn's error block also
+        // renders in the transcript as the failure's durable record; failures
+        // with no live subscriber are instead caught on snapshot by
+        // `nudgeProviderAuthFromPersistedError` above.
         if (
           frame.event.type === "error" &&
           frame.event.code === AUTH_ERROR_CODE

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -781,13 +781,16 @@ export function createChatSessionStore(
     // frame below; this covers failures that happened headlessly (an
     // A2A-triggered turn with no live subscriber) and only surface on
     // subscribe/rehydrate - reload, host restart, reconnect, or opening the
-    // tab after the fact. Deduped by the failed row's `messageId`, NOT once
-    // per store lifetime: a reconnect can surface a NEW headless failure
-    // after the user already re-authed the first one, and that later snapshot
-    // must still invalidate the (long-staleTime) provider query. Re-delivery
-    // of the SAME row across reconnects stays a single nudge; a stale nudge
-    // is a harmless refetch either way (the gate is a pure predicate).
-    let nudgedAuthErrorMessageId: string | null = null;
+    // tab after the fact. Deduped by the failed turn's `turnId` (shared by the
+    // live and persisted paths - `ChatActiveTurn.turnId` mirrors 1:1 onto the
+    // eventual `AssistantMessage.turnId`), NOT once per store lifetime: a
+    // reconnect can surface a NEW headless failure after the user already
+    // re-authed the first one, and that later snapshot must still invalidate
+    // the (long-staleTime) provider query. Re-delivery of the SAME row across
+    // reconnects, or a snapshot arriving right after the live nudge already
+    // fired for the same turn, stays a single nudge; a stale nudge is a
+    // harmless refetch either way (the gate is a pure predicate).
+    let nudgedAuthErrorTurnId: string | null = null;
 
     const nudgeProviderAuthFromPersistedError = (
       messages: ReadonlyArray<Message>,
@@ -797,12 +800,13 @@ export function createChatSessionStore(
         (message): message is AssistantMessage => message.role === "assistant",
       );
       if (lastAssistant === undefined) return;
-      if (nudgedAuthErrorMessageId === lastAssistant.messageId) return;
+      const turnKey = lastAssistant.turnId ?? lastAssistant.messageId;
+      if (nudgedAuthErrorTurnId === turnKey) return;
       const hasAuthError = lastAssistant.blocks.some(
         (block) => block.type === "error" && block.code === AUTH_ERROR_CODE,
       );
       if (!hasAuthError) return;
-      nudgedAuthErrorMessageId = lastAssistant.messageId;
+      nudgedAuthErrorTurnId = turnKey;
       options.onProviderAuthError();
     };
 
@@ -1235,8 +1239,13 @@ export function createChatSessionStore(
           frame.event.code === AUTH_ERROR_CODE
         ) {
           // Nudge `providers.list` to refetch (and read the host's poisoned
-          // `unauthenticated`) so the banner mounts + send blocks.
+          // `unauthenticated`) so the banner mounts + send blocks. Record the
+          // SAME turnId marker `nudgeProviderAuthFromPersistedError` uses, so
+          // the snapshot that follows this live failure (on this connection
+          // or after a reconnect) doesn't nudge a second time for the
+          // identical turn.
           if (options.onProviderAuthError !== null) {
+            nudgedAuthErrorTurnId = get().activeTurn?.turnId ?? null;
             options.onProviderAuthError();
           }
         }

--- a/clients/gui-app/src/stores/chats/rendered-messages.ts
+++ b/clients/gui-app/src/stores/chats/rendered-messages.ts
@@ -22,7 +22,6 @@ import {
   turnCheckpointManifestSchema,
   type TurnCheckpointManifest,
 } from "@traycer/protocol/persistence/epic/checkpoint-manifests";
-import { AUTH_ERROR_CODE } from "@traycer/protocol/host/agent/gui/agent-runtime";
 import {
   buildAttachmentsFromJSONContent,
   extractPlainTextFromComposerJSONContent,
@@ -2470,9 +2469,11 @@ function buildAssistantSegments(
     }
   }
   const nested = suppressRedundantResumeMarkers(nestSubagentChildren(flat));
-  const visible = suppressAuthErrors(
-    suppressEditToolCalls(suppressSubagentSpawnToolCalls(nested)),
-  );
+  // Auth errors (`code: "auth"`) deliberately render as normal error segments:
+  // suppressing them made a headless (A2A-triggered) auth failure completely
+  // invisible after the transient re-auth banner cleared. Like rate-limit
+  // errors, the transcript row and the composer banner now coexist.
+  const visible = suppressEditToolCalls(suppressSubagentSpawnToolCalls(nested));
   // The card's merged change rides on the `artifact_operation` block itself
   // (set at emit from the turn's checkpoint builder), so no manifest enrichment
   // is needed for the card - it's available the moment the edit completes.
@@ -2504,20 +2505,6 @@ function artifactChangeRowsFromManifest(
       },
     ];
   });
-}
-
-/**
- * Drop `error` segments tagged `code: "auth"`. A signed-out provider is a
- * connection condition surfaced live above the composer (the re-auth banner),
- * not a transcript row - so the failed turn collapses to an empty slice instead
- * of leaving a scary red error card. An auth-only turn renders zero segments.
- */
-function suppressAuthErrors<T extends MessageSegment>(
-  flat: ReadonlyArray<T>,
-): ReadonlyArray<T> {
-  return flat.filter(
-    (s) => !(s.kind === "error" && s.code === AUTH_ERROR_CODE),
-  );
 }
 
 function isSubagentChildSegment(

--- a/protocol/src/host/agent/gui/agent-runtime.ts
+++ b/protocol/src/host/agent/gui/agent-runtime.ts
@@ -1036,9 +1036,12 @@ export type ErrorEvent = z.infer<typeof errorEventSchema>;
  * Stable `ErrorEvent.code` flagging a *recoverable* provider auth failure (an
  * invalid/expired/missing credential the user can fix by reconnecting). Part of
  * the wire contract: host harnesses emit it and the renderer keys on it,
- * provider-agnostic, to suppress the transcript row, mount the composer re-auth
- * banner, and restore the doomed prompt for re-send. Lives here (next to
- * `errorEventSchema`) so both sides import the one definition.
+ * provider-agnostic, to mount the composer re-auth banner and restore the
+ * doomed prompt for re-send. The error row itself renders in the transcript
+ * like any other error - it is the failure's durable record (a headless
+ * A2A-triggered turn may fail with no live subscriber, so the persisted row is
+ * the only trace). Lives here (next to `errorEventSchema`) so both sides
+ * import the one definition.
  */
 export const AUTH_ERROR_CODE = "auth";
 


### PR DESCRIPTION
## Problem

An A2A-triggered turn can die on a recoverable auth failure (`code: "auth"`) with no live subscriber. The error row was filtered out of the transcript by `suppressAuthErrors`, and the re-auth banner depended on a live `onBlockDelta` nudge that a headless turn never delivers — so the failure left no visible trace and the chat just looked stuck until the user manually sent another message.

## Changes

- **Durable transcript record**: `suppressAuthErrors` is deleted from the rendered-messages projection. `code: "auth"` error blocks now render as normal error segments, coexisting with the re-auth banner exactly like rate-limit errors.
- **Durable banner nudge**: `chat-session-store` invalidates `providers.list` on snapshot when the latest assistant row carries an auth-coded error block — covering headless failures and reload/reconnect rehydration. Details:
  - Uses `findLast(role === "assistant")`, so a trailing user row can't hide the failed row.
  - Deduped by the failed row's `messageId` (not once per store), so a second headless failure after a reconnect still re-nudges while re-delivery of the same row stays a single nudge.
- **Comment hygiene**: updated the stale comments (protocol `AUTH_ERROR_CODE` doc, store `onBlockDelta`, error-segment test) that still described the deleted suppression as the wire/UI contract.

No protocol schema changes — the `AUTH_ERROR_CODE` edit is a doc comment only.

## Testing

- New store tests: nudge dedupe across reconnect re-delivery, re-nudge for a new failure after recovery, trailing-user-row detection, non-auth no-op.
- Rewritten projection tests: auth error segments render alongside other errors; an auth-only turn keeps its error segment as the durable record.
- Full gui-app suite: 6759 passed. `bun run compile` (protocol + gui-app), prettier, and react-doctor clean.

The host-side counterpart (actionable sender notice naming the failed harness/profile tuple) lands separately in the internal repo.