### PR TITLE
feat(protocol,gui-app): surface Grok account rate limits

### DIFF
--- a/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
+++ b/clients/gui-app/src/components/layout/header/__tests__/rate-limit-popover.test.tsx
@@ -1356,6 +1356,52 @@ describe("<RateLimitPopover /> rail", () => {
     expect(document.querySelectorAll('[class*="bg-border/70"]').length).toBe(1);
   });
 
+  it("wraps an ambient (profile-less) provider's block in the same card codex/claude profiles use, in both tabs", () => {
+    // Design-language fix: grok/openrouter/kilocode render via the
+    // profile-less block, which used to float flat while codex/claude's
+    // per-profile rows sat in a `rounded-lg border ... bg-background/40 p-2`
+    // card. The ambient block now reuses that exact card container so every
+    // provider's usage sits inside a card - in Overview and the detail tab.
+    mocks.configured = [
+      { providerId: "grok", lane: "ephemeralProcess", profiles: undefined },
+    ];
+    mocks.results = {
+      grok: readyResult({
+        provider: "grok",
+        available: true,
+        subscriptionTier: "SuperGrok",
+        periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+        periodStart: NOW,
+        periodEnd: NOW + 7 * 24 * 60 * 60 * 1000,
+        period: {
+          usedPercent: 12,
+          resetsAt: NOW + 7 * 24 * 60 * 60 * 1000,
+          durationMinutes: 10_080,
+        },
+        monthlyLimit: null,
+        onDemandCap: null,
+        onDemandUsed: null,
+        prepaidBalance: 25,
+      }),
+    };
+    renderPopover();
+    // Overview: the block's own name+body sits inside the shared card.
+    const overviewCard = screen
+      .getByText("Grok")
+      .closest('[class*="bg-background/40"]');
+    expect(overviewCard).toBeTruthy();
+    expect(overviewCard?.className).toContain("rounded-lg");
+    expect(overviewCard?.className).toContain("border-border/60");
+    // Detail tab: same card container.
+    fireEvent.click(screen.getByRole("tab", { name: "Grok" }));
+    const detailCard = screen
+      .getByText("Grok")
+      .closest('[class*="bg-background/40"]');
+    expect(detailCard).toBeTruthy();
+    expect(detailCard?.className).toContain("rounded-lg");
+    expect(detailCard?.className).toContain("border-border/60");
+  });
+
   it("switches to a single provider detail (with plan label) on tab click", () => {
     mocks.configured = [
       { providerId: "codex", lane: "ephemeralProcess", profiles: undefined },

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -1285,7 +1285,13 @@ function SingleProfileRateLimitProviderBlock({
       : null;
 
   return (
-    <div className="flex flex-col gap-2">
+    // Ambient (profile-less) providers - grok, openrouter, kilocode - reuse the
+    // exact per-profile card container `RateLimitProviderProfileRow` gives
+    // codex/claude, so every provider's usage sits inside the same card in both
+    // popover tabs (the header+body flat block otherwise floated loose against
+    // the sibling cards - the design-language gap the user flagged). Overview
+    // keeps its between-provider dividers; this cards each block's own content.
+    <div className="flex flex-col gap-2 rounded-lg border border-border/60 bg-background/40 p-2">
       <div className="flex items-center justify-between gap-2">
         <div className="flex min-w-0 items-center gap-1.5">
           {/* Overview stacks every provider's block in one scrollable list with

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -714,6 +714,29 @@ describe("GrokRateLimitView", () => {
     expect(container.querySelectorAll(".bg-foreground\\/15").length).toBe(0);
   });
 
+  it("suppresses the fallback Plan row on popover-detail (the header owns the tier chip), keeping the billing period", () => {
+    // In the single-provider popover tab the header already renders the tier as
+    // a chip (resolveProviderPlanLabel), so the body's Plan row would duplicate
+    // it - same reason Codex/Claude keep the tier out of their card bodies. The
+    // billing-period row, which the chip doesn't carry, still shows.
+    render(
+      <GrokRateLimitView data={grokPeriodLess} variant="popover-detail" />,
+    );
+    expect(screen.queryByText("Plan")).toBeNull();
+    expect(screen.queryByText("SuperGrok")).toBeNull();
+    expect(screen.getByText("Billing period")).toBeTruthy();
+    expect(screen.getByText(expectedBillingPeriod)).toBeTruthy();
+  });
+
+  it("keeps the fallback Plan row on the Overview tab, which renders no tier chip", () => {
+    render(
+      <GrokRateLimitView data={grokPeriodLess} variant="popover-overview" />,
+    );
+    expect(screen.getByText("Plan")).toBeTruthy();
+    expect(screen.getByText("SuperGrok")).toBeTruthy();
+    expect(screen.getByText("Billing period")).toBeTruthy();
+  });
+
   it("renders credit rows only when non-null", () => {
     render(
       <GrokRateLimitView

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-rate-limit-views.test.tsx
@@ -13,6 +13,7 @@ import { formatResetFullDateTime } from "@/lib/relative-time";
 import {
   ClaudeRateLimitView,
   CodexRateLimitView,
+  GrokRateLimitView,
   KiloCodeRateLimitView,
   OpenRouterRateLimitView,
   ProviderRateLimitBody,
@@ -29,8 +30,18 @@ type OpenRouterRateLimits = Extract<
   { provider: "openrouter" }
 >;
 type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
+type GrokRateLimits = Extract<ProviderRateLimits, { provider: "grok" }>;
 
 const NOW = Date.now();
+
+/** Same calendar formatting Grok's billing-period range uses (local TZ). */
+function formatGrokPeriodDate(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
 
 afterEach(() => {
   cleanup();
@@ -636,6 +647,112 @@ describe("KiloCodeRateLimitView", () => {
   });
 });
 
+describe("GrokRateLimitView", () => {
+  // UTC midnights - local toLocaleDateString may shift the calendar day, so
+  // expected range strings are built with the same formatter as production.
+  const periodStart = Date.UTC(2026, 6, 22);
+  const periodEnd = Date.UTC(2026, 6, 29);
+  const expectedBillingPeriod = `${formatGrokPeriodDate(periodStart)} - ${formatGrokPeriodDate(periodEnd)}`;
+
+  const grokWithPeriod: GrokRateLimits = {
+    provider: "grok",
+    available: true,
+    subscriptionTier: "SuperGrok",
+    periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+    periodStart,
+    periodEnd,
+    period: {
+      usedPercent: 12,
+      resetsAt: periodEnd,
+      durationMinutes: 10_080,
+    },
+    monthlyLimit: 100,
+    onDemandCap: 50,
+    onDemandUsed: 5.5,
+    prepaidBalance: 25,
+  };
+
+  const grokPeriodLess: GrokRateLimits = {
+    provider: "grok",
+    available: true,
+    subscriptionTier: "SuperGrok",
+    periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+    periodStart,
+    periodEnd,
+    period: null,
+    monthlyLimit: null,
+    onDemandCap: null,
+    onDemandUsed: null,
+    prepaidBalance: null,
+  };
+
+  it("renders a Weekly usage bar when period is present", () => {
+    const { container } = render(
+      <GrokRateLimitView data={grokWithPeriod} variant="settings" />,
+    );
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("12% used")).toBeTruthy();
+    // Real bar fill (MeterRow track + severity color), not a plain text row.
+    expect(container.querySelectorAll(".bg-foreground\\/15").length).toBe(1);
+    expect(container.querySelectorAll(".bg-blue-500").length).toBe(1);
+    // Fallback plan/date rows stay off when a real period window exists.
+    expect(screen.queryByText("Plan")).toBeNull();
+    expect(screen.queryByText("Billing period")).toBeNull();
+  });
+
+  it("renders Plan + Billing period fallback when period is null (no bar)", () => {
+    const { container } = render(
+      <GrokRateLimitView data={grokPeriodLess} variant="settings" />,
+    );
+    expect(screen.getByText("Plan")).toBeTruthy();
+    // Branded tier is shown verbatim, not title-cased ("Supergrok").
+    expect(screen.getByText("SuperGrok")).toBeTruthy();
+    expect(screen.getByText("Billing period")).toBeTruthy();
+    expect(screen.getByText(expectedBillingPeriod)).toBeTruthy();
+    expect(screen.queryByText("Weekly")).toBeNull();
+    expect(screen.queryByText("% used", { exact: false })).toBeNull();
+    expect(container.querySelectorAll(".bg-foreground\\/15").length).toBe(0);
+  });
+
+  it("renders credit rows only when non-null", () => {
+    render(
+      <GrokRateLimitView
+        data={{
+          ...grokWithPeriod,
+          prepaidBalance: 25,
+          monthlyLimit: 100,
+          onDemandUsed: 5.5,
+          onDemandCap: null,
+        }}
+        variant="settings"
+      />,
+    );
+    expect(screen.getByText("Prepaid balance")).toBeTruthy();
+    expect(screen.getByText("$25.00")).toBeTruthy();
+    expect(screen.getByText("Monthly limit")).toBeTruthy();
+    expect(screen.getByText("$100.00")).toBeTruthy();
+    expect(screen.getByText("On-demand used")).toBeTruthy();
+    expect(screen.getByText("$5.50")).toBeTruthy();
+    // Null onDemandCap drops the On-demand limit row entirely.
+    expect(screen.queryByText("On-demand limit")).toBeNull();
+  });
+
+  it("condenses the Overview to period + Prepaid balance (drops monthly/on-demand)", () => {
+    render(
+      <GrokRateLimitView data={grokWithPeriod} variant="popover-overview" />,
+    );
+    // Kept: period bar + prepaid.
+    expect(screen.getByText("Weekly")).toBeTruthy();
+    expect(screen.getByText("12% used")).toBeTruthy();
+    expect(screen.getByText("Prepaid balance")).toBeTruthy();
+    expect(screen.getByText("$25.00")).toBeTruthy();
+    // Dropped: monthly + on-demand (detail/settings only).
+    expect(screen.queryByText("Monthly limit")).toBeNull();
+    expect(screen.queryByText("On-demand used")).toBeNull();
+    expect(screen.queryByText("On-demand limit")).toBeNull();
+  });
+});
+
 describe("ProviderRateLimitDetail dispatch", () => {
   it("dispatches to the OpenRouter view", () => {
     render(
@@ -675,6 +792,32 @@ describe("ProviderRateLimitDetail dispatch", () => {
     );
     expect(screen.getByText("Credit balance")).toBeTruthy();
     expect(screen.getByText("$7.00")).toBeTruthy();
+  });
+
+  it("dispatches to the Grok view", () => {
+    render(
+      <ProviderRateLimitDetail
+        data={{
+          provider: "grok",
+          available: true,
+          subscriptionTier: "SuperGrok",
+          periodType: null,
+          periodStart: null,
+          periodEnd: null,
+          period: null,
+          monthlyLimit: null,
+          onDemandCap: null,
+          onDemandUsed: null,
+          prepaidBalance: 8,
+        }}
+        variant="settings"
+        codexResetAction={null}
+      />,
+    );
+    expect(screen.getByText("Plan")).toBeTruthy();
+    expect(screen.getByText("SuperGrok")).toBeTruthy();
+    expect(screen.getByText("Prepaid balance")).toBeTruthy();
+    expect(screen.getByText("$8.00")).toBeTruthy();
   });
 });
 

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -1037,8 +1037,8 @@ function formatGrokPeriodDate(epochMs: number): string {
 
 /**
  * The billing period's start-end range ("Jul 22, 2026 - Jul 29, 2026"), shown
- * in grok's zero-usage fallback where there's no usage bar to carry a reset
- * date. `null` unless both bounds are known.
+ * in grok's unmeasured-period fallback where there's no usage bar to carry a
+ * reset date. `null` unless both bounds are known.
  */
 function formatGrokPeriodRange(
   periodStart: number | null,
@@ -1049,9 +1049,8 @@ function formatGrokPeriodRange(
 }
 
 /**
- * Grok's zero-usage fallback: a real SuperGrok subscription that has reported
- * no usage this period returns only its tier and the billing period's bounds
- * (no usage percentage, so the host synthesizes no `period` window). Surfacing
+ * Grok's unmeasured-period fallback: an available subscription may report its
+ * tier and billing-period bounds without a measurable usage window. Surfacing
  * the plan and the period dates keeps the card meaningful instead of blank.
  * Each row drops out on its own when the field is absent.
  *
@@ -1092,8 +1091,8 @@ function GrokPeriodFallback({
  * - `period` present -> the period usage bar, reusing the shared `RateLimitWindowRow`
  *   so its "% used · Resets <date>" reads identically to codex/claude; the bar's
  *   label is the period cadence ("Weekly").
- * - `period` null -> the zero-usage fallback (`GrokPeriodFallback`): the plan
- *   tier and the billing period's dates.
+ * - `period` null -> the unmeasured-period fallback (`GrokPeriodFallback`): the
+ *   plan tier and the billing period's dates.
  * - the raw credit figures (prepaid balance, monthly limit, on-demand
  *   used/limit) render only where xAI actually reported them - it omits fields
  *   freely by account type - as neutral `$`-denominated rows, the same

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -108,6 +108,7 @@ type OpenRouterRateLimits = Extract<
   { provider: "openrouter" }
 >;
 type KiloCodeRateLimits = Extract<ProviderRateLimits, { provider: "kilocode" }>;
+type GrokRateLimits = Extract<ProviderRateLimits, { provider: "grok" }>;
 
 const MINUTES_PER_HOUR = 60;
 // A manual reset expiring inside this window is tinted `text-destructive` in the
@@ -335,6 +336,30 @@ function ProviderNumberRow({
       <span className="text-muted-foreground">{label}</span>
       <span className="font-mono text-ui-xs text-foreground">
         {format(value)}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The string analogue of `ProviderNumberRow`: a neutral labeled value (no bar,
+ * no severity color) for provider fields that are already display strings - a
+ * plan tier, a formatted date range. Renders nothing when the provider didn't
+ * report the value.
+ */
+function ProviderTextRow({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string | null;
+}): ReactNode {
+  if (value === null) return null;
+  return (
+    <div className="flex items-center justify-between gap-3 text-ui-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="min-w-0 truncate font-mono text-ui-xs text-foreground">
+        {value}
       </span>
     </div>
   );
@@ -983,6 +1008,143 @@ export function KiloCodeRateLimitView({
   );
 }
 
+/**
+ * Grok's period bar label: the billing period's cadence taken from the
+ * provider's `periodType` token (e.g. `"USAGE_PERIOD_TYPE_WEEKLY"` -> "Weekly"),
+ * falling back to the synthesized window's own duration when the type token is
+ * absent. Only the last `_`-segment carries the cadence, so the leading
+ * `USAGE_PERIOD_TYPE_` scaffolding is dropped before title-casing.
+ */
+function formatGrokPeriodLabel(
+  periodType: string | null,
+  durationMinutes: number | null,
+): string {
+  if (periodType !== null) {
+    const parts = periodType.split("_").filter((part) => part.length > 0);
+    if (parts.length > 0) return titleCaseFromToken(parts[parts.length - 1]);
+  }
+  return formatWindowDuration(durationMinutes);
+}
+
+/** Compact calendar date ("Jul 22, 2026") for a grok billing-period bound. */
+function formatGrokPeriodDate(epochMs: number): string {
+  return new Date(epochMs).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/**
+ * The billing period's start-end range ("Jul 22, 2026 - Jul 29, 2026"), shown
+ * in grok's zero-usage fallback where there's no usage bar to carry a reset
+ * date. `null` unless both bounds are known.
+ */
+function formatGrokPeriodRange(
+  periodStart: number | null,
+  periodEnd: number | null,
+): string | null {
+  if (periodStart === null || periodEnd === null) return null;
+  return `${formatGrokPeriodDate(periodStart)} - ${formatGrokPeriodDate(periodEnd)}`;
+}
+
+/**
+ * Grok's zero-usage fallback: a real SuperGrok subscription that has reported
+ * no usage this period returns only its tier and the billing period's bounds
+ * (no usage percentage, so the host synthesizes no `period` window). Surfacing
+ * the plan and the period dates keeps the card meaningful instead of blank.
+ * Each row drops out on its own when the field is absent.
+ */
+function GrokPeriodFallback({
+  subscriptionTier,
+  periodStart,
+  periodEnd,
+}: {
+  readonly subscriptionTier: string | null;
+  readonly periodStart: number | null;
+  readonly periodEnd: number | null;
+}): ReactNode {
+  return (
+    <>
+      <ProviderTextRow label="Plan" value={subscriptionTier} />
+      <ProviderTextRow
+        label="Billing period"
+        value={formatGrokPeriodRange(periodStart, periodEnd)}
+      />
+    </>
+  );
+}
+
+/**
+ * Grok's usage detail. Grok reports a billing-period credit picture rather than
+ * rolling-utilization windows, so three shapes are handled:
+ *
+ * - `period` present -> the period usage bar, reusing the shared `RateLimitWindowRow`
+ *   so its "% used · Resets <date>" reads identically to codex/claude; the bar's
+ *   label is the period cadence ("Weekly").
+ * - `period` null -> the zero-usage fallback (`GrokPeriodFallback`): the plan
+ *   tier and the billing period's dates.
+ * - the raw credit figures (prepaid balance, monthly limit, on-demand
+ *   used/limit) render only where xAI actually reported them - it omits fields
+ *   freely by account type - as neutral `$`-denominated rows, the same
+ *   percentage-free treatment OpenRouter/Kilo Code credits get.
+ */
+export function GrokRateLimitView({
+  data,
+  variant,
+}: {
+  readonly data: GrokRateLimits;
+  readonly variant: RateLimitViewVariant;
+}): ReactNode {
+  // Overview keeps only the period usage (bar or fallback) and the prepaid
+  // balance; the monthly limit and on-demand figures are single-provider-tab
+  // detail, matching how OpenRouter/Kilo Code trim their Overview.
+  const overview = isOverviewVariant(variant);
+  return (
+    <div className="flex flex-col gap-3">
+      {data.period !== null ? (
+        <RateLimitWindowRow
+          label={formatGrokPeriodLabel(
+            data.periodType,
+            data.period.durationMinutes,
+          )}
+          window={data.period}
+        />
+      ) : (
+        <GrokPeriodFallback
+          subscriptionTier={data.subscriptionTier}
+          periodStart={data.periodStart}
+          periodEnd={data.periodEnd}
+        />
+      )}
+      <ProviderNumberRow
+        label="Prepaid balance"
+        value={data.prepaidBalance}
+        format={formatProviderCurrency}
+      />
+      {!overview ? (
+        <>
+          <ProviderNumberRow
+            label="Monthly limit"
+            value={data.monthlyLimit}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="On-demand used"
+            value={data.onDemandUsed}
+            format={formatProviderCurrency}
+          />
+          <ProviderNumberRow
+            label="On-demand limit"
+            value={data.onDemandCap}
+            format={formatProviderCurrency}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
 export function ProviderRateLimitBody(
   props: ProviderRateLimitQueryState & {
     readonly codexResetAction: CodexResetCreditActionRenderer | null;
@@ -1088,7 +1250,7 @@ function StaleUsageRefreshNote({
 
 /**
  * Renders one provider's available-arm detail. Exhaustive over every
- * `available: true` arm (`data.provider` is now four-way, not the old binary
+ * `available: true` arm (`data.provider` is now five-way, not the old binary
  * codex/claude split), so a new provider arm added to the wire union fails the
  * build here until it gets a view. Exported so the header popover reuses the
  * exact same per-provider bodies the Settings card shows (Core Flows: "both
@@ -1122,5 +1284,10 @@ export function ProviderRateLimitDetail({
       return <OpenRouterRateLimitView data={data} variant={variant} />;
     case "kilocode":
       return <KiloCodeRateLimitView data={data} variant={variant} />;
+    // Grok reports no rolling usage *windows* either - only a synthesized
+    // billing-period bar plus credit figures - so, like OpenRouter/Kilo Code,
+    // `variant` drives just the Overview-vs-detail trim.
+    case "grok":
+      return <GrokRateLimitView data={data} variant={variant} />;
   }
 }

--- a/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-rate-limit-views.tsx
@@ -1054,19 +1054,29 @@ function formatGrokPeriodRange(
  * (no usage percentage, so the host synthesizes no `period` window). Surfacing
  * the plan and the period dates keeps the card meaningful instead of blank.
  * Each row drops out on its own when the field is absent.
+ *
+ * The `Plan` row is suppressed on `popover-detail`, where the popover header
+ * already renders the same tier as a chip (`resolveProviderPlanLabel`) - the
+ * same reason Codex/Claude keep the tier out of their card bodies. The Settings
+ * card and the Overview tab render no such chip, so there the `Plan` row is the
+ * only tier surface and stays. The billing-period row shows on every surface.
  */
 function GrokPeriodFallback({
   subscriptionTier,
   periodStart,
   periodEnd,
+  variant,
 }: {
   readonly subscriptionTier: string | null;
   readonly periodStart: number | null;
   readonly periodEnd: number | null;
+  readonly variant: RateLimitViewVariant;
 }): ReactNode {
   return (
     <>
-      <ProviderTextRow label="Plan" value={subscriptionTier} />
+      {variant !== "popover-detail" ? (
+        <ProviderTextRow label="Plan" value={subscriptionTier} />
+      ) : null}
       <ProviderTextRow
         label="Billing period"
         value={formatGrokPeriodRange(periodStart, periodEnd)}
@@ -1115,6 +1125,7 @@ export function GrokRateLimitView({
           subscriptionTier={data.subscriptionTier}
           periodStart={data.periodStart}
           periodEnd={data.periodEnd}
+          variant={variant}
         />
       )}
       <ProviderNumberRow

--- a/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
+++ b/clients/gui-app/src/hooks/rate-limits/use-header-rate-limit-bars.ts
@@ -76,10 +76,12 @@ function fiveHourWindow(
       return rateLimits.primary;
     case "claude-code":
       return rateLimits.fiveHour;
-    // OpenRouter/Kilo Code are never queried for a glyph slot; kept for
-    // exhaustiveness over the union.
+    // OpenRouter/Kilo Code/Grok are never queried for a glyph slot (grok stays
+    // out of `GLYPH_PROVIDER_IDS` - its billing period isn't a short rolling
+    // window); kept for exhaustiveness over the union.
     case "openrouter":
     case "kilocode":
+    case "grok":
       return null;
   }
 }
@@ -96,6 +98,7 @@ function weeklyWindow(
       return rateLimits.sevenDay;
     case "openrouter":
     case "kilocode":
+    case "grok":
       return null;
   }
 }

--- a/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
+++ b/clients/gui-app/src/lib/__tests__/provider-rate-limit-content.test.ts
@@ -375,4 +375,42 @@ describe("resolveProviderPlanLabel", () => {
       }),
     ).toBeNull();
   });
+
+  it("returns Grok's subscriptionTier verbatim (not title-cased)", () => {
+    // "SuperGrok" is a branded display token - titleCaseFromToken would lower
+    // the intra-word capital to "Supergrok".
+    expect(
+      resolveProviderPlanLabel({
+        provider: "grok",
+        available: true,
+        subscriptionTier: "SuperGrok",
+        periodType: null,
+        periodStart: null,
+        periodEnd: null,
+        period: null,
+        monthlyLimit: null,
+        onDemandCap: null,
+        onDemandUsed: null,
+        prepaidBalance: null,
+      }),
+    ).toBe("SuperGrok");
+  });
+
+  it("is null when Grok did not report a subscriptionTier", () => {
+    expect(
+      resolveProviderPlanLabel({
+        provider: "grok",
+        available: true,
+        subscriptionTier: null,
+        periodType: null,
+        periodStart: null,
+        periodEnd: null,
+        period: null,
+        monthlyLimit: null,
+        onDemandCap: null,
+        onDemandUsed: null,
+        prepaidBalance: null,
+      }),
+    ).toBeNull();
+  });
 });

--- a/clients/gui-app/src/lib/__tests__/rate-limit-providers.test.ts
+++ b/clients/gui-app/src/lib/__tests__/rate-limit-providers.test.ts
@@ -45,6 +45,12 @@ describe("rateLimitFetchLane", () => {
     expect(rateLimitFetchLane("claude-code")).toBe("ephemeralProcess");
   });
 
+  it("maps grok to the ephemeralProcess (subprocess) lane", () => {
+    // Grok usage is read over the vendored CLI's `_x.ai/billing` ACP extension
+    // (a real subprocess spawn), not a cheap credential GET.
+    expect(rateLimitFetchLane("grok")).toBe("ephemeralProcess");
+  });
+
   it("maps openrouter and kilocode to the httpFetch (cheap GET) lane", () => {
     expect(rateLimitFetchLane("openrouter")).toBe("httpFetch");
     expect(rateLimitFetchLane("kilocode")).toBe("httpFetch");

--- a/clients/gui-app/src/lib/provider-rate-limit-content.ts
+++ b/clients/gui-app/src/lib/provider-rate-limit-content.ts
@@ -250,8 +250,8 @@ export function titleCaseFromToken(value: string): string {
 /**
  * A provider's plan/tier label, where one is fetched - the header popover
  * shows this as a chip next to the provider name (Core Flows: "where the
- * provider reports one"). Only Codex (`planType`) and Claude Code
- * (`subscriptionType`) currently report a plan/tier; OpenRouter and Kilo Code
+ * provider reports one"). Codex (`planType`), Claude Code (`subscriptionType`),
+ * and Grok (`subscriptionTier`) report a plan/tier; OpenRouter and Kilo Code
  * have no analogous field, so they always resolve to `null` and render no chip.
  */
 export function resolveProviderPlanLabel(
@@ -264,6 +264,12 @@ export function resolveProviderPlanLabel(
       return data.subscriptionType !== null
         ? titleCaseFromToken(data.subscriptionType)
         : null;
+    // Grok reports a branded, display-ready tier token ("SuperGrok",
+    // "SuperGrok Heavy"), not a SNAKE_CASE enum - so it's shown verbatim
+    // rather than through `titleCaseFromToken`, which would lower-case the
+    // intra-word capital ("Supergrok").
+    case "grok":
+      return data.subscriptionTier;
     case "openrouter":
     case "kilocode":
       return null;

--- a/clients/gui-app/src/lib/rate-limit-providers.ts
+++ b/clients/gui-app/src/lib/rate-limit-providers.ts
@@ -84,6 +84,11 @@ export function rateLimitFetchLane(
       return "httpFetch";
     case "codex":
     case "claude-code":
+    case "grok":
+      // Grok reads usage over the vendored CLI's own `_x.ai/billing` ACP
+      // extension (a subprocess RPC, so Traycer never touches the grok OAuth
+      // token) - an ephemeral spawn like codex/claude-code, despite grok's
+      // credit-shaped payload resembling the httpFetch providers'.
       return "ephemeralProcess";
   }
 }

--- a/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
@@ -203,14 +203,18 @@ describe("projectProfileUsage", () => {
     expect(projection.windows).toHaveLength(1);
   });
 
-  it("yields no window for a period-less Grok snapshot", () => {
+  it("projects a period-less Grok snapshot as unmeasured, not unavailable", () => {
     // Zero-usage SuperGrok returns tier + period bounds only - no synthesized
-    // period window - so projection has nothing to meter.
-    expect(project("ok", NOW, envelope(grok(null), NOW), false)).toMatchObject({
-      kind: "unavailable",
-      reason: "missing_windows",
+    // period window - so there is nothing to meter. That is available-but-
+    // unmeasured (severity `unknown`, consistent with protocol semantics), not
+    // the alarming unavailable/`missing_windows` state that reads as a fetch or
+    // account failure for a perfectly healthy account.
+    expect(project("ok", NOW, envelope(grok(null), NOW), false)).toEqual({
+      kind: "not_checked",
+      severity: "unknown",
       compactWindow: null,
       windows: [],
+      checkedAt: null,
     });
   });
 

--- a/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/profile-usage-projection.test.ts
@@ -77,6 +77,24 @@ function claude(
   };
 }
 
+function grok(
+  period: ProviderRateLimitWindow | null,
+): Extract<ProviderRateLimits, { provider: "grok"; available: true }> {
+  return {
+    provider: "grok",
+    available: true,
+    subscriptionTier: "SuperGrok",
+    periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+    periodStart: NOW,
+    periodEnd: NOW + 7 * 24 * 60 * 60 * 1000,
+    period,
+    monthlyLimit: null,
+    onDemandCap: null,
+    onDemandUsed: null,
+    prepaidBalance: null,
+  };
+}
+
 function envelope(
   data: Extract<ProviderRateLimits, { available: true }>,
   lastGoodAt: number,
@@ -150,6 +168,45 @@ describe("projectProfileUsage", () => {
     expect(
       project("ok", NOW, envelope(openRouter(null, null), NOW), false),
     ).toMatchObject({
+      kind: "unavailable",
+      reason: "missing_windows",
+      compactWindow: null,
+      windows: [],
+    });
+  });
+
+  it("projects Grok's billing-period window via the shared window path", () => {
+    // Grok rides `rateLimits.period` through the shared window projection, not
+    // the OpenRouter-style credit path - a live period yields a real compact
+    // bar and a non-unknown severity.
+    const projection = project(
+      "ok",
+      NOW,
+      envelope(grok(window(12, 10_080, NOW + 1)), NOW),
+      false,
+    );
+    expect(projection.kind).toBe("detail");
+    expect(projection.severity).not.toBe("unknown");
+    expect(projection).toMatchObject({
+      kind: "detail",
+      severity: "healthy",
+      compactWindow: {
+        id: "period",
+        severity: "healthy",
+        window: {
+          usedPercent: 12,
+          durationMinutes: 10_080,
+          resetsAt: NOW + 1,
+        },
+      },
+    });
+    expect(projection.windows).toHaveLength(1);
+  });
+
+  it("yields no window for a period-less Grok snapshot", () => {
+    // Zero-usage SuperGrok returns tier + period bounds only - no synthesized
+    // period window - so projection has nothing to meter.
+    expect(project("ok", NOW, envelope(grok(null), NOW), false)).toMatchObject({
       kind: "unavailable",
       reason: "missing_windows",
       compactWindow: null,

--- a/clients/gui-app/src/lib/rate-limits/__tests__/rate-limit-envelope.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/rate-limit-envelope.test.ts
@@ -480,7 +480,12 @@ describe("mapResponseToProviderRateLimitEnvelope providers.list convergence", ()
     const providersListKey = ["host", "host-a", "providers.list", {}];
     const unrelatedKey = ["host", "host-a", "host.getRateLimitUsage", {}];
     queryClient.setQueryData(providersListKey, { providers: [] });
-    queryClient.setQueryData(unrelatedKey, {});
+    queryClient.setQueryData(unrelatedKey, {
+      latest: null,
+      lastGood: null,
+      lastGoodAt: null,
+      lastFailureAt: null,
+    });
     mapResponseToProviderRateLimitEnvelope({
       response: response(GROK_GOOD),
       queryClient,

--- a/clients/gui-app/src/lib/rate-limits/__tests__/rate-limit-envelope.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/rate-limit-envelope.test.ts
@@ -477,12 +477,32 @@ describe("mapResponseToProviderRateLimitEnvelope providers.list convergence", ()
   it("invalidates providers.list when a grok fetch resolves", () => {
     const queryClient = new QueryClient();
     const invalidateSpy = invalidateSpyFor(queryClient);
+    const providersListKey = ["host", "host-a", "providers.list", {}];
+    const unrelatedKey = ["host", "host-a", "host.getRateLimitUsage", {}];
+    queryClient.setQueryData(providersListKey, { providers: [] });
+    queryClient.setQueryData(unrelatedKey, {});
     mapResponseToProviderRateLimitEnvelope({
       response: response(GROK_GOOD),
       queryClient,
-      queryKey: ["host", "host-a", "host.getRateLimitUsage", {}],
+      queryKey: unrelatedKey,
     });
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    const predicate = invalidateSpy.mock.calls[0]?.[0]?.predicate;
+    const providersListQuery = queryClient
+      .getQueryCache()
+      .find({ queryKey: providersListKey, exact: true });
+    const unrelatedQuery = queryClient
+      .getQueryCache()
+      .find({ queryKey: unrelatedKey, exact: true });
+    if (
+      predicate === undefined ||
+      providersListQuery === undefined ||
+      unrelatedQuery === undefined
+    ) {
+      throw new Error("expected cached queries and invalidation predicate");
+    }
+    expect(predicate(providersListQuery)).toBe(true);
+    expect(predicate(unrelatedQuery)).toBe(false);
   });
 
   it("does not invalidate providers.list for openrouter/kilocode (never carry managed profiles)", () => {

--- a/clients/gui-app/src/lib/rate-limits/__tests__/rate-limit-envelope.test.ts
+++ b/clients/gui-app/src/lib/rate-limits/__tests__/rate-limit-envelope.test.ts
@@ -68,6 +68,24 @@ const CODEX_WITH_RESET_DETAILS: ProviderRateLimits = {
   rateLimitReachedType: null,
 };
 
+const GROK_GOOD: ProviderRateLimits = {
+  provider: "grok",
+  available: true,
+  subscriptionTier: "SuperGrok",
+  periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+  periodStart: 1_784_678_400_000,
+  periodEnd: 1_785_283_200_000,
+  period: {
+    usedPercent: 12,
+    resetsAt: 1_785_283_200_000,
+    durationMinutes: 10_080,
+  },
+  monthlyLimit: null,
+  onDemandCap: null,
+  onDemandUsed: null,
+  prepaidBalance: null,
+};
+
 function response(
   providerRateLimits: ProviderRateLimits | null,
 ): RateLimitUsageResponse {
@@ -450,6 +468,17 @@ describe("mapResponseToProviderRateLimitEnvelope providers.list convergence", ()
     const invalidateSpy = invalidateSpyFor(queryClient);
     mapResponseToProviderRateLimitEnvelope({
       response: response(CODEX_GOOD),
+      queryClient,
+      queryKey: ["host", "host-a", "host.getRateLimitUsage", {}],
+    });
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates providers.list when a grok fetch resolves", () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = invalidateSpyFor(queryClient);
+    mapResponseToProviderRateLimitEnvelope({
+      response: response(GROK_GOOD),
       queryClient,
       queryKey: ["host", "host-a", "host.getRateLimitUsage", {}],
     });

--- a/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
+++ b/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
@@ -277,6 +277,21 @@ function projectedLiveWindows(
       const credits = openRouterCreditProjection(rateLimits);
       return credits === null ? [] : [credits];
     }
+    case "grok":
+      // Grok rides the shared window path via its synthesized billing-period
+      // window - not the OpenRouter-style credit projection - so its severity
+      // and compact bar come straight from `classifyProviderRateLimits` with
+      // no special-casing. A period-less snapshot (tier + dates only) carries
+      // no window.
+      return [
+        windowProjection({
+          id: "period",
+          role: "primary",
+          name: null,
+          window: rateLimits.period,
+          now,
+        }),
+      ].filter((window): window is ProfileUsageWindow => window !== null);
     case "kilocode":
       return [];
   }

--- a/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
+++ b/clients/gui-app/src/lib/rate-limits/profile-usage-projection.ts
@@ -323,6 +323,26 @@ function emptyDetailProjection(
   input: ProfileUsageProjectionInput,
 ): ProfileUsageProjection {
   const checkedAt = envelope.lastGoodAt ?? input.usageUpdatedAt;
+  // Grok's zero-usage snapshot is `available` with tier + billing-period bounds
+  // but no usage percentage, so it synthesizes no `period` window. That is
+  // "unmeasured", not "unavailable": the account is reachable and healthy, it
+  // just reports nothing to meter this period (the same snapshot the Settings
+  // card renders as tier + billing period, no severity). Project it as the
+  // percentage-free unmeasured state so its severity stays `unknown` -
+  // consistent with protocol `classifyProviderRateLimits` and the (parallel)
+  // host-gauge fix - instead of the alarming unavailable/`missing_windows`
+  // framing, which reads as a fetch/account failure. A grok snapshot whose
+  // period merely rolled (window present but expired) still falls through to
+  // `expired` below, the correct stale framing.
+  if (rateLimits.provider === "grok" && rateLimits.period === null) {
+    return {
+      kind: "not_checked",
+      severity: "unknown",
+      compactWindow: null,
+      windows: [],
+      checkedAt: null,
+    };
+  }
   const severity = classifyProviderRateLimits(rateLimits, input.now);
   if (severity === "limited") {
     return {

--- a/clients/gui-app/src/lib/rate-limits/rate-limit-envelope.ts
+++ b/clients/gui-app/src/lib/rate-limits/rate-limit-envelope.ts
@@ -105,12 +105,11 @@ export interface ProviderRateLimitEnvelope {
 }
 
 /**
- * Whether `response` carries a snapshot for one of the two providers that
- * support managed profiles (v1 is claude-code/codex only) - the only
- * providers `providers.list`'s per-profile `rateLimitStatus` can ever report
- * anything for. Openrouter/kilocode/traycer-aperture reads gate out here so a
- * convergence invalidation isn't spent on a provider that could never affect
- * the switch-prompt banner. Failed probes (`available: false` - timeout,
+ * Whether `response` carries a snapshot for a provider whose `providers.list`
+ * profile rows report cached `rateLimitStatus`: claude-code, codex, or grok.
+ * Openrouter/kilocode/traycer-aperture reads gate out here so a convergence
+ * invalidation isn't spent on a provider that could never affect the
+ * switch-prompt banner. Failed probes (`available: false` - timeout,
  * cli_not_found, ...) gate out too: they carry no usage the host's gauge cache
  * could have captured, so `providers.list` has nothing new to converge on.
  */
@@ -121,7 +120,9 @@ function isManagedProfileCapableRateLimitsResponse(
   return (
     provider !== null &&
     provider.available &&
-    (provider.provider === "codex" || provider.provider === "claude-code")
+    (provider.provider === "codex" ||
+      provider.provider === "claude-code" ||
+      provider.provider === "grok")
   );
 }
 
@@ -215,7 +216,7 @@ export function buildProviderRateLimitEnvelope(
  * for this purpose because it runs inside the same queryFn invocation that
  * will overwrite that slot.
  *
- * Also the single point where a resolved codex/claude-code fetch converges
+ * Also the single point where a resolved codex/claude-code/grok fetch converges
  * `providers.list` (`invalidateProvidersListForConvergence`) - every real
  * `host.getRateLimitUsage` fetch for those two providers folds through this
  * function (the ephemeral queue's own `queryFn`; every other observer of

--- a/clients/shared/host-lock/__tests__/process-identity.test.ts
+++ b/clients/shared/host-lock/__tests__/process-identity.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  __processStartTimeMsFromElapsedSecondsForTest,
   __setAsyncProcessLivenessReaderForTest,
   __setAsyncProcessStartTimeReaderForTest,
   getPublishedProcessIdentityVerdict,
@@ -7,6 +8,35 @@ import {
 
 const PUBLISHED_AT = "2026-01-01T00:00:00.000Z";
 const PUBLISHED_AT_MS = Date.parse(PUBLISHED_AT);
+const NOW_MS = Date.parse("2026-07-22T00:00:00.000Z");
+
+describe("POSIX elapsed-time validation", () => {
+  it("converts a plausible elapsed time into an epoch start time", () => {
+    expect(
+      __processStartTimeMsFromElapsedSecondsForTest(30, NOW_MS, 3_600),
+    ).toBe(NOW_MS - 30_000);
+  });
+
+  it("allows one-second ps resolution slack but rejects the next second", () => {
+    expect(
+      __processStartTimeMsFromElapsedSecondsForTest(3_601, NOW_MS, 3_600),
+    ).toBe(NOW_MS - 3_601_000);
+    expect(
+      __processStartTimeMsFromElapsedSecondsForTest(3_602, NOW_MS, 3_600),
+    ).toBeNull();
+  });
+
+  it("rejects the absurd elapsed value observed on loaded GitHub runners", () => {
+    const observedDriftMs = 38_109_073_018_720_000;
+    expect(
+      __processStartTimeMsFromElapsedSecondsForTest(
+        observedDriftMs / 1_000,
+        NOW_MS,
+        3_600,
+      ),
+    ).toBeNull();
+  });
+});
 
 afterEach(() => {
   __setAsyncProcessLivenessReaderForTest(null);

--- a/clients/shared/host-lock/process-identity.ts
+++ b/clients/shared/host-lock/process-identity.ts
@@ -1,4 +1,5 @@
 import { execFile, execFileSync } from "node:child_process";
+import { uptime } from "node:os";
 
 // Cross-platform process liveness + identity probing. Shared by the CLI's
 // `cli-lock` hardening (holder identity - Host Update Layer Redesign Tech
@@ -165,6 +166,8 @@ export function currentProcessIdentityToken(): ProcessIdentityToken {
 // real pid-reuse collision landing inside a 5s window of the original
 // process's start is not a realistic adversary for this mechanism.
 const START_TIME_MATCH_TOLERANCE_MS = 5000;
+const POSIX_ELAPSED_UPTIME_SLACK_SECONDS = 1;
+const POSIX_PROCESS_START_TIME_MAX_RETRIES = 3;
 
 export type ProcessIdentityVerdict =
   // The token's pid is provably not running any more.
@@ -326,18 +329,53 @@ function readProcessStartTimeMsImpl(pid: number): number | null {
 }
 
 function readPosixProcessStartTimeMs(pid: number): number | null {
-  let stdout: string;
-  try {
-    stdout = execFileSync("ps", ["-p", String(pid), "-o", "etime="], {
-      encoding: "utf8",
-      timeout: 3000,
-    });
-  } catch {
+  for (
+    let retry = 0;
+    retry <= POSIX_PROCESS_START_TIME_MAX_RETRIES;
+    retry += 1
+  ) {
+    let stdout: string;
+    try {
+      stdout = execFileSync("ps", ["-p", String(pid), "-o", "etime="], {
+        encoding: "utf8",
+        timeout: 3000,
+      });
+    } catch {
+      return null;
+    }
+    const elapsedSeconds = parseElapsedSeconds(stdout.trim());
+    if (elapsedSeconds === null) return null;
+    const startedAtMs = processStartTimeMsFromElapsedSeconds(
+      elapsedSeconds,
+      Date.now(),
+      uptime(),
+    );
+    if (startedAtMs !== null) return startedAtMs;
+  }
+  return null;
+}
+
+function processStartTimeMsFromElapsedSeconds(
+  elapsedSeconds: number,
+  nowMs: number,
+  uptimeSeconds: number,
+): number | null {
+  if (
+    !Number.isFinite(elapsedSeconds) ||
+    elapsedSeconds < 0 ||
+    !Number.isFinite(nowMs) ||
+    !Number.isFinite(uptimeSeconds) ||
+    uptimeSeconds < 0 ||
+    elapsedSeconds > uptimeSeconds + POSIX_ELAPSED_UPTIME_SLACK_SECONDS
+  ) {
     return null;
   }
-  const elapsedSeconds = parseElapsedSeconds(stdout.trim());
-  if (elapsedSeconds === null) return null;
-  return Date.now() - elapsedSeconds * 1000;
+  const startedAtMs = nowMs - elapsedSeconds * 1000;
+  return Number.isFinite(startedAtMs) &&
+    startedAtMs >= 0 &&
+    startedAtMs <= nowMs
+    ? startedAtMs
+    : null;
 }
 
 // Parses `ps -o etime=` output: `[[dd-]hh:]mm:ss`. Elapsed time (not a
@@ -441,16 +479,31 @@ async function readProcessStartTimeMsAsyncImpl(
     const parsed = Date.parse(stdout.trim());
     return Number.isFinite(parsed) ? parsed : null;
   }
-  const stdout = await execFileOutput(
-    "ps",
-    ["-p", String(pid), "-o", "etime="],
-    3_000,
-  );
-  if (stdout === null) return null;
-  const elapsedSeconds = parseElapsedSeconds(stdout.trim());
-  return elapsedSeconds === null ? null : Date.now() - elapsedSeconds * 1000;
+  for (
+    let retry = 0;
+    retry <= POSIX_PROCESS_START_TIME_MAX_RETRIES;
+    retry += 1
+  ) {
+    const stdout = await execFileOutput(
+      "ps",
+      ["-p", String(pid), "-o", "etime="],
+      3_000,
+    );
+    if (stdout === null) return null;
+    const elapsedSeconds = parseElapsedSeconds(stdout.trim());
+    if (elapsedSeconds === null) return null;
+    const startedAtMs = processStartTimeMsFromElapsedSeconds(
+      elapsedSeconds,
+      Date.now(),
+      uptime(),
+    );
+    if (startedAtMs !== null) return startedAtMs;
+  }
+  return null;
 }
 
 // Exported for tests so the fixed-format parser can be exercised directly
 // without shelling out to `ps`.
 export const __parseElapsedSecondsForTest = parseElapsedSeconds;
+export const __processStartTimeMsFromElapsedSecondsForTest =
+  processStartTimeMsFromElapsedSeconds;

--- a/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
+++ b/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   downloadToFile,
   fetchText,
+  type NetworkHeartbeat,
   waitForWriterDrain,
 } from "../fetch-resource";
 import { CliError } from "../../runner/errors";
@@ -23,11 +24,20 @@ import {
 } from "./fault-server-test-helpers";
 
 const RESOURCE_URL = "https://registry.example.test/host.tar.gz";
-const NATIVE_SET_IMMEDIATE = setImmediate;
-// Fail closed if a retry scenario genuinely cannot settle within its fake-time
-// budget. `settleRetryTimers` exits as soon as the promise resolves, so this is
-// no longer a wall-clock allowance for 100 unnecessary event-loop turns.
+// Retry tests keep production watchdogs frozen and advance only backoffs that
+// the download reports through its heartbeat. The timeout remains a fail-closed
+// guard for a genuine I/O hang; it is not used to poll fake time.
 const SETTLE_RETRY_TEST_TIMEOUT_MS = 15_000;
+
+function createRetryBackoffSignal() {
+  let notify = (): void => undefined;
+  const promise = new Promise<void>((resolve) => {
+    notify = resolve;
+  });
+  return { promise, notify };
+}
+
+let retryBackoffSignal = createRetryBackoffSignal();
 
 let workDir: string;
 let originalFetch: typeof globalThis.fetch;
@@ -36,6 +46,7 @@ const faultServers: Server[] = [];
 beforeEach(() => {
   workDir = mkdtempSync(join(tmpdir(), "traycer-fetch-resource-"));
   originalFetch = globalThis.fetch;
+  retryBackoffSignal = createRetryBackoffSignal();
 });
 
 afterEach(async () => {
@@ -65,10 +76,15 @@ function failingBody(
   firstChunk: string,
   message: string,
 ): ReadableStream<Uint8Array> {
+  let emittedFirstChunk = false;
   return new ReadableStream<Uint8Array>({
-    start(controller) {
-      controller.enqueue(new TextEncoder().encode(firstChunk));
-      setTimeout(() => controller.error(new Error(message)), 1);
+    pull(controller) {
+      if (!emittedFirstChunk) {
+        emittedFirstChunk = true;
+        controller.enqueue(new TextEncoder().encode(firstChunk));
+        return;
+      }
+      controller.error(new Error(message));
     },
   });
 }
@@ -80,16 +96,14 @@ function downloadOptions(destPath: string, expected: string) {
     expectedSizeBytes: Buffer.byteLength(expected),
     expectedSha256: sha256(expected),
     onProgress: vi.fn(),
-    onHeartbeat: null,
+    onHeartbeat: (heartbeat: NetworkHeartbeat) => {
+      if (heartbeat.phase === "backoff") retryBackoffSignal.notify();
+    },
     signal: null,
   };
 }
 
 async function settleRetryTimers<T>(promise: Promise<T>): Promise<T> {
-  // Retries use a short production backoff. Advance enough timer turns to
-  // cover every attempt while allowing response/body microtasks to run. Stop
-  // once the operation settles: always running all 100 turns made these mocked
-  // tests CPU-contention-sensitive under parallel CI workers.
   let settled = false;
   const outcome = promise.then(
     (value) => {
@@ -101,19 +115,12 @@ async function settleRetryTimers<T>(promise: Promise<T>): Promise<T> {
       return { kind: "rejected" as const, error };
     },
   );
-  for (let index = 0; index < 100 && !settled; index += 1) {
-    await Promise.resolve();
-    // The download uses real fs streams even though fetch and retry timers are
-    // mocked. Yield a native libuv turn so buffered writes and close callbacks
-    // can land before advancing the production retry backoff. A microtask-only
-    // loop can outrun that I/O under parallel runner load, producing a stale
-    // zero-byte resume offset or exhausting the fake-time guard.
-    await new Promise<void>((resolve) => NATIVE_SET_IMMEDIATE(resolve));
+  const settlement = outcome.then(() => undefined);
+  while (!settled) {
+    await Promise.race([settlement, retryBackoffSignal.promise]);
     if (settled) break;
-    await vi.advanceTimersByTimeAsync(1_000);
-  }
-  if (!settled) {
-    throw new Error("retry scenario did not settle within 100 fake-time turns");
+    retryBackoffSignal = createRetryBackoffSignal();
+    await vi.advanceTimersToNextTimerAsync();
   }
   const result = await outcome;
   if (result.kind === "rejected") throw result.error;

--- a/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
+++ b/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
@@ -23,7 +23,7 @@ import {
 } from "./fault-server-test-helpers";
 
 const RESOURCE_URL = "https://registry.example.test/host.tar.gz";
-const nativeSetImmediate = setImmediate;
+const NATIVE_SET_IMMEDIATE = setImmediate;
 // Fail closed if a retry scenario genuinely cannot settle within its fake-time
 // budget. `settleRetryTimers` exits as soon as the promise resolves, so this is
 // no longer a wall-clock allowance for 100 unnecessary event-loop turns.
@@ -108,7 +108,7 @@ async function settleRetryTimers<T>(promise: Promise<T>): Promise<T> {
     // can land before advancing the production retry backoff. A microtask-only
     // loop can outrun that I/O under parallel runner load, producing a stale
     // zero-byte resume offset or exhausting the fake-time guard.
-    await new Promise<void>((resolve) => nativeSetImmediate(resolve));
+    await new Promise<void>((resolve) => NATIVE_SET_IMMEDIATE(resolve));
     if (settled) break;
     await vi.advanceTimersByTimeAsync(1_000);
   }

--- a/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
+++ b/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./fault-server-test-helpers";
 
 const RESOURCE_URL = "https://registry.example.test/host.tar.gz";
+const nativeSetImmediate = setImmediate;
 // Fail closed if a retry scenario genuinely cannot settle within its fake-time
 // budget. `settleRetryTimers` exits as soon as the promise resolves, so this is
 // no longer a wall-clock allowance for 100 unnecessary event-loop turns.
@@ -102,6 +103,12 @@ async function settleRetryTimers<T>(promise: Promise<T>): Promise<T> {
   );
   for (let index = 0; index < 100 && !settled; index += 1) {
     await Promise.resolve();
+    // The download uses real fs streams even though fetch and retry timers are
+    // mocked. Yield a native libuv turn so buffered writes and close callbacks
+    // can land before advancing the production retry backoff. A microtask-only
+    // loop can outrun that I/O under parallel runner load, producing a stale
+    // zero-byte resume offset or exhausting the fake-time guard.
+    await new Promise<void>((resolve) => nativeSetImmediate(resolve));
     if (settled) break;
     await vi.advanceTimersByTimeAsync(1_000);
   }

--- a/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
+++ b/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
@@ -23,9 +23,9 @@ import {
 } from "./fault-server-test-helpers";
 
 const RESOURCE_URL = "https://registry.example.test/host.tar.gz";
-// settleRetryTimers drives ~100 real event-loop turns to advance fake
-// timers past the production backoff; under CI CPU contention that real
-// wall-clock cost alone can exceed vitest's 5s default test timeout.
+// Fail closed if a retry scenario genuinely cannot settle within its fake-time
+// budget. `settleRetryTimers` exits as soon as the promise resolves, so this is
+// no longer a wall-clock allowance for 100 unnecessary event-loop turns.
 const SETTLE_RETRY_TEST_TIMEOUT_MS = 15_000;
 
 let workDir: string;
@@ -86,18 +86,31 @@ function downloadOptions(destPath: string, expected: string) {
 
 async function settleRetryTimers<T>(promise: Promise<T>): Promise<T> {
   // Retries use a short production backoff. Advance enough timer turns to
-  // cover every attempt while allowing response/body microtasks to run.
+  // cover every attempt while allowing response/body microtasks to run. Stop
+  // once the operation settles: always running all 100 turns made these mocked
+  // tests CPU-contention-sensitive under parallel CI workers.
+  let settled = false;
   const outcome = promise.then(
-    (value) => ({ kind: "fulfilled" as const, value }),
-    (error: unknown) => ({ kind: "rejected" as const, error }),
+    (value) => {
+      settled = true;
+      return { kind: "fulfilled" as const, value };
+    },
+    (error: unknown) => {
+      settled = true;
+      return { kind: "rejected" as const, error };
+    },
   );
-  for (let index = 0; index < 100; index += 1) {
+  for (let index = 0; index < 100 && !settled; index += 1) {
     await Promise.resolve();
+    if (settled) break;
     await vi.advanceTimersByTimeAsync(1_000);
   }
-  const settled = await outcome;
-  if (settled.kind === "rejected") throw settled.error;
-  return settled.value;
+  if (!settled) {
+    throw new Error("retry scenario did not settle within 100 fake-time turns");
+  }
+  const result = await outcome;
+  if (result.kind === "rejected") throw result.error;
+  return result.value;
 }
 
 describe("waitForWriterDrain", () => {

--- a/protocol/src/agent/__tests__/agent-profile-format.test.ts
+++ b/protocol/src/agent/__tests__/agent-profile-format.test.ts
@@ -190,7 +190,6 @@ describe("detailed rate-limit formatting", () => {
     expect(human).toContain(
       "billing period: 2026-07-13T09:30:00.000Z - 2026-07-20T09:30:00.000Z",
     );
-    expect(human).not.toContain("0% used");
   });
 
   it("renders the unavailable arm with its reason instead of inventing limits", () => {

--- a/protocol/src/agent/__tests__/agent-profile-format.test.ts
+++ b/protocol/src/agent/__tests__/agent-profile-format.test.ts
@@ -161,6 +161,38 @@ describe("detailed rate-limit formatting", () => {
     expect(human).not.toContain("0% used");
   });
 
+  it("preserves known Grok billing dates for an unmeasured period", () => {
+    const response: AgentGetProviderProfileRateLimitsResponse = {
+      rateLimits: {
+        provider: "grok",
+        available: true,
+        subscriptionTier: "SuperGrok",
+        periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+        periodStart: CAPTURED_AT,
+        periodEnd: Date.UTC(2026, 6, 20, 9, 30, 0),
+        period: null,
+        monthlyLimit: null,
+        onDemandCap: null,
+        onDemandUsed: null,
+        prepaidBalance: null,
+      },
+      usageUpdatedAt: CAPTURED_AT,
+    };
+
+    const human = formatAgentProviderProfileRateLimitsResponse(
+      { kind: "ambient" },
+      response,
+    );
+
+    expect(human).toContain(
+      "period (USAGE_PERIOD_TYPE_WEEKLY): unknown",
+    );
+    expect(human).toContain(
+      "billing period: 2026-07-13T09:30:00.000Z - 2026-07-20T09:30:00.000Z",
+    );
+    expect(human).not.toContain("0% used");
+  });
+
   it("renders the unavailable arm with its reason instead of inventing limits", () => {
     const response: AgentGetProviderProfileRateLimitsResponse = {
       rateLimits: {

--- a/protocol/src/agent/agent-profile-format.ts
+++ b/protocol/src/agent/agent-profile-format.ts
@@ -140,6 +140,28 @@ function formatProviderRateLimits(rateLimits: ProviderRateLimits): string {
       `spend: ${formatNumber(rateLimits.dailySpend)} today, ${formatNumber(rateLimits.weeklySpend)} this week, ${formatNumber(rateLimits.monthlySpend)} this month`,
     ].join("\n");
   }
+  if (rateLimits.provider === "grok") {
+    return [
+      `tier: ${rateLimits.subscriptionTier ?? "unknown"}`,
+      formatWindowLine(
+        rateLimits.periodType === null
+          ? "period"
+          : `period (${rateLimits.periodType})`,
+        rateLimits.period,
+      ),
+      rateLimits.onDemandCap === null && rateLimits.onDemandUsed === null
+        ? null
+        : `on-demand: ${formatNumber(rateLimits.onDemandUsed)}/${formatNumber(rateLimits.onDemandCap)} used`,
+      rateLimits.prepaidBalance === null
+        ? null
+        : `prepaid balance: ${formatNumber(rateLimits.prepaidBalance)}`,
+      rateLimits.monthlyLimit === null
+        ? null
+        : `monthly limit: ${formatNumber(rateLimits.monthlyLimit)}`,
+    ]
+      .filter((line): line is string => line !== null)
+      .join("\n");
+  }
   return [
     `credit balance: ${formatNumber(rateLimits.creditBalance)}`,
     `pass: ${rateLimits.passState ?? "unknown"}`,

--- a/protocol/src/agent/agent-profile-format.ts
+++ b/protocol/src/agent/agent-profile-format.ts
@@ -149,6 +149,11 @@ function formatProviderRateLimits(rateLimits: ProviderRateLimits): string {
           : `period (${rateLimits.periodType})`,
         rateLimits.period,
       ),
+      rateLimits.period !== null ||
+      rateLimits.periodStart === null ||
+      rateLimits.periodEnd === null
+        ? null
+        : `billing period: ${formatTimestamp(rateLimits.periodStart)} - ${formatTimestamp(rateLimits.periodEnd)}`,
       rateLimits.onDemandCap === null && rateLimits.onDemandUsed === null
         ? null
         : `on-demand: ${formatNumber(rateLimits.onDemandUsed)}/${formatNumber(rateLimits.onDemandCap)} used`,

--- a/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
+++ b/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
@@ -699,7 +699,11 @@ describe("agent.getProviderProfileRateLimits v1 <-> v2 hermes-provider translati
     expect(downgraded.ok).toBe(false);
     if (downgraded.ok) return;
     expect(downgraded.error.code).toBe("DOWNGRADE_UNSUPPORTED");
-    expect(downgraded.error.message).toMatch(/hermes/i);
+    // The message was generalized when grok joined the bridge: an
+    // unrepresentable provider (Hermes here) no longer names itself, since the
+    // bridge now pre-maps grok-available to the unavailable shape rather than
+    // failing closed on it.
+    expect(downgraded.error.message).toMatch(/newer Traycer client/i);
   });
 });
 

--- a/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
+++ b/protocol/src/host/agent/__tests__/profile-selection-compat.test.ts
@@ -705,6 +705,75 @@ describe("agent.getProviderProfileRateLimits v1 <-> v2 hermes-provider translati
     // failing closed on it.
     expect(downgraded.error.message).toMatch(/newer Traycer client/i);
   });
+
+  it("degrades a grok-available rate-limit read to unsupported_provider (never errors)", () => {
+    // Grok is in the frozen provider enum (it predates Hermes), so a
+    // grok-available snapshot degrades to the unavailable shape a v1.0 host
+    // returns for grok today - credit/period fields must be gone after reparse.
+    const downgraded =
+      agentGetProviderProfileRateLimitsDowngradeV20ToV10.downgradeResponse({
+        rateLimits: {
+          provider: "grok",
+          available: true,
+          subscriptionTier: "SuperGrok",
+          periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+          periodStart: 1753142400000,
+          periodEnd: 1753747200000,
+          period: {
+            usedPercent: 12,
+            resetsAt: 1753747200000,
+            durationMinutes: 10080,
+          },
+          monthlyLimit: null,
+          onDemandCap: 0,
+          onDemandUsed: 0,
+          prepaidBalance: 0,
+        },
+        usageUpdatedAt: 1753142400000,
+      });
+    expect(downgraded).toEqual({
+      ok: true,
+      value: {
+        rateLimits: {
+          provider: "grok",
+          available: false,
+          reason: "unsupported_provider",
+        },
+        usageUpdatedAt: 1753142400000,
+      },
+    });
+  });
+
+  it("degrades a period-less grok-available rate-limit read to unsupported_provider", () => {
+    const downgraded =
+      agentGetProviderProfileRateLimitsDowngradeV20ToV10.downgradeResponse({
+        rateLimits: {
+          provider: "grok",
+          available: true,
+          subscriptionTier: "SuperGrok",
+          periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+          periodStart: 1753142400000,
+          periodEnd: 1753747200000,
+          period: null,
+          monthlyLimit: null,
+          onDemandCap: null,
+          onDemandUsed: null,
+          prepaidBalance: null,
+        },
+        usageUpdatedAt: null,
+      });
+    expect(downgraded).toEqual({
+      ok: true,
+      value: {
+        rateLimits: {
+          provider: "grok",
+          available: false,
+          reason: "unsupported_provider",
+        },
+        usageUpdatedAt: null,
+      },
+    });
+  });
 });
 
 describe("agent.configure v1 <-> v2 hermes-harness response translation", () => {

--- a/protocol/src/host/agent/profiles.ts
+++ b/protocol/src/host/agent/profiles.ts
@@ -24,6 +24,7 @@ import {
   providerProfileRateLimitStatusSchema,
 } from "@traycer/protocol/host/provider-schemas";
 import {
+  mapGrokAvailableToUnavailable,
   providerRateLimitsSchema,
   providerRateLimitsSchemaV40,
 } from "@traycer/protocol/host/rate-limit/schemas";
@@ -244,18 +245,11 @@ export const agentGetProviderProfileRateLimitsDowngradeV20ToV10 =
     downgradeResponse: (response) => {
       // Grok is representable in the frozen provider enum (it predates Hermes),
       // so a grok-available snapshot degrades to the unavailable
-      // `unsupported_provider` shape - the exact row a v1.0 host returns for
-      // grok today - rather than being dropped. A Hermes rate-limit read stays
-      // unrepresentable on the frozen v1.0 wire and still fails closed below.
-      const rateLimits =
-        response.rateLimits.available &&
-        response.rateLimits.provider === "grok"
-          ? {
-              provider: "grok",
-              available: false,
-              reason: "unsupported_provider",
-            }
-          : response.rateLimits;
+      // `unsupported_provider` shape (via the shared bridge map) - the exact row
+      // a v1.0 host returns for grok today - rather than being dropped. A Hermes
+      // rate-limit read stays unrepresentable on the frozen v1.0 wire and still
+      // fails closed below.
+      const rateLimits = mapGrokAvailableToUnavailable(response.rateLimits);
       // A v1.0 caller only ever reads pre-hermes rate limits, so the common
       // case reparses cleanly through the frozen schema. Fails closed
       // (rather than silently mis-decoding) for any provider unrepresentable

--- a/protocol/src/host/agent/profiles.ts
+++ b/protocol/src/host/agent/profiles.ts
@@ -242,18 +242,36 @@ export const agentGetProviderProfileRateLimitsDowngradeV20ToV10 =
     to: { major: 1, minor: 0 },
     downgradeRequest: (request) => ({ ok: true, value: request }),
     downgradeResponse: (response) => {
+      // Grok is representable in the frozen provider enum (it predates Hermes),
+      // so a grok-available snapshot degrades to the unavailable
+      // `unsupported_provider` shape - the exact row a v1.0 host returns for
+      // grok today - rather than being dropped. A Hermes rate-limit read stays
+      // unrepresentable on the frozen v1.0 wire and still fails closed below.
+      const rateLimits =
+        response.rateLimits.available &&
+        response.rateLimits.provider === "grok"
+          ? {
+              provider: "grok",
+              available: false,
+              reason: "unsupported_provider",
+            }
+          : response.rateLimits;
       // A v1.0 caller only ever reads pre-hermes rate limits, so the common
       // case reparses cleanly through the frozen schema. Fails closed
-      // (rather than silently mis-decoding) for a Hermes rate-limit read.
+      // (rather than silently mis-decoding) for any provider unrepresentable
+      // on the frozen v1.0 wire (Hermes today).
       const parsed =
-        agentGetProviderProfileRateLimitsResponseSchemaV1.safeParse(response);
+        agentGetProviderProfileRateLimitsResponseSchemaV1.safeParse({
+          ...response,
+          rateLimits,
+        });
       if (!parsed.success) {
         return {
           ok: false,
           error: {
             code: "DOWNGRADE_UNSUPPORTED",
             message:
-              "Reading Hermes rate limits requires a newer Traycer client.",
+              "Reading rate limits for this provider requires a newer Traycer client.",
           },
         };
       }

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -683,6 +683,18 @@ describe("host.getRateLimitUsage v3.0 -> v2.1 / v1.2 grok downgrade bridges", ()
     ).toBe(false);
   });
 
+  it("rejects a grok period with no reset when its period end is known", () => {
+    expect(
+      providerRateLimitsSchema.safeParse({
+        ...grokAvailableWithPeriod,
+        period: {
+          ...grokAvailableWithPeriod.period,
+          resetsAt: null,
+        },
+      }).success,
+    ).toBe(false);
+  });
+
   it("degrades a grok-available (with period) snapshot through the 3.0 -> 2.1 bridge", () => {
     const response = {
       totalTokens: 0,

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -3,7 +3,10 @@ import { DEFAULT_ACCOUNT_CONTEXT } from "@traycer/protocol/common/schemas";
 import { downgradeResponseAcrossMajors } from "@traycer/protocol/framework/index";
 import {
   hostGetRateLimitUsageDowngradeV2ToV1,
+  hostGetRateLimitUsageDowngradeV3ToV1,
+  hostGetRateLimitUsageDowngradeV3ToV2,
   hostGetRateLimitUsageUpgradeV20ToV21,
+  hostGetRateLimitUsageUpgradeV21ToV30,
 } from "@traycer/protocol/host/rate-limit/contracts";
 import { hostRpcRegistry } from "@traycer/protocol/host/index";
 import {
@@ -16,6 +19,7 @@ import {
   rateLimitUsageResponseSchemaV12,
   rateLimitUsageResponseSchemaV20,
   rateLimitUsageResponseSchemaV21,
+  rateLimitUsageResponseSchemaV30,
 } from "@traycer/protocol/host/rate-limit/schemas";
 
 describe("providers.consumeRateLimitResetCredit schemas", () => {
@@ -572,5 +576,319 @@ describe("host.getRateLimitUsage v2.0 -> v1.2 downgrade bridge", () => {
       hostRpcRegistry["host.getRateLimitUsage"][1].versions[2].contract
         .schemaVersion,
     ).toEqual({ major: 1, minor: 2 });
+  });
+});
+
+// `host.getRateLimitUsage` major 3.0 - adds the grok available arm. Frozen
+// v2.1 / v1.2 unions have no grok arm, so the 3 -> 2 and 3 -> 1 downgrade
+// bridges degrade a grok-available snapshot to
+// `{ provider: "grok", available: false, reason: "unsupported_provider" }`
+// (the exact row a pre-grok host returns for grok) and reparse through the
+// frozen response schema. 3 -> 1 also composes the existing
+// `usage_fetch_failed` -> `rate_limits_not_available` mapping.
+describe("host.getRateLimitUsage v3.0 -> v2.1 / v1.2 grok downgrade bridges", () => {
+  const grokAvailableWithPeriod = {
+    provider: "grok" as const,
+    available: true as const,
+    subscriptionTier: "SuperGrok",
+    periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+    periodStart: 1753142400000,
+    periodEnd: 1753747200000,
+    period: {
+      usedPercent: 12,
+      resetsAt: 1753747200000,
+      durationMinutes: 10080,
+    },
+    monthlyLimit: null,
+    onDemandCap: 0,
+    onDemandUsed: 0,
+    prepaidBalance: 0,
+  };
+
+  const grokAvailablePeriodLess = {
+    provider: "grok" as const,
+    available: true as const,
+    subscriptionTier: "SuperGrok",
+    periodType: "USAGE_PERIOD_TYPE_WEEKLY",
+    periodStart: 1753142400000,
+    periodEnd: 1753747200000,
+    period: null,
+    monthlyLimit: null,
+    onDemandCap: null,
+    onDemandUsed: null,
+    prepaidBalance: null,
+  };
+
+  const grokUnavailable = {
+    provider: "grok" as const,
+    available: false as const,
+    reason: "unsupported_provider" as const,
+  };
+
+  const codexAvailable = {
+    provider: "codex" as const,
+    available: true as const,
+    planType: "plus",
+    limitId: "plus-primary",
+    limitName: "Plus",
+    primary: {
+      usedPercent: 42,
+      resetsAt: 1735689600000,
+      durationMinutes: 300,
+    },
+    secondary: null,
+    extraWindows: [],
+    credits: null,
+    individualLimit: null,
+    resetCredits: null,
+    rateLimitReachedType: null,
+  };
+
+  it("parses a grok-available snapshot on the live union and rejects it on the frozen v2.1 schema", () => {
+    expect(providerRateLimitsSchema.parse(grokAvailableWithPeriod)).toEqual(
+      grokAvailableWithPeriod,
+    );
+    expect(providerRateLimitsSchema.parse(grokAvailablePeriodLess)).toEqual(
+      grokAvailablePeriodLess,
+    );
+    expect(
+      rateLimitUsageResponseSchemaV30.parse({
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: grokAvailableWithPeriod,
+      }),
+    ).toMatchObject({
+      providerRateLimits: { provider: "grok", available: true },
+    });
+    // The frozen v2.1 response has no grok arm - without the bridge map a
+    // reparse would fail, which is exactly why the bridge exists.
+    expect(
+      rateLimitUsageResponseSchemaV21.safeParse({
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: grokAvailableWithPeriod,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("degrades a grok-available (with period) snapshot through the 3.0 -> 2.1 bridge", () => {
+    const response = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: grokAvailableWithPeriod,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV3ToV2.downgradeResponse(response),
+    ).toEqual({
+      ok: true,
+      value: {
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: grokUnavailable,
+      },
+    });
+  });
+
+  it("degrades a period-less grok-available snapshot through the 3.0 -> 2.1 bridge", () => {
+    const response = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: grokAvailablePeriodLess,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV3ToV2.downgradeResponse(response),
+    ).toEqual({
+      ok: true,
+      value: {
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: grokUnavailable,
+      },
+    });
+  });
+
+  it("passes non-grok available arms and null through the 3.0 -> 2.1 bridge unchanged", () => {
+    const withCodex = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: codexAvailable,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV3ToV2.downgradeResponse(withCodex),
+    ).toEqual({ ok: true, value: withCodex });
+
+    const withNull = {
+      totalTokens: 100,
+      remainingTokens: 50,
+      providerRateLimits: null,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV3ToV2.downgradeResponse(withNull),
+    ).toEqual({ ok: true, value: withNull });
+  });
+
+  it("passes an already-unavailable grok snapshot through the 3.0 -> 2.1 bridge unchanged", () => {
+    const response = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: grokUnavailable,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV3ToV2.downgradeResponse(response),
+    ).toEqual({ ok: true, value: response });
+  });
+
+  it("downgrades the 3.0 -> 2.1 request as the identity", () => {
+    const request = rateLimitUsageRequestSchemaV12.parse({
+      accountContext: DEFAULT_ACCOUNT_CONTEXT,
+      providerId: "grok",
+    });
+    expect(
+      hostGetRateLimitUsageDowngradeV3ToV2.downgradeRequest(request),
+    ).toEqual({ ok: true, value: request });
+  });
+
+  it("degrades grok-available through the host registry major 3 -> 2 path", () => {
+    const response = rateLimitUsageResponseSchemaV30.parse({
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: grokAvailableWithPeriod,
+    });
+    expect(
+      downgradeResponseAcrossMajors(
+        hostRpcRegistry["host.getRateLimitUsage"],
+        3,
+        2,
+        response,
+      ),
+    ).toEqual({
+      ok: true,
+      value: {
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: grokUnavailable,
+      },
+    });
+  });
+
+  it("degrades a grok-available snapshot through the 3.0 -> 1.2 bridge", () => {
+    const response = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: grokAvailableWithPeriod,
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV3ToV1.downgradeResponse(response),
+    ).toEqual({
+      ok: true,
+      value: {
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: grokUnavailable,
+      },
+    });
+  });
+
+  it("maps usage_fetch_failed to rate_limits_not_available on the 3.0 -> 1.2 bridge", () => {
+    const response = {
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: {
+        provider: "codex" as const,
+        available: false as const,
+        reason: "usage_fetch_failed" as const,
+      },
+    };
+    expect(
+      hostGetRateLimitUsageDowngradeV3ToV1.downgradeResponse(response),
+    ).toEqual({
+      ok: true,
+      value: {
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: {
+          provider: "codex",
+          available: false,
+          reason: "rate_limits_not_available",
+        },
+      },
+    });
+  });
+
+  it("degrades grok-available through the host registry major 3 -> 1 path", () => {
+    const response = rateLimitUsageResponseSchemaV30.parse({
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: grokAvailablePeriodLess,
+    });
+    expect(
+      downgradeResponseAcrossMajors(
+        hostRpcRegistry["host.getRateLimitUsage"],
+        3,
+        1,
+        response,
+      ),
+    ).toEqual({
+      ok: true,
+      value: {
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: grokUnavailable,
+      },
+    });
+  });
+
+  it("maps usage_fetch_failed through the host registry major 3 -> 1 path", () => {
+    const response = rateLimitUsageResponseSchemaV30.parse({
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: {
+        provider: "claude-code",
+        available: false,
+        reason: "usage_fetch_failed",
+      },
+    });
+    expect(
+      downgradeResponseAcrossMajors(
+        hostRpcRegistry["host.getRateLimitUsage"],
+        3,
+        1,
+        response,
+      ),
+    ).toEqual({
+      ok: true,
+      value: {
+        totalTokens: 0,
+        remainingTokens: 0,
+        providerRateLimits: {
+          provider: "claude-code",
+          available: false,
+          reason: "rate_limits_not_available",
+        },
+      },
+    });
+  });
+
+  it("upgrades a v2.1 response to v3.0 as the identity", () => {
+    const response = rateLimitUsageResponseSchemaV21.parse({
+      totalTokens: 0,
+      remainingTokens: 0,
+      providerRateLimits: codexAvailable,
+    });
+    const upgraded =
+      hostGetRateLimitUsageUpgradeV21ToV30.upgradeResponse(response);
+    expect(upgraded).toEqual(response);
+    expect(rateLimitUsageResponseSchemaV30.parse(upgraded)).toEqual(response);
+  });
+
+  it("registers host.getRateLimitUsage major 3.0 in the host registry", () => {
+    expect(
+      hostRpcRegistry["host.getRateLimitUsage"][3].versions[0].contract
+        .schemaVersion,
+    ).toEqual({ major: 3, minor: 0 });
+    expect(
+      hostRpcRegistry["host.getRateLimitUsage"][2].versions[1].contract
+        .schemaVersion,
+    ).toEqual({ major: 2, minor: 1 });
   });
 });

--- a/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
+++ b/protocol/src/host/rate-limit/__tests__/rate-limit-schemas.test.ts
@@ -671,6 +671,18 @@ describe("host.getRateLimitUsage v3.0 -> v2.1 / v1.2 grok downgrade bridges", ()
     ).toBe(false);
   });
 
+  it("rejects a grok period whose reset disagrees with its period end", () => {
+    expect(
+      providerRateLimitsSchema.safeParse({
+        ...grokAvailableWithPeriod,
+        period: {
+          ...grokAvailableWithPeriod.period,
+          resetsAt: grokAvailableWithPeriod.periodEnd + 1,
+        },
+      }).success,
+    ).toBe(false);
+  });
+
   it("degrades a grok-available (with period) snapshot through the 3.0 -> 2.1 bridge", () => {
     const response = {
       totalTokens: 0,

--- a/protocol/src/host/rate-limit/contracts.ts
+++ b/protocol/src/host/rate-limit/contracts.ts
@@ -14,7 +14,49 @@ import {
   rateLimitUsageResponseSchemaV12,
   rateLimitUsageResponseSchemaV20,
   rateLimitUsageResponseSchemaV21,
+  rateLimitUsageResponseSchemaV30,
+  type ProviderRateLimits,
 } from "@traycer/protocol/host/rate-limit/schemas";
+
+// A grok-available snapshot has no representation in any frozen provider union
+// below the v3.0 line (grok was not a rate-limit-capable provider then), so a
+// downgrade degrades it to the unavailable `unsupported_provider` shape - the
+// exact row a pre-grok host returns for grok today. `"grok"` is in every frozen
+// `provider` enum (it predates Hermes), so this reparses cleanly through the
+// older union. Any other snapshot (or `null`) passes through unchanged.
+function mapGrokAvailableToUnavailable(
+  providerRateLimits: ProviderRateLimits | null,
+): ProviderRateLimits | null {
+  if (
+    providerRateLimits !== null &&
+    providerRateLimits.available &&
+    providerRateLimits.provider === "grok"
+  ) {
+    return {
+      provider: "grok",
+      available: false,
+      reason: "unsupported_provider",
+    };
+  }
+  return providerRateLimits;
+}
+
+// The v2-only `usage_fetch_failed` reason maps to `rate_limits_not_available`
+// so a v1.2 client's frozen 8-value reason enum keeps parsing. Every other
+// reason and every `available: true` arm is already a valid v1.2 shape. Shared
+// by the 2.1 -> 1.2 and 3.0 -> 1.2 downgrade bridges.
+function mapUsageFetchFailedToNotAvailable(
+  providerRateLimits: ProviderRateLimits | null,
+): ProviderRateLimits | null {
+  if (
+    providerRateLimits !== null &&
+    providerRateLimits.available === false &&
+    providerRateLimits.reason === "usage_fetch_failed"
+  ) {
+    return { ...providerRateLimits, reason: "rate_limits_not_available" };
+  }
+  return providerRateLimits;
+}
 
 export const providersConsumeRateLimitResetCreditV10 = defineRpcContract({
   method: "providers.consumeRateLimitResetCredit",
@@ -150,15 +192,84 @@ export const hostGetRateLimitUsageDowngradeV2ToV1 = defineDowngradePath<
     ok: true,
     value: rateLimitUsageResponseSchemaV12.parse({
       ...response,
-      providerRateLimits:
-        response.providerRateLimits !== null &&
-        response.providerRateLimits.available === false &&
-        response.providerRateLimits.reason === "usage_fetch_failed"
-          ? {
-              ...response.providerRateLimits,
-              reason: "rate_limits_not_available",
-            }
-          : response.providerRateLimits,
+      providerRateLimits: mapUsageFetchFailedToNotAvailable(
+        response.providerRateLimits,
+      ),
+    }),
+  }),
+});
+
+// v3.0 adds the grok available arm to the provider-account snapshot. Shipped as
+// a major (not a minor within major 2) because a new available union arm isn't
+// strippable by the within-major skew handler the way an extra object key is -
+// an old peer's frozen union has no grok arm - so it travels with the
+// downgrade bridges below. The request shape is unchanged from v1.2/v2.x, so
+// this reuses `rateLimitUsageRequestSchemaV12` directly.
+export const hostGetRateLimitUsageV30 = defineRpcContract({
+  method: "host.getRateLimitUsage",
+  schemaVersion: { major: 3, minor: 0 } as const,
+  requestSchema: rateLimitUsageRequestSchemaV12,
+  responseSchema: rateLimitUsageResponseSchemaV30,
+});
+
+// A v2.1 request and a v3.0 request are identical shapes (both use
+// `rateLimitUsageRequestSchemaV12`), so the request upgrade is the identity. A
+// v2.1 response only ever carries the frozen v2.1 union arms, every one of
+// which is a valid v3.0 arm (the v3.0 union is a strict superset), so the
+// response upgrade is the identity too - no re-parse needed.
+export const hostGetRateLimitUsageUpgradeV21ToV30 = defineUpgradePath<
+  typeof hostGetRateLimitUsageV21,
+  typeof hostGetRateLimitUsageV30
+>({
+  from: hostGetRateLimitUsageV21.schemaVersion,
+  to: hostGetRateLimitUsageV30.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+// Downgrade bridge 3.0 -> 2.1: request is identity. A grok-available snapshot
+// degrades to the unavailable `unsupported_provider` shape (grok has no arm in
+// the frozen v2.1 union); every other arm is already valid v2.1 and passes
+// through the re-parse unchanged.
+export const hostGetRateLimitUsageDowngradeV3ToV2 = defineDowngradePath<
+  typeof hostGetRateLimitUsageV30,
+  typeof hostGetRateLimitUsageV21
+>({
+  from: hostGetRateLimitUsageV30.schemaVersion,
+  to: hostGetRateLimitUsageV21.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: rateLimitUsageResponseSchemaV21.parse({
+      ...response,
+      providerRateLimits: mapGrokAvailableToUnavailable(
+        response.providerRateLimits,
+      ),
+    }),
+  }),
+});
+
+// Downgrade bridge 3.0 -> 1.2: request is identity. Composes both frozen-line
+// maps before the v1.2 re-parse - a grok-available snapshot degrades to
+// `unsupported_provider`, and the v2-only `usage_fetch_failed` reason degrades
+// to `rate_limits_not_available` - so a v1.2 client's frozen union and 8-value
+// reason enum both keep parsing. The v1.2 parse also strips v2.1 reset-credit
+// detail. Grok is applied first so a genuinely grok-available snapshot never
+// lands on the usage-fetch-failed branch.
+export const hostGetRateLimitUsageDowngradeV3ToV1 = defineDowngradePath<
+  typeof hostGetRateLimitUsageV30,
+  typeof hostGetRateLimitUsageV12
+>({
+  from: hostGetRateLimitUsageV30.schemaVersion,
+  to: hostGetRateLimitUsageV12.schemaVersion,
+  downgradeRequest: (request) => ({ ok: true, value: request }),
+  downgradeResponse: (response) => ({
+    ok: true,
+    value: rateLimitUsageResponseSchemaV12.parse({
+      ...response,
+      providerRateLimits: mapUsageFetchFailedToNotAvailable(
+        mapGrokAvailableToUnavailable(response.providerRateLimits),
+      ),
     }),
   }),
 });

--- a/protocol/src/host/rate-limit/contracts.ts
+++ b/protocol/src/host/rate-limit/contracts.ts
@@ -15,31 +15,9 @@ import {
   rateLimitUsageResponseSchemaV20,
   rateLimitUsageResponseSchemaV21,
   rateLimitUsageResponseSchemaV30,
+  mapGrokAvailableToUnavailable,
   type ProviderRateLimits,
 } from "@traycer/protocol/host/rate-limit/schemas";
-
-// A grok-available snapshot has no representation in any frozen provider union
-// below the v3.0 line (grok was not a rate-limit-capable provider then), so a
-// downgrade degrades it to the unavailable `unsupported_provider` shape - the
-// exact row a pre-grok host returns for grok today. `"grok"` is in every frozen
-// `provider` enum (it predates Hermes), so this reparses cleanly through the
-// older union. Any other snapshot (or `null`) passes through unchanged.
-function mapGrokAvailableToUnavailable(
-  providerRateLimits: ProviderRateLimits | null,
-): ProviderRateLimits | null {
-  if (
-    providerRateLimits !== null &&
-    providerRateLimits.available &&
-    providerRateLimits.provider === "grok"
-  ) {
-    return {
-      provider: "grok",
-      available: false,
-      reason: "unsupported_provider",
-    };
-  }
-  return providerRateLimits;
-}
 
 // The v2-only `usage_fetch_failed` reason maps to `rate_limits_not_available`
 // so a v1.2 client's frozen 8-value reason enum keeps parsing. Every other

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -232,20 +232,18 @@ const grokRateLimitsSchema = z
     // `period.resetsAt` and `periodEnd` denote the same instant by
     // construction - the host synthesizes the window's reset FROM the period
     // end. The redundancy is deliberate: `periodEnd` is kept as its own field
-    // so the billing-period bounds survive a period-less snapshot (a zero-usage
-    // account reports the period dates but no usage percentage, so `period` is
-    // null and only `periodEnd` carries the end). Enforce that invariant at the
-    // wire boundary so a payload can never present two disagreeing reset
-    // instants for the same period.
+    // so the billing-period bounds survive a period-less, unmeasured snapshot
+    // (`period` is null and only `periodEnd` carries the end). Enforce that
+    // invariant at the wire boundary so a measured period can never omit or
+    // disagree with the known reset instant.
     if (
       value.periodEnd !== null &&
       value.period !== null &&
-      value.period.resetsAt !== null &&
       value.period.resetsAt !== value.periodEnd
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "grok period.resetsAt must equal periodEnd when both are set",
+        message: "grok period.resetsAt must equal periodEnd when period is set",
         path: ["period", "resetsAt"],
       });
     }
@@ -371,9 +369,7 @@ export const providerRateLimitsSchemaV21 = z.union([
   kiloCodeRateLimitsSchema,
   unavailableProviderRateLimitsSchemaV2,
 ]);
-export type ProviderRateLimitsV21 = z.infer<
-  typeof providerRateLimitsSchemaV21
->;
+export type ProviderRateLimitsV21 = z.infer<typeof providerRateLimitsSchemaV21>;
 
 // Latest provider union: identical to the frozen v2.1 union above plus the
 // grok available arm. Feeds the v3.0 host response and the unreleased,

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -87,6 +87,7 @@ export const rateLimitCapableProviderIdSchema = z.enum([
   "claude-code",
   "openrouter",
   "kilocode",
+  "grok",
 ]);
 export type RateLimitCapableProviderId = z.infer<
   typeof rateLimitCapableProviderIdSchema
@@ -205,6 +206,31 @@ const claudeCodeRateLimitsSchema = z.object({
     .nullable(),
 });
 
+// Grok arm - ephemeral-CLI-class provider (usage is read over the vendored
+// grok CLI's own `_x.ai/billing` ACP extension, so Traycer never touches the
+// grok OAuth token), but the payload is billing-period/credit-shaped rather
+// than rolling-window-shaped. Hybrid: a synthesized `period` window (so
+// severity rollups, a2a `rateLimitStatus`, and GUI status logic reuse the
+// shared window primitive with zero special-casing) plus the raw credit
+// fields. Every payload-derived field is nullable: xAI omits fields freely by
+// account type, and a zero-usage subscription reports only period + tier.
+// `period.resetsAt` duplicates `periodEnd` when both exist; `periodEnd` stays a
+// separate field because the period bounds are known even when no usage
+// percentage is reported.
+const grokRateLimitsSchema = z.object({
+  provider: z.literal(rateLimitCapableProviderIdSchema.enum.grok),
+  available: z.literal(true),
+  subscriptionTier: z.string().nullable(),
+  periodType: z.string().nullable(),
+  periodStart: z.number().nullable(),
+  periodEnd: z.number().nullable(),
+  period: providerRateLimitWindowSchema.nullable(),
+  monthlyLimit: z.number().nullable(),
+  onDemandCap: z.number().nullable(),
+  onDemandUsed: z.number().nullable(),
+  prepaidBalance: z.number().nullable(),
+});
+
 // Closed, Traycer-owned set of reasons a provider pull can fail to report
 // rate limits - unlike a provider's own plan/reached-type tokens (owned by
 // that provider, legitimately forward-compat as a bare string), every one of
@@ -310,13 +336,34 @@ export const providerRateLimitsSchemaV2 = z.union([
   unavailableProviderRateLimitsSchemaV2,
 ]);
 
-// Latest provider union (v3): identical to v2 except Codex reset credits may
-// include capped per-credit detail.
+// Frozen v2.1 provider union - a byte-for-byte snapshot of the live union as
+// shipped in `rateLimitUsageResponseSchemaV21` (host.getRateLimitUsage@2.1):
+// codex-with-per-credit-detail + claude-code + openrouter + kilocode +
+// unavailableV2, WITHOUT the grok arm. Feeds `rateLimitUsageResponseSchemaV21`
+// only, so that already-shipped v2.1 response never silently grows when the
+// live union below gains grok. New available arms travel behind a new major
+// (`host.getRateLimitUsage@3.0`) with a downgrade bridge, never an in-place
+// edit here. Do NOT widen this schema.
+export const providerRateLimitsSchemaV21 = z.union([
+  codexRateLimitsSchema,
+  claudeCodeRateLimitsSchema,
+  openRouterRateLimitsSchema,
+  kiloCodeRateLimitsSchema,
+  unavailableProviderRateLimitsSchemaV2,
+]);
+export type ProviderRateLimitsV21 = z.infer<
+  typeof providerRateLimitsSchemaV21
+>;
+
+// Latest provider union: identical to the frozen v2.1 union above plus the
+// grok available arm. Feeds the v3.0 host response and the unreleased,
+// still-growing a2a `agent.getProviderProfileRateLimits@2.0`.
 export const providerRateLimitsSchema = z.union([
   codexRateLimitsSchema,
   claudeCodeRateLimitsSchema,
   openRouterRateLimitsSchema,
   kiloCodeRateLimitsSchema,
+  grokRateLimitsSchema,
   unavailableProviderRateLimitsSchemaV2,
 ]);
 export type ProviderRateLimits = z.infer<typeof providerRateLimitsSchema>;
@@ -382,13 +429,32 @@ export type RateLimitUsageResponseV20 = z.infer<
 // v2.1 adds capped per-credit Codex reset detail. The request and unavailable
 // reason set remain unchanged from v2.0. Released v2.0 stays frozen; the RPC
 // handler projects a canonical v2.1 response through the v2.0 schema for an
-// older caller, stripping the additive detail.
+// older caller, stripping the additive detail. Pinned to the frozen
+// `providerRateLimitsSchemaV21` (NOT the live union) so the grok arm added to
+// the live union never reaches this shipped response - grok travels on the
+// v3.0 line below.
 export const rateLimitUsageResponseSchemaV21 =
   rateLimitUsageResponseSchema.extend({
-    providerRateLimits: providerRateLimitsSchema.nullable(),
+    providerRateLimits: providerRateLimitsSchemaV21.nullable(),
   });
 export type RateLimitUsageResponseV21 = z.infer<
   typeof rateLimitUsageResponseSchemaV21
+>;
+
+// v3.0 response - identical to v2.1 except the provider-account snapshot ranges
+// over the live `providerRateLimitsSchema`, which adds the grok available arm.
+// The request shape is unchanged from v1.2/v2.x, so `hostGetRateLimitUsageV30`
+// in `contracts.ts` reuses `rateLimitUsageRequestSchemaV12` directly. Shipped
+// as a new major (not a v2.2 minor) because a new available union arm is not
+// strippable by the within-major skew handler - an old peer's frozen union has
+// no grok arm - so it needs an explicit downgrade bridge that degrades a
+// grok-available snapshot to the unavailable `unsupported_provider` shape.
+export const rateLimitUsageResponseSchemaV30 =
+  rateLimitUsageResponseSchema.extend({
+    providerRateLimits: providerRateLimitsSchema.nullable(),
+  });
+export type RateLimitUsageResponseV30 = z.infer<
+  typeof rateLimitUsageResponseSchemaV30
 >;
 
 /**

--- a/protocol/src/host/rate-limit/schemas.ts
+++ b/protocol/src/host/rate-limit/schemas.ts
@@ -214,22 +214,42 @@ const claudeCodeRateLimitsSchema = z.object({
 // shared window primitive with zero special-casing) plus the raw credit
 // fields. Every payload-derived field is nullable: xAI omits fields freely by
 // account type, and a zero-usage subscription reports only period + tier.
-// `period.resetsAt` duplicates `periodEnd` when both exist; `periodEnd` stays a
-// separate field because the period bounds are known even when no usage
-// percentage is reported.
-const grokRateLimitsSchema = z.object({
-  provider: z.literal(rateLimitCapableProviderIdSchema.enum.grok),
-  available: z.literal(true),
-  subscriptionTier: z.string().nullable(),
-  periodType: z.string().nullable(),
-  periodStart: z.number().nullable(),
-  periodEnd: z.number().nullable(),
-  period: providerRateLimitWindowSchema.nullable(),
-  monthlyLimit: z.number().nullable(),
-  onDemandCap: z.number().nullable(),
-  onDemandUsed: z.number().nullable(),
-  prepaidBalance: z.number().nullable(),
-});
+const grokRateLimitsSchema = z
+  .object({
+    provider: z.literal(rateLimitCapableProviderIdSchema.enum.grok),
+    available: z.literal(true),
+    subscriptionTier: z.string().nullable(),
+    periodType: z.string().nullable(),
+    periodStart: z.number().nullable(),
+    periodEnd: z.number().nullable(),
+    period: providerRateLimitWindowSchema.nullable(),
+    monthlyLimit: z.number().nullable(),
+    onDemandCap: z.number().nullable(),
+    onDemandUsed: z.number().nullable(),
+    prepaidBalance: z.number().nullable(),
+  })
+  .superRefine((value, ctx) => {
+    // `period.resetsAt` and `periodEnd` denote the same instant by
+    // construction - the host synthesizes the window's reset FROM the period
+    // end. The redundancy is deliberate: `periodEnd` is kept as its own field
+    // so the billing-period bounds survive a period-less snapshot (a zero-usage
+    // account reports the period dates but no usage percentage, so `period` is
+    // null and only `periodEnd` carries the end). Enforce that invariant at the
+    // wire boundary so a payload can never present two disagreeing reset
+    // instants for the same period.
+    if (
+      value.periodEnd !== null &&
+      value.period !== null &&
+      value.period.resetsAt !== null &&
+      value.period.resetsAt !== value.periodEnd
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "grok period.resetsAt must equal periodEnd when both are set",
+        path: ["period", "resetsAt"],
+      });
+    }
+  });
 
 // Closed, Traycer-owned set of reasons a provider pull can fail to report
 // rate limits - unlike a provider's own plan/reached-type tokens (owned by
@@ -367,6 +387,33 @@ export const providerRateLimitsSchema = z.union([
   unavailableProviderRateLimitsSchemaV2,
 ]);
 export type ProviderRateLimits = z.infer<typeof providerRateLimitsSchema>;
+
+// Single home for the grok available -> unavailable degrade every downgrade
+// bridge below the v3.0 line applies. A grok-available snapshot has no
+// representation in any frozen provider union (grok was not a rate-limit-capable
+// provider then), so it degrades to the unavailable `unsupported_provider` shape
+// - the exact row a pre-grok host returns for grok today. `"grok"` is in every
+// frozen `provider` enum (it predates Hermes), so the result reparses cleanly
+// through the older union. Any other snapshot (or `null`) passes through
+// unchanged. Shared by the `host.getRateLimitUsage` 3 -> 2 / 3 -> 1 bridges
+// (`rate-limit/contracts.ts`) and the a2a `agent.getProviderProfileRateLimits`
+// v2 -> v1 bridge (`agent/profiles.ts`).
+export function mapGrokAvailableToUnavailable(
+  providerRateLimits: ProviderRateLimits | null,
+): ProviderRateLimits | null {
+  if (
+    providerRateLimits !== null &&
+    providerRateLimits.available &&
+    providerRateLimits.provider === "grok"
+  ) {
+    return {
+      provider: "grok",
+      available: false,
+      reason: "unsupported_provider",
+    };
+  }
+  return providerRateLimits;
+}
 
 // Frozen pre-Hermes unavailable arm: same v2 reason enum, but `provider` is
 // pinned to `providerIdSchemaV40` (the harness/provider id set as shipped in

--- a/protocol/src/host/rate-limit/semantics.ts
+++ b/protocol/src/host/rate-limit/semantics.ts
@@ -60,6 +60,11 @@ export function providerRateLimitWindows(
           window.secondary,
         ]),
       ].filter((window): window is ProviderRateLimitWindow => window !== null);
+    case "grok":
+      // Hybrid arm: the synthesized billing-period window feeds the shared
+      // severity/rollup path. A period-less snapshot (tier + dates only, no
+      // usage percentage) carries no window.
+      return rateLimits.period !== null ? [rateLimits.period] : [];
     case "openrouter":
     case "kilocode":
       return [];

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -116,11 +116,15 @@ import {
   hostGetRateLimitUsageV12,
   hostGetRateLimitUsageV20,
   hostGetRateLimitUsageV21,
+  hostGetRateLimitUsageV30,
   hostGetRateLimitUsageUpgradeV10ToV11,
   hostGetRateLimitUsageUpgradeV11ToV12,
   hostGetRateLimitUsageUpgradeV12ToV20,
   hostGetRateLimitUsageUpgradeV20ToV21,
+  hostGetRateLimitUsageUpgradeV21ToV30,
   hostGetRateLimitUsageDowngradeV2ToV1,
+  hostGetRateLimitUsageDowngradeV3ToV2,
+  hostGetRateLimitUsageDowngradeV3ToV1,
   providersConsumeRateLimitResetCreditV10,
 } from "@traycer/protocol/host/rate-limit/contracts";
 import {
@@ -2183,6 +2187,19 @@ const HOST_RPC_REGISTRY_DEFINITION = {
         },
       },
       downgradePathsFromLatest: { 1: hostGetRateLimitUsageDowngradeV2ToV1 },
+    },
+    3: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: hostGetRateLimitUsageV30,
+          upgradeFromPreviousVersion: hostGetRateLimitUsageUpgradeV21ToV30,
+        },
+      },
+      downgradePathsFromLatest: {
+        2: hostGetRateLimitUsageDowngradeV3ToV2,
+        1: hostGetRateLimitUsageDowngradeV3ToV1,
+      },
     },
   },
   "providers.consumeRateLimitResetCredit": {


### PR DESCRIPTION
## Summary

- add a Grok rate-limit protocol arm and open `host.getRateLimitUsage@3.0` while preserving released-peer compatibility through explicit downgrade bridges
- surface Grok billing-period usage, subscription tier, and available credit fields in the GUI without adding a header glyph for the weekly window
- treat healthy period-less snapshots as available-but-unmeasured, infer zero usage only under guarded weekly-period evidence, and keep ambient provider cards visually consistent in the popover

## Compatibility

- freeze the shipped `host.getRateLimitUsage@2.1` response union
- degrade Grok-available responses to `unsupported_provider` for older host and agent-profile peers
- preserve the fail-closed behavior for genuinely unrepresentable providers

The host-side reader over the Grok CLI `_x.ai/billing` ACP extension lands in the companion internal PR.

## Verification

- protocol: 1,129 tests passed
- released-baseline compatibility: 12/12 baselines; handshake matrix 50/50
- GUI app: full suite passed (6,753 tests), including rate-limit card, projection, and popover coverage
- four affected workspaces compile cleanly
- `compat-exceptions.json` remains unchanged
- all seven commits include DCO sign-off

## Related issue

None.

## Checklist

- [x] Tests pass for affected workspaces
- [x] Code is formatted
- [x] Tests added and updated
- [x] Commits are signed off under DCO