### PR TITLE
feat(gui-app): Chrome-style split tab follow-up fixes

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/__tests__/epic-shell.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/__tests__/epic-shell.test.tsx
@@ -177,8 +177,11 @@ describe("<EpicShell />", () => {
   it("renders the stable shell frame while the session is not ready", () => {
     render(<EpicShell epicId={EPIC_ID} tabId={TAB_ID} active />);
 
-    expect(screen.getByTestId("epic-shell").dataset.sessionReady).toBe("false");
-    expect(screen.getByTestId("tile-canvas-loading")).not.toBeNull();
+    const shell = screen.getByTestId("epic-shell");
+    const canvas = screen.getByTestId("tile-canvas-loading");
+    expect(shell.dataset.sessionReady).toBe("false");
+    expect(shell.className).not.toContain("rounded-r-lg");
+    expect(canvas.className).not.toContain("rounded-t-lg");
     expect(screen.queryByTestId("epic-session-loading")).toBeNull();
   });
 

--- a/clients/gui-app/src/components/epic-canvas/canvas/tile-canvas.tsx
+++ b/clients/gui-app/src/components/epic-canvas/canvas/tile-canvas.tsx
@@ -61,7 +61,7 @@ export function TileCanvas(props: TileCanvasProps) {
   const renderLive = snapshotLoaded || hasActiveHandoff;
   return (
     <div
-      className="canvas-token-scope relative h-full min-h-0 w-full overflow-hidden rounded-t-lg border border-canvas-border/70 bg-canvas text-canvas-foreground"
+      className="canvas-token-scope relative h-full min-h-0 w-full overflow-hidden border border-canvas-border/70 bg-canvas text-canvas-foreground"
       data-testid="tile-canvas"
     >
       <TileCanvasBody

--- a/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-provider.tsx
+++ b/clients/gui-app/src/components/epic-canvas/dnd/root-dnd-provider.tsx
@@ -43,6 +43,7 @@ import {
   isLeftPanelDropNoop,
   resolveCanvasDropPreview,
   resolveOverlayTileForSource,
+  type HeaderStripDropResult,
   type ResolvedEpicCanvasDrop,
 } from "@/components/epic-canvas/dnd/root-dnd-commits";
 import {
@@ -459,6 +460,29 @@ function commitHeaderEdgeSplit(
   );
 }
 
+/**
+ * Canvas tear-off onto the header strip. Source creation and authoritative
+ * placement run inside ONE suppressed coordinator transaction: the source
+ * store's synchronous reconciliation subscriber fires between them otherwise,
+ * and with a stale legacy `stripOrder` it would rebuild the flat layout and
+ * dissolve existing split groups before placement. Returns the committed drop
+ * only when the new ref was also placed.
+ */
+function commitHeaderStripDropAtIndex(
+  source: EpicCanvasDragSourceData,
+  headerStripIndex: number,
+): HeaderStripDropResult | null {
+  let dropped: HeaderStripDropResult | null = null;
+  const placedRef = tabCommandCoordinator.createSourceRefAtStripIndex(
+    headerStripIndex,
+    () => {
+      dropped = commitHeaderStripDrop(source, headerStripIndex);
+      return dropped === null ? null : { kind: "epic", id: dropped.tabId };
+    },
+  );
+  return placedRef === null ? null : dropped;
+}
+
 interface RootDndProviderProps {
   readonly children: ReactNode;
 }
@@ -621,7 +645,7 @@ export function RootDndProvider(props: RootDndProviderProps) {
       const source = readActiveDragSource(event.active);
       if (source !== null) {
         if (headerStripIndex !== null && canDropOnHeaderStrip(source)) {
-          const result = commitHeaderStripDrop(source, headerStripIndex);
+          const result = commitHeaderStripDropAtIndex(source, headerStripIndex);
           if (result !== null) {
             navigateToTabIntent(
               navigate,

--- a/clients/gui-app/src/components/epic-canvas/epic-shell.tsx
+++ b/clients/gui-app/src/components/epic-canvas/epic-shell.tsx
@@ -39,7 +39,7 @@ export function EpicShell(props: EpicShellProps) {
 
   return (
     <div
-      className="relative flex min-h-0 flex-1 flex-col overflow-hidden rounded-r-lg bg-background"
+      className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background"
       data-testid="epic-shell"
       data-epic-shell-root="true"
       data-epic-id={epicId}
@@ -143,7 +143,7 @@ function CanvasColumn(props: {
 function LoadingTileCanvas() {
   return (
     <div
-      className="canvas-token-scope relative h-full min-h-0 w-full overflow-hidden rounded-t-lg border border-canvas-border/70 bg-canvas text-canvas-foreground"
+      className="canvas-token-scope relative h-full min-h-0 w-full overflow-hidden border border-canvas-border/70 bg-canvas text-canvas-foreground"
       data-testid="tile-canvas-loading"
     >
       <CanvasSkeleton />

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel-phase-activation.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel-phase-activation.test.tsx
@@ -182,7 +182,9 @@ function renderPanel() {
         <TooltipProvider>
           <EpicsListPanel
             variant="embedded"
+            className={undefined}
             onSelectEpic={null}
+            onOpenItem={null}
             routeSearch={null}
             historyNowMs={null}
             autoFocusSearch={false}

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -407,6 +407,21 @@ describe("<EpicsListPanel />", () => {
     expect(router.state.location.pathname).toBe("/");
   });
 
+  it("hides the bulk select/delete flow in the read-only picker variant", async () => {
+    renderPanel("picker", "/");
+
+    await screen.findByRole("link", { name: "Open task Open from landing" });
+
+    expect(
+      screen.queryByRole("button", { name: "Select history items" }),
+    ).toBeNull();
+    // The per-row delete affordance stays rendered (matches the disabled
+    // hover-reveal treatment used elsewhere) but must be inert: clicking it
+    // must not open the destructive delete-confirmation flow.
+    fireEvent.click(await screen.findByTestId("epics-list-row-delete"));
+    expect(screen.queryByText("This action cannot be undone.")).toBeNull();
+  });
+
   afterEach(() => {
     cleanup();
     __resetTabNavigationControllerForTesting();

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -301,6 +301,14 @@ function historyWorktree(): WorktreeHostEntryV12 {
 }
 
 function renderPanel(variant: EpicsListPanelVariant, initialEntry: string) {
+  return renderPanelWithOpenItem(variant, initialEntry, null);
+}
+
+function renderPanelWithOpenItem(
+  variant: EpicsListPanelVariant,
+  initialEntry: string,
+  onOpenItem: ((item: HistoryItem) => void) | null,
+) {
   const rootRoute = createRootRoute({
     component: () => <RootOutlet />,
   });
@@ -310,7 +318,9 @@ function renderPanel(variant: EpicsListPanelVariant, initialEntry: string) {
     component: () => (
       <EpicsListPanel
         variant={variant}
+        className={undefined}
         onSelectEpic={null}
+        onOpenItem={onOpenItem}
         routeSearch={null}
         historyNowMs={null}
         autoFocusSearch={false}
@@ -383,6 +393,18 @@ describe("<EpicsListPanel />", () => {
     __resetTabNavigationControllerForTesting();
     useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
     useHistorySearchStore.setState({ search: DEFAULT_HISTORY_SEARCH });
+  });
+
+  it("lets a destination picker replace normal row navigation", async () => {
+    const onOpenItem = vi.fn();
+    const router = renderPanelWithOpenItem("embedded", "/", onOpenItem);
+
+    fireEvent.click(
+      await screen.findByRole("link", { name: "Open task Open from landing" }),
+    );
+
+    expect(onOpenItem).toHaveBeenCalledWith(testState.items[0]);
+    expect(router.state.location.pathname).toBe("/");
   });
 
   afterEach(() => {
@@ -1336,6 +1358,22 @@ describe("<EpicsListPanel />", () => {
       expect(useHistorySearchStore.getState().search).toMatchObject({
         query: "hello ",
       });
+    });
+  });
+
+  it("renders the picker search in the filters toolbar", async () => {
+    renderPanel("picker", "/");
+
+    const input = await screen.findByRole("searchbox", {
+      name: "Search tasks",
+    });
+    const toolbar = screen.getByRole("button", { name: /filter/i })
+      .parentElement?.parentElement;
+
+    expect(toolbar?.contains(input)).toBe(true);
+    fireEvent.change(input, { target: { value: "logging" } });
+    await waitFor(() => {
+      expect(useHistorySearchStore.getState().search.query).toBe("logging");
     });
   });
 

--- a/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
+++ b/clients/gui-app/src/components/epics/__tests__/epics-list-panel.test.tsx
@@ -422,6 +422,25 @@ describe("<EpicsListPanel />", () => {
     expect(screen.queryByText("This action cannot be undone.")).toBeNull();
   });
 
+  it("disables the row sweep affordance in the read-only picker variant", async () => {
+    testState.worktreesByEpicId = new Map([
+      ["epic-from-history", [historyWorktree()]],
+    ]);
+    renderPanel("picker", "/");
+
+    await screen.findByRole("link", { name: "Open task Open from landing" });
+
+    // A worktree-owning task normally renders the LIVE sweep button (not the
+    // aria-disabled variant) - confirm the picker still shows the disabled
+    // treatment instead of a live-looking control whose click is neutered.
+    expect(screen.queryByTestId("epics-list-row-sweep")).toBeNull();
+    expect(
+      screen
+        .getByTestId("epics-list-row-sweep-disabled")
+        .getAttribute("aria-disabled"),
+    ).toBe("true");
+  });
+
   afterEach(() => {
     cleanup();
     __resetTabNavigationControllerForTesting();

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -369,15 +369,25 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
     setWorktreeCheckOverrides(new Map());
   }, []);
 
+  // `variant="picker"` embeds this panel as a read-only destination browser
+  // (the split chooser's History section) - it must never expose the
+  // select/delete/sweep flow, so every entry point into it is gated here
+  // rather than in the chrome that merely renders it.
+  const selectionEnabled = variant !== "picker";
+
   // A sweep target is a SET: one id from a row action, the whole selection
   // from the bulk action. The set is load-bearing - a worktree shared between
   // two SELECTED tasks is no longer "shared" and becomes an ordinary
   // candidate.
   const [sweepEpicIds, setSweepEpicIds] =
     useState<ReadonlyArray<string> | null>(null);
-  const requestSweep = useCallback((epicId: string) => {
-    setSweepEpicIds([epicId]);
-  }, []);
+  const requestSweep = useCallback(
+    (epicId: string) => {
+      if (!selectionEnabled) return;
+      setSweepEpicIds([epicId]);
+    },
+    [selectionEnabled],
+  );
   const sweepTaskTitle = useMemo(() => {
     if (sweepEpicIds === null || sweepEpicIds.length !== 1) return null;
     const item = items.find(
@@ -400,20 +410,21 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
 
   const toggleSelection = useCallback(
     (id: string) => {
-      if (!selectableIdSet.has(id)) return;
+      if (!selectionEnabled || !selectableIdSet.has(id)) return;
       setSelectedIds((prev) => withMemberToggled(prev, id));
       setSelectionMode(true);
     },
-    [selectableIdSet],
+    [selectableIdSet, selectionEnabled],
   );
 
   const requestDelete = useCallback(
     (ids: ReadonlyArray<string>) => {
+      if (!selectionEnabled) return;
       const deletableIds = ids.filter((id) => selectableIdSet.has(id));
       if (deletableIds.length === 0) return;
       setPendingDeleteIds(deletableIds);
     },
-    [selectableIdSet],
+    [selectableIdSet, selectionEnabled],
   );
 
   const visibleSelectedIds = useMemo(() => {
@@ -433,9 +444,10 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
     [visibleSelectedIds, worktreesByEpicId],
   );
   const enterSelectionMode = useCallback(() => {
+    if (!selectionEnabled) return;
     setSelectedIds(new Set());
     setSelectionMode(true);
-  }, []);
+  }, [selectionEnabled]);
   const selectAllVisible = useCallback(() => {
     setSelectedIds(new Set(selectableItemIds));
   }, [selectableItemIds]);
@@ -531,6 +543,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
             ) : null
           }
           filters={{ active: hasActiveFilters, onClear: handleClear }}
+          showSelection={selectionEnabled}
           selection={
             selectionMode
               ? {
@@ -745,6 +758,9 @@ interface PanelRefreshControls {
 interface PanelChromeBarProps {
   readonly leading: ReactNode;
   readonly filters: PanelFilterControls;
+  /** False for the read-only `variant="picker"` embed: hides the entry point
+   * into bulk select/sweep/delete rather than merely disabling it. */
+  readonly showSelection: boolean;
   readonly selection: PanelSelectionControls;
   readonly sort: HistorySortOption;
   readonly onSortChange: (next: HistorySortOption) => void;
@@ -849,18 +865,20 @@ function PanelChromeBar(props: PanelChromeBarProps): ReactNode {
               onSearchChange={props.onSearchChange}
               facets={props.facets}
             />
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              aria-label="Select history items"
-              disabled={!props.selection.canSelect}
-              className="gap-1.5 overflow-visible text-ui-sm text-muted-foreground hover:text-foreground"
-              onClick={props.selection.onStart}
-            >
-              <ListChecks className="size-4" />
-              Select
-            </Button>
+            {props.showSelection ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                aria-label="Select history items"
+                disabled={!props.selection.canSelect}
+                className="gap-1.5 overflow-visible text-ui-sm text-muted-foreground hover:text-foreground"
+                onClick={props.selection.onStart}
+              >
+                <ListChecks className="size-4" />
+                Select
+              </Button>
+            ) : null}
             <Button
               type="button"
               variant="ghost"

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -598,6 +598,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
               items={items}
               onRetry={handleRetry}
               selectionMode={selectionMode}
+              selectionEnabled={selectionEnabled}
               selectedIds={selectedIds}
               onToggleSelection={toggleSelection}
               onRequestDelete={requestDelete}
@@ -928,6 +929,7 @@ interface EpicsListBodyProps {
   readonly items: ReadonlyArray<HistoryItem>;
   readonly onRetry: () => void;
   readonly selectionMode: boolean;
+  readonly selectionEnabled: boolean;
   readonly selectedIds: ReadonlySet<string>;
   readonly onToggleSelection: (id: string) => void;
   readonly onRequestDelete: (ids: ReadonlyArray<string>) => void;
@@ -957,6 +959,7 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     items,
     onRetry,
     selectionMode,
+    selectionEnabled,
     selectedIds,
     onToggleSelection,
     onRequestDelete,
@@ -1002,6 +1005,7 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
               key={item.id}
               item={item}
               selectionMode={selectionMode}
+              selectionEnabled={selectionEnabled}
               isSelected={selectedIds.has(item.epicId)}
               onToggleSelection={onToggleSelection}
               onRequestDelete={onRequestDelete}
@@ -1073,6 +1077,9 @@ function EpicsListFilteringLoading() {
 interface EpicsListRowProps {
   readonly item: HistoryItem;
   readonly selectionMode: boolean;
+  /** False for the read-only `variant="picker"` embed - disables the sweep
+   * affordance instead of leaving it live-looking but inert. */
+  readonly selectionEnabled: boolean;
   readonly isSelected: boolean;
   readonly onToggleSelection: (id: string) => void;
   readonly onRequestDelete: (ids: ReadonlyArray<string>) => void;
@@ -1139,6 +1146,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
   const {
     item,
     selectionMode,
+    selectionEnabled,
     isSelected,
     onToggleSelection,
     onRequestDelete,
@@ -1153,12 +1161,13 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     isOpen,
   } = props;
   const isPhase = item.taskType === "phase";
-  const rowSweep = useHistoryRowSweep(
+  const rowSweep = useHistoryRowSweep({
     item,
     worktrees,
     selectionMode,
+    selectionEnabled,
     onRequestSweep,
-  );
+  });
   const displayTitle = historyItemDisplayTitle(item);
   const canEditTitle = canEditHistoryItemTitle(item);
   const canDeleteItem = canDeleteHistoryItem(item);
@@ -1580,12 +1589,15 @@ interface HistoryRowSweepState {
  * Cheap and reactive - derived from the same enriched listing the PR pills
  * already join, with no extra host call to render the affordance.
  */
-function useHistoryRowSweep(
-  item: HistoryItem,
-  worktrees: readonly WorktreeHostEntryV12[],
-  selectionMode: boolean,
-  onRequestSweep: (epicId: string) => void,
-): HistoryRowSweepState {
+function useHistoryRowSweep(args: {
+  readonly item: HistoryItem;
+  readonly worktrees: readonly WorktreeHostEntryV12[];
+  readonly selectionMode: boolean;
+  readonly selectionEnabled: boolean;
+  readonly onRequestSweep: (epicId: string) => void;
+}): HistoryRowSweepState {
+  const { item, worktrees, selectionMode, selectionEnabled, onRequestSweep } =
+    args;
   const requestSweep = useCallback(() => {
     onRequestSweep(item.epicId);
   }, [item.epicId, onRequestSweep]);
@@ -1593,11 +1605,16 @@ function useHistoryRowSweep(
   // delete control and the bulk Sweep button behave: the affordance keeps its
   // place in the row instead of appearing and disappearing per row. Phases are
   // still skipped entirely - they never have worktrees, so a permanently dead
-  // control there would be noise rather than consistency.
+  // control there would be noise rather than consistency. The read-only picker
+  // embed (`selectionEnabled=false`) uses the same disabled treatment rather
+  // than a live-looking button whose click is silently neutered upstream.
   return {
     isVisible: !selectionMode && item.taskType !== "phase",
     canSweep:
-      !selectionMode && item.taskType !== "phase" && worktrees.length > 0,
+      selectionEnabled &&
+      !selectionMode &&
+      item.taskType !== "phase" &&
+      worktrees.length > 0,
     requestSweep,
   };
 }

--- a/clients/gui-app/src/components/epics/epics-list-panel.tsx
+++ b/clients/gui-app/src/components/epics/epics-list-panel.tsx
@@ -135,16 +135,22 @@ function historyItemDisplayTitle(item: HistoryItem): string {
       });
 }
 
-export type EpicsListPanelVariant = "page" | "embedded";
+export type EpicsListPanelVariant = "page" | "embedded" | "picker";
 
 interface EpicsListPanelProps {
   readonly variant: EpicsListPanelVariant;
+  readonly className: string | undefined;
   /**
-   * When set, row clicks invoke this callback instead of navigating
-   * via the embedded `<Link>`. Used by the system-tab modal to close
-   * the modal and route the user to the epic in one step.
+   * Called immediately before normal row navigation. The system-tab modal
+   * uses this to close its overlay in the same interaction.
    */
   readonly onSelectEpic: ((epicId: string) => void) | null;
+  /**
+   * Replaces the row's normal navigation when this panel is embedded in a
+   * destination picker. The complete item is provided so callers can preserve
+   * the distinct Epic and legacy Phase activation paths.
+   */
+  readonly onOpenItem: ((item: HistoryItem) => void) | null;
   readonly routeSearch: HistorySearchState | null;
   readonly historyNowMs: number | null;
   /**
@@ -158,7 +164,9 @@ interface EpicsListPanelProps {
 
 interface RouteEpicsListPanelProps {
   readonly variant: EpicsListPanelVariant;
+  readonly className: string | undefined;
   readonly onSelectEpic: ((epicId: string) => void) | null;
+  readonly onOpenItem: ((item: HistoryItem) => void) | null;
   readonly routeSearch: HistorySearchState;
   readonly historyNowMs: number | null;
   readonly autoFocusSearch: boolean;
@@ -166,14 +174,18 @@ interface RouteEpicsListPanelProps {
 
 interface AmbientEpicsListPanelProps {
   readonly variant: EpicsListPanelVariant;
+  readonly className: string | undefined;
   readonly onSelectEpic: ((epicId: string) => void) | null;
+  readonly onOpenItem: ((item: HistoryItem) => void) | null;
   readonly historyNowMs: number | null;
   readonly autoFocusSearch: boolean;
 }
 
 interface EpicsListPanelBodyProps {
   readonly variant: EpicsListPanelVariant;
+  readonly className: string | undefined;
   readonly onSelectEpic: ((epicId: string) => void) | null;
+  readonly onOpenItem: ((item: HistoryItem) => void) | null;
   readonly historyNowMs: number | null;
   readonly historySearch: HistorySearchController;
   readonly autoFocusSearch: boolean;
@@ -195,7 +207,9 @@ export function EpicsListPanel(props: EpicsListPanelProps): ReactNode {
     return (
       <AmbientEpicsListPanel
         variant={props.variant}
+        className={props.className}
         onSelectEpic={props.onSelectEpic}
+        onOpenItem={props.onOpenItem}
         historyNowMs={props.historyNowMs}
         autoFocusSearch={props.autoFocusSearch}
       />
@@ -204,7 +218,9 @@ export function EpicsListPanel(props: EpicsListPanelProps): ReactNode {
   return (
     <RouteEpicsListPanel
       variant={props.variant}
+      className={props.className}
       onSelectEpic={props.onSelectEpic}
+      onOpenItem={props.onOpenItem}
       routeSearch={props.routeSearch}
       historyNowMs={props.historyNowMs}
       autoFocusSearch={props.autoFocusSearch}
@@ -217,7 +233,9 @@ function RouteEpicsListPanel(props: RouteEpicsListPanelProps): ReactNode {
   return (
     <EpicsListPanelBody
       variant={props.variant}
+      className={props.className}
       onSelectEpic={props.onSelectEpic}
+      onOpenItem={props.onOpenItem}
       historyNowMs={props.historyNowMs}
       historySearch={historySearch}
       autoFocusSearch={props.autoFocusSearch}
@@ -230,7 +248,9 @@ function AmbientEpicsListPanel(props: AmbientEpicsListPanelProps): ReactNode {
   return (
     <EpicsListPanelBody
       variant={props.variant}
+      className={props.className}
       onSelectEpic={props.onSelectEpic}
+      onOpenItem={props.onOpenItem}
       historyNowMs={props.historyNowMs}
       historySearch={historySearch}
       autoFocusSearch={props.autoFocusSearch}
@@ -239,7 +259,7 @@ function AmbientEpicsListPanel(props: AmbientEpicsListPanelProps): ReactNode {
 }
 
 function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
-  const { variant, onSelectEpic, historySearch } = props;
+  const { variant, onSelectEpic, onOpenItem, historySearch } = props;
   // Destructure the stable `update`/`clear` functions (the hook returns a fresh
   // wrapper object each render, so closing over `historySearch.update` would
   // give the compiler an unstable dependency and re-create every handler each
@@ -473,7 +493,8 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
     void refetch();
   };
 
-  const showChrome = variant === "page";
+  const showPageSearch = variant === "page";
+  const showToolbarSearch = variant === "picker";
 
   return (
     <TooltipProvider>
@@ -481,9 +502,10 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
         className={cn(
           "flex min-h-0 w-full flex-col",
           variant === "page" ? "mx-auto max-w-3xl flex-1 px-6 pt-6" : "mt-8",
+          props.className,
         )}
       >
-        {showChrome ? (
+        {showPageSearch ? (
           <PanelSearchInput
             value={search.query}
             onChange={(next) => {
@@ -491,9 +513,23 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
             }}
             isFetching={isFetching}
             focusOnMount={props.autoFocusSearch}
+            placement="page"
           />
         ) : null}
         <PanelChromeBar
+          leading={
+            showToolbarSearch ? (
+              <PanelSearchInput
+                value={search.query}
+                onChange={(next) => {
+                  updateSearch({ query: next });
+                }}
+                isFetching={isFetching}
+                focusOnMount={props.autoFocusSearch}
+                placement="toolbar"
+              />
+            ) : null
+          }
           filters={{ active: hasActiveFilters, onClear: handleClear }}
           selection={
             selectionMode
@@ -559,6 +595,7 @@ function EpicsListPanelBody(props: EpicsListPanelBodyProps): ReactNode {
               isFetchingNextPage={isFetchingNextPage}
               onLoadMore={fetchNextPage}
               onSelectEpic={onSelectEpic}
+              onOpenItem={onOpenItem}
               onOpenInNewWindow={openInNewWindowFlow.requestOpen}
               openInNewWindowAvailable={openInNewWindowFlow.isAvailable}
               worktreesByEpicId={worktreesByEpicId}
@@ -607,6 +644,7 @@ interface PanelSearchInputProps {
   readonly onChange: (next: string) => void;
   readonly isFetching: boolean;
   readonly focusOnMount: boolean;
+  readonly placement: "page" | "toolbar";
 }
 
 function PanelSearchInput(props: PanelSearchInputProps): ReactNode {
@@ -626,7 +664,11 @@ function PanelSearchInput(props: PanelSearchInputProps): ReactNode {
     };
   }, [focusOnMount]);
   return (
-    <div className="px-2 pb-3">
+    <div
+      className={cn(
+        props.placement === "page" ? "px-2 pb-3" : "min-w-0 flex-1 sm:max-w-sm",
+      )}
+    >
       <InputGroup>
         <InputGroupAddon align="inline-start">
           {props.isFetching ? (
@@ -701,6 +743,7 @@ interface PanelRefreshControls {
 }
 
 interface PanelChromeBarProps {
+  readonly leading: ReactNode;
   readonly filters: PanelFilterControls;
   readonly selection: PanelSelectionControls;
   readonly sort: HistorySortOption;
@@ -726,7 +769,8 @@ function PanelChromeBar(props: PanelChromeBarProps): ReactNode {
 
   return (
     <div className="flex items-center justify-between gap-2 px-2 pb-2">
-      <div className="min-w-0">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {props.leading}
         {props.filters.active ? (
           <ClearFiltersButton onClick={props.filters.onClear} />
         ) : null}
@@ -876,6 +920,7 @@ interface EpicsListBodyProps {
   readonly isFetchingNextPage: boolean;
   readonly onLoadMore: () => void;
   readonly onSelectEpic: ((epicId: string) => void) | null;
+  readonly onOpenItem: ((item: HistoryItem) => void) | null;
   readonly onOpenInNewWindow: HistoryNewWindowFlow["requestOpen"];
   readonly openInNewWindowAvailable: boolean;
   readonly worktreesByEpicId: ReadonlyMap<
@@ -904,6 +949,7 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
     isFetchingNextPage,
     onLoadMore,
     onSelectEpic,
+    onOpenItem,
     onOpenInNewWindow,
     openInNewWindowAvailable,
     worktreesByEpicId,
@@ -945,6 +991,7 @@ function EpicsListBody(props: EpicsListBodyProps): ReactNode {
               onSetPinned={onSetPinned}
               isPinPending={pendingSetPinnedEpicIds.has(item.epicId)}
               onSelectEpic={onSelectEpic}
+              onOpenItem={onOpenItem}
               onOpenInNewWindow={onOpenInNewWindow}
               openInNewWindowAvailable={openInNewWindowAvailable}
               worktrees={worktreesByEpicId.get(item.epicId) ?? EMPTY_WORKTREES}
@@ -1015,6 +1062,7 @@ interface EpicsListRowProps {
   readonly onSetPinned: (epicId: string, pinned: boolean) => void;
   readonly isPinPending: boolean;
   readonly onSelectEpic: ((epicId: string) => void) | null;
+  readonly onOpenItem: ((item: HistoryItem) => void) | null;
   readonly onOpenInNewWindow: HistoryNewWindowFlow["requestOpen"];
   readonly openInNewWindowAvailable: boolean;
   readonly worktrees: readonly WorktreeHostEntryV12[];
@@ -1080,6 +1128,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     onSetPinned,
     isPinPending,
     onSelectEpic,
+    onOpenItem,
     onOpenInNewWindow,
     openInNewWindowAvailable,
     worktrees,
@@ -1159,6 +1208,10 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
     [],
   );
   const openEpic = useCallback(() => {
+    if (onOpenItem !== null) {
+      onOpenItem(item);
+      return;
+    }
     onSelectEpic?.(item.epicId);
     if (isPhase) {
       // Route the Phase deep link through the canonical activation boundary so
@@ -1188,7 +1241,7 @@ const EpicsListRow = memo(function EpicsListRow(props: EpicsListRowProps) {
       title: item.title,
       source: "direct_ui",
     });
-  }, [isPhase, item.epicId, item.title, navigate, onSelectEpic, pathname]);
+  }, [isPhase, item, navigate, onOpenItem, onSelectEpic, pathname]);
   const toggleEpicSelection = () => {
     if (!canDeleteItem) return;
     onToggleSelection(item.epicId);

--- a/clients/gui-app/src/components/epics/epics-list.tsx
+++ b/clients/gui-app/src/components/epics/epics-list.tsx
@@ -22,7 +22,9 @@ export function EpicsList(props: EpicsListProps) {
     >
       <EpicsListPanel
         variant="page"
+        className={undefined}
         onSelectEpic={null}
+        onOpenItem={null}
         routeSearch={props.routeSearch}
         historyNowMs={props.historyNowMs}
         autoFocusSearch={false}

--- a/clients/gui-app/src/components/epics/history-modal-content.tsx
+++ b/clients/gui-app/src/components/epics/history-modal-content.tsx
@@ -21,7 +21,9 @@ export function HistoryModalContent(
     <div className="flex min-h-0 flex-1 flex-col">
       <EpicsListPanel
         variant="page"
+        className={undefined}
         onSelectEpic={props.onSelectEpic}
+        onOpenItem={null}
         routeSearch={null}
         historyNowMs={null}
         autoFocusSearch

--- a/clients/gui-app/src/components/epics/history-surface.tsx
+++ b/clients/gui-app/src/components/epics/history-surface.tsx
@@ -27,7 +27,9 @@ export function HistorySurface() {
     <div className="flex min-h-0 flex-1 flex-col" data-testid="history-surface">
       <EpicsListPanel
         variant="page"
+        className={undefined}
         onSelectEpic={null}
+        onOpenItem={null}
         routeSearch={routeSearch}
         historyNowMs={history?.historyNowMs ?? null}
         autoFocusSearch={false}

--- a/clients/gui-app/src/components/home/landing-draft-surface.tsx
+++ b/clients/gui-app/src/components/home/landing-draft-surface.tsx
@@ -11,6 +11,7 @@ import { useTabSurfaceActivity } from "@/components/layout/tab-surface-activity-
 import { parseSystemTabOverlayView } from "@/lib/system-tab-overlay-search";
 import { useDraftSurfaceId } from "@/providers/draft-surface-hooks";
 import { useLandingDraftShell } from "@/stores/home/landing-draft-store";
+import { LandingTerminalPaneAnchor } from "@/components/home/terminal-panel/landing-terminal-host";
 
 /**
  * Route-independent landing body. Its exact draft runtime remains the T6
@@ -86,7 +87,9 @@ export function LandingDraftSurface() {
             {!systemModalOpen && activity.visible ? (
               <EpicsListPanel
                 variant="embedded"
+                className={undefined}
                 onSelectEpic={null}
+                onOpenItem={null}
                 routeSearch={null}
                 historyNowMs={null}
                 autoFocusSearch={false}
@@ -95,6 +98,9 @@ export function LandingDraftSurface() {
           </div>
         </div>
       </div>
+      {draftId === null ? null : (
+        <LandingTerminalPaneAnchor draftId={draftId} />
+      )}
     </div>
   );
 }

--- a/clients/gui-app/src/components/home/terminal-panel/landing-terminal-host.tsx
+++ b/clients/gui-app/src/components/home/terminal-panel/landing-terminal-host.tsx
@@ -1,3 +1,6 @@
+import { useCallback, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { create } from "zustand";
 import { useLandingTerminalStore } from "@/stores/home/landing-terminal-store";
 import { useTabsStore } from "@/stores/tabs/store";
 import {
@@ -7,11 +10,62 @@ import {
 import { LandingTerminalPanel } from "./landing-terminal-panel";
 import { LandingTerminalGestureProvider } from "./landing-terminal-gesture-provider";
 
+interface LandingPaneAnchorState {
+  readonly anchors: ReadonlyMap<string, HTMLElement>;
+  readonly setAnchor: (draftId: string, element: HTMLElement | null) => void;
+}
+
 /**
- * The one landing-terminal mount for this window. Draft slots project their
- * focused draft (or visible draft partner) into this existing subsystem. The
- * gesture provider is the single reader of live host/client/folder state; the
- * panel below consumes only the projected target.
+ * Ephemeral registry of each visible landing pane's panel slot. Split drafts
+ * register one anchor apiece; the single host portals the panel into the
+ * selected draft's anchor so the terminal UI stays inside that pane's bounds.
+ */
+const useLandingPaneAnchorStore = create<LandingPaneAnchorState>()((set) => ({
+  anchors: new Map(),
+  setAnchor: (draftId, element) =>
+    set((state) => {
+      if (state.anchors.get(draftId) === (element ?? undefined)) return state;
+      const anchors = new Map(state.anchors);
+      if (element === null) {
+        anchors.delete(draftId);
+      } else {
+        anchors.set(draftId, element);
+      }
+      return { anchors };
+    }),
+}));
+
+/**
+ * The panel slot a landing draft surface exposes inside its own flex row.
+ * `display: contents` keeps the portaled panel participating in the pane's
+ * layout exactly as a direct child would.
+ */
+export function LandingTerminalPaneAnchor(props: {
+  readonly draftId: string;
+}): ReactNode {
+  const setAnchor = useLandingPaneAnchorStore((state) => state.setAnchor);
+  const { draftId } = props;
+  const ref = useCallback(
+    (element: HTMLDivElement | null) => setAnchor(draftId, element),
+    [draftId, setAnchor],
+  );
+  return (
+    <div
+      ref={ref}
+      className="contents"
+      data-testid={`landing-terminal-anchor-${draftId}`}
+    />
+  );
+}
+
+/**
+ * The one landing-terminal mount for this window. The gesture provider is the
+ * single reader of live host/client/folder state and MUST keep its identity
+ * while draft focus moves between split panes - it owns the opening-gesture
+ * snapshot (captured host/cwd/generation) that reconciliation settles against.
+ * Only the panel's presentation moves: it is portaled into the selected
+ * draft's registered pane anchor, so the toggle, opened panel, and resize
+ * behavior stay confined to that pane while provider state survives the move.
  */
 export function LandingTerminalHost() {
   const draftId = useTabsStore((state) => {
@@ -23,11 +77,14 @@ export function LandingTerminalHost() {
     );
   });
   const panelOpen = useLandingTerminalStore((state) => state.panelOpen);
+  const anchor = useLandingPaneAnchorStore((state) =>
+    draftId === null ? null : (state.anchors.get(draftId) ?? null),
+  );
 
   if (draftId === null && !panelOpen) return null;
   return (
     <LandingTerminalGestureProvider draftId={draftId}>
-      <LandingTerminalPanel />
+      {anchor === null ? null : createPortal(<LandingTerminalPanel />, anchor)}
     </LandingTerminalGestureProvider>
   );
 }

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -173,6 +173,30 @@ function openEpicFixture(tab: EpicTab): string {
   return tab.id;
 }
 
+function seedSplitHeaderTabs(): void {
+  openEpicFixture(EPIC_A);
+  openEpicFixture(EPIC_B);
+  const left: TabRef = { kind: "epic", id: EPIC_A.id };
+  const right: TabRef = { kind: "epic", id: EPIC_B.id };
+  useTabsStore.setState({
+    version: 2,
+    items: [
+      {
+        kind: "split",
+        id: "split-a",
+        left: { kind: "tab", ref: left },
+        right: { kind: "tab", ref: right },
+        focusedSide: "left",
+        routeBackingSide: "left",
+        leftRatio: 0.5,
+      },
+    ],
+    activeItemId: "split-a",
+    stripOrder: [left, right],
+    systemTabs: { history: null, settings: null },
+  });
+}
+
 function canvasTabIds(tabId: string): ReadonlyArray<string> {
   const canvas = useEpicCanvasStore.getState().canvasByTabId[tabId] ?? null;
   if (canvas === null) return [];
@@ -630,6 +654,12 @@ describe("<TabStrip />", () => {
     // Distinct from the unconditional divider between the halves - a fix that
     // reused that divider would leave the group-to-tab boundary still blank.
     expect(screen.getByTestId("split-tab-divider-split-a")).toBeDefined();
+    expect(
+      screen.getByTestId("split-tab-group-underline-left-split-a").className,
+    ).toContain("bg-primary");
+    expect(
+      screen.getByTestId("split-tab-group-underline-right-split-a").className,
+    ).toContain("bg-primary");
 
     const plainC = screen.getByTestId(`tab-epic-${EPIC_C.id}`);
     const plainD = screen.getByTestId(`tab-epic-${tabD.id}`);
@@ -638,6 +668,155 @@ describe("<TabStrip />", () => {
     // Suppressed next to the active tab, and after the last item.
     expect(within(plainD).queryByTestId("header-tab-separator")).toBeNull();
     expect(within(plainE).queryByTestId("header-tab-separator")).toBeNull();
+  });
+
+  it("keeps the separator between adjacent split groups when one is active", async () => {
+    const tabD = epicFixture(4);
+    for (const epic of [EPIC_A, EPIC_B, EPIC_C, tabD]) {
+      openEpicFixture(epic);
+    }
+    const refA: TabRef = { kind: "epic", id: EPIC_A.id };
+    const refB: TabRef = { kind: "epic", id: EPIC_B.id };
+    const refC: TabRef = { kind: "epic", id: EPIC_C.id };
+    const refD: TabRef = { kind: "epic", id: tabD.id };
+    useTabsStore.setState({
+      version: 2,
+      items: [
+        {
+          kind: "split",
+          id: "split-a",
+          left: { kind: "tab", ref: refA },
+          right: { kind: "tab", ref: refB },
+          focusedSide: "left",
+          routeBackingSide: "left",
+          leftRatio: 0.5,
+        },
+        {
+          kind: "split",
+          id: "split-b",
+          left: { kind: "tab", ref: refC },
+          right: { kind: "tab", ref: refD },
+          focusedSide: "left",
+          routeBackingSide: "left",
+          leftRatio: 0.5,
+        },
+      ],
+      activeItemId: "split-a",
+      stripOrder: [refA, refB, refC, refD],
+      systemTabs: { history: null, settings: null },
+    });
+    const router = buildRouter(`/epics/${EPIC_A.id}/${EPIC_A.id}`);
+    render(<RouterProvider router={router} />);
+
+    const firstGroup = await screen.findByTestId("split-tab-group-split-a");
+    expect(
+      within(firstGroup).queryByTestId("header-tab-separator"),
+    ).not.toBeNull();
+    expect(
+      within(screen.getByTestId("split-tab-group-split-b")).queryByTestId(
+        "header-tab-separator",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps split arrangement commands flat in the main tab context menu", async () => {
+    seedSplitHeaderTabs();
+    const router = buildRouter("/epics/e-a/e-a");
+    render(<RouterProvider router={router} />);
+
+    fireEvent.contextMenu(await screen.findByTestId("tab-epic-e-a"));
+
+    const separate = await screen.findByTestId("tab-separate-split-epic-e-a");
+    expect(screen.queryByTestId("tab-arrange-split-epic-e-a")).toBeNull();
+    expect(separate.parentElement?.dataset.slot).toBe("context-menu-content");
+    expect(screen.getByTestId("tab-close-left-epic-e-a")).not.toBeNull();
+    expect(screen.getByTestId("tab-close-right-epic-e-a")).not.toBeNull();
+    expect(screen.getByTestId("tab-swap-split-epic-e-a")).not.toBeNull();
+  });
+
+  it("shows leading quick split actions without shrinking the merged titles", async () => {
+    seedSplitHeaderTabs();
+    const router = buildRouter("/epics/e-a/e-a");
+    render(<RouterProvider router={router} />);
+
+    const group = await screen.findByTestId("split-tab-group-split-a");
+    const trigger = screen.getByTestId("split-quick-actions-split-a");
+    const indicator = screen.getByTestId("split-focus-indicator-split-a");
+    const groupUnderline = screen.getByTestId(
+      "split-tab-group-underline-split-a",
+    );
+    const controlUnderline = screen.getByTestId(
+      "split-tab-group-underline-control-split-a",
+    );
+    const leftUnderline = screen.getByTestId(
+      "split-tab-group-underline-left-split-a",
+    );
+    const rightUnderline = screen.getByTestId(
+      "split-tab-group-underline-right-split-a",
+    );
+    const leftTab = screen.getByTestId("tab-epic-e-a");
+    const rightTab = screen.getByTestId("tab-epic-e-b");
+    const leftPane = indicator.querySelector('[data-split-pane="left"]');
+    const rightPane = indicator.querySelector('[data-split-pane="right"]');
+    expect(group.className).toContain("w-[31rem]");
+    expect(trigger.className).toContain("w-10");
+    expect(groupUnderline.className).toContain("bottom-0");
+    expect(groupUnderline.className).toContain("h-px");
+    expect(controlUnderline.className).toContain("bg-primary");
+    expect(screen.queryByTestId("split-tab-divider-split-a")).toBeNull();
+    expect(leftTab.className).toContain("px-5");
+    expect(rightTab.className).toContain("px-1.5");
+    expect(leftUnderline.className).not.toContain("bg-primary");
+    expect(rightUnderline.className).toContain("bg-primary");
+    expect(
+      within(leftTab).getByTestId("tab-chrome-center").style.borderTopColor,
+    ).toBe("var(--color-primary)");
+    expect(within(rightTab).queryByTestId("tab-chrome-center")).toBeNull();
+    expect(screen.queryByTestId("split-member-focus-accent")).toBeNull();
+    expect(trigger.className).toContain("text-blue-600");
+    expect(
+      screen.queryByTestId("split-quick-actions-status-split-a"),
+    ).toBeNull();
+    expect(trigger.getAttribute("aria-label")).toContain("left view focused");
+    expect(indicator.dataset.focusedSide).toBe("left");
+    expect(leftPane?.getAttribute("data-focused")).toBe("true");
+    expect(rightPane?.getAttribute("data-focused")).toBe("false");
+    expect(leftPane?.getAttribute("width")).toBe("8");
+    expect(rightPane?.getAttribute("width")).toBe("8");
+    expect(leftPane?.getAttribute("fill")).toBe("currentColor");
+    expect(rightPane?.getAttribute("fill")).toBe("none");
+
+    act(() => {
+      useTabsStore
+        .getState()
+        .focusSplitSide({ splitId: "split-a", side: "right" });
+    });
+
+    expect(trigger.getAttribute("aria-label")).toContain("right view focused");
+    expect(indicator.dataset.focusedSide).toBe("right");
+    expect(leftPane?.getAttribute("data-focused")).toBe("false");
+    expect(rightPane?.getAttribute("data-focused")).toBe("true");
+    expect(leftPane?.getAttribute("width")).toBe("8");
+    expect(rightPane?.getAttribute("width")).toBe("8");
+    expect(leftPane?.getAttribute("fill")).toBe("none");
+    expect(rightPane?.getAttribute("fill")).toBe("currentColor");
+    expect(leftUnderline.className).toContain("bg-primary");
+    expect(rightUnderline.className).not.toContain("bg-primary");
+    expect(leftTab.className).toContain("px-1.5");
+    expect(rightTab.className).toContain("px-5");
+    expect(within(leftTab).queryByTestId("tab-chrome-center")).toBeNull();
+    expect(
+      within(rightTab).getByTestId("tab-chrome-center").style.borderTopColor,
+    ).toBe("var(--color-primary)");
+
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(await screen.findByTestId("split-quick-swap-epic-e-a"));
+
+    expect(useTabsStore.getState().items[0]).toMatchObject({
+      kind: "split",
+      left: { kind: "tab", ref: { kind: "epic", id: EPIC_B.id } },
+      right: { kind: "tab", ref: { kind: "epic", id: EPIC_A.id } },
+    });
   });
 
   it("keeps the new-tab button after the tabs while preserving overflow", async () => {

--- a/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/tab-strip.test.tsx
@@ -767,12 +767,14 @@ describe("<TabStrip />", () => {
     const router = buildRouter("/epics/e-a/e-a");
     render(<RouterProvider router={router} />);
 
-    const group = await screen.findByTestId("split-tab-group-split-a");
+    // Purely cosmetic geometry (frame width, underline thickness, member
+    // padding) is not asserted via Tailwind class strings - those break on
+    // any restyle without proving behavior. The focus semantics that matter
+    // are the data-focused-side/data-focused attributes and bg-primary state
+    // asserted below.
+    await screen.findByTestId("split-tab-group-split-a");
     const trigger = screen.getByTestId("split-quick-actions-split-a");
     const indicator = screen.getByTestId("split-focus-indicator-split-a");
-    const groupUnderline = screen.getByTestId(
-      "split-tab-group-underline-split-a",
-    );
     const controlUnderline = screen.getByTestId(
       "split-tab-group-underline-control-split-a",
     );
@@ -786,14 +788,8 @@ describe("<TabStrip />", () => {
     const rightTab = screen.getByTestId("tab-epic-e-b");
     const leftPane = indicator.querySelector('[data-split-pane="left"]');
     const rightPane = indicator.querySelector('[data-split-pane="right"]');
-    expect(group.className).toContain("w-[31rem]");
-    expect(trigger.className).toContain("w-10");
-    expect(groupUnderline.className).toContain("bottom-0");
-    expect(groupUnderline.className).toContain("h-px");
     expect(controlUnderline.className).toContain("bg-primary");
     expect(screen.queryByTestId("split-tab-divider-split-a")).toBeNull();
-    expect(leftTab.className).toContain("px-5");
-    expect(rightTab.className).toContain("px-1.5");
     expect(leftUnderline.className).not.toContain("bg-primary");
     expect(rightUnderline.className).toContain("bg-primary");
     expect(

--- a/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
+++ b/clients/gui-app/src/components/layout/__tests__/top-level-tab-host.test.tsx
@@ -2,7 +2,10 @@ import "../../../../__tests__/test-browser-apis";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
-import { LandingTerminalHost } from "@/components/home/terminal-panel/landing-terminal-host";
+import {
+  LandingTerminalHost,
+  LandingTerminalPaneAnchor,
+} from "@/components/home/terminal-panel/landing-terminal-host";
 import {
   MAX_RETAINED_TOP_LEVEL_SURFACES,
   TopLevelTabHost,
@@ -51,7 +54,7 @@ vi.mock(
   }),
 );
 vi.mock("@/components/home/terminal-panel/landing-terminal-panel", () => ({
-  LandingTerminalPanel: () => null,
+  LandingTerminalPanel: () => <div data-testid="landing-terminal-panel-body" />,
 }));
 
 const EPIC_A: TabRef = { kind: "epic", id: "epic-a" };
@@ -324,5 +327,76 @@ describe("<TopLevelTabHost />", () => {
     expect(screen.getByTestId("landing-terminal").dataset.draftId).toBe(
       DRAFT_B.id,
     );
+  });
+
+  it("mounts landing terminal chrome for a standalone New Task tab", () => {
+    seedSources([DRAFT_A]);
+    setSingle(DRAFT_A, [DRAFT_A]);
+
+    render(<LandingTerminalHost />);
+
+    expect(screen.getByTestId("landing-terminal").dataset.draftId).toBe(
+      DRAFT_A.id,
+    );
+  });
+
+  it("keeps the landing terminal bound to the visible draft beside a focused chooser", () => {
+    seedSources([DRAFT_A]);
+    useTabsStore.setState((state) => ({
+      ...state,
+      items: [
+        {
+          kind: "split",
+          id: "chooser",
+          left: { kind: "tab", ref: DRAFT_A },
+          right: { kind: "empty" },
+          focusedSide: "right",
+          routeBackingSide: "left",
+          leftRatio: 0.5,
+        },
+      ],
+      activeItemId: "chooser",
+      stripOrder: [DRAFT_A],
+    }));
+
+    render(<LandingTerminalHost />);
+
+    expect(screen.getByTestId("landing-terminal").dataset.draftId).toBe(
+      DRAFT_A.id,
+    );
+  });
+
+  it("keeps one gesture provider mounted while the panel portals between panes", () => {
+    seedSources([DRAFT_A, DRAFT_B]);
+    setSplit(DRAFT_A, DRAFT_B, "left");
+
+    render(
+      <>
+        <LandingTerminalHost />
+        <LandingTerminalPaneAnchor draftId={DRAFT_A.id} />
+        <LandingTerminalPaneAnchor draftId={DRAFT_B.id} />
+      </>,
+    );
+
+    const provider = screen.getByTestId("landing-terminal");
+    expect(provider.dataset.draftId).toBe(DRAFT_A.id);
+    expect(
+      screen
+        .getByTestId(`landing-terminal-anchor-${DRAFT_A.id}`)
+        .contains(screen.getByTestId("landing-terminal-panel-body")),
+    ).toBe(true);
+
+    act(() => setSplit(DRAFT_A, DRAFT_B, "right"));
+
+    // The provider node survives the focus change: only the panel's DOM moves
+    // between panes, so the captured-gesture state the provider owns (pending
+    // gesture, generation, open-episode draft) is never destroyed mid-flight.
+    expect(screen.getByTestId("landing-terminal")).toBe(provider);
+    expect(provider.dataset.draftId).toBe(DRAFT_B.id);
+    expect(
+      screen
+        .getByTestId(`landing-terminal-anchor-${DRAFT_B.id}`)
+        .contains(screen.getByTestId("landing-terminal-panel-body")),
+    ).toBe(true);
   });
 });

--- a/clients/gui-app/src/components/layout/app-shell.tsx
+++ b/clients/gui-app/src/components/layout/app-shell.tsx
@@ -9,8 +9,8 @@ import { TopLevelTabHost } from "@/components/layout/top-level-tab-host";
 import { TopLevelSurfaceActivationProvider } from "@/components/layout/top-level-surface-activation-provider";
 import { HostScopeReady } from "@/components/layout/host-readiness-controller";
 import { MigrationRunController } from "@/components/migration/migration-run-controller";
-import { OpenFolderDialog } from "@/components/open-folder-dialog";
 import { LandingTerminalHost } from "@/components/home/terminal-panel/landing-terminal-host";
+import { OpenFolderDialog } from "@/components/open-folder-dialog";
 import { useReactiveActiveHostId } from "@/hooks/host/use-reactive-active-host-id";
 
 interface AppShellProps {
@@ -33,16 +33,8 @@ export function AppShell(props: AppShellProps) {
           <div className="relative flex h-screen w-full flex-col">
             <AppHeader variant="app" />
             <main className="relative flex min-h-0 flex-1 flex-col">
-              {/* The app's content viewport. Clips, because everything mounted
-                  here is edge-to-edge by construction: the landing terminal
-                  panel collapses to a 1px resize handle pinned against the
-                  right edge whose `::after` grab area is centred and ten times
-                  wider, and nothing between this row and the document scrolls.
-                  Without the clip that few-pixel overhang became scrollable
-                  document width and the landing page grew a horizontal
-                  scrollbar. The panel used to sit inside the landing page's own
-                  `overflow-hidden` box; hoisting the surfaces up here is what
-                  moved the responsibility onto this row. */}
+              {/* The app's edge-to-edge content viewport. Individual surfaces
+                  own their internal overflow, including the landing terminal. */}
               <div className="relative flex min-h-0 flex-1 overflow-hidden">
                 <TopLevelSurfaceActivationProvider>
                   <TopLevelTabHost />
@@ -53,6 +45,11 @@ export function AppShell(props: AppShellProps) {
                 >
                   {children}
                 </div>
+                {/* Single window-wide terminal mount: the gesture provider's
+                    state must survive draft/split focus changes, so it lives
+                    here rather than inside any one landing pane. The panel's
+                    DOM is portaled into the selected pane's anchor, which owns
+                    its layout and clipping. */}
                 <HostScopeReady scope="default-host">
                   <LandingTerminalHost />
                 </HostScopeReady>

--- a/clients/gui-app/src/components/layout/tabs/__tests__/root-dnd-provider-t9-round4.test.tsx
+++ b/clients/gui-app/src/components/layout/tabs/__tests__/root-dnd-provider-t9-round4.test.tsx
@@ -30,9 +30,17 @@ import {
 import { RootDndProvider } from "@/components/epic-canvas/dnd/root-dnd-provider";
 import { useEpicDndStore } from "@/components/epic-canvas/dnd/dnd-store";
 import {
+  ARTIFACT_TAB_DND_TYPE,
+  getArtifactTabDragId,
+  type EpicCanvasArtifactTabDragData,
+} from "@/components/epic-canvas/dnd/dnd";
+import {
   HEADER_TAB_DND_TYPE,
+  HEADER_TAB_SLOT_DND_TYPE,
   getHeaderTabDragId,
+  getHeaderStripItemSlotDropId,
   type HeaderTabDragData,
+  type HeaderTabSlotDropData,
 } from "@/components/layout/tabs/header-tab-dnd";
 import {
   TOP_LEVEL_EDGE_SPLIT_TARGET,
@@ -42,6 +50,8 @@ import {
 import { EDGE_SPLIT_DWELL_MS } from "@/components/layout/tabs/edge-split-dwell";
 import { __resetTabNavigationControllerForTesting } from "@/lib/tab-navigation";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { collectPanes } from "@/stores/epics/canvas/tile-tree";
+import type { EpicNodeRef } from "@/stores/epics/canvas/types";
 import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import { useTabsStore } from "@/stores/tabs/store";
 import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
@@ -49,6 +59,15 @@ import type { TabRef } from "@/stores/tabs/types";
 
 const SOURCE: TabRef = { kind: "draft", id: "source" };
 const TARGET: TabRef = { kind: "epic", id: "target" };
+const UNRELATED: TabRef = { kind: "draft", id: "unrelated-x" };
+const SPLIT_ID = "split-source-target";
+const TILE: EpicNodeRef = {
+  id: "spec-in-task",
+  instanceId: "spec-in-task-instance",
+  type: "spec",
+  name: "Spec in task",
+  hostId: "host-a",
+};
 
 function rect(left: number, top: number, right: number, bottom: number) {
   return {
@@ -98,6 +117,37 @@ function TestEdgeDropTarget(): ReactNode {
   return <div ref={setNodeRef} data-testid="edge-drop-target" />;
 }
 
+function TestCanvasTabDragSource(props: {
+  readonly data: EpicCanvasArtifactTabDragData;
+}): ReactNode {
+  const { listeners, setNodeRef } = useDraggable({
+    id: getArtifactTabDragId(props.data.sourceGroupId, props.data.tabId),
+    data: props.data,
+  });
+  return (
+    <button
+      ref={setNodeRef}
+      data-testid="canvas-tab-drag-source"
+      {...listeners}
+    >
+      canvas tab
+    </button>
+  );
+}
+
+function TestSplitGroupHeaderDropTarget(): ReactNode {
+  const data: HeaderTabSlotDropData = {
+    kind: HEADER_TAB_SLOT_DND_TYPE,
+    index: 0,
+    isTrailing: false,
+  };
+  const { setNodeRef } = useDroppable({
+    id: getHeaderStripItemSlotDropId(SPLIT_ID),
+    data,
+  });
+  return <div ref={setNodeRef} data-testid="split-group-header-drop-target" />;
+}
+
 function Harness(): ReactNode {
   return (
     <RootDndProvider>
@@ -107,8 +157,19 @@ function Harness(): ReactNode {
   );
 }
 
-function buildRouter(initialPath: string) {
-  const rootRoute = createRootRoute({ component: Harness });
+function CanvasTearOffHarness(props: {
+  readonly source: EpicCanvasArtifactTabDragData;
+}): ReactNode {
+  return (
+    <RootDndProvider>
+      <TestCanvasTabDragSource data={props.source} />
+      <TestSplitGroupHeaderDropTarget />
+    </RootDndProvider>
+  );
+}
+
+function buildRouterWithHarness(initialPath: string, harness: () => ReactNode) {
+  const rootRoute = createRootRoute({ component: harness });
   const draftRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/draft/$draftId",
@@ -132,6 +193,10 @@ function buildRouter(initialPath: string) {
   });
 }
 
+function buildRouter(initialPath: string) {
+  return buildRouterWithHarness(initialPath, Harness);
+}
+
 function seedLayout(): void {
   useLandingDraftStore.getState().createDraftWithId(SOURCE.id, null);
   useEpicCanvasStore
@@ -145,13 +210,55 @@ function seedLayout(): void {
       {
         kind: "tab",
         id: "tab:draft:unrelated-x",
-        ref: { kind: "draft", id: "unrelated-x" },
+        ref: UNRELATED,
       },
     ],
     activeItemId: `tab:${TARGET.kind}:${TARGET.id}`,
-    stripOrder: [SOURCE, TARGET, { kind: "draft", id: "unrelated-x" }],
+    stripOrder: [SOURCE, TARGET, UNRELATED],
     systemTabs: { history: null, settings: null },
   });
+}
+
+function seedCanvasTearOffLayout(): EpicCanvasArtifactTabDragData {
+  useLandingDraftStore.getState().createDraftWithId(SOURCE.id, null);
+  useLandingDraftStore.getState().createDraftWithId(UNRELATED.id, null);
+  useEpicCanvasStore
+    .getState()
+    .openEpicTabWithId(TARGET.id, "target-epic", "Target");
+  useEpicCanvasStore.getState().openTileInTab(TARGET.id, TILE);
+  const canvas = useEpicCanvasStore.getState().canvasByTabId[TARGET.id];
+  const sourceGroupId = collectPanes(canvas?.root ?? null).at(0)?.id;
+  if (sourceGroupId === undefined) throw new Error("Expected source pane");
+  useTabsStore.setState({
+    version: 2,
+    items: [
+      {
+        kind: "split",
+        id: SPLIT_ID,
+        left: { kind: "tab", ref: SOURCE },
+        right: { kind: "tab", ref: TARGET },
+        focusedSide: "right",
+        routeBackingSide: "right",
+        leftRatio: 0.5,
+      },
+      {
+        kind: "tab",
+        id: `tab:${UNRELATED.kind}:${UNRELATED.id}`,
+        ref: UNRELATED,
+      },
+    ],
+    activeItemId: SPLIT_ID,
+    stripOrder: [SOURCE, TARGET, UNRELATED],
+    systemTabs: { history: null, settings: null },
+  });
+  return {
+    kind: ARTIFACT_TAB_DND_TYPE,
+    epicId: "target-epic",
+    viewTabId: TARGET.id,
+    sourceGroupId,
+    tabId: TILE.instanceId,
+    isPreview: false,
+  };
 }
 
 /**
@@ -278,5 +385,137 @@ describe("T9 round-4: RootDndProvider real wiring", () => {
     // a raw `pairTabs` + no navigation, the router would stay on the
     // pre-drag route: this assertion is the real-callsite discriminator.
     expect(router.state.location.pathname).toBe(`/draft/${SOURCE.id}`);
+  });
+
+  it("tears an in-task tile tab onto the main strip beside a split group", async () => {
+    const dragData = seedCanvasTearOffLayout();
+    const router = buildRouterWithHarness(
+      `/epics/target-epic/${TARGET.id}`,
+      () => <CanvasTearOffHarness source={dragData} />,
+    );
+    render(<RouterProvider router={router} />);
+    const source = await screen.findByTestId("canvas-tab-drag-source");
+    const target = await screen.findByTestId("split-group-header-drop-target");
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue(
+      rect(200, 0, 400, 50),
+    );
+
+    act(() => {
+      fireEvent.pointerDown(source, {
+        pointerId: 2,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      fireEvent.pointerMove(source, {
+        pointerId: 2,
+        clientX: 30,
+        clientY: 10,
+      });
+      fireEvent.pointerMove(source, {
+        pointerId: 2,
+        clientX: 350,
+        clientY: 10,
+      });
+    });
+    expect(useEpicDndStore.getState().headerStripDropIndex).toBe(1);
+
+    act(() => {
+      fireEvent.pointerUp(source, {
+        pointerId: 2,
+        clientX: 350,
+        clientY: 10,
+      });
+    });
+
+    const items = useTabsStore.getState().items;
+    expect(items.map((item) => item.kind)).toEqual(["split", "tab", "tab"]);
+    expect(items[0]?.id).toBe(SPLIT_ID);
+    expect(items[2]).toMatchObject({ kind: "tab", ref: UNRELATED });
+    const duplicated = items[1];
+    if (duplicated.kind !== "tab" || duplicated.ref.kind !== "epic") {
+      throw new Error("Expected duplicated task beside the split group");
+    }
+    expect(duplicated.ref.id).not.toBe(TARGET.id);
+    expect(
+      useEpicCanvasStore.getState().tabsById[duplicated.ref.id]?.epicId,
+    ).toBe("target-epic");
+    expect(router.state.location.pathname).toBe(
+      `/epics/target-epic/${duplicated.ref.id}`,
+    );
+  });
+
+  // KEEP LAST: `installSourceReconciliation` subscribes the module-singleton
+  // coordinator to the source stores and cannot be uninstalled, so it must
+  // not run before the tests above.
+  it("keeps the authoritative split when legacy stripOrder is stale during a tear-off", async () => {
+    const dragData = seedCanvasTearOffLayout();
+    // Production wiring: the source-store subscriber runs SYNCHRONOUSLY
+    // between the drop's source mutation and its placement unless both live
+    // in one suppressed coordinator transaction.
+    tabCommandCoordinator.installSourceReconciliation();
+    // A legacy flat caller re-seeding `stripOrder` directly is a supported
+    // compatibility write. Only source-store changes trigger reconciliation,
+    // so the projection stays stale until the next coordinator entry - which
+    // must resolve against the authoritative grouped items, not rebuild the
+    // flat order and dissolve the split.
+    useTabsStore.setState((state) => ({ ...state, stripOrder: [] }));
+
+    const router = buildRouterWithHarness(
+      `/epics/target-epic/${TARGET.id}`,
+      () => <CanvasTearOffHarness source={dragData} />,
+    );
+    render(<RouterProvider router={router} />);
+    const source = await screen.findByTestId("canvas-tab-drag-source");
+    const target = await screen.findByTestId("split-group-header-drop-target");
+    vi.spyOn(target, "getBoundingClientRect").mockReturnValue(
+      rect(200, 0, 400, 50),
+    );
+
+    act(() => {
+      fireEvent.pointerDown(source, {
+        pointerId: 3,
+        isPrimary: true,
+        button: 0,
+        clientX: 10,
+        clientY: 10,
+      });
+      fireEvent.pointerMove(source, {
+        pointerId: 3,
+        clientX: 30,
+        clientY: 10,
+      });
+      fireEvent.pointerMove(source, {
+        pointerId: 3,
+        clientX: 350,
+        clientY: 10,
+      });
+    });
+
+    act(() => {
+      fireEvent.pointerUp(source, {
+        pointerId: 3,
+        clientX: 350,
+        clientY: 10,
+      });
+    });
+
+    const items = useTabsStore.getState().items;
+    expect(items.map((item) => item.kind)).toEqual(["split", "tab", "tab"]);
+    expect(items[0]).toMatchObject({
+      kind: "split",
+      id: SPLIT_ID,
+      left: { kind: "tab", ref: SOURCE },
+      right: { kind: "tab", ref: TARGET },
+    });
+    const duplicated = items[1];
+    if (duplicated.kind !== "tab" || duplicated.ref.kind !== "epic") {
+      throw new Error("Expected duplicated task beside the split group");
+    }
+    expect(duplicated.ref.id).not.toBe(TARGET.id);
+    expect(
+      useEpicCanvasStore.getState().tabsById[duplicated.ref.id]?.epicId,
+    ).toBe("target-epic");
   });
 });

--- a/clients/gui-app/src/components/layout/tabs/__tests__/split-slot-chooser-t9-round4.test.tsx
+++ b/clients/gui-app/src/components/layout/tabs/__tests__/split-slot-chooser-t9-round4.test.tsx
@@ -1,14 +1,48 @@
-/**
- * T9 round-4: real `SplitSlotChooserContent` render coverage for MED1 and
- * MED2. Round 1-3 tests called `getFillableSlotChoicesWithCatalog` as a bare
- * function and asserted on its return array - never rendering the chooser
- * component itself, so a bug in the render/DOM-filtering layer (or a fix
- * that only "worked" when read as an array) would slip through. These tests
- * render the real chooser content component and assert on the actual DOM.
- */
 import "../../../../../__tests__/test-browser-apis";
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import type { HistoryItem } from "@/components/home/data/home-page.data";
+
+const chooserHistoryItem = vi.hoisted<HistoryItem>(() => ({
+  id: "history-epic",
+  epicId: "history-epic",
+  taskType: "epic",
+  title: "History Epic",
+  initialUserPrompt: "",
+  updatedAtMs: 1,
+  updatedLabel: "now",
+  updatedBucket: "today",
+  linkedRepos: [],
+  linkedWorkspaces: [],
+  pullRequestNumbers: [],
+  worktreeBranches: [],
+  worktreePaths: [],
+  ownership: "mine",
+  permissionRole: "owner",
+  isPinned: false,
+}));
+
+vi.mock("@/components/epics/epics-list-panel", () => ({
+  EpicsListPanel: (props: {
+    readonly onOpenItem: ((item: HistoryItem) => void) | null;
+  }) => (
+    <div data-testid="embedded-history-panel">
+      <button
+        type="button"
+        onClick={() => props.onOpenItem?.(chooserHistoryItem)}
+      >
+        History Epic
+      </button>
+    </div>
+  ),
+}));
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import {
   createMemoryHistory,
   createRootRoute,
@@ -19,241 +53,312 @@ import {
   SplitSlotChooserContent,
   type SplitSlotChooserProps,
 } from "@/components/layout/tabs/split-slot-chooser";
-import type { FillableSlotCatalogEntry } from "@/components/layout/tabs/fillable-slot";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
+import { useLandingDraftStore } from "@/stores/home/landing-draft-store";
 import { useTabsStore } from "@/stores/tabs/store";
-import {
-  registerTabStructuralLockPredicate,
-  resetTabStructuralLockForTesting,
-} from "@/stores/tabs/tab-structural-lock";
+import { resetTabStructuralLockForTesting } from "@/stores/tabs/tab-structural-lock";
+import { setTabSplitCompatibility } from "@/stores/tabs/tab-split-compatibility";
 import type { TabRef } from "@/stores/tabs/types";
 
+const PARTNER: TabRef = { kind: "epic", id: "partner" };
+const REUSABLE: TabRef = { kind: "epic", id: "reusable" };
+const SPLIT_START_PAGE: TabRef = { kind: "draft", id: "split-start-page" };
+const OPEN_START_PAGE_A: TabRef = { kind: "draft", id: "open-start-page-a" };
+const OPEN_START_PAGE_B: TabRef = { kind: "draft", id: "open-start-page-b" };
+
 async function renderChooser(
-  props: SplitSlotChooserProps & {
-    readonly catalog: ReadonlyArray<FillableSlotCatalogEntry>;
-  },
+  props: SplitSlotChooserProps & { readonly historyAvailable: boolean },
 ): Promise<void> {
   const rootRoute = createRootRoute({
-    component: () => (
-      <SplitSlotChooserContent
-        {...props}
-        query=""
-        onQueryChange={() => undefined}
-      />
-    ),
+    component: () => <SplitSlotChooserContent {...props} />,
   });
   const router = createRouter({
     routeTree: rootRoute,
     history: createMemoryHistory({ initialEntries: ["/"] }),
   });
   render(<RouterProvider router={router} />);
-  // Confirms the component actually mounted before any absence assertion -
-  // otherwise `queryByRole(...) === null` would trivially pass on an empty
-  // (not-yet-resolved-router) DOM.
-  await screen.findByLabelText("Search tabs and destinations");
+  await screen.findByLabelText(
+    `${props.slot.kind === "unavailable" ? "Unavailable" : "Empty"} split view`,
+  );
+}
+
+function seedSplitLayout(includeReusable: boolean) {
+  useEpicCanvasStore
+    .getState()
+    .openEpicTabWithId(PARTNER.id, "partner-epic", "Partner");
+  if (includeReusable) {
+    useEpicCanvasStore
+      .getState()
+      .openEpicTabWithId(REUSABLE.id, "reusable-epic", "Reusable Epic");
+  }
+  useTabsStore.setState({
+    version: 2,
+    items: [
+      {
+        kind: "split",
+        id: "split-a",
+        left: { kind: "empty" },
+        right: { kind: "tab", ref: PARTNER },
+        focusedSide: "right",
+        routeBackingSide: "right",
+        leftRatio: 0.5,
+      },
+      ...(includeReusable
+        ? [{ kind: "tab" as const, id: "tab:epic:reusable", ref: REUSABLE }]
+        : []),
+    ],
+    activeItemId: "split-a",
+    stripOrder: includeReusable ? [PARTNER, REUSABLE] : [PARTNER],
+    systemTabs: { history: null, settings: null },
+  });
+}
+
+function seedStartPageLayoutWithStaleLegacyOrder() {
+  [SPLIT_START_PAGE, OPEN_START_PAGE_A, OPEN_START_PAGE_B].forEach((ref) => {
+    useLandingDraftStore.getState().createDraftWithId(ref.id, null);
+  });
+  useTabsStore.setState({
+    version: 2,
+    items: [
+      {
+        kind: "tab",
+        id: "tab:draft:open-start-page-a",
+        ref: OPEN_START_PAGE_A,
+      },
+      {
+        kind: "split",
+        id: "split-a",
+        left: { kind: "empty" },
+        right: { kind: "tab", ref: SPLIT_START_PAGE },
+        focusedSide: "right",
+        routeBackingSide: "right",
+        leftRatio: 0.5,
+      },
+      {
+        kind: "tab",
+        id: "tab:draft:open-start-page-b",
+        ref: OPEN_START_PAGE_B,
+      },
+    ],
+    activeItemId: "split-a",
+    // Reproduces the live regression: the grouped header is authoritative and
+    // visible while the legacy flattened projection has not caught up.
+    stripOrder: [],
+    systemTabs: { history: null, settings: null },
+  });
 }
 
 afterEach(() => {
   cleanup();
   useTabsStore.setState(useTabsStore.getInitialState(), true);
   useEpicCanvasStore.setState(useEpicCanvasStore.getInitialState(), true);
+  useLandingDraftStore.setState({ drafts: [], activeDraftId: null });
   resetTabStructuralLockForTesting();
+  setTabSplitCompatibility(true);
 });
 
-describe("T9 round-4: SplitSlotChooserContent real render", () => {
-  it("hides a structurally locked Phase-migration catalog row (MED1)", async () => {
-    const PHASE: TabRef = { kind: "epic", id: "phase-tab" };
-    useEpicCanvasStore.getState().openEpicTabWithId(PHASE.id, "phase-1", "");
-    useEpicCanvasStore.setState((state) => {
-      const tab = state.tabsById[PHASE.id];
-      if (tab === undefined) throw new Error("Expected Phase tab");
-      return {
-        tabsById: {
-          ...state.tabsById,
-          [PHASE.id]: {
-            ...tab,
-            surfaceMode: { kind: "phase-migration", phaseId: "phase-1" },
-          },
-        },
-      };
-    });
-    useTabsStore.setState({
-      version: 2,
-      items: [
-        {
-          kind: "split",
-          id: "split-a",
-          left: { kind: "empty" },
-          right: { kind: "tab", ref: PHASE },
-          focusedSide: "left",
-          routeBackingSide: "right",
-          leftRatio: 0.5,
-        },
-      ],
-      activeItemId: "split-a",
-      stripOrder: [PHASE],
-      systemTabs: { history: null, settings: null },
-    });
-    const unregister = registerTabStructuralLockPredicate(
-      (ref) => ref.kind === PHASE.kind && ref.id === PHASE.id,
-    );
+describe("SplitSlotChooserContent grouped destinations", () => {
+  it("groups reusable tabs above New Task and the embedded landing History panel", async () => {
+    seedSplitLayout(true);
 
     await renderChooser({
       splitId: "split-a",
       side: "left",
       slot: { kind: "empty" },
-      focused: false,
       dropActive: false,
-      catalog: [
-        { kind: "phase-migration", phaseId: "phase-1", name: "Legacy Phase" },
-      ],
+      historyAvailable: true,
     });
 
-    expect(screen.queryByRole("button", { name: "Legacy Phase" })).toBeNull();
-    unregister();
-  });
-
-  it("shows an unlocked Phase-migration catalog row normally", async () => {
-    const PHASE: TabRef = { kind: "epic", id: "phase-tab" };
-    useEpicCanvasStore.getState().openEpicTabWithId(PHASE.id, "phase-1", "");
-    useEpicCanvasStore.setState((state) => {
-      const tab = state.tabsById[PHASE.id];
-      if (tab === undefined) throw new Error("Expected Phase tab");
-      return {
-        tabsById: {
-          ...state.tabsById,
-          [PHASE.id]: {
-            ...tab,
-            surfaceMode: { kind: "phase-migration", phaseId: "phase-1" },
-          },
-        },
-      };
-    });
-    useTabsStore.setState({
-      version: 2,
-      items: [
-        {
-          kind: "split",
-          id: "split-a",
-          left: { kind: "empty" },
-          right: { kind: "tab", ref: PHASE },
-          focusedSide: "left",
-          routeBackingSide: "right",
-          leftRatio: 0.5,
-        },
-      ],
-      activeItemId: "split-a",
-      stripOrder: [PHASE],
-      systemTabs: { history: null, settings: null },
-    });
-
-    await renderChooser({
-      splitId: "split-a",
-      side: "left",
-      slot: { kind: "empty" },
-      focused: false,
-      dropActive: false,
-      catalog: [
-        { kind: "phase-migration", phaseId: "phase-1", name: "Legacy Phase" },
-      ],
-    });
-
-    expect(screen.getByRole("button", { name: "Legacy Phase" })).toBeDefined();
-  });
-
-  it("dedupes an Epic reachable both as an open ref and a catalog destination (MED2a)", async () => {
-    const PARTNER: TabRef = { kind: "epic", id: "partner" };
-    const REUSE: TabRef = { kind: "epic", id: "reuse" };
-    useEpicCanvasStore
-      .getState()
-      .openEpicTabWithId(PARTNER.id, "shared-epic", "Partner");
-    useEpicCanvasStore
-      .getState()
-      .openEpicTabWithId(REUSE.id, "shared-epic", "Partner Copy");
-    useTabsStore.setState({
-      version: 2,
-      items: [
-        {
-          kind: "split",
-          id: "split-a",
-          left: { kind: "empty" },
-          right: { kind: "tab", ref: PARTNER },
-          focusedSide: "left",
-          routeBackingSide: "right",
-          leftRatio: 0.5,
-        },
-        { kind: "tab", id: "tab:epic:reuse", ref: REUSE },
-      ],
-      activeItemId: "split-a",
-      stripOrder: [PARTNER, REUSE],
-      systemTabs: { history: null, settings: null },
-    });
-
-    await renderChooser({
-      splitId: "split-a",
-      side: "left",
-      slot: { kind: "empty" },
-      focused: false,
-      dropActive: false,
-      catalog: [],
-    });
-
-    // The open-ref row (the reusable ungrouped view) is present under its
-    // own label...
-    expect(screen.getByRole("button", { name: "Partner Copy" })).toBeDefined();
-    // ...and the same-Epic catalog destination row (keyed by Epic id, which
-    // never collides with the open row's tab-id-keyed id) must NOT also
-    // render - it is the same Epic, reachable twice.
-    expect(screen.queryByRole("button", { name: "Partner" })).toBeNull();
-  });
-
-  it("does not offer a bogus Epic destination for an incomplete Phase-migration split (MED2b)", async () => {
-    const PHASE: TabRef = { kind: "epic", id: "phase-tab" };
-    useEpicCanvasStore
-      .getState()
-      .openEpicTabWithId(PHASE.id, "phase-1", "Legacy Phase Tab");
-    useEpicCanvasStore.setState((state) => {
-      const tab = state.tabsById[PHASE.id];
-      if (tab === undefined) throw new Error("Expected Phase tab");
-      return {
-        tabsById: {
-          ...state.tabsById,
-          [PHASE.id]: {
-            ...tab,
-            surfaceMode: { kind: "phase-migration", phaseId: "phase-1" },
-          },
-        },
-      };
-    });
-    useTabsStore.setState({
-      version: 2,
-      items: [
-        {
-          kind: "split",
-          id: "split-a",
-          left: { kind: "empty" },
-          right: { kind: "tab", ref: PHASE },
-          focusedSide: "left",
-          routeBackingSide: "right",
-          leftRatio: 0.5,
-        },
-      ],
-      activeItemId: "split-a",
-      stripOrder: [PHASE],
-      systemTabs: { history: null, settings: null },
-    });
-
-    await renderChooser({
-      splitId: "split-a",
-      side: "left",
-      slot: { kind: "empty" },
-      focused: false,
-      dropActive: false,
-      catalog: [],
-    });
-
+    expect(screen.getByRole("heading", { name: "Open Tabs" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "Create" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "History" })).toBeDefined();
+    expect(screen.getByTestId("embedded-history-panel")).toBeDefined();
     expect(
-      screen.queryByRole("button", { name: "Legacy Phase Tab" }),
-    ).toBeNull();
+      within(screen.getByTestId("split-open-tabs")).getByRole("button", {
+        name: "Reusable Epic",
+      }),
+    ).toBeDefined();
+    expect(screen.getByRole("button", { name: "New Task" })).toBeDefined();
+    [
+      "split-open-tabs-card",
+      "split-create-actions-card",
+      "split-history-card",
+    ].forEach((testId) => {
+      const cardClassName = screen.getByTestId(testId).className;
+      expect(cardClassName).not.toContain("rounded-lg");
+      expect(cardClassName).not.toContain("border");
+      expect(cardClassName).not.toContain("bg-card/40");
+    });
+    expect(screen.queryByText("Settings")).toBeNull();
+    expect(screen.queryByLabelText("Search tabs and destinations")).toBeNull();
+    expect(screen.getByTestId("split-slot-chooser-left").className).toContain(
+      "overflow-hidden",
+    );
+    expect(screen.getByTestId("split-history").className).toContain("flex-1");
+    expect(screen.getByTestId("split-create-actions").className).toContain(
+      "border-t",
+    );
+    expect(screen.getByTestId("split-history").className).toContain("border-t");
+    expect(screen.getByTestId("split-history-card").className).toContain(
+      "overflow-y-auto",
+    );
+  });
+
+  it("moves a reusable open tab into the empty split side", async () => {
+    seedSplitLayout(true);
+    await renderChooser({
+      splitId: "split-a",
+      side: "left",
+      slot: { kind: "empty" },
+      dropActive: false,
+      historyAvailable: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reusable Epic" }));
+
+    expect(useTabsStore.getState().items[0]).toMatchObject({
+      kind: "split",
+      left: { kind: "tab", ref: REUSABLE },
+      right: { kind: "tab", ref: PARTNER },
+    });
+  });
+
+  it("detects visible Start Page tabs from authoritative grouped items", async () => {
+    seedStartPageLayoutWithStaleLegacyOrder();
+    await renderChooser({
+      splitId: "split-a",
+      side: "left",
+      slot: { kind: "empty" },
+      dropActive: false,
+      historyAvailable: true,
+    });
+
+    const startPageButtons = within(
+      screen.getByTestId("split-open-tabs"),
+    ).getAllByRole("button", { name: "Start Page" });
+    expect(startPageButtons).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "New Task" })).toBeDefined();
+
+    fireEvent.click(startPageButtons[0]);
+    expect(useTabsStore.getState().items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "split",
+          id: "split-a",
+          left: { kind: "tab", ref: OPEN_START_PAGE_A },
+        }),
+      ]),
+    );
+  });
+
+  it("creates a draft in the empty side from New Task", async () => {
+    seedStartPageLayoutWithStaleLegacyOrder();
+    await renderChooser({
+      splitId: "split-a",
+      side: "left",
+      slot: { kind: "empty" },
+      dropActive: false,
+      historyAvailable: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "New Task" }));
+
+    expect(useTabsStore.getState().items[0]).toMatchObject({
+      kind: "tab",
+    });
+    const split = useTabsStore
+      .getState()
+      .items.find((item) => item.kind === "split" && item.id === "split-a");
+    expect(split).toMatchObject({
+      kind: "split",
+      id: "split-a",
+      left: { kind: "tab", ref: { kind: "draft" } },
+    });
+  });
+
+  it("creates a draft from a right-side chooser beside Start Page", async () => {
+    useLandingDraftStore
+      .getState()
+      .createDraftWithId(SPLIT_START_PAGE.id, null);
+    useTabsStore.setState({
+      version: 2,
+      items: [
+        {
+          kind: "split",
+          id: "split-a",
+          left: { kind: "tab", ref: SPLIT_START_PAGE },
+          right: { kind: "empty" },
+          focusedSide: "right",
+          routeBackingSide: "left",
+          leftRatio: 0.5,
+        },
+      ],
+      activeItemId: "split-a",
+      stripOrder: [SPLIT_START_PAGE],
+      systemTabs: { history: null, settings: null },
+    });
+    setTabSplitCompatibility(false);
+    await renderChooser({
+      splitId: "split-a",
+      side: "right",
+      slot: { kind: "empty" },
+      dropActive: false,
+      historyAvailable: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "New Task" }));
+
+    expect(useTabsStore.getState().items[0]).toMatchObject({
+      kind: "split",
+      left: { kind: "tab", ref: SPLIT_START_PAGE },
+      right: { kind: "tab", ref: { kind: "draft" } },
+      focusedSide: "right",
+      routeBackingSide: "right",
+    });
+  });
+
+  it("fills the split from a row in the reused History panel", async () => {
+    seedSplitLayout(false);
+    await renderChooser({
+      splitId: "split-a",
+      side: "left",
+      slot: { kind: "empty" },
+      dropActive: false,
+      historyAvailable: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "History Epic" }));
+
+    expect(useTabsStore.getState().items[0]).toMatchObject({
+      kind: "split",
+      left: { kind: "tab", ref: { kind: "epic" } },
+    });
+    expect(
+      Object.values(useEpicCanvasStore.getState().tabsById).some(
+        (tab) => tab?.epicId === chooserHistoryItem.epicId,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps unavailable metadata visible while offering the same groups", async () => {
+    seedSplitLayout(false);
+    await renderChooser({
+      splitId: "split-a",
+      side: "left",
+      slot: {
+        kind: "unavailable",
+        previousRef: { kind: "epic", id: "lost" },
+        label: "Lost task unavailable",
+      },
+      dropActive: false,
+      historyAvailable: false,
+    });
+
+    expect(screen.getByText("Lost task unavailable")).toBeDefined();
+    expect(
+      screen.getByText(
+        "History is unavailable while the host is disconnected.",
+      ),
+    ).toBeDefined();
   });
 });

--- a/clients/gui-app/src/components/layout/tabs/__tests__/tab-split-t9.test.tsx
+++ b/clients/gui-app/src/components/layout/tabs/__tests__/tab-split-t9.test.tsx
@@ -471,6 +471,13 @@ describe("T9 split interactions", () => {
     const choices = getFillableSlotChoices("split-a", "left");
 
     expect(choices.map((choice) => choice.id)).not.toContain("open:epic:phase");
+    expect(
+      resolveFillableSlotDestination("split-a", "left", {
+        kind: "phase-migration",
+        phaseId: "phase-1",
+        name: "Phase",
+      }),
+    ).toEqual({ kind: "invalid" });
     unregister();
   });
 

--- a/clients/gui-app/src/components/layout/tabs/fillable-slot.ts
+++ b/clients/gui-app/src/components/layout/tabs/fillable-slot.ts
@@ -263,6 +263,7 @@ export function resolveFillableSlotDestination(
         name: destination.name,
       };
     }
+    if (isTabStructurallyLocked(migration)) return { kind: "invalid" };
     return resolveExistingRef(layout, migration);
   }
   const reusable = findUngroupedEpicRef(layout, destination.epicId);
@@ -402,13 +403,22 @@ function findUngroupedEpicRef(
   layout: PersistedTabStripLayout,
   epicId: string,
 ): TabRef | null {
-  const tab = getHeaderTabs().find(
-    (candidate) =>
-      candidate.kind === "epic" &&
-      candidate.epicId === epicId &&
-      findStripItemForRef(layout, refForTab(candidate))?.kind === "tab",
-  );
-  return tab === undefined ? null : refForTab(tab);
+  // Resolve reusable views from the authoritative grouped items, not the
+  // legacy `stripOrder` projection `getHeaderTabs` reads: an Epic visible as
+  // a standalone item must be moved into the slot - not duplicated - even
+  // while the flat compatibility order is stale.
+  const tabsById = useEpicCanvasStore.getState().tabsById;
+  for (const item of layout.items) {
+    if (item.kind !== "tab" || item.ref.kind !== "epic") continue;
+    const canvasTab = tabsById[item.ref.id];
+    if (canvasTab === undefined || canvasTab.epicId !== epicId) continue;
+    // A Phase-migration tab reuses `epicId` as its phaseId placeholder (see
+    // sameEpicCatalog) - it is never a reusable destination for an Epic row.
+    if (canvasTab.surfaceMode?.kind === "phase-migration") continue;
+    if (isTabStructurallyLocked(item.ref)) continue;
+    return item.ref;
+  }
+  return null;
 }
 
 function findPhaseMigrationRef(phaseId: string): TabRef | null {

--- a/clients/gui-app/src/components/layout/tabs/split-slot-chooser.tsx
+++ b/clients/gui-app/src/components/layout/tabs/split-slot-chooser.tsx
@@ -1,121 +1,86 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { type ReactNode, useCallback, useSyncExternalStore } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { FilePlus2 } from "lucide-react";
+import { toast } from "sonner";
+import { EpicsListPanel } from "@/components/epics/epics-list-panel";
+import type { HistoryItem } from "@/components/home/data/home-page.data";
 import { Button } from "@/components/ui/button";
 import {
   commitFillableSlotDestination,
-  getFillableSlotChoicesWithCatalog,
-  type FillableSlotCatalogEntry,
+  type FillableSlotChoice,
+  type FillableSlotDestination,
 } from "@/components/layout/tabs/fillable-slot";
+import { useHostBinding } from "@/lib/host";
 import { cn } from "@/lib/utils";
 import { navigateToTabIntent } from "@/lib/tab-navigation";
-import { tabResolveIntent } from "@/stores/tabs/registry";
+import { tabResolveIntent, tabSurfaceDescriptor } from "@/stores/tabs/registry";
+import {
+  getHeaderTabs,
+  useHeaderStripItems,
+} from "@/stores/tabs/use-header-tabs";
 import { useTabsStore } from "@/stores/tabs/store";
-import { getHeaderTabs } from "@/stores/tabs/use-header-tabs";
 import type { SplitSide, SplitSideName } from "@/stores/tabs/layout";
-import type { TabRef } from "@/stores/tabs/types";
-import { DEFAULT_HISTORY_SEARCH } from "@/lib/history-search";
-import { useHistoryQuery } from "@/hooks/home/use-history-query";
-import { useHostBinding } from "@/lib/host";
 import {
   getTabStructuralLockRevision,
+  isTabStructurallyLocked,
   subscribeTabStructuralLocks,
 } from "@/stores/tabs/tab-structural-lock";
+import type { TabRef } from "@/stores/tabs/types";
 
 export interface SplitSlotChooserProps {
   readonly splitId: string;
   readonly side: SplitSideName;
   readonly slot: Exclude<SplitSide, { readonly kind: "tab" }>;
-  readonly focused: boolean;
   /** A header tab is hovering this slot and releasing would commit the drop. */
   readonly dropActive: boolean;
 }
 
-export function SplitSlotChooser(props: SplitSlotChooserProps) {
-  const [query, setQuery] = useState("");
+export function SplitSlotChooser(props: SplitSlotChooserProps): ReactNode {
   const binding = useHostBinding();
-  if (binding === null) {
-    return (
-      <SplitSlotChooserContent
-        {...props}
-        catalog={EMPTY_CATALOG}
-        query={query}
-        onQueryChange={setQuery}
-      />
-    );
-  }
   return (
-    <CataloguedSplitSlotChooser
-      {...props}
-      query={query}
-      onQueryChange={setQuery}
-    />
+    <SplitSlotChooserContent {...props} historyAvailable={binding !== null} />
   );
-}
-
-const EMPTY_CATALOG: ReadonlyArray<FillableSlotCatalogEntry> = [];
-
-function CataloguedSplitSlotChooser(
-  props: SplitSlotChooserProps & {
-    readonly query: string;
-    readonly onQueryChange: (query: string) => void;
-  },
-) {
-  const history = useHistoryQuery({
-    search: { ...DEFAULT_HISTORY_SEARCH, query: props.query },
-    nowMs: null,
-  });
-  const catalog = useMemo<ReadonlyArray<FillableSlotCatalogEntry>>(
-    () =>
-      (history.data?.items ?? []).map((item) =>
-        item.taskType === "epic"
-          ? { kind: "epic", epicId: item.epicId, name: item.title }
-          : {
-              kind: "phase-migration",
-              phaseId: item.epicId,
-              name: item.title,
-            },
-      ),
-    [history.data],
-  );
-  return <SplitSlotChooserContent {...props} catalog={catalog} />;
 }
 
 export function SplitSlotChooserContent(
-  props: SplitSlotChooserProps & {
-    readonly catalog: ReadonlyArray<FillableSlotCatalogEntry>;
-    readonly query: string;
-    readonly onQueryChange: (query: string) => void;
-  },
-) {
+  props: SplitSlotChooserProps & { readonly historyAvailable: boolean },
+): ReactNode {
   const navigate = useNavigate();
-  useTabsStore((state) => state.items);
+  const headerItems = useHeaderStripItems();
+  // Store focus can land on this empty side without any DOM focus following
+  // it (keyboard "add split", focus-side commands). Mirroring the focused
+  // side into the search's focus effect gives typing somewhere to go.
+  const sideFocused = useTabsStore((state) =>
+    state.items.some(
+      (item) =>
+        item.kind === "split" &&
+        item.id === props.splitId &&
+        item.focusedSide === props.side,
+    ),
+  );
   useSyncExternalStore(
     subscribeTabStructuralLocks,
     getTabStructuralLockRevision,
     getTabStructuralLockRevision,
   );
-  const searchRef = useRef<HTMLInputElement | null>(null);
-  const choices = getFillableSlotChoicesWithCatalog(
-    props.splitId,
-    props.side,
-    props.catalog,
-  );
-  const filtered = useMemo(
-    () =>
-      choices.filter((choice) =>
-        choice.label
-          .toLocaleLowerCase()
-          .includes(props.query.toLocaleLowerCase()),
-      ),
-    [choices, props.query],
-  );
+  const openTabs = headerItems.flatMap<FillableSlotChoice>((item) => {
+    if (item.kind !== "tab") return [];
+    const ref: TabRef = { kind: item.tab.kind, id: item.tab.id };
+    if (
+      isTabStructurallyLocked(ref) ||
+      tabSurfaceDescriptor(ref.kind).splitEligibility !== "eligible"
+    ) {
+      return [];
+    }
+    return [
+      {
+        id: `open:${ref.kind}:${ref.id}`,
+        label: item.tab.name,
+        destination: { kind: "open-ref", ref },
+        group: "open",
+      },
+    ];
+  });
   const activateFocusedRef = useCallback(
     (ref: TabRef): void => {
       const tab = getHeaderTabs().find(
@@ -127,63 +92,172 @@ export function SplitSlotChooserContent(
     },
     [navigate],
   );
-  useEffect(() => {
-    if (!props.focused) return;
-    searchRef.current?.focus();
-  }, [props.focused]);
-  const emptyHeadline =
-    props.slot.kind === "unavailable"
-      ? props.slot.label
-      : "Choose a view for this split";
-  const headline = props.dropActive ? "Release to open here" : emptyHeadline;
+  const openDestination = useCallback(
+    (destination: FillableSlotDestination): void => {
+      const resolution = commitFillableSlotDestination({
+        splitId: props.splitId,
+        side: props.side,
+        destination,
+        activateFocusedRef,
+      });
+      // Rows come from shared surfaces (History) that cannot pre-filter every
+      // invalid state - a structurally locked legacy Phase being the settled
+      // example. A click that resolves invalid must say so, not silently
+      // leave the slot empty.
+      if (resolution.kind === "invalid") {
+        toast.error(
+          destination.kind === "phase-migration"
+            ? "This Phase is locked open in another view."
+            : "This view can't be opened in the split right now.",
+        );
+      }
+    },
+    [activateFocusedRef, props.side, props.splitId],
+  );
+  const openHistoryItem = useCallback(
+    (item: HistoryItem): void => {
+      openDestination(
+        item.taskType === "phase"
+          ? {
+              kind: "phase-migration",
+              phaseId: item.epicId,
+              name: item.title,
+            }
+          : { kind: "epic", epicId: item.epicId, name: item.title },
+      );
+    },
+    [openDestination],
+  );
 
   return (
     <section
       aria-label={`${props.slot.kind === "unavailable" ? "Unavailable" : "Empty"} split view`}
       className={cn(
-        "flex h-full min-h-0 min-w-0 flex-col items-center justify-center gap-3 border border-dashed border-border/80 bg-muted/20 p-[clamp(0.75rem,3vw,2rem)] transition-colors duration-150 ease-out",
+        "flex h-full min-h-0 min-w-0 flex-col overflow-hidden border border-dashed border-border/80 bg-muted/20 transition-colors duration-150 ease-out",
         props.dropActive && "border-solid border-primary bg-primary/10",
       )}
       data-drop-active={props.dropActive ? "true" : "false"}
       data-testid={`split-slot-chooser-${props.side}`}
     >
-      <div className="max-w-prose text-center">
-        <p className="text-ui-sm font-medium text-foreground">{headline}</p>
-        <p className="mt-1 text-ui-xs text-muted-foreground">
-          Search open tabs or choose a destination. You can also drop an
-          unpaired tab here.
-        </p>
-      </div>
-      <input
-        ref={searchRef}
-        aria-label="Search tabs and destinations"
-        value={props.query}
-        onChange={(event) => props.onQueryChange(event.target.value)}
-        placeholder="Search views"
-        className="w-full max-w-[min(92vw,28rem)] rounded-md border border-input bg-background px-3 py-2 text-ui-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      />
-      <div className="flex w-full max-w-[min(92vw,28rem)] flex-col gap-1 overflow-y-auto">
-        {filtered.map((choice) => (
+      <div className="mx-auto flex h-full min-h-0 w-full max-w-3xl flex-col gap-6 overflow-hidden p-[clamp(1rem,4vw,3rem)]">
+        {props.dropActive ? (
+          <p
+            className="text-center text-ui-sm font-medium text-primary"
+            aria-live="polite"
+          >
+            Release to open here
+          </p>
+        ) : null}
+        {props.slot.kind === "unavailable" ? (
+          <div className="px-1 py-2">
+            <p className="text-ui-sm font-medium text-foreground">
+              {props.slot.label}
+            </p>
+            <p className="mt-1 text-ui-xs text-muted-foreground">
+              Choose another view for this split.
+            </p>
+          </div>
+        ) : null}
+
+        <SplitDestinationGroup
+          id={`open-tabs-${props.splitId}-${props.side}`}
+          title="Open Tabs"
+          testId="split-open-tabs"
+          sectionClassName={undefined}
+          bodyClassName="max-h-[35vh] space-y-1 overflow-y-auto"
+        >
+          {openTabs.length > 0 ? (
+            openTabs.map((choice) => (
+              <Button
+                key={choice.id}
+                type="button"
+                variant="ghost"
+                className="h-11 w-full justify-start rounded-md px-3"
+                onClick={() => openDestination(choice.destination)}
+              >
+                {choice.label}
+              </Button>
+            ))
+          ) : (
+            <p className="px-3 py-2 text-ui-sm text-muted-foreground">
+              No other open tabs
+            </p>
+          )}
+        </SplitDestinationGroup>
+
+        <SplitDestinationGroup
+          id={`create-${props.splitId}-${props.side}`}
+          title="Create"
+          testId="split-create-actions"
+          sectionClassName="border-t border-border/60 pt-5"
+          bodyClassName={undefined}
+        >
           <Button
-            key={choice.id}
             type="button"
             variant="ghost"
-            className={cn(
-              "justify-start",
-              choice.group === "destination" && "text-muted-foreground",
-            )}
-            onClick={() =>
-              commitFillableSlotDestination({
-                splitId: props.splitId,
-                side: props.side,
-                destination: choice.destination,
-                activateFocusedRef,
-              })
-            }
+            className="h-11 w-full justify-start rounded-md px-3"
+            onClick={() => openDestination({ kind: "new-draft" })}
           >
-            {choice.label}
+            <FilePlus2 />
+            New Task
           </Button>
-        ))}
+        </SplitDestinationGroup>
+
+        <SplitDestinationGroup
+          id={`history-${props.splitId}-${props.side}`}
+          title="History"
+          testId="split-history"
+          sectionClassName="flex min-h-0 flex-1 flex-col border-t border-border/60 pt-5"
+          bodyClassName="min-h-0 flex-1 overflow-x-hidden overflow-y-auto pt-1"
+        >
+          {props.historyAvailable ? (
+            <EpicsListPanel
+              variant="picker"
+              className="mt-0"
+              onSelectEpic={null}
+              onOpenItem={openHistoryItem}
+              routeSearch={null}
+              historyNowMs={null}
+              autoFocusSearch={sideFocused}
+            />
+          ) : (
+            <p className="px-1 py-2 text-ui-sm text-muted-foreground">
+              History is unavailable while the host is disconnected.
+            </p>
+          )}
+        </SplitDestinationGroup>
+      </div>
+    </section>
+  );
+}
+
+interface SplitDestinationGroupProps {
+  readonly id: string;
+  readonly title: string;
+  readonly testId: string;
+  readonly sectionClassName: string | undefined;
+  readonly bodyClassName: string | undefined;
+  readonly children: ReactNode;
+}
+
+function SplitDestinationGroup(props: SplitDestinationGroupProps): ReactNode {
+  return (
+    <section
+      aria-labelledby={props.id}
+      data-testid={props.testId}
+      className={props.sectionClassName}
+    >
+      <h2
+        id={props.id}
+        className="mb-1.5 px-1 text-ui-xs font-semibold text-muted-foreground"
+      >
+        {props.title}
+      </h2>
+      <div
+        data-testid={`${props.testId}-card`}
+        className={cn("overflow-hidden", props.bodyClassName)}
+      >
+        {props.children}
       </div>
     </section>
   );

--- a/clients/gui-app/src/components/layout/tabs/split-tab-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/split-tab-item.tsx
@@ -107,8 +107,10 @@ export const SplitTabItem = memo(function SplitTabItem(
       data-testid={`split-tab-group-${props.item.id}`}
       data-active={props.isActive ? "true" : "false"}
       // Two ordinary tab footprints plus the leading quick-actions control.
-      // The extra width keeps that control from stealing either title's share.
-      className="relative flex w-[31rem] min-w-[276px] max-w-[31rem] flex-[1_1_31rem] items-end [container-type:inline-size]"
+      // The extra width keeps that control from stealing either title's
+      // share. Capped by viewport width (not just the rem ceiling) so the
+      // frame stays fluid on narrow windows instead of pinning to 31rem.
+      className="relative flex w-[min(60vw,31rem)] min-w-[276px] max-w-[min(60vw,31rem)] flex-[1_1_min(60vw,31rem)] items-end [container-type:inline-size]"
     >
       {/*
         The shared silhouette's end caps flare over the outer ~20px, so the

--- a/clients/gui-app/src/components/layout/tabs/split-tab-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/split-tab-item.tsx
@@ -1,7 +1,12 @@
 import { memo, useCallback, useMemo, type ReactNode } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import * as m from "motion/react-m";
+import { Button } from "@/components/ui/button";
 import { ContextMenu, ContextMenuTrigger } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   HEADER_TAB_SLOT_DND_TYPE,
   getHeaderStripItemSlotDropId,
@@ -20,14 +25,16 @@ import type { TabSplitCommandId } from "@/stores/tabs/tab-split-commands";
 import {
   HeaderTabSeparator,
   SplitMemberChrome,
-  TabChrome,
   TabItem,
 } from "@/components/layout/tabs/tab-strip-item";
 import {
   HEADER_TAB_LAYOUT_TRANSITION,
   TAB_CLASS_BASE,
 } from "@/components/layout/tabs/tab-chrome-tokens";
-import { SplitSlotMenuContent } from "@/components/layout/tabs/tab-strip-context-menu";
+import {
+  SplitQuickActionsMenuContent,
+  SplitSlotMenuContent,
+} from "@/components/layout/tabs/tab-strip-context-menu";
 
 export interface SplitTabItemProps {
   readonly item: Extract<HeaderStripItem, { readonly kind: "split" }>;
@@ -61,11 +68,9 @@ export interface SplitTabItemProps {
 }
 
 /**
- * A split group occupies exactly one ordinary tab's footprint and draws exactly
- * one tab silhouette around both halves. Earlier this was a rounded bordered
- * box holding two members that each drew their own chrome, which nested a
- * second outline inside the first and made a group read as a foreign object in
- * the strip rather than as a tab.
+ * One reorder frame owns the split control and both members. A persistent
+ * accent underline communicates their group membership, while only the
+ * focused member draws ordinary selected-tab chrome.
  */
 export const SplitTabItem = memo(function SplitTabItem(
   props: SplitTabItemProps,
@@ -87,6 +92,8 @@ export const SplitTabItem = memo(function SplitTabItem(
       state.activeHeaderTab !== null &&
       state.activeHeaderTab.stripItemId === props.item.id,
   );
+  const quickActionsTab =
+    memberTab(props.item.left) ?? memberTab(props.item.right);
 
   return (
     <m.div
@@ -99,11 +106,9 @@ export const SplitTabItem = memo(function SplitTabItem(
       aria-label="Split tab group"
       data-testid={`split-tab-group-${props.item.id}`}
       data-active={props.isActive ? "true" : "false"}
-      // HeaderTabMotionFrame's frame at double width: a group holds two titles,
-      // so it earns two tab footprints. Every value here is exactly 2x the
-      // single-tab frame, keeping a group's flex behaviour proportional to an
-      // ordinary tab's instead of a separate rule.
-      className="relative flex w-[28rem] min-w-[240px] max-w-[28rem] flex-[1_1_28rem] items-end [container-type:inline-size]"
+      // Two ordinary tab footprints plus the leading quick-actions control.
+      // The extra width keeps that control from stealing either title's share.
+      className="relative flex w-[31rem] min-w-[276px] max-w-[31rem] flex-[1_1_31rem] items-end [container-type:inline-size]"
     >
       {/*
         The shared silhouette's end caps flare over the outer ~20px, so the
@@ -111,13 +116,18 @@ export const SplitTabItem = memo(function SplitTabItem(
         half's label and focus wash ride on top of the cap curve and read as
         overlapping chrome.
       */}
-      <div className="relative flex h-10 w-full min-w-0 items-center px-[clamp(0.75rem,5%,1.5rem)]">
-        {/*
-          Only the active silhouette is shared. Hover feedback stays per-half
-          (see SplitMemberChrome) because pointing at one side and lighting up
-          both would misreport which side a click lands on.
-        */}
-        {props.isActive ? <TabChrome isActive /> : null}
+      <div className="relative flex h-10 w-full min-w-0 items-center pr-[clamp(0.75rem,5%,1.5rem)] pl-2">
+        {/* Hover and selection feedback stay per-half (see SplitMemberChrome)
+            so the focused member reads like the selected tab in a group. */}
+        {quickActionsTab === null ? null : (
+          <SplitQuickActions
+            splitId={props.item.id}
+            tab={quickActionsTab}
+            focusedSide={props.item.focusedSide}
+            engaged={props.isActive}
+            onSplitCommand={props.onSplitCommand}
+          />
+        )}
         <SplitMember
           member={props.item.left}
           partner={memberTab(props.item.right)}
@@ -139,11 +149,13 @@ export const SplitTabItem = memo(function SplitTabItem(
           pendingSetPinnedEpicIds={props.pendingSetPinnedEpicIds}
           onSetTaskPinned={props.onSetTaskPinned}
         />
-        <span
-          aria-hidden
-          data-testid={`split-tab-divider-${props.item.id}`}
-          className="relative z-20 my-2 w-px shrink-0 self-stretch bg-border/70"
-        />
+        {props.isActive ? null : (
+          <span
+            aria-hidden
+            data-testid={`split-tab-divider-${props.item.id}`}
+            className="relative z-20 my-2 w-px shrink-0 self-stretch bg-border/70"
+          />
+        )}
         <SplitMember
           member={props.item.right}
           partner={memberTab(props.item.left)}
@@ -166,6 +178,10 @@ export const SplitTabItem = memo(function SplitTabItem(
           onSetTaskPinned={props.onSetTaskPinned}
         />
       </div>
+      <SplitGroupUnderline
+        splitId={props.item.id}
+        selectedSide={props.isActive ? props.item.focusedSide : null}
+      />
       {/*
         Outside the padded inner row so it lands on the group's own right edge,
         where an ordinary tab's separator sits - not inset against the trailing
@@ -175,6 +191,132 @@ export const SplitTabItem = memo(function SplitTabItem(
     </m.div>
   );
 });
+
+function SplitGroupUnderline(props: {
+  readonly splitId: string;
+  readonly selectedSide: "left" | "right" | null;
+}): ReactNode {
+  return (
+    <span
+      aria-hidden="true"
+      data-testid={`split-tab-group-underline-${props.splitId}`}
+      className="pointer-events-none absolute inset-x-0 bottom-0 z-30 flex h-px pr-[clamp(0.75rem,5%,1.5rem)] pl-2"
+    >
+      <span
+        data-testid={`split-tab-group-underline-control-${props.splitId}`}
+        className={cn(
+          "relative w-11 shrink-0 rounded-l-full bg-primary",
+          props.selectedSide === "left" &&
+            "after:absolute after:inset-y-0 after:-right-0.5 after:w-0.5 after:bg-primary",
+        )}
+      />
+      <span
+        data-testid={`split-tab-group-underline-left-${props.splitId}`}
+        className={cn(
+          "relative min-w-0 flex-1 rounded-l-full",
+          props.selectedSide !== "left" && "bg-primary",
+          props.selectedSide === "right" &&
+            "after:absolute after:inset-y-0 after:-right-0.5 after:w-0.5 after:bg-primary",
+        )}
+      />
+      <span
+        className={cn(
+          "shrink-0",
+          props.selectedSide === null ? "w-px bg-primary" : "w-0",
+        )}
+      />
+      <span
+        data-testid={`split-tab-group-underline-right-${props.splitId}`}
+        className={cn(
+          "relative min-w-0 flex-1 rounded-r-full",
+          props.selectedSide !== "right" && "bg-primary",
+          props.selectedSide === "left" &&
+            "before:absolute before:inset-y-0 before:-left-0.5 before:w-0.5 before:bg-primary",
+        )}
+      />
+    </span>
+  );
+}
+
+function SplitQuickActions(props: {
+  readonly splitId: string;
+  readonly tab: HeaderTab;
+  readonly focusedSide: "left" | "right";
+  readonly engaged: boolean;
+  readonly onSplitCommand: (id: TabSplitCommandId, tab: HeaderTab) => void;
+}): ReactNode {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          size="icon-sm"
+          variant="ghost"
+          aria-label={`Split view actions, ${props.focusedSide} view focused`}
+          data-testid={`split-quick-actions-${props.splitId}`}
+          className={cn(
+            "relative z-20 mr-1 h-7 w-10 shrink-0 rounded-md hover:bg-accent/60 [-webkit-app-region:no-drag]",
+            props.engaged
+              ? "text-blue-600 hover:text-blue-500 dark:text-blue-300 dark:hover:text-blue-200"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <SplitFocusIcon
+            splitId={props.splitId}
+            focusedSide={props.focusedSide}
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <SplitQuickActionsMenuContent
+        tab={props.tab}
+        onSplitCommand={props.onSplitCommand}
+      />
+    </DropdownMenu>
+  );
+}
+
+function SplitFocusIcon(props: {
+  readonly splitId: string;
+  readonly focusedSide: "left" | "right";
+}): ReactNode {
+  const leftFocused = props.focusedSide === "left";
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      data-testid={`split-focus-indicator-${props.splitId}`}
+      data-focused-side={props.focusedSide}
+      className="size-5"
+    >
+      <rect
+        data-split-pane="left"
+        data-focused={leftFocused ? "true" : "false"}
+        x="3"
+        y="4"
+        width="8"
+        height="16"
+        rx="1.5"
+        fill={leftFocused ? "currentColor" : "none"}
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+      <rect
+        data-split-pane="right"
+        data-focused={leftFocused ? "false" : "true"}
+        x="13"
+        y="4"
+        width="8"
+        height="16"
+        rx="1.5"
+        fill={leftFocused ? "none" : "currentColor"}
+        stroke="currentColor"
+        strokeWidth="1.75"
+      />
+    </svg>
+  );
+}
 
 function memberTab(member: HeaderStripMember): HeaderTab | null {
   return member.kind === "tab" ? member.tab : null;
@@ -292,7 +434,8 @@ function SplitFillableMember(props: {
       }}
       className={cn(
         TAB_CLASS_BASE,
-        "cursor-pointer gap-1 px-1.5 text-muted-foreground",
+        "cursor-pointer gap-1 text-muted-foreground",
+        props.focused ? "px-5" : "px-1.5",
         "[-webkit-app-region:no-drag]",
         props.focused && "text-foreground",
       )}

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-context-menu.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-context-menu.tsx
@@ -1,6 +1,10 @@
 import {
+  ArrowLeftRight,
   CopyPlus,
   ExternalLink,
+  Maximize2,
+  PanelLeftClose,
+  PanelRightClose,
   Pencil,
   Pin,
   SplitSquareHorizontal,
@@ -11,13 +15,14 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
-  ContextMenuSub,
-  ContextMenuSubContent,
-  ContextMenuSubTrigger,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import type { HeaderTab } from "@/stores/tabs/types";
 import {
-  TAB_SPLIT_ARRANGE_MENU_LABEL,
   TAB_SPLIT_COMMANDS,
   resolveTabSplitCommandAvailability,
   type TabSplitCommandAvailability,
@@ -135,10 +140,9 @@ export function TabContextMenuContent(
 
 /**
  * The split-command section. Availability is resolved here at render time so
- * the menu reflects the live layout. The two creation commands stay at the top
- * level; the four group-scoped ones (separate / close-left / close-right /
- * reverse) sit behind the arrange submenu and only appear once the invoked tab
- * is in a group.
+ * the menu reflects the live layout. Group-scoped commands remain directly in
+ * the main menu: in a split, the creation commands above them are disabled, so
+ * a second arrangement submenu only adds an unnecessary navigation step.
  */
 function TabSplitMenuItems(props: {
   readonly tab: HeaderTab;
@@ -173,20 +177,14 @@ function TabSplitMenuItems(props: {
         {TAB_SPLIT_COMMANDS.pair.label}
       </ContextMenuItem>
       {showsGroupCommands ? (
-        <ContextMenuSub>
-          <ContextMenuSubTrigger
-            data-testid={`tab-arrange-split-${tab.kind}-${tab.id}`}
-          >
-            {TAB_SPLIT_ARRANGE_MENU_LABEL}
-          </ContextMenuSubTrigger>
-          <ContextMenuSubContent>
-            <TabSplitArrangeItems
-              tab={tab}
-              availability={splitAvailability}
-              onSplitCommand={onSplitCommand}
-            />
-          </ContextMenuSubContent>
-        </ContextMenuSub>
+        <>
+          <ContextMenuSeparator />
+          <TabSplitArrangeItems
+            tab={tab}
+            availability={splitAvailability}
+            onSplitCommand={onSplitCommand}
+          />
+        </>
       ) : null}
     </>
   );
@@ -210,6 +208,7 @@ function TabSplitArrangeItems(props: {
         onSelect={() => onSplitCommand(TAB_SPLIT_COMMANDS.separate.id, tab)}
         data-testid={`tab-separate-split-${tab.kind}-${tab.id}`}
       >
+        <Maximize2 />
         {TAB_SPLIT_COMMANDS.separate.label}
       </ContextMenuItem>
       <ContextMenuSeparator />
@@ -218,6 +217,7 @@ function TabSplitArrangeItems(props: {
         onSelect={() => onSplitCommand(TAB_SPLIT_COMMANDS.closeLeft.id, tab)}
         data-testid={`tab-close-left-${tab.kind}-${tab.id}`}
       >
+        <PanelLeftClose />
         {TAB_SPLIT_COMMANDS.closeLeft.label}
       </ContextMenuItem>
       <ContextMenuItem
@@ -225,6 +225,7 @@ function TabSplitArrangeItems(props: {
         onSelect={() => onSplitCommand(TAB_SPLIT_COMMANDS.closeRight.id, tab)}
         data-testid={`tab-close-right-${tab.kind}-${tab.id}`}
       >
+        <PanelRightClose />
         {TAB_SPLIT_COMMANDS.closeRight.label}
       </ContextMenuItem>
       <ContextMenuSeparator />
@@ -233,6 +234,7 @@ function TabSplitArrangeItems(props: {
         onSelect={() => onSplitCommand(TAB_SPLIT_COMMANDS.swap.id, tab)}
         data-testid={`tab-swap-split-${tab.kind}-${tab.id}`}
       >
+        <ArrowLeftRight />
         {TAB_SPLIT_COMMANDS.swap.label}
       </ContextMenuItem>
     </>
@@ -261,5 +263,66 @@ export function SplitSlotMenuContent(props: {
         onSplitCommand={props.onSplitCommand}
       />
     </ContextMenuContent>
+  );
+}
+
+/** Click-menu counterpart to the flattened context-menu arrangement section. */
+export function SplitQuickActionsMenuContent(props: {
+  readonly tab: HeaderTab;
+  readonly onSplitCommand: (id: TabSplitCommandId, tab: HeaderTab) => void;
+}): React.ReactNode {
+  const availability = resolveTabSplitCommandAvailability({
+    kind: props.tab.kind,
+    id: props.tab.id,
+  });
+  return (
+    <DropdownMenuContent
+      align="start"
+      className="w-52"
+      onCloseAutoFocus={(event) => event.preventDefault()}
+    >
+      <DropdownMenuItem
+        disabled={!availability.separate}
+        onSelect={() =>
+          props.onSplitCommand(TAB_SPLIT_COMMANDS.separate.id, props.tab)
+        }
+        data-testid={`split-quick-separate-${props.tab.kind}-${props.tab.id}`}
+      >
+        <Maximize2 />
+        {TAB_SPLIT_COMMANDS.separate.label}
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        disabled={availability.closeLeft === null}
+        onSelect={() =>
+          props.onSplitCommand(TAB_SPLIT_COMMANDS.closeLeft.id, props.tab)
+        }
+        data-testid={`split-quick-close-left-${props.tab.kind}-${props.tab.id}`}
+      >
+        <PanelLeftClose />
+        {TAB_SPLIT_COMMANDS.closeLeft.label}
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        disabled={availability.closeRight === null}
+        onSelect={() =>
+          props.onSplitCommand(TAB_SPLIT_COMMANDS.closeRight.id, props.tab)
+        }
+        data-testid={`split-quick-close-right-${props.tab.kind}-${props.tab.id}`}
+      >
+        <PanelRightClose />
+        {TAB_SPLIT_COMMANDS.closeRight.label}
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        disabled={!availability.swap}
+        onSelect={() =>
+          props.onSplitCommand(TAB_SPLIT_COMMANDS.swap.id, props.tab)
+        }
+        data-testid={`split-quick-swap-${props.tab.kind}-${props.tab.id}`}
+      >
+        <ArrowLeftRight />
+        {TAB_SPLIT_COMMANDS.swap.label}
+      </DropdownMenuItem>
+    </DropdownMenuContent>
   );
 }

--- a/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip-item.tsx
@@ -337,7 +337,7 @@ export const TabItem = memo(function TabItem(props: TabItemProps) {
             // A split half shares the group's silhouette and only has half the
             // width, so it trades the tab's generous side padding for enough
             // room to still show an icon plus a readable title.
-            chrome === "member" && "gap-1 px-1.5",
+            chrome === "member" && cn("gap-1", isActive ? "px-5" : "px-1.5"),
             tabStateClass(isActive),
             NO_DRAG_CLASS,
             "cursor-pointer",
@@ -724,32 +724,26 @@ function StripPairPreview(props: {
 }
 
 /**
- * Focus treatment for one half of a split group.
- *
- * A filled panel was tried first and read as a control pasted inside the tab:
- * the halves sit inside the group's side padding, so any fill floats short of
- * the tab edges instead of looking like a region of it. The focused side is
- * marked with the same accent rule the canvas strip uses for its active tab,
- * spanning exactly that half - a deliberate marker rather than a shape - and
- * carried by the weight/colour split `tabStateClass` already applies. The
- * remaining wash is hover affordance only, so it stays soft and inset.
+ * Selection treatment for one member of a split group. The focused member uses
+ * the same raised silhouette as an ordinary selected tab; group membership is
+ * communicated independently by the split group's accent underline.
  */
 export function SplitMemberChrome(props: { readonly focused: boolean }) {
-  return (
-    <>
-      <span
-        aria-hidden
-        className="pointer-events-none absolute inset-x-px inset-y-1 rounded-sm transition-colors duration-200 ease-out group-hover/tab:bg-accent/20"
+  if (props.focused) {
+    return (
+      <TabChromeBackground
+        fill="var(--color-background)"
+        borderColor="var(--color-primary)"
+        coversBaseline
       />
-      {props.focused ? (
-        <DropLine
-          orientation="horizontal"
-          glow={false}
-          className="absolute inset-x-0 top-0 z-20 animate-in fade-in slide-in-from-bottom-1 duration-200 ease-spring"
-          testId="split-member-focus-accent"
-        />
-      ) : null}
-    </>
+    );
+  }
+
+  return (
+    <span
+      aria-hidden
+      className="pointer-events-none absolute inset-x-px inset-y-1 rounded-sm transition-colors duration-200 ease-out group-hover/tab:bg-accent/20"
+    />
   );
 }
 

--- a/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
+++ b/clients/gui-app/src/components/layout/tabs/tab-strip.tsx
@@ -273,6 +273,7 @@ function TabStripBody() {
                   memberOffset={memberOffsetBefore(layoutItems, index)}
                   isActive={itemId === activeItemId}
                   isNextActive={headerItemIds[index + 1] === activeItemId}
+                  nextIsSplit={layoutItems[index + 1]?.kind === "split"}
                   isLastItem={index === headerItemIds.length - 1}
                   showDropIndicatorBefore={dropIndicatorIndex === index}
                   showDropIndicatorAfter={
@@ -312,6 +313,7 @@ interface HeaderStripItemRendererProps {
   // index is a silent visual bug no type check can catch.
   readonly isActive: boolean;
   readonly isNextActive: boolean;
+  readonly nextIsSplit: boolean;
   readonly isLastItem: boolean;
   readonly showDropIndicatorBefore: boolean;
   readonly showDropIndicatorAfter: boolean;
@@ -338,6 +340,7 @@ const HeaderStripItemRenderer = memo(function HeaderStripItemRenderer(
   const {
     isActive,
     isNextActive,
+    nextIsSplit,
     isLastItem,
     showDropIndicatorBefore,
     showDropIndicatorAfter,
@@ -346,7 +349,9 @@ const HeaderStripItemRenderer = memo(function HeaderStripItemRenderer(
   // Computed once, above the branch, because it applies to every strip item.
   // Restating it inside only the tab branch is what left a split group with no
   // trailing hairline, so the group-to-tab boundary rendered as a blank gap.
-  const showSeparatorAfter = !isLastItem && !isActive && !isNextActive;
+  const isSplitGroupBoundary = item.kind === "split" && nextIsSplit;
+  const showSeparatorAfter =
+    !isLastItem && (isSplitGroupBoundary || (!isActive && !isNextActive));
   if (item.kind === "split") {
     return (
       <SplitTabItem

--- a/clients/gui-app/src/components/layout/tabs/top-level-tab-dnd.ts
+++ b/clients/gui-app/src/components/layout/tabs/top-level-tab-dnd.ts
@@ -112,7 +112,6 @@ export function resolveValidatedTopLevelTabDrop(
   target: TopLevelTabDropTarget,
   layout: PersistedTabStripLayout,
 ): ValidatedTopLevelTabDrop | null {
-  if (!canMutateTabSplits()) return null;
   const ledger = getTabCommandLedger();
   if (ledger.suppressionDepth > 0) return null;
   const source = resolveUnpairedHeaderEdgeSource(headerTab, layout);
@@ -125,9 +124,11 @@ export function resolveValidatedTopLevelTabDrop(
     return null;
   }
   if (target.kind === TOP_LEVEL_EDGE_SPLIT_TARGET) {
+    if (!canMutateTabSplits()) return null;
     return edgeTargetIsLive(source, target, layout) ? { source, target } : null;
   }
   if (target.kind === TOP_LEVEL_STRIP_PAIR_TARGET) {
+    if (!canMutateTabSplits()) return null;
     return stripPairTargetIsLive(source, target, layout)
       ? { source, target }
       : null;

--- a/clients/gui-app/src/components/layout/top-level-tab-host.tsx
+++ b/clients/gui-app/src/components/layout/top-level-tab-host.tsx
@@ -298,7 +298,6 @@ function FillableSplitSlot(props: {
             splitId={props.splitId}
             side={props.side}
             slot={props.slot}
-            focused={props.focused}
             dropActive={dropActive}
           />
         </SurfacePresentationBoundary>

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -669,7 +669,12 @@ export class TabCommandCoordinator {
         const layout = currentLayout();
         const withRef = createLayoutItem(layout, createdRef);
         const item = findStripItemForRef(withRef, createdRef);
-        if (item?.kind !== "tab") return layout;
+        if (item?.kind !== "tab") {
+          // Placement failed - the created ref is not part of the
+          // authoritative layout, so it must not be reported as placed.
+          createdRef = null;
+          return layout;
+        }
         return reorderStripItem(withRef, {
           itemId: item.id,
           targetIndex,

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -627,10 +627,10 @@ export class TabCommandCoordinator {
       return false;
     }
     if (!sourceHasRef(command.ref)) return false;
+    if (isTabStructurallyLocked(command.ref)) return false;
     const layout = currentLayout();
     const existing = findStripItemForRef(layout, command.ref);
     if (existing?.kind === "split") return false;
-    if (existing !== null && isTabStructurallyLocked(command.ref)) return false;
     const withRef = createLayoutItem(layout, command.ref);
     const item = findStripItemForRef(withRef, command.ref);
     if (item?.kind !== "tab") return false;

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -72,6 +72,11 @@ export interface FillSplitSideCommand {
   readonly ref: TabRef;
 }
 
+export interface PlaceSourceRefAtStripIndexCommand {
+  readonly ref: TabRef;
+  readonly targetIndex: number;
+}
+
 export interface CreateDraftForSplitCommand {
   readonly splitId: string;
   readonly side: SplitSideName;
@@ -183,14 +188,19 @@ const MAX_FINALIZATION_ITERATIONS = 8;
 
 let transactionDepth = 0;
 
-function currentLayout(): PersistedTabStripLayout {
+function authoritativeLayout(): PersistedTabStripLayout {
   const state = useTabsStore.getState();
-  const layout: PersistedTabStripLayout = {
+  return {
     version: 2,
     items: state.items,
     activeItemId: state.activeItemId,
     systemTabs: state.systemTabs,
   };
+}
+
+function currentLayout(): PersistedTabStripLayout {
+  const state = useTabsStore.getState();
+  const layout = authoritativeLayout();
   const projected = flattenLayoutRefs(layout);
   const matchesProjection =
     projected.length === state.stripOrder.length &&
@@ -207,6 +217,19 @@ function currentLayout(): PersistedTabStripLayout {
     activeItemId: null,
     systemTabs: state.systemTabs,
   });
+}
+
+function currentLayoutForFillableSplit(command: {
+  readonly splitId: string;
+  readonly side: SplitSideName;
+}): PersistedTabStripLayout {
+  const layout = authoritativeLayout();
+  const split = layout.items.find(
+    (item): item is Extract<StripItem, { readonly kind: "split" }> =>
+      item.kind === "split" && item.id === command.splitId,
+  );
+  if (split !== undefined && split[command.side].kind !== "tab") return layout;
+  return currentLayout();
 }
 
 function refsToLedger(
@@ -289,6 +312,13 @@ function sourceHasRef(ref: TabRef): boolean {
 function canSplitRef(ref: TabRef): boolean {
   return (
     canMutateTabSplits() &&
+    !isTabStructurallyLocked(ref) &&
+    tabSurfaceDescriptor(ref.kind).splitEligibility === "eligible"
+  );
+}
+
+function canFillSplitRef(ref: TabRef): boolean {
+  return (
     !isTabStructurallyLocked(ref) &&
     tabSurfaceDescriptor(ref.kind).splitEligibility === "eligible"
   );
@@ -498,7 +528,7 @@ export class TabCommandCoordinator {
   }
 
   fillSplitSide(command: FillSplitSideCommand): boolean {
-    const layout = currentLayout();
+    const layout = currentLayoutForFillableSplit(command);
     if (!sourceHasRef(command.ref)) return false;
     const existing = findStripItemForRef(layout, command.ref);
     // A chooser may reuse an already-open, unpaired source. Remove its one
@@ -509,7 +539,7 @@ export class TabCommandCoordinator {
     const next = replaceFillableSide(
       withoutUngroupedSource,
       command,
-      canSplitRef,
+      canFillSplitRef,
     );
     if (next === withoutUngroupedSource) return false;
     this.execute({
@@ -582,6 +612,78 @@ export class TabCommandCoordinator {
       applyRemovals: () => undefined,
     });
     return true;
+  }
+
+  /**
+   * Places a source-owned ref at a top-level strip-item index. Canvas tear-off
+   * creates the source tab first; this command then makes its placement
+   * explicit in the authoritative split layout instead of relying on legacy
+   * flat-order reconciliation, which can only append a newly discovered ref.
+   */
+  placeSourceRefAtStripIndex(
+    command: PlaceSourceRefAtStripIndexCommand,
+  ): boolean {
+    if (!Number.isInteger(command.targetIndex) || command.targetIndex < 0) {
+      return false;
+    }
+    if (!sourceHasRef(command.ref)) return false;
+    const layout = currentLayout();
+    const existing = findStripItemForRef(layout, command.ref);
+    if (existing?.kind === "split") return false;
+    if (existing !== null && isTabStructurallyLocked(command.ref)) return false;
+    const withRef = createLayoutItem(layout, command.ref);
+    const item = findStripItemForRef(withRef, command.ref);
+    if (item?.kind !== "tab") return false;
+    const next = reorderStripItem(withRef, {
+      itemId: item.id,
+      targetIndex: command.targetIndex,
+    });
+    if (next === layout) return false;
+    this.execute({
+      layout: next,
+      reservedAdditions: existing === null ? [command.ref] : [],
+      pendingRemovals: [],
+      projectSourceCompatibility: true,
+      applySources: () => undefined,
+      applyRemovals: () => undefined,
+    });
+    return true;
+  }
+
+  /**
+   * Creates a source-owned ref and places it in one suppressed transaction.
+   * The source callback runs only after reconciliation is suppressed; its
+   * freshly minted ref is then inserted into the authoritative layout before
+   * the transaction is finalized. This is the canvas tear-off path, where the
+   * source store owns id creation and cannot reserve the ref ahead of time.
+   */
+  createSourceRefAtStripIndex(
+    targetIndex: number,
+    createSource: () => TabRef | null,
+  ): TabRef | null {
+    if (!Number.isInteger(targetIndex) || targetIndex < 0) return null;
+    let createdRef: TabRef | null = null;
+    this.execute({
+      layout: () => {
+        if (createdRef === null) return currentLayout();
+        const layout = currentLayout();
+        const withRef = createLayoutItem(layout, createdRef);
+        const item = findStripItemForRef(withRef, createdRef);
+        if (item?.kind !== "tab") return layout;
+        return reorderStripItem(withRef, {
+          itemId: item.id,
+          targetIndex,
+        });
+      },
+      reservedAdditions: [],
+      pendingRemovals: [],
+      projectSourceCompatibility: true,
+      applySources: () => {
+        createdRef = createSource();
+      },
+      applyRemovals: () => undefined,
+    });
+    return createdRef;
   }
 
   resizeSplit(command: ResizeSplitArgs): boolean {
@@ -673,8 +775,12 @@ export class TabCommandCoordinator {
 
   createDraftForSplit(command: CreateDraftForSplitCommand): TabRef | null {
     const ref: TabRef = { kind: "draft", id: uuidv4() };
-    const layout = currentLayout();
-    const next = replaceFillableSide(layout, { ...command, ref }, canSplitRef);
+    const layout = currentLayoutForFillableSplit(command);
+    const next = replaceFillableSide(
+      layout,
+      { ...command, ref },
+      canFillSplitRef,
+    );
     if (next === layout) return null;
     this.execute({
       layout: next,
@@ -693,8 +799,12 @@ export class TabCommandCoordinator {
 
   createEpicForSplit(command: CreateEpicForSplitCommand): TabRef | null {
     const ref: TabRef = { kind: "epic", id: uuidv4() };
-    const layout = currentLayout();
-    const next = replaceFillableSide(layout, { ...command, ref }, canSplitRef);
+    const layout = currentLayoutForFillableSplit(command);
+    const next = replaceFillableSide(
+      layout,
+      { ...command, ref },
+      canFillSplitRef,
+    );
     if (next === layout) return null;
     this.execute({
       layout: next,
@@ -717,8 +827,12 @@ export class TabCommandCoordinator {
     command: CreatePhaseMigrationForSplitCommand,
   ): TabRef | null {
     const ref: TabRef = { kind: "epic", id: uuidv4() };
-    const layout = currentLayout();
-    const next = replaceFillableSide(layout, { ...command, ref }, canSplitRef);
+    const layout = currentLayoutForFillableSplit(command);
+    const next = replaceFillableSide(
+      layout,
+      { ...command, ref },
+      canFillSplitRef,
+    );
     if (next === layout) return null;
     this.execute({
       layout: next,
@@ -739,7 +853,7 @@ export class TabCommandCoordinator {
 
   createSystemForSplit(command: CreateSystemForSplitCommand): TabRef | null {
     const ref: TabRef = { kind: command.systemKind, id: command.systemKind };
-    const layout = currentLayout();
+    const layout = currentLayoutForFillableSplit(command);
     if (layout.systemTabs[command.systemKind] !== null) return null;
     const withSystem = {
       ...layout,
@@ -756,7 +870,7 @@ export class TabCommandCoordinator {
     const next = replaceFillableSide(
       withSystem,
       { ...command, ref },
-      canSplitRef,
+      canFillSplitRef,
     );
     if (next === withSystem) return null;
     this.execute({
@@ -1346,7 +1460,7 @@ export class TabCommandCoordinator {
   }
 
   private execute(input: {
-    readonly layout: PersistedTabStripLayout;
+    readonly layout: PersistedTabStripLayout | (() => PersistedTabStripLayout);
     readonly reservedAdditions: ReadonlyArray<TabRef>;
     readonly pendingRemovals: ReadonlyArray<TabRef>;
     readonly projectSourceCompatibility: boolean;
@@ -1367,9 +1481,11 @@ export class TabCommandCoordinator {
       };
       this.notify();
       input.applySources();
-      const layoutFailure = this.replaceLayoutForTransaction(input.layout);
+      const layout =
+        typeof input.layout === "function" ? input.layout() : input.layout;
+      const layoutFailure = this.replaceLayoutForTransaction(layout);
       if (layoutFailure !== null) throw layoutFailure;
-      this.consumePlacedReservations(input.layout);
+      this.consumePlacedReservations(layout);
       this.notify();
       input.applyRemovals();
     } catch (error) {

--- a/clients/gui-app/src/stores/tabs/tab-split-commands.ts
+++ b/clients/gui-app/src/stores/tabs/tab-split-commands.ts
@@ -44,14 +44,6 @@ export const TAB_SPLIT_COMMANDS = {
   },
 } as const;
 
-/**
- * The four group-scoped commands live behind one submenu rather than loose in
- * the tab menu, so an ungrouped tab's menu stays short and the split verbs read
- * as one arrangement surface. Labels deliberately match the platform browser
- * vocabulary users already carry over.
- */
-export const TAB_SPLIT_ARRANGE_MENU_LABEL = "Arrange split view";
-
 export type TabSplitCommandId =
   (typeof TAB_SPLIT_COMMANDS)[keyof typeof TAB_SPLIT_COMMANDS]["id"];
 


### PR DESCRIPTION
## Summary

Follow-up to the split tab view PR (#594): UI polish, a drag/drop regression fix, an empty-split-chooser redesign, a terminal-panel architecture fix, and a review-fix round that resolved 8 validated cold-review findings (3 P1 + 5 P2).

### UI fixes
- Flatten split arrangement actions into the main tab context menu instead of a redundant submenu.
- Add a focus-aware quick-actions icon on merged split tabs, styled to match Chrome's split-view glyph (filled pane tracks the focused side).
- Add a persistent theme-accent underline that groups a split pair, pausing beneath the selected member's own raised-tab silhouette.
- Remove the rounded task-canvas/container corners.

### Regression fix
- Restore tile-tab drag/drop duplication onto the main tab strip, including placement beside an existing split group.

### Empty split chooser redesign
- Replace the flat mixed search/settings list with three sections: **Open Tabs**, **Create** (New Task), and **History** (reusing the landing page's embedded `EpicsListPanel` instead of a lookalike).
- Constrain the chooser to the split's height; only the History body scrolls internally.

### Terminal panel architecture fix
- Restore a single window-wide `LandingTerminalHost` (mounted in `AppShell`) instead of one host per draft surface. The gesture provider's captured host/cwd/generation state must survive split focus changes; only the panel's DOM is now portaled into the selected draft pane's registered anchor (`LandingTerminalPaneAnchor`).

### Review-fix round (3 P1 + 5 P2, all validated findings resolved)
- Pin canvas tear-off's source-creation + authoritative-placement atomicity with a stale-`stripOrder` regression test against the installed production reconciliation subscriber.
- Fix the AppShell suite, which had gone red from the terminal-host mount move.
- Toast feedback when a chooser destination resolves invalid (e.g. a locked legacy Phase row) instead of silently doing nothing.
- Bound/scroll the Open Tabs list so Create and History stay reachable.
- Focus the chooser's History search when its split side becomes focused (keyboard-created empty splits previously left DOM focus behind).
- Resolve reusable History Epics from the authoritative grouped layout instead of the legacy `stripOrder` projection, closing a path that could mint a duplicate view of an already-open Epic.

## Test plan

- [x] `bun run compile` (gui-app + deps)
- [x] `bun run lint`
- [x] `bunx prettier --check` on all touched files
- [x] Focused Vitest suites: 231 tests across touched/adjacent suites, including the previously-red AppShell suite (now 4/4)
- [x] React Doctor: no issues
- [x] Local pre-commit hook: format/lint/compile + DCO sign-off all passed