### PR TITLE
fix(cli): reliable Linux host lifecycle - unit hardening + doctor probes

### DIFF
--- a/clients/traycer-cli/src/doctor/__tests__/systemd-health.test.ts
+++ b/clients/traycer-cli/src/doctor/__tests__/systemd-health.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ProbeCommandResult } from "@traycer-clients/shared/host-lifecycle";
+import { DOCTOR_ISSUE_CODES } from "../issues";
+import {
+  probeLinuxSystemdHealth,
+  type SystemdProbeRunner,
+} from "../systemd-health";
+
+/**
+ * The Linux doctor probes, fixture-driven. Until this module existed doctor
+ * had ZERO Linux probes while `service/platforms/linux.ts` claimed "Doctor
+ * surfaces the missing linger as a warning" - and `service status`
+ * deliberately keys liveness off pid metadata, so a failed / restart-looping
+ * unit read as plain "stopped" with nowhere that told the truth. Each row
+ * here is one of those dead ends.
+ */
+
+const LABEL_ID = "ai.traycer.host";
+const UNIT = `${LABEL_ID}.service`;
+
+function ok(stdout: string): ProbeCommandResult {
+  return {
+    exitCode: 0,
+    stdout,
+    stderr: "",
+    timedOut: false,
+    spawnFailed: false,
+    signal: null,
+  };
+}
+
+function fail(stderr: string): ProbeCommandResult {
+  return {
+    exitCode: 1,
+    stdout: "",
+    stderr,
+    timedOut: false,
+    spawnFailed: false,
+    signal: null,
+  };
+}
+
+interface RecordedProbe {
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+function runnerWith(respond: (probe: RecordedProbe) => ProbeCommandResult): {
+  readonly calls: RecordedProbe[];
+  readonly runner: SystemdProbeRunner;
+} {
+  const calls: RecordedProbe[] = [];
+  const runner: SystemdProbeRunner = (command, args) => {
+    const call: RecordedProbe = { command, args };
+    calls.push(call);
+    return Promise.resolve(respond(call));
+  };
+  return { calls, runner };
+}
+
+function showOutput(props: Record<string, string>): string {
+  return Object.entries(props)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+}
+
+const HEALTHY_SHOW = {
+  LoadState: "loaded",
+  ActiveState: "active",
+  SubState: "running",
+  Result: "success",
+  ConditionResult: "yes",
+  ConditionTimestampMonotonic: "8412345",
+  NRestarts: "0",
+  ExecMainStatus: "0",
+  UnitFileState: "enabled",
+};
+
+function respondHealthy(probe: RecordedProbe): ProbeCommandResult {
+  if (probe.command === "loginctl") return ok("Linger=yes\n");
+  if (probe.args[1] === "show-environment") return ok("PATH=/usr/bin\n");
+  return ok(showOutput(HEALTHY_SHOW));
+}
+
+let savedUser: string | undefined;
+
+beforeEach(() => {
+  savedUser = process.env.USER;
+  process.env.USER = "testuser";
+});
+
+afterEach(() => {
+  if (savedUser === undefined) delete process.env.USER;
+  else process.env.USER = savedUser;
+});
+
+describe("probeLinuxSystemdHealth", () => {
+  it("stays silent on a healthy machine", async () => {
+    const { runner } = runnerWith(respondHealthy);
+    const issues = await probeLinuxSystemdHealth({
+      labelId: LABEL_ID,
+      unitFileInstalled: true,
+      runner,
+    });
+    expect(issues).toEqual([]);
+  });
+
+  it("reports an unreachable user manager - and probes nothing further", async () => {
+    // The WSL-without-systemd / sudo-su / headless-SSH state: the exact
+    // environments where install fails and steers users to doctor.
+    const { calls, runner } = runnerWith((probe) =>
+      probe.args[1] === "show-environment"
+        ? fail("Failed to connect to bus: No medium found")
+        : ok(""),
+    );
+    const issues = await probeLinuxSystemdHealth({
+      labelId: LABEL_ID,
+      unitFileInstalled: true,
+      runner,
+    });
+    expect(issues.map((issue) => issue.code)).toEqual([
+      DOCTOR_ISSUE_CODES.SYSTEMD_USER_UNREACHABLE,
+    ]);
+    expect(issues[0]?.severity).toBe("error");
+    expect(issues[0]?.message).toContain("WSL");
+    // Follow-on probes would only repeat the same failure.
+    expect(calls).toHaveLength(1);
+  });
+
+  it("reports a failed unit with the journal command to read", async () => {
+    const { runner } = runnerWith((probe) => {
+      if (probe.args[1] === "show")
+        return ok(
+          showOutput({
+            ...HEALTHY_SHOW,
+            ActiveState: "failed",
+            SubState: "failed",
+            Result: "exit-code",
+            ExecMainStatus: "127",
+            NRestarts: "5",
+          }),
+        );
+      return respondHealthy(probe);
+    });
+    const issues = await probeLinuxSystemdHealth({
+      labelId: LABEL_ID,
+      unitFileInstalled: true,
+      runner,
+    });
+    expect(issues.map((issue) => issue.code)).toEqual([
+      DOCTOR_ISSUE_CODES.SERVICE_UNIT_FAILED,
+    ]);
+    expect(issues[0]?.terminalCommand).toContain(
+      `journalctl --user -u ${UNIT}`,
+    );
+    expect(issues[0]?.details).toMatchObject({ execMainStatus: "127" });
+  });
+
+  it("reports a restart-looping unit (auto-restart), which status reads as merely stopped", async () => {
+    const { runner } = runnerWith((probe) => {
+      if (probe.args[1] === "show")
+        return ok(
+          showOutput({
+            ...HEALTHY_SHOW,
+            ActiveState: "activating",
+            SubState: "auto-restart",
+            Result: "exit-code",
+          }),
+        );
+      return respondHealthy(probe);
+    });
+    const issues = await probeLinuxSystemdHealth({
+      labelId: LABEL_ID,
+      unitFileInstalled: true,
+      runner,
+    });
+    expect(issues.map((issue) => issue.code)).toEqual([
+      DOCTOR_ISSUE_CODES.SERVICE_UNIT_FAILED,
+    ]);
+  });
+
+  it("reports a start skipped by the missing-CLI condition, pointing at reinstall", async () => {
+    const { runner } = runnerWith((probe) => {
+      if (probe.args[1] === "show")
+        return ok(
+          showOutput({
+            ...HEALTHY_SHOW,
+            ActiveState: "inactive",
+            SubState: "dead",
+            ConditionResult: "no",
+          }),
+        );
+      return respondHealthy(probe);
+    });
+    const issues = await probeLinuxSystemdHealth({
+      labelId: LABEL_ID,
+      unitFileInstalled: true,
+      runner,
+    });
+    expect(issues.map((issue) => issue.code)).toEqual([
+      DOCTOR_ISSUE_CODES.SERVICE_START_CONDITION_UNMET,
+    ]);
+    expect(issues[0]?.fixAction).toBe("host-install");
+  });
+
+  it("stays silent on the not-loaded and never-started property DEFAULTS, which include ConditionResult=no", async () => {
+    // Verified live on systemd 255: `systemctl show` of a NOT-LOADED unit
+    // exits 0 reporting property defaults - ConditionResult=no among them -
+    // and a loaded unit that never attempted a start reports the same
+    // default with ConditionTimestampMonotonic=0. Without the
+    // positive-evidence guard this probe would cry "CLI binary missing" on
+    // every such machine.
+    const { runner } = runnerWith((probe) => {
+      if (probe.args[1] === "show")
+        return ok(
+          showOutput({
+            ...HEALTHY_SHOW,
+            ActiveState: "inactive",
+            SubState: "dead",
+            ConditionResult: "no",
+            ConditionTimestampMonotonic: "0",
+          }),
+        );
+      return respondHealthy(probe);
+    });
+    const issues = await probeLinuxSystemdHealth({
+      labelId: LABEL_ID,
+      unitFileInstalled: true,
+      runner,
+    });
+    expect(issues).toEqual([]);
+  });
+
+  it("warns when lingering is disabled - the promised follow-up for best-effort enable-linger", async () => {
+    const { runner } = runnerWith((probe) =>
+      probe.command === "loginctl" ? ok("Linger=no\n") : respondHealthy(probe),
+    );
+    const issues = await probeLinuxSystemdHealth({
+      labelId: LABEL_ID,
+      unitFileInstalled: true,
+      runner,
+    });
+    expect(issues.map((issue) => issue.code)).toEqual([
+      DOCTOR_ISSUE_CODES.LINGER_DISABLED,
+    ]);
+    expect(issues[0]?.severity).toBe("warning");
+    expect(issues[0]?.terminalCommand).toBe("loginctl enable-linger testuser");
+  });
+
+  it("skips unit and linger probes when no unit file is installed", async () => {
+    const { calls, runner } = runnerWith(respondHealthy);
+    const issues = await probeLinuxSystemdHealth({
+      labelId: LABEL_ID,
+      unitFileInstalled: false,
+      runner,
+    });
+    expect(issues).toEqual([]);
+    expect(calls.map((call) => call.args[1] ?? call.command)).toEqual([
+      "show-environment",
+    ]);
+  });
+});

--- a/clients/traycer-cli/src/doctor/engine.ts
+++ b/clients/traycer-cli/src/doctor/engine.ts
@@ -45,6 +45,10 @@ import {
   createRealLaunchdPrintRunner,
   probeMacosWedgedJob,
 } from "./launchd-wedge";
+import {
+  createRealSystemdProbeRunner,
+  probeLinuxSystemdHealth,
+} from "./systemd-health";
 import { isProcessAlive } from "../store/cli-lock";
 import {
   DOCTOR_ISSUE_CODES,
@@ -443,6 +447,22 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorResult> {
       runner: createRealLaunchdPrintRunner(),
     });
     if (wedgeIssue !== null) issues.push(wedgeIssue);
+  }
+
+  // ---- 4a-linux. systemd user-manager health ----
+  // The Linux counterpart of the launchd wedge probe. Reads the manager's
+  // actual run state: no reachable user bus (WSL without systemd, sudo su),
+  // a failed / restart-looping unit ("stopped" everywhere else, since
+  // liveness deliberately keys off pid metadata), a start skipped because
+  // the CLI binary is gone, and disabled lingering.
+  if (process.platform === "linux") {
+    const systemdIssues = await probeLinuxSystemdHealth({
+      labelId: label.id,
+      unitFileInstalled:
+        serviceStatus !== null && serviceStatus.state !== "not-installed",
+      runner: createRealSystemdProbeRunner(),
+    });
+    issues.push(...systemdIssues);
   }
 
   // ---- 4b. CLI slot binary health ----

