### PR TITLE
fix(cli): flush stdout before exit so large results are not truncated

### DIFF
--- a/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-available.test.ts
@@ -254,3 +254,100 @@ describe("buildHostAvailableCommand's real data envelope against desktop's parse
     });
   });
 });
+
+// The registry manifest carries an asset per supported platform on every
+// version entry, but nothing downstream of this command can use an asset for
+// a platform it is not running on - both consumers do a single-key lookup and
+// discard the rest. `host available` therefore emits only the running
+// platform's asset, which cut the payload 3.2x (70,331 -> 21,689 bytes across
+// 31 real versions). This payload is ONE unsplittable JSON line, so its width
+// is a standing liability: it is what carried it past the 64 KiB pipe buffer
+// (see runner/std-write.ts).
+//
+// The fixtures above are single-platform, so they cannot observe scoping at
+// all - these use a genuinely multi-platform manifest.
+const OTHER_PLATFORM_ASSET: HostPlatformAsset = {
+  ...AVAILABLE_ASSET,
+  url: "https://github.com/traycerai/traycer/releases/download/host-v1.2.0/traycer-host-linux-x64.tar.gz",
+  sha256: "b".repeat(64),
+  signatureUrl:
+    "https://github.com/traycerai/traycer/releases/download/host-v1.2.0/traycer-host-linux-x64.tar.gz.minisig",
+};
+
+function createMultiPlatformManifest(
+  platforms: Readonly<Record<string, HostPlatformAsset>>,
+): HostVersionsManifest {
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-06-22T01:00:00.000Z",
+    latest: "1.2.0",
+    versions: [
+      {
+        version: "1.2.0",
+        releasedAt: "2026-06-22T00:00:00.000Z",
+        releaseNotesUrl: "https://example.com/1.2.0",
+        yanked: false,
+        deprecationReason: null,
+        requiredCliVersion: null,
+        platforms,
+      },
+    ],
+  };
+}
+
+describe("buildHostAvailableListing platform scoping", () => {
+  it("emits only the running platform's asset and drops every other platform", () => {
+    const listing = buildHostAvailableListing({
+      manifest: createMultiPlatformManifest({
+        "darwin-arm64": AVAILABLE_ASSET,
+        "linux-x64": OTHER_PLATFORM_ASSET,
+        "win32-x64": OTHER_PLATFORM_ASSET,
+      }),
+      manifestUrl: "https://example.com/versions.json",
+      platformKey: "darwin-arm64",
+      includePreReleases: false,
+    });
+
+    const entry = listing.manifest.versions[0];
+    expect(Object.keys(entry.platforms)).toEqual(["darwin-arm64"]);
+    // The surviving asset is the real one, not a stub: a projection that
+    // dropped the wrong key would still satisfy the key-count assertion.
+    expect(entry.platforms["darwin-arm64"]).toEqual(AVAILABLE_ASSET);
+  });
+
+  it("keeps a version with no asset for this platform, with an empty platforms map", () => {
+    const listing = buildHostAvailableListing({
+      manifest: createMultiPlatformManifest({
+        "linux-x64": OTHER_PLATFORM_ASSET,
+      }),
+      manifestUrl: "https://example.com/versions.json",
+      platformKey: "darwin-arm64",
+      includePreReleases: false,
+    });
+
+    // Dropped assets must not drop the VERSION - callers distinguish
+    // "exists but not for you" (rendered, tagged no-asset) from "does not
+    // exist at all".
+    expect(listing.manifest.versions.map((e) => e.version)).toEqual(["1.2.0"]);
+    expect(listing.manifest.versions[0].platforms).toEqual({});
+    expect(listing.human).toContain("no-asset");
+  });
+
+  it("still resolves availability through desktop's parser after scoping", async () => {
+    mocks.fetchManifestMock.mockResolvedValue(
+      createMultiPlatformManifest({
+        "darwin-arm64": AVAILABLE_ASSET,
+        "linux-x64": OTHER_PLATFORM_ASSET,
+      }),
+    );
+
+    const command = buildHostAvailableCommand({ includePreReleases: false });
+    const result = await command(fakeCtx());
+
+    // The whole point of the projection is that this is unchanged.
+    expect(parseAvailableSnapshotLikeDesktop(result.data)).toEqual({
+      latest: "1.2.0",
+      versions: [{ version: "1.2.0", available: true }],
+    });
+  });
+});

