### PR TITLE
feat(worktrees): add durable deletion notifications

### DIFF
--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel-phase-activation.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel-phase-activation.test.tsx
@@ -134,6 +134,7 @@ vi.mock("@/hooks/epic/use-epic-activity-status", () => ({
 // epics-list-panel suite does.
 vi.mock("@/hooks/epic/use-epic-sweep-worktree-candidates-query", () => ({
   useEpicSweepWorktreeCandidates: () => ({
+    hostId: "host-test",
     rows: [],
     isPending: false,
     isError: false,

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -212,6 +212,7 @@ vi.mock("@/hooks/epic/use-task-delete-worktree-candidates-query", () => ({
 
 vi.mock("@/hooks/epic/use-epic-sweep-worktree-candidates-query", () => ({
   useEpicSweepWorktreeCandidates: () => ({
+    hostId: "host-test",
     rows: [],
     isPending: false,
     isError: false,

--- a/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
+++ b/clients/gui-app/src/components/epics/sweep-worktrees-dialog.tsx
@@ -84,7 +84,8 @@ const NOTE_COPY: Record<NonNullable<EpicSweepWorktreeRow["note"]>, string> = {
  */
 export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
   const { epicIds, taskTitle, onOpenChange } = props;
-  const { rows, isPending, isError } = useEpicSweepWorktreeCandidates(epicIds);
+  const { hostId, rows, isPending, isError } =
+    useEpicSweepWorktreeCandidates(epicIds);
   const taskCount = epicIds?.length ?? 0;
   const sweepMutation = useEpicSweepWorktrees();
   // Explicit user toggles, cleared whenever the dialog retargets so a
@@ -107,7 +108,7 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
   // per surface (History row and task-status strip each render their own), so
   // a component-local `isPending` would miss a run started from the other one
   // and happily re-stream the same paths.
-  const sweepingPaths = useSweepingWorktreePaths();
+  const sweepingPaths = useSweepingWorktreePaths(hostId);
   const isRowSweeping = (row: EpicSweepWorktreeRow): boolean =>
     sweepingPaths.has(row.entry.worktreePath);
   const isRowChecked = (row: EpicSweepWorktreeRow): boolean => {
@@ -120,12 +121,13 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
   const isSweeping = sweepMutation.isPending;
 
   const handleConfirm = () => {
-    if (checkedRows.length === 0) return;
+    if (hostId === null || checkedRows.length === 0) return;
     // Background model, matching Settings worktree deletion: confirm hands
     // the streamed run off and closes immediately. The mutation acknowledges
     // the kickoff and reports the outcome via toasts; re-opening while the
     // run is live keeps Sweep disabled so the same paths can't double-stream.
     sweepMutation.mutate({
+      hostId,
       worktrees: checkedRows.map((row) => ({
         worktreePath: row.entry.worktreePath,
         branch: row.entry.branch,
@@ -198,7 +200,7 @@ export function SweepWorktreesDialog(props: SweepWorktreesDialogProps) {
             variant="destructive"
             size="sm"
             className="w-full sm:w-auto"
-            disabled={isSweeping || checkedRows.length === 0}
+            disabled={hostId === null || isSweeping || checkedRows.length === 0}
             onClick={handleConfirm}
             data-testid="sweep-worktrees-confirm"
           >

--- a/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.host-switch.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.host-switch.test.tsx
@@ -1,0 +1,567 @@
+/**
+ * Origin-host activation for native `hostSurface` notifications.
+ *
+ * Mounts the bridge over the REAL host machinery - `HostDirectoryService`,
+ * `HostRuntime`, `HostClient`, and the real `useNotificationActivation` - so
+ * the switch actually travels the production seam (directory selection ->
+ * runtime listener -> `hostClient.bind`) instead of a stubbed "switch host"
+ * function that could not fail the way the real one can. Only the router,
+ * the acknowledgment write, and the toast surface are spied, because those
+ * are the observable effects whose ORDER relative to the bind is the point.
+ */
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { useEffect, useState, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HostRuntime } from "@traycer-clients/shared/host-client/host-runtime";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { DefaultRequestContextProvider } from "@traycer-clients/shared/auth/request-context-provider";
+import { createAuthenticatedUserFixture } from "@traycer-clients/shared/test-fixtures/authenticated-user";
+import type { LocalHostSnapshot } from "@traycer-clients/shared/platform/runner-host";
+import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
+import type { NotificationPayload } from "@/lib/notifications/payload";
+
+const navigateSpy = vi.hoisted(() => vi.fn());
+const markAsRead = vi.hoisted(() => vi.fn<(feedId: string) => void>());
+const toastSpy = vi.hoisted(() => ({
+  success: vi.fn<(message: string) => void>(),
+  error: vi.fn(),
+}));
+const bindingRef = vi.hoisted<{
+  current: {
+    readonly hostClient: HostClient<HostRpcRegistry>;
+    readonly directory: HostDirectoryService;
+  } | null;
+}>(() => ({ current: null }));
+
+vi.mock("@tanstack/react-router", async (importActual) => {
+  const actual = await importActual<typeof import("@tanstack/react-router")>();
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+vi.mock("sonner", () => ({ toast: toastSpy }));
+
+vi.mock("@/lib/host-error-toast", () => ({ toastFromHostError: vi.fn() }));
+
+vi.mock("@/lib/host", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/host")>();
+  return {
+    ...actual,
+    useHostBinding: () => bindingRef.current,
+    useHostDirectory: () => bindingRef.current?.directory ?? null,
+  };
+});
+
+vi.mock("@/stores/notifications/merged-notifications", async (importActual) => {
+  const actual =
+    await importActual<
+      typeof import("@/stores/notifications/merged-notifications")
+    >();
+  return {
+    ...actual,
+    useMergedNotificationsActions: () => ({
+      markAsRead,
+      markAllAsRead: vi.fn(),
+      resolve: vi.fn(),
+      loadMoreHost: vi.fn(),
+      canLoadMoreHost: false,
+      isLoadingMoreHost: false,
+      hasHostLoadError: false,
+      loadMoreAttention: vi.fn(),
+      canLoadMoreAttention: false,
+      isLoadingMoreAttention: false,
+      hasAttentionLoadError: false,
+      loadMoreUnreadRecent: vi.fn(),
+      canLoadMoreUnreadRecent: false,
+      isLoadingMoreUnreadRecent: false,
+      hasUnreadRecentLoadError: false,
+    }),
+  };
+});
+
+import { NotificationFocusBridge } from "@/components/layout/bridges/notification-focus-bridge";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import { HostDirectoryService } from "@/lib/host/host-directory-service";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { hostRpcSchedulingPolicy } from "@/lib/host-rpc-policy/host-method-policy-table";
+import { buildNotificationActivationEnvelope } from "@/lib/notifications/notification-activation-envelope";
+import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
+import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
+import { useTabsStore } from "@/stores/tabs/store";
+
+const LOCAL_SNAPSHOT: LocalHostSnapshot = {
+  hostId: "this-mac",
+  websocketUrl: "ws://127.0.0.1:4917/rpc",
+  version: "1.2.3",
+  pid: 4242,
+  systemHostName: "this-mac",
+  displayName: "This Mac",
+};
+
+const ORIGIN_HOST: HostDirectoryEntry = {
+  hostId: "build-box",
+  label: "Build Box",
+  kind: "remote",
+  websocketUrl: "wss://build-box.traycer.invalid/rpc",
+  version: "1.2.3",
+  status: "available",
+};
+
+const WORKTREE_SETTINGS_ROUTE: NotificationPayload = {
+  kind: "hostSurface",
+  surface: "worktreeSettings",
+  focus: undefined,
+};
+
+/** Every shape of "the origin exists in the envelope but cannot be dialed".
+ * All three must reach the SAME safe fallback, because binding any of them
+ * would swap the app onto a host it cannot talk to. */
+const UNREACHABLE_ORIGIN_CASES: ReadonlyArray<{
+  readonly label: string;
+  readonly remoteHosts: readonly HostDirectoryEntry[];
+}> = [
+  { label: "absent from the directory", remoteHosts: [] },
+  {
+    label: "marked unavailable",
+    remoteHosts: [{ ...ORIGIN_HOST, status: "unavailable" }],
+  },
+  {
+    label: "missing a websocket url",
+    remoteHosts: [{ ...ORIGIN_HOST, websocketUrl: null }],
+  },
+];
+
+/** Every observable effect of an activation, in the order it happened, each
+ * stamped with the app-wide host that was active AT THAT MOMENT - the whole
+ * point of switch-then-route is that the stamps read `build-box`. */
+const order: string[] = [];
+
+function activeHostId(): string | null {
+  return bindingRef.current?.hostClient.getActiveHostId() ?? null;
+}
+
+interface Mounted {
+  readonly directory: HostDirectoryService;
+  readonly client: HostClient<HostRpcRegistry>;
+  /** Transient activations - the only selection call the bridge is allowed to
+   * make, and the only route to a `hostClient.bind`, so `0` means "never
+   * bound". */
+  readonly transientSelectCalls: () => number;
+  /** Durable "the user chose this host" writes. Must stay `0` forever: a
+   * notification click is not a picker gesture. */
+  readonly durableSelectCalls: () => number;
+  readonly bindCount: () => number;
+  readonly bump: () => void;
+  /** Replaces the directory's remote hosts and reconciles, standing in for a
+   * host leaving the directory between refreshes. */
+  readonly refreshRemoteHosts: (
+    hosts: readonly HostDirectoryEntry[],
+  ) => Promise<void>;
+}
+
+async function mountBridge(options: {
+  readonly remoteHosts: readonly HostDirectoryEntry[];
+  readonly signedIn: boolean;
+}): Promise<Mounted> {
+  const runnerHost = new MockRunnerHost({
+    signInUrl: "https://auth.traycer.invalid/sign-in",
+    authnBaseUrl: "http://localhost:5005",
+    localHost: LOCAL_SNAPSHOT,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+  let remoteHosts = options.remoteHosts;
+  const directory = new HostDirectoryService({
+    runnerHost,
+    remoteFetcher: () => Promise.resolve(remoteHosts),
+  });
+  await directory.start();
+
+  const provider = new DefaultRequestContextProvider({ origin: "renderer" });
+  if (options.signedIn) {
+    provider.setSignedIn({
+      user: createAuthenticatedUserFixture(undefined),
+      bearerToken: "test-bearer",
+      operationId: undefined,
+      externalAbortSignal: undefined,
+    });
+  }
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  let requestSeq = 0;
+  const runtime = new HostRuntime<HostRpcRegistry>({
+    runnerHost,
+    registry: hostRpcRegistry,
+    messenger: new MockHostMessenger<HostRpcRegistry>({
+      registry: hostRpcRegistry,
+      requestId: () => `host-switch-${++requestSeq}`,
+      handlers: {},
+    }),
+    requestContextProvider: provider,
+    directory,
+    invalidator: createHostQueryInvalidator(queryClient),
+    schedulingPolicy: hostRpcSchedulingPolicy,
+    authorityRegistry: null,
+    requestCoordinator: null,
+  });
+  runtime.start();
+
+  let binds = 0;
+  runtime.hostClient.onChange((change) => {
+    if (change.previousHostId !== change.currentHostId) binds += 1;
+  });
+  bindingRef.current = {
+    hostClient: runtime.hostClient,
+    directory,
+  };
+
+  const bumpHolder: { current: (() => void) | null } = { current: null };
+  function Harness(): ReactNode {
+    const [tick, setTick] = useState(0);
+    useEffect(() => {
+      bumpHolder.current = () => {
+        setTick((value) => value + 1);
+      };
+      return () => {
+        bumpHolder.current = null;
+      };
+    }, []);
+    return (
+      <QueryClientProvider client={queryClient}>
+        <span data-testid="tick">{tick}</span>
+        <NotificationFocusBridge />
+      </QueryClientProvider>
+    );
+  }
+  render(<Harness />);
+  const durableSelectSpy = vi.spyOn(directory, "selectById");
+  const transientSelectSpy = vi.spyOn(directory, "selectTransientById");
+
+  return {
+    directory,
+    client: runtime.hostClient,
+    transientSelectCalls: () => transientSelectSpy.mock.calls.length,
+    durableSelectCalls: () => durableSelectSpy.mock.calls.length,
+    bindCount: () => binds,
+    bump: () => {
+      const bump = bumpHolder.current;
+      if (bump === null) throw new Error("bump not ready");
+      act(() => {
+        bump();
+      });
+    },
+    refreshRemoteHosts: async (hosts) => {
+      remoteHosts = hosts;
+      await act(async () => {
+        await directory.refresh();
+      });
+    },
+  };
+}
+
+function clickNative(route: NotificationPayload, feedSourceId: string): void {
+  act(() => {
+    useNotificationEventsStore.getState().recordClick(
+      buildNotificationActivationEnvelope({
+        route,
+        feed: { source: "host", id: feedSourceId },
+        originHostId: ORIGIN_HOST.hostId,
+      }),
+    );
+  });
+}
+
+describe("NotificationFocusBridge origin-host activation", () => {
+  beforeEach(() => {
+    order.length = 0;
+    navigateSpy.mockReset();
+    navigateSpy.mockImplementation(() => {
+      order.push(`route@${activeHostId()}`);
+    });
+    markAsRead.mockReset();
+    markAsRead.mockImplementation((feedId) => {
+      order.push(`ack:${feedId}@${activeHostId()}`);
+    });
+    toastSpy.success.mockReset();
+    toastSpy.success.mockImplementation((message) => {
+      order.push(`feedback:${message}@${activeHostId()}`);
+    });
+    useNotificationEventsStore.getState().clear();
+    useNotificationsPopoverStore.getState().setOpen(false);
+    useTabsStore.getState().closeSystemTab("settings");
+    useEpicCanvasStore.setState({
+      tabsById: {},
+      openTabOrder: [],
+      activeTabId: null,
+      mostRecentTabIdByEpicId: {},
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    bindingRef.current = null;
+    useNotificationEventsStore.getState().clear();
+    useNotificationsPopoverStore.getState().setOpen(false);
+    vi.restoreAllMocks();
+  });
+
+  it("binds the reachable origin once, then routes and acknowledges against it", async () => {
+    const mounted = await mountBridge({
+      remoteHosts: [ORIGIN_HOST],
+      signedIn: true,
+    });
+    expect(mounted.client.getActiveHostId()).toBe(LOCAL_SNAPSHOT.hostId);
+    const bindsBefore = mounted.bindCount();
+
+    clickNative(WORKTREE_SETTINGS_ROUTE, "n-worktree");
+
+    // Feedback, then navigation, then acknowledgment - each already on the
+    // origin host. A route stamped `this-mac` would mean the app navigated
+    // before the bind; an ack stamped `this-mac` would mark the row read on
+    // the wrong feed.
+    expect(order).toEqual([
+      "feedback:Switched to Build Box@build-box",
+      "route@build-box",
+      "ack:host:n-worktree@build-box",
+    ]);
+    expect(mounted.client.getActiveHostId()).toBe(ORIGIN_HOST.hostId);
+    expect(mounted.directory.getSelected()?.hostId).toBe(ORIGIN_HOST.hostId);
+    expect(mounted.bindCount() - bindsBefore).toBe(1);
+    // Transient, not durable: the click moved the app, it did not answer
+    // "which host do you work on".
+    expect(mounted.transientSelectCalls()).toBe(1);
+    expect(mounted.durableSelectCalls()).toBe(0);
+    // Switch-then-route is a successful activation, not a fallback.
+    expect(useNotificationsPopoverStore.getState().open).toBe(false);
+  });
+
+  it("attributes the switch to the notification source, not a picker gesture", async () => {
+    const track = vi.spyOn(Analytics.getInstance(), "track");
+    await mountBridge({ remoteHosts: [ORIGIN_HOST], signedIn: true });
+
+    clickNative(WORKTREE_SETTINGS_ROUTE, "n-analytics");
+
+    expect(
+      track.mock.calls.filter(
+        (call) => call[0] === AnalyticsEvent.HostSelected,
+      ),
+    ).toEqual([
+      [
+        AnalyticsEvent.HostSelected,
+        { source: "notification", host_kind: "remote" },
+      ],
+    ]);
+  });
+
+  it("hands back to the default host when the activated origin later disappears", async () => {
+    const mounted = await mountBridge({
+      remoteHosts: [ORIGIN_HOST],
+      signedIn: true,
+    });
+
+    clickNative(WORKTREE_SETTINGS_ROUTE, "n-vanishing");
+    expect(mounted.client.getActiveHostId()).toBe(ORIGIN_HOST.hostId);
+
+    // The origin drops out of the directory the way any host does - a refresh
+    // that no longer lists it.
+    await mounted.refreshRemoteHosts([]);
+
+    // Recovery, not a dead end: because the activation never wrote durable
+    // explicit-selection intent, normal default-host promotion still applies
+    // and the app lands back on the local host. A `selectById` here would
+    // have pinned the session to a host that no longer exists, leaving
+    // `getSelected()` null with no way back except the picker.
+    expect(mounted.client.getActiveHostId()).toBe(LOCAL_SNAPSHOT.hostId);
+    expect(mounted.directory.getSelected()?.hostId).toBe(LOCAL_SNAPSHOT.hostId);
+  });
+
+  it("does not announce or record a switch when the app is already on the origin", async () => {
+    const mounted = await mountBridge({
+      remoteHosts: [ORIGIN_HOST],
+      signedIn: true,
+    });
+    // The app moved to the origin before the click arrived - by an earlier
+    // activation, or the picker. Nothing is left to switch.
+    //
+    // `switchToOriginHost` re-reads this live from the client rather than
+    // trusting the rendered host id, so it also holds in the narrower case
+    // this test cannot stage from public APIs: a bind that lands between the
+    // bridge's render and its effect. (The rendered value is derived FROM the
+    // client through `useSyncExternalStore`, so it can only ever lag it -
+    // never lead - which is why the live read is the safe side to trust.)
+    mounted.directory.selectTransientById(ORIGIN_HOST.hostId, "notification");
+    const bindsBefore = mounted.bindCount();
+    const transientBefore = mounted.transientSelectCalls();
+    order.length = 0;
+
+    clickNative(WORKTREE_SETTINGS_ROUTE, "n-already-there");
+
+    // Routed and acknowledged, but with no second bind and no "Switched to"
+    // toast for a switch that never happened.
+    expect(order).toEqual([
+      "route@build-box",
+      "ack:host:n-already-there@build-box",
+    ]);
+    expect(mounted.bindCount() - bindsBefore).toBe(0);
+    expect(mounted.transientSelectCalls() - transientBefore).toBe(0);
+  });
+
+  it("does not repeat the switch, route, or acknowledgment on a replayed event", async () => {
+    const mounted = await mountBridge({
+      remoteHosts: [ORIGIN_HOST],
+      signedIn: true,
+    });
+    const bindsBefore = mounted.bindCount();
+
+    clickNative(WORKTREE_SETTINGS_ROUTE, "n-replay");
+    // The click stays resident in the store; only the processed-event guard
+    // stops these rerenders from dispatching it again (and re-binding).
+    mounted.bump();
+    mounted.bump();
+    mounted.bump();
+
+    expect(order).toHaveLength(3);
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(markAsRead).toHaveBeenCalledTimes(1);
+    expect(toastSpy.success).toHaveBeenCalledTimes(1);
+    expect(mounted.bindCount() - bindsBefore).toBe(1);
+  });
+
+  it("routes a same-host host-surface activation directly, with no switch feedback", async () => {
+    const mounted = await mountBridge({
+      remoteHosts: [ORIGIN_HOST],
+      signedIn: true,
+    });
+    const bindsBefore = mounted.bindCount();
+
+    act(() => {
+      useNotificationEventsStore.getState().recordClick(
+        buildNotificationActivationEnvelope({
+          route: WORKTREE_SETTINGS_ROUTE,
+          feed: { source: "host", id: "n-local" },
+          originHostId: LOCAL_SNAPSHOT.hostId,
+        }),
+      );
+    });
+
+    expect(order).toEqual(["route@this-mac", "ack:host:n-local@this-mac"]);
+    expect(mounted.transientSelectCalls()).toBe(0);
+    expect(mounted.bindCount() - bindsBefore).toBe(0);
+    expect(useNotificationsPopoverStore.getState().open).toBe(false);
+  });
+
+  it.each(UNREACHABLE_ORIGIN_CASES)(
+    "never binds an origin $label and opens the origin-unavailable center",
+    async ({ remoteHosts }) => {
+      const mounted = await mountBridge({ remoteHosts, signedIn: true });
+      const bindsBefore = mounted.bindCount();
+
+      clickNative(WORKTREE_SETTINGS_ROUTE, "n-offline");
+
+      const popover = useNotificationsPopoverStore.getState();
+      expect(popover.open).toBe(true);
+      expect(popover.originUnavailable).toBe(true);
+      expect(order).toEqual([]);
+      expect(mounted.transientSelectCalls()).toBe(0);
+      expect(mounted.bindCount() - bindsBefore).toBe(0);
+      expect(mounted.client.getActiveHostId()).toBe(LOCAL_SNAPSHOT.hostId);
+    },
+  );
+
+  it("names the unreachable origin in the center when the directory knows it", async () => {
+    await mountBridge({
+      remoteHosts: [{ ...ORIGIN_HOST, status: "unavailable" }],
+      signedIn: true,
+    });
+
+    clickNative(WORKTREE_SETTINGS_ROUTE, "n-offline-label");
+
+    expect(
+      useNotificationsPopoverStore.getState().originUnavailableHostLabel,
+    ).toBe("Build Box");
+  });
+
+  it("does not bind or retry when the client has no authenticated identity", async () => {
+    const mounted = await mountBridge({
+      remoteHosts: [ORIGIN_HOST],
+      signedIn: false,
+    });
+    const bindsBefore = mounted.bindCount();
+
+    clickNative(WORKTREE_SETTINGS_ROUTE, "n-signed-out");
+    // Rerenders are the loop a retry would ride in on: nothing re-attempts
+    // the bind, and app-wide auth handling keeps ownership of the recovery.
+    mounted.bump();
+    mounted.bump();
+
+    expect(useNotificationsPopoverStore.getState().originUnavailable).toBe(
+      true,
+    );
+    expect(order).toEqual([]);
+    expect(mounted.transientSelectCalls()).toBe(0);
+    expect(mounted.bindCount() - bindsBefore).toBe(0);
+    expect(mounted.client.getActiveHostId()).toBe(LOCAL_SNAPSHOT.hostId);
+  });
+
+  it("leaves an open terminal tab bound to the host it was created on", async () => {
+    const canvas = useEpicCanvasStore.getState();
+    const tabId = canvas.openEpicTab("epic-terminal", "Terminal epic");
+    canvas.openTileInTab(tabId, {
+      id: "terminal-1",
+      instanceId: "terminal-instance-1",
+      type: "terminal",
+      name: "Terminal",
+      titleSource: "manual",
+      hostId: LOCAL_SNAPSHOT.hostId,
+      cwd: "/repo",
+    });
+    const mounted = await mountBridge({
+      remoteHosts: [ORIGIN_HOST],
+      signedIn: true,
+    });
+
+    clickNative(WORKTREE_SETTINGS_ROUTE, "n-tabs");
+
+    // Only the app-wide scope moves. A PTY cannot migrate, so the tile keeps
+    // its lifetime `hostId` even though the active host is now the origin.
+    expect(mounted.client.getActiveHostId()).toBe(ORIGIN_HOST.hostId);
+    const tile =
+      useEpicCanvasStore.getState().canvasByTabId[tabId]?.tilesByInstanceId[
+        "terminal-instance-1"
+      ];
+    expect(tile?.type).toBe("terminal");
+    expect(tile?.type === "terminal" ? tile.hostId : null).toBe(
+      LOCAL_SNAPSHOT.hostId,
+    );
+  });
+
+  it("leaves epic activation on a different host unchanged - no switch", async () => {
+    const mounted = await mountBridge({
+      remoteHosts: [ORIGIN_HOST],
+      signedIn: true,
+    });
+    const bindsBefore = mounted.bindCount();
+
+    clickNative({ kind: "epic", epicId: "epic-1" }, "n-epic");
+
+    const popover = useNotificationsPopoverStore.getState();
+    expect(popover.open).toBe(true);
+    expect(popover.originUnavailable).toBe(true);
+    expect(popover.originUnavailableHostLabel).toBe("Build Box");
+    expect(order).toEqual([]);
+    expect(mounted.transientSelectCalls()).toBe(0);
+    expect(mounted.bindCount() - bindsBefore).toBe(0);
+    expect(mounted.client.getActiveHostId()).toBe(LOCAL_SNAPSHOT.hostId);
+  });
+});

--- a/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.host-switch.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.host-switch.test.tsx
@@ -89,6 +89,11 @@ import { HostDirectoryService } from "@/lib/host/host-directory-service";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
 import { hostRpcSchedulingPolicy } from "@/lib/host-rpc-policy/host-method-policy-table";
 import { buildNotificationActivationEnvelope } from "@/lib/notifications/notification-activation-envelope";
+import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
+import {
+  __resetTabSyncCoordinatorForTesting,
+  installTabSyncCoordinator,
+} from "@/lib/tab-sync/tab-sync-coordinator";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
 import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
@@ -283,7 +288,15 @@ function clickNative(route: NotificationPayload, feedSourceId: string): void {
 }
 
 describe("NotificationFocusBridge origin-host activation", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // `hostSurface` routing activates a Settings tab through the shared tab
+    // navigation controller. The app installs this above the bridge; make the
+    // suite self-contained instead of relying on test-file execution order.
+    __resetTabNavigationControllerForTesting();
+    __resetTabSyncCoordinatorForTesting();
+    installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+    await Promise.resolve();
+    await Promise.resolve();
     order.length = 0;
     navigateSpy.mockReset();
     navigateSpy.mockImplementation(() => {

--- a/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.origin-ack.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.origin-ack.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * The acknowledgment half of origin-host activation, proven on the wire.
+ *
+ * The sibling `host-switch` suite stubs `useMergedNotificationsActions` to get
+ * a deterministic ordering trace, which means it can only show that SOMETHING
+ * acknowledged after the bind. This file runs the REAL merged-notifications
+ * action, the real `useHostMutation`, and the real `HostClient`, then reads
+ * `MockHostMessenger.calls` - so "acknowledged against the origin feed" is
+ * asserted from the request that actually left the client, including which
+ * host endpoint it was addressed to.
+ *
+ * It also pins the settled post-bind failure policy: once the bind lands,
+ * a host that then refuses the request is app-wide host/auth territory. This
+ * feature does not retry it and does not roll the app back out from under the
+ * user's navigation.
+ */
+import "../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HostRuntime } from "@traycer-clients/shared/host-client/host-runtime";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import { DefaultRequestContextProvider } from "@traycer-clients/shared/auth/request-context-provider";
+import { createAuthenticatedUserFixture } from "@traycer-clients/shared/test-fixtures/authenticated-user";
+import type { LocalHostSnapshot } from "@traycer-clients/shared/platform/runner-host";
+import { hostRpcRegistry, type HostRpcRegistry } from "@traycer/protocol/host";
+import type { NotificationPayload } from "@/lib/notifications/payload";
+
+const navigateSpy = vi.hoisted(() => vi.fn());
+const toastSpy = vi.hoisted(() => ({
+  success: vi.fn<(message: string) => void>(),
+  error: vi.fn(),
+}));
+const toastFromHostError = vi.hoisted(() => vi.fn());
+const bindingRef = vi.hoisted<{
+  current: {
+    readonly hostClient: HostClient<HostRpcRegistry>;
+    readonly directory: HostDirectoryService;
+  } | null;
+}>(() => ({ current: null }));
+
+vi.mock("@tanstack/react-router", async (importActual) => {
+  const actual = await importActual<typeof import("@tanstack/react-router")>();
+  return { ...actual, useNavigate: () => navigateSpy };
+});
+
+vi.mock("sonner", () => ({ toast: toastSpy }));
+
+vi.mock("@/lib/host-error-toast", () => ({ toastFromHostError }));
+
+vi.mock("@/lib/host", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/host")>();
+  return {
+    ...actual,
+    useHostBinding: () => bindingRef.current,
+    useHostDirectory: () => bindingRef.current?.directory ?? null,
+  };
+});
+
+import { NotificationFocusBridge } from "@/components/layout/bridges/notification-focus-bridge";
+import { HostDirectoryService } from "@/lib/host/host-directory-service";
+import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
+import { hostRpcSchedulingPolicy } from "@/lib/host-rpc-policy/host-method-policy-table";
+import { buildNotificationActivationEnvelope } from "@/lib/notifications/notification-activation-envelope";
+import { __resetHostNotificationsStoreForTests } from "@/stores/notifications/host-notifications-store";
+import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
+import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
+import { useTabsStore } from "@/stores/tabs/store";
+
+const LOCAL_SNAPSHOT: LocalHostSnapshot = {
+  hostId: "this-mac",
+  websocketUrl: "ws://127.0.0.1:4917/rpc",
+  version: "1.2.3",
+  pid: 4242,
+  systemHostName: "this-mac",
+  displayName: "This Mac",
+};
+
+const ORIGIN_HOST: HostDirectoryEntry = {
+  hostId: "build-box",
+  label: "Build Box",
+  kind: "remote",
+  websocketUrl: "wss://build-box.traycer.invalid/rpc",
+  version: "1.2.3",
+  status: "available",
+};
+
+const WORKTREE_SETTINGS_ROUTE: NotificationPayload = {
+  kind: "hostSurface",
+  surface: "worktreeSettings",
+  focus: undefined,
+};
+
+interface Mounted {
+  readonly directory: HostDirectoryService;
+  readonly client: HostClient<HostRpcRegistry>;
+  readonly markReadCalls: () => ReadonlyArray<{
+    readonly params: unknown;
+    readonly hostId: string;
+  }>;
+  readonly bindCount: () => number;
+  readonly transientSelectCalls: () => number;
+}
+
+/** `markRead` either answers or refuses - the two sides of the post-bind
+ * policy this file exists to pin down. */
+async function mountBridge(
+  markReadOutcome: "ok" | "refused",
+): Promise<Mounted> {
+  const runnerHost = new MockRunnerHost({
+    signInUrl: "https://auth.traycer.invalid/sign-in",
+    authnBaseUrl: "http://localhost:5005",
+    localHost: LOCAL_SNAPSHOT,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+  const directory = new HostDirectoryService({
+    runnerHost,
+    remoteFetcher: () => Promise.resolve([ORIGIN_HOST]),
+  });
+  await directory.start();
+
+  const provider = new DefaultRequestContextProvider({ origin: "renderer" });
+  provider.setSignedIn({
+    user: createAuthenticatedUserFixture(undefined),
+    bearerToken: "test-bearer",
+    operationId: undefined,
+    externalAbortSignal: undefined,
+  });
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  let requestSeq = 0;
+  const messenger = new MockHostMessenger<HostRpcRegistry>({
+    registry: hostRpcRegistry,
+    requestId: () => `origin-ack-${++requestSeq}`,
+    handlers: {
+      "host.notifications.markRead": () => {
+        if (markReadOutcome === "refused") {
+          throw new Error("host refused the acknowledgment");
+        }
+        return {};
+      },
+    },
+  });
+  const runtime = new HostRuntime<HostRpcRegistry>({
+    runnerHost,
+    registry: hostRpcRegistry,
+    messenger,
+    requestContextProvider: provider,
+    directory,
+    invalidator: createHostQueryInvalidator(queryClient),
+    schedulingPolicy: hostRpcSchedulingPolicy,
+    authorityRegistry: null,
+    requestCoordinator: null,
+  });
+  runtime.start();
+
+  let binds = 0;
+  runtime.hostClient.onChange((change) => {
+    if (change.previousHostId !== change.currentHostId) binds += 1;
+  });
+  bindingRef.current = { hostClient: runtime.hostClient, directory };
+
+  function Harness(): ReactNode {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <NotificationFocusBridge />
+      </QueryClientProvider>
+    );
+  }
+  render(<Harness />);
+  const transientSelectSpy = vi.spyOn(directory, "selectTransientById");
+
+  return {
+    directory,
+    client: runtime.hostClient,
+    markReadCalls: () =>
+      messenger.calls
+        .filter((call) => call.method === "host.notifications.markRead")
+        .map((call) => ({
+          params: call.params,
+          hostId: call.authority.endpoint.hostId,
+        })),
+    bindCount: () => binds,
+    transientSelectCalls: () => transientSelectSpy.mock.calls.length,
+  };
+}
+
+function clickCrossHostWorktreeRow(feedSourceId: string): void {
+  act(() => {
+    useNotificationEventsStore.getState().recordClick(
+      buildNotificationActivationEnvelope({
+        route: WORKTREE_SETTINGS_ROUTE,
+        feed: { source: "host", id: feedSourceId },
+        originHostId: ORIGIN_HOST.hostId,
+      }),
+    );
+  });
+}
+
+/** Lets every queued mutation microtask settle, so "did not retry" is a claim
+ * about a drained queue rather than about timing. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("NotificationFocusBridge origin acknowledgment on the wire", () => {
+  beforeEach(() => {
+    navigateSpy.mockReset();
+    toastSpy.success.mockReset();
+    toastFromHostError.mockReset();
+    useNotificationEventsStore.getState().clear();
+    useNotificationsPopoverStore.getState().setOpen(false);
+    useTabsStore.getState().closeSystemTab("settings");
+    __resetHostNotificationsStoreForTests();
+  });
+
+  afterEach(() => {
+    cleanup();
+    bindingRef.current = null;
+    useNotificationEventsStore.getState().clear();
+    useNotificationsPopoverStore.getState().setOpen(false);
+    __resetHostNotificationsStoreForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("sends markRead to the ORIGIN host's endpoint, exactly once", async () => {
+    const mounted = await mountBridge("ok");
+
+    clickCrossHostWorktreeRow("n-ack");
+
+    await waitFor(() => {
+      expect(mounted.markReadCalls()).toHaveLength(1);
+    });
+    // The request left the client addressed to build-box, not to the host the
+    // app was on when the notification was clicked.
+    expect(mounted.markReadCalls()).toEqual([
+      { params: { kind: "ids", ids: ["n-ack"] }, hostId: ORIGIN_HOST.hostId },
+    ]);
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    // Counted from after mount, so this is the switch itself and nothing else.
+    expect(mounted.bindCount()).toBe(1);
+
+    await settle();
+    expect(mounted.markReadCalls()).toHaveLength(1);
+  });
+
+  it("leaves the app switched, un-retried, and un-rolled-back when the origin refuses the acknowledgment", async () => {
+    const mounted = await mountBridge("refused");
+
+    clickCrossHostWorktreeRow("n-refused");
+
+    await waitFor(() => {
+      expect(mounted.markReadCalls()).toHaveLength(1);
+    });
+    await settle();
+
+    // Settled policy: a host that passed the pre-bind reachability gate and
+    // then refuses is owned by app-wide host/auth handling. This feature does
+    // not invent a rollback target, does not re-select, and does not retry -
+    // the user stays on the surface they navigated to.
+    expect(mounted.markReadCalls()).toHaveLength(1);
+    expect(mounted.client.getActiveHostId()).toBe(ORIGIN_HOST.hostId);
+    expect(mounted.directory.getSelected()?.hostId).toBe(ORIGIN_HOST.hostId);
+    expect(mounted.bindCount()).toBe(1);
+    // The one switch, and nothing after it - no compensating re-selection.
+    expect(mounted.transientSelectCalls()).toBe(1);
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    expect(toastSpy.success).toHaveBeenCalledTimes(1);
+    // No retroactive fallback: the center does not open behind the surface
+    // the user is already looking at.
+    expect(useNotificationsPopoverStore.getState().originUnavailable).toBe(
+      false,
+    );
+  });
+});

--- a/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.origin-ack.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/notification-focus-bridge.origin-ack.test.tsx
@@ -66,6 +66,11 @@ import { HostDirectoryService } from "@/lib/host/host-directory-service";
 import { createHostQueryInvalidator } from "@/lib/host/query-invalidator";
 import { hostRpcSchedulingPolicy } from "@/lib/host-rpc-policy/host-method-policy-table";
 import { buildNotificationActivationEnvelope } from "@/lib/notifications/notification-activation-envelope";
+import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
+import {
+  __resetTabSyncCoordinatorForTesting,
+  installTabSyncCoordinator,
+} from "@/lib/tab-sync/tab-sync-coordinator";
 import { __resetHostNotificationsStoreForTests } from "@/stores/notifications/host-notifications-store";
 import { useNotificationEventsStore } from "@/stores/notifications/notification-events-store";
 import { useNotificationsPopoverStore } from "@/stores/notifications/notifications-popover-store";
@@ -218,7 +223,16 @@ async function settle(): Promise<void> {
 }
 
 describe("NotificationFocusBridge origin acknowledgment on the wire", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // `hostSurface` routing activates a Settings tab through the shared tab
+    // navigation controller. The real app installs this coordinator above the
+    // bridge; make that production prerequisite explicit here so this suite
+    // does not accidentally depend on another test having installed it.
+    __resetTabNavigationControllerForTesting();
+    __resetTabSyncCoordinatorForTesting();
+    installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+    await Promise.resolve();
+    await Promise.resolve();
     navigateSpy.mockReset();
     toastSpy.success.mockReset();
     toastFromHostError.mockReset();

--- a/clients/gui-app/src/components/layout/bridges/notification-focus-bridge.tsx
+++ b/clients/gui-app/src/components/layout/bridges/notification-focus-bridge.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef } from "react";
-import { isNotificationPayloadRoutable } from "@/lib/notifications";
+import { toast } from "sonner";
+import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
+import {
+  isNotificationPayloadRoutable,
+  type NotificationPayload,
+} from "@/lib/notifications";
 import {
   feedIdFromEnvelopeFeed,
   parseNotificationActivationPayload,
@@ -7,6 +12,12 @@ import {
 import { useNotificationActivation } from "@/hooks/notifications/use-notification-activation";
 import { useHostDirectoryEntry } from "@/hooks/host/use-host-directory-entry";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
+import {
+  useHostBinding,
+  type HostDirectoryService,
+  type HostRpcRegistry,
+} from "@/lib/host";
+import { dialableHostEndpoint } from "@/lib/host/transport-key";
 import {
   useMergedNotificationRow,
   useMergedNotificationsActions,
@@ -27,7 +38,10 @@ import { activationResultHandler } from "@/lib/notifications/notification-activa
  * route payload (no feed identity), or unknown.
  *
  * - V1 with a non-null `originHostId` that no longer matches the active host:
- *   never route, switch hosts, or acknowledge - open the center once in the
+ *   a `hostSurface` route may switch to a reachable origin first (see
+ *   `switchToOriginHost`) and then route/acknowledge against it; every other
+ *   route kind, and any origin that cannot be switched to, never routes,
+ *   switches, or acknowledges - the center opens once in the
  *   origin-unavailable state instead.
  * - V1 (origin-valid or host-less) or legacy, and the route actually goes
  *   somewhere (`isNotificationPayloadRoutable`): activate directly through
@@ -42,6 +56,12 @@ export function NotificationFocusBridge(): null {
     (state) => state.notificationEvent,
   );
   const activeHostId = useReactiveActiveHostId();
+  const binding = useHostBinding();
+  // Only consulted on the origin-mismatch branch below, but unwrapped here so
+  // the effect depends on the two things it actually uses rather than on the
+  // whole binding.
+  const hostDirectory = binding?.directory ?? null;
+  const hostClient = binding?.hostClient ?? null;
   const { activate } = useNotificationActivation();
   const actions = useMergedNotificationsActions();
 
@@ -105,7 +125,13 @@ export function NotificationFocusBridge(): null {
     }
     if (
       envelope.originHostId !== null &&
-      envelope.originHostId !== activeHostId
+      envelope.originHostId !== activeHostId &&
+      !switchToOriginHost({
+        route: envelope.route,
+        originHostId: envelope.originHostId,
+        directory: hostDirectory,
+        client: hostClient,
+      })
     ) {
       useNotificationsPopoverStore
         .getState()
@@ -133,7 +159,84 @@ export function NotificationFocusBridge(): null {
     candidateRow,
     activate,
     actions,
+    hostDirectory,
+    hostClient,
   ]);
 
   return null;
+}
+
+/**
+ * Reachability-gated switch to the host a native notification came from.
+ *
+ * Returns `true` ONLY when the app-wide active host IS the origin host by the
+ * time it returns, so the caller can treat it as the single gate for "route
+ * and acknowledge against the origin feed". A `false` return has not bound
+ * anything and lands on the existing origin-unavailable center.
+ *
+ * The gates, in order:
+ *
+ * 1. `hostSurface` routes only. Switching hosts is a narrow policy for a
+ *    host-owned surface (Settings ▸ Worktrees today), NOT a global rule for
+ *    every notification: an epic/chat row that names a foreign host keeps its
+ *    released behavior, and existing chat/terminal tabs stay bound to their
+ *    lifetime `hostId` either way - only the app-wide scope moves.
+ * 2. Already on the origin - re-read LIVE from the client. The caller
+ *    compares against a React-rendered host id, which can lag a bind that
+ *    landed in the same tick; without this the bridge would announce a switch
+ *    it never made and emit a selection event for a host it was already on.
+ * 3. An authenticated client. Without a usable credential lease the switch
+ *    would bind a host we cannot talk to; app-wide authentication handling
+ *    owns that recovery, so this declines ONCE (the caller's processed-event
+ *    guard means a declined click is never retried) rather than binding and
+ *    letting an unauthorized RPC fail.
+ * 4. A LIVE, dialable directory entry - re-read here rather than taken from
+ *    the render snapshot, and with no `await` in between, so the entry cannot
+ *    have gone stale by the time we select it.
+ *
+ * Binding goes through the directory rather than `HostClient.bind` directly:
+ * the directory owns selection, and `HostRuntime` turns one `setSelected`
+ * into exactly one synchronous `hostClient.bind(entry)`. Binding the client
+ * behind the directory's back would leave the two disagreeing, and the next
+ * directory reconcile would snap the app back to the old host.
+ *
+ * It uses `selectTransientById`, not `selectById`, because a notification
+ * click is not the user answering "which host do you work on". The durable
+ * explicit-selection intent stays unwritten, so if this origin later leaves
+ * the directory the normal default-host promotion still recovers the app.
+ *
+ * AFTER the bind, this feature is done. `status: "available"` is a claim from
+ * the last published snapshot, not proof the dial or the bearer will be
+ * accepted, so a switched-to host can still fail on the very next request.
+ * That is deliberately owned by existing app-wide host/auth handling: the
+ * selection stays put, the user stays on the surface they navigated to, and
+ * the click neither retries nor rolls the app back out from under them.
+ */
+function switchToOriginHost(input: {
+  readonly route: NotificationPayload;
+  readonly originHostId: string;
+  readonly directory: HostDirectoryService | null;
+  readonly client: HostClient<HostRpcRegistry> | null;
+}): boolean {
+  if (input.route.kind !== "hostSurface") return false;
+  const { directory, client } = input;
+  if (directory === null || client === null) return false;
+  if (client.getActiveHostId() === input.originHostId) return true;
+  if (client.getRequestContextUserId() === null) return false;
+
+  const entry = directory.findById(input.originHostId);
+  if (entry === null || dialableHostEndpoint(entry) === null) return false;
+
+  directory.selectTransientById(entry.hostId, "notification");
+  // The bind is synchronous through the selection listener; anything else
+  // means the app-wide host did not actually move, and routing now would
+  // acknowledge against the wrong feed.
+  if (client.getActiveHostId() !== entry.hostId) return false;
+
+  // Binding changes the app-wide host context, which is a bigger consequence
+  // than the click asked for - say so before the destination appears.
+  toast.success(
+    `Switched to ${entry.label.length > 0 ? entry.label : entry.hostId}`,
+  );
+  return true;
 }

--- a/clients/gui-app/src/components/notifications/notification-row.tsx
+++ b/clients/gui-app/src/components/notifications/notification-row.tsx
@@ -312,6 +312,11 @@ function notificationRowGlyph(row: MergedNotificationRow): RowGlyph {
       return { icon: MessageCircle, colorClassName: PROMPT_COLOR };
     case "workspace.operation.failed":
       return { icon: CircleAlert, colorClassName: FAILURE_COLOR };
+    // Only reachable for an `info` row: the severity branches above already
+    // claim every `done`/`failure`/`needs_action` host-operation row, and the
+    // kind itself says nothing about how the operation ended.
+    case "host.operation.finished":
+      return { icon: Bell, colorClassName: NEUTRAL_COLOR };
     case null:
       return { icon: Bell, colorClassName: NEUTRAL_COLOR };
   }

--- a/clients/gui-app/src/components/settings/SETTINGS.md
+++ b/clients/gui-app/src/components/settings/SETTINGS.md
@@ -613,10 +613,15 @@ aria-live="polite"` carrying the equivalent text for
     through a **transient per-host client** (`useHostClientFor`) so picking a
     host never swaps the app-wide active host or reloads the Epic list (and
     never affects the branch-prefix default above). Backed by the host
-    `worktree.listAllForHost` / `worktree.deleteByPath` RPCs through
-    `useHostQuery` / `useHostMutation`. Setup/teardown script editing is NOT
-    here - the create-worktree flow owns it, and scripts otherwise live in the
-    committed `.traycer/environment.json`.
+    `worktree.listAllForHost` RPC through `useHostQuery` / `useHostMutation`,
+    and by the `worktree.deleteBatchByPath` stream for deletion: a single or
+    bulk delete is ONE host-owned command that keeps running if this panel
+    unmounts and writes one completion notification when every target settles.
+    Against a host too old to know that method, the panel falls back to the
+    released per-target `worktree.deleteByPath` stream, metered two at a time
+    client-side. Setup/teardown script editing is NOT here - the create-
+    worktree flow owns it, and scripts otherwise live in the committed
+    `.traycer/environment.json`.
   - **Evidence tiers, not a safety verdict.** Each row leads with exactly one
     loud status pill (`WorktreeTierPill`, classification shared with the
     Task-delete dialog and the `traycer-housekeeping` skill via

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -18,6 +18,7 @@ import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock
 import { createRequestContextFixture } from "@traycer-clients/shared/test-fixtures/request-context";
 import { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import type { WorktreeDeleteStreamCallbacks } from "@traycer-clients/shared/host-transport/worktree-delete-stream-client";
+import type { WorktreeDeleteBatchStreamCallbacks } from "@traycer-clients/shared/host-transport/worktree-delete-batch-stream-client";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { WorktreeHostEntryV14 } from "@traycer/protocol/host/index";
 import type {
@@ -48,13 +49,35 @@ import {
 // The delete is a stream: mock the wrapper so a test can drive server frames
 // (started / phase / output / complete / failed) and assert the modal + cache
 // behaviour without a real socket.
+//
+// Tests drive PER-TARGET callbacks even though the current host path opens one
+// batch command: the mock adapts the command's path-tagged callbacks into the
+// per-target shape and synthesizes the terminal `command.complete` once every
+// target has settled, exactly as the host does. That keeps these tests about
+// what the panel shows, not about which wire shape carried it - and the same
+// shims serve the older-host fallback, which really is per-target.
 const streamMock = vi.hoisted(() => ({
   callbacks: null as WorktreeDeleteStreamCallbacks | null,
   callbacksByPath: new Map<string, WorktreeDeleteStreamCallbacks>(),
   paths: [] as string[],
   scriptsByPath: new Map<string, WorktreeEntryScripts | null>(),
   throwForPaths: new Set<string>(),
+  /** Paths whose command must report "this host has no such method". */
+  unsupportedForPaths: new Set<string>(),
+  /**
+   * The last command's RAW callbacks. Tests use these to play a re-attached
+   * observer: the host does not replay per-target frames, so `onCommandComplete`
+   * can legitimately arrive for targets whose own frames were never delivered.
+   */
+  commandCallbacks: null as WorktreeDeleteBatchStreamCallbacks | null,
+  /**
+   * Paths opened through the RELEASED per-target client only. `paths` records
+   * both wires, so this is what distinguishes "the older-host fallback ran a
+   * stream for this path" from "a command covered it".
+   */
+  legacyPaths: [] as string[],
   closeCount: 0,
+  commandCount: 0,
 }));
 
 // Capture the confirm-time "dropped rows" toast so its class-summarized copy can
@@ -173,12 +196,85 @@ vi.mock(
         readonly callbacks: WorktreeDeleteStreamCallbacks;
       }) {
         streamMock.paths.push(options.worktreePath);
+        streamMock.legacyPaths.push(options.worktreePath);
         if (streamMock.throwForPaths.has(options.worktreePath)) {
           throw new Error(`cannot subscribe ${options.worktreePath}`);
         }
         streamMock.scriptsByPath.set(options.worktreePath, options.scripts);
         streamMock.callbacks = options.callbacks;
         streamMock.callbacksByPath.set(options.worktreePath, options.callbacks);
+      }
+      close(): void {
+        streamMock.closeCount += 1;
+      }
+    },
+  }),
+);
+
+vi.mock(
+  "@traycer-clients/shared/host-transport/worktree-delete-batch-stream-client",
+  () => ({
+    WorktreeDeleteBatchStreamClient: class {
+      constructor(options: {
+        readonly commandId: string;
+        readonly targets: ReadonlyArray<{
+          readonly worktreePath: string;
+          readonly scripts: WorktreeEntryScripts | null;
+        }>;
+        readonly callbacks: WorktreeDeleteBatchStreamCallbacks;
+      }) {
+        streamMock.commandCount += 1;
+        streamMock.commandCallbacks = options.callbacks;
+        const paths = options.targets.map((target) => target.worktreePath);
+        if (paths.some((path) => streamMock.unsupportedForPaths.has(path))) {
+          // Reported before any path is recorded: the real client learns this
+          // from the openAck, so the host was never asked to delete anything.
+          options.callbacks.onUnsupported();
+          return;
+        }
+        paths.forEach((path) => streamMock.paths.push(path));
+        if (paths.some((path) => streamMock.throwForPaths.has(path))) {
+          throw new Error(`cannot subscribe ${paths.join(", ")}`);
+        }
+        options.targets.forEach((target) =>
+          streamMock.scriptsByPath.set(target.worktreePath, target.scripts),
+        );
+
+        const settledPaths = new Set<string>();
+        let deletedCount = 0;
+        const settleTarget = (path: string, deleted: boolean): void => {
+          if (settledPaths.has(path)) return;
+          settledPaths.add(path);
+          if (deleted) deletedCount += 1;
+          if (settledPaths.size < paths.length) return;
+          options.callbacks.onCommandComplete({
+            requestedCount: paths.length,
+            deletedCount,
+            failedCount: paths.length - deletedCount,
+          });
+        };
+
+        paths.forEach((path) => {
+          const perTarget: WorktreeDeleteStreamCallbacks = {
+            onStarted: (hasTeardown) =>
+              options.callbacks.onTargetStarted(path, hasTeardown),
+            onPhase: (phase) => options.callbacks.onTargetPhase(path, phase),
+            onOutput: (channel, chunk) =>
+              options.callbacks.onTargetOutput(path, channel, chunk),
+            onComplete: (deleted) => {
+              options.callbacks.onTargetComplete(path, deleted);
+              settleTarget(path, deleted);
+            },
+            onFailed: (reason) => {
+              options.callbacks.onTargetFailed(path, reason);
+              settleTarget(path, false);
+            },
+            onConnectionStatus: (status, reason) =>
+              options.callbacks.onConnectionStatus(status, reason),
+          };
+          streamMock.callbacksByPath.set(path, perTarget);
+          streamMock.callbacks = perTarget;
+        });
       }
       close(): void {
         streamMock.closeCount += 1;
@@ -675,7 +771,11 @@ describe("WorktreesList delete flow", () => {
     streamMock.paths = [];
     streamMock.scriptsByPath.clear();
     streamMock.throwForPaths.clear();
+    streamMock.unsupportedForPaths.clear();
+    streamMock.commandCallbacks = null;
+    streamMock.legacyPaths = [];
     streamMock.closeCount = 0;
+    streamMock.commandCount = 0;
     toastMock.messages = [];
   });
 
@@ -1454,7 +1554,7 @@ describe("WorktreesList delete flow", () => {
     ).toBeNull();
   });
 
-  it("queues bulk deletes across repo groups while every selected row shows progress", () => {
+  it("sends one command for a cross-repo bulk delete while every selected row shows progress", () => {
     const queryClient = new QueryClient();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
     const multiRepoWorktrees = [
@@ -1481,7 +1581,15 @@ describe("WorktreesList delete flow", () => {
     fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
     fireEvent.click(screen.getByTestId("confirm-action"));
 
-    expect(streamMock.paths).toEqual(["/wt/clean", "/wt/dirty"]);
+    // Every selected target rides ONE command: the host schedules them (two at
+    // a time, host-wide), so the renderer no longer meters the fan-out and no
+    // longer decides which two go first.
+    expect(streamMock.commandCount).toBe(1);
+    expect(streamMock.paths).toEqual([
+      "/wt/clean",
+      "/wt/dirty",
+      "/wt/api-clean",
+    ]);
     screen.getByText("0/3 deleted");
     expect(screen.getAllByTestId("worktree-row-deleting-spinner")).toHaveLength(
       3,
@@ -1499,11 +1607,7 @@ describe("WorktreesList delete flow", () => {
     });
 
     screen.getByText("1/3 deleted");
-    expect(streamMock.paths).toEqual([
-      "/wt/clean",
-      "/wt/dirty",
-      "/wt/api-clean",
-    ]);
+    expect(streamMock.commandCount).toBe(1);
     expect(screen.getAllByTestId("worktree-row-deleting-spinner")).toHaveLength(
       3,
     );
@@ -1531,7 +1635,7 @@ describe("WorktreesList delete flow", () => {
     });
   });
 
-  it("continues queued bulk deletes when a queued stream fails to start", () => {
+  it("fails every target non-modally when the command stream cannot start", () => {
     const multiRepoWorktrees = [
       ...WORKTREES,
       entry({
@@ -1568,7 +1672,45 @@ describe("WorktreesList delete flow", () => {
     fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
     fireEvent.click(screen.getByTestId("confirm-action"));
 
+    // The whole selection is one command, so a transport that cannot even be
+    // opened fails all of it - and, being a batch, says so in the progress
+    // strip rather than popping a modal over rows the user selected together.
+    expect(screen.queryByTestId("worktree-delete-progress-modal")).toBeNull();
+    screen.getByText("0/4 deleted, 4 failed");
+  });
+
+  it("falls back to per-target streams when the host has no batch command method", () => {
+    const multiRepoWorktrees = [
+      ...WORKTREES,
+      entry({
+        repoLabel: "acme/api",
+        repoIdentifier: { owner: "acme", repo: "api" },
+        worktreePath: "/wt/api-clean",
+        branch: "feat-api-clean",
+      }),
+    ];
+    streamMock.unsupportedForPaths.add("/wt/clean");
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: multiRepoWorktrees,
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      seededPaths: undefined,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    selectRows(["feat-clean", "feat-dirty", "feat-api-clean"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    // The command was attempted and rejected before the host was asked to
+    // delete anything, so no target ran under it - the fallback then meters
+    // the per-target streams two at a time, client-side, as before.
+    expect(streamMock.commandCount).toBe(1);
     expect(streamMock.paths).toEqual(["/wt/clean", "/wt/dirty"]);
+    screen.getByText("0/3 deleted");
 
     act(() => {
       callbacksFor("/wt/clean").onComplete(true);
@@ -1578,14 +1720,142 @@ describe("WorktreesList delete flow", () => {
       "/wt/clean",
       "/wt/dirty",
       "/wt/api-clean",
-      "/wt/web-clean",
     ]);
-    expect(callbacksFor("/wt/web-clean")).toBeDefined();
-    // A batch item failing to start is surfaced non-modally in the progress
-    // strip (1 deleted, 1 failed, 2 still running) - it must not pop a modal
-    // over the siblings that are still deleting.
-    expect(screen.queryByTestId("worktree-delete-progress-modal")).toBeNull();
-    screen.getByText("1/4 deleted, 1 failed");
+    screen.getByText("1/3 deleted");
+  });
+
+  it("settles targets whose frames were missed while disconnected when the aggregate arrives", () => {
+    renderDefault();
+
+    selectRows(["feat-clean", "feat-dirty"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+
+    act(() => {
+      callbacksFor("/wt/clean").onComplete(true);
+    });
+    screen.getByText("1/2 deleted");
+    // Both rows still read as in-flight: the deleted one until the list drops
+    // it, and `/wt/dirty` because it genuinely has not settled yet.
+    expect(screen.getAllByTestId("worktree-row-deleting-spinner")).toHaveLength(
+      2,
+    );
+
+    // The socket dropped, `/wt/dirty` settled host-side while nobody was
+    // listening, and the re-attached observer receives only the aggregate -
+    // the host never replays per-target frames.
+    act(() => {
+      streamMock.commandCallbacks?.onCommandComplete({
+        requestedCount: 2,
+        deletedCount: 2,
+        failedCount: 0,
+      });
+    });
+
+    // The stranded row settles rather than spinning forever, and it settles
+    // honestly: the client cannot know that target's outcome, so it points at
+    // the refreshed list instead of inventing one. (The remaining spinner is
+    // the confirmed-deleted row, which the refreshed list prunes.)
+    expect(screen.getAllByTestId("worktree-row-deleting-spinner")).toHaveLength(
+      1,
+    );
+    screen.getByText("1/2 deleted, 1 failed");
+  });
+
+  it("hands only still-unsettled targets to the fallback, so a settled one cannot hijack a newer run for its path", () => {
+    renderDefault();
+
+    selectRows(["feat-clean", "feat-dirty"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    const firstCommand = streamMock.commandCallbacks;
+    expect(streamMock.commandCount).toBe(1);
+    expect(streamMock.legacyPaths).toEqual([]);
+
+    // `/wt/clean` settles under the ORIGINAL command and releases its
+    // reservation, so the user can act on that path again.
+    act(() => {
+      callbacksFor("/wt/clean").onFailed("busy");
+    });
+
+    // They do: a fresh single delete opens its own command, whose record sits
+    // in `queued` until the host reports `target.started`.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Delete worktree feat-clean" }),
+    );
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(streamMock.commandCount).toBe(2);
+
+    // Only now does the FIRST command discover it is talking to a host without
+    // the batch method - the replacement-host case, where the observe session's
+    // compatibility check is what reports it.
+    act(() => {
+      firstCommand?.onUnsupported();
+    });
+
+    // The fallback runs the one target that never settled. `/wt/clean` is not
+    // re-queued: its stale entry would otherwise find the NEW command's queued
+    // record and start a second, uncoordinated per-target stream for a run it
+    // has nothing to do with.
+    expect(streamMock.legacyPaths).toEqual(["/wt/dirty"]);
+  });
+
+  it("keeps fallback reservations in step with the queue, so drained and dismissed targets can be deleted again", () => {
+    const multiRepoWorktrees = [
+      ...WORKTREES,
+      entry({
+        repoLabel: "acme/api",
+        repoIdentifier: { owner: "acme", repo: "api" },
+        worktreePath: "/wt/api-clean",
+        branch: "feat-api-clean",
+      }),
+    ];
+    // Older host: every command is rejected up front and the per-target queue
+    // takes over, running two at a time.
+    ["/wt/clean", "/wt/dirty", "/wt/api-clean"].forEach((path) =>
+      streamMock.unsupportedForPaths.add(path),
+    );
+    renderList({
+      hostId: "host-a",
+      queryClient: new QueryClient(),
+      worktrees: multiRepoWorktrees,
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      seededPaths: undefined,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    selectRows(["feat-clean", "feat-dirty", "feat-api-clean"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(streamMock.paths).toEqual(["/wt/clean", "/wt/dirty"]);
+
+    // The queued third target starts only once a slot frees, and every target
+    // releases its reservation as it settles.
+    act(() => {
+      callbacksFor("/wt/clean").onFailed("busy");
+    });
+    expect(streamMock.paths).toEqual([
+      "/wt/clean",
+      "/wt/dirty",
+      "/wt/api-clean",
+    ]);
+    act(() => {
+      callbacksFor("/wt/dirty").onFailed("busy");
+      callbacksFor("/wt/api-clean").onFailed("busy");
+    });
+
+    // All three failed, so all three are selectable and deletable again - a
+    // reservation that outlived its run would make them permanently
+    // un-deletable for the rest of the session.
+    fireEvent.click(screen.getByTestId("worktree-delete-progress-dismiss"));
+    streamMock.paths = [];
+    streamMock.callbacksByPath.clear();
+    selectRows(["feat-clean", "feat-dirty", "feat-api-clean"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    expect(streamMock.paths).toEqual(["/wt/clean", "/wt/dirty"]);
   });
 
   it("shows a plain confirm for a clean worktree", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -1629,6 +1629,7 @@ describe("WorktreesList delete flow", () => {
     expect(invalidateSpy).toHaveBeenCalledTimes(
       WORKTREE_BINDING_INVALIDATIONS.length + 2,
     );
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: hostQueryKeys.methodScope("host-a", "worktree.listAllForHost"),
       refetchType: "active",

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -1629,7 +1629,6 @@ describe("WorktreesList delete flow", () => {
     expect(invalidateSpy).toHaveBeenCalledTimes(
       WORKTREE_BINDING_INVALIDATIONS.length + 2,
     );
-    expect(invalidateSpy).toHaveBeenCalledTimes(1);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: hostQueryKeys.methodScope("host-a", "worktree.listAllForHost"),
       refetchType: "active",

--- a/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/worktrees-settings-panel.test.tsx
@@ -1800,6 +1800,44 @@ describe("WorktreesList delete flow", () => {
     expect(streamMock.legacyPaths).toEqual(["/wt/dirty"]);
   });
 
+  it("invalidates after a replacement host reports unsupported once every target already settled", () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    renderList({
+      hostId: "host-a",
+      queryClient,
+      worktrees: WORKTREES,
+      enrichedByPath: undefined,
+      erroredPaths: undefined,
+      seededPaths: undefined,
+      onVisiblePathsChange: undefined,
+      taskTitlesByEpicId: undefined,
+    });
+
+    selectRows(["feat-clean", "feat-dirty"]);
+    fireEvent.click(screen.getByTestId("worktrees-list-delete-selected"));
+    fireEvent.click(screen.getByTestId("confirm-action"));
+    const command = streamMock.commandCallbacks;
+
+    // A replacement host can make the reattached observer learn that the
+    // batch method disappeared after it already received both target frames,
+    // but before it receives the aggregate command frame.
+    act(() => {
+      command?.onTargetComplete("/wt/clean", true);
+      command?.onTargetComplete("/wt/dirty", true);
+    });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      command?.onUnsupported();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: hostQueryKeys.methodScope("host-a", "worktree.listAllForHost"),
+      refetchType: "active",
+    });
+  });
+
   it("keeps fallback reservations in step with the queue, so drained and dismissed targets can be deleted again", () => {
     const multiRepoWorktrees = [
       ...WORKTREES,

--- a/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
+++ b/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
@@ -10,6 +10,7 @@ import type { WorktreeEntryScripts } from "@traycer/protocol/host/worktree-schem
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import { WorktreeDeleteStreamClient } from "@traycer-clients/shared/host-transport/worktree-delete-stream-client";
+import { WorktreeDeleteBatchStreamClient } from "@traycer-clients/shared/host-transport/worktree-delete-batch-stream-client";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
 import { openOwnedDurableStreamClient } from "@/lib/host/owned-durable-stream-client";
 import {
@@ -49,11 +50,18 @@ const QUEUED_RUN: WorktreeDeleteRunState = {
   status: "queued",
 };
 
-// Each stream can run teardown scripts plus git removal; cap fanout so a large
-// multi-repo selection cannot saturate the host or websocket transport.
+// Fan-out cap for the FALLBACK path only (an older host with no batch
+// command method). On a current host the same cap lives on the host, where it
+// can actually bound the machine rather than one window's share of it.
 const MAX_PARALLEL_DELETE_STREAMS = 2;
 const CONNECTION_LOST_MESSAGE =
   "Lost connection to the host before the delete finished.";
+// A target the host settled while this client was disconnected. The host does
+// not replay per-target frames on re-attach, so its individual outcome is
+// genuinely unknown here - the refreshed list is the authority, and inventing
+// "deleted" or "failed" for it would be a guess presented as a result.
+const REATTACHED_MESSAGE =
+  "Reconnected after this delete finished. Check the refreshed list to see whether this worktree was removed.";
 
 export interface WorktreeDeleteRunRecord {
   readonly key: string;
@@ -321,11 +329,29 @@ const useWorktreeDeleteRunStore = create<WorktreeDeleteRunStore>((set) => ({
 }));
 
 /**
- * Module-level registry for live delete stream clients. Each host/worktree
- * pair owns its own stream, so backgrounding one delete does not release or
- * overwrite another in-flight delete.
+ * Module-level registry for live per-target delete stream clients (the
+ * older-host fallback only). Each host/worktree pair owns its own stream, so
+ * backgrounding one delete does not release or overwrite another in-flight
+ * delete.
  */
 const clientRefs = new Map<string, { close(): void }>();
+
+/**
+ * Live command streams, keyed by command id. One entry per user action on a
+ * current host, however many worktrees it covers.
+ */
+const commandRefs = new Map<string, { close(): void }>();
+
+/**
+ * Every run key (host + worktree path) currently owned by a command or by the
+ * fallback queue.
+ *
+ * Replaces the old "is there a `clientRefs` entry or a queue entry" check,
+ * which no longer answers the question: a target inside a batch command has
+ * neither of those, yet starting a second delete for it would be exactly the
+ * duplicate destructive action the check exists to prevent.
+ */
+const activeTargetKeys = new Set<string>();
 
 interface QueuedWorktreeDelete {
   readonly key: string;
@@ -338,6 +364,7 @@ interface QueuedWorktreeDelete {
 
 const queuedDeletes: QueuedWorktreeDelete[] = [];
 let activeDeleteStreamCount = 0;
+let activeCommandCount = 0;
 const pendingSettledCallbacks = new Set<() => void>();
 
 /**
@@ -406,47 +433,45 @@ export function useWorktreeDeleteRun(
     setBackgrounded(visibleRecord.key, true);
   }, [setBackgrounded, visibleRecord]);
 
+  // Dismisses the modal's record. On the fallback path that also drops the
+  // target's own socket (its historical abort-on-close behaviour, which
+  // settles the run and releases its key through the status handler). A target
+  // inside a command has no socket of its own, and closing the command's
+  // stream here would silence its SIBLINGS - so the command keeps running and
+  // releases the key when the target actually settles, which is both the
+  // detach-not-cancel contract and what stops a dismissed modal from letting
+  // the same worktree be deleted twice concurrently.
   const close = useCallback(() => {
     if (visibleRecord === null) return;
-    clientRefs.get(visibleRecord.key)?.close();
-    clientRefs.delete(visibleRecord.key);
+    closeDeleteClient(visibleRecord.key);
+    discardQueuedDelete(visibleRecord.key);
     clear(visibleRecord.key);
   }, [clear, visibleRecord]);
 
   const startDelete = useCallback(
     (
-      target: WorktreeHostEntry,
-      scripts: WorktreeEntryScripts | null,
+      targets: ReadonlyArray<WorktreeDeleteRequestTarget>,
       backgrounded: boolean,
       batchKey: string | null,
     ) => {
-      const key = worktreeDeleteRunKey(hostId, target.worktreePath);
-      if (
-        clientRefs.has(key) ||
-        queuedDeletes.some((queued) => queued.key === key)
-      ) {
-        return;
-      }
       // Freeze the settle callback at start so a host swap mid-delete can't
       // redirect the cache invalidation to the wrong host scope (the live
       // `onSettledRef` would otherwise rebind to the newly-selected host).
-      const onSettled = onSettledRef.current;
-      begin({ key, hostId, batchKey, target, run: QUEUED_RUN, backgrounded });
-      queuedDeletes.push({
-        key,
+      startWorktreeDeleteCommand({
         hostId,
-        target,
-        scripts,
+        batchKey,
+        backgrounded,
+        targets,
+        begin,
         openStreamTransport,
-        onSettled,
+        onSettled: onSettledRef.current,
       });
-      drainDeleteQueue();
     },
     [begin, hostId, openStreamTransport],
   );
   const start = useCallback(
     (target: WorktreeHostEntry, scripts: WorktreeEntryScripts | null) => {
-      startDelete(target, scripts, false, null);
+      startDelete([{ target, scripts }], false, null);
     },
     [startDelete],
   );
@@ -455,15 +480,14 @@ export function useWorktreeDeleteRun(
       targets: ReadonlyArray<WorktreeHostEntry>,
       scriptsByPath: ReadonlyMap<string, WorktreeEntryScripts>,
     ) => {
-      const batchKey = nextWorktreeDeleteBatchKey(hostId);
-      targets.forEach((target) => {
-        startDelete(
+      startDelete(
+        targets.map((target) => ({
           target,
-          scriptsByPath.get(target.worktreePath) ?? null,
-          true,
-          batchKey,
-        );
-      });
+          scripts: scriptsByPath.get(target.worktreePath) ?? null,
+        })),
+        true,
+        nextWorktreeDeleteBatchKey(hostId),
+      );
     },
     [hostId, startDelete],
   );
@@ -494,11 +518,256 @@ export function useWorktreeDeleteRun(
 export function __resetWorktreeDeleteRunForTests(): void {
   clientRefs.forEach((client) => client.close());
   clientRefs.clear();
+  commandRefs.forEach((client) => client.close());
+  commandRefs.clear();
+  activeTargetKeys.clear();
   queuedDeletes.length = 0;
   activeDeleteStreamCount = 0;
+  activeCommandCount = 0;
   pendingSettledCallbacks.clear();
   batchSequence = 0;
   useWorktreeDeleteRunStore.getState().clearAll();
+}
+
+interface WorktreeDeleteRequestTarget {
+  readonly target: WorktreeHostEntry;
+  readonly scripts: WorktreeEntryScripts | null;
+}
+
+interface StartWorktreeDeleteCommandInput {
+  readonly hostId: string;
+  readonly batchKey: string | null;
+  readonly backgrounded: boolean;
+  readonly targets: ReadonlyArray<WorktreeDeleteRequestTarget>;
+  readonly begin: (input: {
+    readonly key: string;
+    readonly hostId: string;
+    readonly batchKey: string | null;
+    readonly target: WorktreeHostEntry;
+    readonly run: WorktreeDeleteRunState;
+    readonly backgrounded: boolean;
+  }) => void;
+  readonly openStreamTransport: (hostId: string) => DurableStreamTransport;
+  readonly onSettled: () => void;
+}
+
+/**
+ * Opens ONE host-owned deletion command for a user action - a single delete or
+ * a bulk selection alike.
+ *
+ * This replaces the renderer-side queue of N sockets as the primary path. The
+ * queue was never really scheduling: it was the only place that knew a bulk
+ * delete was one user action, so nothing durable could ever describe it. Here
+ * the host holds that identity, which is what lets the work outlive this
+ * window and produce one completion notification instead of N or zero.
+ *
+ * The old queue survives underneath as the older-host fallback, entered only
+ * on `onUnsupported` - i.e. only when the host proved it has no such method,
+ * before it was asked to delete anything.
+ */
+function startWorktreeDeleteCommand(
+  input: StartWorktreeDeleteCommandInput,
+): void {
+  const accepted = input.targets.filter(
+    (item) =>
+      !activeTargetKeys.has(
+        worktreeDeleteRunKey(input.hostId, item.target.worktreePath),
+      ),
+  );
+  if (accepted.length === 0) return;
+
+  accepted.forEach((item) => {
+    const key = worktreeDeleteRunKey(input.hostId, item.target.worktreePath);
+    activeTargetKeys.add(key);
+    input.begin({
+      key,
+      hostId: input.hostId,
+      batchKey: input.batchKey,
+      target: item.target,
+      run: QUEUED_RUN,
+      backgrounded: input.backgrounded,
+    });
+  });
+
+  const commandId = crypto.randomUUID();
+  const keyFor = (worktreePath: string): string =>
+    worktreeDeleteRunKey(input.hostId, worktreePath);
+  const unsettled = new Set(
+    accepted.map((item) => keyFor(item.target.worktreePath)),
+  );
+  activeCommandCount += 1;
+
+  // A holder rather than a plain `let`: the settle happens inside callbacks the
+  // stream client owns, and the post-build guard below has to read the value as
+  // of THEN, not as of the last assignment the compiler can see.
+  const command = { settled: false };
+  /**
+   * Ends the command and drives every target that never reported a terminal
+   * frame into `unsettledReason`.
+   *
+   * That leftover set is NOT just an error path. The host does not replay
+   * per-target frames to an observer that attached late, so a run that lost
+   * its socket for a few seconds mid-batch legitimately reaches
+   * `command.complete` with targets it never saw settle. Leaving them
+   * non-terminal is what strands the progress strip, blocks the acknowledge
+   * control, and stops settled successes from ever being pruned - so the
+   * honest thing is to settle them as failures whose copy sends the user to
+   * the refreshed list, which `onSettled` invalidates moments later.
+   */
+  const settleCommand = (unsettledReason: string): void => {
+    if (command.settled) return;
+    command.settled = true;
+    activeCommandCount = Math.max(0, activeCommandCount - 1);
+    closeCommandClient(commandId);
+    unsettled.forEach((key) => {
+      useWorktreeDeleteRunStore.getState().failRun(key, unsettledReason);
+      releaseTargetKey(key);
+    });
+    unsettled.clear();
+    pendingSettledCallbacks.add(input.onSettled);
+    drainDeleteQueue();
+    flushSettledCallbacksIfIdle();
+  };
+  /**
+   * Ends the command WITHOUT settling anything: this host has no such method,
+   * so the fallback queue is about to run the work per target instead.
+   *
+   * Only STILL-UNSETTLED targets are handed over. On the common path that is
+   * all of them - the compatibility check rejects the very first openAck,
+   * before anything can settle. It matters on the path where the host is
+   * replaced mid-command by a build without the method: the observe session's
+   * compat check reports unsupported, and re-queueing a target that already
+   * reported a terminal frame would let a stale entry act on whatever record
+   * holds that path LATER. If the user has since started a fresh delete for it,
+   * that record is `queued`, and the stale entry would start a second,
+   * uncoordinated per-target stream for someone else's run. Filtering here
+   * keeps the invariant local instead of leaning on store state observed from
+   * the drain.
+   *
+   * Reservations stay held across the hand-off rather than being released and
+   * re-acquired, which would let a concurrent action slip a second delete for
+   * the same path in between. The settled-callback flush deliberately happens
+   * after the queue has the items, so an earlier run's pending invalidation
+   * cannot fire in the gap where the system looks idle but is not.
+   */
+  const handOffToFallback = (): void => {
+    if (command.settled) return;
+    command.settled = true;
+    activeCommandCount = Math.max(0, activeCommandCount - 1);
+    closeCommandClient(commandId);
+    enqueueFallbackDeletes(
+      input,
+      accepted.filter((item) =>
+        unsettled.has(keyFor(item.target.worktreePath)),
+      ),
+    );
+    drainDeleteQueue();
+    flushSettledCallbacksIfIdle();
+  };
+
+  try {
+    const client = openOwnedDurableStreamClient(
+      input.openStreamTransport,
+      input.hostId,
+      (wsStreamClient: WsStreamClient<HostStreamRpcRegistry>) =>
+        new WorktreeDeleteBatchStreamClient({
+          wsStreamClient,
+          commandId,
+          source: "settings",
+          targets: accepted.map((item) => ({
+            worktreePath: item.target.worktreePath,
+            scripts: item.scripts,
+          })),
+          callbacks: {
+            onTargetStarted: (worktreePath, hasTeardown) =>
+              useWorktreeDeleteRunStore
+                .getState()
+                .updateRun(keyFor(worktreePath), (run) => ({
+                  ...run,
+                  status: "running",
+                  hasTeardown,
+                })),
+            onTargetPhase: (worktreePath, phase) =>
+              useWorktreeDeleteRunStore
+                .getState()
+                .updateRun(keyFor(worktreePath), (run) => ({
+                  ...run,
+                  activePhase: phase,
+                })),
+            onTargetOutput: (worktreePath, channel, chunk) =>
+              useWorktreeDeleteRunStore
+                .getState()
+                .updateRun(keyFor(worktreePath), (run) => ({
+                  ...run,
+                  log: [
+                    ...run.log,
+                    { id: run.log.length, channel, text: chunk },
+                  ],
+                })),
+            onTargetComplete: (worktreePath, deleted) => {
+              const key = keyFor(worktreePath);
+              useWorktreeDeleteRunStore.getState().completeRun(key, deleted);
+              unsettled.delete(key);
+              releaseTargetKey(key);
+            },
+            onTargetFailed: (worktreePath, reason) => {
+              const key = keyFor(worktreePath);
+              useWorktreeDeleteRunStore.getState().failRun(key, reason);
+              unsettled.delete(key);
+              releaseTargetKey(key);
+            },
+            // Terminal for the command. Anything still open here is a target
+            // whose own frames were missed while this client was away.
+            onCommandComplete: () => settleCommand(REATTACHED_MESSAGE),
+            onCommandFailed: (reason) => settleCommand(reason),
+            onUnsupported: () => handOffToFallback(),
+            onConnectionStatus: (status, reason) => {
+              // Only a terminal stream close BEFORE the command's terminal
+              // frame is an error. A recoverable drop surfaces as
+              // "reconnecting", and the batch client answers it by re-opening
+              // in observe mode - which can re-attach to a live command but
+              // can never start this one again.
+              if (status !== "closed" || reason === null) return;
+              settleCommand(CONNECTION_LOST_MESSAGE);
+            },
+          },
+        }),
+    );
+    commandRefs.set(commandId, client);
+    // A callback can settle the command DURING the build - in production the
+    // handshake is async, but nothing in the contract promises that, and a
+    // settle that ran before this registry entry existed would leave the
+    // transport open with nobody holding it.
+    if (command.settled) closeCommandClient(commandId);
+  } catch (error) {
+    settleCommand(startStreamErrorMessage(error));
+  }
+}
+
+/**
+ * Older-host fallback: hand the command's targets to the per-target queue that
+ * predates the batch method.
+ *
+ * Safe to run after `onUnsupported` precisely because that signal comes from
+ * the openAck compatibility check - the host never received a subscribe frame,
+ * so no deletion was attempted and re-issuing the work cannot double it.
+ */
+function enqueueFallbackDeletes(
+  input: StartWorktreeDeleteCommandInput,
+  accepted: ReadonlyArray<WorktreeDeleteRequestTarget>,
+): void {
+  accepted.forEach((item) => {
+    queuedDeletes.push({
+      key: worktreeDeleteRunKey(input.hostId, item.target.worktreePath),
+      hostId: input.hostId,
+      target: item.target,
+      scripts: item.scripts,
+      openStreamTransport: input.openStreamTransport,
+      onSettled: input.onSettled,
+    });
+  });
+  // Draining is the caller's, so the enqueue → drain → flush ordering stays
+  // visible in one place.
 }
 
 /**
@@ -600,7 +869,16 @@ function drainDeleteQueue(): void {
     const record = useWorktreeDeleteRunStore
       .getState()
       .runs.find((candidate) => candidate.key === next.key);
-    if (record === undefined || record.run.status !== "queued") continue;
+    if (record === undefined || record.run.status !== "queued") {
+      // Dropped before it ever ran (its modal was dismissed, or the record was
+      // pruned). Nothing started, so the reservation has to go with it -
+      // otherwise that host+worktree pair stays un-deletable for the rest of
+      // the session. Before commands existed the queue entry WAS the
+      // reservation and shifting it released it; now the two are separate and
+      // the release has to be explicit.
+      releaseTargetKey(next.key);
+      continue;
+    }
     startQueuedDelete(next);
   }
 }
@@ -616,6 +894,7 @@ function startQueuedDelete(item: QueuedWorktreeDelete): void {
     if (settled) return;
     settled = true;
     activeDeleteStreamCount = Math.max(0, activeDeleteStreamCount - 1);
+    releaseTargetKey(item.key);
     pendingSettledCallbacks.add(item.onSettled);
     drainDeleteQueue();
     flushSettledCallbacksIfIdle();
@@ -694,6 +973,29 @@ function closeDeleteClient(key: string): void {
   client?.close();
 }
 
+function closeCommandClient(commandId: string): void {
+  const client = commandRefs.get(commandId);
+  commandRefs.delete(commandId);
+  client?.close();
+}
+
+function releaseTargetKey(key: string): void {
+  activeTargetKeys.delete(key);
+}
+
+/**
+ * Drops a fallback-queue entry that has not started yet and frees its
+ * reservation. No-op for a target inside a command (never queued) and for one
+ * whose stream is already live - both settle through their own paths, and a
+ * live delete must keep its reservation until it actually ends.
+ */
+function discardQueuedDelete(key: string): void {
+  const index = queuedDeletes.findIndex((queued) => queued.key === key);
+  if (index === -1) return;
+  queuedDeletes.splice(index, 1);
+  releaseTargetKey(key);
+}
+
 function summarizeProgress(
   runs: readonly WorktreeDeleteRunRecord[],
 ): WorktreeDeleteProgressSummary {
@@ -750,7 +1052,13 @@ function progressGroups(
 }
 
 function flushSettledCallbacksIfIdle(): void {
-  if (activeDeleteStreamCount > 0 || queuedDeletes.length > 0) return;
+  if (
+    activeDeleteStreamCount > 0 ||
+    activeCommandCount > 0 ||
+    queuedDeletes.length > 0
+  ) {
+    return;
+  }
   const callbacks = [...pendingSettledCallbacks];
   pendingSettledCallbacks.clear();
   callbacks.forEach((callback) => callback());

--- a/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
+++ b/clients/gui-app/src/components/settings/panels/use-worktree-delete-run.ts
@@ -655,12 +655,18 @@ function startWorktreeDeleteCommand(
     command.settled = true;
     activeCommandCount = Math.max(0, activeCommandCount - 1);
     closeCommandClient(commandId);
-    enqueueFallbackDeletes(
-      input,
-      accepted.filter((item) =>
-        unsettled.has(keyFor(item.target.worktreePath)),
-      ),
+    const remaining = accepted.filter((item) =>
+      unsettled.has(keyFor(item.target.worktreePath)),
     );
+    if (remaining.length === 0) {
+      // A replacement host can report unsupported after every target already
+      // settled. There is then no fallback item that can add this callback,
+      // but the completed command still changed the worktree list and needs
+      // its usual invalidation once the system is idle.
+      pendingSettledCallbacks.add(input.onSettled);
+    } else {
+      enqueueFallbackDeletes(input, remaining);
+    }
     drainDeleteQueue();
     flushSettledCallbacksIfIdle();
   };

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-batch-delete-mutation.test.ts
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-batch-delete-mutation.test.ts
@@ -21,6 +21,7 @@ import {
   deletedEpicSuccessToastMessage,
   emitEpicDeleteToast,
   pickNeighborAfterDeletingEpics,
+  worktreeCleanupSummary,
 } from "@/hooks/epic/use-epic-batch-delete-mutation";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import type { HeaderTab } from "@/stores/tabs/types";
@@ -242,3 +243,36 @@ function readWarningOptions(): ExternalToast {
   }
   return options;
 }
+
+describe("worktreeCleanupSummary", () => {
+  it("says nothing when the cleanup covered nothing", () => {
+    expect(
+      worktreeCleanupSummary({ removed: [], failed: [], uncertain: [] }),
+    ).toBeNull();
+  });
+
+  it("summarizes removals and failures together", () => {
+    expect(
+      worktreeCleanupSummary({
+        removed: ["/wt/a", "/wt/b"],
+        failed: ["/wt/c"],
+        uncertain: [],
+      }),
+    ).toBe("2 worktrees removed, 1 worktree couldn't be removed");
+  });
+
+  // An unconfirmed target is NOT a failure: the host still owns the command and
+  // its durable completion notification carries the real counts. Saying
+  // "couldn't be removed" here would be a claim this client cannot make.
+  it("keeps unconfirmed targets distinct from failures", () => {
+    expect(
+      worktreeCleanupSummary({
+        removed: ["/wt/a"],
+        failed: ["/wt/b"],
+        uncertain: ["/wt/c", "/wt/d"],
+      }),
+    ).toBe(
+      "1 worktree removed, 1 worktree couldn't be removed, 2 worktrees unconfirmed",
+    );
+  });
+});

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-sweep-worktree-candidates-query.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-sweep-worktree-candidates-query.test.tsx
@@ -154,6 +154,7 @@ describe("useEpicSweepWorktreeCandidates", () => {
     await waitFor(() => {
       expect(result.current.rows).toHaveLength(3);
     });
+    expect(result.current.hostId).toBe("host-1");
     const byPath = new Map(
       result.current.rows.map((row) => [row.entry.worktreePath, row]),
     );
@@ -372,6 +373,7 @@ describe("useEpicSweepWorktreeCandidates", () => {
     await waitFor(() => {
       expect(result.current.isError).toBe(true);
     });
+    expect(result.current.hostId).toBeNull();
     expect(result.current.rows).toEqual([]);
   });
 
@@ -381,6 +383,7 @@ describe("useEpicSweepWorktreeCandidates", () => {
       [],
     );
     const { result } = renderCandidates(null);
+    expect(result.current.hostId).toBeNull();
     expect(result.current.rows).toEqual([]);
     expect(result.current.isPending).toBe(false);
     expect(mockHostClient.request).not.toHaveBeenCalled();

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-sweep-worktrees-mutation.test.ts
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-sweep-worktrees-mutation.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  sweepWorktreeSummary,
+  sweepingWorktreePathsForHost,
+} from "@/hooks/epic/use-epic-sweep-worktrees-mutation";
+
+describe("sweepWorktreeSummary", () => {
+  it("reports a fully observed sweep as successful", () => {
+    expect(
+      sweepWorktreeSummary({
+        removed: ["/wt/a", "/wt/b"],
+        failed: [],
+        uncertain: [],
+      }),
+    ).toEqual({ level: "success", message: "2 worktrees swept" });
+  });
+
+  it("keeps unconfirmed targets distinct from filesystem failures", () => {
+    expect(
+      sweepWorktreeSummary({
+        removed: ["/wt/a"],
+        failed: ["/wt/b"],
+        uncertain: ["/wt/c", "/wt/d"],
+      }),
+    ).toEqual({
+      level: "warning",
+      message:
+        "1 worktree swept, 1 worktree couldn't be removed, 2 worktrees unconfirmed",
+    });
+  });
+
+  it("says nothing when no worktree was part of the command", () => {
+    expect(
+      sweepWorktreeSummary({ removed: [], failed: [], uncertain: [] }),
+    ).toBeNull();
+  });
+});
+
+describe("sweepingWorktreePathsForHost", () => {
+  const target = (worktreePath: string) => ({
+    worktreePath,
+    branch: null,
+    repoIdentifier: null,
+  });
+
+  it("does not let a sweep on one host reserve the same path on another", () => {
+    const pending = [
+      { hostId: "host-1", worktrees: [target("/wt/shared")] },
+      { hostId: "host-2", worktrees: [target("/wt/shared"), target("/wt/b")] },
+    ];
+
+    expect([...sweepingWorktreePathsForHost(pending, "host-1")]).toEqual([
+      "/wt/shared",
+    ]);
+    expect([...sweepingWorktreePathsForHost(pending, "host-2")]).toEqual([
+      "/wt/shared",
+      "/wt/b",
+    ]);
+    expect([...sweepingWorktreePathsForHost(pending, null)]).toEqual([]);
+  });
+});

--- a/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
@@ -172,6 +172,7 @@ export function useEpicBatchDelete(): UseMutationResult<
             openStreamTransport,
             hostId,
             eligibleWorktreePaths,
+            "task_cleanup",
           ).then((outcome) => {
             emitTaskDeleteSummaryToast(epicToast, outcome);
             invalidateWorktreeCachesForHost(queryClient, hostId);

--- a/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-batch-delete-mutation.ts
@@ -349,11 +349,13 @@ function eligibleWorktreeCleanupPaths(
     .map((candidate) => candidate.worktreePath);
 }
 
-function worktreeCleanupSummary(
-  removed: number,
-  failed: number,
+export function worktreeCleanupSummary(
+  outcome: WorktreeCleanupOutcome,
 ): string | null {
-  if (removed === 0 && failed === 0) return null;
+  const removed = outcome.removed.length;
+  const failed = outcome.failed.length;
+  const uncertain = outcome.uncertain.length;
+  if (removed === 0 && failed === 0 && uncertain === 0) return null;
   const parts: string[] = [];
   if (removed > 0) {
     parts.push(`${removed} worktree${removed === 1 ? "" : "s"} removed`);
@@ -363,6 +365,14 @@ function worktreeCleanupSummary(
       `${failed} worktree${failed === 1 ? "" : "s"} couldn't be removed`,
     );
   }
+  // Distinct from "couldn't be removed": the host owns the cleanup command and
+  // is still running it, so claiming a failure here would be a guess. The
+  // durable completion notification carries the real counts.
+  if (uncertain > 0) {
+    parts.push(
+      `${uncertain} worktree${uncertain === 1 ? "" : "s"} unconfirmed`,
+    );
+  }
   return parts.join(", ");
 }
 
@@ -370,17 +380,18 @@ function emitTaskDeleteSummaryToast(
   epicToast: EpicDeleteToastParts,
   outcome: WorktreeCleanupOutcome,
 ): void {
-  const summary = worktreeCleanupSummary(
-    outcome.removed.length,
-    outcome.failed.length,
-  );
+  const summary = worktreeCleanupSummary(outcome);
   if (summary === null) {
     emitEpicDeleteToast(epicToast.level, epicToast.message);
     return;
   }
-  // A worktree that couldn't be removed downgrades the combined toast to a
-  // warning even when every Task deleted cleanly.
-  const level = outcome.failed.length > 0 ? "warning" : epicToast.level;
+  // A worktree that couldn't be removed - or whose removal we never saw
+  // confirmed - downgrades the combined toast to a warning even when every
+  // Task deleted cleanly.
+  const level =
+    outcome.failed.length > 0 || outcome.uncertain.length > 0
+      ? "warning"
+      : epicToast.level;
   emitEpicDeleteToast(level, `${epicToast.message} · ${summary}`);
 }
 

--- a/clients/gui-app/src/hooks/epic/use-epic-sweep-worktree-candidates-query.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-sweep-worktree-candidates-query.ts
@@ -37,6 +37,8 @@ export interface EpicSweepWorktreeRow {
 }
 
 export interface EpicSweepWorktreeCandidatesResult {
+  /** Host on which these rows were freshly proven; null means no usable proof. */
+  readonly hostId: string | null;
   readonly rows: ReadonlyArray<EpicSweepWorktreeRow>;
   /** True while the act-time probe is in flight (first open OR a re-open). */
   readonly isPending: boolean;
@@ -162,11 +164,13 @@ export function useEpicSweepWorktreeCandidates(
     // not surface as offerable rows — the whole point is act-time proof.
     if (
       selectedEpicIds === null ||
+      readiness.hostId === null ||
+      !readiness.isReady ||
       worktrees === undefined ||
       isError ||
       isPending
     ) {
-      return { rows: EMPTY_ROWS, isPending, isError };
+      return { hostId: null, rows: EMPTY_ROWS, isPending, isError };
     }
     // The amalgamation: every worktree owned by ANY selected Task, listed once.
     const selected = new Set(selectedEpicIds);
@@ -175,8 +179,15 @@ export function useEpicSweepWorktreeCandidates(
         ? [classifySweepRow(selected, entry)]
         : [],
     );
-    return { rows, isPending: false, isError };
-  }, [selectedEpicIds, isError, isPending, worktrees]);
+    return { hostId: readiness.hostId, rows, isPending: false, isError };
+  }, [
+    selectedEpicIds,
+    isError,
+    isPending,
+    readiness.hostId,
+    readiness.isReady,
+    worktrees,
+  ]);
 }
 
 function classifySweepRow(

--- a/clients/gui-app/src/hooks/epic/use-epic-sweep-worktrees-mutation.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-sweep-worktrees-mutation.ts
@@ -6,11 +6,13 @@ import {
   type UseMutationResult,
 } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { useHostClient } from "@/lib/host";
 import { epicMutationKeys } from "@/lib/query-keys";
 import { invalidateWorktreeListingAndBindingCaches } from "@/hooks/worktree/invalidations";
 import { useWorktreeDeleteStreamTransportFactory } from "@/lib/host/use-worktree-delete-stream-transport";
-import { runWorktreeCleanup } from "@/lib/epics/run-worktree-cleanup";
+import {
+  runWorktreeCleanup,
+  type WorktreeCleanupOutcome,
+} from "@/lib/epics/run-worktree-cleanup";
 import { reportableWarningToast } from "@/lib/reportable-error-toast";
 import { useWorktreeIntentMemoryStore } from "@/stores/worktree/worktree-intent-memory-store";
 import { useWorktreeIntentStagingStore } from "@/stores/worktree/worktree-intent-staging-store";
@@ -36,24 +38,27 @@ export interface SweepTargetWorktree {
 }
 
 export interface SweepWorktreesVariables {
+  /** Host on which the dialog's act-time safety proof was computed. */
+  readonly hostId: string;
   readonly worktrees: ReadonlyArray<SweepTargetWorktree>;
 }
 
 export interface SweepWorktreesResult {
   readonly removed: ReadonlyArray<string>;
   readonly failed: ReadonlyArray<string>;
+  readonly uncertain: ReadonlyArray<string>;
   readonly hostId: string;
 }
 
 /**
- * The Sweep action: streams one `worktree.deleteByPath` per approved path via
- * the shared cleanup runner (host-side busy-check intact, headless teardown
- * best-effort), then refreshes the worktree listing/binding caches so the
+ * The Sweep action: streams one host-owned batch command for every approved
+ * path via the shared cleanup runner (host-side busy-check intact, headless
+ * teardown best-effort), then refreshes the worktree listing/binding caches so the
  * history PR pills, task rollups, and the task-status strip converge. A bare
  * `useMutation` rather than `useHostMutation`: there is no single host RPC
- * here - the whole mutation is the streamed multi-path run. `hostId` is
- * captured once at mutate time inside the mutationFn, so a host swap
- * mid-flight can't redirect the tail of the run or its cache invalidation.
+ * here - the whole mutation is the streamed multi-path run. `hostId` comes
+ * from the candidate query's settled act-time proof, so a host swap between
+ * proof and confirm cannot redirect the command or its cache invalidation.
  *
  * Runs in the BACKGROUND (matching Settings worktree deletion): the dialog
  * closes at confirm, the kickoff is acknowledged once the host-connection
@@ -65,33 +70,28 @@ export function useEpicSweepWorktrees(): UseMutationResult<
   Error,
   SweepWorktreesVariables
 > {
-  const client = useHostClient();
   const queryClient = useQueryClient();
   const openStreamTransport = useWorktreeDeleteStreamTransportFactory();
   return useMutation<SweepWorktreesResult, Error, SweepWorktreesVariables>({
     mutationKey: epicMutationKeys.sweepWorktrees(),
     mutationFn: async (variables) => {
-      const hostId = client.getActiveHostId();
-      if (hostId === null) {
-        throw new Error("No host connection - can't sweep worktrees.");
-      }
-      // Acknowledged here rather than in `onMutate`: the connection guard
-      // above runs first, so a disconnected host shows ONLY its error toast
-      // instead of "Sweeping 2 worktrees…" immediately contradicted by "No
-      // host connection".
+      // Acknowledged here rather than in `onMutate`: the proof's host identity
+      // is already frozen in the variables, so the command cannot move onto
+      // whichever host happens to be active now.
       const count = variables.worktrees.length;
       toast.info(
         `Sweeping ${count} worktree${count === 1 ? "" : "s"} in the background…`,
       );
       const outcome = await runWorktreeCleanup(
         openStreamTransport,
-        hostId,
+        variables.hostId,
         variables.worktrees.map((target) => target.worktreePath),
+        "task_sweep",
       );
-      return { ...outcome, hostId };
+      return { ...outcome, hostId: variables.hostId };
     },
     onSuccess: (result, variables) => {
-      emitSweepSummaryToast(result.removed.length, result.failed.length);
+      emitSweepSummaryToast(result);
       purgeIntentsForRemovedWorktrees(variables.worktrees, result.removed);
       invalidateWorktreeListingAndBindingCaches(queryClient, result.hostId);
     },
@@ -134,7 +134,9 @@ function purgeIntentsForRemovedWorktrees(
  * run IT started - reopening from the other surface would happily re-stream
  * the same paths. Mirrors `usePendingSetPinnedEpicIds`.
  */
-export function useSweepingWorktreePaths(): ReadonlySet<string> {
+export function useSweepingWorktreePaths(
+  hostId: string | null,
+): ReadonlySet<string> {
   const pendingVariables = useMutationState({
     filters: {
       mutationKey: epicMutationKeys.sweepWorktrees(),
@@ -143,15 +145,21 @@ export function useSweepingWorktreePaths(): ReadonlySet<string> {
     select: (mutation) => mutation.state.variables,
   });
   return useMemo(
-    () =>
-      new Set(
-        pendingVariables.flatMap((variables) =>
-          isSweepWorktreesVariables(variables)
-            ? variables.worktrees.map((target) => target.worktreePath)
-            : [],
-        ),
-      ),
-    [pendingVariables],
+    () => sweepingWorktreePathsForHost(pendingVariables, hostId),
+    [hostId, pendingVariables],
+  );
+}
+
+export function sweepingWorktreePathsForHost(
+  pendingVariables: ReadonlyArray<unknown>,
+  hostId: string | null,
+): ReadonlySet<string> {
+  return new Set(
+    pendingVariables.flatMap((variables) =>
+      isSweepWorktreesVariables(variables) && variables.hostId === hostId
+        ? variables.worktrees.map((target) => target.worktreePath)
+        : [],
+    ),
   );
 }
 
@@ -159,8 +167,9 @@ function isSweepWorktreesVariables(
   value: unknown,
 ): value is SweepWorktreesVariables {
   if (value === null || typeof value !== "object") return false;
-  if (!("worktrees" in value)) return false;
-  const { worktrees } = value;
+  if (!("hostId" in value) || !("worktrees" in value)) return false;
+  const { hostId, worktrees } = value;
+  if (typeof hostId !== "string") return false;
   if (!Array.isArray(worktrees)) return false;
   return worktrees.every(isSweepTargetWorktree);
 }
@@ -171,21 +180,51 @@ function isSweepTargetWorktree(value: unknown): value is SweepTargetWorktree {
   return typeof value.worktreePath === "string";
 }
 
-function emitSweepSummaryToast(removed: number, failed: number): void {
-  const removedPart = `${removed} worktree${removed === 1 ? "" : "s"} swept`;
-  if (failed === 0) {
-    toast.success(removedPart);
+export interface SweepWorktreeSummary {
+  readonly level: "success" | "warning";
+  readonly message: string;
+}
+
+export function sweepWorktreeSummary(
+  outcome: WorktreeCleanupOutcome,
+): SweepWorktreeSummary | null {
+  const removed = outcome.removed.length;
+  const failed = outcome.failed.length;
+  const uncertain = outcome.uncertain.length;
+  if (removed === 0 && failed === 0 && uncertain === 0) return null;
+  const parts: string[] = [];
+  if (removed > 0) {
+    parts.push(`${removed} worktree${removed === 1 ? "" : "s"} swept`);
+  }
+  if (failed > 0) {
+    parts.push(
+      `${failed} worktree${failed === 1 ? "" : "s"} couldn't be removed`,
+    );
+  }
+  // A dropped observation is not a filesystem failure. The host still owns
+  // the command and its durable completion row will carry the actual counts.
+  if (uncertain > 0) {
+    parts.push(
+      `${uncertain} worktree${uncertain === 1 ? "" : "s"} unconfirmed`,
+    );
+  }
+  return {
+    level: failed === 0 && uncertain === 0 ? "success" : "warning",
+    message: parts.join(", "),
+  };
+}
+
+function emitSweepSummaryToast(outcome: WorktreeCleanupOutcome): void {
+  const summary = sweepWorktreeSummary(outcome);
+  if (summary === null) return;
+  if (summary.level === "success") {
+    toast.success(summary.message);
     return;
   }
-  const failedPart = `${failed} couldn't be removed`;
-  reportableWarningToast(
-    removed > 0 ? `${removedPart}, ${failedPart}` : `Sweep: ${failedPart}`,
-    undefined,
-    {
-      title: "Sweep incomplete",
-      message: null,
-      code: null,
-      source: "Worktree sweep",
-    },
-  );
+  reportableWarningToast(summary.message, undefined, {
+    title: "Sweep incomplete",
+    message: null,
+    code: null,
+    source: "Worktree sweep",
+  });
 }

--- a/clients/gui-app/src/lib/epics/__tests__/run-worktree-cleanup.test.ts
+++ b/clients/gui-app/src/lib/epics/__tests__/run-worktree-cleanup.test.ts
@@ -6,7 +6,10 @@ import { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream
 import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
-import { runWorktreeCleanup } from "@/lib/epics/run-worktree-cleanup";
+import {
+  runWorktreeCleanup,
+  type WorktreeCleanupOutcome,
+} from "@/lib/epics/run-worktree-cleanup";
 
 // The current-host path: ONE `worktree.deleteBatchByPath` command per cleanup.
 // Recording every construction is what lets a test assert the migration's core
@@ -140,6 +143,17 @@ function reachHost(): void {
   commandCallbacks().onConnectionStatus("open", null);
 }
 
+function runTaskCleanup(
+  paths: ReadonlyArray<string>,
+): Promise<WorktreeCleanupOutcome> {
+  return runWorktreeCleanup(
+    stubOpenStreamTransport(),
+    "host-1",
+    paths,
+    "task_cleanup",
+  );
+}
+
 /** Hands the whole cleanup to the older-host fan-out. */
 function reportUnsupported(): void {
   commandCallbacks().onUnsupported();
@@ -158,11 +172,7 @@ beforeEach(() => {
 
 describe("runWorktreeCleanup on a current host", () => {
   it("opens ONE task_cleanup command covering every approved path", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-      "/wt/b",
-      "/wt/c",
-    ]);
+    const promise = runTaskCleanup(["/wt/a", "/wt/b", "/wt/c"]);
 
     expect(commandMock.commands).toHaveLength(1);
     const command = commandMock.commands[0];
@@ -189,20 +199,41 @@ describe("runWorktreeCleanup on a current host", () => {
     await promise;
   });
 
+  it("preserves task_sweep as distinct durable command provenance", async () => {
+    const promise = runWorktreeCleanup(
+      stubOpenStreamTransport(),
+      "host-1",
+      ["/wt/sweep"],
+      "task_sweep",
+    );
+
+    expect(commandMock.commands).toHaveLength(1);
+    expect(commandMock.commands[0]?.source).toBe("task_sweep");
+    commandCallbacks().onTargetComplete("/wt/sweep", true);
+    commandCallbacks().onCommandComplete({
+      requestedCount: 1,
+      deletedCount: 1,
+      failedCount: 0,
+    });
+    await expect(promise).resolves.toEqual({
+      removed: ["/wt/sweep"],
+      failed: [],
+      uncertain: [],
+    });
+  });
+
   it("starts no command at all for an empty approved set", async () => {
-    await expect(
-      runWorktreeCleanup(stubOpenStreamTransport(), "host-1", []),
-    ).resolves.toEqual({ removed: [], failed: [], uncertain: [] });
+    await expect(runTaskCleanup([])).resolves.toEqual({
+      removed: [],
+      failed: [],
+      uncertain: [],
+    });
     expect(commandMock.commands).toEqual([]);
     expect(legacyMock.paths).toEqual([]);
   });
 
   it("tallies per-target outcomes independently of one another", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/removed",
-      "/wt/declined",
-      "/wt/busy",
-    ]);
+    const promise = runTaskCleanup(["/wt/removed", "/wt/declined", "/wt/busy"]);
     reachHost();
     const callbacks = commandCallbacks();
     callbacks.onTargetComplete("/wt/removed", true);
@@ -224,10 +255,7 @@ describe("runWorktreeCleanup on a current host", () => {
   });
 
   it("reports targets the host settled while detached as unconfirmed", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/seen",
-      "/wt/missed",
-    ]);
+    const promise = runTaskCleanup(["/wt/seen", "/wt/missed"]);
     reachHost();
     commandCallbacks().onTargetComplete("/wt/seen", true);
     // The host does not replay per-target frames to a late observer, so
@@ -246,10 +274,7 @@ describe("runWorktreeCleanup on a current host", () => {
   });
 
   it("reports a drop after the command reached the host as unconfirmed, without replaying it", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-      "/wt/b",
-    ]);
+    const promise = runTaskCleanup(["/wt/a", "/wt/b"]);
     reachHost();
     commandCallbacks().onTargetComplete("/wt/a", true);
     commandCallbacks().onConnectionStatus("reconnecting", null);
@@ -268,9 +293,7 @@ describe("runWorktreeCleanup on a current host", () => {
   });
 
   it("reports a drop BEFORE the command reached the host as failed", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-    ]);
+    const promise = runTaskCleanup(["/wt/a"]);
     // No `open`: the subscribe frame never got to a live socket, so nothing was
     // attempted and there is nothing uncertain about it.
     commandCallbacks().onConnectionStatus("reconnecting", null);
@@ -284,10 +307,7 @@ describe("runWorktreeCleanup on a current host", () => {
   });
 
   it("reports a host-rejected command as failed", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-      "/wt/b",
-    ]);
+    const promise = runTaskCleanup(["/wt/a", "/wt/b"]);
     reachHost();
     commandCallbacks().onCommandFailed("Worktree service is not ready.");
 
@@ -302,9 +322,7 @@ describe("runWorktreeCleanup on a current host", () => {
   });
 
   it("ignores normal startup statuses", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-    ]);
+    const promise = runTaskCleanup(["/wt/a"]);
     commandCallbacks().onConnectionStatus("connecting", null);
     reachHost();
     commandCallbacks().onTargetComplete("/wt/a", true);
@@ -324,11 +342,7 @@ describe("runWorktreeCleanup on a current host", () => {
 
 describe("runWorktreeCleanup on an older host", () => {
   it("falls back to the bounded per-target fan-out", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-      "/wt/b",
-      "/wt/c",
-    ]);
+    const promise = runTaskCleanup(["/wt/a", "/wt/b", "/wt/c"]);
     // Reported from the openAck compatibility check, BEFORE any subscribe frame
     // reached the host - which is what makes re-issuing the work safe.
     reportUnsupported();
@@ -357,9 +371,7 @@ describe("runWorktreeCleanup on an older host", () => {
   // settle so the summary toast + cache invalidation still fire. Unchanged by
   // the migration: an older host has no command to keep running without us.
   it("fails fast and settles when a per-target stream drops", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-    ]);
+    const promise = runTaskCleanup(["/wt/a"]);
     reportUnsupported();
     legacyCallbacksFor("/wt/a").onConnectionStatus("reconnecting", null);
 
@@ -373,9 +385,7 @@ describe("runWorktreeCleanup on an older host", () => {
   });
 
   it("treats a per-target close before a terminal frame as a failure", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-    ]);
+    const promise = runTaskCleanup(["/wt/a"]);
     reportUnsupported();
     legacyCallbacksFor("/wt/a").onConnectionStatus("closed", null);
 
@@ -404,10 +414,7 @@ describe("runWorktreeCleanup on an older host", () => {
       "[worktree-cleanup] failed to open delete stream",
     );
 
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-      "/wt/b",
-    ]);
+    const promise = runTaskCleanup(["/wt/a", "/wt/b"]);
     reportUnsupported();
 
     // Both paths went out before the fan-out came apart.
@@ -424,9 +431,7 @@ describe("runWorktreeCleanup on an older host", () => {
   });
 
   it("ignores normal per-target startup statuses until a terminal frame arrives", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/a",
-    ]);
+    const promise = runTaskCleanup(["/wt/a"]);
     reportUnsupported();
     legacyCallbacksFor("/wt/a").onConnectionStatus("connecting", null);
     legacyCallbacksFor("/wt/a").onConnectionStatus("open", null);

--- a/clients/gui-app/src/lib/epics/__tests__/run-worktree-cleanup.test.ts
+++ b/clients/gui-app/src/lib/epics/__tests__/run-worktree-cleanup.test.ts
@@ -1,19 +1,79 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WorktreeDeleteStreamCallbacks } from "@traycer-clients/shared/host-transport/worktree-delete-stream-client";
+import type { WorktreeDeleteBatchStreamCallbacks } from "@traycer-clients/shared/host-transport/worktree-delete-batch-stream-client";
+import type { WorktreeDeleteBatchTarget } from "@traycer/protocol/host/worktree-delete-batch-stream";
 import { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
 import { runWorktreeCleanup } from "@/lib/epics/run-worktree-cleanup";
 
-// Records constructor calls + callbacks per worktree path and counts client
-// teardowns, so a test can drive terminal frames / connection drops and assert
-// exactly one subscribe (construction) per path.
-const streamMock = vi.hoisted(() => ({
-  paths: [] as string[],
-  callbacksByPath: new Map<string, WorktreeDeleteStreamCallbacks>(),
+// The current-host path: ONE `worktree.deleteBatchByPath` command per cleanup.
+// Recording every construction is what lets a test assert the migration's core
+// claim - N approved paths produce one command, not N streams.
+const commandMock = vi.hoisted(() => ({
+  commands: [] as Array<{
+    readonly commandId: string;
+    readonly source: string;
+    readonly targets: ReadonlyArray<WorktreeDeleteBatchTarget>;
+  }>,
+  callbacks: null as WorktreeDeleteBatchStreamCallbacks | null,
   closeCount: 0,
 }));
+
+// The older-host fallback: the released per-target stream. Kept separate from
+// `commandMock` so "the fallback ran" is never inferred from a command's frames.
+const legacyMock = vi.hoisted(() => ({
+  paths: [] as string[],
+  callbacksByPath: new Map<string, WorktreeDeleteStreamCallbacks>(),
+  /** Paths whose stream fails to open, driving `deleteOneWorktree`'s catch. */
+  throwForPaths: new Set<string>(),
+  closeCount: 0,
+}));
+
+// The renderer log sink. Making one specific message throw is how a test
+// reaches the fallback's only unguarded region - see the rejection regression.
+const loggerMock = vi.hoisted(() => ({
+  throwForMessages: new Set<string>(),
+  record: (message: string): void => {
+    if (loggerMock.throwForMessages.has(message)) {
+      throw new Error("log sink is gone");
+    }
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  appLogger: {
+    debug: (message: string) => loggerMock.record(message),
+    info: (message: string) => loggerMock.record(message),
+    warn: (message: string) => loggerMock.record(message),
+    error: (message: string) => loggerMock.record(message),
+  },
+}));
+
+vi.mock(
+  "@traycer-clients/shared/host-transport/worktree-delete-batch-stream-client",
+  () => ({
+    WorktreeDeleteBatchStreamClient: class {
+      constructor(options: {
+        readonly commandId: string;
+        readonly source: string;
+        readonly targets: ReadonlyArray<WorktreeDeleteBatchTarget>;
+        readonly callbacks: WorktreeDeleteBatchStreamCallbacks;
+      }) {
+        commandMock.commands.push({
+          commandId: options.commandId,
+          source: options.source,
+          targets: options.targets,
+        });
+        commandMock.callbacks = options.callbacks;
+      }
+      close(): void {
+        commandMock.closeCount += 1;
+      }
+    },
+  }),
+);
 
 vi.mock(
   "@traycer-clients/shared/host-transport/worktree-delete-stream-client",
@@ -23,26 +83,35 @@ vi.mock(
         readonly worktreePath: string;
         readonly callbacks: WorktreeDeleteStreamCallbacks;
       }) {
-        streamMock.paths.push(options.worktreePath);
-        streamMock.callbacksByPath.set(options.worktreePath, options.callbacks);
+        legacyMock.paths.push(options.worktreePath);
+        if (legacyMock.throwForPaths.has(options.worktreePath)) {
+          throw new Error("could not open the delete stream");
+        }
+        legacyMock.callbacksByPath.set(options.worktreePath, options.callbacks);
       }
       close(): void {
-        streamMock.closeCount += 1;
+        legacyMock.closeCount += 1;
       }
     },
   }),
 );
 
-function callbacksFor(path: string): WorktreeDeleteStreamCallbacks {
-  const callbacks = streamMock.callbacksByPath.get(path);
+function commandCallbacks(): WorktreeDeleteBatchStreamCallbacks {
+  const callbacks = commandMock.callbacks;
+  if (callbacks === null) throw new Error("expected a deletion command");
+  return callbacks;
+}
+
+function legacyCallbacksFor(path: string): WorktreeDeleteStreamCallbacks {
+  const callbacks = legacyMock.callbacksByPath.get(path);
   if (callbacks === undefined) {
-    throw new Error(`expected a delete stream for ${path}`);
+    throw new Error(`expected a per-target delete stream for ${path}`);
   }
   return callbacks;
 }
 
 // A real `WsStreamClient` whose WS factory throws if dialled - the mocked stream
-// wrapper never calls `.subscribe`, so this is only a non-null transport token.
+// wrappers never call `.subscribe`, so this is only a non-null transport token.
 function stubOpenStreamTransport(): (hostId: string) => DurableStreamTransport {
   return () => ({
     wsStreamClient: new WsStreamClient<HostStreamRpcRegistry>({
@@ -66,80 +135,307 @@ function stubOpenStreamTransport(): (hostId: string) => DurableStreamTransport {
   });
 }
 
-describe("runWorktreeCleanup", () => {
-  beforeEach(() => {
-    streamMock.paths = [];
-    streamMock.callbacksByPath.clear();
-    streamMock.closeCount = 0;
+/** Drives the command to the point where the host has accepted it. */
+function reachHost(): void {
+  commandCallbacks().onConnectionStatus("open", null);
+}
+
+/** Hands the whole cleanup to the older-host fan-out. */
+function reportUnsupported(): void {
+  commandCallbacks().onUnsupported();
+}
+
+beforeEach(() => {
+  commandMock.commands = [];
+  commandMock.callbacks = null;
+  commandMock.closeCount = 0;
+  legacyMock.paths = [];
+  legacyMock.callbacksByPath.clear();
+  legacyMock.throwForPaths.clear();
+  legacyMock.closeCount = 0;
+  loggerMock.throwForMessages.clear();
+});
+
+describe("runWorktreeCleanup on a current host", () => {
+  it("opens ONE task_cleanup command covering every approved path", async () => {
+    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
+      "/wt/a",
+      "/wt/b",
+      "/wt/c",
+    ]);
+
+    expect(commandMock.commands).toHaveLength(1);
+    const command = commandMock.commands[0];
+    expect(command.source).toBe("task_cleanup");
+    // A validated UUID: the host's single-flight map rejects anything else, so
+    // a shared constant here would collapse distinct cleanups onto one command.
+    expect(command.commandId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    // `scripts: null` keeps the host reading each worktree's own committed
+    // teardown scripts, as the pre-migration cleanup did.
+    expect(command.targets).toEqual([
+      { worktreePath: "/wt/a", scripts: null },
+      { worktreePath: "/wt/b", scripts: null },
+      { worktreePath: "/wt/c", scripts: null },
+    ]);
+    expect(legacyMock.paths).toEqual([]);
+
+    commandCallbacks().onCommandComplete({
+      requestedCount: 3,
+      deletedCount: 0,
+      failedCount: 3,
+    });
+    await promise;
   });
 
-  it("counts a completed delete as removed", async () => {
+  it("starts no command at all for an empty approved set", async () => {
+    await expect(
+      runWorktreeCleanup(stubOpenStreamTransport(), "host-1", []),
+    ).resolves.toEqual({ removed: [], failed: [], uncertain: [] });
+    expect(commandMock.commands).toEqual([]);
+    expect(legacyMock.paths).toEqual([]);
+  });
+
+  it("tallies per-target outcomes independently of one another", async () => {
+    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
+      "/wt/removed",
+      "/wt/declined",
+      "/wt/busy",
+    ]);
+    reachHost();
+    const callbacks = commandCallbacks();
+    callbacks.onTargetComplete("/wt/removed", true);
+    // A decline is `deleted: false`, not a thrown failure - both are failures
+    // for the tally, and neither stops its siblings.
+    callbacks.onTargetComplete("/wt/declined", false);
+    callbacks.onTargetFailed("/wt/busy", "worktree is busy");
+    callbacks.onCommandComplete({
+      requestedCount: 3,
+      deletedCount: 1,
+      failedCount: 2,
+    });
+
+    await expect(promise).resolves.toEqual({
+      removed: ["/wt/removed"],
+      failed: ["/wt/declined", "/wt/busy"],
+      uncertain: [],
+    });
+  });
+
+  it("reports targets the host settled while detached as unconfirmed", async () => {
+    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
+      "/wt/seen",
+      "/wt/missed",
+    ]);
+    reachHost();
+    commandCallbacks().onTargetComplete("/wt/seen", true);
+    // The host does not replay per-target frames to a late observer, so
+    // `command.complete` is terminal for anything still open.
+    commandCallbacks().onCommandComplete({
+      requestedCount: 2,
+      deletedCount: 2,
+      failedCount: 0,
+    });
+
+    await expect(promise).resolves.toEqual({
+      removed: ["/wt/seen"],
+      failed: [],
+      uncertain: ["/wt/missed"],
+    });
+  });
+
+  it("reports a drop after the command reached the host as unconfirmed, without replaying it", async () => {
+    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
+      "/wt/a",
+      "/wt/b",
+    ]);
+    reachHost();
+    commandCallbacks().onTargetComplete("/wt/a", true);
+    commandCallbacks().onConnectionStatus("reconnecting", null);
+
+    await expect(promise).resolves.toEqual({
+      removed: ["/wt/a"],
+      failed: [],
+      uncertain: ["/wt/b"],
+    });
+    // Detach, not cancel, and not restart: exactly one command was ever opened,
+    // its session was released, and no destructive fallback was started behind
+    // the user's back.
+    expect(commandMock.commands).toHaveLength(1);
+    expect(commandMock.closeCount).toBe(1);
+    expect(legacyMock.paths).toEqual([]);
+  });
+
+  it("reports a drop BEFORE the command reached the host as failed", async () => {
     const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
       "/wt/a",
     ]);
-    callbacksFor("/wt/a").onComplete(true);
-    await expect(promise).resolves.toEqual({ removed: ["/wt/a"], failed: [] });
+    // No `open`: the subscribe frame never got to a live socket, so nothing was
+    // attempted and there is nothing uncertain about it.
+    commandCallbacks().onConnectionStatus("reconnecting", null);
+
+    await expect(promise).resolves.toEqual({
+      removed: [],
+      failed: ["/wt/a"],
+      uncertain: [],
+    });
+    expect(legacyMock.paths).toEqual([]);
   });
 
-  it("counts a soft-failed (deleted:false) delete as failed", async () => {
+  it("reports a host-rejected command as failed", async () => {
+    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
+      "/wt/a",
+      "/wt/b",
+    ]);
+    reachHost();
+    commandCallbacks().onCommandFailed("Worktree service is not ready.");
+
+    await expect(promise).resolves.toEqual({
+      removed: [],
+      failed: ["/wt/a", "/wt/b"],
+      uncertain: [],
+    });
+    // `command.failed` means no work ran or will run - re-running it per target
+    // would be this client inventing a deletion the host declined.
+    expect(legacyMock.paths).toEqual([]);
+  });
+
+  it("ignores normal startup statuses", async () => {
     const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
       "/wt/a",
     ]);
-    callbacksFor("/wt/a").onComplete(false);
-    await expect(promise).resolves.toEqual({ removed: [], failed: ["/wt/a"] });
-  });
+    commandCallbacks().onConnectionStatus("connecting", null);
+    reachHost();
+    commandCallbacks().onTargetComplete("/wt/a", true);
+    commandCallbacks().onCommandComplete({
+      requestedCount: 1,
+      deletedCount: 1,
+      failedCount: 0,
+    });
 
-  it("counts a host decline as failed", async () => {
+    await expect(promise).resolves.toEqual({
+      removed: ["/wt/a"],
+      failed: [],
+      uncertain: [],
+    });
+  });
+});
+
+describe("runWorktreeCleanup on an older host", () => {
+  it("falls back to the bounded per-target fan-out", async () => {
     const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
       "/wt/a",
+      "/wt/b",
+      "/wt/c",
     ]);
-    callbacksFor("/wt/a").onFailed("busy");
-    await expect(promise).resolves.toEqual({ removed: [], failed: ["/wt/a"] });
+    // Reported from the openAck compatibility check, BEFORE any subscribe frame
+    // reached the host - which is what makes re-issuing the work safe.
+    reportUnsupported();
+
+    // Two at a time, exactly as the pre-migration cleanup ran.
+    expect(legacyMock.paths).toEqual(["/wt/a", "/wt/b"]);
+    legacyCallbacksFor("/wt/a").onComplete(true);
+    await vi.waitFor(() => expect(legacyMock.paths).toHaveLength(3));
+
+    legacyCallbacksFor("/wt/b").onComplete(false);
+    legacyCallbacksFor("/wt/c").onFailed("busy");
+
+    await expect(promise).resolves.toEqual({
+      removed: ["/wt/a"],
+      failed: ["/wt/b", "/wt/c"],
+      uncertain: [],
+    });
+    // The batch attempt started nothing, so the fan-out is the only deletion.
+    expect(commandMock.commands).toHaveLength(1);
+    expect(commandMock.closeCount).toBe(1);
   });
 
   // Regression: a recoverable drop (`reconnecting`, reason null) before any
   // terminal frame must fail fast - count the path failed, tear the session down
   // (exactly one subscribe, no reconnect re-run), and let the overall promise
-  // settle so the summary toast + cache invalidation still fire.
-  it("fails fast and settles when the stream drops before a terminal frame", async () => {
+  // settle so the summary toast + cache invalidation still fire. Unchanged by
+  // the migration: an older host has no command to keep running without us.
+  it("fails fast and settles when a per-target stream drops", async () => {
     const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
       "/wt/a",
     ]);
-    callbacksFor("/wt/a").onConnectionStatus("reconnecting", null);
-    await expect(promise).resolves.toEqual({ removed: [], failed: ["/wt/a"] });
-    // Exactly one subscribe, and the session was torn down so the transport's
-    // reconnect loop can't re-issue it.
-    expect(streamMock.paths).toEqual(["/wt/a"]);
-    expect(streamMock.closeCount).toBe(1);
+    reportUnsupported();
+    legacyCallbacksFor("/wt/a").onConnectionStatus("reconnecting", null);
+
+    await expect(promise).resolves.toEqual({
+      removed: [],
+      failed: ["/wt/a"],
+      uncertain: [],
+    });
+    expect(legacyMock.paths).toEqual(["/wt/a"]);
+    expect(legacyMock.closeCount).toBe(1);
   });
 
-  it("treats a close before a terminal frame as a failure", async () => {
+  it("treats a per-target close before a terminal frame as a failure", async () => {
     const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
       "/wt/a",
     ]);
-    callbacksFor("/wt/a").onConnectionStatus("closed", null);
-    await expect(promise).resolves.toEqual({ removed: [], failed: ["/wt/a"] });
+    reportUnsupported();
+    legacyCallbacksFor("/wt/a").onConnectionStatus("closed", null);
+
+    await expect(promise).resolves.toEqual({
+      removed: [],
+      failed: ["/wt/a"],
+      uncertain: [],
+    });
   });
 
-  it("ignores normal startup statuses until a terminal frame arrives", async () => {
+  // The cleanup runner's standing invariant is that its promise ALWAYS settles:
+  // the Tasks are already deleted by the time it runs, so a promise that hangs
+  // costs the user their combined toast and the worktree cache invalidation,
+  // silently.
+  //
+  // This drives the one region of the fan-out that can actually break it, end to
+  // end rather than by stubbing a rejected promise: an open failure lands in
+  // `deleteOneWorktree`'s catch, whose only statement before `finish` is the log
+  // call. A log sink that throws there escapes the promise executor, so
+  // `deleteOneWorktree` REJECTS - which rejects its worker, which rejects
+  // `Promise.all`, which rejects `runFallbackCleanup`, which is the hand-off's
+  // rejection branch.
+  it("still settles when the per-target fan-out itself rejects", async () => {
+    legacyMock.throwForPaths.add("/wt/a");
+    loggerMock.throwForMessages.add(
+      "[worktree-cleanup] failed to open delete stream",
+    );
+
+    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
+      "/wt/a",
+      "/wt/b",
+    ]);
+    reportUnsupported();
+
+    // Both paths went out before the fan-out came apart.
+    expect(legacyMock.paths).toEqual(["/wt/a", "/wt/b"]);
+    // Unconfirmed, not failed: the fan-out aborted at an unknown point, so a
+    // removal that already landed is real and "couldn't be removed" would be a
+    // false claim about the filesystem. And nothing is retried - an unknown
+    // destructive outcome is exactly what must not be replayed.
+    await expect(promise).resolves.toEqual({
+      removed: [],
+      failed: [],
+      uncertain: ["/wt/a", "/wt/b"],
+    });
+  });
+
+  it("ignores normal per-target startup statuses until a terminal frame arrives", async () => {
     const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
       "/wt/a",
     ]);
-    callbacksFor("/wt/a").onConnectionStatus("connecting", null);
-    callbacksFor("/wt/a").onConnectionStatus("open", null);
-    callbacksFor("/wt/a").onComplete(true);
-    await expect(promise).resolves.toEqual({ removed: ["/wt/a"], failed: [] });
-  });
+    reportUnsupported();
+    legacyCallbacksFor("/wt/a").onConnectionStatus("connecting", null);
+    legacyCallbacksFor("/wt/a").onConnectionStatus("open", null);
+    legacyCallbacksFor("/wt/a").onComplete(true);
 
-  it("settles a mixed batch of outcomes", async () => {
-    const promise = runWorktreeCleanup(stubOpenStreamTransport(), "host-1", [
-      "/wt/removed",
-      "/wt/dropped",
-    ]);
-    callbacksFor("/wt/removed").onComplete(true);
-    callbacksFor("/wt/dropped").onConnectionStatus("reconnecting", null);
-    const outcome = await promise;
-    expect(outcome.removed).toEqual(["/wt/removed"]);
-    expect(outcome.failed).toEqual(["/wt/dropped"]);
+    await expect(promise).resolves.toEqual({
+      removed: ["/wt/a"],
+      failed: [],
+      uncertain: [],
+    });
   });
 });

--- a/clients/gui-app/src/lib/epics/run-worktree-cleanup.ts
+++ b/clients/gui-app/src/lib/epics/run-worktree-cleanup.ts
@@ -1,4 +1,5 @@
 import { WorktreeDeleteStreamClient } from "@traycer-clients/shared/host-transport/worktree-delete-stream-client";
+import { WorktreeDeleteBatchStreamClient } from "@traycer-clients/shared/host-transport/worktree-delete-batch-stream-client";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
 import { openOwnedDurableStreamClient } from "@/lib/host/owned-durable-stream-client";
 import { appLogger } from "@/lib/logger";
@@ -6,39 +7,257 @@ import { appLogger } from "@/lib/logger";
 export interface WorktreeCleanupOutcome {
   readonly removed: ReadonlyArray<string>;
   readonly failed: ReadonlyArray<string>;
+  /**
+   * Paths whose outcome this client never learned: the command reached the
+   * host and then the observation dropped, so the removal may or may not have
+   * happened.
+   *
+   * Kept apart from `failed` because the two demand different copy. "Couldn't
+   * be removed" is a claim about the filesystem; this is a claim about what we
+   * observed. The host owns the command either way and writes the durable
+   * completion notification with the real counts.
+   */
+  readonly uncertain: ReadonlyArray<string>;
 }
 
-// Each `worktree.deleteByPath` stream may run teardown scripts plus a git
-// removal; cap fanout so a large multi-Task deletion cannot saturate the host
-// or the websocket transport. Mirrors the Settings delete runner's cap.
+const EMPTY_OUTCOME: WorktreeCleanupOutcome = {
+  removed: [],
+  failed: [],
+  uncertain: [],
+};
+
+// Fan-out cap for the FALLBACK path only (an older host with no batch command
+// method). On a current host the cleanup is one command and the host schedules
+// its targets, where the cap can actually bound the machine rather than one
+// window's share of it.
 const MAX_PARALLEL_CLEANUP_STREAMS = 2;
 
 /**
- * Runs the post-Task-deletion worktree cleanup: one `worktree.deleteByPath@1.0`
- * stream per approved path, bounded to {@link MAX_PARALLEL_CLEANUP_STREAMS} in
- * flight, resolving once every path has reached a terminal outcome.
+ * Runs the post-Task-deletion worktree cleanup for the paths whose owning Tasks
+ * all deleted successfully, resolving once every path has an outcome.
+ *
+ * On a current host this is ONE `worktree.deleteBatchByPath@1.0` command. That
+ * is the point of the migration: the renderer used to be the only place that
+ * knew a multi-Task cleanup was one user action, so the host could not attribute
+ * a durable completion notification to it and could not finish the work if this
+ * window went away. Now it can do both, and the `task_cleanup` source is what
+ * lets the resulting row say where the deletion came from.
+ *
+ * On an older host - one whose handshake rejects the batch method outright,
+ * before any subscribe frame asks it to delete anything - the previous bounded
+ * per-path fan-out runs instead, unchanged.
  *
  * This is intentionally NOT wired into the Settings `useWorktreeDeleteRun`
  * store: that store owns the Settings progress modal / strip / backgrounding
- * UX. The Task-delete flow only needs a removed/failed tally for its summary
- * toast, so it drives the lower-level stream client directly with `scripts:
- * null` (the host resolves each worktree's own committed teardown scripts).
+ * UX. The Task-delete flow only needs a tally for its combined summary toast,
+ * so it drives the stream clients directly with `scripts: null` (the host
+ * resolves each worktree's own committed teardown scripts).
  *
- * The host-side busy-check stays intact: a path that became in-use after the
- * dialog opened is declined and lands in `failed`, never silently force-removed.
- *
- * Every per-path delete settles: on an app terminal frame (`complete`/`failed`),
- * on the FIRST connection drop after start (`reconnecting`/`closed`), or on a
- * synchronous open failure. A drop is counted as `failed` and the session is
- * torn down immediately so the transport's reconnect loop can't re-issue the
- * `subscribe` frame (which would re-run the host delete pipeline) - so exactly
- * one subscribe is ever sent per path, and the overall promise always resolves.
+ * The host-side busy-check stays intact on both paths: a path that became
+ * in-use after the dialog opened is declined and lands in `failed`, never
+ * silently force-removed.
  */
-export async function runWorktreeCleanup(
+export function runWorktreeCleanup(
   openStreamTransport: (hostId: string) => DurableStreamTransport,
   hostId: string,
   paths: ReadonlyArray<string>,
 ): Promise<WorktreeCleanupOutcome> {
+  // No approved paths is not a command. Opening one would burn a `commandId`
+  // and ask the host for a "you deleted nothing" notification row.
+  if (paths.length === 0) return Promise.resolve(EMPTY_OUTCOME);
+  return runCleanupCommand(openStreamTransport, hostId, paths);
+}
+
+/**
+ * Opens one host-owned deletion command over every approved path and reports
+ * what it observed.
+ *
+ * Observation and execution are separate here, which is what makes the drop
+ * handling safe. Detaching never cancels: whatever this promise resolves with,
+ * the host keeps deleting the remaining targets and still writes the completion
+ * notification. So when the socket drops there is nothing to replay and nothing
+ * to wait for - the honest move is to stop observing, report the unfinished
+ * paths as uncertain, and let the durable row carry the real result.
+ */
+function runCleanupCommand(
+  openStreamTransport: (hostId: string) => DurableStreamTransport,
+  hostId: string,
+  paths: ReadonlyArray<string>,
+): Promise<WorktreeCleanupOutcome> {
+  return new Promise<WorktreeCleanupOutcome>((resolve) => {
+    const removed: string[] = [];
+    const failed: string[] = [];
+    const pending = new Set(paths);
+    const holder = newCloseHolder();
+    const state = { settled: false, reachedHost: false };
+
+    const settle = (unsettledAre: "failed" | "uncertain"): void => {
+      if (state.settled) return;
+      state.settled = true;
+      requestClose(holder);
+      const unsettled = [...pending];
+      pending.clear();
+      resolve({
+        removed,
+        failed: unsettledAre === "failed" ? [...failed, ...unsettled] : failed,
+        uncertain: unsettledAre === "uncertain" ? unsettled : [],
+      });
+    };
+    /**
+     * This host has no such method, so the per-path fallback runs the work
+     * instead.
+     *
+     * Safe precisely because `onUnsupported` comes from the openAck
+     * compatibility check - the host never received a subscribe frame, so
+     * nothing was attempted and re-issuing the work cannot double it. Only
+     * still-pending paths are handed over, so a path that somehow already
+     * settled is never deleted twice.
+     */
+    const handOffToFallback = (): void => {
+      if (state.settled) return;
+      state.settled = true;
+      requestClose(holder);
+      const remaining = [...pending];
+      pending.clear();
+      void runFallbackCleanup(openStreamTransport, hostId, remaining).then(
+        (fallback) =>
+          resolve({
+            removed: [...removed, ...fallback.removed],
+            failed: [...failed, ...fallback.failed],
+            uncertain: [],
+          }),
+        (error: unknown) => {
+          // `runFallbackCleanup` has no rejecting path today - every
+          // `deleteOneWorktree` settles, and its open failure is handled inside
+          // the executor. This branch keeps "the result promise always settles"
+          // a property of THIS function rather than one inherited from a
+          // callee's current shape: without it, a future throw anywhere in the
+          // fan-out would strand the combined toast and the cache invalidation
+          // silently, with the Tasks already deleted.
+          //
+          // Resolve BEFORE logging. This handler is the last thing standing
+          // between an unexpected failure and feedback the user never gets, so
+          // nothing in it - not even the log sink - may be able to throw first.
+          //
+          // The remaining paths are uncertain, not failed: the fan-out aborted
+          // at an unknown point, so removals that already happened are real and
+          // claiming "couldn't be removed" would be a false statement about the
+          // filesystem. Nothing is retried - a destructive operation whose
+          // outcome we do not know is exactly what must not be replayed.
+          resolve({ removed, failed, uncertain: remaining });
+          appLogger.warn(
+            "[worktree-cleanup] the per-target fallback failed unexpectedly; those worktrees may or may not have been removed",
+            {
+              hostId,
+              remainingCount: remaining.length,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        },
+      );
+    };
+    const settleTarget = (worktreePath: string, deleted: boolean): void => {
+      if (!pending.delete(worktreePath)) return;
+      if (deleted) {
+        removed.push(worktreePath);
+      } else {
+        failed.push(worktreePath);
+      }
+    };
+
+    try {
+      const owned = openOwnedDurableStreamClient(
+        openStreamTransport,
+        hostId,
+        (wsStreamClient) =>
+          new WorktreeDeleteBatchStreamClient({
+            wsStreamClient,
+            commandId: crypto.randomUUID(),
+            source: "task_cleanup",
+            targets: paths.map((worktreePath) => ({
+              worktreePath,
+              scripts: null,
+            })),
+            callbacks: {
+              // No per-target progress surface in this flow - the Task-delete
+              // summary toast is the only feedback, so phases and teardown
+              // output have nowhere to go.
+              onTargetStarted: () => {},
+              onTargetPhase: () => {},
+              onTargetOutput: () => {},
+              onTargetComplete: (worktreePath, deleted) =>
+                settleTarget(worktreePath, deleted),
+              onTargetFailed: (worktreePath) =>
+                settleTarget(worktreePath, false),
+              // Terminal for the command. Anything still pending is a target
+              // the host settled while this client was away - it does not
+              // replay per-target frames to a late observer.
+              onCommandComplete: () => settle("uncertain"),
+              // No work ran or will run under this subscription: the host
+              // cannot serve the command at all. Nothing was deleted.
+              onCommandFailed: (reason) => {
+                appLogger.warn("[worktree-cleanup] host rejected the command", {
+                  hostId,
+                  reason,
+                });
+                settle("failed");
+              },
+              onUnsupported: () => handOffToFallback(),
+              onConnectionStatus: (status) => {
+                if (status === "open") {
+                  state.reachedHost = true;
+                  return;
+                }
+                if (status !== "reconnecting" && status !== "closed") return;
+                // A drop before the session ever opened means the subscribe
+                // frame never reached the host: nothing was attempted, so the
+                // paths failed rather than being unknown. After it opened the
+                // command exists and keeps running without us.
+                if (!state.reachedHost) {
+                  settle("failed");
+                  return;
+                }
+                if (pending.size > 0) {
+                  appLogger.warn(
+                    "[worktree-cleanup] lost the command stream before it finished; the host is still running it",
+                    { hostId, pendingCount: pending.size, status },
+                  );
+                }
+                settle("uncertain");
+              },
+            },
+          }),
+      );
+      adoptClose(holder, owned.close);
+    } catch (error) {
+      appLogger.warn("[worktree-cleanup] failed to open the command stream", {
+        hostId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      settle("failed");
+    }
+  });
+}
+
+/**
+ * Older-host fallback: one `worktree.deleteByPath@1.0` stream per path, bounded
+ * to {@link MAX_PARALLEL_CLEANUP_STREAMS} in flight.
+ *
+ * Unchanged from the pre-command behaviour on purpose - it is what an older
+ * host can serve, and its outcome shape has no `uncertain` bucket because
+ * nothing on that path survives this client: a dropped single-target stream is
+ * work that stopped, which is what `failed` already means there.
+ *
+ * It is also expected never to reject - each path settles through
+ * {@link deleteOneWorktree}. The caller still handles rejection, because the
+ * "always settles" invariant belongs to the caller's promise, not to this
+ * function's present implementation.
+ */
+async function runFallbackCleanup(
+  openStreamTransport: (hostId: string) => DurableStreamTransport,
+  hostId: string,
+  paths: ReadonlyArray<string>,
+): Promise<{ removed: string[]; failed: string[] }> {
   const removed: string[] = [];
   const failed: string[] = [];
   const queue = [...paths];
@@ -64,29 +283,26 @@ export async function runWorktreeCleanup(
   return { removed, failed };
 }
 
+/**
+ * Every per-path delete settles: on an app terminal frame (`complete`/`failed`),
+ * on the FIRST connection drop after start (`reconnecting`/`closed`), or on a
+ * synchronous open failure. A drop is counted as `failed` and the session is
+ * torn down immediately so the transport's reconnect loop can't re-issue the
+ * `subscribe` frame (which would re-run the host delete pipeline) - so exactly
+ * one subscribe is ever sent per path, and the overall promise always resolves.
+ */
 function deleteOneWorktree(
   openStreamTransport: (hostId: string) => DurableStreamTransport,
   hostId: string,
   worktreePath: string,
 ): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    // Held on an object rather than plain locals so the terminal callbacks (which
-    // may, in the pathological case, fire synchronously inside the constructor
-    // before `close` is assigned) can hand a close request back to the
-    // constructor's return path.
-    const state: {
-      settled: boolean;
-      close: (() => void) | null;
-      closeRequested: boolean;
-    } = { settled: false, close: null, closeRequested: false };
+    const holder = newCloseHolder();
+    const state = { settled: false };
     const finish = (deleted: boolean): void => {
       if (state.settled) return;
       state.settled = true;
-      if (state.close !== null) {
-        state.close();
-      } else {
-        state.closeRequested = true;
-      }
+      requestClose(holder);
       resolve(deleted);
     };
 
@@ -130,8 +346,7 @@ function deleteOneWorktree(
             },
           }),
       );
-      state.close = owned.close;
-      if (state.closeRequested) owned.close();
+      adoptClose(holder, owned.close);
     } catch (error) {
       appLogger.warn("[worktree-cleanup] failed to open delete stream", {
         worktreePath,
@@ -140,4 +355,33 @@ function deleteOneWorktree(
       finish(false);
     }
   });
+}
+
+/**
+ * Holds a stream client's `close` for callbacks that may, in the pathological
+ * case, fire synchronously inside the constructor - before
+ * `openOwnedDurableStreamClient` has returned the handle that closes it. A
+ * close requested in that window is applied the moment the handle exists, so a
+ * session can never be left open with nobody holding it.
+ */
+interface CloseHolder {
+  close: (() => void) | null;
+  closeRequested: boolean;
+}
+
+function newCloseHolder(): CloseHolder {
+  return { close: null, closeRequested: false };
+}
+
+function requestClose(holder: CloseHolder): void {
+  if (holder.close === null) {
+    holder.closeRequested = true;
+    return;
+  }
+  holder.close();
+}
+
+function adoptClose(holder: CloseHolder, close: () => void): void {
+  holder.close = close;
+  if (holder.closeRequested) close();
 }

--- a/clients/gui-app/src/lib/epics/run-worktree-cleanup.ts
+++ b/clients/gui-app/src/lib/epics/run-worktree-cleanup.ts
@@ -1,5 +1,6 @@
 import { WorktreeDeleteStreamClient } from "@traycer-clients/shared/host-transport/worktree-delete-stream-client";
 import { WorktreeDeleteBatchStreamClient } from "@traycer-clients/shared/host-transport/worktree-delete-batch-stream-client";
+import type { WorktreeDeletionSource } from "@traycer/protocol/host/worktree-delete-batch-stream";
 import type { DurableStreamTransport } from "@/lib/host/durable-stream-transport";
 import { openOwnedDurableStreamClient } from "@/lib/host/owned-durable-stream-client";
 import { appLogger } from "@/lib/logger";
@@ -33,15 +34,17 @@ const EMPTY_OUTCOME: WorktreeCleanupOutcome = {
 const MAX_PARALLEL_CLEANUP_STREAMS = 2;
 
 /**
- * Runs the post-Task-deletion worktree cleanup for the paths whose owning Tasks
- * all deleted successfully, resolving once every path has an outcome.
+ * Runs one user-approved, multi-path worktree cleanup, resolving once every
+ * path has an observed outcome.
  *
  * On a current host this is ONE `worktree.deleteBatchByPath@1.0` command. That
  * is the point of the migration: the renderer used to be the only place that
- * knew a multi-Task cleanup was one user action, so the host could not attribute
- * a durable completion notification to it and could not finish the work if this
- * window went away. Now it can do both, and the `task_cleanup` source is what
- * lets the resulting row say where the deletion came from.
+ * knew the paths were one user action, so the host could not attribute a
+ * durable completion notification to it and could not finish the work if this
+ * window went away. Now it can do both. The caller supplies the durable source
+ * (`task_cleanup` after deleting Tasks, `task_sweep` for the standalone Sweep
+ * action) so telemetry and future presentation can distinguish the workflows
+ * without adding a notification kind.
  *
  * On an older host - one whose handshake rejects the batch method outright,
  * before any subscribe frame asks it to delete anything - the previous bounded
@@ -49,8 +52,8 @@ const MAX_PARALLEL_CLEANUP_STREAMS = 2;
  *
  * This is intentionally NOT wired into the Settings `useWorktreeDeleteRun`
  * store: that store owns the Settings progress modal / strip / backgrounding
- * UX. The Task-delete flow only needs a tally for its combined summary toast,
- * so it drives the stream clients directly with `scripts: null` (the host
+ * UX. Task deletion and Sweep only need a tally for their summary toasts, so
+ * they drive the stream clients directly with `scripts: null` (the host
  * resolves each worktree's own committed teardown scripts).
  *
  * The host-side busy-check stays intact on both paths: a path that became
@@ -61,11 +64,12 @@ export function runWorktreeCleanup(
   openStreamTransport: (hostId: string) => DurableStreamTransport,
   hostId: string,
   paths: ReadonlyArray<string>,
+  source: WorktreeDeletionSource,
 ): Promise<WorktreeCleanupOutcome> {
   // No approved paths is not a command. Opening one would burn a `commandId`
   // and ask the host for a "you deleted nothing" notification row.
   if (paths.length === 0) return Promise.resolve(EMPTY_OUTCOME);
-  return runCleanupCommand(openStreamTransport, hostId, paths);
+  return runCleanupCommand(openStreamTransport, hostId, paths, source);
 }
 
 /**
@@ -83,6 +87,7 @@ function runCleanupCommand(
   openStreamTransport: (hostId: string) => DurableStreamTransport,
   hostId: string,
   paths: ReadonlyArray<string>,
+  source: WorktreeDeletionSource,
 ): Promise<WorktreeCleanupOutcome> {
   return new Promise<WorktreeCleanupOutcome>((resolve) => {
     const removed: string[] = [];
@@ -173,7 +178,7 @@ function runCleanupCommand(
           new WorktreeDeleteBatchStreamClient({
             wsStreamClient,
             commandId: crypto.randomUUID(),
-            source: "task_cleanup",
+            source,
             targets: paths.map((worktreePath) => ({
               worktreePath,
               scripts: null,

--- a/clients/gui-app/src/lib/host/__tests__/host-directory-service.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/host-directory-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import { mockRemoteHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
 import type { LocalHostSnapshot } from "@traycer-clients/shared/platform/runner-host";
@@ -34,6 +34,10 @@ function makeHost(localHost: LocalHostSnapshot | null): MockRunnerHost {
 }
 
 describe("HostDirectoryService", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("seeds the local entry from the runner-host onLocalHostChange subscription", async () => {
     const host = makeHost(localSnapshot);
     const directory = new HostDirectoryService({
@@ -538,7 +542,6 @@ describe("HostDirectoryService", () => {
           { source: "direct_ui", host_kind: "local" },
         ],
       ]);
-      track.mockRestore();
     });
   });
 });

--- a/clients/gui-app/src/lib/host/__tests__/host-directory-service.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/host-directory-service.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
 import { mockRemoteHostEntry } from "@traycer-clients/shared/host-client/mock/mock-host-directory";
 import type { LocalHostSnapshot } from "@traycer-clients/shared/platform/runner-host";
 import type { HostDirectoryEntry } from "@traycer-clients/shared/host-client/host-directory";
 import { HostDirectoryService } from "@/lib/host/host-directory-service";
+import { Analytics, AnalyticsEvent } from "@/lib/analytics";
 
 const localSnapshot: LocalHostSnapshot = {
   hostId: "desktop-pid-123",
@@ -411,5 +412,133 @@ describe("HostDirectoryService", () => {
     expect(directory.findById(localSnapshot.hostId)?.kind).toBe("local");
     expect(directory.findById(mockRemoteHostEntry.hostId)?.kind).toBe("remote");
     expect(directory.findById("missing")).toBeNull();
+  });
+
+  /**
+   * A transient activation (today: a native notification whose row was minted
+   * on another host) has to move the app WITHOUT claiming the user picked
+   * that host. Same binding authority, no durable intent - which is exactly
+   * what makes it recoverable when that host goes away.
+   */
+  describe("selectTransientById", () => {
+    it("binds through the same selection listener as an explicit pick", async () => {
+      const host = makeHost(localSnapshot);
+      const directory = new HostDirectoryService({
+        runnerHost: host,
+        remoteFetcher: () => Promise.resolve([mockRemoteHostEntry]),
+      });
+      await directory.start();
+
+      const observed: Array<HostDirectoryEntry | null> = [];
+      directory.onSelectionChange((entry) => {
+        observed.push(entry);
+      });
+
+      directory.selectTransientById(mockRemoteHostEntry.hostId, "notification");
+
+      expect(observed.map((entry) => entry?.hostId ?? null)).toEqual([
+        mockRemoteHostEntry.hostId,
+      ]);
+      expect(directory.getSelected()?.hostId).toBe(mockRemoteHostEntry.hostId);
+    });
+
+    it("hands back to the default host when the activated entry leaves the directory", async () => {
+      // The whole point of the transient seam. `selectById` would have pinned
+      // `explicitSelection` here, and the app would sit unbound for the rest
+      // of the session with a perfectly good local host in the directory.
+      const host = makeHost(localSnapshot);
+      let remotes: readonly HostDirectoryEntry[] = [mockRemoteHostEntry];
+      const directory = new HostDirectoryService({
+        runnerHost: host,
+        remoteFetcher: () => Promise.resolve(remotes),
+      });
+      await directory.start();
+
+      directory.selectTransientById(mockRemoteHostEntry.hostId, "notification");
+      expect(directory.getSelected()?.hostId).toBe(mockRemoteHostEntry.hostId);
+
+      const observed: Array<HostDirectoryEntry | null> = [];
+      directory.onSelectionChange((entry) => {
+        observed.push(entry);
+      });
+
+      remotes = [];
+      await directory.refresh();
+
+      // One transition, straight to the default - not an unbind followed by a
+      // later re-promotion, which would flap the app-wide host binding.
+      expect(observed.map((entry) => entry?.hostId ?? null)).toEqual([
+        localSnapshot.hostId,
+      ]);
+      expect(directory.getSelected()?.hostId).toBe(localSnapshot.hostId);
+    });
+
+    it("keeps an explicit pick pinned when ITS host leaves the directory", async () => {
+      // The contrast case, asserted so the transient seam cannot be
+      // generalised into "always fall back": a user who chose a host is not
+      // silently moved to another one.
+      const host = makeHost(localSnapshot);
+      let remotes: readonly HostDirectoryEntry[] = [mockRemoteHostEntry];
+      const directory = new HostDirectoryService({
+        runnerHost: host,
+        remoteFetcher: () => Promise.resolve(remotes),
+      });
+      await directory.start();
+
+      directory.selectById(mockRemoteHostEntry.hostId);
+      remotes = [];
+      await directory.refresh();
+
+      expect(directory.getSelected()).toBeNull();
+    });
+
+    it("is a no-op for an id the directory does not hold, never an unbind", async () => {
+      const host = makeHost(localSnapshot);
+      const directory = new HostDirectoryService({
+        runnerHost: host,
+        remoteFetcher: null,
+      });
+      await directory.start();
+      expect(directory.getSelected()?.hostId).toBe(localSnapshot.hostId);
+
+      const observed: Array<HostDirectoryEntry | null> = [];
+      directory.onSelectionChange((entry) => {
+        observed.push(entry);
+      });
+
+      directory.selectTransientById("host-that-left", "notification");
+
+      expect(observed).toEqual([]);
+      expect(directory.getSelected()?.hostId).toBe(localSnapshot.hostId);
+    });
+
+    it("attributes the selection to the caller's analytics source", async () => {
+      const track = vi.spyOn(Analytics.getInstance(), "track");
+      const host = makeHost(localSnapshot);
+      const directory = new HostDirectoryService({
+        runnerHost: host,
+        remoteFetcher: () => Promise.resolve([mockRemoteHostEntry]),
+      });
+      await directory.start();
+
+      directory.selectTransientById(mockRemoteHostEntry.hostId, "notification");
+      directory.selectById(localSnapshot.hostId);
+
+      expect(
+        track.mock.calls.filter(
+          (call) => call[0] === AnalyticsEvent.HostSelected,
+        ),
+      ).toEqual([
+        [
+          AnalyticsEvent.HostSelected,
+          { source: "notification", host_kind: "remote" },
+        ],
+        [
+          AnalyticsEvent.HostSelected,
+          { source: "direct_ui", host_kind: "local" },
+        ],
+      ]);
+      track.mockRestore();
+    });
   });
 });

--- a/clients/gui-app/src/lib/host/host-directory-service.ts
+++ b/clients/gui-app/src/lib/host/host-directory-service.ts
@@ -10,7 +10,11 @@ import type {
 } from "@traycer-clients/shared/platform/runner-host";
 import type { Disposable } from "@traycer-clients/shared/platform/uri-callback";
 import { appLogger } from "@/lib/logger";
-import { Analytics, AnalyticsEvent } from "@/lib/analytics";
+import {
+  Analytics,
+  AnalyticsEvent,
+  type AnalyticsSource,
+} from "@/lib/analytics";
 
 export interface HostDirectoryServiceOptions {
   readonly runnerHost: IRunnerHost;
@@ -159,6 +163,44 @@ export class HostDirectoryService implements IHostDirectoryService {
     this.setSelected(entry);
   }
 
+  /**
+   * Binds a host for the CURRENT app context without recording it as the
+   * user's chosen host.
+   *
+   * Same single binding authority as `selectById` - it goes through
+   * `setSelected`, so `HostRuntime` still performs exactly one synchronous
+   * `hostClient.bind(entry)` and the directory and client cannot disagree.
+   * What it deliberately does NOT write is `explicitSelection`: activating a
+   * host to show a notification's destination moves the app, it does not
+   * answer "which host do you work on". Leaving that intent unset is what
+   * lets `reconcileSelection` promote `getDefaultEntry()` again if the
+   * activated host later leaves the directory - a durable pin would strand
+   * the session unbound on a host that no longer exists.
+   *
+   * `source` is the caller's analytics attribution: this seam is about
+   * selection LIFETIME, not about who triggered it, so the entry point names
+   * itself rather than being assumed here.
+   *
+   * An id the directory does not currently hold is a no-op, never a clear: a
+   * transient activation must not be able to unbind the app.
+   */
+  selectTransientById(hostId: string, source: AnalyticsSource): void {
+    const entry = this.findById(hostId);
+    appLogger.debug("[host-directory] transient host activation requested", {
+      hostId,
+      resolved: entry !== null,
+      source,
+    });
+    if (entry === null) {
+      return;
+    }
+    Analytics.getInstance().track(AnalyticsEvent.HostSelected, {
+      source,
+      host_kind: entry.kind === "remote" ? "remote" : "local",
+    });
+    this.setSelected(entry);
+  }
+
   getLocalEntry(): HostDirectoryEntry | null {
     return this.localEntry;
   }
@@ -262,37 +304,49 @@ export class HostDirectoryService implements IHostDirectoryService {
   private reconcileSelection(): void {
     if (this.selected !== null) {
       const fresh = this.findById(this.selected.hostId);
-      if (fresh === null) {
-        this.setSelected(null);
+      if (fresh !== null) {
+        if (fresh !== this.selected) {
+          this.selected = fresh;
+          appLogger.debug(
+            "[host-directory] effective host selection refreshed",
+            {
+              hostId: fresh.hostId,
+              kind: fresh.kind,
+              hasWebsocketUrl: fresh.websocketUrl !== null,
+            },
+          );
+          for (const handler of this.selectionListeners) {
+            handler(fresh);
+          }
+        }
         return;
       }
-      if (fresh !== this.selected) {
-        this.selected = fresh;
-        appLogger.debug("[host-directory] effective host selection refreshed", {
-          hostId: fresh.hostId,
-          kind: fresh.kind,
-          hasWebsocketUrl: fresh.websocketUrl !== null,
-        });
-        for (const handler of this.selectionListeners) {
-          handler(fresh);
-        }
-      }
-      return;
+      // The selected host left the directory. Fall through to resolve the
+      // next selection from INTENT rather than clearing and waiting for a
+      // later pass: a selection with no durable intent behind it (a transient
+      // notification activation) hands straight back to the default host in
+      // one transition, instead of leaving the app unbound until the next
+      // refresh happens to arrive. An explicit pick still resolves to the
+      // same `null` it always did - the user chose that host, so we do not
+      // silently move them somewhere else.
     }
+    this.setSelected(this.selectionFromIntent());
+  }
+
+  /**
+   * The selection implied by durable intent alone, ignoring whatever is
+   * currently selected: the user's explicit pick while the directory can
+   * still resolve it, their explicit clear when they made one, and otherwise
+   * the auto-promoted default host.
+   */
+  private selectionFromIntent(): HostDirectoryEntry | null {
     if (this.explicitSelection !== null) {
       if (this.explicitSelection.hostId === null) {
-        return;
+        return null;
       }
-      const explicitEntry = this.findById(this.explicitSelection.hostId);
-      if (explicitEntry !== null) {
-        this.setSelected(explicitEntry);
-      }
-      return;
+      return this.findById(this.explicitSelection.hostId);
     }
-    const defaultEntry = this.getDefaultEntry();
-    if (defaultEntry !== null) {
-      this.setSelected(defaultEntry);
-    }
+    return this.getDefaultEntry();
   }
 
   private emit(): void {

--- a/clients/gui-app/src/lib/notifications/__tests__/host-surface-routing.test.ts
+++ b/clients/gui-app/src/lib/notifications/__tests__/host-surface-routing.test.ts
@@ -10,7 +10,11 @@ import {
   installTabSyncCoordinator,
 } from "@/lib/tab-sync/tab-sync-coordinator";
 import { useTabsStore } from "@/stores/tabs/store";
-import { useWorktreesSettingsViewStore } from "@/stores/settings/worktrees-settings-view-store";
+import {
+  DEFAULT_WORKTREE_SORT_MODE,
+  EMPTY_WORKTREE_TIER_FILTERS,
+  useWorktreesSettingsViewStore,
+} from "@/stores/settings/worktrees-settings-view-store";
 
 /**
  * The `hostSurface` destination family: a notification about a host-managed
@@ -24,6 +28,11 @@ describe("host surface notification routing", () => {
     await Promise.resolve();
     await Promise.resolve();
     useTabsStore.getState().closeSystemTab("settings");
+    useWorktreesSettingsViewStore.setState({
+      searchText: "",
+      sortMode: DEFAULT_WORKTREE_SORT_MODE,
+      tierFilters: EMPTY_WORKTREE_TIER_FILTERS,
+    });
   });
 
   it("opens Settings → Worktrees and remembers the section on the tab", () => {

--- a/clients/gui-app/src/lib/notifications/__tests__/host-surface-routing.test.ts
+++ b/clients/gui-app/src/lib/notifications/__tests__/host-surface-routing.test.ts
@@ -4,6 +4,11 @@ import {
   parseNotificationPayload,
   routeNotification,
 } from "@/lib/notifications/payload";
+import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
+import {
+  __resetTabSyncCoordinatorForTesting,
+  installTabSyncCoordinator,
+} from "@/lib/tab-sync/tab-sync-coordinator";
 import { useTabsStore } from "@/stores/tabs/store";
 import { useWorktreesSettingsViewStore } from "@/stores/settings/worktrees-settings-view-store";
 
@@ -12,7 +17,12 @@ import { useWorktreesSettingsViewStore } from "@/stores/settings/worktrees-setti
  * resource opens a host surface, not a document inside an epic.
  */
 describe("host surface notification routing", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    __resetTabNavigationControllerForTesting();
+    __resetTabSyncCoordinatorForTesting();
+    installTabSyncCoordinator({ readyPromise: Promise.resolve() });
+    await Promise.resolve();
+    await Promise.resolve();
     useTabsStore.getState().closeSystemTab("settings");
   });
 
@@ -24,7 +34,9 @@ describe("host surface notification routing", () => {
       1_000,
     );
 
-    expect(navigate).toHaveBeenCalledWith({ to: "/settings/worktrees" });
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "/settings/worktrees" }),
+    );
     expect(useTabsStore.getState().systemTabs.settings?.lastPath).toBe(
       "/settings/worktrees",
     );
@@ -69,7 +81,9 @@ describe("host surface notification routing", () => {
       1_000,
     );
 
-    expect(navigate).toHaveBeenCalledWith({ to: "/settings/worktrees" });
+    expect(navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "/settings/worktrees" }),
+    );
   });
 
   it("is routable with or without a focus hint", () => {

--- a/clients/gui-app/src/lib/notifications/__tests__/host-surface-routing.test.ts
+++ b/clients/gui-app/src/lib/notifications/__tests__/host-surface-routing.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isNotificationPayloadRoutable,
+  parseNotificationPayload,
+  routeNotification,
+} from "@/lib/notifications/payload";
+import { useTabsStore } from "@/stores/tabs/store";
+import { useWorktreesSettingsViewStore } from "@/stores/settings/worktrees-settings-view-store";
+
+/**
+ * The `hostSurface` destination family: a notification about a host-managed
+ * resource opens a host surface, not a document inside an epic.
+ */
+describe("host surface notification routing", () => {
+  beforeEach(() => {
+    useTabsStore.getState().closeSystemTab("settings");
+  });
+
+  it("opens Settings → Worktrees and remembers the section on the tab", () => {
+    const navigate = vi.fn();
+    routeNotification(
+      navigate,
+      { kind: "hostSurface", surface: "worktreeSettings", focus: undefined },
+      1_000,
+    );
+
+    expect(navigate).toHaveBeenCalledWith({ to: "/settings/worktrees" });
+    expect(useTabsStore.getState().systemTabs.settings?.lastPath).toBe(
+      "/settings/worktrees",
+    );
+  });
+
+  it("leaves the panel's saved search, sort, and tier filters untouched", () => {
+    const view = useWorktreesSettingsViewStore.getState();
+    view.setSearchText("acme/api");
+    view.toggleTierFilter("merged");
+    const before = useWorktreesSettingsViewStore.getState();
+
+    routeNotification(
+      vi.fn(),
+      { kind: "hostSurface", surface: "worktreeSettings", focus: undefined },
+      1_000,
+    );
+
+    // Filters live in a panel-scoped store rather than the route, so
+    // activation returns the user to the list they had set up - the row must
+    // not smuggle a view reset in through navigation.
+    const after = useWorktreesSettingsViewStore.getState();
+    expect(after.searchText).toBe("acme/api");
+    expect(after.sortMode).toBe(before.sortMode);
+    expect([...after.tierFilters]).toEqual([...before.tierFilters]);
+  });
+
+  // Forward-compatibility placeholder, NOT coverage of focus-resolution
+  // logic: `focus` is parsed and typed but no surface consumes it yet, and no
+  // producer emits one. The router dispatches on `surface` alone, so a hint it
+  // cannot use is structurally incapable of blocking navigation. This pins
+  // that property so the first surface to actually READ a hint has to keep
+  // the parent-surface fallback rather than inherit a dead-end activation.
+  it("ignores a focus hint it cannot use and still opens the parent surface", () => {
+    const navigate = vi.fn();
+    routeNotification(
+      navigate,
+      {
+        kind: "hostSurface",
+        surface: "worktreeSettings",
+        focus: { resourceId: "worktree-deleted-an-hour-ago" },
+      },
+      1_000,
+    );
+
+    expect(navigate).toHaveBeenCalledWith({ to: "/settings/worktrees" });
+  });
+
+  it("is routable with or without a focus hint", () => {
+    expect(
+      isNotificationPayloadRoutable({
+        kind: "hostSurface",
+        surface: "worktreeSettings",
+        focus: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      isNotificationPayloadRoutable({
+        kind: "hostSurface",
+        surface: "worktreeSettings",
+        focus: { resourceId: "gone" },
+      }),
+    ).toBe(true);
+  });
+
+  it("parses a native activation envelope's host-surface route, and degrades on an unknown surface", () => {
+    expect(
+      parseNotificationPayload({
+        kind: "hostSurface",
+        surface: "worktreeSettings",
+      }),
+    ).toEqual({
+      kind: "hostSurface",
+      surface: "worktreeSettings",
+      focus: undefined,
+    });
+    // A surface only a NEWER build knows must open the notification centre
+    // rather than resolve to a guessed route.
+    expect(
+      parseNotificationPayload({ kind: "hostSurface", surface: "testBoxes" }),
+    ).toBeNull();
+  });
+});

--- a/clients/gui-app/src/lib/notifications/notification-display.ts
+++ b/clients/gui-app/src/lib/notifications/notification-display.ts
@@ -7,7 +7,7 @@ import {
   type MergedNotificationRow,
 } from "@/stores/notifications/merged-notifications";
 import type { AppLocalNotificationEntry } from "@/stores/notifications/app-local-notifications-store";
-import type { HostNotificationEntry } from "@traycer/protocol/host/notifications/contracts";
+import type { HostNotificationEntryV21 } from "@traycer/protocol/host/notifications/contracts";
 import {
   notificationEntityFromHostEntry,
   notificationEntityMatchesPresence,
@@ -116,7 +116,7 @@ function renderNotificationToast(
  * its own activity; rows for other entities still display.
  */
 export function displayHostChannelEmission(
-  entries: ReadonlyArray<HostNotificationEntry>,
+  entries: ReadonlyArray<HostNotificationEntryV21>,
   target: NotificationDisplayTarget,
   originHostId: string | null,
 ): void {
@@ -225,6 +225,11 @@ function hostEntityReplaceKey(
     case "epic":
     case "terminal":
       return epicReplaceKey(payload.epicId);
+    // Falls through to the per-row id key. Coalescing by entity is right for
+    // repeated activity ON one chat or epic; two finished commands are two
+    // separate results, and replacing the first toast with the second would
+    // hide a failure behind a later success.
+    case "hostSurface":
     case "session":
       return null;
   }

--- a/clients/gui-app/src/lib/notifications/notification-entity.ts
+++ b/clients/gui-app/src/lib/notifications/notification-entity.ts
@@ -1,5 +1,5 @@
 import type {
-  HostNotificationEntry,
+  HostNotificationEntryV21,
   HostNotificationsEntityRef,
   HostNotificationsPresenceEntity,
 } from "@traycer/protocol/host/notifications/contracts";
@@ -13,7 +13,7 @@ import type {
  * only, whose payloads are renderer-typed.
  */
 export function notificationEntityFromHostEntry(
-  entry: HostNotificationEntry,
+  entry: HostNotificationEntryV21,
 ): HostNotificationsEntityRef | null {
   if (entry.epicId === null) return null;
   return entry.chatId === null

--- a/clients/gui-app/src/lib/notifications/payload.ts
+++ b/clients/gui-app/src/lib/notifications/payload.ts
@@ -440,7 +440,7 @@ export function routeNotification(
  * has just been deleted, so the only honest destination is the list.
  */
 function routeHostSurfaceNotification(
-  navigate: NavigateFn,
+  navigate: NotificationNavigate,
   payload: HostSurfaceNotificationPayload,
 ): void {
   navigateToTabIntent(
@@ -449,6 +449,7 @@ function routeHostSurfaceNotification(
       subSection: HOST_SURFACE_SETTINGS_SECTION[payload.surface],
       resetToGeneral: false,
     }),
+    undefined,
   );
 }
 

--- a/clients/gui-app/src/lib/notifications/payload.ts
+++ b/clients/gui-app/src/lib/notifications/payload.ts
@@ -15,6 +15,8 @@ import {
   navigateToTabIntent,
   openOrFocusEpicIntent,
 } from "@/lib/tab-navigation";
+import { ensureSettingsTab } from "@/lib/commands/actions/open-system-tab";
+import type { SettingsSectionId } from "@/lib/settings-sections";
 import {
   findOpenArtifactInTab,
   useEpicCanvasStore,
@@ -27,7 +29,8 @@ export type NotificationPayloadKind =
   | "approval"
   | "interview"
   | "chat"
-  | "terminal";
+  | "terminal"
+  | "hostSurface";
 
 export interface SessionNotificationPayload {
   readonly kind: "session";
@@ -77,6 +80,27 @@ export interface TerminalNotificationPayload {
   readonly tileInstanceId: string;
 }
 
+/**
+ * A host-managed surface rather than a document inside an epic.
+ *
+ * One destination FAMILY, not one payload kind per operation: the notification
+ * model is expected to grow to test boxes, development environments, and other
+ * host-owned resources, and each of those would otherwise add a transport type
+ * for what is really the same navigation shape. `surface` grows here in client
+ * code - it is never persisted in a notification row, because a durable route
+ * would freeze today's UI into data that outlives it.
+ *
+ * `focus` is a HINT. A surface must always be reachable without it: the
+ * resource a row describes may be gone by the time the row is read (a deleted
+ * worktree, by construction), and failing to resolve a focus target must never
+ * turn into a dead-end activation.
+ */
+export interface HostSurfaceNotificationPayload {
+  readonly kind: "hostSurface";
+  readonly surface: "worktreeSettings";
+  readonly focus: { readonly resourceId: string } | undefined;
+}
+
 export type NotificationPayload =
   | SessionNotificationPayload
   | ArtifactNotificationPayload
@@ -84,7 +108,8 @@ export type NotificationPayload =
   | ApprovalNotificationPayload
   | InterviewNotificationPayload
   | ChatNotificationPayload
-  | TerminalNotificationPayload;
+  | TerminalNotificationPayload
+  | HostSurfaceNotificationPayload;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object";
@@ -211,6 +236,28 @@ function parseInterviewPayload(
   };
 }
 
+/**
+ * Total parse of a host-surface destination. An unknown `surface` yields
+ * `null` (degrade to opening the centre) rather than a payload the router
+ * would have to guess at - a native envelope can arrive from a NEWER build
+ * that knows surfaces this one does not.
+ */
+function parseHostSurfacePayload(
+  value: Record<string, unknown>,
+): HostSurfaceNotificationPayload | null {
+  if (value.surface !== "worktreeSettings") {
+    return null;
+  }
+  const focus = isRecord(value.focus)
+    ? readString(value.focus.resourceId)
+    : null;
+  return {
+    kind: "hostSurface",
+    surface: "worktreeSettings",
+    focus: focus === null ? undefined : { resourceId: focus },
+  };
+}
+
 export function parseNotificationPayload(
   value: unknown,
 ): NotificationPayload | null {
@@ -219,6 +266,8 @@ export function parseNotificationPayload(
   }
 
   switch (value.kind) {
+    case "hostSurface":
+      return parseHostSurfacePayload(value);
     case "session":
       return parseSessionPayload(value);
     case "artifact":
@@ -277,10 +326,13 @@ export function isNotificationPayloadRoutable(
   payload: NotificationPayload,
 ): boolean {
   switch (payload.kind) {
+    // `hostSurface` is always routable: the surface needs no ids to resolve,
+    // and its focus hint is allowed to miss.
     case "epic":
     case "chat":
     case "interview":
     case "terminal":
+    case "hostSurface":
       return true;
     case "approval":
       return payload.epicId !== undefined && payload.chatId !== undefined;
@@ -367,10 +419,54 @@ export function routeNotification(
       );
       return;
     }
+    case "hostSurface":
+      routeHostSurfaceNotification(navigate, payload);
+      return;
     case "session":
       return;
   }
 }
+
+/**
+ * Opens the host-managed surface a row points at.
+ *
+ * Goes through `ensureSettingsTab` rather than navigating to the route
+ * directly so the Settings tab exists, is focused, and REMEMBERS worktrees as
+ * its last section - the same path the command palette and header take. Panel
+ * state that lives outside the route (search text, tier filters, sort) is
+ * therefore untouched: the user lands back on the list they had set up.
+ *
+ * Worktree deletion passes no focus hint on purpose. The row it would point at
+ * has just been deleted, so the only honest destination is the list.
+ */
+function routeHostSurfaceNotification(
+  navigate: NavigateFn,
+  payload: HostSurfaceNotificationPayload,
+): void {
+  navigateToTabIntent(
+    navigate,
+    ensureSettingsTab({
+      subSection: HOST_SURFACE_SETTINGS_SECTION[payload.surface],
+      resetToGeneral: false,
+    }),
+  );
+}
+
+/**
+ * Every host surface, mapped to the Settings section that hosts it.
+ *
+ * A `Record` keyed by the surface union rather than a switch: it is exhaustive
+ * by construction, so adding a surface fails to compile here until it declares
+ * a destination. A future surface that is NOT a Settings section (a dedicated
+ * route, say) is the point at which this becomes a real dispatch rather than a
+ * table - which is a change to make then, not a switch to guess at now.
+ */
+const HOST_SURFACE_SETTINGS_SECTION: Record<
+  HostSurfaceNotificationPayload["surface"],
+  SettingsSectionId
+> = {
+  worktreeSettings: "worktrees",
+};
 
 function routeTerminalNotification(
   navigate: NotificationNavigate,

--- a/clients/gui-app/src/stores/notifications/__tests__/host-notifications-store.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/host-notifications-store.test.ts
@@ -5,7 +5,7 @@ import {
 } from "@traycer/protocol/host/registry";
 import {
   hostNotificationsSubscribeClientFrameSchema,
-  type HostNotificationEntry,
+  type HostNotificationEntryV21,
   type HostNotificationsAttentionCursor,
   type HostNotificationsChronologicalCursor,
   type HostNotificationsSubscribeClientFrame,
@@ -45,7 +45,7 @@ function entry(
   id: string,
   updatedAt: number,
   readAt: number | null,
-): HostNotificationEntry {
+): HostNotificationEntryV21 {
   return {
     id,
     updatedAt,
@@ -64,14 +64,14 @@ function entry(
   };
 }
 
-function promptEntry(id: string): HostNotificationEntry {
+function promptEntry(id: string): HostNotificationEntryV21 {
   return promptOccurrence(id, 10);
 }
 
 function promptOccurrence(
   id: string,
   updatedAt: number,
-): HostNotificationEntry {
+): HostNotificationEntryV21 {
   return {
     id,
     updatedAt,
@@ -102,7 +102,7 @@ function attentionCursor(
 }
 
 function defaultSummaryFor(
-  entries: ReadonlyArray<HostNotificationEntry>,
+  entries: ReadonlyArray<HostNotificationEntryV21>,
 ): HostNotificationsSummary {
   return {
     unreadCount: entries.filter((item) => item.readAt === null).length,
@@ -112,7 +112,7 @@ function defaultSummaryFor(
 }
 
 function applySimpleSnapshot(input: {
-  readonly entries: ReadonlyArray<HostNotificationEntry>;
+  readonly entries: ReadonlyArray<HostNotificationEntryV21>;
   readonly summary: HostNotificationsSummary;
   readonly recentCursor: HostNotificationsChronologicalCursor | null;
   readonly attentionNext: HostNotificationsAttentionCursor | null;
@@ -1516,7 +1516,7 @@ describe("host notifications store", () => {
 
   it("uses channelEmission as the only host-source display path", () => {
     const client = new MockWsStreamClient();
-    const displayed: Array<ReadonlyArray<HostNotificationEntry>> = [];
+    const displayed: Array<ReadonlyArray<HostNotificationEntryV21>> = [];
     const liveEntry = entry("live", 200, null);
 
     const close = openHostNotificationsStream(client, null, {
@@ -1559,12 +1559,12 @@ describe("host notifications store", () => {
 
   it("uses the latest feed copy for renderer channel emissions", () => {
     const client = new MockWsStreamClient();
-    const displayed: Array<ReadonlyArray<HostNotificationEntry>> = [];
+    const displayed: Array<ReadonlyArray<HostNotificationEntryV21>> = [];
     const staleEmissionEntry = entry("live", 200, null);
     if (staleEmissionEntry.kind !== "agent.stopped") {
       throw new Error("Expected an agent-stopped notification fixture");
     }
-    const richFeedEntry: HostNotificationEntry = {
+    const richFeedEntry: HostNotificationEntryV21 = {
       ...staleEmissionEntry,
       updatedAt: 201,
       payload: {
@@ -1608,7 +1608,7 @@ describe("host notifications store", () => {
 
   it("ignores non-renderer channelEmission frames for in-app display", () => {
     const client = new MockWsStreamClient();
-    const displayed: Array<ReadonlyArray<HostNotificationEntry>> = [];
+    const displayed: Array<ReadonlyArray<HostNotificationEntryV21>> = [];
     const liveEntry = entry("webhook-live", 240, null);
 
     const close = openHostNotificationsStream(client, null, {

--- a/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/merged-notifications.test.ts
@@ -491,4 +491,67 @@ describe("merged notifications feed", () => {
       severity: "info",
     });
   });
+
+  it("routes a worktree-deletion row to the worktree settings surface with the host's own copy", () => {
+    expect(
+      rowFromHostEntry({
+        id: "worktree.deletion:command-1",
+        updatedAt: 10,
+        readAt: null,
+        kind: "host.operation.finished",
+        sourceRef: "command-1",
+        severity: "failure",
+        outcome: "errored",
+        epicId: null,
+        chatId: null,
+        payload: {
+          kind: "worktree_deletion",
+          operation: "worktree.deletion",
+          title: "Some worktrees were not deleted",
+          message: "Deleted 2 of 3 worktrees; 1 failed.",
+          commandId: "command-1",
+          source: "settings",
+          requestedCount: 3,
+          deletedCount: 2,
+          failedCount: 1,
+        },
+      }),
+    ).toMatchObject({
+      title: "Some worktrees were not deleted",
+      body: "Deleted 2 of 3 worktrees; 1 failed.",
+      // Surface-only: the worktree the row describes is gone, so there is no
+      // resource left to focus.
+      payload: {
+        kind: "hostSurface",
+        surface: "worktreeSettings",
+        focus: undefined,
+      },
+    });
+  });
+
+  it("renders a newer host's unknown operation payload from its common fields, with no destination", () => {
+    const row = rowFromHostEntry({
+      id: "testbox.provision:command-2",
+      updatedAt: 10,
+      readAt: null,
+      kind: "host.operation.finished",
+      sourceRef: "command-2",
+      severity: "done",
+      outcome: "completed",
+      epicId: null,
+      chatId: null,
+      payload: {
+        kind: "testbox_provision",
+        operation: "testbox.provision",
+        title: "Test box ready",
+        message: "Provisioned 1 test box.",
+      },
+    });
+    expect(row).toMatchObject({
+      title: "Test box ready",
+      body: "Provisioned 1 test box.",
+    });
+    // Readable and acknowledgeable, but never routed by guesswork.
+    expect(row.payload).toBeNull();
+  });
 });

--- a/clients/gui-app/src/stores/notifications/host-notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/host-notifications-store.ts
@@ -9,11 +9,11 @@ import type {
 import type { WsStreamClient } from "@traycer-clients/shared/host-transport/ws-stream-client";
 import {
   hostNotificationsSubscribeClientFrameSchema,
-  hostNotificationsSubscribeServerFrameSchema,
-  type HostNotificationEntry,
+  hostNotificationsSubscribeServerFrameSchemaV11,
+  type HostNotificationEntryV21,
   type HostNotificationsAttentionCursor,
   type HostNotificationsChronologicalCursor,
-  type HostNotificationsSubscribeServerFrame,
+  type HostNotificationsSubscribeServerFrameV11,
   type HostNotificationsSummary,
 } from "@traycer/protocol/host/notifications/contracts";
 import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
@@ -37,10 +37,20 @@ export const HOST_NOTIFICATIONS_INITIAL_RECENT_LIMIT = 50;
  */
 export const HOST_NOTIFICATIONS_PRESENCE_HEARTBEAT_MS = 5_000;
 
-export type HostNotificationFeedEntry = HostNotificationEntry;
+/**
+ * The feed parses against the `@1.1` frame union, not the released `@1.0`
+ * one. Stream versions negotiate to `min(client, host)` per method, so a GUI
+ * built from this protocol tree lands on `@1.1` against a host built from it
+ * too - and parsing those frames with the `@1.0` schema would reject any
+ * `host.operation.finished` row, which this store treats as connection
+ * corruption and answers with a reconnect into a snapshot carrying the same
+ * row. Against an older host the negotiated version drops back to `@1.0`,
+ * whose frames are a strict subset of this union and still parse.
+ */
+export type HostNotificationFeedEntry = HostNotificationEntryV21;
 
 export type HostNotificationsFeedFrame = Extract<
-  HostNotificationsSubscribeServerFrame,
+  HostNotificationsSubscribeServerFrameV11,
   | { readonly kind: "snapshot" }
   | { readonly kind: "upserted" }
   | { readonly kind: "readStateChanged" }
@@ -556,7 +566,7 @@ export function openHostNotificationsStream(
         return;
       }
       const parsed =
-        hostNotificationsSubscribeServerFrameSchema.safeParse(envelope);
+        hostNotificationsSubscribeServerFrameSchemaV11.safeParse(envelope);
       if (!parsed.success) {
         reconnect();
         return;

--- a/clients/gui-app/src/stores/notifications/merged-notifications.ts
+++ b/clients/gui-app/src/stores/notifications/merged-notifications.ts
@@ -1134,6 +1134,17 @@ function navigationPayloadFromKnown(
         chatId: known.chatId,
         interviewBlockId: known.interviewBlockId,
       };
+    // No focus hint: the deleted worktree's row is gone, and the list's saved
+    // filters are the authoritative view to return to. A row from a NEWER host
+    // whose operation payload this build cannot parse never reaches here at
+    // all - it renders with common-field copy and no deep link, which is the
+    // designed degradation rather than a guessed destination.
+    case "worktree_deletion":
+      return {
+        kind: "hostSurface",
+        surface: "worktreeSettings",
+        focus: undefined,
+      };
   }
 }
 

--- a/clients/shared/host-transport/__tests__/worktree-delete-batch-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/worktree-delete-batch-stream-client.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { hostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import {
+  createRequestContext,
+  identityFromAuthenticatedUser,
+} from "@traycer/protocol/auth/request-context";
+import { mockLocalHostEntry } from "../../host-client/mock/mock-host-directory";
+import { createAuthenticatedUserFixture } from "../../test-fixtures/authenticated-user";
+import type {
+  WebSocketCloseEvent,
+  WebSocketErrorEvent,
+  WebSocketOpenEvent,
+} from "../ws-factory";
+import type {
+  IStreamWebSocketFactory,
+  StreamWebSocketLike,
+  StreamWebSocketMessageEvent,
+} from "../ws-stream-factory";
+import { WorktreeDeleteBatchStreamClient } from "../worktree-delete-batch-stream-client";
+import { WsStreamClient } from "../ws-stream-client";
+
+const COMMAND_ID = "6f1a6a0e-1f0f-4a1e-9f0d-1b6f0c2c9f11";
+
+class StubStreamWebSocket implements StreamWebSocketLike {
+  onopen: ((event: WebSocketOpenEvent) => void) | null = null;
+  onmessage: ((event: StreamWebSocketMessageEvent) => void) | null = null;
+  onerror: ((event: WebSocketErrorEvent) => void) | null = null;
+  onclose: ((event: WebSocketCloseEvent) => void) | null = null;
+
+  readonly textSent: string[] = [];
+
+  send(data: string | Uint8Array): void {
+    if (typeof data === "string") {
+      this.textSent.push(data);
+    }
+  }
+
+  close(_code: number, _reason: string): void {}
+
+  fireOpen(): void {
+    this.onopen?.({ type: "open" });
+  }
+
+  fireText(data: unknown): void {
+    this.onmessage?.({ type: "text", data: JSON.stringify(data) });
+  }
+
+  fireClose(code: number, reason: string): void {
+    this.onclose?.({ code, reason, wasClean: false });
+  }
+}
+
+function makeFactory(): {
+  readonly factory: IStreamWebSocketFactory;
+  readonly sockets: StubStreamWebSocket[];
+} {
+  const sockets: StubStreamWebSocket[] = [];
+  return {
+    factory: {
+      create(): StreamWebSocketLike {
+        const socket = new StubStreamWebSocket();
+        sockets.push(socket);
+        return socket;
+      },
+    },
+    sockets,
+  };
+}
+
+function makeClient(
+  factory: IStreamWebSocketFactory,
+): WsStreamClient<typeof hostStreamRpcRegistry> {
+  const user = createAuthenticatedUserFixture(undefined);
+  const context = createRequestContext({
+    identity: identityFromAuthenticatedUser(user),
+    bearerToken: "token",
+    origin: "renderer",
+    connectionId: undefined,
+    operationId: undefined,
+    externalAbortSignal: undefined,
+  });
+  return new WsStreamClient({
+    registry: hostStreamRpcRegistry,
+    endpoint: () => mockLocalHostEntry,
+    bearer: () => context.credentials,
+    auth: null,
+    webSocketFactory: factory,
+    dialTimeoutMs: 1_000,
+    openAckTimeoutMs: 1_000,
+    pingIntervalMs: 25_000,
+    pongTimeoutMs: 50_000,
+    initialBackoffMs: 10,
+    maxBackoffMs: 1_000,
+  });
+}
+
+/** Mirrors the host: echo the client's own manifest so the method negotiates. */
+function completeHandshake(socket: StubStreamWebSocket): void {
+  socket.fireOpen();
+  const open = JSON.parse(socket.textSent[0]) as {
+    readonly manifest: Record<string, { major: number; minor: number }>;
+  };
+  socket.fireText({ kind: "openAck", manifest: open.manifest });
+}
+
+function subscribeFrame(socket: StubStreamWebSocket): Record<string, unknown> {
+  const raw = socket.textSent[1];
+  if (raw === undefined) throw new Error("no subscribe frame was sent");
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error("subscribe frame was not an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function subscribeParams(socket: StubStreamWebSocket): Record<string, unknown> {
+  const params = subscribeFrame(socket).params;
+  if (typeof params !== "object" || params === null) {
+    throw new Error("subscribe frame carried no params");
+  }
+  return params as Record<string, unknown>;
+}
+
+const NOOP_CALLBACKS = {
+  onTargetStarted: () => undefined,
+  onTargetPhase: () => undefined,
+  onTargetOutput: () => undefined,
+  onTargetComplete: () => undefined,
+  onTargetFailed: () => undefined,
+  onCommandComplete: () => undefined,
+  onCommandFailed: () => undefined,
+  onUnsupported: () => undefined,
+  onConnectionStatus: () => undefined,
+};
+
+function openBatchClient(
+  wsStreamClient: WsStreamClient<typeof hostStreamRpcRegistry>,
+): WorktreeDeleteBatchStreamClient {
+  return new WorktreeDeleteBatchStreamClient({
+    wsStreamClient,
+    commandId: COMMAND_ID,
+    source: "settings",
+    targets: [
+      { worktreePath: "/wt/a", scripts: null },
+      { worktreePath: "/wt/b", scripts: null },
+    ],
+    callbacks: NOOP_CALLBACKS,
+  });
+}
+
+describe("WorktreeDeleteBatchStreamClient replay safety", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("re-subscribes as observe after a drop, so the transport can never replay the start", () => {
+    const { factory, sockets } = makeFactory();
+    const client = makeClient(factory);
+    const batch = openBatchClient(client);
+
+    completeHandshake(sockets[0]);
+    expect(subscribeParams(sockets[0])).toMatchObject({
+      mode: "start",
+      commandId: COMMAND_ID,
+      source: "settings",
+    });
+
+    // The socket dies after the host already has the command.
+    sockets[0].fireClose(1006, "abnormal");
+    // The swap is synchronous inside the `reconnecting` transition, so the
+    // replacement session dials before any backoff timer could re-send `start`.
+    expect(sockets).toHaveLength(2);
+
+    completeHandshake(sockets[1]);
+    expect(subscribeParams(sockets[1])).toEqual({
+      mode: "observe",
+      commandId: COMMAND_ID,
+    });
+
+    // Every later reconnect stays on observe, however long the outage runs.
+    sockets[1].fireClose(1006, "abnormal");
+    vi.advanceTimersByTime(1_000);
+    expect(sockets).toHaveLength(3);
+    completeHandshake(sockets[2]);
+    expect(subscribeParams(sockets[2])).toEqual({
+      mode: "observe",
+      commandId: COMMAND_ID,
+    });
+
+    const starts = sockets
+      .map((socket) =>
+        socket.textSent.length > 1 ? subscribeParams(socket) : null,
+      )
+      .filter((params) => params?.mode === "start");
+    expect(starts).toHaveLength(1);
+    batch.close();
+  });
+
+  it("keeps retrying start while the drop happened before the host ever saw it", () => {
+    const { factory, sockets } = makeFactory();
+    const client = makeClient(factory);
+    const batch = openBatchClient(client);
+
+    // Dies during the dial: the subscribe frame never went out, so nothing was
+    // started and re-issuing the user's actual request is both safe and what
+    // they asked for.
+    expect(sockets[0].textSent).toHaveLength(0);
+    sockets[0].fireClose(1006, "abnormal");
+    vi.advanceTimersByTime(50);
+    expect(sockets).toHaveLength(2);
+
+    completeHandshake(sockets[1]);
+    expect(subscribeParams(sockets[1])).toMatchObject({
+      mode: "start",
+      commandId: COMMAND_ID,
+    });
+    batch.close();
+  });
+
+  it("reports an unsupported method instead of a connection failure", () => {
+    const { factory, sockets } = makeFactory();
+    const client = makeClient(factory);
+    let unsupported = 0;
+    let statusClosed = 0;
+    const batch = new WorktreeDeleteBatchStreamClient({
+      wsStreamClient: client,
+      commandId: COMMAND_ID,
+      source: "settings",
+      targets: [{ worktreePath: "/wt/a", scripts: null }],
+      callbacks: {
+        ...NOOP_CALLBACKS,
+        onUnsupported: () => {
+          unsupported += 1;
+        },
+        onConnectionStatus: (status) => {
+          if (status === "closed") statusClosed += 1;
+        },
+      },
+    });
+
+    // An older host: its manifest simply has no entry for the method.
+    sockets[0].fireOpen();
+    const open = JSON.parse(sockets[0].textSent[0]) as {
+      readonly manifest: Record<string, { major: number; minor: number }>;
+    };
+    const olderManifest = { ...open.manifest };
+    delete olderManifest["worktree.deleteBatchByPath"];
+    sockets[0].fireText({ kind: "openAck", manifest: olderManifest });
+
+    expect(unsupported).toBe(1);
+    expect(statusClosed).toBe(0);
+    // Rejected on the openAck: no subscribe frame, so no host work started.
+    expect(sockets[0].textSent).toHaveLength(2);
+    expect(JSON.parse(sockets[0].textSent[1])).toMatchObject({
+      kind: "fatalError",
+    });
+    batch.close();
+  });
+});

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -1894,7 +1894,9 @@ describe("WsStreamClient UNAUTHORIZED auth recovery", () => {
     expect(parseText(sockets[0].socket.textSent[1])).toEqual({
       kind: "subscribe",
       method: "host.notifications.feed.subscribe",
-      schemaVersion: { major: 1, minor: 0 },
+      // `@1.1` is the newest installed minor of the feed (the arm carrying
+      // `host.operation.finished`); the mirrored handshake negotiates it.
+      schemaVersion: { major: 1, minor: 1 },
       params: {
         initialAttentionLimit: 50,
         initialRecentLimit: 50,
@@ -1927,7 +1929,9 @@ describe("WsStreamClient UNAUTHORIZED auth recovery", () => {
     expect(parseText(sockets[1].socket.textSent[1])).toEqual({
       kind: "subscribe",
       method: "host.notifications.feed.subscribe",
-      schemaVersion: { major: 1, minor: 0 },
+      // `@1.1` is the newest installed minor of the feed (the arm carrying
+      // `host.operation.finished`); the mirrored handshake negotiates it.
+      schemaVersion: { major: 1, minor: 1 },
       params: {
         initialAttentionLimit: 50,
         initialRecentLimit: 50,

--- a/clients/shared/host-transport/worktree-delete-batch-stream-client.ts
+++ b/clients/shared/host-transport/worktree-delete-batch-stream-client.ts
@@ -1,0 +1,294 @@
+import {
+  worktreeDeleteBatchByPathServerFrameSchema,
+  type WorktreeDeleteBatchByPathOpenRequest,
+  type WorktreeDeleteBatchByPathServerFrame,
+  type WorktreeDeleteBatchOutputChannel,
+  type WorktreeDeleteBatchPhase,
+  type WorktreeDeleteBatchTarget,
+  type WorktreeDeletionSource,
+} from "@traycer/protocol/host/worktree-delete-batch-stream";
+import type { HostStreamRpcRegistry } from "@traycer/protocol/host/registry";
+import type {
+  IStreamSession,
+  StreamCloseReason,
+  StreamConnectionStatus,
+  StreamFrameEnvelope,
+} from "./i-stream-session";
+import type { WsStreamClient } from "./ws-stream-client";
+
+export const WORKTREE_DELETE_BATCH_STREAM_METHOD = "worktree.deleteBatchByPath";
+
+/**
+ * Typed handlers for one `worktree.deleteBatchByPath@1.0` command. Frames flow
+ * server → client only (apart from the transport heartbeat), so there is no
+ * upstream application API on the wrapper.
+ */
+export interface WorktreeDeleteBatchStreamCallbacks {
+  readonly onTargetStarted: (
+    worktreePath: string,
+    hasTeardown: boolean,
+  ) => void;
+  readonly onTargetPhase: (
+    worktreePath: string,
+    phase: WorktreeDeleteBatchPhase,
+  ) => void;
+  readonly onTargetOutput: (
+    worktreePath: string,
+    channel: WorktreeDeleteBatchOutputChannel,
+    chunk: string,
+  ) => void;
+  /** Terminal for one target; `deleted` is its outcome. */
+  readonly onTargetComplete: (worktreePath: string, deleted: boolean) => void;
+  /** Terminal for one target; the host declined or the removal threw. */
+  readonly onTargetFailed: (worktreePath: string, reason: string) => void;
+  /** Terminal for the COMMAND, after every target settled. */
+  readonly onCommandComplete: (counts: {
+    readonly requestedCount: number;
+    readonly deletedCount: number;
+    readonly failedCount: number;
+  }) => void;
+  /** The host rejected the command before any target ran. */
+  readonly onCommandFailed: (reason: string) => void;
+  /**
+   * The host does not implement this method at all - an older build.
+   *
+   * Delivered instead of a connection failure because the two demand opposite
+   * responses: a failure means "the delete may have half-happened, tell the
+   * user", while this means "nothing was attempted, run the older path". The
+   * distinction is safe to act on because the compatibility check that
+   * produces it runs on the openAck, BEFORE the subscribe frame - so the host
+   * has not been asked to delete anything.
+   */
+  readonly onUnsupported: () => void;
+  /**
+   * Connection-status changes. `reason` is non-null only on the `closed`
+   * transition. An unsupported-method close is reported through
+   * `onUnsupported` instead and never reaches this handler.
+   */
+  readonly onConnectionStatus: (
+    status: StreamConnectionStatus,
+    reason: StreamCloseReason | null,
+  ) => void;
+}
+
+export interface WorktreeDeleteBatchStreamClientOptions {
+  readonly wsStreamClient: WsStreamClient<HostStreamRpcRegistry>;
+  /** Client-minted UUID; identifies this command for single-flight reuse. */
+  readonly commandId: string;
+  readonly source: WorktreeDeletionSource;
+  readonly targets: ReadonlyArray<WorktreeDeleteBatchTarget>;
+  readonly callbacks: WorktreeDeleteBatchStreamCallbacks;
+}
+
+/**
+ * Typed wrapper over `WsStreamClient` for `worktree.deleteBatchByPath@1.0`.
+ *
+ * Subscribing opens ONE host-owned deletion command over every target. Unlike
+ * the released single-target wrapper, closing this session does not stop the
+ * work: the host keeps deleting and still writes the completion notification.
+ * Closing means "stop telling me", which is what makes it safe to close a
+ * Settings tab mid-bulk-delete.
+ *
+ * ## Why this wrapper owns a session SWAP
+ *
+ * `WsStreamClient` re-sends a session's original open request on every
+ * reconnect, forever. For a destructive command that is not something the host
+ * can fully defend against on its own: its single-flight map is process-local
+ * and evicted a minute after completion, so a long outage or a host restart
+ * would let an automatic re-subscribe execute the same command twice.
+ *
+ * So this wrapper never lets a `start` be the thing that gets replayed. It
+ * subscribes once in `start` mode, and the moment that session drops AFTER
+ * reaching the host, it closes it and opens a fresh session in `observe` mode
+ * for the same `commandId`. Every subsequent reconnect - however many, however
+ * long after - re-sends `observe`, which can attach to a live command but can
+ * never create one.
+ *
+ * A drop BEFORE the session ever opened is left alone: the subscribe frame
+ * never reached the host, so nothing was started and the transport's own
+ * retry of `start` is both safe and the behaviour the user wants (a host that
+ * was briefly unreachable still runs the delete they asked for).
+ */
+export class WorktreeDeleteBatchStreamClient {
+  private session: IStreamSession;
+  private readonly callbacks: WorktreeDeleteBatchStreamCallbacks;
+  private readonly wsStreamClient: WsStreamClient<HostStreamRpcRegistry>;
+  private readonly commandId: string;
+  private mode: "start" | "observe";
+  /**
+   * True once a session reached `open`, which is the moment the subscribe
+   * frame was handed to a live socket - i.e. the first instant the host may
+   * have created the command.
+   */
+  private reachedHost: boolean;
+  /** Suppresses the `closed` callback from a swap's own deliberate close. */
+  private swapping: boolean;
+  private closed: boolean;
+  private reportedUnsupported: boolean;
+
+  constructor(options: WorktreeDeleteBatchStreamClientOptions) {
+    this.callbacks = options.callbacks;
+    this.wsStreamClient = options.wsStreamClient;
+    this.commandId = options.commandId;
+    this.mode = "start";
+    this.reachedHost = false;
+    this.swapping = false;
+    this.closed = false;
+    this.reportedUnsupported = false;
+
+    this.session = this.openSession({
+      mode: "start",
+      commandId: options.commandId,
+      source: options.source,
+      targets: options.targets.map((target) => ({
+        worktreePath: target.worktreePath,
+        scripts: target.scripts,
+      })),
+    });
+  }
+
+  /** Tears down the underlying session. Idempotent. Detaches; never cancels. */
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.session.close();
+  }
+
+  private openSession(
+    params: WorktreeDeleteBatchByPathOpenRequest,
+  ): IStreamSession {
+    const session = this.wsStreamClient.subscribe(
+      "worktree.deleteBatchByPath",
+      params,
+    );
+    session.onServerFrame((envelope, binaryPayload) => {
+      this.handleServerFrame(envelope, binaryPayload);
+    });
+    session.onStatusChange((status, reason) => {
+      this.handleStatusChange(status, reason);
+    });
+    return session;
+  }
+
+  /**
+   * Replaces the `start` session with an `observe` one for the same command.
+   *
+   * Runs inside the `reconnecting` transition, which `WsStreamClient` emits
+   * BEFORE it arms the redial timer - so closing here cancels the pending
+   * re-subscribe rather than racing it, and the `start` request can never go
+   * out a second time.
+   */
+  private swapToObserve(): void {
+    this.mode = "observe";
+    this.swapping = true;
+    this.session.close();
+    this.swapping = false;
+    this.session = this.openSession({
+      mode: "observe",
+      commandId: this.commandId,
+    });
+  }
+
+  private handleStatusChange(
+    status: StreamConnectionStatus,
+    reason: StreamCloseReason | null,
+  ): void {
+    if (this.closed) {
+      return;
+    }
+    // Our own swap close, echoed back through the session we just closed.
+    if (this.swapping) {
+      return;
+    }
+    if (status === "open") {
+      this.reachedHost = true;
+      this.callbacks.onConnectionStatus(status, reason);
+      return;
+    }
+    // `getMethodSupport` is set to `unsupported` by the handshake immediately
+    // before it closes the session, so it is already authoritative here.
+    // Read it rather than pattern-matching the fatal-error details: support is
+    // the transport's own answer to "does this host have the method", while
+    // the details string is a human-readable summary that may change.
+    if (
+      status === "closed" &&
+      reason !== null &&
+      this.wsStreamClient.getMethodSupport(
+        WORKTREE_DELETE_BATCH_STREAM_METHOD,
+      ) === "unsupported"
+    ) {
+      if (this.reportedUnsupported) return;
+      this.reportedUnsupported = true;
+      this.callbacks.onUnsupported();
+      return;
+    }
+    if (
+      status === "reconnecting" &&
+      this.mode === "start" &&
+      this.reachedHost
+    ) {
+      this.swapToObserve();
+      // Still a reconnect from the consumer's point of view: the run stays
+      // live and waits for the observe session to land.
+      this.callbacks.onConnectionStatus(status, reason);
+      return;
+    }
+    this.callbacks.onConnectionStatus(status, reason);
+  }
+
+  private handleServerFrame(
+    envelope: StreamFrameEnvelope,
+    _binaryPayload: Uint8Array | null,
+  ): void {
+    const parsed =
+      worktreeDeleteBatchByPathServerFrameSchema.safeParse(envelope);
+    if (!parsed.success) {
+      return;
+    }
+    const frame: WorktreeDeleteBatchByPathServerFrame = parsed.data;
+    switch (frame.kind) {
+      case "target.started": {
+        this.callbacks.onTargetStarted(frame.worktreePath, frame.hasTeardown);
+        return;
+      }
+      case "target.phase": {
+        this.callbacks.onTargetPhase(frame.worktreePath, frame.phase);
+        return;
+      }
+      case "target.output": {
+        this.callbacks.onTargetOutput(
+          frame.worktreePath,
+          frame.channel,
+          frame.chunk,
+        );
+        return;
+      }
+      case "target.complete": {
+        this.callbacks.onTargetComplete(frame.worktreePath, frame.deleted);
+        return;
+      }
+      case "target.failed": {
+        this.callbacks.onTargetFailed(frame.worktreePath, frame.reason);
+        return;
+      }
+      case "command.complete": {
+        this.callbacks.onCommandComplete({
+          requestedCount: frame.requestedCount,
+          deletedCount: frame.deletedCount,
+          failedCount: frame.failedCount,
+        });
+        return;
+      }
+      case "command.failed": {
+        this.callbacks.onCommandFailed(frame.reason);
+        return;
+      }
+      case "pong": {
+        // WsStreamClient handles pong internally for heartbeat bookkeeping.
+        return;
+      }
+    }
+  }
+}

--- a/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/worktree-delete.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildWorktreeDeleteCommand } from "../worktree-delete";
 import { CliError, CLI_ERROR_CODES } from "../../runner/errors";
 import type { CommandContext } from "../../runner/runner";
+import type { ProgressInfo } from "../../runner/output";
 import type { StreamCloseReason } from "../../../../shared/host-transport/i-stream-session";
+import type { StreamMethodSupport } from "../../../../shared/host-transport/ws-stream-client";
 import { resolveHostAuth } from "../../internal/host-auth";
 import { resolveEndpoint } from "../../internal/host-rpc";
 
@@ -20,15 +22,24 @@ vi.mock("../../logger", () => ({
   noopLogger: loggerMock,
 }));
 
+type FakeSession = {
+  readonly method: string;
+  readonly params: unknown;
+  statusHandler:
+    ((status: string, reason: StreamCloseReason | null) => void) | null;
+  frameHandler: ((envelope: unknown) => void) | null;
+};
+
 // Shared, hoisted so the module mock factory can reference them.
 const hoisted = vi.hoisted(() => ({
   subscribeMock: vi.fn(),
   clientCloseMock: vi.fn(),
   sessionCloseMock: vi.fn(),
-  ref: {
-    statusHandler: null as
-      ((status: string, reason: StreamCloseReason | null) => void) | null,
-    frameHandler: null as ((envelope: unknown) => void) | null,
+  state: {
+    sessions: [] as FakeSession[],
+    // What the transport's compatibility check would say about the batch
+    // method. Flipped per test to simulate an older host.
+    methodSupport: "supported" as StreamMethodSupport,
   },
 }));
 
@@ -42,6 +53,7 @@ vi.mock("../../../../shared/host-transport/ws-stream-client", () => ({
       isClosed: () => false,
       notifyBearerRotated: () => undefined,
       reconnectAll: () => undefined,
+      getMethodSupport: () => hoisted.state.methodSupport,
     };
   }),
 }));
@@ -62,10 +74,50 @@ const resolveEndpointMock = vi.mocked(resolveEndpoint);
 
 const ctx = {} as CommandContext;
 
+/**
+ * A JSON-mode context, so relayed lifecycle/output lines land on the NDJSON
+ * `progress` channel where a test can read them instead of on stderr.
+ */
+function jsonCtx(recorded: ProgressInfo[]): CommandContext {
+  const noop = (): void => undefined;
+  return {
+    runtime: {
+      json: true,
+      quiet: false,
+      noProgress: false,
+      noBootstrap: true,
+      nonInteractive: true,
+      environment: "production",
+      logger: loggerMock,
+    },
+    output: {
+      progress: noop,
+      human: noop,
+      humanRequired: noop,
+      emitResult: noop,
+      emitError: noop,
+    },
+    progress: (info: ProgressInfo) => recorded.push(info),
+  };
+}
+
+/** The `start`-mode batch session, i.e. the first subscribe of a run. */
+function commandSession(): FakeSession {
+  const session = hoisted.state.sessions[0];
+  if (session === undefined) throw new Error("no command session opened");
+  return session;
+}
+
+async function waitForSessions(count: number): Promise<void> {
+  await vi.waitFor(() => {
+    expect(hoisted.state.sessions.length).toBeGreaterThanOrEqual(count);
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  hoisted.ref.statusHandler = null;
-  hoisted.ref.frameHandler = null;
+  hoisted.state.sessions = [];
+  hoisted.state.methodSupport = "supported";
   resolveHostAuthMock.mockResolvedValue({
     token: "token",
     userId: "user",
@@ -75,18 +127,29 @@ beforeEach(() => {
     hostId: "host-1",
     websocketUrl: "ws://127.0.0.1:9999/rpc",
   });
-  hoisted.subscribeMock.mockImplementation(() => ({
-    onServerFrame: (handler: (envelope: unknown) => void) => {
-      hoisted.ref.frameHandler = handler;
+  hoisted.subscribeMock.mockImplementation(
+    (method: string, params: unknown) => {
+      const session: FakeSession = {
+        method,
+        params,
+        statusHandler: null,
+        frameHandler: null,
+      };
+      hoisted.state.sessions.push(session);
+      return {
+        onServerFrame: (handler: (envelope: unknown) => void) => {
+          session.frameHandler = handler;
+        },
+        onStatusChange: (
+          handler: (status: string, reason: StreamCloseReason | null) => void,
+        ) => {
+          session.statusHandler = handler;
+        },
+        sendClientFrame: () => undefined,
+        close: hoisted.sessionCloseMock,
+      };
     },
-    onStatusChange: (
-      handler: (status: string, reason: StreamCloseReason | null) => void,
-    ) => {
-      hoisted.ref.statusHandler = handler;
-    },
-    sendClientFrame: () => undefined,
-    close: hoisted.sessionCloseMock,
-  }));
+  );
 });
 
 afterEach(() => {
@@ -128,6 +191,99 @@ describe("buildWorktreeDeleteCommand input validation", () => {
   });
 });
 
+describe("buildWorktreeDeleteCommand command shape", () => {
+  it("opens ONE start-mode command carrying a uuid and the single target", async () => {
+    const pending = buildWorktreeDeleteCommand({
+      worktreePath: "/wt/x",
+      readonlySurface: false,
+    })(ctx);
+
+    await waitForSessions(1);
+    const session = commandSession();
+    expect(session.method).toBe("worktree.deleteBatchByPath");
+    expect(session.params).toMatchObject({
+      mode: "start",
+      source: "cli",
+      targets: [{ worktreePath: "/wt/x", scripts: null }],
+    });
+    // A validated UUID, minted once per invocation - the host rejects an open
+    // string, and a shared constant would collapse distinct commands onto one
+    // single-flight entry.
+    expect(
+      (session.params as { readonly commandId: string }).commandId,
+    ).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+
+    session.frameHandler?.({
+      kind: "target.complete",
+      worktreePath: "/wt/x",
+      deleted: true,
+      hasBinaryPayload: false,
+    });
+    await pending;
+  });
+
+  it("preserves the relayed phase and output lines", async () => {
+    const recorded: ProgressInfo[] = [];
+    const pending = buildWorktreeDeleteCommand({
+      worktreePath: "/wt/x",
+      readonlySurface: false,
+    })(jsonCtx(recorded));
+
+    await waitForSessions(1);
+    const session = commandSession();
+    session.frameHandler?.({
+      kind: "target.started",
+      worktreePath: "/wt/x",
+      hasTeardown: true,
+      hasBinaryPayload: false,
+    });
+    session.frameHandler?.({
+      kind: "target.phase",
+      worktreePath: "/wt/x",
+      phase: "teardown",
+      hasBinaryPayload: false,
+    });
+    session.frameHandler?.({
+      kind: "target.output",
+      worktreePath: "/wt/x",
+      channel: "stderr",
+      chunk: "tearing down\n",
+      hasBinaryPayload: false,
+    });
+    session.frameHandler?.({
+      kind: "target.complete",
+      worktreePath: "/wt/x",
+      deleted: true,
+      hasBinaryPayload: false,
+    });
+
+    await pending;
+    expect(recorded).toEqual([
+      {
+        stage: "worktree-delete",
+        message: "starting delete (running teardown script)",
+        percent: null,
+        bytes: null,
+        totalBytes: null,
+      },
+      {
+        stage: "worktree-delete",
+        message: "phase: teardown",
+        percent: null,
+        bytes: null,
+        totalBytes: null,
+      },
+      {
+        stage: "worktree-delete:stderr",
+        message: "tearing down\n",
+        percent: null,
+        bytes: null,
+        totalBytes: null,
+      },
+    ]);
+  });
+});
+
 describe("buildWorktreeDeleteCommand stream-drop safety", () => {
   it("fails non-zero on a drop before a terminal frame, with no re-subscribe", async () => {
     const pending = buildWorktreeDeleteCommand({
@@ -135,45 +291,52 @@ describe("buildWorktreeDeleteCommand stream-drop safety", () => {
       readonlySurface: false,
     })(ctx);
 
-    // Let resolveHostAuth / resolveEndpoint settle and the subscribe register.
-    await vi.waitFor(() => {
-      expect(hoisted.ref.statusHandler).not.toBeNull();
-    });
-
-    // A recoverable transport drop surfaces as `reconnecting` (the shared
-    // client would auto re-subscribe and re-send the destructive delete).
-    hoisted.ref.statusHandler?.("reconnecting", null);
+    await waitForSessions(1);
+    const session = commandSession();
+    // Reaching `open` is the moment the subscribe frame hit a live socket.
+    session.statusHandler?.("open", null);
+    // A recoverable transport drop surfaces as `reconnecting`.
+    session.statusHandler?.("reconnecting", null);
 
     await expect(pending).rejects.toMatchObject({
       code: CLI_ERROR_CODES.UNEXPECTED,
       exitCode: 1,
+      message: expect.stringContaining("may or may not have been removed"),
     });
 
-    // Exactly one subscribe was sent; the drop tore the stream down instead of
-    // reconnecting.
-    expect(hoisted.subscribeMock).toHaveBeenCalledTimes(1);
-    expect(hoisted.subscribeMock).toHaveBeenCalledWith(
-      "worktree.deleteByPath",
-      { worktreePath: "/wt/x", scripts: null },
-    );
+    // The drop tore the run down. The batch client swaps to `observe` inside
+    // the `reconnecting` transition, so if anything WAS re-sent it can only
+    // have been an observe - never a second authorization to delete.
+    expect(
+      hoisted.state.sessions.every(
+        (opened) =>
+          opened.method === "worktree.deleteBatchByPath" &&
+          ((opened.params as { readonly mode: string }).mode === "observe" ||
+            opened === session),
+      ),
+    ).toBe(true);
+    expect(
+      hoisted.state.sessions.filter(
+        (opened) =>
+          (opened.params as { readonly mode: string }).mode === "start",
+      ),
+    ).toHaveLength(1);
     expect(hoisted.sessionCloseMock).toHaveBeenCalled();
     expect(hoisted.clientCloseMock).toHaveBeenCalled();
   });
 });
 
 describe("buildWorktreeDeleteCommand terminal outcomes", () => {
-  it("resolves deleted=true on a complete frame", async () => {
+  it("resolves deleted=true on a target.complete frame", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
       readonlySurface: false,
     })(ctx);
 
-    await vi.waitFor(() => {
-      expect(hoisted.ref.frameHandler).not.toBeNull();
-    });
-
-    hoisted.ref.frameHandler?.({
-      kind: "complete",
+    await waitForSessions(1);
+    commandSession().frameHandler?.({
+      kind: "target.complete",
+      worktreePath: "/wt/x",
       deleted: true,
       hasBinaryPayload: false,
     });
@@ -185,18 +348,16 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
     expect(hoisted.clientCloseMock).toHaveBeenCalled();
   });
 
-  it("resolves deleted=false with a non-zero exit on a complete frame reporting no deletion", async () => {
+  it("resolves deleted=false with a non-zero exit when the host removed nothing", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
       readonlySurface: false,
     })(ctx);
 
-    await vi.waitFor(() => {
-      expect(hoisted.ref.frameHandler).not.toBeNull();
-    });
-
-    hoisted.ref.frameHandler?.({
-      kind: "complete",
+    await waitForSessions(1);
+    commandSession().frameHandler?.({
+      kind: "target.complete",
+      worktreePath: "/wt/x",
       deleted: false,
       hasBinaryPayload: false,
     });
@@ -206,18 +367,16 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
     expect(result.exitCode).toBe(1);
   });
 
-  it("maps a failed frame to a CliError carrying the host's reason", async () => {
+  it("maps a target.failed frame to a CliError carrying the host's reason", async () => {
     const pending = buildWorktreeDeleteCommand({
       worktreePath: "/wt/x",
       readonlySurface: false,
     })(ctx);
 
-    await vi.waitFor(() => {
-      expect(hoisted.ref.frameHandler).not.toBeNull();
-    });
-
-    hoisted.ref.frameHandler?.({
-      kind: "failed",
+    await waitForSessions(1);
+    commandSession().frameHandler?.({
+      kind: "target.failed",
+      worktreePath: "/wt/x",
       reason: "worktree is busy",
       hasBinaryPayload: false,
     });
@@ -227,8 +386,48 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
       exitCode: 1,
       message: expect.stringContaining("worktree is busy"),
     });
-    expect(hoisted.sessionCloseMock).toHaveBeenCalled();
-    expect(hoisted.clientCloseMock).toHaveBeenCalled();
+  });
+
+  it("maps a command.failed frame to a CliError carrying the host's reason", async () => {
+    const pending = buildWorktreeDeleteCommand({
+      worktreePath: "/wt/x",
+      readonlySurface: false,
+    })(ctx);
+
+    await waitForSessions(1);
+    commandSession().frameHandler?.({
+      kind: "command.failed",
+      reason: "Lost track of this delete when the connection dropped.",
+      hasBinaryPayload: false,
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.UNEXPECTED,
+      exitCode: 1,
+      message: expect.stringContaining("Lost track of this delete"),
+    });
+  });
+
+  it("falls back to the command counts when only the command terminal arrives", async () => {
+    // What an observer that attached to an already-settled command sees: no
+    // per-target frames are replayed, so the counts are the whole answer.
+    const pending = buildWorktreeDeleteCommand({
+      worktreePath: "/wt/x",
+      readonlySurface: false,
+    })(ctx);
+
+    await waitForSessions(1);
+    commandSession().frameHandler?.({
+      kind: "command.complete",
+      requestedCount: 1,
+      deletedCount: 1,
+      failedCount: 0,
+      hasBinaryPayload: false,
+    });
+
+    const result = await pending;
+    expect(result.data).toEqual({ worktreePath: "/wt/x", deleted: true });
+    expect(result.exitCode).toBe(0);
   });
 
   it("maps an UNAUTHORIZED fatal close to an auth-rejected CliError", async () => {
@@ -237,11 +436,8 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
       readonlySurface: false,
     })(ctx);
 
-    await vi.waitFor(() => {
-      expect(hoisted.ref.statusHandler).not.toBeNull();
-    });
-
-    hoisted.ref.statusHandler?.("closed", {
+    await waitForSessions(1);
+    commandSession().statusHandler?.("closed", {
       kind: "fatalError",
       details: {
         code: "UNAUTHORIZED",
@@ -263,11 +459,8 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
       readonlySurface: false,
     })(ctx);
 
-    await vi.waitFor(() => {
-      expect(hoisted.ref.statusHandler).not.toBeNull();
-    });
-
-    hoisted.ref.statusHandler?.("closed", {
+    await waitForSessions(1);
+    commandSession().statusHandler?.("closed", {
       kind: "fatalError",
       details: {
         code: "INCOMPATIBLE",
@@ -281,5 +474,69 @@ describe("buildWorktreeDeleteCommand terminal outcomes", () => {
       code: CLI_ERROR_CODES.HOST_INCOMPATIBLE,
       exitCode: 1,
     });
+  });
+});
+
+describe("buildWorktreeDeleteCommand older-host fallback", () => {
+  it("runs the released single-target stream once the host proves it lacks the command method", async () => {
+    hoisted.state.methodSupport = "unsupported";
+    const pending = buildWorktreeDeleteCommand({
+      worktreePath: "/wt/x",
+      readonlySurface: false,
+    })(ctx);
+
+    await waitForSessions(1);
+    // The transport marks support on the openAck and then closes the session -
+    // BEFORE the subscribe frame, so the host was never asked to delete.
+    commandSession().statusHandler?.("closed", {
+      kind: "fatalError",
+      details: {
+        code: "INCOMPATIBLE",
+        reason: "host does not offer worktree.deleteBatchByPath",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+      },
+    });
+
+    await waitForSessions(2);
+    const legacy = hoisted.state.sessions[1]!;
+    expect(legacy.method).toBe("worktree.deleteByPath");
+    expect(legacy.params).toEqual({ worktreePath: "/wt/x", scripts: null });
+
+    legacy.frameHandler?.({
+      kind: "complete",
+      deleted: true,
+      hasBinaryPayload: false,
+    });
+
+    const result = await pending;
+    expect(result.data).toEqual({ worktreePath: "/wt/x", deleted: true });
+    expect(result.exitCode).toBe(0);
+    expect(hoisted.clientCloseMock).toHaveBeenCalled();
+  });
+
+  it("does not fall back after a fatal close that is not an unsupported method", async () => {
+    const pending = buildWorktreeDeleteCommand({
+      worktreePath: "/wt/x",
+      readonlySurface: false,
+    })(ctx);
+
+    await waitForSessions(1);
+    commandSession().statusHandler?.("closed", {
+      kind: "fatalError",
+      details: {
+        code: "INTERNAL",
+        reason: "host blew up",
+        incompatibleMethods: null,
+        upgradeGuidance: null,
+      },
+    });
+
+    await expect(pending).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.UNEXPECTED,
+    });
+    // Exactly one subscribe: a delete that may have half-happened is never
+    // re-issued on the older method.
+    expect(hoisted.state.sessions).toHaveLength(1);
   });
 });

--- a/clients/traycer-cli/src/commands/worktree-delete.ts
+++ b/clients/traycer-cli/src/commands/worktree-delete.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   hostStreamRpcRegistry,
   type HostStreamRpcRegistry,
@@ -6,9 +7,14 @@ import {
   worktreeDeleteByPathServerFrameSchema,
   type WorktreeDeleteOutputChannel,
 } from "@traycer/protocol/host/worktree-delete-stream";
+import type {
+  WorktreeDeleteBatchOutputChannel,
+  WorktreeDeleteBatchPhase,
+} from "@traycer/protocol/host/worktree-delete-batch-stream";
 import type { FatalErrorDetails } from "@traycer/protocol/framework/ws-protocol";
 import { MutableBearerLease } from "../../../shared/auth/bearer-source";
 import { WsStreamClient } from "../../../shared/host-transport/ws-stream-client";
+import { WorktreeDeleteBatchStreamClient } from "../../../shared/host-transport/worktree-delete-batch-stream-client";
 import { createWhatwgStreamWebSocketFactory } from "../../../shared/host-transport/whatwg-stream-ws-factory";
 import { DEFAULT_DIAL_TIMEOUT_MS } from "../../../shared/host-transport/transport-config";
 import type {
@@ -20,8 +26,8 @@ import { resolveEndpoint } from "../internal/host-rpc";
 import { cliError, CLI_ERROR_CODES, type CliError } from "../runner/errors";
 import type { CommandContext, CommandFn } from "../runner/runner";
 
-// Stream timing knobs, mirroring `traycer monitor`. `worktree.deleteByPath`
-// is a one-shot: it runs a teardown script (which can be slow) then removes the
+// Stream timing knobs, mirroring `traycer monitor`. A worktree delete is a
+// one-shot: it runs a teardown script (which can be slow) then removes the
 // worktree, so the ping/pong keepalive must outlast a quiet teardown. A fatal
 // close ends the command - unlike the monitor there is no forever-reconnect
 // loop and no auth-refresh recovery (`auth: null`); a short-lived delete runs
@@ -43,13 +49,17 @@ export interface WorktreeDeleteCommandOpts {
 }
 
 /**
- * `traycer worktree delete --path <p>` - drives the host's streaming
- * `worktree.deleteByPath@1.0` pipeline (busy-check -> teardown script ->
- * `git worktree remove`). Teardown/remove output is relayed live as it
- * streams; the terminal `complete` frame carries the final `deleted` flag and
- * a `failed` frame (busy path, unexpected host error) surfaces as a clean
- * non-zero CliError. Hidden in the `readonly` CLI surface (registered like
- * `agent create`).
+ * `traycer worktree delete --path <p>` - drives the host's deletion pipeline
+ * (busy-check -> teardown script -> `git worktree remove`). Teardown/remove
+ * output is relayed live as it streams; the terminal frame carries the final
+ * `deleted` flag, and a failure (busy path, unexpected host error) surfaces as
+ * a clean non-zero CliError. Hidden in the `readonly` CLI surface (registered
+ * like `agent create`).
+ *
+ * On a host that has `worktree.deleteBatchByPath` this runs as a ONE-TARGET
+ * command, so the CLI's delete queues on the same host-wide scheduler as every
+ * other deletion and leaves the same completion notification behind. Older
+ * hosts fall back to the released single-target stream.
  */
 export function buildWorktreeDeleteCommand(
   opts: WorktreeDeleteCommandOpts,
@@ -73,7 +83,7 @@ export function buildWorktreeDeleteCommand(
         exitCode: 1,
       });
     }
-    const deleted = await runWorktreeDeleteStream(worktreePath, ctx);
+    const deleted = await runWorktreeDelete(worktreePath, ctx);
     return {
       data: { worktreePath, deleted },
       // Output already streamed; add a one-line confirmation for the human
@@ -87,11 +97,20 @@ export function buildWorktreeDeleteCommand(
 }
 
 /**
- * Subscribe to the delete stream and resolve with the final `deleted` flag on
- * the terminal `complete` frame. Rejects with a CliError on a `failed` frame
- * (the host's reason is preserved) or a fatal stream close.
+ * Attempt the command stream first; fall back to the released single-target
+ * stream only when the host proves it has no such method.
+ *
+ * The fallback is safe for a DESTRUCTIVE operation precisely because that
+ * proof arrives from the openAck compatibility check, which runs before the
+ * subscribe frame is sent - the host was never asked to delete anything, so
+ * re-issuing the work on the older method cannot double it. Any other failure
+ * mode (a drop, a fatal close, a host-side rejection) is reported, never
+ * retried on the other method.
+ *
+ * Both attempts share one `WsStreamClient`: each session dials its own socket,
+ * and an unsupported method disposes only that session.
  */
-async function runWorktreeDeleteStream(
+async function runWorktreeDelete(
   worktreePath: string,
   ctx: CommandContext,
 ): Promise<boolean> {
@@ -120,19 +139,162 @@ async function runWorktreeDeleteStream(
     maxBackoffMs: MAX_BACKOFF_MS,
   });
 
+  const attempt = await runDeleteCommand(worktreePath, ctx, client);
+  if (attempt.kind === "settled") {
+    client.close("worktree-delete-settled");
+    if (attempt.error !== null) throw attempt.error;
+    return attempt.deleted;
+  }
+  const deleted = await runLegacyDeleteStream(
+    worktreePath,
+    ctx,
+    client,
+  ).finally(() => {
+    client.close("worktree-delete-settled");
+  });
+  return deleted;
+}
+
+type DeleteAttempt =
+  | {
+      readonly kind: "settled";
+      readonly deleted: boolean;
+      readonly error: CliError | null;
+    }
+  /** This host has no `worktree.deleteBatchByPath`, and ran nothing. */
+  | { readonly kind: "unsupported" };
+
+/**
+ * Run the delete as a one-target `worktree.deleteBatchByPath` command.
+ *
+ * The command id is minted here, once per invocation. `WorktreeDeleteBatchStreamClient`
+ * turns that into the replay-safe pair: it subscribes in `start` mode and, if
+ * that session drops after reaching the host, re-opens in `observe` mode - so
+ * the transport's automatic re-subscription can never re-execute the delete.
+ *
+ * This CLI then goes further and refuses to wait through a reconnect at all. A
+ * one-shot command that silently blocks while a host comes back is the wrong
+ * shape for a script, and the honest answer to a drop is the same as it always
+ * was: the worktree may or may not be gone, go look. Nothing is replayed
+ * either way.
+ */
+function runDeleteCommand(
+  worktreePath: string,
+  ctx: CommandContext,
+  client: WsStreamClient<HostStreamRpcRegistry>,
+): Promise<DeleteAttempt> {
+  return new Promise<DeleteAttempt>((resolve) => {
+    let settled = false;
+    const holder: { command: WorktreeDeleteBatchStreamClient | null } = {
+      command: null,
+    };
+    const finish = (attempt: DeleteAttempt): void => {
+      if (settled) return;
+      settled = true;
+      holder.command?.close();
+      resolve(attempt);
+    };
+    const command = new WorktreeDeleteBatchStreamClient({
+      wsStreamClient: client,
+      commandId: randomUUID(),
+      source: "cli",
+      targets: [{ worktreePath, scripts: null }],
+      callbacks: {
+        onTargetStarted: (_worktreePath, hasTeardown) =>
+          relayStatus(
+            ctx,
+            hasTeardown
+              ? "starting delete (running teardown script)"
+              : "starting delete",
+          ),
+        onTargetPhase: (_worktreePath, phase: WorktreeDeleteBatchPhase) =>
+          relayStatus(ctx, `phase: ${phase}`),
+        onTargetOutput: (
+          _worktreePath,
+          channel: WorktreeDeleteBatchOutputChannel,
+          chunk,
+        ) => relayOutput(ctx, channel, chunk),
+        onTargetComplete: (_worktreePath, deleted) =>
+          finish({ kind: "settled", deleted, error: null }),
+        onTargetFailed: (_worktreePath, reason) =>
+          finish({
+            kind: "settled",
+            deleted: false,
+            error: deleteFailedCliError(reason),
+          }),
+        // With one target this normally arrives after its terminal frame and
+        // is a no-op under the settled guard. It matters when it does NOT: an
+        // observer that attached to an already-settled command is told only
+        // how the COMMAND ended, and the counts are then the whole answer.
+        onCommandComplete: (counts) =>
+          finish({
+            kind: "settled",
+            deleted: counts.deletedCount === 1,
+            error: null,
+          }),
+        onCommandFailed: (reason) =>
+          finish({
+            kind: "settled",
+            deleted: false,
+            error: deleteFailedCliError(reason),
+          }),
+        onUnsupported: () => finish({ kind: "unsupported" }),
+        onConnectionStatus: (
+          status: StreamConnectionStatus,
+          reason: StreamCloseReason | null,
+        ) => {
+          if (status === "connecting" || status === "open") return;
+          if (
+            status === "closed" &&
+            reason !== null &&
+            reason.kind === "fatalError"
+          ) {
+            finish({
+              kind: "settled",
+              deleted: false,
+              error: fatalCloseToCliError(reason.details),
+            });
+            return;
+          }
+          finish({
+            kind: "settled",
+            deleted: false,
+            error: streamDroppedCliError(),
+          });
+        },
+      },
+    });
+    holder.command = command;
+    // A callback can settle DURING construction (the compatibility check is
+    // not contractually async), which would leave the transport open with
+    // nobody holding it.
+    if (settled) command.close();
+  });
+}
+
+/**
+ * Older-host path: the released single-target `worktree.deleteByPath@1.0`
+ * stream, unchanged. Resolves with the final `deleted` flag on the terminal
+ * `complete` frame; rejects with a CliError on a `failed` frame (the host's
+ * reason is preserved) or a fatal stream close.
+ */
+async function runLegacyDeleteStream(
+  worktreePath: string,
+  ctx: CommandContext,
+  client: WsStreamClient<HostStreamRpcRegistry>,
+): Promise<boolean> {
   return new Promise<boolean>((resolve, reject) => {
     let settled = false;
     const session = client.subscribe("worktree.deleteByPath", {
       worktreePath,
       scripts: null,
     });
-    // Tear down both the session and the client on any terminal outcome so the
-    // process can exit (an open socket keeps the event loop alive).
+    // Tear the session down on any terminal outcome; the caller closes the
+    // client (an open socket keeps the event loop alive).
     const finish = (act: () => void): void => {
       if (settled) return;
       settled = true;
       session.close();
-      client.close("worktree-delete-settled");
       act();
     };
     session.onServerFrame((envelope) => {
@@ -158,16 +320,7 @@ async function runWorktreeDeleteStream(
           finish(() => resolve(frame.deleted));
           return;
         case "failed":
-          finish(() =>
-            reject(
-              cliError({
-                code: CLI_ERROR_CODES.UNEXPECTED,
-                message: `traycer: worktree delete failed - ${frame.reason}`,
-                details: null,
-                exitCode: 1,
-              }),
-            ),
-          );
+          finish(() => reject(deleteFailedCliError(frame.reason)));
           return;
         case "pong":
           return;
@@ -228,7 +381,7 @@ function relayStatus(ctx: CommandContext, message: string): void {
  */
 function relayOutput(
   ctx: CommandContext,
-  channel: WorktreeDeleteOutputChannel,
+  channel: WorktreeDeleteOutputChannel | WorktreeDeleteBatchOutputChannel,
   chunk: string,
 ): void {
   if (ctx.runtime.json) {
@@ -245,12 +398,22 @@ function relayOutput(
   sink.write(chunk);
 }
 
+/** The host reported this delete as failed, with a displayable reason. */
+function deleteFailedCliError(reason: string): CliError {
+  return cliError({
+    code: CLI_ERROR_CODES.UNEXPECTED,
+    message: `traycer: worktree delete failed - ${reason}`,
+    details: null,
+    exitCode: 1,
+  });
+}
+
 /**
  * A recoverable transport drop (socket close, dial/openAck timeout, missed
- * pong, malformed frame) arrived before the host sent a terminal frame. The
- * shared client would auto-reconnect and re-send the delete, so we stop here
- * instead. The message is deliberately honest about the destructive
- * uncertainty: the worktree may or may not have been removed.
+ * pong, malformed frame) arrived before the host sent a terminal frame. We
+ * stop here rather than waiting the host out. The message is deliberately
+ * honest about the destructive uncertainty: the worktree may or may not have
+ * been removed, and nothing is replayed to find out.
  */
 function streamDroppedCliError(): CliError {
   return cliError({
@@ -266,6 +429,9 @@ function streamDroppedCliError(): CliError {
  * Map a fatal stream close to a stable CliError. `UNAUTHORIZED` means the host
  * rejected the bearer (no auth recovery is wired for this one-shot); a protocol
  * skew maps to `HOST_INCOMPATIBLE`; anything else is unexpected.
+ *
+ * A host that simply lacks the newer method never reaches here - that is an
+ * `onUnsupported` hand-off to the released stream, not a failure.
  */
 function fatalCloseToCliError(details: FatalErrorDetails): CliError {
   if (details.code === "UNAUTHORIZED") {
@@ -283,7 +449,7 @@ function fatalCloseToCliError(details: FatalErrorDetails): CliError {
   ) {
     return cliError({
       code: CLI_ERROR_CODES.HOST_INCOMPATIBLE,
-      message: `traycer: ${details.reason} - update the host or CLI so their worktree.deleteByPath versions match.`,
+      message: `traycer: ${details.reason} - update the host or CLI so their worktree delete versions match.`,
       details: null,
       exitCode: 1,
     });

--- a/protocol/src/host/__tests__/released-floor.test.ts
+++ b/protocol/src/host/__tests__/released-floor.test.ts
@@ -23,11 +23,13 @@ describe("released floor production module", () => {
       RELEASED_FLOOR_METHOD_NAMES,
     );
 
-    // Latest advertised major for list is 2.0 (native projections); major 1
-    // remains registered for the frozen all/unread bridge, but optional
-    // capability manifests always advertise the method's latest major.
+    // Latest advertised major for list is 2 (native projections), at minor 1
+    // (the `host.operation.finished` arm); major 1 remains registered for the
+    // frozen all/unread bridge, and 2.0 stays installed so an older peer
+    // negotiates down to it, but optional capability manifests always
+    // advertise the method's latest major AND minor.
     expect(split.optionalManifest).toMatchObject({
-      "host.notifications.list": { major: 2, minor: 0 },
+      "host.notifications.list": { major: 2, minor: 1 },
       "host.notifications.markRead": { major: 1, minor: 0 },
       "host.notifications.resolve": { major: 1, minor: 0 },
       "host.notifications.markAllRead": { major: 1, minor: 0 },

--- a/protocol/src/host/notifications/__tests__/host-notifications.test.ts
+++ b/protocol/src/host/notifications/__tests__/host-notifications.test.ts
@@ -16,7 +16,7 @@ import {
   hostNotificationsListResponseSchema,
   hostNotificationsListResponseSchemaV10,
   hostNotificationsListUpgradeV10ToV20,
-  hostNotificationsListDowngradeV20ToV10,
+  hostNotificationsListDowngradeV21ToV10,
   hostNotificationsMarkAllRead,
   hostNotificationsMarkRead,
   hostNotificationsSetConfig,
@@ -328,7 +328,7 @@ describe("host.notifications.list V10↔V20 upgrade/downgrade bridges", () => {
 
   it("downgrades recent/unreadRecent onto all/unread and strips cursor kind", () => {
     expect(
-      hostNotificationsListDowngradeV20ToV10.downgradeRequest({
+      hostNotificationsListDowngradeV21ToV10.downgradeRequest({
         filter: "recent",
         limit: 25,
         cursor: CHRONOLOGICAL_CURSOR,
@@ -345,7 +345,7 @@ describe("host.notifications.list V10↔V20 upgrade/downgrade bridges", () => {
       },
     });
     expect(
-      hostNotificationsListDowngradeV20ToV10.downgradeRequest({
+      hostNotificationsListDowngradeV21ToV10.downgradeRequest({
         filter: "unreadRecent",
         limit: 10,
       }),
@@ -357,7 +357,7 @@ describe("host.notifications.list V10↔V20 upgrade/downgrade bridges", () => {
 
   it("downgrades response cursors by stripping kind", () => {
     expect(
-      hostNotificationsListDowngradeV20ToV10.downgradeResponse({
+      hostNotificationsListDowngradeV21ToV10.downgradeResponse({
         entries: [STOPPED_ENTRY],
         nextCursor: CHRONOLOGICAL_CURSOR,
       }),
@@ -375,7 +375,7 @@ describe("host.notifications.list V10↔V20 upgrade/downgrade bridges", () => {
 
   it("rejects attention downgrade with a structured unsupported error", () => {
     expect(
-      hostNotificationsListDowngradeV20ToV10.downgradeRequest({
+      hostNotificationsListDowngradeV21ToV10.downgradeRequest({
         filter: "attention",
         limit: 25,
         cursor: ATTENTION_CURSOR,
@@ -736,7 +736,7 @@ describe("host.notifications registry membership", () => {
     ).toBe(hostNotificationsListUpgradeV10ToV20);
     expect(
       hostRpcRegistry["host.notifications.list"][2].downgradePathsFromLatest[1],
-    ).toBe(hostNotificationsListDowngradeV20ToV10);
+    ).toBe(hostNotificationsListDowngradeV21ToV10);
   });
 
   it("registers one flat unary contract per non-list method", () => {

--- a/protocol/src/host/notifications/__tests__/host-operation-finished-compat.test.ts
+++ b/protocol/src/host/notifications/__tests__/host-operation-finished-compat.test.ts
@@ -1,0 +1,466 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  hostRpcRegistry,
+  hostStreamRpcRegistry,
+} from "@traycer/protocol/host/registry";
+import {
+  ALL_HOST_NOTIFICATION_KINDS,
+  RELEASED_HOST_NOTIFICATION_KINDS,
+  formatHostNotificationPresentation,
+  hiddenHostNotificationKinds,
+  hostNotificationEntrySchema,
+  hostNotificationEntrySchemaV21,
+  hostNotificationsFeedSubscribeV10,
+  hostNotificationsFeedSubscribeV11,
+  hostNotificationsListDowngradeV21ToV10,
+  hostNotificationsListResponseSchema,
+  hostNotificationsListResponseSchemaV10,
+  hostNotificationsListResponseSchemaV21,
+  hostNotificationsListUpgradeV20ToV21,
+  hostNotificationsListV20,
+  hostNotificationsListV21,
+  hostNotificationsSubscribeServerFrameSchema,
+  hostNotificationsSubscribeServerFrameSchemaV10,
+  hostNotificationsSubscribeServerFrameSchemaV11,
+  hostOperationKnownCopy,
+  isReleasedHostNotificationEntry,
+  parseHostOperationCommonPayload,
+  parseKnownHostNotificationPayload,
+  streamCarriesChannelEmissionFrame,
+  visibleHostNotificationKinds,
+  type HostNotificationEntryV21,
+} from "@traycer/protocol/host/notifications/contracts";
+
+/**
+ * The one-time compatibility cutover for `host.operation.finished`.
+ *
+ * A leaked arm is not a hidden row: on the unary path the host re-parses its
+ * downgraded result against the caller's own contract and answers 500 for the
+ * whole page; on the feed path a failed frame parse reads as connection
+ * corruption and the client reconnects into a snapshot carrying the same row.
+ * These tests pin the boundary that makes that unreachable.
+ */
+
+const AGENT_STOPPED_ENTRY = {
+  id: "agent.stopped:chat-1",
+  updatedAt: 1_700_000_000_000,
+  readAt: null,
+  sourceRef: "chat-1",
+  severity: "done" as const,
+  epicId: "epic-1",
+  chatId: "chat-1",
+  kind: "agent.stopped" as const,
+  outcome: "completed" as const,
+  payload: { outcome: "completed" as const },
+};
+
+const OPERATION_FINISHED_ENTRY = {
+  id: "worktree.deletion:2f1d0a2c-0000-4000-8000-000000000000",
+  updatedAt: 1_700_000_000_001,
+  readAt: null,
+  sourceRef: "2f1d0a2c-0000-4000-8000-000000000000",
+  severity: "done" as const,
+  epicId: null,
+  chatId: null,
+  kind: "host.operation.finished" as const,
+  outcome: "completed" as const,
+  payload: {
+    operation: "some.future.operation",
+    title: "Deleted 3 worktrees",
+    message: "All 3 worktrees were removed.",
+  },
+};
+
+describe("host.operation.finished outer arm", () => {
+  it("is rejected by every released entry parser and accepted by @2.1", () => {
+    expect(
+      hostNotificationEntrySchema.safeParse(OPERATION_FINISHED_ENTRY).success,
+    ).toBe(false);
+    expect(
+      hostNotificationEntrySchemaV21.safeParse(OPERATION_FINISHED_ENTRY)
+        .success,
+    ).toBe(true);
+  });
+
+  it("keeps every released arm parsing identically on both unions", () => {
+    expect(hostNotificationEntrySchema.parse(AGENT_STOPPED_ENTRY)).toEqual(
+      hostNotificationEntrySchemaV21.parse(AGENT_STOPPED_ENTRY),
+    );
+  });
+
+  it("carries no resolvedAt, operation name, or structured detail", () => {
+    const parsed = hostNotificationEntrySchemaV21.parse({
+      ...OPERATION_FINISHED_ENTRY,
+      resolvedAt: 1_700_000_000_002,
+      destination: { kind: "hostSurface" },
+    });
+    expect(parsed).not.toHaveProperty("resolvedAt");
+    expect(parsed).not.toHaveProperty("destination");
+    expect(parsed.kind).toBe("host.operation.finished");
+  });
+
+  it("accepts both terminal outcomes and rejects a null one", () => {
+    for (const outcome of ["completed", "errored", "stopped"] as const) {
+      expect(
+        hostNotificationEntrySchemaV21.safeParse({
+          ...OPERATION_FINISHED_ENTRY,
+          outcome,
+        }).success,
+      ).toBe(true);
+    }
+    expect(
+      hostNotificationEntrySchemaV21.safeParse({
+        ...OPERATION_FINISHED_ENTRY,
+        outcome: null,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("narrows back to the released union", () => {
+    expect(
+      isReleasedHostNotificationEntry(
+        hostNotificationEntrySchemaV21.parse(AGENT_STOPPED_ENTRY),
+      ),
+    ).toBe(true);
+    expect(
+      isReleasedHostNotificationEntry(
+        hostNotificationEntrySchemaV21.parse(OPERATION_FINISHED_ENTRY),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("released schemas stay frozen", () => {
+  it("leaves list @1.0 / @2.0 responses unable to carry the new arm", () => {
+    const page = { entries: [OPERATION_FINISHED_ENTRY], nextCursor: null };
+    expect(hostNotificationsListResponseSchemaV10.safeParse(page).success).toBe(
+      false,
+    );
+    expect(hostNotificationsListResponseSchema.safeParse(page).success).toBe(
+      false,
+    );
+    expect(hostNotificationsListResponseSchemaV21.safeParse(page).success).toBe(
+      true,
+    );
+  });
+
+  it("leaves every released feed frame unable to carry the new arm", () => {
+    const upserted = {
+      kind: "upserted" as const,
+      hasBinaryPayload: false as const,
+      entry: OPERATION_FINISHED_ENTRY,
+      removedIds: [],
+      summary: { unreadCount: 1, attentionCount: 0 },
+    };
+    expect(
+      hostNotificationsSubscribeServerFrameSchema.safeParse(upserted).success,
+    ).toBe(false);
+    expect(
+      hostNotificationsSubscribeServerFrameSchemaV11.safeParse(upserted)
+        .success,
+    ).toBe(true);
+    expect(
+      hostNotificationsSubscribeServerFrameSchemaV10.safeParse({
+        kind: "upserted",
+        hasBinaryPayload: false,
+        entry: OPERATION_FINISHED_ENTRY,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("keeps the released contracts byte-identical to their frozen sources", () => {
+    const dump = (schema: z.ZodType): unknown =>
+      z.toJSONSchema(schema, { unrepresentable: "any" });
+    // The `@1.0` feed and the `@1.1` feed share one open request and one
+    // client frame union; only the server frame widens.
+    expect(dump(hostNotificationsFeedSubscribeV10.openRequestSchema)).toEqual(
+      dump(hostNotificationsFeedSubscribeV11.openRequestSchema),
+    );
+    expect(dump(hostNotificationsFeedSubscribeV10.clientFrameSchema)).toEqual(
+      dump(hostNotificationsFeedSubscribeV11.clientFrameSchema),
+    );
+    expect(
+      dump(hostNotificationsFeedSubscribeV10.serverFrameSchema),
+    ).not.toEqual(dump(hostNotificationsFeedSubscribeV11.serverFrameSchema));
+    // Requests are untouched by the response widening.
+    expect(dump(hostNotificationsListV20.requestSchema)).toEqual(
+      dump(hostNotificationsListV21.requestSchema),
+    );
+  });
+});
+
+describe("registry wiring", () => {
+  it("advertises @2.1 as the canonical list minor with @2.0 still installed", () => {
+    const line = hostRpcRegistry["host.notifications.list"][2];
+    expect(line.latestMinor).toBe(1);
+    expect(line.versions[0].contract).toBe(hostNotificationsListV20);
+    expect(line.versions[1].contract).toBe(hostNotificationsListV21);
+    expect(line.versions[1].upgradeFromPreviousVersion).toBe(
+      hostNotificationsListUpgradeV20ToV21,
+    );
+    expect(line.downgradePathsFromLatest[1]).toBe(
+      hostNotificationsListDowngradeV21ToV10,
+    );
+  });
+
+  it("advertises feed @1.1 with @1.0 still installed for older peers", () => {
+    const line = hostStreamRpcRegistry["host.notifications.feed.subscribe"][1];
+    expect(line.latestMinor).toBe(1);
+    expect(line.versions[0].contract).toBe(hostNotificationsFeedSubscribeV10);
+    expect(line.versions[1].contract).toBe(hostNotificationsFeedSubscribeV11);
+  });
+
+  it("keeps the legacy subscribe stream frozen at @1.0", () => {
+    const line = hostStreamRpcRegistry["host.notifications.subscribe"][1];
+    expect(line.latestMinor).toBe(0);
+    expect(Object.keys(line.versions)).toEqual(["0"]);
+  });
+});
+
+describe("negotiated-version visibility projection", () => {
+  it("hides the new kind from every released version and shows it on the successors", () => {
+    const cases: ReadonlyArray<{
+      readonly surface: Parameters<typeof visibleHostNotificationKinds>[0];
+      readonly version: { major: number; minor: number };
+      readonly sees: boolean;
+    }> = [
+      { surface: { method: "host.notifications.list" }, version: { major: 1, minor: 0 }, sees: false },
+      { surface: { method: "host.notifications.list" }, version: { major: 2, minor: 0 }, sees: false },
+      { surface: { method: "host.notifications.list" }, version: { major: 2, minor: 1 }, sees: true },
+      { surface: { method: "host.notifications.feed.subscribe" }, version: { major: 1, minor: 0 }, sees: false },
+      { surface: { method: "host.notifications.feed.subscribe" }, version: { major: 1, minor: 1 }, sees: true },
+      { surface: { method: "host.notifications.subscribe" }, version: { major: 1, minor: 0 }, sees: false },
+    ];
+    for (const { surface, version, sees } of cases) {
+      const visible = visibleHostNotificationKinds(surface, version);
+      const hidden = hiddenHostNotificationKinds(surface, version);
+      expect(visible.includes("host.operation.finished")).toBe(sees);
+      expect(hidden.includes("host.operation.finished")).toBe(!sees);
+      // Released kinds are visible on every version, always.
+      for (const kind of RELEASED_HOST_NOTIFICATION_KINDS) {
+        expect(visible).toContain(kind);
+        expect(hidden).not.toContain(kind);
+      }
+      expect([...visible, ...hidden].sort()).toEqual(
+        [...ALL_HOST_NOTIFICATION_KINDS].sort(),
+      );
+    }
+  });
+
+  it("fails closed for an unknown future major on every surface", () => {
+    // Majors are breaking by definition, so "newer than the majors I know"
+    // must not read as "carries everything I know" - a `list@3.0` could close
+    // its union around a different set of arms.
+    for (const surface of [
+      { method: "host.notifications.list" } as const,
+      { method: "host.notifications.feed.subscribe" } as const,
+      { method: "host.notifications.subscribe" } as const,
+    ]) {
+      for (const version of [
+        { major: 3, minor: 0 },
+        { major: 3, minor: 9 },
+        { major: 99, minor: 99 },
+        { major: 0, minor: 0 },
+      ]) {
+        expect(visibleHostNotificationKinds(surface, version)).toEqual(
+          RELEASED_HOST_NOTIFICATION_KINDS,
+        );
+        expect(hiddenHostNotificationKinds(surface, version)).toEqual([
+          "host.operation.finished",
+        ]);
+      }
+    }
+  });
+
+  it("keeps a fully-capable caller's exclusion empty", () => {
+    expect(
+      hiddenHostNotificationKinds(
+        { method: "host.notifications.feed.subscribe" },
+        { major: 1, minor: 1 },
+      ),
+    ).toEqual([]);
+  });
+
+  it("covers every kind the entry unions can carry", () => {
+    const armKinds = hostNotificationEntrySchemaV21.options.map(
+      (option) => option.shape.kind.value,
+    );
+    expect([...ALL_HOST_NOTIFICATION_KINDS].sort()).toEqual(
+      [...armKinds].sort(),
+    );
+    const releasedArmKinds = hostNotificationEntrySchema.options.map(
+      (option) => option.shape.kind.value,
+    );
+    expect([...RELEASED_HOST_NOTIFICATION_KINDS].sort()).toEqual(
+      [...releasedArmKinds].sort(),
+    );
+  });
+});
+
+describe("channel-emission capability", () => {
+  it("is declared by every installed stream version and closed for the rest", () => {
+    const feed = { method: "host.notifications.feed.subscribe" } as const;
+    const legacy = { method: "host.notifications.subscribe" } as const;
+    expect(streamCarriesChannelEmissionFrame(feed, { major: 1, minor: 0 })).toBe(
+      true,
+    );
+    expect(streamCarriesChannelEmissionFrame(feed, { major: 1, minor: 1 })).toBe(
+      true,
+    );
+    expect(
+      streamCarriesChannelEmissionFrame(legacy, { major: 1, minor: 0 }),
+    ).toBe(true);
+    // Unknown lines, and a unary method that has no frames at all.
+    expect(streamCarriesChannelEmissionFrame(feed, { major: 2, minor: 0 })).toBe(
+      false,
+    );
+    expect(
+      streamCarriesChannelEmissionFrame(legacy, { major: 1, minor: 1 }),
+    ).toBe(false);
+    expect(
+      streamCarriesChannelEmissionFrame(
+        { method: "host.notifications.list" },
+        { major: 2, minor: 1 },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("@2.1 -> @1.0 downgrade", () => {
+  it("cannot hand a v1.1.7 caller an arm it has no parser for", () => {
+    const result = hostNotificationsListDowngradeV21ToV10.downgradeResponse({
+      entries: [AGENT_STOPPED_ENTRY, OPERATION_FINISHED_ENTRY],
+      nextCursor: { kind: "chronological", updatedAt: 1, id: "x" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.entries.map((entry) => entry.id)).toEqual([
+      AGENT_STOPPED_ENTRY.id,
+    ]);
+    expect(
+      hostNotificationsListResponseSchemaV10.safeParse(result.value).success,
+    ).toBe(true);
+  });
+});
+
+describe("three-tier presentation", () => {
+  const entry = (
+    payload: Record<string, unknown>,
+    outcome: "completed" | "errored" | "stopped",
+  ): HostNotificationEntryV21 =>
+    hostNotificationEntrySchemaV21.parse({
+      ...OPERATION_FINISHED_ENTRY,
+      outcome,
+      payload,
+    });
+
+  it("tier 2: reads host-composed common fields off an unknown operation", () => {
+    expect(
+      formatHostNotificationPresentation(
+        entry(
+          {
+            operation: "some.future.operation",
+            title: "Cleaned up 4 test boxes",
+            message: "All 4 test boxes were released.",
+          },
+          "completed",
+        ),
+      ),
+    ).toEqual({
+      title: "Cleaned up 4 test boxes",
+      body: "All 4 test boxes were released.",
+    });
+  });
+
+  it("tier 3: falls back to generic copy keyed off the durable outcome", () => {
+    expect(formatHostNotificationPresentation(entry({}, "completed"))).toEqual({
+      title: "Host operation finished",
+      body: "Host operation • Done",
+    });
+    expect(formatHostNotificationPresentation(entry({}, "errored"))).toEqual({
+      title: "Host operation failed",
+      body: "Host operation • Failed",
+    });
+    expect(formatHostNotificationPresentation(entry({}, "stopped"))).toEqual({
+      title: "Host operation finished",
+      body: "Host operation • Stopped",
+    });
+  });
+
+  it("tier 3: rejects a partial or wrongly-typed common payload", () => {
+    for (const payload of [
+      { operation: "x", title: "only a title" },
+      { operation: "", title: "t", message: "m" },
+      { operation: "x", title: "", message: "m" },
+      { operation: "x", title: "t", message: 7 },
+    ]) {
+      expect(parseHostOperationCommonPayload(payload)).toBeNull();
+      expect(
+        formatHostNotificationPresentation(entry(payload, "errored")).title,
+      ).toBe("Host operation failed");
+    }
+  });
+
+  it("tier 1: no existing known arm may supply copy for a host-wide row", () => {
+    // The regression this guards: a first-match-wins tier-1 branch that
+    // derived its title from `knownPresentationContext` would render "Task"
+    // and a generic body the moment an arm started matching this kind -
+    // strictly worse than the tier-2 copy the same row shows today. Every arm
+    // that exists is chat-scoped and must decline, so the chain falls through.
+    const armPayloads: readonly Record<string, unknown>[] = [
+      { kind: "chat", epicId: "e", chatId: "c", agentName: "a", taskTitle: "t", outcome: "completed" },
+      { kind: "epic", epicId: "e", tuiAgentId: "t", agentName: "a", taskTitle: "t", outcome: "completed" },
+      { kind: "agent_stalled", epicId: "e", chatId: "c", agentId: "a", agentName: "a", taskTitle: "t", reason: "r", title: "x", outcome: "errored" },
+      { kind: "approval", epicId: "e", chatId: "c", chatTitle: "c", taskTitle: "t", approvalId: "a" },
+      { kind: "interview", epicId: "e", chatId: "c", chatTitle: "c", taskTitle: "t", interviewBlockId: "i" },
+      { kind: "workspace_operation_failed", epicId: "e", chatId: "c", chatTitle: "c", taskTitle: "t", operation: "setup", title: "x", message: "m", outcome: "errored" },
+    ];
+    for (const armPayload of armPayloads) {
+      const known = parseKnownHostNotificationPayload(armPayload);
+      expect(known).not.toBeNull();
+      if (known === null) continue;
+      expect(hostOperationKnownCopy(known)).toBeNull();
+    }
+  });
+
+  it("tier 1 can never render worse than tier 2 for the same payload", () => {
+    // A payload that satisfies BOTH the common convention and an existing
+    // known arm's shape still renders the host-composed copy.
+    //
+    // Today this passes because the kind guard keeps tier 1 unreachable; the
+    // test above is what pins the branch itself. Kept as the end-to-end
+    // statement of the property so it starts covering the live path the
+    // moment `payloadKindMatchesNotificationKind` returns an operation arm.
+    const hybrid = entry(
+      {
+        kind: "workspace_operation_failed",
+        epicId: "epic-1",
+        chatId: "chat-1",
+        chatTitle: "Some chat",
+        taskTitle: "Some task",
+        operation: "worktree.deletion",
+        title: "Deleted 3 worktrees",
+        message: "All 3 worktrees were removed.",
+        outcome: "errored",
+      },
+      "errored",
+    );
+    expect(formatHostNotificationPresentation(hybrid)).toEqual({
+      title: "Deleted 3 worktrees",
+      body: "All 3 worktrees were removed.",
+    });
+  });
+
+  it("keeps released kinds' copy unchanged", () => {
+    expect(
+      formatHostNotificationPresentation(
+        hostNotificationEntrySchemaV21.parse(AGENT_STOPPED_ENTRY),
+      ),
+    ).toEqual(
+      formatHostNotificationPresentation(
+        hostNotificationEntrySchema.parse(AGENT_STOPPED_ENTRY),
+      ),
+    );
+  });
+});

--- a/protocol/src/host/notifications/__tests__/payload-additivity-baseline.ts
+++ b/protocol/src/host/notifications/__tests__/payload-additivity-baseline.ts
@@ -163,4 +163,41 @@ export const PAYLOAD_FINGERPRINT_BASELINE = {
       "interviewBlockId",
     ],
   },
+  worktree_deletion: {
+    type: "object",
+    properties: {
+      kind: { type: "string", const: "worktree_deletion" },
+      operation: { type: "string", const: "worktree.deletion" },
+      title: { type: "string", minLength: 1 },
+      message: { type: "string", minLength: 1 },
+      commandId: { type: "string", minLength: 1 },
+      source: { type: "string", minLength: 1 },
+      requestedCount: {
+        type: "integer",
+        minimum: 0,
+        maximum: 9007199254740991,
+      },
+      deletedCount: {
+        type: "integer",
+        minimum: 0,
+        maximum: 9007199254740991,
+      },
+      failedCount: {
+        type: "integer",
+        minimum: 0,
+        maximum: 9007199254740991,
+      },
+    },
+    required: [
+      "kind",
+      "operation",
+      "title",
+      "message",
+      "commandId",
+      "source",
+      "requestedCount",
+      "deletedCount",
+      "failedCount",
+    ],
+  },
 } satisfies Record<HostNotificationKnownPayloadKind, JsonSchemaFingerprint>;

--- a/protocol/src/host/notifications/__tests__/payload-additivity.test.ts
+++ b/protocol/src/host/notifications/__tests__/payload-additivity.test.ts
@@ -12,6 +12,7 @@ import {
   hostNotificationInterviewPayloadSchema,
   hostNotificationKnownPayloadSchema,
   hostNotificationWorkspaceOperationFailedPayloadSchema,
+  hostNotificationWorktreeDeletionPayloadSchema,
   type HostNotificationKnownPayloadKind,
 } from "@traycer/protocol/host/notifications/payloads";
 import { PAYLOAD_FINGERPRINT_BASELINE } from "./payload-additivity-baseline";
@@ -32,6 +33,7 @@ const LIVE_PAYLOAD_SCHEMAS: Record<HostNotificationKnownPayloadKind, z.ZodType> 
       hostNotificationWorkspaceOperationFailedPayloadSchema,
     approval: hostNotificationApprovalPayloadSchema,
     interview: hostNotificationInterviewPayloadSchema,
+    worktree_deletion: hostNotificationWorktreeDeletionPayloadSchema,
   };
 
 const KINDS = [
@@ -41,6 +43,7 @@ const KINDS = [
   "workspace_operation_failed",
   "approval",
   "interview",
+  "worktree_deletion",
 ] as const satisfies readonly HostNotificationKnownPayloadKind[];
 
 describe("host notification payload additivity", () => {

--- a/protocol/src/host/notifications/__tests__/worktree-deletion-presentation.test.ts
+++ b/protocol/src/host/notifications/__tests__/worktree-deletion-presentation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatHostNotificationPresentation,
+  hostNotificationEntrySchemaV21,
+  hostOperationKnownCopy,
+  parseKnownHostNotificationPayloadForKind,
+} from "@traycer/protocol/host/notifications/contracts";
+
+describe("worktree deletion host-operation presentation", () => {
+  it("matches only host operation rows and preserves the host-composed copy", () => {
+    const payload = {
+      kind: "worktree_deletion" as const,
+      operation: "worktree.deletion" as const,
+      title: "Deleted 3 worktrees",
+      message: "All 3 worktrees were removed.",
+      commandId: "2f1d0a2c-0000-4000-8000-000000000000",
+      source: "settings",
+      requestedCount: 3,
+      deletedCount: 3,
+      failedCount: 0,
+    };
+    const known = parseKnownHostNotificationPayloadForKind(
+      "host.operation.finished",
+      payload,
+    );
+    expect(known?.kind).toBe("worktree_deletion");
+    if (known === null) throw new Error("expected worktree deletion payload");
+    expect(hostOperationKnownCopy(known)).toBeNull();
+    expect(
+      parseKnownHostNotificationPayloadForKind("agent.stopped", payload),
+    ).toBeNull();
+
+    expect(
+      formatHostNotificationPresentation(
+        hostNotificationEntrySchemaV21.parse({
+          id: "worktree.deletion:2f1d0a2c-0000-4000-8000-000000000000",
+          updatedAt: 1_700_000_000_000,
+          readAt: null,
+          sourceRef: payload.commandId,
+          severity: "done",
+          epicId: null,
+          chatId: null,
+          kind: "host.operation.finished",
+          outcome: "completed",
+          payload,
+        }),
+      ),
+    ).toEqual({ title: payload.title, body: payload.message });
+  });
+});

--- a/protocol/src/host/notifications/host-notifications.ts
+++ b/protocol/src/host/notifications/host-notifications.ts
@@ -25,12 +25,22 @@ export type HostNotificationFilterV10 = z.infer<
   typeof hostNotificationFilterSchemaV10
 >;
 
+/**
+ * Every notification kind this build knows, released and unreleased alike.
+ *
+ * NOT a wire schema - no contract references it. It is the closed TypeScript
+ * vocabulary shared by the host's persistence/enrichment layers and the
+ * payload/presentation parsers, which is why adding a kind here is safe while
+ * adding an arm to a released ENTRY union is not (see
+ * `hostNotificationEntrySchema` below).
+ */
 export const hostNotificationKindSchema = z.enum([
   "agent.stopped",
   "agent.stalled",
   "workspace.operation.failed",
   "approval.requested",
   "interview.requested",
+  "host.operation.finished",
 ]);
 export type HostNotificationKind = z.infer<typeof hostNotificationKindSchema>;
 
@@ -91,7 +101,15 @@ const hostNotificationEntryBaseFields = {
   chatId: z.string().min(1).nullable(),
 } as const;
 
-export const hostNotificationEntrySchema = z.discriminatedUnion("kind", [
+/**
+ * The five arms host v1.1.7 shipped. Held as a shared tuple so the released
+ * union below and the successor union that adds `host.operation.finished`
+ * are literally the same objects for these arms - a released client and a
+ * `@2.1`/`@1.1` client can never disagree about an arm they both know.
+ *
+ * FROZEN. Editing an arm here edits every released contract that carries it.
+ */
+const releasedHostNotificationEntryArms = [
   z.object({
     ...hostNotificationEntryBaseFields,
     kind: z.literal("agent.stopped"),
@@ -124,8 +142,179 @@ export const hostNotificationEntrySchema = z.discriminatedUnion("kind", [
     resolvedAt: z.number().int().nonnegative().nullable(),
     payload: hostNotificationPayloadSchema,
   }),
-]);
+] as const;
+
+/**
+ * The RELEASED entry union, shared verbatim by list `@1.0`, list `@2.0`,
+ * legacy subscribe `@1.0`, and feed subscribe `@1.0`.
+ *
+ * This union is CLOSED and frozen. Zod's within-minor downgrade strips
+ * unknown *fields*; it cannot strip an unknown *arm*, so one new-kind row
+ * reaching a released parser is a hard failure, not a cosmetic one: the unary
+ * handler re-parses its downgraded result against the caller's contract and
+ * returns 500, and the GUI feed treats a failed frame parse as connection
+ * corruption and reconnects into a snapshot that replays the same row.
+ * Adding an arm therefore requires a new contract version plus a host-side
+ * projection that keeps the arm out of every older version's rows, summaries,
+ * cursors, and frames - never a post-query filter.
+ */
+export const hostNotificationEntrySchema = z.discriminatedUnion(
+  "kind",
+  releasedHostNotificationEntryArms,
+);
 export type HostNotificationEntry = z.infer<typeof hostNotificationEntrySchema>;
+
+/**
+ * Terminal completion of one host-owned operation, addressed to the user
+ * rather than to an epic/chat entity.
+ *
+ * Deliberately minimal, because it is frozen the day it ships: base fields, an
+ * open `outcome`, and the same open payload record every other arm uses. No
+ * operation names, structured details, actions, destinations, progress states,
+ * `resolvedAt`, or per-operation preferences live here - operation-specific
+ * data belongs in the additive payload tier (see `payloads.ts`), which is what
+ * lets a future operation ship without another outer-kind bump.
+ *
+ * Producers use `done`/`completed` or `failure`/`errored`; blocked-on-input
+ * stays in the approval/interview domains. Existing released
+ * `workspace.operation.failed` producers stay on that frozen chat-scoped kind;
+ * every NEW operation-completion producer - including new failure producers -
+ * uses this one, so the two generic-looking kinds never become arbitrary
+ * alternatives.
+ */
+const hostOperationFinishedEntryArm = z.object({
+  ...hostNotificationEntryBaseFields,
+  kind: z.literal("host.operation.finished"),
+  outcome: hostNotificationOutcomeSchema,
+  payload: hostNotificationPayloadSchema,
+});
+
+/** Released arms plus `host.operation.finished`; list `@2.1` / feed `@1.1`. */
+export const hostNotificationEntrySchemaV21 = z.discriminatedUnion("kind", [
+  ...releasedHostNotificationEntryArms,
+  hostOperationFinishedEntryArm,
+]);
+export type HostNotificationEntryV21 = z.infer<
+  typeof hostNotificationEntrySchemaV21
+>;
+
+/** Narrows a `@2.1` entry to the released union. */
+export function isReleasedHostNotificationEntry(
+  entry: HostNotificationEntryV21,
+): entry is HostNotificationEntry {
+  return entry.kind !== "host.operation.finished";
+}
+
+/** The kinds every released contract version can carry. FROZEN. */
+export const RELEASED_HOST_NOTIFICATION_KINDS: readonly HostNotificationKind[] =
+  [
+    "agent.stopped",
+    "agent.stalled",
+    "workspace.operation.failed",
+    "approval.requested",
+    "interview.requested",
+  ];
+
+/** Every kind this build can carry, on the newest version of each surface. */
+export const ALL_HOST_NOTIFICATION_KINDS: readonly HostNotificationKind[] = [
+  ...RELEASED_HOST_NOTIFICATION_KINDS,
+  "host.operation.finished",
+];
+
+/**
+ * The one negotiated-version → visible-kinds projection.
+ *
+ * Every read path that serves a specific connection - unary pages, stream
+ * snapshots, live frames, cursors, and summaries - derives its filter from
+ * here rather than re-deriving "is this caller new enough". A caller that
+ * negotiated an older version must never observe a kind its parser cannot
+ * represent, and the exclusion has to happen INSIDE the query: filtering
+ * after the fact yields short pages, cursors that skip rows, and counts that
+ * disagree with the page they summarize.
+ */
+export type HostNotificationsSurface =
+  | { readonly method: "host.notifications.list" }
+  | { readonly method: "host.notifications.feed.subscribe" }
+  | { readonly method: "host.notifications.subscribe" };
+
+/**
+ * Enumerated per SUPPORTED major, never `major > N`.
+ *
+ * A major bump is breaking by definition: a future `list@3.0` could close its
+ * entry union around a different set of arms, so treating "newer than the
+ * majors I know" as "carries everything I know" would hand it kinds it may not
+ * be able to represent. An unknown major therefore falls through to the
+ * released set - the only set every contract in this family has ever carried -
+ * which fails in the safe direction (a row is withheld, never leaked). When a
+ * real major 3 ships it adds its own case here and the fallthrough stops
+ * applying to it.
+ */
+export function visibleHostNotificationKinds(
+  surface: HostNotificationsSurface,
+  schemaVersion: { readonly major: number; readonly minor: number },
+): readonly HostNotificationKind[] {
+  switch (surface.method) {
+    case "host.notifications.list":
+      if (schemaVersion.major === 1) return RELEASED_HOST_NOTIFICATION_KINDS;
+      if (schemaVersion.major === 2) {
+        return schemaVersion.minor >= 1
+          ? ALL_HOST_NOTIFICATION_KINDS
+          : RELEASED_HOST_NOTIFICATION_KINDS;
+      }
+      return RELEASED_HOST_NOTIFICATION_KINDS;
+    case "host.notifications.feed.subscribe":
+      if (schemaVersion.major === 1) {
+        return schemaVersion.minor >= 1
+          ? ALL_HOST_NOTIFICATION_KINDS
+          : RELEASED_HOST_NOTIFICATION_KINDS;
+      }
+      return RELEASED_HOST_NOTIFICATION_KINDS;
+    // The frozen host-v1.1.7 stream has no successor minor and never will.
+    case "host.notifications.subscribe":
+      return RELEASED_HOST_NOTIFICATION_KINDS;
+  }
+}
+
+/**
+ * Whether the negotiated stream contract declares a `channelEmission` frame.
+ *
+ * Enumerated per supported (method, major) for the same reason the visibility
+ * projection is: an unknown line gets `false`, so a future version that drops
+ * the frame - or that this build simply does not know - cannot be sent one.
+ * This answers only "does the frame exist on this wire"; WHICH rows may appear
+ * in it is the separate question `visibleHostNotificationKinds` answers, and
+ * both gates apply.
+ */
+export function streamCarriesChannelEmissionFrame(
+  surface: HostNotificationsSurface,
+  schemaVersion: { readonly major: number; readonly minor: number },
+): boolean {
+  switch (surface.method) {
+    // Every installed minor of the feed (`@1.0`, `@1.1`) declares the frame.
+    case "host.notifications.feed.subscribe":
+      return schemaVersion.major === 1;
+    // The frozen released stream declares it at its only version.
+    case "host.notifications.subscribe":
+      return schemaVersion.major === 1 && schemaVersion.minor === 0;
+    // Unary: no frames at all.
+    case "host.notifications.list":
+      return false;
+  }
+}
+
+/**
+ * The complement of {@link visibleHostNotificationKinds}. Read paths filter on
+ * this rather than on the visible set so a fully-capable caller produces an
+ * EMPTY exclusion - and therefore byte-identical SQL to before this projection
+ * existed, which is what keeps the attention/recent partial indexes selected.
+ */
+export function hiddenHostNotificationKinds(
+  surface: HostNotificationsSurface,
+  schemaVersion: { readonly major: number; readonly minor: number },
+): readonly HostNotificationKind[] {
+  const visible = new Set(visibleHostNotificationKinds(surface, schemaVersion));
+  return ALL_HOST_NOTIFICATION_KINDS.filter((kind) => !visible.has(kind));
+}
 
 export const hostNotificationCursorSchemaV10 = z.object({
   updatedAt: z.number().int().nonnegative(),
@@ -233,6 +422,15 @@ export const hostNotificationsListResponseSchema = z.object({
 });
 export type HostNotificationsListResponse = z.infer<
   typeof hostNotificationsListResponseSchema
+>;
+
+/** `@2.1` response: identical projection, widened entry union. */
+export const hostNotificationsListResponseSchemaV21 = z.object({
+  entries: z.array(hostNotificationEntrySchemaV21),
+  nextCursor: hostNotificationsCursorSchema.nullable(),
+});
+export type HostNotificationsListResponseV21 = z.infer<
+  typeof hostNotificationsListResponseSchemaV21
 >;
 
 export const hostNotificationsEntityRefSchema = z.object({
@@ -479,6 +677,78 @@ export type HostNotificationsSubscribeServerFrame = z.infer<
   typeof hostNotificationsSubscribeServerFrameSchema
 >;
 
+/**
+ * Feed `@1.1` server frames: the released `@1.0` union with every entry-
+ * carrying slot widened to `hostNotificationEntrySchemaV21`.
+ *
+ * Written out in full rather than derived from the `@1.0` union. The released
+ * shape above must stay byte-identical forever, and a shared builder would let
+ * a future edit here silently rewrite it - the same reason `@1.0`'s own frames
+ * are spelled out separately from the legacy `V10` union.
+ */
+export const hostNotificationsSubscribeServerFrameSchemaV11 =
+  z.discriminatedUnion("kind", [
+    z.object({
+      kind: z.literal("snapshot"),
+      ...textFrameFields,
+      attention: z.object({
+        entries: z.array(hostNotificationEntrySchemaV21),
+        nextCursor: hostNotificationsAttentionCursorSchema.nullable(),
+      }),
+      recent: z.object({
+        entries: z.array(hostNotificationEntrySchemaV21),
+        nextCursor: hostNotificationsChronologicalCursorSchema.nullable(),
+      }),
+      summary: hostNotificationsSummarySchema,
+    }),
+    z.object({
+      kind: z.literal("upserted"),
+      ...textFrameFields,
+      entry: hostNotificationEntrySchemaV21,
+      removedIds: nonDuplicateIdArraySchema(0),
+      summary: hostNotificationsSummarySchema,
+    }),
+    z.object({
+      kind: z.literal("readStateChanged"),
+      ...textFrameFields,
+      ids: z.array(z.string()).min(1),
+      entityRefs: z.array(hostNotificationsEntityRefSchema),
+      readAt: z.number().int().nonnegative().nullable(),
+      resolvedAt: z.number().int().nonnegative().nullable(),
+      removedIds: nonDuplicateIdArraySchema(0),
+      summary: hostNotificationsSummarySchema,
+    }),
+    z.object({
+      kind: z.literal("removed"),
+      ...textFrameFields,
+      removedIds: nonDuplicateIdArraySchema(1),
+      summary: hostNotificationsSummarySchema,
+    }),
+    z.object({
+      kind: z.literal("cleared"),
+      ...textFrameFields,
+      beforeUpdatedAt: z.number().int().nonnegative(),
+      removedIds: nonDuplicateIdArraySchema(0),
+      summary: hostNotificationsSummarySchema,
+    }),
+    z.object({
+      kind: z.literal("channelEmission"),
+      ...textFrameFields,
+      emissionId: z.string(),
+      channelId: hostNotificationChannelIdSchema,
+      severity: hostNotificationSeveritySchema,
+      rows: z.array(hostNotificationEntrySchemaV21).min(1),
+      reason: hostNotificationsChannelEmissionReasonSchema,
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      ...textFrameFields,
+    }),
+  ]);
+export type HostNotificationsSubscribeServerFrameV11 = z.infer<
+  typeof hostNotificationsSubscribeServerFrameSchemaV11
+>;
+
 export const hostNotificationsSubscribeClientFrameSchema = z.discriminatedUnion(
   "kind",
   [
@@ -616,6 +886,13 @@ export const hostNotificationsListV20 = defineRpcContract({
   responseSchema: hostNotificationsListResponseSchema,
 });
 
+export const hostNotificationsListV21 = defineRpcContract({
+  method: "host.notifications.list",
+  schemaVersion: { major: 2, minor: 1 } as const,
+  requestSchema: hostNotificationsListRequestSchema,
+  responseSchema: hostNotificationsListResponseSchemaV21,
+});
+
 export const hostNotificationsListUpgradeV10ToV20 = defineUpgradePath<
   typeof hostNotificationsListV10,
   typeof hostNotificationsListV20
@@ -638,11 +915,25 @@ export const hostNotificationsListUpgradeV10ToV20 = defineUpgradePath<
   }),
 });
 
-export const hostNotificationsListDowngradeV20ToV10 = defineDowngradePath<
+/**
+ * Request-identical, response-widening. The `@2.0` entry union is a strict
+ * subset of `@2.1`'s, so every `@2.0` response is already a valid `@2.1` one.
+ */
+export const hostNotificationsListUpgradeV20ToV21 = defineUpgradePath<
   typeof hostNotificationsListV20,
-  typeof hostNotificationsListV10
+  typeof hostNotificationsListV21
 >({
   from: hostNotificationsListV20.schemaVersion,
+  to: hostNotificationsListV21.schemaVersion,
+  upgradeRequest: (request) => request,
+  upgradeResponse: (response) => response,
+});
+
+export const hostNotificationsListDowngradeV21ToV10 = defineDowngradePath<
+  typeof hostNotificationsListV21,
+  typeof hostNotificationsListV10
+>({
+  from: hostNotificationsListV21.schemaVersion,
   to: hostNotificationsListV10.schemaVersion,
   downgradeRequest: (request) => {
     if (request.filter === "attention") {
@@ -668,10 +959,16 @@ export const hostNotificationsListDowngradeV20ToV10 = defineDowngradePath<
       },
     };
   },
+  // `entries` is narrowed rather than passed through. A major-1 caller's rows
+  // are already excluded inside SQL - the projection, not this bridge, is what
+  // keeps pages, cursors, and summaries consistent - so this filter is dead
+  // code in practice. It exists because the bridge must be TOTAL over its
+  // declared input: if a future read path ever forgets the projection, a
+  // short page beats an unrepresentable arm reaching a v1.1.7 client.
   downgradeResponse: (response) => ({
     ok: true,
     value: {
-      entries: response.entries,
+      entries: response.entries.filter(isReleasedHostNotificationEntry),
       nextCursor:
         response.nextCursor === null
           ? null
@@ -724,6 +1021,15 @@ export const hostNotificationsFeedSubscribeV10 = defineStreamRpcContract({
   schemaVersion: { major: 1, minor: 0 } as const,
   openRequestSchema: hostNotificationsSubscribeOpenRequestSchema,
   serverFrameSchema: hostNotificationsSubscribeServerFrameSchema,
+  clientFrameSchema: hostNotificationsSubscribeClientFrameSchema,
+});
+
+/** Additive minor: same open request and client frames, widened entry union. */
+export const hostNotificationsFeedSubscribeV11 = defineStreamRpcContract({
+  method: "host.notifications.feed.subscribe",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  openRequestSchema: hostNotificationsSubscribeOpenRequestSchema,
+  serverFrameSchema: hostNotificationsSubscribeServerFrameSchemaV11,
   clientFrameSchema: hostNotificationsSubscribeClientFrameSchema,
 });
 

--- a/protocol/src/host/notifications/payloads.ts
+++ b/protocol/src/host/notifications/payloads.ts
@@ -221,6 +221,92 @@ export type HostNotificationInterviewPayload = z.infer<
   typeof hostNotificationInterviewPayloadSchema
 >;
 
+/**
+ * The common field convention EVERY `host.operation.finished` payload arm
+ * must satisfy, read leniently as an open record.
+ *
+ * This is the middle degradation tier, and the whole reason the outer arm can
+ * stay frozen while operations keep being added: a client that knows
+ * `host.operation.finished` but not the newest operation's payload arm still
+ * gets host-composed, display-safe copy instead of "a host operation
+ * finished". `operation` is an open identifier (first value
+ * `worktree.deletion`), never a closed enum - the precedent is
+ * `workspace_operation_failed.operation`.
+ *
+ * Deliberately NOT a member of `hostNotificationKnownPayloadSchema`: this is a
+ * shape every arm conforms to, not an arm of its own, so it must never win a
+ * discriminated-union match against a real operation payload.
+ */
+export const hostOperationCommonPayloadSchema = z
+  .object({
+    operation: idSchema,
+    title: z.string().min(1),
+    message: z.string().min(1),
+  })
+  .catchall(z.unknown());
+export type HostOperationCommonPayload = z.infer<
+  typeof hostOperationCommonPayloadSchema
+>;
+
+/**
+ * Total lenient parse of the common fields, or `null` when the payload does
+ * not carry them. `null` means "fall through to generic copy" - never an
+ * error, since rows outlive code in both directions.
+ */
+export function parseHostOperationCommonPayload(
+  value: unknown,
+): HostOperationCommonPayload | null {
+  const parsed = hostOperationCommonPayloadSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+/**
+ * The stable `operation` identifier of the first (and so far only)
+ * `host.operation.finished` producer.
+ *
+ * Deliberately NOT the `worktree.delete` RPC method name: this names a
+ * user-authorized deletion COMMAND over N targets, which is a different thing
+ * from the released single-target endpoint, and a durable row must not read
+ * as if it were an RPC trace.
+ */
+export const HOST_OPERATION_WORKTREE_DELETION = "worktree.deletion";
+
+/**
+ * `host.operation.finished` payload for a worktree-deletion command - the
+ * first operation arm, and the template for every later one.
+ *
+ * Carries the common `operation`/`title`/`message` convention (so a client
+ * that knows the outer kind but not this arm still renders host-composed
+ * copy) plus exactly the structured fields presentation and routing need:
+ * the command's identity, where the user started it, and the aggregate
+ * counts.
+ *
+ * What it deliberately EXCLUDES is as much of the contract as what it
+ * carries: no worktree paths, no teardown output, no raw command text, no
+ * arbitrary error strings. A notification row is durable, is delivered to
+ * email and webhooks, and outlives the filesystem it describes - a path in it
+ * is both a leak and a lie. It is also why no retry action exists: a safe
+ * retry would need exactly the paths this must not persist.
+ */
+export const hostNotificationWorktreeDeletionPayloadSchema = z
+  .object({
+    kind: z.literal("worktree_deletion"),
+    operation: z.literal(HOST_OPERATION_WORKTREE_DELETION),
+    title: z.string().min(1),
+    message: z.string().min(1),
+    commandId: idSchema,
+    /** Open string, not the wire enum: a row minted by a newer host with a
+     * source this build has never heard of must still render and route. */
+    source: idSchema,
+    requestedCount: z.number().int().nonnegative(),
+    deletedCount: z.number().int().nonnegative(),
+    failedCount: z.number().int().nonnegative(),
+  })
+  .catchall(z.unknown());
+export type HostNotificationWorktreeDeletionPayload = z.infer<
+  typeof hostNotificationWorktreeDeletionPayloadSchema
+>;
+
 export const hostNotificationKnownPayloadSchema = z.discriminatedUnion("kind", [
   hostNotificationChatStoppedPayloadSchema,
   hostNotificationEpicStoppedPayloadSchema,
@@ -228,6 +314,7 @@ export const hostNotificationKnownPayloadSchema = z.discriminatedUnion("kind", [
   hostNotificationWorkspaceOperationFailedPayloadSchema,
   hostNotificationApprovalPayloadSchema,
   hostNotificationInterviewPayloadSchema,
+  hostNotificationWorktreeDeletionPayloadSchema,
 ]);
 export type HostNotificationKnownPayload = z.infer<
   typeof hostNotificationKnownPayloadSchema
@@ -283,5 +370,11 @@ function payloadKindMatchesNotificationKind(
       return payloadKind === "approval";
     case "interview.requested":
       return payloadKind === "interview";
+    // One operation arm exists so far. A FUTURE operation adds its arm above
+    // and its kind to this list; until a client learns that kind, its rows
+    // degrade to the common-field tier rather than failing - which is the
+    // property the whole payload tier exists to provide.
+    case "host.operation.finished":
+      return payloadKind === "worktree_deletion";
   }
 }

--- a/protocol/src/host/notifications/presentation.ts
+++ b/protocol/src/host/notifications/presentation.ts
@@ -1,9 +1,10 @@
 import {
-  type HostNotificationEntry,
+  type HostNotificationEntryV21,
   type HostNotificationOutcome,
 } from "@traycer/protocol/host/notifications/host-notifications";
 import {
   deriveHostNotificationStoppedReason,
+  parseHostOperationCommonPayload,
   parseKnownHostNotificationPayloadForKind,
   type HostNotificationKnownPayload,
 } from "@traycer/protocol/host/notifications/payloads";
@@ -28,7 +29,7 @@ export interface HostNotificationPresentation {
  * generic copy instead of throwing or exposing untrusted raw error text.
  */
 export function formatHostNotificationPresentation(
-  entry: HostNotificationEntry,
+  entry: HostNotificationEntryV21,
 ): HostNotificationPresentation {
   const known = parseKnownHostNotificationPayloadForKind(
     entry.kind,
@@ -65,7 +66,98 @@ export function formatHostNotificationPresentation(
         title,
         body: `${agentContext} • ${resolvableRequestStatus(entry.resolvedAt, "Question waiting", "Question resolved")}`,
       };
+    case "host.operation.finished":
+      return hostOperationFinishedPresentation(entry.outcome, entry.payload);
   }
+}
+
+/**
+ * Three-tier degradation for a host-wide operation completion, resolved as a
+ * per-FIELD fallback chain rather than a first-match-wins branch:
+ *
+ *  1. a KNOWN operation payload's own copy, when that arm supplies any
+ *     (`hostOperationKnownCopy` - no arm supplies copy yet);
+ *  2. the common `operation`/`title`/`message` convention read leniently off
+ *     the open record, so an operation newer than this build still shows
+ *     host-composed copy;
+ *  3. generic copy, keyed only off the durable `outcome` column.
+ *
+ * The chain is per-field on purpose. A first-match-wins branch would let the
+ * first real operation arm REGRESS a row that already renders host-composed
+ * copy today: recognising the payload would swap "Deleted 3 worktrees" for
+ * whatever the known branch produced. Here an arm can only ever add copy, so
+ * a known payload is never worse than an unknown one - which is the property
+ * that makes the tier ordering safe to activate.
+ *
+ * Tiers 2 and 3 are what make the frozen outer arm affordable: a future
+ * operation is additive at the payload layer and never needs another outer
+ * kind. Copy comes from the host, so it reaches email and hooks unchanged.
+ */
+function hostOperationFinishedPresentation(
+  outcome: HostNotificationOutcome,
+  payload: Record<string, unknown>,
+): HostNotificationPresentation {
+  const known = parseKnownHostNotificationPayloadForKind(
+    "host.operation.finished",
+    payload,
+  );
+  const operationCopy = known === null ? null : hostOperationKnownCopy(known);
+  const common = parseHostOperationCommonPayload(payload);
+  return {
+    title:
+      operationCopy?.title ??
+      common?.title ??
+      hostOperationGenericTitle(outcome),
+    body:
+      operationCopy?.body ??
+      common?.message ??
+      hostOperationGenericBody(outcome),
+  };
+}
+
+/**
+ * Per-operation copy for a payload arm this build fully understands, or
+ * `null` to inherit the common-field/generic copy below it.
+ *
+ * Exhaustive over the known payload union so the first operation arm gets a
+ * compile-visible slot here. Every arm that exists today is chat-scoped and
+ * belongs to a different notification kind, so none of them may supply copy
+ * for a host-wide row: their titles come from `taskTitle`/`chatTitle` fields
+ * a host-wide operation payload does not have, and letting them answer would
+ * render "Task" over the host's own composed title.
+ */
+export function hostOperationKnownCopy(
+  payload: HostNotificationKnownPayload,
+): { readonly title: string | null; readonly body: string | null } | null {
+  switch (payload.kind) {
+    case "chat":
+    case "epic":
+    case "agent_stalled":
+    case "approval":
+    case "interview":
+    case "workspace_operation_failed":
+      return null;
+    // Worktree deletion supplies no copy of its own on purpose: the host
+    // already composed `title`/`message` into the payload's common fields, and
+    // that exact wording is what reached email and notification hooks at mint
+    // time. Re-deriving it here would make the in-app row and the email
+    // disagree about the same command for no gain - the arm's value is the
+    // structured counts and the navigation target, not the prose.
+    case "worktree_deletion":
+      return null;
+  }
+}
+
+function hostOperationGenericTitle(outcome: HostNotificationOutcome): string {
+  return outcome === "errored"
+    ? "Host operation failed"
+    : "Host operation finished";
+}
+
+function hostOperationGenericBody(outcome: HostNotificationOutcome): string {
+  if (outcome === "errored") return "Host operation • Failed";
+  if (outcome === "stopped") return "Host operation • Stopped";
+  return "Host operation • Done";
 }
 
 // The protocol records only whether an approval/interview has resolved, not
@@ -84,7 +176,8 @@ function knownPresentationContext(known: HostNotificationKnownPayload | null) {
     known === null ? null : nonEmptyTitle(knownAgentName(known));
   const chatTitle =
     known === null ? null : nonEmptyTitle(knownChatTitle(known));
-  const taskTitle = known === null ? null : nonEmptyTitle(known.taskTitle);
+  const taskTitle =
+    known === null ? null : nonEmptyTitle(knownTaskTitle(known));
   const title = taskTitle ?? chatTitle ?? agentName ?? "Task";
   return {
     agentName,
@@ -92,6 +185,30 @@ function knownPresentationContext(known: HostNotificationKnownPayload | null) {
     agentContext:
       chatTitle !== null && chatTitle !== title ? chatTitle : "Agent",
   };
+}
+
+/**
+ * The task title a chat-scoped payload carries, or `null` for a payload that
+ * has no task at all.
+ *
+ * Read through a switch rather than off the union directly (`known.taskTitle`)
+ * because host-WIDE operation payloads are not addressed to an epic/chat and
+ * carry no such field. This is the compile-visible seam that stopped the first
+ * host-wide arm from being modelled as "a task notification with the task
+ * fields left blank".
+ */
+function knownTaskTitle(payload: HostNotificationKnownPayload): string | null {
+  switch (payload.kind) {
+    case "chat":
+    case "epic":
+    case "agent_stalled":
+    case "approval":
+    case "interview":
+    case "workspace_operation_failed":
+      return payload.taskTitle;
+    case "worktree_deletion":
+      return null;
+  }
 }
 
 function knownAgentName(payload: HostNotificationKnownPayload): string | null {
@@ -103,6 +220,7 @@ function knownAgentName(payload: HostNotificationKnownPayload): string | null {
     case "approval":
     case "interview":
     case "workspace_operation_failed":
+    case "worktree_deletion":
       return null;
   }
 }
@@ -116,6 +234,7 @@ function knownChatTitle(payload: HostNotificationKnownPayload): string | null {
     case "chat":
     case "epic":
     case "agent_stalled":
+    case "worktree_deletion":
       return null;
   }
 }
@@ -134,6 +253,7 @@ function knownStoppedReason(
     case "approval":
     case "interview":
     case "workspace_operation_failed":
+    case "worktree_deletion":
       return null;
   }
 }
@@ -151,6 +271,7 @@ function knownProviderId(
     case "approval":
     case "interview":
     case "workspace_operation_failed":
+    case "worktree_deletion":
       return null;
   }
 }

--- a/protocol/src/host/notifications/presentation.ts
+++ b/protocol/src/host/notifications/presentation.ts
@@ -67,7 +67,11 @@ export function formatHostNotificationPresentation(
         body: `${agentContext} • ${resolvableRequestStatus(entry.resolvedAt, "Question waiting", "Question resolved")}`,
       };
     case "host.operation.finished":
-      return hostOperationFinishedPresentation(entry.outcome, entry.payload);
+      return hostOperationFinishedPresentation(
+        entry.outcome,
+        entry.payload,
+        known,
+      );
   }
 }
 
@@ -96,11 +100,8 @@ export function formatHostNotificationPresentation(
 function hostOperationFinishedPresentation(
   outcome: HostNotificationOutcome,
   payload: Record<string, unknown>,
+  known: HostNotificationKnownPayload | null,
 ): HostNotificationPresentation {
-  const known = parseKnownHostNotificationPayloadForKind(
-    "host.operation.finished",
-    payload,
-  );
   const operationCopy = known === null ? null : hostOperationKnownCopy(known);
   const common = parseHostOperationCommonPayload(payload);
   return {

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -266,15 +266,18 @@ import {
   hostNotificationsClearAll,
   hostNotificationsGetConfig,
   hostNotificationsIndicatorState,
-  hostNotificationsListDowngradeV20ToV10,
+  hostNotificationsListDowngradeV21ToV10,
   hostNotificationsListUpgradeV10ToV20,
+  hostNotificationsListUpgradeV20ToV21,
   hostNotificationsListV10,
   hostNotificationsListV20,
+  hostNotificationsListV21,
   hostNotificationsMarkAllRead,
   hostNotificationsMarkRead,
   hostNotificationsResolve,
   hostNotificationsSetConfig,
   hostNotificationsFeedSubscribeV10,
+  hostNotificationsFeedSubscribeV11,
   hostNotificationsSubscribeV10,
   notificationsSubscribeV10,
 } from "@traycer/protocol/host/notifications/contracts";
@@ -295,6 +298,7 @@ import {
   migrationRunV10,
   phaseMigrateToEpicV10,
 } from "@traycer/protocol/host/migration/contracts";
+import { worktreeDeleteBatchByPathStreamV10 } from "@traycer/protocol/host/worktree-delete-batch-stream";
 import { worktreeDeleteByPathStreamV10 } from "@traycer/protocol/host/worktree-delete-stream";
 import { worktreeChangedV10 } from "@traycer/protocol/host/worktree-changed-stream";
 import { editorOpenPathsV10 } from "@traycer/protocol/host/editor/contracts";
@@ -2430,15 +2434,19 @@ const HOST_RPC_REGISTRY_DEFINITION = {
       downgradePathsFromLatest: {},
     },
     2: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: hostNotificationsListV20,
           upgradeFromPreviousVersion: hostNotificationsListUpgradeV10ToV20,
         },
+        1: {
+          contract: hostNotificationsListV21,
+          upgradeFromPreviousVersion: hostNotificationsListUpgradeV20ToV21,
+        },
       },
       downgradePathsFromLatest: {
-        1: hostNotificationsListDowngradeV20ToV10,
+        1: hostNotificationsListDowngradeV21ToV10,
       },
     },
   },
@@ -4832,10 +4840,13 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
   },
   "host.notifications.feed.subscribe": {
     1: {
-      latestMinor: 0,
+      latestMinor: 1,
       versions: {
         0: {
           contract: hostNotificationsFeedSubscribeV10,
+        },
+        1: {
+          contract: hostNotificationsFeedSubscribeV11,
         },
       },
     },
@@ -4950,6 +4961,23 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
       versions: {
         0: {
           contract: worktreeDeleteByPathStreamV10,
+        },
+      },
+    },
+  },
+  // Separate method, not a minor of `worktree.deleteByPath`: its request and
+  // frames are released and frozen, and a client that lands on the batch
+  // method must be able to discover THAT, not negotiate down to a per-target
+  // stream it would then have to drive N times. An older host simply omits
+  // this method from its manifest, so the compatibility check rejects it at
+  // openAck - before the subscribe frame, therefore before any host work -
+  // which is what makes fallback safe for a destructive operation.
+  "worktree.deleteBatchByPath": {
+    1: {
+      latestMinor: 0,
+      versions: {
+        0: {
+          contract: worktreeDeleteBatchByPathStreamV10,
         },
       },
     },

--- a/protocol/src/host/worktree-delete-batch-stream.ts
+++ b/protocol/src/host/worktree-delete-batch-stream.ts
@@ -114,7 +114,7 @@ export type WorktreeDeleteBatchTarget = z.infer<
  * and have the single-flight map silently attach the second one to the first's
  * already-finished result.
  */
-const commandIdSchema = z.string().uuid();
+const commandIdSchema = z.uuid();
 
 export const worktreeDeleteBatchByPathOpenRequestSchema = z.discriminatedUnion(
   "mode",

--- a/protocol/src/host/worktree-delete-batch-stream.ts
+++ b/protocol/src/host/worktree-delete-batch-stream.ts
@@ -1,0 +1,244 @@
+/**
+ * `worktree.deleteBatchByPath@1.0` - one host-owned deletion COMMAND over N
+ * approved targets.
+ *
+ * Added rather than growing `worktree.deleteByPath@1.0`, whose request and
+ * frames are released and frozen. The two differ in ownership, not in
+ * mechanism: the released stream is one target whose lifetime is the socket's,
+ * while a command here is minted by the client, owned by the host, and
+ * survives its observer. That is what lets the host aggregate N targets into
+ * ONE durable completion notification - a renderer-side queue of N streams
+ * cannot, because it has no identity the host can attribute the summary to.
+ *
+ * ## Start versus observe
+ *
+ * The open request is a discriminated union, and that discriminant is the
+ * whole replay-safety story for a destructive operation.
+ *
+ * `WsStreamClient` re-sends a session's ORIGINAL open request on every
+ * reconnect, automatically and indefinitely. Single-flight alone cannot make
+ * that safe: the map is process-local and evicted a minute after completion,
+ * so an outage longer than the grace window - or a host restart - would turn
+ * an automatic re-subscribe into a second execution of the same `commandId`,
+ * and its result would overwrite the durable summary the first run wrote.
+ *
+ * So the authority to START work lives in the request itself: only a `start`
+ * may create a command, and a client only ever issues one from an explicit
+ * user action. Once a `start` has actually reached the host, the client
+ * re-subscribes as `observe`, which can attach to a live command but can never
+ * create one. A command the host no longer knows about (evicted, or lost to a
+ * restart) answers `command.failed` - honest uncertainty, no deletion.
+ *
+ * This is deliberately NOT keyed off the completion notification row: policy
+ * can suppress that row and the sink write can fail, so it is not an execution
+ * ledger.
+ *
+ * ## Command semantics (enforced by `WorktreeDeletionCommandService`)
+ *
+ * - `commandId` is a client-minted UUID. Commands are single-flight by
+ *   `(userId, commandId)` for the host process lifetime, so a duplicate
+ *   subscribe during the bounded grace window ATTACHES to the running command
+ *   instead of executing it a second time. There is no cross-restart
+ *   exactly-once claim: an unconfirmed destructive result stays uncertain and
+ *   needs explicit user action.
+ * - Closing the socket detaches that observer. It does NOT cancel accepted
+ *   work: remaining targets run and the completion notification is still
+ *   written. This is the whole point of host ownership - a Settings tab closed
+ *   mid-bulk-delete must not strand half the selection.
+ * - An empty `targets` list is not a command: the resolver answers
+ *   `command.complete` with zero counts, creates no command, and writes no
+ *   notification row.
+ * - Per-target frames are NOT replayed to an observer that attached late, so a
+ *   client that missed some must treat `command.complete` as terminal for
+ *   every target it never saw settle.
+ *
+ * Server frames are tagged by `worktreePath`, the target's own stable key.
+ * Requests carry unique paths (the schema rejects duplicates), so a path
+ * identifies exactly one target for the command's lifetime and a client can
+ * route a frame to its per-target record without minting a parallel id space.
+ *
+ * - `target.started`  - target validated and not busy; `hasTeardown` says
+ *                       whether a teardown step will run.
+ * - `target.phase`    - `teardown` | `remove`.
+ * - `target.output`   - a chunk of teardown stdout/stderr.
+ * - `target.complete` - terminal for that target; `deleted` is its outcome
+ *                       (a declined/no-op delete is `false`, not a failure).
+ * - `target.failed`   - terminal for that target; displayable reason.
+ * - `command.complete`- terminal for the COMMAND, after every target settled.
+ * - `command.failed`  - terminal: no work ran or will run UNDER THIS
+ *                       SUBSCRIPTION, with a displayable reason. Either the
+ *                       host cannot serve the command at all (worktree service
+ *                       unavailable), or an `observe` named a command this host
+ *                       no longer holds. No target frames precede it.
+ * - `pong`            - heartbeat response.
+ *
+ * Client frames: `ping` only, like the released stream.
+ */
+import { z } from "zod";
+import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
+import { worktreeEntryScriptsSchema } from "@traycer/protocol/host/worktree-schemas";
+
+/**
+ * Where the command came from. Durable: it rides into the notification
+ * payload, so the row can say "a bulk delete you started in Settings" without
+ * persisting a route. Closed on purpose - an unrecognized source is a client
+ * bug, not a compatibility event, and every producer is in this repo.
+ */
+export const worktreeDeletionSourceSchema = z.enum([
+  "settings",
+  "task_cleanup",
+  "cli",
+  "legacy_client",
+]);
+export type WorktreeDeletionSource = z.infer<
+  typeof worktreeDeletionSourceSchema
+>;
+
+export const worktreeDeleteBatchTargetSchema = z.object({
+  worktreePath: z.string().min(1),
+  /**
+   * Per-target script override from the Settings review modal. `null` means
+   * "read the worktree's own `.traycer/environment.json`", matching the
+   * released single-target request.
+   */
+  scripts: worktreeEntryScriptsSchema.nullable(),
+});
+export type WorktreeDeleteBatchTarget = z.infer<
+  typeof worktreeDeleteBatchTargetSchema
+>;
+
+/**
+ * Client-minted UUID naming a command. Validated as a UUID rather than an open
+ * string so a client cannot collapse distinct commands onto a shared constant
+ * and have the single-flight map silently attach the second one to the first's
+ * already-finished result.
+ */
+const commandIdSchema = z.string().uuid();
+
+export const worktreeDeleteBatchByPathOpenRequestSchema = z.discriminatedUnion(
+  "mode",
+  [
+    /**
+     * Authorizes execution. Only ever sent for an explicit user action, and
+     * never re-sent automatically after it has reached the host.
+     */
+    z.object({
+      mode: z.literal("start"),
+      commandId: commandIdSchema,
+      source: worktreeDeletionSourceSchema,
+      /**
+       * Every approved target, in one request. Paths must be unique: the frame
+       * tagging keys off `worktreePath`, and a repeated path would make two
+       * target records indistinguishable on the wire (and schedule the same
+       * directory twice).
+       */
+      targets: z
+        .array(worktreeDeleteBatchTargetSchema)
+        .refine(
+          (targets) =>
+            new Set(targets.map((target) => target.worktreePath)).size ===
+            targets.length,
+          { message: "targets must have unique worktreePath values" },
+        ),
+    }),
+    /**
+     * Re-attaches to a command already accepted by this host process. Carries
+     * NO targets on purpose: an observe request that cannot describe work is
+     * structurally incapable of starting any, however it is routed or replayed.
+     */
+    z.object({
+      mode: z.literal("observe"),
+      commandId: commandIdSchema,
+    }),
+  ],
+);
+export type WorktreeDeleteBatchByPathOpenRequest = z.infer<
+  typeof worktreeDeleteBatchByPathOpenRequestSchema
+>;
+
+const worktreeDeleteBatchPhaseSchema = z.enum(["teardown", "remove"]);
+export type WorktreeDeleteBatchPhase = z.infer<
+  typeof worktreeDeleteBatchPhaseSchema
+>;
+
+const worktreeDeleteBatchOutputChannelSchema = z.enum(["stdout", "stderr"]);
+export type WorktreeDeleteBatchOutputChannel = z.infer<
+  typeof worktreeDeleteBatchOutputChannelSchema
+>;
+
+export const worktreeDeleteBatchByPathServerFrameSchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({
+      kind: z.literal("target.started"),
+      worktreePath: z.string().min(1),
+      hasTeardown: z.boolean(),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("target.phase"),
+      worktreePath: z.string().min(1),
+      phase: worktreeDeleteBatchPhaseSchema,
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("target.output"),
+      worktreePath: z.string().min(1),
+      channel: worktreeDeleteBatchOutputChannelSchema,
+      chunk: z.string(),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("target.complete"),
+      worktreePath: z.string().min(1),
+      deleted: z.boolean(),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("target.failed"),
+      worktreePath: z.string().min(1),
+      reason: z.string(),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("command.complete"),
+      requestedCount: z.number().int().nonnegative(),
+      deletedCount: z.number().int().nonnegative(),
+      failedCount: z.number().int().nonnegative(),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("command.failed"),
+      reason: z.string(),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      hasBinaryPayload: z.literal(false),
+    }),
+  ],
+);
+export type WorktreeDeleteBatchByPathServerFrame = z.infer<
+  typeof worktreeDeleteBatchByPathServerFrameSchema
+>;
+
+export const worktreeDeleteBatchByPathClientFrameSchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({
+      kind: z.literal("ping"),
+      hasBinaryPayload: z.literal(false),
+    }),
+  ],
+);
+export type WorktreeDeleteBatchByPathClientFrame = z.infer<
+  typeof worktreeDeleteBatchByPathClientFrameSchema
+>;
+
+export const worktreeDeleteBatchByPathStreamV10 = defineStreamRpcContract({
+  method: "worktree.deleteBatchByPath",
+  schemaVersion: { major: 1, minor: 0 } as const,
+  openRequestSchema: worktreeDeleteBatchByPathOpenRequestSchema,
+  serverFrameSchema: worktreeDeleteBatchByPathServerFrameSchema,
+  clientFrameSchema: worktreeDeleteBatchByPathClientFrameSchema,
+});

--- a/protocol/src/host/worktree-delete-batch-stream.ts
+++ b/protocol/src/host/worktree-delete-batch-stream.ts
@@ -87,6 +87,7 @@ import { worktreeEntryScriptsSchema } from "@traycer/protocol/host/worktree-sche
 export const worktreeDeletionSourceSchema = z.enum([
   "settings",
   "task_cleanup",
+  "task_sweep",
   "cli",
   "legacy_client",
 ]);


### PR DESCRIPTION
## Summary
- add a compatible generic host-operation completion notification contract
- report worktree deletion results from Settings, task/epic cleanup, CLI, and legacy entry points
- route worktree deletion notifications to Settings > Worktrees

## Validation
- protocol, shared, GUI, CLI, host notification, and deletion-focused suites
- live local host run: filesystem deletion, durable row persistence, and feed upsert

## Follow-up
- internal host PR will pin the merged OSS commit after this PR lands.