--- a/clients/traycer-cli/src/doctor/issues.ts
+++ b/clients/traycer-cli/src/doctor/issues.ts
@@ -56,6 +56,23 @@ export const DOCTOR_ISSUE_CODES = {
   // Doctor surfaces this so VDI/shared-machine users can lock the
   // file down manually until we add per-user ACL hardening.
   WINDOWS_CREDENTIALS_ACL_PERMISSIVE: "WINDOWS_CREDENTIALS_ACL_PERMISSIVE",
+  // Linux-only: `systemctl --user` cannot reach a user service manager
+  // (WSL without systemd, `sudo su`, SSH with no logind session). Every
+  // lifecycle operation fails in this state, and install errors steer
+  // users to doctor - which previously had no Linux probes at all.
+  SYSTEMD_USER_UNREACHABLE: "SYSTEMD_USER_UNREACHABLE",
+  // Linux-only: the unit is `failed` or cycling `auto-restart`.
+  // `service status` deliberately keys liveness off pid metadata, so this
+  // state reads there as plain "stopped"; doctor is where it surfaces.
+  SERVICE_UNIT_FAILED: "SERVICE_UNIT_FAILED",
+  // Linux-only: systemd skipped the last start because
+  // ConditionFileIsExecutable found the CLI binary the unit points at
+  // missing - a stranded service definition.
+  SERVICE_START_CONDITION_UNMET: "SERVICE_START_CONDITION_UNMET",
+  // Linux-only: lingering disabled - the host is torn down at last
+  // logout. Enable-linger is best-effort at install (polkit may refuse
+  // non-interactively); this is the promised follow-up surface.
+  LINGER_DISABLED: "LINGER_DISABLED",
 } as const;
 
 export type DoctorIssueCode =

