### PR TITLE
feat(search): add scoped artifact and workspace search

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,10 @@ jobs:
   test:
     name: test (${{ matrix.project }})
     runs-on: ${{ matrix.project == 'traycer-clients-gui-app' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
+    # The GUI suite deliberately runs only two fork workers so large fake-timer
+    # tests remain reliable on CI. Its cold run can exceed the organisation's
+    # ten-minute default once runner setup is included.
+    timeout-minutes: 20
     strategy:
       # Run every project even if one fails, so a single red project doesn't
       # mask the others.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,12 @@ concurrency:
 
 jobs:
   test:
-    name: test (${{ matrix.project }})
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.project == 'traycer-clients-gui-app' && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
-    # The GUI suite deliberately runs only two fork workers so large fake-timer
-    # tests remain reliable on CI. Its cold run can exceed the organisation's
-    # ten-minute default once runner setup is included.
-    timeout-minutes: 20
+    # The GUI suite deliberately runs isolated two-worker forks: disabling
+    # isolation makes tests leak state. The organization caps every job at ten
+    # minutes, so run its deterministic Vitest shards as four parallel matrix
+    # jobs.
     strategy:
       # Run every project even if one fails, so a single red project doesn't
       # mask the others.
@@ -33,12 +33,31 @@ jobs:
         # The nx projects that own a `test` target. Names are exact nx project
         # names (gui-app's differs from its package scope). Keep in sync with
         # `nx show projects --with-target test`.
-        project:
-          - "@traycer/protocol"
-          - traycer-clients-gui-app
-          - "@traycer-clients/desktop"
-          - "@traycer-clients/shared"
-          - "@traycer-clients/traycer-cli"
+        include:
+          - project: "@traycer/protocol"
+            name: "test (@traycer/protocol)"
+            test_args: ""
+          - project: traycer-clients-gui-app
+            name: "test (traycer-clients-gui-app)"
+            test_args: "-- --shard=1/4"
+          - project: traycer-clients-gui-app
+            name: "test (traycer-clients-gui-app shard 2)"
+            test_args: "-- --shard=2/4"
+          - project: traycer-clients-gui-app
+            name: "test (traycer-clients-gui-app shard 3)"
+            test_args: "-- --shard=3/4"
+          - project: traycer-clients-gui-app
+            name: "test (traycer-clients-gui-app shard 4)"
+            test_args: "-- --shard=4/4"
+          - project: "@traycer-clients/desktop"
+            name: "test (@traycer-clients/desktop)"
+            test_args: ""
+          - project: "@traycer-clients/shared"
+            name: "test (@traycer-clients/shared)"
+            test_args: ""
+          - project: "@traycer-clients/traycer-cli"
+            name: "test (@traycer-clients/traycer-cli)"
+            test_args: ""
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -69,7 +88,7 @@ jobs:
             nx-${{ runner.os }}-${{ matrix.project }}-
       - run: bun install --frozen-lockfile
       - name: Test
-        run: bunx nx run-many --target=test --projects="${{ matrix.project }}" --tui=false
+        run: bunx nx run-many --target=test --projects="${{ matrix.project }}" --tui=false ${{ matrix.test_args }}
 
   # macOS job: the desktop workspace's packaging/signing-adjacent assertions
   # (prepack unit suite + the real electron-builder pack in test:packaging)

--- a/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
@@ -5,6 +5,7 @@ import type { HostClient } from "@traycer-clients/shared/host-client/host-client
 
 import { useEpicMentionEntries } from "@/hooks/composer/use-epic-mention-entries";
 import { useWorkspaceEntries } from "@/hooks/composer/use-workspace-entries";
+import { useWorktreeListBindingsForEpicForClient } from "@/hooks/worktree/use-worktree-list-bindings-for-epic-query";
 import { useCloudEpicTasksQuery } from "@/hooks/epics/use-cloud-epic-tasks-query";
 import type { HostRpcRegistry } from "@/lib/host";
 import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
@@ -103,6 +104,27 @@ export function useMentionItems(params: UseMentionItemsParams): void {
   // Radix chrome. Reading live via `getState` at query time keeps the recency
   // sort accurate without subscribing the composer to that churn.
   // `handle === null` is the landing composer (no open epic).
+  // The Epic's attached roots (binding running dirs + workspace paths on this
+  // host) drive which mention roots are eligible for the scoped
+  // `workspace.searchPaths`; anything not in this set (global folders, or every
+  // root when there is no open Epic) keeps the legacy raw-root RPC. Gated on the
+  // picker being open with a current Epic so a closed composer holds no
+  // bindings subscription.
+  const bindingsQuery = useWorktreeListBindingsForEpicForClient({
+    client: hostClient,
+    epicId: currentEpicId ?? "",
+    enabled: active && currentEpicId !== null,
+  });
+  const epicAttachedRoots = useMemo<ReadonlySet<string>>(() => {
+    const rows = bindingsQuery.data?.rows ?? [];
+    if (rows.length === 0) return EMPTY_ATTACHED_ROOTS;
+    const roots = new Set<string>();
+    for (const row of rows) {
+      roots.add(row.runningDir);
+      roots.add(row.workspacePath);
+    }
+    return roots;
+  }, [bindingsQuery.data?.rows]);
   const handle = useMaybeOpenEpicHandle();
   const epicAgentEntries = useMemo<ReadonlyArray<EpicAgentMentionEntry>>(() => {
     if (!active || handle === null || currentEpicId === null) {
@@ -175,8 +197,9 @@ export function useMentionItems(params: UseMentionItemsParams): void {
       epicEntries: EMPTY_EPIC_ENTRIES,
       currentEpicId,
       agentEntries: EMPTY_AGENT_ENTRIES,
+      epicAttachedRoots,
     }),
-    [currentEpicId, mentionRoots, query],
+    [currentEpicId, epicAttachedRoots, mentionRoots, query],
   );
 
   const debouncedRequestContext = useMemo<ComposerMentionProviderContext>(
@@ -188,8 +211,9 @@ export function useMentionItems(params: UseMentionItemsParams): void {
       epicEntries: EMPTY_EPIC_ENTRIES,
       currentEpicId,
       agentEntries: EMPTY_AGENT_ENTRIES,
+      epicAttachedRoots,
     }),
-    [currentEpicId, debouncedQuery, mentionRoots],
+    [currentEpicId, debouncedQuery, epicAttachedRoots, mentionRoots],
   );
 
   const workspaceRequests = useMemo<ReadonlyArray<MentionWorkspaceRequest>>(
@@ -283,10 +307,12 @@ export function useMentionItems(params: UseMentionItemsParams): void {
       epicEntries: epicRequests.length > 0 ? epicEntries : EMPTY_EPIC_ENTRIES,
       currentEpicId,
       agentEntries: epicAgentEntries,
+      epicAttachedRoots,
     }),
     [
       currentEpicId,
       epicAgentEntries,
+      epicAttachedRoots,
       epicEntries,
       epicRequests.length,
       mentionRoots,
@@ -348,6 +374,7 @@ export function useMentionItems(params: UseMentionItemsParams): void {
 }
 
 const EMPTY_AGENT_ENTRIES: ReadonlyArray<EpicAgentMentionEntry> = [];
+const EMPTY_ATTACHED_ROOTS: ReadonlySet<string> = new Set();
 const EMPTY_ARTIFACT_ENTRIES: ReadonlyArray<EpicMentionArtifactSuggestion> = [];
 const EMPTY_TITLE_MAP: ReadonlyMap<string, string> = new Map();
 

--- a/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
+++ b/clients/gui-app/src/components/chat/composer/picker/use-mention-items.ts
@@ -118,12 +118,7 @@ export function useMentionItems(params: UseMentionItemsParams): void {
   const epicAttachedRoots = useMemo<ReadonlySet<string>>(() => {
     const rows = bindingsQuery.data?.rows ?? [];
     if (rows.length === 0) return EMPTY_ATTACHED_ROOTS;
-    const roots = new Set<string>();
-    for (const row of rows) {
-      roots.add(row.runningDir);
-      roots.add(row.workspacePath);
-    }
-    return roots;
+    return new Set(rows.flatMap((row) => [row.runningDir, row.workspacePath]));
   }, [bindingsQuery.data?.rows]);
   const handle = useMaybeOpenEpicHandle();
   const epicAgentEntries = useMemo<ReadonlyArray<EpicAgentMentionEntry>>(() => {

--- a/clients/gui-app/src/components/epic-canvas/canvas/__tests__/search-run-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/__tests__/search-run-view.test.tsx
@@ -1,0 +1,728 @@
+import "../../../../../__tests__/test-browser-apis";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { Command, CommandList } from "@/components/ui/command";
+import { PaletteQueryProvider } from "@/lib/commands/palette-query-context";
+import type { CommandContext } from "@/lib/commands/types";
+import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
+import type { OpenTileIntoTargetGroupArgs } from "@/lib/commands/actions/open-into-target";
+import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
+import type { SearchRunTarget } from "@/lib/commands/sources/open/search-target";
+import type { UseWorkspaceSearchTextArgs } from "@/hooks/workspace/use-workspace-search-text-query";
+
+// Only the fields the component actually reads off a query result. `data` is
+// `unknown` so a test can hand it any response shape (vi.mock factories are
+// untyped, so the real hook's return type never has to be reconstructed).
+interface MockQueryResult {
+  readonly data: unknown;
+  readonly isError: boolean;
+  readonly error: { readonly code: string; readonly message: string } | null;
+}
+
+interface ResolvedArtifactFixture {
+  readonly id: string;
+  readonly kind: string;
+  readonly title: string;
+}
+
+interface MockState {
+  readonly openTileIntoTargetGroup: Mock<
+    (args: OpenTileIntoTargetGroupArgs) => void
+  >;
+  readonly setReveal: Mock<
+    (tabId: string, contentId: string, line: number, col: number | null) => void
+  >;
+  readonly toast: Mock<(message: string) => void>;
+  // Both targets now run through `workspace.searchText`; the mock returns the
+  // code result for a `{ root }` reference and the artifact result for a
+  // `{ kind: "epic-artifacts" }` reference.
+  codeResult: MockQueryResult;
+  artifactResult: MockQueryResult;
+  // The args the component last passed to the (mocked) text-search hook for each
+  // reference kind, so a test can assert options reach the request/query key.
+  lastCodeArgs: UseWorkspaceSearchTextArgs | null;
+  lastArtifactArgs: UseWorkspaceSearchTextArgs | null;
+  // `<root>||<query>` (code) / `<query>` (artifact) recorded for every render
+  // where the hook would issue an RPC (enabled + non-empty query), so a
+  // debounce/coalescing test can assert intermediate keystrokes never fired.
+  readonly codeIssued: string[];
+  readonly artifactIssued: string[];
+  // Logical-artifact-path -> authoritative identity, the live-Yjs resolution a
+  // real artifact open re-runs; an absent path models a stale/deleted result.
+  artifactIndex: Record<string, ResolvedArtifactFixture>;
+  // Records keys that bubbled PAST the cmdk Command to the outer wrapper, so a
+  // test can assert cmdk isolation (Enter/arrows stopped, Escape allowed).
+  readonly outerKeyDown: Mock<(key: string) => void>;
+}
+
+const IDLE: MockQueryResult = { data: undefined, isError: false, error: null };
+
+const state = vi.hoisted<MockState>(() => ({
+  openTileIntoTargetGroup: vi.fn<(args: OpenTileIntoTargetGroupArgs) => void>(),
+  setReveal:
+    vi.fn<
+      (
+        tabId: string,
+        contentId: string,
+        line: number,
+        col: number | null,
+      ) => void
+    >(),
+  toast: vi.fn<(message: string) => void>(),
+  codeResult: { data: undefined, isError: false, error: null },
+  artifactResult: { data: undefined, isError: false, error: null },
+  lastCodeArgs: null,
+  lastArtifactArgs: null,
+  codeIssued: [],
+  artifactIssued: [],
+  artifactIndex: {},
+  outerKeyDown: vi.fn<(key: string) => void>(),
+}));
+
+vi.mock("@/lib/host", () => ({ useHostClient: () => null }));
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "default-host",
+}));
+vi.mock("@/hooks/workspace/use-workspace-search-text-query", () => ({
+  useWorkspaceSearchText: (args: UseWorkspaceSearchTextArgs) => {
+    const ref = args.reference;
+    const isArtifact = ref !== null && "kind" in ref;
+    const nonEmpty = args.enabled && args.query.trim().length > 0;
+    if (isArtifact) {
+      state.lastArtifactArgs = args;
+      if (nonEmpty) state.artifactIssued.push(args.query);
+      return state.artifactResult;
+    }
+    state.lastCodeArgs = args;
+    const root = ref !== null && "root" in ref ? ref.root : "";
+    if (nonEmpty) state.codeIssued.push(`${root}||${args.query}`);
+    return state.codeResult;
+  },
+}));
+vi.mock("@/lib/commands/sources/open/artifact-path-resolver", () => ({
+  useArtifactPathResolver: () => (logicalPath: string) =>
+    state.artifactIndex[logicalPath] ?? null,
+}));
+vi.mock("sonner", () => ({ toast: (message: string) => state.toast(message) }));
+vi.mock("@/lib/commands/actions", () => ({
+  openTileIntoTargetGroup: state.openTileIntoTargetGroup,
+}));
+vi.mock("@/stores/epics/canvas/workspace-file-reveal-store", () => ({
+  setWorkspaceFileRevealTarget: (
+    tabId: string,
+    contentId: string,
+    line: number,
+    col: number | null,
+  ) => state.setReveal(tabId, contentId, line, col),
+}));
+
+import { SearchRunView } from "@/components/epic-canvas/canvas/search-run-view";
+
+const navigateNestedFocusSpy = vi.fn<NavigateNestedFocus>();
+
+function noopRouter(): KeybindingRouter {
+  return {
+    getPathname: () => "/",
+    navigateHome: () => undefined,
+    navigateSettings: () => undefined,
+    navigateToEpic: () => undefined,
+    navigateToEpicTab: () => undefined,
+    navigateToEpicList: () => undefined,
+    navigateSettingsSection: () => undefined,
+    navigateToTabIntent: () => undefined,
+    goBack: () => undefined,
+    goForward: () => undefined,
+    isHistoryNavAvailable: () => false,
+    canGoBack: () => false,
+    canGoForward: () => false,
+    navigateNestedFocus: navigateNestedFocusSpy,
+  };
+}
+
+const CTX: CommandContext = {
+  pathname: "/",
+  router: noopRouter(),
+  activeTabId: "tab-1",
+  activeEpicId: "epic-1",
+  focusedComposerKind: null,
+  targetGroupId: "group-1",
+};
+
+const CODE_TARGET: SearchRunTarget = {
+  kind: "code",
+  hostId: "host-a",
+  root: "/ws",
+};
+
+// The <Command> onKeyDown fires only for keys that actually reach cmdk (i.e.
+// were NOT stopped at a focused control), so a test can assert isolation. cmdk
+// forwards this prop to its root, exactly as the real pane opener passes its own
+// onKeyDown.
+function renderView(target: SearchRunTarget, query: string) {
+  return render(
+    <Command
+      shouldFilter={false}
+      onKeyDown={(event) => state.outerKeyDown(event.key)}
+    >
+      <PaletteQueryProvider value={query}>
+        <CommandList>
+          <SearchRunView target={target} ctx={CTX} />
+        </CommandList>
+      </PaletteQueryProvider>
+    </Command>,
+  );
+}
+
+function codeReady(results: ReadonlyArray<unknown>, truncated: boolean) {
+  return {
+    data: {
+      epicId: "epic-1",
+      root: "/ws",
+      outcome: "ready",
+      truncated,
+      results,
+    },
+    isError: false,
+    error: null,
+  };
+}
+
+beforeEach(() => {
+  state.codeResult = IDLE;
+  state.artifactResult = IDLE;
+  state.lastCodeArgs = null;
+  state.lastArtifactArgs = null;
+  state.codeIssued.length = 0;
+  state.artifactIssued.length = 0;
+  state.artifactIndex = {};
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SearchRunView - code target", () => {
+  it("prompts to type when the query is empty", () => {
+    renderView(CODE_TARGET, "");
+    expect(screen.getByText(/type to search/i)).not.toBeNull();
+  });
+
+  it("renders matches and opens the file revealing the match location", () => {
+    state.codeResult = codeReady(
+      [
+        {
+          relPath: "src/a.ts",
+          lineNumber: 3,
+          column: 5,
+          preview: {
+            text: "const a = 1",
+            ranges: [{ startByte: 0, endByte: 5 }],
+          },
+        },
+      ],
+      false,
+    );
+    renderView(CODE_TARGET, "const");
+
+    const option = screen.getByRole("option");
+    fireEvent.click(option);
+
+    // The reveal is recorded BEFORE the open, with the match's 1-based line/col.
+    expect(state.setReveal).toHaveBeenCalledTimes(1);
+    const reveal = state.setReveal.mock.calls[0];
+    expect(reveal[0]).toBe("tab-1");
+    expect(reveal[2]).toBe(3);
+    expect(reveal[3]).toBe(5);
+
+    const opened = state.openTileIntoTargetGroup.mock.calls.at(0)?.[0];
+    expect(opened?.groupId).toBe("group-1");
+    expect(opened?.ref.type).toBe("workspace-file");
+    expect(opened?.navigateNestedFocus).toBe(navigateNestedFocusSpy);
+  });
+
+  it("shows a distinct message for an invalid regex", () => {
+    state.codeResult = {
+      data: {
+        epicId: "epic-1",
+        root: "/ws",
+        outcome: "invalid_regex",
+        truncated: false,
+        results: [],
+      },
+      isError: false,
+      error: null,
+    };
+    renderView(CODE_TARGET, "a(");
+    expect(screen.getByText(/invalid regular expression/i)).not.toBeNull();
+  });
+
+  it("shows a distinct message when the root is no longer available", () => {
+    state.codeResult = {
+      data: {
+        epicId: "epic-1",
+        root: "/ws",
+        outcome: "root_unavailable",
+        truncated: false,
+        results: [],
+      },
+      isError: false,
+      error: null,
+    };
+    renderView(CODE_TARGET, "foo");
+    expect(screen.getByText(/no longer available/i)).not.toBeNull();
+  });
+
+  it("degrades gracefully when the host does not support text search", () => {
+    state.codeResult = {
+      data: undefined,
+      isError: true,
+      error: { code: "E_HOST_UNSUPPORTED", message: "no" },
+    };
+    renderView(CODE_TARGET, "foo");
+    expect(screen.getByText(/isn.t available on this host/i)).not.toBeNull();
+  });
+
+  it("drops a late payload whose echoed root no longer matches the target", () => {
+    // The response echoes a DIFFERENT root than the current target, so it is a
+    // stale result for a previous selection and must not render.
+    state.codeResult = {
+      data: {
+        epicId: "epic-1",
+        root: "/other-ws",
+        outcome: "ready",
+        truncated: false,
+        results: [
+          {
+            relPath: "stale.ts",
+            lineNumber: 1,
+            column: 1,
+            preview: { text: "stale", ranges: [] },
+          },
+        ],
+      },
+      isError: false,
+      error: null,
+    };
+    renderView(CODE_TARGET, "foo");
+    expect(screen.queryByText("stale.ts")).toBeNull();
+    // Falls back to the in-flight state rather than showing the stale match.
+    expect(screen.getByRole("status")).not.toBeNull();
+  });
+
+  it("exposes accessible, toggleable search options", () => {
+    state.codeResult = codeReady([], false);
+    renderView(CODE_TARGET, "foo");
+    const regex = screen.getByRole("button", {
+      name: /use regular expression/i,
+    });
+    expect(regex.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(regex);
+    expect(regex.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: /match case/i })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: /match whole word/i }),
+    ).not.toBeNull();
+    // The include/exclude glob fields are labeled, focusable text inputs.
+    expect(
+      screen.getByRole("textbox", { name: /files to include/i }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("textbox", { name: /files to exclude/i }),
+    ).not.toBeNull();
+  });
+
+  it("normalizes comma-separated globs into the request and drops empties", () => {
+    state.codeResult = codeReady([], false);
+    renderView(CODE_TARGET, "foo");
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /files to include/i }),
+      { target: { value: "*.ts, src/** ,, " } },
+    );
+    expect(state.lastCodeArgs?.options.includeGlobs).toEqual([
+      "*.ts",
+      "src/**",
+    ]);
+    // Whitespace / stray separators impose no filter.
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /files to exclude/i }),
+      { target: { value: "   ,  " } },
+    );
+    expect(state.lastCodeArgs?.options.excludeGlobs).toEqual([]);
+  });
+
+  it("re-issues the request when an option changes (no stale prior-glob render)", () => {
+    state.codeResult = codeReady([], false);
+    renderView(CODE_TARGET, "foo");
+    // Every option feeds the request and thus the TanStack query key, so a
+    // change mints a new key: a response for the previous glob settings lands
+    // under the old key and can never render for the new one.
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /files to include/i }),
+      { target: { value: "*.ts" } },
+    );
+    expect(state.lastCodeArgs?.options.includeGlobs).toEqual(["*.ts"]);
+    fireEvent.click(
+      screen.getByRole("button", { name: /use regular expression/i }),
+    );
+    expect(state.lastCodeArgs?.options.regex).toBe(true);
+    expect(state.lastCodeArgs?.options.includeGlobs).toEqual(["*.ts"]);
+  });
+
+  it("isolates typing keys from cmdk but lets Escape bubble for back/return", () => {
+    state.codeResult = codeReady(
+      [
+        {
+          relPath: "src/a.ts",
+          lineNumber: 1,
+          column: 1,
+          preview: { text: "hit", ranges: [] },
+        },
+      ],
+      false,
+    );
+    renderView(CODE_TARGET, "foo");
+    const include = screen.getByRole("textbox", { name: /files to include/i });
+
+    // Enter/ArrowDown must NOT reach cmdk (no result opened; nothing bubbles to
+    // the outer wrapper) so the user can type and move the caret freely.
+    fireEvent.keyDown(include, { key: "Enter" });
+    fireEvent.keyDown(include, { key: "ArrowDown" });
+    expect(state.openTileIntoTargetGroup).not.toHaveBeenCalled();
+    expect(state.outerKeyDown).not.toHaveBeenCalledWith("Enter");
+    expect(state.outerKeyDown).not.toHaveBeenCalledWith("ArrowDown");
+
+    // Escape is intentionally allowed through so the opener can back out.
+    fireEvent.keyDown(include, { key: "Escape" });
+    expect(state.outerKeyDown).toHaveBeenCalledWith("Escape");
+  });
+
+  it("resets options when the target sub-page remounts (target switch / back)", () => {
+    state.codeResult = codeReady([], false);
+    const tree = (runKey: string) => (
+      <Command shouldFilter={false}>
+        <PaletteQueryProvider value="foo">
+          <CommandList>
+            <SearchRunView key={runKey} target={CODE_TARGET} ctx={CTX} />
+          </CommandList>
+        </PaletteQueryProvider>
+      </Command>
+    );
+    const { rerender } = render(tree("run-a"));
+    fireEvent.click(
+      screen.getByRole("button", { name: /use regular expression/i }),
+    );
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /files to include/i }),
+      { target: { value: "*.ts" } },
+    );
+    expect(state.lastCodeArgs?.options.regex).toBe(true);
+
+    // A different key remounts the sub-page, exactly as the pane opener does on
+    // a target change or a back-then-re-enter, so option state starts fresh.
+    rerender(tree("run-b"));
+    expect(
+      screen
+        .getByRole("button", { name: /use regular expression/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(
+      screen.getByRole<HTMLInputElement>("textbox", {
+        name: /files to include/i,
+      }).value,
+    ).toBe("");
+  });
+});
+
+describe("SearchRunView - artifact target (workspace.searchText)", () => {
+  const ARTIFACT_TARGET: SearchRunTarget = { kind: "artifact" };
+
+  function artifactMatch(relPath: string) {
+    return {
+      relPath,
+      lineNumber: 2,
+      column: 1,
+      preview: { text: `${relPath} body`, ranges: [] },
+    };
+  }
+
+  function artifactResponse(
+    outcome: string,
+    results: ReadonlyArray<unknown>,
+    truncated: boolean,
+  ) {
+    return {
+      data: {
+        epicId: "epic-1",
+        source: { kind: "epic-artifacts" },
+        outcome,
+        truncated,
+        results,
+      },
+      isError: false,
+      error: null,
+    };
+  }
+
+  it("renders the SAME five controls as the code target", () => {
+    state.artifactResult = artifactResponse("ready", [], false);
+    renderView(ARTIFACT_TARGET, "ticket");
+    expect(screen.getByRole("button", { name: /match case/i })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: /match whole word/i }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: /use regular expression/i }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("textbox", { name: /files to include/i }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("textbox", { name: /files to exclude/i }),
+    ).not.toBeNull();
+  });
+
+  it("searches the typed epic-artifacts source and sends the five options", () => {
+    state.artifactResult = artifactResponse("ready", [], false);
+    renderView(ARTIFACT_TARGET, "ticket");
+    fireEvent.click(
+      screen.getByRole("button", { name: /use regular expression/i }),
+    );
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /files to include/i }),
+      { target: { value: ".md" } },
+    );
+    // The artifact target rides workspace.searchText with the opaque source
+    // selector (never epic.searchArtifacts), and every option reaches the key.
+    expect(state.lastArtifactArgs?.reference).toEqual({
+      kind: "epic-artifacts",
+    });
+    expect(state.lastArtifactArgs?.options.regex).toBe(true);
+    expect(state.lastArtifactArgs?.options.includeGlobs).toEqual(["*.md"]);
+  });
+
+  it("opens a match through authoritative live id + kind, never the mirror", () => {
+    state.artifactIndex = {
+      "tickets/known": { id: "art-1", kind: "ticket", title: "Known" },
+    };
+    state.artifactResult = artifactResponse(
+      "ready",
+      [artifactMatch("tickets/known")],
+      false,
+    );
+    renderView(ARTIFACT_TARGET, "body");
+
+    fireEvent.click(screen.getByRole("option"));
+    const opened = state.openTileIntoTargetGroup.mock.calls.at(0)?.[0];
+    expect(opened?.ref.id).toBe("art-1");
+    expect(opened?.ref.type).toBe("ticket");
+    expect(opened?.ref.name).toBe("Known");
+    expect(opened?.groupId).toBe("group-1");
+    // Authoritative artifact open - NOT a workspace-file reveal of the mirror.
+    expect(state.setReveal).not.toHaveBeenCalled();
+    expect(state.toast).not.toHaveBeenCalled();
+  });
+
+  it("fails safe when re-resolution returns null (stale/deleted OR ambiguous)", () => {
+    // A path with no live identity - a deleted artifact, or an AMBIGUOUS path two
+    // live artifacts share (which the resolver fails closed to `null`) - both
+    // reach the component as a null resolution. The result must never open an
+    // artifact AND never fall through to a workspace-file (mirror) reveal.
+    state.artifactResult = artifactResponse(
+      "ready",
+      [artifactMatch("tickets/gone")],
+      false,
+    );
+    renderView(ARTIFACT_TARGET, "body");
+
+    fireEvent.click(screen.getByRole("option"));
+    expect(state.openTileIntoTargetGroup).not.toHaveBeenCalled();
+    expect(state.setReveal).not.toHaveBeenCalled();
+    expect(state.toast).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a code (root) response for the artifact target (source echo)", () => {
+    // A payload echoing `root` instead of the artifact source is stale here.
+    state.artifactResult = {
+      data: {
+        epicId: "epic-1",
+        root: "/ws",
+        outcome: "ready",
+        truncated: false,
+        results: [artifactMatch("tickets/known")],
+      },
+      isError: false,
+      error: null,
+    };
+    renderView(ARTIFACT_TARGET, "body");
+    expect(screen.queryByRole("option")).toBeNull();
+    // Falls back to the in-flight state rather than rendering the wrong source.
+    expect(screen.getByRole("status")).not.toBeNull();
+  });
+
+  it("renders the artifact root_unavailable state", () => {
+    state.artifactResult = artifactResponse("root_unavailable", [], false);
+    renderView(ARTIFACT_TARGET, "body");
+    expect(screen.getByText(/aren.t available yet/i)).not.toBeNull();
+  });
+
+  it("renders invalid_regex for the artifact target", () => {
+    state.artifactResult = artifactResponse("invalid_regex", [], false);
+    renderView(ARTIFACT_TARGET, "body");
+    expect(screen.getByText(/invalid regular expression/i)).not.toBeNull();
+  });
+
+  it("marks truncation for the artifact target", () => {
+    state.artifactIndex = {
+      "tickets/known": { id: "art-1", kind: "ticket", title: "Known" },
+    };
+    state.artifactResult = artifactResponse(
+      "ready",
+      [artifactMatch("tickets/known")],
+      true,
+    );
+    renderView(ARTIFACT_TARGET, "body");
+    expect(screen.getByText(/showing the first matches/i)).not.toBeNull();
+  });
+
+  it("degrades on an old host that lacks workspace.searchText", () => {
+    state.artifactResult = {
+      data: undefined,
+      isError: true,
+      error: { code: "E_HOST_UNSUPPORTED", message: "nope" },
+    };
+    renderView(ARTIFACT_TARGET, "body");
+    expect(screen.getByText(/isn.t available on this host/i)).not.toBeNull();
+  });
+});
+
+describe("SearchRunView - query debounce", () => {
+  // Comfortably past SEARCH_QUERY_DEBOUNCE_MS (150ms) so the timer settles.
+  const DEBOUNCE_ADVANCE_MS = 200;
+  const CODE_TARGET_B: SearchRunTarget = {
+    kind: "code",
+    hostId: "host-a",
+    root: "/ws-b",
+  };
+
+  // Keyed on the target root so a target switch REMOUNTS, exactly as the pane
+  // opener does (its sub-page id changes), exercising the unmount-clears-timer
+  // path for the scope test.
+  function codeTree(query: string, target: SearchRunTarget) {
+    return (
+      <Command shouldFilter={false}>
+        <PaletteQueryProvider value={query}>
+          <CommandList>
+            <SearchRunView
+              key={target.kind === "code" ? target.root : "artifact"}
+              target={target}
+              ctx={CTX}
+            />
+          </CommandList>
+        </PaletteQueryProvider>
+      </Command>
+    );
+  }
+
+  function artifactTree(query: string) {
+    return (
+      <Command shouldFilter={false}>
+        <PaletteQueryProvider value={query}>
+          <CommandList>
+            <SearchRunView target={{ kind: "artifact" }} ctx={CTX} />
+          </CommandList>
+        </PaletteQueryProvider>
+      </Command>
+    );
+  }
+
+  it("coalesces rapid typing into ONE settled code query", () => {
+    vi.useFakeTimers();
+    try {
+      state.codeResult = codeReady([], false);
+      const { rerender } = render(codeTree("", CODE_TARGET));
+      rerender(codeTree("n", CODE_TARGET));
+      rerender(codeTree("ne", CODE_TARGET));
+      rerender(codeTree("nee", CODE_TARGET));
+      // Nothing settled yet: no intermediate keystroke reached the hook / RPC.
+      expect(state.codeIssued).toEqual([]);
+      act(() => {
+        vi.advanceTimersByTime(DEBOUNCE_ADVANCE_MS);
+      });
+      expect(state.lastCodeArgs?.query).toBe("nee");
+      expect(state.codeIssued).toEqual(["/ws||nee"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("coalesces rapid typing into ONE settled artifact query", () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(artifactTree(""));
+      rerender(artifactTree("t"));
+      rerender(artifactTree("ti"));
+      rerender(artifactTree("tic"));
+      expect(state.artifactIssued).toEqual([]);
+      act(() => {
+        vi.advanceTimersByTime(DEBOUNCE_ADVANCE_MS);
+      });
+      expect(state.lastArtifactArgs?.query).toBe("tic");
+      expect(state.artifactIssued).toEqual(["tic"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears immediately when the query empties (no debounce on clear)", () => {
+    vi.useFakeTimers();
+    try {
+      state.codeResult = codeReady([], false);
+      const { rerender } = render(codeTree("nee", CODE_TARGET));
+      act(() => {
+        vi.advanceTimersByTime(DEBOUNCE_ADVANCE_MS);
+      });
+      expect(state.lastCodeArgs?.query).toBe("nee");
+      // Clearing takes effect WITHOUT advancing timers - back/clear is instant.
+      rerender(codeTree("", CODE_TARGET));
+      expect(state.lastCodeArgs?.query).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a pending debounce cannot fire into a later target/scope", () => {
+    vi.useFakeTimers();
+    try {
+      state.codeResult = codeReady([], false);
+      // Mount empty, then type - so "nee" is a PENDING debounce, not an
+      // immediate mount-time query.
+      const { rerender } = render(codeTree("", CODE_TARGET));
+      rerender(codeTree("nee", CODE_TARGET));
+      // Switch target before the debounce settles; the remount clears the old
+      // timer, so "nee" never issues for the old root.
+      rerender(codeTree("xyz", CODE_TARGET_B));
+      act(() => {
+        vi.advanceTimersByTime(DEBOUNCE_ADVANCE_MS);
+      });
+      expect(state.codeIssued).not.toContain("/ws||nee");
+      expect(state.codeIssued).toContain("/ws-b||xyz");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
@@ -36,6 +36,12 @@ import {
 } from "@/components/command-palette/palette-cmdk-controller";
 import { getOpenerItems } from "@/lib/commands/registry";
 import { PaletteQueryProvider } from "@/lib/commands/palette-query-context";
+import { SearchRunView } from "@/components/epic-canvas/canvas/search-run-view";
+import {
+  isSearchRunSubpageId,
+  parseSearchRunSubpageId,
+} from "@/lib/commands/sources/open/search-target";
+import { isFilesResultSubpageId } from "@/lib/commands/sources/open/files-result-subpage";
 import type { CommandContext } from "@/lib/commands/types";
 
 export interface PaneOpenerProps {
@@ -87,6 +93,60 @@ export function PaneOpener(props: PaneOpenerProps) {
   const openerItems = useMemo(() => getOpenerItems(ctx), [ctx]);
   const { activeSubpage, runItem, popSubpage } = controller;
 
+  // The text-search step-2 sub-page is rendered by a bespoke view (query +
+  // options + results) rather than the generic fuzzy list, and cmdk's own
+  // filtering is disabled for it: content search is literal/regex, so the
+  // pattern must never fuzzy-filter the result rows.
+  const searchRunTarget =
+    activeSubpage !== null && isSearchRunSubpageId(activeSubpage.id)
+      ? parseSearchRunSubpageId(activeSubpage.id)
+      : null;
+
+  // The Files step-2 result lists come pre-ranked from `workspace.searchPaths`
+  // (host Fuse, typo/transposition tolerant). cmdk's own filter must NOT
+  // re-score/re-order them or drop typo matches, and must not hide the typed
+  // notice/truncation rows under a non-matching query. Its filtering stays ON
+  // for the Files step-1 source picker and every other opener page.
+  const hostRankedResultSubpage =
+    activeSubpage !== null && isFilesResultSubpageId(activeSubpage.id);
+
+  const inputPlaceholder = (): string => {
+    if (searchRunTarget !== null) return "Text search…";
+    return activeSubpage !== null ? activeSubpage.title : "Open into pane…";
+  };
+
+  const renderListBody = () => {
+    if (searchRunTarget !== null) {
+      return (
+        <SearchRunView
+          key={activeSubpage?.id}
+          target={searchRunTarget}
+          ctx={ctx}
+        />
+      );
+    }
+    if (activeSubpage !== null) {
+      return (
+        <SubpageView
+          key={activeSubpage.id}
+          subpage={activeSubpage}
+          ctx={ctx}
+          onSelect={runItem}
+        />
+      );
+    }
+    return (
+      <>
+        <OpenerRootView items={openerItems} onSelect={runItem} />
+        {/* Deep search: while typing at the root, every sub-page leaf (n levels
+            down) is also searchable, labelled with its full path. */}
+        {query.trim() !== "" ? (
+          <OpenerDeepView items={openerItems} ctx={ctx} onSelect={runItem} />
+        ) : null}
+      </>
+    );
+  };
+
   // Typing re-filters the list; `handleQueryChange` keeps the auto-selected
   // first match in view by snapping the scroll container back to the top.
   const { listRef, handleQueryChange } = usePaletteScrollReset(setQuery);
@@ -116,6 +176,7 @@ export function PaneOpener(props: PaneOpenerProps) {
       <Command
         filter={paletteFilter}
         label="Open into pane"
+        shouldFilter={searchRunTarget === null && !hostRankedResultSubpage}
         onKeyDown={handleKeyDown}
         className="h-full min-h-0 bg-transparent"
       >
@@ -134,36 +195,13 @@ export function PaneOpener(props: PaneOpenerProps) {
                 </InputGroupButton>
               ) : undefined
             }
-            placeholder={
-              activeSubpage !== null ? activeSubpage.title : "Open into pane…"
-            }
+            placeholder={inputPlaceholder()}
             aria-label="Open into pane"
           />
           {/* `max-h-none` overrides the primitive's `max-h-72` cap so the list
               fills the full pane height instead of clipping mid-way. */}
           <CommandList ref={listRef} className="max-h-none min-h-0 flex-1">
-            {activeSubpage !== null ? (
-              <SubpageView
-                key={activeSubpage.id}
-                subpage={activeSubpage}
-                ctx={ctx}
-                onSelect={runItem}
-              />
-            ) : (
-              <>
-                <OpenerRootView items={openerItems} onSelect={runItem} />
-                {/* Deep search: while typing at the root, every sub-page leaf
-                    (n levels down) is also searchable, labelled with its full
-                    path ("Agents → New agent (Chat)"). */}
-                {query.trim() !== "" ? (
-                  <OpenerDeepView
-                    items={openerItems}
-                    ctx={ctx}
-                    onSelect={runItem}
-                  />
-                ) : null}
-              </>
-            )}
+            {renderListBody()}
           </CommandList>
         </PaletteQueryProvider>
       </Command>

--- a/clients/gui-app/src/components/epic-canvas/canvas/search-run-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/search-run-view.tsx
@@ -1,0 +1,550 @@
+/**
+ * STEP 2 of the opener's two-step content search: the query + options + results
+ * surface. The pane opener renders this (instead of the generic fuzzy list) for
+ * a `open:search:run:*` sub-page, with cmdk's own filtering DISABLED - content
+ * search is literal/regex, never a fuzzy filter over the pattern.
+ *
+ * Both targets run through ONE `workspace.searchText` flow (one options bar, one
+ * debounced query, one set of guards), differing only in source + open:
+ *  - Code (`reference: { root }`): ripgrep over one authorized workspace root; a
+ *    match opens the file preview and reveals the matched line/column.
+ *  - Artifact (`reference: { kind: "epic-artifacts" }`): ripgrep over the Epic's
+ *    on-disk artifact mirror. A match carries a LOGICAL artifact path; opening
+ *    re-resolves it against authoritative live Yjs state (by id + kind) and fails
+ *    safe on a stale/deleted hit - it never opens the editable mirror Markdown.
+ *
+ * Late results are guarded twice: the TanStack key scopes by
+ * epic/host/source/query/options, and the response echoes `epicId` plus its
+ * source (`root` for code, `source` for artifacts), re-checked here so a payload
+ * that crosses a target/source change is dropped.
+ */
+import { useMemo, useState, type KeyboardEvent, type ReactNode } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { toast } from "sonner";
+import { CommandGroup } from "@/components/ui/command";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { PaletteItemRow } from "@/components/command-palette/palette-item-row";
+import { usePaletteLiveQuery } from "@/lib/commands/palette-query-context";
+import { useHostClient } from "@/lib/host";
+import type { HostRpcRegistry } from "@/lib/host";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useWorkspaceSearchText } from "@/hooks/workspace/use-workspace-search-text-query";
+import {
+  highlightSegmentsFromByteRanges,
+  type SnippetByteRange,
+} from "@/lib/artifacts/highlight-byte-ranges";
+import { openTileIntoTargetGroup } from "@/lib/commands/actions";
+import { parseGlobs } from "@/lib/commands/sources/open/parse-globs";
+import { useArtifactPathResolver } from "@/lib/commands/sources/open/artifact-path-resolver";
+import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
+import { workspaceFileRefFromTreePath } from "@/components/epic-canvas/workspace-file/workspace-file-ref";
+import { setWorkspaceFileRevealTarget } from "@/stores/epics/canvas/workspace-file-reveal-store";
+import { getBasename } from "@/lib/path/cross-platform-path";
+import { isOpenableEpicNodeKind } from "@/stores/epics/canvas/types";
+import { cn } from "@/lib/utils";
+import type {
+  HostRpcError,
+  ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type {
+  WorkspaceSearchSource,
+  WorkspaceSearchTextMatch,
+  WorkspaceSearchTextOptions,
+} from "@traycer/protocol/host/workspace/unary-schemas";
+import type { CommandContext } from "@/lib/commands/types";
+import type { SearchRunTarget } from "@/lib/commands/sources/open/search-target";
+
+export interface SearchRunViewProps {
+  readonly target: SearchRunTarget;
+  readonly ctx: CommandContext;
+}
+
+export function SearchRunView({ target, ctx }: SearchRunViewProps) {
+  return <SearchRun target={target} ctx={ctx} />;
+}
+
+/**
+ * Coalesce rapid typing before it feeds a search hook: each keystroke restarts a
+ * short timer and only the settled value reaches the query key / RPC, so a fast
+ * typist spawns ONE ripgrep run per pause instead of one per keystroke. Clearing
+ * (an empty/whitespace query) short-circuits the timer and takes effect
+ * immediately, so back/clear stays instant. Only the query is debounced -
+ * options, target, Epic, and host stay in the key/guards and change at once.
+ */
+const SEARCH_QUERY_DEBOUNCE_MS = 150;
+
+function useDebouncedSearchQuery(query: string): string {
+  const debounced = useDebouncedValue(query, SEARCH_QUERY_DEBOUNCE_MS);
+  return query.trim().length === 0 ? "" : debounced;
+}
+
+// ─── shared presentation ─────────────────────────────────────────────────────
+
+function StatusRow({ children }: { children: ReactNode }) {
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 px-3 py-6 text-center text-ui-sm text-muted-foreground"
+    >
+      {children}
+    </div>
+  );
+}
+
+function Searching() {
+  return (
+    <StatusRow>
+      <AgentSpinningDots
+        className={undefined}
+        testId={undefined}
+        variant={undefined}
+      />
+      <span>Searching…</span>
+    </StatusRow>
+  );
+}
+
+/** True when the optional method is unsupported by an older host (degrade path). */
+function isHostUnsupported(error: HostRpcError | null): boolean {
+  return (
+    error !== null &&
+    (error.code === "E_HOST_UNSUPPORTED" ||
+      error.code === "DOWNGRADE_UNSUPPORTED")
+  );
+}
+
+function HighlightedText({
+  text,
+  ranges,
+}: {
+  readonly text: string;
+  readonly ranges: ReadonlyArray<SnippetByteRange>;
+}) {
+  // Segments partition the line left-to-right; each carries its own char-index
+  // `start` (a distinct offset per segment), so `start` is a stable, unique key
+  // without re-deriving it - alternating highlighted/plain segments never collide.
+  const keyed = useMemo(() => {
+    const segments = highlightSegmentsFromByteRanges(text, ranges);
+    return segments.map((segment) => ({
+      ...segment,
+      key: `${segment.start}:${segment.highlighted ? 1 : 0}`,
+    }));
+  }, [text, ranges]);
+  return (
+    <>
+      {keyed.map((segment) => (
+        <span
+          key={segment.key}
+          className={cn(
+            segment.highlighted &&
+              "rounded-[2px] bg-primary/20 text-foreground",
+          )}
+        >
+          {segment.text}
+        </span>
+      ))}
+    </>
+  );
+}
+
+function TruncatedHint() {
+  return (
+    <div className="px-3 py-1.5 text-ui-xs text-muted-foreground">
+      Showing the first matches — refine the query to narrow results.
+    </div>
+  );
+}
+
+// ─── unified text search (workspace.searchText: code + artifact) ─────────────
+
+function SearchRun({
+  target,
+  ctx,
+}: {
+  readonly target: SearchRunTarget;
+  readonly ctx: CommandContext;
+}) {
+  const client = useHostClient();
+  const defaultHostId = useReactiveActiveHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
+  const resolveArtifact = useArtifactPathResolver(ctx.activeEpicId);
+  const query = usePaletteLiveQuery();
+  const trimmed = query.trim();
+  const debouncedQuery = useDebouncedSearchQuery(query);
+  // Source-of-truth option state. Globs are edited as raw text and normalized
+  // into arrays for the request; this state is reset by remount (the pane opener
+  // keys `SearchRunView` on the target sub-page id, so switching target or
+  // backing out and re-entering starts fresh).
+  const [regex, setRegex] = useState(false);
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [wholeWord, setWholeWord] = useState(false);
+  const [includeText, setIncludeText] = useState("");
+  const [excludeText, setExcludeText] = useState("");
+  const options = useMemo<WorkspaceSearchTextOptions>(
+    () => ({
+      regex,
+      caseSensitive,
+      wholeWord,
+      includeGlobs: parseGlobs(includeText),
+      excludeGlobs: parseGlobs(excludeText),
+    }),
+    [regex, caseSensitive, wholeWord, includeText, excludeText],
+  );
+
+  // The typed source: an attached code root, or the opaque Epic-artifact mirror.
+  // Memoized so its identity is stable across keystrokes (only a target change,
+  // which remounts, mints a new one).
+  const reference = useMemo<WorkspaceSearchSource>(
+    () =>
+      target.kind === "artifact"
+        ? { kind: "epic-artifacts" }
+        : { root: target.root },
+    [target],
+  );
+
+  const epicId = ctx.activeEpicId ?? "";
+  const result = useWorkspaceSearchText({
+    client,
+    epicId,
+    reference,
+    query: debouncedQuery,
+    options,
+    enabled: ctx.activeEpicId !== null,
+  });
+
+  // Late-result guard: only render a payload whose epic AND source echo still
+  // match this target, so a response cannot cross a query/option/source/epic/host
+  // change (the TanStack key already scopes those; this is the belt-and-braces).
+  const data = matchingData(result.data, epicId, target);
+
+  const openCodeMatch = (
+    relPath: string,
+    line: number,
+    column: number,
+  ): void => {
+    if (ctx.activeTabId === null || target.kind !== "code") return;
+    const ref = workspaceFileRefFromTreePath(
+      target.hostId,
+      target.root,
+      relPath,
+      getBasename(relPath),
+    );
+    if (ref === null) return;
+    // Record the reveal BEFORE opening so the (possibly new) preview tile reads
+    // it on mount and scrolls to the match.
+    setWorkspaceFileRevealTarget(ctx.activeTabId, ref.id, line, column);
+    openTileIntoTargetGroup({
+      tabId: ctx.activeTabId,
+      groupId: ctx.targetGroupId,
+      ref,
+      navigateNestedFocus: ctx.router.navigateNestedFocus,
+    });
+  };
+
+  const openArtifactMatch = (logicalPath: string): void => {
+    if (ctx.activeTabId === null) return;
+    // Re-resolve the LOGICAL disk path against authoritative live Yjs state. A
+    // stale/deleted hit (no live artifact at that path, or a non-openable kind)
+    // fails safe: never open the mirror Markdown as a workspace file.
+    const resolved = resolveArtifact(logicalPath);
+    if (resolved === null || !isOpenableEpicNodeKind(resolved.kind)) {
+      toast("Couldn’t open artifact — it may have moved or been deleted.");
+      return;
+    }
+    openTileIntoTargetGroup({
+      tabId: ctx.activeTabId,
+      groupId: ctx.targetGroupId,
+      ref: {
+        id: resolved.id,
+        instanceId: uuidv4(),
+        type: resolved.kind,
+        name:
+          resolved.title.length > 0
+            ? resolved.title
+            : `Untitled ${resolved.kind}`,
+        hostId: defaultHostId,
+      },
+      navigateNestedFocus: ctx.router.navigateNestedFocus,
+    });
+  };
+
+  const sourceLabel =
+    target.kind === "artifact" ? "Artifacts" : getBasename(target.root);
+
+  const renderBody = () => {
+    if (trimmed.length === 0) {
+      return <StatusRow>Type to search {sourceLabel}.</StatusRow>;
+    }
+    if (result.isError) {
+      return (
+        <StatusRow>
+          {isHostUnsupported(result.error)
+            ? "Text search isn’t available on this host."
+            : "Search failed."}
+        </StatusRow>
+      );
+    }
+    if (data === undefined) return <Searching />;
+    if (data.outcome === "root_unavailable") {
+      return (
+        <StatusRow>
+          {target.kind === "artifact"
+            ? "Artifacts aren’t available yet."
+            : "This workspace is no longer available."}
+        </StatusRow>
+      );
+    }
+    if (data.outcome === "invalid_regex") {
+      return <StatusRow>Invalid regular expression.</StatusRow>;
+    }
+    if (data.results.length === 0) return <StatusRow>No matches.</StatusRow>;
+    return (
+      <>
+        <CommandGroup heading={sourceLabel}>
+          {data.results.map((match) => (
+            <SearchResultRow
+              key={`${match.relPath}:${match.lineNumber}:${match.column}`}
+              target={target}
+              match={match}
+              artifactTitle={
+                target.kind === "artifact"
+                  ? (resolveArtifact(match.relPath)?.title ?? null)
+                  : null
+              }
+              onOpen={() =>
+                target.kind === "artifact"
+                  ? openArtifactMatch(match.relPath)
+                  : openCodeMatch(match.relPath, match.lineNumber, match.column)
+              }
+            />
+          ))}
+        </CommandGroup>
+        {data.truncated ? <TruncatedHint /> : null}
+      </>
+    );
+  };
+
+  return (
+    <>
+      <SearchOptionsBar
+        regex={regex}
+        caseSensitive={caseSensitive}
+        wholeWord={wholeWord}
+        includeText={includeText}
+        excludeText={excludeText}
+        artifactSource={target.kind === "artifact"}
+        onRegex={setRegex}
+        onCaseSensitive={setCaseSensitive}
+        onWholeWord={setWholeWord}
+        onIncludeText={setIncludeText}
+        onExcludeText={setExcludeText}
+      />
+      {renderBody()}
+    </>
+  );
+}
+
+/**
+ * The response is a union: a code (`root`) branch and an artifact (`source`)
+ * branch. Keep only a payload whose epic AND source echo match THIS target, so a
+ * late response from a previous target/source is dropped rather than rendered.
+ */
+function matchingData(
+  data: ResponseOfMethod<HostRpcRegistry, "workspace.searchText"> | undefined,
+  epicId: string,
+  target: SearchRunTarget,
+): ResponseOfMethod<HostRpcRegistry, "workspace.searchText"> | undefined {
+  if (data === undefined || data.epicId !== epicId) return undefined;
+  // `"source" in data` selects the artifact response branch; `"root" in data`
+  // the attached-root branch. The wrong branch for this target is a stale echo.
+  if (target.kind === "artifact") {
+    return "source" in data ? data : undefined;
+  }
+  return "root" in data && data.root === target.root ? data : undefined;
+}
+
+interface SearchResultRowProps {
+  readonly target: SearchRunTarget;
+  readonly match: WorkspaceSearchTextMatch;
+  /** Live artifact title for an artifact match, or `null` (code / unresolved). */
+  readonly artifactTitle: string | null;
+  readonly onOpen: () => void;
+}
+
+function SearchResultRow({
+  target,
+  match,
+  artifactTitle,
+  onOpen,
+}: SearchResultRowProps) {
+  const slash = match.relPath.lastIndexOf("/");
+  const dir = slash === -1 ? "" : match.relPath.slice(0, slash + 1);
+  const base = slash === -1 ? match.relPath : match.relPath.slice(slash + 1);
+  return (
+    <PaletteItemRow
+      value={`${target.kind}:${match.relPath}:${match.lineNumber}:${match.column}`}
+      keywords={[]}
+      onSelect={onOpen}
+    >
+      <div className="flex min-w-0 flex-col gap-0.5">
+        {target.kind === "artifact" ? (
+          // Logical artifact path (its folder chain); the resolved title, when
+          // the artifact is still live, leads for readability.
+          <span className="truncate text-ui-xs">
+            <span className="text-foreground">
+              {artifactTitle ?? match.relPath}
+            </span>
+            {artifactTitle !== null ? (
+              <span className="ml-2 text-muted-foreground">
+                {match.relPath}
+              </span>
+            ) : null}
+          </span>
+        ) : (
+          <span className="truncate text-ui-xs">
+            <span className="text-muted-foreground">{dir}</span>
+            <span className="text-foreground">{base}</span>
+            <span className="text-muted-foreground">:{match.lineNumber}</span>
+          </span>
+        )}
+        <span className="truncate font-mono text-ui-xs text-muted-foreground">
+          <HighlightedText
+            text={match.preview.text}
+            ranges={match.preview.ranges}
+          />
+        </span>
+      </div>
+    </PaletteItemRow>
+  );
+}
+
+// ─── options bar (shared by code + artifact) ─────────────────────────────────
+
+interface SearchOptionsBarProps {
+  readonly regex: boolean;
+  readonly caseSensitive: boolean;
+  readonly wholeWord: boolean;
+  readonly includeText: string;
+  readonly excludeText: string;
+  readonly artifactSource: boolean;
+  readonly onRegex: (next: boolean) => void;
+  readonly onCaseSensitive: (next: boolean) => void;
+  readonly onWholeWord: (next: boolean) => void;
+  readonly onIncludeText: (next: string) => void;
+  readonly onExcludeText: (next: string) => void;
+}
+
+function SearchOptionsBar(props: SearchOptionsBarProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Search options"
+      className="flex flex-wrap items-center gap-1.5 border-b border-border px-2 py-1.5"
+    >
+      <OptionToggle
+        label="Match case"
+        active={props.caseSensitive}
+        onToggle={() => props.onCaseSensitive(!props.caseSensitive)}
+      >
+        Aa
+      </OptionToggle>
+      <OptionToggle
+        label="Match whole word"
+        active={props.wholeWord}
+        onToggle={() => props.onWholeWord(!props.wholeWord)}
+      >
+        W
+      </OptionToggle>
+      <OptionToggle
+        label="Use regular expression"
+        active={props.regex}
+        onToggle={() => props.onRegex(!props.regex)}
+      >
+        .*
+      </OptionToggle>
+      <GlobInput
+        label="Files to include"
+        placeholder={
+          props.artifactSource
+            ? "include, e.g. .md, tickets/**"
+            : "include, e.g. .ts, src/**"
+        }
+        value={props.includeText}
+        onChange={props.onIncludeText}
+      />
+      <GlobInput
+        label="Files to exclude"
+        placeholder={
+          props.artifactSource
+            ? "exclude, e.g. drafts/**"
+            : "exclude, e.g. *.test.*, dist/**"
+        }
+        value={props.excludeText}
+        onChange={props.onExcludeText}
+      />
+    </div>
+  );
+}
+
+// Stop a key from reaching cmdk's root handler so it acts on the focused control
+// (typing, caret movement, activation) instead of moving/opening the result
+// list - EXCEPT Escape, which is allowed to bubble so the pane opener's
+// intentional back/return behavior still fires.
+function isolateFromCmdk(event: KeyboardEvent<HTMLElement>): void {
+  if (event.key !== "Escape") event.stopPropagation();
+}
+
+interface OptionToggleProps {
+  readonly label: string;
+  readonly active: boolean;
+  readonly onToggle: () => void;
+  readonly children: ReactNode;
+}
+
+function OptionToggle({
+  label,
+  active,
+  onToggle,
+  children,
+}: OptionToggleProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      aria-label={label}
+      title={label}
+      onClick={onToggle}
+      onKeyDown={isolateFromCmdk}
+      className={cn(
+        "flex h-6 min-w-6 items-center justify-center rounded-sm px-1.5 font-mono text-ui-xs transition-colors",
+        active
+          ? "bg-primary/15 text-foreground ring-1 ring-primary/40"
+          : "text-muted-foreground hover:bg-muted/55 hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+interface GlobInputProps {
+  readonly label: string;
+  readonly placeholder: string;
+  readonly value: string;
+  readonly onChange: (next: string) => void;
+}
+
+function GlobInput({ label, placeholder, value, onChange }: GlobInputProps) {
+  return (
+    <input
+      type="text"
+      aria-label={label}
+      title={`${label} (comma-separated globs)`}
+      placeholder={placeholder}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      onKeyDown={isolateFromCmdk}
+      className="h-6 min-w-[7rem] flex-1 rounded-sm bg-muted/40 px-1.5 text-ui-xs outline-hidden placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-primary/40"
+    />
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-artifact-search.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-artifact-search.test.tsx
@@ -1,0 +1,816 @@
+import "../../../../../__tests__/test-browser-apis";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import type {
+  SearchArtifactHit,
+  SearchArtifactsResponse,
+} from "@traycer/protocol/host/epic/unary-schemas";
+import type { UseEpicSearchArtifactsArgs } from "@/hooks/epic/use-epic-search-artifacts-query";
+
+interface QueryResultStub {
+  readonly isSuccess: boolean;
+  readonly isError: boolean;
+  readonly isFetching: boolean;
+  readonly data: SearchArtifactsResponse | undefined;
+  readonly error: { readonly code: string } | null;
+  readonly refetch: Mock;
+}
+
+interface EpicNodeRefStub {
+  readonly id: string;
+  readonly type: string;
+}
+
+interface ArtifactFilterStub {
+  statuses: ReadonlyArray<number>;
+  kinds: ReadonlyArray<string>;
+  read: "all" | "read" | "unread";
+}
+
+interface Harness {
+  result: QueryResultStub | null;
+  lastArgs: UseEpicSearchArtifactsArgs | null;
+  hostId: string | null;
+  artifactFilter: ArtifactFilterStub;
+  epicNodeRef: EpicNodeRefStub | null;
+  openMock: Mock;
+  isUnreadMock: Mock<(args: { artifactId: string }) => boolean>;
+  artifactsById: Record<string, { updatedAt: number }>;
+  /** Drives the >= ARTIFACT_SEARCH_MIN_COUNT gate on the search affordance. */
+  artifactIds: ReadonlyArray<string>;
+}
+
+const harness = vi.hoisted<Harness>(() => ({
+  result: null,
+  lastArgs: null,
+  hostId: "host-1",
+  artifactFilter: { statuses: [], kinds: [], read: "all" },
+  epicNodeRef: null,
+  openMock: vi.fn(),
+  isUnreadMock: vi.fn((_args: { artifactId: string }) => false),
+  artifactsById: {},
+  artifactIds: [],
+}));
+
+vi.mock("@/hooks/epic/use-epic-search-artifacts-query", () => ({
+  useEpicSearchArtifacts: (args: UseEpicSearchArtifactsArgs) => {
+    harness.lastArgs = args;
+    return harness.result;
+  },
+}));
+vi.mock("@/lib/host", () => ({ useHostClient: () => ({}) }));
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => harness.hostId,
+}));
+vi.mock("@/providers/use-open-epic-handle", () => ({
+  useOpenEpicHandle: () => ({ store: { getState: () => ({}) } }),
+}));
+vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
+  useEpicTileNavigation: () => ({
+    openTilePreviewInTab: harness.openMock,
+    openTileInTab: vi.fn(),
+    openTileInEpic: vi.fn(),
+    openTilePreviewInEpic: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/epic-selectors", () => ({
+  epicNodeRefForNodeId: () => harness.epicNodeRef,
+}));
+vi.mock("@/hooks/use-epic-store", () => ({
+  useEpicStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      artifacts: {
+        byId: harness.artifactsById,
+        allIds: harness.artifactIds,
+      },
+    }),
+}));
+vi.mock("@/stores/epics/left-panel-store", () => ({
+  ARTIFACT_READ: { All: "all", Read: "read", Unread: "unread" },
+  useArtifactFilter: () => harness.artifactFilter,
+}));
+vi.mock("@/stores/epics/artifact-read-state-store", () => {
+  // Stable state object so the component's `useShallow` selector returns a
+  // stable reference across renders (a fresh object each call would churn the
+  // results memo and loop the render-time reset).
+  const READ_STATE = { seedAtByEpic: {}, lastSeenByArtifact: {} };
+  return {
+    isArtifactUnread: (args: { artifactId: string }) =>
+      harness.isUnreadMock(args),
+    useArtifactReadStateStore: (selector: (s: unknown) => unknown) =>
+      selector(READ_STATE),
+  };
+});
+
+import {
+  ArtifactPanelSearchShell,
+  ArtifactSearchBox,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-artifact-search";
+import { ARTIFACT_SEARCH_MIN_COUNT } from "@/components/epic-canvas/sidebar/artifact-search-availability";
+import { usePanelHeaderSearchStore } from "@/stores/epics/panel-header-search-store";
+
+function loadingResult(): QueryResultStub {
+  return {
+    isSuccess: false,
+    isError: false,
+    isFetching: true,
+    data: undefined,
+    error: null,
+    refetch: vi.fn(),
+  };
+}
+
+function successResult(response: SearchArtifactsResponse): QueryResultStub {
+  return {
+    isSuccess: true,
+    isError: false,
+    isFetching: false,
+    data: response,
+    error: null,
+    refetch: vi.fn(),
+  };
+}
+
+function errorResult(code: string): QueryResultStub {
+  return {
+    isSuccess: false,
+    isError: true,
+    isFetching: false,
+    data: undefined,
+    error: { code },
+    refetch: vi.fn(),
+  };
+}
+
+function hit(overrides: Partial<SearchArtifactHit>): SearchArtifactHit {
+  return {
+    artifactId: "art-1",
+    kind: "ticket",
+    title: "Ticket one",
+    status: 1,
+    relativePath: "tickets/ticket-one/index.md",
+    breadcrumb: ["tickets", "ticket-one"],
+    sources: ["title"],
+    score: 1,
+    snippets: [],
+    ...overrides,
+  };
+}
+
+function ready(
+  results: ReadonlyArray<SearchArtifactHit>,
+  truncated: boolean,
+): SearchArtifactsResponse {
+  return { outcome: "ready", results: [...results], truncated };
+}
+
+/**
+ * The box portals its input into the header's slot, so every render needs a
+ * registered slot for the input to exist at all. This stands in for
+ * `PanelHeaderSearchRow`.
+ */
+function BoxHarness(props: {
+  readonly epicId: string;
+  readonly searchQuery: string;
+  readonly debouncedQuery: string;
+}) {
+  const setSearchSlot = usePanelHeaderSearchStore((s) => s.setSearchSlot);
+  return (
+    <>
+      <div
+        ref={(element) => setSearchSlot("artifacts", element)}
+        data-testid="header-search-slot"
+      />
+      <ArtifactSearchBox
+        epicId={props.epicId}
+        tabId="tab-1"
+        searchQuery={props.searchQuery}
+        debouncedQuery={props.debouncedQuery}
+      />
+    </>
+  );
+}
+
+function renderBox(args: {
+  readonly searchQuery: string;
+  readonly debouncedQuery: string;
+  readonly epicId: string;
+}) {
+  return render(
+    <BoxHarness
+      epicId={args.epicId}
+      searchQuery={args.searchQuery}
+      debouncedQuery={args.debouncedQuery}
+    />,
+  );
+}
+
+function searchQueryInStore(): string {
+  return usePanelHeaderSearchStore.getState().queryByPanelId.artifacts ?? "";
+}
+
+function searchOpenInStore(): boolean {
+  return usePanelHeaderSearchStore.getState().openByPanelId.artifacts === true;
+}
+
+beforeEach(() => {
+  harness.result = loadingResult();
+  harness.lastArgs = null;
+  harness.hostId = "host-1";
+  harness.artifactFilter = { statuses: [], kinds: [], read: "all" };
+  harness.epicNodeRef = null;
+  harness.openMock = vi.fn();
+  harness.isUnreadMock = vi.fn(() => false);
+  harness.artifactsById = {};
+  harness.artifactIds = [];
+  usePanelHeaderSearchStore.setState({
+    openByPanelId: {},
+    queryByPanelId: {},
+    slotByPanelId: {},
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ArtifactSearchBox", () => {
+  it("renders only the input and no results region when the query is empty", () => {
+    renderBox({
+      searchQuery: "",
+      debouncedQuery: "",
+      epicId: "epic-1",
+    });
+    expect(screen.getByLabelText("Search artifacts")).toBeTruthy();
+    expect(screen.queryByRole("listbox")).toBeNull();
+    // The host query is disabled while the box is empty.
+    expect(harness.lastArgs?.enabled).toBe(false);
+  });
+
+  it("shows the loading state while the first same-scope result is pending", () => {
+    harness.result = loadingResult();
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    expect(screen.getByTestId("epic-artifact-search-loading")).toBeTruthy();
+    expect(harness.lastArgs?.enabled).toBe(true);
+    expect(harness.lastArgs?.query).toBe("auth");
+  });
+
+  it("renders ranked results without redundant match-source badges and announces the count", () => {
+    harness.result = successResult(
+      ready(
+        [
+          hit({ artifactId: "a1", title: "Login flow", sources: ["title"] }),
+          hit({
+            artifactId: "a2",
+            title: "Session store",
+            sources: ["title", "body"],
+          }),
+        ],
+        false,
+      ),
+    );
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    const listbox = screen.getByRole("listbox", {
+      name: "Artifact search results",
+    });
+    expect(within(listbox).getAllByRole("option")).toHaveLength(2);
+    expect(screen.getByText("Login flow")).toBeTruthy();
+    expect(within(listbox).queryByText("Title")).toBeNull();
+    expect(within(listbox).queryByText("Path")).toBeNull();
+    expect(within(listbox).queryByText("Body")).toBeNull();
+    // Results list keeps the sidebar hidden-scrollbar convention.
+    expect(listbox.className).toContain("no-scrollbar");
+    expect(screen.getByRole("status").textContent).toContain(
+      "2 artifact results",
+    );
+  });
+
+  it("composes the sidebar kind/status filters into the host request", () => {
+    harness.artifactFilter = { statuses: [1], kinds: ["ticket"], read: "all" };
+    harness.result = loadingResult();
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    expect(harness.lastArgs?.kinds).toEqual(["ticket"]);
+    expect(harness.lastArgs?.statuses).toEqual([1]);
+    expect(harness.lastArgs?.subtreePath).toBeNull();
+  });
+
+  it("passes null filter axes when no sidebar filter is set", () => {
+    harness.result = loadingResult();
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    expect(harness.lastArgs?.kinds).toBeNull();
+    expect(harness.lastArgs?.statuses).toBeNull();
+  });
+
+  it("moves the active option with arrow keys and opens it on Enter", () => {
+    harness.epicNodeRef = { id: "a1", type: "ticket" };
+    harness.result = successResult(
+      ready(
+        [
+          hit({ artifactId: "a1", title: "First" }),
+          hit({ artifactId: "a2", title: "Second" }),
+        ],
+        false,
+      ),
+    );
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    const input = screen.getByLabelText("Search artifacts");
+    const options = screen.getAllByRole("option");
+    // First option is active by default.
+    expect(options[0].getAttribute("aria-selected")).toBe("true");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(screen.getAllByRole("option")[1].getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    fireEvent.keyDown(input, { key: "Enter" });
+    // Enter opens the active hit through the authoritative tile-navigation
+    // route (the resolved ref is mocked identically for every hit here).
+    expect(harness.openMock).toHaveBeenCalledWith("tab-1", {
+      id: "a1",
+      type: "ticket",
+    });
+  });
+
+  it("reports a stale hit in place and does not open it", () => {
+    harness.epicNodeRef = null; // not in the authoritative projection
+    harness.result = successResult(
+      ready([hit({ artifactId: "a1", title: "Deleted" })], false),
+    );
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    fireEvent.click(screen.getByTestId("epic-artifact-search-result-a1"));
+    expect(harness.openMock).not.toHaveBeenCalled();
+    expect(screen.getByText("This artifact no longer exists.")).toBeTruthy();
+  });
+
+  it("opens a live hit through the tile-navigation route", () => {
+    harness.epicNodeRef = { id: "a1", type: "ticket" };
+    harness.result = successResult(
+      ready([hit({ artifactId: "a1", title: "Live" })], false),
+    );
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    fireEvent.click(screen.getByTestId("epic-artifact-search-result-a1"));
+    expect(harness.openMock).toHaveBeenCalledWith("tab-1", {
+      id: "a1",
+      type: "ticket",
+    });
+  });
+
+  it("distinguishes mirror-unavailable from a zero-match result", () => {
+    harness.result = successResult({
+      outcome: "mirror-unavailable",
+      results: [],
+      truncated: false,
+    });
+    const { rerender } = renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    expect(
+      screen.getByTestId("epic-artifact-search-mirror-unavailable"),
+    ).toBeTruthy();
+
+    harness.result = successResult(ready([], false));
+    rerender(
+      <BoxHarness epicId="epic-1" searchQuery="auth" debouncedQuery="auth" />,
+    );
+    expect(screen.getByTestId("epic-artifact-search-empty")).toBeTruthy();
+  });
+
+  it("renders the unsupported degrade state without an error", () => {
+    harness.result = errorResult("E_HOST_UNSUPPORTED");
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    expect(screen.getByTestId("epic-artifact-search-unsupported")).toBeTruthy();
+    expect(screen.queryByTestId("epic-artifact-search-error")).toBeNull();
+  });
+
+  it("renders an error state with a working retry", () => {
+    const result = errorResult("RPC_ERROR");
+    harness.result = result;
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    expect(screen.getByTestId("epic-artifact-search-error")).toBeTruthy();
+    fireEvent.click(screen.getByTestId("epic-artifact-search-retry"));
+    expect(result.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the query on the clear button without leaving search mode", () => {
+    harness.result = successResult(ready([hit({ artifactId: "a1" })], false));
+    usePanelHeaderSearchStore.getState().openSearch("artifacts", "auth");
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    fireEvent.click(screen.getByTestId("epic-artifact-search-clear"));
+    expect(searchQueryInStore()).toBe("");
+    // Clearing is not leaving: the header stays swapped so the user can retype.
+    expect(searchOpenInStore()).toBe(true);
+  });
+
+  it("leaves search mode entirely on Escape, restoring the header row", () => {
+    harness.result = successResult(ready([hit({ artifactId: "a1" })], false));
+    usePanelHeaderSearchStore.getState().openSearch("artifacts", "auth");
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    fireEvent.keyDown(screen.getByLabelText("Search artifacts"), {
+      key: "Escape",
+    });
+    expect(searchOpenInStore()).toBe(false);
+    expect(searchQueryInStore()).toBe("");
+  });
+
+  it("leaves search mode from the close button", () => {
+    harness.result = successResult(ready([hit({ artifactId: "a1" })], false));
+    usePanelHeaderSearchStore.getState().openSearch("artifacts", "auth");
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    fireEvent.click(screen.getByTestId("epic-artifact-search-close"));
+    expect(searchOpenInStore()).toBe(false);
+  });
+
+  it("highlights a multibyte body snippet match", () => {
+    harness.result = successResult(
+      ready(
+        [
+          hit({
+            artifactId: "a1",
+            title: "Unicode",
+            sources: ["body"],
+            snippets: [
+              {
+                lineNumber: 1,
+                text: "naïve text",
+                ranges: [{ startByte: 0, endByte: 6 }],
+              },
+            ],
+          }),
+        ],
+        false,
+      ),
+    );
+    renderBox({
+      searchQuery: "naïve",
+      debouncedQuery: "naïve",
+      epicId: "epic-1",
+    });
+    const marks = screen.getAllByText(
+      (_content, element) => element?.tagName.toLowerCase() === "mark",
+    );
+    expect(marks.some((mark) => mark.textContent === "naïve")).toBe(true);
+  });
+
+  it("shows a truthful, count-free truncation note and status", () => {
+    harness.result = successResult(ready([hit({ artifactId: "a1" })], true));
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    const note = screen.getByText(/More matches exist/);
+    // The post-filter count must not leak into the note (would understate the
+    // host's truncated page after a renderer-only read filter).
+    expect(note.textContent).not.toMatch(/\d/);
+    expect(screen.getByRole("status").textContent).toContain(
+      "More are available",
+    );
+  });
+
+  it("gives the input combobox semantics that reference the listbox when shown", () => {
+    harness.result = successResult(ready([hit({ artifactId: "a1" })], false));
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    const input = screen.getByLabelText("Search artifacts");
+    const listbox = screen.getByRole("listbox");
+    expect(input.getAttribute("role")).toBe("combobox");
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+    expect(input.getAttribute("aria-controls")).toBe(listbox.id);
+    expect(input.getAttribute("aria-activedescendant")).toBe(
+      `${listbox.id}-option-0`,
+    );
+  });
+
+  it("does not dangle combobox popup attributes without a listbox", () => {
+    // Loading: no listbox in the DOM, so aria-expanded is false and neither
+    // aria-controls nor aria-activedescendant may reference a missing element.
+    harness.result = loadingResult();
+    const { rerender } = renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    let input = screen.getByLabelText("Search artifacts");
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+    expect(input.getAttribute("aria-controls")).toBeNull();
+    expect(input.getAttribute("aria-activedescendant")).toBeNull();
+
+    // Empty ready result: still no listbox.
+    harness.result = successResult(ready([], false));
+    rerender(
+      <BoxHarness epicId="epic-1" searchQuery="auth" debouncedQuery="auth" />,
+    );
+    input = screen.getByLabelText("Search artifacts");
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+    expect(input.getAttribute("aria-controls")).toBeNull();
+  });
+
+  it("announces loading exactly once (no duplicate live regions)", () => {
+    harness.result = loadingResult();
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    const statuses = screen.getAllByRole("status");
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0].textContent).toContain("Searching artifacts");
+    // The spinner itself is decorative, not a second announcement.
+    expect(
+      screen
+        .getByTestId("epic-artifact-search-loading")
+        .getAttribute("aria-hidden"),
+    ).toBe("true");
+  });
+
+  it("does not render prior-scope results after the Epic changes (late-echo isolation)", () => {
+    harness.result = successResult(
+      ready([hit({ artifactId: "a1", title: "Epic A hit" })], false),
+    );
+    const { rerender } = renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-A",
+    });
+    expect(screen.getByText("Epic A hit")).toBeTruthy();
+
+    // Epic changes and the new scope's query is still pending: the prior Epic's
+    // results must not linger.
+    harness.result = loadingResult();
+    rerender(
+      <BoxHarness epicId="epic-B" searchQuery="auth" debouncedQuery="auth" />,
+    );
+    expect(screen.queryByText("Epic A hit")).toBeNull();
+    expect(screen.getByTestId("epic-artifact-search-loading")).toBeTruthy();
+  });
+
+  it("retains same-scope results across keystrokes while the next query loads", () => {
+    harness.result = successResult(
+      ready([hit({ artifactId: "a1", title: "Kept hit" })], false),
+    );
+    const { rerender } = renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    expect(screen.getByText("Kept hit")).toBeTruthy();
+
+    // Only the query string changed (same Epic/host/filters): keep showing the
+    // previous same-scope results instead of blanking.
+    harness.result = loadingResult();
+    rerender(
+      <BoxHarness epicId="epic-1" searchQuery="authz" debouncedQuery="authz" />,
+    );
+    expect(screen.getByText("Kept hit")).toBeTruthy();
+  });
+
+  it("applies the renderer-only read filter to results", () => {
+    harness.artifactFilter = { statuses: [], kinds: [], read: "unread" };
+    harness.artifactsById = { a1: { updatedAt: 10 }, a2: { updatedAt: 20 } };
+    // Only a1 is unread.
+    harness.isUnreadMock = vi.fn(
+      (args: { artifactId: string }): boolean => args.artifactId === "a1",
+    );
+    harness.result = successResult(
+      ready(
+        [
+          hit({ artifactId: "a1", title: "Unread hit" }),
+          hit({ artifactId: "a2", title: "Read hit" }),
+        ],
+        false,
+      ),
+    );
+    renderBox({
+      searchQuery: "auth",
+      debouncedQuery: "auth",
+      epicId: "epic-1",
+    });
+    expect(screen.getByText("Unread hit")).toBeTruthy();
+    expect(screen.queryByText("Read hit")).toBeNull();
+  });
+});
+
+describe("ArtifactPanelSearchShell", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    harness.result = successResult(
+      ready([hit({ artifactId: "a1", title: "A hit" })], false),
+    );
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /**
+   * The shell renders only the tree; the input is portaled into the header
+   * slot, which the section header owns. This stands in for that header.
+   */
+  function ShellHarness() {
+    const setSearchSlot = usePanelHeaderSearchStore((s) => s.setSearchSlot);
+    return (
+      <>
+        <div
+          ref={(element) => setSearchSlot("artifacts", element)}
+          data-testid="header-search-slot"
+        />
+        <ArtifactPanelSearchShell epicId="epic-1" tabId="tab-1">
+          <div data-testid="tree-stub">artifact tree</div>
+        </ArtifactPanelSearchShell>
+      </>
+    );
+  }
+
+  /** Enough artifacts that the search affordance is available. */
+  function withSearchableArtifactCount() {
+    harness.artifactIds = Array.from(
+      { length: ARTIFACT_SEARCH_MIN_COUNT },
+      (_unused, index) => `art-${index}`,
+    );
+  }
+
+  function renderShell(args: { readonly searchOpen: boolean }) {
+    withSearchableArtifactCount();
+    if (args.searchOpen) {
+      usePanelHeaderSearchStore.getState().openSearch("artifacts", "");
+    }
+    return render(<ShellHarness />);
+  }
+
+  function typeAndSettle(input: HTMLElement, value: string) {
+    fireEvent.change(input, { target: { value } });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+  }
+
+  it("renders no search input at all in browse mode", () => {
+    renderShell({ searchOpen: false });
+    // The whole point of the rework: browse mode spends zero rows on search.
+    expect(screen.queryByLabelText("Search artifacts")).toBeNull();
+    expect(screen.getByTestId("tree-stub")).toBeTruthy();
+  });
+
+  it("enters search mode seeded with the typed character", () => {
+    renderShell({ searchOpen: false });
+    fireEvent.keyDown(screen.getByTestId("epic-artifact-tree-region"), {
+      key: "a",
+    });
+    // The keystroke that started the search is not swallowed by the handoff.
+    expect(searchOpenInStore()).toBe(true);
+    expect(searchQueryInStore()).toBe("a");
+    expect(screen.getByLabelText("Search artifacts")).toBeTruthy();
+  });
+
+  it("ignores type-to-filter below the artifact-count threshold", () => {
+    harness.artifactIds = Array.from(
+      { length: ARTIFACT_SEARCH_MIN_COUNT - 1 },
+      (_unused, index) => `art-${index}`,
+    );
+    render(<ShellHarness />);
+    fireEvent.keyDown(screen.getByTestId("epic-artifact-tree-region"), {
+      key: "a",
+    });
+    expect(searchOpenInStore()).toBe(false);
+  });
+
+  it("ignores modified keys so shortcuts still reach their handlers", () => {
+    renderShell({ searchOpen: false });
+    const region = screen.getByTestId("epic-artifact-tree-region");
+    fireEvent.keyDown(region, { key: "a", metaKey: true });
+    fireEvent.keyDown(region, { key: " " });
+    fireEvent.keyDown(region, { key: "ArrowDown" });
+    expect(searchOpenInStore()).toBe(false);
+  });
+
+  it("keeps the tree viewport as the hidden-scrollbar single scroll surface", () => {
+    renderShell({ searchOpen: false });
+    const region = screen.getByTestId("epic-artifact-tree-region");
+    // The inner tree viewport is the active scroll surface and keeps the
+    // sidebar's hidden-scrollbar convention that SidebarContent used to provide.
+    expect(region.className).toContain("overflow-auto");
+    expect(region.className).toContain("no-scrollbar");
+  });
+
+  it("keeps the tree mounted but hidden while a query is active", () => {
+    renderShell({ searchOpen: true });
+    const input = screen.getByLabelText("Search artifacts");
+    const region = screen.getByTestId("epic-artifact-tree-region");
+    expect(region.className).not.toContain("hidden");
+
+    typeAndSettle(input, "auth");
+    // Tree is still in the DOM (mounted), just hidden — expansion/scroll survive.
+    expect(screen.getByTestId("tree-stub")).toBeTruthy();
+    expect(screen.getByTestId("epic-artifact-tree-region").className).toContain(
+      "hidden",
+    );
+  });
+
+  it("restores the tree in the same cycle on clear (no debounce lag)", () => {
+    renderShell({ searchOpen: true });
+    const input = screen.getByLabelText("Search artifacts");
+    typeAndSettle(input, "auth");
+    expect(screen.getByTestId("epic-artifact-tree-region").className).toContain(
+      "hidden",
+    );
+
+    // Clear: the tree must return immediately, without advancing the debounce.
+    fireEvent.click(screen.getByTestId("epic-artifact-search-clear"));
+    expect(
+      screen.getByTestId("epic-artifact-tree-region").className,
+    ).not.toContain("hidden");
+  });
+
+  it("restores the tree in the same cycle on Escape", () => {
+    renderShell({ searchOpen: true });
+    const input = screen.getByLabelText("Search artifacts");
+    typeAndSettle(input, "auth");
+    expect(screen.getByTestId("epic-artifact-tree-region").className).toContain(
+      "hidden",
+    );
+
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(
+      screen.getByTestId("epic-artifact-tree-region").className,
+    ).not.toContain("hidden");
+  });
+
+  it("restores the tree scroll position when leaving search mode", () => {
+    renderShell({ searchOpen: true });
+    const input = screen.getByLabelText("Search artifacts");
+    const region = screen.getByTestId("epic-artifact-tree-region");
+
+    // The user scrolls the tree, then searches.
+    region.scrollTop = 120;
+    fireEvent.scroll(region);
+    typeAndSettle(input, "auth");
+
+    // Simulate the viewport being lost while the tree is hidden.
+    region.scrollTop = 0;
+    fireEvent.click(screen.getByTestId("epic-artifact-search-clear"));
+
+    expect(screen.getByTestId("epic-artifact-tree-region").scrollTop).toBe(120);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-artifact-search.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-artifact-search.test.tsx
@@ -745,6 +745,15 @@ describe("ArtifactPanelSearchShell", () => {
     expect(searchOpenInStore()).toBe(false);
   });
 
+  it("does not steal typed input from an editable tree descendant", () => {
+    renderShell({ searchOpen: false });
+    const region = screen.getByTestId("epic-artifact-tree-region");
+    const input = document.createElement("input");
+    region.append(input);
+    fireEvent.keyDown(input, { key: "a" });
+    expect(searchOpenInStore()).toBe(false);
+  });
+
   it("keeps the tree viewport as the hidden-scrollbar single scroll surface", () => {
     renderShell({ searchOpen: false });
     const region = screen.getByTestId("epic-artifact-tree-region");

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-report-issue.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-file-tree-report-issue.test.tsx
@@ -311,6 +311,17 @@ vi.mock("@/hooks/workspace/use-list-file-tree-query", () => ({
   }),
 }));
 
+// The active-query path search is a separate host query; this panel test only
+// exercises the browse/error state, so stub it to an inert idle result.
+vi.mock("@/hooks/workspace/use-workspace-search-paths-query", () => ({
+  useWorkspaceSearchPaths: () => ({
+    data: undefined,
+    isError: false,
+    isLoading: false,
+    isFetching: false,
+  }),
+}));
+
 vi.mock("@pierre/trees/react", () => ({
   FileTree: () => <div data-testid="pierre-file-tree-stub" />,
   useFileTree: () => ({

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-nested-focus-boundary.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-nested-focus-boundary.test.tsx
@@ -140,6 +140,19 @@ vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
   useEpicNestedFocusNavigation: () => testState.navigateNested,
 }));
 
+// The artifact panel now hosts a search box; keep its host query inert so these
+// tree-focused tests need no QueryClient. An empty query renders no results.
+vi.mock("@/hooks/epic/use-epic-search-artifacts-query", () => ({
+  useEpicSearchArtifacts: () => ({
+    isSuccess: false,
+    isError: false,
+    isFetching: false,
+    data: undefined,
+    error: null,
+    refetch: () => undefined,
+  }),
+}));
+
 vi.mock("@/hooks/epic/use-epic-export-artifacts-mutation", () => ({
   useEpicExportArtifacts: () => ({ mutate: vi.fn(), isPending: false }),
 }));

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -118,6 +118,19 @@ const testState = vi.hoisted<TestState>(() => ({
   activeHostClient: { getActiveHostId: () => "host-1" },
 }));
 
+// The artifact panel now hosts a search box; keep its host query inert so these
+// tree-focused tests need no QueryClient. An empty query renders no results.
+vi.mock("@/hooks/epic/use-epic-search-artifacts-query", () => ({
+  useEpicSearchArtifacts: () => ({
+    isSuccess: false,
+    isError: false,
+    isFetching: false,
+    data: undefined,
+    error: null,
+    refetch: () => undefined,
+  }),
+}));
+
 vi.mock("@/components/epic-canvas/dnd/epic-canvas-dnd-context-value", () => ({
   useEpicCanvasDnd: () => ({
     activeSource: null,

--- a/clients/gui-app/src/components/epic-canvas/sidebar/artifact-search-availability.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/artifact-search-availability.ts
@@ -1,0 +1,24 @@
+/**
+ * Whether the artifact panel offers search at all.
+ *
+ * Lives apart from `epic-sidebar-artifact-search.tsx` so both that component
+ * and the panel header's action row can read it without either importing the
+ * other's module graph (and so the component file keeps exporting only
+ * components, for Fast Refresh).
+ */
+import { useEpicStore } from "@/hooks/use-epic-store";
+
+/**
+ * Below this many artifacts, scanning the tree beats filtering it - so the
+ * header shows no search affordance and typing into the tree does nothing.
+ * Keeping the control out of small Epics is the point: an always-present box
+ * is exactly the weight this rework removes.
+ */
+export const ARTIFACT_SEARCH_MIN_COUNT = 10;
+
+/** Whether this Epic has enough artifacts to be worth searching. */
+export function useArtifactSearchAvailable(): boolean {
+  return useEpicStore(
+    (s) => s.artifacts.allIds.length >= ARTIFACT_SEARCH_MIN_COUNT,
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-search.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-search.tsx
@@ -153,6 +153,13 @@ export function ArtifactPanelSearchShell(props: ArtifactPanelSearchShellProps) {
     if (region === null) return;
     if (!searchAvailable || searchOpen) return;
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest("input, textarea, [contenteditable='true']") !==
+          null
+      ) {
+        return;
+      }
       if (!isTypeToFilterKey(event)) return;
       event.preventDefault();
       openSearch(ARTIFACTS_PANEL_ID, event.key);

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-search.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-search.tsx
@@ -1,0 +1,799 @@
+/**
+ * Active-query artifact search for the Epic sidebar's artifact panel.
+ *
+ * Search is a MODE, not a permanent fixture: there is no resting search box.
+ * The panel header owns the affordance (a search icon, shown only once the
+ * Epic has enough artifacts for filtering to beat scanning), and entering
+ * search trades the header row for the input rather than stacking a second row
+ * under it. Typing into the focused tree enters the mode too; Escape leaves it.
+ *
+ * While the mode is on, the input's DOM is portaled into the header's slot but
+ * the component tree is unchanged - so the host query, same-scope retention,
+ * combobox keyboard navigation, every load / empty / mirror-unavailable /
+ * unsupported / error state, and opening a hit through the authoritative
+ * selection route all stay in ONE component, right next to the results they
+ * drive.
+ */
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { FileText, Search, SearchX, X } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import type {
+  SearchArtifactHit,
+  SearchArtifactsResponse,
+} from "@traycer/protocol/host/epic/unary-schemas";
+import { useHostClient } from "@/lib/host";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
+import { epicNodeRefForNodeId } from "@/lib/epic-selectors";
+import { useEpicStore } from "@/hooks/use-epic-store";
+import {
+  isArtifactUnread,
+  useArtifactReadStateStore,
+} from "@/stores/epics/artifact-read-state-store";
+import {
+  ARTIFACT_READ,
+  useArtifactFilter,
+} from "@/stores/epics/left-panel-store";
+import { useEpicSearchArtifacts } from "@/hooks/epic/use-epic-search-artifacts-query";
+import {
+  highlightSegmentsFromByteRanges,
+  type SnippetByteRange,
+} from "@/lib/artifacts/highlight-byte-ranges";
+import {
+  EPIC_NODE_ICONS,
+  isEpicArtifactKind,
+} from "@/lib/artifacts/node-display";
+import { displayTitle } from "@/lib/display-title";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
+import {
+  STATUS_DOT_CLASSES,
+  STATUS_LABELS,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
+import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
+import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
+import { useArtifactSearchAvailable } from "@/components/epic-canvas/sidebar/artifact-search-availability";
+import {
+  usePanelHeaderSearchOpen,
+  usePanelHeaderSearchQuery,
+  usePanelHeaderSearchSlot,
+  usePanelHeaderSearchStore,
+} from "@/stores/epics/panel-header-search-store";
+import { SidebarContent } from "@/components/ui/sidebar";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { cn } from "@/lib/utils";
+
+const EMPTY_HITS: ReadonlyArray<SearchArtifactHit> = Object.freeze([]);
+
+/** The panel whose header this search takes over while it is active. */
+const ARTIFACTS_PANEL_ID = "artifacts";
+
+/**
+ * A bare printable character with no modifier - the type-to-filter trigger.
+ * Excludes space so it can keep its tree-row activation meaning, and anything
+ * carrying a modifier so shortcuts still reach their handlers.
+ */
+function isTypeToFilterKey(event: globalThis.KeyboardEvent): boolean {
+  if (event.ctrlKey || event.metaKey || event.altKey) return false;
+  return event.key.length === 1 && event.key !== " ";
+}
+
+interface ArtifactPanelSearchShellProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  /** The artifact tree; kept mounted (just hidden) while results are shown. */
+  readonly children: ReactNode;
+}
+
+/**
+ * Composes the artifact panel. In browse mode this is JUST the tree - no
+ * search box occupies the panel. Entering search mode mounts
+ * `ArtifactSearchBox`, which portals its input up into the header row.
+ *
+ * While a query is active the tree is HIDDEN (display:none) rather than
+ * unmounted, so its expansion/filter state and its scroll viewport both survive
+ * a round-trip through search mode. Leaving search short-circuits the debounce
+ * so the tree returns in the same update cycle, not after the 200 ms delay.
+ */
+export function ArtifactPanelSearchShell(props: ArtifactPanelSearchShellProps) {
+  const searchOpen = usePanelHeaderSearchOpen(ARTIFACTS_PANEL_ID);
+  const searchQuery = usePanelHeaderSearchQuery(ARTIFACTS_PANEL_ID);
+  const openSearch = usePanelHeaderSearchStore((s) => s.openSearch);
+  const searchAvailable = useArtifactSearchAvailable();
+
+  const debouncedRaw = useDebouncedValue(searchQuery, 200);
+  // Treat an empty/whitespace box as immediate: clearing or leaving search must
+  // restore the tree in the same cycle, not after the typing debounce.
+  const debouncedQuery = searchQuery.trim().length === 0 ? "" : debouncedRaw;
+  const searchActive = searchOpen && debouncedQuery.trim().length > 0;
+
+  // Preserve the tree's scroll viewport across search mode. `onScroll` captures
+  // the live position while the tree is visible (a hidden element reports 0), and
+  // the layout effect restores it the moment search is cleared.
+  const treeScrollRef = useRef<HTMLDivElement>(null);
+  const treeScrollTopRef = useRef(0);
+  const handleTreeScroll = useCallback(() => {
+    const element = treeScrollRef.current;
+    if (element !== null) treeScrollTopRef.current = element.scrollTop;
+  }, []);
+  useLayoutEffect(() => {
+    if (!searchActive && treeScrollRef.current !== null) {
+      treeScrollRef.current.scrollTop = treeScrollTopRef.current;
+    }
+  }, [searchActive]);
+
+  // Type-to-filter: a bare printable key anywhere in the focused tree enters
+  // search mode seeded with that character, so the keystroke that started the
+  // search is not swallowed by the focus handoff to the header input.
+  //
+  // Subscribed imperatively rather than via `onKeyDown`: this region is a
+  // scroll container, and a JSX key handler would oblige it to claim an
+  // interactive role it does not have (the tree inside owns `role="tree"`).
+  useEffect(() => {
+    const region = treeScrollRef.current;
+    if (region === null) return;
+    if (!searchAvailable || searchOpen) return;
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (!isTypeToFilterKey(event)) return;
+      event.preventDefault();
+      openSearch(ARTIFACTS_PANEL_ID, event.key);
+    };
+    region.addEventListener("keydown", onKeyDown);
+    return () => region.removeEventListener("keydown", onKeyDown);
+  }, [searchAvailable, searchOpen, openSearch]);
+
+  return (
+    // `overflow-hidden` overrides SidebarContent's default `overflow-auto` so the
+    // outer surface never competes with the inner scroll surfaces below: the
+    // hidden-scrollbar tree viewport (browse mode) and the results list (search
+    // mode) are each the single active scroller for their mode.
+    <SidebarContent className="gap-0 overflow-hidden">
+      {searchOpen ? (
+        <ArtifactSearchBox
+          epicId={props.epicId}
+          tabId={props.tabId}
+          searchQuery={searchQuery}
+          debouncedQuery={debouncedQuery}
+        />
+      ) : null}
+      <div
+        ref={treeScrollRef}
+        onScroll={handleTreeScroll}
+        className={cn(
+          // `no-scrollbar` keeps the sidebar's hidden-scrollbar presentation
+          // that SidebarContent used to provide for the tree.
+          "no-scrollbar flex min-h-0 flex-1 flex-col overflow-auto",
+          searchActive && "hidden",
+        )}
+        data-testid="epic-artifact-tree-region"
+      >
+        {props.children}
+      </div>
+    </SidebarContent>
+  );
+}
+
+interface ArtifactSearchBoxProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly searchQuery: string;
+  /** Debounced form of `searchQuery`; drives the host request. */
+  readonly debouncedQuery: string;
+}
+
+/**
+ * The artifact-panel search control plus its result surface. Mounted only in
+ * search mode. The input row is portaled into the header's slot (so it visually
+ * replaces the header) while the results render here in the panel body - one
+ * component, two DOM homes.
+ */
+// Composes the query, scope-retention, read-filter, keyboard, and open flows in
+// a fixed hook order; the branches are independent, not reducible nesting.
+// eslint-disable-next-line complexity
+export function ArtifactSearchBox(props: ArtifactSearchBoxProps) {
+  const { epicId, tabId, searchQuery, debouncedQuery } = props;
+  const client = useHostClient();
+  const activeHostId = useReactiveActiveHostId();
+  const filter = useArtifactFilter(epicId);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const headerSlot = usePanelHeaderSearchSlot(ARTIFACTS_PANEL_ID);
+  const setSearchQuery = usePanelHeaderSearchStore((s) => s.setSearchQuery);
+  const closeSearch = usePanelHeaderSearchStore((s) => s.closeSearch);
+  const onSearchQueryChange = useCallback(
+    (value: string) => setSearchQuery(ARTIFACTS_PANEL_ID, value),
+    [setSearchQuery],
+  );
+
+  const searchActive = debouncedQuery.trim().length > 0;
+
+  // Compose the sidebar's kind/status filters into the host request; `read` is
+  // renderer-only state applied to the response below. Empty axes stay `null`.
+  const kinds = filter.kinds.length > 0 ? filter.kinds : null;
+  const statuses = filter.statuses.length > 0 ? filter.statuses : null;
+
+  const query = useEpicSearchArtifacts({
+    client,
+    epicId,
+    query: debouncedQuery,
+    kinds,
+    statuses,
+    subtreePath: null,
+    enabled: searchActive,
+  });
+
+  // A response must never render for a scope it wasn't fetched in. The query key
+  // already isolates late async responses per scope; this signature additionally
+  // gates the same-scope retention below so a prior Epic / host / filter result
+  // can't linger on-screen after the scope changes (only the query string
+  // changing keeps the retained results).
+  const scopeSignature = [
+    epicId,
+    activeHostId ?? "",
+    kinds === null ? "" : kinds.join(","),
+    statuses === null ? "" : statuses.join(","),
+  ].join(" ");
+
+  // `useEpicSearchArtifacts` intentionally omits `keepPreviousData`, so
+  // `query.data` is only ever the current key's result. Retain the last
+  // *same-scope* success so the list doesn't blank between keystrokes, but drop
+  // it the instant the scope changes. The setState-during-render idiom keeps
+  // the retained value in sync without an effect and never leaks a prior scope.
+  const [retained, setRetained] = useState<{
+    readonly signature: string;
+    readonly response: SearchArtifactsResponse;
+  } | null>(null);
+  if (
+    query.isSuccess &&
+    (retained === null ||
+      retained.response !== query.data ||
+      retained.signature !== scopeSignature)
+  ) {
+    setRetained({ signature: scopeSignature, response: query.data });
+  }
+  const sameScopeRetained =
+    retained !== null && retained.signature === scopeSignature
+      ? retained.response
+      : null;
+  const response: SearchArtifactsResponse | null = query.isSuccess
+    ? query.data
+    : sameScopeRetained;
+
+  const isUnsupported = query.error?.code === "E_HOST_UNSUPPORTED";
+  const isError = query.isError && !isUnsupported;
+
+  // Read filter (renderer-only). Resolve each hit's authoritative `updatedAt`
+  // from the open-Epic projection; a hit missing from the projection is stale
+  // and cannot be classified, so it drops out whenever a read filter is active.
+  const readFilter = filter.read;
+  const artifactsById = useEpicStore((s) => s.artifacts.byId);
+  const readState = useArtifactReadStateStore(
+    useShallow((s) => ({
+      seedAtByEpic: s.seedAtByEpic,
+      lastSeenByArtifact: s.lastSeenByArtifact,
+    })),
+  );
+  const results = useMemo<ReadonlyArray<SearchArtifactHit>>(() => {
+    if (response === null) return EMPTY_HITS;
+    if (readFilter === ARTIFACT_READ.All) return response.results;
+    return response.results.filter((hit) => {
+      if (!Object.hasOwn(artifactsById, hit.artifactId)) return false;
+      const unread = isArtifactUnread({
+        epicId,
+        artifactId: hit.artifactId,
+        updatedAt: artifactsById[hit.artifactId].updatedAt,
+        seedAtByEpic: readState.seedAtByEpic,
+        lastSeenByArtifact: readState.lastSeenByArtifact,
+      });
+      return readFilter === ARTIFACT_READ.Unread ? unread : !unread;
+    });
+  }, [response, readFilter, artifactsById, readState, epicId]);
+
+  // ── Opening a hit (authoritative selection route) ─────────────────────────
+  const handle = useOpenEpicHandle();
+  const tileNavigation = useEpicTileNavigation();
+  const [staleArtifactId, setStaleArtifactId] = useState<string | null>(null);
+
+  const openHit = useCallback(
+    (hit: SearchArtifactHit) => {
+      // Re-resolve the hit against the authoritative Y.Doc projection rather
+      // than the disk mirror it was found in: a stale / deleted hit resolves to
+      // `null` and is reported in place instead of opening anything.
+      const ref = epicNodeRefForNodeId(
+        handle.store.getState(),
+        hit.artifactId,
+        activeHostId ?? UNKNOWN_HOST_PLACEHOLDER,
+      );
+      if (ref === null) {
+        setStaleArtifactId(hit.artifactId);
+        return;
+      }
+      setStaleArtifactId(null);
+      tileNavigation.openTilePreviewInTab(tabId, ref);
+    },
+    [handle, activeHostId, tileNavigation, tabId],
+  );
+
+  // ── Combobox keyboard navigation ──────────────────────────────────────────
+  const listboxId = useId();
+  const [activeIndex, setActiveIndex] = useState(0);
+  const resultCount = results.length;
+
+  // When the visible result set changes (new query, filter, retained→fresh),
+  // reset the active row to the top and clear any stale marker. Done at render
+  // time keyed on `results` identity rather than in an effect, so there is no
+  // extra commit/paint cycle.
+  const [prevResults, setPrevResults] = useState(results);
+  if (prevResults !== results) {
+    setPrevResults(results);
+    setActiveIndex(0);
+    setStaleArtifactId(null);
+  }
+
+  const clampedActiveIndex =
+    resultCount === 0 ? -1 : Math.min(activeIndex, resultCount - 1);
+  const activeOptionId =
+    clampedActiveIndex >= 0
+      ? `${listboxId}-option-${clampedActiveIndex}`
+      : undefined;
+
+  // Scroll the active option into view without stealing focus from the input.
+  useEffect(() => {
+    if (activeOptionId === undefined) return;
+    const element = document.getElementById(activeOptionId);
+    element?.scrollIntoView({ block: "nearest" });
+  }, [activeOptionId]);
+
+  const clearSearch = useCallback(() => {
+    onSearchQueryChange("");
+    inputRef.current?.focus();
+  }, [onSearchQueryChange]);
+
+  // Leaving search restores the header row and the tree in one step. Escape is
+  // unconditional (not "clear first, then exit"): the mode is the thing the
+  // user wants out of, and an empty box has no separate resting state now.
+  const exitSearch = useCallback(() => {
+    closeSearch(ARTIFACTS_PANEL_ID);
+  }, [closeSearch]);
+
+  // Focus the portaled input as soon as the header slot exists, so both entry
+  // paths (header icon, type-to-filter) land the caret without a mouse click.
+  useEffect(() => {
+    if (headerSlot === null) return;
+    inputRef.current?.focus();
+  }, [headerSlot]);
+
+  const handleInputKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        exitSearch();
+        return;
+      }
+      if (resultCount === 0) return;
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((index) => Math.min(index + 1, resultCount - 1));
+      } else if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((index) => Math.max(index - 1, 0));
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        setActiveIndex(0);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        setActiveIndex(resultCount - 1);
+      } else if (event.key === "Enter") {
+        if (clampedActiveIndex < 0) return;
+        event.preventDefault();
+        openHit(results[clampedActiveIndex]);
+      }
+    },
+    [exitSearch, resultCount, clampedActiveIndex, openHit, results],
+  );
+
+  // The listbox (`role="listbox"`) is only in the DOM when ranked results are
+  // actually shown - not during loading / empty / error / unsupported /
+  // mirror-unavailable. The combobox's `aria-expanded` / `aria-controls` /
+  // `aria-activedescendant` are gated on this so they never reference an absent
+  // element or a non-existent active option.
+  const listboxRendered =
+    searchActive &&
+    !isUnsupported &&
+    !isError &&
+    response !== null &&
+    response.outcome === "ready" &&
+    results.length > 0;
+
+  const statusMessage = deriveStatusMessage({
+    searchActive,
+    isUnsupported,
+    isError,
+    response,
+    resultCount,
+    staleActive: staleArtifactId !== null,
+  });
+
+  const inputRow = (
+    <InputGroup className="h-7 w-full">
+      <InputGroupAddon align="inline-start">
+        <Search className="size-3.5" aria-hidden />
+      </InputGroupAddon>
+      <InputGroupInput
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        value={searchQuery}
+        onChange={(event) => onSearchQueryChange(event.target.value)}
+        onKeyDown={handleInputKeyDown}
+        placeholder="Search artifacts…"
+        aria-label="Search artifacts"
+        aria-autocomplete="list"
+        aria-expanded={listboxRendered}
+        aria-controls={listboxRendered ? listboxId : undefined}
+        aria-activedescendant={listboxRendered ? activeOptionId : undefined}
+        autoComplete="off"
+        spellCheck={false}
+        className="text-ui-sm"
+        data-testid="epic-artifact-search-input"
+      />
+      <InputGroupAddon align="inline-end">
+        {searchQuery.length > 0 ? (
+          <InputGroupButton
+            type="button"
+            size="icon-xs"
+            aria-label="Clear artifact search"
+            onClick={clearSearch}
+            data-testid="epic-artifact-search-clear"
+          >
+            <X className="size-3.5" aria-hidden />
+          </InputGroupButton>
+        ) : null}
+        <InputGroupButton
+          type="button"
+          size="icon-xs"
+          aria-label="Close artifact search"
+          onClick={exitSearch}
+          data-testid="epic-artifact-search-close"
+        >
+          <span aria-hidden className="text-overline uppercase">
+            esc
+          </span>
+        </InputGroupButton>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 flex-col",
+        searchActive ? "flex-1" : "shrink-0",
+      )}
+    >
+      {/* The header slot is written by a ref callback during the header's
+          commit, so it is null only on this component's very first render;
+          the resulting store write re-renders us with the target in hand. */}
+      {headerSlot === null ? null : createPortal(inputRow, headerSlot)}
+
+      <p className="sr-only" role="status" aria-live="polite">
+        {statusMessage}
+      </p>
+
+      {searchActive ? (
+        <ArtifactSearchResultsRegion
+          epicId={epicId}
+          listboxId={listboxId}
+          isUnsupported={isUnsupported}
+          isError={isError}
+          isPending={response === null}
+          isFetching={query.isFetching}
+          onRetry={() => void query.refetch()}
+          response={response}
+          results={results}
+          activeIndex={clampedActiveIndex}
+          onActivate={openHit}
+          onHoverIndex={setActiveIndex}
+          staleArtifactId={staleArtifactId}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function deriveStatusMessage(args: {
+  readonly searchActive: boolean;
+  readonly isUnsupported: boolean;
+  readonly isError: boolean;
+  readonly response: SearchArtifactsResponse | null;
+  readonly resultCount: number;
+  readonly staleActive: boolean;
+}): string {
+  if (!args.searchActive) return "";
+  if (args.isUnsupported)
+    return "Artifact search isn't available on this host.";
+  if (args.isError) return "Artifact search failed.";
+  if (args.staleActive) return "That artifact no longer exists.";
+  if (args.response === null) return "Searching artifacts…";
+  if (args.response.outcome === "mirror-unavailable") {
+    return "Artifact search isn't ready yet.";
+  }
+  if (args.resultCount === 0) {
+    return args.response.truncated
+      ? "No matches shown; more results exist beyond the search limit."
+      : "No artifacts match your search.";
+  }
+  const base = `${args.resultCount} artifact ${
+    args.resultCount === 1 ? "result" : "results"
+  }.`;
+  return args.response.truncated
+    ? `${base} More are available; refine your search.`
+    : base;
+}
+
+interface ArtifactSearchResultsRegionProps {
+  readonly epicId: string;
+  readonly listboxId: string;
+  readonly isUnsupported: boolean;
+  readonly isError: boolean;
+  readonly isPending: boolean;
+  readonly isFetching: boolean;
+  readonly onRetry: () => void;
+  readonly response: SearchArtifactsResponse | null;
+  readonly results: ReadonlyArray<SearchArtifactHit>;
+  readonly activeIndex: number;
+  readonly onActivate: (hit: SearchArtifactHit) => void;
+  readonly onHoverIndex: (index: number) => void;
+  readonly staleArtifactId: string | null;
+}
+
+function ArtifactSearchResultsRegion(props: ArtifactSearchResultsRegionProps) {
+  if (props.isUnsupported) {
+    return (
+      <SidebarPanelEmptyState
+        icon={SearchX}
+        title="Search isn't available on this host."
+        description="Update this device's Traycer host to search artifacts."
+        testId="epic-artifact-search-unsupported"
+      />
+    );
+  }
+  if (props.isError) {
+    return (
+      <div
+        className="flex flex-col items-center gap-2 px-4 py-8 text-center"
+        data-testid="epic-artifact-search-error"
+      >
+        <SearchX className="size-8 text-muted-foreground/45" aria-hidden />
+        <p className="text-ui-sm text-muted-foreground/70">
+          Artifact search failed.
+        </p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={props.onRetry}
+          data-testid="epic-artifact-search-retry"
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+  if (props.isPending) {
+    // Decorative only: the box's persistent `role="status"` region already
+    // announces "Searching artifacts…", so this spinner must not double-announce.
+    return (
+      <div
+        aria-hidden
+        className="flex flex-1 items-center justify-center py-8"
+        data-testid="epic-artifact-search-loading"
+      >
+        <AgentSpinningDots
+          className="text-muted-foreground"
+          testId={undefined}
+          variant={undefined}
+        />
+      </div>
+    );
+  }
+  if (
+    props.response !== null &&
+    props.response.outcome === "mirror-unavailable"
+  ) {
+    return (
+      <SidebarPanelEmptyState
+        icon={Search}
+        title="Artifact search isn't ready yet."
+        description="This Epic's artifacts are still syncing to this device."
+        testId="epic-artifact-search-mirror-unavailable"
+      />
+    );
+  }
+  if (props.results.length === 0) {
+    // A renderer-only read filter can empty a truncated host page while matches
+    // exist beyond the 50-result cap; say so rather than a flat "no matches".
+    const truncated = props.response?.truncated === true;
+    return (
+      <SidebarPanelEmptyState
+        icon={FileText}
+        title="No artifacts match your search."
+        description={
+          truncated
+            ? "More results exist beyond the search limit - refine your query."
+            : null
+        }
+        testId="epic-artifact-search-empty"
+      />
+    );
+  }
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <ul
+        id={props.listboxId}
+        role="listbox"
+        aria-label="Artifact search results"
+        aria-busy={props.isFetching}
+        className="no-scrollbar min-h-0 flex-1 space-y-0.5 overflow-auto px-2 pb-2"
+        data-testid="epic-artifact-search-results"
+      >
+        {props.results.map((hit, index) => (
+          <ArtifactSearchResultRow
+            key={hit.artifactId}
+            optionId={`${props.listboxId}-option-${index}`}
+            hit={hit}
+            active={index === props.activeIndex}
+            stale={props.staleArtifactId === hit.artifactId}
+            onActivate={props.onActivate}
+            onHover={() => props.onHoverIndex(index)}
+          />
+        ))}
+      </ul>
+      {props.response?.truncated === true ? (
+        // Count-free so it stays truthful after the renderer-only read filter,
+        // which can drop hits from the host's already-truncated page.
+        <p className="shrink-0 px-3 pb-1 pt-1 text-ui-xs text-muted-foreground">
+          More matches exist - refine your search to narrow results.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface ArtifactSearchResultRowProps {
+  readonly optionId: string;
+  readonly hit: SearchArtifactHit;
+  readonly active: boolean;
+  readonly stale: boolean;
+  readonly onActivate: (hit: SearchArtifactHit) => void;
+  readonly onHover: () => void;
+}
+
+const ArtifactSearchResultRow = memo(function ArtifactSearchResultRow(
+  props: ArtifactSearchResultRowProps,
+) {
+  const { hit, active, stale, onActivate, onHover } = props;
+  const Icon = isEpicArtifactKind(hit.kind)
+    ? EPIC_NODE_ICONS[hit.kind]
+    : FileText;
+  const title = displayTitle(hit.title, hit.kind);
+  // The RPC breadcrumb includes the artifact's own folder slug last; drop it so
+  // only the ancestor trail shows (the title already names the artifact). These
+  // are folder slugs relative to the artifact root - never host-absolute paths.
+  const ancestors = hit.breadcrumb.slice(0, -1);
+  const showStatusDot =
+    hit.status !== null && Object.hasOwn(STATUS_DOT_CLASSES, hit.status);
+
+  return (
+    <li
+      id={props.optionId}
+      role="option"
+      aria-selected={active}
+      aria-disabled={stale}
+      className={cn(
+        "cursor-pointer rounded-md px-2 py-1.5 outline-none",
+        active ? "bg-accent" : "hover:bg-accent/50",
+        stale && "opacity-60",
+      )}
+      onMouseEnter={onHover}
+      onClick={() => onActivate(hit)}
+      onKeyDown={(event) => {
+        // The combobox input owns navigation; this only matters if a row ever
+        // receives direct focus (satisfies the click/key-parity a11y rule).
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onActivate(hit);
+        }
+      }}
+      data-testid={`epic-artifact-search-result-${hit.artifactId}`}
+    >
+      <div className="flex min-w-0 items-center gap-1.5">
+        {showStatusDot && hit.status !== null ? (
+          <span
+            className={cn(
+              "size-2 shrink-0 rounded-full",
+              STATUS_DOT_CLASSES[hit.status],
+            )}
+            aria-label={STATUS_LABELS[hit.status]}
+          />
+        ) : null}
+        <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
+          {title}
+        </span>
+      </div>
+      {ancestors.length > 0 ? (
+        <p className="truncate pl-5 text-ui-xs text-muted-foreground/70">
+          {ancestors.join(" › ")}
+        </p>
+      ) : null}
+      {stale ? (
+        <p className="pl-5 text-ui-xs text-destructive">
+          This artifact no longer exists.
+        </p>
+      ) : (
+        <ArtifactSnippetList hit={hit} />
+      )}
+    </li>
+  );
+});
+
+function ArtifactSnippetList(props: { readonly hit: SearchArtifactHit }) {
+  if (props.hit.snippets.length === 0) return null;
+  return (
+    <div className="space-y-0.5 pl-5 pt-0.5">
+      {props.hit.snippets.map((snippet) => (
+        <ArtifactSnippetLine
+          key={`${snippet.lineNumber}:${snippet.text}`}
+          text={snippet.text}
+          ranges={snippet.ranges}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ArtifactSnippetLine(props: {
+  readonly text: string;
+  readonly ranges: ReadonlyArray<SnippetByteRange>;
+}) {
+  const segments = useMemo(
+    () => highlightSegmentsFromByteRanges(props.text, props.ranges),
+    [props.text, props.ranges],
+  );
+  return (
+    <p className="truncate text-ui-xs text-muted-foreground">
+      {segments.map((segment) =>
+        segment.highlighted ? (
+          <mark
+            key={segment.start}
+            className="rounded-sm bg-primary/20 text-foreground"
+          >
+            {segment.text}
+          </mark>
+        ) : (
+          <span key={segment.start}>{segment.text}</span>
+        ),
+      )}
+    </p>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-artifact-tree.tsx
@@ -32,6 +32,7 @@ import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus
 import { useEpicExportArtifacts } from "@/hooks/epic/use-epic-export-artifacts-mutation";
 import { cn } from "@/lib/utils";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { ArtifactPanelSearchShell } from "@/components/epic-canvas/sidebar/epic-sidebar-artifact-search";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
@@ -41,11 +42,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ContextMenuContent } from "@/components/ui/context-menu";
-import {
-  SidebarContent,
-  SidebarGroup,
-  SidebarGroupContent,
-} from "@/components/ui/sidebar";
+import { SidebarGroup, SidebarGroupContent } from "@/components/ui/sidebar";
 import { TreeChevron, TreeChevronSpacer } from "@/components/ui/tree-chevron";
 import {
   Tooltip,
@@ -601,13 +598,13 @@ export function ArtifactTreePanelBody(props: ArtifactTreePanelBodyProps) {
   return (
     <SidebarSortContext.Provider value={comparator}>
       <SidebarFilterVisibilityContext.Provider value={visibleIds}>
-        <SidebarContent className="gap-0">
+        <ArtifactPanelSearchShell epicId={epicId} tabId={tabId}>
           <SidebarGroup className="min-h-0 flex-1 px-2 py-1">
             <SidebarGroupContent className="flex min-h-0 flex-1 flex-col">
               {panelContent}
             </SidebarGroupContent>
           </SidebarGroup>
-        </SidebarContent>
+        </ArtifactPanelSearchShell>
       </SidebarFilterVisibilityContext.Provider>
     </SidebarSortContext.Provider>
   );

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-header.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-header.tsx
@@ -11,7 +11,7 @@ import {
 import { type LeftPanelDefinition } from "@/components/epic-canvas/sidebar/epic-sidebar";
 import { Button } from "@/components/ui/button";
 import { ChevronRight } from "lucide-react";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import {
   useEpicLeftPanelStore,
@@ -37,9 +37,13 @@ interface PanelGroupSectionHeaderProps {
 function PanelHeaderSearchRow(props: { readonly panel: LeftPanelDefinition }) {
   const setSearchSlot = usePanelHeaderSearchStore((s) => s.setSearchSlot);
   const panelId = props.panel.id;
+  const setSlotRef = useCallback(
+    (element: HTMLDivElement | null) => setSearchSlot(panelId, element),
+    [panelId, setSearchSlot],
+  );
   return (
     <div
-      ref={(element) => setSearchSlot(panelId, element)}
+      ref={setSlotRef}
       className="flex h-9 shrink-0 items-center px-2"
       data-testid={`epic-sidebar-header-search-slot-${panelId}`}
     />

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-header.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-header.tsx
@@ -17,11 +17,33 @@ import {
   useEpicLeftPanelStore,
   useLeftPanelSectionCollapsed,
 } from "@/stores/epics/left-panel-store";
+import {
+  usePanelHeaderSearchOpen,
+  usePanelHeaderSearchStore,
+} from "@/stores/epics/panel-header-search-store";
 
 interface PanelGroupSectionHeaderProps {
   readonly epicId: string;
   readonly tabId: string;
   readonly panel: LeftPanelDefinition;
+}
+
+/**
+ * Portal target for an opted-in panel's search input. Rendered INSTEAD of the
+ * standard header row (same `h-9`, so the body below never shifts), and left
+ * empty here: the owning panel portals its own input in, keeping that input's
+ * state, refs, and combobox ARIA wiring in a single component.
+ */
+function PanelHeaderSearchRow(props: { readonly panel: LeftPanelDefinition }) {
+  const setSearchSlot = usePanelHeaderSearchStore((s) => s.setSearchSlot);
+  const panelId = props.panel.id;
+  return (
+    <div
+      ref={(element) => setSearchSlot(panelId, element)}
+      className="flex h-9 shrink-0 items-center px-2"
+      data-testid={`epic-sidebar-header-search-slot-${panelId}`}
+    />
+  );
 }
 
 export function PanelGroupSectionHeader(props: PanelGroupSectionHeaderProps) {
@@ -48,6 +70,17 @@ export function PanelGroupSectionHeader(props: PanelGroupSectionHeaderProps) {
     id: getLeftPanelSectionDragId(props.panel.id),
     data: dragData,
   });
+  const searchOpen = usePanelHeaderSearchOpen(props.panel.id);
+  // Search mode takes the whole row rather than adding one below it, so the
+  // list keeps its vertical position and the panel spends no resting space on
+  // a mode that is off most of the time.
+  //
+  // Never while collapsed: the body - and with it the component that portals
+  // the input in - is unmounted, so swapping would leave an empty row with no
+  // input, no chevron, and no way back out.
+  if (props.panel.supportsHeaderSearch && searchOpen && !collapsed) {
+    return <PanelHeaderSearchRow panel={props.panel} />;
+  }
   return (
     <div
       ref={dragRef}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -57,6 +57,7 @@ import {
 import type {
   WorkspaceFileTreeNode,
   WorkspaceSearchPathResult,
+  WorkspaceSearchPathsResponse,
 } from "@traycer/protocol/host/workspace/unary-schemas";
 import { extractPierreItemPathFromEvent } from "@/components/epic-canvas/pierre-tree-adapter";
 import { type GitStatusEntry } from "@pierre/trees";
@@ -1103,6 +1104,23 @@ function FileTreePanelBodyLive(props: LeftPanelBodyProps) {
   );
 }
 
+function readyWorkspacePathSearchData(
+  response: WorkspaceSearchPathsResponse | undefined,
+  epicId: string,
+  root: string,
+) {
+  if (
+    response === undefined ||
+    !("root" in response) ||
+    response.epicId !== epicId ||
+    response.root !== root ||
+    response.outcome !== "ready"
+  ) {
+    return null;
+  }
+  return response;
+}
+
 function FileTreePanelBodyForWorkspace(props: {
   readonly epicId: string;
   readonly tabId: string;
@@ -1152,15 +1170,13 @@ function FileTreePanelBodyForWorkspace(props: {
   // (unattached/moved/escaped/cross-host) is treated as "not ready", so the
   // panel keeps the browse tree + local filter instead of showing an empty
   // search that looks like "no matches".
-  const searchData =
-    searchActive &&
-    searchPathsQuery.data !== undefined &&
-    "root" in searchPathsQuery.data &&
-    searchPathsQuery.data.epicId === props.epicId &&
-    searchPathsQuery.data.root === props.workspacePath &&
-    searchPathsQuery.data.outcome === "ready"
-      ? searchPathsQuery.data
-      : null;
+  const searchData = searchActive
+    ? readyWorkspacePathSearchData(
+        searchPathsQuery.data,
+        props.epicId,
+        props.workspacePath,
+      )
+    : null;
   const searchResultFiles = useMemo(
     () =>
       searchData === null

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -1206,11 +1206,12 @@ function FileTreePanelBodyForWorkspace(props: {
   // still resolves to an openable ref.
   const nameByTreePath = useMemo(() => {
     if (!rpcResultsReady) return browseNameByTreePath;
-    const merged = new Map(browseNameByTreePath);
-    for (const result of searchResultFiles) {
-      merged.set(result.relPath, result.name);
-    }
-    return merged;
+    return new Map([
+      ...browseNameByTreePath,
+      ...searchResultFiles.map(
+        (result) => [result.relPath, result.name] as const,
+      ),
+    ]);
   }, [rpcResultsReady, browseNameByTreePath, searchResultFiles]);
 
   const navigateNested = useEpicNestedFocusNavigation();

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -41,9 +41,12 @@ import { WorkspacePickerWithOpener } from "@/components/worktree/workspace-picke
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { PIERRE_FILE_TREE_THEME_STYLE } from "@/components/epic-canvas/pierre-tree-theme";
 import { useWorkspaceListFileTree } from "@/hooks/workspace/use-list-file-tree-query";
+import { useWorkspaceSearchPaths } from "@/hooks/workspace/use-workspace-search-paths-query";
 import { useWorktreeListBindingsForEpic } from "@/hooks/worktree/use-worktree-list-bindings-for-epic-query";
 import { isBrowsable } from "@/lib/worktree/worktree-row-browsable";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useHostClient } from "@/lib/host";
+import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
 import { requestArtifactEditorFocus } from "@/lib/artifacts/pending-editor-focus";
 import { openProjectedSidebarNodeInTabWhenAvailable } from "@/components/epic-canvas/sidebar/open-projected-sidebar-node";
 import { workspaceFileRefFromTreePath } from "@/components/epic-canvas/workspace-file/workspace-file-ref";
@@ -51,7 +54,10 @@ import {
   type EpicNodeRef,
   type WorkspaceFileRef,
 } from "@/stores/epics/canvas/types";
-import type { WorkspaceFileTreeNode } from "@traycer/protocol/host/workspace/unary-schemas";
+import type {
+  WorkspaceFileTreeNode,
+  WorkspaceSearchPathResult,
+} from "@traycer/protocol/host/workspace/unary-schemas";
 import { extractPierreItemPathFromEvent } from "@/components/epic-canvas/pierre-tree-adapter";
 import { type GitStatusEntry } from "@pierre/trees";
 import {
@@ -151,6 +157,8 @@ import {
   useArtifactReadStateStore,
 } from "@/stores/epics/artifact-read-state-store";
 import { revealCommentThreadAnchor } from "@/lib/comments/comment-editor-registry";
+import { useArtifactSearchAvailable } from "@/components/epic-canvas/sidebar/artifact-search-availability";
+import { usePanelHeaderSearchStore } from "@/stores/epics/panel-header-search-store";
 import { cn } from "@/lib/utils";
 import {
   CheckCheck,
@@ -208,6 +216,8 @@ import { useShallow } from "zustand/react/shallow";
 const EMPTY_FILE_TREE_FILES: ReadonlyArray<WorkspaceFileTreeNode> =
   Object.freeze([]);
 const EMPTY_GIT_STATUS: ReadonlyArray<GitStatusEntry> = Object.freeze([]);
+const EMPTY_SEARCH_PATH_RESULTS: ReadonlyArray<WorkspaceSearchPathResult> =
+  Object.freeze([]);
 
 interface ArtifactReadTarget {
   readonly id: string;
@@ -1103,21 +1113,89 @@ function FileTreePanelBodyForWorkspace(props: {
   // resolving against the same host after a default-host swap or
   // reload (CLAUDE.md: tabs are bound to a host for life).
   const activeHostId = useReactiveActiveHostId();
+  const hostClient = useHostClient();
   const query = useWorkspaceListFileTree(props.workspacePath);
   const files = query.data?.files ?? EMPTY_FILE_TREE_FILES;
   const gitStatus = query.data?.gitStatus ?? EMPTY_GIT_STATUS;
 
   // The host's `files` list is the source of truth for "what is an
-  // openable file and what is its display name". `treePaths` feeds
-  // Pierre (which builds the visual tree, synthesizing directory rows);
-  // `nameByTreePath` lets handlers resolve a clicked path to a file name
+  // openable file and what is its display name" while browsing. `treePaths`
+  // feeds Pierre (which builds the visual tree, synthesizing directory rows);
+  // `browseNameByTreePath` lets handlers resolve a clicked path to a file name
   // without parsing the path string, and a path absent from the map is
   // a directory row and not openable.
   const treePaths = useMemo(() => files.map((file) => file.path), [files]);
-  const nameByTreePath = useMemo(
+  const browseNameByTreePath = useMemo(
     () => new Map(files.map((file) => [file.path, file.name])),
     [files],
   );
+
+  // Active-query search is host-owned: instead of scanning the full tree in the
+  // renderer, we ask `workspace.searchPaths` (scoped to this Epic + workspace)
+  // for host-ranked file matches. Browsing (empty query) keeps the local tree.
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(searchQuery, 200);
+  const searchActive = debouncedQuery.trim().length > 0;
+  const searchPathsQuery = useWorkspaceSearchPaths({
+    client: hostClient,
+    epicId: props.epicId,
+    root: props.workspacePath,
+    query: debouncedQuery,
+    // The panel finds files to open; matched files still reveal their ancestor
+    // folders in the tree. Folder-name matches are a mention-picker concern.
+    kinds: "files",
+    enabled: searchActive,
+  });
+  // Trust the response only when its echoed Epic+root still match the current
+  // selection (so a late reply from a previous workspace never renders here)
+  // AND the host actually searched the root. A `root_unavailable` outcome
+  // (unattached/moved/escaped/cross-host) is treated as "not ready", so the
+  // panel keeps the browse tree + local filter instead of showing an empty
+  // search that looks like "no matches".
+  const searchData =
+    searchActive &&
+    searchPathsQuery.data !== undefined &&
+    "root" in searchPathsQuery.data &&
+    searchPathsQuery.data.epicId === props.epicId &&
+    searchPathsQuery.data.root === props.workspacePath &&
+    searchPathsQuery.data.outcome === "ready"
+      ? searchPathsQuery.data
+      : null;
+  const searchResultFiles = useMemo(
+    () =>
+      searchData === null
+        ? EMPTY_SEARCH_PATH_RESULTS
+        : searchData.results.filter((result) => result.kind === "file"),
+    [searchData],
+  );
+  const rpcResultsReady = searchData !== null;
+
+  // Paths Pierre renders: the ranked host results once a search resolves, else
+  // the full browse tree. The local `hide-non-matches` filter runs only as a
+  // fallback - while the host result is still in flight, or on an old host that
+  // does not support the RPC - so the user gets instant client-side filtering
+  // that the host result silently replaces when it lands.
+  const effectivePaths = useMemo(
+    () =>
+      rpcResultsReady
+        ? searchResultFiles.map((result) => result.relPath)
+        : treePaths,
+    [rpcResultsReady, searchResultFiles, treePaths],
+  );
+  const effectiveSearch =
+    searchActive && !rpcResultsReady ? debouncedQuery : null;
+
+  // Result names come from the RPC (host-computed basename), merged over the
+  // browse map so a matched file the git-based browse listing did not enumerate
+  // still resolves to an openable ref.
+  const nameByTreePath = useMemo(() => {
+    if (!rpcResultsReady) return browseNameByTreePath;
+    const merged = new Map(browseNameByTreePath);
+    for (const result of searchResultFiles) {
+      merged.set(result.relPath, result.name);
+    }
+    return merged;
+  }, [rpcResultsReady, browseNameByTreePath, searchResultFiles]);
 
   const navigateNested = useEpicNestedFocusNavigation();
   const prepareOpenTilePreviewInTabFocusTarget = useEpicCanvasStore(
@@ -1193,41 +1271,23 @@ function FileTreePanelBodyForWorkspace(props: {
       handlersRef.current.onSelect(selectedPath);
     },
   });
-  const [searchQuery, setSearchQuery] = useState("");
-  const searchDebounceTimerRef = useRef<number | null>(null);
-  const clearPendingSearchDebounce = useCallback(() => {
-    if (searchDebounceTimerRef.current === null) return;
-    window.clearTimeout(searchDebounceTimerRef.current);
-    searchDebounceTimerRef.current = null;
-  }, []);
-  const applySearchQuery = useCallback(
-    (query: string) => {
-      model.setSearch(query.length > 0 ? query : null);
-      model.setGitStatus(gitStatus);
-    },
-    [model, gitStatus],
-  );
   const handleSearchQueryChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      const nextQuery = event.target.value;
-      setSearchQuery(nextQuery);
-      clearPendingSearchDebounce();
-      searchDebounceTimerRef.current = window.setTimeout(() => {
-        searchDebounceTimerRef.current = null;
-        applySearchQuery(nextQuery);
-      }, 150);
+      setSearchQuery(event.target.value);
     },
-    [applySearchQuery, clearPendingSearchDebounce],
+    [],
   );
 
-  useEffect(() => clearPendingSearchDebounce, [clearPendingSearchDebounce]);
-
-  // Paths and git status arrive from the host RPC asynchronously; push
-  // them into Pierre's imperative model whenever the query result
-  // changes. Pierre dedupes its own work on stable inputs.
+  // Push the derived paths, search filter, and git status into Pierre's
+  // imperative model. `effectivePaths` is the ranked host results while a
+  // search is resolved, else the browse tree; `effectiveSearch` applies the
+  // local filter only in the fallback window. Pierre dedupes on stable inputs.
   useEffect(() => {
-    model.resetPaths(treePaths);
-  }, [model, treePaths]);
+    model.resetPaths(effectivePaths);
+  }, [model, effectivePaths]);
+  useEffect(() => {
+    model.setSearch(effectiveSearch);
+  }, [model, effectiveSearch]);
   useEffect(() => {
     model.setGitStatus(gitStatus);
   }, [model, gitStatus]);
@@ -1949,11 +2009,41 @@ function MarkAllArtifactsReadButton(props: {
   );
 }
 
+/**
+ * Enters artifact search mode. Only rendered once the Epic holds enough
+ * artifacts for filtering to beat scanning - below that the header carries no
+ * search affordance at all.
+ */
+function ArtifactSearchButton(props: { readonly collapsed: boolean }) {
+  const available = useArtifactSearchAvailable();
+  const openSearch = usePanelHeaderSearchStore((s) => s.openSearch);
+  if (!available) return null;
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      onClick={() => openSearch("artifacts", "")}
+      aria-label="Search artifacts"
+      title="Search artifacts"
+      data-testid="epic-sidebar-search-artifacts"
+      disabled={props.collapsed}
+      className={cn(
+        "text-muted-foreground hover:text-foreground",
+        PANEL_HEADER_ACTION_REVEAL_CLASS,
+      )}
+    >
+      <Search className="size-4" />
+    </Button>
+  );
+}
+
 function ArtifactsPanelActions(props: LeftPanelHeaderSlotProps) {
   const selection = useSidebarBulkSelection();
   if (selection.selectionMode) return <SidebarBulkSelectionActions />;
   return (
     <div className="flex items-center gap-0.5">
+      <ArtifactSearchButton collapsed={props.collapsed} />
       <ArtifactFilterMenu epicId={props.epicId} disabled={props.collapsed} />
       <MarkAllArtifactsReadButton
         epicId={props.epicId}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/left-panel-registry.ts
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/left-panel-registry.ts
@@ -26,6 +26,12 @@ export interface LeftPanelMetadataDefinition {
   readonly title: string;
   readonly icon: LucideIcon;
   readonly isVisible: (context: LeftPanelAvailabilityContext) => boolean;
+  /**
+   * Whether this panel's header row can be traded for a search input while
+   * searching (see `panel-header-search-store`). Panels that opt out never
+   * render the portal target, so their header is always the standard row.
+   */
+  readonly supportsHeaderSearch: boolean;
 }
 
 export const LEFT_PANEL_DEFINITIONS: ReadonlyArray<LeftPanelMetadataDefinition> =
@@ -38,36 +44,42 @@ export const LEFT_PANEL_DEFINITIONS: ReadonlyArray<LeftPanelMetadataDefinition> 
       title: "Agents",
       icon: MessagesSquare,
       isVisible: () => true,
+      supportsHeaderSearch: false,
     },
     {
       id: "terminals",
       title: "Terminals",
       icon: Terminal,
       isVisible: () => true,
+      supportsHeaderSearch: false,
     },
     {
       id: "artifacts",
       title: "Artifacts",
       icon: Files,
       isVisible: () => true,
+      supportsHeaderSearch: true,
     },
     {
       id: "git-diff",
       title: "Git Diff",
       icon: GitBranch,
       isVisible: () => true,
+      supportsHeaderSearch: false,
     },
     {
       id: "file-tree",
       title: "File Tree",
       icon: FolderTree,
       isVisible: () => true,
+      supportsHeaderSearch: false,
     },
     {
       id: "sharing",
       title: "Sharing",
       icon: UserPlus,
       isVisible: () => true,
+      supportsHeaderSearch: false,
     },
     {
       id: "comments",
@@ -75,5 +87,6 @@ export const LEFT_PANEL_DEFINITIONS: ReadonlyArray<LeftPanelMetadataDefinition> 
       icon: MessageSquareText,
       isVisible: (context) =>
         context.commentsPanelRevealed && context.hasActiveCommentableArtifact,
+      supportsHeaderSearch: false,
     },
   ];

--- a/clients/gui-app/src/hooks/composer/__tests__/use-workspace-entries.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-workspace-entries.test.tsx
@@ -121,4 +121,224 @@ describe("useWorkspaceEntries", () => {
 
     expect(messenger.calls).toHaveLength(0);
   });
+
+  function fileSearchRequest() {
+    return {
+      method: "workspace.searchPaths" as const,
+      suggestionKind: "file" as const,
+      root: "/repo",
+      params: {
+        epicId: "epic-1",
+        reference: { root: "/repo" },
+        query: "app",
+        limit: 50,
+        kinds: "files" as const,
+      },
+    };
+  }
+
+  it("reconstructs scoped searchPaths results into mention suggestions", async () => {
+    messenger.setHandlers({
+      "workspace.searchPaths": (params) => ({
+        epicId: params.epicId,
+        root: "root" in params.reference ? params.reference.root : "",
+        outcome: "ready",
+        results: [{ kind: "file", relPath: "src/app.ts", name: "app.ts" }],
+        truncated: false,
+      }),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWorkspaceEntries({
+          client: hostClient,
+          requests: [fileSearchRequest()],
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+    expect(result.current.data[0]).toMatchObject({
+      kind: "file",
+      relPath: "src/app.ts",
+      absolutePath: "/repo/src/app.ts",
+      workspacePath: "/repo",
+    });
+    // The scoped RPC was used - not the legacy raw-root one.
+    expect(messenger.calls.map((call) => call.method)).toEqual([
+      "workspace.searchPaths",
+    ]);
+  });
+
+  it("reconstructs a folders-only scoped result into folder suggestions", async () => {
+    messenger.setHandlers({
+      "workspace.searchPaths": (params) => ({
+        epicId: params.epicId,
+        root: "root" in params.reference ? params.reference.root : "",
+        outcome: "ready",
+        results: [{ kind: "folder", relPath: "src/lib", name: "lib" }],
+        truncated: false,
+      }),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWorkspaceEntries({
+          client: hostClient,
+          requests: [
+            {
+              method: "workspace.searchPaths",
+              suggestionKind: "folder",
+              root: "/repo",
+              params: {
+                epicId: "epic-1",
+                reference: { root: "/repo" },
+                query: "lib",
+                limit: 50,
+                kinds: "folders",
+              },
+            },
+          ],
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+    expect(result.current.data[0]).toMatchObject({
+      kind: "folder",
+      relPath: "src/lib/",
+      absolutePath: "/repo/src/lib",
+      workspacePath: "/repo",
+    });
+  });
+
+  it("falls back to the legacy RPC when a scoped request errors", async () => {
+    messenger.setHandlers({
+      "workspace.searchPaths": () => {
+        throw new Error("host does not support searchPaths");
+      },
+      "workspace.mentionFiles": () => ({
+        entries: [legacyFileSuggestion()],
+      }),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWorkspaceEntries({
+          client: hostClient,
+          requests: [fileSearchRequest()],
+        }),
+      { wrapper },
+    );
+
+    // The scoped failure is recovered by a legacy fallback for the same root,
+    // so the suggestion never disappears and no error surfaces.
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+    expect(result.current.error).toBeNull();
+    expect(messenger.calls.map((call) => call.method)).toContain(
+      "workspace.mentionFiles",
+    );
+  });
+
+  it("falls back to the legacy RPC on a typed root_unavailable outcome", async () => {
+    messenger.setHandlers({
+      "workspace.searchPaths": (params) => ({
+        epicId: params.epicId,
+        root: "root" in params.reference ? params.reference.root : "",
+        outcome: "root_unavailable",
+        results: [],
+        truncated: false,
+      }),
+      "workspace.mentionFiles": () => ({
+        entries: [legacyFileSuggestion()],
+      }),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWorkspaceEntries({
+          client: hostClient,
+          requests: [fileSearchRequest()],
+        }),
+      { wrapper },
+    );
+
+    // A rejected root is observably distinct from a match-less search: it routes
+    // through the legacy RPC rather than dropping the root's suggestions.
+    await waitFor(() =>
+      expect(messenger.calls.map((call) => call.method)).toContain(
+        "workspace.mentionFiles",
+      ),
+    );
+    await waitFor(() => expect(result.current.data).toHaveLength(1));
+  });
+
+  it("does NOT fall back on a ready outcome with zero matches", async () => {
+    messenger.setHandlers({
+      "workspace.searchPaths": (params) => ({
+        epicId: params.epicId,
+        root: "root" in params.reference ? params.reference.root : "",
+        outcome: "ready",
+        results: [],
+        truncated: false,
+      }),
+      "workspace.mentionFiles": () => ({
+        entries: [legacyFileSuggestion()],
+      }),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWorkspaceEntries({
+          client: hostClient,
+          requests: [fileSearchRequest()],
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    // Ready + empty means "searched, nothing matched" - no legacy fallback and
+    // no suggestions.
+    expect(result.current.data).toHaveLength(0);
+    expect(messenger.calls.map((call) => call.method)).toEqual([
+      "workspace.searchPaths",
+    ]);
+  });
+
+  it("drops a late scoped reply whose echoed root no longer matches", async () => {
+    messenger.setHandlers({
+      "workspace.searchPaths": (params) => ({
+        epicId: params.epicId,
+        // A stale reply for a previously-selected workspace.
+        root: "/some/other/workspace",
+        outcome: "ready",
+        results: [{ kind: "file", relPath: "x.ts", name: "x.ts" }],
+        truncated: false,
+      }),
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWorkspaceEntries({
+          client: hostClient,
+          requests: [fileSearchRequest()],
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.data).toHaveLength(0);
+  });
 });
+
+function legacyFileSuggestion() {
+  return {
+    kind: "file" as const,
+    id: "file:/repo:src/app.ts",
+    label: "app.ts",
+    relPath: "src/app.ts",
+    absolutePath: "/repo/src/app.ts",
+    workspacePath: "/repo",
+    description: "src",
+  };
+}

--- a/clients/gui-app/src/hooks/composer/__tests__/use-workspace-entries.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-workspace-entries.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
@@ -56,6 +56,19 @@ function wrapper(props: { children: ReactNode }) {
     <QueryClientProvider client={queryClient}>
       {props.children}
     </QueryClientProvider>
+  );
+}
+
+function isScopedSearchForEpic(
+  call: { readonly method: string; readonly params: unknown },
+  epicId: string,
+) {
+  return (
+    call.method === "workspace.searchPaths" &&
+    typeof call.params === "object" &&
+    call.params !== null &&
+    "epicId" in call.params &&
+    call.params.epicId === epicId
   );
 }
 
@@ -130,6 +143,21 @@ describe("useWorkspaceEntries", () => {
       params: {
         epicId: "epic-1",
         reference: { root: "/repo" },
+        query: "app",
+        limit: 50,
+        kinds: "files" as const,
+      },
+    };
+  }
+
+  function scopedFileSearchRequest(root: string, epicId: string) {
+    return {
+      method: "workspace.searchPaths" as const,
+      suggestionKind: "file" as const,
+      root,
+      params: {
+        epicId,
+        reference: { root },
         query: "app",
         limit: 50,
         kinds: "files" as const,
@@ -328,6 +356,72 @@ describe("useWorkspaceEntries", () => {
 
     await waitFor(() => expect(result.current.isFetching).toBe(false));
     expect(result.current.data).toHaveLength(0);
+  });
+
+  it("does not reuse a pending root's placeholder state after the request slot changes", async () => {
+    let resolveFirst: (() => void) | null = null;
+    messenger.setHandlers({
+      "workspace.searchPaths": (params) => {
+        if ("root" in params.reference && params.reference.root === "/repo-a") {
+          return new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }).then(() => ({
+            epicId: params.epicId,
+            root: "/repo-a",
+            outcome: "root_unavailable" as const,
+            results: [],
+            truncated: false,
+          }));
+        }
+        return {
+          epicId: params.epicId,
+          root: "root" in params.reference ? params.reference.root : "",
+          outcome: "ready" as const,
+          results: [],
+          truncated: false,
+        };
+      },
+      "workspace.mentionFiles": () => ({ entries: [legacyFileSuggestion()] }),
+    });
+
+    const { result, rerender } = renderHook(
+      ({ request }) =>
+        useWorkspaceEntries({ client: hostClient, requests: [request] }),
+      {
+        initialProps: {
+          request: scopedFileSearchRequest("/repo-a", "epic-a"),
+        },
+        wrapper,
+      },
+    );
+
+    await waitFor(() =>
+      expect(
+        messenger.calls.some((call) => isScopedSearchForEpic(call, "epic-a")),
+      ).toBe(true),
+    );
+
+    rerender({ request: scopedFileSearchRequest("/repo-b", "epic-b") });
+
+    await waitFor(() =>
+      expect(
+        messenger.calls.some((call) => isScopedSearchForEpic(call, "epic-b")),
+      ).toBe(true),
+    );
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.data).toHaveLength(0);
+    expect(messenger.calls.map((call) => call.method)).not.toContain(
+      "workspace.mentionFiles",
+    );
+
+    act(() => {
+      resolveFirst?.();
+    });
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.data).toHaveLength(0);
+    expect(messenger.calls.map((call) => call.method)).not.toContain(
+      "workspace.mentionFiles",
+    );
   });
 });
 

--- a/clients/gui-app/src/hooks/composer/__tests__/use-workspace-entries.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-workspace-entries.test.tsx
@@ -423,6 +423,78 @@ describe("useWorkspaceEntries", () => {
       "workspace.mentionFiles",
     );
   });
+
+  it("does not fall back for a previous root_unavailable reply after the request slot changes", async () => {
+    let resolveSecond: (() => void) | null = null;
+    messenger.setHandlers({
+      "workspace.searchPaths": (params) => {
+        if ("root" in params.reference && params.reference.root === "/repo-a") {
+          return {
+            epicId: params.epicId,
+            root: "/repo-a",
+            outcome: "root_unavailable" as const,
+            results: [],
+            truncated: false,
+          };
+        }
+        return new Promise<void>((resolve) => {
+          resolveSecond = resolve;
+        }).then(() => ({
+          epicId: params.epicId,
+          root: "/repo-b",
+          outcome: "ready" as const,
+          results: [],
+          truncated: false,
+        }));
+      },
+      "workspace.mentionFiles": () => ({ entries: [legacyFileSuggestion()] }),
+    });
+
+    const { result, rerender } = renderHook(
+      ({ request }) =>
+        useWorkspaceEntries({ client: hostClient, requests: [request] }),
+      {
+        initialProps: {
+          request: scopedFileSearchRequest("/repo-a", "epic-a"),
+        },
+        wrapper,
+      },
+    );
+
+    await waitFor(() =>
+      expect(messenger.calls.map((call) => call.method)).toContain(
+        "workspace.mentionFiles",
+      ),
+    );
+    const legacyCallCount = messenger.calls.filter(
+      (call) => call.method === "workspace.mentionFiles",
+    ).length;
+
+    rerender({ request: scopedFileSearchRequest("/repo-b", "epic-b") });
+
+    await waitFor(() =>
+      expect(
+        messenger.calls.some((call) => isScopedSearchForEpic(call, "epic-b")),
+      ).toBe(true),
+    );
+    expect(
+      messenger.calls.filter(
+        (call) => call.method === "workspace.mentionFiles",
+      ),
+    ).toHaveLength(legacyCallCount);
+    expect(result.current.data).toHaveLength(0);
+
+    act(() => {
+      resolveSecond?.();
+    });
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.data).toHaveLength(0);
+    expect(
+      messenger.calls.filter(
+        (call) => call.method === "workspace.mentionFiles",
+      ),
+    ).toHaveLength(legacyCallCount);
+  });
 });
 
 function legacyFileSuggestion() {

--- a/clients/gui-app/src/hooks/composer/use-workspace-entries.ts
+++ b/clients/gui-app/src/hooks/composer/use-workspace-entries.ts
@@ -1,13 +1,20 @@
+import { useMemo } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import type { WorkspaceMentionSuggestion } from "@traycer/protocol/host/index";
 import type { HostRpcRegistry } from "@/lib/host";
 import { useHostQueries } from "@/hooks/host/use-host-queries";
+import type { HostRequestSpec } from "@/hooks/host/use-host-queries";
 import type {
+  MentionSearchPathsRequest,
   MentionWorkspaceRequest,
   WorkspaceMentionMethod,
 } from "@/lib/composer/mentions";
+import {
+  fileSuggestionFromSearchResult,
+  folderSuggestionFromSearchResult,
+} from "@/lib/composer/mentions/search-path-suggestions";
 
 export interface UseWorkspaceEntriesParams {
   readonly requests: ReadonlyArray<MentionWorkspaceRequest>;
@@ -21,21 +28,145 @@ export interface UseWorkspaceEntriesResult {
   error: HostRpcError | null;
 }
 
+// The legacy raw-root fallback re-request for a scoped root whose
+// `workspace.searchPaths` query errored (e.g. an old host that predates the
+// method): a small cap keeps the fallback cheap - it only exists so a scoped
+// failure never drops that root's suggestions.
+const SEARCH_PATHS_FALLBACK_LIMIT = 25;
+
+type LegacyMentionRequest = Exclude<
+  MentionWorkspaceRequest,
+  MentionSearchPathsRequest
+>;
+
+/**
+ * Executes the file/folder/git mention requests. Legacy raw-root requests run
+ * as before; scoped `workspace.searchPaths` requests (emitted only for
+ * Epic-attached roots) run separately and their host-ranked results are
+ * reconstructed into the same mention-suggestion shape. If a scoped request
+ * errors, that root is re-issued through the legacy RPC so scoping never makes
+ * a suggestion disappear.
+ */
 export function useWorkspaceEntries(
   params: UseWorkspaceEntriesParams,
 ): UseWorkspaceEntriesResult {
-  const queries = useHostQueries<HostRpcRegistry, WorkspaceMentionMethod>({
+  const legacyRequests = useMemo(
+    () => params.requests.filter(isLegacyRequest),
+    [params.requests],
+  );
+  const searchRequests = useMemo(
+    () => params.requests.filter(isSearchPathsRequest),
+    [params.requests],
+  );
+
+  const searchQueries = useHostQueries<HostRpcRegistry, "workspace.searchPaths">(
+    {
+      client: params.client,
+      cacheKeyIdentity: undefined,
+      requests: useMemo(
+        () =>
+          searchRequests.map((request) => ({
+            method: request.method,
+            params: request.params,
+          })),
+        [searchRequests],
+      ),
+      options: { staleTime: 30_000, placeholderData: keepPreviousData },
+    },
+  );
+
+  // Fall back to the legacy RPC for any scoped root the host could not search:
+  // a query error (e.g. an old host that lacks `workspace.searchPaths`, or a
+  // transient failure) OR a typed `root_unavailable` outcome (the root is no
+  // longer authorized/attached/resolvable). Both keep the existing behavior
+  // instead of silently dropping that root's suggestions; a `ready` outcome
+  // (even with zero matches) does NOT fall back.
+  const fallbackRequests = useMemo(
+    () =>
+      searchRequests.flatMap((request, index) => {
+        const query = searchQueries[index];
+        const unavailable =
+          query.isError || query.data?.outcome === "root_unavailable";
+        return unavailable ? [fallbackLegacyRequest(request)] : [];
+      }),
+    [searchRequests, searchQueries],
+  );
+
+  const legacyQueries = useHostQueries<HostRpcRegistry, WorkspaceMentionMethod>({
     client: params.client,
     cacheKeyIdentity: undefined,
-    requests: params.requests,
+    requests: useMemo(
+      () => [...legacyRequests, ...fallbackRequests],
+      [legacyRequests, fallbackRequests],
+    ),
     options: { staleTime: 30_000, placeholderData: keepPreviousData },
   });
 
+  const legacyData = legacyQueries.flatMap((query) => query.data?.entries ?? EMPTY);
+  const searchData = searchRequests.flatMap((request, index) => {
+    const data = searchQueries[index]?.data;
+    if (data === undefined) return EMPTY;
+    // A `root_unavailable` outcome contributes nothing here - the legacy
+    // fallback above already re-issued that root - so only `ready` data maps.
+    if (data.outcome !== "ready") return EMPTY;
+    // Drop a late reply that crossed an Epic/root selection change (the echoed
+    // ids no longer match the request this slot stands for).
+    if (
+      !("root" in data) ||
+      data.epicId !== request.params.epicId ||
+      data.root !== request.root
+    ) {
+      return EMPTY;
+    }
+    return data.results.flatMap((result) => {
+      if (result.kind !== request.suggestionKind) return [];
+      return [
+        request.suggestionKind === "folder"
+          ? folderSuggestionFromSearchResult(request.root, result)
+          : fileSuggestionFromSearchResult(request.root, result),
+      ];
+    });
+  });
+
   return {
-    data: queries.flatMap((query) => query.data?.entries ?? EMPTY),
-    isLoading: queries.some((query) => query.isLoading),
-    isFetching: queries.some((query) => query.isFetching),
-    error: queries.find((query) => query.error !== null)?.error ?? null,
+    data: [...legacyData, ...searchData],
+    isLoading:
+      legacyQueries.some((query) => query.isLoading) ||
+      searchQueries.some((query) => query.isLoading),
+    isFetching:
+      legacyQueries.some((query) => query.isFetching) ||
+      searchQueries.some((query) => query.isFetching),
+    // A scoped error is recovered by the legacy fallback above, so it must not
+    // surface as the batch error; only a legacy error is user-visible.
+    error: legacyQueries.find((query) => query.error !== null)?.error ?? null,
+  };
+}
+
+function isSearchPathsRequest(
+  request: MentionWorkspaceRequest,
+): request is MentionSearchPathsRequest {
+  return request.method === "workspace.searchPaths";
+}
+
+function isLegacyRequest(
+  request: MentionWorkspaceRequest,
+): request is LegacyMentionRequest {
+  return request.method !== "workspace.searchPaths";
+}
+
+function fallbackLegacyRequest(
+  request: MentionSearchPathsRequest,
+): HostRequestSpec<HostRpcRegistry, WorkspaceMentionMethod> {
+  return {
+    method:
+      request.suggestionKind === "folder"
+        ? "workspace.mentionFolders"
+        : "workspace.mentionFiles",
+    params: {
+      roots: [request.root],
+      query: request.params.query,
+      limit: SEARCH_PATHS_FALLBACK_LIMIT,
+    },
   };
 }
 

--- a/clients/gui-app/src/hooks/composer/use-workspace-entries.ts
+++ b/clients/gui-app/src/hooks/composer/use-workspace-entries.ts
@@ -59,21 +59,22 @@ export function useWorkspaceEntries(
     [params.requests],
   );
 
-  const searchQueries = useHostQueries<HostRpcRegistry, "workspace.searchPaths">(
-    {
-      client: params.client,
-      cacheKeyIdentity: undefined,
-      requests: useMemo(
-        () =>
-          searchRequests.map((request) => ({
-            method: request.method,
-            params: request.params,
-          })),
-        [searchRequests],
-      ),
-      options: { staleTime: 30_000, placeholderData: keepPreviousData },
-    },
-  );
+  const searchQueries = useHostQueries<
+    HostRpcRegistry,
+    "workspace.searchPaths"
+  >({
+    client: params.client,
+    cacheKeyIdentity: undefined,
+    requests: useMemo(
+      () =>
+        searchRequests.map((request) => ({
+          method: request.method,
+          params: request.params,
+        })),
+      [searchRequests],
+    ),
+    options: { staleTime: 30_000, placeholderData: keepPreviousData },
+  });
 
   // Fall back to the legacy RPC for any scoped root the host could not search:
   // a query error (e.g. an old host that lacks `workspace.searchPaths`, or a
@@ -92,17 +93,21 @@ export function useWorkspaceEntries(
     [searchRequests, searchQueries],
   );
 
-  const legacyQueries = useHostQueries<HostRpcRegistry, WorkspaceMentionMethod>({
-    client: params.client,
-    cacheKeyIdentity: undefined,
-    requests: useMemo(
-      () => [...legacyRequests, ...fallbackRequests],
-      [legacyRequests, fallbackRequests],
-    ),
-    options: { staleTime: 30_000, placeholderData: keepPreviousData },
-  });
+  const legacyQueries = useHostQueries<HostRpcRegistry, WorkspaceMentionMethod>(
+    {
+      client: params.client,
+      cacheKeyIdentity: undefined,
+      requests: useMemo(
+        () => [...legacyRequests, ...fallbackRequests],
+        [legacyRequests, fallbackRequests],
+      ),
+      options: { staleTime: 30_000, placeholderData: keepPreviousData },
+    },
+  );
 
-  const legacyData = legacyQueries.flatMap((query) => query.data?.entries ?? EMPTY);
+  const legacyData = legacyQueries.flatMap(
+    (query) => query.data?.entries ?? EMPTY,
+  );
   const searchData = searchRequests.flatMap((request, index) => {
     const data = searchQueries[index]?.data;
     if (data === undefined) return EMPTY;

--- a/clients/gui-app/src/hooks/composer/use-workspace-entries.ts
+++ b/clients/gui-app/src/hooks/composer/use-workspace-entries.ts
@@ -86,8 +86,17 @@ export function useWorkspaceEntries(
     () =>
       searchRequests.flatMap((request, index) => {
         const query = searchQueries[index];
-        const unavailable =
-          query.isError || query.data?.outcome === "root_unavailable";
+        const data = query.data;
+        // `keepPreviousData` can retain a root_unavailable reply while this
+        // slot has already switched to another Epic/root. Only that reply's
+        // echoed identity may request the legacy fallback; query errors have
+        // no response identity and still always recover through legacy.
+        const currentRootUnavailable =
+          data?.outcome === "root_unavailable" &&
+          "root" in data &&
+          data.epicId === request.params.epicId &&
+          data.root === request.root;
+        const unavailable = query.isError || currentRootUnavailable;
         return unavailable ? [fallbackLegacyRequest(request)] : [];
       }),
     [searchRequests, searchQueries],

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-search-artifacts-query.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-search-artifacts-query.test.tsx
@@ -1,0 +1,56 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { UseEpicSearchArtifactsArgs } from "@/hooks/epic/use-epic-search-artifacts-query";
+import { useEpicSearchArtifacts } from "@/hooks/epic/use-epic-search-artifacts-query";
+
+interface CapturedHostQuery {
+  readonly method: string;
+  readonly params: {
+    readonly fields: {
+      readonly title: boolean;
+      readonly path: boolean;
+      readonly body: boolean;
+    };
+  };
+}
+
+const capturedQuery = vi.hoisted((): { current: CapturedHostQuery | null } => ({
+  current: null,
+}));
+
+vi.mock("@/hooks/host/use-host-query", () => ({
+  useHostQuery: (args: CapturedHostQuery) => {
+    capturedQuery.current = args;
+    return {
+      data: undefined,
+      error: null,
+      isError: false,
+      isFetching: false,
+      isSuccess: false,
+      refetch: vi.fn(),
+    };
+  },
+}));
+
+describe("useEpicSearchArtifacts", () => {
+  it("searches artifact titles and bodies without matching mirror-relative paths", () => {
+    const args: UseEpicSearchArtifactsArgs = {
+      client: null,
+      epicId: "epic-1",
+      query: "needle",
+      kinds: null,
+      statuses: null,
+      subtreePath: null,
+      enabled: true,
+    };
+
+    renderHook(() => useEpicSearchArtifacts(args));
+
+    expect(capturedQuery.current?.method).toBe("epic.searchArtifacts");
+    expect(capturedQuery.current?.params.fields).toEqual({
+      title: true,
+      path: false,
+      body: true,
+    });
+  });
+});

--- a/clients/gui-app/src/hooks/epic/use-epic-search-artifacts-query.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-search-artifacts-query.ts
@@ -1,0 +1,88 @@
+import { useMemo } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type {
+  HostRpcError,
+  ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostRpcRegistry } from "@/lib/host";
+import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+
+const EPIC_SEARCH_ARTIFACTS_LIMIT = 50;
+
+/** Artifact search covers user-visible content, not mirror-relative paths. */
+const ARTIFACT_SEARCH_FIELDS = Object.freeze({
+  title: true,
+  path: false,
+  body: true,
+});
+
+export interface UseEpicSearchArtifactsArgs {
+  readonly client: HostClient<HostRpcRegistry> | null;
+  readonly epicId: string;
+  readonly query: string;
+  /** Composed from the sidebar's kind filter. `null` = no kind restriction. */
+  readonly kinds: ReadonlyArray<EpicArtifactKind> | null;
+  /** Composed from the sidebar's status filter. `null` = no status restriction. */
+  readonly statuses: ReadonlyArray<number> | null;
+  /** POSIX subtree relative to the artifact root, or `null` for the whole Epic. */
+  readonly subtreePath: string | null;
+  readonly enabled: boolean;
+}
+
+/**
+ * Scoped, host-ranked artifact search over one Epic (`epic.searchArtifacts`).
+ * Titles are Fuse-ranked over authoritative artifact metadata and bodies are
+ * ripgrep-matched over the Epic's on-disk Markdown mirror - the renderer never
+ * loads or scans Markdown itself.
+ *
+ * The query key is `[host, method, { epicId, query, fields, filters, limit }]`,
+ * so a change of host, Epic, query, or composed filter mints a new key and a
+ * late in-flight response for the previous scope lands in that previous key's
+ * cache slot - never the current one. `keepPreviousData` is intentionally NOT
+ * used: `data` for the current key is therefore only ever this exact scope's
+ * result, and the consumer owns same-scope retention across keystrokes so a
+ * prior Epic/host/filter result can never render.
+ *
+ * `epic.searchArtifacts` is an optional (non-floor) capability: an old host
+ * rejects with `E_HOST_UNSUPPORTED`, surfaced here as `query.error.code` for
+ * the consumer to render a degraded state without a toast.
+ */
+export function useEpicSearchArtifacts(
+  args: UseEpicSearchArtifactsArgs,
+): UseQueryResult<
+  ResponseOfMethod<HostRpcRegistry, "epic.searchArtifacts">,
+  HostRpcError
+> {
+  const trimmedQuery = args.query.trim();
+  const { kinds, statuses, subtreePath } = args;
+  const params = useMemo(
+    () => ({
+      epicId: args.epicId,
+      query: trimmedQuery,
+      fields: ARTIFACT_SEARCH_FIELDS,
+      filters: {
+        kinds: kinds === null ? null : [...kinds],
+        statuses: statuses === null ? null : [...statuses],
+        subtreePath,
+      },
+      limit: EPIC_SEARCH_ARTIFACTS_LIMIT,
+    }),
+    // `kinds`/`statuses` are stable references from the sidebar filter store,
+    // so depending on them directly does not remint the key each render. The
+    // query key is structurally hashed, so params identity is not the gate.
+    [args.epicId, trimmedQuery, kinds, statuses, subtreePath],
+  );
+
+  return useHostQuery<HostRpcRegistry, "epic.searchArtifacts">({
+    cacheKeyIdentity: undefined,
+    client: args.client,
+    method: "epic.searchArtifacts",
+    params,
+    options: {
+      enabled: args.enabled && trimmedQuery.length > 0,
+      staleTime: 5_000,
+    },
+  });
+}

--- a/clients/gui-app/src/hooks/workspace/use-workspace-search-paths-query.ts
+++ b/clients/gui-app/src/hooks/workspace/use-workspace-search-paths-query.ts
@@ -1,0 +1,171 @@
+import { useMemo } from "react";
+import { keepPreviousData, type UseQueryResult } from "@tanstack/react-query";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type {
+  HostRpcError,
+  ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostRpcRegistry } from "@/lib/host";
+import type {
+  WorkspaceSearchPathResult,
+  WorkspaceSearchPathsKindFilter,
+  WorkspaceSearchPathsOutcome,
+  WorkspaceSearchPathsResponse,
+  WorkspaceSearchSource,
+} from "@traycer/protocol/host/workspace/unary-schemas";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+
+const WORKSPACE_SEARCH_PATHS_LIMIT = 50;
+
+export interface UseWorkspaceSearchPathsArgs {
+  readonly client: HostClient<HostRpcRegistry> | null;
+  readonly epicId: string;
+  /**
+   * The selected workspace/worktree root - a binding `runningDir` or resolved
+   * workspace-folder path the Epic pickers expose. The host authorizes it
+   * against the Epic's attached roots; the renderer never sends an arbitrary
+   * absolute path expecting it to be trusted.
+   */
+  readonly root: string | null;
+  readonly query: string;
+  readonly kinds: WorkspaceSearchPathsKindFilter;
+  readonly enabled: boolean;
+}
+
+/**
+ * Scoped, host-ranked file/folder NAME search over one Epic-attached root
+ * (`workspace.searchPaths`). Enumeration + Fuse ranking live in the host, so a
+ * query never ships or scans the full tree in the renderer.
+ *
+ * The query key is `[host, method, { epicId, reference.root, query, ... }]`, so
+ * a change of Epic, host, root, or query mints a new key and a late in-flight
+ * response for the previous selection is discarded rather than applied. The
+ * response also echoes `epicId`/`root` so callers can defensively drop a stale
+ * payload. `keepPreviousData` keeps the last results visible while the next
+ * keystroke's request is in flight, so the list does not blank between strokes.
+ */
+export function useWorkspaceSearchPaths(
+  args: UseWorkspaceSearchPathsArgs,
+): UseQueryResult<
+  ResponseOfMethod<HostRpcRegistry, "workspace.searchPaths">,
+  HostRpcError
+> {
+  const trimmedQuery = args.query.trim();
+  const params = useMemo(
+    () => ({
+      epicId: args.epicId,
+      reference: { root: args.root ?? "" },
+      query: trimmedQuery,
+      limit: WORKSPACE_SEARCH_PATHS_LIMIT,
+      kinds: args.kinds,
+    }),
+    [args.epicId, args.root, trimmedQuery, args.kinds],
+  );
+
+  return useHostQuery<HostRpcRegistry, "workspace.searchPaths">({
+    cacheKeyIdentity: undefined,
+    client: args.client,
+    method: "workspace.searchPaths",
+    params,
+    options: {
+      enabled:
+        args.enabled &&
+        args.root !== null &&
+        args.root.length > 0 &&
+        trimmedQuery.length > 0,
+      staleTime: 5_000,
+      placeholderData: keepPreviousData,
+    },
+  });
+}
+
+export interface UseWorkspaceSearchPathsForSourceArgs {
+  readonly client: HostClient<HostRpcRegistry> | null;
+  readonly epicId: string;
+  /**
+   * The scoped search source: either an attached workspace/worktree `{ root }`
+   * or the host-derived `{ kind: "epic-artifacts" }` mirror. Pass a STABLE
+   * object (module constant or memoized) so the query key is stable across
+   * renders. `null` disables the query.
+   */
+  readonly source: WorkspaceSearchSource | null;
+  readonly query: string;
+  readonly kinds: WorkspaceSearchPathsKindFilter;
+  readonly enabled: boolean;
+}
+
+/**
+ * Source-capable variant of {@link useWorkspaceSearchPaths} for callers (the
+ * new-tab Files opener) that search EITHER an attached root OR the Epic artifact
+ * mirror. Unlike the root-only hook it does NOT gate on a non-empty query - the
+ * opener wants an empty-query passthrough (the host returns a bounded browse
+ * list) - so the caller owns the enable gate. The response is a discriminated
+ * union; read it through {@link readSearchPathsResponseForSource} to echo-guard
+ * a late reply against the requested source.
+ */
+export function useWorkspaceSearchPathsForSource(
+  args: UseWorkspaceSearchPathsForSourceArgs,
+): UseQueryResult<
+  ResponseOfMethod<HostRpcRegistry, "workspace.searchPaths">,
+  HostRpcError
+> {
+  const trimmedQuery = args.query.trim();
+  const source = args.source;
+  const params = useMemo(
+    () => ({
+      epicId: args.epicId,
+      reference: source ?? { root: "" },
+      query: trimmedQuery,
+      limit: WORKSPACE_SEARCH_PATHS_LIMIT,
+      kinds: args.kinds,
+    }),
+    [args.epicId, source, trimmedQuery, args.kinds],
+  );
+
+  return useHostQuery<HostRpcRegistry, "workspace.searchPaths">({
+    cacheKeyIdentity: undefined,
+    client: args.client,
+    method: "workspace.searchPaths",
+    params,
+    options: {
+      enabled: args.enabled && source !== null && isSearchableSource(source),
+      staleTime: 5_000,
+      placeholderData: keepPreviousData,
+    },
+  });
+}
+
+function isSearchableSource(source: WorkspaceSearchSource): boolean {
+  return "kind" in source ? true : source.root.length > 0;
+}
+
+export interface WorkspaceSearchPathsView {
+  readonly outcome: WorkspaceSearchPathsOutcome;
+  readonly results: readonly WorkspaceSearchPathResult[];
+  readonly truncated: boolean;
+}
+
+/**
+ * Reads a `workspace.searchPaths` response for a specific requested source,
+ * discriminating the attached-root vs artifact response branch and dropping a
+ * late/stale reply whose echoed `epicId`/source no longer matches the request.
+ * Returns `null` for "no usable data yet" (undefined response or echo mismatch).
+ */
+export function readSearchPathsResponseForSource(
+  response: WorkspaceSearchPathsResponse | undefined,
+  epicId: string,
+  source: WorkspaceSearchSource,
+): WorkspaceSearchPathsView | null {
+  if (response === undefined || response.epicId !== epicId) return null;
+  if ("kind" in source) {
+    // The artifact response branch is the one carrying `source` (vs `root`).
+    if (!("source" in response)) return null;
+  } else if (!("root" in response) || response.root !== source.root) {
+    return null;
+  }
+  return {
+    outcome: response.outcome,
+    results: response.results,
+    truncated: response.truncated,
+  };
+}

--- a/clients/gui-app/src/hooks/workspace/use-workspace-search-paths-query.ts
+++ b/clients/gui-app/src/hooks/workspace/use-workspace-search-paths-query.ts
@@ -51,31 +51,18 @@ export function useWorkspaceSearchPaths(
   HostRpcError
 > {
   const trimmedQuery = args.query.trim();
-  const params = useMemo(
-    () => ({
-      epicId: args.epicId,
-      reference: { root: args.root ?? "" },
-      query: trimmedQuery,
-      limit: WORKSPACE_SEARCH_PATHS_LIMIT,
-      kinds: args.kinds,
-    }),
-    [args.epicId, args.root, trimmedQuery, args.kinds],
-  );
-
-  return useHostQuery<HostRpcRegistry, "workspace.searchPaths">({
-    cacheKeyIdentity: undefined,
+  const reference = useMemo(() => ({ root: args.root ?? "" }), [args.root]);
+  return useWorkspaceSearchPathsCore({
     client: args.client,
-    method: "workspace.searchPaths",
-    params,
-    options: {
-      enabled:
-        args.enabled &&
-        args.root !== null &&
-        args.root.length > 0 &&
-        trimmedQuery.length > 0,
-      staleTime: 5_000,
-      placeholderData: keepPreviousData,
-    },
+    epicId: args.epicId,
+    reference,
+    query: trimmedQuery,
+    kinds: args.kinds,
+    enabled:
+      args.enabled &&
+      args.root !== null &&
+      args.root.length > 0 &&
+      trimmedQuery.length > 0,
   });
 }
 
@@ -109,17 +96,39 @@ export function useWorkspaceSearchPathsForSource(
   ResponseOfMethod<HostRpcRegistry, "workspace.searchPaths">,
   HostRpcError
 > {
-  const trimmedQuery = args.query.trim();
   const source = args.source;
+  const fallbackSource = useMemo(() => ({ root: "" }), []);
+  return useWorkspaceSearchPathsCore({
+    client: args.client,
+    epicId: args.epicId,
+    reference: source ?? fallbackSource,
+    query: args.query,
+    kinds: args.kinds,
+    enabled: args.enabled && source !== null && isSearchableSource(source),
+  });
+}
+
+function useWorkspaceSearchPathsCore(args: {
+  readonly client: HostClient<HostRpcRegistry> | null;
+  readonly epicId: string;
+  readonly reference: WorkspaceSearchSource;
+  readonly query: string;
+  readonly kinds: WorkspaceSearchPathsKindFilter;
+  readonly enabled: boolean;
+}): UseQueryResult<
+  ResponseOfMethod<HostRpcRegistry, "workspace.searchPaths">,
+  HostRpcError
+> {
+  const trimmedQuery = args.query.trim();
   const params = useMemo(
     () => ({
       epicId: args.epicId,
-      reference: source ?? { root: "" },
+      reference: args.reference,
       query: trimmedQuery,
       limit: WORKSPACE_SEARCH_PATHS_LIMIT,
       kinds: args.kinds,
     }),
-    [args.epicId, source, trimmedQuery, args.kinds],
+    [args.epicId, args.reference, trimmedQuery, args.kinds],
   );
 
   return useHostQuery<HostRpcRegistry, "workspace.searchPaths">({
@@ -128,7 +137,7 @@ export function useWorkspaceSearchPathsForSource(
     method: "workspace.searchPaths",
     params,
     options: {
-      enabled: args.enabled && source !== null && isSearchableSource(source),
+      enabled: args.enabled,
       staleTime: 5_000,
       placeholderData: keepPreviousData,
     },

--- a/clients/gui-app/src/hooks/workspace/use-workspace-search-text-query.ts
+++ b/clients/gui-app/src/hooks/workspace/use-workspace-search-text-query.ts
@@ -1,0 +1,102 @@
+import { useMemo } from "react";
+import { keepPreviousData, type UseQueryResult } from "@tanstack/react-query";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type {
+  HostRpcError,
+  ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import type { HostRpcRegistry } from "@/lib/host";
+import type {
+  WorkspaceSearchSource,
+  WorkspaceSearchTextOptions,
+} from "@traycer/protocol/host/workspace/unary-schemas";
+import { useHostQuery } from "@/hooks/host/use-host-query";
+
+const WORKSPACE_SEARCH_TEXT_LIMIT = 200;
+
+export interface UseWorkspaceSearchTextArgs {
+  readonly client: HostClient<HostRpcRegistry> | null;
+  readonly epicId: string;
+  /**
+   * The search source. Either an attached workspace/worktree root selector (a
+   * binding `runningDir` the Epic pickers expose - the host authorizes it, the
+   * renderer never sends an arbitrary trusted path) or the typed Epic-artifact
+   * mirror source (`{ kind: "epic-artifacts" }`, whose host-local directory the
+   * resolver derives from `epicId`). `null` disables the query.
+   */
+  readonly reference: WorkspaceSearchSource | null;
+  readonly query: string;
+  readonly options: WorkspaceSearchTextOptions;
+  readonly enabled: boolean;
+}
+
+/**
+ * Scoped, host-run TEXT (file-content) search over one source
+ * (`workspace.searchText`) - either an Epic-attached code root or the Epic's
+ * artifact mirror. ripgrep runs in the host; the renderer never scans contents.
+ *
+ * The query key is `[host, method, { epicId, reference, query, options, limit }]`,
+ * so a change of Epic, host, source (root or artifact), query, or any option
+ * mints a new key and a late in-flight response for the previous selection is
+ * discarded rather than applied. The response also echoes `epicId` and its
+ * source (`root` for a code root, `source` for artifacts) so the caller can
+ * defensively drop a stale payload that crosses a source/target change.
+ * `keepPreviousData` keeps the last results visible while the next keystroke's
+ * request is in flight, so the list does not blank between strokes.
+ *
+ * `workspace.searchText` is an optional (non-floor) capability: an old host
+ * rejects with `E_HOST_UNSUPPORTED`, surfaced here as `query.error.code` for the
+ * consumer to render a degraded state without a toast.
+ */
+export function useWorkspaceSearchText(
+  args: UseWorkspaceSearchTextArgs,
+): UseQueryResult<
+  ResponseOfMethod<HostRpcRegistry, "workspace.searchText">,
+  HostRpcError
+> {
+  const trimmedQuery = args.query.trim();
+  const { options, reference } = args;
+  // A source is usable when it is the artifact mirror, or an attached root with
+  // a non-empty path. Everything else disables the query.
+  const hasSource =
+    reference !== null && ("kind" in reference || reference.root.length > 0);
+  // Callers hold the reference and glob arrays in stable state, so depending on
+  // them directly does not churn; the request key varies with any change.
+  const params = useMemo(
+    () => ({
+      epicId: args.epicId,
+      reference: reference ?? { root: "" },
+      query: trimmedQuery,
+      options: {
+        regex: options.regex,
+        caseSensitive: options.caseSensitive,
+        wholeWord: options.wholeWord,
+        includeGlobs: [...options.includeGlobs],
+        excludeGlobs: [...options.excludeGlobs],
+      },
+      limit: WORKSPACE_SEARCH_TEXT_LIMIT,
+    }),
+    [
+      args.epicId,
+      reference,
+      trimmedQuery,
+      options.regex,
+      options.caseSensitive,
+      options.wholeWord,
+      options.includeGlobs,
+      options.excludeGlobs,
+    ],
+  );
+
+  return useHostQuery<HostRpcRegistry, "workspace.searchText">({
+    cacheKeyIdentity: undefined,
+    client: args.client,
+    method: "workspace.searchText",
+    params,
+    options: {
+      enabled: args.enabled && hasSource && trimmedQuery.length > 0,
+      staleTime: 5_000,
+      placeholderData: keepPreviousData,
+    },
+  });
+}

--- a/clients/gui-app/src/lib/artifacts/__tests__/highlight-byte-ranges.test.ts
+++ b/clients/gui-app/src/lib/artifacts/__tests__/highlight-byte-ranges.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { highlightSegmentsFromByteRanges } from "@/lib/artifacts/highlight-byte-ranges";
+
+function highlightedText(
+  segments: ReadonlyArray<{ text: string; highlighted: boolean }>,
+): string {
+  return segments
+    .filter((segment) => segment.highlighted)
+    .map((segment) => segment.text)
+    .join("|");
+}
+
+function joinedText(
+  segments: ReadonlyArray<{ text: string; highlighted: boolean }>,
+): string {
+  return segments.map((segment) => segment.text).join("");
+}
+
+describe("highlightSegmentsFromByteRanges", () => {
+  it("returns an empty list for empty text", () => {
+    expect(highlightSegmentsFromByteRanges("", [{ startByte: 0, endByte: 1 }])).toEqual(
+      [],
+    );
+  });
+
+  it("returns a single non-highlighted segment when there are no ranges", () => {
+    const segments = highlightSegmentsFromByteRanges("hello world", []);
+    expect(segments).toEqual([
+      { text: "hello world", highlighted: false, start: 0 },
+    ]);
+  });
+
+  it("highlights an ASCII byte range on JS-string boundaries", () => {
+    const segments = highlightSegmentsFromByteRanges("hello world", [
+      { startByte: 6, endByte: 11 },
+    ]);
+    expect(joinedText(segments)).toBe("hello world");
+    expect(highlightedText(segments)).toBe("world");
+    expect(segments).toEqual([
+      { text: "hello ", highlighted: false, start: 0 },
+      { text: "world", highlighted: true, start: 6 },
+    ]);
+  });
+
+  it("maps multibyte UTF-8 byte offsets to the correct JS characters", () => {
+    // "naïve" — the ï is 2 UTF-8 bytes, so "naïve" is 6 bytes; the match on
+    // the leading "naïve" word ends at byte 6, not char index 5.
+    const segments = highlightSegmentsFromByteRanges("naïve text", [
+      { startByte: 0, endByte: 6 },
+    ]);
+    expect(highlightedText(segments)).toBe("naïve");
+    expect(joinedText(segments)).toBe("naïve text");
+  });
+
+  it("handles astral (surrogate-pair) characters — 4 UTF-8 bytes, 2 UTF-16 units", () => {
+    // "a😀b": 'a' (1 byte), '😀' (4 bytes, 2 UTF-16 units), 'b' (1 byte).
+    // Highlight the emoji: bytes [1, 5).
+    const segments = highlightSegmentsFromByteRanges("a😀b", [
+      { startByte: 1, endByte: 5 },
+    ]);
+    expect(highlightedText(segments)).toBe("😀");
+    expect(joinedText(segments)).toBe("a😀b");
+  });
+
+  it("merges overlapping and adjacent ranges", () => {
+    const segments = highlightSegmentsFromByteRanges("abcdefgh", [
+      { startByte: 1, endByte: 3 },
+      { startByte: 2, endByte: 4 },
+      { startByte: 4, endByte: 5 },
+    ]);
+    expect(highlightedText(segments)).toBe("bcde");
+    expect(joinedText(segments)).toBe("abcdefgh");
+  });
+
+  it("clamps ranges past the snippet's byte length and drops empty/inverted ranges", () => {
+    const segments = highlightSegmentsFromByteRanges("abc", [
+      { startByte: 2, endByte: 999 },
+      { startByte: 1, endByte: 1 },
+      { startByte: 3, endByte: 2 },
+    ]);
+    expect(highlightedText(segments)).toBe("c");
+    expect(joinedText(segments)).toBe("abc");
+  });
+
+  it("orders multiple disjoint ranges left to right", () => {
+    const segments = highlightSegmentsFromByteRanges("one two three", [
+      { startByte: 4, endByte: 7 },
+      { startByte: 0, endByte: 3 },
+    ]);
+    expect(segments).toEqual([
+      { text: "one", highlighted: true, start: 0 },
+      { text: " ", highlighted: false, start: 3 },
+      { text: "two", highlighted: true, start: 4 },
+      { text: " three", highlighted: false, start: 7 },
+    ]);
+  });
+});

--- a/clients/gui-app/src/lib/artifacts/__tests__/highlight-byte-ranges.test.ts
+++ b/clients/gui-app/src/lib/artifacts/__tests__/highlight-byte-ranges.test.ts
@@ -18,9 +18,9 @@ function joinedText(
 
 describe("highlightSegmentsFromByteRanges", () => {
   it("returns an empty list for empty text", () => {
-    expect(highlightSegmentsFromByteRanges("", [{ startByte: 0, endByte: 1 }])).toEqual(
-      [],
-    );
+    expect(
+      highlightSegmentsFromByteRanges("", [{ startByte: 0, endByte: 1 }]),
+    ).toEqual([]);
   });
 
   it("returns a single non-highlighted segment when there are no ranges", () => {

--- a/clients/gui-app/src/lib/artifacts/highlight-byte-ranges.ts
+++ b/clients/gui-app/src/lib/artifacts/highlight-byte-ranges.ts
@@ -1,0 +1,125 @@
+/**
+ * Turn a body-snippet's UTF-8 byte highlight ranges into ordered, renderable
+ * JS-string segments.
+ *
+ * `epic.searchArtifacts` returns snippet highlight ranges as BYTE offsets into
+ * the UTF-8 encoding of `snippet.text` (ripgrep submatch offsets), not UTF-16 /
+ * JS string indices. A naive `text.slice(startByte, endByte)` would mis-slice
+ * any snippet containing a multibyte character (e.g. `naïve`, emoji, CJK). This
+ * maps each byte boundary to its UTF-16 index by walking the string's code
+ * points once, then slices on those boundaries.
+ *
+ * The host already bounds snippet text and clamps/drops ranges so every range
+ * addresses the returned text (Ticket 2 hardening), but this stays defensive:
+ * ranges are clamped to the snippet's byte length, empty/inverted ranges are
+ * dropped, and overlapping ranges are merged so the output is always a clean,
+ * gap-free left-to-right partition of `text`.
+ */
+
+export interface SnippetByteRange {
+  readonly startByte: number;
+  readonly endByte: number;
+}
+
+export interface HighlightSegment {
+  readonly text: string;
+  readonly highlighted: boolean;
+  /** UTF-16 start index of this segment in the source text; a stable React key. */
+  readonly start: number;
+}
+
+function utf8CodePointByteLength(codePoint: number): number {
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Merge a byte-sorted, non-empty list of ranges so no two overlap or touch.
+ * Input must already be sorted by `startByte`.
+ */
+function mergeSortedRanges(
+  ranges: ReadonlyArray<SnippetByteRange>,
+): ReadonlyArray<SnippetByteRange> {
+  return ranges.reduce<SnippetByteRange[]>((merged, range) => {
+    const last = merged.at(-1);
+    if (last !== undefined && range.startByte <= last.endByte) {
+      merged[merged.length - 1] = {
+        startByte: last.startByte,
+        endByte: Math.max(last.endByte, range.endByte),
+      };
+      return merged;
+    }
+    return [...merged, range];
+  }, []);
+}
+
+/**
+ * Partition `text` into highlighted / non-highlighted segments from UTF-8 byte
+ * ranges. Segments are contiguous and cover the whole string in order, so a
+ * consumer renders them as a flat run of `<span>`s. Returns a single
+ * non-highlighted segment when there is nothing to highlight, and `[]` for an
+ * empty string.
+ */
+export function highlightSegmentsFromByteRanges(
+  text: string,
+  ranges: ReadonlyArray<SnippetByteRange>,
+): ReadonlyArray<HighlightSegment> {
+  if (text.length === 0) return [];
+
+  // Map every UTF-8 byte boundary to its UTF-16 index in one code-point pass.
+  const byteToCharIndex = new Map<number, number>();
+  let byteIndex = 0;
+  let charIndex = 0;
+  byteToCharIndex.set(0, 0);
+  for (const codePoint of text) {
+    byteIndex += utf8CodePointByteLength(codePoint.codePointAt(0) ?? 0);
+    charIndex += codePoint.length;
+    byteToCharIndex.set(byteIndex, charIndex);
+  }
+  const totalBytes = byteIndex;
+
+  const normalized = ranges
+    .map((range) => ({
+      startByte: clamp(range.startByte, 0, totalBytes),
+      endByte: clamp(range.endByte, 0, totalBytes),
+    }))
+    .filter((range) => range.endByte > range.startByte)
+    .sort((a, b) => a.startByte - b.startByte);
+  const merged = mergeSortedRanges(normalized);
+
+  if (merged.length === 0) return [{ text, highlighted: false, start: 0 }];
+
+  const segments: HighlightSegment[] = [];
+  let cursorChar = 0;
+  for (const range of merged) {
+    const startChar = byteToCharIndex.get(range.startByte);
+    const endChar = byteToCharIndex.get(range.endByte);
+    // A boundary that does not land on a code-point edge (should not happen for
+    // ripgrep offsets) is dropped rather than mis-sliced.
+    if (startChar === undefined || endChar === undefined) continue;
+    if (endChar <= startChar) continue;
+    if (startChar > cursorChar) {
+      segments.push({
+        text: text.slice(cursorChar, startChar),
+        highlighted: false,
+        start: cursorChar,
+      });
+    }
+    segments.push({
+      text: text.slice(startChar, endChar),
+      highlighted: true,
+      start: startChar,
+    });
+    cursorChar = endChar;
+  }
+  if (cursorChar < text.length) {
+    segments.push({ text: text.slice(cursorChar), highlighted: false, start: cursorChar });
+  }
+  return segments;
+}

--- a/clients/gui-app/src/lib/artifacts/highlight-byte-ranges.ts
+++ b/clients/gui-app/src/lib/artifacts/highlight-byte-ranges.ts
@@ -119,7 +119,11 @@ export function highlightSegmentsFromByteRanges(
     cursorChar = endChar;
   }
   if (cursorChar < text.length) {
-    segments.push({ text: text.slice(cursorChar), highlighted: false, start: cursorChar });
+    segments.push({
+      text: text.slice(cursorChar),
+      highlighted: false,
+      start: cursorChar,
+    });
   }
   return segments;
 }

--- a/clients/gui-app/src/lib/commands/__tests__/open.source.test.ts
+++ b/clients/gui-app/src/lib/commands/__tests__/open.source.test.ts
@@ -48,6 +48,7 @@ describe("openSource", () => {
       "Artifacts",
       "Files",
       "Diff",
+      "Text search",
     ]);
     for (const item of items) {
       expect(item.group).toBe("open");

--- a/clients/gui-app/src/lib/commands/sources/open.source.ts
+++ b/clients/gui-app/src/lib/commands/sources/open.source.ts
@@ -13,6 +13,7 @@ import { useArtifactsOpenerItems } from "@/lib/commands/sources/open/artifacts-s
 import { useAgentsOpenerItems } from "@/lib/commands/sources/open/agents-subpage";
 import { useDiffOpenerItems } from "@/lib/commands/sources/open/diff-subpage";
 import { useFilesOpenerItems } from "@/lib/commands/sources/open/files-subpage";
+import { useSearchOpenerItems } from "@/lib/commands/sources/open/search-subpage";
 import { useTerminalsOpenerItems } from "@/lib/commands/sources/open/terminals-subpage";
 import type {
   CommandContext,
@@ -62,6 +63,12 @@ const OPENER_CATEGORIES: ReadonlyArray<OpenerCategory> = [
     title: "Diff",
     keywords: ["diff", "changes"],
     useItems: useDiffOpenerItems,
+  },
+  {
+    id: "search",
+    title: "Text search",
+    keywords: ["search", "text", "grep", "find", "content", "code"],
+    useItems: useSearchOpenerItems,
   },
 ];
 

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-display-index.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-display-index.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMPTY_PROJECTED_SLICES,
+  type ArtifactProjection,
+  type ArtifactsSlice,
+  type TreeNode,
+  type TreeSlice,
+} from "@/stores/epics/open-epic/types";
+import {
+  buildArtifactDisplayPathIndex,
+  normalizeArtifactLogicalPath,
+} from "@/lib/commands/sources/open/artifact-display-index";
+
+interface Spec {
+  readonly id: string;
+  readonly folderName: string;
+  readonly title: string;
+  readonly parentId: string | null;
+}
+
+function slices(specs: ReadonlyArray<Spec>): {
+  tree: TreeSlice;
+  artifacts: ArtifactsSlice;
+} {
+  const byId: Record<string, ArtifactProjection> = {};
+  const nodeById: Record<string, TreeNode> = {};
+  for (const spec of specs) {
+    byId[spec.id] = {
+      id: spec.id,
+      kind: "spec",
+      title: spec.title,
+      folderName: spec.folderName,
+      parentId: spec.parentId,
+      artifactRoomId: null,
+      createdAt: 0,
+      updatedAt: 0,
+      status: null,
+      createdManually: false,
+    };
+    nodeById[spec.id] = {
+      id: spec.id,
+      parentId: spec.parentId,
+      title: spec.title,
+      type: "spec",
+      status: null,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  }
+  return {
+    tree: { ...EMPTY_PROJECTED_SLICES.tree, nodeById },
+    artifacts: { allIds: specs.map((s) => s.id), byId },
+  };
+}
+
+describe("buildArtifactDisplayPathIndex", () => {
+  it("indexes unique paths with display title + ancestor-title path", () => {
+    const { tree, artifacts } = slices([
+      { id: "p", folderName: "tickets", title: "Tickets", parentId: null },
+      { id: "c", folderName: "one", title: "First", parentId: "p" },
+    ]);
+    const index = buildArtifactDisplayPathIndex(tree, artifacts);
+    expect(index.get("tickets/one")).toMatchObject({
+      id: "c",
+      title: "First",
+      titlePath: "Tickets / First",
+    });
+  });
+
+  it("fails closed on a two-way collision - the shared path resolves to nothing", () => {
+    const { tree, artifacts } = slices([
+      { id: "a", folderName: "dup", title: "A", parentId: null },
+      { id: "b", folderName: "dup", title: "B", parentId: null },
+    ]);
+    const index = buildArtifactDisplayPathIndex(tree, artifacts);
+    expect(index.has("dup")).toBe(false);
+  });
+
+  it("is order-independent: a reversed allIds order still fails closed", () => {
+    const forward = slices([
+      { id: "a", folderName: "dup", title: "A", parentId: null },
+      { id: "b", folderName: "dup", title: "B", parentId: null },
+    ]);
+    const reversed = slices([
+      { id: "b", folderName: "dup", title: "B", parentId: null },
+      { id: "a", folderName: "dup", title: "A", parentId: null },
+    ]);
+    expect(buildArtifactDisplayPathIndex(forward.tree, forward.artifacts).has("dup")).toBe(false);
+    expect(buildArtifactDisplayPathIndex(reversed.tree, reversed.artifacts).has("dup")).toBe(false);
+  });
+
+  it("keeps a third claimant from re-adding an ambiguous path", () => {
+    const { tree, artifacts } = slices([
+      { id: "a", folderName: "dup", title: "A", parentId: null },
+      { id: "b", folderName: "dup", title: "B", parentId: null },
+      { id: "c", folderName: "dup", title: "C", parentId: null },
+    ]);
+    const index = buildArtifactDisplayPathIndex(tree, artifacts);
+    expect(index.has("dup")).toBe(false);
+  });
+
+  it("does not let a collision poison unique sibling/parent paths", () => {
+    const { tree, artifacts } = slices([
+      { id: "a", folderName: "dup", title: "A", parentId: null },
+      { id: "b", folderName: "dup", title: "B", parentId: null },
+      { id: "u", folderName: "unique", title: "Unique", parentId: null },
+      { id: "p", folderName: "parent", title: "Parent", parentId: null },
+      { id: "k", folderName: "kid", title: "Kid", parentId: "p" },
+    ]);
+    const index = buildArtifactDisplayPathIndex(tree, artifacts);
+    expect(index.has("dup")).toBe(false);
+    expect(index.get("unique")?.id).toBe("u");
+    expect(index.get("parent/kid")?.id).toBe("k");
+  });
+});
+
+describe("normalizeArtifactLogicalPath", () => {
+  it("strips leading and trailing slashes", () => {
+    expect(normalizeArtifactLogicalPath("/tickets/one/")).toBe("tickets/one");
+    expect(normalizeArtifactLogicalPath("one")).toBe("one");
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-display-index.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-display-index.test.ts
@@ -85,8 +85,14 @@ describe("buildArtifactDisplayPathIndex", () => {
       { id: "b", folderName: "dup", title: "B", parentId: null },
       { id: "a", folderName: "dup", title: "A", parentId: null },
     ]);
-    expect(buildArtifactDisplayPathIndex(forward.tree, forward.artifacts).has("dup")).toBe(false);
-    expect(buildArtifactDisplayPathIndex(reversed.tree, reversed.artifacts).has("dup")).toBe(false);
+    expect(
+      buildArtifactDisplayPathIndex(forward.tree, forward.artifacts).has("dup"),
+    ).toBe(false);
+    expect(
+      buildArtifactDisplayPathIndex(reversed.tree, reversed.artifacts).has(
+        "dup",
+      ),
+    ).toBe(false);
   });
 
   it("keeps a third claimant from re-adding an ambiguous path", () => {

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-path-resolver.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-path-resolver.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { buildArtifactPathIndex } from "@/lib/commands/sources/open/artifact-path-resolver";
+import type {
+  ArtifactProjection,
+  ArtifactsSlice,
+  TreeNode,
+  TreeSlice,
+} from "@/stores/epics/open-epic/types";
+
+interface Node {
+  readonly id: string;
+  readonly parentId: string | null;
+  readonly folderName: string;
+  readonly kind: ArtifactProjection["kind"];
+  readonly title: string;
+}
+
+function treeNode(node: Node): TreeNode {
+  return {
+    id: node.id,
+    parentId: node.parentId,
+    title: node.title,
+    type: node.kind,
+    status: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function artifactProjection(node: Node): ArtifactProjection {
+  return {
+    id: node.id,
+    kind: node.kind,
+    title: node.title,
+    folderName: node.folderName,
+    parentId: node.parentId,
+    artifactRoomId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    status: null,
+    createdManually: false,
+  };
+}
+
+function slices(nodes: readonly Node[]): {
+  tree: TreeSlice;
+  artifacts: ArtifactsSlice;
+} {
+  return {
+    tree: {
+      rootIds: nodes.filter((n) => n.parentId === null).map((n) => n.id),
+      childrenByParent: {},
+      nodeById: Object.fromEntries(nodes.map((n) => [n.id, treeNode(n)])),
+    },
+    artifacts: {
+      byId: Object.fromEntries(nodes.map((n) => [n.id, artifactProjection(n)])),
+      allIds: nodes.map((n) => n.id),
+    },
+  };
+}
+
+describe("buildArtifactPathIndex", () => {
+  it("maps each artifact's logical folder-chain path to its identity", () => {
+    const { tree, artifacts } = slices([
+      { id: "a", parentId: null, folderName: "tickets", kind: "story", title: "Tickets" },
+      { id: "b", parentId: "a", folderName: "my-ticket", kind: "ticket", title: "My Ticket" },
+    ]);
+    const index = buildArtifactPathIndex(tree, artifacts);
+    expect(index.get("tickets")).toEqual({
+      id: "a",
+      kind: "story",
+      title: "Tickets",
+    });
+    // A nested artifact keys on its full root-to-leaf chain (the host projects
+    // the mirror `tickets/my-ticket/index.md` to exactly this logical path).
+    expect(index.get("tickets/my-ticket")).toEqual({
+      id: "b",
+      kind: "ticket",
+      title: "My Ticket",
+    });
+  });
+
+  it("returns null-equivalent (no entry) for an unknown logical path", () => {
+    const { tree, artifacts } = slices([
+      { id: "a", parentId: null, folderName: "specs", kind: "spec", title: "Specs" },
+    ]);
+    const index = buildArtifactPathIndex(tree, artifacts);
+    expect(index.get("tickets/gone")).toBeUndefined();
+  });
+
+  it("skips an artifact whose chain cannot resolve (empty folder name)", () => {
+    const { tree, artifacts } = slices([
+      { id: "a", parentId: null, folderName: "", kind: "spec", title: "Legacy" },
+      { id: "b", parentId: null, folderName: "reviews", kind: "review", title: "Reviews" },
+    ]);
+    const index = buildArtifactPathIndex(tree, artifacts);
+    // The malformed (empty folder) entry contributes no path; the valid one does.
+    expect(index.has("")).toBe(false);
+    expect(index.get("reviews")?.id).toBe("b");
+    expect(index.size).toBe(1);
+  });
+
+  it("returns an empty index when slices are absent", () => {
+    expect(buildArtifactPathIndex(null, null).size).toBe(0);
+  });
+
+  it("fails closed (no entry) when two live artifacts share a logical path", () => {
+    // Two distinct artifacts both projecting to `dupes/clash` is ambiguous.
+    const collide: readonly Node[] = [
+      { id: "p", parentId: null, folderName: "dupes", kind: "story", title: "Dupes" },
+      { id: "a", parentId: "p", folderName: "clash", kind: "ticket", title: "A" },
+      { id: "b", parentId: "p", folderName: "clash", kind: "ticket", title: "B" },
+    ];
+    // Same outcome regardless of iteration order - no first/last wins.
+    for (const order of [collide, [...collide].reverse()]) {
+      const { tree, artifacts } = slices(order);
+      const index = buildArtifactPathIndex(tree, artifacts);
+      expect(index.get("dupes/clash")).toBeUndefined();
+      // The unambiguous parent path is unaffected.
+      expect(index.get("dupes")?.id).toBe("p");
+    }
+  });
+
+  it("keeps a colliding path closed even with a third claimant", () => {
+    const { tree, artifacts } = slices([
+      { id: "a", parentId: null, folderName: "clash", kind: "ticket", title: "A" },
+      { id: "b", parentId: null, folderName: "clash", kind: "ticket", title: "B" },
+      { id: "c", parentId: null, folderName: "clash", kind: "ticket", title: "C" },
+    ]);
+    expect(buildArtifactPathIndex(tree, artifacts).get("clash")).toBeUndefined();
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-path-resolver.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-path-resolver.test.ts
@@ -160,13 +160,13 @@ describe("buildArtifactPathIndex", () => {
       },
     ];
     // Same outcome regardless of iteration order - no first/last wins.
-    for (const order of [collide, [...collide].reverse()]) {
+    [collide, [...collide].reverse()].forEach((order) => {
       const { tree, artifacts } = slices(order);
       const index = buildArtifactPathIndex(tree, artifacts);
       expect(index.get("dupes/clash")).toBeUndefined();
       // The unambiguous parent path is unaffected.
       expect(index.get("dupes")?.id).toBe("p");
-    }
+    });
   });
 
   it("keeps a colliding path closed even with a third claimant", () => {

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-path-resolver.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/artifact-path-resolver.test.ts
@@ -62,8 +62,20 @@ function slices(nodes: readonly Node[]): {
 describe("buildArtifactPathIndex", () => {
   it("maps each artifact's logical folder-chain path to its identity", () => {
     const { tree, artifacts } = slices([
-      { id: "a", parentId: null, folderName: "tickets", kind: "story", title: "Tickets" },
-      { id: "b", parentId: "a", folderName: "my-ticket", kind: "ticket", title: "My Ticket" },
+      {
+        id: "a",
+        parentId: null,
+        folderName: "tickets",
+        kind: "story",
+        title: "Tickets",
+      },
+      {
+        id: "b",
+        parentId: "a",
+        folderName: "my-ticket",
+        kind: "ticket",
+        title: "My Ticket",
+      },
     ]);
     const index = buildArtifactPathIndex(tree, artifacts);
     expect(index.get("tickets")).toEqual({
@@ -82,7 +94,13 @@ describe("buildArtifactPathIndex", () => {
 
   it("returns null-equivalent (no entry) for an unknown logical path", () => {
     const { tree, artifacts } = slices([
-      { id: "a", parentId: null, folderName: "specs", kind: "spec", title: "Specs" },
+      {
+        id: "a",
+        parentId: null,
+        folderName: "specs",
+        kind: "spec",
+        title: "Specs",
+      },
     ]);
     const index = buildArtifactPathIndex(tree, artifacts);
     expect(index.get("tickets/gone")).toBeUndefined();
@@ -90,8 +108,20 @@ describe("buildArtifactPathIndex", () => {
 
   it("skips an artifact whose chain cannot resolve (empty folder name)", () => {
     const { tree, artifacts } = slices([
-      { id: "a", parentId: null, folderName: "", kind: "spec", title: "Legacy" },
-      { id: "b", parentId: null, folderName: "reviews", kind: "review", title: "Reviews" },
+      {
+        id: "a",
+        parentId: null,
+        folderName: "",
+        kind: "spec",
+        title: "Legacy",
+      },
+      {
+        id: "b",
+        parentId: null,
+        folderName: "reviews",
+        kind: "review",
+        title: "Reviews",
+      },
     ]);
     const index = buildArtifactPathIndex(tree, artifacts);
     // The malformed (empty folder) entry contributes no path; the valid one does.
@@ -107,9 +137,27 @@ describe("buildArtifactPathIndex", () => {
   it("fails closed (no entry) when two live artifacts share a logical path", () => {
     // Two distinct artifacts both projecting to `dupes/clash` is ambiguous.
     const collide: readonly Node[] = [
-      { id: "p", parentId: null, folderName: "dupes", kind: "story", title: "Dupes" },
-      { id: "a", parentId: "p", folderName: "clash", kind: "ticket", title: "A" },
-      { id: "b", parentId: "p", folderName: "clash", kind: "ticket", title: "B" },
+      {
+        id: "p",
+        parentId: null,
+        folderName: "dupes",
+        kind: "story",
+        title: "Dupes",
+      },
+      {
+        id: "a",
+        parentId: "p",
+        folderName: "clash",
+        kind: "ticket",
+        title: "A",
+      },
+      {
+        id: "b",
+        parentId: "p",
+        folderName: "clash",
+        kind: "ticket",
+        title: "B",
+      },
     ];
     // Same outcome regardless of iteration order - no first/last wins.
     for (const order of [collide, [...collide].reverse()]) {
@@ -123,10 +171,30 @@ describe("buildArtifactPathIndex", () => {
 
   it("keeps a colliding path closed even with a third claimant", () => {
     const { tree, artifacts } = slices([
-      { id: "a", parentId: null, folderName: "clash", kind: "ticket", title: "A" },
-      { id: "b", parentId: null, folderName: "clash", kind: "ticket", title: "B" },
-      { id: "c", parentId: null, folderName: "clash", kind: "ticket", title: "C" },
+      {
+        id: "a",
+        parentId: null,
+        folderName: "clash",
+        kind: "ticket",
+        title: "A",
+      },
+      {
+        id: "b",
+        parentId: null,
+        folderName: "clash",
+        kind: "ticket",
+        title: "B",
+      },
+      {
+        id: "c",
+        parentId: null,
+        folderName: "clash",
+        kind: "ticket",
+        title: "C",
+      },
     ]);
-    expect(buildArtifactPathIndex(tree, artifacts).get("clash")).toBeUndefined();
+    expect(
+      buildArtifactPathIndex(tree, artifacts).get("clash"),
+    ).toBeUndefined();
   });
 });

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/files-cmdk-filtering.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/files-cmdk-filtering.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Drives the Files opener result rows through the REAL `<Command>` filtering
+ * pipeline (`filter={paletteFilter}`) to prove the fixup: when cmdk filtering is
+ * disabled for a Files host-result sub-page, a non-subsequence/typo live query
+ * neither hides the host-ranked rows (host Fuse order is preserved) nor the
+ * typed notice/truncation rows. The companion `shouldFilter` case shows cmdk
+ * WOULD hide them, i.e. why the fix is needed. `isFilesResultSubpageId` (which
+ * `pane-opener` uses to compute `shouldFilter`) is unit-checked alongside.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Command, CommandInput, CommandList } from "@/components/ui/command";
+import { paletteFilter } from "@/components/command-palette/palette-cmdk-controller";
+import { SubpageView } from "@/components/command-palette/palette-cmdk";
+import { PaletteQueryProvider } from "@/lib/commands/palette-query-context";
+import {
+  filesArtifactsResultSubpageId,
+  filesCodeRootResultSubpageId,
+  isFilesResultSubpageId,
+} from "@/lib/commands/sources/open/files-result-subpage";
+import type {
+  CommandContext,
+  CommandItem,
+  CommandSubpage,
+} from "@/lib/commands/types";
+import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
+
+function noopRouter(): KeybindingRouter {
+  return {
+    getPathname: () => "/",
+    navigateHome: () => undefined,
+    navigateSettings: () => undefined,
+    navigateToEpic: () => undefined,
+    navigateToEpicTab: () => undefined,
+    navigateToEpicList: () => undefined,
+    navigateSettingsSection: () => undefined,
+    navigateToTabIntent: () => undefined,
+    goBack: () => undefined,
+    goForward: () => undefined,
+    isHistoryNavAvailable: () => false,
+    canGoBack: () => false,
+    canGoForward: () => false,
+    navigateNestedFocus: vi.fn(),
+  };
+}
+
+const CTX: CommandContext = {
+  pathname: "/",
+  router: noopRouter(),
+  activeTabId: "tab-1",
+  activeEpicId: "epic-1",
+  focusedComposerKind: null,
+  targetGroupId: "group-1",
+};
+
+function actionRow(id: string, label: string): CommandItem {
+  return {
+    id,
+    label,
+    description: null,
+    keywords: [label],
+    group: "open",
+    scope: "actions",
+    shortcut: null,
+    actionId: null,
+    subpage: null,
+    run: () => undefined,
+  };
+}
+
+function noticeRow(id: string, label: string): CommandItem {
+  return { ...actionRow(id, label), keywords: [] };
+}
+
+function renderPipeline(args: {
+  readonly shouldFilter: boolean;
+  readonly query: string;
+  readonly items: ReadonlyArray<CommandItem>;
+}) {
+  const subpage: CommandSubpage = {
+    id: filesArtifactsResultSubpageId(),
+    title: "Artifacts",
+    useItems: () => args.items,
+  };
+  return render(
+    <Command filter={paletteFilter} shouldFilter={args.shouldFilter}>
+      <CommandInput
+        value={args.query}
+        onValueChange={() => undefined}
+        placeholder="q"
+      />
+      <CommandList>
+        <PaletteQueryProvider value={args.query}>
+          <SubpageView subpage={subpage} ctx={CTX} onSelect={() => undefined} />
+        </PaletteQueryProvider>
+      </CommandList>
+    </Command>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe("isFilesResultSubpageId", () => {
+  it("matches step-2 result sub-pages, not the step-1 source picker", () => {
+    expect(isFilesResultSubpageId(filesArtifactsResultSubpageId())).toBe(true);
+    expect(
+      isFilesResultSubpageId(filesCodeRootResultSubpageId("host-1", "/ws/a")),
+    ).toBe(true);
+    // Windows root: encoded, still recognized.
+    expect(
+      isFilesResultSubpageId(filesCodeRootResultSubpageId("host-1", "C:\\r")),
+    ).toBe(true);
+    // Step-1 source picker + unrelated pages keep cmdk filtering.
+    expect(isFilesResultSubpageId("open:category:files")).toBe(false);
+    expect(isFilesResultSubpageId("open:category:diff")).toBe(false);
+    expect(isFilesResultSubpageId("open:search:run:artifact")).toBe(false);
+  });
+});
+
+describe("Files result rows through the real cmdk pipeline", () => {
+  const TYPO_QUERY = "flie"; // not an in-order subsequence of "file.ts"
+
+  it("with filtering disabled, a typo query keeps host rows visible AND in host order", () => {
+    renderPipeline({
+      shouldFilter: false,
+      query: TYPO_QUERY,
+      items: [
+        actionRow("open:files:artifacts:a1", "file.ts"),
+        actionRow("open:files:artifacts:a2", "second.ts"),
+      ],
+    });
+    // Both survive the non-subsequence query...
+    expect(screen.getByText("file.ts")).toBeTruthy();
+    expect(screen.getByText("second.ts")).toBeTruthy();
+    // ...and render in the host-provided order (cmdk did not re-rank).
+    const rendered = screen.getAllByRole("option").map((el) => el.textContent);
+    expect(rendered).toEqual(["file.ts", "second.ts"]);
+  });
+
+  it("with filtering disabled, a non-matching query still shows the notice and truncation rows", () => {
+    renderPipeline({
+      shouldFilter: false,
+      query: "zzz",
+      items: [
+        noticeRow(
+          "open:files:artifacts:unavailable",
+          "Artifacts are unavailable",
+        ),
+        noticeRow(
+          "open:files-artifacts:truncated",
+          "Showing first 50 - type to filter",
+        ),
+      ],
+    });
+    expect(screen.getByText("Artifacts are unavailable")).toBeTruthy();
+    expect(screen.getByText("Showing first 50 - type to filter")).toBeTruthy();
+  });
+
+  it("proves the bug the fix avoids: with filtering ENABLED, the same query hides both", () => {
+    renderPipeline({
+      shouldFilter: true,
+      query: "zzz",
+      items: [
+        actionRow("open:files:artifacts:a1", "file.ts"),
+        noticeRow(
+          "open:files:artifacts:unavailable",
+          "Artifacts are unavailable",
+        ),
+      ],
+    });
+    expect(screen.queryByText("file.ts")).toBeNull();
+    expect(screen.queryByText("Artifacts are unavailable")).toBeNull();
+  });
+
+  it("ready-empty stays distinct: an empty result list shows the sub-page empty copy, no notice", () => {
+    renderPipeline({ shouldFilter: false, query: "zzz", items: [] });
+    expect(screen.getByText("Nothing available.")).toBeTruthy();
+    expect(screen.queryByText("Artifacts are unavailable")).toBeNull();
+    expect(screen.queryByRole("option")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/open-files-diff.test.tsx
@@ -1,23 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createElement, type ReactNode } from "react";
 import { cleanup, renderHook } from "@testing-library/react";
-import { PaletteQueryProvider } from "@/lib/commands/palette-query-context";
 import type {
   GitChangedFile,
   WorktreeBindingSelectorRowV12,
 } from "@traycer/protocol/host";
+import type {
+  WorkspaceSearchPathResult,
+  WorkspaceSearchPathsOutcome,
+  WorkspaceSearchPathsResponse,
+  WorkspaceSearchSource,
+} from "@traycer/protocol/host/workspace/unary-schemas";
 import type { CommandContext, CommandItem } from "@/lib/commands/types";
 import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
 import type { OpenTileIntoTargetGroupArgs } from "@/lib/commands/actions/open-into-target";
 import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
+import {
+  EMPTY_PROJECTED_SLICES,
+  type ArtifactProjection,
+  type EpicProjectedSlices,
+  type TreeNode,
+} from "@/stores/epics/open-epic/types";
 import { DEFAULT_DIFF_VIEWER_PREFERENCES } from "@/lib/diff/diff-viewer-preferences";
 import { getBasename } from "@/lib/path/cross-platform-path";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 
-interface FileNode {
-  readonly path: string;
-  readonly name: string;
-}
 interface GitListChangedFilesArgs {
   readonly hostId: string;
   readonly runningDir: string | null;
@@ -29,10 +35,19 @@ const state = vi.hoisted(() => ({
   openTileIntoTargetGroup: vi.fn<(args: OpenTileIntoTargetGroupArgs) => void>(),
   query: "",
   rows: [] as ReadonlyArray<WorktreeBindingSelectorRowV12>,
-  files: [] as ReadonlyArray<FileNode>,
-  truncated: false,
   changedFiles: [] as ReadonlyArray<GitChangedFile>,
   gitListChangedFilesArgs: [] as GitListChangedFilesArgs[],
+  // workspace.searchPaths mock knobs
+  searchResults: [] as ReadonlyArray<WorkspaceSearchPathResult>,
+  // `true` yields the typed `root_unavailable` outcome, else `ready`.
+  searchRootUnavailable: false,
+  searchTruncated: false,
+  searchIsError: false,
+  // Force the echoed source to a different root, to exercise the stale-reply
+  // guard (a late response for a workspace the user has since left).
+  echoRootOverride: null as string | null,
+  projection: null as EpicProjectedSlices | null,
+  defaultHostId: "default-host",
 }));
 
 vi.mock("@/lib/commands/actions", () => ({
@@ -45,19 +60,56 @@ vi.mock("@/hooks/worktree/use-worktree-list-bindings-for-epic-query", () => ({
     isError: false,
   }),
 }));
-vi.mock("@/hooks/workspace/use-list-file-tree-query", () => ({
-  useWorkspaceListFileTree: (workspacePath: string | null) => ({
-    data:
-      workspacePath === null
-        ? undefined
-        : {
-            workspacePath,
-            files: state.files,
-            gitStatus: [],
-            truncated: state.truncated,
-          },
-  }),
+vi.mock("@/lib/host", () => ({ useHostClient: () => ({}) }));
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => state.defaultHostId,
 }));
+vi.mock("@/hooks/ui/use-debounced-value", () => ({
+  useDebouncedValue: (value: unknown) => value,
+}));
+vi.mock("@/lib/commands/sources/open/use-active-epic-projection", () => ({
+  useActiveEpicProjection: () => state.projection,
+}));
+vi.mock("@/hooks/workspace/use-workspace-search-paths-query", async () => {
+  const actual = await vi.importActual(
+    "@/hooks/workspace/use-workspace-search-paths-query",
+  );
+  return {
+    ...actual,
+    // Echo the requested source (or a forced-different root) so the REAL
+    // `readSearchPathsResponseForSource` guard is exercised end-to-end.
+    useWorkspaceSearchPathsForSource: (args: {
+      readonly source: WorkspaceSearchSource | null;
+      readonly epicId: string;
+    }) => ({
+      data:
+        args.source === null
+          ? undefined
+          : buildSearchResponse(args.source, args.epicId),
+      isError: state.searchIsError,
+    }),
+  };
+});
+
+function buildSearchResponse(
+  source: WorkspaceSearchSource,
+  epicId: string,
+): WorkspaceSearchPathsResponse {
+  const outcome: WorkspaceSearchPathsOutcome = state.searchRootUnavailable
+    ? "root_unavailable"
+    : "ready";
+  const common = {
+    epicId,
+    outcome,
+    results: [...state.searchResults],
+    truncated: state.searchTruncated,
+  };
+  if ("kind" in source) {
+    return { ...common, source: { kind: "epic-artifacts" } };
+  }
+  return { ...common, root: state.echoRootOverride ?? source.root };
+}
+
 vi.mock("@/hooks/git/use-git-list-changed-files-subscription", () => ({
   useGitListChangedFilesSubscription: (args: GitListChangedFilesArgs) => {
     state.gitListChangedFilesArgs.push(args);
@@ -174,22 +226,6 @@ function renderSubpageItems(item: CommandItem): ReadonlyArray<CommandItem> {
   ).result.current;
 }
 
-function queryWrapper(
-  query: string,
-): (props: { readonly children: ReactNode }) => ReactNode {
-  return ({ children }) =>
-    createElement(PaletteQueryProvider, { value: query }, children);
-}
-
-function renderItemsWithQuery(
-  hook: (ctx: CommandContext) => ReadonlyArray<CommandItem>,
-  query: string,
-): ReadonlyArray<CommandItem> {
-  return renderHook<ReadonlyArray<CommandItem>, unknown>(() => hook(CTX), {
-    wrapper: queryWrapper(query),
-  }).result.current;
-}
-
 function runById(items: ReadonlyArray<CommandItem>, id: string): void {
   const item = items.find((entry) => entry.id === id);
   if (item === undefined) throw new Error(`no opener item ${id}`);
@@ -205,10 +241,15 @@ function lastTileOpen(): OpenTileIntoTargetGroupArgs {
 beforeEach(() => {
   state.query = "";
   state.rows = [];
-  state.files = [];
-  state.truncated = false;
   state.changedFiles = [];
   state.gitListChangedFilesArgs = [];
+  state.searchResults = [];
+  state.searchRootUnavailable = false;
+  state.searchTruncated = false;
+  state.searchIsError = false;
+  state.echoRootOverride = null;
+  state.projection = null;
+  state.defaultHostId = "default-host";
   useSettingsStore.setState({
     diffViewerPreferences: DEFAULT_DIFF_VIEWER_PREFERENCES,
   });
@@ -219,106 +260,276 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("Files opener sub-page", () => {
-  it("multi-workspace shows a workspace step that drills into files", () => {
-    state.rows = [bindingRow("/ws/alpha", true), bindingRow("/ws/beta", false)];
-    state.files = [{ path: "src/a.ts", name: "a.ts" }];
+function fileResult(relPath: string, name: string): WorkspaceSearchPathResult {
+  return { kind: "file", relPath, name };
+}
+
+interface ArtifactSpec {
+  readonly id: string;
+  readonly folderName: string;
+  readonly title: string;
+  readonly parentId: string | null;
+}
+
+function projectionOf(specs: ReadonlyArray<ArtifactSpec>): EpicProjectedSlices {
+  const byId: Record<string, ArtifactProjection> = {};
+  const nodeById: Record<string, TreeNode> = {};
+  for (const spec of specs) {
+    byId[spec.id] = {
+      id: spec.id,
+      kind: "spec",
+      title: spec.title,
+      folderName: spec.folderName,
+      parentId: spec.parentId,
+      artifactRoomId: null,
+      createdAt: 0,
+      updatedAt: 0,
+      status: null,
+      createdManually: false,
+    };
+    nodeById[spec.id] = {
+      id: spec.id,
+      parentId: spec.parentId,
+      title: spec.title,
+      type: "spec",
+      status: null,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  }
+  return {
+    ...EMPTY_PROJECTED_SLICES,
+    artifacts: { allIds: specs.map((spec) => spec.id), byId },
+    tree: {
+      rootIds: specs
+        .filter((spec) => spec.parentId === null)
+        .map((spec) => spec.id),
+      childrenByParent: {},
+      nodeById,
+    },
+  };
+}
+
+describe("Files opener sub-page (source list)", () => {
+  it("always offers Artifacts first, then each browsable root - no single-workspace shortcut", () => {
+    state.rows = [bindingRow("/ws/alpha", true), bindingRow("/ws/only", true)];
     const items = renderItems(useFilesOpenerItems);
     expect(items.map((i) => i.id)).toEqual([
+      "open:files:artifacts",
       "open:files:ws:default-host:%2Fws%2Falpha",
-      "open:files:ws:default-host:%2Fws%2Fbeta",
+      "open:files:ws:default-host:%2Fws%2Fonly",
     ]);
-    const fileItems = renderSubpageItems(items[0]);
-    expect(fileItems[0].id).toBe("open:files:/ws/alpha:src/a.ts");
-    runById(fileItems, "open:files:/ws/alpha:src/a.ts");
+    // Every entry is a step (subpage), never an immediate file open.
+    expect(items.every((i) => i.subpage !== null)).toBe(true);
+  });
+
+  it("keeps Artifacts available even with a single workspace (no auto-skip)", () => {
+    state.rows = [bindingRow("/ws/only", true)];
+    const items = renderItems(useFilesOpenerItems);
+    expect(items.map((i) => i.id)).toEqual([
+      "open:files:artifacts",
+      "open:files:ws:default-host:%2Fws%2Fonly",
+    ]);
+  });
+
+  it("offers Artifacts for an Epic with no attached code workspace", () => {
+    state.rows = [];
+    const items = renderItems(useFilesOpenerItems);
+    expect(items.map((i) => i.id)).toEqual(["open:files:artifacts"]);
+  });
+
+  it("includes bound worktree roots as sources", () => {
+    state.rows = [
+      bindingRow("/ws/main", true),
+      worktreeBindingRow("/ws/main", "/worktrees/feature"),
+    ];
+    const items = renderItems(useFilesOpenerItems);
+    expect(items.map((i) => i.id)).toEqual([
+      "open:files:artifacts",
+      "open:files:ws:default-host:%2Fws%2Fmain",
+      "open:files:ws:default-host:%2Fworktrees%2Ffeature",
+    ]);
+  });
+});
+
+describe("Files opener sub-page (code root step)", () => {
+  function codeStepItems(root: string): ReadonlyArray<CommandItem> {
+    state.rows = [bindingRow(root, true)];
+    const items = renderItems(useFilesOpenerItems);
+    const rootItem = items.find((i) => i.id.startsWith("open:files:ws:"));
+    if (rootItem === undefined) throw new Error("no code-root source");
+    return renderSubpageItems(rootItem);
+  }
+
+  it("opens a host-ranked file result as a WorkspaceFileRef", () => {
+    state.searchResults = [fileResult("src/a.ts", "a.ts")];
+    const fileItems = codeStepItems("/ws/only");
+    expect(fileItems.map((i) => i.id)).toEqual([
+      "open:files:/ws/only:src/a.ts",
+    ]);
+    runById(fileItems, "open:files:/ws/only:src/a.ts");
     const opened = lastTileOpen();
     expect(opened.groupId).toBe("group-1");
-    // Proves the opener leaf threads the ctx.router navigation seam through
-    // to openTileIntoTargetGroup instead of bypassing it.
     expect(opened.navigateNestedFocus).toBe(navigateNestedFocusSpy);
     expect(opened.ref.type).toBe("workspace-file");
     expect(opened.ref.id).toContain("src%2Fa.ts");
   });
 
-  it("single-workspace skips straight to the file step", () => {
-    state.rows = [bindingRow("/ws/only", true)];
-    state.files = [{ path: "src/b.ts", name: "b.ts" }];
-    const items = renderItems(useFilesOpenerItems);
-    expect(items.map((i) => i.id)).toEqual(["open:files:/ws/only:src/b.ts"]);
-    runById(items, "open:files:/ws/only:src/b.ts");
-    expect(lastTileOpen().ref.type).toBe("workspace-file");
-  });
-
-  it("caps a large tree and appends a truncated hint", () => {
-    state.rows = [bindingRow("/ws/only", true)];
-    state.files = Array.from({ length: 250 }, (_, i) => ({
-      path: `src/f${i}.ts`,
-      name: `f${i}.ts`,
-    }));
-    const items = renderItems(useFilesOpenerItems);
-    expect(items.length).toBe(101); // OPENER_RESULT_CAP (100) + hint row
-    expect(items[items.length - 1].id).toBe("open:files:truncated");
-  });
-
-  it("filters the file step by the surface's live query, not the global store", () => {
-    // The store query is left empty; only the provided surface query should
-    // narrow the list. This guards against the modal palette's query bleeding
-    // into an open in-pane opener (they keep independent query state).
-    state.query = "";
-    state.rows = [bindingRow("/ws/only", true)];
-    state.files = [
-      { path: "src/alpha.ts", name: "alpha.ts" },
-      { path: "src/beta.ts", name: "beta.ts" },
-    ];
-    const items = renderItemsWithQuery(useFilesOpenerItems, "alpha");
-    expect(items.map((i) => i.id)).toEqual([
-      "open:files:/ws/only:src/alpha.ts",
+  it("appends a truncated hint when the host caps the result set", () => {
+    state.searchResults = [fileResult("src/a.ts", "a.ts")];
+    state.searchTruncated = true;
+    const fileItems = codeStepItems("/ws/only");
+    expect(fileItems.map((i) => i.id)).toEqual([
+      "open:files:/ws/only:src/a.ts",
+      "open:files:truncated",
     ]);
   });
 
-  it("narrows a large tree by a bare filename query", () => {
-    state.rows = [bindingRow("/ws/only", true)];
-    state.files = [
-      ...Array.from({ length: 250 }, (_, i) => ({
-        path: `src/f${i}.ts`,
-        name: `f${i}.ts`,
-      })),
-      { path: "src/deep/needle.tsx", name: "needle.tsx" },
-    ];
-    const items = renderItemsWithQuery(useFilesOpenerItems, "needle.tsx");
-    expect(items.map((i) => i.id)).toEqual([
-      "open:files:/ws/only:src/deep/needle.tsx",
+  it("shows a distinct notice when the workspace root is unavailable", () => {
+    state.searchRootUnavailable = true;
+    const fileItems = codeStepItems("/ws/only");
+    expect(fileItems.map((i) => i.id)).toEqual([
+      "open:files:ws:/ws/only:unavailable",
+    ]);
+    expect(fileItems.every((i) => i.subpage === null)).toBe(true);
+  });
+
+  it("shows a distinct notice when the host lacks the search RPC", () => {
+    state.searchIsError = true;
+    const fileItems = codeStepItems("/ws/only");
+    expect(fileItems.map((i) => i.id)).toEqual([
+      "open:files:ws:/ws/only:unsupported",
     ]);
   });
 
-  it("resolves a pasted absolute path to its workspace-relative file", () => {
-    state.rows = [bindingRow("/ws/only", true)];
-    state.files = [
-      { path: "src/a.ts", name: "a.ts" },
-      { path: "src/components/foo.tsx", name: "foo.tsx" },
+  it("returns no rows for a ready-but-empty search (distinct from unavailable)", () => {
+    state.searchResults = [];
+    state.searchRootUnavailable = false;
+    const fileItems = codeStepItems("/ws/only");
+    expect(fileItems).toEqual([]);
+  });
+
+  it("drops a late reply echoing a different root (stale-selection guard)", () => {
+    state.searchResults = [fileResult("src/a.ts", "a.ts")];
+    state.echoRootOverride = "/ws/some-previous-workspace";
+    const fileItems = codeStepItems("/ws/only");
+    expect(fileItems).toEqual([]);
+  });
+
+  it("keeps a Windows workspace root verbatim in the opened ref", () => {
+    state.searchResults = [fileResult("src/win.ts", "win.ts")];
+    const fileItems = codeStepItems("C:\\repo");
+    runById(fileItems, "open:files:C:\\repo:src/win.ts");
+    const opened = lastTileOpen();
+    expect(opened.ref.type).toBe("workspace-file");
+    // The host-canonical relPath and native root both survive into the ref id.
+    expect(opened.ref.id).toContain("src%2Fwin.ts");
+  });
+});
+
+describe("Files opener sub-page (Artifacts step)", () => {
+  function artifactStepItems(): ReadonlyArray<CommandItem> {
+    const items = renderItems(useFilesOpenerItems);
+    const artifactsItem = items.find((i) => i.id === "open:files:artifacts");
+    if (artifactsItem === undefined) throw new Error("no artifacts source");
+    return renderSubpageItems(artifactsItem);
+  }
+
+  it("resolves a logical artifact path to an authoritative artifact and opens it", () => {
+    state.projection = projectionOf([
+      { id: "a1", folderName: "one", title: "First Spec", parentId: null },
+    ]);
+    state.searchResults = [fileResult("one", "one")];
+    const items = artifactStepItems();
+    expect(items.map((i) => i.id)).toEqual(["open:files:artifacts:a1"]);
+    expect(items[0].label).toBe("First Spec");
+    runById(items, "open:files:artifacts:a1");
+    const opened = lastTileOpen();
+    expect(opened.ref.type).toBe("spec");
+    expect(opened.ref.id).toBe("a1");
+    expect(opened.ref.name).toBe("First Spec");
+  });
+
+  it("disambiguates duplicate leaf titles by their ancestor-title path", () => {
+    state.projection = projectionOf([
+      { id: "p1", folderName: "parent-a", title: "Parent A", parentId: null },
+      { id: "p2", folderName: "parent-b", title: "Parent B", parentId: null },
+      { id: "c1", folderName: "child", title: "Notes", parentId: "p1" },
+      { id: "c2", folderName: "child", title: "Notes", parentId: "p2" },
+    ]);
+    state.searchResults = [
+      fileResult("parent-a/child", "child"),
+      fileResult("parent-b/child", "child"),
     ];
-    const items = renderItemsWithQuery(
-      useFilesOpenerItems,
-      "/ws/only/src/components/foo.tsx",
+    const items = artifactStepItems();
+    expect(items.map((i) => i.label)).toEqual([
+      "Parent A / Notes",
+      "Parent B / Notes",
+    ]);
+    expect(items.map((i) => i.id)).toEqual([
+      "open:files:artifacts:c1",
+      "open:files:artifacts:c2",
+    ]);
+  });
+
+  it("drops a stale/deleted artifact whose path is not in authoritative state", () => {
+    state.projection = projectionOf([
+      { id: "a1", folderName: "kept", title: "Kept", parentId: null },
+    ]);
+    state.searchResults = [
+      fileResult("kept", "kept"),
+      fileResult("deleted-on-disk", "deleted-on-disk"),
+    ];
+    const items = artifactStepItems();
+    // Only the still-projected artifact survives; the orphan disk row is gone.
+    expect(items.map((i) => i.id)).toEqual(["open:files:artifacts:a1"]);
+  });
+
+  it("fails closed on an ambiguous logical path - no row, no open", () => {
+    // Two live artifacts claim the same folder chain "dup" (a malformed
+    // projection). The shared fail-closed index resolves it to no identity, so
+    // the result row is dropped and clicking opens nothing.
+    state.projection = projectionOf([
+      { id: "a", folderName: "dup", title: "A", parentId: null },
+      { id: "b", folderName: "dup", title: "B", parentId: null },
+    ]);
+    state.searchResults = [fileResult("dup", "dup")];
+    const items = artifactStepItems();
+    expect(items.some((i) => i.id.startsWith("open:files:artifacts:"))).toBe(
+      false,
     );
+    expect(state.openTileIntoTargetGroup).not.toHaveBeenCalled();
+  });
+
+  it("shows a distinct notice when the artifact mirror is unavailable", () => {
+    state.projection = projectionOf([]);
+    state.searchRootUnavailable = true;
+    const items = artifactStepItems();
     expect(items.map((i) => i.id)).toEqual([
-      "open:files:/ws/only:src/components/foo.tsx",
+      "open:files:artifacts:unavailable",
     ]);
   });
 
-  it("includes bound worktree roots in the workspace step", () => {
-    state.rows = [
-      bindingRow("/ws/main", true),
-      worktreeBindingRow("/ws/main", "/worktrees/feature"),
-    ];
-    state.files = [{ path: "src/wt.ts", name: "wt.ts" }];
-    const items = renderItems(useFilesOpenerItems);
+  it("shows a distinct notice when the host lacks the search RPC", () => {
+    state.projection = projectionOf([]);
+    state.searchIsError = true;
+    const items = artifactStepItems();
     expect(items.map((i) => i.id)).toEqual([
-      "open:files:ws:default-host:%2Fws%2Fmain",
-      "open:files:ws:default-host:%2Fworktrees%2Ffeature",
+      "open:files:artifacts:unsupported",
     ]);
-    const fileItems = renderSubpageItems(items[1]);
-    expect(fileItems[0].id).toBe("open:files:/worktrees/feature:src/wt.ts");
+  });
+
+  it("appends a truncated hint for a capped artifact result set", () => {
+    state.projection = projectionOf([
+      { id: "a1", folderName: "one", title: "One", parentId: null },
+    ]);
+    state.searchResults = [fileResult("one", "one")];
+    state.searchTruncated = true;
+    const items = artifactStepItems();
+    expect(items.map((i) => i.id)).toEqual([
+      "open:files:artifacts:a1",
+      "open:files-artifacts:truncated",
+    ]);
   });
 });
 

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/parse-globs.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/parse-globs.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { parseGlobs } from "@/lib/commands/sources/open/parse-globs";
+
+describe("parseGlobs", () => {
+  it("splits multiple comma-separated patterns and trims whitespace", () => {
+    expect(parseGlobs("*.ts, src/** ,  lib/*.js")).toEqual([
+      "*.ts",
+      "src/**",
+      "lib/*.js",
+    ]);
+  });
+
+  it("drops empty tokens from blank / whitespace / stray-separator input", () => {
+    expect(parseGlobs("")).toEqual([]);
+    expect(parseGlobs("   ")).toEqual([]);
+    expect(parseGlobs(" , ,, ")).toEqual([]);
+    expect(parseGlobs("*.ts,,")).toEqual(["*.ts"]);
+  });
+
+  it("expands extension shorthand into a basename glob", () => {
+    expect(parseGlobs(".md, .tsx")).toEqual(["*.md", "*.tsx"]);
+  });
+
+  it("keeps commas inside a brace expression as one pattern", () => {
+    expect(parseGlobs("{a,b}.ts")).toEqual(["{a,b}.ts"]);
+    expect(parseGlobs("src/{a,b,c}/**, *.js")).toEqual([
+      "src/{a,b,c}/**",
+      "*.js",
+    ]);
+    // Nested braces track depth correctly.
+    expect(parseGlobs("{a,{b,c}}.ts, x.js")).toEqual(["{a,{b,c}}.ts", "x.js"]);
+  });
+
+  it("keeps an escaped comma as a literal within one pattern", () => {
+    // The backslash-escape survives to rg, which unescapes `\,` to a literal.
+    expect(parseGlobs("a\\,b.ts")).toEqual(["a\\,b.ts"]);
+    expect(parseGlobs("a\\,b, c")).toEqual(["a\\,b", "c"]);
+  });
+
+  it("handles malformed/unbalanced braces as a defined single token", () => {
+    // Unbalanced OPEN brace swallows the rest (rg then rejects it) - never a
+    // silent mis-split.
+    expect(parseGlobs("{a,b")).toEqual(["{a,b"]);
+    // An unbalanced CLOSE brace keeps depth at floor 0, so the comma still
+    // splits.
+    expect(parseGlobs("a,b}")).toEqual(["a", "b}"]);
+  });
+
+  it("keeps a trailing backslash without consuming a missing next char", () => {
+    expect(parseGlobs("a\\")).toEqual(["a\\"]);
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/search-subpage.test.tsx
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/search-subpage.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import type { CommandContext, CommandItem } from "@/lib/commands/types";
+import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
+
+interface Row {
+  readonly hostId: string;
+  readonly runningDir: string;
+  readonly disabledReason: string | null;
+}
+
+const state = vi.hoisted(() => ({ rows: [] as ReadonlyArray<Row> }));
+
+vi.mock("@/hooks/worktree/use-worktree-list-bindings-for-epic-query", () => ({
+  useWorktreeListBindingsForEpic: () => ({
+    data: { rows: state.rows },
+    isPending: false,
+    isError: false,
+  }),
+}));
+
+import { useSearchOpenerItems } from "@/lib/commands/sources/open/search-subpage";
+
+function noopRouter(): KeybindingRouter {
+  return {
+    getPathname: () => "/",
+    navigateHome: () => undefined,
+    navigateSettings: () => undefined,
+    navigateToEpic: () => undefined,
+    navigateToEpicTab: () => undefined,
+    navigateToEpicList: () => undefined,
+    navigateSettingsSection: () => undefined,
+    navigateToTabIntent: () => undefined,
+    goBack: () => undefined,
+    goForward: () => undefined,
+    isHistoryNavAvailable: () => false,
+    canGoBack: () => false,
+    canGoForward: () => false,
+  };
+}
+
+const CTX: CommandContext = {
+  pathname: "/",
+  router: noopRouter(),
+  activeTabId: "tab-1",
+  activeEpicId: "epic-1",
+  focusedComposerKind: null,
+  targetGroupId: "group-1",
+};
+
+function items(): ReadonlyArray<CommandItem> {
+  return renderHook<ReadonlyArray<CommandItem>, unknown>(() =>
+    useSearchOpenerItems(CTX),
+  ).result.current;
+}
+
+function row(runningDir: string, disabledReason: string | null): Row {
+  return { hostId: "host-a", runningDir, disabledReason };
+}
+
+beforeEach(() => {
+  state.rows = [];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useSearchOpenerItems (step 1: target selection)", () => {
+  it("always lists the Epic artifact workspace even with no code workspace", () => {
+    const result = items();
+    expect(result.map((i) => i.label)).toEqual(["Artifacts"]);
+    expect(result[0].subpage?.id).toBe("open:search:run:artifact");
+  });
+
+  it("lists only browsable workspace/worktree roots after the artifact target", () => {
+    state.rows = [
+      row("/ws/alpha", null),
+      row("/ws/disabled", "setup_pending"),
+      row("/worktrees/feature", null),
+    ];
+    const result = items();
+    expect(result.map((i) => i.label)).toEqual([
+      "Artifacts",
+      "alpha",
+      "feature",
+    ]);
+    expect(result[1].subpage?.id).toBe(
+      "open:search:run:code:host-a:%2Fws%2Falpha",
+    );
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/search-target.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/search-target.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSearchRunSubpageId,
+  parseSearchRunSubpageId,
+  searchRunSubpageId,
+  type SearchRunTarget,
+} from "@/lib/commands/sources/open/search-target";
+
+describe("search-target sub-page id round-trip", () => {
+  const cases: ReadonlyArray<SearchRunTarget> = [
+    { kind: "artifact" },
+    { kind: "code", hostId: "host-a", root: "/ws/alpha" },
+    // A Windows drive root contains `:` - encodeURIComponent escapes it, so it
+    // cannot collide with the field separator.
+    { kind: "code", hostId: "host-b", root: "C:\\Users\\dev\\repo" },
+    // Colons and spaces in the root survive the round-trip.
+    { kind: "code", hostId: "h:1", root: "/ws/a b:c/deep" },
+  ];
+
+  it.each(cases)("round-trips %o", (target) => {
+    const id = searchRunSubpageId(target);
+    expect(isSearchRunSubpageId(id)).toBe(true);
+    expect(parseSearchRunSubpageId(id)).toEqual(target);
+  });
+
+  it("recognizes only search-run ids", () => {
+    expect(isSearchRunSubpageId("open:files:ws:host:root")).toBe(false);
+    expect(isSearchRunSubpageId("open:search:target:artifact")).toBe(false);
+    expect(parseSearchRunSubpageId("open:files:x")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/commands/sources/open/__tests__/search-target.test.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/__tests__/search-target.test.ts
@@ -28,4 +28,10 @@ describe("search-target sub-page id round-trip", () => {
     expect(isSearchRunSubpageId("open:search:target:artifact")).toBe(false);
     expect(parseSearchRunSubpageId("open:files:x")).toBeNull();
   });
+
+  it("rejects malformed percent-encoded code ids without throwing", () => {
+    const id = "open:search:run:code:host-a:%";
+    expect(isSearchRunSubpageId(id)).toBe(true);
+    expect(parseSearchRunSubpageId(id)).toBeNull();
+  });
 });

--- a/clients/gui-app/src/lib/commands/sources/open/artifact-display-index.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/artifact-display-index.ts
@@ -1,0 +1,79 @@
+/**
+ * Display index for the Files opener's Epic-artifacts step: a
+ * `logicalPath -> { id, kind, title, titlePath }` map for rendering + opening a
+ * `workspace.searchPaths` artifact result.
+ *
+ * Path resolution is delegated to the SHARED, fail-closed
+ * {@link buildArtifactPathIndex} (Ticket 7's `artifact-path-resolver.ts`) so the
+ * two opener flows cannot diverge: a logical path claimed by two or more live
+ * artifacts is ambiguous and resolves to NO identity (never first/last-writer
+ * wins), so an ambiguous result opens nothing. This module only layers the
+ * display fields the Files rows need on top of that shared resolution: the
+ * user-facing {@link displayTitle} and an ancestor-title path that distinguishes
+ * duplicate leaf titles.
+ */
+import { displayTitle } from "@/lib/display-title";
+import { buildArtifactPathIndex } from "@/lib/commands/sources/open/artifact-path-resolver";
+import type {
+  ArtifactsSlice,
+  TreeSlice,
+} from "@/stores/epics/open-epic/types";
+import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+
+export interface ArtifactPathEntry {
+  readonly id: string;
+  readonly kind: EpicArtifactKind;
+  /** Display title of the leaf artifact (host-independent, user-renamed). */
+  readonly title: string;
+  /**
+   * Ancestor-to-leaf display titles joined by " / ". Distinguishes duplicate
+   * leaf titles by their parent context and reads better than the folder slug
+   * path, while the slug path stays available as a search keyword.
+   */
+  readonly titlePath: string;
+}
+
+export function buildArtifactDisplayPathIndex(
+  tree: TreeSlice,
+  artifacts: ArtifactsSlice,
+): ReadonlyMap<string, ArtifactPathEntry> {
+  const resolution = buildArtifactPathIndex(tree, artifacts);
+  const index = new Map<string, ArtifactPathEntry>();
+  for (const [logicalPath, resolved] of resolution) {
+    index.set(logicalPath, {
+      id: resolved.id,
+      kind: resolved.kind,
+      title: displayTitle(resolved.title, resolved.kind),
+      titlePath: artifactTitlePath(tree, artifacts, resolved.id),
+    });
+  }
+  return index;
+}
+
+/** Root-to-leaf display titles for `artifactId`, joined by " / ". */
+function artifactTitlePath(
+  tree: TreeSlice,
+  artifacts: ArtifactsSlice,
+  artifactId: string,
+): string {
+  const titles: string[] = [];
+  const visited = new Set<string>();
+  let current: string | null = artifactId;
+  while (current !== null) {
+    if (visited.has(current)) break;
+    visited.add(current);
+    if (Object.hasOwn(artifacts.byId, current)) {
+      const artifact = artifacts.byId[current];
+      titles.unshift(displayTitle(artifact.title, artifact.kind));
+    }
+    current = Object.hasOwn(tree.nodeById, current)
+      ? tree.nodeById[current].parentId
+      : null;
+  }
+  return titles.join(" / ");
+}
+
+/** Strip leading/trailing slashes so client + host path forms compare equal. */
+export function normalizeArtifactLogicalPath(rawRelPath: string): string {
+  return rawRelPath.replace(/^\/+/, "").replace(/\/+$/, "");
+}

--- a/clients/gui-app/src/lib/commands/sources/open/artifact-display-index.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/artifact-display-index.ts
@@ -14,10 +14,7 @@
  */
 import { displayTitle } from "@/lib/display-title";
 import { buildArtifactPathIndex } from "@/lib/commands/sources/open/artifact-path-resolver";
-import type {
-  ArtifactsSlice,
-  TreeSlice,
-} from "@/stores/epics/open-epic/types";
+import type { ArtifactsSlice, TreeSlice } from "@/stores/epics/open-epic/types";
 import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
 
 export interface ArtifactPathEntry {

--- a/clients/gui-app/src/lib/commands/sources/open/artifact-path-resolver.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/artifact-path-resolver.ts
@@ -1,0 +1,86 @@
+/**
+ * Resolve a text-search result's LOGICAL artifact path back to the authoritative
+ * artifact identity in live Yjs Epic state.
+ *
+ * `workspace.searchText` `{ kind: "epic-artifacts" }` returns matches keyed by a
+ * logical artifact path (the on-disk `<chain>/index.md` mirror projected to its
+ * folder chain, e.g. `tickets/my-ticket`). A result is an eventually-consistent
+ * DISK projection and grants no authority to open anything: before opening, the
+ * renderer re-resolves that logical path against the live projection so a stale
+ * or deleted disk hit fails safe (resolver returns `null`) instead of opening the
+ * mirror Markdown as a workspace file. The logical path equals
+ * `artifactFolderChain(...).join("/")`, so the index is built the same way the
+ * host projects the path - no reverse RPC needed.
+ */
+import { useCallback, useMemo } from "react";
+import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+import { artifactFolderChain } from "@/lib/artifacts/artifact-folder-chain";
+import { useActiveEpicProjection } from "@/lib/commands/sources/open/use-active-epic-projection";
+import type { ArtifactsSlice, TreeSlice } from "@/stores/epics/open-epic/types";
+
+export interface ResolvedArtifact {
+  readonly id: string;
+  readonly kind: EpicArtifactKind;
+  readonly title: string;
+}
+
+/**
+ * Build a `logicalPath -> { id, kind, title }` index for every live artifact
+ * whose folder chain resolves. Artifacts with an unresolvable chain (unknown
+ * ancestor, cycle, empty folder name) are skipped, matching the host, which can
+ * only project a mirror path from a well-formed chain.
+ *
+ * A logical path claimed by TWO OR MORE live artifacts is AMBIGUOUS and fails
+ * closed: it is omitted from the index (order-independently), so the resolver
+ * returns no identity rather than opening one of them by iteration order. The
+ * caller then falls back to the same safe path as a stale/deleted hit (toast, no
+ * open). This can only happen from a malformed projection - the host mirror
+ * layout is one directory per artifact - but resolution stays deterministic.
+ */
+export function buildArtifactPathIndex(
+  tree: TreeSlice | null,
+  artifacts: ArtifactsSlice | null,
+): Map<string, ResolvedArtifact> {
+  const index = new Map<string, ResolvedArtifact>();
+  if (tree === null || artifacts === null) return index;
+  const ambiguous = new Set<string>();
+  for (const id of artifacts.allIds) {
+    const chain = artifactFolderChain(tree, artifacts, id);
+    if (chain === null) continue;
+    const key = chain.join("/");
+    if (ambiguous.has(key)) continue;
+    if (index.has(key)) {
+      // A second artifact claims this path: drop it entirely and remember it so
+      // a later third claimant does not re-add it. `.get()` then misses no
+      // matter the iteration order - fail closed, never first/last wins.
+      index.delete(key);
+      ambiguous.add(key);
+      continue;
+    }
+    const artifact = artifacts.byId[id];
+    index.set(key, {
+      id,
+      kind: artifact.kind,
+      title: artifact.title,
+    });
+  }
+  return index;
+}
+
+/**
+ * Returns a resolver from a logical artifact path to its authoritative identity,
+ * or `null` when no live artifact occupies that path (stale/deleted result).
+ */
+export function useArtifactPathResolver(
+  epicId: string | null,
+): (logicalPath: string) => ResolvedArtifact | null {
+  const projection = useActiveEpicProjection(epicId);
+  const index = useMemo(
+    () => buildArtifactPathIndex(projection?.tree ?? null, projection?.artifacts ?? null),
+    [projection],
+  );
+  return useCallback(
+    (logicalPath: string) => index.get(logicalPath) ?? null,
+    [index],
+  );
+}

--- a/clients/gui-app/src/lib/commands/sources/open/artifact-path-resolver.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/artifact-path-resolver.ts
@@ -76,7 +76,11 @@ export function useArtifactPathResolver(
 ): (logicalPath: string) => ResolvedArtifact | null {
   const projection = useActiveEpicProjection(epicId);
   const index = useMemo(
-    () => buildArtifactPathIndex(projection?.tree ?? null, projection?.artifacts ?? null),
+    () =>
+      buildArtifactPathIndex(
+        projection?.tree ?? null,
+        projection?.artifacts ?? null,
+      ),
     [projection],
   );
   return useCallback(

--- a/clients/gui-app/src/lib/commands/sources/open/files-result-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/files-result-subpage.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared identity for the Files opener's step-2 RESULT sub-pages (the artifact
+ * step and each code workspace/worktree step).
+ *
+ * Step 2 lists come straight from `workspace.searchPaths` - already scoped to
+ * the query and ranked by the host's Fuse (typo/transposition tolerant). The
+ * pane opener recognizes these ids to turn cmdk's own filtering OFF for them, so
+ * the host order is preserved unchanged and cmdk's strict subsequence scorer
+ * neither re-ranks the rows nor hides typo matches or the typed
+ * notice/truncation rows. cmdk filtering stays ON for the step-1 SOURCE picker
+ * (`open:category:files`) and every unrelated opener page.
+ *
+ * The target is carried IN the id (like `search-target.ts`) so no other sub-page
+ * constructor or the shared `CommandSubpage` type has to change.
+ */
+
+const ARTIFACTS_ID = "open:files:artifacts";
+const CODE_PREFIX = "open:files:ws:";
+
+export function filesArtifactsResultSubpageId(): string {
+  return ARTIFACTS_ID;
+}
+
+/**
+ * `hostId` is left verbatim (it is a colon-free device id) and `runningDir` is
+ * `encodeURIComponent`d (which escapes `:` and `/`, so a Windows `C:\…` root
+ * cannot collide with the field separator or the prefix).
+ */
+export function filesCodeRootResultSubpageId(
+  hostId: string,
+  runningDir: string,
+): string {
+  return `${CODE_PREFIX}${hostId}:${encodeURIComponent(runningDir)}`;
+}
+
+/** True for a step-2 host-result sub-page; false for the step-1 source picker. */
+export function isFilesResultSubpageId(id: string): boolean {
+  return id === ARTIFACTS_ID || id.startsWith(CODE_PREFIX);
+}

--- a/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
@@ -1,25 +1,50 @@
 /**
- * Opener "Files" sub-page (two-step): step 1 picks a linked workspace, step 2
- * fuzzes the workspace file tree. A single-workspace epic skips straight to the
- * file step. The chosen file opens into the target group as a WorkspaceFileRef.
+ * Opener "Files" sub-page (two-step): step 1 picks a source - the always-present
+ * `Artifacts` source plus every browsable attached workspace/worktree -
+ * and step 2 fuzz-searches that source's logical paths through the host
+ * `workspace.searchPaths` RPC (host `rg --files` enumeration + Fuse ranking),
+ * NOT a full renderer-side tree download + substring filter.
  *
- * Large-tree handling: the host caps the tree at 25k entries (response
- * `truncated`); we additionally substring-filter by the live palette query and
- * render only the top `OPENER_RESULT_CAP` rows so the sub-page stays
- * responsive, appending a hint row when results are capped.
+ * There is no single-workspace shortcut: `Artifacts` is a first-class
+ * source, so auto-skipping to a lone workspace would hide it. A code result
+ * opens as a `WorkspaceFileRef`; an artifact result is resolved against the
+ * authoritative open-epic Yjs projection and opens as an `EpicArtifactRef`
+ * (stale/deleted disk results resolve to nothing and are dropped).
+ *
+ * The pane opener disables cmdk filtering for the result step so host Fuse
+ * ranking, typo-tolerant matches, and search-state notices are preserved. The
+ * source-picker step and unrelated opener pages keep cmdk filtering enabled.
  */
 import { useMemo } from "react";
-import { getBasename } from "@/lib/path/cross-platform-path";
+import { v4 as uuidv4 } from "uuid";
 import type { WorktreeBindingSelectorRow } from "@traycer/protocol/host";
-import { useWorkspaceListFileTree } from "@/hooks/workspace/use-list-file-tree-query";
+import type { WorkspaceSearchSource } from "@traycer/protocol/host/workspace/unary-schemas";
+import { getBasename } from "@/lib/path/cross-platform-path";
+import { useHostClient } from "@/lib/host";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
+import { useDebouncedValue } from "@/hooks/ui/use-debounced-value";
+import {
+  readSearchPathsResponseForSource,
+  useWorkspaceSearchPathsForSource,
+  type WorkspaceSearchPathsView,
+} from "@/hooks/workspace/use-workspace-search-paths-query";
 import { useWorktreeListBindingsForEpic } from "@/hooks/worktree/use-worktree-list-bindings-for-epic-query";
 import { workspaceFileRefFromTreePath } from "@/components/epic-canvas/workspace-file/workspace-file-ref";
 import { openTileIntoTargetGroup } from "@/lib/commands/actions";
 import { usePaletteLiveQuery } from "@/lib/commands/palette-query-context";
-import { matchesPathQuery } from "@/lib/commands/path-query";
 import { isBrowsable } from "@/lib/worktree/worktree-row-browsable";
+import { useActiveEpicProjection } from "@/lib/commands/sources/open/use-active-epic-projection";
 import {
-  OPENER_RESULT_CAP,
+  buildArtifactDisplayPathIndex,
+  normalizeArtifactLogicalPath,
+  type ArtifactPathEntry,
+} from "@/lib/commands/sources/open/artifact-display-index";
+import {
+  filesArtifactsResultSubpageId,
+  filesCodeRootResultSubpageId,
+} from "@/lib/commands/sources/open/files-result-subpage";
+import {
   openerActionLeaf,
   openerSubpageLeaf,
   openerTruncatedHint,
@@ -29,82 +54,253 @@ import type {
   CommandItem,
   CommandSubpage,
 } from "@/lib/commands/types";
+import type { EpicArtifactRef } from "@/stores/epics/canvas/types";
 
-interface FileNode {
-  readonly path: string;
-  readonly name: string;
+const FILES_SEARCH_DEBOUNCE_MS = 150;
+
+// A stable source object so the search hook's query key is stable across
+// renders (the host derives the mirror root from the request `epicId`).
+const EPIC_ARTIFACTS_SOURCE: WorkspaceSearchSource = { kind: "epic-artifacts" };
+
+const EMPTY_ARTIFACT_PATH_INDEX: ReadonlyMap<string, ArtifactPathEntry> =
+  new Map();
+
+/**
+ * Non-actionable notice row for a distinct non-`ready` state (an unavailable
+ * source, or a host without the search RPC). Keyed per-category so it never
+ * collides with a result row.
+ */
+function openerNotice(id: string, label: string): CommandItem {
+  return {
+    id,
+    label,
+    description: null,
+    keywords: [],
+    group: "open",
+    scope: "actions",
+    shortcut: null,
+    actionId: null,
+    subpage: null,
+    run: () => undefined,
+  };
 }
 
-interface FileLeavesArgs {
+// --- Step 2a: code workspace/worktree root ---------------------------------
+
+interface CodeFileLeavesArgs {
   readonly ctx: CommandContext;
   readonly hostId: string;
   readonly workspacePath: string;
-  readonly files: ReadonlyArray<FileNode>;
-  readonly truncated: boolean;
-  readonly query: string;
+  readonly view: WorkspaceSearchPathsView | null;
+  readonly isError: boolean;
 }
 
-function fileLeaves(args: FileLeavesArgs): ReadonlyArray<CommandItem> {
-  const { ctx, hostId, workspacePath, files, truncated, query } = args;
-  const matched = files.filter((file) => matchesPathQuery(query, file.path));
-  const shown = matched.slice(0, OPENER_RESULT_CAP);
-  const leaves = shown.map((file) =>
-    openerActionLeaf({
-      id: `open:files:${workspacePath}:${file.path}`,
-      // Workspace-relative path (not just `file.name`) so duplicate basenames
-      // are distinguishable; the row dims the directory, emphasizes the name.
-      label: file.path,
-      keywords: [file.path],
-      run: () => {
-        const ref = workspaceFileRefFromTreePath(
-          hostId,
-          workspacePath,
-          file.path,
-          file.name,
-        );
-        if (ref === null) return;
-        openTileIntoTargetGroup({
-          tabId: ctx.activeTabId,
-          groupId: ctx.targetGroupId,
-          ref,
-          navigateNestedFocus: ctx.router.navigateNestedFocus,
-        });
-      },
-    }),
-  );
-  if (truncated || matched.length > shown.length) {
-    return [...leaves, openerTruncatedHint("files", shown.length)];
+function codeFileLeaves(args: CodeFileLeavesArgs): ReadonlyArray<CommandItem> {
+  const { ctx, hostId, workspacePath, view, isError } = args;
+  if (isError) {
+    return [
+      openerNotice(
+        `open:files:ws:${workspacePath}:unsupported`,
+        "File search is unavailable on this host",
+      ),
+    ];
   }
-  return leaves;
+  // No usable response yet (loading, or a late reply for a different source).
+  if (view === null) return [];
+  if (view.outcome === "root_unavailable") {
+    return [
+      openerNotice(
+        `open:files:ws:${workspacePath}:unavailable`,
+        "This workspace is unavailable",
+      ),
+    ];
+  }
+  const leaves = view.results.flatMap((result) => {
+    if (result.kind !== "file") return [];
+    return [
+      openerActionLeaf({
+        id: `open:files:${workspacePath}:${result.relPath}`,
+        // Workspace-relative path so duplicate basenames are distinguishable,
+        // and so the host-searched text is what cmdk re-filters on.
+        label: result.relPath,
+        keywords: [result.relPath, result.name],
+        run: () => {
+          const ref = workspaceFileRefFromTreePath(
+            hostId,
+            workspacePath,
+            result.relPath,
+            result.name,
+          );
+          if (ref === null) return;
+          openTileIntoTargetGroup({
+            tabId: ctx.activeTabId,
+            groupId: ctx.targetGroupId,
+            ref,
+            navigateNestedFocus: ctx.router.navigateNestedFocus,
+          });
+        },
+      }),
+    ];
+  });
+  return view.truncated
+    ? [...leaves, openerTruncatedHint("files", leaves.length)]
+    : leaves;
 }
 
-function useFilesStepItems(
+function useCodeRootStepItems(
   ctx: CommandContext,
   row: WorktreeBindingSelectorRow,
 ): ReadonlyArray<CommandItem> {
-  const tree = useWorkspaceListFileTree(row.runningDir);
+  const client = useHostClient();
   const query = usePaletteLiveQuery();
-  const data = tree.data;
-  return useMemo<ReadonlyArray<CommandItem>>(() => {
-    if (data === undefined) return [];
-    return fileLeaves({
-      ctx,
-      hostId: row.hostId,
-      workspacePath: row.runningDir,
-      files: data.files,
-      truncated: data.truncated,
-      query,
-    });
-  }, [ctx, row.hostId, row.runningDir, data, query]);
+  const debouncedQuery = useDebouncedValue(query, FILES_SEARCH_DEBOUNCE_MS);
+  const epicId = ctx.activeEpicId ?? "";
+  const source = useMemo<WorkspaceSearchSource>(
+    () => ({ root: row.runningDir }),
+    [row.runningDir],
+  );
+  const search = useWorkspaceSearchPathsForSource({
+    client,
+    epicId,
+    source,
+    query: debouncedQuery,
+    kinds: "files",
+    enabled: ctx.activeEpicId !== null,
+  });
+  const view = readSearchPathsResponseForSource(search.data, epicId, source);
+  const isError = search.isError;
+  return useMemo<ReadonlyArray<CommandItem>>(
+    () =>
+      codeFileLeaves({
+        ctx,
+        hostId: row.hostId,
+        workspacePath: row.runningDir,
+        view,
+        isError,
+      }),
+    [ctx, row.hostId, row.runningDir, view, isError],
+  );
 }
 
-function makeFilesStepSubpage(row: WorktreeBindingSelectorRow): CommandSubpage {
+function makeCodeRootStepSubpage(
+  row: WorktreeBindingSelectorRow,
+): CommandSubpage {
   return {
-    id: `open:files:ws:${row.hostId}:${encodeURIComponent(row.runningDir)}`,
+    id: filesCodeRootResultSubpageId(row.hostId, row.runningDir),
     title: getBasename(row.runningDir),
-    useItems: (ctx) => useFilesStepItems(ctx, row),
+    useItems: (ctx) => useCodeRootStepItems(ctx, row),
   };
 }
+
+// --- Step 2b: Artifacts ----------------------------------------------------
+
+interface ArtifactLeavesArgs {
+  readonly ctx: CommandContext;
+  readonly defaultHostId: string;
+  readonly view: WorkspaceSearchPathsView | null;
+  readonly isError: boolean;
+  readonly pathIndex: ReadonlyMap<string, ArtifactPathEntry>;
+}
+
+function artifactLeaves(args: ArtifactLeavesArgs): ReadonlyArray<CommandItem> {
+  const { ctx, defaultHostId, view, isError, pathIndex } = args;
+  if (isError) {
+    return [
+      openerNotice(
+        "open:files:artifacts:unsupported",
+        "Artifact search is unavailable on this host",
+      ),
+    ];
+  }
+  if (view === null) return [];
+  if (view.outcome === "root_unavailable") {
+    return [
+      openerNotice(
+        "open:files:artifacts:unavailable",
+        "Artifacts are unavailable",
+      ),
+    ];
+  }
+  const leaves = view.results.flatMap((result) => {
+    if (result.kind !== "file") return [];
+    // Resolve the host logical path against authoritative Yjs state; a
+    // deleted/renamed/not-yet-projected artifact is absent → drop the row.
+    const entry = pathIndex.get(normalizeArtifactLogicalPath(result.relPath));
+    if (entry === undefined) return [];
+    const ref: EpicArtifactRef = {
+      id: entry.id,
+      instanceId: uuidv4(),
+      type: entry.kind,
+      name: entry.title,
+      hostId: defaultHostId,
+    };
+    return [
+      openerActionLeaf({
+        id: `open:files:artifacts:${entry.id}`,
+        // Ancestor-title path distinguishes duplicate leaf titles and reads
+        // better than the folder slug; the slug path rides in keywords so the
+        // host match survives cmdk's re-filter.
+        label: entry.titlePath.length > 0 ? entry.titlePath : entry.title,
+        keywords: [result.relPath, result.name, entry.title, entry.titlePath],
+        run: () => {
+          openTileIntoTargetGroup({
+            tabId: ctx.activeTabId,
+            groupId: ctx.targetGroupId,
+            ref,
+            navigateNestedFocus: ctx.router.navigateNestedFocus,
+          });
+        },
+      }),
+    ];
+  });
+  return view.truncated
+    ? [...leaves, openerTruncatedHint("files-artifacts", leaves.length)]
+    : leaves;
+}
+
+function useArtifactsStepItems(
+  ctx: CommandContext,
+): ReadonlyArray<CommandItem> {
+  const client = useHostClient();
+  const defaultHostId = useReactiveActiveHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
+  const query = usePaletteLiveQuery();
+  const debouncedQuery = useDebouncedValue(query, FILES_SEARCH_DEBOUNCE_MS);
+  const epicId = ctx.activeEpicId ?? "";
+  const projection = useActiveEpicProjection(ctx.activeEpicId);
+  const search = useWorkspaceSearchPathsForSource({
+    client,
+    epicId,
+    source: EPIC_ARTIFACTS_SOURCE,
+    query: debouncedQuery,
+    kinds: "files",
+    enabled: ctx.activeEpicId !== null,
+  });
+  const view = readSearchPathsResponseForSource(
+    search.data,
+    epicId,
+    EPIC_ARTIFACTS_SOURCE,
+  );
+  const isError = search.isError;
+  const pathIndex = useMemo(
+    () =>
+      projection === null
+        ? EMPTY_ARTIFACT_PATH_INDEX
+        : buildArtifactDisplayPathIndex(projection.tree, projection.artifacts),
+    [projection],
+  );
+  return useMemo<ReadonlyArray<CommandItem>>(
+    () => artifactLeaves({ ctx, defaultHostId, view, isError, pathIndex }),
+    [ctx, defaultHostId, view, isError, pathIndex],
+  );
+}
+
+const ARTIFACTS_STEP_SUBPAGE: CommandSubpage = {
+  id: filesArtifactsResultSubpageId(),
+  title: "Artifacts",
+  useItems: useArtifactsStepItems,
+};
+
+// --- Step 1: source list ----------------------------------------------------
 
 export function useFilesOpenerItems(
   ctx: CommandContext,
@@ -117,32 +313,26 @@ export function useFilesOpenerItems(
     () => bindingsQuery.data?.rows.filter(isBrowsable) ?? [],
     [bindingsQuery.data?.rows],
   );
-  // Single-workspace epics skip the workspace step. The file-tree hook is
-  // called unconditionally (null = disabled) to keep the hook order stable.
-  const singleRow = workspaceRoots.length === 1 ? workspaceRoots[0] : null;
-  const singlePath = singleRow === null ? null : singleRow.runningDir;
-  const singleTree = useWorkspaceListFileTree(singlePath);
-  const query = usePaletteLiveQuery();
-  const singleData = singleTree.data;
   return useMemo<ReadonlyArray<CommandItem>>(() => {
-    if (singleRow !== null) {
-      if (singleData === undefined) return [];
-      return fileLeaves({
-        ctx,
-        hostId: singleRow.hostId,
-        workspacePath: singleRow.runningDir,
-        files: singleData.files,
-        truncated: singleData.truncated,
-        query,
-      });
-    }
-    return workspaceRoots.map((row) =>
+    if (ctx.activeEpicId === null) return [];
+    // `Artifacts` is always offered (even for an Epic with no attached
+    // code workspace); the old single-workspace shortcut is gone because it
+    // would hide this source.
+    return [
       openerSubpageLeaf({
-        id: `open:files:ws:${row.hostId}:${encodeURIComponent(row.runningDir)}`,
-        label: getBasename(row.runningDir),
-        keywords: [row.runningDir],
-        subpage: makeFilesStepSubpage(row),
+        id: filesArtifactsResultSubpageId(),
+        label: "Artifacts",
+        keywords: ["artifact", "spec", "ticket", "story", "review"],
+        subpage: ARTIFACTS_STEP_SUBPAGE,
       }),
-    );
-  }, [ctx, workspaceRoots, singleRow, singleData, query]);
+      ...workspaceRoots.map((row) =>
+        openerSubpageLeaf({
+          id: filesCodeRootResultSubpageId(row.hostId, row.runningDir),
+          label: getBasename(row.runningDir),
+          keywords: [row.runningDir],
+          subpage: makeCodeRootStepSubpage(row),
+        }),
+      ),
+    ];
+  }, [ctx.activeEpicId, workspaceRoots]);
 }

--- a/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/files-subpage.ts
@@ -227,13 +227,6 @@ function artifactLeaves(args: ArtifactLeavesArgs): ReadonlyArray<CommandItem> {
     // deleted/renamed/not-yet-projected artifact is absent → drop the row.
     const entry = pathIndex.get(normalizeArtifactLogicalPath(result.relPath));
     if (entry === undefined) return [];
-    const ref: EpicArtifactRef = {
-      id: entry.id,
-      instanceId: uuidv4(),
-      type: entry.kind,
-      name: entry.title,
-      hostId: defaultHostId,
-    };
     return [
       openerActionLeaf({
         id: `open:files:artifacts:${entry.id}`,
@@ -243,6 +236,13 @@ function artifactLeaves(args: ArtifactLeavesArgs): ReadonlyArray<CommandItem> {
         label: entry.titlePath.length > 0 ? entry.titlePath : entry.title,
         keywords: [result.relPath, result.name, entry.title, entry.titlePath],
         run: () => {
+          const ref: EpicArtifactRef = {
+            id: entry.id,
+            instanceId: uuidv4(),
+            type: entry.kind,
+            name: entry.title,
+            hostId: defaultHostId,
+          };
           openTileIntoTargetGroup({
             tabId: ctx.activeTabId,
             groupId: ctx.targetGroupId,

--- a/clients/gui-app/src/lib/commands/sources/open/parse-globs.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/parse-globs.ts
@@ -1,0 +1,58 @@
+/**
+ * Split a raw include/exclude field into ripgrep glob patterns.
+ *
+ * Patterns are comma-separated, but a comma is NOT a separator when it is:
+ *   - inside a brace expression `{a,b}` (ripgrep alternation) — tracked by depth;
+ *     an UNBALANCED `{` swallows the rest of the field into one pattern (which rg
+ *     then rejects), a defined outcome rather than a silent mis-split; or
+ *   - backslash-escaped (`\,`) — a literal comma within a single pattern.
+ *
+ * Each resulting pattern is trimmed of surrounding whitespace and empty patterns
+ * are dropped, so a blank field, whitespace, or stray separators impose no
+ * filter. A bare extension such as `.md` is accepted as friendly shorthand for
+ * `*.md`. Braces and escapes are otherwise passed through to ripgrep verbatim —
+ * rg owns their meaning; this parser only decides the split points.
+ */
+export function parseGlobs(text: string): string[] {
+  const patterns: string[] = [];
+  let current = "";
+  let braceDepth = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "\\") {
+      // Keep the backslash AND the next char literally, so `\,` never splits and
+      // reaches rg as an escaped literal comma. A trailing backslash is kept.
+      current += char;
+      if (index + 1 < text.length) {
+        current += text[index + 1];
+        index += 1;
+      }
+      continue;
+    }
+    if (char === "{") {
+      braceDepth += 1;
+      current += char;
+      continue;
+    }
+    if (char === "}") {
+      if (braceDepth > 0) braceDepth -= 1;
+      current += char;
+      continue;
+    }
+    if (char === "," && braceDepth === 0) {
+      pushTrimmed(patterns, current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  pushTrimmed(patterns, current);
+  return patterns;
+}
+
+function pushTrimmed(out: string[], raw: string): void {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return;
+  const extensionShorthand = /^\.[a-z0-9][a-z0-9._+-]*$/i.test(trimmed);
+  out.push(extensionShorthand ? `*${trimmed}` : trimmed);
+}

--- a/clients/gui-app/src/lib/commands/sources/open/search-subpage.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/search-subpage.ts
@@ -1,0 +1,69 @@
+/**
+ * Opener "Text search" sub-page - STEP 1 of the two-step content-search flow:
+ * pick a search target. The list is the explicitly labeled artifact
+ * workspace (always present, even with no code workspace attached) plus every
+ * attached workspace/worktree root browsable for the active Epic/host.
+ *
+ * Selecting a target pushes a step-2 sub-page ({@link searchRunSubpageId}); the
+ * pane opener recognizes that id and renders `SearchRunView` (query + options +
+ * results) rather than the generic fuzzy list. Artifact targets run
+ * `epic.searchArtifacts`; code targets run `workspace.searchText`.
+ */
+import { useMemo } from "react";
+import { getBasename } from "@/lib/path/cross-platform-path";
+import { useWorktreeListBindingsForEpic } from "@/hooks/worktree/use-worktree-list-bindings-for-epic-query";
+import { isBrowsable } from "@/lib/worktree/worktree-row-browsable";
+import { openerSubpageLeaf } from "@/lib/commands/sources/open/open-leaf";
+import {
+  searchRunSubpageId,
+  type SearchRunTarget,
+} from "@/lib/commands/sources/open/search-target";
+import type {
+  CommandContext,
+  CommandItem,
+  CommandSubpage,
+} from "@/lib/commands/types";
+
+function makeRunSubpage(
+  target: SearchRunTarget,
+  title: string,
+): CommandSubpage {
+  // `useItems` is never consulted: the pane opener special-cases this id and
+  // renders `SearchRunView` instead of the generic list. Kept as an empty
+  // passthrough so the shared `CommandSubpage` shape needs no new field.
+  return { id: searchRunSubpageId(target), title, useItems: () => [] };
+}
+
+export function useSearchOpenerItems(
+  ctx: CommandContext,
+): ReadonlyArray<CommandItem> {
+  const bindingsQuery = useWorktreeListBindingsForEpic({
+    epicId: ctx.activeEpicId ?? "",
+    enabled: ctx.activeEpicId !== null,
+  });
+  const workspaceRoots = useMemo(
+    () => bindingsQuery.data?.rows.filter(isBrowsable) ?? [],
+    [bindingsQuery.data?.rows],
+  );
+
+  return useMemo<ReadonlyArray<CommandItem>>(() => {
+    const artifactLeaf = openerSubpageLeaf({
+      id: "open:search:target:artifact",
+      label: "Artifacts",
+      keywords: ["artifact", "artifacts", "spec", "ticket", "story", "review"],
+      subpage: makeRunSubpage({ kind: "artifact" }, "Artifacts"),
+    });
+    const codeLeaves = workspaceRoots.map((row) =>
+      openerSubpageLeaf({
+        id: `open:search:target:code:${row.hostId}:${row.runningDir}`,
+        label: getBasename(row.runningDir),
+        keywords: [row.runningDir],
+        subpage: makeRunSubpage(
+          { kind: "code", hostId: row.hostId, root: row.runningDir },
+          getBasename(row.runningDir),
+        ),
+      }),
+    );
+    return [artifactLeaf, ...codeLeaves];
+  }, [workspaceRoots]);
+}

--- a/clients/gui-app/src/lib/commands/sources/open/search-target.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/search-target.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared identity for the opener's text-search sub-flow.
+ *
+ * The two-step search flow reuses the generic opener sub-page stack: step 1 (a
+ * normal cmdk list) picks a target; selecting it pushes a step-2 sub-page whose
+ * `id` is built here. `PaneOpener` recognizes that id and renders the bespoke
+ * `SearchRunView` (query input + options + results) instead of the generic
+ * fuzzy-filtered list, because content search is literal/regex - never a cmdk
+ * fuzzy filter. The target is carried IN the id (rather than a new field on the
+ * shared `CommandSubpage` type) so no other sub-page constructor has to change.
+ */
+
+export type SearchRunTarget =
+  | { readonly kind: "artifact" }
+  | { readonly kind: "code"; readonly hostId: string; readonly root: string };
+
+const RUN_PREFIX = "open:search:run";
+const ARTIFACT_ID = `${RUN_PREFIX}:artifact`;
+const CODE_PREFIX = `${RUN_PREFIX}:code:`;
+
+/**
+ * The step-2 sub-page id for a target. `hostId`/`root` are `encodeURIComponent`d
+ * (which escapes `:`, so a Windows `C:\…` root cannot collide with the field
+ * separator) and reconstructed by {@link parseSearchRunSubpageId}.
+ */
+export function searchRunSubpageId(target: SearchRunTarget): string {
+  if (target.kind === "artifact") return ARTIFACT_ID;
+  return `${CODE_PREFIX}${encodeURIComponent(target.hostId)}:${encodeURIComponent(target.root)}`;
+}
+
+export function isSearchRunSubpageId(id: string): boolean {
+  return id === ARTIFACT_ID || id.startsWith(CODE_PREFIX);
+}
+
+export function parseSearchRunSubpageId(id: string): SearchRunTarget | null {
+  if (id === ARTIFACT_ID) return { kind: "artifact" };
+  if (!id.startsWith(CODE_PREFIX)) return null;
+  const rest = id.slice(CODE_PREFIX.length);
+  const sep = rest.indexOf(":");
+  if (sep === -1) return null;
+  return {
+    kind: "code",
+    hostId: decodeURIComponent(rest.slice(0, sep)),
+    root: decodeURIComponent(rest.slice(sep + 1)),
+  };
+}

--- a/clients/gui-app/src/lib/commands/sources/open/search-target.ts
+++ b/clients/gui-app/src/lib/commands/sources/open/search-target.ts
@@ -38,9 +38,13 @@ export function parseSearchRunSubpageId(id: string): SearchRunTarget | null {
   const rest = id.slice(CODE_PREFIX.length);
   const sep = rest.indexOf(":");
   if (sep === -1) return null;
-  return {
-    kind: "code",
-    hostId: decodeURIComponent(rest.slice(0, sep)),
-    root: decodeURIComponent(rest.slice(sep + 1)),
-  };
+  try {
+    return {
+      kind: "code",
+      hostId: decodeURIComponent(rest.slice(0, sep)),
+      root: decodeURIComponent(rest.slice(sep + 1)),
+    };
+  } catch {
+    return null;
+  }
 }

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
@@ -3,6 +3,7 @@ import type {
   ComposerMentionProviderContext,
   MentionFlowStep,
   MentionMenuEntry,
+  MentionSearchPathsRequest,
 } from "../providers";
 import { mentionProviderRegistry, ROOT_MENTION_STEP } from "../providers";
 import type {
@@ -22,6 +23,7 @@ function context(
     epicEntries: [],
     currentEpicId: null,
     agentEntries: [],
+    epicAttachedRoots: new Set(),
     ...overrides,
   };
 }
@@ -458,6 +460,102 @@ describe("mention provider registry", () => {
       "epic.mentionTickets",
       "epic.mentionStories",
       "epic.mentionReviews",
+    ]);
+  });
+
+  it("scopes an Epic-attached root to searchPaths and keeps unattached roots legacy", () => {
+    const requests = mentionProviderRegistry.workspaceRequests(
+      ROOT_MENTION_STEP,
+      context({
+        query: "index",
+        roots: ["/attached", "/global"],
+        currentEpicId: "epic-1",
+        epicAttachedRoots: new Set(["/attached"]),
+      }),
+    );
+    const scoped = requests.filter(
+      (request): request is MentionSearchPathsRequest =>
+        request.method === "workspace.searchPaths",
+    );
+    // The attached root produces one scoped request per file/folder provider.
+    expect(scoped).toHaveLength(2);
+    for (const request of scoped) {
+      expect(request.root).toBe("/attached");
+      expect(request.params.epicId).toBe("epic-1");
+      expect("root" in request.params.reference).toBe(true);
+      if ("root" in request.params.reference) {
+        expect(request.params.reference.root).toBe("/attached");
+      }
+    }
+    expect(scoped.map((request) => request.method)).toEqual([
+      "workspace.searchPaths",
+      "workspace.searchPaths",
+    ]);
+    // Each provider requests exactly its own kind so folders are never starved
+    // by files sharing the limit.
+    expect(
+      scoped.map((request) => ({
+        kind: request.suggestionKind,
+        kinds: request.params.kinds,
+      })),
+    ).toEqual([
+      { kind: "file", kinds: "files" },
+      { kind: "folder", kinds: "folders" },
+    ]);
+
+    // The unattached root keeps the legacy raw-root RPCs (files + folders).
+    const legacyFileRoots = requests.flatMap((request) =>
+      request.method === "workspace.mentionFiles" ? [request.params.roots] : [],
+    );
+    expect(legacyFileRoots).toEqual([["/global"]]);
+    const legacyFolderRoots = requests.flatMap((request) =>
+      request.method === "workspace.mentionFolders"
+        ? [request.params.roots]
+        : [],
+    );
+    expect(legacyFolderRoots).toEqual([["/global"]]);
+  });
+
+  it("emits no legacy file/folder request when every root is Epic-attached", () => {
+    const requests = mentionProviderRegistry.workspaceRequests(
+      ROOT_MENTION_STEP,
+      context({
+        query: "index",
+        roots: ["/a", "/b"],
+        currentEpicId: "epic-1",
+        epicAttachedRoots: new Set(["/a", "/b"]),
+      }),
+    );
+    expect(
+      requests.some(
+        (request) =>
+          request.method === "workspace.mentionFiles" ||
+          request.method === "workspace.mentionFolders",
+      ),
+    ).toBe(false);
+    // Two roots x two providers (files + folders) = four scoped requests.
+    expect(
+      requests.filter((request) => request.method === "workspace.searchPaths"),
+    ).toHaveLength(4);
+  });
+
+  it("uses only legacy RPCs when there is no current Epic, even with attached roots", () => {
+    const requests = mentionProviderRegistry.workspaceRequests(
+      ROOT_MENTION_STEP,
+      context({
+        query: "index",
+        roots: ["/a"],
+        currentEpicId: null,
+        epicAttachedRoots: new Set(["/a"]),
+      }),
+    );
+    expect(
+      requests.some((request) => request.method === "workspace.searchPaths"),
+    ).toBe(false);
+    expect(requests.map((request) => request.method)).toEqual([
+      "workspace.mentionFiles",
+      "workspace.mentionFolders",
+      "workspace.mentionWorktrees",
     ]);
   });
 

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
@@ -482,6 +482,7 @@ describe("mention provider registry", () => {
     for (const request of scoped) {
       expect(request.root).toBe("/attached");
       expect(request.params.epicId).toBe("epic-1");
+      expect(request.params.limit).toBe(25);
       expect("root" in request.params.reference).toBe(true);
       if ("root" in request.params.reference) {
         expect(request.params.reference.root).toBe("/attached");

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/search-path-suggestions.test.ts
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/search-path-suggestions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceSearchPathResult } from "@traycer/protocol/host/workspace/unary-schemas";
+import {
+  fileSuggestionFromSearchResult,
+  folderSuggestionFromSearchResult,
+  joinWithinRoot,
+} from "../search-path-suggestions";
+
+function fileResult(relPath: string, name: string): WorkspaceSearchPathResult {
+  return { kind: "file", relPath, name };
+}
+function folderResult(
+  relPath: string,
+  name: string,
+): WorkspaceSearchPathResult {
+  return { kind: "folder", relPath, name };
+}
+
+describe("search-path suggestion reconstruction", () => {
+  it("rebuilds a file suggestion matching the legacy shape", () => {
+    const suggestion = fileSuggestionFromSearchResult(
+      "/repo",
+      fileResult("src/app.ts", "app.ts"),
+    );
+    expect(suggestion).toEqual({
+      kind: "file",
+      id: "file:/repo:src/app.ts",
+      label: "app.ts",
+      relPath: "src/app.ts",
+      absolutePath: "/repo/src/app.ts",
+      workspacePath: "/repo",
+      description: "src",
+    });
+  });
+
+  it("gives a root-level file an empty description", () => {
+    const suggestion = fileSuggestionFromSearchResult(
+      "/repo",
+      fileResult("README.md", "README.md"),
+    );
+    expect(suggestion.description).toBe("");
+    expect(suggestion.absolutePath).toBe("/repo/README.md");
+  });
+
+  it("rebuilds a folder suggestion with a trailing-slash relPath", () => {
+    const suggestion = folderSuggestionFromSearchResult(
+      "/repo",
+      folderResult("src/lib", "lib"),
+    );
+    expect(suggestion).toEqual({
+      kind: "folder",
+      id: "folder:/repo:src/lib/",
+      label: "lib",
+      relPath: "src/lib/",
+      absolutePath: "/repo/src/lib",
+      workspacePath: "/repo",
+      description: "src",
+    });
+  });
+
+  it("joins onto a Windows root using the root's separator", () => {
+    expect(joinWithinRoot("C:\\Users\\me\\repo", "src/app.ts")).toBe(
+      "C:\\Users\\me\\repo\\src\\app.ts",
+    );
+    const suggestion = fileSuggestionFromSearchResult(
+      "C:\\Users\\me\\repo",
+      fileResult("src/app.ts", "app.ts"),
+    );
+    expect(suggestion.absolutePath).toBe("C:\\Users\\me\\repo\\src\\app.ts");
+    // relPath stays host-canonical POSIX for the mention token.
+    expect(suggestion.relPath).toBe("src/app.ts");
+  });
+
+  it("stays within the root when a malformed relPath contains traversal", () => {
+    // The host jails relPath; this only proves the client never escapes even on
+    // a malformed payload.
+    expect(joinWithinRoot("/repo", "../../etc/passwd")).toBe("/repo/etc/passwd");
+    expect(joinWithinRoot("/repo", "/leading/slash")).toBe(
+      "/repo/leading/slash",
+    );
+  });
+});

--- a/clients/gui-app/src/lib/composer/mentions/__tests__/search-path-suggestions.test.ts
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/search-path-suggestions.test.ts
@@ -74,7 +74,9 @@ describe("search-path suggestion reconstruction", () => {
   it("stays within the root when a malformed relPath contains traversal", () => {
     // The host jails relPath; this only proves the client never escapes even on
     // a malformed payload.
-    expect(joinWithinRoot("/repo", "../../etc/passwd")).toBe("/repo/etc/passwd");
+    expect(joinWithinRoot("/repo", "../../etc/passwd")).toBe(
+      "/repo/etc/passwd",
+    );
     expect(joinWithinRoot("/repo", "/leading/slash")).toBe(
       "/repo/leading/slash",
     );

--- a/clients/gui-app/src/lib/composer/mentions/providers.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/providers.tsx
@@ -34,7 +34,13 @@ const EMPTY_WORKSPACE_REQUESTS: ReadonlyArray<MentionWorkspaceRequest> = [];
 const EMPTY_EPIC_REQUESTS: ReadonlyArray<MentionEpicRequest> = [];
 
 export type MentionProviderId =
-  "files" | "folders" | "worktree" | "git" | "epic" | "chat" | EpicArtifactKind;
+  | "files"
+  | "folders"
+  | "worktree"
+  | "git"
+  | "epic"
+  | "chat"
+  | EpicArtifactKind;
 
 export interface MentionMenuCopy {
   readonly header: string;
@@ -80,7 +86,8 @@ export type WorkspaceGitMentionMethod =
   | "workspace.mentionGitCommits";
 
 export type WorkspaceMentionMethod =
-  WorkspacePathMentionMethod | WorkspaceGitMentionMethod;
+  | WorkspacePathMentionMethod
+  | WorkspaceGitMentionMethod;
 
 export type EpicMentionMethod =
   | "epic.mentionEpics"
@@ -949,22 +956,23 @@ function workspacePathOrSearchRequests(
   if (context.roots.length === 0) return EMPTY_WORKSPACE_REQUESTS;
   const epicId = context.currentEpicId;
   if (epicId === null) {
-    return [legacyPathRequestForRoots(context, [...context.roots], legacyMethod)];
+    return [
+      legacyPathRequestForRoots(context, [...context.roots], legacyMethod),
+    ];
   }
 
-  const requests: MentionWorkspaceRequest[] = [];
-  const legacyRoots: string[] = [];
-  for (const root of context.roots) {
-    if (context.epicAttachedRoots.has(root)) {
-      requests.push(
-        searchPathsMentionRequest(context, epicId, root, suggestionKind),
-      );
-    } else {
-      legacyRoots.push(root);
-    }
-  }
+  const requests: MentionWorkspaceRequest[] = context.roots
+    .filter((root) => context.epicAttachedRoots.has(root))
+    .map((root) =>
+      searchPathsMentionRequest(context, epicId, root, suggestionKind),
+    );
+  const legacyRoots = context.roots.filter(
+    (root) => !context.epicAttachedRoots.has(root),
+  );
   if (legacyRoots.length > 0) {
-    requests.push(legacyPathRequestForRoots(context, legacyRoots, legacyMethod));
+    requests.push(
+      legacyPathRequestForRoots(context, legacyRoots, legacyMethod),
+    );
   }
   return requests.length > 0 ? requests : EMPTY_WORKSPACE_REQUESTS;
 }

--- a/clients/gui-app/src/lib/composer/mentions/providers.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/providers.tsx
@@ -104,8 +104,6 @@ type WorkspaceSearchPathsRequestParams = RequestOfMethod<
   "workspace.searchPaths"
 >;
 
-const WORKSPACE_SEARCH_PATHS_MENTION_LIMIT = 50;
-
 type WorkspaceGitMentionRequestParams = RequestOfMethod<
   HostRpcRegistry,
   "workspace.mentionGitRoot"
@@ -984,7 +982,7 @@ function searchPathsMentionRequest(
       epicId,
       reference: { root },
       query: context.query.trim(),
-      limit: WORKSPACE_SEARCH_PATHS_MENTION_LIMIT,
+      limit: context.limit,
       // Request exactly the kind this provider renders so the host spends the
       // whole limit on it (a folder mention is never starved by files).
       kinds: suggestionKind === "folder" ? "folders" : "files",

--- a/clients/gui-app/src/lib/composer/mentions/providers.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/providers.tsx
@@ -99,6 +99,13 @@ type WorkspacePathMentionRequestParams = RequestOfMethod<
   "workspace.mentionFiles"
 >;
 
+type WorkspaceSearchPathsRequestParams = RequestOfMethod<
+  HostRpcRegistry,
+  "workspace.searchPaths"
+>;
+
+const WORKSPACE_SEARCH_PATHS_MENTION_LIMIT = 50;
+
 type WorkspaceGitMentionRequestParams = RequestOfMethod<
   HostRpcRegistry,
   "workspace.mentionGitRoot"
@@ -114,6 +121,20 @@ type EpicArtifactMentionRequestParams = RequestOfMethod<
   "epic.mentionSpecs"
 >;
 
+/**
+ * Scoped file/folder search over ONE Epic-attached root. Emitted (instead of
+ * the legacy raw-root `workspace.mentionFiles`/`mentionFolders`) only for roots
+ * demonstrably attached to the current Epic on this host. `suggestionKind` says
+ * which result kind the reconstruction keeps; `root` is the known, already
+ * authorized root the reconstruction joins against.
+ */
+export interface MentionSearchPathsRequest {
+  readonly method: "workspace.searchPaths";
+  readonly params: WorkspaceSearchPathsRequestParams;
+  readonly suggestionKind: "file" | "folder";
+  readonly root: string;
+}
+
 export type MentionWorkspaceRequest =
   | {
       readonly method: WorkspacePathMentionMethod;
@@ -122,7 +143,8 @@ export type MentionWorkspaceRequest =
   | {
       readonly method: WorkspaceGitMentionMethod;
       readonly params: WorkspaceGitMentionRequestParams;
-    };
+    }
+  | MentionSearchPathsRequest;
 
 export type MentionEpicRequest =
   | {
@@ -143,6 +165,14 @@ export interface ComposerMentionProviderContext {
   readonly currentEpicId: string | null;
   /** Every referenceable Agent in the open Task, both interfaces. */
   readonly agentEntries: ReadonlyArray<EpicAgentMentionEntry>;
+  /**
+   * The subset of `roots` demonstrably attached to `currentEpicId` on this
+   * host (a binding running dir or resolved workspace folder). File/folder
+   * mentions for these roots use the scoped `workspace.searchPaths`; roots
+   * outside this set (global folders, or any root when there is no current
+   * Epic) keep the legacy raw-root RPC so a suggestion never disappears.
+   */
+  readonly epicAttachedRoots: ReadonlySet<string>;
 }
 
 export const ROOT_MENTION_STEP: MentionFlowStep = { kind: "root" };
@@ -239,8 +269,11 @@ class FileMentionProvider extends ComposerMentionProvider {
   rootWorkspaceRequests(
     context: ComposerMentionProviderContext,
   ): ReadonlyArray<MentionWorkspaceRequest> {
-    if (context.roots.length === 0) return EMPTY_WORKSPACE_REQUESTS;
-    return [workspacePathRequest(context, "workspace.mentionFiles")];
+    return workspacePathOrSearchRequests(
+      context,
+      "workspace.mentionFiles",
+      "file",
+    );
   }
 
   workspaceRequests(
@@ -291,8 +324,11 @@ class FolderMentionProvider extends ComposerMentionProvider {
   rootWorkspaceRequests(
     context: ComposerMentionProviderContext,
   ): ReadonlyArray<MentionWorkspaceRequest> {
-    if (context.roots.length === 0) return EMPTY_WORKSPACE_REQUESTS;
-    return [workspacePathRequest(context, "workspace.mentionFolders")];
+    return workspacePathOrSearchRequests(
+      context,
+      "workspace.mentionFolders",
+      "folder",
+    );
   }
 
   workspaceRequests(
@@ -344,7 +380,15 @@ class WorktreeMentionProvider extends ComposerMentionProvider {
     context: ComposerMentionProviderContext,
   ): ReadonlyArray<MentionWorkspaceRequest> {
     if (context.roots.length === 0) return EMPTY_WORKSPACE_REQUESTS;
-    return [workspacePathRequest(context, "workspace.mentionWorktrees")];
+    // Worktrees are directory-context mentions, not file/folder path search, so
+    // they stay on the legacy raw-root RPC.
+    return [
+      legacyPathRequestForRoots(
+        context,
+        [...context.roots],
+        "workspace.mentionWorktrees",
+      ),
+    ];
   }
 
   workspaceRequests(
@@ -890,14 +934,72 @@ function scoreAgentEntry(
   return null;
 }
 
-function workspacePathRequest(
+/**
+ * Build the file/folder mention requests for the current roots, splitting them
+ * between the scoped `workspace.searchPaths` (for roots attached to the current
+ * Epic on this host) and the legacy raw-root RPC (for everything else, and for
+ * all roots when there is no current Epic). A root that cannot be scoped always
+ * falls back to legacy, so a suggestion is never dropped by scoping.
+ */
+function workspacePathOrSearchRequests(
   context: ComposerMentionProviderContext,
+  legacyMethod: WorkspacePathMentionMethod,
+  suggestionKind: "file" | "folder",
+): ReadonlyArray<MentionWorkspaceRequest> {
+  if (context.roots.length === 0) return EMPTY_WORKSPACE_REQUESTS;
+  const epicId = context.currentEpicId;
+  if (epicId === null) {
+    return [legacyPathRequestForRoots(context, [...context.roots], legacyMethod)];
+  }
+
+  const requests: MentionWorkspaceRequest[] = [];
+  const legacyRoots: string[] = [];
+  for (const root of context.roots) {
+    if (context.epicAttachedRoots.has(root)) {
+      requests.push(
+        searchPathsMentionRequest(context, epicId, root, suggestionKind),
+      );
+    } else {
+      legacyRoots.push(root);
+    }
+  }
+  if (legacyRoots.length > 0) {
+    requests.push(legacyPathRequestForRoots(context, legacyRoots, legacyMethod));
+  }
+  return requests.length > 0 ? requests : EMPTY_WORKSPACE_REQUESTS;
+}
+
+function searchPathsMentionRequest(
+  context: ComposerMentionProviderContext,
+  epicId: string,
+  root: string,
+  suggestionKind: "file" | "folder",
+): MentionSearchPathsRequest {
+  return {
+    method: "workspace.searchPaths",
+    suggestionKind,
+    root,
+    params: {
+      epicId,
+      reference: { root },
+      query: context.query.trim(),
+      limit: WORKSPACE_SEARCH_PATHS_MENTION_LIMIT,
+      // Request exactly the kind this provider renders so the host spends the
+      // whole limit on it (a folder mention is never starved by files).
+      kinds: suggestionKind === "folder" ? "folders" : "files",
+    },
+  };
+}
+
+function legacyPathRequestForRoots(
+  context: ComposerMentionProviderContext,
+  roots: ReadonlyArray<string>,
   method: WorkspacePathMentionMethod,
 ): MentionWorkspaceRequest {
   return {
     method,
     params: {
-      roots: [...context.roots],
+      roots: [...roots],
       query: context.query.trim(),
       limit: context.limit,
     },

--- a/clients/gui-app/src/lib/composer/mentions/providers.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/providers.tsx
@@ -34,13 +34,7 @@ const EMPTY_WORKSPACE_REQUESTS: ReadonlyArray<MentionWorkspaceRequest> = [];
 const EMPTY_EPIC_REQUESTS: ReadonlyArray<MentionEpicRequest> = [];
 
 export type MentionProviderId =
-  | "files"
-  | "folders"
-  | "worktree"
-  | "git"
-  | "epic"
-  | "chat"
-  | EpicArtifactKind;
+  "files" | "folders" | "worktree" | "git" | "epic" | "chat" | EpicArtifactKind;
 
 export interface MentionMenuCopy {
   readonly header: string;
@@ -86,8 +80,7 @@ export type WorkspaceGitMentionMethod =
   | "workspace.mentionGitCommits";
 
 export type WorkspaceMentionMethod =
-  | WorkspacePathMentionMethod
-  | WorkspaceGitMentionMethod;
+  WorkspacePathMentionMethod | WorkspaceGitMentionMethod;
 
 export type EpicMentionMethod =
   | "epic.mentionEpics"

--- a/clients/gui-app/src/lib/composer/mentions/search-path-suggestions.ts
+++ b/clients/gui-app/src/lib/composer/mentions/search-path-suggestions.ts
@@ -1,0 +1,94 @@
+import type {
+  WorkspaceFileMentionSuggestion,
+  WorkspaceFolderMentionSuggestion,
+  WorkspaceSearchPathResult,
+} from "@traycer/protocol/host/workspace/unary-schemas";
+import { dirnameOfPath } from "@/lib/path";
+
+/**
+ * Rebuilds file/folder @-mention suggestions from a `workspace.searchPaths`
+ * result. The scoped RPC deliberately does NOT return a host-absolute path as
+ * authority; the renderer reconstructs the mention's fields from the root it
+ * already holds (and already authorized by selecting it) plus the host-returned
+ * relative path. The reconstruction mirrors the host's legacy
+ * `workspace.mentionFiles`/`mentionFolders` suggestion shape so downstream
+ * mention rendering, preview, and serialization are identical whichever RPC
+ * produced the entry.
+ *
+ * `root` is the caller's known workspace/worktree root (never widened from the
+ * RPC result). `relPath` is host-canonical POSIX. The absolute path is a
+ * display/serialization target, not new authority.
+ */
+
+export function fileSuggestionFromSearchResult(
+  root: string,
+  result: WorkspaceSearchPathResult,
+): WorkspaceFileMentionSuggestion {
+  const relPath = normalizeRel(result.relPath);
+  const description = mentionDescription(relPath);
+  return {
+    kind: "file",
+    id: `file:${root}:${relPath}`,
+    label: result.name,
+    relPath,
+    absolutePath: joinWithinRoot(root, relPath),
+    workspacePath: root,
+    description,
+  };
+}
+
+export function folderSuggestionFromSearchResult(
+  root: string,
+  result: WorkspaceSearchPathResult,
+): WorkspaceFolderMentionSuggestion {
+  const relPath = normalizeRel(result.relPath);
+  const description = mentionDescription(relPath);
+  // The legacy folder suggestion carries a trailing-slash `relPath`; match it so
+  // the two RPCs produce indistinguishable folder entries.
+  return {
+    kind: "folder",
+    id: `folder:${root}:${relPath}/`,
+    label: result.name,
+    relPath: `${relPath}/`,
+    absolutePath: joinWithinRoot(root, relPath),
+    workspacePath: root,
+    description,
+  };
+}
+
+function mentionDescription(relPath: string): string {
+  const dir = dirnameOfPath(relPath);
+  return dir === "" ? "" : dir;
+}
+
+// Strip any leading slash and reject parent-traversal segments defensively -
+// the host already jails the relative path, so this only guards against a
+// malformed payload; it never fabricates authority.
+function normalizeRel(rawRelPath: string): string {
+  const trimmed = rawRelPath.replace(/^\/+/, "").replace(/\/+$/, "");
+  const safe = trimmed
+    .split("/")
+    .filter((segment) => segment.length > 0 && segment !== "..")
+    .join("/");
+  return safe;
+}
+
+/**
+ * Joins a POSIX relative path onto a host root, honoring the root's separator
+ * convention so the absolute path resolves on the host the agent runs on. The
+ * relative path is host-provided and jailed (see {@link normalizeRel}), so the
+ * result always stays within `root`.
+ */
+export function joinWithinRoot(root: string, posixRelPath: string): string {
+  const rel = normalizeRel(posixRelPath);
+  const windows = isWindowsRoot(root);
+  const separator = windows ? "\\" : "/";
+  const trimmedRoot = root.replace(/[\\/]+$/, "");
+  const nativeRel = windows ? rel.replaceAll("/", "\\") : rel;
+  if (nativeRel.length === 0) return trimmedRoot;
+  return `${trimmedRoot}${separator}${nativeRel}`;
+}
+
+function isWindowsRoot(root: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(root) || root.includes("\\");
+}

--- a/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
+++ b/clients/gui-app/src/lib/host-rpc-policy/host-method-policy-table.ts
@@ -399,6 +399,8 @@ export const HOST_METHOD_POLL_TABLE = {
   "workspace.mentionGitRoot": { ...LATEST_SCHEDULING, poll: null },
   "workspace.mentionGitBranches": { ...LATEST_SCHEDULING, poll: null },
   "workspace.mentionGitCommits": { ...LATEST_SCHEDULING, poll: null },
+  "workspace.searchPaths": { ...LATEST_SCHEDULING, poll: null },
+  "workspace.searchText": { ...LATEST_SCHEDULING, poll: null },
   "workspace.resolvePathsByRepoIdentifiers": {
     ...LATEST_SCHEDULING,
     poll: null,
@@ -536,6 +538,7 @@ export const HOST_METHOD_POLL_TABLE = {
   },
   "epic.listCommentThreads": { ...LATEST_SCHEDULING, poll: null },
   "epic.resolveArtifactByPath": { ...LATEST_SCHEDULING, poll: null },
+  "epic.searchArtifacts": { ...LATEST_SCHEDULING, poll: null },
   // Opening paths changes state in the user's editor.
   "editor.openPaths": { mode: "fifo", joinResponseTimeoutMs: null, poll: null },
   "git.listChangedFiles": {

--- a/clients/gui-app/src/stores/epics/panel-header-search-store.ts
+++ b/clients/gui-app/src/stores/epics/panel-header-search-store.ts
@@ -1,0 +1,99 @@
+/**
+ * Ephemeral per-panel "header search" state for the Epic left sidebar.
+ *
+ * A panel that opts in (`supportsHeaderSearch`) trades its whole header row -
+ * chevron, icon, title, actions - for a search input while searching, instead
+ * of stacking a permanently-visible box underneath it. That keeps the resting
+ * panel one row taller and stops a rarely-used mode from carrying constant
+ * visual weight.
+ *
+ * State lives here rather than in `left-panel-store` because none of it should
+ * persist: reopening the app should land you in browse mode, never in a
+ * half-typed search. `slotByPanelId` holds the header's live portal target, so
+ * the owning search component can keep its input, results, refs, and combobox
+ * ARIA wiring in ONE component while the input's DOM renders up in the header.
+ */
+import { create } from "zustand";
+import type { LeftPanelId } from "@/stores/epics/left-panel-store";
+
+interface PanelHeaderSearchStore {
+  readonly openByPanelId: Readonly<Partial<Record<LeftPanelId, boolean>>>;
+  readonly queryByPanelId: Readonly<Partial<Record<LeftPanelId, string>>>;
+  readonly slotByPanelId: Readonly<Partial<Record<LeftPanelId, HTMLElement>>>;
+
+  /**
+   * Enter search mode. `seed` is the character that triggered it for the
+   * type-to-filter path (the keystroke would otherwise be swallowed by the
+   * focus handoff), or "" when opened from the header icon.
+   */
+  readonly openSearch: (panelId: LeftPanelId, seed: string) => void;
+  readonly closeSearch: (panelId: LeftPanelId) => void;
+  readonly setSearchQuery: (panelId: LeftPanelId, query: string) => void;
+  /** Ref-callback sink for the header's portal target; `null` on unmount. */
+  readonly setSearchSlot: (
+    panelId: LeftPanelId,
+    element: HTMLElement | null,
+  ) => void;
+}
+
+function withoutKey<T>(
+  record: Readonly<Partial<Record<LeftPanelId, T>>>,
+  panelId: LeftPanelId,
+): Readonly<Partial<Record<LeftPanelId, T>>> {
+  if (!Object.hasOwn(record, panelId)) return record;
+  const { [panelId]: _dropped, ...rest } = record;
+  return rest;
+}
+
+export const usePanelHeaderSearchStore = create<PanelHeaderSearchStore>(
+  (set) => ({
+    openByPanelId: {},
+    queryByPanelId: {},
+    slotByPanelId: {},
+
+    openSearch: (panelId, seed) =>
+      set((state) => ({
+        openByPanelId: { ...state.openByPanelId, [panelId]: true },
+        queryByPanelId: { ...state.queryByPanelId, [panelId]: seed },
+      })),
+
+    closeSearch: (panelId) =>
+      set((state) => ({
+        openByPanelId: withoutKey(state.openByPanelId, panelId),
+        queryByPanelId: withoutKey(state.queryByPanelId, panelId),
+      })),
+
+    setSearchQuery: (panelId, query) =>
+      set((state) => ({
+        queryByPanelId: { ...state.queryByPanelId, [panelId]: query },
+      })),
+
+    setSearchSlot: (panelId, element) =>
+      set((state) => ({
+        slotByPanelId:
+          element === null
+            ? withoutKey(state.slotByPanelId, panelId)
+            : { ...state.slotByPanelId, [panelId]: element },
+      })),
+  }),
+);
+
+export function usePanelHeaderSearchOpen(panelId: LeftPanelId): boolean {
+  return usePanelHeaderSearchStore(
+    (state) => state.openByPanelId[panelId] === true,
+  );
+}
+
+export function usePanelHeaderSearchQuery(panelId: LeftPanelId): string {
+  return usePanelHeaderSearchStore(
+    (state) => state.queryByPanelId[panelId] ?? "",
+  );
+}
+
+export function usePanelHeaderSearchSlot(
+  panelId: LeftPanelId,
+): HTMLElement | null {
+  return usePanelHeaderSearchStore(
+    (state) => state.slotByPanelId[panelId] ?? null,
+  );
+}

--- a/clients/gui-app/vitest.config.ts
+++ b/clients/gui-app/vitest.config.ts
@@ -7,8 +7,8 @@ const availableParallelism =
     ? os.availableParallelism()
     : os.cpus().length;
 const MAX_TEST_WORKERS = Math.min(
-  4,
-  Math.max(2, Math.floor(availableParallelism / 2)),
+  2,
+  Math.max(1, Math.floor(availableParallelism / 2)),
 );
 
 export default defineConfig({
@@ -54,6 +54,8 @@ export default defineConfig({
     ],
     globals: false,
     pool: "forks",
+    // A few suites advance large fake-timer windows. Limiting concurrently
+    // running files keeps those timers responsive on CI's shared runners.
     maxWorkers: MAX_TEST_WORKERS,
     testTimeout: 20_000,
     hookTimeout: 20_000,

--- a/protocol/src/host/epic/__tests__/epic-search-artifacts-schema.test.ts
+++ b/protocol/src/host/epic/__tests__/epic-search-artifacts-schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { searchArtifactsRequestSchema } from "../unary-schemas";
+
+function requestWithSubtreePath(subtreePath: string | null) {
+  return {
+    epicId: "epic-1",
+    query: "needle",
+    fields: { title: true, path: true, body: true },
+    filters: { kinds: null, statuses: null, subtreePath },
+    limit: 50,
+  };
+}
+
+describe("searchArtifactsRequestSchema subtreePath", () => {
+  it.each(["tickets", "tickets/child", "unicode/ñandú"])(
+    "accepts relative POSIX path %s",
+    (subtreePath) => {
+      expect(
+        searchArtifactsRequestSchema.safeParse(
+          requestWithSubtreePath(subtreePath),
+        ).success,
+      ).toBe(true);
+    },
+  );
+
+  it.each(["", "/absolute", ".", "..", "tickets/../escape", "tickets//child"])(
+    "rejects unsafe subtree path %s",
+    (subtreePath) => {
+      expect(
+        searchArtifactsRequestSchema.safeParse(
+          requestWithSubtreePath(subtreePath),
+        ).success,
+      ).toBe(false);
+    },
+  );
+});

--- a/protocol/src/host/epic/contracts.ts
+++ b/protocol/src/host/epic/contracts.ts
@@ -51,6 +51,8 @@ import {
   removeEpicRepoResponseSchema,
   resolveArtifactByPathRequestSchema,
   resolveArtifactByPathResponseSchema,
+  searchArtifactsRequestSchema,
+  searchArtifactsResponseSchema,
   renameArtifactRequestSchema,
   renameArtifactResponseSchema,
   renameChatRequestSchema,
@@ -433,6 +435,17 @@ export const epicResolveArtifactByPathV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: resolveArtifactByPathRequestSchema,
   responseSchema: resolveArtifactByPathResponseSchema,
+});
+
+// `epic.searchArtifacts@1.0` - Epic-scoped artifact title/path/body search over
+// the epic's on-disk Markdown mirror + authoritative Y.Doc metadata. Optional
+// (non-floor): an old host lacks it in its optional manifest and returns
+// E_HOST_UNSUPPORTED for this call only, so the sidebar degrades to no search.
+export const epicSearchArtifactsV10 = defineRpcContract({
+  method: "epic.searchArtifacts",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: searchArtifactsRequestSchema,
+  responseSchema: searchArtifactsResponseSchema,
 });
 
 export { epicSubscribeV10 };

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -1415,14 +1415,18 @@ export const searchArtifactsRequestSchema = z.object({
   query: z.string(),
   fields: searchArtifactsFieldsSchema,
   filters: searchArtifactsFiltersSchema,
-  limit: z.number().int().positive(),
+  limit: z.number().int().min(1).max(1_000),
 });
 export type SearchArtifactsRequest = z.infer<
   typeof searchArtifactsRequestSchema
 >;
 
 /** Which surface produced a hit. A hit may carry more than one source. */
-export const searchArtifactMatchSourceSchema = z.enum(["title", "path", "body"]);
+export const searchArtifactMatchSourceSchema = z.enum([
+  "title",
+  "path",
+  "body",
+]);
 export type SearchArtifactMatchSource = z.infer<
   typeof searchArtifactMatchSourceSchema
 >;
@@ -1447,10 +1451,14 @@ export const searchArtifactSnippetSchema = z.object({
   lineNumber: z.number().int().nonnegative(),
   text: z.string(),
   ranges: z.array(
-    z.object({
-      startByte: z.number().int().nonnegative(),
-      endByte: z.number().int().nonnegative(),
-    }),
+    z
+      .object({
+        startByte: z.number().int().nonnegative(),
+        endByte: z.number().int().nonnegative(),
+      })
+      .refine((range) => range.endByte >= range.startByte, {
+        message: "endByte must not precede startByte",
+      }),
   ),
 });
 export type SearchArtifactSnippet = z.infer<typeof searchArtifactSnippetSchema>;

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -1461,7 +1461,7 @@ export const SEARCH_ARTIFACT_SNIPPET_MAX_BYTES = 512;
  * match past that bound is dropped rather than pointing outside `text`.
  */
 export const searchArtifactSnippetSchema = z.object({
-  lineNumber: z.number().int().nonnegative(),
+  lineNumber: z.number().int().positive(),
   text: z.string(),
   ranges: z.array(
     z

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -28,6 +28,10 @@ import {
   worktreeIntentSchema,
 } from "@traycer/protocol/host/worktree-schemas";
 import {
+  SEARCH_TEXT_PREVIEW_MAX_BYTES,
+  searchTextPreviewRangeSchema,
+} from "@traycer/protocol/host/search-text-preview-schema";
+import {
   chatRunSettingsSchema,
   chatRunSettingsStrictSchema,
   userMessageSenderSchema,
@@ -1451,7 +1455,7 @@ export type SearchArtifactMatchSource = z.infer<
  * clamping/dropping highlight ranges so every returned range still addresses the
  * returned text. Bounds response weight against a pathological single-line body.
  */
-export const SEARCH_ARTIFACT_SNIPPET_MAX_BYTES = 512;
+export const SEARCH_ARTIFACT_SNIPPET_MAX_BYTES = SEARCH_TEXT_PREVIEW_MAX_BYTES;
 
 /**
  * One body-match line. `ranges` are BYTE offsets into the UTF-8 encoding of
@@ -1463,16 +1467,7 @@ export const SEARCH_ARTIFACT_SNIPPET_MAX_BYTES = 512;
 export const searchArtifactSnippetSchema = z.object({
   lineNumber: z.number().int().positive(),
   text: z.string(),
-  ranges: z.array(
-    z
-      .object({
-        startByte: z.number().int().nonnegative(),
-        endByte: z.number().int().nonnegative(),
-      })
-      .refine((range) => range.endByte >= range.startByte, {
-        message: "endByte must not precede startByte",
-      }),
-  ),
+  ranges: z.array(searchTextPreviewRangeSchema),
 });
 export type SearchArtifactSnippet = z.infer<typeof searchArtifactSnippetSchema>;
 

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -1375,3 +1375,127 @@ export const resolveArtifactByPathResponseSchema = z.object({
 export type ResolveArtifactByPathResponse = z.infer<
   typeof resolveArtifactByPathResponseSchema
 >;
+
+// ─── Search artifacts (epic.searchArtifacts@1.0 wire shape) ──────────────────
+// Epic-scoped artifact search. `epicId` is ALWAYS required: the protocol cannot
+// represent an omitted epic, an "all epics" sentinel, or a cross-epic scope, so
+// artifact search can never grow into a cloud-wide index (search decision log,
+// "Context-derived search scope"). `fields` selects which of title / relative
+// path / Markdown body are searched; title/path are Fuse-ranked over authoritative
+// artifact metadata, body is ripgrep-matched over the epic's on-disk Markdown
+// mirror. All paths returned are RELATIVE to the epic's artifact root - a
+// host-absolute path is never exposed.
+
+/** Which of the artifact's searchable surfaces a query is run against. */
+export const searchArtifactsFieldsSchema = z.object({
+  title: z.boolean(),
+  path: z.boolean(),
+  body: z.boolean(),
+});
+export type SearchArtifactsFields = z.infer<typeof searchArtifactsFieldsSchema>;
+
+/**
+ * Server-side filters composed with the query. `kinds`/`statuses` restrict by
+ * artifact metadata; `subtreePath` restricts to a subtree of the artifact tree,
+ * expressed as a POSIX path RELATIVE to the epic artifact root (never an
+ * absolute filesystem root - the host derives and authorizes the real root
+ * internally). A `null` field means "no restriction on this axis".
+ */
+export const searchArtifactsFiltersSchema = z.object({
+  kinds: z.array(LatestEpicArtifactKindSchema).nullable(),
+  statuses: z.array(z.number().int()).nullable(),
+  subtreePath: z.string().nullable(),
+});
+export type SearchArtifactsFilters = z.infer<
+  typeof searchArtifactsFiltersSchema
+>;
+
+export const searchArtifactsRequestSchema = z.object({
+  epicId: z.string(),
+  query: z.string(),
+  fields: searchArtifactsFieldsSchema,
+  filters: searchArtifactsFiltersSchema,
+  limit: z.number().int().positive(),
+});
+export type SearchArtifactsRequest = z.infer<
+  typeof searchArtifactsRequestSchema
+>;
+
+/** Which surface produced a hit. A hit may carry more than one source. */
+export const searchArtifactMatchSourceSchema = z.enum(["title", "path", "body"]);
+export type SearchArtifactMatchSource = z.infer<
+  typeof searchArtifactMatchSourceSchema
+>;
+
+/**
+ * Maximum size, in UTF-8 bytes, of a single {@link searchArtifactSnippetSchema}
+ * `text`. The host enforces this bound (ripgrep's `--max-columns` does NOT bound
+ * the JSON `lines.text` payload), truncating on a UTF-8 character boundary and
+ * clamping/dropping highlight ranges so every returned range still addresses the
+ * returned text. Bounds response weight against a pathological single-line body.
+ */
+export const SEARCH_ARTIFACT_SNIPPET_MAX_BYTES = 512;
+
+/**
+ * One body-match line. `ranges` are BYTE offsets into the UTF-8 encoding of
+ * `text` (ripgrep submatch offsets), not UTF-16/JS string indices, so a
+ * consumer that wants character indices converts deliberately. `text` is bounded
+ * to {@link SEARCH_ARTIFACT_SNIPPET_MAX_BYTES} bytes host-side; a highlight for a
+ * match past that bound is dropped rather than pointing outside `text`.
+ */
+export const searchArtifactSnippetSchema = z.object({
+  lineNumber: z.number().int().nonnegative(),
+  text: z.string(),
+  ranges: z.array(
+    z.object({
+      startByte: z.number().int().nonnegative(),
+      endByte: z.number().int().nonnegative(),
+    }),
+  ),
+});
+export type SearchArtifactSnippet = z.infer<typeof searchArtifactSnippetSchema>;
+
+/**
+ * One ranked artifact hit. `artifactId`/`kind`/`title` are authoritative
+ * (resolved against the epic's Y.Doc index, so a stale disk entry for a deleted
+ * artifact never appears); `status` is read from the trusted disk mirror.
+ * `relativePath` and `breadcrumb` are relative to the epic artifact root. The
+ * hit is NOT authoritative for opening: the caller re-resolves the path through
+ * the existing `epic.resolveArtifactByPath` route so a stale disk result cannot
+ * mutate or resurrect deleted state.
+ */
+export const searchArtifactHitSchema = z.object({
+  artifactId: z.string(),
+  kind: LatestEpicArtifactKindSchema,
+  title: z.string(),
+  status: z.number().int().nullable(),
+  relativePath: z.string(),
+  breadcrumb: z.array(z.string()),
+  sources: z.array(searchArtifactMatchSourceSchema),
+  score: z.number(),
+  snippets: z.array(searchArtifactSnippetSchema),
+});
+export type SearchArtifactHit = z.infer<typeof searchArtifactHitSchema>;
+
+/**
+ * `ready` = the mirror was searched (an empty `results` is a legitimate
+ * zero-match). `mirror-unavailable` = the epic's on-disk mirror does not exist
+ * yet / is not a directory - a DISTINCT typed condition from zero matches, so a
+ * caller can tell "nothing matched" apart from "nothing to search yet".
+ */
+export const searchArtifactsOutcomeSchema = z.enum([
+  "ready",
+  "mirror-unavailable",
+]);
+export type SearchArtifactsOutcome = z.infer<
+  typeof searchArtifactsOutcomeSchema
+>;
+
+export const searchArtifactsResponseSchema = z.object({
+  outcome: searchArtifactsOutcomeSchema,
+  results: z.array(searchArtifactHitSchema),
+  truncated: z.boolean(),
+});
+export type SearchArtifactsResponse = z.infer<
+  typeof searchArtifactsResponseSchema
+>;

--- a/protocol/src/host/epic/unary-schemas.ts
+++ b/protocol/src/host/epic/unary-schemas.ts
@@ -1404,7 +1404,20 @@ export type SearchArtifactsFields = z.infer<typeof searchArtifactsFieldsSchema>;
 export const searchArtifactsFiltersSchema = z.object({
   kinds: z.array(LatestEpicArtifactKindSchema).nullable(),
   statuses: z.array(z.number().int()).nullable(),
-  subtreePath: z.string().nullable(),
+  subtreePath: z
+    .string()
+    .min(1)
+    .refine(
+      (path) =>
+        !path.startsWith("/") &&
+        path
+          .split("/")
+          .every(
+            (segment) => segment !== "" && segment !== "." && segment !== "..",
+          ),
+      "subtreePath must be a non-empty relative POSIX path without traversal",
+    )
+    .nullable(),
 });
 export type SearchArtifactsFilters = z.infer<
   typeof searchArtifactsFiltersSchema

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -165,6 +165,7 @@ import {
   epicReparentChatV10,
   epicReplyToCommentThreadV10,
   epicResolveArtifactByPathV10,
+  epicSearchArtifactsV10,
   epicRevokeCollaboratorV10,
   epicSetCommentThreadResolvedV10,
   epicSetPinnedV10,
@@ -184,6 +185,8 @@ import {
   workspacePrepareFoldersV10,
   workspaceReadFileV10,
   workspaceResolvePathsByRepoIdentifiersV10,
+  workspaceSearchPathsV10,
+  workspaceSearchTextV10,
 } from "@traycer/protocol/host/workspace/contracts";
 import {
   terminalCreateDowngradeV20ToV10,
@@ -2961,6 +2964,40 @@ const HOST_RPC_REGISTRY_DEFINITION = {
       downgradePathsFromLatest: {},
     },
   },
+  // Additive, post-v1.0.0 optional method: a host that predates it simply lacks
+  // it and the renderer falls back to its local file-tree filter, so it rides
+  // the optional-capability channel (`degrade: unsupported`) and stays out of
+  // the released floor / baseline surface.
+  "workspace.searchPaths": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: workspaceSearchPathsV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+  },
+  // Additive, post-v1.0.0 optional method: scoped code TEXT search. A host that
+  // predates it simply lacks it and the renderer disables the text-search flow,
+  // so it rides the optional-capability channel (`degrade: unsupported`) and
+  // stays out of the released floor / baseline surface.
+  "workspace.searchText": {
+    degrade: { kind: "unsupported" },
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: workspaceSearchTextV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+  },
   "workspace.mentionFiles": {
     1: {
       latestMinor: 0,
@@ -3459,6 +3496,22 @@ const HOST_RPC_REGISTRY_DEFINITION = {
       },
       downgradePathsFromLatest: {},
     },
+  },
+  // Optional (non-floor) capability: Epic-scoped artifact search. An old peer
+  // lacks it in its optional manifest; callers get E_HOST_UNSUPPORTED for this
+  // call only and the sidebar degrades to no search (no cross-Epic fallback).
+  "epic.searchArtifacts": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: epicSearchArtifactsV10,
+          upgradeFromPreviousVersion: null,
+        },
+      },
+      downgradePathsFromLatest: {},
+    },
+    degrade: { kind: "unsupported" },
   },
   "editor.openPaths": {
     1: {

--- a/protocol/src/host/search-text-preview-schema.ts
+++ b/protocol/src/host/search-text-preview-schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * Maximum UTF-8 byte length of a text-search preview. Hosts truncate previews
+ * at a character boundary and clamp or omit ranges that exceed this bound.
+ */
+export const SEARCH_TEXT_PREVIEW_MAX_BYTES = 512;
+
+/** Byte offsets into a UTF-8 text-search preview. */
+export const searchTextPreviewRangeSchema = z
+  .object({
+    startByte: z.number().int().nonnegative(),
+    endByte: z.number().int().nonnegative(),
+  })
+  .refine(
+    (range) =>
+      range.endByte >= range.startByte &&
+      range.endByte <= SEARCH_TEXT_PREVIEW_MAX_BYTES,
+    {
+      message: `endByte must not precede startByte or exceed ${SEARCH_TEXT_PREVIEW_MAX_BYTES}`,
+    },
+  );

--- a/protocol/src/host/workspace/__tests__/workspace-search-sources.test.ts
+++ b/protocol/src/host/workspace/__tests__/workspace-search-sources.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
+import {
+  workspaceSearchPathsRequestSchema,
+  workspaceSearchPathsResponseSchema,
+  workspaceSearchTextRequestSchema,
+  workspaceSearchTextResponseSchema,
+} from "../unary-schemas";
+
+describe("workspace shared search sources", () => {
+  it("preserves attached-root request and response wire shapes", () => {
+    const request = {
+      epicId: "epic-1",
+      reference: { root: "/attached/workspace" },
+      query: "needle",
+      limit: 10,
+      kinds: "files" as const,
+    };
+    expect(workspaceSearchPathsRequestSchema.parse(request)).toEqual(request);
+
+    const response = {
+      epicId: "epic-1",
+      root: "/attached/workspace",
+      outcome: "ready" as const,
+      results: [{ kind: "file" as const, relPath: "src/a.ts", name: "a.ts" }],
+      truncated: false,
+    };
+    expect(workspaceSearchPathsResponseSchema.parse(response)).toEqual(response);
+
+    const textRequest = {
+      epicId: "epic-1",
+      reference: { root: "/attached/workspace" },
+      query: "needle",
+      options: {
+        regex: false,
+        caseSensitive: false,
+        wholeWord: false,
+        includeGlobs: [],
+        excludeGlobs: [],
+      },
+      limit: 10,
+    };
+    expect(workspaceSearchTextRequestSchema.parse(textRequest)).toEqual(textRequest);
+
+    const textResponse = {
+      epicId: "epic-1",
+      root: "/attached/workspace",
+      outcome: "ready" as const,
+      results: [
+        {
+          relPath: "src/a.ts",
+          lineNumber: 1,
+          column: 1,
+          preview: { text: "needle", ranges: [{ startByte: 0, endByte: 6 }] },
+        },
+      ],
+      truncated: false,
+    };
+    expect(workspaceSearchTextResponseSchema.parse(textResponse)).toEqual(textResponse);
+  });
+
+  it("adds opaque Epic-artifact source variants without a mirror path", () => {
+    const request = {
+      epicId: "epic-1",
+      reference: { kind: "epic-artifacts" as const },
+      query: "needle",
+      options: {
+        regex: false,
+        caseSensitive: false,
+        wholeWord: false,
+        includeGlobs: [],
+        excludeGlobs: [],
+      },
+      limit: 10,
+    };
+    expect(workspaceSearchTextRequestSchema.parse(request)).toEqual(request);
+
+    const response = {
+      epicId: "epic-1",
+      source: { kind: "epic-artifacts" as const },
+      outcome: "ready" as const,
+      results: [
+        {
+          relPath: "tickets/one",
+          lineNumber: 7,
+          column: 1,
+          preview: { text: "needle", ranges: [{ startByte: 0, endByte: 6 }] },
+        },
+      ],
+      truncated: false,
+    };
+    expect(workspaceSearchTextResponseSchema.parse(response)).toEqual(response);
+    expect(JSON.stringify(response)).not.toContain("/epics/");
+    expect(RELEASED_FLOOR_METHOD_NAMES).not.toContain("workspace.searchPaths");
+    expect(RELEASED_FLOOR_METHOD_NAMES).not.toContain("workspace.searchText");
+  });
+
+  it("gives an artifact discriminant precedence over an accidental root", () => {
+    const pathRequest = workspaceSearchPathsRequestSchema.parse({
+      epicId: "epic-1",
+      reference: {
+        kind: "epic-artifacts",
+        root: "/tmp/attached",
+        epicId: "other-epic",
+      },
+      query: "needle",
+      limit: 10,
+      kinds: "files",
+    });
+    expect(pathRequest.reference).toEqual({ kind: "epic-artifacts" });
+
+    const textRequest = workspaceSearchTextRequestSchema.parse({
+      epicId: "epic-1",
+      reference: { kind: "epic-artifacts", root: "/tmp/attached" },
+      query: "needle",
+      options: {
+        regex: false,
+        caseSensitive: false,
+        wholeWord: false,
+        includeGlobs: [],
+        excludeGlobs: [],
+      },
+      limit: 10,
+    });
+    expect(textRequest.reference).toEqual({ kind: "epic-artifacts" });
+  });
+});

--- a/protocol/src/host/workspace/__tests__/workspace-search-sources.test.ts
+++ b/protocol/src/host/workspace/__tests__/workspace-search-sources.test.ts
@@ -1,13 +1,40 @@
 import { describe, expect, it } from "vitest";
 import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
 import {
+  SEARCH_ARTIFACT_SNIPPET_MAX_BYTES,
+  searchArtifactSnippetSchema,
+} from "@traycer/protocol/host/epic/unary-schemas";
+import {
+  WORKSPACE_SEARCH_TEXT_PREVIEW_MAX_BYTES,
   workspaceSearchPathsRequestSchema,
   workspaceSearchPathsResponseSchema,
   workspaceSearchTextRequestSchema,
+  workspaceSearchTextPreviewSchema,
   workspaceSearchTextResponseSchema,
 } from "../unary-schemas";
 
 describe("workspace shared search sources", () => {
+  it("shares the text preview byte limit and range validation with artifact search", () => {
+    const outOfBoundsRange = { startByte: 0, endByte: 513 };
+
+    expect(WORKSPACE_SEARCH_TEXT_PREVIEW_MAX_BYTES).toBe(
+      SEARCH_ARTIFACT_SNIPPET_MAX_BYTES,
+    );
+    expect(
+      workspaceSearchTextPreviewSchema.safeParse({
+        text: "needle",
+        ranges: [outOfBoundsRange],
+      }).success,
+    ).toBe(false);
+    expect(
+      searchArtifactSnippetSchema.safeParse({
+        lineNumber: 1,
+        text: "needle",
+        ranges: [outOfBoundsRange],
+      }).success,
+    ).toBe(false);
+  });
+
   it("preserves attached-root request and response wire shapes", () => {
     const request = {
       epicId: "epic-1",

--- a/protocol/src/host/workspace/contracts.ts
+++ b/protocol/src/host/workspace/contracts.ts
@@ -19,6 +19,10 @@ import {
   workspaceReadFileResponseSchema,
   workspaceResolvePathsByRepoIdentifiersRequestSchema,
   workspaceResolvePathsByRepoIdentifiersResponseSchema,
+  workspaceSearchPathsRequestSchema,
+  workspaceSearchPathsResponseSchema,
+  workspaceSearchTextRequestSchema,
+  workspaceSearchTextResponseSchema,
   workspaceWorktreeMentionSuggestionsResponseSchema,
 } from "@traycer/protocol/host/workspace/unary-schemas";
 
@@ -97,4 +101,18 @@ export const workspaceReadFileV10 = defineRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   requestSchema: workspaceReadFileRequestSchema,
   responseSchema: workspaceReadFileResponseSchema,
+});
+
+export const workspaceSearchPathsV10 = defineRpcContract({
+  method: "workspace.searchPaths",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: workspaceSearchPathsRequestSchema,
+  responseSchema: workspaceSearchPathsResponseSchema,
+});
+
+export const workspaceSearchTextV10 = defineRpcContract({
+  method: "workspace.searchText",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  requestSchema: workspaceSearchTextRequestSchema,
+  responseSchema: workspaceSearchTextResponseSchema,
 });

--- a/protocol/src/host/workspace/unary-schemas.ts
+++ b/protocol/src/host/workspace/unary-schemas.ts
@@ -348,3 +348,310 @@ export const workspaceReadFileResponseSchema = z.object({
 export type WorkspaceReadFileResponse = z.infer<
   typeof workspaceReadFileResponseSchema
 >;
+
+/**
+ * Scoped file/folder name search over a SINGLE Epic-attached root.
+ *
+ * `epicId` is explicit and required (the decision log forbids an omitted Epic
+ * or a cross-Epic sentinel). `reference.root` names the client-selected
+ * workspace-folder or worktree root - it is the same on-disk path the Epic
+ * workspace pickers already expose (a binding `runningDir` or a resolved
+ * workspace-folder path). It is a SELECTOR, not authority: the host resolves
+ * the Epic's attached folders/bindings for THIS host, canonicalizes both
+ * sides, and rejects any root that is not in that allow-list (unknown, moved,
+ * escaped, or cross-host). The host never accepts an arbitrary absolute path
+ * as search authority - this is the boundary that `workspace.listFileTree`
+ * (which trusts the client `workspacePath`) does not enforce.
+ */
+export const workspaceSearchPathsReferenceSchema = z.object({
+  root: z.string(),
+});
+export type WorkspaceSearchPathsReference = z.infer<
+  typeof workspaceSearchPathsReferenceSchema
+>;
+
+/**
+ * An opaque, Epic-scoped source selector. The renderer may name this source,
+ * but never the host-local mirror directory behind it; the resolver derives
+ * that directory from the required request `epicId` after authorizing access.
+ */
+export const workspaceEpicArtifactsSourceSchema = z.object({
+  kind: z.literal("epic-artifacts"),
+});
+export type WorkspaceEpicArtifactsSource = z.infer<
+  typeof workspaceEpicArtifactsSourceSchema
+>;
+
+/**
+ * A search source is either the original attached-root selector or the
+ * additive, host-derived Epic artifact source. Keep the `{ root }` branch
+ * intact: already-built renderers continue to send and receive its legacy
+ * shape without learning about artifact mirrors.
+ */
+export const workspaceSearchSourceSchema = z.union([
+  workspaceEpicArtifactsSourceSchema,
+  workspaceSearchPathsReferenceSchema,
+]);
+export type WorkspaceSearchSource = z.infer<typeof workspaceSearchSourceSchema>;
+
+/**
+ * Which candidate kinds a caller wants back. The host filters candidates to
+ * this set BEFORE ranking and applying `limit`, so a `folders` request spends
+ * every one of its `limit` slots on folders (files never crowd them out) and a
+ * `files` request never pays to rank/serialize folders. `both` ranks the union.
+ */
+export const workspaceSearchPathsKindFilterSchema = z.enum([
+  "files",
+  "folders",
+  "both",
+]);
+export type WorkspaceSearchPathsKindFilter = z.infer<
+  typeof workspaceSearchPathsKindFilterSchema
+>;
+
+export const workspaceSearchPathsRequestSchema = z.object({
+  epicId: z.string(),
+  reference: workspaceSearchSourceSchema,
+  query: z.string(),
+  limit: z.number().int().min(1).max(100),
+  kinds: workspaceSearchPathsKindFilterSchema,
+});
+export type WorkspaceSearchPathsRequest = z.infer<
+  typeof workspaceSearchPathsRequestSchema
+>;
+
+export const workspaceSearchPathResultKindSchema = z.enum(["file", "folder"]);
+export type WorkspaceSearchPathResultKind = z.infer<
+  typeof workspaceSearchPathResultKindSchema
+>;
+
+/**
+ * A single ranked result. `relPath` is host-canonical: POSIX-relative to the
+ * authorized root, `/`-separated, no leading slash, and (for folders) no
+ * trailing slash. `name` is the host-computed display basename so the renderer
+ * never parses the path. The renderer reconstructs any absolute/open target by
+ * joining `relPath` onto the reference root it already holds - the host does
+ * NOT return a host-absolute path as search authority.
+ */
+export const workspaceSearchPathResultSchema = z.object({
+  kind: workspaceSearchPathResultKindSchema,
+  relPath: z.string(),
+  name: z.string(),
+});
+export type WorkspaceSearchPathResult = z.infer<
+  typeof workspaceSearchPathResultSchema
+>;
+
+/**
+ * Distinguishes a genuine search from a refused root:
+ * - `ready`: the root was authorized and searched. `results` is the (possibly
+ *   empty) match set - an empty `ready` means "searched, nothing matched".
+ * - `root_unavailable`: the selected root is not authorized/attached/resolvable
+ *   for this Epic on this host (unknown, moved, escaped, or cross-host). No
+ *   search ran; `results` is empty. This is deliberately a status, NOT a reason
+ *   or a path, so it never leaks WHY a root was refused. Callers treat it like
+ *   an unsupported/errored request: the file-tree panel falls back to its local
+ *   filter, and mention callers re-issue that root through the legacy RPC.
+ */
+export const workspaceSearchPathsOutcomeSchema = z.enum([
+  "ready",
+  "root_unavailable",
+]);
+export type WorkspaceSearchPathsOutcome = z.infer<
+  typeof workspaceSearchPathsOutcomeSchema
+>;
+
+/**
+ * Echoes the authorized `epicId` and `root` so a late response that crosses an
+ * Epic/host/workspace/worktree selection change is detectable and discardable
+ * by the caller. `truncated` marks that enumeration hit an internal cap.
+ */
+export const workspaceSearchPathsAttachedRootResponseSchema = z.object({
+  epicId: z.string(),
+  root: z.string(),
+  outcome: workspaceSearchPathsOutcomeSchema,
+  results: z.array(workspaceSearchPathResultSchema),
+  truncated: z.boolean(),
+});
+export type WorkspaceSearchPathsAttachedRootResponse = z.infer<
+  typeof workspaceSearchPathsAttachedRootResponseSchema
+>;
+
+/**
+ * Additive response branch for the opaque artifact source. It echoes the typed
+ * selector rather than a mirror path, so a stale response is still detectable
+ * without making the host filesystem layout part of the wire contract.
+ */
+export const workspaceSearchPathsEpicArtifactsResponseSchema = z.object({
+  epicId: z.string(),
+  source: workspaceEpicArtifactsSourceSchema,
+  outcome: workspaceSearchPathsOutcomeSchema,
+  results: z.array(workspaceSearchPathResultSchema),
+  truncated: z.boolean(),
+});
+export type WorkspaceSearchPathsEpicArtifactsResponse = z.infer<
+  typeof workspaceSearchPathsEpicArtifactsResponseSchema
+>;
+
+export const workspaceSearchPathsResponseSchema = z.union([
+  workspaceSearchPathsAttachedRootResponseSchema,
+  workspaceSearchPathsEpicArtifactsResponseSchema,
+]);
+export type WorkspaceSearchPathsResponse = z.infer<
+  typeof workspaceSearchPathsResponseSchema
+>;
+
+/**
+ * Scoped code TEXT (file-content) search over one attached root or the
+ * host-derived Epic artifact source.
+ *
+ * Same authorization boundary as {@link workspaceSearchPathsRequestSchema}:
+ * `epicId` is explicit/required. For `reference: { root }`, the host authorizes
+ * that selector against the Epic's attached folders/bindings for THIS host
+ * (never an arbitrary absolute path). For `reference: { kind: "epic-artifacts" }`,
+ * the host authorizes the Epic first, then derives its mirror root internally.
+ * An unavailable source yields the typed `root_unavailable` outcome without
+ * ever reaching ripgrep.
+ *
+ * Where path search fuzzy-ranks file NAMES, text search matches file CONTENTS
+ * with ripgrep. Matching semantics are literal by default; `options.regex`
+ * enables explicit regex (a bad pattern returns the typed `invalid_regex`
+ * outcome, distinct from a zero-match `ready`). Arguments are passed directly to
+ * `rg` as an argv array - the host never builds a shell string.
+ */
+export const workspaceSearchTextOptionsSchema = z.object({
+  // `false` (default) matches the query literally (`rg --fixed-strings`); `true`
+  // treats it as a regular expression. An invalid regex is reported as the
+  // `invalid_regex` outcome rather than throwing.
+  regex: z.boolean(),
+  // `false` (default) is case-insensitive; `true` forces a case-sensitive
+  // match. This mirrors the renderer's "Match case" toggle directly.
+  caseSensitive: z.boolean(),
+  // `true` requires the match to fall on word boundaries (`rg --word-regexp`).
+  wholeWord: z.boolean(),
+  // ripgrep `--glob` include / exclude filters (relative to the selected
+  // source). Include globs restrict the walked set; exclude globs are sent as
+  // negated globs (`!<glob>`). For the artifact source, a terminal `.md` is a
+  // virtual alias for its extensionless logical artifact path; the private
+  // `index.md` mirror layout is never exposed. Empty arrays impose no filter.
+  includeGlobs: z.array(z.string()),
+  excludeGlobs: z.array(z.string()),
+});
+export type WorkspaceSearchTextOptions = z.infer<
+  typeof workspaceSearchTextOptionsSchema
+>;
+
+export const workspaceSearchTextRequestSchema = z.object({
+  epicId: z.string(),
+  reference: workspaceSearchSourceSchema,
+  query: z.string(),
+  options: workspaceSearchTextOptionsSchema,
+  limit: z.number().int().min(1).max(1_000),
+});
+export type WorkspaceSearchTextRequest = z.infer<
+  typeof workspaceSearchTextRequestSchema
+>;
+
+/**
+ * Maximum size, in UTF-8 bytes, of a single match `preview.text`. ripgrep
+ * returns the FULL matched line in `--json` mode (its `--max-columns` does NOT
+ * bound the JSON `lines.text` payload), so the host truncates the preview to
+ * this bound on a UTF-8 character boundary and clamps/drops highlight ranges so
+ * every returned range still addresses the returned text. Bounds response weight
+ * against a pathological single-line file.
+ */
+export const WORKSPACE_SEARCH_TEXT_PREVIEW_MAX_BYTES = 512;
+
+/**
+ * One preview line for a match. `text` is bounded to
+ * {@link WORKSPACE_SEARCH_TEXT_PREVIEW_MAX_BYTES} UTF-8 bytes host-side. `ranges`
+ * are BYTE offsets into the UTF-8 encoding of `text` (ripgrep submatch offsets),
+ * not UTF-16/JS string indices, so a consumer that wants character indices
+ * converts deliberately; a highlight past the truncation bound is dropped.
+ */
+export const workspaceSearchTextPreviewSchema = z.object({
+  text: z.string(),
+  ranges: z.array(
+    z.object({
+      startByte: z.number().int().nonnegative(),
+      endByte: z.number().int().nonnegative(),
+    }),
+  ),
+});
+export type WorkspaceSearchTextPreview = z.infer<
+  typeof workspaceSearchTextPreviewSchema
+>;
+
+/**
+ * A single content match. `relPath` is host-canonical: POSIX-relative to the
+ * authorized root, `/`-separated, no leading slash - the renderer opens it by
+ * joining onto the reference root it already holds (the host never returns an
+ * absolute path as authority). `lineNumber` is 1-based; `column` is the 1-based
+ * CHARACTER column of the first submatch on the line (for editor navigation),
+ * computed over the full line before preview truncation.
+ */
+export const workspaceSearchTextMatchSchema = z.object({
+  relPath: z.string(),
+  lineNumber: z.number().int().positive(),
+  column: z.number().int().positive(),
+  preview: workspaceSearchTextPreviewSchema,
+});
+export type WorkspaceSearchTextMatch = z.infer<
+  typeof workspaceSearchTextMatchSchema
+>;
+
+/**
+ * Distinguishes a genuine search from a refused root and from a bad pattern:
+ * - `ready`: the root was authorized and searched. `results` is the (possibly
+ *   empty) match set - an empty `ready` means "searched, nothing matched".
+ * - `root_unavailable`: the selected root is not authorized/attached/resolvable
+ *   for this Epic on this host. No search ran; deliberately a bare status that
+ *   never leaks WHY. Callers fall back exactly as for `workspace.searchPaths`.
+ * - `invalid_regex`: `options.regex` was set and the query is not a valid
+ *   regular expression. No matches; a distinct typed condition so the UI can
+ *   show "invalid pattern" rather than a misleading empty result.
+ */
+export const workspaceSearchTextOutcomeSchema = z.enum([
+  "ready",
+  "root_unavailable",
+  "invalid_regex",
+]);
+export type WorkspaceSearchTextOutcome = z.infer<
+  typeof workspaceSearchTextOutcomeSchema
+>;
+
+/**
+ * Echoes the authorized `epicId` and `root` so a late response that crosses an
+ * Epic/host/workspace/worktree/query change is detectable and discardable by the
+ * caller. `truncated` marks that the search hit an internal result/byte/timeout
+ * cap.
+ */
+export const workspaceSearchTextAttachedRootResponseSchema = z.object({
+  epicId: z.string(),
+  root: z.string(),
+  outcome: workspaceSearchTextOutcomeSchema,
+  results: z.array(workspaceSearchTextMatchSchema),
+  truncated: z.boolean(),
+});
+export type WorkspaceSearchTextAttachedRootResponse = z.infer<
+  typeof workspaceSearchTextAttachedRootResponseSchema
+>;
+
+export const workspaceSearchTextEpicArtifactsResponseSchema = z.object({
+  epicId: z.string(),
+  source: workspaceEpicArtifactsSourceSchema,
+  outcome: workspaceSearchTextOutcomeSchema,
+  results: z.array(workspaceSearchTextMatchSchema),
+  truncated: z.boolean(),
+});
+export type WorkspaceSearchTextEpicArtifactsResponse = z.infer<
+  typeof workspaceSearchTextEpicArtifactsResponseSchema
+>;
+
+export const workspaceSearchTextResponseSchema = z.union([
+  workspaceSearchTextAttachedRootResponseSchema,
+  workspaceSearchTextEpicArtifactsResponseSchema,
+]);
+export type WorkspaceSearchTextResponse = z.infer<
+  typeof workspaceSearchTextResponseSchema
+>;

--- a/protocol/src/host/workspace/unary-schemas.ts
+++ b/protocol/src/host/workspace/unary-schemas.ts
@@ -279,9 +279,7 @@ export const workspaceFileTreeNodeSchema = z.object({
   path: z.string().min(1),
   name: z.string().min(1),
 });
-export type WorkspaceFileTreeNode = z.infer<
-  typeof workspaceFileTreeNodeSchema
->;
+export type WorkspaceFileTreeNode = z.infer<typeof workspaceFileTreeNodeSchema>;
 
 export const workspaceListFileTreeResponseSchema = z.object({
   workspacePath: z.string(),
@@ -572,10 +570,14 @@ export const WORKSPACE_SEARCH_TEXT_PREVIEW_MAX_BYTES = 512;
 export const workspaceSearchTextPreviewSchema = z.object({
   text: z.string(),
   ranges: z.array(
-    z.object({
-      startByte: z.number().int().nonnegative(),
-      endByte: z.number().int().nonnegative(),
-    }),
+    z
+      .object({
+        startByte: z.number().int().nonnegative(),
+        endByte: z.number().int().nonnegative(),
+      })
+      .refine((range) => range.endByte >= range.startByte, {
+        message: "endByte must not precede startByte",
+      }),
   ),
 });
 export type WorkspaceSearchTextPreview = z.infer<

--- a/protocol/src/host/workspace/unary-schemas.ts
+++ b/protocol/src/host/workspace/unary-schemas.ts
@@ -7,6 +7,10 @@
  */
 import { z } from "zod";
 import { taskRepoIdentifierSchema } from "@traycer/protocol/host/epic/unary-schemas";
+import {
+  SEARCH_TEXT_PREVIEW_MAX_BYTES,
+  searchTextPreviewRangeSchema,
+} from "@traycer/protocol/host/search-text-preview-schema";
 
 export const workspaceMentionGitTypeSchema = z.enum([
   "against_uncommitted_changes",
@@ -558,7 +562,8 @@ export type WorkspaceSearchTextRequest = z.infer<
  * every returned range still addresses the returned text. Bounds response weight
  * against a pathological single-line file.
  */
-export const WORKSPACE_SEARCH_TEXT_PREVIEW_MAX_BYTES = 512;
+export const WORKSPACE_SEARCH_TEXT_PREVIEW_MAX_BYTES =
+  SEARCH_TEXT_PREVIEW_MAX_BYTES;
 
 /**
  * One preview line for a match. `text` is bounded to
@@ -569,16 +574,7 @@ export const WORKSPACE_SEARCH_TEXT_PREVIEW_MAX_BYTES = 512;
  */
 export const workspaceSearchTextPreviewSchema = z.object({
   text: z.string(),
-  ranges: z.array(
-    z
-      .object({
-        startByte: z.number().int().nonnegative(),
-        endByte: z.number().int().nonnegative(),
-      })
-      .refine((range) => range.endByte >= range.startByte, {
-        message: "endByte must not precede startByte",
-      }),
-  ),
+  ranges: z.array(searchTextPreviewRangeSchema),
 });
 export type WorkspaceSearchTextPreview = z.infer<
   typeof workspaceSearchTextPreviewSchema


### PR DESCRIPTION
## Summary
- add optional, permission-scoped workspace path and text search RPCs backed by bundled ripgrep
- add Epic artifact source support, sidebar artifact search, new-tab text search, and Files-menu artifact paths
- preserve legacy root-source wire shapes and graceful old-host fallback

## Verification
- `bun run --filter @traycer/protocol compile`
- `bun run --filter @traycer-clients/gui-app compile`
- focused GUI suites: 85 tests

Internal host integration follows in a dependent PR.