### PR TITLE
feat: publish agent activity on the per-user notification room

### DIFF
--- a/clients/gui-app/src/__tests__/agent-activity-presence-harness.ts
+++ b/clients/gui-app/src/__tests__/agent-activity-presence-harness.ts
@@ -1,0 +1,96 @@
+/**
+ * Test harness for the per-user notification room's agent-activity presence.
+ *
+ * Drives the REAL path a suite would otherwise have to stub: each simulated
+ * host owns its own y-protocols `Awareness` producer, its entry is encoded with
+ * `encodeAwarenessUpdate`, and the bytes are handed to the notifications store
+ * exactly as an inbound `awareness` frame would be. That means the frozen field
+ * names, the binary decode, the cross-host merge and the store projection are
+ * all exercised, so a test asserting on a surface is asserting on the wire
+ * shape a host actually publishes.
+ *
+ * Producers are stable per host index across calls, so a second `publish` with
+ * a changed entry is a genuine clock-advancing update rather than a new host
+ * appearing. Hosts omitted from a later publish have their entry removed, the
+ * same way a host disconnecting from the room does.
+ */
+import { Awareness, encodeAwarenessUpdate } from "y-protocols/awareness";
+import * as Y from "yjs";
+import {
+  AGENT_ACTIVITY_AWARENESS_FIELD,
+  AGENT_ACTIVITY_HOST_ID_AWARENESS_FIELD,
+} from "@/lib/notifications/agent-activity-presence";
+import {
+  __applyNotificationsAwarenessForTests,
+  __clearNotificationsAwarenessForTests,
+} from "@/stores/notifications/notifications-store";
+
+/**
+ * One host's entry. `byEpic` is deliberately `unknown` so a suite can publish
+ * malformed shapes (a non-object bucket, a `turn` that is not an array, ...)
+ * and assert the reader degrades that piece alone.
+ */
+export interface AgentActivityHostEntry {
+  readonly hostId: string | null;
+  readonly byEpic: unknown;
+}
+
+interface Producer {
+  readonly awareness: Awareness;
+  readonly doc: Y.Doc;
+}
+
+const producers: Producer[] = [];
+
+function producerAt(index: number): Producer {
+  const existing = producers[index] as Producer | undefined;
+  if (existing !== undefined) return existing;
+  const doc = new Y.Doc();
+  const producer: Producer = { doc, awareness: new Awareness(doc) };
+  producers[index] = producer;
+  return producer;
+}
+
+/**
+ * Publishes one awareness entry per element of `entries` into the room replica.
+ * Index position identifies the host, so re-publishing with a different entry
+ * at index 0 updates that host rather than adding another.
+ */
+export function publishAgentActivity(
+  entries: readonly AgentActivityHostEntry[],
+): void {
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index];
+    const producer = producerAt(index);
+    const state: Record<string, unknown> = {
+      [AGENT_ACTIVITY_AWARENESS_FIELD]: entry.byEpic,
+    };
+    if (entry.hostId !== null) {
+      state[AGENT_ACTIVITY_HOST_ID_AWARENESS_FIELD] = entry.hostId;
+    }
+    producer.awareness.setLocalState(state);
+    __applyNotificationsAwarenessForTests(
+      encodeAwarenessUpdate(producer.awareness, [producer.awareness.clientID]),
+    );
+  }
+  // Hosts that dropped out of the list disconnected: clear their entry so the
+  // union stops reporting their agents.
+  for (let index = entries.length; index < producers.length; index += 1) {
+    const producer = producerAt(index);
+    if (producer.awareness.getLocalState() === null) continue;
+    producer.awareness.setLocalState(null);
+    __applyNotificationsAwarenessForTests(
+      encodeAwarenessUpdate(producer.awareness, [producer.awareness.clientID]),
+    );
+  }
+}
+
+/** Tears every simulated host down and empties the replica. Use in afterEach. */
+export function resetAgentActivityPresence(): void {
+  for (const producer of producers) {
+    producer.awareness.destroy();
+    producer.doc.destroy();
+  }
+  producers.length = 0;
+  __clearNotificationsAwarenessForTests();
+}

--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-node-tab-icon.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-node-tab-icon.test.tsx
@@ -1,7 +1,10 @@
 import "../../../../__tests__/test-browser-apis";
 import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
+import {
+  publishAgentActivity,
+  resetAgentActivityPresence,
+} from "@/__tests__/agent-activity-presence-harness";
 import { EpicNodeTabIcon } from "@/components/epic-canvas/epic-node-tab-icon";
 import { NotificationIndicatorsProvider } from "@/components/notifications/notification-indicators-provider";
 import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
@@ -104,43 +107,63 @@ describe("<EpicNodeTabIcon /> terminal-agent activity", () => {
   afterEach(() => {
     cleanup();
     __getOpenEpicRegistryForTests().disposeAll();
+    resetAgentActivityPresence();
     __resetAppLocalNotificationsStoreForTests();
   });
 
   // Regression: the TUI-agent tab used to hardcode `running={false}`, so a
   // working agent spun in the sidebar but never in its own tab.
   it("swaps the idle icon for the spinner while the agent is working", () => {
-    const handle = registerEpicSession("epic-1");
+    registerEpicSession("epic-1");
 
     renderTuiAgentTabIcon();
 
     expect(screen.queryByRole("status", { name: SPINNER_LABEL })).toBeNull();
 
     act(() => {
-      handle.awareness.setLocalState({
-        [AGENT_WORKING_AWARENESS_FIELD]: [TUI_AGENT_NODE.id],
-      });
+      publishWorking([TUI_AGENT_NODE.id]);
     });
 
     expect(screen.getByRole("status", { name: SPINNER_LABEL })).toBeTruthy();
 
     act(() => {
-      handle.awareness.setLocalState({
-        [AGENT_WORKING_AWARENESS_FIELD]: [],
-      });
+      publishWorking([]);
     });
 
     expect(screen.queryByRole("status", { name: SPINNER_LABEL })).toBeNull();
   });
 
   // The shared icon renders outside an open-epic session too (drag previews,
-  // mount-lifecycle tests); an unregistered Epic must read as idle, not throw.
+  // mount-lifecycle tests); an Epic with no presence must read as idle, not
+  // throw.
   it("renders the idle icon with no registered Epic session", () => {
     renderTuiAgentTabIcon();
 
     expect(screen.queryByRole("status", { name: SPINNER_LABEL })).toBeNull();
   });
+
+  // The defect this whole signal move fixes: activity for an Epic this window
+  // has NEVER opened. There is no session and no per-epic room here, so the
+  // spinner can only come from the per-user notification room.
+  it("spins for an Epic that was never opened in this window", () => {
+    renderTuiAgentTabIcon();
+
+    act(() => {
+      publishWorking([TUI_AGENT_NODE.id]);
+    });
+
+    expect(screen.getByRole("status", { name: SPINNER_LABEL })).toBeTruthy();
+  });
 });