--- a/clients/traycer-cli/src/doctor/systemd-health.ts
+++ b/clients/traycer-cli/src/doctor/systemd-health.ts
@@ -1,0 +1,237 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import {
+  classifyLingerState,
+  type ProbeCommandResult,
+} from "@traycer-clients/shared/host-lifecycle";
+import { DOCTOR_ISSUE_CODES, type DoctorIssue } from "./issues";
+
+// The Linux half of doctor's run-state reading. The comment atop
+// `service/platforms/linux.ts` promised "Doctor surfaces the missing linger
+// as a warning" from the day linger became best-effort - but doctor had NO
+// Linux probes at all, and `service status` deliberately keys liveness off
+// pid metadata, never systemd. The result was a diagnostic dead end on the
+// platform with the most failure modes: a restart-looping unit read as
+// plain "stopped", a WSL box without systemd read as healthy-but-stopped,
+// and a disabled linger (host dies at logout) was invisible everywhere.
+//
+// Same philosophy as the launchd wedge probe: read the manager's ACTUAL
+// run state, report only on positive evidence, stay silent on healthy
+// machines.
+
+const execFileAsync = promisify(execFile);
+
+/** Runs a probe command (`systemctl`/`loginctl`) and never rejects. */
+export type SystemdProbeRunner = (
+  command: string,
+  args: readonly string[],
+) => Promise<ProbeCommandResult>;
+
+type ExecFileFailure = {
+  readonly code: string | number | undefined;
+  readonly stdout: string | undefined;
+  readonly stderr: string | undefined;
+  readonly killed: boolean | undefined;
+  readonly signal: NodeJS.Signals | undefined;
+};
+
+export function createRealSystemdProbeRunner(): SystemdProbeRunner {
+  return async (
+    command: string,
+    args: readonly string[],
+  ): Promise<ProbeCommandResult> => {
+    try {
+      const { stdout, stderr } = await execFileAsync(command, [...args], {
+        timeout: 10_000,
+        encoding: "utf8",
+      });
+      return {
+        exitCode: 0,
+        stdout,
+        stderr,
+        timedOut: false,
+        spawnFailed: false,
+        signal: null,
+      };
+    } catch (error) {
+      const failure = error as ExecFileFailure;
+      if (typeof failure.code === "string") {
+        return {
+          exitCode: -1,
+          stdout: "",
+          stderr: "",
+          timedOut: false,
+          spawnFailed: true,
+          signal: null,
+        };
+      }
+      return {
+        exitCode: typeof failure.code === "number" ? failure.code : -1,
+        stdout: failure.stdout ?? "",
+        stderr: failure.stderr ?? "",
+        timedOut: failure.killed === true,
+        spawnFailed: false,
+        signal: failure.signal ?? null,
+      };
+    }
+  };
+}
+
+export interface LinuxSystemdProbeInput {
+  readonly labelId: string;
+  // Whether the unit file is on disk - the unit-state probe only runs for
+  // an installed service; the reachability probe runs regardless, because
+  // "no bus" is exactly why an install may have failed.
+  readonly unitFileInstalled: boolean;
+  readonly runner: SystemdProbeRunner;
+}
+
+/** Parse `systemctl show` `Key=Value` lines into a map. */
+function parseShowProperties(stdout: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const line of stdout.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq > 0) out.set(line.slice(0, eq).trim(), line.slice(eq + 1).trim());
+  }
+  return out;
+}
+
+export async function probeLinuxSystemdHealth(
+  input: LinuxSystemdProbeInput,
+): Promise<DoctorIssue[]> {
+  const issues: DoctorIssue[] = [];
+  const unit = `${input.labelId}.service`;
+
+  // ---- user-manager reachability ----
+  // `systemctl --user` needs a per-user manager on a session bus. On WSL
+  // without systemd, in `sudo su` shells, or SSH sessions with no logind
+  // session, every lifecycle operation fails - and before this probe, in
+  // exactly the environments where things fail, doctor had nothing to say
+  // (install errors even steer users here).
+  const reachability = await input.runner("systemctl", [
+    "--user",
+    "show-environment",
+  ]);
+  if (
+    reachability.spawnFailed ||
+    reachability.timedOut ||
+    reachability.exitCode !== 0
+  ) {
+    issues.push({
+      code: DOCTOR_ISSUE_CODES.SYSTEMD_USER_UNREACHABLE,
+      severity: "error",
+      title: "systemd user manager unreachable",
+      message:
+        "systemctl --user cannot reach a user service manager, so the host cannot be registered to start automatically. " +
+        "If this is WSL, enable systemd ('[boot]' / 'systemd=true' in /etc/wsl.conf, then 'wsl --shutdown' from Windows). " +
+        "On a headless machine, log in through a systemd session or enable lingering.",
+      fixAction: null,
+      terminalCommand: "systemctl --user status",
+      details: {
+        stderr: reachability.stderr.trim(),
+        exitCode: reachability.exitCode,
+        spawnFailed: reachability.spawnFailed,
+      },
+    });
+    // Without a reachable manager the remaining probes would only repeat
+    // the same failure.
+    return issues;
+  }
+
+  if (input.unitFileInstalled) {
+    const show = await input.runner("systemctl", [
+      "--user",
+      "show",
+      unit,
+      "-p",
+      "LoadState,ActiveState,SubState,Result,ConditionResult,ConditionTimestampMonotonic,NRestarts,ExecMainStatus,UnitFileState",
+    ]);
+    if (!show.spawnFailed && !show.timedOut && show.exitCode === 0) {
+      const props = parseShowProperties(show.stdout);
+      const loadState = props.get("LoadState") ?? "";
+      const activeState = props.get("ActiveState") ?? "";
+      const subState = props.get("SubState") ?? "";
+      // Positive-evidence guard, verified against a live systemd 255:
+      // `systemctl show` on a NOT-LOADED unit exits 0 and reports the
+      // property DEFAULTS - which include `ConditionResult=no` - and a
+      // loaded unit that has never attempted a start reports the same
+      // default with ConditionTimestampMonotonic=0. Only a start that
+      // actually evaluated the condition (non-zero timestamp, loaded
+      // unit) may report "skipped because the CLI is missing".
+      const conditionStamp = props.get("ConditionTimestampMonotonic") ?? "";
+      const conditionEvaluated =
+        loadState === "loaded" &&
+        conditionStamp !== "" &&
+        conditionStamp !== "0";
+      const conditionResult = conditionEvaluated
+        ? (props.get("ConditionResult") ?? "")
+        : "";
+
+      // A unit that landed `failed` (start-limit hit) or is cycling
+      // `auto-restart` is the exact state `service status` reads as plain
+      // "stopped" - liveness there deliberately keys off pid metadata.
+      // This is where the truth surfaces.
+      if (activeState === "failed" || subState === "auto-restart") {
+        issues.push({
+          code: DOCTOR_ISSUE_CODES.SERVICE_UNIT_FAILED,
+          severity: "error",
+          title: "Host service is failing to start",
+          message: `The systemd unit '${unit}' is ${activeState === "failed" ? "in the failed state" : "restart-looping"} (result: ${props.get("Result") ?? "unknown"}, last exit: ${props.get("ExecMainStatus") ?? "unknown"}, restarts: ${props.get("NRestarts") ?? "unknown"}). The journal has the failing start's output.`,
+          fixAction: null,
+          terminalCommand: `journalctl --user -u ${unit} -n 50 --no-pager`,
+          details: {
+            unit,
+            activeState,
+            subState,
+            result: props.get("Result") ?? null,
+            execMainStatus: props.get("ExecMainStatus") ?? null,
+            restarts: props.get("NRestarts") ?? null,
+          },
+        });
+      }
+
+      // ConditionFileIsExecutable gates the start on the CLI binary
+      // existing; `no` here means systemd skipped the last start because
+      // the binary the unit points at is gone - stranded definition.
+      if (conditionResult === "no") {
+        issues.push({
+          code: DOCTOR_ISSUE_CODES.SERVICE_START_CONDITION_UNMET,
+          severity: "error",
+          title: "Host service skipped: CLI binary missing",
+          message: `systemd skipped starting '${unit}' because the CLI binary the unit points at no longer exists or is not executable. Reinstalling the host repairs the service definition.`,
+          fixAction: "host-install",
+          terminalCommand: "traycer host install",
+          details: { unit },
+        });
+      }
+    }
+
+    // ---- linger ----
+    // Without linger the user manager - and the host with it - is torn
+    // down at last logout and only returns at next login. Enabling it is
+    // best-effort at install (polkit may refuse non-interactively); this
+    // warning is the promised follow-up surface.
+    const user = process.env.USER ?? process.env.USERNAME ?? "";
+    const lingerResult = await input.runner("loginctl", [
+      "show-user",
+      user,
+      "-p",
+      "Linger",
+    ]);
+    const linger = classifyLingerState(lingerResult, user.length > 0);
+    if (linger.kind === "observed" && !linger.enabled) {
+      issues.push({
+        code: DOCTOR_ISSUE_CODES.LINGER_DISABLED,
+        severity: "warning",
+        title: "Host stops at logout (lingering disabled)",
+        message:
+          "systemd lingering is disabled for this user, so the host is torn down at your last logout and background work stops until you log in again.",
+        fixAction: null,
+        terminalCommand: `loginctl enable-linger ${user}`,
+        details: { user },
+      });
+    }
+  }
+
+  return issues;
+}

