### PR TITLE
feat(gui-app): search the pane opener n levels deep with path labels

### DIFF
--- a/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
@@ -5,6 +5,7 @@
  * opener root view. Non-component helpers (filter, row value, controller hook)
  * live in `palette-cmdk-controller.ts`.
  */
+import { Fragment } from "react";
 import { CommandEmpty, CommandGroup } from "@/components/ui/command";
 import { PaletteItemRow } from "@/components/command-palette/palette-item-row";
 import { buildCmdkValue } from "@/components/command-palette/palette-cmdk-controller";
@@ -69,6 +70,110 @@ export function SubpageView(props: SubpageViewProps) {
 interface OpenerRootViewProps {
   readonly items: ReadonlyArray<CommandItemShape>;
   readonly onSelect: (item: CommandItemShape) => void;
+}
+
+/**
+ * Deep-row label: the sub-page path dimmed ("Agents → "), then the leaf label
+ * through `SubpageItemLabel` so file-path labels keep their directory dimming.
+ */
+function DeepPathLabel(props: {
+  readonly path: ReadonlyArray<string>;
+  readonly label: string;
+}) {
+  const { path, label } = props;
+  return (
+    <span className="flex min-w-0 items-baseline gap-1">
+      <span className="truncate text-muted-foreground">
+        {path.join(" → ")} →
+      </span>
+      <SubpageItemLabel label={label} />
+    </span>
+  );
+}
+
+/**
+ * Depth bound for the deep view's recursion. The opener's own sub-pages bottom
+ * out at level 3 (category → workspace → file); the cap only exists so a future
+ * self-referential sub-page can't recurse the renderer to a hang.
+ */
+const OPENER_DEEP_MAX_DEPTH = 4;
+
+interface OpenerDeepRowsProps {
+  readonly subpage: CommandSubpage;
+  readonly ctx: CommandContext;
+  readonly path: ReadonlyArray<string>;
+  readonly onSelect: (item: CommandItemShape) => void;
+}
+
+/**
+ * One sub-page's rows for the deep view, recursing into nested sub-pages.
+ * Recursion is per-component (one `useItems` hook call each), so a dynamic
+ * number of nested sub-pages stays rules-of-hooks safe. The path segments are
+ * appended to the row's keywords so combined queries like "agents new" match.
+ */
+function OpenerDeepRows(props: OpenerDeepRowsProps) {
+  const { subpage, ctx, path, onSelect } = props;
+  const items = subpage.useItems(ctx);
+  return (
+    <>
+      {items.map((item) => (
+        <Fragment key={item.id}>
+          <PaletteItemRow
+            value={buildCmdkValue(item)}
+            keywords={[
+              ...item.keywords,
+              ...path.map((segment) => segment.toLowerCase()),
+            ]}
+            onSelect={() => onSelect(item)}
+          >
+            <DeepPathLabel path={path} label={item.label} />
+          </PaletteItemRow>
+          {item.subpage !== null && path.length < OPENER_DEEP_MAX_DEPTH ? (
+            <OpenerDeepRows
+              subpage={item.subpage}
+              ctx={ctx}
+              path={[...path, item.label]}
+              onSelect={onSelect}
+            />
+          ) : null}
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+interface OpenerDeepViewProps {
+  readonly items: ReadonlyArray<CommandItemShape>;
+  readonly ctx: CommandContext;
+  readonly onSelect: (item: CommandItemShape) => void;
+}
+
+/**
+ * Flattened deep matches for the opener root: every sub-page leaf, any number
+ * of levels down, rendered with its full category path so a root query like
+ * "create" surfaces "Agents → New agent (Chat)" without drilling in. Mounted
+ * only while a query is typed (the empty-query root shows categories alone);
+ * cmdk's filter owns which rows actually show.
+ */
+export function OpenerDeepView(props: OpenerDeepViewProps) {
+  const { items, ctx, onSelect } = props;
+  const categories = items.filter(
+    (item): item is CommandItemShape & { readonly subpage: CommandSubpage } =>
+      item.subpage !== null,
+  );
+  return (
+    <CommandGroup>
+      {categories.map((item) => (
+        <OpenerDeepRows
+          key={item.id}
+          subpage={item.subpage}
+          ctx={ctx}
+          path={[item.label]}
+          onSelect={onSelect}
+        />
+      ))}
+    </CommandGroup>
+  );
 }
 
 /**

--- a/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
+++ b/clients/gui-app/src/components/command-palette/palette-cmdk.tsx
@@ -72,9 +72,17 @@ interface OpenerRootViewProps {
   readonly onSelect: (item: CommandItemShape) => void;
 }
 
+/** The full "Agents → New agent (Chat)" trail a deep row represents. */
+function deepRowName(path: ReadonlyArray<string>, label: string): string {
+  return [...path, label].join(" → ");
+}
+
 /**
  * Deep-row label: the sub-page path dimmed ("Agents → "), then the leaf label
  * through `SubpageItemLabel` so file-path labels keep their directory dimming.
+ * The row carries an explicit `aria-label` (see `deepRowName`) because the
+ * separators here are split across elements and styled with a flex `gap` - the
+ * name computed from text content alone would run them together.
  */
 function DeepPathLabel(props: {
   readonly path: ReadonlyArray<string>;
@@ -124,6 +132,7 @@ function OpenerDeepRows(props: OpenerDeepRowsProps) {
               ...item.keywords,
               ...path.map((segment) => segment.toLowerCase()),
             ]}
+            aria-label={deepRowName(path, item.label)}
             onSelect={() => onSelect(item)}
           >
             <DeepPathLabel path={path} label={item.label} />

--- a/clients/gui-app/src/components/epic-canvas/canvas/__tests__/pane-opener.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/__tests__/pane-opener.test.tsx
@@ -23,6 +23,29 @@ const spies = vi.hoisted(() => ({
     >(),
 }));
 
+const DEEPEST_SUBPAGE: CommandSubpage = {
+  id: "open:cat:nested",
+  title: "Nested",
+  useItems: (ctx: CommandContext): ReadonlyArray<CommandItem> => [
+    {
+      id: "open:cat:nested:create",
+      label: "Deep Create Leaf",
+      description: null,
+      keywords: ["create"],
+      group: "open",
+      scope: "actions",
+      shortcut: null,
+      actionId: null,
+      subpage: null,
+      run: () =>
+        spies.openTileIntoTargetGroup({
+          tabId: ctx.activeTabId,
+          groupId: ctx.targetGroupId,
+        }),
+    },
+  ],
+};
+
 const INNER_SUBPAGE: CommandSubpage = {
   id: "open:cat",
   title: "Category",
@@ -37,6 +60,18 @@ const INNER_SUBPAGE: CommandSubpage = {
       shortcut: null,
       actionId: null,
       subpage: null,
+      run: () => undefined,
+    },
+    {
+      id: "open:cat:nested",
+      label: "Nested",
+      description: null,
+      keywords: ["nested"],
+      group: "open",
+      scope: "actions",
+      shortcut: null,
+      actionId: null,
+      subpage: DEEPEST_SUBPAGE,
       run: () => undefined,
     },
   ],
@@ -174,6 +209,57 @@ describe("PaneOpener", () => {
     expect(screen.queryByText("Inner Leaf")).toBeNull();
     expect(screen.getByText("Open Leaf")).not.toBeNull();
     expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+  });
+
+  it("root query surfaces leaves n levels deep with their full path", () => {
+    const { container } = render(
+      <PaneOpener
+        epicId="epic-1"
+        tabId="tab-deep"
+        groupId="group-deep"
+        active={false}
+      />,
+    );
+    // Deep rows are absent while the query is empty.
+    expect(screen.queryByText("Deep Create Leaf")).toBeNull();
+
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-slot="command-input"]',
+    );
+    if (input === null) throw new Error("missing command input");
+    fireEvent.change(input, { target: { value: "create" } });
+
+    // The level-3 leaf matches from the root, labelled with its full path.
+    expect(screen.getByText("Deep Create Leaf")).not.toBeNull();
+    expect(screen.getByText("Category → Nested →")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("Deep Create Leaf"));
+    expect(spies.openTileIntoTargetGroup).toHaveBeenCalledWith({
+      tabId: "tab-deep",
+      groupId: "group-deep",
+    });
+  });
+
+  it("selecting a deep row that bears a sub-page drills into it", () => {
+    const { container } = render(
+      <PaneOpener
+        epicId="epic-1"
+        tabId="tab-drill"
+        groupId="group-drill"
+        active={false}
+      />,
+    );
+    const input = container.querySelector<HTMLInputElement>(
+      'input[data-slot="command-input"]',
+    );
+    if (input === null) throw new Error("missing command input");
+    fireEvent.change(input, { target: { value: "nested" } });
+
+    fireEvent.click(screen.getByText("Nested"));
+
+    // Now inside the "Nested" sub-page: its leaf shows, Back is available.
+    expect(screen.getByText("Deep Create Leaf")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Back" })).not.toBeNull();
   });
 
   it("two empty panes keep independent sub-page state", () => {

--- a/clients/gui-app/src/components/epic-canvas/canvas/__tests__/pane-opener.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/__tests__/pane-opener.test.tsx
@@ -135,6 +135,15 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+/**
+ * The opener's search box. cmdk renders its input as a combobox (same accessor
+ * shape the modal palette's tests use), named by the `aria-label` the opener
+ * sets.
+ */
+function searchInput(): HTMLElement {
+  return screen.getByRole("combobox", { name: "Open into pane" });
+}
+
 describe("PaneOpener", () => {
   it("renders the opener categories inline in the pane", () => {
     render(
@@ -212,7 +221,7 @@ describe("PaneOpener", () => {
   });
 
   it("root query surfaces leaves n levels deep with their full path", () => {
-    const { container } = render(
+    render(
       <PaneOpener
         epicId="epic-1"
         tabId="tab-deep"
@@ -221,19 +230,21 @@ describe("PaneOpener", () => {
       />,
     );
     // Deep rows are absent while the query is empty.
-    expect(screen.queryByText("Deep Create Leaf")).toBeNull();
+    expect(
+      screen.queryByRole("option", { name: /Deep Create Leaf/ }),
+    ).toBeNull();
 
-    const input = container.querySelector<HTMLInputElement>(
-      'input[data-slot="command-input"]',
-    );
-    if (input === null) throw new Error("missing command input");
-    fireEvent.change(input, { target: { value: "create" } });
+    fireEvent.change(searchInput(), { target: { value: "create" } });
 
-    // The level-3 leaf matches from the root, labelled with its full path.
-    expect(screen.getByText("Deep Create Leaf")).not.toBeNull();
-    expect(screen.getByText("Category → Nested →")).not.toBeNull();
+    // The level-3 leaf matches from the root; its accessible name carries the
+    // full path, so the hierarchy is what the user actually reads.
+    expect(
+      screen.getByRole("option", {
+        name: "Category → Nested → Deep Create Leaf",
+      }),
+    ).not.toBeNull();
 
-    fireEvent.click(screen.getByText("Deep Create Leaf"));
+    fireEvent.click(screen.getByRole("option", { name: /Deep Create Leaf/ }));
     expect(spies.openTileIntoTargetGroup).toHaveBeenCalledWith({
       tabId: "tab-deep",
       groupId: "group-deep",
@@ -241,7 +252,7 @@ describe("PaneOpener", () => {
   });
 
   it("selecting a deep row that bears a sub-page drills into it", () => {
-    const { container } = render(
+    render(
       <PaneOpener
         epicId="epic-1"
         tabId="tab-drill"
@@ -249,16 +260,14 @@ describe("PaneOpener", () => {
         active={false}
       />,
     );
-    const input = container.querySelector<HTMLInputElement>(
-      'input[data-slot="command-input"]',
-    );
-    if (input === null) throw new Error("missing command input");
-    fireEvent.change(input, { target: { value: "nested" } });
+    fireEvent.change(searchInput(), { target: { value: "nested" } });
 
-    fireEvent.click(screen.getByText("Nested"));
+    fireEvent.click(screen.getByRole("option", { name: "Category → Nested" }));
 
     // Now inside the "Nested" sub-page: its leaf shows, Back is available.
-    expect(screen.getByText("Deep Create Leaf")).not.toBeNull();
+    expect(
+      screen.getByRole("option", { name: "Deep Create Leaf" }),
+    ).not.toBeNull();
     expect(screen.getByRole("button", { name: "Back" })).not.toBeNull();
   });
 

--- a/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
@@ -110,8 +110,12 @@ export function PaneOpener(props: PaneOpenerProps) {
       data-group-id={groupId}
       className="flex h-full min-h-0 w-full flex-col"
     >
+      {/* `label` is what actually names the search box: cmdk points the input's
+          `aria-labelledby` at its own hidden label element, so without this the
+          input's `aria-label` is overridden by an empty name. */}
       <Command
         filter={paletteFilter}
+        label="Open into pane"
         onKeyDown={handleKeyDown}
         className="h-full min-h-0 bg-transparent"
       >

--- a/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
@@ -24,6 +24,7 @@ import { Command, CommandInput, CommandList } from "@/components/ui/command";
 import { InputGroupButton } from "@/components/ui/input-group";
 import { useCommandPaletteRouter } from "@/components/command-palette/command-palette-context";
 import {
+  OpenerDeepView,
   OpenerRootView,
   SubpageView,
 } from "@/components/command-palette/palette-cmdk";
@@ -145,7 +146,19 @@ export function PaneOpener(props: PaneOpenerProps) {
                 onSelect={runItem}
               />
             ) : (
-              <OpenerRootView items={openerItems} onSelect={runItem} />
+              <>
+                <OpenerRootView items={openerItems} onSelect={runItem} />
+                {/* Deep search: while typing at the root, every sub-page leaf
+                    (n levels down) is also searchable, labelled with its full
+                    path ("Agents → New agent (Chat)"). */}
+                {query.trim() !== "" ? (
+                  <OpenerDeepView
+                    items={openerItems}
+                    ctx={ctx}
+                    onSelect={runItem}
+                  />
+                ) : null}
+              </>
             )}
           </CommandList>
         </PaletteQueryProvider>


### PR DESCRIPTION
## Summary

The blank-tab pane opener only matched its five top-level categories, so reaching **New agent (Chat)** meant knowing to drill into **Agents** first. Typing a query at the opener root now also matches every sub-page leaf, any number of levels down, each row labelled with its full category path — **Agents → New agent (Chat)** — so the hierarchy stays legible.

- Add `OpenerDeepView` / `OpenerDeepRows` in `palette-cmdk.tsx`: a recursive flattening of the opener sub-page tree into searchable rows. Recursion is per-component, so one `useItems` hook call per sub-page keeps a dynamic tree rules-of-hooks safe.
- Dim the path prefix and render the leaf label through the existing `SubpageItemLabel`, so file/diff rows keep their directory dimming.
- Append the path segments to each row's cmdk keywords, so combined queries like `agents new` match as well as the leaf's own terms.
- Selecting a deep row runs its action into the pane; a deep row that itself bears a sub-page drills into that page as before.
- Mount the deep rows only while a query is typed, so the empty-query root keeps its short category list.
- Bound the recursion at depth 4. The opener's own pages bottom out at level 3 (category → workspace → file); the cap only stops a future self-referential sub-page from hanging the renderer.

Scope is the in-pane opener (`pane-opener.tsx`); the modal ⌘K palette is untouched.

## Accepted limitations

- Typing at the root now mounts every category's sub-page, so the Files tree and Diff changed-file queries fire on the first keystroke rather than on drill-in. Both are TanStack Query-cached and already query-filtered to a 100-row cap, so this front-loads work the user was usually about to trigger anyway.
- Truncation hint rows (`Showing first N…`) are part of the flattened set, so a query that matches their text can surface them.

## Related issue

<!-- none -->

## Verification

- `bun run compile` clean.
- `bun run lint` clean at `--max-warnings 0`.
- `bun run test`: 6837 passed, 1 skipped, 746 files.
- Focused palette/opener/commands suites re-run after the depth cap: 192 passed, 26 files.
- Changed-file Prettier check passed.
- React Doctor changed-scope scan found no issues.
- New tests cover a level-3 leaf matching from the root with its path label and dispatching into the pane, and drilling into a deep row that carries its own sub-page.

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
