### PR TITLE
test(desktop): sandbox the suite's home at the os boundary on every runtime

### DIFF
--- a/clients/desktop/src/electron-main/__tests__/home-sandbox.test.ts
+++ b/clients/desktop/src/electron-main/__tests__/home-sandbox.test.ts
@@ -1,0 +1,78 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os, { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { sandboxHome } from "./sandbox-home";
+
+// Pins the contract of vitest.setup.ts + sandboxHome(): the suite's notion
+// of "home" must be impossible to point at the real `~` - on ANY runtime.
+// The escape this closes wrote the `cli-bytes-v2` fixture into the real
+// `~/.traycer/cli/bin/traycer` (a dead CLI in the field on v1.1.9-rc.3)
+// and "Studio Mac" into the real `~/.traycer/host/host-name.json`, because
+// Bun's `os.homedir()` ignores a mid-process `process.env.HOME` mutation
+// while Node's follows it.
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+
+afterEach(() => {
+  if (ORIGINAL_HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = ORIGINAL_HOME;
+  }
+  if (ORIGINAL_USERPROFILE === undefined) {
+    delete process.env.USERPROFILE;
+  } else {
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+  }
+});
+
+describe("home sandbox (vitest.setup.ts + sandboxHome)", () => {
+  it("baselines homedir() into a temp sandbox before any test runs", () => {
+    // The setup file must have redirected home before this file loaded, so
+    // even a suite that never touches HOME (or writes through electron-log)
+    // resolves a sandbox, never the real user home.
+    expect(homedir()).toContain("traycer-desktop-tests-home-");
+  });
+
+  it("homedir() follows a mid-test sandboxHome() redirect on every runtime", () => {
+    // Node re-reads $HOME per call; Bun caches home at startup and needs
+    // the setup's homedir re-point for this to hold. Either way, the suite
+    // contract is the same: after sandboxHome(dir), homedir() IS dir.
+    const dir = mkdtempSync(join(tmpdir(), "home-sandbox-contract-"));
+    try {
+      sandboxHome(dir);
+      expect(homedir()).toBe(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("sandboxHome throws before the subject runs when homedir() does not follow", () => {
+    // Simulates the escape: a runtime whose homedir() ignores the env
+    // redirect (Bun without the setup re-point). The tripwire must refuse
+    // to hand control to a test body that would write home-relative paths.
+    const patched = os.homedir;
+    (os as { homedir: () => string }).homedir = () =>
+      "/definitely/not/the/sandbox";
+    try {
+      expect(() => sandboxHome("/tmp/some-sandbox")).toThrowError(
+        /refusing to run a suite that writes home-relative paths/,
+      );
+    } finally {
+      (os as { homedir: () => string }).homedir = patched;
+    }
+  });
+
+  it("electron-log's file transport resolves under the sandbox, not the real user log", async () => {
+    // The Jul 2026 pollution vector: suites importing the real electron-log
+    // appended their error stacks to the REAL ~/Library/Logs/Traycer/
+    // main.log, because its file transport finds "home" via require("os")
+    // .homedir(). With the setup baseline in place it must land in the
+    // sandbox.
+    const log = (await import("electron-log")).default;
+    const file = log.transports.file.getFile();
+    expect(file.path).toContain("traycer-desktop-tests-home-");
+  });
+});

--- a/clients/desktop/src/electron-main/__tests__/sandbox-home.ts
+++ b/clients/desktop/src/electron-main/__tests__/sandbox-home.ts
@@ -1,0 +1,37 @@
+import os from "node:os";
+
+/**
+ * Redirect `HOME`/`USERPROFILE` to the given per-test sandbox and PROVE the
+ * redirect took effect before returning.
+ *
+ * Under Node, `os.homedir()` re-reads the env on every call, so the check
+ * passes trivially. Under the Bun runtime the mid-process env mutation is
+ * IGNORED (Bun caches the home at process start), and when
+ * `vitest.setup.ts` has not been loaded to re-point `homedir` - `bun test`
+ * never loads vitest setup files - `homedir()` keeps resolving the REAL
+ * home. That exact escape let desktop suites write their fixtures into the
+ * real `~/.traycer/cli/bin/traycer` (the v1.1.9-rc.3 dead-CLI incident) and
+ * the real `~/.traycer/host/host-name.json`. Throwing here kills the test
+ * before its subject can write anything.
+ *
+ * Every desktop test that points home-relative production code at a temp
+ * dir must go through this helper instead of assigning `process.env.HOME`
+ * directly.
+ */
+export function sandboxHome(sandboxDir: string): void {
+  process.env.HOME = sandboxDir;
+  process.env.USERPROFILE = sandboxDir;
+  // Read `homedir` off the module object at CALL time (a named import
+  // captures the binding at import time and would keep seeing whatever was
+  // installed when this module loaded, defeating both the check and its
+  // contract test).
+  const resolved = os.homedir();
+  if (resolved !== sandboxDir) {
+    throw new Error(
+      `home sandbox did not take effect: os.homedir() resolved "${resolved}" instead of "${sandboxDir}". ` +
+        "This runtime does not follow process.env.HOME (Bun caches the home at startup) and the vitest.setup.ts " +
+        "homedir re-point is not active - refusing to run a suite that writes home-relative paths against the " +
+        "real home. Run the suite with vitest on Node (`bun run test`), not `bun test` or `bunx --bun vitest`.",
+    );
+  }
+}

--- a/clients/desktop/src/electron-main/auth/__tests__/credentials-migration.test.ts
+++ b/clients/desktop/src/electron-main/auth/__tests__/credentials-migration.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 import { cliCredentialsPath } from "@traycer/protocol/config/paths";
 import {
   readCredentialsFile,
@@ -213,7 +214,7 @@ describe("FileTokenStore.migrateLegacyCredentials (real fs + lock/WAL)", () => {
   beforeEach(async () => {
     homeDir = mkdtempSync(join(tmpdir(), "traycer-credentials-migration-"));
     previousHome = process.env.HOME;
-    process.env.HOME = homeDir;
+    sandboxHome(homeDir);
     vi.resetModules();
     ({ FileTokenStore } = await import("../file-token-store"));
   });

--- a/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
+++ b/clients/desktop/src/electron-main/auth/__tests__/file-token-store.test.ts
@@ -15,6 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 import { cliCredentialsPath } from "@traycer/protocol/config/paths";
 import {
   deleteCredentialsFile,
@@ -112,7 +113,7 @@ describe("FileTokenStore (real fs + lock/WAL)", () => {
   beforeEach(async () => {
     homeDir = mkdtempSync(join(tmpdir(), "traycer-file-token-store-"));
     previousHome = process.env.HOME;
-    process.env.HOME = homeDir;
+    sandboxHome(homeDir);
     vi.resetModules();
     ({ FileTokenStore } = await import("../file-token-store"));
     // Default: any refresh mints a deterministic rotated pair.

--- a/clients/desktop/src/electron-main/cli/__tests__/install-bundled-cli.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/install-bundled-cli.test.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 
 // The slot used to be a POSIX symlink into the .app bundle - field report
 // 5's "file exists but won't run": remove or replace the bundle and the
@@ -58,10 +59,7 @@ beforeEach(() => {
   work = mkdtempSync(join(tmpdir(), "traycer-install-bundled-cli-"));
   homeDir = join(work, "home");
   mkdirSync(homeDir, { recursive: true });
-  process.env.HOME = homeDir;
-  if (process.platform === "win32") {
-    process.env.USERPROFILE = homeDir;
-  }
+  sandboxHome(homeDir);
   vi.resetModules();
 });
 

--- a/clients/desktop/src/electron-main/cli/__tests__/resolve-cli-invocation-dev.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/resolve-cli-invocation-dev.test.ts
@@ -8,6 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 
 import devWrapperPaths from "../dev-wrapper-paths.json";
 import { DEV_DESKTOP_SLOT_ENV } from "../../host/dev-desktop-slot";
@@ -90,10 +91,7 @@ beforeEach(() => {
   work = mkdtempSync(join(tmpdir(), "traycer-cli-discovery-dev-"));
   homeDir = join(work, "home");
   mkdirSync(homeDir, { recursive: true });
-  process.env.HOME = homeDir;
-  if (process.platform === "win32") {
-    process.env.USERPROFILE = homeDir;
-  }
+  sandboxHome(homeDir);
 });
 
 afterEach(() => {

--- a/clients/desktop/src/electron-main/cli/__tests__/resolve-cli-invocation-staging.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/resolve-cli-invocation-staging.test.ts
@@ -8,6 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 
 // Internal-only `staging` deploy slot. Like dev, staging is a NON-production
 // build, but unlike dev it is NOT `isDevBuild`. CLI discovery must still skip
@@ -100,10 +101,7 @@ beforeEach(() => {
   resourcesDir = join(work, "resources");
   mkdirSync(homeDir, { recursive: true });
   mkdirSync(resourcesDir, { recursive: true });
-  process.env.HOME = homeDir;
-  if (process.platform === "win32") {
-    process.env.USERPROFILE = homeDir;
-  }
+  sandboxHome(homeDir);
   Object.defineProperty(process, "resourcesPath", {
     value: resourcesDir,
     configurable: true,

--- a/clients/desktop/src/electron-main/cli/__tests__/resolve-cli-invocation.test.ts
+++ b/clients/desktop/src/electron-main/cli/__tests__/resolve-cli-invocation.test.ts
@@ -8,6 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 
 // Native-packaging ticket - `resolveTraycerCliInvocation` in packaged
 // mode must use the CLI discovery model (Tech Plan Decision 6):
@@ -109,10 +110,7 @@ beforeEach(() => {
   mkdirSync(resourcesDir, { recursive: true });
   cliBinDir = join(homeDir, ".traycer", "cli", "bin");
   manifestPath = join(homeDir, ".traycer", "cli", "manifest.json");
-  process.env.HOME = homeDir;
-  if (process.platform === "win32") {
-    process.env.USERPROFILE = homeDir;
-  }
+  sandboxHome(homeDir);
   Object.defineProperty(process, "resourcesPath", {
     value: resourcesDir,
     configurable: true,

--- a/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
+++ b/clients/desktop/src/electron-main/host/__tests__/host-controller.test.ts
@@ -10,6 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 
 // Host Update Layer Redesign Tech Plan - Ticket: "Desktop main: HostController
 // two-lane scheduler + policy cutover". This is the ticket's own verification
@@ -150,8 +151,7 @@ let workHome: string;
 
 beforeEach(() => {
   workHome = mkdtempSync(join(tmpdir(), "traycer-host-controller-"));
-  process.env.HOME = workHome;
-  process.env.USERPROFILE = workHome;
+  sandboxHome(workHome);
   delete process.env[DEV_DESKTOP_SLOT_ENV];
   // `withDesktopCliLock`'s `open(path, "wx", ...)` needs the lock file's
   // parent directory to already exist (production always has it - the CLI

--- a/clients/desktop/src/electron-main/ipc/__tests__/host-management-channel.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/host-management-channel.test.ts
@@ -18,6 +18,7 @@ import {
   vi,
   type Mock,
 } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 import type { IpcHostController } from "../runner-ipc-bridge";
 import type {
   ActivateInstalledOk,
@@ -78,8 +79,7 @@ let workHome: string;
 
 beforeEach(() => {
   workHome = mkdtempSync(join(tmpdir(), "traycer-host-mgmt-environment-"));
-  process.env.HOME = workHome;
-  process.env.USERPROFILE = workHome;
+  sandboxHome(workHome);
   vi.resetModules();
 });
 

--- a/clients/desktop/src/electron-main/ipc/__tests__/registry-update-cache.test.ts
+++ b/clients/desktop/src/electron-main/ipc/__tests__/registry-update-cache.test.ts
@@ -9,6 +9,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sandboxHome } from "../../__tests__/sandbox-home";
 import type { IpcHostController } from "../runner-ipc-bridge";
 import type { HostControllerStatus } from "../../host/host-controller-types";
 import { DEV_DESKTOP_SLOT_ENV } from "../../host/dev-desktop-slot";
@@ -93,8 +94,7 @@ interface RegistryPlatformAssetFixture {
 
 beforeEach(() => {
   workHome = mkdtempSync(join(tmpdir(), "traycer-registry-cache-"));
-  process.env.HOME = workHome;
-  process.env.USERPROFILE = workHome;
+  sandboxHome(workHome);
   vi.resetModules();
 });
 

--- a/clients/desktop/vitest.config.ts
+++ b/clients/desktop/vitest.config.ts
@@ -44,5 +44,11 @@ export default defineConfig({
     // jsdom provides `self` / `window` / `localStorage` so the renderer-shell
     // tests can `import "encrypt-storage"` (UMD wrapper references `self`).
     environment: "jsdom",
+    // Home sandbox: re-points `os.homedir()` at the (per-test) env and
+    // baselines HOME to a temp dir, so no suite - nor electron-log's file
+    // transport - can write into the real `~` on any runtime. Deliberately
+    // NOT wired into vitest.config.packaging.ts: the real electron-builder
+    // pack there needs the real `~/Library/Caches/electron-builder`.
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/clients/desktop/vitest.setup.ts
+++ b/clients/desktop/vitest.setup.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import os from "node:os";
 import { join } from "node:path";
 import { afterAll } from "vitest";
@@ -55,6 +56,14 @@ if (process.platform === "win32") {
 (os as { homedir: () => string }).homedir = () =>
   (process.platform === "win32" ? process.env.USERPROFILE : process.env.HOME) ??
   baselineHome;
+// vite-node-transformed modules (every first-party file and test) read the
+// property off the module object at import time, so they see the patch
+// without this. But an UNTRANSFORMED dependency running as real Node ESM
+// holds static named bindings (`import { homedir } from "node:os"`) that
+// only re-sync with the module object when this is called. One call
+// suffices: the installed function is a closure over the env, so its
+// identity never changes again.
+syncBuiltinESMExports();
 
 afterAll(() => {
   rmSync(baselineHome, { recursive: true, force: true });

--- a/clients/desktop/vitest.setup.ts
+++ b/clients/desktop/vitest.setup.ts
@@ -38,6 +38,19 @@ const baselineHome = mkdtempSync(
 );
 process.env.HOME = baselineHome;
 process.env.USERPROFILE = baselineHome;
+// The platform app-dir env family short-circuits homedir()-based
+// resolution: electron-log's Linux logs path is `XDG_CONFIG_HOME ||
+// ~/.config` and its Windows path is `APPDATA || ~\AppData\Roaming`, and
+// GitHub's ubuntu runners EXPORT XDG_CONFIG_HOME - so without re-pointing
+// these, the sandbox leaks back to the real home exactly where CI runs.
+process.env.XDG_CONFIG_HOME = join(baselineHome, ".config");
+process.env.XDG_DATA_HOME = join(baselineHome, ".local", "share");
+process.env.XDG_STATE_HOME = join(baselineHome, ".local", "state");
+process.env.XDG_CACHE_HOME = join(baselineHome, ".cache");
+if (process.platform === "win32") {
+  process.env.APPDATA = join(baselineHome, "AppData", "Roaming");
+  process.env.LOCALAPPDATA = join(baselineHome, "AppData", "Local");
+}
 
 (os as { homedir: () => string }).homedir = () =>
   (process.platform === "win32" ? process.env.USERPROFILE : process.env.HOME) ??

--- a/clients/desktop/vitest.setup.ts
+++ b/clients/desktop/vitest.setup.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterAll } from "vitest";
+
+// Sandbox the suite's notion of "home" at the `os` boundary, not the env var.
+//
+// `os.homedir()` under the Bun runtime resolves the REAL home even after
+// `process.env.HOME` is reassigned mid-process (Bun caches the home at
+// startup; Node re-reads the env on every call). Every suite here that
+// sandboxes itself with `process.env.HOME = <tempdir>` in a `beforeEach`
+// therefore escapes silently when vitest is executed on the Bun runtime
+// (`bunx --bun vitest`, `bun node_modules/.bin/vitest`) - the production
+// code under test writes its fixtures into the real `~`. That is not
+// hypothetical: one escaped run overwrote the real
+// `~/.traycer/cli/bin/traycer` with the `cli-bytes-v2` fixture (a dead CLI
+// in the field on v1.1.9-rc.3, because launch-time reconcile then trusted
+// the poisoned manifest) and another planted "Studio Mac" as the user's
+// real host display name.
+//
+// Re-pointing `homedir` on the module object covers every consumer in the
+// worker: `node:os` and `os` resolve to the same builtin instance, so
+// first-party `import { homedir } from "node:os"` call sites and
+// electron-log's internal `require("os")` (which is how its file transport
+// finds `~/Library/Logs` - previously appending test noise to the REAL
+// user log) all follow the env from here on, on every runtime.
+//
+// The baseline below points at a per-worker temp dir so suites that never
+// touch HOME are sandboxed too. Suites that redirect HOME per test keep
+// doing so through `sandboxHome()` (src/electron-main/__tests__/
+// sandbox-home.ts), whose tripwire refuses to run the test when this file
+// was never loaded to make the redirect effective - `bun test` (Bun's own
+// runner) ignores vitest setup files entirely, so the tripwire is the
+// backstop there.
+
+const baselineHome = mkdtempSync(
+  join(os.tmpdir(), "traycer-desktop-tests-home-"),
+);
+process.env.HOME = baselineHome;
+process.env.USERPROFILE = baselineHome;
+
+(os as { homedir: () => string }).homedir = () =>
+  (process.platform === "win32" ? process.env.USERPROFILE : process.env.HOME) ??
+  baselineHome;
+
+afterAll(() => {
+  rmSync(baselineHome, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Problem

Desktop suites sandboxed themselves with `process.env.HOME = <tempdir>` in a `beforeEach`. Node's `os.homedir()` re-reads the env on every call, so that held under vitest on Node — but **Bun caches the home at process start and ignores the mid-process mutation**, so any Bun-runtime execution of the same tests (`bunx --bun vitest`, `bun node_modules/.bin/vitest`) ran with `homedir()` resolving the **real** home.

Two escapes are known to have shipped fixtures into real user state:

- `cli-bytes-v2` overwrote the real `~/.traycer/cli/bin/traycer` — surfaced in the field on v1.1.9-rc.3 as a dead CLI (`line 1: cli-bytes-v2: command not found` / `spawn ENOEXEC`), because launch-time reconcile then trusted the poisoned manifest (self-heal fixed in #810).
- `"Studio Mac"` became the user's real host display name via `~/.traycer/host/host-name.json`.

Separately, suites importing the real `electron-log` appended their error stacks to the real `~/Library/Logs/Traycer/main.log` on every full run, on **any** runtime — its file transport resolves `~` via `require("os").homedir()`.

## Fix — three layers

1. **`vitest.setup.ts`** re-points `os.homedir` at the env (platform-appropriate var; per-worker temp baseline otherwise) on the shared builtin module object, which `node:os` and `os` consumers — including electron-log — all resolve. Per-test redirects are then effective on every runtime, and suites that never touch HOME land in the baseline sandbox instead of the real home.
2. **`sandboxHome()`** replaces every direct HOME assignment in the nine redirecting suites and *proves* the redirect took effect before returning. Under `bun test` — which never loads vitest setup files — it throws before the test body can write anything (verified against the real Bun runtime).
3. **`home-sandbox.test.ts`** pins the contract: the baseline redirect, follow-on-redirect behavior, the tripwire's refusal, and electron-log's file transport resolving under the sandbox.

The packaging config (`vitest.config.packaging.ts`) deliberately keeps the real home: the real electron-builder pack it runs needs the real `~/Library/Caches/electron-builder`.

## Verification

- Full desktop suite: 89 files / 1097 tests green under the sandbox.
- Real `~/Library/Logs/Traycer/main.log` mtime is byte-identical before/after a full run (previously every run appended to it).
- Tripwire verified red under the actual Bun runtime in an isolated scratch copy.