### PR TITLE
fix(gui-app): restore rate-limit profile switching

### DIFF
--- a/clients/gui-app/src/components/chat/composer/__tests__/profile-rate-limit-task-wide-switch.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/profile-rate-limit-task-wide-switch.test.tsx
@@ -12,7 +12,10 @@ import type { ProviderProfile } from "@traycer/protocol/host/provider-schemas";
 import type { ProfileDropdownUsageEntry } from "@/components/providers/profile-dropdown-usage";
 import { profileCommitId } from "@/components/providers/provider-profile-model";
 import { ProfileRateLimitSwitchBanner } from "../profile-rate-limit-switch-banner";
-import type { ProfileRateLimitDestination } from "../use-profile-rate-limit-switch-prompt";
+import {
+  initialPreviewProfileId,
+  type ProfileRateLimitDestination,
+} from "../use-profile-rate-limit-switch-prompt";
 import { createComposerToolbarStore } from "@/stores/composer/composer-toolbar-store";
 import { commitProfileSelection } from "@/stores/composer/commit-selection";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -32,7 +35,7 @@ function profile(
   profileId: string,
   kind: "ambient" | "managed",
   label: string,
-  rateLimitStatus: "ok" | "hard_limit",
+  rateLimitStatus: "ok" | "hard_limit" | "unknown",
 ): ProviderProfile {
   return {
     profileId,
@@ -63,6 +66,12 @@ const CURRENT = profile(
 );
 const ALTERNATIVE = profile("fresh-uuid", "managed", "Fresh profile", "ok");
 const SECOND = profile("second-uuid", "managed", "Second profile", "ok");
+const UNKNOWN = profile(
+  "personal-uuid",
+  "managed",
+  "Personal profile",
+  "unknown",
+);
 const AMBIENT = profile("ambient", "ambient", "Terminal account", "ok");
 const BLOCKED = profile(
   "blocked-uuid",
@@ -304,6 +313,34 @@ describe("rate-limit banner task-wide switch", () => {
     expect(onSwitchProfileForTask).not.toHaveBeenCalled();
   });
 
+  it("offers an authenticated unchecked profile and can apply that explicit choice to all affected chats", () => {
+    const onSwitchProfile = vi.fn();
+    const onSwitchProfileForTask = vi.fn();
+    renderBanner({
+      affectedChatCount: 3,
+      destinations: [destination(UNKNOWN, true)],
+      profiles: [CURRENT, UNKNOWN],
+      primaryTarget: null,
+      onSwitchProfile,
+      onSwitchProfileForTask,
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Choose a profile" }),
+    ).toBeDefined();
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Choose a profile" }),
+    );
+    const personal = screen.getByRole("menuitem", {
+      name: /Personal profile, Not checked, Available to switch/,
+    });
+    fireEvent.click(personal);
+
+    expect(onSwitchProfile).toHaveBeenCalledWith(UNKNOWN.profileId);
+    expect(onSwitchProfileForTask).toHaveBeenCalledWith(UNKNOWN.profileId);
+  });
+
   it("keeps unavailable rows inspectable and prevents dispatch", () => {
     const onSwitchProfile = vi.fn();
     const unavailable = destination(SECOND, false);
@@ -497,5 +534,60 @@ describe("rate-limit banner task-wide switch", () => {
         name: "Usage details for Fresh profile",
       }),
     ).toBeDefined();
+  });
+});
+
+describe("initialPreviewProfileId (ambient destination handling)", () => {
+  const ambientDestination: ProfileRateLimitDestination = {
+    profile: AMBIENT,
+    profileId: profileCommitId(AMBIENT),
+    selectable: true,
+  };
+  const managedDestination: ProfileRateLimitDestination = {
+    profile: ALTERNATIVE,
+    profileId: profileCommitId(ALTERNATIVE),
+    selectable: true,
+  };
+
+  it("previews the ambient primary target instead of falling through a `??` chain", () => {
+    expect(ambientDestination.profileId).toBeNull();
+    expect(
+      initialPreviewProfileId(ambientDestination, CURRENT, [
+        ambientDestination,
+        managedDestination,
+      ]),
+    ).toBeNull();
+  });
+
+  it("previews the ambient first-selectable destination when there is no primary target", () => {
+    expect(
+      initialPreviewProfileId(null, CURRENT, [
+        ambientDestination,
+        managedDestination,
+      ]),
+    ).toBeNull();
+  });
+
+  it("still falls back to the current profile's commit id when nothing is selectable", () => {
+    const readOnlyDestination: ProfileRateLimitDestination = {
+      profile: BLOCKED,
+      profileId: profileCommitId(BLOCKED),
+      selectable: false,
+    };
+    expect(
+      initialPreviewProfileId(null, AMBIENT, [readOnlyDestination]),
+    ).toBeNull();
+    expect(initialPreviewProfileId(null, CURRENT, [readOnlyDestination])).toBe(
+      CURRENT.profileId,
+    );
+  });
+
+  it("previews a non-ambient primary target normally", () => {
+    expect(
+      initialPreviewProfileId(managedDestination, CURRENT, [
+        managedDestination,
+        ambientDestination,
+      ]),
+    ).toBe(ALTERNATIVE.profileId);
   });
 });

