### PR TITLE
fix(gui-app): preserve landing terminal focus through bootstrap

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-find.test.tsx
@@ -11,6 +11,7 @@ import {
 import { PaneVisibilityContext } from "@/components/epic-tabs/pane-visibility-context";
 import { TileFindScope } from "@/components/epic-canvas/tile-find/tile-find-scope";
 import { TerminalXtermHost } from "@/components/epic-canvas/renderers/terminal-tile-xterm";
+import { TerminalGridMeasureProbe } from "@/components/epic-canvas/renderers/terminal-grid-measure-probe";
 import {
   __disposeAllXtermHostsForTests,
   __getXtermHostEntryForTests,
@@ -22,6 +23,10 @@ import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
 import { useTileFindStore } from "@/stores/tile-find";
 import type { TerminalDataWriter } from "@/stores/terminals/terminal-session-store";
 import type { TerminalTileFindKind } from "@/components/epic-canvas/renderers/terminal-tile-find-adapter";
+import {
+  focusTerminalInstance,
+  resetTerminalFocusRegistryForTests,
+} from "@/lib/terminals/terminal-focus-registry";
 
 type Disposable = {
   readonly dispose: () => void;
@@ -37,6 +42,7 @@ type SearchResultListener = (result: SearchResult) => void;
 type MockTerminalInstance = {
   readonly focus: Mock;
   readonly paste: Mock;
+  readonly textarea: HTMLTextAreaElement;
   readonly isDisposed: () => boolean;
 };
 
@@ -85,7 +91,8 @@ vi.mock("@xterm/xterm", () => ({
     rows = 24;
     options: Record<string, unknown>;
     readonly buffer = { active: { baseY: 0, length: 24 } };
-    readonly focus = vi.fn();
+    readonly textarea = document.createElement("textarea");
+    readonly focus = vi.fn(() => this.textarea.focus());
     readonly paste = vi.fn((data: string) => {
       this.dataListeners.forEach((listener) => {
         listener(`\x1b[200~${data}\x1b[201~`);
@@ -96,6 +103,10 @@ vi.mock("@xterm/xterm", () => ({
 
     constructor(options: Record<string, unknown>) {
       this.options = options;
+      this.textarea.addEventListener("keydown", (event) => {
+        if (event.key.length !== 1) return;
+        this.dataListeners.forEach((listener) => listener(event.key));
+      });
       xtermMocks.terminals.push(this);
     }
 
@@ -105,7 +116,8 @@ vi.mock("@xterm/xterm", () => ({
       }
     }
 
-    open(_container: HTMLElement): void {
+    open(container: HTMLElement): void {
+      container.appendChild(this.textarea);
       setTimeout(() => {
         if (this.disposed) {
           throw new TypeError(
@@ -261,6 +273,7 @@ function ScopedTerminalHost(props: ScopedTerminalHostProps) {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane={props.isActive}
+        registerImperativeFocus
         findTargetId={findTargetId}
         keepAlive={props.keepAlive}
         chrome="padded"
@@ -305,6 +318,7 @@ function getSearchAddon(index: number): MockSearchAddonInstance {
 describe("<TerminalXtermHost /> terminal find", () => {
   afterEach(() => {
     cleanup();
+    resetTerminalFocusRegistryForTests();
     __disposeAllXtermHostsForTests();
     vi.useRealTimers();
     xtermMocks.terminals.length = 0;
@@ -330,6 +344,52 @@ describe("<TerminalXtermHost /> terminal find", () => {
     useTileFindStore.getState().resetForTests();
   });
 
+  it("keeps landing focus parked through the real measurement-probe to live-host handoff", async () => {
+    const instanceId = "landing-focus-instance";
+    const sessionId = "landing-focus-session";
+    const onLiveInput = vi.fn();
+
+    focusTerminalInstance(instanceId);
+    const rendered = render(
+      <TerminalGridMeasureProbe
+        sessionId={sessionId}
+        instanceId={instanceId}
+        tileKind="terminal"
+        chrome="flush"
+        onMeasured={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(xtermMocks.terminals).toHaveLength(1));
+    const terminal = xtermMocks.terminals[0];
+    expect(terminal.focus).not.toHaveBeenCalled();
+    expect(document.activeElement).not.toBe(terminal.textarea);
+
+    rendered.rerender(
+      <TerminalXtermHost
+        sessionId={sessionId}
+        tileKind="terminal"
+        instanceId={instanceId}
+        effectiveCols={80}
+        effectiveRows={24}
+        onUserInput={onLiveInput}
+        onContainerResize={vi.fn()}
+        onWriterReady={vi.fn()}
+        shouldFocusOnActivePane={false}
+        registerImperativeFocus
+        findTargetId={null}
+        keepAlive
+        chrome="flush"
+      />,
+    );
+
+    await waitFor(() => expect(document.activeElement).toBe(terminal.textarea));
+    expect(terminal.focus).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(terminal.textarea, { key: "x", code: "KeyX" });
+    expect(onLiveInput).toHaveBeenCalledWith("x");
+  });
+
   it("reuses one xterm engine across a StrictMode remount, then disposes it once on unmount", () => {
     vi.useFakeTimers();
 
@@ -345,6 +405,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
           onContainerResize={vi.fn()}
           onWriterReady={vi.fn()}
           shouldFocusOnActivePane={false}
+          registerImperativeFocus
           findTargetId="terminal:test"
           keepAlive={false}
           chrome="padded"
@@ -381,6 +442,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"
@@ -410,6 +472,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
       onContainerResize: vi.fn(),
       onWriterReady: vi.fn(),
       shouldFocusOnActivePane: false,
+      registerImperativeFocus: true,
       findTargetId: "terminal:test",
       keepAlive: false,
       chrome: "padded",
@@ -455,6 +518,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane
+        registerImperativeFocus
         findTargetId="terminal:test"
         keepAlive={false}
         chrome="padded"
@@ -492,6 +556,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane
+        registerImperativeFocus
         findTargetId="terminal:test"
         keepAlive={false}
         chrome="padded"
@@ -912,6 +977,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane
+        registerImperativeFocus
         findTargetId="terminal:test"
         keepAlive={false}
         chrome="padded"
@@ -940,6 +1006,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
           writer = nextWriter;
         }}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"
@@ -996,6 +1063,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
           writer = nextWriter;
         }}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"
@@ -1063,6 +1131,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
           writer = nextWriter;
         }}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"
@@ -1121,6 +1190,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
           onContainerResize={vi.fn()}
           onWriterReady={vi.fn()}
           shouldFocusOnActivePane
+          registerImperativeFocus
           findTargetId="terminal:test"
           keepAlive={false}
           chrome="padded"
@@ -1145,6 +1215,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
           onContainerResize={vi.fn()}
           onWriterReady={vi.fn()}
           shouldFocusOnActivePane
+          registerImperativeFocus
           findTargetId="terminal:test"
           keepAlive={false}
           chrome="padded"
@@ -1169,6 +1240,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"
@@ -1193,6 +1265,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"
@@ -1215,6 +1288,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane
+        registerImperativeFocus
         findTargetId="terminal:test"
         keepAlive={false}
         chrome="padded"
@@ -1255,6 +1329,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
             onContainerResize={vi.fn()}
             onWriterReady={vi.fn()}
             shouldFocusOnActivePane={active}
+            registerImperativeFocus
             findTargetId={active ? "terminal:test" : null}
             keepAlive={false}
             chrome="padded"
@@ -1300,6 +1375,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"
@@ -1356,6 +1432,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
           onContainerResize={vi.fn()}
           onWriterReady={vi.fn()}
           shouldFocusOnActivePane={false}
+          registerImperativeFocus
           findTargetId={null}
           keepAlive={false}
           chrome="padded"
@@ -1404,6 +1481,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"
@@ -1449,6 +1527,7 @@ describe("<TerminalXtermHost /> terminal find", () => {
         onContainerResize={vi.fn()}
         onWriterReady={vi.fn()}
         shouldFocusOnActivePane={false}
+        registerImperativeFocus
         findTargetId={null}
         keepAlive={false}
         chrome="padded"

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-links.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-links.test.tsx
@@ -158,6 +158,7 @@ function renderHost(): void {
       onContainerResize={vi.fn()}
       onWriterReady={vi.fn()}
       shouldFocusOnActivePane={false}
+      registerImperativeFocus
       findTargetId={null}
       keepAlive={false}
       chrome="padded"

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-grid-measure-probe.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-grid-measure-probe.tsx
@@ -46,6 +46,11 @@ export function TerminalGridMeasureProbe(props: {
         onContainerResize={props.onMeasured}
         onWriterReady={ignoreWriter}
         shouldFocusOnActivePane={false}
+        // A landing-panel open can park focus before this probe mounts. Leave
+        // that request parked for the live host: focusing the probe would both
+        // route early keystrokes into `dropInput` and lose DOM focus when the
+        // persistent xterm container is reparented into the live host.
+        registerImperativeFocus={false}
         findTargetId={null}
         // The engine must survive the probe -> live-host swap (that is the
         // point); if the tab closes before a session ever registers, the

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
@@ -159,6 +159,13 @@ export interface TerminalXtermHostProps {
    */
   readonly shouldFocusOnActivePane: boolean;
   /**
+   * Whether this host is an interactive focus target for explicit surface
+   * gestures. Measurement-only hosts reuse the real xterm engine before a
+   * session handle exists, but must leave a parked focus request untouched so
+   * the live host can fulfil it after taking ownership of input.
+   */
+  readonly registerImperativeFocus: boolean;
+  /**
    * Whether the underlying terminal session is still live. The host keeps the
    * persistent xterm engine cached across unmount when true, so splitting a
    * pane / switching tabs / reopening does not dispose the `Terminal` and lose
@@ -423,13 +430,12 @@ export function TerminalXtermHost(props: TerminalXtermHostProps) {
   // flip (the landing panel expanding around an always-mounted tile, or a tab
   // created before its engine exists) focus through the registry instead of
   // `shouldFocusOnActivePane`.
-  useEffect(
-    () =>
-      registerTerminalFocus(props.instanceId, () => {
-        termRef.current?.focus();
-      }),
-    [props.instanceId],
-  );
+  useEffect(() => {
+    if (!props.registerImperativeFocus) return;
+    return registerTerminalFocus(props.instanceId, () => {
+      termRef.current?.focus();
+    });
+  }, [props.instanceId, props.registerImperativeFocus]);
 
   const pastePaths = useCallback((paths: readonly string[]): void => {
     const input = terminalPathInput(uniquePaths(paths));

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile.tsx
@@ -421,6 +421,7 @@ function TerminalLive(props: TerminalLiveProps) {
             onContainerResize={handleContainerResize}
             onWriterReady={handleWriterReady}
             shouldFocusOnActivePane={props.isActive}
+            registerImperativeFocus
             findTargetId={
               props.isActive
                 ? `terminal:${props.viewTabId}:${props.tileId}:${handle.sessionId}`

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -1228,6 +1228,7 @@ function TerminalAgentLive(props: TerminalAgentLiveProps) {
           onContainerResize={handleContainerResize}
           onWriterReady={handleWriterReady}
           shouldFocusOnActivePane={props.isActive}
+          registerImperativeFocus
           findTargetId={
             props.isActive
               ? `terminal-agent:${props.viewTabId}:${props.tileId}:${handle.sessionId}`

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-tile.tsx
@@ -194,6 +194,7 @@ function LandingTerminalTileLive(props: {
             // Focus moves here only through explicit gestures, routed via the
             // terminal-focus registry by the panel.
             shouldFocusOnActivePane={false}
+            registerImperativeFocus
             findTargetId={null}
             // Mirrors the registry's linger rule: while the session is live its
             // handle outlives this unmount (tab switch away from the landing


### PR DESCRIPTION
## Summary

- keep an imperative terminal focus request parked while the measurement-only xterm probe owns the persistent engine
- register imperative focus only after the live terminal host owns input and its final DOM container
- add a regression that mounts the real measurement probe, hands the same engine to the live host, verifies textarea focus, and proves a DOM key reaches live input

## Root cause

The landing panel issued one focus request before terminal bootstrap. The measurement probe registered first under the same instance ID, consumed that request, and routed early input to its intentional sink. The persistent xterm container then moved to the live host, which cleared browser focus without creating a second focus request.

## Verification

- pre-commit run --all-files
- full gui-app Vitest suite: 743 files passed, 6,756 tests passed, 1 skipped
- React Doctor diff scan: no issues
- focused terminal and landing-panel suites: 6 files, 79 tests passed