### PR TITLE
fix(host): make large host archive downloads resumable

### DIFF
--- a/clients/desktop/src/electron-main/cli/__tests__/traycer-cli-envelope.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/traycer-cli-envelope.test.ts
@@ -626,7 +626,7 @@ describe("streamTraycerCliJson reports an external kill by its signal", () => {
       args: ["host", "install", "--release", "1.1.8-rc.2"],
       onEvent: () => undefined,
       env: null,
-      timeoutMs: 5_000,
+      idleTimeoutMs: 5_000,
       signal: null,
     });
     await vi.waitFor(() => {

--- a/clients/desktop/src/electron-main/cli/__tests__/traycer-cli-envelope.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/traycer-cli-envelope.test.ts
@@ -432,7 +432,7 @@ describe("streamTraycerCliJson resolves data, fans progress, and converts error 
       args: ["host", "download", "--automatic"],
       onEvent: () => undefined,
       env: null,
-      timeoutMs: 5_000,
+      idleTimeoutMs: 5_000,
       signal: null,
     });
 
@@ -484,7 +484,7 @@ describe("streamTraycerCliJson resolves data, fans progress, and converts error 
         }
       },
       env: null,
-      timeoutMs: 5_000,
+      idleTimeoutMs: 5_000,
       signal: null,
     });
     expect(capturedArgs).toContain("--json");
@@ -520,7 +520,7 @@ describe("streamTraycerCliJson resolves data, fans progress, and converts error 
         args: ["host", "install", "latest", "--json"],
         onEvent: () => undefined,
         env: null,
-        timeoutMs: 5_000,
+        idleTimeoutMs: 5_000,
         signal: null,
       });
     } catch (err) {
@@ -551,7 +551,7 @@ describe("streamTraycerCliJson kills the subprocess when its signal aborts", () 
       args: ["host", "download", "--automatic"],
       onEvent: () => undefined,
       env: null,
-      timeoutMs: 5_000,
+      idleTimeoutMs: 5_000,
       signal: abortController.signal,
     });
 
