### PR TITLE
fix(windows): preserve env override casing and explain shell behavior

### DIFF
--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -420,7 +420,18 @@ dialog.tsx` / `notification-hook-draft.ts`, unchanged by this pass).
     when the selected program is a login shell, and a quiet _Restore default
     flags_ action shown only while the visible flags deviate from the family
     default - reverting the SELECTED shell via
-    `useRunnerTraycerShellRevertArgsMutation`); and a **`"Host environment ·
+    `useRunnerTraycerShellRevertArgsMutation`). **On Windows hosts with WSL
+    selected** (classified by binary via `windowsShellCaptionFamily`, shared
+    with the host resolver) a single quiet line sits directly under the picker
+    in its column - "Agents won't see tools installed in WSL", amber dot +
+    `Info` glyph - with the explanation and the "run the Traycer host inside
+    WSL" remedy link (docs.traycer.ai/settings/shell#using-wsl) in a
+    `HoverCard`; the glyph is itself a focusable anchor to that docs page so
+    keyboard users reach the remedy without the pointer-only hover card. Only
+    WSL earns a caption: PowerShell / Git Bash profile loading and cmd's plain
+    Windows environment are expected behavior, so those selections (and all
+    non-Windows hosts) render nothing, and the picker row top-aligns only
+    while the caption is shown. There is also a **`"Host environment ·
 After restart"`** card with the shared inline `EnvOverrideEditor`
     (host-process scope only - set/unset mode, value edit, key rename, and
     staged add/remove; per-harness env lives in Settings → Providers). Existing

