### PR TITLE
fix(gui-app): float the A2A message copy button over the box corner

### DIFF
--- a/clients/gui-app/src/components/chat/segments/agent-message-body.tsx
+++ b/clients/gui-app/src/components/chat/segments/agent-message-body.tsx
@@ -4,9 +4,10 @@ import { AgentMessageCopyButton } from "./agent-message-copy-button";
 
 /**
  * Scrollable message text plus its copy affordance for an A2A send/received
- * segment body. The copy button is a static sibling in its own gutter column
- * (not overlaid on the scroll container) so it never intercepts the box's
- * native scrollbar.
+ * segment body. The copy button floats over the box's top-right corner
+ * (mirroring the artifact diff viewer's expand control); the box carries
+ * `pr-10` so text clears the button and keeps its own border + native
+ * scrollbar flush against that border.
  */
 export function AgentMessageBody(props: {
   readonly value: string;
@@ -15,10 +16,10 @@ export function AgentMessageBody(props: {
 }): ReactNode {
   const { value, bodyFindUnitId, isStreaming } = props;
   return (
-    <div className="flex min-w-0 items-start gap-1.5">
+    <div className="relative min-w-0">
       <div
         data-chat-find-unit={bodyFindUnitId}
-        className="max-h-[min(40vh,24rem)] min-w-0 flex-1 overflow-auto rounded-md border border-canvas-border/30 bg-canvas/40 px-3 py-2"
+        className="max-h-[min(40vh,24rem)] overflow-auto rounded-md border border-canvas-border/30 bg-canvas/40 px-3 py-2 pr-10"
       >
         <AgentReferenceMarkdown
           isStreaming={isStreaming}

--- a/clients/gui-app/src/components/chat/segments/agent-message-copy-button.tsx
+++ b/clients/gui-app/src/components/chat/segments/agent-message-copy-button.tsx
@@ -16,11 +16,12 @@ const handleCopyError = (): void => {
 };
 
 /**
- * Copy affordance for an A2A send/received message body, styled like
- * `OpenFullDiffControl`'s corner control but rendered as a static sibling in
- * a dedicated, non-scrolling gutter next to the scrollable message box
- * (never overlaid on top of it), so it never intercepts clicks or drags meant
- * for that box's native scrollbar.
+ * Floating copy affordance pinned to the top-right corner of an A2A
+ * send/received message body, mirroring `OpenFullDiffControl`'s always-visible
+ * corner placement over the artifact diff viewer. Absolutely positioned over
+ * the scrollable message box (which carries `pr-10` so text clears it); the
+ * box keeps its own border and native scrollbar, so the scrollbar stays flush
+ * against that border rather than being pushed inward by a reserved gutter.
  */
 export function AgentMessageCopyButton(props: {
   readonly value: string;
@@ -40,7 +41,7 @@ export function AgentMessageCopyButton(props: {
       aria-label={copied ? "Copied" : "Copy message"}
       title={copied ? "Copied" : "Copy message"}
       className={cn(
-        "flex size-7 shrink-0 items-center justify-center",
+        "absolute top-2 right-2 z-10 flex size-7 items-center justify-center",
         "cursor-pointer rounded-md border border-border bg-muted text-muted-foreground shadow-md",
         "transition-colors hover:bg-accent hover:text-foreground",
         "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",


### PR DESCRIPTION
## What

Follow-up to #602. On expanded A2A **Sent/Received message** cards, the copy button was rendered in its own reserved flex-gutter column beside the scrollable message box, so it consumed a full column of width instead of sitting in the box's top-right corner.

This restores the diff-viewer-style **overlay**: the copy button floats absolutely at the box's top-right (mirroring `OpenFullDiffControl`), the scroll box keeps `pr-10` so text clears the button, and the box retains its own border + native scrollbar flush against that border.

## Why

The gutter layout shipped in #602 was introduced to resolve a CodeRabbit comment about the absolute button overlapping the scrollbar's hit area. In practice the reserved-column result reads as an oddly wide control detached from the message, and the intended UX (from the original card redesign) is a corner overlay identical to the artifact diff viewer's expand control. Reverting to the overlay keeps the scrollbar flush against the box border (a constraint from earlier review feedback) while putting the button back in the corner.

## Changes

- `agent-message-copy-button.tsx` — button is `absolute top-2 right-2 z-10` again (was a static gutter sibling).
- `agent-message-body.tsx` — wrapper is `relative` and the scroll box carries `pr-10` again (was a `flex` gutter with the box as `flex-1`).

Both A2A cards (`chat-message-user-body.tsx`, `tool-segment.tsx`) render through the shared `AgentMessageBody`, so both are fixed by this change.

## Validation

- `bun run compile` (gui-app) — clean
- `bun run test src/components/chat` — 92 files / 969 tests pass
- `react-doctor --scope changed --base main` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)