### PR TITLE
feat: add agent roles feature setting

### DIFF
--- a/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/runner-ipc.test.ts
@@ -48,6 +48,21 @@ import type {
 } from "../../../ipc-contracts/window-types";
 import { createAuthenticatedUserFixture } from "@traycer-clients/shared/test-fixtures/authenticated-user";
 
+const featureSettings = vi.hoisted(() => ({ agentRoles: false }));
+const readFeatureSettingsMock = vi.hoisted(() =>
+  vi.fn(async () => ({ agentRoles: featureSettings.agentRoles })),
+);
+const setAgentRolesEnabledMock = vi.hoisted(() =>
+  vi.fn(async (enabled: boolean) => {
+    featureSettings.agentRoles = enabled;
+  }),
+);
+vi.mock("@traycer/protocol/config/store", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@traycer/protocol/config/store")>()),
+  readFeatureSettings: readFeatureSettingsMock,
+  setAgentRolesEnabled: setAgentRolesEnabledMock,
+}));
+
 /**
  * Runner-IPC bridge tests. We mock `electron` so the bridge can install its
  * handlers against a plain-JS `ipcMain` double, then drive the host and
@@ -560,6 +575,9 @@ beforeEach(() => {
   ipcMainState.syncListeners.clear();
   sentMessages.length = 0;
   vi.unstubAllGlobals();
+  featureSettings.agentRoles = false;
+  readFeatureSettingsMock.mockClear();
+  setAgentRolesEnabledMock.mockClear();
 });
 
 afterEach(() => {
@@ -728,6 +746,8 @@ describe("RunnerIpcBridge", () => {
         RunnerHostInvoke.gpuAccelerationSet,
         RunnerHostInvoke.logLevelsGet,
         RunnerHostInvoke.logLevelsSet,
+        RunnerHostInvoke.featureSettingsGet,
+        RunnerHostInvoke.agentRolesEnabledSet,
         RunnerHostInvoke.fontsList,
         RunnerHostInvoke.zoomGet,
         RunnerHostInvoke.zoomSet,
@@ -736,6 +756,47 @@ describe("RunnerIpcBridge", () => {
         RunnerHostInvoke.zoomReset,
       ].sort(),
     );
+    bridge.dispose();
+  });
+
+  it("gets and sets agent roles through typed IPC, rejecting non-boolean payloads", async () => {
+    const mod = await import("../register-runner-ipc");
+    const bridge = new mod.RunnerIpcBridge({
+      host: new FakeHost(),
+      hostController: new FakeHostController(),
+      authnBaseUrl: "http://localhost:5005",
+      authRedirectUri: null,
+      tray: null,
+      zoomController: undefined,
+      authTokenStore: undefined,
+      window: buildWindow(),
+    });
+    bridge.install();
+
+    const getHandler = ipcMainState.handlers.get(
+      RunnerHostInvoke.featureSettingsGet,
+    );
+    const setHandler = ipcMainState.handlers.get(
+      RunnerHostInvoke.agentRolesEnabledSet,
+    );
+    if (getHandler === undefined || setHandler === undefined) {
+      throw new Error("feature-settings IPC handlers were not registered");
+    }
+
+    await expect(getHandler(bareEvent())).resolves.toEqual({
+      agentRoles: false,
+    });
+    await expect(setHandler(bareEvent(), true)).resolves.toEqual({
+      agentRoles: true,
+    });
+    expect(setAgentRolesEnabledMock).toHaveBeenCalledWith(true);
+    await expect(getHandler(bareEvent())).resolves.toEqual({
+      agentRoles: true,
+    });
+    await expect(setHandler(bareEvent(), "yes")).rejects.toThrow(
+      "featureSettings:agentRoles:set requires a boolean",
+    );
+    expect(setAgentRolesEnabledMock).toHaveBeenCalledTimes(1);
     bridge.dispose();
   });
 

--- a/clients/desktop/src/electron-main/ipc/platform-ipc.ts
+++ b/clients/desktop/src/electron-main/ipc/platform-ipc.ts
@@ -64,11 +64,17 @@ import {
   getDesktopLogLevel,
   setDesktopLogLevel,
 } from "../app/desktop-log-level";
-import { readLogLevels, setLogLevels } from "@traycer/protocol/config/store";
+import {
+  readFeatureSettings,
+  readLogLevels,
+  setAgentRolesEnabled,
+  setLogLevels,
+} from "@traycer/protocol/config/store";
 import { isLogLevel, type LogLevel } from "@traycer/protocol/config/log-level";
 import type {
   LogLevelScope,
   LogLevelsSnapshot,
+  FeatureSettingsSnapshot,
 } from "../../ipc-contracts/platform-types";
 
 /**
@@ -416,6 +422,22 @@ export function registerPlatformIpc(bridge: RunnerIpcBridge): void {
         );
       }
       return readLogLevelsSnapshot();
+    },
+  );
+
+  bridge.handleInvoke(
+    RunnerHostInvoke.featureSettingsGet,
+    (): Promise<FeatureSettingsSnapshot> => readFeatureSettings(),
+  );
+
+  bridge.handleInvoke(
+    RunnerHostInvoke.agentRolesEnabledSet,
+    async (_event, enabled: unknown): Promise<FeatureSettingsSnapshot> => {
+      if (typeof enabled !== "boolean") {
+        throw new Error("featureSettings:agentRoles:set requires a boolean");
+      }
+      await setAgentRolesEnabled(enabled);
+      return readFeatureSettings();
     },
   );
 

--- a/clients/desktop/src/electron-preload/platform-bridge.ts
+++ b/clients/desktop/src/electron-preload/platform-bridge.ts
@@ -7,6 +7,7 @@ import type {
   AccessibilityThemeSnapshot,
   BackgroundMaterial,
   DisplayTopology,
+  FeatureSettingsSnapshot,
   InstalledFont,
   LogLevel,
   LogLevelScope,
@@ -107,6 +108,10 @@ export interface PlatformBridgeSurface {
   logLevels: {
     get(): Promise<LogLevelsSnapshot>;
     set(scope: LogLevelScope, level: LogLevel): Promise<LogLevelsSnapshot>;
+  };
+  featureSettings: {
+    get(): Promise<FeatureSettingsSnapshot>;
+    setAgentRolesEnabled(enabled: boolean): Promise<FeatureSettingsSnapshot>;
   };
   fonts: {
     list(): Promise<readonly InstalledFont[]>;
@@ -298,6 +303,17 @@ export function buildPlatformBridge(): PlatformBridgeSurface {
           scope,
           level,
         }) as Promise<LogLevelsSnapshot>,
+    },
+    featureSettings: {
+      get: () =>
+        ipcRenderer.invoke(
+          RunnerHostInvoke.featureSettingsGet,
+        ) as Promise<FeatureSettingsSnapshot>,
+      setAgentRolesEnabled: (enabled) =>
+        ipcRenderer.invoke(
+          RunnerHostInvoke.agentRolesEnabledSet,
+          enabled,
+        ) as Promise<FeatureSettingsSnapshot>,
     },
     fonts: {
       list: () =>

--- a/clients/desktop/src/ipc-contracts/ipc-channels.ts
+++ b/clients/desktop/src/ipc-contracts/ipc-channels.ts
@@ -154,6 +154,8 @@ export const RunnerHostInvoke = {
   gpuAccelerationSet: "runnerHost:gpu:set",
   logLevelsGet: "runnerHost:logLevels:get",
   logLevelsSet: "runnerHost:logLevels:set",
+  featureSettingsGet: "runnerHost:featureSettings:get",
+  agentRolesEnabledSet: "runnerHost:featureSettings:agentRoles:set",
   // Enumerates fonts installed on this machine for the Appearance font
   // pickers (Settings → Appearance → UI/Code/Terminal font).
   fontsList: "runnerHost:fonts:list",

--- a/clients/desktop/src/ipc-contracts/platform-types.ts
+++ b/clients/desktop/src/ipc-contracts/platform-types.ts
@@ -99,6 +99,10 @@ export interface LogLevelsSnapshot {
   readonly desktopLogLevel: LogLevel;
 }
 
+export interface FeatureSettingsSnapshot {
+  readonly agentRoles: boolean;
+}
+
 /** A font family installed on this machine, offered by the Appearance font pickers. */
 export interface InstalledFont {
   readonly family: string;

--- a/clients/gui-app/src/components/chat/segments/__tests__/text-segment-next-steps.test.tsx
+++ b/clients/gui-app/src/components/chat/segments/__tests__/text-segment-next-steps.test.tsx
@@ -68,6 +68,10 @@ vi.mock("@/hooks/epic/use-epic-tile-navigation", () => ({
   }),
 }));
 