+
+function publishWorking(agentIds: readonly string[]): void {
+  publishAgentActivity([
+    {
+      hostId: "host-1",
+      byEpic: { "epic-1": { working: agentIds, turn: agentIds } },
+    },
+  ]);
+}
 
 function registerEpicSession(epicId: string): OpenEpicStoreHandle {
   return __getOpenEpicRegistryForTests().acquire(epicId, () =>

--- a/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip-title.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/tab-strip-title.test.tsx
@@ -23,7 +23,10 @@ import {
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as Y from "yjs";
-import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
+import {
+  publishAgentActivity,
+  resetAgentActivityPresence,
+} from "@/__tests__/agent-activity-presence-harness";
 import { TabStrip } from "@/components/epic-canvas/canvas/tab-strip";
 import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
@@ -178,11 +181,12 @@ async function flushEpicSnapshot(): Promise<void> {
 }
 
 function markChatWorking(): void {
-  const handle = __getOpenEpicRegistryForTests().get(EPIC_ID);
-  if (handle === null) throw new Error("expected open epic handle");
-  handle.awareness.setLocalState({
-    [AGENT_WORKING_AWARENESS_FIELD]: [CHAT_ID],
-  });
+  publishAgentActivity([
+    {
+      hostId: "host-a",
+      byEpic: { [EPIC_ID]: { working: [CHAT_ID], turn: [CHAT_ID] } },
+    },
+  ]);
 }
 
 describe("TabStrip title", () => {
@@ -206,6 +210,7 @@ describe("TabStrip title", () => {
   afterEach(() => {
     cleanup();
     queryClient.clear();
+    resetAgentActivityPresence();
     harness.teardown();
     useEpicCanvasStore.getState().clearAllTitleGenerationPending();
   });

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -16,7 +16,10 @@ import {
   ensureHistoryTab,
   ensureSettingsTab,
 } from "@/lib/commands/actions/open-system-tab";
-import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
+import {
+  publishAgentActivity,
+  resetAgentActivityPresence,
+} from "@/__tests__/agent-activity-presence-harness";
 import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
 import { __getChatSessionRegistryForTests } from "@/lib/registries/chat-session-registry";
 import type { PermissionRole } from "@/lib/epic-collaborator-roles";
@@ -186,8 +189,27 @@ function registerEpicHeader(
   permissionRole: PermissionRole,
 ): void {
   __getOpenEpicRegistryForTests().acquire(tab.id, () =>
-    buildHeaderEpicHandle(tab, permissionRole, [], []),
+    buildHeaderEpicHandle(tab, permissionRole, []),
   );
+}
+
+/**
+ * Agent activity now arrives on the per-user notification room, so the epic
+ * handle only supplies the live projection (the liveness filter) while the
+ * working set is published as host presence.
+ */
+function publishHeaderActivity(
+  tab: EpicTab,
+  activeAgentIds: ReadonlyArray<string>,
+): void {
+  publishAgentActivity([
+    {
+      hostId: "host-a",
+      byEpic: {
+        [tab.id]: { working: activeAgentIds, turn: activeAgentIds },
+      },
+    },
+  ]);
 }
 
 function registerActiveEpicHeader(
@@ -196,8 +218,9 @@ function registerActiveEpicHeader(
   activeAgentIds: ReadonlyArray<string>,
 ): void {
   __getOpenEpicRegistryForTests().acquire(tab.id, () =>
-    buildHeaderEpicHandle(tab, permissionRole, activeAgentIds, activeAgentIds),
+    buildHeaderEpicHandle(tab, permissionRole, activeAgentIds),
   );
+  publishHeaderActivity(tab, activeAgentIds);
 }
 
 function registerLiveEpicHeader(
@@ -206,24 +229,29 @@ function registerLiveEpicHeader(
   liveAgentIds: ReadonlyArray<string>,
 ): void {
   __getOpenEpicRegistryForTests().acquire(tab.id, () =>
-    buildHeaderEpicHandle(tab, permissionRole, [], liveAgentIds),
+    buildHeaderEpicHandle(tab, permissionRole, liveAgentIds),
   );
 }
 
+/**
+ * Presence naming an agent the epic's live projection no longer holds. The
+ * session IS registered, so its (empty) projection is authoritative and the
+ * liveness filter must drop the stale id.
+ */
 function registerStaleActiveEpicHeader(
   tab: EpicTab,
   permissionRole: PermissionRole,
   activeAgentIds: ReadonlyArray<string>,
 ): void {
   __getOpenEpicRegistryForTests().acquire(tab.id, () =>
-    buildHeaderEpicHandle(tab, permissionRole, activeAgentIds, []),
+    buildHeaderEpicHandle(tab, permissionRole, []),
   );
+  publishHeaderActivity(tab, activeAgentIds);
 }
 
 function buildHeaderEpicHandle(
   tab: EpicTab,
   permissionRole: PermissionRole,
-  activeAgentIds: ReadonlyArray<string>,
   liveAgentIds: ReadonlyArray<string>,
 ): OpenEpicStoreHandle {
   const liveChatsById = Object.fromEntries(
@@ -265,15 +293,7 @@ function buildHeaderEpicHandle(
     subscribe: () => () => undefined,
   });
   const awareness = {
-    getStates: () =>
-      new Map<number, Record<string, unknown>>([
-        [
-          1,
-          {
-            [AGENT_WORKING_AWARENESS_FIELD]: activeAgentIds,
-          },
-        ],
-      ]),
+    getStates: () => new Map<number, Record<string, unknown>>(),
     on: () => undefined,
     off: () => undefined,
   };
@@ -480,6 +500,7 @@ describe("<TabStrip />", () => {
   afterEach(() => {
     cleanup();
     queryClient.clear();
+    resetAgentActivityPresence();
     resetStores();
   });
 

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -198,18 +198,24 @@ function registerEpicHeader(
  * handle only supplies the live projection (the liveness filter) while the
  * working set is published as host presence.
  */
+const headerActivityByEpic = new Map<string, ReadonlyArray<string>>();
+
 function publishHeaderActivity(
   tab: EpicTab,
   activeAgentIds: ReadonlyArray<string>,
 ): void {
-  publishAgentActivity([
-    {
-      hostId: "host-a",
-      byEpic: {
-        [tab.id]: { working: activeAgentIds, turn: activeAgentIds },
-      },
-    },
-  ]);
+  // Accumulate: one host publishes ONE entry carrying every epic it is working
+  // on, so republishing only the latest tab would silently clear the presence
+  // an earlier call established.
+  headerActivityByEpic.set(tab.id, activeAgentIds);
+  const byEpic: Record<
+    string,
+    { working: ReadonlyArray<string>; turn: ReadonlyArray<string> }
+  > = {};
+  for (const [epicId, ids] of headerActivityByEpic) {
+    byEpic[epicId] = { working: ids, turn: ids };
+  }
+  publishAgentActivity([{ hostId: "host-a", byEpic }]);
 }
 
 function registerActiveEpicHeader(
@@ -500,6 +506,7 @@ describe("<TabStrip />", () => {
   afterEach(() => {
     cleanup();
     queryClient.clear();
+    headerActivityByEpic.clear();
     resetAgentActivityPresence();
     resetStores();
   });

--- a/clients/gui-app/src/hooks/agent/use-agent-stop-controls.ts
+++ b/clients/gui-app/src/hooks/agent/use-agent-stop-controls.ts
@@ -40,7 +40,7 @@ function surfaceOf(type: string): "gui" | "tui" | null {
  * agent on top with Stop all, its active descendants beneath.
  *
  * Structure + titles come from the reactive epic tree (instant on spawn); the
- * live `active` bit comes from the cross-host awareness `agentWorking` set
+ * live `active` bit comes from the global activity awareness source
  * (`useEpicActiveAgentIds`) - push-driven, no polling.
  */
 export function useAgentStopControls(input: {

--- a/clients/gui-app/src/hooks/epic/__tests__/use-epic-activity-status.test.tsx
+++ b/clients/gui-app/src/hooks/epic/__tests__/use-epic-activity-status.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Task-level activity aggregation, with the layering that survived the move to
+ * per-user presence: an open chat session that reads some activity is
+ * authoritative for its own tier, and host-published presence backfills
+ * everything else.
+ *
+ * The load-bearing case is the last pair: presence for an epic this window has
+ * NEVER opened must show through (no projection to check it against), while
+ * presence naming an agent a LIVE projection no longer holds must be filtered
+ * out. Both look like "an empty candidate set" if you only count ids, which is
+ * why the hook distinguishes "no session" from "a session with no agents".
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useEpicActivityStatus } from "@/hooks/epic/use-epic-activity-status";
+import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
+import {
+  createOpenEpicStore,
+  type EpicStreamClientFactory,
+} from "@/stores/epics/open-epic/store";
+import {
+  publishAgentActivity,
+  resetAgentActivityPresence,
+} from "@/__tests__/agent-activity-presence-harness";
+
+const EPIC_ID = "epic-activity";
+const AGENT_ID = "chat-1";
+
+const noopStreamClientFactory: EpicStreamClientFactory = () => ({
+  applyUpdate: () => undefined,
+  awareness: () => undefined,
+  applyArtifactRoomUpdate: () => undefined,
+  artifactRoomAwareness: () => undefined,
+  retryMigration: () => undefined,
+  close: () => undefined,
+});
+
+function registerEmptySession(): void {
+  __getOpenEpicRegistryForTests().acquire(EPIC_ID, () =>
+    createOpenEpicStore({
+      epicId: EPIC_ID,
+      userId: null,
+      streamClientFactory: noopStreamClientFactory,
+      onAuthError: null,
+    }),
+  );
+}
+
+function publishWorking(agentIds: readonly string[], turnIds: unknown): void {
+  publishAgentActivity([
+    {
+      hostId: "host-a",
+      byEpic: { [EPIC_ID]: { working: agentIds, turn: turnIds } },
+    },
+  ]);
+}
+
+afterEach(() => {
+  __getOpenEpicRegistryForTests().disposeAll();
+  resetAgentActivityPresence();
+});
+
+describe("useEpicActivityStatus", () => {
+  it("reads idle when no host reports work for the epic", () => {
+    const { result } = renderHook(() => useEpicActivityStatus(EPIC_ID));
+    expect(result.current).toBe("idle");
+  });
+
+  it("reports a turn for an epic this window has never opened", () => {
+    // The defect the per-user room fixes: no session, no projection, and the
+    // agent is still working.
+    const { result } = renderHook(() => useEpicActivityStatus(EPIC_ID));
+    act(() => {
+      publishWorking([AGENT_ID], [AGENT_ID]);
+    });
+    expect(result.current).toBe("turn");
+  });
+
+  it("reports background-only work for an unopened epic", () => {
+    const { result } = renderHook(() => useEpicActivityStatus(EPIC_ID));
+    act(() => {
+      publishWorking([AGENT_ID], []);
+    });
+    expect(result.current).toBe("background");
+  });
+
+  it("degrades an unclassified host's working ids to a turn", () => {
+    const { result } = renderHook(() => useEpicActivityStatus(EPIC_ID));
+    act(() => {
+      publishWorking([AGENT_ID], "not an array");
+    });
+    expect(result.current).toBe("turn");
+  });
+
+  it("filters presence against a live projection that no longer holds the agent", () => {
+    // A session IS registered, so its (empty) projection is authoritative and
+    // the stale id must not keep a spinner alive.
+    registerEmptySession();
+    const { result } = renderHook(() => useEpicActivityStatus(EPIC_ID));
+    act(() => {
+      publishWorking([AGENT_ID], [AGENT_ID]);
+    });
+    expect(result.current).toBe("idle");
+  });
+
+  it("stops filtering once the epic's session is evicted from the MRU", () => {
+    // The handle -> null transition the liveness filter turns on. While the
+    // session is live its projection is authoritative and suppresses the stale
+    // id; the moment the MRU evicts it the epic is UNKNOWN again, so
+    // host-published presence has to show through rather than staying
+    // suppressed by a projection that no longer exists.
+    registerEmptySession();
+    const { result } = renderHook(() => useEpicActivityStatus(EPIC_ID));
+    act(() => {
+      publishWorking([AGENT_ID], [AGENT_ID]);
+    });
+    expect(result.current).toBe("idle");
+
+    act(() => {
+      __getOpenEpicRegistryForTests().release(EPIC_ID);
+    });
+
+    expect(result.current).toBe("turn");
+  });
+
+  it("clears when the publishing host drops out", () => {
+    const { result } = renderHook(() => useEpicActivityStatus(EPIC_ID));
+    act(() => {
+      publishWorking([AGENT_ID], [AGENT_ID]);
+    });
+    expect(result.current).toBe("turn");
+    act(() => {
+      publishAgentActivity([]);
+    });
+    expect(result.current).toBe("idle");
+  });
+
+  it("reads idle for a null epic id", () => {
+    const { result } = renderHook(() => useEpicActivityStatus(null));
+    act(() => {
+      publishWorking([AGENT_ID], [AGENT_ID]);
+    });
+    expect(result.current).toBe("idle");
+  });
+});

--- a/clients/gui-app/src/hooks/epic/use-epic-activity-status.ts
+++ b/clients/gui-app/src/hooks/epic/use-epic-activity-status.ts
@@ -46,46 +46,55 @@ export function useEpicActivityStatus(
 
 /**
  * Reads session activity across a candidate set of chat ids, falling back to
- * the host-published awareness tier for agents whose session state did not
+ * the host-published activity tier for agents whose session state did not
  * resolve locally. `candidateIds` scopes the aggregation: the whole epic's
  * live agents for {@link useEpicActivityStatus}, or a node's descendant ids
  * for {@link useSubtreeChatActivityTier}.
  *
  * An open chat session is authoritative for its own tier ONLY when it reads
- * some activity - a local `"turn"`/`"background"` is never overridden by
- * awareness, so the two tiers can't be re-conflated. A session reading idle is
- * deliberately NOT treated as resolved: it still defers to awareness, which
+ * some activity - a local `"turn"`/`"background"` is never overridden by the
+ * global source, so the two tiers can't be re-conflated. A session reading idle
+ * is deliberately NOT treated as resolved: it still defers to presence, which
  * backfills the brief subscription-gap window where a genuinely running chat's
  * store has not received its first snapshot yet (same rule as the per-chat icon
- * in `chat-progress-icon.tsx`). Stale awareness is handled by `candidateIds`
- * liveness, not by local idle.
+ * in `chat-progress-icon.tsx`).
  *
  * Everything else - a chat that was never opened, or one whose warm session was
  * evicted - is resolved from `activityTiers`, which reports `"turn"` for any
  * host that does not classify its agents. That keeps the pre-existing
- * conservative reading intact against an older host while letting a newer one
- * report background-only work accurately.
+ * conservative reading intact against an unclassified host while letting a
+ * classifying one report background-only work accurately.
+ *
+ * `candidateIds` is a LIVENESS filter over that fallback: an agent the epic's
+ * projection no longer holds must not keep a spinner alive. `null` means this
+ * window has NO session for the epic, so there is no projection to check
+ * against and the filter is skipped entirely - that is the never-opened epic
+ * the per-user activity room exists to cover, and filtering it against an
+ * empty set would put the original defect straight back. An empty SET is a
+ * different statement: a live projection that authoritatively holds no agents.
  */
 function getChatSessionActivity(
   epicId: string | null,
   activityTiers: ReadonlyMap<string, AgentActivityTier>,
-  candidateIds: ReadonlySet<string>,
+  candidateIds: ReadonlySet<string> | null,
 ): EpicActivityStatus {
   if (epicId === null) return "idle";
   let hasBackgroundActivity = false;
   const locallyResolvedAgentIds = new Set<string>();
-  for (const handle of CHAT_REGISTRY.listHandles()) {
-    if (handle.epicId !== epicId) continue;
-    if (!candidateIds.has(handle.chatId)) continue;
-    const activity = chatSessionActivity(handle.store.getState());
-    if (activity === "turn") return "turn";
-    if (activity === "background") {
-      hasBackgroundActivity = true;
-      locallyResolvedAgentIds.add(handle.chatId);
+  if (candidateIds !== null) {
+    for (const handle of CHAT_REGISTRY.listHandles()) {
+      if (handle.epicId !== epicId) continue;
+      if (!candidateIds.has(handle.chatId)) continue;
+      const activity = chatSessionActivity(handle.store.getState());
+      if (activity === "turn") return "turn";
+      if (activity === "background") {
+        hasBackgroundActivity = true;
+        locallyResolvedAgentIds.add(handle.chatId);
+      }
     }
   }
   for (const [agentId, tier] of activityTiers) {
-    if (!candidateIds.has(agentId)) continue;
+    if (candidateIds !== null && !candidateIds.has(agentId)) continue;
     if (locallyResolvedAgentIds.has(agentId)) continue;
     if (tier === "turn") return "turn";
     hasBackgroundActivity = true;
@@ -96,10 +105,12 @@ function getChatSessionActivity(
 /** Subscribes only to live chats in `candidateIds` belonging to this epic. */
 function subscribeChatSessionActivity(
   epicId: string | null,
-  candidateIds: ReadonlySet<string>,
+  candidateIds: ReadonlySet<string> | null,
   onChange: () => void,
 ): () => void {
-  if (epicId === null || candidateIds.size === 0) return noopUnsubscribe;
+  if (epicId === null || candidateIds === null || candidateIds.size === 0) {
+    return noopUnsubscribe;
+  }
   const handleSubs = new Map<ChatSessionStoreHandle, () => void>();
 
   const resync = (): void => {

--- a/clients/gui-app/src/lib/__tests__/agent-activity-tiers-awareness.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/agent-activity-tiers-awareness.test.tsx
@@ -1,111 +1,61 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { act, renderHook } from "@testing-library/react";
-import {
-  AGENT_WORKING_AWARENESS_FIELD,
-  AGENT_WORKING_TURN_AWARENESS_FIELD,
-} from "@traycer/protocol/host/epic/subscribe";
 import { useRegisteredEpicAgentActivityTiers } from "@/lib/epic-selectors";
-import { __getOpenEpicRegistryForTests } from "@/lib/registries/epic-session-registry";
-import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
+import {
+  publishAgentActivity,
+  resetAgentActivityPresence,
+  type AgentActivityHostEntry,
+} from "@/__tests__/agent-activity-presence-harness";
 
 const EPIC_ID = "epic-awareness";
+const OTHER_EPIC_ID = "epic-other";
 
 /**
- * One awareness entry per host, exactly as the cloud merges them. Each entry
- * independently decides whether it carries the turn field, which is the whole
- * point of these tests: mixed shapes are the steady state, not a rollout
- * window.
+ * One awareness entry per host on the per-user notification room, exactly as
+ * the cloud merges them. Each entry independently decides whether it carries a
+ * usable `turn` list, which is the whole point of these tests: mixed shapes are
+ * the steady state, not a rollout window.
+ *
+ * The epic this suite asserts on is never opened in this window - no session,
+ * no per-epic collaboration room - so every reading here comes from the global
+ * source alone. That is the defect the per-user room exists to fix.
  */
 type HostEntry = {
   readonly working: unknown;
   readonly turn: unknown;
 };
 
-function awarenessStates(
-  entries: readonly HostEntry[],
-): Map<number, Record<string, unknown>> {
-  return new Map<number, Record<string, unknown>>(
-    entries.map((entry, index) => [
-      index,
-      entry.turn === undefined
-        ? { [AGENT_WORKING_AWARENESS_FIELD]: entry.working }
-        : {
-            [AGENT_WORKING_AWARENESS_FIELD]: entry.working,
-            [AGENT_WORKING_TURN_AWARENESS_FIELD]: entry.turn,
-          },
-    ]),
-  );
-}
-
-/**
- * A real emitter, not a no-op stub: `on`/`off` register listeners and
- * `publish` fires them, so a test can mutate awareness and assert the hook
- * re-subscribes, recomputes, and re-renders - covering the subscription wiring
- * and not just the first snapshot.
- */
-function buildAwarenessEmitter(initial: readonly HostEntry[]) {
-  const listeners = new Set<() => void>();
-  let states = awarenessStates(initial);
-  let onCalls = 0;
-  let offCalls = 0;
-  return {
-    awareness: {
-      getStates: () => states,
-      on: (_event: string, listener: () => void) => {
-        onCalls += 1;
-        listeners.add(listener);
-      },
-      off: (_event: string, listener: () => void) => {
-        offCalls += 1;
-        listeners.delete(listener);
-      },
+function entriesFor(
+  hosts: readonly HostEntry[],
+): readonly AgentActivityHostEntry[] {
+  return hosts.map((host, index) => ({
+    hostId: `host-${index}`,
+    byEpic: {
+      [EPIC_ID]:
+        host.turn === undefined
+          ? { working: host.working }
+          : { working: host.working, turn: host.turn },
     },
-    publish: (next: readonly HostEntry[]) => {
-      states = awarenessStates(next);
-      for (const listener of listeners) listener();
-    },
-    subscribeBalance: () => ({ onCalls, offCalls }),
-  };
+  }));
 }
 
-function buildEpicHandle(awareness: unknown): OpenEpicStoreHandle {
-  const state = { bindingVersion: 0 };
-  const storeCallable = (_selector: unknown): unknown => state;
-  const storeBase: unknown = Object.assign(storeCallable, {
-    getState: () => state as never,
-    subscribe: () => () => undefined,
-  });
-  return {
-    epicId: EPIC_ID,
-    userId: null,
-    doc: {} as never,
-    awareness: awareness as never,
-    store: storeBase as OpenEpicStoreHandle["store"],
-    dispose: () => undefined,
-    requestFreshSnapshot: () => undefined,
-    isClean: () => true,
-  };
+function publish(hosts: readonly HostEntry[]): void {
+  publishAgentActivity(entriesFor(hosts));
 }
 
-function renderTiers(entries: readonly HostEntry[]) {
-  const emitter = buildAwarenessEmitter(entries);
-  __getOpenEpicRegistryForTests().acquire(EPIC_ID, () =>
-    buildEpicHandle(emitter.awareness),
-  );
-  return {
-    ...renderHook(() => useRegisteredEpicAgentActivityTiers(EPIC_ID)),
-    emitter,
-  };
+function renderTiers(hosts: readonly HostEntry[]) {
+  publish(hosts);
+  return renderHook(() => useRegisteredEpicAgentActivityTiers(EPIC_ID));
 }
 
 afterEach(() => {
-  __getOpenEpicRegistryForTests().disposeAll();
+  resetAgentActivityPresence();
 });
 
-describe("agent activity tiers from awareness", () => {
+describe("agent activity tiers from notification-room presence", () => {
   it("resolves every working id to 'turn' for a host that omits the turn field", () => {
-    // An older host: no `agentWorkingTurn` at all. Its agents are unclassified,
-    // so they must keep the pre-existing conservative reading.
+    // An unclassified host: no `turn` list at all. Its agents keep the
+    // pre-existing conservative reading.
     const { result } = renderTiers([{ working: ["a", "b"], turn: undefined }]);
     expect(result.current.get("a")).toBe("turn");
     expect(result.current.get("b")).toBe("turn");
@@ -124,9 +74,9 @@ describe("agent activity tiers from awareness", () => {
   });
 
   it("applies the absence rule per host, not globally", () => {
-    // Old host and new host visible at the same time. The old host's agent
-    // must NOT be downgraded to background just because another host
-    // publishes the field.
+    // An unclassified host and a classifying host visible at the same time. The
+    // unclassified one's agent must NOT be downgraded to background just
+    // because another host publishes the field.
     const { result } = renderTiers([
       { working: ["old"], turn: undefined },
       { working: ["new-turn", "new-bg"], turn: ["new-turn"] },
@@ -144,13 +94,47 @@ describe("agent activity tiers from awareness", () => {
     expect(result.current.get("shared")).toBe("turn");
   });
 
-  it("ignores entries whose agentWorking is not an array", () => {
+  it("ignores entries whose activity field is not an object", () => {
+    publishAgentActivity([
+      { hostId: "host-broken", byEpic: "not an object" },
+      { hostId: "host-ok", byEpic: { [EPIC_ID]: { working: ["real"] } } },
+    ]);
+    const { result } = renderHook(() =>
+      useRegisteredEpicAgentActivityTiers(EPIC_ID),
+    );
+    expect(result.current.get("real")).toBe("turn");
+    expect(result.current.size).toBe(1);
+  });
+
+  it("ignores buckets whose working list is not an array", () => {
     const { result } = renderTiers([
       { working: { not: "an array" }, turn: ["x"] },
       { working: ["real"], turn: undefined },
     ]);
     expect(result.current.has("x")).toBe(false);
     expect(result.current.get("real")).toBe("turn");
+  });
+
+  it("skips only the malformed bucket, not the host's other epics", () => {
+    // Rule 3 of the frozen shape: one bad bucket must not blank out the rest of
+    // the SAME host's map.
+    publishAgentActivity([
+      {
+        hostId: "host-mixed",
+        byEpic: {
+          [EPIC_ID]: "garbage",
+          [OTHER_EPIC_ID]: { working: ["healthy"], turn: ["healthy"] },
+        },
+      },
+    ]);
+    const broken = renderHook(() =>
+      useRegisteredEpicAgentActivityTiers(EPIC_ID),
+    );
+    const healthy = renderHook(() =>
+      useRegisteredEpicAgentActivityTiers(OTHER_EPIC_ID),
+    );
+    expect(broken.result.current.size).toBe(0);
+    expect(healthy.result.current.get("healthy")).toBe("turn");
   });
 
   it("ignores a malformed turn field by falling back to 'turn'", () => {
@@ -168,38 +152,81 @@ describe("agent activity tiers from awareness", () => {
     expect(result.current.get("a")).toBe("turn");
   });
 
-  it("re-renders with the new tier when awareness changes", () => {
-    // Drives the real subscription path: the hook must re-read the snapshot on
-    // an awareness "change" event, not just on first render.
-    const { result, emitter } = renderTiers([{ working: ["a"], turn: ["a"] }]);
+  it("reads idle for an epic no host reports", () => {
+    const { result } = renderTiers([{ working: ["a"], turn: ["a"] }]);
+    const other = renderHook(() =>
+      useRegisteredEpicAgentActivityTiers(OTHER_EPIC_ID),
+    );
+    expect(result.current.size).toBe(1);
+    expect(other.result.current.size).toBe(0);
+  });
+
+  it("re-renders with the new tier when presence changes", () => {
+    // Drives the real subscription path: the hook must re-read on an inbound
+    // awareness frame, not just on first render.
+    const { result } = renderTiers([{ working: ["a"], turn: ["a"] }]);
     expect(result.current.get("a")).toBe("turn");
 
     // The turn ends but a background task keeps the agent working.
     act(() => {
-      emitter.publish([{ working: ["a"], turn: [] }]);
+      publish([{ working: ["a"], turn: [] }]);
     });
     expect(result.current.get("a")).toBe("background");
 
     // The agent goes fully idle.
     act(() => {
-      emitter.publish([{ working: [], turn: [] }]);
+      publish([{ working: [], turn: [] }]);
     });
     expect(result.current.has("a")).toBe(false);
   });
 
+  it("clears an epic's tiers when the publishing host drops out", () => {
+    // A host that dies or disconnects ages out of awareness; its spinners must
+    // clear with no cleanup protocol.
+    const { result } = renderTiers([{ working: ["a"], turn: ["a"] }]);
+    expect(result.current.get("a")).toBe("turn");
+    act(() => {
+      publishAgentActivity([]);
+    });
+    expect(result.current.size).toBe(0);
+  });
+
   it("keeps the same Map ref when a change leaves tiers untouched", () => {
-    // Ref stability is what lets useSyncExternalStore bail the re-render; an
-    // unrelated awareness event must not churn every consumer.
-    const { result, emitter } = renderTiers([{ working: ["a"], turn: ["a"] }]);
+    // Ref stability is what lets a consumer bail the re-render; an unrelated
+    // presence event must not churn every indicator.
+    const { result } = renderTiers([{ working: ["a"], turn: ["a"] }]);
     const first = result.current;
     act(() => {
-      emitter.publish([{ working: ["a"], turn: ["a"] }]);
+      publish([{ working: ["a"], turn: ["a"] }]);
     });
     expect(result.current).toBe(first);
   });
 
-  it("subscribes to awareness while mounted", () => {
-    const { emitter } = renderTiers([{ working: ["a"], turn: ["a"] }]);
-    expect(emitter.subscribeBalance().onCalls).toBeGreaterThan(0);
+  it("keeps one epic's slice stable while another epic changes", () => {
+    publishAgentActivity([
+      {
+        hostId: "host-0",
+        byEpic: {
+          [EPIC_ID]: { working: ["a"], turn: ["a"] },
+          [OTHER_EPIC_ID]: { working: ["b"], turn: ["b"] },
+        },
+      },
+    ]);
+    const { result } = renderHook(() =>
+      useRegisteredEpicAgentActivityTiers(EPIC_ID),
+    );
+    const first = result.current;
+    act(() => {
+      publishAgentActivity([
+        {
+          hostId: "host-0",
+          byEpic: {
+            [EPIC_ID]: { working: ["a"], turn: ["a"] },
+            [OTHER_EPIC_ID]: { working: [], turn: [] },
+          },
+        },
+      ]);
+    });
+    expect(result.current).toBe(first);
   });
 });

--- a/clients/gui-app/src/lib/epic-selectors.ts
+++ b/clients/gui-app/src/lib/epic-selectors.ts
@@ -36,10 +36,6 @@ import type {
 } from "@traycer/protocol/persistence/epic/schemas";
 import type { WorktreeBindingOwnerKind } from "@traycer/protocol/host/worktree-schemas";
 import type { SnapshotMetaEpic } from "@traycer/protocol/host/epic/snapshot-meta";
-import {
-  AGENT_WORKING_AWARENESS_FIELD,
-  AGENT_WORKING_TURN_AWARENESS_FIELD,
-} from "@traycer/protocol/host/epic/subscribe";
 import type { StreamConnectionStatus } from "@traycer-clients/shared/host-transport/i-stream-session";
 import type { HostClient } from "@traycer-clients/shared/host-client/host-client";
 import type { HostRpcRegistry } from "@/lib/host";
@@ -49,6 +45,11 @@ import {
   type EpicHostDirtyState,
   type EpicSyncPillState,
 } from "@/lib/epic-sync-pill-state";
+import {
+  agentActivityTiers,
+  type AgentActivityTier,
+} from "@/lib/notifications/agent-activity-presence";
+import { useEpicAgentActivity } from "@/stores/notifications/notifications-store";
 import { useEpicStore } from "@/hooks/use-epic-store";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
@@ -783,135 +784,37 @@ export function useEpicDocBinding(): {
   return { doc: handle.doc, awareness: handle.awareness };
 }
 
-// ─── Agent activity (awareness-derived; NOT projected, per EPIC_PROJECTOR) ──
+// ─── Agent activity (per-user notification-room presence) ─────────────────
+//
+// The source is the awareness replica on `notifications:<userId>` - the room
+// every signed-in client subscribes to app-wide - NOT the per-epic
+// collaboration room. That is what makes these hooks correct for an epic this
+// window has never opened: the old per-epic reader could only see hosts whose
+// epic room this client had joined, so the task list, epics panel and tab strip
+// all read idle for a working agent in an epic that was never opened.
+//
+// Membership and tier semantics are unchanged from the retired per-epic fields
+// - see `agent-activity-presence.ts` for the frozen-shape reader rules - so
+// every consumer keeps reading exactly what it read before, from a source that
+// now covers the whole user rather than this window's open sessions.
 
-const EMPTY_ACTIVE_AGENT_IDS: ReadonlySet<string> = new Set<string>();
+export type { AgentActivityTier };
 
-const activeAgentIdsCache = new WeakMap<
-  Awareness,
-  { readonly ids: ReadonlySet<string>; readonly key: string }
->();
-
-/**
- * Live-activity tier of a working agent, as published by its host. See
- * {@link AGENT_WORKING_TURN_AWARENESS_FIELD}: hosts that do not publish the
- * turn field leave their agents' tier unknown, which reads as `"turn"`.
- */
-export type AgentActivityTier = "turn" | "background";
-
-const EMPTY_AGENT_ACTIVITY_TIERS: ReadonlyMap<string, AgentActivityTier> =
-  new Map<string, AgentActivityTier>();
-
-const agentActivityTiersCache = new WeakMap<
-  Awareness,
-  {
-    readonly tiers: ReadonlyMap<string, AgentActivityTier>;
-    readonly key: string;
-  }
->();
 const registeredLiveAgentIdsCache = new WeakMap<
   OpenEpicStoreHandle,
   { readonly ids: ReadonlySet<string>; readonly key: string }
 >();
 
 /**
- * Unions the `agentWorking` ids across every awareness entry (each host
- * publishes one). Returns the prior Set ref when membership is unchanged so
- * `useSyncExternalStore` sees a referentially-stable snapshot.
- */
-function activeAgentIdsSnapshot(awareness: Awareness): ReadonlySet<string> {
-  const ids = new Set<string>();
-  for (const state of awareness.getStates().values()) {
-    const working: unknown = state[AGENT_WORKING_AWARENESS_FIELD];
-    if (!Array.isArray(working)) continue;
-    for (const id of working as readonly unknown[]) {
-      if (typeof id === "string") ids.add(id);
-    }
-  }
-  const key = [...ids].sort().join(" ");
-  const cached = activeAgentIdsCache.get(awareness);
-  if (cached !== undefined && cached.key === key) return cached.ids;
-  const entry = { ids, key };
-  activeAgentIdsCache.set(awareness, entry);
-  return entry.ids;
-}
-
-/**
- * Same union as {@link activeAgentIdsSnapshot}, but resolving each working
- * agent to its {@link AgentActivityTier}.
- *
- * The turn field is read PER AWARENESS ENTRY (one entry per host) because its
- * presence is per-host, and mixed shapes are the steady state rather than a
- * rollout window - see `AGENT_WORKING_TURN_AWARENESS_FIELD`. A host that omits
- * it has not classified its agents, so they stay `"turn"` (the conservative
- * pre-existing reading); a host that publishes it is authoritative, so its
- * working ids absent from that list are genuinely background-only.
- *
- * `"turn"` wins when the same agent appears under two hosts. Returns the prior
- * Map ref while membership AND tiers are unchanged so `useSyncExternalStore`
- * sees a referentially-stable snapshot.
- */
-function agentActivityTiersSnapshot(
-  awareness: Awareness,
-): ReadonlyMap<string, AgentActivityTier> {
-  const tiers = new Map<string, AgentActivityTier>();
-  for (const state of awareness.getStates().values()) {
-    const working: unknown = state[AGENT_WORKING_AWARENESS_FIELD];
-    if (!Array.isArray(working)) continue;
-    const turnField: unknown = state[AGENT_WORKING_TURN_AWARENESS_FIELD];
-    const turnIds = Array.isArray(turnField)
-      ? new Set(
-          (turnField as readonly unknown[]).filter(
-            (id): id is string => typeof id === "string",
-          ),
-        )
-      : null;
-    for (const id of working as readonly unknown[]) {
-      if (typeof id !== "string") continue;
-      const tier: AgentActivityTier =
-        turnIds === null || turnIds.has(id) ? "turn" : "background";
-      if (tier === "turn" || !tiers.has(id)) tiers.set(id, tier);
-    }
-  }
-  const key = [...tiers.entries()]
-    .map(([id, tier]) => `${id}:${tier}`)
-    .sort()
-    .join(" ");
-  const cached = agentActivityTiersCache.get(awareness);
-  if (cached !== undefined && cached.key === key) return cached.tiers;
-  const entry = { tiers, key };
-  agentActivityTiersCache.set(awareness, entry);
-  return entry.tiers;
-}
-
-/**
  * The set of agents currently "working" (executing right now) anywhere in the
- * epic, unioned across every host's awareness `agentWorking` entry - so it is
- * cross-host and reactive (re-renders when any host's working set changes).
- * Replaces the `agent.list` 2s poll for the Active Agents / stop panels.
+ * epic, unioned across every host publishing into the user's notification room
+ * - so it is cross-host and reactive (re-renders when any host's working set
+ * changes). Replaces the `agent.list` 2s poll for the Active Agents / stop
+ * panels.
  */
 export function useEpicActiveAgentIds(): ReadonlySet<string> {
-  const handle = useOpenEpicHandle();
-  useStore(handle.store, (s) => s.bindingVersion); // re-resolve on replica swap
-  const awareness = handle.awareness;
-  const subscribe = useMemo(
-    () => (onChange: () => void) => {
-      awareness.on("change", onChange);
-      return () => {
-        awareness.off("change", onChange);
-      };
-    },
-    [awareness],
-  );
-  const getSnapshot = useMemo(
-    () => () => activeAgentIdsSnapshot(awareness),
-    [awareness],
-  );
-  return useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    () => EMPTY_ACTIVE_AGENT_IDS,
-  );
+  const epicId = useOpenEpicHandle().epicId;
+  return useEpicAgentActivity(epicId).working;
 }
 
 /**
@@ -923,123 +826,47 @@ export function useEpicAgentActivityTiers(): ReadonlyMap<
   string,
   AgentActivityTier
 > {
-  const handle = useOpenEpicHandle();
-  useStore(handle.store, (s) => s.bindingVersion); // re-resolve on replica swap
-  const awareness = handle.awareness;
-  const subscribe = useMemo(
-    () => (onChange: () => void) => {
-      awareness.on("change", onChange);
-      return () => {
-        awareness.off("change", onChange);
-      };
-    },
-    [awareness],
-  );
-  const getSnapshot = useMemo(
-    () => () => agentActivityTiersSnapshot(awareness),
-    [awareness],
-  );
-  return useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    () => EMPTY_AGENT_ACTIVITY_TIERS,
-  );
+  const epicId = useOpenEpicHandle().epicId;
+  return agentActivityTiers(useEpicAgentActivity(epicId));
 }
 
+/**
+ * {@link useEpicActiveAgentIds} for surfaces that render outside the open-epic
+ * provider (epic tabs, the epics panel, the task list). It no longer resolves a
+ * registered session handle - presence for an epic no longer depends on this
+ * window having a session for it - but the name is kept so these call sites
+ * still read as a set with their `useRegisteredEpic*` neighbours.
+ */
 export function useRegisteredEpicActiveAgentIds(
   epicId: string | null,
 ): ReadonlySet<string> {
-  const registry = getOpenEpicRegistry();
-  const handle = useSyncExternalStore(
-    (listener) => registry.subscribe(listener),
-    () => (epicId === null ? null : registry.peek(epicId)),
-    () => null,
-  );
-  useSyncExternalStore(
-    (listener) =>
-      handle?.store.subscribe((state, prev) => {
-        if (state.bindingVersion === prev.bindingVersion) return;
-        listener();
-      }) ?? noopSubscribe,
-    () => handle?.store.getState().bindingVersion ?? 0,
-    () => 0,
-  );
-  const awareness = handle?.awareness ?? null;
-  const subscribe = useMemo(
-    () => (onChange: () => void) => {
-      if (awareness === null) return noopUnsubscribe;
-      awareness.on("change", onChange);
-      return () => {
-        awareness.off("change", onChange);
-      };
-    },
-    [awareness],
-  );
-  const getSnapshot = useMemo(
-    () => () =>
-      awareness === null
-        ? EMPTY_ACTIVE_AGENT_IDS
-        : activeAgentIdsSnapshot(awareness),
-    [awareness],
-  );
-  return useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    () => EMPTY_ACTIVE_AGENT_IDS,
-  );
+  return useEpicAgentActivity(epicId).working;
 }
 
 /**
  * {@link useRegisteredEpicActiveAgentIds} with each working agent resolved to
- * its {@link AgentActivityTier}, for surfaces that run outside the open-epic
- * provider (epic tabs, the epic list).
+ * its {@link AgentActivityTier}.
  */
 export function useRegisteredEpicAgentActivityTiers(
   epicId: string | null,
 ): ReadonlyMap<string, AgentActivityTier> {
-  const registry = getOpenEpicRegistry();
-  const handle = useSyncExternalStore(
-    (listener) => registry.subscribe(listener),
-    () => (epicId === null ? null : registry.peek(epicId)),
-    () => null,
-  );
-  useSyncExternalStore(
-    (listener) =>
-      handle?.store.subscribe((state, prev) => {
-        if (state.bindingVersion === prev.bindingVersion) return;
-        listener();
-      }) ?? noopSubscribe,
-    () => handle?.store.getState().bindingVersion ?? 0,
-    () => 0,
-  );
-  const awareness = handle?.awareness ?? null;
-  const subscribe = useMemo(
-    () => (onChange: () => void) => {
-      if (awareness === null) return noopUnsubscribe;
-      awareness.on("change", onChange);
-      return () => {
-        awareness.off("change", onChange);
-      };
-    },
-    [awareness],
-  );
-  const getSnapshot = useMemo(
-    () => () =>
-      awareness === null
-        ? EMPTY_AGENT_ACTIVITY_TIERS
-        : agentActivityTiersSnapshot(awareness),
-    [awareness],
-  );
-  return useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    () => EMPTY_AGENT_ACTIVITY_TIERS,
-  );
+  return agentActivityTiers(useEpicAgentActivity(epicId));
 }
 
+/**
+ * The agent ids this epic's live projection currently holds, or `null` when
+ * this window has no session for the epic at all.
+ *
+ * The `null` arm is load-bearing, and is why this does not simply return an
+ * empty set: an epic with a session and no agents is authoritatively empty,
+ * while an epic with no session is UNKNOWN. Callers use this as a liveness
+ * filter over host-published presence, and filtering an unknown epic by an
+ * empty set is exactly the bug the per-user activity room removes - an agent
+ * working in an epic this window never opened would read idle again.
+ */
 export function useRegisteredEpicLiveAgentIds(
   epicId: string | null,
-): ReadonlySet<string> {
+): ReadonlySet<string> | null {
   const registry = getOpenEpicRegistry();
   const handle = useSyncExternalStore(
     (listener) => registry.subscribe(listener),
@@ -1049,14 +876,14 @@ export function useRegisteredEpicLiveAgentIds(
   return useSyncExternalStore(
     (listener) => handle?.store.subscribe(listener) ?? noopSubscribe,
     () => liveAgentIdsSnapshot(handle),
-    () => EMPTY_ACTIVE_AGENT_IDS,
+    () => null,
   );
 }
 
 function liveAgentIdsSnapshot(
   handle: OpenEpicStoreHandle | null,
-): ReadonlySet<string> {
-  if (handle === null) return EMPTY_ACTIVE_AGENT_IDS;
+): ReadonlySet<string> | null {
+  if (handle === null) return null;
   const state = handle.store.getState();
   const key = [...state.chats.allIds, ...state.tuiAgents.allIds]
     .sort()

--- a/clients/gui-app/src/lib/notifications/agent-activity-presence.ts
+++ b/clients/gui-app/src/lib/notifications/agent-activity-presence.ts
@@ -1,0 +1,207 @@
+/**
+ * Reader for the agent-activity presence published on the per-user
+ * notification room (`notifications:<userId>`) - the cross-epic, cross-host
+ * source every activity indicator in the app reads.
+ *
+ * One awareness entry per host, merged by the cloud. The entry shape is FROZEN
+ * (see `AGENT_ACTIVITY_AWARENESS_FIELD` in the protocol) and rides an opaque
+ * binary payload outside `major`/`minor` negotiation, so this module never
+ * assumes a peer publishes anything: every field is shape-checked where it is
+ * read, and an unreadable piece degrades that piece alone.
+ *
+ * The four reader rules, all load-bearing:
+ *
+ * 1. Shape-check PER ENTRY: an entry whose activity field is not a plain
+ *    object is skipped whole. One malformed publisher must not blank out the
+ *    other hosts.
+ * 2. Shape-check PER EPIC BUCKET: a bucket whose `working` is not an array is
+ *    skipped, leaving the SAME host's other epics intact.
+ * 3. Absence is per-HOST: a bucket with no usable `turn` array has an UNKNOWN
+ *    tier, so its working ids degrade to turns (the conservative pre-existing
+ *    reading). A sibling host that does publish `turn` is unaffected.
+ * 4. Ids in `working` but not `turn` are genuinely background-only, and
+ *    `"turn"` wins when the same agent shows up under two hosts.
+ *
+ * An epicId absent from every entry's map is idle.
+ */
+import {
+  AGENT_ACTIVITY_AWARENESS_FIELD,
+  AGENT_ACTIVITY_HOST_ID_AWARENESS_FIELD,
+} from "@traycer/protocol/host/notifications/subscribe";
+
+/**
+ * Live-activity tier of a working agent, as classified by the host running it.
+ * A host that publishes no usable tier information leaves its agents unknown,
+ * which reads as `"turn"`.
+ */
+export type AgentActivityTier = "turn" | "background";
+
+/**
+ * One epic's slice of the cross-host union. `turn` is always a subset of
+ * `working`; ids in `working` alone are background-only. The unknown-tier
+ * degrade is already applied, so a consumer never has to know which host
+ * contributed which id.
+ */
+export interface EpicAgentActivity {
+  readonly working: ReadonlySet<string>;
+  readonly turn: ReadonlySet<string>;
+}
+
+const EMPTY_ID_SET: ReadonlySet<string> = new Set<string>();
+
+export const EMPTY_EPIC_AGENT_ACTIVITY: EpicAgentActivity = Object.freeze({
+  working: EMPTY_ID_SET,
+  turn: EMPTY_ID_SET,
+});
+
+export const EMPTY_AGENT_ACTIVITY_BY_EPIC: ReadonlyMap<
+  string,
+  EpicAgentActivity
+> = new Map<string, EpicAgentActivity>();
+
+export const EMPTY_AGENT_ACTIVITY_TIERS: ReadonlyMap<
+  string,
+  AgentActivityTier
+> = new Map<string, AgentActivityTier>();
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function collectStringIds(value: unknown, into: Set<string>): void {
+  for (const id of value as readonly unknown[]) {
+    if (typeof id === "string") into.add(id);
+  }
+}
+
+interface MutableEpicActivity {
+  readonly working: Set<string>;
+  readonly turn: Set<string>;
+}
+
+/**
+ * Folds every awareness entry into `epicId -> {working, turn}`.
+ *
+ * `previous` is the last result this reader produced; buckets whose membership
+ * is byte-for-byte unchanged are returned by REFERENCE, and an entirely
+ * unchanged union returns `previous` itself. Consumers subscribe through
+ * per-epic selectors, so identity reuse is what stops one host's unrelated
+ * epic from re-rendering every other epic's indicator.
+ */
+export function readAgentActivityByEpic(
+  states: Iterable<Record<string, unknown>>,
+  previous: ReadonlyMap<string, EpicAgentActivity>,
+): ReadonlyMap<string, EpicAgentActivity> {
+  const merged = new Map<string, MutableEpicActivity>();
+  for (const state of states) {
+    // Rule 1: per-entry shape check. `agentActivityHostId` is optional by
+    // design and is never a key or a filter - an entry missing it is still a
+    // valid activity entry.
+    const byEpic: unknown = state[AGENT_ACTIVITY_AWARENESS_FIELD];
+    if (!isPlainObject(byEpic)) continue;
+    for (const epicId of Object.keys(byEpic)) {
+      // Rule 2: per-bucket shape check, skipping only the offending bucket.
+      const bucket: unknown = byEpic[epicId];
+      if (!isPlainObject(bucket)) continue;
+      const working: unknown = bucket.working;
+      if (!Array.isArray(working)) continue;
+      let slot = merged.get(epicId);
+      if (slot === undefined) {
+        slot = { working: new Set<string>(), turn: new Set<string>() };
+        merged.set(epicId, slot);
+      }
+      mergeBucket(slot, working, bucket.turn);
+    }
+  }
+  return reconcileWithPrevious(merged, previous);
+}
+
+/**
+ * Folds one host's bucket for one epic into the accumulating union.
+ *
+ * `turn` decides the tier rule: an array means this host classified its agents,
+ * so working-minus-turn is genuinely background-only (rule 4); anything else
+ * (absent, or malformed) means an UNKNOWN tier for this host alone, so its
+ * working ids degrade to turns (rule 3). `"turn"` therefore wins whenever any
+ * host reports the agent as one.
+ */
+function mergeBucket(
+  slot: MutableEpicActivity,
+  working: unknown,
+  turnField: unknown,
+): void {
+  const classified = Array.isArray(turnField) ? new Set<string>() : null;
+  if (classified !== null) collectStringIds(turnField, classified);
+  for (const id of working as readonly unknown[]) {
+    if (typeof id !== "string") continue;
+    slot.working.add(id);
+    if (classified === null || classified.has(id)) slot.turn.add(id);
+  }
+}
+
+function reconcileWithPrevious(
+  merged: ReadonlyMap<string, MutableEpicActivity>,
+  previous: ReadonlyMap<string, EpicAgentActivity>,
+): ReadonlyMap<string, EpicAgentActivity> {
+  if (merged.size === 0) {
+    return previous.size === 0 ? previous : EMPTY_AGENT_ACTIVITY_BY_EPIC;
+  }
+  const next = new Map<string, EpicAgentActivity>();
+  let changed = merged.size !== previous.size;
+  for (const [epicId, slot] of merged) {
+    const prior = previous.get(epicId);
+    if (
+      prior !== undefined &&
+      sameIdSet(prior.working, slot.working) &&
+      sameIdSet(prior.turn, slot.turn)
+    ) {
+      next.set(epicId, prior);
+      continue;
+    }
+    changed = true;
+    next.set(epicId, { working: slot.working, turn: slot.turn });
+  }
+  return changed ? next : previous;
+}
+
+function sameIdSet(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const id of a) {
+    if (!b.has(id)) return false;
+  }
+  return true;
+}
+
+const tiersCache = new WeakMap<
+  EpicAgentActivity,
+  ReadonlyMap<string, AgentActivityTier>
+>();
+
+/**
+ * Projects one epic's activity to `agentId -> tier`. Cached on the activity
+ * object's identity, so a consumer reading tiers gets the same Map back for as
+ * long as its epic's slice is unchanged.
+ */
+export function agentActivityTiers(
+  activity: EpicAgentActivity,
+): ReadonlyMap<string, AgentActivityTier> {
+  if (activity.working.size === 0) return EMPTY_AGENT_ACTIVITY_TIERS;
+  const cached = tiersCache.get(activity);
+  if (cached !== undefined) return cached;
+  const tiers = new Map<string, AgentActivityTier>();
+  for (const id of activity.working) {
+    tiers.set(id, activity.turn.has(id) ? "turn" : "background");
+  }
+  tiersCache.set(activity, tiers);
+  return tiers;
+}
+
+/**
+ * The awareness fields this reader understands, re-exported so a test (or a
+ * future publisher-side check) names the same constants the protocol froze
+ * rather than re-typing the string literals.
+ */
+export {
+  AGENT_ACTIVITY_AWARENESS_FIELD,
+  AGENT_ACTIVITY_HOST_ID_AWARENESS_FIELD,
+};

--- a/clients/gui-app/src/lib/notifications/agent-activity-presence.ts
+++ b/clients/gui-app/src/lib/notifications/agent-activity-presence.ts
@@ -68,8 +68,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function collectStringIds(value: unknown, into: Set<string>): void {
-  for (const id of value as readonly unknown[]) {
+function collectStringIds(value: readonly unknown[], into: Set<string>): void {
+  for (const id of value) {
     if (typeof id === "string") into.add(id);
   }
 }
@@ -127,12 +127,18 @@ export function readAgentActivityByEpic(
  */
 function mergeBucket(
   slot: MutableEpicActivity,
-  working: unknown,
+  working: readonly unknown[],
   turnField: unknown,
 ): void {
-  const classified = Array.isArray(turnField) ? new Set<string>() : null;
-  if (classified !== null) collectStringIds(turnField, classified);
-  for (const id of working as readonly unknown[]) {
+  // Narrow inside the guard: `Array.isArray` only refines `turnField` within
+  // this block, so collecting here is what lets `collectStringIds` take a typed
+  // array instead of re-asserting one.
+  let classified: Set<string> | null = null;
+  if (Array.isArray(turnField)) {
+    classified = new Set<string>();
+    collectStringIds(turnField, classified);
+  }
+  for (const id of working) {
     if (typeof id !== "string") continue;
     slot.working.add(id);
     if (classified === null || classified.has(id)) slot.turn.add(id);

--- a/clients/gui-app/src/stores/epics/open-epic/__tests__/session-registry.test.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/__tests__/session-registry.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  publishAgentActivity,
+  resetAgentActivityPresence,
+} from "@/__tests__/agent-activity-presence-harness";
 import { OpenEpicSessionRegistry } from "@/stores/epics/open-epic/session-registry";
 import {
   createOpenEpicStore,
@@ -105,6 +108,11 @@ function buildTestHandle(id: string, clean: boolean): TestHandle {
 function h(t: TestHandle): OpenEpicStoreHandle {
   return t.handle;
 }
+
+afterEach(() => {
+  workingByEpic.clear();
+  resetAgentActivityPresence();
+});
 
 describe("OpenEpicSessionRegistry", () => {
   it("evicts the LRU clean entry when adding a sixth session", () => {
@@ -308,14 +316,32 @@ describe("OpenEpicSessionRegistry", () => {
   });
 });
 
+/**
+ * Prune eligibility now rides the per-user notification room's presence, not
+ * the epic's own collaboration awareness, so these helpers publish one host
+ * entry covering every epic that currently has work. Publishing the whole set
+ * each time mirrors the host, which republishes its full entry on every
+ * activity boundary.
+ */
+const workingByEpic = new Map<string, readonly string[]>();
+
+function publishWorkingSet(): void {
+  const byEpic: Record<
+    string,
+    { working: readonly string[]; turn: readonly string[] }
+  > = {};
+  for (const [epicId, agentIds] of workingByEpic) {
+    byEpic[epicId] = { working: agentIds, turn: agentIds };
+  }
+  publishAgentActivity([{ hostId: "host-registry", byEpic }]);
+}
+
 function markAgentWorking(handle: TestHandle, agentId: string): void {
-  handle.handle.awareness.setLocalState({
-    [AGENT_WORKING_AWARENESS_FIELD]: [agentId],
-  });
+  workingByEpic.set(handle.handle.epicId, [agentId]);
+  publishWorkingSet();
 }
 
 function clearAgentWorking(handle: TestHandle): void {
-  handle.handle.awareness.setLocalState({
-    [AGENT_WORKING_AWARENESS_FIELD]: [],
-  });
+  workingByEpic.set(handle.handle.epicId, []);
+  publishWorkingSet();
 }

--- a/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
+++ b/clients/gui-app/src/stores/epics/open-epic/session-registry.ts
@@ -1,7 +1,10 @@
 import type { OpenEpicStoreHandle } from "@/stores/epics/open-epic/store";
 import { appLogger } from "@/lib/logger";
 import { useSyncExternalStore } from "react";
-import { AGENT_WORKING_AWARENESS_FIELD } from "@traycer/protocol/host/epic/subscribe";
+import {
+  getEpicAgentActivity,
+  subscribeAgentActivity,
+} from "@/stores/notifications/notifications-store";
 
 /**
  * MRU registry for live Epic sessions. Keeps up to 5 open in the background
@@ -32,6 +35,10 @@ interface RegistryEntry {
    * the underlying session is gone.
    */
   unsubscribe: (() => void) | null;
+  /**
+   * Unsubscribe from the cross-epic agent-activity presence signal that gates
+   * this entry's prune eligibility.
+   */
   unsubscribeAwareness: (() => void) | null;
   /**
    * Last-seen value of the only four store fields that affect prune
@@ -44,10 +51,13 @@ interface RegistryEntry {
   lastEligibilityKey: string;
 }
 
-function eligibilityKeyFor(handle: OpenEpicStoreHandle): string {
+function eligibilityKeyFor(
+  epicId: string,
+  handle: OpenEpicStoreHandle,
+): string {
   const state = handle.store.getState();
   const metaTitle = state.snapshotMeta?.epicLight?.title ?? "";
-  return `${handle.isClean() ? 1 : 0}:${hasActiveAgentWork(handle) ? 1 : 0}:${state.isDirty ? 1 : 0}:${state.unsyncedQueueSize}:${metaTitle}`;
+  return `${handle.isClean() ? 1 : 0}:${hasActiveAgentWork(epicId) ? 1 : 0}:${state.isDirty ? 1 : 0}:${state.unsyncedQueueSize}:${metaTitle}`;
 }
 
 /**
@@ -162,10 +172,10 @@ export class OpenEpicSessionRegistry {
       mountedRefs,
       unsubscribe: null,
       unsubscribeAwareness: null,
-      lastEligibilityKey: eligibilityKeyFor(handle),
+      lastEligibilityKey: eligibilityKeyFor(epicId, handle),
     };
     const handleEligibilityChange = (): void => {
-      const nextKey = eligibilityKeyFor(handle);
+      const nextKey = eligibilityKeyFor(epicId, handle);
       if (nextKey === entry.lastEligibilityKey) return;
       entry.lastEligibilityKey = nextKey;
       this.prune();
@@ -183,16 +193,13 @@ export class OpenEpicSessionRegistry {
       typeof maybeSubscribe === "function"
         ? maybeSubscribe.call(handle.store, handleEligibilityChange)
         : null;
-    entry.unsubscribeAwareness =
-      typeof handle.awareness.on === "function" &&
-      typeof handle.awareness.off === "function"
-        ? () => {
-            handle.awareness.off("change", handleEligibilityChange);
-          }
-        : null;
-    if (entry.unsubscribeAwareness !== null) {
-      handle.awareness.on("change", handleEligibilityChange);
-    }
+    // Agent activity is no longer carried by this epic's own awareness, so the
+    // guard re-evaluates off the per-user room instead. Same contract as
+    // before: an epic whose agents just started working must stop being
+    // prunable without waiting for an unrelated store write.
+    entry.unsubscribeAwareness = subscribeAgentActivity(
+      handleEligibilityChange,
+    );
     this.entries.set(epicId, entry);
     this.prune();
     this.emit();
@@ -284,7 +291,7 @@ export class OpenEpicSessionRegistry {
       if (this.entries.size <= this.maxLive) return;
       if (entry.mountedRefs > 0) continue;
       if (!entry.handle.isClean()) continue;
-      if (hasActiveAgentWork(entry.handle)) continue;
+      if (hasActiveAgentWork(entry.epicId)) continue;
       this.entries.delete(entry.epicId);
       this.disposeEntry(entry);
     }
@@ -303,14 +310,17 @@ export class OpenEpicSessionRegistry {
   }
 }
 
-function hasActiveAgentWork(handle: OpenEpicStoreHandle): boolean {
-  if (typeof handle.awareness.getStates !== "function") return false;
-  return Array.from(handle.awareness.getStates().values()).some((state) => {
-    const working: unknown = state[AGENT_WORKING_AWARENESS_FIELD];
-    return (
-      Array.isArray(working) && working.some((id) => typeof id === "string")
-    );
-  });
+/**
+ * Prune guard: never evict a session whose epic has an agent working on it.
+ *
+ * Reads the per-user notification room's activity presence rather than the
+ * epic's own collaboration awareness. Both answer the same question for a
+ * session that is open (which is all this guard ever asks about), but the room
+ * source needs no live epic subscription, so the guard keeps working through
+ * the window where an epic session is still attaching.
+ */
+function hasActiveAgentWork(epicId: string): boolean {
+  return getEpicAgentActivity(epicId).working.size > 0;
 }
 
 function resolveUnsyncedTitle(

--- a/clients/gui-app/src/stores/notifications/__tests__/notifications-activity-replica.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/notifications-activity-replica.test.ts
@@ -247,6 +247,21 @@ describe("notification-room activity replica", () => {
     // reader bound to it would leave one dead closure per reopen behind, each
     // retaining a retired instance's states and meta.
     const notificationsDoc = useNotificationsStore.getState().doc;
+
+    // Positive control. `_observers` is a lib0 `ObservableV2` implementation
+    // detail: if a yjs/lib0 update stopped tracking `destroy` there, every
+    // count below would read 0 and the leak assertion would pass vacuously.
+    // Proving the probe SEES a listener it just registered makes that failure
+    // mode loud instead of silent. There is no public API that distinguishes a
+    // fully retired reader from one whose closure is still held, so the
+    // internal read stays - guarded rather than trusted.
+    const probeDoc = new Y.Doc();
+    const probeBaseline = destroyListenerCount(probeDoc);
+    const probeAwareness = new Awareness(probeDoc);
+    expect(destroyListenerCount(probeDoc)).toBe(probeBaseline + 1);
+    probeAwareness.destroy();
+    probeDoc.destroy();
+
     const before = destroyListenerCount(notificationsDoc);
 
     for (let i = 0; i < 4; i += 1) {

--- a/clients/gui-app/src/stores/notifications/__tests__/notifications-activity-replica.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/notifications-activity-replica.test.ts
@@ -107,7 +107,13 @@ function encodeHostPresence(agentIds: readonly string[]): {
       [EPIC_ID]: { working: agentIds, turn: agentIds },
     },
   });
-  return { bytes: encodeAwarenessUpdate(producer, [producer.clientID]) };
+  const bytes = encodeAwarenessUpdate(producer, [producer.clientID]);
+  // One-shot: the bytes are captured, so the producer has no reason to outlive
+  // this call holding its renewal interval open. `createHostPresenceProducer`
+  // is the variant to reach for when a caller needs a persistent clientID.
+  producer.destroy();
+  doc.destroy();
+  return { bytes };
 }
 
 function workingIds(): ReadonlySet<string> {

--- a/clients/gui-app/src/stores/notifications/__tests__/notifications-activity-replica.test.ts
+++ b/clients/gui-app/src/stores/notifications/__tests__/notifications-activity-replica.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Lifecycle of the agent-activity awareness replica the per-user notification
+ * room feeds. Covers the two resets that keep it honest - identity teardown and
+ * a per-stream room reopen - plus the `@1.0` host case, where no `awareness`
+ * frame ever arrives.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { Awareness, encodeAwarenessUpdate } from "y-protocols/awareness";
+import * as Y from "yjs";
+import type { NotificationsStreamCallbacks } from "@traycer-clients/shared/host-transport/notifications-stream-client";
+import { AGENT_ACTIVITY_AWARENESS_FIELD } from "@/lib/notifications/agent-activity-presence";
+import {
+  __applyNotificationsAwarenessForTests,
+  __resetNotificationsStoreForTests,
+  openNotificationsStream,
+  useNotificationsStore,
+} from "@/stores/notifications/notifications-store";
+
+/**
+ * How many `destroy` listeners are registered on a Y.Doc. `Y.Doc` extends
+ * lib0's `ObservableV2`, whose `_observers` map is part of its published type,
+ * so this needs no cast - and it is the only observable that distinguishes
+ * "the retired reader was fully torn down" from "its closure is still held".
+ */
+function destroyListenerCount(target: Y.Doc): number {
+  return target._observers.get("destroy")?.size ?? 0;
+}
+
+const EPIC_ID = "epic-1";
+
+interface OpenedStream {
+  readonly callbacks: NotificationsStreamCallbacks;
+  readonly dispose: () => void;
+}
+
+function openStream(): OpenedStream {
+  const captured: { value: NotificationsStreamCallbacks | null } = {
+    value: null,
+  };
+  const dispose = openNotificationsStream((callbacks) => {
+    captured.value = callbacks;
+    return {
+      applyUpdate: () => undefined,
+      close: () => undefined,
+    };
+  }, null);
+  const callbacks = captured.value;
+  if (callbacks === null) throw new Error("factory was never invoked");
+  return { callbacks, dispose };
+}
+
+/**
+ * A persistent publishing host. Holding the producer (and therefore its
+ * clientId and awareness clock) across calls is what makes `replay()`
+ * meaningful: it re-ships the CURRENT state at the CURRENT clock, exactly as
+ * the host resolver's attach-time `emitExistingAwarenessStates` does. A test
+ * that builds a fresh producer per encode gets a brand-new clientId every time
+ * and can never catch a clock-rejection bug.
+ */
+interface HostPresenceProducer {
+  publish(agentIds: readonly string[]): Uint8Array;
+  replay(): Uint8Array;
+  /** A clean room disconnect: a null state at a bumped clock. */
+  disconnect(): Uint8Array;
+  destroy(): void;
+}
+
+function createHostPresenceProducer(): HostPresenceProducer {
+  const doc = new Y.Doc();
+  const producer = new Awareness(doc);
+  const encode = (): Uint8Array =>
+    encodeAwarenessUpdate(producer, [producer.clientID]);
+  return {
+    publish: (agentIds) => {
+      producer.setLocalState({
+        [AGENT_ACTIVITY_AWARENESS_FIELD]: {
+          [EPIC_ID]: { working: agentIds, turn: agentIds },
+        },
+      });
+      return encode();
+    },
+    replay: encode,
+    disconnect: () => {
+      producer.setLocalState(null);
+      return encode();
+    },
+    destroy: () => {
+      producer.destroy();
+      doc.destroy();
+    },
+  };
+}
+
+/**
+ * One host's presence, encoded exactly as it arrives on the wire so the test
+ * exercises the real y-protocols decode rather than a hand-built state map.
+ * Each call is a DISTINCT host - use {@link createHostPresenceProducer} when
+ * the test needs the same host across a transition.
+ */
+function encodeHostPresence(agentIds: readonly string[]): {
+  readonly bytes: Uint8Array;
+} {
+  const doc = new Y.Doc();
+  const producer = new Awareness(doc);
+  producer.setLocalState({
+    [AGENT_ACTIVITY_AWARENESS_FIELD]: {
+      [EPIC_ID]: { working: agentIds, turn: agentIds },
+    },
+  });
+  return { bytes: encodeAwarenessUpdate(producer, [producer.clientID]) };
+}
+
+function workingIds(): ReadonlySet<string> {
+  return (
+    useNotificationsStore.getState().agentActivityByEpic.get(EPIC_ID)
+      ?.working ?? new Set<string>()
+  );
+}
+
+afterEach(() => {
+  __resetNotificationsStoreForTests();
+});
+
+describe("notification-room activity replica", () => {
+  it("folds an inbound awareness frame into the cross-epic union", () => {
+    const stream = openStream();
+    const { bytes } = encodeHostPresence(["agent-a"]);
+
+    stream.callbacks.onAwareness(bytes);
+
+    expect([...workingIds()]).toEqual(["agent-a"]);
+    stream.dispose();
+  });
+
+  it("reads idle against a host that never sends an awareness frame", () => {
+    // A `@1.0` host: the transport downgrades the negotiated minor and the
+    // frame simply never arrives. Every surface then reads idle from this
+    // source and falls back to the local session state it already layers on.
+    const stream = openStream();
+
+    stream.callbacks.onSnapshot(
+      { schemaVersion: "1.0.0" },
+      Y.encodeStateAsUpdate(new Y.Doc()),
+    );
+
+    expect(useNotificationsStore.getState().agentActivityByEpic.size).toBe(0);
+    stream.dispose();
+  });
+
+  it("clears the union on identity reset (sign-out / user switch)", () => {
+    const stream = openStream();
+    const { bytes } = encodeHostPresence(["agent-a"]);
+    stream.callbacks.onAwareness(bytes);
+    expect(workingIds().size).toBe(1);
+
+    stream.dispose();
+    useNotificationsStore.getState().reset();
+
+    expect(useNotificationsStore.getState().agentActivityByEpic.size).toBe(0);
+  });
+
+  it("keeps applying frames after an identity reset swaps the replica", () => {
+    const first = openStream();
+    first.callbacks.onAwareness(encodeHostPresence(["agent-a"]).bytes);
+    first.dispose();
+    useNotificationsStore.getState().reset();
+
+    const second = openStream();
+    second.callbacks.onAwareness(encodeHostPresence(["agent-b"]).bytes);
+
+    expect([...workingIds()]).toEqual(["agent-b"]);
+    second.dispose();
+  });
+
+  it("drops carried-over presence when the room stream is reopened", () => {
+    // A reopen only happens after the session has been dead for minutes, so
+    // every entry still held is stale by construction; the attaching host
+    // re-ships whatever is actually current.
+    const first = openStream();
+    first.callbacks.onAwareness(encodeHostPresence(["agent-a"]).bytes);
+    expect(workingIds().size).toBe(1);
+    first.dispose();
+
+    const second = openStream();
+
+    expect(useNotificationsStore.getState().agentActivityByEpic.size).toBe(0);
+
+    second.callbacks.onAwareness(encodeHostPresence(["agent-c"]).bytes);
+    expect([...workingIds()]).toEqual(["agent-c"]);
+    second.dispose();
+  });
+
+  it("accepts the same host's attach-time replay after a reopen", () => {
+    // Regression: resetting with `removeAwarenessStates` dropped the entries
+    // but kept each remote clientId's `meta.clock`. The reopened session's
+    // replay re-ships the SAME state at the SAME clock, which
+    // `applyAwarenessUpdate` then rejected (`currClock === clock`) - so the
+    // agent stayed invisible until the publisher's next renewal ~15s later.
+    // The host is unchanged across the reopen here, which is the only way to
+    // see it.
+    const host = createHostPresenceProducer();
+    const first = openStream();
+    first.callbacks.onAwareness(host.publish(["agent-a"]));
+    expect([...workingIds()]).toEqual(["agent-a"]);
+    first.dispose();
+
+    const second = openStream();
+    expect(useNotificationsStore.getState().agentActivityByEpic.size).toBe(0);
+
+    second.callbacks.onAwareness(host.replay());
+
+    expect([...workingIds()]).toEqual(["agent-a"]);
+    second.dispose();
+    host.destroy();
+  });
+
+  it("accepts the same host's replay after an identity reset", () => {
+    // `replace()` swaps the instance outright, so it never had the clock bug -
+    // but the two resets must not be allowed to drift apart.
+    //
+    // The replay goes in through the apply seam DIRECTLY, with no intervening
+    // `openStream()`: reopening would run `clearAwareness` and reset the clocks
+    // a second time, so a `replace()` that started retaining them would still
+    // pass. This asserts `replace()` on its own.
+    const host = createHostPresenceProducer();
+    const first = openStream();
+    first.callbacks.onAwareness(host.publish(["agent-a"]));
+    first.dispose();
+    useNotificationsStore.getState().reset();
+    expect(useNotificationsStore.getState().agentActivityByEpic.size).toBe(0);
+
+    __applyNotificationsAwarenessForTests(host.replay());
+
+    expect([...workingIds()]).toEqual(["agent-a"]);
+    host.destroy();
+  });
+
+  it("does not accumulate listeners on the notifications doc across reopens", () => {
+    // `Awareness` registers an anonymous `doc.on("destroy")` its own `destroy()`
+    // never unregisters. The notifications doc outlives every reader swap, so a
+    // reader bound to it would leave one dead closure per reopen behind, each
+    // retaining a retired instance's states and meta.
+    const notificationsDoc = useNotificationsStore.getState().doc;
+    const before = destroyListenerCount(notificationsDoc);
+
+    for (let i = 0; i < 4; i += 1) {
+      const stream = openStream();
+      stream.callbacks.onAwareness(encodeHostPresence([`agent-${i}`]).bytes);
+      stream.dispose();
+    }
+
+    expect(destroyListenerCount(notificationsDoc)).toBe(before);
+  });
+
+  it("clears a host that disconnects cleanly", () => {
+    // The primary self-clearing path: a host leaving the room removes its own
+    // awareness entry, which arrives as a null state at a bumped clock. No
+    // cleanup protocol on either side.
+    //
+    // The BACKSTOP - y-protocols' ~30s sweep of entries that stopped renewing,
+    // for a host that dies without a clean disconnect - is deliberately not
+    // covered here: `lib0/time` binds `getUnixTime = Date.now` by reference at
+    // module load, and y-protocols is an externalized dependency, so neither
+    // `vi.useFakeTimers()` nor a module mock can move the clock it reads. What
+    // this replica owns for that path is the reader-only local state that keeps
+    // the sweep's eviction arm live; the sweep itself is upstream behaviour and
+    // needs the dev-app check.
+    const host = createHostPresenceProducer();
+    const stream = openStream();
+    stream.callbacks.onAwareness(host.publish(["agent-a"]));
+    expect(workingIds().size).toBe(1);
+
+    stream.callbacks.onAwareness(host.disconnect());
+
+    expect(useNotificationsStore.getState().agentActivityByEpic.size).toBe(0);
+    stream.dispose();
+    host.destroy();
+  });
+});

--- a/clients/gui-app/src/stores/notifications/notifications-store.ts
+++ b/clients/gui-app/src/stores/notifications/notifications-store.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { create, type UseBoundStore, type StoreApi } from "zustand";
 import * as Y from "yjs";
+import { Awareness, applyAwarenessUpdate } from "y-protocols/awareness";
 import type { StreamConnectionStatus } from "@traycer-clients/shared/host-transport/i-stream-session";
 import type {
   NotificationsSnapshotMeta,
@@ -22,6 +23,12 @@ type NotificationsStreamClientHandle = Pick<
   NotificationsStreamClient,
   "applyUpdate" | "close"
 >;
+import {
+  EMPTY_AGENT_ACTIVITY_BY_EPIC,
+  EMPTY_EPIC_AGENT_ACTIVITY,
+  readAgentActivityByEpic,
+  type EpicAgentActivity,
+} from "@/lib/notifications/agent-activity-presence";
 
 export type NotificationsStreamClientFactory = (
   callbacks: NotificationsStreamCallbacks,
@@ -35,6 +42,18 @@ interface NotificationsState {
   readonly entryIds: ReadonlyArray<string>;
   readonly unreadCount: number;
   readonly revision: number;
+  /**
+   * Cross-epic, cross-host agent-activity presence, folded from the room's
+   * awareness entries (one per host). THE source for every activity indicator
+   * in the app - unlike per-epic collaboration awareness it covers epics this
+   * window has never opened, which is the whole point of moving the signal
+   * onto the always-subscribed per-user room.
+   *
+   * Per-epic values are identity-stable while that epic's membership is
+   * unchanged, so a per-epic selector bails the re-render when an unrelated
+   * epic's agents start or stop.
+   */
+  readonly agentActivityByEpic: ReadonlyMap<string, EpicAgentActivity>;
 
   markAsRead: (notificationId: string) => void;
   markAllAsRead: () => void;
@@ -81,15 +100,123 @@ interface NotificationsReplica {
   getDoc(): Y.Doc;
   project(): NotificationsProjection;
   onProjection(handler: () => void): () => void;
+  /**
+   * Folds the room's awareness entries into the cross-epic activity union.
+   * Returns the prior map by reference when nothing changed.
+   */
+  projectAgentActivity(): ReadonlyMap<string, EpicAgentActivity>;
+  onAwareness(handler: () => void): () => void;
+  applyAwareness(updateBytes: Uint8Array): void;
+  /**
+   * Discards the whole awareness replica - entries AND their per-clientId
+   * clocks - and notifies awareness subscribers. Used when a room session is
+   * (re)opened: awareness has no CRDT-style merge that would make carrying
+   * stale entries safe, and the attaching host re-ships the current states.
+   */
+  clearAwareness(): void;
   replace(): void;
+}
+
+/**
+ * A reader-only `Awareness` paired with the throwaway Y.Doc it is bound to.
+ *
+ * Reader-only means it never publishes a local state, which matters twice over:
+ * `applyAwarenessUpdate` refuses a remote removal of our OWN clientID while we
+ * hold a local state, and y-protocols' outdated-entry sweep (~30s) only runs
+ * its eviction arm for a reader. That sweep is what clears a crashed or
+ * disconnected host's spinners with no cleanup protocol.
+ */
+interface ReaderAwareness {
+  readonly awareness: Awareness;
+  readonly doc: Y.Doc;
+}
+
+/**
+ * Builds a reader over its OWN disposable doc - deliberately NOT the
+ * notifications doc.
+ *
+ * `Awareness`'s constructor registers an anonymous `doc.on("destroy", () =>
+ * this.destroy())` that its own `destroy()` never unregisters. Every reset
+ * swaps the reader instance while the notifications doc lives on, so binding
+ * readers to that doc would leave one dead closure per reset behind, each
+ * retaining a retired instance's states and meta until an identity reset
+ * finally destroyed the doc. Giving the reader a doc of its own makes teardown
+ * total: destroying that doc takes the listener with it.
+ *
+ * Nothing is lost by decoupling them - this replica never reads or writes
+ * notifications-doc content, it only decodes awareness bytes off the wire. The
+ * one visible consequence is that our own clientID churns per swap, which is
+ * irrelevant for a reader whose local state is always null.
+ */
+function createReaderAwareness(): ReaderAwareness {
+  const doc = new Y.Doc();
+  const awareness = new Awareness(doc);
+  awareness.setLocalState(null);
+  return { awareness, doc };
 }
 
 function createNotificationsReplica(): NotificationsReplica {
   let doc = new Y.Doc();
+  let reader = createReaderAwareness();
   let lastProjectionKey: string | null = null;
   let lastEntries: ReadonlyArray<NotificationEntry> = [];
   let lastEntryIds: ReadonlyArray<string> = [];
   let lastUnread = 0;
+  let lastAgentActivity: ReadonlyMap<string, EpicAgentActivity> =
+    EMPTY_AGENT_ACTIVITY_BY_EPIC;
+
+  // The replica - not the store - owns the awareness listener fan-out, because
+  // resetting awareness means REPLACING the instance (see `installAwareness`).
+  // Subscribers register once here and survive every swap; a single internal
+  // bridge is what actually moves between instances.
+  const awarenessListeners = new Set<() => void>();
+  const notifyAwareness = (): void => {
+    for (const listener of [...awarenessListeners]) listener();
+  };
+  let detachAwareness = attachAwarenessBridge(reader.awareness);
+
+  function attachAwarenessBridge(target: Awareness): () => void {
+    // "change" (not "update"): clock-only renewals carry no membership change,
+    // and re-folding the union on each one would churn every indicator.
+    target.on("change", notifyAwareness);
+    return () => {
+      target.off("change", notifyAwareness);
+    };
+  }
+
+  /**
+   * Tears the current reader down completely - listener bridge, instance, and
+   * the doc it was bound to. Destroying that doc is what drops the anonymous
+   * destroy listener `Awareness` registered on it; the instance's own
+   * `destroy()` cannot. (The cascade calls `destroy()` a second time, which is
+   * a no-op on an already-torn-down instance.)
+   */
+  function retireAwareness(): void {
+    detachAwareness();
+    reader.awareness.destroy();
+    reader.doc.destroy();
+  }
+
+  /**
+   * Installs a fresh reader and republishes the (now empty) union.
+   *
+   * Every awareness reset goes through here, and every one of them REPLACES the
+   * instance rather than calling `removeAwarenessStates`: that helper deletes
+   * the states but leaves `meta.clock` behind for each remote clientId, and
+   * `applyAwarenessUpdate` drops an inbound entry whose clock is not strictly
+   * greater. The replacement session's attach-time replay re-ships each host's
+   * CURRENT state at its CURRENT clock, so a clock-retaining reset would make
+   * that whole replay a no-op and blank every indicator until each publisher's
+   * next renewal (~15s later). Only a fresh `meta` accepts the replay.
+   */
+  function installAwareness(): void {
+    reader = createReaderAwareness();
+    detachAwareness = attachAwarenessBridge(reader.awareness);
+    lastAgentActivity = EMPTY_AGENT_ACTIVITY_BY_EPIC;
+    // No "change" fires for a swap, so drive the projection by hand - otherwise
+    // the store would keep rendering the retired instance's union.
+    notifyAwareness();
+  }
 
   function project(): NotificationsProjection {
     const arr = getNotificationsArray(doc);
@@ -134,19 +261,52 @@ function createNotificationsReplica(): NotificationsReplica {
     };
   }
 
+  function projectAgentActivity(): ReadonlyMap<string, EpicAgentActivity> {
+    lastAgentActivity = readAgentActivityByEpic(
+      reader.awareness.getStates().values(),
+      lastAgentActivity,
+    );
+    return lastAgentActivity;
+  }
+
+  function onAwareness(handler: () => void): () => void {
+    awarenessListeners.add(handler);
+    return () => {
+      awarenessListeners.delete(handler);
+    };
+  }
+
+  function applyAwareness(updateBytes: Uint8Array): void {
+    applyAwarenessUpdate(reader.awareness, updateBytes, STREAM_ORIGIN);
+  }
+
+  function clearAwareness(): void {
+    retireAwareness();
+    installAwareness();
+  }
+
   function replace(): void {
+    // Both reset paths route through the same retire/install pair so they
+    // cannot drift. The reader owns its own doc, so retiring it is independent
+    // of the notifications doc being swapped here.
+    retireAwareness();
     doc.destroy();
     doc = new Y.Doc();
     lastProjectionKey = null;
     lastEntries = [];
     lastEntryIds = [];
     lastUnread = 0;
+    installAwareness();
   }
 
   return {
     getDoc: () => doc,
     project,
     onProjection,
+    projectAgentActivity,
+    onAwareness,
+    applyAwareness,
+    clearAwareness,
     replace,
   };
 }
@@ -156,7 +316,7 @@ function createNotificationsStore(
 ): UseBoundStore<StoreApi<NotificationsState>> {
   let unwireProjection: (() => void) | null = null;
 
-  const store = create<NotificationsState>()((set) => {
+  const store = create<NotificationsState>()((set, get) => {
     const projectFromDoc = (): void => {
       const projected = replica.project();
       if (!projected.changed) return;
@@ -168,7 +328,20 @@ function createNotificationsStore(
       });
     };
 
+    const projectFromAwareness = (): void => {
+      const next = replica.projectAgentActivity();
+      // The reader returns the prior map by reference when the union is
+      // unchanged, so this bails every awareness event that only moved an
+      // unrelated field or re-stamped an identical entry.
+      if (next === get().agentActivityByEpic) return;
+      set({ agentActivityByEpic: next });
+    };
+
     unwireProjection = replica.onProjection(projectFromDoc);
+    // Registered once for the life of this singleton store - the replica keeps
+    // the handler across every awareness instance swap, so there is nothing to
+    // re-wire on reset.
+    replica.onAwareness(projectFromAwareness);
 
     return {
       doc: replica.getDoc(),
@@ -178,6 +351,7 @@ function createNotificationsStore(
       entryIds: [],
       unreadCount: 0,
       revision: 0,
+      agentActivityByEpic: EMPTY_AGENT_ACTIVITY_BY_EPIC,
 
       markAsRead: (notificationId) => {
         const doc = replica.getDoc();
@@ -220,6 +394,9 @@ function createNotificationsStore(
       },
 
       reset: () => {
+        // Only the doc projection needs re-wiring: `onProjection` binds to the
+        // Y.Doc that `replace()` swaps out, whereas the awareness registration
+        // lives on the replica and follows it across instance swaps.
         if (unwireProjection !== null) {
           unwireProjection();
           unwireProjection = null;
@@ -233,6 +410,10 @@ function createNotificationsStore(
           entryIds: [],
           unreadCount: 0,
           revision: 0,
+          // The activity union is user-scoped presence, so it dies with the
+          // rest of the replica on sign-out / user-switch - the incoming user
+          // must never inherit the outgoing one's spinners.
+          agentActivityByEpic: EMPTY_AGENT_ACTIVITY_BY_EPIC,
           connectionStatus: "connecting" as StreamConnectionStatus,
         });
       },
@@ -256,16 +437,18 @@ export const useNotificationsStore = createNotificationsStore(replica);
  * filters on that so only user-driven writes travel upstream, never snapshot
  * or remote-update applications which are tagged `"stream"`.
  *
- * A terminal close ("closed" + fatalError) disposes the underlying transport
- * session, which can never redial itself — the factory is re-invoked on
- * capped backoff so one bad window doesn't leave collaboration rows frozen
- * until app restart. The re-landed snapshot merges into the same Y.Doc, the
- * same convergence path a plain reconnect already uses.
+ * The Y.Doc is deliberately NOT reset here (a reconnect's snapshot merges into
+ * it), but the awareness replica IS: awareness has no merge that makes a
+ * carried-over entry safe, and the attaching session re-ships every current
+ * state anyway. The reset discards the per-clientId CLOCKS along with the
+ * entries - see `clearAwareness`, where keeping them would make that attach-time
+ * replay a no-op.
  */
 export function openNotificationsStream(
   factory: NotificationsStreamClientFactory,
   onAuthError: (() => void) | null,
 ): () => void {
+  replica.clearAwareness();
   const targetDoc = replica.getDoc();
   let disposed = false;
   let currentClient: NotificationsStreamClientHandle | null = null;
@@ -274,6 +457,10 @@ export function openNotificationsStream(
   const reopenScheduler = createNotificationStreamReopenScheduler(() => {
     currentClient?.close();
     currentClient = null;
+    // The scheduler reopens the stream without recreating this store. Reset the
+    // reader so the host's attach-time awareness replay is accepted at its
+    // current clocks rather than being discarded against retained metadata.
+    replica.clearAwareness();
     openClient();
   });
 
@@ -320,6 +507,10 @@ export function openNotificationsStream(
       onUpdate: (updateBytes) => {
         if (!isCurrent()) return;
         Y.applyUpdate(targetDoc, updateBytes, STREAM_ORIGIN);
+      },
+      onAwareness: (awarenessBytes) => {
+        if (!isCurrent()) return;
+        replica.applyAwareness(awarenessBytes);
       },
       onConnectionStatus: (status, reason) => {
         if (!isCurrent()) return;
@@ -387,7 +578,75 @@ export function useNotificationEntryById(id: string): NotificationEntry | null {
 
 export function useNotificationUnreadCount(): number {
   return useNotificationsStore((state) => state.unreadCount);
-} /**
+}
+
+// ---------------------------------------------------------------------------
+// Agent-activity presence (cross-epic, cross-host)
+// ---------------------------------------------------------------------------
+
+/**
+ * This epic's slice of the room-wide activity union, or the shared empty slice
+ * when no host reports work for it. Identity-stable while the epic's membership
+ * is unchanged, so an unrelated epic's agents starting or stopping does not
+ * re-render this consumer.
+ *
+ * `null` epicId is accepted (and reads idle) because several cross-epic
+ * surfaces render before their epic id resolves.
+ */
+export function useEpicAgentActivity(epicId: string | null): EpicAgentActivity {
+  const selector = useMemo(() => makeSelectEpicAgentActivity(epicId), [epicId]);
+  return useNotificationsStore(selector);
+}
+
+function makeSelectEpicAgentActivity(epicId: string | null) {
+  return (state: NotificationsState): EpicAgentActivity => {
+    if (epicId === null) return EMPTY_EPIC_AGENT_ACTIVITY;
+    return state.agentActivityByEpic.get(epicId) ?? EMPTY_EPIC_AGENT_ACTIVITY;
+  };
+}
+
+/**
+ * Imperative read of one epic's activity, for callers that are not React (the
+ * MRU prune guard). Pair with {@link subscribeAgentActivity} when the caller
+ * has to re-evaluate on change.
+ */
+export function getEpicAgentActivity(epicId: string): EpicAgentActivity {
+  return (
+    useNotificationsStore.getState().agentActivityByEpic.get(epicId) ??
+    EMPTY_EPIC_AGENT_ACTIVITY
+  );
+}
+
+/** Fires whenever the cross-epic activity union changes membership. */
+export function subscribeAgentActivity(listener: () => void): () => void {
+  let previous = useNotificationsStore.getState().agentActivityByEpic;
+  return useNotificationsStore.subscribe((state) => {
+    if (state.agentActivityByEpic === previous) return;
+    previous = state.agentActivityByEpic;
+    listener();
+  });
+}
+
+/**
+ * Test seam: applies a raw y-protocols awareness update to the room replica,
+ * exactly as an inbound `awareness` frame would. Lets a suite drive the real
+ * decode + fold path instead of stubbing the store field.
+ */
+export function __applyNotificationsAwarenessForTests(
+  updateBytes: Uint8Array,
+): void {
+  replica.applyAwareness(updateBytes);
+}
+
+/**
+ * Test seam: drops every awareness entry, the same way opening (or reopening)
+ * a room session does.
+ */
+export function __clearNotificationsAwarenessForTests(): void {
+  replica.clearAwareness();
+}
+
+/**
  * Test helper - delegates to the public `reset()` action so tests get the
  * same teardown semantics as a sign-out transition in production.
  */

--- a/clients/shared/host-transport/notifications-stream-client.ts
+++ b/clients/shared/host-transport/notifications-stream-client.ts
@@ -23,7 +23,7 @@ export interface NotificationsSnapshotMeta {
 }
 
 /**
- * Typed handlers for a `notifications.subscribe@1.0` session.
+ * Typed handlers for a `notifications.subscribe@1.0` / `@1.1` session.
  *
  * Symmetric to `EpicStreamCallbacks` but with no `epicId` - the host
  * infers `userId` from the authenticated `/stream` connection, so the
@@ -35,6 +35,15 @@ export interface NotificationsStreamCallbacks {
     snapshotBytes: Uint8Array,
   ) => void;
   readonly onUpdate: (updateBytes: Uint8Array) => void;
+  /**
+   * A y-protocols awareness update for the per-user notification room,
+   * carrying each host's agent-activity presence. Only ever fires on a
+   * session that negotiated `@1.1`: against a `@1.0` host the transport
+   * declares `1.0` on the wire and the host never emits the frame, so the
+   * consumer simply sees no presence (and every activity surface reads
+   * idle from this source).
+   */
+  readonly onAwareness: (awarenessBytes: Uint8Array) => void;
   /**
    * Connection-status changes. `reason` is non-null only on the
    * `closed` transition; see `EpicStreamCallbacks.onConnectionStatus`.
@@ -51,12 +60,18 @@ export interface NotificationsStreamClientOptions {
 }
 
 /**
- * Typed wrapper over `WsStreamClient` for `notifications.subscribe@1.0`.
+ * Typed wrapper over `WsStreamClient` for `notifications.subscribe`.
  *
  * Opens exactly one session on construction, binds the callback surface,
  * and exposes the fire-and-forget `applyUpdate` path plus `close`. Zod
  * parse on inbound frames is the boundary where the raw envelope becomes
  * a typed variant of `NotificationsSubscribeServerFrame`.
+ *
+ * The negotiated minor is chosen by `WsStreamClient` from the shared
+ * registry (canonical `1.1`, downgraded on the wire to `1.0` against an
+ * older host), so nothing here plumbs a version: parsing against the
+ * latest installed frame schema is safe because a `@1.0` peer simply never
+ * sends the `awareness` kind.
  */
 export class NotificationsStreamClient {
   private readonly session: IStreamSession;
@@ -127,6 +142,13 @@ export class NotificationsStreamClient {
           return;
         }
         this.callbacks.onUpdate(binaryPayload);
+        return;
+      }
+      case "awareness": {
+        if (binaryPayload === null) {
+          return;
+        }
+        this.callbacks.onAwareness(binaryPayload);
         return;
       }
       case "pong": {

--- a/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
+++ b/protocol/src/framework/__tests__/versioned-stream-rpc.test.ts
@@ -29,7 +29,7 @@ describe("validateVersionedStreamRpcRegistry", () => {
     expect(hostStreamRpcRegistry["chat.subscribe"][1].latestMinor).toBe(5);
     expect(
       hostStreamRpcRegistry["notifications.subscribe"][1].latestMinor,
-    ).toBe(0);
+    ).toBe(1);
   });
 
   it("rejects a minor that drops a server-frame field from an earlier minor", () => {

--- a/protocol/src/host/epic/subscribe.ts
+++ b/protocol/src/host/epic/subscribe.ts
@@ -64,48 +64,6 @@
 import { z } from "zod";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
 
-/**
- * Awareness state field under which each host publishes the ids of its
- * locally-working agents (the `hasActivity` level) for an epic. The cloud-merged
- * awareness (one entry per host) is the cross-host union, so a client sees
- * working agents regardless of which host runs them. Written by the host's
- * per-epic awareness publisher; read by the gui-app Active Agents panel. Shared
- * here so writer and reader cannot drift.
- */
-export const AGENT_WORKING_AWARENESS_FIELD = "agentWorking";
-
-/**
- * Awareness state field under which each host publishes the subset of its
- * {@link AGENT_WORKING_AWARENESS_FIELD} ids whose work is an actual agent
- * **turn** (running or activating), as opposed to background-only work
- * (`run_in_background` / a subagent / Monitor / a scheduled wakeup) that keeps
- * a session non-idle while the agent itself is not executing.
- *
- * Additive and OPTIONAL by design. Awareness rides an opaque binary payload
- * (the `awareness` frame is `hasBinaryPayload: true`), so this value is NOT
- * schema-validated and is NOT covered by the stream contract's
- * `major`/`minor` negotiation - a reader cannot learn from the handshake
- * whether its peer publishes this field. Two rules follow, and both are
- * load-bearing:
- *
- * 1. NEVER change the shape of `agentWorking` itself. Existing readers do
- *    `Array.isArray(...)` on it and skip the whole entry otherwise, so
- *    repurposing it makes agents silently vanish from the working set on older
- *    clients.
- * 2. Absence is per-HOST, and must be read that way. Cloud-merged awareness
- *    carries one entry per host, so a single client can see an old host (field
- *    absent) and a new host (field present) simultaneously - indefinitely, not
- *    just during a rollout. Readers must therefore decide per entry:
- *      - field absent  -> tier unknown for that host; treat its working ids
- *                         conservatively as turns (the pre-existing behaviour).
- *      - field present -> ids listed here are turns; working ids NOT listed
- *                         here are genuinely background-only.
- *
- * Because "turn" is the conservative default, a publisher only needs to list
- * ids it can positively classify; agents with no turn/background distinction
- * (terminal agents, CLI/TUI runs) simply stay in the turn set.
- */
-export const AGENT_WORKING_TURN_AWARENESS_FIELD = "agentWorkingTurn";
 import { getRecordSchema } from "@traycer/protocol/framework/index";
 import { commonRecordRegistry } from "@traycer/protocol/common/registry";
 

--- a/protocol/src/host/notifications/__tests__/notifications-subscribe.test.ts
+++ b/protocol/src/host/notifications/__tests__/notifications-subscribe.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest";
+import { hostStreamRpcRegistry } from "@traycer/protocol/host/index";
 import {
+  AGENT_ACTIVITY_AWARENESS_FIELD,
+  AGENT_ACTIVITY_HOST_ID_AWARENESS_FIELD,
   notificationsSubscribeClientFrameSchema,
   notificationsSubscribeServerFrameSchema,
+  notificationsSubscribeServerFrameSchemaV10,
+  notificationsSubscribeServerFrameSchemaV11,
   notificationsSubscribeV10,
+  notificationsSubscribeV11,
 } from "@traycer/protocol/host/notifications/subscribe";
 
 /**
- * `notifications.subscribe@1.0` frame fixtures.
+ * `notifications.subscribe@1.0` / `@1.1` frame fixtures.
  *
  * Covers every frame kind the contract declares, including the binary-bearing
  * frames (`hasBinaryPayload: true`) that ride a paired binary payload and the
@@ -16,7 +22,7 @@ import {
 
 describe("notifications.subscribe@1.0 server frames", () => {
   it("parses a binary-bearing snapshot frame with a semver schemaVersion", () => {
-    const parsed = notificationsSubscribeServerFrameSchema.parse({
+    const parsed = notificationsSubscribeServerFrameSchemaV10.parse({
       kind: "snapshot",
       meta: {
         schemaVersion: "1.0.0",
@@ -32,7 +38,7 @@ describe("notifications.subscribe@1.0 server frames", () => {
   });
 
   it("parses a binary-bearing update frame", () => {
-    const update = notificationsSubscribeServerFrameSchema.parse({
+    const update = notificationsSubscribeServerFrameSchemaV10.parse({
       kind: "update",
       hasBinaryPayload: true,
     });
@@ -52,7 +58,7 @@ describe("notifications.subscribe@1.0 server frames", () => {
 
   it("rejects a pong frame that claims a binary payload", () => {
     expect(() =>
-      notificationsSubscribeServerFrameSchema.parse({
+      notificationsSubscribeServerFrameSchemaV10.parse({
         kind: "pong",
         hasBinaryPayload: true,
       }),
@@ -61,7 +67,7 @@ describe("notifications.subscribe@1.0 server frames", () => {
 
   it("rejects a snapshot frame that is missing the meta envelope", () => {
     expect(() =>
-      notificationsSubscribeServerFrameSchema.parse({
+      notificationsSubscribeServerFrameSchemaV10.parse({
         kind: "snapshot",
         hasBinaryPayload: true,
       }),
@@ -70,7 +76,7 @@ describe("notifications.subscribe@1.0 server frames", () => {
 
   it("rejects a snapshot frame with a numeric schemaVersion", () => {
     expect(() =>
-      notificationsSubscribeServerFrameSchema.parse({
+      notificationsSubscribeServerFrameSchemaV10.parse({
         kind: "snapshot",
         meta: {
           schemaVersion: 1,
@@ -106,5 +112,100 @@ describe("notifications.subscribe@1.0 open request", () => {
   it("accepts an empty object", () => {
     const parsed = notificationsSubscribeV10.openRequestSchema.parse({});
     expect(parsed).toEqual({});
+  });
+});
+
+describe("notifications.subscribe@1.1 awareness frame", () => {
+  it("parses a binary-bearing awareness frame", () => {
+    const parsed = notificationsSubscribeServerFrameSchemaV11.parse({
+      kind: "awareness",
+      hasBinaryPayload: true,
+    });
+
+    expect(parsed.kind).toBe("awareness");
+    expect(parsed.hasBinaryPayload).toBe(true);
+  });
+
+  it("rejects an awareness frame that claims no binary payload", () => {
+    expect(() =>
+      notificationsSubscribeServerFrameSchemaV11.parse({
+        kind: "awareness",
+        hasBinaryPayload: false,
+      }),
+    ).toThrow();
+  });
+
+  it("keeps the @1.0 union frozen against the new frame kind", () => {
+    expect(() =>
+      notificationsSubscribeServerFrameSchemaV10.parse({
+        kind: "awareness",
+        hasBinaryPayload: true,
+      }),
+    ).toThrow();
+  });
+
+  it("still parses every @1.0 frame kind", () => {
+    expect(
+      notificationsSubscribeServerFrameSchemaV11.parse({
+        kind: "snapshot",
+        meta: { schemaVersion: "1.0.0" },
+        hasBinaryPayload: true,
+      }).kind,
+    ).toBe("snapshot");
+    expect(
+      notificationsSubscribeServerFrameSchemaV11.parse({
+        kind: "update",
+        hasBinaryPayload: true,
+      }).kind,
+    ).toBe("update");
+    expect(
+      notificationsSubscribeServerFrameSchemaV11.parse({
+        kind: "pong",
+        hasBinaryPayload: false,
+      }).kind,
+    ).toBe("pong");
+  });
+
+  it("exposes @1.1 as the latest installed server-frame shape", () => {
+    expect(notificationsSubscribeServerFrameSchema).toBe(
+      notificationsSubscribeServerFrameSchemaV11,
+    );
+  });
+
+  it("adds no client frame - the GUI only reads activity", () => {
+    expect(notificationsSubscribeV11.clientFrameSchema).toBe(
+      notificationsSubscribeClientFrameSchema,
+    );
+    expect(() =>
+      notificationsSubscribeClientFrameSchema.parse({
+        kind: "awareness",
+        hasBinaryPayload: true,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("agent-activity awareness fields", () => {
+  it("pins the frozen field names writer and reader share", () => {
+    expect(AGENT_ACTIVITY_AWARENESS_FIELD).toBe("agentActivityByEpic");
+    expect(AGENT_ACTIVITY_HOST_ID_AWARENESS_FIELD).toBe("agentActivityHostId");
+  });
+});
+
+describe("notifications.subscribe registry membership", () => {
+  it("installs @1.0 and @1.1 on the stream registry at major 1", () => {
+    const entry = hostStreamRpcRegistry["notifications.subscribe"];
+    expect(entry).toBeDefined();
+    expect(entry[1].latestMinor).toBe(1);
+    expect(entry[1].versions[0].contract).toBe(notificationsSubscribeV10);
+    expect(entry[1].versions[1].contract).toBe(notificationsSubscribeV11);
+    expect(notificationsSubscribeV10.schemaVersion).toEqual({
+      major: 1,
+      minor: 0,
+    });
+    expect(notificationsSubscribeV11.schemaVersion).toEqual({
+      major: 1,
+      minor: 1,
+    });
   });
 });

--- a/protocol/src/host/notifications/contracts.ts
+++ b/protocol/src/host/notifications/contracts.ts
@@ -1,6 +1,9 @@
-import { notificationsSubscribeV10 } from "@traycer/protocol/host/notifications/subscribe";
+import {
+  notificationsSubscribeV10,
+  notificationsSubscribeV11,
+} from "@traycer/protocol/host/notifications/subscribe";
 
 export * from "@traycer/protocol/host/notifications/host-notifications";
 export * from "@traycer/protocol/host/notifications/payloads";
 export * from "@traycer/protocol/host/notifications/presentation";
-export { notificationsSubscribeV10 };
+export { notificationsSubscribeV10, notificationsSubscribeV11 };

--- a/protocol/src/host/notifications/subscribe.ts
+++ b/protocol/src/host/notifications/subscribe.ts
@@ -1,18 +1,23 @@
 /**
- * `notifications.subscribe@1.0` - versioned streaming-RPC contract for the
- * per-user notifications Y.Doc subscription.
+ * `notifications.subscribe@1.0` / `@1.1` - versioned streaming-RPC contract for
+ * the per-user notifications Y.Doc subscription.
  *
  * `userId` is inferred from the host authentication context, so the open
  * request carries no parameters.
  *
  * Server frames:
  *
- * - `snapshot` - initial state for the user's notifications doc. Text
- *                envelope carries just the notifications-doc schema version
- *                as a semver string; the Y.Doc snapshot rides the paired
- *                binary payload.
- * - `update`   - an incremental Y.Doc update. Binary-only payload.
- * - `pong`     - heartbeat response to a client `ping`. Text-only.
+ * - `snapshot`  - initial state for the user's notifications doc. Text
+ *                 envelope carries just the notifications-doc schema version
+ *                 as a semver string; the Y.Doc snapshot rides the paired
+ *                 binary payload.
+ * - `update`    - an incremental Y.Doc update. Binary-only payload.
+ * - `pong`      - heartbeat response to a client `ping`. Text-only.
+ * - `awareness` - (`@1.1`) awareness update for the per-user notification
+ *                 room, carrying agent-activity presence. Binary-only payload
+ *                 (a y-protocols awareness encoding). Server-only: the GUI
+ *                 reads activity and never publishes it, so there is no
+ *                 matching client frame.
  *
  * Client frames:
  *
@@ -23,6 +28,68 @@
 import { z } from "zod";
 import { defineStreamRpcContract } from "@traycer/protocol/framework/versioned-stream-rpc";
 
+/**
+ * Awareness state field under which each host publishes its agent-activity
+ * presence for the per-user notification room (`notifications:<userId>`),
+ * grouped by epic:
+ *
+ * ```ts
+ * { [epicId: string]: { working: string[]; turn: string[] } }
+ * ```
+ *
+ * `working` is every agent id at the `hasActivity` level; `turn` is the subset
+ * whose work is an actual agent **turn** (running or activating), as opposed to
+ * background-only work (`run_in_background` / a subagent / Monitor / a
+ * scheduled wakeup) that keeps a session non-idle while the agent itself is not
+ * executing. The cloud merges one awareness entry per host, so the cross-host
+ * union is free: a client sees working agents regardless of which host runs
+ * them, and a host that dies or disconnects ages out of awareness, clearing its
+ * own spinners with no cleanup protocol.
+ *
+ * Awareness rides an opaque binary payload (the `awareness` frame is
+ * `hasBinaryPayload: true`), so this value is NOT schema-validated and is NOT
+ * covered by the stream contract's `major`/`minor` negotiation - a reader
+ * cannot learn from the handshake whether its peer publishes it. Four rules
+ * follow, and all of them are load-bearing:
+ *
+ * 1. The shape above is FROZEN. Never reshape it; extend only by adding new
+ *    awareness fields beside it. Readers shape-check what they find and drop
+ *    what they do not recognise, so repurposing this field makes agents
+ *    silently vanish from the working set on older clients.
+ * 2. Absence is per-HOST, and must be read that way. Cloud-merged awareness
+ *    carries one entry per host, so a single client can see an old host (field
+ *    absent) and a new host (field present) simultaneously - indefinitely, not
+ *    just during a rollout. An epicId absent from every entry's map is idle.
+ * 3. Shape-check PER ENTRY and per epic bucket (`Array.isArray` on `working`
+ *    and `turn`), and skip the offending entry or bucket rather than the whole
+ *    read. One malformed publisher must not blank out every other host.
+ * 4. Ids in `working` but not in `turn` are genuinely background-only. A host
+ *    whose entry carries no usable tier information (`turn` absent or
+ *    malformed) has an UNKNOWN tier: degrade its working ids to turns, the
+ *    conservative pre-existing behaviour. A publisher therefore only needs to
+ *    list ids it can positively classify; agents with no turn/background
+ *    distinction (terminal agents, CLI/TUI runs) simply stay in the turn set.
+ *
+ * Published by the host's per-user notification-room activity pin, filtered to
+ * the room's userId (rooms are per-user; publishing another user's agents would
+ * leak spinners across users on a shared host). Read by the gui-app's
+ * cross-epic activity surfaces. Shared here so writer and reader cannot drift.
+ */
+export const AGENT_ACTIVITY_AWARENESS_FIELD = "agentActivityByEpic";
+
+/**
+ * Awareness state field under which each host stamps its own `hostId` on the
+ * {@link AGENT_ACTIVITY_AWARENESS_FIELD} entry it publishes. Diagnostics, plus
+ * it lets a client tell its own host's entry apart from remote ones.
+ *
+ * Same frozen-shape and per-host-absence rules as
+ * {@link AGENT_ACTIVITY_AWARENESS_FIELD}: a plain string, outside
+ * `major`/`minor` negotiation, and OPTIONAL by design - an entry missing this
+ * field is still a valid activity entry and its epic buckets must still be
+ * read. Never treat it as a key or a filter.
+ */
+export const AGENT_ACTIVITY_HOST_ID_AWARENESS_FIELD = "agentActivityHostId";
+
 export const notificationsSubscribeOpenRequestSchema = z.object({});
 export type NotificationsSubscribeOpenRequest = z.infer<
   typeof notificationsSubscribeOpenRequestSchema
@@ -32,7 +99,13 @@ const notificationsSnapshotMetaSchema = z.object({
   schemaVersion: z.string(),
 });
 
-export const notificationsSubscribeServerFrameSchema = z.discriminatedUnion(
+// ─── Frozen notifications.subscribe@1.0 shape (as shipped) ────────────────
+//
+// IMMUTABLE. A client that negotiated @1.0 agreed to exactly these three frame
+// kinds, so this union must never learn a new one - sending a peer a frame it
+// did not negotiate is the host breaking the contract, not a "graceful"
+// degrade the peer happens to drop.
+export const notificationsSubscribeServerFrameSchemaV10 = z.discriminatedUnion(
   "kind",
   [
     z.object({
@@ -50,9 +123,57 @@ export const notificationsSubscribeServerFrameSchema = z.discriminatedUnion(
     }),
   ],
 );
-export type NotificationsSubscribeServerFrame = z.infer<
-  typeof notificationsSubscribeServerFrameSchema
+export type NotificationsSubscribeServerFrameV10 = z.infer<
+  typeof notificationsSubscribeServerFrameSchemaV10
 >;
+
+// ─── notifications.subscribe@1.1 - additive: room awareness ───────────────
+//
+// Adds the `awareness` frame: a y-protocols awareness update for the per-user
+// notification room, carrying each host's agent-activity presence (see
+// `AGENT_ACTIVITY_AWARENESS_FIELD`). Binary-only, like the room's `update`
+// frame - the payload is opaque to this contract and is NOT covered by
+// `major`/`minor` negotiation, which is why the awareness FIELD shapes are
+// frozen at their constants above.
+//
+// Server-only: the GUI reads activity and never publishes it, so the client
+// frame union is unchanged and shared by both minors.
+//
+// Eligibility MUST be gated on the NEGOTIATED minor by the emitting resolver:
+// a @1.0 client must never be sent this frame. Nothing in this contract
+// enforces that at runtime (streams have no bridges), so the gate is a
+// resolver obligation.
+export const notificationsSubscribeServerFrameSchemaV11 = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({
+      kind: z.literal("snapshot"),
+      meta: notificationsSnapshotMetaSchema,
+      hasBinaryPayload: z.literal(true),
+    }),
+    z.object({
+      kind: z.literal("update"),
+      hasBinaryPayload: z.literal(true),
+    }),
+    z.object({
+      kind: z.literal("pong"),
+      hasBinaryPayload: z.literal(false),
+    }),
+    z.object({
+      kind: z.literal("awareness"),
+      hasBinaryPayload: z.literal(true),
+    }),
+  ],
+);
+export type NotificationsSubscribeServerFrameV11 = z.infer<
+  typeof notificationsSubscribeServerFrameSchemaV11
+>;
+
+/** The latest installed shape. Host code builds frames against this. */
+export const notificationsSubscribeServerFrameSchema =
+  notificationsSubscribeServerFrameSchemaV11;
+export type NotificationsSubscribeServerFrame =
+  NotificationsSubscribeServerFrameV11;
 
 export const notificationsSubscribeClientFrameSchema = z.discriminatedUnion(
   "kind",
@@ -75,6 +196,14 @@ export const notificationsSubscribeV10 = defineStreamRpcContract({
   method: "notifications.subscribe",
   schemaVersion: { major: 1, minor: 0 } as const,
   openRequestSchema: notificationsSubscribeOpenRequestSchema,
-  serverFrameSchema: notificationsSubscribeServerFrameSchema,
+  serverFrameSchema: notificationsSubscribeServerFrameSchemaV10,
+  clientFrameSchema: notificationsSubscribeClientFrameSchema,
+});
+
+export const notificationsSubscribeV11 = defineStreamRpcContract({
+  method: "notifications.subscribe",
+  schemaVersion: { major: 1, minor: 1 } as const,
+  openRequestSchema: notificationsSubscribeOpenRequestSchema,
+  serverFrameSchema: notificationsSubscribeServerFrameSchemaV11,
   clientFrameSchema: notificationsSubscribeClientFrameSchema,
 });

--- a/protocol/src/host/registry.ts
+++ b/protocol/src/host/registry.ts
@@ -280,6 +280,7 @@ import {
   hostNotificationsFeedSubscribeV11,
   hostNotificationsSubscribeV10,
   notificationsSubscribeV10,
+  notificationsSubscribeV11,
 } from "@traycer/protocol/host/notifications/contracts";
 import { RELEASED_FLOOR_METHOD_NAMES } from "@traycer/protocol/host/released-floor";
 import {
@@ -4820,10 +4821,18 @@ const HOST_STREAM_RPC_REGISTRY_OTHER_DEFINITION = {
   },
   "notifications.subscribe": {
     1: {
-      latestMinor: 0,
+      // @1.1 adds the additive, server-only `awareness` frame (agent-activity
+      // presence on the per-user notification room). @1.0 stays installed and
+      // FROZEN: a client that negotiated it must never receive the new kind -
+      // the emitting resolver MUST gate on the negotiated version rather than
+      // assuming the peer will tolerate an unknown frame.
+      latestMinor: 1,
       versions: {
         0: {
           contract: notificationsSubscribeV10,
+        },
+        1: {
+          contract: notificationsSubscribeV11,
         },
       },
     },


### PR DESCRIPTION
## Problem

The "agent is working" spinner rides Yjs **awareness on per-epic collab rooms**, so it only reaches a client that has a live `epic.subscribe` session — an epic open in a tab, or still warm in the 5-slot MRU registry.

Consequence: an epic **never opened in this window** shows idle while its agent is actively running. Close a task while a turn is in flight and task history goes quiet. `useRegisteredEpicActiveAgentIds` returns an empty set for an unregistered epic, so `useEpicActivityStatus` reads `"idle"`, and no other channel carries "working" to a closed epic.

The defect is the room scoping, not presence itself.

## Approach

Move the signal to awareness on the **per-user notification room** (`notifications:<userId>`), which every signed-in client already subscribes to app-wide via `notifications.subscribe`.

Presence semantics are kept deliberately, because they are what makes this cheap and self-healing:

- the cloud merges **one awareness entry per host**, so a client sees the cross-host union for free;
- a host that dies or disconnects **ages out of awareness**, so its spinners clear with no cleanup protocol and no stuck-spinner failure mode.

```
host tracker → notification room → cloud (merge per host) → resolver → client replica → every surface
```

## What's here

**`notifications.subscribe@1.1`** — one additive server-only `awareness` frame (binary payload). No client awareness frame: the GUI only reads activity. The `@1.0` tree stays installed and frozen; a `@1.0` peer must never be sent the new kind, and the emitting resolver is obliged to gate on the negotiated minor (nothing in the contract can enforce that at runtime).

**Frozen awareness shape.** Awareness rides an opaque binary payload, outside `major`/`minor` negotiation, so the field shapes are frozen on day one and extended only by adding fields:

```ts
{
  agentActivityByEpic: { [epicId]: { working: string[], turn: string[] } },
  agentActivityHostId: string,
}
```

Reader rules mirror the retired epic fields: shape-check per entry and skip the offender, absence is per-host, ids in `working` but not `turn` are background-only, and an unclassifiable tier degrades to `turn`.

**Client global activity source.** The notifications store keeps a reader-only y-protocols `Awareness` replica and derives the cross-host union as `epicId → {working, turn}`. The four `epic-selectors` activity hooks are the migration seam, so task list, epics panel, tab strip, chat progress icons, sidebar tree, Active Agents panel, stop controls, TUI tiles and the MRU prune guard all move with them.

The replica is **swapped whole on every open** rather than cleared in place: `removeAwarenessStates` retains per-client `meta.clock`, which would make the host's attach-time replay a no-op and blank activity until the publisher's next renewal. It is backed by its own throwaway `Y.Doc` because `Awareness`'s constructor registers a `doc.on("destroy")` listener that `destroy()` never unregisters — reusing the long-lived notifications doc would retain every retired instance.

`useRegisteredEpicLiveAgentIds` returns `ReadonlySet | null`: `null` means "no session for this epic in this window" (unknown), an empty set means "a live projection that authoritatively holds no agents". That distinction is load-bearing — filtering a never-opened epic against an empty set would reinstate the original defect, while ignoring liveness entirely would resurrect stale spinners for deleted chats.

**Retirement.** The per-epic `agentWorking` / `agentWorkingTurn` fields and their readers are removed outright rather than dual-published, under a lock-step host+app assumption. The epic `awareness` frames themselves stay — cursors and selections still ride them.

## Interop

Host and app move together. Against an older host that only offers `@1.0`, no awareness frame is ever sent, the union is empty, and cross-epic surfaces read idle — an open epic still shows activity from its own chat session state.

## Verification

`bun run compile` green across protocol / shared / gui-app / desktop / CLI. gui-app suite: **835 files, 7973 tests passing**.

Behaviour confirmed in the dev app: a turn left running in a **closed** task keeps spinning in task history — the case the per-epic path could never cover.

Still exercised only by dogfooding: cross-host visibility (agent on host B seen from host A) and the ~30s awareness sweep clearing an ungracefully-killed host's spinners. The sweep is not expressible in vitest — `lib0`'s `getUnixTime` binds `Date.now` at module load, so a fake-timer test passes vacuously.

## Note on scope

This branch originally carried a notifications-session reopen driver as a companion fix. #751 landed the same fix independently and is the one kept here; that commit was dropped. The awareness replica composes with it explicitly — the scheduler reopens via its internal `openClient()` rather than re-entering `openNotificationsStream`, so the replica is reset at both entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
