### PR TITLE
fix(desktop): keep an unreadable manifest directory distinct from absent

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/host-login-item.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/host-login-item.test.ts
@@ -771,6 +771,31 @@ describe("retireCompetingCliRegistrationAtLaunch", () => {
     },
   );
 
+  // An unreadable LaunchAgents directory must not read as "already clean".
+  // `0o600` drops the directory's SEARCH (execute) bit, which is the one that
+  // makes `access` on a known filename fail with EACCES; a directory that is
+  // merely unlistable (`0o300`) still resolves names inside it just fine. That
+  // EACCES-vs-ENOENT split is the whole distinction under test. Skipped as
+  // root for the same reason as the test above.
+  it.skipIf(process.getuid?.() === 0)(
+    "does not report an unreadable LaunchAgents directory as nothing-to-retire",
+    async () => {
+      getLoginItemSettings.mockReturnValue({ status: "enabled" });
+      writeLegacyCliManifest();
+      const agentsDir = join(workHome, "Library", "LaunchAgents");
+      chmodSync(agentsDir, 0o600);
+      try {
+        await expect(retireCompetingCliRegistrationAtLaunch()).resolves.toBe(
+          "retire-failed",
+        );
+      } finally {
+        chmodSync(agentsDir, 0o755);
+      }
+      // Untouched: we never attempt an `rm` on a path we could not read.
+      expect(existsSync(legacyCliManifestPath())).toBe(true);
+    },
+  );
+
   // The doc comment sells serialization through the registration lock as a
   // safety property; pin it. A repair must not interleave with a register
   // cycle's own CLI-label cleanup.

--- a/clients/desktop/src/electron-main/app/host-login-item.ts
+++ b/clients/desktop/src/electron-main/app/host-login-item.ts
@@ -367,6 +367,38 @@ async function retireLegacyLabelRegistrations(): Promise<void> {
   });
 }
 
+// Whether the competing CLI manifest is there. Mirrors `ManifestProbe` in the
+// CLI's `service/platforms/macos.ts`, and for the same reason: "we could not
+// read the directory" has to stay distinct from "there is no manifest".
+//
+// Deliberately local rather than folded into `fileExists` - that helper's
+// other callers WANT the swallow. `hasPendingLoginItemRevision` documents a
+// read error as "no pending revision" so an FS hiccup never blocks the ensure
+// fast path, and `hostManagesHostLoginItem` fails safe to "not a host-managed
+// build". Only the retire path treats absent as proof of a clean machine.
+type CliManifestProbe =
+  | { readonly kind: "present" }
+  | { readonly kind: "absent" }
+  | { readonly kind: "unreadable"; readonly cause: unknown };
+
+async function probeCliLabelManifest(
+  manifest: string,
+): Promise<CliManifestProbe> {
+  try {
+    await access(manifest, constants.F_OK);
+    return { kind: "present" };
+  } catch (cause) {
+    // ENOENT - and only ENOENT - is positive proof there is no manifest.
+    // EACCES on the containing directory means we could not look.
+    const missing =
+      typeof cause === "object" &&
+      cause !== null &&
+      "code" in cause &&
+      cause.code === "ENOENT";
+    return missing ? { kind: "absent" } : { kind: "unreadable", cause };
+  }
+}
+
 /**
  * Delete `~/Library/LaunchAgents/<cli-label>.plist` - the manifest that would
  * `RunAtLoad` a second host beside the agent-label one.
@@ -381,7 +413,22 @@ async function removeCliLabelManifest(): Promise<
   "removed" | "absent" | "failed"
 > {
   const manifest = userLaunchAgentPlistPath(CLI_HOST_LABEL);
-  if (!(await fileExists(manifest))) return "absent";
+  const probe = await probeCliLabelManifest(manifest);
+  if (probe.kind === "absent") return "absent";
+  if (probe.kind === "unreadable") {
+    // NOT `absent`: that is the value the launch repair turns into
+    // `nothing-to-retire` ("this machine is already clean"), and an
+    // unreadable `~/Library/LaunchAgents` proves no such thing. No `rm`
+    // attempt either - `rm(force)` cannot tell "removed" from "was never
+    // there", so on a path we could not even read it would report a removal
+    // that may not have happened. Hedged wording for the same reason: we
+    // cannot see whether a manifest is there at all.
+    log.warn(
+      "[host-login-item] could not read the CLI LaunchAgent manifest, so it was not removed — if one is present it may auto-start a competing host at next login",
+      { manifest, err: probe.cause },
+    );
+    return "failed";
+  }
   try {
     await rm(manifest, { force: true });
   } catch (err) {
@@ -405,9 +452,13 @@ async function removeCliLabelManifest(): Promise<
  *   - `agent-not-enabled` - SMAppService is not reporting `enabled`, so we
  *     have no proof a host would still start at login without the CLI
  *     registration. Deliberately does nothing (see the doc below).
- *   - `nothing-to-retire` - no competing manifest on disk. Steady state.
- *   - `retired` / `retire-failed` - a competing manifest was found, and the
- *     removal did or did not succeed.
+ *   - `nothing-to-retire` - positively no competing manifest on disk. Steady
+ *     state, and never inferred from a directory we could not read.
+ *   - `retired` - a competing manifest was found and removed.
+ *   - `retire-failed` - the manifest was not removed: either the removal
+ *     itself failed, or `~/Library/LaunchAgents` was unreadable so we could
+ *     not tell whether one is there. Both leave the relapse possible, which
+ *     is what this value means.
  */
 export type LaunchCompetingRegistrationRepair =
   | "not-applicable"


