### PR TITLE
fix(desktop): tear down the Windows host autostart on OS-native uninstall

### DIFF
--- a/clients/desktop/package.json
+++ b/clients/desktop/package.json
@@ -226,7 +226,8 @@
     "nsis": {
       "oneClick": false,
       "perMachine": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "include": "uninstall-host-autostart.nsh"
     }
   },
   "author": {

--- a/clients/desktop/resources/bundle/uninstall-host-autostart.nsh
+++ b/clients/desktop/resources/bundle/uninstall-host-autostart.nsh
@@ -1,0 +1,112 @@
+; Tears down the host's per-user autostart when Traycer is REMOVED through the
+; OS-native route (Add/Remove Programs -> this NSIS uninstaller).
+;
+; WHY THIS FILE EXISTS
+; -------------------
+; The host does not auto-start from anything inside $INSTDIR. `traycer host
+; service install` registers a per-user Scheduled Task `\Traycer\Host` whose
+; action runs a launcher VBS under the user profile, so deleting the app
+; directory removes the UI and leaves the host starting at every single logon,
+; with no discoverable stop vector left (the task is `<Hidden>true</Hidden>`,
+; and logon-trigger tasks are not listed in the Startup-apps panel).
+;
+; Settings -> "Remove Traycer" in the app already does a full, tested teardown
+; via `traycer host uninstall --all`. This macro exists only for the users who
+; never open Settings and remove the app the way Windows tells them to.
+;
+; WHY RAW COMMANDS AND NOT THE BUNDLED CLI
+; ---------------------------------------
+; `$INSTDIR\resources\cli\win32-x64\traycer.exe host uninstall --all` still
+; exists at this point (files are deleted after `customUnInstall`) and would be
+; the more complete teardown - it also kills an already-running host through a
+; slot-scoped, pid-verified scan this macro deliberately does not attempt.
+; It is not used because an uninstaller must be bounded and must not depend on
+; the application's own binaries being functional: a user reaching for
+; Add/Remove Programs is frequently doing so *because* the app is broken, and
+; NSIS has no timeout for a child process that hangs. Every command below is a
+; bounded OS utility, and each is best-effort - nothing here may fail the
+; uninstall.
+;
+; Residue deliberately left: `%USERPROFILE%\.traycer` (chats, SQLite, models,
+; credentials). Uninstalling an app does not destroy the user's data, and the
+; CLI's own `host uninstall` has no destructive purge path either. The
+; *execution* is what has to stop.
+;
+; Production identity is hardcoded because it is the only one that ships: the
+; Windows release job runs `set-deploy-target.cjs --target=production`, and
+; `set-deploy-target.cjs` defines no target that would produce a Windows
+; installer under another label. The names below must stay in lockstep with
+; `windowsTaskName()` in clients/traycer-cli/src/service/label.ts (production ->
+; `\Traycer\Host`) and `hiddenHostLauncherPath()` in
+; clients/traycer-cli/src/service/platforms/windows.ts, which resolves to
+; `<cliInstallHomeDir("production")>\host-start-hidden.vbs` =
+; `%USERPROFILE%\.traycer\cli\host-start-hidden.vbs`.
+
+!macro customUnInstall
+  ; THE UPDATE GUARD - the single most important line in this file.
+  ;
+  ; electron-builder runs the OLD uninstaller as part of an in-place update:
+  ;   templates/nsis/include/installUtil.nsh
+  ;     StrCpy $0 "$0 --updated"
+  ;     ExecWait '"$uninstallerFileNameTemp" /S /KEEP_APP_DATA $0 _?=$installationDir'
+  ; and `customUnInstall` is inserted near the TOP of the un.Uninstall section,
+  ; so it fires on every update as well as on a real removal. Without this
+  ; guard, upgrading Traycer would silently delete the logon task and the host
+  ; would stop starting after every update - a far worse defect than the one
+  ; this file fixes.
+  ;
+  ; `--updated` is read directly rather than through electron-builder's
+  ; `${isUpdated}` because the flag is verifiable from the invocation above,
+  ; whereas `${isUpdated}` is defined in NSIS resources fetched at build time
+  ; and cannot be inspected from this repo. `${GetParameters}`/`${GetOptions}`
+  ; are the same idiom, and are already used bare a few lines below this
+  ; insertion point in electron-builder's own uninstaller.nsh, so they are
+  ; known-available in uninstaller context. $R0/$R1 are scratch here: that same
+  ; code re-runs ClearErrors + GetParameters into them immediately afterwards.
+  ClearErrors
+  ${GetParameters} $R0
+  ${GetOptions} $R0 "--updated" $R1
+  ${ifNot} ${Errors}
+    DetailPrint "Traycer: in-place update - leaving the host autostart registered"
+  ${else}
+    DetailPrint "Traycer: removing the host autostart (Scheduled Task + launcher)"
+
+    ; Stop the instance the task currently owns. This is not a complete stop -
+    ; Task Scheduler does not job-object the tree, so a wrapper -> node child
+    ; can survive as an orphan until reboot (see `killHostProcessTree` in
+    ; windows.ts, which needs a pid-verified scan to do better). That orphan is
+    ; harmless here: it holds no handle on $INSTDIR, so it cannot block this
+    ; uninstall, and with the trigger deleted below it never comes back.
+    nsExec::ExecToLog 'schtasks /End /TN "\Traycer\Host"'
+    Pop $R0
+
+    ; Delete the logon trigger. THIS is the fix - it is what stops the host
+    ; coming back at every future logon.
+    nsExec::ExecToLog 'schtasks /Delete /TN "\Traycer\Host" /F'
+    Pop $R0
+
+    ; Remove the launcher the task's action pointed at.
+    Delete "$PROFILE\.traycer\cli\host-start-hidden.vbs"
+
+    ; `schtasks /Delete` removes only the task; the `\Traycer` FOLDER it lived
+    ; in survives and stays visible in the Task Scheduler tree. schtasks has no
+    ; verb for folders, so this uses the same Schedule.Service COM call the CLI
+    ; uninstall path already ships, and the same only-when-empty guard: a
+    ; machine that also has a dev/staging host registered keeps its folder.
+    ; Two quoting rules are load-bearing here:
+    ;
+    ;   1. `$$` emits a literal `$`, so PowerShell's own variables survive NSIS
+    ;      variable expansion (`$s` would otherwise be read as an NSIS var).
+    ;   2. The argument is delimited with BACKTICKS. NSIS accepts `"`, `'` and
+    ;      backtick as string delimiters but has NO escape for the delimiter
+    ;      itself - doubling it (`''`, the SQL/VB habit) does not escape it, it
+    ;      ends the string early and silently mangles the command. PowerShell
+    ;      needs both `"` and `'`, so the backtick form is the only one that
+    ;      leaves them both literal.
+    ;
+    ; Wrapped in try/catch because GetFolder throws when the folder is already
+    ; gone, which is a perfectly normal outcome here.
+    nsExec::ExecToLog `powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "try{$$s=New-Object -ComObject Schedule.Service;$$s.Connect();$$f=$$s.GetFolder('\Traycer');if((@($$f.GetTasks(1)).Count -eq 0) -and (@($$f.GetFolders(0)).Count -eq 0)){$$s.GetFolder('\').DeleteFolder('Traycer',0)}}catch{}"`
+    Pop $R0
+  ${endIf}
+!macroend

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows-uninstall-nsh-lockstep.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows-uninstall-nsh-lockstep.test.ts
@@ -121,13 +121,33 @@ describe("windows OS-native uninstall macro", () => {
     // the macro fixes.
     const macro = readUninstallMacro();
     expect(macro).toContain(`\${GetOptions} $R0 "--updated" $R1`);
-    // The teardown must sit in the branch taken when the flag is ABSENT.
-    const guardIndex = macro.indexOf('"--updated"');
-    const deleteIndex = macro.indexOf("schtasks /Delete");
-    expect(guardIndex).toBeGreaterThan(-1);
-    expect(deleteIndex).toBeGreaterThan(guardIndex);
-    expect(macro.slice(guardIndex, deleteIndex)).toContain(
-      "${ifNot} ${Errors}",
-    );
+
+    // `${GetOptions}` sets the error flag when the option is ABSENT, so
+    // `${ifNot} ${Errors}` is the arm taken when `--updated` WAS passed - the
+    // update - and every teardown command has to live in its `${else}`.
+    //
+    // Both arms are sliced and asserted, rather than only checking that the
+    // delete follows the guard: that weaker form stays green when the two arms
+    // are SWAPPED, which is precisely the inversion this test exists to catch.
+    const optionIndex = macro.indexOf('"--updated"');
+    const guardIndex = macro.indexOf("${ifNot} ${Errors}");
+    const elseIndex = macro.indexOf("${else}", guardIndex);
+    const endIfIndex = macro.indexOf("${endIf}", elseIndex);
+    expect(optionIndex).toBeGreaterThan(-1);
+    expect(guardIndex).toBeGreaterThan(optionIndex);
+    expect(elseIndex).toBeGreaterThan(guardIndex);
+    expect(endIfIndex).toBeGreaterThan(elseIndex);
+
+    const updateArm = macro.slice(guardIndex, elseIndex);
+    const removalArm = macro.slice(elseIndex, endIfIndex);
+    for (const command of [
+      "schtasks /End",
+      "schtasks /Delete",
+      "host-start-hidden.vbs",
+      "DeleteFolder('Traycer',0)",
+    ]) {
+      expect(removalArm).toContain(command);
+      expect(updateArm).not.toContain(command);
+    }
   });
 });

