### PR TITLE
ci(protocol-compat): prefer each release's published protocol-surface.json over tag reconstruction

### DIFF
--- a/.github/workflows/protocol-compat.yml
+++ b/.github/workflows/protocol-compat.yml
@@ -6,14 +6,17 @@ name: Protocol Compatibility
 #  - `protocol-compat` resolves the protected set from the remote's release
 #    tags AT RUN TIME (never from a file in the tree, so a PR cannot shrink
 #    it - the only in-tree knob is `protocol/scripts/compat/support-floor.json`,
-#    guarded by the tripwire job below), dumps each baseline's protocol
-#    surface from its immutable tag in a git worktree, checks the PR tree
-#    against every one in a single combined report (two-sided handshake
-#    bridging + same-version wire-schema rules), and drives the real client
-#    transports against the baseline manifests. This is one job with a
-#    stable name that loops over baselines internally rather than fanning
-#    out a matrix job per baseline, so the required-status-check list in
-#    branch protection never has to change as new releases ship.
+#    guarded by the tripwire job below), obtains each baseline's protocol
+#    surface - preferring the protocol-surface.json asset the release itself
+#    published, which is truthful regardless of where the release tag sits,
+#    and reconstructing it from the tag in a git worktree when the asset is
+#    absent - checks the PR tree against every one in a single combined
+#    report (two-sided handshake bridging + same-version wire-schema rules),
+#    and drives the real client transports against the baseline manifests.
+#    This is one job with a stable name that loops over baselines internally
+#    rather than fanning out a matrix job per baseline, so the
+#    required-status-check list in branch protection never has to change as
+#    new releases ship.
 #  - `guarded-files-tripwire` fails any PR that edits (not adds) the compat
 #    governance files without the `protocol-compat-override` label, making
 #    baseline regeneration a deliberate, reviewable act. This closes the
@@ -70,28 +73,56 @@ jobs:
           jq -r '.[] | "  " + .tags[0] + " (" + .sha + ")"' /tmp/baselines.json
       - name: Dump the working tree's protocol surface
         run: bun run protocol/scripts/compat/dump-protocol-surface.ts > /tmp/working-tree.json
-      - name: Dump every released baseline's protocol surface from its tag
+      - name: Obtain every released baseline's protocol surface (published asset, else reconstruct from tag)
+        env:
+          # Assets live on the BASE repo's releases, same as the tag set.
+          BASE_REPO_URL: ${{ github.event.pull_request.base.repo.clone_url || format('https://github.com/{0}.git', github.repository) }}
         run: |
           set -e
           mkdir -p /tmp/surfaces
           : > /tmp/baseline-args.txt
