### PR TITLE
fix(gui-app): roll back orphaned source on strip-placement failure

### DIFF
--- a/clients/gui-app/src/stores/tabs/__tests__/transaction-coordinator.test.ts
+++ b/clients/gui-app/src/stores/tabs/__tests__/transaction-coordinator.test.ts
@@ -13,6 +13,7 @@ import {
   __resetTabSyncCoordinatorForTesting,
   installTabSyncCoordinator,
 } from "@/lib/tab-sync/tab-sync-coordinator";
+import { createEmptyCanvas } from "@/stores/epics/canvas/canvas-state";
 import { useEpicCanvasStore } from "@/stores/epics/canvas/store";
 import {
   setLandingDraftDesktopProjectionBridge,
@@ -450,6 +451,103 @@ describe("tab command coordinator transactions", () => {
     );
     expectFinalizedOnce(session);
     expect(useLandingDraftStore.getState().drafts).toEqual([]);
+  });
+
+  it("createSourceRefAtStripIndex rolls back the source createSource() minted when placement fails", () => {
+    const collidingRef: TabRef = { kind: "epic", id: "collide-id" };
+    // collidingRef lives only inside a split side here (not yet an open
+    // tab) - a stale layout entry that reconciliation itself would prune,
+    // orthogonal to what this test exercises. It stands in for createSource()
+    // minting a ref that collides with one already occupying a split side,
+    // which is the only way createLayoutItem's placement can reject a ref.
+    seedCommittedLayout({
+      version: 2,
+      items: [
+        {
+          kind: "split",
+          id: "split-existing",
+          left: { kind: "empty" },
+          right: { kind: "tab", ref: collidingRef },
+          focusedSide: "right",
+          routeBackingSide: "right",
+          leftRatio: 0.5,
+        },
+      ],
+      activeItemId: "split-existing",
+      systemTabs: { history: null, settings: null },
+    });
+
+    const session = captureSession();
+    const placed = tabCommandCoordinator.createSourceRefAtStripIndex(0, () => {
+      // A split side is not a top-level strip position, so placing
+      // collidingRef at a strip index fails - this mimics createSource()
+      // minting a ref that collides with one already living inside a split.
+      useEpicCanvasStore.setState((state) => ({
+        tabsById: {
+          ...state.tabsById,
+          [collidingRef.id]: {
+            tabId: collidingRef.id,
+            epicId: "epic-b",
+            name: "B",
+          },
+        },
+        canvasByTabId: {
+          ...state.canvasByTabId,
+          [collidingRef.id]: createEmptyCanvas(),
+        },
+        openTabOrder: [...state.openTabOrder, collidingRef.id],
+        activeTabId: collidingRef.id,
+      }));
+      return collidingRef;
+    });
+    session.dispose();
+
+    expect(placed).toBeNull();
+    session.assertAllSafe();
+    // The source rolled back - createSource()'s mint never survives as a
+    // known source, so a later reconciliation pass has nothing left to
+    // re-adopt as an orphaned, active top-level tab.
+    expect(useEpicCanvasStore.getState().openTabOrder).not.toContain(
+      collidingRef.id,
+    );
+    expect(flattenLayoutRefs(layoutFromTabsState())).not.toContainEqual(
+      collidingRef,
+    );
+  });
+
+  it("createSourceRefAtStripIndex does not close a pre-existing tab createSource() resolves to on failure", () => {
+    const { ref: existingRef } = openEpicSource("epic-b", "B");
+    seedCommittedLayout({
+      version: 2,
+      items: [
+        {
+          kind: "split",
+          id: "split-existing",
+          left: { kind: "empty" },
+          right: { kind: "tab", ref: existingRef },
+          focusedSide: "right",
+          routeBackingSide: "right",
+          leftRatio: 0.5,
+        },
+      ],
+      activeItemId: "split-existing",
+      systemTabs: { history: null, settings: null },
+    });
+    const layoutBefore = layoutFromTabsState();
+
+    const session = captureSession();
+    const placed = tabCommandCoordinator.createSourceRefAtStripIndex(
+      0,
+      () => existingRef,
+    );
+    session.dispose();
+
+    expect(placed).toBeNull();
+    session.assertAllSafe();
+    expect(useEpicCanvasStore.getState().openTabOrder).toContain(
+      existingRef.id,
+    );
+    expect(layoutFromTabsState()).toEqual(layoutBefore);
   });
 
   it("nested source write during applySources stays reserved, marks dirty, and defers placement", () => {

--- a/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
+++ b/clients/gui-app/src/stores/tabs/tab-command-coordinator.ts
@@ -662,6 +662,7 @@ export class TabCommandCoordinator {
     createSource: () => TabRef | null,
   ): TabRef | null {
     if (!Number.isInteger(targetIndex) || targetIndex < 0) return null;
+    const knownBeforeCreate = new Set(tabSourceRefs().map(tabRefKey));
     let createdRef: TabRef | null = null;
     this.execute({
       layout: () => {
@@ -672,6 +673,14 @@ export class TabCommandCoordinator {
         if (item?.kind !== "tab") {
           // Placement failed - the created ref is not part of the
           // authoritative layout, so it must not be reported as placed.
+          // createSource() already minted it in the source store, so undo
+          // that here (before finalize's reconciliation runs) or it gets
+          // re-adopted as an orphaned, active tab on the next pass. Only
+          // roll back refs this call actually minted - a ref that already
+          // existed before createSource() ran must not be closed here.
+          if (!knownBeforeCreate.has(tabRefKey(createdRef))) {
+            this.removeSourceRef(createdRef);
+          }
           createdRef = null;
           return layout;
         }


### PR DESCRIPTION
## Summary
- `createSourceRefAtStripIndex` only nulled `createdRef` when strip placement was rejected, leaving `createSource()`'s source-store mutation (the newly opened tab) in place.
- The orphaned ref stayed a known source without ever being placed in the authoritative layout, so a later reconciliation pass could re-adopt it instead of the call cleanly reporting failure.
- Roll back via the coordinator's existing `removeSourceRef` before `finalize()` runs, guarded so a ref that already existed before `createSource()` ran (i.e. not something this call minted) is never closed out from under the user.

Follow-up to #789 (the `createSourceRefAtStripIndex` shape landed there); this addresses a reviewer finding on that same function that came in after merge.

## Test plan
- [x] New regression tests in `transaction-coordinator.test.ts`: rollback happens on a genuinely-new minted ref; a pre-existing ref `createSource()` resolves to is never closed.
- [x] Mutation-probe: reverted the fix, confirmed only the new rollback test goes red (20/21 still pass).
- [x] `bun run compile`, `bun run lint`, `prettier --check` on changed files.
- [x] Full `src/stores/tabs/` + `src/components/layout/tabs/__tests__/` suite (127 tests) green.