### PR TITLE
fix(gui): un-strand host-scoped queries after a host stall

### DIFF
--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-error-retry.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-error-retry.test.tsx
@@ -73,29 +73,27 @@ describe("terminal sidebar error-state Retry", () => {
   });
 
   it("shows the error with a Retry button that refetches the list", () => {
-    const { getByTestId } = render(
+    const { getByRole, getByText } = render(
       wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
     );
 
-    expect(getByTestId("epic-terminal-sidebar-error").textContent).toContain(
-      "WebSocket dial timed out after 10000ms",
-    );
+    getByText("WebSocket dial timed out after 10000ms");
 
-    const retry = getByTestId("epic-terminal-sidebar-retry");
-    expect(retry.textContent).toContain("Retry");
+    const retry = getByRole("button", { name: "Retry" });
     fireEvent.click(retry);
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 
   it("disables Retry while the refetch is in flight, keeping the label", () => {
     listState.isFetching = true;
-    const { getByTestId } = render(
+    const { getByRole } = render(
       wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
     );
 
-    const retry = getByTestId("epic-terminal-sidebar-retry");
+    // The accessible name stays "Retry" mid-flight - the spinner is
+    // `aria-hidden`, so the label never swaps to "Retrying...".
+    const retry = getByRole("button", { name: "Retry" });
     expect(retry).toHaveProperty("disabled", true);
-    expect(retry.textContent).toContain("Retry");
     fireEvent.click(retry);
     expect(refetch).not.toHaveBeenCalled();
   });

--- a/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-error-retry.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/__tests__/terminal-sidebar-error-retry.test.tsx
@@ -1,0 +1,102 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { SnapshotLoadingProvider } from "@/components/epic-canvas/snapshots/snapshot-loading-context";
+
+const TAB_ID = "tab-1";
+
+const refetch = vi.fn();
+const listState = vi.hoisted<{ isFetching: boolean }>(() => ({
+  isFetching: false,
+}));
+
+vi.mock("@/lib/host", () => ({
+  useHostClient: () => null,
+}));
+
+vi.mock("@/hooks/host/use-reactive-active-host-id", () => ({
+  useReactiveActiveHostId: () => "host-1",
+}));
+
+// The stranded state this guards: `terminal.list` errored (transport already
+// retried), no automatic refetch route exists, and the panel must offer a
+// manual way back.
+vi.mock("@/hooks/terminal/use-terminal-list-query", () => ({
+  useTerminalList: () => ({
+    data: undefined,
+    isPending: false,
+    isError: true,
+    isFetching: listState.isFetching,
+    error: new Error("WebSocket dial timed out after 10000ms"),
+    refetch,
+  }),
+}));
+
+vi.mock("@/hooks/terminal/use-terminal-kill-mutation", () => ({
+  useTerminalKill: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/terminal/use-terminal-rename-mutation", () => ({
+  useTerminalRename: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+import { TerminalsPanelBody } from "../epic-terminal-sidebar";
+
+function wrapper(node: ReactNode): ReactNode {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <SnapshotLoadingProvider
+          value={{ snapshotLoaded: true, snapshotFetchError: null }}
+        >
+          {node}
+        </SnapshotLoadingProvider>
+      </TooltipProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("terminal sidebar error-state Retry", () => {
+  beforeEach(() => {
+    refetch.mockClear();
+    listState.isFetching = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the error with a Retry button that refetches the list", () => {
+    const { getByTestId } = render(
+      wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
+    );
+
+    expect(getByTestId("epic-terminal-sidebar-error").textContent).toContain(
+      "WebSocket dial timed out after 10000ms",
+    );
+
+    const retry = getByTestId("epic-terminal-sidebar-retry");
+    expect(retry.textContent).toContain("Retry");
+    fireEvent.click(retry);
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Retry while the refetch is in flight, keeping the label", () => {
+    listState.isFetching = true;
+    const { getByTestId } = render(
+      wrapper(<TerminalsPanelBody epicId="epic-1" tabId={TAB_ID} />),
+    );
+
+    const retry = getByTestId("epic-terminal-sidebar-retry");
+    expect(retry).toHaveProperty("disabled", true);
+    expect(retry.textContent).toContain("Retry");
+    fireEvent.click(retry);
+    expect(refetch).not.toHaveBeenCalled();
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
+++ b/clients/gui-app/src/components/epic-canvas/sidebar/epic-terminal-sidebar.tsx
@@ -108,6 +108,14 @@ function TerminalsPanelBodyLive(props: {
   const { epicId, tabId } = props;
   const hostClient = useHostClient();
   const list = useTerminalList({ kind: "epic", epicId }, hostClient);
+  // Manual escape hatch for a stranded error state: host-scoped queries get
+  // no automatic retry/refetch routes (transport already retried), so without
+  // this the only recoveries are accidental (collapse/re-expand remounts the
+  // body) or the stream-driven `availability-recovered` invalidation.
+  const refetchList = list.refetch;
+  const retryList = useCallback(() => {
+    void refetchList();
+  }, [refetchList]);
   const navigateNested = useEpicNestedFocusNavigation();
   const prepareOpenTileInTabFocusTarget = useEpicCanvasStore(
     (s) => s.prepareOpenTileInTabFocusTarget,
@@ -161,6 +169,8 @@ function TerminalsPanelBodyLive(props: {
             isLoading={list.isPending}
             isError={list.isError}
             errorMessage={list.error?.message ?? null}
+            isRetrying={list.isFetching}
+            onRetry={retryList}
             sessions={sessions}
             epicId={epicId}
             tabId={tabId}
@@ -188,6 +198,8 @@ interface TerminalSidebarBodyProps {
   readonly isLoading: boolean;
   readonly isError: boolean;
   readonly errorMessage: string | null;
+  readonly isRetrying: boolean;
+  readonly onRetry: () => void;
   readonly sessions: ReadonlyArray<CanonicalTerminalSessionInfo>;
   readonly epicId: string;
   readonly tabId: string;
@@ -211,22 +223,41 @@ function TerminalSidebarBody(props: TerminalSidebarBodyProps) {
   if (props.isError) {
     return (
       <div
-        className="flex items-center gap-2 px-2 py-1.5 text-ui-sm text-destructive"
+        className="flex flex-col gap-2 px-2 py-1.5 text-ui-sm text-destructive"
         data-testid="epic-terminal-sidebar-error"
       >
-        <span className="min-w-0 flex-1">
+        <span className="min-w-0">
           {props.errorMessage ?? "Failed to load terminals."}
         </span>
-        <ReportIssueAction
-          context={createReportIssueContext({
-            title: "Failed to load terminals",
-            message: "The terminal list could not be loaded.",
-            code: null,
-            source: "Terminals",
-          })}
-          presentation="icon"
-          className="text-current"
-        />
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={props.isRetrying}
+            data-testid="epic-terminal-sidebar-retry"
+            onClick={props.onRetry}
+          >
+            {props.isRetrying ? (
+              <AgentSpinningDots
+                className="shrink-0"
+                testId={undefined}
+                variant={undefined}
+              />
+            ) : null}
+            Retry
+          </Button>
+          <ReportIssueAction
+            context={createReportIssueContext({
+              title: "Failed to load terminals",
+              message: "The terminal list could not be loaded.",
+              code: null,
+              source: "Terminals",
+            })}
+            presentation="icon"
+            className="text-current"
+          />
+        </div>
       </div>
     );
   }

--- a/clients/gui-app/src/lib/host/__tests__/availability-recovery.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/availability-recovery.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { wireAvailabilityRecovery } from "../availability-recovery";
+
+function harness(nowValue: { value: number }) {
+  let listener: (() => void) | null = null;
+  const dispose = vi.fn();
+  const notify = vi.fn();
+  const unsubscribe = wireAvailabilityRecovery({
+    wsStreamClient: {
+      subscribeAvailabilityRecovered: (l) => {
+        listener = l;
+        return dispose;
+      },
+    },
+    target: { notifyAvailabilityRecovered: notify },
+    cooldownMs: 10_000,
+    now: () => nowValue.value,
+  });
+  return {
+    notify,
+    dispose,
+    unsubscribe,
+    emit: (): void => {
+      if (listener === null) {
+        throw new Error("evidence listener was never subscribed");
+      }
+      listener();
+    },
+  };
+}
+
+describe("wireAvailabilityRecovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("notifies on the leading edge and coalesces a burst inside the cooldown", () => {
+    const now = { value: 1_000 };
+    const h = harness(now);
+
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+
+    // A burst: every open session observes the same recovery within ms.
+    now.value = 1_050;
+    h.emit();
+    now.value = 5_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+
+    // Past the cooldown a fresh recovery notifies again immediately.
+    now.value = 11_000;
+    vi.runAllTimers();
+    now.value = 25_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(3);
+  });
+
+  it("delivers a suppressed emission at the cooldown's trailing edge instead of dropping it", () => {
+    const now = { value: 1_000 };
+    const h = harness(now);
+
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+
+    // A DISTINCT second recovery episode 3s later: the host stalled again
+    // and came back. Its newly-stranded queries have no other automatic
+    // signal, so the gate must defer this notify, not swallow it.
+    now.value = 4_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+
+    now.value = 11_000;
+    vi.advanceTimersByTime(7_000);
+    expect(h.notify).toHaveBeenCalledTimes(2);
+
+    // Only ONE trailing notify however many emissions were suppressed.
+    vi.runAllTimers();
+    expect(h.notify).toHaveBeenCalledTimes(2);
+  });
+
+  it("a clock rollback resets the gate rather than suppressing under a future watermark", () => {
+    const now = { value: 100_000 };
+    const h = harness(now);
+
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+
+    // The wall clock steps backwards (NTP adjustment). Without the reset the
+    // watermark sits in the future and suppresses real evidence.
+    now.value = 50_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(2);
+  });
+
+  it("disposing cancels an armed trailing notify and the transport subscription", () => {
+    const now = { value: 1_000 };
+    const h = harness(now);
+
+    h.emit();
+    now.value = 4_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+
+    h.unsubscribe();
+    expect(h.dispose).toHaveBeenCalledTimes(1);
+    vi.runAllTimers();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/gui-app/src/lib/host/__tests__/availability-recovery.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/availability-recovery.test.ts
@@ -96,6 +96,44 @@ describe("wireAvailabilityRecovery", () => {
     expect(h.notify).toHaveBeenCalledTimes(2);
   });
 
+  it("a leading edge taken while a catch-up is armed cancels it instead of notifying twice", () => {
+    const now = { value: 1_000 };
+    const h = harness(now);
+
+    h.emit();
+    now.value = 4_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+
+    // The event loop stalls - this feature's own scenario. The injected clock
+    // moves past the cooldown while the armed timer is still overdue, so the
+    // next evidence message is dispatched BEFORE the timer it already owes.
+    now.value = 20_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(2);
+
+    // The superseded catch-up must not fire a duplicate invalidation.
+    vi.runAllTimers();
+    expect(h.notify).toHaveBeenCalledTimes(2);
+  });
+
+  it("a clock rollback with a catch-up armed notifies once, not twice", () => {
+    const now = { value: 100_000 };
+    const h = harness(now);
+
+    h.emit();
+    now.value = 103_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(1);
+
+    now.value = 50_000;
+    h.emit();
+    expect(h.notify).toHaveBeenCalledTimes(2);
+
+    vi.runAllTimers();
+    expect(h.notify).toHaveBeenCalledTimes(2);
+  });
+
   it("disposing cancels an armed trailing notify and the transport subscription", () => {
     const now = { value: 1_000 };
     const h = harness(now);

--- a/clients/gui-app/src/lib/host/__tests__/durable-stream-transport.test.ts
+++ b/clients/gui-app/src/lib/host/__tests__/durable-stream-transport.test.ts
@@ -37,6 +37,7 @@ const AUTH: StreamAuthRevalidator = {
 
 function buildParams(closeWs: () => void) {
   const order: string[] = [];
+  let availabilityListener: (() => void) | null = null;
   const fakeWs = {
     close: vi.fn(() => {
       order.push("ws");
@@ -44,11 +45,22 @@ function buildParams(closeWs: () => void) {
     }),
     reconnectAll: vi.fn(),
     notifyBearerRotated: vi.fn(),
+    subscribeAvailabilityRecovered: vi.fn((listener: () => void) => {
+      availabilityListener = listener;
+      return () => {
+        availabilityListener = null;
+      };
+    }),
   };
   mocks.buildHostStreamClient.mockReturnValue(fakeWs);
+  const notifyAvailabilityRecovered = vi.fn();
   return {
     order,
     fakeWs,
+    notifyAvailabilityRecovered,
+    fireAvailabilityRecovered: (): void => {
+      availabilityListener?.();
+    },
     params: {
       endpoint: () => null,
       bearer: () => null,
@@ -61,6 +73,7 @@ function buildParams(closeWs: () => void) {
       },
       // No endpoint ever moves in these assembly tests; return a no-op disposer.
       subscribeEndpointChange: () => () => undefined,
+      notifyAvailabilityRecovered,
     },
   };
 }
@@ -148,9 +161,32 @@ describe("openDurableStreamTransport", () => {
     expect(order).toEqual(["bearer", "ws"]);
   });
 
+  it("wires the transport's recovery evidence to the bound-host notify callback", () => {
+    const built = buildParams(() => undefined);
+    mocks.subscribeStreamWakeReconnect.mockReturnValue(() => undefined);
+
+    const transport = openDurableStreamTransport(built.params);
+
+    // Evidence from THIS transport's heartbeat reaches the caller's notify -
+    // this is the only wiring that covers a tab bound to a non-active host.
+    expect(built.fakeWs.subscribeAvailabilityRecovered).toHaveBeenCalledTimes(
+      1,
+    );
+    built.fireAvailabilityRecovered();
+    expect(built.notifyAvailabilityRecovered).toHaveBeenCalledTimes(1);
+
+    transport.close();
+    built.fireAvailabilityRecovered();
+    expect(built.notifyAvailabilityRecovered).toHaveBeenCalledTimes(1);
+  });
+
   it("re-dials at once when the host's dialable endpoint moves, not on benign re-emits", () => {
     const reconnectAll = vi.fn();
-    const fakeWs = { close: vi.fn(), reconnectAll };
+    const fakeWs = {
+      close: vi.fn(),
+      reconnectAll,
+      subscribeAvailabilityRecovered: () => () => undefined,
+    };
     mocks.buildHostStreamClient.mockReturnValue(fakeWs);
     mocks.subscribeStreamWakeReconnect.mockReturnValue(() => undefined);
 
@@ -167,6 +203,7 @@ describe("openDurableStreamTransport", () => {
         fireDirectoryChange = onChange;
         return () => undefined;
       },
+      notifyAvailabilityRecovered: () => undefined,
     };
 
     const transport = openDurableStreamTransport(params);

--- a/clients/gui-app/src/lib/host/availability-recovery.ts
+++ b/clients/gui-app/src/lib/host/availability-recovery.ts
@@ -1,0 +1,94 @@
+import { appLogger } from "@/lib/logger";
+
+/**
+ * Bridges stream-transport recovery evidence onto the query layer.
+ *
+ * `HostClient.notifyAvailabilityRecovered()` is the designed escape hatch for
+ * host-scoped queries stranded in a permanent error state (every automatic
+ * TanStack recovery route is deliberately disabled for host RPCs - transport
+ * retries already ran, no polling, no focus/reconnect refetch). This module
+ * gives it its production callers: the app-wide `WsStreamClient` heartbeats
+ * against the ACTIVE host, and every durable per-tab transport heartbeats its
+ * BOUND host, so their availability evidence (a session re-opening after a
+ * drop, or a pong landing after a stall-length gap) is exactly the "endpoint
+ * recovered" signal the method's contract asks for. Without this, a host
+ * event-loop stall that outlives the unary dial+retry budget leaves panels
+ * (terminals, git-diff, file-tree) errored forever with no path back.
+ */
+
+/**
+ * Minimum spacing between two notify calls from one wiring. When a stall
+ * clears, every open stream session observes recovery within milliseconds of
+ * each other; the first notification refetches all active host-scoped
+ * queries, so the follow-ups inside the window add nothing but refetch churn.
+ */
+export const AVAILABILITY_RECOVERY_COOLDOWN_MS = 10_000;
+
+export interface AvailabilityEvidenceSource {
+  subscribeAvailabilityRecovered(listener: () => void): () => void;
+}
+
+export interface AvailabilityRecoveryTarget {
+  notifyAvailabilityRecovered(): void;
+}
+
+/**
+ * Subscribes `target` to the stream client's recovery evidence, cooldown-
+ * coalesced. Returns a disposer that also cancels any armed trailing notify.
+ * `now` is injected so tests control the clock.
+ *
+ * The gate is leading-edge WITH a trailing catch-up: evidence outside the
+ * cooldown notifies immediately; evidence inside it arms ONE deferred notify
+ * at window end instead of being dropped. The trailing half matters because a
+ * suppressed emission can be a DISTINCT second recovery episode (stall →
+ * recover → notify, then stall again → recover at t+3s) whose newly-stranded
+ * queries have no other automatic signal - swallowing it would strand them
+ * until the next stall. A backwards `now` step (clock adjustment) resets the
+ * gate rather than suppressing under a future-dated watermark.
+ */
+export function wireAvailabilityRecovery(args: {
+  readonly wsStreamClient: AvailabilityEvidenceSource;
+  readonly target: AvailabilityRecoveryTarget;
+  readonly cooldownMs: number;
+  readonly now: () => number;
+}): () => void {
+  let lastNotifiedAt: number | null = null;
+  let trailingTimer: number | null = null;
+  const notify = (): void => {
+    lastNotifiedAt = args.now();
+    appLogger.info(
+      "[stream] host availability recovered - refetching host-scoped queries",
+      {},
+    );
+    args.target.notifyAvailabilityRecovered();
+  };
+  const disposeEvidence = args.wsStreamClient.subscribeAvailabilityRecovered(
+    () => {
+      const at = args.now();
+      if (lastNotifiedAt !== null && at < lastNotifiedAt) {
+        lastNotifiedAt = null;
+      }
+      if (lastNotifiedAt === null || at - lastNotifiedAt >= args.cooldownMs) {
+        notify();
+        return;
+      }
+      if (trailingTimer !== null) {
+        return;
+      }
+      trailingTimer = window.setTimeout(
+        () => {
+          trailingTimer = null;
+          notify();
+        },
+        args.cooldownMs - (at - lastNotifiedAt),
+      );
+    },
+  );
+  return () => {
+    disposeEvidence();
+    if (trailingTimer !== null) {
+      window.clearTimeout(trailingTimer);
+      trailingTimer = null;
+    }
+  };
+}

--- a/clients/gui-app/src/lib/host/availability-recovery.ts
+++ b/clients/gui-app/src/lib/host/availability-recovery.ts
@@ -44,7 +44,9 @@ export interface AvailabilityRecoveryTarget {
  * recover → notify, then stall again → recover at t+3s) whose newly-stranded
  * queries have no other automatic signal - swallowing it would strand them
  * until the next stall. A backwards `now` step (clock adjustment) resets the
- * gate rather than suppressing under a future-dated watermark.
+ * gate rather than suppressing under a future-dated watermark. Whenever the
+ * leading edge is taken, any armed catch-up is cancelled, so the two halves
+ * can never both deliver the same episode.
  */
 export function wireAvailabilityRecovery(args: {
   readonly wsStreamClient: AvailabilityEvidenceSource;
@@ -55,6 +57,17 @@ export function wireAvailabilityRecovery(args: {
   let lastNotifiedAt: number | null = null;
   let trailingTimer: number | null = null;
   const notify = (): void => {
+    // Any notify supersedes an armed catch-up: the trailing timer exists only
+    // to deliver an episode that was suppressed, and this call just delivered
+    // one. Two paths reach the leading edge with a timer still armed - a clock
+    // rollback resetting the gate, and (in this feature's own scenario) a
+    // stalled event loop dispatching an evidence message before the timer it
+    // already owes. Leaving the timer armed fires a duplicate invalidation
+    // moments later, which is exactly the churn the cooldown exists to stop.
+    if (trailingTimer !== null) {
+      window.clearTimeout(trailingTimer);
+      trailingTimer = null;
+    }
     lastNotifiedAt = args.now();
     appLogger.info(
       "[stream] host availability recovered - refetching host-scoped queries",

--- a/clients/gui-app/src/lib/host/durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/durable-stream-transport.ts
@@ -6,6 +6,10 @@ import type { StreamAuthRevalidator } from "@traycer-clients/shared/auth/bearer-
 import type { IRunnerHost } from "@traycer-clients/shared/platform/runner-host";
 import { buildHostStreamClient } from "@/hooks/host/use-host-stream-client-for";
 import { subscribeStreamWakeReconnect } from "@/lib/host/stream-wake-reconnect";
+import {
+  AVAILABILITY_RECOVERY_COOLDOWN_MS,
+  wireAvailabilityRecovery,
+} from "@/lib/host/availability-recovery";
 import { appLogger } from "@/lib/logger";
 
 export interface DurableStreamTransport {
@@ -20,12 +24,12 @@ export interface DurableStreamTransport {
 /**
  * Builds a LONG-LIVED host stream transport for a SESSION STORE to own across
  * its warm lifetime (not a React tile). This is the ONE place "durable stream =
- * transport + auth + wake + endpoint-change re-dial" lives: the chat, terminal,
- * and epic session stores all build their transport here, and the app-wide
- * stream uses the same `buildHostStreamClient` + reconnect primitives - so a new
- * durable consumer cannot wire a subset (auth without wake, or a socket without
- * the endpoint-change re-dial) and silently reintroduce the freeze / slow-wake /
- * stuck-after-restart bugs this replaced.
+ * transport + auth + wake + endpoint-change re-dial + availability recovery"
+ * lives: the chat, terminal, and epic session stores all build their transport
+ * here, and the app-wide stream uses the same `buildHostStreamClient` +
+ * reconnect primitives - so a new durable consumer cannot wire a subset (auth
+ * without wake, or a socket without the endpoint-change re-dial) and silently
+ * reintroduce the freeze / slow-wake / stuck-after-restart bugs this replaced.
  *
  *  - `endpoint` is read LIVE on every (re)dial, so a host that respawns on a
  *    new `websocketUrl` while the session is warm (no tile mounted to recompute
@@ -65,6 +69,17 @@ export function openDurableStreamTransport(params: {
    * down to a genuine dialable-endpoint move before re-dialing.
    */
   readonly subscribeEndpointChange: (onChange: () => void) => () => void;
+  /**
+   * Called (cooldown-coalesced by this module) when this transport's own
+   * heartbeat evidences the BOUND host recovering - a session re-open after a
+   * drop, or a pong after a stall-length gap. The factory routes it to
+   * `HostClient.notifyHostAvailabilityRecovered(hostId)` so the bound host's
+   * stranded unary queries refetch. This must live here, not on the app-wide
+   * stream: tabs bind a `hostId` for life, so a tab can heartbeat a host that
+   * is NOT the active one, and only its own transport ever observes that
+   * host's recovery.
+   */
+  readonly notifyAvailabilityRecovered: () => void;
 }): DurableStreamTransport {
   const wsStreamClient = buildHostStreamClient({
     endpoint: params.endpoint,
@@ -90,6 +105,16 @@ export function openDurableStreamTransport(params: {
         params.endpoint,
         params.subscribeEndpointChange,
       ),
+    );
+    disposers.push(
+      wireAvailabilityRecovery({
+        wsStreamClient,
+        target: {
+          notifyAvailabilityRecovered: params.notifyAvailabilityRecovered,
+        },
+        cooldownMs: AVAILABILITY_RECOVERY_COOLDOWN_MS,
+        now: () => Date.now(),
+      }),
     );
   } catch (cause) {
     appLogger.error("[stream] durable transport wiring failed", {}, cause);

--- a/clients/gui-app/src/lib/host/stream-runtime.tsx
+++ b/clients/gui-app/src/lib/host/stream-runtime.tsx
@@ -21,6 +21,10 @@ import type { StreamRuntimeBinding } from "@/lib/host/stream-runtime-context";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
 import { useSurfaceReadiness } from "@/components/layout/host-readiness-controller-context";
 import { useStreamWakeReconnect } from "@/lib/host/stream-wake-reconnect";
+import {
+  AVAILABILITY_RECOVERY_COOLDOWN_MS,
+  wireAvailabilityRecovery,
+} from "@/lib/host/availability-recovery";
 import { appLogger } from "@/lib/logger";
 
 export interface HostStreamProviderProps {
@@ -137,6 +141,25 @@ export function HostStreamProvider(props: HostStreamProviderProps): ReactNode {
     }
     return hostClient.onBearerRotated(() => {
       wsStreamClient.notifyBearerRotated();
+    });
+  }, [wsStreamClient, hostClient]);
+
+  // The app-wide stream heartbeats against the active host continuously, so
+  // its recovery evidence (session re-open after a drop, pong after a
+  // stall-length gap) drives `notifyAvailabilityRecovered()` - un-stranding
+  // every host-scoped query left in a terminal error state while the host
+  // was stalled or restarting. This is the production caller that method was
+  // designed for; the stream client and the host client are bound to the
+  // same active-host identity by construction here.
+  useEffect(() => {
+    if (wsStreamClient === null || hostClient === null) {
+      return;
+    }
+    return wireAvailabilityRecovery({
+      wsStreamClient,
+      target: hostClient,
+      cooldownMs: AVAILABILITY_RECOVERY_COOLDOWN_MS,
+      now: () => Date.now(),
     });
   }, [wsStreamClient, hostClient]);
 

--- a/clients/gui-app/src/lib/host/use-durable-stream-transport.ts
+++ b/clients/gui-app/src/lib/host/use-durable-stream-transport.ts
@@ -50,6 +50,12 @@ export function useDurableStreamTransportFactory(): (
           const subscription = liveRef.current.directory.onChange(onChange);
           return () => subscription.dispose();
         },
+        // Recovery evidence targets the BOUND host, not the active one: a
+        // tab's queries are keyed by its own `hostId`, and only this
+        // transport heartbeats that host when it is not the active
+        // selection.
+        notifyAvailabilityRecovered: () =>
+          liveRef.current.globalClient.notifyHostAvailabilityRecovered(hostId),
       }),
     [],
   );

--- a/clients/shared/host-client/__tests__/host-client.test.ts
+++ b/clients/shared/host-client/__tests__/host-client.test.ts
@@ -289,6 +289,28 @@ describe("HostClient", () => {
     expect(events[0].reason).toBe("availability-recovered");
   });
 
+  it("explicit-host recovery invalidates a NON-active host's scope without announcing an active-host change", () => {
+    const { client, invalidator, events } = buildHostClientWithMock();
+    client.bind(mockLocalHostEntry);
+    invalidator.calls.length = 0;
+    invalidator.options.length = 0;
+    events.length = 0;
+
+    // A tab-bound durable stream heartbeats its own host, which need not be
+    // the active one; its queries are keyed by THAT id.
+    client.notifyHostAvailabilityRecovered("other-host");
+    expect(invalidator.calls).toEqual(["other-host"]);
+    expect(invalidator.options).toEqual([{ refetchActive: true }]);
+    expect(events).toEqual([]);
+
+    // For the active host it is exactly notifyAvailabilityRecovered(),
+    // change event included.
+    client.notifyHostAvailabilityRecovered("mock-local");
+    expect(invalidator.calls).toEqual(["other-host", "mock-local"]);
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe("availability-recovered");
+  });
+
   it("delegates unary requests to the bound messenger", async () => {
     const { client, messenger } = buildHostClientWithMock();
     client.bind(mockLocalHostEntry);

--- a/clients/shared/host-client/host-client.ts
+++ b/clients/shared/host-client/host-client.ts
@@ -301,6 +301,25 @@ export class HostClient<Registry extends VersionedRpcRegistry> {
   }
 
   /**
+   * {@link notifyAvailabilityRecovered} for an explicitly-named host. Tabs
+   * bind a `hostId` for life, so a durable per-tab stream can heartbeat (and
+   * observe recovering) a host that is NOT the active one - that host's
+   * stranded unary queries are keyed by ITS id and would never be reached by
+   * the active-host variant. For the active host this delegates (including
+   * the change event); for any other host it invalidates that host's scope so
+   * active observers refetch, without announcing an active-host change.
+   */
+  notifyHostAvailabilityRecovered(hostId: string): void {
+    if (this.activeHost !== null && this.activeHost.hostId === hostId) {
+      this.notifyAvailabilityRecovered();
+      return;
+    }
+    this.invalidator.invalidateHostScope(hostId, {
+      refetchActive: true,
+    });
+  }
+
+  /**
    * Updates the `RequestContext` the messenger threads onto outgoing
    * requests. An identity transition (the previous and next contexts have
    * different `userId`s, OR one side is `null`) invalidates the

--- a/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
+++ b/clients/shared/host-transport/__tests__/ws-stream-client.test.ts
@@ -1022,6 +1022,78 @@ describe("WsStreamClient", () => {
     vi.useRealTimers();
   });
 
+  it("emits availability recovery when a session re-opens after a drop, not on the initial clean open", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+
+    const { factory, sockets } = makeFactory();
+    const client = makeClient({
+      factory,
+      authToken: "t",
+      pingIntervalMs: 25_000,
+      pongTimeoutMs: 50_000,
+      initialBackoffMs: 10,
+      maxBackoffMs: 1_000,
+    });
+    const recovered = vi.fn();
+    client.subscribeAvailabilityRecovered(recovered);
+
+    const session = client.subscribe("epic.subscribe", { epicId: "epic-1" });
+    completeHandshake(sockets[0].socket);
+    // The first clean connect is not recovery - nothing was stranded yet.
+    expect(recovered).not.toHaveBeenCalled();
+
+    // Recoverable drop → backoff → fresh dial → handshake completes: the host
+    // just proved it is reachable again.
+    sockets[0].socket.fireClose(1006, "connection-lost", false);
+    vi.advanceTimersByTime(1_000);
+    expect(sockets).toHaveLength(2);
+    completeHandshake(sockets[1].socket);
+    expect(recovered).toHaveBeenCalledTimes(1);
+
+    session.close();
+    vi.useRealTimers();
+  });
+
+  it("emits availability recovery when a pong lands after a stall-length gap without any drop", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+
+    const { factory, sockets } = makeFactory();
+    const client = makeClient({
+      factory,
+      authToken: "t",
+      pingIntervalMs: 25_000,
+      pongTimeoutMs: 50_000,
+      initialBackoffMs: 10,
+      maxBackoffMs: 1_000,
+    });
+    const recovered = vi.fn();
+    client.subscribeAvailabilityRecovered(recovered);
+
+    const session = client.subscribe("epic.subscribe", { epicId: "epic-1" });
+    const socket = sockets[0].socket;
+    completeHandshake(socket);
+
+    // Healthy cadence: the pong answering the t=25s ping arrives one ping
+    // interval after `lastPongAt` was seeded at openAck - below the
+    // interval-plus-slack recovery threshold, so no emission.
+    vi.advanceTimersByTime(25_000);
+    socket.fireText({ kind: "pong", hasBinaryPayload: false });
+    expect(recovered).not.toHaveBeenCalled();
+
+    // Host event-loop stall: the t=50s ping goes unanswered until t=60s. The
+    // 35s pong gap exceeds pingIntervalMs + 5s slack → recovery evidence,
+    // while staying under the 50s missed-pong cutoff → the socket never
+    // dropped and the reconnect-recovery path never ran.
+    vi.advanceTimersByTime(25_000);
+    vi.advanceTimersByTime(10_000);
+    socket.fireText({ kind: "pong", hasBinaryPayload: false });
+    expect(recovered).toHaveBeenCalledTimes(1);
+    expect(socket.closed).toBeNull();
+
+    session.close();
+    vi.useRealTimers();
+  });
+
   it("requestReconnect drops the live socket and redials through existing backoff without disposing the session", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: false });
 

--- a/clients/shared/host-transport/ws-stream-client.ts
+++ b/clients/shared/host-transport/ws-stream-client.ts
@@ -163,6 +163,7 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
   private readonly methodSchemaVersions = new Map<string, SchemaVersion>();
   private readonly methodSupportListeners = new Set<() => void>();
   private readonly closedListeners = new Set<() => void>();
+  private readonly availabilityRecoveredListeners = new Set<() => void>();
   private closed = false;
   private closedReason: string | null = null;
 
@@ -220,6 +221,9 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
       onDispose: () => removeSession(),
       onMethodSupport: (nextMethod, support, schemaVersion) => {
         this.setMethodSupport(nextMethod, support, schemaVersion);
+      },
+      onAvailabilityRecovered: () => {
+        this.emitAvailabilityRecovered();
       },
     });
     removeSession = () => {
@@ -317,6 +321,26 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
   }
 
   /**
+   * Subscribes to positive evidence that the host endpoint just RECOVERED
+   * availability after a period of being unreachable or unresponsive. Fired by
+   * any owned session when (a) it re-opens after a drop (its status was
+   * `"reconnecting"` when the handshake completed), or (b) a heartbeat pong
+   * lands after a stall-length gap WITHOUT the socket ever dropping - the
+   * host-event-loop-stall case, where an established stream survives the
+   * 60s pong cutoff while fresh unary dials time out and strand their
+   * queries in a permanent error state. Consumers use this to drive
+   * `HostClient.notifyAvailabilityRecovered()` so those stranded queries
+   * refetch; multiple sessions recovering at once each fire, so consumers
+   * should coalesce.
+   */
+  subscribeAvailabilityRecovered(listener: () => void): () => void {
+    this.availabilityRecoveredListeners.add(listener);
+    return () => {
+      this.availabilityRecoveredListeners.delete(listener);
+    };
+  }
+
+  /**
    * Proactively drops and re-dials every open session immediately. Driven by a
    * device-wake / network-online signal: after an OS sleep the sockets can be
    * half-open (frozen by the OS) while the client still believes it is
@@ -353,6 +377,25 @@ export class WsStreamClient<Registry extends VersionedStreamRpcRegistry> {
     );
     for (const session of Array.from(this.ownedSessions)) {
       session.forceReconnect(reason);
+    }
+  }
+
+  private emitAvailabilityRecovered(): void {
+    if (this.closed) {
+      return;
+    }
+    // Guarded per listener: the emission happens inside a session's inbound
+    // frame handling (the pong path), so a throwing consumer must not break
+    // the socket's message processing or the other listeners.
+    for (const listener of Array.from(this.availabilityRecoveredListeners)) {
+      try {
+        listener();
+      } catch (error) {
+        console.error(
+          `[stream] availability-recovered listener threw (client=${this.instanceId})`,
+          error,
+        );
+      }
     }
   }
 
@@ -442,7 +485,30 @@ interface StreamSessionOptions<Registry extends VersionedStreamRpcRegistry> {
     support: StreamMethodSupport,
     schemaVersion: SchemaVersion | null,
   ) => void;
+  /**
+   * Reports positive host-recovery evidence to the owning client - see
+   * `WsStreamClient.subscribeAvailabilityRecovered` for the two emission
+   * sites and why they exist.
+   */
+  readonly onAvailabilityRecovered: () => void;
 }
+
+/**
+ * Slack added to `pingIntervalMs` before a pong gap counts as recovery
+ * evidence. On a healthy connection consecutive pongs arrive one ping
+ * interval apart (the ping timer is exact; the pong round-trip is
+ * RTT-scale), so a gap exceeding the interval by several seconds means at
+ * least one ping sat unanswered - the host was unresponsive and has just
+ * come back. Kept well under `pongTimeoutMs - pingIntervalMs` so this
+ * detects the stalls the drop cutoff deliberately tolerates.
+ *
+ * Known benign false positive: a backgrounded renderer throttles timers, so
+ * pings go out late and the measured gap stretches without any host stall.
+ * The resulting notify fires as the tab foregrounds and costs one refetch of
+ * active host-scoped queries - freshness on return, not churn - so it is
+ * accepted rather than special-cased with visibility heuristics.
+ */
+const PONG_GAP_RECOVERY_SLACK_MS = 5_000;
 
 /**
  * One open stream. Owns the per-connect socket plus every timer wired to
@@ -824,7 +890,18 @@ class StreamSession<
     }
 
     if (envelope.kind === "pong") {
-      this.lastPongAt = Date.now();
+      const now = Date.now();
+      const pongGapMs = now - this.lastPongAt;
+      this.lastPongAt = now;
+      if (
+        pongGapMs >=
+        this.config.pingIntervalMs + PONG_GAP_RECOVERY_SLACK_MS
+      ) {
+        // The host just answered after leaving at least one ping hanging: it
+        // was unresponsive (event-loop stall) and has recovered - without the
+        // socket ever dropping, so the reconnect path below never fires.
+        this.config.onAvailabilityRecovered();
+      }
       return;
     }
 
@@ -943,12 +1020,20 @@ class StreamSession<
       "supported",
       prepared.onWireVersion,
     );
+    // Read BEFORE `transitionTo("open")` overwrites it: a session that was
+    // "reconnecting" (dropped socket, or failed dial attempts) has just proved
+    // the host is reachable again. The initial clean connect ("connecting" →
+    // "open") is NOT recovery - nothing was stuck - so it stays silent.
+    const recoveredFromUnavailable = this.status === "reconnecting";
     this.phase = "subscribed";
     this.reconnectAttempt = 0;
     this.noProgressUnauthorizedReconnects = 0;
     this.lastPongAt = Date.now();
     this.startHeartbeat();
     this.transitionTo("open", null);
+    if (recoveredFromUnavailable) {
+      this.config.onAvailabilityRecovered();
+    }
     // If the bearer rotated DURING the handshake - after the open frame was sent
     // but before we became `subscribed` - that rotation's `notifyBearerRotated`
     // was dropped (we weren't subscribed yet) and the open frame carried the now


### PR DESCRIPTION
## Problem

Host RPCs deliberately disable **every** automatic TanStack recovery route (transport retries already ran, no polling, no focus/reconnect refetch). So when a unary call fails during a host event-loop stall of 10–45s — the class root-caused separately on the host side — the query stays errored *forever*. The terminals panel is the visible symptom: `terminal.list` uses its own WS per request with a 10s dial × 3 ≈ 30.6s envelope, and 23 stalls ≥10s/day were observed on the profiled host.

`HostClient.notifyAvailabilityRecovered()` is the designed escape hatch for exactly this, and it had **zero production callers**.

## Fix

- **`WsStreamClient` emits availability-recovered evidence** on (a) session re-open after a drop, and (b) a pong landing after a gap ≥ `pingIntervalMs` + slack. (b) is load-bearing: a 25–45s stall eats the unary dial budget while the *established* stream survives the 60s pong cutoff, so reconnect-success alone never fires for the most common stranding class.
- **Both wiring sites.** The app-wide stream client notifies the active host. Every durable per-tab transport notifies its **bound** host through the new `notifyHostAvailabilityRecovered(hostId)`, which invalidates that host's query scope without emitting an active-host change event. This matters because tabs bind a `hostId` for life — a tab on a non-active host would otherwise never recover. The wiring is a *required* param of `openDurableStreamTransport`, so a new transport call site cannot silently skip it.
- **Cooldown is leading-edge with a trailing catch-up.** A distinct second recovery episode inside the 10s window (stall → recover → notify, then stall again → recover at t+3s) is deferred to window end rather than dropped, since its newly-stranded queries have no other automatic signal. Plus a clock-rollback gate reset.
- **Terminals sidebar error state gained a Retry button** mirroring the tile's, covering phase-aligned stalls the pong gap cannot observe.

A perfectly phase-aligned stall shorter than the ping interval stays invisible to auto-recovery by design; the Retry button is the backstop. The pong gap's one known false positive — a backgrounded renderer whose timers are throttled — is documented as accepted-benign at the constant: it costs one refetch when the tab is foregrounded.

## Verification

- 184 shared + 266 gui-app tests pass; `nx` compile and gui-app `tsc -b` clean; ESLint (`--max-warnings 0`) and Prettier clean on every touched file.
- **Mutation-probed**: reverting both emission sites reddens exactly the 2 new transport tests; disabling the trailing timer reddens exactly the 2 trailing-edge tests and nothing else.
- New coverage: burst coalescing including the trailing edge, trailing delivery, clock rollback, disposer cancelling an armed trailing timer, transport wiring, and the explicit-host invalidation path (a non-active host invalidates its own scope with `refetchActive` and emits no events).

This changeset was cold-reviewed by an independent agent against the RCA; the tab-bound-host gap and the dropped-second-episode bug above were both findings from that review and are fixed here.
