### PR TITLE
fix(desktop,gui-app): surface busy-denied host restarts as information, not errors

### DIFF
--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -5703,6 +5703,38 @@ describe("packaged-mac register failure: CLI-owned LaunchAgent takeover fallback
     expect(registerHostLoginItem).toHaveBeenCalledTimes(1);
   });
 
+  // Field RCA 2026-07-28: the very restart that exercised this fallback in
+  // the field hit a live host that denied the takeover's shutdown claim
+  // (E_HOST_BUSY) - a self-recovering state (the retry 14s later
+  // succeeded), yet it surfaced as a `failed` outcome and therefore a
+  // reportable "Couldn't restart host" error toast. The denial must
+  // resolve `deferred` so restart surfaces present it as information.
+  it("activation cycle: a takeover denied by a busy host is deferred - retry-later information, not a reportable failure", async () => {
+    const controller = stagePackagedMacWorld();
+    vi.mocked(registerHostLoginItem).mockResolvedValue("not-found");
+    vi.mocked(runBundledTraycerCliJson).mockRejectedValue(
+      new TraycerCliError(
+        "E_HOST_BUSY",
+        "service install --takeover: the running host has work in progress and denied the shutdown claim; retry once the work completes.",
+      ),
+    );
+
+    const outcome = await controller.respawn();
+
+    expect(outcome.kind).toBe("deferred");
+    if (outcome.kind === "deferred") {
+      // User-facing retry copy - not the CLI's takeover jargon, and none
+      // of the failure message's escape-hatch instructions.
+      expect(outcome.message).toContain("work in progress");
+      expect(outcome.message).toContain("Try again");
+      expect(outcome.message).not.toContain("service uninstall");
+    }
+    // The denial still quarantines this SMAppService session: the register
+    // cycle is just as doomed as any other takeover-recoverable failure.
+    expect(registerHostLoginItem).toHaveBeenCalledTimes(1);
+    expect(controller.isPendingRevisionRefreshQuarantined()).toBe(true);
+  });
+
   it("activation cycle: a takeover that registered but never produced a ready host is a failure, not a silent success", async () => {
     const controller = stagePackagedMacWorld();
     vi.mocked(registerHostLoginItem).mockResolvedValue("not-registered");

--- a/clients/desktop/src/electron-main/host/host-controller.ts
+++ b/clients/desktop/src/electron-main/host/host-controller.ts
@@ -1145,7 +1145,19 @@ export class HostController {
     readonly expectedRuntimeVersion: string | null;
   }): Promise<
     | { readonly recovered: true; readonly version: string | null }
-    | { readonly recovered: false; readonly message: string }
+    | {
+        readonly recovered: false;
+        // The takeover's cooperative stop was DENIED by a live host with
+        // work in progress - by the takeover contract that aborts rather
+        // than trample the work, and a later retry succeeds once the work
+        // drains. Callers resolve this as a deferred outcome, not a
+        // failure: surfacing it as an error invites issue reports for a
+        // self-recovering condition (field RCA 2026-07-28 - the very
+        // restart that validated this fallback in the field toasted
+        // "Report issue" while the host was healthy and protecting work).
+        readonly hostBusy: boolean;
+        readonly message: string;
+      }
   > {
     // SMAppService is unusable for the rest of this session - quarantine the
     // pending-revision refresh so it cannot boot the fallback host out for a
@@ -1166,8 +1178,22 @@ export class HostController {
         ...this.devServiceInstallExtras(),
       ]);
     } catch (err) {
+      if (err instanceof TraycerCliError && err.code === HOST_BUSY_CODE) {
+        log.info(
+          "[host-controller] CLI takeover declined - the running host has work in progress",
+          { status: args.failedStatus },
+        );
+        return {
+          recovered: false,
+          hostBusy: true,
+          message:
+            "The host has work in progress, so it was not restarted. " +
+            "Try again once the work completes.",
+        };
+      }
       return {
         recovered: false,
+        hostBusy: false,
         message: `Failed to register the host login item (status=${args.failedStatus}), and the fallback service registration failed: ${describeError(err)} Run 'traycer host service uninstall' and relaunch Traycer, or run 'traycer host doctor' to recover.`,
       };
     }
@@ -1181,6 +1207,7 @@ export class HostController {
     } catch (err) {
       return {
         recovered: false,
+        hostBusy: false,
         message: `Failed to register the host login item (status=${args.failedStatus}); the fallback service was registered but the host did not come up: ${describeError(err)}`,
       };
     }
@@ -1233,6 +1260,19 @@ export class HostController {
   ): Promise<MutationOutcome<T>> {
     await this.reloadAfterServiceCycleFailure();
     return { kind: "installed-not-converged", message };
+  }
+
+  // Deferred sibling of `failedAfterServiceCycle`, for the takeover's
+  // host-busy denial: the same snapshot healing applies (the cycle may
+  // have cleared the renderer-facing snapshot, and a busy denial proves
+  // the host is alive and publishing pid.json), but the outcome resolves
+  // `deferred` so restart surfaces present "not restarted, retry later"
+  // as information rather than a reportable failure.
+  private async deferredAfterServiceCycle<T>(
+    message: string,
+  ): Promise<MutationOutcome<T>> {
+    await this.reloadAfterServiceCycleFailure();
+    return { kind: "deferred", message };
   }
 
   // ---- Shared locked macOS SMAppService activation cycle ------------------
@@ -1463,7 +1503,9 @@ export class HostController {
         expectedRuntimeVersion: step.expectedRuntimeVersion,
       });
       if (!recovery.recovered) {
-        return this.failedAfterServiceCycle(recovery.message);
+        return recovery.hostBusy
+          ? this.deferredAfterServiceCycle(recovery.message)
+          : this.failedAfterServiceCycle(recovery.message);
       }
       return { kind: "ok", value: { activated: true } };
     }
