### PR TITLE
fix(cli): Windows task identity and lifecycle hygiene (Author, folder residue, VBS rollback, WSH probe)

### DIFF
--- a/clients/traycer-cli/src/doctor/engine.ts
+++ b/clients/traycer-cli/src/doctor/engine.ts
@@ -462,6 +462,21 @@ export async function runDoctor(opts: RunDoctorOptions): Promise<DoctorResult> {
     if (aclIssue !== null) issues.push(aclIssue);
   }
 
+  // ---- 5b. Windows Script Host policy ----
+  // The scheduled task launches the host through wscript.exe. With the WSH
+  // Enabled=0 policy set (common enterprise hardening), the launcher never
+  // executes and nothing surfaces - probed live: `//B` suppresses even the
+  // block dialog, so the host silently never starts at login. Install-time
+  // verification can't see a policy applied later; this can.
+  if (
+    process.platform === "win32" &&
+    serviceStatus !== null &&
+    serviceStatus.state !== "not-installed"
+  ) {
+    const wshIssue = probeWindowsScriptHostPolicy();
+    if (wshIssue !== null) issues.push(wshIssue);
+  }
+
   // ---- 6. Recent bootstrap markers ----
   const recentMarkers = await readBootstrapMarkers(opts.environment, 20);
   const recentCrash = lastCrashMarker(recentMarkers);
@@ -575,6 +590,48 @@ function formatMarkerMessage(entry: BootstrapLogEntry): string {
 // principal other than the file owner / well-known system principals
 // has read access. Returns null when the file is owner-only or when
 // the probe itself fails (icacls missing, transient error).
+/**
+ * Reads the Windows Script Host Enabled policy from both hives. `0` in
+ * either disables wscript.exe for this user, which kills the host's
+ * scheduled-task launch chain silently. HKCU wins over HKLM only in the
+ * sense that EITHER being 0 blocks; a missing value means enabled.
+ */
+function probeWindowsScriptHostPolicy(): DoctorIssue | null {
+  const disabledIn: string[] = [];
+  for (const hive of ["HKLM", "HKCU"]) {
+    let stdout: string;
+    try {
+      stdout = execFileSync(
+        "reg",
+        [
+          "query",
+          `${hive}\\Software\\Microsoft\\Windows Script Host\\Settings`,
+          "/v",
+          "Enabled",
+        ],
+        { encoding: "utf8", windowsHide: true, timeout: 5000 },
+      );
+    } catch {
+      // Key or value absent - WSH enabled by default.
+      continue;
+    }
+    if (/Enabled\s+REG_DWORD\s+0x0\b/i.test(stdout)) disabledIn.push(hive);
+  }
+  if (disabledIn.length === 0) return null;
+  return {
+    code: DOCTOR_ISSUE_CODES.WINDOWS_SCRIPT_HOST_DISABLED,
+    severity: "error",
+    title: "Windows Script Host is disabled by policy",
+    message:
+      `The host's scheduled task starts through wscript.exe, and the Windows Script Host Enabled=0 policy is set in ${disabledIn.join(" and ")}. ` +
+      "The launcher never executes and nothing surfaces an error, so the host silently never starts at login. " +
+      "Remove the policy (or have your administrator exempt this machine) to restore host auto-start.",
+    fixAction: null,
+    terminalCommand: `reg query "${disabledIn[0]}\\Software\\Microsoft\\Windows Script Host\\Settings" /v Enabled`,
+    details: { disabledIn },
+  };
+}
+
 async function probeWindowsCredentialsAcl(
   environment: Environment,
 ): Promise<DoctorIssue | null> {

--- a/clients/traycer-cli/src/doctor/issues.ts
+++ b/clients/traycer-cli/src/doctor/issues.ts
@@ -56,6 +56,14 @@ export const DOCTOR_ISSUE_CODES = {
   // Doctor surfaces this so VDI/shared-machine users can lock the
   // file down manually until we add per-user ACL hardening.
   WINDOWS_CREDENTIALS_ACL_PERMISSIVE: "WINDOWS_CREDENTIALS_ACL_PERMISSIVE",
+  // Windows-only: the host's Scheduled Task launches through Windows
+  // Script Host (wscript.exe), and enterprise hardening commonly disables
+  // WSH via the registry Enabled=0 policy. Probed live: with the policy
+  // set, the launcher never executes and NOTHING surfaces (`//B` batch
+  // mode suppresses the block dialog) - the host silently never starts at
+  // login. A policy applied after install is invisible to install-time
+  // verification, so doctor is the surface that has to say it.
+  WINDOWS_SCRIPT_HOST_DISABLED: "WINDOWS_SCRIPT_HOST_DISABLED",
 } as const;
 
 export type DoctorIssueCode =

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  buildScheduledTaskXml,
   buildWindowsSlotProcessScanScript,
   createWindowsController,
   parseSchtasksLastRunResult,
@@ -225,6 +226,35 @@ describe("Windows service stale host cleanup", () => {
     await controller.stop(serviceLabelFor("staging"));
 
     expect(mocks.removeHostPidMetadata).toHaveBeenCalledWith("staging");
+  });
+});
+
+describe("Scheduled Task XML identity", () => {
+  it("names Traycer as the task Author", () => {
+    // Probed live on Windows 11: a task registered from this XML without an
+    // <Author> shows `Author: N/A` in `schtasks /Query /V` and in the Task
+    // Scheduler UI - anonymous provenance for the one entry that starts a
+    // background process at every login. Same defect class as the macOS
+    // "sh from Unknown Developer" login item, one field cheaper to fix.
+    const prevDomain = process.env.USERDOMAIN;
+    const prevUser = process.env.USERNAME;
+    process.env.USERDOMAIN = "TESTBOX";
+    process.env.USERNAME = "testuser";
+    try {
+      const xml = buildScheduledTaskXml({
+        label: serviceLabelFor("staging"),
+        cli: {
+          command: "C:\\Users\\test\\.traycer\\cli\\bin\\traycer.exe",
+          args: [],
+        },
+      });
+      expect(xml).toContain("<Author>Traycer</Author>");
+    } finally {
+      if (prevDomain === undefined) delete process.env.USERDOMAIN;
+      else process.env.USERDOMAIN = prevDomain;
+      if (prevUser === undefined) delete process.env.USERNAME;
+      else process.env.USERNAME = prevUser;
+    }
   });
 });
 

