### PR TITLE
fix(gui-app): let the keyboard move through a chat transcript

### DIFF
--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -586,6 +586,17 @@ describe("ChatMessages Virtuoso renderer", () => {
     fireEvent.keyDown(trigger, { key: "ArrowDown" });
     expect(scroller.scrollTop).toBe(1_000);
 
+    // ...but a popover trigger (`aria-haspopup="dialog"`, e.g. the composer's
+    // context-usage chip) opens on Enter/Space, so it holds no claim on the
+    // arrows and the transcript still scrolls.
+    const popover = document.createElement("button");
+    popover.setAttribute("aria-haspopup", "dialog");
+    tile.appendChild(popover);
+    popover.focus();
+    fireEvent.keyDown(popover, { key: "ArrowUp" });
+    expect(scroller.scrollTop).toBe(1_000 - CHAT_ARROW_SCROLL_STEP_PX);
+    scroller.scrollTop = 1_000;
+
     // Inert canvas chrome (the pane tab layer focus is parked on) is not a
     // widget, so it still scrolls.
     const paneChrome = document.createElement("div");

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -56,6 +56,7 @@ import {
   TileFindContext,
   type TileFindContextValue,
 } from "@/components/epic-canvas/tile-find/tile-find-adapter-context";
+import { CHAT_ARROW_SCROLL_STEP_PX } from "@/components/chat/chat-messages-virtuoso-helpers";
 import { ChatUserMessageMinimap } from "@/components/chat/chat-user-message-minimap";
 import {
   chatMinimapClipRegionProps,
@@ -80,6 +81,7 @@ const VIRTUOSO_TEST_CONTEXT = {
   viewportHeight: 500,
 };
 const TILE_FIND_TEST_INSTANCE_ID = "test-instance";
+const TEST_PANE_GROUP_ID = "test-pane-group";
 const TILE_FIND_CONTEXT_VALUE: TileFindContextValue = {
   tileInstanceId: TILE_FIND_TEST_INSTANCE_ID,
   registerAdapter: (adapter: TileFindAdapter) =>
@@ -195,31 +197,41 @@ function chatMessagesJsx(
     scrollRequest: ChatMessageScrollRequest | null;
   },
 ): ReactNode {
+  // Mirrors the canvas DOM the tile actually lives in: the owning pane carries
+  // `data-group-id`, and its tab strip is a SIBLING of the tile that carries
+  // the same id (see `tab-group-view.tsx` / `tab-strip.tsx`).
   return (
     <div data-tile-find-scope="" data-active="true">
-      <div
-        data-chat-keyboard-scroll-scope=""
-        data-active="true"
-        data-testid="chat-keyboard-scroll-scope"
-      >
-        <VirtuosoMessageListTestingContext.Provider
-          value={VIRTUOSO_TEST_CONTEXT}
+      <div data-group-id={TEST_PANE_GROUP_ID} data-testid="canvas-pane-root">
+        <div
+          data-group-id={TEST_PANE_GROUP_ID}
+          data-testid="canvas-tab-strip"
+          tabIndex={-1}
+        />
+        <div
+          data-chat-keyboard-scroll-scope=""
+          data-active="true"
+          data-testid="chat-keyboard-scroll-scope"
         >
-          <ChatMessages
-            taskTitle="Transcript"
-            taskId="test-task"
-            messages={messages}
-            backgroundItems={opts.backgroundItems}
-            minimapItems={opts.minimapItems}
-            scrollStateKey={opts.scrollStateKey}
-            getMessageActions={() => null}
-            nextStepActions={null}
-            instanceId={TILE_FIND_TEST_INSTANCE_ID}
-            visible={opts.visible}
-            systemOverlayActive={opts.systemOverlayActive}
-            scrollRequest={opts.scrollRequest}
-          />
-        </VirtuosoMessageListTestingContext.Provider>
+          <VirtuosoMessageListTestingContext.Provider
+            value={VIRTUOSO_TEST_CONTEXT}
+          >
+            <ChatMessages
+              taskTitle="Transcript"
+              taskId="test-task"
+              messages={messages}
+              backgroundItems={opts.backgroundItems}
+              minimapItems={opts.minimapItems}
+              scrollStateKey={opts.scrollStateKey}
+              getMessageActions={() => null}
+              nextStepActions={null}
+              instanceId={TILE_FIND_TEST_INSTANCE_ID}
+              visible={opts.visible}
+              systemOverlayActive={opts.systemOverlayActive}
+              scrollRequest={opts.scrollRequest}
+            />
+          </VirtuosoMessageListTestingContext.Provider>
+        </div>
       </div>
     </div>
   );
@@ -501,6 +513,68 @@ describe("ChatMessages Virtuoso renderer", () => {
     fireEvent.keyDown(sibling, { key: "PageUp" });
     expect(scroller.scrollTop).toBe(1_500);
     sibling.remove();
+  });
+
+  // Switching to a chat by clicking its canvas tab leaves focus ON the tab -
+  // a SIBLING of the tile, not an ancestor - so the scroll keys were silently
+  // dropped exactly when the user had just chosen this transcript to read.
+  it("claims scroll keys rooted on its own pane's chrome", () => {
+    const messages = makeMessages(100);
+    renderChatMessages(
+      messages,
+      makeDefaultOpts({ minimapItems: minimapItemsFor(messages) }),
+    );
+    const scroller = screen.getByTestId("virtuoso-scroller");
+    Object.defineProperties(scroller, {
+      clientHeight: { configurable: true, value: 500 },
+      scrollHeight: { configurable: true, value: 2_000 },
+    });
+
+    const ownTabStrip = screen.getByTestId("canvas-tab-strip");
+    scroller.scrollTop = 1_000;
+    fireEvent.keyDown(ownTabStrip, { key: "PageUp" });
+    expect(scroller.scrollTop).toBe(500);
+
+    // Another pane's chrome is still never claimed.
+    const otherPane = document.createElement("div");
+    otherPane.setAttribute("data-group-id", "other-pane-group");
+    document.body.appendChild(otherPane);
+    fireEvent.keyDown(otherPane, { key: "PageUp" });
+    expect(scroller.scrollTop).toBe(500);
+    otherPane.remove();
+  });
+
+  // The transcript rows are not focusable, so the browser never makes the
+  // scroller the default keyboard scroller: arrow keys moved nothing at all.
+  it("scrolls the transcript line-by-line with the arrow keys", () => {
+    const messages = makeMessages(100);
+    renderChatMessages(
+      messages,
+      makeDefaultOpts({ minimapItems: minimapItemsFor(messages) }),
+    );
+    const scroller = screen.getByTestId("virtuoso-scroller");
+    Object.defineProperties(scroller, {
+      clientHeight: { configurable: true, value: 500 },
+      scrollHeight: { configurable: true, value: 2_000 },
+    });
+
+    scroller.scrollTop = 1_000;
+    fireEvent.keyDown(document.body, { key: "ArrowUp" });
+    expect(scroller.scrollTop).toBe(1_000 - CHAT_ARROW_SCROLL_STEP_PX);
+
+    fireEvent.keyDown(document.body, { key: "ArrowDown" });
+    expect(scroller.scrollTop).toBe(1_000);
+
+    // Editable targets keep the arrows for caret movement.
+    const composer = document.createElement("textarea");
+    screen.getByTestId("chat-keyboard-scroll-scope").appendChild(composer);
+    composer.focus();
+    fireEvent.keyDown(composer, { key: "ArrowUp" });
+    expect(scroller.scrollTop).toBe(1_000);
+
+    // Modified arrows are editor/selection chords - never transcript scroll.
+    fireEvent.keyDown(document.body, { key: "ArrowUp", shiftKey: true });
+    expect(scroller.scrollTop).toBe(1_000);
   });
 
   it("keeps scrolling from a focused descendant when the tile is inactive", () => {

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -203,11 +203,15 @@ function chatMessagesJsx(
   return (
     <div data-tile-find-scope="" data-active="true">
       <div data-group-id={TEST_PANE_GROUP_ID} data-testid="canvas-pane-root">
-        <div
-          data-group-id={TEST_PANE_GROUP_ID}
-          data-testid="canvas-tab-strip"
-          tabIndex={-1}
-        />
+        <div data-group-id={TEST_PANE_GROUP_ID} data-testid="canvas-tab-strip">
+          {/* Same shape as the real canvas tab root in `tab-strip.tsx`. */}
+          <div
+            role="tab"
+            aria-selected="true"
+            tabIndex={0}
+            data-testid="canvas-tab"
+          />
+        </div>
         <div
           data-chat-keyboard-scroll-scope=""
           data-active="true"
@@ -566,8 +570,9 @@ describe("ChatMessages Virtuoso renderer", () => {
     expect(scroller.scrollTop).toBe(1_000);
 
     // Editable targets keep the arrows for caret movement.
+    const tile = screen.getByTestId("chat-keyboard-scroll-scope");
     const composer = document.createElement("textarea");
-    screen.getByTestId("chat-keyboard-scroll-scope").appendChild(composer);
+    tile.appendChild(composer);
     composer.focus();
     fireEvent.keyDown(composer, { key: "ArrowUp" });
     expect(scroller.scrollTop).toBe(1_000);
@@ -575,6 +580,34 @@ describe("ChatMessages Virtuoso renderer", () => {
     // Modified arrows are editor/selection chords - never transcript scroll.
     fireEvent.keyDown(document.body, { key: "ArrowUp", shiftKey: true });
     expect(scroller.scrollTop).toBe(1_000);
+
+    // A focusable widget inside the tile (the composer's provider-reauth
+    // Select trigger, a profile dropdown) opens/navigates on the arrows
+    // itself - swallowing them as transcript scroll would break it.
+    const trigger = document.createElement("button");
+    trigger.setAttribute("role", "combobox");
+    tile.appendChild(trigger);
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+    expect(scroller.scrollTop).toBe(1_000);
+
+    // Inert canvas chrome (the pane tab layer focus is parked on) is not a
+    // widget, so it still scrolls.
+    const paneChrome = document.createElement("div");
+    paneChrome.tabIndex = -1;
+    tile.appendChild(paneChrome);
+    paneChrome.focus();
+    fireEvent.keyDown(paneChrome, { key: "ArrowUp" });
+    expect(scroller.scrollTop).toBe(1_000 - CHAT_ARROW_SCROLL_STEP_PX);
+
+    // A canvas tab is `role="tab"` + `tabIndex={0}` but has no arrow behaviour
+    // of its own, so arrows keep scrolling the transcript from there. Guards
+    // written in terms of "focusable" rather than "arrow-driven" break this.
+    scroller.scrollTop = 1_000;
+    const canvasTab = screen.getByTestId("canvas-tab");
+    canvasTab.focus();
+    fireEvent.keyDown(canvasTab, { key: "ArrowUp" });
+    expect(scroller.scrollTop).toBe(1_000 - CHAT_ARROW_SCROLL_STEP_PX);
   });
 
   it("keeps scrolling from a focused descendant when the tile is inactive", () => {

--- a/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
+++ b/clients/gui-app/src/components/chat/__tests__/chat-messages.test.tsx
@@ -205,12 +205,7 @@ function chatMessagesJsx(
       <div data-group-id={TEST_PANE_GROUP_ID} data-testid="canvas-pane-root">
         <div data-group-id={TEST_PANE_GROUP_ID} data-testid="canvas-tab-strip">
           {/* Same shape as the real canvas tab root in `tab-strip.tsx`. */}
-          <div
-            role="tab"
-            aria-selected="true"
-            tabIndex={0}
-            data-testid="canvas-tab"
-          />
+          <div role="tab" aria-selected="true" tabIndex={0} />
         </div>
         <div
           data-chat-keyboard-scroll-scope=""
@@ -604,7 +599,7 @@ describe("ChatMessages Virtuoso renderer", () => {
     // of its own, so arrows keep scrolling the transcript from there. Guards
     // written in terms of "focusable" rather than "arrow-driven" break this.
     scroller.scrollTop = 1_000;
-    const canvasTab = screen.getByTestId("canvas-tab");
+    const canvasTab = screen.getByRole("tab");
     canvasTab.focus();
     fireEvent.keyDown(canvasTab, { key: "ArrowUp" });
     expect(scroller.scrollTop).toBe(1_000 - CHAT_ARROW_SCROLL_STEP_PX);

--- a/clients/gui-app/src/components/chat/chat-messages-virtuoso-helpers.ts
+++ b/clients/gui-app/src/components/chat/chat-messages-virtuoso-helpers.ts
@@ -41,6 +41,13 @@ const MINIMAP_SCROLL_OFFSET_PX = -48;
 const MINIMAP_ACTIVE_ANCHOR_OFFSET_PX = Math.abs(MINIMAP_SCROLL_OFFSET_PX) + 1;
 const BOTTOM_FOLLOW_TOLERANCE_PX = 48;
 
+/**
+ * Per-press step for the transcript's arrow-key scrolling. Chromium's own
+ * arrow-key scroll step is 40px; matching it keeps the transcript feeling like
+ * any other scroll region.
+ */
+export const CHAT_ARROW_SCROLL_STEP_PX = 40;
+
 const INITIAL_SCROLL_MODIFIER: ScrollModifier = {
   type: "item-location",
   location: {

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -697,10 +697,14 @@ function ChatMessagesInner(props: ChatMessagesProps) {
   // A downward user gesture (wheel/keys/touch toward the tail) also takes over
   // from an in-flight restore: cancel the defend loop so it can't re-assert the
   // saved offset against the user's own scroll during the post-show window.
-  // No-op outside that window (no retry in flight).
+  // No-op outside that window (no retry in flight). It cancels an in-flight
+  // SMOOTH scroll for the same reason the unpin path does - a minimap jump
+  // rewrites `scrollTop` for ~50 frames, and a downward key pressed during that
+  // window would otherwise be painted over and read as a dead key.
   const markDownwardUserGesture = useCallback((): void => {
     cancelScrollRestorationRetry();
     lastScrollGestureRef.current = "down";
+    virtuosoRef.current?.cancelSmoothScroll();
   }, [cancelScrollRestorationRetry]);
 
   const handleScroll = useCallback(

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -142,6 +142,50 @@ function isUnmodified(event: globalThis.KeyboardEvent): boolean {
   return !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
 }
 
+/**
+ * Controls whose own keyboard contract is bound to the arrows: text entry,
+ * value pickers, and anything that opens or steps a list on them (the
+ * composer's provider-reauth `SelectTrigger` is a `role="combobox"`; Radix
+ * dropdown triggers advertise `aria-haspopup` and open on ArrowDown). Arrows
+ * aimed at those must reach them, so the transcript does not claim them.
+ *
+ * Deliberately NOT listed: plain buttons, links, `role="tab"`, and focusable
+ * chrome in general. A canvas tab is a `role="tab"` div with `tabIndex={0}` and
+ * has no arrow behaviour of its own - focus parks there after a tab click, and
+ * that IS a transcript-scroll target.
+ */
+const ARROW_KEY_OWNER_SELECTOR = [
+  "input",
+  "select",
+  "textarea",
+  '[contenteditable="true"]',
+  '[role="combobox"]',
+  '[role="grid"]',
+  '[role="gridcell"]',
+  '[role="listbox"]',
+  '[role="menu"]',
+  '[role="menubar"]',
+  '[role="menuitem"]',
+  '[role="menuitemcheckbox"]',
+  '[role="menuitemradio"]',
+  '[role="option"]',
+  '[role="radio"]',
+  '[role="radiogroup"]',
+  '[role="slider"]',
+  '[role="spinbutton"]',
+  '[role="tablist"]',
+  '[role="textbox"]',
+  '[role="tree"]',
+  '[role="treeitem"]',
+  '[aria-haspopup]:not([aria-haspopup="false"])',
+].join(",");
+
+function ownsArrowKeys(target: EventTarget | null): boolean {
+  if (isEditableTarget(target)) return true;
+  if (!(target instanceof Element)) return false;
+  return target.closest(ARROW_KEY_OWNER_SELECTOR) !== null;
+}
+
 function canvasPaneIdOf(node: Node | null): string | null {
   const element = node instanceof Element ? node : node?.parentElement;
   return (
@@ -166,13 +210,13 @@ function chatKeyboardScrollAction(
   if (event.key === "PageDown") return "page-down";
   // Plain arrows step the transcript. The transcript rows are not focusable, so
   // the browser never adopts the scroller as its default keyboard scroller and
-  // would otherwise scroll nothing at all. Editable targets (the composer, a
-  // code editor in a message) keep the arrows for caret movement, and any
-  // modifier makes it an editor/selection chord we must not claim.
+  // would otherwise scroll nothing at all. Targets that own the arrows
+  // themselves keep them (see `ownsArrowKeys`), and any modifier makes it an
+  // editor/selection chord we must not claim.
   if (
     (event.key === "ArrowUp" || event.key === "ArrowDown") &&
     isUnmodified(event) &&
-    !isEditableTarget(event.target)
+    !ownsArrowKeys(event.target)
   ) {
     return event.key === "ArrowUp" ? "line-up" : "line-down";
   }

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/chat/chat-message";
 import {
   buildMessageIdToIndex,
+  CHAT_ARROW_SCROLL_STEP_PX,
   chatScrollLocationForMessage,
   chatComputeItemKey,
   chatItemIdentity,
@@ -122,7 +123,11 @@ const SCROLLBAR_POINTER_HIT_SLOP_PX = 24;
 const TOUCH_SCROLL_DIRECTION_THRESHOLD_PX = 4;
 const EMPTY_BACKGROUND_TOOL_BLOCK_IDS: ReadonlySet<string> = new Set();
 
-type ChatKeyboardScrollAction = "page-up" | "page-down" | "top" | "bottom";
+type ChatKeyboardScrollAction =
+  "page-up" | "page-down" | "line-up" | "line-down" | "top" | "bottom";
+
+const UPWARD_CHAT_SCROLL_ACTIONS: ReadonlySet<ChatKeyboardScrollAction> =
+  new Set<ChatKeyboardScrollAction>(["page-up", "line-up", "top"]);
 
 function isEditableTarget(target: EventTarget | null): boolean {
   return (
@@ -133,11 +138,44 @@ function isEditableTarget(target: EventTarget | null): boolean {
   );
 }
 
+function isUnmodified(event: globalThis.KeyboardEvent): boolean {
+  return !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
+}
+
+function canvasPaneIdOf(node: Node | null): string | null {
+  const element = node instanceof Element ? node : node?.parentElement;
+  return (
+    element?.closest("[data-group-id]")?.getAttribute("data-group-id") ?? null
+  );
+}
+
+/**
+ * Whether `target` sits in the same canvas pane as `tile` - the pane's tab
+ * strip is a SIBLING of the tile, so containment alone cannot tell "this pane's
+ * own chrome" apart from an unrelated surface.
+ */
+function sharesCanvasPane(tile: HTMLElement, target: Node): boolean {
+  const paneId = canvasPaneIdOf(tile);
+  return paneId !== null && canvasPaneIdOf(target) === paneId;
+}
+
 function chatKeyboardScrollAction(
   event: globalThis.KeyboardEvent,
 ): ChatKeyboardScrollAction | null {
   if (event.key === "PageUp") return "page-up";
   if (event.key === "PageDown") return "page-down";
+  // Plain arrows step the transcript. The transcript rows are not focusable, so
+  // the browser never adopts the scroller as its default keyboard scroller and
+  // would otherwise scroll nothing at all. Editable targets (the composer, a
+  // code editor in a message) keep the arrows for caret movement, and any
+  // modifier makes it an editor/selection chord we must not claim.
+  if (
+    (event.key === "ArrowUp" || event.key === "ArrowDown") &&
+    isUnmodified(event) &&
+    !isEditableTarget(event.target)
+  ) {
+    return event.key === "ArrowUp" ? "line-up" : "line-down";
+  }
   // Plain Home/End scroll the transcript. On macOS they scroll even from the
   // composer (Cocoa editors never use them for caret movement - that's
   // Cmd+arrows); elsewhere an editable target keeps them for line navigation
@@ -147,6 +185,17 @@ function chatKeyboardScrollAction(
     (isPlainBoundaryKey(event) && (isMac() || !isEditableTarget(event.target)));
   if (!boundary) return null;
   return event.key === "Home" ? "top" : "bottom";
+}
+
+function chatKeyboardScrollDelta(
+  scroller: HTMLElement,
+  action: ChatKeyboardScrollAction,
+): number {
+  if (action === "page-up") return -scroller.clientHeight;
+  if (action === "page-down") return scroller.clientHeight;
+  return action === "line-up"
+    ? -CHAT_ARROW_SCROLL_STEP_PX
+    : CHAT_ARROW_SCROLL_STEP_PX;
 }
 
 function applyChatKeyboardScroll(
@@ -165,11 +214,9 @@ function applyChatKeyboardScroll(
     scroller.scrollTop = maxScrollTop;
     return;
   }
-  const delta =
-    action === "page-up" ? -scroller.clientHeight : scroller.clientHeight;
   scroller.scrollTop = Math.min(
     maxScrollTop,
-    Math.max(0, scroller.scrollTop + delta),
+    Math.max(0, scroller.scrollTop + chatKeyboardScrollDelta(scroller, action)),
   );
 }
 
@@ -647,27 +694,15 @@ function ChatMessagesInner(props: ChatMessagesProps) {
       const scroller = virtuosoRef.current?.scrollerElement();
       if (scroller === null || scroller === undefined) return;
       const scrollAction = chatKeyboardScrollAction(event);
-      if (scrollAction !== null) {
-        event.preventDefault();
-        event.stopPropagation();
-        if (scrollAction === "page-up" || scrollAction === "top") {
-          unpinFromUserGesture();
-        } else {
-          markDownwardUserGesture();
-        }
-        applyChatKeyboardScroll(scroller, scrollAction);
-        return;
-      }
-      const targetInsideScroller =
-        event.target instanceof Node && scroller.contains(event.target);
-      if (!targetInsideScroller) return;
-      if (event.key === "ArrowUp" || event.key === "Home") {
+      if (scrollAction === null) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (UPWARD_CHAT_SCROLL_ACTIONS.has(scrollAction)) {
         unpinFromUserGesture();
-        return;
-      }
-      if (event.key === "ArrowDown" || event.key === "End") {
+      } else {
         markDownwardUserGesture();
       }
+      applyChatKeyboardScroll(scroller, scrollAction);
     },
     [markDownwardUserGesture, unpinFromUserGesture],
   );
@@ -676,9 +711,11 @@ function ChatMessagesInner(props: ChatMessagesProps) {
   // transcript leaves the key event rooted above the tile - on `body` or on
   // canvas chrome like the pane tab layer / tab-group root (the canvas focus
   // management parks focus there). Listen at `window` so the active chat can
-  // claim navigation keys from those states: a target that CONTAINS the tile
-  // means no more-specific widget owns the keys. Events rooted in a sibling
-  // subtree (another pane's tile, a dialog, the sidebar) are never claimed.
+  // claim navigation keys from those states: a target that CONTAINS the tile,
+  // or that lives in the SAME pane's chrome (its tab strip - a sibling, which
+  // is exactly where focus lands after clicking a canvas tab to reach this
+  // chat), means no more-specific widget owns the keys. Events rooted anywhere
+  // else (another pane's tile, a dialog, the sidebar) are never claimed.
   useLayoutEffect(() => {
     const tile = transcriptContainerRef.current?.closest(
       "[data-chat-keyboard-scroll-scope]",
@@ -687,14 +724,12 @@ function ChatMessagesInner(props: ChatMessagesProps) {
     const handleWindowKeyDown = (event: globalThis.KeyboardEvent): void => {
       const target = event.target;
       if (!(target instanceof Node)) return;
-      const targetInsideTile = tile.contains(target);
-      const targetIsTileAncestor = target.contains(tile);
-      if (
-        !targetInsideTile &&
-        !(tile.dataset.active === "true" && targetIsTileAncestor)
-      ) {
+      if (tile.contains(target)) {
+        handleKeyDownCapture(event);
         return;
       }
+      if (tile.dataset.active !== "true") return;
+      if (!target.contains(tile) && !sharesCanvasPane(tile, target)) return;
       handleKeyDownCapture(event);
     };
     window.addEventListener("keydown", handleWindowKeyDown, { capture: true });

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -177,7 +177,15 @@ const ARROW_KEY_OWNER_SELECTOR = [
   '[role="textbox"]',
   '[role="tree"]',
   '[role="treeitem"]',
-  '[aria-haspopup]:not([aria-haspopup="false"])',
+  // Only popups the arrows actually open/step. A `dialog` popup (Radix
+  // `PopoverTrigger`, e.g. the composer's context-usage chip) activates on
+  // Enter/Space, so it must not hold the arrows hostage. Bare `true` is the
+  // legacy spelling of `menu`.
+  '[aria-haspopup="true"]',
+  '[aria-haspopup="menu"]',
+  '[aria-haspopup="listbox"]',
+  '[aria-haspopup="tree"]',
+  '[aria-haspopup="grid"]',
 ].join(",");
 
 function ownsArrowKeys(target: EventTarget | null): boolean {

--- a/clients/gui-app/src/components/chat/chat-messages.tsx
+++ b/clients/gui-app/src/components/chat/chat-messages.tsx
@@ -231,9 +231,15 @@ function chatKeyboardScrollAction(
   return event.key === "Home" ? "top" : "bottom";
 }
 
+/** The relative steps - `top`/`bottom` are absolute and carry no delta. */
+type ChatKeyboardScrollStep = Exclude<
+  ChatKeyboardScrollAction,
+  "top" | "bottom"
+>;
+
 function chatKeyboardScrollDelta(
   scroller: HTMLElement,
-  action: ChatKeyboardScrollAction,
+  action: ChatKeyboardScrollStep,
 ): number {
   if (action === "page-up") return -scroller.clientHeight;
   if (action === "page-down") return scroller.clientHeight;


### PR DESCRIPTION
## Summary

Two independent defects left a chat transcript unreachable from the keyboard, so a long conversation read as "stuck at the bottom".

**Arrow keys never scrolled the transcript — in any build.** `ArrowUp`/`ArrowDown` only recorded a follow-intent flag, and even that was gated on the event target sitting inside the Virtuoso scroller. That never happens: transcript rows are not focusable, so clicking the transcript parks focus on the pane tab layer, an ancestor *outside* the scroller. The branch assumed the browser would scroll natively and we would just note the direction, but the browser only adopts a scroller its focus is inside — so nothing moved either way. This is the same root cause #387 fixed for the page/boundary keys; the arrows were left on the broken assumption.

They are now first-class scroll actions stepping `CHAT_ARROW_SCROLL_STEP_PX` (40px, matching Chromium's own arrow step), claimed only for unmodified presses on non-editable targets so the composer, in-message editors, and Shift/Ctrl/Alt chords keep them. Routing them through the same action path also fixes the follow-intent bookkeeping they were meant to drive: `ArrowUp` now unpins from the tail, `ArrowDown` re-arms it.

**Page Up / Page Down / Home / End were dropped when focus sat on the pane's own tab strip.** The window-level claim accepted a target that *contains* the tile, but the tab strip is a *sibling* of it — so the keys died right after the user clicked that chat's canvas tab to read it. The tile's own pane is now accepted too, matched on the `data-group-id` that both the pane root and its tab strip carry. Other panes, dialogs, the palette, and the sidebar stay unclaimed, as before.

Scope note: this second half is narrow. Measured on Traycer Desktop v1.1.8, the page keys already worked with focus in the composer or in the message area; the canvas tab was the one dead state. The arrows are the substantive change.

### Reproduce (before this change)

1. Open a chat with enough history to scroll and let it sit at the latest message.
2. Click once in the message area, then press <kbd>↑</kbd> repeatedly — nothing moves, ever.
3. Click the chat's canvas tab (the tab you use to switch between this chat and a terminal/diff), then press <kbd>Page Up</kbd> — nothing moves.

Measured against Traycer Desktop v1.1.8 on Windows 11 by driving the shipped build over CDP: `ArrowUp x5` left `scrollTop` at `587` in every focus state tried (composer, canvas tab, message area), and `PageUp` left it at `587` with focus on the canvas tab. Both fixes are in renderer logic with no platform-specific branches.

### Tests

Two cases in `chat-messages.test.tsx`, both failing before the change:

- arrows step the transcript by one line, up and back down, while an editable target and modified chords keep them;
- the page keys are claimed from the tile's own pane chrome, and still not from another pane's.

The suite's DOM fixture gained the pane wrapper + sibling tab strip the tile really renders inside, so the claim rules are exercised against the real shape.

### Not addressed here

`Page Up` overshoots by roughly half a viewport — `applyChatKeyboardScroll` writes `scrollTop` directly and Virtuoso then adds its own remeasure adjustment. Pre-existing and left alone; fixing it means routing the page step through Virtuoso rather than a raw write.

## Related issue

Part of #712 (the conversation-scrolling half; the split-view half shipped in #766).

## Checklist

- [x] `bun run build`, `bun run lint`, and `bun run test` pass
- [x] Code is formatted (`bun run format`)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)
