### PR TITLE
fix(gui-app): keep routine sync churn quiet

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
@@ -207,7 +207,9 @@ describe("<EpicConnectionPill />", () => {
     );
     expect(
       screen.getByTestId("epic-connection-pill").getAttribute("aria-label"),
-    ).not.toContain("saved locally");
+    ).toBe(
+      "Offline. Some recent changes are still being saved on this device. Keep this window open.",
+    );
     await expectTooltip(OFFLINE_UNSAVED_TOOLTIP);
     expect(screen.getByRole("status").textContent).toContain(
       "Some recent changes are still being saved",
@@ -227,7 +229,9 @@ describe("<EpicConnectionPill />", () => {
     expect(screen.getByTestId("epic-connection-pill-dot").textContent).toBe("");
     expect(
       screen.getByTestId("epic-connection-pill").getAttribute("aria-label"),
-    ).not.toContain("saved locally");
+    ).toBe(
+      "Offline. This device is still processing pending changes; keep it running.",
+    );
     await expectTooltip(
       "The cloud connection is down. This device is still processing pending changes; keep it running.",
     );

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
@@ -214,6 +214,11 @@ describe("<EpicConnectionPill />", () => {
     expect(screen.getByRole("status").textContent).toContain(
       "Some recent changes are still being saved",
     );
+    expect(
+      screen
+        .getByTestId("epic-connection-pill")
+        .contains(screen.getByRole("status")),
+    ).toBe(false);
   });
 
   it("shows host-pending offline work without claiming it is durable", async () => {

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
@@ -295,17 +295,23 @@ describe("<EpicConnectionPill />", () => {
   });
 
   describe("settle behavior (750ms hold before claiming synced)", () => {
-    it("first mount with a derived synced verdict waits through the settle delay", () => {
+    it("settles the synced visuals while exposing the raw accessible verdict", () => {
       vi.useFakeTimers();
       renderPill("synced");
 
       expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
-      expect(pillClaimsSynced()).toBe(false);
+      expect(pillClaimsSynced()).toBe(true);
+      expect(
+        screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
+      ).toBe("syncing");
 
       act(() => {
         vi.advanceTimersByTime(750);
       });
       expect(pillClaimsSynced()).toBe(true);
+      expect(
+        screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
+      ).toBe("synced");
     });
 
     it("flips syncing -> synced only after holding for 750ms, staying quiet in between", () => {
@@ -317,7 +323,10 @@ describe("<EpicConnectionPill />", () => {
       rerender(pillTree());
 
       expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
-      expect(pillClaimsSynced()).toBe(false);
+      expect(pillClaimsSynced()).toBe(true);
+      expect(
+        screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
+      ).toBe("syncing");
 
       act(() => {
         vi.advanceTimersByTime(750);
@@ -326,7 +335,7 @@ describe("<EpicConnectionPill />", () => {
       expect(pillClaimsSynced()).toBe(true);
     });
 
-    it("never renders All changes synced for a synced window shorter than the settle delay", () => {
+    it("never renders synced visuals for a synced window shorter than the settle delay", () => {
       vi.useFakeTimers();
       const { rerender } = renderPill("syncing");
 
@@ -336,7 +345,10 @@ describe("<EpicConnectionPill />", () => {
       act(() => {
         vi.advanceTimersByTime(300);
       });
-      expect(pillClaimsSynced()).toBe(false);
+      expect(pillClaimsSynced()).toBe(true);
+      expect(
+        screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
+      ).toBe("syncing");
 
       mocks.useEpicSyncPillState.mockReturnValue("syncing");
       rerender(pillTree());

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
@@ -214,6 +214,28 @@ describe("<EpicConnectionPill />", () => {
     );
   });
 
+  it("shows host-pending offline work without claiming it is durable", async () => {
+    renderPill("offlineWithHostPending");
+
+    expect(screen.getByText("Offline — changes pending")).not.toBeNull();
+    expect(
+      screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
+    ).toBe("offlineWithHostPending");
+    expect(screen.getByTestId("epic-connection-pill-dot").className).toContain(
+      "bg-amber-500",
+    );
+    expect(screen.getByTestId("epic-connection-pill-dot").textContent).toBe("");
+    expect(
+      screen.getByTestId("epic-connection-pill").getAttribute("aria-label"),
+    ).not.toContain("saved locally");
+    await expectTooltip(
+      "The cloud connection is down. This device is still processing pending changes; keep it running.",
+    );
+    expect(screen.getByRole("status").textContent).toContain(
+      "still processing pending changes",
+    );
+  });
+
   it("preserves keyboard focus when a quiet save becomes an offline warning", () => {
     const { rerender } = renderPill("syncing");
     const before = screen.getByTestId("epic-connection-pill");

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-connection-pill.test.tsx
@@ -21,7 +21,8 @@ vi.mock("@/lib/epic-selectors", () => ({
 
 const OFFLINE_COPY =
   "Disconnected. Unsent changes stay in this window until it reconnects — keep it open.";
-const SYNCING_TOOLTIP = "Some changes have not reached the cloud yet.";
+const OFFLINE_UNSAVED_TOOLTIP =
+  "The cloud connection is down, and some recent changes are still being saved on this device. Keep this window open.";
 
 function pillTree() {
   return (
@@ -103,7 +104,7 @@ describe("<EpicConnectionPill />", () => {
     await expectTooltip("All changes synced");
   });
 
-  it("renders connecting as the amber bootstrap pill with no tooltip", () => {
+  it("renders connecting as the amber bootstrap pill", async () => {
     renderPill("connecting");
 
     expect(screen.getByText("Connecting…")).not.toBeNull();
@@ -117,11 +118,10 @@ describe("<EpicConnectionPill />", () => {
     expect(
       screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
     ).toBe("connecting");
-    fireEvent.focus(screen.getByTestId("epic-connection-pill"));
-    expect(screen.queryByRole("tooltip")).toBeNull();
+    await expectTooltip("Connecting to server");
   });
 
-  it("renders reconnecting as the amber pill with no tooltip", () => {
+  it("renders reconnecting as the amber pill", async () => {
     renderPill("reconnecting");
 
     expect(screen.getByText("Reconnecting…")).not.toBeNull();
@@ -134,8 +134,7 @@ describe("<EpicConnectionPill />", () => {
     expect(
       screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
     ).toBe("reconnecting");
-    fireEvent.focus(screen.getByTestId("epic-connection-pill"));
-    expect(screen.queryByRole("tooltip")).toBeNull();
+    await expectTooltip("Reconnecting to server");
   });
 
   it("renders the offline state as a red pill with disconnect tooltip text", async () => {
@@ -169,10 +168,10 @@ describe("<EpicConnectionPill />", () => {
     await expectTooltip(OFFLINE_COPY);
   });
 
-  it("renders syncing with the Syncing… label, never claims synced, and shows no emerald pulse", async () => {
+  it("keeps normal renderer-to-host saving quiet and makes no synced claim", () => {
     renderPill("syncing");
 
-    expect(screen.getByText("Syncing…")).not.toBeNull();
+    expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
     expect(pillClaimsSynced()).toBe(false);
     expect(screen.getByTestId("epic-connection-pill").innerHTML).not.toContain(
       "animate-ping",
@@ -183,7 +182,49 @@ describe("<EpicConnectionPill />", () => {
     expect(
       screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
     ).toBe("syncing");
-    await expectTooltip(SYNCING_TOOLTIP);
+    expect(
+      screen.getByTestId("epic-connection-pill").getAttribute("aria-label"),
+    ).toBe("Saving changes");
+  });
+
+  it("keeps ordinary host-pending churn quiet indefinitely", () => {
+    renderPill("hostPending");
+    expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
+    expect(
+      screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
+    ).toBe("hostPending");
+  });
+
+  it("shows the unsafe overlap warning immediately without a durability claim", async () => {
+    renderPill("offlineWithUnsavedChanges");
+
+    expect(screen.getByText("Offline — saving changes…")).not.toBeNull();
+    expect(
+      screen.getByTestId("epic-connection-pill").getAttribute("data-status"),
+    ).toBe("offlineWithUnsavedChanges");
+    expect(screen.getByTestId("epic-connection-pill").className).toContain(
+      "bg-amber-500/10",
+    );
+    expect(
+      screen.getByTestId("epic-connection-pill").getAttribute("aria-label"),
+    ).not.toContain("saved locally");
+    await expectTooltip(OFFLINE_UNSAVED_TOOLTIP);
+    expect(screen.getByRole("status").textContent).toContain(
+      "Some recent changes are still being saved",
+    );
+  });
+
+  it("preserves keyboard focus when a quiet save becomes an offline warning", () => {
+    const { rerender } = renderPill("syncing");
+    const before = screen.getByTestId("epic-connection-pill");
+    before.focus();
+
+    mocks.useEpicSyncPillState.mockReturnValue("offlineWithUnsavedChanges");
+    rerender(pillTree());
+
+    const after = screen.getByTestId("epic-connection-pill");
+    expect(after).toBe(before);
+    expect(document.activeElement).toBe(after);
   });
 
   it("renders neutral Connected without a synced or durability assertion", () => {
@@ -232,7 +273,7 @@ describe("<EpicConnectionPill />", () => {
       vi.useFakeTimers();
       renderPill("synced");
 
-      expect(screen.getByText("Syncing…")).not.toBeNull();
+      expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
       expect(pillClaimsSynced()).toBe(false);
 
       act(() => {
@@ -241,15 +282,15 @@ describe("<EpicConnectionPill />", () => {
       expect(pillClaimsSynced()).toBe(true);
     });
 
-    it("flips syncing -> synced only after holding for 750ms, reading Syncing… in between", () => {
+    it("flips syncing -> synced only after holding for 750ms, staying quiet in between", () => {
       vi.useFakeTimers();
       const { rerender } = renderPill("syncing");
-      expect(screen.getByText("Syncing…")).not.toBeNull();
+      expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
 
       mocks.useEpicSyncPillState.mockReturnValue("synced");
       rerender(pillTree());
 
-      expect(screen.getByText("Syncing…")).not.toBeNull();
+      expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
       expect(pillClaimsSynced()).toBe(false);
 
       act(() => {
@@ -274,7 +315,7 @@ describe("<EpicConnectionPill />", () => {
       mocks.useEpicSyncPillState.mockReturnValue("syncing");
       rerender(pillTree());
       expect(pillClaimsSynced()).toBe(false);
-      expect(screen.getByText("Syncing…")).not.toBeNull();
+      expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
 
       // The abandoned settle timer from the earlier synced window must not
       // fire later and flash the stale claim.
@@ -284,31 +325,17 @@ describe("<EpicConnectionPill />", () => {
       expect(pillClaimsSynced()).toBe(false);
     });
 
-    // The display holds "Syncing…" through the settle on purpose - a
-    // conservative LABEL is the anti-strobe trade. The tooltip is a different
-    // kind of statement: "some changes have not reached the cloud yet" is a
-    // fact, and during the hold the derived verdict already says it is false.
-    it("drops the syncing tooltip during the settle hold, where the derived verdict is already synced", () => {
+    it("exposes the truthful synced tooltip during the visual settle hold", () => {
       vi.useFakeTimers();
-      const pill = () => screen.getByTestId("epic-connection-pill");
       const { rerender } = renderPill("syncing");
-
-      // Control, so the assertion below can't pass vacuously: a genuinely
-      // syncing verdict shows the syncing tooltip.
-      fireEvent.focus(pill());
-      expect(screen.queryByRole("tooltip")?.textContent).toBe(SYNCING_TOOLTIP);
 
       mocks.useEpicSyncPillState.mockReturnValue("synced");
       rerender(pillTree());
 
-      // The LABEL still holds "Syncing…" (the anti-strobe trade), but the
-      // tooltip must not keep asserting a fact the verdict has already
-      // retracted. Every state now carries a tooltip, so the check is that the
-      // syncing copy is gone - not that the tooltip vanished.
-      expect(screen.getByText("Syncing…")).not.toBeNull();
-      fireEvent.focus(pill());
-      expect(screen.queryByRole("tooltip")?.textContent).not.toBe(
-        SYNCING_TOOLTIP,
+      expect(screen.getByTestId("epic-connection-pill").textContent).toBe("");
+      fireEvent.focus(screen.getByTestId("epic-connection-pill"));
+      expect(screen.queryByRole("tooltip")?.textContent).toBe(
+        "All changes synced",
       );
 
       // ...and once the hold expires the pill catches up to the verdict.
@@ -320,6 +347,9 @@ describe("<EpicConnectionPill />", () => {
 
     it.each<EpicSyncPillState>([
       "syncing",
+      "hostPending",
+      "offlineWithUnsavedChanges",
+      "offlineWithHostPending",
       "connected",
       "offline",
       "offlineChangesSavedLocally",

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
@@ -26,6 +26,8 @@ import { cn } from "@/lib/utils";
 export function EpicConnectionPill() {
   const derived = useEpicSyncPillState();
   const state = useSyncPillDisplayState(derived);
+  // Visuals use the settled state to avoid strobing; the tooltip uses the raw
+  // verdict so it can truthfully say synced during the positive settle hold.
   const indicator = indicatorFor(state);
   const tooltip = indicatorFor(derived).tooltip;
 

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
@@ -33,29 +33,31 @@ export function EpicConnectionPill() {
   const tooltip = rawIndicator.tooltip;
 
   return (
-    <TooltipWrapper
-      label={tooltip}
-      side="top"
-      sideOffset={undefined}
-      align={undefined}
-    >
-      <button
-        type="button"
-        data-testid="epic-connection-pill"
-        data-status={state}
-        aria-label={rawIndicator.ariaLabel}
-        className={cn(
-          "inline-flex items-center gap-1 text-ui-xs font-medium text-current focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-          indicator.containerClassName,
-        )}
+    <>
+      <TooltipWrapper
+        label={tooltip}
+        side="top"
+        sideOffset={undefined}
+        align={undefined}
       >
-        <ConnectionPillDot indicator={indicator} />
-        {indicator.label}
-        <span className="sr-only" role="status" aria-live="polite">
-          {warningAnnouncement(state, indicator)}
-        </span>
-      </button>
-    </TooltipWrapper>
+        <button
+          type="button"
+          data-testid="epic-connection-pill"
+          data-status={state}
+          aria-label={rawIndicator.ariaLabel}
+          className={cn(
+            "inline-flex items-center gap-1 text-ui-xs font-medium text-current focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            indicator.containerClassName,
+          )}
+        >
+          <ConnectionPillDot indicator={indicator} />
+          {indicator.label}
+        </button>
+      </TooltipWrapper>
+      <span className="sr-only" role="status" aria-live="polite">
+        {warningAnnouncement(state, indicator)}
+      </span>
+    </>
   );
 }
 

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
@@ -25,14 +25,8 @@ import { cn } from "@/lib/utils";
  */
 export function EpicConnectionPill() {
   const derived = useEpicSyncPillState();
-  const state = useSettledSyncPillState(derived);
+  const state = useSyncPillDisplayState(derived);
   const indicator = indicatorFor(state);
-  // The tooltip reads the DERIVED verdict, not the settled display state. The
-  // two differ in exactly one case - the 750ms hold, where the display still
-  // says "Syncing…" after the verdict has already gone `synced` - and in that
-  // window the `syncing` tooltip's "some changes have not reached the cloud
-  // yet" is false. Holding a conservative LABEL is the anti-strobe trade; a
-  // tooltip that asserts an untrue fact is not part of it.
   const tooltip = indicatorFor(derived).tooltip;
 
   return (
@@ -54,9 +48,27 @@ export function EpicConnectionPill() {
       >
         <ConnectionPillDot indicator={indicator} />
         {indicator.label}
+        <span className="sr-only" role="status" aria-live="polite">
+          {warningAnnouncement(state, indicator)}
+        </span>
       </button>
     </TooltipWrapper>
   );
+}
+
+function warningAnnouncement(
+  state: EpicSyncPillState,
+  indicator: PillIndicator,
+): string | null {
+  switch (state) {
+    case "offlineWithUnsavedChanges":
+    case "offlineWithHostPending":
+    case "offlineChangesSavedLocally":
+    case "offline":
+      return indicator.ariaLabel;
+    default:
+      return null;
+  }
 }
 
 /**
@@ -76,12 +88,11 @@ export function EpicConnectionPill() {
 const SYNCED_SETTLE_MS = 750;
 
 /**
- * Smooths the settle into `synced` without ever smoothing the way out of it.
- * A verdict that is not `synced` is displayed the instant it is derived; the
- * `synced` verdict is displayed only after it has held for
- * {@link SYNCED_SETTLE_MS}, and reads as "Syncing…" until then.
+ * Keeps routine saving quiet and holds the positive `synced` claim long enough
+ * to prevent strobing. Actionable connection and durability warnings bypass
+ * this settle behavior and render immediately.
  */
-function useSettledSyncPillState(
+function useSyncPillDisplayState(
   derived: EpicSyncPillState,
 ): EpicSyncPillState {
   // A first render may happen before the current subscription has established
@@ -172,19 +183,43 @@ function indicatorFor(state: EpicSyncPillState): PillIndicator {
         tooltip: "All changes synced",
         ariaLabel: "All changes synced",
       };
-    // Same quiet treatment as `synced` rather than the amber alert styling:
-    // outstanding work is the normal steady state right after an edit, and an
-    // amber flash on every save would train users to ignore the pill. The
-    // difference that matters is that it no longer CLAIMS synced.
+    // Normal renderer→host and host→cloud churn stays icon-only. The neutral
+    // dot makes no durability claim and avoids a permanent spinner while an
+    // active agent continuously updates the Epic.
     case "syncing":
+    case "hostPending":
       return {
         containerClassName: QUIET_CONTAINER_CLASS,
-        dotClassName: "text-muted-foreground",
-        label: "Syncing…",
+        dotClassName: "",
+        label: null,
+        showAgentSpinner: false,
+        pulse: "idle",
+        tooltip: "Saving changes",
+        ariaLabel: "Saving changes",
+      };
+    case "offlineWithUnsavedChanges":
+      return {
+        containerClassName: AMBER_CONTAINER_CLASS,
+        dotClassName: "text-amber-500",
+        label: "Offline — saving changes…",
         showAgentSpinner: true,
         pulse: null,
-        tooltip: "Some changes have not reached the cloud yet.",
-        ariaLabel: "Syncing changes",
+        tooltip:
+          "The cloud connection is down, and some recent changes are still being saved on this device. Keep this window open.",
+        ariaLabel:
+          "Offline. Some recent changes are still being saved on this device. Keep this window open.",
+      };
+    case "offlineWithHostPending":
+      return {
+        containerClassName: AMBER_CONTAINER_CLASS,
+        dotClassName: "bg-amber-500",
+        label: "Offline — changes pending",
+        showAgentSpinner: false,
+        pulse: null,
+        tooltip:
+          "The cloud connection is down. This device is still processing pending changes; keep it running.",
+        ariaLabel:
+          "Offline. This device is still processing pending changes; keep it running.",
       };
     // No spinner: nothing is in flight while the host's cloud link is down.
     // The durability claim in this copy is load-bearing and true - the host
@@ -212,7 +247,7 @@ function indicatorFor(state: EpicSyncPillState): PillIndicator {
         label: "Connected",
         showAgentSpinner: false,
         pulse: null,
-        tooltip: null,
+        tooltip: "Connected",
         ariaLabel: "Connected",
       };
     // The three link states below make NO durability claim. While the
@@ -225,7 +260,7 @@ function indicatorFor(state: EpicSyncPillState): PillIndicator {
         label: "Connecting…",
         showAgentSpinner: true,
         pulse: null,
-        tooltip: null,
+        tooltip: "Connecting to server",
         ariaLabel: "Connecting to server",
       };
     case "reconnecting":
@@ -235,7 +270,7 @@ function indicatorFor(state: EpicSyncPillState): PillIndicator {
         label: "Reconnecting…",
         showAgentSpinner: true,
         pulse: null,
-        tooltip: null,
+        tooltip: "Reconnecting to server",
         ariaLabel: "Reconnecting to server",
       };
     case "offline":

--- a/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
+++ b/clients/gui-app/src/components/epic-canvas/panels/epic-connection-pill.tsx
@@ -29,7 +29,8 @@ export function EpicConnectionPill() {
   // Visuals use the settled state to avoid strobing; the tooltip uses the raw
   // verdict so it can truthfully say synced during the positive settle hold.
   const indicator = indicatorFor(state);
-  const tooltip = indicatorFor(derived).tooltip;
+  const rawIndicator = indicatorFor(derived);
+  const tooltip = rawIndicator.tooltip;
 
   return (
     <TooltipWrapper
@@ -42,7 +43,7 @@ export function EpicConnectionPill() {
         type="button"
         data-testid="epic-connection-pill"
         data-status={state}
-        aria-label={indicator.ariaLabel}
+        aria-label={rawIndicator.ariaLabel}
         className={cn(
           "inline-flex items-center gap-1 text-ui-xs font-medium text-current focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           indicator.containerClassName,

--- a/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
@@ -195,10 +195,10 @@ describe("useEpicSyncPillState", () => {
       wrapper: openEpicWrapper(handle),
     });
 
-    expect(result.current).toBe("syncing");
+    expect(result.current).toBe("hostPending");
   });
 
-  it("flips syncing -> synced live as a room's dirty flag flips true -> false", () => {
+  it("flips hostPending -> synced live as a room's dirty flag flips true -> false", () => {
     const handle = createHandle("epic-dirty-transition");
     healthyBaseline(handle);
     handle.store.setState({
@@ -209,7 +209,7 @@ describe("useEpicSyncPillState", () => {
       wrapper: openEpicWrapper(handle),
     });
 
-    expect(result.current).toBe("syncing");
+    expect(result.current).toBe("hostPending");
 
     act(() => {
       handle.store.setState({
@@ -229,7 +229,7 @@ describe("useEpicSyncPillState", () => {
       wrapper: openEpicWrapper(handle),
     });
 
-    expect(result.current).toBe("syncing");
+    expect(result.current).toBe("hostPending");
 
     act(() => {
       handle.store.setState({ rootDirty: false });

--- a/clients/gui-app/src/lib/__tests__/epic-sync-pill-state.test.ts
+++ b/clients/gui-app/src/lib/__tests__/epic-sync-pill-state.test.ts
@@ -66,12 +66,12 @@ describe("deriveEpicSyncPillState", () => {
     expect(deriveEpicSyncPillState(HEALTHY_INPUTS)).toBe("synced");
   });
 
-  it("RCA case: known host-dirty work alone forces syncing even though every other leg reads healthy", () => {
+  it("distinguishes host-durable cloud-pending work from renderer-only work", () => {
     const result = deriveEpicSyncPillState({
       ...HEALTHY_INPUTS,
       hostDirtyState: "dirty",
     });
-    expect(result).toBe("syncing");
+    expect(result).toBe("hostPending");
   });
 
   it("unsynced local changes alone force syncing", () => {
@@ -82,13 +82,13 @@ describe("deriveEpicSyncPillState", () => {
     expect(result).toBe("syncing");
   });
 
-  it("cloud disconnected with known host-durable work reads offlineChangesSavedLocally", () => {
+  it("cloud disconnected with aggregate host-pending work makes no durability claim", () => {
     const result = deriveEpicSyncPillState({
       ...HEALTHY_INPUTS,
       cloudSyncStatus: "disconnected",
       hostDirtyState: "dirty",
     });
-    expect(result).toBe("offlineChangesSavedLocally");
+    expect(result).toBe("offlineWithHostPending");
   });
 
   it("cloud reconnecting with known host-durable work reads offlineChangesSavedLocally", () => {
@@ -97,17 +97,17 @@ describe("deriveEpicSyncPillState", () => {
       cloudSyncStatus: "reconnecting",
       hostDirtyState: "dirty",
     });
-    expect(result).toBe("offlineChangesSavedLocally");
+    expect(result).toBe("offlineWithHostPending");
   });
 
-  it("never calls renderer-only work saved locally while the cloud is down", () => {
+  it("warns immediately without calling renderer-only work saved locally while the cloud is down", () => {
     const result = deriveEpicSyncPillState({
       ...HEALTHY_INPUTS,
       cloudSyncStatus: "disconnected",
       hostDirtyState: "dirty",
       hasUnsyncedLocalChanges: true,
     });
-    expect(result).toBe("syncing");
+    expect(result).toBe("offlineWithUnsavedChanges");
   });
 
   it("uses neutral connected while the host-dirty snapshot is unknown", () => {
@@ -223,7 +223,7 @@ describe("deriveEpicSyncPillState", () => {
       expect(result).toBe("connected");
     });
 
-    it("keeps renderer-only work in the non-durability syncing state", () => {
+    it("warns about renderer-only work when the known cloud link is down", () => {
       const result = deriveEpicSyncPillState({
         hostTransportStatus: "open",
         cloudSyncStatus: "disconnected",
@@ -232,7 +232,7 @@ describe("deriveEpicSyncPillState", () => {
         hasUnsyncedLocalChanges: true,
         hasConnectedOnce: true,
       });
-      expect(result).toBe("syncing");
+      expect(result).toBe("offlineWithUnsavedChanges");
     });
   });
 });

--- a/clients/gui-app/src/lib/epic-sync-pill-state.ts
+++ b/clients/gui-app/src/lib/epic-sync-pill-state.ts
@@ -12,8 +12,14 @@ import type { StreamConnectionStatus } from "@traycer-clients/shared/host-transp
 export type EpicSyncPillState =
   /** Every leg of the chain has acknowledged everything we know about. */
   | "synced"
-  /** Work exists, but this label makes no claim about where it is durable. */
+  /** Work has not yet been acknowledged by the host. */
   | "syncing"
+  /** The host reports pending work without asserting its durability stage. */
+  | "hostPending"
+  /** Cloud is down while renderer-only work still awaits host acknowledgement. */
+  | "offlineWithUnsavedChanges"
+  /** Cloud is down and the host reports pending work with unknown durability. */
+  | "offlineWithHostPending"
   /**
    * Host reachable and holding outstanding work durably, cloud link down.
    * The only state that claims local durability, and it is true because the
@@ -101,7 +107,8 @@ export interface EpicSyncPillInputs {
  * 3. An unknown cloud status or host-durability snapshot yields neutral
  *    `connected`, never `synced`.
  * 4. Link up + cloud up: `synced` requires a clean host snapshot and no local
- *    divergence. Host-durable outstanding work reads `syncing`.
+ *    divergence. Host-reported pending work stays quiet as `hostPending`; the
+ *    aggregate dirty bit does not prove whether the newest bytes are durable.
  * 5. Link up + cloud down: only known host-durable work with no renderer-only
  *    divergence may read "saved locally". With nothing outstanding the pill
  *    falls back to reporting the link.
@@ -113,15 +120,23 @@ export function deriveEpicSyncPillState(
   if (inputs.hostTransportStatus !== "open") {
     return linkComingUpState(inputs.hasConnectedOnce);
   }
-  if (inputs.hasUnsyncedLocalChanges) return "syncing";
+  if (inputs.hasUnsyncedLocalChanges) {
+    if (
+      inputs.hasFreshCloudSyncStatus &&
+      inputs.cloudSyncStatus !== "connected"
+    ) {
+      return "offlineWithUnsavedChanges";
+    }
+    return "syncing";
+  }
   if (!inputs.hasFreshCloudSyncStatus || inputs.hostDirtyState === "unknown") {
     return "connected";
   }
   if (inputs.cloudSyncStatus === "connected") {
-    return inputs.hostDirtyState === "dirty" ? "syncing" : "synced";
+    return inputs.hostDirtyState === "dirty" ? "hostPending" : "synced";
   }
   return inputs.hostDirtyState === "dirty"
-    ? "offlineChangesSavedLocally"
+    ? "offlineWithHostPending"
     : linkComingUpState(inputs.hasConnectedOnce);
 }
 


### PR DESCRIPTION
## Summary

- keep normal renderer-to-host and host-pending sync churn visually quiet
- surface cloud-offline overlap states immediately without overstating local durability
- preserve keyboard focus across status transitions and announce actionable offline warnings
- remove the client-side delayed-sync timer so continuously active tasks do not appear stuck

## Verification

- pre-commit affected build, compile, lint, and format checks
- focused sync-pill, selector, and state tests (52 tests)
- React Doctor
- two cold review passes with all retained findings addressed or removed from scope

Signed-off-by: Hardik Shingala <hardik@traycer.ai>