### PR TITLE
perf(gui): reconcile epic-tab existence via id-scoped getTaskContexts

### DIFF
--- a/clients/gui-app/src/lib/epics/__tests__/epic-tab-existence.test.ts
+++ b/clients/gui-app/src/lib/epics/__tests__/epic-tab-existence.test.ts
@@ -1,82 +1,33 @@
-import { describe, expect, it, vi } from "vitest";
-import type {
-  EpicLight,
-  ListTasksResponse,
-  TaskLight,
-} from "@traycer/protocol/host/epic/unary-schemas";
-import {
-  fetchExistingEpicIdsFromPages,
-  missingEpicIds,
-} from "@/lib/epics/epic-tab-existence";
+import { describe, expect, it } from "vitest";
+import { missingEpicIds } from "@/lib/epics/epic-tab-existence";
 
-function task(epicId: string): TaskLight {
-  const light: EpicLight = {
-    id: epicId,
-    title: epicId,
-    initialUserPrompt: "",
-    ticketCount: 0,
-    specCount: 0,
-    storyCount: 0,
-    reviewCount: 0,
-    status: "active",
-    createdAt: 0,
-    updatedAt: 0,
-    createdBy: "test",
-    version: "2.0.0",
-  };
-  return {
-    epic: {
-      light,
-      permission: null,
-      repos: [],
-      workspaces: [],
-      roomInfo: null,
-    },
-  };
-}
-
-describe("epic tab existence reconciliation", () => {
-  it("fetches every page before deciding which persisted epic tabs are stale", async () => {
-    const pages: ReadonlyArray<ListTasksResponse> = [
-      { tasks: [task("epic-a")], hasMore: true, nextCursor: "page-2" },
-      { tasks: [task("epic-b")], hasMore: false },
-    ];
-    const fetchPage = vi.fn((cursor: string | undefined) => {
-      const page = cursor === undefined ? pages[0] : pages[1];
-      return Promise.resolve(page);
-    });
-
-    const existingEpicIds = await fetchExistingEpicIdsFromPages(fetchPage);
-
-    expect(fetchPage).toHaveBeenCalledTimes(2);
-    expect(fetchPage).toHaveBeenNthCalledWith(1, undefined);
-    expect(fetchPage).toHaveBeenNthCalledWith(2, "page-2");
-    expect(Array.from(existingEpicIds).sort()).toEqual(["epic-a", "epic-b"]);
+describe("missingEpicIds", () => {
+  it("reports only the open ids the host did not confirm", () => {
     expect(
-      missingEpicIds(["epic-a", "epic-b", "epic-deleted"], existingEpicIds),
+      missingEpicIds(
+        ["epic-a", "epic-b", "epic-deleted"],
+        new Set(["epic-a", "epic-b"]),
+      ),
     ).toEqual(["epic-deleted"]);
   });
 
-  it("does not treat malformed epic rows as existing epics", async () => {
-    const existingEpicIds = await fetchExistingEpicIdsFromPages(() =>
-      Promise.resolve({
-        tasks: [
-          {
-            epic: {
-              light: null,
-              permission: null,
-              repos: [],
-              workspaces: [],
-              roomInfo: null,
-            },
-          },
-        ],
-        hasMore: false,
-      }),
-    );
-
-    expect(missingEpicIds(["epic-missing"], existingEpicIds)).toEqual([
-      "epic-missing",
+  it("reports every open id when nothing was confirmed", () => {
+    // The reconciler must never reach this with an unresolved lookup - an
+    // empty confirmed set means every tab is stale. `EpicTabExistenceProbe`
+    // passes `null` (conclude nothing) instead; see
+    // epic-tab-existence-reconciler.test.tsx.
+    expect(missingEpicIds(["epic-a", "epic-b"], new Set())).toEqual([
+      "epic-a",
+      "epic-b",
     ]);
+  });
+
+  it("preserves open-tab order and ignores confirmed ids with no open tab", () => {
+    expect(
+      missingEpicIds(
+        ["epic-c", "epic-a", "epic-b"],
+        new Set(["epic-a", "epic-unopened"]),
+      ),
+    ).toEqual(["epic-c", "epic-b"]);
   });
 });

--- a/clients/gui-app/src/lib/epics/epic-tab-existence.ts
+++ b/clients/gui-app/src/lib/epics/epic-tab-existence.ts
@@ -1,36 +1,11 @@
-import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
-
-type FetchEpicListPage = (
-  cursor: string | undefined,
-) => Promise<ListTasksResponse>;
-
-export async function fetchExistingEpicIdsFromPages(
-  fetchPage: FetchEpicListPage,
-): Promise<ReadonlySet<string>> {
-  const epicIds = new Set<string>();
-  let cursor: string | undefined = undefined;
-
-  for (;;) {
-    const page = await fetchPage(cursor);
-
-    for (const task of page.tasks) {
-      const epic = task.epic?.light ?? null;
-      if (epic !== null) {
-        epicIds.add(epic.id);
-      }
-    }
-
-    if (
-      !page.hasMore ||
-      typeof page.nextCursor !== "string" ||
-      page.nextCursor.length === 0
-    ) {
-      return epicIds;
-    }
-    cursor = page.nextCursor;
-  }
-}
-
+/**
+ * Open epic tabs whose ids the host did NOT confirm as existing epics.
+ *
+ * `existingEpicIds` must be a positively-established set - see
+ * `EpicTabExistenceReconciler`, whose only action on the result is destructive
+ * (force-closing tabs), so an absent or failed lookup must never reach here as
+ * an empty set.
+ */
 export function missingEpicIds(
   openEpicIds: ReadonlyArray<string>,
   existingEpicIds: ReadonlySet<string>,

--- a/clients/gui-app/src/providers/__tests__/epic-tab-existence-reconciler.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/epic-tab-existence-reconciler.test.tsx
@@ -1,0 +1,366 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MockHostMessenger } from "@traycer-clients/shared/host-client/mock/mock-host-messenger";
+import { MockRunnerHost } from "@traycer-clients/shared/host-client/mock/mock-runner-host";
+import {
+  HostRpcError,
+  type RequestOfMethod,
+  type ResponseOfMethod,
+} from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  recordNegotiatedHostMethods,
+  resetNegotiatedManifests,
+} from "@traycer-clients/shared/host-transport/negotiated-manifest-registry";
+import type { LocalHostSnapshot } from "@traycer-clients/shared/platform/runner-host";
+import {
+  HostCompatibilityProvider,
+  hostRpcRegistry,
+  HostRuntimeProvider,
+  type HostRpcRegistry,
+  type MessengerFactory,
+} from "@/lib/host";
+import { EpicTabExistenceReconciler } from "@/providers/epic-tab-existence-reconciler";
+import { RunnerHostProvider } from "@/providers/runner-host-provider";
+import { useAuthStore } from "@/stores/auth/auth-store";
+import {
+  collectOpenEpicIds,
+  useEpicCanvasStore,
+} from "@/stores/epics/canvas/store";
+import { useTabsStore } from "@/stores/tabs/store";
+import { tabCommandCoordinator } from "@/stores/tabs/tab-command-coordinator";
+import { useInitialChatHandoffStore } from "@/stores/epics/initial-chat-handoff-store";
+import { clearSessionCreatedEpics } from "@/lib/epics/session-created-epics";
+
+/**
+ * The reconciler's only action is destructive: it force-closes epic tabs whose
+ * epics it believes are gone. `epic.getTaskContexts` is an OPTIONAL (non-floor)
+ * method, so a pre-1.1.7 host rejects it client-side with
+ * `E_HOST_UNSUPPORTED`. Every test here pins the same invariant from a
+ * different failure direction: absent evidence must close NOTHING.
+ *
+ * The happy path (a confirmed tab survives, an unconfirmed one is pruned) is
+ * covered in host-compatibility-provider.test.tsx; these are its complements,
+ * and they only discriminate because that test proves pruning does happen
+ * under the same fixture shape.
+ */
+
+const OPEN_EPIC_ID = "epic-open-persisted";
+
+const localSnapshot: LocalHostSnapshot = {
+  hostId: "desktop-pid-reconciler",
+  websocketUrl: "ws://127.0.0.1:4918/rpc",
+  version: "1.2.3",
+  pid: 4343,
+  systemHostName: "hardiks-macbook",
+  displayName: "hardiks-macbook",
+};
+
+type HostStatusResponse = ResponseOfMethod<HostRpcRegistry, "host.status">;
+type GetTaskContextsResponse = ResponseOfMethod<
+  HostRpcRegistry,
+  "epic.getTaskContexts"
+>;
+type GetTaskContextsRequest = RequestOfMethod<
+  HostRpcRegistry,
+  "epic.getTaskContexts"
+>;
+
+const compatibleHostStatus: HostStatusResponse = {
+  ready: true,
+  hostVersion: "1.2.3",
+  protocolVersion: { major: 1, minor: 0 },
+};
+
+let restoreFetch: () => void = () => undefined;
+
+function installAuthFetch(): () => void {
+  const originalFetch: unknown = (globalThis as { fetch?: unknown }).fetch;
+  Object.defineProperty(globalThis, "fetch", {
+    configurable: true,
+    writable: true,
+    value: (input: unknown): Promise<Response> => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.endsWith("/api/v3/user")) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              user: {
+                id: "test-user",
+                name: "Test User",
+                providerId: "gh-1",
+                providerHandle: "test-user",
+                providerType: "GITHUB",
+                email: "test@example.com",
+                avatarUrl: null,
+                activatedAt: null,
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                lastSeenAt: null,
+                privacyMode: false,
+                isLearningEnabled: true,
+              },
+              userSubscription: {
+                id: "sub-1",
+                userID: "test-user",
+                orgID: null,
+                teamID: null,
+                customerId: "cus-1",
+                createdAt: "2024-01-01T00:00:00.000Z",
+                updatedAt: "2024-01-01T00:00:00.000Z",
+                subscriptionExpiry: null,
+                trialEndsAt: null,
+                subscriptionStatus: "FREE",
+                hasPaymentMethod: false,
+                isInTrial: false,
+                rechargeRateSeconds: 0,
+              },
+              teamSubscriptions: [],
+              payAsYouGoUsage: { allowPayAsYouGo: false },
+            }),
+            { status: 200 },
+          ),
+        );
+      }
+      return Promise.reject(
+        new Error(`unexpected fetch in reconciler test: ${url}`),
+      );
+    },
+  });
+  return () => {
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: originalFetch,
+    });
+  };
+}
+
+interface MountOptions {
+  readonly getTaskContexts: (
+    params: GetTaskContextsRequest,
+  ) => Promise<GetTaskContextsResponse> | GetTaskContextsResponse;
+}
+
+function buildMessengerFactory(
+  options: MountOptions,
+): MessengerFactory<HostRpcRegistry> {
+  return (args) =>
+    new MockHostMessenger<HostRpcRegistry>({
+      registry: args.registry,
+      requestId: () => `req-${String(nextRequestId++)}`,
+      handlers: {
+        "host.status": () => compatibleHostStatus,
+        "epic.getTaskContexts": (params) => options.getTaskContexts(params),
+      },
+    });
+}
+
+let nextRequestId = 1;
+
+function mountReconciler(options: MountOptions): QueryClient {
+  const host = new MockRunnerHost({
+    signInUrl: "https://auth.traycer.invalid/sign-in",
+    authnBaseUrl: "http://localhost:5005",
+    localHost: localSnapshot,
+    hosts: [],
+    workspaceFolderPickerPaths: undefined,
+    hasLocalHost: undefined,
+    traycerCli: undefined,
+  });
+  void host.tokenStore.signIn(
+    { token: "test-token", refreshToken: "test-refresh-token" },
+    { id: "user-1", email: "test@example.com", name: "Test User" },
+  );
+  useAuthStore.getState().setSignedIn(
+    {
+      userId: "test-user",
+      userName: "Test User",
+      email: "test@example.com",
+    },
+    { userId: "test-user", username: "Test User" },
+    [],
+  );
+  useEpicCanvasStore.getState().openEpicTab(OPEN_EPIC_ID, "Open Epic");
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  render(
+    <RunnerHostProvider runnerHost={host}>
+      <QueryClientProvider client={queryClient}>
+        <HostRuntimeProvider
+          registry={hostRpcRegistry}
+          messengerFactory={buildMessengerFactory(options)}
+          invalidator={null}
+          requestId={null}
+          remoteFetcher={() => Promise.resolve([])}
+          fallback={<div data-testid="runtime-fallback">runtime loading</div>}
+        >
+          <HostCompatibilityProvider>
+            <EpicTabExistenceReconciler />
+          </HostCompatibilityProvider>
+        </HostRuntimeProvider>
+      </QueryClientProvider>
+    </RunnerHostProvider>,
+  );
+  return queryClient;
+}
+
+function unsupportedError(): HostRpcError {
+  return new HostRpcError({
+    code: "E_HOST_UNSUPPORTED",
+    message: "This host does not support 'epic.getTaskContexts'.",
+    requestId: "req-unsupported",
+    method: "epic.getTaskContexts",
+    fatalDetails: {
+      code: "E_HOST_UNSUPPORTED",
+      reason: "This host does not support 'epic.getTaskContexts'.",
+      incompatibleMethods: null,
+      upgradeGuidance: { clientShouldUpgrade: false, hostShouldUpgrade: true },
+    },
+  });
+}
+
+describe("EpicTabExistenceReconciler fail-closed paths", () => {
+  beforeEach(() => {
+    restoreFetch = installAuthFetch();
+    useTabsStore.setState(useTabsStore.getInitialState(), true);
+    tabCommandCoordinator.installSourceReconciliation();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useAuthStore.getState().setSignedOut();
+    useEpicCanvasStore.getState().closeTabsForEpics([OPEN_EPIC_ID]);
+    useInitialChatHandoffStore.getState().resetForTests();
+    clearSessionCreatedEpics();
+    resetNegotiatedManifests();
+    vi.restoreAllMocks();
+    restoreFetch();
+  });
+
+  it("never calls the method when the host has not advertised it", async () => {
+    // A host that completed a handshake WITHOUT epic.getTaskContexts: known
+    // absent, not merely unknown. Reconciliation must not run at all.
+    recordNegotiatedHostMethods(localSnapshot.hostId, ["host.status"]);
+    const getTaskContexts = vi.fn(
+      (_params: GetTaskContextsRequest): GetTaskContextsResponse => ({
+        tasks: {},
+      }),
+    );
+
+    const queryClient = mountReconciler({ getTaskContexts });
+
+    // Settle the runtime: host.status has to resolve before the reconciler's
+    // other gates would have opened, so this waits past the point where an
+    // ungated run would have fired.
+    await waitFor(() => {
+      expect(
+        queryClient
+          .getQueryCache()
+          .getAll()
+          .some((query) => query.state.status === "success"),
+      ).toBe(true);
+    });
+    expect(getTaskContexts).not.toHaveBeenCalled();
+    expect(collectOpenEpicIds()).toContain(OPEN_EPIC_ID);
+    queryClient.clear();
+  });
+
+  it("closes no tabs when the method is unsupported at call time", async () => {
+    // The manifest advertised it (so the run starts) but the call rejects with
+    // E_HOST_UNSUPPORTED - the shape a host downgraded between handshake and
+    // call produces. An empty-map degrade here would prune every open tab.
+    recordNegotiatedHostMethods(localSnapshot.hostId, [
+      "host.status",
+      "epic.getTaskContexts",
+    ]);
+    const getTaskContexts = vi.fn((_params: GetTaskContextsRequest) => {
+      throw unsupportedError();
+    });
+
+    const queryClient = mountReconciler({ getTaskContexts });
+
+    await waitFor(() => {
+      expect(getTaskContexts).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(
+        queryClient
+          .getQueryCache()
+          .getAll()
+          .some((query) => query.state.status === "error"),
+      ).toBe(true);
+    });
+    expect(collectOpenEpicIds()).toContain(OPEN_EPIC_ID);
+    queryClient.clear();
+  });
+
+  it("closes no tabs when the lookup fails for an ordinary transport reason", async () => {
+    recordNegotiatedHostMethods(localSnapshot.hostId, [
+      "host.status",
+      "epic.getTaskContexts",
+    ]);
+    const getTaskContexts = vi.fn((_params: GetTaskContextsRequest) => {
+      throw new HostRpcError({
+        code: "RPC_ERROR",
+        message: "connection reset",
+        requestId: "req-boom",
+        method: "epic.getTaskContexts",
+        fatalDetails: null,
+      });
+    });
+
+    const queryClient = mountReconciler({ getTaskContexts });
+
+    await waitFor(() => {
+      expect(getTaskContexts).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(
+        queryClient
+          .getQueryCache()
+          .getAll()
+          .some((query) => query.state.status === "error"),
+      ).toBe(true);
+    });
+    expect(collectOpenEpicIds()).toContain(OPEN_EPIC_ID);
+    queryClient.clear();
+  });
+
+  it("closes no tabs while the lookup is still in flight", async () => {
+    recordNegotiatedHostMethods(localSnapshot.hostId, [
+      "host.status",
+      "epic.getTaskContexts",
+    ]);
+    let resolveLookup: (value: GetTaskContextsResponse) => void = () => {
+      throw new Error("deferred resolver was not initialized");
+    };
+    const pending = new Promise<GetTaskContextsResponse>((resolve) => {
+      resolveLookup = resolve;
+    });
+    const getTaskContexts = vi.fn((_params: GetTaskContextsRequest) => pending);
+
+    const queryClient = mountReconciler({ getTaskContexts });
+
+    await waitFor(() => {
+      expect(getTaskContexts).toHaveBeenCalledTimes(1);
+    });
+    expect(collectOpenEpicIds()).toContain(OPEN_EPIC_ID);
+
+    // Resolving with the id unconfirmed prunes it - the same fixture that had
+    // to leave the tab open while pending. Without this the test would pass
+    // even if the reconciler never concluded anything at all.
+    act(() => {
+      resolveLookup({ tasks: { [OPEN_EPIC_ID]: null } });
+    });
+    await waitFor(() => {
+      expect(collectOpenEpicIds()).not.toContain(OPEN_EPIC_ID);
+    });
+    queryClient.clear();
+  });
+});

