### PR TITLE
Revert "feat(gui-app): merge completed thinking blocks into the activity group (#597)"

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-activity-groups.test.ts
+++ b/clients/gui-app/src/components/chat/__tests__/chat-activity-groups.test.ts
@@ -109,112 +109,73 @@ describe("chat activity grouping", () => {
     ]);
   });
 
-  it("folds a completed reasoning block into the following activity group", () => {
+  it("promotes reasoning to its own segment before operational activity", () => {
     const timeline = buildCompleteTimeline([
-      reasoningSegment("reasoning-1", false, 2000),
+      reasoningSegment("reasoning-1", false),
       commandSegment("command-1", "bun test", false),
     ]);
 
-    expect(timeline.map((item) => item.kind)).toEqual(["activity_group"]);
-    if (timeline[0]?.kind !== "activity_group") {
-      throw new Error("Expected a single merged activity group");
+    expect(timeline.map((item) => item.kind)).toEqual([
+      "segment",
+      "activity_group",
+    ]);
+    if (timeline[0]?.kind !== "segment") {
+      throw new Error("Expected promoted reasoning segment");
     }
-    expect(timeline[0].group.summary).toBe("Thought for 2s, ran 1 command");
-    expect(timeline[0].group.segments.map((segment) => segment.kind)).toEqual([
-      "reasoning",
+    expect(timeline[0].segment.kind).toBe("reasoning");
+    if (timeline[1]?.kind !== "activity_group") {
+      throw new Error("Expected operational activity group");
+    }
+    expect(timeline[1].group.summary).toBe("Ran 1 command");
+    expect(timeline[1].group.segments.map((segment) => segment.kind)).toEqual([
       "command",
     ]);
   });
 
-  it("accumulates duration across every reasoning block in the run", () => {
+  it("promotes each reasoning block between operational phases", () => {
     const timeline = buildCompleteTimeline([
-      reasoningSegment("reasoning-1", false, 2000),
+      reasoningSegment("reasoning-1", false),
       commandSegment("command-1", "pwd", false),
-      reasoningSegment("reasoning-2", false, 4000),
+      reasoningSegment("reasoning-2", false),
       toolSegment("tool-1", "read_file", { path: "/repo/a.ts" }),
     ]);
 
-    expect(timeline.map((item) => item.kind)).toEqual(["activity_group"]);
-    if (timeline[0]?.kind !== "activity_group") {
-      throw new Error("Expected a single merged activity group");
+    expect(timeline.map((item) => item.kind)).toEqual([
+      "segment",
+      "activity_group",
+      "segment",
+      "activity_group",
+    ]);
+    if (timeline[1]?.kind !== "activity_group") {
+      throw new Error("Expected first activity group");
     }
-    expect(timeline[0].group.summary).toBe(
-      "Thought for 6s, read 1 file, ran 1 command",
-    );
-    expect(timeline[0].group.segments.map((segment) => segment.kind)).toEqual([
-      "reasoning",
-      "command",
-      "reasoning",
+    expect(timeline[1].group.summary).toBe("Ran 1 command");
+    if (timeline[3]?.kind !== "activity_group") {
+      throw new Error("Expected second activity group");
+    }
+    expect(timeline[3].group.summary).toBe("Read 1 file");
+    expect(timeline[3].group.segments.map((segment) => segment.kind)).toEqual([
       "tool",
     ]);
   });
 
-  it("merges consecutive completed reasoning blocks and still breaks on text", () => {
+  it("renders consecutive reasoning blocks as standalone segments", () => {
     const timeline = buildCompleteTimeline([
-      reasoningSegment("reasoning-1", false, 1000),
-      reasoningSegment("reasoning-2", false, 1000),
+      reasoningSegment("reasoning-1", false),
+      reasoningSegment("reasoning-2", false),
       textSegment("text-1", "Done"),
     ]);
 
     expect(timeline.map((item) => item.kind)).toEqual([
-      "activity_group",
+      "segment",
+      "segment",
       "segment",
     ]);
-    if (timeline[0]?.kind !== "activity_group") {
-      throw new Error("Expected a single merged activity group");
-    }
-    expect(timeline[0].group.summary).toBe("Thought for 2s");
-    expect(timeline[0].group.segments.map((segment) => segment.kind)).toEqual([
-      "reasoning",
-      "reasoning",
-    ]);
-    if (timeline[1]?.kind !== "segment") {
-      throw new Error("Expected the trailing text segment");
-    }
-    expect(timeline[1].segment.kind).toBe("text");
-  });
-
-  it("keeps a still-streaming reasoning block standalone, then folds it in once complete", () => {
-    const streamingTimeline = buildCompleteTimeline([
-      commandSegment("command-1", "pwd", false),
-      reasoningSegment("reasoning-1", true, null),
-    ]);
-
-    expect(streamingTimeline.map((item) => item.kind)).toEqual([
-      "activity_group",
-      "segment",
-    ]);
-    if (streamingTimeline[1]?.kind !== "segment") {
-      throw new Error("Expected the streaming reasoning block to stand alone");
-    }
-    expect(streamingTimeline[1].segment.kind).toBe("reasoning");
-
-    const completedTimeline = buildCompleteTimeline([
-      commandSegment("command-1", "pwd", false),
-      reasoningSegment("reasoning-1", false, 3000),
-    ]);
-
-    expect(completedTimeline.map((item) => item.kind)).toEqual([
-      "activity_group",
-    ]);
-    if (completedTimeline[0]?.kind !== "activity_group") {
-      throw new Error("Expected the completed reasoning to fold in");
-    }
-    expect(completedTimeline[0].group.summary).toBe(
-      "Thought for 3s, ran 1 command",
-    );
-  });
-
-  it("renders a lone completed reasoning block as a plain segment, not a group", () => {
-    const timeline = buildCompleteTimeline([
-      reasoningSegment("reasoning-1", false, 3000),
-    ]);
-
-    expect(timeline.map((item) => item.kind)).toEqual(["segment"]);
-    if (timeline[0]?.kind !== "segment") {
-      throw new Error("Expected a plain reasoning segment, not a group");
-    }
-    expect(timeline[0].segment.kind).toBe("reasoning");
+    expect(
+      timeline.map((item) =>
+        item.kind === "segment" ? item.segment.kind : item.kind,
+      ),
+    ).toEqual(["reasoning", "reasoning", "text"]);
   });
 
   it("keeps streaming activity active with a stable summary label", () => {
@@ -943,17 +904,13 @@ function subagentSegment(
   };
 }
 
-function reasoningSegment(
-  id: string,
-  isStreaming: boolean,
-  durationMs: number | null,
-): MessageSegment {
+function reasoningSegment(id: string, isStreaming: boolean): MessageSegment {
   return {
     id,
     kind: "reasoning",
     markdown: "Thinking",
     isStreaming,
-    durationMs,
+    durationMs: null,
   };
 }
 

--- a/clients/gui-app/src/components/chat/chat-activity-groups.ts
+++ b/clients/gui-app/src/components/chat/chat-activity-groups.ts
@@ -7,7 +7,6 @@ import {
   toolUseIdFromInterviewBlockId,
 } from "@traycer/protocol/host/agent/gui/interview-tools";
 import { filePathFromInputDetail } from "@/lib/segment-summary";
-import { formatClockDuration } from "@/lib/format-duration";
 import { formatSingleLine } from "@/lib/utils";
 import type {
   ApprovalSegment,
@@ -15,7 +14,6 @@ import type {
   FileChangeSegment,
   InterviewSegment,
   MessageSegment,
-  ReasoningSegment,
   SubagentSegment,
   ToolSegment,
 } from "@/stores/composer/chat-store";
@@ -31,11 +29,9 @@ export type ActivitySegment =
   | SubagentSegment
   | ApprovalSegment;
 
-// A completed reasoning block folds into the surrounding activity group (its
-// duration accumulates into the "Thought for Xm Ys" summary clause). A
-// still-streaming one is excluded here - it stands on its own with the live
-// "Thinking" UI until it completes, then the next timeline build absorbs it.
-export type ActivityGroupDetailSegment = ActivitySegment | ReasoningSegment;
+// Reasoning is promoted to its own inline segment; activity groups carry only
+// operational activity.
+export type ActivityGroupDetailSegment = ActivitySegment;
 
 export interface ActivityGroupModel {
   readonly id: string;
@@ -77,8 +73,6 @@ export type ChatActivityTimelineItem =
     };
 
 interface ActivitySummaryCounts {
-  // Summed duration of every completed reasoning block folded into the group.
-  thinkingDurationMs: number;
   exploredFiles: number;
   readFiles: number;
   searched: number;
@@ -166,7 +160,6 @@ const RUN_TOOL_NAMES = new Set(["bash", "shell", "run_command", "command"]);
 
 function createEmptyCounts(): ActivitySummaryCounts {
   return {
-    thinkingDurationMs: 0,
     exploredFiles: 0,
     readFiles: 0,
     searched: 0,
@@ -227,17 +220,6 @@ function buildChatActivityTimelineImpl(
 
   const flushRun = (): void => {
     if (run.length === 0) return;
-    // A lone reasoning block has nothing to summarize alongside it - wrapping
-    // it in a group would render its "Thought for Xs" header twice (once as
-    // the group summary, once as the child's own header). Render it as the
-    // plain standalone reasoning segment instead, same as before it could
-    // join a group.
-    if (run.length === 1 && run[0].kind === "reasoning") {
-      const only = run[0];
-      out.push({ kind: "segment", id: only.id, segment: only });
-      run = [];
-      return;
-    }
     const group = activityGroupFromRun(run);
     out.push({ kind: "activity_group", id: group.id, group });
     run = [];
@@ -292,10 +274,9 @@ function buildChatActivityTimelineImpl(
       run.push(segment);
       continue;
     }
-    // Everything else - a still-streaming reasoning block, text, etc. -
-    // stands on its own in chronological position rather than folding into
-    // the activity group. A streaming reasoning block joins the next group
-    // once it completes (isActivitySegment admits completed reasoning).
+    // Everything else - reasoning (now a first-class inline segment), text,
+    // etc. - stands on its own in chronological position rather than folding
+    // into the operational activity group.
     flushRun();
     out.push({ kind: "segment", id: segment.id, segment });
   }
@@ -337,7 +318,6 @@ export function activityGroupSummary(
   const counts = createEmptyCounts();
   segments.forEach((segment) => countActivitySegment(counts, segment));
   const parts = [
-    thinkingPhrase(counts.thinkingDurationMs),
     countPhrase(counts.exploredFiles, "explored", "file", "files"),
     countPhrase(counts.readFiles, "read", "file", "files"),
     countPhrase(counts.searched, "searched", "place", "places"),
@@ -524,7 +504,7 @@ function markTrailingActivityGroupActive(
 
 function isActivitySegment(
   segment: MessageSegment,
-): segment is ActivityGroupDetailSegment {
+): segment is ActivitySegment {
   if (
     segment.kind === "tool" ||
     segment.kind === "command" ||
@@ -533,16 +513,10 @@ function isActivitySegment(
   ) {
     return true;
   }
-  if (segment.kind === "approval") return segment.decision !== null;
-  // A streaming reasoning block stays standalone with its live "Thinking" UI;
-  // only a completed one folds into the group.
-  if (segment.kind === "reasoning") return !segment.isStreaming;
-  return false;
+  return segment.kind === "approval" && segment.decision !== null;
 }
 
-function isStreamingActivitySegment(
-  segment: ActivityGroupDetailSegment,
-): boolean {
+function isStreamingActivitySegment(segment: ActivitySegment): boolean {
   if (segment.kind === "approval") return false;
   return segment.isStreaming;
 }
@@ -582,14 +556,8 @@ function isSuppressedQuestionTool(
 
 function countActivitySegment(
   counts: ActivitySummaryCounts,
-  segment: ActivityGroupDetailSegment,
+  segment: ActivitySegment,
 ): void {
-  if (segment.kind === "reasoning") {
-    if (segment.durationMs !== null) {
-      counts.thinkingDurationMs += segment.durationMs;
-    }
-    return;
-  }
   if (segment.kind === "command") {
     counts.ranCommands += 1;
     return;
@@ -661,12 +629,6 @@ function countPhrase(
 ): string | null {
   if (count === 0) return null;
   return `${verb} ${count} ${count === 1 ? singular : plural}`;
-}
-
-function thinkingPhrase(thinkingDurationMs: number): string | null {
-  if (thinkingDurationMs <= 0) return null;
-  const seconds = Math.max(1, Math.round(thinkingDurationMs / 1000));
-  return `thought for ${formatClockDuration(seconds)}`;
 }
 
 function capitalizeFirst(value: string): string {

--- a/clients/gui-app/src/components/chat/chat-find-projection.ts
+++ b/clients/gui-app/src/components/chat/chat-find-projection.ts
@@ -432,8 +432,6 @@ function activityGroupChildHeaderSearchText(
       return approvalHeaderSearchText(segment);
     case "subagent":
       return [];
-    case "reasoning":
-      return reasoningSegmentSearchText(segment);
     default: {
       const _exhaustive: never = segment;
       void _exhaustive;

--- a/clients/gui-app/src/components/chat/segments/activity-group-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/activity-group-segment.tsx
@@ -29,7 +29,6 @@ import {
 import { ResolvedApprovalSegment } from "./approval-segment";
 import { CommandSegment } from "./command-segment";
 import { FileChangeSegment } from "./file-change-segment";
-import { ReasoningSegment } from "./reasoning-segment";
 import { LiveElapsed } from "./segment-elapsed";
 import { SubagentSegment } from "./subagent-segment";
 import { ToolSegment } from "./tool-segment";
@@ -71,17 +70,10 @@ export function ActivityGroupSegment(props: ActivityGroupSegmentProps) {
         data-chat-find-unit={summaryFindUnitId}
         aria-label={group.label}
         className={cn(
-          "group/activity flex max-w-full items-center gap-2 overflow-hidden rounded-sm px-1 py-1 text-left text-muted-foreground transition-colors",
+          "group/activity flex max-w-full items-center gap-2 overflow-hidden rounded-sm py-1 pr-1 text-left text-muted-foreground transition-colors",
           "hover:text-foreground focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         )}
       >
-        <ChevronRight
-          className={cn(
-            "size-3 shrink-0 text-muted-foreground/50 transition-transform",
-            "group-data-[state=open]/activity:rotate-90",
-          )}
-          aria-hidden
-        />
         <Box className="size-3.5 shrink-0 transition-colors" aria-hidden />
         {group.isActive ? (
           <Shimmer
@@ -108,6 +100,15 @@ export function ActivityGroupSegment(props: ActivityGroupSegmentProps) {
             <LiveElapsed startedAt={group.activeStartedAt} />
           </span>
         ) : null}
+        <ChevronRight
+          className={cn(
+            "size-3.5 shrink-0 -translate-x-1 text-muted-foreground/65 opacity-0 transition-[opacity,transform,color]",
+            "group-hover/activity:translate-x-0 group-hover/activity:text-foreground group-hover/activity:opacity-100",
+            "group-focus-visible/activity:translate-x-0 group-focus-visible/activity:text-foreground group-focus-visible/activity:opacity-100",
+            "group-data-[state=open]/activity:translate-x-0 group-data-[state=open]/activity:rotate-90 group-data-[state=open]/activity:text-foreground group-data-[state=open]/activity:opacity-100",
+          )}
+          aria-hidden
+        />
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="mt-0.5 ml-5 flex flex-col gap-0.5 border-l border-border/35 pl-3">
@@ -198,15 +199,6 @@ function ActivityChildSegment(props: ActivityChildSegmentProps) {
           workflowMeta={segment.workflowMeta}
           nested={segment.children}
           variant="row"
-        />
-      );
-    case "reasoning":
-      return (
-        <ReasoningSegment
-          findUnitId={headerFindUnitId}
-          markdown={segment.markdown}
-          isStreaming={segment.isStreaming}
-          durationMs={segment.durationMs}
         />
       );
     case "approval":

--- a/clients/gui-app/src/components/chat/segments/reasoning-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/reasoning-segment.tsx
@@ -138,17 +138,10 @@ export function ReasoningSegment(props: ReasoningSegmentProps) {
         aria-expanded={expanded}
         aria-controls={bodyShown ? bodyId : undefined}
         className={cn(
-          "group/reasoning flex max-w-full items-center gap-2 overflow-hidden rounded-md px-1 py-1 text-left text-ui-sm text-muted-foreground transition-colors",
+          "group/reasoning flex max-w-full items-center gap-2 overflow-hidden rounded-md py-1 pr-1 text-left text-ui-sm text-muted-foreground transition-colors",
           "hover:text-foreground focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         )}
       >
-        <ChevronRight
-          className={cn(
-            "size-3 shrink-0 text-muted-foreground/50 transition-transform",
-            expanded && "rotate-90",
-          )}
-          aria-hidden
-        />
         <Brain className="size-3.5 shrink-0 transition-colors" aria-hidden />
         {isStreaming ? (
           <Shimmer
@@ -170,6 +163,15 @@ export function ReasoningSegment(props: ReasoningSegmentProps) {
             {label}
           </span>
         )}
+        <ChevronRight
+          className={cn(
+            "size-3.5 shrink-0 -translate-x-1 text-muted-foreground/65 opacity-0 transition-[opacity,transform,color]",
+            "group-hover/reasoning:translate-x-0 group-hover/reasoning:text-foreground group-hover/reasoning:opacity-100",
+            "group-focus-visible/reasoning:translate-x-0 group-focus-visible/reasoning:text-foreground group-focus-visible/reasoning:opacity-100",
+            expanded && "translate-x-0 rotate-90 text-foreground opacity-100",
+          )}
+          aria-hidden
+        />
       </button>
       {body}
     </div>


### PR DESCRIPTION
This reverts commit 1356d8cd4f3b5e9cee01c29314feb448db69c57c.

## Summary

<!-- What does this change, and why? -->

## Related issue

<!-- e.g. Closes #123 -->

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [ ] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [ ] Tests added/updated where it makes sense
- [ ] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