--- a/clients/gui-app/src/components/settings/panels/__tests__/shell-settings-panel-windows-caption.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/shell-settings-panel-windows-caption.test.tsx
@@ -1,0 +1,106 @@
+import "../../../../../__tests__/test-browser-apis";
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
+import {
+  MockRunnerHost,
+  MockTraycerCli,
+} from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { ShellSettingsPanel } from "@/components/settings/panels/shell-settings-panel";
+
+// `isWindows()` is computed once at module load from UA hints, so the host
+// platform is faked through a togglable mock rather than a per-test navigator
+// tweak. The rest of the module (mac/modifier helpers) stays real.
+const platformState = vi.hoisted(() => ({ windows: true }));
+vi.mock("@/lib/keybindings/platform", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/keybindings/platform")>()),
+  isWindows: () => platformState.windows,
+}));
+
+afterEach(() => {
+  cleanup();
+  platformState.windows = true;
+});
+
+function renderPanel(path: string): void {
+  const cli = new MockTraycerCli();
+  cli.shellConfig = { path, args: [], synthesised: false };
+  const host: IRunnerHost = new MockRunnerHost({
+    signInUrl: "https://example.invalid/signin",
+    authnBaseUrl: "https://example.invalid",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: cli,
+  });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RunnerHostProvider runnerHost={host}>
+        <ShellSettingsPanel />
+      </RunnerHostProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const WSL_CAPTION = /Agents won't see tools installed in WSL/;
+
+describe("<ShellSettingsPanel /> WSL agent caption", () => {
+  it("shows the one-line caption for wsl.exe, with the remedy in a hover card", async () => {
+    renderPanel("C:\\Windows\\System32\\wsl.exe");
+    expect(await screen.findByText(WSL_CAPTION)).toBeTruthy();
+    // The remedy prose stays out of the inline caption - hover card only.
+    expect(
+      screen.queryByText(/run a Traycer host in your WSL distro/),
+    ).toBeNull();
+  });
+
+  it("exposes the WSL remedy as a keyboard-focusable docs link", async () => {
+    renderPanel("C:\\Windows\\System32\\wsl.exe");
+    await screen.findByText(WSL_CAPTION);
+    // The hover card is pointer-only; the docs link must ALSO exist in the
+    // sequential tab order - the caption's Info glyph is a real anchor.
+    const link = screen.getByRole("link", { name: /agents inside WSL/i });
+    expect(link.getAttribute("href")).toBe(
+      "https://docs.traycer.ai/settings/shell#using-wsl",
+    );
+  });
+
+  it("renders no WSL docs link for other shells", async () => {
+    renderPanel("C:\\Windows\\System32\\cmd.exe");
+    await screen.findByText("Startup flags for cmd.exe");
+    expect(
+      screen.queryByRole("link", { name: /agents inside WSL/i }),
+    ).toBeNull();
+  });
+
+  it("shows no caption for PowerShell (profile loading is expected behavior)", async () => {
+    renderPanel("C:\\Program Files\\PowerShell\\7\\pwsh.exe");
+    await screen.findByText("Startup flags for pwsh.exe");
+    expect(screen.queryByText(WSL_CAPTION)).toBeNull();
+  });
+
+  it("shows no caption for a Git-install bash", async () => {
+    renderPanel("C:\\Program Files\\Git\\bin\\bash.exe");
+    await screen.findByText("Startup flags for bash.exe");
+    expect(screen.queryByText(WSL_CAPTION)).toBeNull();
+  });
+
+  it("shows no caption for cmd", async () => {
+    renderPanel("C:\\Windows\\System32\\cmd.exe");
+    await screen.findByText("Startup flags for cmd.exe");
+    expect(screen.queryByText(WSL_CAPTION)).toBeNull();
+  });
+
+  it("shows no caption on a non-Windows host, even for a wsl-named path", async () => {
+    platformState.windows = false;
+    renderPanel("/bin/zsh");
+    await screen.findByText("Startup flags for zsh");
+    expect(screen.queryByText(WSL_CAPTION)).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/shell-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/shell-settings-panel.tsx
@@ -1,14 +1,21 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { Check, RotateCcw } from "lucide-react";
+import { Check, Info, RotateCcw } from "lucide-react";
 import {
   defaultShellArgs,
   isLoginShellFamily,
+  windowsShellCaptionFamily,
 } from "@traycer/protocol/config/shell-family";
 import type {
   TraycerDetectedShell,
   TraycerEnvOverride,
   TraycerShellConfig,
 } from "@traycer-clients/shared/platform/runner-host";
+import { isWindows } from "@/lib/keybindings/platform";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { SettingsGroup } from "@/components/settings/settings-group";
 import { SettingsPanelShell } from "@/components/settings/settings-panel-shell";
 import { EffectiveCommandPreview } from "@/components/settings/panels/shell/effective-command-preview";
@@ -34,6 +41,14 @@ const PANEL_DESCRIPTION =
   "How Traycer launches terminals, the host, and provider harnesses. New terminals pick up shell changes immediately; host env changes apply on restart.";
 const SAVED_FLASH_MS = 1600;
 type ShellSaveTarget = "program" | "flags";
+
+// WSL is the one shell selection where the choice silently diverges from what
+// agents see: agent chats stay Windows processes, so tools installed inside
+// WSL never reach them. Every other family behaves as users expect
+// (PowerShell / Git Bash profiles are read into the agent env), so only WSL
+// earns a caption (Windows hosts only) - one quiet line under the picker, with
+// the remedy behind a hover card instead of inline prose.
+const WSL_AGENTS_DOCS_URL = "https://docs.traycer.ai/settings/shell#using-wsl";
 
 /** Final path segment of the resolved shell, used to name its flags. */
 function programName(path: string): string {
@@ -343,6 +358,10 @@ function TerminalShellGroup(props: {
   readonly onRevertFlags: () => void;
 }) {
   const { config } = props;
+  const showWslCaption =
+    config !== undefined &&
+    isWindows() &&
+    windowsShellCaptionFamily(config.path) === "wsl";
   return (
     <SettingsGroup
       title="Terminal shell · New terminals"
@@ -372,7 +391,10 @@ function TerminalShellGroup(props: {
             </div>
             <div
               className={cn(
-                "flex flex-wrap items-center justify-between gap-4 border-t border-border/40",
+                "flex flex-wrap justify-between gap-4 border-t border-border/40",
+                // The WSL caption stacks under the picker in its own column,
+                // so the row top-aligns only while it is shown.
+                showWslCaption ? "items-start" : "items-center",
                 props.compact ? "px-4 py-2.5" : "px-5 py-4",
               )}
             >
@@ -384,24 +406,27 @@ function TerminalShellGroup(props: {
                   Pick a shell, or add any program on this machine.
                 </p>
               </div>
-              <div className="flex max-w-full items-center gap-2">
-                <ShellProgramCombobox
-                  value={config.path}
-                  synthesised={config.synthesised}
-                  shells={props.shells}
-                  disabled={props.pending}
-                  onSelect={props.onSavePath}
-                  onAdd={props.onAddShell}
-                  onRemove={props.onRemoveShell}
-                  onUseSystemDefault={props.onUseSystemDefault}
-                />
-                <TransientSaveIndicator
-                  pending={
-                    props.pending ? props.saveTarget === "program" : false
-                  }
-                  saved={props.savedTarget === "program"}
-                  testId="settings-shell-program-saving-spinner"
-                />
+              <div className="flex max-w-full flex-col items-end gap-1.5">
+                <div className="flex max-w-full items-center gap-2">
+                  <ShellProgramCombobox
+                    value={config.path}
+                    synthesised={config.synthesised}
+                    shells={props.shells}
+                    disabled={props.pending}
+                    onSelect={props.onSavePath}
+                    onAdd={props.onAddShell}
+                    onRemove={props.onRemoveShell}
+                    onUseSystemDefault={props.onUseSystemDefault}
+                  />
+                  <TransientSaveIndicator
+                    pending={
+                      props.pending ? props.saveTarget === "program" : false
+                    }
+                    saved={props.savedTarget === "program"}
+                    testId="settings-shell-program-saving-spinner"
+                  />
+                </div>
+                {showWslCaption ? <WslAgentCaption /> : null}
               </div>
             </div>
             <div
@@ -450,6 +475,57 @@ function TerminalShellGroup(props: {
         )}
       </>
     </SettingsGroup>
+  );
+}
+
+/**
+ * The WSL boundary in one quiet line: terminal tabs open in WSL, but
+ * agent chats stay Windows processes, so WSL-installed tools never reach them.
+ * The full explanation and the remedy (a Traycer host inside WSL) live
+ * in the hover card - reachable because `HoverCard`'s close grace lets the
+ * pointer travel into the card's link. The hover card is pointer-only, so the
+ * Info glyph is itself a focusable anchor to the same docs page - keyboard
+ * users reach the remedy without a mouse.
+ */
+function WslAgentCaption() {
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        <span className="inline-flex cursor-default items-center gap-1.5 text-ui-xs text-muted-foreground">
+          <span
+            aria-hidden
+            className="size-1.5 rounded-full bg-[var(--term-ansi-yellow)]"
+          />
+          Agents won&apos;t see tools installed in WSL
+          <a
+            href={WSL_AGENTS_DOCS_URL}
+            target="_blank"
+            rel="noreferrer"
+            aria-label="How to run agents inside WSL"
+            className="rounded transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60"
+          >
+            <Info className="size-3" />
+          </a>
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent
+        align="end"
+        className="w-[min(90vw,20rem)] space-y-2 text-ui-xs"
+      >
+        <p className="text-muted-foreground">
+          Terminal tabs open in WSL, but agent chats run as Windows processes
+          with the Windows environment.
+        </p>
+        <a
+          href={WSL_AGENTS_DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-block font-medium text-foreground underline underline-offset-4 hover:opacity-80"
+        >
+          Run agents inside WSL
+        </a>
+      </HoverCardContent>
+    </HoverCard>
   );
 }
 

--- a/protocol/src/config/__tests__/apply-env-overrides.test.ts
+++ b/protocol/src/config/__tests__/apply-env-overrides.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `applyEnvOverrides` must match keys case-insensitively on win32 (where the
+// process env is case-insensitive and the PATH key is spelled `Path`, not
+// `PATH`) while staying case-sensitive on POSIX. The platform is the only OS
+// input this behavior depends on, so - exactly like `detect-shells.test.ts` -
+// we mock `os.platform()` to exercise both branches honestly from one runner.
+const world = vi.hoisted(() => ({ platform: "linux" as NodeJS.Platform }));
+vi.mock("node:os", async (importActual) => {
+  const actual = await importActual<typeof import("node:os")>();
+  return { ...actual, platform: () => world.platform };
+});
+
+import { applyEnvOverrides } from "../store";
+
+/** All keys in `env` that name the PATH variable in any casing. */
+function pathKeys(env: NodeJS.ProcessEnv): string[] {
+  return Object.keys(env).filter((key) => /^path$/i.test(key));
+}
+
+beforeEach(() => {
+  world.platform = "linux";
+});
+
+describe("applyEnvOverrides - POSIX key matching (case-sensitive, unchanged)", () => {
+  it("treats `PATH` and `Path` as distinct keys (no case-folding)", () => {
+    // On POSIX a `PATH` override does NOT touch an existing `Path`; both keys
+    // coexist. This locks the current behavior against the win32 change below.
+    expect(applyEnvOverrides({ Path: "orig" }, { PATH: "new" })).toEqual({
+      Path: "orig",
+      PATH: "new",
+    });
+  });
+
+  it("deletes only the exactly-cased key on a null override", () => {
+    expect(applyEnvOverrides({ Path: "orig" }, { PATH: null })).toEqual({
+      Path: "orig",
+    });
+    expect(applyEnvOverrides({ Path: "orig" }, { Path: null })).toEqual({});
+  });
+
+  it("still layers unrelated overrides and null-deletes (existing contract)", () => {
+    expect(
+      applyEnvOverrides(
+        { OPENAI_API_KEY: "inherited", ANTHROPIC_API_KEY: "kept" },
+        { OPENAI_API_KEY: null, GEMINI_API_KEY: "set" },
+      ),
+    ).toEqual({ ANTHROPIC_API_KEY: "kept", GEMINI_API_KEY: "set" });
+  });
+});
+
+describe("applyEnvOverrides - win32 key matching (case-insensitive)", () => {
+  beforeEach(() => {
+    world.platform = "win32";
+  });
+
+  it("replaces an existing `Path` value in place when overriding `PATH`", () => {
+    // The real key on Windows is `Path`; a Settings->Shell override keyed
+    // `PATH` must update THAT value, not add a second colliding key. The
+    // original key's casing is preserved (replace in place).
+    const result = applyEnvOverrides({ Path: "orig" }, { PATH: "new" });
+    expect(pathKeys(result)).toEqual(["Path"]);
+    expect(result).toEqual({ Path: "new" });
+  });
+
+  it("matches regardless of the override's casing", () => {
+    const result = applyEnvOverrides(
+      { Path: "orig", TEMP: "t" },
+      { path: "new" },
+    );
+    expect(result).toEqual({ Path: "new", TEMP: "t" });
+  });
+
+  it("deletes the case-insensitively matching key on a null override", () => {
+    expect(applyEnvOverrides({ Path: "orig" }, { PATH: null })).toEqual({});
+    expect(applyEnvOverrides({ Path: "orig" }, { path: null })).toEqual({});
+  });
+
+  it("adds a genuinely new key that matches nothing existing", () => {
+    expect(applyEnvOverrides({ Path: "orig" }, { FOO: "bar" })).toEqual({
+      Path: "orig",
+      FOO: "bar",
+    });
+  });
+
+  it("keeps a single PATH-like key when several overrides target it", () => {
+    // Two overrides both naming PATH in different casings must still collapse
+    // onto the one existing key - never leave `Path`, `PATH` and `path` all set.
+    const result = applyEnvOverrides(
+      { Path: "orig" },
+      { PATH: "first", path: "second" },
+    );
+    expect(pathKeys(result)).toHaveLength(1);
+    expect(Object.values(result)).toEqual(["second"]);
+  });
+
+  it("matches non-PATH vars case-insensitively too (Windows env semantics)", () => {
+    // The win32 rule is general to the env object, not special-cased to PATH:
+    // an inherited `Temp` is replaced by a `TEMP` override in place.
+    const result = applyEnvOverrides({ Temp: "old" }, { TEMP: "new" });
+    expect(Object.keys(result)).toEqual(["Temp"]);
+    expect(result.Temp).toBe("new");
+  });
+});

--- a/protocol/src/config/__tests__/shell-family.test.ts
+++ b/protocol/src/config/__tests__/shell-family.test.ts
@@ -22,8 +22,9 @@ describe("windowsShellCaptionFamily", () => {
     ["C:\\msys64\\usr\\bin\\bash.exe", "git-bash"],
     // The Settings path is user-typed and may use forward slashes.
     ["C:/Program Files/Git/bin/bash.exe", "git-bash"],
-    // System32's bash.exe is legacy WSL, never probed as Git Bash.
-    ["C:\\Windows\\System32\\bash.exe", "other"],
+    // System32's bash.exe is the legacy WSL launcher: never probed as Git
+    // Bash, and it earns the same WSL boundary caption as wsl.exe.
+    ["C:\\Windows\\System32\\bash.exe", "wsl"],
     // WSL runs agents as Windows processes.
     ["C:\\Windows\\System32\\wsl.exe", "wsl"],
     // cmd and any custom program get the registry-merged environment only.

--- a/protocol/src/config/__tests__/shell-family.test.ts
+++ b/protocol/src/config/__tests__/shell-family.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  windowsShellCaptionFamily,
+  type WindowsShellCaptionFamily,
+} from "../shell-family";
+
+describe("windowsShellCaptionFamily", () => {
+  const cases: ReadonlyArray<readonly [string, WindowsShellCaptionFamily]> = [
+    // PowerShell 7 and Windows PowerShell 5.1 - both profile-probed.
+    ["C:\\Program Files\\PowerShell\\7\\pwsh.exe", "powershell"],
+    [
+      "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      "powershell",
+    ],
+    // Git Bash: bash.exe in an MSYS layout (`<install>\bin` / `<install>\usr\bin`),
+    // regardless of the install directory name - PortableGit unzips anywhere.
+    ["C:\\Program Files\\Git\\bin\\bash.exe", "git-bash"],
+    ["C:\\Program Files\\Git\\usr\\bin\\bash.exe", "git-bash"],
+    ["C:\\Tools\\PortableGit\\usr\\bin\\bash.exe", "git-bash"],
+    // Any MSYS-layout bash is probed (deliberate broadening - a bash that can't
+    // produce the cygpath dump degrades to the registry fallback on the host).
+    ["C:\\msys64\\usr\\bin\\bash.exe", "git-bash"],
+    // The Settings path is user-typed and may use forward slashes.
+    ["C:/Program Files/Git/bin/bash.exe", "git-bash"],
+    // System32's bash.exe is legacy WSL, never probed as Git Bash.
+    ["C:\\Windows\\System32\\bash.exe", "other"],
+    // WSL runs agents as Windows processes.
+    ["C:\\Windows\\System32\\wsl.exe", "wsl"],
+    // cmd and any custom program get the registry-merged environment only.
+    ["C:\\Windows\\System32\\cmd.exe", "other"],
+    ["C:\\tools\\nu.exe", "other"],
+  ];
+
+  for (const [path, expected] of cases) {
+    it(`classifies ${path} as ${expected}`, () => {
+      expect(windowsShellCaptionFamily(path)).toBe(expected);
+    });
+  }
+
+  it("is case-insensitive on the binary name and Git-install segment", () => {
+    expect(windowsShellCaptionFamily("C:\\Program Files\\PowerShell\\7\\PWSH.EXE")).toBe(
+      "powershell",
+    );
+    expect(
+      windowsShellCaptionFamily("C:\\Program Files\\GIT\\BIN\\BASH.EXE"),
+    ).toBe("git-bash");
+  });
+});

--- a/protocol/src/config/shell-family.ts
+++ b/protocol/src/config/shell-family.ts
@@ -87,6 +87,9 @@ export function windowsShellCaptionFamily(
   ) {
     return "git-bash";
   }
+  // Both wsl.exe and the legacy System32 bash.exe launcher open WSL - the
+  // same terminals-cross-the-boundary caption applies to either.
   if (base === "wsl.exe") return "wsl";
+  if (base === "bash.exe" && lower.includes("\\system32\\")) return "wsl";
   return "other";
 }

--- a/protocol/src/config/shell-family.ts
+++ b/protocol/src/config/shell-family.ts
@@ -50,3 +50,43 @@ export function isLoginShellFamily(path: string): boolean {
 export function defaultShellArgs(path: string): readonly string[] {
   return isLoginShellFamily(path) ? ["-i", "-l"] : [];
 }
+
+/**
+ * How the host derives a spawned agent's environment for a given Windows shell,
+ * for the Settings → Shell caption. Kept in lockstep with the host's
+ * `windowsShellFamily` (`traycer-host/.../provider-search-dirs.ts`) and
+ * `detectShells` friendly-naming: PowerShell (pwsh 7 / Windows PowerShell 5.1)
+ * and Git Bash are profile-probed; WSL runs agents as Windows processes; every
+ * other shell (cmd, custom) gets the registry-merged Windows environment only.
+ */
+export type WindowsShellCaptionFamily =
+  | "powershell"
+  | "git-bash"
+  | "wsl"
+  | "other";
+
+const WINDOWS_POWERSHELL_BASENAMES: ReadonlySet<string> = new Set([
+  "pwsh.exe",
+  "powershell.exe",
+]);
+
+export function windowsShellCaptionFamily(
+  path: string,
+): WindowsShellCaptionFamily {
+  const base = shellBasename(path);
+  if (WINDOWS_POWERSHELL_BASENAMES.has(base)) return "powershell";
+  // Git Bash is a `bash.exe` in an MSYS/Git-for-Windows layout
+  // (`<install>\bin\` or `<install>\usr\bin\`, any install dir name - e.g.
+  // PortableGit), matching the host classifier. System32's bash.exe is legacy
+  // WSL. The Settings path is user-typed and may use forward slashes.
+  const lower = path.toLowerCase().replace(/\//g, "\\");
+  if (
+    base === "bash.exe" &&
+    /\\(usr\\)?bin\\bash\.exe$/.test(lower) &&
+    !lower.includes("\\system32\\")
+  ) {
+    return "git-bash";
+  }
+  if (base === "wsl.exe") return "wsl";
+  return "other";
+}

--- a/protocol/src/config/store.ts
+++ b/protocol/src/config/store.ts
@@ -958,12 +958,21 @@ export function applyEnvOverrides(
   base: NodeJS.ProcessEnv,
   overrides: Readonly<Record<string, EnvOverrideValue>>,
 ): NodeJS.ProcessEnv {
+  // The Windows environment block is case-insensitive and Node preserves the
+  // existing key's casing (the real PATH key is spelled `Path`, not `PATH`), so
+  // an override keyed `PATH` must land on the existing `Path` in place rather
+  // than creating a second, colliding key. POSIX stays case-sensitive.
+  const isWindows = osPlatform() === "win32";
   const env: NodeJS.ProcessEnv = { ...base };
   for (const [key, value] of Object.entries(overrides)) {
+    const targetKey = isWindows
+      ? (Object.keys(env).find((k) => k.toLowerCase() === key.toLowerCase()) ??
+        key)
+      : key;
     if (value === null) {
-      delete env[key];
+      delete env[targetKey];
     } else {
-      env[key] = value;
+      env[targetKey] = value;
     }
   }
   return env;


### PR DESCRIPTION
## What changed

- apply environment overrides case-insensitively on Windows while preserving the inherited key's original casing
- add a shared Windows shell-family classifier for PowerShell, Git Bash, WSL, and other shells
- explain in Shell settings how the selected Windows shell affects spawned agent environments
- document the behavior and add protocol/UI regression coverage

## Why

The host-side fix for #541 reconstructs a normal Windows environment, where PATH is commonly keyed as `Path`. A user override keyed as `PATH` must update that value in place instead of creating a second colliding entry. The settings caption also makes the PowerShell, Git Bash, WSL, and registry-only behavior explicit to users.

## Impact

Windows overrides now follow the platform's case-insensitive environment semantics without changing POSIX behavior. Windows users can also see whether agents receive shell-profile additions or only the registry-merged environment.

Companion host PR: https://github.com/traycerai/traycer-internal/pull/4625

Part of #541

## Validation

- protocol tests: 18 passed
- Shell settings caption tests: 5 passed
- `bun run compile` in `protocol/` and `clients/gui-app/`
- protocol and GUI workspace lint
- React Doctor: no issues
- affected-workspace pre-commit build, compile, lint, and format checks