### PR TITLE
fix(gui-app): restore the plain chat glyph on sidebar chat rows

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -750,7 +750,7 @@ describe("epic sidebar selection mode", () => {
     expect(screen.getByTestId("epic-sidebar-more-chat-root")).not.toBeNull();
   });
 
-  it("subscripts only TUI harness brands", () => {
+  it("brands only TUI agent rows", () => {
     seedChatTree();
     testState.chatHarnessIds = {
       "chat-root": "codex",
@@ -760,11 +760,9 @@ describe("epic sidebar selection mode", () => {
 
     render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
 
-    expect(
-      screen
-        .getByTestId("sidebar-agent-harness-chat-root")
-        .getAttribute("data-agent-surface"),
-    ).toBe("gui");
+    // A persisted chat harness must NOT reach the row: chat rows keep the plain
+    // chat glyph so the panel isn't a column of multi-colored provider marks.
+    expect(screen.queryByTestId("sidebar-agent-harness-chat-root")).toBeNull();
     expect(screen.queryByTestId("sidebar-agent-surface-chat-root")).toBeNull();
     expect(
       screen
@@ -778,7 +776,7 @@ describe("epic sidebar selection mode", () => {
     ).toBe("tui");
   });
 
-  it("does not subscript harness brands in a GUI-only task", () => {
+  it("renders no harness brand in a GUI-only task", () => {
     seedGuiChatTree();
     testState.chatHarnessIds = {
       "chat-root": "codex",
@@ -787,6 +785,8 @@ describe("epic sidebar selection mode", () => {
 
     render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
 
+    expect(screen.queryByTestId("sidebar-agent-harness-chat-root")).toBeNull();
+    expect(screen.queryByTestId("sidebar-agent-harness-chat-child")).toBeNull();
     expect(screen.queryByTestId("sidebar-agent-surface-chat-root")).toBeNull();
     expect(screen.queryByTestId("sidebar-agent-surface-chat-child")).toBeNull();
   });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -99,7 +99,6 @@ import {
   useEpicAgentActivityTiers,
   type AgentActivityTier,
   useEpicArtifactRecords,
-  useEpicChatHarnessId,
   useEpicConnectionStatus,
   useEpicNodeHostId,
   useEpicNodeOwnerKind,
@@ -1749,8 +1748,21 @@ interface ChatSidebarNodeIconProps {
 
 function ChatSidebarNodeIcon(props: ChatSidebarNodeIconProps) {
   if (props.artifactType === "chat") {
+    // No idle-slot override: `ChatProgressIcon` falls back to the plain chat
+    // glyph (per-type icon color included) and stays authoritative for
+    // read-only, activity, approval, failure, and completion states. Chat rows
+    // deliberately do NOT wear the harness brand - a column of multi-colored
+    // provider marks reads as noise; the harness is surfaced in the row's
+    // tooltip, header, and composer instead.
     return (
-      <GuiChatSidebarNodeIcon epicId={props.epicId} nodeId={props.nodeId} />
+      <ChatProgressIcon
+        epicId={props.epicId}
+        chatId={props.nodeId}
+        className={undefined}
+        mutedClassName="text-muted-foreground/70"
+        testId="chat-sidebar-spinner"
+        defaultIcon={undefined}
+      />
     );
   }
   if (props.artifactType === "terminal-agent") {
@@ -1768,36 +1780,6 @@ function ChatSidebarNodeIcon(props: ChatSidebarNodeIconProps) {
       Icon={props.Icon}
       artifactIconColorMode={props.artifactIconColorMode}
       iconStyle={props.iconStyle}
-    />
-  );
-}
-
-/**
- * GUI chat sidebar icon. The persisted harness brand occupies the idle slot;
- * `ChatProgressIcon` remains authoritative for read-only, activity, approval,
- * failure, and completion states.
- */
-function GuiChatSidebarNodeIcon(props: {
-  readonly epicId: string;
-  readonly nodeId: string;
-}) {
-  const harnessId = useEpicChatHarnessId(props.nodeId);
-  return (
-    <ChatProgressIcon
-      epicId={props.epicId}
-      chatId={props.nodeId}
-      className={undefined}
-      mutedClassName="text-muted-foreground/70"
-      testId="chat-sidebar-spinner"
-      defaultIcon={
-        harnessId === null ? undefined : (
-          <SidebarAgentHarnessIcon
-            nodeId={props.nodeId}
-            harnessId={harnessId}
-            surface="gui"
-          />
-        )
-      }
     />
   );
 }
@@ -1824,11 +1806,7 @@ function TerminalAgentProgressIcon(props: {
     // generic bot glyph is the fallback for unresolved/legacy records.
     if (harnessId !== null) {
       return (
-        <SidebarAgentHarnessIcon
-          nodeId={props.nodeId}
-          harnessId={harnessId}
-          surface="tui"
-        />
+        <SidebarAgentHarnessIcon nodeId={props.nodeId} harnessId={harnessId} />
       );
     }
     return (
@@ -1858,35 +1836,31 @@ function TerminalAgentProgressIcon(props: {
 }
 
 /**
- * Harness identity with a terminal-only surface mark. GUI chats use the brand
- * unchanged; TUI agents add a bare terminal glyph without a background so the
- * harness mark stays visible beneath it.
+ * TUI-agent harness identity with a terminal surface mark. The brand mark is a
+ * TUI-only affordance - GUI chat rows keep the plain chat glyph - so the bare
+ * terminal glyph rides along without a background, keeping the harness mark
+ * visible beneath it.
  */
 function SidebarAgentHarnessIcon(props: {
   readonly nodeId: string;
   readonly harnessId: ProviderId;
-  readonly surface: "gui" | "tui";
 }) {
   const TerminalIcon = EPIC_NODE_ICONS.terminal;
-  const surfaceTitle =
-    props.surface === "gui" ? "GUI chat" : "TUI terminal agent";
   return (
     <span
       data-testid={`sidebar-agent-harness-${props.nodeId}`}
-      data-agent-surface={props.surface}
+      data-agent-surface="tui"
       className="relative inline-flex h-3.5 w-[1.125rem] shrink-0 items-center"
-      title={surfaceTitle}
+      title="TUI terminal agent"
     >
       <HarnessIcon harnessId={props.harnessId} className="size-3.5" />
-      {props.surface === "tui" ? (
-        <TerminalIcon
-          aria-hidden="true"
-          data-testid={`sidebar-agent-surface-${props.nodeId}`}
-          data-agent-surface="tui"
-          className="pointer-events-none absolute -right-1 -bottom-1.5 size-2 text-muted-foreground"
-          strokeWidth={3}
-        />
-      ) : null}
+      <TerminalIcon
+        aria-hidden="true"
+        data-testid={`sidebar-agent-surface-${props.nodeId}`}
+        data-agent-surface="tui"
+        className="pointer-events-none absolute -right-1 -bottom-1.5 size-2 text-muted-foreground"
+        strokeWidth={3}
+      />
     </span>
   );
 }


### PR DESCRIPTION
## Summary

#499 put the persisted harness brand in the idle slot of every GUI chat row in the epic sidebar. In a task with a few agents the left panel became a column of multi-colored provider marks — visual overburden. It also silently bypassed the per-type icon-color setting, since brand marks carry their own colors.

Chat rows go back to `EPIC_NODE_ICONS.chat` by dropping the idle-slot override and letting `ChatProgressIcon` use its existing no-override fallback — which restores `artifactIconColorMode` / `artifactIconColors.chat` along with it. Everything above idle is untouched: the read-only lock, running spinner, and approval/failure/completion indicators were already `ChatProgressIcon`'s and stay authoritative.

Terminal-agent rows **keep** their harness brand and terminal subscript. That predates #499 (it landed in #151) and is the only way to tell TUI harnesses apart. With the GUI caller gone, `SidebarAgentHarnessIcon` is TUI-only, so its `surface` prop collapses to a constant and the subscript becomes unconditional.

`useEpicChatHarnessId` stays exported — `agent-reference-chip.tsx` still uses it.

### Tests

The two brand-mark tests still seed `chatHarnessIds`, so they now assert the real invariant: *even with a persisted chat harness, no brand reaches the row*. That's the assertion that fails without this change.

## Related issue

None. Reverts the chat-row half of #499.

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

Validation scope, precisely: full `gui-app` suite — 6,852 passed / 1 skipped across 747 files; `gui-app` compile and Prettier clean; pre-commit's `build · compile · lint · format (nx affected)` and `DCO sign-off` hooks passed on the commit. Repo-wide `bun run build` / `bun run test` beyond the nx-affected set was not run separately — the change is confined to one `gui-app` component and exports nothing new. `bun run react-doctor` hung on its `npx` fetch and is unrun; the diff is a net deletion with no new hooks or render paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)