### PR TITLE
feat(gui-app): add compact-conversation action to context usage chip

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/context-usage-chip.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   domAnimation,
   hasReducedMotionListener,
@@ -280,12 +280,14 @@ describe("buildContextUsageRows", () => {
 
 describe("ContextUsageChip", () => {
   it("renders nothing when usage is null", () => {
-    const { container } = render(<ContextUsageChip usage={null} />);
+    const { container } = render(
+      <ContextUsageChip usage={null} onCompact={null} />,
+    );
     expect(container.firstChild).toBe(null);
   });
 
   it("renders a compact button for a usage with a contextWindow", () => {
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
     const button = screen.getByRole("button", {
       name: /Context window 75% left/,
     });
@@ -313,6 +315,7 @@ describe("ContextUsageChip", () => {
           totalTokens: 51_000,
           contextTokens: 50_000,
         }}
+        onCompact={null}
       />,
     );
     expect(container.firstChild).toBe(null);
@@ -330,6 +333,7 @@ describe("ContextUsageChip", () => {
           cacheReadInputTokens: 100_000,
           contextWindow: 258_000,
         }}
+        onCompact={null}
       />,
     );
     fireEvent.click(
@@ -349,7 +353,7 @@ describe("ContextUsageChip", () => {
   });
 
   it("updates the pinned context usage setting from the popover action", async () => {
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -381,7 +385,7 @@ describe("ContextUsageChip", () => {
   });
 
   it("preserves trigger focus when the popover opens from a pointer action", async () => {
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     const trigger = screen.getByRole("button", {
       name: /Context window 75% left/,
@@ -397,7 +401,7 @@ describe("ContextUsageChip", () => {
   });
 
   it("moves focus to the popover action when the popover opens from keyboard activation", async () => {
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     const trigger = screen.getByRole("button", {
       name: /Context window 75% left/,
@@ -414,7 +418,7 @@ describe("ContextUsageChip", () => {
 
   it("renders the pinned strip when the setting is enabled and reliable usage exists", () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     expect(
       screen.queryByRole("button", {
@@ -443,7 +447,7 @@ describe("ContextUsageChip", () => {
   });
 
   it("keeps detailed popover values on the static text path", async () => {
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -470,6 +474,7 @@ describe("ContextUsageChip", () => {
           totalTokens: 51_000,
           contextTokens: 50_000,
         }}
+        onCompact={null}
       />,
     );
 
@@ -479,7 +484,7 @@ describe("ContextUsageChip", () => {
 
   it("unpins from the inline pinned strip action", () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -498,7 +503,7 @@ describe("ContextUsageChip", () => {
 
   it("moves focus to the restored compact trigger after focused inline unpin", () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     const unpinButton = screen.getByRole("button", {
       name: "Unpin context usage breakdown",
@@ -514,7 +519,7 @@ describe("ContextUsageChip", () => {
 
   it("omits noisy cache rows from the pinned strip when cache values are absent", () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     const strip = screen.getByTestId("context-usage-pinned-strip");
     expect(within(strip).getByText("Used")).toBeTruthy();
@@ -526,7 +531,9 @@ describe("ContextUsageChip", () => {
 
   it("updates the pinned strip from the same usage value", async () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
-    const { rerender } = render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    const { rerender } = render(
+      <ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />,
+    );
 
     expect(queryCompactContextTrigger()).toBeNull();
     expect(screen.getByText("50K / 200K used")).toBeTruthy();
@@ -540,6 +547,7 @@ describe("ContextUsageChip", () => {
           contextTokens: 150_000,
           contextWindow: 200_000,
         }}
+        onCompact={null}
       />,
     );
 
@@ -556,7 +564,9 @@ describe("ContextUsageChip", () => {
   it("updates the pinned percent instantly when reduced motion is requested", () => {
     installReducedMotionPreference(true);
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
-    const { rerender } = render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    const { rerender } = render(
+      <ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />,
+    );
 
     expect(
       screen.getByTestId("context-usage-pinned-percent-value").textContent,
@@ -571,6 +581,7 @@ describe("ContextUsageChip", () => {
           contextTokens: 150_000,
           contextWindow: 200_000,
         }}
+        onCompact={null}
       />,
     );
 
@@ -581,7 +592,7 @@ describe("ContextUsageChip", () => {
 
   it("marks the pinned strip summary and details with container-query collapse classes", () => {
     useSettingsStore.getState().setPinContextUsageBreakdown(true);
-    render(<ContextUsageChip usage={RELIABLE_USAGE} />);
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
 
     expect(
       screen.getByTestId("context-usage-pinned-summary").className,
@@ -589,5 +600,46 @@ describe("ContextUsageChip", () => {
     expect(
       screen.getByTestId("context-usage-pinned-details").className,
     ).toContain("@max-[34rem]:hidden");
+  });
+
+  it("omits the compact action entirely when the harness cannot compact on demand", () => {
+    // Absent, not disabled: a greyed-out control reads as "try again later"
+    // when the truth is that this harness has no manual compaction at all.
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={null} />);
+    expect(screen.queryByTestId("context-usage-compact-action")).toBe(null);
+  });
+
+  it("renders the compact action before the chip and invokes it on click", () => {
+    const onCompact = vi.fn();
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={onCompact} />);
+
+    const action = screen.getByTestId("context-usage-compact-action");
+    const trigger = screen.getByTestId("context-usage-chip");
+    // Leading position, per the composer-dock layout.
+    expect(
+      action.compareDocumentPosition(trigger) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.click(action);
+    expect(onCompact).toHaveBeenCalledTimes(1);
+  });
+
+  it("trails the usage figures with the compact action in the pinned strip", () => {
+    useSettingsStore.getState().setPinContextUsageBreakdown(true);
+    const onCompact = vi.fn();
+    render(<ContextUsageChip usage={RELIABLE_USAGE} onCompact={onCompact} />);
+
+    const strip = screen.getByTestId("context-usage-pinned-strip");
+    const action = within(strip).getByTestId("context-usage-compact-action");
+    const details = within(strip).getByTestId("context-usage-pinned-details");
+    // Pinned, the action sits AFTER the usage data rather than before it.
+    expect(
+      details.compareDocumentPosition(action) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    fireEvent.click(action);
+    expect(onCompact).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/gui-app/src/components/chat/context-usage-chip.tsx
+++ b/clients/gui-app/src/components/chat/context-usage-chip.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useRef, type CSSProperties, type Ref } from "react";
-import { Pin, PinOff } from "lucide-react";
+import { FoldVertical, Pin, PinOff } from "lucide-react";
 import {
   animate,
   useMotionValue,
@@ -35,6 +35,16 @@ interface ContextUsageChipProps {
    * percent isn't a finite number.
    */
   readonly usage: TokenUsage | null;
+  /**
+   * Runs the harness's own compaction. `null` when this session can't be
+   * compacted on demand - either the harness has no compaction at all
+   * (amp, droid, cursor) or it only ever compacts automatically (copilot,
+   * which exposes no manual command). The affordance is then absent rather
+   * than disabled: a greyed-out control reads as "temporarily unavailable"
+   * when the truth is "this harness can't do this", the same fail-closed rule
+   * the chip itself follows when a harness reports no context window.
+   */
+  readonly onCompact: (() => void) | null;
 }
 
 type ContextUsageMeterStyle = CSSProperties & {
@@ -46,7 +56,7 @@ const PINNED_NUMBER_TRANSITION = {
   ease: "easeOut",
 } as const;
 
-export function ContextUsageChip({ usage }: ContextUsageChipProps) {
+export function ContextUsageChip({ usage, onCompact }: ContextUsageChipProps) {
   const preserveFocusOnOpenRef = useRef(false);
   const pinBreakdownActionRef = useRef<HTMLButtonElement>(null);
   const compactTriggerRef = useRef<HTMLButtonElement>(null);
@@ -98,6 +108,7 @@ export function ContextUsageChip({ usage }: ContextUsageChipProps) {
         rows={rows}
         effective={effective}
         onUnpin={unpinFromPinnedStrip}
+        onCompact={onCompact}
         actionRef={pinnedUnpinActionRef}
       />
     );
@@ -111,7 +122,8 @@ export function ContextUsageChip({ usage }: ContextUsageChipProps) {
   };
 
   return (
-    <div className="min-w-0 justify-self-end">
+    <div className="flex min-w-0 items-center gap-0.5 justify-self-end">
+      {onCompact === null ? null : <CompactAction onCompact={onCompact} />}
       <Popover>
         <PopoverTrigger asChild>
           <button
@@ -174,6 +186,42 @@ export function ContextUsageChip({ usage }: ContextUsageChipProps) {
   );
 }
 
+interface CompactActionProps {
+  readonly onCompact: () => void;
+}
+
+/**
+ * Triggers the harness's own compaction from the context surface - the one
+ * place that already reports how much window is left, so the remedy sits with
+ * the reading that motivates it. Never starts a turn mid-flight: while one is
+ * running this queues `/compact` ahead of the rest of the queue, and only runs
+ * it outright when there is nothing to wait for. `self-center` because the
+ * pinned strip lays its usage figures out on a shared text baseline, which a
+ * button box would otherwise be dragged onto.
+ */
+function CompactAction({ onCompact }: CompactActionProps) {
+  return (
+    <TooltipWrapper
+      label="Compact conversation"
+      side="top"
+      sideOffset={6}
+      align={undefined}
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        aria-label="Compact conversation"
+        data-testid="context-usage-compact-action"
+        className="shrink-0 self-center text-muted-foreground hover:text-foreground"
+        onClick={onCompact}
+      >
+        <FoldVertical className="size-3.5" aria-hidden />
+      </Button>
+    </TooltipWrapper>
+  );
+}
+
 interface ContextUsageBreakdownProps {
   readonly rows: readonly ContextUsageRow[];
   readonly effective: EffectiveContextUsage;
@@ -230,6 +278,7 @@ interface ContextUsagePinnedStripProps {
   readonly rows: readonly ContextUsageRow[];
   readonly effective: EffectiveContextUsage;
   readonly onUnpin: (restoreFocus: boolean) => void;
+  readonly onCompact: (() => void) | null;
   readonly actionRef: Ref<HTMLButtonElement>;
 }
 
@@ -237,6 +286,7 @@ function ContextUsagePinnedStrip({
   rows,
   effective,
   onUnpin,
+  onCompact,
   actionRef,
 }: ContextUsagePinnedStripProps) {
   const usedSummary = `${formatContextWindowTokens(effective.used)} / ${formatContextWindowTokens(effective.window)} used`;
@@ -276,6 +326,7 @@ function ContextUsagePinnedStrip({
               <PinnedUsageRow key={row.key} row={row} />
             ))}
           </div>
+          {onCompact === null ? null : <CompactAction onCompact={onCompact} />}
         </div>
         <TooltipWrapper
           label="Unpin context usage breakdown"

--- a/clients/gui-app/src/components/chat/segments/compaction-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/compaction-segment.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, Minimize2 } from "lucide-react";
+import { ChevronDown, ChevronRight, FoldVertical } from "lucide-react";
 import { useState } from "react";
 import { useChatMeasuredBooleanToggle } from "@/components/chat/chat-measured-item-change-context";
 import { cn } from "@/lib/utils";
@@ -53,7 +53,8 @@ function compactionMetricText(
 }
 
 export function CompactionSegment(props: CompactionSegmentProps) {
-  const { status, preTokens, postTokens, durationMs, summary, error } = props;
+  const { status, trigger, preTokens, postTokens, durationMs, summary, error } =
+    props;
   const isStreaming = status === "streaming";
   const [expanded, setExpanded] = useState(false);
   const toggleExpanded = useChatMeasuredBooleanToggle(setExpanded);
@@ -62,6 +63,11 @@ export function CompactionSegment(props: CompactionSegmentProps) {
 
   const hasSummary = !isStreaming && summary !== null && summary.length > 0;
   const ExpandIcon = expanded ? ChevronDown : ChevronRight;
+  // Only `auto` earns a distinct label. A manual compaction is one the user
+  // just asked for, so naming it adds nothing; an automatic one interrupted
+  // them because the window filled up, and that is worth saying. `null` (most
+  // harnesses report no trigger) stays neutral rather than guessing.
+  const isAuto = trigger === "auto";
 
   const labelInner = isStreaming ? (
     <div className="flex items-center gap-2 text-ui-xs text-muted-foreground">
@@ -70,13 +76,13 @@ export function CompactionSegment(props: CompactionSegmentProps) {
         testId={undefined}
         variant={undefined}
       />
-      <span>Compacting…</span>
+      <span>{isAuto ? "Auto-compacting…" : "Compacting…"}</span>
     </div>
   ) : (
     <div className="flex items-center gap-2 text-ui-xs text-muted-foreground">
-      <Minimize2 className="size-3.5 shrink-0" aria-hidden />
+      <FoldVertical className="size-3.5 shrink-0" aria-hidden />
       <span>
-        Compacted
+        {isAuto ? "Auto-compacted" : "Compacted"}
         <span className="text-muted-foreground/80">{metricText}</span>
       </span>
       {hasSummary ? (

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
@@ -119,7 +119,7 @@ function queryCompactContextTrigger() {
 
 function UsageLeafProbe() {
   const usage = useUsageProbeStore((s) => s.usage);
-  return <ContextUsageChip usage={usage} />;
+  return <ContextUsageChip usage={usage} onCompact={null} />;
 }
 
 // ── Stable composer-relevant props (built once, never re-identified) ──────────

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -198,6 +198,13 @@ const EMPTY_BACKGROUND_STOP_TASK_IDS: ReadonlySet<string> = new Set();
 // or double-tap can't fire the compaction twice.
 const COMPACT_ACTION_LOCK_MS = 1500;
 
+/** Per-chat compact-conversation state, keyed by `handle.chatId` - see the comment on `compactConversation`. */
+interface CompactChatState {
+  locked: boolean;
+  lockTimeoutId: number | null;
+  cancelPromotion: (() => void) | null;
+}
+
 interface ChatTileProps {
   node: EpicNodeRef;
   viewTabId: string;
@@ -1428,30 +1435,34 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
   // effect on the host - `deliveryPolicy` only ever branches on
   // `after_safe_point` - it purely decides, client-side, whether the
   // promotion watcher below needs to be armed at all.
-  const compactPromotionCancelRef = useRef<(() => void) | null>(null);
+  //
+  // `ChatTile` is rendered without a `key` on `node.id` (`tile-render.tsx`,
+  // `tab-group-view.tsx`), so switching this slot to a different chat
+  // repoints `handle` in place rather than remounting. State is keyed by
+  // `handle.chatId` rather than held in one shared ref, so compacting chat B
+  // can never clear chat A's click-lock early or cancel A's pending
+  // promotion - each chat's send against `handle.store` (a durable,
+  // registry-owned store that outlives this tile's display of it,
+  // `useChatSessionHandle`) settles on its own regardless of what this slot
+  // repoints to afterward.
+  const compactStateByChatIdRef = useRef(new Map<string, CompactChatState>());
   useEffect(
     () => () => {
-      compactPromotionCancelRef.current?.();
+      for (const state of compactStateByChatIdRef.current.values()) {
+        if (state.lockTimeoutId !== null) {
+          window.clearTimeout(state.lockTimeoutId);
+        }
+        state.cancelPromotion?.();
+      }
     },
     [],
   );
-  const compactActionLockedRef = useRef(false);
-  // `ChatTile` is rendered without a `key` on `node.id` (`tile-render.tsx`,
-  // `tab-group-view.tsx`), so switching this slot to a different chat repoints
-  // `handle` in place rather than remounting - these refs would otherwise
-  // carry state across chats that never share a click. Only the lock resets:
-  // it is a purely local UI debounce for this tile's own button. The pending
-  // promotion is intentionally left running - it tracks a specific send
-  // against `handle.store`, a durable session store the registry keeps alive
-  // independent of tile display (`useChatSessionHandle`), so an in-flight
-  // promotion for the chat the user just navigated away from should still
-  // settle rather than being abandoned mid-flight.
-  useEffect(() => {
-    compactActionLockedRef.current = false;
-  }, [handle]);
   const compactConversation = useCallback(
     (commandName: string): void => {
-      if (!canSendNextStep || compactActionLockedRef.current) return;
+      if (!canSendNextStep) return;
+      const states = compactStateByChatIdRef.current;
+      const existing = states.get(handle.chatId);
+      if (existing?.locked === true) return;
       const sender = userMessageSenderForProfile(profile);
       if (sender === null) return;
       const content = buildSubmittedChatJSONContent(
@@ -1460,10 +1471,16 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       // A cheap re-entrancy guard against a double-click firing two real
       // compactions: the optimistic-queue dedupe only suppresses the second
       // row's on-screen echo, not the frame that already went to the host.
-      compactActionLockedRef.current = true;
-      window.setTimeout(() => {
-        compactActionLockedRef.current = false;
+      const lockTimeoutId = window.setTimeout(() => {
+        const current = states.get(handle.chatId);
+        if (current !== undefined) current.locked = false;
       }, COMPACT_ACTION_LOCK_MS);
+      const state: CompactChatState = {
+        locked: true,
+        lockTimeoutId,
+        cancelPromotion: existing?.cancelPromotion ?? null,
+      };
+      states.set(handle.chatId, state);
       const { activeTurn, queue } = handle.store.getState();
       const runNow = activeTurn === null && queue.items.length === 0;
       const sent = chatActions.sendMessage(
@@ -1473,14 +1490,21 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
         runNow ? "auto" : "after_turn",
       );
       if (sent === null || runNow) return;
-      compactPromotionCancelRef.current?.();
-      compactPromotionCancelRef.current = promoteQueuedMessageToFront({
+      state.cancelPromotion?.();
+      state.cancelPromotion = promoteQueuedMessageToFront({
         store: handle.store,
         messageId: sent.messageId,
         reorder: chatActions.queueReorder,
       });
     },
-    [canSendNextStep, chatActions, handle.store, nextStepSettings, profile],
+    [
+      canSendNextStep,
+      chatActions,
+      handle.chatId,
+      handle.store,
+      nextStepSettings,
+      profile,
+    ],
   );
   const nextStepActions = useMemo(
     () => ({

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -26,6 +26,7 @@ import type {
   ChatRunSettings,
 } from "@traycer/protocol/host/agent/gui/subscribe";
 import type { WorktreeBinding } from "@traycer/protocol/host/worktree-schemas";
+import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import {
   ChatMessages,
   type ChatMessageScrollRequest,
@@ -104,6 +105,12 @@ import {
 import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus-navigation";
 import { cloneChatOnHostSwitch } from "@/lib/commands/actions/clone-chat-on-host-switch";
 import { enqueuePersistChatRunSettings } from "@/lib/chats/chat-run-settings-write-queue";
+import {
+  COMPACT_COMMAND_TEXT,
+  findManualCompactCommand,
+  promoteQueuedMessageToFront,
+} from "@/lib/chats/compact-conversation";
+import { useSlashCommands } from "@/hooks/composer/use-slash-commands";
 import { ChatDeadTileBanner, ChatHostStartingBanner } from "./dead-tile-banner";
 import { useHostQuery } from "@/hooks/host/use-host-query";
 import { useTabHostClient } from "@/hooks/host/use-tab-host-client";
@@ -1398,6 +1405,33 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     },
     [canSendNextStep, chatActions, nextStepSettings, profile],
   );
+  // Runs the harness's own compaction from the context-usage chip. Never
+  // interrupts: with a turn running (or work already queued) `/compact` is
+  // queued and then promoted to the front so it runs next, and only an
+  // otherwise-idle chat compacts outright - queueing there would just park a
+  // one-item queue the user has to release by hand.
+  const compactConversation = useCallback((): void => {
+    if (!canSendNextStep) return;
+    const sender = userMessageSenderForProfile(profile);
+    if (sender === null) return;
+    const content = buildSubmittedChatJSONContent(
+      plainTextPromptContent(COMPACT_COMMAND_TEXT),
+    );
+    const { activeTurn, queue } = handle.store.getState();
+    const runNow = activeTurn === null && queue.items.length === 0;
+    const sent = chatActions.sendMessage(
+      content,
+      sender,
+      nextStepSettings,
+      runNow ? "auto" : "after_turn",
+    );
+    if (sent === null || runNow) return;
+    promoteQueuedMessageToFront({
+      store: handle.store,
+      messageId: sent.messageId,
+      reorder: chatActions.queueReorder,
+    });
+  }, [canSendNextStep, chatActions, handle.store, nextStepSettings, profile]);
   const nextStepActions = useMemo(
     () => ({
       canSend: canSendNextStep,
@@ -1524,8 +1558,23 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     ],
   );
   const usageChip = useMemo(
-    () => <ContextUsageChipForChat handle={handle} />,
-    [handle],
+    () => (
+      <ContextUsageChipForChat
+        handle={handle}
+        harnessId={currentComposerSettings.harnessId}
+        workingDirectories={composerMentionRoots}
+        isActive={isActive}
+        onCompact={canSendNextStep ? compactConversation : null}
+      />
+    ),
+    [
+      canSendNextStep,
+      compactConversation,
+      composerMentionRoots,
+      currentComposerSettings.harnessId,
+      handle,
+      isActive,
+    ],
   );
   // Composer v3 cluster: host select + Workspace rail picker on the left, with
   // the context-usage leaf owning its trailing chip and optional full-width
@@ -1803,9 +1852,32 @@ function findLastAssistantUsage(
 
 function ContextUsageChipForChat(props: {
   readonly handle: ChatSessionStoreHandle;
+  readonly harnessId: GuiHarnessId;
+  readonly workingDirectories: ReadonlyArray<string>;
+  readonly isActive: boolean;
+  readonly onCompact: (() => void) | null;
 }): ReactNode {
   const usage = useStore(props.handle.store, selectContextUsage);
-  return <ContextUsageChip usage={usage} />;
+  const client = useTabHostClient();
+  // Shares the active composer's already-warm command catalog rather than
+  // opening a second subscription: `useKnownSlashCommandNames` fetches the same
+  // query with the same `enabled: isActive` gate, so an active tile pays no
+  // extra RPC and an inactive one still fetches nothing. An inactive tile
+  // therefore shows no compact affordance - it also has no focusable composer
+  // to compact from.
+  const { data: commands } = useSlashCommands("", {
+    hostClient: client,
+    harnessId: props.harnessId,
+    workingDirectories: props.workingDirectories,
+    enabled: props.isActive,
+  });
+  const canCompact = findManualCompactCommand(commands) !== null;
+  return (
+    <ContextUsageChip
+      usage={usage}
+      onCompact={canCompact ? props.onCompact : null}
+    />
+  );
 }
 
 function ChatSessionMessagesSurface(

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -1436,6 +1436,19 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     [],
   );
   const compactActionLockedRef = useRef(false);
+  // `ChatTile` is rendered without a `key` on `node.id` (`tile-render.tsx`,
+  // `tab-group-view.tsx`), so switching this slot to a different chat repoints
+  // `handle` in place rather than remounting - these refs would otherwise
+  // carry state across chats that never share a click. Only the lock resets:
+  // it is a purely local UI debounce for this tile's own button. The pending
+  // promotion is intentionally left running - it tracks a specific send
+  // against `handle.store`, a durable session store the registry keeps alive
+  // independent of tile display (`useChatSessionHandle`), so an in-flight
+  // promotion for the chat the user just navigated away from should still
+  // settle rather than being abandoned mid-flight.
+  useEffect(() => {
+    compactActionLockedRef.current = false;
+  }, [handle]);
   const compactConversation = useCallback(
     (commandName: string): void => {
       if (!canSendNextStep || compactActionLockedRef.current) return;

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -106,7 +106,6 @@ import { useEpicNestedFocusNavigation } from "@/hooks/epic/use-epic-nested-focus
 import { cloneChatOnHostSwitch } from "@/lib/commands/actions/clone-chat-on-host-switch";
 import { enqueuePersistChatRunSettings } from "@/lib/chats/chat-run-settings-write-queue";
 import {
-  COMPACT_COMMAND_TEXT,
   findManualCompactCommand,
   promoteQueuedMessageToFront,
 } from "@/lib/chats/compact-conversation";
@@ -194,6 +193,10 @@ import { SurfaceActivityProvider } from "@/components/home/composer/surface-acti
 
 const EMPTY_WORKSPACE_PATH_SET: ReadonlySet<string> = new Set();
 const EMPTY_BACKGROUND_STOP_TASK_IDS: ReadonlySet<string> = new Set();
+// How long a compact-conversation click stays locked out against a repeat
+// click. Not tied to the send settling - just long enough that a double-click
+// or double-tap can't fire the compaction twice.
+const COMPACT_ACTION_LOCK_MS = 1500;
 
 interface ChatTileProps {
   node: EpicNodeRef;
@@ -953,6 +956,18 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     mentionRoots,
     !isFolderlessWorkspace,
   );
+  // The exact roots the active composer resolves to for slash-command
+  // discovery (`ChatComposerImpl` derives the same value internally from
+  // `composerMentionRoots` + this same fallback flag). The context-usage
+  // chip's own catalog lookup shares this rather than the raw
+  // `composerMentionRoots`, so it lands on the SAME `agent.gui.listCommands`
+  // cache entry the composer already warmed instead of opening a second one
+  // with a different (and, on a folder-fallback chat, narrower) working
+  // directory set.
+  const resolvedComposerMentionRoots = useWorkspaceMentionRoots(
+    composerMentionRoots,
+    !isFolderlessWorkspace,
+  );
   // The composer is runnable when the chat carries its own folder binding OR
   // when the epic has at least one workspace folder (the chat then runs local
   // against it). The workspace selector itself stays owner-scoped to the
@@ -1406,32 +1421,54 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     [canSendNextStep, chatActions, nextStepSettings, profile],
   );
   // Runs the harness's own compaction from the context-usage chip. Never
-  // interrupts: with a turn running (or work already queued) `/compact` is
-  // queued and then promoted to the front so it runs next, and only an
-  // otherwise-idle chat compacts outright - queueing there would just park a
-  // one-item queue the user has to release by hand.
-  const compactConversation = useCallback((): void => {
-    if (!canSendNextStep) return;
-    const sender = userMessageSenderForProfile(profile);
-    if (sender === null) return;
-    const content = buildSubmittedChatJSONContent(
-      plainTextPromptContent(COMPACT_COMMAND_TEXT),
-    );
-    const { activeTurn, queue } = handle.store.getState();
-    const runNow = activeTurn === null && queue.items.length === 0;
-    const sent = chatActions.sendMessage(
-      content,
-      sender,
-      nextStepSettings,
-      runNow ? "auto" : "after_turn",
-    );
-    if (sent === null || runNow) return;
-    promoteQueuedMessageToFront({
-      store: handle.store,
-      messageId: sent.messageId,
-      reorder: chatActions.queueReorder,
-    });
-  }, [canSendNextStep, chatActions, handle.store, nextStepSettings, profile]);
+  // interrupts: with a turn running (or work already queued) the compact
+  // command is queued and then promoted to the front so it runs next, and
+  // only an otherwise-idle chat compacts outright - queueing there would just
+  // park a one-item queue the user has to release by hand. `runNow` has no
+  // effect on the host - `deliveryPolicy` only ever branches on
+  // `after_safe_point` - it purely decides, client-side, whether the
+  // promotion watcher below needs to be armed at all.
+  const compactPromotionCancelRef = useRef<(() => void) | null>(null);
+  useEffect(
+    () => () => {
+      compactPromotionCancelRef.current?.();
+    },
+    [],
+  );
+  const compactActionLockedRef = useRef(false);
+  const compactConversation = useCallback(
+    (commandName: string): void => {
+      if (!canSendNextStep || compactActionLockedRef.current) return;
+      const sender = userMessageSenderForProfile(profile);
+      if (sender === null) return;
+      const content = buildSubmittedChatJSONContent(
+        plainTextPromptContent(`/${commandName}`),
+      );
+      // A cheap re-entrancy guard against a double-click firing two real
+      // compactions: the optimistic-queue dedupe only suppresses the second
+      // row's on-screen echo, not the frame that already went to the host.
+      compactActionLockedRef.current = true;
+      window.setTimeout(() => {
+        compactActionLockedRef.current = false;
+      }, COMPACT_ACTION_LOCK_MS);
+      const { activeTurn, queue } = handle.store.getState();
+      const runNow = activeTurn === null && queue.items.length === 0;
+      const sent = chatActions.sendMessage(
+        content,
+        sender,
+        nextStepSettings,
+        runNow ? "auto" : "after_turn",
+      );
+      if (sent === null || runNow) return;
+      compactPromotionCancelRef.current?.();
+      compactPromotionCancelRef.current = promoteQueuedMessageToFront({
+        store: handle.store,
+        messageId: sent.messageId,
+        reorder: chatActions.queueReorder,
+      });
+    },
+    [canSendNextStep, chatActions, handle.store, nextStepSettings, profile],
+  );
   const nextStepActions = useMemo(
     () => ({
       canSend: canSendNextStep,
@@ -1562,7 +1599,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
       <ContextUsageChipForChat
         handle={handle}
         harnessId={currentComposerSettings.harnessId}
-        workingDirectories={composerMentionRoots}
+        workingDirectories={resolvedComposerMentionRoots}
         isActive={isActive}
         onCompact={canSendNextStep ? compactConversation : null}
       />
@@ -1570,7 +1607,7 @@ function useChatTileSessionViewModel(props: ChatTileSessionViewProps) {
     [
       canSendNextStep,
       compactConversation,
-      composerMentionRoots,
+      resolvedComposerMentionRoots,
       currentComposerSettings.harnessId,
       handle,
       isActive,
@@ -1855,29 +1892,33 @@ function ContextUsageChipForChat(props: {
   readonly harnessId: GuiHarnessId;
   readonly workingDirectories: ReadonlyArray<string>;
   readonly isActive: boolean;
-  readonly onCompact: (() => void) | null;
+  readonly onCompact: ((commandName: string) => void) | null;
 }): ReactNode {
   const usage = useStore(props.handle.store, selectContextUsage);
   const client = useTabHostClient();
-  // Shares the active composer's already-warm command catalog rather than
-  // opening a second subscription: `useKnownSlashCommandNames` fetches the same
-  // query with the same `enabled: isActive` gate, so an active tile pays no
-  // extra RPC and an inactive one still fetches nothing. An inactive tile
-  // therefore shows no compact affordance - it also has no focusable composer
-  // to compact from.
+  // `workingDirectories` is the composer's own resolved mention roots
+  // (`resolvedComposerMentionRoots` in the parent), not the raw chat binding -
+  // that's what makes this the SAME `agent.gui.listCommands` cache entry
+  // `useKnownSlashCommandNames` already warms, not just a query sharing its
+  // `enabled: isActive` gate. An active tile therefore pays no extra RPC, and
+  // an inactive one still fetches nothing and shows no compact affordance - it
+  // also has no focusable composer to compact from.
   const { data: commands } = useSlashCommands("", {
     hostClient: client,
     harnessId: props.harnessId,
     workingDirectories: props.workingDirectories,
     enabled: props.isActive,
   });
-  const canCompact = findManualCompactCommand(commands) !== null;
-  return (
-    <ContextUsageChip
-      usage={usage}
-      onCompact={canCompact ? props.onCompact : null}
-    />
-  );
+  const compactCommand = findManualCompactCommand(commands);
+  const requestCompact = props.onCompact;
+  // The catalog is matched on `providerKind`, not on name (a differently
+  // named compaction command is what this is for), so the literal text this
+  // sends has to come from the matched command rather than a hardcoded guess.
+  const onCompact =
+    compactCommand === null || requestCompact === null
+      ? null
+      : () => requestCompact(compactCommand.name);
+  return <ContextUsageChip usage={usage} onCompact={onCompact} />;
 }
 
 function ChatSessionMessagesSurface(

--- a/clients/gui-app/src/lib/chats/__tests__/compact-conversation.test.ts
+++ b/clients/gui-app/src/lib/chats/__tests__/compact-conversation.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type {
+  ChatQueuedItem,
+  ChatQueueState,
+} from "@traycer/protocol/host/agent/gui/subscribe";
+import type { GuiAgentCommandOption } from "@traycer/protocol/host/index";
+
+import {
+  findManualCompactCommand,
+  promoteQueuedMessageToFront,
+} from "@/lib/chats/compact-conversation";
+import { optimisticQueuedItemId } from "@/stores/chats/optimistic-queue";
+
+function command(
+  name: string,
+  metadata: Record<string, unknown>,
+): GuiAgentCommandOption {
+  return {
+    harnessId: "claude",
+    name,
+    description: "",
+    argumentHint: null,
+    kind: "slash-command",
+    metadata,
+  };
+}
+
+function queuedItem(queueItemId: string, messageId: string): ChatQueuedItem {
+  return {
+    queueItemId,
+    messageId,
+    message: { kind: "user", content: { type: "doc", content: [] } },
+    sender: { type: "user", userId: "u1" },
+    settings: {
+      harnessId: "claude",
+      model: "claude-opus-5",
+      permissionMode: "supervised",
+      reasoningEffort: null,
+      serviceTier: null,
+      agentMode: "regular",
+      profileId: null,
+    },
+    accountContext: { type: "PERSONAL" },
+    delivery: "next_turn",
+    status: "pending",
+    targetTurnId: null,
+    steerRequest: null,
+    fallbackReason: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function queue(items: ReadonlyArray<ChatQueuedItem>): ChatQueueState {
+  return { status: "running", items: [...items] };
+}
+
+/** Minimal zustand-shaped store: the helper only ever reads `queue`. */
+function makeStore(initial: ChatQueueState) {
+  let state = { queue: initial };
+  const listeners = new Set<(next: { queue: ChatQueueState }) => void>();
+  return {
+    getState: () => state,
+    subscribe: (listener: (next: { queue: ChatQueueState }) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    push: (next: ChatQueueState) => {
+      state = { queue: next };
+      for (const listener of [...listeners]) listener(state);
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+describe("findManualCompactCommand", () => {
+  it("matches the providerKind marker, not the command name", () => {
+    // Name alone is not the contract: a harness could expose a differently
+    // named compaction command, and a user skill could be called "compact".
+    const commands = [
+      command("compact", { providerKind: "skill" }),
+      command("summarise", { providerKind: "compaction" }),
+    ];
+    expect(findManualCompactCommand(commands)?.name).toBe("summarise");
+  });
+
+  it("returns null for an auto-only harness that advertises no command", () => {
+    // Copilot's shape: it compacts on its own and exposes nothing to invoke.
+    const commands = [command("explain", { providerKind: "skill" })];
+    expect(findManualCompactCommand(commands)).toBe(null);
+  });
+});
+
+describe("promoteQueuedMessageToFront", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for the authoritative item before reordering", () => {
+    // The optimistic row carries a synthetic id the host has never seen, so
+    // reordering against it would target nothing. This is the whole reason the
+    // promotion cannot be issued inline with the send.
+    const store = makeStore(
+      queue([
+        queuedItem("q-existing", "m-existing"),
+        queuedItem(optimisticQueuedItemId("action-1"), "m-compact"),
+      ]),
+    );
+    const reorder = vi.fn(() => "ok");
+
+    promoteQueuedMessageToFront({ store, messageId: "m-compact", reorder });
+    expect(reorder).not.toHaveBeenCalled();
+
+    store.push(
+      queue([
+        queuedItem("q-existing", "m-existing"),
+        queuedItem("q-compact", "m-compact"),
+      ]),
+    );
+    expect(reorder).toHaveBeenCalledExactlyOnceWith("q-compact", "q-existing");
+  });
+
+  it("stops watching once the reorder is issued", () => {
+    const store = makeStore(
+      queue([queuedItem(optimisticQueuedItemId("a"), "m-compact")]),
+    );
+    const reorder = vi.fn(() => "ok");
+    promoteQueuedMessageToFront({ store, messageId: "m-compact", reorder });
+
+    store.push(
+      queue([
+        queuedItem("q-first", "m-other"),
+        queuedItem("q-compact", "m-compact"),
+      ]),
+    );
+    expect(reorder).toHaveBeenCalledTimes(1);
+    expect(store.listenerCount()).toBe(0);
+
+    // A later queue change must not re-issue a second reorder.
+    store.push(
+      queue([
+        queuedItem("q-compact", "m-compact"),
+        queuedItem("q-first", "m-other"),
+      ]),
+    );
+    expect(reorder).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when the message is already first", () => {
+    const store = makeStore(
+      queue([
+        queuedItem("q-compact", "m-compact"),
+        queuedItem("q-other", "m-other"),
+      ]),
+    );
+    const reorder = vi.fn(() => "ok");
+    promoteQueuedMessageToFront({ store, messageId: "m-compact", reorder });
+    expect(reorder).not.toHaveBeenCalled();
+    expect(store.listenerCount()).toBe(0);
+  });
+
+  it("never aims at another send's optimistic row", () => {
+    // A concurrent send's optimistic row sits ahead of ours. Using it as
+    // `beforeQueueItemId` would be rejected host-side, so it is skipped and
+    // the first authoritative row is targeted instead.
+    const store = makeStore(
+      queue([
+        queuedItem(optimisticQueuedItemId("other"), "m-other"),
+        queuedItem("q-real", "m-real"),
+        queuedItem("q-compact", "m-compact"),
+      ]),
+    );
+    const reorder = vi.fn(() => "ok");
+    promoteQueuedMessageToFront({ store, messageId: "m-compact", reorder });
+    expect(reorder).toHaveBeenCalledExactlyOnceWith("q-compact", "q-real");
+  });
+
+  it("gives up quietly if the host never acknowledges the send", () => {
+    // Failure leaves the message queued at the back rather than reordered -
+    // a worse position, never a lost message.
+    const store = makeStore(
+      queue([queuedItem(optimisticQueuedItemId("a"), "m-compact")]),
+    );
+    const reorder = vi.fn(() => "ok");
+    promoteQueuedMessageToFront({ store, messageId: "m-compact", reorder });
+
+    vi.advanceTimersByTime(15_000);
+    expect(store.listenerCount()).toBe(0);
+
+    store.push(queue([queuedItem("q-compact", "m-compact")]));
+    expect(reorder).not.toHaveBeenCalled();
+  });
+
+  it("can be cancelled by the caller", () => {
+    const store = makeStore(
+      queue([queuedItem(optimisticQueuedItemId("a"), "m-compact")]),
+    );
+    const reorder = vi.fn(() => "ok");
+    const cancel = promoteQueuedMessageToFront({
+      store,
+      messageId: "m-compact",
+      reorder,
+    });
+
+    cancel();
+    expect(store.listenerCount()).toBe(0);
+
+    store.push(
+      queue([
+        queuedItem("q-other", "m-other"),
+        queuedItem("q-compact", "m-compact"),
+      ]),
+    );
+    expect(reorder).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/lib/chats/__tests__/compact-conversation.test.ts
+++ b/clients/gui-app/src/lib/chats/__tests__/compact-conversation.test.ts
@@ -194,6 +194,34 @@ describe("promoteQueuedMessageToFront", () => {
     expect(reorder).not.toHaveBeenCalled();
   });
 
+  it("does not re-filter the queue when the reference is unchanged", () => {
+    // The watch fires on every store notification, including the rAF-cadence
+    // stream-flush delta while a turn runs - none of which touch `queue`.
+    // This pins the reference-equality gate that keeps those from re-running
+    // attempt()'s filter+scan.
+    const items = [queuedItem(optimisticQueuedItemId("a"), "m-compact")];
+    const filterSpy = vi.spyOn(items, "filter");
+    const q: ChatQueueState = { status: "running", items };
+    const store = makeStore(q);
+    const reorder = vi.fn(() => "ok");
+    promoteQueuedMessageToFront({ store, messageId: "m-compact", reorder });
+    filterSpy.mockClear();
+
+    // Same reference: the gate should skip attempt() entirely.
+    store.push(q);
+    expect(filterSpy).not.toHaveBeenCalled();
+    expect(reorder).not.toHaveBeenCalled();
+
+    // A genuinely new queue reference still gets scanned and reordered.
+    store.push(
+      queue([
+        queuedItem("q-other", "m-other"),
+        queuedItem("q-compact", "m-compact"),
+      ]),
+    );
+    expect(reorder).toHaveBeenCalledExactlyOnceWith("q-compact", "q-other");
+  });
+
   it("can be cancelled by the caller", () => {
     const store = makeStore(
       queue([queuedItem(optimisticQueuedItemId("a"), "m-compact")]),

--- a/clients/gui-app/src/lib/chats/compact-conversation.ts
+++ b/clients/gui-app/src/lib/chats/compact-conversation.ts
@@ -1,0 +1,116 @@
+import type { GuiAgentCommandOption } from "@traycer/protocol/host/index";
+import type {
+  ChatQueuedItem,
+  ChatQueueState,
+} from "@traycer/protocol/host/agent/gui/subscribe";
+
+import { isOptimisticQueuedItem } from "@/stores/chats/optimistic-queue";
+
+/** The literal prompt every compaction-capable harness parses as its own command. */
+export const COMPACT_COMMAND_TEXT = "/compact";
+
+/**
+ * Whether the user can trigger compaction on this harness, as opposed to the
+ * harness only ever compacting on its own.
+ *
+ * `providerKind: "compaction"` is the marker every adapter stamps on its native
+ * compaction command - hardcoded for codex/opencode/traycer/openrouter/omp/pi,
+ * derived from the ACP handshake list for grok/kimi/kiro/qwen/kilocode/hermes/
+ * devin, and from the SDK command catalog for claude.
+ *
+ * Copilot deliberately reads `false`: it compacts automatically and advertises
+ * no command, so it supports compaction but not on demand. amp, droid and
+ * cursor have no compaction at all.
+ */
+export function findManualCompactCommand(
+  commands: ReadonlyArray<GuiAgentCommandOption>,
+): GuiAgentCommandOption | null {
+  return (
+    commands.find(
+      (command) => command.metadata.providerKind === "compaction",
+    ) ?? null
+  );
+}
+
+/**
+ * How long to wait for the host to acknowledge a freshly queued message before
+ * giving up on reordering it. Generous: the only cost of waiting is that the
+ * message sits at the back of the queue for longer than intended.
+ */
+const QUEUE_PROMOTION_TIMEOUT_MS = 15_000;
+
+function isAuthoritative(item: ChatQueuedItem): boolean {
+  return !isOptimisticQueuedItem(item);
+}
+
+/**
+ * Moves a just-sent queued message to the front of the queue.
+ *
+ * `sendMessage` appends its item optimistically and the host assigns the real
+ * `queueItemId` only when the `queueChanged` frame lands, so the reorder cannot
+ * be issued inline - `queueReorder` against an optimistic id has no server-side
+ * target. This watches the queue until the authoritative item appears, issues a
+ * single reorder, and stops.
+ *
+ * Failure is deliberately inert: if the frame never arrives the watch expires
+ * and the message simply stays where it was queued - last rather than first,
+ * which is a worse ordering but never a lost or duplicated message.
+ *
+ * Returns a cancel function; call it if the surface unmounts first.
+ */
+export function promoteQueuedMessageToFront<
+  TState extends { readonly queue: ChatQueueState },
+>(input: {
+  /**
+   * Structural rather than the concrete `ChatSessionStoreHandle["store"]`: this
+   * only ever reads `queue`, and narrowing the surface is what lets the tests
+   * drive it without standing up a whole chat session.
+   */
+  readonly store: {
+    readonly getState: () => TState;
+    readonly subscribe: (listener: (state: TState) => void) => () => void;
+  };
+  readonly messageId: string;
+  readonly reorder: (
+    queueItemId: string,
+    beforeQueueItemId: string | null,
+  ) => string | null;
+}): () => void {
+  let settled = false;
+  let unsubscribe: (() => void) | null = null;
+  let timer: number | null = null;
+
+  const finish = (): void => {
+    if (settled) return;
+    settled = true;
+    if (timer !== null) window.clearTimeout(timer);
+    unsubscribe?.();
+  };
+
+  // Returns true once there is nothing further to do - either the reorder was
+  // issued, or the message is already first, or it can never be reordered.
+  const attempt = (state: TState): boolean => {
+    // Optimistic rows are skipped on BOTH sides: our own row is unreorderable
+    // until the host names it, and an optimistic row belonging to some other
+    // in-flight send is an invalid `beforeQueueItemId` to aim at.
+    const settledItems = state.queue.items.filter(isAuthoritative);
+    const index = settledItems.findIndex(
+      (item) => item.messageId === input.messageId,
+    );
+    if (index === -1) return false;
+    // Index >= 1 guarantees a distinct item at 0 to insert ahead of.
+    if (index === 0) return true;
+    input.reorder(settledItems[index].queueItemId, settledItems[0].queueItemId);
+    return true;
+  };
+
+  unsubscribe = input.store.subscribe((state) => {
+    if (settled) return;
+    if (attempt(state)) finish();
+  });
+  timer = window.setTimeout(finish, QUEUE_PROMOTION_TIMEOUT_MS);
+  // The host may already have acknowledged the send by the time this runs.
+  if (attempt(input.store.getState())) finish();
+
+  return finish;
+}

--- a/clients/gui-app/src/lib/chats/compact-conversation.ts
+++ b/clients/gui-app/src/lib/chats/compact-conversation.ts
@@ -6,9 +6,6 @@ import type {
 
 import { isOptimisticQueuedItem } from "@/stores/chats/optimistic-queue";
 
-/** The literal prompt every compaction-capable harness parses as its own command. */
-export const COMPACT_COMMAND_TEXT = "/compact";
-
 /**
  * Whether the user can trigger compaction on this harness, as opposed to the
  * harness only ever compacting on its own.
@@ -56,6 +53,13 @@ function isAuthoritative(item: ChatQueuedItem): boolean {
  * and the message simply stays where it was queued - last rather than first,
  * which is a worse ordering but never a lost or duplicated message.
  *
+ * The reorder can also land after its target has drained (the turn ends and
+ * the host works through the head of the queue between the read below and the
+ * frame arriving). The host's own reorder handler falls back to appending at
+ * the end when `beforeQueueItemId` no longer exists, so in that narrow window
+ * the message can end up behind work queued after the promotion was
+ * requested - bounded and rare, never lost or duplicated.
+ *
  * Returns a cancel function; call it if the surface unmounts first.
  */
 export function promoteQueuedMessageToFront<
@@ -98,14 +102,24 @@ export function promoteQueuedMessageToFront<
       (item) => item.messageId === input.messageId,
     );
     if (index === -1) return false;
-    // Index >= 1 guarantees a distinct item at 0 to insert ahead of.
+    // Index >= 1 guarantees a distinct item at 0 to insert ahead of, right
+    // now - see the reorder-can-land-late note above for what can change
+    // between this read and the frame reaching the host.
     if (index === 0) return true;
     input.reorder(settledItems[index].queueItemId, settledItems[0].queueItemId);
     return true;
   };
 
+  // The store has no `subscribeWithSelector`, so this fires on every state
+  // change - including the rAF-cadence stream-flush delta while a turn is
+  // running. `queue` is only ever replaced wholesale on a real queue
+  // mutation, so a reference check skips `attempt()`'s filter+scan on every
+  // unrelated notification for the (up to 15s) life of the watch.
+  let lastQueue = input.store.getState().queue;
   unsubscribe = input.store.subscribe((state) => {
     if (settled) return;
+    if (state.queue === lastQueue) return;
+    lastQueue = state.queue;
     if (attempt(state)) finish();
   });
   timer = window.setTimeout(finish, QUEUE_PROMOTION_TIMEOUT_MS);


### PR DESCRIPTION
## Summary
- Adds a manual "compact now" affordance to the context-usage chip, gated on the harness's command catalog advertising a `providerKind: "compaction"` command (present for claude, codex, opencode/traycer/openrouter, omp, pi, and the six ACP-based harnesses; absent for auto-only copilot and no-compaction amp/droid/cursor). Placed left of the chip trigger when unpinned, at the end of the usage figures in the pinned strip.
- The action queues the harness's compaction command and promotes it to the front of the queue when a turn is running or work is already queued, and runs it outright when idle. Promotion can't be issued inline (the host only assigns the real `queueItemId` once its `queueChanged` frame lands), so `promoteQueuedMessageToFront` watches the queue for the authoritative row and reorders once, giving up inertly (never losing or duplicating the message) if that never arrives within 15s.
- Switches `CompactionSegment`'s icon from `Minimize2` to `FoldVertical` (the prior glyph collided with the segment's own adjacent collapse chevron) and renders its previously-dropped `trigger` prop so an auto-triggered compaction reads differently from a manual one.
- Follow-up commit addresses findings from a cold review of the above: shares the composer's resolved mention-roots (was opening a second `agent.gui.listCommands` call, and on Claude a second CLI spawn), gates the queue watcher on the queue's own object reference (was re-scanning on every stream-flush tick), cleans up the watcher on unmount, sends the matched command's actual name instead of a hardcoded `/compact`, adds a double-click guard, and corrects two comments that overstated guarantees (`deliveryPolicy` has no effect on queue-vs-run; a promoted reorder can still land behind newer work in a narrow race).

## Test plan
- [x] `bun run compile` (submodule graph) — clean
- [x] `bun run lint` (gui-app) — clean
- [x] Full `gui-app` test suite — 7,168 passed, 1 skipped, no regressions
- [x] New/updated tests: `compact-conversation.test.ts` (capability lookup, queue promotion, reference-equality gate), `context-usage-chip.test.tsx` (action gating + placement)