### PR TITLE
fix(desktop): recover from SMAppService register failures instead of locking the gate

### DIFF
--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -3943,11 +3943,15 @@ describe("applyPendingLoginItemRevisionIfIdle", () => {
     expect(waitForHostReady).not.toHaveBeenCalled();
   });
 
-  // Fixup C3: ported from the deleted `host-ensure-ipc.test.ts` ("throws
-  // the login-item error when the idle refresh cycle ends a non-enabled,
-  // non-approval status" + "quarantines the refresh for the rest of the
-  // session after a cycle that did not land enabled").
-  it("registerHostLoginItem returning a non-enabled, non-approval status fails, quarantines, and a second attempt never re-runs the cycle", async () => {
+  // Field RCA 2026-07-28: this cycle's leading bootout had just torn down a
+  // verified-idle host when SMAppService answered `not-found` for every
+  // subsequent call in the session - the old terminal failure stranded the
+  // machine with nothing running AND nothing registered. The refresh must
+  // restore service via the CLI-owned LaunchAgent (which bypasses
+  // SMAppService/BTM), keep the quarantine so this session never re-runs
+  // the doomed cycle, and leave the marker for the next launch's fresh
+  // SMAppService session.
+  it("registerHostLoginItem returning a non-enabled, non-approval status recovers via the CLI takeover fallback, quarantines, and a second attempt never re-runs the cycle", async () => {
     vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
     const controller = newController("production");
     writeInstallRecord("production", {
@@ -3957,15 +3961,28 @@ describe("applyPendingLoginItemRevisionIfIdle", () => {
     writePidMetadata("production", { version: "1.7.0", pid: process.pid });
     vi.mocked(hasUnappliedPendingLoginItemRevision).mockResolvedValue(true);
     vi.mocked(registerHostLoginItem).mockResolvedValue("not-registered");
+    // The recovered host must publish the runtime the committed install
+    // expects - the beforeEach default (1.0.0) would rightly be rejected.
+    vi.mocked(waitForHostReady).mockResolvedValue({
+      ready: true,
+      version: "1.7.0",
+      pid: 1,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      reason: "ready",
+    });
 
     const outcome = await controller.applyPendingLoginItemRevisionIfIdle();
 
     expect(outcome).toEqual({
-      kind: "failed",
-      message: expect.stringContaining(
-        "could not be enabled (status: not-registered)",
-      ),
+      kind: "ok",
+      value: { running: true, version: "1.7.0" },
     });
+    expect(runBundledTraycerCliJson).toHaveBeenCalledWith([
+      "host",
+      "service",
+      "install",
+      "--takeover",
+    ]);
     expect(controller.isPendingRevisionRefreshQuarantined()).toBe(true);
     expect(registerHostLoginItem).toHaveBeenCalledTimes(1);
 
@@ -3976,6 +3993,33 @@ describe("applyPendingLoginItemRevisionIfIdle", () => {
     const second = await controller.applyPendingLoginItemRevisionIfIdle();
     expect(second).toBeNull();
     expect(registerHostLoginItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("a failing CLI fallback after a failed refresh cycle surfaces BOTH failures with the manual escape hatch", async () => {
+    vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "1.7.0",
+      runtimeVersion: "1.7.0",
+    });
+    writePidMetadata("production", { version: "1.7.0", pid: process.pid });
+    vi.mocked(hasUnappliedPendingLoginItemRevision).mockResolvedValue(true);
+    vi.mocked(registerHostLoginItem).mockResolvedValue("not-found");
+    vi.mocked(runBundledTraycerCliJson).mockRejectedValue(
+      new Error("takeover exploded"),
+    );
+
+    const outcome = await controller.applyPendingLoginItemRevisionIfIdle();
+
+    expect(outcome).toEqual({
+      kind: "failed",
+      message: expect.stringContaining("status=not-found"),
+    });
+    if (outcome !== null && outcome.kind === "failed") {
+      expect(outcome.message).toContain("takeover exploded");
+      expect(outcome.message).toContain("service uninstall");
+    }
+    expect(controller.isPendingRevisionRefreshQuarantined()).toBe(true);
   });
 
   // Fixup C3: ported from the deleted `host-ensure-ipc.test.ts` ("throws
@@ -5585,5 +5629,147 @@ describe("packaged-mac activation: bounded auto-retry on readiness timeout", () 
 
     expect(outcome.kind).toBe("failed");
     expect(waitForHostReady).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Field RCA 2026-07-28 (`make install-desktop-production`, ad-hoc build):
+// SMAppService answered `not-found` for a byte-correct in-bundle plist for
+// the remainder of the app process's life, AFTER the register cycle's own
+// bootout had already torn down the loaded agent. Every same-session retry
+// (S8 auto-retry, the monitor, the gate card's Retry button) re-ran the
+// same doomed SMAppService call, so the user was locked out with no
+// recovery affordance. These rows pin the escalation: a register failure
+// hands off to the CLI-owned raw LaunchAgent (`host service install
+// --takeover`), which does not go through SMAppService/BTM at all.
+describe("packaged-mac register failure: CLI-owned LaunchAgent takeover fallback", () => {
+  const TAKEOVER_ARGV = ["host", "service", "install", "--takeover"];
+
+  function stagePackagedMacWorld(): HostController {
+    vi.mocked(hostManagesHostLoginItem).mockResolvedValue(true);
+    const controller = newController("production");
+    writeInstallRecord("production", {
+      version: "1.7.0",
+      runtimeVersion: "1.7.0",
+    });
+    writePidMetadata("production", { version: "1.7.0", pid: process.pid });
+    // The fallback's readiness check keeps the normal version-equality
+    // guard: the recovered host must publish the runtime the committed
+    // installation expects (the beforeEach default reports 1.0.0, which
+    // this world would rightly reject).
+    vi.mocked(waitForHostReady).mockResolvedValue({
+      ready: true,
+      version: "1.7.0",
+      pid: 1,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      reason: "ready",
+    });
+    return controller;
+  }
+
+  it("activation cycle: register not-found recovers via the CLI takeover without a second SMAppService attempt", async () => {
+    const controller = stagePackagedMacWorld();
+    vi.mocked(registerHostLoginItem).mockResolvedValue("not-found");
+
+    const outcome = await controller.respawn();
+
+    expect(outcome.kind).toBe("ok");
+    expect(runBundledTraycerCliJson).toHaveBeenCalledWith(TAKEOVER_ARGV);
+    // The futile-retry pin: `not-found` is sticky for this SMAppService
+    // session, so neither the S8 wrapper nor the fallback may re-run the
+    // register cycle.
+    expect(registerHostLoginItem).toHaveBeenCalledTimes(1);
+    // SMAppService is unusable this session - the pending-revision monitor
+    // must not boot the fallback host back out for a plist revision it
+    // cannot land.
+    expect(controller.isPendingRevisionRefreshQuarantined()).toBe(true);
+  });
+
+  it("activation cycle: a failing takeover surfaces one terminal message naming the status and the manual escape hatch", async () => {
+    const controller = stagePackagedMacWorld();
+    vi.mocked(registerHostLoginItem).mockResolvedValue("not-found");
+    vi.mocked(runBundledTraycerCliJson).mockRejectedValue(
+      new Error("takeover exploded"),
+    );
+
+    const outcome = await controller.respawn();
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind === "failed") {
+      expect(outcome.message).toContain("status=not-found");
+      expect(outcome.message).toContain("takeover exploded");
+      expect(outcome.message).toContain("service uninstall");
+    }
+    expect(registerHostLoginItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("activation cycle: a takeover that registered but never produced a ready host is a failure, not a silent success", async () => {
+    const controller = stagePackagedMacWorld();
+    vi.mocked(registerHostLoginItem).mockResolvedValue("not-registered");
+    vi.mocked(waitForHostReady).mockResolvedValue({
+      ready: false,
+      version: null,
+      pid: null,
+      startedAt: null,
+      reason: "pid metadata never appeared",
+    });
+
+    const outcome = await controller.respawn();
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind === "failed") {
+      expect(outcome.message).toContain("status=not-registered");
+      expect(outcome.message).toContain("pid metadata never appeared");
+    }
+  });
+
+  it("registerService: register not-found recovers via the CLI takeover and reports registered", async () => {
+    const controller = stagePackagedMacWorld();
+    vi.mocked(registerHostLoginItem).mockResolvedValue("not-found");
+
+    const outcome = await controller.registerService();
+
+    expect(outcome).toEqual({ kind: "ok", value: { registered: true } });
+    expect(runBundledTraycerCliJson).toHaveBeenCalledWith(TAKEOVER_ARGV);
+  });
+
+  it("requires-approval NEVER escalates to the takeover - the toggle is the user's alone", async () => {
+    const controller = stagePackagedMacWorld();
+    vi.mocked(registerHostLoginItem).mockResolvedValue("requires-approval");
+    // `requires-approval` still means the plist is registered, so the cycle
+    // waits for readiness; only when the host does NOT come up does the
+    // approval failure surface. A ready host here would be a legitimate
+    // success and prove nothing about the escalation gate.
+    vi.mocked(waitForHostReady).mockResolvedValue({
+      ready: false,
+      version: null,
+      pid: null,
+      startedAt: null,
+      reason: "pid metadata never appeared",
+    });
+    vi.mocked(readHostLoginItemStatus).mockImplementation(() =>
+      vi.mocked(waitForHostReady).mock.calls.length > 0
+        ? "requires-approval"
+        : "enabled",
+    );
+
+    const respawnOutcome = await controller.respawn();
+    const registerOutcome = await controller.registerService();
+
+    expect(respawnOutcome.kind).toBe("failed");
+    expect(registerOutcome.kind).toBe("failed");
+    expect(runBundledTraycerCliJson).not.toHaveBeenCalledWith(TAKEOVER_ARGV);
+  });
+
+  it("removed-by-user NEVER escalates to the takeover - reinstalling the service would defy the removal", async () => {
+    const controller = stagePackagedMacWorld();
+    // The register cycle's own in-lock re-check found the removal sentinel
+    // (persisted mid-cycle by an in-app uninstall) - the fallback would
+    // resurrect the exact registration the user just removed.
+    vi.mocked(registerHostLoginItem).mockResolvedValue("removed-by-user");
+
+    const outcome = await controller.respawn();
+
+    expect(outcome.kind).toBe("failed");
+    expect(runBundledTraycerCliJson).not.toHaveBeenCalledWith(TAKEOVER_ARGV);
   });
 });

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -125,9 +125,10 @@ import {
   HostController,
   type HostControllerHostLifecycle,
 } from "../host-controller";
-import type {
-  MutationLaneStatus,
-  MutationProgress,
+import {
+  HOST_REMOVED_BY_USER_MESSAGE,
+  type MutationLaneStatus,
+  type MutationProgress,
 } from "../host-controller-types";
 import { getHostFsLayout, cliLockPath } from "../host-paths";
 import { DEV_DESKTOP_SLOT_ENV } from "../dev-desktop-slot";
@@ -5757,6 +5758,11 @@ describe("packaged-mac register failure: CLI-owned LaunchAgent takeover fallback
 
     expect(respawnOutcome.kind).toBe("failed");
     expect(registerOutcome.kind).toBe("failed");
+    // Guards against a vacuous pass: the pre-bootout `requires-approval`
+    // preflight must not have short-circuited before either cycle actually
+    // reached registration - otherwise "failed" and no takeover would hold
+    // trivially without exercising the escalation gate at all.
+    expect(registerHostLoginItem).toHaveBeenCalledTimes(2);
     expect(runBundledTraycerCliJson).not.toHaveBeenCalledWith(TAKEOVER_ARGV);
   });
 
@@ -5770,6 +5776,9 @@ describe("packaged-mac register failure: CLI-owned LaunchAgent takeover fallback
     const outcome = await controller.respawn();
 
     expect(outcome.kind).toBe("failed");
+    if (outcome.kind === "failed") {
+      expect(outcome.message).toBe(HOST_REMOVED_BY_USER_MESSAGE);
+    }
     expect(runBundledTraycerCliJson).not.toHaveBeenCalledWith(TAKEOVER_ARGV);
   });
 });

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -1103,6 +1103,22 @@ export class HostController {
     }
   }
 
+  // The three `HostLoginItemStatus` values that mean SMAppService has
+  // definitively failed to register the LaunchAgent (as opposed to
+  // `requires-approval`, which means it IS registered and only needs the
+  // user's own toggle) - the CLI's raw-LaunchAgent takeover can recover from
+  // exactly these. Single source of truth for the three call sites below so
+  // a future `HostLoginItemStatus` member can't drift between them.
+  private isCliTakeoverRecoverableStatus(
+    status: RegisterHostLoginItemResult,
+  ): status is "not-registered" | "not-found" | "not-supported" {
+    return (
+      status === "not-registered" ||
+      status === "not-found" ||
+      status === "not-supported"
+    );
+  }
+
   // Last-rung recovery for a macOS register cycle whose SMAppService calls
   // failed (`not-found` / `not-registered` / `not-supported`) AFTER the
   // cycle's own bootout already tore down the loaded agent. Field RCA
@@ -1401,11 +1417,7 @@ export class HostController {
             ),
           };
         }
-        if (
-          registerResult === "not-registered" ||
-          registerResult === "not-found" ||
-          registerResult === "not-supported"
-        ) {
+        if (this.isCliTakeoverRecoverableStatus(registerResult)) {
           // Not terminal: this cycle's own bootout already tore the loaded
           // agent down, so failing here would strand the machine with no
           // registration at all and a Retry that re-runs the same doomed
@@ -1730,7 +1742,7 @@ export class HostController {
       this.pendingRevisionRefreshQuarantined = true;
       return { kind: "failed", message: approvalRequiredMessage() };
     }
-    if (status !== "enabled") {
+    if (this.isCliTakeoverRecoverableStatus(status)) {
       this.pendingRevisionRefreshQuarantined = true;
       log.warn(
         "[host-controller] pending LaunchAgent revision refresh did not enable the agent",
@@ -2778,11 +2790,7 @@ export class HostController {
             }
             return { kind: "ok", value: { registered: true } };
           }
-          if (
-            registration.status === "not-registered" ||
-            registration.status === "not-found" ||
-            registration.status === "not-supported"
-          ) {
+          if (this.isCliTakeoverRecoverableStatus(registration.status)) {
             const recovery = await this.recoverRegistrationViaCliTakeover({
               failedStatus: registration.status,
               prePid: registration.prePid,

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -10,6 +10,7 @@ import {
   readHostLoginItemStatus,
   registerHostLoginItem,
   unregisterHostLoginItem,
+  type HostLoginItemStatus,
   type RegisterHostLoginItemResult,
 } from "../app/host-login-item";
 import { resolveBundledCliPath } from "../cli/cli-discovery";
@@ -631,15 +632,25 @@ export interface HostControllerOptions {
 /**
  * `runLockedMacActivationCycle`'s desktop-locked closure result (fixup A7).
  * `"terminal"` short-circuits with a final outcome decided under the lock
- * (no host installed, busy, registration failure). `"registered"` carries
- * just enough state for the CALLER to finish the choreography (stamp-runtime
- * CAS + readiness wait) AFTER the lock has released - those steps must never
- * run while still holding it, see the comment at the return site.
+ * (no host installed, busy). `"registered"` carries just enough state for
+ * the CALLER to finish the choreography (stamp-runtime CAS + readiness
+ * wait) AFTER the lock has released - those steps must never run while
+ * still holding it, see the comment at the return site.
+ * `"register-failed"` is the SMAppService refusal
+ * (`not-found`/`not-registered`/`not-supported`) - also resolved after the
+ * lock releases, because its recovery spawns the CLI, which re-acquires
+ * this same lock (lock rule 3).
  */
 type LockedMacActivationStep =
   | {
       readonly phase: "terminal";
       readonly outcome: MutationOutcome<{ readonly activated: boolean }>;
+    }
+  | {
+      readonly phase: "register-failed";
+      readonly status: HostLoginItemStatus;
+      readonly prePid: number | null;
+      readonly expectedRuntimeVersion: string | null;
     }
   | {
       readonly phase: "registered";
@@ -1092,6 +1103,82 @@ export class HostController {
     }
   }
 
+  // Last-rung recovery for a macOS register cycle whose SMAppService calls
+  // failed (`not-found` / `not-registered` / `not-supported`) AFTER the
+  // cycle's own bootout already tore down the loaded agent. Field RCA
+  // (2026-07-28): SMAppService can answer `not-found` for a byte-correct
+  // in-bundle plist for the remainder of the app process's life (the BTM
+  // record's identity keyed to a previous build), so re-running the same
+  // cycle - which is all the gate card's Retry does - can never recover,
+  // and the machine is stranded with NOTHING registered and no way out.
+  //
+  // The CLI's raw LaunchAgent (`host service install --takeover`) does not
+  // go through SMAppService/BTM at all: takeover cooperatively stops a
+  // still-loaded agent first (aborting on live busy work, proceeding when
+  // it is unreachable), is a no-op when the agent is already gone (this
+  // path's common case - the failed cycle booted it out), and the desktop
+  // re-retires the CLI registration on its next healthy SMAppService
+  // cycle - so the fallback is temporary by construction.
+  //
+  // Must be called OUTSIDE `withDesktopCliLock` sections: the spawned CLI
+  // re-acquires that same lock (lock rule 3: CLI-locked and desktop-locked
+  // sections are sequenced, not nested).
+  private async recoverRegistrationViaCliTakeover(args: {
+    readonly failedStatus: HostLoginItemStatus;
+    readonly prePid: number | null;
+    readonly expectedRuntimeVersion: string | null;
+  }): Promise<
+    | { readonly recovered: true; readonly version: string | null }
+    | { readonly recovered: false; readonly message: string }
+  > {
+    // SMAppService is unusable for the rest of this session - quarantine the
+    // pending-revision refresh so it cannot boot the fallback host out for a
+    // plist revision it has just proven it cannot land. The on-disk marker
+    // deliberately survives for the next launch's fresh session.
+    this.pendingRevisionRefreshQuarantined = true;
+    log.warn(
+      "[host-controller] SMAppService registration failed - falling back to the CLI-owned LaunchAgent",
+      { status: args.failedStatus },
+    );
+    let raw: unknown;
+    try {
+      raw = await this.runBundled<unknown>([
+        "host",
+        "service",
+        "install",
+        "--takeover",
+        ...this.devServiceInstallExtras(),
+      ]);
+    } catch (err) {
+      return {
+        recovered: false,
+        message: `Failed to register the host login item (status=${args.failedStatus}), and the fallback service registration failed: ${describeError(err)} Run 'traycer host service uninstall' and relaunch Traycer, or run 'traycer host doctor' to recover.`,
+      };
+    }
+    const result = parseServiceStartResult(raw);
+    try {
+      await this.completeServiceStart(
+        args.prePid,
+        result.runtimeWasNull ? result.installGeneration : null,
+        result.runtimeVersion ?? args.expectedRuntimeVersion,
+      );
+    } catch (err) {
+      return {
+        recovered: false,
+        message: `Failed to register the host login item (status=${args.failedStatus}); the fallback service was registered but the host did not come up: ${describeError(err)}`,
+      };
+    }
+    const version = await readRunningRuntimeVersion(
+      this.layout,
+      this.reachabilityProbe,
+    );
+    log.info(
+      "[host-controller] CLI-owned LaunchAgent fallback recovered the host",
+      { status: args.failedStatus, version },
+    );
+    return { recovered: true, version };
+  }
+
   // Success paths which start, cycle, or otherwise claim a live host publish
   // through this one gate. A service manager acknowledgement or a readiness
   // handshake is not sufficient by itself: the renderer-facing snapshot must
@@ -1319,12 +1406,17 @@ export class HostController {
           registerResult === "not-found" ||
           registerResult === "not-supported"
         ) {
+          // Not terminal: this cycle's own bootout already tore the loaded
+          // agent down, so failing here would strand the machine with no
+          // registration at all and a Retry that re-runs the same doomed
+          // SMAppService call in the same poisoned session. Recovery spawns
+          // the CLI, which re-acquires the lock this closure holds (lock
+          // rule 3), so hand the failure to the post-lock fallback.
           return {
-            phase: "terminal",
-            outcome: {
-              kind: "failed",
-              message: `Failed to register the host login item (status=${registerResult}).`,
-            },
+            phase: "register-failed",
+            status: registerResult,
+            prePid,
+            expectedRuntimeVersion: record.runtimeVersion,
           };
         }
         // Fixup A7: the desktop lock is released as soon as this closure
@@ -1351,6 +1443,17 @@ export class HostController {
     const step = outcome.result;
     if (step.phase === "terminal") {
       return step.outcome;
+    }
+    if (step.phase === "register-failed") {
+      const recovery = await this.recoverRegistrationViaCliTakeover({
+        failedStatus: step.status,
+        prePid: step.prePid,
+        expectedRuntimeVersion: step.expectedRuntimeVersion,
+      });
+      if (!recovery.recovered) {
+        return this.failedAfterServiceCycle(recovery.message);
+      }
+      return { kind: "ok", value: { activated: true } };
     }
     const {
       registerResult,
@@ -1633,9 +1736,24 @@ export class HostController {
         "[host-controller] pending LaunchAgent revision refresh did not enable the agent",
         { status },
       );
+      // This cycle just booted out a host that was verified reachable and
+      // idle moments before - a bare failure here strands the machine with
+      // nothing running AND nothing registered (field RCA 2026-07-28: the
+      // installer restarted the host, this refresh tore it down,
+      // SMAppService answered `not-found`, and the session was locked
+      // out). Restore service via the CLI-owned fallback; the pending
+      // marker deliberately survives for the next launch.
+      const recovery = await this.recoverRegistrationViaCliTakeover({
+        failedStatus: status,
+        prePid,
+        expectedRuntimeVersion,
+      });
+      if (!recovery.recovered) {
+        return this.failedAfterServiceCycle(recovery.message);
+      }
       return {
-        kind: "failed",
-        message: `The host's macOS login item could not be enabled (status: ${status}). Open Doctor or run 'traycer host doctor' to recover.`,
+        kind: "ok",
+        value: { running: true, version: recovery.version ?? currentVersion },
       };
     }
     const readiness = await waitForHostReady(
@@ -2657,6 +2775,21 @@ export class HostController {
               );
             } catch (err) {
               return this.failedAfterServiceCycle(err);
+            }
+            return { kind: "ok", value: { registered: true } };
+          }
+          if (
+            registration.status === "not-registered" ||
+            registration.status === "not-found" ||
+            registration.status === "not-supported"
+          ) {
+            const recovery = await this.recoverRegistrationViaCliTakeover({
+              failedStatus: registration.status,
+              prePid: registration.prePid,
+              expectedRuntimeVersion: registration.expectedRuntimeVersion,
+            });
+            if (!recovery.recovered) {
+              return this.failedAfterServiceCycle(recovery.message);
             }
             return { kind: "ok", value: { registered: true } };
           }


### PR DESCRIPTION
## Problem

Field lockout on 2026-07-28 (`make install-desktop-production`, ad-hoc build): the gate showed **"Failed to register the host login item (status=not-found)."** with a Retry that could never work, and no other way out. Desktop log evidence: SMAppService answered `not-found` for a byte-correct in-bundle plist on **every** call (clear, register, status read) for the remainder of that app process's life — across six register cycles in 27s (bounded auto-retry + pending-revision monitor + user Retry clicks) — after the cycle's own bootout had already torn down the loaded agent. The machine was left with nothing registered and nothing running. A fresh app process later registered `enabled` in 11ms.

The terminal branch dates to the staged-update redesign (#528); it was the one register dead-end #738's recovery work did not repair (S4/S8 covered only the readiness-timeout card).

## Fix

A register failure (`not-found` / `not-registered` / `not-supported`) now escalates to the CLI-owned raw LaunchAgent via `host service install --takeover` — which does not go through SMAppService/BTM at all — instead of surfacing a dead-end card:

| Property | Behaviour |
|---|---|
| Takeover semantics | Cooperatively stops a still-loaded agent (aborts on live busy work); no-op when the agent is already gone — the common case, since the failed cycle booted it out |
| Temporary by construction | The desktop re-retires the CLI registration on its next *healthy* SMAppService cycle |
| Session hygiene | A fallback quarantines the pending-revision refresh so it cannot tear the fallback host back down; the on-disk marker survives for the next launch's fresh SMAppService session |
| Never escalates | `requires-approval` (the toggle is the user's alone) and `removed-by-user` (would defy the removal) |
| Terminal card | Only when the fallback itself fails; the message now names both failures and the manual escape hatch (`service uninstall` + relaunch, `host doctor`) |

Wired at all three dead-end sites: the locked activation cycle (resolved post-lock — the spawned CLI re-acquires the same lock, lock rule 3), the pending-revision refresh (which had just booted out a verified-idle host), and Settings → Re-register.

## Tests

8 new/rewritten rows in `host-controller.test.ts` (156/156; full desktop suite 1081/1081): recovery on all three paths, the futile-retry pin (exactly one SMAppService attempt per cycle), version-equality guard on the recovered host, combined failure message, and negative pins for `requires-approval` / `removed-by-user`.
