### PR TITLE
fix(cli): detect SMAppService ownership when launchctl reports no bundle path

### DIFF
--- a/clients/shared/host-client/host-activity-probe.ts
+++ b/clients/shared/host-client/host-activity-probe.ts
@@ -45,6 +45,30 @@ export async function probeHostActivityBusy(
   }
 }
 
+/**
+ * Returns `true` when SOMETHING is serving HTTP on the host's loopback
+ * endpoint - any status code counts, including a pre-feature host's 404.
+ * Connect errors, malformed URLs, and timeouts return `false`.
+ *
+ * Deliberately NOT `probeHostActivityBusy`: that one folds "unreachable"
+ * into "busy" so an indeterminate answer can never green-light a teardown.
+ * Reachability needs the opposite bias - callers use it to decide whether an
+ * incumbent host is really there, and treating an unreachable host as
+ * present would strand the machine with no host at all.
+ */
+export async function probeHostReachable(
+  websocketUrl: string,
+): Promise<boolean> {
+  try {
+    await fetch(toActivityUrl(websocketUrl), {
+      signal: AbortSignal.timeout(ACTIVITY_PROBE_TIMEOUT_MS),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // `ws://127.0.0.1:<port>/rpc` -> `http://127.0.0.1:<port>/activity`. The host
 // binds loopback HTTP (not TLS). A malformed URL throws and is caught above as
 // the busy fail-safe.

--- a/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
@@ -343,24 +343,40 @@ describe("runHostStart - incumbent host guard", () => {
     expect(recorded.spawnCalls).toHaveLength(1);
   });
 
-  it("checks for an incumbent only after the install record resolves", async () => {
-    // A missing install record must still surface its own stable error code
-    // rather than being masked by the guard.
+  // A live incumbent settles what this invocation should do regardless of
+  // whether THIS label can resolve its own install target. Resolving first
+  // exited 69, which `KeepAlive.SuccessfulExit = false` treats as
+  // restartable, so launchd relaunched the job into a throttled crash loop
+  // while a healthy host was serving. Reachable whenever the record breaks
+  // after the incumbent came up: uninstall, failed install, or the window
+  // where `host install` has swapped `install/` aside.
+  it("declines with exit 0 when a host owns the data dir even if the install record is broken", async () => {
     const { recorded, deps } = makeRunStubs(null, null);
-    let probed = false;
     const guarded: Partial<RunHostStartDeps> = {
       ...deps,
-      findIncumbentHost: async () => {
-        probed = true;
-        return null;
-      },
+      findIncumbentHost: async () => ({
+        pid: 40769,
+        version: "1.1.8",
+        websocketUrl: "ws://127.0.0.1:58036/rpc",
+      }),
     };
 
     await runHostStart({ environment: "production", cwd: null }, guarded);
 
-    expect(probed).toBe(false);
+    expect(recorded.exited).toBe(0);
+    expect(recorded.spawnCalls).toHaveLength(0);
+    // Not a spawn attempt, so no failed-to-spawn marker either.
+    expect(recorded.markers).toHaveLength(0);
+  });
+
+  it("still surfaces the install-record error when no host owns the data dir", async () => {
+    const { recorded, deps } = makeRunStubs(null, null);
+
+    await runHostStart({ environment: "production", cwd: null }, deps);
+
     expect(recorded.exited).toBe(69);
     expect(recorded.spawnCalls).toHaveLength(0);
+    expect(recorded.markers.map((m) => m.phase)).toContain("failed-to-spawn");
   });
 });
 

--- a/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
@@ -211,6 +211,11 @@ function makeRunStubs(
     // `undefined` as nullish just like a missing key, so it must be
     // supplied explicitly here, not left to the `Partial` default.
     logger: noopLogger,
+    // Same hazard as `logger` above: left unset, the `Partial` default falls
+    // through to the REAL `findLiveIncumbentHost`, which reads the developer's
+    // actual `~/.traycer/host/pid.json` and probes whatever host is live on
+    // this machine. Every test below would then decline instead of spawning.
+    findIncumbentHost: async () => null,
     readInstallRecord: async () => installRecord,
     pathExists: async (p: string) =>
       (existsOverride ?? ((q: string) => q === installRecord?.executablePath))(
@@ -289,6 +294,75 @@ async function runUntilExit(
   }
   expect(recorded.exited).not.toBeNull();
 }
+
+/**
+ * One host per data dir.
+ *
+ * launchd runs at most one instance of a LABEL, but the CLI label
+ * (`ai.traycer.host`) and Desktop's SMAppService agent label
+ * (`ai.traycer.host.agent`) are distinct labels that both invoke this
+ * supervisor against the same data dir, both with `RunAtLoad`. A machine
+ * carrying both registrations spawned two hosts at every login, racing the
+ * same pid.json and stores.
+ */
+describe("runHostStart - incumbent host guard", () => {
+  it("declines with exit 0 and never spawns when a live host owns the data dir", async () => {
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+    const guarded: Partial<RunHostStartDeps> = {
+      ...deps,
+      findIncumbentHost: async () => ({
+        pid: 40769,
+        version: "1.1.8",
+        websocketUrl: "ws://127.0.0.1:58036/rpc",
+      }),
+    };
+
+    await runHostStart({ environment: "production", cwd: null }, guarded);
+
+    expect(recorded.spawnCalls).toHaveLength(0);
+    // Exit 0 is load-bearing: the macOS plists set
+    // `KeepAlive.SuccessfulExit = false`, so a clean exit leaves the job
+    // down. Any non-zero code would have launchd relaunch this supervisor
+    // immediately and flap against the incumbent forever.
+    expect(recorded.exited).toBe(0);
+    // Declining is not a spawn attempt - it must not look like one in the
+    // bootstrap markers doctor/host-status read.
+    expect(recorded.markers).toHaveLength(0);
+  });
+
+  it("spawns normally when no live host owns the data dir", async () => {
+    const exec = "/opt/traycer/host/install/traycer-host";
+    const { child, recorded, deps } = makeRunStubs(sampleRecord(exec), null);
+
+    const invoke = () =>
+      runHostStart({ environment: "production", cwd: null }, deps);
+    setTimeout(() => child.emit("exit", 0, null));
+    await runUntilExit(invoke, recorded);
+
+    expect(recorded.spawnCalls).toHaveLength(1);
+  });
+
+  it("checks for an incumbent only after the install record resolves", async () => {
+    // A missing install record must still surface its own stable error code
+    // rather than being masked by the guard.
+    const { recorded, deps } = makeRunStubs(null, null);
+    let probed = false;
+    const guarded: Partial<RunHostStartDeps> = {
+      ...deps,
+      findIncumbentHost: async () => {
+        probed = true;
+        return null;
+      },
+    };
+
+    await runHostStart({ environment: "production", cwd: null }, guarded);
+
+    expect(probed).toBe(false);
+    expect(recorded.exited).toBe(69);
+    expect(recorded.spawnCalls).toHaveLength(0);
+  });
+});
 
 describe("runHostStart - installed-record launch path", () => {
   it("spawns record.executablePath directly with no shell wrapping and the environment env exported", async () => {

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -15,6 +15,10 @@ import {
 } from "../host/bootstrap-log";
 import { rotateHostLogIfOversized } from "../host/host-log-rotation";
 import {
+  findLiveIncumbentHost,
+  type IncumbentHost,
+} from "../host/incumbent-check";
+import {
   readHostInstallRecord,
   type HostInstallRecord,
 } from "../manifest/host-install";
@@ -148,6 +152,11 @@ export type SpawnImpl = (
 
 export interface RunHostStartDeps extends ResolveHostStartTargetDeps {
   readonly spawn: SpawnImpl;
+  // Injected so tests can drive the "another host already owns this data
+  // dir" branch without a real pid.json or a live loopback listener.
+  readonly findIncumbentHost: (
+    environment: Environment | undefined,
+  ) => Promise<IncumbentHost | null>;
   readonly openLogFd: (environment: Environment) => Promise<number>;
   readonly rotateLog: (
     environment: Environment,
@@ -167,6 +176,7 @@ export interface RunHostStartDeps extends ResolveHostStartTargetDeps {
 const defaultRunDeps: RunHostStartDeps = {
   ...defaultDeps,
   spawn: (cmd, args, options) => nodeSpawn(cmd, args.slice(), options),
+  findIncumbentHost: findLiveIncumbentHost,
   openLogFd: openBootstrapLogFd,
   rotateLog: rotateHostLogIfOversized,
   readEnvOverrides: async () => ({ ...(await listEnvOverrides()) }),
@@ -253,6 +263,44 @@ export async function runHostStart(
     argCount: target.args.length,
     hasCwdOverride: opts.cwd !== null,
   });
+
+  // One host per data dir. launchd runs at most one instance of a LABEL, but
+  // the CLI label (`ai.traycer.host`) and Desktop's SMAppService agent label
+  // (`ai.traycer.host.agent`) are distinct labels that both invoke this
+  // supervisor against the same data dir - and both carry `RunAtLoad`. On a
+  // machine that ended up with both registered, every login spawned two
+  // hosts racing the same pid.json and stores, with the loser invisible to
+  // new clients.
+  //
+  // Declining is the whole policy here: never evict the incumbent.
+  // Intentional version replacement belongs to the install lifecycle
+  // (`beforeSwap` stops the running host before the swap), which knows it is
+  // an upgrade; this supervisor cannot tell an upgrade from an accidental
+  // second job. Evicting from here would also deadlock against KeepAlive -
+  // the victim's `Crashed = true` restarts it, it evicts us back, and the
+  // two labels flap forever.
+  //
+  // Exit 0 specifically: the macOS plists set `KeepAlive.SuccessfulExit =
+  // false`, so a clean exit leaves this job down until the next login
+  // instead of relaunching it in a loop. No bootstrap marker is written -
+  // declining is not a spawn attempt, and the existing phases all describe
+  // one.
+  const incumbent = await deps.findIncumbentHost(opts.environment);
+  if (incumbent !== null) {
+    logger.warn(
+      "Host supervisor declined to start - another host already owns this data dir",
+      {
+        environment: opts.environment,
+        incumbentPid: incumbent.pid,
+        incumbentVersion: incumbent.version,
+        incumbentWebsocketUrl: incumbent.websocketUrl,
+        resolvedVersion: target.record.version,
+        attemptId,
+        supervisorPid,
+      },
+    );
+    return deps.exit(0);
+  }
 
   const envOverrides = await deps.readEnvOverrides();
   logger.debug("Host supervisor loaded env overrides", {

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -217,55 +217,20 @@ export async function runHostStart(
     supervisorPid,
   });
 
-  let target: HostStartTarget;
-  try {
-    target = await resolveHostStartTarget(opts, deps);
-  } catch (err) {
-    if (err instanceof CliError) {
-      logger.warn("Host supervisor target resolution failed", {
-        environment: opts.environment,
-        code: err.code,
-        exitCode: err.exitCode,
-        attemptId,
-      });
-      const detailLine = JSON.stringify({
-        code: err.code,
-        message: err.message,
-        details: err.details,
-      });
-      await deps.writeMarker(
-        opts.environment,
-        "failed-to-spawn",
-        markerFields(attemptId, supervisorPid, {
-          shell: undefined,
-          args: undefined,
-          bundle: undefined,
-          exitCode: undefined,
-          signal: undefined,
-          error: `${err.code}: ${err.message}`,
-        }),
-      );
-      deps.onError(`traycer host start: ${err.code}: ${err.message}`);
-      deps.onError(detailLine);
-      return deps.exit(err.exitCode);
-    }
-    logger.error(
-      "Host supervisor target resolution threw unexpectedly",
-      { environment: opts.environment, exitCode: 1 },
-      errorFromUnknown(err),
-    );
-    throw err;
-  }
-
-  logger.info("Host supervisor target resolved", {
-    environment: opts.environment,
-    version: target.record.version,
-    argCount: target.args.length,
-    hasCwdOverride: opts.cwd !== null,
-  });
-
   // Best-effort backstop against stacking a second host on a live one.
   // BE PRECISE ABOUT WHAT THIS DOES AND DOES NOT COVER.
+  //
+  // Runs BEFORE `resolveHostStartTarget` on purpose. Another host already
+  // owning this data dir settles what this invocation should do regardless
+  // of whether THIS label can resolve its own install target, and the two
+  // exit codes disagree: a resolution failure exits 69 / 1, which
+  // `KeepAlive.SuccessfulExit = false` treats as restartable, so launchd
+  // relaunches this job into a throttled crash loop while a perfectly
+  // healthy host is serving. Probing first turns that into a quiet exit 0.
+  // The record can be missing or invalid while a host is live - an
+  // uninstall, a failed install, or the window where `host install` has
+  // swapped `install/` aside - so this is reachable, not theoretical. With
+  // no incumbent the resolution error still surfaces exactly as before.
   //
   // Covered (deterministic): any STAGGERED start where a host is already
   // publishing - a raw `traycer host start` against a running host, one
@@ -313,13 +278,59 @@ export async function runHostStart(
         incumbentPid: incumbent.pid,
         incumbentVersion: incumbent.version,
         incumbentWebsocketUrl: incumbent.websocketUrl,
-        resolvedVersion: target.record.version,
         attemptId,
         supervisorPid,
       },
     );
     return deps.exit(0);
   }
+
+  let target: HostStartTarget;
+  try {
+    target = await resolveHostStartTarget(opts, deps);
+  } catch (err) {
+    if (err instanceof CliError) {
+      logger.warn("Host supervisor target resolution failed", {
+        environment: opts.environment,
+        code: err.code,
+        exitCode: err.exitCode,
+        attemptId,
+      });
+      const detailLine = JSON.stringify({
+        code: err.code,
+        message: err.message,
+        details: err.details,
+      });
+      await deps.writeMarker(
+        opts.environment,
+        "failed-to-spawn",
+        markerFields(attemptId, supervisorPid, {
+          shell: undefined,
+          args: undefined,
+          bundle: undefined,
+          exitCode: undefined,
+          signal: undefined,
+          error: `${err.code}: ${err.message}`,
+        }),
+      );
+      deps.onError(`traycer host start: ${err.code}: ${err.message}`);
+      deps.onError(detailLine);
+      return deps.exit(err.exitCode);
+    }
+    logger.error(
+      "Host supervisor target resolution threw unexpectedly",
+      { environment: opts.environment, exitCode: 1 },
+      errorFromUnknown(err),
+    );
+    throw err;
+  }
+
+  logger.info("Host supervisor target resolved", {
+    environment: opts.environment,
+    version: target.record.version,
+    argCount: target.args.length,
+    hasCwdOverride: opts.cwd !== null,
+  });
 
   const envOverrides = await deps.readEnvOverrides();
   logger.debug("Host supervisor loaded env overrides", {

--- a/clients/traycer-cli/src/commands/host-start.ts
+++ b/clients/traycer-cli/src/commands/host-start.ts
@@ -264,27 +264,46 @@ export async function runHostStart(
     hasCwdOverride: opts.cwd !== null,
   });
 
-  // One host per data dir. launchd runs at most one instance of a LABEL, but
-  // the CLI label (`ai.traycer.host`) and Desktop's SMAppService agent label
-  // (`ai.traycer.host.agent`) are distinct labels that both invoke this
-  // supervisor against the same data dir - and both carry `RunAtLoad`. On a
-  // machine that ended up with both registered, every login spawned two
-  // hosts racing the same pid.json and stores, with the loser invisible to
-  // new clients.
+  // Best-effort backstop against stacking a second host on a live one.
+  // BE PRECISE ABOUT WHAT THIS DOES AND DOES NOT COVER.
   //
-  // Declining is the whole policy here: never evict the incumbent.
-  // Intentional version replacement belongs to the install lifecycle
-  // (`beforeSwap` stops the running host before the swap), which knows it is
-  // an upgrade; this supervisor cannot tell an upgrade from an accidental
-  // second job. Evicting from here would also deadlock against KeepAlive -
-  // the victim's `Crashed = true` restarts it, it evicts us back, and the
-  // two labels flap forever.
+  // Covered (deterministic): any STAGGERED start where a host is already
+  // publishing - a raw `traycer host start` against a running host, one
+  // launchd label starting while the other's host is up, a crash-restart of
+  // one label mid-session. That is the shape of the field bug: an install
+  // bootstrapping the CLI label beside Desktop's already-running agent.
   //
-  // Exit 0 specifically: the macOS plists set `KeepAlive.SuccessfulExit =
-  // false`, so a clean exit leaves this job down until the next login
-  // instead of relaunching it in a loop. No bootstrap marker is written -
-  // declining is not a spawn attempt, and the existing phases all describe
-  // one.
+  // NOT covered: two supervisors starting SIMULTANEOUSLY, which is what a
+  // cold login does when a machine carries both the CLI label
+  // (`ai.traycer.host`) and Desktop's SMAppService label
+  // (`ai.traycer.host.agent`), since both set `RunAtLoad`. pid.json does not
+  // exist yet - the host unlinks it on graceful shutdown and publishes only
+  // after `listen()` succeeds - so both callers observe no incumbent and
+  // both spawn. This check is a read-only observation with no reservation
+  // behind it; it cannot serialise that. The host binds an ephemeral port
+  // (`listenPort: 0`), so there is no OS-level collision to fall back on
+  // either.
+  //
+  // That residual is contained elsewhere, not here: `installService`'s
+  // ownership refusals stop a dual registration from being CREATED at all,
+  // and Desktop's `retireLegacyLabelRegistrations` deletes the legacy plist
+  // and boots out the stale label - killing a duplicate mid-session, not
+  // only at next login. Real mutual exclusion belongs in the host process
+  // as a single-instance lock held for its lifetime, which is tracked
+  // separately.
+  //
+  // Declining is the whole policy: never evict the incumbent. Intentional
+  // version replacement belongs to the install lifecycle (`beforeSwap`
+  // stops the running host before the swap), which knows it is an upgrade;
+  // this supervisor cannot tell an upgrade from an accidental second job.
+  // Evicting would also flap against KeepAlive - a signal-killed supervisor
+  // exits 128+N, which `SuccessfulExit: false` treats as restartable, so
+  // the victim comes back and evicts us in turn.
+  //
+  // Exit 0 specifically: `KeepAlive.SuccessfulExit = false` leaves a
+  // cleanly-exited job down until the next login instead of relaunching it
+  // in a loop. No bootstrap marker is written - declining is not a spawn
+  // attempt, and the existing phases all describe one.
   const incumbent = await deps.findIncumbentHost(opts.environment);
   if (incumbent !== null) {
     logger.warn(

--- a/clients/traycer-cli/src/host/__tests__/incumbent-check.test.ts
+++ b/clients/traycer-cli/src/host/__tests__/incumbent-check.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// `findLiveIncumbentHost` decides whether the supervisor defers to a host
+// that is already serving this data dir. Both directions are load-bearing
+// and they are NOT symmetric:
+//
+//   - a false "present" makes the supervisor decline and leaves the machine
+//     with NO host, which is far worse than
+//   - a false "absent", which merely stacks a duplicate.
+//
+// So endpoint reachability is the positive signal and process identity only
+// ever REMOVES an incumbent that is positively proven to be an impostor.
+
+const mocks = vi.hoisted(() => ({
+  readHostPidMetadataMock: vi.fn(),
+  identityVerdictMock: vi.fn(),
+}));
+
+vi.mock("../pid-metadata", async () => {
+  // Keep `isValidLocalHostWebsocketUrl` real; only the pid.json read is stubbed.
+  const actual =
+    await vi.importActual<typeof import("../pid-metadata")>("../pid-metadata");
+  return {
+    ...actual,
+    readHostPidMetadata: mocks.readHostPidMetadataMock,
+  };
+});
+
+vi.mock("../../store/process-identity", () => ({
+  getPublishedProcessIdentityVerdict: mocks.identityVerdictMock,
+}));
+
+import { findLiveIncumbentHost } from "../incumbent-check";
+
+const VALID_META = {
+  pid: 4242,
+  hostId: "d1",
+  version: "1.1.8",
+  websocketUrl: "ws://127.0.0.1:58036/rpc",
+  startedAt: "2026-01-01T00:00:00.000Z",
+};
+
+// `probeHostReachable` is a plain loopback GET, so driving global fetch keeps
+// the real probe logic under test instead of stubbing the module out.
+function stubReachable(reachable: boolean): void {
+  vi.spyOn(globalThis, "fetch").mockImplementation(() =>
+    reachable
+      ? Promise.resolve(new Response("{}", { status: 200 }))
+      : Promise.reject(new Error("ECONNREFUSED")),
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  mocks.readHostPidMetadataMock.mockReset();
+  mocks.identityVerdictMock.mockReset();
+});
+
+describe("findLiveIncumbentHost", () => {
+  it("returns null when there is no pid.json", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue(null);
+    await expect(findLiveIncumbentHost("production")).resolves.toBeNull();
+  });
+
+  it("returns null for a non-loopback websocket url", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      ...VALID_META,
+      websocketUrl: "ws://10.0.0.5:58036/rpc",
+    });
+    await expect(findLiveIncumbentHost("production")).resolves.toBeNull();
+  });
+
+  it("returns null when nothing answers the recorded endpoint", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue(VALID_META);
+    stubReachable(false);
+
+    await expect(findLiveIncumbentHost("production")).resolves.toBeNull();
+    // Reachability is the positive signal; a dead endpoint short-circuits
+    // before the identity probe is worth paying for.
+    expect(mocks.identityVerdictMock).not.toHaveBeenCalled();
+  });
+
+  it("reports the incumbent when the endpoint answers and identity is current", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue(VALID_META);
+    mocks.identityVerdictMock.mockResolvedValue("current");
+    stubReachable(true);
+
+    await expect(findLiveIncumbentHost("production")).resolves.toEqual({
+      pid: 4242,
+      version: "1.1.8",
+      websocketUrl: "ws://127.0.0.1:58036/rpc",
+    });
+    expect(mocks.identityVerdictMock).toHaveBeenCalledWith(
+      4242,
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+
+  // The bias that matters. `isProcessAlive` would have reported `true` here
+  // too, but for the wrong reason - it collapses "indeterminate" into alive.
+  // The point is that an UNREADABLE os probe must not be read as evidence
+  // that a healthy, answering endpoint is down.
+  it("keeps the incumbent when process identity is indeterminate", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue(VALID_META);
+    mocks.identityVerdictMock.mockResolvedValue("indeterminate");
+    stubReachable(true);
+
+    await expect(findLiveIncumbentHost("production")).resolves.not.toBeNull();
+  });
+
+  // The case bare `isProcessAlive` could not see: the pid outlived its host
+  // and was recycled onto an unrelated process, so whatever answered that
+  // port is not this record's host.
+  it("returns null when the recorded pid was recycled onto another process", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue(VALID_META);
+    mocks.identityVerdictMock.mockResolvedValue("mismatch");
+    stubReachable(true);
+
+    await expect(findLiveIncumbentHost("production")).resolves.toBeNull();
+  });
+
+  it("returns null when the recorded process is gone", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue(VALID_META);
+    mocks.identityVerdictMock.mockResolvedValue("dead");
+    stubReachable(true);
+
+    await expect(findLiveIncumbentHost("production")).resolves.toBeNull();
+  });
+
+  it("never treats our own supervisor pid as the incumbent", async () => {
+    mocks.readHostPidMetadataMock.mockResolvedValue({
+      ...VALID_META,
+      pid: process.pid,
+    });
+    stubReachable(true);
+
+    await expect(findLiveIncumbentHost("production")).resolves.toBeNull();
+  });
+});

--- a/clients/traycer-cli/src/host/incumbent-check.ts
+++ b/clients/traycer-cli/src/host/incumbent-check.ts
@@ -1,0 +1,68 @@
+import { probeHostReachable } from "@traycer-clients/shared/host-client/host-activity-probe";
+import {
+  isValidLocalHostWebsocketUrl,
+  readHostPidMetadata,
+} from "./pid-metadata";
+import { isProcessAlive } from "../store/cli-lock";
+import type { Environment } from "../runner/environment";
+
+// One host per `--host-data-dir`, enforced where the spawn happens.
+//
+// launchd runs at most one instance of a LABEL, but the label split
+// (`ai.traycer.host` for the CLI, `ai.traycer.host.agent` for Desktop's
+// SMAppService registration) means two DISTINCT labels can both invoke
+// `traycer host start` against the same data dir. Both have `RunAtLoad`, so
+// a machine that ends up with both registered spawns two hosts at every
+// login - racing the same `pid.json`, stores, and epic file syncs, with the
+// loser silently invisible to new clients.
+//
+// The install lifecycle already owns intentional version replacement
+// (`beforeSwap` stops a running host before the swap). This check is the
+// backstop for the case that has no install in it at all: two registrations
+// that already exist on disk.
+
+export interface IncumbentHost {
+  readonly pid: number;
+  readonly version: string;
+  readonly websocketUrl: string;
+}
+
+/**
+ * Returns the live host already serving this environment's data dir, or
+ * `null` when the caller should go ahead and spawn.
+ *
+ * Deliberately biased toward spawning. A false positive here means the
+ * supervisor declines and the machine is left with NO host, which is far
+ * worse than the duplicate it prevents - so "present" requires two
+ * independent signals: the recorded pid is alive AND something is actually
+ * serving HTTP on the recorded loopback endpoint. A recycled pid clears the
+ * first but not the second; a wedged host that answers nothing is treated as
+ * absent so a healthy replacement can take over.
+ */
+export async function findLiveIncumbentHost(
+  environment: Environment | undefined,
+): Promise<IncumbentHost | null> {
+  const metadata = await readHostPidMetadata(environment);
+  if (metadata === null) {
+    return null;
+  }
+  if (!isValidLocalHostWebsocketUrl(metadata.websocketUrl)) {
+    return null;
+  }
+  // Our own supervisor pid can never be the incumbent host; guard anyway so a
+  // recycled pid that happens to match cannot deadlock the spawn path.
+  if (metadata.pid === process.pid) {
+    return null;
+  }
+  if (!isProcessAlive(metadata.pid)) {
+    return null;
+  }
+  if (!(await probeHostReachable(metadata.websocketUrl))) {
+    return null;
+  }
+  return {
+    pid: metadata.pid,
+    version: metadata.version,
+    websocketUrl: metadata.websocketUrl,
+  };
+}

--- a/clients/traycer-cli/src/host/incumbent-check.ts
+++ b/clients/traycer-cli/src/host/incumbent-check.ts
@@ -3,23 +3,21 @@ import {
   isValidLocalHostWebsocketUrl,
   readHostPidMetadata,
 } from "./pid-metadata";
-import { isProcessAlive } from "../store/cli-lock";
+import { getPublishedProcessIdentityVerdict } from "../store/process-identity";
 import type { Environment } from "../runner/environment";
 
-// One host per `--host-data-dir`, enforced where the spawn happens.
+// Best-effort "is a host already serving this data dir?" probe, used by the
+// supervisor to avoid stacking a second host on top of a live one.
 //
-// launchd runs at most one instance of a LABEL, but the label split
-// (`ai.traycer.host` for the CLI, `ai.traycer.host.agent` for Desktop's
-// SMAppService registration) means two DISTINCT labels can both invoke
-// `traycer host start` against the same data dir. Both have `RunAtLoad`, so
-// a machine that ends up with both registered spawns two hosts at every
-// login - racing the same `pid.json`, stores, and epic file syncs, with the
-// loser silently invisible to new clients.
+// This is NOT mutual exclusion, and callers must not treat it as such. It is
+// a read-only observation with no reservation behind it: two callers that
+// observe simultaneously both see the same answer. See the guard in
+// `commands/host-start.ts` for exactly which races it does and does not
+// cover.
 //
-// The install lifecycle already owns intentional version replacement
-// (`beforeSwap` stops a running host before the swap). This check is the
-// backstop for the case that has no install in it at all: two registrations
-// that already exist on disk.
+// The install lifecycle owns intentional version replacement (`beforeSwap`
+// stops a running host before the swap). This probe exists only for the
+// case that has no install in it at all.
 
 export interface IncumbentHost {
   readonly pid: number;
@@ -28,16 +26,28 @@ export interface IncumbentHost {
 }
 
 /**
- * Returns the live host already serving this environment's data dir, or
- * `null` when the caller should go ahead and spawn.
+ * Returns the host already serving this environment's data dir, or `null`
+ * when the caller should go ahead and spawn.
  *
- * Deliberately biased toward spawning. A false positive here means the
- * supervisor declines and the machine is left with NO host, which is far
- * worse than the duplicate it prevents - so "present" requires two
- * independent signals: the recorded pid is alive AND something is actually
- * serving HTTP on the recorded loopback endpoint. A recycled pid clears the
- * first but not the second; a wedged host that answers nothing is treated as
- * absent so a healthy replacement can take over.
+ * Deliberately biased toward spawning: a false positive means the supervisor
+ * declines and the machine is left with NO host, which is far worse than the
+ * duplicate it prevents.
+ *
+ * Order matters. Endpoint reachability comes FIRST and is the positive
+ * liveness signal - something must actually be serving the recorded loopback
+ * endpoint. Only then does process identity run, and only to rule out a
+ * positively demonstrated recycled-PID impostor.
+ *
+ * `getPublishedProcessIdentityVerdict` is used rather than `isProcessAlive`
+ * on purpose. `isProcessAlive` is `probeProcessLiveness(pid) !== "dead"`, so
+ * it reports `true` for an *indeterminate* OS probe and cannot distinguish
+ * the publisher from an unrelated process that inherited a recycled pid.
+ * The verdict helper compares the process start time against pid.json's
+ * publication time and reports `mismatch` for exactly that impostor case.
+ *
+ * `indeterminate` deliberately KEEPS the incumbent: a failed OS probe is not
+ * evidence that a healthy, answering endpoint is down. Taking the opposite
+ * reading here would spawn a duplicate every time `ps` was slow.
  */
 export async function findLiveIncumbentHost(
   environment: Environment | undefined,
@@ -54,10 +64,18 @@ export async function findLiveIncumbentHost(
   if (metadata.pid === process.pid) {
     return null;
   }
-  if (!isProcessAlive(metadata.pid)) {
+  if (!(await probeHostReachable(metadata.websocketUrl))) {
     return null;
   }
-  if (!(await probeHostReachable(metadata.websocketUrl))) {
+  const identity = await getPublishedProcessIdentityVerdict(
+    metadata.pid,
+    metadata.startedAt,
+  );
+  // `mismatch` - the pid was recycled onto an unrelated occupant, so whatever
+  // answered the endpoint is not this record's host. `dead` - the recorded
+  // process is gone despite something answering that port. Both mean the
+  // record no longer describes a host we should defer to.
+  if (identity === "mismatch" || identity === "dead") {
     return null;
   }
   return {

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -18,9 +18,9 @@ import {
 
 import {
   buildLaunchAgentPlist,
+  classifyLaunchdPrintOutput,
   createMacosController,
   isSmAppServiceLaunchAgentPath,
-  parseLaunchctlPrintPath,
   readRegisteredCliInvocation,
   type ProcessRunner,
 } from "../macos";
@@ -872,12 +872,90 @@ describe("macOS service lifecycle", () => {
       ),
     ).toBe(false);
     expect(
-      parseLaunchctlPrintPath(
+      classifyLaunchdPrintOutput(
         `gui/501/ai.traycer.host = {\n\tpath = /Applications/Traycer.app/Contents/Library/LaunchAgents/ai.traycer.host.plist\n\tstate = running\n}\n`,
       ),
-    ).toBe(
-      "/Applications/Traycer.app/Contents/Library/LaunchAgents/ai.traycer.host.plist",
-    );
+    ).toEqual({
+      kind: "smappservice",
+      path: "/Applications/Traycer.app/Contents/Library/LaunchAgents/ai.traycer.host.plist",
+    });
+  });
+
+  // Verbatim `launchctl print` output captured from a macOS build that
+  // reports SMAppService jobs WITHOUT an in-bundle plist path. Keying
+  // ownership on the bundle path alone classified this as `cli-or-other`,
+  // which silently disarmed every SMAppService guard at once and let
+  // `host install` bootstrap a second host beside Desktop's agent.
+  it("classifies an SMAppService job that reports no bundle path", () => {
+    const printOutput = [
+      "gui/501/ai.traycer.host.staging.agent = {",
+      "\tactive count = 1",
+      "\tpath = (submitted by smd.321)",
+      "\ttype = Submitted",
+      "\tmanaged_by = com.apple.xpc.ServiceManagement",
+      "\tstate = running",
+      "",
+      "\tprogram identifier = Contents/Library/LaunchAgents/Traycer Staging Host.app/Contents/MacOS/traycer (mode: 2)",
+      "\tparent bundle identifier = ai.traycer.desktop.staging",
+      "\targuments = {",
+      "\t\tContents/Library/LaunchAgents/Traycer Staging Host.app/Contents/MacOS/traycer",
+      "\t\thost",
+      "\t\tstart",
+      "\t}",
+      "",
+      "\tenvironment = {",
+      "\t\tOSLogRateLimit => 64",
+      "\t\tXPC_SERVICE_NAME => ai.traycer.host.staging.agent",
+      "\t}",
+      "}",
+      "",
+    ].join("\n");
+
+    expect(classifyLaunchdPrintOutput(printOutput)).toEqual({
+      kind: "smappservice",
+      path: "(submitted by smd.321)",
+    });
+  });
+
+  it("classifies a raw CLI-bootstrapped LaunchAgent as cli-or-other", () => {
+    const printOutput = [
+      "gui/501/ai.traycer.host = {",
+      "\tactive count = 1",
+      "\tpath = /Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+      "\ttype = LaunchAgent",
+      "\tstate = running",
+      "",
+      "\tprogram = /Users/me/.traycer/cli/bin/traycer",
+      "\targuments = {",
+      "\t\t/Users/me/.traycer/cli/bin/traycer",
+      "\t\thost",
+      "\t\tstart",
+      "\t}",
+      "}",
+      "",
+    ].join("\n");
+
+    expect(classifyLaunchdPrintOutput(printOutput)).toEqual({
+      kind: "cli-or-other",
+      path: "/Users/me/Library/LaunchAgents/ai.traycer.host.plist",
+    });
+  });
+
+  it("treats managed_by and type as independent SMAppService signals", () => {
+    expect(
+      classifyLaunchdPrintOutput(
+        "gui/501/x = {\n\tmanaged_by = com.apple.xpc.ServiceManagement\n}\n",
+      ),
+    ).toEqual({
+      kind: "smappservice",
+      path: "(SMAppService-managed; no plist path)",
+    });
+    expect(
+      classifyLaunchdPrintOutput("gui/501/x = {\n\ttype = Submitted\n}\n"),
+    ).toEqual({
+      kind: "smappservice",
+      path: "(SMAppService-managed; no plist path)",
+    });
   });
 
   it("reports externally-managed when launchd loads the label from an SMAppService path even if a stale raw plist exists", async () => {

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -364,10 +364,9 @@ type LaunchdOwnership =
   | { readonly kind: "cli-or-other"; readonly path: string | null };
 
 // Probe launchd for who currently owns this label. `launchctl print`
-// exits 0 when loaded and includes `path = <plist>`; non-zero means not
-// loaded. Tolerate non-zero so a fresh install skips bootout. Genuine
-// launchctl unavailability surfaces later at bootstrap with a clearer
-// error.
+// exits 0 when loaded; non-zero means not loaded. Tolerate non-zero so a
+// fresh install skips bootout. Genuine launchctl unavailability surfaces
+// later at bootstrap with a clearer error.
 //
 // Point-in-time by design: this reads what launchd has LOADED right now.
 // With Desktop's login item disabled (requires-approval) or BTM unloaded,
@@ -391,9 +390,55 @@ async function inspectLaunchdOwnership(
   if (result.exitCode !== 0) {
     return { kind: "not-loaded" };
   }
-  const path = parseLaunchctlPrintPath(`${result.stdout}\n${result.stderr}`);
-  if (path !== null && isSmAppServiceLaunchAgentPath(path)) {
-    return { kind: "smappservice", path };
+  return classifyLaunchdPrintOutput(`${result.stdout}\n${result.stderr}`);
+}
+
+// Marker launchd prints for jobs submitted through the ServiceManagement
+// framework (SMAppService / SMJobSubmit) rather than bootstrapped from a
+// plist path.
+const SERVICE_MANAGEMENT_MANAGED_BY = "com.apple.xpc.ServiceManagement";
+const SERVICE_MANAGEMENT_JOB_TYPE = "Submitted";
+// `launchctl print` of an SMAppService job can report a placeholder instead
+// of a plist path; keep the refusal messages readable when even that is
+// absent.
+const SMAPPSERVICE_PATH_UNKNOWN = "(SMAppService-managed; no plist path)";
+
+/**
+ * Decide who owns a loaded label from `launchctl print` output.
+ *
+ * Three independent signals, because the output format is NOT stable across
+ * macOS releases and keying on any single one has already broken once:
+ *
+ *   - `managed_by = com.apple.xpc.ServiceManagement` - the precise marker.
+ *   - `type = Submitted` - the same job family; a plist bootstrapped from
+ *     `~/Library/LaunchAgents` always reports `type = LaunchAgent`, so this
+ *     cannot misclassify a CLI-managed job.
+ *   - an in-bundle `<App>.app/Contents/Library/LaunchAgents/` plist path.
+ *
+ * The bundle-path signal alone was the original implementation. On macOS
+ * builds that print
+ *
+ *     path = (submitted by smd.321)
+ *     type = Submitted
+ *     managed_by = com.apple.xpc.ServiceManagement
+ *
+ * there is no bundle path at all, so ownership fell through to
+ * `cli-or-other` and EVERY consumer of this probe failed at once:
+ * `installService`'s two SMAppService refusals, `statusService`'s
+ * `externally-managed` state, install-lifecycle's externally-managed
+ * short-circuit, and the stop/start/restart guards. The observable damage
+ * was a second host bootstrapped under the CLI label beside Desktop's
+ * agent, both racing the same `pid.json` and stores.
+ */
+function classifyLaunchdPrintOutput(printOutput: string): LaunchdOwnership {
+  const fields = parseLaunchctlPrintFields(printOutput);
+  const path = fields.get("path") ?? null;
+  const isServiceManagement =
+    fields.get("managed_by") === SERVICE_MANAGEMENT_MANAGED_BY ||
+    fields.get("type") === SERVICE_MANAGEMENT_JOB_TYPE ||
+    (path !== null && isSmAppServiceLaunchAgentPath(path));
+  if (isServiceManagement) {
+    return { kind: "smappservice", path: path ?? SMAPPSERVICE_PATH_UNKNOWN };
   }
   return { kind: "cli-or-other", path };
 }
@@ -406,15 +451,32 @@ function isSmAppServiceLaunchAgentPath(plistPath: string): boolean {
   return /\/[^/]+\.app\/Contents\/Library\/LaunchAgents\//i.test(plistPath);
 }
 
-// Extract `path = ...` from `launchctl print` output. Format is stable
-// enough across recent macOS releases; missing path is treated as
-// non-SMAppService (fail open to CLI ownership for CLI-managed installs).
-function parseLaunchctlPrintPath(printOutput: string): string | null {
-  const match = printOutput.match(/^\s*path\s*=\s*(.+?)\s*$/m);
-  if (match === null) return null;
-  const raw = match[1];
-  if (raw === undefined || raw.length === 0) return null;
-  return raw;
+/**
+ * Collect the top-level `key = value` pairs from `launchctl print` output.
+ *
+ * First occurrence wins: the fields we care about (`path`, `type`,
+ * `managed_by`) are printed in the job's top-level block, while nested
+ * blocks (`environment`, `arguments`, ...) can repeat similar keys further
+ * down. Nested environment entries use `=>` rather than `=` and are
+ * excluded outright so they can never shadow a real field.
+ */
+function parseLaunchctlPrintFields(
+  printOutput: string,
+): ReadonlyMap<string, string> {
+  const fields = new Map<string, string>();
+  for (const line of printOutput.split("\n")) {
+    const match = line.match(
+      /^\s*([A-Za-z_][A-Za-z0-9_ ]*?)\s*=(?!>)\s*(.+?)\s*$/,
+    );
+    if (match === null) continue;
+    const key = match[1];
+    const value = match[2];
+    if (key === undefined || value === undefined || value.length === 0) {
+      continue;
+    }
+    if (!fields.has(key)) fields.set(key, value);
+  }
+  return fields;
 }
 
 // launchctl returns "Service is already loaded" / "Bootstrap failed:
@@ -909,7 +971,7 @@ function unescapeXml(value: string): string {
 
 export {
   buildPlist as buildLaunchAgentPlist,
+  classifyLaunchdPrintOutput,
   isSmAppServiceLaunchAgentPath,
-  parseLaunchctlPrintPath,
   readRegisteredCliInvocation,
 };

--- a/clients/traycer-cli/src/store/process-identity.ts
+++ b/clients/traycer-cli/src/store/process-identity.ts
@@ -11,6 +11,7 @@ export {
   __setProcessStartTimeReaderForTest,
   computeProcessIdentityVerdict,
   currentProcessIdentityToken,
+  getPublishedProcessIdentityVerdict,
   isProcessAlive,
   readLiveProcessStartTimeMs,
   readProcessStartTimeMs,
@@ -18,4 +19,5 @@ export {
   type ProcessIdentityToken,
   type ProcessIdentityVerdict,
   type ProcessLivenessVerdict,
+  type PublishedProcessIdentityVerdict,
 } from "@traycer-clients/shared/host-lock/process-identity";


### PR DESCRIPTION
## Problem

`inspectLaunchdOwnership` decided "Desktop owns this label" by regexing `launchctl print` output for an in-bundle `<App>.app/Contents/Library/LaunchAgents/` plist path. On macOS builds that print

```
path = (submitted by smd.321)
type = Submitted
managed_by = com.apple.xpc.ServiceManagement
```

there is no bundle path at all. Ownership fell through to `cli-or-other`, and because **every** SMAppService guard reads that one probe, they all failed together:

- both SMAppService refusals in `installService`
- `statusService`'s `externally-managed` state
- install-lifecycle's externally-managed short-circuit
- the stop/start/restart agent guards

## Impact

Reproduced on a desktop-managed machine (Darwin 25.5):

- `traycer host install` saw `statusService` → `not-installed`, so `beforeSwap` stopped nothing, then `afterSwap` bootstrapped a **second** host under the CLI label beside Desktop's agent. Two hosts on one `--host-data-dir`, racing `pid.json` and the shared stores, with the loser invisible to new clients.
- An interactive `traycer host status` reaches the same place with no install involved: auto-bootstrap reads `serviceRegistered` from the same blinded status, misreads it as false, and takes the service-repair branch.

The desktop auto-update path is unaffected — it picks its branch from the in-bundle plist's presence and passes `--no-service-register` throughout.

## Fix

1. **Classifier** — treat `managed_by = com.apple.xpc.ServiceManagement` and `type = Submitted` as SMAppService ownership alongside the bundle path. A plist bootstrapped from `~/Library/LaunchAgents` always reports `type = LaunchAgent`, so a CLI-managed job cannot be misclassified.
2. **Supervisor backstop** — `traycer host start` declines (exit 0, no spawn) when a live host already owns the data dir. This covers machines that *already* carry both registrations, where two `RunAtLoad` labels spawn two hosts every login with no install involved.

The supervisor never evicts the incumbent. Version replacement stays with the install lifecycle, which knows it is an upgrade; evicting from the supervisor would flap against `KeepAlive.Crashed`. Exit 0 is load-bearing — the plists set `KeepAlive.SuccessfulExit = false`, so a clean exit leaves the job down.

`findLiveIncumbentHost` is biased toward spawning: "present" needs both a live recorded pid **and** something answering on the recorded loopback endpoint, so a recycled pid or a wedged host can never strand a machine with no host at all.

## Tests

- Fixtures in the current `launchctl print` format, captured verbatim from an affected machine. The existing fixtures all mocked the older bundle-path shape, which is why the guard suite stayed green against output macOS no longer produces.
- Mutation-probed: reverting the classifier to bundle-path-only fails the two new format tests and leaves the `cli-or-other` test passing.
- Supervisor decline path: no spawn, exit 0, no bootstrap markers; plus ordering (install-record errors still surface first).
- `makeRunStubs` now stubs `findIncumbentHost` — left unset it falls through to the real probe and reads the developer's live `~/.traycer/host/pid.json`.

Full `@traycer-clients/traycer-cli` suite: 875 passed, 1 skipped.