### PR TITLE
fix(desktop): never auto-restart a host whose process still exists

### DIFF
--- a/clients/desktop/src/electron-main/host/__tests__/host-health-monitor.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-health-monitor.test.ts
@@ -16,11 +16,49 @@ vi.mock("electron-log", () => ({
   },
 }));
 
-import { startHostHealthMonitor } from "../host-health-monitor";
+import {
+  startHostHealthMonitor,
+  type HostHealthMonitor,
+} from "../host-health-monitor";
+import {
+  createHostRecoveryGovernor,
+  type HostProcessLiveness,
+} from "../host-recovery-governor";
 import { HostRecoveryDeferredError } from "../../startup/host-health-respawn";
 import { __setAsyncProcessLivenessReaderForTest } from "../process-identity";
 
 const INTERVAL_MS = 1_000;
+
+const DEAD = (): Promise<HostProcessLiveness> => Promise.resolve("dead");
+const ALIVE = (): Promise<HostProcessLiveness> => Promise.resolve("alive");
+
+/**
+ * These suites predate the recovery governor and exercise the monitor against
+ * a host whose process is GONE - the genuinely dead case they were written
+ * for, and the one where a respawn is the right answer.
+ */
+function startMonitor(deps: {
+  readonly host: IpcHostLifecycle;
+  readonly intervalMs: number;
+  readonly probe: (websocketUrl: string) => Promise<boolean>;
+  readonly readMetadata: (
+    path: string,
+  ) => Promise<DesktopLocalHostSnapshot | null>;
+  readonly respawn: () => Promise<void>;
+}): HostHealthMonitor {
+  return startHostHealthMonitor({
+    host: deps.host,
+    intervalMs: deps.intervalMs,
+    probe: deps.probe,
+    readMetadata: deps.readMetadata,
+    respawn: deps.respawn,
+    governor: createHostRecoveryGovernor({
+      readLiveness: DEAD,
+      now: undefined,
+    }),
+    readLiveness: DEAD,
+  });
+}
 
 const SNAPSHOT: DesktopLocalHostSnapshot = {
   hostId: "host-1",
@@ -74,7 +112,7 @@ describe("startHostHealthMonitor", () => {
 
   it("respawns after two consecutive failed probes with pid metadata still on disk", async () => {
     const respawn = vi.fn(async () => {});
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({}),
       intervalMs: INTERVAL_MS,
       probe: vi.fn(async () => false),
@@ -94,7 +132,7 @@ describe("startHostHealthMonitor", () => {
     // port; the stale snapshot's endpoint is dead but a reload surfaces the
     // healthy replacement - restarting it would kill a live host.
     const reload = vi.fn(async () => SNAPSHOT);
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({ reloadSnapshotFromDisk: reload }),
       intervalMs: INTERVAL_MS,
       probe: vi.fn(async () => false),
@@ -103,6 +141,45 @@ describe("startHostHealthMonitor", () => {
     });
     await ticks(2);
     expect(reload).toHaveBeenCalledTimes(1);
+    expect(respawn).not.toHaveBeenCalled();
+    monitor.dispose();
+  });
+
+  it("still converges on a replacement host whose own process is alive", async () => {
+    // Same supervisor-respawn as above, but with the liveness gate in play. The
+    // gate asks about whatever pid.json currently holds - which here is the
+    // REPLACEMENT, alive and healthy - while the snapshot the renderer is
+    // pointed at names the dead predecessor. Reading "alive" as "the snapshot's
+    // host is merely busy" would hold the stale snapshot for the whole
+    // unreachable-demote window, leaving the renderer on a dead endpoint for ten
+    // minutes when a reload converges it on the next tick.
+    const replacement: DesktopLocalHostSnapshot = {
+      ...SNAPSHOT,
+      pid: SNAPSHOT.pid + 1,
+      websocketUrl: "ws://127.0.0.1:55556/rpc",
+    };
+    const reload = vi.fn(async () => replacement);
+    const respawn = vi.fn(async () => {});
+    const monitor = startHostHealthMonitor({
+      host: fakeHost({
+        getSnapshot: () => SNAPSHOT,
+        reloadSnapshotFromDisk: reload,
+      }),
+      intervalMs: INTERVAL_MS,
+      probe: vi.fn(async (url: string) => url === replacement.websocketUrl),
+      readMetadata: vi.fn(async () => replacement),
+      respawn,
+      governor: createHostRecoveryGovernor({
+        readLiveness: ALIVE,
+        now: undefined,
+      }),
+      readLiveness: ALIVE,
+    });
+
+    await ticks(2);
+    expect(reload).toHaveBeenCalledTimes(1);
+    // Converging is the whole point - the replacement is healthy and must not
+    // be restarted, and neither must the predecessor be resurrected.
     expect(respawn).not.toHaveBeenCalled();
     monitor.dispose();
   });
@@ -119,7 +196,7 @@ describe("startHostHealthMonitor", () => {
       return null;
     });
     const readMetadata = vi.fn(async () => (stopped ? null : SNAPSHOT));
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({ reloadSnapshotFromDisk: reload }),
       intervalMs: INTERVAL_MS,
       probe: vi.fn(async () => false),
@@ -135,7 +212,7 @@ describe("startHostHealthMonitor", () => {
   it("does not respawn when a failure streak is broken by a healthy probe", async () => {
     const respawn = vi.fn(async () => {});
     let reachable = false;
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({}),
       intervalMs: INTERVAL_MS,
       probe: vi.fn(async () => reachable),
@@ -161,7 +238,7 @@ describe("startHostHealthMonitor", () => {
     );
     const reload = vi.fn(async () => null);
     const respawn = vi.fn(async () => {});
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({
         getSnapshot: () => staleSnapshot,
         reloadSnapshotFromDisk: reload,
@@ -188,7 +265,7 @@ describe("startHostHealthMonitor", () => {
   it("treats missing pid metadata as a deliberate stop: demote, never respawn", async () => {
     const respawn = vi.fn(async () => {});
     const reload = vi.fn(async () => null);
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({ reloadSnapshotFromDisk: reload }),
       intervalMs: INTERVAL_MS,
       probe: vi.fn(async () => false),
@@ -203,7 +280,7 @@ describe("startHostHealthMonitor", () => {
 
   it("idles while the snapshot is null (recovery owned by ensure/respawn flows)", async () => {
     const probe = vi.fn(async () => false);
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({ getSnapshot: () => null }),
       intervalMs: INTERVAL_MS,
       probe,
@@ -222,7 +299,7 @@ describe("startHostHealthMonitor", () => {
       respawnCalls += 1;
       if (respawnCalls === 1) throw new HostRecoveryDeferredError();
     });
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({
         getSnapshot: () => snapshot,
         reloadSnapshotFromDisk: vi.fn(async () => {
@@ -262,7 +339,7 @@ describe("startHostHealthMonitor", () => {
       respawnCalls += 1;
       if (respawnCalls === 1) throw new HostRecoveryDeferredError();
     });
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({
         getSnapshot: () => snapshot,
         reloadSnapshotFromDisk: reload,
@@ -292,7 +369,7 @@ describe("startHostHealthMonitor", () => {
       if (respawnCalls === 1) throw new HostRecoveryDeferredError();
       throw new Error("restart failed");
     });
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({
         getSnapshot: () => snapshot,
         reloadSnapshotFromDisk: vi.fn(async () => {
@@ -306,11 +383,21 @@ describe("startHostHealthMonitor", () => {
       respawn,
     });
 
-    // The first attempt is lock-deferred (not a restart). The next three
-    // failed restart attempts consume the full recovery budget; tick six
-    // must not initiate a fourth failed restart from the null-snapshot arm.
-    await ticks(6);
-    expect(respawn).toHaveBeenCalledTimes(4);
+    // The first attempt is lock-deferred: another Traycer process held the
+    // lock, so the host was never touched and the budget must be refunded -
+    // the retry that follows is immediate rather than paced behind a backoff
+    // it did not earn.
+    await ticks(3);
+    expect(respawn).toHaveBeenCalledTimes(2);
+
+    // From here the attempts are real failures, so they are paced. Retry
+    // ownership survives the null snapshot (without it, every later tick
+    // returns at the null-snapshot arm and the dead host is never retried),
+    // but the budget still runs out.
+    await ticks(1_600);
+    expect(respawn).toHaveBeenCalledTimes(6);
+    await ticks(1_000);
+    expect(respawn).toHaveBeenCalledTimes(6);
     monitor.dispose();
   });
 
@@ -323,7 +410,7 @@ describe("startHostHealthMonitor", () => {
       respawnCalls += 1;
       if (respawnCalls === 1) throw new HostRecoveryDeferredError();
     });
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({
         getSnapshot: () => snapshot,
         reloadSnapshotFromDisk: vi.fn(async () => {
@@ -355,7 +442,131 @@ describe("startHostHealthMonitor", () => {
     expect(respawn).toHaveBeenCalledTimes(1);
   });
 
-  it("stops auto-respawning after the budget is exhausted without a recovery", async () => {
+  it("paces repeated respawns instead of restarting on every confirmed outage", async () => {
+    const respawn = vi.fn(async () => {});
+    const monitor = startMonitor({
+      host: fakeHost({ reloadSnapshotFromDisk: vi.fn(async () => null) }),
+      intervalMs: INTERVAL_MS,
+      probe: vi.fn(async () => false),
+      readMetadata: vi.fn(async () => SNAPSHOT),
+      respawn,
+    });
+    // First outage restarts immediately - the overwhelmingly common case is a
+    // host that really is dead.
+    await ticks(2);
+    expect(respawn).toHaveBeenCalledTimes(1);
+    // Everything inside the first backoff window is refused, however many
+    // outages are confirmed in it.
+    await ticks(30);
+    expect(respawn).toHaveBeenCalledTimes(1);
+    // Past the window, one more is allowed.
+    await ticks(32);
+    expect(respawn).toHaveBeenCalledTimes(2);
+    monitor.dispose();
+  });
+
+  it("does NOT re-arm the respawn budget on a single successful probe", async () => {
+    // The v1.1.8-rc.2 restart loop was infinite for exactly this reason: every
+    // freshly spawned host answered one probe before stalling again, which
+    // reset the budget, so the attempt counter never advanced past its first
+    // value and the loop had no end. Recovery must be SUSTAINED to count.
+    const respawn = vi.fn(async () => {});
+    let reachable = false;
+    const monitor = startMonitor({
+      host: fakeHost({}),
+      intervalMs: INTERVAL_MS,
+      probe: vi.fn(async () => reachable),
+      readMetadata: vi.fn(async () => SNAPSHOT),
+      respawn,
+    });
+
+    // Drive five paced respawns, each separated by its backoff, with a single
+    // successful probe in between - the shape of the incident.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      reachable = false;
+      await ticks(320);
+      reachable = true;
+      await ticks(1);
+    }
+    expect(respawn).toHaveBeenCalledTimes(5);
+
+    // Sixth confirmed outage: the budget is spent, so recovery belongs to the
+    // user's Retry rather than to another restart.
+    reachable = false;
+    await ticks(320);
+    expect(respawn).toHaveBeenCalledTimes(5);
+    monitor.dispose();
+  });
+
+  it("clears the budget once the host stays reachable for the sustained window", async () => {
+    const respawn = vi.fn(async () => {});
+    let reachable = false;
+    const monitor = startMonitor({
+      host: fakeHost({}),
+      intervalMs: INTERVAL_MS,
+      probe: vi.fn(async () => reachable),
+      readMetadata: vi.fn(async () => SNAPSHOT),
+      respawn,
+    });
+
+    // Spend the budget down to a TRIPPED breaker first. Asserting from a merely
+    // paced state proves nothing: enough time passes to satisfy the backoff
+    // anyway, so the next respawn happens whether or not sustained health
+    // forgave anything. From a tripped breaker, only forgiveness can.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      reachable = false;
+      await ticks(320);
+      reachable = true;
+      await ticks(1);
+    }
+    reachable = false;
+    await ticks(320);
+    expect(respawn).toHaveBeenCalledTimes(5);
+
+    // A genuinely recovered host: reachable continuously past the sustained
+    // window, which forgives the spent attempts and re-arms recovery.
+    reachable = true;
+    await ticks(320);
+    reachable = false;
+    // Two ticks: just enough to confirm one outage, so this counts the grant
+    // the re-armed budget allowed rather than however many a long window fits.
+    await ticks(2);
+    expect(respawn).toHaveBeenCalledTimes(6);
+    monitor.dispose();
+  });
+
+  it("holds the snapshot and does not respawn while the host process is alive", async () => {
+    // The incident in one test: a host mid-epic-open answers no probe, but its
+    // process is plainly still there. It must not be restarted - and, just as
+    // important, its snapshot must not be demoted, or the user watches a
+    // healthy session flip to "host unavailable" for the length of the open.
+    const respawn = vi.fn(async () => {});
+    const reload = vi.fn(async () => null);
+    const liveness = vi.fn(ALIVE);
+    const monitor = startHostHealthMonitor({
+      host: fakeHost({ reloadSnapshotFromDisk: reload }),
+      intervalMs: INTERVAL_MS,
+      probe: vi.fn(async () => false),
+      readMetadata: vi.fn(async () => SNAPSHOT),
+      respawn,
+      governor: createHostRecoveryGovernor({
+        readLiveness: ALIVE,
+        now: undefined,
+      }),
+      readLiveness: liveness,
+    });
+
+    await ticks(60);
+    expect(liveness).toHaveBeenCalled();
+    expect(respawn).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+    monitor.dispose();
+  });
+
+  it("surfaces manual recovery after a long unreachable stretch but still refuses to kill it", async () => {
+    // Alive, but nothing has answered for far longer than any epic open. The
+    // renderer gets its unavailable card so Retry is reachable; the decision to
+    // actually kill a running process stays with the user.
     const respawn = vi.fn(async () => {});
     const reload = vi.fn(async () => null);
     const monitor = startHostHealthMonitor({
@@ -364,39 +575,98 @@ describe("startHostHealthMonitor", () => {
       probe: vi.fn(async () => false),
       readMetadata: vi.fn(async () => SNAPSHOT),
       respawn,
+      governor: createHostRecoveryGovernor({
+        readLiveness: ALIVE,
+        now: undefined,
+      }),
+      readLiveness: ALIVE,
     });
-    // Each confirmed outage takes 2 failed ticks; budget is 3 respawns.
-    await ticks(8);
-    expect(respawn).toHaveBeenCalledTimes(3);
-    // Every attempted restart gets a second reload-confirmation before the
-    // monitor releases ownership (four outage reloads + three confirmations).
-    expect(reload).toHaveBeenCalledTimes(7);
+
+    // Inside the window: held, no demote.
+    await ticks(300);
+    expect(reload).not.toHaveBeenCalled();
+
+    // Past 10 minutes of continuous unreachability: demote for Retry, but the
+    // process is still never killed.
+    await ticks(400);
+    expect(reload).toHaveBeenCalled();
+    expect(respawn).not.toHaveBeenCalled();
     monitor.dispose();
   });
 
-  it("resets the respawn budget once a probe succeeds", async () => {
+  it("stops re-probing a demoted host whose process is still alive", async () => {
+    // Once demoted with a living process, recovery belongs to the user - the
+    // answer cannot change until the process exits or Retry is pressed. Asking
+    // every tick is not free: each liveness probe spawns a child process (`ps`,
+    // or `tasklist` + `powershell` on Windows), so an afternoon-long wedge would
+    // spawn thousands for an answer nobody is waiting on.
     const respawn = vi.fn(async () => {});
-    let reachable = false;
+    let snapshot: DesktopLocalHostSnapshot | null = SNAPSHOT;
+    // One spy for both readers, so this counts total probes the way the machine
+    // pays for them.
+    const readLiveness = vi.fn(ALIVE);
     const monitor = startHostHealthMonitor({
-      host: fakeHost({}),
+      host: fakeHost({
+        getSnapshot: () => snapshot,
+        reloadSnapshotFromDisk: vi.fn(async () => {
+          snapshot = null; // the demote the renderer sees
+          return null;
+        }),
+      }),
       intervalMs: INTERVAL_MS,
-      probe: vi.fn(async () => reachable),
+      probe: vi.fn(async () => false),
       readMetadata: vi.fn(async () => SNAPSHOT),
       respawn,
+      governor: createHostRecoveryGovernor({
+        readLiveness,
+        now: undefined,
+      }),
+      readLiveness,
     });
-    await ticks(6); // three respawns, budget exhausted
-    expect(respawn).toHaveBeenCalledTimes(3);
-    reachable = true;
-    await ticks(1); // recovery
-    reachable = false;
-    await ticks(2); // fresh outage after recovery
-    expect(respawn).toHaveBeenCalledTimes(4);
+
+    // Past the demote window, so the snapshot is gone and every later tick lands
+    // in the null-snapshot arm - the one that used to ask on every pass.
+    await ticks(700);
+    const atDemote = readLiveness.mock.calls.length;
+
+    // Four more minutes of unchanged wedge. Ungated this is one probe per tick.
+    await ticks(240);
+    expect(readLiveness.mock.calls.length - atDemote).toBeLessThanOrEqual(4);
+    // Still never killed, which is the point of holding at all.
+    expect(respawn).not.toHaveBeenCalled();
+    monitor.dispose();
+  });
+
+  it("respawns once the process is gone, proving 'alive' is not a permanent shield", async () => {
+    const respawn = vi.fn(async () => {});
+    let liveness: HostProcessLiveness = "alive";
+    const readLiveness = (): Promise<HostProcessLiveness> =>
+      Promise.resolve(liveness);
+    const monitor = startHostHealthMonitor({
+      host: fakeHost({ reloadSnapshotFromDisk: vi.fn(async () => null) }),
+      intervalMs: INTERVAL_MS,
+      probe: vi.fn(async () => false),
+      readMetadata: vi.fn(async () => SNAPSHOT),
+      respawn,
+      governor: createHostRecoveryGovernor({
+        readLiveness,
+        now: undefined,
+      }),
+      readLiveness,
+    });
+
+    await ticks(10);
+    expect(respawn).not.toHaveBeenCalled();
+    // The process exited - or its pid was recycled onto something unrelated.
+    liveness = "dead";
+    await ticks(2);
+    expect(respawn).toHaveBeenCalledTimes(1);
     monitor.dispose();
   });
 
   it("stops probing after dispose", async () => {
     const probe = vi.fn(async () => true);
-    const monitor = startHostHealthMonitor({
+    const monitor = startMonitor({
       host: fakeHost({}),
       intervalMs: INTERVAL_MS,
       probe,

--- a/clients/desktop/src/electron-main/host/__tests__/host-health-monitor.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-health-monitor.test.ts
@@ -21,13 +21,24 @@ import {
   type HostHealthMonitor,
 } from "../host-health-monitor";
 import {
+  BREAKER_MAX_CONSECUTIVE_GRANTS,
   createHostRecoveryGovernor,
+  RESPAWN_BACKOFF_MS,
+  SUSTAINED_HEALTH_MS,
   type HostProcessLiveness,
 } from "../host-recovery-governor";
 import { HostRecoveryDeferredError } from "../../startup/host-health-respawn";
 import { __setAsyncProcessLivenessReaderForTest } from "../process-identity";
 
 const INTERVAL_MS = 1_000;
+
+// Derived from the governor's own constants, not re-guessed here, so a
+// retuned backoff or sustained-health window can't silently desync these
+// waits from what they are meant to cross.
+const BACKOFF_TICKS =
+  Math.ceil(RESPAWN_BACKOFF_MS[RESPAWN_BACKOFF_MS.length - 1] / INTERVAL_MS) +
+  20;
+const SUSTAINED_TICKS = Math.ceil(SUSTAINED_HEALTH_MS / INTERVAL_MS) + 20;
 
 const DEAD = (): Promise<HostProcessLiveness> => Promise.resolve("dead");
 const ALIVE = (): Promise<HostProcessLiveness> => Promise.resolve("alive");
@@ -482,9 +493,13 @@ describe("startHostHealthMonitor", () => {
 
     // Drive five paced respawns, each separated by its backoff, with a single
     // successful probe in between - the shape of the incident.
-    for (let attempt = 0; attempt < 5; attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < BREAKER_MAX_CONSECUTIVE_GRANTS;
+      attempt += 1
+    ) {
       reachable = false;
-      await ticks(320);
+      await ticks(BACKOFF_TICKS);
       reachable = true;
       await ticks(1);
     }
@@ -493,7 +508,7 @@ describe("startHostHealthMonitor", () => {
     // Sixth confirmed outage: the budget is spent, so recovery belongs to the
     // user's Retry rather than to another restart.
     reachable = false;
-    await ticks(320);
+    await ticks(BACKOFF_TICKS);
     expect(respawn).toHaveBeenCalledTimes(5);
     monitor.dispose();
   });
@@ -513,20 +528,24 @@ describe("startHostHealthMonitor", () => {
     // paced state proves nothing: enough time passes to satisfy the backoff
     // anyway, so the next respawn happens whether or not sustained health
     // forgave anything. From a tripped breaker, only forgiveness can.
-    for (let attempt = 0; attempt < 5; attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < BREAKER_MAX_CONSECUTIVE_GRANTS;
+      attempt += 1
+    ) {
       reachable = false;
-      await ticks(320);
+      await ticks(BACKOFF_TICKS);
       reachable = true;
       await ticks(1);
     }
     reachable = false;
-    await ticks(320);
+    await ticks(BACKOFF_TICKS);
     expect(respawn).toHaveBeenCalledTimes(5);
 
     // A genuinely recovered host: reachable continuously past the sustained
     // window, which forgives the spent attempts and re-arms recovery.
     reachable = true;
-    await ticks(320);
+    await ticks(SUSTAINED_TICKS);
     reachable = false;
     // Two ticks: just enough to confirm one outage, so this counts the grant
     // the re-armed budget allowed rather than however many a long window fits.

--- a/clients/desktop/src/electron-main/host/__tests__/host-process-liveness.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-process-liveness.test.ts
@@ -1,0 +1,134 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { readPublishedHostProcessLiveness } from "../host-process-liveness";
+import {
+  __setAsyncProcessLivenessReaderForTest,
+  __setAsyncProcessStartTimeReaderForTest,
+} from "../process-identity";
+
+const HOST_PID = 4242;
+const PUBLISHED_AT = "2026-07-25T10:00:00.000Z";
+
+describe("readPublishedHostProcessLiveness", () => {
+  let dir: string;
+  let pidFile: string;
+  // These seams are process-GLOBAL and test files share a fork, so restore
+  // whatever was installed before rather than resetting to the real probes -
+  // `null` would reset to the real OS calls and change behaviour for any other
+  // suite in this fork, which is a different kind of leak.
+  let previousLiveness: Parameters<
+    typeof __setAsyncProcessLivenessReaderForTest
+  >[0] = null;
+  let previousStartTime: Parameters<
+    typeof __setAsyncProcessStartTimeReaderForTest
+  >[0] = null;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "host-liveness-"));
+    pidFile = join(dir, "pid.json");
+  });
+
+  afterEach(() => {
+    __setAsyncProcessLivenessReaderForTest(previousLiveness);
+    __setAsyncProcessStartTimeReaderForTest(previousStartTime);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function publishPid(): void {
+    writeFileSync(
+      pidFile,
+      JSON.stringify({
+        pid: HOST_PID,
+        hostId: "host-1",
+        version: "1.1.8",
+        websocketUrl: "ws://127.0.0.1:55555/rpc",
+        startedAt: PUBLISHED_AT,
+      }),
+      "utf8",
+    );
+  }
+
+  function stubProcess(
+    liveness: "alive" | "dead" | "indeterminate",
+    startTimeMs: number | null,
+  ): void {
+    previousLiveness = __setAsyncProcessLivenessReaderForTest(() =>
+      Promise.resolve(liveness),
+    );
+    previousStartTime = __setAsyncProcessStartTimeReaderForTest(() =>
+      Promise.resolve(startTimeMs),
+    );
+  }
+
+  it("reports a running host as alive - the case that must never be auto-killed", async () => {
+    publishPid();
+    stubProcess("alive", Date.parse(PUBLISHED_AT) - 1_000);
+
+    await expect(readPublishedHostProcessLiveness(pidFile)).resolves.toBe(
+      "alive",
+    );
+  });
+
+  it("reports a vanished process as dead so recovery can run", async () => {
+    publishPid();
+    stubProcess("dead", null);
+
+    await expect(readPublishedHostProcessLiveness(pidFile)).resolves.toBe(
+      "dead",
+    );
+  });
+
+  it("treats a recycled pid as dead rather than an eternal shield", async () => {
+    // Something unrelated now owns this pid: it started well AFTER pid.json was
+    // published, so it cannot be the host. Without this, recovery would be
+    // blocked forever by a stranger's process.
+    publishPid();
+    stubProcess("alive", Date.parse(PUBLISHED_AT) + 60_000);
+
+    await expect(readPublishedHostProcessLiveness(pidFile)).resolves.toBe(
+      "dead",
+    );
+  });
+
+  it("errs towards alive when the probe cannot conclude", async () => {
+    // No start-time source (or a refused `tasklist`). Guessing "dead" here
+    // would kill a host that may be working perfectly; guessing "alive" costs
+    // at most a wait for the demote window and a manual Retry.
+    publishPid();
+    stubProcess("alive", null);
+
+    await expect(readPublishedHostProcessLiveness(pidFile)).resolves.toBe(
+      "alive",
+    );
+  });
+
+  it("errs towards alive when pid.json cannot be read at all", async () => {
+    // A partial write, or an EACCES/EIO/EMFILE under memory pressure, leaves
+    // the file's fate UNKNOWN - which is why `readPidMetadataState` keeps that
+    // apart from ENOENT. Only ENOENT means the host is gone; an inconclusive
+    // read must never buy a restart, least of all under the pressure that
+    // produces it, when the host is most likely alive and merely stalled.
+    writeFileSync(pidFile, '{"pid": 4242, "hostId": "host-1"', "utf8");
+    // Sharpest possible stub: anything that reaches the process probe answers
+    // "dead", so a regression that falls through instead of short-circuiting
+    // fails here rather than passing by luck.
+    stubProcess("dead", null);
+
+    await expect(readPublishedHostProcessLiveness(pidFile)).resolves.toBe(
+      "alive",
+    );
+  });
+
+  it("reports dead when no pid metadata is published", async () => {
+    // A deliberate stop unlinks pid.json, and a host that has not bound yet
+    // never published one. Either way there is no process for this gate to
+    // protect - the monitor's own metadata check decides what happens next.
+    stubProcess("alive", Date.parse(PUBLISHED_AT));
+
+    await expect(readPublishedHostProcessLiveness(pidFile)).resolves.toBe(
+      "dead",
+    );
+  });
+});

--- a/clients/desktop/src/electron-main/host/__tests__/host-recovery-governor.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-recovery-governor.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("electron", () => ({
+  app: { isPackaged: false, getAppPath: (): string => "/fake/app/path" },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    transports: { file: { level: "info" }, console: { level: "info" } },
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  BREAKER_MAX_CONSECUTIVE_GRANTS,
+  RESPAWN_BACKOFF_MS,
+  SUSTAINED_HEALTH_MS,
+  createHostRecoveryGovernor,
+  type HostProcessLiveness,
+  type HostRecoveryGovernor,
+} from "../host-recovery-governor";
+
+const DEAD: HostProcessLiveness = "dead";
+
+function makeGovernor(verdict: () => HostProcessLiveness): {
+  governor: HostRecoveryGovernor;
+  advance: (ms: number) => void;
+} {
+  let clock = 1_000_000;
+  const governor = createHostRecoveryGovernor({
+    readLiveness: () => Promise.resolve(verdict()),
+    now: () => clock,
+  });
+  return {
+    governor,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+  };
+}
+
+/** Drives `count` grants, waiting out each backoff. */
+async function drainGrants(
+  governor: HostRecoveryGovernor,
+  advance: (ms: number) => void,
+  count: number,
+): Promise<number> {
+  let granted = 0;
+  for (let i = 0; i < count; i += 1) {
+    const decision = await governor.requestRespawn("test");
+    if (decision.kind === "granted") granted += 1;
+    advance(RESPAWN_BACKOFF_MS[RESPAWN_BACKOFF_MS.length - 1]);
+  }
+  return granted;
+}
+
+describe("createHostRecoveryGovernor", () => {
+  it("refuses to restart a host whose process exists, however long it stays unreachable", async () => {
+    // THE invariant. An unreachable host may simply be busy, and the whole
+    // incident this module exists for was a watchdog that could not tell the
+    // difference and guessed "dead" every time.
+    const { governor, advance } = makeGovernor(() => "alive");
+
+    for (let i = 0; i < 20; i += 1) {
+      const decision = await governor.requestRespawn("health-monitor");
+      expect(decision).toEqual({ kind: "denied", reason: "alive" });
+      advance(600_000);
+    }
+    // Refusals must not consume budget: the host was never at fault.
+    expect(governor.isTripped).toBe(false);
+  });
+
+  it("never grants while the process exists, even after budget was spent on a dead one", async () => {
+    let verdict: HostProcessLiveness = DEAD;
+    const { governor, advance } = makeGovernor(() => verdict);
+
+    await drainGrants(governor, advance, 2);
+    verdict = "alive";
+
+    const decision = await governor.requestRespawn("test");
+    expect(decision.kind).toBe("denied");
+    expect(decision.kind === "denied" && decision.reason).toBe("alive");
+  });
+
+  it("grants the first recovery immediately, then paces the rest", async () => {
+    const { governor, advance } = makeGovernor(() => DEAD);
+
+    expect((await governor.requestRespawn("first")).kind).toBe("granted");
+
+    const tooSoon = await governor.requestRespawn("second");
+    expect(tooSoon.kind).toBe("denied");
+    expect(tooSoon.kind === "denied" && tooSoon.reason).toBe("backoff");
+
+    advance(RESPAWN_BACKOFF_MS[1]);
+    expect((await governor.requestRespawn("second")).kind).toBe("granted");
+  });
+
+  it("trips after the consecutive-grant limit - the breaker is actually reachable", async () => {
+    // A window-based breaker ("N in M minutes") could never fire once the
+    // backoff spaced grants beyond the window, so the promised "give up and
+    // let the user decide" state never arrived. Counting consecutive grants
+    // composes with any backoff.
+    const { governor, advance } = makeGovernor(() => DEAD);
+
+    const granted = await drainGrants(
+      governor,
+      advance,
+      BREAKER_MAX_CONSECUTIVE_GRANTS,
+    );
+    expect(granted).toBe(BREAKER_MAX_CONSECUTIVE_GRANTS);
+
+    const decision = await governor.requestRespawn("one too many");
+    expect(decision).toEqual({ kind: "denied", reason: "tripped" });
+    expect(governor.isTripped).toBe(true);
+  });
+
+  it("does not forgive the budget for a single healthy observation", async () => {
+    // The exact re-arming bug: each freshly spawned host answered one probe
+    // before stalling again, which reset the counter, so the loop was endless.
+    const { governor, advance } = makeGovernor(() => DEAD);
+
+    for (let i = 0; i < BREAKER_MAX_CONSECUTIVE_GRANTS; i += 1) {
+      expect((await governor.requestRespawn("attempt")).kind).toBe("granted");
+      governor.noteHealthy();
+      governor.noteUnhealthy();
+      advance(RESPAWN_BACKOFF_MS[RESPAWN_BACKOFF_MS.length - 1]);
+    }
+
+    expect((await governor.requestRespawn("attempt")).kind).toBe("denied");
+    expect(governor.isTripped).toBe(true);
+  });
+
+  it("forgives the budget once the host stays healthy for the sustained window", async () => {
+    const { governor, advance } = makeGovernor(() => DEAD);
+    await drainGrants(governor, advance, BREAKER_MAX_CONSECUTIVE_GRANTS);
+    expect((await governor.requestRespawn("trip it")).kind).toBe("denied");
+    expect(governor.isTripped).toBe(true);
+
+    // Continuous reachability across the window: real recovery.
+    governor.noteHealthy();
+    advance(SUSTAINED_HEALTH_MS);
+    governor.noteHealthy();
+
+    expect(governor.isTripped).toBe(false);
+    expect((await governor.requestRespawn("after recovery")).kind).toBe(
+      "granted",
+    );
+  });
+
+  it("restarts the sustained-health clock when reachability breaks", async () => {
+    const { governor, advance } = makeGovernor(() => DEAD);
+    await drainGrants(governor, advance, BREAKER_MAX_CONSECUTIVE_GRANTS);
+
+    // Healthy, but interrupted before the window elapses - a flapping host
+    // must not accumulate credit across its outages.
+    governor.noteHealthy();
+    advance(SUSTAINED_HEALTH_MS / 2);
+    governor.noteUnhealthy();
+    governor.noteHealthy();
+    advance(SUSTAINED_HEALTH_MS / 2);
+    governor.noteHealthy();
+
+    expect((await governor.requestRespawn("still flapping")).kind).toBe(
+      "denied",
+    );
+  });
+
+  it("refunds a grant that never became a restart", async () => {
+    const { governor } = makeGovernor(() => DEAD);
+    expect((await governor.requestRespawn("deferred")).kind).toBe("granted");
+
+    // Another process held the CLI lock: nothing was restarted, so neither the
+    // attempt count nor the backoff should be charged.
+    governor.releaseGrant();
+
+    expect((await governor.requestRespawn("retry")).kind).toBe("granted");
+  });
+});

--- a/clients/desktop/src/electron-main/host/host-health-monitor.ts
+++ b/clients/desktop/src/electron-main/host/host-health-monitor.ts
@@ -6,6 +6,11 @@ import {
   readPidMetadataState,
 } from "./host-lifecycle";
 import { isPublishedHostEndpointReachable } from "./host-endpoint-reachability";
+import { readPublishedHostProcessLiveness } from "./host-process-liveness";
+import type {
+  HostProcessLiveness,
+  HostRecoveryGovernor,
+} from "./host-recovery-governor";
 import type { IpcHostLifecycle } from "../ipc/runner-ipc-bridge";
 import type { DesktopLocalHostSnapshot } from "../../ipc-contracts/host-types";
 
@@ -40,16 +45,63 @@ import type { DesktopLocalHostSnapshot } from "../../ipc-contracts/host-types";
  * While the snapshot is null (host known-down, respawn/provision flows in
  * progress) the monitor idles - recovery ownership stays with those flows
  * and the lifecycle's own reachability retry ladder.
+ *
+ * ### Unreachable is not dead
+ *
+ * The endpoint probe answers "is the main thread serving?", which a host that
+ * is merely BUSY also fails - opening a large epic blocks it for tens of
+ * seconds in one un-yieldable `Y.applyUpdate`. Treating that as death is how
+ * v1.1.8-rc.2 killed healthy hosts in a loop. So before this monitor concludes
+ * anything from a failed probe it asks whether the process still EXISTS, and
+ * an existing process ends the tick: no demote, no respawn, no escalation. The
+ * renderer's own WebSocket retry rides the stall out.
+ *
+ * That check happens BEFORE `reloadSnapshotFromDisk()` on purpose. The reload
+ * demotes the snapshot when the endpoint is unreachable, which flips the
+ * renderer to its unavailable card and hands recovery ownership to other
+ * flows - so checking afterwards would prevent the SIGTERM while still
+ * inflicting the outage it exists to avoid.
+ *
+ * A host that stays unreachable for a very long time is eventually surfaced
+ * anyway (`UNREACHABLE_DEMOTE_MS`) so the user has a Retry button, but it is
+ * still never auto-killed: deciding to restart a process that is running is
+ * the user's call, not this watchdog's.
  */
 
 const HEALTH_POLL_INTERVAL_MS = 15_000;
 // Two consecutive failed probes before acting, so one transiently refused
 // connect (host mid-GC, socket backlog blip) doesn't trigger a restart.
 const CONFIRMED_DOWN_AFTER_FAILURES = 2;
-// A crash-looping host gets a bounded number of automatic restarts; after
-// that the renderer's unavailable card (manual Retry) is the escape hatch.
-// Any successful probe resets the budget.
-const MAX_AUTO_RESPAWNS_WITHOUT_RECOVERY = 3;
+/**
+ * How long the endpoint may stay continuously unreachable - with the process
+ * demonstrably alive - before the renderer is shown the unavailable card so
+ * manual Retry becomes reachable.
+ *
+ * This escalates the UI only. It deliberately does NOT authorize a kill:
+ * "unreachable for a long time" is not "dead", and every automatic restart
+ * still has to get past the governor's liveness gate. A genuinely deadlocked
+ * host is recovered by the user pressing Retry - an explicit decision, rather
+ * than a guess this watchdog makes on their behalf.
+ */
+const UNREACHABLE_DEMOTE_MS = 600_000;
+
+/**
+ * How long to wait before asking again about a host that was already demoted
+ * and is demonstrably ALIVE.
+ *
+ * That state is terminal until something outside this monitor changes it: the
+ * process exits, or the user presses Retry. Asking at tick cadence cannot make
+ * either happen sooner, and each ask is not free - the liveness probe spawns a
+ * child process (`ps` on POSIX, `tasklist` plus `powershell` on Windows), so a
+ * wedge lasting an afternoon would spawn thousands of them for an answer that
+ * cannot change. Only the `alive` denial waits: a lock-deferred or failed
+ * respawn still retries on the very next tick, because those outcomes CAN
+ * change on their own.
+ *
+ * The cost of the wait is bounded and small - a host that dies while wedged is
+ * picked up within this window rather than within one tick.
+ */
+const ALIVE_RECHECK_INTERVAL_MS = 120_000;
 
 export interface HostHealthMonitorDeps {
   readonly host: IpcHostLifecycle;
@@ -66,6 +118,19 @@ export interface HostHealthMonitorDeps {
    * can stand up itself.
    */
   readonly respawn: () => Promise<void>;
+  /**
+   * The single authority for automatic respawns: owns the busy gate and the
+   * attempt budget. This monitor asks; it does not decide.
+   */
+  readonly governor: HostRecoveryGovernor;
+  /**
+   * Does the published host process still exist? Test seam; production callers
+   * pass undefined. Used here only to decide what the USER should see (busy vs
+   * unavailable) - the kill decision is the governor's, which checks again
+   * itself.
+   */
+  readonly readLiveness:
+    ((pidMetadataFile: string) => Promise<HostProcessLiveness>) | undefined;
 }
 
 export interface HostHealthMonitor {
@@ -108,11 +173,23 @@ export function startHostHealthMonitor(
       : null;
   };
   const respawn = deps.respawn;
+  const governor = deps.governor;
+  const readLiveness = deps.readLiveness ?? readPublishedHostProcessLiveness;
   let consecutiveFailures = 0;
-  let respawnsSinceRecovery = 0;
   let recoveryPending = false;
   let ticking = false;
   let disposed = false;
+  // Rate-limits the "busy" log to once per stall rather than once per tick, so
+  // a long epic open leaves one line instead of dozens.
+  let busyLogged = false;
+  // When the endpoint first became unreachable in the CURRENT outage. Reset by
+  // any reachable observation, so only a continuously unreachable host reaches
+  // the demote window.
+  let unreachableSince: number | null = null;
+  // Earliest tick that may ask the governor again after an `alive` denial. See
+  // ALIVE_RECHECK_INTERVAL_MS: this throttles the ONE path that would otherwise
+  // re-probe a demoted-but-living host forever.
+  let nextRecoveryAttemptAt = 0;
 
   const isDisposed = (): boolean => disposed || deps.host.isDisposed;
 
@@ -124,7 +201,6 @@ export function startHostHealthMonitor(
       return false;
     }
     recoveryPending = false;
-    respawnsSinceRecovery = 0;
     log.info(
       "[host-health] recovery converged onto a reachable host snapshot",
       { pid: surfaced.pid },
@@ -135,25 +211,89 @@ export function startHostHealthMonitor(
   const attemptRecovery = async (
     metadata: DesktopLocalHostSnapshot,
   ): Promise<void> => {
-    if (respawnsSinceRecovery >= MAX_AUTO_RESPAWNS_WITHOUT_RECOVERY) {
+    // The governor owns both the liveness gate and the budget; it re-reads
+    // pid.json itself so this is a real decision point, not a formality.
+    const decision = await governor.requestRespawn("health-monitor");
+    if (isDisposed()) return;
+    if (decision.kind === "denied") {
+      if (decision.reason === "alive") {
+        log.info(
+          "[host-health] endpoint unresponsive but the host process exists - not respawning",
+          { pid: metadata.pid },
+        );
+        // Stay in recovery ownership: the stall will end, and a later tick's
+        // reload converges the snapshot back onto the live host. Nothing this
+        // monitor does can shorten the wait, so stop asking at tick cadence -
+        // the answer is the user's to change.
+        recoveryPending = true;
+        nextRecoveryAttemptAt = Date.now() + ALIVE_RECHECK_INTERVAL_MS;
+        return;
+      }
+      if (decision.reason === "backoff") {
+        log.info("[host-health] respawn deferred by backoff", {
+          pid: metadata.pid,
+          retryInMs: decision.retryInMs,
+        });
+        recoveryPending = true;
+        return;
+      }
       log.warn(
         "[host-health] endpoint down but auto-respawn budget exhausted - leaving recovery to the renderer",
         { pid: metadata.pid },
       );
       return;
     }
-    respawnsSinceRecovery += 1;
     // The prior reload demoted the lifecycle snapshot. Retain ownership
     // through this attempt (including a generic failure) until a subsequent
     // reload proves that a host is actually published again.
     recoveryPending = true;
     log.warn(
       "[host-health] endpoint down with live pid metadata - auto-respawning",
-      { pid: metadata.pid, attempt: respawnsSinceRecovery },
+      { pid: metadata.pid },
     );
     await respawn();
     if (isDisposed()) return;
     await reloadRecoverySnapshot();
+  };
+
+  /**
+   * Decides what an unreachable endpoint MEANS, before anything is demoted or
+   * restarted. Returns true when the tick should stop here because the host
+   * process is alive and merely unresponsive.
+   */
+  const isBusyRatherThanDown = async (
+    snapshot: DesktopLocalHostSnapshot,
+    now: number,
+  ): Promise<boolean> => {
+    const liveness = await readLiveness(deps.host.pidMetadataFile);
+    if (isDisposed()) return false;
+    if (liveness === "dead") {
+      // The process is gone - or its pid was recycled onto something else -
+      // so fall through to the existing dead-host handling.
+      busyLogged = false;
+      return false;
+    }
+    const unreachableForMs =
+      unreachableSince === null ? 0 : now - unreachableSince;
+    if (unreachableForMs >= UNREACHABLE_DEMOTE_MS) {
+      // Alive, but nothing has answered for a very long time. Let the demote
+      // proceed so the renderer offers Retry - and still refuse to kill it
+      // here: restarting a running process is the user's call.
+      log.warn(
+        "[host-health] host process alive but unreachable for a long time - surfacing manual recovery",
+        { pid: snapshot.pid, unreachableForMs },
+      );
+      busyLogged = false;
+      return false;
+    }
+    if (!busyLogged) {
+      busyLogged = true;
+      log.info(
+        "[host-health] endpoint unresponsive but the host process exists - busy, holding the snapshot",
+        { pid: snapshot.pid },
+      );
+    }
+    return true;
   };
 
   const tick = async (): Promise<void> => {
@@ -170,8 +310,13 @@ export function startHostHealthMonitor(
         // is never retried.
         if (!recoveryPending) {
           consecutiveFailures = 0;
+          unreachableSince = null;
           return;
         }
+        // Throttled only after an `alive` denial (see
+        // ALIVE_RECHECK_INTERVAL_MS). Lock-deferred and failed respawns leave
+        // this at 0 and so still retry on the next tick.
+        if (Date.now() < nextRecoveryAttemptAt) return;
         const metadata = await readMetadata(deps.host.pidMetadataFile);
         if (isDisposed()) return;
         if (metadata === null) {
@@ -193,16 +338,43 @@ export function startHostHealthMonitor(
         ))
       ) {
         consecutiveFailures = 0;
-        respawnsSinceRecovery = 0;
+        busyLogged = false;
+        unreachableSince = null;
+        // A reachable host is new information, so the next outage is judged
+        // immediately rather than serving out a throttle earned by the last one.
+        nextRecoveryAttemptAt = 0;
+        governor.noteHealthy();
         return;
       }
       // Re-check after every await: dispose() landing during a slow probe
       // or metadata read (app quit) must not let this in-flight tick spawn
       // a host the app is tearing down.
       if (isDisposed()) return;
+      governor.noteUnhealthy();
+      const now = Date.now();
+      if (unreachableSince === null) unreachableSince = now;
       consecutiveFailures += 1;
       if (consecutiveFailures < CONFIRMED_DOWN_AFTER_FAILURES) return;
       consecutiveFailures = 0;
+
+      // Is it dead, or just blocked? Asked BEFORE the reload below, because
+      // that reload demotes the snapshot and a busy host must not cost the
+      // user their session for the duration of an epic open.
+      //
+      // Only when pid.json still names THIS host. The liveness answer is about
+      // whatever pid.json currently holds, so when disk names a DIFFERENT host
+      // - a supervisor respawned it on a new port and the watcher edge was
+      // coalesced away, the case the reload below exists for - "alive" is about
+      // the replacement, not about the snapshot's process. Treating that as
+      // busy would pin the renderer to a dead endpoint for the whole
+      // unreachable-demote window instead of converging on the next tick.
+      const publishedIsThisHost =
+        published !== null &&
+        isCurrentPublishedSnapshot(snapshot, published.snapshot);
+      if (publishedIsThisHost && (await isBusyRatherThanDown(snapshot, now))) {
+        return;
+      }
+      if (isDisposed()) return;
 
       // Reload FIRST, then decide. The advertised endpoint is dead, but the
       // disk may already name a healthy replacement (launchd/systemd respawned
@@ -215,7 +387,12 @@ export function startHostHealthMonitor(
           "[host-health] stale snapshot converged onto a reachable host - no respawn needed",
           { pid: surfaced.pid },
         );
-        respawnsSinceRecovery = 0;
+        unreachableSince = null;
+        // One reachable observation starts the sustained-health clock; it does
+        // not by itself forgive the attempt budget. A freshly spawned host
+        // answers exactly one probe before stalling again, and treating that as
+        // recovery is what let the original loop re-arm itself forever.
+        governor.noteHealthy();
         return;
       }
 
@@ -235,7 +412,10 @@ export function startHostHealthMonitor(
       await attemptRecovery(metadata);
     } catch (err) {
       if (err instanceof HostRecoveryDeferredError) {
-        respawnsSinceRecovery = Math.max(0, respawnsSinceRecovery - 1);
+        // Another Traycer process held the lock, so the host was never
+        // touched: hand the grant back rather than spending budget on a
+        // restart that did not happen.
+        governor.releaseGrant();
         recoveryPending = true;
         return;
       }

--- a/clients/desktop/src/electron-main/host/host-process-liveness.ts
+++ b/clients/desktop/src/electron-main/host/host-process-liveness.ts
@@ -1,0 +1,65 @@
+import { readPidMetadataState } from "./host-lifecycle";
+import { getPublishedProcessIdentityVerdict } from "./process-identity";
+import type { HostProcessLiveness } from "./host-recovery-governor";
+
+/**
+ * "Does the host process still exist?" - the one question the desktop's
+ * automatic recovery is entitled to act on.
+ *
+ * ### Why existence, and not responsiveness
+ *
+ * An unreachable endpoint proves only that the host's main thread isn't
+ * serving. It cannot distinguish a dead process from one blocked for tens of
+ * seconds inside a single un-yieldable `Y.applyUpdate` on a large epic - and
+ * v1.1.8-rc.2 resolved that ambiguity by SIGTERM-ing healthy hosts in a loop.
+ *
+ * The fix is not a finer-grained progress signal but a narrower question.
+ * Under the settled policy an existing process is never auto-killed, whatever
+ * it is doing, so busy / wedged / deadlocked all take the same path (manual
+ * Retry). Existence is therefore the only input any automated decision needs.
+ *
+ * ### Evidence
+ *
+ * `pid.json` is written on bind and removed on graceful shutdown, and carries
+ * `startedAt`. `getPublishedProcessIdentityVerdict` combines a cross-platform
+ * liveness probe (`kill(pid, 0)` on POSIX, `tasklist` on Windows) with a
+ * start-time comparison against that timestamp - so a recycled pid now owned
+ * by an unrelated process is positively identified rather than mistaken for a
+ * living host. That helper is shared with the CLI's `cli-lock` hardening by
+ * explicit design, which is why this reuses it instead of calling
+ * `process.kill(pid, 0)` directly.
+ */
+export async function readPublishedHostProcessLiveness(
+  pidMetadataFile: string,
+): Promise<HostProcessLiveness> {
+  const state = await readPidMetadataState(pidMetadataFile);
+  // ENOENT - and ONLY ENOENT - means no process this gate could be protecting:
+  // a deliberate stop already unlinked pid.json, and a host that has not bound
+  // yet is invisible either way. The monitor's own metadata check decides
+  // whether a respawn is even appropriate; here it simply removes the shield.
+  if (state.kind === "absent") return "dead";
+  // Every other read failure (a partial write, EACCES/EIO/EMFILE) leaves the
+  // file's fate UNKNOWN - which is why `readPidMetadataState` keeps the two
+  // apart. An inconclusive read must never become permission to restart, for
+  // the same reason an inconclusive process probe must not: the transient
+  // failures that produce it cluster under exactly the memory pressure a
+  // stalled host is already under, so "I couldn't read it" would authorise
+  // killing the host precisely when it is most likely to be alive and working.
+  if (state.kind !== "parsed") return "alive";
+
+  const verdict = await getPublishedProcessIdentityVerdict(
+    state.snapshot.pid,
+    state.startedAt,
+  );
+  // `mismatch` is a positively identified recycled pid - the process running
+  // under that number started AFTER pid.json was published, so it cannot be
+  // the host. Treat it as dead so recovery is not blocked forever by an
+  // unrelated process.
+  if (verdict === "dead" || verdict === "mismatch") return "dead";
+  // `current` is alive with identity confirmed. `indeterminate` means the
+  // probe could not conclude (no start-time source, a refused `tasklist`), and
+  // resolves to alive on purpose: guessing "dead" here kills a host that may
+  // be working, while guessing "alive" costs at most a wait for the
+  // unreachable-demote window and a manual Retry.
+  return "alive";
+}

--- a/clients/desktop/src/electron-main/host/host-recovery-governor.ts
+++ b/clients/desktop/src/electron-main/host/host-recovery-governor.ts
@@ -1,0 +1,217 @@
+import { log } from "../app/logger";
+
+/**
+ * The single authority for AUTOMATIC host respawns.
+ *
+ * ### Why this owns the liveness check
+ *
+ * The obvious place for "don't kill a host that is merely busy" is the health
+ * monitor's tick, since that is where the decision is felt. That placement is
+ * wrong: it protects one caller. Any other path to an automatic restart - the
+ * controller's own recovery re-drive today, whatever is added tomorrow -
+ * bypasses a check that lives in the monitor, and the host dies anyway. So the
+ * gate lives HERE, in the function every automatic restart must call, and the
+ * invariant is structural rather than remembered:
+ *
+ *   **No automatic respawn is granted while the host process exists.**
+ *
+ * Process EXISTENCE is the whole question, and deliberately so. An unreachable
+ * endpoint tells us the main thread isn't serving; it cannot tell us whether
+ * that is death or a 20-second `Y.applyUpdate` on a large epic - and under this
+ * policy it doesn't need to, because busy, wedged and deadlocked all get the
+ * same treatment: never auto-killed, manual Retry as the escape. A finer signal
+ * (how much progress the event loop is making) would change no decision here,
+ * so the desktop asks the only question whose answer it acts on.
+ *
+ * Deliberate user intent (Settings → Restart Host, the unavailable card's
+ * Retry) does NOT come through here. That path is `HostController.respawn()`
+ * and it is allowed to kill a busy or wedged host - it is the documented
+ * escape hatch, and a user who asks for a restart has decided. It needs no
+ * explicit "reset the breaker" hook either: a manual retry that works produces
+ * a reachable host, and sustained reachability clears the budget on its own.
+ * One that does NOT work leaves the breaker tripped, which is correct.
+ *
+ * ### Why the breaker counts consecutive grants, not grants per window
+ *
+ * A window-based breaker ("N restarts in M minutes") cannot fire once restarts
+ * are spaced by a backoff: with 0s/60s/5m spacing, a 10-minute window holds at
+ * most three grants, so a "5 in 10 minutes" rule is unreachable and the
+ * promised "give up and show Retry" state never arrives - the host just
+ * restarts forever, more slowly. Counting CONSECUTIVE grants that were never
+ * interrupted by a sustained-health reset composes correctly with any backoff
+ * schedule.
+ */
+
+/** Consecutive grants, with no intervening recovery, before giving up. */
+export const BREAKER_MAX_CONSECUTIVE_GRANTS = 5;
+
+/**
+ * Minimum spacing between grants, indexed by how many have already been made.
+ * The first recovery is immediate (the common case is a genuinely dead host);
+ * repeats slow down fast. The last entry repeats for further attempts.
+ */
+export const RESPAWN_BACKOFF_MS: readonly number[] = [0, 60_000, 300_000];
+
+/**
+ * How long the host must stay continuously reachable before the attempt
+ * counter is forgiven. A single successful probe deliberately does NOT reset
+ * anything: that was the bug that made the original loop infinite, because
+ * every freshly spawned host answers exactly one probe before stalling again,
+ * re-arming the budget forever.
+ */
+export const SUSTAINED_HEALTH_MS = 300_000;
+
+/**
+ * Whether the published host process still exists.
+ *
+ * `dead` covers both "no such process" and a positively identified recycled
+ * pid; anything else - including a probe that could not reach a conclusion - is
+ * `alive`, because the cost of guessing wrong in that direction is killing a
+ * working host, while the cost in the other is a wait for manual Retry.
+ */
+export type HostProcessLiveness = "alive" | "dead";
+
+export type RespawnDecision =
+  | { readonly kind: "granted" }
+  | {
+      /** The process exists. Never restart it automatically. */
+      readonly kind: "denied";
+      readonly reason: "alive";
+    }
+  | {
+      /** Too soon after the last grant. */
+      readonly kind: "denied";
+      readonly reason: "backoff";
+      readonly retryInMs: number;
+    }
+  | {
+      /** Budget exhausted - recovery now belongs to the user. */
+      readonly kind: "denied";
+      readonly reason: "tripped";
+    };
+
+export interface HostRecoveryGovernorDeps {
+  /**
+   * Does the host process published in `pid.json` still exist? An ABSENT
+   * pid.json resolves to `dead` - there is no process to protect, and a host
+   * that has not yet bound is invisible here either way. An UNREADABLE one
+   * resolves to `alive`: "I couldn't find out" is not evidence of death, and
+   * must not buy a restart.
+   */
+  readonly readLiveness: () => Promise<HostProcessLiveness>;
+  /** Test seam. */
+  readonly now: (() => number) | undefined;
+}
+
+export interface HostRecoveryGovernor {
+  requestRespawn(reason: string): Promise<RespawnDecision>;
+  /** Call on every observation that the host is reachable. */
+  noteHealthy(): void;
+  /** Call on every observation that it is not. */
+  noteUnhealthy(): void;
+  /**
+   * Return a grant that never turned into a restart (e.g. another process held
+   * the CLI lock), so a deferral doesn't consume budget.
+   */
+  releaseGrant(): void;
+  readonly isTripped: boolean;
+}
+
+export function createHostRecoveryGovernor(
+  deps: HostRecoveryGovernorDeps,
+): HostRecoveryGovernor {
+  const now = deps.now ?? (() => Date.now());
+  let consecutiveGrants = 0;
+  let lastGrantAt: number | null = null;
+  let healthySince: number | null = null;
+  let tripped = false;
+
+  const reset = (): void => {
+    consecutiveGrants = 0;
+    lastGrantAt = null;
+    tripped = false;
+  };
+
+  const backoffForNextGrant = (): number => {
+    const index = Math.min(consecutiveGrants, RESPAWN_BACKOFF_MS.length - 1);
+    return RESPAWN_BACKOFF_MS[index];
+  };
+
+  return {
+    get isTripped(): boolean {
+      return tripped;
+    },
+
+    noteHealthy: (): void => {
+      const at = now();
+      if (healthySince === null) {
+        healthySince = at;
+        return;
+      }
+      if (at - healthySince < SUSTAINED_HEALTH_MS) return;
+      // Sustained recovery: this host has proven itself, so previous attempts
+      // no longer count against it.
+      if (consecutiveGrants > 0 || tripped) {
+        log.info(
+          "[host-recovery] host healthy for the sustained window - clearing respawn budget",
+          { consecutiveGrants, wasTripped: tripped },
+        );
+      }
+      reset();
+    },
+
+    noteUnhealthy: (): void => {
+      healthySince = null;
+    },
+
+    requestRespawn: async (reason: string): Promise<RespawnDecision> => {
+      if (tripped) return { kind: "denied", reason: "tripped" };
+
+      // THE invariant. Checked before the budget so an unreachable-but-alive
+      // host never spends any of it, and checked here rather than in the caller
+      // so every present and future automatic path inherits the protection.
+      if ((await deps.readLiveness()) === "alive") {
+        return { kind: "denied", reason: "alive" };
+      }
+
+      if (consecutiveGrants >= BREAKER_MAX_CONSECUTIVE_GRANTS) {
+        tripped = true;
+        log.warn(
+          "[host-recovery] automatic respawns exhausted - handing recovery to the user",
+          { reason, consecutiveGrants },
+        );
+        return { kind: "denied", reason: "tripped" };
+      }
+
+      const at = now();
+      const backoffMs = backoffForNextGrant();
+      if (lastGrantAt !== null && at - lastGrantAt < backoffMs) {
+        return {
+          kind: "denied",
+          reason: "backoff",
+          retryInMs: backoffMs - (at - lastGrantAt),
+        };
+      }
+
+      consecutiveGrants += 1;
+      lastGrantAt = at;
+      healthySince = null;
+      log.warn("[host-recovery] granting automatic respawn", {
+        reason,
+        attempt: consecutiveGrants,
+        limit: BREAKER_MAX_CONSECUTIVE_GRANTS,
+      });
+      return { kind: "granted" };
+    },
+
+    releaseGrant: (): void => {
+      // Clearing the clock alongside the count looks like it erases pacing an
+      // earlier grant earned, but it cannot: the released grant only happened
+      // because it already cleared the SAME backoff window (index
+      // `consecutiveGrants - 1`) that the refunded state re-checks, so the next
+      // request passes either way. Refund both and keep one source of truth.
+      consecutiveGrants = Math.max(0, consecutiveGrants - 1);
+      lastGrantAt = null;
+    },
+  };
+}

--- a/clients/desktop/src/electron-main/startup/desktop-startup.ts
+++ b/clients/desktop/src/electron-main/startup/desktop-startup.ts
@@ -27,6 +27,8 @@ import {
   HostController,
 } from "../host/host-controller";
 import { getHostFsLayout, labelForEnvironment } from "../host/host-paths";
+import { readPublishedHostProcessLiveness } from "../host/host-process-liveness";
+import { createHostRecoveryGovernor } from "../host/host-recovery-governor";
 import {
   refreshRegistryUpdateState,
   setActiveEnvironment,
@@ -694,12 +696,23 @@ function runDeferredBackground(state: BootState, services: AppServices): void {
   // disk still names an unreachable host. Started after bootstrap so the
   // initial 60s readiness wait can't register as an outage.
   void hostReady.then(() => {
+    // One authority for automatic restarts, holding both the liveness gate and
+    // the attempt budget. It re-reads pid.json itself inside `requestRespawn`
+    // so the "never kill a live host" rule can't be bypassed by adding another
+    // caller later.
+    const recoveryGovernor = createHostRecoveryGovernor({
+      now: undefined,
+      readLiveness: () =>
+        readPublishedHostProcessLiveness(services.host.pidMetadataFile),
+    });
     const healthMonitor = startHostHealthMonitor({
       host: services.host,
       intervalMs: undefined,
       probe: undefined,
       readMetadata: undefined,
       respawn: () => respawnIfDown(services.hostController),
+      governor: recoveryGovernor,
+      readLiveness: undefined,
     });
     state.bridge?.disposeFns.push(() => healthMonitor.dispose());
   });


### PR DESCRIPTION
## Summary

The desktop watchdog probed the host with a bare TCP connect and treated a failed probe as death. A host is also unreachable while it is merely **busy** — opening a large epic blocks its main thread for tens of seconds inside one un-yieldable `Y.applyUpdate` — so on v1.1.8-rc.2 the watchdog SIGTERM-ed healthy hosts, the fresh host answered exactly one probe, that re-armed the retry budget, and the loop had no end (~26 kills in 40 minutes on a 379-artifact / 87 MB epic).

An unreachable endpoint proves neither death nor life. This replaces that inference with the only question automatic recovery is entitled to act on: **does the process still exist?**

- **`host-process-liveness.ts`** answers it from the published `pid.json`, mapping `getPublishedProcessIdentityVerdict` onto alive/dead. That helper is shared with the CLI's `cli-lock` by explicit design and already carries the start-time comparison that identifies a recycled pid, so this reuses it rather than calling `process.kill(pid, 0)`. Only an **ENOENT** `pid.json` reads as dead; an unreadable one (partial write, EACCES/EMFILE) is inconclusive and must never buy a restart.

- **`host-recovery-governor.ts`** is the single authority every automatic respawn routes through, so the invariant is structural rather than remembered: *no grant while the process exists*. It also holds the attempt budget — a breaker counting **consecutive** grants, because a per-window breaker is unreachable once grants are spaced by a backoff (0s/60s/5m gives at most three grants in ten minutes, so "5 in 10 minutes" never fires). A single successful probe deliberately does not forgive it; only five minutes of sustained reachability does. That single-probe reset is precisely what made the original loop infinite.

- **The monitor asks before it demotes, not after.** A demote flips the renderer to its unavailable card, so a check that only prevents the SIGTERM still inflicts the outage it exists to avoid. A host unreachable for ten minutes is surfaced for manual Retry — and still never auto-killed, because restarting a running process is the user's call.

Deliberate user intent (`HostController.respawn()`, Settings → Restart Host, the unavailable card's Retry) does not come through the governor and is still allowed to restart a wedged host.

## Review fixes folded in

- The busy gate is consulted **only when `pid.json` still names the snapshot's host**. Otherwise "alive" describes a supervisor-respawned *replacement* while the renderer is pointed at the dead predecessor — and reading that as "busy" would pin it there for the whole demote window instead of converging on the next tick, which is the monitor's primary documented duty.
- After a demote with a living process, the liveness probe is throttled to once every two minutes. That state is terminal until the process exits or the user retries, and each ask spawns a child process (`ps`, or `tasklist` + `powershell` on Windows).

## Known residual

On Windows, a box where `tasklist` cannot run yields `indeterminate` → `alive`, so auto-respawn never fires there — on the platform where it matters most, since the Scheduled Task cannot restart-on-failure. Bounded by the ten-minute demote to manual Retry. Called out for a deliberate decision rather than fixed silently.

## Verification

- `bun run --filter @traycer-clients/desktop compile`
- `bun run --filter @traycer-clients/desktop test` — 962 passed, 80 files
- `bun run --filter @traycer-clients/desktop lint`, `prettier --check` on all changed files
- Cold review in a fresh agent that did not write the code; both blocking findings fixed here.
- Mutation probes: removing the pid-scoping, the sustained-health reset, or the recheck throttle each fails the test that names it (240 probes vs 4), confirming the new tests are load-bearing rather than descriptive.