### PR TITLE
feat(gui-app): full-screen mobile epic view (Phase 1)

### DIFF
--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -909,12 +909,18 @@ function ChatMessagesInner(props: ChatMessagesProps) {
               aria-hidden="true"
               className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-linear-to-t from-background to-transparent"
             />
+            {/* The 2px hover-rail minimap is untappable on touch and its
+                hover-expand never fires; hide it below md and reclaim the right
+                edge. `contents` keeps the absolutely-positioned rail's layout
+                identical on desktop (>=768px). */}
             {hasContent ? (
-              <ChatUserMessageMinimap
-                items={minimapItems}
-                activeMessageId={activeUserMessageId}
-                onItemClick={onMinimapItemClick}
-              />
+              <div className="contents max-md:hidden">
+                <ChatUserMessageMinimap
+                  items={minimapItems}
+                  activeMessageId={activeUserMessageId}
+                  onItemClick={onMinimapItemClick}
+                />
+              </div>
             ) : null}
             {hasContent ? (
               <ScrollToBottomChip

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-menu.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-menu.test.tsx
@@ -1,0 +1,127 @@
+import "../../../../__tests__/test-browser-apis";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EpicMobileHeaderMenu,
+  MobileEpicHeaderActionsBinder,
+} from "@/components/epic-canvas/mobile/epic-mobile-header-menu";
+import { useMobileHeaderStore } from "@/stores/layout/mobile-header-store";
+
+interface RenameVariables {
+  readonly epicDelta: {
+    readonly id: string;
+    readonly title: string;
+    readonly updatedAt: number;
+  };
+}
+
+let role: "owner" | "viewer" = "owner";
+let mobileValue = true;
+const openSpy = vi.fn();
+const setComposerModeSpy = vi.fn();
+const mutateSpy =
+  vi.fn<(vars: RenameVariables, options: { onSuccess: () => void }) => void>();
+
+vi.mock("@/hooks/ui/use-mobile", () => ({
+  useIsMobile: () => mobileValue,
+}));
+vi.mock("@/lib/epic-selectors", () => ({
+  useRegisteredEpicPermissionRole: () => role,
+  useRegisteredEpicTitle: () => "My Epic",
+}));
+vi.mock("@/stores/epics/new-conversation-modal-open-store", () => ({
+  useNewConversationModalOpenStore: { getState: () => ({ open: openSpy }) },
+}));
+vi.mock("@/stores/epics/new-conversation-modal-store", () => ({
+  useNewConversationModalStore: {
+    getState: () => ({ setComposerMode: setComposerModeSpy }),
+  },
+}));
+vi.mock("@/hooks/epic/use-epic-title-mutation", () => ({
+  useEpicUpdateTitle: () => ({ mutate: mutateSpy, isPending: false }),
+}));
+
+function renderMenu() {
+  return render(<EpicMobileHeaderMenu epicId="epic-1" tabId="tab-1" />);
+}
+
+function openMenu() {
+  fireEvent.pointerDown(screen.getByTestId("mobile-epic-actions-trigger"));
+}
+
+describe("<EpicMobileHeaderMenu />", () => {
+  beforeEach(() => {
+    role = "owner";
+    openSpy.mockClear();
+    setComposerModeSpy.mockClear();
+    mutateSpy.mockClear();
+  });
+  afterEach(cleanup);
+
+  it("shows exactly New chat and Rename for an editor", () => {
+    renderMenu();
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: "New chat" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Rename" })).toBeTruthy();
+    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+  });
+
+  it("hides Rename for a non-editor (viewer keeps only New chat)", () => {
+    role = "viewer";
+    renderMenu();
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: "New chat" })).toBeTruthy();
+    expect(screen.queryByRole("menuitem", { name: "Rename" })).toBeNull();
+  });
+
+  it("New chat opens the shared New Conversation modal request for this epic", () => {
+    renderMenu();
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "New chat" }));
+    expect(setComposerModeSpy).toHaveBeenCalledWith("epic-1", "chat");
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        epicId: "epic-1",
+        tabId: "tab-1",
+        parentId: null,
+      }),
+    );
+  });
+
+  it("Rename opens a dialog and submits the new title via the rename mutation", () => {
+    renderMenu();
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename" }));
+    const input = screen.getByTestId("mobile-epic-rename-input");
+    fireEvent.change(input, { target: { value: "Renamed epic" } });
+    fireEvent.click(screen.getByTestId("mobile-epic-rename-save"));
+    expect(mutateSpy).toHaveBeenCalledTimes(1);
+    const variables = mutateSpy.mock.calls[0][0];
+    expect(variables.epicDelta.id).toBe("epic-1");
+    expect(variables.epicDelta.title).toBe("Renamed epic");
+  });
+});
+
+describe("<MobileEpicHeaderActionsBinder />", () => {
+  afterEach(() => {
+    cleanup();
+    mobileValue = true;
+    useMobileHeaderStore.getState().setRightActions(null);
+  });
+
+  it("fills the header slot on mobile and clears it on unmount", () => {
+    mobileValue = true;
+    const { unmount } = render(
+      <MobileEpicHeaderActionsBinder epicId="epic-1" tabId="tab-1" />,
+    );
+    expect(useMobileHeaderStore.getState().rightActions).not.toBeNull();
+    unmount();
+    expect(useMobileHeaderStore.getState().rightActions).toBeNull();
+  });
+
+  it("does not fill the slot on desktop", () => {
+    mobileValue = false;
+    render(<MobileEpicHeaderActionsBinder epicId="epic-1" tabId="tab-1" />);
+    expect(useMobileHeaderStore.getState().rightActions).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-menu.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-mobile-header-menu.test.tsx
@@ -66,12 +66,13 @@ describe("<EpicMobileHeaderMenu />", () => {
     expect(screen.getAllByRole("menuitem")).toHaveLength(2);
   });
 
-  it("hides Rename for a non-editor (viewer keeps only New chat)", () => {
+  it("renders no trigger at all for a viewer (no editable actions)", () => {
     role = "viewer";
     renderMenu();
-    openMenu();
-    expect(screen.getByRole("menuitem", { name: "New chat" })).toBeTruthy();
-    expect(screen.queryByRole("menuitem", { name: "Rename" })).toBeNull();
+    // A viewer can neither create nor rename, so the whole ⋮ is hidden - no
+    // dead-end New chat, no empty menu.
+    expect(screen.queryByTestId("mobile-epic-actions-trigger")).toBeNull();
+    expect(screen.queryByRole("menuitem")).toBeNull();
   });
 
   it("New chat opens the shared New Conversation modal request for this epic", () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/mobile-current-tile-bar.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/mobile-current-tile-bar.test.tsx
@@ -1,0 +1,60 @@
+import "../../../../__tests__/test-browser-apis";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MobileCurrentTileBar } from "@/components/epic-canvas/mobile/mobile-current-tile-bar";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+
+// The live tile icon is covered by the tab-strip tests; stub it here so this
+// test targets the bar's own composition (title, affordance, tap).
+vi.mock("@/components/epic-canvas/canvas/tab-strip", () => ({
+  TabIcon: () => <span data-testid="tab-icon" />,
+  TabStrip: () => null,
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicTabDisplayTitle: (node: { readonly name: string }) => node.name,
+  useEpicLiveArtifactTitleGenerating: () => false,
+}));
+
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => null,
+}));
+
+const TILE: EpicCanvasTileRef = {
+  id: "spec-1",
+  instanceId: "inst-1",
+  type: "spec",
+  name: "Life Philosophy",
+  hostId: "host-A",
+};
+
+describe("<MobileCurrentTileBar />", () => {
+  afterEach(cleanup);
+
+  it("shows the current tile title, icon, and an accessible switch affordance", () => {
+    render(
+      <MobileCurrentTileBar
+        epicId="epic-1"
+        tile={TILE}
+        onOpenSwitcher={() => undefined}
+      />,
+    );
+    const bar = screen.getByTestId("mobile-current-tile-bar");
+    expect(bar.textContent).toContain("Life Philosophy");
+    expect(screen.getByTestId("tab-icon")).not.toBeNull();
+    expect(bar.getAttribute("aria-label")).toContain("Life Philosophy");
+  });
+
+  it("invokes onOpenSwitcher when tapped", () => {
+    const onOpenSwitcher = vi.fn();
+    render(
+      <MobileCurrentTileBar
+        epicId="epic-1"
+        tile={TILE}
+        onOpenSwitcher={onOpenSwitcher}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("mobile-current-tile-bar"));
+    expect(onOpenSwitcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/__tests__/mobile-epic-tile-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/mobile-epic-tile-view.test.tsx
@@ -1,13 +1,15 @@
 import "../../../../__tests__/test-browser-apis";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MobileEpicTileView } from "@/components/epic-canvas/mobile/mobile-epic-tile-view";
 import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { collectPanes } from "@/stores/epics/canvas/tile-tree";
 import type {
   EpicCanvasState,
   EpicCanvasTileRef,
   TileGroup,
+  TileLayoutNode,
   TilePane,
 } from "@/stores/epics/canvas/types";
 
@@ -37,6 +39,15 @@ vi.mock("@/components/epic-canvas/renderers/epic-node-tile", () => ({
 // it to a marker so the empty-canvas branch is observable in isolation.
 vi.mock("@/components/epic-canvas/canvas/pane-opener", () => ({
   PaneOpener: () => <div data-testid="pane-opener" />,
+}));
+
+// The current-tile bar is covered by its own test; stub it here to a marker
+// carrying the tile it was handed, so the view test can assert WHICH tile the
+// bar reflects without pulling the bar's host/title hooks.
+vi.mock("@/components/epic-canvas/mobile/mobile-current-tile-bar", () => ({
+  MobileCurrentTileBar: ({ tile }: { readonly tile: EpicCanvasTileRef }) => (
+    <div data-testid="current-tile-bar" data-tile-id={tile.id} />
+  ),
 }));
 
 function spec(n: number): EpicCanvasTileRef {
@@ -103,6 +114,10 @@ function renderView() {
 
 function renderedTileCount(): number {
   return document.querySelectorAll('[data-testid^="tile-"]').length;
+}
+
+function paneIds(root: TileLayoutNode | null): ReadonlyArray<string> {
+  return collectPanes(root).map((pane) => pane.id);
 }
 
 describe("selectMobileTile", () => {
@@ -189,6 +204,35 @@ describe("<MobileEpicTileView />", () => {
     expect(after).toBe(before);
     expect(after?.root).toBe(before?.root);
     expect(after?.sizesByGroupId).toBe(before?.sizesByGroupId);
+  });
+
+  it("hands the current tile to the current-tile bar", () => {
+    seed(twoPaneCanvas("pane-B"));
+    renderView();
+    expect(
+      screen.getByTestId("current-tile-bar").getAttribute("data-tile-id"),
+    ).toBe("spec-3");
+  });
+
+  it("swaps the rendered tile when activation moves to another pane", () => {
+    seed(twoPaneCanvas("pane-A"));
+    renderView();
+    expect(screen.queryByTestId("tile-spec-1")).not.toBeNull();
+    const before = useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID];
+
+    // Same store transition `useMobileEpicTiles.selectTile` drives.
+    act(() => {
+      useEpicCanvasStore
+        .getState()
+        .prepareSetActiveTileTabFocusTarget(VIEW_TAB_ID, "pane-B", "inst-3");
+    });
+
+    expect(screen.queryByTestId("tile-spec-3")).not.toBeNull();
+    expect(renderedTileCount()).toBe(1);
+    const after = useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID];
+    // The split STRUCTURE + sizes are unchanged - only activation moved.
+    expect(paneIds(after?.root ?? null)).toEqual(["pane-A", "pane-B"]);
+    expect(after?.sizesByGroupId).toEqual(before?.sizesByGroupId);
   });
 
   it("renders the inline opener (not a blank screen) for an empty pane", () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/mobile-epic-tile-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/mobile-epic-tile-view.test.tsx
@@ -1,0 +1,187 @@
+import "../../../../__tests__/test-browser-apis";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MobileEpicTileView } from "@/components/epic-canvas/mobile/mobile-epic-tile-view";
+import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type {
+  EpicCanvasState,
+  EpicCanvasTileRef,
+  TileGroup,
+  TilePane,
+} from "@/stores/epics/canvas/types";
+
+const VIEW_TAB_ID = "view-tab-1";
+
+// ActiveTabBody reads permission/snapshot/artifact state through epic-selectors;
+// stub them so the shared tile body mounts without a HostRuntimeProvider /
+// EpicSessionProvider (mirrors tab-group-view.test).
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicArtifact: (id: string) => ({ id }),
+  useEpicTabDisplayTitle: (node: { readonly name: string }) => node.name,
+  useEpicLiveArtifactTitleGenerating: () => false,
+  useEpicPermissionRole: () => "owner",
+  useEpicSnapshotLoaded: () => true,
+  useMaybeEpicTuiAgentHarnessId: () => null,
+}));
+
+// The real tile bodies pull the full chat/host machinery; the single-tile view
+// only needs to prove WHICH tile renders, so stub the render seam to a marker.
+vi.mock("@/components/epic-canvas/renderers/epic-node-tile", () => ({
+  EpicNodeTile: ({ node }: { readonly node: EpicCanvasTileRef }) => (
+    <div data-testid={`tile-${node.id}`} />
+  ),
+}));
+
+function spec(n: number): EpicCanvasTileRef {
+  return {
+    id: `spec-${n}`,
+    instanceId: `inst-${n}`,
+    type: "spec",
+    name: `Spec ${n}`,
+    hostId: "host-A",
+  };
+}
+
+function makePane(
+  id: string,
+  tiles: ReadonlyArray<EpicCanvasTileRef>,
+  activeTabId: string | null,
+): TilePane {
+  return {
+    kind: "pane",
+    id,
+    tabInstanceIds: tiles.map((tile) => tile.instanceId),
+    activeTabId,
+    previewTabId: null,
+    activationHistory: activeTabId === null ? [] : [activeTabId],
+  };
+}
+
+// A persisted TWO-pane split: pane-A (spec-1 active, spec-2) beside pane-B
+// (spec-3 active). Mobile must pick exactly one without touching the tree.
+function twoPaneCanvas(activePaneId: string | null): EpicCanvasState {
+  const root: TileGroup = {
+    kind: "group",
+    id: "root-group",
+    direction: "horizontal",
+    children: [
+      makePane("pane-A", [spec(1), spec(2)], "inst-1"),
+      makePane("pane-B", [spec(3)], "inst-3"),
+    ],
+  };
+  return {
+    root,
+    activePaneId,
+    tilesByInstanceId: {
+      "inst-1": spec(1),
+      "inst-2": spec(2),
+      "inst-3": spec(3),
+    },
+    sizesByGroupId: { "root-group": [0.5, 0.5] },
+  };
+}
+
+function seed(canvas: EpicCanvasState): void {
+  useEpicCanvasStore.setState({
+    tabsById: {
+      [VIEW_TAB_ID]: { tabId: VIEW_TAB_ID, epicId: "epic-1", name: "Epic 1" },
+    },
+    canvasByTabId: { [VIEW_TAB_ID]: canvas },
+  });
+}
+
+function renderView() {
+  return render(<MobileEpicTileView epicId="epic-1" tabId={VIEW_TAB_ID} />);
+}
+
+function renderedTileCount(): number {
+  return document.querySelectorAll('[data-testid^="tile-"]').length;
+}
+
+describe("selectMobileTile", () => {
+  it("returns null for an empty (rootless) canvas", () => {
+    expect(
+      selectMobileTile({
+        root: null,
+        activePaneId: null,
+        tilesByInstanceId: {},
+        sizesByGroupId: {},
+      }),
+    ).toBeNull();
+  });
+
+  it("picks the active pane's active tab", () => {
+    const selection = selectMobileTile(twoPaneCanvas("pane-B"));
+    expect(selection?.paneId).toBe("pane-B");
+    expect(selection?.ref.id).toBe("spec-3");
+  });
+
+  it("falls back to the first pane when there is no active pane", () => {
+    const selection = selectMobileTile(twoPaneCanvas(null));
+    expect(selection?.paneId).toBe("pane-A");
+    expect(selection?.ref.id).toBe("spec-1");
+  });
+
+  it("falls back to the first tab instance when the pane has no active tab", () => {
+    const selection = selectMobileTile({
+      root: makePane("pane-A", [spec(1), spec(2)], null),
+      activePaneId: "pane-A",
+      tilesByInstanceId: { "inst-1": spec(1), "inst-2": spec(2) },
+      sizesByGroupId: {},
+    });
+    expect(selection?.ref.id).toBe("spec-1");
+  });
+
+  it("skips an emptied active pane and picks the next pane holding a tile", () => {
+    const root: TileGroup = {
+      kind: "group",
+      id: "g",
+      direction: "horizontal",
+      children: [makePane("pane-A", [], null), makePane("pane-B", [spec(3)], "inst-3")],
+    };
+    const selection = selectMobileTile({
+      root,
+      activePaneId: "pane-A",
+      tilesByInstanceId: { "inst-3": spec(3) },
+      sizesByGroupId: {},
+    });
+    expect(selection?.paneId).toBe("pane-B");
+    expect(selection?.ref.id).toBe("spec-3");
+  });
+});
+
+describe("<MobileEpicTileView />", () => {
+  afterEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  });
+
+  it("renders exactly one tile - the active pane's active tile", () => {
+    seed(twoPaneCanvas("pane-A"));
+    renderView();
+    expect(screen.queryByTestId("tile-spec-1")).not.toBeNull();
+    expect(screen.queryByTestId("tile-spec-2")).toBeNull();
+    expect(screen.queryByTestId("tile-spec-3")).toBeNull();
+    expect(renderedTileCount()).toBe(1);
+  });
+
+  it("shows the active pane's tile in a multi-split layout (picks exactly one)", () => {
+    seed(twoPaneCanvas("pane-B"));
+    renderView();
+    expect(screen.queryByTestId("tile-spec-3")).not.toBeNull();
+    expect(renderedTileCount()).toBe(1);
+  });
+
+  it("performs zero writes to the persisted split layout when viewed", () => {
+    seed(twoPaneCanvas("pane-A"));
+    const before = useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID];
+    renderView();
+    const after = useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID];
+    // Reference-identical: rendering the mobile view mutates neither the split
+    // tree nor the group sizes.
+    expect(after).toBe(before);
+    expect(after?.root).toBe(before?.root);
+    expect(after?.sizesByGroupId).toBe(before?.sizesByGroupId);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/__tests__/mobile-epic-tile-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/mobile-epic-tile-view.test.tsx
@@ -33,6 +33,12 @@ vi.mock("@/components/epic-canvas/renderers/epic-node-tile", () => ({
   ),
 }));
 
+// The empty-pane opener pulls the command-palette router/provider stack; stub
+// it to a marker so the empty-canvas branch is observable in isolation.
+vi.mock("@/components/epic-canvas/canvas/pane-opener", () => ({
+  PaneOpener: () => <div data-testid="pane-opener" />,
+}));
+
 function spec(n: number): EpicCanvasTileRef {
   return {
     id: `spec-${n}`,
@@ -183,5 +189,20 @@ describe("<MobileEpicTileView />", () => {
     expect(after).toBe(before);
     expect(after?.root).toBe(before?.root);
     expect(after?.sizesByGroupId).toBe(before?.sizesByGroupId);
+  });
+
+  it("renders the inline opener (not a blank screen) for an empty pane", () => {
+    // A non-null root whose only pane holds no tiles - the user closed the last
+    // tab. selectMobileTile returns null; the view must still offer an
+    // affordance, not a dead-end.
+    seed({
+      root: makePane("pane-A", [], null),
+      activePaneId: "pane-A",
+      tilesByInstanceId: {},
+      sizesByGroupId: {},
+    });
+    renderView();
+    expect(screen.queryByTestId("pane-opener")).not.toBeNull();
+    expect(renderedTileCount()).toBe(0);
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/__tests__/use-mobile-epic-tiles.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/use-mobile-epic-tiles.test.tsx
@@ -1,0 +1,126 @@
+import "../../../../__tests__/test-browser-apis";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useMobileEpicTiles } from "@/components/epic-canvas/mobile/use-mobile-epic-tiles";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { collectPanes, findPaneById } from "@/stores/epics/canvas/tile-tree";
+import type {
+  EpicCanvasState,
+  EpicCanvasTileRef,
+  TileGroup,
+  TileLayoutNode,
+  TilePane,
+} from "@/stores/epics/canvas/types";
+
+const VIEW_TAB_ID = "view-tab-1";
+
+function spec(n: number): EpicCanvasTileRef {
+  return {
+    id: `spec-${n}`,
+    instanceId: `inst-${n}`,
+    type: "spec",
+    name: `Spec ${n}`,
+    hostId: "host-A",
+  };
+}
+
+function makePane(
+  id: string,
+  tiles: ReadonlyArray<EpicCanvasTileRef>,
+  activeTabId: string,
+): TilePane {
+  return {
+    kind: "pane",
+    id,
+    tabInstanceIds: tiles.map((tile) => tile.instanceId),
+    activeTabId,
+    previewTabId: null,
+    activationHistory: [activeTabId],
+  };
+}
+
+function twoPaneCanvas(activePaneId: string): EpicCanvasState {
+  const root: TileGroup = {
+    kind: "group",
+    id: "root-group",
+    direction: "horizontal",
+    children: [
+      makePane("pane-A", [spec(1), spec(2)], "inst-1"),
+      makePane("pane-B", [spec(3)], "inst-3"),
+    ],
+  };
+  return {
+    root,
+    activePaneId,
+    tilesByInstanceId: {
+      "inst-1": spec(1),
+      "inst-2": spec(2),
+      "inst-3": spec(3),
+    },
+    sizesByGroupId: { "root-group": [0.5, 0.5] },
+  };
+}
+
+function seed(canvas: EpicCanvasState): void {
+  useEpicCanvasStore.setState({
+    tabsById: {
+      [VIEW_TAB_ID]: { tabId: VIEW_TAB_ID, epicId: "epic-1", name: "Epic 1" },
+    },
+    canvasByTabId: { [VIEW_TAB_ID]: canvas },
+  });
+}
+
+function paneIds(root: TileLayoutNode | null): ReadonlyArray<string> {
+  return collectPanes(root).map((pane) => pane.id);
+}
+
+describe("useMobileEpicTiles", () => {
+  afterEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  });
+
+  it("lists every tile across panes in tree order with the current one flagged", () => {
+    seed(twoPaneCanvas("pane-A"));
+    const { result } = renderHook(() => useMobileEpicTiles(VIEW_TAB_ID));
+    expect(result.current.tiles.map((tile) => tile.instanceId)).toEqual([
+      "inst-1",
+      "inst-2",
+      "inst-3",
+    ]);
+    expect(result.current.tiles.map((tile) => tile.paneId)).toEqual([
+      "pane-A",
+      "pane-A",
+      "pane-B",
+    ]);
+    expect(result.current.currentInstanceId).toBe("inst-1");
+  });
+
+  it("tracks the active pane for currentInstanceId", () => {
+    seed(twoPaneCanvas("pane-B"));
+    const { result } = renderHook(() => useMobileEpicTiles(VIEW_TAB_ID));
+    expect(result.current.currentInstanceId).toBe("inst-3");
+  });
+
+  it("selectTile switches activation but leaves the split layout intact", () => {
+    seed(twoPaneCanvas("pane-A"));
+    const before = useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID];
+    const { result } = renderHook(() => useMobileEpicTiles(VIEW_TAB_ID));
+
+    act(() => {
+      result.current.selectTile("pane-B", "inst-3");
+    });
+
+    const after = useEpicCanvasStore.getState().canvasByTabId[VIEW_TAB_ID];
+    // Activation moved to the picked tile...
+    expect(after?.activePaneId).toBe("pane-B");
+    expect(findPaneById(after?.root ?? null, "pane-B")?.activeTabId).toBe(
+      "inst-3",
+    );
+    expect(result.current.currentInstanceId).toBe("inst-3");
+    // ...but the split STRUCTURE and sizes are unchanged (activation-only).
+    expect(after?.root?.kind).toBe("group");
+    expect(paneIds(after?.root ?? null)).toEqual(["pane-A", "pane-B"]);
+    expect(after?.sizesByGroupId).toEqual(before?.sizesByGroupId);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-group-view.tsx
@@ -419,7 +419,7 @@ export const TabGroupView = memo(function TabGroupView(
   );
 });
 
-interface ActiveTabBodyProps {
+export interface ActiveTabBodyProps {
   readonly activeTab: EpicCanvasTileRef;
   readonly epicId: string;
   readonly groupId: string;
@@ -428,7 +428,14 @@ interface ActiveTabBodyProps {
   readonly globallyActive: boolean;
 }
 
-function ActiveTabBody(props: ActiveTabBodyProps) {
+/**
+ * Renders one tile body with the desktop remote-deleted guard and `isActive`
+ * computation. Exported so the mobile single-tile view
+ * (`epic-canvas/mobile/mobile-epic-tile-view.tsx`) renders the selected tile
+ * through the identical logic instead of duplicating the deleted-guard and the
+ * `role && selected && globallyActive` derivation.
+ */
+export function ActiveTabBody(props: ActiveTabBodyProps) {
   const { activeTab, epicId, groupId, tabId } = props;
   const navigateNested = useEpicNestedFocusNavigation();
   const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(

--- a/clients/gui-app/src/components/epic-canvas/canvas/tab-strip.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tab-strip.tsx
@@ -899,7 +899,13 @@ function TabStripEndDropIndicator(props: { readonly visible: boolean }) {
   );
 }
 
-function TabIcon(props: {
+/**
+ * Live tile icon (chat progress spinner / harness brand / static kind glyph,
+ * with diff + blank fallbacks). Exported so the mobile current-tile bar
+ * (`epic-canvas/mobile/mobile-current-tile-bar.tsx`) renders the identical icon
+ * as the desktop tab strip instead of duplicating the dispatch.
+ */
+export function TabIcon(props: {
   readonly epicId: string;
   readonly tab: EpicCanvasTileRef;
   readonly titleGenerationPending: boolean;

--- a/clients/gui-app/src/components/epic-canvas/canvas/tile-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tile-canvas.tsx
@@ -24,6 +24,8 @@ import { CanvasSkeleton } from "@/components/epic-canvas/skeletons/canvas-skelet
 import { TabGroupView } from "@/components/epic-canvas/canvas/tab-group-view";
 import { EpicCanvasDragInteractionShield } from "@/components/epic-canvas/dnd/drag-interaction-shield";
 import { useEmptyShellDropActive } from "@/components/epic-canvas/dnd/dnd-store";
+import { MobileEpicTileView } from "@/components/epic-canvas/mobile/mobile-epic-tile-view";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
 
 interface TileCanvasPaneContextValue {
   readonly epicId: string;
@@ -119,6 +121,7 @@ function TileCanvasLive(
   );
   const resizeSplitInTab = useEpicCanvasStore((s) => s.resizeSplitInTab);
   const hasRecords = useEpicHasArtifactRecords();
+  const isMobile = useIsMobile();
 
   const onResizeGroup = useCallback(
     (groupId: string, sizes: ReadonlyArray<number>) => {
@@ -139,6 +142,14 @@ function TileCanvasLive(
       return <EmptyEpicBlankRoot tabId={tabId} />;
     }
     return <EmptyShell epicId={epicId} tabId={tabId} />;
+  }
+  // Below the mobile breakpoint an open epic shows exactly ONE tile
+  // full-screen instead of the recursively-splitting canvas. The split tree is
+  // read but never mutated, so the persisted desktop layout is unchanged on
+  // return. Desktop (>=768px) falls through to the SplitContainer path below,
+  // which stays byte-for-byte identical.
+  if (isMobile) {
+    return <MobileEpicTileView epicId={epicId} tabId={tabId} />;
   }
   return (
     <TileCanvasPaneContext.Provider value={paneContext}>

--- a/clients/gui-app/src/components/epic-canvas/epic-route-session-body.tsx
+++ b/clients/gui-app/src/components/epic-canvas/epic-route-session-body.tsx
@@ -1,5 +1,6 @@
 import { EpicMigrationModal } from "@/components/epic-canvas/dialogs/epic-migration-modal";
 import { EpicShell } from "@/components/epic-canvas/epic-shell";
+import { MobileEpicHeaderActionsBinder } from "@/components/epic-canvas/mobile/epic-mobile-header-menu";
 import { useInitialChatHandoff } from "@/components/epic-canvas/hooks/use-initial-chat-handoff";
 import { useEpicRouteSynchronization } from "@/components/epic-canvas/hooks/use-epic-route-synchronization";
 import { NewConversationModalHost } from "@/components/epic-canvas/sidebar/new-conversation-modal";
@@ -53,6 +54,9 @@ function EpicRouteActiveEffects(props: EpicRouteSessionBodyProps) {
     <>
       <EpicMigrationModal tabId={props.tabId} />
       <NewConversationModalHost epicId={props.epicId} tabId={props.tabId} />
+      {/* Fills the mobile header's right-actions slot (⋮ New chat / Rename) for
+          the active epic; self-gates on mobile, so desktop renders nothing. */}
+      <MobileEpicHeaderActionsBinder epicId={props.epicId} tabId={props.tabId} />
     </>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/epic-shell.tsx
+++ b/clients/gui-app/src/components/epic-canvas/epic-shell.tsx
@@ -89,7 +89,9 @@ function EpicShellStatusRow(props: EpicShellStatusRowProps) {
   return (
     <output
       data-testid="epic-shell-status-row"
-      className="flex h-10 shrink-0 items-center justify-end gap-3 px-3 text-foreground"
+      // The phone single-tile design has no status row; the global mobile
+      // header carries app-wide status instead. Desktop (>=768px) is unchanged.
+      className="flex h-10 shrink-0 items-center justify-end gap-3 px-3 text-foreground max-md:hidden"
     >
       {props.snapshotLoaded ? <EpicConnectionPill /> : null}
     </output>

--- a/clients/gui-app/src/components/epic-canvas/mobile/epic-mobile-header-menu.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/epic-mobile-header-menu.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState, type SyntheticEvent } from "react";
+import { EllipsisVertical } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
+import { useMobileHeaderStore } from "@/stores/layout/mobile-header-store";
+import {
+  useRegisteredEpicPermissionRole,
+  useRegisteredEpicTitle,
+} from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
+import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
+import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
+import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
+import { useEpicUpdateTitle } from "@/hooks/epic/use-epic-title-mutation";
+
+interface EpicHeaderIdentity {
+  readonly epicId: string;
+  readonly tabId: string;
+}
+
+/**
+ * Fills Phase 0's mobile-header right-actions slot on the epic route with a "⋮"
+ * overflow menu: **New chat** and **Rename** (the two settled actions).
+ *
+ * Rendered by `MobileAppHeader` (inside the app provider stack, OUTSIDE the
+ * epic session tree), so it derives epic state from app-global registries keyed
+ * on `epicId` - never epic-session React context. The stored element only
+ * closes over the stable route ids; everything volatile (title, permission,
+ * mutation) is read from hooks here, so there is no stale closure. See
+ * {@link MobileEpicHeaderActionsBinder} for why this stays a `ReactNode` slot.
+ */
+export function EpicMobileHeaderMenu(props: EpicHeaderIdentity) {
+  const { epicId, tabId } = props;
+  const role = useRegisteredEpicPermissionRole(epicId);
+  const canRename = isEditableRole(role);
+  const [renameOpen, setRenameOpen] = useState(false);
+
+  const handleNewChat = () => {
+    // The exact desktop funnel (see NewConversationModalAction): force chat
+    // mode, then open the shared New Conversation modal request for this epic.
+    // NewConversationModalHost (mounted on the active epic route) renders it.
+    useNewConversationModalStore.getState().setComposerMode(epicId, "chat");
+    useNewConversationModalOpenStore.getState().open({
+      epicId,
+      tabId,
+      placement: ACTIVE_TILE_PLACEMENT,
+      parentId: null,
+    });
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Epic actions"
+            data-testid="mobile-epic-actions-trigger"
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <EllipsisVertical className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={handleNewChat}>New chat</DropdownMenuItem>
+          {canRename ? (
+            <DropdownMenuItem onSelect={() => setRenameOpen(true)}>
+              Rename
+            </DropdownMenuItem>
+          ) : null}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <EpicRenameDialog
+        epicId={epicId}
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+      />
+    </>
+  );
+}
+
+interface EpicRenameDialogProps {
+  readonly epicId: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+function EpicRenameDialog(props: EpicRenameDialogProps) {
+  const { epicId, open, onOpenChange } = props;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(92vw,28rem)] max-w-[min(92vw,28rem)]">
+        <DialogHeader>
+          <DialogTitle>Rename epic</DialogTitle>
+          <DialogDescription>Give this epic a new name.</DialogDescription>
+        </DialogHeader>
+        {/* Mounted only while open (Radix unmounts closed content), so the form
+            re-seeds from the current title on every open without an effect. */}
+        {open ? (
+          <EpicRenameForm epicId={epicId} onDone={() => onOpenChange(false)} />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EpicRenameForm(props: {
+  readonly epicId: string;
+  readonly onDone: () => void;
+}) {
+  const { epicId, onDone } = props;
+  const currentTitle = useRegisteredEpicTitle(epicId) ?? "";
+  const [value, setValue] = useState(currentTitle);
+  const updateTitle = useEpicUpdateTitle();
+  const trimmed = value.trim();
+  const canSubmit = trimmed.length > 0 && !updateTitle.isPending;
+
+  const handleSubmit = (event: SyntheticEvent) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    // Reuse the canonical epic-rename mutation. The active epic route's
+    // title sync (use-epic-route-synchronization) mirrors the resulting epic
+    // title into the header title, so no separate tab-name write is needed.
+    updateTitle.mutate(
+      { epicDelta: { id: epicId, title: trimmed, updatedAt: Date.now() } },
+      { onSuccess: () => onDone() },
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {/* Radix Dialog moves focus to the first focusable element (this input)
+          on open, so no autoFocus prop is needed. */}
+      <Input
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        aria-label="Epic title"
+        data-testid="mobile-epic-rename-input"
+      />
+      <DialogFooter>
+        <Button type="button" variant="ghost" onClick={onDone}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          disabled={!canSubmit}
+          data-testid="mobile-epic-rename-save"
+        >
+          Save
+          {updateTitle.isPending ? (
+            <AgentSpinningDots
+              className="size-3.5"
+              testId="mobile-epic-rename-pending"
+              variant="dots2"
+            />
+          ) : null}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+/**
+ * Fills / clears the mobile-header right-actions slot for the ACTIVE epic
+ * route. Mounted once (from the active epic's route effects), self-gated on
+ * `useIsMobile()`. The slot stores a `ReactNode` element (Phase 0 shape kept):
+ * this is safe because the element is a self-contained component keyed only on
+ * the stable `{epicId, tabId}` route ids - it re-reads volatile state from its
+ * own hooks each header render, so nothing goes stale. A render-fn slot would
+ * be isomorphic (a fn returning the same element) but a larger store change; a
+ * baked-in menu that closed over epic-session handlers WOULD go stale, which is
+ * exactly what this shape avoids.
+ */
+export function MobileEpicHeaderActionsBinder(props: EpicHeaderIdentity) {
+  const { epicId, tabId } = props;
+  const isMobile = useIsMobile();
+  const setRightActions = useMobileHeaderStore((s) => s.setRightActions);
+
+  useEffect(() => {
+    if (!isMobile) return;
+    setRightActions(<EpicMobileHeaderMenu epicId={epicId} tabId={tabId} />);
+    return () => setRightActions(null);
+  }, [isMobile, epicId, tabId, setRightActions]);
+
+  return null;
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/epic-mobile-header-menu.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/epic-mobile-header-menu.tsx
@@ -44,11 +44,24 @@ interface EpicHeaderIdentity {
  * closes over the stable route ids; everything volatile (title, permission,
  * mutation) is read from hooks here, so there is no stale closure. See
  * {@link MobileEpicHeaderActionsBinder} for why this stays a `ReactNode` slot.
+ *
+ * Both actions require edit rights: New chat mirrors the desktop sidebar's
+ * `canMutate` editable gate (`epic-sidebar-chat-tree.tsx` - a viewer's create is
+ * server-rejected, so an ungated item would open a dead-end modal), and Rename
+ * is likewise editor-only. A viewer therefore has no actions, so the whole
+ * trigger is hidden (no empty menu). The role reads through
+ * `useRegisteredEpicPermissionRole` + `isEditableRole` - the same predicate on
+ * the same permission the sidebar uses, via the header-safe registry accessor
+ * (not a parallel check). The transient `!isDisconnected` half of desktop's
+ * `canMutate` is intentionally not mirrored - there is no app-global connection
+ * accessor to read without inventing a parallel check, and a disconnected
+ * editor only hits the modal's own submit gate (self-heals on reconnect), not a
+ * permanent dead-end.
  */
 export function EpicMobileHeaderMenu(props: EpicHeaderIdentity) {
   const { epicId, tabId } = props;
   const role = useRegisteredEpicPermissionRole(epicId);
-  const canRename = isEditableRole(role);
+  const canEdit = isEditableRole(role);
   const [renameOpen, setRenameOpen] = useState(false);
 
   const handleNewChat = () => {
@@ -63,6 +76,10 @@ export function EpicMobileHeaderMenu(props: EpicHeaderIdentity) {
       parentId: null,
     });
   };
+
+  // No editable action for a viewer -> no trigger at all (avoids an empty menu
+  // and the viewer new-chat dead-end).
+  if (!canEdit) return null;
 
   return (
     <>
@@ -81,11 +98,9 @@ export function EpicMobileHeaderMenu(props: EpicHeaderIdentity) {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem onSelect={handleNewChat}>New chat</DropdownMenuItem>
-          {canRename ? (
-            <DropdownMenuItem onSelect={() => setRenameOpen(true)}>
-              Rename
-            </DropdownMenuItem>
-          ) : null}
+          <DropdownMenuItem onSelect={() => setRenameOpen(true)}>
+            Rename
+          </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
       <EpicRenameDialog

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-current-tile-bar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-current-tile-bar.tsx
@@ -1,0 +1,72 @@
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { TabIcon } from "@/components/epic-canvas/canvas/tab-strip";
+import "@/components/layout/shell/mobile-shell-touch-targets.css";
+import {
+  useEpicTabDisplayTitle,
+  useEpicLiveArtifactTitleGenerating,
+} from "@/lib/epic-selectors";
+import { useHostClientForHostId } from "@/hooks/host/use-host-client-for-host-id";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+
+interface MobileCurrentTileBarProps {
+  readonly epicId: string;
+  readonly tile: EpicCanvasTileRef;
+  readonly onOpenSwitcher: () => void;
+}
+
+/**
+ * Slim bar under the mobile header showing the current tile (live icon +
+ * display title) with a chevron. Tapping it opens the "Switch tab" bottom
+ * sheet - Phase 2 owns the sheet; Phase 1 wires the affordance to
+ * `onOpenSwitcher`.
+ *
+ * Icon + title reuse the exact desktop tab-strip resolution (`TabIcon`,
+ * `useEpicTabDisplayTitle`), including the terminal bound-host client so a
+ * terminal tab shows its live host title rather than the stored name.
+ */
+export function MobileCurrentTileBar(props: MobileCurrentTileBarProps) {
+  const { epicId, tile, onOpenSwitcher } = props;
+  const isTerminal = tile.type === "terminal";
+  // Terminal titles resolve against the tab's bound host; `null` for every
+  // other kind (mirrors the tab strip). `useHostClientForHostId(null)` returns
+  // the DEFAULT client, so the non-terminal branch must pass null explicitly.
+  const resolvedHostClient = useHostClientForHostId(
+    isTerminal ? tile.hostId : null,
+  );
+  const terminalHostClient = isTerminal ? resolvedHostClient : null;
+  const displayTitle = useEpicTabDisplayTitle(
+    { id: tile.id, name: tile.name, type: tile.type },
+    epicId,
+    terminalHostClient,
+  );
+  const titleGenerationPending = useEpicLiveArtifactTitleGenerating(
+    tile.type === "chat" ? tile.id : null,
+  );
+
+  return (
+    <div
+      data-mobile-shell-touch-scope=""
+      className="shrink-0 border-b border-canvas-border/70 bg-canvas"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={onOpenSwitcher}
+        data-testid="mobile-current-tile-bar"
+        aria-label={`Switch tab. Current tab: ${displayTitle}`}
+        className="flex min-h-11 w-full items-center justify-start gap-2 rounded-none px-3 text-left"
+      >
+        <TabIcon
+          epicId={epicId}
+          tab={tile}
+          titleGenerationPending={titleGenerationPending}
+        />
+        <span className="min-w-0 flex-1 truncate text-ui-sm font-medium text-foreground">
+          {displayTitle}
+        </span>
+        <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+      </Button>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
@@ -1,8 +1,12 @@
 import { useMemo } from "react";
 import { ActiveTabBody } from "@/components/epic-canvas/canvas/tab-group-view";
 import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body-selected-context";
+import { PaneOpener } from "@/components/epic-canvas/canvas/pane-opener";
 import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
-import { useEpicCanvas, useIsActivePane } from "@/stores/epics/canvas/store";
+import { usePaneVisible } from "@/components/epic-tabs/pane-visibility-context";
+import { useEpicCanvas } from "@/stores/epics/canvas/store";
+import { firstPaneId } from "@/stores/epics/canvas/tile-tree";
+import type { TileLayoutNode } from "@/stores/epics/canvas/types";
 
 interface MobileEpicTileViewProps {
   readonly epicId: string;
@@ -32,12 +36,14 @@ export function MobileEpicTileView(props: MobileEpicTileViewProps) {
   const { epicId, tabId } = props;
   const canvas = useEpicCanvas(tabId);
   const selection = useMemo(() => selectMobileTile(canvas), [canvas]);
-  // Match the desktop `globallyActive` signal for this tile so `isActive`
-  // (focused-composer registration) is computed identically; `""` is a
-  // no-match sentinel that resolves to `false` while there is no selection.
-  const globallyActive = useIsActivePane(tabId, selection?.paneId ?? "");
 
-  if (selection === null) return null;
+  // Non-null root with no resolvable tile = an empty pane (e.g. the user closed
+  // the last tab). Desktop renders the inline `PaneOpener` for this; do the
+  // same on mobile instead of a blank dead-end. `PaneOpener` is fully fluid
+  // (flex column, no fixed widths), so it is usable at phone width as-is.
+  if (selection === null) {
+    return <MobileEmptyEpicPane epicId={epicId} tabId={tabId} root={canvas.root} />;
+  }
 
   return (
     <div
@@ -52,10 +58,43 @@ export function MobileEpicTileView(props: MobileEpicTileViewProps) {
             groupId={selection.paneId}
             tabId={tabId}
             selected
-            globallyActive={globallyActive}
+            // The single visible mobile tile IS the epic's active surface, so
+            // it is always globally active (drives focused-composer
+            // registration). Unlike desktop it is not gated on `activePaneId`,
+            // which can lag the shown tile in the fallback-pane case. This is a
+            // pure render prop - no store write - so flipping back to desktop
+            // re-derives activation from the real `activePaneId`.
+            globallyActive
           />
         </TabBodySelectedContext.Provider>
       </div>
+    </div>
+  );
+}
+
+interface MobileEmptyEpicPaneProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly root: TileLayoutNode | null;
+}
+
+function MobileEmptyEpicPane(props: MobileEmptyEpicPaneProps) {
+  const { epicId, tabId, root } = props;
+  const paneVisible = usePaneVisible();
+  // Defensive: this component is only reached with a non-null root (the mobile
+  // branch in TileCanvasLive gates on it), but guard rather than assert.
+  if (root === null) return null;
+  return (
+    <div
+      className="flex h-full min-h-0 w-full flex-col bg-canvas"
+      data-testid="mobile-epic-empty-pane"
+    >
+      <PaneOpener
+        epicId={epicId}
+        tabId={tabId}
+        groupId={firstPaneId(root)}
+        active={paneVisible}
+      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+import { ActiveTabBody } from "@/components/epic-canvas/canvas/tab-group-view";
+import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body-selected-context";
+import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
+import { useEpicCanvas, useIsActivePane } from "@/stores/epics/canvas/store";
+
+interface MobileEpicTileViewProps {
+  readonly epicId: string;
+  readonly tabId: string;
+}
+
+/**
+ * Phone (<768px) epic view: renders exactly ONE canvas tile full-screen in
+ * place of the desktop split canvas. Mounted only from the `useIsMobile()`
+ * branch in `TileCanvasLive` (non-null root), so the desktop tiling layer is
+ * never built here. The tile is chosen by {@link selectMobileTile}, which reads
+ * but never writes the split tree.
+ *
+ * The selected tile renders through the shared `ActiveTabBody` (identical
+ * remote-deleted guard + `isActive` derivation as the desktop tab group),
+ * wrapped in `TabBodySelectedContext value` because it is the one shown
+ * surface. Pane visibility still comes from `EpicTabHost`, so a hidden
+ * keep-alive epic pane stays non-visible.
+ *
+ * v1 keep-alive tradeoff (user-approved): only the current tile mounts, so
+ * switching tiles remounts the body - chat scroll position and terminal
+ * scrollback reset, though the host PTY session itself survives. A later
+ * iteration can mount hidden sibling layers like `TabGroupView` if per-tile
+ * view state must persist across switches.
+ */
+export function MobileEpicTileView(props: MobileEpicTileViewProps) {
+  const { epicId, tabId } = props;
+  const canvas = useEpicCanvas(tabId);
+  const selection = useMemo(() => selectMobileTile(canvas), [canvas]);
+  // Match the desktop `globallyActive` signal for this tile so `isActive`
+  // (focused-composer registration) is computed identically; `""` is a
+  // no-match sentinel that resolves to `false` while there is no selection.
+  const globallyActive = useIsActivePane(tabId, selection?.paneId ?? "");
+
+  if (selection === null) return null;
+
+  return (
+    <div
+      className="flex h-full min-h-0 w-full flex-col bg-canvas"
+      data-testid="mobile-epic-tile-view"
+    >
+      <div className="relative min-h-0 flex-1">
+        <TabBodySelectedContext.Provider value>
+          <ActiveTabBody
+            activeTab={selection.ref}
+            epicId={epicId}
+            groupId={selection.paneId}
+            tabId={tabId}
+            selected
+            globallyActive={globallyActive}
+          />
+        </TabBodySelectedContext.Provider>
+      </div>
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { ActiveTabBody } from "@/components/epic-canvas/canvas/tab-group-view";
 import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body-selected-context";
 import { PaneOpener } from "@/components/epic-canvas/canvas/pane-opener";
+import { MobileCurrentTileBar } from "@/components/epic-canvas/mobile/mobile-current-tile-bar";
 import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
 import { usePaneVisible } from "@/components/epic-tabs/pane-visibility-context";
 import { useEpicCanvas } from "@/stores/epics/canvas/store";
@@ -36,6 +37,11 @@ export function MobileEpicTileView(props: MobileEpicTileViewProps) {
   const { epicId, tabId } = props;
   const canvas = useEpicCanvas(tabId);
   const selection = useMemo(() => selectMobileTile(canvas), [canvas]);
+  // Phase-1 placeholder: Phase 2 replaces this no-op with opening the "Switch
+  // tab" bottom sheet (which consumes `useMobileEpicTiles(tabId)` for the tile
+  // list + `selectTile`). Wired now so the bar's affordance and tap target ship
+  // in Phase 1.
+  const handleOpenSwitcher = useCallback(() => undefined, []);
 
   // Non-null root with no resolvable tile = an empty pane (e.g. the user closed
   // the last tab). Desktop renders the inline `PaneOpener` for this; do the
@@ -50,6 +56,11 @@ export function MobileEpicTileView(props: MobileEpicTileViewProps) {
       className="flex h-full min-h-0 w-full flex-col bg-canvas"
       data-testid="mobile-epic-tile-view"
     >
+      <MobileCurrentTileBar
+        epicId={epicId}
+        tile={selection.ref}
+        onOpenSwitcher={handleOpenSwitcher}
+      />
       <div className="relative min-h-0 flex-1">
         <TabBodySelectedContext.Provider value>
           <ActiveTabBody

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-tile-selection.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-tile-selection.ts
@@ -11,6 +11,33 @@ export interface MobileTileSelection {
   readonly ref: EpicCanvasTileRef;
 }
 
+export interface MobileEpicTile {
+  readonly paneId: string;
+  readonly instanceId: string;
+  readonly ref: EpicCanvasTileRef;
+}
+
+const EMPTY_TILES: ReadonlyArray<MobileEpicTile> = [];
+
+/**
+ * Every open tile across every pane, in tree order, as
+ * `{ paneId, instanceId, ref }`. InstanceIds with no resolved payload are
+ * skipped. Read-only - the Phase-2 "Switch tab" sheet and the current-tile bar
+ * list from this.
+ */
+export function flattenMobileTiles(
+  canvas: EpicCanvasState,
+): ReadonlyArray<MobileEpicTile> {
+  const { root, tilesByInstanceId } = canvas;
+  if (root === null) return EMPTY_TILES;
+  return collectPanes(root).flatMap((pane) =>
+    pane.tabInstanceIds.flatMap((instanceId) => {
+      const ref = tilesByInstanceId[instanceId];
+      return ref === undefined ? [] : [{ paneId: pane.id, instanceId, ref }];
+    }),
+  );
+}
+
 /**
  * Deterministic "the one tile to show on mobile" rule. Read-only: it inspects
  * `activePaneId` / `root` / `tilesByInstanceId` and NEVER writes `root` or

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-tile-selection.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-tile-selection.ts
@@ -1,0 +1,57 @@
+import { collectPanes, findPaneById } from "@/stores/epics/canvas/tile-tree";
+import type {
+  EpicCanvasState,
+  EpicCanvasTileRef,
+  TilePane,
+  TilesByInstanceId,
+} from "@/stores/epics/canvas/types";
+
+export interface MobileTileSelection {
+  readonly paneId: string;
+  readonly ref: EpicCanvasTileRef;
+}
+
+/**
+ * Deterministic "the one tile to show on mobile" rule. Read-only: it inspects
+ * `activePaneId` / `root` / `tilesByInstanceId` and NEVER writes `root` or
+ * `sizesByGroupId`, so viewing an epic on a phone leaves the persisted desktop
+ * split layout untouched.
+ *
+ * Rule: the active pane's active tab, else the first pane's active tab, else
+ * that pane's first tab instance. Panes are walked in tree order (active pane
+ * first) and the first one that still resolves a live tile wins, so an emptied
+ * active pane still yields a tile instead of a blank screen.
+ */
+export function selectMobileTile(
+  canvas: EpicCanvasState,
+): MobileTileSelection | null {
+  const { root, activePaneId, tilesByInstanceId } = canvas;
+  if (root === null) return null;
+  const orderedPanes = collectPanes(root);
+  const activePane =
+    activePaneId === null ? null : findPaneById(root, activePaneId);
+  const candidatePanes =
+    activePane === null
+      ? orderedPanes
+      : [
+          activePane,
+          ...orderedPanes.filter((pane) => pane.id !== activePane.id),
+        ];
+  for (const pane of candidatePanes) {
+    const instanceId = resolvePaneTileInstanceId(pane, tilesByInstanceId);
+    if (instanceId === null) continue;
+    const ref = tilesByInstanceId[instanceId];
+    if (ref !== undefined) return { paneId: pane.id, ref };
+  }
+  return null;
+}
+
+function resolvePaneTileInstanceId(
+  pane: TilePane,
+  tiles: TilesByInstanceId,
+): string | null {
+  if (pane.activeTabId !== null && tiles[pane.activeTabId] !== undefined) {
+    return pane.activeTabId;
+  }
+  return pane.tabInstanceIds.find((id) => tiles[id] !== undefined) ?? null;
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/use-mobile-epic-tiles.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/use-mobile-epic-tiles.ts
@@ -1,0 +1,68 @@
+import { useCallback, useMemo } from "react";
+import {
+  flattenMobileTiles,
+  selectMobileTile,
+  type MobileEpicTile,
+} from "@/components/epic-canvas/mobile/mobile-tile-selection";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { useEpicCanvas, useEpicCanvasStore } from "@/stores/epics/canvas/store";
+
+export interface MobileEpicTilesApi {
+  /** Every open tile across every pane, in tree order. */
+  readonly tiles: ReadonlyArray<MobileEpicTile>;
+  /** The instanceId of the tile currently shown full-screen, or null. */
+  readonly currentInstanceId: string | null;
+  /** Switch the shown tile to `{ paneId, instanceId }`. */
+  readonly selectTile: (paneId: string, instanceId: string) => void;
+}
+
+/**
+ * Tile-switch contract for the mobile epic view. The current-tile bar and
+ * Phase 2's "Switch tab" bottom sheet both read `tiles` + `currentInstanceId`
+ * and switch via `selectTile` from here, so there is one source of truth for
+ * "which tiles exist and which is current".
+ *
+ * `currentInstanceId` is derived from the SAME {@link selectMobileTile} rule
+ * that `MobileEpicTileView` renders, so the bar/sheet highlight always matches
+ * the tile on screen.
+ */
+export function useMobileEpicTiles(tabId: string): MobileEpicTilesApi {
+  const canvas = useEpicCanvas(tabId);
+  const epicId = useEpicCanvasStore((s) => s.tabsById[tabId]?.epicId ?? null);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareSetActiveTileTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareSetActiveTileTabFocusTarget,
+  );
+
+  const tiles = useMemo(() => flattenMobileTiles(canvas), [canvas]);
+  const currentInstanceId = useMemo(
+    () => selectMobileTile(canvas)?.ref.instanceId ?? null,
+    [canvas],
+  );
+
+  const selectTile = useCallback(
+    (paneId: string, instanceId: string) => {
+      // Reuse desktop tab-selection exactly (same call TabGroupView makes):
+      // `setActiveTab` sets the pane's active tab AND makes that pane the
+      // globally-active one, and `navigateNested` commits the resulting focus
+      // to the route. Accepted tradeoff (user-approved): this moves desktop's
+      // active pane/tab too, so a tile picked on a phone is where the desktop
+      // reopens ("resume where you left off"). It writes activation only - the
+      // split-tree shape and `sizesByGroupId` are never touched, so the
+      // persisted desktop layout is unchanged.
+      const prepare = () =>
+        prepareSetActiveTileTabFocusTarget(tabId, paneId, instanceId);
+      if (epicId === null) {
+        prepare();
+        return;
+      }
+      navigateNested(epicId, tabId, prepare);
+    },
+    [epicId, navigateNested, prepareSetActiveTileTabFocusTarget, tabId],
+  );
+
+  return useMemo(
+    () => ({ tiles, currentInstanceId, selectTile }),
+    [tiles, currentInstanceId, selectTile],
+  );
+}


### PR DESCRIPTION
## Phase 1 of the mobile no-tabs redesign — full-screen epic (chat) view

Second of three stacked phases (Phase 0 = #630, merged). Below 768px an open epic renders **one tile full-screen** instead of the desktop split canvas. **Desktop ≥768px is unchanged** — every change is gated behind `useIsMobile()`/`max-md:` or is a desktop-neutral export/class edit.

### What this adds (mobile only)
- **Single-tile epic view** — `TileCanvasLive` renders a new `MobileEpicTileView` instead of the recursive `SplitContainer`; the desktop tiling layer (splits, resize handles, per-pane tab strip, drag-and-drop) never mounts on phones. The shown tile is the canvas's active pane's active tab, resolved read-only — **the persisted desktop split layout is never written** (test-asserted).
- **Current-tile bar** under the header (tile icon + name + chevron) — the chevron is the Phase 2 bottom-sheet trigger (placeholder here).
- **`useMobileEpicTiles` hook** — the tile-list/switch contract Phase 2 consumes; `selectTile` reuses the exact store call a desktop tab-click makes.
- **Epic header ⋮ menu** (fills Phase 0's header slot): **New chat + Rename**, editor-gated (viewers see no menu).
- **Empty-pane state** renders the existing inline opener (no blank screen); desktop-only status row + transcript minimap hidden on phones.

### Desktop neutrality
Shared-file edits are export-only (`ActiveTabBody`, `TabIcon`) or `max-md:` class trims (`epic-shell.tsx`, `chat-messages.tsx`); the `tile-canvas.tsx` mobile branch is a `useIsMobile()` early return leaving the desktop `SplitContainer` path byte-identical. Everything else is new `mobile/*` code that only mounts on phones.

### Verification
- Independently cold-reviewed (fresh agent) per ticket + a whole-phase pass: SHIP.
- Our Phase 1 tests pass; desktop epic-canvas + chat suites green.
- **Pre-existing CI reds** (duplicate `prosemirror-model` editor/export tests; a flaky desktop `host-lifecycle` test) are unrelated to this change and predate it — same as on `mobile-app`.

### Known v1 tradeoffs (accepted)
Switching tiles remounts (chat scroll resets, terminal scrollback discarded — the host PTY survives); the last tile viewed on mobile becomes desktop's active tab ("resume where you left off").

Phase 2 (bottom-sheet switcher) follows as the next stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)