### PR TITLE
fix(desktop): name the macOS Login Items entry after the product

### DIFF
--- a/clients/desktop/scripts/prepack/__tests__/inject-host-launch-agent.test.ts
+++ b/clients/desktop/scripts/prepack/__tests__/inject-host-launch-agent.test.ts
@@ -22,7 +22,9 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { createRequire } from "node:module";
 import {
+  accessSync,
   chmodSync,
+  constants,
   cpSync,
   existsSync,
   mkdirSync,
@@ -249,10 +251,84 @@ describe("inject-host-launch-agent afterPack", () => {
             ),
           );
           const plist = readFileSync(plistPath, "utf8");
-          expect(plist).toContain("traycer-host-start");
+          // Deliberately the full launcher path, not a `toContain` of the
+          // basename: the helper bundle directory is `<product> Host.app`, so
+          // a bare substring check for `<product> Host` passes no matter what
+          // the launcher is called - it matches the directory. Verified by
+          // mutation probe (reverting the basename left the loose form green).
+          expect(plist).toContain(
+            `<string>Contents/Library/LaunchAgents/${PRODUCT_NAME} Host.app/Contents/MacOS/${PRODUCT_NAME} Host</string>`,
+          );
           expect(plist).not.toContain("<string>/bin/sh</string>");
           expect(plist).toContain(expectedLabel);
         }
