### PR TITLE
chore(gui-app): remove Release candidate updates toggle from General settings

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
@@ -125,15 +125,6 @@ const runnerHostMock = vi.hoisted((): { current: TestRunnerHost } => ({
   current: { hostManagement: null },
 }));
 
-const appUpdatesMock = vi.hoisted(() => ({
-  current: {
-    bridge: null as {
-      setAllowPrerelease: Mock<(value: boolean) => Promise<unknown>>;
-    } | null,
-    snapshot: { allowPrerelease: false },
-  },
-}));
-
 const hostQueryMocks = vi.hoisted((): HostQueryMocks => ({
   queryResult: {
     data: { bytes: 432 * 1024 * 1024 },
@@ -198,10 +189,6 @@ vi.mock("@/providers/use-runner-host", () => ({
   useRunnerHost: () => runnerHostMock.current,
 }));
 
-vi.mock("@/hooks/runner/use-desktop-app-updates", () => ({
-  useDesktopAppUpdates: () => appUpdatesMock.current,
-}));
-
 vi.mock("@tanstack/react-router", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@tanstack/react-router")>();
@@ -245,10 +232,6 @@ describe("GeneralSettingsPanel", () => {
     navigateMock.mockReset();
     windowsBridgeMock.current = null;
     runnerHostMock.current = { hostManagement: null };
-    appUpdatesMock.current = {
-      bridge: null,
-      snapshot: { allowPrerelease: false },
-    };
     clearAllPersistedStoresMock.mockClear();
     clearAllPersistedStoresMock.mockResolvedValue(undefined);
     useAuthStore.setState({
@@ -292,121 +275,6 @@ describe("GeneralSettingsPanel", () => {
     fireEvent.click(button);
 
     expect(migrationStart.fn).toHaveBeenCalledTimes(1);
-  });
-
-  it("defaults release candidate updates off and saves an explicit opt-in", async () => {
-    const setAllowPrerelease = vi.fn(() => Promise.resolve({}));
-    appUpdatesMock.current = {
-      bridge: { setAllowPrerelease },
-      snapshot: { allowPrerelease: false },
-    };
-    renderPanel();
-
-    const toggle = screen.getByRole("switch", {
-      name: "Allow release candidate updates",
-    });
-    expect(toggle.getAttribute("data-state")).toBe("unchecked");
-    fireEvent.click(toggle);
-
-    await waitFor(() => {
-      expect(setAllowPrerelease).toHaveBeenCalledWith(true);
-    });
-  });
-
-  it("shows progress and disables the release-channel toggle while saving", async () => {
-    const setAllowPrerelease = vi.fn(() => new Promise<unknown>(() => {}));
-    appUpdatesMock.current = {
-      bridge: { setAllowPrerelease },
-      snapshot: { allowPrerelease: false },
-    };
-    renderPanel();
-
-    const toggle = screen.getByRole("switch", {
-      name: "Allow release candidate updates",
-    });
-    fireEvent.click(toggle);
-
-    await waitFor(() => {
-      expect(toggle.hasAttribute("disabled")).toBe(true);
-    });
-    expect(
-      screen.getByTestId("release-channel-pending-indicator"),
-    ).toBeTruthy();
-  });
-
-  // Review finding 5's amendment: a refusal (main rejects the invoke, e.g.
-  // an update is downloading/staged) must surface as a mutation error and
-  // must NOT be tracked as a successful setting change or invalidate any Host
-  // query - only a durable success does that.
-  it("keeps the switch in its old position, toasts an error, and skips analytics/invalidation when the channel change is refused", async () => {
-    const { Analytics } = await import("@/lib/analytics");
-    const trackSpy = vi.spyOn(Analytics.getInstance(), "track");
-    const setAllowPrerelease = vi.fn(() =>
-      Promise.reject(
-        new Error(
-          "Finish or restart into the pending Traycer update before changing the release channel.",
-        ),
-      ),
-    );
-    appUpdatesMock.current = {
-      bridge: { setAllowPrerelease },
-      snapshot: { allowPrerelease: false },
-    };
-    runnerHostMock.current = { hostManagement: {} as never };
-    const queryClient = renderPanel();
-    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
-
-    const toggle = screen.getByRole("switch", {
-      name: "Allow release candidate updates",
-    });
-    fireEvent.click(toggle);
-
-    await waitFor(() => {
-      expect(setAllowPrerelease).toHaveBeenCalledWith(true);
-    });
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalled();
-    });
-
-    // Main never persisted the change, so the pushed snapshot this window
-    // renders from never moved off stable - the switch reads it directly (no
-    // optimistic local state to snap back).
-    expect(toggle.getAttribute("data-state")).toBe("unchecked");
-    expect(trackSpy).not.toHaveBeenCalled();
-    expect(invalidateQueries).not.toHaveBeenCalled();
-  });
-
-  it("tracks the setting and invalidates Host queries on a durable channel change", async () => {
-    const { Analytics } = await import("@/lib/analytics");
-    const trackSpy = vi.spyOn(Analytics.getInstance(), "track");
-    const setAllowPrerelease = vi.fn(() =>
-      Promise.resolve({ allowPrerelease: true }),
-    );
-    appUpdatesMock.current = {
-      bridge: { setAllowPrerelease },
-      snapshot: { allowPrerelease: false },
-    };
-    runnerHostMock.current = { hostManagement: {} as never };
-    const queryClient = renderPanel();
-    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
-
-    fireEvent.click(
-      screen.getByRole("switch", {
-        name: "Allow release candidate updates",
-      }),
-    );
-
-    await waitFor(() => {
-      expect(setAllowPrerelease).toHaveBeenCalledWith(true);
-    });
-    await waitFor(() => {
-      expect(trackSpy).toHaveBeenCalledWith(
-        "setting_changed",
-        expect.objectContaining({ section: "general" }),
-      );
-    });
-    expect(invalidateQueries).toHaveBeenCalled();
-    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("renders the pinned context usage breakdown row and toggles the setting", () => {

--- a/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
@@ -12,14 +12,12 @@ import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-di
 import { Switch } from "@/components/ui/switch";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useRunnerUninstallTraycer } from "@/hooks/runner/use-runner-uninstall-traycer-mutation";
-import { useDesktopAppUpdates } from "@/hooks/runner/use-desktop-app-updates";
 import { requestAppQuit } from "@/lib/desktop-app-lifecycle";
 import { useHostQuery, useHostMutation } from "@/hooks/host/use-host-query";
 import { useHostClient, type HostRpcRegistry } from "@/lib/host";
 import {
   hostQueryKeys,
   runnerMutationKeys,
-  runnerQueryKeys,
   snapshotsMutationKeys,
 } from "@/lib/query-keys";
 import { clearAllPersistedStores } from "@/lib/persist";
@@ -108,7 +106,6 @@ export function GeneralSettingsPanel() {
 
   return (
     <SettingsPanelShell title="General">
-      <PrereleaseUpdatesRow />
       <SettingsRow
         label="Prevent sleep while running"
         description="Keep the computer awake while an agent is running, so work continues when you step away."
@@ -231,68 +228,6 @@ export function GeneralSettingsPanel() {
       />
       <DangerZoneSection />
     </SettingsPanelShell>
-  );
-}
-
-function PrereleaseUpdatesRow() {
-  const runnerHost = useRunnerHost();
-  const management = runnerHost.hostManagement;
-  const queryClient = useQueryClient();
-  const { bridge, snapshot } = useDesktopAppUpdates();
-  const preferenceMutation = useMutation({
-    mutationKey: runnerMutationKeys.setAllowPrereleaseUpdates(),
-    mutationFn: (allowPrerelease: boolean) => {
-      if (bridge === null) {
-        return Promise.reject(new Error("Desktop updates are unavailable"));
-      }
-      return bridge.setAllowPrerelease(allowPrerelease);
-    },
-    // Only a durably-persisted change reaches here - main raises a mutation
-    // error when it refuses the switch (an update already downloading/staged),
-    // so a refusal never tracks analytics or invalidates Host state.
-    //
-    // Main has already force-refreshed the Host registry and broadcast the new
-    // channel's state to *every* window and the native menu/tray before this
-    // resolves; these invalidations only nudge this window's channel-scoped
-    // caches, which is why renderer-local invalidation alone was insufficient.
-    onSuccess: () => {
-      trackGeneralSetting("allowPrereleaseUpdates");
-      if (management === null) return;
-      void queryClient.invalidateQueries({
-        queryKey: runnerQueryKeys.hostAvailableVersionsScope(management),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: runnerQueryKeys.hostRegistryUpdate(management),
-      });
-    },
-    onError: (error) =>
-      toastFromRunnerError(error, "Couldn't update the release channel."),
-  });
-
-  if (bridge === null) return null;
-
-  return (
-    <SettingsRow
-      label="Release candidate updates"
-      description="Allow Traycer Desktop and Host update checks to install RC releases. Stable releases remain eligible."
-      control={
-        <div className="flex items-center gap-2">
-          {preferenceMutation.isPending ? (
-            <AgentSpinningDots
-              className="size-3"
-              testId="release-channel-pending-indicator"
-              variant={undefined}
-            />
-          ) : null}
-          <Switch
-            checked={snapshot.allowPrerelease}
-            disabled={preferenceMutation.isPending}
-            onCheckedChange={(value) => preferenceMutation.mutate(value)}
-            aria-label="Allow release candidate updates"
-          />
-        </div>
-      }
-    />
   );
 }
 


### PR DESCRIPTION
## Summary
- Remove the **Release candidate updates** toggle (`PrereleaseUpdatesRow`) from **Settings → General**. RC access already lives on the **Host** page — its Advanced section exposes RC releases in the version picker — so the dedicated General row is redundant for now.
- The durable auto-update RC opt-in (`bridge.setAllowPrerelease`) will get a better home after the RC release flow has been exercised. The underlying desktop IPC is left untouched; only the General-settings UI control is removed.
- Drop the now-unused `useDesktopAppUpdates` / `runnerQueryKeys` imports, and remove the row's four dedicated tests plus their mock scaffolding from `general-settings-panel.test.tsx`.

## Test plan
- [x] `bun run compile` (gui-app workspace) — 0 errors
- [x] `bun run test` for `general-settings-panel.test.tsx` — 17/17 passing
- [x] `eslint` + `prettier --check` clean on both touched files
- [x] Pre-commit hooks (build/compile/lint/format + DCO sign-off) passed on commit