+vi.mock("@/hooks/runner/use-runner-feature-settings-query", () => ({
+  useAgentRolesEnabled: () => true,
+}));
+
 const COMPLETE_BLOCK = [
   "<TRAYCER_NEXT_STEPS>",
   "Implementation is complete.",

--- a/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
@@ -122,6 +122,13 @@ interface TestRunnerHost {
   hostManagement: { uninstallTraycer: Mock } | null;
 }
 
+interface TestFeatureSettingsBridge {
+  readonly get: Mock<() => Promise<{ readonly agentRoles: boolean }>>;
+  readonly setAgentRolesEnabled: Mock<
+    (enabled: boolean) => Promise<{ readonly agentRoles: boolean }>
+  >;
+}
+
 const runnerHostMock = vi.hoisted((): { current: TestRunnerHost } => ({
   current: { hostManagement: null },
 }));
@@ -263,6 +270,80 @@ describe("GeneralSettingsPanel", () => {
     useAuthStore.getState().setSignedOut();
     useLocalSnapshotClearStore.setState({ clearedAtByScope: {} });
     useOnboardingStore.setState({ completedAt: null, step: 0 });
+    delete (globalThis as { runnerHost?: unknown }).runnerHost;
+  });
+
+  it("hydrates and updates Agent roles under Experimental", async () => {
+    const bridge: TestFeatureSettingsBridge = {
+      get: vi.fn(() => Promise.resolve({ agentRoles: false })),
+      setAgentRolesEnabled: vi.fn((enabled) =>
+        Promise.resolve({ agentRoles: enabled }),
+      ),
+    };
+    (globalThis as { runnerHost?: unknown }).runnerHost = {
+      platform: { featureSettings: bridge },
+    };
+
+    renderPanel();
+
+    expect(screen.getByText("Experimental")).toBeTruthy();
+    const toggle = screen.getByRole("switch", { name: "Agent roles" });
+    await waitFor(() => expect(toggle.hasAttribute("disabled")).toBe(false));
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(bridge.setAgentRolesEnabled).toHaveBeenCalledWith(true),
+    );
+    await waitFor(() =>
+      expect(toggle.getAttribute("aria-checked")).toBe("true"),
+    );
+  });
+
+  it("surfaces feature-settings read failures and keeps Agent roles disabled", async () => {
+    const bridge: TestFeatureSettingsBridge = {
+      get: vi.fn(() => Promise.reject(new Error("invalid config"))),
+      setAgentRolesEnabled: vi.fn((enabled) =>
+        Promise.resolve({ agentRoles: enabled }),
+      ),
+    };
+    (globalThis as { runnerHost?: unknown }).runnerHost = {
+      platform: { featureSettings: bridge },
+    };
+
+    renderPanel();
+
+    expect(
+      await screen.findByText(/Couldn't read feature settings/),
+    ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("switch", { name: "Agent roles" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(bridge.setAgentRolesEnabled).not.toHaveBeenCalled();
+  });
+
+  it("preserves the Agent roles value when the settings write fails", async () => {
+    const bridge: TestFeatureSettingsBridge = {
+      get: vi.fn(() => Promise.resolve({ agentRoles: false })),
+      setAgentRolesEnabled: vi.fn(() =>
+        Promise.reject(new Error("write failed")),
+      ),
+    };
+    (globalThis as { runnerHost?: unknown }).runnerHost = {
+      platform: { featureSettings: bridge },
+    };
+
+    renderPanel();
+
+    const toggle = screen.getByRole("switch", { name: "Agent roles" });
+    await waitFor(() => expect(toggle.hasAttribute("disabled")).toBe(false));
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(bridge.setAgentRolesEnabled).toHaveBeenCalledWith(true),
+    );
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
   });
 
   it("renders the Data migration row and starts the stream on click", () => {

--- a/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
+++ b/clients/gui-app/src/components/settings/panels/__tests__/general-settings-panel.test.tsx
@@ -274,11 +274,13 @@ describe("GeneralSettingsPanel", () => {
   });
 
   it("hydrates and updates Agent roles under Experimental", async () => {
+    let agentRoles = false;
     const bridge: TestFeatureSettingsBridge = {
-      get: vi.fn(() => Promise.resolve({ agentRoles: false })),
-      setAgentRolesEnabled: vi.fn((enabled) =>
-        Promise.resolve({ agentRoles: enabled }),
-      ),
+      get: vi.fn(() => Promise.resolve({ agentRoles })),
+      setAgentRolesEnabled: vi.fn((enabled) => {
+        agentRoles = enabled;
+        return Promise.resolve({ agentRoles });
+      }),
     };
     (globalThis as { runnerHost?: unknown }).runnerHost = {
       platform: { featureSettings: bridge },
@@ -297,6 +299,7 @@ describe("GeneralSettingsPanel", () => {
     await waitFor(() =>
       expect(toggle.getAttribute("aria-checked")).toBe("true"),
     );
+    await waitFor(() => expect(bridge.get).toHaveBeenCalledTimes(2));
   });
 
   it("surfaces feature-settings read failures and keeps Agent roles disabled", async () => {

--- a/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
@@ -44,6 +44,9 @@ import { useLocalSnapshotClearStore } from "@/stores/settings/local-snapshot-cle
 import { useOnboardingStore } from "@/stores/onboarding/onboarding-store";
 import { trackSettingChanged, type AnalyticsSetting } from "@/lib/analytics";
 import { modLabel } from "@/lib/keybindings/platform";
+import { getFeatureSettingsBridge } from "@/lib/desktop-feature-settings";
+import { useRunnerFeatureSettingsQuery } from "@/hooks/runner/use-runner-feature-settings-query";
+import { useRunnerAgentRolesSet } from "@/hooks/runner/use-runner-agent-roles-set-mutation";
 
 const MIGRATION_PROGRESS_LABEL = "Migrating tasks";
 const SNAPSHOTS_LOCAL_STORAGE_PARAMS = {};
@@ -115,6 +118,9 @@ export function GeneralSettingsPanel() {
     (s) => s.setSteerOnModEnterEnabled,
   );
   const compact = useSettingsDensity() === "compact";
+  const featureSettings = useRunnerFeatureSettingsQuery();
+  const setAgentRoles = useRunnerAgentRolesSet();
+  const featureSettingsAvailable = getFeatureSettingsBridge() !== null;
 
   return (
     <SettingsPanelShell
@@ -223,6 +229,37 @@ export function GeneralSettingsPanel() {
             }
           />
         </SettingsGroup>
+
+        {featureSettingsAvailable ? (
+          <SettingsGroup
+            title="Experimental"
+            tone="default"
+            dataTestId={undefined}
+            fill={false}
+          >
+            <SettingsRow
+              label="Agent roles"
+              description={
+                featureSettings.isError
+                  ? "Couldn't read feature settings. Fix or delete ~/.traycer/cli/config.json, then reopen Settings."
+                  : "Let agents claim durable responsibilities and coordinate through role-aware tools and prompts."
+              }
+              control={
+                <Switch
+                  checked={featureSettings.data?.agentRoles === true}
+                  disabled={
+                    featureSettings.data === undefined ||
+                    setAgentRoles.isPending
+                  }
+                  onCheckedChange={(enabled) => {
+                    setAgentRoles.mutate(enabled);
+                  }}
+                  aria-label="Agent roles"
+                />
+              }
+            />
+          </SettingsGroup>
+        ) : null}
 
         <SettingsGroup
           title="Setup & migration"

--- a/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
+++ b/clients/gui-app/src/components/settings/panels/general-settings-panel.tsx
@@ -241,7 +241,7 @@ export function GeneralSettingsPanel() {
               label="Agent roles"
               description={
                 featureSettings.isError
-                  ? "Couldn't read feature settings. Fix or delete ~/.traycer/cli/config.json, then reopen Settings."
+                  ? "Couldn't read feature settings. Repair ~/.traycer/cli/config.json, or back it up before resetting it, then reopen Settings."
                   : "Let agents claim durable responsibilities and coordinate through role-aware tools and prompts."
               }
               control={

--- a/clients/gui-app/src/hooks/runner/use-runner-agent-roles-set-mutation.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-agent-roles-set-mutation.ts
@@ -22,8 +22,11 @@ export function useRunnerAgentRolesSet() {
       }
       return bridge.setAgentRolesEnabled(enabled);
     },
-    onSuccess: (snapshot: FeatureSettingsSnapshot) => {
-      queryClient.setQueryData(runnerQueryKeys.featureSettings(), snapshot);
+    onSuccess: async (snapshot: FeatureSettingsSnapshot) => {
+      const queryKey = runnerQueryKeys.featureSettings();
+      await queryClient.cancelQueries({ queryKey });
+      queryClient.setQueryData(queryKey, snapshot);
+      await queryClient.invalidateQueries({ queryKey });
     },
     onError: (error) =>
       toastFromRunnerError(error, "Couldn't update agent roles"),

--- a/clients/gui-app/src/hooks/runner/use-runner-agent-roles-set-mutation.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-agent-roles-set-mutation.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getFeatureSettingsBridge,
+  type FeatureSettingsSnapshot,
+} from "@/lib/desktop-feature-settings";
+import {
+  runnerMutationKeys,
+  runnerQueryKeys,
+} from "@/lib/query-keys/runner-mutation-keys";
+import { toastFromRunnerError } from "@/lib/runner-error-toast";
+
+export function useRunnerAgentRolesSet() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: runnerMutationKeys.agentRolesEnabledSet(),
+    mutationFn: (enabled: boolean) => {
+      const bridge = getFeatureSettingsBridge();
+      if (bridge === null) {
+        throw new Error(
+          "Feature settings are only available in the desktop app.",
+        );
+      }
+      return bridge.setAgentRolesEnabled(enabled);
+    },
+    onSuccess: (snapshot: FeatureSettingsSnapshot) => {
+      queryClient.setQueryData(runnerQueryKeys.featureSettings(), snapshot);
+    },
+    onError: (error) =>
+      toastFromRunnerError(error, "Couldn't update agent roles"),
+  });
+}

--- a/clients/gui-app/src/hooks/runner/use-runner-feature-settings-query.ts
+++ b/clients/gui-app/src/hooks/runner/use-runner-feature-settings-query.ts
@@ -1,0 +1,29 @@
+import { queryOptions, useQuery } from "@tanstack/react-query";
+import {
+  getFeatureSettingsBridge,
+  type FeatureSettingsSnapshot,
+} from "@/lib/desktop-feature-settings";
+import { runnerQueryKeys } from "@/lib/query-keys/runner-mutation-keys";
+
+export function useRunnerFeatureSettingsQuery() {
+  return useQuery(
+    queryOptions<FeatureSettingsSnapshot>({
+      queryKey: runnerQueryKeys.featureSettings(),
+      queryFn: () => {
+        const bridge = getFeatureSettingsBridge();
+        if (bridge === null) {
+          throw new Error(
+            "Feature settings are only available in the desktop app.",
+          );
+        }
+        return bridge.get();
+      },
+      enabled: getFeatureSettingsBridge() !== null,
+      staleTime: 30_000,
+    }),
+  );
+}
+
+export function useAgentRolesEnabled(): boolean {
+  return useRunnerFeatureSettingsQuery().data?.agentRoles === true;
+}

--- a/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
+++ b/clients/gui-app/src/lib/__tests__/epic-selectors.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { act, cleanup, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   ChatRunSettings,
   GuiHarnessId,
@@ -9,9 +9,16 @@ import type {
 import { EpicSessionContext } from "@/lib/registries/epic-session-registry";
 import {
   useEpicChatHarnessId,
+  useEpicAgentRoleClaims,
+  useEpicAgentRoleClaimsByAgentId,
   useEpicSyncPillState,
   useMaybeEpicTuiAgentHarnessId,
 } from "@/lib/epic-selectors";
+
+const featureSettings = vi.hoisted(() => ({ enabled: true }));
+vi.mock("@/hooks/runner/use-runner-feature-settings-query", () => ({
+  useAgentRolesEnabled: () => featureSettings.enabled,
+}));
 import {
   createOpenEpicStore,
   type EpicStreamClientFactory,
@@ -26,6 +33,7 @@ const handles: OpenEpicStoreHandle[] = [];
 
 afterEach(() => {
   cleanup();
+  featureSettings.enabled = true;
   for (const handle of handles) {
     handle.dispose();
   }
@@ -236,6 +244,44 @@ describe("useEpicSyncPillState", () => {
     });
 
     expect(result.current).toBe("synced");
+  });
+});
+
+describe("agent role selectors", () => {
+  const claim = {
+    claimId: "11111111-1111-4111-8111-111111111111",
+    agentId: "agent-1",
+    userId: "user-1",
+    role: "Planner",
+    scope: "selector tests",
+    claimedAt: 1,
+  };
+
+  it("hides projected claims while disabled and restores them without a Yjs update", () => {
+    const handle = createHandle("epic-role-selector-gate");
+    handle.store.setState({
+      agentRoles: { byAgentId: { "agent-1": [claim] } },
+    });
+
+    const { result, rerender } = renderHook(
+      () => ({
+        claims: useEpicAgentRoleClaims("agent-1"),
+        byAgent: useEpicAgentRoleClaimsByAgentId(),
+      }),
+      { wrapper: openEpicWrapper(handle) },
+    );
+    expect(result.current.claims).toEqual([claim]);
+    expect(result.current.byAgent).toEqual({ "agent-1": [claim] });
+
+    featureSettings.enabled = false;
+    rerender();
+    expect(result.current.claims).toEqual([]);
+    expect(result.current.byAgent).toEqual({});
+
+    featureSettings.enabled = true;
+    rerender();
+    expect(result.current.claims).toEqual([claim]);
+    expect(result.current.byAgent).toEqual({ "agent-1": [claim] });
   });
 });
 

--- a/clients/gui-app/src/lib/desktop-feature-settings.ts
+++ b/clients/gui-app/src/lib/desktop-feature-settings.ts
@@ -1,0 +1,21 @@
+export interface FeatureSettingsSnapshot {
+  readonly agentRoles: boolean;
+}
+
+export interface FeatureSettingsBridge {
+  readonly get: () => Promise<FeatureSettingsSnapshot>;
+  readonly setAgentRolesEnabled: (
+    enabled: boolean,
+  ) => Promise<FeatureSettingsSnapshot>;
+}
+
+interface RunnerHostWindowShape {
+  readonly platform:
+    { readonly featureSettings: FeatureSettingsBridge | undefined } | undefined;
+}
+
+export function getFeatureSettingsBridge(): FeatureSettingsBridge | null {
+  const host = (globalThis as { runnerHost?: RunnerHostWindowShape })
+    .runnerHost;
+  return host?.platform?.featureSettings ?? null;
+}

--- a/clients/gui-app/src/lib/epic-selectors.ts
+++ b/clients/gui-app/src/lib/epic-selectors.ts
@@ -53,6 +53,7 @@ import { useEpicStore } from "@/hooks/use-epic-store";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 import { UNKNOWN_HOST_PLACEHOLDER } from "@/lib/host/constants";
 import { useTerminalDisplayTitle } from "@/hooks/terminal/use-terminal-display-title";
+import { useAgentRolesEnabled } from "@/hooks/runner/use-runner-feature-settings-query";
 import {
   useMaybeOpenEpicHandle,
   useOpenEpicHandle,
@@ -126,6 +127,9 @@ const EMPTY_NODES_AS_ARTIFACTS: ReadonlyArray<ArtifactProjection> =
 const EMPTY_TREE_ID_ARRAY: readonly string[] = EMPTY_ARRAY;
 const EMPTY_TREE_ID_SET: ReadonlySet<string> = new Set<string>();
 const EMPTY_ROLE_CLAIMS: readonly RoleClaim[] = Object.freeze([]);
+const EMPTY_ROLE_CLAIMS_BY_AGENT_ID: Readonly<
+  Record<string, readonly RoleClaim[]>
+> = Object.freeze({});
 
 export { EMPTY_TREE_ID_ARRAY, EMPTY_TREE_ID_SET };
 
@@ -1098,17 +1102,21 @@ export function useEpicTreeNode(id: string): TreeNode | null {
 }
 
 export function useEpicAgentRoleClaims(agentId: string): readonly RoleClaim[] {
-  return useEpicStore((s) =>
+  const enabled = useAgentRolesEnabled();
+  const claims = useEpicStore((s) =>
     Object.hasOwn(s.agentRoles.byAgentId, agentId)
       ? s.agentRoles.byAgentId[agentId]
       : EMPTY_ROLE_CLAIMS,
   );
+  return enabled ? claims : EMPTY_ROLE_CLAIMS;
 }
 
 export function useEpicAgentRoleClaimsByAgentId(): Readonly<
   Record<string, readonly RoleClaim[]>
 > {
-  return useEpicStore((s) => s.agentRoles.byAgentId);
+  const enabled = useAgentRolesEnabled();
+  const claims = useEpicStore((s) => s.agentRoles.byAgentId);
+  return enabled ? claims : EMPTY_ROLE_CLAIMS_BY_AGENT_ID;
 }
 
 /**

--- a/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
+++ b/clients/gui-app/src/lib/query-keys/runner-mutation-keys.ts
@@ -56,6 +56,8 @@ export const runnerMutationKeys = {
   // Settings → log level (desktop/cli/host). Machine-local config, not
   // host-scoped, so a single static key suffices.
   logLevelsSet: () => ["runner.logLevels.set"] as const,
+  agentRolesEnabledSet: () =>
+    ["runner.featureSettings.agentRoles.set"] as const,
   setAllowPrereleaseUpdates: () =>
     ["runner.appUpdates.setAllowPrerelease"] as const,
   globalShortcutsSet: (id: GlobalShortcutId) =>
@@ -121,6 +123,7 @@ export const runnerQueryKeys = {
   // The three configurable log thresholds, read together from the desktop
   // platform bridge. Machine-local, so not host-scoped.
   logLevels: () => ["runner.logLevels"] as const,
+  featureSettings: () => ["runner.featureSettings"] as const,
   // Fonts installed on this machine (Settings → Appearance font pickers).
   // Machine-local and effectively static for the session, so a single
   // static key suffices.

--- a/clients/traycer-cli/src/__tests__/cli-version.test.ts
+++ b/clients/traycer-cli/src/__tests__/cli-version.test.ts
@@ -1,7 +1,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { LOCAL_CLI_VERSION, buildProgram, resolveCliVersion } from "../index";
+import type { Command } from "commander";
+import {
+  LOCAL_CLI_VERSION,
+  buildProgram,
+  buildProgramWithAgentRoles,
+  resolveCliVersion,
+} from "../index";
 
 // `traycer --version` must report the release-injected
 // `TRAYCER_CLI_VERSION` for SEA builds and the local/dev fallback
@@ -143,5 +149,46 @@ describe("buildProgram() Commander version registration", () => {
         process.env.TRAYCER_CLI_VERSION = previous;
       }
     }
+  });
+});
+
+describe("buildProgramWithAgentRoles() command registration", () => {
+  function commandNames(program: Command): string[] {
+    return program.commands.map((command) => command.name());
+  }
+
+  function nestedCommandNames(program: Command, parentName: string): string[] {
+    const parent = program.commands.find(
+      (command) => command.name() === parentName,
+    );
+    if (parent === undefined) return [];
+    return parent.commands.map((command) => command.name());
+  }
+
+  it("omits agent role commands when the feature is disabled", () => {
+    const program = buildProgramWithAgentRoles(false);
+    const agent = program.commands.find(
+      (command) => command.name() === "agent",
+    );
+
+    expect(commandNames(program)).toContain("agent");
+    expect(nestedCommandNames(program, "agent")).not.toContain("role");
+    expect(agent?.helpInformation()).not.toContain("role");
+  });
+
+  it("registers the role command group and its operations when enabled", () => {
+    const program = buildProgramWithAgentRoles(true);
+    const agent = program.commands.find(
+      (command) => command.name() === "agent",
+    );
+    const role = agent?.commands.find((command) => command.name() === "role");
+
+    expect(role).toBeDefined();
+    expect(role?.commands.map((command) => command.name())).toEqual([
+      "claim",
+      "list",
+      "relinquish",
+    ]);
+    expect(agent?.helpInformation()).toContain("role");
   });
 });

--- a/clients/traycer-cli/src/commands/__tests__/agent-role.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/agent-role.test.ts
@@ -29,7 +29,7 @@ import {
   buildAgentRoleRelinquishCommand,
 } from "../agent-role";
 import { callHostRpc } from "../../internal/host-rpc";
-import { buildProgram } from "../../index";
+import { buildProgramWithAgentRoles } from "../../index";
 import { CliError } from "../../runner/errors";
 import type { CommandContext } from "../../runner/runner";
 import type { RuntimeContext } from "../../runner/runtime";
@@ -274,7 +274,7 @@ describe("agent role relinquish command function", () => {
 
 describe("Commander registration (buildProgram)", () => {
   function findRoleCommand() {
-    const program = buildProgram();
+    const program = buildProgramWithAgentRoles(true);
     const agent = program.commands.find((cmd) => cmd.name() === "agent");
     expect(agent).toBeDefined();
     const role = agent?.commands.find((cmd) => cmd.name() === "role");
@@ -322,5 +322,11 @@ describe("Commander registration (buildProgram)", () => {
     expect(help).toContain("claim");
     expect(help).toContain("list");
     expect(help).toContain("relinquish");
+  });
+
+  it("does not register the role subgroup when agent roles are disabled", () => {
+    const program = buildProgramWithAgentRoles(false);
+    const agent = program.commands.find((cmd) => cmd.name() === "agent");
+    expect(agent?.commands.map((cmd) => cmd.name())).not.toContain("role");
   });
 });

--- a/clients/traycer-cli/src/index.ts
+++ b/clients/traycer-cli/src/index.ts
@@ -8,6 +8,7 @@ import {
   type Command as CommanderCommand,
 } from "commander";
 import { AGENT_FACING_HARNESS_ID_LIST } from "@traycer/protocol/host/agent/shared";
+import { readFeatureSettingsSync } from "@traycer/protocol/config/store";
 import { config } from "./config";
 import { cliFinalizeUpgradeCommand } from "./commands/cli-finalize-upgrade";
 import { buildCliMarkSourceCommand } from "./commands/cli-mark-source";
@@ -207,6 +208,12 @@ export function resolveCliVersion(
 // follow-up bug) without spawning a subprocess. The script-mode call at
 // the bottom of this file is the only place that invokes parseAsync.
 export function buildProgram(): Command {
+  return buildProgramWithAgentRoles(readFeatureSettingsSync().agentRoles);
+}
+
+export function buildProgramWithAgentRoles(
+  agentRolesEnabled: boolean,
+): Command {
   const program = new Command();
   program
     .name("traycer")
@@ -218,7 +225,7 @@ export function buildProgram(): Command {
   // `optsWithGlobals()` which is what the runner-aware action handlers
   // rely on.
   addRunnerFlags(program);
-  registerCommands(program);
+  registerCommands(program, agentRolesEnabled);
   // Route commander's own parse failures (missing required option, unknown
   // option/command) through the runner's error contract so `--json`
   // consumers get a structured `result/error` envelope instead of a bare
@@ -302,7 +309,7 @@ function collectValueOptionFlags(root: Command): Set<string> {
 // group and returns void after wiring its commands onto `program`. Keep
 // this split when adding new commands - the body of `registerCommands`
 // stays a single page of declarative registrations.
-function registerCommands(program: Command): void {
+function registerCommands(program: Command, agentRolesEnabled: boolean): void {
   registerAuthCommands(program);
   registerHostCommands(program);
   registerCliCommands(program);
@@ -310,7 +317,7 @@ function registerCommands(program: Command): void {
   registerCommentsCommands(program);
   registerWorkspaceCommands(program);
   registerWorktreeCommands(program);
-  registerAgentCommands(program);
+  registerAgentCommands(program, agentRolesEnabled);
   registerMonitorCommand(program);
 }
 
@@ -1447,7 +1454,10 @@ function registerWorktreeCommands(program: Command): void {
   );
 }
 
-function registerAgentCommands(program: Command): void {
+function registerAgentCommands(
+  program: Command,
+  agentRolesEnabled: boolean,
+): void {
   const cliSurface = resolveAgentCliSurface(readonlyEnv());
   const readonlyHidden = { hidden: cliSurface === "readonly" };
   const harnessHelp = `Harness id: ${AGENT_FACING_HARNESS_ID_LIST}`;
@@ -1745,73 +1755,75 @@ function registerAgentCommands(program: Command): void {
       }),
   );
 
-  const role = agent
-    .command("role")
-    .description(
-      "Claim, list, and relinquish durable Task-local roles for the calling agent",
+  if (agentRolesEnabled) {
+    const role = agent
+      .command("role")
+      .description(
+        "Claim, list, and relinquish durable Task-local roles for the calling agent",
+      );
+
+    withRunner(
+      role
+        .command("claim", readonlyHidden)
+        .description(
+          "Claim a durable role for the calling agent in this Task's role registry",
+        )
+        .requiredOption(
+          "--role <name>",
+          "Role name to claim. Short and memorable; disambiguate against existing roles.",
+        )
+        .requiredOption(
+          "--scope <scope>",
+          "Task-local scope of responsibility this role covers",
+        )
+        .option("--epic-id <id>", "Epic (defaults to $TRAYCER_EPIC_ID)")
+        .option(
+          "--agent-id <id>",
+          "Claiming agent (defaults to $TRAYCER_AGENT_ID)",
+        ),
+      (opts) =>
+        buildAgentRoleClaimCommand({
+          epicId: typeof opts.epicId === "string" ? opts.epicId : null,
+          agentId: typeof opts.agentId === "string" ? opts.agentId : null,
+          role: typeof opts.role === "string" ? opts.role : null,
+          scope: typeof opts.scope === "string" ? opts.scope : null,
+        }),
     );
 
-  withRunner(
-    role
-      .command("claim", readonlyHidden)
-      .description(
-        "Claim a durable role for the calling agent in this Task's role registry",
-      )
-      .requiredOption(
-        "--role <name>",
-        "Role name to claim. Short and memorable; disambiguate against existing roles.",
-      )
-      .requiredOption(
-        "--scope <scope>",
-        "Task-local scope of responsibility this role covers",
-      )
-      .option("--epic-id <id>", "Epic (defaults to $TRAYCER_EPIC_ID)")
-      .option(
-        "--agent-id <id>",
-        "Claiming agent (defaults to $TRAYCER_AGENT_ID)",
-      ),
-    (opts) =>
-      buildAgentRoleClaimCommand({
-        epicId: typeof opts.epicId === "string" ? opts.epicId : null,
-        agentId: typeof opts.agentId === "string" ? opts.agentId : null,
-        role: typeof opts.role === "string" ? opts.role : null,
-        scope: typeof opts.scope === "string" ? opts.scope : null,
-      }),
-  );
+    withRunner(
+      role
+        .command("list")
+        .description(
+          "List the roles currently claimed in this Task (your account's live agents only)",
+        )
+        .option("--epic-id <id>", "Epic (defaults to $TRAYCER_EPIC_ID)"),
+      (opts) =>
+        buildAgentRoleListCommand({
+          epicId: typeof opts.epicId === "string" ? opts.epicId : null,
+        }),
+    );
 
-  withRunner(
-    role
-      .command("list")
-      .description(
-        "List the roles currently claimed in this Task (your account's live agents only)",
-      )
-      .option("--epic-id <id>", "Epic (defaults to $TRAYCER_EPIC_ID)"),
-    (opts) =>
-      buildAgentRoleListCommand({
-        epicId: typeof opts.epicId === "string" ? opts.epicId : null,
-      }),
-  );
-
-  withRunner(
-    role
-      .command("relinquish", readonlyHidden)
-      .description("Relinquish a role claim held by the calling agent")
-      .requiredOption(
-        "--claim-id <id>",
-        "Claim id to relinquish (see 'traycer agent role list')",
-      )
-      .option("--epic-id <id>", "Epic (defaults to $TRAYCER_EPIC_ID)")
-      .option(
-        "--agent-id <id>",
-        "Relinquishing agent (defaults to $TRAYCER_AGENT_ID)",
-      ),
-    (opts) =>
-      buildAgentRoleRelinquishCommand({
-        epicId: typeof opts.epicId === "string" ? opts.epicId : null,
-        agentId: typeof opts.agentId === "string" ? opts.agentId : null,
-        claimId: typeof opts.claimId === "string" ? opts.claimId : null,
-      }),
-  );
+    withRunner(
+      role
+        .command("relinquish", readonlyHidden)
+        .description("Relinquish a role claim held by the calling agent")
+        .requiredOption(
+          "--claim-id <id>",
+          "Claim id to relinquish (see 'traycer agent role list')",
+        )
+        .option("--epic-id <id>", "Epic (defaults to $TRAYCER_EPIC_ID)")
+        .option(
+          "--agent-id <id>",
+          "Relinquishing agent (defaults to $TRAYCER_AGENT_ID)",
+        ),
+      (opts) =>
+        buildAgentRoleRelinquishCommand({
+          epicId: typeof opts.epicId === "string" ? opts.epicId : null,
+          agentId: typeof opts.agentId === "string" ? opts.agentId : null,
+          claimId: typeof opts.claimId === "string" ? opts.claimId : null,
+        }),
+    );
+  }
 
   withRunner(
     agent

--- a/protocol/src/config/__tests__/store.test.ts
+++ b/protocol/src/config/__tests__/store.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -41,12 +41,15 @@ import {
   loadEffectiveShellConfig,
   migrateCliConfig,
   readCliConfig,
+  readFeatureSettings,
+  readFeatureSettingsSync,
   readLogLevels,
   readLogLevelsSync,
   removeShell,
   resetShell,
   revertShellArgs,
   setEnvOverride,
+  setAgentRolesEnabled,
   setLogLevels,
   setShell,
   writeCliConfig,
@@ -70,6 +73,11 @@ describe("cli config store", () => {
     expect(await readCliConfig()).toEqual(EMPTY_CLI_CONFIG);
   });
 
+  it("defaults agent roles off when feature settings are missing", async () => {
+    expect(await readFeatureSettings()).toEqual({ agentRoles: false });
+    expect(readFeatureSettingsSync()).toEqual({ agentRoles: false });
+  });
+
   it("round-trips a written config through the schema", async () => {
     const cfg = {
       version: 1 as const,
@@ -80,6 +88,7 @@ describe("cli config store", () => {
       },
       envOverrides: { FOO: "bar" },
       logs: { cliLogLevel: "info" as const, hostLogLevel: "info" as const },
+      features: { agentRoles: false },
     };
     await writeCliConfig(cfg);
     expect(await readCliConfig()).toEqual(cfg);
@@ -142,6 +151,79 @@ describe("cli config store", () => {
     expect(readLogLevelsSync()).toEqual({
       cliLogLevel: "debug",
       hostLogLevel: "trace",
+    });
+  });
+
+  it("fails closed for malformed and future-version feature config reads", async () => {
+    await writeRaw("{ not json");
+    expect(readFeatureSettingsSync()).toEqual({ agentRoles: false });
+
+    await writeRaw(
+      JSON.stringify({
+        version: 999,
+        shell: { path: null, args: null },
+        envOverrides: {},
+        features: { agentRoles: true },
+      }),
+    );
+    expect(readFeatureSettingsSync()).toEqual({ agentRoles: false });
+
+    await writeRaw(
+      JSON.stringify({
+        version: 1,
+        shell: { path: null, args: null },
+        envOverrides: {},
+        features: { agentRoles: "yes" },
+      }),
+    );
+    expect(readFeatureSettingsSync()).toEqual({ agentRoles: false });
+  });
+
+  it.skipIf(process.platform === "win32" || process.getuid?.() === 0)(
+    "fails closed when feature config is unreadable",
+    async () => {
+      await writeRaw(
+        JSON.stringify({
+          version: 1,
+          features: { agentRoles: true },
+        }),
+      );
+      await chmod(cliConfigPath(), 0o000);
+      try {
+        expect(readFeatureSettingsSync()).toEqual({ agentRoles: false });
+      } finally {
+        await chmod(cliConfigPath(), 0o600);
+      }
+    },
+  );
+
+  it("sets agent roles without changing shell, env, or log settings", async () => {
+    await setShell("/bin/fish", ["-l"]);
+    await setEnvOverride("FOO", "bar");
+    await setLogLevels("debug", "warn");
+
+    await setAgentRolesEnabled(true);
+    expect(await readFeatureSettings()).toEqual({ agentRoles: true });
+    expect(await readCliConfig()).toMatchObject({
+      shell: {
+        path: "/bin/fish",
+        args: ["-l"],
+      },
+      envOverrides: { FOO: "bar" },
+      logs: { cliLogLevel: "debug", hostLogLevel: "warn" },
+      features: { agentRoles: true },
+    });
+
+    await setAgentRolesEnabled(false);
+    expect(await readFeatureSettings()).toEqual({ agentRoles: false });
+    expect(await readCliConfig()).toMatchObject({
+      shell: {
+        path: "/bin/fish",
+        args: ["-l"],
+      },
+      envOverrides: { FOO: "bar" },
+      logs: { cliLogLevel: "debug", hostLogLevel: "warn" },
+      features: { agentRoles: false },
     });
   });
 
@@ -214,6 +296,7 @@ describe("cli config store", () => {
       shell: { path: "/bin/zsh", args: null, entries: [] },
       envOverrides: {},
       logs: { cliLogLevel: "info", hostLogLevel: "info" },
+      features: { agentRoles: false },
     });
   });
 
@@ -328,7 +411,9 @@ describe("shell entries + mirror invariant", () => {
     // are remembered against the login shell's entry.
     expect(autoState.shell.path).toBeNull();
     expect(autoState.shell.args).toBeNull();
-    expect(autoState.shell.entries).toEqual([{ path: defaultPath, args: ["-x"] }]);
+    expect(autoState.shell.entries).toEqual([
+      { path: defaultPath, args: ["-x"] },
+    ]);
 
     await setShell("/bin/cat", null); // pick a non-shell: mirror materialises to []
     const cfg = await readCliConfig();
@@ -422,7 +507,10 @@ describe("shell entries + mirror invariant", () => {
 });
 
 describe("flag deviations - canonicalisation + revert", () => {
-  function entryArgs(cfg: CliConfig, path: string): string[] | null | undefined {
+  function entryArgs(
+    cfg: CliConfig,
+    path: string,
+  ): string[] | null | undefined {
     return cfg.shell.entries.find((e) => e.path === path)?.args;
   }
 
@@ -515,7 +603,10 @@ describe("legacy (pre-entries) shell resolution", () => {
     // Switch away: without seeding the customisation would be lost.
     await setShell("/bin/cat", null);
     const cfg = await readCliConfig();
-    expect(cfg.shell.entries).toContainEqual({ path: "/bin/bash", args: ["-i"] });
+    expect(cfg.shell.entries).toContainEqual({
+      path: "/bin/bash",
+      args: ["-i"],
+    });
     // Returning to bash restores the seeded flags rather than the family default.
     await setShell("/bin/bash", null);
     expect((await readCliConfig()).shell.args).toEqual(["-i"]);
@@ -530,39 +621,42 @@ describe("legacy (pre-entries) shell resolution", () => {
 
 // POSIX-only: on win32 `defaultShellPath` takes the COMSPEC branch and never
 // consults passwd, so these assertions are meaningless there.
-describe.skipIf(process.platform === "win32")("defaultShellPath - POSIX", () => {
-  const originalShell = process.env.SHELL;
-  afterEach(() => {
-    if (originalShell === undefined) delete process.env.SHELL;
-    else process.env.SHELL = originalShell;
-  });
+describe.skipIf(process.platform === "win32")(
+  "defaultShellPath - POSIX",
+  () => {
+    const originalShell = process.env.SHELL;
+    afterEach(() => {
+      if (originalShell === undefined) delete process.env.SHELL;
+      else process.env.SHELL = originalShell;
+    });
 
-  it("prefers the passwd login shell over a leaked $SHELL", () => {
-    h.passwdShell = "/usr/bin/fish";
-    process.env.SHELL = "/bin/bash";
-    expect(defaultShellPath()).toBe("/usr/bin/fish");
-  });
+    it("prefers the passwd login shell over a leaked $SHELL", () => {
+      h.passwdShell = "/usr/bin/fish";
+      process.env.SHELL = "/bin/bash";
+      expect(defaultShellPath()).toBe("/usr/bin/fish");
+    });
 
-  it("falls back to $SHELL when there is no passwd entry", () => {
-    h.passwdThrows = true;
-    process.env.SHELL = "/bin/bash";
-    expect(defaultShellPath()).toBe("/bin/bash");
-  });
+    it("falls back to $SHELL when there is no passwd entry", () => {
+      h.passwdThrows = true;
+      process.env.SHELL = "/bin/bash";
+      expect(defaultShellPath()).toBe("/bin/bash");
+    });
 
-  it("falls back to $SHELL when the passwd shell field is empty", () => {
-    h.passwdShell = "";
-    process.env.SHELL = "/bin/bash";
-    expect(defaultShellPath()).toBe("/bin/bash");
-  });
+    it("falls back to $SHELL when the passwd shell field is empty", () => {
+      h.passwdShell = "";
+      process.env.SHELL = "/bin/bash";
+      expect(defaultShellPath()).toBe("/bin/bash");
+    });
 
-  it("falls back to the platform default when passwd and $SHELL are both absent", () => {
-    h.passwdThrows = true;
-    delete process.env.SHELL;
-    expect(defaultShellPath()).toBe(
-      process.platform === "darwin" ? "/bin/zsh" : "/bin/bash",
-    );
-  });
-});
+    it("falls back to the platform default when passwd and $SHELL are both absent", () => {
+      h.passwdThrows = true;
+      delete process.env.SHELL;
+      expect(defaultShellPath()).toBe(
+        process.platform === "darwin" ? "/bin/zsh" : "/bin/bash",
+      );
+    });
+  },
+);
 
 describe("migrateCliConfig", () => {
   it("passes a current-version config through unchanged", () => {

--- a/protocol/src/config/schema.ts
+++ b/protocol/src/config/schema.ts
@@ -42,6 +42,13 @@ export const logsConfigSchema = z
   .default({ cliLogLevel: DEFAULT_LOG_LEVEL, hostLogLevel: DEFAULT_LOG_LEVEL });
 export type LogsConfig = z.infer<typeof logsConfigSchema>;
 
+export const featureSettingsSchema = z
+  .object({
+    agentRoles: z.boolean().default(false),
+  })
+  .default({ agentRoles: false });
+export type FeatureSettings = z.infer<typeof featureSettingsSchema>;
+
 /**
  * Zod schema for `~/.traycer/cli/config.json` - the single on-disk source
  * of truth for the user's shell + env-override config, shared by the CLI
@@ -104,6 +111,7 @@ export const cliConfigSchema = z.object({
     .default({ path: null, args: null, entries: [] }),
   envOverrides: envOverrideMapSchema.default({}),
   logs: logsConfigSchema,
+  features: featureSettingsSchema,
 });
 
 export type CliConfig = z.infer<typeof cliConfigSchema>;
@@ -149,4 +157,5 @@ export const EMPTY_CLI_CONFIG: CliConfig = {
   shell: { path: null, args: null, entries: [] },
   envOverrides: {},
   logs: { cliLogLevel: DEFAULT_LOG_LEVEL, hostLogLevel: DEFAULT_LOG_LEVEL },
+  features: { agentRoles: false },
 };

--- a/protocol/src/config/store.ts
+++ b/protocol/src/config/store.ts
@@ -468,15 +468,15 @@ export async function readCliConfig(): Promise<CliConfig> {
     }
     throw err;
   }
-  const result = (() => {
-    try {
-      return parseCliConfig(raw);
-    } catch {
-      throw new Error(
-        "~/.traycer/cli/config.json is not valid JSON; refusing to overwrite. Fix or delete it.",
-      );
-    }
-  })();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(
+      "~/.traycer/cli/config.json is not valid JSON; refusing to overwrite. Fix or delete it.",
+    );
+  }
+  const result = parseCliConfig(parsed);
   if (!result.success) {
     throw new Error(
       `~/.traycer/cli/config.json does not match the expected schema: ${result.error.message}`,
@@ -485,9 +485,9 @@ export async function readCliConfig(): Promise<CliConfig> {
   return result.data;
 }
 
-/** Parses, migrates, and validates a complete config document. */
-function parseCliConfig(raw: string) {
-  return cliConfigSchema.safeParse(migrateCliConfig(JSON.parse(raw)));
+/** Migrates and validates a parsed config document. */
+function parseCliConfig(parsed: unknown) {
+  return cliConfigSchema.safeParse(migrateCliConfig(parsed));
 }
 
 /**
@@ -899,7 +899,7 @@ export async function readLogLevels(): Promise<LogsConfig> {
 export function readLogLevelsSync(): LogsConfig {
   try {
     const raw = readFileSync(cliConfigPath(), "utf8");
-    const result = parseCliConfig(raw);
+    const result = parseCliConfig(JSON.parse(raw));
     if (result.success) return result.data.logs;
   } catch {
     // A logger must never crash on a config read — fall through to defaults.
@@ -919,7 +919,7 @@ export async function readFeatureSettings(): Promise<FeatureSettings> {
 export function readFeatureSettingsSync(): FeatureSettings {
   try {
     const raw = readFileSync(cliConfigPath(), "utf8");
-    const result = parseCliConfig(raw);
+    const result = parseCliConfig(JSON.parse(raw));
     if (result.success) return result.data.features;
   } catch {
     // Feature gates must remain safe even when config cannot be read.

--- a/protocol/src/config/store.ts
+++ b/protocol/src/config/store.ts
@@ -18,6 +18,7 @@ import {
   CLI_CONFIG_VERSION,
   EMPTY_CLI_CONFIG,
   type CliConfig,
+  type FeatureSettings,
   type DetectedShell,
   type EnvOverrideValue,
   type EffectiveShellConfig,
@@ -750,6 +751,7 @@ export async function setShell(
     shell: { path: nextPath, args: nextArgs, entries },
     envOverrides: current.envOverrides,
     logs: current.logs,
+    features: current.features,
   });
   return { path: nextPath, args: nextArgs };
 }
@@ -779,6 +781,7 @@ export async function addShell(
     shell: { path, args, entries },
     envOverrides: current.envOverrides,
     logs: current.logs,
+    features: current.features,
   });
   return { path, entries };
 }
@@ -819,6 +822,7 @@ export async function revertShellArgs(
     shell: { path: current.shell.path, args: nextArgs, entries },
     envOverrides: current.envOverrides,
     logs: current.logs,
+    features: current.features,
   });
   return { path, reverted: true };
 }
@@ -853,6 +857,7 @@ export async function removeShell(
     shell: { path: nextPath, args: nextArgs, entries },
     envOverrides: current.envOverrides,
     logs: current.logs,
+    features: current.features,
   });
   return { removed, path: nextPath };
 }
@@ -870,6 +875,7 @@ export async function resetShell(): Promise<void> {
     shell: { path: null, args: null, entries: current.shell.entries },
     envOverrides: current.envOverrides,
     logs: current.logs,
+    features: current.features,
   });
 }
 
@@ -888,6 +894,7 @@ export async function setLogLevels(
     shell: current.shell,
     envOverrides: current.envOverrides,
     logs: { cliLogLevel, hostLogLevel },
+    features: current.features,
   });
 }
 
@@ -913,6 +920,35 @@ export function readLogLevelsSync(): LogsConfig {
   return { cliLogLevel: DEFAULT_LOG_LEVEL, hostLogLevel: DEFAULT_LOG_LEVEL };
 }
 
+/** The local experimental feature settings (defaults when unset). */
+export async function readFeatureSettings(): Promise<FeatureSettings> {
+  return (await readCliConfig()).features;
+}
+
+/**
+ * Best-effort synchronous feature read for command, prompt, tool, and operation
+ * gates. Feature checks fail closed when the config is absent or invalid.
+ */
+export function readFeatureSettingsSync(): FeatureSettings {
+  try {
+    const raw = readFileSync(cliConfigPath(), "utf8");
+    const result = cliConfigSchema.safeParse(migrateCliConfig(JSON.parse(raw)));
+    if (result.success) return result.data.features;
+  } catch {
+    // Feature gates must remain safe even when config cannot be read.
+  }
+  return { agentRoles: false };
+}
+
+/** Enables or disables agent roles while preserving the rest of the config. */
+export async function setAgentRolesEnabled(enabled: boolean): Promise<void> {
+  const current = await readCliConfig();
+  await writeCliConfig({
+    ...current,
+    features: { ...current.features, agentRoles: enabled },
+  });
+}
+
 export async function listEnvOverrides(): Promise<
   Readonly<Record<string, EnvOverrideValue>>
 > {
@@ -935,6 +971,7 @@ export async function setEnvOverride(
     shell: current.shell,
     envOverrides: { ...current.envOverrides, [key]: value },
     logs: current.logs,
+    features: current.features,
   });
 }
 
@@ -950,6 +987,7 @@ export async function deleteEnvOverride(key: string): Promise<boolean> {
     shell: current.shell,
     envOverrides: nextOverrides,
     logs: current.logs,
+    features: current.features,
   });
   return true;
 }

--- a/protocol/src/config/store.ts
+++ b/protocol/src/config/store.ts
@@ -468,21 +468,26 @@ export async function readCliConfig(): Promise<CliConfig> {
     }
     throw err;
   }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new Error(
-      "~/.traycer/cli/config.json is not valid JSON; refusing to overwrite. Fix or delete it.",
-    );
-  }
-  const result = cliConfigSchema.safeParse(migrateCliConfig(parsed));
+  const result = (() => {
+    try {
+      return parseCliConfig(raw);
+    } catch {
+      throw new Error(
+        "~/.traycer/cli/config.json is not valid JSON; refusing to overwrite. Fix or delete it.",
+      );
+    }
+  })();
   if (!result.success) {
     throw new Error(
       `~/.traycer/cli/config.json does not match the expected schema: ${result.error.message}`,
     );
   }
   return result.data;
+}
+
+/** Parses, migrates, and validates a complete config document. */
+function parseCliConfig(raw: string) {
+  return cliConfigSchema.safeParse(migrateCliConfig(JSON.parse(raw)));
 }
 
 /**
@@ -747,11 +752,8 @@ export async function setShell(
     nextArgs = current.shell.args;
   }
   await writeCliConfig({
-    version: CLI_CONFIG_VERSION,
+    ...current,
     shell: { path: nextPath, args: nextArgs, entries },
-    envOverrides: current.envOverrides,
-    logs: current.logs,
-    features: current.features,
   });
   return { path: nextPath, args: nextArgs };
 }
@@ -777,11 +779,8 @@ export async function addShell(
     isWindows,
   );
   await writeCliConfig({
-    version: CLI_CONFIG_VERSION,
+    ...current,
     shell: { path, args, entries },
-    envOverrides: current.envOverrides,
-    logs: current.logs,
-    features: current.features,
   });
   return { path, entries };
 }
@@ -818,11 +817,8 @@ export async function revertShellArgs(
     ? [...defaultShellArgs(path)]
     : current.shell.args;
   await writeCliConfig({
-    version: CLI_CONFIG_VERSION,
+    ...current,
     shell: { path: current.shell.path, args: nextArgs, entries },
-    envOverrides: current.envOverrides,
-    logs: current.logs,
-    features: current.features,
   });
   return { path, reverted: true };
 }
@@ -853,11 +849,8 @@ export async function removeShell(
   const nextPath = wasSelected ? null : current.shell.path;
   const nextArgs = wasSelected ? null : current.shell.args;
   await writeCliConfig({
-    version: CLI_CONFIG_VERSION,
+    ...current,
     shell: { path: nextPath, args: nextArgs, entries },
-    envOverrides: current.envOverrides,
-    logs: current.logs,
-    features: current.features,
   });
   return { removed, path: nextPath };
 }
@@ -871,11 +864,8 @@ export async function removeShell(
 export async function resetShell(): Promise<void> {
   const current = await readConfigWithSeededEntries();
   await writeCliConfig({
-    version: CLI_CONFIG_VERSION,
+    ...current,
     shell: { path: null, args: null, entries: current.shell.entries },
-    envOverrides: current.envOverrides,
-    logs: current.logs,
-    features: current.features,
   });
 }
 
@@ -890,11 +880,8 @@ export async function setLogLevels(
 ): Promise<void> {
   const current = await readCliConfig();
   await writeCliConfig({
-    version: CLI_CONFIG_VERSION,
-    shell: current.shell,
-    envOverrides: current.envOverrides,
+    ...current,
     logs: { cliLogLevel, hostLogLevel },
-    features: current.features,
   });
 }
 
@@ -912,7 +899,7 @@ export async function readLogLevels(): Promise<LogsConfig> {
 export function readLogLevelsSync(): LogsConfig {
   try {
     const raw = readFileSync(cliConfigPath(), "utf8");
-    const result = cliConfigSchema.safeParse(migrateCliConfig(JSON.parse(raw)));
+    const result = parseCliConfig(raw);
     if (result.success) return result.data.logs;
   } catch {
     // A logger must never crash on a config read — fall through to defaults.
@@ -932,7 +919,7 @@ export async function readFeatureSettings(): Promise<FeatureSettings> {
 export function readFeatureSettingsSync(): FeatureSettings {
   try {
     const raw = readFileSync(cliConfigPath(), "utf8");
-    const result = cliConfigSchema.safeParse(migrateCliConfig(JSON.parse(raw)));
+    const result = parseCliConfig(raw);
     if (result.success) return result.data.features;
   } catch {
     // Feature gates must remain safe even when config cannot be read.
@@ -967,11 +954,8 @@ export async function setEnvOverride(
 ): Promise<void> {
   const current = await readCliConfig();
   await writeCliConfig({
-    version: CLI_CONFIG_VERSION,
-    shell: current.shell,
+    ...current,
     envOverrides: { ...current.envOverrides, [key]: value },
-    logs: current.logs,
-    features: current.features,
   });
 }
 
@@ -983,11 +967,8 @@ export async function deleteEnvOverride(key: string): Promise<boolean> {
   };
   delete nextOverrides[key];
   await writeCliConfig({
-    version: CLI_CONFIG_VERSION,
-    shell: current.shell,
+    ...current,
     envOverrides: nextOverrides,
-    logs: current.logs,
-    features: current.features,
   });
   return true;
 }


### PR DESCRIPTION
## Summary

- Add a machine-local `features.agentRoles` setting, stored in the existing JSON config and disabled by default.
- Expose the setting in Desktop → Settings → Experimental; its read/write path uses Desktop IPC and preserves the current state on write failure.
- Hide role claims from GUI projections while preserving their stored state, and register `traycer agent role` only when the setting is enabled.
- Include fail-closed config, IPC, renderer, selector, and CLI regression coverage.

## Validation

- Pre-commit affected build, compile, lint, and format checks passed.
- Focused protocol, CLI, Desktop IPC, GUI Settings, and selector suites passed.
- Commits are DCO signed.