--- a/clients/traycer-cli/src/commands/__tests__/legacy-json-migration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/legacy-json-migration.test.ts
@@ -52,16 +52,25 @@ beforeEach(() => {
   process.env.USERPROFILE = workHome;
   stdoutChunks = [];
   stderrChunks = [];
+  // `write`'s completion callback is load-bearing, not decoration: the
+  // runner awaits it (via `flushStdio`) before `process.exit` so a terminal
+  // NDJSON line larger than the 64 KiB pipe buffer is not truncated on the
+  // way to Desktop. A stub that swallows the callback would leave that
+  // flush waiting on a write that never reports completion, so invoke it.
   stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
     chunk: string | Uint8Array,
+    callback: (() => void) | undefined,
   ) => {
     stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    if (callback !== undefined) callback();
     return true;
   }) as never);
   stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((
     chunk: string | Uint8Array,
+    callback: (() => void) | undefined,
   ) => {
     stderrChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    if (callback !== undefined) callback();
     return true;
   }) as never);
   // The runner owns process.exit - translate to a throw so the test

--- a/clients/traycer-cli/src/commands/__tests__/runner-discipline-migration.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/runner-discipline-migration.test.ts
@@ -52,16 +52,25 @@ beforeEach(() => {
   process.env.USERPROFILE = workHome;
   stdoutChunks = [];
   stderrChunks = [];
+  // `write`'s completion callback is load-bearing, not decoration: the
+  // runner awaits it (via `flushStdio`) before `process.exit` so a terminal
+  // NDJSON line larger than the 64 KiB pipe buffer is not truncated on the
+  // way to Desktop. A stub that swallows the callback would leave that
+  // flush waiting on a write that never reports completion, so invoke it.
   stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(((
     chunk: string | Uint8Array,
+    callback: (() => void) | undefined,
   ) => {
     stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    if (callback !== undefined) callback();
     return true;
   }) as never);
   stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(((
     chunk: string | Uint8Array,
+    callback: (() => void) | undefined,
   ) => {
     stderrChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+    if (callback !== undefined) callback();
     return true;
   }) as never);
   exitSpy = vi.spyOn(process, "exit").mockImplementation(((

--- a/clients/traycer-cli/src/commands/host-available.ts
+++ b/clients/traycer-cli/src/commands/host-available.ts
@@ -66,7 +66,7 @@ export function buildHostAvailableListing(
   const versions = filterHostAvailableVersions(
     args.manifest.versions,
     args.includePreReleases,
-  );
+  ).map((entry) => projectPlatformAsset(entry, args.platformKey));
   const manifest: HostVersionsManifest = {
     ...args.manifest,
     versions,
@@ -100,6 +100,42 @@ export function buildHostAvailableListing(
   return {
     manifest,
     human: lines.join("\n"),
+  };
+}
+
+// Emit only the asset for the platform this CLI is running on.
+//
+// The registry manifest carries one asset per supported platform on every
+// version entry - roughly 1.6 KB of a ~2.3 KB entry that no caller on this
+// machine can use. Both consumers of this payload already do a single-key
+// lookup and discard the rest: Desktop's `projectAvailableSnapshot`
+// (ipc/host-management-ipc.ts) and `host-controller.ts`, whose own comment
+// documents the expected shape as `versions[].platforms[platformKey]`.
+//
+// Dropping the other platforms cut the emitted line 3.2x - 70,331 to 21,689
+// bytes across 31 versions - with no rendered row changed. That matters
+// because this payload is one unsplittable JSON line whose growth is what
+// put it past the 64 KiB pipe buffer in the first place (see
+// runner/std-write.ts); the flush fixed the truncation, this keeps the line
+// from growing into other limits.
+//
+// Shape-compatible in both directions, which is why this needs no flag or
+// version negotiation: an older Desktop only ever looks up the key it
+// computed for its own platform and still finds it, and a newer Desktop
+// reading an older CLI's output ignores the extra platforms it is handed.
+//
+// An entry with no asset for this platform keeps an empty `platforms`
+// object rather than being dropped: the listing still reports it (tagged
+// `no-asset`), and callers distinguish "version exists but not for you"
+// from "version does not exist".
+function projectPlatformAsset(
+  entry: HostVersionEntry,
+  platformKey: HostPlatformKey,
+): HostVersionEntry {
+  const asset = entry.platforms[platformKey];
+  return {
+    ...entry,
+    platforms: asset === undefined ? {} : { [platformKey]: asset },
   };
 }
 

--- a/clients/traycer-cli/src/commands/host-logs.ts
+++ b/clients/traycer-cli/src/commands/host-logs.ts
@@ -1,6 +1,7 @@
 import { open, readFile, stat } from "node:fs/promises";
 import type { CommandFn, CommandResult } from "../runner/runner";
 import { hostLogPath } from "../store/paths";
+import { writeStdoutBytes } from "../runner/std-write";
 
 // `traycer host logs [--tail N] [--follow]` - surfaces the host
 // log file the supervisor writes into. JSON mode emits the tail string
@@ -68,7 +69,7 @@ export function buildHostLogsCommand(args: HostLogsArgs): CommandFn {
     // Thread `--quiet` into the streaming loop so it matches the
     // non-follow path and `output.ts` semantics: `--quiet --follow`
     // keeps the follower alive (offset tracking, rotation handling) but
-    // suppresses every streamed line, since the raw `process.stdout.write`
+    // suppresses every streamed line, since the raw `writeStdoutBytes`
     // below bypasses `ctx.output.human`'s quiet gate.
     await followLog(path, ctx.runtime.quiet);
     return {
@@ -149,7 +150,7 @@ async function followLog(path: string, quiet: boolean): Promise<void> {
               // follow wouldn't re-emit these bytes; gate only the write
               // so `--quiet` mirrors `ctx.output.human`'s suppression.
               if (!quiet) {
-                process.stdout.write(buf.subarray(0, bytesRead));
+                writeStdoutBytes(buf.subarray(0, bytesRead));
               }
               offset += bytesRead;
             }

--- a/clients/traycer-cli/src/commands/monitor.ts
+++ b/clients/traycer-cli/src/commands/monitor.ts
@@ -34,6 +34,7 @@ import {
   readHostPidMetadata,
 } from "../host/pid-metadata";
 import { resolveHostAuth } from "../internal/host-auth";
+import { writeStderr, writeStdout } from "../runner/std-write";
 import {
   createCliCredentialsStore,
   createStoreBackedRevalidator,
@@ -578,7 +579,7 @@ function printInboxMessage(item: AgentInboxMessage): void {
     reply: item.reply,
     body: item.prompt,
   });
-  process.stdout.write(`${output}\n`);
+  writeStdout(`${output}\n`);
 }
 
 /**
@@ -632,7 +633,7 @@ function printInboxNotice(notice: AgentInboxNotice): void {
     `[traycer inbox] based on your judgment decide how to proceed — read transcript, follow up, launch a new agent, etc.`,
     "",
   ];
-  process.stdout.write(`${lines.join("\n")}\n`);
+  writeStdout(`${lines.join("\n")}\n`);
 }
 
 /**
@@ -643,7 +644,7 @@ function printInboxNotice(notice: AgentInboxNotice): void {
 function printRoleAwareness(event: RoleAwarenessEvent): void {
   const verb =
     event.kind === "role-claimed" ? "claimed role" : "relinquished role";
-  process.stdout.write(
+  writeStdout(
     `[traycer roles] agent ${event.claim.agentId} ${verb} "${event.claim.role}" (scope: ${event.claim.scope})\n`,
   );
 }
@@ -681,9 +682,9 @@ function printReceiverCancelledNotice(
     `[traycer inbox] if you are working on the user's behalf, wait for their next instruction; if you are working on behalf of another agent, let that agent know`,
     "",
   ];
-  process.stdout.write(`${lines.join("\n")}\n`);
+  writeStdout(`${lines.join("\n")}\n`);
 }
 
 function diag(message: string): void {
-  process.stderr.write(`[traycer monitor] ${message}\n`);
+  writeStderr(`[traycer monitor] ${message}\n`);
 }

--- a/clients/traycer-cli/src/commands/worktree-delete.ts
+++ b/clients/traycer-cli/src/commands/worktree-delete.ts
@@ -25,6 +25,7 @@ import { resolveHostAuth } from "../internal/host-auth";
 import { resolveEndpoint } from "../internal/host-rpc";
 import { cliError, CLI_ERROR_CODES, type CliError } from "../runner/errors";
 import type { CommandContext, CommandFn } from "../runner/runner";
+import { writeStderr } from "../runner/std-write";
 
 // Stream timing knobs, mirroring `traycer monitor`. A worktree delete is a
 // one-shot: it runs a teardown script (which can be slow) then removes the
@@ -371,7 +372,7 @@ function relayStatus(ctx: CommandContext, message: string): void {
     });
     return;
   }
-  process.stderr.write(`[traycer worktree delete] ${message}\n`);
+  writeStderr(`[traycer worktree delete] ${message}\n`);
 }
 
 /**

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -84,6 +84,7 @@ import { addRunnerFlags, extractRunnerFlags } from "./runner/commander-flags";
 import { parsePositiveIntegerArg } from "./runner/parse-positive-integer-arg";
 import { runCommand, type CommandFn } from "./runner/runner";
 import { readonlyEnv } from "./runner/runtime";
+import { flushStdio, writeStderr, writeStdout } from "./runner/std-write";
 
 // Helper: register a runner-aware action handler. The runner owns
 // process.exit, so anything composed via `withRunner` participates in
@@ -244,11 +245,11 @@ function applyRunnerErrorRouting(root: Command): void {
     cmd.exitOverride();
     cmd.configureOutput({
       writeErr: (str) => {
-        if (!argvRequestsJson(root)) process.stderr.write(str);
+        if (!argvRequestsJson(root)) writeStderr(str);
       },
       writeOut: (str) => {
         if (argvRequestsJson(root)) commanderStdoutBuffer += str;
-        else process.stdout.write(str);
+        else writeStdout(str);
       },
     });
     for (const sub of cmd.commands) route(sub);
@@ -435,7 +436,7 @@ function registerHostCommands(program: Command): void {
           : { kind: "list", json: opts.json === true },
       );
       if (response.stdout.length > 0) {
-        process.stdout.write(response.stdout);
+        writeStdout(response.stdout);
       }
       process.exitCode = response.exitCode;
     });
@@ -1994,11 +1995,12 @@ function registerMonitorCommand(program: Command): void {
         { exitCode: 1 },
         errorFromUnknown(err),
       );
-      process.stderr.write(
+      writeStderr(
         `[traycer monitor] fatal: ${
           err instanceof Error ? err.message : String(err)
         }\n`,
       );
+      await flushStdio();
       process.exit(1);
     }
   });
@@ -2020,7 +2022,7 @@ if (isTraycerCliEntrypoint(entryArgv)) {
     environment: config.environment,
     argvLength: process.argv.length,
   });
-  program.parseAsync(process.argv).catch((err) => {
+  program.parseAsync(process.argv).catch(async (err) => {
     if (err instanceof CommanderError) {
       const jsonMode = argvRequestsJson(program);
       // Help (`--help`) and version (`--version`) flow through exitOverride
@@ -2041,8 +2043,11 @@ if (isTraycerCliEntrypoint(entryArgv)) {
             data: { output: commanderStdoutBuffer.trimEnd() },
             timestamp: new Date().toISOString(),
           };
-          process.stdout.write(`${JSON.stringify(event)}\n`);
+          writeStdout(`${JSON.stringify(event)}\n`);
         }
+        // `--help` under `--json` wraps the whole help text in one line;
+        // long help easily clears the 64 KiB pipe buffer. See std-write.ts.
+        await flushStdio();
         process.exit(0);
       }
       // Parse failure. In --json mode emit the runner's NDJSON error
@@ -2068,8 +2073,9 @@ if (isTraycerCliEntrypoint(entryArgv)) {
           },
           timestamp: new Date().toISOString(),
         };
-        process.stdout.write(`${JSON.stringify(event)}\n`);
+        writeStdout(`${JSON.stringify(event)}\n`);
       }
+      await flushStdio();
       process.exit(err.exitCode || 1);
     }
     const error = errorFromUnknown(err);
@@ -2090,12 +2096,13 @@ if (isTraycerCliEntrypoint(entryArgv)) {
         },
         timestamp: new Date().toISOString(),
       };
-      process.stdout.write(`${JSON.stringify(event)}\n`);
+      writeStdout(`${JSON.stringify(event)}\n`);
     } else {
-      process.stderr.write(
+      writeStderr(
         `error: unexpected CLI failure [code=${CLI_ERROR_CODES.UNEXPECTED}]\n`,
       );
     }
+    await flushStdio();
     process.exit(1);
   });
 }
@@ -2127,7 +2134,7 @@ function exitAfterUnhandledFailure(
   const error = errorFromUnknown(cause);
   logger.error(message, { exitCode: 1 }, error);
   Sentry.captureException(cause);
-  process.stderr.write(
+  writeStderr(
     `error: unexpected CLI failure [code=${CLI_ERROR_CODES.UNEXPECTED}]\n`,
   );
   void Sentry.flush(2000)
@@ -2137,6 +2144,7 @@ function exitAfterUnhandledFailure(
         errorMessage: errorFromUnknown(flushErr).message,
       });
     })
+    .then(() => flushStdio())
     .finally(() => {
       process.exit(1);
     });

--- a/clients/traycer-cli/src/runner/__tests__/fixtures/large-result-worker.ts
+++ b/clients/traycer-cli/src/runner/__tests__/fixtures/large-result-worker.ts
@@ -1,0 +1,32 @@
+import { runCommand } from "../../runner";
+
+// Worker for `std-write.test.ts`. Emits a `result` payload of
+// `WORKER_PAYLOAD_BYTES` through the REAL runner - `createOutput` ->
+// `emitResult` -> `process.exit()` - so the test exercises the actual
+// write-then-exit sequence rather than a hand-rolled imitation of it.
+//
+// `runCommand` owns the exit, so nothing after it runs.
+const payloadBytes = Number(process.env.WORKER_PAYLOAD_BYTES);
+if (!Number.isInteger(payloadBytes) || payloadBytes <= 0) {
+  throw new Error(
+    `WORKER_PAYLOAD_BYTES must be a positive integer, got ${String(
+      process.env.WORKER_PAYLOAD_BYTES,
+    )}`,
+  );
+}
+
+await runCommand(
+  async () => ({
+    // One unsplittable JSON string, mirroring `host available`, whose
+    // entire listing is a single `data.manifest` blob on one line.
+    data: { filler: "x".repeat(payloadBytes) },
+    human: null,
+    exitCode: 0,
+  }),
+  {
+    json: true,
+    quiet: false,
+    noProgress: true,
+    noBootstrap: true,
+  },
+);

--- a/clients/traycer-cli/src/runner/__tests__/std-write.test.ts
+++ b/clients/traycer-cli/src/runner/__tests__/std-write.test.ts
@@ -1,0 +1,132 @@
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression coverage for the `host available --include-pre-releases`
+// truncation (Settings -> Host -> "Pick a different version" reporting
+// `traycer-cli emitted no terminal result line`).
+//
+// The runner emits its terminal NDJSON line and immediately `process.exit()`s.
+// `process.stdout.write` is asynchronous on a PIPE, and exit does not drain
+// the stream buffer, so before the `std-write` fix only the first 64 KiB (the
+// kernel pipe buffer) survived - the rest was dropped and the process still
+// exited 0. Desktop saw half a JSON line and no envelope.
+//
+// Why a real subprocess over a real pipe: the bug lives in the interaction
+// between the OS pipe buffer and process teardown. Nothing in-process can
+// reproduce it, and neither can a shell redirect to a FILE - file writes are
+// synchronous, so `traycer host available --json > out.json` succeeds at any
+// size and hides the defect completely. That false-negative is exactly how
+// this shipped.
+//
+// Both payloads run through the identical code path; only the size differs.
+// The small case is the control that keeps the large case honest - if the
+// worker were silently failing to emit anything at all, both would fail.
+
+const WORKER = join(import.meta.dirname, "fixtures", "large-result-worker.ts");
+
+// macOS and Linux both cap a pipe at 64 KiB. `LARGE` must exceed it by
+// enough that a truncated write cannot coincidentally still parse.
+const PIPE_BUFFER_BYTES = 65_536;
+const SMALL_PAYLOAD_BYTES = 1_024;
+const LARGE_PAYLOAD_BYTES = 200_000;
+
+// Spawning bun and compiling the fixture exceeds vitest's default 5s budget
+// on a cold cache.
+const SPAWN_TIMEOUT_MS = 30_000;
+
+interface WorkerRun {
+  readonly stdout: string;
+  readonly error: Error | null;
+}
+
+// `bun` rather than the vitest host process: the CLI ships as a
+// `bun --compile` binary, so bun is the runtime whose flush-on-exit behaviour
+// has to hold. (Node truncates identically here, but pinning the shipped
+// runtime is what makes this test evidence about the artifact we release.)
+function runWorker(payloadBytes: number): Promise<WorkerRun> {
+  return new Promise((resolve) => {
+    execFile(
+      "bun",
+      ["run", WORKER],
+      {
+        encoding: "utf8",
+        // Well above LARGE so a maxBuffer kill can never be mistaken for
+        // the truncation this test is about.
+        maxBuffer: 8 * 1024 * 1024,
+        env: { ...process.env, WORKER_PAYLOAD_BYTES: String(payloadBytes) },
+      },
+      (error, stdout) => {
+        resolve({ stdout: String(stdout), error });
+      },
+    );
+  });
+}
+
+function terminalResultOf(stdout: string): unknown {
+  const lines = stdout.split("\n").filter((line) => line.length > 0);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // A truncated terminal line lands here - that IS the bug, so fall
+      // through and let the caller's assertion report the miss.
+      continue;
+    }
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      (parsed as { type: unknown }).type === "result"
+    ) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+describe("runner stdout survives process.exit", () => {
+  it(
+    "delivers a terminal result line larger than the 64 KiB pipe buffer",
+    async () => {
+      // Guard on the CONSTANT, not on observed stdout: this is what keeps
+      // the test meaningful if the payload is ever tuned down, and unlike
+      // an assertion on `run.stdout.length` it stays independent of the
+      // defect under test (a truncated run lands at exactly 65,536 bytes,
+      // which would report as a byte-count mismatch rather than as the
+      // missing envelope that actually breaks Desktop).
+      expect(LARGE_PAYLOAD_BYTES).toBeGreaterThan(PIPE_BUFFER_BYTES);
+
+      const run = await runWorker(LARGE_PAYLOAD_BYTES);
+      expect(run.error).toBeNull();
+
+      const terminal = terminalResultOf(run.stdout);
+      expect(terminal).not.toBeNull();
+      expect(terminal).toMatchObject({ type: "result", status: "ok" });
+      // Not just parseable - complete. A write cut at the pipe boundary
+      // would still be 65,536 bytes of valid-looking prefix.
+      expect(
+        (terminal as { data: { filler: string } }).data.filler.length,
+      ).toBe(LARGE_PAYLOAD_BYTES);
+    },
+    SPAWN_TIMEOUT_MS,
+  );
+
+  it(
+    "delivers a terminal result line smaller than the pipe buffer",
+    async () => {
+      const run = await runWorker(SMALL_PAYLOAD_BYTES);
+
+      expect(run.error).toBeNull();
+      expect(run.stdout.length).toBeLessThan(PIPE_BUFFER_BYTES);
+
+      const terminal = terminalResultOf(run.stdout);
+      expect(terminal).toMatchObject({ type: "result", status: "ok" });
+      expect(
+        (terminal as { data: { filler: string } }).data.filler.length,
+      ).toBe(SMALL_PAYLOAD_BYTES);
+    },
+    SPAWN_TIMEOUT_MS,
+  );
+});

--- a/clients/traycer-cli/src/runner/output.ts
+++ b/clients/traycer-cli/src/runner/output.ts
@@ -1,5 +1,6 @@
 import type { CliErrorCode } from "./errors";
 import type { RuntimeContext } from "./runtime";
+import { writeStderr, writeStdout } from "./std-write";
 
 // NDJSON envelope shapes per the Native Packaging tech plan. Every line
 // on stdout in --json mode is one of these three discriminated by
@@ -79,12 +80,15 @@ function now(): string {
   return new Date().toISOString();
 }
 
+// Synchronous by way of `std-write`: the runner `process.exit()`s the instant
+// `emitResult` / `emitError` returns, so a buffered write here loses
+// everything past the 64 KiB pipe buffer. See std-write.ts.
 function writeStdoutLine(line: string): void {
-  process.stdout.write(`${line}\n`);
+  writeStdout(`${line}\n`);
 }
 
 function writeStderrLine(line: string): void {
-  process.stderr.write(`${line}\n`);
+  writeStderr(`${line}\n`);
 }
 
 function formatBytes(n: number): string {
@@ -191,7 +195,7 @@ export function createOutput(runtime: RuntimeContext): Output {
   let lastNonTtyDecile = -1;
   const closeProgressLine = (): void => {
     if (progressOpen) {
-      process.stderr.write("\n");
+      writeStderr("\n");
       progressOpen = false;
       openBarInfo = null;
     }
@@ -203,7 +207,7 @@ export function createOutput(runtime: RuntimeContext): Output {
         if (isTty) {
           // `\r` returns to column 0; `\x1b[2K` clears the line so a shorter
           // render can't leave stale characters from a longer previous one.
-          process.stderr.write(`\r\x1b[2K${renderProgressBar(info)}`);
+          writeStderr(`\r\x1b[2K${renderProgressBar(info)}`);
           progressOpen = true;
           openBarInfo = info;
           return;
@@ -231,7 +235,7 @@ export function createOutput(runtime: RuntimeContext): Output {
         openBarInfo !== null &&
         isArchiveHeartbeatStage(info.stage)
       ) {
-        process.stderr.write(
+        writeStderr(
           `\r\x1b[2K${renderProgressBar({
             stage: info.stage,
             message: info.message ?? openBarInfo.message,

--- a/clients/traycer-cli/src/runner/runner.ts
+++ b/clients/traycer-cli/src/runner/runner.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/node";
 import { errorFromUnknown } from "../logger";
 import { toCliError } from "./errors";
 import { createOutput, type Output, type ProgressInfo } from "./output";
+import { flushStdio } from "./std-write";
 import {
   type RawRunnerFlags,
   readonlyEnv,
@@ -89,6 +90,9 @@ export async function runCommand(
       });
       // best-effort; do not let a flush failure prevent exit
     }
+    // The error envelope was just written to a possibly-piped stdout;
+    // `process.exit` would drop everything past the 64 KiB pipe buffer.
+    await flushStdio();
     process.exit(cliErr.exitCode);
   }
   runtime.logger.info("CLI command completed", {
@@ -101,5 +105,10 @@ export async function runCommand(
   } else if (result.human !== null && !runtime.quiet) {
     output.human(result.human);
   }
+  // Terminal `result` line just went out. This is the flush the
+  // `host available --include-pre-releases` truncation turned on: without
+  // it, any payload over 64 KiB reaches Desktop as half a JSON line with
+  // exit code 0. See std-write.ts.
+  await flushStdio();
   process.exit(result.exitCode);
 }

--- a/clients/traycer-cli/src/runner/std-write.ts
+++ b/clients/traycer-cli/src/runner/std-write.ts
@@ -1,0 +1,109 @@
+// Every byte this CLI writes to stdout/stderr goes through here, so that
+// `flushStdio()` can guarantee it actually reached the OS before the process
+// exits.
+//
+// Why this exists: `process.stdout.write` is ASYNCHRONOUS whenever stdout is
+// a pipe, which is every Desktop invocation (`execFile` / `spawn` in
+// desktop/src/electron-main/cli/traycer-cli.ts). The runner and the script
+// entrypoint both `process.exit()` immediately after emitting their terminal
+// NDJSON line, and `process.exit` tears the process down WITHOUT draining the
+// stream buffer. Only what the kernel pipe buffer accepted synchronously
+// (65,536 bytes on macOS and Linux) was ever delivered - the remainder was
+// discarded and the process still exited 0. Desktop then read a truncated,
+// unparseable JSON line and reported "traycer-cli emitted no terminal result
+// line for: <args>", with no coded envelope to diagnose from.
+//
+// This is a payload-size cliff, not a code regression: `host available --json
+// --include-pre-releases` emits its whole listing on ONE line, and that line
+// crossed 64 KiB when host 1.1.8 was published (2026-07-25), breaking the
+// Settings -> Host "Include release candidates" row with no change on either
+// side. Stable-only is at ~22 KiB and grows ~2.4 KiB per release, so the
+// same cliff is ahead for the default listing too.
+//
+// Two "obvious" flushes that DO NOT work - both measured against bun, the
+// runtime the CLI ships as (`bun --compile`), writing 70,000 bytes to a pipe.
+// Both delivered exactly 65,536:
+//
+//   - `process.stdout.write("", cb)` as a flush sentinel after the real
+//     write: bun fires that callback immediately rather than behind the
+//     preceding write, so the process still exits mid-flush.
+//   - awaiting `"drain"` / testing `writableLength`: `drain` only fires after
+//     a write returns false, and bun reports `writableLength === 0` with
+//     bytes still outstanding.
+//
+// What does work, and what this module relies on, is the per-write completion
+// callback (`stream.write(chunk, cb)`) - verified end-to-end on both bun and
+// node at 500 KB. Because a sentinel write cannot be trusted to queue behind
+// earlier ones, each write's own callback is captured and chained, and
+// `flushStdio()` awaits the accumulated tail rather than probing the stream.
+//
+// Writes still go through `process.stdout` / `process.stderr` rather than a
+// raw `fs.writeSync(1, ...)`: that keeps the stream the rest of the codebase
+// (and its tests) observes as the single output seam.
+
+const FLUSH_TIMEOUT_MS = 10_000;
+
+// Tail of the write-completion chain per descriptor. Replaced on every write,
+// so resolved links are collectable and a long-running `host logs --follow`
+// does not accumulate them.
+let stdoutTail: Promise<void> = Promise.resolve();
+let stderrTail: Promise<void> = Promise.resolve();
+
+function tracked(
+  stream: NodeJS.WriteStream,
+  chunk: string | Buffer,
+  tail: Promise<void>,
+): Promise<void> {
+  const written = new Promise<void>((resolve) => {
+    // The callback fires once the chunk has been handed off, INCLUDING on
+    // error (e.g. EPIPE when the reader closed), so this always settles and
+    // a failed write cannot wedge the flush.
+    stream.write(chunk, () => resolve());
+  });
+  return tail.then(() => written);
+}
+
+export function writeStdout(text: string): void {
+  stdoutTail = tracked(process.stdout, text, stdoutTail);
+}
+
+// Raw byte passthrough for callers already holding a Buffer (`host logs
+// --follow` streams file chunks verbatim). Kept separate from `writeStdout`
+// so those bytes are never round-tripped through a string.
+export function writeStdoutBytes(chunk: Buffer): void {
+  stdoutTail = tracked(process.stdout, chunk, stdoutTail);
+}
+
+export function writeStderr(text: string): void {
+  stderrTail = tracked(process.stderr, text, stderrTail);
+}
+
+/**
+ * Await every write issued through this module. MUST be awaited before any
+ * `process.exit()` that follows CLI output - see the module comment for what
+ * gets lost otherwise.
+ *
+ * Never rejects, and never blocks teardown indefinitely: a write whose
+ * completion callback never arrives (a stubbed stream in a test, an exotic
+ * descriptor) falls back to a bounded wait rather than hanging the CLI. The
+ * timer is cleared on the normal path so it cannot hold the event loop open.
+ */
+export async function flushStdio(): Promise<void> {
+  await Promise.all([bounded(stdoutTail), bounded(stderrTail)]);
+}
+
+function bounded(tail: Promise<void>): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, FLUSH_TIMEOUT_MS);
+    void tail.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Two commits, both in `traycer-cli`:

1. **`fix(cli)`** — await a stdout/stderr flush before every `process.exit` that follows CLI output.
2. **`perf(cli)`** — emit only the running platform's asset from `host available`.

## The bug

Settings → Host → "Include release candidates" reported:

```
TraycerCliError: traycer-cli emitted no terminal result line for:
host available --json --include-pre-releases
```

The runner emits its terminal NDJSON line and immediately `process.exit()`s. `process.stdout.write` is asynchronous whenever stdout is a pipe — which is every Desktop invocation — and exit does not drain the stream buffer. Only what the kernel pipe buffer accepted synchronously (65,536 bytes on macOS and Linux) was delivered; the rest was dropped and **the process still exited 0**. Desktop read half a JSON line, with no coded envelope to diagnose from.

This is a payload-size cliff, not a code regression. `host available` emits its whole listing on one line, and that line crossed 64 KiB when host `1.1.8` was published on 2026-07-25 — `1.1.8-rc.3` sat 194 bytes under the limit. It broke with no code change on either side, so there is nothing to bisect.

## Notes for reviewers

Two obvious flushes **silently do nothing** under bun, the runtime the CLI ships as. Both measured writing 70,000 bytes to a pipe; both delivered exactly 65,536:

- `process.stdout.write("", cb)` as a sentinel — bun fires that callback immediately rather than behind the preceding write
- awaiting `"drain"` / testing `writableLength` — `drain` only fires after a write returns false, and bun reports `writableLength === 0` with bytes outstanding

Only the per-write completion callback works, so each write's callback is captured and chained. `flushStdio()` never rejects and cannot hang — a callback that never arrives falls back to a bounded wait.

An earlier draft used `fs.writeSync(1, …)`, which is structurally stronger (no await discipline to forget). It was backed out: it bypasses `process.stdout.write`, the seam 7 test files deliberately spy on, and broke 32 tests. Two migration tests stub `write` with mocks that ignore the callback argument; that callback is now load-bearing, so those stubs were updated to invoke it.

`host start`'s injected `exit` dep is the one exit path without a flush — its output is small `console.error` lines, so the 64 KiB cliff does not apply.

## Payload scoping

The manifest carries one asset per platform on every version entry — ~1.6 KB of a ~2.3 KB entry that nothing on this machine can use. Both consumers already do a single-key lookup and discard the rest (`projectAvailableSnapshot`, and `host-controller.ts`, whose own comment documents the shape as `versions[].platforms[platformKey]`).

Measured against the live registry, 31 versions:

| | before | after |
|---|---|---|
| `host available --json --include-pre-releases` | 70,517 B | 21,875 B |
| `host available --json` | 22,507 B | 7,281 B |

Human-mode output is byte-identical. Shape-compatible in both directions, so no flag or negotiation: an older Desktop only looks up the key it computed for its own platform and still finds it; a newer Desktop reading an older CLI's output ignores the extras.

This does **not** bound growth — the manifest still accumulates every release. At ~700 B/entry scoped there is room for ~93 entries versus ~29 before, so it buys runway, not a limit. A retention policy (RCs are 21 of the 31 entries) is still worth having.

## Validation

- `traycer-cli` suite: **1109 passed**, 12 skipped, 0 failed
- desktop consumer suites (`host-management-channel`, `host-controller`): 182 passed; both workspaces compile clean
- `smoke:ndjson` + `smoke:sea`: pass
- built the SEA binary and ran the real failing command through the same `execFile` options Desktop uses:
  **before** 65,721 bytes / no envelope → **after** 70,517 bytes / envelope found
- mutation probes: removing `await flushStdio()` fails the new test with `expected null not to be null`; removing the platform projection fails 2 of 3 new scoping tests

The regression test spawns a real subprocess over a real pipe. Nothing in-process reproduces this, and neither does a shell redirect to a **file** — file writes are synchronous, so `host available --json > out.json` succeeds at any size and hides the defect completely. That false negative is how this shipped.