### PR TITLE
fix(desktop,gui-app): stop handing back a report id the upload never delivered

### DIFF
--- a/clients/desktop/src/electron-main/app/__tests__/support-report-delivery.test.ts
+++ b/clients/desktop/src/electron-main/app/__tests__/support-report-delivery.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+interface CapturedAttachment {
+  readonly filename: string;
+  readonly data: string;
+}
+
+interface CapturedHint {
+  readonly captureContext: { readonly tags: Record<string, string> };
+  readonly attachments: readonly CapturedAttachment[];
+}
+
+const sentryMock = vi.hoisted(() => ({
+  isInitialized: vi.fn<() => boolean>(),
+  captureFeedback: vi.fn<(feedback: unknown, hint: CapturedHint) => string>(),
+  flush: vi.fn<(timeout: number) => Promise<boolean>>(),
+}));
+
+const loggerMock = vi.hoisted(() => ({
+  desktopLogPath: "",
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("electron", () => ({
+  app: { getVersion: (): string => "1.1.9" },
+  shell: { showItemInFolder: vi.fn() },
+}));
+
+vi.mock("@sentry/electron/main", () => sentryMock);
+
+vi.mock("../logger", () => ({
+  log: loggerMock.log,
+  resolveDesktopLogPath: (): string => loggerMock.desktopLogPath,
+}));
+
+import { DesktopSupportService } from "../support";
+import type { HostFsLayout } from "../../host/host-paths";
+
+const FORM = {
+  title: "Host will not start",
+  whatHappened: "It hangs on launch",
+  stepsToReproduce: "1. Open the app",
+  expectedBehavior: "It starts",
+  actualBehavior: "It hangs",
+};
+
+const LOG_ATTACHMENT_MAX_BYTES = 512_000;
+
+let tempDir = "";
+let hostLogPath = "";
+
+function buildService(): DesktopSupportService {
+  const hostLayout: HostFsLayout = {
+    rootDir: tempDir,
+    pidMetadataFile: join(tempDir, "pid.json"),
+    logFile: hostLogPath,
+    installDir: join(tempDir, "install"),
+    installRecordFile: join(tempDir, "install.json"),
+    stagedDir: join(tempDir, "staged"),
+    stagedRecordFile: join(tempDir, "staged.json"),
+    pendingLoginItemRevisionFile: join(tempDir, "login-item"),
+    environment: "production",
+  };
+  return new DesktopSupportService({
+    appName: "Traycer",
+    host: { getSnapshot: () => null },
+    authSession: {
+      get: () => ({ status: "signed-out", token: null, profile: null }),
+    },
+    hostLayout,
+  });
+}
+
+function lastHint(): CapturedHint {
+  const call = sentryMock.captureFeedback.mock.calls.at(-1);
+  if (call === undefined) throw new Error("captureFeedback was never called");
+  return call[1];
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "traycer-support-"));
+  loggerMock.desktopLogPath = join(tempDir, "traycer-desktop.log");
+  hostLogPath = join(tempDir, "host.log");
+  await writeFile(loggerMock.desktopLogPath, "desktop log line\n", "utf8");
+  await writeFile(hostLogPath, "host log line\n", "utf8");
+  sentryMock.isInitialized.mockReturnValue(true);
+  sentryMock.flush.mockResolvedValue(true);
+});
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("DesktopSupportService.submitReport", () => {
+  it("returns the report id once the upload is confirmed flushed", async () => {
+    const result = await buildService().submitReport(FORM);
+
+    expect(result.reportId).toMatch(/^rpt_[0-9a-f]{32}$/);
+    expect(sentryMock.captureFeedback).toHaveBeenCalledTimes(1);
+  });
+
+  it("tags the feedback event with the id it hands back", async () => {
+    const result = await buildService().submitReport(FORM);
+
+    // The id is a `reportId` tag, not a Sentry event id - it is the only handle
+    // triage has, so an id that is not on the event would be unfindable.
+    expect(lastHint().captureContext.tags.reportId).toBe(result.reportId);
+  });
+
+  it("attaches both log tails", async () => {
+    await buildService().submitReport(FORM);
+
+    expect(lastHint().attachments.map((a) => a.filename)).toEqual([
+      "desktop.log",
+      "host.log",
+    ]);
+  });
+
+  it("returns null and uploads nothing when Sentry has no DSN", async () => {
+    sentryMock.isInitialized.mockReturnValue(false);
+
+    const result = await buildService().submitReport(FORM);
+
+    expect(result.reportId).toBeNull();
+    expect(sentryMock.captureFeedback).not.toHaveBeenCalled();
+    expect(sentryMock.flush).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the flush times out", async () => {
+    sentryMock.flush.mockResolvedValue(false);
+
+    const result = await buildService().submitReport(FORM);
+
+    // The pre-fix code discarded the flush result, so a timed-out upload still
+    // handed back an id and stamped it into the GitHub issue.
+    expect(result.reportId).toBeNull();
+    expect(loggerMock.log.error).toHaveBeenCalled();
+  });
+
+  it("returns null when the flush rejects", async () => {
+    sentryMock.flush.mockRejectedValue(new Error("transport closed"));
+
+    const result = await buildService().submitReport(FORM);
+
+    expect(result.reportId).toBeNull();
+  });
+
+  it("bounds each attachment by bytes, not just line count", async () => {
+    // 500 lines is not a size bound: one host log line can carry a multi-KB
+    // payload, and an oversized envelope is dropped by Sentry after the event
+    // is otherwise accepted.
+    // ~2 MB across 100 lines, so line count alone would let all of it through.
+    const fatLog = Array.from(
+      { length: 100 },
+      (_, i) => `line-${i}-${"x".repeat(20_000)}`,
+    ).join("\n");
+    await writeFile(hostLogPath, fatLog, "utf8");
+
+    await buildService().submitReport(FORM);
+
+    const hostAttachment = lastHint().attachments.find(
+      (a) => a.filename === "host.log",
+    );
+    expect(hostAttachment).toBeDefined();
+    const data = hostAttachment?.data ?? "";
+    expect(Buffer.byteLength(data, "utf8")).toBeLessThanOrEqual(
+      LOG_ATTACHMENT_MAX_BYTES,
+    );
+    // Truncation keeps the tail - the failure being reported lives there.
+    expect(data).toContain("line-99-");
+    expect(data).not.toContain("line-0-");
+  });
+
+  it("waits longer than the old 2s budget before giving up", async () => {
+    await buildService().submitReport(FORM);
+
+    expect(sentryMock.flush).toHaveBeenCalledWith(10_000);
+  });
+});

