### PR TITLE
fix(gui): measure terminal cells with the Unicode 11 width tables

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -111,6 +111,7 @@
         "@xterm/addon-clipboard": "catalog:",
         "@xterm/addon-fit": "catalog:",
         "@xterm/addon-search": "catalog:",
+        "@xterm/addon-unicode11": "catalog:",
         "@xterm/addon-web-links": "catalog:",
         "@xterm/addon-webgl": "catalog:",
         "@xterm/xterm": "catalog:",
@@ -331,6 +332,7 @@
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.1.0-beta.0",
@@ -1528,6 +1530,8 @@
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
     "@xterm/addon-search": ["@xterm/addon-search@0.16.0", "", {}, "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA=="],
+
+    "@xterm/addon-unicode11": ["@xterm/addon-unicode11@0.9.0", "", {}, "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw=="],
 
     "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
 

--- a/clients/gui-app/package.json
+++ b/clients/gui-app/package.json
@@ -57,6 +57,7 @@
     "@xterm/addon-clipboard": "catalog:",
     "@xterm/addon-fit": "catalog:",
     "@xterm/addon-search": "catalog:",
+    "@xterm/addon-unicode11": "catalog:",
     "@xterm/addon-web-links": "catalog:",
     "@xterm/addon-webgl": "catalog:",
     "@xterm/xterm": "catalog:",

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-find.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-find.test.tsx
@@ -94,6 +94,10 @@ vi.mock("@xterm/xterm", () => ({
     rows = 24;
     options: Record<string, unknown>;
     readonly buffer = { active: { baseY: 0, length: 24 } };
+    // Real cell-width behaviour is covered in
+    // terminal-xterm-host-unicode-width.test.tsx against a real Terminal; here
+    // the addon just needs somewhere to register.
+    readonly unicode = { activeVersion: "6", register: vi.fn() };
     readonly textarea = document.createElement("textarea");
     readonly focus = vi.fn(() => this.textarea.focus());
     readonly paste = vi.fn((data: string) => {

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-links.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-links.test.tsx
@@ -55,6 +55,10 @@ vi.mock("@xterm/xterm", () => ({
     readonly buffer = {
       active: { baseY: 0, length: 24, type: "normal" as const },
     };
+    // Real cell-width behaviour is covered in
+    // terminal-xterm-host-unicode-width.test.tsx against a real Terminal; here
+    // the addon just needs somewhere to register.
+    readonly unicode = { activeVersion: "6", register: vi.fn() };
     readonly focus = vi.fn();
     readonly scrollPages = vi.fn();
     readonly scrollToTop = vi.fn();

--- a/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-unicode-width.test.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/__tests__/terminal-xterm-host-unicode-width.test.tsx
@@ -1,0 +1,121 @@
+import "../../../../../__tests__/test-browser-apis";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { TerminalXtermHost } from "@/components/epic-canvas/renderers/terminal-tile-xterm";
+import {
+  __disposeAllXtermHostsForTests,
+  __getXtermHostEntryForTests,
+} from "@/components/epic-canvas/renderers/xterm-host-registry";
+import type { Terminal } from "@xterm/xterm";
+
+const INSTANCE_ID = "unicode-width-instance";
+
+vi.mock("@/providers/use-runner-host", () => ({
+  useRunnerHost: () => ({
+    openExternalLink: vi.fn(() => Promise.resolve()),
+  }),
+}));
+
+vi.mock("@/lib/terminal-theme", () => ({
+  useTerminalTheme: () => ({}),
+}));
+
+// The only part of a 2D context xterm's DOM-renderer WidthCache touches.
+type MeasuringContext = {
+  font: string;
+  measureText: (text: string) => { readonly width: number };
+};
+
+// The shared setup stubs `getContext` to null, which is enough for components
+// that skip drawing when there is no context - but the WidthCache is built
+// during `open()` and throws on a null context. This suite needs a REAL
+// `Terminal`, opened, so it measures real cell widths; monospace-ish text
+// measurement is all the cache asks for.
+beforeAll(() => {
+  const measuringContext: MeasuringContext = {
+    font: "",
+    measureText: (text: string) => ({ width: text.length * 8 }),
+  };
+  const getContext = (contextId: string): MeasuringContext | null =>
+    contextId === "2d" ? measuringContext : null;
+  // `defineProperty` rather than assignment: the real `getContext` is a set of
+  // overloads returning full context types, so no narrower function is
+  // assignable to it without an assertion the type rules here rightly forbid.
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    value: getContext,
+  });
+});
+
+function renderHost(): void {
+  render(
+    <TerminalXtermHost
+      sessionId="unicode-width-session"
+      tileKind="terminal"
+      instanceId={INSTANCE_ID}
+      effectiveCols={40}
+      effectiveRows={4}
+      onUserInput={vi.fn()}
+      onContainerResize={vi.fn()}
+      onWriterReady={vi.fn()}
+      shouldFocusOnActivePane={false}
+      registerImperativeFocus
+      findTargetId={null}
+      keepAlive={false}
+      chrome="padded"
+    />,
+  );
+}
+
+async function mountedTerminal(): Promise<Terminal> {
+  renderHost();
+  await waitFor(() => {
+    expect(__getXtermHostEntryForTests(INSTANCE_ID)).not.toBeNull();
+  });
+  const entry = __getXtermHostEntryForTests(INSTANCE_ID);
+  if (entry === null) throw new Error("xterm host engine was never created");
+  return entry.term;
+}
+
+function write(term: Terminal, chunk: string): Promise<void> {
+  return new Promise((resolve) => term.write(chunk, () => resolve()));
+}
+
+function lineText(term: Terminal, row: number): string {
+  return term.buffer.active.getLine(row)?.translateToString(true) ?? "";
+}
+
+// The host advertises `TERM_PROGRAM=kitty` to TUI sessions, so chat TUIs
+// (claude-code, codex) do their cursor math with string-width semantics, where
+// U+2705 / U+274C are width 2. xterm defaults to the Unicode 6 tables, where
+// they are width 1. These tests pin the renderer to the same width model the
+// TUIs assume - see the Unicode11Addon comment in terminal-tile-xterm.tsx.
+describe("<TerminalXtermHost /> emoji cell width", () => {
+  afterEach(() => {
+    cleanup();
+    __disposeAllXtermHostsForTests();
+  });
+
+  it("advances the cursor two columns for an emoji the TUI counts as width 2", async () => {
+    const term = await mountedTerminal();
+
+    await write(term, "✅X");
+
+    expect(term.buffer.active.cursorX).toBe(3);
+  });
+
+  it("keeps an incremental repaint aligned when the TUI positions with width-2 math", async () => {
+    const term = await mountedTerminal();
+    const row = "│ ✅ ok │ ❌ iterate │ end";
+    // Where the TUI believes "iterate" starts: 13 columns of prefix counting
+    // both emoji as width 2. It repaints that span with a RELATIVE move
+    // (column 1, then cursor-forward), which is exactly what makes the drift
+    // visible - one column per emoji if the grid disagrees about the width.
+    const iterateColumnOffset = 13;
+
+    await write(term, `\x1b[1;1H\x1b[2K${row}`);
+    await write(term, `\x1b[1;1H\x1b[${iterateColumnOffset}CUPDATED`);
+
+    expect(lineText(term, 0)).toBe("│ ✅ ok │ ❌ UPDATED │ end");
+  });
+});

--- a/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
+++ b/clients/gui-app/src/components/epic-canvas/renderers/terminal-tile-xterm.tsx
@@ -18,6 +18,7 @@ import {
 } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { CanvasAddon } from "@xterm/addon-canvas";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import "@xterm/xterm/css/xterm.css";
 import { useRegisterTileFindAdapter } from "@/components/epic-canvas/tile-find/tile-find-adapter-context";
 import {
@@ -605,6 +606,22 @@ function createXtermEntry(
   containerEl.dataset.testid = "terminal-xterm-host";
 
   const term = new Terminal(initialOptions);
+  // Measure cells with the Unicode 11 width tables, not xterm's Unicode 6
+  // default. The host advertises `TERM_PROGRAM=kitty` to TUI sessions, so chat
+  // TUIs (claude-code, codex) lay out their frames with string-width
+  // semantics, where emoji like U+2705/U+274C are two columns wide. Unicode 6
+  // calls those one column, and the disagreement only shows up on INCREMENTAL
+  // repaints: the TUI moves the cursor relatively (column 1 + cursor-forward)
+  // to rewrite a span, lands one column short per emoji, and paints over its
+  // own table borders - garble that "fixes itself" on the next resize because
+  // that forces a full redraw with absolute positioning.
+  //
+  // This is one half of a width contract with the host's snapshot emulator
+  // (traycer-host `terminal-snapshot-emulator.ts`), which sets the same
+  // unicode version so a reattach snapshot replays into an identically
+  // measured grid. The two must move together.
+  term.loadAddon(new Unicode11Addon());
+  term.unicode.activeVersion = "11";
   const fitAddon = new FitAddon();
   term.loadAddon(fitAddon);
   // Route every clicked link to the host's external-browser path. Left at its

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.1.0-beta.0",


### PR DESCRIPTION
## Symptom

TUI terminal tiles garble emoji-bearing tables while you scroll, and the garble
"fixes itself" the moment you resize the pane.

## Root cause

The host advertises `TERM_PROGRAM=kitty` to TUI sessions (deliberately — it is
what makes the kitty keyboard protocol, and therefore Shift+Enter, work). Chat
TUIs take that at face value and lay out their frames with string-width
semantics, where emoji like ✅ U+2705 and ❌ U+274C are **two** columns wide.

xterm defaults to the Unicode 6 width tables, where those are **one** column.

Full redraws hide the disagreement because they position absolutely. Incremental
repaints do not: to rewrite a span the TUI moves the cursor relatively (column 1,
then cursor-forward by its own computed offset), so it lands one column short per
emoji ahead of the span and paints over its own table borders. A resize looks
like a fix only because it forces a full, absolutely-positioned redraw.

```
TUI intends : │ ✅ ok │ ❌ UPDATED │ end
xterm renders: │ ✅ ok │ ❌ itUPDATED end
```

## Fix

Load `Unicode11Addon` and select unicode version 11 on the one `Terminal` the
GUI creates (`createXtermEntry`), so the renderer measures cells the same way the
TUI does.

This is one half of a width contract. The host's snapshot emulator
(`terminal-snapshot-emulator.ts`) serializes a grid that is replayed into this
terminal, so it is moving to Unicode 11 in the same change set; the two versions
must stay in lockstep. The code comment at the call site says so.

`@xterm/addon-unicode-graphemes` is deliberately **not** used — it crashes
against the `@xterm/xterm` 6.1.0-beta train this repo pins.

## Tests

`terminal-xterm-host-unicode-width.test.tsx` mounts the real `TerminalXtermHost`
with a **real** `@xterm/xterm` `Terminal` (the shared setup stubs `getContext` to
null, which the DOM renderer's `WidthCache` rejects, so this suite installs a
text-measuring 2D stub) and asserts against the live buffer:

- `✅X` leaves the cursor at column 3, not 2.
- The repaint scenario above lands as `│ ✅ ok │ ❌ UPDATED │ end`.

Both were confirmed failing before the fix, with exactly the drift shown above:

```
AssertionError: expected 2 to be 3
AssertionError: expected '│ ✅ ok │ ❌ itUPDATED end' to be '│ ✅ ok │ ❌ UPDATED │ end'
```

The two existing renderer suites that mock `@xterm/xterm` needed a `unicode`
stub on their mock `Terminal` for the addon to register against. All 226 tests
across the 32 renderer suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
