### PR TITLE
fix(gui-app): preserve worktree selection across settings navigation

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -39,6 +39,7 @@ import {
   EMPTY_WORKTREE_TIER_FILTERS,
   useWorktreesSettingsViewStore,
 } from "@/stores/settings/worktrees-settings-view-store";
+import { useWorktreesSettingsSelectionStore } from "@/stores/settings/worktrees-settings-selection-store";
 import {
   installWorktreeVirtualizerOffsetHeight,
   WORKTREE_TEST_VIRTUAL_ITEM_HEIGHT,
@@ -300,6 +301,9 @@ beforeEach(() => {
     searchText: "",
     sortMode: DEFAULT_WORKTREE_SORT_MODE,
     tierFilters: EMPTY_WORKTREE_TIER_FILTERS,
+  });
+  useWorktreesSettingsSelectionStore.setState({
+    selectedPathsByHost: new Map(),
   });
   virtualViewportHeight = 100_000;
   restoreOffsetHeight = installWorktreeVirtualizerOffsetHeight(
@@ -954,6 +958,39 @@ describe("WorktreesList delete flow", () => {
     ).toBe("false");
   });
 
+  it("preserves selection when the Worktrees settings panel remounts", () => {
+    const rendered = renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: WORKTREES,
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      seededPaths: undefined,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select worktree feat-clean" }),
+    );
+    expect(screen.getByText("1 selected")).not.toBeNull();
+
+    rendered.unmount();
+    renderDefault();
+
+    expect(screen.getByText("1 selected")).not.toBeNull();
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select worktree feat-clean" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select worktree feat-dirty" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+  });
+
   it("gives the scroll viewport a minimum bottom clearance while selecting, and removes it once cleared", () => {
     renderDefault();
     const scrollRegion = screen.getByTestId("worktrees-virtual-scroll");
@@ -1065,6 +1102,41 @@ describe("WorktreesList delete flow", () => {
 
     fireEvent.click(screen.getByTestId("worktrees-select-all"));
     expect(screen.getByText("1 selected")).not.toBeNull();
+
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(streamMock.paths).toEqual(["/wt/dirty"]);
+  });
+
+  it("preserves hidden selections when a searched worktree is deselected", () => {
+    renderDefault();
+
+    fireEvent.click(screen.getByTestId("worktrees-select-all"));
+    expect(screen.getByText("2 selected")).not.toBeNull();
+
+    const search = screen.getByRole("searchbox", {
+      name: "Search worktrees",
+    });
+    fireEvent.change(search, { target: { value: "clean" } });
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Select worktree feat-clean" }),
+    );
+
+    expect(screen.queryByTestId("worktrees-selection-action-bar")).toBeNull();
+
+    fireEvent.change(search, { target: { value: "" } });
+
+    expect(screen.getByText("1 selected")).not.toBeNull();
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select worktree feat-clean" })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select worktree feat-dirty" })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
 
     fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
     fireEvent.click(screen.getByTestId("confirm-action"));

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -142,6 +142,11 @@ import {
   useWorktreesSettingsViewStore,
   type WorktreeSortMode,
 } from "@/stores/settings/worktrees-settings-view-store";
+import {
+  EMPTY_SELECTED_WORKTREE_PATHS,
+  useWorktreesSettingsSelectionStore,
+  type SelectedWorktreePathsUpdate,
+} from "@/stores/settings/worktrees-settings-selection-store";
 
 type WorktreeRowDeleteStatus = "deleting";
 // Per-row activity-enrichment state, driving ONLY the tier pill's presentation:
@@ -1058,8 +1063,18 @@ export function WorktreesList(props: {
     close,
     dismissTerminalBackgrounded,
   } = useWorktreeDeleteRun(hostId, openStreamTransport, invalidate);
-  const [selectedPaths, setSelectedPaths] = useState<ReadonlySet<string>>(
-    () => new Set(),
+  const selectedPaths = useWorktreesSettingsSelectionStore(
+    (state) =>
+      state.selectedPathsByHost.get(hostId) ?? EMPTY_SELECTED_WORKTREE_PATHS,
+  );
+  const setSelectedPathsForHost = useWorktreesSettingsSelectionStore(
+    (state) => state.setSelectedPaths,
+  );
+  const setSelectedPaths = useCallback(
+    (update: SelectedWorktreePathsUpdate): void => {
+      setSelectedPathsForHost(hostId, update);
+    },
+    [hostId, setSelectedPathsForHost],
   );
   const [pendingDeleteTargets, setPendingDeleteTargets] =
     useState<ReadonlyArray<WorktreeHostEntryV14> | null>(null);
@@ -1272,10 +1287,10 @@ export function WorktreesList(props: {
       }
       return next;
     });
-  }, [allVisibleSelected, selectableWorktreePaths]);
+  }, [allVisibleSelected, selectableWorktreePaths, setSelectedPaths]);
   const clearSelection = useCallback(() => {
     setSelectedPaths(new Set());
-  }, []);
+  }, [setSelectedPaths]);
   const toggleRepoCollapsed = useCallback(
     (group: WorktreeRepoGroup, collapsed: boolean) => {
       if (collapsed) {
@@ -1285,7 +1300,7 @@ export function WorktreesList(props: {
         setSelectedPaths((prev) => removeSelectedWorktrees(prev, group.items));
       }
     },
-    [],
+    [setSelectedPaths],
   );
   const toggleAllReposCollapsed = useCallback(() => {
     if (allReposCollapsed) {
@@ -1294,7 +1309,7 @@ export function WorktreesList(props: {
     }
     dispatchCollapsedRepoKeys({ type: "collapse-all", keys: repoKeys });
     setSelectedPaths(new Set());
-  }, [allReposCollapsed, repoKeys]);
+  }, [allReposCollapsed, repoKeys, setSelectedPaths]);
   const requestDeleteTargets = useCallback(
     (targets: ReadonlyArray<WorktreeHostEntryV14>) => {
       // A `Checking` row's tier isn't known yet, so it never opens a delete

--- a/clients/gui-app/src/stores/settings/worktrees-settings-selection-store.ts
+++ b/clients/gui-app/src/stores/settings/worktrees-settings-selection-store.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+
+export const EMPTY_SELECTED_WORKTREE_PATHS: ReadonlySet<string> = new Set();
+
+export type SelectedWorktreePathsUpdate =
+  | ReadonlySet<string>
+  | ((selectedPaths: ReadonlySet<string>) => ReadonlySet<string>);
+
+interface WorktreesSettingsSelectionStoreState {
+  readonly selectedPathsByHost: ReadonlyMap<string, ReadonlySet<string>>;
+  readonly setSelectedPaths: (
+    hostId: string,
+    update: SelectedWorktreePathsUpdate,
+  ) => void;
+}
+
+/**
+ * Session-only Worktrees settings selection. This survives the panel being
+ * unmounted while the user visits another Settings section or closes and
+ * reopens Settings, but deliberately is not persisted across app restarts.
+ * Selections are host-scoped so changing the managed host cannot leak paths
+ * into another host's list.
+ */
+export const useWorktreesSettingsSelectionStore =
+  create<WorktreesSettingsSelectionStoreState>()((set, get) => ({
+    selectedPathsByHost: new Map(),
+    setSelectedPaths: (hostId, update) => {
+      const current =
+        get().selectedPathsByHost.get(hostId) ?? EMPTY_SELECTED_WORKTREE_PATHS;
+      const next = typeof update === "function" ? update(current) : update;
+      if (next === current) return;
+
+      const selectedPathsByHost = new Map(get().selectedPathsByHost);
+      if (next.size === 0) selectedPathsByHost.delete(hostId);
+      else selectedPathsByHost.set(hostId, next);
+      set({ selectedPathsByHost });
+    },
+  }));


### PR DESCRIPTION
## Summary

- preserve selected Worktrees rows when the Settings panel unmounts and remounts
- keep selection scoped to the active host and limited to the current app session
- add regression coverage for Settings navigation and search-filter selection behavior

## Verification

- worktrees settings panel: 103 tests passed
- gui-app compile, ESLint, Prettier, React Doctor
- pre-commit run --all-files