### PR TITLE
fix(protocol,gui-app): preserve ordered list start values

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/queued-message-content-preview.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/queued-message-content-preview.test.tsx
@@ -13,6 +13,37 @@ function renderPreview(content: JsonContent) {
 }
 
 describe("QueuedMessageContentPreview", () => {
+  it("preserves a non-one ordered-list start", () => {
+    const content: JsonContent = {
+      type: "doc",
+      content: [
+        {
+          type: "orderedList",
+          attrs: { start: 2 },
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: "Second" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    renderPreview(content);
+
+    const orderedList = screen.getByRole("list");
+    if (!(orderedList instanceof HTMLOListElement)) {
+      throw new Error("expected an ordered list");
+    }
+    expect(orderedList.start).toBe(2);
+  });
+
   it("renders mention chips inline instead of summary badges", () => {
     const content: JsonContent = {
       type: "doc",

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-list-input.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-list-input.test.tsx
@@ -1,8 +1,16 @@
 import "../../../../../__tests__/test-browser-apis";
+import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { jsonContentToMarkdown } from "@traycer/protocol/common/json-content-serializer";
+import type { JsonContent } from "@traycer/protocol/common/registry";
 
+import {
+  buildSubmittedChatJSONContent,
+  numberValue,
+} from "@/lib/composer/tiptap-json-content";
+import { ComposerContentRenderer } from "../content-renderer";
 import { buildComposerExtensions } from "../editor/editor-config";
 import { createComposerPickerStore } from "../picker/composer-picker-store";
 
@@ -38,6 +46,7 @@ function makeFixture(): {
 }
 
 afterEach(() => {
+  cleanup();
   editors.splice(0).forEach((editor) => editor.destroy());
   elements.splice(0).forEach((element) => element.remove());
 });
@@ -127,7 +136,89 @@ describe("composer list input", () => {
     expect(submitCalls.count).toBe(0);
     expect(listItemTexts(editor)).toEqual(["first", "second"]);
   });
+
+  it("preserves a non-one starting number from input through sent-message rendering", () => {
+    const { editor, submitCalls } = makeFixture();
+    typeText(editor, "2. Hello");
+
+    expect(firstNodeOfType(editor, "orderedList")?.attrs.start).toBe(2);
+    expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+    expect(submitCalls.count).toBe(1);
+
+    const submitted = buildSubmittedChatJSONContent(editor.getJSON());
+    expect(serializeForAgent(submitted)).toBe("2. Hello");
+
+    const orderedList = renderSubmittedContent(submitted).querySelector("ol");
+    expect(orderedList).not.toBeNull();
+    expect(orderedList?.start).toBe(2);
+    expect(orderedList?.textContent).toBe("Hello");
+  });
+
+  it("keeps a later-starting multi-item list sequential after submission", () => {
+    const { editor, submitCalls } = makeFixture();
+    typeText(editor, "2. First");
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
+    typeText(editor, "Second");
+
+    expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+    expect(submitCalls.count).toBe(1);
+
+    const submitted = buildSubmittedChatJSONContent(editor.getJSON());
+    expect(serializeForAgent(submitted)).toBe("2. First\n3. Second");
+
+    const orderedList = renderSubmittedContent(submitted).querySelector("ol");
+    expect(orderedList).not.toBeNull();
+    expect(orderedList?.start).toBe(2);
+    expect(
+      Array.from(orderedList?.querySelectorAll("li") ?? []).map(
+        (item) => item.textContent,
+      ),
+    ).toEqual(["First", "Second"]);
+  });
+
+  it("preserves separately entered list starts when two appears before one", () => {
+    const { editor, submitCalls } = makeFixture();
+    typeText(editor, "2. Second");
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
+    expect(editor.commands.keyboardShortcut("Shift-Enter")).toBe(true);
+    typeText(editor, "1. First");
+
+    expect(
+      editor
+        .getJSON()
+        .content.filter((node) => node.type === "orderedList")
+        .map((node) => numberValue(node.attrs?.start)),
+    ).toEqual([2, 1]);
+    expect(editor.commands.keyboardShortcut("Enter")).toBe(true);
+    expect(submitCalls.count).toBe(1);
+
+    const submitted = buildSubmittedChatJSONContent(editor.getJSON());
+    expect(serializeForAgent(submitted)).toBe("2. Second\n\n1. First");
+    expect(
+      Array.from(renderSubmittedContent(submitted).querySelectorAll("ol")).map(
+        (list) => list.start,
+      ),
+    ).toEqual([2, 1]);
+  });
 });
+
+function renderSubmittedContent(content: JsonContent): HTMLElement {
+  return render(
+    <ComposerContentRenderer
+      content={content}
+      variant={undefined}
+      className={undefined}
+      testId={undefined}
+    />,
+  ).container;
+}
+
+function serializeForAgent(content: JsonContent): string {
+  return jsonContentToMarkdown(content, {
+    mentionFormat: "llm",
+    platform: "POSIX",
+  });
+}
 
 function typeText(editor: Editor, value: string): void {
   Array.from(value).forEach((char) => typeChar(editor, char));

--- a/clients/gui-app/src/components/chat/composer/__tests__/composer-list-input.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/composer-list-input.test.tsx
@@ -1,5 +1,5 @@
 import "../../../../../__tests__/test-browser-apis";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { Editor } from "@tiptap/core";
 import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
@@ -148,10 +148,10 @@ describe("composer list input", () => {
     const submitted = buildSubmittedChatJSONContent(editor.getJSON());
     expect(serializeForAgent(submitted)).toBe("2. Hello");
 
-    const orderedList = renderSubmittedContent(submitted).querySelector("ol");
-    expect(orderedList).not.toBeNull();
-    expect(orderedList?.start).toBe(2);
-    expect(orderedList?.textContent).toBe("Hello");
+    const rendered = renderSubmittedContent(submitted);
+    const orderedList = orderedListElement(within(rendered).getByRole("list"));
+    expect(orderedList.start).toBe(2);
+    expect(within(orderedList).getByRole("listitem").textContent).toBe("Hello");
   });
 
   it("keeps a later-starting multi-item list sequential after submission", () => {
@@ -166,13 +166,13 @@ describe("composer list input", () => {
     const submitted = buildSubmittedChatJSONContent(editor.getJSON());
     expect(serializeForAgent(submitted)).toBe("2. First\n3. Second");
 
-    const orderedList = renderSubmittedContent(submitted).querySelector("ol");
-    expect(orderedList).not.toBeNull();
-    expect(orderedList?.start).toBe(2);
+    const rendered = renderSubmittedContent(submitted);
+    const orderedList = orderedListElement(within(rendered).getByRole("list"));
+    expect(orderedList.start).toBe(2);
     expect(
-      Array.from(orderedList?.querySelectorAll("li") ?? []).map(
-        (item) => item.textContent,
-      ),
+      within(orderedList)
+        .getAllByRole("listitem")
+        .map((item) => item.textContent),
     ).toEqual(["First", "Second"]);
   });
 
@@ -194,10 +194,11 @@ describe("composer list input", () => {
 
     const submitted = buildSubmittedChatJSONContent(editor.getJSON());
     expect(serializeForAgent(submitted)).toBe("2. Second\n\n1. First");
+    const rendered = renderSubmittedContent(submitted);
     expect(
-      Array.from(renderSubmittedContent(submitted).querySelectorAll("ol")).map(
-        (list) => list.start,
-      ),
+      within(rendered)
+        .getAllByRole("list")
+        .map((list) => orderedListElement(list).start),
     ).toEqual([2, 1]);
   });
 });
@@ -211,6 +212,13 @@ function renderSubmittedContent(content: JsonContent): HTMLElement {
       testId={undefined}
     />,
   ).container;
+}
+
+function orderedListElement(element: HTMLElement): HTMLOListElement {
+  if (!(element instanceof HTMLOListElement)) {
+    throw new Error("expected an ordered list");
+  }
+  return element;
 }
 
 function serializeForAgent(content: JsonContent): string {

--- a/clients/gui-app/src/components/chat/composer/content-renderer/render-node.tsx
+++ b/clients/gui-app/src/components/chat/composer/content-renderer/render-node.tsx
@@ -8,6 +8,7 @@ import {
   stringValue,
   mentionAttachmentFromAttrs,
   mentionPlainTextFromAttrs,
+  numberValue,
   slashCommandPlainTextFromAttrs,
 } from "@/lib/composer/tiptap-json-content";
 import { fallbackImageAttachmentDisplayLabel } from "@/lib/composer/image-attachment-labels";
@@ -179,6 +180,7 @@ const RENDERERS: Partial<Record<string, NodeRenderer>> = {
         />
       ),
       nodeKey: key,
+      start: numberValue(node.attrs?.start) ?? 1,
     }),
   listItem: (node, key, context) =>
     context.profile.renderListItem({

--- a/clients/gui-app/src/components/chat/composer/content-renderer/render-profile.tsx
+++ b/clients/gui-app/src/components/chat/composer/content-renderer/render-profile.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import type {
   ComposerContentBlockRenderArgs,
   ComposerContentCodeBlockRenderArgs,
+  ComposerContentOrderedListRenderArgs,
   ComposerContentRenderProfile,
   ComposerContentRenderVariant,
   ComposerContentRootRenderArgs,
@@ -129,9 +130,14 @@ function renderBulletList({
 function renderOrderedList({
   children,
   nodeKey,
-}: ComposerContentBlockRenderArgs) {
+  start,
+}: ComposerContentOrderedListRenderArgs) {
   return (
-    <ol key={nodeKey} className="my-0.5 list-decimal pl-5">
+    <ol
+      key={nodeKey}
+      start={start === 1 ? undefined : start}
+      className="my-0.5 list-decimal pl-5"
+    >
       {children}
     </ol>
   );

--- a/clients/gui-app/src/components/chat/composer/content-renderer/types.ts
+++ b/clients/gui-app/src/components/chat/composer/content-renderer/types.ts
@@ -25,6 +25,10 @@ export interface ComposerContentBlockRenderArgs {
   readonly nodeKey: string;
 }
 
+export interface ComposerContentOrderedListRenderArgs extends ComposerContentBlockRenderArgs {
+  readonly start: number;
+}
+
 export interface ComposerContentCodeBlockRenderArgs {
   readonly language: string;
   readonly nodeKey: string;
@@ -44,7 +48,7 @@ export interface ComposerContentRenderProfile {
     args: ComposerContentBlockRenderArgs,
   ) => ReactNode;
   readonly renderOrderedList: (
-    args: ComposerContentBlockRenderArgs,
+    args: ComposerContentOrderedListRenderArgs,
   ) => ReactNode;
   readonly renderListItem: (args: ComposerContentBlockRenderArgs) => ReactNode;
   readonly renderBlockquote: (

--- a/clients/gui-app/src/components/comments/__tests__/comment-content-renderer.test.tsx
+++ b/clients/gui-app/src/components/comments/__tests__/comment-content-renderer.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { JsonContent } from "@traycer/protocol/common/registry";
+
+import { CommentContent } from "../comment-content-renderer";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CommentContent ordered lists", () => {
+  it("preserves a non-one start across multiple rendered items", () => {
+    render(
+      <CommentContent
+        content={orderedList(["Second", "Third"], 2)}
+        className={undefined}
+      />,
+    );
+
+    const orderedListElement = screen.getByRole("list");
+    if (!(orderedListElement instanceof HTMLOListElement)) {
+      throw new Error("expected an ordered list");
+    }
+    expect(orderedListElement.start).toBe(2);
+    expect(
+      within(orderedListElement)
+        .getAllByRole("listitem")
+        .map((item) => item.textContent),
+    ).toEqual(["Second", "Third"]);
+  });
+});
+
+function orderedList(items: ReadonlyArray<string>, start: number): JsonContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "orderedList",
+        attrs: { start },
+        content: items.map((text) => ({
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text }],
+            },
+          ],
+        })),
+      },
+    ],
+  };
+}

--- a/clients/gui-app/src/components/comments/comment-content-renderer.tsx
+++ b/clients/gui-app/src/components/comments/comment-content-renderer.tsx
@@ -1,5 +1,6 @@
 import { Fragment, type ReactNode } from "react";
 import type { JsonContent } from "@traycer/protocol/common/registry";
+import { numberValue } from "@/lib/composer/tiptap-json-content";
 import { cn } from "@/lib/utils";
 
 /**
@@ -84,12 +85,17 @@ function renderBlock(node: JsonContent): ReactNode {
           <CommentNodeList nodes={node.content ?? []} />
         </ul>
       );
-    case "orderedList":
+    case "orderedList": {
+      const start = numberValue(node.attrs?.start) ?? 1;
       return (
-        <ol className="my-1 list-decimal pl-5">
+        <ol
+          start={start === 1 ? undefined : start}
+          className="my-1 list-decimal pl-5"
+        >
           <CommentNodeList nodes={node.content ?? []} />
         </ol>
       );
+    }
     case "listItem":
       return (
         <li>

--- a/protocol/src/common/__tests__/json-content-serializer-lists.test.ts
+++ b/protocol/src/common/__tests__/json-content-serializer-lists.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import type { JsonContent } from "../registry";
+import { jsonContentToMarkdown } from "../json-content-serializer";
+
+describe("jsonContentToMarkdown ordered lists", () => {
+  it("preserves an explicit starting number and increments later items", () => {
+    expect(toMarkdown(orderedList(["First", "Second"], 2))).toBe(
+      "2. First\n3. Second",
+    );
+  });
+
+  it("keeps the default start at one when the attribute is absent", () => {
+    expect(toMarkdown(orderedList(["First", "Second"], null))).toBe(
+      "1. First\n2. Second",
+    );
+  });
+});
+
+function orderedList(
+  items: ReadonlyArray<string>,
+  start: number | null,
+): JsonContent {
+  return {
+    type: "doc",
+    content: [
+      {
+        type: "orderedList",
+        attrs: start === null ? undefined : { start },
+        content: items.map((text) => ({
+          type: "listItem",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text }],
+            },
+          ],
+        })),
+      },
+    ],
+  };
+}
+
+function toMarkdown(content: JsonContent): string {
+  return jsonContentToMarkdown(content, {
+    mentionFormat: "llm",
+    platform: "POSIX",
+  });
+}

--- a/protocol/src/common/json-content-serializer.ts
+++ b/protocol/src/common/json-content-serializer.ts
@@ -652,7 +652,7 @@ function serializeOrderedList(
   };
 
   if (node.content) {
-    let index = 1;
+    let index = readNumberAttr(node.attrs, "start", 1);
     for (const child of node.content) {
       if (child.type === "listItem") {
         items.push(serializeListItem(child, childCtx, true, index));


### PR DESCRIPTION
Summary:
- preserve TipTap ordered-list start values in sent, queued, and comment renderers
- seed agent-facing Markdown numbering from the persisted start attribute
- cover non-one starts, multi-item sequencing, and reversed independent lists end to end

Validation:
- pre-commit affected lint, format, compile, and build checks
- focused GUI and protocol regression suites