--- a/clients/traycer-cli/src/service/platforms/__tests__/windows-uninstall-nsh-lockstep.test.ts
+++ b/clients/traycer-cli/src/service/platforms/__tests__/windows-uninstall-nsh-lockstep.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Lockstep between the desktop's NSIS uninstaller macro and the CLI code that
+ * actually creates the artifacts it removes.
+ *
+ * The macro (`clients/desktop/resources/bundle/uninstall-host-autostart.nsh`)
+ * closes the OS-native-uninstall gap: removing Traycer through Add/Remove
+ * Programs used to delete the app while leaving the `\Traycer\Host` Scheduled
+ * Task and its launcher VBS behind, so the host kept starting at every logon.
+ *
+ * It necessarily HARDCODES the task name and the launcher path - NSIS cannot
+ * import TypeScript, and the desktop package has no dependency on this one. So
+ * the strings are duplicated, and duplication that nothing checks is exactly
+ * how an uninstaller silently stops uninstalling: rename the task in
+ * `windowsTaskName` and the macro keeps issuing `schtasks /Delete` against a
+ * name that no longer exists, succeeding loudly and doing nothing.
+ *
+ * This test lives in the CLI package rather than the desktop one because this
+ * package owns the source of truth. It reads the desktop's files by path (no
+ * import), which is also why it can assert against the REAL committed macro
+ * rather than a copy of its contents.
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { serviceLabelFor, windowsTaskName } from "../../label";
+import { cliInstallHomeDir } from "../../../store/paths";
+
+const DESKTOP_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "desktop",
+);
+
+function readDesktopJson(relativePath: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(join(DESKTOP_ROOT, relativePath), "utf8"),
+  ) as Record<string, unknown>;
+}
+
+/**
+ * Resolves the macro through the SAME field electron-builder reads, rather
+ * than by hardcoding the filename here. `nsis.include` is resolved against
+ * `directories.buildResources` (app-builder-lib `getResource`), so a move of
+ * either the file or the buildResources dir has to keep this readable.
+ */
+function readUninstallMacro(): string {
+  const build = readDesktopJson("package.json").build as {
+    readonly directories: { readonly buildResources: string };
+    readonly nsis: { readonly include?: string };
+  };
+  const include = build.nsis.include;
+  if (include === undefined) {
+    throw new Error(
+      "desktop package.json build.nsis.include is unset - the uninstaller macro is not wired in at all",
+    );
+  }
+  return readFileSync(
+    join(DESKTOP_ROOT, build.directories.buildResources, include),
+    "utf8",
+  );
+}
+
+describe("windows OS-native uninstall macro", () => {
+  it("deletes the exact Scheduled Task name windowsTaskName() registers for production", () => {
+    const expected = windowsTaskName(serviceLabelFor("production"));
+    expect(expected).toBe("\\Traycer\\Host");
+    // The delete is the fix; assert the real command, not just the name
+    // appearing somewhere in a comment.
+    expect(readUninstallMacro()).toContain(
+      `schtasks /Delete /TN "${expected}" /F`,
+    );
+  });
+
+  it("deletes the launcher at the path the Scheduled Task's action actually runs", () => {
+    // `hiddenHostLauncherPath` is module-private in windows.ts, so rebuild it
+    // from its two real inputs: `cliInstallHomeDir("production")` and the
+    // launcher filename. The home dir is absolute and platform-native, so
+    // compare the part BELOW the user profile, spelled the way NSIS spells it
+    // (`$PROFILE\...`).
+    const belowProfile = relative(homedir(), cliInstallHomeDir("production"));
+    const windowsTail = belowProfile.split(/[\\/]/).join("\\");
+    expect(windowsTail).toBe(".traycer\\cli");
+    expect(readUninstallMacro()).toContain(
+      `Delete "$PROFILE\\${windowsTail}\\host-start-hidden.vbs"`,
+    );
+  });
+
+  it("never delimits an nsExec argument with a quote it also needs inside", () => {
+    // NSIS accepts `"`, `'` and backtick as string delimiters but has NO
+    // escape for the delimiter itself - doubling it (`''`) does not escape, it
+    // ends the string early. The folder-cleanup command needs both `"` and `'`
+    // for PowerShell, so it must be backtick-delimited. This is unverifiable
+    // by any test that only greps for command substrings, and makensis is not
+    // available on the dev/CI platforms this suite runs on, so the quoting is
+    // pinned structurally instead.
+    for (const line of readUninstallMacro().split("\n")) {
+      const command = line.trim();
+      if (!command.startsWith("nsExec::")) continue;
+      const argument = command.slice(command.indexOf(" ") + 1).trim();
+      const delimiter = argument[0];
+      expect(["'", '"', "`"]).toContain(delimiter);
+      expect(argument.endsWith(delimiter)).toBe(true);
+      // The delimiter must not appear inside the argument at all.
+      expect(argument.slice(1, -1)).not.toContain(delimiter);
+    }
+  });
+
+  it("does NOT tear the autostart down during an in-place update", () => {
+    // The catastrophic-regression guard. electron-builder runs the OLD
+    // uninstaller with `--updated` as part of every update
+    // (templates/nsis/include/installUtil.nsh), and `customUnInstall` is
+    // inserted near the top of the un.Uninstall section, so it fires then too.
+    // Unguarded, upgrading Traycer would delete the logon task and the host
+    // would never start again after an update - strictly worse than the defect
+    // the macro fixes.
+    const macro = readUninstallMacro();
+    expect(macro).toContain(`\${GetOptions} $R0 "--updated" $R1`);
+    // The teardown must sit in the branch taken when the flag is ABSENT.
+    const guardIndex = macro.indexOf('"--updated"');
+    const deleteIndex = macro.indexOf("schtasks /Delete");
+    expect(guardIndex).toBeGreaterThan(-1);
+    expect(deleteIndex).toBeGreaterThan(guardIndex);
+    expect(macro.slice(guardIndex, deleteIndex)).toContain(
+      "${ifNot} ${Errors}",
+    );
+  });
+});