-          while IFS=$'\t' read -r sha label; do
-            echo "::group::dump ${label} (${sha})"
-            git fetch --no-tags origin "$sha"
-            git worktree add --detach "/tmp/baseline-${label}" "$sha"
-            # Baselines that predate the compat tooling get the (self-contained)
-            # dump script injected; newer tags run their own committed copy.
-            mkdir -p "/tmp/baseline-${label}/protocol/scripts/compat" \
-                     "/tmp/baseline-${label}/protocol/src/framework"
-            [ -f "/tmp/baseline-${label}/protocol/scripts/compat/dump-protocol-surface.ts" ] || \
-              cp protocol/scripts/compat/dump-protocol-surface.ts "/tmp/baseline-${label}/protocol/scripts/compat/"
-            [ -f "/tmp/baseline-${label}/protocol/src/framework/surface-build.ts" ] || \
-              cp protocol/src/framework/surface-build.ts "/tmp/baseline-${label}/protocol/src/framework/"
-            (cd "/tmp/baseline-${label}" && bun install >/dev/null && bun run protocol/scripts/compat/dump-protocol-surface.ts) \
-              > "/tmp/surfaces/${label}.json"
-            echo "${label}=/tmp/surfaces/${label}.json" >> /tmp/baseline-args.txt
+          release_repo_url="${BASE_REPO_URL%.git}"
+          while IFS=$'\t' read -r sha tags; do
+            label="${tags%% *}"
+            echo "::group::surface ${label} (${sha})"
+            out="/tmp/surfaces/${label}.json"
+            # Prefer the protocol-surface.json asset the release itself
+            # published: it was dumped from the build's pinned tree by that
+            # release's own gate, so it stays truthful even when the release
+            # tag was planted on the wrong commit (exactly what blocked the
+            # v1.1.9 desktop release with a phantom stream finding). Any tag
+            # in the sha-group may carry the asset; releases predating it
+            # fall back to reconstructing the surface from the tag commit.
+            fetched=""
+            read -r -a group_tags <<< "$tags"
+            for tag in "${group_tags[@]}"; do
+              if curl -sfL --retry 3 "${release_repo_url}/releases/download/${tag}/protocol-surface.json" -o "$out" \
+                && jq -e 'has("formatVersion") and has("unary") and has("stream")' "$out" >/dev/null 2>&1; then
+                fetched="$tag"
+                break
+              fi
+              rm -f "$out"
+            done
+            if [ -n "$fetched" ]; then
+              echo "using the protocol-surface.json asset published on ${fetched}"
+            else
+              echo "no usable release asset; reconstructing the surface from the tag commit"
+              git fetch --no-tags origin "$sha"
+              git worktree add --detach "/tmp/baseline-${label}" "$sha"
+              # Baselines that predate the compat tooling get the (self-contained)
+              # dump script injected; newer tags run their own committed copy.
+              mkdir -p "/tmp/baseline-${label}/protocol/scripts/compat" \
+                       "/tmp/baseline-${label}/protocol/src/framework"
+              [ -f "/tmp/baseline-${label}/protocol/scripts/compat/dump-protocol-surface.ts" ] || \
+                cp protocol/scripts/compat/dump-protocol-surface.ts "/tmp/baseline-${label}/protocol/scripts/compat/"
+              [ -f "/tmp/baseline-${label}/protocol/src/framework/surface-build.ts" ] || \
+                cp protocol/src/framework/surface-build.ts "/tmp/baseline-${label}/protocol/src/framework/"
+              (cd "/tmp/baseline-${label}" && bun install >/dev/null && bun run protocol/scripts/compat/dump-protocol-surface.ts) \
+                > "$out"
+            fi
+            echo "${label}=${out}" >> /tmp/baseline-args.txt
             echo "::endgroup::"
-          done < <(jq -r '.[] | [.sha, .tags[0]] | @tsv' /tmp/baselines.json)
+          done < <(jq -r '.[] | [.sha, (.tags | join(" "))] | @tsv' /tmp/baselines.json)
       - name: Check surface compatibility against every released baseline (two-sided handshake + wire schemas)
         run: |
           args=()

--- a/.github/workflows/protocol-compat.yml
+++ b/.github/workflows/protocol-compat.yml
@@ -102,7 +102,13 @@ jobs:
             for tag in "${group_tags[@]}"; do
               if curl -sSfL --retry 3 --connect-timeout 10 --max-time 60 \
                 "${release_repo_url}/releases/download/${tag}/protocol-surface.json" -o "$out" \
-                && jq -e 'has("formatVersion") and has("unary") and has("stream")' "$out" >/dev/null 2>&1; then
+                && SURFACE_PATH="$out" bun -e '
+                  import { readFileSync } from "node:fs";
+                  import { protocolSurfaceSchema } from "./protocol/src/framework/surface-compat.ts";
+                  const path = process.env.SURFACE_PATH;
+                  if (path === undefined) throw new Error("SURFACE_PATH is required");
+                  protocolSurfaceSchema.parse(JSON.parse(readFileSync(path, "utf8")));
+                ' >/dev/null 2>&1; then
                 fetched="$tag"
                 break
               fi

