### PR TITLE
fix(ci): cache Nx computations and fix dependency-aware test invalidation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,19 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
+      # Restore the Nx computation cache so a project whose inputs (own files +
+      # dependency source, see `test` inputs in nx.json) are unchanged replays a
+      # cached result in seconds instead of re-running the full suite. Keyed per
+      # matrix project so the legs don't clobber each other; the SHA suffix makes
+      # every run save the freshest cache while restore-keys pull the latest
+      # same-project cache (populated by pushes to main, readable by PRs).
+      - name: Cache Nx computation cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-${{ matrix.project }}-${{ github.sha }}
+          restore-keys: |
+            nx-${{ runner.os }}-${{ matrix.project }}-
       - run: bun install --frozen-lockfile
       - name: Test
         run: bunx nx run-many --target=test --projects="${{ matrix.project }}" --tui=false
@@ -83,6 +96,17 @@ jobs:
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
+      # Same Nx computation cache as the `test` job. The runner.os in the key is
+      # load-bearing here: the desktop suite runs darwin-gated blocks that are
+      # skipped on Linux, so a Linux-computed result must never replay on macOS
+      # (and vice versa) — scoping the cache by OS keeps the two separate.
+      - name: Cache Nx computation cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-@traycer-clients/desktop-${{ github.sha }}
+          restore-keys: |
+            nx-${{ runner.os }}-@traycer-clients/desktop-
       - run: bun install --frozen-lockfile
       - name: Desktop unit tests (darwin-gated blocks included)
         run: bunx nx run-many --target=test --projects="@traycer-clients/desktop" --tui=false

--- a/clients/gui-app/project.json
+++ b/clients/gui-app/project.json
@@ -1,5 +1,6 @@
 {
   "name": "traycer-clients-gui-app",
+  "implicitDependencies": ["@traycer-clients/shared", "@traycer/protocol"],
   "namedInputs": {
     "default": ["{projectRoot}/**/*"]
   },

--- a/clients/gui-app/project.json
+++ b/clients/gui-app/project.json
@@ -5,9 +5,6 @@
     "default": ["{projectRoot}/**/*"]
   },
   "targets": {
-    "test": {
-      "inputs": ["{projectRoot}/**/*", "sharedGlobals"]
-    },
     "build": {
       "inputs": ["{projectRoot}/**/*", "sharedGlobals"]
     },

--- a/nx.json
+++ b/nx.json
@@ -24,14 +24,7 @@
     },
     "test": {
       "cache": true,
-      "inputs": [
-        "{projectRoot}/**/*.ts",
-        "{projectRoot}/**/*.tsx",
-        "{projectRoot}/**/*.js",
-        "{projectRoot}/**/*.jsx",
-        "{projectRoot}/vitest.config.*",
-        "{projectRoot}/jest.config.*"
-      ]
+      "inputs": ["default", "^production", "sharedGlobals"]
     },
     "format": {
       "cache": true,


### PR DESCRIPTION
## Summary
- `test.yml` restores `.nx/cache` for both the matrix `test` job (keyed per project) and `test-macos-packaging` (keyed by `runner.os`, so a Linux-computed result never replays on macOS and vice versa). Previously every PR re-ran every project's full suite with no cache reuse.
- `nx.json`'s `test` target inputs were project-local only, so a change to a project's *dependency* (not the project itself) didn't invalidate its cache. Switched to `["default", "^production", "sharedGlobals"]` so dependency changes correctly invalidate.
- `clients/gui-app/project.json` adds `implicitDependencies` on `@traycer-clients/shared` and `@traycer/protocol`. Found while validating: gui-app imports both only through tsconfig/vite path aliases, never a `package.json` dependency, so Nx's package-based project graph had **zero edges** from gui-app to either — meaning `^production` alone would have resolved to nothing for gui-app, silently missing invalidation on a real dependency change. Verified with `nx show projects --affected`: a `clients/shared` change now correctly includes `gui-app` in the affected set; an unrelated `traycer-cli`-only change correctly still excludes it.

## Test plan
- [x] `nx.json` and `clients/gui-app/project.json` parse as strict JSON; `test.yml` parses as YAML
- [x] `nx show project traycer-clients-gui-app --json` confirms the new `test` inputs resolve
- [x] `nx show projects --affected --with-target test --files=clients/shared/src/index.ts` includes `traycer-clients-gui-app` (previously did not)
- [x] `nx show projects --affected --with-target test --files=clients/traycer-cli/src/index.ts` correctly excludes `traycer-clients-gui-app`
- [x] `pre-commit run --all-files` passes locally (hygiene hooks, shellcheck, DCO sign-off, and the `workspace-checks` build/compile/lint/format hook triggered by the `nx.json` change)
- [ ] First CI run after merge will warm the per-project cache; expect the first few PRs to miss until a `main` push populates it