### PR TITLE
fix(cli): stop the host LaunchAgent showing as 'sh' in macOS Login Items

### DIFF
--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -160,6 +160,23 @@ describe("macOS service lifecycle", () => {
     expect(plist).not.toContain("HardResourceLimits");
   });
 
+  // Without this key, background-task management names the login item
+  // after ProgramArguments[0] - literally "sh" from an "Unknown
+  // Developer" - on every CLI-registered install (dev machines and the
+  // desktop's takeover fallback alike). The association groups it under
+  // the Traycer app in System Settings → Login Items.
+  it("associates the LaunchAgent with the Traycer desktop app so Login Items does not show it as 'sh'", () => {
+    const plist = buildLaunchAgentPlist({
+      label,
+      cli: { command: "/usr/local/bin/traycer", args: [] },
+    });
+
+    expect(plist).toContain(`<key>AssociatedBundleIdentifiers</key>
+  <array>
+    <string>ai.traycer.desktop</string>
+  </array>`);
+  });
+
   it("starts both an N-1 CLI without --service-label and a current CLI with it, preserving leading invocation args", async () => {
     const work = mkdtempSync(join(tmpdir(), "traycer-host-start-compat-"));
     const oldCli = join(work, "old-cli.sh");

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -1563,6 +1563,19 @@ const SYSTEM_PATH_FLOOR =
 // internal repository's scripts/desktop-install-cloud.js.
 const HOST_SOFT_FILE_DESCRIPTOR_LIMIT = 8_192;
 
+// `AssociatedBundleIdentifiers` groups this raw LaunchAgent under the
+// Traycer app in System Settings → Login Items (macOS 13+; older releases
+// ignore the key). Without it, background-task management names the item
+// after `ProgramArguments[0]` - literally "sh" from an "Unknown
+// Developer", which reads as malware (field observation 2026-07-28:
+// `sfltool dumpbtm` showed `Name: sh, Parent Identifier: Unknown
+// Developer` for this agent, on every CLI-registered install - dev
+// machines have no in-bundle SMAppService plist, so they ALWAYS take this
+// path, as does the desktop's takeover fallback). The id is the desktop
+// app's `appId` for every deploy target; when the app is not installed
+// the key is inert.
+const DESKTOP_APP_BUNDLE_ID = "ai.traycer.desktop";
+
 /**
  * The PATH to bake into the host's LaunchAgent. launchd would otherwise
  * give the host a bare PATH that can't see provider CLIs installed via
@@ -1605,6 +1618,10 @@ function buildPlist(options: BuildPlistOptions): string {
 <dict>
   <key>Label</key>
   <string>${escapeXml(options.label.id)}</string>
+  <key>AssociatedBundleIdentifiers</key>
+  <array>
+    <string>${DESKTOP_APP_BUNDLE_ID}</string>
+  </array>
   <key>ProgramArguments</key>
   <array>
 ${programArgsXml}


### PR DESCRIPTION
## Problem

The CLI-registered raw LaunchAgent wraps the host launch in `/bin/sh` (the N-1 CLI compatibility probe), so background-task management names the login item after `ProgramArguments[0]`: System Settings → Login Items shows a bare **"sh"** from an **"Unknown Developer"**, which reads as malware.

This is not a corner case. Every CLI-registered install shows it:
- **dev machines** — `make dev-desktop` runs unpackaged, so no in-bundle SMAppService plist exists and registration always takes the CLI path (field report: even local dev shows "sh"),
- the desktop's **SMAppService takeover fallback** (#759),
- pre-label-split upgrade paths.

Field verification 2026-07-28, `sfltool dumpbtm`:

```
Name: sh
Developer Name: (null)
Identifier: 8.ai.traycer.host
Executable Path: /bin/sh
Parent Identifier: Unknown Developer
```

while the desktop's own SMAppService item on the same machine correctly groups:

```
Name: traycer-host-start
Parent Identifier: 2.ai.traycer.desktop
```

## Fix

Add `AssociatedBundleIdentifiers` (macOS 13+; older releases ignore the key) to the generated plist, naming the desktop app id (`ai.traycer.desktop` — the `appId` for every deploy target), so BTM groups the item under Traycer exactly the way the SMAppService agent already groups. When the app is not installed, the key is inert. Existing installs pick the key up the next time the service definition is (re)written (`service install` / `host update`'s re-register).

The `/bin/sh` wrapper itself is untouched — it remains load-bearing for the N-1 CLI `--service-label` capability probe, and `readRegisteredCliInvocation`'s closed two-shape parse contract is unchanged (it only reads `ProgramArguments`).

## Verification

- New pin in `macos.test.ts` asserting the exact key/array in the built plist; full macOS platform suite 78 passed.
- `pre-commit` (build · compile · lint · format, nx affected) green.