### PR DESCRIPTION
## The defect

Removing Traycer through **Add/Remove Programs** deleted the app and left the `\Traycer\Host` Scheduled Task and its launcher VBS behind. The host kept starting at every logon, with no discoverable stop vector — the task is `<Hidden>true</Hidden>`, and logon-trigger tasks aren't listed in the Startup-apps panel.

Settings → "Remove Traycer" in the app already does a full, tested teardown via `traycer host uninstall --all`. This macro is for the users who remove the app the way Windows tells them to.

## The trap that matters most

**`customUnInstall` fires on updates, not just uninstalls.** `app-builder-lib/templates/nsis/include/installUtil.nsh` runs the *old* uninstaller as part of every in-place update:

```
StrCpy $0 "$0 --updated"
ExecWait '"$uninstallerFileNameTemp" /S /KEEP_APP_DATA $0 _?=$installationDir'
```

and the hook is inserted near the top of the `un.Uninstall` section. **Unguarded, upgrading Traycer would delete the logon task and the host would never start again after an update** — strictly worse than the defect being fixed.

The macro guards on `--updated`, read with `${GetParameters}`/`${GetOptions}` rather than electron-builder's `${isUpdated}`. `${isUpdated}` is used throughout their own templates but is defined **nowhere in the installed package** — it comes from NSIS resources fetched at build time, so its semantics aren't verifiable from this repo. The `--updated` invocation above is.