--- a/clients/gui-app/src/components/chat/composer/__tests__/use-profile-rate-limit-switch-prompt.test.tsx
+++ b/clients/gui-app/src/components/chat/composer/__tests__/use-profile-rate-limit-switch-prompt.test.tsx
@@ -289,17 +289,18 @@ describe("useProfileRateLimitSwitchPrompt", () => {
     expect(
       result.current.destinations.map((entry) => entry.profile.label),
     ).toEqual(["Blocked", "Unknown", "Healthy", "Signed out"]);
-    // Unknown is NOT weakly healthy: absence of gauge evidence never powers
-    // the one-click switch. The proven-ok profile is the first selectable.
+    // Unknown is a deliberate menu option, but absence of gauge evidence
+    // never powers the one-click recommendation. The proven-ok profile is
+    // still the primary target.
     expect(
       result.current.destinations.map((entry) => entry.selectable),
-    ).toEqual([false, false, true, false]);
+    ).toEqual([false, true, true, false]);
     expect(result.current.primaryTarget?.profile.label).toBe("Healthy");
     // A known primary exists, so no automatic check is spent on the unknown.
     expect(result.current.probeTarget).toBeNull();
   });
 
-  it("keeps an unknown destination unselectable and nominates it as the probe target when no known primary exists", () => {
+  it("allows an authenticated unknown destination as an explicit choice without recommending it", () => {
     const current = profile({
       profileId: "ambient",
       kind: "ambient",
@@ -328,9 +329,13 @@ describe("useProfileRateLimitSwitchPrompt", () => {
 
     const { result } = currentPrompt(null);
     const prompt = visiblePrompt(result.current);
-    // Even against a HARD-limited current profile, unknown is incomparable -
-    // never strictly better, never the confident one-click button.
-    expect(prompt.destinations.every((entry) => !entry.selectable)).toBe(true);
+    // Unknown remains incomparable and therefore never becomes the confident
+    // one-click target. It is still available as a deliberate menu choice;
+    // the signed-out unknown profile is not.
+    expect(prompt.destinations.map((entry) => entry.selectable)).toEqual([
+      false,
+      true,
+    ]);
     expect(prompt.primaryTarget).toBeNull();
     // The single automatic check goes to the first AUTHENTICATED unknown.
     expect(prompt.probeTarget?.profile.label).toBe("Unknown");
@@ -519,6 +524,82 @@ describe("useProfileRateLimitSwitchPrompt", () => {
     const resurfaced = visiblePrompt(result.current);
     expect(resurfaced.severity).toBe("near_limit");
     expect(resurfaced.warningKey).not.toBe(firstWarningKey);
+  });
+
+  describe("dismissal re-arming around probe results", () => {
+    const source = profile({
+      profileId: "ambient",
+      kind: "ambient",
+      label: "Company",
+      rateLimitStatus: "near_limit",
+      rateLimitLimitedScopes: null,
+      authenticated: true,
+    });
+    const unknownA = profile({
+      profileId: "unknown-a",
+      kind: "managed",
+      label: "Unknown A",
+      rateLimitStatus: "unknown",
+      rateLimitLimitedScopes: null,
+      authenticated: true,
+    });
+    const unknownB = profile({
+      profileId: "unknown-b",
+      kind: "managed",
+      label: "Unknown B",
+      rateLimitStatus: "unknown",
+      rateLimitLimitedScopes: null,
+      authenticated: true,
+    });
+
+    it("re-arms a dismissed warning once an unknown destination is proven the recommended target", () => {
+      mocks.providers = [claudeState([source, unknownA, unknownB])];
+      const { result, rerender } = currentPrompt(null);
+      expect(result.current.kind).toBe("visible");
+      if (result.current.kind !== "visible") return;
+      expect(result.current.primaryTarget).toBeNull();
+      const dismissedKey = result.current.warningKey;
+      act(() => result.current.dismiss());
+      expect(result.current.kind).toBe("hidden");
+
+      // Probe proves unknown-a strictly better: it flips false -> true on
+      // its own `recommended` flag, so the key changes and the earlier
+      // dismissal doesn't carry over to the resurfaced, more confident
+      // warning.
+      mocks.providers = [
+        claudeState([source, { ...unknownA, rateLimitStatus: "ok" }, unknownB]),
+      ];
+      rerender();
+      const resurfaced = visiblePrompt(result.current);
+      expect(resurfaced.warningKey).not.toBe(dismissedKey);
+      expect(resurfaced.primaryTarget?.profile.label).toBe("Unknown A");
+    });
+
+    it("keeps a dismissed warning hidden once an unknown destination is proven known-limited (no cascade)", () => {
+      mocks.providers = [claudeState([source, unknownA, unknownB])];
+      const { result, rerender } = currentPrompt(null);
+      expect(result.current.kind).toBe("visible");
+      if (result.current.kind !== "visible") return;
+      // Only the first authenticated unknown gets the automatic probe.
+      expect(result.current.probeTarget?.profile.label).toBe("Unknown A");
+      act(() => result.current.dismiss());
+      expect(result.current.kind).toBe("hidden");
+
+      // Probe proves unknown-a known-but-not-better: it drops out of the
+      // selectable set entirely, but it was never `recommended` (false in
+      // both states), so the key stays identical - no fresh warning
+      // episode, and (because the composer keys the banner by this key) no
+      // remount to re-arm a second automatic probe onto unknown-b.
+      mocks.providers = [
+        claudeState([
+          source,
+          { ...unknownA, rateLimitStatus: "hard_limit" },
+          unknownB,
+        ]),
+      ];
+      rerender();
+      expect(result.current.kind).toBe("hidden");
+    });
   });
 
   it("shares dismissal across hook instances for the same warning", () => {

--- a/clients/gui-app/src/components/chat/composer/chat-composer.tsx
+++ b/clients/gui-app/src/components/chat/composer/chat-composer.tsx
@@ -312,7 +312,9 @@ function ChatComposerImpl(props: ChatComposerProps) {
   const taskProfileSwitch = useTaskProfileRateLimitSwitch({
     enabled:
       rateLimitPrompt.kind === "visible" &&
-      rateLimitPrompt.primaryTarget !== null,
+      rateLimitPrompt.destinations.some(
+        (destination) => destination.selectable,
+      ),
     harnessId,
     profileId,
     selectedModel,

--- a/clients/gui-app/src/components/chat/composer/profile-rate-limit-switch-banner.tsx
+++ b/clients/gui-app/src/components/chat/composer/profile-rate-limit-switch-banner.tsx
@@ -40,9 +40,10 @@ import {
 import { TooltipWrapper } from "@/components/ui/tooltip-wrapper";
 import { useProfileUsagePresentation } from "@/hooks/rate-limits/use-profile-usage-presentation";
 import { cn } from "@/lib/utils";
-import type {
-  ProfileRateLimitDestination,
-  ProfileRateLimitSeverity,
+import {
+  initialPreviewProfileId,
+  type ProfileRateLimitDestination,
+  type ProfileRateLimitSeverity,
 } from "./use-profile-rate-limit-switch-prompt";
 
 interface ProfileRateLimitSwitchBannerProps {
@@ -117,7 +118,8 @@ function profileMenuRows(
   destinations: ReadonlyArray<ProfileRateLimitDestination>,
   primaryTarget: ProfileRateLimitDestination | null,
 ): ReadonlyArray<ProfileMenuRow> {
-  if (primaryTarget === null) {
+  const readOnly = !destinations.some((destination) => destination.selectable);
+  if (readOnly) {
     return profiles.map((profile) => ({
       profile,
       destination: null,
@@ -130,17 +132,9 @@ function profileMenuRows(
     destination,
     selectable: destination.selectable,
     isPrimaryTarget:
+      primaryTarget !== null &&
       destination.profile.profileId === primaryTarget.profile.profileId,
   }));
-}
-
-function initialPreviewProfileId(
-  primaryTarget: ProfileRateLimitDestination | null,
-  current: ProviderProfile,
-): string | null {
-  return primaryTarget === null
-    ? profileCommitId(current)
-    : primaryTarget.profileId;
 }
 
 function profileMenuStatus(
@@ -211,9 +205,11 @@ export function ProfileRateLimitSwitchBanner(
 ) {
   const [includeOtherChats, setIncludeOtherChats] = useState(false);
   const checkboxId = useId();
-  const canIncludeOtherChats = props.affectedChatCount > 1;
+  const readOnly = !props.destinations.some(
+    (destination) => destination.selectable,
+  );
+  const canIncludeOtherChats = !readOnly && props.affectedChatCount > 1;
   const effectiveTaskScope = canIncludeOtherChats && includeOtherChats;
-  const readOnly = props.primaryTarget === null;
   const usagePresentation = useProfileUsagePresentation({
     runTargetHostId: props.runTargetHostId,
     providerId: props.providerId,
@@ -329,14 +325,20 @@ export function ProfileRateLimitSwitchBanner(
 function ProfileRateLimitDestinationMenu(
   props: ProfileRateLimitDestinationMenuProps,
 ) {
+  const readOnly = !props.destinations.some(
+    (destination) => destination.selectable,
+  );
   const [menuOpen, setMenuOpen] = useState(false);
   const [previewProfileId, setPreviewProfileId] = useState<string | null>(() =>
-    initialPreviewProfileId(props.primaryTarget, props.current),
+    initialPreviewProfileId(
+      props.primaryTarget,
+      props.current,
+      props.destinations,
+    ),
   );
   const [previewAnchor, setPreviewAnchor] = useState<HTMLElement | null>(null);
   const keyboardPreviewEnabledRef = useRef(false);
   const usagePresentation = props.usagePresentation;
-  const readOnly = props.primaryTarget === null;
   const rows = profileMenuRows(
     props.profiles,
     props.destinations,
@@ -358,7 +360,11 @@ function ProfileRateLimitDestinationMenu(
       return;
     }
     setPreviewProfileId(
-      initialPreviewProfileId(props.primaryTarget, props.current),
+      initialPreviewProfileId(
+        props.primaryTarget,
+        props.current,
+        props.destinations,
+      ),
     );
   };
   const preview = (profile: ProviderProfile, anchor: HTMLElement): void => {
@@ -378,6 +384,7 @@ function ProfileRateLimitDestinationMenu(
       <ProfileRateLimitMenuTrigger
         harnessId={props.harnessId}
         primaryTarget={props.primaryTarget}
+        readOnly={readOnly}
         onSwitchProfile={props.onSwitchProfile}
       />
       <ProfileRateLimitMenuContent
@@ -410,23 +417,26 @@ function ProfileRateLimitDestinationMenu(
 function ProfileRateLimitMenuTrigger({
   harnessId,
   primaryTarget,
+  readOnly,
   onSwitchProfile,
 }: {
   readonly harnessId: GuiHarnessId;
   readonly primaryTarget: ProfileRateLimitDestination | null;
+  readonly readOnly: boolean;
   readonly onSwitchProfile: (profileId: string | null) => void;
 }): ReactNode {
   if (primaryTarget === null) {
+    const label = readOnly ? "View profile limits" : "Choose a profile";
     return (
       <DropdownMenuTrigger asChild>
         <Button
           type="button"
           size="sm"
           variant="outline"
-          aria-label="View profile limits"
+          aria-label={label}
           className="w-full min-w-0 sm:w-auto sm:justify-self-end"
         >
-          <span className="min-w-0 truncate">View profile limits</span>
+          <span className="min-w-0 truncate">{label}</span>
         </Button>
       </DropdownMenuTrigger>
     );

--- a/clients/gui-app/src/components/chat/composer/use-profile-rate-limit-switch-prompt.ts
+++ b/clients/gui-app/src/components/chat/composer/use-profile-rate-limit-switch-prompt.ts
@@ -26,6 +26,9 @@ export interface ProfileRateLimitDestination {
   /** Normalized for composer-selection semantics: `null` is the ambient
    * profile even though its wire id is the literal ambient sentinel. */
   readonly profileId: string | null;
+  /** Whether the user may deliberately choose this destination. An
+   * authenticated profile with unknown usage remains selectable, but is never
+   * promoted to `primaryTarget` until a rate-limit read proves it is better. */
   readonly selectable: boolean;
 }
 
@@ -49,8 +52,9 @@ interface VisibleProfileRateLimitPrompt {
   /** Every other provider profile in the host's stable order. Rows that
    * are unavailable for switching stay here so the menu can explain why. */
   readonly destinations: ReadonlyArray<ProfileRateLimitDestination>;
-  /** First selectable destination in provider order. Usage is never used
-   * to rank this default action. */
+  /** First proven-better destination in provider order. Unknown-usage
+   * profiles may be selectable from the menu, but never become this confident
+   * one-click recommendation. Usage is not used to rank eligible targets. */
   readonly primaryTarget: ProfileRateLimitDestination | null;
   /** Set only when `primaryTarget` is null: the first authenticated
    * destination with UNKNOWN rate-limit state, for the banner's single
@@ -100,15 +104,12 @@ function findLimitedProfile(
 }
 
 /**
- * A destination is worth suggesting only when its rate-limit state is KNOWN
- * and, for the selected model, sits in a strictly better tier than the
- * limited current profile (not limited < near_limit < hard_limit) -
- * same-or-worse is no escape. A destination that is limited only on a family
- * the selected model doesn't use stays selectable. Unknown (never read,
- * stale, or failed-probe gauge) is incomparable, NOT weakly healthy: absence
- * of evidence must never power the confident one-click switch, no matter how
- * limited the current profile is. Unknown candidates are instead surfaced
- * through `probeTarget` for a single automatic freshness check.
+ * A user may deliberately choose an authenticated destination unless it is
+ * known to be no better for the selected model. Unknown (never read, stale,
+ * or failed-probe gauge) is therefore a menu option, but remains incomparable
+ * rather than weakly healthy; `recommendedDestination` separately prevents it
+ * from powering the confident one-click switch. A destination limited only
+ * on a family the selected model does not use stays selectable.
  */
 function selectableDestination(
   profile: ProviderProfile,
@@ -118,6 +119,21 @@ function selectableDestination(
   const assessment = assessProfileRateLimit(profile, selectedModel);
   return (
     profile.auth.status === "authenticated" &&
+    (!assessment.known ||
+      rateLimitSeverityTier(assessment.severity) <
+        rateLimitSeverityTier(currentSeverity))
+  );
+}
+
+/** The stricter confidence gate for the banner's one-click recommendation. */
+function recommendedDestination(
+  destination: ProfileRateLimitDestination,
+  selectedModel: ModelOption | null,
+  currentSeverity: ProfileRateLimitSeverity,
+): boolean {
+  if (!destination.selectable) return false;
+  const assessment = assessProfileRateLimit(destination.profile, selectedModel);
+  return (
     assessment.known &&
     rateLimitSeverityTier(assessment.severity) <
       rateLimitSeverityTier(currentSeverity)
@@ -144,6 +160,28 @@ function findProbeTarget(
         !assessProfileRateLimit(destination.profile, selectedModel).known,
     ) ?? null
   );
+}
+
+/**
+ * The banner's default menu preview target, before any hover/keyboard
+ * preview overrides it. `profileId` is the commit id, which is `null` for
+ * the ambient profile - a plain `??` chain on `.profileId` would treat a
+ * legitimately-ambient primary/first-selectable target as absent and fall
+ * through to the wrong destination. Each candidate is therefore null-checked
+ * on the destination object itself, not its `profileId`.
+ */
+export function initialPreviewProfileId(
+  primaryTarget: ProfileRateLimitDestination | null,
+  current: ProviderProfile,
+  destinations: ReadonlyArray<ProfileRateLimitDestination>,
+): string | null {
+  if (primaryTarget !== null) return primaryTarget.profileId;
+  const firstSelectable = destinations.find(
+    (destination) => destination.selectable,
+  );
+  return firstSelectable !== undefined
+    ? firstSelectable.profileId
+    : profileCommitId(current);
 }
 
 function destinationsForLimitedProfile(
@@ -208,7 +246,13 @@ function warningProjection(input: {
     limited.severity,
   );
   const primaryTarget =
-    destinations.find((destination) => destination.selectable) ?? null;
+    destinations.find((destination) =>
+      recommendedDestination(
+        destination,
+        input.selectedModel,
+        limited.severity,
+      ),
+    ) ?? null;
   const probeTarget =
     primaryTarget === null
       ? findProbeTarget(destinations, input.selectedModel)
@@ -233,9 +277,31 @@ function warningProjection(input: {
         : matchingScopes
             .map((scope) => `${scope.family ?? ""}\u0000${scope.severity}`)
             .toSorted(),
+      // Destination identity: each destination contributes {profileId,
+      // recommended} rather than mere membership in the selectable set. A
+      // probe that proves an unknown destination strictly better flips its
+      // `recommended` flag false -> true, changing the key and re-arming the
+      // dismissal - the banner just gained a confident one-click switch. A
+      // probe that instead proves it known-but-not-better only drops the
+      // destination out of the selectable set; `recommended` was false and
+      // stays false, so the key is unchanged - no fresh warning episode, and
+      // (because the composer keys the banner by this key) no remount to
+      // re-arm the banner's single automatic probe onto the next unknown
+      // profile. A destination that appears or disappears entirely still
+      // changes the array and re-arms, as before.
       destinations
-        .filter((destination) => destination.selectable)
-        .map((destination) => destination.profile.profileId)
+        .map(
+          (destination) =>
+            `${destination.profile.profileId}\u0000${
+              recommendedDestination(
+                destination,
+                input.selectedModel,
+                limited.severity,
+              )
+                ? "1"
+                : "0"
+            }`,
+        )
         .toSorted(),
     ]),
     providerId: input.providerId,

--- a/clients/gui-app/src/components/chat/composer/use-task-profile-rate-limit-switch.ts
+++ b/clients/gui-app/src/components/chat/composer/use-task-profile-rate-limit-switch.ts
@@ -42,10 +42,13 @@ const NO_AFFECTED: ReadonlyArray<AffectedTaskChat> = [];
  * Whether a sibling chat's persisted settings make it eligible for a task-wide
  * switch off the limited profile. Beyond the same harness + limited profile,
  * the sibling must use the SAME model as the composer that owns the banner:
- * the destination was validated as strictly better only for that model
- * (`useProfileRateLimitSwitchPrompt`'s `selectedModel`), so the guarantee
- * transfers only to same-model chats. A differently-modeled sibling could
- * otherwise be moved to a profile that is equal or worse for ITS model.
+ * a proven-better destination is only proven for that model, and an
+ * unknown-usage destination was only ever offered as a deliberate choice to
+ * that model's composer - nothing was validated for it at all
+ * (`useProfileRateLimitSwitchPrompt`'s `selectedModel` scopes both). Either
+ * way the guarantee (or deliberate choice) transfers only to same-model
+ * chats; a differently-modeled sibling could otherwise be moved to a profile
+ * that is equal, worse, or simply unvetted for ITS model.
  * `selectedModelSlug` is `null` when the composer's model is unresolved
  * (catalog still loading); no persisted sibling matches a null slug, so
  * task-wide switching is conservatively withheld until the model resolves.

--- a/clients/gui-app/src/lib/chats/__tests__/chat-turn-completions.test.ts
+++ b/clients/gui-app/src/lib/chats/__tests__/chat-turn-completions.test.ts
@@ -13,7 +13,7 @@ function phase(overrides: Partial<ChatTurnPhase>): ChatTurnPhase {
   return {
     runningTurn: false,
     stopping: false,
-    settled: false,
+    turnEnded: false,
     connectionClosed: false,
     ...overrides,
   };
@@ -21,8 +21,8 @@ function phase(overrides: Partial<ChatTurnPhase>): ChatTurnPhase {
 
 const RUNNING = phase({ runningTurn: true });
 const STOPPING = phase({ stopping: true });
-const SETTLED = phase({ settled: true });
-const CLOSED = phase({ connectionClosed: true, settled: true });
+const TURN_ENDED = phase({ turnEnded: true });
+const CLOSED = phase({ connectionClosed: true, turnEnded: true });
 
 function runSequence(
   seed: ChatTurnPhase,
@@ -37,14 +37,14 @@ function runSequence(
 }
 
 describe("advanceTurnNotify", () => {
-  it("fires once on the running to fully-settled edge", () => {
+  it("fires once when a running turn ends", () => {
     const afterRun = advanceTurnNotify(INITIAL_TURN_NOTIFY_STATE, RUNNING);
     expect(afterRun.completed).toBe(false);
     expect(afterRun.state.armed).toBe(true);
 
-    const afterSettle = advanceTurnNotify(afterRun.state, SETTLED);
-    expect(afterSettle.completed).toBe(true);
-    expect(afterSettle.state).toEqual(INITIAL_TURN_NOTIFY_STATE);
+    const afterEnd = advanceTurnNotify(afterRun.state, TURN_ENDED);
+    expect(afterEnd.completed).toBe(true);
+    expect(afterEnd.state).toEqual(INITIAL_TURN_NOTIFY_STATE);
   });
 
   it("does not fire on a closed socket and drops the latch", () => {
@@ -55,36 +55,33 @@ describe("advanceTurnNotify", () => {
   });
 
   it("does not fire for a user-initiated stop", () => {
-    expect(runSequence(SETTLED, [RUNNING, STOPPING, SETTLED])).toEqual([
+    expect(runSequence(TURN_ENDED, [RUNNING, STOPPING, TURN_ENDED])).toEqual([
       false,
       false,
       false,
     ]);
   });
 
-  it("fires once when a queued run drains across two frames", () => {
-    const runStatusSettledQueueBusy = phase({ settled: false });
+  it("stays armed across an intermediate frame before the turn ends", () => {
+    const runningWithoutActiveTurn = phase({ turnEnded: false });
     expect(
-      runSequence(SETTLED, [RUNNING, runStatusSettledQueueBusy, SETTLED]),
+      runSequence(TURN_ENDED, [RUNNING, runningWithoutActiveTurn, TURN_ENDED]),
     ).toEqual([false, false, true]);
   });
 
   it("counts a turn already running when first observed", () => {
-    expect(runSequence(RUNNING, [SETTLED])).toEqual([true]);
+    expect(runSequence(RUNNING, [TURN_ENDED])).toEqual([true]);
   });
 
   it("does not fire on reconnect until a turn runs again", () => {
-    expect(runSequence(SETTLED, [RUNNING, CLOSED, SETTLED])).toEqual([
+    expect(runSequence(TURN_ENDED, [RUNNING, CLOSED, TURN_ENDED])).toEqual([
       false,
       false,
       false,
     ]);
-    expect(runSequence(SETTLED, [RUNNING, CLOSED, RUNNING, SETTLED])).toEqual([
-      false,
-      false,
-      false,
-      true,
-    ]);
+    expect(
+      runSequence(TURN_ENDED, [RUNNING, CLOSED, RUNNING, TURN_ENDED]),
+    ).toEqual([false, false, false, true]);
   });
 });
 
@@ -110,12 +107,12 @@ describe("toChatTurnPhase", () => {
     ).toEqual({
       runningTurn: true,
       stopping: false,
-      settled: false,
+      turnEnded: false,
       connectionClosed: false,
     });
   });
 
-  it("projects a fully-settled, connected chat", () => {
+  it("projects an ended turn in a connected chat", () => {
     expect(
       toChatTurnPhase({
         runStatus: "idle",
@@ -126,7 +123,56 @@ describe("toChatTurnPhase", () => {
     ).toEqual({
       runningTurn: false,
       stopping: false,
-      settled: true,
+      turnEnded: true,
+      connectionClosed: false,
+    });
+  });
+
+  it("projects an errored turn as complete while its queued messages remain paused", () => {
+    expect(
+      toChatTurnPhase({
+        runStatus: "idle",
+        activeTurn: null,
+        queue: {
+          status: "paused",
+          items: [
+            {
+              queueItemId: "queued-after-error",
+              messageId: "message-2",
+              message: {
+                kind: "user",
+                content: {
+                  type: "doc",
+                  content: [{ type: "paragraph" }],
+                },
+              },
+              sender: { type: "user", userId: "user-1" },
+              settings: {
+                harnessId: "claude",
+                model: "claude-opus",
+                permissionMode: "supervised",
+                reasoningEffort: null,
+                serviceTier: null,
+                agentMode: "regular",
+                profileId: "work",
+              },
+              accountContext: { type: "PERSONAL" },
+              delivery: "next_turn",
+              status: "paused",
+              targetTurnId: null,
+              steerRequest: null,
+              fallbackReason: null,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        },
+        connectionStatus: "open",
+      }),
+    ).toEqual({
+      runningTurn: false,
+      stopping: false,
+      turnEnded: true,
       connectionClosed: false,
     });
   });

--- a/clients/gui-app/src/lib/chats/chat-turn-completions.ts
+++ b/clients/gui-app/src/lib/chats/chat-turn-completions.ts
@@ -1,6 +1,5 @@
 import type { GuiHarnessId } from "@traycer/protocol/host/index";
 import {
-  isChatSessionSettled,
   type ChatSessionState,
   type ChatSessionStoreHandle,
 } from "@/stores/chats/chat-session-store";
@@ -24,7 +23,7 @@ type ChatRunInputs = Pick<
 export interface ChatTurnPhase {
   readonly runningTurn: boolean;
   readonly stopping: boolean;
-  readonly settled: boolean;
+  readonly turnEnded: boolean;
   readonly connectionClosed: boolean;
 }
 
@@ -32,7 +31,11 @@ export function toChatTurnPhase(state: ChatRunInputs): ChatTurnPhase {
   return {
     runningTurn: state.runStatus === "running" && state.activeTurn !== null,
     stopping: state.runStatus === "stopping",
-    settled: isChatSessionSettled(state),
+    // A turn is complete once the host has stopped running it. Do not require
+    // the queue to be empty: an errored turn deliberately parks queued
+    // messages in `paused`, and completion-driven usage/profile refreshes must
+    // still observe the provider failure that caused the pause.
+    turnEnded: state.runStatus === "idle" && state.activeTurn === null,
     connectionClosed: state.connectionStatus === "closed",
   };
 }
@@ -60,7 +63,7 @@ export function advanceTurnNotify(
   }
   const armed = prev.armed || phase.runningTurn;
   const stopRequested = prev.stopRequested || phase.stopping;
-  if (armed && phase.settled) {
+  if (armed && phase.turnEnded) {
     return { state: INITIAL_TURN_NOTIFY_STATE, completed: !stopRequested };
   }
   return { state: { armed, stopRequested }, completed: false };

--- a/clients/gui-app/src/stores/chats/chat-session-store.ts
+++ b/clients/gui-app/src/stores/chats/chat-session-store.ts
@@ -2757,9 +2757,11 @@ function findRestorableSendByMessageId<
 
 /**
  * A chat session is "fully settled" when no turn is running, none is active,
- * and the queue is empty/idle. Single source of truth for the
- * render-send-as-pending check and the turn-completion refresh subscribers
- * (`lib/chats/chat-turn-completions.ts`).
+ * and the queue is empty/idle. Used only by the render-send-as-pending check
+ * below - the turn-completion refresh subscribers
+ * (`lib/chats/chat-turn-completions.ts`) intentionally use their own looser
+ * `turnEnded` (idle + no active turn; the queue may still be paused), so an
+ * errored turn's parked queue still drives a completion refresh.
  */
 export function isChatSessionSettled(
   state: Pick<ChatSessionState, "runStatus" | "activeTurn" | "queue">,


### PR DESCRIPTION
## Summary

- refresh provider profile state when a rate-limited turn ends with its queue paused
- keep unknown authenticated profiles available as explicit choices without recommending them prematurely
- restore task-wide switching, stable dismissal re-arming, and ambient-profile preview behavior
- add regression coverage for paused error queues, unknown-profile selection, warning transitions, and ambient targets

## Validation

- bun run test --run src/lib/chats/__tests__/chat-turn-completions.test.ts src/components/chat/composer/__tests__/use-profile-rate-limit-switch-prompt.test.tsx src/components/chat/composer/__tests__/profile-rate-limit-task-wide-switch.test.tsx (48 tests)
- bun run compile
- bun run lint
- Prettier check on all changed files
- React Doctor on the changed diff
- DCO sign-off present