### PR DESCRIPTION
Follow-up to #660, completing the symmetry it left behind.

## Why

#660 fixed this on the CLI side in two places: a manifest probe and an ownership probe that both answered "we couldn't determine that" with "assume the machine is fine." The desktop repair had the same flaw and #660 left it, deliberately, as a noted residual. This closes it.

The desktop launch repair turns `absent` into `nothing-to-retire` — which means **"this machine is already clean"**. But its local `fileExists` is `access(...).then(() => true, () => false)`, swallowing *every* error. So an unreadable `~/Library/LaunchAgents` reported a machine that may still start a second host at every login as needing no repair, and said so only at debug level.

## What

Only `ENOENT` now proves absence. Anything else is `unreadable` and reports `retire-failed` with a warning.

| Probe result | Before | After |
|---|---|---|
| file present | `present` | `present` |
| `ENOENT` | `absent` → `nothing-to-retire` | unchanged |
| `EACCES` / other | **`absent` → `nothing-to-retire`** | `unreadable` → `retire-failed` + warn |

No `rm` attempt on a path we could not read — `rm(force)` cannot distinguish "removed" from "was never there", so it would report a durable half that may not have happened. The warning is hedged for the same reason: through an unreadable directory we cannot tell a present manifest from an absent one, so it names the risk without asserting the relapse.

## Scope: why not just fix `fileExists`

Its other two callers *want* the swallow, so changing it would be wrong for both:

- `hasPendingLoginItemRevision` **documents** a read error as "no pending revision" so a transient FS hiccup never blocks the ensure fast path.
- `hostManagesHostLoginItem` fails safe to "not a host-managed build".

Neither treats absence as proof of anything. Only the retire path does, so only the retire path needed the distinction — the same asymmetry as the CLI side, where the agent probe still deliberately collapses to "do nothing" while the other two do not.

## Testing

New test pins that an unreadable directory does not report `nothing-to-retire`, and that the manifest is left untouched. **Mutation-probed**: folding `unreadable` back into `absent` fails exactly this test.

Note the directory mode is `0o600`, not `0o500`/`0o300` — dropping the *search* (execute) bit is what makes `access` on a known filename fail with `EACCES`. A merely unlistable directory still resolves names inside it, which is precisely why the first draft of this test passed against the unfixed code.

Desktop suite: 972 passing. Both workspaces compile.