## Design call: raw commands, not the bundled CLI

`$INSTDIR\resources\cli\win32-x64\traycer.exe host uninstall --all` still exists at this point and would be the more complete teardown — it also kills a running host through a pid-verified scan this macro deliberately doesn't attempt. It isn't used because an uninstaller must be bounded and must not depend on the application's own binaries working: someone in Add/Remove Programs is frequently there *because* the app is broken, and NSIS has no timeout for a hung child.

**Accepted residue:** an already-running host can survive as an orphan until reboot. It holds no `$INSTDIR` handle so it can't block the uninstall, and with the trigger deleted it never comes back.

**User data under `%USERPROFILE%\.traycer` is deliberately left in place** — chats, SQLite, models, credentials. Uninstalling an app doesn't destroy the user's data, and the CLI's own `host uninstall` has no destructive purge path either. The only file removed under there is the launcher VBS the task's action pointed at. The *execution* is what has to stop.

## Live probe on a Windows 11 VM

**Compile:** the real committed macro compiles under electron-builder's own `makensis`, exit 0. That settles a question I'd flagged as genuinely open — the bare `${GetParameters}`/`${GetOptions}` *do* work inside `Section "un.Uninstall"` with only `!include FileFunc.nsh`, and the backtick-delimited `nsExec` argument is accepted.

