### PR TITLE
fix(desktop): re-stage the bundled CLI when the slot binary fails the version probe

### DIFF
--- a/clients/desktop/src/electron-main/cli/__tests__/cli-reconcile.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/cli-reconcile.test.ts
@@ -311,6 +311,9 @@ describe("reconcileCli - newest-wins", () => {
   });
 
   it("trusts a newer manifest CLI silently", async () => {
+    // The probe must CONFIRM the newer version - trusting rests on the
+    // binary being able to answer, not on the manifest's claim alone (see
+    // the probe-failure tests below for the other half of that contract).
     const { deps, install } = makeDeps({
       manifest: {
         version: "2.0.0",
@@ -321,6 +324,7 @@ describe("reconcileCli - newest-wins", () => {
       },
       bundledPath: "/bundled/traycer",
       bundledVersion: "1.4.2",
+      probeCliVersion: () => "2.0.0",
     });
     const result = await reconcileCli(deps);
     expect(install).not.toHaveBeenCalled();
@@ -328,6 +332,62 @@ describe("reconcileCli - newest-wins", () => {
     if (result.kind === "trusted-equal") {
       expect(result.installedVersion).toBe("2.0.0");
       expect(result.binaryPath).toBe("/new/traycer");
+    }
+  });
+
+  it("re-stages the bundled CLI over a desktop-owned slot binary that fails the version probe", async () => {
+    // v1.1.9-rc.3 field incident: the slot binary was overwritten with a
+    // non-executable file while the manifest kept claiming 2.0.0. The
+    // version compare then read "newer than bundled" on every launch and
+    // trusted a binary that could not even print `--version` - a
+    // permanently dead CLI with no self-heal short of reinstalling the
+    // app. A failed probe on the desktop-owned slot must route through
+    // the upgrade path, never the trust branch.
+    const { deps, install } = makeDeps({
+      manifest: {
+        version: "2.0.0",
+        installedAt: "2026-04-01T00:00:00Z",
+        binaryPath: "/stable/traycer",
+        source: "desktop",
+        pendingUpgrade: null,
+      },
+      bundledPath: "/bundled/traycer",
+      bundledVersion: "1.4.2",
+      probeCliVersion: () => null,
+    });
+    const result = await reconcileCli(deps);
+    expect(install).toHaveBeenCalledWith({
+      bundledCliPath: "/bundled/traycer",
+      version: "1.4.2",
+      source: "desktop",
+    });
+    expect(result.kind).toBe("upgraded");
+    if (result.kind === "upgraded") {
+      expect(result.previousVersion).toBe("2.0.0");
+      expect(result.newVersion).toBe("1.4.2");
+    }
+  });
+
+  it("routes a probe-failed slot to upgrade-blocked when no bundled binary is reachable", async () => {
+    // Broken slot AND no bundled source to heal from (a packaging bug):
+    // surfacing upgrade-blocked beats calling the dead binary trusted.
+    const { deps, install } = makeDeps({
+      manifest: {
+        version: "2.0.0",
+        installedAt: "2026-04-01T00:00:00Z",
+        binaryPath: "/stable/traycer",
+        source: "desktop",
+        pendingUpgrade: null,
+      },
+      bundledPath: null,
+      bundledVersion: "1.4.2",
+      probeCliVersion: () => null,
+    });
+    const result = await reconcileCli(deps);
+    expect(install).not.toHaveBeenCalled();
+    expect(result.kind).toBe("upgrade-blocked");
+    if (result.kind === "upgrade-blocked") {
+      expect(result.reason).toBe("manifest-rewrite-failed");
     }
   });
 
@@ -557,6 +617,7 @@ describe("reconcileCli - newest-wins", () => {
       },
       bundledPath: "/bundled/traycer",
       bundledVersion: "1.4.2",
+      probeCliVersion: () => "1.4.2",
     });
     const result = await reconcileCli(deps);
     expect(install).not.toHaveBeenCalled();

--- a/clients/desktop/src/electron-main/cli/cli-reconcile.ts
+++ b/clients/desktop/src/electron-main/cli/cli-reconcile.ts
@@ -29,6 +29,11 @@ type PackageManagerSource =
  *     path and rewrite the manifest. If the live binary is locked (typical
  *     on Windows), surface a `pendingUpgrade` instead of erroring.
  *
+ *   - If the Desktop-owned slot binary is present but cannot report its
+ *     version (failed probe: corrupt file, ENOEXEC, hang), never let the
+ *     manifest's recorded version stand in for it - route through the same
+ *     upgrade path and re-stage the bundled CLI over it.
+ *
  *   - If a **package-manager**-owned CLI (homebrew/npm/winget/scoop/apt/rpm) is
  *     older than the bundled CLI, **do not** overwrite it. Return a
  *     reconciliation outcome with platform/source-specific upgrade
@@ -331,9 +336,36 @@ export async function reconcileCli(
     });
   }
 
+  // Case 2b: the desktop-owned slot binary is present (case 2a saw it) but
+  // cannot report its version - a corrupt file's ENOEXEC, garbage
+  // `--version` output, and a hung binary all collapse to a null probe.
+  // The manifest's recorded version is exactly what must NOT stand in for
+  // it then: a broken slot plus a record claiming >= bundled reads
+  // "trusted-equal" on every launch, and the CLI stays dead until a manual
+  // reinstall (v1.1.9-rc.3 field incident: the slot held a non-executable
+  // file while the manifest claimed 2.0.0, so reconcile trusted it
+  // indefinitely). A binary that cannot even print its version has nothing
+  // worth preserving, so route it through the upgrade path below - which
+  // re-stages the app's own bundled CLI and already owns the
+  // binary-locked/pendingUpgrade fallbacks - instead of the trust branch.
+  // A transiently failing probe (the 2s timeout under cold-launch I/O)
+  // merely re-stages bytes the desktop owns anyway; the next launch probes
+  // the healthy copy and trusts it again.
+  const slotBinaryUnresponsive =
+    manifest.source === "desktop" && probedManifestVersion === null;
+
   // Case 2: manifest present. Compare versions.
   const cmp = compareSemver(installedVersion, bundledVersion);
-  if (cmp >= 0) {
+  if (slotBinaryUnresponsive) {
+    deps.logger.warn(
+      "[cli-reconcile] desktop-owned slot binary failed the version probe - re-staging the bundled CLI over it instead of trusting the manifest record",
+      {
+        binaryPath: manifest.binaryPath,
+        manifestVersion: manifest.version,
+        bundledVersion,
+      },
+    );
+  } else if (cmp >= 0) {
     // Version comparison is blind between two dogfood builds: every local
     // build stamps the same `0.0.0-local` sentinel, so a stale slot CLI
     // reads "equal" forever and keeps running host installs/stops with old


### PR DESCRIPTION
## Problem

Launch-time CLI reconcile trusted the manifest's **recorded** version whenever the slot binary's `--version` probe failed. `probeCliVersion` collapses ENOEXEC, garbage output, and hangs to `null`, and the fallback (`probedManifestVersion ?? manifest.version`) substituted the manifest's claim into the version compare.

A corrupt desktop-owned slot binary whose manifest claims ≥ bundled therefore read `trusted-equal` on **every** launch — a permanently dead CLI (shell: `command not found`; desktop: `spawn ENOEXEC` on every `runnerHost:traycer:host:*` call) with no self-heal short of reinstalling the app.

Case 2a heals a **missing** slot binary. A present-but-non-executable one is the other half of field report 5's "exists but won't run" class, and it was hit in the field on v1.1.9-rc.3: the slot held a non-executable file while the manifest claimed `2.0.0`, and reconcile trusted it indefinitely.

## Fix

A desktop-owned slot binary that cannot report its version now routes through the **existing upgrade path** — re-staging the app's own bundled CLI and reusing the binary-locked / `pendingUpgrade` handling — instead of the trust branch.

- With no bundled binary to heal from (packaging bug), it surfaces `upgrade-blocked` rather than calling the dead binary trusted.
- A transient probe failure (the 2 s timeout under cold-launch I/O) merely re-stages bytes the desktop owns anyway; the next launch probes the healthy copy and trusts it again. Non-desktop sources are never probed and keep their existing semantics.

## Tests

- New: a probe-failed slot with a manifest claiming a *newer* version re-stages the bundled CLI (the exact rc.3 shape).
- New: a probe-failed slot with no bundled binary reachable surfaces `upgrade-blocked`, not `trusted-equal`.
- Sharpened: the two "trust" tests now pass an explicit healthy probe, pinning that trusting rests on the binary answering — not on the manifest's claim alone.
- Mutation-probed: disabling the reroute fails exactly the two new tests (37/39 stay green).