### PR TITLE
fix(gui-app,protocol): don't label a failed compaction as compacted

### DIFF
--- a/clients/gui-app/src/components/chat/segments/__tests__/compaction-segment.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/compaction-segment.test.tsx
@@ -1,0 +1,89 @@
+import "../../../../../__tests__/test-browser-apis";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CompactionSegment } from "../compaction-segment";
+
+describe("<CompactionSegment />", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("reports a completed compaction with its before/after metrics", () => {
+    render(
+      <CompactionSegment
+        status="completed"
+        trigger="manual"
+        preTokens={120000}
+        postTokens={30000}
+        durationMs={85000}
+        summary={null}
+        error={null}
+        findUnitId={null}
+      />,
+    );
+
+    expect(screen.getByText("Compacted")).toBeDefined();
+    // Token grouping is locale-dependent, so match the shape, not the digits.
+    expect(screen.getByText(/→ .* tokens · 1m 25s/)).toBeDefined();
+  });
+
+  // The failure this guards: a compaction that died mid-flight (provider 529,
+  // for instance) used to render the success bar, so the transcript claimed the
+  // context had been folded when it had not.
+  it("says a failed compaction failed instead of claiming success", () => {
+    render(
+      <CompactionSegment
+        status="errored"
+        trigger="manual"
+        preTokens={120000}
+        postTokens={null}
+        durationMs={null}
+        summary={null}
+        error="Error during compaction: API Error: 529 Overloaded."
+        findUnitId={null}
+      />,
+    );
+
+    expect(screen.getByText("Compaction failed")).toBeDefined();
+    expect(screen.queryByText("Compacted")).toBeNull();
+    expect(
+      screen.getByText("Error during compaction: API Error: 529 Overloaded."),
+    ).toBeDefined();
+  });
+
+  it("names an automatic compaction's failure as automatic", () => {
+    render(
+      <CompactionSegment
+        status="errored"
+        trigger="auto"
+        preTokens={null}
+        postTokens={null}
+        durationMs={null}
+        summary={null}
+        error="Compaction failed"
+        findUnitId={null}
+      />,
+    );
+
+    expect(screen.getByText("Auto-compaction failed")).toBeDefined();
+  });
+
+  // A stale summary carried over from the started event is not a result, so a
+  // failed bar must not offer it for expansion.
+  it("offers no summary expander on a failed compaction", () => {
+    render(
+      <CompactionSegment
+        status="errored"
+        trigger="manual"
+        preTokens={null}
+        postTokens={null}
+        durationMs={null}
+        summary="Half-written summary"
+        error="Compaction failed"
+        findUnitId={null}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/clients/gui-app/src/components/chat/segments/compaction-segment.tsx
+++ b/clients/gui-app/src/components/chat/segments/compaction-segment.tsx
@@ -52,16 +52,35 @@ function compactionMetricText(
   return metricParts.length === 0 ? "" : ` · ${metricParts.join(" · ")}`;
 }
 
+// "Compacted" is a claim about what happened to the context. When compaction
+// failed nothing was folded, so the bar must not make that claim - it marks the
+// attempt, and the destructive line below carries the reason.
+function terminalCompactionLabel(
+  status: "completed" | "errored",
+  isAuto: boolean,
+): string {
+  if (status === "errored") {
+    return isAuto ? "Auto-compaction failed" : "Compaction failed";
+  }
+  return isAuto ? "Auto-compacted" : "Compacted";
+}
+
 export function CompactionSegment(props: CompactionSegmentProps) {
   const { status, trigger, preTokens, postTokens, durationMs, summary, error } =
     props;
   const isStreaming = status === "streaming";
+  const isErrored = status === "errored";
   const [expanded, setExpanded] = useState(false);
   const toggleExpanded = useChatMeasuredBooleanToggle(setExpanded);
 
-  const metricText = compactionMetricText(preTokens, postTokens, durationMs);
+  // A failed compaction has no boundary, so there are no real metrics and no
+  // summary to expand - only the failure and its reason.
+  const metricText = isErrored
+    ? ""
+    : compactionMetricText(preTokens, postTokens, durationMs);
 
-  const hasSummary = !isStreaming && summary !== null && summary.length > 0;
+  const hasSummary =
+    status === "completed" && summary !== null && summary.length > 0;
   const ExpandIcon = expanded ? ChevronDown : ChevronRight;
   // Only `auto` earns a distinct label. A manual compaction is one the user
   // just asked for, so naming it adds nothing; an automatic one interrupted
@@ -82,7 +101,7 @@ export function CompactionSegment(props: CompactionSegmentProps) {
     <div className="flex items-center gap-2 text-ui-xs text-muted-foreground">
       <FoldVertical className="size-3.5 shrink-0" aria-hidden />
       <span>
-        {isAuto ? "Auto-compacted" : "Compacted"}
+        {terminalCompactionLabel(isErrored ? "errored" : "completed", isAuto)}
         <span className="text-muted-foreground/80">{metricText}</span>
       </span>
       {hasSummary ? (

--- a/clients/gui-app/src/lib/chat/content-block-text.ts
+++ b/clients/gui-app/src/lib/chat/content-block-text.ts
@@ -122,6 +122,9 @@ function planBlockText(block: PlanBlock): string {
 }
 
 function compactionBlockText(block: CompactionBlock): string {
+  if (block.status === "errored") {
+    return block.error ?? "Context compaction failed";
+  }
   return block.summary ?? "Context compacted";
 }
 

--- a/protocol/src/host/agent/gui/__tests__/agent-runtime-accumulator.test.ts
+++ b/protocol/src/host/agent/gui/__tests__/agent-runtime-accumulator.test.ts
@@ -1506,6 +1506,85 @@ describe("accumulateEvent", () => {
     expect((blocks[0] as CompactionBlock).postTokens).toBe(400);
   });
 
+  // A compaction cut short (user hit Stop, harness died) never reports a
+  // boundary, so it folded nothing. Finalizing it as "completed" would render
+  // the success bar - "Compacted" with no error line to contradict it - and
+  // persist that claim to the transcript, while the context chip still reads
+  // full. It must finalize as a failure instead.
+  it("turn.interrupted finalizes an in-flight compaction as errored, not completed", () => {
+    let blocks = makeBlocks();
+    blocks = accumulateEvent(blocks, {
+      type: "compaction.started",
+      blockId: "compact-cut-short",
+      timestamp: 1,
+      trigger: "manual",
+      preTokens: 120000,
+    });
+    blocks = accumulateEvent(blocks, {
+      type: "turn.interrupted",
+      blockId: "turn",
+      timestamp: 5,
+      turnId: "turn",
+      reason: "Stopped by the user.",
+      code: "USER_STOP",
+      recoverable: true,
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].status).toBe("errored");
+    expect((blocks[0] as CompactionBlock).error).toBe(
+      "Compaction did not finish",
+    );
+  });
+
+  it("turn.completed finalizes an in-flight compaction as errored", () => {
+    let blocks = makeBlocks();
+    blocks = accumulateEvent(blocks, {
+      type: "compaction.started",
+      blockId: "compact-orphaned",
+      timestamp: 1,
+      trigger: "auto",
+      preTokens: 120000,
+    });
+    blocks = accumulateEvent(blocks, {
+      type: "turn.completed",
+      blockId: "turn",
+      timestamp: 5,
+      turnId: "turn",
+    });
+
+    expect(blocks[0].status).toBe("errored");
+  });
+
+  // Only the in-flight case is a failure: a compaction that already reported its
+  // boundary keeps the result it earned when the turn later ends.
+  it("turn end leaves an already-completed compaction alone", () => {
+    let blocks = makeBlocks();
+    blocks = accumulateEvent(blocks, {
+      type: "compaction.started",
+      blockId: "compact-done",
+      timestamp: 1,
+      trigger: "manual",
+      preTokens: 1000,
+    });
+    blocks = accumulateEvent(blocks, {
+      type: "compaction.completed",
+      blockId: "compact-done",
+      timestamp: 2,
+      postTokens: 400,
+      durationMs: 50,
+    });
+    blocks = accumulateEvent(blocks, {
+      type: "turn.completed",
+      blockId: "turn",
+      timestamp: 5,
+      turnId: "turn",
+    });
+
+    expect(blocks[0].status).toBe("completed");
+    expect((blocks[0] as CompactionBlock).error).toBeNull();
+  });
+
   // ── interview events ─────────────────────────────────────────
 
   it("interview events create and complete InterviewBlock", () => {

--- a/protocol/src/host/agent/gui/agent-runtime-accumulator.ts
+++ b/protocol/src/host/agent/gui/agent-runtime-accumulator.ts
@@ -163,6 +163,22 @@ export function finalizeStreamingActionBlocks(
             block.planStatus === "drafting" ? "ready" : block.planStatus,
         };
       }
+      // A compaction still in flight at turn end never reported a boundary, so
+      // it folded nothing. The content fallthrough below would mark it
+      // "completed" and the bar would claim a result it never produced - the
+      // silent version of a failed compaction, with no error line to contradict
+      // it. Compaction is not an action block, so `interrupted`/`superseded` are
+      // not in its schema; `errored` is the honest terminal state. No harness
+      // leaves a compaction running across a turn end (each yields its own
+      // terminal event first), so this only ever fires on a genuine cut-short.
+      if (block.type === "compaction") {
+        return {
+          ...block,
+          status: "errored" as const,
+          error: block.error ?? "Compaction did not finish",
+          timestamp,
+        };
+      }
       // text/reasoning are content, not actions: a partial thought/sentence is
       // not a failure. Always "completed", with `timestamp` advanced to turn-end
       // so a derived duration ("Thought for Xs") spans first delta → turn end.


### PR DESCRIPTION
## Problem

Compaction that fails still renders as success. Running `/compact` and hitting a
provider 529 produced a **"Compacted"** divider — the error text underneath was
the only thing contradicting it.

Two independent paths caused it:

1. `compaction.errored` arrived at the renderer intact, but `CompactionSegment`
   only checked for `"streaming"` and treated every other status as success.
2. A compaction still in flight when the turn ends (user hits Stop, harness
   dies) is force-finalized by `finalizeStreamingActionBlocks`. Compaction
   wasn't excluded, so it fell into the text/reasoning fallthrough and became
   `completed` — the success bar with **no error line at all**, persisted to the
   transcript while the context chip still reads full.

## Changes

**`protocol`**
- `finalizeStreamingActionBlocks` now finalizes an in-flight compa
  `errored` ("Compaction did not finish") instead of `completed`. `errored` is
  already in the compaction schema, so no migration or version bum

**`gui-app`**
- Failed compactions render "Compaction failed" / "Auto-compaction failed".
- No token metrics on a failure — nothing was folded, so there is
  quote.
- No summary expander on a failure.
- Copying the chat pastes the error instead of "Context compacted".

## Scope

The accumulator change is on the shared path, so it applies to every harness
with compaction: claude, codex, copilot, omp, pi, opencode, and th
(devin, grok, hermes, kilocode, kimi, kiro, qwen). Codex is the notable one —
it emits `compaction.started`/`completed` but has no `errored` pat
`completed` was previously the only terminal state its compactions could reach.

Success and streaming paths are unchanged: for `completed` the labels and metric
text are byte-identical to before, and `hasSummary` was already fa
streaming.

## Testing

- 3 accumulator tests: Stop mid-compaction → `errored`, orphaned at turn end →
  `errored`, and an already-completed compaction is left alone (gu
  opposite direction).
- 4 segment tests: failed label, never "Compacted", error shown, n
- `protocol` full suite: 1397 passed.
- `gui-app` `components/chat` + `stores/chats` + `lib/chat`: 1407
- Host suites that replay real event streams through the accumulator
  (`chat-stream-resolver`, `claude-converter`, `codex-converter`,
  `permission-diff-undo-e2e`): 509 passed.