--- a/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
+++ b/clients/gui-app/src/providers/__tests__/host-compatibility-provider.test.tsx
@@ -9,6 +9,10 @@ import {
   type RequestOfMethod,
   type ResponseOfMethod,
 } from "@traycer-clients/shared/host-transport/host-messenger";
+import {
+  recordNegotiatedHostMethods,
+  resetNegotiatedManifests,
+} from "@traycer-clients/shared/host-transport/negotiated-manifest-registry";
 import type { LocalHostSnapshot } from "@traycer-clients/shared/platform/runner-host";
 import {
   HostCompatibilityProvider,
@@ -78,8 +82,15 @@ const localSnapshot: LocalHostSnapshot = {
 };
 
 type HostStatusResponse = ResponseOfMethod<HostRpcRegistry, "host.status">;
-type ListTasksResponse = ResponseOfMethod<HostRpcRegistry, "epic.listTasks">;
-type ListTasksRequest = RequestOfMethod<HostRpcRegistry, "epic.listTasks">;
+type GetTaskContextsResponse = ResponseOfMethod<
+  HostRpcRegistry,
+  "epic.getTaskContexts"
+>;
+type GetTaskContextsRequest = RequestOfMethod<
+  HostRpcRegistry,
+  "epic.getTaskContexts"
+>;
+type TaskContextRow = GetTaskContextsResponse["tasks"][string];
 type ListHarnessesResponse = ResponseOfMethod<
   HostRpcRegistry,
   "agent.gui.listHarnesses"
@@ -92,9 +103,9 @@ interface Deferred<T> {
 
 interface StartupConsumersOptions {
   readonly hostStatus: () => Promise<HostStatusResponse> | HostStatusResponse;
-  readonly listTasks: (
-    params: ListTasksRequest,
-  ) => Promise<ListTasksResponse> | ListTasksResponse;
+  readonly getTaskContexts: (
+    params: GetTaskContextsRequest,
+  ) => Promise<GetTaskContextsResponse> | GetTaskContextsResponse;
   readonly listHarnesses: () =>
     Promise<ListHarnessesResponse> | ListHarnessesResponse;
   readonly onMethod: (method: string) => void;
@@ -144,9 +155,9 @@ function buildMessengerFactory(
           options.onMethod("host.status");
           return options.hostStatus();
         },
-        "epic.listTasks": (params) => {
-          options.onMethod("epic.listTasks");
-          return options.listTasks(params);
+        "epic.getTaskContexts": (params) => {
+          options.onMethod("epic.getTaskContexts");
+          return options.getTaskContexts(params);
         },
         "agent.gui.listHarnesses": () => {
           options.onMethod("agent.gui.listHarnesses");
@@ -222,7 +233,7 @@ function getCompatibilityStatusText(): string | null {
   }).textContent;
 }
 
-function epicTask(epicId: string): ListTasksResponse["tasks"][number] {
+function epicTask(epicId: string): TaskContextRow {
   return {
     epic: {
       light: {
@@ -247,21 +258,36 @@ function epicTask(epicId: string): ListTasksResponse["tasks"][number] {
   };
 }
 
+// Resolves every requested id, confirming only `confirmedEpicIds` and
+// returning `null` (deleted / not permitted - indistinguishable by design) for
+// the rest. Mirrors the host contract: the response is keyed by the requested
+// task ids, so a caller learns nothing about ids it did not ask about.
+function taskContextsFor(
+  confirmedEpicIds: ReadonlyArray<string>,
+): (params: GetTaskContextsRequest) => GetTaskContextsResponse {
+  const confirmed = new Set(confirmedEpicIds);
+  return (params) => ({
+    tasks: Object.fromEntries(
+      params.taskIds.map((taskId): readonly [string, TaskContextRow] => [
+        taskId,
+        confirmed.has(taskId) ? epicTask(taskId) : null,
+      ]),
+    ),
+  });
+}
+
 // Shared harness for the "freshly-created epic survives reconciliation" tests.
-// `epic.listTasks` returns only the pre-existing startup tab, so a just-created
-// epic (absent from the page while epic.listTasks lags epic.create) is pruned
-// unless a protection guard exempts it.
+// The host confirms only the pre-existing startup tab, so a just-created epic
+// (absent from cloud reads while they lag epic.create) is pruned unless a
+// protection guard exempts it.
 function mountReconcilerHarness(): { readonly queryClient: QueryClient } {
-  const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
-    tasks: [epicTask(STARTUP_EPIC_ID)],
-    hasMore: false,
-  }));
+  const getTaskContexts = vi.fn(taskContextsFor([STARTUP_EPIC_ID]));
   const listHarnesses = vi.fn((): ListHarnessesResponse => ({
     harnesses: [],
   }));
   const { queryClient } = mountStartupConsumers({
     hostStatus: () => compatibleHostStatus,
-    listTasks,
+    getTaskContexts,
     listHarnesses,
     onMethod: () => undefined,
   });
@@ -343,6 +369,16 @@ describe("HostCompatibilityProvider startup consumers", () => {
     // instead of hand-mirroring each auto-generated tab id into a second
     // fixture.
     tabCommandCoordinator.installSourceReconciliation();
+    // `EpicTabExistenceReconciler` gates on the OPTIONAL (non-floor)
+    // `epic.getTaskContexts` being advertised by this host. The real transport
+    // records that from every `openAck`; `MockHostMessenger` has no handshake,
+    // so the manifest is seeded here - without it the reconciler correctly
+    // refuses to run and every prune assertion below would pass vacuously.
+    recordNegotiatedHostMethods(localSnapshot.hostId, [
+      "host.status",
+      "epic.getTaskContexts",
+      "agent.gui.listHarnesses",
+    ]);
   });
 
   afterEach(() => {
@@ -358,6 +394,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
       ]);
     useInitialChatHandoffStore.getState().resetForTests();
     clearSessionCreatedEpics();
+    resetNegotiatedManifests();
     vi.restoreAllMocks();
     restoreFetch();
   });
@@ -365,16 +402,13 @@ describe("HostCompatibilityProvider startup consumers", () => {
   it("holds startup host RPC consumers until host.status succeeds", async () => {
     const hostStatus = createDeferred<HostStatusResponse>();
     const methods: string[] = [];
-    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
-      tasks: [],
-      hasMore: false,
-    }));
+    const getTaskContexts = vi.fn(taskContextsFor([STARTUP_EPIC_ID]));
     const listHarnesses = vi.fn((): ListHarnessesResponse => ({
       harnesses: [],
     }));
     const { queryClient } = mountStartupConsumers({
       hostStatus: () => hostStatus.promise,
-      listTasks,
+      getTaskContexts,
       listHarnesses,
       onMethod: (method) => {
         methods.push(method);
@@ -384,7 +418,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
     await waitFor(() => {
       expect(methods).toEqual(["host.status"]);
     });
-    expect(listTasks).not.toHaveBeenCalled();
+    expect(getTaskContexts).not.toHaveBeenCalled();
     expect(listHarnesses).not.toHaveBeenCalled();
     expect(getCompatibilityStatusText()).toBe("checking");
 
@@ -393,15 +427,17 @@ describe("HostCompatibilityProvider startup consumers", () => {
     });
 
     await waitFor(() => {
-      expect(listTasks).toHaveBeenCalledTimes(1);
+      expect(getTaskContexts).toHaveBeenCalledTimes(1);
       expect(listHarnesses).toHaveBeenCalledTimes(1);
     });
+    // One id-scoped batch for the single open tab - not a paginated sweep.
+    expect(getTaskContexts.mock.calls[0][0].taskIds).toEqual([STARTUP_EPIC_ID]);
     expect(getCompatibilityStatusText()).toBe("compatible");
     expect(methods[0]).toBe("host.status");
     expect(methods).toEqual(
       expect.arrayContaining([
         "host.status",
-        "epic.listTasks",
+        "epic.getTaskContexts",
         "agent.gui.listHarnesses",
       ]),
     );
@@ -410,10 +446,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
 
   it("does not start startup host RPC consumers after an incompatible status verdict", async () => {
     const methods: string[] = [];
-    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
-      tasks: [],
-      hasMore: false,
-    }));
+    const getTaskContexts = vi.fn(taskContextsFor([STARTUP_EPIC_ID]));
     const listHarnesses = vi.fn((): ListHarnessesResponse => ({
       harnesses: [],
     }));
@@ -427,7 +460,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
           fatalDetails: null,
         });
       },
-      listTasks,
+      getTaskContexts,
       listHarnesses,
       onMethod: (method) => {
         methods.push(method);
@@ -438,17 +471,14 @@ describe("HostCompatibilityProvider startup consumers", () => {
       expect(getCompatibilityStatusText()).toBe("incompatible");
     });
     expect(methods).toEqual(["host.status"]);
-    expect(listTasks).not.toHaveBeenCalled();
+    expect(getTaskContexts).not.toHaveBeenCalled();
     expect(listHarnesses).not.toHaveBeenCalled();
     queryClient.clear();
   });
 
   it("surfaces exhausted non-terminal status probe failures without starting startup consumers", async () => {
     const methods: string[] = [];
-    const listTasks = vi.fn((_params: ListTasksRequest): ListTasksResponse => ({
-      tasks: [],
-      hasMore: false,
-    }));
+    const getTaskContexts = vi.fn(taskContextsFor([STARTUP_EPIC_ID]));
     const listHarnesses = vi.fn((): ListHarnessesResponse => ({
       harnesses: [],
     }));
@@ -462,7 +492,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
           fatalDetails: null,
         });
       },
-      listTasks,
+      getTaskContexts,
       listHarnesses,
       onMethod: (method) => {
         methods.push(method);
@@ -473,76 +503,48 @@ describe("HostCompatibilityProvider startup consumers", () => {
       expect(getCompatibilityStatusText()).toBe("failed");
     });
     expect(methods).toEqual(["host.status", "host.status", "host.status"]);
-    expect(listTasks).not.toHaveBeenCalled();
+    expect(getTaskContexts).not.toHaveBeenCalled();
     expect(listHarnesses).not.toHaveBeenCalled();
     queryClient.clear();
   });
 
