### PR TITLE
feat(gui-app): sweep worktrees for a History multi-selection

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sweep-action.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sweep-action.tsx
@@ -90,7 +90,9 @@ function EpicSweepActionBody(props: {
           aria-label={
             hasWorktrees ? "Sweep worktrees" : "No worktrees to sweep"
           }
-          aria-haspopup="dialog"
+          // Only claimed when the button can actually open the dialog -
+          // announcing a popup that cannot appear misdescribes it to AT.
+          aria-haspopup={hasWorktrees ? "dialog" : undefined}
           data-testid="epic-sweep-action"
           className={cn(
             "text-muted-foreground",

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sweep-action.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sweep-action.tsx
@@ -17,14 +17,16 @@ import {
   taskMergeRollupLabel,
 } from "@/lib/worktree/task-merge-rollup";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { cn } from "@/lib/utils";
 
 const EMPTY_ENTRIES: readonly WorktreeHostEntryV12[] = [];
 
 /**
  * Icon-only Sweep affordance in the Epic status row (top-right), next to the
- * sync pill. Shown whenever the Task owns worktrees on this host; the dialog
- * does the judging - it lists every worktree with its proof state and
- * pre-checks only the ones proven safe.
+ * sync pill. Always present - faded and non-actionable when the Task owns no
+ * worktrees - so the row keeps a stable shape; the dialog does the judging,
+ * listing every worktree with its proof state and pre-checking only the ones
+ * proven safe.
  *
  * Host-backed, so callers must only mount it where the host runtime and the
  * Epic session exist (the status row gates on `snapshotLoaded`, which implies
@@ -61,13 +63,21 @@ function EpicSweepActionBody(props: {
     return tab?.epicId === epicId ? tab.name : null;
   });
   const [sweepOpen, setSweepOpen] = useState(false);
-
-  if (entries.length === 0) return null;
+  // Kept in place (faded, non-actionable) when there is nothing to sweep, so
+  // the status row does not gain and lose a control as worktrees come and go -
+  // the same treatment History's row action and bulk button use. `aria-disabled`
+  // rather than `disabled`: a truly disabled button swallows the pointer events
+  // the tooltip needs, and the tooltip is where the reason lives.
+  const hasWorktrees = entries.length > 0;
 
   return (
     <>
       <TooltipWrapper
-        label={sweepTooltip(entries.length, taskMergeRollupLabel(rollup))}
+        label={
+          hasWorktrees
+            ? sweepTooltip(entries.length, taskMergeRollupLabel(rollup))
+            : "No worktrees to sweep for this task"
+        }
         side="bottom"
         sideOffset={undefined}
         align="end"
@@ -76,11 +86,22 @@ function EpicSweepActionBody(props: {
           type="button"
           variant="ghost"
           size="icon-xs"
-          aria-label="Sweep worktrees"
+          aria-disabled={hasWorktrees ? undefined : true}
+          aria-label={
+            hasWorktrees ? "Sweep worktrees" : "No worktrees to sweep"
+          }
           aria-haspopup="dialog"
           data-testid="epic-sweep-action"
-          className="text-muted-foreground hover:text-foreground"
-          onClick={() => setSweepOpen(true)}
+          className={cn(
+            "text-muted-foreground",
+            hasWorktrees
+              ? "hover:text-foreground"
+              : "cursor-not-allowed text-muted-foreground/50 hover:text-muted-foreground/50",
+          )}
+          onClick={() => {
+            if (!hasWorktrees) return;
+            setSweepOpen(true);
+          }}
         >
           <Paintbrush className="size-3.5" />
         </Button>

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-sweep-action.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-sweep-action.tsx
@@ -86,7 +86,7 @@ function EpicSweepActionBody(props: {
         </Button>
       </TooltipWrapper>
       <SweepWorktreesDialog
-        epicId={sweepOpen ? epicId : null}
+        epicIds={sweepOpen ? epicIds : null}
         taskTitle={tabName}
         onOpenChange={(open) => {
           if (!open) setSweepOpen(false);

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -531,6 +531,28 @@ describe("<EpicsListPanel />", () => {
     expect(screen.queryByTestId("epics-list-row-pin")).toBeNull();
   });
 
+  // The Sweep control keeps its slot in every task row rather than appearing
+  // and disappearing per row: enabled when the task owns worktrees, faded and
+  // non-actionable when it does not.
+  it("renders the row Sweep action when the task owns worktrees", async () => {
+    testState.worktreesByEpicId = new Map([
+      ["epic-from-history", [historyWorktree()]],
+    ]);
+    renderPanel("embedded", "/");
+
+    expect(await screen.findByTestId("epics-list-row-sweep")).not.toBeNull();
+    expect(screen.queryByTestId("epics-list-row-sweep-disabled")).toBeNull();
+  });
+
+  it("keeps a disabled Sweep action on a task with no worktrees", async () => {
+    testState.worktreesByEpicId = new Map();
+    renderPanel("embedded", "/");
+
+    const disabled = await screen.findByTestId("epics-list-row-sweep-disabled");
+    expect(disabled.getAttribute("aria-disabled")).toBe("true");
+    expect(screen.queryByTestId("epics-list-row-sweep")).toBeNull();
+  });
+
   it("shows task PR pills without replacing the row navigation layer", async () => {
     testState.worktreesByEpicId = new Map([
       ["epic-from-history", [historyWorktree()]],

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -540,17 +540,26 @@ describe("<EpicsListPanel />", () => {
     ]);
     renderPanel("embedded", "/");
 
-    expect(await screen.findByTestId("epics-list-row-sweep")).not.toBeNull();
-    expect(screen.queryByTestId("epics-list-row-sweep-disabled")).toBeNull();
+    const sweep = await screen.findByRole("button", {
+      name: /^sweep worktrees for /i,
+    });
+    expect(sweep.getAttribute("aria-disabled")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /^no worktrees to sweep for /i }),
+    ).toBeNull();
   });
 
   it("keeps a disabled Sweep action on a task with no worktrees", async () => {
     testState.worktreesByEpicId = new Map();
     renderPanel("embedded", "/");
 
-    const disabled = await screen.findByTestId("epics-list-row-sweep-disabled");
+    const disabled = await screen.findByRole("button", {
+      name: /^no worktrees to sweep for /i,
+    });
     expect(disabled.getAttribute("aria-disabled")).toBe("true");
-    expect(screen.queryByTestId("epics-list-row-sweep")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /^sweep worktrees for /i }),
+    ).toBeNull();
   });
 
   it("shows task PR pills without replacing the row navigation layer", async () => {

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -346,15 +346,22 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
     setWorktreeCheckOverrides(new Map());
   }, []);
 
-  const [sweepEpicId, setSweepEpicId] = useState<string | null>(null);
+  // A sweep target is a SET: one id from a row action, the whole selection
+  // from the bulk action. The set is load-bearing - a worktree shared between
+  // two SELECTED tasks is no longer "shared" and becomes an ordinary
+  // candidate.
+  const [sweepEpicIds, setSweepEpicIds] =
+    useState<ReadonlyArray<string> | null>(null);
   const requestSweep = useCallback((epicId: string) => {
-    setSweepEpicId(epicId);
+    setSweepEpicIds([epicId]);
   }, []);
   const sweepTaskTitle = useMemo(() => {
-    if (sweepEpicId === null) return null;
-    const item = items.find((candidate) => candidate.epicId === sweepEpicId);
+    if (sweepEpicIds === null || sweepEpicIds.length !== 1) return null;
+    const item = items.find(
+      (candidate) => candidate.epicId === sweepEpicIds[0],
+    );
     return item === undefined ? null : historyItemDisplayTitle(item);
-  }, [items, sweepEpicId]);
+  }, [items, sweepEpicIds]);
 
   const selectableItemIds = useMemo(
     () =>
@@ -489,6 +496,13 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
                   onDeleteSelected: () => {
                     requestDelete(visibleSelectedIds);
                   },
+                  onSweepSelected: () => {
+                    // The whole selection goes in as ONE set so a worktree
+                    // shared between two selected tasks is judged against the
+                    // selection, not one task, and stops reading as "shared".
+                    if (visibleSelectedIds.length === 0) return;
+                    setSweepEpicIds(visibleSelectedIds);
+                  },
                 }
               : {
                   kind: "idle",
@@ -551,10 +565,10 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
         onTogglePath={toggleWorktreePathChecked}
       />
       <SweepWorktreesDialog
-        epicId={sweepEpicId}
+        epicIds={sweepEpicIds}
         taskTitle={sweepTaskTitle}
         onOpenChange={(open) => {
-          if (!open) setSweepEpicId(null);
+          if (!open) setSweepEpicIds(null);
         }}
       />
       <UnsyncedEpicMoveDialog flow={openInNewWindowFlow.epicFlow} />
@@ -659,6 +673,7 @@ type PanelSelectionControls =
       readonly onDeselectAll: () => void;
       readonly onCancel: () => void;
       readonly onDeleteSelected: () => void;
+      readonly onSweepSelected: () => void;
     };
 
 interface PanelRefreshControls {
@@ -724,6 +739,23 @@ function PanelChromeBar(props: PanelChromeBarProps): ReactNode {
             >
               <X />
               Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label={
+                props.selection.selectedCount > 0
+                  ? `Sweep worktrees for ${props.selection.selectedCount} selected tasks`
+                  : "Sweep worktrees for selected tasks"
+              }
+              aria-haspopup="dialog"
+              data-testid="epics-list-sweep-selected"
+              disabled={props.selection.selectedCount === 0}
+              className="text-muted-foreground hover:text-foreground"
+              onClick={props.selection.onSweepSelected}
+            >
+              <Paintbrush />
             </Button>
             <Button
               type="button"

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -1277,7 +1277,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
       })}
     >
       {rowInteractionLayer}
-      <div className={historyRowContentClassName(rowSweep.canSweep)}>
+      <div className={historyRowContentClassName(rowSweep.isVisible)}>
         <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
           <HistoryRowLeadingIcon item={item} />
           {isRenaming ? (
@@ -1460,6 +1460,9 @@ function historySelectedForDelete(args: {
 }
 
 interface HistoryRowSweepState {
+  /** The control renders at all (hidden for phases / during selection). */
+  readonly isVisible: boolean;
+  /** There is something to open the dialog for. */
   readonly canSweep: boolean;
   readonly requestSweep: () => void;
 }
@@ -1480,7 +1483,13 @@ function useHistoryRowSweep(
   const requestSweep = useCallback(() => {
     onRequestSweep(item.epicId);
   }, [item.epicId, onRequestSweep]);
+  // Visible-but-disabled when the Task owns no worktrees, matching how the
+  // delete control and the bulk Sweep button behave: the affordance keeps its
+  // place in the row instead of appearing and disappearing per row. Phases are
+  // still skipped entirely - they never have worktrees, so a permanently dead
+  // control there would be noise rather than consistency.
   return {
+    isVisible: !selectionMode && item.taskType !== "phase",
     canSweep:
       !selectionMode && item.taskType !== "phase" && worktrees.length > 0,
     requestSweep,
@@ -1491,24 +1500,49 @@ function HistoryRowSweepControl(props: {
   readonly sweep: HistoryRowSweepState;
   readonly displayTitle: string;
 }): ReactNode {
-  if (!props.sweep.canSweep) return null;
+  if (!props.sweep.isVisible) return null;
+  if (props.sweep.canSweep) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Sweep worktrees for ${props.displayTitle}`}
+            aria-haspopup="dialog"
+            data-testid="epics-list-row-sweep"
+            className="absolute right-11 top-1/2 -translate-y-1/2 opacity-0 transition-opacity hover:bg-muted focus-visible:opacity-100 group-hover:opacity-100"
+            onClick={props.sweep.requestSweep}
+          >
+            <Paintbrush />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Sweep this task's worktrees</TooltipContent>
+      </Tooltip>
+    );
+  }
+  // `aria-disabled` rather than `disabled`, matching the delete control: a
+  // truly disabled button swallows pointer events, and the tooltip is the only
+  // place the reason is stated.
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button
+        <button
           type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label={`Sweep worktrees for ${props.displayTitle}`}
-          aria-haspopup="dialog"
-          data-testid="epics-list-row-sweep"
-          className="absolute right-11 top-1/2 -translate-y-1/2 opacity-0 transition-opacity hover:bg-muted focus-visible:opacity-100 group-hover:opacity-100"
-          onClick={props.sweep.requestSweep}
+          aria-disabled="true"
+          aria-label={`No worktrees to sweep for ${props.displayTitle}`}
+          data-testid="epics-list-row-sweep-disabled"
+          className="absolute right-11 top-1/2 inline-flex size-8 -translate-y-1/2 cursor-not-allowed items-center justify-center rounded-md text-muted-foreground/50 opacity-0 transition-opacity outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/50 group-hover:opacity-100"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
         >
-          <Paintbrush />
-        </Button>
+          <Paintbrush className="size-4" />
+        </button>
       </TooltipTrigger>
-      <TooltipContent>Sweep this task's worktrees</TooltipContent>
+      <TooltipContent>This task has no worktrees on this host</TooltipContent>
     </Tooltip>
   );
 }
@@ -1528,12 +1562,12 @@ function HistorySweepMenuItem(props: {
   );
 }
 
-function historyRowContentClassName(canSweep: boolean): string {
+function historyRowContentClassName(hasSweepControl: boolean): string {
   return cn(
     "pointer-events-none relative z-10 flex items-center justify-between gap-3 p-3 pr-12 text-ui-sm",
     // Reserve room for the second hover control so the sweep button never
     // overlaps the trailing metadata / PR pills.
-    canSweep && "pr-20",
+    hasSweepControl && "pr-20",
   );
 }
 

--- a/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
@@ -34,8 +34,14 @@ import {
 import { cn } from "@/lib/utils";
 
 interface SweepWorktreesDialogProps {
-  /** The Task being swept; `null` keeps the dialog closed and its query off. */
-  readonly epicId: string | null;
+  /**
+   * The Tasks being swept. `null` (or empty) keeps the dialog closed and its
+   * query off. More than one comes from History's multi-select, and the extra
+   * members are load-bearing rather than cosmetic: a worktree shared between
+   * two selected Tasks stops counting as "shared".
+   */
+  readonly epicIds: ReadonlyArray<string> | null;
+  /** Title for a single-Task sweep; `null` for bulk or unknown. */
   readonly taskTitle: string | null;
   readonly onOpenChange: (open: boolean) => void;
 }
@@ -58,24 +64,28 @@ const TIER_PILL_CLASS: Record<WorktreeTier, string> = {
 };
 
 const NOTE_COPY: Record<NonNullable<EpicSweepWorktreeRow["note"]>, string> = {
-  shared: "Also used by another Task — sweeping breaks its binding",
+  shared:
+    "Also used by a Task outside this selection — sweeping breaks its binding",
   "in-use": "In use by an active agent or terminal",
   checking: "Still checking — facts unverified",
   "not-landed": "Not proven landed — work here may be lost",
 };
 
 /**
- * The Sweep confirmation. EVERY worktree the Task owns is listed with
- * Settings-grade detail (branch, tier pill, PR chips, path); only the
- * proven-safe rows (Landed / At base commit, exclusively owned, not busy)
- * start checked. Unproven or shared rows are unchecked but deliberately
- * checkable — sweeping them is the user's conscious call — while busy and
- * still-checking rows are disabled. Self-contained: both the history rows and
- * the task-status strip render this with just an epicId.
+ * The Sweep confirmation. EVERY worktree owned by the selected Task(s) is
+ * listed once with Settings-grade detail (branch, tier pill, PR chips, path);
+ * only the proven-safe rows (Landed / At base commit, exclusively owned by the
+ * selection, not busy) start checked. Unproven or shared rows are unchecked but
+ * deliberately checkable — sweeping them is the user's conscious call — while
+ * busy and still-checking rows are disabled.
+ *
+ * Self-contained: the History row, History's bulk selection, and the Epic
+ * status row all render it with just a list of epic ids.
  */
 export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
-  const { epicId, taskTitle, onOpenChange } = props;
-  const { rows, isPending, isError } = useEpicSweepWorktreeCandidates(epicId);
+  const { epicIds, taskTitle, onOpenChange } = props;
+  const { rows, isPending, isError } = useEpicSweepWorktreeCandidates(epicIds);
+  const taskCount = epicIds?.length ?? 0;
   const sweepMutation = useEpicSweepWorktrees();
   // Explicit user toggles, cleared whenever the dialog retargets so a
   // reopened dialog starts from the per-row defaults again (the
@@ -83,9 +93,14 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
   const [checkOverrides, setCheckOverrides] = useState<
     ReadonlyMap<string, boolean>
   >(() => new Map());
-  const [previousEpicId, setPreviousEpicId] = useState(epicId);
-  if (epicId !== previousEpicId) {
-    setPreviousEpicId(epicId);
+  // Keyed on the selection itself so re-opening with a DIFFERENT set of Tasks
+  // starts from the per-row defaults again.
+  const selectionKey =
+    epicIds === null ? null : [...new Set(epicIds)].sort().join(",");
+  const [previousSelectionKey, setPreviousSelectionKey] =
+    useState(selectionKey);
+  if (selectionKey !== previousSelectionKey) {
+    setPreviousSelectionKey(selectionKey);
     setCheckOverrides(new Map());
   }
   // Read from the mutation cache, not this instance: the dialog is mounted
@@ -121,7 +136,7 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
   };
 
   return (
-    <Dialog open={epicId !== null} onOpenChange={onOpenChange}>
+    <Dialog open={taskCount > 0} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
         className="flex max-h-[min(90dvh,42rem)] w-[min(92vw,34rem)] min-w-0 flex-col gap-0 overflow-hidden p-0 sm:max-w-xl"
@@ -133,9 +148,7 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
           </div>
           <div className="min-h-0 min-w-0 flex-1 space-y-1.5">
             <DialogTitle className="text-ui font-semibold leading-snug wrap-anywhere">
-              {taskTitle === null
-                ? "Sweep worktrees?"
-                : `Sweep worktrees for "${taskTitle}"?`}
+              {sweepDialogTitle(taskCount, taskTitle)}
             </DialogTitle>
             <DialogDescription className="text-ui-sm leading-relaxed text-muted-foreground wrap-anywhere">
               Removes the selected worktrees and their branches from this host.
@@ -204,6 +217,18 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
   );
 }
 
+/**
+ * Names what is being swept. A single Task uses its title when we have one;
+ * a bulk sweep names the count instead, because listing titles would push the
+ * worktree list (the thing being confirmed) below the fold.
+ */
+function sweepDialogTitle(taskCount: number, taskTitle: string | null): string {
+  if (taskCount > 1) return `Sweep worktrees for ${taskCount} tasks?`;
+  return taskTitle === null
+    ? "Sweep worktrees?"
+    : `Sweep worktrees for "${taskTitle}"?`;
+}
+
 function SweepRowList(props: {
   readonly isPending: boolean;
   readonly isError: boolean;
@@ -232,8 +257,8 @@ function SweepRowList(props: {
         data-testid="sweep-worktrees-empty"
       >
         {props.isError
-          ? "Couldn't check this Task's worktrees. Try again from Settings ▸ Worktrees."
-          : "This Task has no worktrees on this host."}
+          ? "Couldn't check these worktrees. Try again from Settings ▸ Worktrees."
+          : "No worktrees on this host for the selected tasks."}
       </p>
     );
   }

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-sweep-worktree-candidates-query.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-sweep-worktree-candidates-query.test.tsx
@@ -117,9 +117,9 @@ function wrapperFor(queryClient: QueryClient) {
   );
 }
 
-function renderCandidates(epicId: string | null) {
+function renderCandidates(epicIds: ReadonlyArray<string> | null) {
   const queryClient = new QueryClient();
-  return renderHook(() => useEpicSweepWorktreeCandidates(epicId), {
+  return renderHook(() => useEpicSweepWorktreeCandidates(epicIds), {
     wrapper: wrapperFor(queryClient),
   });
 }
@@ -150,7 +150,7 @@ describe("useEpicSweepWorktreeCandidates", () => {
         entry({ worktreePath: "/wt/review" }),
       ],
     );
-    const { result } = renderCandidates("epic-1");
+    const { result } = renderCandidates(["epic-1"]);
     await waitFor(() => {
       expect(result.current.rows).toHaveLength(3);
     });
@@ -212,7 +212,7 @@ describe("useEpicSweepWorktreeCandidates", () => {
         }),
       ],
     );
-    const { result } = renderCandidates("epic-1");
+    const { result } = renderCandidates(["epic-1"]);
     await waitFor(() => {
       expect(result.current.rows).toHaveLength(1);
     });
@@ -245,7 +245,7 @@ describe("useEpicSweepWorktreeCandidates", () => {
       }),
     ];
     mockActTimeProbe(probed, probed);
-    const { result } = renderCandidates("epic-1");
+    const { result } = renderCandidates(["epic-1"]);
     await waitFor(() => {
       expect(result.current.rows).toHaveLength(3);
     });
@@ -269,12 +269,91 @@ describe("useEpicSweepWorktreeCandidates", () => {
     });
   });
 
+  // The bulk-sweep rule the multi-select exists for: "shared" is judged
+  // against the SELECTION, not one Task. Selecting every owner of a shared
+  // worktree satisfies the constraint, because sweeping the selection removes
+  // every binding that referenced it.
+  it("stops treating a worktree as shared once ALL its owner tasks are selected", async () => {
+    const probed = [
+      entry({
+        worktreePath: "/wt/shared",
+        owners: [owner("epic-1"), owner("epic-2")],
+        prState: "merged",
+        mergedHeadShaMatches: true,
+      }),
+    ];
+    mockActTimeProbe(probed, probed);
+    const { result } = renderCandidates(["epic-1", "epic-2"]);
+    await waitFor(() => {
+      expect(result.current.rows).toHaveLength(1);
+    });
+    expect(result.current.rows[0]).toMatchObject({
+      tier: "merged",
+      defaultChecked: true,
+      disabled: false,
+      note: null,
+    });
+  });
+
+  it("keeps a partially-selected shared worktree unchecked and marked shared", async () => {
+    const probed = [
+      entry({
+        worktreePath: "/wt/shared",
+        owners: [owner("epic-1"), owner("epic-2"), owner("epic-3")],
+        prState: "merged",
+        mergedHeadShaMatches: true,
+      }),
+    ];
+    mockActTimeProbe(probed, probed);
+    // epic-3 is NOT selected, so one binding would survive the sweep.
+    const { result } = renderCandidates(["epic-1", "epic-2"]);
+    await waitFor(() => {
+      expect(result.current.rows).toHaveLength(1);
+    });
+    expect(result.current.rows[0]).toMatchObject({
+      defaultChecked: false,
+      disabled: false,
+      note: "shared",
+    });
+  });
+
+  // The amalgamation: a worktree owned by two selected tasks is ONE row, and
+  // the probe covers every selected task's paths.
+  it("lists the union of the selection's worktrees, de-duplicated", async () => {
+    const shared = entry({
+      worktreePath: "/wt/shared",
+      owners: [owner("epic-1"), owner("epic-2")],
+      atBaseCommit: true,
+    });
+    const onlyOne = entry({ worktreePath: "/wt/one", atBaseCommit: true });
+    const onlyTwo = entry({
+      worktreePath: "/wt/two",
+      owners: [owner("epic-2")],
+      atBaseCommit: true,
+    });
+    mockActTimeProbe([shared, onlyOne, onlyTwo], [shared, onlyOne, onlyTwo]);
+    const { result } = renderCandidates(["epic-1", "epic-2"]);
+    await waitFor(() => {
+      expect(result.current.rows).toHaveLength(3);
+    });
+    expect(result.current.rows.map((r) => r.entry.worktreePath)).toEqual([
+      "/wt/shared",
+      "/wt/one",
+      "/wt/two",
+    ]);
+    expect(mockHostClient.request).toHaveBeenNthCalledWith(
+      2,
+      "worktree.listAllForHost",
+      forcedProbeParams(["/wt/shared", "/wt/one", "/wt/two"]),
+    );
+  });
+
   it("skips the forced probe entirely when the Task owns no worktrees", async () => {
     mockActTimeProbe(
       [entry({ worktreePath: "/wt/foreign", owners: [owner("epic-2")] })],
       [],
     );
-    const { result } = renderCandidates("epic-1");
+    const { result } = renderCandidates(["epic-1"]);
     await waitFor(() => {
       expect(result.current.isPending).toBe(false);
     });
@@ -289,7 +368,7 @@ describe("useEpicSweepWorktreeCandidates", () => {
 
   it("yields zero rows on a failed probe (failure -> no candidates)", async () => {
     mockHostClient.request.mockRejectedValue(new Error("probe failed"));
-    const { result } = renderCandidates("epic-1");
+    const { result } = renderCandidates(["epic-1"]);
     await waitFor(() => {
       expect(result.current.isError).toBe(true);
     });

--- a/clients/gui-app/src/hooks/epic/use-epic-sweep-worktree-candidates-query.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-sweep-worktree-candidates-query.ts
@@ -58,10 +58,17 @@ const EMPTY_ROWS: ReadonlyArray<EpicSweepWorktreeRow> = [];
  * facts (uncommitted count, branch) and merge proofs — bounded by the Task's
  * worktree count, never the fleet.
  *
- * EVERY task-owned worktree is returned, classified: green + exclusive + not
- * busy rows default-checked, everything else unchecked with its reason (still
- * checkable except busy/unverified rows), so the dialog shows the Task's full
- * worktree picture rather than a silently pre-filtered subset.
+ * Takes the SELECTED SET of Tasks, not one Task, so History's multi-select can
+ * sweep in bulk. The returned rows are the amalgamation - every worktree owned
+ * by any selected Task, listed once - and "shared" is judged against the whole
+ * selection: a worktree owned by two Tasks is only shared while at least one of
+ * its owners is unselected, so selecting both satisfies the constraint and the
+ * row becomes an ordinary candidate.
+ *
+ * EVERY owned worktree is returned, classified: green + exclusive + not busy
+ * rows default-checked, everything else unchecked with its reason (still
+ * checkable except busy/unverified rows), so the dialog shows the full worktree
+ * picture rather than a silently pre-filtered subset.
  *
  * Known residual: PR facts are read non-blocking on the host, so the first
  * forced probe after an EXTERNAL merge can still serve the stale `open` fact
@@ -71,16 +78,25 @@ const EMPTY_ROWS: ReadonlyArray<EpicSweepWorktreeRow> = [];
  *
  * Rows are recomputed only from a settled probe (`isPending` while in flight,
  * including re-opens), so the dialog can never offer rows from a previous
- * open. Pass `null` while the dialog is closed to disable the query. Any
- * error yields zero rows ("failure -> no candidates"); the host-side
+ * open. Pass `null` (or an empty selection) while the dialog is closed to
+ * disable the query. Any error yields zero rows ("failure -> no candidates");
+ * the host-side
  * busy-check on `worktree.deleteByPath` remains the authoritative backstop
  * either way.
  */
 export function useEpicSweepWorktreeCandidates(
-  epicId: string | null,
+  epicIds: ReadonlyArray<string> | null,
 ): EpicSweepWorktreeCandidatesResult {
   const client = useHostClient();
   const readiness = useReactiveHostReadiness(client);
+  // Sorted + de-duplicated so the cache identity does not depend on selection
+  // ORDER, and so re-selecting the same tasks reuses the same query slot.
+  const selectedEpicIds = useMemo(
+    () => (epicIds === null ? null : [...new Set(epicIds)].sort()),
+    [epicIds],
+  );
+  const selectedEpicKey =
+    selectedEpicIds === null ? "" : selectedEpicIds.join(",");
   const fetchFreshTaskWorktrees =
     async (): Promise<WorktreeListAllForHostResponseV14> => {
       // Cheap disk-truth walk (no git/gh probes, host cache is fine): only
@@ -95,8 +111,9 @@ export function useEpicSweepWorktreeCandidates(
           forceRefresh: false,
         },
       );
+      const selected = new Set(selectedEpicIds ?? []);
       const ownedPaths = base.worktrees.flatMap((entry) =>
-        entry.owners.some((owner) => owner.epicId === epicId)
+        entry.owners.some((owner) => selected.has(owner.epicId))
           ? [entry.worktreePath]
           : [],
       );
@@ -123,10 +140,13 @@ export function useEpicSweepWorktreeCandidates(
     queryOptions<WorktreeListAllForHostResponseV14, HostRpcError>({
       queryKey: hostQueryKeys.sweepWorktreeCandidates(
         readiness.hostId,
-        epicId ?? "",
+        selectedEpicKey,
       ),
       queryFn: fetchFreshTaskWorktreesNormalized,
-      enabled: epicId !== null && readiness.isReady,
+      enabled:
+        selectedEpicIds !== null &&
+        selectedEpicIds.length > 0 &&
+        readiness.isReady,
       // Always stale: every dialog open re-runs the forced probe rather than
       // trusting a previous open's proof.
       staleTime: 0,
@@ -134,25 +154,33 @@ export function useEpicSweepWorktreeCandidates(
     }),
   );
 
-  const isPending = epicId !== null && isFetching;
+  const isPending =
+    selectedEpicIds !== null && selectedEpicIds.length > 0 && isFetching;
   const worktrees = data?.worktrees;
   return useMemo<EpicSweepWorktreeCandidatesResult>(() => {
     // While the probe is in flight, retained data from a PREVIOUS open must
     // not surface as offerable rows — the whole point is act-time proof.
-    if (epicId === null || worktrees === undefined || isError || isPending) {
+    if (
+      selectedEpicIds === null ||
+      worktrees === undefined ||
+      isError ||
+      isPending
+    ) {
       return { rows: EMPTY_ROWS, isPending, isError };
     }
+    // The amalgamation: every worktree owned by ANY selected Task, listed once.
+    const selected = new Set(selectedEpicIds);
     const rows = worktrees.flatMap((entry) =>
-      entry.owners.some((owner) => owner.epicId === epicId)
-        ? [classifySweepRow(epicId, entry)]
+      entry.owners.some((owner) => selected.has(owner.epicId))
+        ? [classifySweepRow(selected, entry)]
         : [],
     );
     return { rows, isPending: false, isError };
-  }, [epicId, isError, isPending, worktrees]);
+  }, [selectedEpicIds, isError, isPending, worktrees]);
 }
 
 function classifySweepRow(
-  epicId: string,
+  selectedEpicIds: ReadonlySet<string>,
   entry: WorktreeHostEntryV14,
 ): EpicSweepWorktreeRow {
   const tier = classifyWorktreeTier(entry);
@@ -163,7 +191,10 @@ function classifySweepRow(
   if (entry.resolvedAt === null) {
     return { ...base, disabled: true, note: "checking" };
   }
-  if (entry.owners.some((owner) => owner.epicId !== epicId)) {
+  // Exclusivity is judged against the WHOLE selection, not one Task: a
+  // worktree shared by two Tasks stops being "shared" once both are selected,
+  // because sweeping the selection removes every binding that referenced it.
+  if (entry.owners.some((owner) => !selectedEpicIds.has(owner.epicId))) {
     return { ...base, disabled: false, note: "shared" };
   }
   if (!sweepEligibleTier(tier)) {

--- a/clients/gui-app/src/lib/query-keys/host-query-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/host-query-keys.ts
@@ -73,8 +73,10 @@ export const hostQueryKeys = {
     ),
   /**
    * The Sweep dialog's act-time candidate probe: a composed fetch (un-probed
-   * base walk to find the Task's paths, then a selection-mode `forceRefresh`
-   * enrichment of exactly those paths). Epic-scoped and deliberately OUTSIDE
+   * base walk to find the selected Tasks' paths, then a selection-mode
+   * `forceRefresh` enrichment of exactly those paths). `epicKey` is the
+   * sorted, comma-joined selection, so the same set reuses one slot whatever
+   * the click order. Selection-scoped and deliberately OUTSIDE
    * the `worktree.listAllForHost` method scope: the forced probe itself makes
    * the host publish a `worktree.changed` burst, and the client's blanket
    * listing invalidation (refetchType "active") would refetch this very query
@@ -82,11 +84,11 @@ export const hostQueryKeys = {
    * flashing the candidate list back to "Checking…". External invalidation
    * buys it nothing anyway: `staleTime: 0` already re-proves on every open.
    */
-  sweepWorktreeCandidates: (hostId: string | null, epicId: string) =>
+  sweepWorktreeCandidates: (hostId: string | null, epicKey: string) =>
     [
       ...hostQueryKeys.scope(hostId),
       "worktree.sweepCandidates",
-      epicId,
+      epicKey,
     ] as const,
   /**
    * Batch task-context title lookup (`epic.getTaskContexts`). Key shape matches


### PR DESCRIPTION
## What

History already had multi-select for bulk delete; Sweep now shares it. The selection bar gains a Sweep action beside Delete, and the dialog takes the **whole selected set** rather than one Task.

## Why the set is load-bearing

"Shared with another Task" was the one Sweep exclusion that could be **satisfied by selecting more**. A worktree owned by two Tasks is only shared while one of its owners sits outside the selection — sweeping the selection removes every binding that referenced it.

So exclusivity is judged against the selection:

| Selection | Worktree owned by | Result |
|---|---|---|
| `{A}` | A, B | `shared`, unchecked |
| `{A, B}` | A, B | ordinary candidate, **default-checked** |
| `{A, B}` | A, B, C | `shared`, unchecked (C would survive) |

## Amalgamation

Rows are the union of every worktree owned by any selected Task, listed **once** even when several of them own it. The forced act-time probe covers the union of their paths, and the query key is the sorted, comma-joined selection so the same set reuses one cache slot whatever the click order.

## Notes

- Single-Task entry points (History row action, Epic status row) are unchanged in behaviour — they pass a one-element set.
- Dialog title names the count for a bulk sweep; a single Task keeps its title.
- Follows #727.

## Testing

- 3 new hook tests: shared-becomes-candidate when all owners are selected, stays shared when partially selected, and the de-duplicated union with its probe payload.
- 1209 tests pass across the affected suites (`components/epics`, `components/epic-canvas`, `stores/worktree`, `hooks/epic`); compile and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)