### PR TITLE
feat(gui-app): drag active agents into tiles

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-active-agents-panel.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-active-agents-panel.test.tsx
@@ -1,10 +1,64 @@
 import "../../../../__tests__/test-browser-apis";
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ActiveAgentsPanel } from "@/components/chat/chat-active-agents-panel";
 import { AgentStopList } from "@/components/chat/chat-agent-stop-list";
+import { readEpicCanvasDragSourceData } from "@/components/epic-canvas/dnd/dnd";
 import type { AgentRow } from "@/hooks/agent/use-agent-stop-controls";
+import type { EpicCanvasTileRef } from "@/stores/epics/canvas/types";
+
+interface CapturedDraggable {
+  readonly id: string;
+  readonly disabled: boolean;
+  readonly data: unknown;
+}
+
+interface CanvasMockState {
+  resolvedTabId: string | null;
+}
+
+const dnd = vi.hoisted(() => ({
+  draggables: [] as CapturedDraggable[],
+}));
+
+const navigation = vi.hoisted(() => ({
+  openTileInEpic: vi.fn<(epicId: string, node: EpicCanvasTileRef) => null>(
+    () => null,
+  ),
+}));
+
+const canvas = vi.hoisted((): CanvasMockState => ({
+  resolvedTabId: "tab-1",
+}));
+
+vi.mock("@dnd-kit/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/core")>();
+  return {
+    ...actual,
+    useDraggable: (input: CapturedDraggable) => {
+      dnd.draggables.push(input);
+      return {
+        attributes: {},
+        listeners: {},
+        setNodeRef: () => undefined,
+        isDragging: false,
+      };
+    },
+  };
+});
+
+vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
+  useEpicTileNavigation: () => ({
+    openTileInEpic: navigation.openTileInEpic,
+  }),
+}));
+
+vi.mock("@/stores/epics/canvas/store", () => ({
+  useEpicCanvasStore: (selector: (state: typeof canvas) => unknown) =>
+    selector(canvas),
+  resolveTabIdForEpic: () => canvas.resolvedTabId,
+}));
 
 // Stub the host-coupled stop button so these render tests stay focused on the
 // panel/list structure (header "Stop all", per-row hover stops, self-stop
@@ -37,6 +91,12 @@ function row(over: Partial<AgentRow> & Pick<AgentRow, "id">): AgentRow {
     ...over,
   };
 }
+
+beforeEach(() => {
+  dnd.draggables = [];
+  navigation.openTileInEpic.mockClear();
+  canvas.resolvedTabId = "tab-1";
+});
 
 afterEach(cleanup);
 
@@ -94,6 +154,94 @@ describe("ActiveAgentsPanel", () => {
         "group-hover:opacity-100",
       );
     }
+  });
+
+  it("opens the current agent or a descendant from its row", () => {
+    renderPanel();
+    fireEvent.click(screen.getByText("Active agents"));
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Root chat" }));
+    fireEvent.click(screen.getByRole("button", { name: "Open Sub-agent two" }));
+
+    expect(
+      navigation.openTileInEpic.mock.calls.map(
+        ([epicId, { instanceId, ...node }]) => ({
+          epicId,
+          instanceIdType: typeof instanceId,
+          node,
+        }),
+      ),
+    ).toEqual([
+      {
+        epicId: "epic-1",
+        instanceIdType: "string",
+        node: {
+          id: "self",
+          type: "chat",
+          name: "Root chat",
+          hostId: "d1",
+        },
+      },
+      {
+        epicId: "epic-1",
+        instanceIdType: "string",
+        node: {
+          id: "child-2",
+          type: "chat",
+          name: "Sub-agent two",
+          hostId: "d1",
+        },
+      },
+    ]);
+  });
+
+  it("registers every row as a unique sidebar-node drag source", () => {
+    renderPanel();
+    fireEvent.click(screen.getByText("Active agents"));
+
+    const draggables = dnd.draggables.filter(
+      (draggable) =>
+        readEpicCanvasDragSourceData(draggable.data)?.kind === "sidebar-node",
+    );
+    expect(draggables).toHaveLength(3);
+    expect(new Set(draggables.map((draggable) => draggable.id)).size).toBe(3);
+    expect(
+      draggables.every((draggable) => draggable.id.startsWith("active-agent:")),
+    ).toBe(true);
+    expect(
+      draggables.map((draggable) => ({
+        disabled: draggable.disabled,
+        source: readEpicCanvasDragSourceData(draggable.data),
+      })),
+    ).toEqual([
+      {
+        disabled: false,
+        source: {
+          kind: "sidebar-node",
+          epicId: "epic-1",
+          viewTabId: "tab-1",
+          nodeId: "self",
+        },
+      },
+      {
+        disabled: false,
+        source: {
+          kind: "sidebar-node",
+          epicId: "epic-1",
+          viewTabId: "tab-1",
+          nodeId: "child-1",
+        },
+      },
+      {
+        disabled: false,
+        source: {
+          kind: "sidebar-node",
+          epicId: "epic-1",
+          viewTabId: "tab-1",
+          nodeId: "child-2",
+        },
+      },
+    ]);
   });
 });
 

