### PR TITLE
fix(gui-app): recover dead action buttons after sleep/wake

### DIFF
--- a/clients/gui-app/src/components/layout/bridges/chat-session-wake-retry-controller.tsx
+++ b/clients/gui-app/src/components/layout/bridges/chat-session-wake-retry-controller.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from "react";
+import { subscribeChatSessionWakeRetry } from "@/lib/chats/chat-session-wake-retry";
+import { useRunnerHostOrNull } from "@/providers/use-runner-host";
+
+/**
+ * Revives terminally-closed warm chat sessions on OS wake. The durable
+ * transport already force-reconnects every LIVE session on the wake pulse, but
+ * a session whose stream went terminal (`connectionStatus === "closed"`) has
+ * no timer left and no retry affordance while its snapshot is on screen - its
+ * composer / next-steps / approvals stayed dead until an app relaunch. This
+ * bridge gives each such session one fresh dial per wake. Mounted once at the
+ * app root OUTSIDE `HostReadyGate` (it needs only the runner host + the
+ * module-global registry): warm sessions outlive the gate, so the listener
+ * must too, or a wake landing during a host-unavailable window is silently
+ * missed and never replayed.
+ */
+export function ChatSessionWakeRetryController() {
+  const runnerHost = useRunnerHostOrNull();
+  useEffect(() => {
+    return subscribeChatSessionWakeRetry(runnerHost);
+  }, [runnerHost]);
+  return null;
+}

--- a/clients/gui-app/src/lib/__tests__/query-client.test.ts
+++ b/clients/gui-app/src/lib/__tests__/query-client.test.ts
@@ -1,0 +1,46 @@
+import { MutationObserver, onlineManager } from "@tanstack/react-query";
+import { afterEach, describe, expect, it } from "vitest";
+import { createAppQueryClient } from "@/lib/query-client";
+
+// Regression coverage for the wake-from-sleep freeze: Chromium can report
+// `navigator.onLine === false` indefinitely after an OS sleep/wake in the
+// desktop shell, and under TanStack's default `networkMode: "online"` that
+// silently parked every query (`fetchStatus: "paused"`) and every mutation
+// (paused-pending) until the app was relaunched - send / next-steps buttons
+// went inert while the stream layer (wired to the OS resume pulse) kept
+// flowing. The app's `networkMode: "always"` default must keep both running
+// regardless of what the browser thinks connectivity is; host RPCs target the
+// loopback host anyway.
+describe("createAppQueryClient while the browser reports offline", () => {
+  afterEach(() => {
+    onlineManager.setOnline(true);
+  });
+
+  it("still fetches queries", async () => {
+    onlineManager.setOnline(false);
+    const client = createAppQueryClient();
+    const result = await client.fetchQuery({
+      queryKey: ["offline-regression", "query"],
+      queryFn: () => Promise.resolve("fetched"),
+    });
+    expect(result).toBe("fetched");
+    expect(
+      client.getQueryCache().find({
+        queryKey: ["offline-regression", "query"],
+      })?.state.fetchStatus,
+    ).not.toBe("paused");
+  });
+
+  it("still runs mutations instead of pausing them", async () => {
+    onlineManager.setOnline(false);
+    const client = createAppQueryClient();
+    const observer = new MutationObserver(client, {
+      mutationFn: () => Promise.resolve("sent"),
+    });
+    const mutation = observer.mutate();
+    // The paused-pending state is the dead-button symptom: `mutate()` accepted
+    // the click but nothing will ever run until connectivity is re-reported.
+    expect(observer.getCurrentResult().isPaused).toBe(false);
+    await expect(mutation).resolves.toBe("sent");
+  });
+});

