### PR TITLE
fix(gui-app): reopen closed terminal tiles from the resource monitor

### DIFF
--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -142,6 +142,14 @@ const canvasMock = vi.hoisted(() => {
   const prepareOpenTileInTabFocusTarget = vi.fn();
   const prepareSetActiveTileTabFocusTarget = vi.fn();
   const resolveTargetTabForEpic = vi.fn(() => "tab-2");
+  const closedTilePayloadsByTabId: Record<
+    string,
+    | Record<
+        string,
+        { node: Record<string, unknown>; pendingCreate: boolean } | undefined
+      >
+    | undefined
+  > = {};
   const state = {
     openTabOrder: ["tab-1", "tab-2"],
     tabsById: {
@@ -224,6 +232,7 @@ const canvasMock = vi.hoisted(() => {
         sizesByGroupId: {},
       },
     },
+    closedTilePayloadsByTabId,
     artifactTreeByEpicId: {
       "epic-1": [
         {
@@ -446,6 +455,9 @@ afterEach(() => {
     ...canvasMock.state.artifactTreeByEpicId["epic-1"][0],
     name: "Agent Chat",
   };
+  for (const key of Object.keys(canvasMock.state.closedTilePayloadsByTabId)) {
+    Reflect.deleteProperty(canvasMock.state.closedTilePayloadsByTabId, key);
+  }
   tabNavigationMock.resourceEpicTabIntent.mockClear();
   tabNavigationMock.activateTabIntent.mockClear();
   canvasMock.prepareOpenTileInTabFocusTarget.mockReset();
@@ -1233,6 +1245,141 @@ describe("ResourceMonitorPopover", () => {
       expect.objectContaining({ tabId: "tab-closed" }),
       undefined,
     );
+  });
+
+  it("reopens a CLOSED terminal tile from its preserved payload via cross-route navigation", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    canvasMock.state.closedTilePayloadsByTabId["tab-closed"] = {
+      "tile-term-bg": {
+        node: {
+          id: "term-bg",
+          instanceId: "tile-term-bg",
+          type: "terminal",
+          name: "Background Build",
+          titleSource: "manual",
+          hostId: "host-1",
+          cwd: "/work/background",
+        },
+        pendingCreate: false,
+      },
+    };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "terminal",
+                hostId: "host-1",
+                epicId: "epic-2",
+                ownerId: "term-bg",
+              },
+              harnessId: null,
+              activeProcessName: "make",
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    // The row label comes from the preserved ref's manual title, not the
+    // running process name.
+    fireEvent.click(await screen.findByText("Background Build"));
+
+    expect(navigateNestedMock).not.toHaveBeenCalled();
+    expect(tabNavigationMock.resourceEpicTabIntent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        epicId: "epic-2",
+        tabId: "tab-closed",
+        preparation: {
+          kind: "open-tile",
+          node: {
+            id: "term-bg",
+            instanceId: "tile-term-bg",
+            type: "terminal",
+            name: "Background Build",
+            titleSource: "manual",
+            hostId: "host-1",
+            cwd: "/work/background",
+          },
+        },
+      }),
+    );
+    expect(tabNavigationMock.activateTabIntent).toHaveBeenCalledWith(
+      routerMock.navigate,
+      expect.objectContaining({ tabId: "tab-closed" }),
+      undefined,
+    );
+  });
+
+  it("reopens a closed terminal tile of the CURRENT tab through the same-route boundary", async () => {
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    canvasMock.state.closedTilePayloadsByTabId["tab-1"] = {
+      "tile-term-gone": {
+        node: {
+          id: "term-gone",
+          instanceId: "tile-term-gone",
+          type: "terminal",
+          name: "Terminal Gamma",
+          titleSource: "manual",
+          hostId: "host-1",
+          cwd: "/work",
+        },
+        pendingCreate: false,
+      },
+    };
+    canvasMock.prepareOpenTileInTabFocusTarget.mockReturnValue({
+      paneId: "pane-1",
+      tileInstanceId: "tile-term-gone",
+    });
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(
+        projection({
+          owners: [
+            owner({
+              owner: {
+                kind: "terminal",
+                hostId: "host-1",
+                epicId: "epic-1",
+                ownerId: "term-gone",
+              },
+              harnessId: null,
+              activeProcessName: "node",
+            }),
+          ],
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    fireEvent.click(await screen.findByText("Terminal Gamma"));
+
+    expect(navigateNestedMock).toHaveBeenCalledWith(
+      "epic-1",
+      "tab-1",
+      expect.any(Function),
+    );
+    expect(canvasMock.prepareOpenTileInTabFocusTarget).toHaveBeenCalledWith(
+      "tab-1",
+      {
+        id: "term-gone",
+        instanceId: "tile-term-gone",
+        type: "terminal",
+        name: "Terminal Gamma",
+        titleSource: "manual",
+        hostId: "host-1",
+        cwd: "/work",
+      },
+    );
+    expect(tabNavigationMock.resourceEpicTabIntent).not.toHaveBeenCalled();
+    expect(tabNavigationMock.activateTabIntent).not.toHaveBeenCalled();
   });
 
   it("commits a not-yet-open owner through prepareOpenTileInTabFocusTarget + cross-route navigation", async () => {

--- a/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
+++ b/clients/gui-app/src/components/resources/__tests__/resource-monitor-popover.test.tsx
@@ -1287,8 +1287,14 @@ describe("ResourceMonitorPopover", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Resources" }));
     // The row label comes from the preserved ref's manual title, not the
-    // running process name.
-    fireEvent.click(await screen.findByText("Background Build"));
+    // running process name. Assert the row button is ENABLED before clicking:
+    // a disabled row is the exact regression this covers, and it would
+    // otherwise show up only indirectly as a missing navigation call.
+    const row = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /^Background Build/,
+    });
+    expect(row.disabled).toBe(false);
+    fireEvent.click(row);
 
     expect(navigateNestedMock).not.toHaveBeenCalled();
     expect(tabNavigationMock.resourceEpicTabIntent).toHaveBeenCalledWith(
@@ -1359,7 +1365,11 @@ describe("ResourceMonitorPopover", () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Resources" }));
-    fireEvent.click(await screen.findByText("Terminal Gamma"));
+    const row = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /^Terminal Gamma/,
+    });
+    expect(row.disabled).toBe(false);
+    fireEvent.click(row);
 
     expect(navigateNestedMock).toHaveBeenCalledWith(
       "epic-1",
@@ -1380,6 +1390,53 @@ describe("ResourceMonitorPopover", () => {
     );
     expect(tabNavigationMock.resourceEpicTabIntent).not.toHaveBeenCalled();
     expect(tabNavigationMock.activateTabIntent).not.toHaveBeenCalled();
+  });
+
+  it("prefers a live tile over a stale preserved payload for the same owner", async () => {
+    // Reachable state: a tile is closed (payload captured) and the same
+    // terminal is later reopened. Eviction only happens in
+    // `restoreClosedTilePreview` (keyed on that exact instanceId) and
+    // `discardClosedTilePayload`, so the stale payload outlives the reopen.
+    // The live tile MUST win - reopening would otherwise add a duplicate tile
+    // instead of focusing the one already on the canvas.
+    routerMock.pathname = "/epics/epic-1/tab-1";
+    canvasMock.state.closedTilePayloadsByTabId["tab-1"] = {
+      "tile-term-1-stale": {
+        node: {
+          id: "term-1",
+          instanceId: "tile-term-1-stale",
+          type: "terminal",
+          name: "Stale Alpha",
+          titleSource: "manual",
+          hostId: "host-1",
+          cwd: "/work",
+        },
+        pendingCreate: false,
+      },
+    };
+    const stub = installStubFactory();
+    renderPopover();
+
+    act(() => {
+      stub.emit().onSnapshot(projection({ owners: [owner({})] }));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Resources" }));
+    // Label comes from the LIVE tile's ref, not the stale payload's name.
+    expect(screen.queryByText("Stale Alpha")).toBeNull();
+    const row = await screen.findByRole<HTMLButtonElement>("button", {
+      name: /^Terminal Alpha/,
+    });
+    expect(row.disabled).toBe(false);
+    fireEvent.click(row);
+
+    // activate-tile against the live tile - NOT open-tile from the payload.
+    expect(canvasMock.prepareSetActiveTileTabFocusTarget).toHaveBeenCalledWith(
+      "tab-1",
+      "pane-1",
+      "tile-term-1",
+    );
+    expect(canvasMock.prepareOpenTileInTabFocusTarget).not.toHaveBeenCalled();
   });
 
   it("commits a not-yet-open owner through prepareOpenTileInTabFocusTarget + cross-route navigation", async () => {

--- a/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
+++ b/clients/gui-app/src/components/resources/resource-monitor-popover.tsx
@@ -96,6 +96,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useCloudEpicTasksQuery } from "@/hooks/epics/use-cloud-epic-tasks-query";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import type { ClosedTilePayload } from "@/stores/epics/canvas/store";
 import { collectPanes } from "@/stores/epics/canvas/tile-tree";
 import type {
   EpicCanvasState,
@@ -143,6 +144,12 @@ interface CanvasResourceSnapshot {
   readonly openTabOrder: readonly string[];
   readonly tabsById: Readonly<Record<string, EpicViewTab | undefined>>;
   readonly canvasByTabId: Readonly<Record<string, EpicCanvasState | undefined>>;
+  readonly closedTilePayloadsByTabId: Readonly<
+    Record<
+      string,
+      Readonly<Record<string, ClosedTilePayload | undefined>> | undefined
+    >
+  >;
   readonly artifactTreeByEpicId: Readonly<
     Record<string, readonly EpicNodeRecord[] | undefined>
   >;
@@ -156,8 +163,21 @@ interface OpenOwnerLocation {
   readonly ref: EpicNodeRef;
 }
 
+/**
+ * A closed tile whose payload is preserved in `closedTilePayloadsByTabId`.
+ * The preserved ref carries everything needed to reopen the tile (for a
+ * terminal: name, titleSource, cwd - none of which the resource wire
+ * snapshot has), so an owner without a live tile stays clickable, matching
+ * how notification clicks reopen closed terminal/agent tiles.
+ */
+interface ClosedOwnerTile {
+  readonly tabId: string;
+  readonly node: EpicNodeRef;
+}
+
 interface CanvasResourceIndex {
   readonly locationByOwner: ReadonlyMap<string, OpenOwnerLocation>;
+  readonly closedTileByOwner: ReadonlyMap<string, ClosedOwnerTile>;
   readonly tabOrderByOwner: ReadonlyMap<string, number>;
 }
 
@@ -172,6 +192,7 @@ interface OwnerDisplayRow {
   readonly canOpen: boolean;
   readonly tabOrder: number;
   readonly location: OpenOwnerLocation | null;
+  readonly closedTile: ClosedOwnerTile | null;
   readonly record: EpicNodeRecord | null;
   readonly treeCpuPercent: number;
   readonly treeRssBytes: number;
@@ -794,6 +815,7 @@ function useResourceCanvasSnapshot(): CanvasResourceSnapshot {
       openTabOrder: state.openTabOrder,
       tabsById: state.tabsById,
       canvasByTabId: state.canvasByTabId,
+      closedTilePayloadsByTabId: state.closedTilePayloadsByTabId,
       artifactTreeByEpicId: state.artifactTreeByEpicId,
     })),
   );
@@ -1452,7 +1474,7 @@ function OwnerTreeRow(props: {
   );
   const label = ownerLabel(
     props.row.snapshot,
-    props.row.location,
+    ownerTileRef(props.row.location, props.row.closedTile),
     props.row.record,
     liveArtifactTitle,
   );
@@ -1877,6 +1899,7 @@ function buildTaskRows(input: {
         snapshot.owner.ownerId,
       );
       const location = input.canvasIndex.locationByOwner.get(key) ?? null;
+      const closedTile = input.canvasIndex.closedTileByOwner.get(key) ?? null;
       const record = input.recordByOwner.get(key) ?? null;
       const processRows = buildProcessRows(
         snapshot.processes,
@@ -1886,11 +1909,17 @@ function buildTaskRows(input: {
       );
       return {
         snapshot,
-        label: ownerLabel(snapshot, location, record, null),
-        canOpen: canOpenOwner(snapshot, location, record),
+        label: ownerLabel(
+          snapshot,
+          ownerTileRef(location, closedTile),
+          record,
+          null,
+        ),
+        canOpen: canOpenOwner(snapshot, location, closedTile, record),
         tabOrder:
           input.canvasIndex.tabOrderByOwner.get(key) ?? Number.MAX_SAFE_INTEGER,
         location,
+        closedTile,
         record,
         treeCpuPercent: processRows.treeCpuPercent,
         treeRssBytes: processRows.treeRssBytes,
@@ -1968,7 +1997,29 @@ function buildCanvasResourceIndex(
     }
   });
 
-  return { locationByOwner, tabOrderByOwner };
+  // A tile closed out of a tab's canvas keeps its payload in
+  // `closedTilePayloadsByTabId`; index those refs so the owner row can reopen
+  // the tile (terminals have no artifact record, so this preserved ref is the
+  // only way to reconstruct their tile).
+  const closedTileByOwner = new Map<string, ClosedOwnerTile>();
+  for (const tabId of indexedTabIds) {
+    const tab = canvas.tabsById[tabId];
+    if (tab === undefined) continue;
+    for (const payload of Object.values(
+      canvas.closedTilePayloadsByTabId[tabId] ?? {},
+    )) {
+      const node = payload?.node;
+      if (node === undefined || !isOwnerNodeRef(node)) continue;
+      const ownerKind = resourceOwnerKindForRef(node);
+      if (ownerKind === null) continue;
+      const key = ownerKey(tab.epicId, ownerKind, node.id);
+      if (!closedTileByOwner.has(key)) {
+        closedTileByOwner.set(key, { tabId, node });
+      }
+    }
+  }
+
+  return { locationByOwner, closedTileByOwner, tabOrderByOwner };
 }
 
 function buildRecordByOwner(
@@ -2085,6 +2136,30 @@ function openResourceOwner(args: {
   }
 
   const snapshot = args.row.snapshot;
+
+  // No live tile, but the tile's payload survived its close (same store the
+  // notification reopen path reads). Reopen the preserved ref in its original
+  // tab - `setActiveTab` reinserts a hidden tab into the strip, and the
+  // open-tile preparation re-adds the tile to that tab's canvas. This is the
+  // only reopen path for terminals, whose refs (cwd, title) cannot be rebuilt
+  // from the resource snapshot or an artifact record.
+  const closedTile = args.row.closedTile;
+  if (closedTile !== null) {
+    commitOwnerFocus({
+      epicId: snapshot.owner.epicId,
+      tabId: closedTile.tabId,
+      name: undefined,
+      focus: focusForOwner(snapshot),
+      preparation: { kind: "open-tile", node: closedTile.node },
+      navigate: args.navigate,
+      navigateNested: args.navigateNested,
+      activeEpicId: args.activeEpicId,
+      activeTabId: args.activeTabId,
+      desktopNestedFocusEnabled: args.desktopNestedFocusEnabled,
+    });
+    return true;
+  }
+
   if (
     snapshot.owner.kind !== "chat" &&
     snapshot.owner.kind !== "terminal-agent"
@@ -2286,18 +2361,28 @@ function harnessProviderSubtitle(
   return activeProcessName === null ? base : `${base} · ${activeProcessName}`;
 }
 
+/**
+ * The owner's tile ref for labelling - the live canvas tile when one is
+ * open, otherwise the preserved closed-tile payload's ref, so a closed
+ * terminal keeps its manually-set title readable after the tile leaves the
+ * canvas.
+ */
+function ownerTileRef(
+  location: OpenOwnerLocation | null,
+  closedTile: ClosedOwnerTile | null,
+): EpicNodeRef | null {
+  return location?.ref ?? closedTile?.node ?? null;
+}
+
 function ownerLabel(
   snapshot: OwnerResourceSnapshotWireV13,
-  location: OpenOwnerLocation | null,
+  ref: EpicNodeRef | null,
   record: EpicNodeRecord | null,
   liveArtifactTitle: string | null,
 ): string {
   if (snapshot.owner.kind === "terminal") {
-    if (
-      location?.ref.type === "terminal" &&
-      location.ref.titleSource === "manual"
-    ) {
-      return location.ref.name;
+    if (ref?.type === "terminal" && ref.titleSource === "manual") {
+      return ref.name;
     }
     return terminalSessionTitle({
       title: null,
@@ -2309,12 +2394,12 @@ function ownerLabel(
     // to "Untitled agent" (this light surface carries no first-user-message to
     // derive from).
     return displayTitle(
-      liveArtifactTitle || location?.ref.name || record?.name || "",
+      liveArtifactTitle || ref?.name || record?.name || "",
       "agent",
     );
   }
   if (liveArtifactTitle !== null) return liveArtifactTitle;
-  if (location !== null) return location.ref.name;
+  if (ref !== null) return ref.name;
   if (record !== null) return record.name;
   return ownerKindLabel(snapshot.owner.kind);
 }
@@ -2322,9 +2407,11 @@ function ownerLabel(
 function canOpenOwner(
   snapshot: OwnerResourceSnapshotWireV13,
   location: OpenOwnerLocation | null,
+  closedTile: ClosedOwnerTile | null,
   record: EpicNodeRecord | null,
 ): boolean {
   if (location !== null) return true;
+  if (closedTile !== null) return true;
   if (snapshot.owner.kind === "terminal") return false;
   return record !== null;
 }


### PR DESCRIPTION
Terminal rows in the Resource Monitor were clickable only while their tile was open. Close the tile (or the task tab that held it) and the row went inert — even though the process was still running and still listed right there with its CPU and memory.

## Why the row went dead

`canOpenOwner` gates on a live canvas tile (`location`) or, for chat/terminal-agent owners, an artifact record to rebuild a tile from.

#314 already covered a closed **task tab** — its tab and canvas are retained, so the tile stays indexed and the row keeps working. A closed **tile** is a different case: it leaves the canvas entirely, and a terminal has no artifact record. Neither branch applied, so the row rendered disabled.

## The fix

The store already preserves what's needed. `closedTilePayloadsByTabId` holds each closed tile's ref — that's how notification clicks reopen closed terminal/agent tiles today. This indexes the same map by owner key and routes a hit through the existing `commitOwnerFocus` boundary with an `open-tile` preparation aimed at the tile's original tab:

- **cross-route** — the navigation controller reactivates the (possibly hidden) task tab, `setActiveTab` reinserts it into the strip, and the preparation re-adds the tile to that tab's canvas
- **same-route** — the tile reopens in place via the nested-focus hook

No new navigation path, and the raw canvas mutations stay untouched (the test mock deliberately omits them, so a regression to calling them directly throws).

That preserved ref is also the only source for a terminal's `cwd`, `titleSource`, and host binding — none of which are on the resources wire — so it is the only way a terminal tile can be reconstructed at all. It doubles as the label source, so a closed terminal now keeps its manually-set title instead of falling back to the running process name.

## Known boundary

The payloads are session-only and bounded per tab, so a closed terminal is **not** reopenable after an app restart. That's unchanged from before this PR, and not fixable without either persisting the payloads or putting `cwd` on the resources wire — happy to follow up if that's wanted.

## Verification

- `bun run compile`, `bun run lint`, `react-doctor` — clean
- popover suite 29/29, including two new cases: cross-route reopen of a closed tile in a hidden tab, and same-route reopen in the active tab
- confirmed working in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)