### PR TITLE
feat(gui-app): mobile bottom-sheet tile switcher (Phase 2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -157,6 +157,7 @@
         "unified": "catalog:",
         "unist-util-visit": "catalog:",
         "uuid": "catalog:",
+        "vaul": "catalog:",
         "wavesurfer.js": "^7.12.11",
         "y-protocols": "catalog:",
         "yjs": "catalog:",
@@ -423,6 +424,7 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "uuid": "^14.0.1",
+    "vaul": "^1.1.2",
     "vite": "^8.1.5",
     "vitest": "^4.1.10",
     "y-protocols": "^1.0.7",
@@ -3613,6 +3615,8 @@
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
+    "vaul": ["vaul@1.1.2", "", { "dependencies": { "@radix-ui/react-dialog": "^1.1.1" }, "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
@@ -3728,6 +3732,7 @@
     "@capacitor/cli/fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
 
     "@capacitor/cli/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
@@ -3782,8 +3787,6 @@
 
     "@eslint/eslintrc/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
-    "@eslint/eslintrc/js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
-
     "@floating-ui/react/@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
@@ -3791,6 +3794,7 @@
     "@ionic/utils-fs/@types/fs-extra": ["@types/fs-extra@8.1.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ=="],
 
     "@ionic/utils-fs/fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
+
     "@lobehub/fluent-emoji/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "@lobehub/fluent-emoji/lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
@@ -3926,8 +3930,6 @@
     "conf/json-schema-typed": ["json-schema-typed@7.0.3", "", {}, "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="],
 
     "conf/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "create-ecdh/bn.js": ["bn.js@4.12.5", "", {}, "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ=="],
 

--- a/clients/gui-app/package.json
+++ b/clients/gui-app/package.json
@@ -103,6 +103,7 @@
     "unified": "catalog:",
     "unist-util-visit": "catalog:",
     "uuid": "catalog:",
+    "vaul": "catalog:",
     "wavesurfer.js": "^7.12.11",
     "y-protocols": "catalog:",
     "yjs": "catalog:",

--- a/clients/gui-app/src/components/epic-canvas/__tests__/mobile-epic-tile-view.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/mobile-epic-tile-view.test.tsx
@@ -50,6 +50,12 @@ vi.mock("@/components/epic-canvas/mobile/mobile-current-tile-bar", () => ({
   ),
 }));
 
+// The bottom-sheet is a leaf of the view but out of this test's scope; it pulls
+// the resolved-theme context (and much more), so stub it to nothing.
+vi.mock("@/components/epic-canvas/mobile/tab-switcher-sheet", () => ({
+  TabSwitcherSheet: () => null,
+}));
+
 function spec(n: number): EpicCanvasTileRef {
   return {
     id: `spec-${n}`,

--- a/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/pane-opener.tsx
@@ -22,6 +22,7 @@ import {
 import { ArrowLeftIcon } from "lucide-react";
 import { Command, CommandInput, CommandList } from "@/components/ui/command";
 import { InputGroupButton } from "@/components/ui/input-group";
+import { isMobileViewport } from "@/hooks/ui/use-mobile";
 import { useCommandPaletteRouter } from "@/components/command-palette/command-palette-context";
 import {
   OpenerRootView,
@@ -56,7 +57,11 @@ export function PaneOpener(props: PaneOpenerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!active) return;
+    // Suppress autofocus on coarse pointers: opening an empty pane on a phone
+    // would otherwise pop the soft keyboard. Desktop (fine pointer) is
+    // unchanged. Command-time read - the opener never re-opens across a
+    // viewport change, so it needs no reactive dependency.
+    if (!active || isMobileViewport()) return;
     const input = containerRef.current?.querySelector<HTMLInputElement>(
       'input[data-slot="command-input"]',
     );

--- a/clients/gui-app/src/components/epic-canvas/canvas/tile-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tile-canvas.tsx
@@ -63,7 +63,7 @@ export function TileCanvas(props: TileCanvasProps) {
   const renderLive = snapshotLoaded || hasActiveHandoff;
   return (
     <div
-      className="canvas-token-scope relative h-full min-h-0 w-full overflow-hidden rounded-t-lg border border-canvas-border/70 bg-canvas text-canvas-foreground"
+      className="canvas-token-scope relative h-full min-h-0 w-full overflow-hidden rounded-t-lg border border-canvas-border/70 bg-canvas text-canvas-foreground max-md:rounded-none max-md:border-0"
       data-testid="tile-canvas"
     >
       <TileCanvasBody

--- a/clients/gui-app/src/components/epic-canvas/epic-shell.tsx
+++ b/clients/gui-app/src/components/epic-canvas/epic-shell.tsx
@@ -113,7 +113,7 @@ function CanvasColumn(props: {
 function LoadingTileCanvas() {
   return (
     <div
-      className="canvas-token-scope relative h-full min-h-0 w-full overflow-hidden rounded-t-lg border border-canvas-border/70 bg-canvas text-canvas-foreground"
+      className="canvas-token-scope relative h-full min-h-0 w-full overflow-hidden rounded-t-lg border border-canvas-border/70 bg-canvas text-canvas-foreground max-md:rounded-none max-md:border-0"
       data-testid="tile-canvas-loading"
     >
       <CanvasSkeleton />

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-create-actions.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-create-actions.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SwitcherNewAgentButton,
+  SwitcherNewArtifactMenu,
+} from "@/components/epic-canvas/mobile/switcher-create-actions";
+
+const spies = vi.hoisted(() => ({
+  setComposerMode: vi.fn(),
+  openModal: vi.fn(),
+  createArtifact: vi.fn(),
+}));
+
+vi.mock("@/stores/epics/new-conversation-modal-store", () => ({
+  useNewConversationModalStore: {
+    getState: () => ({ setComposerMode: spies.setComposerMode }),
+  },
+}));
+vi.mock("@/stores/epics/new-conversation-modal-open-store", () => ({
+  useNewConversationModalOpenStore: {
+    getState: () => ({ open: spies.openModal }),
+  },
+}));
+vi.mock("@/components/epic-canvas/mobile/use-switcher-create-artifact", () => ({
+  useSwitcherCreateArtifact: () => ({
+    create: spies.createArtifact,
+    isPending: false,
+  }),
+}));
+
+beforeEach(() => {
+  spies.setComposerMode.mockClear();
+  spies.openModal.mockClear();
+  spies.createArtifact.mockClear();
+});
+afterEach(cleanup);
+
+describe("<SwitcherNewAgentButton />", () => {
+  it("opens the New Conversation modal (chat mode, active-tile placement) and closes the sheet", () => {
+    const onClose = vi.fn();
+    render(
+      <SwitcherNewAgentButton epicId="epic-1" tabId="tab-1" onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByTestId("switcher-new-agent"));
+    expect(spies.setComposerMode).toHaveBeenCalledWith("epic-1", "chat");
+    expect(spies.openModal).toHaveBeenCalledWith(
+      expect.objectContaining({ epicId: "epic-1", tabId: "tab-1", parentId: null }),
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("<SwitcherNewArtifactMenu />", () => {
+  it("creates the chosen artifact kind through the shared create hook", () => {
+    render(
+      <SwitcherNewArtifactMenu epicId="epic-1" tabId="tab-1" onClose={() => {}} />,
+    );
+    fireEvent.pointerDown(screen.getByTestId("switcher-new-artifact"));
+    fireEvent.click(screen.getByTestId("switcher-new-artifact-spec"));
+    expect(spies.createArtifact).toHaveBeenCalledWith("spec");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -1,0 +1,176 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SwitcherAgentsList } from "@/components/epic-canvas/mobile/switcher-agents-list";
+import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-artifacts-list";
+import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
+
+interface FixtureRecord {
+  readonly id: string;
+  readonly parentId: string | null;
+  readonly name: string;
+  readonly type: string;
+  readonly status: number | null;
+  readonly hostId: string;
+}
+interface FixtureSession {
+  readonly sessionId: string;
+  readonly title: string | null;
+  readonly activeProcessName: string | null;
+  readonly cwd: string;
+}
+interface ActivateCall {
+  readonly id: string;
+  readonly ref: { readonly type: string };
+}
+interface Holder {
+  records: ReadonlyArray<FixtureRecord>;
+  sessions: ReadonlyArray<FixtureSession>;
+  activeId: string | null;
+  role: "owner" | "viewer";
+  activateCalls: ActivateCall[];
+}
+
+const holder = vi.hoisted(
+  (): Holder => ({
+    records: [],
+    sessions: [],
+    activeId: null,
+    role: "owner",
+    activateCalls: [],
+  }),
+);
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useEpicArtifactRecords: () => holder.records,
+  useEpicActiveAgentIds: () => new Set<string>(),
+  useEpicChatHarnessId: () => null,
+  useMaybeEpicTuiAgentHarnessId: () => null,
+  useEpicPermissionRole: () => holder.role,
+}));
+vi.mock("@/stores/epics/canvas/canvas-selectors", () => ({
+  useIsActiveEpicArtifact: (_tabId: string, id: string) => holder.activeId === id,
+  findOpenArtifactInTab: () => null,
+}));
+vi.mock("@/components/epic-canvas/mobile/use-switcher-activate", () => ({
+  useSwitcherActivate:
+    () => (id: string, buildRef: () => { readonly type: string }) => {
+      holder.activateCalls.push({ id, ref: buildRef() });
+    },
+}));
+vi.mock("@/hooks/terminal/use-terminal-list-query", () => ({
+  useTerminalList: () => ({ data: { sessions: holder.sessions } }),
+}));
+vi.mock("@/lib/host", () => ({ useHostClient: () => null }));
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-A",
+}));
+vi.mock("@/lib/terminals/terminal-session-filters", () => ({
+  isVisibleEpicTerminalSession: () => true,
+}));
+// Keep the row menu's mutation + focus hooks inert so it mounts without a
+// QueryClient / host client (the menu's editor gating is what we assert).
+vi.mock("@/hooks/epic/use-epic-chat-mutations", () => ({
+  useEpicRenameChat: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicDeleteChat: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/epic/use-epic-tui-agent-mutations", () => ({
+  useEpicRenameTuiAgent: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicDeleteTuiAgent: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/epic/use-epic-node-mutations", () => ({
+  useEpicDeleteArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+  useEpicRenameArtifact: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/terminal/use-terminal-rename-mutation", () => ({
+  useTerminalRename: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/terminal/use-terminal-kill-mutation", () => ({
+  useTerminalKill: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation: () => vi.fn(),
+}));
+
+const PROPS = { epicId: "epic-1", tabId: "tab-1", onClose: () => {} };
+
+beforeEach(() => {
+  holder.records = [];
+  holder.sessions = [];
+  holder.activeId = null;
+  holder.role = "owner";
+  holder.activateCalls = [];
+});
+afterEach(cleanup);
+
+describe("<SwitcherAgentsList />", () => {
+  beforeEach(() => {
+    holder.records = [
+      { id: "chat-1", parentId: null, name: "Alpha", type: "chat", status: null, hostId: "host-A" },
+      { id: "tui-1", parentId: null, name: "Beta", type: "terminal-agent", status: null, hostId: "host-A" },
+      { id: "spec-1", parentId: null, name: "Spec", type: "spec", status: null, hostId: "host-A" },
+    ];
+  });
+
+  it("renders one row per chat + terminal-agent (artifacts excluded) from the projection", () => {
+    render(<SwitcherAgentsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-agent-row-chat-1").textContent).toContain("Alpha");
+    expect(screen.getByTestId("switcher-agent-row-tui-1").textContent).toContain("Beta");
+    expect(screen.queryByTestId("switcher-agent-row-spec-1")).toBeNull();
+  });
+
+  it("marks the active tile with a check and taps open it (chat ref)", () => {
+    holder.activeId = "chat-1";
+    render(<SwitcherAgentsList {...PROPS} />);
+    const activeRow = screen.getByTestId("switcher-agent-row-chat-1");
+    expect(activeRow.getAttribute("aria-current")).toBe("true");
+    fireEvent.click(activeRow);
+    expect(holder.activateCalls).toHaveLength(1);
+    expect(holder.activateCalls[0].id).toBe("chat-1");
+    expect(holder.activateCalls[0].ref.type).toBe("chat");
+  });
+
+  it("shows the '…' menu for an editor and hides it entirely for a viewer", () => {
+    const editor = render(<SwitcherAgentsList {...PROPS} />);
+    expect(screen.getByTestId("switcher-more-chat-1")).toBeTruthy();
+    editor.unmount();
+
+    holder.role = "viewer";
+    render(<SwitcherAgentsList {...PROPS} />);
+    expect(screen.queryByTestId("switcher-more-chat-1")).toBeNull();
+  });
+});
+
+describe("<SwitcherTerminalsList />", () => {
+  it("renders a row per visible PTY session and taps open a terminal ref", () => {
+    holder.sessions = [
+      { sessionId: "term-1", title: "Build", activeProcessName: null, cwd: "/repo" },
+    ];
+    render(<SwitcherTerminalsList {...PROPS} />);
+    const row = screen.getByTestId("switcher-terminal-row-term-1");
+    expect(row.textContent).toContain("Build");
+    fireEvent.click(row);
+    expect(holder.activateCalls).toHaveLength(1);
+    expect(holder.activateCalls[0].id).toBe("term-1");
+    expect(holder.activateCalls[0].ref.type).toBe("terminal");
+  });
+
+  it("shows an empty state when there are no terminals", () => {
+    render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.getByText("No terminals yet.")).toBeTruthy();
+  });
+});
+
+describe("<SwitcherArtifactsList />", () => {
+  it("renders artifact rows with a status dot for a ticket", () => {
+    holder.records = [
+      { id: "chat-1", parentId: null, name: "Alpha", type: "chat", status: null, hostId: "host-A" },
+      { id: "tk-1", parentId: null, name: "Ticket One", type: "ticket", status: 1, hostId: "host-A" },
+    ];
+    render(<SwitcherArtifactsList {...PROPS} />);
+    // Chats are excluded from the artifacts list.
+    expect(screen.queryByTestId("switcher-artifact-row-chat-1")).toBeNull();
+    const row = screen.getByTestId("switcher-artifact-row-tk-1");
+    expect(row.textContent).toContain("Ticket One");
+    expect(screen.getByTitle("In Progress")).toBeTruthy();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -107,6 +107,21 @@ vi.mock("@/hooks/terminal/use-terminal-kill-mutation", () => ({
 vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
   useEpicNestedFocusNavigation: () => vi.fn(),
 }));
+// Create affordances pull the modal funnel / host pickers; stub them so the
+// list headers render and we can assert editor-gating in isolation.
+vi.mock("@/components/epic-canvas/mobile/switcher-create-actions", () => ({
+  SwitcherNewAgentButton: () => (
+    <button type="button" data-testid="new-agent-action" />
+  ),
+  SwitcherNewArtifactMenu: () => (
+    <button type="button" data-testid="new-artifact-action" />
+  ),
+}));
+vi.mock("@/components/epic-canvas/sidebar/new-terminal-picker", () => ({
+  NewTerminalPicker: () => (
+    <button type="button" data-testid="new-terminal-action" />
+  ),
+}));
 
 const PROPS = { epicId: "epic-1", tabId: "tab-1", onClose: () => {} };
 
@@ -198,5 +213,40 @@ describe("<SwitcherArtifactsList />", () => {
     const row = screen.getByTestId("switcher-artifact-row-tk-1");
     expect(row.textContent).toContain("Ticket One");
     expect(screen.getByTitle("In Progress")).toBeTruthy();
+  });
+});
+
+describe("switcher create affordances (editor-gated)", () => {
+  it("shows New agent for an editor and hides it for a viewer", () => {
+    holder.records = [
+      { id: "chat-1", parentId: null, name: "Alpha", type: "chat", status: null, hostId: "host-A" },
+    ];
+    const editor = render(<SwitcherAgentsList {...PROPS} />);
+    expect(screen.getByTestId("new-agent-action")).toBeTruthy();
+    editor.unmount();
+
+    holder.role = "viewer";
+    render(<SwitcherAgentsList {...PROPS} />);
+    expect(screen.queryByTestId("new-agent-action")).toBeNull();
+  });
+
+  it("shows New terminal for an editor and hides it for a viewer", () => {
+    const editor = render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.getByTestId("new-terminal-action")).toBeTruthy();
+    editor.unmount();
+
+    holder.role = "viewer";
+    render(<SwitcherTerminalsList {...PROPS} />);
+    expect(screen.queryByTestId("new-terminal-action")).toBeNull();
+  });
+
+  it("shows New artifact for an editor and hides it for a viewer", () => {
+    const editor = render(<SwitcherArtifactsList {...PROPS} />);
+    expect(screen.getByTestId("new-artifact-action")).toBeTruthy();
+    editor.unmount();
+
+    holder.role = "viewer";
+    render(<SwitcherArtifactsList {...PROPS} />);
+    expect(screen.queryByTestId("new-artifact-action")).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-lists.test.tsx
@@ -46,6 +46,23 @@ vi.mock("@/lib/epic-selectors", () => ({
   useEpicChatHarnessId: () => null,
   useMaybeEpicTuiAgentHarnessId: () => null,
   useEpicPermissionRole: () => holder.role,
+  // The lists sort by tree-node recency; expose nodes for the fixtures so the
+  // real epic-sort comparator resolves every id.
+  useEpicTreeIndex: () => ({
+    rootIds: [],
+    childrenByParent: {},
+    nodeById: Object.fromEntries(
+      holder.records.map((record, index) => [
+        record.id,
+        {
+          id: record.id,
+          title: record.name,
+          createdAt: index,
+          updatedAt: index,
+        },
+      ]),
+    ),
+  }),
 }));
 vi.mock("@/stores/epics/canvas/canvas-selectors", () => ({
   useIsActiveEpicArtifact: (_tabId: string, id: string) => holder.activeId === id,
@@ -111,11 +128,20 @@ describe("<SwitcherAgentsList />", () => {
     ];
   });
 
-  it("renders one row per chat + terminal-agent (artifacts excluded) from the projection", () => {
+  it("renders chats + terminal-agents interleaved by recency (artifacts excluded)", () => {
     render(<SwitcherAgentsList {...PROPS} />);
     expect(screen.getByTestId("switcher-agent-row-chat-1").textContent).toContain("Alpha");
     expect(screen.getByTestId("switcher-agent-row-tui-1").textContent).toContain("Beta");
     expect(screen.queryByTestId("switcher-agent-row-spec-1")).toBeNull();
+    // tui-1 (updatedAt 1) is more recent than chat-1 (updatedAt 0), so the list
+    // interleaves by recency rather than grouping all chats before agents.
+    const order = Array.from(
+      document.querySelectorAll('[data-testid^="switcher-agent-row-"]'),
+    ).map((row) => row.getAttribute("data-testid"));
+    expect(order).toEqual([
+      "switcher-agent-row-tui-1",
+      "switcher-agent-row-chat-1",
+    ]);
   });
 
   it("marks the active tile with a check and taps open it (chat ref)", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-panel-embed.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/switcher-panel-embed.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SwitcherPanelEmbed } from "@/components/epic-canvas/mobile/switcher-panel-embed";
+
+// Embed, don't fork: the desktop bodies pull host queries + Pierre + the epic
+// session, so stub them at the module boundary and assert the embed routes each
+// category to the right body.
+vi.mock("@/components/epic-canvas/sidebar/epic-sidebar", () => ({
+  FileTreePanelBody: () => <div data-testid="file-tree-body" />,
+}));
+vi.mock("@/components/epic-canvas/git-diff/git-diff-panel-body-live", () => ({
+  GitDiffPanelBodyLive: () => <div data-testid="git-diff-body" />,
+}));
+
+describe("<SwitcherPanelEmbed />", () => {
+  afterEach(cleanup);
+
+  it("embeds the file-tree body for the file-tree category", () => {
+    render(<SwitcherPanelEmbed category="file-tree" epicId="e" tabId="t" />);
+    expect(screen.getByTestId("file-tree-body")).toBeTruthy();
+    expect(screen.queryByTestId("git-diff-body")).toBeNull();
+  });
+
+  it("embeds the git-diff body for the git-diff category", () => {
+    render(<SwitcherPanelEmbed category="git-diff" epicId="e" tabId="t" />);
+    expect(screen.getByTestId("git-diff-body")).toBeTruthy();
+    expect(screen.queryByTestId("file-tree-body")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +12,18 @@ import type {
   TilePane,
   WorkspaceFileRef,
 } from "@/stores/epics/canvas/types";
+
+// Source of the mobile-shell hit-slop CSS the sheet imports (via
+// `data-mobile-shell-touch-scope`), read so the root-fix invariant - the slop
+// `::after` must never paint - is asserted against the real rule; jsdom can't
+// compute a coarse-pointer pseudo-element. Vitest's cwd is the gui-app root.
+const touchTargetsCss = readFileSync(
+  join(
+    process.cwd(),
+    "src/components/layout/shell/mobile-shell-touch-targets.css",
+  ),
+  "utf8",
+);
 
 const mobileState = vi.hoisted(() => ({ value: true }));
 vi.mock("@/hooks/ui/use-mobile", () => ({
@@ -71,13 +85,32 @@ describe("<TabSwitcherSheet />", () => {
     expect(screen.getAllByRole("tab")).toHaveLength(5);
   });
 
-  it("labels the chats category 'Chats' and forces the active tab's fill transparent", () => {
+  it("labels the chats category 'Chats' and renders the active tab as an underline, not a box", () => {
     renderSheet(true, () => {});
     const active = screen.getByRole("tab", { name: "Chats" });
     expect(active.getAttribute("data-state")).toBe("active");
-    // The base `data-active:bg-*` fill is overridden so the active line tab is
-    // underline-only, not a solid box (the live-review defect).
+    // The base `data-active:bg-*` fill is neutralised, so the active line tab
+    // never paints a solid fill behind the label.
     expect(active.className).toContain("data-active:bg-transparent");
+    // The visible active indicator is a collision-free `::before` underline. The
+    // trigger's single `::after` is claimed by the mobile touch hit-slop, so
+    // ui/tabs' `after:bg-foreground` indicator legitimately stays in the class
+    // list (the shared touch CSS neutralises its paint) and is NOT re-overridden
+    // here - re-adding `after:bg-transparent` would be a redundant second
+    // mechanism.
+    expect(active.className).toContain("after:bg-foreground");
+    expect(active.className).toContain("before:bg-foreground");
+    expect(active.className).toContain("data-active:before:opacity-100");
+  });
+
+  it("forces the mobile touch hit-slop ::after transparent so a merged indicator can't box the tab", () => {
+    // Root fix (mobile-shell-touch-targets.css): the hit-slop shares each
+    // trigger's single `::after`; without a transparent background it merges with
+    // ui/tabs' `after:bg-foreground` active indicator and paints a full-cover,
+    // near-white box over the label on touch (coarse-pointer) devices.
+    expect(touchTargetsCss).toMatch(
+      /tabs-trigger"\]\)::after\s*\{[^}]*background:\s*transparent/,
+    );
   });
 
   it("defaults to the Agents category and shows its body", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TabSwitcherSheet } from "@/components/epic-canvas/mobile/tab-switcher-sheet";
 import { useLeftPanelStore } from "@/stores/epics/left-panel-store";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
-import type { EpicArtifactRef, TilePane } from "@/stores/epics/canvas/types";
+import type {
+  EpicArtifactRef,
+  EpicCanvasTileRef,
+  TilePane,
+  WorkspaceFileRef,
+} from "@/stores/epics/canvas/types";
 
 const mobileState = vi.hoisted(() => ({ value: true }));
 vi.mock("@/hooks/ui/use-mobile", () => ({
@@ -94,11 +99,26 @@ function artifactRef(id: string, instanceId: string): EpicArtifactRef {
   return { id, instanceId, type: "spec", name: id, hostId: "host-A" };
 }
 
-function seedCanvasActiveTile(activeTabId: string): void {
+function workspaceFileRef(id: string, instanceId: string): WorkspaceFileRef {
+  return {
+    id,
+    instanceId,
+    type: "workspace-file",
+    name: id,
+    hostId: "host-A",
+    workspacePath: "/ws",
+    filePath: id,
+  };
+}
+
+function seedCanvas(
+  tilesByInstanceId: Record<string, EpicCanvasTileRef>,
+  activeTabId: string,
+): void {
   const root: TilePane = {
     kind: "pane",
     id: "pane-A",
-    tabInstanceIds: ["inst-1", "inst-2"],
+    tabInstanceIds: Object.keys(tilesByInstanceId),
     activeTabId,
     previewTabId: null,
     activationHistory: [activeTabId],
@@ -106,15 +126,7 @@ function seedCanvasActiveTile(activeTabId: string): void {
   useEpicCanvasStore.setState({
     tabsById: { [TAB_ID]: { tabId: TAB_ID, epicId: "epic-1", name: "Epic 1" } },
     canvasByTabId: {
-      [TAB_ID]: {
-        root,
-        activePaneId: "pane-A",
-        tilesByInstanceId: {
-          "inst-1": artifactRef("a1", "inst-1"),
-          "inst-2": artifactRef("a2", "inst-2"),
-        },
-        sizesByGroupId: {},
-      },
+      [TAB_ID]: { root, activePaneId: "pane-A", tilesByInstanceId, sizesByGroupId: {} },
     },
   });
 }
@@ -129,19 +141,35 @@ describe("<TabSwitcherSheet /> close-on-open", () => {
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
   });
 
-  it("closes when the shown tile changes while open (an embed opened a tile)", () => {
-    seedCanvasActiveTile("inst-1");
+  it("closes when a file-tree/git-diff tap lands an embed-originated tile", () => {
+    const tiles = {
+      "inst-1": artifactRef("a1", "inst-1"),
+      "inst-2": workspaceFileRef("f1", "inst-2"),
+    };
+    seedCanvas(tiles, "inst-1");
     const onOpenChange = vi.fn();
     renderSheet(true, onOpenChange);
     expect(onOpenChange).not.toHaveBeenCalled();
-    // A file/diff open lands a different tile as the shown tile.
-    act(() => seedCanvasActiveTile("inst-2"));
+    act(() => seedCanvas(tiles, "inst-2")); // shown tile -> workspace-file
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("stays open when a background chat/artifact open changes the shown tile", () => {
+    const tiles = {
+      "inst-1": artifactRef("a1", "inst-1"),
+      "inst-2": artifactRef("a2", "inst-2"),
+    };
+    seedCanvas(tiles, "inst-1");
+    const onOpenChange = vi.fn();
+    renderSheet(true, onOpenChange);
+    // A background handoff/remote-delete lands a non-embed tile as shown.
+    act(() => seedCanvas(tiles, "inst-2"));
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it("stays open when only the category changes (no tile opened)", async () => {
     const user = userEvent.setup();
-    seedCanvasActiveTile("inst-1");
+    seedCanvas({ "inst-1": artifactRef("a1", "inst-1") }, "inst-1");
     const onOpenChange = vi.fn();
     renderSheet(true, onOpenChange);
     await user.click(screen.getByRole("tab", { name: "Git Diff" }));

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -16,6 +16,9 @@ vi.mock("@/hooks/ui/use-mobile", () => ({
   useIsMobile: () => mobileState.value,
   isMobileViewport: () => mobileState.value,
 }));
+vi.mock("@/providers/use-resolved-theme", () => ({
+  useResolvedTheme: () => ({ resolvedTheme: "dark", themePreset: "neutral" }),
+}));
 
 // The category bodies pull the epic projection / host queries; this test covers
 // the shell + tabs + persistence, so stub the lists to markers.
@@ -34,7 +37,7 @@ vi.mock("@/components/epic-canvas/mobile/switcher-panel-embed", () => ({
 
 const TAB_ID = "tab-switcher-test";
 const CATEGORY_NAMES = [
-  "Agents",
+  "Chats",
   "Artifacts",
   "File Tree",
   "Git Diff",
@@ -66,6 +69,15 @@ describe("<TabSwitcherSheet />", () => {
       expect(screen.getByRole("tab", { name })).toBeTruthy();
     }
     expect(screen.getAllByRole("tab")).toHaveLength(5);
+  });
+
+  it("labels the chats category 'Chats' and forces the active tab's fill transparent", () => {
+    renderSheet(true, () => {});
+    const active = screen.getByRole("tab", { name: "Chats" });
+    expect(active.getAttribute("data-state")).toBe("active");
+    // The base `data-active:bg-*` fill is overridden so the active line tab is
+    // underline-only, not a solid box (the live-review defect).
+    expect(active.className).toContain("data-active:bg-transparent");
   });
 
   it("defaults to the Agents category and shows its body", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TabSwitcherSheet } from "@/components/epic-canvas/mobile/tab-switcher-sheet";
+import { useLeftPanelStore } from "@/stores/epics/left-panel-store";
+
+const mobileState = vi.hoisted(() => ({ value: true }));
+vi.mock("@/hooks/ui/use-mobile", () => ({
+  useIsMobile: () => mobileState.value,
+  isMobileViewport: () => mobileState.value,
+}));
+
+const TAB_ID = "tab-switcher-test";
+const CATEGORY_NAMES = [
+  "Agents",
+  "Artifacts",
+  "File Tree",
+  "Git Diff",
+  "Terminals",
+];
+
+function renderSheet(open: boolean, onOpenChange: (open: boolean) => void) {
+  return render(
+    <TabSwitcherSheet
+      epicId="epic-1"
+      tabId={TAB_ID}
+      open={open}
+      onOpenChange={onOpenChange}
+    />,
+  );
+}
+
+describe("<TabSwitcherSheet />", () => {
+  beforeEach(() => {
+    mobileState.value = true;
+    // Reset the shared left-panel store so category selection never leaks.
+    useLeftPanelStore.setState({ activePanelIdByTabId: {} });
+  });
+  afterEach(cleanup);
+
+  it("renders exactly the five curated category tabs when open on mobile", () => {
+    renderSheet(true, () => {});
+    for (const name of CATEGORY_NAMES) {
+      expect(screen.getByRole("tab", { name })).toBeTruthy();
+    }
+    expect(screen.getAllByRole("tab")).toHaveLength(5);
+  });
+
+  it("defaults to the Agents category and shows its body", () => {
+    renderSheet(true, () => {});
+    expect(screen.getByTestId("mobile-switcher-panel-chats")).toBeTruthy();
+  });
+
+  it("persists a category selection to the left-panel store and swaps the body", async () => {
+    const user = userEvent.setup();
+    renderSheet(true, () => {});
+    await user.click(screen.getByRole("tab", { name: "Artifacts" }));
+    expect(useLeftPanelStore.getState().getActivePanelId(TAB_ID)).toBe(
+      "artifacts",
+    );
+    expect(screen.getByTestId("mobile-switcher-panel-artifacts")).toBeTruthy();
+  });
+
+  it("renders nothing when closed (controlled open prop)", () => {
+    renderSheet(false, () => {});
+    expect(screen.queryByTestId("mobile-tab-switcher-sheet")).toBeNull();
+  });
+
+  it("renders nothing on desktop even when asked to open", () => {
+    mobileState.value = false;
+    renderSheet(true, () => {});
+    expect(screen.queryByTestId("mobile-tab-switcher-sheet")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -1,8 +1,10 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TabSwitcherSheet } from "@/components/epic-canvas/mobile/tab-switcher-sheet";
 import { useLeftPanelStore } from "@/stores/epics/left-panel-store";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicArtifactRef, TilePane } from "@/stores/epics/canvas/types";
 
 const mobileState = vi.hoisted(() => ({ value: true }));
 vi.mock("@/hooks/ui/use-mobile", () => ({
@@ -20,6 +22,9 @@ vi.mock("@/components/epic-canvas/mobile/switcher-terminals-list", () => ({
 }));
 vi.mock("@/components/epic-canvas/mobile/switcher-artifacts-list", () => ({
   SwitcherArtifactsList: () => <div data-testid="mock-artifacts-list" />,
+}));
+vi.mock("@/components/epic-canvas/mobile/switcher-panel-embed", () => ({
+  SwitcherPanelEmbed: () => <div data-testid="mock-panel-embed" />,
 }));
 
 const TAB_ID = "tab-switcher-test";
@@ -82,5 +87,64 @@ describe("<TabSwitcherSheet />", () => {
     mobileState.value = false;
     renderSheet(true, () => {});
     expect(screen.queryByTestId("mobile-tab-switcher-sheet")).toBeNull();
+  });
+});
+
+function artifactRef(id: string, instanceId: string): EpicArtifactRef {
+  return { id, instanceId, type: "spec", name: id, hostId: "host-A" };
+}
+
+function seedCanvasActiveTile(activeTabId: string): void {
+  const root: TilePane = {
+    kind: "pane",
+    id: "pane-A",
+    tabInstanceIds: ["inst-1", "inst-2"],
+    activeTabId,
+    previewTabId: null,
+    activationHistory: [activeTabId],
+  };
+  useEpicCanvasStore.setState({
+    tabsById: { [TAB_ID]: { tabId: TAB_ID, epicId: "epic-1", name: "Epic 1" } },
+    canvasByTabId: {
+      [TAB_ID]: {
+        root,
+        activePaneId: "pane-A",
+        tilesByInstanceId: {
+          "inst-1": artifactRef("a1", "inst-1"),
+          "inst-2": artifactRef("a2", "inst-2"),
+        },
+        sizesByGroupId: {},
+      },
+    },
+  });
+}
+
+describe("<TabSwitcherSheet /> close-on-open", () => {
+  beforeEach(() => {
+    mobileState.value = true;
+    useLeftPanelStore.setState({ activePanelIdByTabId: {} });
+  });
+  afterEach(() => {
+    cleanup();
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  });
+
+  it("closes when the shown tile changes while open (an embed opened a tile)", () => {
+    seedCanvasActiveTile("inst-1");
+    const onOpenChange = vi.fn();
+    renderSheet(true, onOpenChange);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    // A file/diff open lands a different tile as the shown tile.
+    act(() => seedCanvasActiveTile("inst-2"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("stays open when only the category changes (no tile opened)", async () => {
+    const user = userEvent.setup();
+    seedCanvasActiveTile("inst-1");
+    const onOpenChange = vi.fn();
+    renderSheet(true, onOpenChange);
+    await user.click(screen.getByRole("tab", { name: "Git Diff" }));
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/tab-switcher-sheet.test.tsx
@@ -10,6 +10,18 @@ vi.mock("@/hooks/ui/use-mobile", () => ({
   isMobileViewport: () => mobileState.value,
 }));
 
+// The category bodies pull the epic projection / host queries; this test covers
+// the shell + tabs + persistence, so stub the lists to markers.
+vi.mock("@/components/epic-canvas/mobile/switcher-agents-list", () => ({
+  SwitcherAgentsList: () => <div data-testid="mock-agents-list" />,
+}));
+vi.mock("@/components/epic-canvas/mobile/switcher-terminals-list", () => ({
+  SwitcherTerminalsList: () => <div data-testid="mock-terminals-list" />,
+}));
+vi.mock("@/components/epic-canvas/mobile/switcher-artifacts-list", () => ({
+  SwitcherArtifactsList: () => <div data-testid="mock-artifacts-list" />,
+}));
+
 const TAB_ID = "tab-switcher-test";
 const CATEGORY_NAMES = [
   "Agents",
@@ -48,7 +60,7 @@ describe("<TabSwitcherSheet />", () => {
 
   it("defaults to the Agents category and shows its body", () => {
     renderSheet(true, () => {});
-    expect(screen.getByTestId("mobile-switcher-panel-chats")).toBeTruthy();
+    expect(screen.getByTestId("mock-agents-list")).toBeTruthy();
   });
 
   it("persists a category selection to the left-panel store and swaps the body", async () => {
@@ -58,7 +70,7 @@ describe("<TabSwitcherSheet />", () => {
     expect(useLeftPanelStore.getState().getActivePanelId(TAB_ID)).toBe(
       "artifacts",
     );
-    expect(screen.getByTestId("mobile-switcher-panel-artifacts")).toBeTruthy();
+    expect(screen.getByTestId("mock-artifacts-list")).toBeTruthy();
   });
 
   it("renders nothing when closed (controlled open prop)", () => {

--- a/clients/gui-app/src/components/epic-canvas/mobile/__tests__/use-switcher-activate.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/__tests__/use-switcher-activate.test.tsx
@@ -1,0 +1,110 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { makeSelectActiveEpicArtifactId } from "@/stores/epics/canvas/canvas-selectors";
+import type {
+  EpicArtifactRef,
+  EpicCanvasState,
+  TilePane,
+} from "@/stores/epics/canvas/types";
+
+// Run the prepared focus mutation synchronously and skip route focus routing,
+// so the real canvas store transitions run in the test (mirrors the tile-view
+// test's direct-prepare approach).
+vi.mock("@/hooks/epic/use-epic-nested-focus-navigation", () => ({
+  useEpicNestedFocusNavigation:
+    () => (_epicId: string, _tabId: string, prepare: () => unknown) => {
+      prepare();
+    },
+}));
+
+const TAB_ID = "tab-activate";
+const EPIC_ID = "epic-1";
+
+function spec(n: number, instanceId: string): EpicArtifactRef {
+  return {
+    id: `spec-${n}`,
+    instanceId,
+    type: "spec",
+    name: `Spec ${n}`,
+    hostId: "host-A",
+  };
+}
+
+function singlePaneCanvas(): EpicCanvasState {
+  const root: TilePane = {
+    kind: "pane",
+    id: "pane-A",
+    tabInstanceIds: ["inst-1", "inst-2"],
+    activeTabId: "inst-1",
+    previewTabId: null,
+    activationHistory: ["inst-1"],
+  };
+  return {
+    root,
+    activePaneId: "pane-A",
+    tilesByInstanceId: { "inst-1": spec(1, "inst-1"), "inst-2": spec(2, "inst-2") },
+    sizesByGroupId: {},
+  };
+}
+
+function seed(): void {
+  useEpicCanvasStore.setState({
+    tabsById: { [TAB_ID]: { tabId: TAB_ID, epicId: EPIC_ID, name: "Epic 1" } },
+    canvasByTabId: { [TAB_ID]: singlePaneCanvas() },
+  });
+}
+
+function activeArtifactId(): string | null {
+  return makeSelectActiveEpicArtifactId(TAB_ID)(useEpicCanvasStore.getState());
+}
+
+describe("useSwitcherActivate", () => {
+  afterEach(() => {
+    useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  });
+
+  it("activates an already-open tile without disturbing the split structure or sizes, then closes", () => {
+    seed();
+    const onClose = vi.fn();
+    const before = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
+    const { result } = renderHook(() =>
+      useSwitcherActivate(EPIC_ID, TAB_ID, onClose),
+    );
+
+    act(() => {
+      // spec-2 is already open (inst-2) - never used the buildRef path.
+      result.current("spec-2", () => spec(2, "unused"));
+    });
+
+    expect(activeArtifactId()).toBe("spec-2");
+    const after = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
+    const beforePane = before?.root;
+    const afterPane = after?.root;
+    if (beforePane?.kind !== "pane" || afterPane?.kind !== "pane") {
+      throw new Error("expected a single-pane root");
+    }
+    // Only activation moved: same tabs in the same order, sizes untouched.
+    expect(afterPane.tabInstanceIds).toEqual(beforePane.tabInstanceIds);
+    expect(after?.sizesByGroupId).toEqual(before?.sizesByGroupId);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens a not-yet-open item as a new tile, then closes", () => {
+    seed();
+    const onClose = vi.fn();
+    const { result } = renderHook(() =>
+      useSwitcherActivate(EPIC_ID, TAB_ID, onClose),
+    );
+
+    act(() => {
+      result.current("spec-3", () => spec(3, "inst-3"));
+    });
+
+    expect(activeArtifactId()).toBe("spec-3");
+    const after = useEpicCanvasStore.getState().canvasByTabId[TAB_ID];
+    expect(after?.tilesByInstanceId["inst-3"]?.id).toBe("spec-3");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { ActiveTabBody } from "@/components/epic-canvas/canvas/tab-group-view";
 import { TabBodySelectedContext } from "@/components/epic-canvas/canvas/tab-body-selected-context";
 import { PaneOpener } from "@/components/epic-canvas/canvas/pane-opener";
 import { MobileCurrentTileBar } from "@/components/epic-canvas/mobile/mobile-current-tile-bar";
+import { TabSwitcherSheet } from "@/components/epic-canvas/mobile/tab-switcher-sheet";
 import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
 import { usePaneVisible } from "@/components/epic-tabs/pane-visibility-context";
 import { useEpicCanvas } from "@/stores/epics/canvas/store";
@@ -37,11 +38,10 @@ export function MobileEpicTileView(props: MobileEpicTileViewProps) {
   const { epicId, tabId } = props;
   const canvas = useEpicCanvas(tabId);
   const selection = useMemo(() => selectMobileTile(canvas), [canvas]);
-  // Phase-1 placeholder: Phase 2 replaces this no-op with opening the "Switch
-  // tab" bottom sheet (which consumes `useMobileEpicTiles(tabId)` for the tile
-  // list + `selectTile`). Wired now so the bar's affordance and tap target ship
-  // in Phase 1.
-  const handleOpenSwitcher = useCallback(() => undefined, []);
+  // The current-tile bar chevron opens the "Switch tab" bottom sheet (P2.1).
+  // Local view state: the sheet is a leaf of this one view, so no store is
+  // warranted (per ticket).
+  const [switcherOpen, setSwitcherOpen] = useState(false);
 
   // Non-null root with no resolvable tile = an empty pane (e.g. the user closed
   // the last tab). Desktop renders the inline `PaneOpener` for this; do the
@@ -59,7 +59,7 @@ export function MobileEpicTileView(props: MobileEpicTileViewProps) {
       <MobileCurrentTileBar
         epicId={epicId}
         tile={selection.ref}
-        onOpenSwitcher={handleOpenSwitcher}
+        onOpenSwitcher={() => setSwitcherOpen(true)}
       />
       <div className="relative min-h-0 flex-1">
         <TabBodySelectedContext.Provider value>
@@ -79,6 +79,12 @@ export function MobileEpicTileView(props: MobileEpicTileViewProps) {
           />
         </TabBodySelectedContext.Provider>
       </div>
+      <TabSwitcherSheet
+        epicId={epicId}
+        tabId={tabId}
+        open={switcherOpen}
+        onOpenChange={setSwitcherOpen}
+      />
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/mobile-epic-tile-view.tsx
@@ -9,6 +9,7 @@ import { usePaneVisible } from "@/components/epic-tabs/pane-visibility-context";
 import { useEpicCanvas } from "@/stores/epics/canvas/store";
 import { firstPaneId } from "@/stores/epics/canvas/tile-tree";
 import type { TileLayoutNode } from "@/stores/epics/canvas/types";
+import "@/components/layout/shell/mobile-shell-touch-targets.css";
 
 interface MobileEpicTileViewProps {
   readonly epicId: string;
@@ -103,6 +104,7 @@ function MobileEmptyEpicPane(props: MobileEmptyEpicPaneProps) {
   if (root === null) return null;
   return (
     <div
+      data-mobile-shell-touch-scope=""
       className="flex h-full min-h-0 w-full flex-col bg-canvas"
       data-testid="mobile-epic-empty-pane"
     >

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agent-icon.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agent-icon.tsx
@@ -1,0 +1,63 @@
+import { Terminal } from "lucide-react";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { HarnessIcon } from "@/components/home/pickers/harness-icon";
+import { EPIC_NODE_ICONS } from "@/lib/artifacts/node-display";
+import {
+  useEpicActiveAgentIds,
+  useEpicChatHarnessId,
+  useMaybeEpicTuiAgentHarnessId,
+} from "@/lib/epic-selectors";
+
+/**
+ * Agent-row icon for the switcher, reusing the desktop resolution pieces
+ * without its tree rendering: a running spinner when the agent is active
+ * (`useEpicActiveAgentIds`), else the harness brand (`HarnessIcon`) - GUI chats
+ * from `useEpicChatHarnessId`, TUI agents from `useMaybeEpicTuiAgentHarnessId`
+ * with a small terminal badge to mark the surface - else the generic node
+ * glyph. Every hook is called unconditionally; only chat/terminal-agent nodes
+ * reach this component.
+ */
+export function SwitcherAgentIcon(props: {
+  readonly nodeId: string;
+  readonly type: "chat" | "terminal-agent";
+}) {
+  const { nodeId, type } = props;
+  const isActive = useEpicActiveAgentIds().has(nodeId);
+  const guiHarnessId = useEpicChatHarnessId(nodeId);
+  const tuiHarnessId = useMaybeEpicTuiAgentHarnessId(nodeId);
+
+  if (isActive) {
+    return (
+      <AgentSpinningDots
+        className="size-4 text-muted-foreground"
+        testId={`switcher-agent-active-${nodeId}`}
+        variant="dots2"
+      />
+    );
+  }
+
+  if (type === "chat" && guiHarnessId !== null) {
+    return <HarnessIcon harnessId={guiHarnessId} className="size-4" />;
+  }
+
+  if (type === "terminal-agent" && tuiHarnessId !== null) {
+    return (
+      <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
+        <HarnessIcon harnessId={tuiHarnessId} className="size-4" />
+        <Terminal
+          aria-hidden
+          className="pointer-events-none absolute -right-1 -bottom-1 size-2 text-muted-foreground"
+          strokeWidth={3}
+        />
+      </span>
+    );
+  }
+
+  const FallbackIcon = EPIC_NODE_ICONS[type];
+  return (
+    <FallbackIcon
+      aria-hidden
+      className="size-4 shrink-0 text-muted-foreground"
+    />
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -48,7 +48,7 @@ export function SwitcherAgentsList(props: SwitcherListProps) {
   }
 
   return (
-    <div className="flex flex-col gap-0.5 p-1">
+    <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
       {agents.map((record) => (
         <SwitcherAgentRow
           key={record.id}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useMemo } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { SwitcherAgentIcon } from "@/components/epic-canvas/mobile/switcher-agent-icon";
+import {
+  SwitcherListEmpty,
+  SwitcherListRow,
+} from "@/components/epic-canvas/mobile/switcher-list-row";
+import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { useEpicArtifactRecords, type EpicTreeRecord } from "@/lib/epic-selectors";
+import {
+  computeDescendantCounts,
+  formatCascadeSummary,
+} from "@/lib/epic-tree-cascade";
+import { useIsActiveEpicArtifact } from "@/stores/epics/canvas/canvas-selectors";
+import {
+  isOpenableEpicNodeKind,
+  makeOpenableNodeRef,
+} from "@/stores/epics/canvas/types";
+
+interface SwitcherListProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}
+
+/**
+ * Agents category: GUI chats and TUI agents interleaved in one flat list
+ * (decision: interleaved, flat, no gui/tui filter v1) over the shared
+ * `useEpicArtifactRecords()` projection - no duplicated data path and none of
+ * the desktop tree's dnd / indentation / hover machinery.
+ */
+export function SwitcherAgentsList(props: SwitcherListProps) {
+  const records = useEpicArtifactRecords();
+  const agents = useMemo(
+    () =>
+      records.filter(
+        (record) =>
+          record.type === "chat" || record.type === "terminal-agent",
+      ),
+    [records],
+  );
+
+  if (agents.length === 0) {
+    return <SwitcherListEmpty message="No agents yet." />;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 p-1">
+      {agents.map((record) => (
+        <SwitcherAgentRow
+          key={record.id}
+          record={record}
+          records={records}
+          epicId={props.epicId}
+          tabId={props.tabId}
+          onClose={props.onClose}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SwitcherAgentRow(props: {
+  readonly record: EpicTreeRecord;
+  readonly records: ReadonlyArray<EpicTreeRecord>;
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}) {
+  const { record, records, epicId, tabId, onClose } = props;
+  const activate = useSwitcherActivate(epicId, tabId, onClose);
+  const isActive = useIsActiveEpicArtifact(tabId, record.id);
+  const agentType: "chat" | "terminal-agent" =
+    record.type === "terminal-agent" ? "terminal-agent" : "chat";
+
+  const onSelect = useCallback(() => {
+    const type = record.type;
+    if (!isOpenableEpicNodeKind(type)) return;
+    activate(record.id, () =>
+      makeOpenableNodeRef({
+        id: record.id,
+        instanceId: uuidv4(),
+        type,
+        name: record.name,
+        hostId: record.hostId,
+      }),
+    );
+  }, [activate, record]);
+
+  const cascadeSummary = formatCascadeSummary(
+    computeDescendantCounts(records, record.id),
+  );
+
+  return (
+    <SwitcherListRow
+      icon={<SwitcherAgentIcon nodeId={record.id} type={agentType} />}
+      label={record.name}
+      active={isActive}
+      onSelect={onSelect}
+      selectTestId={`switcher-agent-row-${record.id}`}
+      actions={
+        <SwitcherRowActions
+          epicId={epicId}
+          tabId={tabId}
+          kind={agentType}
+          nodeId={record.id}
+          name={record.name}
+          cascadeSummary={cascadeSummary}
+        />
+      }
+    />
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -3,12 +3,19 @@ import { v4 as uuidv4 } from "uuid";
 import { SwitcherAgentIcon } from "@/components/epic-canvas/mobile/switcher-agent-icon";
 import {
   SwitcherListEmpty,
+  SwitcherListHeader,
   SwitcherListRow,
 } from "@/components/epic-canvas/mobile/switcher-list-row";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import { SwitcherNewAgentButton } from "@/components/epic-canvas/mobile/switcher-create-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
 import { useOrderedSwitcherRecords } from "@/components/epic-canvas/mobile/switcher-record-order";
-import { useEpicArtifactRecords, type EpicTreeRecord } from "@/lib/epic-selectors";
+import {
+  useEpicArtifactRecords,
+  useEpicPermissionRole,
+  type EpicTreeRecord,
+} from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
 import {
   computeDescendantCounts,
   formatCascadeSummary,
@@ -32,6 +39,7 @@ interface SwitcherListProps {
  * the desktop tree's dnd / indentation / hover machinery.
  */
 export function SwitcherAgentsList(props: SwitcherListProps) {
+  const { epicId, tabId, onClose } = props;
   const records = useEpicArtifactRecords();
   const filtered = useMemo(
     () =>
@@ -42,23 +50,37 @@ export function SwitcherAgentsList(props: SwitcherListProps) {
     [records],
   );
   const agents = useOrderedSwitcherRecords(filtered);
-
-  if (agents.length === 0) {
-    return <SwitcherListEmpty message="No agents yet." />;
-  }
+  const canMutate = isEditableRole(useEpicPermissionRole());
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
-      {agents.map((record) => (
-        <SwitcherAgentRow
-          key={record.id}
-          record={record}
-          records={records}
-          epicId={props.epicId}
-          tabId={props.tabId}
-          onClose={props.onClose}
-        />
-      ))}
+    <div className="flex min-h-0 flex-1 flex-col">
+      <SwitcherListHeader
+        action={
+          canMutate ? (
+            <SwitcherNewAgentButton
+              epicId={epicId}
+              tabId={tabId}
+              onClose={onClose}
+            />
+          ) : null
+        }
+      />
+      {agents.length === 0 ? (
+        <SwitcherListEmpty message="No agents yet." />
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
+          {agents.map((record) => (
+            <SwitcherAgentRow
+              key={record.id}
+              record={record}
+              records={records}
+              epicId={epicId}
+              tabId={tabId}
+              onClose={onClose}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-agents-list.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/epic-canvas/mobile/switcher-list-row";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { useOrderedSwitcherRecords } from "@/components/epic-canvas/mobile/switcher-record-order";
 import { useEpicArtifactRecords, type EpicTreeRecord } from "@/lib/epic-selectors";
 import {
   computeDescendantCounts,
@@ -32,7 +33,7 @@ interface SwitcherListProps {
  */
 export function SwitcherAgentsList(props: SwitcherListProps) {
   const records = useEpicArtifactRecords();
-  const agents = useMemo(
+  const filtered = useMemo(
     () =>
       records.filter(
         (record) =>
@@ -40,6 +41,7 @@ export function SwitcherAgentsList(props: SwitcherListProps) {
       ),
     [records],
   );
+  const agents = useOrderedSwitcherRecords(filtered);
 
   if (agents.length === 0) {
     return <SwitcherListEmpty message="No agents yet." />;

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useMemo } from "react";
+import { v4 as uuidv4 } from "uuid";
+import {
+  SwitcherListEmpty,
+  SwitcherListRow,
+} from "@/components/epic-canvas/mobile/switcher-list-row";
+import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { useEpicArtifactRecords, type EpicTreeRecord } from "@/lib/epic-selectors";
+import {
+  computeDescendantCounts,
+  formatCascadeSummary,
+} from "@/lib/epic-tree-cascade";
+import { EPIC_NODE_ICONS } from "@/lib/artifacts/node-display";
+import {
+  STATUS_DOT_CLASSES,
+  STATUS_LABELS,
+  computeArtifactNodeStatusDot,
+} from "@/components/epic-canvas/sidebar/epic-sidebar-tree-shared";
+import { useIsActiveEpicArtifact } from "@/stores/epics/canvas/canvas-selectors";
+import {
+  isOpenableEpicNodeKind,
+  makeOpenableNodeRef,
+} from "@/stores/epics/canvas/types";
+import { cn } from "@/lib/utils";
+
+interface SwitcherListProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}
+
+/**
+ * Artifacts category: spec / ticket / story / review as a flat list over the
+ * shared `useEpicArtifactRecords()` projection (everything that is not a chat or
+ * terminal-agent). Reuses the desktop status-dot helpers; no tree rendering.
+ */
+export function SwitcherArtifactsList(props: SwitcherListProps) {
+  const records = useEpicArtifactRecords();
+  const artifacts = useMemo(
+    () =>
+      records.filter(
+        (record) =>
+          record.type !== "chat" && record.type !== "terminal-agent",
+      ),
+    [records],
+  );
+
+  if (artifacts.length === 0) {
+    return <SwitcherListEmpty message="No artifacts yet." />;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 p-1">
+      {artifacts.map((record) => (
+        <SwitcherArtifactRow
+          key={record.id}
+          record={record}
+          records={records}
+          epicId={props.epicId}
+          tabId={props.tabId}
+          onClose={props.onClose}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SwitcherArtifactRow(props: {
+  readonly record: EpicTreeRecord;
+  readonly records: ReadonlyArray<EpicTreeRecord>;
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}) {
+  const { record, records, epicId, tabId, onClose } = props;
+  const activate = useSwitcherActivate(epicId, tabId, onClose);
+  const isActive = useIsActiveEpicArtifact(tabId, record.id);
+
+  const onSelect = useCallback(() => {
+    const type = record.type;
+    if (!isOpenableEpicNodeKind(type)) return;
+    activate(record.id, () =>
+      makeOpenableNodeRef({
+        id: record.id,
+        instanceId: uuidv4(),
+        type,
+        name: record.name,
+        hostId: record.hostId,
+      }),
+    );
+  }, [activate, record]);
+
+  const cascadeSummary = formatCascadeSummary(
+    computeDescendantCounts(records, record.id),
+  );
+
+  return (
+    <SwitcherListRow
+      icon={<SwitcherArtifactIcon type={record.type} status={record.status} />}
+      label={record.name}
+      active={isActive}
+      onSelect={onSelect}
+      selectTestId={`switcher-artifact-row-${record.id}`}
+      actions={
+        <SwitcherRowActions
+          epicId={epicId}
+          tabId={tabId}
+          kind="artifact"
+          nodeId={record.id}
+          name={record.name}
+          cascadeSummary={cascadeSummary}
+        />
+      }
+    />
+  );
+}
+
+function SwitcherArtifactIcon(props: {
+  readonly type: EpicTreeRecord["type"];
+  readonly status: number | null;
+}) {
+  const { type, status } = props;
+  const Icon = EPIC_NODE_ICONS[type];
+  const showDot = computeArtifactNodeStatusDot(type, status);
+  return (
+    <span className="relative inline-flex size-4 shrink-0 items-center justify-center">
+      <Icon aria-hidden className="size-4 text-muted-foreground" />
+      {showDot && status !== null ? (
+        <span
+          className={cn(
+            "absolute -right-1 -bottom-1 size-1.5 rounded-full ring-1 ring-popover",
+            STATUS_DOT_CLASSES[status],
+          )}
+          title={STATUS_LABELS[status]}
+        />
+      ) : null}
+    </span>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
@@ -53,7 +53,7 @@ export function SwitcherArtifactsList(props: SwitcherListProps) {
   }
 
   return (
-    <div className="flex flex-col gap-0.5 p-1">
+    <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
       {artifacts.map((record) => (
         <SwitcherArtifactRow
           key={record.id}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/epic-canvas/mobile/switcher-list-row";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { useOrderedSwitcherRecords } from "@/components/epic-canvas/mobile/switcher-record-order";
 import { useEpicArtifactRecords, type EpicTreeRecord } from "@/lib/epic-selectors";
 import {
   computeDescendantCounts,
@@ -37,7 +38,7 @@ interface SwitcherListProps {
  */
 export function SwitcherArtifactsList(props: SwitcherListProps) {
   const records = useEpicArtifactRecords();
-  const artifacts = useMemo(
+  const filtered = useMemo(
     () =>
       records.filter(
         (record) =>
@@ -45,6 +46,7 @@ export function SwitcherArtifactsList(props: SwitcherListProps) {
       ),
     [records],
   );
+  const artifacts = useOrderedSwitcherRecords(filtered);
 
   if (artifacts.length === 0) {
     return <SwitcherListEmpty message="No artifacts yet." />;

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-artifacts-list.tsx
@@ -2,12 +2,19 @@ import { useCallback, useMemo } from "react";
 import { v4 as uuidv4 } from "uuid";
 import {
   SwitcherListEmpty,
+  SwitcherListHeader,
   SwitcherListRow,
 } from "@/components/epic-canvas/mobile/switcher-list-row";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import { SwitcherNewArtifactMenu } from "@/components/epic-canvas/mobile/switcher-create-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
 import { useOrderedSwitcherRecords } from "@/components/epic-canvas/mobile/switcher-record-order";
-import { useEpicArtifactRecords, type EpicTreeRecord } from "@/lib/epic-selectors";
+import {
+  useEpicArtifactRecords,
+  useEpicPermissionRole,
+  type EpicTreeRecord,
+} from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
 import {
   computeDescendantCounts,
   formatCascadeSummary,
@@ -37,6 +44,7 @@ interface SwitcherListProps {
  * terminal-agent). Reuses the desktop status-dot helpers; no tree rendering.
  */
 export function SwitcherArtifactsList(props: SwitcherListProps) {
+  const { epicId, tabId, onClose } = props;
   const records = useEpicArtifactRecords();
   const filtered = useMemo(
     () =>
@@ -47,23 +55,37 @@ export function SwitcherArtifactsList(props: SwitcherListProps) {
     [records],
   );
   const artifacts = useOrderedSwitcherRecords(filtered);
-
-  if (artifacts.length === 0) {
-    return <SwitcherListEmpty message="No artifacts yet." />;
-  }
+  const canMutate = isEditableRole(useEpicPermissionRole());
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
-      {artifacts.map((record) => (
-        <SwitcherArtifactRow
-          key={record.id}
-          record={record}
-          records={records}
-          epicId={props.epicId}
-          tabId={props.tabId}
-          onClose={props.onClose}
-        />
-      ))}
+    <div className="flex min-h-0 flex-1 flex-col">
+      <SwitcherListHeader
+        action={
+          canMutate ? (
+            <SwitcherNewArtifactMenu
+              epicId={epicId}
+              tabId={tabId}
+              onClose={onClose}
+            />
+          ) : null
+        }
+      />
+      {artifacts.length === 0 ? (
+        <SwitcherListEmpty message="No artifacts yet." />
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
+          {artifacts.map((record) => (
+            <SwitcherArtifactRow
+              key={record.id}
+              record={record}
+              records={records}
+              epicId={epicId}
+              tabId={tabId}
+              onClose={onClose}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-categories.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-categories.ts
@@ -1,0 +1,67 @@
+import {
+  LEFT_PANEL_DEFINITIONS,
+  type LeftPanelAvailabilityContext,
+  type LeftPanelMetadataDefinition,
+} from "@/components/epic-canvas/sidebar/left-panel-registry";
+import {
+  DEFAULT_LEFT_PANEL_ID,
+  type LeftPanelId,
+} from "@/stores/epics/left-panel-store";
+
+/**
+ * The mobile "Switch tab" sheet exposes the desktop left-panel categories as a
+ * horizontally-scrollable tab bar. Curated to the five settled for v1 (decision
+ * table): Agents (`chats`), Artifacts, File tree, Git diff, Terminals. Sharing
+ * is deferred and Comments live inside the artifact tile, so both are excluded.
+ * Identity (title + icon) is reused verbatim from `LEFT_PANEL_DEFINITIONS` so
+ * mobile never forks the category copy.
+ */
+const CURATED_ORDER: readonly LeftPanelId[] = [
+  "chats",
+  "artifacts",
+  "file-tree",
+  "git-diff",
+  "terminals",
+];
+
+const DEFINITION_BY_ID = new Map<LeftPanelId, LeftPanelMetadataDefinition>(
+  LEFT_PANEL_DEFINITIONS.map((definition) => [definition.id, definition]),
+);
+
+export const MOBILE_SWITCHER_CATEGORY_DEFS: ReadonlyArray<LeftPanelMetadataDefinition> =
+  CURATED_ORDER.flatMap((id) => {
+    const definition = DEFINITION_BY_ID.get(id);
+    return definition === undefined ? [] : [definition];
+  });
+
+const MOBILE_SWITCHER_CATEGORY_IDS: ReadonlyArray<LeftPanelId> =
+  MOBILE_SWITCHER_CATEGORY_DEFS.map((definition) => definition.id);
+
+/**
+ * Every curated category is unconditionally visible in the registry, so this
+ * benign context only exists to honour each definition's `isVisible()` contract
+ * (Comments/Sharing - the only context-dependent panels - are not in the set).
+ */
+const SWITCHER_AVAILABILITY: LeftPanelAvailabilityContext = {
+  commentsPanelRevealed: false,
+  hasActiveCommentableArtifact: false,
+};
+
+export function visibleSwitcherCategoryDefs(): ReadonlyArray<LeftPanelMetadataDefinition> {
+  return MOBILE_SWITCHER_CATEGORY_DEFS.filter((definition) =>
+    definition.isVisible(SWITCHER_AVAILABILITY),
+  );
+}
+
+/**
+ * Clamp a persisted active left-panel id to the mobile-curated set so a desktop
+ * selection outside the five (e.g. Sharing) falls back to Agents rather than
+ * leaving the sheet with no matching tab.
+ */
+export function clampToSwitcherCategory(id: LeftPanelId): LeftPanelId {
+  return MOBILE_SWITCHER_CATEGORY_IDS.includes(id) ? id : DEFAULT_LEFT_PANEL_ID;
+}
+
+export function isSwitcherCategory(value: string): value is LeftPanelId {
+  return MOBILE_SWITCHER_CATEGORY_IDS.some((id) => id === value);
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-categories.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-categories.ts
@@ -54,6 +54,22 @@ export function visibleSwitcherCategoryDefs(): ReadonlyArray<LeftPanelMetadataDe
 }
 
 /**
+ * Mobile-only display-label overrides for the category tabs. The desktop
+ * `LEFT_PANEL_DEFINITIONS` title stays "Agents" (id `chats`); on mobile the user
+ * wants the tab labelled "Chats" to correlate directly with what it lists. The
+ * id (persisted selection, store key) is untouched - only the label changes.
+ */
+const MOBILE_SWITCHER_TITLE_OVERRIDES: Partial<Record<LeftPanelId, string>> = {
+  chats: "Chats",
+};
+
+export function switcherCategoryTitle(
+  definition: LeftPanelMetadataDefinition,
+): string {
+  return MOBILE_SWITCHER_TITLE_OVERRIDES[definition.id] ?? definition.title;
+}
+
+/**
  * Clamp a persisted active left-panel id to the mobile-curated set so a desktop
  * selection outside the five (e.g. Sharing) falls back to Agents rather than
  * leaving the sheet with no matching tab.

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
@@ -1,0 +1,34 @@
+import { TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { visibleSwitcherCategoryDefs } from "@/components/epic-canvas/mobile/switcher-categories";
+
+/**
+ * The category tab bar for the mobile "Switch tab" sheet: a `line`-variant
+ * `TabsList` whose triggers take natural width and scroll horizontally when the
+ * five curated categories overflow phone width. Rendered inside the sheet's
+ * `Tabs` root so selection flows through Radix. Identity comes from
+ * {@link visibleSwitcherCategoryDefs} (the desktop left-panel registry).
+ */
+export function SwitcherCategoryTabs() {
+  return (
+    <TabsList
+      variant="line"
+      className="w-full justify-start gap-1 overflow-x-auto px-2"
+      aria-label="Tab categories"
+    >
+      {visibleSwitcherCategoryDefs().map((definition) => {
+        const Icon = definition.icon;
+        return (
+          <TabsTrigger
+            key={definition.id}
+            value={definition.id}
+            className="min-h-9 flex-none gap-1.5"
+            data-testid={`mobile-switcher-tab-${definition.id}`}
+          >
+            <Icon className="size-4" />
+            {definition.title}
+          </TabsTrigger>
+        );
+      })}
+    </TabsList>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
@@ -24,12 +24,21 @@ export function SwitcherCategoryTabs() {
           <TabsTrigger
             key={definition.id}
             value={definition.id}
-            // Force the line-variant active state to underline-only: the base
-            // trigger's `data-active:bg-*` fill (which the `:where()`-neutralised
-            // line override can't out-specify) paints a solid box wherever the
-            // active `--background` differs from the sheet's `--popover`. Same
-            // `data-active:` prefix, so tailwind-merge drops the base fill.
-            className="min-h-9 flex-none gap-1.5 data-active:bg-transparent dark:data-active:bg-transparent"
+            // `data-active:bg-transparent`: force the line-variant active state
+            // fill-less (the `:where()`-neutralised line override can't
+            // out-specify the base `data-active:bg-*`; same prefix here, so
+            // tailwind-merge drops it) - otherwise it paints a box wherever the
+            // active `--background` differs from the sheet surface, e.g. a white
+            // box in a light portal.
+            //
+            // The active indicator is a `::before` underline, NOT ui/tabs'
+            // `::after` one: the mobile-shell hit-slop
+            // (`mobile-shell-touch-targets.css`) claims every trigger's single
+            // `::after` under `@media (pointer: coarse)`, so on touch devices
+            // that `::after` is the (now transparent) slop, not the indicator.
+            // `::before` is untouched by both ui/tabs and the slop rule, so it
+            // renders the underline cleanly with no shared-pseudo collision.
+            className="min-h-9 flex-none gap-1.5 data-active:bg-transparent dark:data-active:bg-transparent before:pointer-events-none before:absolute before:inset-x-0 before:bottom-0 before:h-0.5 before:rounded-full before:bg-foreground before:opacity-0 before:transition-opacity data-active:before:opacity-100"
             data-testid={`mobile-switcher-tab-${definition.id}`}
           >
             <Icon className="size-4" />

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-category-tabs.tsx
@@ -1,5 +1,8 @@
 import { TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { visibleSwitcherCategoryDefs } from "@/components/epic-canvas/mobile/switcher-categories";
+import {
+  switcherCategoryTitle,
+  visibleSwitcherCategoryDefs,
+} from "@/components/epic-canvas/mobile/switcher-categories";
 
 /**
  * The category tab bar for the mobile "Switch tab" sheet: a `line`-variant
@@ -21,11 +24,16 @@ export function SwitcherCategoryTabs() {
           <TabsTrigger
             key={definition.id}
             value={definition.id}
-            className="min-h-9 flex-none gap-1.5"
+            // Force the line-variant active state to underline-only: the base
+            // trigger's `data-active:bg-*` fill (which the `:where()`-neutralised
+            // line override can't out-specify) paints a solid box wherever the
+            // active `--background` differs from the sheet's `--popover`. Same
+            // `data-active:` prefix, so tailwind-merge drops the base fill.
+            className="min-h-9 flex-none gap-1.5 data-active:bg-transparent dark:data-active:bg-transparent"
             data-testid={`mobile-switcher-tab-${definition.id}`}
           >
             <Icon className="size-4" />
-            {definition.title}
+            {switcherCategoryTitle(definition)}
           </TabsTrigger>
         );
       })}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-create-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-create-actions.tsx
@@ -1,0 +1,112 @@
+import { Plus } from "lucide-react";
+import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useSwitcherCreateArtifact } from "@/components/epic-canvas/mobile/use-switcher-create-artifact";
+import { useNewConversationModalStore } from "@/stores/epics/new-conversation-modal-store";
+import { useNewConversationModalOpenStore } from "@/stores/epics/new-conversation-modal-open-store";
+import { ACTIVE_TILE_PLACEMENT } from "@/lib/canvas/conversation-tile-placement";
+import { EPIC_NODE_ICONS, EPIC_NODE_LABELS } from "@/lib/artifacts/node-display";
+
+const ARTIFACT_KINDS: ReadonlyArray<EpicArtifactKind> = [
+  "spec",
+  "ticket",
+  "story",
+  "review",
+];
+
+/**
+ * "New agent" affordance for the Agents category: opens the shared New
+ * Conversation modal via the exact P1.3 funnel (force chat mode, then request
+ * the modal with `ACTIVE_TILE_PLACEMENT`). The modal's Chat/Terminal interface
+ * switcher covers both a GUI chat and a TUI terminal-agent, so one entry point
+ * serves the whole Agents category. The modal replaces the sheet, so we close
+ * the sheet as it opens.
+ */
+export function SwitcherNewAgentButton(props: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}) {
+  const { epicId, tabId, onClose } = props;
+  const handleClick = () => {
+    useNewConversationModalStore.getState().setComposerMode(epicId, "chat");
+    useNewConversationModalOpenStore.getState().open({
+      epicId,
+      tabId,
+      placement: ACTIVE_TILE_PLACEMENT,
+      parentId: null,
+    });
+    onClose();
+  };
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      aria-label="New agent"
+      data-testid="switcher-new-agent"
+      className="text-muted-foreground hover:text-foreground"
+      onClick={handleClick}
+    >
+      <Plus className="size-4" />
+    </Button>
+  );
+}
+
+/**
+ * "New artifact" affordance for the Artifacts category: a curated kind menu
+ * (spec / ticket / story / review) that fires the exact desktop create path
+ * (`useEpicCreateArtifact` + open-when-projected). The artifact tile is not an
+ * embed kind, so the sheet's watcher won't close on it; instead the create hook
+ * closes the sheet (via `onClose`) the moment the tile opens, landing it as the
+ * visible tile. `AddNodeDropdown` can't be filtered to artifact kinds, so the
+ * menu is bespoke but the create function is shared.
+ */
+export function SwitcherNewArtifactMenu(props: {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}) {
+  const { create } = useSwitcherCreateArtifact(
+    props.epicId,
+    props.tabId,
+    props.onClose,
+  );
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="New artifact"
+          data-testid="switcher-new-artifact"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <Plus className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {ARTIFACT_KINDS.map((kind) => {
+          const Icon = EPIC_NODE_ICONS[kind];
+          return (
+            <DropdownMenuItem
+              key={kind}
+              data-testid={`switcher-new-artifact-${kind}`}
+              onSelect={() => create(kind)}
+            >
+              <Icon className="size-3.5" />
+              {EPIC_NODE_LABELS[kind]}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-create-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-create-actions.tsx
@@ -1,5 +1,6 @@
 import { Plus } from "lucide-react";
 import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -73,7 +74,7 @@ export function SwitcherNewArtifactMenu(props: {
   readonly tabId: string;
   readonly onClose: () => void;
 }) {
-  const { create } = useSwitcherCreateArtifact(
+  const { create, isPending } = useSwitcherCreateArtifact(
     props.epicId,
     props.tabId,
     props.onClose,
@@ -87,9 +88,18 @@ export function SwitcherNewArtifactMenu(props: {
           size="icon-sm"
           aria-label="New artifact"
           data-testid="switcher-new-artifact"
+          disabled={isPending}
           className="text-muted-foreground hover:text-foreground"
         >
-          <Plus className="size-4" />
+          {isPending ? (
+            <AgentSpinningDots
+              className="size-4"
+              testId="switcher-new-artifact-pending"
+              variant="dots2"
+            />
+          ) : (
+            <Plus className="size-4" />
+          )}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
@@ -53,3 +53,16 @@ export function SwitcherListEmpty(props: { readonly message: string }) {
     </div>
   );
 }
+
+/**
+ * Right-aligned header bar hosting a category's "+" create affordance. Renders
+ * nothing when `action` is null (a viewer with no create rights).
+ */
+export function SwitcherListHeader(props: { readonly action: ReactNode }) {
+  if (props.action === null) return null;
+  return (
+    <div className="flex shrink-0 items-center justify-end px-2 pt-1.5">
+      {props.action}
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-list-row.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+/**
+ * One flat row in a switcher category list: leading icon, truncating label, a
+ * check on the active tile, and an optional trailing "…" actions slot. Tapping
+ * the row body activates the tile; the actions slot (null for viewers) is a
+ * sibling button so its taps never trigger a row open. The 44px min height plus
+ * the sheet's coarse-pointer touch scope satisfy the touch-target guideline.
+ */
+export function SwitcherListRow(props: {
+  readonly icon: ReactNode;
+  readonly label: string;
+  readonly active: boolean;
+  readonly onSelect: () => void;
+  readonly actions: ReactNode;
+  readonly selectTestId: string;
+}) {
+  const { icon, label, active, onSelect, actions, selectTestId } = props;
+  return (
+    <div className="flex items-center gap-1">
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={onSelect}
+        data-testid={selectTestId}
+        aria-current={active ? "true" : undefined}
+        className="flex min-h-11 flex-1 items-center justify-start gap-2 rounded-md px-2 text-left font-normal"
+      >
+        <span className="flex size-4 shrink-0 items-center justify-center">
+          {icon}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-ui-sm text-foreground">
+          {label}
+        </span>
+        {active ? (
+          <Check
+            className="size-4 shrink-0 text-primary"
+            aria-label="Current tab"
+          />
+        ) : null}
+      </Button>
+      {actions}
+    </div>
+  );
+}
+
+export function SwitcherListEmpty(props: { readonly message: string }) {
+  return (
+    <div className="flex min-h-24 items-center justify-center p-6 text-center text-ui-sm text-muted-foreground">
+      {props.message}
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-panel-embed.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-panel-embed.tsx
@@ -1,0 +1,31 @@
+import { GitDiffPanelBodyLive } from "@/components/epic-canvas/git-diff/git-diff-panel-body-live";
+import { FileTreePanelBody } from "@/components/epic-canvas/sidebar/epic-sidebar";
+
+/**
+ * File-tree and Git-diff categories. Unlike the flat lists these are not
+ * row-per-item surfaces (research §B): they embed the EXACT desktop panel
+ * bodies - already click-driven and Pierre-rendered - rather than being
+ * rebuilt. Both bodies mount cleanly here: the app-shell `RootDndProvider`
+ * supplies the dnd-kit context the file-tree drag bridge needs (it only
+ * activates on pointer drag, never a tap), and the canvas-side
+ * `SnapshotLoadingProvider` satisfies the file-tree `SnapshotGate`. Opening a
+ * file / diff tile is detected by the sheet's active-tile watcher, which closes
+ * the sheet; in-panel navigation (repo / workspace switch) opens no tile and
+ * keeps the sheet open.
+ */
+export function SwitcherPanelEmbed(props: {
+  readonly category: "file-tree" | "git-diff";
+  readonly epicId: string;
+  readonly tabId: string;
+}) {
+  const { category, epicId, tabId } = props;
+  return (
+    <div className="min-h-0 flex-1 pb-[env(safe-area-inset-bottom)]">
+      {category === "file-tree" ? (
+        <FileTreePanelBody epicId={epicId} tabId={tabId} />
+      ) : (
+        <GitDiffPanelBodyLive epicId={epicId} tabId={tabId} />
+      )}
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-record-order.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-record-order.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react";
+import { useEpicTreeIndex, type EpicTreeRecord } from "@/lib/epic-selectors";
+import {
+  DEFAULT_SORT_MODE,
+  makeNodeComparator,
+  sortNodeIds,
+} from "@/lib/epic-sort";
+
+/**
+ * Orders a flat record slice most-recently-updated first, resolving timestamps
+ * through the tree index. `useEpicArtifactRecords()` yields records grouped by
+ * source (all chats, then all TUI agents, then all artifacts); the switcher
+ * lists want a single interleaved list, so we sort by the desktop default mode
+ * (last updated, descending) via the shared `epic-sort` comparator rather than
+ * inventing a parallel ordering.
+ */
+export function useOrderedSwitcherRecords(
+  records: ReadonlyArray<EpicTreeRecord>,
+): ReadonlyArray<EpicTreeRecord> {
+  const nodeById = useEpicTreeIndex().nodeById;
+  return useMemo(() => {
+    if (records.length < 2) return records;
+    const orderedIds = sortNodeIds(
+      records.map((record) => record.id),
+      nodeById,
+      makeNodeComparator(DEFAULT_SORT_MODE),
+    );
+    const recordById = new Map(records.map((record) => [record.id, record]));
+    return orderedIds.flatMap((id) => {
+      const record = recordById.get(id);
+      return record === undefined ? [] : [record];
+    });
+  }, [records, nodeById]);
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-rename-dialog.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-rename-dialog.tsx
@@ -1,0 +1,83 @@
+import { useState, type SyntheticEvent } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Rename dialog for a switcher row. Desktop renames inline in the tree row,
+ * which has no touch analog, so mobile drives the same canonical rename
+ * mutations from a minimal dialog (mirrors the P1.3 epic-rename dialog shape).
+ * The caller's `onSubmit` fires the matching mutation; the dialog closes on
+ * submit and the new name lands via the projection.
+ */
+export function SwitcherRenameDialog(props: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly title: string;
+  readonly initialValue: string;
+  readonly nodeId: string;
+  readonly onSubmit: (value: string) => void;
+}) {
+  const { open, onOpenChange, title, initialValue, nodeId, onSubmit } = props;
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(92vw,28rem)] max-w-[min(92vw,28rem)]">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        {/* Radix unmounts closed content, so the form re-seeds from the current
+            name on every open without an effect. */}
+        {open ? (
+          <SwitcherRenameForm
+            initialValue={initialValue}
+            nodeId={nodeId}
+            onSubmit={onSubmit}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SwitcherRenameForm(props: {
+  readonly initialValue: string;
+  readonly nodeId: string;
+  readonly onSubmit: (value: string) => void;
+}) {
+  const { initialValue, nodeId, onSubmit } = props;
+  const [value, setValue] = useState(initialValue);
+  const trimmed = value.trim();
+  const canSubmit = trimmed.length > 0 && trimmed !== initialValue;
+
+  const handleSubmit = (event: SyntheticEvent) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    onSubmit(trimmed);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <Input
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        aria-label="New name"
+        data-testid={`switcher-rename-input-${nodeId}`}
+      />
+      <DialogFooter>
+        <Button
+          type="submit"
+          disabled={!canSubmit}
+          data-testid={`switcher-rename-save-${nodeId}`}
+        >
+          Save
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-actions.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-row-actions.tsx
@@ -1,0 +1,229 @@
+import { useCallback, useState } from "react";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  SidebarDropdownMenuItems,
+  type SidebarRowMenuEntry,
+} from "@/components/epic-canvas/sidebar/sidebar-row-menu-items";
+import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
+import { SwitcherRenameDialog } from "@/components/epic-canvas/mobile/switcher-rename-dialog";
+import { useEpicPermissionRole } from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
+import {
+  useEpicDeleteChat,
+  useEpicRenameChat,
+} from "@/hooks/epic/use-epic-chat-mutations";
+import {
+  useEpicDeleteTuiAgent,
+  useEpicRenameTuiAgent,
+} from "@/hooks/epic/use-epic-tui-agent-mutations";
+import {
+  useEpicDeleteArtifact,
+  useEpicRenameArtifact,
+} from "@/hooks/epic/use-epic-node-mutations";
+import { useTerminalRename } from "@/hooks/terminal/use-terminal-rename-mutation";
+import { useTerminalKill } from "@/hooks/terminal/use-terminal-kill-mutation";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { findOpenArtifactInTab } from "@/stores/epics/canvas/canvas-selectors";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+
+export type SwitcherRowKind = "chat" | "terminal-agent" | "artifact" | "terminal";
+
+interface SwitcherRowActionsProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly kind: SwitcherRowKind;
+  /** Content id: the node id for agents/artifacts, the session id for a PTY. */
+  readonly nodeId: string;
+  readonly name: string;
+  /** "… and N nested" summary for a cascading delete; null when none / N/A. */
+  readonly cascadeSummary: string | null;
+}
+
+const RENAME_TITLE: Record<SwitcherRowKind, string> = {
+  chat: "Rename agent",
+  "terminal-agent": "Rename agent",
+  artifact: "Rename artifact",
+  terminal: "Rename terminal",
+};
+
+/**
+ * The per-row "…" actions for the switcher's flat lists: Rename + Delete for
+ * agents/artifacts (delete confirmed), Rename + Close for PTY terminals (Close
+ * is immediate, matching desktop parity). Reuses the exact desktop mutation
+ * hooks and the shared row-menu item renderer; the whole affordance is
+ * editor-gated (a viewer gets no menu at all, so no dead-end mutations). Delete
+ * also closes the item's open canvas tile so the mobile view never lands on a
+ * dead tile.
+ */
+export function SwitcherRowActions(props: SwitcherRowActionsProps) {
+  const { epicId, tabId, kind, nodeId, name, cascadeSummary } = props;
+  const canMutate = isEditableRole(useEpicPermissionRole());
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const renameChat = useEpicRenameChat();
+  const renameTuiAgent = useEpicRenameTuiAgent();
+  const renameArtifact = useEpicRenameArtifact(true);
+  const renameTerminal = useTerminalRename();
+  const deleteChat = useEpicDeleteChat();
+  const deleteTuiAgent = useEpicDeleteTuiAgent();
+  const deleteArtifact = useEpicDeleteArtifact();
+  const killTerminal = useTerminalKill();
+
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareCloseCanvasTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareCloseCanvasTabFocusTarget,
+  );
+
+  // Deleting/closing an item that is open must also close its canvas tile, or
+  // the single mobile tile view would keep rendering a now-dead tile.
+  const closeOpenTile = useCallback(() => {
+    const found = findOpenArtifactInTab(tabId, nodeId);
+    if (found === null) return;
+    navigateNested(epicId, tabId, () =>
+      prepareCloseCanvasTabFocusTarget(tabId, found.paneId, found.instanceId),
+    );
+  }, [epicId, nodeId, navigateNested, prepareCloseCanvasTabFocusTarget, tabId]);
+
+  const submitRename = useCallback(
+    (title: string) => {
+      if (kind === "chat") renameChat.mutate({ epicId, chatId: nodeId, title });
+      else if (kind === "terminal-agent")
+        renameTuiAgent.mutate({ epicId, tuiAgentId: nodeId, title });
+      else if (kind === "artifact")
+        renameArtifact.mutate({ epicId, artifactId: nodeId, title });
+      else renameTerminal.mutate({ sessionId: nodeId, title });
+      setRenameOpen(false);
+    },
+    [
+      epicId,
+      kind,
+      nodeId,
+      renameArtifact,
+      renameChat,
+      renameTerminal,
+      renameTuiAgent,
+    ],
+  );
+
+  const confirmDelete = useCallback(() => {
+    if (kind === "chat")
+      deleteChat.mutate({ epicId, chatId: nodeId }, { onSuccess: closeOpenTile });
+    else if (kind === "terminal-agent")
+      deleteTuiAgent.mutate(
+        { epicId, tuiAgentId: nodeId },
+        { onSuccess: closeOpenTile },
+      );
+    else if (kind === "artifact")
+      deleteArtifact.mutate(
+        { epicId, artifactId: nodeId },
+        { onSuccess: closeOpenTile },
+      );
+    setConfirmOpen(false);
+  }, [
+    closeOpenTile,
+    deleteArtifact,
+    deleteChat,
+    deleteTuiAgent,
+    epicId,
+    kind,
+    nodeId,
+  ]);
+
+  // Terminal "Close" terminates the PTY immediately (no confirm - desktop
+  // parity), closing the open tile first so the action is mount-independent.
+  const closeTerminal = useCallback(() => {
+    if (killTerminal.isPending) return;
+    closeOpenTile();
+    killTerminal.mutate({ sessionId: nodeId });
+  }, [closeOpenTile, killTerminal, nodeId]);
+
+  if (!canMutate) return null;
+
+  const isTerminal = kind === "terminal";
+  const deleteLabel = isTerminal ? "Close" : "Delete";
+  const deletePending =
+    deleteChat.isPending || deleteTuiAgent.isPending || deleteArtifact.isPending;
+
+  const entries: ReadonlyArray<SidebarRowMenuEntry> = [
+    {
+      kind: "item",
+      id: "rename",
+      label: "Rename",
+      icon: <Pencil className="size-3.5" />,
+      disabled: false,
+      variant: "default",
+      testIds: {
+        dropdown: `switcher-rename-${nodeId}`,
+        context: `switcher-rename-ctx-${nodeId}`,
+      },
+      onSelect: () => setRenameOpen(true),
+    },
+    { kind: "separator", id: "before-delete" },
+    {
+      kind: "item",
+      id: "delete",
+      label: deleteLabel,
+      icon: <Trash2 className="size-3.5" />,
+      disabled: isTerminal ? killTerminal.isPending : false,
+      variant: "destructive",
+      testIds: {
+        dropdown: `switcher-delete-${nodeId}`,
+        context: `switcher-delete-ctx-${nodeId}`,
+      },
+      onSelect: isTerminal ? closeTerminal : () => setConfirmOpen(true),
+    },
+  ];
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Actions for ${name}`}
+            data-testid={`switcher-more-${nodeId}`}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <SidebarDropdownMenuItems entries={entries} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <SwitcherRenameDialog
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        title={RENAME_TITLE[kind]}
+        initialValue={name}
+        nodeId={nodeId}
+        onSubmit={submitRename}
+      />
+      {isTerminal ? null : (
+        <ConfirmDestructiveDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          title={`Delete "${name}"?`}
+          description={
+            kind === "artifact"
+              ? "This permanently deletes the artifact."
+              : "This permanently deletes the agent and its history."
+          }
+          cascadeSummary={cascadeSummary}
+          actionLabel="Delete"
+          isPending={deletePending}
+          onConfirm={confirmDelete}
+        />
+      )}
+    </>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
@@ -1,0 +1,110 @@
+import { useCallback } from "react";
+import { Terminal } from "lucide-react";
+import { v4 as uuidv4 } from "uuid";
+import type { CanonicalTerminalSessionInfo } from "@traycer/protocol/host/terminal/unary-schemas";
+import {
+  SwitcherListEmpty,
+  SwitcherListRow,
+} from "@/components/epic-canvas/mobile/switcher-list-row";
+import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
+import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { useHostClient } from "@/lib/host";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { useTerminalList } from "@/hooks/terminal/use-terminal-list-query";
+import { isVisibleEpicTerminalSession } from "@/lib/terminals/terminal-session-filters";
+import {
+  deriveTitleSourceFromSessionTitle,
+  terminalSessionTitle,
+} from "@/lib/terminals/terminal-title";
+import { useIsActiveEpicArtifact } from "@/stores/epics/canvas/canvas-selectors";
+
+interface SwitcherListProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}
+
+/**
+ * Terminals category: raw PTY sessions from the host `terminal.list` query
+ * (NOT the Y.Doc projection), filtered by the shared visibility rule. Sessions
+ * on an unreachable host are still shown (decision); opening one lands on the
+ * existing dead-tile handling.
+ */
+export function SwitcherTerminalsList(props: SwitcherListProps) {
+  const { epicId, tabId, onClose } = props;
+  const hostClient = useHostClient();
+  const list = useTerminalList({ kind: "epic", epicId }, hostClient);
+  const sessions = (list.data?.sessions ?? []).filter((session) =>
+    isVisibleEpicTerminalSession(session, epicId),
+  );
+
+  if (sessions.length === 0) {
+    return <SwitcherListEmpty message="No terminals yet." />;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5 p-1">
+      {sessions.map((session) => (
+        <SwitcherTerminalRow
+          key={session.sessionId}
+          session={session}
+          epicId={epicId}
+          tabId={tabId}
+          onClose={onClose}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SwitcherTerminalRow(props: {
+  readonly session: CanonicalTerminalSessionInfo;
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}) {
+  const { session, epicId, tabId, onClose } = props;
+  const activate = useSwitcherActivate(epicId, tabId, onClose);
+  const isActive = useIsActiveEpicArtifact(tabId, session.sessionId);
+  const hostId = useReactiveActiveHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
+  const label = terminalSessionTitle({
+    title: session.title,
+    activeProcessName: session.activeProcessName,
+  });
+
+  const onSelect = useCallback(() => {
+    activate(session.sessionId, () => ({
+      id: session.sessionId,
+      instanceId: uuidv4(),
+      type: "terminal",
+      name: terminalSessionTitle({
+        title: session.title,
+        activeProcessName: session.activeProcessName,
+      }),
+      titleSource: deriveTitleSourceFromSessionTitle(session.title),
+      hostId,
+      cwd: session.cwd,
+    }));
+  }, [activate, hostId, session]);
+
+  return (
+    <SwitcherListRow
+      icon={<Terminal className="size-4 shrink-0 text-muted-foreground" />}
+      label={label}
+      active={isActive}
+      onSelect={onSelect}
+      selectTestId={`switcher-terminal-row-${session.sessionId}`}
+      actions={
+        <SwitcherRowActions
+          epicId={epicId}
+          tabId={tabId}
+          kind="terminal"
+          nodeId={session.sessionId}
+          name={label}
+          cascadeSummary={null}
+        />
+      }
+    />
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
@@ -44,7 +44,7 @@ export function SwitcherTerminalsList(props: SwitcherListProps) {
   }
 
   return (
-    <div className="flex flex-col gap-0.5 p-1">
+    <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
       {sessions.map((session) => (
         <SwitcherTerminalRow
           key={session.sessionId}

--- a/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/switcher-terminals-list.tsx
@@ -4,10 +4,14 @@ import { v4 as uuidv4 } from "uuid";
 import type { CanonicalTerminalSessionInfo } from "@traycer/protocol/host/terminal/unary-schemas";
 import {
   SwitcherListEmpty,
+  SwitcherListHeader,
   SwitcherListRow,
 } from "@/components/epic-canvas/mobile/switcher-list-row";
 import { SwitcherRowActions } from "@/components/epic-canvas/mobile/switcher-row-actions";
 import { useSwitcherActivate } from "@/components/epic-canvas/mobile/use-switcher-activate";
+import { NewTerminalPicker } from "@/components/epic-canvas/sidebar/new-terminal-picker";
+import { useEpicPermissionRole } from "@/lib/epic-selectors";
+import { isEditableRole } from "@/lib/epic-permissions";
 import { useHostClient } from "@/lib/host";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
@@ -38,22 +42,38 @@ export function SwitcherTerminalsList(props: SwitcherListProps) {
   const sessions = (list.data?.sessions ?? []).filter((session) =>
     isVisibleEpicTerminalSession(session, epicId),
   );
-
-  if (sessions.length === 0) {
-    return <SwitcherListEmpty message="No terminals yet." />;
-  }
+  const canMutate = isEditableRole(useEpicPermissionRole());
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
-      {sessions.map((session) => (
-        <SwitcherTerminalRow
-          key={session.sessionId}
-          session={session}
-          epicId={epicId}
-          tabId={tabId}
-          onClose={onClose}
-        />
-      ))}
+    <div className="flex min-h-0 flex-1 flex-col">
+      <SwitcherListHeader
+        action={
+          canMutate ? (
+            // Reused as-is; `onLaunched` closes the sheet so the new terminal
+            // lands as the visible tile (its own tile kind isn't embed-scoped).
+            <NewTerminalPicker
+              epicId={epicId}
+              tabId={tabId}
+              onLaunched={onClose}
+            />
+          ) : null
+        }
+      />
+      {sessions.length === 0 ? (
+        <SwitcherListEmpty message="No terminals yet." />
+      ) : (
+        <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-1 pb-[env(safe-area-inset-bottom)]">
+          {sessions.map((session) => (
+            <SwitcherTerminalRow
+              key={session.sessionId}
+              session={session}
+              epicId={epicId}
+              tabId={tabId}
+              onClose={onClose}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
@@ -1,0 +1,125 @@
+import { useCallback } from "react";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
+import { SwitcherCategoryTabs } from "@/components/epic-canvas/mobile/switcher-category-tabs";
+import {
+  MOBILE_SWITCHER_CATEGORY_DEFS,
+  clampToSwitcherCategory,
+  isSwitcherCategory,
+} from "@/components/epic-canvas/mobile/switcher-categories";
+import { useIsMobile } from "@/hooks/ui/use-mobile";
+import {
+  useActiveLeftPanelId,
+  useLeftPanelStore,
+  type LeftPanelId,
+} from "@/stores/epics/left-panel-store";
+import "@/components/layout/shell/mobile-shell-touch-targets.css";
+
+interface TabSwitcherSheetProps {
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * The mobile "Switch tab" bottom sheet (the screenshot-2 surface). A
+ * drag-dismissable `vaul` drawer whose category bar mirrors the desktop
+ * left-panel registry and whose content region shows the active category's
+ * body. Foundation ticket (P2.1): the bar + shell + category persistence ship
+ * here; the per-category bodies are placeholders that P2.2 (flat lists) and P2.3
+ * (panel embeds) replace in place.
+ *
+ * Opened from the Phase-1 current-tile bar chevron. Only meaningful on phones -
+ * it is mounted from `MobileEpicTileView`, which itself renders only under the
+ * `useIsMobile()` canvas branch - and self-gates on `useIsMobile()` as defence.
+ */
+export function TabSwitcherSheet(props: TabSwitcherSheetProps) {
+  const { epicId, tabId, open, onOpenChange } = props;
+  const isMobile = useIsMobile();
+  const persistedCategory = useActiveLeftPanelId(tabId);
+  const setActivePanelId = useLeftPanelStore((s) => s.setActivePanelId);
+  const activeCategory = clampToSwitcherCategory(persistedCategory);
+
+  const handleCategoryChange = useCallback(
+    (value: string) => {
+      // Persist through the SAME desktop left-panel store so mobile and desktop
+      // stay in sync; ignore any value outside the curated set defensively.
+      if (isSwitcherCategory(value)) setActivePanelId(tabId, value);
+    },
+    [setActivePanelId, tabId],
+  );
+
+  const handleClose = useCallback(() => onOpenChange(false), [onOpenChange]);
+
+  if (!isMobile) return null;
+
+  return (
+    <Drawer direction="bottom" open={open} onOpenChange={onOpenChange}>
+      <DrawerContent
+        data-mobile-shell-touch-scope=""
+        data-testid="mobile-tab-switcher-sheet"
+        className="max-h-[min(90dvh,44rem)]"
+      >
+        <DrawerHeader className="pb-2">
+          <DrawerTitle>Switch tab</DrawerTitle>
+        </DrawerHeader>
+        <Tabs
+          value={activeCategory}
+          onValueChange={handleCategoryChange}
+          className="min-h-0 flex-1 gap-0"
+        >
+          <div className="shrink-0 border-b border-canvas-border/70">
+            <SwitcherCategoryTabs />
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pb-[env(safe-area-inset-bottom)]">
+            {MOBILE_SWITCHER_CATEGORY_DEFS.map((definition) => (
+              <TabsContent key={definition.id} value={definition.id}>
+                <SwitcherCategoryBody
+                  categoryId={definition.id}
+                  epicId={epicId}
+                  tabId={tabId}
+                  onClose={handleClose}
+                />
+              </TabsContent>
+            ))}
+          </div>
+        </Tabs>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+interface SwitcherCategoryBodyProps {
+  readonly categoryId: LeftPanelId;
+  readonly epicId: string;
+  readonly tabId: string;
+  readonly onClose: () => void;
+}
+
+/**
+ * Content-region registry. P2.1 ships a placeholder per category so the sheet
+ * is functional end-to-end; P2.2 replaces the `chats`/`terminals`/`artifacts`
+ * cases with flat lists and P2.3 the `file-tree`/`git-diff` cases with the
+ * embedded desktop panel bodies. `onClose` is threaded now so those tickets can
+ * close the sheet on selection without touching this signature.
+ */
+function SwitcherCategoryBody(props: SwitcherCategoryBodyProps) {
+  return <SwitcherCategoryPlaceholder categoryId={props.categoryId} />;
+}
+
+function SwitcherCategoryPlaceholder(props: { readonly categoryId: LeftPanelId }) {
+  return (
+    <div
+      data-testid={`mobile-switcher-panel-${props.categoryId}`}
+      className="flex min-h-24 items-center justify-center p-6 text-ui-sm text-muted-foreground"
+    >
+      Coming soon
+    </div>
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { Suspense, lazy, useCallback, useEffect, useMemo, useRef } from "react";
 import {
   Drawer,
   DrawerContent,
@@ -6,6 +6,7 @@ import {
   DrawerTitle,
 } from "@/components/ui/drawer";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
+import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { SwitcherCategoryTabs } from "@/components/epic-canvas/mobile/switcher-category-tabs";
 import {
   MOBILE_SWITCHER_CATEGORY_DEFS,
@@ -15,7 +16,6 @@ import {
 import { SwitcherAgentsList } from "@/components/epic-canvas/mobile/switcher-agents-list";
 import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
 import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-artifacts-list";
-import { SwitcherPanelEmbed } from "@/components/epic-canvas/mobile/switcher-panel-embed";
 import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
 import { useEpicCanvas } from "@/stores/epics/canvas/store";
 import {
@@ -31,6 +31,15 @@ import {
   type LeftPanelId,
 } from "@/stores/epics/left-panel-store";
 import "@/components/layout/shell/mobile-shell-touch-targets.css";
+
+// Lazy so the desktop File-tree / Git-diff bodies - and the heavy epic-sidebar
+// module they pull in - load only when a phone user opens those categories, and
+// never sit in the mobile tile view's eager module graph.
+const SwitcherPanelEmbed = lazy(() =>
+  import("@/components/epic-canvas/mobile/switcher-panel-embed").then((m) => ({
+    default: m.SwitcherPanelEmbed,
+  })),
+);
 
 interface TabSwitcherSheetProps {
   readonly epicId: string;
@@ -179,13 +188,37 @@ function SwitcherCategoryBody(props: SwitcherCategoryBodyProps) {
       );
     case "file-tree":
       return (
-        <SwitcherPanelEmbed category="file-tree" epicId={epicId} tabId={tabId} />
+        <Suspense fallback={<SwitcherEmbedFallback />}>
+          <SwitcherPanelEmbed
+            category="file-tree"
+            epicId={epicId}
+            tabId={tabId}
+          />
+        </Suspense>
       );
     case "git-diff":
       return (
-        <SwitcherPanelEmbed category="git-diff" epicId={epicId} tabId={tabId} />
+        <Suspense fallback={<SwitcherEmbedFallback />}>
+          <SwitcherPanelEmbed
+            category="git-diff"
+            epicId={epicId}
+            tabId={tabId}
+          />
+        </Suspense>
       );
     default:
       return null;
   }
+}
+
+function SwitcherEmbedFallback() {
+  return (
+    <div className="flex min-h-24 flex-1 items-center justify-center p-6">
+      <AgentSpinningDots
+        className="size-4 text-muted-foreground"
+        testId="switcher-embed-loading"
+        variant="dots2"
+      />
+    </div>
+  );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
@@ -25,11 +25,13 @@ import {
   type EpicCanvasTileRef,
 } from "@/stores/epics/canvas/types";
 import { useIsMobile } from "@/hooks/ui/use-mobile";
+import { useResolvedTheme } from "@/providers/use-resolved-theme";
 import {
   useActiveLeftPanelId,
   useLeftPanelStore,
   type LeftPanelId,
 } from "@/stores/epics/left-panel-store";
+import { cn } from "@/lib/utils";
 import "@/components/layout/shell/mobile-shell-touch-targets.css";
 
 // Lazy so the desktop File-tree / Git-diff bodies - and the heavy epic-sidebar
@@ -71,6 +73,10 @@ function isEmbedOriginatedTileRef(ref: EpicCanvasTileRef): boolean {
 export function TabSwitcherSheet(props: TabSwitcherSheetProps) {
   const { epicId, tabId, open, onOpenChange } = props;
   const isMobile = useIsMobile();
+  // The drawer content is portaled to <body>; re-assert the app's resolved
+  // theme on it so `--popover` / `--background` (and the preset tokens) resolve
+  // correctly inside the portal instead of falling back to the light :root.
+  const { resolvedTheme, themePreset } = useResolvedTheme();
   const persistedCategory = useActiveLeftPanelId(tabId);
   const setActivePanelId = useLeftPanelStore((s) => s.setActivePanelId);
   const activeCategory = clampToSwitcherCategory(persistedCategory);
@@ -123,7 +129,8 @@ export function TabSwitcherSheet(props: TabSwitcherSheetProps) {
       <DrawerContent
         data-mobile-shell-touch-scope=""
         data-testid="mobile-tab-switcher-sheet"
-        className="max-h-[min(90dvh,44rem)]"
+        data-theme={themePreset}
+        className={cn(resolvedTheme === "dark" && "dark", "h-[70dvh]")}
       >
         <DrawerHeader className="pb-2">
           <DrawerTitle>Switch tab</DrawerTitle>

--- a/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   Drawer,
   DrawerContent,
@@ -15,6 +15,9 @@ import {
 import { SwitcherAgentsList } from "@/components/epic-canvas/mobile/switcher-agents-list";
 import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
 import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-artifacts-list";
+import { SwitcherPanelEmbed } from "@/components/epic-canvas/mobile/switcher-panel-embed";
+import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
+import { useEpicCanvas } from "@/stores/epics/canvas/store";
 import { useIsMobile } from "@/hooks/ui/use-mobile";
 import {
   useActiveLeftPanelId,
@@ -33,10 +36,9 @@ interface TabSwitcherSheetProps {
 /**
  * The mobile "Switch tab" bottom sheet (the screenshot-2 surface). A
  * drag-dismissable `vaul` drawer whose category bar mirrors the desktop
- * left-panel registry and whose content region shows the active category's
- * body. Foundation ticket (P2.1): the bar + shell + category persistence ship
- * here; the per-category bodies are placeholders that P2.2 (flat lists) and P2.3
- * (panel embeds) replace in place.
+ * left-panel registry and whose content region shows the active category:
+ * flat lists for Agents/Terminals/Artifacts (P2.2) and the embedded desktop
+ * File-tree / Git-diff panel bodies (P2.3).
  *
  * Opened from the Phase-1 current-tile bar chevron. Only meaningful on phones -
  * it is mounted from `MobileEpicTileView`, which itself renders only under the
@@ -60,6 +62,32 @@ export function TabSwitcherSheet(props: TabSwitcherSheetProps) {
 
   const handleClose = useCallback(() => onOpenChange(false), [onOpenChange]);
 
+  // Close-on-open for the embedded panel bodies. The flat lists close the sheet
+  // explicitly (they own the open call), but the File-tree / Git-diff bodies
+  // open a tile through their own internal navigation - which we do not fork -
+  // so instead watch the shown tile: when it changes while the sheet is open, a
+  // selection landed, so close. In-panel navigation (repo / workspace switch)
+  // opens no tile and leaves the shown tile - and the sheet - untouched.
+  const canvas = useEpicCanvas(tabId);
+  const currentInstanceId = useMemo(
+    () => selectMobileTile(canvas)?.ref.instanceId ?? null,
+    [canvas],
+  );
+  const openedInstanceIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!open) {
+      openedInstanceIdRef.current = null;
+      return;
+    }
+    if (openedInstanceIdRef.current === null) {
+      openedInstanceIdRef.current = currentInstanceId;
+      return;
+    }
+    if (currentInstanceId !== openedInstanceIdRef.current) {
+      onOpenChange(false);
+    }
+  }, [open, currentInstanceId, onOpenChange]);
+
   if (!isMobile) return null;
 
   return (
@@ -80,9 +108,13 @@ export function TabSwitcherSheet(props: TabSwitcherSheetProps) {
           <div className="shrink-0 border-b border-canvas-border/70">
             <SwitcherCategoryTabs />
           </div>
-          <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pb-[env(safe-area-inset-bottom)]">
+          <div className="flex min-h-0 flex-1 flex-col">
             {MOBILE_SWITCHER_CATEGORY_DEFS.map((definition) => (
-              <TabsContent key={definition.id} value={definition.id}>
+              <TabsContent
+                key={definition.id}
+                value={definition.id}
+                className="flex min-h-0 flex-1 flex-col overflow-hidden"
+              >
                 <SwitcherCategoryBody
                   categoryId={definition.id}
                   epicId={epicId}
@@ -106,16 +138,18 @@ interface SwitcherCategoryBodyProps {
 }
 
 /**
- * Content-region registry. The `chats`/`terminals`/`artifacts` categories are
- * flat lists (P2.2); `file-tree`/`git-diff` remain placeholders until P2.3
- * embeds the desktop panel bodies. `onClose` closes the sheet after a selection
- * so the chosen item becomes the full-screen mobile tile.
+ * Content-region registry: flat lists (P2.2) for the row-per-item categories;
+ * embedded desktop panel bodies (P2.3) for File tree + Git diff. The flat lists
+ * call `onClose` on selection; the embeds rely on the sheet's active-tile
+ * watcher.
  */
 function SwitcherCategoryBody(props: SwitcherCategoryBodyProps) {
   const { categoryId, epicId, tabId, onClose } = props;
   switch (categoryId) {
     case "chats":
-      return <SwitcherAgentsList epicId={epicId} tabId={tabId} onClose={onClose} />;
+      return (
+        <SwitcherAgentsList epicId={epicId} tabId={tabId} onClose={onClose} />
+      );
     case "terminals":
       return (
         <SwitcherTerminalsList epicId={epicId} tabId={tabId} onClose={onClose} />
@@ -124,18 +158,15 @@ function SwitcherCategoryBody(props: SwitcherCategoryBodyProps) {
       return (
         <SwitcherArtifactsList epicId={epicId} tabId={tabId} onClose={onClose} />
       );
+    case "file-tree":
+      return (
+        <SwitcherPanelEmbed category="file-tree" epicId={epicId} tabId={tabId} />
+      );
+    case "git-diff":
+      return (
+        <SwitcherPanelEmbed category="git-diff" epicId={epicId} tabId={tabId} />
+      );
     default:
-      return <SwitcherCategoryPlaceholder categoryId={categoryId} />;
+      return null;
   }
-}
-
-function SwitcherCategoryPlaceholder(props: { readonly categoryId: LeftPanelId }) {
-  return (
-    <div
-      data-testid={`mobile-switcher-panel-${props.categoryId}`}
-      className="flex min-h-24 items-center justify-center p-6 text-ui-sm text-muted-foreground"
-    >
-      Coming soon
-    </div>
-  );
 }

--- a/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
@@ -12,6 +12,9 @@ import {
   clampToSwitcherCategory,
   isSwitcherCategory,
 } from "@/components/epic-canvas/mobile/switcher-categories";
+import { SwitcherAgentsList } from "@/components/epic-canvas/mobile/switcher-agents-list";
+import { SwitcherTerminalsList } from "@/components/epic-canvas/mobile/switcher-terminals-list";
+import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-artifacts-list";
 import { useIsMobile } from "@/hooks/ui/use-mobile";
 import {
   useActiveLeftPanelId,
@@ -103,14 +106,27 @@ interface SwitcherCategoryBodyProps {
 }
 
 /**
- * Content-region registry. P2.1 ships a placeholder per category so the sheet
- * is functional end-to-end; P2.2 replaces the `chats`/`terminals`/`artifacts`
- * cases with flat lists and P2.3 the `file-tree`/`git-diff` cases with the
- * embedded desktop panel bodies. `onClose` is threaded now so those tickets can
- * close the sheet on selection without touching this signature.
+ * Content-region registry. The `chats`/`terminals`/`artifacts` categories are
+ * flat lists (P2.2); `file-tree`/`git-diff` remain placeholders until P2.3
+ * embeds the desktop panel bodies. `onClose` closes the sheet after a selection
+ * so the chosen item becomes the full-screen mobile tile.
  */
 function SwitcherCategoryBody(props: SwitcherCategoryBodyProps) {
-  return <SwitcherCategoryPlaceholder categoryId={props.categoryId} />;
+  const { categoryId, epicId, tabId, onClose } = props;
+  switch (categoryId) {
+    case "chats":
+      return <SwitcherAgentsList epicId={epicId} tabId={tabId} onClose={onClose} />;
+    case "terminals":
+      return (
+        <SwitcherTerminalsList epicId={epicId} tabId={tabId} onClose={onClose} />
+      );
+    case "artifacts":
+      return (
+        <SwitcherArtifactsList epicId={epicId} tabId={tabId} onClose={onClose} />
+      );
+    default:
+      return <SwitcherCategoryPlaceholder categoryId={categoryId} />;
+  }
 }
 
 function SwitcherCategoryPlaceholder(props: { readonly categoryId: LeftPanelId }) {

--- a/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
+++ b/clients/gui-app/src/components/epic-canvas/mobile/tab-switcher-sheet.tsx
@@ -18,6 +18,12 @@ import { SwitcherArtifactsList } from "@/components/epic-canvas/mobile/switcher-
 import { SwitcherPanelEmbed } from "@/components/epic-canvas/mobile/switcher-panel-embed";
 import { selectMobileTile } from "@/components/epic-canvas/mobile/mobile-tile-selection";
 import { useEpicCanvas } from "@/stores/epics/canvas/store";
+import {
+  isGitDiffTileRef,
+  isSnapshotDiffTileRef,
+  isWorkspaceFileRef,
+  type EpicCanvasTileRef,
+} from "@/stores/epics/canvas/types";
 import { useIsMobile } from "@/hooks/ui/use-mobile";
 import {
   useActiveLeftPanelId,
@@ -31,6 +37,15 @@ interface TabSwitcherSheetProps {
   readonly tabId: string;
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
+}
+
+/** Tile kinds only the embedded File-tree / Git-diff bodies open. */
+function isEmbedOriginatedTileRef(ref: EpicCanvasTileRef): boolean {
+  return (
+    isWorkspaceFileRef(ref) ||
+    isGitDiffTileRef(ref) ||
+    isSnapshotDiffTileRef(ref)
+  );
 }
 
 /**
@@ -65,28 +80,32 @@ export function TabSwitcherSheet(props: TabSwitcherSheetProps) {
   // Close-on-open for the embedded panel bodies. The flat lists close the sheet
   // explicitly (they own the open call), but the File-tree / Git-diff bodies
   // open a tile through their own internal navigation - which we do not fork -
-  // so instead watch the shown tile: when it changes while the sheet is open, a
-  // selection landed, so close. In-panel navigation (repo / workspace switch)
-  // opens no tile and leaves the shown tile - and the sheet - untouched.
+  // so instead watch the shown tile. Close ONLY when the newly-shown tile is an
+  // embed-originated kind (a file-tree tap -> `workspace-file`, a git-diff tap
+  // -> `git-diff` / `snapshot-diff`). A background chat/terminal/artifact open
+  // (agent handoff, remote-delete re-resolve, cross-window nav on the shared
+  // canvas store) also changes the shown tile, but must NOT close the sheet
+  // under the user mid-browse - those flat-list opens close via their own
+  // `onClose` instead.
   const canvas = useEpicCanvas(tabId);
-  const currentInstanceId = useMemo(
-    () => selectMobileTile(canvas)?.ref.instanceId ?? null,
+  const shownTile = useMemo(
+    () => selectMobileTile(canvas)?.ref ?? null,
     [canvas],
   );
-  const openedInstanceIdRef = useRef<string | null>(null);
+  const shownInstanceId = shownTile?.instanceId ?? null;
+  const shownInstanceIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (!open) {
-      openedInstanceIdRef.current = null;
+      shownInstanceIdRef.current = null;
       return;
     }
-    if (openedInstanceIdRef.current === null) {
-      openedInstanceIdRef.current = currentInstanceId;
-      return;
-    }
-    if (currentInstanceId !== openedInstanceIdRef.current) {
+    const previous = shownInstanceIdRef.current;
+    shownInstanceIdRef.current = shownInstanceId;
+    if (previous === null || shownInstanceId === previous) return;
+    if (shownTile !== null && isEmbedOriginatedTileRef(shownTile)) {
       onOpenChange(false);
     }
-  }, [open, currentInstanceId, onOpenChange]);
+  }, [open, shownInstanceId, shownTile, onOpenChange]);
 
   if (!isMobile) return null;
 

--- a/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-activate.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-activate.ts
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+import { useMobileEpicTiles } from "@/components/epic-canvas/mobile/use-mobile-epic-tiles";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { findOpenArtifactInTab } from "@/stores/epics/canvas/canvas-selectors";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+
+export type SwitcherActivate = (
+  contentId: string,
+  buildRef: () => EpicNodeRef,
+) => void;
+
+/**
+ * Shared row-tap handler for the switcher's flat lists. If the item is already
+ * an open tile in this tab, activate it via the existing desktop tab-selection
+ * path (`useMobileEpicTiles().selectTile`); otherwise open it permanently
+ * (`openTileInTab`) through `navigateNested` + the lint-blessed
+ * `prepareOpenTileInTabFocusTarget` (raw canvas actions are ESLint-banned).
+ * Either way the sheet closes, so the chosen tile becomes the full-screen
+ * mobile tile.
+ */
+export function useSwitcherActivate(
+  epicId: string,
+  tabId: string,
+  onClose: () => void,
+): SwitcherActivate {
+  const { selectTile } = useMobileEpicTiles(tabId);
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
+
+  return useCallback(
+    (contentId, buildRef) => {
+      const found = findOpenArtifactInTab(tabId, contentId);
+      if (found !== null) {
+        selectTile(found.paneId, found.instanceId);
+      } else {
+        navigateNested(epicId, tabId, () =>
+          prepareOpenTileInTabFocusTarget(tabId, buildRef()),
+        );
+      }
+      onClose();
+    },
+    [
+      epicId,
+      navigateNested,
+      onClose,
+      prepareOpenTileInTabFocusTarget,
+      selectTile,
+      tabId,
+    ],
+  );
+}

--- a/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-create-artifact.ts
+++ b/clients/gui-app/src/components/epic-canvas/mobile/use-switcher-create-artifact.ts
@@ -1,0 +1,86 @@
+import { useCallback } from "react";
+import type { EpicArtifactKind } from "@traycer/protocol/common/registry";
+import { useEpicCreateArtifact } from "@/hooks/epic/use-epic-node-mutations";
+import { openProjectedSidebarNodeInTabWhenAvailable } from "@/components/epic-canvas/sidebar/open-projected-sidebar-node";
+import { useOpenEpicHandle } from "@/providers/use-open-epic-handle";
+import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
+import { DEFAULT_EPIC_NODE_NAMES } from "@/lib/artifacts/node-display";
+import type { EpicNodeRef } from "@/stores/epics/canvas/types";
+
+export interface SwitcherCreateArtifact {
+  readonly create: (type: EpicArtifactKind) => void;
+  readonly isPending: boolean;
+}
+
+/**
+ * One-shot artifact creation from the switcher, reusing the exact desktop
+ * `addRoot` functions: `useEpicCreateArtifact` then the shared
+ * `openProjectedSidebarNodeInTabWhenAvailable` seam, which opens the artifact
+ * once it projects. That open lands it as the visible mobile tile, which trips
+ * the sheet's active-tile watcher to close. The desktop's inline
+ * pending-create staging (a left-panel-only UI) is intentionally omitted; the
+ * create + open functions are identical.
+ */
+export function useSwitcherCreateArtifact(
+  epicId: string,
+  tabId: string,
+  onOpened: () => void,
+): SwitcherCreateArtifact {
+  const createArtifact = useEpicCreateArtifact();
+  const epicHandle = useOpenEpicHandle();
+  const navigateNested = useEpicNestedFocusNavigation();
+  const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
+    (s) => s.prepareOpenTileInTabFocusTarget,
+  );
+  const activeHostId = useReactiveActiveHostId() ?? UNKNOWN_HOST_PLACEHOLDER;
+
+  const create = useCallback(
+    (type: EpicArtifactKind) => {
+      createArtifact.mutate(
+        {
+          epicId,
+          parentId: null,
+          artifactType: type,
+          title: DEFAULT_EPIC_NODE_NAMES[type],
+        },
+        {
+          onSuccess: (result) => {
+            openProjectedSidebarNodeInTabWhenAvailable({
+              epicHandle,
+              tabId,
+              nodeId: result.artifactId,
+              fallbackHostId: activeHostId,
+              openTileInTab: (targetTabId, nodeRef: EpicNodeRef) => {
+                navigateNested(epicId, targetTabId, () =>
+                  prepareOpenTileInTabFocusTarget(targetTabId, nodeRef),
+                );
+              },
+              onBeforeOpen: null,
+              // The artifact tile is not embed-originated, so the sheet's
+              // watcher won't close on it; close here when it actually opens so
+              // the new artifact lands as the visible tile.
+              onOpened,
+              onUnavailable: () => undefined,
+              onCleanup: null,
+            });
+          },
+        },
+      );
+    },
+    [
+      activeHostId,
+      createArtifact,
+      epicHandle,
+      epicId,
+      navigateNested,
+      onOpened,
+      prepareOpenTileInTabFocusTarget,
+      tabId,
+    ],
+  );
+
+  return { create, isPending: createArtifact.isPending };
+}

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker-no-double.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker-no-double.test.tsx
@@ -110,7 +110,7 @@ describe("<NewTerminalPicker /> double-launch guard", () => {
 
   it("opens a single terminal when Launch fires twice after row selection", () => {
     const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic");
-    render(<NewTerminalPicker epicId="epic-1" tabId={tabId} />);
+    render(<NewTerminalPicker epicId="epic-1" tabId={tabId} onLaunched={null} />);
     fireEvent.click(screen.getByTestId("epic-terminals-panel-add"));
 
     fireEvent.click(screen.getByTestId("double-pick-row"));

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/new-terminal-picker.test.tsx
@@ -108,7 +108,7 @@ function openPicker(): string {
   const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Epic");
   render(
     <TooltipProvider>
-      <NewTerminalPicker epicId="epic-1" tabId={tabId} />
+      <NewTerminalPicker epicId="epic-1" tabId={tabId} onLaunched={null} />
     </TooltipProvider>,
   );
   fireEvent.click(screen.getByTestId("epic-terminals-panel-add"));

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -1040,7 +1040,11 @@ function GitDiffPanelBody(props: LeftPanelBodyProps): ReactNode {
   return <GitDiffPanelBodyLive epicId={props.epicId} tabId={props.tabId} />;
 }
 
-function FileTreePanelBody(props: LeftPanelBodyProps) {
+// Exported (export-only, desktop-neutral) so the mobile "Switch tab" sheet can
+// embed the same file-tree body the desktop left panel renders, rather than
+// forking it. The `SnapshotGate` resolves against the canvas-side
+// `SnapshotLoadingProvider` that already wraps the mobile tile view.
+export function FileTreePanelBody(props: LeftPanelBodyProps) {
   return (
     <SnapshotGate skeleton={FILE_TREE_PANEL_SKELETON}>
       <FileTreePanelBodyLive epicId={props.epicId} tabId={props.tabId} />

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -180,7 +180,13 @@ function TerminalsPanelBodyLive(props: {
  * every host list update.
  */
 export function TerminalsPanelActions(props: LeftPanelSlotProps) {
-  return <NewTerminalPicker epicId={props.epicId} tabId={props.tabId} />;
+  return (
+    <NewTerminalPicker
+      epicId={props.epicId}
+      tabId={props.tabId}
+      onLaunched={null}
+    />
+  );
 }
 
 interface TerminalSidebarBodyProps {

--- a/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/new-terminal-picker.tsx
@@ -34,9 +34,16 @@ import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 interface NewTerminalPickerProps {
   readonly epicId: string;
   readonly tabId: string;
+  /**
+   * Fired synchronously right after a terminal is launched (before the popover
+   * closes). The desktop sidebar passes `null`; the mobile switcher sheet uses
+   * it to close itself so the new terminal lands as the visible tile.
+   */
+  readonly onLaunched: (() => void) | null;
 }
 
 export function NewTerminalPicker(props: NewTerminalPickerProps) {
+  const { onLaunched } = props;
   const [isOpen, setIsOpen] = useState(false);
   // The user's explicit pick. Null means "follow the auto-selected default";
   // the effective selection is derived below so a default never has to be
@@ -116,11 +123,13 @@ export function NewTerminalPicker(props: NewTerminalPickerProps) {
       }),
     );
     setIsOpen(false);
+    if (onLaunched !== null) onLaunched();
   }, [
     navigateNested,
     prepareOpenTileInTabFocusTarget,
     props.epicId,
     props.tabId,
+    onLaunched,
     launchTarget,
   ]);
 

--- a/clients/gui-app/src/components/layout/shell/mobile-shell-touch-targets.css
+++ b/clients/gui-app/src/components/layout/shell/mobile-shell-touch-targets.css
@@ -33,4 +33,11 @@
     height: max(100%, 44px);
     transform: translateY(-50%);
   }
+
+  /* Command-palette opener rows (e.g. the empty-pane opener) stack vertically,
+     so enlarge the row itself to the 44px target instead of adding vertical
+     hit-slop that would overlap the neighbouring row. */
+  [data-mobile-shell-touch-scope] [data-slot="command-item"] {
+    min-height: 44px;
+  }
 }

--- a/clients/gui-app/src/components/layout/shell/mobile-shell-touch-targets.css
+++ b/clients/gui-app/src/components/layout/shell/mobile-shell-touch-targets.css
@@ -2,14 +2,15 @@
  * Mobile-shell-scoped touch-target enlargement, mirroring the settings/home
  * pattern (settings-touch-targets.css / home-touch-targets.css).
  *
- * The phone shell's icon-size controls - the header hamburger and the
- * drawer / notifications-sheet close buttons (Button icon-sm ~28px) - sit
+ * The phone shell's icon-size controls - the header hamburger, the
+ * drawer / notifications-sheet close buttons (Button icon-sm ~28px), and the
+ * tab-switcher sheet's category tabs (tabs-trigger min-h-9 ~36px) - sit
  * below the 44px touch-target guideline. These rules extend each control's
  * *hit area* to >=44px via an invisible pseudo-element; visual size and layout
  * are unchanged on every device, and the scope attribute (set on the mobile
- * header, the nav drawer, and the notifications sheet) keeps the rest of the
- * app untouched. The mobile shell only renders below md, so desktop never
- * carries the scope.
+ * header, the nav drawer, the notifications sheet, and the switcher sheet)
+ * keeps the rest of the app untouched. The mobile shell only renders below md,
+ * so desktop never carries the scope.
  *
  * Vertical-only slop, matching precedent: flush horizontal neighbours would
  * otherwise capture each other's taps. `.absolute` controls (the drawer's
@@ -18,11 +19,13 @@
  * them into flow; an absolutely positioned control anchors its ::after itself.
  */
 @media (pointer: coarse) {
-  [data-mobile-shell-touch-scope] [data-slot="button"]:not(.absolute) {
+  [data-mobile-shell-touch-scope]
+    :is([data-slot="button"], [data-slot="tabs-trigger"]):not(.absolute) {
     position: relative;
   }
 
-  [data-mobile-shell-touch-scope] [data-slot="button"]::after {
+  [data-mobile-shell-touch-scope]
+    :is([data-slot="button"], [data-slot="tabs-trigger"])::after {
     content: "";
     position: absolute;
     inset-inline: 0;

--- a/clients/gui-app/src/components/layout/shell/mobile-shell-touch-targets.css
+++ b/clients/gui-app/src/components/layout/shell/mobile-shell-touch-targets.css
@@ -27,6 +27,14 @@
   [data-mobile-shell-touch-scope]
     :is([data-slot="button"], [data-slot="tabs-trigger"])::after {
     content: "";
+    /* Pure hit-area - this pseudo must NEVER paint. An element has a single
+       `::after`, so this rule merges with a control's own `::after` (e.g.
+       ui/tabs' `line`-variant active indicator, `after:bg-foreground`). Being
+       unlayered we win the geometry (`height:max(100%,44px)`, centred) while
+       the control's `background`/`opacity` would otherwise survive and paint a
+       full-cover, opaque box over the label. Forcing the background transparent
+       keeps the slop invisible for every current and future control it wraps. */
+    background: transparent;
     position: absolute;
     inset-inline: 0;
     top: 50%;

--- a/clients/gui-app/src/components/ui/drawer.tsx
+++ b/clients/gui-app/src/components/ui/drawer.tsx
@@ -35,7 +35,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/40 supports-backdrop-filter:backdrop-blur-xs data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+        "fixed inset-0 z-50 bg-black/40 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className,
       )}
       {...props}

--- a/clients/gui-app/src/components/ui/drawer.tsx
+++ b/clients/gui-app/src/components/ui/drawer.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
+
+import { cn } from "@/lib/utils";
+
+function Drawer({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+}
+
+function DrawerTrigger({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
+}
+
+function DrawerPortal({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
+}
+
+function DrawerClose({
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+  return (
+    <DrawerPrimitive.Overlay
+      data-slot="drawer-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/40 supports-backdrop-filter:backdrop-blur-xs data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+/**
+ * `vaul` drawer primitive (drag-dismissable). Direction is caller-set via
+ * `Drawer direction="bottom"`. The content imposes NO max-height itself so the
+ * composing surface caps it with a viewport-aware value (e.g.
+ * `max-h-[min(90dvh,…)]`) and owns its own internal scroll region. The grab
+ * handle renders only for the bottom direction.
+ */
+function DrawerContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  return (
+    <DrawerPortal data-slot="drawer-portal">
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        data-slot="drawer-content"
+        className={cn(
+          "group/drawer-content fixed z-50 flex h-auto flex-col bg-popover bg-clip-padding text-popover-foreground shadow-lg",
+          "data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b",
+          "data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t",
+          "data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm",
+          "data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=left]:sm:max-w-sm",
+          className,
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-3 hidden h-1.5 w-12 shrink-0 rounded-full bg-border group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  );
+}
+
+function DrawerTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn(
+        "font-heading text-ui font-medium text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn("text-ui-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+};

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "uuid": "^14.0.1",
+    "vaul": "^1.1.2",
     "vite": "^8.1.5",
     "vitest": "^4.1.10",
     "y-protocols": "^1.0.7",


### PR DESCRIPTION
## Phase 2 of the mobile no-tabs redesign — the "Switch tab" bottom sheet

Final of three stacked phases (Phase 0 = #630, Phase 1 = #633, both merged). Tapping the current-tile bar's chevron opens a bottom sheet that switches **and creates** tiles by category. **Desktop ≥768px is unchanged** — every change is gated behind `useIsMobile()`/`max-md:` or is a desktop-neutral export/prop edit.

### What this adds (mobile only)
- **Bottom-sheet switcher** (`vaul` drawer, opens at 70dvh) with category tabs driven by the **desktop left-panel registry**: **Chats · Artifacts · File tree · Git diff · Terminals** (so categories never drift from desktop).
- **Flat lists** (Chats / Terminals / Artifacts) built over the same selectors the desktop sidebar uses; tapping a row activates it (dedup — never opens a duplicate) or opens it, then closes the sheet. Per-row "…" = Rename/Delete (Close for terminals), editor-gated.
- **File tree + Git diff** embed the **real desktop panel bodies** (one export-only line in `epic-sidebar.tsx`), lazy-loaded.
- **Create ("+")** per category — new chat / terminal / artifact — reusing the exact desktop creation funnels; editor-gated.
- Carried-over Phase-1 polish (empty-pane keyboard/touch, edge-to-edge canvas) + the theme/height/label fixes.

### The one new dependency
`vaul` (shadcn drawer), pinned via the bun catalog; it dedupes onto the app's single `@radix-ui/react-dialog` — no version skew. It's the only bottom-sheet primitive the app lacked.

### Desktop-touching edits (each proven neutral)
- `new-terminal-picker.tsx` gains a required `onLaunched: (() => void) | null`; the sole desktop caller passes `null` (guarded) → byte-unchanged.
- `epic-sidebar.tsx` — one export-only line.
- `mobile-shell-touch-targets.css` — coarse-pointer/scoped only; includes the fix so the touch hit-slop `::after` never paints (also cured a latent white-box on the notifications tabs).

### Verification
- Independently cold-reviewed per ticket + a whole-phase pass: SHIP.
- Device-confirmed by the user (dark sheet, 70dvh, readable active tab).
- **Pre-existing CI reds** (duplicate `prosemirror-model` editor/export tests; flaky desktop `host-lifecycle`) are unrelated and predate this — same as on `mobile-app`.

### Deferred (tracked, not lost)
8 small polish items (agent-row notification dots, per-type icon colors, current-host label, dropdown-item touch size, a couple of sheet edge-cases) — none blocking; listed in the epic plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)