### PR TITLE
fix(cli,desktop): run the host LaunchAgent in launchd's Interactive band

### DIFF
--- a/clients/desktop/scripts/prepack/inject-host-launch-agent.cjs
+++ b/clients/desktop/scripts/prepack/inject-host-launch-agent.cjs
@@ -111,6 +111,12 @@ function helperAppPathFor(appPath) {
   );
 }
 
+// Stays in lockstep with `buildPlist` in
+// clients/traycer-cli/src/service/platforms/macos.ts, including
+// `ProcessType: Interactive` - the only launchd band that runs with app-
+// equivalent (i.e. no) resource limits. `Standard` is defined as "equivalent
+// to no ProcessType being set", which means launchd throttles CPU and I/O;
+// see the rationale comment on `installService` in that file.
 function buildLaunchAgentPlist(label, helperBinaryRelativePath) {
   const hostPath = [
     "/opt/homebrew/bin",
@@ -149,7 +155,7 @@ ${programArgsXml}
   <key>ThrottleInterval</key>
   <integer>10</integer>
   <key>ProcessType</key>
-  <string>Standard</string>
+  <string>Interactive</string>
   <key>SoftResourceLimits</key>
   <dict>
     <key>NumberOfFiles</key>

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -76,10 +76,18 @@ async function installService(
   // Register the host by writing a user-domain LaunchAgent plist:
   // `RunAtLoad` makes it auto-start at login and surface in System Settings →
   // Login Items / "Allow in the Background" (that BTM row is driven by the
-  // registration itself, not by `ProcessType`). `ProcessType: Standard` keeps
-  // the host out of launchd's throttled Background band - it does
+  // registration itself, not by `ProcessType`). `ProcessType: Interactive`
+  // is the only band that runs "with the same resource limitations as apps,
+  // that is to say, none" (launchd.plist(5)) - the host does
   // latency-sensitive RPC work and being CPU/IO-throttled (and pinned to
   // efficiency cores on Apple Silicon) starved the event loop on open.
+  // `Standard` is NOT that band: the man page defines it as "equivalent to
+  // no ProcessType being set", and unset means launchd applies "light
+  // resource limits to the job, throttling its CPU usage and I/O
+  // bandwidth". Measured under `Standard`, the host and every process it
+  // spawns sat at scheduling priority 20 (BASEPRI_UTILITY) while idle,
+  // versus 31 for a normal shell and 47 for a foreground app - so it lost
+  // every CPU race to the GUI it serves.
   const guiTarget = guiDomain();
   const serviceTarget = `${guiTarget}/${options.label.id}`;
   // Refuse to take over a label Desktop already owns via SMAppService.
@@ -1186,7 +1194,7 @@ ${programArgsXml}
   <key>ThrottleInterval</key>
   <integer>10</integer>
   <key>ProcessType</key>
-  <string>Standard</string>
+  <string>Interactive</string>
   <key>SoftResourceLimits</key>
   <dict>
     <key>NumberOfFiles</key>

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -630,7 +630,10 @@ function buildTaskXml(options: BuildTaskXmlOptions): string {
   // Normal CPU + Low I/O priority) - the host does latency-sensitive RPC work
   // and its priority class is inherited by every child it spawns (git,
   // provider CLIs), so the throttled band starved the whole app. Windows
-  // counterpart of the macOS LaunchAgent ProcessType Background->Standard fix.
+  // counterpart of the macOS LaunchAgent `ProcessType: Interactive` fix in
+  // platforms/macos.ts (that one landed in two steps - Background->Standard,
+  // then Standard->Interactive once `Standard` turned out to be launchd's
+  // throttled default rather than an unthrottled middle band).
   const action = buildTaskAction(options.label);
   const userId = resolveTaskUserId();
   return `<?xml version="1.0" encoding="UTF-16"?>


### PR DESCRIPTION
## Problem

`launchd.plist(5)` defines `ProcessType: Standard` as **"equivalent to no ProcessType being set"** — and unset means launchd applies *"light resource limits to the job, throttling its CPU usage and I/O bandwidth"*.

So `Standard` was never the unthrottled middle band it reads like. The host — which does latency-sensitive RPC work — and **every process it spawns** (agents, provider CLIs, terminals, dev stacks) ran in launchd's throttled band.

## Evidence

Measured on macOS 26.2. Under `Standard`, the host agent and its whole descendant tree sat at scheduling priority **20** (`BASEPRI_UTILITY`) *while idle* — so this was an assigned band, not CPU decay:

```
PID    PPID   NI  PRI  COMM
 3925  99943   0   20  zsh
99943  86663   0   20  claude
86663  86662   0   20  traycer-host runtime
86662      1   0   20  Traycer Host (launchd agent)
```

For reference on the same machine: `31` = normal shell (`iTermServer`), `46/47` = foreground app. A dev stack launched from a host-spawned terminal inherited band 20 and lost every CPU race to the GUI it serves — 1.6 s of CPU work stretched to 7.4 s wall (27% CPU utilisation), which was blowing a downstream service's 10 s Fastify plugin-boot timeout under load.

After the change, the same chain measures **31–37**, and `launchctl print` reports `spawn type = interactive (4)` instead of `daemon (3)`.

## Change

`ProcessType: Standard` → `Interactive` in both plist templates that must stay in lockstep:

- `clients/traycer-cli/src/service/platforms/macos.ts` — the CLI-written `~/Library/LaunchAgents` plist
- `clients/desktop/scripts/prepack/inject-host-launch-agent.cjs` — the in-bundle SMAppService plist

`Interactive` is the only band that runs *"with the same resource limitations as apps, that is to say, none"*.

## Other platforms

Audited; macOS was the only throttled one, so no functional change elsewhere:

| Platform | Mechanism | State |
|---|---|---|
| Windows | Task Scheduler `<Priority>` | `4` = `NORMAL_PRIORITY_CLASS` — already fixed |
| Linux | systemd user unit | no `Nice` / `CPUWeight` / `IOSchedulingClass` — never throttled |

`windows.ts` carried a cross-reference to the *superseded* macOS `Background->Standard` fix; it now points at the current state so it doesn't mislead.

## Rollout note

This changes the plist body, not the registration. Existing installs keep their loaded registration until an SMAppService bootout → unregister → register cycle runs (the same path the `pending-login-item-revision` marker exists for). Installs whose update bumps the host runtime pick it up on next launch; others need an ensure/repair cycle.

## Test plan

- [x] `pre-commit run --files <changed>` — all hooks pass, including `build · compile · lint · format (nx affected)`
- [x] Reinstalled locally; both in-bundle plists render `Interactive`
- [x] `launchctl print` confirms `spawn type = interactive (4)` and a respawned pid — the registration genuinely refreshed
- [x] Descendant chain verified off band 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)