### PR TITLE
feat(gui-app): consolidate task artifact mentions

### DIFF
--- a/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/__tests__/providers.test.tsx
@@ -106,9 +106,7 @@ describe("mention provider registry", () => {
       "Worktrees",
       "Git",
       "Task",
-      "Spec",
-      "Ticket",
-      "Story",
+      "Artifacts",
       "Review",
     ]);
   });
@@ -143,9 +141,7 @@ describe("mention provider registry", () => {
       "Git",
       "Task",
       "Agents",
-      "Spec",
-      "Ticket",
-      "Story",
+      "Artifacts",
       "Review",
     ]);
 
@@ -459,6 +455,104 @@ describe("mention provider registry", () => {
       "epic.mentionStories",
       "epic.mentionReviews",
     ]);
+
+    const artifactStep: MentionFlowStep = {
+      kind: "provider",
+      providerId: "artifacts",
+      stepId: "root",
+      workspacePath: null,
+    };
+    expect(
+      mentionProviderRegistry
+        .epicRequests(artifactStep, context({ query: "login" }))
+        .map((request) => request.method),
+    ).toEqual([
+      "epic.mentionSpecs",
+      "epic.mentionTickets",
+      "epic.mentionStories",
+    ]);
+  });
+
+  it("lists specs, tickets, and stories together while preserving mention types", () => {
+    const artifactStep: MentionFlowStep = {
+      kind: "provider",
+      providerId: "artifacts",
+      stepId: "root",
+      workspacePath: null,
+    };
+    const entries = mentionProviderRegistry.entries(
+      artifactStep,
+      context({
+        epicEntries: [
+          {
+            kind: "epic-artifact",
+            id: "spec:epic-1:spec-1",
+            token: "spec:epic-1/spec-1",
+            epicId: "epic-1",
+            epicTitle: "Auth epic",
+            artifactId: "spec-1",
+            artifactType: "spec",
+            label: "Auth spec",
+            description: "Auth epic",
+            status: null,
+            updatedAt: 30,
+          },
+          {
+            kind: "epic-artifact",
+            id: "ticket:epic-1:ticket-1",
+            token: "ticket:epic-1/ticket-1",
+            epicId: "epic-1",
+            epicTitle: "Auth epic",
+            artifactId: "ticket-1",
+            artifactType: "ticket",
+            label: "Auth ticket",
+            description: "Auth epic",
+            status: 1,
+            updatedAt: 20,
+          },
+          {
+            kind: "epic-artifact",
+            id: "story:epic-1:story-1",
+            token: "story:epic-1/story-1",
+            epicId: "epic-1",
+            epicTitle: "Auth epic",
+            artifactId: "story-1",
+            artifactType: "story",
+            label: "Auth story",
+            description: "Auth epic",
+            status: 0,
+            updatedAt: 10,
+          },
+          {
+            kind: "epic-artifact",
+            id: "review:epic-1:review-1",
+            token: "review:epic-1/review-1",
+            epicId: "epic-1",
+            epicTitle: "Auth epic",
+            artifactId: "review-1",
+            artifactType: "review",
+            label: "Auth review",
+            description: "Auth epic",
+            status: null,
+            updatedAt: 5,
+          },
+        ],
+      }),
+    );
+
+    expect(labels(entries)).toEqual([
+      "Back",
+      "Auth spec",
+      "Auth ticket",
+      "Auth story",
+    ]);
+    expect(completeEntry(entries[1]).contextType).toBe("spec");
+    expect(completeEntry(entries[2]).contextType).toBe("ticket");
+    expect(completeEntry(entries[3]).contextType).toBe("story");
+    expect(mentionProviderRegistry.menuCopy(artifactStep)).toEqual({
+      header: "Artifacts",
+      empty: "No artifacts available",
+    });
   });
 
   it("keeps task and epic provider aliases backward-compatible for task requests", () => {
@@ -621,7 +715,7 @@ describe("mention preview payloads", () => {
   it("previews an artifact entry with its full title and parent epic title", () => {
     const step: MentionFlowStep = {
       kind: "provider",
-      providerId: "spec",
+      providerId: "artifacts",
       stepId: "root",
       workspacePath: null,
     };

--- a/clients/gui-app/src/lib/composer/mentions/mention-entry-display.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/mention-entry-display.tsx
@@ -1,4 +1,5 @@
 import {
+  Files,
   Folder,
   FolderGit2,
   GitBranch,
@@ -226,6 +227,10 @@ export function epicIcon(): ReactElement {
 
 export function artifactIcon(kind: EpicArtifactKind): ReactElement {
   return epicNodeIcon(kind);
+}
+
+export function artifactsIcon(): ReactElement {
+  return <Files className={MENU_ICON_CLASS} aria-hidden />;
 }
 
 export function epicNodeIcon(

--- a/clients/gui-app/src/lib/composer/mentions/providers.tsx
+++ b/clients/gui-app/src/lib/composer/mentions/providers.tsx
@@ -16,6 +16,7 @@ import type { RequestOfMethod } from "@traycer-clients/shared/host-transport/hos
 import { mentionAttachmentFromSuggestion } from "./attachments";
 import {
   artifactIcon,
+  artifactsIcon,
   descriptionForSuggestion,
   detailForSuggestion,
   epicIcon,
@@ -34,7 +35,14 @@ const EMPTY_WORKSPACE_REQUESTS: ReadonlyArray<MentionWorkspaceRequest> = [];
 const EMPTY_EPIC_REQUESTS: ReadonlyArray<MentionEpicRequest> = [];
 
 export type MentionProviderId =
-  "files" | "folders" | "worktree" | "git" | "epic" | "chat" | EpicArtifactKind;
+  | "files"
+  | "folders"
+  | "worktree"
+  | "git"
+  | "epic"
+  | "chat"
+  | "artifacts"
+  | "review";
 
 export interface MentionMenuCopy {
   readonly header: string;
@@ -579,28 +587,16 @@ const EPIC_ARTIFACT_MENTION_METHODS: Record<
   review: "epic.mentionReviews",
 };
 
-const EPIC_ARTIFACT_PLURAL_LABELS: Record<EpicArtifactKind, string> = {
-  spec: "Specs",
-  ticket: "Tickets",
-  story: "Stories",
-  review: "Reviews",
-};
+const STANDARD_ARTIFACT_KINDS: ReadonlyArray<EpicArtifactKind> = [
+  "spec",
+  "ticket",
+  "story",
+];
 
-const EPIC_ARTIFACT_DESCRIPTIONS: Record<EpicArtifactKind, string> = {
-  spec: "Spec artifacts",
-  ticket: "Ticket artifacts",
-  story: "Story artifacts",
-  review: "Review artifacts",
-};
 function isArtifactMentionProviderId(
   providerId: MentionProviderId,
-): providerId is EpicArtifactKind {
-  return (
-    providerId === "spec" ||
-    providerId === "ticket" ||
-    providerId === "story" ||
-    providerId === "review"
-  );
+): providerId is "artifacts" | "review" {
+  return providerId === "artifacts" || providerId === "review";
 }
 
 export function isArtifactMentionStep(step: MentionFlowStep): boolean {
@@ -610,27 +606,32 @@ export function isArtifactMentionStep(step: MentionFlowStep): boolean {
 }
 
 class ArtifactMentionProvider extends ComposerMentionProvider {
-  readonly id: EpicArtifactKind;
+  readonly id: "artifacts" | "review";
   readonly rootOrder: number;
   protected readonly label: string;
   protected readonly description: string;
-  private readonly artifactKind: EpicArtifactKind;
+  private readonly artifactKinds: ReadonlySet<EpicArtifactKind>;
 
-  constructor(kind: EpicArtifactKind, rootOrder: number) {
+  constructor(
+    id: "artifacts" | "review",
+    artifactKinds: ReadonlyArray<EpicArtifactKind>,
+    rootOrder: number,
+  ) {
     super();
-    this.id = kind;
+    this.id = id;
     this.rootOrder = rootOrder;
-    this.artifactKind = kind;
-    this.label = EPIC_NODE_LABELS[kind];
-    this.description = EPIC_ARTIFACT_DESCRIPTIONS[kind];
+    this.artifactKinds = new Set(artifactKinds);
+    this.label = id === "artifacts" ? "Artifacts" : EPIC_NODE_LABELS.review;
+    this.description =
+      id === "artifacts" ? "Task artifacts" : "Review artifacts";
   }
 
   rootEntry(_context: ComposerMentionProviderContext): MentionMenuEntry | null {
     return providerEntry({
-      id: `provider:${this.artifactKind}`,
+      id: `provider:${this.id}`,
       label: this.label,
       description: this.description,
-      icon: artifactIcon(this.artifactKind),
+      icon: this.id === "artifacts" ? artifactsIcon() : artifactIcon("review"),
       step: this.providerStep("root", null),
     });
   }
@@ -639,7 +640,8 @@ class ArtifactMentionProvider extends ComposerMentionProvider {
     context: ComposerMentionProviderContext,
   ): ReadonlyArray<MentionMenuEntry> {
     return context.epicEntries.flatMap((entry) =>
-      entry.kind === "epic-artifact" && entry.artifactType === this.artifactKind
+      entry.kind === "epic-artifact" &&
+      this.artifactKinds.has(entry.artifactType)
         ? suggestionEntry(entry)
         : [],
     );
@@ -648,9 +650,9 @@ class ArtifactMentionProvider extends ComposerMentionProvider {
   rootEpicRequests(
     context: ComposerMentionProviderContext,
   ): ReadonlyArray<MentionEpicRequest> {
-    return [
-      epicRequest(context, EPIC_ARTIFACT_MENTION_METHODS[this.artifactKind]),
-    ];
+    return [...this.artifactKinds].map((kind) =>
+      epicRequest(context, EPIC_ARTIFACT_MENTION_METHODS[kind]),
+    );
   }
 
   epicRequests(
@@ -668,7 +670,7 @@ class ArtifactMentionProvider extends ComposerMentionProvider {
       backEntry("Mentions"),
       ...context.epicEntries.flatMap((entry) =>
         entry.kind === "epic-artifact" &&
-        entry.artifactType === this.artifactKind
+        this.artifactKinds.has(entry.artifactType)
           ? suggestionEntry(entry)
           : [],
       ),
@@ -676,7 +678,7 @@ class ArtifactMentionProvider extends ComposerMentionProvider {
   }
 
   menuCopy(_step: MentionFlowStep): MentionMenuCopy {
-    const plural = EPIC_ARTIFACT_PLURAL_LABELS[this.artifactKind];
+    const plural = this.id === "artifacts" ? "Artifacts" : "Reviews";
     return {
       header: plural,
       empty: `No ${plural.toLowerCase()} available`,
@@ -770,10 +772,8 @@ export const mentionProviderRegistry = new MentionProviderRegistry([
   new GitMentionProvider(),
   new EpicMentionProvider(),
   new AgentMentionProvider(),
-  new ArtifactMentionProvider("spec", 50),
-  new ArtifactMentionProvider("ticket", 60),
-  new ArtifactMentionProvider("story", 70),
-  new ArtifactMentionProvider("review", 80),
+  new ArtifactMentionProvider("artifacts", STANDARD_ARTIFACT_KINDS, 50),
+  new ArtifactMentionProvider("review", ["review"], 60),
 ]);
 
 interface ProviderEntryArgs {


### PR DESCRIPTION
## Summary
- replace separate Spec, Ticket, and Story mention roots with a unified Artifacts root
- preserve the underlying artifact context type for selected mentions
- keep reviews as a separate mention root

## Validation
- bun run test src/lib/composer/mentions/__tests__/providers.test.tsx
- bun x eslint src/lib/composer/mentions/providers.tsx src/lib/composer/mentions/mention-entry-display.tsx src/lib/composer/mentions/__tests__/providers.test.tsx --max-warnings 0
- bun run compile
- npx react-doctor@latest . --verbose --scope changed --base main --offline --no-score
- pre-commit affected build, compile, lint, and format