### PR TITLE
fix(gui-app): show full agent title on hover

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx
@@ -818,6 +818,18 @@ describe("epic sidebar selection mode", () => {
     expect(screen.queryByText("No agents use this interface.")).toBeNull();
   });
 
+  it("exposes each full agent title on hover without worktree metadata", () => {
+    seedChatTree();
+    testState.rowHostId = null;
+
+    render(<EpicLeftPanelHost epicId={EPIC_ID} tabId={TAB_ID} side="left" />);
+
+    expect(screen.getByRole("tooltip", { name: "Root chat" })).toBeTruthy();
+    expect(
+      screen.getByRole("tooltip", { name: "Terminal agent" }),
+    ).toBeTruthy();
+  });
+
   it("blames the interface filter, not the Task, when a filter hides every agent", () => {
     seedGuiChatTree();
     testState.chatFilterOrigin = "tui";

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-sidebar-chat-tree.tsx
@@ -2076,10 +2076,9 @@ function ChatRowButton(props: ChatRowButtonProps) {
         </span>
       </label>
     );
-    if (roleHoverContent === null) return selectionRow;
     return (
       <TooltipWrapper
-        label={roleHoverContent}
+        label={roleHoverContent ?? nodeName}
         side="right"
         sideOffset={6}
         align="start"
@@ -2162,6 +2161,7 @@ function ChatRowButton(props: ChatRowButtonProps) {
     return (
       <WorktreeOwnerMetadataTooltip
         trigger={button}
+        title={nodeName}
         hostId={ownerHostId}
         epicId={epicId}
         ownerId={nodeId}
@@ -2170,10 +2170,9 @@ function ChatRowButton(props: ChatRowButtonProps) {
       />
     );
   }
-  if (roleHoverContent === null) return button;
   return (
     <TooltipWrapper
-      label={roleHoverContent}
+      label={roleHoverContent ?? nodeName}
       side="right"
       sideOffset={6}
       align="start"

--- a/clients/gui-app/src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx
+++ b/clients/gui-app/src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx
@@ -65,6 +65,7 @@ function renderTooltip(onClick: (() => void) | undefined): HTMLElement {
           Chat row
         </button>
       }
+      title="A complete chat title that should remain visible"
       hostId="host-1"
       epicId="epic-1"
       ownerId="owner-1"
@@ -95,6 +96,17 @@ describe("WorktreeOwnerMetadataTooltip hover gate", () => {
     settleOpenDelay();
 
     expect(cardIsOpen()).toBe(true);
+  });
+
+  it("shows the owner's full title in the opened card", () => {
+    const trigger = renderTooltip(undefined);
+
+    hoverIn(trigger);
+    settleOpenDelay();
+
+    expect(
+      screen.getByTestId("chat-navigator-hover-title-owner-1").textContent,
+    ).toBe("A complete chat title that should remain visible");
   });
 
   it("swallows an open that lands after the press (the reported race)", () => {

--- a/clients/gui-app/src/components/worktree/worktree-owner-metadata.tsx
+++ b/clients/gui-app/src/components/worktree/worktree-owner-metadata.tsx
@@ -54,6 +54,7 @@ const CLOSED_HOVER_STATE: OwnerMetadataHoverState = {
 
 export function WorktreeOwnerMetadataTooltip(props: {
   readonly trigger: ReactElement;
+  readonly title: string;
   readonly hostId: string;
   readonly epicId: string;
   readonly ownerId: string;
@@ -116,18 +117,26 @@ export function WorktreeOwnerMetadataTooltip(props: {
   return (
     <HoverPreviewCard
       content={
-        // Sized by its FIRST ROW, between a floor and a ceiling. The settings
-        // line is a single unbreakable unit - model, reasoning, permission mode
-        // - and wrapping it onto a second line was worse than a wider card: it
-        // pushed the permission mode, the one value here with a safety
-        // consequence, below the fold of the eye. So the card grows to fit it
-        // instead, from the old fixed 24rem (now the floor, so a short line
-        // still gets a card that reads as a card) up to a viewport-capped
-        // ceiling, past which the header ellipsizes rather than growing further.
+        // Sized by the run-settings row, between a floor and a ceiling. The
+        // title and workspace blocks stretch to that resolved width without
+        // voting on it. The settings line is a single unbreakable unit - model,
+        // reasoning, permission mode - and wrapping it onto a second line was
+        // worse than a wider card: it pushed the permission mode, the one value
+        // here with a safety consequence, below the fold of the eye. So the
+        // card grows to fit it instead, from the old fixed 24rem (now the floor,
+        // so a short line still gets a card that reads as a card) up to a
+        // viewport-capped ceiling, past which the header ellipsizes rather than
+        // growing further.
         <div
           className="block w-fit min-w-[min(92vw,24rem)] max-w-[min(92vw,36rem)]"
           data-testid={`chat-navigator-worktree-hover-${props.ownerId}`}
         >
+          <span
+            className="block w-0 min-w-full break-words border-b border-border/70 px-3 py-2 text-ui-sm font-medium text-foreground"
+            data-testid={`chat-navigator-hover-title-${props.ownerId}`}
+          >
+            {props.title}
+          </span>
           <WorktreeOwnerSettingsHeader
             ownerId={props.ownerId}
             hostId={props.hostId}


### PR DESCRIPTION
## Summary

- Show the complete agent title at the top of the existing worktree metadata hover card.
- Provide the full title via a standard tooltip when worktree metadata is unavailable.
- Cover both hover paths with regression tests.

## Related issue

None.

## Checklist

- [ ] `bun run build`, `bun run lint`, and `bun run test` pass
- [ ] Code is formatted (`bun run format`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Tests added/updated where it makes sense
- [x] Commits are signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

## Validation

- `bun run test src/components/worktree/__tests__/worktree-owner-metadata-hover-gate.test.tsx src/components/epic-canvas/sidebar/__tests__/epic-sidebar-selection-mode.test.tsx` (89 passed)
- `npx -y react-doctor@latest . --verbose --scope changed --base main --offline --no-score`