**Runtime**, production-faithful (the *user* creates `\Traycer` and the task, and the same user runs the uninstaller):

| Arm | Before | After | |
|---|---|---|---|
| Update (`--updated`) | task ✔ vbs ✔ folder ✔ | task ✔ vbs ✔ folder ✔ | autostart survives ✅ |
| Real uninstall | task ✔ vbs ✔ folder ✔ | task ✗ vbs ✗ folder ✗ | fully torn down ✅ |
| Re-run when clean | — | task ✗ vbs ✗ folder ✗ | idempotent ✅ |

Getting there took three false negatives, all fixture fidelity, none a product bug: the uninstaller is 32-bit so SYSTEM's `$PROFILE` was WOW64-redirected (proven by planting a file at the redirect target and watching NSIS delete *that* one); the fixture task used `/RU SYSTEM` where the real task is `InteractiveToken` + `LeastPrivilege`; and the `\Traycer` folder had been created by SYSTEM, so a non-elevated user couldn't delete tasks inside it. No code changes came out of the probe.

## A bug caught before it shipped

The first draft embedded PowerShell's single quotes by doubling them (`''`) inside a `'…'` NSIS string. **NSIS has no escape for its string delimiter** — doubling is a SQL/VB habit that here terminates the string early and silently mangles the command. Fixed by delimiting with backticks, which leaves both `"` and `'` literal. There's a structural test asserting no `nsExec::` argument contains its own delimiter, since no substring-grep test could catch this.

## Tests

4 lockstep tests in the CLI package (which owns the source of truth; it reads the desktop files by path, so it asserts against the **real committed macro**): the task name cross-checked against `windowsTaskName()`, the VBS path against `cliInstallHomeDir()`, the update guard's branch placement, and the quoting rule. Each was individually mutation-probed.

The macro is resolved through `build.nsis.include` + `directories.buildResources` — the same fields electron-builder reads — so moving either the file or the resources dir has to keep it findable.
