### PR TITLE
fix(gui-app): route chat toasts with window router

### DIFF
--- a/clients/gui-app/src/hooks/notifications/__tests__/use-notification-activation.test.tsx
+++ b/clients/gui-app/src/hooks/notifications/__tests__/use-notification-activation.test.tsx
@@ -11,6 +11,7 @@ import {
 import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
 import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import type { NotificationNavigate } from "@/lib/notifications";
 
 type CapturedNavigate = {
   readonly to: string;
@@ -26,6 +27,13 @@ type CapturedNavigate = {
 const navigateSpy = vi.hoisted(() =>
   vi.fn<(options: CapturedNavigate) => void>(),
 );
+const explicitNavigateCalls = vi.hoisted(() =>
+  vi.fn<(options: unknown) => void>(),
+);
+const explicitNavigate: NotificationNavigate = (options) => {
+  explicitNavigateCalls(options);
+  return Promise.resolve();
+};
 const activeHostIdStub: { value: string | null } = vi.hoisted(() => ({
   value: "stub-host",
 }));
@@ -53,7 +61,10 @@ vi.mock("@/lib/host-error-toast", () => ({
   toastFromHostError: vi.fn(),
 }));
 
-import { useNotificationActivation } from "@/hooks/notifications/use-notification-activation";
+import {
+  useNotificationActivation,
+  useNotificationActivationWithNavigate,
+} from "@/hooks/notifications/use-notification-activation";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 
 function createTestQueryClient(): QueryClient {
@@ -90,6 +101,7 @@ describe("useNotificationActivation", () => {
   beforeEach(() => {
     navigateSpy.mockReset();
     navigateSpy.mockImplementation(() => undefined);
+    explicitNavigateCalls.mockReset();
     activeHostIdStub.value = "stub-host";
     bindStubClient();
     useEpicCanvasStore.setState({
@@ -97,6 +109,33 @@ describe("useNotificationActivation", () => {
       openTabOrder: [],
       activeTabId: null,
       mostRecentTabIdByEpicId: {},
+    });
+  });
+
+  it("routes with an explicitly owned router outside ambient router context", () => {
+    const hook = renderHook(
+      () => useNotificationActivationWithNavigate(explicitNavigate),
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      hook.result.current.activate({
+        payload: { kind: "chat", epicId: "epic-owned", chatId: "chat-owned" },
+        receivedAt: 789,
+        feedId: "host:n-owned",
+        onResult: null,
+      });
+    });
+
+    expect(explicitNavigateCalls).toHaveBeenCalledTimes(1);
+    expect(navigateSpy).not.toHaveBeenCalled();
+    expect(explicitNavigateCalls.mock.calls[0][0]).toMatchObject({
+      to: "/epics/$epicId/$tabId",
+      params: { epicId: "epic-owned" },
+      search: {
+        focusedAt: 789,
+        focusArtifactId: "chat-owned",
+      },
     });
   });
 

--- a/clients/gui-app/src/hooks/notifications/use-notification-activation.ts
+++ b/clients/gui-app/src/hooks/notifications/use-notification-activation.ts
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useHostBinding } from "@/lib/host";
 import {
   routeNotification,
+  type NotificationNavigate,
   type NotificationPayload,
 } from "@/lib/notifications";
 
@@ -52,9 +53,23 @@ function isHostFeedId(feedId: string | null): boolean {
  * no-acknowledgment rather than crediting the wrong host's notification.
  */
 export function useNotificationActivation(): NotificationActivationController {
+  return useNotificationActivationWithNavigate(useNavigate());
+}
+
+/**
+ * Binds notification activation to an explicitly owned router.
+ *
+ * The host notification stream intentionally mounts above `RouterProvider`,
+ * so its toast callback cannot use TanStack's ambient router context. The app
+ * passes the per-window router's navigate function through this seam; routed
+ * notification surfaces mounted below `RouterProvider` use the ambient hook
+ * above.
+ */
+export function useNotificationActivationWithNavigate(
+  navigate: NotificationNavigate,
+): NotificationActivationController {
   const binding = useHostBinding();
   const client = binding?.hostClient ?? null;
-  const navigate = useNavigate();
 
   const activate = useCallback(
     (input: NotificationActivationInput) => {

--- a/clients/gui-app/src/lib/notifications/index.ts
+++ b/clients/gui-app/src/lib/notifications/index.ts
@@ -9,6 +9,7 @@ export {
   type EpicNotificationPayload,
   type NotificationPayload,
   type NotificationPayloadKind,
+  type NotificationNavigate,
   type SessionNotificationPayload,
 } from "./payload";
 export {

--- a/clients/gui-app/src/lib/notifications/payload.ts
+++ b/clients/gui-app/src/lib/notifications/payload.ts
@@ -264,7 +264,7 @@ export function buildPayloadFromEvent(
   }
 }
 
-type NavigateFn = UseNavigateResult<string>;
+export type NotificationNavigate = UseNavigateResult<string>;
 
 /**
  * Pure predicate mirroring `routeNotification`'s no-op branches, without
@@ -297,7 +297,7 @@ export function isNotificationPayloadRoutable(
  * contract in one place so the two surfaces cannot drift.
  */
 export function routeNotification(
-  navigate: NavigateFn,
+  navigate: NotificationNavigate,
   payload: NotificationPayload,
   receivedAt: number,
 ): void {
@@ -371,7 +371,7 @@ export function routeNotification(
 }
 
 function routeTerminalNotification(
-  navigate: NavigateFn,
+  navigate: NotificationNavigate,
   payload: TerminalNotificationPayload,
   receivedAt: number,
 ): void {
@@ -415,7 +415,7 @@ function routeTerminalNotification(
 }
 
 function routeEpicChatNotification(
-  navigate: NavigateFn,
+  navigate: NotificationNavigate,
   payload: ChatNotificationPayload,
   receivedAt: number,
 ): void {
@@ -440,7 +440,7 @@ function isChatArtifactTileType(type: string | undefined): boolean {
 }
 
 function routeOpenChatNotification(
-  navigate: NavigateFn,
+  navigate: NotificationNavigate,
   payload: ChatNotificationPayload,
   receivedAt: number,
 ): boolean {
@@ -518,7 +518,7 @@ function routeOpenChatNotification(
 }
 
 function routeLegacyTerminalNotification(
-  navigate: NavigateFn,
+  navigate: NotificationNavigate,
   payload: ChatNotificationPayload,
   receivedAt: number,
 ): boolean {

--- a/clients/gui-app/src/providers/__tests__/notifications-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/notifications-session-provider.test.tsx
@@ -1,6 +1,7 @@
 import "../../../__tests__/test-browser-apis";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import { mockLocalHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
@@ -89,6 +90,9 @@ const activateMock = vi.hoisted(() =>
     }) => void
   >(),
 );
+const notificationNavigateMock = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve()),
+);
 const markAsReadMock = vi.hoisted(() => vi.fn<(feedId: string) => void>());
 const lastHostDisplay = vi.hoisted(() => ({
   originHostId: null as string | null,
@@ -102,7 +106,7 @@ const lastHostDisplay = vi.hoisted(() => ({
 }));
 
 vi.mock("@/hooks/notifications/use-notification-activation", () => ({
-  useNotificationActivation: () => ({
+  useNotificationActivationWithNavigate: () => ({
     activate: activateMock,
     pendingFeedId: null,
   }),
@@ -158,7 +162,7 @@ vi.mock("@/lib/notifications/notification-display", async (importActual) => {
   };
 });
 
-import { NotificationsSessionProvider } from "@/providers/notifications-session-provider";
+import { NotificationsSessionProvider as RoutedNotificationsSessionProvider } from "@/providers/notifications-session-provider";
 import { __setNotificationsStreamFactoryForTests } from "@/providers/notifications-stream-factory-override";
 import { NotificationsBell } from "@/components/notifications/notifications-bell";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -181,6 +185,16 @@ import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
 import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
 import { selectNotificationIndicatorState } from "@/stores/notifications/notification-indicator-state";
 import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
+
+function NotificationsSessionProvider(props: {
+  readonly children: ReactNode;
+}): ReactNode {
+  return (
+    <RoutedNotificationsSessionProvider navigate={notificationNavigateMock}>
+      {props.children}
+    </RoutedNotificationsSessionProvider>
+  );
+}
 
 interface ControlledStream {
   closeCount: number;

--- a/clients/gui-app/src/providers/__tests__/notifications-session-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/notifications-session-provider.test.tsx
@@ -36,6 +36,7 @@ import {
   createNotificationRoomEntryMap,
   type NotificationRoomEntryMap,
 } from "@traycer/protocol/notifications/notification-room";
+import type { NotificationNavigate } from "@/lib/notifications";
 
 interface HostState {
   id: string | null;
@@ -93,6 +94,9 @@ const activateMock = vi.hoisted(() =>
 const notificationNavigateMock = vi.hoisted(() =>
   vi.fn(() => Promise.resolve()),
 );
+const activationHookState = vi.hoisted<{
+  navigate: NotificationNavigate | null;
+}>(() => ({ navigate: null }));
 const markAsReadMock = vi.hoisted(() => vi.fn<(feedId: string) => void>());
 const lastHostDisplay = vi.hoisted(() => ({
   originHostId: null as string | null,
@@ -106,10 +110,13 @@ const lastHostDisplay = vi.hoisted(() => ({
 }));
 
 vi.mock("@/hooks/notifications/use-notification-activation", () => ({
-  useNotificationActivationWithNavigate: () => ({
-    activate: activateMock,
-    pendingFeedId: null,
-  }),
+  useNotificationActivationWithNavigate: (navigate: NotificationNavigate) => {
+    activationHookState.navigate = navigate;
+    return {
+      activate: activateMock,
+      pendingFeedId: null,
+    };
+  },
 }));
 
 vi.mock("@/stores/notifications/merged-notifications", async (importActual) => {
@@ -491,6 +498,7 @@ describe("<NotificationsSessionProvider />", () => {
         dispose: vi.fn(),
       }),
     );
+    activationHookState.navigate = null;
     __resetNotificationsStoreForTests();
     __resetHostNotificationsStoreForTests();
     useAppLocalNotificationsStore.getState().resetForTests();
@@ -1773,6 +1781,7 @@ describe("<NotificationsSessionProvider />", () => {
     const { AnalyticsEvent } = await import("@/lib/analytics");
 
     const { streamClient } = await renderHostNotificationsProvider();
+    expect(activationHookState.navigate).toBe(notificationNavigateMock);
 
     act(() => {
       streamClient.session.emitServerFrame({

--- a/clients/gui-app/src/providers/notifications-session-provider.tsx
+++ b/clients/gui-app/src/providers/notifications-session-provider.tsx
@@ -25,7 +25,7 @@ import { useAuthStore } from "@/stores/auth/auth-store";
 import { useAuthService, useHostClient } from "@/lib/host";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { useNotificationShow } from "@/hooks/notifications/use-notifications";
-import { useNotificationActivation } from "@/hooks/notifications/use-notification-activation";
+import { useNotificationActivationWithNavigate } from "@/hooks/notifications/use-notification-activation";
 import { useNotificationMarkEntityRead } from "@/hooks/notifications/use-notification-mark-entity-read-mutation";
 import { useWindowsBridge } from "@/providers/windows-bridge-context";
 import {
@@ -45,6 +45,7 @@ import {
   notificationEntitiesMatch,
   notificationEntityFromHostEntry,
   notificationPayloadBelongsToEntity,
+  type NotificationNavigate,
 } from "@/lib/notifications";
 import { useAppLocalNotificationsStore } from "@/stores/notifications/app-local-notifications-store";
 import type { HostNotificationsEntityRef } from "@traycer/protocol/host/notifications/contracts";
@@ -56,6 +57,8 @@ import { activationResultHandler } from "@/lib/notifications/notification-activa
 
 export interface NotificationsSessionProviderProps {
   readonly children: ReactNode;
+  /** The live per-window router owns this provider's toast navigation. */
+  readonly navigate: NotificationNavigate;
 }
 
 /**
@@ -74,7 +77,7 @@ export function NotificationsSessionProvider(
   const authService = useAuthService();
   const hostClient = useHostClient();
   const showNotification = useNotificationShow();
-  const { activate } = useNotificationActivation();
+  const { activate } = useNotificationActivationWithNavigate(props.navigate);
   const mergedActions = useMergedNotificationsActions();
   const windowsBridge = useWindowsBridge();
   const status = useAuthStore((state) => state.status);

--- a/clients/gui-app/src/traycer-app.tsx
+++ b/clients/gui-app/src/traycer-app.tsx
@@ -193,7 +193,9 @@ function TraycerAuthenticatedRuntime(props: TraycerAuthenticatedRuntimeProps) {
                       <HostStreamProvider>
                         <WorktreeChangedStreamMount />
                         <AppLocalNotificationsPersistLifecycleBridge>
-                          <NotificationsSessionProvider>
+                          <NotificationsSessionProvider
+                            navigate={props.router.navigate}
+                          >
                             <TraycerAppRuntimeSurface router={props.router} />
                           </NotificationsSessionProvider>
                         </AppLocalNotificationsPersistLifecycleBridge>


### PR DESCRIPTION
## Summary

- pass the mounted window router into the notification session provider
- keep notification activation reusable for router-owned and explicitly-owned navigation
- add regressions for the provider wiring and out-of-context toast activation

## Root cause

The host-stream chat-done toast handler is mounted above `RouterProvider`. Its ambient `useNavigate()` therefore did not belong to the visible per-window router: notification activation updated the canvas store, but the displayed route remained on the previous task.

## Verification

- reproduced against a live renderer over CDP
- confirmed the chat notification payload and target task/chat tile were correct
- confirmed activation changed `activeTabId` while `location.href` and the visible pane stayed unchanged
- affected GUI build, compile, lint, format, and tests pass via pre-commit