--- a/clients/traycer-cli/src/service/platforms/__tests__/linux-install-flow.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/linux-install-flow.test.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync } from "node:fs";
+import { readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { createLinuxController, type ProcessRunner } from "../linux";
+import { serviceManifestPath, type ServiceLabel } from "../../label";
+import { ProcessRunError, type RunResult } from "../../process-runner";
+import { CLI_ERROR_CODES } from "../../../runner/errors";
+import { fileExists } from "../../install-binary";
+
+/**
+ * The systemd install FLOW - as opposed to the emitted artifact, which
+ * `linux.test.ts` executes. Three defects fixed together, each pinned here:
+ *
+ *   1. no preflight: on a box with no reachable user manager (WSL with
+ *      systemd disabled, `sudo su`, headless SSH) the old flow wrote the
+ *      unit file FIRST and then threw a raw ProcessRunError out of
+ *      `daemon-reload` - residue plus an error naming neither systemd nor
+ *      WSL;
+ *   2. no rollback: a failed daemon-reload/enable left the just-written
+ *      unit file behind as an orphan;
+ *   3. no reset-failed on uninstall: a unit that had restart-looped into
+ *      `failed` kept its failed entry in the user manager after its file
+ *      was deleted.
+ */
+
+// Same isolation as macos.test.ts: `serviceManifestPath` resolves under the
+// real home dir, and this suite exercises real writes/removals of the
+// manifest, so redirect it to a private temp dir.
+const TEST_UNIT_DIR = mkdtempSync(
+  join(tmpdir(), "traycer-linux-service-test-"),
+);
+vi.mock("../../label", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../label")>();
+  return {
+    ...actual,
+    serviceManifestPath: (label: { readonly id: string }) =>
+      join(TEST_UNIT_DIR, `${label.id}.service`),
+  };
+});
+
+const label: ServiceLabel = {
+  id: "ai.traycer.host.dev",
+  displayName: "Traycer Host (test)",
+  environment: "dev",
+  devSlot: null,
+};
+
+const unitFile = (): string => serviceManifestPath(label);
+
+interface RecordedCall {
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
+function ok(): RunResult {
+  return { stdout: "", stderr: "", exitCode: 0 };
+}
+
+function busError(command: string, args: readonly string[]): ProcessRunError {
+  return new ProcessRunError(
+    `${command} ${args.join(" ")} exited with code 1: Failed to connect to bus: No medium found`,
+    command,
+    args,
+    1,
+    "",
+    "Failed to connect to bus: No medium found",
+  );
+}
+
+/** A runner that records every call and fails those `failWhen` selects. */
+function recordingRunner(failWhen: (call: RecordedCall) => boolean): {
+  readonly calls: RecordedCall[];
+  readonly runner: ProcessRunner;
+} {
+  const calls: RecordedCall[] = [];
+  const runner: ProcessRunner = (command, args) => {
+    const call: RecordedCall = { command, args };
+    calls.push(call);
+    if (failWhen(call)) {
+      return Promise.reject(busError(command, args));
+    }
+    return Promise.resolve(ok());
+  };
+  return { calls, runner };
+}
+
+function installWith(runner: ProcessRunner): Promise<void> {
+  return createLinuxController(runner).install({
+    label,
+    cli: { command: "/usr/local/bin/traycer", args: [] },
+    enableLinger: true,
+  });
+}
+
+/** The systemctl verb (or loginctl verb) of a recorded call, for sequences. */
+function verbOf(call: RecordedCall): string {
+  return call.command === "systemctl"
+    ? (call.args[1] ?? "")
+    : `${call.command}:${call.args[0] ?? ""}`;
+}
+
+afterEach(async () => {
+  await rm(unitFile(), { force: true });
+});
+
+afterAll(async () => {
+  await rm(TEST_UNIT_DIR, { recursive: true, force: true });
+});
+
+describe("linux service install flow", () => {
+  it("refuses to install - writing NOTHING - when the user manager is unreachable, and says so", async () => {
+    const { calls, runner } = recordingRunner(
+      (call) => call.args[1] === "show-environment",
+    );
+
+    await expect(installWith(runner)).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message: expect.stringContaining("WSL"),
+    });
+    // The preflight is the FIRST thing that runs, and on failure nothing
+    // else does: no unit file, no daemon-reload attempt.
+    expect(await fileExists(unitFile())).toBe(false);
+    expect(calls.map(verbOf)).toEqual(["show-environment"]);
+  });
+
+  it("rolls the unit file back when daemon-reload fails", async () => {
+    const { runner } = recordingRunner(
+      (call) => call.args[1] === "daemon-reload",
+    );
+
+    await expect(installWith(runner)).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message: expect.stringContaining("unit file was removed"),
+    });
+    expect(await fileExists(unitFile())).toBe(false);
+  });
+
+  it("rolls the unit file back - and re-reloads - when enable --now fails", async () => {
+    const { calls, runner } = recordingRunner(
+      (call) => call.args[1] === "enable",
+    );
+
+    await expect(installWith(runner)).rejects.toMatchObject({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+    });
+    expect(await fileExists(unitFile())).toBe(false);
+    // The rollback daemon-reload runs AFTER the failed enable, so systemd
+    // forgets the removed unit rather than holding a loaded orphan.
+    expect(calls.map(verbOf)).toEqual([
+      "show-environment",
+      "daemon-reload",
+      "enable",
+      "daemon-reload",
+    ]);
+  });
+
+  it("on success runs preflight → reload → enable --now → linger and leaves the unit installed", async () => {
+    const { calls, runner } = recordingRunner(() => false);
+
+    await installWith(runner);
+
+    expect(calls.map(verbOf)).toEqual([
+      "show-environment",
+      "daemon-reload",
+      "enable",
+      "loginctl:enable-linger",
+    ]);
+    const unit = await readFile(unitFile(), "utf8");
+    expect(unit).toContain(`SyslogIdentifier=${label.id}`);
+  });
+
+  it("uninstall clears a failed unit entry after removing the file", async () => {
+    const { calls, runner } = recordingRunner(() => false);
+
+    await createLinuxController(runner).uninstall({ label });
+
+    expect(calls.map(verbOf)).toEqual([
+      "disable",
+      "daemon-reload",
+      "reset-failed",
+    ]);
+  });
+});

