### PR TITLE
fix(gui-app): make worktree re-provision retry idempotent-safe and surface its failures

### DIFF
--- a/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/setup-card-segment.test.tsx
@@ -16,9 +16,30 @@ import {
   type SetupWorkspaceState,
 } from "@/components/chat/segments/setup-card-segment";
 
+// Shapes the typed `createMutate` mock needs so per-call `onSuccess` handling
+// (the perEntry-failure toast) can be exercised without `any` leakage.
+type CreatePerEntryResult = {
+  workspacePath: string;
+  ok: boolean;
+  worktreePath: string | null;
+  branch: string | null;
+  errorMessage: string | null;
+};
+type CreateMutateOptions = {
+  onSuccess: (response: {
+    binding: { entries: [] };
+    perEntry: CreatePerEntryResult[];
+  }) => void;
+};
+
 const focusTerminal = vi.hoisted(() => vi.fn());
 const retryMutate = vi.hoisted(() => vi.fn());
-const createMutate = vi.hoisted(() => vi.fn());
+const createMutate = vi.hoisted(() =>
+  vi.fn<
+    (variables: unknown, options: CreateMutateOptions | undefined) => void
+  >(),
+);
+const errorToast = vi.hoisted(() => vi.fn());
 // `value === undefined` models the "liveness not yet known" window (the query
 // has not settled); an array models a settled `terminal.list` response.
 const terminalSessions = vi.hoisted<{
@@ -64,6 +85,10 @@ vi.mock("@/hooks/worktree/use-worktree-create-mutation", () => ({
     mutate: createMutate,
     isPending: false,
   }),
+}));
+
+vi.mock("@/lib/reportable-error-toast", () => ({
+  reportableErrorToast: errorToast,
 }));
 
 // Contract guard: the state union is exactly these five. If it drifts,
@@ -133,6 +158,7 @@ beforeEach(() => {
   focusTerminal.mockReset();
   retryMutate.mockReset();
   createMutate.mockReset();
+  errorToast.mockReset();
   terminalSessions.value = undefined;
   tabClient.value = {};
   retryClientArg.value = "unset";
@@ -357,13 +383,81 @@ describe("<SetupCardSegment /> single-repo dropdown (two steps)", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Retry setup" }));
-    expect(createMutate).toHaveBeenCalledWith({
+    expect(createMutate).toHaveBeenCalledTimes(1);
+    expect(createMutate.mock.calls[0][0]).toEqual({
       epicId: EPIC_ID,
       ownerId: OWNER_ID,
       ownerKind: "chat",
       entries: [folderIntent],
     });
     expect(retryMutate).not.toHaveBeenCalled();
+  });
+
+  it("toasts the per-entry error when the re-provision resolves with a failed entry", () => {
+    // A failed entry does NOT reject the RPC - it rides `perEntry` on a
+    // successful response - so the hook-level onError toast never fires and
+    // the per-call onSuccess must surface it instead.
+    const folderIntent = {
+      kind: "worktree" as const,
+      workspacePath: "/repo",
+      repoIdentifier: null,
+      isPrimary: true,
+      branch: {
+        type: "new" as const,
+        name: "traycer/fresh-fox",
+        source: "main",
+        carryUncommittedChanges: false,
+      },
+      scripts: null,
+    };
+    renderCard(
+      viewModel("failed", [
+        workspace({
+          state: "failed",
+          worktreePath: null,
+          errorMessage: "git worktree add failed",
+          retryFolderIntent: folderIntent,
+        }),
+      ]),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Retry setup" }));
+
+    const options = createMutate.mock.calls[0][1];
+    expect(options).toBeDefined();
+
+    // An all-ok response never toasts.
+    options?.onSuccess({
+      binding: { entries: [] },
+      perEntry: [
+        {
+          workspacePath: "/repo",
+          ok: true,
+          worktreePath: "/worktrees/fresh-fox",
+          branch: "traycer/fresh-fox",
+          errorMessage: null,
+        },
+      ],
+    });
+    expect(errorToast).not.toHaveBeenCalled();
+
+    options?.onSuccess({
+      binding: { entries: [] },
+      perEntry: [
+        {
+          workspacePath: "/repo",
+          ok: false,
+          worktreePath: null,
+          branch: "traycer/fresh-fox",
+          errorMessage:
+            "traycer/fresh-fox is already checked out in /elsewhere",
+        },
+      ],
+    });
+    expect(errorToast).toHaveBeenCalledWith(
+      "traycer/fresh-fox is already checked out in /elsewhere",
+      undefined,
+      expect.objectContaining({ title: "Worktree re-provision failed" }),
+    );
   });
 
   it("renders the provision failure reason on the failed card", () => {

--- a/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/setup-card-segment.tsx
@@ -26,6 +26,7 @@ import {
 import { FilePathTooltip } from "@/components/file-path-tooltip";
 import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { createReportIssueContext } from "@/lib/report-issue-context";
+import { reportableErrorToast } from "@/lib/reportable-error-toast";
 import { StartTruncatedText } from "@/components/ui/start-truncated-text";
 import { useFocusEpicTerminalSession } from "@/components/epic-canvas/renderers/chat-tile-focus-terminal";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
@@ -189,12 +190,37 @@ export function SetupCardSegment(props: {
     // Script failures keep the in-place `retrySetup` path: the worktree
     // exists and only its setup script needs to re-run.
     if (workspace.retryFolderIntent !== null) {
-      worktreeCreate.mutate({
-        epicId: aggregate.epicId,
-        ownerId: aggregate.ownerId,
-        ownerKind: aggregate.ownerKind,
-        entries: [workspace.retryFolderIntent],
-      });
+      worktreeCreate.mutate(
+        {
+          epicId: aggregate.epicId,
+          ownerId: aggregate.ownerId,
+          ownerKind: aggregate.ownerKind,
+          entries: [workspace.retryFolderIntent],
+        },
+        {
+          // A failed entry does NOT reject the RPC - it rides `perEntry` on a
+          // successful response, so the hook's `onError` toast never sees it.
+          // Surface it here; the host separately appends a fresh
+          // `setup.failed` event that refreshes this card's reason.
+          onSuccess: (response) => {
+            const failed = response.perEntry.find(
+              (entry) =>
+                entry.workspacePath === workspace.workspacePath && !entry.ok,
+            );
+            if (failed === undefined) return;
+            reportableErrorToast(
+              failed.errorMessage ?? "Couldn't create worktree.",
+              undefined,
+              createReportIssueContext({
+                title: "Worktree re-provision failed",
+                message: failed.errorMessage,
+                code: null,
+                source: "Setup",
+              }),
+            );
+          },
+        },
+      );
       return;
     }
     retrySetup.mutate({


### PR DESCRIPTION
## Summary
- The setup card's Retry for a provision failure replays the exact folder intent through `worktree.create`; a per-entry failure rides `perEntry` on a successful RPC response instead of rejecting, so the retry mutation's `onError` toast never saw it and a failing retry looked silent.
- Add a per-call `onSuccess` handler on the retry-create mutation that inspects `perEntry` and toasts the real failure reason.

Companion host-side change (idempotent `WorktreeService.add` + `setup.failed` propagation for a failing direct create) is in a separate `traycer-internal` PR.

## Test plan
- [x] `bun run compile`
- [x] `bunx vitest run src/components/chat/segments/__tests__/setup-card-segment.test.tsx` (28 passed)
- [x] `react-doctor` on the touched directory (clean)