### PR TITLE
feat(gui-app): show Oh My Pi's PATH-only install guidance

### DIFF
--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -996,6 +996,47 @@ describe("<ProvidersSettingsPanel />", () => {
     ).toBeNull();
   });
 
+  it("shows Oh My Pi's PATH-only not-found guidance without a bundled row", () => {
+    providerMocks.listResult.data = {
+      providers: [
+        providerState({
+          providerId: "omp",
+          selected: { kind: "path" },
+          candidates: [],
+          envOverrides: [],
+        }),
+      ],
+    };
+
+    render(
+      <RunnerHostContext.Provider value={createRunnerHost()}>
+        <TooltipProvider>
+          <ProvidersSettingsPanel />
+        </TooltipProvider>
+      </RunnerHostContext.Provider>,
+    );
+
+    expect(
+      screen.getByText(
+        "Oh My Pi must be installed on this machine. It ships without a bundled binary.",
+      ),
+    ).toBeDefined();
+    const guide = screen.getByRole("link", {
+      name: "Oh My Pi installation guide",
+    });
+    expect(guide.getAttribute("href")).toBe("https://omp.sh/#install");
+    fireEvent.click(guide);
+    expect(providerMocks.openExternalLink).toHaveBeenCalledWith(
+      "https://omp.sh/#install",
+    );
+    expect(
+      screen.getByRole("button", { name: "Add custom path" }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("radio", { name: "Select bundled binary" }),
+    ).toBeNull();
+  });
+
   it("orders the provider rail by the default provider order", () => {
     providerMocks.listResult.data = {
       providers: [

--- a/clients/gui-app/src/components/settings/panels/provider-cli-candidates-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-cli-candidates-section.tsx
@@ -24,8 +24,33 @@ import { cn } from "@/lib/utils";
 // table past the panel width.
 const TABLE_GRID =
   "grid grid-cols-[2.25rem_minmax(0,1fr)_minmax(5.5rem,auto)_2.25rem] items-center";
-const HERMES_INSTALLATION_URL =
-  "https://hermes-agent.nousresearch.com/docs/getting-started/installation";
+
+type ProviderId = ProviderCliState["providerId"];
+
+interface PathOnlyInstallGuide {
+  // Short binary-facing label for the "<name> must be installed" sentence.
+  // Deliberately not `PROVIDER_DISPLAY_NAMES`, whose product names ("Hermes
+  // Agent") read wrong in that sentence.
+  readonly name: string;
+  readonly url: string;
+}
+
+// Providers that ship no bundled binary: the host can only discover them on
+// PATH, so an empty candidate list means "not installed" and the empty table
+// is replaced by install guidance. Keyed by provider id, never by display
+// name - "Oh My Pi" contains the separate "Pi" provider's name as a
+// substring.
+const PATH_ONLY_INSTALL_GUIDES: Partial<
+  Record<ProviderId, PathOnlyInstallGuide>
+> = {
+  hermes: {
+    name: "Hermes",
+    url: "https://hermes-agent.nousresearch.com/docs/getting-started/installation",
+  },
+  // Anchor, not the site root: omp.sh is a single landing page and `#install`
+  // is its install section, so the link lands where the label promises.
+  omp: { name: "Oh My Pi", url: "https://omp.sh/#install" },
+};
 
 interface ProviderCandidateConfig {
   readonly selected: ProviderSelection;
@@ -114,19 +139,21 @@ export function ProviderCliCandidatesSection({
 
   if (!showCliCandidates) return null;
 
-  const isEmptyHermesState =
-    providerId === "hermes" && cliConfig.candidates.length === 0;
+  const installGuide =
+    cliConfig.candidates.length === 0
+      ? PATH_ONLY_INSTALL_GUIDES[providerId]
+      : undefined;
 
   return (
     <>
-      {isEmptyHermesState && !adding ? (
+      {installGuide !== undefined && !adding ? (
         <div className="rounded-lg border border-border/60 bg-muted/10 p-3 text-ui-sm text-muted-foreground">
           <p>
-            Hermes must be installed on this machine. It ships without a bundled
-            binary.
+            {installGuide.name} must be installed on this machine. It ships
+            without a bundled binary.
           </p>
           <a
-            href={HERMES_INSTALLATION_URL}
+            href={installGuide.url}
             target="_blank"
             rel="noreferrer"
             onClick={(event) => {
@@ -137,11 +164,11 @@ export function ProviderCliCandidatesSection({
               if (runnerHost === null) return;
               // oxlint-disable-next-line react-doctor/no-prevent-default -- desktop shell opens external links via the Electron `openExternalLink` bridge, not renderer navigation; the null-guard above preserves native anchor nav in web builds.
               event.preventDefault();
-              openExternalLink.mutate(HERMES_INSTALLATION_URL);
+              openExternalLink.mutate(installGuide.url);
             }}
             className="mt-1 inline-flex text-ui-xs font-medium text-primary transition-colors hover:text-primary/80 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 rounded"
           >
-            Hermes installation guide
+            {installGuide.name} installation guide
           </a>
         </div>
       ) : (


### PR DESCRIPTION
## Summary

`omp` landed in #675 with the full protocol line and renderer surface, but not the
**PATH-only not-found state**. Oh My Pi ships without a bundled binary, exactly like
Hermes — yet only Hermes tells the user so. Today an omp user who hasn't installed the
CLI opens **Settings > Providers > Oh My Pi** and gets a bare `Path`/`Version` table:
no rows, no explanation, nowhere to go.

Hermes' arm was a hard-coded `providerId === "hermes"` branch, so bolting omp on beside
it would have meant a second copy of the same JSX. Instead it becomes a lookup:

```ts
const PATH_ONLY_INSTALL_GUIDES: Partial<Record<ProviderId, PathOnlyInstallGuide>> = {
  hermes: { name: "Hermes", url: "https://hermes-agent.nousresearch.com/..." },
  omp:    { name: "Oh My Pi", url: "https://omp.sh/#install" },
};
```

Both providers share one code path, and the next PATH-only provider is a table row
instead of another branch. The shape mirrors `API_KEY_DASHBOARD_URL` in the sibling
`provider-api-key-section.tsx`.

Three details worth calling out:

- **Keyed by provider id, never by display name.** `"Oh My Pi"` contains the separate
  `"Pi"` provider's name as a substring — the same collision #675 flagged.
- **`omp.sh/#install`, not the site root.** omp.sh is a single landing page whose install
  section is `<section id="install">`; the anchor lands where the "installation guide"
  label promises, matching the Hermes entry's deep link. Verified in a browser.
- **`name` is deliberately not `PROVIDER_DISPLAY_NAMES`.** That map holds product names
  (`"Hermes Agent"`), which read wrong in "<name> must be installed on this machine."
  Keeping the short form also leaves Hermes' shipped copy byte-identical.

**Hermes rendering is unchanged** — same gate, same copy, same URL. Its existing
PATH-only test is untouched and is what covers the refactor.

Not addressed here: the empty state still doesn't consult `availabilityPending`, so it
can flash during a probe. That's pre-existing Hermes behaviour and out of scope for this
change.

## Related issue

Closes #696

Follow-up to #675 (`omp` harness).

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

<sub>Verification run: `pre-commit run --files <the two touched files>` → all hooks
Passed, including `build · compile · lint · format (nx affected)`. Full gui-app suite:
**7097 passed / 1 skipped / 0 failed** across 765 files. Rebased on `main` @ `c531352b`.</sub>