--- a/.github/workflows/protocol-compat.yml
+++ b/.github/workflows/protocol-compat.yml
@@ -100,7 +100,7 @@ jobs:
             fetched=""
             read -r -a group_tags <<< "$tags"
             for tag in "${group_tags[@]}"; do
-              if curl -sfL --retry 3 --connect-timeout 10 --max-time 60 \
+              if curl -sSfL --retry 3 --connect-timeout 10 --max-time 60 \
                 "${release_repo_url}/releases/download/${tag}/protocol-surface.json" -o "$out" \
                 && jq -e 'has("formatVersion") and has("unary") and has("stream")' "$out" >/dev/null 2>&1; then
                 fetched="$tag"

--- a/.github/workflows/protocol-compat.yml
+++ b/.github/workflows/protocol-compat.yml
@@ -69,6 +69,10 @@ jobs:
         run: |
           bun run protocol/scripts/compat/resolve-baselines.ts "$BASE_REPO_URL" \
             | jq -c '.baselines' > /tmp/baselines.json
+          if [ "$(jq 'length' /tmp/baselines.json)" = "0" ]; then
+            echo "::error::resolve-baselines.ts produced no protected baselines; refusing to run the gate with zero baselines." >&2
+            exit 1
+          fi
           echo "Protected baselines:"
           jq -r '.[] | "  " + .tags[0] + " (" + .sha + ")"' /tmp/baselines.json
       - name: Dump the working tree's protocol surface
@@ -96,7 +100,8 @@ jobs:
             fetched=""
             read -r -a group_tags <<< "$tags"
             for tag in "${group_tags[@]}"; do
-              if curl -sfL --retry 3 "${release_repo_url}/releases/download/${tag}/protocol-surface.json" -o "$out" \
+              if curl -sfL --retry 3 --connect-timeout 10 --max-time 60 \
+                "${release_repo_url}/releases/download/${tag}/protocol-surface.json" -o "$out" \
                 && jq -e 'has("formatVersion") and has("unary") and has("stream")' "$out" >/dev/null 2>&1; then
                 fetched="$tag"
                 break


### PR DESCRIPTION
## Problem

The gate reconstructs each released baseline's protocol surface from its release tag, which trusts the tag to sit on the commit the release was built from. Host tags historically did not — the internal cross-repo publish created them un-targeted, so GitHub planted every `host-v*` tag on this repo's default-branch HEAD at publish time. That is how the v1.1.9 desktop release gate failed BLOCKING on a `worktree.deleteBatchByPath` stream the shipped host never carried (the tag sat on `main` while the release was built from the `release-v1.1.9` lineage). The v1.1.9 tags have been retargeted, and the internal publish now pins `--target`, but the gate should not have to trust tag placement at all.

## Fix

Prefer the `protocol-surface.json` asset each release publishes (dumped from the build's pinned tree by that release's own gate run, so truthful regardless of tag placement):

- For each sha-deduped baseline group, try each tag's release asset (unauthenticated `curl` from the base repo's releases; sanity-checked with `jq` for `formatVersion`/`unary`/`stream`).
- Any failure — asset absent (releases before cli-v1.1.5 / host-v1.1.7), download error, malformed JSON — falls back to the existing worktree reconstruction.
- The chosen source per baseline is logged in the step's log groups.

## Verification

- Byte-equivalence: for a correctly-tagged release (`cli-v1.1.8`), the published asset and the worktree reconstruction produce identical surfaces (`jq -S` diff clean).
- The equivalent loop was run locally against this repo's live tags: assets served `cli-v1.1.5`…`cli-v1.1.9`, `host-v1.1.7`, `host-v1.1.8`; older baselines reconstructed; every baseline compatible.
- This PR's own `protocol-compat` check runs the modified loop.

Note: this workflow file is tripwire-guarded, so this PR carries the `protocol-compat-override` label. A companion internal PR applies the same change to the internal composite gate. Known follow-up: `snapshot-released-baseline.ts` (the fixture sync) still reconstructs from the newest tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)