--- a/clients/gui-app/src/components/chat/__tests__/chat-active-agents-panel.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-active-agents-panel.test.tsx
@@ -119,7 +119,7 @@ describe("ActiveAgentsPanel", () => {
 
   it("moves 'Stop all' onto the current agent's row and reveals descendant stops on hover when expanded", () => {
     renderPanel();
-    fireEvent.click(screen.getByText("Active agents"));
+    fireEvent.click(screen.getByRole("button", { name: /active agents/i }));
 
     // "Stop all" now lives on the current agent's row (compact, icon-only) and
     // stays visible there - the header no longer shows a duplicate, and the
@@ -149,7 +149,7 @@ describe("ActiveAgentsPanel", () => {
 
   it("opens the current agent or a descendant from its row", () => {
     renderPanel();
-    fireEvent.click(screen.getByText("Active agents"));
+    fireEvent.click(screen.getByRole("button", { name: /active agents/i }));
 
     fireEvent.click(screen.getByRole("button", { name: "Open Root chat" }));
     fireEvent.click(screen.getByRole("button", { name: "Open Sub-agent two" }));
@@ -188,7 +188,7 @@ describe("ActiveAgentsPanel", () => {
 
   it("registers every row as a unique, host-bound active-agent drag source", () => {
     renderPanel();
-    fireEvent.click(screen.getByText("Active agents"));
+    fireEvent.click(screen.getByRole("button", { name: /active agents/i }));
 
     expect(dnd.draggables).toHaveLength(3);
     expect(new Set(dnd.draggables.map((draggable) => draggable.id)).size).toBe(

--- a/clients/gui-app/src/components/chat/__tests__/chat-active-agents-panel.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-active-agents-panel.test.tsx
@@ -14,22 +14,14 @@ interface CapturedDraggable {
   readonly data: unknown;
 }
 
-interface CanvasMockState {
-  resolvedTabId: string | null;
-}
-
 const dnd = vi.hoisted(() => ({
   draggables: [] as CapturedDraggable[],
 }));
 
 const navigation = vi.hoisted(() => ({
-  openTileInEpic: vi.fn<(epicId: string, node: EpicCanvasTileRef) => null>(
+  openTileInTab: vi.fn<(viewTabId: string, node: EpicCanvasTileRef) => null>(
     () => null,
   ),
-}));
-
-const canvas = vi.hoisted((): CanvasMockState => ({
-  resolvedTabId: "tab-1",
 }));
 
 vi.mock("@dnd-kit/core", async (importOriginal) => {
@@ -50,14 +42,8 @@ vi.mock("@dnd-kit/core", async (importOriginal) => {
 
 vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
   useEpicTileNavigation: () => ({
-    openTileInEpic: navigation.openTileInEpic,
+    openTileInTab: navigation.openTileInTab,
   }),
-}));
-
-vi.mock("@/stores/epics/canvas/store", () => ({
-  useEpicCanvasStore: (selector: (state: typeof canvas) => unknown) =>
-    selector(canvas),
-  resolveTabIdForEpic: () => canvas.resolvedTabId,
 }));
 
 // Stub the host-coupled stop button so these render tests stay focused on the
@@ -94,8 +80,7 @@ function row(over: Partial<AgentRow> & Pick<AgentRow, "id">): AgentRow {
 
 beforeEach(() => {
   dnd.draggables = [];
-  navigation.openTileInEpic.mockClear();
-  canvas.resolvedTabId = "tab-1";
+  navigation.openTileInTab.mockClear();
 });
 
 afterEach(cleanup);
@@ -105,10 +90,16 @@ describe("ActiveAgentsPanel", () => {
     return render(
       <ActiveAgentsPanel
         epicId="epic-1"
+        viewTabId="tab-1"
         self={row({ id: "self", title: "Root chat", active: true })}
         descendants={[
           row({ id: "child-1", title: "Sub-agent one" }),
-          row({ id: "child-2", title: "Sub-agent two" }),
+          row({
+            id: "child-2",
+            title: "Sub-agent two",
+            surface: "tui",
+            hostId: "d2",
+          }),
         ]}
         scrollRegionMaxHeightClass="max-h-40"
         separated={false}
@@ -164,16 +155,16 @@ describe("ActiveAgentsPanel", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open Sub-agent two" }));
 
     expect(
-      navigation.openTileInEpic.mock.calls.map(
-        ([epicId, { instanceId, ...node }]) => ({
-          epicId,
+      navigation.openTileInTab.mock.calls.map(
+        ([viewTabId, { instanceId, ...node }]) => ({
+          viewTabId,
           instanceIdType: typeof instanceId,
           node,
         }),
       ),
     ).toEqual([
       {
-        epicId: "epic-1",
+        viewTabId: "tab-1",
         instanceIdType: "string",
         node: {
           id: "self",
@@ -183,33 +174,33 @@ describe("ActiveAgentsPanel", () => {
         },
       },
       {
-        epicId: "epic-1",
+        viewTabId: "tab-1",
         instanceIdType: "string",
         node: {
           id: "child-2",
-          type: "chat",
+          type: "terminal-agent",
           name: "Sub-agent two",
-          hostId: "d1",
+          hostId: "d2",
         },
       },
     ]);
   });
 
-  it("registers every row as a unique sidebar-node drag source", () => {
+  it("registers every row as a unique, host-bound active-agent drag source", () => {
     renderPanel();
     fireEvent.click(screen.getByText("Active agents"));
 
-    const draggables = dnd.draggables.filter(
-      (draggable) =>
-        readEpicCanvasDragSourceData(draggable.data)?.kind === "sidebar-node",
+    expect(dnd.draggables).toHaveLength(3);
+    expect(new Set(dnd.draggables.map((draggable) => draggable.id)).size).toBe(
+      3,
     );
-    expect(draggables).toHaveLength(3);
-    expect(new Set(draggables.map((draggable) => draggable.id)).size).toBe(3);
     expect(
-      draggables.every((draggable) => draggable.id.startsWith("active-agent:")),
+      dnd.draggables.every((draggable) =>
+        draggable.id.startsWith("active-agent:"),
+      ),
     ).toBe(true);
     expect(
-      draggables.map((draggable) => ({
+      dnd.draggables.map((draggable) => ({
         disabled: draggable.disabled,
         source: readEpicCanvasDragSourceData(draggable.data),
       })),
@@ -217,28 +208,43 @@ describe("ActiveAgentsPanel", () => {
       {
         disabled: false,
         source: {
-          kind: "sidebar-node",
+          kind: "active-agent",
           epicId: "epic-1",
           viewTabId: "tab-1",
-          nodeId: "self",
+          agent: {
+            id: "self",
+            type: "chat",
+            name: "Root chat",
+            hostId: "d1",
+          },
         },
       },
       {
         disabled: false,
         source: {
-          kind: "sidebar-node",
+          kind: "active-agent",
           epicId: "epic-1",
           viewTabId: "tab-1",
-          nodeId: "child-1",
+          agent: {
+            id: "child-1",
+            type: "chat",
+            name: "Sub-agent one",
+            hostId: "d1",
+          },
         },
       },
       {
         disabled: false,
         source: {
-          kind: "sidebar-node",
+          kind: "active-agent",
           epicId: "epic-1",
           viewTabId: "tab-1",
-          nodeId: "child-2",
+          agent: {
+            id: "child-2",
+            type: "terminal-agent",
+            name: "Sub-agent two",
+            hostId: "d2",
+          },
         },
       },
     ]);
@@ -250,6 +256,7 @@ describe("AgentStopList (TUI popover surface)", () => {
     render(
       <AgentStopList
         epicId="epic-1"
+        viewTabId="tab-1"
         self={row({ id: "self", title: "Root chat" })}
         descendants={[row({ id: "child-1", title: "Sub-agent one" })]}
         surface="tui-popover"

--- a/clients/gui-app/src/components/chat/__tests__/chat-lower-dock.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-lower-dock.test.tsx
@@ -173,6 +173,7 @@ function renderDock(input: {
       <ChatLowerDock
         snapshotLoaded
         epicId="epic-1"
+        viewTabId="tab-1"
         selfAgent={null}
         activeAgents={[]}
         todo={input.todo}

--- a/clients/gui-app/src/components/chat/chat-active-agents-panel.tsx
+++ b/clients/gui-app/src/components/chat/chat-active-agents-panel.tsx
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
  */
 export function ActiveAgentsPanel(props: {
   readonly epicId: string;
+  readonly viewTabId: string;
   readonly self: AgentRow;
   readonly descendants: ReadonlyArray<AgentRow>;
   readonly scrollRegionMaxHeightClass: string;
@@ -94,6 +95,7 @@ export function ActiveAgentsPanel(props: {
         >
           <AgentStopList
             epicId={props.epicId}
+            viewTabId={props.viewTabId}
             self={props.self}
             descendants={props.descendants}
             surface="composer-panel"

--- a/clients/gui-app/src/components/chat/chat-agent-stop-list.tsx
+++ b/clients/gui-app/src/components/chat/chat-agent-stop-list.tsx
@@ -1,11 +1,22 @@
-import { useCallback, type ReactNode } from "react";
+import { useDraggable } from "@dnd-kit/core";
+import { useCallback, useId, useMemo, type ReactNode } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
+import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { AgentStopButton } from "@/components/chat/agent-stop-button";
+import {
+  getActiveAgentDragId,
+  SIDEBAR_NODE_DND_TYPE,
+  type EpicCanvasSidebarNodeDragData,
+} from "@/components/epic-canvas/dnd/dnd";
 import type { AgentRow } from "@/hooks/agent/use-agent-stop-controls";
 import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
+import {
+  resolveTabIdForEpic,
+  useEpicCanvasStore,
+} from "@/stores/epics/canvas/store";
+import { cn } from "@/lib/utils";
 
-import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 /**
  * A row's `surface` is UI copy ("gui"/"tui"); opening a tile needs the
  * record-backed node kind. The two map 1:1 (the inverse of `surfaceOf` in
@@ -53,6 +64,117 @@ function StopAffordance(props: {
 }
 
 /**
+ * One openable active-agent row. It emits the same `sidebar-node` payload as
+ * the navigator, so the root canvas DnD system supplies the established pane,
+ * empty-canvas, and header-tab drop behavior without a parallel commit path.
+ *
+ * The drag id is occurrence-scoped because this is another rendering of a node
+ * that is usually mounted in the sidebar at the same time. The trailing stop
+ * action stays outside the drag/open button so stopping never starts a drag or
+ * opens the tile.
+ */
+function AgentStopRow(props: {
+  readonly epicId: string;
+  readonly viewTabId: string | null;
+  readonly agent: AgentRow;
+  readonly self: boolean;
+  readonly compact: boolean;
+  readonly onOpen: (agent: AgentRow) => void;
+}) {
+  const { epicId, viewTabId, agent, self, compact, onOpen } = props;
+  const occurrenceId = useId();
+  const dragData = useMemo<EpicCanvasSidebarNodeDragData | undefined>(() => {
+    if (viewTabId === null) return undefined;
+    return {
+      kind: SIDEBAR_NODE_DND_TYPE,
+      epicId,
+      viewTabId,
+      nodeId: agent.id,
+    };
+  }, [agent.id, epicId, viewTabId]);
+  const {
+    attributes,
+    listeners,
+    setNodeRef: dragRef,
+    isDragging,
+  } = useDraggable({
+    id: getActiveAgentDragId(occurrenceId),
+    disabled: dragData === undefined,
+    data: dragData,
+  });
+  const openAgent = useCallback(() => onOpen(agent), [agent, onOpen]);
+  let cursorClass = "cursor-grab";
+  if (dragData === undefined) cursorClass = "cursor-pointer";
+  else if (isDragging) cursorClass = "cursor-grabbing";
+
+  return (
+    <li
+      className={cn(
+        "group flex min-w-0 items-center gap-2 rounded-md",
+        self ? "bg-muted/50 px-2" : "pl-5 pr-2 hover:bg-muted/40",
+        isDragging && "opacity-60",
+      )}
+    >
+      <TooltipWrapper
+        label={`Open ${agent.title}`}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
+      >
+        <button
+          ref={dragRef}
+          {...attributes}
+          {...listeners}
+          type="button"
+          aria-label={`Open ${agent.title}`}
+          onClick={openAgent}
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-2 rounded-md py-1 text-left focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
+            cursorClass,
+          )}
+        >
+          <ActivityDot active={agent.active} />
+          <span
+            className={cn(
+              "block min-w-0 flex-1 truncate text-ui-xs text-foreground/85",
+              self && "font-medium",
+            )}
+          >
+            {agent.title}
+          </span>
+          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-ui-xs uppercase text-muted-foreground">
+            {agent.surface}
+          </span>
+        </button>
+      </TooltipWrapper>
+      {self ? (
+        // The current agent's "Stop all" stays visible - it is the primary
+        // action and keeps the parent row from looking stop-less.
+        <AgentStopButton
+          epicId={epicId}
+          agentId={agent.id}
+          hostId={agent.hostId}
+          label="Stop all"
+          iconOnly={compact}
+          testId="agent-stop-all"
+        />
+      ) : (
+        <StopAffordance revealOnHover={compact}>
+          <AgentStopButton
+            epicId={epicId}
+            agentId={agent.id}
+            hostId={agent.hostId}
+            label="Stop"
+            iconOnly={compact}
+            testId={undefined}
+          />
+        </StopAffordance>
+      )}
+    </li>
+  );
+}
+
+/**
  * Shared row list for both agent-stop surfaces. The current agent is the
  * topmost row; its active descendants follow, indented, each individually
  * stoppable. Keeping this in one place is what guarantees the two surfaces stay
@@ -75,8 +197,12 @@ export function AgentStopList(props: {
 }) {
   const compact = props.surface === "composer-panel";
   const tileNavigation = useEpicTileNavigation();
-  // Opening a sub-agent reuses the same path as the agent-reference chip:
-  // resolve the epic's target tab and open (or focus) the agent's tile there.
+  // Resolve once for the whole list. Rendering drag sources must not create or
+  // switch a header tab; if this epic has none open, click-to-open still works
+  // while dragging is defensively disabled.
+  const viewTabId = useEpicCanvasStore((state) =>
+    resolveTabIdForEpic(state, props.epicId),
+  );
   const openAgent = useCallback(
     (agent: AgentRow) => {
       tileNavigation.openTileInEpic(props.epicId, {
@@ -91,61 +217,24 @@ export function AgentStopList(props: {
   );
   return (
     <ul className="m-0 flex list-none flex-col gap-0.5 p-1.5">
-      <li className="flex min-w-0 items-center gap-2 rounded-md bg-muted/50 px-2 py-1">
-        <ActivityDot active={props.self.active} />
-        <span className="block min-w-0 flex-1 truncate text-ui-xs font-medium text-foreground/85">
-          {props.self.title}
-        </span>
-        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-ui-xs uppercase text-muted-foreground">
-          {props.self.surface}
-        </span>
-        {/* The current agent's "Stop all" stays visible - it is the primary
-            action and keeps the parent row from looking stop-less. */}
-        <AgentStopButton
-          epicId={props.epicId}
-          agentId={props.self.id}
-          hostId={props.self.hostId}
-          label="Stop all"
-          iconOnly={compact}
-          testId="agent-stop-all"
-        />
-      </li>
+      <AgentStopRow
+        epicId={props.epicId}
+        viewTabId={viewTabId}
+        agent={props.self}
+        self
+        compact={compact}
+        onOpen={openAgent}
+      />
       {props.descendants.map((agent) => (
-        <li
+        <AgentStopRow
           key={agent.id}
-          className="group flex min-w-0 items-center gap-2 rounded-md pl-5 pr-2 hover:bg-muted/40"
-        >
-          <TooltipWrapper
-            label={`Open ${agent.title}`}
-            side="top"
-            sideOffset={undefined}
-            align={undefined}
-          >
-            <button
-              type="button"
-              onClick={() => openAgent(agent)}
-              className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md py-1 text-left focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-            >
-              <ActivityDot active={agent.active} />
-              <span className="block min-w-0 flex-1 truncate text-ui-xs text-foreground/85">
-                {agent.title}
-              </span>
-              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-ui-xs uppercase text-muted-foreground">
-                {agent.surface}
-              </span>
-            </button>
-          </TooltipWrapper>
-          <StopAffordance revealOnHover={compact}>
-            <AgentStopButton
-              epicId={props.epicId}
-              agentId={agent.id}
-              hostId={agent.hostId}
-              label="Stop"
-              iconOnly={compact}
-              testId={undefined}
-            />
-          </StopAffordance>
-        </li>
+          epicId={props.epicId}
+          viewTabId={viewTabId}
+          agent={agent}
+          self={false}
+          compact={compact}
+          onOpen={openAgent}
+        />
       ))}
     </ul>
   );

--- a/clients/gui-app/src/components/chat/chat-agent-stop-list.tsx
+++ b/clients/gui-app/src/components/chat/chat-agent-stop-list.tsx
@@ -5,16 +5,12 @@ import { AgentSpinningDots } from "@/components/ui/agent-spinning-dots";
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { AgentStopButton } from "@/components/chat/agent-stop-button";
 import {
+  ACTIVE_AGENT_DND_TYPE,
   getActiveAgentDragId,
-  SIDEBAR_NODE_DND_TYPE,
-  type EpicCanvasSidebarNodeDragData,
+  type EpicCanvasActiveAgentDragData,
 } from "@/components/epic-canvas/dnd/dnd";
 import type { AgentRow } from "@/hooks/agent/use-agent-stop-controls";
 import { useEpicTileNavigation } from "@/hooks/epic/use-epic-tile-navigation";
-import {
-  resolveTabIdForEpic,
-  useEpicCanvasStore,
-} from "@/stores/epics/canvas/store";
 import { cn } from "@/lib/utils";
 
 /**
@@ -64,9 +60,9 @@ function StopAffordance(props: {
 }
 
 /**
- * One openable active-agent row. It emits the same `sidebar-node` payload as
- * the navigator, so the root canvas DnD system supplies the established pane,
- * empty-canvas, and header-tab drop behavior without a parallel commit path.
+ * One openable active-agent row. Its self-describing payload keeps the same
+ * pane, empty-canvas, and header-tab behavior as the navigator while preserving
+ * the agent's tab-bound host instead of consulting the app's active device.
  *
  * The drag id is occurrence-scoped because this is another rendering of a node
  * that is usually mounted in the sidebar at the same time. The trailing stop
@@ -75,7 +71,7 @@ function StopAffordance(props: {
  */
 function AgentStopRow(props: {
   readonly epicId: string;
-  readonly viewTabId: string | null;
+  readonly viewTabId: string;
   readonly agent: AgentRow;
   readonly self: boolean;
   readonly compact: boolean;
@@ -83,15 +79,20 @@ function AgentStopRow(props: {
 }) {
   const { epicId, viewTabId, agent, self, compact, onOpen } = props;
   const occurrenceId = useId();
-  const dragData = useMemo<EpicCanvasSidebarNodeDragData | undefined>(() => {
-    if (viewTabId === null) return undefined;
-    return {
-      kind: SIDEBAR_NODE_DND_TYPE,
+  const dragData = useMemo<EpicCanvasActiveAgentDragData>(
+    () => ({
+      kind: ACTIVE_AGENT_DND_TYPE,
       epicId,
       viewTabId,
-      nodeId: agent.id,
-    };
-  }, [agent.id, epicId, viewTabId]);
+      agent: {
+        id: agent.id,
+        type: nodeKindForSurface(agent.surface),
+        name: agent.title,
+        hostId: agent.hostId,
+      },
+    }),
+    [agent.hostId, agent.id, agent.surface, agent.title, epicId, viewTabId],
+  );
   const {
     attributes,
     listeners,
@@ -99,13 +100,11 @@ function AgentStopRow(props: {
     isDragging,
   } = useDraggable({
     id: getActiveAgentDragId(occurrenceId),
-    disabled: dragData === undefined,
+    disabled: false,
     data: dragData,
   });
   const openAgent = useCallback(() => onOpen(agent), [agent, onOpen]);
-  let cursorClass = "cursor-grab";
-  if (dragData === undefined) cursorClass = "cursor-pointer";
-  else if (isDragging) cursorClass = "cursor-grabbing";
+  const cursorClass = isDragging ? "cursor-grabbing" : "cursor-grab";
 
   return (
     <li
@@ -191,21 +190,16 @@ function AgentStopRow(props: {
  */
 export function AgentStopList(props: {
   readonly epicId: string;
+  readonly viewTabId: string;
   readonly self: AgentRow;
   readonly descendants: ReadonlyArray<AgentRow>;
   readonly surface: "composer-panel" | "tui-popover";
 }) {
   const compact = props.surface === "composer-panel";
   const tileNavigation = useEpicTileNavigation();
-  // Resolve once for the whole list. Rendering drag sources must not create or
-  // switch a header tab; if this epic has none open, click-to-open still works
-  // while dragging is defensively disabled.
-  const viewTabId = useEpicCanvasStore((state) =>
-    resolveTabIdForEpic(state, props.epicId),
-  );
   const openAgent = useCallback(
     (agent: AgentRow) => {
-      tileNavigation.openTileInEpic(props.epicId, {
+      tileNavigation.openTileInTab(props.viewTabId, {
         id: agent.id,
         instanceId: uuidv4(),
         type: nodeKindForSurface(agent.surface),
@@ -213,13 +207,13 @@ export function AgentStopList(props: {
         hostId: agent.hostId,
       });
     },
-    [props.epicId, tileNavigation],
+    [props.viewTabId, tileNavigation],
   );
   return (
     <ul className="m-0 flex list-none flex-col gap-0.5 p-1.5">
       <AgentStopRow
         epicId={props.epicId}
-        viewTabId={viewTabId}
+        viewTabId={props.viewTabId}
         agent={props.self}
         self
         compact={compact}
@@ -229,7 +223,7 @@ export function AgentStopList(props: {
         <AgentStopRow
           key={agent.id}
           epicId={props.epicId}
-          viewTabId={viewTabId}
+          viewTabId={props.viewTabId}
           agent={agent}
           self={false}
           compact={compact}

--- a/clients/gui-app/src/components/chat/chat-lower-dock.tsx
+++ b/clients/gui-app/src/components/chat/chat-lower-dock.tsx
@@ -18,6 +18,7 @@ import type { ChatPinnedStackTopSpacing } from "@/components/chat/chat-pinned-st
 export interface ChatLowerDockProps {
   readonly snapshotLoaded: boolean;
   readonly epicId: string;
+  readonly viewTabId: string;
   readonly selfAgent: AgentRow | null;
   readonly activeAgents: ReadonlyArray<AgentRow>;
   readonly todo: PinnedTodoSnapshot | null;
@@ -150,6 +151,7 @@ function AgentsSection(props: {
   return (
     <ActiveAgentsPanel
       epicId={dock.epicId}
+      viewTabId={dock.viewTabId}
       self={selfAgent}
       descendants={dock.activeAgents}
       scrollRegionMaxHeightClass={dock.scrollRegionMaxHeightClass}

--- a/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/chat-tile-composer-rerender.test.tsx
@@ -218,6 +218,7 @@ function props(
 ): ChatLowerInteractionSurfacesProps {
   return {
     epicId: "epic-1",
+    viewTabId: "tab-1",
     chatId: "chat-1",
     runtime: RUNTIME,
     access: ACCESS,

--- a/clients/gui-app/src/components/epic-canvas/dnd/__tests__/active-agent-source.test.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/__tests__/active-agent-source.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVE_AGENT_DND_TYPE,
+  readEpicCanvasDragSourceData,
+  type EpicCanvasActiveAgentDragData,
+} from "@/components/epic-canvas/dnd/dnd";
+import {
+  canDropOnHeaderStrip,
+  sourceToTileRef,
+} from "@/components/epic-canvas/dnd/root-dnd-commits";
+
+const ACTIVE_AGENT_SOURCE: EpicCanvasActiveAgentDragData = {
+  kind: ACTIVE_AGENT_DND_TYPE,
+  epicId: "epic-1",
+  viewTabId: "tab-containing-agent-list",
+  agent: {
+    id: "agent-1",
+    type: "chat",
+    name: "Bound agent",
+    hostId: "host-bound-to-agent",
+  },
+};
+
+describe("active-agent canvas drag source", () => {
+  it("round-trips host-bound GUI and TUI agent identities", () => {
+    expect(readEpicCanvasDragSourceData(ACTIVE_AGENT_SOURCE)).toEqual(
+      ACTIVE_AGENT_SOURCE,
+    );
+    expect(
+      readEpicCanvasDragSourceData({
+        ...ACTIVE_AGENT_SOURCE,
+        agent: {
+          ...ACTIVE_AGENT_SOURCE.agent,
+          type: "terminal-agent",
+        },
+      }),
+    ).toEqual({
+      ...ACTIVE_AGENT_SOURCE,
+      agent: {
+        ...ACTIVE_AGENT_SOURCE.agent,
+        type: "terminal-agent",
+      },
+    });
+  });
+
+  it("rejects an unknown agent kind or a missing host binding", () => {
+    expect(
+      readEpicCanvasDragSourceData({
+        ...ACTIVE_AGENT_SOURCE,
+        agent: { ...ACTIVE_AGENT_SOURCE.agent, type: "ticket" },
+      }),
+    ).toBeNull();
+    expect(
+      readEpicCanvasDragSourceData({
+        ...ACTIVE_AGENT_SOURCE,
+        agent: { ...ACTIVE_AGENT_SOURCE.agent, hostId: "" },
+      }),
+    ).toBeNull();
+  });
+
+  it("opens on the bound host with a fresh instance per conversion", () => {
+    const first = sourceToTileRef(ACTIVE_AGENT_SOURCE);
+    const second = sourceToTileRef(ACTIVE_AGENT_SOURCE);
+
+    expect(first).toMatchObject({
+      id: "agent-1",
+      type: "chat",
+      name: "Bound agent",
+      hostId: "host-bound-to-agent",
+    });
+    expect(second).toMatchObject({
+      id: "agent-1",
+      hostId: "host-bound-to-agent",
+    });
+    expect(first?.instanceId).not.toBe(second?.instanceId);
+  });
+
+  it("can open in a new header tab", () => {
+    expect(canDropOnHeaderStrip(ACTIVE_AGENT_SOURCE)).toBe(true);
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/dnd/dnd.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/dnd.ts
@@ -39,6 +39,7 @@ export const TERMINAL_TILE_DND_TYPE = "terminal-tile";
 export const GIT_DIFF_TILE_DND_TYPE = "git-diff-tile";
 export const WORKSPACE_FILE_DND_TYPE = "workspace-file";
 export const CHAT_ARTIFACT_DND_TYPE = "chat-artifact";
+export const ACTIVE_AGENT_DND_TYPE = "active-agent";
 export const LEFT_PANEL_RAIL_ITEM_DND_TYPE = "left-panel-rail-item";
 export const EPIC_CANVAS_DND_SOURCE_TYPES = [
   ARTIFACT_TAB_DND_TYPE,
@@ -47,6 +48,7 @@ export const EPIC_CANVAS_DND_SOURCE_TYPES = [
   GIT_DIFF_TILE_DND_TYPE,
   WORKSPACE_FILE_DND_TYPE,
   CHAT_ARTIFACT_DND_TYPE,
+  ACTIVE_AGENT_DND_TYPE,
 ];
 
 export interface RectLike {
@@ -141,6 +143,24 @@ export interface EpicCanvasChatArtifactDragData {
   };
 }
 
+/**
+ * An agent row rendered outside the sidebar tree. Unlike `sidebar-node`, this
+ * source carries its bound host explicitly: chat projections do not own host
+ * identity, and resolving against the app's active host would violate the
+ * tab-for-life host binding when another device is selected.
+ */
+export interface EpicCanvasActiveAgentDragData {
+  readonly kind: typeof ACTIVE_AGENT_DND_TYPE;
+  readonly epicId: string;
+  readonly viewTabId: string;
+  readonly agent: {
+    readonly id: string;
+    readonly type: "chat" | "terminal-agent";
+    readonly name: string;
+    readonly hostId: string;
+  };
+}
+
 export type EpicCanvasDragSourceData =
   | EpicCanvasArtifactTabDragData
   | EpicCanvasSidebarNodeDragData
@@ -148,6 +168,7 @@ export type EpicCanvasDragSourceData =
   | EpicCanvasGitDiffTileDragData
   | EpicCanvasWorkspaceFileDragData
   | EpicCanvasChatArtifactDragData
+  | EpicCanvasActiveAgentDragData
   | EpicCanvasLeftPanelRailDragData;
 
 export type LeftPanelRailDropPosition = "before" | "after" | "combine";
@@ -493,6 +514,32 @@ function readChatArtifactSource(
   };
 }
 
+function readActiveAgentSource(
+  value: Record<string, unknown>,
+): EpicCanvasDragSourceData | null {
+  const scope = readCanvasSourceScope(value);
+  if (scope === null || !isRecord(value.agent)) return null;
+  const agent = value.agent;
+  if (
+    !isNonEmptyString(agent.id) ||
+    !isNonEmptyString(agent.name) ||
+    !isNonEmptyString(agent.hostId) ||
+    (agent.type !== "chat" && agent.type !== "terminal-agent")
+  ) {
+    return null;
+  }
+  return {
+    kind: ACTIVE_AGENT_DND_TYPE,
+    ...scope,
+    agent: {
+      id: agent.id,
+      type: agent.type,
+      name: agent.name,
+      hostId: agent.hostId,
+    },
+  };
+}
+
 function readLeftPanelRailItemSource(
   value: Record<string, unknown>,
 ): EpicCanvasDragSourceData | null {
@@ -521,6 +568,7 @@ export function readEpicCanvasDragSourceData(
     return readWorkspaceFileSource(value);
   if (value.kind === CHAT_ARTIFACT_DND_TYPE)
     return readChatArtifactSource(value);
+  if (value.kind === ACTIVE_AGENT_DND_TYPE) return readActiveAgentSource(value);
   if (value.kind === LEFT_PANEL_RAIL_ITEM_DND_TYPE)
     return readLeftPanelRailItemSource(value);
   return null;

--- a/clients/gui-app/src/components/epic-canvas/dnd/dnd.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/dnd.ts
@@ -290,6 +290,16 @@ export function getSidebarNodeDragId(nodeId: string): string {
   return `sidebar-node:${nodeId}`;
 }
 
+/**
+ * Active-agent rows are a second rendering of nodes already registered by the
+ * sidebar. Key them by occurrence rather than node id so dnd-kit's registry
+ * never collides with the sidebar row (or another open tile showing the same
+ * active-agent list).
+ */
+export function getActiveAgentDragId(occurrenceKey: string): string {
+  return `active-agent:${occurrenceKey}`;
+}
+
 export function getTerminalTileDragId(sessionId: string): string {
   return `terminal-tile:${sessionId}`;
 }

--- a/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-commits.ts
+++ b/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-commits.ts
@@ -11,6 +11,7 @@
  */
 import { v4 as uuidv4 } from "uuid";
 import {
+  ACTIVE_AGENT_DND_TYPE,
   ARTIFACT_TAB_DND_TYPE,
   CHAT_ARTIFACT_DND_TYPE,
   GIT_DIFF_TILE_DND_TYPE,
@@ -99,21 +100,23 @@ export function canDropOnHeaderStrip(
       | typeof TERMINAL_TILE_DND_TYPE
       | typeof GIT_DIFF_TILE_DND_TYPE
       | typeof WORKSPACE_FILE_DND_TYPE
-      | typeof CHAT_ARTIFACT_DND_TYPE;
+      | typeof CHAT_ARTIFACT_DND_TYPE
+      | typeof ACTIVE_AGENT_DND_TYPE;
   }
 > {
-  // Every openable canvas source can tear off into a new header tab. A
-  // chat-artifact belongs here alongside sidebar nodes / workspace files:
-  // collision already offers it the header slot (via EPIC_CANVAS_DND_SOURCE_TYPES
-  // -> CANVAS_TARGET_KINDS), so omitting it here would leave the header strip a
-  // silent dead zone (preview + commit both gate on this predicate).
+  // Every openable canvas source can tear off into a new header tab. The
+  // self-describing chat-artifact and active-agent sources belong here beside
+  // sidebar nodes / workspace files: collision already offers them the header
+  // slot (via EPIC_CANVAS_DND_SOURCE_TYPES -> CANVAS_TARGET_KINDS), so omitting
+  // either would leave the header strip a silent dead zone.
   return (
     source?.kind === ARTIFACT_TAB_DND_TYPE ||
     source?.kind === SIDEBAR_NODE_DND_TYPE ||
     source?.kind === TERMINAL_TILE_DND_TYPE ||
     source?.kind === GIT_DIFF_TILE_DND_TYPE ||
     source?.kind === WORKSPACE_FILE_DND_TYPE ||
-    source?.kind === CHAT_ARTIFACT_DND_TYPE
+    source?.kind === CHAT_ARTIFACT_DND_TYPE ||
+    source?.kind === ACTIVE_AGENT_DND_TYPE
   );
 }
 
@@ -151,6 +154,11 @@ export function sourceToTileRef(
     // artifact identity only, so two drags of the same card never reuse an
     // instanceId and collide in `tilesByInstanceId`.
     return makeOpenableNodeRef({ ...source.artifact, instanceId: uuidv4() });
+  }
+  if (source.kind === ACTIVE_AGENT_DND_TYPE) {
+    // The payload preserves the agent's bound host; never substitute the app's
+    // currently selected host for a chat or terminal-agent tile.
+    return makeOpenableNodeRef({ ...source.agent, instanceId: uuidv4() });
   }
   return null;
 }

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile-lower-surfaces.tsx
@@ -43,6 +43,7 @@ type ComposerSlotBottomSpacing = "normal" | "none";
 
 export interface ChatLowerInteractionSurfacesProps {
   readonly epicId: string;
+  readonly viewTabId: string;
   readonly chatId: string;
   readonly runtime: ChatLowerRuntimeState;
   readonly access: ChatLowerAccessState;
@@ -327,6 +328,7 @@ export function ChatLowerInteractionSurfaces(
       <ChatLowerDock
         snapshotLoaded={props.runtime.snapshotLoaded}
         epicId={props.epicId}
+        viewTabId={props.viewTabId}
         selfAgent={stopControls.self}
         activeAgents={activeAgents}
         todo={props.todo}

--- a/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/chat-tile.tsx
@@ -704,6 +704,7 @@ function ChatTileSessionView(props: ChatTileSessionViewProps) {
             <SurfaceActivityProvider active={view.surfaceFocused}>
               <ChatLowerInteractionSurfaces
                 epicId={view.currentEpicId}
+                viewTabId={view.viewTabId}
                 chatId={view.node.id}
                 runtime={view.lower.runtime}
                 access={view.lower.access}

--- a/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/tui-agent-tile.tsx
@@ -879,6 +879,7 @@ function TerminalAgentPreLaunchToolbar(
         />
         <TerminalAgentHeaderControls
           epicId={props.epicId}
+          viewTabId={props.viewTabId}
           tuiAgentId={props.agent.id}
         />
       </div>
@@ -1009,6 +1010,7 @@ function TerminalAgentTileShell(props: {
  */
 function TerminalAgentHeaderControls(props: {
   readonly epicId: string;
+  readonly viewTabId: string;
   readonly tuiAgentId: string;
 }) {
   const controls = useAgentStopControls({
@@ -1044,6 +1046,7 @@ function TerminalAgentHeaderControls(props: {
         <PopoverContent align="end" className="w-[min(90vw,22rem)] p-0">
           <AgentStopList
             epicId={props.epicId}
+            viewTabId={props.viewTabId}
             self={self}
             descendants={controls.descendants}
             surface="tui-popover"


### PR DESCRIPTION
## Summary

- make every row in the active-agents composer panel click-to-open, including the current agent
- reuse the sidebar-node drag payload so running agents can be dropped into panes, splits, empty canvases, and header tabs
- keep stop controls outside the drag surface and use occurrence-scoped drag IDs to avoid collisions with sidebar copies

## Related issue

No linked issue.

## Validation

- [x] Focused active-agent panel tests pass (5/5)
- [x] Affected Nx build, compile, lint, and format checks pass via pre-commit
- [x] PR-range pre-commit hooks pass on current `origin/main`
- [x] Tests added for click-to-open and drag payload registration
- [x] Commit is signed off per the DCO