--- a/clients/gui-app/src/lib/chats/__tests__/chat-session-wake-retry.test.ts
+++ b/clients/gui-app/src/lib/chats/__tests__/chat-session-wake-retry.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import type { ChatStreamCallbacks } from "@traycer-clients/shared/host-transport/chat-stream-client";
+import {
+  createChatSessionStore,
+  type ChatSessionStoreHandle,
+} from "@/stores/chats/chat-session-store";
+import { IMMEDIATE_STREAM_FLUSH_COORDINATOR } from "@/stores/chats/stream-flush-coordinator";
+import {
+  __getChatSessionRegistryForTests,
+  disposeAllChatSessions,
+} from "@/lib/registries/chat-session-registry";
+import {
+  retryClosedChatSessions,
+  subscribeChatSessionWakeRetry,
+  WAKE_RETRY_EPISODE_MS,
+} from "@/lib/chats/chat-session-wake-retry";
+
+const EPIC_ID = "epic-wake";
+const CHAT_ID = "chat-wake";
+
+interface Harness {
+  readonly handle: ChatSessionStoreHandle;
+  readonly factoryRuns: () => number;
+  readonly callbacks: () => ChatStreamCallbacks;
+  /** Makes the NEXT factory invocation throw (one-shot). */
+  readonly failNextFactoryRun: () => void;
+}
+
+function createHarness(chatId: string): Harness {
+  let runs = 0;
+  let failNext = false;
+  let lastCallbacks: ChatStreamCallbacks | null = null;
+  const handle = createChatSessionStore({
+    epicId: EPIC_ID,
+    chatId,
+    userId: "user-wake",
+    onAuthError: null,
+    onProviderAuthError: null,
+    streamFlushCoordinator: IMMEDIATE_STREAM_FLUSH_COORDINATOR,
+    streamClientFactory: (_epicId, _chatId, nextCallbacks) => {
+      runs += 1;
+      if (failNext) {
+        failNext = false;
+        throw new Error("transport wiring failed");
+      }
+      lastCallbacks = nextCallbacks;
+      return {
+        sendAction: () => undefined,
+        sameTurnSteeringProtocolSupported: () => false,
+        close: () => undefined,
+      };
+    },
+  });
+  return {
+    handle,
+    factoryRuns: () => runs,
+    callbacks: () => {
+      if (lastCallbacks === null) throw new Error("Expected callbacks");
+      return lastCallbacks;
+    },
+    failNextFactoryRun: () => {
+      failNext = true;
+    },
+  };
+}
+
+function driveTerminallyClosed(harness: Harness): void {
+  harness.callbacks().onConnectionStatus("closed", {
+    kind: "fatalError",
+    details: {
+      code: "UNAUTHORIZED",
+      reason: "no-progress UNAUTHORIZED reconnects exhausted",
+      incompatibleMethods: null,
+      upgradeGuidance: null,
+    },
+  });
+}
+
+function makeRunnerHost(): MockRunnerHost {
+  return new MockRunnerHost({
+    signInUrl: "https://auth.traycer.invalid/sign-in",
+    authnBaseUrl: "http://localhost:5005",
+    localHost: null,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+}
+
+afterEach(() => {
+  disposeAllChatSessions();
+  vi.restoreAllMocks();
+});
+
+describe("retryClosedChatSessions", () => {
+  it("re-dials a terminally closed session and clears its fatal close", () => {
+    const harness = createHarness(CHAT_ID);
+    driveTerminallyClosed(harness);
+    expect(harness.handle.store.getState().connectionStatus).toBe("closed");
+    expect(harness.factoryRuns()).toBe(1);
+
+    const attempted = retryClosedChatSessions([harness.handle], "wake-resume");
+
+    expect(attempted).toEqual([harness.handle]);
+    expect(harness.factoryRuns()).toBe(2);
+    expect(harness.handle.store.getState().connectionStatus).toBe("connecting");
+    expect(harness.handle.store.getState().fatalClose).toBeNull();
+    harness.handle.dispose();
+  });
+
+  it("leaves live sessions untouched - only closed ones get the wake dial", () => {
+    const harness = createHarness(CHAT_ID);
+    harness.callbacks().onConnectionStatus("open", null);
+
+    const attempted = retryClosedChatSessions([harness.handle], "wake-resume");
+
+    expect(attempted).toEqual([]);
+    expect(harness.factoryRuns()).toBe(1);
+    expect(harness.handle.store.getState().connectionStatus).toBe("open");
+    harness.handle.dispose();
+  });
+
+  it("contains a throwing retry: the session returns to a retryable closed state and later handles still run", () => {
+    const broken = createHarness("chat-broken");
+    const healthy = createHarness("chat-healthy");
+    driveTerminallyClosed(broken);
+    driveTerminallyClosed(healthy);
+    broken.failNextFactoryRun();
+
+    const attempted = retryClosedChatSessions(
+      [broken.handle, healthy.handle],
+      "wake-resume",
+    );
+
+    // Both were attempted; the broken one is back in "closed" (NOT stranded in
+    // "connecting") with its fatal close preserved, so a later pulse can try
+    // again; the healthy one re-dialed despite the earlier throw.
+    expect(attempted).toEqual([broken.handle, healthy.handle]);
+    expect(broken.handle.store.getState().connectionStatus).toBe("closed");
+    expect(broken.handle.store.getState().fatalClose?.code).toBe(
+      "UNAUTHORIZED",
+    );
+    expect(healthy.handle.store.getState().connectionStatus).toBe("connecting");
+    expect(healthy.factoryRuns()).toBe(2);
+
+    // The broken session is retryable on the next pass.
+    const second = retryClosedChatSessions([broken.handle], "wake-online");
+    expect(second).toEqual([broken.handle]);
+    expect(broken.handle.store.getState().connectionStatus).toBe("connecting");
+    expect(broken.factoryRuns()).toBe(3);
+
+    broken.handle.dispose();
+    healthy.handle.dispose();
+  });
+});
+
+describe("subscribeChatSessionWakeRetry", () => {
+  function wireResumeSpy(runnerHost: MockRunnerHost): {
+    readonly fireResume: () => void;
+    readonly resumeDispose: Mock<() => void>;
+  } {
+    let capturedResume: (() => void) | null = null;
+    const resumeDispose = vi.fn<() => void>();
+    vi.spyOn(runnerHost, "onSystemResumed").mockImplementation((listener) => {
+      capturedResume = listener;
+      return { dispose: resumeDispose };
+    });
+    // Read through a function so the closure-assigned var keeps its declared
+    // type (a direct narrow on the `let` collapses the else-branch to `never`).
+    const fireResume = (): void => {
+      if (capturedResume === null) throw new Error("Expected resume listener");
+      capturedResume();
+    };
+    return { fireResume, resumeDispose };
+  }
+
+  it("retries registry sessions on the OS resume pulse, and detaches on dispose", () => {
+    const runnerHost = makeRunnerHost();
+    const { fireResume, resumeDispose } = wireResumeSpy(runnerHost);
+
+    const harness = createHarness(CHAT_ID);
+    __getChatSessionRegistryForTests().acquire(
+      EPIC_ID,
+      CHAT_ID,
+      "wake-test-scope",
+      () => harness.handle,
+    );
+    driveTerminallyClosed(harness);
+
+    const dispose = subscribeChatSessionWakeRetry(runnerHost);
+
+    fireResume();
+    expect(harness.factoryRuns()).toBe(2);
+    expect(harness.handle.store.getState().connectionStatus).toBe("connecting");
+
+    // A second pulse while the session is no longer closed is a no-op.
+    fireResume();
+    expect(harness.factoryRuns()).toBe(2);
+
+    dispose();
+    expect(resumeDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("folds a burst of wake pulses into one dial per episode for a fast-re-closing session", () => {
+    const runnerHost = makeRunnerHost();
+    const { fireResume } = wireResumeSpy(runnerHost);
+    let nowMs = 1_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+
+    const harness = createHarness(CHAT_ID);
+    __getChatSessionRegistryForTests().acquire(
+      EPIC_ID,
+      CHAT_ID,
+      "wake-test-scope",
+      () => harness.handle,
+    );
+    driveTerminallyClosed(harness);
+
+    const dispose = subscribeChatSessionWakeRetry(runnerHost);
+
+    // Pulse 1 (resume) re-dials; the session immediately goes terminal again
+    // (a permanently fatal close, e.g. INCOMPATIBLE).
+    fireResume();
+    expect(harness.factoryRuns()).toBe(2);
+    driveTerminallyClosed(harness);
+
+    // Pulses 2/3 (unlock-screen fan-out, debounced 'online') land inside the
+    // same wake episode: no additional rebuild.
+    nowMs += 300;
+    fireResume();
+    expect(harness.factoryRuns()).toBe(2);
+
+    // The next physical wake (outside the episode window) dials again.
+    nowMs += WAKE_RETRY_EPISODE_MS;
+    fireResume();
+    expect(harness.factoryRuns()).toBe(3);
+
+    dispose();
+  });
+});

--- a/clients/gui-app/src/lib/chats/chat-session-wake-retry.ts
+++ b/clients/gui-app/src/lib/chats/chat-session-wake-retry.ts
@@ -1,0 +1,111 @@
+import type { ChatSessionStoreHandle } from "@/stores/chats/chat-session-store";
+import { getChatSessionRegistry } from "@/lib/registries/chat-session-registry";
+import {
+  subscribeWakeSignals,
+  type WakeSignalReason,
+} from "@/lib/host/stream-wake-reconnect";
+import { onWakeReconnect } from "@/lib/host/wake-reconnect";
+import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
+import { appLogger, describeLogError } from "@/lib/logger";
+
+/**
+ * One physical wake fans out as several pulses: the desktop shell fires the
+ * resume AND unlock-screen bridges, and the `online` event lands after its own
+ * ~250ms debounce. A live session absorbs that (`forceReconnect` is cheap and
+ * idempotent), but a retry is a full stream-client rebuild, and a permanently
+ * fatal session (e.g. INCOMPATIBLE) re-closes fast enough to be re-attempted
+ * by every pulse. Handles attempted within this window are skipped, folding
+ * the burst into one dial per wake.
+ */
+export const WAKE_RETRY_EPISODE_MS = 5_000;
+
+/**
+ * Re-dials warm chat sessions whose stream went TERMINALLY closed, on the OS
+ * wake pulse. Every non-closed status self-heals on wake (the durable
+ * transport's `subscribeStreamWakeReconnect` force-reconnects live sessions),
+ * but a `closed` session's `StreamSession` is disposed - no timer will ever
+ * fire again - and the tile only surfaces a retry affordance while the
+ * snapshot never loaded. A warm tile (snapshot on screen) whose stream went
+ * terminal during a sleep - e.g. the transport's bounded UNAUTHORIZED give-up,
+ * whose own log says "reload required" - therefore kept its composer, next
+ * steps, and approvals dead until an app relaunch. Waking is exactly the
+ * moment the conditions that killed the stream (frozen timers, an expired
+ * bearer, a half-open authn socket) are gone, so give each dead session one
+ * fresh dial per wake; `retry()` rebuilds the stream client with live deps.
+ * Bounded: a close that is genuinely permanent (e.g. INCOMPATIBLE) re-closes
+ * once per wake episode and goes back to rest.
+ *
+ * Returns the handles that were ATTEMPTED (successfully re-dialed or not), so
+ * the caller can stamp them into the episode window. A throwing `retry()` is
+ * contained per handle - one broken session must not block the rest of the
+ * registry from recovering.
+ */
+export function retryClosedChatSessions(
+  handles: readonly ChatSessionStoreHandle[],
+  reason: WakeSignalReason,
+): ChatSessionStoreHandle[] {
+  const attempted: ChatSessionStoreHandle[] = [];
+  for (const handle of handles) {
+    const state = handle.store.getState();
+    if (state.connectionStatus !== "closed") {
+      continue;
+    }
+    appLogger.info("[chat-session] wake retry for closed session", {
+      reason,
+      epicId: handle.epicId,
+      chatId: handle.chatId,
+      fatalCode: state.fatalClose?.code ?? null,
+    });
+    attempted.push(handle);
+    try {
+      state.retry();
+    } catch (cause) {
+      // `retry()` restored the session to a retryable closed state before
+      // rethrowing; a later pulse can attempt it again.
+      appLogger.warn("[chat-session] wake retry failed", {
+        epicId: handle.epicId,
+        chatId: handle.chatId,
+        error: describeLogError(cause),
+      });
+    }
+  }
+  return attempted;
+}
+
+/**
+ * Wires `retryClosedChatSessions` over the live registry to the two OS-wake
+ * triggers, with the per-wake episode dedupe. Returns a disposer. Mounted once
+ * per window by `ChatSessionWakeRetryController`. The OS-resume wiring is
+ * best-effort (mirroring the auth service's wake refresh): with no runner host
+ * (host-less test harness) or a throwing resume subscription, the `online`
+ * listener alone still nudges dead sessions when the network returns.
+ */
+export function subscribeChatSessionWakeRetry(
+  runnerHost: IRunnerHost | null,
+): () => void {
+  const lastAttemptAt = new WeakMap<ChatSessionStoreHandle, number>();
+  const onWake = (reason: WakeSignalReason): void => {
+    const now = Date.now();
+    const due = getChatSessionRegistry()
+      .listHandles()
+      .filter((handle) => {
+        const last = lastAttemptAt.get(handle);
+        return last === undefined || now - last >= WAKE_RETRY_EPISODE_MS;
+      });
+    for (const handle of retryClosedChatSessions(due, reason)) {
+      lastAttemptAt.set(handle, now);
+    }
+  };
+  if (runnerHost !== null) {
+    try {
+      return subscribeWakeSignals(runnerHost, onWake);
+    } catch (cause) {
+      appLogger.warn("[chat-session] OS-resume wake retry unavailable", {
+        error: describeLogError(cause),
+      });
+    }
+  }
+  return onWakeReconnect(() => {
+    onWake("wake-online");
+  });
+}

--- a/clients/gui-app/src/lib/host/stream-wake-reconnect.ts
+++ b/clients/gui-app/src/lib/host/stream-wake-reconnect.ts
@@ -6,6 +6,42 @@ import { onWakeReconnect } from "@/lib/host/wake-reconnect";
 import { appLogger } from "@/lib/logger";
 import { useRunnerHost } from "@/providers/use-runner-host";
 
+/** The two OS-wake triggers a wake subscriber can fire on. */
+export type WakeSignalReason = "wake-online" | "wake-resume";
+
+/**
+ * Subscribes `onWake` to the two OS-wake triggers - `window 'online'`
+ * (`onWakeReconnect`) and `IRunnerHost.onSystemResumed` (Electron
+ * `powerMonitor` bridged from the shell) - and returns a disposer. The shared
+ * primitive under every renderer-side wake consumer (stream re-dial, closed
+ * chat-session retry), so a new consumer cannot wire only one trigger and miss
+ * the same-network lid-open (`online` never fires) or the web shell (no OS
+ * resume signal).
+ */
+export function subscribeWakeSignals(
+  runnerHost: IRunnerHost,
+  onWake: (reason: WakeSignalReason) => void,
+): () => void {
+  const offOnline = onWakeReconnect(() => {
+    onWake("wake-online");
+  });
+  try {
+    const resumeSubscription = runnerHost.onSystemResumed(() => {
+      onWake("wake-resume");
+    });
+    return () => {
+      offOnline();
+      resumeSubscription.dispose();
+    };
+  } catch (cause) {
+    // Roll back the already-registered 'online' listener if wiring the OS-resume
+    // subscription throws, so a failed open never leaks a dangling reconnect
+    // callback (the disposer is never returned to the caller in that case).
+    offOnline();
+    throw cause;
+  }
+}
+
 /**
  * Non-hook core of the wake-reconnect wiring. Subscribes a stream client to the
  * two OS-wake triggers and returns a disposer. Used directly (not via React) by
@@ -17,29 +53,13 @@ export function subscribeStreamWakeReconnect(
   client: WsStreamClient<HostStreamRpcRegistry>,
   runnerHost: IRunnerHost,
 ): () => void {
-  const offOnline = onWakeReconnect(() => {
-    appLogger.debug("[stream] wake reconnect requested", {
-      reason: "wake-online",
-    });
-    client.reconnectAll("wake-online");
-  });
   try {
-    const resumeSubscription = runnerHost.onSystemResumed(() => {
-      appLogger.debug("[stream] wake reconnect requested", {
-        reason: "wake-resume",
-      });
-      client.reconnectAll("wake-resume");
+    return subscribeWakeSignals(runnerHost, (reason) => {
+      appLogger.debug("[stream] wake reconnect requested", { reason });
+      client.reconnectAll(reason);
     });
-    return () => {
-      offOnline();
-      resumeSubscription.dispose();
-    };
   } catch (cause) {
     appLogger.error("[stream] wake reconnect subscription failed", {}, cause);
-    // Roll back the already-registered 'online' listener if wiring the OS-resume
-    // subscription throws, so a failed open never leaks a dangling reconnect
-    // callback (the disposer is never returned to the caller in that case).
-    offOnline();
     throw cause;
   }
 }

--- a/clients/gui-app/src/lib/query-client.ts
+++ b/clients/gui-app/src/lib/query-client.ts
@@ -63,6 +63,24 @@ export function createAppQueryClient(): QueryClient {
           !(error instanceof RetryableTransportError) && failureCount < 1,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,
+        // Never let `onlineManager` pause work. Its inputs (`navigator.onLine`
+        // + window online/offline events) are exactly the browser signals the
+        // wake-reconnect layer already documents as unreliable in the desktop
+        // shell: after a sleep/wake Chromium can report offline indefinitely,
+        // which under the default `networkMode: "online"` silently parked
+        // every query (`fetchStatus: "paused"`) and every mutation
+        // (paused-pending, so `disabled={isPending}` gates froze) until the
+        // app was relaunched - the whole UI went inert while the streams
+        // (wired to the OS resume pulse instead) kept flowing. Host RPCs
+        // target the loopback host anyway, so "the network is down" must not
+        // gate them even when true; cloud-bound calls fail fast into the
+        // existing toast/error paths instead of pausing.
+        networkMode: "always",
+      },
+      mutations: {
+        // Same reasoning as the query default above: a paused mutation is a
+        // dead button.
+        networkMode: "always",
       },
     },
   });

--- a/clients/gui-app/src/routes/root-route-components.tsx
+++ b/clients/gui-app/src/routes/root-route-components.tsx
@@ -7,6 +7,7 @@ import { AppShell } from "@/components/layout/app-shell";
 import { WindowsMenuBar } from "@/components/layout/header/windows-menu-bar";
 import { useWindowsMenuBarActive } from "@/components/layout/header/use-windows-menu-bar-active";
 import { MenuCommandListener } from "@/components/layout/bridges/menu-command-listener";
+import { ChatSessionWakeRetryController } from "@/components/layout/bridges/chat-session-wake-retry-controller";
 import { PreventSleepController } from "@/components/layout/bridges/prevent-sleep-controller";
 import { NotificationEmissionController } from "@/components/layout/bridges/notification-emission-controller";
 import { NotificationFocusBridge } from "@/components/layout/bridges/notification-focus-bridge";
@@ -41,11 +42,17 @@ export function RootComponent() {
           readiness (the "Setting up Traycer Host…" screen). The menu command
           listener routes native menu items; the dialog host renders
           host-independent About/Logs dialogs; notification emission drains
-          app-local persisted rows. All only depend on the runner host + auth +
-          local stores, which are available without a ready host. */}
+          app-local persisted rows; the wake-retry bridge revives
+          terminally-closed warm chat sessions (it must live OUTSIDE the gate:
+          a wake pulse arriving while the gate shows its fallback would
+          otherwise find no listener and never be replayed, leaving the warm
+          session dead after the host comes back). All only depend on the
+          runner host + auth + local stores/registries, which are available
+          without a ready host. */}
       <MenuCommandListener />
       <DesktopDialogHost />
       <NotificationEmissionController />
+      <ChatSessionWakeRetryController />
       {/* Everything host-dependent stays BEHIND the gate, preserving the exact
           mount timing it had when the gate wrapped the whole RouterProvider -
           these bridges + the page only mount once the host is reachable (or the

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -1637,13 +1637,30 @@ export function createChatSessionStore(
         if (disposed) return;
         closeStreamClient();
         clearBufferedDeltas();
+        const prior = get();
         set({
           connectionStatus: "connecting",
           steerProtocolSupported: false,
           fatalClose: null,
           snapshotLoaded: false,
         });
-        streamClient = createStreamClient();
+        try {
+          streamClient = createStreamClient();
+        } catch (cause) {
+          // The replacement factory can throw (durable-transport wiring throws
+          // on a failed subscription). Without this restore the session would
+          // strand in "connecting" with NO stream client - nothing ever moves
+          // it again, and recovery passes (the wake retry, the tile's retry
+          // affordance) all key off a terminal status. Restore the pre-attempt
+          // terminal state so the next pulse or click can try again, then
+          // rethrow for the caller to report.
+          set({
+            connectionStatus: "closed",
+            fatalClose: prior.fatalClose,
+            snapshotLoaded: prior.snapshotLoaded,
+          });
+          throw cause;
+        }
       },
       refreshMissingWorktreePaths: (update) => {
         if (disposed) return;


### PR DESCRIPTION
## Problem

After an OS sleep/wake, chat action controls (send, next-steps rows, approvals, plan actions) could stay unclickable until the app was relaunched, even though the transcript kept rendering. Two independent gates caused this:

1. **App-wide:** the `QueryClient` left TanStack's `networkMode` at the default `"online"`. Chromium can keep `navigator.onLine === false` indefinitely after a sleep/wake in the desktop shell — the same signal the stream layer already distrusts (it uses Electron's `powerMonitor` resume pulse instead). While the browser reports offline, every host query silently stops fetching and every mutation parks as `paused-pending`: clicks are accepted but never run, and `disabled={isPending}` gates freeze. Host RPCs target the loopback host, so this reporting should never gate them.

2. **Per chat tab:** every chat-pane control gates on the chat stream's `connectionStatus === "open"`. Live streams already force-reconnect on the OS wake pulse, but a stream that went *terminally* closed during sleep (e.g. the transport's bounded no-progress `UNAUTHORIZED` give-up) is disposed with no timer left to recover it, and a warm tile's retry affordance only renders while its snapshot never loaded — so it stayed dead until relaunch.

## Changes

- `lib/query-client.ts` — `networkMode: "always"` for both queries and mutations, so connectivity reporting never gates a loopback-host call. (Side benefit: the app now works fully against the local host while genuinely offline.)
- `lib/host/stream-wake-reconnect.ts` — extracted `subscribeWakeSignals`, the shared `window 'online'` + `IRunnerHost.onSystemResumed` wiring (with its existing rollback-on-throw semantics), so a new wake consumer can reuse it instead of re-deriving it.
- `lib/chats/chat-session-wake-retry.ts` — retries every terminally-closed warm chat session once per OS wake pulse via `state.retry()`. Per-handle failures are isolated (one broken session can't block the rest), and retries within a 5s wake episode are deduped so the resume/unlock-screen/online fan-out doesn't rebuild a permanently fatal session (e.g. `INCOMPATIBLE`) more than once per physical wake.
- `components/layout/bridges/chat-session-wake-retry-controller.tsx` + `routes/root-route-components.tsx` — mounts the retry bridge **outside** `HostReadyGate`, since warm sessions outlive the gate and a wake pulse landing while the gate shows its fallback must not be silently lost.
- `stores/chats/chat-session-store.ts` — `retry()` is now exception-safe: if the replacement stream-client factory throws, the session is restored to a retryable `closed` state (preserving the fatal-close reason) instead of stranding in `connecting` with no client and no way to recover.

## Verification

- New regression tests fail with each fix reverted (mutation parks paused; closed session never re-dials; a throwing retry strands the session; a wake burst double-rebuilds a fast-re-closing session) and pass with the fixes in place.
- Full `gui-app` test suite green; `bun run compile`, `bun run lint`, and `react-doctor` clean on the changed files.
- Reviewed by an independent cold pass (fresh agent, no prior context on this change), which surfaced 3 real issues — all fixed and covered by tests above.