@@ -598,7 +598,7 @@ describe("streamTraycerCliJson kills the subprocess when its signal aborts", () 
       args: ["host", "download", "--automatic"],
       onEvent: () => undefined,
       env: null,
-      timeoutMs: 5_000,
+      idleTimeoutMs: 5_000,
       signal: abortController.signal,
     });
     await vi.waitFor(() => {
@@ -653,7 +653,7 @@ describe("streamTraycerCliJson timeout waits for the child close", () => {
         args: ["host", "download", "--automatic"],
         onEvent: () => undefined,
         env: null,
-        timeoutMs: 5_000,
+        idleTimeoutMs: 5_000,
         signal: null,
       });
 
@@ -673,8 +673,61 @@ describe("streamTraycerCliJson timeout waits for the child close", () => {
       await Promise.resolve();
       expect(settled).toBe(false);
 
+      // The idle kill is a SIGKILL, so `close` carries a signal. The
+      // timeout check runs before the signal branch, so this still reports
+      // the idle budget rather than the bare "killed by SIGKILL".
       child.close(null, "SIGKILL");
-      await expect(promise).rejects.toThrow("timed out");
+      await expect(promise).rejects.toThrow("produced no output");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // traycer#585/#589: this budget is inactivity, not wall-clock. A 700MB
+  // host download on a throttled link runs far past any fixed ceiling we
+  // would be willing to set, but it never stops reporting - the CLI emits a
+  // progress event per chunk and heartbeats while a transfer is stalled.
+  it("re-arms the idle budget on every event, and only kills a child that goes quiet", async () => {
+    vi.useFakeTimers();
+    try {
+      const child = new HangingFakeChild();
+      spawnImpl = () => child;
+      const { streamTraycerCliJson } = await import("../traycer-cli");
+
+      const promise = streamTraycerCliJson<unknown>({
+        args: ["host", "download", "--automatic"],
+        onEvent: () => undefined,
+        env: null,
+        idleTimeoutMs: 5_000,
+        signal: null,
+      });
+
+      // Four reporting rounds - 16s in total, well past the 5s budget.
+      for (let round = 0; round < 4; round += 1) {
+        await vi.advanceTimersByTimeAsync(4_000);
+        expect(child.killed).toBe(false);
+        child.stdout.emit(
+          "data",
+          `${JSON.stringify({
+            type: "progress",
+            stage: "download",
+            percent: round * 25,
+            bytes: round * 1_000_000,
+            totalBytes: 4_000_000,
+            message: "downloading host",
+            timestamp: "2026-05-15T00:00:00Z",
+          })}\n`,
+        );
+      }
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(child.killed).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(child.killed).toBe(true);
+      expect(child.killSignal).toBe("SIGKILL");
+
+      child.close(null, "SIGKILL");
+      await expect(promise).rejects.toThrow("produced no output for 5000ms");
     } finally {
       vi.useRealTimers();
     }

--- a/clients/desktop/src/electron-main/cli/__tests__/traycer-cli-idle-timeout-integration.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/traycer-cli-idle-timeout-integration.test.ts
@@ -1,0 +1,154 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Integration counterpart to the fake-child unit tests in
+// `traycer-cli-envelope.test.ts`: a REAL subprocess, REAL pipes and REAL
+// timers, so this proves the wiring end to end rather than the timer
+// arithmetic in isolation.
+//
+// The regression it guards is traycer#585/#589: `CLI_STREAM_TIMEOUT_MS` was
+// an absolute ceiling, so Desktop SIGKILLed the CLI 10 minutes into a host
+// download that was still transferring - which is why a 700MB+ archive
+// could never install on a slow link. The budget is now inactivity, and a
+// child that keeps reporting must survive past it.
+
+const scriptDir = mkdtempSync(join(tmpdir(), "traycer-cli-idle-itest-"));
+
+vi.mock("../cli-discovery", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cli-discovery")>();
+  return {
+    ...actual,
+    discoverCli: async () => ({
+      kind: "manifest" as const,
+      binaryPath: join(scriptDir, "fake-cli.mjs"),
+      version: "1.1.8-rc.2",
+    }),
+    resolveBundledCliPath: async () => join(scriptDir, "fake-cli.mjs"),
+  };
+});
+
+import { streamTraycerCliJson } from "../traycer-cli";
+
+// Stands in for `traycer host download --json`: emits NDJSON progress on a
+// tick, then a terminal ok. `node` runs it directly (the shebang keeps it
+// spawnable as a bare command path).
+function writeFakeCli(opts: {
+  readonly tickMs: number;
+  readonly ticks: number;
+  readonly trailingSilenceMs: number;
+  readonly exitAfterSilence: boolean;
+}): void {
+  const script = `#!/usr/bin/env node
+const tickMs = ${opts.tickMs};
+const ticks = ${opts.ticks};
+const trailingSilenceMs = ${opts.trailingSilenceMs};
+const exitAfterSilence = ${String(opts.exitAfterSilence)};
+let sent = 0;
+function emit(obj) { process.stdout.write(JSON.stringify(obj) + "\\n"); }
+// The real CLI reports its first stage as soon as the command body starts
+// (\`resolve\`, before any transfer), so the budget only ever has to cover
+// process startup - never a whole transfer.
+emit({
+  type: "progress",
+  stage: "resolve",
+  percent: null,
+  bytes: null,
+  totalBytes: null,
+  message: "resolving host 1.1.8-rc.2",
+  timestamp: new Date().toISOString(),
+});
+const timer = setInterval(() => {
+  sent += 1;
+  emit({
+    type: "progress",
+    stage: "download",
+    percent: Math.round((sent / ticks) * 100),
+    bytes: sent * 1024 * 1024,
+    totalBytes: ticks * 1024 * 1024,
+    message: "downloading host 1.1.8-rc.2",
+    timestamp: new Date().toISOString(),
+  });
+  if (sent >= ticks) {
+    clearInterval(timer);
+    setTimeout(() => {
+      if (exitAfterSilence) {
+        emit({ type: "result", status: "ok", data: { version: "1.1.8-rc.2" } });
+        process.exit(0);
+      }
+      // Otherwise hang forever: the idle budget is the only thing that can
+      // end this process.
+      setInterval(() => undefined, 1000);
+    }, trailingSilenceMs);
+  }
+}, tickMs);
+`;
+  const path = join(scriptDir, "fake-cli.mjs");
+  writeFileSync(path, script, "utf8");
+  chmodSync(path, 0o755);
+}
+
+beforeAll(() => {
+  process.env.TRAYCER_TEST_FAKE_CLI = "1";
+});
+
+afterAll(() => {
+  rmSync(scriptDir, { recursive: true, force: true });
+});
+
+describe("streamTraycerCliJson idle budget against a real subprocess", () => {
+  it("keeps a child alive far past the budget while it keeps reporting", async () => {
+    // 15 ticks x 200ms = 3s of runtime under a 1.2s budget. Under the old
+    // absolute-ceiling semantics this child would have been SIGKILLed at
+    // 1.2s with progress still flowing - the exact shape of the reported
+    // failure, just compressed in time.
+    writeFakeCli({
+      tickMs: 200,
+      ticks: 15,
+      trailingSilenceMs: 0,
+      exitAfterSilence: true,
+    });
+    const progress: number[] = [];
+    const started = Date.now();
+    const result = await streamTraycerCliJson<{ version: string }>({
+      args: ["host", "download", "--automatic"],
+      onEvent: (event) => {
+        if (event.type === "progress" && event.percent !== null) {
+          progress.push(event.percent);
+        }
+      },
+      env: null,
+      idleTimeoutMs: 1_200,
+      signal: null,
+    });
+    const elapsed = Date.now() - started;
+
+    expect(result.data.version).toBe("1.1.8-rc.2");
+    expect(progress).toHaveLength(15);
+    expect(elapsed).toBeGreaterThan(2_500);
+  }, 30_000);
+
+  it("kills a child that stops reporting, once the budget elapses", async () => {
+    writeFakeCli({
+      tickMs: 100,
+      ticks: 3,
+      trailingSilenceMs: 0,
+      exitAfterSilence: false,
+    });
+    const started = Date.now();
+    await expect(
+      streamTraycerCliJson<unknown>({
+        args: ["host", "download", "--automatic"],
+        onEvent: () => undefined,
+        env: null,
+        idleTimeoutMs: 700,
+        signal: null,
+      }),
+    ).rejects.toThrow("produced no output for 700ms");
+    const elapsed = Date.now() - started;
+
+    // Killed only after the last event plus the budget, never before.
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+  }, 20_000);
+});

--- a/clients/desktop/src/electron-main/cli/traycer-cli.ts
+++ b/clients/desktop/src/electron-main/cli/traycer-cli.ts
@@ -466,12 +466,24 @@ export interface StreamTraycerCliOptions {
   readonly args: readonly string[];
   readonly onEvent: (event: NdjsonEvent) => void;
   readonly env: Readonly<Record<string, string>> | null;
-  readonly timeoutMs: number;
-  // Fixup C4: killed the moment this fires (SIGKILL, same as the timeout
-  // path below) instead of only flipping `.aborted` on a controller nothing
-  // downstream ever consulted. `null` for callers with no cancellation
-  // surface (every mutation-lane call via `streamBundled` - only the
-  // download lane's `AbortController` ever aborts).
+  // INACTIVITY budget, not a wall-clock ceiling: the timer is armed at
+  // spawn and re-armed on every NDJSON event the child emits, so the child
+  // is only killed once it has gone quiet for this long.
+  //
+  // It used to be an absolute cap. That made a first install impossible on
+  // any connection slower than <archive size> / <cap> (traycer#585/#589):
+  // the CLI was SIGKILLed at exactly 10 minutes with bytes still flowing,
+  // and the partial download died with it. The CLI already guarantees a
+  // liveness signal well inside any sane window - a progress event per
+  // chunk, plus watchdog/backoff heartbeats while a transfer is stalled
+  // (`registry/fetch-resource.ts`'s 30s `DOWNLOAD_WATCHDOG_MS`) - so
+  // silence, not duration, is the real evidence that a child is wedged.
+  readonly idleTimeoutMs: number;
+  // Fixup C4: killed the moment this fires (SIGKILL, same as the idle-
+  // timeout path below) instead of only flipping `.aborted` on a controller
+  // nothing downstream ever consulted. `null` for callers with no
+  // cancellation surface (every mutation-lane call via `streamBundled` -
+  // only the download lane's `AbortController` ever aborts).
   readonly signal: AbortSignal | null;
 }
 
@@ -536,7 +548,8 @@ async function streamTraycerCliJsonWithInvocation<T>(
         opts.signal.removeEventListener("abort", onAbort);
       }
     };
-    const timer = setTimeout(() => {
+    let timer: NodeJS.Timeout | null = null;
+    const onIdleTimeout = (): void => {
       if (settled) return;
       // Killing a timed-out child does not mean it has released its files.
       // Keep this stream promise pending until `close`, just like explicit
@@ -544,7 +557,7 @@ async function streamTraycerCliJsonWithInvocation<T>(
       // uninstall while the child is still exiting.
       timeoutError = new TraycerCliError(
         {
-          message: `traycer-cli timed out after ${opts.timeoutMs}ms (${augmentedArgs.join(" ")})`,
+          message: `traycer-cli produced no output for ${opts.idleTimeoutMs}ms (${augmentedArgs.join(" ")})`,
           code: null,
           details: null,
           exitCode: null,
@@ -557,7 +570,21 @@ async function streamTraycerCliJsonWithInvocation<T>(
       } catch {
         // ignore - already exited
       }
-    }, opts.timeoutMs);
+    };
+    // Re-armed by `armIdleTimer` on every NDJSON event below. Deliberately
+    // driven by parsed events rather than raw stdout bytes: in `--json`
+    // mode every line the CLI writes is an event, so a child emitting
+    // anything else is not evidence of progress.
+    const armIdleTimer = (): void => {
+      if (settled || abortError !== null || timeoutError !== null) return;
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(onIdleTimeout, opts.idleTimeoutMs);
+    };
+    const clearIdleTimer = (): void => {
+      if (timer !== null) clearTimeout(timer);
+      timer = null;
+    };
+    armIdleTimer();
     // Fixup C4: the ONLY current caller (`runDownloadLane`'s
     // `abortInFlightDownload`) used to flip `AbortController.signal.aborted`
     // with nothing downstream ever wired to it - the spawned CLI subprocess
@@ -568,7 +595,7 @@ async function streamTraycerCliJsonWithInvocation<T>(
     // cannot race a child still holding or promoting files.
     const onAbort = (): void => {
       if (settled || abortError !== null || timeoutError !== null) return;
-      clearTimeout(timer);
+      clearIdleTimer();
       abortError = new TraycerCliError(
         {
           message: `traycer-cli aborted: ${augmentedArgs.join(" ")}`,
@@ -615,6 +642,10 @@ async function streamTraycerCliJsonWithInvocation<T>(
         }
         const event = parseNdjsonEvent(parsed);
         if (event === null) continue;
+        // The child is demonstrably alive and reporting: restart its
+        // inactivity budget. This is what lets a multi-hour download on a
+        // throttled link run to completion.
+        armIdleTimer();
         if (event.type === "progress") {
           opts.onEvent(event);
           continue;
@@ -647,7 +678,7 @@ async function streamTraycerCliJsonWithInvocation<T>(
     child.on("error", (err) => {
       if (settled || abortError !== null || timeoutError !== null) return;
       settled = true;
-      clearTimeout(timer);
+      clearIdleTimer();
       cleanupAbortListener();
       reject(
         new TraycerCliError(
@@ -671,7 +702,7 @@ async function streamTraycerCliJsonWithInvocation<T>(
     child.on("close", (exitCode, signal) => {
       if (settled) return;
       settled = true;
-      clearTimeout(timer);
+      clearIdleTimer();
       cleanupAbortListener();
       if (abortError !== null) {
         reject(abortError);

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -767,6 +767,83 @@ describe("update-flow findings: Mo-A approval preflight, Mi-1 heartbeat carry-fo
       }),
     ]);
   });
+
+  it("a registry liveness tick keeps the running stage, but a real stage transition still lands", async () => {
+    // `registry-*` ticks are emitted from inside whatever stage is already
+    // running, so letting one overwrite `stage` flipped the renderer's
+    // heading away from "Downloading Traycer Host…" and back on every
+    // retry - constant flicker on the throttled links the retry budget
+    // exists for. The tick's message must still come through.
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "1.7.0",
+      runtimeVersion: "1.7.0",
+    });
+    writeStagedRecord("production", "1.8.0", "1.8.0");
+    vi.mocked(waitForHostReady).mockResolvedValue({
+      ready: true,
+      version: "1.8.0",
+      pid: process.pid,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      reason: "ready",
+    });
+    const progresses: MutationProgress[] = [];
+    const unsubscribeProgress = controller.onMutationProgress((p) => {
+      progresses.push(p);
+    });
+    vi.mocked(runBundledTraycerCliJson).mockResolvedValue(
+      availableSnapshotFixture("1.8.0", ["1.8.0"]),
+    );
+    vi.mocked(streamBundledTraycerCliJson).mockImplementation(async (opts) => {
+      if (opts.args.includes("download")) return { data: {} };
+      opts.onEvent({
+        type: "progress",
+        stage: "download",
+        percent: 45,
+        bytes: 45,
+        totalBytes: 100,
+        message: "downloading host 1.8.0",
+      });
+      opts.onEvent({
+        type: "progress",
+        stage: "registry-archive-backoff",
+        percent: null,
+        bytes: null,
+        totalBytes: null,
+        message: "retrying host archive shortly",
+      });
+      opts.onEvent({
+        type: "progress",
+        stage: "extract",
+        percent: null,
+        bytes: null,
+        totalBytes: null,
+        message: "extracting host 1.8.0",
+      });
+      return {
+        data: {
+          outcome: "applied",
+          record: { version: "1.8.0", runtimeVersion: "1.8.0" },
+          runningActivated: true,
+          installGeneration: null,
+        },
+      };
+    });
+
+    const outcome = await controller.applyStaged("manual", false);
+    unsubscribeProgress();
+
+    expect(outcome.kind).toBe("ok");
+    expect(progresses).toEqual([
+      expect.objectContaining({ stage: "download", percent: 45 }),
+      expect.objectContaining({
+        stage: "download",
+        percent: 45,
+        message: "retrying host archive shortly",
+      }),
+      expect.objectContaining({ stage: "extract", percent: 45 }),
+    ]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -77,7 +77,18 @@ import {
 // directly now submits an intent here instead - see the ticket's "Single-
 // writer cutover" for the exhaustive list of call sites this replaces.
 
-const CLI_STREAM_TIMEOUT_MS = 10 * 60_000;
+// How long a streaming CLI child may stay SILENT before it is treated as
+// wedged and killed. Not a ceiling on how long the work may take: the timer
+// re-arms on every NDJSON event (`streamTraycerCliJson`), and the CLI emits
+// progress per downloaded chunk plus watchdog/backoff heartbeats while a
+// transfer is stalled.
+//
+// As an absolute cap this same 10 minutes made the host download
+// unfinishable below ~1.2 MB/s - the CLI was SIGKILLed mid-transfer and the
+// partial went with it (traycer#585/#589). Kept at 10 minutes as an idle
+// budget: comfortably longer than the CLI's own 30s transfer watchdog, so
+// only a child that has genuinely stopped reporting trips it.
+const CLI_STREAM_IDLE_TIMEOUT_MS = 10 * 60_000;
 // Fixup A9: the production desktop-held cli-lock wait/poll - matches the
 // CLI's own `waitMs: 30_000` at every `withCliLock` call site (fixup A8).
 // Exported (not just a local default) so `HostControllerOptions.desktopLockWaitMs`/
@@ -137,6 +148,16 @@ function progressFromNdjson(
     totalBytes: event.totalBytes,
     message: event.message,
   };
+}
+
+// The CLI names its network liveness ticks `registry-<resource>-<phase>`
+// (registry/client.ts, commands/cli-upgrade.ts). They report that a fetch is
+// still alive, not that the work moved to a new stage - see
+// `setMutationProgress`.
+const REGISTRY_LIVENESS_STAGE_PREFIX = "registry-";
+
+function isRegistryLivenessStage(stage: string | null): boolean {
+  return stage !== null && stage.startsWith(REGISTRY_LIVENESS_STAGE_PREFIX);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -797,14 +818,26 @@ export class HostController {
     if (this.mutationStatus === null) return;
     // Mi-1: carry the last concrete percent/bytes/totalBytes forward so a bare
     // heartbeat (an event that omits them) holds the bar instead of blanking
-    // it; stage/message still track the incoming event so a genuine stage
-    // transition is honored. A later event with real numbers overrides.
+    // it; message still tracks the incoming event so the retry text is
+    // visible. A later event with real numbers overrides.
+    //
+    // `stage` is carried forward too, but only for a registry liveness tick.
+    // Those are emitted from INSIDE whatever stage is already running (the
+    // manifest fetch, the archive transfer, the signature fetch) rather than
+    // being stages in their own right, so letting one overwrite `stage` made
+    // the renderer's heading flip away from "Downloading Traycer Host…" and
+    // back on every retry. The progress-aware retry budget turned that from a
+    // rare blip into a constant flicker on exactly the throttled links it
+    // exists for. A genuine stage transition (resolve/download/extract/swap/
+    // …) still lands.
     const prior = this.mutationStatus.progress;
     const merged: MutationProgress =
       prior === null
         ? progress
         : {
-            stage: progress.stage,
+            stage: isRegistryLivenessStage(progress.stage)
+              ? prior.stage
+              : progress.stage,
             percent: progress.percent ?? prior.percent,
             bytes: progress.bytes ?? prior.bytes,
             totalBytes: progress.totalBytes ?? prior.totalBytes,
@@ -864,7 +897,7 @@ export class HostController {
     const result = await streamBundledTraycerCliJson<T>({
       args,
       env: null,
-      timeoutMs: CLI_STREAM_TIMEOUT_MS,
+      idleTimeoutMs: CLI_STREAM_IDLE_TIMEOUT_MS,
       // Every mutation-lane call goes through here - none of them are
       // cancellable (only the download lane's `runDownloadLane`, below, has
       // an `AbortController`).
@@ -1943,7 +1976,7 @@ export class HostController {
         await streamBundledTraycerCliJson<unknown>({
           args,
           env: null,
-          timeoutMs: CLI_STREAM_TIMEOUT_MS,
+          idleTimeoutMs: CLI_STREAM_IDLE_TIMEOUT_MS,
           // Fixup C4: this download's own `AbortController` - `abortInFlightDownload`
           // (only called by `removeTraycer`) now actually kills the spawned CLI
           // subprocess instead of only flipping `.aborted` on a signal nothing

--- a/clients/shared/host-lock/process-identity.ts
+++ b/clients/shared/host-lock/process-identity.ts
@@ -273,6 +273,28 @@ export function verifyProcessIdentity(
   );
 }
 
+// Same verdict as `verifyProcessIdentity`, without blocking the event loop.
+// The synchronous form shells out via `execFileSync` (a 3s timeout and up to
+// three retries on POSIX), which is fine for a lock acquisition that is
+// about to block anyway but not for a caller that judges MANY tokens in a
+// row before doing any work - `registry/download-cache.ts` sweeps every
+// entry in the download cache before a download is allowed to start, and a
+// cache holding a handful of distinct stale owners could otherwise burn tens
+// of seconds of wall clock with the process wedged and emitting nothing.
+export async function verifyProcessIdentityAsync(
+  token: ProcessIdentityToken,
+): Promise<ProcessIdentityVerdict> {
+  if (token.pid === process.pid) return verifyOwnProcessIdentity(token);
+  const liveness = await asyncProcessLivenessReader(token.pid);
+  const currentStartedAtMs =
+    liveness === "dead" ? null : await asyncProcessStartTimeReader(token.pid);
+  return computeProcessIdentityVerdict(
+    liveness,
+    token.startedAtMs,
+    currentStartedAtMs,
+  );
+}
+
 // Mutable indirection for the start-time probe `verifyProcessIdentity`
 // consults, defaulting to the real `readProcessStartTimeMs` below. Exists
 // solely so tests can force a probe failure for a specific pid at the

--- a/clients/traycer-cli/src/commands/cli-upgrade.ts
+++ b/clients/traycer-cli/src/commands/cli-upgrade.ts
@@ -243,10 +243,14 @@ export function buildCliUpgradeCommand(args: CliUpgradeArgs): CommandFn {
                 message:
                   heartbeat.phase === "watchdog"
                     ? "CLI download stalled; retrying"
-                    : `CLI download ${heartbeat.phase} ${heartbeat.attempt}/${heartbeat.maxAttempts}`,
+                    : `CLI download ${heartbeat.phase} ${heartbeat.attempt}`,
                 percent: null,
-                bytes: heartbeat.attempt,
-                totalBytes: heartbeat.maxAttempts,
+                // Attempt counters are not a transfer measurement. Feeding
+                // them to the byte fields made the progress bar redraw as
+                // "1 of 200" on every retry; all three stay null so the
+                // renderer holds the last real download values.
+                bytes: null,
+                totalBytes: null,
               }),
             signal: null,
           });

--- a/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
@@ -330,6 +330,10 @@ describe("downloadAndStageHost", () => {
     archiveTmpDir = mkdtempSync(
       join(tmpdir(), "traycer-download-stage-archives-"),
     );
+    // Cleared per test so an absence assertion cannot pass against a stale
+    // path from an earlier test whose files are already gone - that would
+    // make a "the slot was released" check succeed without a release.
+    lastFakeArchivePath = "";
   });
 
   afterEach(() => {
@@ -604,6 +608,9 @@ describe("downloadAndStageHost", () => {
     // its own archive plus the ownership marker and nothing else. The old
     // `rm(dirname(archivePath))` would take the whole cache with it -
     // including another process's in-flight partial.
+    // The download actually ran, so the absence checks below are about this
+    // test's own archive rather than an empty path.
+    expect(lastFakeArchivePath).not.toBe("");
     expect(existsSync(lastFakeArchivePath)).toBe(false);
     expect(existsSync(`${lastFakeArchivePath}.owner`)).toBe(false);
     expect(existsSync(dirname(lastFakeArchivePath))).toBe(true);

--- a/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
@@ -228,6 +228,40 @@ function fakeRegistryClient(opts: FakeClientOptions): RegistryClient {
   };
 }
 
+// Downloads "successfully" but stages an archive whose basename is not the
+// expected host executable, so `resolveHostExecutable` throws AFTER the
+// transfer and verification have both passed. Reproduces every local
+// post-download failure - a bad extract, a tree missing the binary, a
+// `cli-lock` wait that times out - in the one shape this harness can force.
+function unresolvableArchiveRegistryClient(
+  base: RegistryClient,
+  onArchive: (archivePath: string) => void,
+): RegistryClient {
+  return {
+    ...base,
+    async downloadAndVerify(entry, asset, onProgress) {
+      onProgress({
+        downloadedBytes: asset.sizeBytes,
+        totalBytes: asset.sizeBytes,
+      });
+      const callDir = mkdtempSync(join(archiveTmpDir, "arc-"));
+      const archivePath = join(callDir, "not-the-host-binary");
+      writeFileSync(archivePath, "fake host binary");
+      writeFileSync(
+        `${archivePath}.owner`,
+        JSON.stringify({ pid: process.pid, startedAtMs: null }),
+      );
+      onArchive(archivePath);
+      return {
+        archivePath,
+        archiveSha256: "fake-sha256",
+        signatureKeyId: "fake-key-id",
+        signatureVerifiedAt: new Date().toISOString(),
+      };
+    },
+  };
+}
+
 function throwingRegistryClient(base: RegistryClient): RegistryClient {
   return {
     ...base,
@@ -573,6 +607,41 @@ describe("downloadAndStageHost", () => {
     expect(existsSync(lastFakeArchivePath)).toBe(false);
     expect(existsSync(`${lastFakeArchivePath}.owner`)).toBe(false);
     expect(existsSync(dirname(lastFakeArchivePath))).toBe(true);
+  });
+
+  it("keeps the verified archive and drops only the claim when the work AFTER the download fails", async () => {
+    await writeInstall("1.0.0", {});
+    let stagedArchivePath = "";
+    const client = unresolvableArchiveRegistryClient(
+      fakeRegistryClient({
+        latest: "1.5.0",
+        versions: [
+          { version: "1.0.0", yanked: false },
+          { version: "1.5.0", yanked: false },
+        ],
+        downloadGate: null,
+        onDownloadStart: null,
+      }),
+      (archivePath) => {
+        stagedArchivePath = archivePath;
+      },
+    );
+    await expect(
+      downloadAndStageHost({
+        environment: ENV,
+        versionRequest: null,
+        automatic: false,
+        onProgress: noopProgress,
+        registryClient: client,
+      }),
+    ).rejects.toThrow(/expected executable/);
+    // These bytes already cleared sha256 AND minisign. Whatever failed
+    // afterwards is local, so re-downloading them over the throttled link
+    // this whole feature exists for could not produce anything different -
+    // the next run resumes this file over a single 416 instead. Only the
+    // ownership claim comes off, so another process is free to take it.
+    expect(existsSync(stagedArchivePath)).toBe(true);
+    expect(existsSync(`${stagedArchivePath}.owner`)).toBe(false);
   });
 
   it("yank-heal: discards a now-yanked stage with no download when the target resolves back to installed", async () => {

--- a/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/download-stage.test.ts
@@ -1,4 +1,5 @@
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -8,7 +9,7 @@ import {
 } from "node:fs";
 import { platform as osPlatform } from "node:os";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type Environment = "dev" | "production";
@@ -97,6 +98,9 @@ import { downloadAndStageHost } from "../download-stage";
 
 const ENV: Environment = "production";
 let archiveTmpDir = "";
+// Path the fake registry client handed back on its most recent download,
+// so a test can assert the caller released that exact slot.
+let lastFakeArchivePath = "";
 
 function executableBasename(): string {
   return osPlatform() === "win32" ? "traycer-host.exe" : "traycer-host";
@@ -204,6 +208,16 @@ function fakeRegistryClient(opts: FakeClientOptions): RegistryClient {
       const callDir = mkdtempSync(join(archiveTmpDir, "arc-"));
       const archivePath = join(callDir, executableBasename());
       writeFileSync(archivePath, "fake host binary");
+      // The real client stages into the shared download cache and stamps
+      // the archive with an ownership marker holding ITS OWN process identity
+      // (registry/download-cache.ts). Mirror that sibling faithfully - the
+      // release path is a compare-and-delete, so a marker recording someone
+      // else's pid is deliberately left alone.
+      writeFileSync(
+        `${archivePath}.owner`,
+        JSON.stringify({ pid: process.pid, startedAtMs: null }),
+      );
+      lastFakeArchivePath = archivePath;
       return {
         archivePath,
         archiveSha256: "fake-sha256",
@@ -533,7 +547,7 @@ describe("downloadAndStageHost", () => {
     expect(staged?.source).toEqual({ kind: "registry", value: "1.5.0" });
   });
 
-  it("removes the whole download temp directory, not just the archive file, on a successful promote", async () => {
+  it("releases the download slot - archive and ownership marker - on a successful promote, without touching the cache dir", async () => {
     await writeInstall("1.0.0", {});
     const client = fakeRegistryClient({
       latest: "1.5.0",
@@ -551,12 +565,14 @@ describe("downloadAndStageHost", () => {
       onProgress: noopProgress,
       registryClient: client,
     });
-    // The fake client's `downloadAndVerify` creates its archive inside a
-    // fresh `arc-*` subdirectory of `archiveTmpDir` (mirroring the real
-    // registry client's `mkdtemp(tmpdir(), "traycer-host-dl-")` shape) -
-    // removing only the archive FILE would leave that directory behind
-    // on every successful download.
-    expect(readdirSync(archiveTmpDir)).toEqual([]);
+    // The archive now lives in the SHARED download cache keyed by
+    // version+sha (registry/download-cache.ts), so the consumer must drop
+    // its own archive plus the ownership marker and nothing else. The old
+    // `rm(dirname(archivePath))` would take the whole cache with it -
+    // including another process's in-flight partial.
+    expect(existsSync(lastFakeArchivePath)).toBe(false);
+    expect(existsSync(`${lastFakeArchivePath}.owner`)).toBe(false);
+    expect(existsSync(dirname(lastFakeArchivePath))).toBe(true);
   });
 
   it("yank-heal: discards a now-yanked stage with no download when the target resolves back to installed", async () => {

--- a/clients/traycer-cli/src/installer/__tests__/extract.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/extract.test.ts
@@ -97,7 +97,11 @@ describe("extractHostSource (tar)", () => {
     const archive = join(scratchRoot, "benign.tar");
     await tarCreate({ file: archive, cwd: sourceDir }, ["ok.txt"]);
     const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
-    await extractHostSource({ source: archive, targetDir });
+    await extractHostSource({
+      source: archive,
+      targetDir,
+      onEntry: () => undefined,
+    });
     const contents = await readFile(join(targetDir, "ok.txt"), "utf8");
     expect(contents).toBe("ok\n");
   });
@@ -124,7 +128,11 @@ describe("extractHostSource (tar)", () => {
     const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
     let caught: unknown = null;
     try {
-      await extractHostSource({ source: archive, targetDir });
+      await extractHostSource({
+        source: archive,
+        targetDir,
+        onEntry: () => undefined,
+      });
     } catch (err) {
       caught = err;
     }
@@ -144,7 +152,11 @@ describe("extractHostSource (tar)", () => {
     const archive = join(scratchRoot, "dotfile.tar");
     await tarCreate({ file: archive, cwd: sourceDir }, [".marker"]);
     const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
-    await extractHostSource({ source: archive, targetDir });
+    await extractHostSource({
+      source: archive,
+      targetDir,
+      onEntry: () => undefined,
+    });
     const markerStat = await stat(join(targetDir, ".marker"));
     expect(markerStat.isFile()).toBe(true);
   });
@@ -161,7 +173,11 @@ describe("extractHostSource (tar)", () => {
     const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
     let caught: unknown = null;
     try {
-      await extractHostSource({ source: archive, targetDir });
+      await extractHostSource({
+        source: archive,
+        targetDir,
+        onEntry: () => undefined,
+      });
     } catch (err) {
       caught = err;
     }
@@ -193,7 +209,11 @@ describe("extractHostSource (tar)", () => {
     const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
     let caught: unknown = null;
     try {
-      await extractHostSource({ source: archive, targetDir });
+      await extractHostSource({
+        source: archive,
+        targetDir,
+        onEntry: () => undefined,
+      });
     } catch (err) {
       caught = err;
     }
@@ -216,7 +236,11 @@ describe("extractHostSource (tar)", () => {
     const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
     let caught: unknown = null;
     try {
-      await extractHostSource({ source: archive, targetDir });
+      await extractHostSource({
+        source: archive,
+        targetDir,
+        onEntry: () => undefined,
+      });
     } catch (err) {
       caught = err;
     }

--- a/clients/traycer-cli/src/installer/__tests__/extract.test.ts
+++ b/clients/traycer-cli/src/installer/__tests__/extract.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { tmpdir, platform as osPlatform } from "node:os";
 import { join } from "node:path";
@@ -255,5 +261,101 @@ describe("extractHostSource (tar)", () => {
     }
     const targetEntries = await readdir(targetDir);
     expect(targetEntries).toEqual([]);
+  });
+});
+
+// `onEntry` is the only liveness signal during an extract that can run for
+// minutes: Desktop SIGKILLs a CLI whose NDJSON stream goes quiet, and the
+// download cache hands a slot whose archive stopped being touched to another
+// process. A callback that silently never fires - a mistyped `zip.on(...)`
+// event being the easiest way to get there - restores both failures with
+// every other test still green, so each unpack shape asserts it directly.
+describe("extractHostSource (onEntry liveness)", () => {
+  it("fires once per entry while unpacking a tar", async () => {
+    const sourceDir = mkdtempSync(join(scratchRoot, "src-"));
+    writeFileSync(join(sourceDir, "a.txt"), "a\n");
+    writeFileSync(join(sourceDir, "b.txt"), "b\n");
+    writeFileSync(join(sourceDir, "c.txt"), "c\n");
+    const archive = join(scratchRoot, "ticks.tar");
+    await tarCreate({ file: archive, cwd: sourceDir }, [
+      "a.txt",
+      "b.txt",
+      "c.txt",
+    ]);
+    const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
+    let ticks = 0;
+    await extractHostSource({
+      source: archive,
+      targetDir,
+      onEntry: () => {
+        ticks += 1;
+      },
+    });
+    expect(ticks).toBe(3);
+    expect((await readdir(targetDir)).sort()).toEqual([
+      "a.txt",
+      "b.txt",
+      "c.txt",
+    ]);
+  });
+
+  it("fires while unpacking a zip", async () => {
+    // Guards the `zip.on("extract", ...)` wiring specifically - the event
+    // name is a string the compiler cannot check.
+    const archive = join(scratchRoot, "ticks.zip");
+    writeFileSync(archive, buildZipWithEntry("host.txt", "host\n"));
+    const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
+    let ticks = 0;
+    await extractHostSource({
+      source: archive,
+      targetDir,
+      onEntry: () => {
+        ticks += 1;
+      },
+    });
+    expect(ticks).toBe(1);
+    expect(await readFile(join(targetDir, "host.txt"), "utf8")).toBe("host\n");
+  });
+
+  it("fires per top-level entry while copying a source directory", async () => {
+    const sourceDir = mkdtempSync(join(scratchRoot, "src-"));
+    writeFileSync(join(sourceDir, "host"), "binary\n");
+    mkdirSync(join(sourceDir, "resources"));
+    writeFileSync(join(sourceDir, "resources", "nested.txt"), "nested\n");
+    const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
+    let ticks = 0;
+    await extractHostSource({
+      source: sourceDir,
+      targetDir,
+      onEntry: () => {
+        ticks += 1;
+      },
+    });
+    expect(ticks).toBe(2);
+    // Per-entry copying must still reproduce the tree, subdirectories and
+    // all - it replaced a single recursive `cp` of the whole directory.
+    expect(await readFile(join(targetDir, "host"), "utf8")).toBe("binary\n");
+    expect(
+      await readFile(join(targetDir, "resources", "nested.txt"), "utf8"),
+    ).toBe("nested\n");
+  });
+
+  it("fires while copying a bare executable", async () => {
+    const sourceDir = mkdtempSync(join(scratchRoot, "src-"));
+    const source = join(sourceDir, "traycer-host");
+    writeFileSync(source, "binary\n");
+    const targetDir = mkdtempSync(join(scratchRoot, "tgt-"));
+    let ticks = 0;
+    await extractHostSource({
+      source,
+      targetDir,
+      onEntry: () => {
+        ticks += 1;
+      },
+    });
+    expect(ticks).toBe(1);
+    expect(await readFile(join(targetDir, "traycer-host"), "utf8")).toBe(
+      "binary\n",
+    );
   });
 });

--- a/clients/traycer-cli/src/installer/download-stage.ts
+++ b/clients/traycer-cli/src/installer/download-stage.ts
@@ -14,6 +14,7 @@ import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 import {
   createDefaultRegistryClient,
   currentHostPlatformKey,
+  releaseDownloadSlot,
   type HostVersionsManifest,
   type RegistryClient,
 } from "../registry";
@@ -33,6 +34,7 @@ import {
   readExtractedRuntimeVersion,
 } from "./install";
 import { extractHostSource, resolveHostExecutable } from "./extract";
+import { createExtractHeartbeat } from "./extract-heartbeat";
 import { invalidateAsideDir } from "./aside-dirs";
 import { renameWithRetry } from "./rename-retry";
 import { purgeHostStage, reconcileHostStage } from "./stage-reconcile";
@@ -356,6 +358,12 @@ export async function downloadAndStageHost(
     await extractHostSource({
       source: verified.archivePath,
       targetDir: tempPath,
+      onEntry: createExtractHeartbeat({
+        environment: opts.environment,
+        archivePath: verified.archivePath,
+        version: entry.version,
+        onProgress: opts.onProgress,
+      }),
     });
     const executablePath = await resolveHostExecutable(tempPath, osPlatform());
     const runtimeVersion = await readExtractedRuntimeVersion(
@@ -479,15 +487,14 @@ export async function downloadAndStageHost(
         () => undefined,
       );
     }
-    // The registry client's own temp archive dir is not auto-cleaned on
-    // success (by contract - see registry/client.ts's `downloadAndVerify`)
-    // - the caller owns removing it. Remove the WHOLE directory
-    // (`dirname(archivePath)`), not just the archive file: the directory
-    // itself (an `mkdtemp`-created `traycer-host-dl-*` dir under the OS
-    // tmpdir) is otherwise leaked on every successful download.
-    await rm(dirname(verified.archivePath), {
-      recursive: true,
-      force: true,
-    }).catch(() => undefined);
+    // The verified archive is not auto-cleaned on success (by contract -
+    // see registry/client.ts's `downloadAndVerify`): the caller owns
+    // releasing it once it has extracted what it needs. This drops the
+    // archive AND the download-cache claim on it; it must never be a plain
+    // `rm(dirname(...))`, because that directory is now the SHARED
+    // download cache, not a private per-invocation temp.
+    await releaseDownloadSlot(opts.environment, verified.archivePath).catch(
+      () => undefined,
+    );
   }
 }

--- a/clients/traycer-cli/src/installer/download-stage.ts
+++ b/clients/traycer-cli/src/installer/download-stage.ts
@@ -15,6 +15,7 @@ import {
   createDefaultRegistryClient,
   currentHostPlatformKey,
   releaseDownloadSlot,
+  releaseDownloadSlotOwnership,
   type HostVersionsManifest,
   type RegistryClient,
 } from "../registry";
@@ -343,6 +344,12 @@ export async function downloadAndStageHost(
 
   let ownedPath: string | null = null;
   let ownedConsumed = false;
+  // Whether the promote phase ran to a decision. Only then is the archive
+  // finished with; anything that THROWS out of the block below (a failed
+  // extract, a missing executable in the tree, a `cli-lock` wait that times
+  // out) leaves a downloaded, sha256- and signature-verified archive that a
+  // retry can reuse as-is. See the `finally`.
+  let archiveConsumed = false;
   try {
     progressStage(
       opts.onProgress,
@@ -387,7 +394,7 @@ export async function downloadAndStageHost(
 
     // Phase 3 - brief lock: reconcile, re-read, re-check the install
     // record still exists, and promote only per the intent policy.
-    return await withCliLock(
+    const outcome = await withCliLock(
       {
         environment: opts.environment,
         reason: "host-download-promote",
@@ -481,6 +488,12 @@ export async function downloadAndStageHost(
         } satisfies HostDownloadOutcome;
       },
     );
+    // Reached only by a normal return from the promote phase - promoted, or
+    // deliberately discarded because the install record vanished or the
+    // version is not newer. Either way this download is over and the archive
+    // will not be wanted again.
+    archiveConsumed = true;
+    return outcome;
   } finally {
     if (ownedPath !== null && !ownedConsumed) {
       await rm(ownedPath, { recursive: true, force: true }).catch(
@@ -489,12 +502,26 @@ export async function downloadAndStageHost(
     }
     // The verified archive is not auto-cleaned on success (by contract -
     // see registry/client.ts's `downloadAndVerify`): the caller owns
-    // releasing it once it has extracted what it needs. This drops the
-    // archive AND the download-cache claim on it; it must never be a plain
-    // `rm(dirname(...))`, because that directory is now the SHARED
-    // download cache, not a private per-invocation temp.
-    await releaseDownloadSlot(opts.environment, verified.archivePath).catch(
-      () => undefined,
-    );
+    // releasing it once it has extracted what it needs. Whichever release
+    // runs, it must never be a plain `rm(dirname(...))` - that directory is
+    // now the SHARED download cache, not a private per-invocation temp.
+    if (archiveConsumed) {
+      // Drop the archive AND the claim on it.
+      await releaseDownloadSlot(opts.environment, verified.archivePath).catch(
+        () => undefined,
+      );
+    } else {
+      // Something between the transfer and the promote decision threw. These
+      // bytes already cleared sha256 AND minisign, so re-downloading them
+      // could not produce anything different - it would just spend another
+      // ~800MB over the same throttled link this work exists for, only to
+      // hit the same local failure. Drop the claim and leave them: the next
+      // run's `acquireDownloadSlot` spares this version's slot from the
+      // sweep and resumes it over a single 416 round-trip.
+      await releaseDownloadSlotOwnership(
+        opts.environment,
+        verified.archivePath,
+      ).catch(() => undefined);
+    }
   }
 }

--- a/clients/traycer-cli/src/installer/extract-heartbeat.ts
+++ b/clients/traycer-cli/src/installer/extract-heartbeat.ts
@@ -1,0 +1,38 @@
+import type { Environment } from "../runner/environment";
+import type { ProgressInfo } from "../runner/output";
+import { refreshDownloadSlotClaim } from "../registry";
+
+// Extraction of a ~800MB archive can run for minutes while producing no
+// output of its own. Two independent mechanisms read that silence as death:
+// Desktop SIGKILLs a CLI whose NDJSON stream goes quiet (`host-controller.ts`'s
+// idle budget), and the download cache lets another process take over a slot
+// whose archive has stopped being touched - extraction only READS the archive,
+// so its mtime stops advancing the moment the transfer ends.
+//
+// One heartbeat answers both: emit a progress event AND stamp the ownership
+// marker. Throttled, because the underlying hook fires once per archive entry.
+const EXTRACT_HEARTBEAT_INTERVAL_MS = 2_000;
+
+export function createExtractHeartbeat(opts: {
+  readonly environment: Environment;
+  readonly archivePath: string;
+  readonly version: string;
+  readonly onProgress: (info: ProgressInfo) => void;
+}): () => void {
+  let lastAtMs = 0;
+  return () => {
+    const nowMs = Date.now();
+    if (nowMs - lastAtMs < EXTRACT_HEARTBEAT_INTERVAL_MS) return;
+    lastAtMs = nowMs;
+    opts.onProgress({
+      stage: "extract",
+      message: `extracting host ${opts.version}`,
+      percent: null,
+      bytes: null,
+      totalBytes: null,
+    });
+    void refreshDownloadSlotClaim(opts.environment, opts.archivePath).catch(
+      () => undefined,
+    );
+  };
+}

--- a/clients/traycer-cli/src/installer/extract-heartbeat.ts
+++ b/clients/traycer-cli/src/installer/extract-heartbeat.ts
@@ -11,6 +11,22 @@ import { refreshDownloadSlotClaim } from "../registry";
 //
 // One heartbeat answers both: emit a progress event AND stamp the ownership
 // marker. Throttled, because the underlying hook fires once per archive entry.
+//
+// Deliberately driven by entries rather than by a wall-clock interval, even
+// though that leaves one gap: an archive whose payload is a single enormous
+// member ticks once and then goes quiet until that member is written. The
+// trade is what makes it the right default anyway - an entry tick is evidence
+// of PROGRESS, while an interval only proves the process still exists, so an
+// interval would keep Desktop's inactivity budget armed forever around an
+// extract that is genuinely wedged on I/O. That budget is the only thing that
+// ever catches a stuck extract.
+//
+// The residual risk is small and now cheap: crossing the 10-minute budget
+// inside one member needs pathological I/O, and if it does happen the child
+// is killed, the staging temp is swept, and the verified archive SURVIVES
+// (download-stage.ts releases ownership rather than the file on a throw), so
+// the retry re-extracts without re-downloading. Revisit if the host archive
+// ever becomes a single-member archive.
 const EXTRACT_HEARTBEAT_INTERVAL_MS = 2_000;
 
 export function createExtractHeartbeat(opts: {

--- a/clients/traycer-cli/src/installer/extract.ts
+++ b/clients/traycer-cli/src/installer/extract.ts
@@ -26,6 +26,14 @@ import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 export interface ExtractOptions {
   readonly source: string;
   readonly targetDir: string;
+  // Called as entries are written. Extraction of a ~800MB archive can run
+  // for minutes with nothing else to show for it, and two separate
+  // mechanisms treat that silence as death: Desktop's inactivity timer
+  // SIGKILLs a CLI that emits no NDJSON, and the download cache's idle rule
+  // lets another process take over a slot whose archive has stopped being
+  // touched (extraction only READS it, so its mtime stops advancing).
+  // Callers throttle - this fires per entry.
+  readonly onEntry: () => void;
 }
 
 export async function extractHostSource(opts: ExtractOptions): Promise<void> {
@@ -44,11 +52,11 @@ export async function extractHostSource(opts: ExtractOptions): Promise<void> {
     lower.endsWith(".tar.gz") ||
     lower.endsWith(".tar.xz")
   ) {
-    await extractTarArchive(opts.source, opts.targetDir);
+    await extractTarArchive(opts.source, opts.targetDir, opts.onEntry);
     return;
   }
   if (ext === ".zip") {
-    await extractZipArchive(opts.source, opts.targetDir);
+    await extractZipArchive(opts.source, opts.targetDir, opts.onEntry);
     return;
   }
   // Bare executable. Copy into the target dir keeping the basename so
@@ -73,6 +81,7 @@ async function copyDirectoryShallow(
 async function extractTarArchive(
   source: string,
   targetDir: string,
+  onEntry: () => void,
 ): Promise<void> {
   let rejected: { entry: string; reason: string } | null = null;
   await tarExtract({
@@ -102,6 +111,7 @@ async function extractTarArchive(
         if (rejected === null) rejected = { entry: path, reason };
         return false;
       }
+      onEntry();
       return true;
     },
   });
@@ -119,8 +129,10 @@ async function extractTarArchive(
 async function extractZipArchive(
   source: string,
   targetDir: string,
+  onEntry: () => void,
 ): Promise<void> {
   const zip = new StreamZip.async({ file: source });
+  zip.on("extract", () => onEntry());
   try {
     const entries = await zip.entries();
     for (const entry of Object.values(entries)) {

--- a/clients/traycer-cli/src/installer/extract.ts
+++ b/clients/traycer-cli/src/installer/extract.ts
@@ -26,20 +26,24 @@ import { CLI_ERROR_CODES, cliError } from "../runner/errors";
 export interface ExtractOptions {
   readonly source: string;
   readonly targetDir: string;
-  // Called as entries are written. Extraction of a ~800MB archive can run
-  // for minutes with nothing else to show for it, and two separate
-  // mechanisms treat that silence as death: Desktop's inactivity timer
-  // SIGKILLs a CLI that emits no NDJSON, and the download cache's idle rule
-  // lets another process take over a slot whose archive has stopped being
-  // touched (extraction only READS it, so its mtime stops advancing).
-  // Callers throttle - this fires per entry.
+  // Called once per entry as the source is unpacked - for tar from the
+  // `filter`, i.e. just BEFORE that entry is written, and for zip just
+  // after. The exact side of the write does not matter; what matters is
+  // that something fires while the work is running.
+  //
+  // Extraction of a ~800MB archive can run for minutes with nothing else to
+  // show for it, and two separate mechanisms treat that silence as death:
+  // Desktop's inactivity timer SIGKILLs a CLI that emits no NDJSON, and the
+  // download cache's idle rule lets another process take over a slot whose
+  // archive has stopped being touched (extraction only READS it, so its
+  // mtime stops advancing). Callers throttle.
   readonly onEntry: () => void;
 }
 
 export async function extractHostSource(opts: ExtractOptions): Promise<void> {
   const sourceStat = await stat(opts.source);
   if (sourceStat.isDirectory()) {
-    await copyDirectoryShallow(opts.source, opts.targetDir);
+    await copyDirectoryShallow(opts.source, opts.targetDir, opts.onEntry);
     return;
   }
   const ext = extname(opts.source).toLowerCase();
@@ -61,15 +65,30 @@ export async function extractHostSource(opts: ExtractOptions): Promise<void> {
   }
   // Bare executable. Copy into the target dir keeping the basename so
   // resolveExecutable() can find it.
+  //
+  // A single `copyFile` has no interior to report from, so the one tick
+  // goes out before it starts rather than after: a ~100MB host binary onto
+  // a slow disk is the case worth covering, and a tick that lands after the
+  // copy is a tick the watchers never needed.
+  opts.onEntry();
   await copyFile(opts.source, join(opts.targetDir, basename(opts.source)));
 }
 
+// Per top-level entry rather than one bulk `cp` of the whole tree: the bulk
+// form reports nothing for however long it runs, which is the silence both
+// watchers read as a dead process. Each entry is still copied recursively,
+// so the resulting tree is identical.
 async function copyDirectoryShallow(
   source: string,
   target: string,
+  onEntry: () => void,
 ): Promise<void> {
   await mkdir(target, { recursive: true });
-  await cp(source, target, { recursive: true });
+  const entries = await readdir(source);
+  for (const entry of entries) {
+    onEntry();
+    await cp(join(source, entry), join(target, entry), { recursive: true });
+  }
 }
 
 // Reject any tar entry whose name is absolute, contains a `..` segment,

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -15,6 +15,7 @@ import {
 import {
   createDefaultRegistryClient,
   currentHostPlatformKey,
+  releaseDownloadSlot,
 } from "../registry";
 import type { ProgressInfo } from "../runner/output";
 import type { Environment } from "../runner/environment";
@@ -23,6 +24,7 @@ import { createCliLogger, errorFromUnknown, type ILogger } from "../logger";
 import { createOwnedTempDir } from "../store/owned-temp";
 import { hostHomeDir, hostInstallDir, ensureHostHomeDir } from "../store/paths";
 import { extractHostSource, resolveHostExecutable } from "./extract";
+import { createExtractHeartbeat } from "./extract-heartbeat";
 import { hashFileSha256 } from "./sha256";
 import {
   invalidateAsideDir,
@@ -212,6 +214,12 @@ export async function stageHostInstallSource(
     await extractHostSource({
       source: staging.archivePath,
       targetDir: staging.stagingDir,
+      onEntry: createExtractHeartbeat({
+        environment: opts.environment,
+        archivePath: staging.archivePath,
+        version: staging.version,
+        onProgress: opts.onProgress,
+      }),
     });
     logger.info("Host install archive extracted", {
       environment: opts.environment,
@@ -394,13 +402,18 @@ async function cleanupStagingArtifacts(
   logger: ILogger,
 ): Promise<void> {
   if (opts.archiveIsTemporary) {
-    await rm(opts.archivePath, { force: true }).catch((err) => {
-      logger.warn("Host install failed to remove temporary archive", {
-        environment: opts.environment,
-        errorName: errorFromUnknown(err).name,
-        errorMessage: errorFromUnknown(err).message,
-      });
-    });
+    // `releaseDownloadSlot`, not a bare `rm`: a registry-downloaded
+    // archive lives in the shared download cache and carries an ownership
+    // claim that has to come off with it (registry/download-cache.ts).
+    await releaseDownloadSlot(opts.environment, opts.archivePath).catch(
+      (err) => {
+        logger.warn("Host install failed to remove temporary archive", {
+          environment: opts.environment,
+          errorName: errorFromUnknown(err).name,
+          errorMessage: errorFromUnknown(err).message,
+        });
+      },
+    );
   }
   if (!opts.swapped) {
     await rm(opts.stagingDir, { recursive: true, force: true }).catch((err) => {

--- a/clients/traycer-cli/src/installer/install.ts
+++ b/clients/traycer-cli/src/installer/install.ts
@@ -16,6 +16,7 @@ import {
   createDefaultRegistryClient,
   currentHostPlatformKey,
   releaseDownloadSlot,
+  releaseDownloadSlotOwnership,
 } from "../registry";
 import type { ProgressInfo } from "../runner/output";
 import type { Environment } from "../runner/environment";
@@ -263,7 +264,9 @@ export async function stageHostInstallSource(
     // The owner-tokened temp (and its archive, if separate) is
     // exclusively ours until committed - a thrown extract/resolve must
     // not leak it. Mirrors `discardStagedHostInstallSource`'s cleanup
-    // for the "staged but never committed" case.
+    // for the "staged but never committed" case. The archive itself is
+    // NOT consumed: extraction is exactly what failed, so a retry needs
+    // these same verified bytes.
     await cleanupStagingArtifacts(
       {
         environment: opts.environment,
@@ -271,6 +274,7 @@ export async function stageHostInstallSource(
         archiveIsTemporary: staging.archiveIsTemporary,
         stagingDir: staging.stagingDir,
         swapped: false,
+        archiveConsumed: false,
       },
       logger,
     );
@@ -295,6 +299,9 @@ export async function discardStagedHostInstallSource(
       archiveIsTemporary: staged.archiveIsTemporary,
       stagingDir: staged.stagingDir,
       swapped: false,
+      // Declining to commit is not consuming: `--if-idle` finding the host
+      // busy is a retry-later, and that retry re-stages from the archive.
+      archiveConsumed: false,
     },
     logger,
   );
@@ -379,6 +386,10 @@ export async function commitHostInstallSource(
         archiveIsTemporary: opts.staged.archiveIsTemporary,
         stagingDir: opts.staged.stagingDir,
         swapped,
+        // The swap is the moment the archive's contents become the install,
+        // so it is also the moment the archive stops being worth keeping. A
+        // commit that threw before it leaves a retry to re-stage.
+        archiveConsumed: swapped,
       },
       logger,
     );
@@ -398,22 +409,33 @@ async function cleanupStagingArtifacts(
     readonly archiveIsTemporary: boolean;
     readonly stagingDir: string;
     readonly swapped: boolean;
+    // Whether this install is finished with the archive. False on every
+    // path that could still be retried - see the two release calls below.
+    readonly archiveConsumed: boolean;
   },
   logger: ILogger,
 ): Promise<void> {
   if (opts.archiveIsTemporary) {
-    // `releaseDownloadSlot`, not a bare `rm`: a registry-downloaded
-    // archive lives in the shared download cache and carries an ownership
-    // claim that has to come off with it (registry/download-cache.ts).
-    await releaseDownloadSlot(opts.environment, opts.archivePath).catch(
-      (err) => {
-        logger.warn("Host install failed to remove temporary archive", {
-          environment: opts.environment,
-          errorName: errorFromUnknown(err).name,
-          errorMessage: errorFromUnknown(err).message,
-        });
-      },
-    );
+    // Neither branch may be a bare `rm`: a registry-downloaded archive
+    // lives in the shared download cache and carries an ownership claim
+    // that has to come off with it (registry/download-cache.ts).
+    const release = opts.archiveConsumed
+      ? // Installed, so the archive has done its job - drop it and the claim.
+        releaseDownloadSlot
+      : // Staging failed, or the caller chose not to commit. The bytes are
+        // already sha256- and minisign-verified, and a retry re-runs
+        // extraction against this same archive, so discarding them here
+        // forces a fresh ~800MB transfer that cannot yield anything
+        // different. Drop only the claim and let the next run resume it.
+        releaseDownloadSlotOwnership;
+    await release(opts.environment, opts.archivePath).catch((err) => {
+      logger.warn("Host install failed to release temporary archive", {
+        environment: opts.environment,
+        archiveConsumed: opts.archiveConsumed,
+        errorName: errorFromUnknown(err).name,
+        errorMessage: errorFromUnknown(err).message,
+      });
+    });
   }
   if (!opts.swapped) {
     await rm(opts.stagingDir, { recursive: true, force: true }).catch((err) => {

--- a/clients/traycer-cli/src/registry/__tests__/client.test.ts
+++ b/clients/traycer-cli/src/registry/__tests__/client.test.ts
@@ -1,4 +1,11 @@
-import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -13,7 +20,7 @@ import {
 } from "vitest";
 import { createRegistryClient } from "../client";
 import type { RegistryTransport } from "../client";
-import { CliError } from "../../runner/errors";
+import { CLI_ERROR_CODES, CliError, cliError } from "../../runner/errors";
 import {
   closeFaultServer,
   sha256,
@@ -40,6 +47,25 @@ vi.mock("../../logger", () => ({
 vi.mock("../manifest-url", () => ({
   resolveManifestUrl: () => ({ url: manifestUrlMock.url }),
 }));
+
+// `downloadAndVerify` now stages the archive in the download cache under
+// the host home (registry/download-cache.ts) instead of a throwaway
+// `mkdtemp`. Redirect just that directory into the suite's own tmp root so
+// a test run never touches the developer's real ~/.traycer.
+vi.mock("../../store/paths", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../store/paths")>(
+      "../../store/paths",
+    );
+  const cacheDir = (): string => join(tmpRoot, "download-cache");
+  return {
+    ...actual,
+    hostDownloadCacheDir: () => cacheDir(),
+    ensureHostDownloadCacheDir: async () => {
+      mkdirSync(cacheDir(), { recursive: true });
+    },
+  };
+});
 
 // Smoke-level test that wires the client end-to-end against a fake
 // transport so we can assert manifest parsing, version resolution,
@@ -333,6 +359,139 @@ describe("registry client", () => {
     expect(progress).toContainEqual({
       stage: "registry-manifest-watchdog",
       message: "fetching manifest stalled; retrying",
+    });
+  });
+
+  it("keeps a verified archive when only the signature fetch fails", async () => {
+    // The bytes are complete and already sha256-verified against the
+    // manifest; the sub-1KB `.minisig` fetch is what failed, and it gives up
+    // after four attempts. Deleting a 700MB verified archive over that
+    // reproduced the reported never-finishes loop on a throttled link.
+    let archivePath = "";
+    const client = await createRegistryClient({
+      environment: "production",
+      transport: {
+        fetchText: async ({ url }) => {
+          if (url.endsWith(".minisig")) {
+            throw cliError({
+              code: CLI_ERROR_CODES.REGISTRY_UNAVAILABLE,
+              message: "signature fetch failed",
+              details: null,
+              exitCode: 1,
+            });
+          }
+          return MANIFEST_BODY;
+        },
+        downloadToFile: async (opts) => {
+          archivePath = opts.destPath;
+          writeFileSync(opts.destPath, Buffer.alloc(opts.expectedSizeBytes));
+          return {
+            downloadedBytes: opts.expectedSizeBytes,
+            sha256: opts.expectedSha256,
+          };
+        },
+      },
+      onProgress: null,
+      requireTrustedKeys: false,
+    });
+    const { entry, asset } = await client.resolveAsset(
+      "latest",
+      "darwin-arm64",
+    );
+
+    await expect(
+      client.downloadAndVerify(entry, asset, () => undefined),
+    ).rejects.toMatchObject({ code: "E_REGISTRY_UNAVAILABLE" });
+
+    expect(existsSync(archivePath)).toBe(true);
+    // The claim comes off so the next invocation can pick the archive up and
+    // re-verify it over a single 416 round-trip.
+    expect(existsSync(`${archivePath}.owner`)).toBe(false);
+  });
+
+  it("discards an archive the trust chain rejected", async () => {
+    // The contrast to the case above: a signature that does not check out
+    // condemns the bytes, and re-running would only reproduce the verdict.
+    let archivePath = "";
+    const client = await createRegistryClient({
+      environment: "production",
+      transport: {
+        fetchText: async ({ url }) =>
+          url.endsWith(".minisig") ? "not-a-signature" : MANIFEST_BODY,
+        downloadToFile: async (opts) => {
+          archivePath = opts.destPath;
+          writeFileSync(opts.destPath, Buffer.alloc(opts.expectedSizeBytes));
+          return {
+            downloadedBytes: opts.expectedSizeBytes,
+            sha256: opts.expectedSha256,
+          };
+        },
+      },
+      onProgress: null,
+      requireTrustedKeys: false,
+    });
+    const { entry, asset } = await client.resolveAsset(
+      "latest",
+      "darwin-arm64",
+    );
+
+    await expect(
+      client.downloadAndVerify(entry, asset, () => undefined),
+    ).rejects.toMatchObject({ code: "E_HOST_VERIFY_FAILED" });
+
+    expect(existsSync(archivePath)).toBe(false);
+    expect(existsSync(`${archivePath}.owner`)).toBe(false);
+  });
+
+  it("quotes an attempt ceiling only when one actually binds", async () => {
+    // `fetchText` gives up after 4 attempts, so "attempt 1/4" is a real
+    // countdown. An archive download is bounded by consecutive stalls
+    // instead - its attempt counter has a runaway guard, not a budget, and
+    // quoting "attempt 1/200" would describe a countdown that is not
+    // running.
+    const progress: Array<{ stage: string; message: string }> = [];
+    const client = await createRegistryClient({
+      environment: "production",
+      transport: {
+        fetchText: async ({ onHeartbeat }) => {
+          onHeartbeat?.({ phase: "attempt", attempt: 1, maxAttempts: 4 });
+          return MANIFEST_BODY;
+        },
+        downloadToFile: async (opts) => {
+          opts.onHeartbeat?.({
+            phase: "attempt",
+            attempt: 41,
+            maxAttempts: null,
+          });
+          writeFileSync(opts.destPath, Buffer.alloc(opts.expectedSizeBytes));
+          return {
+            downloadedBytes: opts.expectedSizeBytes,
+            sha256: opts.expectedSha256,
+          };
+        },
+      },
+      onProgress: (event) => {
+        if (event.message !== null) {
+          progress.push({ stage: event.stage, message: event.message });
+        }
+      },
+      requireTrustedKeys: false,
+    });
+    const { entry, asset } = await client.resolveAsset(
+      "latest",
+      "darwin-arm64",
+    );
+    await expect(
+      client.downloadAndVerify(entry, asset, () => undefined),
+    ).rejects.toThrow();
+
+    expect(progress).toContainEqual({
+      stage: "registry-manifest-attempt",
+      message: "fetching manifest (attempt 1/4)",
+    });
+    expect(progress).toContainEqual({
+      stage: "registry-archive-attempt",
+      message: "fetching host archive (attempt 41)",
     });
   });
 

--- a/clients/traycer-cli/src/registry/__tests__/download-cache.test.ts
+++ b/clients/traycer-cli/src/registry/__tests__/download-cache.test.ts
@@ -315,6 +315,28 @@ describe("acquireDownloadSlot", () => {
     expect(basename(slot.archivePath)).not.toMatch(/[/\\]/);
     expect(basename(slot.archivePath)).not.toContain("..");
   });
+
+  it("keeps a publisher basename out of the reserved bookkeeping suffixes", async () => {
+    // `sanitizeSegment` preserves `.` and `-`, so a published asset named
+    // `…owner` / `…break` would otherwise produce a slot file the sweep
+    // mistakes for its own bookkeeping: `readMarkerRaw` would read a
+    // multi-hundred-MB partial into a string, a `.break` name would never be
+    // reclaimed, and the marker for a neighbouring slot would resolve onto
+    // the archive itself.
+    for (const hostile of ["host.owner", "host.break"]) {
+      const slot = await acquireDownloadSlot({
+        ...SLOT,
+        version: `1.0.0-${hostile}`,
+        urlBasename: hostile,
+      });
+      const name = basename(slot.archivePath);
+      expect(name.endsWith(".owner")).toBe(false);
+      expect(name.endsWith(".break")).toBe(false);
+      // Still recognizable - the fold swaps the separator, it does not
+      // discard the publisher's name.
+      expect(name).toContain(hostile.replace(".", "-"));
+    }
+  });
 });
 
 describe("releaseDownloadSlot", () => {

--- a/clients/traycer-cli/src/registry/__tests__/download-cache.test.ts
+++ b/clients/traycer-cli/src/registry/__tests__/download-cache.test.ts
@@ -1,0 +1,394 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let sandboxRoot = "";
+
+vi.mock("../../logger", () => ({
+  createCliLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+  errorFromUnknown: (value: unknown) =>
+    value instanceof Error ? value : new Error(String(value)),
+}));
+
+vi.mock("../../store/paths", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../store/paths")>(
+      "../../store/paths",
+    );
+  type Environment = "dev" | "production";
+  const cacheDirFor = (environment: Environment): string =>
+    join(sandboxRoot, "host", environment, "download-cache");
+  return {
+    ...actual,
+    hostDownloadCacheDir: (environment: Environment) =>
+      cacheDirFor(environment),
+    ensureHostDownloadCacheDir: async (environment: Environment) => {
+      mkdirSync(cacheDirFor(environment), { recursive: true });
+    },
+  };
+});
+
+import {
+  acquireDownloadSlot,
+  refreshDownloadSlotClaim,
+  releaseDownloadSlot,
+  releaseDownloadSlotOwnership,
+} from "../download-cache";
+
+// Comfortably past `UNIDENTIFIED_OWNER_IDLE_TAKEOVER_MS` (15 minutes).
+const IDLE_PAST_TAKEOVER_MS = 20 * 60 * 1000;
+// Short enough that an entry touched this recently is still "being worked
+// on" under the same rule.
+const IDLE_WITHIN_TAKEOVER_MS = 60 * 1000;
+// Past `BREAK_MARKER_GRACE_MS` (30s), so the sub-lock looks abandoned on age
+// alone - which must not be enough to take it.
+const BREAK_MARKER_AGED_MS = 60 * 1000;
+
+const SLOT = {
+  environment: "production" as const,
+  version: "1.5.0",
+  sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  urlBasename: "traycer-host-windows-x64.zip",
+};
+
+function cacheDir(): string {
+  return join(sandboxRoot, "host", "production", "download-cache");
+}
+
+function ageFile(path: string, ms: number): void {
+  const old = new Date(Date.now() - ms);
+  utimesSync(path, old, old);
+}
+
+// A pid that is provably not running, so `verifyProcessIdentity` returns
+// "dead" rather than "indeterminate" - the SIGKILLed-previous-invocation
+// case. `startedAtMs: null` would only ever be "indeterminate".
+function writeDeadOwner(ownerPath: string): void {
+  writeFileSync(
+    ownerPath,
+    JSON.stringify({ pid: 0x7fffffff, startedAtMs: Date.now() }),
+    "utf8",
+  );
+}
+
+beforeEach(() => {
+  sandboxRoot = mkdtempSync(join(tmpdir(), "traycer-download-cache-test-"));
+});
+
+afterEach(() => {
+  rmSync(sandboxRoot, { recursive: true, force: true });
+});
+
+describe("acquireDownloadSlot", () => {
+  it("resolves the same path for the same version+sha across invocations", async () => {
+    const first = await acquireDownloadSlot(SLOT);
+    await releaseDownloadSlotOwnership("production", first.archivePath);
+    const second = await acquireDownloadSlot(SLOT);
+
+    expect(second.archivePath).toBe(first.archivePath);
+    expect(second.resumable).toBe(true);
+    expect(dirname(first.archivePath)).toBe(cacheDir());
+  });
+
+  it("takes over a slot whose owner is gone, keeping the partial bytes", async () => {
+    // The reported failure: Desktop SIGKILLs the CLI mid-download, so the
+    // marker outlives its process. The next invocation must inherit the
+    // partial, not delete it.
+    const slot = await acquireDownloadSlot(SLOT);
+    writeFileSync(slot.archivePath, "partial-bytes", "utf8");
+    writeDeadOwner(`${slot.archivePath}.owner`);
+
+    const reacquired = await acquireDownloadSlot(SLOT);
+
+    expect(reacquired.archivePath).toBe(slot.archivePath);
+    expect(reacquired.resumable).toBe(true);
+    expect(readFileSync(slot.archivePath, "utf8")).toBe("partial-bytes");
+    expect(JSON.parse(readFileSync(`${slot.archivePath}.owner`, "utf8")).pid) //
+      .toBe(process.pid);
+  });
+
+  it("hands out a private path while a live process holds the slot", async () => {
+    // Two writers appending to one file would corrupt both, so the second
+    // caller trades cross-process resume for a path of its own.
+    const held = await acquireDownloadSlot(SLOT);
+    writeFileSync(held.archivePath, "held", "utf8");
+
+    const other = await acquireDownloadSlot(SLOT);
+
+    expect(other.resumable).toBe(false);
+    expect(other.archivePath).not.toBe(held.archivePath);
+    expect(dirname(other.archivePath)).toMatch(/private-/);
+    expect(readFileSync(held.archivePath, "utf8")).toBe("held");
+  });
+
+  it("keeps a superseded version's partial only while its owner lives", async () => {
+    const stale = await acquireDownloadSlot({ ...SLOT, version: "1.4.0" });
+    writeFileSync(stale.archivePath, "old-partial", "utf8");
+    const live = await acquireDownloadSlot({ ...SLOT, version: "1.4.1" });
+    writeFileSync(live.archivePath, "live-partial", "utf8");
+    writeDeadOwner(`${stale.archivePath}.owner`);
+
+    const current = await acquireDownloadSlot(SLOT);
+
+    expect(existsSync(stale.archivePath)).toBe(false);
+    expect(existsSync(`${stale.archivePath}.owner`)).toBe(false);
+    // Still owned by this (live) process - never swept out from under it.
+    expect(existsSync(live.archivePath)).toBe(true);
+    expect(existsSync(current.archivePath)).toBe(false);
+  });
+
+  it("sweeps an unowned leftover but spares an unidentifiable one until it goes idle", async () => {
+    mkdirSync(cacheDir(), { recursive: true });
+    const orphan = join(cacheDir(), "1.0.0-deadbeefdeadbeef-host.zip");
+    writeFileSync(orphan, "orphan", "utf8");
+    const unverifiable = join(cacheDir(), "1.0.1-deadbeefdeadbeef-host.zip");
+    writeFileSync(unverifiable, "unverifiable", "utf8");
+    // A marker that cannot be parsed is not positive evidence of anything,
+    // so the idle rule - not the identity rule - decides.
+    writeFileSync(`${unverifiable}.owner`, "{not json", "utf8");
+
+    await acquireDownloadSlot(SLOT);
+
+    expect(existsSync(orphan)).toBe(false);
+    expect(existsSync(unverifiable)).toBe(true);
+
+    // An old marker beside an archive that is still GROWING is a live
+    // downloader mid-transfer, not litter: the newest mtime across the pair
+    // is what decides, so this must still be spared.
+    ageFile(`${unverifiable}.owner`, IDLE_PAST_TAKEOVER_MS);
+    ageFile(unverifiable, IDLE_WITHIN_TAKEOVER_MS);
+    await acquireDownloadSlot({ ...SLOT, version: "1.6.0" });
+
+    expect(existsSync(unverifiable)).toBe(true);
+
+    // Nothing has touched either one for longer than the takeover window.
+    ageFile(unverifiable, IDLE_PAST_TAKEOVER_MS);
+    await acquireDownloadSlot({ ...SLOT, version: "1.7.0" });
+
+    expect(existsSync(unverifiable)).toBe(false);
+    expect(existsSync(`${unverifiable}.owner`)).toBe(false);
+  });
+
+  it("hands the slot to exactly one of two processes racing the same stale marker", async () => {
+    // Proving a marker stale is not the same as being allowed to replace it.
+    // Two contenders reach the same conclusion about the same marker, and
+    // the gap between deciding and acting spans a `ps`/`tasklist` probe - if
+    // both then win, both append to one file and the partial stops being a
+    // prefix of the archive.
+    const slot = await acquireDownloadSlot(SLOT);
+    writeFileSync(slot.archivePath, "partial-bytes", "utf8");
+    writeDeadOwner(`${slot.archivePath}.owner`);
+
+    const [first, second] = await Promise.all([
+      acquireDownloadSlot(SLOT),
+      acquireDownloadSlot(SLOT),
+    ]);
+
+    expect([first.resumable, second.resumable].filter(Boolean)).toHaveLength(1);
+    const winner = first.resumable ? first : second;
+    const loser = first.resumable ? second : first;
+    expect(winner.archivePath).toBe(slot.archivePath);
+    expect(readFileSync(slot.archivePath, "utf8")).toBe("partial-bytes");
+    expect(dirname(loser.archivePath)).toMatch(/private-/);
+    // The break sub-lock is transient - it must not be left behind to wedge
+    // every future takeover of this slot.
+    expect(existsSync(`${slot.archivePath}.owner.break`)).toBe(false);
+  });
+
+  it("declines to steal the break sub-lock from a breaker that is still alive", async () => {
+    // Another process is mid-takeover of this slot. Its sub-lock is old
+    // enough to look abandoned, but its recorded identity does not say it
+    // crashed - and age alone is not evidence. Stealing it would put two
+    // processes in the critical section at once, and the descheduled one's
+    // unlink would then land on the marker the other just wrote for itself,
+    // leaving both appending to one archive.
+    const slot = await acquireDownloadSlot(SLOT);
+    writeFileSync(slot.archivePath, "partial-bytes", "utf8");
+    writeDeadOwner(`${slot.archivePath}.owner`);
+    const breakPath = `${slot.archivePath}.owner.break`;
+    writeFileSync(
+      breakPath,
+      JSON.stringify({
+        pid: process.pid,
+        startedAtMs: null,
+        nonce: "held-by-someone-else",
+      }),
+      "utf8",
+    );
+    ageFile(breakPath, BREAK_MARKER_AGED_MS);
+
+    const contender = await acquireDownloadSlot(SLOT);
+
+    expect(contender.resumable).toBe(false);
+    // The sub-lock and the partial both survive untouched.
+    expect(readFileSync(breakPath, "utf8")).toContain("held-by-someone-else");
+    expect(readFileSync(slot.archivePath, "utf8")).toBe("partial-bytes");
+  });
+
+  it("refreshing the claim keeps an unidentifiable owner's slot from being taken over", async () => {
+    // Everything after the transfer - hashing, signature verification, and
+    // above all the caller's extract - only READS the archive, so its mtime
+    // stops advancing while the slot is still legitimately held. The refresh
+    // is what keeps the idle rule from handing the slot away mid-extract.
+    const slot = await acquireDownloadSlot(SLOT);
+    writeFileSync(slot.archivePath, "partial-bytes", "utf8");
+    writeFileSync(
+      `${slot.archivePath}.owner`,
+      JSON.stringify({ pid: process.pid, startedAtMs: null }),
+      "utf8",
+    );
+    ageFile(`${slot.archivePath}.owner`, IDLE_PAST_TAKEOVER_MS);
+    ageFile(slot.archivePath, IDLE_PAST_TAKEOVER_MS);
+
+    await refreshDownloadSlotClaim("production", slot.archivePath);
+
+    expect((await acquireDownloadSlot(SLOT)).resumable).toBe(false);
+  });
+
+  it("takes over a slot whose owner cannot be identified once it goes idle", async () => {
+    // Where the liveness probe itself is unavailable - a locked-down Windows
+    // with no usable `tasklist` - every verdict is "indeterminate". Identity
+    // alone would then pin the slot indefinitely and silently turn
+    // cross-process resume back off, which is the behaviour being fixed.
+    const slot = await acquireDownloadSlot(SLOT);
+    writeFileSync(slot.archivePath, "partial-bytes", "utf8");
+    writeFileSync(
+      `${slot.archivePath}.owner`,
+      // Alive pid, unknowable start time -> "indeterminate".
+      JSON.stringify({ pid: process.pid, startedAtMs: null }),
+      "utf8",
+    );
+
+    // Still being written to, so it is not up for grabs yet.
+    expect((await acquireDownloadSlot(SLOT)).resumable).toBe(false);
+
+    ageFile(`${slot.archivePath}.owner`, IDLE_PAST_TAKEOVER_MS);
+    ageFile(slot.archivePath, IDLE_PAST_TAKEOVER_MS);
+    const takenOver = await acquireDownloadSlot(SLOT);
+
+    expect(takenOver.resumable).toBe(true);
+    expect(takenOver.archivePath).toBe(slot.archivePath);
+    expect(readFileSync(slot.archivePath, "utf8")).toBe("partial-bytes");
+  });
+
+  it("spares a private slot whose claim exists before its directory", async () => {
+    // The window `createPrivateSlot` closes by claiming first: mid-creation
+    // the marker exists and the directory does not, and a concurrent sweep
+    // must read that as a claim to respect rather than an unowned entry to
+    // remove.
+    const held = await acquireDownloadSlot(SLOT);
+    writeFileSync(held.archivePath, "held", "utf8");
+    const priv = await acquireDownloadSlot(SLOT);
+    const privateDir = dirname(priv.archivePath);
+    rmSync(privateDir, { recursive: true, force: true });
+
+    await acquireDownloadSlot({ ...SLOT, version: "9.9.9" });
+
+    expect(existsSync(`${privateDir}.owner`)).toBe(true);
+  });
+
+  it("folds a hostile publisher basename into one safe path segment", async () => {
+    const slot = await acquireDownloadSlot({
+      ...SLOT,
+      urlBasename: "../../../etc/passwd",
+    });
+
+    // The publisher-controlled segment can never contribute a separator or
+    // a parent-dir hop: whatever it contained, the archive resolves to one
+    // plain entry directly inside the cache dir.
+    expect(dirname(slot.archivePath)).toBe(cacheDir());
+    expect(basename(slot.archivePath)).not.toMatch(/[/\\]/);
+    expect(basename(slot.archivePath)).not.toContain("..");
+  });
+});
+
+describe("releaseDownloadSlot", () => {
+  it("drops the archive and the claim once the caller has consumed it", async () => {
+    const slot = await acquireDownloadSlot(SLOT);
+    writeFileSync(slot.archivePath, "verified", "utf8");
+
+    await releaseDownloadSlot("production", slot.archivePath);
+
+    expect(readdirSync(cacheDir())).toEqual([]);
+  });
+
+  it("leaves the slot alone when the claim has changed hands", async () => {
+    // A slot legitimately changes owner while this process holds it - the
+    // idle takeover fires during a long extract. After that the archive and
+    // the marker belong to a fresh holder that is resuming them, so this
+    // process's release must not delete either.
+    const slot = await acquireDownloadSlot(SLOT);
+    writeFileSync(slot.archivePath, "verified", "utf8");
+    writeFileSync(
+      `${slot.archivePath}.owner`,
+      JSON.stringify({ pid: 0x7ffffffe, startedAtMs: Date.now() }),
+      "utf8",
+    );
+
+    await releaseDownloadSlot("production", slot.archivePath);
+
+    expect(existsSync(slot.archivePath)).toBe(true);
+    expect(existsSync(`${slot.archivePath}.owner`)).toBe(true);
+  });
+
+  it("escalates to a recursive remove only for a private slot inside the cache", async () => {
+    // Exported and called for any archive the installer considers temporary,
+    // including archives this module never created. Deciding "this is a
+    // private slot, remove its whole directory" from the parent's NAME alone
+    // would let such an archive aim an `rm -rf` at its own parent.
+    const outside = join(sandboxRoot, "elsewhere", "private-not-ours");
+    mkdirSync(outside, { recursive: true });
+    const archive = join(outside, "host.zip");
+    writeFileSync(archive, "archive", "utf8");
+    writeFileSync(
+      `${archive}.owner`,
+      JSON.stringify({ pid: process.pid, startedAtMs: null }),
+      "utf8",
+    );
+    const sibling = join(outside, "keep-me.txt");
+    writeFileSync(sibling, "keep", "utf8");
+
+    await releaseDownloadSlot("production", archive);
+
+    expect(existsSync(archive)).toBe(false);
+    expect(existsSync(sibling)).toBe(true);
+    expect(existsSync(outside)).toBe(true);
+  });
+
+  it("keeps the partial but drops the claim when only ownership is released", async () => {
+    const slot = await acquireDownloadSlot(SLOT);
+    writeFileSync(slot.archivePath, "partial", "utf8");
+
+    await releaseDownloadSlotOwnership("production", slot.archivePath);
+
+    expect(readFileSync(slot.archivePath, "utf8")).toBe("partial");
+    expect(existsSync(`${slot.archivePath}.owner`)).toBe(false);
+  });
+
+  it("removes the whole private directory, never the shared cache dir", async () => {
+    const held = await acquireDownloadSlot(SLOT);
+    const priv = await acquireDownloadSlot(SLOT);
+    writeFileSync(priv.archivePath, "private", "utf8");
+
+    await releaseDownloadSlot("production", priv.archivePath);
+
+    expect(existsSync(dirname(priv.archivePath))).toBe(false);
+    expect(existsSync(cacheDir())).toBe(true);
+    expect(existsSync(`${held.archivePath}.owner`)).toBe(true);
+  });
+});

--- a/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
+++ b/clients/traycer-cli/src/registry/__tests__/fetch-resource.test.ts
@@ -221,7 +221,7 @@ describe("downloadToFile resume and integrity policy", () => {
   );
 
   it(
-    "restarts from zero when the failed response had no validator",
+    "resumes with a bare Range when the failed response had no validator",
     async () => {
       const destPath = join(workDir, "no-validator.tar.gz");
       const requests: Request[] = [];
@@ -231,16 +231,284 @@ describe("downloadToFile resume and integrity policy", () => {
         call += 1;
         return call === 1
           ? response(failingBody("abc", "transient stream failure"), 200, {})
-          : response("abcdef", 200, {});
+          : response("def", 206, { "content-range": "bytes 3-5/6" });
       }) as typeof globalThis.fetch;
 
       const pending = downloadToFile(downloadOptions(destPath, "abcdef"));
       await settleRetryTimers(pending);
 
       expect(requests).toHaveLength(2);
-      expect(requests[1]?.headers.get("range")).toBeNull();
+      expect(requests[1]?.headers.get("range")).toBe("bytes=3-");
       expect(requests[1]?.headers.get("if-range")).toBeNull();
       expect(readFileSync(destPath, "utf8")).toBe("abcdef");
+    },
+    SETTLE_RETRY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "resumes a partial left behind by a previous process",
+    async () => {
+      // The cross-invocation case (traycer#588): a fresh downloader sees
+      // bytes on disk and no validator for them - it must put the offset on
+      // the wire, not delete the file before the first request.
+      const destPath = join(workDir, "prior-process.tar.gz");
+      writeFileSync(destPath, "abc");
+      const requests: Request[] = [];
+      globalThis.fetch = vi.fn(async (input, init) => {
+        requests.push(new Request(input, init));
+        return response("def", 206, { "content-range": "bytes 3-5/6" });
+      }) as typeof globalThis.fetch;
+
+      const result = await settleRetryTimers(
+        downloadToFile(downloadOptions(destPath, "abcdef")),
+      );
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.headers.get("range")).toBe("bytes=3-");
+      expect(requests[0]?.headers.get("if-range")).toBeNull();
+      expect(result).toEqual({ downloadedBytes: 6, sha256: sha256("abcdef") });
+      expect(readFileSync(destPath, "utf8")).toBe("abcdef");
+    },
+    SETTLE_RETRY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "reports the resumed offset before the attempt's first byte arrives",
+    async () => {
+      // Desktop carries the last concrete progress value forward, but a
+      // freshly spawned process has no prior value to carry. A resumed
+      // download that stays silent until its first chunk therefore renders
+      // no progress bar at all while a large partial sits on disk - the
+      // resume itself becomes invisible, which reads as "it started over".
+      // The offset has to be published before the request goes out.
+      const destPath = join(workDir, "resume-progress.tar.gz");
+      writeFileSync(destPath, "abc");
+      const opts = downloadOptions(destPath, "abcdef");
+      let progressTicksWhenRequestIssued = -1;
+      globalThis.fetch = vi.fn(async () => {
+        progressTicksWhenRequestIssued = opts.onProgress.mock.calls.length;
+        return response("def", 206, { "content-range": "bytes 3-5/6" });
+      }) as typeof globalThis.fetch;
+
+      await settleRetryTimers(downloadToFile(opts));
+
+      expect(opts.onProgress.mock.calls[0]?.[0]).toEqual({
+        downloadedBytes: 3,
+        totalBytes: 6,
+      });
+      // Published by the time the request was issued, so it is the partial
+      // being reported rather than a byte of the new response.
+      expect(progressTicksWhenRequestIssued).toBe(1);
+    },
+    SETTLE_RETRY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "reports the rewind when a resume is forced to restart from zero",
+    async () => {
+      // An origin that answers 200 to a Range makes the downloader discard
+      // the partial. The offset tick at the top of the next attempt is what
+      // moves the bar back to 0 immediately; without it the bar would hold
+      // the stale pre-restart percentage until the next chunk landed.
+      const destPath = join(workDir, "restart-progress.tar.gz");
+      writeFileSync(destPath, "abc");
+      const opts = downloadOptions(destPath, "abcdef");
+      globalThis.fetch = vi.fn(async () =>
+        response("abcdef", 200, {}),
+      ) as typeof globalThis.fetch;
+
+      await settleRetryTimers(downloadToFile(opts));
+
+      const reported = opts.onProgress.mock.calls.map(
+        (call) => call[0].downloadedBytes,
+      );
+      expect(reported[0]).toBe(3);
+      expect(reported[1]).toBe(0);
+      expect(readFileSync(destPath, "utf8")).toBe("abcdef");
+    },
+    SETTLE_RETRY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "resumes a body that ends short without raising a stream error",
+    async () => {
+      // Not every truncation surfaces as a stream error: bun's fetch
+      // reports some mid-body connection drops as a clean end-of-stream,
+      // and a response without a usable length can end short on any
+      // runtime. Trusting `done` alone let a truncated transfer be reported
+      // as a finished download, so the size check failed terminally and
+      // took the partial with it - traycer#585's "downloaded 231 MB of
+      // 721 MB before failure". A short body must stay a retryable
+      // transfer failure that the next attempt resumes.
+      const destPath = join(workDir, "short-clean-eof.tar.gz");
+      const requests: Request[] = [];
+      let call = 0;
+      globalThis.fetch = vi.fn(async (input, init) => {
+        requests.push(new Request(input, init));
+        call += 1;
+        // Ends cleanly after 3 of 6 bytes - no error on the stream.
+        return call === 1
+          ? response("abc", 200, { etag: '"etag-1"' })
+          : response("def", 206, { "content-range": "bytes 3-5/6" });
+      }) as typeof globalThis.fetch;
+
+      const result = await settleRetryTimers(
+        downloadToFile(downloadOptions(destPath, "abcdef")),
+      );
+
+      expect(requests).toHaveLength(2);
+      expect(requests[1]?.headers.get("range")).toBe("bytes=3-");
+      expect(result).toEqual({ downloadedBytes: 6, sha256: sha256("abcdef") });
+      expect(readFileSync(destPath, "utf8")).toBe("abcdef");
+    },
+    SETTLE_RETRY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps going after a forced restart as long as every attempt transfers",
+    async () => {
+      // One Range-ignoring hop (a CDN edge, a corporate proxy) forces a
+      // restart from zero mid-resume. Everything after it makes real forward
+      // progress and must be allowed to finish. Judging that progress against
+      // a high-water mark left over from BEFORE the restart made it
+      // unreachable, so a 700MB resume gave up inside six attempts while
+      // genuinely transferring on every one of them.
+      const destPath = join(workDir, "restart-then-progress.tar.gz");
+      // The pre-restart partial has to sit far enough above what the post-
+      // restart dribble can reach inside the stall budget, or the download
+      // escapes the stale mark by accident and the regression hides: 30 of 40
+      // bytes already on disk, then 2 bytes per attempt, needs 16 attempts to
+      // climb back past 30 against a budget of 6.
+      const expected = "a".repeat(40);
+      writeFileSync(destPath, "a".repeat(30));
+      let call = 0;
+      globalThis.fetch = vi.fn(async (input, init) => {
+        const request = new Request(input, init);
+        call += 1;
+        // 1: ignores the Range and answers 200 -> partial discarded.
+        if (call === 1) return response(expected, 200, {});
+        // Then two bytes per attempt, each body ending short of its promise
+        // so the attempt stays a retryable transfer failure.
+        const range = request.headers.get("range");
+        const offset =
+          range === null ? 0 : Number(/^bytes=(\d+)-$/.exec(range)?.[1] ?? 0);
+        const slice = expected.slice(offset, offset + 2);
+        return offset === 0
+          ? response(slice, 200, {})
+          : response(slice, 206, {
+              "content-range": `bytes ${offset}-${expected.length - 1}/${expected.length}`,
+            });
+      }) as typeof globalThis.fetch;
+
+      const result = await settleRetryTimers(
+        downloadToFile(downloadOptions(destPath, expected)),
+      );
+
+      expect(result).toEqual({
+        downloadedBytes: expected.length,
+        sha256: sha256(expected),
+      });
+      expect(readFileSync(destPath, "utf8")).toBe(expected);
+    },
+    SETTLE_RETRY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "gives up promptly when the origin's entity is shorter than the manifest declares",
+    async () => {
+      // A truncated publish, or a mirror serving a partial object. Judging
+      // progress against the attempt's own starting offset let this run
+      // forever: the short body looked like progress, the next attempt's
+      // Range past the end took a 416 and restarted from zero, and the one
+      // after that "progressed" over the same bytes again - resetting the
+      // stall counter every other attempt and burning the whole runaway
+      // guard on ~100 complete re-transfers of an archive that can never
+      // verify. Against a high-water mark that only ever rises, re-reading
+      // the same bytes is correctly not progress.
+      const destPath = join(workDir, "short-entity.tar.gz");
+      const requests: Request[] = [];
+      globalThis.fetch = vi.fn(async (input, init) => {
+        const request = new Request(input, init);
+        requests.push(request);
+        // The origin only ever holds 3 of the 6 declared bytes.
+        return request.headers.get("range") === null
+          ? response("abc", 200, { etag: '"short-entity"' })
+          : response(null, 416, { "content-range": "bytes */3" });
+      }) as typeof globalThis.fetch;
+
+      await expect(
+        settleRetryTimers(downloadToFile(downloadOptions(destPath, "abcdef"))),
+      ).rejects.toBeInstanceOf(CliError);
+
+      // Two attempts per stall (a transfer then a 416 restart) plus a little
+      // slack - nowhere near `MAX_DOWNLOAD_ATTEMPTS`.
+      expect(requests.length).toBeLessThanOrEqual(16);
+    },
+    SETTLE_RETRY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "keeps the partial file when the attempt budget is exhausted",
+    async () => {
+      // The next CLI invocation resumes from these bytes. Deleting them is
+      // what made a throttled download restart from zero forever.
+      const destPath = join(workDir, "exhausted.tar.gz");
+      let call = 0;
+      globalThis.fetch = vi.fn(async () => {
+        call += 1;
+        // One byte per attempt, then a reset: never completes, and each
+        // attempt is a stall (no forward progress) after the first.
+        return call === 1
+          ? response(failingBody("abc", "reset"), 200, { etag: '"etag-1"' })
+          : response(null, 500, {});
+      }) as typeof globalThis.fetch;
+
+      await expect(
+        settleRetryTimers(downloadToFile(downloadOptions(destPath, "abcdef"))),
+      ).rejects.toBeInstanceOf(CliError);
+
+      expect(readFileSync(destPath, "utf8")).toBe("abc");
+    },
+    SETTLE_RETRY_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "spends stall budget only on attempts that made no progress",
+    async () => {
+      // Six resets that each append a byte must not exhaust a budget that a
+      // dead endpoint burns in six attempts - forward progress is what buys
+      // the next round (traycer#589).
+      const destPath = join(workDir, "progress-budget.tar.gz");
+      const payload = "abcdefghij";
+      let call = 0;
+      globalThis.fetch = vi.fn(async (_input, _init) => {
+        call += 1;
+        if (call > payload.length) {
+          throw new Error(`unexpected attempt ${call}`);
+        }
+        const next = payload.slice(call - 1, call);
+        return call === payload.length
+          ? response(next, 206, {
+              "content-range": `bytes ${call - 1}-${call - 1}/${payload.length}`,
+            })
+          : response(
+              failingBody(next, "reset after one byte"),
+              call === 1 ? 200 : 206,
+              call === 1
+                ? {}
+                : {
+                    "content-range": `bytes ${call - 1}-${payload.length - 1}/${payload.length}`,
+                  },
+            );
+      }) as typeof globalThis.fetch;
+
+      const result = await settleRetryTimers(
+        downloadToFile(downloadOptions(destPath, payload)),
+      );
+
+      expect(call).toBe(payload.length);
+      expect(result.sha256).toBe(sha256(payload));
+      expect(readFileSync(destPath, "utf8")).toBe(payload);
     },
     SETTLE_RETRY_TEST_TIMEOUT_MS,
   );
@@ -471,11 +739,19 @@ describe("downloadToFile resume and integrity policy", () => {
     expect(sawRequest).toBe(true);
     await vi.advanceTimersByTimeAsync(30_000);
     await closeFaultServer(server);
-    for (let attempt = 0; attempt < 4; attempt += 1) {
+    // A blackholed archive never transfers a byte, so every attempt counts
+    // against the stall budget. Drive enough rounds (watchdog + the growing
+    // backoff) for that budget to run out; each iteration advances past the
+    // longest single wait either can impose.
+    let done = false;
+    void outcome.then(() => {
+      done = true;
+    });
+    for (let attempt = 0; attempt < 20 && !done; attempt += 1) {
       await new Promise<void>((resolve) => {
         nativeSetTimeout(resolve, 10);
       });
-      await vi.advanceTimersByTimeAsync(750);
+      await vi.advanceTimersByTimeAsync(30_000);
     }
 
     const settled = await outcome;
@@ -541,8 +817,11 @@ describe("downloadToFile resume and integrity policy", () => {
   );
 
   it(
-    "does not resume a weak ETag without a Last-Modified validator",
+    "never sends a weak ETag as If-Range, but still resumes by offset",
     async () => {
+      // A weak validator cannot certify byte-for-byte identity, so it must
+      // not gate the server's resume decision. The bare Range still goes
+      // out - Content-Range and sha256 are what make that safe.
       const destPath = join(workDir, "weak-etag.tar.gz");
       const requests: Request[] = [];
       let call = 0;
@@ -553,15 +832,16 @@ describe("downloadToFile resume and integrity policy", () => {
           ? response(failingBody("abc", "stream reset"), 200, {
               etag: 'W/"weak-etag"',
             })
-          : response("abcdef", 200, {});
+          : response("def", 206, { "content-range": "bytes 3-5/6" });
       }) as typeof globalThis.fetch;
 
       await settleRetryTimers(
         downloadToFile(downloadOptions(destPath, "abcdef")),
       );
 
-      expect(requests[1]?.headers.get("range")).toBeNull();
+      expect(requests[1]?.headers.get("range")).toBe("bytes=3-");
       expect(requests[1]?.headers.get("if-range")).toBeNull();
+      expect(readFileSync(destPath, "utf8")).toBe("abcdef");
     },
     SETTLE_RETRY_TEST_TIMEOUT_MS,
   );

--- a/clients/traycer-cli/src/registry/client.ts
+++ b/clients/traycer-cli/src/registry/client.ts
@@ -406,11 +406,21 @@ export async function createRegistryClient(
       } finally {
         // On success the caller owns the verified archive until it has
         // extracted it, and releases the slot itself.
+        //
+        // Both releases are `.catch`-guarded. Today neither can reject -
+        // download-cache.ts swallows its own fs errors - but that is its
+        // internal detail, and an unguarded await in a `finally` would let a
+        // future change there replace the error being propagated. Callers
+        // route on `REGISTRY_UNAVAILABLE` vs `HOST_VERIFY_FAILED`; losing
+        // that code to a cleanup failure would turn a retryable download
+        // into an unrecognized one.
         if (!succeeded && transferred && isTrustFailure(failure)) {
           // Complete bytes that the trust chain rejected. Resuming into
           // them would just reproduce the same verdict, so drop the file
           // with the claim.
-          await releaseDownloadSlot(opts.environment, archivePath);
+          await releaseDownloadSlot(opts.environment, archivePath).catch(
+            () => undefined,
+          );
           logger.warn("Registry discarded an unverifiable download", {
             environment: opts.environment,
           });
@@ -422,7 +432,10 @@ export async function createRegistryClient(
           // complete and sha256-verified and only the signature fetch has
           // yet to succeed - the next run re-verifies it over one 416
           // round-trip instead of re-downloading it.
-          await releaseDownloadSlotOwnership(opts.environment, archivePath);
+          await releaseDownloadSlotOwnership(
+            opts.environment,
+            archivePath,
+          ).catch(() => undefined);
           logger.warn("Registry left a resumable download in place", {
             environment: opts.environment,
             transferComplete: transferred,

--- a/clients/traycer-cli/src/registry/client.ts
+++ b/clients/traycer-cli/src/registry/client.ts
@@ -1,10 +1,12 @@
-import { mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import type { Environment } from "../runner/environment";
 import type { ProgressInfo } from "../runner/output";
 import { createCliLogger, errorFromUnknown } from "../logger";
-import { CLI_ERROR_CODES, cliError } from "../runner/errors";
+import { CLI_ERROR_CODES, CliError, cliError } from "../runner/errors";
+import {
+  acquireDownloadSlot,
+  releaseDownloadSlot,
+  releaseDownloadSlotOwnership,
+} from "./download-cache";
 import {
   downloadToFile,
   fetchText,
@@ -312,16 +314,39 @@ export async function createRegistryClient(
           exitCode: 1,
         });
       }
-      const tmpDir = await mkdtemp(join(tmpdir(), "traycer-host-dl-"));
+      // The archive path is stable across CLI invocations (keyed by
+      // version + sha256) so a re-spawned CLI resumes the previous
+      // process's partial file instead of starting from zero - the whole
+      // point of traycer#585/#588. `acquireDownloadSlot` owns the
+      // concurrency + sweep policy for that shared location.
+      const slot = await acquireDownloadSlot({
+        environment: opts.environment,
+        version: entry.version,
+        sha256: asset.sha256,
+        urlBasename: archiveBasenameFromUrl(asset.url),
+      });
+      const archivePath = slot.archivePath;
       logger.debug("Registry download started", {
         environment: opts.environment,
+        resumable: slot.resumable,
       });
-      // Track whether we succeeded so the `finally` block can clean up
-      // the tmpdir on failure. On success the caller (installer) is
-      // responsible for moving the archive out and removing the dir.
+      // The `finally` has to tell three outcomes apart, and it needs BOTH
+      // of these to do it. `transferred` says the bytes are complete and
+      // sha256-verified; `failure` says whether what went wrong afterwards
+      // condemns them.
+      //
+      // Only a TRUST failure condemns an archive: a bad signature, or a
+      // keyId that does not match the manifest. Those reproduce on every
+      // retry, so the file must go. Everything else after the transfer -
+      // above all fetching the sub-1KB `.minisig`, which gives up after
+      // four attempts and would fail routinely on the throttled links this
+      // work exists for - is a transport failure, and deleting a fully
+      // verified 700MB archive because a tiny signature fetch flaked is
+      // exactly the "downloads forever, never finishes" loop being fixed.
       let succeeded = false;
+      let transferred = false;
+      let failure: unknown = null;
       try {
-        const archivePath = join(tmpDir, archiveBasenameFromUrl(asset.url));
         const download = await transport.downloadToFile({
           url: asset.url,
           destPath: archivePath,
@@ -331,6 +356,7 @@ export async function createRegistryClient(
           onHeartbeat: (heartbeat) =>
             emitRegistryHeartbeat(opts.onProgress, "archive", heartbeat),
         });
+        transferred = true;
         const signatureText = await transport.fetchText({
           url: asset.signatureUrl,
           onHeartbeat: (heartbeat) =>
@@ -374,25 +400,32 @@ export async function createRegistryClient(
           signatureKeyId: verifyResult.keyId,
           signatureVerifiedAt: new Date().toISOString(),
         };
+      } catch (err) {
+        failure = err;
+        throw err;
       } finally {
-        // On failure, scrub the tmpdir so we don't leak the partial
-        // archive (downloadToFile aborts on size-cap / stream error
-        // without unlinking) or an empty tmpdir. Best-effort: rm errors
-        // are swallowed so they don't mask the original throw - the
-        // pathological case (rm fails on a tmpdir) leaves at worst the
-        // empty dir behind, which the OS cleans up on reboot anyway.
-        if (!succeeded) {
-          await rm(tmpDir, { recursive: true, force: true }).catch((err) => {
-            logger.warn(
-              "Registry failed to clean temporary download directory",
-              {
-                environment: opts.environment,
-                errorName: errorFromUnknown(err).name,
-              },
-            );
-          });
-          logger.warn("Registry cleaned failed download attempt", {
+        // On success the caller owns the verified archive until it has
+        // extracted it, and releases the slot itself.
+        if (!succeeded && transferred && isTrustFailure(failure)) {
+          // Complete bytes that the trust chain rejected. Resuming into
+          // them would just reproduce the same verdict, so drop the file
+          // with the claim.
+          await releaseDownloadSlot(opts.environment, archivePath);
+          logger.warn("Registry discarded an unverifiable download", {
             environment: opts.environment,
+          });
+        } else if (!succeeded) {
+          // Keep whatever landed on disk and drop only the ownership
+          // claim, so the next invocation resumes it. Covers both a failed
+          // transfer (the case a throttled connection hits over and over)
+          // and a post-transfer transport failure, where the archive is
+          // complete and sha256-verified and only the signature fetch has
+          // yet to succeed - the next run re-verifies it over one 416
+          // round-trip instead of re-downloading it.
+          await releaseDownloadSlotOwnership(opts.environment, archivePath);
+          logger.warn("Registry left a resumable download in place", {
+            environment: opts.environment,
+            transferComplete: transferred,
           });
         }
       }
@@ -484,8 +517,13 @@ function emitRegistryHeartbeat(
     stage: `registry-${resource}-${heartbeat.phase}`,
     message: registryHeartbeatMessage(resourceLabel, heartbeat),
     percent: null,
-    bytes: heartbeat.attempt,
-    totalBytes: heartbeat.maxAttempts,
+    // Attempt counters belong in the message, not in the byte fields. A
+    // heartbeat is a liveness tick, not a transfer measurement: putting
+    // `attempt`/`maxAttempts` here made Desktop's progress bar redraw as
+    // "1 byte of 4" every time a retry fired mid-download. All three
+    // numeric fields stay null so the renderer holds the last real values.
+    bytes: null,
+    totalBytes: null,
   });
 }
 
@@ -494,12 +532,28 @@ function registryHeartbeatMessage(
   heartbeat: NetworkHeartbeat,
 ): string {
   if (heartbeat.phase === "attempt") {
-    return `fetching ${resourceLabel} (attempt ${heartbeat.attempt}/${heartbeat.maxAttempts})`;
+    // No denominator when the counter has no ceiling worth quoting - an
+    // archive download is bounded by consecutive stalls, not by attempts,
+    // so "attempt 41/200" would read as a countdown that is not running.
+    const of =
+      heartbeat.maxAttempts === null ? "" : `/${heartbeat.maxAttempts}`;
+    return `fetching ${resourceLabel} (attempt ${heartbeat.attempt}${of})`;
   }
   if (heartbeat.phase === "watchdog") {
     return `fetching ${resourceLabel} stalled; retrying`;
   }
   return `retrying ${resourceLabel} shortly`;
+}
+
+// Whether a post-transfer failure condemns the bytes on disk. The verify
+// chain reports `HOST_VERIFY_FAILED` for everything that makes an archive
+// untrustworthy (a signature that does not check out, a keyId the manifest
+// does not pin); a network failure fetching the signature reports
+// `REGISTRY_UNAVAILABLE` and says nothing about the archive itself.
+function isTrustFailure(err: unknown): boolean {
+  return (
+    err instanceof CliError && err.code === CLI_ERROR_CODES.HOST_VERIFY_FAILED
+  );
 }
 
 function archiveBasenameFromUrl(url: string): string {

--- a/clients/traycer-cli/src/registry/download-cache.ts
+++ b/clients/traycer-cli/src/registry/download-cache.ts
@@ -46,6 +46,10 @@ import {
 const OWNER_SUFFIX = ".owner";
 const PRIVATE_DIR_PREFIX = "private-";
 const BREAK_SUFFIX = ".break";
+// Every suffix that means something to `sweepDownloadCache`. A slot file name
+// must not end in one - see `foldReservedSuffixes`. Add to this list, not
+// just to the sweep, when introducing a new bookkeeping suffix.
+const RESERVED_SLOT_SUFFIXES: readonly string[] = [OWNER_SUFFIX, BREAK_SUFFIX];
 // A break sub-lock's critical section is a read plus an unlink, so one older
 // than this belongs to a breaker that died mid-section.
 const BREAK_MARKER_GRACE_MS = 30_000;
@@ -272,9 +276,43 @@ function sanitizeBasename(value: string): string {
     // stays boring and greppable.
     .replace(/\.{2,}/g, ".")
     .replace(/^[.]+/, "");
-  return cleaned.length === 0
-    ? "host-archive"
-    : cleaned.slice(0, MAX_SLOT_SEGMENT_LENGTH);
+  const bounded =
+    cleaned.length === 0
+      ? "host-archive"
+      : cleaned.slice(0, MAX_SLOT_SEGMENT_LENGTH);
+  // AFTER the length cap, so a truncation cannot re-expose a suffix the fold
+  // already removed.
+  return foldReservedSuffixes(bounded);
+}
+
+// This module distinguishes an archive from its own bookkeeping purely by
+// suffix, so a slot file must never END in one the sweep would act on.
+// Nothing upstream prevents it: the basename is the manifest URL's last path
+// segment, and `sanitizeSegment` deliberately preserves `.` and `-`, so a
+// published asset named `…owner` or `…break` would land as `<version>-<digest>
+// -x.owner`. Three things break at once if it does:
+//
+//   - `sweepDownloadCache` classifies it as an orphaned marker and hands it
+//     to `readMarkerRaw`, which reads the whole file as UTF-8 - a several
+//     hundred MB partial archive loaded into a string.
+//   - A `.break` name is skipped by the sweep unconditionally, so its
+//     partial is never reclaimed and pins the disk for good.
+//   - `ownerPathFor` of a DIFFERENT slot named `x` resolves to `x.owner`,
+//     which is that archive itself - the marker and the payload collide.
+//
+// Replacing the separating dot keeps the name recognizable while taking it
+// out of the reserved namespace.
+function foldReservedSuffixes(name: string): string {
+  let folded = name;
+  for (;;) {
+    const reserved = RESERVED_SLOT_SUFFIXES.find((suffix) =>
+      folded.endsWith(suffix),
+    );
+    // Terminates: every replacement ends in `-<suffix>`, which no reserved
+    // suffix (each of which starts with `.`) can match.
+    if (reserved === undefined) return folded;
+    folded = `${folded.slice(0, -reserved.length)}-${reserved.slice(1)}`;
+  }
 }
 
 function sanitizeSegment(value: string): string {

--- a/clients/traycer-cli/src/registry/download-cache.ts
+++ b/clients/traycer-cli/src/registry/download-cache.ts
@@ -1,0 +1,665 @@
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { basename, dirname, join, resolve } from "node:path";
+import type { Environment } from "../runner/environment";
+import { createCliLogger, errorFromUnknown, type ILogger } from "../logger";
+import {
+  ensureHostDownloadCacheDir,
+  hostDownloadCacheDir,
+  HOST_DOWNLOAD_CACHE_SUBDIR,
+} from "../store/paths";
+import {
+  currentProcessIdentityToken,
+  verifyProcessIdentityAsync,
+  type ProcessIdentityToken,
+  type ProcessIdentityVerdict,
+} from "../store/process-identity";
+
+// Cross-invocation staging for registry archive downloads (traycer#585,
+// #586, #588).
+//
+// The archive used to land in a fresh `mkdtemp` dir per CLI process, so a
+// re-spawned CLI could never see the previous invocation's partial file:
+// every retry restarted from byte zero, and a 700MB host archive over a
+// link that resets every few MB could never finish. Here the path is
+// DERIVED from the version + sha256 instead, so the next process finds the
+// partial and `downloadToFile` resumes it with a Range request.
+//
+// A predictable path means two CLI processes could otherwise append to the
+// same file concurrently (`host download` runs its transfer phase outside
+// the cli-lock, and nothing stops a user running `traycer host install` in
+// a terminal while Desktop's download lane is mid-flight). Every entry is
+// therefore claimed with an owner marker holding the claimant's process
+// identity - the same pid + start-time token `install-staging/`'s temp dirs
+// use. A live owner makes the caller fall back to a private, unshared path
+// (correct, just without cross-process resume); a dead owner - the SIGKILL
+// case this whole change exists for - is taken over and resumed.
+
+const OWNER_SUFFIX = ".owner";
+const PRIVATE_DIR_PREFIX = "private-";
+const BREAK_SUFFIX = ".break";
+// A break sub-lock's critical section is a read plus an unlink, so one older
+// than this belongs to a breaker that died mid-section.
+const BREAK_MARKER_GRACE_MS = 30_000;
+// Longest a publisher-controlled path component may contribute to a slot
+// name. `sanitizeSegment` already reduces the alphabet; this bounds the
+// length so a pathological manifest cannot push the resolved path past the
+// filesystem's limit and fail every download with ENAMETOOLONG.
+const MAX_SLOT_SEGMENT_LENGTH = 96;
+
+// How long an entry whose owner CANNOT be identified must sit completely
+// idle before another process may take it over. Only reached when
+// `verifyProcessIdentity` answers "indeterminate" - a probe that positively
+// says dead or alive-different frees the entry at once, and "alive-same"
+// holds it regardless of age.
+//
+// Idleness, not the marker's own age, is the signal: a live downloader
+// appends to its archive continuously and cannot go quiet for longer than
+// `DOWNLOAD_WATCHDOG_MS` plus a capped backoff without aborting the
+// attempt, and the verify/extract phase that follows still finishes well
+// inside this window. A flat 24h marker-age ceiling was safe but far too
+// blunt - on a host where the liveness probe itself is unavailable (a
+// locked-down Windows with no usable `tasklist`, which is the reporter's
+// platform) EVERY verdict is indeterminate, so the first abandoned marker
+// pinned the shared slot for a day and silently turned cross-process
+// resume back off: exactly the pre-fix behaviour, with a 700MB partial
+// stranded next to it.
+const UNIDENTIFIED_OWNER_IDLE_TAKEOVER_MS = 15 * 60 * 1000;
+
+export interface DownloadSlot {
+  // Where the archive should be streamed. Stable across CLI invocations
+  // when `resumable` is true.
+  readonly archivePath: string;
+  // False when another live process already owns the shared slot and this
+  // caller got a private per-invocation path instead. Callers do not need
+  // to branch on it - it exists for logging and tests.
+  readonly resumable: boolean;
+}
+
+export interface AcquireDownloadSlotOptions {
+  readonly environment: Environment;
+  readonly version: string;
+  readonly sha256: string;
+  readonly urlBasename: string;
+}
+
+// Claims the shared slot for `version`+`sha256`, falling back to a private
+// temp path when a live process already holds it. Also sweeps entries no
+// live process owns, so a superseded partial cannot pin hundreds of MB.
+export async function acquireDownloadSlot(
+  opts: AcquireDownloadSlotOptions,
+): Promise<DownloadSlot> {
+  const logger = createCliLogger(opts.environment);
+  await ensureHostDownloadCacheDir(opts.environment);
+  const cacheDir = hostDownloadCacheDir(opts.environment);
+  const sharedName = slotFileName(opts);
+  const archivePath = join(cacheDir, sharedName);
+  const verdicts: IdentityVerdictCache = new Map();
+  const slot =
+    (await claimEntry(archivePath, verdicts)) !== "denied"
+      ? { archivePath, resumable: true }
+      : await createPrivateSlot(cacheDir, opts, logger);
+  // The shared slot for THIS version is spared even when this caller fell
+  // back to a private path - falling back is precisely what proves another
+  // process is working on it. Without that, the loser of a race would sweep
+  // the entry the winner is mid-takeover of: claim it in the window between
+  // the winner's unlink and its own marker write, delete the partial, and
+  // leave both processes on private paths with the resumable bytes gone.
+  await sweepDownloadCache(
+    opts.environment,
+    new Set([
+      sharedName,
+      basename(claimedPathFor(opts.environment, slot.archivePath)),
+    ]),
+    verdicts,
+  );
+  return slot;
+}
+
+// Drops this process's claim while KEEPING the partial file, so the next
+// invocation resumes it. For the failed-transfer path only.
+export async function releaseDownloadSlotOwnership(
+  environment: Environment,
+  archivePath: string,
+): Promise<void> {
+  await releaseOwnerMarker(
+    ownerPathFor(claimedPathFor(environment, archivePath)),
+  );
+}
+
+// Removes the archive and its claim. For the terminal paths: the caller
+// consumed the archive, or it is verified-bad and must not be resumed.
+//
+// Both halves are gated on still OWNING the claim. A slot legitimately
+// changes hands while this process holds it - the idle takeover below fires
+// during a long extract, for instance - and after that the archive and the
+// marker belong to a fresh holder that is resuming them. Deleting on the
+// path alone would blow away that holder's live claim and the bytes it is
+// working on. Mirrors `host-lock/cross-process-lock.ts`'s compare-and-delete
+// `release()`, which exists for exactly this reason.
+export async function releaseDownloadSlot(
+  environment: Environment,
+  archivePath: string,
+): Promise<void> {
+  const claimed = claimedPathFor(environment, archivePath);
+  if (!(await ownsMarker(ownerPathFor(claimed)))) return;
+  await rm(claimed, { recursive: true, force: true }).catch(() => undefined);
+  await rm(ownerPathFor(claimed), { force: true }).catch(() => undefined);
+}
+
+// Marks the claim as still being worked on. The idle rule that frees an
+// unidentifiable owner measures the newest mtime across the marker and the
+// entry it claims, and the phases AFTER the transfer - hashing, signature
+// verification, and above all the caller's extract - only ever READ the
+// archive, so its mtime stops advancing while the slot is still legitimately
+// held. Without this the idle clock would run out mid-extract and another
+// process could take the slot over.
+export async function refreshDownloadSlotClaim(
+  environment: Environment,
+  archivePath: string,
+): Promise<void> {
+  const ownerPath = ownerPathFor(claimedPathFor(environment, archivePath));
+  if (!(await ownsMarker(ownerPath))) return;
+  const now = new Date();
+  await utimes(ownerPath, now, now).catch(() => undefined);
+}
+
+// Compare-and-delete of an owner marker: drop it only if it is still ours.
+async function releaseOwnerMarker(ownerPath: string): Promise<void> {
+  if (!(await ownsMarker(ownerPath))) return;
+  await rm(ownerPath, { force: true }).catch(() => undefined);
+}
+
+// Whether the marker at `ownerPath` is still this process's own claim. A pid
+// is unique among live processes, so a marker recording our pid can only be
+// ours. Anything we cannot positively attribute to ourselves is left alone.
+async function ownsMarker(ownerPath: string): Promise<boolean> {
+  const raw = await readMarkerRaw(ownerPath);
+  if (raw === null) return false;
+  const token = parseOwnerToken(raw);
+  return token !== null && token.pid === process.pid;
+}
+
+// A shared slot is claimed at the archive path itself; a private slot is
+// claimed at its containing `private-*` directory, so removing the claim
+// removes the whole directory the archive sits in.
+//
+// The private case escalates a targeted delete into a RECURSIVE one, so it
+// is admitted only for a directory that provably resolves to a child of this
+// environment's own download cache. `releaseDownloadSlot` is exported and
+// called for any archive the installer considers temporary, including
+// archives this module never created; matching on the directory's name would
+// let such an archive aim an `rm -rf` at its own parent.
+function claimedPathFor(environment: Environment, archivePath: string): string {
+  const parent = resolve(dirname(archivePath));
+  const isPrivateSlot =
+    basename(parent).startsWith(PRIVATE_DIR_PREFIX) &&
+    dirname(parent) === resolve(hostDownloadCacheDir(environment));
+  return isPrivateSlot ? parent : archivePath;
+}
+
+async function createPrivateSlot(
+  cacheDir: string,
+  opts: AcquireDownloadSlotOptions,
+  logger: ILogger,
+): Promise<DownloadSlot> {
+  // A private path costs this invocation a full re-download, but two
+  // writers appending to one file would corrupt both.
+  //
+  // Claim BEFORE creating the directory. The reverse order (the `mkdtemp`
+  // this replaced) left a real window in which the directory existed with
+  // no marker beside it, and a concurrent process's sweep reads exactly
+  // that - an unowned entry - and recursively removes a live download.
+  // With the marker first, a sweep landing mid-creation finds an orphaned
+  // marker, reads this process's own live token from it, and leaves it
+  // alone.
+  const privateDir = join(cacheDir, `${PRIVATE_DIR_PREFIX}${randomUUID()}`);
+  if (!(await createOwnerMarker(ownerPathFor(privateDir)))) {
+    throw new Error(
+      `host registry: download slot ${privateDir} is already claimed`,
+    );
+  }
+  try {
+    await mkdir(privateDir, { mode: 0o700 });
+  } catch (err) {
+    // Claiming first is what makes this safe, but it also means the claim
+    // outlives a failed creation. Nothing would ever collect it: the sweep
+    // judges an orphaned marker by its own freshness, and this one is fresh.
+    await rm(ownerPathFor(privateDir), { force: true }).catch(() => undefined);
+    throw err;
+  }
+  logger.warn("Registry download slot is owned by another live process", {
+    environment: opts.environment,
+    version: opts.version,
+  });
+  return {
+    archivePath: join(privateDir, sanitizeBasename(opts.urlBasename)),
+    resumable: false,
+  };
+}
+
+// `<version>-<sha-prefix>-<publisher basename>`. The sha prefix is what
+// makes resume safe across a re-publish: a changed asset resolves to a
+// different path, so a stale partial is never appended to a new entity.
+function slotFileName(opts: AcquireDownloadSlotOptions): string {
+  // Both the version and the basename come off the manifest, so both are
+  // length-capped; only the digest has a bound of its own.
+  const version = sanitizeSegment(opts.version).slice(
+    0,
+    MAX_SLOT_SEGMENT_LENGTH,
+  );
+  const digest = sanitizeSegment(opts.sha256).slice(0, 16);
+  return `${version}-${digest}-${sanitizeBasename(opts.urlBasename)}`;
+}
+
+// The basename comes from the manifest URL's last path segment, which is
+// publisher-controlled. Everything outside a conservative allowlist is
+// folded away so it can never contribute a separator, a parent-dir hop, or
+// a leading dot to the resolved path.
+function sanitizeBasename(value: string): string {
+  const cleaned = sanitizeSegment(value)
+    // A run of dots is never part of a real archive name, and a leading dot
+    // would make the entry hidden. Neither can traverse anywhere once the
+    // separators are gone, but both are folded away so the resolved name
+    // stays boring and greppable.
+    .replace(/\.{2,}/g, ".")
+    .replace(/^[.]+/, "");
+  return cleaned.length === 0
+    ? "host-archive"
+    : cleaned.slice(0, MAX_SLOT_SEGMENT_LENGTH);
+}
+
+function sanitizeSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, "-");
+}
+
+function ownerPathFor(claimedPath: string): string {
+  return `${claimedPath}${OWNER_SUFFIX}`;
+}
+
+// How this process came to hold an entry. The sweep needs the distinction:
+// "created from nothing" against an entry whose marker WAS listed a moment
+// ago means the marker vanished in between, which is another process
+// mid-takeover rather than litter.
+type ClaimOutcome = "created" | "took-over" | "denied";
+
+// Claims `claimedPath` for this process. Every path to a non-"denied"
+// outcome ends in an EXCLUSIVE create, so at most one process can hold a
+// given entry at a time; a loser falls back to a private slot.
+//
+// Deliberately not `host-lock/cross-process-lock`'s `acquireLock`, whose
+// protocol this mirrors: that lock's contract is "wait for the holder", and
+// an unidentifiable holder there correctly wedges forever because a wedge is
+// safer than concurrent mutation of an install tree. A download slot wants
+// the opposite two things - fall back to a private path instead of waiting,
+// and eventually take over an entry nobody is working on, because "wait"
+// here does not mean "be safe", it means "silently stop resuming and
+// re-download 700MB".
+async function claimEntry(
+  claimedPath: string,
+  verdicts: IdentityVerdictCache,
+): Promise<ClaimOutcome> {
+  const ownerPath = ownerPathFor(claimedPath);
+  if (await createOwnerMarker(ownerPath)) return "created";
+  // The exact bytes every decision below is made on.
+  const decisionRaw = await readMarkerRaw(ownerPath);
+  // Gone between the failed create and this read - it was released, or
+  // another contender broke it. Either way the path may be free now.
+  if (decisionRaw === null) {
+    return (await createOwnerMarker(ownerPath)) ? "created" : "denied";
+  }
+  if (!(await markerIsStale(decisionRaw, ownerPath, verdicts))) return "denied";
+  if (!(await breakStaleMarker(ownerPath, decisionRaw, verdicts))) {
+    return "denied";
+  }
+  return (await createOwnerMarker(ownerPath)) ? "took-over" : "denied";
+}
+
+// Serializes the removal of a marker proved stale, then re-verifies the
+// decision under that exclusivity.
+//
+// Both halves are load-bearing. Proving a marker stale is not the same as
+// being the one allowed to replace it: two processes can reach that
+// conclusion about the same marker, and the gap between deciding and acting
+// is not microseconds - `markerIsStale` may shell out to `ps`/`tasklist`
+// with a 3s timeout and retries, during which the real owner can exit and a
+// THIRD process can claim the slot legitimately.
+//
+// A rename-to-claim protocol cannot close this, for the reason
+// `host-lock/cross-process-lock.ts` sets out where it rejected the same
+// idea: `rename` cannot be made conditional on what it is overwriting, so a
+// delayed contender renames away a marker some genuinely fresh holder has
+// since written, and any "restore it" recovery path can then clobber a
+// third. Serializing the unlink behind an exclusively-created sub-lock is
+// what makes it sound - while that sub-lock is held nobody else can unlink
+// the marker, so a raw-byte comparison taken under it is conclusive proof
+// the marker is still the exact one the staleness decision was made on.
+async function breakStaleMarker(
+  ownerPath: string,
+  decisionRaw: string,
+  verdicts: IdentityVerdictCache,
+): Promise<boolean> {
+  const breakPath = `${ownerPath}${BREAK_SUFFIX}`;
+  const nonce = await acquireBreakMarker(breakPath, verdicts);
+  if (nonce === null) return false;
+  try {
+    // A read failure is not evidence, and a marker whose bytes changed
+    // belongs to a holder that appeared after the decision. Neither may be
+    // unlinked.
+    if ((await readMarkerRaw(ownerPath)) !== decisionRaw) return false;
+    await rm(ownerPath, { force: true });
+    return true;
+  } finally {
+    await releaseBreakMarker(breakPath, nonce);
+  }
+}
+
+// Returns this acquisition's nonce, or null if another breaker holds the
+// sub-lock. Recovery from a sub-lock left behind by a CRASHED breaker
+// requires positive evidence that its writer is gone - age alone is not
+// evidence. A live breaker descheduled between its re-read and its unlink
+// would otherwise have its sub-lock stolen, and then two processes hold it:
+// the second completes a legitimate takeover, and the first's unlink lands
+// on the marker the second just wrote for itself. Both would append to one
+// archive. Same ordering as
+// `cross-process-lock.ts`'s `tryRecoverCrashedBreakLock` - identity first,
+// age as an additional gate.
+async function acquireBreakMarker(
+  breakPath: string,
+  verdicts: IdentityVerdictCache,
+): Promise<string | null> {
+  const first = await createBreakMarker(breakPath);
+  if (first !== null) return first;
+  const raw = await readMarkerRaw(breakPath);
+  if (raw === null) return createBreakMarker(breakPath);
+  const token = parseOwnerToken(raw);
+  if (token !== null) {
+    const verdict = await identityVerdictFor(token, verdicts);
+    if (verdict !== "dead" && verdict !== "alive-different") return null;
+  }
+  const ageMs = await entryAgeMs(breakPath);
+  if (ageMs === null || ageMs < BREAK_MARKER_GRACE_MS) return null;
+  await rm(breakPath, { force: true }).catch(() => undefined);
+  return createBreakMarker(breakPath);
+}
+
+// Compare-and-delete, mirroring `cross-process-lock.ts`'s
+// `releaseBreakLock`: a recoverer that correctly took this sub-lock over
+// from a presumed-crashed breaker must not have its ownership silently
+// clobbered by that breaker's own late release.
+async function releaseBreakMarker(
+  breakPath: string,
+  nonce: string,
+): Promise<void> {
+  const raw = await readMarkerRaw(breakPath);
+  if (raw === null) return;
+  if (parseBreakMarkerNonce(raw) !== nonce) return;
+  await rm(breakPath, { force: true }).catch(() => undefined);
+}
+
+// The sub-lock carries this process's identity (so a contender can tell a
+// crashed breaker from a live one) plus a per-acquisition nonce (so the
+// release above can tell its own claim from a successor's).
+async function createBreakMarker(breakPath: string): Promise<string | null> {
+  const nonce = randomUUID();
+  const payload = JSON.stringify({
+    ...currentProcessIdentityToken(),
+    nonce,
+  });
+  return (await createExclusive(breakPath, payload)) ? nonce : null;
+}
+
+function parseBreakMarkerNonce(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const nonce = (parsed as Record<string, unknown>).nonce;
+  return typeof nonce === "string" ? nonce : null;
+}
+
+async function createOwnerMarker(ownerPath: string): Promise<boolean> {
+  return createExclusive(
+    ownerPath,
+    JSON.stringify(currentProcessIdentityToken()),
+  );
+}
+
+// Exclusive create: `wx` fails with EEXIST rather than truncating, which is
+// what makes a claim a claim.
+async function createExclusive(
+  path: string,
+  contents: string,
+): Promise<boolean> {
+  try {
+    await writeFile(path, contents, { encoding: "utf8", flag: "wx" });
+    return true;
+  } catch (err) {
+    if (!isExistsError(err)) throw err;
+    return false;
+  }
+}
+
+// One `acquireDownloadSlot` call judges the slot it wants plus every entry
+// in the sweep, and each judgement can shell out to `ps`/`tasklist` with a
+// 3s timeout and retries - synchronously, on the event loop, before the
+// download is allowed to start. Entries abandoned by the same process share
+// a token, so memoizing per token collapses that to one probe per distinct
+// owner.
+type IdentityVerdictCache = Map<string, ProcessIdentityVerdict>;
+
+async function identityVerdictFor(
+  token: ProcessIdentityToken,
+  cache: IdentityVerdictCache,
+): Promise<ProcessIdentityVerdict> {
+  const key = `${token.pid}:${token.startedAtMs ?? "unknown"}`;
+  const cached = cache.get(key);
+  if (cached !== undefined) return cached;
+  const verdict = await verifyProcessIdentityAsync(token);
+  cache.set(key, verdict);
+  return verdict;
+}
+
+// True when the process that wrote `decisionRaw` is not working on the
+// entry any more.
+async function markerIsStale(
+  decisionRaw: string,
+  ownerPath: string,
+  verdicts: IdentityVerdictCache,
+): Promise<boolean> {
+  const token = parseOwnerToken(decisionRaw);
+  if (token !== null) {
+    const verdict = await identityVerdictFor(token, verdicts);
+    // "alive-same" is the only verdict that proves the recorded downloader
+    // still exists. "alive-different" means the pid was recycled onto an
+    // unrelated process, which is positive evidence the owner is gone.
+    if (verdict === "alive-same") return false;
+    if (verdict === "dead" || verdict === "alive-different") return true;
+  }
+  // The marker says nothing usable - it is corrupt, or the identity probe
+  // itself failed. Fall back to whether the claim is still being WORKED ON
+  // rather than to how old the marker is.
+  const idleMs = await entryIdleMs(ownerPath);
+  return idleMs !== null && idleMs >= UNIDENTIFIED_OWNER_IDLE_TAKEOVER_MS;
+}
+
+// How long since anything last touched this claim: the newest mtime across
+// the marker and the entry it claims. A private slot claims a DIRECTORY
+// whose own mtime does not move while the archive inside it grows, so a
+// directory resolves to the newest mtime among its children too.
+async function entryIdleMs(ownerPath: string): Promise<number | null> {
+  const claimedPath = ownerPath.slice(0, -OWNER_SUFFIX.length);
+  const [markerMs, claimedMs] = await Promise.all([
+    newestMtimeMs(ownerPath),
+    newestMtimeMs(claimedPath),
+  ]);
+  const newest =
+    markerMs === null || claimedMs === null
+      ? (markerMs ?? claimedMs)
+      : Math.max(markerMs, claimedMs);
+  return newest === null ? null : Date.now() - newest;
+}
+
+async function entryAgeMs(path: string): Promise<number | null> {
+  try {
+    return Date.now() - (await stat(path)).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+async function newestMtimeMs(path: string): Promise<number | null> {
+  let entryStat;
+  try {
+    entryStat = await stat(path);
+  } catch {
+    return null;
+  }
+  if (!entryStat.isDirectory()) return entryStat.mtimeMs;
+  let children: string[];
+  try {
+    children = await readdir(path);
+  } catch {
+    return entryStat.mtimeMs;
+  }
+  const childTimes = await Promise.all(
+    children.map(async (child) => {
+      try {
+        return (await stat(join(path, child))).mtimeMs;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return childTimes.reduce<number>(
+    (newest, value) => (value !== null && value > newest ? value : newest),
+    entryStat.mtimeMs,
+  );
+}
+
+// `null` means the marker could not be read at all - it is absent, or the
+// read failed. Neither is evidence about an owner, and neither may be
+// compared against a staleness decision.
+async function readMarkerRaw(ownerPath: string): Promise<string | null> {
+  try {
+    return await readFile(ownerPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function parseOwnerToken(raw: string): ProcessIdentityToken | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (typeof obj.pid !== "number") return null;
+  return {
+    pid: obj.pid,
+    startedAtMs: typeof obj.startedAtMs === "number" ? obj.startedAtMs : null,
+  };
+}
+
+// Best-effort removal of every entry no live process owns, except the one
+// the caller just claimed. A partial for a superseded version is dead
+// weight the moment a newer one resolves - the only file worth keeping
+// across invocations is the one being downloaded now.
+async function sweepDownloadCache(
+  environment: Environment,
+  spareNames: ReadonlySet<string>,
+  verdicts: IdentityVerdictCache,
+): Promise<void> {
+  const logger = createCliLogger(environment);
+  const cacheDir = hostDownloadCacheDir(environment);
+  let entries;
+  try {
+    entries = await readdir(cacheDir);
+  } catch {
+    return;
+  }
+  const present = new Set(entries);
+  const spared = (name: string): boolean =>
+    spareNames.has(name) ||
+    (name.endsWith(OWNER_SUFFIX) &&
+      spareNames.has(name.slice(0, -OWNER_SUFFIX.length)));
+  for (const name of entries) {
+    if (spared(name)) continue;
+    // Break sub-locks are transient and owned by whoever is mid-takeover;
+    // `acquireBreakMarker` ages them out itself.
+    if (name.endsWith(BREAK_SUFFIX)) continue;
+    const entryPath = join(cacheDir, name);
+    if (name.endsWith(OWNER_SUFFIX)) {
+      // A marker whose claimed entry still exists is decided together with
+      // that entry, below; only an orphaned marker is judged on its own,
+      // and removing one is still an unlink another contender could be
+      // racing, so it goes through the same arbitration.
+      if (present.has(name.slice(0, -OWNER_SUFFIX.length))) continue;
+      const orphanRaw = await readMarkerRaw(entryPath);
+      if (orphanRaw === null) continue;
+      if (!(await markerIsStale(orphanRaw, entryPath, verdicts))) continue;
+      await breakStaleMarker(entryPath, orphanRaw, verdicts);
+      continue;
+    }
+    // Claim the entry before deleting it. Proving it stale is not enough on
+    // its own: another process can be taking the very same entry over to
+    // RESUME it, and a sweep that deleted the archive out from under a
+    // successful claim would throw away exactly the partial this cache
+    // exists to preserve. Winning the claim is what proves nobody else got
+    // there first; losing it means someone did, so leave it alone.
+    const outcome = await claimEntry(entryPath, verdicts);
+    if (outcome === "denied") continue;
+    // The listing showed a marker, yet the claim created one from nothing:
+    // the marker vanished in between, which is a contender that has already
+    // unlinked it and is about to write its own. Sparing the CURRENT
+    // version's slot is not enough to cover this - the entry being taken
+    // over belongs to whatever version that other process wants, not ours.
+    // Hand the claim straight back and leave its partial alone.
+    if (outcome === "created" && present.has(ownerPathFor(name))) {
+      await releaseOwnerMarker(ownerPathFor(entryPath));
+      continue;
+    }
+    await removeSwept(entryPath, environment, logger);
+    await removeSwept(ownerPathFor(entryPath), environment, logger);
+  }
+}
+
+async function removeSwept(
+  path: string,
+  environment: Environment,
+  logger: ILogger,
+): Promise<void> {
+  await rm(path, { recursive: true, force: true }).catch((err) => {
+    logger.warn("Registry failed to sweep a stale download-cache entry", {
+      environment,
+      errorName: errorFromUnknown(err).name,
+    });
+  });
+}
+
+function isExistsError(err: unknown): boolean {
+  return errnoCodeOf(err) === "EEXIST";
+}
+
+function errnoCodeOf(err: unknown): string | null {
+  if (err === null || typeof err !== "object" || !("code" in err)) return null;
+  return typeof err.code === "string" ? err.code : null;
+}

--- a/clients/traycer-cli/src/registry/fetch-resource.ts
+++ b/clients/traycer-cli/src/registry/fetch-resource.ts
@@ -50,6 +50,34 @@ const FETCH_TEXT_ATTEMPT_CAP_MS = 20_000;
 const MAX_NETWORK_ATTEMPTS = 4;
 const NETWORK_RETRY_BACKOFF_MS = 750;
 
+// Archive downloads get their own budget, separate from `fetchText`'s
+// small-payload one (traycer#585/#588). On a throttled link the connection
+// is reset every few MB, so a flat 4-attempt cap gives up after ~20MB of a
+// 700MB archive even though every attempt made real progress.
+//
+// What terminates a download is therefore the CONSECUTIVE-STALL count, not
+// the attempt count: an attempt that appended bytes to the partial file
+// resets it, so a reset-prone-but-advancing link keeps going while a
+// genuinely dead endpoint still fails within seconds. `MAX_DOWNLOAD_
+// ATTEMPTS` is only a runaway guard for a peer that dribbles a byte per
+// attempt - it is not the budget that is expected to bind.
+const MAX_DOWNLOAD_ATTEMPTS = 200;
+const MAX_DOWNLOAD_STALL_ATTEMPTS = 6;
+// A restart discards every byte on disk, so it is the one event the stall
+// budget cannot police - it resets the yardstick progress is measured
+// against. Bounded separately: a healthy origin restarts a resume at most
+// once or twice (one edge in a CDN ignoring `Range`), while an origin whose
+// entity simply does not match the manifest restarts on every single
+// attempt and must not be allowed to re-transfer the archive indefinitely.
+const MAX_DOWNLOAD_RESTARTS = 3;
+// Backoff grows only while the download is STALLED (750ms, 1.5s, 3s, 6s,
+// 12s, capped) - an ISP that resets connections once a data threshold is
+// crossed needs a pause to recover, and hammering it every 750ms just
+// re-enters the same throttling window. An attempt that transferred bytes
+// resets the exponent with it, so an occasional reset on an otherwise
+// healthy link never pays more than the base delay.
+const DOWNLOAD_RETRY_BACKOFF_CAP_MS = 15_000;
+
 interface DrainableWriter {
   readonly destroyed: boolean;
   readonly writableEnded: boolean;
@@ -69,7 +97,15 @@ export interface FetchOptions {
 export interface NetworkHeartbeat {
   readonly phase: "attempt" | "watchdog" | "backoff";
   readonly attempt: number;
-  readonly maxAttempts: number;
+  // The ceiling this attempt counter is actually judged against, or `null`
+  // when the counter has no meaningful ceiling to show. `fetchText` reports
+  // a real budget (4 attempts and the payload is abandoned). An archive
+  // download does not: what terminates it is the consecutive-stall count,
+  // while `MAX_DOWNLOAD_ATTEMPTS` is only a runaway guard set far above any
+  // real transfer. Rendering "attempt 41/200" there describes a countdown
+  // that does not exist - the download would survive 200 more resets as
+  // long as each one moved bytes.
+  readonly maxAttempts: number | null;
 }
 
 export type NetworkHeartbeatListener = (heartbeat: NetworkHeartbeat) => void;
@@ -93,16 +129,27 @@ export async function fetchText(
   }
   let lastError: unknown = null;
   for (let attempt = 1; attempt <= MAX_NETWORK_ATTEMPTS; attempt += 1) {
-    emitHeartbeat(opts.onHeartbeat, "attempt", attempt);
+    emitHeartbeat(opts.onHeartbeat, "attempt", attempt, MAX_NETWORK_ATTEMPTS);
     const controller = new AbortController();
     const linkedSignal = linkAbortSignals(controller, opts.signal);
     const watchdog = createWatchdog({
       controller,
       timeoutMs: FETCH_TEXT_WATCHDOG_MS,
-      onTimeout: () => emitHeartbeat(opts.onHeartbeat, "watchdog", attempt),
+      onTimeout: () =>
+        emitHeartbeat(
+          opts.onHeartbeat,
+          "watchdog",
+          attempt,
+          MAX_NETWORK_ATTEMPTS,
+        ),
     });
     const attemptCap = setTimeout(() => {
-      emitHeartbeat(opts.onHeartbeat, "watchdog", attempt);
+      emitHeartbeat(
+        opts.onHeartbeat,
+        "watchdog",
+        attempt,
+        MAX_NETWORK_ATTEMPTS,
+      );
       controller.abort();
     }, FETCH_TEXT_ATTEMPT_CAP_MS);
     try {
@@ -150,11 +197,11 @@ export async function fetchText(
       clearTimeout(attemptCap);
     }
     if (attempt < MAX_NETWORK_ATTEMPTS) {
-      emitHeartbeat(opts.onHeartbeat, "backoff", attempt);
-      await waitForRetry();
+      emitHeartbeat(opts.onHeartbeat, "backoff", attempt, MAX_NETWORK_ATTEMPTS);
+      await waitForRetry(NETWORK_RETRY_BACKOFF_MS);
     }
   }
-  throw exhaustedNetworkError(url, lastError);
+  throw exhaustedNetworkError(url, lastError, MAX_NETWORK_ATTEMPTS);
 }
 
 export interface DownloadToFileOptions extends FetchOptions {
@@ -211,16 +258,52 @@ async function downloadWithRetries(opts: DownloadToFileOptions): Promise<void> {
     sawFirstSuccessfulResponse: false,
   };
   let lastError: unknown = null;
-  for (let attempt = 1; attempt <= MAX_NETWORK_ATTEMPTS; attempt += 1) {
-    let offset = await partialSize(opts.destPath);
-    if (offset > 0 && state.entityValidator === null) {
-      await restartFromZero(opts.destPath, state);
-      offset = 0;
-    }
-    emitHeartbeat(opts.onHeartbeat, "attempt", attempt);
+  let stalledAttempts = 0;
+  let attempt = 1;
+  // The most bytes on disk since the last restart. Progress is judged
+  // against this high-water mark rather than against the attempt's own
+  // starting offset, so re-reading ground the download has already covered
+  // is correctly not progress: without that, an origin whose entity is
+  // shorter than the manifest declares oscillates forever - transfer the
+  // short body (looks like progress), Range past the end, 416, restart,
+  // transfer it again - resetting the stall counter every other attempt and
+  // running the full runaway guard on ~100 complete re-transfers.
+  //
+  // It is reset by a restart, and must be: a restart deletes the partial, so
+  // the mark would otherwise describe bytes that no longer exist and every
+  // subsequent attempt would be measured against a total it cannot reach.
+  // A 700MB resume that meets one Range-ignoring proxy would then give up
+  // inside six attempts while genuinely transferring on every one of them.
+  // `MAX_DOWNLOAD_RESTARTS` is what bounds the oscillation instead.
+  let bytesHighWaterMark = await partialSize(opts.destPath);
+  let restarts = 0;
+  for (; attempt <= MAX_DOWNLOAD_ATTEMPTS; attempt += 1) {
+    // No pre-flight restart: a partial file left by a PREVIOUS process is
+    // exactly what we want to resume, and this process has no validator for
+    // it yet. `downloadAttempt` puts the offset on the wire as a Range and
+    // handles every answer the server can give (206 resume, 416 already
+    // complete, 200 range-ignored -> restart), which is what makes the
+    // validator-less resume safe.
+    const offset = await partialSize(opts.destPath);
+    emitHeartbeat(opts.onHeartbeat, "attempt", attempt, null);
+    // Publish the starting point BEFORE the request goes out. A resumed
+    // process otherwise reports nothing until the first byte of the new
+    // attempt lands, so Desktop - whose carry-forward has no prior value in
+    // a fresh process - renders no progress bar at all while a 400MB partial
+    // sits on disk. On a stalling link that silence lasts a watchdog period
+    // per attempt, which is exactly the "it starts over every time" the
+    // resume work is meant to disprove. Emitted on every attempt, not just
+    // resumes, so a `restartFromZero` reports its rewind immediately instead
+    // of holding a stale percentage until the next chunk arrives.
+    opts.onProgress({
+      downloadedBytes: offset,
+      totalBytes: opts.expectedSizeBytes,
+    });
+    let restarted = false;
     try {
       const result = await downloadAttempt({ opts, state, offset, attempt });
       if (result.kind === "complete") return;
+      restarted = true;
       lastError = new Error(result.reason);
     } catch (err) {
       if (isCliError(err)) {
@@ -229,13 +312,44 @@ async function downloadWithRetries(opts: DownloadToFileOptions): Promise<void> {
       }
       lastError = err;
     }
-    if (attempt < MAX_NETWORK_ATTEMPTS) {
-      emitHeartbeat(opts.onHeartbeat, "backoff", attempt);
-      await waitForRetry();
+    if (restarted) {
+      restarts += 1;
+      if (restarts > MAX_DOWNLOAD_RESTARTS) break;
+      // The partial is gone, so the mark it described is meaningless now.
+      bytesHighWaterMark = 0;
     }
+    // Forward progress buys another round: only an attempt that pushed the
+    // partial file past its high-water mark counts as progress.
+    const landedBytes = await partialSize(opts.destPath);
+    if (landedBytes > bytesHighWaterMark) {
+      bytesHighWaterMark = landedBytes;
+      stalledAttempts = 0;
+    } else {
+      stalledAttempts += 1;
+    }
+    if (stalledAttempts >= MAX_DOWNLOAD_STALL_ATTEMPTS) break;
+    emitHeartbeat(opts.onHeartbeat, "backoff", attempt, null);
+    await waitForRetry(downloadRetryBackoffMs(stalledAttempts));
   }
-  await discardPartial(opts.destPath);
-  throw exhaustedNetworkError(opts.url, lastError);
+  // The partial file deliberately SURVIVES an exhausted budget: the next
+  // invocation resumes it from `destPath` (registry/download-cache.ts keeps
+  // that path stable across processes). Only positively-bad bytes get
+  // discarded - a size-cap abort above, or the sha256 mismatch in
+  // `downloadToFile`.
+  throw exhaustedNetworkError(
+    opts.url,
+    lastError,
+    Math.min(attempt, MAX_DOWNLOAD_ATTEMPTS),
+  );
+}
+
+function downloadRetryBackoffMs(stalledAttempts: number): number {
+  // Zero stalls (the attempt transferred bytes) and the first stall both
+  // pay only the base delay; the exponent starts climbing from the second
+  // consecutive stall.
+  const exponential =
+    NETWORK_RETRY_BACKOFF_MS * 2 ** Math.max(0, stalledAttempts - 1);
+  return Math.min(exponential, DOWNLOAD_RETRY_BACKOFF_CAP_MS);
 }
 
 interface DownloadAttemptOptions {
@@ -251,16 +365,24 @@ async function downloadAttempt(
   const { opts, state, offset, attempt } = options;
   const controller = new AbortController();
   const linkedSignal = linkAbortSignals(controller, opts.signal);
-  const resuming = offset > 0 && state.entityValidator !== null;
+  const resuming = offset > 0;
   const headers = new Headers();
-  if (resuming && state.entityValidator !== null) {
+  if (resuming) {
     headers.set("Range", `bytes=${offset}-`);
-    headers.set("If-Range", state.entityValidator);
+    // `If-Range` only when this process has seen the entity itself. Without
+    // it the server may answer a Range against a DIFFERENT entity than the
+    // partial bytes came from - so the 206 branch below refuses any
+    // Content-Range whose total is not the manifest's declared size, and
+    // the sha256 check in `downloadToFile` is the final backstop for a
+    // replacement entity of identical length.
+    if (state.entityValidator !== null) {
+      headers.set("If-Range", state.entityValidator);
+    }
   }
   const watchdog = createWatchdog({
     controller,
     timeoutMs: DOWNLOAD_WATCHDOG_MS,
-    onTimeout: () => emitHeartbeat(opts.onHeartbeat, "watchdog", attempt),
+    onTimeout: () => emitHeartbeat(opts.onHeartbeat, "watchdog", attempt, null),
   });
   try {
     const response = await fetch(opts.url, { signal: linkedSignal, headers });
@@ -351,6 +473,24 @@ async function downloadAttempt(
         });
       }
       await finishWriter(writer);
+      if (downloadedBytes < opts.expectedSizeBytes) {
+        // The body ended early. Most runtimes raise a stream error for a
+        // truncated response, but not all of them do for every truncation
+        // shape - bun's fetch reports some mid-body connection drops as a
+        // clean end-of-stream, and a response without a usable length can
+        // end short on any runtime. Treating "the reader said done" as
+        // proof of a finished transfer is what turned a resumable network
+        // failure into a terminal `HOST_VERIFY_FAILED` on the size check,
+        // burning the partial with it (traycer#585's "downloaded 231 MB of
+        // 721 MB before failure").
+        //
+        // Failing here instead keeps this a plain transfer error: the bytes
+        // that did land stay on disk and the next attempt resumes from
+        // them.
+        throw new Error(
+          `host registry: ${opts.url} ended after ${downloadedBytes} of ${opts.expectedSizeBytes} bytes`,
+        );
+      }
       return { kind: "complete" };
     } catch (err) {
       controller.abort();
@@ -407,9 +547,10 @@ function emitHeartbeat(
   listener: NetworkHeartbeatListener | null,
   phase: NetworkHeartbeat["phase"],
   attempt: number,
+  maxAttempts: number | null,
 ): void {
   if (listener === null) return;
-  listener({ phase, attempt, maxAttempts: MAX_NETWORK_ATTEMPTS });
+  listener({ phase, attempt, maxAttempts });
 }
 
 function createWatchdog(opts: {
@@ -435,9 +576,9 @@ function createWatchdog(opts: {
   };
 }
 
-async function waitForRetry(): Promise<void> {
+async function waitForRetry(delayMs: number): Promise<void> {
   await new Promise<void>((resolve) => {
-    setTimeout(resolve, NETWORK_RETRY_BACKOFF_MS);
+    setTimeout(resolve, delayMs);
   });
 }
 
@@ -447,13 +588,17 @@ function httpStatusError(url: string, response: Response): Error {
   );
 }
 
-function exhaustedNetworkError(url: string, lastError: unknown): Error {
+function exhaustedNetworkError(
+  url: string,
+  lastError: unknown,
+  attempts: number,
+): Error {
   return cliError({
     code: CLI_ERROR_CODES.REGISTRY_UNAVAILABLE,
-    message: `host registry: GET ${url} failed after ${MAX_NETWORK_ATTEMPTS} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+    message: `host registry: GET ${url} failed after ${attempts} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
     details: {
       url,
-      attempts: MAX_NETWORK_ATTEMPTS,
+      attempts,
       lastError:
         lastError instanceof Error ? lastError.message : String(lastError),
     },

--- a/clients/traycer-cli/src/registry/index.ts
+++ b/clients/traycer-cli/src/registry/index.ts
@@ -8,6 +8,16 @@ export type {
 export type { CreateRegistryClientOptions, RegistryTransport } from "./client";
 export { createDefaultRegistryClient, createRegistryClient } from "./client";
 export { currentHostPlatformKey } from "./platform-key";
+export {
+  acquireDownloadSlot,
+  releaseDownloadSlot,
+  releaseDownloadSlotOwnership,
+  refreshDownloadSlotClaim,
+} from "./download-cache";
+export type {
+  AcquireDownloadSlotOptions,
+  DownloadSlot,
+} from "./download-cache";
 export { resolveManifestUrl } from "./manifest-url";
 export {
   parseHostVersionsManifest,

--- a/clients/traycer-cli/src/store/paths.ts
+++ b/clients/traycer-cli/src/store/paths.ts
@@ -26,6 +26,7 @@ import { devDesktopSlotForEnvironment } from "./dev-desktop-slot";
 //   ~/.traycer/host/install/                 - prod host install dir (atomic-swap target)
 //   ~/.traycer/host/install/install.json     - prod host install record
 //   ~/.traycer/host/staging/                 - prod host staging root (verify-before-replace)
+//   ~/.traycer/host/download-cache/          - prod resumable archive partials (cross-invocation)
 //   ~/.traycer/host/dev/                     - legacy/no-slot dev host runtime root
 //   ~/.traycer/host/dev-runs/<slot>/         - multi-run dev host runtime root
 //   ~/.traycer/host/dev-runs/<slot>/install/install.json - multi-run dev install record
@@ -49,6 +50,18 @@ const HOST_INSTALL_RECORD_FILENAME = "install.json";
 // final install dir.
 const HOST_STAGED_SUBDIR = "staged";
 const HOST_STAGED_RECORD_FILENAME = "staged.json";
+// Where a registry archive is streamed to disk while it downloads. Unlike
+// `install-staging/`, this area is deliberately NOT per-invocation: the
+// archive path is derived from the version + sha256 so a re-spawned CLI
+// finds the previous invocation's partial file and resumes it with a Range
+// request instead of starting from zero (traycer#585/#588 - a 700MB host
+// archive over a throttled link never survives a single process). Contents
+// are owner-tokened and swept by `registry/download-cache.ts`, not by the
+// `install-staging/` temp sweep.
+// Exported so `registry/download-cache.ts` can recognize its own private
+// slot directories structurally (`<...>/download-cache/private-*/`) rather
+// than by directory name alone - see `claimedPathFor` there.
+export const HOST_DOWNLOAD_CACHE_SUBDIR = "download-cache";
 const CLI_LOG_FILENAME = "cli.log";
 const HOST_LOG_FILENAME = "host.log";
 // Single retained generation of the host log. One is enough: it exists so the
@@ -167,6 +180,9 @@ export function hostStagingRoot(environment: Environment): string {
 export function hostInstallRecordPath(environment: Environment): string {
   return join(hostInstallDir(environment), HOST_INSTALL_RECORD_FILENAME);
 }
+export function hostDownloadCacheDir(environment: Environment): string {
+  return join(hostHomeDir(environment), HOST_DOWNLOAD_CACHE_SUBDIR);
+}
 
 // Single-slot staged store - see the `HOST_STAGED_SUBDIR` comment above.
 export function hostStagedDir(environment: Environment): string {
@@ -199,6 +215,21 @@ export async function ensureHostStagingRoot(
   environment: Environment,
 ): Promise<void> {
   await mkdir(hostStagingRoot(environment), { recursive: true });
+}
+
+export async function ensureHostDownloadCacheDir(
+  environment: Environment,
+): Promise<void> {
+  // 0o700: the cache holds a partially-written archive at a PREDICTABLE
+  // path (that predictability is the whole point - it is what lets the next
+  // invocation resume it). Under ~/.traycer it is already user-owned, and
+  // an explicit private mode keeps it that way even if the parent's mode is
+  // later relaxed, so no other local account can pre-create or swap the
+  // file we are about to append to.
+  await mkdir(hostDownloadCacheDir(environment), {
+    recursive: true,
+    mode: 0o700,
+  });
 }
 
 export async function ensureHostHomeDirForStaged(

--- a/clients/traycer-cli/src/store/process-identity.ts
+++ b/clients/traycer-cli/src/store/process-identity.ts
@@ -16,6 +16,7 @@ export {
   readLiveProcessStartTimeMs,
   readProcessStartTimeMs,
   verifyProcessIdentity,
+  verifyProcessIdentityAsync,
   type ProcessIdentityToken,
   type ProcessIdentityVerdict,
   type ProcessLivenessVerdict,


### PR DESCRIPTION
Fixes the reports in #585, #586, #588 and #589: a ~795MB host archive never finishes installing on a throttled or reset-prone connection, and every retry starts over from zero.

These are four reports of one failure, but not of one bug. Five independent defects each ended the transfer *and* discarded the bytes that had already landed — so fixing any one of them alone still leaves the download unable to finish. Two further defects made a working resume *look* like a restart in the UI.

## Root causes

| # | Defect | Effect |
|---|---|---|
| 1 | Desktop's 10-minute CLI stream timeout was an absolute wall-clock cap | Any link slower than ~1.2MB/s was `SIGKILL`ed mid-transfer, with bytes still flowing |
| 2 | Archive downloads shared `fetchText`'s flat 4-attempt retry budget | Gave up after ~20MB of a 700MB archive, even though every attempt made real progress |
| 3 | The archive streamed into a per-invocation temp dir | A partial could never be resumed by a later process |
| 4 | A truncated body ending in a clean EOF was treated as a complete transfer | Turned a resumable network failure into a terminal `HOST_VERIFY_FAILED`, burning the partial with it — #585's "downloaded 231 MB of 721 MB before failure" |
| 5 | Resume was gated on an entity validator *the current process* had seen | A freshly spawned CLI always restarted from zero, even with a large partial on disk |

## Fixes

**Inactivity budget, not a deadline** (1). The timer is armed at spawn and re-armed on every NDJSON event the child emits, so only a child that has genuinely stopped reporting is killed. The CLI already guarantees a liveness signal well inside the window — a progress event per chunk, plus watchdog and backoff heartbeats while a transfer is stalled.

**Terminate on stalls, not attempts** (2). What ends a download is now the *consecutive-stall* count: an attempt that pushed the partial past its high-water mark resets it. A link that resets every few MB keeps going; a genuinely dead endpoint still fails within seconds. `MAX_DOWNLOAD_ATTEMPTS = 200` remains only as a runaway guard for a peer dribbling a byte per attempt. Backoff grows only while stalled, since an ISP that resets on a data threshold needs a pause to recover.

**A resumable download cache** (3). The archive lands in `~/.traycer/host/download-cache/` at a path derived from version + sha256, so the next invocation finds the previous one's partial. Because that path is deliberately shared, it carries an ownership claim: an owner marker created with exclusive-create, broken only on positive evidence that the owner is gone (process identity: pid + start time), with an idle-based rule reserved for owners that cannot be identified at all. A process that loses the claim gets a private slot rather than appending into someone else's file. Breaking a stale marker is serialized behind a second exclusively-created sub-lock, and the marker's raw bytes are re-verified under it, so two processes cannot both conclude they won.

**Short bodies fail as transfer errors** (4). The bytes on disk survive and the next attempt resumes from them. Most runtimes raise a stream error for a truncated response, but bun's `fetch` reports some mid-body connection drops as a clean end-of-stream — which is precisely the case that was being misread as success.

**Validator-less resume** (5). The `Range` goes out regardless; `If-Range` is added only when this process has seen the entity itself. The guards are layered instead: the 206 branch refuses any `Content-Range` whose total is not the manifest's declared size, and the sha256 check is the final backstop for a replacement entity of identical length.

## Presentation

Two defects made the fix invisible, which matters — "it starts over every time" is the symptom the reports describe:

- **The resume blind window.** Desktop has no prior value to carry forward in a fresh process, so it rendered no progress bar at all while a 400MB partial sat on disk. Each attempt now publishes the partial's offset *before* the request goes out.
- **Heading flicker.** A registry liveness tick (`registry-*`) is emitted from inside whatever stage is already running, but was overwriting `stage` — flipping the heading away from "Downloading Traycer Host…" and back on every retry. The progress-aware retry budget turned that from a rare blip into a constant flicker on exactly the links it exists for. Liveness ticks now hold the prior stage; genuine transitions still land.
- **`attempt N/200`** is gone. 200 is a runaway guard, not a countdown the download is working through.

## Extraction heartbeat

Extracting an ~800MB archive runs for minutes with nothing to show, and two mechanisms independently read that silence as death: Desktop's inactivity timer, and the download cache's idle rule (extraction only *reads* the archive, so its mtime stops advancing). One throttled heartbeat closes both — it emits progress *and* stamps the ownership marker.

## Testing

`930` traycer-cli, `405` shared, `976` desktop tests pass. New coverage includes resume across a mid-body truncation, the stall budget outlasting a reset-prone link, restart bounding, the cache's claim/takeover/sweep interactions, extraction heartbeats, and an integration test for the idle timeout re-arming.

Each new safety test was checked to *fail* against the pre-fix code rather than merely pass against the new code.

## Not in this change

Serving the archive from a mirror reachable at speed from the affected regions. That is the remaining half of #585 — this PR makes a throttled-CDN download survive to completion, but not fast. Left open deliberately.