+      });
+
+      it("names the executable BTM shows in Login Items after the product, not after a slug filename", async () => {
+        // System Settings → Login Items renders this agent under whatever
+        // BTM recorded as `Name`, and BTM takes that from the VERBATIM
+        // basename of the plist's `BundleProgram`. It is not bundle-aware:
+        // live-probed 2026-07-29 (macOS 26.5, real `SMAppService.agent`
+        // registration read back with `sfltool dumpbtm`), a variant whose
+        // `BundleProgram` pointed at the helper bundle's own
+        // `CFBundleExecutable` still recorded that executable's basename and
+        // ignored `CFBundleDisplayName`/`CFBundleName`/the `.app` name. So
+        // the helper's Info.plist naming keys - asserted elsewhere in this
+        // file - do NOT cover this, and cannot: the basename is the only
+        // lever, which is what makes it worth its own test.
+        //
+        // The prior basename `traycer-host-start` shipped a filename into a
+        // product surface. Reverting it must fail here.
+        const { modulePath, appOutDir, appPath } = createFixture("production");
+        const injected = loadModule(modulePath);
+
+        await injected.afterPack({
+          electronPlatformName: "darwin",
+          appOutDir,
+          arch: Arch.arm64,
+        });
+
+        const agentLabel = smAppServiceAgentLabelId(
+          labelForEnvironment("production").id,
+        );
+        const agentPlist = readFileSync(
+          path.join(
+            appPath,
+            "Contents",
+            "Library",
+            "LaunchAgents",
+            `${agentLabel}.plist`,
+          ),
+          "utf8",
+        );
+        const bundleProgram = agentPlist.match(
+          /<key>BundleProgram<\/key>\s*<string>([^<]+)<\/string>/,
+        )?.[1];
+        if (bundleProgram === undefined) {
+          throw new Error("BundleProgram not found in the generated plist");
+        }
+
+        // The one assertion this test is named for: what the user reads.
+        expect(path.basename(bundleProgram)).toBe(`${PRODUCT_NAME} Host`);
+
+        // launchd execs `BundleProgram`, so a name BTM likes is worthless if
+        // the file it points at is not actually there and executable. The
+        // live probe confirmed launchd resolves and runs a space-containing
+        // basename (`$0` intact, exit 0); this pins our half of that.
+        const launcherOnDisk = path.join(appPath, bundleProgram);
+        expect(existsSync(launcherOnDisk)).toBe(true);
+        expect(() => {
+          accessSync(launcherOnDisk, constants.X_OK);
+        }).not.toThrow();
+
+        // ProgramArguments[0] and BundleProgram must name the same file.
+        // launchd uses BundleProgram for the exec, but the argv is what
+        // `attestTraycerRegistration` reads, so drift between them would
+        // leave the two halves disagreeing about which file this job is.
+        const firstProgramArgument = agentPlist.match(
+          /<key>ProgramArguments<\/key>\s*<array>\s*<string>([^<]+)<\/string>/,
+        )?.[1];
+        expect(firstProgramArgument).toBe(bundleProgram);
       });
 
       it("stages a signed helper .app and a relocatable NumberOfFiles=8192 LaunchAgent plist, both valid via plutil -lint", async () => {
@@ -358,7 +434,9 @@ describe("inject-host-launch-agent afterPack", () => {
         }
         const relativeLauncherPath = bundleProgramMatch[1];
         expect(relativeLauncherPath.startsWith("/")).toBe(false);
-        expect(relativeLauncherPath.endsWith("/traycer-host-start")).toBe(true);
+        expect(relativeLauncherPath.endsWith(`/${PRODUCT_NAME} Host`)).toBe(
+          true,
+        );
 
         // Actually relocate the packaged .app (cp -R to a different path) and
         // confirm BundleProgram - parsed from the plist, not just grepped -

--- a/clients/desktop/scripts/prepack/inject-host-launch-agent.cjs
+++ b/clients/desktop/scripts/prepack/inject-host-launch-agent.cjs
@@ -66,7 +66,40 @@ const PRODUCT_NAME = pkg.build.productName;
 const APP_ID = pkg.build.appId;
 const CONFIG_PATH = path.resolve(__dirname, "..", "..", "src", "config.ts");
 const CLI_BINARY_NAME = "traycer";
-const HOST_START_COMPAT_LAUNCHER = "traycer-host-start";
+// The launcher's BASENAME is what the user reads in System Settings → Login
+// Items, so it is a product name, not a filename.
+//
+// BTM records `Name` as the verbatim basename of the plist's `BundleProgram`
+// and is NOT bundle-aware — live-probed 2026-07-29 on macOS 26.5 with a
+// signed throwaway app registering four variants through the real
+// `SMAppService.agent(plistName:)` and read back with `sfltool dumpbtm`:
+//
+//   BundleProgram basename        BTM Name
+//   probe-host-start          →   probe-host-start
+//   probeexec (CFBundleExecutable) →  probeexec
+//   Probe Launcher Named      →   Probe Launcher Named
+//   Probe Host (RunAtLoad)    →   Probe Host          (exit code 0)
+//
+// The helper bundle's `CFBundleDisplayName`, `CFBundleName` and even its own
+// `.app` directory name were all ignored — including in the variant whose
+// `BundleProgram` pointed at that bundle's `CFBundleExecutable`. So the
+// obvious-looking fix (retarget `BundleProgram` at `CFBundleExecutable`) does
+// NOT surface a product name; it would have shipped `Name: traycer`. Renaming
+// the launcher file is the only lever, which is the same conclusion the CLI
+// path reached for `/bin/sh` (see `HOST_START_LAUNCHER_BASENAME`).
+//
+// Spaces are load-bearing-safe: the probe's space-named variant both
+// registered AND was exec'd by launchd with `$0` intact.
+//
+// This name is NOT the CLI's `HOST_START_LAUNCHER_BASENAME`, and must not be
+// unified with it. That constant is the one
+// `attestTraycerRegistration`/`isHostStartInvocation` matches on for the
+// CLI's `~/.traycer/service/<label-id>/…` launcher form, where a rename is a
+// field-compatibility and eviction-attestation change. The bundled agent
+// below never matches that arm (its launcher's parent directory is `MacOS`,
+// not the label id) — it attests through its label signal — so this basename
+// is free to be chosen for the human reading it.
+const HOST_START_COMPAT_LAUNCHER = `${PRODUCT_NAME} Host`;
 const HOST_NODE_OPTIONS = "--max-semi-space-size=16";
 const HOST_SOFT_FILE_DESCRIPTOR_LIMIT = 8_192;
 // Matches `PRODUCTION_LABEL.id` in `src/electron-main/host/host-paths.ts`.


### PR DESCRIPTION
## The defect

System Settings → Login Items shows the bundled host agent as **`traycer-host-start`** — a filename leaking into a product surface.

BTM records its `Name` from the **verbatim basename of the plist's `BundleProgram`**, and is not bundle-aware at all.

## Probe evidence

The backlog's hypothesis was *"point `BundleProgram` at the helper's `CFBundleExecutable` and BTM will show `Traycer Host`"*. That is **wrong**, and this PR is a different shape as a result.

Probed live on macOS 26.5: a throwaway app registered four variants through the real `SMAppService.agent(plistName:)`, each with deliberately distinct name fields, read back with `sfltool dumpbtm`.

| `BundleProgram` basename | helper bundle's name fields | BTM `Name` |
|---|---|---|
| `probe-host-start` (control) | display=`ProbeDisplayName`, name=`ProbeBundleName`, dir=`Probe Host.app` | `probe-host-start` |
| `probeexec` — the helper's own `CFBundleExecutable` | same | `probeexec` |
| `Probe Launcher Named` | same | `Probe Launcher Named` |
| `Probe Host` + `RunAtLoad` | same | `Probe Host` (exec'd, exit 0) |

`CFBundleDisplayName`, `CFBundleName` and the `.app` directory name were **all ignored** — including in the variant pointing at `CFBundleExecutable`, which would have shipped `Name: traycer`. **Renaming the launcher file is the only lever** — the same conclusion the CLI path reached for `/bin/sh` in #790.

The fourth arm confirms a space-containing basename both registers *and* gets exec'd by launchd with `$0` intact.

## The change

`HOST_START_COMPAT_LAUNCHER` becomes `` `${PRODUCT_NAME} Host` `` — derived, not hardcoded, so a product rename can't strand a stale name in Login Items.

**Not unified with the CLI's `HOST_START_LAUNCHER_BASENAME`, deliberately.** That constant is what `isHostStartInvocation` matches for the CLI's `~/.traycer/service/<label-id>/…` launcher form, so renaming *it* is a field-compatibility and eviction-attestation change. This bundled agent never matched that arm — its launcher's parent directory is `MacOS`, not the label id, so it attests through its label signal. That's precisely what makes this basename free to choose for the human reading it.

## Tests

A dedicated test asserts the basename, that the file exists and is executable at that path, and that `ProgramArguments[0]` and `BundleProgram` name the same file.

Each assertion was mutation-probed. That caught a real problem: the first version used `toContain("Traycer Host")`, which is **vacuous** — the helper directory is `Traycer Host.app`, so it passes for any launcher name. Reverting the constant left it green. The assertions now pin the full path and go red on revert.

## Lockstep

`scripts/desktop-install-cloud.js` in the internal repo is the twin and carries the same change; its PR is linked in a comment below once opened.
