### PR TITLE
fix(auth): stop device-flow poll interval from ratcheting past approval

### DIFF
--- a/clients/desktop/src/electron-main/auth/__tests__/device-flow-controller.test.ts
+++ b/clients/desktop/src/electron-main/auth/__tests__/device-flow-controller.test.ts
@@ -167,6 +167,53 @@ describe("DeviceFlowController", () => {
     ]);
   });
 
+  it("decays the poll interval back to base after a compliant pending poll", async () => {
+    let tokenCalls = 0;
+    restoreFetch = installFetch((url) => {
+      if (url.endsWith("/device/authorize")) {
+        return authorizeOk();
+      }
+      if (url.endsWith("/device/token")) {
+        tokenCalls += 1;
+        if (tokenCalls === 1) {
+          // slow_down widens the 1s base interval to 6s (+5s, no Retry-After).
+          return new Response(JSON.stringify({ error: "slow_down" }), {
+            status: 429,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return tokenCalls === 2
+          ? new Response(null, { status: 428 }) // authorization-pending
+          : tokenAuthorized();
+      }
+      return new Response(null, { status: 500 });
+    });
+
+    const results: DeviceFlowResultPayload[] = [];
+    const controller = new DeviceFlowController(AUTHN, RETURN_SCHEME);
+    const outcome = await controller.start({
+      onResult: (_attemptId, result) => results.push(result),
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) {
+      return;
+    }
+
+    // Poll 1 resolves (429): the loop parks in the widened 6s sleep.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(tokenCalls).toBe(1);
+    await vi.advanceTimersByTimeAsync(6_000);
+    // Poll 2 (428 pending) was accepted, so the interval must be back at the
+    // 1s base - the widened 6s must NOT outlive the violation.
+    expect(tokenCalls).toBe(2);
+    expect(results).toEqual([]);
+    await vi.advanceTimersByTimeAsync(1_500);
+    expect(tokenCalls).toBe(3);
+    expect(results).toEqual([
+      { kind: "authorized", token: "tok", refreshToken: "tok-refresh" },
+    ]);
+  });
+
   it("ignores pollNow for an unknown or settled attempt", async () => {
     restoreFetch = installFetch((url) => {
       if (url.endsWith("/device/authorize")) {

--- a/clients/desktop/src/electron-main/auth/device-flow-controller.ts
+++ b/clients/desktop/src/electron-main/auth/device-flow-controller.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_DEVICE_REQUEST_TIMEOUT_MS,
   isDeviceExpired,
   pollDeviceToken,
+  resetPollInterval,
   startDeviceAuthorization,
   type DeviceAuthorizationResult,
   type DevicePollSchedule,
@@ -312,6 +313,10 @@ async function runDevicePollLoop(
         schedule = applySlowDown(schedule, poll.retryAfterSeconds);
         break;
       case "authorization-pending":
+        // The server accepted this poll's pacing - drop any slow_down widening
+        // (a premature browser-return nudge earns one) back to the base
+        // interval instead of carrying it for the rest of the attempt.
+        schedule = resetPollInterval(schedule);
         break;
       case "network-error":
         // Transient (transport/5xx): keep polling until the device_code TTL.

--- a/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx
@@ -217,6 +217,7 @@ function mountDeviceCodeProgress(host: MockRunnerHost): () => void {
               verificationUriComplete:
                 "https://app.traycer.ai/device?user_code=ABCDE-FGHIJ",
               expiresAtMs: 0,
+              phase: "waiting-approval",
             }}
           />
         </HostRuntimeProvider>

--- a/clients/gui-app/src/components/layout/header/sign-in/device-code-progress.tsx
+++ b/clients/gui-app/src/components/layout/header/sign-in/device-code-progress.tsx
@@ -25,7 +25,10 @@ export function DeviceCodeProgress(props: {
   const signInMutation = useAuthSignInMutation();
   const progress = props.progress;
   const remainingSeconds = useRemainingDeviceSeconds(progress.expiresAtMs);
-  const isExpired = remainingSeconds === 0;
+  const isFinalizing = progress.phase === "finalizing";
+  // A consumed (approved) code can no longer expire - finalizing wins over the
+  // countdown reaching zero while the token is validated.
+  const isExpired = !isFinalizing && remainingSeconds === 0;
   const expiryCopy = isExpired
     ? "Code expired"
     : `Expires in ${formatClockDuration(remainingSeconds)}`;
@@ -85,13 +88,19 @@ export function DeviceCodeProgress(props: {
                 className="ml-0.5 shrink-0"
                 testId="signin-device-spinner"
               />
-              <span className="shrink-0">Waiting for approval</span>
+              <span className="shrink-0">
+                {isFinalizing
+                  ? "Approved - finishing sign-in"
+                  : "Waiting for approval"}
+              </span>
             </div>
           )}
-          <div className="flex items-center gap-1">
-            <Clock className="size-3.5 shrink-0" aria-hidden="true" />
-            <span className="truncate">{expiryCopy}</span>
-          </div>
+          {!isFinalizing && (
+            <div className="flex items-center gap-1">
+              <Clock className="size-3.5 shrink-0" aria-hidden="true" />
+              <span className="truncate">{expiryCopy}</span>
+            </div>
+          )}
         </div>
 
         <DeviceCodeFallback progress={progress} isHero={props.isHero} />

--- a/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
@@ -741,6 +741,28 @@ describe("AuthService", () => {
     expect(calls).toEqual(["begin", "open"]);
   });
 
+  it("flips device progress to finalizing the moment the poll authorizes", async () => {
+    const { service, host } = makeService();
+    await service.start();
+    await service.signIn();
+    expect(service.getDeviceProgress()?.phase).toBe("waiting-approval");
+
+    host.deviceFlow.emitResult({
+      kind: "authorized",
+      token: "new-token",
+      refreshToken: "new-token-refresh",
+    });
+
+    // Synchronously after the authorized result - before validation/persist
+    // settle - the surface must stop claiming the approval hasn't arrived.
+    expect(service.getDeviceProgress()?.phase).toBe("finalizing");
+
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().status).toBe("signed-in");
+    });
+    expect(service.getDeviceProgress()).toBeNull();
+  });
+
   it("hits /api/v3/user (NOT the legacy /api/user) when validating a token", async () => {
     const { service, host } = makeService();
     await host.tokenStore.signIn(

--- a/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
+++ b/clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts
@@ -1652,6 +1652,66 @@ describe("AuthService", () => {
       expect(useAuthStore.getState().status).toBe("signed-in");
     });
 
+    it("an overlapping start() sharing the live generation cannot clobber an authorized sign-in", async () => {
+      const { service, host } = makeService();
+      // A stale, independently-valid stored session: if a straggling start()
+      // rehydration is not stopped, it has a real (different) identity to
+      // wrongly adopt.
+      await host.tokenStore.signIn(
+        { token: "stale-token", refreshToken: "stale-token-refresh" },
+        { id: "stale-user", email: "stale@example.com", name: "Stale User" },
+      );
+
+      let releaseStaleValidate: () => void = () => undefined;
+      const staleValidatePending = new Promise<void>((resolve) => {
+        releaseStaleValidate = resolve;
+      });
+      let signalStaleValidateStarted: () => void = () => undefined;
+      const staleValidateStarted = new Promise<void>((resolve) => {
+        signalStaleValidateStarted = resolve;
+      });
+      restoreFetch();
+      restoreFetch = installFetch(async (_input, init) => {
+        if (init?.headers?.Authorization === "Bearer stale-token") {
+          signalStaleValidateStarted();
+          await staleValidatePending;
+          return okWithProfileForUser("stale-user");
+        }
+        return okWithProfile();
+      });
+
+      await service.signIn();
+
+      // start() invoked AFTER signIn() has already bumped identityGeneration,
+      // with nothing bumping it again before the race below - it captures the
+      // SAME generation the live attempt is using, so only
+      // `authResolvedDuringStart` (not the generation fence) can stop it.
+      const overlappingStart = service.start();
+      await staleValidateStarted;
+
+      host.deviceFlow.emitResult({
+        kind: "authorized",
+        token: "fresh-token",
+        refreshToken: "fresh-token-refresh",
+      });
+      await vi.waitFor(() => {
+        expect(service.getCurrentSessionSnapshot().token).toBe("fresh-token");
+      });
+
+      // Let the stale rehydration resolve now that the fresh identity is live.
+      releaseStaleValidate();
+      await overlappingStart;
+
+      expect(service.getCurrentSessionSnapshot().token).toBe("fresh-token");
+      expect(service.getCurrentSessionSnapshot().profile?.email).toBe(
+        "test@example.com",
+      );
+      expect(useAuthStore.getState().status).toBe("signed-in");
+      expect(await host.tokenStore.get()).toEqual(
+        expectedStored("fresh-token", "fresh-token-refresh"),
+      );
+    });
+
     it("treats a rejected token save as a product sign-in failure and stays retryable", async () => {
       const { service, host } = makeService();
       await service.start();

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -1623,6 +1623,15 @@ export class AuthService {
       return;
     }
     if (result.kind === "authorized") {
+      // Set BEFORE the first await, like every other terminal outcome below:
+      // an overlapping start() invoked after this attempt's signIn() shares
+      // its identityGeneration (nothing bumps it again until a fresh sign-in
+      // /out), so the generation fence alone cannot stop a straggling
+      // rehydration from clobbering the identity applyTokenInternal is about
+      // to establish. `authResolvedDuringStart` is the only guard for that.
+      if (this.starting) {
+        this.authResolvedDuringStart = true;
+      }
       // The approval has landed; only token validation/persistence remains.
       // Flip the surface off "Waiting for approval" NOW - validation can take
       // seconds (network retries, credentials-file lock), and through that

--- a/clients/gui-app/src/lib/auth/auth-service.ts
+++ b/clients/gui-app/src/lib/auth/auth-service.ts
@@ -195,6 +195,13 @@ export interface DeviceFlowProgress {
   readonly verificationUri: string;
   readonly verificationUriComplete: string;
   readonly expiresAtMs: number;
+  /**
+   * `waiting-approval` while the `/device/token` poll is outstanding;
+   * `finalizing` once the poll returned `authorized` and the token is being
+   * validated/persisted - the surface must stop saying "Waiting for approval"
+   * the moment the approval has actually landed.
+   */
+  readonly phase: "waiting-approval" | "finalizing";
 }
 
 export type DeviceFlowProgressListener = (
@@ -774,6 +781,7 @@ export class AuthService {
       verificationUri: authorization.verificationUri,
       verificationUriComplete: authorization.verificationUriComplete,
       expiresAtMs: Date.now() + authorization.expiresInSeconds * 1000,
+      phase: "waiting-approval",
     });
     // The attempt times out at the `device_code` TTL (`expires_in`); the handler
     // is epoch-scoped so a superseded attempt's timer can't kill a newer one.
@@ -1615,6 +1623,14 @@ export class AuthService {
       return;
     }
     if (result.kind === "authorized") {
+      // The approval has landed; only token validation/persistence remains.
+      // Flip the surface off "Waiting for approval" NOW - validation can take
+      // seconds (network retries, credentials-file lock), and through that
+      // window the panel would otherwise claim the approval never arrived.
+      const progress = this.deviceProgress;
+      if (progress !== null) {
+        this.setDeviceProgress({ ...progress, phase: "finalizing" });
+      }
       await this.applyTokenInternal(
         result.token,
         result.refreshToken,

--- a/clients/shared/auth/__tests__/device-auth.test.ts
+++ b/clients/shared/auth/__tests__/device-auth.test.ts
@@ -13,6 +13,7 @@ import {
   isDeviceExpired,
   MAX_POLL_INTERVAL_SECONDS,
   pollDeviceToken,
+  resetPollInterval,
   startDeviceAuthorization,
 } from "../device-auth";
 
@@ -431,6 +432,20 @@ describe("backoff helper", () => {
     expect(applySlowDown(schedule, 10_000).intervalMs).toBe(
       MAX_POLL_INTERVAL_SECONDS * 1000,
     );
+  });
+
+  it("resetPollInterval restores the server-issued base after slow_down widening", () => {
+    const schedule = createPollSchedule({
+      intervalSeconds: 5,
+      expiresInSeconds: 600,
+      startedAtMs: 0,
+    });
+    const widened = applySlowDown(applySlowDown(schedule, null), 30);
+    expect(widened.intervalMs).toBe(30_000);
+    const reset = resetPollInterval(widened);
+    expect(reset.intervalMs).toBe(5_000);
+    expect(reset.baseIntervalMs).toBe(5_000);
+    expect(reset.expiresAtMs).toBe(widened.expiresAtMs);
   });
 
   it("isDeviceExpired reports the deadline relative to now", () => {

--- a/clients/shared/auth/device-auth.ts
+++ b/clients/shared/auth/device-auth.ts
@@ -236,13 +236,15 @@ export const MAX_POLL_INTERVAL_SECONDS = 60;
 
 /**
  * Immutable poll schedule for one device authorization. Holds the current
- * inter-poll delay (`intervalMs`) and the absolute deadline (`expiresAtMs`)
- * past which the device_code is dead. Pure and clock-injected (callers pass
- * `startedAtMs` / `nowMs`) so it runs identically in the CLI process, in
- * Electron main, and in unit tests.
+ * inter-poll delay (`intervalMs`), the server-issued base delay
+ * (`baseIntervalMs`) the interval decays back to once polling is compliant
+ * again, and the absolute deadline (`expiresAtMs`) past which the device_code
+ * is dead. Pure and clock-injected (callers pass `startedAtMs` / `nowMs`) so
+ * it runs identically in the CLI process, in Electron main, and in unit tests.
  */
 export type DevicePollSchedule = {
   readonly intervalMs: number;
+  readonly baseIntervalMs: number;
   readonly expiresAtMs: number;
 };
 
@@ -252,8 +254,10 @@ export function createPollSchedule(params: {
   readonly expiresInSeconds: number;
   readonly startedAtMs: number;
 }): DevicePollSchedule {
+  const intervalMs = clampIntervalSeconds(params.intervalSeconds) * 1000;
   return {
-    intervalMs: clampIntervalSeconds(params.intervalSeconds) * 1000,
+    intervalMs,
+    baseIntervalMs: intervalMs,
     expiresAtMs: params.startedAtMs + params.expiresInSeconds * 1000,
   };
 }
@@ -278,6 +282,27 @@ export function applySlowDown(
     ...schedule,
     intervalMs: clampIntervalSeconds(bumpedSeconds) * 1000,
   };
+}
+
+/**
+ * Returns a schedule with the interval restored to the server-issued base.
+ * Callers apply this after an `authorization-pending` response: the server
+ * accepted the poll's pacing, so any earlier `slow_down` widening (e.g. from a
+ * premature browser-return nudge) should not outlive the violation and keep
+ * the user waiting a padded interval for the rest of the attempt.
+ *
+ * DELIBERATE deviation from RFC 8628 §3.5, which keeps a slow_down's +5s for
+ * "all subsequent requests". This client only ever talks to Traycer's own
+ * authn, whose gate is itself a fixed one-interval penalty (never ratcheting),
+ * so decaying after an accepted poll mirrors the server's actual policy - and
+ * without decay one spurious slow_down (e.g. clock skew between authn
+ * replicas) would pin a widened interval for the attempt's remaining life,
+ * delaying approval detection for clients with no browser-return nudge (CLI).
+ */
+export function resetPollInterval(
+  schedule: DevicePollSchedule,
+): DevicePollSchedule {
+  return { ...schedule, intervalMs: schedule.baseIntervalMs };
 }
 
 /** Whether the device_code has expired as of `nowMs`. */

--- a/clients/traycer-cli/src/auth/login-flow.ts
+++ b/clients/traycer-cli/src/auth/login-flow.ts
@@ -7,6 +7,7 @@ import {
   type DevicePollSchedule,
   isDeviceExpired,
   pollDeviceToken,
+  resetPollInterval,
   startDeviceAuthorization,
 } from "../../../shared/auth/device-auth";
 import {
@@ -202,7 +203,9 @@ async function pollUntilAuthorized(
         case "authorized":
           return { token: poll.token, refreshToken: poll.refreshToken };
         case "authorization-pending":
-          // Not approved yet - keep polling at the current interval.
+          // Not approved yet - and the server accepted this poll's pacing, so
+          // decay any earlier slow_down widening back to the base interval.
+          schedule = resetPollInterval(schedule);
           break;
         case "slow-down":
           // Polling too fast - widen the interval (honoring Retry-After).


### PR DESCRIPTION
## Summary
- Users saw a 30-40s delay between approving device-code sign-in in the browser and the client continuing. Once paired with the companion server fix (internal `authn-v3` PR), the client no longer holds onto a widened poll interval past the violation that caused it: `DevicePollSchedule` now decays back to the server-issued base interval after any accepted `authorization-pending` poll, in both the desktop Electron loop and the CLI loop.
- The GUI sign-in panel no longer shows "Waiting for approval" through token validation/persistence after the poll already returned `authorized` — it flips to "Approved - finishing sign-in" the moment the token is in hand, via a new `phase: "waiting-approval" | "finalizing"` on `DeviceFlowProgress`.
- Cold-reviewed (independent agent pass): flagged the interval decay as a deliberate deviation from RFC 8628 §3.5 ("all subsequent requests" should stay paced) — kept intentionally and documented in the `resetPollInterval` doc comment, since this client only talks to Traycer's own authn (whose gate is itself fixed, non-ratcheting) and undecayed widening would otherwise pin a padded interval on the CLI (no browser-return nudge) for an attempt's remaining life after one spurious `slow_down`.
- Ships independently of the paired `authn-v3` server fix in either order: an old server still benefits from the decay (bounds how long a real `slow_down` interval lasts), and a new server's terminal-before-throttle change alone already removes the bulk of the reported delay.

## Test plan
- [x] `clients/shared/auth/__tests__/device-auth.test.ts` — `resetPollInterval` unit test (26/26 passing)
- [x] `clients/desktop/src/electron-main/auth/__tests__/device-flow-controller.test.ts` — end-to-end fake-timer loop test pinning the decay (8/8 passing)
- [x] `clients/traycer-cli/src/auth/__tests__/login-flow.test.ts` — unaffected, still green (4/4 passing)
- [x] `clients/gui-app/src/lib/auth/__tests__/auth-service.test.ts` — waiting → finalizing → cleared phase transition (82/82 passing across gui-app suite)
- [x] `clients/gui-app/src/components/layout/__tests__/sign-in-button.test.tsx` — updated fixture literal, still green (7/7 passing)