### PR TITLE
test(protocol): stabilize credentials lock contention

### DIFF
--- a/protocol/src/config/__tests__/credentials-lock.test.ts
+++ b/protocol/src/config/__tests__/credentials-lock.test.ts
@@ -244,7 +244,7 @@ describe("acquireCredentialsLock", () => {
       const acquired = await Promise.all(
         Array.from({ length: 4 }, () =>
           (async () => {
-            const r = await acquireCredentialsLock(opts({ waitMs: 3000 }));
+            const r = await acquireCredentialsLock(opts({ waitMs: 10_000 }));
             if (r.acquired) await r.handle.release();
             return r.acquired;
           })(),
@@ -254,6 +254,7 @@ describe("acquireCredentialsLock", () => {
       expect(acquired.every(Boolean)).toBe(true);
       expect(() => readFileSync(lockPath, "utf8")).toThrow();
     },
+    15_000,
   );
 });
 


### PR DESCRIPTION
## Summary

- increase the test-only deadline for serialized credential-lock contenders under CI parallelism
- add an explicit Vitest timeout aligned with that deadline

## Verification

- `bunx vitest run src/config/__tests__/credentials-lock.test.ts` ×20

The production lock behavior is unchanged.