@@ -1761,7 +1803,9 @@ export class HostController {
         expectedRuntimeVersion,
       });
       if (!recovery.recovered) {
-        return this.failedAfterServiceCycle(recovery.message);
+        return recovery.hostBusy
+          ? this.deferredAfterServiceCycle(recovery.message)
+          : this.failedAfterServiceCycle(recovery.message);
       }
       return {
         kind: "ok",
@@ -2797,7 +2841,9 @@ export class HostController {
               expectedRuntimeVersion: registration.expectedRuntimeVersion,
             });
             if (!recovery.recovered) {
-              return this.failedAfterServiceCycle(recovery.message);
+              return recovery.hostBusy
+                ? this.deferredAfterServiceCycle(recovery.message)
+                : this.failedAfterServiceCycle(recovery.message);
             }
             return { kind: "ok", value: { registered: true } };
           }

--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -2621,7 +2621,9 @@ describe("RunnerIpcBridge", () => {
     if (respawnHandler === undefined) {
       throw new Error("requestHostRespawn handler missing");
     }
-    await respawnHandler(bareEvent());
+    await expect(respawnHandler(bareEvent())).resolves.toEqual({
+      kind: "restarted",
+    });
     await respawnHandler(bareEvent());
     expect(hostController.respawnCalls).toBe(2);
     bridge.dispose();
@@ -2657,6 +2659,52 @@ describe("RunnerIpcBridge", () => {
     );
     bridge.dispose();
   });
+
+  // Field RCA 2026-07-28: the takeover fallback's host-busy denial resolves
+  // `deferred`, and the invoke must RESOLVE it as `declined` rather than
+  // reject - a rejected invoke lands on the renderer's reportable error
+  // toast, inviting "Report issue" for a self-recovering condition.
+  it.each([
+    {
+      kind: "deferred" as const,
+      message: "The host has work in progress, so it was not restarted.",
+    },
+    {
+      kind: "busy" as const,
+      continuation: "activate" as const,
+      message: "The host has work in progress; restart it to finish.",
+    },
+  ])(
+    "resolves requestHostRespawn as declined when respawn() resolves $kind",
+    async (outcome) => {
+      const mod = await import("../register-runner-ipc");
+      const hostController = new FakeHostController();
+      hostController.respawn = async () => outcome;
+      const bridge = new mod.RunnerIpcBridge({
+        host: new FakeHost(),
+        hostController,
+        authnBaseUrl: "http://localhost:5005",
+        authRedirectUri: null,
+        tray: null,
+        zoomController: undefined,
+        authTokenStore: undefined,
+        window: buildWindow(),
+      });
+      bridge.install();
+
+      const respawnHandler = ipcMainState.handlers.get(
+        RunnerHostInvoke.requestHostRespawn,
+      );
+      if (respawnHandler === undefined) {
+        throw new Error("requestHostRespawn handler missing");
+      }
+      await expect(respawnHandler(bareEvent())).resolves.toEqual({
+        kind: "declined",
+        message: outcome.message,
+      });
+      bridge.dispose();
+    },
+  );
 
   it("serves authnBaseUrl synchronously via ipcMain.on", async () => {
     const mod = await import("../register-runner-ipc");

--- a/clients/desktop/src/electron-main/ipc/host-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-ipc.ts
@@ -3,7 +3,31 @@ import {
   RunnerHostInvoke,
 } from "../../ipc-contracts/ipc-channels";
 import type { DesktopLocalHostSnapshot } from "../../ipc-contracts/host-types";
+import type {
+  HostRestartRequestResult,
+  MutationOutcome,
+} from "../../ipc-contracts/host-management-types";
 import type { RunnerIpcBridge } from "./runner-ipc-bridge";
+
+// Collapses a restart-intent outcome to the wire result both restart
+// surfaces resolve (this handler and `traycerHostRestart`). `busy` and
+// `deferred` become a resolved `declined` - the host was deliberately NOT
+// restarted (in-progress work denied the shutdown claim, removed-by-user,
+// lock contention), a state that clears on its own or on a later retry -
+// so the renderer can present it as information. Every other non-"ok"
+// kind still rejects the invoke, keeping genuine failures on the existing
+// catch-based reportable-error path (field RCA 2026-07-28: throwing the
+// busy denial produced a "Report issue" error toast for a self-recovering
+// condition).
+export function restartRequestResultFromOutcome<TOk>(
+  outcome: MutationOutcome<TOk>,
+): HostRestartRequestResult {
+  if (outcome.kind === "ok") return { kind: "restarted" };
+  if (outcome.kind === "busy" || outcome.kind === "deferred") {
+    return { kind: "declined", message: outcome.message };
+  }
+  throw new Error(outcome.message);
+}
 
 export function registerHostIpc(bridge: RunnerIpcBridge): void {
   // Renderer-driven host respawn.
@@ -15,14 +39,16 @@ export function registerHostIpc(bridge: RunnerIpcBridge): void {
   // SMAppService unregister/register cycles) and the routing between the
   // SMAppService cycle (macOS host-owned login item) and the CLI restart
   // path. `HostController` never rejects (wait-never-reject); this handler
-  // re-throws a non-"ok" outcome so the renderer's existing catch-based
-  // error handling for this invoke keeps working unchanged.
-  bridge.handleInvoke(RunnerHostInvoke.requestHostRespawn, async () => {
-    const outcome = await bridge.options.hostController.respawn();
-    if (outcome.kind !== "ok") {
-      throw new Error(outcome.message);
-    }
-  });
+  // resolves ok/busy/deferred as a `HostRestartRequestResult` and re-throws
+  // the rest so the renderer's catch-based error handling stays for
+  // genuine failures.
+  bridge.handleInvoke(
+    RunnerHostInvoke.requestHostRespawn,
+    async (): Promise<HostRestartRequestResult> => {
+      const outcome = await bridge.options.hostController.respawn();
+      return restartRequestResultFromOutcome(outcome);
+    },
+  );
 
   const onHostChange = (snapshot: DesktopLocalHostSnapshot | null): void => {
     bridge.fanOut(RunnerHostEvent.localHostChange, snapshot);

--- a/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/host-management-ipc.ts
@@ -32,6 +32,7 @@ import {
   writeHostNameSettings,
 } from "../host/host-display-name";
 import type { IpcHostController, RunnerIpcBridge } from "./runner-ipc-bridge";
+import { restartRequestResultFromOutcome } from "./host-ipc";
 
 export const LONG_OP_TIMEOUT_MS = 10 * 60_000;
 const REGISTRY_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -764,8 +765,13 @@ export function registerHostManagementIpc(bridge: RunnerIpcBridge): void {
     return readInstalledHostRecord();
   });
 
+  // Deliberately NOT `okOrThrow`: a busy/deferred respawn outcome resolves
+  // as a `declined` result the renderer presents as information - see
+  // `restartRequestResultFromOutcome`.
   bridge.handleInvoke(RunnerHostInvoke.traycerHostRestart, async () => {
-    okOrThrow(await bridge.options.hostController.respawn());
+    return restartRequestResultFromOutcome(
+      await bridge.options.hostController.respawn(),
+    );
   });
 
   bridge.handleInvoke(

--- a/clients/desktop/src/electron-preload/__tests__/preload-bridge.test.ts
+++ b/clients/desktop/src/electron-preload/__tests__/preload-bridge.test.ts
@@ -147,7 +147,7 @@ interface PreloadBridge {
     copyTemporaryFiles(paths: readonly string[]): Promise<readonly string[]>;
     saveFile(input: unknown): Promise<string | null>;
   };
-  requestHostRespawn(): Promise<void>;
+  requestHostRespawn(): Promise<unknown>;
   hostManagement: {
     convergeReady(force: boolean): Promise<unknown>;
     applyStaged(trigger: "launch" | "manual", force: boolean): Promise<unknown>;

--- a/clients/desktop/src/electron-preload/host-bridge.ts
+++ b/clients/desktop/src/electron-preload/host-bridge.ts
@@ -4,6 +4,7 @@ import {
   RunnerHostInvoke,
 } from "../ipc-contracts/ipc-channels";
 import type { DesktopLocalHostSnapshot } from "../ipc-contracts/host-types";
+import type { HostRestartRequestResult } from "../ipc-contracts/host-management-types";
 import { subscribe, type Disposable, type Listener } from "./subscribe";
 
 /**
@@ -43,7 +44,7 @@ export interface HostBridgeSurface {
     handler: Listener<DesktopLocalHostSnapshot | null>,
   ): Disposable;
   onSystemResumed(handler: () => void): Disposable;
-  requestHostRespawn(): Promise<void>;
+  requestHostRespawn(): Promise<HostRestartRequestResult>;
   hostPicker: {
     requestOpen(): Promise<void>;
     requestClose(): Promise<void>;
@@ -62,7 +63,9 @@ export function buildHostBridge(): HostBridgeSurface {
       subscribe<void>(RunnerHostEvent.systemResumed, handler),
 
     requestHostRespawn: () =>
-      ipcRenderer.invoke(RunnerHostInvoke.requestHostRespawn) as Promise<void>,
+      ipcRenderer.invoke(
+        RunnerHostInvoke.requestHostRespawn,
+      ) as Promise<HostRestartRequestResult>,
 
     hostPicker: {
       requestOpen: () =>

--- a/clients/desktop/src/electron-preload/host-management-bridge.ts
+++ b/clients/desktop/src/electron-preload/host-management-bridge.ts
@@ -18,6 +18,7 @@ import type {
   HostNameSettings,
   HostRegistryUpdateState,
   HostRemovalState,
+  HostRestartRequestResult,
   HostTrayCommand,
   HostUninstallResult,
   InstallVersionOk,
@@ -56,7 +57,7 @@ export interface HostManagementBridgeSurface {
   uninstallTraycer(): Promise<TraycerUninstallResult>;
   getRemovalState(): Promise<HostRemovalState>;
   clearRemoval(): Promise<void>;
-  restartHost(): Promise<void>;
+  restartHost(): Promise<HostRestartRequestResult>;
   getHostLogs(input: {
     readonly tailLines: number;
   }): Promise<HostLogsTailResult>;
@@ -121,7 +122,9 @@ export function buildHostManagementBridge(): HostManagementBridgeSurface {
         RunnerHostInvoke.traycerHostRemovalClear,
       ) as Promise<void>,
     restartHost: () =>
-      ipcRenderer.invoke(RunnerHostInvoke.traycerHostRestart) as Promise<void>,
+      ipcRenderer.invoke(
+        RunnerHostInvoke.traycerHostRestart,
+      ) as Promise<HostRestartRequestResult>,
     getHostLogs: ({ tailLines }) =>
       ipcRenderer.invoke(RunnerHostInvoke.traycerHostLogs, {
         tailLines,

--- a/clients/desktop/src/ipc-contracts/host-management-types.ts
+++ b/clients/desktop/src/ipc-contracts/host-management-types.ts
@@ -35,6 +35,7 @@ export type {
   HostNameSettings,
   HostRegistryUpdateState,
   HostRemovalState,
+  HostRestartRequestResult,
   HostTrayCommand,
   HostUninstallResult,
   InstallVersionOk,

--- a/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
+++ b/clients/desktop/src/renderer-shell/__tests__/desktop-runner-host.test.ts
@@ -137,6 +137,7 @@ function buildFakeBridge(
     }),
     requestHostRespawn: async () => {
       respawnCounter.count += 1;
+      return { kind: "restarted" as const };
     },
     trayState: {
       setEpics: async (_epics: readonly TrayEpic[]) => undefined,
@@ -496,7 +497,7 @@ function buildFakeBridge(
       },
       getRemovalState: async () => ({ removedByUser: false }),
       clearRemoval: async () => undefined,
-      restartHost: async () => undefined,
+      restartHost: async () => ({ kind: "restarted" as const }),
       getHostLogs: async () => ({ path: null, tail: "" }),
       runDoctor: async () => ({ issues: [], ranAt: "" }),
       availableVersions: async () => {

--- a/clients/desktop/src/renderer-shell/desktop-runner-host.ts
+++ b/clients/desktop/src/renderer-shell/desktop-runner-host.ts
@@ -17,6 +17,7 @@ import type {
   HostRemovalState,
   HostTrayCommand,
   HostUninstallResult,
+  HostRestartRequestResult,
   InstallVersionOk,
   MutationOutcome,
   ServiceRegistrationOk,
@@ -153,7 +154,7 @@ export interface DesktopPreloadBridge {
     dispose: () => void;
   };
   onSystemResumed(handler: () => void): { dispose: () => void };
-  requestHostRespawn(): Promise<void>;
+  requestHostRespawn(): Promise<HostRestartRequestResult>;
   trayState: {
     setEpics(epics: readonly TrayEpic[]): Promise<void>;
     setIndicator(state: TrayIndicatorState): Promise<void>;
@@ -222,7 +223,7 @@ export interface DesktopHostManagementBridge {
   uninstallTraycer(): Promise<TraycerUninstallResult>;
   getRemovalState(): Promise<HostRemovalState>;
   clearRemoval(): Promise<void>;
-  restartHost(): Promise<void>;
+  restartHost(): Promise<HostRestartRequestResult>;
   getHostLogs(input: {
     readonly tailLines: number;
   }): Promise<HostLogsTailResult>;
@@ -748,7 +749,7 @@ export class DesktopRunnerHost implements IRunnerHost {
     return toDisposable(this.bridge.onSystemResumed(handler));
   }
 
-  requestHostRespawn(): Promise<void> {
+  requestHostRespawn(): Promise<HostRestartRequestResult> {
     return this.bridge.requestHostRespawn();
   }
 

--- a/clients/gui-app/src/components/__tests__/host-update-cross-surface.test.tsx
+++ b/clients/gui-app/src/components/__tests__/host-update-cross-surface.test.tsx
@@ -84,7 +84,7 @@ function makeManagement(overrides: {
     activateInstalled: vi.fn(notImplemented("activateInstalled")),
     installVersion: vi.fn(notImplemented("installVersion")),
     uninstallHost: vi.fn(notImplemented("uninstallHost")),
-    restartHost: vi.fn(() => Promise.resolve()),
+    restartHost: vi.fn(() => Promise.resolve({ kind: "restarted" as const })),
     uninstallTraycer: vi.fn(notImplemented("uninstallTraycer")),
     getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: false })),
     clearRemoval: vi.fn(() => Promise.resolve()),

--- a/clients/gui-app/src/components/home/__tests__/host-update-banner.test.tsx
+++ b/clients/gui-app/src/components/home/__tests__/host-update-banner.test.tsx
@@ -77,7 +77,7 @@ function makeManagement(overrides: Overrides): IHostManagement {
     ),
     installVersion: vi.fn(notImplemented("installVersion")),
     uninstallHost: vi.fn(notImplemented("uninstallHost")),
-    restartHost: vi.fn(() => Promise.resolve()),
+    restartHost: vi.fn(() => Promise.resolve({ kind: "restarted" as const })),
     uninstallTraycer: vi.fn(notImplemented("uninstallTraycer")),
     getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: false })),
     clearRemoval: vi.fn(() => Promise.resolve()),

--- a/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/desktop-dialog-host.test.tsx
@@ -261,7 +261,7 @@ function createBaseRunnerHost(): IRunnerHost {
     },
     onLocalHostChange: () => ({ dispose: () => undefined }),
     onSystemResumed: () => ({ dispose: () => undefined }),
-    requestHostRespawn: () => Promise.resolve(),
+    requestHostRespawn: () => Promise.resolve({ kind: "restarted" as const }),
     service: null,
     traycerCli: null,
     migration: null,

--- a/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/host-tray-command-listener.mounted.test.tsx
@@ -137,7 +137,7 @@ function makeManagement(overrides: ManagementOverrides): IHostManagement {
         deregisteredService: true,
       }),
     ),
-    restartHost: vi.fn(() => Promise.resolve()),
+    restartHost: vi.fn(() => Promise.resolve({ kind: "restarted" as const })),
     uninstallTraycer: vi.fn(() =>
       Promise.resolve({
         removedHost: true,
@@ -251,7 +251,7 @@ function makeHost(tray: IHostTray, management: IHostManagement): IRunnerHost {
     },
     onLocalHostChange: () => ({ dispose: () => undefined }),
     onSystemResumed: () => ({ dispose: () => undefined }),
-    requestHostRespawn: () => Promise.resolve(),
+    requestHostRespawn: () => Promise.resolve({ kind: "restarted" as const }),
     service: null,
     traycerCli: null,
     migration: null,

--- a/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/menu-command-listener.test.tsx
@@ -205,7 +205,9 @@ function createRunnerHost(menu: FakeDesktopMenu): FakeRunnerHost {
       },
       onLocalHostChange: () => ({ dispose: () => undefined }),
       onSystemResumed: () => ({ dispose: () => undefined }),
-      requestHostRespawn: vi.fn(() => Promise.resolve()),
+      requestHostRespawn: vi.fn(() =>
+        Promise.resolve({ kind: "restarted" as const }),
+      ),
       service: null,
       traycerCli: null,
       migration: null,
@@ -599,7 +601,7 @@ describe("<MenuCommandListener />", () => {
       ),
       installVersion: vi.fn(() => Promise.reject(new Error("not used"))),
       uninstallHost: vi.fn(() => Promise.reject(new Error("not used"))),
-      restartHost: vi.fn(() => Promise.resolve()),
+      restartHost: vi.fn(() => Promise.resolve({ kind: "restarted" as const })),
       uninstallTraycer: vi.fn(() => Promise.reject(new Error("not used"))),
       getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: false })),
       clearRemoval: vi.fn(() => Promise.resolve()),
@@ -779,7 +781,9 @@ describe("<MenuCommandListener />", () => {
 
   it("opens a confirmation dialog for host.restart and only respawns after confirm", async () => {
     const menu = createMenu();
-    const requestHostRespawn = vi.fn(() => Promise.resolve());
+    const requestHostRespawn = vi.fn(() =>
+      Promise.resolve({ kind: "restarted" as const }),
+    );
     const runnerHost = Object.assign(createRunnerHost(menu), {
       requestHostRespawn,
     });

--- a/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/host-tray-command-listener.tsx
@@ -6,6 +6,7 @@ import type {
   ActivateInstalledOk,
   ApplyStagedOk,
   BusyContinuation,
+  HostRestartRequestResult,
   HostTrayCommand,
   MutationOutcome,
 } from "@traycer-clients/shared/platform/runner-host";
@@ -13,6 +14,7 @@ import { useRunnerHost } from "@/providers/use-runner-host";
 import { useDesktopDialogStore } from "@/stores/dialogs/desktop-dialog-store";
 import { runnerMutationKeys, runnerQueryKeys } from "@/lib/query-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import { toastHostRestartDeclined } from "@/lib/host-restart-toast";
 import { ConfirmDestructiveDialog } from "@/components/ui/confirm-destructive-dialog";
 import { resolveSettingsTabIntent } from "@/lib/commands/actions/open-system-tab";
 import { activateTabIntent } from "@/lib/tab-navigation";
@@ -153,7 +155,7 @@ export function HostTrayCommandListener() {
     );
   };
 
-  const restartMutation = useMutation<void>({
+  const restartMutation = useMutation<HostRestartRequestResult>({
     mutationKey: runnerMutationKeys.hostRestart(),
     mutationFn: () => {
       if (management === null) {
@@ -161,9 +163,16 @@ export function HostTrayCommandListener() {
       }
       return management.restartHost();
     },
-    onSuccess: () => {
-      toast.success("Host restart requested");
+    onSuccess: (result) => {
       setPendingRestart(false);
+      // `declined` resolves (rather than rejecting) because it is not an
+      // error - the host deliberately was not restarted and a later retry
+      // succeeds on its own; see `toastHostRestartDeclined`.
+      if (result.kind === "declined") {
+        toastHostRestartDeclined(result.message);
+        return;
+      }
+      toast.success("Host restart requested");
       if (management !== null) {
         void queryClient.invalidateQueries({
           queryKey: runnerQueryKeys.hostInstalledRecord(management),

--- a/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
+++ b/clients/gui-app/src/components/layout/bridges/menu-command-listener.tsx
@@ -6,6 +6,7 @@ import type {
   ActivateInstalledOk,
   ApplyStagedOk,
   BusyContinuation,
+  HostRestartRequestResult,
   IRunnerHost,
   MutationOutcome,
 } from "@traycer-clients/shared/platform/runner-host";
@@ -17,6 +18,7 @@ import {
   runnerQueryKeys,
 } from "@/lib/query-keys/runner-mutation-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import { toastHostRestartDeclined } from "@/lib/host-restart-toast";
 import { resolveDesktopMenuBridge } from "@/lib/windows/desktop-capabilities";
 import type {
   DesktopMenuCommandId,
@@ -104,12 +106,19 @@ export function MenuCommandListener() {
   const [pendingHostRestart, setPendingHostRestart] = useState<boolean>(false);
   const [busy, setBusy] = useState<MenuBusyState | null>(null);
 
-  const restartHostMutation = useMutation<void>({
+  const restartHostMutation = useMutation<HostRestartRequestResult>({
     mutationKey: runnerMutationKeys.requestHostRespawn(),
     mutationFn: () => runnerHost.requestHostRespawn(),
-    onSuccess: () => {
-      toast.success("Host restart requested");
+    onSuccess: (result) => {
       setPendingHostRestart(false);
+      // `declined` resolves (rather than rejecting) because it is not an
+      // error - the host deliberately was not restarted and a later retry
+      // succeeds on its own; see `toastHostRestartDeclined`.
+      if (result.kind === "declined") {
+        toastHostRestartDeclined(result.message);
+        return;
+      }
+      toast.success("Host restart requested");
       if (traycerCli !== null) {
         void queryClient.invalidateQueries({
           queryKey: runnerQueryKeys.traycerHostStatus(traycerCli),

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-doctor-card.test.tsx
@@ -13,6 +13,7 @@ import { RunnerHostProvider } from "@/providers/runner-host-provider";
 import type {
   HostDoctorIssue,
   HostDoctorReport,
+  HostRestartRequestResult,
   FreePortAndRestartInput,
   IHostManagement,
   IRunnerHost,
@@ -29,7 +30,7 @@ vi.mock("sonner", () => ({
 
 interface ManagementOverrides {
   readonly runDoctor?: () => Promise<HostDoctorReport>;
-  readonly restartHost?: () => Promise<void>;
+  readonly restartHost?: () => Promise<HostRestartRequestResult>;
   readonly freePortAndRestart?: (
     input: FreePortAndRestartInput,
   ) => Promise<FreePortAndRestartInput>;
@@ -45,7 +46,9 @@ function makeManagement(overrides: ManagementOverrides): IHostManagement {
     activateInstalled: vi.fn(notImplemented("activateInstalled")),
     installVersion: vi.fn(notImplemented("installVersion")),
     uninstallHost: vi.fn(notImplemented("uninstallHost")),
-    restartHost: overrides.restartHost ?? vi.fn(() => Promise.resolve()),
+    restartHost:
+      overrides.restartHost ??
+      vi.fn(() => Promise.resolve({ kind: "restarted" as const })),
     uninstallTraycer: vi.fn(notImplemented("uninstallTraycer")),
     getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: false })),
     clearRemoval: vi.fn(() => Promise.resolve()),
@@ -267,7 +270,9 @@ describe("HostDoctorCard pending CLI upgrade", () => {
     const freePortAndRestart = vi.fn((input: FreePortAndRestartInput) =>
       Promise.resolve(input),
     );
-    const restartHost = vi.fn(() => Promise.resolve());
+    const restartHost = vi.fn(() =>
+      Promise.resolve({ kind: "restarted" as const }),
+    );
     // A defective Doctor record that *claims* it can free a port but
     // has no port/PID. The card must NOT pop the kill dialog.
     const issue: HostDoctorIssue = {
@@ -340,7 +345,9 @@ describe("HostDoctorCard pending CLI upgrade", () => {
   });
 
   it("calls management.restartHost() when the fix button is clicked", async () => {
-    const restartHost = vi.fn(() => Promise.resolve());
+    const restartHost = vi.fn(() =>
+      Promise.resolve({ kind: "restarted" as const }),
+    );
     const management = makeManagement({
       runDoctor: () =>
         Promise.resolve<HostDoctorReport>({

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-mutations.test.tsx
@@ -6,6 +6,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
@@ -33,6 +34,7 @@ vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
     error: vi.fn(),
+    info: vi.fn(),
     message: vi.fn(),
   },
 }));
@@ -41,12 +43,15 @@ afterEach(() => {
   cleanup();
   vi.mocked(toast.success).mockClear();
   vi.mocked(toast.error).mockClear();
+  vi.mocked(toast.info).mockClear();
   vi.mocked(toast.message).mockClear();
 });
 
 describe("<HostSettingsPanel /> - mutation flows", () => {
   it("opens a confirmation dialog before restarting the host", async () => {
-    const restartHost = vi.fn(() => Promise.resolve());
+    const restartHost = vi.fn(() =>
+      Promise.resolve({ kind: "restarted" as const }),
+    );
     const { management } = makeManagement({ restartHost });
 
     renderPanel(makeHost(management, makeLocalHostSnapshot()));
@@ -64,6 +69,37 @@ describe("<HostSettingsPanel /> - mutation flows", () => {
       expect(restartHost).toHaveBeenCalledTimes(1);
     });
     expect(toast.success).toHaveBeenCalledWith("Host restart requested");
+  });
+
+  // Field RCA 2026-07-28: a busy host denying the restart surfaced as a
+  // reportable "Couldn't restart host" error toast, inviting "Report
+  // issue" for a self-recovering condition. A declined result must render
+  // as plain information - never as a success and never as an error.
+  it("renders a declined restart as an informational toast, not success or a reportable error", async () => {
+    const restartHost = vi.fn(() =>
+      Promise.resolve({
+        kind: "declined" as const,
+        message: "The host has work in progress, so it was not restarted.",
+      }),
+    );
+    const { management } = makeManagement({ restartHost });
+
+    renderPanel(makeHost(management, makeLocalHostSnapshot()));
+
+    fireEvent.click(await waitForButton("Restart"));
+    fireEvent.click(
+      within(
+        await screen.findByTestId("confirm-destructive-dialog"),
+      ).getByTestId("confirm-action"),
+    );
+
+    await waitFor(() => {
+      expect(toast.info).toHaveBeenCalledWith("Host not restarted", {
+        description: "The host has work in progress, so it was not restarted.",
+      });
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("saves a custom host name from the Host settings page", async () => {
@@ -748,7 +784,9 @@ function makeManagement(
       overrides.installVersion ?? vi.fn(notImplemented("installVersion")),
     uninstallHost:
       overrides.uninstallHost ?? vi.fn(notImplemented("uninstallHost")),
-    restartHost: overrides.restartHost ?? vi.fn(() => Promise.resolve()),
+    restartHost:
+      overrides.restartHost ??
+      vi.fn(() => Promise.resolve({ kind: "restarted" as const })),
     uninstallTraycer: vi.fn(notImplemented("uninstallTraycer")),
     getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: false })),
     clearRemoval: vi.fn(() => Promise.resolve()),

--- a/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-pkg-hint.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/host-settings-panel-pkg-hint.test.tsx
@@ -55,7 +55,7 @@ function makeManagement(
     activateInstalled: vi.fn(notImplemented("activateInstalled")),
     installVersion: vi.fn(notImplemented("installVersion")),
     uninstallHost: vi.fn(notImplemented("uninstallHost")),
-    restartHost: vi.fn(() => Promise.resolve()),
+    restartHost: vi.fn(() => Promise.resolve({ kind: "restarted" as const })),
     uninstallTraycer: vi.fn(notImplemented("uninstallTraycer")),
     getRemovalState: vi.fn(() => Promise.resolve({ removedByUser: false })),
     clearRemoval: vi.fn(() => Promise.resolve()),

--- a/clients/gui-app/src/components/settings/panels/host-doctor-actions.ts
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-actions.ts
@@ -52,10 +52,19 @@ export function fixActionLabel(fixAction: string): string {
   }
 }
 
+// `declined` mirrors `HostRestartRequestResult`: the restart fix resolved
+// without restarting because the host deliberately refused (busy with
+// in-progress work, removed-by-user, lock contention). The card must not
+// announce "Fix applied" for it - and must not route it through the
+// reportable error toast either, since the condition clears on its own.
+export type FixActionResult =
+  | { readonly kind: "applied" }
+  | { readonly kind: "declined"; readonly message: string };
+
 export async function runFixAction(
   management: IHostManagement,
   issue: HostDoctorIssue,
-): Promise<void> {
+): Promise<FixActionResult> {
   switch (issue.fixAction) {
     case "host-install-latest": {
       // No "install latest" intent survives the two-lane cutover - the
@@ -66,29 +75,33 @@ export async function runFixAction(
       if (outcome.kind !== "ok") {
         throw new Error(outcome.message);
       }
-      return;
+      return { kind: "applied" };
     }
     case "service-install": {
       const outcome = await management.registerService();
       if (outcome.kind !== "ok") {
         throw new Error(outcome.message);
       }
-      return;
+      return { kind: "applied" };
     }
     case "host-start":
-    case "host-restart":
-      await management.restartHost();
-      return;
+    case "host-restart": {
+      const result = await management.restartHost();
+      if (result.kind === "declined") {
+        return { kind: "declined", message: result.message };
+      }
+      return { kind: "applied" };
+    }
     case "host-logs":
       await management.getHostLogs({ tailLines: 200 });
-      return;
+      return { kind: "applied" };
     case "host-free-port-and-restart": {
       const input = parseFreePortInput(issue);
       if (input === null) {
         throw new Error("Doctor issue is missing a valid conflicting port.");
       }
       await management.freePortAndRestart(input);
-      return;
+      return { kind: "applied" };
     }
     default:
       throw new Error(`Unknown fix action: ${issue.fixAction}`);

--- a/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-doctor-card.tsx
@@ -11,6 +11,7 @@ import {
 import {
   parseFreePortInput,
   runFixAction,
+  type FixActionResult,
 } from "@/components/settings/panels/host-doctor-actions";
 import {
   queryOptions,
@@ -25,6 +26,7 @@ import {
   runnerQueryKeys,
 } from "@/lib/query-keys/runner-mutation-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import { toastHostRestartDeclined } from "@/lib/host-restart-toast";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import type {
   HostDoctorIssue,
@@ -87,7 +89,7 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
   );
 
   const fixMutation = useMutation<
-    void,
+    FixActionResult,
     Error,
     HostDoctorIssue,
     { readonly management: IHostManagement }
@@ -95,10 +97,17 @@ function HostDoctorCardInner(props: HostDoctorCardInnerProps) {
     mutationKey: runnerMutationKeys.hostRunDoctor(),
     onMutate: () => ({ management }),
     mutationFn: async (issue) => {
-      if (issue.fixAction === null) return;
-      await runFixAction(management, issue);
+      if (issue.fixAction === null) return { kind: "applied" };
+      return runFixAction(management, issue);
     },
-    onSuccess: (_data, _issue, context) => {
+    onSuccess: (result, _issue, context) => {
+      // A declined restart fix is neither applied nor failed: the host
+      // refused for a self-clearing reason (busy work, lock contention).
+      // Announce it as information and leave the recurrence model alone.
+      if (result.kind === "declined") {
+        toastHostRestartDeclined(result.message);
+        return;
+      }
       toast.success("Fix applied");
       recurrenceModel.setRecurrence({ failures: [], locked: false });
       void queryClient.invalidateQueries({

--- a/clients/gui-app/src/components/settings/panels/host-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/host-settings-panel.tsx
@@ -32,6 +32,7 @@ import {
   runnerQueryKeys,
 } from "@/lib/query-keys/runner-mutation-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import { toastHostRestartDeclined } from "@/lib/host-restart-toast";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { useRunnerHostControllerStatusQuery } from "@/hooks/runner/use-runner-host-controller-status-query";
 import { useRunnerConvergeReady } from "@/hooks/runner/use-runner-converge-ready-mutation";
@@ -320,8 +321,15 @@ function HostSettingsPanelInner(props: HostSettingsPanelInnerProps) {
   const restartMutation = useMutation({
     mutationKey: runnerMutationKeys.hostRestart(),
     mutationFn: () => management.restartHost(),
-    onSuccess: () => {
+    onSuccess: (result) => {
       setRestartConfirmOpen(false);
+      // `declined` resolves (rather than rejecting) because it is not an
+      // error - the host deliberately was not restarted and a later retry
+      // succeeds on its own; see `toastHostRestartDeclined`.
+      if (result.kind === "declined") {
+        toastHostRestartDeclined(result.message);
+        return;
+      }
       toast.success("Host restart requested");
       void queryClient.invalidateQueries({
         queryKey: runnerQueryKeys.hostInstalledRecord(management),

--- a/clients/gui-app/src/hooks/runner/use-runner-request-host-respawn-mutation.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-request-host-respawn-mutation.ts
@@ -3,9 +3,11 @@ import {
   useQueryClient,
   type UseMutationResult,
 } from "@tanstack/react-query";
+import type { HostRestartRequestResult } from "@traycer-clients/shared/platform/runner-host";
 import { useRunnerHost } from "@/providers/use-runner-host";
 import { runnerMutationKeys, runnerQueryKeys } from "@/lib/query-keys";
 import { toastFromRunnerError } from "@/lib/runner-error-toast";
+import { toastHostRestartDeclined } from "@/lib/host-restart-toast";
 
 // Surfaces respawn failures via toast.
 //
@@ -27,17 +29,25 @@ import { toastFromRunnerError } from "@/lib/runner-error-toast";
 // gate UI - toasts here only fire on hard failures the stream can't
 // represent.
 export function useRunnerRequestHostRespawn(): UseMutationResult<
-  void,
+  HostRestartRequestResult,
   Error,
   void
 > {
   const runnerHost = useRunnerHost();
   const queryClient = useQueryClient();
   const traycerCli = runnerHost.traycerCli;
-  return useMutation<void>({
+  return useMutation<HostRestartRequestResult>({
     mutationKey: runnerMutationKeys.requestHostRespawn(),
     mutationFn: () => runnerHost.requestHostRespawn(),
-    onSuccess: () => {
+    onSuccess: (result) => {
+      // A `declined` result resolves (rather than rejecting) because it is
+      // not an error: the host deliberately was not restarted - busy work,
+      // removed-by-user, lock contention - and a later retry succeeds on
+      // its own; see `toastHostRestartDeclined`.
+      if (result.kind === "declined") {
+        toastHostRestartDeclined(result.message);
+        return;
+      }
       if (traycerCli === null) return;
       void queryClient.invalidateQueries({
         queryKey: runnerQueryKeys.traycerHostStatus(traycerCli),

--- a/clients/gui-app/src/lib/host-restart-toast.ts
+++ b/clients/gui-app/src/lib/host-restart-toast.ts
@@ -1,0 +1,13 @@
+import { toast } from "sonner";
+
+// A `declined` restart result is not an error: the host deliberately was
+// not restarted - it denied the shutdown claim to protect in-progress
+// work, was removed by the user, or another Traycer process holds the
+// management lock - and the condition clears on its own or on a later
+// retry. Routing it through `toastFromRunnerError` gave it a "Report
+// issue" affordance, inviting issue reports for a self-recovering state
+// (field RCA 2026-07-28), so every restart surface renders it through
+// this plain informational toast instead.
+export function toastHostRestartDeclined(message: string): void {
+  toast.info("Host not restarted", { description: message });
+}

--- a/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/windows-bridge-provider.test.tsx
@@ -208,7 +208,7 @@ function createBaseRunnerHost(): IRunnerHost {
       return { dispose: () => undefined };
     },
     onSystemResumed: () => ({ dispose: () => undefined }),
-    requestHostRespawn: () => Promise.resolve(),
+    requestHostRespawn: () => Promise.resolve({ kind: "restarted" as const }),
     service: null,
     traycerCli: null,
     migration: null,

--- a/clients/shared/host-client/__tests__/runner-host.test.ts
+++ b/clients/shared/host-client/__tests__/runner-host.test.ts
@@ -308,7 +308,9 @@ describe("MockRunnerHost - IRunnerHost contract", () => {
 
     expect(host.requestHostRespawnCalls).toBe(0);
 
-    await expect(host.requestHostRespawn()).resolves.toBeUndefined();
+    await expect(host.requestHostRespawn()).resolves.toEqual({
+      kind: "restarted",
+    });
     expect(host.requestHostRespawnCalls).toBe(1);
 
     await host.requestHostRespawn();

--- a/clients/shared/host-client/mock/mock-runner-host.ts
+++ b/clients/shared/host-client/mock/mock-runner-host.ts
@@ -4,6 +4,7 @@ import type {
   DeviceFlowAuthorization,
   DeviceFlowResult,
   DeviceFlowSession,
+  HostRestartRequestResult,
   IDeviceFlowHost,
   IHostPicker,
   IHostManagement,
@@ -363,8 +364,9 @@ export class MockRunnerHost implements IRunnerHost {
     });
   }
 
-  async requestHostRespawn(): Promise<void> {
+  async requestHostRespawn(): Promise<HostRestartRequestResult> {
     this.requestHostRespawnCalls += 1;
+    return { kind: "restarted" };
   }
 
   readonly notifications: INotificationHost = {

--- a/clients/shared/platform/runner-host.ts
+++ b/clients/shared/platform/runner-host.ts
@@ -205,10 +205,14 @@ export interface IRunnerHost {
    * Asks the shell to re-spawn its detached local host. Desktop delegates
    * to `HostLifecycle.respawn()` via the preload IPC bridge; mobile shells
    * (and any shell without a local host) implement this as a resolved
-   * no-op. `gui-app` drives this from the host-Retry UX so the renderer
-   * never touches the lifecycle process directly.
+   * `restarted` no-op. `gui-app` drives this from the host-Retry UX so the
+   * renderer never touches the lifecycle process directly. Resolves
+   * `declined` when the host was deliberately not restarted (busy with
+   * in-progress work, removed by the user, lock contention) - callers
+   * present that as information, not as an error; the promise rejects only
+   * on genuine failures.
    */
-  requestHostRespawn(): Promise<void>;
+  requestHostRespawn(): Promise<HostRestartRequestResult>;
 
   /**
    * OS-service control surface used by the Service Health settings pane.
@@ -1042,6 +1046,20 @@ export interface HostControllerStatus {
 // of the consumed apply/pin.
 export type BusyContinuation = "retry-with-force" | "activate";
 
+// Result of an explicit restart request (`requestHostRespawn` /
+// `IHostManagement.restartHost`). `declined` is a resolved value, not an
+// error: the host was deliberately NOT restarted - it denied the shutdown
+// claim to protect in-progress work, was removed by the user, or another
+// Traycer process holds the management lock - and the condition clears on
+// its own or on a later retry. Surfaces render `declined` as plain
+// information; only a rejected promise means something actually broke and
+// deserves an error affordance (field RCA 2026-07-28: a busy denial inside
+// the SMAppService-register fallback surfaced as a reportable error toast,
+// inviting issue reports for a self-recovering condition).
+export type HostRestartRequestResult =
+  | { readonly kind: "restarted" }
+  | { readonly kind: "declined"; readonly message: string };
+
 // Per-intent result. Every mutation intent resolves ONE of these - the
 // lane itself never rejects ("wait-never-reject"); a busy/deferred/failed
 // outcome is a normal resolved value the calling surface renders.
@@ -1210,7 +1228,10 @@ export interface IHostManagement {
   // Clears the removal sentinel so a subsequent `ensureHost` reinstalls the
   // host (the Reinstall escape hatch on the removed surface).
   readonly clearRemoval: () => Promise<void>;
-  readonly restartHost: () => Promise<void>;
+  // Explicit "restart the host now" (Settings / tray). Same contract as
+  // `IRunnerHost.requestHostRespawn`: resolves `declined` when the host
+  // was deliberately not restarted; rejects only on genuine failures.
+  readonly restartHost: () => Promise<HostRestartRequestResult>;
   readonly getHostLogs: (input: {
     readonly tailLines: number;
   }) => Promise<HostLogsTailResult>;


### PR DESCRIPTION
## Problem

Field occurrence 2026-07-28, on a build carrying the #759 SMAppService-recovery fallback: clicking **Restart host** while the register cycle was in the `not-found` fallback path produced this reportable error toast:

> **Couldn't restart host**
> Error invoking remote method 'runnerHost:host:requestRespawn': Error: Failed to register the host login item (status=not-found), and the fallback service registration failed: service install --takeover: the running host has work in progress and denied the shutdown claim; retry once the work completes. Run 'traycer host service uninstall' and relaunch Traycer, or run 'traycer host doctor' to recover.

Everything in that moment was working as designed: the takeover asked the live host to shut down cooperatively, the host had in-progress agent work and denied the claim, and the takeover aborted rather than trample the work. The retry **14 seconds later succeeded** (`CLI-owned LaunchAgent fallback recovered the host`). Yet the UI presented a compound failure with a **Report issue** button and recovery instructions for a different problem — users will file issue reports for a condition that recovers on its own.

## Fix

Classify the busy denial as *information*, end to end:

- **`HostController`**: the takeover fallback's `E_HOST_BUSY` now resolves a `deferred` outcome with user-facing retry copy ("The host has work in progress, so it was not restarted. Try again once the work completes."), instead of collapsing into the three-part `failed` message. The SMAppService session is still quarantined; every other takeover failure keeps the full diagnostic message and escape hatch.
- **IPC restart surfaces** (`requestHostRespawn`, `traycerHostRestart`): both now resolve `HostRestartRequestResult` — `{kind:"restarted"} | {kind:"declined", message}` — mapping `busy`/`deferred` outcomes to `declined`. Only genuine failures reject, so the existing catch-based reportable-error path is preserved for them. (`declined` also covers removed-by-user and CLI-lock contention — equally self-clearing, equally non-reportable.)
- **Renderer** (settings panel, tray listener, menu listener, respawn hook, doctor fix action): `declined` renders as one shared informational toast — "Host not restarted" + the message — with no report affordance. The doctor card no longer announces "Fix applied" for a restart the host declined, and leaves its failure-recurrence model untouched.

The health monitor's `respawnIfDown` already maps `deferred` → `HostRecoveryDeferredError` (re-arm and retry later), which is exactly right for a busy denial, so automatic recovery needed no changes.

## Verification

- `bun run compile` green across all 5 projects; `react-doctor` (changed scope) clean.
- Affected suites: desktop 239 passed (runner-ipc, host-controller, desktop-runner-host, preload-bridge), shared 15 passed, gui-app 129 passed across 12 files.
- New pins:
  - controller: busy-denied takeover → `deferred` with retry copy (not `failed`, no `service uninstall` instructions), session still quarantined. **Mutation-probed**: breaking the `E_HOST_BUSY` code match makes this test fail; restored and re-verified green.
  - IPC: `deferred` and `busy` outcomes **resolve** `declined` (parameterized); `failed` still rejects (existing pin kept).
  - renderer: declined restart renders `toast.info("Host not restarted", …)` and neither the success nor the error toast.
