### PR TITLE
fix(gui-app): sidebar chat hover-card fixes + native-tooltip migration

### DIFF
--- a/clients/gui-app/eslint.config.mjs
+++ b/clients/gui-app/eslint.config.mjs
@@ -96,7 +96,7 @@ const nativeTitleTooltipDomBan = {
 // no rule at all.
 const nativeTitleTooltipForwardingBan = {
   selector:
-    "JSXOpeningElement[name.name=/^(Button|Badge|DropdownMenuItem|SelectTrigger|Switch|ToolbarIconButton|ToolbarPillButton|StartTruncatedText|NodeViewWrapper|WorktreePickerTrigger)$/] > JSXAttribute[name.name='title']",
+    "JSXOpeningElement[name.name=/^(Button|Badge|DropdownMenuItem|DropdownMenuTrigger|DialogTrigger|PopoverTrigger|SelectTrigger|Switch|ToolbarIconButton|ToolbarPillButton|StartTruncatedText|NodeViewWrapper|WorktreePickerTrigger)$/] > JSXAttribute[name.name='title']",
   message:
     "This component forwards `title` to a DOM node, making it a native tooltip. Wrap it in <TooltipWrapper label={...}> (@/components/ui/tooltip-wrapper) instead.",
 };

--- a/clients/gui-app/eslint.config.mjs
+++ b/clients/gui-app/eslint.config.mjs
@@ -58,6 +58,49 @@ const reactForwardRefCallBan = {
   message:
     "React 19 treats refs as regular props. Type and destructure a `ref` prop instead of wrapping the component in React.forwardRef.",
 };
+// Native `title=` is a browser tooltip: ~700ms delay we do not control, no
+// styling, no touch support, invisible to most screen readers as anything more
+// than a duplicate of the accessible name, and it clips at the OS window edge.
+// `TooltipWrapper` is the app's one tooltip surface.
+//
+// SCOPE: lowercase names only, i.e. real DOM tags. `title` is an ordinary React
+// prop on plenty of components here (`SettingsPanelShell`, `SectionHeading`,
+// `ConfirmDestructiveDialog`, …) where it is a heading, not a tooltip - a
+// blanket ban on the attribute name would flag ~65 of those. The exceptions
+// below are the tags where `title` is SEMANTIC rather than a hover hint:
+// `iframe` (its accessible name - `jsx-a11y/iframe-has-title` actively requires
+// it), `abbr`/`dfn` (expansion of the term), and the metadata/option tags that
+// never render a hoverable box at all.
+//
+// Components that merely forward `title` to a DOM node (`Button`, `Badge`, …)
+// are covered by the companion ban below - they are native tooltips wearing a
+// capital letter.
+const nativeTitleTooltipDomBan = {
+  selector:
+    "JSXOpeningElement[name.name=/^(?!(iframe|abbr|dfn|optgroup|option|track|link|style|meta)$)[a-z][a-zA-Z0-9-]*$/] > JSXAttribute[name.name='title']",
+  message:
+    "Do not use the native `title` attribute as a tooltip. Wrap the element in <TooltipWrapper label={...}> (@/components/ui/tooltip-wrapper), and keep `aria-label` for the accessible name.",
+};
+
+// The shared primitives that spread their props onto a real DOM node, so a
+// `title` passed to them lands as a native tooltip exactly as if it had been
+// written on a `<button>`. Hand-maintained on purpose: it is the price of
+// letting `title` stay a legitimate prop name elsewhere. Add a component here
+// when it starts forwarding `title` to the DOM.
+//
+// The app's OWN wrappers are deliberately absent: rather than police a `title`
+// prop on each of them, they were renamed to take `tooltip` and now own a
+// `TooltipWrapper` internally (`StopButtonShell`, `RoleBadge`,
+// `PillToggleButton`, `ReferenceChipButton`, `IndicatorSpan`). A prop literally
+// named `tooltip` cannot be confused with the native attribute, so those need
+// no rule at all.
+const nativeTitleTooltipForwardingBan = {
+  selector:
+    "JSXOpeningElement[name.name=/^(Button|Badge|DropdownMenuItem|SelectTrigger|Switch|ToolbarIconButton|ToolbarPillButton|StartTruncatedText|NodeViewWrapper|WorktreePickerTrigger)$/] > JSXAttribute[name.name='title']",
+  message:
+    "This component forwards `title` to a DOM node, making it a native tooltip. Wrap it in <TooltipWrapper label={...}> (@/components/ui/tooltip-wrapper) instead.",
+};
+
 const epicTabRouteConstructionBan = {
   selector: "CallExpression[callee.name='epicTabRoute']",
   message:
@@ -72,6 +115,8 @@ const tabNavigationStoreActionBans = tabNavigationStoreActionRestrictions([]);
 const generalCustomSyntaxRestrictions = [
   jsxKeyNullishCoalesceLiteral,
   jsxKeyNullishCoalesceTemplate,
+  nativeTitleTooltipDomBan,
+  nativeTitleTooltipForwardingBan,
   forwardRefImportBan,
   forwardRefCallBan,
   reactForwardRefCallBan,
@@ -214,6 +259,27 @@ export default tseslint.config(
             },
           ],
         },
+      ],
+    },
+  },
+  {
+    // Rendered MARKDOWN, not app chrome. A Markdown link title is written by
+    // the document author and belongs on the anchor as `title` - that is the
+    // attribute the syntax maps to. Routing it through `TooltipWrapper` would
+    // restyle author content as app UI and drop the attribute from the DOM.
+    // The ban stays on for every other tooltip in this directory.
+    files: ["src/markdown/components/markdown-anchor.tsx"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...traycerTypeSafetyRestrictions,
+        noFullStoreSubscription,
+        ...generalCustomSyntaxRestrictions.filter(
+          (restriction) =>
+            restriction !== nativeTitleTooltipDomBan &&
+            restriction !== nativeTitleTooltipForwardingBan,
+        ),
+        ...nestedFocusBoundaryRestrictions([]),
       ],
     },
   },

