### PR TITLE
fix(desktop): register app scheme after Sentry crash reporter init

### DIFF
--- a/clients/desktop/src/electron-main/startup/__tests__/desktop-startup.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/desktop-startup.test.ts
@@ -16,11 +16,14 @@ import {
 // `desktop-startup.ts` is the Electron main-process boot sequence: importing
 // it pulls in ~40 sibling modules (tray, updater, host lifecycle, IPC,
 // crash reporting, ...) that are only ever called from inside
-// `runDesktopStartup`/`runOnReady`/`runWindowPhase`/`runDeferred`, none of
-// which this suite invokes. Every one of those sibling imports is stubbed
-// below so the module loads without touching real Electron APIs, real
-// filesystem state, or third-party SDKs (e.g. `@sentry/electron`, pulled in
-// transitively by `../app/diagnostics`) - only `electron` itself and
+// `runDesktopStartup`/`runOnReady`/`runWindowPhase`/`runDeferred`/`runPreReady`,
+// none of which this suite invokes end-to-end (the "runPreReady - scheme/
+// crash-reporter ordering" suite below calls the real `runPreReady()`
+// directly, but only to assert call order on two already-stubbed sibling
+// mocks). Every one of those sibling imports is stubbed below so the module
+// loads without touching real Electron APIs, real filesystem state, or
+// third-party SDKs (e.g. `@sentry/electron`, pulled in transitively by
+// `../app/diagnostics`) - only `electron` itself and
 // `../windows/window-registry` need to behave like the real thing, and
 // `window-registry` is left completely real.
 

--- a/clients/desktop/src/electron-main/startup/__tests__/desktop-startup.test.ts
+++ b/clients/desktop/src/electron-main/startup/__tests__/desktop-startup.test.ts
@@ -166,7 +166,7 @@ vi.mock("../../notifications", () => ({
   installNotificationActivationHandler: () => undefined,
 }));
 vi.mock("../../app/crash-reporter", () => ({
-  initCrashReporter: () => undefined,
+  initCrashReporter: vi.fn(),
   installGlobalErrorHandlers: () => undefined,
   installProcessGoneListeners: () => undefined,
   logGpuInfo: () => undefined,
@@ -196,7 +196,7 @@ vi.mock("../../app/cert-trust", () => ({
 }));
 vi.mock("../../app/app-protocol", () => ({
   installAppProtocolHandler: () => undefined,
-  registerAppScheme: () => undefined,
+  registerAppScheme: vi.fn(),
 }));
 vi.mock("../../app/gpu-acceleration", () => ({
   applyHardwareAccelerationPreference: () => undefined,
@@ -424,5 +424,33 @@ describe("createMruWindowProxy (decision 10) - real production proxy", () => {
 
     await registry.closeById(windowId);
     expect(proxy.isDestroyed()).toBe(true);
+  });
+});
+
+describe("runPreReady - scheme/crash-reporter ordering", () => {
+  it("registers the crash reporter before the app scheme, so Sentry's raw protocol.registerSchemesAsPrivileged call cannot discard app's privileges", async () => {
+    const { runPreReady } = await import("../desktop-startup");
+    const { initCrashReporter } = await import("../../app/crash-reporter");
+    const { registerAppScheme } = await import("../../app/app-protocol");
+
+    runPreReady({
+      config: {
+        environment: "dev",
+        isDev: true,
+        iconPath: "",
+        preloadPath: "",
+        authnBaseUrl: "",
+      },
+      pendingAuthReturnSignal: false,
+      bridge: null,
+    });
+
+    expect(initCrashReporter).toHaveBeenCalledTimes(1);
+    expect(registerAppScheme).toHaveBeenCalledTimes(1);
+    const crashReporterOrder =
+      vi.mocked(initCrashReporter).mock.invocationCallOrder[0];
+    const appSchemeOrder =
+      vi.mocked(registerAppScheme).mock.invocationCallOrder[0];
+    expect(crashReporterOrder).toBeLessThan(appSchemeOrder);
   });
 });

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -326,7 +326,7 @@ async function timed(
 // (two documented sync-filesystem exceptions: the GPU preference read in
 // app/gpu-acceleration.ts and the memory-backed /proc write in
 // app/core-dump-guard.ts, which must land before Chromium spawns children).
-function runPreReady(state: BootState): void {
+export function runPreReady(state: BootState): void {
   trimUnusedChromiumFeatures();
   configureV8HeapSize();
   applyHardwareAccelerationPreference();

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -330,10 +330,20 @@ function runPreReady(state: BootState): void {
   trimUnusedChromiumFeatures();
   configureV8HeapSize();
   applyHardwareAccelerationPreference();
-  registerAppScheme();
   suppressWslKernelCoreDumps();
+  // `initCrashReporter()` must run before `registerAppScheme()`. When a
+  // Sentry DSN is configured, `SentryElectron.init()` makes its own raw
+  // `protocol.registerSchemesAsPrivileged([sentry-ipc])` call and only
+  // afterwards replaces that method with a Proxy that merges every later
+  // registration into its own. Electron keeps only the last RAW call, so
+  // registering `app` first (before Sentry) gets silently discarded -
+  // `app://renderer` loses its secure/cors/fetch privileges and becomes a
+  // non-secure context, disabling `navigator.clipboard`/`crypto.subtle` in
+  // the renderer. Registering `app` after Sentry lets its Proxy fold it in
+  // alongside `sentry-ipc`. Do not reorder these two calls.
   initCrashReporter();
   installGlobalErrorHandlers();
+  registerAppScheme();
   installProcessGoneListeners();
 
   registerDeepLinkHandling(() => deliverAuthReturnSignal(state));


### PR DESCRIPTION
## Bug

Packaged desktop builds with a Sentry DSN configured lose the `app://` scheme's secure/cors/fetch privileges at startup. `app://renderer` becomes a non-secure context, so Chromium withholds `navigator.clipboard`, `ClipboardItem`, `crypto.subtle`, and `crypto.randomUUID` from the renderer.

Root cause: `runPreReady()` called `registerAppScheme()` (raw `protocol.registerSchemesAsPrivileged` call for the `app` scheme) before `initCrashReporter()`. `SentryElectron.init()` makes its own raw `protocol.registerSchemesAsPrivileged([sentry-ipc])` call and only afterwards replaces that method with a Proxy that merges later registrations into its own. Electron keeps only the last raw call, so our earlier `app` registration was silently discarded once Sentry initialized.

This shipped in 1.1.8-rc (Sentry only started initializing in shipped desktop builds once the DSN was populated in CI) and surfaced as two user-facing bugs: the message-copy toolbar button failing with "Couldn't copy to clipboard.", and landing-composer image paste failing with "Could not attach the image." (the latter needs `crypto.subtle.digest` for content hashing).

## Fix

Reorder `runPreReady()` so `initCrashReporter()` runs before `registerAppScheme()`. Sentry's Proxy is designed to merge later registrations, so registering `app` after Sentry initializes lets it fold `app`'s privileges in alongside `sentry-ipc` instead of losing them. Verified in the installed `@sentry/electron` source that this proxy-merge behavior is real and unconditional. No other `registerSchemesAsPrivileged` caller exists in desktop src.

## Validation

Built a real packaged staging app (`make install-desktop-staging`) with a Sentry DSN set, matching the production condition. Verified live via Playwright/CDP against the packaged renderer:

- Renderer process argv: `--secure-schemes=app,sentry-ipc --cors-schemes=app,sentry-ipc --fetch-schemes=app,sentry-ipc` (both schemes now coexist; the broken build shows `sentry-ipc` only)
- `window.isSecureContext === true`; `navigator.clipboard`, `crypto.subtle`, `crypto.randomUUID`, `ClipboardItem` all defined
- Desktop log confirms `sentry initialized` (not the no-DSN disabled path)
- Functional, real UI interaction: pasting a real image into the landing composer attaches it with no error toast; clicking a message's "Copy message" button writes the exact message text to the real OS clipboard, with no error toast

Also added a unit test (`runPreReady - scheme/crash-reporter ordering`) asserting `initCrashReporter()`'s call order precedes `registerAppScheme()`'s. Confirmed the test fails against the pre-fix ordering and passes against the fix.