--- a/clients/traycer-cli/src/service/platforms/windows.ts
+++ b/clients/traycer-cli/src/service/platforms/windows.ts
@@ -162,6 +162,14 @@ async function installService(
       },
     );
   } catch (cause) {
+    // Roll the launcher back: `stageTaskDefinition` wrote the persistent
+    // VBS before /Create ran, and a launcher without a task is an orphan
+    // that outlives the failed install (only a later uninstall would
+    // collect it). Best-effort - the error the operator sees is the
+    // install failure, not the rollback's.
+    await rm(hiddenHostLauncherPath(options.label), { force: true }).catch(
+      () => undefined,
+    );
     throw cliError({
       code: CLI_ERROR_CODES.SERVICE_INSTALL_FAILED,
       message: `schtasks /Create failed for ${taskName}: ${describeCause(cause)}`,
@@ -198,6 +206,30 @@ async function uninstallService(
     tolerateNonZeroExit: true,
   });
   await rm(hiddenHostLauncherPath(options.label), { force: true });
+  // `schtasks /Delete` removes only the task; the `\Traycer` FOLDER it was
+  // auto-created in stays behind forever (probed live on Windows 11: the
+  // empty folder remains visible in Task Scheduler Library - and folders
+  // show even though the task itself was hidden). schtasks has no verb for
+  // folders, so ask the Schedule.Service COM API - and ONLY when the
+  // folder is genuinely empty: other environments' tasks (`Host-Dev`,
+  // `Host-Staging`) live in the same folder and must survive this
+  // uninstall. Best-effort: a missing folder or denied delete changes
+  // nothing about the uninstall's outcome.
+  await run(
+    "powershell",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "$s=New-Object -ComObject Schedule.Service;$s.Connect();$f=$s.GetFolder('\\Traycer');if((@($f.GetTasks(1)).Count -eq 0) -and (@($f.GetFolders(0)).Count -eq 0)){$s.GetFolder('\\').DeleteFolder('Traycer',0)}",
+    ],
+    {
+      env: undefined,
+      cwd: undefined,
+      timeoutMs: 30_000,
+      tolerateNonZeroExit: true,
+    },
+  ).catch(() => undefined);
   // Same rationale as stopService: the force-kill above skips the host's
   // graceful pid.json cleanup, and metadata surviving an uninstall reads as
   // a crashed (rather than removed) host to anything that finds it later.
@@ -718,6 +750,7 @@ function buildTaskXml(options: BuildTaskXmlOptions): string {
   return `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
+    <Author>Traycer</Author>
     <Description>${escapeXml(options.label.displayName)}</Description>
   </RegistrationInfo>
   <Triggers>


### PR DESCRIPTION
## Problem

The proactive lifecycle sweep (same audit as #790 / #792) found four Windows defects. Every OS-behavioral claim below was **probed live on a Windows 11 VM** by registering tasks from the real emitter's XML — no live-Windows CI leg exists, so probing was the only way to settle them.

1. **Anonymous task provenance**: the emitted XML had no `<Author>`, so `schtasks /Query /V` and the Task Scheduler UI showed `Author: N/A` for the one entry that starts a background process at every login. Same class as the macOS "sh from Unknown Developer" login item.
2. **Scheduler folder residue**: `schtasks /Delete` removes only the task; the auto-created `\Traycer` folder stayed behind forever — and folders are visible in the Library even though the task itself is `<Hidden>`.
3. **Orphan launcher on failed install**: the persistent `host-start-hidden.vbs` is written before `/Create`; a create failure cleaned only the staged XML, leaving the VBS behind until some later uninstall.
4. **WSH kill-switch is silent**: with the enterprise `Windows Script Host / Enabled=0` registry policy set, the launcher **never executes and nothing surfaces** — probed live: `//B` suppresses even the block dialog. A policy applied *after* install is invisible to install-time `/Run` verification; the host just never starts at login again.

## Fix

- `<Author>Traycer</Author>` in `RegistrationInfo` — verified live: the column now reads `Traycer`.
- Uninstall removes the `\Traycer` folder via the `Schedule.Service` COM API, **only when genuinely empty** — other environments' tasks (`Host-Dev`, `Host-Staging`) share the folder and must survive. Both arms verified live: folder kept while a task remains; deleted once empty. Best-effort (tolerated + caught).
- The `/Create` failure path rolls the launcher VBS back, mirroring #792's Linux unit-file rollback.
- Doctor gains **WINDOWS_SCRIPT_HOST_DISABLED** (error), reading `Enabled` from both HKLM and HKCU, only when a service registration exists, with the remediation named. Counterpart of #792's `SYSTEMD_USER_UNREACHABLE`.

## Verification

- Live on Windows 11 (VM): Author renders; folder-cleanup both arms; WSH policy probe scenario (policy set → launcher silent no-op, marker file never created; policy removed → runs again). The VM was restored to its pre-probe state (policy deleted, probe task/folder/files removed).
- CLI suite 1124 passed (one known flake passed on rerun); new Author pin in windows.test.ts; compile green.