--- a/clients/desktop/src/electron-main/app/support.ts
+++ b/clients/desktop/src/electron-main/app/support.ts
@@ -18,6 +18,14 @@ import type {
 } from "../../ipc-contracts/window-types";
 import { buildSupportLinks, TRAYCER_SUPPORT_EMAIL } from "./support-links";
 
+const LOG_TAIL_LINES = 500;
+// Per attachment. Two logs stay well inside Sentry's envelope limits, and the
+// transport gzips before sending, so this is ~50 KB on the wire in practice.
+const LOG_ATTACHMENT_MAX_BYTES = 512_000;
+// The user is watching a spinner, but losing the report costs far more than
+// waiting: 2s was not enough to upload two log attachments on a slow link.
+const SENTRY_FLUSH_TIMEOUT_MS = 10_000;
+
 export interface SupportHostSnapshotProvider {
   getSnapshot(): DesktopLocalHostSnapshot | null;
 }
@@ -100,17 +108,29 @@ export class DesktopSupportService {
   ): Promise<SupportSubmitReportResult> {
     const reportId = generateReportId();
     const snapshot = this.getSnapshot();
-    const [desktopLogContent, hostLogContent] = await Promise.all([
-      readLogTail(resolveDesktopLogPath(), 500),
-      readLogTail(this.hostLayout.logFile, 500),
-    ]);
 
-    // No DSN baked in (dev/staging without sentry) - keep the user-facing
-    // flow working by returning the locally generated id; the GitHub issue
-    // will still open with environment + report id in the body.
+    // No DSN baked in (dev/staging without sentry). Nothing is uploaded, so
+    // there is no report to hand back - returning the locally generated id
+    // here is what put ids into GitHub issues that exist nowhere in Sentry.
     if (!Sentry.isInitialized()) {
-      return { reportId };
+      log.warn("[support] sentry unavailable, report not uploaded", {
+        reportId,
+      });
+      return { reportId: null };
     }
+
+    const [desktopLogContent, hostLogContent] = await Promise.all([
+      readLogTail(
+        resolveDesktopLogPath(),
+        LOG_TAIL_LINES,
+        LOG_ATTACHMENT_MAX_BYTES,
+      ),
+      readLogTail(
+        this.hostLayout.logFile,
+        LOG_TAIL_LINES,
+        LOG_ATTACHMENT_MAX_BYTES,
+      ),
+    ]);
 
     const message = [
       `Title: ${form.title}`,
@@ -151,10 +171,19 @@ export class DesktopSupportService {
       },
     );
 
-    try {
-      await Sentry.flush(2000);
-    } catch (err) {
-      log.error("[support] sentry flush failed", { reportId, err });
+    // `flush` resolves false when the queue did not drain inside the timeout.
+    // The result used to be discarded, which made a timed-out upload
+    // indistinguishable from a delivered one - the report id still reached the
+    // GitHub issue and triage then hunted for a report that never arrived.
+    const flushed = await Sentry.flush(SENTRY_FLUSH_TIMEOUT_MS).catch(
+      (err: unknown) => {
+        log.error("[support] sentry flush failed", { reportId, err });
+        return false;
+      },
+    );
+    if (!flushed) {
+      log.error("[support] report upload did not complete", { reportId });
+      return { reportId: null };
     }
     return { reportId };
   }
@@ -189,10 +218,28 @@ async function ensureLogFile(path: string): Promise<void> {
   await handle.close();
 }
 
-async function readLogTail(path: string, lines: number): Promise<string> {
+async function readLogTail(
+  path: string,
+  lines: number,
+  maxBytes: number,
+): Promise<string> {
   const content = await readFile(path, "utf-8").catch(() => "");
-  const all = content.split("\n");
-  return all.slice(-lines).join("\n");
+  const tail = content.split("\n").slice(-lines).join("\n");
+  return truncateToTrailingBytes(tail, maxBytes);
+}
+
+// A line count is not a size bound: one host log line can carry a multi-KB
+// JSON payload, so 500 lines can run to megabytes. Sentry rejects oversized
+// envelopes, and that rejection surfaces as a delivered event whose attachment
+// silently vanished - exactly the failure mode this file is fixing. Keep the
+// trailing bytes; the tail is where the failure being reported lives.
+function truncateToTrailingBytes(text: string, maxBytes: number): string {
+  const encoded = Buffer.from(text, "utf8");
+  if (encoded.byteLength <= maxBytes) return text;
+  const kept = encoded.subarray(-maxBytes).toString("utf8");
+  // The byte cut can land mid-codepoint or mid-line; drop the partial head.
+  const firstNewline = kept.indexOf("\n");
+  return firstNewline === -1 ? kept : kept.slice(firstNewline + 1);
 }
 
 function generateReportId(): string {

--- a/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
+++ b/clients/desktop/src/electron-main/ipc/runner-ipc-bridge.ts
@@ -1313,7 +1313,7 @@ class NullSupportService implements IpcSupportService {
   submitReport(
     _form: SupportSubmitReportRequest,
   ): Promise<SupportSubmitReportResult> {
-    return Promise.resolve({ reportId: "" });
+    return Promise.resolve({ reportId: null });
   }
 
   tailLog(input: {

--- a/clients/desktop/src/ipc-contracts/window-types.ts
+++ b/clients/desktop/src/ipc-contracts/window-types.ts
@@ -204,7 +204,12 @@ export interface SupportSubmitReportRequest {
 }
 
 export interface SupportSubmitReportResult {
-  readonly reportId: string;
+  // `null` when the diagnostics upload did not reach Sentry (no DSN baked in,
+  // or the flush timed out). There is then no report for triage to look up, so
+  // the GitHub issue must not advertise one. An id exists if and only if the
+  // upload was confirmed - the invariant is structural, not a parallel flag
+  // that can drift out of sync with the delivery outcome.
+  readonly reportId: string | null;
 }
 
 export interface SupportLogTailResult {

--- a/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
+++ b/clients/gui-app/src/components/layout/dialogs/desktop/report-issue-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Bug } from "lucide-react";
+import { toast } from "sonner";
 import { useMutation } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
@@ -82,6 +83,16 @@ export function ReportIssueDialog(
         outcome: "succeeded",
         blocker: null,
       });
+      // The hand-off to GitHub is the primary channel and must survive a
+      // Sentry outage, so a failed diagnostics upload does not block it. It
+      // does have to be visible: this dialog closes below, so the warning goes
+      // to a toast rather than an inline banner nobody would ever see.
+      if (reportId === null) {
+        toast.warning("Diagnostic logs could not be uploaded", {
+          description:
+            "Your report will still open on GitHub. Attach your logs manually from Settings → Diagnostics so the team can diagnose it.",
+        });
+      }
       const url = buildSupportIssueUrl(
         submission.snapshot,
         submission.form,
@@ -262,7 +273,7 @@ function reportIssueFormFromContext(
 function buildSupportIssueUrl(
   snapshot: DesktopSupportSnapshot | null,
   form: ReportIssueForm,
-  reportId: string,
+  reportId: string | null,
 ): string {
   return buildGitHubIssueUrl({
     ...supportSnapshotIssueFields(snapshot),

--- a/clients/gui-app/src/lib/windows/types.ts
+++ b/clients/gui-app/src/lib/windows/types.ts
@@ -305,7 +305,10 @@ export interface DesktopReportIssueForm {
 }
 
 export interface DesktopSubmitReportResult {
-  readonly reportId: string;
+  // `null` when the diagnostics upload never reached Sentry. The issue is
+  // still filed, but without a Support Report row - there is nothing to look
+  // up, and advertising an id that resolves to nothing is the bug being fixed.
+  readonly reportId: string | null;
 }
 
 export interface DesktopSupportBridge {


### PR DESCRIPTION
## Summary

`submitReport` generated a local `rpt_<32 hex>` id, uploaded a Sentry feedback
event plus two log attachments, and returned that id unconditionally — including
on two paths where nothing reached Sentry at all:

- **No DSN baked in** (`Sentry.isInitialized()` false, e.g. dev/staging builds).
  The early return still handed back the id, and both log files were read for
  nothing.
- **`Sentry.flush()` resolved `false`** (queue did not drain inside the timeout)
  **or rejected.** Both outcomes were discarded by a `try`/`catch`, which made a
  timed-out upload indistinguishable from a delivered one.

The id then reached the GitHub issue body as a `Support Report` row, so triage
searched Sentry for a report that had never arrived.

### Fix

Make the invariant **structural** rather than a parallel flag that can drift out
of sync with the delivery outcome. `SupportSubmitReportResult.reportId` becomes
`string | null`, so **an id exists if and only if the upload was confirmed** —
there is no way to render an id for a failed upload, because there isn't one.

`buildIssueBody` already omitted the row for a null id, so the shared issue
builder needed no change; the issue simply carries no report reference.

Two supporting fixes in the same path:

- **Flush budget 2s → 10s.** Two log attachments do not finish on a slow link
  inside 2s, and losing the report costs far more than the wait.
- **Attachments bounded to 512 KB of trailing bytes.** A 500-line tail is not a
  size bound — one host log line can carry a multi-KB JSON payload, so 500 lines
  can run to megabytes. Sentry drops an oversized envelope *after* otherwise
  accepting the event, which is the same silent loss in a different place.
  Truncation keeps the tail, where the failure being reported lives, and drops
  the partial head line left by a byte-aligned cut.

### Behaviour on failure

The GitHub hand-off is the primary channel and must survive a Sentry outage, so
it still runs: the issue opens as usual, minus the `Support Report` row, and the
renderer raises a warning toast pointing the user at their log files. A toast
rather than an inline banner because the dialog closes on success, so a banner
would never be seen.

Analytics still reports `outcome: "succeeded"` — correct, since
`ReportIssueHandedOff` names the GitHub hand-off, which does succeed.

### Not addressed here

`flush() === true` means the transport queue drained, not that Sentry accepted
the envelope — a 429 or 413 still counts as delivered. A real acknowledgement
needs `client.on('afterSendEvent')`, which is a larger change than the two
silent-loss paths this PR closes.

## Related issue

N/A — reported through support reports whose ids resolved to nothing in Sentry.

## Verification

- `pre-commit` gate passed on the commit: `build · compile · lint · format
  (nx affected)` and `DCO sign-off`.
- `bun run compile --skip-nx-cache` — 5 projects clean.
- Full suites, each run with `--skip-nx-cache`:
  - desktop — 84 files / 1041 tests
  - gui-app — 788 files / 7389 tests (+1 skipped)
  - protocol — 96 files / 1288 tests
  - traycer-cli — 97 files / 949 tests (+1 skipped)
  - shared — 33 files / 405 tests
- `bun run lint` — 5 projects clean; `prettier --check` clean on all 6 touched
  files.
- 8 new tests in `support-report-delivery.test.ts` cover each null path (no DSN,
  flush resolves false, flush rejects), that the returned id equals the
  `reportId` tag actually attached to the event, that both log tails are
  attached, the byte cap, and the 10s flush budget.

One note on the suite: a single `traycer-cli` test
(`runner-discipline-migration.test.ts`) hit its 5s timeout once under
five-project parallel load. It passes 3/3 in isolation and the CLI suite passes
in full on its own; this PR touches no CLI files.

## Notes

Branched off current `main` rather than the pinned submodule commit. That surfaced
a real break worth calling out: `HostFsLayout` gained `stagedDir` and
`stagedRecordFile` in #528, so the new test's layout fixture needed both fields —
it would have compiled green on the older base and failed on merge.

No internal-repo consumers exist for any of the widened types, so this lands
standalone and only needs a routine gitlink bump afterwards.

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the DCO
