### PR TITLE
fix(gui-app): surface the host's per-entry reason in the terminal-agent launch-abort toast

### DIFF
--- a/clients/gui-app/src/hooks/agent/__tests__/use-create-tui-agent.test.tsx
+++ b/clients/gui-app/src/hooks/agent/__tests__/use-create-tui-agent.test.tsx
@@ -77,6 +77,7 @@ import { peekPreparedTerminalAgentLaunch } from "@/stores/terminals/prepared-ter
 const EPIC_ID = "epic-1";
 const TAB_ID = "tab-1";
 const WORKSPACE_PATH = "/tmp/workspace-a";
+const SECOND_WORKSPACE_PATH = "/tmp/workspace-b";
 
 function queryClientWrapper(
   queryClient: QueryClient,
@@ -246,6 +247,91 @@ describe("useCreateTuiAgent", () => {
     expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
       'Couldn\'t prepare the workspace for "workspace-a". The terminal agent was not launched.',
       expect.objectContaining({ description: "branch already exists" }),
+    );
+  });
+
+  it("does not borrow a later entry's reason for the folder the message names", async () => {
+    vi.mocked(toast.error).mockClear();
+    hookMocks.request.mockImplementation((method, payload) => {
+      if (method === "worktree.create") {
+        // Both entries failed, but only the SECOND carries a reason. The
+        // headline names the first, so attributing the second's message to it
+        // would misreport which folder hit what.
+        return Promise.resolve({
+          binding: { entries: [] },
+          perEntry: [
+            {
+              workspacePath: WORKSPACE_PATH,
+              ok: false,
+              worktreePath: null,
+              branch: null,
+              errorMessage: null,
+            },
+            {
+              workspacePath: SECOND_WORKSPACE_PATH,
+              ok: false,
+              worktreePath: null,
+              branch: null,
+              errorMessage: "branch already exists",
+            },
+          ],
+        });
+      }
+      return Promise.resolve(worktreeCreateOkResponse(payload));
+    });
+    const queryClient = makeQueryClient();
+    const { result } = renderHook(() => useCreateTuiAgent(), {
+      wrapper: queryClientWrapper(queryClient),
+    });
+
+    const worktreeEntry = (
+      workspacePath: string,
+    ): WorktreeIntent["entries"][number] => ({
+      kind: "worktree",
+      scripts: null,
+      workspacePath,
+      repoIdentifier: { owner: "traycerai", repo: "traycer" },
+      isPrimary: workspacePath === WORKSPACE_PATH,
+      branch: {
+        type: "new",
+        name: "traycer/fix-x",
+        source: "main",
+        carryUncommittedChanges: false,
+      },
+    });
+    const intent: WorktreeIntent = {
+      entries: [
+        worktreeEntry(WORKSPACE_PATH),
+        worktreeEntry(SECOND_WORKSPACE_PATH),
+      ],
+    };
+
+    await act(async () => {
+      await expect(
+        result.current.create({
+          epicId: EPIC_ID,
+          tabId: TAB_ID,
+          parentId: null,
+          title: "",
+          placement: { kind: "active-tile" },
+          harnessId: "claude",
+          model: null,
+          reasoningEffort: null,
+          agentMode: "regular",
+          forkSourceHarnessSessionId: null,
+          onStatusChange: null,
+          workspaceMode: "inherit",
+          worktreeIntent: intent,
+          terminalAgentArgs: null,
+          profileId: null,
+        }),
+      ).rejects.toThrow(/^Couldn't prepare the workspace for 2 folders/);
+    });
+
+    // Falls back to the folder-only headline: no description, and the other
+    // folder's reason never rides along.
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+      'Couldn\'t prepare the workspace for 2 folders, starting with "workspace-a". The terminal agent was not launched.',
     );
   });
 

--- a/clients/gui-app/src/hooks/agent/__tests__/use-create-tui-agent.test.tsx
+++ b/clients/gui-app/src/hooks/agent/__tests__/use-create-tui-agent.test.tsx
@@ -67,6 +67,7 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
+import { toast } from "sonner";
 import {
   type CreateTuiAgentStatus,
   useCreateTuiAgent,
@@ -229,7 +230,9 @@ describe("useCreateTuiAgent", () => {
           terminalAgentArgs: null,
           profileId: null,
         }),
-      ).rejects.toThrow("Couldn't prepare the workspace");
+      ).rejects.toThrow(
+        /Couldn't prepare the workspace .* branch already exists/,
+      );
     });
 
     // Launching against the partial binding never proceeds to harness work.
