### PR TITLE
fix(gui-app): keep landing composer caret stable when attaching images

### DIFF
--- a/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/home-page.test.tsx
@@ -1,7 +1,8 @@
 import "../../../../__tests__/test-browser-apis";
-import type { ReactNode } from "react";
+import { useLayoutEffect, useRef, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -23,6 +24,21 @@ import { useLandingComposerActions } from "@/components/home/hooks/use-landing-c
 import { useSurfaceActivity } from "@/components/home/composer/surface-activity-hooks";
 import { useWorkspaceFoldersStore } from "@/stores/workspace/workspace-folders-store";
 
+/**
+ * Commit-level observation of HomePage's LandingComposer keying.
+ * `useLayoutEffect` runs after each committed render (before paint / before
+ * passive effects), so a passive-effect pending rotation leaves a detectable
+ * intermediate commit that a render-phase rotation never produces.
+ */
+type ComposerCommit = {
+  readonly draftId: string | null;
+  readonly pendingCreateId: string | null;
+  /** HomePage uses `draftId ?? pendingDraftId` as the React key. */
+  readonly effectiveKey: string | null;
+  readonly instanceId: number;
+  readonly phase: "mount" | "commit" | "unmount";
+};
+
 const homeMocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   systemModalOpen: false,
@@ -37,6 +53,8 @@ const homeMocks = vi.hoisted(() => ({
     version: "0.0.0-test",
     status: "available",
   })),
+  composerCommits: [] as ComposerCommit[],
+  nextInstanceId: 0,
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -95,8 +113,10 @@ vi.mock("@/components/home/home-hero", () => ({
 vi.mock("@/components/home/composer/landing-composer", () => ({
   LandingComposer: (props: {
     draftId: string | null;
+    pendingCreateId: string | null;
     initialPrompt: string | undefined;
     initialSettings: unknown;
+    workspaceControls: ReactNode;
     workspaceSlot: ReactNode;
   }) => {
     // The real composer reads surface activity from context (provided by
@@ -105,6 +125,48 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
     const actions = useLandingComposerActions();
     const setSnapshot = useLandingComposerStore((s) => s.setSnapshot);
     const draftId = props.draftId;
+    const pendingCreateId = props.pendingCreateId;
+    const effectiveKey = draftId ?? pendingCreateId;
+    const instanceIdRef = useRef<number | null>(null);
+    if (instanceIdRef.current === null) {
+      homeMocks.nextInstanceId += 1;
+      instanceIdRef.current = homeMocks.nextInstanceId;
+    }
+    const instanceId = instanceIdRef.current;
+
+    // Instance lifetime (keyed remounts). `instanceId` is allocated once per
+    // React key identity; depend only on it so prop updates do not fake unmounts.
+    useLayoutEffect(() => {
+      homeMocks.composerCommits.push({
+        draftId: null,
+        pendingCreateId: null,
+        effectiveKey: null,
+        instanceId,
+        phase: "mount",
+      });
+      return () => {
+        homeMocks.composerCommits.push({
+          draftId: null,
+          pendingCreateId: null,
+          effectiveKey: null,
+          instanceId,
+          phase: "unmount",
+        });
+      };
+    }, [instanceId]);
+
+    // Every committed prop snapshot (catches a stale key frame that reuses
+    // the same React instance when the React key has not changed yet).
+    useLayoutEffect(() => {
+      homeMocks.composerCommits.push({
+        draftId,
+        pendingCreateId,
+        effectiveKey,
+        instanceId,
+        phase: "commit",
+      });
+    });
+
     const handleClick = (): void => {
       actions.submit({
         editor: editorHandleForPrompt("Plan the GUI migration"),
@@ -122,13 +184,27 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
       });
     };
     const handlePromptChangeTwice = (): void => {
-      setSnapshot(draftId, jsonContentForPrompt("first draft"), null);
-      setSnapshot(draftId, jsonContentForPrompt("second draft"), null);
+      setSnapshot(
+        draftId,
+        jsonContentForPrompt("first draft"),
+        null,
+        draftId === null ? (pendingCreateId ?? undefined) : undefined,
+      );
+      setSnapshot(
+        draftId,
+        jsonContentForPrompt("second draft"),
+        null,
+        draftId === null ? (pendingCreateId ?? undefined) : undefined,
+      );
     };
     return (
       <div
         data-testid="landing-composer"
         data-activity-enabled={String(activityEnabled)}
+        data-draft-id={draftId ?? ""}
+        data-pending-create-id={pendingCreateId ?? ""}
+        data-effective-key={effectiveKey ?? ""}
+        data-instance-id={String(instanceId)}
       >
         <button
           type="button"
@@ -147,6 +223,7 @@ vi.mock("@/components/home/composer/landing-composer", () => ({
         <div data-testid="landing-initial-prompt">
           {props.initialPrompt ?? ""}
         </div>
+        {props.workspaceControls}
         {props.workspaceSlot}
       </div>
     );
@@ -190,6 +267,8 @@ describe("<HomePage />", () => {
       version: "0.0.0-test",
       status: "available",
     });
+    homeMocks.composerCommits.length = 0;
+    homeMocks.nextInstanceId = 0;
     useAuthStore.setState({
       status: "signed-in",
       profile: {
@@ -313,7 +392,9 @@ describe("<HomePage />", () => {
         },
       },
     });
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     useLandingDraftStore.getState().setActiveDraft(draftId);
     useWorkspaceFoldersStore.setState({
       folders: ["/tmp/global-app"],
@@ -492,6 +573,156 @@ describe("<HomePage />", () => {
       ],
     });
     queryClient.clear();
+  });
+
+  describe("null-draft mount key rotation (production HomePage)", () => {
+    function renderHome(): QueryClient {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 } },
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <HomePage />
+        </QueryClientProvider>,
+      );
+      return queryClient;
+    }
+
+    function commitSnapshots(): ReadonlyArray<ComposerCommit> {
+      return homeMocks.composerCommits.filter((c) => c.phase === "commit");
+    }
+
+    function mounts(): ReadonlyArray<ComposerCommit> {
+      return homeMocks.composerCommits.filter((c) => c.phase === "mount");
+    }
+
+    it("never commits a null-draft frame still keyed by a pending-created draft id", () => {
+      const queryClient = renderHome();
+
+      // Initial null session: pendingCreateId is the mount key.
+      const initial = commitSnapshots().at(-1);
+      expect(initial?.draftId).toBeNull();
+      expect(initial?.pendingCreateId).toBeTruthy();
+      const pendingKey = initial?.pendingCreateId ?? "";
+      expect(initial?.effectiveKey).toBe(pendingKey);
+
+      // Create the draft WITH that pre-minted id (mirrors setSnapshot create branch).
+      act(() => {
+        useLandingDraftStore.getState().createDraft(null, pendingKey);
+      });
+      expect(useLandingDraftStore.getState().activeDraftId).toBe(pendingKey);
+      const bound = commitSnapshots().at(-1);
+      expect(bound?.draftId).toBe(pendingKey);
+      expect(bound?.pendingCreateId).toBeNull();
+      expect(bound?.effectiveKey).toBe(pendingKey);
+
+      const commitsBeforeClear = homeMocks.composerCommits.length;
+      const mountsBeforeClear = mounts().length;
+
+      act(() => {
+        useLandingDraftStore.getState().clearActiveDraft();
+      });
+
+      // Passive-effect rotation would leave a committed frame with
+      // draftId=null and effectiveKey=pendingKey (retired id) before reminting.
+      // Render-phase rotation must never produce that frame.
+      const afterClear = homeMocks.composerCommits.slice(commitsBeforeClear);
+      const nullCommits = afterClear.filter(
+        (c) => c.phase === "commit" && c.draftId === null,
+      );
+      expect(nullCommits.length).toBeGreaterThan(0);
+      expect(nullCommits.every((c) => c.effectiveKey !== pendingKey)).toBe(
+        true,
+      );
+      // Exactly one distinct new null-session key (no double remount).
+      const nullKeys = [
+        ...new Set(nullCommits.map((c) => c.effectiveKey).filter(Boolean)),
+      ];
+      expect(nullKeys).toHaveLength(1);
+      expect(nullKeys[0]).not.toBe(pendingKey);
+
+      // One remount for the rotation (not zero, not two).
+      const mountsAfter = mounts().length - mountsBeforeClear;
+      expect(mountsAfter).toBe(1);
+
+      // Flush passive effects: still no late second remint.
+      act(() => {
+        /* flush */
+      });
+      const lateNullKeys = [
+        ...new Set(
+          homeMocks.composerCommits
+            .slice(commitsBeforeClear)
+            .filter((c) => c.phase === "commit" && c.draftId === null)
+            .map((c) => c.effectiveKey)
+            .filter(Boolean),
+        ),
+      ];
+      expect(lateNullKeys).toEqual(nullKeys);
+
+      queryClient.clear();
+    });
+
+    it("remounts exactly once when a pre-existing bound draft goes null", () => {
+      // Bind a draft whose id is NOT the HomePage pending mint.
+      const existingId = useLandingDraftStore
+        .getState()
+        .createDraft(null, undefined);
+      useLandingDraftStore.getState().setActiveDraft(existingId);
+
+      const queryClient = renderHome();
+
+      const bound = commitSnapshots().at(-1);
+      expect(bound?.draftId).toBe(existingId);
+      expect(bound?.effectiveKey).toBe(existingId);
+      const mountsBeforeClear = mounts().length;
+      // Capture any pending id that was never used as a key while bound.
+      const commitsBeforeClear = homeMocks.composerCommits.length;
+
+      act(() => {
+        useLandingDraftStore.getState().clearActiveDraft();
+      });
+
+      const afterClear = homeMocks.composerCommits.slice(commitsBeforeClear);
+      // Every mount after the clear — intermediate stale-pending would be
+      // an extra mount entry.
+      const mountsAfterClear = afterClear.filter((c) => c.phase === "mount");
+      expect(mountsAfterClear).toHaveLength(1);
+
+      const nullCommits = afterClear.filter(
+        (c) => c.phase === "commit" && c.draftId === null,
+      );
+      expect(nullCommits.length).toBeGreaterThan(0);
+      // No committed null frame still keyed by the retired bound draft.
+      expect(nullCommits.every((c) => c.effectiveKey !== existingId)).toBe(
+        true,
+      );
+      // Exactly one distinct null-session key across ALL commits (not
+      // existing → stale-pending → new-pending collapsing to endpoints).
+      const nullKeys = [
+        ...new Set(nullCommits.map((c) => c.effectiveKey).filter(Boolean)),
+      ];
+      expect(nullKeys).toHaveLength(1);
+
+      // Flush passives: a useEffect remint would add a second mount/key.
+      act(() => {
+        /* flush */
+      });
+      const mountsTotalAfter = mounts().length - mountsBeforeClear;
+      expect(mountsTotalAfter).toBe(1);
+      const lateNullKeys = [
+        ...new Set(
+          homeMocks.composerCommits
+            .slice(commitsBeforeClear)
+            .filter((c) => c.phase === "commit" && c.draftId === null)
+            .map((c) => c.effectiveKey)
+            .filter(Boolean),
+        ),
+      ];
+      expect(lateNullKeys).toHaveLength(1);
+
+      queryClient.clear();
+    });
   });
 });
 

--- a/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/use-landing-composer-actions.test.tsx
@@ -1048,7 +1048,7 @@ describe("useLandingComposerActions", () => {
         },
       },
     });
-    useLandingDraftStore.getState().createDraft(null);
+    useLandingDraftStore.getState().createDraft(null, undefined);
     useWorkspaceFoldersStore.setState({
       folders: [GLOBAL_WORKSPACE_PATH],
       folderInfoByPath: {

--- a/clients/gui-app/src/components/home/composer/__tests__/composer-body.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/composer-body.test.tsx
@@ -15,12 +15,14 @@ vi.mock("@/components/chat/composer/composer-prompt-editor", () => ({
     readonly onPaste: ClipboardEventHandler<HTMLElement>;
     readonly onDragOver: DragEventHandler<HTMLElement>;
     readonly onDrop: DragEventHandler<HTMLElement>;
+    readonly stabilizeImageAttachmentCaret: boolean;
   }) => (
     <textarea
       aria-label="Prompt editor"
       onPaste={props.onPaste}
       onDragOver={props.onDragOver}
       onDrop={props.onDrop}
+      data-stabilize-caret={String(props.stabilizeImageAttachmentCaret)}
     />
   ),
 }));
@@ -168,6 +170,15 @@ describe("ComposerBody file-transfer routing", () => {
     expect(paste.onDrop).toHaveBeenCalledOnce();
     expect(paste.onPaste).toHaveBeenCalledOnce();
     expect(shell.getAttribute("data-overlay")).toBe("paths");
+  });
+});
+
+describe("ComposerBody image-attachment caret stabilization", () => {
+  it("enables caret stabilization on the underlying prompt editor", () => {
+    renderComposerBody("chat", makePaste(), null, null);
+
+    const editor = screen.getByRole("textbox", { name: "Prompt editor" });
+    expect(editor.getAttribute("data-stabilize-caret")).toBe("true");
   });
 });
 

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-rate-limit-banner.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-rate-limit-banner.test.tsx
@@ -281,6 +281,7 @@ function renderLandingComposer(): RenderResult {
   return render(
     <LandingComposer
       draftId={null}
+      pendingCreateId={null}
       initialSettings={null}
       workspaceControls={null}
     />,

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-composer-submit-gate.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-composer-submit-gate.test.tsx
@@ -234,6 +234,7 @@ describe("LandingComposer direct submit gate", () => {
     const view = render(
       <LandingComposer
         draftId={null}
+        pendingCreateId={null}
         initialSettings={null}
         workspaceControls={null}
       />,
@@ -249,6 +250,7 @@ describe("LandingComposer direct submit gate", () => {
     view.rerender(
       <LandingComposer
         draftId={null}
+        pendingCreateId={null}
         initialSettings={null}
         workspaceControls={null}
       />,
@@ -264,6 +266,7 @@ describe("LandingComposer direct submit gate", () => {
     const view = render(
       <LandingComposer
         draftId={null}
+        pendingCreateId={null}
         initialSettings={null}
         workspaceControls={null}
       />,
@@ -284,6 +287,7 @@ describe("LandingComposer direct submit gate", () => {
     view.rerender(
       <LandingComposer
         draftId={null}
+        pendingCreateId={null}
         initialSettings={null}
         workspaceControls={null}
       />,
@@ -301,6 +305,7 @@ describe("LandingComposer direct submit gate", () => {
     view.rerender(
       <LandingComposer
         draftId={null}
+        pendingCreateId={null}
         initialSettings={null}
         workspaceControls={null}
       />,
@@ -315,6 +320,7 @@ describe("LandingComposer direct submit gate", () => {
     const view = render(
       <LandingComposer
         draftId={null}
+        pendingCreateId={null}
         initialSettings={null}
         workspaceControls={null}
       />,
@@ -330,6 +336,7 @@ describe("LandingComposer direct submit gate", () => {
     view.rerender(
       <LandingComposer
         draftId={null}
+        pendingCreateId={null}
         initialSettings={null}
         workspaceControls={null}
       />,

--- a/clients/gui-app/src/components/home/composer/__tests__/landing-paste-lifecycle.test.tsx
+++ b/clients/gui-app/src/components/home/composer/__tests__/landing-paste-lifecycle.test.tsx
@@ -2,10 +2,11 @@
  * Round-5 landing paste lifecycle seams.
  *
  * Drives the REAL LandingComposer + REAL landing-composer-store + REAL
- * landing-draft-store through the HomePage keyed remount boundary
- * (`key={activeDraftId}`). Fakes only idb-keyval timing (putImage durable
- * write). Does NOT re-implement ingest on a bare Editor — that is exactly
- * why round 4 missed the store/remount defect.
+ * landing-draft-store through the HomePage mount-key boundary (pre-minted
+ * id while `activeDraftId` is null; key switches only when changing between
+ * existing drafts). Fakes only idb-keyval timing (putImage durable write).
+ * Does NOT re-implement ingest on a bare Editor — that is exactly why round
+ * 4 missed the store/remount defect.
  */
 import "../../../../../__tests__/test-browser-apis";
 import {
@@ -18,7 +19,8 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStore } from "zustand/vanilla";
-import type { ComponentProps, ReactElement } from "react";
+import { useState, type ComponentProps, type ReactElement } from "react";
+import { v4 as uuidv4 } from "uuid";
 import type { JsonContent } from "@traycer/protocol/common/registry";
 
 import {
@@ -372,16 +374,19 @@ afterEach(() => {
 });
 
 /**
- * HomePage keying: `<LandingComposer key={draftId} draftId={draftId}>`.
- * Subscribes to the REAL store's activeDraftId so createDraft flipping the
- * active id genuinely remounts the composer (and re-runs mount-time re-entry).
+ * Pre-mint only — covers the null→id seam for real Tiptap (draft created under
+ * the mount key so the editor is not remounted). Bound→null rotation is pinned
+ * against production HomePage in home-page.test.tsx (not duplicated here).
  */
 function KeyedLandingComposerHarness(): ReactElement {
   const draftId = useLandingDraftStore((state) => state.activeDraftId);
+  const [pendingCreateId] = useState(() => uuidv4());
+  const mountId = draftId ?? pendingCreateId;
   return (
     <LandingComposer
-      key={draftId}
+      key={mountId}
       draftId={draftId}
+      pendingCreateId={draftId === null ? pendingCreateId : null}
       initialSettings={null}
       workspaceControls={null}
     />
@@ -389,6 +394,30 @@ function KeyedLandingComposerHarness(): ReactElement {
 }
 
 describe("landing paste lifecycle (real stores + keyed LandingComposer)", () => {
+  // Pre-mint mount identity: the null→id activeDraftId flip must not remount
+  // the editor. Assert DOM node identity survives the first image-atom
+  // snapshot that creates the draft (the exact seam the pre-mint fix targets).
+  it("preserves the editor DOM node across the null→id activeDraftId flip", async () => {
+    render(<KeyedLandingComposerHarness />);
+    await waitForEditorReady();
+
+    const editorBefore = screen.getByRole("textbox", {
+      name: "Ask Traycer anything. @ mention for context",
+    });
+
+    const bytes = bytesOf([8, 8, 8]);
+    pasteComposerContent(imageOnlyContent(bytesToBase64(bytes), "stable.png"));
+
+    await waitFor(() => {
+      expect(useLandingDraftStore.getState().activeDraftId).not.toBeNull();
+    });
+
+    const editorAfter = screen.getByRole("textbox", {
+      name: "Ask Traycer anything. @ mention for context",
+    });
+    expect(editorAfter).toBe(editorBefore);
+  });
+
   // Seam 1: null-bound paste → draft create → keyed remount → pending survives
   // → resolve write → hash-only in editor, draft store, and both serializers.
   it("null-bound mixed paste survives keyed remount and converges to hash-only everywhere", async () => {
@@ -652,6 +681,7 @@ describe("landing paste lifecycle (real stores + keyed LandingComposer)", () => 
       <LandingComposer
         key={draftId}
         draftId={draftId}
+        pendingCreateId={null}
         initialSettings={null}
         workspaceControls={null}
       />,

--- a/clients/gui-app/src/components/home/composer/composer-body.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-body.tsx
@@ -137,7 +137,7 @@ export function ComposerBody({
                 disabled={false}
                 placeholder={COMPOSER_PLACEHOLDER}
                 editorClassName={editorClassName}
-                stabilizeImageAttachmentCaret={false}
+                stabilizeImageAttachmentCaret
                 onSnapshot={onSnapshot}
                 onSubmit={onSubmit}
                 onPaste={chatPasteActive ? paste.onPaste : NOOP}

--- a/clients/gui-app/src/components/home/composer/landing-composer.tsx
+++ b/clients/gui-app/src/components/home/composer/landing-composer.tsx
@@ -80,6 +80,12 @@ import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 interface LandingComposerProps {
   readonly draftId: string | null;
+  /**
+   * Pre-minted draft id used as the React mount key while `draftId` is null.
+   * Threaded into `setSnapshot`'s create branch so the first substantive edit
+   * creates the draft under that same id (no editor remount). Null when bound.
+   */
+  readonly pendingCreateId: string | null;
   readonly initialSettings: ChatRunSettings | null;
   readonly workspaceControls: ReactNode;
 }
@@ -426,9 +432,14 @@ export function LandingComposer(props: LandingComposerProps) {
 
   const handleSnapshot = useCallback(
     (content: JsonContent, selection: { from: number; to: number }) => {
-      setSnapshot(draftId, content, selection);
+      setSnapshot(
+        draftId,
+        content,
+        selection,
+        draftId === null ? (props.pendingCreateId ?? undefined) : undefined,
+      );
     },
-    [draftId, setSnapshot],
+    [draftId, props.pendingCreateId, setSnapshot],
   );
 
   const handleSubmit = useCallback(() => {

--- a/clients/gui-app/src/components/home/home-page.tsx
+++ b/clients/gui-app/src/components/home/home-page.tsx
@@ -1,5 +1,6 @@
 import { useRouterState } from "@tanstack/react-router";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
 import { useActiveLandingDraftShell } from "@/stores/home/landing-draft-store";
 import { HomeHero } from "@/components/home/home-hero";
 import { LandingComposer } from "@/components/home/composer/landing-composer";
@@ -16,6 +17,26 @@ export function HomePage() {
   // once at mount (keyed by draft id), so excluding it here keeps typing from
   // re-rendering the entire home surface.
   const { draftId, workspaceFolders, settings } = useActiveLandingDraftShell();
+
+  // Pre-mint the mount identity for the null-draft landing so the first
+  // substantive edit (which creates a draft and flips activeDraftId null→id)
+  // does not remount the Tiptap editor. Switching between existing drafts still
+  // remounts via a changing key.
+  //
+  // Bound→null rotation is a render-phase state adjustment (React docs pattern):
+  // a passive useEffect would leave one committed frame still keyed by the
+  // retired draft id (stale interactive editor). Adjusting here re-renders
+  // synchronously before commit so the new pending id is the first key after
+  // the transition — exactly one remount, no stale frame.
+  const [pendingDraftId, setPendingDraftId] = useState(() => uuidv4());
+  const [prevDraftId, setPrevDraftId] = useState<string | null>(draftId);
+  if (draftId !== prevDraftId) {
+    setPrevDraftId(draftId);
+    if (draftId === null) {
+      setPendingDraftId(uuidv4());
+    }
+  }
+  const composerMountId = draftId ?? pendingDraftId;
 
   // The Settings / History modal renders over the home page. While it's open the
   // embedded list is fully occluded, yet it shares the history-search store +
@@ -57,8 +78,9 @@ export function HomePage() {
           <div className="shrink-0">
             <SurfaceActivityProvider active={!systemModalOpen}>
               <LandingComposer
-                key={draftId}
+                key={composerMountId}
                 draftId={draftId}
+                pendingCreateId={draftId === null ? pendingDraftId : null}
                 initialSettings={settings}
                 workspaceControls={workspaceControls}
               />

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-cap-eviction.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-cap-eviction.test.ts
@@ -132,7 +132,9 @@ describe("useHomeWorkspaceSource addResolvedFolders - cap eviction unstages the 
       numberedFolder(index),
     );
     useWorkspaceFoldersStore.getState().addResolvedFolders(initialFolders);
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
 
     // Keep both representations at the supported 50-folder cap while making
     // their membership and primary choices diverge. On the next add, global

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-primary.test.ts
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/use-home-workspace-source-primary.test.ts
@@ -62,7 +62,9 @@ describe("useHomeWorkspaceSource primaryWorkspacePath - the pinned folder wins",
   });
 
   it("resolves the pinned folder for the active landing draft", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     const stagingKey: WorktreeStagingKey = { surface: "landing", draftId };
     const { result } = renderHook(() =>
       useHomeWorkspaceSource(stagingKey, null),

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip-app-route.test.tsx
@@ -219,7 +219,9 @@ describe("app route tab-strip navigation", () => {
       name: "History",
       lastPath: "/epics",
     });
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     const router = renderAppAt(`/epics/epic-current/${epicTabId}`);
     await screen.findByTestId("epic-route-session-body");
 

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -995,7 +995,9 @@ describe("<TabStrip />", () => {
       name: "History",
       lastPath: "/epics",
     });
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
 
     const router = buildRouter(`/epics/epic-current/${epicTabId}`);
     render(<RouterProvider router={router} />);

--- a/clients/gui-app/src/components/layout/__tests__/use-tab-close-command.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/use-tab-close-command.test.tsx
@@ -42,7 +42,9 @@ describe("useTabCloseCommand", () => {
   });
 
   it("dispatches a draft close through the draft descriptor", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     expect(
       useLandingDraftStore.getState().drafts.some((d) => d.id === draftId),
     ).toBe(true);

--- a/clients/gui-app/src/hooks/composer/__tests__/use-workspace-mention-roots.test.tsx
+++ b/clients/gui-app/src/hooks/composer/__tests__/use-workspace-mention-roots.test.tsx
@@ -167,7 +167,9 @@ describe("useLandingComposerMentionRoots", () => {
 
   it("uses an imported draft worktree path for draft-scoped landing composers", () => {
     setGlobalFolders(["/repo"]);
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     useWorktreeIntentStagingStore
       .getState()
       .stageIntent(

--- a/clients/gui-app/src/lib/__tests__/tab-navigation.test.ts
+++ b/clients/gui-app/src/lib/__tests__/tab-navigation.test.ts
@@ -144,7 +144,9 @@ describe("tab navigation single-path contract", () => {
   });
 
   it("activating an epic tab clears the active landing draft marker", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     const tabId = useEpicCanvasStore.getState().openEpicTab("epic-1", "Alpha");
     const navigateMock = makeNavigate();
 
@@ -182,7 +184,9 @@ describe("tab navigation single-path contract", () => {
   });
 
   it("keybinding switch to a draft tab also funnels through router.navigateToTabIntent", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     useTabsStore.setState({
       stripOrder: [{ kind: "draft", id: draftId }],
       systemTabs: { history: null, settings: null },

--- a/clients/gui-app/src/lib/commands/actions/new-epic.ts
+++ b/clients/gui-app/src/lib/commands/actions/new-epic.ts
@@ -23,7 +23,10 @@ import type { KeybindingRouter } from "@/lib/keybindings/dispatch";
 export function openNewEpicDraft(): string {
   return useLandingDraftStore
     .getState()
-    .createDraft(useComposerRunSettingsStore.getState().globalLastRunSettings);
+    .createDraft(
+      useComposerRunSettingsStore.getState().globalLastRunSettings,
+      undefined,
+    );
 }
 
 export function openNewEpic(router: KeybindingRouter): void {

--- a/clients/gui-app/src/lib/history-navigation/__tests__/liveness.test.ts
+++ b/clients/gui-app/src/lib/history-navigation/__tests__/liveness.test.ts
@@ -266,7 +266,9 @@ describe("isHistoryEntryDead — conservative liveness", () => {
   });
 
   it("keeps a draft href whose id is present in the landing-draft store", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     expect(isHistoryEntryDead(`/draft/${draftId}`)).toBe(false);
   });
 

--- a/clients/gui-app/src/providers/__tests__/history-prune-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/history-prune-provider.test.tsx
@@ -150,8 +150,8 @@ describe("HistoryPruneProvider", () => {
 
   it("prunes a deleted active draft's forward entry without a load (delete active draft)", () => {
     const draftStore = useLandingDraftStore.getState();
-    const currentDraftId = draftStore.createDraft(null);
-    const forwardDraftId = draftStore.createDraft(null);
+    const currentDraftId = draftStore.createDraft(null, undefined);
+    const forwardDraftId = draftStore.createDraft(null, undefined);
 
     const history = seedPersistentHistory(
       [`/draft/${currentDraftId}`, `/draft/${forwardDraftId}`],

--- a/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
+++ b/clients/gui-app/src/providers/__tests__/keybinding-provider.test.ts
@@ -296,7 +296,7 @@ describe("dispatchAction", () => {
       .openEpicTab("epic-route-guard", "Route Guard");
     useEpicCanvasStore.getState().openTileInTab(tabId, specRef("spec-a"));
     useEpicCanvasStore.getState().openTileInTab(tabId, specRef("spec-b"));
-    useLandingDraftStore.getState().createDraft(null);
+    useLandingDraftStore.getState().createDraft(null, undefined);
     const before = canvasTabIds(tabId);
 
     const { router } = buildRouter(`/epics/epic-route-guard/${tabId}`);
@@ -312,7 +312,7 @@ describe("dispatchAction", () => {
       .openEpicTab("epic-route-active", "Route Active");
     useEpicCanvasStore.getState().openTileInTab(tabId, specRef("spec-a"));
     useEpicCanvasStore.getState().openTileInTab(tabId, specRef("spec-b"));
-    useLandingDraftStore.getState().createDraft(null);
+    useLandingDraftStore.getState().createDraft(null, undefined);
     tabActivate(
       existingEpicTabIntent({
         epicId: "epic-route-active",

--- a/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
@@ -539,7 +539,7 @@ describe("<WindowsBridgeProvider />", () => {
     act(() => {
       tabId = useEpicCanvasStore.getState().openEpicTab("epic-a", "A");
       useEpicCanvasStore.getState().renameTab(tabId, "A Prime");
-      draftId = useLandingDraftStore.getState().createDraft(null);
+      draftId = useLandingDraftStore.getState().createDraft(null, undefined);
       useLandingDraftStore
         .getState()
         .setDraftContent(draftId, landingTextContent("first prompt"), null);
@@ -583,7 +583,7 @@ describe("<WindowsBridgeProvider />", () => {
     act(() => {
       tabA = useEpicCanvasStore.getState().openEpicTab("epic-a", "A");
       tabB = useEpicCanvasStore.getState().openEpicTab("epic-b", "B");
-      draftId = useLandingDraftStore.getState().createDraft(null);
+      draftId = useLandingDraftStore.getState().createDraft(null, undefined);
       useLandingDraftStore
         .getState()
         .setDraftContent(draftId, landingTextContent("old prompt"), null);
@@ -644,7 +644,7 @@ describe("<WindowsBridgeProvider />", () => {
     act(() => {
       tabA = useEpicCanvasStore.getState().openEpicTab("epic-a", "A");
       tabB = useEpicCanvasStore.getState().openEpicTab("epic-b", "B");
-      draftId = useLandingDraftStore.getState().createDraft(null);
+      draftId = useLandingDraftStore.getState().createDraft(null, undefined);
       useLandingDraftStore
         .getState()
         .setDraftContent(draftId, landingTextContent("final prompt"), null);

--- a/clients/gui-app/src/stores/composer/__tests__/landing-composer-store.test.ts
+++ b/clients/gui-app/src/stores/composer/__tests__/landing-composer-store.test.ts
@@ -67,7 +67,7 @@ describe("landing-composer-store draft binding", () => {
   it("creates the draft synchronously on the first non-empty null-binding edit", () => {
     useLandingComposerStore
       .getState()
-      .setSnapshot(null, content("hello"), null);
+      .setSnapshot(null, content("hello"), null, undefined);
 
     const drafts = useLandingDraftStore.getState().drafts;
     expect(drafts).toHaveLength(1);
@@ -75,10 +75,22 @@ describe("landing-composer-store draft binding", () => {
     expect(useLandingDraftStore.getState().activeDraftId).toBe(drafts[0].id);
   });
 
+  it("creates the draft under a pre-supplied id when createWithId is given", () => {
+    const preMintedId = "pre-minted-draft-id";
+    useLandingComposerStore
+      .getState()
+      .setSnapshot(null, content("hello"), null, preMintedId);
+
+    const drafts = useLandingDraftStore.getState().drafts;
+    expect(drafts).toHaveLength(1);
+    expect(drafts[0].id).toBe(preMintedId);
+    expect(useLandingDraftStore.getState().activeDraftId).toBe(preMintedId);
+  });
+
   it("keeps same-tick null-binding snapshots on the one created draft", () => {
     const store = useLandingComposerStore.getState();
-    store.setSnapshot(null, content("first"), null);
-    store.setSnapshot(null, content("first second"), null);
+    store.setSnapshot(null, content("first"), null, undefined);
+    store.setSnapshot(null, content("first second"), null, undefined);
 
     const drafts = useLandingDraftStore.getState().drafts;
     expect(drafts).toHaveLength(1);
@@ -90,7 +102,7 @@ describe("landing-composer-store draft binding", () => {
   it("creates a draft for image-only null-binding edits", () => {
     useLandingComposerStore
       .getState()
-      .setSnapshot(null, imageContent("img-1"), null);
+      .setSnapshot(null, imageContent("img-1"), null, undefined);
 
     const drafts = useLandingDraftStore.getState().drafts;
     expect(drafts).toHaveLength(1);
@@ -99,7 +111,7 @@ describe("landing-composer-store draft binding", () => {
   });
 
   it("seeds currentContent from the bound draft on openDraft", () => {
-    const id = useLandingDraftStore.getState().createDraft(null);
+    const id = useLandingDraftStore.getState().createDraft(null, undefined);
     useLandingDraftStore
       .getState()
       .setDraftContent(id, content("persisted text"), null);
@@ -111,12 +123,12 @@ describe("landing-composer-store draft binding", () => {
   });
 
   it("reopens a bound draft from the remembered full editor content", () => {
-    const draftA = useLandingDraftStore.getState().createDraft(null);
-    const draftB = useLandingDraftStore.getState().createDraft(null);
+    const draftA = useLandingDraftStore.getState().createDraft(null, undefined);
+    const draftB = useLandingDraftStore.getState().createDraft(null, undefined);
     useLandingComposerStore.getState().openDraft(draftA);
     useLandingComposerStore
       .getState()
-      .setSnapshot(draftA, imageContent("img-1"), null);
+      .setSnapshot(draftA, imageContent("img-1"), null, undefined);
 
     // openDraft(draftB) flushes the pending debounced write to draftA, so
     // reopening draftA seeds from its now-persisted full editor content.
@@ -129,15 +141,15 @@ describe("landing-composer-store draft binding", () => {
 
   it("lands a trailing debounced write on the BOUND draft, not the active one", () => {
     vi.useFakeTimers();
-    const draftA = useLandingDraftStore.getState().createDraft(null);
-    const draftB = useLandingDraftStore.getState().createDraft(null);
+    const draftA = useLandingDraftStore.getState().createDraft(null, undefined);
+    const draftB = useLandingDraftStore.getState().createDraft(null, undefined);
     useLandingDraftStore.getState().setActiveDraft(draftA);
     useLandingComposerStore.getState().openDraft(draftA);
 
     // A keystroke schedules the debounced write for draft A...
     useLandingComposerStore
       .getState()
-      .setSnapshot(draftA, content("edit A"), null);
+      .setSnapshot(draftA, content("edit A"), null, undefined);
     // ...then the user switches to draft B before the debounce fires.
     useLandingDraftStore.getState().setActiveDraft(draftB);
     vi.runAllTimers();
@@ -148,12 +160,12 @@ describe("landing-composer-store draft binding", () => {
 
   it("flushes the previous binding's pending write when a new draft opens", () => {
     vi.useFakeTimers();
-    const draftA = useLandingDraftStore.getState().createDraft(null);
-    const draftB = useLandingDraftStore.getState().createDraft(null);
+    const draftA = useLandingDraftStore.getState().createDraft(null, undefined);
+    const draftB = useLandingDraftStore.getState().createDraft(null, undefined);
     useLandingComposerStore.getState().openDraft(draftA);
     useLandingComposerStore
       .getState()
-      .setSnapshot(draftA, content("edit A"), null);
+      .setSnapshot(draftA, content("edit A"), null, undefined);
 
     // Rebinding (the keyed remount's mount path) commits the trailing write
     // immediately so returning to draft A restores the latest content.
@@ -165,11 +177,11 @@ describe("landing-composer-store draft binding", () => {
 
   it("reset cancels a pending write and clears the session", () => {
     vi.useFakeTimers();
-    const draftA = useLandingDraftStore.getState().createDraft(null);
+    const draftA = useLandingDraftStore.getState().createDraft(null, undefined);
     useLandingComposerStore.getState().openDraft(draftA);
     useLandingComposerStore
       .getState()
-      .setSnapshot(draftA, content("typed"), null);
+      .setSnapshot(draftA, content("typed"), null, undefined);
 
     useLandingComposerStore.getState().reset();
     vi.runAllTimers();

--- a/clients/gui-app/src/stores/composer/landing-composer-store.ts
+++ b/clients/gui-app/src/stores/composer/landing-composer-store.ts
@@ -24,8 +24,9 @@ const EMPTY_CONTENT: JsonContent = EMPTY_LANDING_DRAFT_CONTENT;
 // not the draft; the tab title and persistence only need eventual consistency),
 // so steady-state writes to an EXISTING bound draft are debounced. Writes made
 // while the binding is still `null` (the keystrokes that create the draft and
-// land before the keyed remount commits) are synchronous - the remount reads the
-// content back at mount, so a trailing write would seed it stale.
+// land before React re-renders with the new active id) are synchronous - the
+// mount key is pre-minted so the editor is not remounted, but same-tick follow-up
+// snapshots still target the just-created draft via `createdDraftId`.
 // `flushPendingLandingDraftContent` commits the pending write immediately and is
 // called on composer unmount / rebind so switching away from and back to a draft
 // restores the latest content.
@@ -92,7 +93,7 @@ interface LandingComposerStore {
   readonly currentContent: JsonContent;
   /**
    * Draft created by `setSnapshot(null, ...)` while this binding session is
-   * still `null` (the remount keyed on the new id hasn't committed yet). Routes
+   * still `null` (React has not yet re-rendered with the new active id). Routes
    * the session's follow-up snapshots to that same draft so same-tick edits
    * can't mint a second draft.
    */
@@ -111,11 +112,17 @@ interface LandingComposerStore {
    * + selection into that draft (creating it on the first non-empty edit of a
    * `null` binding) so draft persistence is a side-effect of typing rather than
    * a callback the parent has to thread.
+   *
+   * `createWithId` is used only on the null-binding create branch: when the
+   * parent pre-minted the React mount key for the null-draft landing, pass that
+   * same id so `activeDraftId` flips null→id without changing the keyed mount.
+   * Pass `undefined` to allocate a fresh id (or when `draftId` is non-null).
    */
   readonly setSnapshot: (
     draftId: string | null,
     content: JsonContent,
     selection: DraftSelection | null,
+    createWithId: string | undefined,
   ) => void;
   /**
    * Wipe the snapshot back to an empty document. Called after submission so
@@ -142,7 +149,7 @@ export const useLandingComposerStore = create<LandingComposerStore>(
       return content;
     },
 
-    setSnapshot: (draftId, content, selection) => {
+    setSnapshot: (draftId, content, selection, createWithId) => {
       const previousContent = get().currentContent;
       set({ currentContent: content });
       // In-editor image removal drops a hash from the live mirror — reconcile so
@@ -158,18 +165,20 @@ export const useLandingComposerStore = create<LandingComposerStore>(
       const draftStore = useLandingDraftStore.getState();
       const createdDraftId = get().createdDraftId;
       if (createdDraftId !== null) {
-        // Still pre-remount: keep the just-created draft current synchronously,
-        // so the keyed remount reads the latest content.
+        // Still in the null-binding session before React re-renders with the new
+        // active id: keep the just-created draft current synchronously.
         draftStore.setDraftContent(createdDraftId, content, selection);
         return;
       }
       const text = extractPlainTextFromComposerJSONContent(content);
       if (text.length === 0 && !containsImageAtoms(content)) return;
-      // Creating the draft flips the bound id null -> id, which remounts the
-      // composer (keyed by draft id); that mount reads the content back, so this
-      // first write must be synchronous or the just-typed content would be lost.
+      // Creating the draft flips activeDraftId null -> id. The landing shell
+      // pre-mints that id as the React mount key (`createWithId`), so the editor
+      // is not remounted; the first write is still synchronous so same-tick
+      // follow-ups and any residual keyed remount see the latest content.
       const id = draftStore.createDraft(
         useComposerRunSettingsStore.getState().globalLastRunSettings,
+        createWithId,
       );
       draftStore.setDraftContent(id, content, selection);
       set({ createdDraftId: id });

--- a/clients/gui-app/src/stores/epics/__tests__/new-conversation-modal-store.test.ts
+++ b/clients/gui-app/src/stores/epics/__tests__/new-conversation-modal-store.test.ts
@@ -86,7 +86,9 @@ describe("useNewConversationModalStore setPrimaryFolder", () => {
         [WORKSPACE_B.path]: WORKSPACE_B,
       },
     };
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
 
     useNewConversationModalStore
       .getState()

--- a/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
+++ b/clients/gui-app/src/stores/home/__tests__/landing-draft-store.test.ts
@@ -420,21 +420,33 @@ describe("useLandingDraftStore", () => {
 
   it("createDraft always creates a new draft and sets it active", () => {
     const { createDraft } = useLandingDraftStore.getState();
-    const first = createDraft(null);
+    const first = createDraft(null, undefined);
     expect(first.length).toBeGreaterThan(0);
     expect(useLandingDraftStore.getState().activeDraftId).toBe(first);
 
-    const second = createDraft(null);
+    const second = createDraft(null, undefined);
     expect(second).not.toBe(first);
     expect(useLandingDraftStore.getState().drafts).toHaveLength(2);
     expect(useLandingDraftStore.getState().activeDraftId).toBe(second);
     expect(useEpicCanvasStore.getState().openTabOrder).toEqual([]);
   });
 
+  it("createDraft uses a pre-minted id verbatim when provided", () => {
+    const { createDraft } = useLandingDraftStore.getState();
+    const preMintedId = "pre-minted-id-123";
+
+    const id = createDraft(null, preMintedId);
+
+    expect(id).toBe(preMintedId);
+    expect(useLandingDraftStore.getState().activeDraftId).toBe(preMintedId);
+    expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
+    expect(useLandingDraftStore.getState().drafts[0].id).toBe(preMintedId);
+  });
+
   it("setDraftContent stores content on the target draft and bails on no-op writes", () => {
     const { createDraft, setDraftContent } = useLandingDraftStore.getState();
 
-    const id = createDraft(null);
+    const id = createDraft(null, undefined);
     setDraftContent(id, textContent("hello world"), null);
     expect(useLandingDraftStore.getState().drafts[0].content).toEqual(
       textContent("hello world"),
@@ -452,8 +464,8 @@ describe("useLandingDraftStore", () => {
     const { createDraft, setDraftSettings } = useLandingDraftStore.getState();
     const mutableHaikuSettings = { ...HAIKU_SETTINGS };
     const mutableSonnetSettings = { ...SONNET_SETTINGS };
-    const haikuDraftId = createDraft(mutableHaikuSettings);
-    const sonnetDraftId = createDraft(mutableSonnetSettings);
+    const haikuDraftId = createDraft(mutableHaikuSettings, undefined);
+    const sonnetDraftId = createDraft(mutableSonnetSettings, undefined);
 
     setDraftSettings(sonnetDraftId, mutableSonnetSettings);
     mutableHaikuSettings.model = "mutated-haiku";
@@ -471,8 +483,8 @@ describe("useLandingDraftStore", () => {
   it("keeps composer mode independent per draft", () => {
     const { createDraft, setDraftComposerMode } =
       useLandingDraftStore.getState();
-    const a = createDraft(null);
-    const b = createDraft(null);
+    const a = createDraft(null, undefined);
+    const b = createDraft(null, undefined);
 
     setDraftComposerMode(a, "terminal");
 
@@ -488,7 +500,7 @@ describe("useLandingDraftStore", () => {
   it("seeds new drafts with the global last-used composer mode", () => {
     useSettingsStore.setState({ composerMode: "terminal" });
 
-    const id = useLandingDraftStore.getState().createDraft(null);
+    const id = useLandingDraftStore.getState().createDraft(null, undefined);
 
     expect(
       useLandingDraftStore.getState().drafts.find((draft) => draft.id === id)
@@ -501,13 +513,13 @@ describe("useLandingDraftStore", () => {
       folders: [WORKSPACE_A.path],
       folderInfoByPath: { [WORKSPACE_A.path]: WORKSPACE_A },
     });
-    const draftA = useLandingDraftStore.getState().createDraft(null);
+    const draftA = useLandingDraftStore.getState().createDraft(null, undefined);
 
     useWorkspaceFoldersStore.setState({
       folders: [WORKSPACE_B.path],
       folderInfoByPath: { [WORKSPACE_B.path]: WORKSPACE_B },
     });
-    const draftB = useLandingDraftStore.getState().createDraft(null);
+    const draftB = useLandingDraftStore.getState().createDraft(null, undefined);
     useLandingDraftStore
       .getState()
       .addDraftResolvedFolders(draftB, [WORKSPACE_C]);
@@ -567,7 +579,9 @@ describe("useLandingDraftStore", () => {
   });
 
   it("caps draft-added workspace folders to the newest 50 entries, never evicting primary", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     const folders = Array.from({ length: 55 }, (_, index) =>
       numberedWorkspace(index),
     );
@@ -592,7 +606,9 @@ describe("useLandingDraftStore", () => {
   });
 
   it("50->51 cap transition never silently moves an EXPLICIT primary that isn't the oldest folder", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     const folders = Array.from({ length: 50 }, (_, index) =>
       numberedWorkspace(index),
     );
@@ -617,7 +633,9 @@ describe("useLandingDraftStore", () => {
   });
 
   it("setDraftWorkspacePrimary scopes primary to the draft, leaving the global workspace store untouched", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     useLandingDraftStore
       .getState()
       .addDraftResolvedFolders(draftId, [WORKSPACE_A, WORKSPACE_B]);
@@ -634,7 +652,9 @@ describe("useLandingDraftStore", () => {
   });
 
   it("a folder outside the draft's workspace is not settable as primary (no-op)", () => {
-    const draftId = useLandingDraftStore.getState().createDraft(null);
+    const draftId = useLandingDraftStore
+      .getState()
+      .createDraft(null, undefined);
     useLandingDraftStore
       .getState()
       .addDraftResolvedFolders(draftId, [WORKSPACE_A]);
@@ -651,9 +671,9 @@ describe("useLandingDraftStore", () => {
   it("closeDraft removes the draft and picks another as active", () => {
     const { createDraft, setDraftContent, closeDraft } =
       useLandingDraftStore.getState();
-    const a = createDraft(null);
+    const a = createDraft(null, undefined);
     setDraftContent(a, textContent("wip"), null);
-    const b = createDraft(null);
+    const b = createDraft(null, undefined);
 
     closeDraft(a);
     expect(useLandingDraftStore.getState().drafts).toHaveLength(1);
@@ -664,7 +684,7 @@ describe("useLandingDraftStore", () => {
 
   it("closeDraft sets activeDraftId to null when last draft is removed", () => {
     const { createDraft, closeDraft } = useLandingDraftStore.getState();
-    const id = createDraft(null);
+    const id = createDraft(null, undefined);
     closeDraft(id);
     expect(useLandingDraftStore.getState().drafts).toHaveLength(0);
     expect(useLandingDraftStore.getState().activeDraftId).toBeNull();
@@ -679,8 +699,8 @@ describe("useLandingDraftStore", () => {
 
   it("setActiveDraft switches the active draft", () => {
     const { createDraft, setActiveDraft } = useLandingDraftStore.getState();
-    const a = createDraft(null);
-    const b = createDraft(null);
+    const a = createDraft(null, undefined);
+    const b = createDraft(null, undefined);
     expect(useLandingDraftStore.getState().activeDraftId).toBe(b);
     setActiveDraft(a);
     expect(useLandingDraftStore.getState().activeDraftId).toBe(a);
@@ -688,7 +708,7 @@ describe("useLandingDraftStore", () => {
 
   it("clearActiveDraft clears the active marker without removing drafts", () => {
     const { createDraft, clearActiveDraft } = useLandingDraftStore.getState();
-    const draftId = createDraft(null);
+    const draftId = createDraft(null, undefined);
 
     clearActiveDraft();
 
@@ -703,8 +723,8 @@ describe("useLandingDraftStore", () => {
     const epicTabId = useEpicCanvasStore
       .getState()
       .openEpicTab("epic-a", "Epic A");
-    const a = createDraft(null);
-    const b = createDraft(null);
+    const a = createDraft(null, undefined);
+    const b = createDraft(null, undefined);
 
     expect(useEpicCanvasStore.getState().openTabOrder).toEqual([epicTabId]);
     expect(useLandingDraftStore.getState().drafts.map((tab) => tab.id)).toEqual(
@@ -738,7 +758,7 @@ describe("useLandingDraftStore", () => {
       activeDraftId: "draft-old",
     });
 
-    const next = useLandingDraftStore.getState().createDraft(null);
+    const next = useLandingDraftStore.getState().createDraft(null, undefined);
 
     expect(
       useLandingDraftStore.getState().drafts.map((draft) => draft.id),
@@ -891,7 +911,7 @@ describe("useLandingDraftStore", () => {
 
   it("keeps the initial landing-draft projection clean for a new window", () => {
     const { createDraft, setDraftContent } = useLandingDraftStore.getState();
-    const id = createDraft(null);
+    const id = createDraft(null, undefined);
     setDraftContent(id, textContent("do not inherit me"), null);
 
     const initial = useLandingDraftStore.getInitialState();
@@ -988,7 +1008,7 @@ describe("useLandingDraftStore", () => {
     });
 
     try {
-      const id = useLandingDraftStore.getState().createDraft(null);
+      const id = useLandingDraftStore.getState().createDraft(null, undefined);
       useLandingDraftStore
         .getState()
         .setDraftContent(id, imageContent, { from: 2, to: 5 });
@@ -1085,7 +1105,7 @@ describe("useLandingDraftStore", () => {
 
   it("persists drafts to localStorage under the versioned key", async () => {
     const { createDraft, setDraftContent } = useLandingDraftStore.getState();
-    const id = createDraft(null);
+    const id = createDraft(null, undefined);
     setDraftContent(id, textContent("survives reload"), null);
 
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -1169,7 +1189,7 @@ describe("useLandingDraftStore", () => {
     };
 
     it("setDraftContent keeps the pending b64 node in the canonical in-memory draft", () => {
-      const id = useLandingDraftStore.getState().createDraft(null);
+      const id = useLandingDraftStore.getState().createDraft(null, undefined);
       useLandingDraftStore
         .getState()
         .setDraftContent(id, mixedPendingContent, null);
@@ -1192,7 +1212,7 @@ describe("useLandingDraftStore", () => {
         dispose: () => undefined,
       });
       try {
-        const id = useLandingDraftStore.getState().createDraft(null);
+        const id = useLandingDraftStore.getState().createDraft(null, undefined);
         useLandingDraftStore
           .getState()
           .setDraftContent(id, mixedPendingContent, null);
@@ -1205,7 +1225,7 @@ describe("useLandingDraftStore", () => {
     });
 
     it("the localStorage partialize strips the pending b64 node (keeping text + hash)", async () => {
-      const id = useLandingDraftStore.getState().createDraft(null);
+      const id = useLandingDraftStore.getState().createDraft(null, undefined);
       useLandingDraftStore
         .getState()
         .setDraftContent(id, mixedPendingContent, null);
@@ -1251,7 +1271,7 @@ describe("useLandingDraftStore", () => {
         dispose: () => undefined,
       });
       try {
-        const id = useLandingDraftStore.getState().createDraft(null);
+        const id = useLandingDraftStore.getState().createDraft(null, undefined);
         useLandingDraftStore.getState().setDraftContent(id, onlyPending, null);
         // In-memory keeps the pending group verbatim...
         expect(
@@ -1297,7 +1317,7 @@ describe("useLandingDraftStore", () => {
         // The first host-owned snapshot is authoritative even when empty. Only
         // later empty updates may be rejected as spurious live-window churn.
         applyLandingDraftDesktopProjection(emptyWindowSnapshot({}));
-        const id = useLandingDraftStore.getState().createDraft(null);
+        const id = useLandingDraftStore.getState().createDraft(null, undefined);
         useLandingDraftStore
           .getState()
           .setDraftContent(id, textContent("alive draft"), null);
@@ -1349,7 +1369,9 @@ describe("useLandingDraftStore", () => {
       });
 
       try {
-        const staleId = useLandingDraftStore.getState().createDraft(null);
+        const staleId = useLandingDraftStore
+          .getState()
+          .createDraft(null, undefined);
         useLandingDraftStore
           .getState()
           .setDraftContent(staleId, textContent("stale local draft"), null);

--- a/clients/gui-app/src/stores/home/landing-draft-store.ts
+++ b/clients/gui-app/src/stores/home/landing-draft-store.ts
@@ -71,8 +71,15 @@ export interface LandingDraftWorkspaceSnapshot {
 interface LandingDraftStoreState {
   readonly drafts: ReadonlyArray<LandingDraftTab>;
   readonly activeDraftId: string | null;
-  /** Always creates a fresh draft, sets it as active, returns its id. */
-  createDraft: (settings: ChatRunSettings | null) => string;
+  /**
+   * Always creates a fresh draft, sets it as active, returns its id.
+   * Pass `id` to create with a pre-minted identity (landing null-draft mount
+   * key stability); pass `undefined` to allocate a new uuid.
+   */
+  createDraft: (
+    settings: ChatRunSettings | null,
+    id: string | undefined,
+  ) => string;
   /** Remove a draft by id. If it was the active draft, clears `activeDraftId`;
    *  strip-neighbor navigation in the close-flow handles where the user lands. */
   closeDraft: (id: string) => void;
@@ -322,9 +329,9 @@ export const useLandingDraftStore = create<LandingDraftStoreState>()(
       drafts: [],
       activeDraftId: null,
 
-      createDraft: (settings) => {
+      createDraft: (settings, id) => {
         const next: LandingDraftTab = {
-          id: uuidv4(),
+          id: id ?? uuidv4(),
           content: EMPTY_LANDING_DRAFT_CONTENT,
           selection: null,
           lastTouchedAt: Date.now(),


### PR DESCRIPTION
## Summary

Clean cherry-pick of https://github.com/traycerai/traycer/pull/653 for v1.1.8.

Supersedes #655. The release cherry-pick was recreated on a fresh branch so the author-matching DCO trailer could be added without rewriting published history.

## Conflict resolution

None. The cherry-pick applied cleanly without conflict resolution.