-  it("fetches every reconciliation page before pruning persisted epic tabs", async () => {
+  it("asks only about the open epic tabs and prunes the ids the host does not confirm", async () => {
     const methods: string[] = [];
-    const listTasks = vi.fn((params: ListTasksRequest): ListTasksResponse =>
-      params.cursor === undefined
-        ? { tasks: [], hasMore: true, nextCursor: "page-2" }
-        : { tasks: [epicTask(STARTUP_EPIC_ID)], hasMore: false },
-    );
+    const getTaskContexts = vi.fn(taskContextsFor([STARTUP_EPIC_ID]));
     const listHarnesses = vi.fn((): ListHarnessesResponse => ({
       harnesses: [],
     }));
     const { queryClient } = mountStartupConsumers({
       hostStatus: () => compatibleHostStatus,
-      listTasks,
+      getTaskContexts,
       listHarnesses,
       onMethod: (method) => {
         methods.push(method);
       },
     });
+    act(() => {
+      useEpicCanvasStore.getState().openEpicTab(STALE_EPIC_ID, "Stale");
+    });
 
     await waitFor(() => {
-      expect(listTasks).toHaveBeenCalledTimes(2);
+      expect(collectOpenEpicIds()).not.toContain(STALE_EPIC_ID);
     });
-    expect(
-      listTasks.mock.calls.map(([params]) => params.cursor ?? null),
-    ).toEqual([null, "page-2"]);
+    // The confirmed tab survives, and the host was asked about exactly the
+    // open ids - never about the rest of the account's epic history.
     expect(collectOpenEpicIds()).toContain(STARTUP_EPIC_ID);
-    expect(methods[0]).toBe("host.status");
-    queryClient.clear();
-  });
-
-  it("treats repeated reconciliation cursors as terminal before pruning persisted epic tabs", async () => {
-    const methods: string[] = [];
-    const listTasks = vi.fn((params: ListTasksRequest): ListTasksResponse =>
-      params.cursor === undefined
-        ? { tasks: [], hasMore: true, nextCursor: "repeat" }
-        : { tasks: [], hasMore: true, nextCursor: "repeat" },
+    expect(getTaskContexts).toHaveBeenCalledTimes(1);
+    expect([...getTaskContexts.mock.calls[0][0].taskIds].sort()).toEqual(
+      [STALE_EPIC_ID, STARTUP_EPIC_ID].sort(),
     );
-    const listHarnesses = vi.fn((): ListHarnessesResponse => ({
-      harnesses: [],
-    }));
-    const { queryClient } = mountStartupConsumers({
-      hostStatus: () => compatibleHostStatus,
-      listTasks,
-      listHarnesses,
-      onMethod: (method) => {
-        methods.push(method);
-      },
-    });
-
-    await waitFor(() => {
-      expect(collectOpenEpicIds()).not.toContain(STARTUP_EPIC_ID);
-    });
-    expect(listTasks).toHaveBeenCalledTimes(2);
-    expect(
-      listTasks.mock.calls.map(([params]) => params.cursor ?? null),
-    ).toEqual([null, "repeat"]);
     expect(methods[0]).toBe("host.status");
     queryClient.clear();
   });
 
-  it("keeps a freshly-created epic tab absent from the reconcile page but protected by an active initial-chat handoff", async () => {
+  it("keeps a freshly-created epic tab unconfirmed by the host but protected by an active initial-chat handoff", async () => {
     const { queryClient } = mountReconcilerHarness();
 
-    // FRESH_EPIC_ID models a just-created epic: absent from the reconcile page
-    // (epic.listTasks lags epic.create) but carrying an active initial-chat
+    // FRESH_EPIC_ID models a just-created epic: unconfirmed by the host
+    // (cloud reads lag epic.create) but carrying an active initial-chat
     // handoff. STALE_EPIC_ID is a genuinely-stale persisted tab with no
     // protection. Both are opened before the reconciler run captures
     // openEpicIds (host.status resolves on a later microtask, so this
@@ -562,7 +564,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
     queryClient.clear();
   });
 
-  it("keeps a freshly-created epic tab absent from the reconcile page but marked created-this-session (terminal-agent path, no handoff)", async () => {
+  it("keeps a freshly-created epic tab unconfirmed by the host but marked created-this-session (terminal-agent path, no handoff)", async () => {
     const { queryClient } = mountReconcilerHarness();
 
     // Terminal-agent create registers no initial-chat handoff, so only the
@@ -608,17 +610,17 @@ describe("HostCompatibilityProvider startup consumers", () => {
   });
 
   it("retries tab reconciliation after an in-flight compatibility interruption", async () => {
-    const listTasksDeferred = createDeferred<ListTasksResponse>();
+    const taskContextsDeferred = createDeferred<GetTaskContextsResponse>();
     const methods: string[] = [];
-    const listTasks = vi.fn(
-      (_params: ListTasksRequest) => listTasksDeferred.promise,
+    const getTaskContexts = vi.fn(
+      (_params: GetTaskContextsRequest) => taskContextsDeferred.promise,
     );
     const listHarnesses = vi.fn((): ListHarnessesResponse => ({
       harnesses: [],
     }));
     const { queryClient, host } = mountStartupConsumers({
       hostStatus: () => compatibleHostStatus,
-      listTasks,
+      getTaskContexts,
       listHarnesses,
       onMethod: (method) => {
         methods.push(method);
@@ -626,7 +628,7 @@ describe("HostCompatibilityProvider startup consumers", () => {
     });
 
     await waitFor(() => {
-      expect(listTasks).toHaveBeenCalledTimes(1);
+      expect(getTaskContexts).toHaveBeenCalledTimes(1);
     });
 
     act(() => {
@@ -640,11 +642,13 @@ describe("HostCompatibilityProvider startup consumers", () => {
       host.setLocalHost(localSnapshot);
     });
     await waitFor(() => {
-      expect(listTasks).toHaveBeenCalledTimes(2);
+      expect(getTaskContexts).toHaveBeenCalledTimes(2);
     });
 
     act(() => {
-      listTasksDeferred.resolve({ tasks: [], hasMore: false });
+      taskContextsDeferred.resolve({
+        tasks: { [STARTUP_EPIC_ID]: epicTask(STARTUP_EPIC_ID) },
+      });
     });
     expect(methods[0]).toBe("host.status");
     queryClient.clear();

--- a/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
+++ b/clients/gui-app/src/providers/epic-tab-existence-reconciler.tsx
@@ -5,18 +5,20 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
 import {
-  CURRENT_EPIC_VERSION,
-  CURRENT_PHASE_VERSION,
-} from "@traycer-clients/shared/epic/epic-version";
-import type { ListTasksResponse } from "@traycer/protocol/host/epic/unary-schemas";
+  GET_TASK_CONTEXTS_MAX_IDS,
+  type GetTaskContextsResponse,
+} from "@traycer/protocol/host/epic/unary-schemas";
+import type { HostRpcError } from "@traycer-clients/shared/host-transport/host-messenger";
 import { useShallow } from "zustand/react/shallow";
 import {
   useHostClient,
   useHostCompatibility,
   type HostRpcRegistry,
 } from "@/lib/host";
-import { useHostQuery } from "@/hooks/host/use-host-query";
+import { useHostQueries } from "@/hooks/host/use-host-queries";
+import { useHostMethodSupport } from "@/hooks/host/use-host-supports-method";
 import { useReactiveHostReadiness } from "@/hooks/host/use-reactive-host-readiness";
 import { missingEpicIds } from "@/lib/epics/epic-tab-existence";
 import { wasEpicCreatedThisSession } from "@/lib/epics/session-created-epics";
@@ -31,9 +33,28 @@ import {
   useInitialChatHandoffStore,
 } from "@/stores/epics/initial-chat-handoff-store";
 
-const EPIC_TAB_RECONCILE_PAGE_LIMIT = 100;
-const EMPTY_EXISTING_EPIC_IDS: ReadonlyArray<string> = [];
-const EMPTY_SEEN_RECONCILE_CURSORS: ReadonlySet<string> = new Set();
+/**
+ * Resolves existence for exactly the epic ids that have an open tab, via
+ * `epic.getTaskContexts` - id-scoped, so the cost is O(open tabs) rather than
+ * O(the account's whole epic history) as the previous `epic.listTasks` sweep
+ * was (it paged the entire list and then intersected).
+ *
+ * `epic.getTaskContexts` is an OPTIONAL (non-floor) method: it is absent from
+ * `RELEASED_FLOOR_METHOD_NAMES`, so a host that predates it negotiates it away
+ * instead of failing the handshake, and the client rejects the call locally
+ * with `E_HOST_UNSUPPORTED`. Because this reconciler's only action is
+ * DESTRUCTIVE (force-closing tabs), every path where existence is not
+ * positively established must conclude nothing:
+ *
+ *  - the host has not advertised the method (or no handshake has completed
+ *    yet) - the run never starts;
+ *  - any batch is still pending, or failed for any reason including
+ *    `E_HOST_UNSUPPORTED` - no ids are treated as missing.
+ *
+ * Reading an absent/failed response as "no epics exist" would make
+ * `missingEpicIds` return every open tab and close all of them.
+ */
+const RECONCILE_METHOD = "epic.getTaskContexts" as const;
 
 export function EpicTabExistenceReconciler() {
   const seed = usePersistedEpicTabReconcileSeed();
@@ -50,12 +71,6 @@ interface ReconcileRun extends ReconcileSeed {
   readonly attempt: number;
 }
 
-interface ReconcilePage {
-  readonly existingEpicIds: ReadonlyArray<string>;
-  readonly cursor: string | undefined;
-  readonly seenCursors: ReadonlySet<string>;
-}
-
 function usePersistedEpicTabReconcileSeed(): ReconcileSeed | null {
   const client = useHostClient();
   const compatibility = useHostCompatibility();
@@ -67,6 +82,16 @@ function usePersistedEpicTabReconcileSeed(): ReconcileSeed | null {
   );
   const canvasHydrationVersion = useEpicCanvasHydrationVersion();
   const openEpicIds = useVisibleEpicIds();
+  // Three-valued on purpose (`null` = no handshake yet, `false` = known
+  // absent): only `true` may license a run. `compatibility.status` cannot
+  // stand in for this - it is a `host.status` probe over the released FLOOR
+  // channel and says nothing about an optional method. In practice the
+  // manifest is already known by the time the gates below pass, because a
+  // `compatible` verdict required a completed handshake with this host.
+  const methodSupport = useHostMethodSupport(
+    readiness.hostId,
+    RECONCILE_METHOD,
+  );
 
   const identity = useMemo(() => {
     if (!windowsHydrated) return null;
@@ -75,12 +100,14 @@ function usePersistedEpicTabReconcileSeed(): ReconcileSeed | null {
     if (readiness.hostId === null) return null;
     if (authUserId === null) return null;
     if (readiness.requestContextUserId !== authUserId) return null;
+    if (methodSupport !== true) return null;
     return `${readiness.hostId}:${authUserId}:${canvasHydrationVersion}`;
   }, [
     authStatus,
     authUserId,
     canvasHydrationVersion,
     compatibility.status,
+    methodSupport,
     readiness.hostId,
     readiness.requestContextUserId,
     windowsHydrated,
@@ -104,106 +131,106 @@ function EpicTabReconciliationRun(props: { readonly seed: ReconcileSeed }) {
     };
   });
 
-  return (
-    <EpicTabReconciliationPage
-      run={run}
-      page={{
-        existingEpicIds: EMPTY_EXISTING_EPIC_IDS,
-        cursor: undefined,
-        seenCursors: EMPTY_SEEN_RECONCILE_CURSORS,
-      }}
-    />
-  );
+  return <EpicTabExistenceProbe run={run} />;
 }
 
-function EpicTabReconciliationPage(props: {
-  readonly run: ReconcileRun;
-  readonly page: ReconcilePage;
-}) {
+function EpicTabExistenceProbe(props: { readonly run: ReconcileRun }) {
   const client = useHostClient();
   const completionAppliedRef = useRef(false);
-  const {
-    cursor: pageCursor,
-    existingEpicIds: previousExistingEpicIds,
-    seenCursors,
-  } = props.page;
-  const reconcileParams = useMemo(
-    () => ({
-      limit: EPIC_TAB_RECONCILE_PAGE_LIMIT,
-      cursor: pageCursor,
-      filters: { taskType: "epic" as const },
-      extensionPhaseVersion: String(CURRENT_PHASE_VERSION),
-      extensionEpicVersion: String(CURRENT_EPIC_VERSION),
-    }),
-    [pageCursor],
+  const openEpicIds = props.run.openEpicIds;
+  const requests = useMemo(
+    () =>
+      chunkEpicIds(openEpicIds, GET_TASK_CONTEXTS_MAX_IDS).map((chunk) => ({
+        method: RECONCILE_METHOD,
+        params: { taskIds: [...chunk] },
+      })),
+    [openEpicIds],
   );
-  const existingEpicsQuery = useHostQuery<HostRpcRegistry, "epic.listTasks">({
+  // `null` until EVERY batch has succeeded - see the file header. The combined
+  // value is a fresh `Set` per computation, so the effect below can re-run on
+  // an unrelated render; `completionAppliedRef` keeps the apply once-only, as
+  // it did for the paginated implementation.
+  const existingEpicIds = useHostQueries<
+    HostRpcRegistry,
+    typeof RECONCILE_METHOD,
+    ReadonlySet<string> | null
+  >({
     client,
-    method: "epic.listTasks",
-    params: reconcileParams,
-    cacheKeyIdentity: [props.run.identity, props.run.attempt],
-    options: {
-      enabled: true,
-    },
+    requests,
+    cacheKeyIdentity: `${props.run.identity}|${props.run.attempt}`,
+    options: { enabled: true },
+    combine: combineExistingEpicIds,
   });
-  const nextPage = useMemo((): ReconcilePage | null => {
-    if (!existingEpicsQuery.isSuccess) return null;
-    const existingEpicIds = mergeExistingEpicIds(
-      previousExistingEpicIds,
-      existingEpicsQuery.data,
-    );
-    const cursor = nextReconcileCursor(existingEpicsQuery.data);
-    if (cursor === null || seenCursors.has(cursor)) {
-      return {
-        existingEpicIds,
-        cursor: undefined,
-        seenCursors,
-      };
-    }
-    return {
-      existingEpicIds,
-      cursor,
-      seenCursors: addSeenReconcileCursor(seenCursors, cursor),
-    };
-  }, [
-    existingEpicsQuery.data,
-    existingEpicsQuery.isSuccess,
-    previousExistingEpicIds,
-    seenCursors,
-  ]);
-  const terminalExistingEpicIds =
-    nextPage !== null && nextPage.cursor === undefined
-      ? nextPage.existingEpicIds
-      : null;
 
   useEffect(() => {
-    if (terminalExistingEpicIds === null) return;
+    if (existingEpicIds === null) return;
     if (completionAppliedRef.current) return;
     completionAppliedRef.current = true;
     // Never force-close an epic this session just created (or is creating):
-    // `epic.listTasks` lags `epic.create` (that lag is exactly why
+    // cloud reads lag `epic.create` (that lag is exactly why
     // `useEpicCreate.onSuccess` manually patches the cloud-tasks cache), so a
-    // freshly-created epic is legitimately absent from the reconcile page for a
-    // short window. Closing its tab strands the route on a loading skeleton
-    // that never recovers. Such epics carry a live open-epic session and/or an
-    // active initial-chat handoff; a genuinely-stale persisted tab (its epic
-    // deleted while the app was closed) carries neither. A remote delete of an
-    // OPEN epic is handled by `EpicAccessCoordinator` (via the live session's
-    // `epicDeleted` / `accessLost` / unavailable-`snapshotFetchError` signals),
-    // not here, so this exclusion cannot hide a real "epic is gone" signal.
+    // freshly-created epic is legitimately absent for a short window. Closing
+    // its tab strands the route on a loading skeleton that never recovers.
+    // Such epics carry a live open-epic session and/or an active initial-chat
+    // handoff; a genuinely-stale persisted tab (its epic deleted while the app
+    // was closed) carries neither. A remote delete of an OPEN epic is handled
+    // by `EpicAccessCoordinator` (via the live session's `epicDeleted` /
+    // `accessLost` / unavailable-`snapshotFetchError` signals), not here, so
+    // this exclusion cannot hide a real "epic is gone" signal.
     const staleEpicIds = closableStaleEpicIds(
-      missingEpicIds(props.run.openEpicIds, new Set(terminalExistingEpicIds)),
+      missingEpicIds(openEpicIds, existingEpicIds),
     );
     if (staleEpicIds.length > 0) {
       useComposerRunSettingsStore.getState().clearEpicRunSettings(staleEpicIds);
       tabCommandCoordinator.handleEpicAccessLoss(staleEpicIds);
     }
-  }, [props.run.openEpicIds, terminalExistingEpicIds]);
+  }, [existingEpicIds, openEpicIds]);
 
-  if (nextPage === null) return null;
-  if (nextPage.cursor === undefined) return null;
+  return null;
+}
 
-  return <EpicTabReconciliationPage run={props.run} page={nextPage} />;
+/**
+ * The subset of `openEpicIds` the host positively confirmed, or `null` when
+ * existence has not been established for every requested id.
+ *
+ * `null` covers pending batches and ANY failure - a transport error, and
+ * specifically `E_HOST_UNSUPPORTED` from a host that does not carry the
+ * method. Do not soften this into an empty set: `useEpicGetTaskContexts`
+ * deliberately degrades unsupported to an empty map because its callers only
+ * enrich titles, but here an empty set means "every open tab is stale".
+ *
+ * A confirmed id is one whose response row is non-null AND carries an epic
+ * `light` - a row that resolves to a phase, or an epic row without `light`, is
+ * not an existing epic, matching what the epic-filtered sweep counted.
+ */
+function combineExistingEpicIds(
+  results: Array<UseQueryResult<GetTaskContextsResponse, HostRpcError>>,
+): ReadonlySet<string> | null {
+  if (results.length === 0) return null;
+  const existingEpicIds = new Set<string>();
+  for (const result of results) {
+    if (!result.isSuccess) return null;
+    for (const [taskId, task] of Object.entries(result.data.tasks)) {
+      if (task === null) continue;
+      const epic = task.epic;
+      if (epic === null || epic === undefined) continue;
+      if (epic.light === null) continue;
+      existingEpicIds.add(taskId);
+    }
+  }
+  return existingEpicIds;
+}
+
+function chunkEpicIds(
+  epicIds: ReadonlyArray<string>,
+  maxPerChunk: number,
+): ReadonlyArray<ReadonlyArray<string>> {
+  if (epicIds.length === 0) return [];
+  return Array.from(
+    { length: Math.ceil(epicIds.length / maxPerChunk) },
+    (_value, index) =>
+      epicIds.slice(index * maxPerChunk, (index + 1) * maxPerChunk),
+  );
 }
 
 /**
@@ -216,7 +243,7 @@ function EpicTabReconciliationPage(props: {
  *    disturbing MRU ordering);
  *  - it has an active (non-failed) initial-chat handoff (the GUI-chat flow).
  * Each marks an epic this session opened or created, for which a transient
- * `epic.listTasks` miss is propagation lag rather than a deletion. Evaluated
+ * absence from the cloud is propagation lag rather than a deletion. Evaluated
  * fresh here, at close time, so a session/handoff that appears after the
  * reconcile RPC resolves still counts.
  */
@@ -232,37 +259,6 @@ function closableStaleEpicIds(
       registry.peek(epicId) === null &&
       !selectHasActiveInitialChatHandoffForEpic(handoffState, epicId),
   );
-}
-
-function mergeExistingEpicIds(
-  previousIds: ReadonlyArray<string>,
-  page: ListTasksResponse,
-): ReadonlyArray<string> {
-  return Array.from(
-    new Set([
-      ...previousIds,
-      ...page.tasks.flatMap((task) => {
-        const epicId = task.epic?.light?.id ?? null;
-        return epicId === null ? [] : [epicId];
-      }),
-    ]),
-  );
-}
-
-function nextReconcileCursor(page: ListTasksResponse): string | null {
-  if (!page.hasMore) return null;
-  if (typeof page.nextCursor !== "string") return null;
-  if (page.nextCursor.length === 0) return null;
-  return page.nextCursor;
-}
-
-function addSeenReconcileCursor(
-  seenCursors: ReadonlySet<string>,
-  cursor: string,
-): ReadonlySet<string> {
-  const nextSeenCursors = new Set(seenCursors);
-  nextSeenCursors.add(cursor);
-  return nextSeenCursors;
 }
 
 function useVisibleEpicIds(): ReadonlyArray<string> {


### PR DESCRIPTION
## What

Rewrites `EpicTabExistenceReconciler` — the startup check that closes tabs whose epics were deleted while the app was closed — to resolve existence for exactly the open tabs' ids via batched `epic.getTaskContexts`, instead of paging the account's **entire epic history** through `epic.listTasks` and intersecting.

- Cost drops from O(all epics ever) to O(open tabs): one `getTaskContexts` round trip per `GET_TASK_CONTEXTS_MAX_IDS` ids (batches run concurrently) instead of a sequential cursor walk over every list page.
- Removes the reconciler as a consumer of `epic.listTasks` entirely — this was the heaviest client-side caller of the list endpoint.

## Why fail-closed gating matters here

The reconciler's only action is destructive (force-closing tabs), so every path where existence is not positively established must conclude nothing:

- `epic.getTaskContexts` is an **optional (non-floor)** method. A run only starts once the host's negotiated manifest advertises it (`useHostMethodSupport` — three-valued on purpose: `null` = no handshake yet, `false` = known absent; only `true` licenses a run).
- The combined result stays `null` — never an empty set — while any batch is pending or failed, **including `E_HOST_UNSUPPORTED`** from a host that negotiated the method away. Softening that to an empty set would make `missingEpicIds` return every open tab and close all of them. (`useEpicGetTaskContexts` deliberately degrades unsupported to an empty map because its callers only enrich titles; this caller must not.)
- A confirmed id is one whose response row is non-null and carries an epic `light` — a row resolving to a phase, or an epic row without `light`, is not an existing epic, matching what the epic-filtered sweep counted.

Unchanged: the exclusion for epics created this session (cloud reads lag `epic.create`), and remote deletes of an *open* epic remain `EpicAccessCoordinator`'s job via the live session's signals.

## Tests

- New `epic-tab-existence-reconciler.test.tsx`: fail-closed complements — method not advertised → the call never fires; `E_HOST_UNSUPPORTED` at call time → no tabs closed; ordinary transport failure → no tabs closed; in-flight → no tabs closed, then the same fixture resolves with the id unconfirmed and the tab **is** pruned (so the pending assertion discriminates).
- `host-compatibility-provider.test.tsx`: happy path updated for the method-support gate (confirmed tab survives, unconfirmed tab pruned).
- `epic-tab-existence.test.ts`: paging-helper tests removed with the helper; `missingEpicIds` coverage kept.