--- a/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-progress-icon.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@/lib/registries/chat-session-registry", () => ({
 
 import { ChatProgressIcon } from "@/components/chat/chat-progress-icon";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 const createdHandles: ChatSessionStoreHandle[] = [];
 
 afterEach(() => {
@@ -70,7 +71,9 @@ describe("<ChatProgressIcon />", () => {
     renderIcon();
 
     expect(screen.queryByTestId(RUNNING_TEST_ID)).not.toBeNull();
-    expect(screen.queryByTitle("Agent in progress")).not.toBeNull();
+    expect(tooltipTextNear(screen.getByTestId(RUNNING_TEST_ID))).toBe(
+      "Agent in progress",
+    );
   });
 
   it("shows the static chat icon when an unopened chat is not active", () => {
@@ -144,7 +147,9 @@ describe("<ChatProgressIcon />", () => {
     renderIcon();
 
     expect(screen.queryByTestId(RUNNING_TEST_ID)).not.toBeNull();
-    expect(screen.queryByTitle("Agent in progress")).not.toBeNull();
+    expect(tooltipTextNear(screen.getByTestId(RUNNING_TEST_ID))).toBe(
+      "Agent in progress",
+    );
   });
 
   it("shows the muted background indicator instead of the turn spinner when only background work runs", () => {
@@ -203,7 +208,9 @@ describe("<ChatProgressIcon />", () => {
 
     expect(screen.queryByTestId(RUNNING_TEST_ID)).not.toBeNull();
     expect(screen.queryByTitle("Waiting for your approval")).toBeNull();
-    expect(screen.queryByTitle("Agent in progress")).not.toBeNull();
+    expect(tooltipTextNear(screen.getByTestId(RUNNING_TEST_ID))).toBe(
+      "Agent in progress",
+    );
   });
 
   it("shows the background glyph for an UNOPENED chat the host reports as background-only", () => {

--- a/clients/gui-app/src/components/chat/__tests__/queued-message-surface.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/queued-message-surface.test.tsx
@@ -21,6 +21,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import type { ChatSessionState } from "@/stores/chats/chat-session-store";
 import { optimisticQueuedItemId } from "@/stores/chats/optimistic-queue";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 interface TestDndEvent {
   readonly active: {
     readonly data: { readonly current: unknown };
@@ -604,8 +605,10 @@ describe("<QueuedMessagePanel />", () => {
     ).toBeNull();
     // ...but it is labelled as received and can still be reordered.
     expect(
-      within(agentRow).getByTitle(/Response received from/),
-    ).not.toBeNull();
+      tooltipTextNear(
+        within(agentRow).getByTestId("queued-message-sender-badge"),
+      ),
+    ).toMatch(/Response received from/);
     expect(
       within(agentRow).getByTestId("queued-message-drag-handle"),
     ).not.toBeNull();

--- a/clients/gui-app/src/components/chat/agent-stop-button.tsx
+++ b/clients/gui-app/src/components/chat/agent-stop-button.tsx
@@ -14,6 +14,7 @@ import { isUnknownHost } from "@/lib/host/constants";
 import { agentMutationKeys } from "@/lib/query-keys";
 import { toastFromHostError } from "@/lib/host-error-toast";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 /**
  * Resolves the directory entry for `hostId`, referentially stable across
  * renders (`useHostClientFor` requires a stable target). `null` for a local /
@@ -33,39 +34,49 @@ function StopButtonShell(props: {
   readonly disabled: boolean;
   readonly pending: boolean;
   readonly iconOnly: boolean;
-  readonly title: string | undefined;
+  /** Hover label; `tooltip` rather than `title` so a call site cannot be read
+   *  as the native attribute. */
+  readonly tooltip: string | undefined;
   readonly onClick: (() => void) | undefined;
   readonly testId: string | undefined;
 }) {
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="xs"
-      // NB: no `text-{color}` here. `cn`/tailwind-merge treats the custom
-      // `text-ui-xs` font-size token (from `size="xs"`) as a text-color class,
-      // so adding a real color class would win the conflict and silently drop
-      // the font size - leaving the button at the inherited (larger) size. The
-      // ghost variant already supplies the resting/hover colors, matching the
-      // sibling "Undo all" button.
-      className="shrink-0"
-      disabled={props.disabled}
-      onClick={props.onClick}
-      title={props.iconOnly ? (props.title ?? props.label) : props.title}
-      aria-label={props.iconOnly ? props.label : undefined}
-      data-testid={props.testId}
+    <TooltipWrapper
+      label={props.iconOnly ? (props.tooltip ?? props.label) : props.tooltip}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {props.pending ? (
-        <AgentSpinningDots
-          className="size-3"
-          testId={undefined}
-          variant={undefined}
-        />
-      ) : (
-        <Square aria-hidden className="size-3" />
-      )}
-      {props.iconOnly ? null : props.label}
-    </Button>
+      <span className="inline-flex">
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          // NB: no `text-{color}` here. `cn`/tailwind-merge treats the custom
+          // `text-ui-xs` font-size token (from `size="xs"`) as a text-color class,
+          // so adding a real color class would win the conflict and silently drop
+          // the font size - leaving the button at the inherited (larger) size. The
+          // ghost variant already supplies the resting/hover colors, matching the
+          // sibling "Undo all" button.
+          className="shrink-0"
+          disabled={props.disabled}
+          onClick={props.onClick}
+          aria-label={props.iconOnly ? props.label : undefined}
+          data-testid={props.testId}
+        >
+          {props.pending ? (
+            <AgentSpinningDots
+              className="size-3"
+              testId={undefined}
+              variant={undefined}
+            />
+          ) : (
+            <Square aria-hidden className="size-3" />
+          )}
+          {props.iconOnly ? null : props.label}
+        </Button>
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -89,11 +100,11 @@ function ReachableStopButton(props: {
   });
   return (
     <StopButtonShell
+      tooltip={undefined}
       label={props.label}
       disabled={stop.isPending}
       pending={stop.isPending}
       iconOnly={props.iconOnly}
-      title={undefined}
       testId={props.testId}
       onClick={() =>
         stop.mutate({
@@ -134,15 +145,15 @@ export function AgentStopButton(props: {
   if (!reachable || client === null) {
     return (
       <StopButtonShell
-        label={props.label}
-        disabled
-        pending={false}
-        iconOnly={props.iconOnly}
-        title={
+        tooltip={
           reachability.status === "unreachable"
             ? `Runs on ${reachability.hostLabel}`
             : undefined
         }
+        label={props.label}
+        disabled
+        pending={false}
+        iconOnly={props.iconOnly}
         onClick={undefined}
         testId={props.testId}
       />

--- a/clients/gui-app/src/components/chat/chat-agent-stop-list.tsx
+++ b/clients/gui-app/src/components/chat/chat-agent-stop-list.tsx
@@ -5,6 +5,7 @@ import { AgentStopButton } from "@/components/chat/agent-stop-button";
 import type { AgentRow } from "@/hooks/agent/use-agent-stop-controls";
 import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 /**
  * A row's `surface` is UI copy ("gui"/"tui"); opening a tile needs the
  * record-backed node kind. The two map 1:1 (the inverse of `surfaceOf` in
@@ -114,20 +115,26 @@ export function AgentStopList(props: {
           key={agent.id}
           className="group flex min-w-0 items-center gap-2 rounded-md pl-5 pr-2 hover:bg-muted/40"
         >
-          <button
-            type="button"
-            onClick={() => openAgent(agent)}
-            title={`Open ${agent.title}`}
-            className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md py-1 text-left focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+          <TooltipWrapper
+            label={`Open ${agent.title}`}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            <ActivityDot active={agent.active} />
-            <span className="block min-w-0 flex-1 truncate text-ui-xs text-foreground/85">
-              {agent.title}
-            </span>
-            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-ui-xs uppercase text-muted-foreground">
-              {agent.surface}
-            </span>
-          </button>
+            <button
+              type="button"
+              onClick={() => openAgent(agent)}
+              className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md py-1 text-left focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+            >
+              <ActivityDot active={agent.active} />
+              <span className="block min-w-0 flex-1 truncate text-ui-xs text-foreground/85">
+                {agent.title}
+              </span>
+              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-ui-xs uppercase text-muted-foreground">
+                {agent.surface}
+              </span>
+            </button>
+          </TooltipWrapper>
           <StopAffordance revealOnHover={compact}>
             <AgentStopButton
               epicId={props.epicId}

--- a/clients/gui-app/src/components/chat/chat-background-items-panel.tsx
+++ b/clients/gui-app/src/components/chat/chat-background-items-panel.tsx
@@ -27,6 +27,7 @@ import { TreeGroupGuide } from "@/components/epic-canvas/sidebar/epic-sidebar-tr
 import { buildTreeFromFlatRecords } from "@/lib/tree-utils";
 import type { TreeNodeNested } from "@/lib/tree-types";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface RememberedBackgroundNode {
   readonly kind: BackgroundItem["kind"];
   readonly title: string;
@@ -183,23 +184,31 @@ function BackgroundStopButton(props: {
   readonly onClick: () => void;
 }) {
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="xs"
-      className="shrink-0"
-      disabled={props.disabled}
-      aria-label={props.iconOnly ? props.label : undefined}
-      title={props.iconOnly ? props.label : undefined}
-      data-testid={props.testId}
-      onClick={(event) => {
-        event.stopPropagation();
-        props.onClick();
-      }}
+    <TooltipWrapper
+      label={props.iconOnly ? props.label : undefined}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <Square aria-hidden className="size-3" />
-      {props.iconOnly ? null : props.label}
-    </Button>
+      <span className="inline-flex">
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="shrink-0"
+          disabled={props.disabled}
+          aria-label={props.iconOnly ? props.label : undefined}
+          data-testid={props.testId}
+          onClick={(event) => {
+            event.stopPropagation();
+            props.onClick();
+          }}
+        >
+          <Square aria-hidden className="size-3" />
+          {props.iconOnly ? null : props.label}
+        </Button>
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -403,37 +412,47 @@ function BackgroundTreeRow(props: {
         }}
       >
         {item === null ? (
-          <div
-            className="flex min-w-0 flex-1 items-center gap-2 py-1 text-left"
-            title={displayTitle}
+          <TooltipWrapper
+            label={displayTitle}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            <BackgroundKindIcon kind={node.kind} />
-            <span className="block min-w-0 flex-1 truncate text-ui-xs text-muted-foreground">
-              {displayTitle}
-            </span>
-            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-ui-xs uppercase text-muted-foreground">
-              {backgroundKindLabel(node.kind)}
-            </span>
-          </div>
-        ) : (
-          <>
-            <button
-              type="button"
-              title={displayTitle}
-              className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md py-1 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              onClick={() => props.onItemClick(item)}
-            >
-              <BackgroundKindIcon kind={item.kind} />
-              <span className="block min-w-0 flex-1 truncate text-ui-xs text-foreground/85">
+            <div className="flex min-w-0 flex-1 items-center gap-2 py-1 text-left">
+              <BackgroundKindIcon kind={node.kind} />
+              <span className="block min-w-0 flex-1 truncate text-ui-xs text-muted-foreground">
                 {displayTitle}
               </span>
-              {item.kind === "mcp" && item.startedAt !== null ? (
-                <LiveElapsed startedAt={item.startedAt} />
-              ) : null}
               <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-ui-xs uppercase text-muted-foreground">
-                {backgroundKindLabel(item.kind)}
+                {backgroundKindLabel(node.kind)}
               </span>
-            </button>
+            </div>
+          </TooltipWrapper>
+        ) : (
+          <>
+            <TooltipWrapper
+              label={displayTitle}
+              side="top"
+              sideOffset={undefined}
+              align={undefined}
+            >
+              <button
+                type="button"
+                className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md py-1 text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                onClick={() => props.onItemClick(item)}
+              >
+                <BackgroundKindIcon kind={item.kind} />
+                <span className="block min-w-0 flex-1 truncate text-ui-xs text-foreground/85">
+                  {displayTitle}
+                </span>
+                {item.kind === "mcp" && item.startedAt !== null ? (
+                  <LiveElapsed startedAt={item.startedAt} />
+                ) : null}
+                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-ui-xs uppercase text-muted-foreground">
+                  {backgroundKindLabel(item.kind)}
+                </span>
+              </button>
+            </TooltipWrapper>
             <span className="inline-flex opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
               <BackgroundStopButton
                 label={backgroundStopLabel(item.kind)}

--- a/clients/gui-app/src/components/chat/chat-progress-icon.tsx
+++ b/clients/gui-app/src/components/chat/chat-progress-icon.tsx
@@ -16,6 +16,7 @@ import { EPIC_NODE_ICONS } from "@/lib/artifacts/node-display";
 import { cn } from "@/lib/utils";
 import { useSettingsStore } from "@/stores/settings/settings-store";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface ChatProgressIconProps {
   readonly epicId: string;
   readonly chatId: string;
@@ -134,15 +135,21 @@ function ChatProgressPresentation(props: {
   let idleIcon: ReactNode;
   if (props.isReadOnly) {
     idleIcon = (
-      <span
-        role="status"
-        aria-label="Read-only agent"
-        className={icon.className}
-        style={icon.style}
-        title="Read-only agent"
+      <TooltipWrapper
+        label="Read-only agent"
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <MessageSquareLock aria-hidden className="size-3.5" />
-      </span>
+        <span
+          role="status"
+          aria-label="Read-only agent"
+          className={icon.className}
+          style={icon.style}
+        >
+          <MessageSquareLock aria-hidden className="size-3.5" />
+        </span>
+      </TooltipWrapper>
     );
   } else if (props.defaultIcon !== undefined) {
     idleIcon = props.defaultIcon;

--- a/clients/gui-app/src/components/chat/composer/attachments/image-attachment-chip.tsx
+++ b/clients/gui-app/src/components/chat/composer/attachments/image-attachment-chip.tsx
@@ -13,6 +13,7 @@ import { useImageBlobUrl } from "@/lib/attachments/use-image-blob-url";
 import type { ImageAttachmentDisplayLabel } from "@/lib/composer/image-attachment-labels";
 import { fallbackImageAttachmentDisplayLabel } from "@/lib/composer/image-attachment-labels";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export interface ImageAttachmentChipProps {
   atom: ComposerImageAtom;
   displayLabel: ImageAttachmentDisplayLabel | undefined;
@@ -49,7 +50,6 @@ export function ImageAttachmentChip(props: ImageAttachmentChipProps) {
       <div
         ref={wrapperRef}
         className="group relative size-14 shrink-0 overflow-hidden rounded-md border border-border/70 bg-muted/40"
-        title={label.title}
       >
         <span
           className="pointer-events-none absolute left-0.5 top-0.5 z-10 flex h-4 min-w-4 items-center justify-center rounded-sm border border-border/70 bg-background/90 px-1 text-[0.625rem] font-semibold leading-none text-foreground shadow-sm"
@@ -57,27 +57,37 @@ export function ImageAttachmentChip(props: ImageAttachmentChipProps) {
         >
           {label.badgeLabel}
         </span>
-        <DialogTrigger asChild>
-          <button
-            type="button"
-            aria-label={`Open ${label.ariaLabel}`}
-            className="block size-full cursor-zoom-in focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            {src === null ? (
-              <div
-                className="size-full animate-pulse bg-muted/60"
-                aria-hidden
-              />
-            ) : (
-              <img
-                src={src}
-                alt={alt}
-                className="size-full object-cover"
-                draggable={false}
-              />
-            )}
-          </button>
-        </DialogTrigger>
+        {/* Scoped to the open/zoom trigger, not the chip: the chip also
+              holds the Remove button, and a chip-wide trigger meant focusing
+              Remove surfaced the filename tooltip. */}
+        <TooltipWrapper
+          label={label.title}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
+        >
+          <DialogTrigger asChild>
+            <button
+              type="button"
+              aria-label={`Open ${label.ariaLabel}`}
+              className="block size-full cursor-zoom-in focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {src === null ? (
+                <div
+                  className="size-full animate-pulse bg-muted/60"
+                  aria-hidden
+                />
+              ) : (
+                <img
+                  src={src}
+                  alt={alt}
+                  className="size-full object-cover"
+                  draggable={false}
+                />
+              )}
+            </button>
+          </DialogTrigger>
+        </TooltipWrapper>
         <Button
           type="button"
           size="icon"

--- a/clients/gui-app/src/components/chat/composer/content-renderer/render-node.tsx
+++ b/clients/gui-app/src/components/chat/composer/content-renderer/render-node.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { applyMarks } from "./render-marks";
 import type { ComposerContentRenderContext } from "./types";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const SKIPPED_NODES = new Set(["attachmentGroup"]);
 
 type NodeRenderer = (
@@ -98,17 +99,23 @@ function renderImageAttachment(
     });
   const classNames = context.profile.inlineChipClassNames;
   return (
-    <span
-      key={key}
-      aria-label={`Attached ${label.ariaLabel}`}
-      className={cn(classNames.root, "text-foreground/90")}
-      data-composer-image-id={id ?? undefined}
-      data-composer-chip="image-attachment"
-      title={label.title}
+    <TooltipWrapper
+      label={label.title}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <ImageIcon className={classNames.mutedIcon} aria-hidden />
-      <span className={classNames.text}>{label.inlineLabel}</span>
-    </span>
+      <span
+        key={key}
+        aria-label={`Attached ${label.ariaLabel}`}
+        className={cn(classNames.root, "text-foreground/90")}
+        data-composer-image-id={id ?? undefined}
+        data-composer-chip="image-attachment"
+      >
+        <ImageIcon className={classNames.mutedIcon} aria-hidden />
+        <span className={classNames.text}>{label.inlineLabel}</span>
+      </span>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/chat/composer/editor/nodes/image-attachment-node-view.tsx
+++ b/clients/gui-app/src/components/chat/composer/editor/nodes/image-attachment-node-view.tsx
@@ -7,6 +7,7 @@ import { fallbackImageAttachmentDisplayLabel } from "@/lib/composer/image-attach
 import { stringValue } from "@/lib/composer/tiptap-json-content";
 import { imageAttachmentDisplayLabelFromDecorations } from "./image-attachment-label-decorations";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const IMAGE_ATTACHMENT_CLASS_NAMES = composerInlineChipClassNames("regular");
 
 function ImageAttachmentNodeViewBase(props: NodeViewProps) {
@@ -20,24 +21,30 @@ function ImageAttachmentNodeViewBase(props: NodeViewProps) {
     });
 
   return (
-    <NodeViewWrapper
-      as="span"
-      aria-label={`Attached ${label.ariaLabel}`}
-      className={IMAGE_ATTACHMENT_CLASS_NAMES.root}
-      contentEditable={false}
-      data-composer-image-atom=""
-      data-composer-image-id={id ?? undefined}
-      data-composer-chip="image-attachment"
-      title={label.title}
+    <TooltipWrapper
+      label={label.title}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <ImageIcon
-        className={IMAGE_ATTACHMENT_CLASS_NAMES.mutedIcon}
-        aria-hidden
-      />
-      <span className={IMAGE_ATTACHMENT_CLASS_NAMES.text}>
-        {label.inlineLabel}
-      </span>
-    </NodeViewWrapper>
+      <NodeViewWrapper
+        as="span"
+        aria-label={`Attached ${label.ariaLabel}`}
+        className={IMAGE_ATTACHMENT_CLASS_NAMES.root}
+        contentEditable={false}
+        data-composer-image-atom=""
+        data-composer-image-id={id ?? undefined}
+        data-composer-chip="image-attachment"
+      >
+        <ImageIcon
+          className={IMAGE_ATTACHMENT_CLASS_NAMES.mutedIcon}
+          aria-hidden
+        />
+        <span className={IMAGE_ATTACHMENT_CLASS_NAMES.text}>
+          {label.inlineLabel}
+        </span>
+      </NodeViewWrapper>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/chat/composer/menu/composer-menu.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/composer-menu.tsx
@@ -46,6 +46,7 @@ import { MentionPreviewPanel } from "./mention-preview-panel";
 import { SlashMenuItem } from "./slash-menu-item";
 import { ZERO_DOM_RECT } from "./zero-dom-rect";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const SLASH_MENU_COPY = {
   header: "Slash commands",
   empty: "No matching commands",
@@ -314,26 +315,34 @@ function ComposerMenuPortal(props: ComposerMenuPortalProps) {
             ) : null}
           </div>
           {refreshAvailable ? (
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              aria-label="Refresh artifacts"
-              title="Refresh artifacts"
-              className="-my-1 text-muted-foreground/70 hover:text-foreground"
-              disabled={artifactRefresh.refreshing}
-              onMouseDown={(event) => {
-                event.preventDefault();
-              }}
-              onClick={artifactRefresh.trigger}
+            <TooltipWrapper
+              label="Refresh artifacts"
+              side="top"
+              sideOffset={undefined}
+              align={undefined}
             >
-              <RefreshCwIcon
-                className={cn(
-                  "size-3.5",
-                  artifactRefresh.refreshing && "animate-spin",
-                )}
-              />
-            </Button>
+              <span className="inline-flex">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label="Refresh artifacts"
+                  className="-my-1 text-muted-foreground/70 hover:text-foreground"
+                  disabled={artifactRefresh.refreshing}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                  }}
+                  onClick={artifactRefresh.trigger}
+                >
+                  <RefreshCwIcon
+                    className={cn(
+                      "size-3.5",
+                      artifactRefresh.refreshing && "animate-spin",
+                    )}
+                  />
+                </Button>
+              </span>
+            </TooltipWrapper>
           ) : null}
         </div>
         <div

--- a/clients/gui-app/src/components/chat/composer/menu/mention-menu-item.tsx
+++ b/clients/gui-app/src/components/chat/composer/menu/mention-menu-item.tsx
@@ -1,5 +1,6 @@
 import type { MentionMenuEntry } from "@/lib/composer/mentions";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export type { MentionMenuEntry } from "@/lib/composer/mentions";
 
 export interface MentionMenuItemProps {
@@ -16,12 +17,16 @@ export function MentionMenuItem(props: MentionMenuItemProps) {
         {entry.label}
       </span>
       {trailing ? (
-        <span
-          className="min-w-0 shrink max-w-[45%] truncate text-ui-xs text-muted-foreground/70"
-          title={entry.preview === null ? trailing : undefined}
+        <TooltipWrapper
+          label={entry.preview === null ? trailing : undefined}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          {trailing}
-        </span>
+          <span className="min-w-0 shrink max-w-[45%] truncate text-ui-xs text-muted-foreground/70">
+            {trailing}
+          </span>
+        </TooltipWrapper>
       ) : null}
     </div>
   );

--- a/clients/gui-app/src/components/chat/queued-message-surface.tsx
+++ b/clients/gui-app/src/components/chat/queued-message-surface.tsx
@@ -44,6 +44,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import type {
   ChatActiveTurn,
   ChatQueuedItem,
@@ -300,49 +301,55 @@ function QueuedMessageHeader(props: {
   });
 
   const header = (
-    <div
-      className="flex items-stretch"
-      data-testid="queued-message-header"
-      title={tooltip ?? undefined}
-    >
-      <CollapsibleTrigger
-        className="group/queue flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-        data-testid="queued-message-header-toggle"
+    <div className="flex items-stretch" data-testid="queued-message-header">
+      {/* On the collapse trigger, not the header strip: the strip also holds
+          Resume/Pause, and a strip-wide trigger surfaced this queue-state text
+          while hovering either of those buttons. */}
+      <TooltipWrapper
+        label={tooltip}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <ChevronDown
-          aria-hidden
-          className={cn(
-            "size-3 shrink-0 text-muted-foreground/70 transition-transform",
-            open ? null : "-rotate-90",
-          )}
-        />
-        {queueStatus === "running" ? (
-          <LivePulse
-            size="xs"
-            tone="active"
-            ariaLabel="Queue running"
-            className={undefined}
-          />
-        ) : null}
-        <span className="shrink-0 text-ui-xs font-medium text-foreground/85">
-          Message Queue
-        </span>
-        <span
-          aria-hidden
-          data-testid="queued-message-header-divider"
-          className="shrink-0 text-muted-foreground/40"
+        <CollapsibleTrigger
+          className="group/queue flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          data-testid="queued-message-header-toggle"
         >
-          ·
-        </span>
-        <ListOrdered
-          className="size-3.5 shrink-0 text-muted-foreground/70"
-          data-testid="queued-message-header-status-icon"
-          aria-hidden
-        />
-        <span className="min-w-0 flex-1 truncate text-ui-xs text-muted-foreground">
-          {count === 1 ? "1 message" : `${count} messages`}
-        </span>
-      </CollapsibleTrigger>
+          <ChevronDown
+            aria-hidden
+            className={cn(
+              "size-3 shrink-0 text-muted-foreground/70 transition-transform",
+              open ? null : "-rotate-90",
+            )}
+          />
+          {queueStatus === "running" ? (
+            <LivePulse
+              size="xs"
+              tone="active"
+              ariaLabel="Queue running"
+              className={undefined}
+            />
+          ) : null}
+          <span className="shrink-0 text-ui-xs font-medium text-foreground/85">
+            Message Queue
+          </span>
+          <span
+            aria-hidden
+            data-testid="queued-message-header-divider"
+            className="shrink-0 text-muted-foreground/40"
+          >
+            ·
+          </span>
+          <ListOrdered
+            className="size-3.5 shrink-0 text-muted-foreground/70"
+            data-testid="queued-message-header-status-icon"
+            aria-hidden
+          />
+          <span className="min-w-0 flex-1 truncate text-ui-xs text-muted-foreground">
+            {count === 1 ? "1 message" : `${count} messages`}
+          </span>
+        </CollapsibleTrigger>
+      </TooltipWrapper>
       {readOnly ? (
         <span className="flex shrink-0 items-center px-3 text-ui-xs text-muted-foreground">
           Owner manages queue
@@ -714,13 +721,20 @@ function ReceivedAgentBadge(props: {
       ? props.sender.displayName
       : `${props.sender.agentId.slice(0, 8)}…`;
   return (
-    <span
-      className="inline-flex shrink-0 items-center gap-1 rounded-sm border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-ui-xs font-medium text-primary"
-      title={`Response received from ${name}`}
+    <TooltipWrapper
+      label={`Response received from ${name}`}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <Inbox className="size-3" aria-hidden />
-      <span className="max-w-[8rem] truncate">{name}</span>
-    </span>
+      <span
+        className="inline-flex shrink-0 items-center gap-1 rounded-sm border border-primary/30 bg-primary/10 px-1.5 py-0.5 text-ui-xs font-medium text-primary"
+        data-testid="queued-message-sender-badge"
+      >
+        <Inbox className="size-3" aria-hidden />
+        <span className="max-w-[8rem] truncate">{name}</span>
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -831,7 +845,6 @@ function QueuedMessageAbortSteerButton(props: {
             variant="ghost"
             className="size-7 shrink-0 text-muted-foreground"
             aria-label="Cancel steer"
-            title="Cancel steer"
             onClick={props.onAbortSteer}
           >
             <Undo2 className="size-3.5" />
@@ -857,30 +870,42 @@ function QueuedMessageRowActions(props: {
   return (
     <div className="ml-auto flex shrink-0 items-center justify-end gap-0.5">
       <span className="flex shrink-0 items-center gap-0.5">
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          className="size-7 shrink-0 text-muted-foreground"
-          disabled={props.actionsDisabled}
-          aria-label={props.editLabel}
-          title={props.editTitle}
-          onClick={props.onEdit}
+        <TooltipWrapper
+          label={props.editTitle}
+          side="top"
+          sideOffset={6}
+          align={undefined}
         >
-          <Pencil className="size-3.5" />
-        </Button>
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          className="size-7 shrink-0 text-muted-foreground"
-          disabled={props.actionsDisabled}
-          aria-label="Delete queued message"
-          title="Delete queued message"
-          onClick={props.onCancel}
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="size-7 shrink-0 text-muted-foreground"
+            disabled={props.actionsDisabled}
+            aria-label={props.editLabel}
+            onClick={props.onEdit}
+          >
+            <Pencil className="size-3.5" />
+          </Button>
+        </TooltipWrapper>
+        <TooltipWrapper
+          label="Delete queued message"
+          side="top"
+          sideOffset={6}
+          align={undefined}
         >
-          <Trash2 className="size-3.5" />
-        </Button>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="size-7 shrink-0 text-muted-foreground"
+            disabled={props.actionsDisabled}
+            aria-label="Delete queued message"
+            onClick={props.onCancel}
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+        </TooltipWrapper>
       </span>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -892,7 +917,6 @@ function QueuedMessageRowActions(props: {
               className="size-7 shrink-0 text-muted-foreground"
               disabled={props.steerNowDisabled}
               aria-label="Steer queued message now"
-              title="Steer queued message now"
               onClick={props.onSteerNow}
             >
               <SendHorizontal className="size-3.5" />

--- a/clients/gui-app/src/components/chat/segments/__tests__/artifact-card-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/artifact-card-segment.test.tsx
@@ -7,6 +7,7 @@ import { commitResolvedCanvasDrop } from "@/components/epic-canvas/dnd/root-dnd-
 import type { EpicArtifactRef } from "@/stores/epics/canvas/types";
 import type { NavigateNestedFocus } from "@/lib/epic-nested-focus-navigation";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 type TestArtifactProjection = {
   readonly id: string;
   readonly kind: EpicArtifactKind;
@@ -350,7 +351,7 @@ describe("<ArtifactCardSegment />", () => {
     expect(screen.getByText("−")).toBeTruthy();
     const title = screen.getByText("Removed Spec");
     expect(title.className).toContain("line-through");
-    expect(title.getAttribute("title")).toBe("This artifact was deleted.");
+    expect(tooltipTextNear(title)).toBe("This artifact was deleted.");
     expect(screen.queryByText("deleted")).toBeNull();
     // A tombstone has no body - it cannot be opened.
     expect(screen.queryByRole("button", { name: /Open/ })).toBeNull();
@@ -372,7 +373,7 @@ describe("<ArtifactCardSegment />", () => {
     expect(screen.getByText("−")).toBeTruthy();
     const title = screen.getByText("Fallback Deleted Spec");
     expect(title.className).toContain("line-through");
-    expect(title.getAttribute("title")).toBe("This artifact was deleted.");
+    expect(tooltipTextNear(title)).toBe("This artifact was deleted.");
     expect(screen.queryByRole("button", { name: /Open/ })).toBeNull();
   });
 
@@ -393,7 +394,7 @@ describe("<ArtifactCardSegment />", () => {
     expect(screen.queryByText("−")).toBeNull();
     const title = screen.getByText("Deleted Before Tombstone");
     expect(title.className).toContain("line-through");
-    expect(title.getAttribute("title")).toBe("This artifact was deleted.");
+    expect(tooltipTextNear(title)).toBe("This artifact was deleted.");
     expect(screen.queryByText("deleted")).toBeNull();
     expect(screen.queryByRole("button", { name: /Open/ })).toBeNull();
   });
@@ -416,7 +417,7 @@ describe("<ArtifactCardSegment />", () => {
     expect(screen.queryByText("−")).toBeNull();
     const title = screen.getByText("Missing Created Spec");
     expect(title.className).toContain("line-through");
-    expect(title.getAttribute("title")).toBe("This artifact was deleted.");
+    expect(tooltipTextNear(title)).toBe("This artifact was deleted.");
     expect(screen.queryByText("deleted")).toBeNull();
     expect(screen.queryByRole("button", { name: /Open/ })).toBeNull();
   });

--- a/clients/gui-app/src/components/chat/segments/agent-message-copy-button.tsx
+++ b/clients/gui-app/src/components/chat/segments/agent-message-copy-button.tsx
@@ -4,6 +4,7 @@ import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 import { cn } from "@/lib/utils";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const COPIED_RESET_MS = 1600;
 
 const handleCopyError = (): void => {
@@ -35,23 +36,29 @@ export function AgentMessageCopyButton(props: {
   const handleCopy = useCallback(() => copy(value), [copy, value]);
 
   return (
-    <button
-      type="button"
-      onClick={handleCopy}
-      aria-label={copied ? "Copied" : "Copy message"}
-      title={copied ? "Copied" : "Copy message"}
-      className={cn(
-        "absolute top-2 right-2 z-10 flex size-7 items-center justify-center",
-        "cursor-pointer rounded-md border border-border bg-muted text-muted-foreground shadow-md",
-        "transition-colors hover:bg-accent hover:text-foreground",
-        "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
-      )}
+    <TooltipWrapper
+      label={copied ? "Copied" : "Copy message"}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {copied ? (
-        <Check className="size-3.5" aria-hidden />
-      ) : (
-        <Copy className="size-3.5" aria-hidden />
-      )}
-    </button>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : "Copy message"}
+        className={cn(
+          "absolute top-2 right-2 z-10 flex size-7 items-center justify-center",
+          "cursor-pointer rounded-md border border-border bg-muted text-muted-foreground shadow-md",
+          "transition-colors hover:bg-accent hover:text-foreground",
+          "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+        )}
+      >
+        {copied ? (
+          <Check className="size-3.5" aria-hidden />
+        ) : (
+          <Copy className="size-3.5" aria-hidden />
+        )}
+      </button>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/chat/segments/approval-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/approval-segment.tsx
@@ -7,6 +7,7 @@ import { SegmentCard } from "./segment-card";
 import { SegmentRow } from "./segment-row";
 import { ToolInputPanel } from "./tool-input-panel";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface ResolvedApprovalSegmentProps {
   toolName: string | null;
   description: string | null;
@@ -131,12 +132,16 @@ function ResolvedApprovalHeader(props: {
         <span aria-hidden className="flex-1" />
       )}
       {!decision.approved && decision.reason !== null ? (
-        <span
-          className="@max-[28rem]:hidden shrink-0 truncate text-ui-xs text-destructive/80"
-          title={decision.reason}
+        <TooltipWrapper
+          label={decision.reason}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          {decision.reason}
-        </span>
+          <span className="@max-[28rem]:hidden shrink-0 truncate text-ui-xs text-destructive/80">
+            {decision.reason}
+          </span>
+        </TooltipWrapper>
       ) : null}
     </>
   );

--- a/clients/gui-app/src/components/chat/segments/artifact-card-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/artifact-card-segment.tsx
@@ -22,6 +22,7 @@ import { useArtifactDragSource } from "@/components/epic-canvas/dnd/use-artifact
 import { OpenFullDiffControl } from "./open-full-diff-control";
 import { SnapshotHashInlineDiff } from "./snapshot-hash-inline-diff";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface ArtifactCardSegmentProps {
   readonly operation: ArtifactOperationAction;
   readonly artifactKind: EpicArtifactKind;
@@ -45,25 +46,31 @@ function ArtifactDiffToggle(props: {
 }) {
   const label = props.open ? "Hide diff" : "View diff";
   return (
-    <button
-      type="button"
-      aria-label={label}
-      aria-expanded={props.open}
-      title={label}
-      onClick={(event) => {
-        event.stopPropagation();
-        props.onToggle();
-      }}
-      className={cn(
-        "flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md border transition-colors",
-        "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
-        props.open
-          ? "border-border bg-muted/60 text-foreground"
-          : "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-      )}
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <FileDiff aria-hidden className="size-3.5" />
-    </button>
+      <button
+        type="button"
+        aria-label={label}
+        aria-expanded={props.open}
+        onClick={(event) => {
+          event.stopPropagation();
+          props.onToggle();
+        }}
+        className={cn(
+          "flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-md border transition-colors",
+          "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+          props.open
+            ? "border-border bg-muted/60 text-foreground"
+            : "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+        )}
+      >
+        <FileDiff aria-hidden className="size-3.5" />
+      </button>
+    </TooltipWrapper>
   );
 }
 
@@ -212,46 +219,64 @@ function ArtifactOperationBadge(props: {
   const label = artifactOperationVerb(props.operation);
   if (props.operation === "create") {
     return (
-      <span
-        className={cn(
-          base,
-          "border-emerald-500 bg-emerald-50 text-emerald-600 dark:border-emerald-400 dark:bg-emerald-950/60 dark:text-emerald-300",
-        )}
-        title={label}
+      <TooltipWrapper
+        label={label}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <span className="sr-only">{label}</span>
-        <span aria-hidden>+</span>
-      </span>
+        <span
+          className={cn(
+            base,
+            "border-emerald-500 bg-emerald-50 text-emerald-600 dark:border-emerald-400 dark:bg-emerald-950/60 dark:text-emerald-300",
+          )}
+        >
+          <span className="sr-only">{label}</span>
+          <span aria-hidden>+</span>
+        </span>
+      </TooltipWrapper>
     );
   }
   if (props.operation === "update") {
     return (
-      <span
-        className={cn(
-          base,
-          "border-amber-500 bg-amber-50 shadow-amber-950/5 dark:border-amber-400 dark:bg-amber-950/60",
-        )}
-        title={label}
+      <TooltipWrapper
+        label={label}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <span className="sr-only">{label}</span>
         <span
-          className="size-1.5 rounded-sm bg-amber-500 dark:bg-amber-300"
-          aria-hidden
-        />
-      </span>
+          className={cn(
+            base,
+            "border-amber-500 bg-amber-50 shadow-amber-950/5 dark:border-amber-400 dark:bg-amber-950/60",
+          )}
+        >
+          <span className="sr-only">{label}</span>
+          <span
+            className="size-1.5 rounded-sm bg-amber-500 dark:bg-amber-300"
+            aria-hidden
+          />
+        </span>
+      </TooltipWrapper>
     );
   }
   return (
-    <span
-      className={cn(
-        base,
-        "border-red-500 bg-red-50 text-red-600 dark:border-red-500 dark:bg-red-950/60 dark:text-red-300",
-      )}
-      title={label}
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <span className="sr-only">{label}</span>
-      <span aria-hidden>−</span>
-    </span>
+      <span
+        className={cn(
+          base,
+          "border-red-500 bg-red-50 text-red-600 dark:border-red-500 dark:bg-red-950/60 dark:text-red-300",
+        )}
+      >
+        <span className="sr-only">{label}</span>
+        <span aria-hidden>−</span>
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -390,15 +415,21 @@ function ArtifactTitle(props: {
     );
   }
   return (
-    <span
-      className={cn(
-        "min-w-0 flex-1 truncate text-ui-base font-semibold text-foreground/95",
-        props.isDeleted && "text-muted-foreground line-through",
-      )}
-      title={props.isDeleted ? "This artifact was deleted." : undefined}
+    <TooltipWrapper
+      label={props.isDeleted ? "This artifact was deleted." : undefined}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {props.title}
-    </span>
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate text-ui-base font-semibold text-foreground/95",
+          props.isDeleted && "text-muted-foreground line-through",
+        )}
+      >
+        {props.title}
+      </span>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/chat/segments/composer-slot-file-edit-approval-queue.tsx
+++ b/clients/gui-app/src/components/chat/segments/composer-slot-file-edit-approval-queue.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface ComposerSlotFileEditApprovalQueueProps {
   readonly approvals: ReadonlyArray<ChatFileEditApprovalState>;
   readonly canAct: boolean;
@@ -115,13 +116,17 @@ function FileEditApprovalRow(props: FileEditApprovalRowProps) {
       {props.approval.paths.length > 0 ? (
         <ul className="m-0 flex min-w-0 flex-col gap-1 p-0">
           {props.approval.paths.map((filePath) => (
-            <li
+            <TooltipWrapper
               key={filePath}
-              className="min-w-0 truncate rounded-sm bg-canvas/70 px-2 py-1 font-mono text-code-sm text-canvas-foreground/80"
-              title={filePath}
+              label={filePath}
+              side="top"
+              sideOffset={undefined}
+              align={undefined}
             >
-              {filePath}
-            </li>
+              <li className="min-w-0 truncate rounded-sm bg-canvas/70 px-2 py-1 font-mono text-code-sm text-canvas-foreground/80">
+                {filePath}
+              </li>
+            </TooltipWrapper>
           ))}
         </ul>
       ) : (

--- a/clients/gui-app/src/components/chat/segments/forked-chat-link-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/forked-chat-link-segment.tsx
@@ -2,6 +2,7 @@ import { GitBranch } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface ForkedChatLinkSegmentProps {
   readonly viewTabId: string;
   readonly sourceChatId: string;
@@ -29,20 +30,26 @@ export function ForkedChatLinkSegment(props: ForkedChatLinkSegmentProps) {
       className="flex w-full items-center gap-3 py-4 text-ui-sm text-muted-foreground"
     >
       <div className="h-px min-w-0 flex-1 bg-border" aria-hidden />
-      <button
-        type="button"
-        data-find-include="true"
-        className="inline-flex min-w-0 items-center gap-1.5 text-primary underline underline-offset-4 transition-colors hover:text-primary/80 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-        aria-label={`Open source conversation ${sourceChatTitle}`}
-        title={sourceChatTitle}
-        onClick={openSourceConversation}
+      <TooltipWrapper
+        label={sourceChatTitle}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <GitBranch
-          className="size-3.5 shrink-0 text-muted-foreground"
-          aria-hidden
-        />
-        <span className="truncate">Forked from conversation</span>
-      </button>
+        <button
+          type="button"
+          data-find-include="true"
+          className="inline-flex min-w-0 items-center gap-1.5 text-primary underline underline-offset-4 transition-colors hover:text-primary/80 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+          aria-label={`Open source conversation ${sourceChatTitle}`}
+          onClick={openSourceConversation}
+        >
+          <GitBranch
+            className="size-3.5 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+          <span className="truncate">Forked from conversation</span>
+        </button>
+      </TooltipWrapper>
       <div className="h-px min-w-0 flex-1 bg-border" aria-hidden />
     </div>
   );

--- a/clients/gui-app/src/components/chat/segments/open-full-diff-control.tsx
+++ b/clients/gui-app/src/components/chat/segments/open-full-diff-control.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/chat/chat-diff-target";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 /**
  * Floating "open full diff" affordance for the artifact diff viewer. Opens the
  * merged diff in a canvas tab, mirroring a `file_change` path-click: single
@@ -44,36 +45,42 @@ export function OpenFullDiffControl(props: {
   );
   if (handlers === null) return null;
   return (
-    <span
-      role="button"
-      tabIndex={0}
-      aria-label="Open full diff"
-      title="Open full diff"
-      onClick={(event) => {
-        event.stopPropagation();
-        handlers.onClick();
-      }}
-      onDoubleClick={(event) => {
-        event.stopPropagation();
-        handlers.onDoubleClick();
-      }}
-      onKeyDown={(event) => {
-        if (event.key !== "Enter" && event.key !== " ") return;
-        event.preventDefault();
-        event.stopPropagation();
-        handlers.onClick();
-      }}
-      className={cn(
-        "absolute top-full right-2 z-30 mt-2 flex size-7 items-center justify-center",
-        // A solid surface so the button reads clearly over diff rows. `--muted`
-        // is the distinct neutral (unlike `--popover`/`--card`, which equal
-        // `--background` in most themes and so blend into the diff base rows).
-        "cursor-pointer rounded-md border border-border bg-muted text-muted-foreground shadow-md",
-        "transition-colors hover:bg-accent hover:text-foreground",
-        "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
-      )}
+    <TooltipWrapper
+      label="Open full diff"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <Maximize2 aria-hidden className="size-3.5" />
-    </span>
+      <span
+        role="button"
+        tabIndex={0}
+        aria-label="Open full diff"
+        onClick={(event) => {
+          event.stopPropagation();
+          handlers.onClick();
+        }}
+        onDoubleClick={(event) => {
+          event.stopPropagation();
+          handlers.onDoubleClick();
+        }}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter" && event.key !== " ") return;
+          event.preventDefault();
+          event.stopPropagation();
+          handlers.onClick();
+        }}
+        className={cn(
+          "absolute top-full right-2 z-30 mt-2 flex size-7 items-center justify-center",
+          // A solid surface so the button reads clearly over diff rows. `--muted`
+          // is the distinct neutral (unlike `--popover`/`--card`, which equal
+          // `--background` in most themes and so blend into the diff base rows).
+          "cursor-pointer rounded-md border border-border bg-muted text-muted-foreground shadow-md",
+          "transition-colors hover:bg-accent hover:text-foreground",
+          "focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+        )}
+      >
+        <Maximize2 aria-hidden className="size-3.5" />
+      </span>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/chat/user-message-attachment-gallery.tsx
+++ b/clients/gui-app/src/components/chat/user-message-attachment-gallery.tsx
@@ -19,6 +19,7 @@ import {
 import type { Attachment, ImageAttachment } from "@/lib/composer/types";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface UserMessageAttachmentGalleryProps {
   readonly align: "start" | "end";
   readonly attachments: ReadonlyArray<Attachment>;
@@ -168,20 +169,26 @@ function ImageAttachmentThumb({
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <button
-          type="button"
-          aria-label={triggerAriaLabel}
-          title={label.title}
-          className="group relative size-12 overflow-hidden rounded-md border border-border/70 bg-muted/40 outline-none transition-colors hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring"
+        <TooltipWrapper
+          label={label.title}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          <span
-            className="pointer-events-none absolute left-0.5 top-0.5 z-10 flex h-4 min-w-4 items-center justify-center rounded-sm border border-border/70 bg-background/90 px-1 text-[0.625rem] font-semibold leading-none text-foreground shadow-sm"
-            data-user-message-image-badge={label.badgeLabel}
+          <button
+            type="button"
+            aria-label={triggerAriaLabel}
+            className="group relative size-12 overflow-hidden rounded-md border border-border/70 bg-muted/40 outline-none transition-colors hover:border-foreground/40 focus-visible:ring-2 focus-visible:ring-ring"
           >
-            {label.badgeLabel}
-          </span>
-          {thumbnail}
-        </button>
+            <span
+              className="pointer-events-none absolute left-0.5 top-0.5 z-10 flex h-4 min-w-4 items-center justify-center rounded-sm border border-border/70 bg-background/90 px-1 text-[0.625rem] font-semibold leading-none text-foreground shadow-sm"
+              data-user-message-image-badge={label.badgeLabel}
+            >
+              {label.badgeLabel}
+            </span>
+            {thumbnail}
+          </button>
+        </TooltipWrapper>
       </DialogTrigger>
       <DialogContent
         className="w-[min(95vw,80rem)] max-w-[min(95vw,80rem)] bg-popover/95 p-2 sm:max-w-[min(95vw,80rem)]"

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip-title.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip-title.test.tsx
@@ -31,6 +31,7 @@ import type { SplitDirection } from "@/stores/epics/canvas/types";
 import { TestEpicSessionWrapper } from "./test-epic-session";
 import { createEpicSessionTestHarness } from "./test-epic-session-harness";
 
+import { anyTooltipHasText } from "@/components/ui/__tests__/tooltip-probe";
 vi.mock("@tanstack/react-router", () => ({
   useNavigate: () => vi.fn(),
 }));
@@ -271,7 +272,7 @@ describe("TabStrip title", () => {
         screen.getByTestId(`chat-tab-spinner-activity-${CHAT_ID}`),
       ).toBeTruthy();
     });
-    expect(screen.getByTitle("Agent in progress")).toBeTruthy();
+    expect(anyTooltipHasText("Agent in progress")).toBe(true);
     expect(
       screen.queryByTestId(`tab-title-generating-${TAB.instanceId}`),
     ).toBeNull();

--- a/clients/gui-app/src/components/epic-canvas/canvas/search-run-view.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/search-run-view.tsx
@@ -55,6 +55,7 @@ import type {
 import type { CommandContext } from "@/lib/commands/types";
 import type { SearchRunTarget } from "@/lib/commands/sources/open/search-target";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export interface SearchRunViewProps {
   readonly target: SearchRunTarget;
   readonly ctx: CommandContext;
@@ -508,22 +509,28 @@ function OptionToggle({
   children,
 }: OptionToggleProps) {
   return (
-    <button
-      type="button"
-      aria-pressed={active}
-      aria-label={label}
-      title={label}
-      onClick={onToggle}
-      onKeyDown={isolateFromCmdk}
-      className={cn(
-        "flex h-6 min-w-6 items-center justify-center rounded-sm px-1.5 font-mono text-ui-xs transition-colors",
-        active
-          ? "bg-primary/15 text-foreground ring-1 ring-primary/40"
-          : "text-muted-foreground hover:bg-muted/55 hover:text-foreground",
-      )}
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {children}
-    </button>
+      <button
+        type="button"
+        aria-pressed={active}
+        aria-label={label}
+        onClick={onToggle}
+        onKeyDown={isolateFromCmdk}
+        className={cn(
+          "flex h-6 min-w-6 items-center justify-center rounded-sm px-1.5 font-mono text-ui-xs transition-colors",
+          active
+            ? "bg-primary/15 text-foreground ring-1 ring-primary/40"
+            : "text-muted-foreground hover:bg-muted/55 hover:text-foreground",
+        )}
+      >
+        {children}
+      </button>
+    </TooltipWrapper>
   );
 }
 
@@ -536,15 +543,21 @@ interface GlobInputProps {
 
 function GlobInput({ label, placeholder, value, onChange }: GlobInputProps) {
   return (
-    <input
-      type="text"
-      aria-label={label}
-      title={`${label} (comma-separated globs)`}
-      placeholder={placeholder}
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-      onKeyDown={isolateFromCmdk}
-      className="h-6 min-w-[7rem] flex-1 rounded-sm bg-muted/40 px-1.5 text-ui-xs outline-hidden placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-primary/40"
-    />
+    <TooltipWrapper
+      label={`${label} (comma-separated globs)`}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <input
+        type="text"
+        aria-label={label}
+        placeholder={placeholder}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={isolateFromCmdk}
+        className="h-6 min-w-[7rem] flex-1 rounded-sm bg-muted/40 px-1.5 text-ui-xs outline-hidden placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-primary/40"
+      />
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-changed-file-row.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-changed-file-row.test.tsx
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import type { GitChangedFile } from "@traycer/protocol/host";
 import { GitChangedFileRow } from "@/components/epic-canvas/git-diff/git-changed-file-row";
 import { NO_HIGHLIGHT, type HighlightRanges } from "@/lib/git/path-highlight";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 afterEach(() => {
   cleanup();
 });
@@ -309,7 +310,25 @@ describe("GitChangedFileRow panel density", () => {
 });
 
 describe("GitChangedFileRow tile density", () => {
-  it("keeps the native title tooltip", () => {
+  it("keeps the full-path tooltip", () => {
+    renderRow({
+      file: makeFile({ path: "src/app.tsx", previousPath: null }),
+      density: "tile",
+      active: false,
+      pathRanges: NO_HIGHLIGHT,
+    });
+
+    // Scoped to the FILENAME, not the row: the row also carries the status
+    // badge, which owns its own tooltip at this density.
+    const row = screen.getByRole("button", { name: "Modified app.tsx" });
+    expect(tooltipTextNear(within(row).getByText("app.tsx"))).toBe(
+      "src/app.tsx",
+    );
+  });
+
+  it("keeps the status badge's own tooltip separate from the path", () => {
+    // One tooltip per hover target: hovering the badge must explain the STATUS,
+    // not repeat the path.
     renderRow({
       file: makeFile({ path: "src/app.tsx", previousPath: null }),
       density: "tile",
@@ -318,6 +337,8 @@ describe("GitChangedFileRow tile density", () => {
     });
 
     const row = screen.getByRole("button", { name: "Modified app.tsx" });
-    expect(row.getAttribute("title")).toBe("src/app.tsx");
+    expect(tooltipTextNear(within(row).getByLabelText("Modified"))).toBe(
+      "Modified",
+    );
   });
 });

--- a/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-repo-switcher.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/__tests__/git-diff-repo-switcher.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { WorktreeBindingSelectorRowV12 } from "@traycer/protocol/host";
 import type { GitSubmoduleSummary } from "@/lib/git/git-repo-tree";
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 import {
   buildGitDiffRepoSwitcherModel,
   type GitDiffRepoSelection,
@@ -188,13 +189,13 @@ describe("<GitDiffRepoSwitcherDropdown />", () => {
       screen.getByTestId("repo-switcher-trigger").textContent,
     ).not.toContain("vendor/traycer");
     expect(
-      screen.getByTestId("repo-switcher-trigger").getAttribute("title"),
+      tooltipTextNear(screen.getByTestId("repo-switcher-trigger")),
     ).toContain(`Path: /repo`);
     expect(
-      screen.getByTestId("repo-switcher-trigger").getAttribute("title"),
+      tooltipTextNear(screen.getByTestId("repo-switcher-trigger")),
     ).toContain("1 changed submodule");
     expect(
-      screen.getByTestId("repo-switcher-trigger").getAttribute("title"),
+      tooltipTextNear(screen.getByTestId("repo-switcher-trigger")),
     ).toContain("6 changed files");
     expect(
       screen.getByRole("button", {
@@ -261,7 +262,7 @@ describe("<GitDiffRepoSwitcherDropdown />", () => {
     expect(trigger.getAttribute("data-unavailable")).toBe("true");
     expect(trigger.getAttribute("aria-invalid")).toBeNull();
     expect(trigger.getAttribute("aria-label")).toContain("unavailable");
-    expect(trigger.getAttribute("title")).toContain("Status: unavailable");
+    expect(tooltipTextNear(trigger)).toContain("Status: unavailable");
   });
 
   it("renders workspace rows only with stable path subtext", () => {

--- a/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-toolbar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/diff-tab-toolbar.tsx
@@ -29,6 +29,7 @@ import {
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 // @pierre/diffs gutter indicator styles, mapped to a representative icon.
 const INDICATOR_OPTIONS: ReadonlyArray<{
   readonly value: GitDiffIndicatorStyle;
@@ -104,76 +105,106 @@ export function DiffTabToolbar(props: DiffTabToolbarProps) {
   return (
     <div className="flex items-center gap-0.5">
       {collapseAll !== null ? (
+        <TooltipWrapper
+          label={collapseAll.allCollapsed ? "Expand all" : "Collapse all"}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
+        >
+          <Button
+            type="button"
+            onClick={() =>
+              props.onViewPatch({
+                collapsedFilePaths: collapseAll.allCollapsed
+                  ? []
+                  : [...collapseAll.filePaths],
+              })
+            }
+            variant="ghost"
+            size="icon-sm"
+            aria-label={
+              collapseAll.allCollapsed ? "Expand all" : "Collapse all"
+            }
+            className="text-muted-foreground hover:text-foreground"
+          >
+            {collapseAll.allCollapsed ? (
+              <ChevronsUpDown className="size-4" />
+            ) : (
+              <ChevronsDownUp className="size-4" />
+            )}
+          </Button>
+        </TooltipWrapper>
+      ) : null}
+
+      <TooltipWrapper
+        label={isSplit ? "Split view" : "Unified view"}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
+      >
         <Button
           type="button"
           onClick={() =>
-            props.onViewPatch({
-              collapsedFilePaths: collapseAll.allCollapsed
-                ? []
-                : [...collapseAll.filePaths],
-            })
+            props.onViewPatch({ mode: isSplit ? "unified" : "split" })
           }
           variant="ghost"
           size="icon-sm"
-          aria-label={collapseAll.allCollapsed ? "Expand all" : "Collapse all"}
-          title={collapseAll.allCollapsed ? "Expand all" : "Collapse all"}
+          aria-label={
+            isSplit ? "Switch to unified view" : "Switch to split view"
+          }
           className="text-muted-foreground hover:text-foreground"
         >
-          {collapseAll.allCollapsed ? (
-            <ChevronsUpDown className="size-4" />
+          {isSplit ? (
+            <DiffSplitIcon className="size-4" />
           ) : (
-            <ChevronsDownUp className="size-4" />
+            <DiffUnifiedIcon className="size-4" />
           )}
         </Button>
-      ) : null}
-
-      <Button
-        type="button"
-        onClick={() =>
-          props.onViewPatch({ mode: isSplit ? "unified" : "split" })
-        }
-        variant="ghost"
-        size="icon-sm"
-        aria-label={isSplit ? "Switch to unified view" : "Switch to split view"}
-        title={isSplit ? "Split view" : "Unified view"}
-        className="text-muted-foreground hover:text-foreground"
-      >
-        {isSplit ? (
-          <DiffSplitIcon className="size-4" />
-        ) : (
-          <DiffUnifiedIcon className="size-4" />
-        )}
-      </Button>
+      </TooltipWrapper>
 
       {props.onRefresh !== null ? (
-        <Button
-          type="button"
-          onClick={props.onRefresh}
-          disabled={props.refreshing}
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Refresh diff"
-          title="Refresh diff"
-          className="text-muted-foreground hover:text-foreground"
+        <TooltipWrapper
+          label="Refresh diff"
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          <RotateCcw
-            className={cn("size-4", props.refreshing && "animate-spin")}
-          />
-        </Button>
+          <span className="inline-flex">
+            <Button
+              type="button"
+              onClick={props.onRefresh}
+              disabled={props.refreshing}
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Refresh diff"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <RotateCcw
+                className={cn("size-4", props.refreshing && "animate-spin")}
+              />
+            </Button>
+          </span>
+        </TooltipWrapper>
       ) : null}
 
       <Popover>
         <PopoverTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Diff settings"
-            title="Diff settings"
-            className="text-muted-foreground hover:text-foreground"
+          <TooltipWrapper
+            label="Diff settings"
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            <Settings2 className="size-4" />
-          </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Diff settings"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <Settings2 className="size-4" />
+            </Button>
+          </TooltipWrapper>
         </PopoverTrigger>
         <PopoverContent align="end" className="w-[min(80vw,15rem)] gap-0 p-1">
           {settings.map((setting) => (
@@ -265,23 +296,29 @@ function IndicatorStyleControl(props: {
         const Icon = option.icon;
         const active = props.value === option.value;
         return (
-          <button
+          <TooltipWrapper
             key={option.value}
-            type="button"
-            role="radio"
-            aria-checked={active}
-            aria-label={option.label}
-            title={option.label}
-            onClick={() => props.onChange(option.value)}
-            className={cn(
-              "relative z-10 flex size-7 items-center justify-center rounded-sm transition-colors",
-              active
-                ? "text-foreground"
-                : "text-muted-foreground hover:text-foreground",
-            )}
+            label={option.label}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            <Icon className="size-3.5" />
-          </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={active}
+              aria-label={option.label}
+              onClick={() => props.onChange(option.value)}
+              className={cn(
+                "relative z-10 flex size-7 items-center justify-center rounded-sm transition-colors",
+                active
+                  ? "text-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Icon className="size-3.5" />
+            </button>
+          </TooltipWrapper>
         );
       })}
     </div>

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-changed-file-row.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-changed-file-row.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import { GitStatusBadge } from "./git-status-badge";
 import { HighlightedText } from "./highlighted-text";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export type GitChangedFileRowDensity = "panel" | "tile";
 
 export interface GitChangedFileRowProps {
@@ -142,7 +143,7 @@ function PanelRowContent(props: {
         letter={metadata.statusLetter}
         tone={metadata.statusTone}
         label={metadata.statusLabel}
-        withNativeTitle={false}
+        withTooltip={false}
       />
       <WorkspaceFileIcon fileName={metadata.fileName} className="size-3.5" />
       <MiddleTruncatedFileName
@@ -202,12 +203,22 @@ function TileRowContent(props: {
         letter={metadata.statusLetter}
         tone={metadata.statusTone}
         label={metadata.statusLabel}
-        withNativeTitle
+        withTooltip
       />
       <WorkspaceFileIcon fileName={metadata.fileName} className="size-3.5" />
-      <span className="min-w-0 truncate font-mono text-ui-sm">
-        {metadata.fileName}
-      </span>
+      {/* Scoped to the filename rather than the whole row: the row also holds
+          the status badge, which owns a tooltip of its own at this density. A
+          row-wide trigger opened both at once. */}
+      <TooltipWrapper
+        label={props.file.path}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
+      >
+        <span className="min-w-0 truncate font-mono text-ui-sm">
+          {metadata.fileName}
+        </span>
+      </TooltipWrapper>
       {metadata.previousFileName ? (
         <span className="truncate text-ui-xs text-muted-foreground">
           from {metadata.previousFileName}
@@ -276,7 +287,6 @@ export function GitChangedFileRow(props: GitChangedFileRowProps): ReactNode {
         props.active ? "hover:bg-accent" : "hover:bg-accent/50",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       )}
-      title={isPanel ? undefined : props.file.path}
       aria-label={ariaLabel}
       aria-expanded={props.ariaExpanded}
       aria-current={props.active ? true : undefined}

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-repo-switcher.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-diff-repo-switcher.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/lib/git/git-diff-repo-switcher";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export interface GitDiffRepoSwitcherProps {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
@@ -72,27 +73,33 @@ export function GitDiffRepoSwitcher(
 
   return (
     <Popover open={props.open} onOpenChange={props.onOpenChange}>
-      <PopoverTrigger asChild>
-        <WorktreePickerTrigger
-          worktreeLabel={model.trigger.label}
-          secondaryLabel={model.trigger.secondaryLabel}
-          changeCount={null}
-          trailingStatus={
-            <GitDiffCountBadges
-              fileChangeCount={model.trigger.fileChangeCount}
-              moduleChangeCount={model.trigger.moduleChangeCount}
-            />
-          }
-          testId={props.triggerTestId}
-          className={props.triggerClassName}
-          aria-label={triggerAccessibleName(model)}
-          title={triggerTooltip(model)}
-          aria-haspopup="dialog"
-          aria-expanded={props.open}
-          aria-controls={props.open ? contentId : undefined}
-          data-unavailable={model.trigger.unavailable ? "true" : undefined}
-        />
-      </PopoverTrigger>
+      <TooltipWrapper
+        label={triggerTooltip(model)}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
+      >
+        <PopoverTrigger asChild>
+          <WorktreePickerTrigger
+            worktreeLabel={model.trigger.label}
+            secondaryLabel={model.trigger.secondaryLabel}
+            changeCount={null}
+            trailingStatus={
+              <GitDiffCountBadges
+                fileChangeCount={model.trigger.fileChangeCount}
+                moduleChangeCount={model.trigger.moduleChangeCount}
+              />
+            }
+            testId={props.triggerTestId}
+            className={props.triggerClassName}
+            aria-label={triggerAccessibleName(model)}
+            aria-haspopup="dialog"
+            aria-expanded={props.open}
+            aria-controls={props.open ? contentId : undefined}
+            data-unavailable={model.trigger.unavailable ? "true" : undefined}
+          />
+        </PopoverTrigger>
+      </TooltipWrapper>
       <PopoverContent
         id={contentId}
         role="dialog"
@@ -353,26 +360,38 @@ function GitDiffCountBadges(props: {
   return (
     <span className="flex shrink-0 items-center gap-1">
       {moduleLabel === null ? null : (
-        <Badge
-          variant="secondary"
-          className="gap-1 px-1.5 tabular-nums"
-          aria-label={moduleLabel}
-          title={moduleLabel}
+        <TooltipWrapper
+          label={moduleLabel}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          <FolderGit2 className="size-3" aria-hidden />
-          <span aria-hidden>{props.moduleChangeCount}</span>
-        </Badge>
+          <Badge
+            variant="secondary"
+            className="gap-1 px-1.5 tabular-nums"
+            aria-label={moduleLabel}
+          >
+            <FolderGit2 className="size-3" aria-hidden />
+            <span aria-hidden>{props.moduleChangeCount}</span>
+          </Badge>
+        </TooltipWrapper>
       )}
       {fileLabel === null ? null : (
-        <Badge
-          variant="secondary"
-          className="gap-1 px-1.5 tabular-nums"
-          aria-label={fileLabel}
-          title={fileLabel}
+        <TooltipWrapper
+          label={fileLabel}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          <FileText className="size-3" aria-hidden />
-          <span aria-hidden>{props.fileChangeCount}</span>
-        </Badge>
+          <Badge
+            variant="secondary"
+            className="gap-1 px-1.5 tabular-nums"
+            aria-label={fileLabel}
+          >
+            <FileText className="size-3" aria-hidden />
+            <span aria-hidden>{props.fileChangeCount}</span>
+          </Badge>
+        </TooltipWrapper>
       )}
     </span>
   );

--- a/clients/gui-app/src/components/epic-canvas/git-diff/git-status-badge.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/git-status-badge.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import type { StatusBadgeStyle } from "@/lib/git/status-icon";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const toneClass: Record<StatusBadgeStyle["tone"], string> = {
   success: "bg-success/10 text-success",
   destructive: "bg-destructive/10 text-destructive",
@@ -14,8 +15,10 @@ interface GitStatusBadgeBaseProps {
   readonly letter: string;
   readonly tone: StatusBadgeStyle["tone"];
   readonly label: string;
-  /** Native title is off where a Radix tooltip already owns the row hover. */
-  readonly withNativeTitle: boolean;
+  /** Off where something above already owns the hover for this area - the
+   *  dense panel row, which has no room for a second hover target. Named for
+   *  the tooltip, not the old native `title` it used to toggle. */
+  readonly withTooltip: boolean;
 }
 
 interface GitStatusBadgeClassNameProps extends GitStatusBadgeBaseProps {
@@ -28,16 +31,22 @@ type GitStatusBadgeProps =
 export function GitStatusBadge(props: GitStatusBadgeProps): ReactNode {
   const className = "className" in props ? props.className : undefined;
   return (
-    <span
-      className={cn(
-        "inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded px-1 text-[10px] font-bold",
-        toneClass[props.tone],
-        className,
-      )}
-      title={props.withNativeTitle ? props.label : undefined}
-      aria-label={props.label}
+    <TooltipWrapper
+      label={props.withTooltip ? props.label : undefined}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {props.letter}
-    </span>
+      <span
+        className={cn(
+          "inline-flex h-5 min-w-5 shrink-0 items-center justify-center rounded px-1 text-[10px] font-bold",
+          toneClass[props.tone],
+          className,
+        )}
+        aria-label={props.label}
+      >
+        {props.letter}
+      </span>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/git-diff/section.tsx
+++ b/clients/gui-app/src/components/epic-canvas/git-diff/section.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export interface SectionProps {
   readonly title: string;
   readonly count: number;
@@ -125,15 +126,23 @@ export function Section(props: SectionProps): ReactNode {
               {title}
             </span>
 
-            <span
-              className={cn(
-                "min-w-0 truncate whitespace-nowrap text-ui-xs tabular-nums",
-                isEmpty ? "text-muted-foreground/55" : "text-muted-foreground",
-              )}
-              title={fileCountLabel}
+            <TooltipWrapper
+              label={fileCountLabel}
+              side="top"
+              sideOffset={undefined}
+              align={undefined}
             >
-              {fileCountLabel}
-            </span>
+              <span
+                className={cn(
+                  "min-w-0 truncate whitespace-nowrap text-ui-xs tabular-nums",
+                  isEmpty
+                    ? "text-muted-foreground/55"
+                    : "text-muted-foreground",
+                )}
+              >
+                {fileCountLabel}
+              </span>
+            </TooltipWrapper>
 
             <span aria-hidden className="ml-auto" />
             {summary}

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/access-lists.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/access-lists.tsx
@@ -26,6 +26,7 @@ import { computeInitials } from "@/lib/auth/compute-initials";
 import { type AssignableCollaboratorRole } from "@/lib/epic-collaborator-roles";
 import { formatGithubHandle } from "@/lib/epic-invites";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export interface PeopleWithAccessProps {
   readonly loadState: SharingAccessLoadState;
   readonly collaborators: ReadonlyArray<EpicCollaboratorView>;
@@ -281,27 +282,35 @@ function CollaboratorRow(props: {
         onRoleChange={props.onRoleChange}
       />
       {isOwner && collaborator.userId !== null ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          onClick={canRevoke ? props.onRevokeRequest : undefined}
-          disabled={!canRevoke || isRevokePending}
-          title={lastOwnerTitle}
-          aria-label={`Remove ${collaborator.displayName}`}
-          className="text-muted-foreground hover:text-destructive disabled:opacity-30"
-          data-testid="collaborator-revoke-button"
+        <TooltipWrapper
+          label={lastOwnerTitle}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          {isRevokePending ? (
-            <AgentSpinningDots
-              className="text-muted-foreground"
-              testId="collaborator-revoke-spinner"
-              variant={undefined}
-            />
-          ) : (
-            <Trash2 className="size-3.5" />
-          )}
-        </Button>
+          <span className="inline-flex">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={canRevoke ? props.onRevokeRequest : undefined}
+              disabled={!canRevoke || isRevokePending}
+              aria-label={`Remove ${collaborator.displayName}`}
+              className="text-muted-foreground hover:text-destructive disabled:opacity-30"
+              data-testid="collaborator-revoke-button"
+            >
+              {isRevokePending ? (
+                <AgentSpinningDots
+                  className="text-muted-foreground"
+                  testId="collaborator-revoke-spinner"
+                  variant={undefined}
+                />
+              ) : (
+                <Trash2 className="size-3.5" />
+              )}
+            </Button>
+          </span>
+        </TooltipWrapper>
       ) : null}
     </li>
   );
@@ -455,6 +464,7 @@ function CollaboratorRoleControl(props: {
   }
   return (
     <RoleBadge
+      tooltip={lastOwnerTitle}
       value={collaborator.role}
       testId={
         isLastOwner ? "collaborator-role-last-owner" : "collaborator-role-badge"
@@ -462,7 +472,6 @@ function CollaboratorRoleControl(props: {
       ariaLabel={
         isLastOwner ? `Change role for ${collaborator.displayName}` : undefined
       }
-      title={lastOwnerTitle}
     />
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/role-control.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sharing/role-control.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/epic-collaborator-roles";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export const ROLE_PILL_CLASS =
   "rounded-md bg-muted px-2.5 py-1 text-ui-xs text-muted-foreground";
 
@@ -106,7 +107,7 @@ export function RoleOrBadge(props: {
         value={props.value}
         testId={`${props.testId}-badge`}
         ariaLabel={undefined}
-        title={undefined}
+        tooltip={undefined}
       />
     );
   }
@@ -127,16 +128,24 @@ export function RoleBadge(props: {
   readonly value: PermissionRole;
   readonly testId: string;
   readonly ariaLabel: string | undefined;
-  readonly title: string | undefined;
+  /** Hover label; `tooltip` rather than `title` so the call site cannot be
+   *  mistaken for the native attribute. */
+  readonly tooltip: string | undefined;
 }) {
   return (
-    <span
-      className={ROLE_PILL_CLASS}
-      title={props.title}
-      aria-label={props.ariaLabel}
-      data-testid={props.testId}
+    <TooltipWrapper
+      label={props.tooltip}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {EPIC_COLLABORATOR_ROLE_LABELS[props.value]}
-    </span>
+      <span
+        className={ROLE_PILL_CLASS}
+        aria-label={props.ariaLabel}
+        data-testid={props.testId}
+      >
+        {EPIC_COLLABORATOR_ROLE_LABELS[props.value]}
+      </span>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/snapshot-bundle-diff-tile-content.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/snapshot-bundle-diff-tile-content.tsx
@@ -36,6 +36,7 @@ import { cn } from "@/lib/utils";
 import { getBasename, getDirname } from "@/lib/path/cross-platform-path";
 import type { BundleDiffFindFileInput } from "@/stores/tile-find";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export type SnapshotCumulativeBundleDiffTileRef = Omit<
   SnapshotDiffTileRef,
   "diff"
@@ -281,30 +282,36 @@ function SnapshotBundleFileRow(props: {
   readonly onToggleCollapsed: () => void;
 }): ReactNode {
   return (
-    <button
-      type="button"
-      onClick={props.onToggleCollapsed}
-      className={cn(
-        "flex min-h-7 w-full items-center gap-2 px-2 py-1 text-left text-ui-sm",
-        "transition-colors hover:bg-accent/50",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      )}
-      title={props.entry.filePath}
-      aria-label={`${snapshotOperationLabel(props.entry.operation)} ${props.entry.filePath}`}
-      aria-expanded={!props.collapsed}
+    <TooltipWrapper
+      label={props.entry.filePath}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {props.leading}
-      <FileChangeHeader
-        filePath={props.entry.filePath}
-        operation={props.entry.operation}
-        additions={props.additions}
-        deletions={props.deletions}
-        isStreaming={false}
-        endState={null}
-        reason={props.entry.reason}
-        clickHandlers={null}
-      />
-    </button>
+      <button
+        type="button"
+        onClick={props.onToggleCollapsed}
+        className={cn(
+          "flex min-h-7 w-full items-center gap-2 px-2 py-1 text-left text-ui-sm",
+          "transition-colors hover:bg-accent/50",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        )}
+        aria-label={`${snapshotOperationLabel(props.entry.operation)} ${props.entry.filePath}`}
+        aria-expanded={!props.collapsed}
+      >
+        {props.leading}
+        <FileChangeHeader
+          filePath={props.entry.filePath}
+          operation={props.entry.operation}
+          additions={props.additions}
+          deletions={props.deletions}
+          isStreaming={false}
+          endState={null}
+          reason={props.entry.reason}
+          clickHandlers={null}
+        />
+      </button>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -87,6 +87,7 @@ import { ReportIssueAction } from "@/components/report-issue/report-issue-action
 import { createReportIssueContext } from "@/lib/report-issue-context";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 /**
  * A bound worktree/folder is gone from disk. The host's prepare-launch
  * resolver rejects with the typed `WORKTREE_MISSING` envelope instead of
@@ -841,22 +842,30 @@ function TerminalAgentPreLaunchToolbar(
         }}
       />
       <AgentModeReadonlyLabel value={props.agentMode} />
-      <Button
-        type="button"
-        variant="ghost"
-        size="sm"
-        className="h-7 gap-1 px-2 text-ui-xs text-muted-foreground hover:text-foreground"
-        disabled={forkDisabled}
-        title={
+      <TooltipWrapper
+        label={
           forkDisabled
             ? "Fork is available after the terminal agent session and workspace binding are ready."
             : "Fork terminal agent"
         }
-        onClick={openForkDialog}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <GitFork aria-hidden className="size-3.5" />
-        Fork
-      </Button>
+        <span className="inline-flex">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 px-2 text-ui-xs text-muted-foreground hover:text-foreground"
+            disabled={forkDisabled}
+            onClick={openForkDialog}
+          >
+            <GitFork aria-hidden className="size-3.5" />
+            Fork
+          </Button>
+        </span>
+      </TooltipWrapper>
       {/* Right-aligned status-bar group: the worktree-creation notice sits
           beside the agent controls. The notice's expanded detail opens as a
           downward Popover overlay, so it never reflows the terminal below. */}

--- a/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/workspace-file-tile.tsx
@@ -39,6 +39,7 @@ import { useNativeDivScrollRestoration } from "@/hooks/scroll/use-native-div-scr
 import { WorkspaceFileDeadTileBanner } from "./dead-tile-banner";
 import { WorkspaceMarkdownLinkProvider } from "@/components/epic-canvas/workspace-file/workspace-markdown-link-provider";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const MAX_MARKDOWN_PREVIEW_CHARS = 100_000;
 
 type WorkspaceFileViewMode = "source" | "preview";
@@ -420,26 +421,34 @@ function MarkdownViewModeToggle(props: {
         const active = props.mode === option.mode;
         const disabled = option.mode === "preview" && props.previewDisabled;
         return (
-          <button
+          <TooltipWrapper
             key={option.mode}
-            type="button"
-            aria-pressed={active}
-            disabled={disabled}
-            title={
+            label={
               disabled ? "Preview unavailable - file is too large" : undefined
             }
-            className={cn(
-              "inline-flex h-6 items-center rounded-[3px] px-1.5 text-ui-xs leading-none font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none",
-              disabled &&
-                "cursor-not-allowed opacity-45 hover:text-muted-foreground",
-              active && "bg-muted text-foreground",
-            )}
-            onClick={() => {
-              props.onModeChange(option.mode);
-            }}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            {option.label}
-          </button>
+            <span className="inline-flex">
+              <button
+                type="button"
+                aria-pressed={active}
+                disabled={disabled}
+                className={cn(
+                  "inline-flex h-6 items-center rounded-[3px] px-1.5 text-ui-xs leading-none font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none",
+                  disabled &&
+                    "cursor-not-allowed opacity-45 hover:text-muted-foreground",
+                  active && "bg-muted text-foreground",
+                )}
+                onClick={() => {
+                  props.onModeChange(option.mode);
+                }}
+              >
+                {option.label}
+              </button>
+            </span>
+          </TooltipWrapper>
         );
       })}
     </div>

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -271,8 +271,10 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: (props: { readonly children: ReactNode }) => props.children,
   TooltipTrigger: (props: { readonly children: ReactNode }) => props.children,
+  // `role="tooltip"` so `tooltipTextIn` can find the label this mock renders
+  // eagerly (the real content only exists while the tooltip is open).
   TooltipContent: (props: { readonly children: ReactNode }) => (
-    <div>{props.children}</div>
+    <div role="tooltip">{props.children}</div>
   ),
 }));
 
@@ -1384,6 +1386,17 @@ function leadingStatusKinds(nodeId: string): readonly string[] {
  * so it appears only once no attention tone, activity tier or unread completion
  * has claimed the icon. Scoped to the row so a sibling's lock cannot satisfy it.
  */
+/**
+ * The hover label attached to `el`. The real `TooltipContent` is portalled and
+ * open-only, but this file's `@/components/ui/tooltip` mock renders it inline -
+ * as a sibling of the trigger, since the mocked `Tooltip`/`TooltipTrigger` both
+ * render their children directly.
+ */
+function tooltipTextIn(el: HTMLElement): string | null {
+  const tip = el.parentElement?.querySelector('[role="tooltip"]') ?? null;
+  return tip === null ? null : tip.textContent;
+}
+
 function readOnlyLock(nodeId: string): HTMLElement | null {
   const row = screen.queryByTestId(`epic-sidebar-item-${nodeId}`);
   if (row === null) return null;
@@ -1554,7 +1567,7 @@ describe("chat descendant status rollup", () => {
     const nested = screen.getByTestId(
       "chat-descendant-status-failure-chat-root",
     );
-    expect(nested.getAttribute("title")).toBe(
+    expect(tooltipTextIn(nested)).toBe(
       "Nested: 1 needs attention · 1 running · 1 completed",
     );
     // The nested rollup owns the slot, so the parent's own spinner is absent.
@@ -1642,8 +1655,8 @@ describe("chat descendant status rollup", () => {
     const icon = screen.getByTestId("chat-descendant-status-running-chat-root");
     expect(icon).toBeTruthy();
     // The tooltip breaks the aggregate down across both tiers.
-    expect(icon.getAttribute("title")).toContain("1 running");
-    expect(icon.getAttribute("title")).toContain("1 in background");
+    expect(tooltipTextIn(icon)).toContain("1 running");
+    expect(tooltipTextIn(icon)).toContain("1 in background");
   });
 
   it("lets a descendant's turn outrank the parent's own background work", () => {
@@ -1902,7 +1915,7 @@ describe("chat row read-only arm", () => {
 
     const lock = readOnlyLock("chat-child");
     expect(lock).toBeTruthy();
-    expect(lock?.getAttribute("title")).toBe("Read-only agent");
+    expect(lock === null ? null : tooltipTextIn(lock)).toBe("Read-only agent");
     // It replaces the IDLE GLYPH, not the trailing time: a viewer still sees
     // when the row last moved.
     const row = screen.getByTestId("epic-sidebar-item-chat-child");
@@ -2837,7 +2850,7 @@ describe("chat row archive", () => {
     // "no status". Scoped to the row, since several rows carry the same label.
     const lock = readOnlyLock("chat-child");
     expect(lock).toBeTruthy();
-    expect(lock?.getAttribute("title")).toBe("Read-only agent");
+    expect(lock === null ? null : tooltipTextIn(lock)).toBe("Read-only agent");
   });
 
   // --- B8: status survives selection mode and rename (archive must not blank it)

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -71,6 +71,7 @@ import {
   SidebarGroup,
   SidebarGroupContent,
 } from "@/components/ui/sidebar";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { TreeChevron, TreeChevronSpacer } from "@/components/ui/tree-chevron";
 import {
   isChatFilterActive,
@@ -1752,18 +1753,24 @@ function TerminalAgentProgressIcon(props: { readonly nodeId: string }) {
   const icon = useNodeIconDisplay("terminal-agent");
   if (isActive && tier === "background") {
     return (
-      <span
-        role="status"
-        aria-label={BACKGROUND_ACTIVITY_TITLE}
-        className={cn(
-          "inline-flex items-center justify-center",
-          icon.className,
-        )}
-        style={icon.style}
-        title={BACKGROUND_ACTIVITY_TITLE}
+      <TooltipWrapper
+        label={BACKGROUND_ACTIVITY_TITLE}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <BackgroundActivityGlyph testId="terminal-agent-sidebar-background" />
-      </span>
+        <span
+          role="status"
+          aria-label={BACKGROUND_ACTIVITY_TITLE}
+          className={cn(
+            "inline-flex items-center justify-center",
+            icon.className,
+          )}
+          style={icon.style}
+        >
+          <BackgroundActivityGlyph testId="terminal-agent-sidebar-background" />
+        </span>
+      </TooltipWrapper>
     );
   }
   if (!isActive) {
@@ -1779,17 +1786,28 @@ function TerminalAgentProgressIcon(props: { readonly nodeId: string }) {
     return <StaticSidebarNodeIcon artifactType="terminal-agent" />;
   }
   return (
-    <span
-      className={cn("inline-flex items-center justify-center", icon.className)}
-      style={icon.style}
-      title="Agent in progress"
+    <TooltipWrapper
+      label="Agent in progress"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <AgentSpinningDots
-        className="text-current"
-        testId="terminal-agent-sidebar-spinner"
-        variant={undefined}
-      />
-    </span>
+      <span
+        role="status"
+        aria-label="Agent in progress"
+        className={cn(
+          "inline-flex items-center justify-center",
+          icon.className,
+        )}
+        style={icon.style}
+      >
+        <AgentSpinningDots
+          className="text-current"
+          testId="terminal-agent-sidebar-spinner"
+          variant={undefined}
+        />
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -1805,21 +1823,27 @@ function SidebarAgentHarnessIcon(props: {
 }) {
   const TerminalIcon = EPIC_NODE_ICONS.terminal;
   return (
-    <span
-      data-testid={`sidebar-agent-harness-${props.nodeId}`}
-      data-agent-surface="tui"
-      className="relative inline-flex h-3.5 w-[1.125rem] shrink-0 items-center"
-      title="TUI terminal agent"
+    <TooltipWrapper
+      label="TUI terminal agent"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <HarnessIcon harnessId={props.harnessId} className="size-3.5" />
-      <TerminalIcon
-        aria-hidden="true"
-        data-testid={`sidebar-agent-surface-${props.nodeId}`}
+      <span
+        data-testid={`sidebar-agent-harness-${props.nodeId}`}
         data-agent-surface="tui"
-        className="pointer-events-none absolute -right-1 -bottom-1.5 size-2 text-muted-foreground"
-        strokeWidth={3}
-      />
-    </span>
+        className="relative inline-flex h-3.5 w-[1.125rem] shrink-0 items-center"
+      >
+        <HarnessIcon harnessId={props.harnessId} className="size-3.5" />
+        <TerminalIcon
+          aria-hidden="true"
+          data-testid={`sidebar-agent-surface-${props.nodeId}`}
+          data-agent-surface="tui"
+          className="pointer-events-none absolute -right-1 -bottom-1.5 size-2 text-muted-foreground"
+          strokeWidth={3}
+        />
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -2255,15 +2279,21 @@ function NestedChatStatusIcon(props: {
 }): ReactNode {
   const title = nestedChatStatusSummary(props.rollup);
   return (
-    <span
-      role="status"
-      aria-label={title}
-      title={title}
-      data-testid={`chat-descendant-status-${props.rollup.kind}-${props.nodeId}`}
-      className="inline-flex size-3.5 shrink-0 items-center justify-center opacity-60"
+    <TooltipWrapper
+      label={title}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <NestedChatStatusGlyph kind={props.rollup.kind} />
-    </span>
+      <span
+        role="status"
+        aria-label={title}
+        data-testid={`chat-descendant-status-${props.rollup.kind}-${props.nodeId}`}
+        className="inline-flex size-3.5 shrink-0 items-center justify-center opacity-60"
+      >
+        <NestedChatStatusGlyph kind={props.rollup.kind} />
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -2589,26 +2619,32 @@ function ChatRowArchiveButton(props: {
     ? `Unarchive ${props.nodeName}`
     : `Archive ${props.nodeName}`;
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-xs"
-      aria-label={label}
-      title={label}
-      disabled={props.pending}
-      data-testid={`epic-sidebar-archive-${props.nodeId}`}
-      className="absolute right-7 top-1/2 -translate-y-1/2 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/tree-item:opacity-100"
-      onClick={(event) => {
-        event.stopPropagation();
-        props.onToggle();
-      }}
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {props.isArchived ? (
-        <ArchiveRestore className="size-3" />
-      ) : (
-        <Archive className="size-3" />
-      )}
-    </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label={label}
+        disabled={props.pending}
+        data-testid={`epic-sidebar-archive-${props.nodeId}`}
+        className="absolute right-7 top-1/2 -translate-y-1/2 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/tree-item:opacity-100"
+        onClick={(event) => {
+          event.stopPropagation();
+          props.onToggle();
+        }}
+      >
+        {props.isArchived ? (
+          <ArchiveRestore className="size-3" />
+        ) : (
+          <Archive className="size-3" />
+        )}
+      </Button>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar.tsx
@@ -217,6 +217,7 @@ import {
 import { SidebarPanelEmptyState } from "@/components/epic-canvas/sidebar/sidebar-panel-empty-state";
 import { useShallow } from "zustand/react/shallow";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const EMPTY_FILE_TREE_FILES: ReadonlyArray<WorkspaceFileTreeNode> =
   Object.freeze([]);
 const EMPTY_GIT_STATUS: ReadonlyArray<GitStatusEntry> = Object.freeze([]);
@@ -1865,23 +1866,31 @@ function TreePanelActions(props: TreePanelActionsProps) {
 
   return (
     <div className="flex items-center gap-0.5">
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        onClick={collapseAll}
-        aria-label="Collapse all"
-        title="Collapse all"
-        data-testid={`epic-sidebar-collapse-all-${props.panelId}`}
-        disabled={props.collapsed}
-        className={cn(
-          "text-muted-foreground hover:text-foreground",
-          PANEL_HEADER_ACTION_REVEAL_CLASS,
-          COMPACT_PANEL_HEADER_DIRECT_ACTION_CLASS,
-        )}
+      <TooltipWrapper
+        label="Collapse all"
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <CopyMinus className="size-4" />
-      </Button>
+        <span className="inline-flex">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={collapseAll}
+            aria-label="Collapse all"
+            data-testid={`epic-sidebar-collapse-all-${props.panelId}`}
+            disabled={props.collapsed}
+            className={cn(
+              "text-muted-foreground hover:text-foreground",
+              PANEL_HEADER_ACTION_REVEAL_CLASS,
+              COMPACT_PANEL_HEADER_DIRECT_ACTION_CLASS,
+            )}
+          >
+            <CopyMinus className="size-4" />
+          </Button>
+        </span>
+      </TooltipWrapper>
       {props.panelId === "chats" ? (
         <NewConversationModalAction
           epicId={props.epicId}
@@ -2052,23 +2061,36 @@ function CompactMoreMenuTrigger(props: {
   readonly collapsed: boolean;
 }) {
   return (
-    <DropdownMenuTrigger asChild>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        aria-label={props.label}
-        title={props.label}
-        disabled={props.collapsed}
-        className={cn(
-          "hidden text-muted-foreground hover:text-foreground aria-expanded:opacity-100 @max-[21rem]:inline-flex",
-          PANEL_HEADER_ACTION_REVEAL_CLASS,
-        )}
-        data-testid={props.testId}
-      >
-        <MoreHorizontal className="size-4" />
-      </Button>
-    </DropdownMenuTrigger>
+    // Tooltip OUTSIDE the menu trigger, with no span between them: both are
+    // `asChild`, so nesting this way merges the tooltip's and the menu's props
+    // onto the button itself. A guard span in between took delivery of them
+    // instead - which broke this button's own `aria-expanded:opacity-100` (the
+    // attribute landed on the span) and left the always-`inline-flex` span
+    // rendered in the header while its `@max-[21rem]:inline-flex` child stayed
+    // hidden at wider widths.
+    <TooltipWrapper
+      label={props.label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={props.label}
+          disabled={props.collapsed}
+          className={cn(
+            "hidden text-muted-foreground hover:text-foreground aria-expanded:opacity-100 @max-[21rem]:inline-flex",
+            PANEL_HEADER_ACTION_REVEAL_CLASS,
+          )}
+          data-testid={props.testId}
+        >
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+    </TooltipWrapper>
   );
 }
 
@@ -2183,23 +2205,31 @@ function MarkAllArtifactsReadButton(props: {
   }, [markRead, props.epicId, unreadArtifacts]);
 
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      onClick={handleMarkAllRead}
-      aria-label="Mark all unread artifacts as read"
-      title="Mark all unread artifacts as read"
-      data-testid="epic-sidebar-mark-all-artifacts-read"
-      disabled={props.collapsed || unreadArtifacts.length === 0}
-      className={cn(
-        "text-muted-foreground hover:text-foreground",
-        PANEL_HEADER_ACTION_REVEAL_CLASS,
-        COMPACT_PANEL_HEADER_DIRECT_ACTION_CLASS,
-      )}
+    <TooltipWrapper
+      label="Mark all unread artifacts as read"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <CheckCheck className="size-4" />
-    </Button>
+      <span className="inline-flex">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={handleMarkAllRead}
+          aria-label="Mark all unread artifacts as read"
+          data-testid="epic-sidebar-mark-all-artifacts-read"
+          disabled={props.collapsed || unreadArtifacts.length === 0}
+          className={cn(
+            "text-muted-foreground hover:text-foreground",
+            PANEL_HEADER_ACTION_REVEAL_CLASS,
+            COMPACT_PANEL_HEADER_DIRECT_ACTION_CLASS,
+          )}
+        >
+          <CheckCheck className="size-4" />
+        </Button>
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -2213,22 +2243,30 @@ function ArtifactSearchButton(props: { readonly collapsed: boolean }) {
   const openSearch = usePanelHeaderSearchStore((s) => s.openSearch);
   if (!available) return null;
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      onClick={() => openSearch("artifacts", "")}
-      aria-label="Search artifacts"
-      title="Search artifacts"
-      data-testid="epic-sidebar-search-artifacts"
-      disabled={props.collapsed}
-      className={cn(
-        "text-muted-foreground hover:text-foreground @max-[14rem]:hidden",
-        PANEL_HEADER_ACTION_REVEAL_CLASS,
-      )}
+    <TooltipWrapper
+      label="Search artifacts"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <Search className="size-4" />
-    </Button>
+      <span className="inline-flex">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => openSearch("artifacts", "")}
+          aria-label="Search artifacts"
+          data-testid="epic-sidebar-search-artifacts"
+          disabled={props.collapsed}
+          className={cn(
+            "text-muted-foreground hover:text-foreground @max-[14rem]:hidden",
+            PANEL_HEADER_ACTION_REVEAL_CLASS,
+          )}
+        >
+          <Search className="size-4" />
+        </Button>
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -2340,17 +2378,25 @@ function SidebarBulkSelectionActions() {
       >
         {selection.allVisibleSelected ? "Deselect all" : "Select all"}
       </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        aria-label="Cancel selection"
-        title="Cancel selection"
-        disabled={selection.deletePending}
-        onClick={selection.cancelSelection}
+      <TooltipWrapper
+        label="Cancel selection"
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <X className="size-3.5" />
-      </Button>
+        <span className="inline-flex">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Cancel selection"
+            disabled={selection.deletePending}
+            onClick={selection.cancelSelection}
+          >
+            <X className="size-3.5" />
+          </Button>
+        </span>
+      </TooltipWrapper>
       {selection.panelId === "artifacts" ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/clients/gui-app/src/components/epic-canvas/tile-find/tile-find-bar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/tile-find/tile-find-bar.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/stores/tile-find/tile-find-store";
 import type { TileFindStateSnapshot } from "@/stores/tile-find/types";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 // Chat search scans the whole transcript, so keystrokes are coalesced into a
 // single search instead of one per character. Mirrors the artifact adapter's
 // rescan debounce window (ARTIFACT_FIND_RESCAN_DEBOUNCE_MS).
@@ -391,17 +392,23 @@ function TileFindStatusLabel(props: {
       snapshot.query.length > 0 &&
       snapshot.total === 0);
   return (
-    <span
-      className={cn(
-        "min-w-[5ch] text-right text-ui-xs text-muted-foreground",
-        destructive && "text-destructive",
-        snapshot.status === "partial" && "text-amber-600 dark:text-amber-400",
-      )}
-      data-status={snapshot.status}
-      title={snapshot.coverageMessage ?? snapshot.errorMessage ?? undefined}
+    <TooltipWrapper
+      label={snapshot.coverageMessage ?? snapshot.errorMessage ?? undefined}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {label}
-    </span>
+      <span
+        className={cn(
+          "min-w-[5ch] text-right text-ui-xs text-muted-foreground",
+          destructive && "text-destructive",
+          snapshot.status === "partial" && "text-amber-600 dark:text-amber-400",
+        )}
+        data-status={snapshot.status}
+      >
+        {label}
+      </span>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -42,6 +42,7 @@ import type { DesktopWindowsBridge } from "@/lib/windows/types";
 import type { WorktreeHostEntryV12 } from "@traycer/protocol/host/worktree-schemas";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
+import { anyTooltipHasText } from "@/components/ui/__tests__/tooltip-probe";
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
 });
@@ -650,7 +651,7 @@ describe("<EpicsListPanel />", () => {
     expect(
       await screen.findByTestId("epics-list-row-activity-epic-from-history"),
     ).toBeDefined();
-    expect(screen.queryByTitle("Task activity in progress")).not.toBeNull();
+    expect(anyTooltipHasText("Task activity in progress")).toBe(true);
   });
 
   it("shows the background activity status on history rows", async () => {
@@ -663,9 +664,7 @@ describe("<EpicsListPanel />", () => {
     expect(backgroundIcon.getAttribute("class")).toContain(
       "lucide-message-square-clock",
     );
-    expect(
-      screen.queryByTitle("Background activity — agent idle"),
-    ).not.toBeNull();
+    expect(anyTooltipHasText("Background activity — agent idle")).toBe(true);
   });
 
   it("selects a history row from the outside checkbox without opening the epic", async () => {

--- a/clients/gui-app/src/components/epics/delete-tasks-dialog.tsx
+++ b/clients/gui-app/src/components/epics/delete-tasks-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import type { TaskDeleteWorktreeCandidate } from "@/hooks/epic/use-task-delete-worktree-candidates-query";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface DeleteTasksDialogProps {
   readonly open: boolean;
   readonly onOpenChange: (open: boolean) => void;
@@ -228,12 +229,16 @@ function WorktreeCleanupRow(props: {
               {candidate.repoLabel}
             </span>
           </span>
-          <span
-            className="mt-1 block max-w-full truncate font-mono text-ui-xs text-muted-foreground"
-            title={candidate.worktreePath}
+          <TooltipWrapper
+            label={candidate.worktreePath}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            {candidate.worktreePath}
-          </span>
+            <span className="mt-1 block max-w-full truncate font-mono text-ui-xs text-muted-foreground">
+              {candidate.worktreePath}
+            </span>
+          </TooltipWrapper>
           {hint}
         </span>
       </label>

--- a/clients/gui-app/src/components/epics/epics-filter-popover.tsx
+++ b/clients/gui-app/src/components/epics/epics-filter-popover.tsx
@@ -23,6 +23,7 @@ import type {
 } from "@/lib/history-search";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface EpicsFilterPopoverProps {
   readonly availableRepos: ReadonlyArray<string>;
   readonly availableWorkspaces: ReadonlyArray<HistoryWorkspaceRef>;
@@ -233,9 +234,16 @@ function FilterOption(props: {
         {props.checked ? <Check className="size-3" /> : null}
       </span>
       {props.truncateLabelFromStart ? (
-        <StartTruncatedText className="min-w-0 flex-1" title={props.label}>
-          {props.label}
-        </StartTruncatedText>
+        <TooltipWrapper
+          label={props.label}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
+        >
+          <StartTruncatedText className="min-w-0 flex-1">
+            {props.label}
+          </StartTruncatedText>
+        </TooltipWrapper>
       ) : (
         <span className="min-w-0 flex-1 truncate">{props.label}</span>
       )}

--- a/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/harness-model-picker.test.tsx
@@ -468,6 +468,7 @@ import { formatChordForDisplay } from "@/lib/keybindings/chord";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ALL_PERMISSION_MODES } from "@traycer/protocol/persistence/epic/foundation";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 const CODEX_HARNESS: HarnessOption = {
   id: "codex",
   label: "Codex",
@@ -1154,7 +1155,7 @@ describe("<HarnessModelPicker />", () => {
     const claudeTab = screen.getByRole("tab", { name: "Claude" });
 
     expect(codexTab.getAttribute("aria-disabled")).toBe("true");
-    expect(codexTab.getAttribute("title")).toBe(
+    expect(tooltipTextNear(codexTab)).toBe(
       "Provider cannot be changed while forking terminal agent",
     );
     expect(claudeTab.getAttribute("aria-disabled")).toBeNull();
@@ -2206,7 +2207,7 @@ describe("<HarnessModelPicker />", () => {
       throw new Error("Expected create-new-profile row to render as a button.");
     }
     expect(row.disabled).toBe(true);
-    expect(row.title).toBe(
+    expect(tooltipTextNear(row)).toBe(
       "Add profiles from a local host with browser sign-in available.",
     );
     fireEvent.click(row);
@@ -2387,7 +2388,7 @@ describe("<HarnessModelPicker />", () => {
       throw new Error("Expected create-new-profile row to render as a button.");
     }
     expect(row.disabled).toBe(true);
-    expect(row.title).toBe(
+    expect(tooltipTextNear(row)).toBe(
       "Add profiles from a local host with browser sign-in available.",
     );
   });

--- a/clients/gui-app/src/components/home/composer/composer-send-button.tsx
+++ b/clients/gui-app/src/components/home/composer/composer-send-button.tsx
@@ -60,19 +60,27 @@ function ComposerSendButtonImpl(props: ComposerSendButtonProps) {
   );
 
   const button = (
-    <Button
-      type="button"
-      size="icon"
-      onClick={submitOrStopTurn}
-      disabled={hintActive ? false : disabled}
-      aria-disabled={hintActive || undefined}
-      aria-label={label}
-      title={hintActive ? undefined : buttonTitle}
-      data-testid={stopMode ? "chat-stop-button" : undefined}
-      className={buttonClassName}
+    <TooltipWrapper
+      label={hintActive ? undefined : buttonTitle}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {composerSendButtonIcon(attachmentPending, stopMode)}
-    </Button>
+      <span className="inline-flex">
+        <Button
+          type="button"
+          size="icon"
+          onClick={submitOrStopTurn}
+          disabled={hintActive ? false : disabled}
+          aria-disabled={hintActive || undefined}
+          aria-label={label}
+          data-testid={stopMode ? "chat-stop-button" : undefined}
+          className={buttonClassName}
+        >
+          {composerSendButtonIcon(attachmentPending, stopMode)}
+        </Button>
+      </span>
+    </TooltipWrapper>
   );
 
   if (!hintActive) return button;

--- a/clients/gui-app/src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/__tests__/folder-controls.test.tsx
@@ -77,6 +77,7 @@ import { WorkspaceFolderSummaryControl } from "../workspace-folder-summary-contr
 import { WorkspaceSummaryTrigger } from "../workspace-summary-trigger";
 import type { WorkspaceRunItem } from "../workspace-run-item";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 const NOOP = (): void => undefined;
 const NOOP_ADD = (): Promise<boolean> => Promise.resolve(false);
 const EMPTY_COUNTS: ReadonlyMap<string, number> = new Map();
@@ -429,7 +430,10 @@ describe("FolderRow", () => {
     expect(identity.children[1].className).toContain("text-foreground/90");
     expect(location.className).toContain("var(--color-muted-foreground)");
     expect(branch.className).toContain("text-foreground/75");
-    expect(identity.getAttribute("title")).toBe("/repo");
+    // The path tooltip is scoped to the NAME now, not the whole chip - the
+    // chip also carries the copy-path button and missing-folder warning, each
+    // with a tooltip of its own.
+    expect(tooltipTextNear(identity.children[1])).toBe("/repo");
   });
 
   it("reserves two stable trailing action slots", () => {

--- a/clients/gui-app/src/components/home/host-workspace-selector/copy-path-button.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/copy-path-button.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy } from "lucide-react";
 import { useClipboardCopy } from "@/hooks/ui/use-clipboard-copy";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 /**
  * Copies the path a chat/terminal actually runs from (the adopted worktree
  * path, or the folder itself for local). Shared by the click-open folder rows
@@ -20,18 +21,28 @@ export function CopyPathButton(props: {
     onError: null,
   });
   return (
-    <button
-      type="button"
-      aria-label="Copy folder path"
-      title="Copy path"
-      data-testid={props.testId}
-      onClick={(event) => {
-        event.stopPropagation();
-        copy(props.path);
-      }}
-      className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+    <TooltipWrapper
+      label="Copy path"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-    </button>
+      <button
+        type="button"
+        aria-label="Copy folder path"
+        data-testid={props.testId}
+        onClick={(event) => {
+          event.stopPropagation();
+          copy(props.path);
+        }}
+        className="inline-flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground outline-none transition-colors hover:bg-accent/50 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+      >
+        {copied ? (
+          <Check className="size-3.5" />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+      </button>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/folder-row.tsx
@@ -36,15 +36,25 @@ export function FolderRow(props: {
       <span
         className="inline-flex w-full max-w-full min-w-0 items-center gap-1.5 px-1 py-1 text-ui-sm"
         data-testid="folder-chip"
-        title={item.displayPath}
       >
         <Folder
           className="size-3.5 shrink-0 text-muted-foreground/70"
           aria-hidden
         />
-        <span className="min-w-0 truncate font-medium text-foreground/90">
-          {item.displayName}
-        </span>
+        {/* Scoped to the NAME, not the whole chip. The chip also holds the
+              missing-folder warning and the copy-path button, each with its own
+              tooltip - a chip-wide trigger meant hovering either one could
+              surface the path tooltip alongside theirs. */}
+        <TooltipWrapper
+          label={item.displayPath}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
+        >
+          <span className="min-w-0 truncate font-medium text-foreground/90">
+            {item.displayName}
+          </span>
+        </TooltipWrapper>
         {item.missing ? (
           <TooltipWrapper
             label="This bound folder is missing on disk."
@@ -258,20 +268,26 @@ function EnvironmentButton(props: {
   readonly onEdit: (workspacePath: string) => void;
 }) {
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      aria-label="Edit setup and teardown scripts"
-      title="Setup & teardown scripts"
-      data-testid="folder-scripts-trigger"
-      onClick={() => props.onEdit(props.item.displayPath)}
-      // Always visible (muted, brightening on hover/focus) - user decision:
-      // hover-revealed row actions were not discoverable.
-      className="text-muted-foreground opacity-[var(--fc-opacity,0.7)] transition-opacity hover:bg-accent/50 hover:text-foreground hover:opacity-100 focus-visible:opacity-100"
+    <TooltipWrapper
+      label="Setup & teardown scripts"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <FileSliders className="size-4" />
-    </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label="Edit setup and teardown scripts"
+        data-testid="folder-scripts-trigger"
+        onClick={() => props.onEdit(props.item.displayPath)}
+        // Always visible (muted, brightening on hover/focus) - user decision:
+        // hover-revealed row actions were not discoverable.
+        className="text-muted-foreground opacity-[var(--fc-opacity,0.7)] transition-opacity hover:bg-accent/50 hover:text-foreground hover:opacity-100 focus-visible:opacity-100"
+      >
+        <FileSliders className="size-4" />
+      </Button>
+    </TooltipWrapper>
   );
 }
 
@@ -285,32 +301,32 @@ function EnvironmentButton(props: {
  */
 function MakePrimaryButton(props: { readonly item: WorkspaceRunItem }) {
   const { item } = props;
-  const button = (
-    <button
-      type="button"
-      aria-label="Set as primary"
-      aria-disabled={item.makePrimaryDisabled}
-      title="Set as primary"
-      data-testid="folder-make-primary"
-      onClick={item.makePrimaryDisabled ? undefined : item.onMakePrimary}
-      className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-[var(--fc-opacity,0.7)] outline-none transition-[opacity,color,background-color] hover:bg-accent/50 hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/60 aria-disabled:cursor-not-allowed aria-disabled:text-muted-foreground/60 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground/60 aria-disabled:hover:opacity-[var(--fc-opacity,0.7)]"
+  // ONE tooltip, not one per concern: when the pin is disabled the reason is
+  // strictly more informative than restating the action, and rendering both
+  // put two tooltips on a single trigger.
+  const label =
+    item.makePrimaryDisabled && item.makePrimaryDisabledReason !== null
+      ? item.makePrimaryDisabledReason
+      : "Set as primary";
+  return (
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <Pin className="size-3.5" />
-    </button>
-  );
-  if (item.makePrimaryDisabled && item.makePrimaryDisabledReason !== null) {
-    return (
-      <TooltipWrapper
-        label={item.makePrimaryDisabledReason}
-        side="top"
-        sideOffset={undefined}
-        align={undefined}
+      <button
+        type="button"
+        aria-label="Set as primary"
+        aria-disabled={item.makePrimaryDisabled}
+        data-testid="folder-make-primary"
+        onClick={item.makePrimaryDisabled ? undefined : item.onMakePrimary}
+        className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-[var(--fc-opacity,0.7)] outline-none transition-[opacity,color,background-color] hover:bg-accent/50 hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/60 aria-disabled:cursor-not-allowed aria-disabled:text-muted-foreground/60 aria-disabled:hover:bg-transparent aria-disabled:hover:text-muted-foreground/60 aria-disabled:hover:opacity-[var(--fc-opacity,0.7)]"
       >
-        {button}
-      </TooltipWrapper>
-    );
-  }
-  return button;
+        <Pin className="size-3.5" />
+      </button>
+    </TooltipWrapper>
+  );
 }
 
 function RemoveFolderButton(props: { readonly item: WorkspaceRunItem }) {

--- a/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/host-workspace-selector.tsx
@@ -110,6 +110,7 @@ import { toast } from "sonner";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 import { trackUserInitiatedWorktreeWrite } from "@/lib/worktree/user-worktree-analytics";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 /**
  *
  *
@@ -857,22 +858,33 @@ function HostOnlySelect(props: {
       onValueChange={props.onSelect}
       disabled={disabled}
     >
-      <SelectTrigger
-        size="sm"
-        aria-label="Host"
-        title={disabled ? "Terminal host is fixed" : undefined}
-        data-testid="composer-host-trigger"
-        className="h-7 w-full min-w-0 max-w-full justify-start gap-1.5 overflow-hidden border-transparent bg-transparent px-1.5 text-ui-sm text-muted-foreground opacity-70 transition-[background-color,opacity] hover:bg-accent/50 hover:opacity-100 focus-visible:opacity-100 disabled:opacity-70 data-[state=open]:rounded-b-none dark:bg-transparent dark:hover:bg-accent/50 *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:flex-1 *:data-[slot=select-value]:overflow-hidden *:data-[slot=select-value]:truncate"
+      <TooltipWrapper
+        label={disabled ? "Terminal host is fixed" : undefined}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <SelectValue placeholder={props.hostLabel} />
-        {props.loading ? (
-          <AgentSpinningDots
-            className="text-current/70"
-            testId={undefined}
-            variant={undefined}
-          />
-        ) : null}
-      </SelectTrigger>
+        {/* `flex w-full min-w-0`, NOT `inline-flex`: the trigger below is
+            `w-full`, and a shrink-to-fit guard would make that resolve against
+            the guard rather than the selector's cell, collapsing the control. */}
+        <span className="flex w-full min-w-0">
+          <SelectTrigger
+            size="sm"
+            aria-label="Host"
+            data-testid="composer-host-trigger"
+            className="h-7 w-full min-w-0 max-w-full justify-start gap-1.5 overflow-hidden border-transparent bg-transparent px-1.5 text-ui-sm text-muted-foreground opacity-70 transition-[background-color,opacity] hover:bg-accent/50 hover:opacity-100 focus-visible:opacity-100 disabled:opacity-70 data-[state=open]:rounded-b-none dark:bg-transparent dark:hover:bg-accent/50 *:data-[slot=select-value]:min-w-0 *:data-[slot=select-value]:flex-1 *:data-[slot=select-value]:overflow-hidden *:data-[slot=select-value]:truncate"
+          >
+            <SelectValue placeholder={props.hostLabel} />
+            {props.loading ? (
+              <AgentSpinningDots
+                className="text-current/70"
+                testId={undefined}
+                variant={undefined}
+              />
+            ) : null}
+          </SelectTrigger>
+        </span>
+      </TooltipWrapper>
       <SelectContent
         data-testid="composer-host-popover"
         sideOffset={0}

--- a/clients/gui-app/src/components/home/host-workspace-selector/new-worktree-form.tsx
+++ b/clients/gui-app/src/components/home/host-workspace-selector/new-worktree-form.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/home/worktree/worktree-unified-picker-model";
 import { promotePickerRow } from "./promote-picker-row";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 type RepoIdentifier = WorktreeFolderIntent["repoIdentifier"];
 
 const WORKTREE_AUTOSAVE_DELAY_MS = 500;
@@ -243,25 +244,37 @@ export function ImportedWorktreeBranchForm(
         <dt className="text-ui-xs font-medium text-muted-foreground">
           Source branch
         </dt>
-        <dd
-          title={props.sourceBranch}
-          className="mt-1 min-w-0 truncate text-ui-sm text-foreground/85"
-          data-testid="import-worktree-source-branch"
+        <TooltipWrapper
+          label={props.sourceBranch}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          {props.sourceBranch}
-        </dd>
+          <dd
+            className="mt-1 min-w-0 truncate text-ui-sm text-foreground/85"
+            data-testid="import-worktree-source-branch"
+          >
+            {props.sourceBranch}
+          </dd>
+        </TooltipWrapper>
       </div>
       <div className="min-w-0">
         <dt className="text-ui-xs font-medium text-muted-foreground">
           Current branch
         </dt>
-        <dd
-          title={props.currentBranchName}
-          className="mt-1 min-w-0 truncate text-ui-sm text-foreground/85"
-          data-testid="import-worktree-branch-name"
+        <TooltipWrapper
+          label={props.currentBranchName}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          {props.currentBranchName}
-        </dd>
+          <dd
+            className="mt-1 min-w-0 truncate text-ui-sm text-foreground/85"
+            data-testid="import-worktree-branch-name"
+          >
+            {props.currentBranchName}
+          </dd>
+        </TooltipWrapper>
       </div>
     </dl>
   );

--- a/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
+++ b/clients/gui-app/src/components/home/pickers/harness-model-picker-group.tsx
@@ -103,15 +103,21 @@ export function ProviderRail(props: ProviderRailProps) {
         label="Refresh providers & models"
         className="mt-1"
       />
-      <button
-        type="button"
-        aria-label="Provider CLI settings"
-        title="Provider CLI settings"
-        onClick={onOpenProviderSettings}
-        className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+      <TooltipWrapper
+        label="Provider CLI settings"
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <Settings className="size-4" />
-      </button>
+        <button
+          type="button"
+          aria-label="Provider CLI settings"
+          onClick={onOpenProviderSettings}
+          className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+        >
+          <Settings className="size-4" />
+        </button>
+      </TooltipWrapper>
     </div>
   );
 }
@@ -144,12 +150,11 @@ function ProviderRailButton(props: ProviderRailButtonProps) {
   const degradedDescriptionId = useId();
   const harness = entry.harness;
   return (
+    // One wrapper, not two: `railButtonTitle` already resolves the locked
+    // reason, the "checking availability…" state and the plain harness label,
+    // so a second wrapper for the locked case put two tooltips on one trigger.
     <TooltipWrapper
-      label={
-        disabled && !harness.availabilityPending
-          ? LOCKED_PROVIDER_TOOLTIP
-          : null
-      }
+      label={railButtonTitle(entry, disabled)}
       side="right"
       sideOffset={6}
       align={undefined}
@@ -169,7 +174,6 @@ function ProviderRailButton(props: ProviderRailButtonProps) {
             ? degradedDescriptionId
             : undefined
         }
-        title={railButtonTitle(entry, disabled)}
         tabIndex={disabled ? -1 : undefined}
         data-active={active}
         data-degraded={entry.degraded ? true : undefined}

--- a/clients/gui-app/src/components/home/pickers/permissions-picker.tsx
+++ b/clients/gui-app/src/components/home/pickers/permissions-picker.tsx
@@ -59,10 +59,17 @@ export function PermissionsPicker(props: PermissionsPickerProps) {
   return (
     <DropdownMenu>
       <NarrowOnlyTooltip label={label}>
+        {/* No tooltip of its own: `NarrowOnlyTooltip` above already renders one
+            (it IS a `TooltipWrapper`), and the label is VISIBLE on this pill
+            until the composer goes narrow - which is exactly when that wrapper
+            takes over. A second wrapper here put two tooltips carrying the same
+            text on one trigger, and its guard span sat between
+            `DropdownMenuTrigger asChild` and the button, so Radix's menu props
+            - `aria-haspopup`, `aria-expanded`, `data-state`, the ref - landed
+            on a generic span instead of the focusable control. */}
         <DropdownMenuTrigger asChild>
           <ToolbarPillButton
             aria-label={label}
-            title={label}
             disabled={disabled}
             className="max-w-[min(32cqw,13rem)] disabled:cursor-not-allowed disabled:opacity-50"
           >

--- a/clients/gui-app/src/components/home/toolbar/composer-mic-button.tsx
+++ b/clients/gui-app/src/components/home/toolbar/composer-mic-button.tsx
@@ -8,6 +8,7 @@ import { DICTATION_ACTION_ID } from "@/hooks/composer/use-dictation-hotkey";
 import type { DictationPreparingStatus } from "@/hooks/composer/use-dictation-availability";
 import type { VoiceDictationState } from "@/hooks/composer/use-voice-dictation";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 /**
  * Presentation-only control bundle the composer hands to the toolbar so the mic
  * button stays a dumb view over the dictation hook's state. The recording timer
@@ -57,18 +58,24 @@ export function ComposerMicButton({
       : label;
 
   return (
-    <ToolbarIconButton
-      aria-label={label}
-      title={title}
-      aria-pressed={isRecording}
-      onClick={onToggle}
-      className={cn(
-        isRecording &&
-          "bg-destructive/15 text-destructive hover:bg-destructive/20 hover:text-destructive",
-      )}
+    <TooltipWrapper
+      label={title}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <MicButtonIcon isBusy={isBusy} isRecording={isRecording} />
-    </ToolbarIconButton>
+      <ToolbarIconButton
+        aria-label={label}
+        aria-pressed={isRecording}
+        onClick={onToggle}
+        className={cn(
+          isRecording &&
+            "bg-destructive/15 text-destructive hover:bg-destructive/20 hover:text-destructive",
+        )}
+      >
+        <MicButtonIcon isBusy={isBusy} isRecording={isRecording} />
+      </ToolbarIconButton>
+    </TooltipWrapper>
   );
 }
 
@@ -153,15 +160,22 @@ export function ComposerMicPreparing({
   // gets no pointer events). Put the tooltip on a wrapping span and make the
   // button `pointer-events-none` so the hover lands on the span.
   return (
-    <span title={label} className="inline-flex">
-      <ToolbarIconButton
-        aria-label={label}
-        disabled
-        aria-busy
-        className="pointer-events-none text-muted-foreground disabled:opacity-100"
-      >
-        <MicProgressRing progress={progress} />
-      </ToolbarIconButton>
-    </span>
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <span className="inline-flex">
+        <ToolbarIconButton
+          aria-label={label}
+          disabled
+          aria-busy
+          className="pointer-events-none text-muted-foreground disabled:opacity-100"
+        >
+          <MicProgressRing progress={progress} />
+        </ToolbarIconButton>
+      </span>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/home/toolbar/composer-toolbar-left.tsx
+++ b/clients/gui-app/src/components/home/toolbar/composer-toolbar-left.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@/components/home/data/landing-options";
 import { AgentModeToggle } from "@/components/home/pickers/agent-mode-toggle";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface ComposerToolbarLeftProps {
   onAttachImages: (files: ReadonlyArray<File>) => void;
   agentMode: AgentMode;
@@ -76,13 +77,19 @@ function ComposerToolbarLeftImpl(props: ComposerToolbarLeftProps) {
         className="hidden"
         onChange={handleImageChange}
       />
-      <ToolbarIconButton
-        aria-label="Attach image"
-        title="Attach image"
-        onClick={handleOpenImagePicker}
+      <TooltipWrapper
+        label="Attach image"
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <ImagePlus className="size-4" />
-      </ToolbarIconButton>
+        <ToolbarIconButton
+          aria-label="Attach image"
+          onClick={handleOpenImagePicker}
+        >
+          <ImagePlus className="size-4" />
+        </ToolbarIconButton>
+      </TooltipWrapper>
       <PermissionsPicker
         value={permission}
         disabled={settingsLocked}

--- a/clients/gui-app/src/components/home/toolbar/dictation-recording-bar.tsx
+++ b/clients/gui-app/src/components/home/toolbar/dictation-recording-bar.tsx
@@ -5,6 +5,7 @@ import { MutedAgentSpinner } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import type { VoiceDictationState } from "@/hooks/composer/use-voice-dictation";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface DictationRecordingBarProps {
   readonly state: VoiceDictationState;
   readonly getStream: () => MediaStream | null;
@@ -65,28 +66,40 @@ function RecordingControls({
       <div className="h-7 min-w-0 flex-1 text-primary">
         <DictationWaveform getStream={getStream} className={undefined} />
       </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="size-7 shrink-0"
-        onClick={onCancel}
-        aria-label="Cancel voice input"
-        title="Cancel (Esc)"
+      <TooltipWrapper
+        label="Cancel (Esc)"
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <X className="size-4" />
-      </Button>
-      <Button
-        type="button"
-        size="sm"
-        className="h-7 shrink-0 gap-1.5"
-        onClick={onStop}
-        aria-label="Stop and insert transcript"
-        title="Stop and insert"
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7 shrink-0"
+          onClick={onCancel}
+          aria-label="Cancel voice input"
+        >
+          <X className="size-4" />
+        </Button>
+      </TooltipWrapper>
+      <TooltipWrapper
+        label="Stop and insert"
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <Square className="size-3 fill-current" />
-        Stop
-      </Button>
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 shrink-0 gap-1.5"
+          onClick={onStop}
+          aria-label="Stop and insert transcript"
+        >
+          <Square className="size-3 fill-current" />
+          Stop
+        </Button>
+      </TooltipWrapper>
     </>
   );
 }

--- a/clients/gui-app/src/components/home/toolbar/match-mode-toggle.tsx
+++ b/clients/gui-app/src/components/home/toolbar/match-mode-toggle.tsx
@@ -12,20 +12,20 @@ export function MatchModeToggle(props: MatchModeToggleProps) {
   return (
     <div className="inline-flex rounded-md border border-border/60 bg-background/60 p-0.5 font-mono text-code-xs font-medium">
       <PillToggleButton
+        tooltip={`Match any selected ${selectedLabel}`}
         active={value === "any"}
         onClick={() => {
           onChange("any");
         }}
-        title={`Match any selected ${selectedLabel}`}
       >
         OR
       </PillToggleButton>
       <PillToggleButton
+        tooltip={`Match all selected ${selectedLabel}`}
         active={value === "all"}
         onClick={() => {
           onChange("all");
         }}
-        title={`Match all selected ${selectedLabel}`}
       >
         AND
       </PillToggleButton>

--- a/clients/gui-app/src/components/home/toolbar/pill-toggle-button.tsx
+++ b/clients/gui-app/src/components/home/toolbar/pill-toggle-button.tsx
@@ -1,28 +1,37 @@
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface PillToggleButtonProps {
   active: boolean;
   onClick: () => void;
-  title: string;
+  /** Hover label. Named `tooltip`, not `title`: a `title` prop on a
+   *  DOM-spreading component is indistinguishable from the native attribute. */
+  tooltip: string;
   children: ReactNode;
 }
 
 export function PillToggleButton(props: PillToggleButtonProps) {
-  const { active, onClick, title, children } = props;
+  const { active, onClick, tooltip, children } = props;
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={title}
-      className={cn(
-        "rounded-sm px-2 py-0.5 transition-colors",
-        active
-          ? "bg-accent text-foreground"
-          : "text-muted-foreground hover:text-foreground",
-      )}
+    <TooltipWrapper
+      label={tooltip}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {children}
-    </button>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          "rounded-sm px-2 py-0.5 transition-colors",
+          active
+            ? "bg-accent text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        {children}
+      </button>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -46,6 +46,7 @@ import {
 } from "vitest";
 import "../../../../__tests__/test-browser-apis";
 
+import { anyTooltipHasText } from "@/components/ui/__tests__/tooltip-probe";
 vi.mock("@/hooks/notifications/use-host-notification-indicators-query", () => ({
   useHostNotificationIndicators: () => ({
     data: { epics: {}, chats: {} },
@@ -622,9 +623,7 @@ describe("<TabStrip />", () => {
       "lucide-message-square-clock",
     );
     expect(screen.queryByTestId(`header-tab-activity-${EPIC_A.id}`)).toBeNull();
-    expect(
-      screen.queryByTitle("Background activity — agent idle"),
-    ).not.toBeNull();
+    expect(anyTooltipHasText("Background activity — agent idle")).toBe(true);
   });
 
   it("prioritizes turn activity over background work from another chat", async () => {

--- a/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
+++ b/clients/gui-app/src/components/layout/header/rate-limit-popover.tsx
@@ -839,15 +839,21 @@ function RateLimitRail({
         providers={providers}
         traycerRefreshTarget={traycerRefreshTarget}
       />
-      <button
-        type="button"
-        aria-label="Provider settings"
-        title="Provider settings"
-        onClick={openProviderSettings}
-        className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+      <TooltipWrapper
+        label="Provider settings"
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <Settings className="size-4" />
-      </button>
+        <button
+          type="button"
+          aria-label="Provider settings"
+          onClick={openProviderSettings}
+          className="mt-1 flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+        >
+          <Settings className="size-4" />
+        </button>
+      </TooltipWrapper>
     </div>
   );
 }
@@ -870,7 +876,6 @@ function RailTab({
         role="tab"
         aria-selected={selected}
         aria-label={label}
-        title={label}
         onClick={onSelect}
         className={cn(
           "flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60",

--- a/clients/gui-app/src/components/layout/header/sign-in/copyable-approval-field.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/copyable-approval-field.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/lib/utils";
 import { COPY_CONFIRMATION_RESET_MS } from "./styles";
 import { reportableErrorToast } from "@/lib/reportable-error-toast";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const handleCopyError = (): void => {
   reportableErrorToast("Couldn't copy to clipboard.", undefined, {
     title: "Could not copy to clipboard",
@@ -45,19 +46,25 @@ export function CopyableApprovalField(props: {
             : "border-border bg-background focus-within:border-ring",
         )}
       >
-        <span
-          className={cn(
-            "min-w-0 flex-1 px-3 py-2 text-left font-mono font-semibold",
-            props.valueKind === "code"
-              ? "tracking-widest"
-              : "truncate tracking-normal",
-            props.isHero ? "text-white" : "text-foreground",
-          )}
-          title={props.value}
-          data-testid={props.testId}
+        <TooltipWrapper
+          label={props.value}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          {props.value}
-        </span>
+          <span
+            className={cn(
+              "min-w-0 flex-1 px-3 py-2 text-left font-mono font-semibold",
+              props.valueKind === "code"
+                ? "tracking-widest"
+                : "truncate tracking-normal",
+              props.isHero ? "text-white" : "text-foreground",
+            )}
+            data-testid={props.testId}
+          >
+            {props.value}
+          </span>
+        </TooltipWrapper>
         <button
           type="button"
           onClick={() => copy(props.value)}

--- a/clients/gui-app/src/components/notifications/__tests__/notification-indicator-icon.test.tsx
+++ b/clients/gui-app/src/components/notifications/__tests__/notification-indicator-icon.test.tsx
@@ -1,6 +1,7 @@
 import "../../../../__tests__/test-browser-apis";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
+import { anyTooltipHasText } from "@/components/ui/__tests__/tooltip-probe";
 import {
   NotificationIndicatorIcon,
   type IndicatorRunningKind,
@@ -40,7 +41,7 @@ describe("<NotificationIndicatorIcon />", () => {
     expect(
       screen.getByTestId("indicator-failure-subject-1").getAttribute("class"),
     ).toContain("lucide-message-square-x");
-    expect(screen.getByTitle("Task needs attention")).toBeDefined();
+    expect(anyTooltipHasText("Task needs attention")).toBe(true);
     expect(screen.queryByTestId("indicator-activity-subject-1")).toBeNull();
 
     rerender(

--- a/clients/gui-app/src/components/notifications/notification-indicator-icon.tsx
+++ b/clients/gui-app/src/components/notifications/notification-indicator-icon.tsx
@@ -7,6 +7,7 @@ import {
   type IndicatorTone,
 } from "@/components/notifications/notification-indicator-tones";
 import type { NotificationIndicatorState } from "@/stores/notifications/notification-indicator-state";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { cn } from "@/lib/utils";
 
 export const BACKGROUND_ACTIVITY_TITLE = "Background activity — agent idle";
@@ -49,7 +50,7 @@ export function NotificationIndicatorIcon(
   }
   if (props.running === "turn") {
     return (
-      <IndicatorSpan indicatorProps={props} title={props.runningTitle}>
+      <IndicatorSpan indicatorProps={props} tooltip={props.runningTitle}>
         <AgentSpinningDots
           className="text-current"
           testId={`${props.testIdPrefix}-activity-${props.subjectId}`}
@@ -60,7 +61,7 @@ export function NotificationIndicatorIcon(
   }
   if (props.running === "background") {
     return (
-      <IndicatorSpan indicatorProps={props} title={BACKGROUND_ACTIVITY_TITLE}>
+      <IndicatorSpan indicatorProps={props} tooltip={BACKGROUND_ACTIVITY_TITLE}>
         <BackgroundActivityGlyph
           testId={`${props.testIdPrefix}-background-activity-${props.subjectId}`}
         />
@@ -91,22 +92,16 @@ function IndicatorStatus(props: {
 }): ReactNode {
   const Icon = props.tone.Icon;
   return (
-    <span
-      role="status"
-      aria-label={props.tone.title}
-      className={cn(
-        "inline-flex size-3.5 shrink-0 items-center justify-center",
-        props.indicatorProps.className,
-      )}
-      style={props.indicatorProps.style}
-      title={props.tone.title}
+    <IndicatorSpan
+      indicatorProps={props.indicatorProps}
+      tooltip={props.tone.title}
     >
       <Icon
         aria-hidden
         className={cn("size-3.5", props.tone.className)}
         data-testid={`${props.indicatorProps.testIdPrefix}-${props.tone.testId}-${props.indicatorProps.subjectId}`}
       />
-    </span>
+    </IndicatorSpan>
   );
 }
 
@@ -115,42 +110,53 @@ function IndicatorDot(props: {
   readonly indicatorProps: NotificationIndicatorIconProps;
 }): ReactNode {
   return (
-    <span
-      role="status"
-      aria-label={props.tone.title}
-      className={cn(
-        "inline-flex size-3.5 shrink-0 items-center justify-center",
-        props.indicatorProps.className,
-      )}
-      style={props.indicatorProps.style}
-      title={props.tone.title}
+    <IndicatorSpan
+      indicatorProps={props.indicatorProps}
+      tooltip={props.tone.title}
     >
       <AgentSpinningDots
         className={props.tone.className}
         testId={`${props.indicatorProps.testIdPrefix}-${props.tone.testId}-${props.indicatorProps.subjectId}`}
         variant="static"
       />
-    </span>
+    </IndicatorSpan>
   );
 }
 
+/**
+ * The one status-glyph leaf: `role="status"` + accessible name + the hover
+ * tooltip. The tone/dot/running variants above differ only in their glyph, and
+ * each used to re-spell this span - including its own native `title`, which is
+ * how three copies of the same "aria-label and title say the same thing"
+ * pairing ended up here.
+ *
+ * The prop is `tooltip`, not `title`: `title` on a component that spreads onto
+ * a DOM node is indistinguishable at the call site from the native attribute
+ * this replaces.
+ */
 function IndicatorSpan(props: {
   readonly indicatorProps: NotificationIndicatorIconProps;
-  readonly title: string;
+  readonly tooltip: string;
   readonly children: ReactNode;
 }): ReactNode {
   return (
-    <span
-      role="status"
-      aria-label={props.title}
-      className={cn(
-        "inline-flex size-3.5 shrink-0 items-center justify-center",
-        props.indicatorProps.className,
-      )}
-      style={props.indicatorProps.style}
-      title={props.title}
+    <TooltipWrapper
+      label={props.tooltip}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {props.children}
-    </span>
+      <span
+        role="status"
+        aria-label={props.tooltip}
+        className={cn(
+          "inline-flex size-3.5 shrink-0 items-center justify-center",
+          props.indicatorProps.className,
+        )}
+        style={props.indicatorProps.style}
+      >
+        {props.children}
+      </span>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-detected-agents.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/provider-ordering";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 type InstallState = "detected" | "missing" | "pending";
 
 function installStateFor(state: ProviderCliState | undefined): InstallState {
@@ -133,14 +134,20 @@ function accountDescription(state: ProviderCliState | undefined): ReactNode {
   if (state === undefined) return null;
   const account = accountLineFor(state);
   return (
-    <span
-      title={account.title ?? undefined}
-      className={cn(
-        account.tone === "good" ? "text-[#7fd6a4]" : "text-white/45",
-      )}
+    <TooltipWrapper
+      label={account.title ?? undefined}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {account.text}
-    </span>
+      <span
+        className={cn(
+          account.tone === "good" ? "text-[#7fd6a4]" : "text-white/45",
+        )}
+      >
+        {account.text}
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -161,21 +168,28 @@ function ProviderEnableSwitch(props: {
     onSetEnabled,
   } = props;
   return (
-    <Switch
-      checked={enabled}
-      onCheckedChange={(next) => {
-        if (isSettingEnabled || (!next && disablingLastEnabled)) return;
-        onSetEnabled(providerId, next);
-      }}
-      disabled={isSettingEnabled || disablingLastEnabled}
-      aria-label={`Enable ${name}`}
-      title={
-        disablingLastEnabled
-          ? "At least one provider must stay enabled."
-          : undefined
+    <TooltipWrapper
+      label={
+        disablingLastEnabled ? "At least one provider must stay enabled." : null
       }
-      className="ml-auto"
-    />
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      {/* Guard span: the Switch is `disabled` in exactly the state this
+          explains, and a disabled control emits no pointer events. */}
+      <span className="ml-auto inline-flex">
+        <Switch
+          checked={enabled}
+          onCheckedChange={(next) => {
+            if (isSettingEnabled || (!next && disablingLastEnabled)) return;
+            onSetEnabled(providerId, next);
+          }}
+          disabled={isSettingEnabled || disablingLastEnabled}
+          aria-label={`Enable ${name}`}
+        />
+      </span>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/onboarding/onboarding-theme-picker.tsx
+++ b/clients/gui-app/src/components/onboarding/onboarding-theme-picker.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/stores/settings/settings-store";
 import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const MODES: ReadonlyArray<{ id: ThemeMode; label: string }> = [
   { id: "light", label: "Light" },
   { id: "dark", label: "Dark" },
@@ -64,34 +65,40 @@ export function OnboardingThemePicker() {
         className="flex w-full max-w-[min(90vw,24rem)] flex-wrap gap-2"
       >
         {THEME_PRESETS.map((preset) => (
-          <button
+          <TooltipWrapper
             key={preset.id}
-            type="button"
-            aria-pressed={themePreset === preset.id}
-            aria-label={preset.label}
-            title={preset.label}
-            onClick={() => {
-              if (preset.id === themePreset) return;
-              Analytics.getInstance().track(
-                AnalyticsEvent.OnboardingThemeChanged,
-                { theme: `preset:${preset.id}` },
-              );
-              setThemePreset(preset.id);
-            }}
-            className={cn(
-              "relative size-7 shrink-0 overflow-hidden rounded-full border transition-transform duration-200",
-              themePreset === preset.id
-                ? "scale-110 border-white"
-                : "border-white/25 hover:scale-105 hover:border-white/60",
-            )}
-            style={{ backgroundColor: preset.swatch }}
+            label={preset.label}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            <span
-              aria-hidden="true"
-              className="absolute inset-x-0 bottom-0 h-1/3"
-              style={{ backgroundColor: preset.accent }}
-            />
-          </button>
+            <button
+              type="button"
+              aria-pressed={themePreset === preset.id}
+              aria-label={preset.label}
+              onClick={() => {
+                if (preset.id === themePreset) return;
+                Analytics.getInstance().track(
+                  AnalyticsEvent.OnboardingThemeChanged,
+                  { theme: `preset:${preset.id}` },
+                );
+                setThemePreset(preset.id);
+              }}
+              className={cn(
+                "relative size-7 shrink-0 overflow-hidden rounded-full border transition-transform duration-200",
+                themePreset === preset.id
+                  ? "scale-110 border-white"
+                  : "border-white/25 hover:scale-105 hover:border-white/60",
+              )}
+              style={{ backgroundColor: preset.swatch }}
+            >
+              <span
+                aria-hidden="true"
+                className="absolute inset-x-0 bottom-0 h-1/3"
+                style={{ backgroundColor: preset.accent }}
+              />
+            </button>
+          </TooltipWrapper>
         ))}
       </div>
 

--- a/clients/gui-app/src/components/providers/__tests__/profile-dropdown.test.tsx
+++ b/clients/gui-app/src/components/providers/__tests__/profile-dropdown.test.tsx
@@ -74,6 +74,7 @@ vi.mock("@/components/ui/dropdown-menu", () => {
 
 import { ProfileDropdown } from "../profile-dropdown";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 function profile(
   profileId: string,
   kind: ProviderProfile["kind"],
@@ -333,7 +334,7 @@ describe("<ProfileDropdown />", () => {
       throw new Error("Expected create row mock to render as a button.");
     }
     expect(row.disabled).toBe(true);
-    expect(row.getAttribute("title")).toBe("Local sign-in required.");
+    expect(tooltipTextNear(row)).toBe("Local sign-in required.");
     fireEvent.click(row);
     expect(onCreateProfile).not.toHaveBeenCalled();
   });

--- a/clients/gui-app/src/components/providers/profile-dropdown.tsx
+++ b/clients/gui-app/src/components/providers/profile-dropdown.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils";
 import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
 import { useState } from "react";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const PROFILE_DROPDOWN_KEYS = new Set([
   "ArrowDown",
   "ArrowUp",
@@ -264,14 +265,25 @@ export function ProfileDropdown(props: ProfileDropdownProps) {
           );
         })}
         <DropdownMenuSeparator />
-        <DropdownMenuItem
-          disabled={createProfileDisabled}
-          title={createProfileDisabledReason}
-          onSelect={onCreateProfile}
+        <TooltipWrapper
+          label={createProfileDisabledReason}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          <Plus className="size-3.5" />
-          Create new profile
-        </DropdownMenuItem>
+          {/* `flex w-full`, not `inline-flex`: the guard becomes the menu
+              content's layout child, and a shrink-to-fit one would narrow the
+              row to its text. */}
+          <span className="flex w-full">
+            <DropdownMenuItem
+              disabled={createProfileDisabled}
+              onSelect={onCreateProfile}
+            >
+              <Plus className="size-3.5" />
+              Create new profile
+            </DropdownMenuItem>
+          </span>
+        </TooltipWrapper>
       </DropdownMenuContent>
       {usagePresentation !== null &&
       open &&

--- a/clients/gui-app/src/components/refresh-icon-button.tsx
+++ b/clients/gui-app/src/components/refresh-icon-button.tsx
@@ -2,6 +2,7 @@ import { RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useRefreshSpinner } from "@/hooks/use-refresh-spinner";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 // Hard cap on the spinning/disabled state so a hung refetch can't wedge the
 // button; a normal catalog/provider refetch settles in well under a second.
 const REFRESH_TIMEOUT_MS = 10_000;
@@ -33,18 +34,26 @@ export function RefreshIconButton(props: RefreshIconButtonProps) {
   });
 
   return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      onClick={trigger}
-      disabled={refreshing}
-      className={cn(
-        "flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-muted-foreground",
-        className,
-      )}
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <RefreshCw className={cn("size-4", refreshing && "animate-spin")} />
-    </button>
+      <span className="inline-flex">
+        <button
+          type="button"
+          aria-label={label}
+          onClick={trigger}
+          disabled={refreshing}
+          className={cn(
+            "flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent disabled:hover:text-muted-foreground",
+            className,
+          )}
+        >
+          <RefreshCw className={cn("size-4", refreshing && "animate-spin")} />
+        </button>
+      </span>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/components/resources/resource-usage-chip.tsx
+++ b/clients/gui-app/src/components/resources/resource-usage-chip.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/resources/format-resource-usage";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 function pluralize(count: number, singular: string, plural: string): string {
   return count === 1 ? singular : plural;
 }
@@ -23,18 +24,24 @@ function ResourceChipFrame(props: {
   readonly children: ReactNode;
 }) {
   return (
-    <span
-      data-slot={props.slot}
-      title={props.description}
-      aria-label={props.description}
-      className={cn(
-        "inline-flex shrink-0 items-center gap-1 text-ui-xs tabular-nums text-muted-foreground",
-        props.className,
-      )}
+    <TooltipWrapper
+      label={props.description}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <Cpu aria-hidden className="size-3 shrink-0" />
-      {props.children}
-    </span>
+      <span
+        data-slot={props.slot}
+        aria-label={props.description}
+        className={cn(
+          "inline-flex shrink-0 items-center gap-1 text-ui-xs tabular-nums text-muted-foreground",
+          props.className,
+        )}
+      >
+        <Cpu aria-hidden className="size-3 shrink-0" />
+        {props.children}
+      </span>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/settings/controls/terminal-cursor-style-picker.tsx
+++ b/clients/gui-app/src/components/settings/controls/terminal-cursor-style-picker.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/utils";
 import type { TerminalCursorStyle } from "@/stores/settings/settings-store";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface TerminalCursorStylePickerProps {
   value: TerminalCursorStyle;
   onChange: (next: TerminalCursorStyle) => void;
@@ -36,32 +37,38 @@ export function TerminalCursorStylePicker(
       {STYLES.map((style) => {
         const active = style.id === value;
         return (
-          <button
+          <TooltipWrapper
             key={style.id}
-            type="button"
-            aria-pressed={active}
-            aria-label={style.label}
-            title={style.label}
-            onClick={() => {
-              onChange(style.id);
-            }}
-            className={cn(
-              "grid h-8 w-11 place-items-center rounded-sm transition-colors",
-              active
-                ? "bg-card text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
+            label={style.label}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            <span className="relative block h-5 w-[0.55rem] text-current">
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "absolute rounded-[1px] bg-current",
-                  SHAPE_CLASS[style.id],
-                )}
-              />
-            </span>
-          </button>
+            <button
+              type="button"
+              aria-pressed={active}
+              aria-label={style.label}
+              onClick={() => {
+                onChange(style.id);
+              }}
+              className={cn(
+                "grid h-8 w-11 place-items-center rounded-sm transition-colors",
+                active
+                  ? "bg-card text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <span className="relative block h-5 w-[0.55rem] text-current">
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "absolute rounded-[1px] bg-current",
+                    SHAPE_CLASS[style.id],
+                  )}
+                />
+              </span>
+            </button>
+          </TooltipWrapper>
         );
       })}
     </div>

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
@@ -28,6 +28,7 @@ import type {
 } from "@traycer-clients/shared/platform/runner-host";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -344,7 +345,7 @@ describe("<HostSettingsPanel /> - mutation flows", () => {
     ).toBeTruthy();
     const installButton = screen.getByRole("button", { name: "Install" });
     expect(installButton.hasAttribute("disabled")).toBe(true);
-    expect(installButton.getAttribute("title")).toBe(
+    expect(tooltipTextNear(installButton)).toBe(
       "Unavailable on this platform.",
     );
   });

--- a/clients/gui-app/src/components/settings/panels/__tests__/provider-profile-scoped-section-profile-summary.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/provider-profile-scoped-section-profile-summary.test.tsx
@@ -1,0 +1,152 @@
+import "../../../../../__tests__/test-browser-apis";
+import type { ProviderCliState } from "@traycer/protocol/host/provider-schemas";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { tooltipTextFor } from "@/components/ui/__tests__/tooltip-probe";
+
+// Same rationale as the sibling report-issue test: `ProfileEditDialog` and the
+// refresh button pull in mutation/host hooks unconditionally, so those are
+// mocked to keep this test scoped to a QueryClient, no bound host.
+vi.mock("@/lib/host", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/host")>();
+  return { ...actual, useHostClient: () => null };
+});
+vi.mock("@/hooks/providers/use-remove-provider-profile-mutation", () => ({
+  useRemoveProviderProfile: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+vi.mock("@/hooks/providers/use-rename-provider-profile-mutation", () => ({
+  useRenameProviderProfile: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+vi.mock("@/hooks/providers/use-recolor-provider-profile-mutation", () => ({
+  useRecolorProviderProfile: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  }),
+}));
+vi.mock("@/hooks/providers/use-refresh-providers", () => ({
+  useRefreshProviders: () => () => Promise.resolve(),
+}));
+
+import { ProviderProfileScopedSection } from "@/components/settings/panels/provider-profile-scoped-section";
+
+const RAW_EMAIL = "worker@example.com";
+// Matches `redactEmail`'s format: first local-part char + fixed mask + the
+// domain's first char. Duplicated here rather than imported so the test
+// fails loudly if the two definitions ever drift apart.
+const REDACTED_EMAIL = "w•••@e…";
+
+function managedProfile(): ProviderCliState["profiles"][number] {
+  return {
+    profileId: "profile-managed",
+    kind: "managed",
+    authType: "oauth",
+    label: "Work account",
+    auth: {
+      status: "authenticated",
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    identity: { email: RAW_EMAIL, tier: null, accountUuid: null },
+    usageUpdatedAt: null,
+    rateLimitStatus: "unknown",
+    rateLimitLimitedScopes: null,
+    duplicateOfProfileId: null,
+    accentColor: null,
+    ambientDriftNotice: null,
+  };
+}
+
+// `opencode` is not in the rate-limit-capable provider set, so the embedded
+// usage card and refresh button take their no-query branch - no additional
+// host-query mocking needed for this section-level test.
+function opencodeState(): ProviderCliState {
+  return {
+    providerId: "opencode",
+    enabled: true,
+    disabledBy: null,
+    selected: { kind: "bundled" },
+    candidates: [],
+    auth: {
+      status: "authenticated",
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    authPending: false,
+    checkedAt: null,
+    apiKey: { supported: false, configured: false, source: null },
+    terminalAgentArgs: "",
+    envOverrides: [],
+    loginCapability: null,
+    availabilityPending: false,
+    profiles: [managedProfile()],
+  };
+}
+
+function renderSection(
+  overrides: Partial<Parameters<typeof ProviderProfileScopedSection>[0]>,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <ProviderProfileScopedSection
+          state={opencodeState()}
+          hostId="host-1"
+          isSelectedHostLocal
+          canAddProfile
+          startInReauth={false}
+          failedAttempt={null}
+          onAddProfile={() => undefined}
+          onDismissFailedAttempt={() => undefined}
+          selectedProfileId="profile-managed"
+          onSelectedProfileIdChange={() => undefined}
+          {...overrides}
+        />
+      </TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("<ProviderProfileScopedSection /> profile summary email reveal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not leak the raw email through the tooltip while redacted", () => {
+    renderSection({});
+
+    // The visible text is redacted...
+    expect(screen.queryByText(RAW_EMAIL)).toBeNull();
+    const emailSpan = screen.getByText(REDACTED_EMAIL);
+    // ...and hovering the redacted text must not read the raw address either -
+    // the whole point of redaction is defeated if the tooltip still says it.
+    expect(tooltipTextFor(emailSpan)).not.toBe(RAW_EMAIL);
+  });
+
+  it("reveals the raw email in both the text and the tooltip once toggled", () => {
+    renderSection({});
+
+    fireEvent.click(screen.getByRole("button", { name: /Reveal email/ }));
+
+    const emailSpan = screen.getByText(RAW_EMAIL);
+    expect(tooltipTextFor(emailSpan)).toBe(RAW_EMAIL);
+  });
+});

--- a/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/providers-settings-panel.test.tsx
@@ -487,6 +487,7 @@ import { redactEmail } from "@/lib/providers/redact-email";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { useProvidersFocusStore } from "@/stores/settings/providers-focus-store";
 
+import { tooltipTextNear } from "@/components/ui/__tests__/tooltip-probe";
 const OPENCODE_CANDIDATES: readonly ProviderCliCandidate[] = [
   {
     kind: "bundled",
@@ -1393,7 +1394,9 @@ describe("<ProvidersSettingsPanel />", () => {
     }
     const removeProfileDisabledReason =
       "This profile uses your default CLI login and cannot be removed.";
-    expect(removeProfileTooltipTrigger.title).toBe(removeProfileDisabledReason);
+    expect(tooltipTextNear(removeProfileTooltipTrigger)).toBe(
+      removeProfileDisabledReason,
+    );
     expect(removeProfileButton.getAttribute("aria-label")).toBe(
       `Remove profile. ${removeProfileDisabledReason}`,
     );
@@ -1407,7 +1410,15 @@ describe("<ProvidersSettingsPanel />", () => {
     const refreshButton = screen.getByRole("button", {
       name: "Refresh profile statuses and usage limits",
     });
-    expect(addProfileButton.nextElementSibling).toBe(refreshButton);
+    // The add-profile button now sits inside the span that lets its tooltip
+    // fire while it is disabled, so adjacency is measured from that span.
+    // Both buttons now sit inside the span that lets their tooltip fire while
+    // disabled, so adjacency is asserted between those spans.
+    expect(
+      addProfileButton.parentElement?.nextElementSibling?.contains(
+        refreshButton,
+      ),
+    ).toBe(true);
     fireEvent.click(refreshButton);
     await waitFor(() => {
       expect(providerMocks.refreshProviders).toHaveBeenCalledTimes(1);

--- a/clients/gui-app/src/components/settings/panels/host-settings-available-versions-list.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-available-versions-list.tsx
@@ -2,6 +2,7 @@ import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
 import { ReportIssueAction } from "@/components/report-issue/report-issue-action";
 import { createReportIssueContext } from "@/lib/report-issue-context";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import {
   formatInstallDate,
   VERSION_LIST_PREVIEW,
@@ -155,20 +156,28 @@ function renderVersionRow(props: {
           </span>
         ) : null}
       </div>
-      <Button
-        variant="secondary"
-        size="sm"
-        disabled={
-          anyPending ||
-          isInstalled ||
-          entry.yanked ||
-          unavailableReason !== null
-        }
-        title={unavailableReason === null ? undefined : unavailableReason}
-        onClick={() => onInstallVersion(entry.version)}
+      <TooltipWrapper
+        label={unavailableReason === null ? undefined : unavailableReason}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        Install
-      </Button>
+        <span className="inline-flex">
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={
+              anyPending ||
+              isInstalled ||
+              entry.yanked ||
+              unavailableReason !== null
+            }
+            onClick={() => onInstallVersion(entry.version)}
+          >
+            Install
+          </Button>
+        </span>
+      </TooltipWrapper>
     </li>
   );
 }

--- a/clients/gui-app/src/components/settings/panels/host-settings-updates-row.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-updates-row.tsx
@@ -1,6 +1,7 @@
 import { SettingsRow } from "@/components/settings/settings-row";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import {
   formatCheckedAtTooltip,
   updatesDescription,
@@ -167,22 +168,30 @@ function UpdatesControl(props: {
   return (
     <div className="flex flex-wrap items-center justify-end gap-2">
       <span className="text-ui-sm text-emerald-500">Up to date</span>
-      <Button
-        variant="ghost"
-        size="sm"
-        disabled={registryFetching}
-        onClick={onRefresh}
-        title={tooltipLabel}
+      <TooltipWrapper
+        label={tooltipLabel}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        {registryFetching ? (
-          <AgentSpinningDots
-            className="mr-2 size-3"
-            testId={undefined}
-            variant={undefined}
-          />
-        ) : null}
-        Check now
-      </Button>
+        <span className="inline-flex">
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={registryFetching}
+            onClick={onRefresh}
+          >
+            {registryFetching ? (
+              <AgentSpinningDots
+                className="mr-2 size-3"
+                testId={undefined}
+                variant={undefined}
+              />
+            ) : null}
+            Check now
+          </Button>
+        </span>
+      </TooltipWrapper>
     </div>
   );
 }

--- a/clients/gui-app/src/components/settings/panels/provider-profile-scoped-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-profile-scoped-section.tsx
@@ -164,8 +164,8 @@ export function ProviderProfileScopedSection(
     ) ?? orderedProfiles[0];
   const providerLabel = PROVIDER_DISPLAY_NAMES[state.providerId];
   const addProfileDisabled = !canAddProfile || !isSelectedHostLocal;
-  // `null`, not `undefined`: `TooltipWrapper` degrades to a passthrough Slot on
-  // a null label only, so an `undefined` here renders an empty tooltip box.
+  // `TooltipWrapper` degrades to a passthrough Slot for both `null` and
+  // `undefined` labels; `null` here is just the plainer of the two spellings.
   const addProfileDisabledReason = addProfileDisabled
     ? "Add profiles from a local host with browser sign-in available."
     : null;
@@ -398,7 +398,7 @@ function ProfileSummary({
     <div className="flex min-w-0 flex-1 items-center gap-2 text-ui-xs text-muted-foreground">
       <div className="flex min-w-0 flex-1 items-center gap-1">
         <TooltipWrapper
-          label={email}
+          label={emailRevealed ? email : null}
           side="top"
           sideOffset={undefined}
           align="start"

--- a/clients/gui-app/src/components/settings/panels/provider-profile-scoped-section.tsx
+++ b/clients/gui-app/src/components/settings/panels/provider-profile-scoped-section.tsx
@@ -164,9 +164,11 @@ export function ProviderProfileScopedSection(
     ) ?? orderedProfiles[0];
   const providerLabel = PROVIDER_DISPLAY_NAMES[state.providerId];
   const addProfileDisabled = !canAddProfile || !isSelectedHostLocal;
+  // `null`, not `undefined`: `TooltipWrapper` degrades to a passthrough Slot on
+  // a null label only, so an `undefined` here renders an empty tooltip box.
   const addProfileDisabledReason = addProfileDisabled
     ? "Add profiles from a local host with browser sign-in available."
-    : undefined;
+    : null;
   const duplicateLabel = duplicateProfileLabel(selectedProfile, profiles);
   const driftKey = profileDriftKey(state.providerId, selectedProfile);
   const driftDismissed =
@@ -195,18 +197,29 @@ export function ProviderProfileScopedSection(
         <div className="flex items-center justify-between gap-2">
           <div className="text-ui-sm font-medium text-foreground">Profiles</div>
           <div className="flex items-center gap-1">
-            <Button
-              type="button"
-              size="xs"
-              variant="outline"
-              className="shrink-0"
-              disabled={addProfileDisabled}
-              title={addProfileDisabledReason}
-              onClick={onAddProfile}
+            <TooltipWrapper
+              label={addProfileDisabledReason}
+              side="top"
+              sideOffset={6}
+              align="start"
             >
-              <Plus className="size-3.5" />
-              Add profile
-            </Button>
+              {/* Span between the tooltip and the button because a `disabled`
+                  button emits no pointer events for Radix to hover-detect -
+                  and the reason it is disabled is exactly what this says. */}
+              <span className="inline-flex">
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="outline"
+                  className="shrink-0"
+                  disabled={addProfileDisabled}
+                  onClick={onAddProfile}
+                >
+                  <Plus className="size-3.5" />
+                  Add profile
+                </Button>
+              </span>
+            </TooltipWrapper>
             <ProviderProfilesRefreshButton
               providerId={state.providerId}
               profileId={profileCommitId(selectedProfile)}
@@ -225,7 +238,7 @@ export function ProviderProfileScopedSection(
           onSelectProfile={onSelectedProfileIdChange}
           onCreateProfile={onAddProfile}
           createProfileDisabled={addProfileDisabled}
-          createProfileDisabledReason={addProfileDisabledReason}
+          createProfileDisabledReason={addProfileDisabledReason ?? undefined}
           // ⌘⇧-digit isn't wired to Settings - no picker leader scope here.
           shortcutHintForIndex={noProfileShortcutHint}
           contentContainer={null}
@@ -241,22 +254,30 @@ export function ProviderProfileScopedSection(
             profile={selectedProfile}
           />
           {selectedProfile.auth.status === "unauthenticated" ? (
-            <Button
-              type="button"
-              size="xs"
-              variant="secondary"
-              className="shrink-0"
-              disabled={!canAddProfile}
-              title={
+            <TooltipWrapper
+              label={
                 canAddProfile
-                  ? undefined
+                  ? null
                   : "Sign in requires a local host with browser sign-in available."
               }
-              onClick={openProfileSignIn}
+              side="top"
+              sideOffset={6}
+              align="start"
             >
-              <LogIn data-icon="inline-start" />
-              Sign in
-            </Button>
+              <span className="inline-flex">
+                <Button
+                  type="button"
+                  size="xs"
+                  variant="secondary"
+                  className="shrink-0"
+                  disabled={!canAddProfile}
+                  onClick={openProfileSignIn}
+                >
+                  <LogIn data-icon="inline-start" />
+                  Sign in
+                </Button>
+              </span>
+            </TooltipWrapper>
           ) : null}
           <TooltipWrapper
             label="Change the profile name and accent color, sign in again, or remove this profile."
@@ -376,9 +397,14 @@ function ProfileSummary({
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2 text-ui-xs text-muted-foreground">
       <div className="flex min-w-0 flex-1 items-center gap-1">
-        <span className="min-w-0 truncate" title={email ?? undefined}>
-          {emailText}
-        </span>
+        <TooltipWrapper
+          label={email}
+          side="top"
+          sideOffset={undefined}
+          align="start"
+        >
+          <span className="min-w-0 truncate">{emailText}</span>
+        </TooltipWrapper>
         {email !== null ? (
           <button
             type="button"
@@ -403,13 +429,19 @@ function ProfileSummary({
         {profileAuthStatusText(profile)}
       </Badge>
       {planText !== null ? (
-        <Badge
-          variant="outline"
-          className="h-5 max-w-[min(28vw,14rem)] shrink-0 px-1.5 text-[10px]"
-          title={planText}
+        <TooltipWrapper
+          label={planText}
+          side="top"
+          sideOffset={undefined}
+          align="end"
         >
-          <span className="truncate">{planText}</span>
-        </Badge>
+          <Badge
+            variant="outline"
+            className="h-5 max-w-[min(28vw,14rem)] shrink-0 px-1.5 text-[10px]"
+          >
+            <span className="truncate">{planText}</span>
+          </Badge>
+        </TooltipWrapper>
       ) : null}
     </div>
   );
@@ -640,31 +672,42 @@ function ProfileEditDialog({
                 onDone={() => setSwitchingAccount(false)}
               />
             ) : (
-              <button
-                type="button"
-                aria-label="Switch account"
-                className="group flex w-full items-center gap-3 rounded-lg border border-border/60 bg-muted/20 p-3 text-left transition-colors hover:bg-muted/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={!canOauth || savePending || invalid}
-                title={
+              <TooltipWrapper
+                label={
                   canOauth
-                    ? undefined
+                    ? null
                     : "Switch account requires a local host with browser sign-in available."
                 }
-                onClick={switchAccount}
+                side="top"
+                sideOffset={6}
+                align={undefined}
               >
-                <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground ring-1 ring-border/60 transition-colors group-hover:text-foreground">
-                  <RefreshCw className="size-4" />
+                {/* `flex w-full` on the span, not `inline-flex`: the button it
+                    guards is full-width, and an inline-flex wrapper would
+                    collapse the row. */}
+                <span className="flex w-full">
+                  <button
+                    type="button"
+                    aria-label="Switch account"
+                    className="group flex w-full items-center gap-3 rounded-lg border border-border/60 bg-muted/20 p-3 text-left transition-colors hover:bg-muted/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={!canOauth || savePending || invalid}
+                    onClick={switchAccount}
+                  >
+                    <span className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground ring-1 ring-border/60 transition-colors group-hover:text-foreground">
+                      <RefreshCw className="size-4" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-ui-sm font-medium text-foreground">
+                        Switch account
+                      </span>
+                      <span className="block text-ui-xs text-muted-foreground">
+                        Sign in with a different account for this profile.
+                      </span>
+                    </span>
+                    <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
+                  </button>
                 </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block text-ui-sm font-medium text-foreground">
-                    Switch account
-                  </span>
-                  <span className="block text-ui-xs text-muted-foreground">
-                    Sign in with a different account for this profile.
-                  </span>
-                </span>
-                <ChevronRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" />
-              </button>
+              </TooltipWrapper>
             )}
 
             <ProfileEditErrors
@@ -688,10 +731,7 @@ function ProfileEditDialog({
                 sideOffset={6}
                 align="start"
               >
-                <span
-                  className="inline-flex"
-                  title={removeProfileDisabledReason ?? undefined}
-                >
+                <span className="inline-flex">
                   <Button
                     type="button"
                     size="sm"

--- a/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/providers-settings-panel.tsx
@@ -55,6 +55,7 @@ import { TerminalAgentArgsSection } from "./terminal-agent-args-section";
 import { ProviderEnvOverridesSection } from "./provider-env-overrides-section";
 import { ProviderCliCandidatesSection } from "./provider-cli-candidates-section";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 type ProviderId = ProviderCliState["providerId"];
 type ProvidersListQuery = UseQueryResult<
   ResponseOfMethod<HostRpcRegistry, "providers.list">,
@@ -450,18 +451,26 @@ function ProviderEnableSwitch(props: {
   const { id, providerId, enabled, isPending, onSetEnabled } = props;
   const disablingLast = enabled && props.enabledProviderCount <= 1;
   return (
-    <Switch
-      id={id}
-      checked={enabled}
-      onCheckedChange={(next) => {
-        if (isPending || (!next && disablingLast)) return;
-        onSetEnabled(providerId, next);
-      }}
-      disabled={isPending || disablingLast}
-      title={
-        disablingLast ? "At least one provider must stay enabled." : undefined
-      }
-    />
+    <TooltipWrapper
+      label={disablingLast ? "At least one provider must stay enabled." : null}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      {/* Guard span: the Switch is `disabled` in exactly the state this
+          explains, and a disabled control emits no pointer events. */}
+      <span className="inline-flex">
+        <Switch
+          id={id}
+          checked={enabled}
+          onCheckedChange={(next) => {
+            if (isPending || (!next && disablingLast)) return;
+            onSetEnabled(providerId, next);
+          }}
+          disabled={isPending || disablingLast}
+        />
+      </span>
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/worktrees-settings-panel.tsx
@@ -1768,35 +1768,43 @@ function WorktreeSelectAllToggle(props: {
   else if (indeterminate) indicator = <Minus className="size-3" />;
   const label = "Select all visible worktrees";
   return (
-    <button
-      type="button"
-      role="checkbox"
-      aria-checked={ariaChecked}
-      aria-label={label}
-      title={label}
-      data-testid="worktrees-select-all"
-      disabled={props.selectableCount === 0}
-      onClick={props.onToggle}
-      className={cn(
-        "flex h-7 shrink-0 items-center gap-1.5 rounded-sm border px-2 text-ui-xs font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
-        allSelected || indeterminate
-          ? "border-border bg-muted text-foreground"
-          : "border-border bg-background text-foreground hover:border-foreground hover:bg-muted",
-      )}
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <span
-        aria-hidden
-        className={cn(
-          "flex size-3.5 items-center justify-center rounded-[0.1875rem] border",
-          allSelected || indeterminate
-            ? "border-foreground/70 bg-foreground text-background"
-            : "border-muted-foreground/50",
-        )}
-      >
-        {indicator}
+      <span className="inline-flex">
+        <button
+          type="button"
+          role="checkbox"
+          aria-checked={ariaChecked}
+          aria-label={label}
+          data-testid="worktrees-select-all"
+          disabled={props.selectableCount === 0}
+          onClick={props.onToggle}
+          className={cn(
+            "flex h-7 shrink-0 items-center gap-1.5 rounded-sm border px-2 text-ui-xs font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-40",
+            allSelected || indeterminate
+              ? "border-border bg-muted text-foreground"
+              : "border-border bg-background text-foreground hover:border-foreground hover:bg-muted",
+          )}
+        >
+          <span
+            aria-hidden
+            className={cn(
+              "flex size-3.5 items-center justify-center rounded-[0.1875rem] border",
+              allSelected || indeterminate
+                ? "border-foreground/70 bg-foreground text-background"
+                : "border-muted-foreground/50",
+            )}
+          >
+            {indicator}
+          </span>
+          <span>Select all</span>
+        </button>
       </span>
-      <span>Select all</span>
-    </button>
+    </TooltipWrapper>
   );
 }
 
@@ -1963,13 +1971,17 @@ function WorktreeBulkDeleteDialog(props: {
             </div>
             <ul className="max-h-[min(30vh,12rem)] overflow-y-auto border-t border-border/60 px-5 py-2">
               {summary.paths.map((path) => (
-                <li
+                <TooltipWrapper
                   key={path}
-                  className="truncate py-0.5 text-ui-xs text-muted-foreground"
-                  title={path}
+                  label={path}
+                  side="top"
+                  sideOffset={undefined}
+                  align={undefined}
                 >
-                  {path}
-                </li>
+                  <li className="truncate py-0.5 text-ui-xs text-muted-foreground">
+                    {path}
+                  </li>
+                </TooltipWrapper>
               ))}
             </ul>
             <div className="flex justify-end gap-2 border-t border-border/60 bg-muted/20 px-5 py-3">
@@ -2729,17 +2741,23 @@ function WorktreeTaskAssociation(props: {
             variant="outline"
             className="max-w-[min(60vw,16rem)] cursor-pointer font-normal hover:bg-muted hover:text-muted-foreground"
           >
-            <button
-              type="button"
-              title={item.title}
-              aria-label={`Open Task ${item.title}`}
-              onClick={(event) => {
-                event.stopPropagation();
-                props.onOpenTask(item.epicId);
-              }}
+            <TooltipWrapper
+              label={item.title}
+              side="top"
+              sideOffset={undefined}
+              align={undefined}
             >
-              <span className="truncate">{item.title}</span>
-            </button>
+              <button
+                type="button"
+                aria-label={`Open Task ${item.title}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  props.onOpenTask(item.epicId);
+                }}
+              >
+                <span className="truncate">{item.title}</span>
+              </button>
+            </TooltipWrapper>
           </Badge>
           <TaskMergeRollupBadge
             rollup={props.taskRollupByEpicId.get(item.epicId) ?? null}
@@ -2777,18 +2795,24 @@ function TaskMergeRollupBadge(props: {
   if (rollup === null || rollup.status === "none") return null;
   const fullyMerged = rollup.status === "merged";
   return (
-    <span
-      className="text-ui-xs text-muted-foreground"
-      data-testid="task-merge-rollup"
-      data-rollup-status={rollup.status}
-      title={
+    <TooltipWrapper
+      label={
         fullyMerged
           ? "Every branch this Task owns has a merged PR"
           : `${rollup.merged} of ${rollup.total} owned branches merged`
       }
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      Task {taskMergeRollupLabel(rollup)}
-    </span>
+      <span
+        className="text-ui-xs text-muted-foreground"
+        data-testid="task-merge-rollup"
+        data-rollup-status={rollup.status}
+      >
+        Task {taskMergeRollupLabel(rollup)}
+      </span>
+    </TooltipWrapper>
   );
 }
 
@@ -2813,22 +2837,28 @@ function WorktreesRepoExpansionControl(props: {
 }): ReactNode {
   const label = props.allCollapsed ? "Expand all" : "Collapse all";
   return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      aria-label={label}
-      title={label}
-      data-testid="worktrees-toggle-all-repos"
-      className="text-muted-foreground hover:text-foreground"
-      onClick={props.onToggle}
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {props.allCollapsed ? (
-        <CopyPlus className="size-4" />
-      ) : (
-        <CopyMinus className="size-4" />
-      )}
-    </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label={label}
+        data-testid="worktrees-toggle-all-repos"
+        className="text-muted-foreground hover:text-foreground"
+        onClick={props.onToggle}
+      >
+        {props.allCollapsed ? (
+          <CopyPlus className="size-4" />
+        ) : (
+          <CopyMinus className="size-4" />
+        )}
+      </Button>
+    </TooltipWrapper>
   );
 }
 
@@ -2947,18 +2977,29 @@ function WorktreeRowActions(props: {
             <FileSliders className="size-3.5" aria-hidden />
             {props.scriptsLabel}
           </DropdownMenuItem>
-          <DropdownMenuItem
-            data-testid="worktree-row-delete"
-            variant="destructive"
-            aria-label={deleteLabel}
-            title={deleteLabel}
-            disabled={deleteDisabled}
-            onSelect={props.onDelete}
-            className="gap-2 px-2 py-2"
+          <TooltipWrapper
+            label={deleteLabel}
+            side="top"
+            sideOffset={undefined}
+            align={undefined}
           >
-            <Trash2 className="size-3.5" aria-hidden />
-            Delete worktree
-          </DropdownMenuItem>
+            {/* `flex w-full`, not `inline-flex`: the guard becomes the menu
+                content's layout child, and a shrink-to-fit one would narrow the
+                row to its text. */}
+            <span className="flex w-full">
+              <DropdownMenuItem
+                data-testid="worktree-row-delete"
+                variant="destructive"
+                aria-label={deleteLabel}
+                disabled={deleteDisabled}
+                onSelect={props.onDelete}
+                className="gap-2 px-2 py-2"
+              >
+                <Trash2 className="size-3.5" aria-hidden />
+                Delete worktree
+              </DropdownMenuItem>
+            </span>
+          </TooltipWrapper>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/clients/gui-app/src/components/ui/__tests__/tooltip-probe.ts
+++ b/clients/gui-app/src/components/ui/__tests__/tooltip-probe.ts
@@ -1,0 +1,55 @@
+import { fireEvent, screen } from "@testing-library/react";
+
+/**
+ * Read the hover hint attached to `trigger`.
+ *
+ * Tooltips replaced the app's native `title` attributes, and a `title` could be
+ * asserted straight off the DOM node. A Radix tooltip cannot: its content is
+ * portalled and exists only while open. This opens it the cheap way - FOCUS,
+ * which Radix honours immediately, where pointer-enter sits behind the 500ms
+ * open delay and would force every caller onto fake timers.
+ *
+ * Returns `null` when the trigger carries no tooltip, so "there is no hint
+ * here" reads the same way it did against `getAttribute("title")`.
+ */
+export function tooltipTextFor(trigger: Element): string | null {
+  // `fireEvent.focus` is enough: Testing Library dispatches the bubbling
+  // `focusin` alongside it (and `focusout` alongside `blur`), which is what
+  // React actually delegates `onFocus` from. Firing `focusIn` explicitly as
+  // well just delivers React's handler twice.
+  //
+  // TRAP: Radix's `TooltipTrigger.onFocus` early-returns while its
+  // `isPointerDownRef` is set - which stays set until a document `pointerup`.
+  // Probing straight after a bare `fireEvent.pointerDown` therefore reports
+  // "no tooltip" no matter what is wired up.
+  fireEvent.focus(trigger);
+  const tip = screen.queryByRole("tooltip");
+  const text = tip === null ? null : tip.textContent;
+  // Leave the DOM as we found it: an open tooltip is a live `role="tooltip"`
+  // node, and a later query in the same test would otherwise find this one too.
+  fireEvent.blur(trigger);
+  return text;
+}
+
+/**
+ * The hint on `el` or on the nearest ancestor that is a tooltip trigger.
+ *
+ * `TooltipWrapper` forwards to its child via `asChild`, so the trigger is
+ * usually the element a test already has a handle on - but where the wrapper
+ * guards a disabled control it sits on an intermediate span instead, and the
+ * caller should not have to know which.
+ */
+export function tooltipTextNear(el: Element): string | null {
+  const trigger = el.closest('[data-slot="tooltip-trigger"]');
+  return trigger === null ? null : tooltipTextFor(trigger);
+}
+
+/** Whether any tooltip trigger currently rendered carries `text`. */
+export function anyTooltipHasText(text: string | RegExp): boolean {
+  const triggers = document.querySelectorAll('[data-slot="tooltip-trigger"]');
+  return [...triggers].some((trigger) => {
+    const actual = tooltipTextFor(trigger);
+    if (actual === null) return false;
+    return typeof text === "string" ? actual === text : text.test(actual);
+  });
+}

--- a/clients/gui-app/src/components/ui/sidebar.tsx
+++ b/clients/gui-app/src/components/ui/sidebar.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/tooltip";
 import { PanelLeftIcon } from "lucide-react";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
@@ -267,25 +268,31 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar();
 
   return (
-    <button
-      type="button"
-      data-sidebar="rail"
-      data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
-      tabIndex={-1}
-      onClick={toggleSidebar}
-      title="Toggle Sidebar"
-      className={cn(
-        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
-        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
-        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-background",
-        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
-        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
-        className,
-      )}
-      {...props}
-    />
+    <TooltipWrapper
+      label="Toggle Sidebar"
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
+    >
+      <button
+        type="button"
+        data-sidebar="rail"
+        data-slot="sidebar-rail"
+        aria-label="Toggle Sidebar"
+        tabIndex={-1}
+        onClick={toggleSidebar}
+        className={cn(
+          "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+          "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+          "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+          "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-background",
+          "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+          "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+          className,
+        )}
+        {...props}
+      />
+    </TooltipWrapper>
   );
 }
 

--- a/clients/gui-app/src/components/ui/tooltip-wrapper.tsx
+++ b/clients/gui-app/src/components/ui/tooltip-wrapper.tsx
@@ -38,7 +38,16 @@ export function TooltipWrapper(props: TooltipWrapperProps) {
     onOpenChange,
     ...rest
   } = props;
-  if (label === null || (typeof label === "string" && label.length === 0)) {
+  // `undefined` degrades exactly like `null`. It used to fall through and
+  // render an empty tooltip box, which is never what a caller means - and the
+  // shape that produces it (`someReason ?? undefined`, left over from the
+  // native `title` attribute this component replaces) is the single most
+  // common way to call it.
+  if (
+    label === null ||
+    label === undefined ||
+    (typeof label === "string" && label.length === 0)
+  ) {
     return <Slot.Root {...rest}>{children}</Slot.Root>;
   }
   return (

--- a/clients/gui-app/src/components/ui/tooltip.tsx
+++ b/clients/gui-app/src/components/ui/tooltip.tsx
@@ -5,24 +5,49 @@ import { Tooltip as TooltipPrimitive } from "radix-ui";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Whether a `TooltipProvider` is already above us. Radix owns the provider's
+ * real state but exposes no way to ask "is one mounted?", and `Tooltip` THROWS
+ * without one - so presence is tracked alongside it here.
+ */
+const TooltipProviderPresence = React.createContext(false);
+
 function TooltipProvider({
   delayDuration,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   const effectiveDelay = delayDuration ?? 500;
   return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delayDuration={effectiveDelay}
-      {...props}
-    />
+    <TooltipProviderPresence.Provider value>
+      <TooltipPrimitive.Provider
+        data-slot="tooltip-provider"
+        delayDuration={effectiveDelay}
+        {...props}
+      />
+    </TooltipProviderPresence.Provider>
   );
 }
 
+/**
+ * Self-provides ONLY when nothing above it does. A missing provider is a
+ * crash, not a degradation - and with tooltips now the app's single hover-hint
+ * mechanism (they replaced ~118 native `title` attributes), any component
+ * rendered outside the app shell would take one down. That includes every
+ * isolated component test, which is where this actually bites.
+ *
+ * The nesting is deliberate rather than unconditional: `TooltipProvider` also
+ * carries `delayDuration`, and several surfaces tune it for their own subtree
+ * (the sidebar rail's 150ms, the notifications popover's 300ms). Always
+ * wrapping would silently reset those to the default and break the shared
+ * skip-delay grouping that makes a second tooltip appear instantly.
+ */
 function Tooltip({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+  const provided = React.useContext(TooltipProviderPresence);
+  const root = <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+  if (provided) return root;
+  return <TooltipProvider>{root}</TooltipProvider>;
 }
 
 function TooltipTrigger({

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx
@@ -23,6 +23,8 @@ vi.mock("@/components/worktree/worktree-pr-metadata", () => ({
 vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
   useHostClientForHostId: () => null,
 }));
+const refreshSpy = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
 vi.mock("@/hooks/worktree/use-worktree-owner-metadata-query", () => ({
   useWorktreeOwnerMetadata: () => ({
     binding: null,
@@ -32,7 +34,7 @@ vi.mock("@/hooks/worktree/use-worktree-owner-metadata-query", () => ({
     error: null,
     checkedAt: null,
     isRefreshing: false,
-    refresh: () => Promise.resolve(),
+    refresh: refreshSpy,
   }),
 }));
 
@@ -201,9 +203,9 @@ describe("WorktreeOwnerMetadataTooltip hover gate", () => {
     settleOpenDelay();
 
     expect(cardIsOpen()).toBe(false);
-    // No throw and no refresh surface: the listener went with the card.
+    refreshSpy.mockClear();
     fireEvent.keyDown(window, { key: "r" });
-    expect(screen.queryByTestId("owner-workspace-refresh")).toBeNull();
+    expect(refreshSpy).not.toHaveBeenCalled();
   });
 
   it("keeps the row's own click handler working", () => {

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx
@@ -1,0 +1,219 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WorktreeOwnerMetadataTooltip } from "@/components/worktree/worktree-owner-metadata";
+
+// The card's three content blocks are stubbed: each one reaches for the epic
+// store, the harness catalog and two host queries, none of which this file is
+// about. Stubbed as `span`s because `HoverCardContent` renders its children
+// inside one.
+vi.mock("@/components/worktree/worktree-owner-settings-header", () => ({
+  WorktreeOwnerSettingsHeader: () => <span data-testid="settings-header" />,
+}));
+vi.mock("@/components/worktree/worktree-pr-metadata", () => ({
+  OwnerWorkspaceMetadataContent: () => (
+    <span data-testid="workspace-metadata" />
+  ),
+}));
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => null,
+}));
+vi.mock("@/hooks/worktree/use-worktree-owner-metadata-query", () => ({
+  useWorktreeOwnerMetadata: () => ({
+    binding: null,
+    worktrees: [],
+    workspaces: [],
+    isPending: false,
+    error: null,
+    checkedAt: null,
+    isRefreshing: false,
+    refresh: () => Promise.resolve(),
+  }),
+}));
+
+// `hover-card.tsx`'s own default, and the width of the window this whole gate
+// exists to cover.
+const OPEN_DELAY_MS = 500;
+
+function cardIsOpen(): boolean {
+  return document.querySelector('[data-slot="hover-card-content"]') !== null;
+}
+
+/** Radix's trigger opens on a TIMER, and skips touch pointers outright. */
+function hoverIn(trigger: HTMLElement): void {
+  fireEvent.pointerEnter(trigger, { pointerType: "mouse" });
+}
+
+function settleOpenDelay(): void {
+  act(() => {
+    vi.advanceTimersByTime(OPEN_DELAY_MS * 2);
+  });
+}
+
+function renderTooltip(onClick: (() => void) | undefined): HTMLElement {
+  render(
+    <WorktreeOwnerMetadataTooltip
+      trigger={
+        <button type="button" data-testid="row" onClick={onClick}>
+          Chat row
+        </button>
+      }
+      hostId="host-1"
+      epicId="epic-1"
+      ownerId="owner-1"
+      ownerKind="chat"
+    />,
+  );
+  return screen.getByTestId("row");
+}
+
+describe("WorktreeOwnerMetadataTooltip hover gate", () => {
+  beforeEach(() => {
+    // `shouldAdvanceTime` keeps Testing Library's own async plumbing alive
+    // while the Radix open/close timers stay under our control.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("opens on a settled hover", () => {
+    // Non-regression floor: the gate must not cost the card its actual job.
+    const trigger = renderTooltip(undefined);
+
+    hoverIn(trigger);
+    settleOpenDelay();
+
+    expect(cardIsOpen()).toBe(true);
+  });
+
+  it("swallows an open that lands after the press (the reported race)", () => {
+    // THE BUG. Radix dismisses an open card on any outside pointerdown - but
+    // that dismissal lives on the content's `DismissableLayer`, which does not
+    // exist yet during the 500ms open delay. A click inside that window is
+    // therefore seen by nothing, and the card mounts afterwards over the tab
+    // the click just opened, anchored to a row that has moved out from under
+    // the pointer - so no pointer-leave is coming to close it either.
+    const trigger = renderTooltip(undefined);
+
+    hoverIn(trigger);
+    fireEvent.pointerDown(trigger);
+    settleOpenDelay();
+
+    expect(cardIsOpen()).toBe(false);
+  });
+
+  it("stays shut after click-then-leave, despite Radix's orphaned open timer", () => {
+    // THE REPORTED REGRESSION, and the reason the re-arm hangs off
+    // pointer-ENTER rather than pointer-leave.
+    //
+    // Radix's `handleOpen` assigns `openTimerRef.current` WITHOUT clearing the
+    // timer already there, and it runs on both `pointerenter` and `focus`. A
+    // real click fires pointerdown and then focuses the row - so two open
+    // timers are pending and only the focus one is tracked. Pointer-leave's
+    // `handleClose` cancels that one; the hover one survives and fires ~500ms
+    // later, with the pointer long gone and no pointer-leave left to close what
+    // it opens.
+    const trigger = renderTooltip(undefined);
+
+    hoverIn(trigger);
+    fireEvent.pointerDown(trigger);
+    // The focus a click delivers - this is what orphans the first timer.
+    // ONE dispatch: Testing Library already pairs `focusin` with `focus`, and
+    // firing both would manufacture extra timers rather than reproduce a click.
+    fireEvent.focus(trigger);
+    fireEvent.pointerLeave(trigger, { pointerType: "mouse" });
+    settleOpenDelay();
+
+    expect(cardIsOpen()).toBe(false);
+  });
+
+  it("does not resurrect the swallowed card when the pointer leaves", () => {
+    // The reason the late open is swallowed rather than merely masked: a
+    // recorded `hoverOpen` would still be armed, and lifting the press gate on
+    // pointer-leave is exactly when it would spring open.
+    const trigger = renderTooltip(undefined);
+    hoverIn(trigger);
+    fireEvent.pointerDown(trigger);
+    settleOpenDelay();
+
+    fireEvent.pointerLeave(trigger, { pointerType: "mouse" });
+    settleOpenDelay();
+
+    expect(cardIsOpen()).toBe(false);
+  });
+
+  it("re-arms on the next pointer-enter, not on the leave", () => {
+    // The gate is held until a FRESH hover starts, so re-entering must release
+    // it - otherwise one click would kill the card for that row until it
+    // remounted.
+    const trigger = renderTooltip(undefined);
+    hoverIn(trigger);
+    fireEvent.pointerDown(trigger);
+    settleOpenDelay();
+    fireEvent.pointerLeave(trigger, { pointerType: "mouse" });
+
+    hoverIn(trigger);
+    settleOpenDelay();
+
+    expect(cardIsOpen()).toBe(true);
+  });
+
+  it("survives the pointer travelling from the row into the card", () => {
+    // The one thing this card must not lose: its Refresh button lives inside
+    // the content, so the pointer has to be able to cross the 4px gap. This is
+    // why the gate has no `onPointerLeave` that clears `hoverOpen` - Radix's
+    // own `closeDelay` owns the travel window, and a leave handler that closed
+    // eagerly would make the button unreachable.
+    const trigger = renderTooltip(undefined);
+    hoverIn(trigger);
+    settleOpenDelay();
+    expect(cardIsOpen()).toBe(true);
+
+    fireEvent.pointerLeave(trigger, { pointerType: "mouse" });
+    const content = document.querySelector('[data-slot="hover-card-content"]');
+    if (content === null) throw new Error("expected the card to be mounted");
+    fireEvent.pointerEnter(content, { pointerType: "mouse" });
+    settleOpenDelay();
+
+    expect(cardIsOpen()).toBe(true);
+    expect(screen.getByTestId("owner-workspace-refresh")).toBeTruthy();
+  });
+
+  it("tears down the window R listener when a press closes the card", () => {
+    // `R` is bound at the WINDOW while the card is open, so if the press gate
+    // closed the card visually but left `open` true, a stray "r" typed into the
+    // composer would still fire a refresh.
+    const trigger = renderTooltip(undefined);
+    hoverIn(trigger);
+    settleOpenDelay();
+    expect(cardIsOpen()).toBe(true);
+
+    fireEvent.pointerDown(trigger);
+    settleOpenDelay();
+
+    expect(cardIsOpen()).toBe(false);
+    // No throw and no refresh surface: the listener went with the card.
+    fireEvent.keyDown(window, { key: "r" });
+    expect(screen.queryByTestId("owner-workspace-refresh")).toBeNull();
+  });
+
+  it("keeps the row's own click handler working", () => {
+    // The gate hangs off a `Slot.Root` nested inside `HoverCardTrigger asChild`,
+    // which COMPOSES with the row's handlers. If it ever replaced them instead,
+    // clicking a sidebar row would silently stop opening the chat.
+    const onClick = vi.fn();
+    const trigger = renderTooltip(onClick);
+
+    fireEvent.click(trigger);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
@@ -187,7 +187,7 @@ describe("WorktreeOwnerSettingsHeader", () => {
     });
 
     expect(screen.getByText("Full access")).toBeTruthy();
-    expect(permissionIconClass()).not.toContain("lucide-lock ");
+    expect(permissionIconClass().split(/\s+/)).not.toContain("lucide-lock");
     expect(permissionIconClass()).toMatch(/open|unlock/);
   });
 
@@ -203,10 +203,8 @@ describe("WorktreeOwnerSettingsHeader", () => {
     expect(screen.queryByText("Work account")).toBeNull();
     // ...but it is still announced, since `AccentDot` itself is aria-hidden.
     expect(
-      screen
-        .getByTestId("owner-settings-harness-mark")
-        .getAttribute("aria-label"),
-    ).toBe("Claude Code, Work account");
+      screen.getByRole("img", { name: "Claude Code, Work account" }),
+    ).toBeTruthy();
     expect(accentDotText()).toBe("W");
   });
 
@@ -218,10 +216,8 @@ describe("WorktreeOwnerSettingsHeader", () => {
     });
 
     expect(
-      screen
-        .getByTestId("owner-settings-harness-mark")
-        .getAttribute("aria-label"),
-    ).toBe("Claude Code, Terminal account");
+      screen.getByRole("img", { name: "Claude Code, Terminal account" }),
+    ).toBeTruthy();
   });
 
   it("omits the dot when the provider has a single profile", () => {
@@ -231,8 +227,7 @@ describe("WorktreeOwnerSettingsHeader", () => {
       profiles: [profile("profile-1", "managed", "Work account")],
     });
 
-    const mark = screen.getByTestId("owner-settings-harness-mark");
-    expect(mark.getAttribute("aria-label")).toBe("Claude Code");
+    expect(screen.getByRole("img", { name: "Claude Code" })).toBeTruthy();
     expect(accentDotText()).toBeNull();
   });
 });

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-header.test.tsx
@@ -1,0 +1,238 @@
+import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe";
+import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WorktreeOwnerSettingsHeader } from "@/components/worktree/worktree-owner-settings-header";
+import type { PermissionMode } from "@/components/home/data/landing-options";
+
+const chatSettings = vi.hoisted(() => ({
+  current: null as ChatRunSettings | null,
+}));
+const wireProfiles = vi.hoisted(() => ({
+  current: [] as ReadonlyArray<ProviderProfile>,
+}));
+
+vi.mock("@/lib/epic-selectors", () => ({
+  useChatById: () => ({ settings: chatSettings.current, updatedAt: 1_700_000 }),
+}));
+vi.mock("@/hooks/use-epic-store", () => ({
+  useEpicStore: (select: (state: unknown) => unknown) =>
+    select({ tuiAgents: { byId: {} } }),
+}));
+vi.mock("@/hooks/host/use-host-client-for-host-id", () => ({
+  useHostClientForHostId: () => null,
+}));
+vi.mock("@/hooks/harnesses/use-gui-harness-catalog", () => ({
+  useGuiHarnessCatalog: () => ({
+    harnesses: [
+      {
+        id: "claude",
+        label: "Claude Code",
+        models: [
+          {
+            harnessId: "claude",
+            slug: "sonnet-4.5",
+            label: "Claude Sonnet 4.5",
+            supportedReasoningEfforts: [
+              { id: "high", label: "High", description: null },
+            ],
+            metadata: {},
+          },
+        ],
+      },
+    ],
+  }),
+}));
+vi.mock("@/hooks/providers/use-providers-list-query", () => ({
+  useProvidersListForClient: () => ({
+    // `claude-code` is the WIRE id for the `claude` harness; the header has to
+    // map across that boundary to find these at all.
+    data: {
+      providers: [
+        { providerId: "claude-code", profiles: wireProfiles.current },
+      ],
+    },
+  }),
+}));
+
+function profile(
+  profileId: string,
+  kind: "ambient" | "managed",
+  label: string,
+): ProviderProfile {
+  return {
+    profileId,
+    kind,
+    authType: "oauth",
+    label,
+    auth: {
+      status: "authenticated",
+      badgeText: null,
+      label: null,
+      detail: null,
+    },
+    identity: null,
+    usageUpdatedAt: null,
+    rateLimitStatus: "unknown",
+    rateLimitLimitedScopes: null,
+    duplicateOfProfileId: null,
+    accentColor: null,
+    ambientDriftNotice: null,
+  };
+}
+
+function renderHeader(args: {
+  readonly permissionMode: PermissionMode;
+  readonly profileId: string | null;
+  readonly profiles: ReadonlyArray<ProviderProfile>;
+}): void {
+  chatSettings.current = {
+    harnessId: "claude",
+    model: "sonnet-4.5",
+    permissionMode: args.permissionMode,
+    reasoningEffort: "high",
+    serviceTier: null,
+    agentMode: "regular",
+    profileId: args.profileId,
+  };
+  wireProfiles.current = args.profiles;
+  render(
+    <WorktreeOwnerSettingsHeader
+      ownerId="owner-1"
+      hostId="host-1"
+      ownerKind="chat"
+    />,
+  );
+}
+
+/** Identifies which lucide glyph rendered, without pinning its exact name. */
+function permissionIconClass(): string {
+  const svg = document.querySelector(
+    '[data-testid="owner-settings-permissions"] svg',
+  );
+  return svg?.getAttribute("class") ?? "";
+}
+
+/**
+ * The `AccentDot` itself, found by its inline accent color - the wrapper's
+ * `textContent` is unusable here because the harness brand SVG carries its own
+ * `<title>`.
+ */
+function accentDotText(): string | null {
+  const mark = screen.getByTestId("owner-settings-harness-mark");
+  const dot = mark.querySelector('span[style*="background-color"]');
+  return dot === null ? null : dot.textContent;
+}
+
+const TWO_PROFILES = [
+  profile("ambient", "ambient", "Terminal account"),
+  profile("profile-1", "managed", "Work account"),
+];
+
+describe("WorktreeOwnerSettingsHeader", () => {
+  afterEach(() => {
+    cleanup();
+    chatSettings.current = null;
+    wireProfiles.current = [];
+  });
+
+  it("renders a distinct icon for each permission mode", () => {
+    // The regression this guards: the row hardcoded ONE padlock for all three
+    // modes. Any future hardcoding collapses these three classes into one.
+    const seen = new Set<string>();
+    for (const mode of [
+      "supervised",
+      "auto_accept_edits",
+      "full_access",
+    ] as const) {
+      renderHeader({ permissionMode: mode, profileId: null, profiles: [] });
+      seen.add(permissionIconClass());
+      cleanup();
+    }
+
+    expect(seen.size).toBe(3);
+  });
+
+  it("keeps the settings line unwrapped so the card widens instead", () => {
+    // jsdom does no layout, so this asserts the CONTRACT rather than a measured
+    // width: the row must not wrap, and the model must be the segment that
+    // gives way when the card hits its ceiling. Re-adding `flex-wrap` here is
+    // exactly the regression - it silently restores the two-line header the
+    // widening behaviour replaced.
+    renderHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+    });
+
+    const row = screen.getByTestId("owner-settings-header").className;
+    expect(row).toContain("flex-nowrap");
+    expect(row).not.toContain("flex-wrap");
+    expect(screen.getByTestId("owner-settings-model").className).toContain(
+      "truncate",
+    );
+    // Short, bounded values hold their ground rather than competing with it.
+    expect(
+      screen.getByTestId("owner-settings-permissions").className,
+    ).toContain("shrink-0");
+  });
+
+  it("does not render Full access behind a padlock", () => {
+    // The specific inversion reported: the LEAST restricted mode was the one
+    // drawn as locked shut.
+    renderHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: [],
+    });
+
+    expect(screen.getByText("Full access")).toBeTruthy();
+    expect(permissionIconClass()).not.toContain("lucide-lock ");
+    expect(permissionIconClass()).toMatch(/open|unlock/);
+  });
+
+  it("shows the profile as a corner dot, not as trailing text", () => {
+    renderHeader({
+      permissionMode: "full_access",
+      profileId: "profile-1",
+      profiles: TWO_PROFILES,
+    });
+
+    // The name is gone from the line - that is the whole point, it was what
+    // wrapped the row in two.
+    expect(screen.queryByText("Work account")).toBeNull();
+    // ...but it is still announced, since `AccentDot` itself is aria-hidden.
+    expect(
+      screen
+        .getByTestId("owner-settings-harness-mark")
+        .getAttribute("aria-label"),
+    ).toBe("Claude Code, Work account");
+    expect(accentDotText()).toBe("W");
+  });
+
+  it("badges the ambient profile the chat actually runs on", () => {
+    renderHeader({
+      permissionMode: "full_access",
+      profileId: null,
+      profiles: TWO_PROFILES,
+    });
+
+    expect(
+      screen
+        .getByTestId("owner-settings-harness-mark")
+        .getAttribute("aria-label"),
+    ).toBe("Claude Code, Terminal account");
+  });
+
+  it("omits the dot when the provider has a single profile", () => {
+    renderHeader({
+      permissionMode: "full_access",
+      profileId: "profile-1",
+      profiles: [profile("profile-1", "managed", "Work account")],
+    });
+
+    const mark = screen.getByTestId("owner-settings-harness-mark");
+    expect(mark.getAttribute("aria-label")).toBe("Claude Code");
+    expect(accentDotText()).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-model.test.ts
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-settings-model.test.ts
@@ -105,7 +105,10 @@ describe("deriveOwnerSettingsHeader", () => {
           serviceTier: "fast",
           profileId,
         },
-        profiles: [providerProfile(profileId, "managed", "Work account")],
+        profiles: [
+          providerProfile("ambient", "ambient", "Terminal account"),
+          providerProfile(profileId, "managed", "Work account"),
+        ],
       }),
     );
 
@@ -115,9 +118,59 @@ describe("deriveOwnerSettingsHeader", () => {
       modelLabel: "Claude Sonnet 4.5",
       reasoningLabel: "High",
       fastMode: true,
-      profileLabel: "Work account",
-      permissionLabel: "Supervised",
+      profileAccentDot: {
+        profileId,
+        accentColor: null,
+        label: "Work account",
+      },
+      permissionMode: "supervised",
     });
+  });
+
+  it.each([
+    { permissionMode: "supervised" as const },
+    { permissionMode: "auto_accept_edits" as const },
+    { permissionMode: "full_access" as const },
+  ])("passes permissionMode %j through verbatim", ({ permissionMode }) => {
+    // The mode, not a label: the header resolves BOTH its label and its icon
+    // from `findPermissionOption`, which is what stops "Full access" from
+    // rendering behind a closed padlock again.
+    const view = deriveOwnerSettingsHeader(
+      baseInput({
+        chatSettings: { ...BASE_CHAT_SETTINGS, permissionMode },
+      }),
+    );
+
+    expect(view?.permissionMode).toBe(permissionMode);
+  });
+
+  it("badges the ambient profile when the provider has two or more", () => {
+    // `profileId: null` is AMBIENT, not "no profile" - it resolves against the
+    // ambient row's `profileCommitId()` of null and earns its own mark.
+    const view = deriveOwnerSettingsHeader(
+      baseInput({
+        chatSettings: { ...BASE_CHAT_SETTINGS, profileId: null },
+        profiles: [
+          providerProfile("ambient", "ambient", "Terminal account"),
+          providerProfile("profile-1", "managed", "Work account"),
+        ],
+      }),
+    );
+
+    expect(view?.profileAccentDot?.label).toBe("Terminal account");
+  });
+
+  it("omits the accent dot when the provider has a single profile", () => {
+    // Progressive disclosure: a dot that is always there distinguishes nothing.
+    const profileId = "profile-1";
+    const view = deriveOwnerSettingsHeader(
+      baseInput({
+        chatSettings: { ...BASE_CHAT_SETTINGS, profileId },
+        profiles: [providerProfile(profileId, "managed", "Work account")],
+      }),
+    );
+
+    expect(view?.profileAccentDot).toBeNull();
   });
 
   it("falls back to raw slugs when the catalog is empty", () => {
@@ -129,29 +182,31 @@ describe("deriveOwnerSettingsHeader", () => {
     expect(view?.reasoningLabel).toBe(BASE_CHAT_SETTINGS.reasoningEffort);
   });
 
-  it("omits the profile row when the profile id isn't in the profiles list", () => {
-    // Unresolved (cold provider cache / removed profile): omitted, same as the
-    // ambient `profileId: null` case below — a raw profileId is opaque and
-    // unlike harness/model slugs isn't readable on its own.
+  it("omits the accent dot when the profile id isn't in the profiles list", () => {
+    // Unresolved (cold provider cache / removed profile): omitted rather than
+    // guessing a color from an opaque host-generated id.
     const view = deriveOwnerSettingsHeader(
       baseInput({
         chatSettings: { ...BASE_CHAT_SETTINGS, profileId: "unknown-profile" },
-        profiles: [providerProfile("other-profile", "managed", "Other")],
+        profiles: [
+          providerProfile("other-profile", "managed", "Other"),
+          providerProfile("third-profile", "managed", "Third"),
+        ],
       }),
     );
 
-    expect(view?.profileLabel).toBeNull();
+    expect(view?.profileAccentDot).toBeNull();
   });
 
-  it("omits the profile row when profileId is null", () => {
-    // Ambient: there is no profile to resolve in the first place.
+  it("omits the accent dot when the provider cache is cold", () => {
     const view = deriveOwnerSettingsHeader(
       baseInput({
         chatSettings: { ...BASE_CHAT_SETTINGS, profileId: null },
+        profiles: [],
       }),
     );
 
-    expect(view?.profileLabel).toBeNull();
+    expect(view?.profileAccentDot).toBeNull();
   });
 
   it.each([{ serviceTier: null }, { serviceTier: "" }])(
@@ -196,8 +251,8 @@ describe("deriveOwnerSettingsHeader", () => {
       modelLabel: "Claude Sonnet 4.5",
       reasoningLabel: null,
       fastMode: false,
-      profileLabel: null,
-      permissionLabel: null,
+      profileAccentDot: null,
+      permissionMode: null,
     });
   });
 

--- a/clients/gui-app/src/components/worktree/worktree-owner-metadata.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-metadata.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactElement, type ReactNode } from "react";
+import { Slot } from "radix-ui";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { Button } from "@/components/ui/button";
@@ -16,6 +17,41 @@ import { useCompactRelativeTime } from "@/lib/relative-time";
 // but still a leash, so a wedged host can't strand the button disabled.
 const OWNER_METADATA_REFRESH_TIMEOUT_MS = 20_000;
 
+/**
+ * Hover state gated on a press, the same shape the composer's folder picker
+ * uses (`workspace-folder-summary-control.tsx`) - ONE state object rather than
+ * two `useState`s, so the press and the delayed hover-open cannot interleave
+ * into a torn combination.
+ *
+ * `pressed` is what a Tooltip would give for free and a HoverCard does not: a
+ * HoverCard is purely pointer-driven and has no notion of the trigger being
+ * activated, so clicking a row leaves the card floating over the tab that the
+ * click just opened.
+ */
+interface OwnerMetadataHoverState {
+  /**
+   * The trigger was pressed, and no FRESH hover has started since.
+   *
+   * Cleared on pointer-ENTER, never on pointer-leave. Leaving looks like the
+   * natural moment to re-arm, and it is wrong: Radix's `handleOpen` overwrites
+   * `openTimerRef` without clearing the timer already in it, and it runs on
+   * both `pointerenter` and `focus`. A click therefore leaves TWO open timers
+   * pending - the hover's and the focus's - with only the second tracked, so
+   * the `handleClose` that pointer-leave triggers cancels only that one. The
+   * orphan then fires ~500ms after the pointer is gone. Re-arming on leave
+   * un-gates exactly in time to let it through, and the card opens anchored to
+   * a row the pointer has already left, with no pointer-leave left to close it.
+   */
+  readonly pressed: boolean;
+  /** Radix's own hover intent, recorded even while `pressed` suppresses it. */
+  readonly hoverOpen: boolean;
+}
+
+const CLOSED_HOVER_STATE: OwnerMetadataHoverState = {
+  pressed: false,
+  hoverOpen: false,
+};
+
 export function WorktreeOwnerMetadataTooltip(props: {
   readonly trigger: ReactElement;
   readonly hostId: string;
@@ -23,7 +59,9 @@ export function WorktreeOwnerMetadataTooltip(props: {
   readonly ownerId: string;
   readonly ownerKind: WorktreeBindingOwnerKind;
 }): ReactNode {
-  const [open, setOpen] = useState(false);
+  const [hoverState, setHoverState] =
+    useState<OwnerMetadataHoverState>(CLOSED_HOVER_STATE);
+  const open = !hoverState.pressed && hoverState.hoverOpen;
   const client = useHostClientForHostId(props.hostId);
   const metadata = useWorktreeOwnerMetadata({
     client,
@@ -77,8 +115,16 @@ export function WorktreeOwnerMetadataTooltip(props: {
   return (
     <HoverPreviewCard
       content={
+        // Sized by its FIRST ROW, between a floor and a ceiling. The settings
+        // line is a single unbreakable unit - model, reasoning, permission mode
+        // - and wrapping it onto a second line was worse than a wider card: it
+        // pushed the permission mode, the one value here with a safety
+        // consequence, below the fold of the eye. So the card grows to fit it
+        // instead, from the old fixed 24rem (now the floor, so a short line
+        // still gets a card that reads as a card) up to a viewport-capped
+        // ceiling, past which the header ellipsizes rather than growing further.
         <span
-          className="block w-[min(92vw,24rem)]"
+          className="block w-fit min-w-[min(92vw,24rem)] max-w-[min(92vw,36rem)]"
           data-testid={`chat-navigator-worktree-hover-${props.ownerId}`}
         >
           <WorktreeOwnerSettingsHeader
@@ -86,13 +132,22 @@ export function WorktreeOwnerMetadataTooltip(props: {
             hostId={props.hostId}
             ownerKind={props.ownerKind}
           />
-          <OwnerWorkspaceMetadataContent
-            binding={metadata.binding}
-            worktrees={metadata.worktrees}
-            workspaces={metadata.workspaces}
-            pending={metadata.isPending}
-            error={metadata.error !== null}
-          />
+          {/* `w-0 min-w-full` so the folder block takes the width the header
+              settled on WITHOUT voting on it. Its run path is `break-all`, but
+              break points do not shrink an element's max-content contribution -
+              a 90-character worktree path would peg every card at the ceiling
+              regardless of how short its settings line was. Width 0 removes it
+              from that intrinsic calculation; the percentage min-width then
+              stretches it back to the resolved width. */}
+          <span className="block w-0 min-w-full">
+            <OwnerWorkspaceMetadataContent
+              binding={metadata.binding}
+              worktrees={metadata.worktrees}
+              workspaces={metadata.workspaces}
+              pending={metadata.isPending}
+              error={metadata.error !== null}
+            />
+          </span>
           <OwnerMetadataRefreshFooter
             checkedAt={metadata.checkedAt}
             refreshing={refresh.refreshing}
@@ -105,9 +160,53 @@ export function WorktreeOwnerMetadataTooltip(props: {
       sideOffset={4}
       align="start"
       open={open}
-      onOpenChange={setOpen}
+      // A late open is SWALLOWED rather than recorded while pressed: the
+      // 500ms open delay routinely fires AFTER the click that started during
+      // it, and recording it would leave `hoverOpen` armed to re-open the card
+      // the instant the press gate lifts.
+      onOpenChange={(next) => {
+        setHoverState((current) => {
+          if (next && current.pressed) return current;
+          return { ...current, hoverOpen: next };
+        });
+      }}
     >
-      {props.trigger}
+      {/* The gate hangs off the TRIGGER, not `onOpenChange`. Radix only reports
+          a transition its controlled `open` does not already match, so once
+          this holds `open` at false, the close that would otherwise re-arm it
+          is never announced - the trigger's own pointer events are the only
+          signal left.
+
+          `Slot.Root` nested inside `HoverCardTrigger asChild` composes with the
+          row button's own handlers instead of replacing them, the same way the
+          folder picker nests `PopoverTrigger` inside its hover card. */}
+      <Slot.Root
+        // The re-arm, and the ONLY one - see `pressed`. A new pointer-enter is
+        // the one signal that means "a fresh hover is starting", which is
+        // exactly when suppressing the next open would be wrong. Deliberately
+        // leaves `hoverOpen` alone: if the card is already open and the pointer
+        // travels back from the content onto the row, this must not re-trigger
+        // anything.
+        onPointerEnter={() => {
+          setHoverState((current) =>
+            current.pressed ? { ...current, pressed: false } : current,
+          );
+        }}
+        // Covers left, right and middle press alike, so the row's click, its
+        // context menu and a middle-click open all dismiss the card.
+        //
+        // No `onPointerLeave` counterpart: leaving must NOT clear `hoverOpen`
+        // either, or the card would close as the pointer crosses the 4px gap
+        // into it - and that card holds a Refresh button. Radix's own
+        // `closeDelay` already owns the travel window.
+        onPointerDown={() => setHoverState({ pressed: true, hoverOpen: false })}
+        // Keyboard activation (Enter/Space on a focused row) fires no
+        // pointerdown at all, and Radix opens on focus - so without this the
+        // card could settle over the tab the keypress just opened.
+        onClick={() => setHoverState({ pressed: true, hoverOpen: false })}
+      >
+        {props.trigger}
+      </Slot.Root>
     </HoverPreviewCard>
   );
 }

--- a/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-settings-header.tsx
@@ -1,8 +1,17 @@
 import { Fragment, type ReactNode } from "react";
-import { Lock } from "lucide-react";
-import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
+import type {
+  ProviderProfile,
+  ProviderId as WireProviderId,
+} from "@traycer/protocol/host/provider-schemas";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
+import { guiHarnessIdToProviderId } from "@/lib/provider-ordering";
 import { HarnessIcon } from "@/components/home/pickers/harness-icon";
+import { AccentDot } from "@/components/providers/accent-dot";
+import {
+  findPermissionOption,
+  type PermissionMode,
+  type ProviderId,
+} from "@/components/home/data/landing-options";
 import { useCompactRelativeTime } from "@/lib/relative-time";
 import {
   deriveOwnerSettingsHeader,
@@ -66,8 +75,11 @@ export function WorktreeOwnerSettingsHeader(props: {
     subscribed: hasSubject,
   });
 
-  const profileId = chatSettings?.profileId ?? null;
-  const profileNeeded = profileId !== null;
+  // Every CHAT needs the provider list, not just profile-bearing ones: a null
+  // `profileId` is the AMBIENT profile and now earns its own accent dot, so a
+  // subscription gated on `profileId !== null` left ambient chats unable to
+  // re-render when the list landed in cache after mount.
+  const profileNeeded = isChat;
   const hostClient = useHostClientForHostId(props.hostId);
   // Profile label is a PURE CACHE READ: `enabled: false` never fires a request,
   // so the profile row costs no RPC of its own. It resolves only when the chat
@@ -84,7 +96,10 @@ export function WorktreeOwnerSettingsHeader(props: {
     tuiHarnessId: tuiAgent?.harnessId ?? null,
     tuiModel: tuiAgent?.model ?? null,
     harnesses: catalog.harnesses,
-    profiles: listedProfiles(providersList.data?.providers ?? null),
+    profiles: harnessProfiles(
+      providersList.data?.providers ?? null,
+      chatSettings?.harnessId ?? null,
+    ),
   });
   if (view === null) return null;
   return (
@@ -95,14 +110,32 @@ export function WorktreeOwnerSettingsHeader(props: {
   );
 }
 
-/** Flattens every provider's profiles, or the shared empty list when cold. */
-function listedProfiles(
+/**
+ * The chat harness's OWN profiles, or the shared empty list when the provider
+ * cache is cold. Scoped rather than flattened across every provider: the accent
+ * dot is gated on "this provider has 2+ accounts", and a flattened list crosses
+ * that gate as soon as ANY two providers each have one - which would badge a
+ * single-account provider on the strength of an unrelated one.
+ *
+ * The two id spaces are NOT interchangeable despite both being spelled
+ * `ProviderId`: the GUI harness id is `claude` where the wire provider id is
+ * `claude-code`, so this goes through `guiHarnessIdToProviderId` rather than
+ * comparing the two directly (which type-checks nowhere and would silently
+ * match zero providers if it did).
+ */
+function harnessProfiles(
   providers: ReadonlyArray<{
+    readonly providerId: WireProviderId;
     readonly profiles: ReadonlyArray<ProviderProfile>;
   }> | null,
+  harnessId: ProviderId | null,
 ): ReadonlyArray<ProviderProfile> {
-  if (providers === null) return EMPTY_PROFILES;
-  return providers.flatMap((provider) => provider.profiles);
+  if (providers === null || harnessId === null) return EMPTY_PROFILES;
+  const providerId = guiHarnessIdToProviderId(harnessId);
+  if (providerId === null) return EMPTY_PROFILES;
+  const provider =
+    providers.find((candidate) => candidate.providerId === providerId) ?? null;
+  return provider === null ? EMPTY_PROFILES : provider.profiles;
 }
 
 /** Both record kinds carry `updatedAt`; read whichever this owner is. */
@@ -118,15 +151,28 @@ function ownerUpdatedAt(
 
 /**
  * The run settings as ONE dense line: provider mark, model, reasoning, then the
- * permission mode behind a lock. Field labels ("Provider", "Model", …) are
- * deliberately gone - each value is self-identifying, and the label column was
- * costing four stacked rows to say what one line says. The harness NAME is
+ * permission mode behind its own icon. Field labels ("Provider", "Model", …)
+ * are deliberately gone - each value is self-identifying, and the label column
+ * was costing four stacked rows to say what one line says. The harness NAME is
  * dropped too: its brand mark already identifies it, and repeating the word
  * next to the icon was the same redundancy in miniature.
  *
- * `flex-wrap` rather than a hard single line: a long model + profile pair on a
- * narrow card wraps instead of overflowing or forcing a truncation that would
- * hide the permission mode - the one value here with a safety consequence.
+ * The PROFILE is dropped from the line for the same reason, but one step
+ * further: it rides the harness mark as a corner dot instead of a trailing word
+ * (`OwnerSettingsHarnessMark`). As text it was the one unbounded value here -
+ * a user-chosen account name - and a long one wrapped the row in two, pushing
+ * the permission mode onto a second line.
+ *
+ * ONE LINE, always. This row does not wrap - the card grows to fit it instead
+ * (see the container in `worktree-owner-metadata.tsx`, which sizes itself from
+ * this row between a 24rem floor and a viewport-capped ceiling). Wrapping was
+ * the previous behaviour and it read badly: the line broke between two values
+ * that belong together and pushed the permission mode - the one value here with
+ * a safety consequence - onto a second row.
+ *
+ * At the ceiling the MODEL gives way first: it carries `min-w-0 truncate`, so
+ * an unbounded model name ellipsizes while reasoning and the permission mode,
+ * both short and bounded, stay whole.
  */
 function OwnerSettingsHeaderRows(props: {
   readonly view: OwnerSettingsHeaderView;
@@ -144,8 +190,12 @@ function OwnerSettingsHeaderRows(props: {
       : {
           key: "model",
           node: (
+            // The only segment allowed to shrink. Model names are the
+            // unbounded value on this line ("Claude Opus 4.7 (1M context)"),
+            // so at the card's ceiling this ellipsizes and the short, bounded
+            // segments beside it survive intact.
             <span
-              className="truncate font-medium"
+              className="min-w-0 truncate font-medium"
               data-testid="owner-settings-model"
             >
               {view.modelLabel}
@@ -157,8 +207,14 @@ function OwnerSettingsHeaderRows(props: {
       : {
           key: "reasoning",
           node: (
+            // Second to give way, after the model. NOT `shrink-0`: this label
+            // comes from the harness catalog (`supportedReasoningEfforts[].label`),
+            // i.e. provider-supplied text we do not bound. If every segment but
+            // the model were unshrinkable, a verbose one could push the row past
+            // the card's ceiling and - since the card is `overflow-hidden` - clip
+            // the permission mode off the right edge with no ellipsis at all.
             <span
-              className="truncate text-muted-foreground"
+              className="min-w-0 truncate text-muted-foreground"
               data-testid="owner-settings-reasoning"
             >
               {view.reasoningLabel}
@@ -170,7 +226,7 @@ function OwnerSettingsHeaderRows(props: {
           key: "fast-mode",
           node: (
             <span
-              className="text-muted-foreground"
+              className="shrink-0 text-muted-foreground"
               data-testid="owner-settings-fast-mode"
             >
               Fast
@@ -178,32 +234,11 @@ function OwnerSettingsHeaderRows(props: {
           ),
         }
       : null,
-    view.permissionLabel === null
+    view.permissionMode === null
       ? null
       : {
           key: "permissions",
-          node: (
-            <span
-              className="flex min-w-0 items-center gap-1 text-muted-foreground"
-              data-testid="owner-settings-permissions"
-            >
-              <Lock className="size-3 shrink-0" />
-              <span className="truncate">{view.permissionLabel}</span>
-            </span>
-          ),
-        },
-    view.profileLabel === null
-      ? null
-      : {
-          key: "profile",
-          node: (
-            <span
-              className="truncate text-muted-foreground"
-              data-testid="owner-settings-profile"
-            >
-              {view.profileLabel}
-            </span>
-          ),
+          node: <OwnerSettingsPermission mode={view.permissionMode} />,
         },
   ];
   const segments = allSegments.filter(
@@ -211,10 +246,10 @@ function OwnerSettingsHeaderRows(props: {
   );
   return (
     <span
-      className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-border/70 px-3 py-2 text-ui-xs"
+      className="flex flex-nowrap items-center gap-2 whitespace-nowrap border-b border-border/70 px-3 py-2 text-ui-xs"
       data-testid="owner-settings-header"
     >
-      <HarnessIcon harnessId={view.harnessId} className="size-3.5 shrink-0" />
+      <OwnerSettingsHarnessMark view={view} />
       {segments.map((segment, index) => (
         <Fragment key={segment.key}>
           {index === 0 ? null : (
@@ -233,11 +268,81 @@ function OwnerSettingsHeaderRows(props: {
         </Fragment>
       ))}
       {props.updatedAt === null ? null : (
-        // `ml-auto` pins it to the far right of the line. Placed last so that
-        // when the row wraps on a narrow card the time trails the settings
-        // rather than stranding them under it.
+        // `ml-auto` pins it to the far right whenever the line is shorter than
+        // the card's floor width; at the ceiling the auto margin collapses and
+        // it simply trails the settings across a `gap-2`.
         <OwnerSettingsUpdatedAt updatedAt={props.updatedAt} />
       )}
+    </span>
+  );
+}
+
+/**
+ * Harness brand mark carrying the profile as a corner dot - the composer
+ * model-picker trigger's exact pairing (`harness-model-trigger.tsx`), down to
+ * the `size-4` mark and the `compact` corner dot, so the same account reads as
+ * the same mark whether you are picking it or auditing it.
+ *
+ * Named here rather than left as a bare icon because `AccentDot` is
+ * `aria-hidden` by construction and its own contract requires callers to pair
+ * it with a name. With the profile's text segment gone, this label is the only
+ * place the account is announced at all - so it carries the harness and the
+ * profile together, which is also the first time this row named its harness to
+ * a screen reader.
+ */
+function OwnerSettingsHarnessMark(props: {
+  readonly view: OwnerSettingsHeaderView;
+}): ReactNode {
+  const { view } = props;
+  const accentDot = view.profileAccentDot;
+  return (
+    <span
+      role="img"
+      aria-label={
+        accentDot === null
+          ? view.harnessName
+          : `${view.harnessName}, ${accentDot.label}`
+      }
+      className="relative flex shrink-0 items-center"
+      data-testid="owner-settings-harness-mark"
+    >
+      <HarnessIcon harnessId={view.harnessId} className="size-4 shrink-0" />
+      {accentDot === null ? null : (
+        <AccentDot
+          profileId={accentDot.profileId}
+          accentColor={accentDot.accentColor}
+          label={accentDot.label}
+          variant="corner"
+          size="compact"
+          className={undefined}
+        />
+      )}
+    </span>
+  );
+}
+
+/**
+ * Permission mode with the icon the rest of the app already uses for it -
+ * `ShieldCheck` / `FileCheck2` / `UnlockKeyhole`, resolved through the shared
+ * `findPermissionOption` table rather than chosen here.
+ *
+ * This row previously hardcoded a closed padlock for ALL THREE modes, so the
+ * least restricted one - "Full access" - was the one that read as locked down.
+ * Taking the icon from the same lookup as the label is what makes that
+ * inversion unrepresentable rather than merely fixed.
+ */
+function OwnerSettingsPermission(props: {
+  readonly mode: PermissionMode;
+}): ReactNode {
+  const option = findPermissionOption(props.mode);
+  const Icon = option.icon;
+  return (
+    <span
+      className="flex shrink-0 items-center gap-1 text-muted-foreground"
+      data-testid="owner-settings-permissions"
+    >
+      <Icon aria-hidden className="size-3 shrink-0" />
+      <span>{option.label}</span>
     </span>
   );
 }

--- a/clients/gui-app/src/components/worktree/worktree-owner-settings-model.ts
+++ b/clients/gui-app/src/components/worktree/worktree-owner-settings-model.ts
@@ -2,16 +2,17 @@ import type { ChatRunSettings } from "@traycer/protocol/host/agent/gui/subscribe
 import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
 import {
-  findPermissionLabel,
   findReasoningLabel,
   isFastModeEnabled,
   modelDisplayLabel,
   type ModelOption,
+  type PermissionMode,
   type ProviderId,
 } from "@/components/home/data/landing-options";
 import {
+  profileAccentDotInput,
   profileCommitId,
-  profileDisplayLabel,
+  type ProfileAccentDotInput,
 } from "@/components/providers/provider-profile-model";
 import type { GuiHarnessCatalogEntry } from "@/hooks/harnesses/use-gui-harness-catalog";
 
@@ -29,8 +30,19 @@ export interface OwnerSettingsHeaderView {
   readonly modelLabel: string | null;
   readonly reasoningLabel: string | null;
   readonly fastMode: boolean;
-  readonly profileLabel: string | null;
-  readonly permissionLabel: string | null;
+  /** Corner badge for the harness mark, NOT a text segment: the profile name
+   *  used to ride at the end of the line, where a long label ("Anthropic work
+   *  account") wrapped the row onto a second line and pushed the permission
+   *  mode - the one value here with a safety consequence - out of first sight.
+   *  Same `AccentDot` projection the composer's model-picker trigger uses, so
+   *  the same profile reads as the same mark on both surfaces. */
+  readonly profileAccentDot: ProfileAccentDotInput | null;
+  /** The raw mode, not a pre-resolved label: the header needs BOTH the label
+   *  and the mode's icon, and `findPermissionOption` is the single source of
+   *  truth for that pair (`landing-options`). Resolving only the label here is
+   *  what let this surface drift into hardcoding one padlock for all three
+   *  modes. */
+  readonly permissionMode: PermissionMode | null;
 }
 
 export interface OwnerSettingsHeaderInput {
@@ -46,9 +58,10 @@ export interface OwnerSettingsHeaderInput {
    *  the catalog is cold or the host is unreachable, which drives the
    *  raw-slug fallback. */
   readonly harnesses: ReadonlyArray<GuiHarnessCatalogEntry>;
-  /** The chat host's provider profiles, flattened across providers. Used only
-   *  to resolve the chat's `profileId` to a label; when it cannot be resolved
-   *  the profile row is omitted rather than showing the opaque id. */
+  /** The chat harness's OWN profiles - not every provider's, flattened. The
+   *  accent dot is gated on this list crossing the 2-profile mark, and that
+   *  gate only means "this provider has more than one account" if the list is
+   *  scoped to the provider in question. */
   readonly profiles: ReadonlyArray<ProviderProfile>;
 }
 
@@ -81,8 +94,11 @@ function deriveChatHeader(
     modelLabel: model === null ? settings.model : modelDisplayLabel(model),
     reasoningLabel: resolveReasoningLabel(settings.reasoningEffort, model),
     fastMode: isFastModeEnabled(settings.serviceTier),
-    profileLabel: resolveProfileLabel(settings.profileId, input.profiles),
-    permissionLabel: findPermissionLabel(settings.permissionMode),
+    profileAccentDot: resolveProfileAccentDot(
+      settings.profileId,
+      input.profiles,
+    ),
+    permissionMode: settings.permissionMode,
   };
 }
 
@@ -100,8 +116,8 @@ function deriveTerminalAgentHeader(
     modelLabel: model === null ? input.tuiModel : modelDisplayLabel(model),
     reasoningLabel: null,
     fastMode: false,
-    profileLabel: null,
-    permissionLabel: null,
+    profileAccentDot: null,
+    permissionMode: null,
   };
 }
 
@@ -136,19 +152,25 @@ function resolveReasoningLabel(
   );
 }
 
-// Ambient (`null`) omits the row, and so does an id we cannot resolve to a
-// human name (profiles not cached, host unreachable, or a removed profile).
-// Unlike the harness/model slugs - which are themselves readable ("claude",
-// "gpt-5.5-codex") - a raw `profileId` is an opaque host-generated string, so
-// showing it under a "Profile" label would be noise rather than a degraded
-// answer.
-function resolveProfileLabel(
+// Deliberately the same three lines as the model picker's own badge resolution
+// (`deriveHarnessModelPickerPresentation`), including the shape of what it
+// declines to show:
+//
+//   - Fewer than 2 profiles is the progressive-disclosure gate. A dot that is
+//     always present signals nothing; it earns its pixels only once the
+//     provider actually has more than one account to be confused between.
+//   - `null` here is AMBIENT, not "no profile" - it matches the ambient row via
+//     `profileCommitId`, so a chat running on the Terminal account gets its own
+//     mark rather than silently reading as an unconfigured one.
+//   - An id matching nothing (cold provider cache, host unreachable, deleted
+//     profile) omits the badge rather than guessing a color from an opaque id.
+function resolveProfileAccentDot(
   profileId: string | null,
   profiles: ReadonlyArray<ProviderProfile>,
-): string | null {
-  if (profileId === null) return null;
+): ProfileAccentDotInput | null {
+  if (profiles.length < 2) return null;
   const profile =
     profiles.find((candidate) => profileCommitId(candidate) === profileId) ??
     null;
-  return profile === null ? null : profileDisplayLabel(profile);
+  return profile === null ? null : profileAccentDotInput(profile);
 }

--- a/clients/gui-app/src/components/worktree/worktree-pr-state-icons.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-pr-state-icons.tsx
@@ -10,6 +10,7 @@ import { useRunnerOpenExternalLink } from "@/hooks/runner/use-open-external-link
 import { cn } from "@/lib/utils";
 import { RunnerHostContext } from "@/providers/runner-host-context";
 import type { WorktreePrReference } from "@/components/worktree/worktree-pr-metadata-model";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import {
   PR_STATE_ICON,
   PR_STATE_TINT_CLASS,
@@ -96,24 +97,30 @@ function WorktreePrStateIcon(props: {
   );
   const Icon = PR_STATE_ICON[props.reference.state];
   return (
-    <span
-      role="link"
-      tabIndex={0}
-      aria-label={props.reference.ariaLabel}
-      title={props.reference.label}
-      data-testid="worktree-pr-state-icon"
-      data-pr-state={props.reference.state}
-      className={cn(
-        "inline-flex shrink-0 cursor-pointer items-center gap-0.5 font-medium",
-        "focus-visible:ring-ring rounded-sm focus-visible:outline-none focus-visible:ring-2",
-        PR_STATE_TINT_CLASS[props.reference.state],
-      )}
-      onClick={openOnClick}
-      onKeyDown={openOnKeyDown}
-      onPointerDown={stopDragActivation}
+    <TooltipWrapper
+      label={props.reference.label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <Icon className="size-3" aria-hidden />
-      <span>#{props.reference.prNumber}</span>
-    </span>
+      <span
+        role="link"
+        tabIndex={0}
+        aria-label={props.reference.ariaLabel}
+        data-testid="worktree-pr-state-icon"
+        data-pr-state={props.reference.state}
+        className={cn(
+          "inline-flex shrink-0 cursor-pointer items-center gap-0.5 font-medium",
+          "focus-visible:ring-ring rounded-sm focus-visible:outline-none focus-visible:ring-2",
+          PR_STATE_TINT_CLASS[props.reference.state],
+        )}
+        onClick={openOnClick}
+        onKeyDown={openOnKeyDown}
+        onPointerDown={stopDragActivation}
+      >
+        <Icon className="size-3" aria-hidden />
+        <span>#{props.reference.prNumber}</span>
+      </span>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/editor-core/links/artifact-link-popover.tsx
+++ b/clients/gui-app/src/editor-core/links/artifact-link-popover.tsx
@@ -42,6 +42,7 @@ import { reportableErrorToast } from "@/lib/reportable-error-toast";
 import { cn } from "@/lib/utils";
 import { isSingleTextblockLinkRange } from "./artifact-link-selection";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 const HOVER_SHOW_DELAY_MS = 300;
 const HOVER_HIDE_DELAY_MS = 100;
 
@@ -587,48 +588,68 @@ function LinkPreview(props: LinkPreviewProps) {
         href={props.href}
       />
       {openable ? (
-        <Button
-          type="button"
-          size="xs"
-          variant="ghost"
-          aria-label={`Open link: ${props.href}`}
-          title={props.href}
-          className="min-w-0 max-w-[min(55vw,16rem)] justify-start px-1.5 font-normal text-muted-foreground hover:text-foreground"
-          disabled={props.href.trim().length === 0 || externalOpenPending}
-          onClick={props.onOpen}
+        <TooltipWrapper
+          label={props.href}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          <span className="truncate">{props.href}</span>
-          {externalOpenPending ? (
-            <AgentSpinningDots
-              className={undefined}
-              testId="artifact-link-open-pending"
-              variant={undefined}
-            />
-          ) : null}
-        </Button>
+          <span className="inline-flex">
+            <Button
+              type="button"
+              size="xs"
+              variant="ghost"
+              aria-label={`Open link: ${props.href}`}
+              className="min-w-0 max-w-[min(55vw,16rem)] justify-start px-1.5 font-normal text-muted-foreground hover:text-foreground"
+              disabled={props.href.trim().length === 0 || externalOpenPending}
+              onClick={props.onOpen}
+            >
+              <span className="truncate">{props.href}</span>
+              {externalOpenPending ? (
+                <AgentSpinningDots
+                  className={undefined}
+                  testId="artifact-link-open-pending"
+                  variant={undefined}
+                />
+              ) : null}
+            </Button>
+          </span>
+        </TooltipWrapper>
       ) : (
-        <span
-          title={props.href}
-          className="min-w-0 max-w-[min(55vw,16rem)] truncate px-1.5 text-ui-xs text-muted-foreground"
+        <TooltipWrapper
+          label={props.href}
+          side="top"
+          sideOffset={undefined}
+          align={undefined}
         >
-          {props.href}
-        </span>
+          <span className="min-w-0 max-w-[min(55vw,16rem)] truncate px-1.5 text-ui-xs text-muted-foreground">
+            {props.href}
+          </span>
+        </TooltipWrapper>
       )}
-      <Button
-        type="button"
-        size="icon-xs"
-        variant="ghost"
-        disabled={props.href.trim().length === 0}
-        aria-label={props.copied ? "Copied" : "Copy link"}
-        title={props.copied ? "Copied" : "Copy link"}
-        onClick={props.onCopy}
+      <TooltipWrapper
+        label={props.copied ? "Copied" : "Copy link"}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        {props.copied ? (
-          <Check aria-hidden="true" />
-        ) : (
-          <Copy aria-hidden="true" />
-        )}
-      </Button>
+        <span className="inline-flex">
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="ghost"
+            disabled={props.href.trim().length === 0}
+            aria-label={props.copied ? "Copied" : "Copy link"}
+            onClick={props.onCopy}
+          >
+            {props.copied ? (
+              <Check aria-hidden="true" />
+            ) : (
+              <Copy aria-hidden="true" />
+            )}
+          </Button>
+        </span>
+      </TooltipWrapper>
       {props.editable ? (
         <Button
           type="button"

--- a/clients/gui-app/src/editor-core/toolbar/toolbar-button.tsx
+++ b/clients/gui-app/src/editor-core/toolbar/toolbar-button.tsx
@@ -1,5 +1,6 @@
 import type { ComponentPropsWithoutRef, ReactNode, Ref } from "react";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 export interface ToolbarButtonProps extends Omit<
   ComponentPropsWithoutRef<"button">,
   "children" | "title"
@@ -20,17 +21,25 @@ export interface ToolbarButtonProps extends Omit<
 export function ToolbarButton(props: ToolbarButtonProps) {
   const { icon, label, active, disabled, type, className, ...rest } = props;
   return (
-    <button
-      type={type ?? "button"}
-      title={label}
-      aria-label={label}
-      aria-pressed={active}
-      data-active={active ? "true" : "false"}
-      disabled={disabled}
-      className={className}
-      {...rest}
+    <TooltipWrapper
+      label={label}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      {icon}
-    </button>
+      <span className="inline-flex">
+        <button
+          type={type ?? "button"}
+          aria-label={label}
+          aria-pressed={active}
+          data-active={active ? "true" : "false"}
+          disabled={disabled}
+          className={className}
+          {...rest}
+        >
+          {icon}
+        </button>
+      </span>
+    </TooltipWrapper>
   );
 }

--- a/clients/gui-app/src/markdown/components/markdown-anchor.tsx
+++ b/clients/gui-app/src/markdown/components/markdown-anchor.tsx
@@ -98,8 +98,13 @@ export function MarkdownAnchor({
     [href, linkPolicy, reportIssueAvailable, runnerHost],
   );
 
+  // Native `title` ON PURPOSE - see the eslint exemption for this file. This
+  // is not app chrome: it is the link title the DOCUMENT AUTHOR wrote, and
+  // `title` is where a Markdown link title belongs. Routing it through the
+  // app's tooltip surface would restyle author content as UI and strip the
+  // attribute off the rendered anchor.
   return (
-    <a href={href} title={title} className={className} onClick={routeLinkClick}>
+    <a href={href} className={className} title={title} onClick={routeLinkClick}>
       {children}
     </a>
   );

--- a/clients/gui-app/src/markdown/components/traycer-reference-chip.tsx
+++ b/clients/gui-app/src/markdown/components/traycer-reference-chip.tsx
@@ -11,6 +11,7 @@ import type { EpicNodeRef } from "@/stores/epics/canvas/types";
 import { isEpicArtifactKind } from "@/lib/artifacts/node-display";
 import { cn } from "@/lib/utils";
 
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 interface TraycerReferenceChipProps {
   readonly icon: ReactNode;
   readonly children: ReactNode;
@@ -48,8 +49,8 @@ export function TraycerReferenceChip(props: TraycerReferenceChipProps) {
   }
   return (
     <ReferenceChipButton
+      tooltip={props.title}
       icon={props.icon}
-      title={props.title}
       refKind={props.refKind}
       onOpen={props.onOpen}
       drag={null}
@@ -113,8 +114,8 @@ function DraggableReferenceChip(
 
   return (
     <ReferenceChipButton
+      tooltip={props.title}
       icon={props.icon}
-      title={props.title}
       refKind={refKind}
       onOpen={props.onOpen}
       drag={
@@ -146,38 +147,46 @@ interface ReferenceChipDragWiring {
 function ReferenceChipButton(props: {
   readonly icon: ReactNode;
   readonly children: ReactNode;
-  readonly title: string | undefined;
+  /** Hover label; `tooltip` not `title` so the call site cannot read as the
+   *  native attribute. */
+  readonly tooltip: string | undefined;
   readonly refKind: "spec" | "ticket" | "chat" | "epic";
   readonly onOpen: (event: MouseEvent<HTMLButtonElement>) => void;
   readonly drag: ReferenceChipDragWiring | null;
 }) {
   const drag = props.drag;
   return (
-    <button
-      ref={drag === null ? undefined : drag.ref}
-      {...(drag === null ? undefined : drag.attributes)}
-      {...(drag === null ? undefined : drag.listeners)}
-      type="button"
-      onClick={props.onOpen}
-      title={props.title}
-      data-traycer-ref={props.refKind}
-      // Excluded from quote selection: it's an interactive chip inside quotable
-      // prose, so a drag across it must not append its label as quoted text.
-      data-quote-exclude=""
-      className={cn(
-        "mx-px inline-flex max-w-full items-center gap-1 rounded-md border border-border/60 bg-muted/60 px-1.5 py-0.5 align-baseline text-ui-sm font-medium text-foreground/90 no-underline",
-        "transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none",
-        // Affordance (plan section 6): whole pill is the drag surface -
-        // grab cursor + a subtle border/ring emphasis on hover, no inline grip.
-        drag !== null &&
-          "cursor-grab hover:border-primary/40 hover:ring-1 hover:ring-primary/40",
-        drag !== null && drag.isDragging && "cursor-grabbing opacity-60",
-      )}
+    <TooltipWrapper
+      label={props.tooltip}
+      side="top"
+      sideOffset={undefined}
+      align={undefined}
     >
-      <span className="flex size-3.5 shrink-0 items-center justify-center text-muted-foreground">
-        {props.icon}
-      </span>
-      <span className="truncate">{props.children}</span>
-    </button>
+      <button
+        ref={drag === null ? undefined : drag.ref}
+        {...(drag === null ? undefined : drag.attributes)}
+        {...(drag === null ? undefined : drag.listeners)}
+        type="button"
+        onClick={props.onOpen}
+        data-traycer-ref={props.refKind}
+        // Excluded from quote selection: it's an interactive chip inside quotable
+        // prose, so a drag across it must not append its label as quoted text.
+        data-quote-exclude=""
+        className={cn(
+          "mx-px inline-flex max-w-full items-center gap-1 rounded-md border border-border/60 bg-muted/60 px-1.5 py-0.5 align-baseline text-ui-sm font-medium text-foreground/90 no-underline",
+          "transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none",
+          // Affordance (plan section 6): whole pill is the drag surface -
+          // grab cursor + a subtle border/ring emphasis on hover, no inline grip.
+          drag !== null &&
+            "cursor-grab hover:border-primary/40 hover:ring-1 hover:ring-primary/40",
+          drag !== null && drag.isDragging && "cursor-grabbing opacity-60",
+        )}
+      >
+        <span className="flex size-3.5 shrink-0 items-center justify-center text-muted-foreground">
+          {props.icon}
+        </span>
+        <span className="truncate">{props.children}</span>
+      </button>
+    </TooltipWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- Fixes three chat-sidebar hover-card bugs: a hardcoded permission icon showing a closed padlock under Full access, a long profile name wrapping the header row onto two lines, and a hover/click race that could leave the card open with no pointer-leave left to close it (Radix's `handleOpen` orphans an open timer across a click, so the re-arm now hangs off pointer-enter rather than pointer-leave).
- The card now expands width instead of wrapping to a second line as its content grows, and swaps the spelled-out profile name for the harness+profile accent-dot pairing already used in the model picker.
- Adds a repo-wide ESLint rule banning native `title` tooltips in favor of `TooltipWrapper`/the design system's `Tooltip`, and migrates the ~118 existing native-tooltip call sites, scoping several over-broad triggers down to the specific element each label describes.

## Test plan
- [x] `pre-commit run --all-files` (build, compile, lint, format, DCO) — passed
- [x] Full gui-app test suite — 7,109 passing (1 skipped)
- [x] New hover-gate regression tests (`worktree-owner-metadata-hover-gate.test.tsx`) confirmed to fail against the pre-fix code
- [x] New settings-header tests cover permission icon and profile accent-dot rendering
- [ ] Manual click-then-leave and pointer-travel-into-card check in the running app