### PR TITLE
docs: slim AGENTS.md files to agent-actionable essentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ bun run build
 bun run compile                 # never tsc directly
 bun run test && bun run lint && bun run format
 bunx nx run @traycer-clients/traycer-cli:build   # single package
-pre-commit run --all-files
+pre-commit run --all-files      # explicit full-repo / CI-style validation
 
 make dev-desktop                # signed host from Releases + HMR desktop
 make dev-desktop VERSION=1.2.3  # pin host release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,154 +1,76 @@
-- ALWAYS USE PARALLEL TOOLS WHEN APPLICABLE.
-- The default branch in this repo is `main`.
+# AGENTS.md
 
-## Project Overview
+Default branch: `main`. Bun 1.3.12 workspaces + Nx.
 
-Traycer is an AI-powered pair-programming platform. This repository holds the
-**open-source clients, CLI, and protocol** — the parts that run on a developer's
-machine and talk to the Traycer host. It uses **Bun workspaces** and **Nx** for
-task orchestration.
+Open-source **clients, CLI, and protocol**. The Traycer Host and cloud backends
+are **not** here — the CLI provisions a signed host from GitHub Releases; see
+[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
 
-The Traycer Host and cloud backend are **not** part of this repo: the CLI
-provisions a signed **host** binary from GitHub Releases, and the clients run
-against the production cloud. See [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
+## Nested docs (read when editing there)
 
-### Workspaces
+- [`clients/gui-app/AGENTS.md`](clients/gui-app/AGENTS.md)
+- [`clients/desktop/AGENTS.md`](clients/desktop/AGENTS.md)
 
-| Path | Package | Responsibility |
+## Map
+
+| Path | Package | Role |
 |---|---|---|
-| `protocol/` | `@traycer/protocol` | Versioned, runtime-negotiated client⇄host wire contract (schemas, RPC). |
-| `clients/traycer-cli/` | `@traycer-clients/traycer-cli` | The `traycer` CLI — provisions/upgrades the host, auth, agent & workspace commands. |
-| `clients/shared/` | `@traycer-clients/shared` | Transport (WebSocket/RPC), auth (PKCE/bearer), and formatting shared across clients. |
-| `clients/gui-app/` | `@traycer-clients/gui-app` | GUI renderer (React + Vite + TanStack Router/Query + Zustand + shadcn/ui). |
-| `clients/desktop/` | `@traycer-clients/desktop` | Electron shell around `gui-app`. |
+| `protocol/` | `@traycer/protocol` | Client⇄host wire contract |
+| `clients/traycer-cli/` | `@traycer-clients/traycer-cli` | CLI (host install, auth, agents) |
+| `clients/shared/` | `@traycer-clients/shared` | Transport / auth / formatting |
+| `clients/gui-app/` | `@traycer-clients/gui-app` | GUI renderer |
+| `clients/desktop/` | `@traycer-clients/desktop` | Electron shell |
 
-### Workspace-Specific Agent Docs
-
-- `clients/gui-app/` — read [`clients/gui-app/AGENTS.md`](clients/gui-app/AGENTS.md)
-  before app-specific changes; it lists the GUI-focused skills in
-  `.agents/skills/` to prefer there.
-- `clients/desktop/` — read [`clients/desktop/AGENTS.md`](clients/desktop/AGENTS.md).
-
-## Common Commands
+## Commands
 
 ```bash
 bun install
-bun run build      # build the publishable packages (Nx)
-bun run compile    # type-check every package
-bun run test       # Vitest
-bun run lint       # ESLint
-bun run format     # Prettier
+bun run build
+bun run compile                 # never tsc directly
+bun run test && bun run lint && bun run format
+bunx nx run @traycer-clients/traycer-cli:build   # single package
+pre-commit run --all-files
 
-pre-commit run --all-files   # hygiene + workspace checks
+make dev-desktop                # signed host from Releases + HMR desktop
+make dev-desktop VERSION=1.2.3  # pin host release
 ```
 
-Nx caches and only rebuilds what changed. Target a single package with e.g.
-`bunx nx run @traycer-clients/traycer-cli:build`.
+`make dev-desktop` talks to the **production** cloud — no local backends. Details:
+[`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
 
-### Running the desktop locally
+**Commits:** do **not** manually run `compile` / `build` / `lint` / `format`
+before committing. `pre-commit` already runs the affected workspace checks
+(build, compile, lint, format). Tests run in CI (`test.yml`), not in the hook —
+only re-run checks yourself when diagnosing a hook or CI failure. Commits need
+DCO (`git commit -s`).
 
-```bash
-make dev-desktop                 # download the latest released host + run the HMR desktop shell
-make dev-desktop VERSION=1.2.3   # pin a specific host release
+## Non-negotiable
+
+**Protocol** — `@traycer/protocol` uses per-method `{ major, minor }` RPC versions
+negotiated at handshake (not npm semver). CLI **inlines** protocol at build time.
+See `protocol/README.md`.
+
+**Host identity** (GUI):
+
+1. `hostId` is canonical; "device" is UI copy — no parallel `deviceId` field.
+2. Tabs bind a `hostId` for life (`<TabHostProvider>` → `useTabHostId()`). Never
+   use `useReactiveActiveHostId()` inside a tab. Cross-host = **clone-not-migrate**.
+   Reachability checked at tab-open only.
+
+**Shared code** — transport/auth in `clients/shared/`; wire contract in
+`protocol/`. Don't duplicate.
+
+## Type safety (ESLint — do not bypass)
+
+```ts
+// BAD                         // GOOD
+fn(x?: T)                      fn(x: T | undefined)
+fn(x = 1)                      fn(x: number)  // caller passes explicitly
+...args: [T?] | []             // no rest-tuple optionals
+as any / as unknown / chained  // narrow or define a real type
+ReturnType<typeof fn>          // name the concrete type
 ```
 
-This downloads the signed host from GitHub Releases, verifies it against the
-trust key committed in `clients/traycer-cli/src/config.ts`, and runs the Electron
-dev shell against the production cloud — no secrets or local backend services.
-macOS / Linux. See [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md).
+## Skills
 
-## Architecture
-
-### Protocol
-
-`@traycer/protocol` is the **versioned, runtime-negotiated** client⇄host wire
-contract — per-method `{ major, minor }` compatibility negotiated at the
-handshake, not npm semver. Clients and the host can ship independently as long as
-their versions stay compatible. The CLI **inlines** the protocol at build time,
-so the published CLI has no runtime protocol dependency.
-
-### Host identity model
-
-Two domain rules govern how the renderer addresses hosts:
-
-1. **`hostId` ≡ `deviceId`.** The same identifier names a physical machine and the
-   host process running on it. `hostId` is canonical in code and schemas;
-   "device" is UI-only copy. Don't introduce a parallel `deviceId` field that
-   maps 1:1 to an existing `hostId`.
-
-2. **Tabs are bound to a host for life.** Every chat tab and every terminal tab
-   carries a `hostId` persisted in its artifact schema. The React tree projects
-   this with `<TabHostProvider hostId>`; consumers read `useTabHostId()` from
-   context, never `useReactiveActiveHostId()`. Cross-host continuation is
-   **clone-not-migrate**:
-   - **Chat**: continuing on a different host clones the artifact (new id, copied
-     history).
-   - **Terminal**: bound for life — a PTY can't migrate. If the host is
-     unreachable, the tab is permanently dead until that host returns.
-
-   Reachability is checked **at tab-open time only**, not reactively. There is no
-   "swap host" affordance.
-
-The renderer addresses **two host scopes** simultaneously:
-
-- **Default host**: machine-local host for app-wide features (Epic list, opening
-  artifacts, notifications, host-status footer). Accessed via
-  `useReactiveActiveHostId()` / `useHostClient()`.
-- **Tab-scoped host**: per-tab binding from the artifact schema. Accessed via
-  `useTabHostId()` from `<TabHostProvider>`.
-
-When adding a query/mutation hook, decide explicitly which scope it serves. Don't
-write a hook that silently switches scopes based on render context.
-
-## Skills Usage
-
-When working in a workspace, search its `.agents/` or `.claude/` folder for
-relevant skills and use them for the task at hand. The GUI workspace
-(`clients/gui-app/`) ships local skills (shadcn, Tailwind v4, TanStack
-Router/Query, Zustand) — see its `AGENTS.md`.
-
-## Style Guide
-
-- Keep things in one function unless composable or reusable.
-- Avoid `try`/`catch` except at boundaries where you can handle or add context.
-- Avoid the `any` type.
-- Rely on type inference; avoid explicit annotations/interfaces unless needed for
-  exports or clarity.
-- Prefer functional array methods (`flatMap`, `filter`, `map`) over for-loops; use
-  type guards on `filter` to keep type inference downstream.
-
-## Code Guidelines
-
-- **Naming**: files `kebab-case`, classes/types `PascalCase`, functions
-  `camelCase`, constants `UPPER_SNAKE_CASE`.
-- **Strict typing**: avoid `any` and unsafe assertions. Do not use `as any`,
-  `as unknown`, or chained assertions like `as unknown as`.
-- **Function signatures**: do not use optional parameters (`?:`). Use explicit
-  unions such as `value: T | undefined` or `value: T | null`.
-- **Required arguments**: do not use default parameter values; every argument is
-  passed explicitly by the caller.
-- **No pseudo-optionals**: do not use rest-parameter tuple/union shims such as
-  `...args: [value: T | undefined]`.
-- **Explicit types**: do not use utility aliases like `ReturnType<...>` to infer
-  another function's return type; define the concrete type directly.
-- **Lint policy**: these type-safety rules apply to production code and tests. Do
-  not bypass them with `eslint-disable` / `eslint-ignore` or equivalent
-  suppressions.
-- **Shared code**: put transport/auth/formatting shared across clients in
-  `clients/shared/`, and the client⇄host wire contract in `protocol/`. Don't
-  duplicate.
-- **Error handling**: catch only at boundaries where you can handle or add
-  context.
-- **Logging**: log at task/transport boundaries. Never log secrets or user code.
-  Don't "log + rethrow" deep in the stack.
-- **Sizing (UI)**: no fixed pixel/rem widths or heights for layout surfaces. Use
-  fluid constraints — `w-full`, `max-w-*`, `min-h-*`, `max-h-*`, `%`,
-  `vw`/`vh`/`dvh`, `clamp()`, `min()`, `max()`, flex/grid sizing. For
-  popovers/dialogs/sheets cap with viewport-aware values like `w-[min(90vw,Nrem)]`,
-  `max-h-[min(70vh,Nrem)]`. Hardcoded sizes only for inherently fixed elements:
-  icons, hairlines, badges, touch targets.
-
-## Type Checking
-
-- Always run `bun run compile` for the workspaces containing your changes, never
-  `tsc` directly.
+Use when the task matches. GUI skills: see `clients/gui-app/AGENTS.md`.

--- a/clients/desktop/AGENTS.md
+++ b/clients/desktop/AGENTS.md
@@ -1,185 +1,70 @@
-# AGENTS.md - clients/desktop
+# AGENTS.md — clients/desktop
 
-This workspace contains the Electron desktop shell that hosts the `gui-app`
-renderer.
+Electron shell around `@traycer-clients/gui-app`. Read with repo-root
+`AGENTS.md`.
 
-## Purpose
+## Role
 
-`desktop` hosts the production Electron app that:
+1. Load the `gui-app` renderer.
+2. Delegate host lifecycle to the **Traycer CLI** — Desktop never spawns the
+   host. Discover WS URL from `~/.traycer/host[/dev]/pid.json`; tail
+   `~/.traycer/host[/dev]/host.log`.
+3. Expose `IRunnerHost` via `contextBridge` / `ipcMain.handle`.
 
-1. Loads the `gui-app` renderer.
-2. Delegates host lifecycle (install / start / stop / restart / doctor) to the
-   bundled Traycer CLI - Desktop never spawns the host directly. It reads
-   `~/.traycer/host[/dev]/pid.json` to discover the host's websocket URL,
-   and tails `~/.traycer/host[/dev]/host.log` for startup diagnostics.
-3. Exposes the `IRunnerHost` surface from
-   `@traycer-clients/shared/platform/runner-host` through a `contextBridge` /
-   `ipcMain.handle` bridge.
-
-The shell is transport-agnostic: it never proxies host RPC traffic. `gui-app`
-talks directly to the host's localhost HTTP/WebSocket URLs once they are
-discovered from `LocalHostSnapshot`.
-
-## Layout
-
-- `src/electron-main/` - Electron main process. Entrypoint: `main-process.ts`.
-  Feature subfolders: `app/` (logger/updater/about/support cross-cutting
-  services), `auth/` (deep-link, sessions, secure storage), `host/`
-  (local-host lifecycle/paths/log piper), `windows/` (window factory +
-  registry + per-window state), `menu/`, `tray/`, and `ipc/` (per-feature IPC
-  handlers split out of the former `runner-ipc.ts` monolith - see
-  `ipc/register-runner-ipc.ts` for the composer entry).
-- `src/electron-preload/` - Context-isolated preload exposing
-  `window.runnerHost`. Entrypoint: `preload-bridge.ts`. Per-feature bridges live
-  in sibling `*-bridge.ts` files (auth, host, tray, windows, ownership,
-  per-window-state, menu, support, lifecycle); the entry composes them after
-  their module-load `ipcRenderer.on` subscriptions register.
-- `src/renderer-shell/` - Thin React shell (`main.tsx`, `index.html`,
-  `desktop-runner-host.ts`). The actual UI is `@traycer-clients/gui-app`,
-  consumed as a workspace library via vite aliases.
-- `src/ipc-contracts/` - Plain-data types shared by all three Electron processes
-  (channel names, window/host/auth-session types, lifecycle types). Keep these
-  in sync with the canonical shared module.
-- `scripts/` - Build helpers, grouped by purpose: `dev/` (dev-main,
-  write-main-entry), `prepack/` (bundled CLI + tray asset prechecks, macOS
-  bundled-CLI signing verification), `assets/` (tray-icon generator).
-- `resources/host/` - Empty placeholder kept solely because `package.json`'s
-  `build.extraResources` still references the path. Desktop **never** bundles a
-  host binary, host runtime, or developer Node binary; host lifecycle is fully
-  owned by the Traycer CLI subprocess, and the host itself is provisioned as a
-  signed release binary - it is not shipped inside Desktop. The one exception
-  is macOS **production** packaging: `scripts/prepack/inject-host-launch-agent.cjs`
-  (electron-builder `afterPack`; no `afterSign` - electron-builder's own
-  signing pass already deep-signs the injected helper) stages a helper `.app`
-  wrapping the bundled CLI plus an SMAppService LaunchAgent plist (`BundleProgram`, relative
-  path, `NumberOfFiles = 8192`) into the bundle so Login Items attribution and
-  the host's descriptor limit work out of the box; unstamped/dev builds no-op.
-  The `extraResources` filter is restricted to `README.md` + `.gitkeep`. No live
-  `src/` code reads from this directory, and the removed symbols
-  `resolveHostBinaryPath` / `TRAYCER_HOST_BINARY` no longer exist anywhere in
-  this workspace.
-- `resources/cli/` - Bundled Traycer CLI staging directory. The CLI ships as a
-  single-file Node SEA per `<platform>-<arch>`. CI release workflows stage the
-  CLI binary into `resources/cli/<platform>-<arch>/traycer[.exe]`;
-  `electron-builder`'s `extraResources` (`resources/cli` → `cli`) maps that into
-  `process.resourcesPath/cli/`. First-launch Setup self-heals the bundled CLI
-  into the per-user stable path `~/.traycer/cli/bin/traycer`.
-- `resources/tray/` - Tray icon PNGs (`trayTemplate.png` + `@2x` for the macOS
-  template image; `tray.png` + `@2x` for Windows / Linux). Committed to source
-  control and regenerated via `scripts/assets/generate-tray-icons.cjs`. Mapped
-  into `process.resourcesPath/tray/` by `extraResources` for packaged builds;
-  resolved repo-relative in `bun run dev` via the helper in
-  `src/electron-main/tray/tray.ts` (`resolveTrayIconPath`). The build precheck
-  `scripts/prepack/check-tray-assets.cjs` (`prepack:check-tray`) fails fast if
-  any required variant is missing or corrupted, preventing an invisible-tray
-  regression from shipping.
+Transport-agnostic: do **not** proxy host RPC. `gui-app` talks to the host's
+localhost HTTP/WS after `LocalHostSnapshot`.
 
 ## Commands
 
 ```bash
-bun run dev          # Launch gui-app dev server + Electron against it (this workspace only)
-bun run build        # Build TS main + renderer + staged assets (no packaging)
-bun run package      # Produce a packaged Electron binary via electron-builder
-bun run package:dir  # Unpacked package (faster smoke-test)
-bun run compile      # Type-check only (no emit)
+# from clients/desktop/
+bun run dev           # shell + renderer only
+bun run compile       # type-check (no emit)
+bun run build         # main + renderer (no package)
+bun run package       # electron-builder
+bun run package:dir   # unpacked smoke build
+bun run test
+
+# end-to-end (repo root, macOS/Linux) — production cloud + released host
+make dev-desktop
+make dev-desktop VERSION=1.2.3
 ```
 
-### Dev loop: `make dev-desktop` (macOS / Linux)
+Details: [`docs/DEVELOPMENT.md`](../../docs/DEVELOPMENT.md).
 
-For end-to-end work, the root `make dev-desktop` provisions a host and runs the
-HMR Electron shell against the **production** cloud (this workspace's
-`bun run dev` launches only the shell + renderer):
+**Commits:** don't manually run `compile` / `build` / `lint` / `format` before
+committing — repo-root `pre-commit` already runs the affected checks (see root
+`AGENTS.md`). Tests are CI, not the hook. Re-run checks only when diagnosing
+failures.
 
-```bash
-make dev-desktop                 # download + run against the LATEST released host
-make dev-desktop VERSION=1.2.3   # pin a specific host release
-```
+## Layout
 
-This invokes `scripts/dev-desktop.js` at the repo root. The orchestrator stages a
-dev CLI wrapper at `~/.traycer/cli/dev/bin/traycer` that exec's
-`bun <repo>/clients/traycer-cli/src/index.ts "$@"`, then hands the host install
-off to the CLI (which discovers the staged wrapper via the well-known
-per-environment bin path):
-
-```bash
-traycer host install [--release <version>] --allow-self-invocation
-```
-
-The CLI **downloads the signed host from GitHub Releases**, verifies it against
-the trust key committed in `clients/traycer-cli/src/config.ts`, stages the dev
-install dir, writes `~/.traycer/host/dev/install/install.json`, registers the
-`ai.traycer.host.dev` service (which invokes the staged wrapper with
-`host start`), and starts the host. The Traycer Host is **not** built from source
-in this repo - it is provisioned as a release binary.
-
-After install, `concurrently` runs two foreground streams: the HMR Electron shell
-(`bun run --cwd clients/desktop dev`) and a follower on
-`~/.traycer/host/dev/host.log`. The clients talk to the **production** cloud
-(`authn.traycer.ai`, `platform.traycer.ai`) and to the host over its localhost
-WebSocket - there are no local backend services to run. The host is supervised by
-the OS service manager (launchd / systemd-user), not a direct child of
-`concurrently`; the `host` stream is a pure log follower.
-
-Ctrl-C hands off to the CLI (`traycer host uninstall --all`): it stops the host,
-deregisters the `ai.traycer.host.dev` service, and removes
-`~/.traycer/host/dev/install/`. Your `~/.traycer/` user data (credentials,
-config, epics, sqlite, logs) and any production host/CLI state are preserved.
-
-The runtime ownership boundary is deliberate: Electron main owns shell state,
-windows, tray, deep links, and secure token storage via `safeStorage`; the host
-(external to this repo) is the only process that opens app-assets SQLite through
-Prisma / `better-sqlite3`. Do not add Electron-specific native SQLite rebuilds or
-custom binding-path environment variables to the desktop shell.
-
-`make dev-desktop` uses `tail -F` (POSIX), so it targets macOS / Linux; the
-packaged-app build (`bun run package`) remains cross-platform via
-`electron-builder`.
-
-## Release pipeline
-
-Desktop releases (signed installers + update feeds) are built and signed in
-Traycer's **internal** repository and published to this repo's
-[Releases](../../releases) cross-repo; signing secrets never enter this repo. For
-a local packaged build, use `bun run package` (unsigned) or `bun run package:dir`
-(unpacked, faster smoke test).
-
-> **CLI-resource precheck modes.** `prepack:check-cli` runs in two modes.
-> `bun run --cwd clients/desktop package:dir` invokes it without
-> `--platform`/`--arch`, so it runs in **host-lenient mode** - it only verifies
-> the current host's `resources/cli/<platform>-<arch>/` triplet. The CI release
-> pipeline passes explicit `--platform`/`--arch` flags so it runs in
-> **matrix-strict mode**. If you run `package:dir` locally and CI later rejects
-> the same tree, re-run with `--platform`/`--arch` to hit the stricter checks.
-
-## Epic disk sync
-
-When a user opens an epic in the GUI, the renderer subscribes with
-`enableFileSync: true` and the host mirrors the epic's artifacts to disk:
-
-```text
-~/.traycer/epics/<epicId>/artifacts/<artifactId>/index.md
-~/.traycer/epics/<epicId>/artifacts/<parent>/<child>/index.md
-```
-
-This on-disk layout is the host's contract (defined in the external
-Traycer Host and consumed by its file watcher + system prompt; Desktop
-only reads it). The folder name is the artifact's id (slug) on disk; folder
-nesting expresses the parent-child relation. Frontmatter holds `title`, `kind`,
-plus `status` and `assignee` for ticket/story kinds - internal metadata stays in
-yjs. On open, yjs is the source of truth; the renderer's first sync overwrites
-disk to match the cloud Y.Doc, then bidirectional propagation begins.
-
-Background subscriptions (e.g. agent-only opens that pass `enableFileSync: false`
-or omit the flag) never write to disk.
+| Path                    | Role                                                                                                                   |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `src/electron-main/`    | Main process (`main-process.ts`); feature folders under `app/`, `auth/`, `host/`, `windows/`, `menu/`, `tray/`, `ipc/` |
+| `src/electron-preload/` | `window.runnerHost` bridges (`preload-bridge.ts` + `*-bridge.ts`)                                                      |
+| `src/renderer-shell/`   | Thin React host; UI is `gui-app` via vite aliases                                                                      |
+| `src/ipc-contracts/`    | Plain-data types shared across main/preload/renderer                                                                   |
+| `scripts/`              | `dev/`, `prepack/`, `assets/`                                                                                          |
+| `resources/cli/`        | Staged CLI SEA (`<platform>-<arch>/traycer`) → `process.resourcesPath/cli/`                                            |
+| `resources/tray/`       | Tray icons (regenerate via `scripts/assets/generate-tray-icons.cjs`)                                                   |
+| `resources/host/`       | Placeholder only — **never** ship a host binary here                                                                   |
 
 ## Invariants
 
-- Bundle output goes to `dist/`. The main process entry is `dist/main/index.js`.
-- Desktop bundles only the Traycer CLI (`resources/cli/<platform>-<arch>/`), not
-  a host binary. The CLI is resolved at runtime via `cli-discovery.ts`; the
-  host is owned by the CLI under `~/.traycer/host/install/`.
-- The tray icon is loaded from `process.resourcesPath/tray/` in packaged builds
-  and from `<appPath>/resources/tray/` in development. `tray.ts` must never
-  construct the `Tray` from `nativeImage.createEmpty()` - that path was removed
-  because it produced an invisible system-tray entry on end-user machines.
-- Preload must remain CommonJS and must only import from `src/ipc-contracts/`.
+- Bundle CLI only, not the host. Host lives under `~/.traycer/host/` via CLI.
+- Main entry: `dist/main/index.js`.
+- Preload stays CommonJS and imports only from `src/ipc-contracts/`.
+- Never build `Tray` from `nativeImage.createEmpty()` (invisible tray).
+- No Electron-native SQLite / `better-sqlite3` rebuilds in this shell — host owns
+  app-assets DB.
+- Signed releases are built in the **internal** repo; this repo has no signing
+  secrets. Local: `bun run package` (unsigned) / `package:dir`.
+- `prepack:check-cli` without `--platform`/`--arch` is host-lenient; CI passes
+  both for matrix-strict checks.
+
+## Boundaries
+
+- Don't add host binaries or Node runtimes to the Desktop bundle.
+- Don't proxy host RPC through Electron.
+- Don't edit generated `dist/`.

--- a/clients/gui-app/AGENTS.md
+++ b/clients/gui-app/AGENTS.md
@@ -1,365 +1,116 @@
-# AGENTS.md
+# AGENTS.md — clients/gui-app
 
-This file is the local agent guide for `clients/gui-app`. Read it
-together with the repo-root `AGENTS.md`.
+GUI renderer for Traycer. Read with repo-root `AGENTS.md`. Treat as a normal
+browser React app unless the task needs native/desktop integration.
 
-## Workspace Purpose
+**Stack:** Vite, React, TS, TanStack Router (file-based) + Query, Zustand,
+Tailwind v4, shadcn/ui, Vitest + Testing Library.
 
-`gui-app` is the standalone Traycer application shell. It is separate from the
-older `clients/gui/` webview work and should be treated as a normal
-browser-run React application unless the user explicitly asks for native or
-desktop-specific integration.
-
-## Stack
-
-- Vite
-- React
-- TypeScript
-- TanStack Router with file-based routing
-- TanStack Query
-- Zustand
-- Tailwind CSS v4
-- shadcn/ui primitives
-- Vitest + Testing Library
-
-## Important Commands
-
-Run these from `clients/gui-app/`:
+## Commands
 
 ```bash
+# from clients/gui-app/
 bun run dev
 bun run build
 bun run test
 bun run lint
 bun run compile
-bun run react-doctor
+bun run react-doctor   # manual after .ts/.tsx changes; not in pre-commit
 ```
 
-Run `bun run react-doctor` manually after touching gui-app `.ts`/`.tsx` files
-and address any findings before committing. It is not wired into pre-commit. For
-changed-files-only output against the base branch use
-`npx -y react-doctor@latest . --verbose --diff <base> --offline --no-score`.
-
-## Folder Structure
-
-- `src/` Main application source.
-
-- `src/routes/` File-based route modules and route composition.
-
-- `src/components/` App-specific components and layout composition.
-
-- `src/components/ui/` Primitive UI building blocks installed and managed
-  through shadcn workflows. Prefer composing these before modifying them.
-
-- `src/providers/` Global providers such as theming and app-wide context setup.
-
-- `src/stores/` Zustand stores for local client state.
-
-- `src/lib/` Shared app-local utilities and infrastructure helpers.
-
-- `src/hooks/` Reusable app-local hooks.
-
-- `public/` Static public assets.
-
-- `__tests__/` Workspace-level tests and smoke checks.
-
-- `dist/` Build output. Treat as generated.
-
-- `.tanstack/` Tool-managed router metadata/cache. Treat as generated.
-
-## Working Rules
-
-- Prefer route and composition changes before editing primitives.
-- If the user asks to use primitives directly, keep changes in app composition
-  and avoid rewriting `src/components/ui/` unless necessary.
-- Use `src/components/ui/agent-spinning-dots.tsx` (`AgentSpinningDots`) for
-  loading spinners and animated loading dots. Do not add new ad hoc spinner
-  components or inline spinner markup when this component can represent the
-  loading state.
-- Keep the app browser-safe unless the task explicitly introduces a native host.
-- Prefer viewport-agnostic responsive sizing for UI surfaces and layouts. Use
-  fluid constraints such as flex/grid sizing, `w-full`, `max-w-*`, `min-h-*`,
-  `max-h-*`, percentages, `clamp()`, and viewport units before reaching for
-  fixed pixel widths or heights. Only use hardcoded pixel sizing when the size
-  is inherently fixed, such as icons, hairlines, or explicit touch targets. Is
-  it a good pattern that we have implemented and protected against?- Avoid
-  nullish-coalescing fallbacks in JSX `key` props when `undefined` already
-  expresses the same remount behavior.
-- Preserve TanStack Router file-based routing.
-- Use Zustand for local UI/client state, not server-state caching.
-- Use TanStack Query for fetched data once data fetching is introduced.
-- Always concatenate className values through `cn(...)` from `@/lib/utils`. Do
-  not build class strings with template literals, `+`, or `${}` interpolation,
-  and do not assemble arrays and `.join(" ")` them. `cn` is the single source of
-  truth for conditional classes, conflict resolution via `tailwind-merge`, and
-  de-duplication - bypassing it produces stale variants that override the
-  intended Tailwind state. Static single-string literals that need no
-  composition may remain as plain strings.
-
-## Backend Actions And TanStack Query
-
-Every request/response backend call (host RPC, AuthService, RunnerHost) must
-flow through TanStack Query. No `useState<boolean>` loading flags around awaited
-backend calls, no ad-hoc try/catch + `toast.error` orchestration in components.
-
-- Host RPC: use `useHostQuery` / `useHostMutation` for single calls and
-  `useHostQueries` for arrays. The wrappers own the host-scoped query key
-  and the `hostId === null` enabled gate. Do not roll your own
-  `queryOptions(...)` + `useQueries(...)` pair against `client.request(...)`.
-- Non-host (`AuthService`, `IRunnerHost`): use bare `useMutation` / `useQuery`
-  with a stable `mutationKey` from `src/lib/query-keys/`. Do not inline the key
-  shape at the call site.
-- Hooks return raw `UseMutationResult` / `UseQueryResult`. Do not narrow the
-  surface - callers want `isPending`, `error`, `mutate`, `mutateAsync`, `reset`,
-  `data`, `variables`. Hook layout:
-  `src/hooks/<namespace>/use-<verb>-<noun>-mutation.ts` (or `-query.ts`);
-  namespaces: `epic`, `workspace`, `agent`, `auth`, `runner`. Hook name pattern:
-  `use<Namespace><Verb><Noun>` - e.g. `useEpicCreate`,
-  `useRunnerCliLogin`, `useRunnerRequestHostRespawn`.
-- Cache: `invalidateQueries` in `onSuccess` is the default. Optimistic
-  `setQueryData` is reserved for response-equals-state cases and must be
-  justified explicitly; new mutations should not introduce optimistic writes
-  without prior discussion.
-- Host-swap race protection: capture the active host id in `onMutate` and
-  consume it from the mutation context in `onSuccess`/`onError` so a host swap
-  mid-flight does not invalidate the wrong scope.
-- Error mapping: each source has one helper in `src/lib/`:
-  `toastFromHostError`, `toastFromAuthError`, `toastFromRunnerError`. Mutation
-  hooks call the matching helper from `onError`. The exception is surfaces that
-  must stay inline-only: the hook omits `onError` and the component renders
-  `mutation.error?.message` directly.
-- Pending UX recipe: `disabled={mutation.isPending}` + keep the button label
-  unchanged + render `AgentSpinningDots` inline next to the label. Do not swap
-  labels (no "Submitting…", no "Retrying…").
-- Mutation key builders live under
-  `src/lib/query-keys/<namespace>-mutation-keys.ts` and are re-exported through
-  `src/lib/query-keys/index.ts`. Add new builders there; never inline
-  `["mutation", "..."]` literals in hooks or components.
-
-## Remembered Patterns
-
-- Prefer configured import aliases over long relative imports whenever an alias
-  exists. In this workspace, use `@/*` for app code and workspace aliases like
-  `@core/*`, `@traycer-clients/shared/*`, and `@traycer/protocol/*` instead of
-  manual `../../..` paths.
-
-- Structured perf telemetry (separate from the human log) goes through
-  `src/lib/perf/perf-telemetry.ts` `logPerfEvent(name, fields)`. It prints a
-  `[traycer-perf]` console line the desktop shell appends to a dedicated
-  machine-parseable file, `<Electron userData>/traycer-perf.ndjson` (rotates to
-  `.ndjson.1` at ~5 MB), instead of `traycer-desktop.log`. Enable with
-  `localStorage["traycer:perf:telemetry"] = "1"` (on by default in dev, off in
-  tests, opt-in in prod). Sibling gated probes: `main-thread-block-probe.ts`
-  (`traycer:perf:mainthread`) and `terminal-load-perf.ts`
-  (`traycer:perf:terminal`).
-
-- Keep query-key management centralized. Define durable query-key builders in a
-  dedicated `src/lib/query-keys/` area and expose them through a barrel export,
-  rather than rebuilding key shapes ad hoc in components, hooks, or tests.
-
-- Keep query fetching concerns separate from query-key definitions. Query keys
-  describe cache identity; query helpers can live next to the integration they
-  support, but they should consume the centralized key builders instead of
-  inventing parallel key layouts.
-
-- For host-scoped TanStack Query data, keep the key hierarchy semantic and
-  prefix-based so broad invalidation stays predictable: base host scope →
-  host id scope → method/resource scope → params or filters. Invalidating a
-  host scope should naturally drop all queries tied to that host.
-
-- Prefer TanStack Router route lifecycle APIs for route concerns: `beforeLoad`
-  for auth/redirect guards and route-context setup, `validateSearch` for
-  canonical URL/search normalization, and route `loader` + Query prefetch for
-  critical server-state hydration. Do not use component effects for work that
-  belongs to routing.
-
-- Do not mutate UI/client state from route preloading paths. With Router intent
-  preloading enabled, `beforeLoad` and `loader` may run before navigation is
-  committed, so tab creation, local store writes, and similar UI mutations must
-  stay in committed component lifecycle or explicit user actions.
-
-- Apply the React “You Might Not Need an Effect” bar consistently: use effects
-  only for true external synchronization (router ↔ external store, live stream ↔
-  UI store, browser API subscriptions). Derived values, cache identities, and
-  route control flow should be expressed without effects whenever possible.
-
-## Preferred Local Skills
-
-This repo includes GUI-relevant local skills under `.agents/skills/`. Prefer
-using them when the task matches their scope:
-
-- `shadcn` Use for shadcn init/apply flows, preset codes, component lookup,
-  registry usage, and primitive composition questions.
-
-- `tailwind-v4-shadcn` Use for Tailwind v4 + shadcn setup, theme token wiring,
-  CSS variable issues, dark mode behavior, and Tailwind v4 migration/debugging.
-
-- `tanstack-router-best-practices` Use for route structure, loaders, search
-  params, navigation, code splitting, and TanStack Router organization.
-
-- `tanstack-query-best-practices` Use for fetched data, cache keys,
-  invalidation, mutations, hydration, and general TanStack Query behavior.
-
-- `tanstack-integration-best-practices` Use when Router and Query need to work
-  together, especially loaders, preloading, SSR/hydration, and cache
-  coordination.
-
-- `zustand-5` Use for client-side state stores, selectors, persist middleware,
-  slices, and Zustand 5 usage patterns.
-
-If multiple skills apply, use the smallest relevant set rather than loading all
-of them by default.
-
-## Generated And Tool-Managed Files
-
-These may change automatically and should not be treated as stable design
-documentation:
-
-- `src/routeTree.gen.ts` Generated by TanStack Router tooling.
-
-- `components.json` Managed by shadcn init/add workflows.
-
-- `dist/` Build output.
-
-- `.tanstack/` Tool-managed artifacts.
-
-- `.eslintcache` Lint cache output.
-
-When applying a shadcn preset, expect tool-managed updates to:
-
-- `components.json`
-- app-level CSS entrypoints
-- files under `src/components/ui/`
-
-After any preset or scaffold operation, re-run build and tests.
-
-## Per-Epic State + Y.Doc Projector
-
-Per-Epic state, the editor binding (`Y.XmlFragment`), comment anchors, snapshot
-ingest / replica swap / dirty tracking, and the live-Y escape hatch
-(`getArtifactFragment`) live under `src/stores/epics/open-epic/`. This area
-carries render-count invariants — read the existing code and tests there before
-adding fields, actions, or selectors.
-
-## Navigation Advice
-
-- Start in `src/routes/` for page and route work.
-- Start in `src/components/` for app-specific UI composition.
-- Start in `src/components/ui/` only when the change is truly primitive-level.
-- Start in `src/providers/` for theme/provider behavior.
-- Start in `src/stores/` for Zustand-driven UI state.
-- Start in `src/lib/commands/` for command palette behavior. Sources, dispatch,
-  subpages, and the scope/prefix/pin machinery live here. Palette-visible user
-  actions must delegate to a function in `src/lib/commands/actions/` (both
-  palette sources and manual UI call the same function so behavior stays in
-  lockstep).
-- Start in `src/components/command-palette/` for the dialog shell, chips, pin
-  toggle, and sub-page rendering.
-
-## Testing Philosophy
-
-- Prefer end-to-end tests that run as much of the real machinery as possible
-  (real filesystem, real watchers, real docs/stores) over isolated unit tests.
-  Most bugs live in the seams between layers, and an end-to-end test also fails
-  when an underlying unit is wrong — its capture group is strictly larger.
-- Fake only true external boundaries (network, cloud services) or sources of
-  nondeterminism.
-- Unit tests are acceptable for isolated logic, but treat them as a supplement,
-  never as the reason to skip exercising the integrated path.
-
-## Testing Notes
-
-- Tests use Testing Library role queries, so semantic markup and accessible
-  names matter.
-- If state leaks between tests, reset store state in test setup instead of
-  weakening assertions.
-
-## Terminal Theming
-
-xterm.js terminals (`TerminalXtermHost`, used by both `TerminalTile` and
-`TerminalAgentTile`) follow the active theme preset + light/dark variant. The
-architecture is intentionally small - three TS files plus one CSS file - so
-adding a new preset only needs a CSS block.
-
-- **CSS tokens.** Per-preset ANSI palettes live in
-  `src/styles/terminal-themes.css` as named custom properties:
-  `--term-ansi-{black|red|green|yellow|blue|magenta|cyan|white}` and the
-  matching `--term-ansi-bright-*`. `:root` and `.dark` carry the neutral
-  defaults that the "neutral" preset and the six accent-only presets share;
-  `[data-theme="X"]` and `.dark[data-theme="X"]` blocks override every slot for
-  full-palette presets (dracula, github, gruvbox, …). When a theme publishes
-  only 8 colors, leave the bright slots unset and the build helper L-shifts
-  normals at runtime. Adding a new full-palette preset is one new CSS block; no
-  TS changes.
-
-- **DOM cascade owner.** `src/lib/theme-applier.ts` is the imperative owner of
-  `<html>` `class` / `data-theme` / `color-scheme`. It subscribes directly to
-  the Zustand settings store and the `matchMedia` listener at module load -
-  outside React. On any theme/preset change, the applier mutates the DOM
-  **before** React re-renders. This is non-negotiable for xterm: the host
-  captures its palette as a JS object via `getComputedStyle` inside a `useMemo`
-  during render. If `applyVariant` lived in `ThemeProvider`'s `useEffect`, child
-  effects would fire before the parent's commit - pushing the previous-toggle's
-  palette into `term.options.theme` while the surrounding Tailwind UI flipped to
-  the new cascade. (Tailwind doesn't show this race because utilities resolve
-  `var(...)` at paint time against the live cascade, with no JS snapshot.) Don't
-  write `<html>` class/data-theme attributes from anywhere else.
-
-- **Resolved theme context.** `src/providers/theme-provider.tsx` exposes
-  `useResolvedTheme(): { resolvedTheme, themePreset }` via context. The resolved
-  value is mirrored from the applier through
-  `useSyncExternalStore(subscribeResolvedTheme, getResolvedTheme)`, so by the
-  time the context updates downstream, the DOM cascade is already flipped. Read
-  context for the resolved value; never read the store directly for it.
-
-- **Build helper.** `src/lib/terminal-theme.ts` -
-  `buildTerminalTheme(resolvedTheme, doc)` reads `--term-ansi-*` and the
-  semantic tokens (`--foreground`, `--background`, `--primary`) via
-  `getComputedStyle`, parses them with culori (the same dependency
-  `mermaid-theme.ts` uses), and returns a fully populated xterm `ITheme`.
-  `selectionBackground` is `--primary` at α 0.3; `selectionForeground` is
-  intentionally undefined so selected glyphs keep their original ANSI color
-  (standard terminal behavior). `useTerminalTheme()` wraps the builder in a
-  `useMemo` keyed on `[resolvedTheme, themePreset]`. The build is synchronous so
-  `new Terminal({ theme })` paints the right palette on the first frame - no
-  flash of default xterm colors.
-
-- **L-shift brightening.** When a `--term-ansi-bright-*` slot is unset, the
-  builder takes the matching normal, parses to oklch, shifts L by `+0.08` in
-  dark mode and `−0.08` in light mode, and reformats to `rgb(...)`. The
-  directional flip matches Solarized Light / GitHub Light / Gruvbox Light
-  convention (brights are darker / more saturated on a light backdrop, lighter
-  on a dark one).
-
-- **Atlas scheduler.** `src/lib/terminal-theme-scheduler.ts` exports
-  `scheduleAtlasClear(terminal, webglAddon | null)`. Theme- and font-change
-  effects in `terminal-tile-xterm.tsx` enqueue here; one `requestAnimationFrame`
-  flushes every pending entry, deduplicated per Terminal instance. Toggling a
-  preset with N tiles open fires one rAF burst, not N. Disposed addons (the
-  WebGL fallback path) are tolerated.
-
-- **Lazy-loaded host.** `TerminalXtermHost` exports a default symbol so
-  `TerminalTile` and `TerminalAgentTile` lazy-load the chunk via
-  `lazy(() => import("./terminal-tile-xterm"))` and wrap usage in
-  `<Suspense fallback={<TerminalLoadingSkeleton />}>`. The ~150 KB of `@xterm/*`
-  is deferred until first terminal mount per session.
-
-- **Font.** `fontSize` and `fontFamily` are the effective terminal values from
-  the settings store: `terminalFontSize ?? codeFontSize` and
-  `terminalFontFamily ?? codeFontFamily` prepended to the shared default mono
-  stack (`src/lib/default-font-stacks.ts`). The font-family string is built
-  from store values rather than read from `--traycer-font-mono`, because xterm
-  can't resolve CSS variables in its canvas measurement pass and a
-  `getComputedStyle` read would race the `ThemeProvider` effect that writes
-  the variable's inline override. Live size or family changes trigger a
-  `fitAddon.fit()` refit alongside the atlas clear.
-
-- **What stays pinned.** No per-tab terminal palette overrides - every terminal
-  mirrors the app theme. The xterm.js stylesheet (`@xterm/xterm/css/xterm.css`)
-  is left untouched; scrollbar / search overlay use xterm defaults. Scrollback
-  size and `allowProposedApi` are constants in `terminal-tile-xterm.tsx`. Cursor
-  shape and cursor blink are Settings → Appearance values
-  (`terminalCursorStyle` / `terminalCursorBlink`): captured in
-  `initialOptionsRef` for the first paint and live-synced through
-  `useTerminalAppearanceSync` (no refit/atlas clear - they don't change cell
-  geometry).
+Changed-files-only: `npx -y react-doctor@latest . --verbose --diff <base> --offline --no-score`.
+
+**Commits:** don't manually run `compile` / `build` / `lint` / `format` before
+committing — repo-root `pre-commit` already runs the affected checks (see root
+`AGENTS.md`). Tests are CI, not the hook. Re-run checks only when diagnosing
+failures. `react-doctor` stays manual (not hooked).
+
+## Map
+
+| Path                          | Role                                                                   |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `src/routes/`                 | File-based routes                                                      |
+| `src/components/`             | App UI; `components/ui/` = shadcn primitives (compose, don't rewrite)  |
+| `src/stores/`                 | Zustand (UI/client state only)                                         |
+| `src/hooks/`                  | App hooks (`hooks/<ns>/use-<verb>-<noun>-{mutation,query}.ts`)         |
+| `src/lib/query-keys/`         | Central query/mutation key builders                                    |
+| `src/lib/commands/`           | Command palette sources + `actions/` (palette and UI call the same fn) |
+| `src/stores/epics/open-epic/` | Per-epic Y.Doc projector — read code/tests before changing             |
+| `src/providers/`              | App-wide providers                                                     |
+
+Generated — don't hand-edit: `src/routeTree.gen.ts`, `dist/`, `.tanstack/`.
+
+## Non-negotiable rules
+
+- **`cn(...)`** from `@/lib/utils` for all composed `className`s. No template
+  literals / `+` / `.join(" ")`. Static single strings OK.
+- **Fluid layout sizing** — `w-full`, `max-w-*`, viewport caps. No fixed px/rem
+  for layout surfaces (icons / touch targets OK).
+- Prefer composition over editing `src/components/ui/`.
+- Spinners: `AgentSpinningDots` only — no new ad-hoc spinners.
+- No `key={x ?? fallback}` when `undefined` already remounts correctly.
+- Zustand = client UI state; TanStack Query = server/host data.
+- Keep browser-safe unless the task adds a native host.
+
+## Backend calls → TanStack Query
+
+Every host RPC / AuthService / RunnerHost request goes through Query. No
+`useState` loading flags or ad-hoc `toast.error` in components.
+
+| Kind     | Use                                                                               |
+| -------- | --------------------------------------------------------------------------------- |
+| Host RPC | `useHostQuery` / `useHostMutation` / `useHostQueries` (owns host key + null gate) |
+| Non-host | bare `useQuery` / `useMutation` + key from `src/lib/query-keys/`                  |
+
+- Return full `UseQueryResult` / `UseMutationResult` — don't narrow.
+- Hook names: `use<Namespace><Verb><Noun>` (e.g. `useEpicCreate`).
+- Default cache update: `invalidateQueries` in `onSuccess`. Optimistic
+  `setQueryData` only when justified.
+- Host-swap races: capture `hostId` in `onMutate`, use it in
+  `onSuccess`/`onError`.
+- Errors: `toastFromHostError` / `toastFromAuthError` / `toastFromRunnerError`
+  in `onError` (omit only for inline-error surfaces).
+- Pending UX: `disabled={isPending}` + unchanged label + inline
+  `AgentSpinningDots`. Never swap labels ("Submitting…").
+- Never inline `["mutation", "..."]` keys — add builders under
+  `src/lib/query-keys/`.
+
+Host scope: tab tiles use `useTabHostId()` / `useTabHostClient()`; app-wide
+surfaces use `useReactiveActiveHostId()` / `useHostClient()`. Don't mix.
+
+## Routing
+
+- Auth/redirects → route `beforeLoad`; search → `validateSearch`; critical
+  data → route `loader` + Query prefetch. Not component effects.
+- Don't mutate UI/stores from preload paths (`beforeLoad`/`loader` may run
+  before commit).
+- Effects only for external sync (router↔store, streams, browser APIs).
+
+## Testing
+
+Prefer integrated tests (real stores/docs/watchers) over isolated units. Fake
+only external/nondeterministic boundaries. Reset stores between tests; use
+Testing Library role queries.
+
+## Skills (use when matched)
+
+| Skill                             | When                           |
+| --------------------------------- | ------------------------------ |
+| `shadcn`                          | Init/add/primitives            |
+| `tailwind-v4-shadcn`              | Theme tokens, dark mode, TW v4 |
+| `react-best-practices`            | React / `.tsx`                 |
+| `frontend-design`                 | New UI / visual work           |
+| `vite` / `vitest` / `zod` / `bun` | As named                       |
+
+Materialized from `skills-lock.json` under `.agents/` / `.claude/`.
+
+## Terminal theming (xterm)
+
+Invariants only — read `src/lib/theme-applier.ts`, `terminal-theme.ts`,
+`styles/terminal-themes.css` before changing:
+
+- `theme-applier.ts` owns `<html>` class / `data-theme` (module-load, outside
+  React). Don't write those attributes elsewhere.
+- ANSI tokens in CSS (`--term-ansi-*`); new full-palette preset = one CSS block.
+- `buildTerminalTheme` is sync (no flash); unset bright slots L-shift at runtime.
+- Lazy-load `TerminalXtermHost`; clear atlas via `scheduleAtlasClear`.


### PR DESCRIPTION
## Summary
- Rewrite root, `clients/gui-app`, and `clients/desktop` `AGENTS.md` for modern agent context limits (~70–110 lines each): commands, domain rules, and non-obvious invariants only.
- Drop README-duplicating prose (dev-desktop orchestration, terminal-theming essays, style fluff).
- Document that `pre-commit` already runs affected build/compile/lint/format, so agents should not re-run those before committing (tests remain CI).

## Test plan
- [ ] Skim each `AGENTS.md` for accuracy against current layout/commands
- [ ] Confirm DCO sign-off present on the commit
- [ ] No code changes — docs only