@@ -237,6 +240,13 @@ describe("useCreateTuiAgent", () => {
     expect(methodOrder).toContain("worktree.create");
     expect(methodOrder).not.toContain("agent.tui.prepareLaunch");
     expect(methodOrder).not.toContain("epic.createTuiAgent");
+
+    // The host's causal per-entry reason reaches the toast, not just the
+    // folder-name headline.
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+      'Couldn\'t prepare the workspace for "workspace-a". The terminal agent was not launched.',
+      expect.objectContaining({ description: "branch already exists" }),
+    );
   });
 
   it("Worktree-mode (create) dispatches worktree.create BEFORE agent.tui.prepareLaunch", async () => {

--- a/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
+++ b/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
@@ -442,22 +442,43 @@ async function dispatchWorktreeIntent(
       .filter((entryResult) => entryResult.ok)
       .map((entryResult) => entryResult.workspacePath),
   );
-  const failedPaths = intent.entries
+  const failedEntries = intent.entries
     .map((entry) => entry.workspacePath)
-    .filter((workspacePath) => !okPaths.has(workspacePath));
-  if (failedPaths.length > 0) {
-    const folder = workspaceFolderName(failedPaths[0]);
+    .filter((workspacePath) => !okPaths.has(workspacePath))
+    .map((workspacePath) => ({
+      workspacePath,
+      // A failed entry rides `perEntry` with `ok: false` and the host's causal
+      // `errorMessage` (git stderr tail, checked-out-elsewhere, …); an entry
+      // the host reported nothing about has no row, hence no reason.
+      errorMessage:
+        result.perEntry.find(
+          (entryResult) =>
+            entryResult.workspacePath === workspacePath && !entryResult.ok,
+        )?.errorMessage ?? null,
+    }));
+  if (failedEntries.length > 0) {
+    const folder = workspaceFolderName(failedEntries[0].workspacePath);
     const scope =
-      failedPaths.length === 1
+      failedEntries.length === 1
         ? `"${folder}"`
-        : `${failedPaths.length} folders, starting with "${folder}"`;
+        : `${failedEntries.length} folders, starting with "${folder}"`;
+    const reason =
+      failedEntries
+        .map((entry) => entry.errorMessage)
+        .find(
+          (errorMessage): errorMessage is string => errorMessage !== null,
+        ) ?? null;
     const message = `Couldn't prepare the workspace for ${scope}. The terminal agent was not launched.`;
-    reportableErrorToast(message, undefined, {
-      title: "Terminal agent launch aborted",
-      message: null,
-      code: null,
-      source: "Worktree create",
-    });
-    throw new Error(message);
+    reportableErrorToast(
+      message,
+      reason === null ? undefined : { description: reason },
+      {
+        title: "Terminal agent launch aborted",
+        message: reason,
+        code: null,
+        source: "Worktree create",
+      },
+    );
+    throw new Error(reason === null ? message : `${message} ${reason}`);
   }
 }

--- a/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
+++ b/clients/gui-app/src/hooks/agent/use-create-tui-agent.ts
@@ -442,32 +442,26 @@ async function dispatchWorktreeIntent(
       .filter((entryResult) => entryResult.ok)
       .map((entryResult) => entryResult.workspacePath),
   );
-  const failedEntries = intent.entries
+  const failedPaths = intent.entries
     .map((entry) => entry.workspacePath)
-    .filter((workspacePath) => !okPaths.has(workspacePath))
-    .map((workspacePath) => ({
-      workspacePath,
-      // A failed entry rides `perEntry` with `ok: false` and the host's causal
-      // `errorMessage` (git stderr tail, checked-out-elsewhere, …); an entry
-      // the host reported nothing about has no row, hence no reason.
-      errorMessage:
-        result.perEntry.find(
-          (entryResult) =>
-            entryResult.workspacePath === workspacePath && !entryResult.ok,
-        )?.errorMessage ?? null,
-    }));
-  if (failedEntries.length > 0) {
-    const folder = workspaceFolderName(failedEntries[0].workspacePath);
+    .filter((workspacePath) => !okPaths.has(workspacePath));
+  if (failedPaths.length > 0) {
+    const folder = workspaceFolderName(failedPaths[0]);
     const scope =
-      failedEntries.length === 1
+      failedPaths.length === 1
         ? `"${folder}"`
-        : `${failedEntries.length} folders, starting with "${folder}"`;
+        : `${failedPaths.length} folders, starting with "${folder}"`;
+    // The reason must describe the SAME entry `scope` names, so read it off
+    // `failedPaths[0]` rather than the first entry that happens to carry one -
+    // a later entry's message would misattribute the failure. A failed entry
+    // rides `perEntry` with `ok: false` and the host's causal `errorMessage`
+    // (git stderr tail, checked-out-elsewhere, …); an entry the host reported
+    // nothing about has no row, so the headline stands alone.
     const reason =
-      failedEntries
-        .map((entry) => entry.errorMessage)
-        .find(
-          (errorMessage): errorMessage is string => errorMessage !== null,
-        ) ?? null;
+      result.perEntry.find(
+        (entryResult) =>
+          entryResult.workspacePath === failedPaths[0] && !entryResult.ok,
+      )?.errorMessage ?? null;
     const message = `Couldn't prepare the workspace for ${scope}. The terminal agent was not launched.`;
     reportableErrorToast(
       message,


### PR DESCRIPTION
## Summary
- A failed `worktree.create` entry rides `perEntry` on a successful RPC response carrying the host's causal `errorMessage` (git stderr tail, checked-out-elsewhere, branch-exists, …), but the terminal-agent launch path dropped it: the "Terminal agent launch aborted" toast showed only the folder name and passed `message: null` into the report-issue context, so users and support reports never saw why the launch failed.
- `dispatchWorktreeIntent` now pairs each failed path with its `perEntry.errorMessage`, threads the first reason into the toast description, the report-issue context, and the thrown error. Entries the host reported nothing about still fall back to the folder-name-only headline.

Follow-up to #600 (same surfacing for the chat setup card's retry path); companion host-side diagnostics landed in the internal worktree re-provision PR. Context: #516, #532 — the failure those issues hit is fixed host-side, this closes the remaining opaque-toast gap on the terminal-agent surface.

## Test plan
- [x] `bun run compile` (gui-app)
- [x] `bunx vitest run src/hooks/agent/__tests__/use-create-tui-agent.test.tsx` (16 passed) — the per-entry-failure test now asserts the reason reaches both the thrown error and the toast description
- [x] `react-doctor` diff scan vs `origin/main` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)