### PR TITLE
fix(cli): execute the host LaunchAgent through a named launcher file so macOS stops calling it 'sh'

### DIFF
--- a/clients/shared/host-lifecycle/identity.ts
+++ b/clients/shared/host-lifecycle/identity.ts
@@ -56,6 +56,25 @@ const HOST_START_WITH_LABEL_TAIL = [
   "start",
   "--service-label",
 ] as const;
+
+/**
+ * Basename of the launcher-file form of the macOS LaunchAgent (2026-07):
+ * `ProgramArguments = [<...>/<label-id>/traycer-host-start, <cli-command>,
+ * <cli-args...>]`. The wrapper moved from an inline `/bin/sh -c` program to
+ * an executable file because macOS background-task management names a raw
+ * login item after `ProgramArguments[0]` - the inline form surfaced as a
+ * bare "sh" from an "Unknown Developer" in System Settings on every
+ * CLI-registered install.
+ *
+ * Single source of truth for the same reason as
+ * `COMPATIBLE_HOST_START_SCRIPT_PREFIX` directly below: the emitter
+ * (`traycer-cli`'s service platform) builds the launcher path from this
+ * constant, and this recognizer attests plists by it. If either side moved
+ * alone, `attestTraycerRegistration` would degrade to `indeterminate` for
+ * plists this codebase just wrote, and `isEvictableTraycerIdentity`
+ * refuses eviction on `indeterminate` - a lockout surviving the repair.
+ */
+export const HOST_START_LAUNCHER_BASENAME = "traycer-host-start";
 /**
  * The invariant head of the `/bin/sh -c` program the macOS LaunchAgent plist
  * and the systemd user unit both run — everything up to and including the
@@ -260,6 +279,20 @@ function isHostStartInvocation(
   args: readonly string[],
   labelId: string | null,
 ): boolean {
+  // Launcher-file form: [<...>/<label-id>/traycer-host-start, <cli>, ...].
+  // The label id sits in the launcher's parent directory, so a label match
+  // is still required when a label is known - mirroring the inline-script
+  // arm below, a launcher registered for a DIFFERENT label is not this
+  // label's invocation.
+  const launcher = args[0];
+  if (
+    args.length >= 2 &&
+    launcher !== undefined &&
+    launcher.endsWith(`/${HOST_START_LAUNCHER_BASENAME}`) &&
+    (labelId === null || launcher.includes(`/${labelId}/`))
+  ) {
+    return true;
+  }
   const script = args[2];
   if (
     args.length >= 4 &&

--- a/clients/shared/host-lifecycle/identity.ts
+++ b/clients/shared/host-lifecycle/identity.ts
@@ -280,16 +280,22 @@ function isHostStartInvocation(
   labelId: string | null,
 ): boolean {
   // Launcher-file form: [<...>/<label-id>/traycer-host-start, <cli>, ...].
-  // The label id sits in the launcher's parent directory, so a label match
-  // is still required when a label is known - mirroring the inline-script
-  // arm below, a launcher registered for a DIFFERENT label is not this
-  // label's invocation.
+  // The label id must be the launcher's IMMEDIATE parent directory - an
+  // exact `/<label-id>/traycer-host-start` suffix, not merely present
+  // somewhere earlier in the path. `.includes()` let a path like
+  // `/tmp/<label-id>/nested/traycer-host-start` attest for a label it never
+  // named as its parent, and a null label (no label context) accepted ANY
+  // path ending in the launcher basename - both are exactly the "path
+  // alone" / "looks like ours" evidence this module's header forbids for
+  // an eviction target. A label is now required for this arm, mirroring
+  // the inline-script arm below where a launcher registered for a
+  // DIFFERENT (or unknown) label is not this label's invocation.
   const launcher = args[0];
   if (
     args.length >= 2 &&
     launcher !== undefined &&
-    launcher.endsWith(`/${HOST_START_LAUNCHER_BASENAME}`) &&
-    (labelId === null || launcher.includes(`/${labelId}/`))
+    labelId !== null &&
+    launcher.endsWith(`/${labelId}/${HOST_START_LAUNCHER_BASENAME}`)
   ) {
     return true;
   }

--- a/clients/shared/host-lifecycle/index.ts
+++ b/clients/shared/host-lifecycle/index.ts
@@ -22,6 +22,7 @@ export {
   isTraycerLabelShape,
   traycerLabelIdsForBase,
   COMPATIBLE_HOST_START_SCRIPT_PREFIX,
+  HOST_START_LAUNCHER_BASENAME,
   TRAYCER_HOST_CONTENT_TAG,
 } from "./identity";
 

--- a/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
+++ b/clients/traycer-cli/src/commands/__tests__/host-start.test.ts
@@ -931,9 +931,11 @@ describe("service manifests never leak a flag `host start` does not have", () =>
         args: [],
       },
     });
-    // launchd execs ProgramArguments[0]; the compatibility program is a
-    // `/bin/sh -c` vector, so the shell must be argv[0].
-    expect(xml).toContain("<string>/bin/sh</string>");
+    // launchd execs ProgramArguments[0]; the compatibility program is the
+    // per-label launcher FILE (macOS names the login item after it - the
+    // former inline `/bin/sh -c` vector surfaced as "sh" in Login Items).
+    expect(xml).toContain("/ai.traycer.host.prod/traycer-host-start</string>");
+    expect(xml).not.toContain("<string>/bin/sh</string>");
     for (const flag of REMOVED_FLAGS) expect(xml).not.toContain(flag);
   });
 

--- a/clients/traycer-cli/src/service/label.ts
+++ b/clients/traycer-cli/src/service/label.ts
@@ -1,5 +1,6 @@
 import { homedir, platform as osPlatform } from "node:os";
 import { join } from "node:path";
+import { HOST_START_LAUNCHER_BASENAME } from "@traycer-clients/shared/host-lifecycle";
 import type { Environment } from "../runner/environment";
 import { devDesktopSlotForEnvironment } from "../store/dev-desktop-slot";
 
@@ -101,6 +102,23 @@ export function serviceManifestPath(label: ServiceLabel): string {
     return "";
   }
   return join(home, ".config", "systemd", "user", `${label.id}.service`);
+}
+
+// On-disk home of the macOS launcher file the LaunchAgent executes
+// (`~/.traycer/service/<label-id>/traycer-host-start`). The label id is the
+// parent directory - load-bearing, not tidiness: the shared recognizer
+// (`attestTraycerRegistration`) matches a launcher-form plist to a label by
+// finding `/<label-id>/` in `ProgramArguments[0]`, and the basename is the
+// name macOS shows in Login Items. Written by `service install` alongside
+// the plist and removed by `service uninstall`.
+export function serviceLauncherScriptPath(label: ServiceLabel): string {
+  return join(
+    homedir(),
+    ".traycer",
+    "service",
+    label.id,
+    HOST_START_LAUNCHER_BASENAME,
+  );
 }
 
 // Windows Scheduled Task identifier. production = `\Traycer\Host`,

--- a/clients/traycer-cli/src/service/platforms/__tests__/identity-host-start-script-lockstep.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/identity-host-start-script-lockstep.test.ts
@@ -127,6 +127,50 @@ describe("host-start script / identity attestation lockstep", () => {
     expect(isEvictableTraycerIdentity(attestation)).toBe(true);
   });
 
+  it("does not attest a launcher whose label sits ABOVE its immediate parent directory", () => {
+    // The label id must be the launcher's immediate parent, not merely
+    // present earlier in the path. A recognizer that used `.includes()`
+    // here would attest this path - the label is present, just not as the
+    // basename's parent - and treat an arbitrarily nested foreign launcher
+    // as this label's own registration.
+    const attestation = attestTraycerRegistration({
+      labelId,
+      knownLabels: null,
+      programArguments: [
+        `/Users/u/.traycer/service/${labelId}/nested/${HOST_START_LAUNCHER_BASENAME}`,
+        "/usr/local/bin/traycer",
+      ],
+      contentTag: null,
+      sourceText: null,
+    });
+
+    expect(attestation.kind).toBe("indeterminate");
+    expect(isEvictableTraycerIdentity(attestation)).toBe(false);
+  });
+
+  it("does not attest a launcher-shaped path with no label context", () => {
+    // `labelId: null` (no label known - e.g. a cross-environment scan) must
+    // not treat ANY path ending in the launcher basename as a positive
+    // signal. Requiring a label for this arm is what stops a foreign
+    // `.../traycer-host-start` from attesting as ours merely because no
+    // label was supplied to compare against. With no label signal and no
+    // recognised invocation shape, this is a positive refutation
+    // (`not-traycer`), not merely `indeterminate`.
+    const attestation = attestTraycerRegistration({
+      labelId: null,
+      knownLabels: null,
+      programArguments: [
+        `/tmp/unrelated/${HOST_START_LAUNCHER_BASENAME}`,
+        "/usr/local/bin/traycer",
+      ],
+      contentTag: null,
+      sourceText: null,
+    });
+
+    expect(attestation.kind).toBe("not-traycer");
+    expect(isEvictableTraycerIdentity(attestation)).toBe(false);
+  });
+
   it("does not attest a launcher registered for a DIFFERENT label as this label's invocation", () => {
     // The label id lives in the launcher's parent directory. A launcher
     // path for another environment's label must not count as this label's

--- a/clients/traycer-cli/src/service/platforms/__tests__/identity-host-start-script-lockstep.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/identity-host-start-script-lockstep.test.ts
@@ -3,9 +3,14 @@ import {
   attestTraycerRegistration,
   isEvictableTraycerIdentity,
   COMPATIBLE_HOST_START_SCRIPT_PREFIX,
+  HOST_START_LAUNCHER_BASENAME,
 } from "@traycer-clients/shared/host-lifecycle";
 import { HOST_CAPABILITY_SERVICE_LABEL } from "../../../host/capabilities";
-import { buildCompatibleHostStartScript } from "../host-start-script";
+import {
+  buildCompatibleHostStartScript,
+  buildHostStartLauncherScript,
+} from "../host-start-script";
+import { serviceLauncherScriptPath } from "../../label";
 
 /**
  * The emitter and the recognizer must agree on one string.
@@ -93,6 +98,68 @@ describe("host-start script / identity attestation lockstep", () => {
     });
 
     expect(attestation.kind).toBe("attested");
+  });
+
+  it("attests a launcher-file registration built by the real path helper, on label shape alone", () => {
+    // The 2026-07 plist shape: ProgramArguments[0] is the launcher FILE
+    // (`~/.traycer/service/<label>/traycer-host-start`), so there is no
+    // inline script for the recognizer to read. The same regression class
+    // as the inline-prefix drift applies: if the emitter's path layout and
+    // the recognizer's basename/label matching moved apart, every
+    // launcher-form plist would attest `indeterminate` and stop being
+    // evictable. This row uses the REAL `serviceLauncherScriptPath` so the
+    // two cannot drift silently.
+    const launcherPath = serviceLauncherScriptPath({
+      id: labelId,
+      displayName: "Traycer Host (Dev)",
+      environment: "dev",
+      devSlot: null,
+    });
+    const attestation = attestTraycerRegistration({
+      labelId,
+      knownLabels: null,
+      programArguments: [launcherPath, "/usr/local/bin/traycer"],
+      contentTag: null,
+      sourceText: null,
+    });
+
+    expect(attestation.kind).toBe("attested");
+    expect(isEvictableTraycerIdentity(attestation)).toBe(true);
+  });
+
+  it("does not attest a launcher registered for a DIFFERENT label as this label's invocation", () => {
+    // The label id lives in the launcher's parent directory. A launcher
+    // path for another environment's label must not count as this label's
+    // invocation signal - same rule as the inline arm, which requires the
+    // script to name the label.
+    const attestation = attestTraycerRegistration({
+      labelId,
+      knownLabels: null,
+      programArguments: [
+        `/Users/u/.traycer/service/ai.traycer.host.staging/${HOST_START_LAUNCHER_BASENAME}`,
+        "/usr/local/bin/traycer",
+      ],
+      contentTag: null,
+      sourceText: null,
+    });
+
+    expect(attestation.kind).toBe("indeterminate");
+    expect(isEvictableTraycerIdentity(attestation)).toBe(false);
+  });
+
+  it("emits a launcher file whose basename macOS will surface, carrying the same capability probe", () => {
+    expect(
+      serviceLauncherScriptPath({
+        id: labelId,
+        displayName: "Traycer Host (Dev)",
+        environment: "dev",
+        devSlot: null,
+      }).endsWith(`/${labelId}/${HOST_START_LAUNCHER_BASENAME}`),
+    ).toBe(true);
+    const script = buildHostStartLauncherScript(labelId);
+    expect(script.startsWith("#!/bin/sh\n")).toBe(true);
+    expect(script).toContain(HOST_CAPABILITY_SERVICE_LABEL);
+    expect(script).toContain(`--service-label '${labelId}'`);
   });
 
   it("still refuses to evict a foreign script on the same label shape", () => {

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -26,10 +26,17 @@ import {
   readRegisteredCliInvocation,
   type ProcessRunner,
 } from "../macos";
-import { buildCompatibleHostStartScript } from "../host-start-script";
+import {
+  buildCompatibleHostStartScript,
+  buildHostStartLauncherScript,
+} from "../host-start-script";
 import { ProcessRunError, type RunResult } from "../../process-runner";
 import type { ServiceController } from "../../index";
-import { serviceLabelFor, smAppServiceAgentLabelId } from "../../label";
+import {
+  serviceLabelFor,
+  serviceLauncherScriptPath,
+  smAppServiceAgentLabelId,
+} from "../../label";
 import { CLI_ERROR_CODES } from "../../../runner/errors";
 
 const execFileAsync = promisify(execFile);
@@ -225,6 +232,82 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
     } finally {
       await rm(work, { recursive: true, force: true });
     }
+  });
+
+  // The launcher-FILE form of the same contract: the macOS plist executes
+  // `~/.traycer/service/<label>/traycer-host-start <cli> <args...>` (so BTM
+  // names the login item after the file, not after /bin/sh), and BOTH CLI
+  // generations must still start. Executes the real emitted file, exactly
+  // like the inline-form row above.
+  it("launcher file: starts both an N-1 CLI without --service-label and a current CLI with it, preserving leading invocation args", async () => {
+    const work = mkdtempSync(join(tmpdir(), "traycer-host-start-launcher-"));
+    const launcher = join(work, "traycer-host-start");
+    const oldCli = join(work, "old-cli.sh");
+    const newCli = join(work, "new-cli.sh");
+    const oldArgs = join(work, "old-args.txt");
+    const newArgs = join(work, "new-args.txt");
+    try {
+      await writeFile(
+        launcher,
+        buildHostStartLauncherScript("ai.traycer.host.compat"),
+        "utf8",
+      );
+      await chmod(launcher, 0o755);
+      await writeFile(
+        oldCli,
+        `#!/bin/sh
+if [ "$1" = "host" ] && [ "$2" = "capabilities" ]; then
+  echo "error: unknown command 'capabilities'" >&2
+  exit 1
+fi
+printf '%s\\n' "$@" > ${JSON.stringify(oldArgs)}
+`,
+        "utf8",
+      );
+      await writeFile(
+        newCli,
+        `#!/bin/sh
+if [ "$1" = "--entry=cli-entry.js" ] && [ "$2" = "host" ] && [ "$3" = "capabilities" ] && [ "$4" = "--has" ] && [ "$5" = "service-label" ]; then exit 0; fi
+printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
+`,
+        "utf8",
+      );
+      await chmod(oldCli, 0o700);
+      await chmod(newCli, 0o700);
+
+      await execFileAsync(launcher, [oldCli]);
+      await execFileAsync(launcher, [newCli, "--entry=cli-entry.js"]);
+
+      expect(await readFile(oldArgs, "utf8")).toBe("host\nstart\n");
+      expect(await readFile(newArgs, "utf8")).toBe(
+        "--entry=cli-entry.js\nhost\nstart\n--service-label\nai.traycer.host.compat\n",
+      );
+    } finally {
+      await rm(work, { recursive: true, force: true });
+    }
+  });
+
+  // Field observation 2026-07-28 (sfltool dumpbtm): with `/bin/sh` as
+  // ProgramArguments[0], BTM recorded `Name: sh, Parent Identifier:
+  // Unknown Developer` for every CLI-registered install, and
+  // AssociatedBundleIdentifiers alone was probed and ignored for that
+  // shape. The plist must execute the per-label launcher file, whose
+  // basename is what macOS shows.
+  it("puts the per-label launcher file first in ProgramArguments so BTM names the item traycer-host-start", () => {
+    const plist = buildLaunchAgentPlist({
+      label,
+      cli: { command: "/usr/local/bin/traycer", args: ["--entry=e.js"] },
+    });
+
+    const launcherPath = serviceLauncherScriptPath(label);
+    expect(launcherPath.endsWith(`/${label.id}/traycer-host-start`)).toBe(true);
+    expect(plist).toContain(`<key>ProgramArguments</key>
+  <array>
+    <string>${launcherPath}</string>
+    <string>/usr/local/bin/traycer</string>
+    <string>--entry=e.js</string>
+  </array>`);
+    expect(plist).not.toContain("/bin/sh");
   });
 
   // The blocker this contract replaces: `--service-label` used to be passed

--- a/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/macos.test.ts
@@ -2626,5 +2626,23 @@ printf '%s\\n' "$@" > ${JSON.stringify(newArgs)}
       );
       await expect(readRegisteredCliInvocation(label)).resolves.toBeNull();
     });
+
+    it("refuses a launcher-form manifest whose path is not this label's own serviceLauncherScriptPath", async () => {
+      // Same basename, wrong path - e.g. an attacker-writable plist
+      // engineered to look like the launcher-file form. Matching on the
+      // `traycer-host-start` basename alone would treat this as a genuine
+      // registration and PRESERVE its command across the next `host
+      // update`, persisting an arbitrary CLI path into the freshly
+      // rewritten plist. Only the exact path this label's own
+      // `serviceLauncherScriptPath` resolves to may attest.
+      createdPlistPath = join(tempPlistDir, `${label.id}.plist`);
+      await writeFile(
+        createdPlistPath,
+        `<plist><dict><key>ProgramArguments</key><array><string>/tmp/attacker-controlled/traycer-host-start</string><string>${process.execPath}</string></array></dict></plist>`,
+        "utf8",
+      );
+
+      await expect(readRegisteredCliInvocation(label)).resolves.toBeNull();
+    });
   });
 });

--- a/clients/traycer-cli/src/service/platforms/host-start-script.ts
+++ b/clients/traycer-cli/src/service/platforms/host-start-script.ts
@@ -1,4 +1,7 @@
-import { COMPATIBLE_HOST_START_SCRIPT_PREFIX as SHARED_COMPATIBLE_HOST_START_SCRIPT_PREFIX } from "@traycer-clients/shared/host-lifecycle";
+import {
+  COMPATIBLE_HOST_START_SCRIPT_PREFIX as SHARED_COMPATIBLE_HOST_START_SCRIPT_PREFIX,
+  HOST_START_LAUNCHER_BASENAME as SHARED_HOST_START_LAUNCHER_BASENAME,
+} from "@traycer-clients/shared/host-lifecycle";
 
 /**
  * The `/bin/sh -c` program shared by the macOS LaunchAgent plist and the
@@ -49,6 +52,47 @@ export const COMPATIBLE_HOST_START_SCRIPT_PREFIX =
  */
 export function buildCompatibleHostStartScript(serviceLabel: string): string {
   return `${COMPATIBLE_HOST_START_SCRIPT_PREFIX} >/dev/null 2>&1 && exec "$0" "$@" host start --service-label ${posixShellQuote(serviceLabel)} || exec "$0" "$@" host start`;
+}
+
+/**
+ * Basename of the launcher file the macOS LaunchAgent executes. Re-exported
+ * from the shared substrate for the same lockstep reason as the prefix
+ * above: `attestTraycerRegistration` recognises launcher-form plists by
+ * this basename, so the emitter must not spell it independently.
+ */
+export const HOST_START_LAUNCHER_BASENAME = SHARED_HOST_START_LAUNCHER_BASENAME;
+
+/**
+ * The launcher-FILE form of the compatibility wrapper, for platforms where
+ * `ProgramArguments[0]` is user-visible identity. macOS background-task
+ * management names a raw login item after its executable: with the inline
+ * `/bin/sh -c` form, System Settings → Login Items showed a bare "sh" from
+ * an "Unknown Developer" on every CLI-registered install (field
+ * observation 2026-07-28, `sfltool dumpbtm`: `Name: sh, Parent Identifier:
+ * Unknown Developer`; `AssociatedBundleIdentifiers` alone was probed and
+ * is ignored for a `/bin/sh` legacy item). Executing this file instead
+ * makes BTM record `Name: traycer-host-start` - probe-verified on a live
+ * record, which BTM renames on re-registration of the same label.
+ *
+ * Same probe/exec chain as `buildCompatibleHostStartScript`, adjusted for
+ * file execution: the plist invokes
+ *
+ *     <launcher-path> <cli-command> <cli-args...>
+ *
+ * so the CLI invocation is `"$@"` (in the `sh -c` form it was `"$0" "$@"`,
+ * because `-c` binds the first trailing operand to `$0`). Neither
+ * direction can fail to start, exactly as before: a current CLI answers
+ * the capability probe and receives `--service-label`; an N-1 CLI exits
+ * non-zero from the probe and starts the host exactly as it always did.
+ */
+export function buildHostStartLauncherScript(serviceLabel: string): string {
+  return `#!/bin/sh
+# Traycer host launcher. Written by 'traycer host service install'; the
+# LaunchAgent plist executes this file with the CLI invocation as its
+# arguments. It exists as a FILE (not an inline 'sh -c' program) so macOS
+# names the login item after it instead of after /bin/sh.
+"$@" host capabilities --has service-label >/dev/null 2>&1 && exec "$@" host start --service-label ${posixShellQuote(serviceLabel)} || exec "$@" host start
+`;
 }
 
 /**

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -11,7 +11,6 @@ import { escapeXml } from "../escape-xml";
 import {
   buildHostStartLauncherScript,
   COMPATIBLE_HOST_START_SCRIPT_PREFIX,
-  HOST_START_LAUNCHER_BASENAME,
 } from "./host-start-script";
 import { fileExists } from "../install-binary";
 import {
@@ -1700,14 +1699,18 @@ ${programArgsXml}
  *
  * Only ever parses a plist this module's `buildPlist` wrote, so the shape is
  * closed at exactly three members: the current `<launcher-file> <cli>
- * <args...>` vector (the launcher's basename is `traycer-host-start`; see
- * `buildHostStartLauncherScript`), the prior inline `/bin/sh -c
- * <compat-script> <cli> <args...>` vector still on disk wherever the
- * definition has not been rewritten since, and the legacy vector that ends
- * at `host start`. There is deliberately no fourth branch for a plist whose
- * ProgramArguments end in `--service-label <label>` - no version of
- * `buildPlist` has ever emitted that shape, and a speculative parse arm on
- * a closed set is a liability, not tolerance.
+ * <args...>` vector - matched by exact equality against
+ * `serviceLauncherScriptPath(label)`, this label's own deterministic
+ * launcher path, not merely a `traycer-host-start` basename suffix, since a
+ * basename-only match would treat an attacker-writable plist pointing at
+ * ANY same-named file as this label's registration and preserve whatever
+ * command it named across the next `host update` - the prior inline
+ * `/bin/sh -c <compat-script> <cli> <args...>` vector still on disk
+ * wherever the definition has not been rewritten since, and the legacy
+ * vector that ends at `host start`. There is deliberately no fourth branch
+ * for a plist whose ProgramArguments end in `--service-label <label>` - no
+ * version of `buildPlist` has ever emitted that shape, and a speculative
+ * parse arm on a closed set is a liability, not tolerance.
  */
 async function readRegisteredCliInvocation(
   label: ServiceLabel,
@@ -1728,10 +1731,7 @@ async function readRegisteredCliInvocation(
     .map((m) => m[1])
     .filter((value): value is string => value !== undefined)
     .map(unescapeXml);
-  if (
-    args.length >= 2 &&
-    args[0]?.endsWith(`/${HOST_START_LAUNCHER_BASENAME}`) === true
-  ) {
+  if (args.length >= 2 && args[0] === serviceLauncherScriptPath(label)) {
     const command = args[1];
     if (command === undefined || !(await fileExists(command))) return null;
     return { command, args: args.slice(2) };

--- a/clients/traycer-cli/src/service/platforms/macos.ts
+++ b/clients/traycer-cli/src/service/platforms/macos.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname } from "node:path";
 import { readHostPidMetadata } from "../../host/pid-metadata";
@@ -9,8 +9,9 @@ import type { CliInvocation } from "../cli-binary";
 import { HOST_V8_FLAGS } from "../host-node-options";
 import { escapeXml } from "../escape-xml";
 import {
-  buildCompatibleHostStartScript,
+  buildHostStartLauncherScript,
   COMPATIBLE_HOST_START_SCRIPT_PREFIX,
+  HOST_START_LAUNCHER_BASENAME,
 } from "./host-start-script";
 import { fileExists } from "../install-binary";
 import {
@@ -18,6 +19,7 @@ import {
   STOP_EXIT_GRACE_MARGIN_MS,
 } from "@traycer/protocol/host/lifecycle-constants";
 import {
+  serviceLauncherScriptPath,
   serviceManifestPath,
   smAppServiceAgentLabelId,
   type ServiceLabel,
@@ -298,6 +300,19 @@ async function installService(
       exitCode: 1,
     });
   }
+  // The launcher file must exist (and be executable) before the plist that
+  // points at it is bootstrapped - launchd spawns `ProgramArguments[0]`
+  // directly. `chmod` runs unconditionally after the write because
+  // `writeFile`'s `mode` only applies when the file is created, not when an
+  // existing launcher is rewritten.
+  const launcherPath = serviceLauncherScriptPath(options.label);
+  await mkdir(dirname(launcherPath), { recursive: true });
+  await writeFile(
+    launcherPath,
+    buildHostStartLauncherScript(options.label.id),
+    "utf8",
+  );
+  await chmod(launcherPath, 0o755);
   const manifestPath = serviceManifestPath(options.label);
   await mkdir(dirname(manifestPath), { recursive: true });
   await writeFile(
@@ -721,6 +736,12 @@ async function uninstallService(
     });
   }
   await rm(serviceManifestPath(options.label), { force: true });
+  // The launcher directory is per-label and exists solely for the plist
+  // that was just removed.
+  await rm(dirname(serviceLauncherScriptPath(options.label)), {
+    recursive: true,
+    force: true,
+  });
 }
 
 function isBenignBootoutFailure(cause: unknown): boolean {
@@ -1602,10 +1623,15 @@ function hostAgentPath(): string {
 
 function buildPlist(options: BuildPlistOptions): string {
   const home = homedir();
+  // `ProgramArguments[0]` is the launcher FILE, not `/bin/sh -c <script>`:
+  // macOS background-task management names the login item after the
+  // executable, and the inline form surfaced as a bare "sh" from an
+  // "Unknown Developer" in System Settings on every CLI-registered
+  // install. The launcher carries the same N-1 capability probe; see
+  // `buildHostStartLauncherScript`. `installService` writes the file
+  // before this plist is bootstrapped.
   const programArgs = [
-    "/bin/sh",
-    "-c",
-    buildCompatibleHostStartScript(options.label.id),
+    serviceLauncherScriptPath(options.label),
     options.cli.command,
     ...options.cli.args,
   ];
@@ -1673,12 +1699,15 @@ ${programArgsXml}
  * repoints the service" contract while still refreshing the definition.
  *
  * Only ever parses a plist this module's `buildPlist` wrote, so the shape is
- * closed at exactly two members: the current `/bin/sh -c <compat-script>
- * <cli> <args...>` vector, and the legacy vector that ends at `host start`.
- * There is deliberately no third branch for a plist whose ProgramArguments
- * end in `--service-label <label>` - no version of `buildPlist` has ever
- * emitted that shape, and a speculative parse arm on a closed set is a
- * liability, not tolerance.
+ * closed at exactly three members: the current `<launcher-file> <cli>
+ * <args...>` vector (the launcher's basename is `traycer-host-start`; see
+ * `buildHostStartLauncherScript`), the prior inline `/bin/sh -c
+ * <compat-script> <cli> <args...>` vector still on disk wherever the
+ * definition has not been rewritten since, and the legacy vector that ends
+ * at `host start`. There is deliberately no fourth branch for a plist whose
+ * ProgramArguments end in `--service-label <label>` - no version of
+ * `buildPlist` has ever emitted that shape, and a speculative parse arm on
+ * a closed set is a liability, not tolerance.
  */
 async function readRegisteredCliInvocation(
   label: ServiceLabel,
@@ -1699,6 +1728,14 @@ async function readRegisteredCliInvocation(
     .map((m) => m[1])
     .filter((value): value is string => value !== undefined)
     .map(unescapeXml);
+  if (
+    args.length >= 2 &&
+    args[0]?.endsWith(`/${HOST_START_LAUNCHER_BASENAME}`) === true
+  ) {
+    const command = args[1];
+    if (command === undefined || !(await fileExists(command))) return null;
+    return { command, args: args.slice(2) };
+  }
   if (
     args.length >= 4 &&
     args[0] === "/bin/sh" &&


### PR DESCRIPTION
## Problem

#776 added `AssociatedBundleIdentifiers` to the CLI-generated LaunchAgent plist — and it turned out to be insufficient. Verified live on a dev slot running a build **with** the key present: BTM still recorded

```
Name: sh
Developer Name: (null)
Executable Path: /bin/sh
Parent Identifier: Unknown Developer
```

and macOS notified **"'sh' can run in the background"** on every dev run. BTM ignores the association for a legacy item whose executable is Apple's `/bin/sh` — it names raw login items after `ProgramArguments[0]`, full stop.

## Fix

Move the compatibility wrapper from an inline `/bin/sh -c <script>` vector into an executable file — `~/.traycer/service/<label>/traycer-host-start` — and make the plist execute that.

**Probe-verified end-to-end on the same machine before writing the code**: re-registering the *same label* (which already carried the "sh" BTM record) with exactly this shape made BTM replace the record:

```
Name: traycer-host-start
Executable Path: ~/.traycer/service/ai.traycer.host.dev.…/traycer-host-start
```

So existing field machines get renamed the next time their service definition is rewritten — BTM does not keep the stale name.

The wrapper's semantics are byte-equivalent: same N-1 capability probe, same `A && exec B || exec C` chain, adjusted only for file execution (`"$@"` instead of `"$0" "$@"`, since `-c` bound the first operand to `$0`). Neither CLI generation can fail to start, and the launcher-file execution test proves both directions against the real emitted file. The launcher is written (and `chmod 755`ed — `writeFile`'s `mode` doesn't apply to existing files) before the plist on install, and removed with its per-label directory on uninstall.

## The part that was NOT optional: recognizer lockstep

Two recognizers key on the old plist shape, and shipping the emitter change alone would have rebuilt the exact lockout class this epic exists to kill:

- **`attestTraycerRegistration`** (shared substrate) recognized our plists by the inline script in `ProgramArguments[2]`. A launcher-form plist has no inline script → attestation would degrade to `indeterminate` → `isEvictableTraycerIdentity` refuses eviction → every repair path declines to touch a registration this codebase just wrote. It now attests the launcher argv shape: basename from the new shared `HOST_START_LAUNCHER_BASENAME` constant (single source of truth, same pattern as `COMPATIBLE_HOST_START_SCRIPT_PREFIX` and for the same historical reason), label matched via the launcher's parent directory. A launcher registered for a *different* label deliberately does not attest as this label's invocation.
- **`readRegisteredCliInvocation`** gains the launcher arm as the third member of its closed shape set. The inline and legacy forms stay recognized (the field's existing plists), and the inline form stays *emitted* on Linux, where systemd shows the unit name and none of this applies.

## Verification

- CLI 1114 passed, shared 678 passed, compile green across all 5 projects.
- New pins: launcher-file N-1/current execution (runs the real emitted file); `buildPlist` launcher shape (and `not.toContain("/bin/sh")`); lockstep rows tying `serviceLauncherScriptPath` ↔ attestation; different-label launcher refused; the `host-start` manifest leak test updated from pinning `/bin/sh` to pinning the launcher.
- **Mutation-probed both recognizers**: neutering the attestation arm reddens only the new lockstep row; neutering the parse arm reddens only the `buildPlist` round-trip row. Restored and re-verified green.
