### PR TITLE
fix(gui-app): split the pane when its only tab is dropped on its own edge

### DIFF
--- a/clients/gui-app/src/stores/epics/canvas/__tests__/actions.test.ts
+++ b/clients/gui-app/src/stores/epics/canvas/__tests__/actions.test.ts
@@ -643,14 +643,70 @@ describe("splitPaneAtEdge", () => {
     expectCanvasInvariants(next);
   });
 
-  it("does not split a sole tab onto its own pane edge", () => {
+  // Dropping a pane's ONLY tab on that pane's own edge is the common way to
+  // split a freshly opened Git Diff / Terminal, and the pane drop zone paints
+  // the half-pane split preview for it. The commit must produce that split -
+  // the dragged tile in the highlighted half, the source pane left behind as
+  // an empty opener pane - instead of silently discarding the drop.
+  it("splits a sole tab onto its own pane edge, leaving an empty opener pane", () => {
     const state = openPinned(createEmptyCanvas(), SPEC_A);
     const paneId = rootPane(state).id;
+
     const next = splitPaneAtEdge(state, paneId, "right", {
       kind: "node",
       node: SPEC_A,
     });
-    expect(next).toBe(state);
+
+    const group = rootGroup(next);
+    expect(group.direction).toBe("horizontal");
+    const [leading, trailing] = collectPanes(next.root);
+    expect(leading.id).toBe(paneId);
+    expect(leading.tabInstanceIds).toEqual([]);
+    expect(paneTabIds(next, trailing)).toEqual([SPEC_A.id]);
+    expect(next.activePaneId).toBe(trailing.id);
+    expectCanvasInvariants(next);
+  });
+
+  it("splits a sole tab onto the leading edge with the tile in the leading pane", () => {
+    const state = openPinned(createEmptyCanvas(), SPEC_A);
+    const paneId = rootPane(state).id;
+
+    const next = splitPaneAtEdge(state, paneId, "left", {
+      kind: "tab",
+      sourcePaneId: paneId,
+      tabId: SPEC_A.instanceId,
+      node: SPEC_A,
+    });
+
+    const [leading, trailing] = collectPanes(next.root);
+    expect(paneTabIds(next, leading)).toEqual([SPEC_A.id]);
+    expect(trailing.id).toBe(paneId);
+    expect(trailing.tabInstanceIds).toEqual([]);
+    expectCanvasInvariants(next);
+  });
+
+  // Only the SAME-pane drop keeps the emptied pane: dragging a pane's last tab
+  // into a DIFFERENT pane still collapses the pane it came from.
+  it("still collapses the source pane when its last tab lands on another pane's edge", () => {
+    let state = openPinned(createEmptyCanvas(), SPEC_A);
+    const targetPaneId = rootPane(state).id;
+    state = splitPaneAtEdge(state, targetPaneId, "right", {
+      kind: "node",
+      node: SPEC_B,
+    });
+    const sourcePaneId = state.activePaneId;
+    if (sourcePaneId === null) throw new Error("expected source pane");
+
+    const next = splitPaneAtEdge(state, targetPaneId, "bottom", {
+      kind: "tab",
+      sourcePaneId,
+      tabId: SPEC_B.instanceId,
+      node: SPEC_B,
+    });
+
+    expect(findPaneById(next.root, sourcePaneId)).toBeNull();
+    expect(collectPanes(next.root)).toHaveLength(2);
+    expectCanvasInvariants(next);
   });
 
   it("rejects an edge split that would exceed MAX_TREE_DEPTH (no-op)", () => {

--- a/clients/gui-app/src/stores/epics/canvas/actions.ts
+++ b/clients/gui-app/src/stores/epics/canvas/actions.ts
@@ -1156,23 +1156,23 @@ function resolveSplitSource(
   if (sourcePane === null) return null;
   const fromIndex = sourcePane.tabInstanceIds.indexOf(source.tabId);
   if (fromIndex === -1) return null;
-  // Splitting a single-tab source pane onto its own edge would just
-  // rearrange the same pane - reject as no-op.
-  if (
-    source.sourcePaneId === targetPaneId &&
-    sourcePane.tabInstanceIds.length === 1
-  ) {
-    return null;
-  }
   const ref = state.tilesByInstanceId[source.tabId];
   if (ref === undefined) return null;
   const removed = removeTabAtIndexWithSyntheticFallback(sourcePane, fromIndex);
   const root = replacePane(state.root, source.sourcePaneId, () => removed.pane);
+  // An emptied source pane normally collapses - a tab dragged OUT of a pane
+  // shouldn't leave a hole behind. But when the drop targets that same pane,
+  // collapsing would undo the very split the drop preview just promised (the
+  // sole-tab case: open a Git Diff or Terminal, drag it to the pane edge). Keep
+  // the emptied pane as the split's other half, where it renders the standard
+  // opener - the same shape the "Split group" button produces.
+  const emptiedSourcePane = removed.pane.tabInstanceIds.length === 0;
+  const splitsIntoItself = source.sourcePaneId === targetPaneId;
   return {
     state: { ...state, root },
     node: ref,
     collapseSourcePaneId:
-      removed.pane.tabInstanceIds.length === 0 ? source.sourcePaneId : null,
+      emptiedSourcePane && !splitsIntoItself ? source.sourcePaneId : null,
   };
 }
 


### PR DESCRIPTION
## Summary

A canvas pane holding **exactly one tab** — the normal state right after opening a Git Diff or a Terminal — paints the half-pane split preview at full opacity while you hover its edge, then silently discards the drop on release. With two or more tabs in the pane the same gesture splits correctly, which is why it reads as intermittent rather than broken.

`resolveSplitSource` rejected a same-pane edge split whenever the source pane held a single tab, reasoning that the pane would only rearrange itself. The pane drop zone never learned about that rejection, so the UI promised a split the commit threw away.

This treats the gesture as the split it advertises: the dragged tile lands in the highlighted half, and the emptied source pane stays as the other half where it renders the standard opener — the same shape the "Split group right/down" button already produces. An emptied source pane still collapses when the tab was dragged into a **different** pane, so no stray hole is left behind there.

### Reproduce (before this change)

1. Open an epic and get the canvas pane down to exactly one tab (open a Git Diff or a Terminal, close the others).
2. Drag that tab into the outer ~15% of the pane body — e.g. hard against the right edge.
3. The dashed half-pane split preview lights up.
4. Release. Nothing happens.

Open a second canvas tab and repeat: it splits. That single-tab-vs-multi-tab difference is the whole bug.

Verified against Traycer Desktop v1.1.8 on Windows 11 and reproduced by the reporter on macOS; the guard is in pure store logic, so it is platform-independent.

### Tests

`splitPaneAtEdge` gained three cases, all failing before the change:

- a sole tab dropped on its own pane's trailing edge splits, leaving an empty opener pane behind;
- the leading-edge variant puts the tile in the leading pane;
- a pane's last tab dropped on **another** pane's edge still collapses the pane it came from.

The previous `does not split a sole tab onto its own pane edge` case asserted the old behaviour and is replaced — the drop preview promises the opposite.

## Related issue

Part of #712 (the split-view half; the conversation-scrolling half is a separate change).

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
