### PR TITLE
feat(gui-app): mobile shell & navigation (Phase 0)

### DIFF
--- a/clients/gui-app/src/components/layout/__tests__/app-header-mobile-switch.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/app-header-mobile-switch.test.tsx
@@ -1,0 +1,82 @@
+import "../../../../__tests__/test-browser-apis";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppHeader } from "@/components/layout/header/app-header";
+
+// Drive the viewport switch directly; the desktop-only header children need
+// host/query/auth providers, so stub them (and both branch markers) to keep
+// the test to the switch itself.
+const mobileState = vi.hoisted(() => ({ value: false }));
+vi.mock("@/hooks/ui/use-mobile", () => ({
+  useIsMobile: () => mobileState.value,
+  isMobileViewport: () => mobileState.value,
+}));
+vi.mock("@/components/layout/header/mobile-app-header", () => ({
+  MobileAppHeader: () => (
+    <button type="button" aria-label="Open menu">
+      menu
+    </button>
+  ),
+}));
+vi.mock("@/components/layout/tabs/tab-strip", () => ({
+  TabStrip: () => <div role="tablist" aria-label="Open tabs" />,
+}));
+vi.mock("@/components/layout/header/history-nav-buttons", () => ({
+  HistoryNavButtons: () => null,
+}));
+vi.mock("@/components/layout/header/app-update-button", () => ({
+  AppUpdateHeaderButton: () => null,
+}));
+vi.mock("@/components/layout/header/rate-limit-icon", () => ({
+  RateLimitIconButton: () => null,
+}));
+vi.mock("@/components/resources/resource-monitor-popover", () => ({
+  ResourceMonitorPopover: () => null,
+}));
+vi.mock("@/components/layout/header/history-button", () => ({
+  HistoryButton: () => null,
+}));
+vi.mock("@/components/notifications/notifications-bell", () => ({
+  NotificationsBell: () => null,
+}));
+vi.mock("@/components/auth/user-menu", () => ({
+  UserMenu: () => null,
+}));
+vi.mock("@/components/layout/header/sign-in-button", () => ({
+  SignInButton: () => null,
+}));
+
+describe("AppHeader mobile/desktop switch", () => {
+  beforeEach(() => {
+    mobileState.value = false;
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders the mobile hamburger header below md", () => {
+    mobileState.value = true;
+    render(<AppHeader variant="app" />);
+    expect(
+      screen.getByRole("button", { name: "Open menu" }),
+    ).not.toBeNull();
+    expect(screen.queryByRole("tablist", { name: "Open tabs" })).toBeNull();
+  });
+
+  it("renders the desktop tab-strip header at >=md", () => {
+    mobileState.value = false;
+    render(<AppHeader variant="app" />);
+    expect(
+      screen.getByRole("tablist", { name: "Open tabs" }),
+    ).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Open menu" })).toBeNull();
+  });
+
+  it("keeps the desktop header for the host-loading variant even below md", () => {
+    mobileState.value = true;
+    render(<AppHeader variant="host-loading" />);
+    // host-loading never shows the tab strip, but it must NOT switch to the
+    // mobile hamburger header either.
+    expect(screen.queryByRole("button", { name: "Open menu" })).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/layout/__tests__/mobile-app-header.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/mobile-app-header.test.tsx
@@ -55,10 +55,11 @@ describe("MobileAppHeader", () => {
     useEpicCanvasStore.setState({ tabsById: {} });
   });
 
-  it("renders the hamburger and NOT the desktop tab strip", async () => {
+  it("renders the hamburger menu trigger", async () => {
     renderAt("/");
-    expect(await screen.findByTestId("mobile-nav-trigger")).not.toBeNull();
-    expect(screen.queryByTestId("tab-strip")).toBeNull();
+    expect(
+      await screen.findByRole("button", { name: "Open menu" }),
+    ).not.toBeNull();
   });
 
   it("opens the navigation drawer store when the hamburger is tapped", async () => {

--- a/clients/gui-app/src/components/layout/__tests__/mobile-app-header.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/mobile-app-header.test.tsx
@@ -1,0 +1,101 @@
+import "../../../../__tests__/test-browser-apis";
+import {
+  Outlet,
+  RouterProvider,
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+} from "@tanstack/react-router";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MobileAppHeader } from "@/components/layout/header/mobile-app-header";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useMobileHeaderStore } from "@/stores/layout/mobile-header-store";
+import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
+
+function renderAt(path: string) {
+  const rootRoute = createRootRoute({
+    component: () => (
+      <>
+        <MobileAppHeader />
+        <Outlet />
+      </>
+    ),
+  });
+  const nullComponent = () => null;
+  const routeTree = rootRoute.addChildren([
+    createRoute({ getParentRoute: () => rootRoute, path: "/", component: nullComponent }),
+    createRoute({ getParentRoute: () => rootRoute, path: "/epics", component: nullComponent }),
+    createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/epics/$epicId/$tabId",
+      component: nullComponent,
+    }),
+    createRoute({ getParentRoute: () => rootRoute, path: "/settings", component: nullComponent }),
+    createRoute({ getParentRoute: () => rootRoute, path: "/draft/new", component: nullComponent }),
+  ]);
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [path] }),
+  });
+  render(<RouterProvider router={router} />);
+}
+
+describe("MobileAppHeader", () => {
+  beforeEach(() => {
+    useMobileNavStore.setState({ open: false });
+    useMobileHeaderStore.setState({ rightActions: null });
+    useEpicCanvasStore.setState({ tabsById: {} });
+  });
+  afterEach(() => {
+    cleanup();
+    useMobileNavStore.setState({ open: false });
+    useMobileHeaderStore.setState({ rightActions: null });
+    useEpicCanvasStore.setState({ tabsById: {} });
+  });
+
+  it("renders the hamburger and NOT the desktop tab strip", async () => {
+    renderAt("/");
+    expect(await screen.findByTestId("mobile-nav-trigger")).not.toBeNull();
+    expect(screen.queryByTestId("tab-strip")).toBeNull();
+  });
+
+  it("opens the navigation drawer store when the hamburger is tapped", async () => {
+    renderAt("/");
+    fireEvent.click(await screen.findByTestId("mobile-nav-trigger"));
+    expect(useMobileNavStore.getState().open).toBe(true);
+  });
+
+  it("titles the History and Settings surfaces from the route", async () => {
+    renderAt("/epics");
+    expect(
+      (await screen.findByTestId("mobile-header-title")).textContent,
+    ).toBe("History");
+    cleanup();
+    renderAt("/settings");
+    expect(
+      (await screen.findByTestId("mobile-header-title")).textContent,
+    ).toBe("Settings");
+  });
+
+  it("titles the epic surface with the open epic's name", async () => {
+    useEpicCanvasStore.setState({
+      tabsById: { t1: { tabId: "t1", epicId: "e1", name: "Wire up billing" } },
+    });
+    renderAt("/epics/e1/t1");
+    expect(
+      (await screen.findByTestId("mobile-header-title")).textContent,
+    ).toBe("Wire up billing");
+  });
+
+  it("renders route-contributed right actions from the slot store", async () => {
+    useMobileHeaderStore.setState({
+      rightActions: <button type="button">epic action</button>,
+    });
+    renderAt("/epics/e1/t1");
+    expect(
+      await screen.findByRole("button", { name: "epic action" }),
+    ).not.toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/layout/__tests__/mobile-app-header.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/mobile-app-header.test.tsx
@@ -8,11 +8,27 @@ import {
   createRouter,
 } from "@tanstack/react-router";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MobileAppHeader } from "@/components/layout/header/mobile-app-header";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useMobileHeaderStore } from "@/stores/layout/mobile-header-store";
 import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
+
+// The real rate-limit / resource-monitor controls pull host + stream
+// providers; stub them to their accessible trigger so the header renders in
+// this minimal harness while the switch on the resource-monitor toggle stays
+// observable.
+vi.mock("@/components/layout/header/rate-limit-icon", () => ({
+  RateLimitIconButton: () => (
+    <button type="button" aria-label="Usage limits" />
+  ),
+}));
+vi.mock("@/components/resources/resource-monitor-popover", () => ({
+  ResourceMonitorPopover: () => (
+    <button type="button" aria-label="Resource monitor" />
+  ),
+}));
 
 function renderAt(path: string) {
   const rootRoute = createRootRoute({
@@ -47,6 +63,7 @@ describe("MobileAppHeader", () => {
     useMobileNavStore.setState({ open: false });
     useMobileHeaderStore.setState({ rightActions: null });
     useEpicCanvasStore.setState({ tabsById: {} });
+    useSettingsStore.setState({ showGlobalResourceMonitor: false });
   });
   afterEach(() => {
     cleanup();
@@ -88,6 +105,29 @@ describe("MobileAppHeader", () => {
     expect(
       (await screen.findByTestId("mobile-header-title")).textContent,
     ).toBe("Wire up billing");
+  });
+
+  it("always renders the rate-limit control", async () => {
+    renderAt("/");
+    expect(
+      await screen.findByRole("button", { name: "Usage limits" }),
+    ).not.toBeNull();
+  });
+
+  it("shows the resource monitor only when the global toggle is on", async () => {
+    useSettingsStore.setState({ showGlobalResourceMonitor: true });
+    renderAt("/");
+    expect(
+      await screen.findByRole("button", { name: "Resource monitor" }),
+    ).not.toBeNull();
+
+    cleanup();
+    useSettingsStore.setState({ showGlobalResourceMonitor: false });
+    renderAt("/");
+    await screen.findByRole("button", { name: "Open menu" });
+    expect(
+      screen.queryByRole("button", { name: "Resource monitor" }),
+    ).toBeNull();
   });
 
   it("renders route-contributed right actions from the slot store", async () => {

--- a/clients/gui-app/src/components/layout/app-shell.tsx
+++ b/clients/gui-app/src/components/layout/app-shell.tsx
@@ -24,9 +24,9 @@ export function AppShell(props: AppShellProps) {
 
   return (
     <DiffWorkerPoolProvider>
-      <div className="min-h-screen bg-canvas text-canvas-foreground">
+      <div className="min-h-dvh bg-canvas text-canvas-foreground">
         <RootDndProvider>
-          <div className="relative flex h-screen w-full flex-col">
+          <div className="relative flex h-dvh w-full flex-col">
             <AppHeader variant="app" />
             <main className="relative flex min-h-0 flex-1 flex-col">
               {children}

--- a/clients/gui-app/src/components/layout/app-shell.tsx
+++ b/clients/gui-app/src/components/layout/app-shell.tsx
@@ -5,9 +5,11 @@ import { TileFindOwnerBridge } from "@/components/epic-canvas/tile-find/tile-fin
 import { QuitInterceptBridge } from "@/components/layout/bridges/quit-intercept-bridge";
 import { MigrationBlockingModalHost } from "@/components/layout/dialogs/migration-blocking-modal-host";
 import { AppHeader } from "@/components/layout/header/app-header";
+import { MobileNavDrawer } from "@/components/layout/shell/mobile-nav-drawer";
 import { MigrationRunController } from "@/components/migration/migration-run-controller";
 import { OpenFolderDialog } from "@/components/open-folder-dialog";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
 
 interface AppShellProps {
   children: ReactNode;
@@ -21,6 +23,9 @@ interface AppShellProps {
 export function AppShell(props: AppShellProps) {
   const { children } = props;
   const activeHostId = useReactiveActiveHostId();
+  // Phones get the hamburger navigation drawer; it is only mounted below md so
+  // desktop mounts nothing extra and stays unchanged.
+  const isMobile = useIsMobile();
 
   return (
     <DiffWorkerPoolProvider>
@@ -36,6 +41,7 @@ export function AppShell(props: AppShellProps) {
             <QuitInterceptBridge />
             <MigrationRunController />
             <MigrationBlockingModalHost />
+            {isMobile ? <MobileNavDrawer /> : null}
             {/* Test-only probe: binds the active hostId to a hidden DOM
                 attribute so the mobile-cardinality integration tests can
                 assert the runner-host auto-bind machinery without depending

--- a/clients/gui-app/src/components/layout/header/app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/app-header.tsx
@@ -1,5 +1,6 @@
 import { type CSSProperties, type ReactNode } from "react";
 import { UserMenu } from "@/components/auth/user-menu";
+import { MobileAppHeader } from "@/components/layout/header/mobile-app-header";
 import { TabStrip } from "@/components/layout/tabs/tab-strip";
 import { AppUpdateHeaderButton } from "@/components/layout/header/app-update-button";
 import { HistoryButton } from "@/components/layout/header/history-button";
@@ -9,6 +10,7 @@ import { ResourceMonitorPopover } from "@/components/resources/resource-monitor-
 import { SignInButton } from "@/components/layout/header/sign-in-button";
 import { NotificationsBell } from "@/components/notifications/notifications-bell";
 import { cn } from "@/lib/utils";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
 import { useAuthStore } from "@/stores/auth/auth-store";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 import { useTitleBarDraggingSuppressed } from "@/stores/layout/title-bar-drag-store";
@@ -46,11 +48,24 @@ export interface AppHeaderProps {
 }
 
 /**
- * App navigation chrome. Frameless desktop shells use this row as the native
- * title bar: tabs and controls stay interactive, while the empty spacer before
- * the right-side controls remains available for window dragging.
+ * App navigation chrome. On phones this delegates to the hamburger
+ * `MobileAppHeader`; at >=768px it renders the desktop tab-strip header
+ * (`DesktopAppHeader`) exactly as before.
  */
 export function AppHeader(props: AppHeaderProps): ReactNode {
+  const isMobile = useIsMobile();
+  if (props.variant === "app" && isMobile) {
+    return <MobileAppHeader />;
+  }
+  return <DesktopAppHeader variant={props.variant} />;
+}
+
+/**
+ * Desktop navigation chrome. Frameless desktop shells use this row as the
+ * native title bar: tabs and controls stay interactive, while the empty spacer
+ * before the right-side controls remains available for window dragging.
+ */
+function DesktopAppHeader(props: AppHeaderProps): ReactNode {
   const { variant } = props;
   const showTabStrip = variant === "app";
   // Host-loading renders above the router and above the

--- a/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
@@ -2,10 +2,13 @@ import { type ReactNode } from "react";
 import { Menu } from "lucide-react";
 import { useMatch, useRouterState } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
+import { RateLimitIconButton } from "@/components/layout/header/rate-limit-icon";
+import { ResourceMonitorPopover } from "@/components/resources/resource-monitor-popover";
 import "@/components/layout/shell/mobile-shell-touch-targets.css";
 import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
 import { useMobileHeaderStore } from "@/stores/layout/mobile-header-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useSettingsStore } from "@/stores/settings/settings-store";
 import { isHistoryPath } from "@/stores/tabs/kinds/history";
 import { isSettingsPath } from "@/stores/tabs/kinds/settings";
 
@@ -18,6 +21,9 @@ import { isSettingsPath } from "@/stores/tabs/kinds/settings";
 export function MobileAppHeader(): ReactNode {
   const setNavOpen = useMobileNavStore((state) => state.setOpen);
   const rightActions = useMobileHeaderStore((state) => state.rightActions);
+  const showGlobalResourceMonitor = useSettingsStore(
+    (state) => state.showGlobalResourceMonitor,
+  );
   const title = useMobileHeaderTitle();
   return (
     <header
@@ -43,9 +49,18 @@ export function MobileAppHeader(): ReactNode {
       >
         {title}
       </span>
-      {/* Right slot: the active route (e.g. the epic view) contributes its own
-          actions via the mobile-header store. Empty on surfaces that add none. */}
-      <div className="flex shrink-0 items-center gap-1">{rightActions}</div>
+      {/* Right cluster: global status controls sit parallel to the hamburger,
+          mirroring the desktop header's rate-limit + resource-monitor gating
+          (navDisabled never applies here - MobileAppHeader only renders for the
+          "app" variant). They come before the route-provided actions so a
+          route's own controls (e.g. the epic overflow) land outermost. */}
+      <div className="flex shrink-0 items-center gap-1">
+        <RateLimitIconButton />
+        {showGlobalResourceMonitor ? (
+          <ResourceMonitorPopover className={undefined} />
+        ) : null}
+        {rightActions}
+      </div>
     </header>
   );
 }

--- a/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
@@ -1,0 +1,70 @@
+import { type ReactNode } from "react";
+import { Menu } from "lucide-react";
+import { useMatch, useRouterState } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
+import { useMobileHeaderStore } from "@/stores/layout/mobile-header-store";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { isHistoryPath } from "@/stores/tabs/kinds/history";
+import { isSettingsPath } from "@/stores/tabs/kinds/settings";
+
+/**
+ * The phone app header. Replaces the desktop tab strip + control cluster with a
+ * hamburger (opens the navigation drawer), the current surface title, and a
+ * right slot the active route fills with its own actions. Rendered only below
+ * md (see `AppHeader`), so desktop is untouched.
+ */
+export function MobileAppHeader(): ReactNode {
+  const setNavOpen = useMobileNavStore((state) => state.setOpen);
+  const rightActions = useMobileHeaderStore((state) => state.rightActions);
+  const title = useMobileHeaderTitle();
+  return (
+    <header
+      data-testid="app-header"
+      data-variant="app"
+      className="relative z-20 flex h-10 shrink-0 items-center gap-1 bg-canvas px-2 text-canvas-foreground after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border/90 after:content-['']"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="Open menu"
+        data-testid="mobile-nav-trigger"
+        onClick={() => setNavOpen(true)}
+        className="shrink-0 text-muted-foreground hover:text-foreground"
+      >
+        <Menu className="size-4" />
+      </Button>
+      <span
+        className="min-w-0 flex-1 truncate font-medium text-foreground"
+        data-testid="mobile-header-title"
+      >
+        {title}
+      </span>
+      {/* Right slot: the active route (e.g. the epic view) contributes its own
+          actions via the mobile-header store. Empty on surfaces that add none. */}
+      <div className="flex shrink-0 items-center gap-1">{rightActions}</div>
+    </header>
+  );
+}
+
+/**
+ * Derives the header title from the active route: the open epic's name on the
+ * epic route, otherwise a per-surface label.
+ */
+function useMobileHeaderTitle(): string {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const epicTabId = useMatch({
+    from: "/epics/$epicId/$tabId",
+    shouldThrow: false,
+    select: (match) => match.params.tabId,
+  });
+  const epicName = useEpicCanvasStore((state) =>
+    epicTabId === undefined ? null : (state.tabsById[epicTabId]?.name ?? null),
+  );
+  if (epicTabId !== undefined) return epicName ?? "";
+  if (isSettingsPath(pathname)) return "Settings";
+  if (isHistoryPath(pathname)) return "History";
+  if (pathname.startsWith("/draft")) return "New task";
+  return "Traycer";
+}

--- a/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react";
 import { Menu } from "lucide-react";
 import { useMatch, useRouterState } from "@tanstack/react-router";
 import { Button } from "@/components/ui/button";
+import "@/components/layout/shell/mobile-shell-touch-targets.css";
 import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
 import { useMobileHeaderStore } from "@/stores/layout/mobile-header-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
@@ -22,6 +23,7 @@ export function MobileAppHeader(): ReactNode {
     <header
       data-testid="app-header"
       data-variant="app"
+      data-mobile-shell-touch-scope=""
       className="relative z-20 flex h-10 shrink-0 items-center gap-1 bg-canvas px-2 text-canvas-foreground after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border/90 after:content-['']"
     >
       <Button

--- a/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
@@ -62,7 +62,9 @@ function useMobileHeaderTitle(): string {
   const epicName = useEpicCanvasStore((state) =>
     epicTabId === undefined ? null : (state.tabsById[epicTabId]?.name ?? null),
   );
-  if (epicTabId !== undefined) return epicName ?? "";
+  // While the epic tab name is still unresolved, fall through to the app-name
+  // fallback rather than flashing an empty header.
+  if (epicTabId !== undefined && epicName !== null) return epicName;
   if (isSettingsPath(pathname)) return "Settings";
   if (isHistoryPath(pathname)) return "History";
   if (pathname.startsWith("/draft")) return "New task";

--- a/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
+++ b/clients/gui-app/src/components/layout/header/mobile-app-header.tsx
@@ -24,7 +24,7 @@ export function MobileAppHeader(): ReactNode {
       data-testid="app-header"
       data-variant="app"
       data-mobile-shell-touch-scope=""
-      className="relative z-20 flex h-10 shrink-0 items-center gap-1 bg-canvas px-2 text-canvas-foreground after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border/90 after:content-['']"
+      className="relative z-20 flex h-[calc(2.5rem_+_env(safe-area-inset-top))] shrink-0 items-center gap-1 bg-canvas px-2 pt-[env(safe-area-inset-top)] text-canvas-foreground after:absolute after:inset-x-0 after:bottom-0 after:z-1 after:h-px after:bg-border/90 after:content-['']"
     >
       <Button
         type="button"

--- a/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
+++ b/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
@@ -110,7 +110,7 @@ export function MobileNavDrawer(): ReactNode {
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetContent
         side="left"
-        className="gap-0 p-0"
+        className="gap-0 p-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
         data-testid="mobile-nav-drawer"
         data-mobile-shell-touch-scope=""
       >

--- a/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
+++ b/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
@@ -17,6 +17,7 @@ import {
   SheetContent,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { computeInitials } from "@/lib/auth/compute-initials";
 import { resolveManageSubscriptionUrl } from "@/lib/auth/manage-subscription-url";
 import { useAuthService } from "@/lib/host";
@@ -66,10 +67,19 @@ export function MobileNavDrawer(): ReactNode {
   };
   const handleSettings = () => {
     close();
+    // Mirror the desktop user-menu call site's telemetry (user-menu.tsx). Not
+    // lifted into the shared action, which would double-fire for the desktop
+    // callers that already track here.
+    Analytics.getInstance().track(AnalyticsEvent.SettingsOpened, {
+      source: "direct_ui",
+      section: "general",
+    });
     openSettings({ section: null, resetToGeneral: true });
   };
   const handleNotifications = () => {
     close();
+    // Mirror the desktop bell's open telemetry (notifications-bell.tsx).
+    Analytics.getInstance().track(AnalyticsEvent.NotificationCenterOpened, null);
     setNotificationsOpen(true);
   };
   const handleSwitchHost = () => {
@@ -78,12 +88,20 @@ export function MobileNavDrawer(): ReactNode {
   };
   const handleManageSubscription = () => {
     close();
-    void runnerHost.openExternalLink(
-      resolveManageSubscriptionUrl(runnerHost.authnBaseUrl),
-    );
+    void runnerHost
+      .openExternalLink(resolveManageSubscriptionUrl(runnerHost.authnBaseUrl))
+      .then(() => {
+        Analytics.getInstance().track(
+          AnalyticsEvent.SubscriptionManagementOpened,
+          { source: "direct_ui" },
+        );
+      });
   };
   const handleSignOut = () => {
     close();
+    Analytics.getInstance().track(AnalyticsEvent.SignOutRequested, {
+      source: "direct_ui",
+    });
     void auth.signOut();
   };
 

--- a/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
+++ b/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
@@ -17,6 +17,7 @@ import {
   SheetContent,
   SheetTitle,
 } from "@/components/ui/sheet";
+import "@/components/layout/shell/mobile-shell-touch-targets.css";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { computeInitials } from "@/lib/auth/compute-initials";
 import { resolveManageSubscriptionUrl } from "@/lib/auth/manage-subscription-url";
@@ -111,6 +112,7 @@ export function MobileNavDrawer(): ReactNode {
         side="left"
         className="gap-0 p-0"
         data-testid="mobile-nav-drawer"
+        data-mobile-shell-touch-scope=""
       >
         <SheetTitle className="sr-only">Menu</SheetTitle>
         <div className="flex shrink-0 items-center gap-3 border-b border-border/60 p-4 pr-12">

--- a/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
+++ b/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
@@ -8,12 +8,14 @@ import {
   Server,
   Settings,
   SquareArrowOutUpRight,
+  X,
 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -110,12 +112,16 @@ export function MobileNavDrawer(): ReactNode {
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetContent
         side="left"
+        showCloseButton={false}
         className="gap-0 p-0 pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
         data-testid="mobile-nav-drawer"
         data-mobile-shell-touch-scope=""
       >
         <SheetTitle className="sr-only">Menu</SheetTitle>
-        <div className="flex shrink-0 items-center gap-3 border-b border-border/60 p-4 pr-12">
+        {/* In-flow close (not the primitive's absolute one), so the top
+            safe-area padding pushes it below the notch. Mirrors the pattern in
+            notifications-mobile-sheet.tsx. */}
+        <div className="flex shrink-0 items-center gap-3 border-b border-border/60 p-4">
           {profile === null ? null : (
             <>
               <Avatar size="sm">
@@ -126,7 +132,7 @@ export function MobileNavDrawer(): ReactNode {
                   {computeInitials(profile.userName, profile.email)}
                 </AvatarFallback>
               </Avatar>
-              <div className="flex min-w-0 flex-col">
+              <div className="flex min-w-0 flex-1 flex-col">
                 <span className="truncate text-ui-sm font-medium text-foreground">
                   {profile.userName}
                 </span>
@@ -136,6 +142,18 @@ export function MobileNavDrawer(): ReactNode {
               </div>
             </>
           )}
+          <SheetClose asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Close menu"
+              data-testid="mobile-nav-close"
+              className="ml-auto"
+            >
+              <X />
+            </Button>
+          </SheetClose>
         </div>
         <nav className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
           <Button

--- a/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
+++ b/clients/gui-app/src/components/layout/shell/mobile-nav-drawer.tsx
@@ -1,0 +1,206 @@
+import { type ReactNode } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  Bell,
+  History,
+  LogOut,
+  Plus,
+  Server,
+  Settings,
+  SquareArrowOutUpRight,
+} from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { computeInitials } from "@/lib/auth/compute-initials";
+import { resolveManageSubscriptionUrl } from "@/lib/auth/manage-subscription-url";
+import { useAuthService } from "@/lib/host";
+import { useRunnerHost } from "@/providers/use-runner-host";
+import { openNewEpicDraft } from "@/lib/commands/actions/new-epic";
+import { draftTabIntent, navigateToTabIntent } from "@/lib/tab-navigation";
+import { cn } from "@/lib/utils";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import { useMobileNavStore } from "@/stores/layout/mobile-nav-store";
+import { useMergedNotificationUnreadCount } from "@/stores/notifications/merged-notifications";
+import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
+import { useSystemTabModalActions } from "@/stores/tabs/use-system-tab-modal";
+
+const ROW_CLASS = "h-11 w-full justify-start gap-3 px-3";
+
+/**
+ * Left hamburger drawer for the mobile shell. It re-homes the global controls
+ * that the desktop header carries (History, Settings, notifications, identity /
+ * account, host) into a single menu, plus a "New task" entry, since the tab
+ * strip and header right-cluster are hidden on phones. Every action reuses the
+ * same helper the desktop surfaces call. Mounted only on mobile (see AppShell),
+ * so desktop is untouched.
+ */
+export function MobileNavDrawer(): ReactNode {
+  const open = useMobileNavStore((state) => state.open);
+  const setOpen = useMobileNavStore((state) => state.setOpen);
+  const navigate = useNavigate();
+  const profile = useAuthStore((state) => state.profile);
+  const { openHistory, openSettings } = useSystemTabModalActions();
+  const setNotificationsOpen = useNotificationsPopoverStore(
+    (state) => state.setOpen,
+  );
+  const unread = useMergedNotificationUnreadCount();
+  const runnerHost = useRunnerHost();
+  const auth = useAuthService();
+
+  const close = () => {
+    setOpen(false);
+  };
+  const handleNewTask = () => {
+    close();
+    navigateToTabIntent(navigate, draftTabIntent(openNewEpicDraft()));
+  };
+  const handleHistory = () => {
+    close();
+    openHistory();
+  };
+  const handleSettings = () => {
+    close();
+    openSettings({ section: null, resetToGeneral: true });
+  };
+  const handleNotifications = () => {
+    close();
+    setNotificationsOpen(true);
+  };
+  const handleSwitchHost = () => {
+    close();
+    runnerHost.hostPicker.requestOpen();
+  };
+  const handleManageSubscription = () => {
+    close();
+    void runnerHost.openExternalLink(
+      resolveManageSubscriptionUrl(runnerHost.authnBaseUrl),
+    );
+  };
+  const handleSignOut = () => {
+    close();
+    void auth.signOut();
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetContent
+        side="left"
+        className="gap-0 p-0"
+        data-testid="mobile-nav-drawer"
+      >
+        <SheetTitle className="sr-only">Menu</SheetTitle>
+        <div className="flex shrink-0 items-center gap-3 border-b border-border/60 p-4 pr-12">
+          {profile === null ? null : (
+            <>
+              <Avatar size="sm">
+                {profile.avatarUrl !== null ? (
+                  <AvatarImage src={profile.avatarUrl} alt="" />
+                ) : null}
+                <AvatarFallback>
+                  {computeInitials(profile.userName, profile.email)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-ui-sm font-medium text-foreground">
+                  {profile.userName}
+                </span>
+                <span className="truncate text-ui-xs text-muted-foreground">
+                  {profile.email}
+                </span>
+              </div>
+            </>
+          )}
+        </div>
+        <nav className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
+          <Button
+            type="button"
+            variant="ghost"
+            className={ROW_CLASS}
+            data-testid="mobile-nav-new-task"
+            onClick={handleNewTask}
+          >
+            <Plus className="size-4" />
+            <span className="flex-1 text-left">New task</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className={ROW_CLASS}
+            data-testid="mobile-nav-history"
+            onClick={handleHistory}
+          >
+            <History className="size-4" />
+            <span className="flex-1 text-left">History</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className={ROW_CLASS}
+            data-testid="mobile-nav-settings"
+            onClick={handleSettings}
+          >
+            <Settings className="size-4" />
+            <span className="flex-1 text-left">Settings</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className={ROW_CLASS}
+            data-testid="mobile-nav-notifications"
+            onClick={handleNotifications}
+          >
+            <Bell className="size-4" />
+            <span className="flex-1 text-left">Notifications</span>
+            {unread > 0 ? (
+              <Badge
+                variant="destructive"
+                className="h-5 min-w-5 px-1.5 text-overline tabular-nums"
+                data-testid="mobile-nav-notifications-unread"
+              >
+                {unread > 99 ? "99+" : unread}
+              </Badge>
+            ) : null}
+          </Button>
+        </nav>
+        <div className="flex shrink-0 flex-col gap-1 border-t border-border/60 p-2">
+          <Button
+            type="button"
+            variant="ghost"
+            className={ROW_CLASS}
+            data-testid="mobile-nav-switch-host"
+            onClick={handleSwitchHost}
+          >
+            <Server className="size-4" />
+            <span className="flex-1 text-left">Switch host</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className={ROW_CLASS}
+            data-testid="mobile-nav-manage-subscription"
+            onClick={handleManageSubscription}
+          >
+            <SquareArrowOutUpRight className="size-4" />
+            <span className="flex-1 text-left">Manage subscription</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            className={cn(ROW_CLASS, "text-destructive hover:text-destructive")}
+            data-testid="mobile-nav-sign-out"
+            onClick={handleSignOut}
+          >
+            <LogOut className="size-4" />
+            <span className="flex-1 text-left">Sign out</span>
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/clients/gui-app/src/components/layout/shell/mobile-shell-touch-targets.css
+++ b/clients/gui-app/src/components/layout/shell/mobile-shell-touch-targets.css
@@ -1,0 +1,33 @@
+/*
+ * Mobile-shell-scoped touch-target enlargement, mirroring the settings/home
+ * pattern (settings-touch-targets.css / home-touch-targets.css).
+ *
+ * The phone shell's icon-size controls - the header hamburger and the
+ * drawer / notifications-sheet close buttons (Button icon-sm ~28px) - sit
+ * below the 44px touch-target guideline. These rules extend each control's
+ * *hit area* to >=44px via an invisible pseudo-element; visual size and layout
+ * are unchanged on every device, and the scope attribute (set on the mobile
+ * header, the nav drawer, and the notifications sheet) keeps the rest of the
+ * app untouched. The mobile shell only renders below md, so desktop never
+ * carries the scope.
+ *
+ * Vertical-only slop, matching precedent: flush horizontal neighbours would
+ * otherwise capture each other's taps. `.absolute` controls (the drawer's
+ * built-in close) skip the position:relative fallback - this file is unlayered
+ * CSS and would otherwise beat Tailwind's layered `absolute` utility and yank
+ * them into flow; an absolutely positioned control anchors its ::after itself.
+ */
+@media (pointer: coarse) {
+  [data-mobile-shell-touch-scope] [data-slot="button"]:not(.absolute) {
+    position: relative;
+  }
+
+  [data-mobile-shell-touch-scope] [data-slot="button"]::after {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    top: 50%;
+    height: max(100%, 44px);
+    transform: translateY(-50%);
+  }
+}

--- a/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notifications-popover.test.tsx
@@ -92,7 +92,12 @@ function buildRouterWithCapture(target: TargetCapture, onNavigate: () => void) {
   const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/",
-    component: () => <NotificationsPopover onNavigate={onNavigate} />,
+    component: () => (
+      <NotificationsPopover
+        onNavigate={onNavigate}
+        frameClassName="h-[min(70vh,32rem)] w-[min(90vw,24rem)]"
+      />
+    ),
   });
   const epicRoute = createRoute({
     getParentRoute: () => rootRoute,

--- a/clients/gui-app/src/components/notifications/notifications-bell.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-bell.tsx
@@ -80,7 +80,10 @@ export function NotificationsBell() {
         className="w-auto overflow-hidden p-0"
         onOpenAutoFocus={(event: Event) => event.preventDefault()}
       >
-        <NotificationsPopover onNavigate={handleNavigate} />
+        <NotificationsPopover
+          onNavigate={handleNavigate}
+          frameClassName="h-[min(var(--radix-popover-content-available-height,70vh),32rem)] w-[min(90vw,24rem)]"
+        />
       </PopoverContent>
     </Popover>
   );

--- a/clients/gui-app/src/components/notifications/notifications-mobile-sheet.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-mobile-sheet.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { NotificationsPopover } from "@/components/notifications/notifications-popover";
 import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
 import { useIsMobile } from "@/hooks/ui/use-mobile";
+import "@/components/layout/shell/mobile-shell-touch-targets.css";
 
 /**
  * Full-screen notifications surface for phones. Reuses the exact
@@ -32,6 +33,7 @@ export function NotificationsMobileSheet(): ReactNode {
         <DialogPrimitive.Content
           data-slot="dialog-content"
           data-testid="notifications-mobile-sheet"
+          data-mobile-shell-touch-scope=""
           aria-describedby={undefined}
           className="fixed inset-0 z-50 flex flex-col bg-background text-foreground outline-none data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
         >

--- a/clients/gui-app/src/components/notifications/notifications-mobile-sheet.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-mobile-sheet.tsx
@@ -35,7 +35,7 @@ export function NotificationsMobileSheet(): ReactNode {
           data-testid="notifications-mobile-sheet"
           data-mobile-shell-touch-scope=""
           aria-describedby={undefined}
-          className="fixed inset-0 z-50 flex flex-col bg-background text-foreground outline-none data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
+          className="fixed inset-0 z-50 flex flex-col bg-background pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] text-foreground outline-none data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
         >
           {/* Close lives on the left so it never collides with the popover
               header's own top-right actions (mark all / clear / settings). The

--- a/clients/gui-app/src/components/notifications/notifications-mobile-sheet.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-mobile-sheet.tsx
@@ -1,0 +1,68 @@
+import { type ReactNode } from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { NotificationsPopover } from "@/components/notifications/notifications-popover";
+import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
+
+/**
+ * Full-screen notifications surface for phones. Reuses the exact
+ * `NotificationsPopover` list + actions, presented full-bleed (mirroring how
+ * History/Settings present full-screen below md) instead of the desktop bell
+ * popover. Opened from the mobile hamburger drawer's Notifications row and
+ * shares the popover's open state, so there is a single source of truth.
+ *
+ * Renders nothing on desktop, where the header bell + anchored popover stay
+ * exactly as before - the mobile shell simply drops the bell and reaches this
+ * surface through the drawer instead.
+ */
+export function NotificationsMobileSheet(): ReactNode {
+  const isMobile = useIsMobile();
+  const open = useNotificationsPopoverStore((state) => state.open);
+  const setOpen = useNotificationsPopoverStore((state) => state.setOpen);
+  if (!isMobile) return null;
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          data-slot="dialog-overlay"
+          className="fixed inset-0 z-50 bg-black/30 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
+        />
+        <DialogPrimitive.Content
+          data-slot="dialog-content"
+          data-testid="notifications-mobile-sheet"
+          aria-describedby={undefined}
+          className="fixed inset-0 z-50 flex flex-col bg-background text-foreground outline-none data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
+        >
+          {/* Close lives on the left so it never collides with the popover
+              header's own top-right actions (mark all / clear / settings). The
+              visible "Notifications" heading comes from the reused popover, so
+              the dialog title here is screen-reader only to avoid duplication. */}
+          <header className="flex shrink-0 items-center gap-2 border-b border-border/60 bg-secondary px-2 py-2">
+            <DialogPrimitive.Close asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Close notifications"
+                data-testid="notifications-mobile-close"
+              >
+                <X />
+              </Button>
+            </DialogPrimitive.Close>
+            <DialogPrimitive.Title className="sr-only">
+              Notifications
+            </DialogPrimitive.Title>
+          </header>
+          <div className="flex min-h-0 flex-1 overflow-hidden">
+            <NotificationsPopover
+              onNavigate={() => setOpen(false)}
+              frameClassName="h-full w-full"
+            />
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/clients/gui-app/src/components/notifications/notifications-popover.tsx
+++ b/clients/gui-app/src/components/notifications/notifications-popover.tsx
@@ -42,6 +42,11 @@ import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface NotificationsPopoverProps {
   readonly onNavigate: () => void;
+  /**
+   * Sizing for the surface root. The desktop bell passes its fixed popover
+   * box; the mobile full-screen host passes `h-full w-full` to fill the sheet.
+   */
+  readonly frameClassName: string;
 }
 
 type NotificationsTab = "unread" | "all";
@@ -118,7 +123,10 @@ export function NotificationsPopover(props: NotificationsPopoverProps) {
       <Tabs
         value={activeTab}
         onValueChange={handleTabChange}
-        className="flex h-[min(var(--radix-popover-content-available-height,70vh),32rem)] w-[min(90vw,24rem)] min-w-0 flex-col gap-0 overflow-hidden"
+        className={cn(
+          "flex min-w-0 flex-col gap-0 overflow-hidden",
+          props.frameClassName,
+        )}
         data-testid="notifications-popover"
       >
         <header className="flex shrink-0 flex-col gap-3 border-b border-border/60 bg-popover px-4 pt-3 pb-2">

--- a/clients/gui-app/src/routes/epics-layout-route-components.tsx
+++ b/clients/gui-app/src/routes/epics-layout-route-components.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useMatch } from "@tanstack/react-router";
 import { EpicSidebarColumn } from "@/components/epic-canvas/sidebar/epic-sidebar-column";
 import { EpicTabHost } from "@/components/epic-tabs/epic-tab-host";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
 
 /**
  * Layout for `/epics` and `/epics/$epicId/$tabId`. Hosts the single hoisted
@@ -23,6 +24,11 @@ import { EpicTabHost } from "@/components/epic-tabs/epic-tab-host";
  *   suppressed), so the sidebar hides with it.
  */
 export function EpicsLayoutRoute() {
+  // Phones present one full-screen surface at a time: the desktop epic
+  // sidebar (artifact/chat/terminal tree + resize rail) is dropped below md so
+  // the pane container spans the full width. Its navigation re-homes into the
+  // mobile tile switcher (separate work). Desktop (>=768px) is unaffected.
+  const isMobile = useIsMobile();
   const activeRoute = useMatch({
     from: "/epics/$epicId/$tabId",
     shouldThrow: false,
@@ -40,7 +46,7 @@ export function EpicsLayoutRoute() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-row">
-      {sidebarRoute === null ? null : (
+      {sidebarRoute === null || isMobile ? null : (
         <EpicSidebarColumn
           epicId={sidebarRoute.epicId}
           tabId={sidebarRoute.tabId}

--- a/clients/gui-app/src/routes/root-route-components.tsx
+++ b/clients/gui-app/src/routes/root-route-components.tsx
@@ -8,6 +8,7 @@ import { PreventSleepController } from "@/components/layout/bridges/prevent-slee
 import { NotificationEmissionController } from "@/components/layout/bridges/notification-emission-controller";
 import { NotificationFocusBridge } from "@/components/layout/bridges/notification-focus-bridge";
 import { SystemTabModalHost } from "@/components/layout/dialogs/system-tab-modal-host";
+import { NotificationsMobileSheet } from "@/components/notifications/notifications-mobile-sheet";
 import { TrayOpenEpicBridge } from "@/components/layout/bridges/tray-open-epic-bridge";
 import { ProviderProfileAddFlowHost } from "@/components/providers/provider-profile-add-flow-host";
 import { EpicAccessCoordinator } from "@/providers/epic-access-coordinator";
@@ -59,7 +60,14 @@ export function RootComponent() {
           showOnboarding={showOnboarding}
           isStandalone={isStandalone}
         />
-        {isStandalone ? null : <SystemTabModalHost />}
+        {isStandalone ? null : (
+          <>
+            <SystemTabModalHost />
+            {/* Mobile-only full-screen notifications surface (renders null on
+                desktop, where the header bell + popover are used instead). */}
+            <NotificationsMobileSheet />
+          </>
+        )}
       </HostReadyGate>
     </>
   );

--- a/clients/gui-app/src/stores/layout/mobile-header-store.ts
+++ b/clients/gui-app/src/stores/layout/mobile-header-store.ts
@@ -1,0 +1,21 @@
+import { type ReactNode } from "react";
+import { create } from "zustand";
+
+/**
+ * Slot for route-contributed actions on the right of the mobile header. The
+ * active surface (e.g. the epic view) sets its own controls here from where it
+ * has the session context; the header renders whatever is present. Phase 0
+ * leaves this empty - the epic overflow/actions fill lands with the single-tile
+ * epic view. Desktop never renders the mobile header, so this is unused there.
+ */
+interface MobileHeaderState {
+  readonly rightActions: ReactNode | null;
+  readonly setRightActions: (node: ReactNode | null) => void;
+}
+
+export const useMobileHeaderStore = create<MobileHeaderState>((set) => ({
+  rightActions: null,
+  setRightActions: (node) => {
+    set({ rightActions: node });
+  },
+}));

--- a/clients/gui-app/src/stores/layout/mobile-nav-store.ts
+++ b/clients/gui-app/src/stores/layout/mobile-nav-store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+/**
+ * Open state for the mobile hamburger navigation drawer. Kept in a tiny
+ * external store so the header's hamburger trigger and the drawer surface can
+ * live in different parts of the tree without prop drilling. Desktop never
+ * mounts either, so this stays untouched there.
+ */
+interface MobileNavState {
+  readonly open: boolean;
+  readonly setOpen: (next: boolean) => void;
+}
+
+export const useMobileNavStore = create<MobileNavState>((set) => ({
+  open: false,
+  setOpen: (next) => {
+    set({ open: next });
+  },
+}));

--- a/clients/gui-app/src/stores/tabs/__tests__/use-system-tab-modal.test.tsx
+++ b/clients/gui-app/src/stores/tabs/__tests__/use-system-tab-modal.test.tsx
@@ -378,3 +378,83 @@ describe("canPopOverlayEntry", () => {
     expect(canPopOverlayEntry(history)).toBe(false);
   });
 });
+
+describe("openHistory viewport gate", () => {
+  const originalInnerWidth = window.innerWidth;
+
+  function setInnerWidth(value: number) {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value,
+    });
+  }
+
+  function buildHistoryRouter() {
+    const rootRoute = createRootRoute({
+      validateSearch: (raw) => systemTabOverlaySearchSchema.parse(raw),
+      component: () => (
+        <>
+          <ModalProbe />
+          <Outlet />
+        </>
+      ),
+    });
+    const indexRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/",
+      component: () => <div data-testid="home" />,
+    });
+    const epicsRoute = createRoute({
+      getParentRoute: () => rootRoute,
+      path: "/epics",
+      component: () => <div data-testid="epics-page" />,
+    });
+    return createRouter({
+      routeTree: rootRoute.addChildren([indexRoute, epicsRoute]),
+      history: createMemoryHistory({ initialEntries: ["/"] }),
+    });
+  }
+
+  beforeEach(() => {
+    modalProbe.current = null;
+    useTabsStore.setState({ systemTabs: { history: null, settings: null } });
+  });
+  afterEach(() => {
+    cleanup();
+    setInnerWidth(originalInnerWidth);
+    useTabsStore.setState({ systemTabs: { history: null, settings: null } });
+  });
+
+  it("routes to the /epics full page on phones", async () => {
+    setInnerWidth(375);
+    const router = buildHistoryRouter();
+    render(<RouterProvider router={router} />);
+    await waitFor(() => expect(modalProbe.current).not.toBeNull());
+
+    act(() => {
+      modalProbe.current?.openHistory();
+    });
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/epics");
+    });
+  });
+
+  it("opens the modal overlay on desktop", async () => {
+    setInnerWidth(1024);
+    const router = buildHistoryRouter();
+    render(<RouterProvider router={router} />);
+    await waitFor(() => expect(modalProbe.current).not.toBeNull());
+
+    act(() => {
+      modalProbe.current?.openHistory();
+    });
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({
+        historyOverlay: true,
+      });
+    });
+    expect(router.state.location.pathname).toBe("/");
+  });
+});

--- a/clients/gui-app/src/stores/tabs/use-system-tab-modal.ts
+++ b/clients/gui-app/src/stores/tabs/use-system-tab-modal.ts
@@ -115,6 +115,15 @@ export function useSystemTabModalActions(): SystemTabModalActions {
   );
 
   const openHistory = useCallback(() => {
+    // On phones History is only the full-page `/epics` route, never the modal
+    // or a strip tab. Every entry point (header/hamburger, palette, keybindings
+    // via the bridge) funnels through here, so this one gate routes them all to
+    // the routed surface. No `search` reducer: leaving the current route drops
+    // the overlay params on its own, mirroring the mobile `openSettings` gate.
+    if (isMobileViewport()) {
+      void router.navigate({ to: "/epics" });
+      return;
+    }
     const historyTab = useTabsStore.getState().systemTabs.history;
     if (historyTab !== null) {
       navigateToTabClearingOverlay(ensureHistoryTab());


### PR DESCRIPTION
## Phase 0 of the mobile no-tabs redesign — shell & navigation

First of three stacked phases. Below 768px the GUI gets a phone shell; **desktop ≥768px is unchanged** (every change is gated behind \`useIsMobile()\`/\`max-md:\` or is a desktop-neutral export/prop edit).

### What this adds (mobile only)
- **Mobile app header** — replaces the desktop tab strip with a hamburger + surface title + a right cluster (rate-limit status, resource monitor, a route-fillable actions slot). Desktop header body moved verbatim into \`DesktopAppHeader\`; \`AppHeader\` is now a thin `useIsMobile()` switch.
- **Hamburger navigation drawer** (left sheet) — New task, History, Settings, Notifications, Switch host, Manage subscription, Sign out; each row reuses the existing desktop action.
- **Full-screen Notifications** surface on phones (reuses the desktop popover body).
- **History → \`/epics\` full page** on phones (mirrors the existing mobile Settings redirect).
- Shell height uses \`dvh\` (no mobile-browser bottom cutoff); iOS safe-area insets; coarse-pointer 44px touch targets.

### Desktop neutrality
Only three desktop-rendered files are touched, all provably neutral: \`app-header.tsx\` (verbatim extraction + a mobile branch), \`notifications-popover.tsx\`/\`-bell.tsx\` (sizing became a prop; the bell passes the identical prior value), \`use-system-tab-modal.ts\` (a mobile-only early return in \`openHistory\`). Everything else is new \`mobile/*\` code that only mounts under \`useIsMobile()\`.

### Verification
- \`compile\`: only the pre-existing prosemirror-model dup-version errors (unrelated).
- \`lint\` clean, \`react-doctor\` clean, mobile + affected desktop suites green.
- Independently cold-reviewed (fresh agent): SHIP.
- **Not yet device-verified** — desktop-window-resize verified; on-device iOS pass pending.

Base is \`mobile-app\` (not \`main\`), consistent with PR #570. Phases 1 (full-screen chat) and 2 (bottom-sheet switcher) follow as stacked PRs after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)