### PR TITLE
fix(gui-app): keep onboarding skip button clear of Windows window controls

### DIFF
--- a/clients/gui-app/src/components/onboarding/onboarding-page.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-page.tsx
@@ -667,7 +667,11 @@ export function OnboardingPage(props: { readonly replay: boolean }) {
               data-testid="onboarding-skip"
               onClick={() => finish("skipped")}
               disabled={agentGuideSaving}
-              className="absolute right-10 flex h-9 items-center justify-center gap-2 rounded px-2 font-heading text-[0.875rem] leading-[1.125rem] font-normal tracking-normal text-white transition-colors hover:bg-white/10 disabled:pointer-events-none disabled:opacity-55 [@media(min-height:920px)]:h-10 [@media(min-height:920px)]:text-[0.9375rem] max-sm:right-5"
+              // Frameless desktop: the OS window controls overlay this corner
+              // (Windows draws min/max/close on the right), so shift the
+              // button past them while they are visible. Same env()-inset
+              // pattern as the app header's trailing padding.
+              className="absolute right-10 flex h-9 items-center justify-center gap-2 rounded px-2 font-heading text-[0.875rem] leading-[1.125rem] font-normal tracking-normal text-white transition-colors hover:bg-white/10 disabled:pointer-events-none disabled:opacity-55 wco:right-[max(2.5rem,calc(100vw-env(titlebar-area-x,82px)-env(titlebar-area-width,100vw)+0.75rem))] [@media(min-height:920px)]:h-10 [@media(min-height:920px)]:text-[0.9375rem] max-sm:right-5 max-sm:wco:right-[max(1.25rem,calc(100vw-env(titlebar-area-x,82px)-env(titlebar-area-width,100vw)+0.75rem))]"
             >
               <span>Skip intro</span>
               <Kbd tone="light">Esc</Kbd>


### PR DESCRIPTION
## Problem

On frameless Windows builds, Electron's Window Controls Overlay draws the native minimize/maximize/close buttons on top of the page's top-right corner — exactly where the onboarding **Skip intro** button sits (`absolute right-10`). Clicks in that corner hit the OS controls instead of the button, so skipping onboarding is effectively blocked by the window controls.

## Fix

Add a `wco:`-scoped right inset to the Skip button that shifts it left past the native controls while they are visible:

```
wco:right-[max(2.5rem,calc(100vw-env(titlebar-area-x,82px)-env(titlebar-area-width,100vw)+0.75rem))]
```

`100vw − titlebar-area-x − titlebar-area-width` is the width the OS controls occupy on the trailing edge, read live from the browser's WCO env vars; `max()` keeps the existing `right-10` / `max-sm:right-5` insets as the floor. This is the same pattern the app header already uses for its trailing padding (`app-header.tsx`), driven by the existing `.wco` class bridge in `lib/window-controls-overlay.ts`.

## Behavior

- **Windows (controls visible):** button sits just left of the native controls, at any overlay size — including the zoom-scaled overlay heights from the Windows menu bar work on `traycer/daring-lion` (no file overlap with that branch).
- **macOS / browser shells:** env expression collapses to ≤ the floor, so nothing moves.
- **Fullscreen (controls hidden):** `.wco` class is off, original position applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)