--- a/clients/traycer-cli/src/service/platforms/__tests__/linux.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/linux.test.ts
@@ -240,6 +240,46 @@ describe("systemd unit — scaffolding and the token guard", () => {
     expect(unit).not.toContain("--node-bin");
   });
 
+  it("names the journald stream after the label, not the /bin/sh wrapper", () => {
+    // journald's default SYSLOG_IDENTIFIER is the basename of the Exec
+    // line's first executable - `sh` - and the stdout stream opens BEFORE
+    // the wrapper exec's the CLI, so exec never renames it. Without this
+    // line every supervisor message the debugging user reads in
+    // `journalctl --user -u <unit>` is attributed to `sh[pid]`.
+    const unit = buildSystemdUnit({
+      label: labelFor("ai.traycer.host.dev"),
+      cli: { command: "/home/test/.traycer/cli/bin/traycer", args: [] },
+    });
+    expect(unit).toContain("\nSyslogIdentifier=ai.traycer.host.dev\n");
+  });
+
+  it("gates the start on the CLI binary existing, so a stranded definition goes inert instead of restart-looping", () => {
+    // A definition can outlive the CLI it points at (`apt remove
+    // traycer-cli` with the unit still enabled). Without the condition,
+    // every login exec's a missing $0 → exit 127 → Restart=on-failure loops
+    // it into a `failed` unit on every boot. With it, systemd skips the
+    // start as "condition not met": visible in status, not failing, and
+    // re-evaluated fresh by the next `systemctl start` after a reinstall.
+    const unit = buildSystemdUnit({
+      label: labelFor("ai.traycer.host.dev"),
+      cli: { command: "/home/test/.traycer/cli/bin/traycer", args: [] },
+    });
+    expect(unit).toContain(
+      "\nConditionFileIsExecutable=/home/test/.traycer/cli/bin/traycer\n",
+    );
+  });
+
+  it("omits the path condition for a non-absolute CLI command", () => {
+    // systemd rejects relative paths in Condition*= values; the self-invoke
+    // fallback can in principle yield a bare command, which must degrade to
+    // "no condition" rather than an invalid unit.
+    const unit = buildSystemdUnit({
+      label: labelFor("ai.traycer.host.dev"),
+      cli: { command: "traycer", args: [] },
+    });
+    expect(unit).not.toContain("ConditionFileIsExecutable");
+  });
+
   it("refuses to emit a unit when a CLI path carries a character systemd would mis-parse", () => {
     expect(() =>
       buildSystemdUnit({

--- a/clients/traycer-cli/src/service/platforms/linux.ts
+++ b/clients/traycer-cli/src/service/platforms/linux.ts
@@ -1,5 +1,5 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, isAbsolute } from "node:path";
 import { readHostPidMetadata } from "../../host/pid-metadata";
 import { CLI_ERROR_CODES, cliError } from "../../runner/errors";
 import { isProcessAlive } from "../../store/cli-lock";
@@ -24,31 +24,32 @@ import type {
 // silent skip if polkit would prompt - Doctor surfaces the missing
 // linger as a warning so the user can enable it later.
 
-// Linux currently doesn't use the pluggable runner test seam - the
-// systemctl/loginctl calls go straight to `runCommand`. Take the
-// argument anyway so the three platform-controller factories share one
-// signature (`createMacos|Linux|WindowsController(runner: ProcessRunner | null)`).
-// Tests on Linux can pass `null`; production callers always pass null.
+// The pluggable runner seam is live on Linux too: `null` selects the real
+// `runCommand`, tests inject a fake to drive the install/uninstall flows
+// (preflight, rollback-on-failure) without a systemd instance. Same factory
+// signature as macOS/Windows
+// (`createMacos|Linux|WindowsController(runner: ProcessRunner | null)`).
 export function createLinuxController(
-  _runner: ProcessRunner | null,
+  runner: ProcessRunner | null,
 ): ServiceController {
+  const run = runner ?? runCommand;
   return {
-    install: (options) => installService(options),
-    uninstall: (options) => uninstallService(options),
+    install: (options) => installService(options, run),
+    uninstall: (options) => uninstallService(options, run),
     status: (label) => statusService(label),
-    stop: (label) => stopService(label),
-    start: (label) => startService(label),
-    restart: (label) => restartService(label),
+    stop: (label) => stopService(label, run),
+    start: (label) => startService(label, run),
+    restart: (label) => restartService(label, run),
     // There is no Desktop/SMAppService split on Linux, so the restart halves
     // are exactly the stop and start the command already performed - the
     // named seam only exists so `host restart` has one shape on every
     // platform. `forcedRecycle` is never set: `stopService` is a real
     // systemd stop, so the unit is genuinely down before the start.
     stopForRestart: async (label) => {
-      await stopService(label);
+      await stopService(label, run);
       return { forcedRecycle: false };
     },
-    relaunchAfterRestart: (label) => startService(label),
+    relaunchAfterRestart: (label) => startService(label, run),
     // SMAppService is macOS-only, so there is no second registration path
     // that could compete with systemd's user unit here.
     retireCompetingRegistration: () =>
@@ -63,7 +64,47 @@ export function createLinuxController(
 // doesn't currently use the seam.
 export type ProcessRunner = typeof runCommand;
 
-async function installService(options: InstallServiceOptions): Promise<void> {
+/**
+ * Proves the user systemd instance is reachable BEFORE anything is written.
+ *
+ * `systemctl --user` needs a per-user service manager on a session bus, and
+ * that is exactly what does not exist on a WSL distro without systemd
+ * enabled, in a `sudo su <user>` shell, or over SSH to a box whose logind
+ * never started a user manager. The previous order wrote the unit file
+ * first and then let `daemon-reload` throw a raw `ProcessRunError`: an
+ * orphan unit file left behind, and a stack trace naming neither systemd
+ * nor WSL. Failing here fails with nothing installed and an error that
+ * says what to do.
+ */
+async function assertSystemdUserReachable(
+  label: ServiceLabel,
+  run: ProcessRunner,
+): Promise<void> {
+  try {
+    await run("systemctl", ["--user", "show-environment"], {
+      env: undefined,
+      cwd: undefined,
+      timeoutMs: 10_000,
+      tolerateNonZeroExit: false,
+    });
+  } catch (cause) {
+    throw cliError({
+      code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
+      message:
+        `the systemd user manager is not reachable, so the ${unitName(label)} service cannot be installed: ${describeCause(cause)}. ` +
+        `If this is WSL, enable systemd ('[boot]' / 'systemd=true' in /etc/wsl.conf, then 'wsl --shutdown' from Windows). ` +
+        `On a headless machine, log in through a systemd session first. Nothing was installed.`,
+      details: { unit: unitName(label), cause: describeCause(cause) },
+      exitCode: 1,
+    });
+  }
+}
+
+async function installService(
+  options: InstallServiceOptions,
+  run: ProcessRunner,
+): Promise<void> {
+  await assertSystemdUserReachable(options.label, run);
   const manifestPath = serviceManifestPath(options.label);
   await mkdir(dirname(manifestPath), { recursive: true });
   await writeFile(
@@ -73,14 +114,14 @@ async function installService(options: InstallServiceOptions): Promise<void> {
   );
   // daemon-reload picks up the new unit; enable --now both registers
   // the auto-start and starts the unit immediately.
-  await runCommand("systemctl", ["--user", "daemon-reload"], {
-    env: undefined,
-    cwd: undefined,
-    timeoutMs: 10_000,
-    tolerateNonZeroExit: false,
-  });
   try {
-    await runCommand(
+    await run("systemctl", ["--user", "daemon-reload"], {
+      env: undefined,
+      cwd: undefined,
+      timeoutMs: 10_000,
+      tolerateNonZeroExit: false,
+    });
+    await run(
       "systemctl",
       ["--user", "enable", "--now", unitName(options.label)],
       {
@@ -91,24 +132,36 @@ async function installService(options: InstallServiceOptions): Promise<void> {
       },
     );
   } catch (cause) {
+    // Roll the write back: a unit file systemd was never told about (or
+    // refused to enable) must not outlive the failed install - it would sit
+    // in ~/.config/systemd/user as an orphan that a later daemon-reload
+    // silently registers. Both cleanup steps are best-effort; the error the
+    // operator sees is the install failure, not the rollback's.
+    await rm(manifestPath, { force: true }).catch(() => undefined);
+    await run("systemctl", ["--user", "daemon-reload"], {
+      env: undefined,
+      cwd: undefined,
+      timeoutMs: 10_000,
+      tolerateNonZeroExit: true,
+    }).catch(() => undefined);
     throw cliError({
       code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
-      message: `systemctl enable --now failed for ${unitName(options.label)}: ${describeCause(cause)}`,
+      message: `systemd registration failed for ${unitName(options.label)}: ${describeCause(cause)} (the partially-written unit file was removed)`,
       details: { unit: unitName(options.label), cause: describeCause(cause) },
       exitCode: 1,
     });
   }
   if (options.enableLinger) {
-    await tryEnableLinger();
+    await tryEnableLinger(run);
   }
 }
 
-async function tryEnableLinger(): Promise<void> {
+async function tryEnableLinger(run: ProcessRunner): Promise<void> {
   const user = process.env.USER ?? process.env.USERNAME ?? "";
   if (user.length === 0) return;
   // Tolerate non-zero exit so a polkit prompt or already-enabled state
   // doesn't fail the install. Doctor flags the absence later.
-  await runCommand("loginctl", ["enable-linger", user], {
+  await run("loginctl", ["enable-linger", user], {
     env: undefined,
     cwd: undefined,
     timeoutMs: 30_000,
@@ -118,8 +171,9 @@ async function tryEnableLinger(): Promise<void> {
 
 async function uninstallService(
   options: UninstallServiceOptions,
+  run: ProcessRunner,
 ): Promise<void> {
-  await runCommand(
+  await run(
     "systemctl",
     ["--user", "disable", "--now", unitName(options.label)],
     {
@@ -130,12 +184,22 @@ async function uninstallService(
     },
   );
   await rm(serviceManifestPath(options.label), { force: true });
-  await runCommand("systemctl", ["--user", "daemon-reload"], {
+  await run("systemctl", ["--user", "daemon-reload"], {
     env: undefined,
     cwd: undefined,
     timeoutMs: 10_000,
     tolerateNonZeroExit: true,
   });
+  // A unit that ended up `failed` (e.g. it restart-looped before this
+  // uninstall) leaves a failed entry in the user manager even after its
+  // file is gone; clear it so `systemctl --user list-units` and
+  // `is-system-running` stop reporting a service that no longer exists.
+  await run("systemctl", ["--user", "reset-failed", unitName(options.label)], {
+    env: undefined,
+    cwd: undefined,
+    timeoutMs: 10_000,
+    tolerateNonZeroExit: true,
+  }).catch(() => undefined);
 }
 
 async function statusService(label: ServiceLabel): Promise<ServiceStatus> {
@@ -155,8 +219,11 @@ async function statusService(label: ServiceLabel): Promise<ServiceStatus> {
   return { state: "stopped", version: null, listenUrl: null, pid: null };
 }
 
-async function stopService(label: ServiceLabel): Promise<void> {
-  await runCommand("systemctl", ["--user", "stop", unitName(label)], {
+async function stopService(
+  label: ServiceLabel,
+  run: ProcessRunner,
+): Promise<void> {
+  await run("systemctl", ["--user", "stop", unitName(label)], {
     env: undefined,
     cwd: undefined,
     timeoutMs: 15_000,
@@ -164,9 +231,12 @@ async function stopService(label: ServiceLabel): Promise<void> {
   });
 }
 
-async function startService(label: ServiceLabel): Promise<void> {
+async function startService(
+  label: ServiceLabel,
+  run: ProcessRunner,
+): Promise<void> {
   try {
-    await runCommand("systemctl", ["--user", "start", unitName(label)], {
+    await run("systemctl", ["--user", "start", unitName(label)], {
       env: undefined,
       cwd: undefined,
       timeoutMs: 15_000,
@@ -182,9 +252,12 @@ async function startService(label: ServiceLabel): Promise<void> {
   }
 }
 
-async function restartService(label: ServiceLabel): Promise<void> {
+async function restartService(
+  label: ServiceLabel,
+  run: ProcessRunner,
+): Promise<void> {
   try {
-    await runCommand("systemctl", ["--user", "restart", unitName(label)], {
+    await run("systemctl", ["--user", "restart", unitName(label)], {
       env: undefined,
       cwd: undefined,
       timeoutMs: 15_000,
@@ -251,12 +324,31 @@ function buildUnit(options: BuildUnitOptions): string {
   const execStart = programArgs
     .map((arg) => `"${arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`)
     .join(" ");
+  // A definition can outlive the CLI it points at (the CLI package removed
+  // while the unit stays enabled). Without the condition, every login then
+  // exec's a missing $0, `Restart=on-failure` loops it into a `failed` unit
+  // on every boot, and `systemctl --user is-system-running` degrades. With
+  // it, systemd skips the start as "condition not met" - inert and visible
+  // in `systemctl --user status`, not failing. A skipped condition does not
+  // trigger Restart=, and a later `systemctl start` (the reinstall path)
+  // re-evaluates it fresh. Conditions require absolute paths; the CLI
+  // command always is one in production (guarded here for the self-invoke
+  // fallback).
+  const condition = isAbsolute(options.cli.command)
+    ? `ConditionFileIsExecutable=${options.cli.command}\n`
+    : "";
+  // SyslogIdentifier: journald names a stream after the FIRST executable of
+  // the Exec line - /bin/sh - and the stream is opened before the wrapper
+  // exec's the CLI, so without this every supervisor line lands in the
+  // journal as `sh[pid]`. The label id keys the lines to the exact
+  // service instance (`journalctl --user -t ai.traycer.host`).
   return `[Unit]
 Description=${options.label.displayName}
 After=default.target
-
+${condition}
 [Service]
 Type=simple
+SyslogIdentifier=${options.label.id}
 ExecStart=${execStart}
 Restart=on-failure
 RestartSec=5


### PR DESCRIPTION
## Problem

A proactive sweep of the Linux host-lifecycle surface found four defects in the systemd path — the same audit that produced the macOS launcher fix (#790). All four are the "host doesn't come up reliably / fails without evidence" class this refactor exists to end.

1. **Journal misattribution**: no `SyslogIdentifier=`, so journald names the stream after the Exec line's first executable — `/bin/sh` — and the stream opens before the wrapper `exec`s the CLI. Every supervisor line in `journalctl --user -u ai.traycer.host.service` read `sh[pid]: …`.
2. **No systemd preflight**: on a box with no reachable user manager (WSL with systemd disabled, `sudo su`, headless SSH), install wrote the unit file FIRST, then threw a raw `ProcessRunError` from `daemon-reload` — orphan residue plus an error naming neither systemd nor WSL.
3. **No rollback**: a failed `daemon-reload`/`enable` left the just-written unit file behind as an orphan.
4. **Stranded definitions restart-looped**: a unit whose CLI is gone (CLI package removed with the unit still enabled) exec'd a missing `$0` at every login → exit 127 → `Restart=on-failure` → a **failed unit on every boot**, degrading `systemctl --user is-system-running`.

## Fix

- `SyslogIdentifier=<label.id>` in the emitted unit.
- Install preflights `systemctl --user show-environment` **before writing anything** and fails with a wrapped `SERVICE_INSTALL_FAILED` explaining WSL/headless remediation. Nothing is installed on failure.
- `daemon-reload`/`enable --now` failures roll the unit file back and re-reload — a failed install leaves nothing.
- `ConditionFileIsExecutable=<cli>` gates the start: a stranded definition goes **inert and visible** ("condition not met") instead of failing every boot; `systemctl start` after a reinstall re-evaluates it fresh. Uninstall additionally runs `reset-failed` so a previously-failed entry doesn't outlive its file.
- The pluggable runner seam the factory always accepted is now actually wired on Linux (it was documented as unused), which is what the new install-flow tests run through.

## Live verification (Ubuntu 24.04 VM, systemd 255, real emitted unit)

- `SYSLOG_IDENTIFIER=ai.traycer.host.vmtest` in `journalctl -o verbose`; journal lines attributed to the label, `ps` shows no resident `sh` (both arms `exec`).
- N-1 chain executed correctly through the real unit (`args: host start`, no label flag to an N-1 CLI).
- CLI removed → `start` exit 0, `ConditionResult=no`, unit `inactive/dead`, `is-system-running` stays `running`. CLI restored → unit runs again.
- No-bus probe: `Failed to connect to bus` / exit 1 — exactly the signal the preflight wraps.
- **The probe caught a real bug**: the first spelling, `ConditionPathIsExecutable`, does not exist — systemd silently ignores unknown condition keys, leaving the restart loop intact, and every unit test stayed green. The shipped directive is the real `ConditionFileIsExecutable`, verified skipping and re-arming live.

## Tests

CLI suite 1120 passed. New: 5 install-flow rows (preflight refusal writes nothing; rollback on reload/enable failure with call-sequence pins; success sequence; uninstall reset-failed) + 3 emitter rows. SyslogIdentifier and preflight arms mutation-probed — each neutering reddened exactly the intended rows.


## Second commit: doctor Linux probes

Doctor had **zero** Linux probes (platform sections were darwin/win32 only) while `linux.ts` promised "Doctor surfaces the missing linger as a warning" — and install failures steer users to doctor. New `systemd-health.ts` probe module (launchd-wedge philosophy: read actual run state, positive evidence only, silent when healthy):

- **SYSTEMD_USER_UNREACHABLE** (error): no reachable user manager — WSL guidance inline; follow-on probes skipped.
- **SERVICE_UNIT_FAILED** (error): unit `failed`/`auto-restart` — the state `service status` deliberately reads as plain "stopped" (liveness keys off pid metadata by design) — with Result/last-exit/restarts and the exact `journalctl` command.
- **SERVICE_START_CONDITION_UNMET** (error): start skipped because the CLI binary is gone; fixAction `host-install`.
- **LINGER_DISABLED** (warning): host torn down at last logout; `loginctl enable-linger` command included.

Live-probing systemd 255 caught a second trap: `systemctl show` of a **not-loaded** unit exits 0 with property defaults *including* `ConditionResult=no`, and a never-started loaded unit reports the same with `ConditionTimestampMonotonic=0`. The condition arm requires positive evidence (LoadState=loaded + non-zero condition timestamp); a fixture row pins those defaults staying silent.

8 fixture rows, auto-restart arm mutation-probed. Doctor suite 64 passed, CLI suite 1128 passed.
